### PR TITLE
Behaviour of ParallaxNode is wrong

### DIFF
--- a/cocos/2d/CCParallaxNode.cpp
+++ b/cocos/2d/CCParallaxNode.cpp
@@ -121,7 +121,7 @@ The positions are updated at visit because:
 - using a timer is not guaranteed that it will called after all the positions were updated
 - overriding "draw" will only precise if the children have a z > 0
 */
-void ParallaxNode::visit(Renderer *renderer, const Mat4 &parentTransform, bool parentTransformUpdated)
+void ParallaxNode::visit(Renderer *renderer, const Mat4 &parentTransform, uint32_t parentFlags)
 {
     Vec2 pos = parallaxPosition;
 
@@ -134,7 +134,7 @@ void ParallaxNode::visit(Renderer *renderer, const Mat4 &parentTransform, bool p
         }
         _lastPosition = pos;
     }
-    Node::visit(renderer, parentTransform, parentTransformUpdated);
+    Node::visit(renderer, parentTransform, parentFlags);
 }
 
 NS_CC_END

--- a/cocos/2d/CCParallaxNode.cpp
+++ b/cocos/2d/CCParallaxNode.cpp
@@ -78,13 +78,6 @@ ParallaxNode::~ParallaxNode()
     }
 }
 
-ParallaxNode * ParallaxNode::create()
-{
-    ParallaxNode *ret = new ParallaxNode();
-    ret->autorelease();
-    return ret;
-}
-
 void ParallaxNode::addChild(Node * child, int zOrder, int tag)
 {
     CC_UNUSED_PARAM(zOrder);
@@ -128,26 +121,20 @@ The positions are updated at visit because:
 - using a timer is not guaranteed that it will called after all the positions were updated
 - overriding "draw" will only precise if the children have a z > 0
 */
-void ParallaxNode::visit(Renderer *renderer, const Mat4 &parentTransform, uint32_t parentFlags)
+void ParallaxNode::visit(Renderer *renderer, const Mat4 &parentTransform, bool parentTransformUpdated)
 {
-    //    Vec2 pos = position_;
-    //    Vec2    pos = [self convertToWorldSpace:Vec2::ZERO];
-    Vec2 pos = this->getPosition();
-    pos = this->getParent()->convertToWorldSpace(pos);
+    Vec2 pos = parallaxPosition;
 
-    if( ! pos.equals(_lastPosition) )
-    {
-        for( int i=0; i < _parallaxArray->num; i++ ) 
-        {
+    if (!pos.equals(_lastPosition)) {
+        for( int i=0; i < _parallaxArray->num; i++ ) {
             PointObject *point = (PointObject*)_parallaxArray->arr[i];
             float x = pos.x * point->getRatio().x + point->getOffset().x;
             float y = pos.y * point->getRatio().y + point->getOffset().y;
-            auto childPos = this->convertToNodeSpace({x, y});
-            point->getChild()->setPosition(childPos);
+            point->getChild()->setPosition({x, y});
         }
         _lastPosition = pos;
     }
-    Node::visit(renderer, parentTransform, parentFlags);
+    Node::visit(renderer, parentTransform, parentTransformUpdated);
 }
 
 NS_CC_END

--- a/cocos/2d/CCParallaxNode.cpp
+++ b/cocos/2d/CCParallaxNode.cpp
@@ -137,6 +137,11 @@ Vec2 ParallaxNode::absolutePosition()
         cn = cn->getParent();
         ret = ret + cn->getPosition();
     }
+
+    auto glView = cocos2d::Director::getInstance()->getOpenGLView();
+    ret.x *= glView->getFrameSize().width / glView->getDesignResolutionSize().width;
+    ret.y *= glView->getFrameSize().height / v->getDesignResolutionSize().height;
+
     return ret;
 }
 

--- a/cocos/2d/CCParallaxNode.cpp
+++ b/cocos/2d/CCParallaxNode.cpp
@@ -128,7 +128,7 @@ The positions are updated at visit because:
 - using a timer is not guaranteed that it will called after all the positions were updated
 - overriding "draw" will only precise if the children have a z > 0
 */
-void ParallaxNode::visit(Renderer *renderer, const Mat4 &parentTransform, bool parentTransformUpdated)
+void ParallaxNode::visit(Renderer *renderer, const Mat4 &parentTransform, uint32_t parentFlags)
 {
     //    Vec2 pos = position_;
     //    Vec2    pos = [self convertToWorldSpace:Vec2::ZERO];
@@ -147,7 +147,7 @@ void ParallaxNode::visit(Renderer *renderer, const Mat4 &parentTransform, bool p
         }
         _lastPosition = pos;
     }
-    Node::visit(renderer, parentTransform, parentTransformUpdated);
+    Node::visit(renderer, parentTransform, parentFlags);
 }
 
 NS_CC_END

--- a/cocos/2d/CCParallaxNode.h
+++ b/cocos/2d/CCParallaxNode.h
@@ -48,7 +48,9 @@ class CC_DLL ParallaxNode : public Node
 {
 public:
     // Create a Parallax node
-    static ParallaxNode * create();
+    CREATE_FUNC(ParallaxNode);
+
+    Vec2 parallaxPosition = {0.0, 0.0};
 
     // prevents compiler warning: "Included function hides overloaded virtual functions"
     using Node::addChild;
@@ -61,13 +63,21 @@ public:
     struct _ccArray* getParallaxArray() { return _parallaxArray; }
     const struct _ccArray* getParallaxArray() const { return _parallaxArray; }
 
+    inline void setParallaxX(float x) { parallaxPosition.x = x; }
+    inline void setParallaxY(float y) { parallaxPosition.y = y; }
+    inline void setParallaxPosition(float x, float y) { setParallaxX(x); setParallaxY(y); }
+
+    inline float getParallaxX() { return parallaxPosition.x; }
+    inline float getParallaxY() { return parallaxPosition.y; }
+    inline Vec2 getParallaxPosition() const { return parallaxPosition; }
+
     //
     // Overrides
     //
     virtual void addChild(Node * child, int zOrder, int tag) override;
     virtual void removeChild(Node* child, bool cleanup) override;
     virtual void removeAllChildrenWithCleanup(bool cleanup) override;
-    virtual void visit(Renderer *renderer, const Mat4 &parentTransform, uint32_t parentFlags) override;
+    virtual void visit(Renderer *renderer, const Mat4 &parentTransform, bool parentTransformUpdated) override;
 
 protected:
     /** Adds a child to the container with a z-order, a parallax ratio and a position offset

--- a/cocos/2d/CCParallaxNode.h
+++ b/cocos/2d/CCParallaxNode.h
@@ -82,8 +82,6 @@ protected:
      */
     virtual ~ParallaxNode();
 
-    Vec2 absolutePosition();
-
     Vec2    _lastPosition;
     struct _ccArray* _parallaxArray;
 

--- a/cocos/2d/CCParallaxNode.h
+++ b/cocos/2d/CCParallaxNode.h
@@ -77,7 +77,7 @@ public:
     virtual void addChild(Node * child, int zOrder, int tag) override;
     virtual void removeChild(Node* child, bool cleanup) override;
     virtual void removeAllChildrenWithCleanup(bool cleanup) override;
-    virtual void visit(Renderer *renderer, const Mat4 &parentTransform, bool parentTransformUpdated) override;
+    virtual void visit(Renderer *renderer, const Mat4 &parentTransform, uint32_t parentFlags) override;
 
 protected:
     /** Adds a child to the container with a z-order, a parallax ratio and a position offset


### PR DESCRIPTION
Behaviour of ParallaxNode is wrong when glFrameSize is not identical to DesignResolutionSize. 

Don't know if this should be fixed using multiplying with a matrix - but at least at my tests it works with this fix. But would be great if someone who knows more about the internal rendering will have a look at this problem.

To test the problem:
- Create a cocos2d-x app
- In AppDelegate create a GLView with a different size to designResolution, for example:

[...]
        glview = GLView::createWithRect("testApp", {0,0, 960, 512});
        director->setOpenGLView(glview);
[...]
    glview->setDesignResolutionSize(480, 512, ResolutionPolicy::FIXED_WIDTH);
[...]
- Then create some ParallaxNodes and add it to your scene and scroll it around in the update-method
