### PR TITLE
don't have to compare in step since it is done in init function

### DIFF
--- a/cocos/2d/CCActionInterval.cpp
+++ b/cocos/2d/CCActionInterval.cpp
@@ -120,9 +120,7 @@ void ActionInterval::step(float dt)
     }
     
     this->update(MAX (0,                                  // needed for rewind. elapsed could be negative
-                      MIN(1, _elapsed /
-                          MAX(_duration, FLT_EPSILON)   // division by 0
-                          )
+                      MIN(1, _elapsed /_duration)
                       )
                  );
 }


### PR DESCRIPTION
In `ActionInterval::initWithDuration()`, there is codes 

``` cpp
// prevent division by 0
    // This comparison could be in step:, but it might decrease the performance
    // by 3% in heavy based action games.
    if (_duration == 0)
    {
        _duration = FLT_EPSILON;
    }
```

But it also compares in `ActionInterval::step()` too.
