### PR TITLE
fix bug:backgourd  of PageView,ListView,ClippingNode display green

### DIFF
--- a/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxActivity.java
+++ b/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxActivity.java
@@ -192,9 +192,12 @@ public abstract class Cocos2dxActivity extends Activity implements Cocos2dxHelpe
         // Set framelayout as the content view
 		setContentView(mFrameLayout);
 	}
-	
+
     public Cocos2dxGLSurfaceView onCreateView() {
-    	return new Cocos2dxGLSurfaceView(this);
+        Cocos2dxGLSurfaceView glSurfaceView = new Cocos2dxGLSurfaceView(this);
+        glSurfaceView.setEGLConfigChooser(5, 6, 5, 0, 16, 8);
+
+        return glSurfaceView;
     }
 
    private final static boolean isAndroidEmulator() {


### PR DESCRIPTION
I found backgourd  of PageView,ListView,ClippingNode display green in android device. 
