### PR TITLE
Skip UTF8 BOM if it exists and bug fix for unterminated string

### DIFF
--- a/cocos/editor-support/cocostudio/CCDataReaderHelper.cpp
+++ b/cocos/editor-support/cocostudio/CCDataReaderHelper.cpp
@@ -1185,8 +1185,22 @@ ContourData *DataReaderHelper::decodeContour(tinyxml2::XMLElement *contourXML, D
 void DataReaderHelper::addDataFromJsonCache(const std::string& fileContent, DataInfo *dataInfo)
 {
 	rapidjson::Document json;
-	
-	json.Parse<0>(fileContent.c_str());
+    rapidjson::StringStream stream(fileContent.c_str());
+    
+    if (fileContent.size() >= 3) {
+        // Skip BOM if exists
+        const unsigned char* c = (const unsigned char *)fileContent.c_str();
+	    unsigned bom = c[0] | (c[1] << 8) | (c[2] << 16);
+        
+        if (bom == 0xBFBBEF)  // UTF8 BOM
+        {
+            stream.Take();
+            stream.Take();
+            stream.Take();
+        }
+    }
+    
+    json.ParseStream<0>(stream);
     if (json.HasParseError()) {
         CCLOG("GetParseError %s\n",json.GetParseError());
     }

--- a/cocos/platform/CCFileUtils.cpp
+++ b/cocos/platform/CCFileUtils.cpp
@@ -548,7 +548,7 @@ static Data getData(const std::string& filename, bool forString)
         }
     } while (0);
     
-    if (nullptr == buffer || 0 == size)
+    if (nullptr == buffer || 0 == readsize)
     {
         std::string msg = "Get data from file(";
         msg.append(filename).append(") failed!");
@@ -556,7 +556,7 @@ static Data getData(const std::string& filename, bool forString)
     }
     else
     {
-        ret.fastSet(buffer, size);
+        ret.fastSet(buffer, readsize);
     }
     
     return ret;

--- a/cocos/platform/CCFileUtils.cpp
+++ b/cocos/platform/CCFileUtils.cpp
@@ -512,6 +512,7 @@ static Data getData(const std::string& filename, bool forString)
     Data ret;
     unsigned char* buffer = nullptr;
     ssize_t size = 0;
+    size_t readsize;
     const char* mode = nullptr;
     if (forString)
         mode = "rt";
@@ -538,8 +539,13 @@ static Data getData(const std::string& filename, bool forString)
             buffer = (unsigned char*)malloc(sizeof(unsigned char) * size);
         }
         
-        size = fread(buffer, sizeof(unsigned char), size, fp);
+        readsize = fread(buffer, sizeof(unsigned char), size, fp);
         fclose(fp);
+        
+        if (forString && readsize < size)
+        {
+            buffer[readsize] = '\0';
+        }
     } while (0);
     
     if (nullptr == buffer || 0 == size)


### PR DESCRIPTION
- Skip UTF8 BOM if it exists
- Fix when string isn't terminated if fread() reads less size than paramter at FileUtils getData
