### PR TITLE
[ci skip], modify android apk name in cocos-console-test.py.

### DIFF
--- a/tools/jenkins-scripts/cocos-console-test.py
+++ b/tools/jenkins-scripts/cocos-console-test.py
@@ -310,6 +310,10 @@ APP_FILE_SUFFIX = {
 	'ios':'.app',
 	'android':'-debug-unaligned.apk'
 }
+if os.environ.has_key('APP_FILE_SUFFIX'):
+	str_app_suffix = os.environ['APP_FILE_SUFFIX']
+	APP_FILE_SUFFIX = eval(str_app_suffix)
+
 def getPackageSize():
 	for proj in project_types:
 		for phone in phonePlats:


### PR DESCRIPTION
[ci skip], modify android apk name in cocos-console-test.py.
