### PR TITLE
Fix crash when try to remove videoView(STATE_PLAYBACK_COMPLETED) in android

### DIFF
--- a/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxVideoView.java
+++ b/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxVideoView.java
@@ -399,7 +399,7 @@ public class Cocos2dxVideoView extends SurfaceView implements MediaPlayerControl
             mCurrentState = STATE_PLAYBACK_COMPLETED;
             mTargetState = STATE_PLAYBACK_COMPLETED;
             
-            mp.release();
+            release(true);
             if (mOnVideoEventListener != null) {
                 mOnVideoEventListener.onVideoEvent(mViewTag,EVENT_COMPLETED);
             }


### PR DESCRIPTION
# Sample code

``` cpp
videoPlayer->addEventListener([](Ref *ref, cocos2d::experimental::ui::VideoPlayer::EventType type) {
  switch (type) {
    case experimental::ui::VideoPlayer::EventType::COMPLETED:
      Director::getInstance()->popScene(); // crash
      break;
  }
});
```
# Error log

```
E/AndroidRuntime(22989): java.lang.IllegalStateException
E/AndroidRuntime(22989):    at android.media.MediaPlayer._stop(Native Method)
E/AndroidRuntime(22989):    at android.media.MediaPlayer.stop(MediaPlayer.java:1077)
E/AndroidRuntime(22989):    at org.cocos2dx.lib.Cocos2dxVideoView.stopPlayback(Cocos2dxVideoView.java:243)
E/AndroidRuntime(22989):    at org.cocos2dx.lib.Cocos2dxVideoHelper._removeVideoView(Cocos2dxVideoHelper.java:212)
E/AndroidRuntime(22989):    at org.cocos2dx.lib.Cocos2dxVideoHelper.access$100(Cocos2dxVideoHelper.java:38)
E/AndroidRuntime(22989):    at org.cocos2dx.lib.Cocos2dxVideoHelper$VideoHandler.handleMessage(Cocos2dxVideoHelper.java:85)
E/AndroidRuntime(22989):    at android.os.Handler.dispatchMessage(Handler.java:102)
E/AndroidRuntime(22989):    at android.os.Looper.loop(Looper.java:136)
E/AndroidRuntime(22989):    at android.app.ActivityThread.main(ActivityThread.java:5017)
E/AndroidRuntime(22989):    at java.lang.reflect.Method.invokeNative(Native Method)
E/AndroidRuntime(22989):    at java.lang.reflect.Method.invoke(Method.java:515)
E/AndroidRuntime(22989):    at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:779)
E/AndroidRuntime(22989):    at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:595)
E/AndroidRuntime(22989):    at dalvik.system.NativeStart.main(Native Method)
```
