### PR TITLE
Fix label using system font on iOS not use premultiplied alpha blend;

### DIFF
--- a/cocos/2d/CCTexture2D.cpp
+++ b/cocos/2d/CCTexture2D.cpp
@@ -1140,7 +1140,7 @@ bool Texture2D::initWithString(const char *text, const FontDefinition& textDefin
     {
         free(outTempData);
     }
-#if (CC_TARGET_PLATFORM == CC_PLATFORM_ANDROID) || (CC_TARGET_PLATFORM == CC_PLATFORM_LINUX)
+#if (CC_TARGET_PLATFORM == CC_PLATFORM_ANDROID) || (CC_TARGET_PLATFORM == CC_PLATFORM_IOS) || (CC_TARGET_PLATFORM == CC_PLATFORM_LINUX)
     _hasPremultipliedAlpha = true;
 #else
     _hasPremultipliedAlpha = false;


### PR DESCRIPTION
Fix `Label` using system font on iOS draw without use premultiplied alpha blend;
