### PR TITLE
Upgrade build_native.py to take variable number of arguments

### DIFF
--- a/templates/cpp-template-default/proj.android/build_native.py
+++ b/templates/cpp-template-default/proj.android/build_native.py
@@ -84,7 +84,7 @@ def do_build(cocos_root, ndk_root, app_android_root,ndk_build_param,sdk_root,and
     if ndk_build_param == None:
         command = '%s -j%d -C %s %s' % (ndk_path, num_of_cpu, app_android_root, ndk_module_path)
     else:
-        command = '%s -j%d -C %s %s %s' % (ndk_path, num_of_cpu, app_android_root, ''.join(str(e) for e in ndk_build_param), ndk_module_path)
+        command = '%s -j%d -C %s %s %s' % (ndk_path, num_of_cpu, app_android_root, ' '.join(str(e) for e in ndk_build_param), ndk_module_path)
     if os.system(command) != 0:
         raise Exception("Build dynamic library for project [ " + app_android_root + " ] fails!")
     elif android_platform is not None:
@@ -156,7 +156,7 @@ def build(ndk_build_param,android_platform,build_mode):
 if __name__ == '__main__':
 
     parser = OptionParser()
-    parser.add_option("-n", "--ndk", dest="ndk_build_param", help='parameter for ndk-build')
+    parser.add_option("-n", "--ndk", dest="ndk_build_param", help='parameter for ndk-build', action="append")
     parser.add_option("-p", "--platform", dest="android_platform", 
     help='parameter for android-update.Without the parameter,the script just build dynamic library for project. Valid android-platform are:[10|11|12|13|14|15|16|17|18|19]')
     parser.add_option("-b", "--build", dest="build_mode", 


### PR DESCRIPTION
`build_native.py` --ndk option can't take variable arguments.
I upgrade build_native.py to take variable arguments.

before

```
$ ./build_native.py --ndk APP_OPTIM=debug 'APP_ABI=x86,armeabi'
↓
/usr/local/opt/android-ndk/ndk-build -j8 -C /path/to/proj.android APP_OPTIM=debug NDK_MODULE_PATH=/path/to/cocos2d:/path/to/cocos2d/external:/path/to/cocos2d/cocos
```

after

```
$ ./build_native.py --ndk APP_OPTIM=debug --ndk 'APP_ABI=x86,armeabi'
↓
/usr/local/opt/android-ndk/ndk-build -j8 -C /path/to/proj.android APP_OPTIM=debug APP_ABI=x86,armeabi NDK_MODULE_PATH=/path/to/cocos2d:/path/to/cocos2d/external:/path/to/cocos2d/cocos
```
