### PR TITLE
Lua template should fail to launch on lua error

### DIFF
--- a/templates/lua-template-default/frameworks/runtime-src/Classes/AppDelegate.cpp
+++ b/templates/lua-template-default/frameworks/runtime-src/Classes/AppDelegate.cpp
@@ -36,9 +36,11 @@ bool AppDelegate::applicationDidFinishLaunching()
     director->setAnimationInterval(1.0 / 60);
 
 
-	auto engine = LuaEngine::getInstance();
-	ScriptEngineManager::getInstance()->setScriptEngine(engine);
-	engine->executeScriptFile("src/main.lua");
+    auto engine = LuaEngine::getInstance();
+    ScriptEngineManager::getInstance()->setScriptEngine(engine);
+    if (engine->executeScriptFile("src/main.lua")) {
+        return false;
+    }
 
     return true;
 }

--- a/templates/lua-template-default/src/main.lua
+++ b/templates/lua-template-default/src/main.lua
@@ -12,6 +12,7 @@ function __G__TRACKBACK__(msg)
     cclog("LUA ERROR: " .. tostring(msg) .. "\n")
     cclog(debug.traceback())
     cclog("----------------------------------------")
+    return msg
 end
 
 local function main()
@@ -230,4 +231,7 @@ local function main()
 end
 
 
-xpcall(main, __G__TRACKBACK__)
+local status, msg = xpcall(main, __G__TRACKBACK__)
+if not status then
+    error(msg)
+end

--- a/templates/lua-template-runtime/frameworks/runtime-src/Classes/AppDelegate.cpp
+++ b/templates/lua-template-runtime/frameworks/runtime-src/Classes/AppDelegate.cpp
@@ -43,7 +43,9 @@ bool AppDelegate::applicationDidFinishLaunching()
 
     auto engine = LuaEngine::getInstance();
     ScriptEngineManager::getInstance()->setScriptEngine(engine);
-    engine->executeScriptFile("src/main.lua");
+    if (engine->executeScriptFile("src/main.lua")) {
+        return false;
+    }
     return true;
 }
 

--- a/templates/lua-template-runtime/src/main.lua
+++ b/templates/lua-template-runtime/src/main.lua
@@ -12,6 +12,7 @@ function __G__TRACKBACK__(msg)
     cclog("LUA ERROR: " .. tostring(msg) .. "\n")
     cclog(debug.traceback())
     cclog("----------------------------------------")
+    return msg
 end
 
 local function main()
@@ -230,4 +231,7 @@ local function main()
 end
 
 
-xpcall(main, __G__TRACKBACK__)
+local status, msg = xpcall(main, __G__TRACKBACK__)
+if not status then
+    error(msg)
+end


### PR DESCRIPTION
Without this change, the app continues to run, attempts to access the
badly-initialised scene and issues more error messages. This causes
further errors every frame, covering up the original error in the output
