### PR TITLE
Memory leak in cc sprite frame cache

### DIFF
--- a/cocos2dx/sprite_nodes/CCSpriteFrameCache.cpp
+++ b/cocos2dx/sprite_nodes/CCSpriteFrameCache.cpp
@@ -203,10 +203,15 @@ void CCSpriteFrameCache::addSpriteFramesWithDictionary(CCDictionary* dictionary,
 
 void CCSpriteFrameCache::addSpriteFramesWithFile(const char *pszPlist, CCTexture2D *pobTexture)
 {
+	if (m_pLoadedFileNames->find(pszPlist) != m_pLoadedFileNames->end())
+	{
+		return;//We already added it
+	}
     std::string fullPath = CCFileUtils::sharedFileUtils()->fullPathForFilename(pszPlist);
     CCDictionary *dict = CCDictionary::createWithContentsOfFileThreadSafe(fullPath.c_str());
 
     addSpriteFramesWithDictionary(dict, pobTexture);
+	m_pLoadedFileNames->insert(pszPlist);
 
     dict->release();
 }

--- a/cocos2dx/sprite_nodes/CCSpriteFrameCache.cpp
+++ b/cocos2dx/sprite_nodes/CCSpriteFrameCache.cpp
@@ -203,15 +203,15 @@ void CCSpriteFrameCache::addSpriteFramesWithDictionary(CCDictionary* dictionary,
 
 void CCSpriteFrameCache::addSpriteFramesWithFile(const char *pszPlist, CCTexture2D *pobTexture)
 {
-	if (m_pLoadedFileNames->find(pszPlist) != m_pLoadedFileNames->end())
-	{
-		return;//We already added it
-	}
+    if (m_pLoadedFileNames->find(pszPlist) != m_pLoadedFileNames->end())
+    {
+        return;//We already added it
+    }
     std::string fullPath = CCFileUtils::sharedFileUtils()->fullPathForFilename(pszPlist);
     CCDictionary *dict = CCDictionary::createWithContentsOfFileThreadSafe(fullPath.c_str());
 
     addSpriteFramesWithDictionary(dict, pobTexture);
-	m_pLoadedFileNames->insert(pszPlist);
+    m_pLoadedFileNames->insert(pszPlist);
 
     dict->release();
 }


### PR DESCRIPTION
Previous PR https://github.com/cocos2d/cocos2d-x/pull/5680

---

If we add again the same Plist file we will have ~200KB of memory leak.
Ofcourse it will be cleared in some time but the case it when we reload
Plist for example in restartGame() function.

Example:

//We want clean memory every game start

CCSpriteFrameCache::sharedSpriteFrameCache()->purgeSharedSpriteFrameCache();
CCTextureCache::sharedTextureCache()->purgeSharedTextureCache();

///////////////////////////////////////////////////////////////////////////////////////////////

LevelConfiguration config = getCurrentLevelConfiguration();
CCTextureCache::sharedTextureCache()->addImage(config.textureFileName.c_str());

CCSpriteFrameCache::sharedSpriteFrameCache()->addSpriteFramesWithFile(config.plistFileName.c_str(),config.textureFileName);

Also when someone use another function than
void CCSpriteFrameCache::addSpriteFramesWithFile(const char *pszPlist);

we don't add to loaded file names:
m_pLoadedFileNames->insert(pszPlist);
