### PR TITLE
Fix precision

### DIFF
--- a/cocos2dx/shaders/CCGLProgram.cpp
+++ b/cocos2dx/shaders/CCGLProgram.cpp
@@ -190,7 +190,11 @@ bool CCGLProgram::compileShader(GLuint * shader, GLenum type, const GLchar* sour
     
     const GLchar *sources[] = {
 #if (CC_TARGET_PLATFORM != CC_PLATFORM_WIN32 && CC_TARGET_PLATFORM != CC_PLATFORM_LINUX && CC_TARGET_PLATFORM != CC_PLATFORM_MAC)
+#if CC_TARGET_PLATFORM == CC_PLATFORM_NACL
+        "precision highp float;\n"
+#else
         (type == GL_VERTEX_SHADER ? "precision highp float;\n" : "precision mediump float;\n"),
+#endif
 #endif
         "uniform mat4 CC_PMatrix;\n"
         "uniform mat4 CC_MVMatrix;\n"
@@ -295,13 +299,12 @@ bool CCGLProgram::link()
     }
     
     m_uVertShader = m_uFragShader = 0;
-	
-#if defined(DEBUG) || (CC_TARGET_PLATFORM == CC_PLATFORM_WINRT) || (CC_TARGET_PLATFORM == CC_PLATFORM_WP8)
+#if (defined(COCOS2D_DEBUG) && COCOS2D_DEBUG) || (CC_TARGET_PLATFORM == CC_PLATFORM_WINRT) || (CC_TARGET_PLATFORM == CC_PLATFORM_WP8)
     glGetProgramiv(m_uProgram, GL_LINK_STATUS, &status);
-	
+
     if (status == GL_FALSE)
     {
-        CCLOG("cocos2d: ERROR: Failed to link program: %i", m_uProgram);
+        CCLOG("cocos2d: ERROR: Failed to link program: %i\n%s", m_uProgram, programLog());
         ccGLDeleteProgram(m_uProgram);
         m_uProgram = 0;
     }


### PR DESCRIPTION
Recent version of chrome will fail to link shader programs
that contain the same type names with different precisions.

Previously CCGLProgram::compileShader was delaring the
CC_PMatrix and friends to be highp in the vertex shader
and mediump in the fragment shader. This is technically
against the GLES spec but I assume that most implementation
allow it anyway.

This changes the precision to highp for both vertext
and fragment shaders when building for NaCl.  It might
be desirable to make this true for all platform but I'm
not sure what the consequences would be.

Also, print linker logs when shader programs fail to link.
The fact that this was not previously done made this problem
hard to debug.

Also, the code for checking the link status was guarded by
DEBUG (which AFIAKT is never defined) rather than
COCOS2D_DEBUG.
