### PR TITLE
Reproduce twice calling.

### DIFF
--- a/tests/cpp-tests/Classes/SceneTest/SceneTest.cpp
+++ b/tests/cpp-tests/Classes/SceneTest/SceneTest.cpp
@@ -93,6 +93,16 @@ void SceneTestLayer1::onQuit(Ref* sender)
     //    [[UIApplication sharedApplication] performSelector:@selector(terminate)];
 }
 
+void SceneTestLayer1::onExit()
+{
+    Layer::onExit();
+
+    struct timeval now;
+    gettimeofday(&now, nullptr);
+
+    CCLOG("1 - onExit: this - %d, time - %d", this, now.tv_sec);
+}
+
 //------------------------------------------------------------------
 //
 // SceneTestLayer2
@@ -154,6 +164,16 @@ void SceneTestLayer2::onReplaceSceneTran(Ref* sender)
     scene->release();
 }
 
+void SceneTestLayer2::onExit()
+{
+    Layer::onExit();
+
+    struct timeval now;
+    gettimeofday(&now, nullptr);
+
+    CCLOG("2 - onExit: this - %d, time - %d", this, now.tv_sec);
+}
+
 //------------------------------------------------------------------
 //
 // SceneTestLayer3
@@ -195,7 +215,7 @@ bool SceneTestLayer3::init()
 
 void SceneTestLayer3::testDealloc(float dt)
 {
-    log("Layer3:testDealloc");
+    //log("Layer3:testDealloc");
 }
 
 void SceneTestLayer3::item0Clicked(Ref* sender)
@@ -218,6 +238,25 @@ void SceneTestLayer3::item2Clicked(Ref* sender)
 void SceneTestLayer3::item3Clicked(Ref* sender)
 {
     Director::getInstance()->popToSceneStackLevel(2);
+}
+//----------------------------------------------------------------------------------------------------------------------
+void SceneTestLayer3::onExit()
+{
+    Layer::onExit();
+
+    struct timeval now;
+    gettimeofday(&now, nullptr);
+
+    CCLOG("3 - onExit: this - %d, time - %d", this, now.tv_sec);
+}
+
+void SceneTestLayer3::cleanup()
+{
+    Layer::cleanup();
+    
+    struct timeval now;
+    gettimeofday(&now, nullptr);
+    CCLOG("3 - Cleanup: this - %d, time - %d", this, now.tv_sec);
 }
 
 void SceneTestScene::runThisTest()

--- a/tests/cpp-tests/Classes/SceneTest/SceneTest.h
+++ b/tests/cpp-tests/Classes/SceneTest/SceneTest.h
@@ -12,6 +12,7 @@ public:
 
     virtual void onEnter() override;
     virtual void onEnterTransitionDidFinish() override;
+    virtual void onExit() override;
 
     void testDealloc(float dt);
     void onPushScene(Ref* sender);
@@ -26,7 +27,7 @@ class SceneTestLayer2 : public Layer
     float    _timeCounter;
 public:
     SceneTestLayer2();
-
+    virtual void onExit() override;
     void testDealloc(float dt);
     void onGoBack(Ref* sender);
     void onReplaceScene(Ref* sender);
@@ -40,7 +41,10 @@ class SceneTestLayer3 : public LayerColor
 public:
     SceneTestLayer3();
     bool init();
+    virtual void onExit() override;
     virtual void testDealloc(float dt);
+    virtual void cleanup() override;
+
     void item0Clicked(Ref* sender);
     void item1Clicked(Ref* sender);
     void item2Clicked(Ref* sender);


### PR DESCRIPTION
Reproduce twice calling onExit().

Run ccp-test
Node: Scene -> Test push scene -> Replace scene -> Touch to pushScene (self) -> Touch to popToSceneStackLevel(2)

In console, you will see:
1 - onExit: this - 89793000, time - 58865
2 - onExit: this - 89551320, time - 58858
3 - onExit: this - 89211328, time - 58870
// Touch to popToSceneStackLevel(2)
3 - onExit: this - 89559664, time - 58872 <- first calling
3 - Cleanup: this - 89559664, time - 58872
3 - onExit: this - 89559664, time - 58872 <- second calling after cleanup

Do not merge this PR.
