### PR TITLE
Fix mingw64 build: convert from LPVOID to DWORD losses precision on 64-b...

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -153,7 +153,7 @@ include_directories(
   ${CMAKE_CURRENT_SOURCE_DIR}/external/xxhash
 )
 
-if(WIN32)
+if(WIN32 AND NOT MINGW)
   include_directories(
     ${CMAKE_CURRENT_SOURCE_DIR}/external/${PLATFORM_FOLDER}-specific/gles/include/OGLES
     ${CMAKE_CURRENT_SOURCE_DIR}/external/${PLATFORM_FOLDER}-specific/icon/include

--- a/cocos/audio/win32/MciPlayer.cpp
+++ b/cocos/audio/win32/MciPlayer.cpp
@@ -142,9 +142,9 @@ void MciPlayer::Resume()
         MCI_STATUS_PARMS mciStatusParms;
         MCI_PLAY_PARMS   mciPlayParms;  
         mciStatusParms.dwItem = MCI_STATUS_POSITION;   
-        _SendGenericCommand(MCI_STATUS, MCI_STATUS_ITEM,(DWORD)(LPVOID)&mciStatusParms); // MCI_STATUS   
+        _SendGenericCommand(MCI_STATUS, MCI_STATUS_ITEM, reinterpret_cast<DWORD_PTR>(&mciStatusParms)); // MCI_STATUS   
         mciPlayParms.dwFrom = mciStatusParms.dwReturn;  // get position  
-        _SendGenericCommand(MCI_PLAY, MCI_FROM, (DWORD)(LPVOID)&mciPlayParms); // MCI_FROM
+        _SendGenericCommand(MCI_PLAY, MCI_FROM, reinterpret_cast<DWORD_PTR>(&mciPlayParms)); // MCI_FROM
     } 
     else
     {

--- a/tests/cpp-empty-test/CMakeLists.txt
+++ b/tests/cpp-empty-test/CMakeLists.txt
@@ -73,3 +73,7 @@ else()
 endif()
 
 target_link_libraries(${APP_NAME} audio cocos2d)
+# MinGW builds need to link libws2_32 and libglew32 manually
+if (MINGW)
+  target_link_libraries(${APP_NAME} glew32 ws2_32)
+endif()

--- a/tests/cpp-tests/CMakeLists.txt
+++ b/tests/cpp-tests/CMakeLists.txt
@@ -205,6 +205,10 @@ target_link_libraries(${APP_NAME}
   cocos2d
   box2d
 )
+# MinGW builds need to link libws2_32 manually
+if (MINGW)
+  target_link_libraries(${APP_NAME} ws2_32)
+endif()
 
 set(APP_BIN_DIR "${CMAKE_BINARY_DIR}/bin/${APP_NAME}")
 


### PR DESCRIPTION
Fix mingw64 build: convert from LPVOID to DWORD losses precision on 64-bit platforms.
Should be DWORD_PTR.
