### PR TITLE
Fix the RenderTexture bounding box issue.

### DIFF
--- a/cocos/2d/CCRenderTexture.cpp
+++ b/cocos/2d/CCRenderTexture.cpp
@@ -191,6 +191,8 @@ bool RenderTexture::initWithWidthAndHeight(int w, int h, Texture2D::PixelFormat 
 
     bool ret = false;
     void *data = nullptr;
+    int designWidth = w;
+    int designHeight = h;
     do 
     {
         _fullRect = _rtTextureRect = Rect(0,0,w,h);
@@ -275,6 +277,12 @@ bool RenderTexture::initWithWidthAndHeight(int w, int h, Texture2D::PixelFormat 
         CCASSERT(glCheckFramebufferStatus(GL_FRAMEBUFFER) == GL_FRAMEBUFFER_COMPLETE, "Could not attach texture to framebuffer");
 
         _texture->setAliasTexParameters();
+        
+        // default transform anchor: center
+        setAnchorPoint(Vector2(0.5f, 0.5f));
+        
+        // content size using design resolution
+        setContentSize(Size(designWidth, designHeight));
 
         // retained
         setSprite(Sprite::createWithTexture(_texture));
@@ -672,7 +680,7 @@ void RenderTexture::draw(Renderer *renderer, const Matrix &transform, bool trans
         for(const auto &child: _children)
         {
             if (child != _sprite)
-                child->visit(renderer, transform, transformUpdated);
+                child->visit(renderer, Matrix::identity(), transformUpdated);
         }
 
         //End will pop the current render group

--- a/cocos/2d/CCRenderTexture.h
+++ b/cocos/2d/CCRenderTexture.h
@@ -150,6 +150,7 @@ public:
         CC_SAFE_RETAIN(sprite);
         CC_SAFE_RELEASE(_sprite);
         _sprite = sprite;
+        _sprite->setAnchorPoint(Vector2::ZERO);
     };
     
     // Overrides

--- a/tests/cpp-tests/Classes/RenderTextureTest/RenderTextureTest.cpp
+++ b/tests/cpp-tests/Classes/RenderTextureTest/RenderTextureTest.cpp
@@ -646,8 +646,9 @@ void RenderTextureTargetNode::update(float dt)
 {
     static float time = 0;
     float r = 80;
-    sprite1->setPosition(Vector2(cosf(time * 2) * r, sinf(time * 2) * r));
-    sprite2->setPosition(Vector2(sinf(time * 2) * r, cosf(time * 2) * r));
+    Size winSize = Director::getInstance()->getWinSize();
+    sprite1->setPosition(Vector2(cosf(time * 2) * r + winSize.width / 2, sinf(time * 2) * r + winSize.height / 2));
+    sprite2->setPosition(Vector2(sinf(time * 2) * r + winSize.width / 2, cosf(time * 2) * r + winSize.height / 2));
     
     time += dt;
 }


### PR DESCRIPTION
1. the default anchor point of RenderTexture is center now; 
2. the default anchor point of the bound sprite is left-bottom now which insures its BB is consistent with the RenderTexture; 
3. the transforms of the bound children of a RenderTexture should ONLY based on the their parent. 
4. update RenderTextureTest.
