### PR TITLE
Fix Repeat will run one more over in rare situations

### DIFF
--- a/cocos/2d/CCActionInterval.cpp
+++ b/cocos/2d/CCActionInterval.cpp
@@ -439,7 +439,7 @@ void Repeat::update(float dt)
 
             _innerAction->stop();
             _innerAction->startWithTarget(_target);
-            _nextDt += _innerAction->getDuration()/_duration;
+            _nextDt = _innerAction->getDuration()/_duration * (_total+1);
         }
 
         // fix for issue #1288, incorrect end value of repeat

--- a/tests/cpp-tests/Classes/ActionsTest/ActionsTest.cpp
+++ b/tests/cpp-tests/Classes/ActionsTest/ActionsTest.cpp
@@ -81,7 +81,8 @@ static std::function<Layer*()> createFunctions[] = {
     CL(Issue1288),
     CL(Issue1288_2),
     CL(Issue1327),
-    CL(Issue1398)
+    CL(Issue1398),
+    CL(Issue2599)
 };
 
 static int sceneIdx=-1;
@@ -2092,6 +2093,38 @@ std::string Issue1398::subtitle() const
 std::string Issue1398::title() const
 {
     return "Issue 1398";
+}
+
+void Issue2599::onEnter()
+{
+    ActionsDemo::onEnter();
+    this->centerSprites(0);
+    
+    _count = 0;
+    log("before: count = %d", _count);
+    
+    log("start count up 50 times using Repeat action");
+    auto delay = 1.0f / 50;
+    auto repeatAction = Repeat::create(
+        Sequence::createWithTwoActions(
+            CallFunc::create([&](){ this->_count++; }),
+            DelayTime::create(delay)),
+        50);
+    this->runAction(
+        Sequence::createWithTwoActions(
+            repeatAction,
+            CallFunc::create([&]() { log("after: count = %d", this->_count); })
+        ));
+}
+
+std::string Issue2599::subtitle() const
+{
+    return "See console: You should see '50'";
+}
+
+std::string Issue2599::title() const
+{
+    return "Issue 2599";
 }
 
 /** ActionCatmullRom

--- a/tests/cpp-tests/Classes/ActionsTest/ActionsTest.h
+++ b/tests/cpp-tests/Classes/ActionsTest/ActionsTest.h
@@ -564,6 +564,18 @@ private:
     int _testInteger;
 };
 
+class Issue2599 : public ActionsDemo
+{
+public:
+    CREATE_FUNC(Issue2599);
+    
+    virtual void onEnter() override;
+    virtual std::string subtitle() const override;
+    virtual std::string title() const override;
+private:
+    int _count;
+};
+
 class ActionCatmullRom : public ActionsDemo
 {
 public:


### PR DESCRIPTION
When times specified at `Repeat::create` is big, `_nextDt` in `Repeat::update` will may have some error that cause `Repeat` to run one more over than you specified.

Bug can be appeared in below code.

``` C++
    auto action = Sequence::createWithTwoActions(CallFunc::create([&]() {
        // some count up
    }),
                                                 DelayTime::create(1.0f / 50));
    this->runAction(Repeat::create(action, 50));
    // count up will be executed 51 times!
```
