### PR TITLE
uniform sampler CC_Texture0 MUST NOT be defined on shaders

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 cocos2d-x-3.1-rc0 May.16 2014
     [FIX]           Math: Vector2->Vec2, Vector3->Vec3, Vector4->Vec4, Matrix->Mat4
+    [FIX]           GLProgram: uniform CC_Texture0 is pre-defined by cocos2d. MUST NOT be defined in shaders
     [FIX]           GLProgramState: Supports multitexturing
     [FIX]           Studio:ActionObject: correct TotalTime of ActionObject
 

--- a/cocos/renderer/CCGLProgram.cpp
+++ b/cocos/renderer/CCGLProgram.cpp
@@ -398,6 +398,10 @@ bool GLProgram::compileShader(GLuint * shader, GLenum type, const GLchar* source
         "uniform vec4 CC_SinTime;\n"
         "uniform vec4 CC_CosTime;\n"
         "uniform vec4 CC_Random01;\n"
+        "uniform sampler2D CC_Texture0;\n"
+        "uniform sampler2D CC_Texture1;\n"
+        "uniform sampler2D CC_Texture2;\n"
+        "uniform sampler2D CC_Texture3;\n"
         "//CC INCLUDES END\n\n",
         source,
     };

--- a/cocos/renderer/ccShader_Label_df.frag
+++ b/cocos/renderer/ccShader_Label_df.frag
@@ -6,8 +6,7 @@ precision lowp float;
  
 varying vec4 v_fragmentColor; 
 varying vec2 v_texCoord; 
-uniform sampler2D CC_Texture0; 
-uniform vec4 v_textColor; 
+uniform vec4 v_textColor;
  
 void main() 
 {

--- a/cocos/renderer/ccShader_Label_df_glow.frag
+++ b/cocos/renderer/ccShader_Label_df_glow.frag
@@ -6,7 +6,6 @@ precision lowp float;
  
 varying vec4 v_fragmentColor; 
 varying vec2 v_texCoord; 
-uniform sampler2D CC_Texture0; 
 uniform vec4 v_effectColor; 
 uniform vec4 v_textColor; 
  

--- a/cocos/renderer/ccShader_Label_normal.frag
+++ b/cocos/renderer/ccShader_Label_normal.frag
@@ -30,7 +30,6 @@ precision lowp float;
 
 varying vec4 v_fragmentColor;
 varying vec2 v_texCoord;
-uniform sampler2D CC_Texture0;
 uniform vec4 v_textColor; 
 
 void main()

--- a/cocos/renderer/ccShader_Label_outline.frag
+++ b/cocos/renderer/ccShader_Label_outline.frag
@@ -8,7 +8,6 @@ precision lowp float;
  
 varying vec4 v_fragmentColor; 
 varying vec2 v_texCoord; 
-uniform sampler2D CC_Texture0; 
 uniform vec4 v_effectColor; 
 uniform vec4 v_textColor; 
  

--- a/cocos/renderer/ccShader_PositionTexture.frag
+++ b/cocos/renderer/ccShader_PositionTexture.frag
@@ -30,7 +30,6 @@ precision lowp float;
 \n#endif\n
 
 varying vec2 v_texCoord;
-uniform sampler2D CC_Texture0;
 
 void main()
 {

--- a/cocos/renderer/ccShader_PositionTextureA8Color.frag
+++ b/cocos/renderer/ccShader_PositionTextureA8Color.frag
@@ -31,7 +31,6 @@ precision lowp float;
 
 varying vec4 v_fragmentColor;
 varying vec2 v_texCoord;
-uniform sampler2D CC_Texture0;
 
 void main()
 {

--- a/cocos/renderer/ccShader_PositionTextureColor.frag
+++ b/cocos/renderer/ccShader_PositionTextureColor.frag
@@ -30,7 +30,6 @@ precision lowp float;
 
 varying vec4 v_fragmentColor;
 varying vec2 v_texCoord;
-uniform sampler2D CC_Texture0;
 
 void main()
 {

--- a/cocos/renderer/ccShader_PositionTextureColorAlphaTest.frag
+++ b/cocos/renderer/ccShader_PositionTextureColorAlphaTest.frag
@@ -30,7 +30,6 @@ precision lowp float;
 
 varying vec4 v_fragmentColor;
 varying vec2 v_texCoord;
-uniform sampler2D CC_Texture0;
 uniform float CC_alpha_value;
 
 void main()

--- a/cocos/renderer/ccShader_PositionTextureColor_noMVP.frag
+++ b/cocos/renderer/ccShader_PositionTextureColor_noMVP.frag
@@ -30,7 +30,6 @@ precision lowp float;
 
 varying vec4 v_fragmentColor;
 varying vec2 v_texCoord;
-uniform sampler2D CC_Texture0;
 
 void main()
 {

--- a/cocos/renderer/ccShader_PositionTexture_uColor.frag
+++ b/cocos/renderer/ccShader_PositionTexture_uColor.frag
@@ -33,8 +33,6 @@ uniform vec4 u_color;
 
 varying vec2 v_texCoord;
 
-uniform sampler2D CC_Texture0;
-
 void main()
 {
     gl_FragColor =  texture2D(CC_Texture0, v_texCoord) * u_color;

--- a/tests/cpp-tests/Classes/ShaderTest/ShaderTest.cpp
+++ b/tests/cpp-tests/Classes/ShaderTest/ShaderTest.cpp
@@ -747,24 +747,65 @@ std::string ShaderMultiTexture::subtitle() const
     return "MultiTexture";
 }
 
+ui::Slider* ShaderMultiTexture::createSliderCtl()
+{
+    auto screenSize = Director::getInstance()->getWinSize();
+
+    ui::Slider* slider = ui::Slider::create();
+    slider->loadBarTexture("cocosui/sliderTrack.png");
+    slider->loadSlidBallTextures("cocosui/sliderThumb.png", "cocosui/sliderThumb.png", "");
+    slider->loadProgressBarTexture("cocosui/sliderProgress.png");
+
+    slider->setPosition(Vec2(screenSize.width / 2.0f, screenSize.height / 3.0f));
+    addChild(slider);
+
+    slider->addEventListener([&](Ref* sender, ui::Slider::EventType type) {
+
+        if (type == ui::Slider::EventType::ON_PERCENTAGE_CHANGED)
+        {
+            ui::Slider* slider = dynamic_cast<ui::Slider*>(sender);
+            float p = slider->getPercent() / 100.0f;
+            _sprite->getGLProgramState()->setUniformFloat("u_interpolate",p);
+        }
+    });
+    return slider;
+}
+
 bool ShaderMultiTexture::init()
 {
     if (ShaderTestDemo::init())
     {
         auto s = Director::getInstance()->getWinSize();
 
-        auto sprite = Sprite::create("Images/grossinis_sister1.png");
+        // Left: normal sprite
+        auto left = Sprite::create("Images/grossinis_sister1.png");
+        addChild(left);
+        left->setPosition(s.width*1/4, s.height/2);
+
+        // Right: normal sprite
+        auto right = Sprite::create("Images/grossinis_sister2.png");
+        addChild(right);
+        right->setPosition(s.width*3/4, s.height/2);
+
+
+        // Center: MultiTexture
+        _sprite = Sprite::create("Images/grossinis_sister1.png");
         Texture2D *texture1 = Director::getInstance()->getTextureCache()->addImage("Images/grossinis_sister2.png");
 
-        addChild(sprite);
+        addChild(_sprite);
 
-        sprite->setPosition(Vec2(s.width/2, s.height/2));
+        _sprite->setPosition(Vec2(s.width/2, s.height/2));
 
         auto glprogram = GLProgram::createWithFilenames("Shaders/example_MultiTexture.vsh", "Shaders/example_MultiTexture.fsh");
         auto glprogramstate = GLProgramState::getOrCreateWithGLProgram(glprogram);
-        sprite->setGLProgramState(glprogramstate);
+        _sprite->setGLProgramState(glprogramstate);
 
         glprogramstate->setUniformTexture("u_texture1", texture1);
+
+
+        // slider
+        createSliderCtl();
+
         return true;
     }
 

--- a/tests/cpp-tests/Classes/ShaderTest/ShaderTest.h
+++ b/tests/cpp-tests/Classes/ShaderTest/ShaderTest.h
@@ -1,6 +1,8 @@
 #ifndef _SHADER_TEST_H_
 #define _SHADER_TEST_H_
 
+#include "ui/CocosGUI.h"
+
 #include "../testBasic.h"
 #include "extensions/cocos-ext.h"
 #include "../BaseTest.h"
@@ -166,6 +168,8 @@ class ShaderMultiTexture : public ShaderTestDemo
 {
 public:
     ShaderMultiTexture();
+    ui::Slider* createSliderCtl();
+    Sprite *_sprite;
 
     virtual std::string title() const override;
     virtual std::string subtitle() const override;

--- a/tests/cpp-tests/Resources/Shaders/example_Blur.fsh
+++ b/tests/cpp-tests/Resources/Shaders/example_Blur.fsh
@@ -7,8 +7,6 @@ precision mediump float;
 varying vec4 v_fragmentColor;
 varying vec2 v_texCoord;
 
-uniform sampler2D CC_Texture0;
-
 uniform vec4 gaussianCoefficient;
 uniform vec2 onePixelSize;
 

--- a/tests/cpp-tests/Resources/Shaders/example_ColorBars.fsh
+++ b/tests/cpp-tests/Resources/Shaders/example_ColorBars.fsh
@@ -5,7 +5,6 @@ precision lowp float;
 #endif
 
 varying vec2 v_texCoord;
-uniform sampler2D CC_Texture0;
 
 vec4 getColorByCoord(int y){
     if(y < 5){

--- a/tests/cpp-tests/Resources/Shaders/example_HorizontalColor.fsh
+++ b/tests/cpp-tests/Resources/Shaders/example_HorizontalColor.fsh
@@ -5,7 +5,6 @@ precision lowp float;
 #endif
 
 varying vec2 v_texCoord;
-uniform sampler2D CC_Texture0;
 
 vec4 colors[10];
 

--- a/tests/cpp-tests/Resources/Shaders/example_MultiTexture.fsh
+++ b/tests/cpp-tests/Resources/Shaders/example_MultiTexture.fsh
@@ -6,13 +6,12 @@ precision mediump float;
 varying vec4 v_fragmentColor;
 varying vec2 v_texCoord;
 
-uniform sampler2D CC_Texture0;
 uniform sampler2D u_texture1;
-
+uniform float u_interpolate;
 
 void main() {
-    vec4 color1 = texture2D(CC_Texture0, v_texCoord) * vec4(1,1,1,CC_SinTime[3]);
-    vec4 color2 = texture2D(u_texture1, v_texCoord) * vec4(1,1,1,CC_CosTime[3]);
-    gl_FragColor = (color1 + color2) * v_fragmentColor;
+    vec4 color1 = texture2D(CC_Texture0, v_texCoord);
+    vec4 color2 = texture2D(u_texture1, v_texCoord);
+    gl_FragColor = v_fragmentColor * mix( color1, color2, u_interpolate);
 }
 

--- a/tests/cpp-tests/Resources/Shaders/example_Noisy.fsh
+++ b/tests/cpp-tests/Resources/Shaders/example_Noisy.fsh
@@ -8,7 +8,6 @@ varying vec4 v_fragmentColor;
 varying vec2 v_texCoord;
 
 uniform vec2 resolution;
-uniform sampler2D CC_Texture0;
 
 const float intensity = 0.05;
 vec3 noise(vec2 uv)

--- a/tests/cpp-tests/Resources/Shaders/example_bloom.fsh
+++ b/tests/cpp-tests/Resources/Shaders/example_bloom.fsh
@@ -6,7 +6,6 @@ varying vec4 v_fragmentColor;
 varying vec2 v_texCoord;
 
 uniform vec2 resolution;
-uniform sampler2D CC_Texture0;
 
 
 const float blurSize = 1.0/512.0;

--- a/tests/cpp-tests/Resources/Shaders/example_celShading.fsh
+++ b/tests/cpp-tests/Resources/Shaders/example_celShading.fsh
@@ -6,8 +6,6 @@ varying vec4 v_fragmentColor;
 varying vec2 v_texCoord;
 
 uniform vec2 resolution;
-uniform sampler2D CC_Texture0;
-
 
 #define FILTER_SIZE 3
 #define COLOR_LEVELS 7.0

--- a/tests/cpp-tests/Resources/Shaders/example_edgeDetection.fsh
+++ b/tests/cpp-tests/Resources/Shaders/example_edgeDetection.fsh
@@ -6,7 +6,6 @@ varying vec4 v_fragmentColor;
 varying vec2 v_texCoord;
 
 uniform vec2 resolution;
-uniform sampler2D CC_Texture0;
 
 float lookup(vec2 p, float dx, float dy)
 {

--- a/tests/cpp-tests/Resources/Shaders/example_greyScale.fsh
+++ b/tests/cpp-tests/Resources/Shaders/example_greyScale.fsh
@@ -5,8 +5,6 @@ precision mediump float;
 varying vec4 v_fragmentColor;
 varying vec2 v_texCoord;
 
-uniform sampler2D CC_Texture0;
-
 void main(void)
 {
 	vec4 c = texture2D(CC_Texture0, v_texCoord);

--- a/tests/cpp-tests/Resources/Shaders/example_lensFlare.fsh
+++ b/tests/cpp-tests/Resources/Shaders/example_lensFlare.fsh
@@ -7,7 +7,6 @@ varying vec2 v_texCoord;
 
 uniform vec2 resolution;
 uniform vec2 textureResolution;
-uniform sampler2D CC_Texture0;
 
 /*by musk License Creative Commons Attribution-NonCommercial-ShareAlike 3.0 Unported License.
  

--- a/tests/cpp-tests/Resources/Shaders/example_normal.fsh
+++ b/tests/cpp-tests/Resources/Shaders/example_normal.fsh
@@ -5,8 +5,6 @@ precision mediump float;
 varying vec4 v_fragmentColor;
 varying vec2 v_texCoord;
 
-uniform sampler2D CC_Texture0;
-
 void main(void)
 {
 	gl_FragColor = texture2D(CC_Texture0, v_texCoord);

--- a/tests/cpp-tests/Resources/Shaders/example_outline.fsh
+++ b/tests/cpp-tests/Resources/Shaders/example_outline.fsh
@@ -6,8 +6,6 @@ http://www.idevgames.com/forums/thread-3010.html
 varying vec2 v_texCoord;
 varying vec4 v_fragmentColor;
 
-uniform sampler2D CC_Texture0;
-
 uniform vec3 u_outlineColor;
 uniform float u_threshold;
 uniform float u_radius;

--- a/tests/cpp-tests/Resources/Shaders/example_sepia.fsh
+++ b/tests/cpp-tests/Resources/Shaders/example_sepia.fsh
@@ -5,8 +5,6 @@ precision mediump float;
 varying vec4 v_fragmentColor;
 varying vec2 v_texCoord;
 
-uniform sampler2D CC_Texture0;
-
 void main(void)
 {
 	vec4 c = texture2D(CC_Texture0, v_texCoord);


### PR DESCRIPTION
since it is a built-in.
Built-in uniforms MUST NOT be defined on shaders.
Basically all CC_ uniforms must be defined by cocos2d-x
