### PR TITLE
fix UIText's fontSize

### DIFF
--- a/cocos/ui/UIText.cpp
+++ b/cocos/ui/UIText.cpp
@@ -147,6 +147,7 @@ void Text::setFontName(const std::string& name)
     {
         TTFConfig config = _labelRenderer->getTTFConfig();
         config.fontFilePath = name;
+        config.fontSize = _fontSize;
         _labelRenderer->setTTFConfig(config);
         _type = Type::TTF;
     }


### PR DESCRIPTION
if set fontsize before setting font family, fontsize was wrong
