### PR TITLE
close #5032:A potential crash bug of Lua binding

### DIFF
--- a/cocos/scripting/lua-bindings/manual/LuaBasicConversions.cpp
+++ b/cocos/scripting/lua-bindings/manual/LuaBasicConversions.cpp
@@ -340,6 +340,38 @@ bool luaval_to_vector3(lua_State* L,int lo,cocos2d::Vector3* outValue)
     return ok;
 }
 
+bool luaval_to_blendfunc(lua_State* L, int lo, cocos2d::BlendFunc* outValue)
+{
+    if (nullptr == L || nullptr == outValue)
+        return false;
+    
+    bool ok = true;
+    
+    tolua_Error tolua_err;
+    if (!tolua_istable(L, lo, 0, &tolua_err) )
+    {
+#if COCOS2D_DEBUG >=1
+        luaval_to_native_err(L,"#ferror:",&tolua_err);
+#endif
+        ok = false;
+    }
+    
+    
+    if (ok)
+    {
+        lua_pushstring(L, "src");
+        lua_gettable(L, lo);
+        outValue->src = lua_isnil(L, -1) ? 0 : lua_tonumber(L, -1);
+        lua_pop(L, 1);
+        
+        lua_pushstring(L, "dst");
+        lua_gettable(L, lo);
+        outValue->dst = lua_isnil(L, -1) ? 0 : lua_tonumber(L, -1);
+        lua_pop(L, 1);
+    }
+    return ok;
+}
+
 bool luaval_to_physics_material(lua_State* L,int lo,PhysicsMaterial* outValue)
 {
     if (NULL == L || NULL == outValue)
@@ -815,6 +847,60 @@ bool luaval_to_fontdefinition(lua_State* L, int lo, FontDefinition* outValue )
 
     
     return ok;
+}
+
+bool luaval_to_ttfconfig(lua_State* L,int lo, cocos2d::TTFConfig* outValue)
+{
+    if (nullptr == L || nullptr == outValue)
+        return false;
+    
+    bool ok = true;
+    
+    tolua_Error tolua_err;
+    if (!tolua_istable(L, lo, 0, &tolua_err) )
+    {
+#if COCOS2D_DEBUG >=1
+        luaval_to_native_err(L,"#ferror:",&tolua_err);
+#endif
+        ok = false;
+    }
+    
+    if (ok)
+    {
+        lua_pushstring(L, "fontFilePath");         /* L: paramStack key */
+        lua_gettable(L,lo);                        /* L: paramStack paramStack[lo][key] */
+        outValue->fontFilePath = lua_isstring(L, -1)? lua_tostring(L, -1) : "";
+        lua_pop(L,1);                              /* L: paramStack*/
+        
+        lua_pushstring(L, "fontSize");
+        lua_gettable(L,lo);
+        outValue->fontSize = lua_isnumber(L, -1)?(int)lua_tointeger(L, -1) : 0;
+        lua_pop(L,1);
+        
+        lua_pushstring(L, "glyphs");
+        lua_gettable(L, lo);
+        outValue->glyphs = lua_isnumber(L, -1)?static_cast<GlyphCollection>(lua_tointeger(L, -1)) : GlyphCollection::NEHE;
+        lua_pop(L, 1);
+        
+        lua_pushstring(L, "customGlyphs");
+        lua_gettable(L, lo);
+        outValue->customGlyphs = lua_isstring(L, -1)?lua_tostring(L, -1) : "";
+        lua_pop(L, 1);
+        
+        lua_pushstring(L, "distanceFieldEnabled");
+        lua_gettable(L, lo);
+        outValue->distanceFieldEnabled = lua_isboolean(L, -1)?lua_toboolean(L, -1) : false;
+        lua_pop(L, 1);
+        
+        lua_pushstring(L, "outlineSize");
+        lua_gettable(L, lo);
+        outValue->outlineSize = lua_isnumber(L, -1)?(int)lua_tointeger(L, -1) : 0;
+        lua_pop(L, 1);
+        
+        return true;
+    }
+    
+    return false;
 }
 
 bool luaval_to_matrix(lua_State* L, int lo, cocos2d::Matrix* outValue )
@@ -2335,4 +2421,58 @@ void matrix_to_luaval(lua_State* L, const cocos2d::Matrix& mat)
         lua_rawset(L, -3);
         ++indexTable;
     }
+}
+
+void blendfunc_to_luaval(lua_State* L, const cocos2d::BlendFunc& func)
+{
+    if (nullptr == L)
+        return;
+    
+    lua_newtable(L);                                    /* L: table */
+    
+    lua_pushstring(L, "src");                           /* L: table key */
+    lua_pushnumber(L, (lua_Number) func.src);           /* L: table key value*/
+    lua_rawset(L, -3);                                  /* table[key] = value, L: table */
+    lua_pushstring(L, "dst");                           /* L: table key */
+    lua_pushnumber(L, (lua_Number) func.dst);           /* L: table key value*/
+    lua_rawset(L, -3);
+}
+
+void ttfconfig_to_luaval(lua_State* L, const cocos2d::TTFConfig& config)
+{
+    if (nullptr == L)
+        return;
+    
+    lua_newtable(L);
+    
+    lua_pushstring(L, "fontFilePath");
+    lua_pushstring(L, config.fontFilePath.c_str());
+    lua_rawset(L, -3);
+    
+    lua_pushstring(L, "fontSize");
+    lua_pushnumber(L, (lua_Number)config.fontSize);
+    lua_rawset(L, -3);
+    
+    lua_pushstring(L, "glyphs");
+    lua_pushnumber(L, (lua_Number)config.glyphs);
+    lua_rawset(L, -3);
+    
+    lua_pushstring(L, "customGlyphs");
+    if (nullptr != config.customGlyphs && strlen(config.customGlyphs) > 0)
+    {
+        lua_pushstring(L, config.customGlyphs);
+    }
+    else
+    {
+        lua_pushstring(L, "");
+    }
+    lua_rawset(L, -3);
+    
+    lua_pushstring(L, "distanceFieldEnabled");
+    lua_pushboolean(L, config.distanceFieldEnabled);
+    lua_rawset(L, -3);
+    
+    lua_pushstring(L, "outlineSize");
+    lua_pushnumber(L, (lua_Number)config.outlineSize);
+    lua_rawset(L, -3);
 }

--- a/cocos/scripting/lua-bindings/manual/LuaBasicConversions.h
+++ b/cocos/scripting/lua-bindings/manual/LuaBasicConversions.h
@@ -77,6 +77,8 @@ extern bool luavals_variadic_to_array(lua_State* L,int argc, __Array** ret);
 extern bool luavals_variadic_to_ccvaluevector(lua_State* L, int argc, cocos2d::ValueVector* ret);
 extern bool luaval_to_vector2(lua_State* L,int lo,cocos2d::Vector2* outValue);
 extern bool luaval_to_vector3(lua_State* L,int lo,cocos2d::Vector3* outValue);
+extern bool luaval_to_blendfunc(lua_State* L, int lo, cocos2d::BlendFunc* outValue);
+extern bool luaval_to_ttfconfig(lua_State* L, int lo, cocos2d::TTFConfig* outValue);
 
 CC_DEPRECATED_ATTRIBUTE static inline bool luaval_to_point(lua_State* L,int lo,cocos2d::Vector2* outValue)
 {
@@ -248,6 +250,8 @@ extern void fontdefinition_to_luaval(lua_State* L,const FontDefinition& inValue)
 extern void array_to_luaval(lua_State* L, __Array* inValue);
 extern void dictionary_to_luaval(lua_State* L, __Dictionary* dict);
 extern void matrix_to_luaval(lua_State* L, const cocos2d::Matrix& mat);
+extern void blendfunc_to_luaval(lua_State* L, const cocos2d::BlendFunc& func);
+extern void ttfconfig_to_luaval(lua_State* L, const cocos2d::TTFConfig& config);
 
 CC_DEPRECATED_ATTRIBUTE static inline void point_to_luaval(lua_State* L,const cocos2d::Vector2& pt)
 {

--- a/cocos/scripting/lua-bindings/manual/lua_cocos2dx_manual.cpp
+++ b/cocos/scripting/lua-bindings/manual/lua_cocos2dx_manual.cpp
@@ -4894,60 +4894,6 @@ static void extendGridAction(lua_State* tolua_S)
     lua_pop(tolua_S, 1);
 }
 
-static bool luaval_to_TTFConfig(lua_State* L,int lo, TTFConfig* ret)
-{
-    if (nullptr == ret)
-        return false;
-    
-    bool ok = true;
-    
-    tolua_Error tolua_err;
-    if (!tolua_istable(L, lo, 0, &tolua_err) )
-    {
-#if COCOS2D_DEBUG >=1
-        luaval_to_native_err(L,"#ferror:",&tolua_err);
-#endif
-        ok = false;
-    }
-    
-    if (ok)
-    {
-        lua_pushstring(L, "fontFilePath");         /* L: paramStack key */
-        lua_gettable(L,lo);                        /* L: paramStack paramStack[lo][key] */
-        ret->fontFilePath = lua_isstring(L, -1)? lua_tostring(L, -1) : "";
-        lua_pop(L,1);                              /* L: paramStack*/
-        
-        lua_pushstring(L, "fontSize");
-        lua_gettable(L,lo);
-        ret->fontSize = lua_isnumber(L, -1)?(int)lua_tointeger(L, -1) : 0;
-        lua_pop(L,1);
-        
-        lua_pushstring(L, "glyphs");
-        lua_gettable(L, lo);
-        ret->glyphs = lua_isnumber(L, -1)?static_cast<GlyphCollection>(lua_tointeger(L, -1)) : GlyphCollection::NEHE;
-        lua_pop(L, 1);
-        
-        lua_pushstring(L, "customGlyphs");
-        lua_gettable(L, lo);
-        ret->customGlyphs = lua_isstring(L, -1)?lua_tostring(L, -1) : "";
-        lua_pop(L, 1);
-        
-        lua_pushstring(L, "distanceFieldEnabled");
-        lua_gettable(L, lo);
-        ret->distanceFieldEnabled = lua_isboolean(L, -1)?lua_toboolean(L, -1) : false;
-        lua_pop(L, 1);
-        
-        lua_pushstring(L, "outlineSize");
-        lua_gettable(L, lo);
-        ret->outlineSize = lua_isnumber(L, -1)?(int)lua_tointeger(L, -1) : 0;
-        lua_pop(L, 1);
-        
-        return true;
-    }
-    
-    return false;
-}
-
 static int lua_cocos2dx_Label_createWithTTF00(lua_State* L)
 {
     if (nullptr == L)
@@ -4978,7 +4924,7 @@ static int lua_cocos2dx_Label_createWithTTF00(lua_State* L)
         TTFConfig ttfConfig("");
         std::string text = "";
 
-        ok &= luaval_to_TTFConfig(L, 2, &ttfConfig);
+        ok &= luaval_to_ttfconfig(L, 2, &ttfConfig);
         if (!ok)
             return 0;
         
@@ -5002,57 +4948,6 @@ tolua_lerror:
     tolua_error(L,"#ferror in function 'lua_cocos2dx_Label_createWithTTF'.",&tolua_err);
 #endif
     return 0;
-}
-
-static int lua_cocos2dx_Label_setTTFConfig(lua_State* L)
-{
-    if (nullptr == L)
-        return 0;
-    
-    int argc = 0;
-    cocos2d::Label* self = nullptr;
-    bool ok  = true;
-    
-#if COCOS2D_DEBUG >= 1
-	tolua_Error tolua_err;
-	if (!tolua_isusertype(L,1,"cc.Label",0,&tolua_err)) goto tolua_lerror;
-#endif
-    
-    self = static_cast<cocos2d::Label*>(tolua_tousertype(L, 1, 0));
-    
-#if COCOS2D_DEBUG >= 1
-    if (nullptr == self)
-    {
-		tolua_error(L,"invalid 'self' in function 'lua_cocos2dx_Label_setTTFConfig'\n", nullptr);
-		return 0;
-	}
-#endif
-    
-    argc = lua_gettop(L) - 1;
-    if(1 == argc)
-    {
-        
-#if COCOS2D_DEBUG >= 1
-        if (!tolua_istable(L, 2, 0, &tolua_err))
-            goto tolua_lerror;
-#endif
-        TTFConfig ttfConfig("");
-        ok &= luaval_to_TTFConfig(L, 2, &ttfConfig);
-        if (!ok)
-            return 0;
-        
-        self->setTTFConfig(ttfConfig);
-        return 1;
-    }
-    
-    CCLOG("'create' has wrong number of arguments: %d, was expecting %d\n", argc, 1);
-	return 0;
-    
-#if COCOS2D_DEBUG >= 1
-tolua_lerror:
-    tolua_error(L,"#ferror in function 'setTTFConfig'.",&tolua_err);
-    return 0;
-#endif
 }
 
 static int lua_cocos2dx_Label_createWithTTF01(lua_State* L)
@@ -5163,7 +5058,6 @@ static void extendLabel(lua_State* tolua_S)
     if (lua_istable(tolua_S,-1))
     {
         tolua_function(tolua_S, "createWithTTF", lua_cocos2dx_Label_createWithTTF00);
-        tolua_function(tolua_S, "setTTFConfig",  lua_cocos2dx_Label_setTTFConfig);
         tolua_function(tolua_S, "createWithTTF", lua_cocos2dx_Label_createWithTTF01);
         tolua_function(tolua_S, "create", lua_cocos2dx_Label_create_deprecated);
     }

--- a/cocos/scripting/lua-bindings/manual/lua_cocos2dx_spine_manual.cpp
+++ b/cocos/scripting/lua-bindings/manual/lua_cocos2dx_spine_manual.cpp
@@ -306,6 +306,135 @@ static int tolua_spine_SkeletoneAnimation_setBlendFunc(lua_State* tolua_S)
     return tolua_cocos2dx_setBlendFunc<spine::SkeletonAnimation>(tolua_S,"sp.SkeletonAnimation");
 }
 
+static int lua_cocos2dx_spine_SkeletonAnimation_addAnimation(lua_State* tolua_S)
+{
+    int argc = 0;
+    spine::SkeletonAnimation* cobj = nullptr;
+    bool ok  = true;
+    
+#if COCOS2D_DEBUG >= 1
+    tolua_Error tolua_err;
+#endif
+    
+    
+#if COCOS2D_DEBUG >= 1
+    if (!tolua_isusertype(tolua_S,1,"sp.SkeletonAnimation",0,&tolua_err)) goto tolua_lerror;
+#endif
+    
+    cobj = (spine::SkeletonAnimation*)tolua_tousertype(tolua_S,1,0);
+    
+#if COCOS2D_DEBUG >= 1
+    if (!cobj)
+    {
+        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_cocos2dx_spine_SkeletonAnimation_addAnimation'", nullptr);
+        return 0;
+    }
+#endif
+    
+    argc = lua_gettop(tolua_S)-1;
+    if (argc == 3)
+    {
+        int arg0;
+        const char* arg1;
+        bool arg2;
+        
+        ok &= luaval_to_int32(tolua_S, 2,(int *)&arg0);
+        
+        std::string arg1_tmp; ok &= luaval_to_std_string(tolua_S, 3, &arg1_tmp); arg1 = arg1_tmp.c_str();
+        
+        ok &= luaval_to_boolean(tolua_S, 4,&arg2);
+        if(!ok)
+            return 0;
+        cobj->addAnimation(arg0, arg1, arg2);
+        
+        return 0;
+    }
+    if (argc == 4)
+    {
+        int arg0;
+        const char* arg1;
+        bool arg2;
+        double arg3;
+        
+        ok &= luaval_to_int32(tolua_S, 2,(int *)&arg0);
+        
+        std::string arg1_tmp; ok &= luaval_to_std_string(tolua_S, 3, &arg1_tmp); arg1 = arg1_tmp.c_str();
+        
+        ok &= luaval_to_boolean(tolua_S, 4,&arg2);
+        
+        ok &= luaval_to_number(tolua_S, 5,&arg3);
+        if(!ok)
+            return 0;
+        
+        cobj->addAnimation(arg0, arg1, arg2, arg3);
+
+        return 0;
+    }
+    CCLOG("%s has wrong number of arguments: %d, was expecting %d \n", "addAnimation",argc, 3);
+    return 0;
+    
+#if COCOS2D_DEBUG >= 1
+tolua_lerror:
+    tolua_error(tolua_S,"#ferror in function 'lua_cocos2dx_spine_SkeletonAnimation_addAnimation'.",&tolua_err);
+#endif
+    
+    return 0;
+}
+
+static int lua_cocos2dx_spine_SkeletonAnimation_setAnimation(lua_State* tolua_S)
+{
+    int argc = 0;
+    spine::SkeletonAnimation* cobj = nullptr;
+    bool ok  = true;
+    
+#if COCOS2D_DEBUG >= 1
+    tolua_Error tolua_err;
+#endif
+    
+    
+#if COCOS2D_DEBUG >= 1
+    if (!tolua_isusertype(tolua_S,1,"sp.SkeletonAnimation",0,&tolua_err)) goto tolua_lerror;
+#endif
+    
+    cobj = (spine::SkeletonAnimation*)tolua_tousertype(tolua_S,1,0);
+    
+#if COCOS2D_DEBUG >= 1
+    if (!cobj)
+    {
+        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_cocos2dx_spine_SkeletonAnimation_setAnimation'", nullptr);
+        return 0;
+    }
+#endif
+    
+    argc = lua_gettop(tolua_S)-1;
+    if (argc == 3)
+    {
+        int arg0;
+        const char* arg1;
+        bool arg2;
+        
+        ok &= luaval_to_int32(tolua_S, 2,(int *)&arg0);
+        
+        std::string arg1_tmp; ok &= luaval_to_std_string(tolua_S, 3, &arg1_tmp); arg1 = arg1_tmp.c_str();
+        
+        ok &= luaval_to_boolean(tolua_S, 4,&arg2);
+        if(!ok)
+            return 0;
+        
+        cobj->setAnimation(arg0, arg1, arg2);
+        
+        return 0;
+    }
+    CCLOG("%s has wrong number of arguments: %d, was expecting %d \n", "setAnimation",argc, 3);
+    return 0;
+    
+#if COCOS2D_DEBUG >= 1
+tolua_lerror:
+    tolua_error(tolua_S,"#ferror in function 'lua_cocos2dx_spine_SkeletonAnimation_setAnimation'.",&tolua_err);
+#endif
+    
+    return 0;
+}
 
 static void extendCCSkeletonAnimation(lua_State* L)
 {
@@ -321,6 +450,8 @@ static void extendCCSkeletonAnimation(lua_State* L)
         tolua_function(L, "setDebugSlots", tolua_Cocos2d_CCSkeletonAnimation_setDebugSlots00);
         tolua_function(L, "setDebugBones", tolua_Cocos2d_CCSkeletonAnimation_setDebugBones00);
         tolua_function(L, "setPremultipliedAlpha", tolua_Cocos2d_CCSkeletonAnimation_setPremultipliedAlpha00);
+        tolua_function(L, "addAnimation", lua_cocos2dx_spine_SkeletonAnimation_addAnimation);
+        tolua_function(L, "setAnimation", lua_cocos2dx_spine_SkeletonAnimation_setAnimation);
     }
     lua_pop(L, 1);
 }

--- a/cocos/scripting/lua-bindings/script/Cocos2dConstants.lua
+++ b/cocos/scripting/lua-bindings/script/Cocos2dConstants.lua
@@ -363,6 +363,16 @@ cc.GLYPHCOLLECTION_NEHE    = 1
 cc.GLYPHCOLLECTION_ASCII   = 2
 cc.GLYPHCOLLECTION_CUSTOM  = 3
 
+cc.ResolutionPolicy = 
+{
+    EXACT_FIT = 0,
+    NO_BORDER = 1,
+    SHOW_ALL  = 2,
+    FIXED_HEIGHT  = 3,
+    FIXED_WIDTH  = 4,
+    UNKNOWN  = 5,
+}
+
 cc.LabelEffect = 
 {
     NORMAL  = 0,

--- a/tools/tolua/cocos2dx.ini
+++ b/tools/tolua/cocos2dx.ini
@@ -48,7 +48,7 @@ skip = Node::[setGLServerState description getUserObject .*UserData getGLServerS
         Layer.*::[didAccelerate (g|s)etBlendFunc keyPressed keyReleased],
         Menu.*::[.*Target getSubItems create initWithItems alignItemsInRows alignItemsInColumns],
         MenuItem.*::[create setCallback initWithCallback],
-        Label::[getLettersInfo createWithTTF setTTFConfig listenToBackground listenToFontAtlasPurge],
+        Label::[getLettersInfo createWithTTF listenToBackground listenToFontAtlasPurge],
         Copying::[*],
         LabelProtocol::[*],
         LabelTextFormatProtocol::[*],
@@ -83,7 +83,7 @@ skip = Node::[setGLServerState description getUserObject .*UserData getGLServerS
         EventListener.*::[create],
         EventTouch::[(s|g)etTouches],
         NotificationObserver::[*],
-        Image::[initWithString initWithImageData initWithRawData],
+        Image::[initWithString initWithImageData initWithRawData getData getMipmaps],
         Sequence::[create],
         Spawn::[create],
         GLProgram::[getProgram setUniformLocationWith2f.* setUniformLocationWith1f.* setUniformLocationWith3f.* setUniformLocationWith4f.*],
@@ -117,7 +117,9 @@ skip = Node::[setGLServerState description getUserObject .*UserData getGLServerS
         EventDispatcher::[dispatchCustomEvent],
         EventCustom::[getUserData setUserData],
         Component::[serialize],
-        Console::[addCommand]
+        Console::[addCommand],
+        ParallaxNode::[getParallaxArray],
+        TileMapAtlas::[getTGAInfo]
 
 rename_functions = SpriteFrameCache::[addSpriteFramesWithFile=addSpriteFrames getSpriteFrameByName=getSpriteFrame],
     ProgressTimer::[setReverseProgress=setReverseDirection],

--- a/tools/tolua/cocos2dx_spine.ini
+++ b/tools/tolua/cocos2dx_spine.ini
@@ -37,7 +37,7 @@ classes = Skeleton SkeletonAnimation
 # functions from all classes.
 
 skip = Skeleton::[findBone findSlot getAttachment setAttachment update draw createWith.*],
-        SkeletonAnimation::[addAnimationState setAnimationStateData update createWith.* (s|g)etBlendFunc]
+        SkeletonAnimation::[addAnimationState setAnimationStateData update createWith.* (s|g)etBlendFunc addAnimation getCurrent setAnimation]
 
 rename_functions = 
 


### PR DESCRIPTION
When the Lua binding functions didn't push the value to the stack,but the return value is greater than zero, this situation may lead to potentail crash.For example:

```
int lua_cocos2dx_spine_SkeletonAnimation_setAnimation(lua_State* tolua_S)
```

When this Lua binding function called in Lua script on the Mac platform，it leads to crash.
