### PR TITLE
Fix NSNotificationCenter and NSTimer leaks

### DIFF
--- a/cocos/platform/ios/CCDirectorCaller.h
+++ b/cocos/platform/ios/CCDirectorCaller.h
@@ -34,6 +34,7 @@
 }
 @property (readwrite) int interval;
 -(void) startMainLoop;
+-(void) stopMainLoop;
 -(void) doCaller: (id) sender;
 -(void) setAnimationInterval:(double)interval;
 +(id) sharedDirectorCaller;

--- a/cocos/platform/ios/CCDirectorCaller.mm
+++ b/cocos/platform/ios/CCDirectorCaller.mm
@@ -58,6 +58,7 @@ static id s_sharedDirectorCaller;
 
 +(void) destroy
 {
+    [s_sharedDirectorCaller stopMainLoop];
     [s_sharedDirectorCaller release];
     s_sharedDirectorCaller = nil;
 }
@@ -76,25 +77,29 @@ static id s_sharedDirectorCaller;
 -(void) startMainLoop
 {
         // Director::setAnimationInterval() is called, we should invalidate it first
-        [displayLink invalidate];
-        displayLink = nil;
-        
-        displayLink = [NSClassFromString(@"CADisplayLink") displayLinkWithTarget:self selector:@selector(doCaller:)];
-        [displayLink setFrameInterval: self.interval];
-        [displayLink addToRunLoop:[NSRunLoop currentRunLoop] forMode:NSDefaultRunLoopMode];
+    [self stopMainLoop];
+    
+    displayLink = [NSClassFromString(@"CADisplayLink") displayLinkWithTarget:self selector:@selector(doCaller:)];
+    [displayLink setFrameInterval: self.interval];
+    [displayLink addToRunLoop:[NSRunLoop currentRunLoop] forMode:NSDefaultRunLoopMode];
+}
+
+-(void) stopMainLoop
+{
+    [displayLink invalidate];
+    displayLink = nil;
 }
 
 -(void) setAnimationInterval:(double)intervalNew
 {
-        // Director::setAnimationInterval() is called, we should invalidate it first
-        [displayLink invalidate];
-        displayLink = nil;
+    // Director::setAnimationInterval() is called, we should invalidate it first
+    [self stopMainLoop];
         
-        self.interval = 60.0 * intervalNew;
+    self.interval = 60.0 * intervalNew;
         
-        displayLink = [NSClassFromString(@"CADisplayLink") displayLinkWithTarget:self selector:@selector(doCaller:)];
-        [displayLink setFrameInterval: self.interval];
-        [displayLink addToRunLoop:[NSRunLoop currentRunLoop] forMode:NSDefaultRunLoopMode];
+    displayLink = [NSClassFromString(@"CADisplayLink") displayLinkWithTarget:self selector:@selector(doCaller:)];
+    [displayLink setFrameInterval: self.interval];
+    [displayLink addToRunLoop:[NSRunLoop currentRunLoop] forMode:NSDefaultRunLoopMode];
 }
                       
 -(void) doCaller: (id) sender

--- a/cocos/platform/ios/CCEAGLView.mm
+++ b/cocos/platform/ios/CCEAGLView.mm
@@ -243,6 +243,7 @@ Copyright (C) 2008 Apple Inc. All Rights Reserved.
 
 - (void) dealloc
 {
+    [[NSNotificationCenter defaultCenter] removeObserver:self]; // remove keyboard notification
     [renderer_ release];
     self.keyboardShowNotification = nullptr; // implicit release
     [super dealloc];


### PR DESCRIPTION
- Remove keyboard notifications from NSNotificationCenter.
- Invalidate NSTimer instance of the main loop.
