### PR TITLE
#5506 bug fix

### DIFF
--- a/cocos/base/CCDirector.cpp
+++ b/cocos/base/CCDirector.cpp
@@ -1,4 +1,4 @@
-/****************************************************************************
+﻿/****************************************************************************
 Copyright (c) 2008-2010 Ricardo Quesada
 Copyright (c) 2010-2013 cocos2d-x.org
 Copyright (c) 2011      Zynga Inc.
@@ -762,6 +762,18 @@ Vec2 Director::convertToUI(const Vec2& glPoint)
     // Need to calculate the zero depth from the transform.
     Vec4 glCoord(glPoint.x, glPoint.y, 0.0, 1);
     transform.transformVector(glCoord, &clipCoord);
+
+	/*
+	BUG-FIX #5506
+
+	a = (Vx, Vy, Vz, 1)
+	b = (a×M)T
+	Out = 1 ⁄ bw(bx, by, bz)
+	*/
+	
+	clipCoord.x = clipCoord.x / clipCoord.w;
+	clipCoord.y = clipCoord.y / clipCoord.w;
+	clipCoord.z = clipCoord.z / clipCoord.w;
 
     Size glSize = _openGLView->getDesignResolutionSize();
     float factor = 1.0/glCoord.w;


### PR DESCRIPTION
http://cocos2d-x.org/issues/5506

when Director->convertToUI() called, returned wrong value.

kazmath code (under 3.0 version.)
//********************************************************
kmVec3\* kmVec3TransformCoord(kmVec3\* pOut, const kmVec3\* pV, const kmMat4\* pM)
{
 /*
        a = (Vx, Vy, Vz, 1)
        b = (a×M)T
        Out = 1 ⁄ bw(bx, by, bz)
 */

```
kmVec4 v;
kmVec4 inV;
kmVec4Fill(&inV, pV->x, pV->y, pV->z, 1.0);

kmVec4Transform(&v, &inV,pM);
```

 pOut->x = v.x / v.w;
 pOut->y = v.y / v.w;
 pOut->z = v.z / v.w;

 return pOut;
}
//********************************************************

Mat4.h & MathUtil version (3.1 or later)
//********************************************************
inline void MathUtil::transformVec4(const float\* m, const float\* v, float\* dst)
{
    // Handle case where v == dst.
    float x = v[0] \* m[0] + v[1] \* m[4] + v[2] \* m[8] + v[3] \* m[12];
    float y = v[0] \* m[1] + v[1] \* m[5] + v[2] \* m[9] + v[3] \* m[13];
    float z = v[0] \* m[2] + v[1] \* m[6] + v[2] \* m[10] + v[3] \* m[14];
    float w = v[0] \* m[3] + v[1] \* m[7] + v[2] \* m[11] + v[3] \* m[15];

```
dst[0] = x;
dst[1] = y;
dst[2] = z;
dst[3] = w;
```

}

//****************************************************

Transforms 3-D vector or an array of 3-D vectors using a given matrix, projecting the result back into w = 1.
but, it is not apply w = 1.
