### PR TITLE
Cleanup travis.yml and re-enable on all branches.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,12 @@
---- 
 language: cpp
-env: 
-  matrix: 
+env:
+  matrix:
   - GEN_JSB=YES
   - PLATFORM=linux DEBUG=1
   - PLATFORM=nacl DEBUG=1
   - PLATFORM=android
   - PLATFORM=emscripten DEBUG=1
-  global: 
+  global:
   - secure: |-
       cHXOjAda+t2tmBVuVAiQfvhDN+unToO6hX1rc3dJeGDOk4rlQnylJacjA7o/
       enkWeHagbW2Ja4h7BxQz4h7dada8zEbIbEMK4VEHx6AWwQM+GIEqkJPv5g8k
@@ -20,16 +19,7 @@ env:
       Wsngwo3jlZtvuPfr3RNhqrz/liNIhKYnlw4KYJO90gMQ9ZQKRTlMv2BMiPw/
       9lV+vgJQDRcFe7dKwtC86vk10EU7Ym2bhVmhMxi/AlmJXgavjmPVdizRT7rh
       X2Ry/Nb6hGRkH3WS0T3D/KG1+e7lP/TMB9bvo6/locLJ2A6Z1YI=
-script: 
-- export NACL_SDK_ROOT=$HOME/bin/nacl_sdk/pepper_canary
-- export PATH=$PATH:$NACL_SDK_ROOT/toolchain/linux_x86_newlib/bin
-- export NDK_ROOT=$HOME/bin/android-ndk
-- ./tools/travis-scripts/run-script.sh
-
-before_install: 
-- ./tools/travis-scripts/before-install.sh
-
-# whitelist
-branches:
-  only:
-    - v2
+script:
+- tools/travis-scripts/run-script.sh
+before_install:
+- tools/travis-scripts/before-install.sh

--- a/tools/travis-scripts/before-install.sh
+++ b/tools/travis-scripts/before-install.sh
@@ -82,7 +82,7 @@ fi
 
 if [ "$PLATFORM"x = "nacl"x ]; then
     sudo apt-get update
-    sudo apt-get install libc6:i386
+    sudo apt-get install libc6:i386 libstdc++6:i386
     echo "Download nacl_sdk ..."
     wget http://storage.googleapis.com/nativeclient-mirror/nacl/nacl_sdk/nacl_sdk.zip
     echo "Decompress nacl_sdk.zip"

--- a/tools/travis-scripts/generate-jsbindings.sh
+++ b/tools/travis-scripts/generate-jsbindings.sh
@@ -42,7 +42,9 @@ else
     sudo apt-get --force-yes --yes install python-yaml python-cheetah
 fi
 
-if [ "$GEN_JSB"x != "YES"x ]; then
+# this script is running on some repo other than cocos2d/cocos2d-x then
+# don't try to create create PR, just regenerate the bindings locally.
+if [ "$GEN_JSB" != "YES" -o "${TRAVIS_REPO_SLUG}" != "cocos2d/cocos2d-x" ]; then
     pushd "$TOJS_ROOT"
     ./genbindings.sh
     popd
@@ -50,15 +52,15 @@ if [ "$GEN_JSB"x != "YES"x ]; then
 fi
 
 #Set git user
-git config --global user.email ${GH_EMAIL}
-git config --global user.name ${GH_USER}
+git config user.email ${GH_EMAIL}
+git config user.name ${GH_USER}
 
 # Update submodule of auto-gen JSBinding repo.
 pushd "$GENERATED_WORKTREE"
 
 git checkout -B v2
-#Set remotes
-git remote add upstream https://${GH_USER}:${GH_PASSWORD}@github.com/folecr/cocos2dx-autogen-bindings.git 2> /dev/null > /dev/null
+#Set remote
+git remote add upstream https://${GH_USER}:${GH_PASSWORD}@github.com/folecr/cocos2dx-autogen-bindings.git > /dev/null
 
 echo "Delete all directories and files except '.git' and 'README'."
 ls -a | grep -E -v ^\[.\]\{1,2\}$ | grep -E -v ^\.git$ | grep -E -v ^README$ | xargs -I{} rm -rf {}


### PR DESCRIPTION
This change re-enables travis for branches other than 'v2'.

The NaCl broken NaCl build was actually fixed by a new release of Native Client but this change is still useful for those of use who want to use travis on our own repos and branchs.
