### PR TITLE
Fix CCPhysicsSprite::setPosition

### DIFF
--- a/extensions/physics-nodes/CCPhysicsSprite.cpp
+++ b/extensions/physics-nodes/CCPhysicsSprite.cpp
@@ -288,6 +288,7 @@ void PhysicsSprite::setPosition(const Vec2 &pos)
     _pB2Body->SetTransform(b2Vec2(pos.x / _PTMRatio, pos.y / _PTMRatio), angle);
 #endif
 
+    Sprite::setPosition(pos);
 }
 
 float PhysicsSprite::getRotation() const


### PR DESCRIPTION
As it is currently, if you call `CCPhysicsSprite::setPosition` it will set the physics body's position without setting the `CCSprite`'s position. This pull request fixes the issue.
