### PR TITLE
Add cocos/audio/include to the include directories of lua-binding

### DIFF
--- a/cocos/scripting/lua-bindings/CMakeLists.txt
+++ b/cocos/scripting/lua-bindings/CMakeLists.txt
@@ -29,6 +29,7 @@ set(LUABINDING_SRC
 include_directories(
   auto
   manual
+  ../../audio/include
   ../../editor-support/cocosbuilder
   ../../editor-support/cocostudio
   ../../editor-support/spine


### PR DESCRIPTION
The commit 56f737db1ec934aba8be20493c66779150217b83 broke the build, due
to a missing header file.
