### PR TITLE
iOS 计算文字高度bug

### DIFF
--- a/cocos/platform/ios/CCDevice.mm
+++ b/cocos/platform/ios/CCDevice.mm
@@ -215,30 +215,39 @@ static inline void lazyCheckIOS7()
 
 static CGSize _calculateStringSize(NSString *str, id font, CGSize *constrainSize)
 {
-    NSArray *listItems = [str componentsSeparatedByString: @"\n"];
-    CGSize dim = CGSizeZero;
+//    NSArray *listItems = [str componentsSeparatedByString: @"\n"];
+//    CGSize dim = CGSizeZero;
+//    CGSize textRect = CGSizeZero;
+//    textRect.width = constrainSize->width > 0 ? constrainSize->width
+//    : 0x7fffffff;
+//    textRect.height = constrainSize->height > 0 ? constrainSize->height
+//    : 0x7fffffff;
+//    
+//    for (NSString *s in listItems)
+//    {
+//        CGSize tmp = [s sizeWithFont:font constrainedToSize:textRect];
+//        
+//        if (tmp.width > dim.width)
+//        {
+//            dim.width = tmp.width;
+//        }
+//        
+//        dim.height += tmp.height;
+//    }
+//    
+//    dim.width = ceilf(dim.width);
+//    dim.height = ceilf(dim.height);
+    
+    
     CGSize textRect = CGSizeZero;
     textRect.width = constrainSize->width > 0 ? constrainSize->width
     : 0x7fffffff;
     textRect.height = constrainSize->height > 0 ? constrainSize->height
     : 0x7fffffff;
     
-    for (NSString *s in listItems)
-    {
-        CGSize tmp = [s sizeWithFont:font constrainedToSize:textRect];
-        
-        if (tmp.width > dim.width)
-        {
-            dim.width = tmp.width;
-        }
-        
-        dim.height += tmp.height;
-    }
+    CGSize tmp = [str sizeWithFont:font constrainedToSize:textRect];
     
-    dim.width = ceilf(dim.width);
-    dim.height = ceilf(dim.height);
-    
-    return dim;
+    return tmp;
 }
 
 // refer Image::ETextAlign


### PR DESCRIPTION
文字如果存在换行符，计算高度会有误差。
