### PR TITLE
V3 mac secure input

### DIFF
--- a/cocos/base/CCPlatformMacros.h
+++ b/cocos/base/CCPlatformMacros.h
@@ -164,6 +164,10 @@ public: virtual varType get##funName(void) const { return varName; }
 protected: varType varName;\
 public: virtual const varType& get##funName(void) const { return varName; }
 
+#define CC_SYNTHESIZE_READONLY_PURE_REF(varType, varName, funName)\
+protected: varType varName;\
+public: virtual varType& get##funName(void) { return varName; }
+
 /** CC_SYNTHESIZE is used to declare a protected variable.
  We can use getter to read the variable, and use the setter to change the variable.
  @param varType     the type of variable.

--- a/cocos/base/CCPlatformMacros.h
+++ b/cocos/base/CCPlatformMacros.h
@@ -164,10 +164,6 @@ public: virtual varType get##funName(void) const { return varName; }
 protected: varType varName;\
 public: virtual const varType& get##funName(void) const { return varName; }
 
-#define CC_SYNTHESIZE_READONLY_PURE_REF(varType, varName, funName)\
-protected: varType varName;\
-public: virtual varType& get##funName(void) { return varName; }
-
 /** CC_SYNTHESIZE is used to declare a protected variable.
  We can use getter to read the variable, and use the setter to change the variable.
  @param varType     the type of variable.

--- a/extensions/GUI/CCEditBox/CCEditBoxImplMac.h
+++ b/extensions/GUI/CCEditBox/CCEditBoxImplMac.h
@@ -36,21 +36,16 @@
 #include "extensions/ExtensionMacros.h"
 #include "CCEditBoxImpl.h"
 
-@interface CCCustomNSTextField : NSTextField
-{
-}
-
-@end
 
 @interface CCEditBoxImplMac : NSObject <NSTextFieldDelegate>
 {
-    CCCustomNSTextField* textField_;
     void* editBox_;
     BOOL editState_;
     NSMutableDictionary* placeholderAttributes_;
 }
 
 @property(nonatomic, retain) NSTextField* textField;
+@property(nonatomic, retain) NSSecureTextField* secureTextField;
 @property(nonatomic, retain) NSMutableDictionary* placeholderAttributes;
 @property(nonatomic, readonly, getter = isEditState) BOOL editState;
 @property(nonatomic, assign) void* editBox;


### PR DESCRIPTION
Hi!

The main feature of this pull request is the implementation of `NSSecureTextField` on Mac, so now CCEditBox shows a password field when `InputFlag::PASSWORD` is set:

![](http://mazyod.com/images/example-NSSecureTextField.png)

Another important change is the removal of `CCCustomNSTextField` class. It was apparently copied from the iOS implementation, but `UITextField` and `NSTextField` are **vastly** different.

Two other minor changes exist, fixing the `init` method to be according to the Objective-C convention, and removing the call `self.textField = NULL`, since it's dangerous to call setters in dealloc. Instead, the ivar should be released manually.

Best,
Maz
