### PR TITLE
Fix crash: use cocostudio gui editor, create a action in editor, when yo...

### DIFF
--- a/cocos/editor-support/cocostudio/CCActionObject.cpp
+++ b/cocos/editor-support/cocostudio/CCActionObject.cpp
@@ -52,6 +52,7 @@ ActionObject::~ActionObject()
 {
 	_actionNodeList.clear();
 	CC_SAFE_RELEASE(_pScheduler);
+	CC_SAFE_RELEASE(_CallBack);
 }
 
 void ActionObject::setName(const char* name)
@@ -166,6 +167,7 @@ void ActionObject::play(CallFunc* func)
 {
 	this->play();
 	this->_CallBack = func;
+	CC_SAFE_RETAIN(_CallBack);
 }
 void ActionObject::pause()
 {
@@ -213,6 +215,11 @@ void ActionObject::simulationActionUpdate(float dt)
 		if (_loop)
 		{
 			this->play();
+		}
+		else
+		{
+			CC_SAFE_RELEASE_NULL(_CallBack);
+			_pScheduler->unschedule(schedule_selector(ActionObject::simulationActionUpdate), this);
 		}
 	}
 }

--- a/cocos/editor-support/cocostudio/CCActionObject.cpp
+++ b/cocos/editor-support/cocostudio/CCActionObject.cpp
@@ -218,7 +218,6 @@ void ActionObject::simulationActionUpdate(float dt)
 		}
 		else
 		{
-			CC_SAFE_RELEASE_NULL(_CallBack);
 			_pScheduler->unschedule(schedule_selector(ActionObject::simulationActionUpdate), this);
 		}
 	}


### PR DESCRIPTION
Fix crash: use cocostudio gui editor, create a action in editor, when you play like:

```
auto _action = getActionByName("action_name");
    _action->play(CallFunc::create([](){
    CCLOG("done.");
    }));
```

It'll crash.

if we just     CC_SAFE_RETAIN(_CallBack) and relase _CallBack, the log will not stop, so unschedule 
