### PR TITLE
Fix GL state cache inconsistency on texture delete with multi-texturing

### DIFF
--- a/cocos/renderer/ccGLStateCache.cpp
+++ b/cocos/renderer/ccGLStateCache.cpp
@@ -171,10 +171,17 @@ void deleteTexture(GLuint textureId)
 void deleteTextureN(GLuint textureUnit, GLuint textureId)
 {
 #if CC_ENABLE_GL_STATE_CACHE
-	if (s_currentBoundTexture[textureUnit] == textureId)
+    
+    // Need to check if the texture is still bound against any of the available texture units and mark it as unbound.
+    // Internally GL will do this if the texture is deleted so our state cache needs to be kept consitent with the internal GL state.
+    for (size_t i = 0; i < MAX_ACTIVE_TEXTURE; ++i)
     {
-		s_currentBoundTexture[textureUnit] = -1;
+        if (s_currentBoundTexture[i] == textureId)
+        {
+            s_currentBoundTexture[i] = -1;
+        }
     }
+
 #endif // CC_ENABLE_GL_STATE_CACHE
     
 	glDeleteTextures(1, &textureId);


### PR DESCRIPTION
When deleting a texture check if it is bound against any of the available texture units rather than just assuming it is bound to the first unit, which might not be the case if we are using multi-texturing. Failure to do this can result in inconsistencies between the cocos2d-x GL state cache and the internal GL driver state, resulting in rendering issues. OpenGL will unbind the deleted texture from any texture units it is bound to on the call to glDeleteTextures(), therefore we should perform the same behaviour in the state cache.
