### PR TITLE
fix keycode_back  from  KEY_ESCAPE to  KEY_BACKSPACE

### DIFF
--- a/cocos/platform/android/jni/TouchesJni.cpp
+++ b/cocos/platform/android/jni/TouchesJni.cpp
@@ -77,7 +77,7 @@ extern "C" {
     
     
     static std::unordered_map<int, cocos2d::EventKeyboard::KeyCode> g_keyCodeMap = {
-        { KEYCODE_BACK , cocos2d::EventKeyboard::KeyCode::KEY_ESCAPE},
+        { KEYCODE_BACK , cocos2d::EventKeyboard::KeyCode::KEY_BACKSPACE},
         { KEYCODE_MENU , cocos2d::EventKeyboard::KeyCode::KEY_MENU},
         { KEYCODE_DPAD_UP  , cocos2d::EventKeyboard::KeyCode::KEY_DPAD_UP },
         { KEYCODE_DPAD_DOWN , cocos2d::EventKeyboard::KeyCode::KEY_DPAD_DOWN },


### PR DESCRIPTION
Keypad test in cpptest and luatest can't work , because of the KEYCODE_BACK defined incorrectly.
