### PR TITLE
EventDispatcher bug fix

### DIFF
--- a/cocos/base/CCEventDispatcher.cpp
+++ b/cocos/base/CCEventDispatcher.cpp
@@ -293,11 +293,11 @@ void EventDispatcher::pauseEventListenersForTarget(Node* target, bool recursive/
         }
     }
 
-    for (auto addedListenerIter : _toAddedListeners)
+    for (auto& listener : _toAddedListeners)
     {
-        if (addedListenerIter->getAssociatedNode() == target)
+        if (listener->getAssociatedNode() == target)
         {
-            addedListenerIter->setPaused(true);
+            listener->setPaused(true);
         }
     }
     
@@ -323,11 +323,11 @@ void EventDispatcher::resumeEventListenersForTarget(Node* target, bool recursive
         }
     }
     
-    for (auto addedListenerIter : _toAddedListeners)
+    for (auto& listener : _toAddedListeners)
     {
-        if (addedListenerIter->getAssociatedNode() == target)
+        if (listener->getAssociatedNode() == target)
         {
-            addedListenerIter->setPaused(false);
+            listener->setPaused(false);
         }
     }
 

--- a/cocos/base/CCEventDispatcher.cpp
+++ b/cocos/base/CCEventDispatcher.cpp
@@ -292,6 +292,14 @@ void EventDispatcher::pauseEventListenersForTarget(Node* target, bool recursive/
             l->setPaused(true);
         }
     }
+
+    for (auto addedListenerIter : _toAddedListeners)
+    {
+        if (addedListenerIter->getAssociatedNode() == target)
+        {
+            addedListenerIter->setPaused(true);
+        }
+    }
     
     if (recursive)
     {
@@ -314,6 +322,15 @@ void EventDispatcher::resumeEventListenersForTarget(Node* target, bool recursive
             l->setPaused(false);
         }
     }
+    
+    for (auto addedListenerIter : _toAddedListeners)
+    {
+        if (addedListenerIter->getAssociatedNode() == target)
+        {
+            addedListenerIter->setPaused(false);
+        }
+    }
+
     setDirtyForNode(target);
     
     if (recursive)


### PR DESCRIPTION
Hi
This is EventDispatcher bug fix branch.
The issue occurs when...
1. Push the button. (So, EventDispatcher's _inDispatch > 0)
2. Create a layer.
3. Call EventDispatcher's addListenerSceneGraph to listen touch events. The node is the layer.
4. Not associated immediately. Because _inDispatch is bigger then 0.
5. Call Director's pushScene a scene that has the layer.
5. So when the layer is entering -> layer resumed -> calls EventDispatcher's resumeEventListenersForTarget -> cannot find the layer. -> added listener is not resumed. -> bug
