### PR TITLE
Bug fix cc scheduler blocked element

### DIFF
--- a/cocos2dx/CCScheduler.cpp
+++ b/cocos2dx/CCScheduler.cpp
@@ -469,7 +469,7 @@ void CCScheduler::scheduleUpdateForTarget(CCObject *pTarget, int nPriority, bool
         CCAssert(pHashElement->entry->markedForDeletion,"");
 #endif
         // TODO: check if priority has changed!
-
+		pHashElement->entry->paused = bPaused;
         pHashElement->entry->markedForDeletion = false;
         return;
     }

--- a/cocos2dx/CCScheduler.cpp
+++ b/cocos2dx/CCScheduler.cpp
@@ -469,7 +469,7 @@ void CCScheduler::scheduleUpdateForTarget(CCObject *pTarget, int nPriority, bool
         CCAssert(pHashElement->entry->markedForDeletion,"");
 #endif
         // TODO: check if priority has changed!
-		pHashElement->entry->paused = bPaused;
+	pHashElement->entry->paused = bPaused;
         pHashElement->entry->markedForDeletion = false;
         return;
     }

--- a/cocos2dx/CCScheduler.cpp
+++ b/cocos2dx/CCScheduler.cpp
@@ -469,7 +469,7 @@ void CCScheduler::scheduleUpdateForTarget(CCObject *pTarget, int nPriority, bool
         CCAssert(pHashElement->entry->markedForDeletion,"");
 #endif
         // TODO: check if priority has changed!
-	pHashElement->entry->paused = bPaused;
+        pHashElement->entry->paused = bPaused;
         pHashElement->entry->markedForDeletion = false;
         return;
     }


### PR DESCRIPTION
Previous PR https://github.com/cocos2d/cocos2d-x/pull/5732

---

Example

We scheduled teget for example method update

void MyObject::update(float dt)
{
//Here CCScheduler::m_bUpdateHashLocked is set to true
//Also here scheduler for LeafAnimator::getInstance() is
paused!

CCDirector::sharedDirector()->getScheduler()->unscheduleUpdateForTarget(&LeafAnimator::getInstance()
);

CCDirector::sharedDirector()->getScheduler()->scheduleUpdateForTarget
(&LeafAnimator::getInstance(), INT_MAX, false );
//So when we want reschedule paused field isn't updated. Priority also
but this is in todo :)
}
