### PR TITLE
Update CCNode.h

### DIFF
--- a/cocos2dx/base_nodes/CCNode.h
+++ b/cocos2dx/base_nodes/CCNode.h
@@ -1007,7 +1007,7 @@ public:
      * @return A "local" axis aligned boudning box of the node.
      * @js getBoundingBox
      */
-    CCRect boundingBox(void);
+    virtual CCRect boundingBox(void);
 
     /// @{
     /// @name Actions


### PR DESCRIPTION
By adding "virtual"  CCArmature and other subclasses's boundingBox() functions get properly called.
