### PR TITLE
add autoscale for director

### DIFF
--- a/cocos/base/CCDirector.cpp
+++ b/cocos/base/CCDirector.cpp
@@ -65,7 +65,7 @@ THE SOFTWARE.
 
 /**
  Position of the FPS
- 
+
  Default: 0,0 (bottom-left corner)
  */
 #ifndef CC_DIRECTOR_STATS_POSITION
@@ -1235,6 +1235,27 @@ void Director::setEventDispatcher(EventDispatcher* dispatcher)
         CC_SAFE_RETAIN(dispatcher);
         CC_SAFE_RELEASE(_eventDispatcher);
         _eventDispatcher = dispatcher;
+    }
+}
+
+void Director::autoScaleFactor(bool autoscale)
+{
+    if (autoscale)
+    {
+        // fix value ref for autoscale
+        Size sizeref=Size(1280,800);
+        // Get screen size
+        Size screen=this->getWinSize();
+        //calculate ratio relative real screen size
+        float wrif=sizeref.width;
+        float hrif=sizeref.height;
+        float wvideo=screen.width;
+        float hvideo=screen.height;
+        float wratio=wrif/wvideo;
+        float hratio=hrif/hvideo;
+        float scale=(wratio+hratio)/2;
+        //add global scale factor for all object
+        this->setContentScaleFactor(scale);
     }
 }
 

--- a/cocos/base/CCDirector.h
+++ b/cocos/base/CCDirector.h
@@ -368,28 +368,35 @@ public:
      @since v2.0
      */
     ActionManager* getActionManager() const { return _actionManager; }
-    
+
     /** Sets the ActionManager associated with this director
      @since v2.0
      */
     void setActionManager(ActionManager* actionManager);
-    
-    /** Gets the EventDispatcher associated with this director 
+
+    /** Gets the EventDispatcher associated with this director
      @since v3.0
      */
     EventDispatcher* getEventDispatcher() const { return _eventDispatcher; }
-    
-    /** Sets the EventDispatcher associated with this director 
+
+    /** Sets the EventDispatcher associated with this director
      @since v3.0
      */
     void setEventDispatcher(EventDispatcher* dispatcher);
 
     /** Returns the Renderer
+
      @since v3.0
      */
     Renderer* getRenderer() const { return _renderer; }
 
-    /** Returns the Console 
+    /**
+     * Automatic scale factor from size of display device
+     @since v3.0
+     */
+    void autoScaleFactor(bool autoscale);
+
+    /** Returns the Console
      @since v3.0
      */
 #if  (CC_TARGET_PLATFORM != CC_PLATFORM_WINRT)

--- a/templates/cpp-template-default/Classes/AppDelegate.cpp
+++ b/templates/cpp-template-default/Classes/AppDelegate.cpp
@@ -19,7 +19,9 @@ bool AppDelegate::applicationDidFinishLaunching() {
         glview = GLView::create("My Game");
         director->setOpenGLView(glview);
     }
-
+    // if param true automatic global scale
+    // for size of display device
+    director->autoScaleFactor(true);
     // turn on display FPS
     director->setDisplayStats(true);
 

--- a/tests/cpp-tests/Classes/AppDelegate.cpp
+++ b/tests/cpp-tests/Classes/AppDelegate.cpp
@@ -57,7 +57,9 @@ bool AppDelegate::applicationDidFinishLaunching()
         glview = GLView::create("Cpp Tests");
         director->setOpenGLView(glview);
     }
-
+    // if param true automatic global scale
+    // for size of display device
+    director->autoScaleFactor(true);
     director->setDisplayStats(true);
     director->setAnimationInterval(1.0 / 60);
 


### PR DESCRIPTION
Autoscale method useful if you work with ,fixed size or position.
If is set true in AppDelegate before startup app, setup the scale factor of main director and extend it for all object .
Tried in Android 3.0 ~ 4.4 , landscape view.
