### PR TITLE
fix: Subclass of Scene can't call this->scheduleUpdate() with physics feature.

### DIFF
--- a/cocos/2d/CCScene.cpp
+++ b/cocos/2d/CCScene.cpp
@@ -97,9 +97,8 @@ void Scene::addChild(Node* child, int zOrder, int tag)
     addChildToPhysicsWorld(child);
 }
 
-void Scene::update(float delta)
+void Scene::updatePhysicsWorld(float delta)
 {
-    Node::update(delta);
     if (nullptr != _physicsWorld)
     {
         _physicsWorld->update(delta);
@@ -131,7 +130,7 @@ bool Scene::initWithPhysics()
         this->setContentSize(director->getWinSize());
         CC_BREAK_IF(! (_physicsWorld = PhysicsWorld::construct(*this)));
         
-        this->scheduleUpdate();
+        this->schedule(schedule_selector(Scene::updatePhysicsWorld));
         // success
         ret = true;
     } while (0);

--- a/cocos/2d/CCScene.h
+++ b/cocos/2d/CCScene.h
@@ -77,7 +77,7 @@ private:
 #if CC_USE_PHYSICS
 public:
     virtual void addChild(Node* child, int zOrder, int tag) override;
-    virtual void update(float delta) override;
+    virtual void updatePhysicsWorld(float delta);
     inline PhysicsWorld* getPhysicsWorld() { return _physicsWorld; }
     static Scene *createWithPhysics();
     


### PR DESCRIPTION
Refactor Scene with physics feature.
If use 'update(float)' and 'scheduleUpdate' will cause subclass of Scene can't call 'this->scheduleUpdate()', because it has already called in super class. That's confused API design.
So, I think there should be an  separate update function for Physics Scene.
