### PR TITLE
Fix MinGW build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,6 +100,8 @@ endif()
 if(MINGW)
   add_definitions(-DGLEW_STATIC)
   add_definitions(-D__SSIZE_T)
+  set(CMAKE_C_STANDARD_LIBRARIES "${CMAKE_C_STANDARD_LIBRARIES} -lws2_32")
+  set(CMAKE_CXX_STANDARD_LIBRARIES "${CMAKE_CXX_STANDARD_LIBRARIES} -lws2_32")
 endif()
 
 

--- a/cocos/network/CMakeLists.txt
+++ b/cocos/network/CMakeLists.txt
@@ -24,14 +24,14 @@ set(COCOS_NETWORK_SRC
   ${PLATFORM_SRC}
 )
 
-IF ( WIN32 )
-set(COCOS_NETWORK_LINK
-  libcurl_imp
-  ${PLATFORM_LINK}
-)
+IF (WIN32 AND NOT MINGW)
+  set(COCOS_NETWORK_LINK
+    libcurl_imp
+    ${PLATFORM_LINK}
+  )
 ELSE()
-set(COCOS_NETWORK_LINK
-  curl
-  ${PLATFORM_LINK}
-)
+  set(COCOS_NETWORK_LINK
+    curl
+    ${PLATFORM_LINK}
+  )
 ENDIF()

--- a/tests/cpp-empty-test/CMakeLists.txt
+++ b/tests/cpp-empty-test/CMakeLists.txt
@@ -73,7 +73,3 @@ else()
 endif()
 
 target_link_libraries(${APP_NAME} audio cocos2d)
-# MinGW builds need to link libws2_32 and libglew32 manually
-if (MINGW)
-  target_link_libraries(${APP_NAME} glew32 ws2_32)
-endif()

--- a/tests/cpp-tests/CMakeLists.txt
+++ b/tests/cpp-tests/CMakeLists.txt
@@ -202,10 +202,6 @@ target_link_libraries(${APP_NAME}
   cocos2d
   box2d
 )
-# MinGW builds need to link libws2_32 manually
-if (MINGW)
-  target_link_libraries(${APP_NAME} ws2_32)
-endif()
 
 set(APP_BIN_DIR "${CMAKE_BINARY_DIR}/bin/${APP_NAME}")
 


### PR DESCRIPTION
Previous commits changed `libcurl` dependency to `libcurl_imp`, but it was not the case on mingw toolchains.

Add `libws2_32` as standard library, so that all executables can automatically link to it.
