### PR TITLE
Fix twice calling on exit

### DIFF
--- a/cocos/base/CCDirector.cpp
+++ b/cocos/base/CCDirector.cpp
@@ -887,8 +887,8 @@ void Director::popToSceneStackLevel(int level)
     if (level >= c)
         return;
 
-    auto currentRunningScene = _scenesStack.back();
-    if (currentRunningScene == _runningScene)
+    auto fisrtOnStackScene = _scenesStack.back();
+    if (fisrtOnStackScene == _runningScene)
     {
         _scenesStack.popBack();
         --c;
@@ -910,6 +910,8 @@ void Director::popToSceneStackLevel(int level)
     }
 
     _nextScene = _scenesStack.back();
+
+    // cleanup running scene
     _sendCleanupToScene = true;
 }
 

--- a/cocos/base/CCDirector.cpp
+++ b/cocos/base/CCDirector.cpp
@@ -887,6 +887,13 @@ void Director::popToSceneStackLevel(int level)
     if (level >= c)
         return;
 
+    auto currentRunningScene = _scenesStack.back();
+    if (currentRunningScene == _runningScene)
+    {
+        _scenesStack.popBack();
+        --c;
+    }
+
     // pop stack until reaching desired level
     while (c > level)
     {
@@ -903,7 +910,7 @@ void Director::popToSceneStackLevel(int level)
     }
 
     _nextScene = _scenesStack.back();
-    _sendCleanupToScene = false;
+    _sendCleanupToScene = true;
 }
 
 void Director::end()


### PR DESCRIPTION
http://www.cocos2d-x.org/issues/5091
onExit() method calling twice for running scene.
Now, for running scene onExit() calling only in setNextScene method.
