### PR TITLE
Bugfix autorelease pool manager

### DIFF
--- a/cocos/base/CCAutoreleasePool.cpp
+++ b/cocos/base/CCAutoreleasePool.cpp
@@ -111,8 +111,7 @@ PoolManager* PoolManager::getInstance()
     {
         s_singleInstance = new PoolManager();
         // Add the first auto release pool
-        s_singleInstance->_curReleasePool = new AutoreleasePool("cocos2d autorelease pool");
-        s_singleInstance->_releasePoolStack.push_back(s_singleInstance->_curReleasePool);
+        new AutoreleasePool("cocos2d autorelease pool");
     }
     return s_singleInstance;
 }
@@ -134,7 +133,6 @@ PoolManager::~PoolManager()
     while (!_releasePoolStack.empty())
     {
         AutoreleasePool* pool = _releasePoolStack.back();
-        _releasePoolStack.pop_back();
         
         delete pool;
     }
@@ -164,16 +162,9 @@ void PoolManager::push(AutoreleasePool *pool)
 
 void PoolManager::pop()
 {
-    // Can not pop the pool that created by engine
-    CC_ASSERT(_releasePoolStack.size() >= 1);
-    
+    CC_ASSERT(!_releasePoolStack.empty());
     _releasePoolStack.pop_back();
-    
-    // Should update _curReleasePool if a temple pool is released
-    if (_releasePoolStack.size() > 1)
-    {
-        _curReleasePool = _releasePoolStack.back();
-    }
+    _curReleasePool = _releasePoolStack.empty() ? nullptr : _releasePoolStack.back();
 }
 
 NS_CC_END

--- a/cocos/base/CCAutoreleasePool.cpp
+++ b/cocos/base/CCAutoreleasePool.cpp
@@ -124,6 +124,7 @@ void PoolManager::destroyInstance()
 
 PoolManager::PoolManager()
 {
+    _releasePoolStack.reserve(10);
 }
 
 PoolManager::~PoolManager()

--- a/cocos/base/CCAutoreleasePool.cpp
+++ b/cocos/base/CCAutoreleasePool.cpp
@@ -141,7 +141,7 @@ PoolManager::~PoolManager()
 
 AutoreleasePool* PoolManager::getCurrentPool() const
 {
-    return _curReleasePool;
+    return _releasePoolStack.back();
 }
 
 bool PoolManager::isObjectInPools(Ref* obj) const
@@ -157,14 +157,12 @@ bool PoolManager::isObjectInPools(Ref* obj) const
 void PoolManager::push(AutoreleasePool *pool)
 {
     _releasePoolStack.push_back(pool);
-    _curReleasePool = pool;
 }
 
 void PoolManager::pop()
 {
     CC_ASSERT(!_releasePoolStack.empty());
     _releasePoolStack.pop_back();
-    _curReleasePool = _releasePoolStack.empty() ? nullptr : _releasePoolStack.back();
 }
 
 NS_CC_END

--- a/cocos/base/CCAutoreleasePool.h
+++ b/cocos/base/CCAutoreleasePool.h
@@ -164,7 +164,6 @@ private:
     static PoolManager* s_singleInstance;
     
     std::deque<AutoreleasePool*> _releasePoolStack;
-    AutoreleasePool *_curReleasePool;
 };
 
 // end of base_nodes group

--- a/cocos/base/CCAutoreleasePool.h
+++ b/cocos/base/CCAutoreleasePool.h
@@ -163,7 +163,7 @@ private:
     
     static PoolManager* s_singleInstance;
     
-    std::deque<AutoreleasePool*> _releasePoolStack;
+    std::vector<AutoreleasePool*> _releasePoolStack;
 };
 
 // end of base_nodes group

--- a/tests/cpp-tests/Classes/ReleasePoolTest/ReleasePoolTest.cpp
+++ b/tests/cpp-tests/Classes/ReleasePoolTest/ReleasePoolTest.cpp
@@ -75,6 +75,11 @@ void ReleasePoolTestScene::runThisTest()
     }
     
     // object in pool2 should be released
+
+    {
+        new AutoreleasePool;
+        PoolManager::destroyInstance();
+    }
     
     Director::getInstance()->replaceScene(this);
 }


### PR DESCRIPTION
Continue with pull request #6780.

Commit dbca937 will break AutoreleasePool test case.
Other commits fix it.

It may not be a bug, but a 'feature'. If that, explicit code/documentation should be added.

TestCase AutoreleasePool passed.
