### PR TITLE
Custom uniform search optimization

### DIFF
--- a/cocos/renderer/CCGLProgramState.cpp
+++ b/cocos/renderer/CCGLProgramState.cpp
@@ -309,7 +309,8 @@ bool GLProgramState::init(GLProgram* glprogram)
 
     for(auto &uniform : _glprogram->_userUniforms) {
         UniformValue value(&uniform.second, _glprogram);
-        _uniforms[uniform.first] = value;
+        _uniforms[uniform.second.location] = value;
+        _uniformsByName[uniform.first] = uniform.second.location;
     }
 
     return true;
@@ -329,9 +330,9 @@ void GLProgramState::apply(const Mat4& modelView)
     CCASSERT(_glprogram, "invalid glprogram");
     if(_uniformAttributeValueDirty)
     {
-        for(auto& uniformValue : _uniforms)
+        for(auto& uniformLocation : _uniformsByName)
         {
-            uniformValue.second._uniform = _glprogram->getUniform(uniformValue.first);
+            _uniforms[uniformLocation.second]._uniform = _glprogram->getUniform(uniformLocation.first);
         }
         
         _vertexAttribsFlags = 0;
@@ -377,11 +378,19 @@ void GLProgramState::setGLProgram(GLProgram *glprogram)
     }
 }
 
+UniformValue* GLProgramState::getUniformValue(GLint uniformLocation)
+{
+    const auto itr = _uniforms.find(uniformLocation);
+    if (itr != _uniforms.end())
+        return &itr->second;
+    return nullptr;
+}
+
 UniformValue* GLProgramState::getUniformValue(const std::string &name)
 {
-    const auto itr = _uniforms.find(name);
-    if( itr != _uniforms.end())
-        return &itr->second;
+    const auto itr = _uniformsByName.find(name);
+    if (itr != _uniformsByName.end())
+        return &_uniforms[itr->second];
     return nullptr;
 }
 
@@ -431,6 +440,15 @@ void GLProgramState::setUniformCallback(const std::string &uniformName, const st
         CCLOG("cocos2d: warning: Uniform not found: %s", uniformName.c_str());
 }
 
+void GLProgramState::setUniformCallback(GLint uniformLocation, const std::function<void(GLProgram*, Uniform*)> &callback)
+{
+    auto v = getUniformValue(uniformLocation);
+    if (v)
+        v->setCallback(callback);
+    else
+        CCLOG("cocos2d: warning: Uniform at location not found: %i", uniformLocation);
+}
+
 void GLProgramState::setUniformFloat(const std::string &uniformName, float value)
 {
     auto v = getUniformValue(uniformName);
@@ -438,6 +456,15 @@ void GLProgramState::setUniformFloat(const std::string &uniformName, float value
         v->setFloat(value);
     else
         CCLOG("cocos2d: warning: Uniform not found: %s", uniformName.c_str());
+}
+
+void GLProgramState::setUniformFloat(GLint uniformLocation, float value)
+{
+    auto v = getUniformValue(uniformLocation);
+    if (v)
+        v->setFloat(value);
+    else
+        CCLOG("cocos2d: warning: Uniform at location not found: %i", uniformLocation);
 }
 
 void GLProgramState::setUniformInt(const std::string &uniformName, int value)
@@ -449,6 +476,16 @@ void GLProgramState::setUniformInt(const std::string &uniformName, int value)
         CCLOG("cocos2d: warning: Uniform not found: %s", uniformName.c_str());
 }
 
+void GLProgramState::setUniformInt(GLint uniformLocation, int value)
+{
+    auto v = getUniformValue(uniformLocation);
+    if (v)
+        v->setInt(value);
+    else
+        CCLOG("cocos2d: warning: Uniform at location not found: %i", uniformLocation);
+
+}
+
 void GLProgramState::setUniformVec2(const std::string &uniformName, const Vec2& value)
 {
     auto v = getUniformValue(uniformName);
@@ -456,6 +493,15 @@ void GLProgramState::setUniformVec2(const std::string &uniformName, const Vec2& 
         v->setVec2(value);
     else
         CCLOG("cocos2d: warning: Uniform not found: %s", uniformName.c_str());
+}
+
+void GLProgramState::setUniformVec2(GLint uniformLocation, const Vec2& value)
+{
+    auto v = getUniformValue(uniformLocation);
+    if (v)
+        v->setVec2(value);
+    else
+        CCLOG("cocos2d: warning: Uniform at location not found: %i", uniformLocation);
 }
 
 void GLProgramState::setUniformVec3(const std::string &uniformName, const Vec3& value)
@@ -467,6 +513,15 @@ void GLProgramState::setUniformVec3(const std::string &uniformName, const Vec3& 
         CCLOG("cocos2d: warning: Uniform not found: %s", uniformName.c_str());
 }
 
+void GLProgramState::setUniformVec3(GLint uniformLocation, const Vec3& value)
+{
+    auto v = getUniformValue(uniformLocation);
+    if (v)
+        v->setVec3(value);
+    else
+        CCLOG("cocos2d: warning: Uniform at location not found: %i", uniformLocation);
+}
+
 void GLProgramState::setUniformVec4(const std::string &uniformName, const Vec4& value)
 {
     auto v = getUniformValue(uniformName);
@@ -474,6 +529,15 @@ void GLProgramState::setUniformVec4(const std::string &uniformName, const Vec4& 
         v->setVec4(value);
     else
         CCLOG("cocos2d: warning: Uniform not found: %s", uniformName.c_str());
+}
+
+void GLProgramState::setUniformVec4(GLint uniformLocation, const Vec4& value)
+{
+    auto v = getUniformValue(uniformLocation);
+    if (v)
+        v->setVec4(value);
+    else
+        CCLOG("cocos2d: warning: Uniform at location not found: %i", uniformLocation);
 }
 
 void GLProgramState::setUniformMat4(const std::string &uniformName, const Mat4& value)
@@ -485,12 +549,27 @@ void GLProgramState::setUniformMat4(const std::string &uniformName, const Mat4& 
         CCLOG("cocos2d: warning: Uniform not found: %s", uniformName.c_str());
 }
 
+void GLProgramState::setUniformMat4(GLint uniformLocation, const Mat4& value)
+{
+    auto v = getUniformValue(uniformLocation);
+    if (v)
+        v->setMat4(value);
+    else
+        CCLOG("cocos2d: warning: Uniform at location not found: %i", uniformLocation);
+}
+
 // Textures
 
 void GLProgramState::setUniformTexture(const std::string &uniformName, Texture2D *texture)
 {
     CCASSERT(texture, "Invalid texture");
     setUniformTexture(uniformName, texture->getName());
+}
+
+void GLProgramState::setUniformTexture(GLint uniformLocation, Texture2D *texture)
+{
+    CCASSERT(texture, "Invalid texture");
+    setUniformTexture(uniformLocation, texture->getName());
 }
 
 void GLProgramState::setUniformTexture(const std::string &uniformName, GLuint textureId)
@@ -514,5 +593,25 @@ void GLProgramState::setUniformTexture(const std::string &uniformName, GLuint te
     }
 }
 
+void GLProgramState::setUniformTexture(GLint uniformLocation, GLuint textureId)
+{
+    auto v = getUniformValue(uniformLocation);
+    if (v)
+    {
+        if (_boundTextureUnits.find(v->_uniform->name) != _boundTextureUnits.end())
+        {
+            v->setTexture(textureId, _boundTextureUnits[v->_uniform->name]);
+        }
+        else
+        {
+            v->setTexture(textureId, _textureUnitIndex);
+            _boundTextureUnits[v->_uniform->name] = _textureUnitIndex++;
+        }
+    }
+    else
+    {
+        CCLOG("cocos2d: warning: Uniform at location not found: %i", uniformLocation);
+    }
+}
 
 NS_CC_END

--- a/cocos/renderer/CCGLProgramState.h
+++ b/cocos/renderer/CCGLProgramState.h
@@ -179,7 +179,17 @@ public:
     void setUniformCallback(const std::string &uniformName, const std::function<void(GLProgram*, Uniform*)> &callback);
     void setUniformTexture(const std::string &uniformName, Texture2D *texture);
     void setUniformTexture(const std::string &uniformName, GLuint textureId);
-    
+
+    void setUniformInt(GLint uniformLocation, int value);
+    void setUniformFloat(GLint uniformLocation, float value);
+    void setUniformVec2(GLint uniformLocation, const Vec2& value);
+    void setUniformVec3(GLint uniformLocation, const Vec3& value);
+    void setUniformVec4(GLint uniformLocation, const Vec4& value);
+    void setUniformMat4(GLint uniformLocation, const Mat4& value);
+    void setUniformCallback(GLint uniformLocation, const std::function<void(GLProgram*, Uniform*)> &callback);
+    void setUniformTexture(GLint uniformLocation, Texture2D *texture);
+    void setUniformTexture(GLint uniformLocation, GLuint textureId);
+
 protected:
     GLProgramState();
     ~GLProgramState();
@@ -187,9 +197,11 @@ protected:
     void resetGLProgram();
     VertexAttribValue* getVertexAttribValue(const std::string &attributeName);
     UniformValue* getUniformValue(const std::string &uniformName);
+    UniformValue* getUniformValue(GLint uniformLocation);
     
     bool _uniformAttributeValueDirty;
-    std::unordered_map<std::string, UniformValue> _uniforms;
+    std::unordered_map<std::string, GLint> _uniformsByName;
+    std::unordered_map<GLint, UniformValue> _uniforms;
     std::unordered_map<std::string, VertexAttribValue> _attributes;
     std::unordered_map<std::string, int> _boundTextureUnits;
 


### PR DESCRIPTION
- Switched ProgramState from unordered_map(string, Uniform) to unordered_map(GLint, Uniform) for faster uniform search. This will give opportunity to access uniforms in program state by their location that gives faster search speed than using strings.
