### PR TITLE
Update the reference of submodule cocos2d-console.

### DIFF
--- a/templates/lua-template-runtime/cocos-project-template.json
+++ b/templates/lua-template-runtime/cocos-project-template.json
@@ -5,13 +5,41 @@
             "runtime/config.json",
             "runtime/version.json"
         ],
+        "append_from_template": {
+            "from": "frameworks/runtime-src/proj.android",
+            "to": "frameworks/runtime-src/proj.android",
+            "exclude": [
+                "bin",
+                "assets"
+            ]
+        },
         "project_replace_project_name": {
             "src_project_name": "HelloLua",
             "files": [
                 "config.json",
-                ".project"]
+                ".project",
+                "frameworks/runtime-src/proj.android/.project",
+                "frameworks/runtime-src/proj.android/AndroidManifest.xml",
+                "frameworks/runtime-src/proj.android/build.xml",
+                "frameworks/runtime-src/proj.android/res/values/strings.xml"
+            ]
         },
         "append_dir": [
+            {
+                "from": "cocos/platform/android/java",
+                "to": "frameworks/cocos2d-x/cocos/platform/android/java"
+            },
+            {
+                "from": "cocos/scripting/lua-bindings/script",
+                "to": "frameworks/cocos2d-x/cocos/scripting/lua-bindings/script"
+            },
+            {
+                "from": "external/lua/luasocket",
+                "to": "frameworks/cocos2d-x/external/lua/luasocket",
+                "include": [
+                    "*.lua"
+                ]
+            },
             {
                 "from": "cocos/scripting/lua-bindings/script",
                 "to": "runtime/mac/PrebuiltRuntimeLua.app/Contents/Resources",
@@ -104,9 +132,7 @@
             "from": "frameworks/runtime-src",
             "to": "frameworks/runtime-src",
             "exclude": [
-                "proj.android/bin",
-                "proj.android/assets",
-                "proj.android/libs",
+                "proj.android",
                 "proj.ios_mac/HelloLua.xcodeproj/project.xcworkspace",
                 "proj.ios_mac/HelloLua.xcodeproj/xcuserdata",
                 "proj.win32/Debug.win32",
@@ -139,10 +165,6 @@
                 "frameworks/runtime-src/proj.win32/PROJECT_NAME.sln",
                 "frameworks/runtime-src/proj.win32/main.cpp",
                 "frameworks/runtime-src/proj.win32/Runtime_win32.cpp",
-                "frameworks/runtime-src/proj.android/.project",
-                "frameworks/runtime-src/proj.android/AndroidManifest.xml",
-                "frameworks/runtime-src/proj.android/build.xml",
-                "frameworks/runtime-src/proj.android/res/values/strings.xml",
                 "frameworks/runtime-src/proj.ios_mac/ios/main.m",
                 "frameworks/runtime-src/proj.ios_mac/ios/Prefix.pch",
                 "frameworks/runtime-src/proj.ios_mac/mac/SimulatorApp.mm",


### PR DESCRIPTION
1. Support generate release apk with prebuilt libs.
2. Support skip ndk-build when the value of parameter --ndk-mode is none.
