### PR TITLE
Add new functionality for managing scenes. Fix bugs, added example of use.

### DIFF
--- a/cocos/2d/CCTransition.cpp
+++ b/cocos/2d/CCTransition.cpp
@@ -157,6 +157,15 @@ void TransitionScene::hideOutShowIn()
     _outScene->setVisible(false);
 }
 
+Scene* TransitionScene::getInScene() const
+{
+    return _inScene;
+}
+
+Scene* TransitionScene::getOutScene() const
+{
+    return _outScene;
+}
 
 // custom onEnter
 void TransitionScene::onEnter()

--- a/cocos/2d/CCTransition.h
+++ b/cocos/2d/CCTransition.h
@@ -82,6 +82,12 @@ public:
     /** creates a base transition with duration and incoming scene */
     static TransitionScene * create(float t, Scene *scene);
 
+    /** getter for in scene */
+    Scene* getInScene() const;
+    
+    /** getter for out scene */
+    Scene* getOutScene() const;
+
     /** called after the transition finishes */
     void finish(void);
 

--- a/cocos/base/CCDirector.cpp
+++ b/cocos/base/CCDirector.cpp
@@ -820,13 +820,26 @@ void Director::replaceScene(Scene *scene)
     
     if (_nextScene)
     {
-        if (_nextScene->isRunning())
+        TransitionScene* transitionScene = dynamic_cast<TransitionScene*>(scene);
+
+        // scene is transition and check: are transition contains next scene as _inScene?
+        if (transitionScene != nullptr && transitionScene->getInScene() == _nextScene)
         {
-            _nextScene->onExitTransitionDidStart();
-            _nextScene->onExit();
+            // nothing to do, because scene contains current _nextScene
+            // example
+            // auto newScene = Director::getInstance()->popToRootScene();
+            // Director::getInstance()->pushScene(TransitionFade::create(0.5, newScene, Color3B(0,255,255)));
         }
-        _nextScene->cleanup();
-        _nextScene = nullptr;
+        else
+        {
+            if (_nextScene->isRunning())
+            {
+                _nextScene->onExitTransitionDidStart();
+                _nextScene->onExit();
+            }
+            _nextScene->cleanup();
+            _nextScene = nullptr;
+        }
     }
 
     ssize_t index = _scenesStack.size();
@@ -847,7 +860,7 @@ void Director::pushScene(Scene *scene)
     _nextScene = scene;
 }
 
-void Director::popScene(void)
+Scene* Director::popScene(void)
 {
     CCASSERT(_runningScene != nullptr, "running scene should not null");
 
@@ -857,53 +870,59 @@ void Director::popScene(void)
     if (c == 0)
     {
         end();
+        return nullptr;
     }
     else
     {
         _sendCleanupToScene = true;
         _nextScene = _scenesStack.at(c - 1);
+        return _nextScene;
     }
 }
 
-void Director::popToRootScene(void)
+Scene* Director::popToRootScene(void)
 {
-    popToSceneStackLevel(1);
+    return popToSceneStackLevel(1);
 }
 
-void Director::popToSceneStackLevel(int level)
+Scene* Director::popToSceneStackLevel(int level)
 {
     CCASSERT(_runningScene != nullptr, "A running Scene is needed");
-    ssize_t c = _scenesStack.size();
 
     // level 0? -> end
     if (level == 0)
     {
         end();
-        return;
+        return nullptr;
     }
 
+    ssize_t stackSize = _scenesStack.size();
+
     // current level or lower -> nothing
-    if (level >= c)
-        return;
+    if (level >= stackSize)
+        return nullptr;
+
+    // pop from stack running scene
+    auto currentRunningScene = _scenesStack.back();
+    _scenesStack.popBack();
+    CCASSERT(currentRunningScene == _runningScene, "Invalid state of scene stack.");
+
+    // current scene will be cleaned up 
+    _sendCleanupToScene = true;
+    --stackSize;
 
     // pop stack until reaching desired level
-    while (c > level)
+    while (stackSize > level)
     {
         auto current = _scenesStack.back();
-
-        if (current->isRunning())
-        {
-            current->onExitTransitionDidStart();
-            current->onExit();
-        }
-
         current->cleanup();
         _scenesStack.popBack();
-        --c;
+        --stackSize;
     }
 
     _nextScene = _scenesStack.back();
-    _sendCleanupToScene = false;
+
+    return _nextScene;
 }
 
 void Director::end()

--- a/cocos/base/CCDirector.h
+++ b/cocos/base/CCDirector.h
@@ -270,20 +270,20 @@ public:
      * The running scene will be deleted. If there are no more scenes in the stack the execution is terminated.
      * ONLY call it if there is a running scene.
      */
-    void popScene();
+    Scene* popScene();
 
     /** Pops out all scenes from the stack until the root scene in the queue.
      * This scene will replace the running one.
      * Internally it will call `popToSceneStackLevel(1)`
      */
-    void popToRootScene();
+    Scene* popToRootScene();
 
     /** Pops out all scenes from the stack until it reaches `level`.
      If level is 0, it will end the director.
      If level is 1, it will pop all scenes until it reaches to root scene.
      If level is <= than the current stack level, it won't do anything.
      */
- 	void popToSceneStackLevel(int level);
+    Scene* popToSceneStackLevel(int level);
 
     /** Replaces the running scene with a new one. The running scene is terminated.
      * ONLY call it if there is a running scene.

--- a/tests/cpp-tests/Classes/SceneTest/SceneTest.cpp
+++ b/tests/cpp-tests/Classes/SceneTest/SceneTest.cpp
@@ -30,10 +30,18 @@ SceneTestLayer1::SceneTestLayer1()
     auto s = Director::getInstance()->getWinSize();
     auto sprite = Sprite::create(s_pathGrossini);
     addChild(sprite);
-    sprite->setPosition( Vector2(s.width-40, s.height/2) );
     auto rotate = RotateBy::create(2, 360);
     auto repeat = RepeatForever::create(rotate);
     sprite->runAction(repeat);
+
+    auto move = Sequence::create(
+        MoveTo::create(2, Vector2(0.0f, s.height)),
+        MoveTo::create(2, Vector2(s.width, s.height)),
+        MoveTo::create(2, Vector2(s.width, 0.0f)),
+        MoveTo::create(2, Vector2(0.0f, 0.0f)),
+        nullptr);
+    auto repeatMove = RepeatForever::create(move);
+    sprite->runAction(repeatMove);
 
     schedule( schedule_selector(SceneTestLayer1::testDealloc) );
 }
@@ -84,13 +92,7 @@ void SceneTestLayer1::onPushSceneTran(Ref* sender)
 
 void SceneTestLayer1::onQuit(Ref* sender)
 {
-    //getCocosApp()->exit();
-    //CCDirector::getInstance()->poscene();
-
-    //// HA HA... no more terminate on sdk v3.0
-    //// http://developer.apple.com/iphone/library/qa/qa2008/qa1561.html
-    //if( [[UIApplication sharedApplication] respondsToSelector:@selector(terminate)] )
-    //    [[UIApplication sharedApplication] performSelector:@selector(terminate)];
+    Director::getInstance()->popToSceneStackLevel(0);
 }
 
 //------------------------------------------------------------------
@@ -106,8 +108,9 @@ SceneTestLayer2::SceneTestLayer2()
     auto item1 = MenuItemFont::create( "replaceScene", CC_CALLBACK_1(SceneTestLayer2::onReplaceScene, this));
     auto item2 = MenuItemFont::create( "replaceScene w/transition", CC_CALLBACK_1(SceneTestLayer2::onReplaceSceneTran, this));
     auto item3 = MenuItemFont::create( "Go Back", CC_CALLBACK_1(SceneTestLayer2::onGoBack, this));
+    auto item4 = MenuItemFont::create("Go Back w/transition", CC_CALLBACK_1(SceneTestLayer2::onGoBackTransition, this));
     
-    auto menu = Menu::create( item1, item2, item3, NULL );
+    auto menu = Menu::create(item1, item2, item3, item4, nullptr);
     menu->alignItemsVertically();
     
     addChild( menu );
@@ -115,10 +118,18 @@ SceneTestLayer2::SceneTestLayer2()
     auto s = Director::getInstance()->getWinSize();
     auto sprite = Sprite::create(s_pathGrossini);
     addChild(sprite);
-    sprite->setPosition( Vector2(s.width-40, s.height/2) );
     auto rotate = RotateBy::create(2, 360);
     auto repeat = RepeatForever::create(rotate);
     sprite->runAction(repeat);
+
+    auto move = Sequence::create(
+        MoveTo::create(2, Vector2(0.0f, s.height)),
+        MoveTo::create(2, Vector2(s.width, s.height)),
+        MoveTo::create(2, Vector2(s.width, 0.0f)),
+        MoveTo::create(2, Vector2(0.0f, 0.0f)),
+        nullptr);
+    auto repeatMove = RepeatForever::create(move);
+    sprite->runAction(repeatMove);
 
     schedule( schedule_selector(SceneTestLayer2::testDealloc) );
 }
@@ -133,6 +144,11 @@ void SceneTestLayer2::testDealloc(float dt)
 void SceneTestLayer2::onGoBack(Ref* sender)
 {
     Director::getInstance()->popScene();
+}
+
+void SceneTestLayer2::onGoBackTransition(Ref* sender)
+{
+    Director::getInstance()->replaceScene(TransitionFlipX::create(2, Director::getInstance()->popScene()));
 }
 
 void SceneTestLayer2::onReplaceScene(Ref* sender)
@@ -171,12 +187,15 @@ bool SceneTestLayer3::init()
     {
         auto s = Director::getInstance()->getWinSize();
 
-        auto item0 = MenuItemFont::create("Touch to pushScene (self)", CC_CALLBACK_1(SceneTestLayer3::item0Clicked, this));
-        auto item1 = MenuItemFont::create("Touch to poscene", CC_CALLBACK_1(SceneTestLayer3::item1Clicked, this));
-        auto item2 = MenuItemFont::create("Touch to popToRootScene", CC_CALLBACK_1(SceneTestLayer3::item2Clicked, this));
-        auto item3 = MenuItemFont::create("Touch to popToSceneStackLevel(2)", CC_CALLBACK_1(SceneTestLayer3::item3Clicked, this));
+        auto item0 = MenuItemFont::create("pushScene (self)", CC_CALLBACK_1(SceneTestLayer3::item0Clicked, this));
+        auto item1 = MenuItemFont::create("popScene", CC_CALLBACK_1(SceneTestLayer3::item1Clicked, this));
+        auto item2 = MenuItemFont::create("popToRootScene", CC_CALLBACK_1(SceneTestLayer3::item2Clicked, this));
+        auto item3 = MenuItemFont::create("popToSceneStackLevel(2)", CC_CALLBACK_1(SceneTestLayer3::item3Clicked, this));
+        auto item4 = MenuItemFont::create("popScene w/transition", CC_CALLBACK_1(SceneTestLayer3::item4Clicked, this));
+        auto item5 = MenuItemFont::create("popToRootScene w/transition", CC_CALLBACK_1(SceneTestLayer3::item5Clicked, this));
+        auto item6 = MenuItemFont::create("popToSceneStackLevel(2) w/transition", CC_CALLBACK_1(SceneTestLayer3::item6Clicked, this));
 
-        auto menu = Menu::create(item0, item1, item2, item3, NULL);
+        auto menu = Menu::create(item0, item1, item2, item3, item4, item5, item6, nullptr);
         this->addChild(menu);
         menu->alignItemsVertically();
 
@@ -184,10 +203,19 @@ bool SceneTestLayer3::init()
 
         auto sprite = Sprite::create(s_pathGrossini);
         addChild(sprite);
-        sprite->setPosition( Vector2(s.width/2, 40) );
         auto rotate = RotateBy::create(2, 360);
         auto repeat = RepeatForever::create(rotate);
         sprite->runAction(repeat);
+
+        auto move = Sequence::create(
+            MoveTo::create(2, Vector2(0.0f, s.height)),
+            MoveTo::create(2, Vector2(s.width, s.height)),
+            MoveTo::create(2, Vector2(s.width, 0.0f)),
+            MoveTo::create(2, Vector2(0.0f, 0.0f)),
+            nullptr);
+        auto repeatMove = RepeatForever::create(move);
+        sprite->runAction(repeatMove);
+
         return true;
     }
     return false;
@@ -218,6 +246,36 @@ void SceneTestLayer3::item2Clicked(Ref* sender)
 void SceneTestLayer3::item3Clicked(Ref* sender)
 {
     Director::getInstance()->popToSceneStackLevel(2);
+}
+
+void SceneTestLayer3::item4Clicked(Ref* sender)
+{
+    auto nextScene = Director::getInstance()->popScene();
+    // if pop scene is successful
+    if (nextScene != nullptr)
+    {
+        Director::getInstance()->replaceScene(TransitionFlipX::create(2, nextScene));
+    }
+}
+
+void SceneTestLayer3::item5Clicked(Ref* sender)
+{
+    auto nextScene = Director::getInstance()->popToRootScene();
+    // if pop to root scene is successful
+    if (nextScene != nullptr)
+    {
+        Director::getInstance()->replaceScene(TransitionFlipX::create(2, nextScene));
+    }
+}
+
+void SceneTestLayer3::item6Clicked(Ref* sender)
+{
+    auto nextScene = Director::getInstance()->popToSceneStackLevel(2);
+    // if pop tot scenes stack level is successful
+    if (nextScene != nullptr)
+    {
+        Director::getInstance()->replaceScene(TransitionFlipX::create(2, nextScene));
+    }
 }
 
 void SceneTestScene::runThisTest()

--- a/tests/cpp-tests/Classes/SceneTest/SceneTest.h
+++ b/tests/cpp-tests/Classes/SceneTest/SceneTest.h
@@ -29,6 +29,7 @@ public:
 
     void testDealloc(float dt);
     void onGoBack(Ref* sender);
+    void onGoBackTransition(Ref* sender);
     void onReplaceScene(Ref* sender);
     void onReplaceSceneTran(Ref* sender);
 
@@ -45,6 +46,10 @@ public:
     void item1Clicked(Ref* sender);
     void item2Clicked(Ref* sender);
     void item3Clicked(Ref* sender);
+    void item4Clicked(Ref* sender);
+    void item5Clicked(Ref* sender);
+    void item6Clicked(Ref* sender);
+
     CREATE_FUNC(SceneTestLayer3)
 } ;
 


### PR DESCRIPTION
Now, next methods returning _nextScene.
Scene\* popScene();
Scene\* popToRootScene();
Scene\* popToSceneStackLevel(int level);
This makes it possible to creating transition for popScene (or other).
Example of use:
Director::sharedDirector()->replaceScene(TransitionSlideInL::create(0.5,Director::sharedDirector()->popSceneBack()));
Similar pull request https://github.com/cocos2d/cocos2d-x/pull/3244

But this pull request is wrong, because Replace scene cleaning up _nextScene.
In method  "replaceScene" now checks this situation.
Also, fixed bug with double calling onExitTransitionDidStart() and onExit() in popToSceneStackLevel for running scene.
Example of use for this functionality added to TestScene. Аdded more visual presentation for using this functionality.
