### PR TITLE
updated angle to fix memory leak when closing angle

### DIFF
--- a/cocos2dx/platform/wp8-xaml/Direct3DInterop.cpp
+++ b/cocos2dx/platform/wp8-xaml/Direct3DInterop.cpp
@@ -55,14 +55,12 @@ IDrawingSurfaceBackgroundContentProvider^ Direct3DInterop::CreateContentProvider
 // Interface With Direct3DContentProvider
 HRESULT Direct3DInterop::Connect(_In_ IDrawingSurfaceRuntimeHostNative* host, _In_ ID3D11Device1* device)
 {
-    //m_renderer->SetDevice(device);
     return S_OK;
 }
 
 void Direct3DInterop::Disconnect()
 {
-    std::lock_guard<std::mutex> guard(mRenderingMutex);
-    m_renderer->Disconnect();
+    m_renderer->Disconnect();  
 }
 
 // IDrawingSurfaceManipulationHandler
@@ -165,8 +163,6 @@ HRESULT Direct3DInterop::PrepareResources(_In_ const LARGE_INTEGER* presentTarge
 
 HRESULT Direct3DInterop::Draw(_In_ ID3D11Device1* device, _In_ ID3D11DeviceContext1* context, _In_ ID3D11RenderTargetView* renderTargetView)
 {
-    std::lock_guard<std::mutex> guard(mRenderingMutex);
-
     m_renderer->UpdateDevice(device, context, renderTargetView);
 #if 0
     if(mCurrentOrientation != WindowOrientation)

--- a/cocos2dx/platform/wp8-xaml/Direct3DInterop.h
+++ b/cocos2dx/platform/wp8-xaml/Direct3DInterop.h
@@ -91,7 +91,6 @@ private:
 
     std::queue<std::shared_ptr<InputEvent>> mInputEvents;
     std::mutex mMutex;
-    std::mutex mRenderingMutex;
 
     Cocos2dEventDelegate^ m_delegate;
     Cocos2dMessageBoxDelegate^ m_messageBoxDelegate;

--- a/cocos2dx/platform/wp8-xaml/DirectXBase.cpp
+++ b/cocos2dx/platform/wp8-xaml/DirectXBase.cpp
@@ -168,12 +168,12 @@ void DirectXBase::Render()
 
 void DirectXBase::CloseAngle()
 {
+    eglMakeCurrent(NULL, NULL, NULL, NULL);
 
-	if(m_eglDisplay && m_eglSurface)
+    if(m_eglPhoneWindow != nullptr)
     {
-        eglDestroySurface(m_eglDisplay, m_eglSurface);
-        m_eglSurface = nullptr;
-    }
+        m_eglPhoneWindow->Update(nullptr, nullptr, nullptr);
+    }  
 
 	if(m_eglDisplay && m_eglContext)
     {
@@ -181,18 +181,17 @@ void DirectXBase::CloseAngle()
         m_eglContext = nullptr;
     }    
 
-	if(m_eglDisplay)
+	if(m_eglDisplay && m_eglSurface)
+    {
+        eglDestroySurface(m_eglDisplay, m_eglSurface);
+        m_eglSurface = nullptr;
+    }
+
+    if(m_eglDisplay)
     {
         eglTerminate(m_eglDisplay);
         m_eglDisplay = nullptr;
-    }
-
-    if(m_eglPhoneWindow != nullptr)
-    {
-         m_eglPhoneWindow->Update(nullptr, nullptr, nullptr);
-    }
-
-    eglMakeCurrent(NULL, NULL, NULL, NULL);
+    }  
 
     if(m_device)
     {
@@ -200,11 +199,8 @@ void DirectXBase::CloseAngle()
         m_device = nullptr;
     }
 
-#if 0
     m_eglPhoneWindow = nullptr;
     m_eglWindow = nullptr;  
-#endif // 0
-
 
     m_bAngleInitialized = false;
 }


### PR DESCRIPTION
This pull request updates cocos2d-x for WP8 to fix a memory leak when the phone switches between apps.

The updated Angle libs were submitted in the following pull request

https://github.com/cocos2d/cocos2d-x-3rd-party-libs-bin/pulls
