### PR TITLE
Fix the variable "isTween" value error.

### DIFF
--- a/cocos/editor-support/cocostudio/CCDatas.cpp
+++ b/cocos/editor-support/cocostudio/CCDatas.cpp
@@ -291,6 +291,7 @@ void FrameData::copy(const BaseData *baseData)
         }
 
         blendFunc = frameData->blendFunc;
+        isTween = frameData->isTween;
     }
 }
 


### PR DESCRIPTION
In the function "FrameData::copy", the variable "isTween" had not
assigned correctly.
