### PR TITLE
_nextDt sometimes may be > 1.0f

### DIFF
--- a/cocos/2d/CCActionInterval.cpp
+++ b/cocos/2d/CCActionInterval.cpp
@@ -436,7 +436,7 @@ void Repeat::update(float dt)
 
             _innerAction->stop();
             _innerAction->startWithTarget(_target);
-            _nextDt += _innerAction->getDuration()/_duration;
+            _nextDt = fmod(_nextDt + _innerAction->getDuration()/_duration, 1.0f);
         }
 
         // fix for issue #1288, incorrect end value of repeat


### PR DESCRIPTION
平台：XP
在调试模式下，检测到，_nextDt累加有时候会大于1.0f,Repeat一直不能结束，导致内存泄露。
