### PR TITLE
Fix Progress Action. Not working with charging from 100 to 0.

### DIFF
--- a/cocos/2d/CCActionProgressTimer.cpp
+++ b/cocos/2d/CCActionProgressTimer.cpp
@@ -72,13 +72,6 @@ void ProgressTo::startWithTarget(Node *target)
 {
     ActionInterval::startWithTarget(target);
     _from = ((kProgressTimerCast)(target))->getPercentage();
-
-    // XXX: Is this correct ?
-    // Adding it to support Repeat
-    if (_from == 100)
-    {
-        _from = 0;
-    }
 }
 
 void ProgressTo::update(float time)

--- a/tests/cpp-tests/Classes/ActionsProgressTest/ActionsProgressTest.cpp
+++ b/tests/cpp-tests/Classes/ActionsProgressTest/ActionsProgressTest.cpp
@@ -157,8 +157,8 @@ void SpriteProgressToRadial::onEnter()
     
     auto s = Director::getInstance()->getWinSize();
 
-    auto to1 = ProgressTo::create(2, 100);
-    auto to2 = ProgressTo::create(2, 100);
+    auto to1 = Sequence::createWithTwoActions(ProgressTo::create(2, 100), ProgressTo::create(0, 0));
+    auto to2 = Sequence::createWithTwoActions(ProgressTo::create(2, 100), ProgressTo::create(0, 0));
 
     auto left = ProgressTimer::create(Sprite::create(s_pathSister1));
     left->setType( ProgressTimer::Type::RADIAL );
@@ -192,8 +192,8 @@ void SpriteProgressToHorizontal::onEnter()
     
     auto s = Director::getInstance()->getWinSize();
     
-    auto to1 = ProgressTo::create(2, 100);
-    auto to2 = ProgressTo::create(2, 100);
+    auto to1 = Sequence::createWithTwoActions(ProgressTo::create(2, 100), ProgressTo::create(0, 0));
+    auto to2 = Sequence::createWithTwoActions(ProgressTo::create(2, 100), ProgressTo::create(0, 0));
     
     auto left = ProgressTimer::create(Sprite::create(s_pathSister1));
     left->setType(ProgressTimer::Type::BAR);
@@ -232,8 +232,8 @@ void SpriteProgressToVertical::onEnter()
     
     auto s = Director::getInstance()->getWinSize();
     
-    auto to1 = ProgressTo::create(2, 100);
-    auto to2 = ProgressTo::create(2, 100);
+    auto to1 = Sequence::createWithTwoActions(ProgressTo::create(2, 100), ProgressTo::create(0, 0));
+    auto to2 = Sequence::createWithTwoActions(ProgressTo::create(2, 100), ProgressTo::create(0, 0));
     
     auto left = ProgressTimer::create(Sprite::create(s_pathSister1));
     left->setType(ProgressTimer::Type::BAR);
@@ -273,7 +273,7 @@ void SpriteProgressToRadialMidpointChanged::onEnter()
 
     auto s = Director::getInstance()->getWinSize();
 
-    auto action = ProgressTo::create(2, 100);
+    auto action = Sequence::createWithTwoActions(ProgressTo::create(2, 100), ProgressTo::create(0, 0));
 
     /**
    *  Our image on the left should be a radial progress indicator, clockwise
@@ -317,7 +317,7 @@ void SpriteProgressBarVarious::onEnter()
 
     auto s = Director::getInstance()->getWinSize();
 
-    auto to = ProgressTo::create(2, 100);
+    auto to = Sequence::createWithTwoActions(ProgressTo::create(2, 100), ProgressTo::create(0, 0));
 
     auto left = ProgressTimer::create(Sprite::create(s_pathSister1));
     left->setType(ProgressTimer::Type::BAR);
@@ -367,7 +367,7 @@ void SpriteProgressBarTintAndFade::onEnter()
 
     auto s = Director::getInstance()->getWinSize();
 
-    auto to = ProgressTo::create(6, 100);
+    auto to = Sequence::createWithTwoActions(ProgressTo::create(6, 100), ProgressTo::create(0, 0));
 	auto tint = Sequence::create(TintTo::create(1, 255, 0, 0),
 								   TintTo::create(1, 0, 255, 0),
 								   TintTo::create(1, 0, 0, 255),
@@ -434,7 +434,7 @@ void SpriteProgressWithSpriteFrame::onEnter()
 
     auto s = Director::getInstance()->getWinSize();
 
-    auto to = ProgressTo::create(6, 100);
+    auto to = Sequence::createWithTwoActions(ProgressTo::create(6, 100), ProgressTo::create(0, 0));
 
     SpriteFrameCache::getInstance()->addSpriteFramesWithFile("zwoptex/grossini.plist");
 


### PR DESCRIPTION
Do not change the value in the deep methods.
RepeatForever::create(ProgressTo::create(2, 100));
This means that you want to repeat to progress 100. But if progress is equal to 100 - nothing should happen.
If you want to repeat charging from 0 to 100, you must drop down value to 0.
RepeatForever::create(Sequence::createWithTwoActions(ProgressTo::create(2, 100), ProgressTo::create(0, 0)));
