### PR TITLE
math fixes

### DIFF
--- a/cocos/deprecated/CCDeprecated.h
+++ b/cocos/deprecated/CCDeprecated.h
@@ -770,6 +770,7 @@ CC_DEPRECATED_ATTRIBUTE typedef GLView CCEGLView;
 CC_DEPRECATED_ATTRIBUTE typedef Component CCComponent;
 CC_DEPRECATED_ATTRIBUTE typedef AffineTransform CCAffineTransform;
 CC_DEPRECATED_ATTRIBUTE typedef Vector2 CCPoint;
+CC_DEPRECATED_ATTRIBUTE typedef Vector2 Point;
 CC_DEPRECATED_ATTRIBUTE typedef Size CCSize;
 CC_DEPRECATED_ATTRIBUTE typedef Rect CCRect;
 CC_DEPRECATED_ATTRIBUTE typedef Color3B ccColor3B;

--- a/cocos/math/CCGeometry.h
+++ b/cocos/math/CCGeometry.h
@@ -42,11 +42,6 @@ USING_NS_CC_MATH;
  * @{
  */
 
-// for Vector2 assignement operator and copy constructor
-class CC_DLL Size;
-
-CC_DEPRECATED_ATTRIBUTE typedef Vector2 Point;
-
 class CC_DLL Size
 {
 public:

--- a/cocos/math/CCMathBase.h
+++ b/cocos/math/CCMathBase.h
@@ -23,9 +23,9 @@
 //#define M_1_PI                      0.31830988618379067154
 
 #ifdef __cplusplus
-    #define NS_CC_MATH_BEGIN                     namespace cocos2d { namespace math {
-    #define NS_CC_MATH_END                       } }
-    #define USING_NS_CC_MATH                     using namespace cocos2d::math
+    #define NS_CC_MATH_BEGIN                     namespace cocos2d {
+    #define NS_CC_MATH_END                       }
+    #define USING_NS_CC_MATH                     using namespace cocos2d
 #else
     #define NS_CC_MATH_BEGIN 
     #define NS_CC_MATH_END 

--- a/cocos/math/Vector2.h
+++ b/cocos/math/Vector2.h
@@ -764,6 +764,8 @@ public:
  */
 inline const Vector2 operator*(float x, const Vector2& v);
 
+typedef Vector2 Point2;
+
 NS_CC_MATH_END
 
 #include "Vector2.inl"

--- a/cocos/math/Vector3.h
+++ b/cocos/math/Vector3.h
@@ -491,6 +491,8 @@ public:
  */
 inline const Vector3 operator*(float x, const Vector3& v);
 
+typedef Vector3 Point3;
+
 NS_CC_MATH_END
 
 #include "Vector3.inl"


### PR DESCRIPTION
- Moves deprecated Point to CCDeprecated.h
- Adds Point2 and Point3
- removes `math` from `cocos2d::math` namespace
