### PR TITLE
Fix bug that the position of CCMenuItem was not the same as setting in CocosBuilder

### DIFF
--- a/extensions/CCBReader/CCMenuLoader.h
+++ b/extensions/CCBReader/CCMenuLoader.h
@@ -17,7 +17,15 @@ class CC_EX_DLL CCMenuLoader : public CCLayerLoader {
         CCB_STATIC_NEW_AUTORELEASE_OBJECT_METHOD(CCMenuLoader, loader);
 
     protected:
-        CCB_VIRTUAL_NEW_AUTORELEASE_CREATECCNODE_METHOD(CCMenu);
+//        CCB_VIRTUAL_NEW_AUTORELEASE_CREATECCNODE_METHOD(CCMenu);
+    
+    virtual cocos2d::CCMenu * createCCNode(cocos2d::CCNode * pParent, cocos2d::extension::CCBReader * ccbReader) {
+        cocos2d::CCMenu* pMenu = cocos2d::CCMenu::create();
+        
+        pMenu->setContentSize(cocos2d::CCSize(0,0));
+        
+        return pMenu;
+    };
 };
 
 NS_CC_EXT_END


### PR DESCRIPTION
the position of CCMenuItem is depend on the content size of CCMenu.The default content size of CCMenu in cocosBuilder is (0,0).But not in cocos2d-x.
