### PR TITLE
fix lua-binding release build

### DIFF
--- a/cocos/scripting/lua-bindings/manual/lua_cocos2dx_manual.cpp
+++ b/cocos/scripting/lua-bindings/manual/lua_cocos2dx_manual.cpp
@@ -5384,7 +5384,14 @@ static int lua_cocos2dx_GLProgramState_setVertexAttribPointer(lua_State* tolua_S
         {
             lua_pushnumber(tolua_S,i + 1);
             lua_gettable(tolua_S,7);
-            if (tolua_isnumber(tolua_S, -1, 0, &tolua_err))
+            bool isnum = true;
+#if COCOS2D_DEBUG >= 1
+            if (!tolua_isnumber(tolua_S, -1, 0, &tolua_err))
+            {
+                isnum = false;
+            }
+#endif
+            if (isnum)
             {
                 arg5[i] = tolua_tonumber(tolua_S, -1, 0);
             }


### PR DESCRIPTION
when release mode, compile error like this

```
[armeabi] Compile++ thumb: cocos_lua_static <= lua_cocos2dx_manual.cpp
/Users/n_totani/test/frameworks/runtime-src/proj.android/../../cocos2d-x/cocos//scripting/lua-bindings/manual/lua_cocos2dx_manual.cpp: In function 'int lua_cocos2dx_GLProgramState_setVertexAttribPointer(lua_State*)':
/Users/n_totani/test/frameworks/runtime-src/proj.android/../../cocos2d-x/cocos//scripting/lua-bindings/manual/lua_cocos2dx_manual.cpp:5387:49: error: 'tolua_err' was not declared in this scope
             if (tolua_isnumber(tolua_S, -1, 0, &tolua_err))
                                                 ^
```

To fix it, check number only debug mode.
