### PR TITLE
Added 'optional' paramater to GLProgramState::setUniformTexture to manually specify textureUnitIndex.

### DIFF
--- a/cocos/renderer/CCGLProgramState.cpp
+++ b/cocos/renderer/CCGLProgramState.cpp
@@ -455,17 +455,20 @@ void GLProgramState::setUniformMat4(const std::string &uniformName, const Mat4& 
 
 // Textures
 
-void GLProgramState::setUniformTexture(const std::string &uniformName, Texture2D *texture)
+void GLProgramState::setUniformTexture(const std::string &uniformName, Texture2D *texture, int textureUnitIndex)
 {
     CCASSERT(texture, "Invalid texture");
-    setUniformTexture(uniformName, texture->getName());
+    setUniformTexture(uniformName, texture->getName(), textureUnitIndex);
 }
 
-void GLProgramState::setUniformTexture(const std::string &uniformName, GLuint textureId)
+void GLProgramState::setUniformTexture(const std::string &uniformName, GLuint textureId, int textureUnitIndex)
 {
     auto v = getUniformValue(uniformName);
-    if (v)
+    if (v) {
+        if (textureUnitIndex != -1)
+            _textureUnitIndex = textureUnitIndex;
         v->setTexture(textureId, _textureUnitIndex++);
+    }
     else
         CCLOG("cocos2d: warning: Uniform not found: %s", uniformName.c_str());
 }

--- a/cocos/renderer/CCGLProgramState.h
+++ b/cocos/renderer/CCGLProgramState.h
@@ -175,8 +175,8 @@ public:
     void setUniformVec4(const std::string &uniformName, const Vec4& value);
     void setUniformMat4(const std::string &uniformName, const Mat4& value);
     void setUniformCallback(const std::string &uniformName, const std::function<void(Uniform*)> &callback);
-    void setUniformTexture(const std::string &uniformName, Texture2D *texture);
-    void setUniformTexture(const std::string &uniformName, GLuint textureId);
+    void setUniformTexture(const std::string &uniformName, Texture2D *texture, int textureUnitIndex = -1);
+    void setUniformTexture(const std::string &uniformName, GLuint textureId, int textureUnitIndex = -1);
 
 protected:
     GLProgramState();


### PR DESCRIPTION
Added 'optional' paramater to GLProgramState::setUniformTexture to manually specify textureUnitIndex.

Needed to specify textures in a different order, and when changing the texture to process using a shader.
