### PR TITLE
Fix compilation error using arch i386

### DIFF
--- a/extensions/GUI/CCEditBox/CCEditBoxImplMac.h
+++ b/extensions/GUI/CCEditBox/CCEditBoxImplMac.h
@@ -47,6 +47,7 @@
     CCCustomNSTextField* textField_;
     void* editBox_;
     BOOL editState_;
+    NSMutableDictionary* placeholderAttributes_;
 }
 
 @property(nonatomic, retain) NSTextField* textField;


### PR DESCRIPTION
Adding a member variable to hold the `placeholderAttributes` property fixes a compilation error regarding synthesis when building with ARCH=i386.
