### PR TITLE
Simplify BlendFunc operator< judgement

### DIFF
--- a/cocos/base/ccTypes.h
+++ b/cocos/base/ccTypes.h
@@ -328,7 +328,7 @@ struct BlendFunc
 
     bool operator<(const BlendFunc &a) const
     {
-        return src < a.src;
+        return src < a.src || (src == a.src && dst < a.dst);
     }
 };
 

--- a/cocos/base/ccTypes.h
+++ b/cocos/base/ccTypes.h
@@ -328,7 +328,7 @@ struct BlendFunc
 
     bool operator<(const BlendFunc &a) const
     {
-        return src < a.src || (src < a.src && dst < a.dst);
+        return src < a.src;
     }
 };
 


### PR DESCRIPTION
Simplify BlendFunc operator< judgement, and the older method of comparation is superfluous.
