### PR TITLE
Fix CCImage to be compatible with UNIX2003

### DIFF
--- a/cocos/platform/CCImage.cpp
+++ b/cocos/platform/CCImage.cpp
@@ -39,6 +39,7 @@ THE SOFTWARE.
 
 extern "C"
 {
+#if defined(__APPLE__) || defined(__unix) 
 #ifndef __ENABLE_COMPATIBILITY_WITH_UNIX_2003__
 #define __ENABLE_COMPATIBILITY_WITH_UNIX_2003__
 #include <stdio.h>
@@ -54,6 +55,7 @@ extern "C"
     {
         return strerror(errnum);
     }
+#endif
 #endif
 #include "png.h"
 #include "tiffio.h"

--- a/cocos/platform/CCImage.cpp
+++ b/cocos/platform/CCImage.cpp
@@ -39,6 +39,22 @@ THE SOFTWARE.
 
 extern "C"
 {
+#ifndef __ENABLE_COMPATIBILITY_WITH_UNIX_2003__
+#define __ENABLE_COMPATIBILITY_WITH_UNIX_2003__
+#include <stdio.h>
+    FILE *fopen$UNIX2003( const char *filename, const char *mode )
+    {
+        return fopen(filename, mode);
+    }
+    size_t fwrite$UNIX2003( const void *a, size_t b, size_t c, FILE *d )
+    {
+        return fwrite(a, b, c, d);
+    }
+    char *strerror$UNIX2003( int errnum )
+    {
+        return strerror(errnum);
+    }
+#endif
 #include "png.h"
 #include "tiffio.h"
 #include "base/etc1.h"


### PR DESCRIPTION
Without this wrapper I get errors below.
Mac Os X 10.9.3 Xcode 6 beta(the same problem also exists in Xcode 5)
I found a solution at http://stackoverflow.com/questions/8732393/code-coverage-with-xcode-4-2-missing-files and added one more wrapping function.

Undefined symbols for architecture i386:
  "_fwrite$UNIX2003", referenced from:
      _unixErrorHandler in libcocos2dx iOS.a(tif_unix.o)
      _unixWarningHandler in libcocos2dx iOS.a(tif_unix.o)
      _empty_output_buffer in libcocos2dx iOS.a(jdatadst.o)
      _term_destination in libcocos2dx iOS.a(jdatadst.o)
      _Fax3PrintDir in libcocos2dx iOS.a(tif_fax3.o)
      _PredictorPrintDir in libcocos2dx iOS.a(tif_predict.o)
  "_strerror$UNIX2003", referenced from:
      _TIFFOpen in libcocos2dx iOS.a(tif_unix.o)
ld: symbol(s) not found for architecture i386
clang: error: linker command failed with exit code 1 (use -v to see invocation)
