### PR TITLE
Fix the crash in TextureAsync test

### DIFF
--- a/cocos/renderer/CCTextureCache.cpp
+++ b/cocos/renderer/CCTextureCache.cpp
@@ -144,7 +144,7 @@ void TextureCache::addImageAsync(const std::string &path, const std::function<vo
 void TextureCache::unbindImageAsync(const std::string& filename)
 {
     std::string fullpath = FileUtils::getInstance()->fullPathForFilename(filename);
-    auto found = std::find_if(_imageInfoQueue->begin(), _imageInfoQueue->end(), [&](ImageInfo* ptr)->bool{ return ptr->asyncStruct->filename == fullpath; });
+    auto found = std::find_if(_imageInfoQueue->begin(), _imageInfoQueue->end(), [&fullpath](ImageInfo* ptr)->bool{ return ptr->asyncStruct->filename == fullpath; });
     if (found != _imageInfoQueue->end())
     {
         _imageInfoMutex.lock();
@@ -162,6 +162,7 @@ void TextureCache::unbindAllImageAsync()
         _imageInfoMutex.unlock();
     }
 }
+
 
 void TextureCache::loadImage()
 {

--- a/cocos/renderer/CCTextureCache.cpp
+++ b/cocos/renderer/CCTextureCache.cpp
@@ -143,13 +143,16 @@ void TextureCache::addImageAsync(const std::string &path, const std::function<vo
 
 void TextureCache::unbindImageAsync(const std::string& filename)
 {
-    std::string fullpath = FileUtils::getInstance()->fullPathForFilename(filename);
-    auto found = std::find_if(_imageInfoQueue->begin(), _imageInfoQueue->end(), [&fullpath](ImageInfo* ptr)->bool{ return ptr->asyncStruct->filename == fullpath; });
-    if (found != _imageInfoQueue->end())
+    if (_imageInfoQueue && !_imageInfoQueue->empty())
     {
-        _imageInfoMutex.lock();
-        (*found)->asyncStruct->callback = nullptr;
-        _imageInfoMutex.unlock();
+        std::string fullpath = FileUtils::getInstance()->fullPathForFilename(filename);
+        auto found = std::find_if(_imageInfoQueue->begin(), _imageInfoQueue->end(), [&fullpath](ImageInfo* ptr)->bool{ return ptr->asyncStruct->filename == fullpath; });
+        if (found != _imageInfoQueue->end())
+        {
+            _imageInfoMutex.lock();
+            (*found)->asyncStruct->callback = nullptr;
+            _imageInfoMutex.unlock();
+        }
     }
 }
 

--- a/cocos/renderer/CCTextureCache.cpp
+++ b/cocos/renderer/CCTextureCache.cpp
@@ -143,27 +143,27 @@ void TextureCache::addImageAsync(const std::string &path, const std::function<vo
 
 void TextureCache::unbindImageAsync(const std::string& filename)
 {
+    _imageInfoMutex.lock();
     if (_imageInfoQueue && !_imageInfoQueue->empty())
     {
         std::string fullpath = FileUtils::getInstance()->fullPathForFilename(filename);
         auto found = std::find_if(_imageInfoQueue->begin(), _imageInfoQueue->end(), [&fullpath](ImageInfo* ptr)->bool{ return ptr->asyncStruct->filename == fullpath; });
         if (found != _imageInfoQueue->end())
         {
-            _imageInfoMutex.lock();
             (*found)->asyncStruct->callback = nullptr;
-            _imageInfoMutex.unlock();
         }
     }
+    _imageInfoMutex.unlock();
 }
 
 void TextureCache::unbindAllImageAsync()
 {
+    _imageInfoMutex.lock();
     if (_imageInfoQueue && !_imageInfoQueue->empty())
     {
-        _imageInfoMutex.lock();
         std::for_each(_imageInfoQueue->begin(), _imageInfoQueue->end(), [](ImageInfo* ptr) { ptr->asyncStruct->callback = nullptr; });
-        _imageInfoMutex.unlock();
     }
+    _imageInfoMutex.unlock();
 }
 
 

--- a/cocos/renderer/CCTextureCache.cpp
+++ b/cocos/renderer/CCTextureCache.cpp
@@ -143,27 +143,27 @@ void TextureCache::addImageAsync(const std::string &path, const std::function<vo
 
 void TextureCache::unbindImageAsync(const std::string& filename)
 {
-    _imageInfoMutex.lock();
     if (_imageInfoQueue && !_imageInfoQueue->empty())
     {
+        _imageInfoMutex.lock();
         std::string fullpath = FileUtils::getInstance()->fullPathForFilename(filename);
         auto found = std::find_if(_imageInfoQueue->begin(), _imageInfoQueue->end(), [&fullpath](ImageInfo* ptr)->bool{ return ptr->asyncStruct->filename == fullpath; });
         if (found != _imageInfoQueue->end())
         {
             (*found)->asyncStruct->callback = nullptr;
         }
+        _imageInfoMutex.unlock();
     }
-    _imageInfoMutex.unlock();
 }
 
 void TextureCache::unbindAllImageAsync()
 {
-    _imageInfoMutex.lock();
     if (_imageInfoQueue && !_imageInfoQueue->empty())
     {
+        _imageInfoMutex.lock();
         std::for_each(_imageInfoQueue->begin(), _imageInfoQueue->end(), [](ImageInfo* ptr) { ptr->asyncStruct->callback = nullptr; });
+        _imageInfoMutex.unlock();
     }
-    _imageInfoMutex.unlock();
 }
 
 

--- a/cocos/renderer/CCTextureCache.cpp
+++ b/cocos/renderer/CCTextureCache.cpp
@@ -141,6 +141,28 @@ void TextureCache::addImageAsync(const std::string &path, const std::function<vo
     _sleepCondition.notify_one();
 }
 
+void TextureCache::unbindImageAsync(const std::string& filename)
+{
+    std::string fullpath = FileUtils::getInstance()->fullPathForFilename(filename);
+    auto found = std::find_if(_imageInfoQueue->begin(), _imageInfoQueue->end(), [&](ImageInfo* ptr)->bool{ return ptr->asyncStruct->filename == fullpath; });
+    if (found != _imageInfoQueue->end())
+    {
+        _imageInfoMutex.lock();
+        (*found)->asyncStruct->callback = nullptr;
+        _imageInfoMutex.unlock();
+    }
+}
+
+void TextureCache::unbindAllImageAsync()
+{
+    if (_imageInfoQueue && !_imageInfoQueue->empty())
+    {
+        _imageInfoMutex.lock();
+        std::for_each(_imageInfoQueue->begin(), _imageInfoQueue->end(), [](ImageInfo* ptr) { ptr->asyncStruct->callback = nullptr; });
+        _imageInfoMutex.unlock();
+    }
+}
+
 void TextureCache::loadImage()
 {
     AsyncStruct *asyncStruct = nullptr;

--- a/cocos/renderer/CCTextureCache.cpp
+++ b/cocos/renderer/CCTextureCache.cpp
@@ -166,7 +166,6 @@ void TextureCache::unbindAllImageAsync()
     _imageInfoMutex.unlock();
 }
 
-
 void TextureCache::loadImage()
 {
     AsyncStruct *asyncStruct = nullptr;

--- a/cocos/renderer/CCTextureCache.cpp
+++ b/cocos/renderer/CCTextureCache.cpp
@@ -143,27 +143,27 @@ void TextureCache::addImageAsync(const std::string &path, const std::function<vo
 
 void TextureCache::unbindImageAsync(const std::string& filename)
 {
+    _imageInfoMutex.lock();
     if (_imageInfoQueue && !_imageInfoQueue->empty())
     {
-        _imageInfoMutex.lock();
         std::string fullpath = FileUtils::getInstance()->fullPathForFilename(filename);
         auto found = std::find_if(_imageInfoQueue->begin(), _imageInfoQueue->end(), [&fullpath](ImageInfo* ptr)->bool{ return ptr->asyncStruct->filename == fullpath; });
         if (found != _imageInfoQueue->end())
         {
             (*found)->asyncStruct->callback = nullptr;
         }
-        _imageInfoMutex.unlock();
     }
+    _imageInfoMutex.unlock();
 }
 
 void TextureCache::unbindAllImageAsync()
 {
+    _imageInfoMutex.lock();
     if (_imageInfoQueue && !_imageInfoQueue->empty())
     {
-        _imageInfoMutex.lock();
         std::for_each(_imageInfoQueue->begin(), _imageInfoQueue->end(), [](ImageInfo* ptr) { ptr->asyncStruct->callback = nullptr; });
-        _imageInfoMutex.unlock();
     }
+    _imageInfoMutex.unlock();
 }
 
 

--- a/cocos/renderer/CCTextureCache.h
+++ b/cocos/renderer/CCTextureCache.h
@@ -118,6 +118,18 @@ public:
     * @since v0.8
     */
     virtual void addImageAsync(const std::string &filepath, const std::function<void(Texture2D*)>& callback);
+    
+    /* Unbind a specified bound image asynchronous callback
+     * In the case an object who was bound to an image asynchronous callback was destroyed before the callback is invoked,
+     * the object always need to unbind this callback manually.
+     * @since v3.1
+     */
+    virtual void unbindImageAsync(const std::string &filename);
+    
+    /* Unbind all bound image asynchronous load callbacks
+     * @since v3.1
+     */
+    virtual void unbindAllImageAsync();
 
     /** Returns a Texture2D object given an Image.
     * If the image was not previously loaded, it will create a new Texture2D object and it will return it.

--- a/tests/cpp-tests/Classes/Texture2dTest/Texture2dTest.cpp
+++ b/tests/cpp-tests/Classes/Texture2dTest/Texture2dTest.cpp
@@ -1533,6 +1533,7 @@ void TextureAsync::onEnter()
 
 TextureAsync::~TextureAsync()
 {
+    Director::getInstance()->getTextureCache()->unbindAllImageAsync();
     Director::getInstance()->getTextureCache()->removeAllTextures();
 }
 


### PR DESCRIPTION
add new interfaces for TextureCache to unbind the bound image asynchronous load callbacks.
