### PR TITLE
Set jpeg save quality to 90 (default is only 75, on a scale of 0 to 100)

### DIFF
--- a/cocos/platform/CCImage.cpp
+++ b/cocos/platform/CCImage.cpp
@@ -2120,7 +2120,8 @@ bool Image::saveImageToJPG(const std::string& filePath)
         cinfo.in_color_space = JCS_RGB;       /* colorspace of input image */
 
         jpeg_set_defaults(&cinfo);
-
+        jpeg_set_quality(&cinfo, 90, TRUE);
+        
         jpeg_start_compress(&cinfo, TRUE);
 
         row_stride = _width * 3; /* JSAMPLEs per row in image_buffer */


### PR DESCRIPTION
Set jpeg save quality to 90 (default is only 75, on a scale of 0 to 100)

Default jpeg save quality of 75 sometimes gives blurs around sharp edges or boxes on smooth gradients. Jpeg quality above 95 gives much larger saved file size. Quality setting of 90 gives good quality image without big difference in image file size.
