### PR TITLE
add TimelineAction

### DIFF
--- a/extensions/CocoStudio/ActionTimeline/CCActionTimeline.cpp
+++ b/extensions/CocoStudio/ActionTimeline/CCActionTimeline.cpp
@@ -23,7 +23,7 @@ THE SOFTWARE.
 ****************************************************************************/
 
 #include "CCActionTimeline.h"
-#include "CCNodeCache.h"
+#include "CCNodeReader.h"
 
 using namespace cocos2d;
 

--- a/extensions/CocoStudio/ActionTimeline/CCActionTimeline.cpp
+++ b/extensions/CocoStudio/ActionTimeline/CCActionTimeline.cpp
@@ -1,0 +1,273 @@
+/****************************************************************************
+Copyright (c) 2013 cocos2d-x.org
+
+http://www.cocos2d-x.org
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+****************************************************************************/
+
+#include "CCActionTimeline.h"
+#include "CCNodeCache.h"
+
+using namespace cocos2d;
+
+NS_TIMELINE_BEGIN
+
+ActionTimeline* ActionTimeline::create()
+{
+    ActionTimeline* object = new ActionTimeline();
+    if (object && object->init())
+    {
+        object->autorelease();
+        return object;
+    }
+    CC_SAFE_DELETE(object);
+    return NULL;
+}
+
+ActionTimeline::ActionTimeline()
+    : _timelineList(NULL)
+    , _duration(0)
+    , _time(0)
+    , _timeSpeed(1)
+    , _frameInternal(1/60.0f)
+    , _playing(false)
+    , _currentFrame(0)
+    , _endFrame(0)
+    , _frameEventCallFunc(NULL)
+    , _frameEventTarget(NULL)
+{
+}
+
+ActionTimeline::~ActionTimeline()
+{
+    std::map<int, cocos2d::CCArray*>::const_iterator i = _timelineMap.begin();
+    for (; i != _timelineMap.end(); i++)
+    {
+        CCArray* timelines = i->second;
+        CC_SAFE_DELETE(timelines);
+    }
+
+    CC_SAFE_DELETE(_timelineList);
+}
+
+bool ActionTimeline::init()
+{
+    _timelineList = new cocos2d::CCArray();
+    _timelineList->init();
+
+    return true;
+}
+
+void ActionTimeline::gotoFrameAndPlay(int startIndex)
+{
+    gotoFrameAndPlay(startIndex, true);
+}
+
+void ActionTimeline::gotoFrameAndPlay(int startIndex, bool loop)
+{
+    gotoFrameAndPlay(startIndex, _duration, loop);
+}
+
+void ActionTimeline::gotoFrameAndPlay(int startIndex, int endIndex, bool loop)
+{
+    _endFrame = endIndex;
+    _loop = loop;
+    _currentFrame = startIndex;
+    _time = _currentFrame*_frameInternal;
+
+    resume();
+    gotoFrame(_currentFrame);
+}
+
+void ActionTimeline::gotoFrameAndPause(int startIndex)
+{
+    _time =_currentFrame = startIndex;
+
+    pause();
+    gotoFrame(_currentFrame);
+}
+
+void ActionTimeline::pause()
+{
+    _playing = false;
+}
+
+void ActionTimeline::resume()
+{
+    _playing = true;
+}
+
+bool ActionTimeline::isPlaying() const
+{
+    return _playing;
+}
+
+ActionTimeline* ActionTimeline::clone() const
+{
+    ActionTimeline* newAction = ActionTimeline::create();
+    newAction->setDuration(_duration);
+    newAction->setTimeSpeed(_timeSpeed);
+    
+    std::map<int, cocos2d::CCArray*>::const_iterator i = _timelineMap.begin();
+    for (; i != _timelineMap.end(); i++)
+    {
+        CCObject* object = NULL;
+        CCARRAY_FOREACH(i->second, object)
+        {      
+            Timeline* timeline = static_cast<Timeline*>(object);
+            Timeline* newTimeline = timeline->clone();
+            newAction->addTimeline(newTimeline);
+        }
+    }
+
+    return newAction;
+}
+
+void ActionTimeline::step(float delta)
+{
+    if (!_playing || _timelineMap.size() == 0 || _duration == 0)
+    {
+        return;
+    }
+
+    _time += delta * _timeSpeed;
+    _currentFrame = (int)(_time / _frameInternal);
+
+    if (_currentFrame > _endFrame)
+    {
+        _playing = _loop;
+        if(!_playing)
+            _currentFrame = _time = _endFrame;
+        else           
+            _currentFrame = _time = 0;
+    }
+
+    stepToFrame(_currentFrame);
+}
+
+
+void ActionTimeline::foreachNodeDescendant(CCNode* parent)
+{
+    TimelineActionData* data = dynamic_cast<TimelineActionData*>(parent->getUserObject());
+    CCObject* object = NULL;
+
+    if(data)
+    {
+        int actionTag = data->getActionTag();
+
+        if(_timelineMap.find(actionTag) != _timelineMap.end())
+        {
+            CCArray* timelines = this->_timelineMap[actionTag];
+            CCARRAY_FOREACH (timelines, object)
+            {
+                Timeline* timeline = static_cast<Timeline*>(object);
+                timeline->setNode(parent);
+            }
+        }
+    }
+
+    CCArray* children = parent->getChildren();
+    CCARRAY_FOREACH (children, object)
+    {
+        CCNode* child = static_cast<CCNode*>(object);
+        foreachNodeDescendant(child);
+    }
+}
+
+void ActionTimeline::startWithTarget(CCNode *target)
+{
+    CCAction::startWithTarget(target);
+
+    foreachNodeDescendant(target);
+}
+
+void ActionTimeline::addTimeline(Timeline* timeline)
+{
+    int tag = timeline->getActionTag();
+    if (_timelineMap.find(tag) == _timelineMap.end())
+    {
+        CCArray* timelines = new CCArray();
+        timelines->init();
+        _timelineMap[tag] = timelines;
+    }
+
+    if (!_timelineMap[tag]->containsObject(timeline))
+    {
+        _timelineList->addObject(timeline);
+        _timelineMap[tag]->addObject(timeline);
+        timeline->setActionTimeline(this);
+    }
+}
+
+void ActionTimeline::removeTimeline(Timeline* timeline)
+{
+    int tag = timeline->getActionTag();
+    if (_timelineMap.find(tag) != _timelineMap.end())
+    {
+        if(_timelineMap[tag]->containsObject(timeline))
+        {
+            _timelineMap[tag]->removeObject(timeline);
+            _timelineList->removeObject(timeline);
+            timeline->setActionTimeline(NULL);
+        }
+    }
+}
+
+void ActionTimeline::setFrameEventCallFunc  (CCObject *target, SEL_FrameEventCallFunc callFunc)
+{
+    _frameEventTarget   = target;
+    _frameEventCallFunc = callFunc;
+}
+
+void ActionTimeline::clearFrameEventCallFunc()
+{
+    _frameEventTarget   = NULL;
+    _frameEventCallFunc = NULL;
+}
+
+void ActionTimeline::emitFrameEvent(Frame* frame)
+{
+    if (_frameEventTarget != NULL && _frameEventCallFunc != NULL)
+    {
+        (_frameEventTarget->*_frameEventCallFunc)(frame);
+    }
+}
+
+void ActionTimeline::gotoFrame(int frameIndex)
+{
+    int size = _timelineList->count();
+    Timeline** timelines = (Timeline**)_timelineList->data->arr;
+    for(int i = 0; i<size; i++)
+    {      
+        timelines[i]->gotoFrame(frameIndex);
+    }
+}
+
+void ActionTimeline::stepToFrame(int frameIndex)
+{
+    int size = _timelineList->count();
+    Timeline** timelines = (Timeline**)_timelineList->data->arr;
+    for(int i = 0; i<size; i++)
+    {      
+        timelines[i]->stepToFrame(frameIndex);
+    }
+}
+
+NS_TIMELINE_END

--- a/extensions/CocoStudio/ActionTimeline/CCActionTimeline.h
+++ b/extensions/CocoStudio/ActionTimeline/CCActionTimeline.h
@@ -1,0 +1,151 @@
+/****************************************************************************
+Copyright (c) 2013 cocos2d-x.org
+
+http://www.cocos2d-x.org
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+****************************************************************************/
+
+#ifndef __CCTIMELINE_ACTION_H__
+#define __CCTIMELINE_ACTION_H__
+
+#include "cocos2d.h"
+#include "CCTimeLine.h"
+
+NS_TIMELINE_BEGIN
+
+typedef void (cocos2d::CCObject::*SEL_FrameEventCallFunc)(Frame *);
+
+#define frameEvent_selector(_SELECTOR) (SEL_FrameEventCallFunc)(&_SELECTOR)
+
+class CC_EX_DLL ActionTimeline : public cocos2d::CCAction
+{
+public:
+
+    static ActionTimeline* create();
+
+    ActionTimeline();
+    virtual ~ActionTimeline();
+
+    virtual bool init();
+
+    /** Goto the specified frame index, and start playing from this index.
+     * @param startIndex The animation will play from this index.
+     */
+    virtual void gotoFrameAndPlay(int startIndex);
+
+    /** Goto the specified frame index, and start playing from this index.
+     * @param startIndex The animation will play from this index.
+     * @param loop Whether or not the animation need loop. 
+     */
+    virtual void gotoFrameAndPlay(int startIndex, bool loop);
+
+    /** Goto the specified frame index, and start playing from start index, end at end index.
+     * @param startIndex The animation will play from this index.
+     * @param endIndex The animation will end at this index.
+     * @param loop Whether or not the animation need loop. 
+     */
+    virtual void gotoFrameAndPlay(int startIndex, int endIndex, bool loop);
+
+    /** Goto the specified frame index, and pause at this index.
+     * @param startIndex The animation will pause at this index.
+     */
+    virtual void gotoFrameAndPause(int startIndex);
+
+    /** Pause the animation. */
+    virtual void pause();
+    /** Resume the animation. */
+    virtual void resume();
+
+    /** Whether or not Action is playing. */
+    virtual bool isPlaying() const;
+
+    /** Set the animation speed, this will speed up or slow down the speed. */
+    virtual void  setTimeSpeed(float speed) { _timeSpeed = speed; }
+    /** Get current animation speed. */
+    virtual float getTimeSpeed() const { return _timeSpeed; }
+
+    /** duration of the whole action*/
+    virtual void setDuration(int duration) { _duration = duration; }
+    virtual int  getDuration() const { return _duration; }
+
+    /** End frame of this action.
+     * When action play to this frame, if action is not loop, then it will stop, 
+     * or it will play from start frame again. */
+    virtual void setEndFrame(int endFrame) { _endFrame = endFrame; }
+    virtual int  getEndFrame() const { return _endFrame; }
+
+    /** Get current frame. */
+    virtual int  getCurrentFrame() const { return _currentFrame; }
+
+    /** add Timeline to ActionTimeline */
+    virtual void addTimeline(Timeline* timeline);
+    virtual void removeTimeline(Timeline* timeline);
+
+    /**
+     * Set action's frame event callback function
+     */
+    void setFrameEventCallFunc  (CCObject *target, SEL_FrameEventCallFunc callFunc);
+    void clearFrameEventCallFunc();
+
+    /** Inherit from cocos2d::Action. */
+
+    /** Returns a clone of ActionTimeline */
+    virtual ActionTimeline* clone() const; 
+
+    /** Returns a reverse of ActionTimeline. 
+     *  Not implement yet.
+     */
+    virtual ActionTimeline* reverse() const { return NULL; }
+
+    virtual void step(float delta); 
+    virtual void startWithTarget(cocos2d::CCNode *target);  
+    virtual bool isDone() { return false; }
+protected:
+    friend class Frame;
+
+    void foreachNodeDescendant(cocos2d::CCNode* parent);
+
+    virtual void gotoFrame  (int frameIndex);
+    virtual void stepToFrame(int frameIndex);
+
+    /** emit frame event, call it when enter a frame*/
+    void emitFrameEvent(Frame* frame);
+
+    std::map<int, cocos2d::CCArray*> _timelineMap; // <int, cocos2d::Vector<Timeline*>>
+    cocos2d::CCArray* _timelineList;      // cocos2d::Vector<Timeline*>
+
+    int     _duration;
+    double  _time;
+    float   _timeSpeed;
+    float   _frameInternal;
+    bool    _playing;
+    int     _currentFrame;
+    int     _endFrame;
+    bool    _loop;
+
+
+    SEL_FrameEventCallFunc _frameEventCallFunc;
+    cocos2d::CCObject*     _frameEventTarget;
+};
+
+NS_TIMELINE_END
+
+
+#endif /*__CCTIMELINE_ACTION_H__*/

--- a/extensions/CocoStudio/ActionTimeline/CCActionTimelineCache.cpp
+++ b/extensions/CocoStudio/ActionTimeline/CCActionTimelineCache.cpp
@@ -1,0 +1,425 @@
+/****************************************************************************
+Copyright (c) 2013 cocos2d-x.org
+
+http://www.cocos2d-x.org
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+****************************************************************************/
+
+#include "CCActionTimelineCache.h"
+#include "CCActionTimeline.h"
+#include "CCFrame.h"
+
+using namespace cocos2d;
+using namespace cocos2d::extension;
+
+NS_TIMELINE_BEGIN
+
+static const char* FrameType_VisibleFrame       = "VisibleFrame";
+static const char* FrameType_PositionFrame      = "PositionFrame";
+static const char* FrameType_ScaleFrame         = "ScaleFrame";
+static const char* FrameType_RotationFrame      = "RotationFrame";
+static const char* FrameType_SkewFrame          = "SkewFrame";
+static const char* FrameType_RotationSkewFrame  = "RotationSkewFrame";
+static const char* FrameType_AnchorFrame        = "AnchorFrame";
+static const char* FrameType_InnerActionFrame   = "InnerActionFrame";
+static const char* FrameType_ColorFrame         = "ColorFrame";
+static const char* FrameType_TextureFrame       = "TextureFrame";
+static const char* FrameType_EventFrame         = "EventFrame";
+static const char* FrameType_ZOrderFrame        = "ZOrderFrame";
+
+
+
+static const char* ACTION           = "action";
+static const char* NAME             = "name";
+static const char* DURATION         = "duration";
+static const char* NODES            = "nodes";
+static const char* TIMELINES        = "timelines";
+static const char* FRAME_TYPE       = "frameType";
+static const char* FRAMES           = "frames";
+static const char* FRAME_INDEX      = "frameIndex";
+static const char* VISIBLE          = "visible";
+static const char* TWEEN            = "tween";
+static const char* TIME_SPEED       = "speed";
+static const char* ACTION_TAG       = "actionTag";
+static const char* INNER_ACTION     = "innerActionType";
+static const char* START_FRAME      = "startFrame";
+
+static const char* X                = "x";
+static const char* Y                = "y";
+static const char* SCALE_X          = "scaleX";
+static const char* SCALE_Y          = "scaleY";
+static const char* SKEW_X           = "skewX";
+static const char* SKEW_Y           = "skewY";
+static const char* ROTATION         = "rotation";
+static const char* ROTATION_SKEW_X  = "rotationSkewX";
+static const char* ROTATION_SKEW_Y  = "rotationSkewY";
+static const char* ANCHOR_X         = "anchorPointX";
+static const char* ANCHOR_Y         = "anchorPointY";
+static const char* ALPHA            = "alpha";
+static const char* RED              = "red";
+static const char* GREEN            = "green";
+static const char* BLUE             = "blue";
+static const char* Value            = "value";
+
+
+
+// FrameCreateCallFunc
+FrameCreateCallFunc* FrameCreateCallFunc::create(CCObject* target, FrameCreateCallback callback)
+{
+    FrameCreateCallFunc* func = new FrameCreateCallFunc();
+    if (func && func->init(target, callback))
+    {
+        func->autorelease();
+        return func;
+    }
+    CC_SAFE_DELETE(func);
+    return NULL;
+}
+
+FrameCreateCallFunc::FrameCreateCallFunc()
+    : _target(NULL)
+    , _callback(NULL)
+{
+}
+
+FrameCreateCallFunc::~FrameCreateCallFunc()
+{
+    CC_SAFE_RELEASE_NULL(_target);
+}
+
+bool FrameCreateCallFunc::init(CCObject* target, FrameCreateCallback callback)
+{
+    if(target == NULL)
+        return false;
+
+    _target = target;
+    _target->retain();
+    _callback = callback;
+
+    return true;
+}
+
+Frame* FrameCreateCallFunc::excute(const rapidjson::Value& json)
+{
+    return (_target->*_callback)(json);
+}
+
+
+
+// TimelineActionCache
+
+static TimelineActionCache* _sharedActionCache = NULL;
+
+TimelineActionCache* TimelineActionCache::getInstance()
+{
+    if (! _sharedActionCache)
+    {
+        _sharedActionCache = new TimelineActionCache();
+        _sharedActionCache->init();
+    }
+
+    return _sharedActionCache;
+}
+
+void TimelineActionCache::destroyInstance()
+{
+    CC_SAFE_DELETE(_sharedActionCache);
+}
+
+TimelineActionCache::~TimelineActionCache()
+{
+    CC_SAFE_DELETE(_funcs);
+    CC_SAFE_DELETE(_timelineActions);
+}
+
+void TimelineActionCache::purge()
+{
+    _timelineActions->removeAllObjects();
+}
+
+void TimelineActionCache::init()
+{
+    _funcs = new cocos2d::CCDictionary();
+    _timelineActions = new cocos2d::CCDictionary();
+
+    
+    _funcs->setObject(FrameCreateCallFunc::create(this, FrameCreateCallback_selector(TimelineActionCache::loadVisibleFrame)),     FrameType_VisibleFrame);
+    _funcs->setObject(FrameCreateCallFunc::create(this, FrameCreateCallback_selector(TimelineActionCache::loadPositionFrame)),    FrameType_PositionFrame);
+    _funcs->setObject(FrameCreateCallFunc::create(this, FrameCreateCallback_selector(TimelineActionCache::loadScaleFrame)),       FrameType_ScaleFrame);
+    _funcs->setObject(FrameCreateCallFunc::create(this, FrameCreateCallback_selector(TimelineActionCache::loadRotationFrame)),    FrameType_RotationFrame);
+    _funcs->setObject(FrameCreateCallFunc::create(this, FrameCreateCallback_selector(TimelineActionCache::loadSkewFrame)),        FrameType_SkewFrame);
+    _funcs->setObject(FrameCreateCallFunc::create(this, FrameCreateCallback_selector(TimelineActionCache::loadRotationSkewFrame)),FrameType_RotationSkewFrame);
+    _funcs->setObject(FrameCreateCallFunc::create(this, FrameCreateCallback_selector(TimelineActionCache::loadAnchorPointFrame)), FrameType_AnchorFrame);
+    _funcs->setObject(FrameCreateCallFunc::create(this, FrameCreateCallback_selector(TimelineActionCache::loadInnerActionFrame)), FrameType_InnerActionFrame);
+    _funcs->setObject(FrameCreateCallFunc::create(this, FrameCreateCallback_selector(TimelineActionCache::loadColorFrame)),       FrameType_ColorFrame);
+    _funcs->setObject(FrameCreateCallFunc::create(this, FrameCreateCallback_selector(TimelineActionCache::loadTextureFrame)),     FrameType_TextureFrame);
+    _funcs->setObject(FrameCreateCallFunc::create(this, FrameCreateCallback_selector(TimelineActionCache::loadEventFrame)),       FrameType_EventFrame);
+    _funcs->setObject(FrameCreateCallFunc::create(this, FrameCreateCallback_selector(TimelineActionCache::loadZOrderFrame)),      FrameType_ZOrderFrame);
+
+}
+
+void TimelineActionCache::removeAction(const std::string& fileName)
+{
+    _timelineActions->removeObjectForKey(fileName);
+}
+
+ActionTimeline* TimelineActionCache::createAction(const std::string& fileName)
+{
+    ActionTimeline* action = static_cast<ActionTimeline*>(_timelineActions->objectForKey(fileName));
+    if (action == NULL)
+    {
+        action = loadAnimationActionWithFile(fileName);
+    }
+    return action->clone();
+}
+
+ActionTimeline* TimelineActionCache::loadAnimationActionWithFile(const std::string& fileName)
+{
+    // Read content from file
+    std::string fullPath = CCFileUtils::sharedFileUtils()->fullPathForFilename(fileName.c_str());
+    unsigned long size;
+    std::string contentStr((const char*)CCFileUtils::sharedFileUtils()->getFileData(fullPath.c_str() , "r", &size), size);
+
+    return loadAnimationActionWithContent(fileName, contentStr);
+}
+
+ActionTimeline* TimelineActionCache::loadAnimationActionWithContent(const std::string&fileName, const std::string& content)
+{
+    // if already exists an action with filename, then return this action
+    ActionTimeline* action = static_cast<ActionTimeline*>(_timelineActions->objectForKey(fileName));
+    if(action)
+        return action;
+
+    rapidjson::Document doc;
+    doc.Parse<0>(content.c_str());
+    if (doc.HasParseError()) 
+    {
+        CCLOG("GetParseError %s\n", doc.GetParseError());
+    }
+
+    const rapidjson::Value& json = DICTOOL->getSubDictionary_json(doc, ACTION);
+
+    action = ActionTimeline::create();
+
+    action->setDuration(DICTOOL->getIntValue_json(json, DURATION));
+    action->setTimeSpeed(DICTOOL->getFloatValue_json(json, TIME_SPEED, 1.0f));
+
+    int timelineLength = DICTOOL->getArrayCount_json(json, TIMELINES);
+    for (int i = 0; i<timelineLength; i++)
+    {
+        const rapidjson::Value& dic = DICTOOL->getSubDictionary_json(json, TIMELINES, i);
+        Timeline* timeline = loadTimeline(dic);
+
+        if(timeline)
+            action->addTimeline(timeline);
+    }
+
+    _timelineActions->setObject(action, fileName);
+
+    return action;
+}
+
+
+Timeline* TimelineActionCache::loadTimeline(const rapidjson::Value& json)
+{
+    Timeline* timeline = NULL;
+
+    // get frame type 
+    const char* frameType = DICTOOL->getStringValue_json(json, FRAME_TYPE);
+	if(frameType == NULL)
+		return NULL;
+
+    FrameCreateCallFunc* func = static_cast<FrameCreateCallFunc*>(_funcs->objectForKey(frameType));
+
+    if(frameType && func)
+    {
+        timeline = Timeline::create();
+
+        int actionTag = DICTOOL->getIntValue_json(json, ACTION_TAG);
+        timeline->setActionTag(actionTag);
+
+
+        int length = DICTOOL->getArrayCount_json(json, FRAMES);
+        for (int i = 0; i<length; i++)
+        {
+            const rapidjson::Value& dic = DICTOOL->getSubDictionary_json(json, FRAMES, i);
+
+            Frame* frame = NULL;
+            frame = func->excute(dic);
+
+            int frameIndex = DICTOOL->getIntValue_json(dic, FRAME_INDEX);
+            frame->setFrameIndex(frameIndex);
+
+            bool tween = DICTOOL->getBooleanValue_json(dic, TWEEN, false);
+            frame->setTween(tween);
+
+            timeline->addFrame(frame);
+        }
+    }
+
+    return timeline;
+}
+
+Frame* TimelineActionCache::loadVisibleFrame(const rapidjson::Value& json)
+{
+    VisibleFrame* frame = VisibleFrame::create();
+
+    bool visible = DICTOOL->getBooleanValue_json(json, Value);
+    frame->setVisible(visible);
+
+    return frame;
+}
+
+Frame* TimelineActionCache::loadPositionFrame(const rapidjson::Value& json)
+{
+    PositionFrame* frame = PositionFrame::create();
+
+    float x = DICTOOL->getFloatValue_json(json, X);
+    float y = DICTOOL->getFloatValue_json(json, Y);
+    frame->setPosition(CCPoint(x,y));
+
+    return frame;
+}
+
+Frame* TimelineActionCache::loadScaleFrame(const rapidjson::Value& json)
+{
+   ScaleFrame* frame = ScaleFrame::create();
+
+   float scalex = DICTOOL->getFloatValue_json(json, X);
+   float scaley = DICTOOL->getFloatValue_json(json, Y);
+
+   frame->setScaleX(scalex);
+   frame->setScaleY(scaley);
+
+    return frame;
+}
+
+Frame* TimelineActionCache::loadSkewFrame(const rapidjson::Value& json)
+{
+    SkewFrame* frame = SkewFrame::create();
+
+    float skewx = DICTOOL->getFloatValue_json(json, X);
+    float skewy = DICTOOL->getFloatValue_json(json, Y);
+
+    frame->setSkewX(skewx);
+    frame->setSkewY(skewy);
+
+    return frame;
+}
+
+Frame* TimelineActionCache::loadRotationSkewFrame(const rapidjson::Value& json)
+{
+    RotationSkewFrame* frame = RotationSkewFrame::create();
+
+    float skewx = DICTOOL->getFloatValue_json(json, X);
+    float skewy = DICTOOL->getFloatValue_json(json, Y);
+
+    frame->setSkewX(skewx);
+    frame->setSkewY(skewy);
+
+    return frame;
+}
+
+Frame* TimelineActionCache::loadRotationFrame(const rapidjson::Value& json)
+{
+    RotationFrame* frame = RotationFrame::create();
+
+    float rotation = DICTOOL->getFloatValue_json(json, ROTATION);
+    frame->setRotation(rotation);
+
+    return frame;
+}
+
+Frame* TimelineActionCache::loadAnchorPointFrame (const rapidjson::Value& json)
+{
+    AnchorPointFrame* frame = AnchorPointFrame::create();
+
+    float anchorx = DICTOOL->getFloatValue_json(json, X);
+    float anchory = DICTOOL->getFloatValue_json(json, Y);
+
+    frame->setAnchorPoint(CCPoint(anchorx, anchory));
+
+    return frame;
+}
+
+Frame* TimelineActionCache::loadInnerActionFrame(const rapidjson::Value& json)
+{
+    InnerActionFrame* frame = InnerActionFrame::create();
+
+    InnerActionType type = (InnerActionType)DICTOOL->getIntValue_json(json, INNER_ACTION);
+    int startFrame       = DICTOOL->getIntValue_json(json, START_FRAME); 
+
+    frame->setInnerActionType(type);
+    frame->setStartFrameIndex(startFrame);
+
+    return frame;
+}
+
+Frame* TimelineActionCache::loadColorFrame(const rapidjson::Value& json)
+{
+    ColorFrame* frame = ColorFrame::create();
+
+    GLubyte alpha = (GLubyte)DICTOOL->getIntValue_json(json, ALPHA);
+    GLubyte red   = (GLubyte)DICTOOL->getIntValue_json(json, RED);
+    GLubyte green = (GLubyte)DICTOOL->getIntValue_json(json, GREEN);
+    GLubyte blue  = (GLubyte)DICTOOL->getIntValue_json(json, BLUE);
+
+    frame->setAlpha(alpha);
+    frame->setColor(ccc3(red, green, blue));
+
+    return frame;
+}
+
+
+Frame* TimelineActionCache::loadTextureFrame(const rapidjson::Value& json)
+{
+    TextureFrame* frame = TextureFrame::create();
+
+    const char* texture = DICTOOL->getStringValue_json(json, Value);
+
+    if(texture != NULL)
+        frame->setTextureName(texture);
+
+    return frame;
+}
+
+Frame* TimelineActionCache::loadEventFrame(const rapidjson::Value& json)
+{
+    EventFrame* frame = EventFrame::create();
+
+    const char* evnt = DICTOOL->getStringValue_json(json, Value);
+
+    if(evnt != NULL)
+        frame->setEvent(evnt);
+
+    return frame;
+}
+
+Frame* TimelineActionCache::loadZOrderFrame(const rapidjson::Value& json)
+{
+    ZOrderFrame* frame = ZOrderFrame::create();
+
+    int zorder = DICTOOL->getIntValue_json(json, Value);
+    frame->setZOrder(zorder);
+
+    return frame;
+}
+
+NS_TIMELINE_END

--- a/extensions/CocoStudio/ActionTimeline/CCActionTimelineCache.cpp
+++ b/extensions/CocoStudio/ActionTimeline/CCActionTimelineCache.cpp
@@ -123,64 +123,64 @@ Frame* FrameCreateCallFunc::excute(const rapidjson::Value& json)
 
 
 
-// TimelineActionCache
+// ActionTimelineCache
 
-static TimelineActionCache* _sharedActionCache = NULL;
+static ActionTimelineCache* _sharedActionCache = NULL;
 
-TimelineActionCache* TimelineActionCache::getInstance()
+ActionTimelineCache* ActionTimelineCache::getInstance()
 {
     if (! _sharedActionCache)
     {
-        _sharedActionCache = new TimelineActionCache();
+        _sharedActionCache = new ActionTimelineCache();
         _sharedActionCache->init();
     }
 
     return _sharedActionCache;
 }
 
-void TimelineActionCache::destroyInstance()
+void ActionTimelineCache::destroyInstance()
 {
     CC_SAFE_DELETE(_sharedActionCache);
 }
 
-TimelineActionCache::~TimelineActionCache()
+ActionTimelineCache::~ActionTimelineCache()
 {
     CC_SAFE_DELETE(_funcs);
     CC_SAFE_DELETE(_timelineActions);
 }
 
-void TimelineActionCache::purge()
+void ActionTimelineCache::purge()
 {
     _timelineActions->removeAllObjects();
 }
 
-void TimelineActionCache::init()
+void ActionTimelineCache::init()
 {
     _funcs = new cocos2d::CCDictionary();
     _timelineActions = new cocos2d::CCDictionary();
 
     
-    _funcs->setObject(FrameCreateCallFunc::create(this, FrameCreateCallback_selector(TimelineActionCache::loadVisibleFrame)),     FrameType_VisibleFrame);
-    _funcs->setObject(FrameCreateCallFunc::create(this, FrameCreateCallback_selector(TimelineActionCache::loadPositionFrame)),    FrameType_PositionFrame);
-    _funcs->setObject(FrameCreateCallFunc::create(this, FrameCreateCallback_selector(TimelineActionCache::loadScaleFrame)),       FrameType_ScaleFrame);
-    _funcs->setObject(FrameCreateCallFunc::create(this, FrameCreateCallback_selector(TimelineActionCache::loadRotationFrame)),    FrameType_RotationFrame);
-    _funcs->setObject(FrameCreateCallFunc::create(this, FrameCreateCallback_selector(TimelineActionCache::loadSkewFrame)),        FrameType_SkewFrame);
-    _funcs->setObject(FrameCreateCallFunc::create(this, FrameCreateCallback_selector(TimelineActionCache::loadRotationSkewFrame)),FrameType_RotationSkewFrame);
-    _funcs->setObject(FrameCreateCallFunc::create(this, FrameCreateCallback_selector(TimelineActionCache::loadAnchorPointFrame)), FrameType_AnchorFrame);
-    _funcs->setObject(FrameCreateCallFunc::create(this, FrameCreateCallback_selector(TimelineActionCache::loadInnerActionFrame)), FrameType_InnerActionFrame);
-    _funcs->setObject(FrameCreateCallFunc::create(this, FrameCreateCallback_selector(TimelineActionCache::loadColorFrame)),       FrameType_ColorFrame);
-    _funcs->setObject(FrameCreateCallFunc::create(this, FrameCreateCallback_selector(TimelineActionCache::loadTextureFrame)),     FrameType_TextureFrame);
-    _funcs->setObject(FrameCreateCallFunc::create(this, FrameCreateCallback_selector(TimelineActionCache::loadEventFrame)),       FrameType_EventFrame);
-    _funcs->setObject(FrameCreateCallFunc::create(this, FrameCreateCallback_selector(TimelineActionCache::loadZOrderFrame)),      FrameType_ZOrderFrame);
+    _funcs->setObject(FrameCreateCallFunc::create(this, FrameCreateCallback_selector(ActionTimelineCache::loadVisibleFrame)),     FrameType_VisibleFrame);
+    _funcs->setObject(FrameCreateCallFunc::create(this, FrameCreateCallback_selector(ActionTimelineCache::loadPositionFrame)),    FrameType_PositionFrame);
+    _funcs->setObject(FrameCreateCallFunc::create(this, FrameCreateCallback_selector(ActionTimelineCache::loadScaleFrame)),       FrameType_ScaleFrame);
+    _funcs->setObject(FrameCreateCallFunc::create(this, FrameCreateCallback_selector(ActionTimelineCache::loadRotationFrame)),    FrameType_RotationFrame);
+    _funcs->setObject(FrameCreateCallFunc::create(this, FrameCreateCallback_selector(ActionTimelineCache::loadSkewFrame)),        FrameType_SkewFrame);
+    _funcs->setObject(FrameCreateCallFunc::create(this, FrameCreateCallback_selector(ActionTimelineCache::loadRotationSkewFrame)),FrameType_RotationSkewFrame);
+    _funcs->setObject(FrameCreateCallFunc::create(this, FrameCreateCallback_selector(ActionTimelineCache::loadAnchorPointFrame)), FrameType_AnchorFrame);
+    _funcs->setObject(FrameCreateCallFunc::create(this, FrameCreateCallback_selector(ActionTimelineCache::loadInnerActionFrame)), FrameType_InnerActionFrame);
+    _funcs->setObject(FrameCreateCallFunc::create(this, FrameCreateCallback_selector(ActionTimelineCache::loadColorFrame)),       FrameType_ColorFrame);
+    _funcs->setObject(FrameCreateCallFunc::create(this, FrameCreateCallback_selector(ActionTimelineCache::loadTextureFrame)),     FrameType_TextureFrame);
+    _funcs->setObject(FrameCreateCallFunc::create(this, FrameCreateCallback_selector(ActionTimelineCache::loadEventFrame)),       FrameType_EventFrame);
+    _funcs->setObject(FrameCreateCallFunc::create(this, FrameCreateCallback_selector(ActionTimelineCache::loadZOrderFrame)),      FrameType_ZOrderFrame);
 
 }
 
-void TimelineActionCache::removeAction(const std::string& fileName)
+void ActionTimelineCache::removeAction(const std::string& fileName)
 {
     _timelineActions->removeObjectForKey(fileName);
 }
 
-ActionTimeline* TimelineActionCache::createAction(const std::string& fileName)
+ActionTimeline* ActionTimelineCache::createAction(const std::string& fileName)
 {
     ActionTimeline* action = static_cast<ActionTimeline*>(_timelineActions->objectForKey(fileName));
     if (action == NULL)
@@ -190,7 +190,7 @@ ActionTimeline* TimelineActionCache::createAction(const std::string& fileName)
     return action->clone();
 }
 
-ActionTimeline* TimelineActionCache::loadAnimationActionWithFile(const std::string& fileName)
+ActionTimeline* ActionTimelineCache::loadAnimationActionWithFile(const std::string& fileName)
 {
     // Read content from file
     std::string fullPath = CCFileUtils::sharedFileUtils()->fullPathForFilename(fileName.c_str());
@@ -200,7 +200,7 @@ ActionTimeline* TimelineActionCache::loadAnimationActionWithFile(const std::stri
     return loadAnimationActionWithContent(fileName, contentStr);
 }
 
-ActionTimeline* TimelineActionCache::loadAnimationActionWithContent(const std::string&fileName, const std::string& content)
+ActionTimeline* ActionTimelineCache::loadAnimationActionWithContent(const std::string&fileName, const std::string& content)
 {
     // if already exists an action with filename, then return this action
     ActionTimeline* action = static_cast<ActionTimeline*>(_timelineActions->objectForKey(fileName));
@@ -237,7 +237,7 @@ ActionTimeline* TimelineActionCache::loadAnimationActionWithContent(const std::s
 }
 
 
-Timeline* TimelineActionCache::loadTimeline(const rapidjson::Value& json)
+Timeline* ActionTimelineCache::loadTimeline(const rapidjson::Value& json)
 {
     Timeline* timeline = NULL;
 
@@ -277,7 +277,7 @@ Timeline* TimelineActionCache::loadTimeline(const rapidjson::Value& json)
     return timeline;
 }
 
-Frame* TimelineActionCache::loadVisibleFrame(const rapidjson::Value& json)
+Frame* ActionTimelineCache::loadVisibleFrame(const rapidjson::Value& json)
 {
     VisibleFrame* frame = VisibleFrame::create();
 
@@ -287,7 +287,7 @@ Frame* TimelineActionCache::loadVisibleFrame(const rapidjson::Value& json)
     return frame;
 }
 
-Frame* TimelineActionCache::loadPositionFrame(const rapidjson::Value& json)
+Frame* ActionTimelineCache::loadPositionFrame(const rapidjson::Value& json)
 {
     PositionFrame* frame = PositionFrame::create();
 
@@ -298,7 +298,7 @@ Frame* TimelineActionCache::loadPositionFrame(const rapidjson::Value& json)
     return frame;
 }
 
-Frame* TimelineActionCache::loadScaleFrame(const rapidjson::Value& json)
+Frame* ActionTimelineCache::loadScaleFrame(const rapidjson::Value& json)
 {
    ScaleFrame* frame = ScaleFrame::create();
 
@@ -311,7 +311,7 @@ Frame* TimelineActionCache::loadScaleFrame(const rapidjson::Value& json)
     return frame;
 }
 
-Frame* TimelineActionCache::loadSkewFrame(const rapidjson::Value& json)
+Frame* ActionTimelineCache::loadSkewFrame(const rapidjson::Value& json)
 {
     SkewFrame* frame = SkewFrame::create();
 
@@ -324,7 +324,7 @@ Frame* TimelineActionCache::loadSkewFrame(const rapidjson::Value& json)
     return frame;
 }
 
-Frame* TimelineActionCache::loadRotationSkewFrame(const rapidjson::Value& json)
+Frame* ActionTimelineCache::loadRotationSkewFrame(const rapidjson::Value& json)
 {
     RotationSkewFrame* frame = RotationSkewFrame::create();
 
@@ -337,7 +337,7 @@ Frame* TimelineActionCache::loadRotationSkewFrame(const rapidjson::Value& json)
     return frame;
 }
 
-Frame* TimelineActionCache::loadRotationFrame(const rapidjson::Value& json)
+Frame* ActionTimelineCache::loadRotationFrame(const rapidjson::Value& json)
 {
     RotationFrame* frame = RotationFrame::create();
 
@@ -347,7 +347,7 @@ Frame* TimelineActionCache::loadRotationFrame(const rapidjson::Value& json)
     return frame;
 }
 
-Frame* TimelineActionCache::loadAnchorPointFrame (const rapidjson::Value& json)
+Frame* ActionTimelineCache::loadAnchorPointFrame (const rapidjson::Value& json)
 {
     AnchorPointFrame* frame = AnchorPointFrame::create();
 
@@ -359,7 +359,7 @@ Frame* TimelineActionCache::loadAnchorPointFrame (const rapidjson::Value& json)
     return frame;
 }
 
-Frame* TimelineActionCache::loadInnerActionFrame(const rapidjson::Value& json)
+Frame* ActionTimelineCache::loadInnerActionFrame(const rapidjson::Value& json)
 {
     InnerActionFrame* frame = InnerActionFrame::create();
 
@@ -372,7 +372,7 @@ Frame* TimelineActionCache::loadInnerActionFrame(const rapidjson::Value& json)
     return frame;
 }
 
-Frame* TimelineActionCache::loadColorFrame(const rapidjson::Value& json)
+Frame* ActionTimelineCache::loadColorFrame(const rapidjson::Value& json)
 {
     ColorFrame* frame = ColorFrame::create();
 
@@ -388,7 +388,7 @@ Frame* TimelineActionCache::loadColorFrame(const rapidjson::Value& json)
 }
 
 
-Frame* TimelineActionCache::loadTextureFrame(const rapidjson::Value& json)
+Frame* ActionTimelineCache::loadTextureFrame(const rapidjson::Value& json)
 {
     TextureFrame* frame = TextureFrame::create();
 
@@ -400,7 +400,7 @@ Frame* TimelineActionCache::loadTextureFrame(const rapidjson::Value& json)
     return frame;
 }
 
-Frame* TimelineActionCache::loadEventFrame(const rapidjson::Value& json)
+Frame* ActionTimelineCache::loadEventFrame(const rapidjson::Value& json)
 {
     EventFrame* frame = EventFrame::create();
 
@@ -412,7 +412,7 @@ Frame* TimelineActionCache::loadEventFrame(const rapidjson::Value& json)
     return frame;
 }
 
-Frame* TimelineActionCache::loadZOrderFrame(const rapidjson::Value& json)
+Frame* ActionTimelineCache::loadZOrderFrame(const rapidjson::Value& json)
 {
     ZOrderFrame* frame = ZOrderFrame::create();
 

--- a/extensions/CocoStudio/ActionTimeline/CCActionTimelineCache.h
+++ b/extensions/CocoStudio/ActionTimeline/CCActionTimelineCache.h
@@ -1,0 +1,104 @@
+/****************************************************************************
+Copyright (c) 2013 cocos2d-x.org
+
+http://www.cocos2d-x.org
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+****************************************************************************/
+
+#ifndef __CCTIMELINE_ACTION_CACHE_H__
+#define __CCTIMELINE_ACTION_CACHE_H__
+
+#include "cocos2d.h"
+#include "../Json/DictionaryHelper.h"
+
+#include "CCTimeLine.h"
+
+NS_TIMELINE_BEGIN
+    
+class ActionTimeline;
+
+typedef Frame* (cocos2d::CCObject::*FrameCreateCallback)(const rapidjson::Value& json);
+#define FrameCreateCallback_selector(_SELECTOR) (FrameCreateCallback)(&_SELECTOR)
+
+class CC_EX_DLL FrameCreateCallFunc : public cocos2d::CCObject
+{
+public:
+    static FrameCreateCallFunc* create(CCObject* target, FrameCreateCallback callback);
+
+    FrameCreateCallFunc();
+    ~FrameCreateCallFunc();
+    bool init(CCObject* target, FrameCreateCallback callback);
+    Frame* excute(const rapidjson::Value& json);
+
+protected:
+    CCObject* _target;
+    FrameCreateCallback _callback;
+};
+
+class CC_EX_DLL TimelineActionCache : public cocos2d::CCObject
+{
+public:
+    /** Gets the singleton */
+    static TimelineActionCache* getInstance();
+
+    /** Destroys the singleton */
+    static void destroyInstance();
+
+    virtual ~TimelineActionCache();
+    void purge();
+
+    void init();
+
+    /** Remove action with filename, and also remove other resource relate with this file */
+    void removeAction(const std::string& fileName);
+
+    /** Clone a action with the specified name from the container. */
+    ActionTimeline* createAction(const std::string& fileName);
+
+    ActionTimeline* loadAnimationActionWithFile(const std::string& fileName);
+    ActionTimeline* loadAnimationActionWithContent(const std::string&fileName, const std::string& content);
+protected:
+
+    Timeline* loadTimeline(const rapidjson::Value& json);
+
+    Frame* loadVisibleFrame     (const rapidjson::Value& json);
+    Frame* loadPositionFrame    (const rapidjson::Value& json);
+    Frame* loadScaleFrame       (const rapidjson::Value& json);
+    Frame* loadSkewFrame        (const rapidjson::Value& json);
+    Frame* loadRotationSkewFrame(const rapidjson::Value& json);
+    Frame* loadRotationFrame    (const rapidjson::Value& json);
+    Frame* loadAnchorPointFrame (const rapidjson::Value& json);
+    Frame* loadInnerActionFrame (const rapidjson::Value& json);
+    Frame* loadColorFrame       (const rapidjson::Value& json);
+    Frame* loadTextureFrame     (const rapidjson::Value& json);
+    Frame* loadEventFrame       (const rapidjson::Value& json);
+    Frame* loadZOrderFrame      (const rapidjson::Value& json);
+
+
+protected:
+
+    cocos2d::CCDictionary* _funcs;              // <std::string, FrameCreateCallFunc*>
+    cocos2d::CCDictionary* _timelineActions;    // <std::string, ActionTimeline*>
+};
+
+NS_TIMELINE_END
+
+
+#endif /*__CCTIMELINE_ACTION_CACHE_H__*/

--- a/extensions/CocoStudio/ActionTimeline/CCActionTimelineCache.h
+++ b/extensions/CocoStudio/ActionTimeline/CCActionTimelineCache.h
@@ -52,16 +52,16 @@ protected:
     FrameCreateCallback _callback;
 };
 
-class CC_EX_DLL TimelineActionCache : public cocos2d::CCObject
+class CC_EX_DLL ActionTimelineCache : public cocos2d::CCObject
 {
 public:
     /** Gets the singleton */
-    static TimelineActionCache* getInstance();
+    static ActionTimelineCache* getInstance();
 
     /** Destroys the singleton */
     static void destroyInstance();
 
-    virtual ~TimelineActionCache();
+    virtual ~ActionTimelineCache();
     void purge();
 
     void init();

--- a/extensions/CocoStudio/ActionTimeline/CCFrame.cpp
+++ b/extensions/CocoStudio/ActionTimeline/CCFrame.cpp
@@ -1,0 +1,654 @@
+/****************************************************************************
+Copyright (c) 2013 cocos2d-x.org
+
+http://www.cocos2d-x.org
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+****************************************************************************/
+
+#include "CCFrame.h"
+#include "CCTimeLine.h"
+#include "CCActionTimeline.h"
+
+using namespace cocos2d;
+
+NS_TIMELINE_BEGIN
+
+// Frame
+Frame::Frame()
+    : _frameIndex(0)
+    , _tween(true)
+    , _timeline(NULL)
+    , _node(NULL)
+{
+}
+
+Frame::~Frame()
+{
+}
+
+void Frame::emitEvent()
+{
+    if (_timeline)
+    {
+        _timeline->getActionTimeline()->emitFrameEvent(this);
+    }
+}
+
+void Frame::cloneProperty(Frame* frame)
+{
+    _frameIndex = frame->getFrameIndex();
+    _tween = frame->isTween();
+}
+
+
+// VisibleFrame
+VisibleFrame* VisibleFrame::create()
+{
+    VisibleFrame* frame = new VisibleFrame();
+    if (frame)
+    {
+        frame->autorelease();
+        return frame;
+    }
+    CC_SAFE_DELETE(frame);
+    return NULL;
+}
+
+VisibleFrame::VisibleFrame()
+    : _visible(true)
+{
+}
+
+void VisibleFrame::onEnter(Frame *nextFrame)
+{
+    _node->setVisible(_visible);
+}
+
+
+Frame* VisibleFrame::clone()
+{
+    VisibleFrame* frame = VisibleFrame::create();
+    frame->setVisible(_visible);
+
+    frame->cloneProperty(this);
+
+    return frame;
+}
+
+
+// TextureFrame
+TextureFrame* TextureFrame::create()
+{
+    TextureFrame* frame = new TextureFrame();
+    if (frame)
+    {
+        frame->autorelease();
+        return frame;
+    }
+    CC_SAFE_DELETE(frame);
+    return NULL;
+}
+
+TextureFrame::TextureFrame()
+    : _textureName("")
+{
+}
+
+void TextureFrame::setNode(cocos2d::CCNode* node)
+{
+    Frame::setNode(node);
+
+    _sprite = dynamic_cast<CCSprite*>(node);
+}
+
+void TextureFrame::onEnter(Frame *nextFrame)
+{
+    if(_sprite)
+    {
+        CCSpriteFrame* spriteFrame = CCSpriteFrameCache::sharedSpriteFrameCache()->spriteFrameByName(_textureName.c_str());
+
+        if(spriteFrame != NULL)
+            _sprite->initWithSpriteFrame(spriteFrame);
+        else
+            _sprite->initWithFile(_textureName.c_str());
+    }
+}
+
+
+Frame* TextureFrame::clone()
+{
+    TextureFrame* frame = TextureFrame::create();
+    frame->setTextureName(_textureName);
+
+    frame->cloneProperty(this);
+
+    return frame;
+}
+
+
+// RotationFrame
+RotationFrame* RotationFrame::create()
+{
+    RotationFrame* frame = new RotationFrame();
+    if (frame)
+    {
+        frame->autorelease();
+        return frame;
+    }
+    CC_SAFE_DELETE(frame);
+    return NULL;
+}
+
+RotationFrame::RotationFrame()
+    : _rotation(0)
+{
+}
+
+void RotationFrame::onEnter(Frame *nextFrame)
+{
+    if (!_tween)
+    {
+        _node->setRotation(_rotation);
+    }
+    else
+    {
+        _betwennRotation = static_cast<RotationFrame*>(nextFrame)->_rotation - _rotation;
+    }
+}
+
+void RotationFrame::apply(float percent)
+{
+    if (_tween)
+    {
+        float rotation = _rotation + percent * _betwennRotation;
+        _node->setRotation(rotation);
+    }
+}
+
+Frame* RotationFrame::clone()
+{
+    RotationFrame* frame = RotationFrame::create();
+    frame->setRotation(_rotation);
+
+    frame->cloneProperty(this);
+
+    return frame;
+}
+
+
+
+// SkewFrame
+SkewFrame* SkewFrame::create()
+{
+    SkewFrame* frame = new SkewFrame();
+    if (frame)
+    {
+        frame->autorelease();
+        return frame;
+    }
+    CC_SAFE_DELETE(frame);
+    return NULL;
+}
+
+SkewFrame::SkewFrame()
+    : _skewX(0)
+    , _skewY(0)
+{
+}
+
+void SkewFrame::onEnter(Frame *nextFrame)
+{
+    if (!_tween || nextFrame == this)
+    {
+        _node->setSkewX(_skewX);
+        _node->setSkewY(_skewY);
+    }
+    
+    if(_tween)
+    {
+        _betweenSkewX = static_cast<SkewFrame*>(nextFrame)->_skewX - _skewX;
+        _betweenSkewY = static_cast<SkewFrame*>(nextFrame)->_skewY - _skewY;
+    }
+
+}
+
+void SkewFrame::apply(float percent)
+{
+    if (_tween)
+    {
+        float skewx = _skewX + percent * _betweenSkewX;
+        float skewy = _skewY + percent * _betweenSkewY;
+
+        _node->setSkewX(skewx);
+        _node->setSkewY(skewy);
+    }
+}
+
+Frame* SkewFrame::clone()
+{
+    SkewFrame* frame = SkewFrame::create();
+    frame->setSkewX(_skewX);
+    frame->setSkewY(_skewY);
+
+    frame->cloneProperty(this);
+
+    return frame;
+}
+
+
+
+
+// RotationSkewFrame
+RotationSkewFrame* RotationSkewFrame::create()
+{
+    RotationSkewFrame* frame = new RotationSkewFrame();
+    if (frame)
+    {
+        frame->autorelease();
+        return frame;
+    }
+    CC_SAFE_DELETE(frame);
+    return NULL;
+}
+
+RotationSkewFrame::RotationSkewFrame()
+{
+}
+
+void RotationSkewFrame::onEnter(Frame *nextFrame)
+{
+    if (!_tween || nextFrame == this)
+    {
+        _node->setRotationX(_skewX);
+        _node->setRotationY(_skewY);
+    }
+    
+    if(_tween)
+    {
+        _betweenSkewX = static_cast<RotationSkewFrame*>(nextFrame)->_skewX - _skewX;
+        _betweenSkewY = static_cast<RotationSkewFrame*>(nextFrame)->_skewY - _skewY;
+    }
+}
+
+void RotationSkewFrame::apply(float percent)
+{
+    if (_tween)
+    {
+        float skewx = _skewX + percent * _betweenSkewX;
+        float skewy = _skewY + percent * _betweenSkewY;
+
+        _node->setRotationX(skewx);
+        _node->setRotationY(skewy);
+    }
+}
+
+Frame* RotationSkewFrame::clone()
+{
+    RotationSkewFrame* frame = RotationSkewFrame::create();
+    frame->setSkewX(_skewX);
+    frame->setSkewY(_skewY);
+
+    frame->cloneProperty(this);
+
+    return frame;
+}
+
+
+// PositionFrame
+PositionFrame* PositionFrame::create()
+{
+    PositionFrame* frame = new PositionFrame();
+    if (frame)
+    {
+        frame->autorelease();
+        return frame;
+    }
+    CC_SAFE_DELETE(frame);
+    return NULL;
+}
+
+PositionFrame::PositionFrame()
+    : _position(0,0)
+{
+}
+
+void PositionFrame::onEnter(Frame *nextFrame)
+{
+    if (!_tween || nextFrame == this)
+    {
+        _node->setPosition(_position);
+    }
+
+    if(_tween)
+    {
+        _betweenX = static_cast<PositionFrame*>(nextFrame)->_position.x - _position.x;
+        _betweenY = static_cast<PositionFrame*>(nextFrame)->_position.y - _position.y;
+    }
+}
+
+void PositionFrame::apply(float percent)
+{
+    if (_tween)
+    {
+        CCPoint p;
+        p.x = _position.x + _betweenX * percent;
+        p.y = _position.y + _betweenY * percent;
+
+        _node->setPosition(p);
+    }
+}
+
+Frame* PositionFrame::clone()
+{
+    PositionFrame* frame = PositionFrame::create();
+    frame->setPosition(_position);
+
+    frame->cloneProperty(this);
+
+    return frame;
+}
+
+
+// ScaleFrame
+ScaleFrame* ScaleFrame::create()
+{
+    ScaleFrame* frame = new ScaleFrame();
+    if (frame)
+    {
+        frame->autorelease();
+        return frame;
+    }
+    CC_SAFE_DELETE(frame);
+    return NULL;
+}
+
+ScaleFrame::ScaleFrame()
+    : _scaleX(1)
+    , _scaleY(1)
+{
+}
+
+void ScaleFrame::onEnter(Frame *nextFrame)
+{
+    if (!_tween || nextFrame == this)
+    {
+        _node->setScaleX(_scaleX);
+        _node->setScaleY(_scaleY);
+    }
+    
+    if(_tween)
+    {
+        _betweenScaleX = static_cast<ScaleFrame*>(nextFrame)->_scaleX - _scaleX;
+        _betweenScaleY = static_cast<ScaleFrame*>(nextFrame)->_scaleY - _scaleY;
+    }
+}
+
+void ScaleFrame::apply(float percent)
+{
+    if (_tween)
+    {
+        float scaleX = _scaleX + _betweenScaleX * percent;
+        float scaleY = _scaleY + _betweenScaleY * percent;
+
+        _node->setScaleX(scaleX);
+        _node->setScaleY(scaleY);
+    }
+}
+
+Frame* ScaleFrame::clone()
+{
+    ScaleFrame* frame = ScaleFrame::create();
+    frame->setScaleX(_scaleX);
+    frame->setScaleY(_scaleY);  
+
+    frame->cloneProperty(this);
+
+    return frame;
+}
+
+
+// AnchorPointFrame
+AnchorPointFrame* AnchorPointFrame::create()
+{
+    AnchorPointFrame* frame = new AnchorPointFrame();
+    if (frame)
+    {
+        frame->autorelease();
+        return frame;
+    }
+    CC_SAFE_DELETE(frame);
+    return NULL;
+}
+
+AnchorPointFrame::AnchorPointFrame()
+    : _anchorPoint(0.5f,0.5f)
+{
+}
+
+void AnchorPointFrame::onEnter(Frame *nextFrame)
+{
+    _node->setAnchorPoint(_anchorPoint);
+}
+
+
+Frame* AnchorPointFrame::clone()
+{
+    AnchorPointFrame* frame = AnchorPointFrame::create();
+    frame->setAnchorPoint(_anchorPoint);
+
+    frame->cloneProperty(this);
+
+    return frame;
+}
+
+
+
+// InnerActionFrame
+InnerActionFrame* InnerActionFrame::create()
+{
+    InnerActionFrame* frame = new InnerActionFrame();
+    if (frame)
+    {
+        frame->autorelease();
+        return frame;
+    }
+    CC_SAFE_DELETE(frame);
+    return NULL;
+}
+
+InnerActionFrame::InnerActionFrame()
+    : _innerActionType(LoopAction)
+    , _startFrameIndex(0)
+{
+}
+
+void InnerActionFrame::onEnter(Frame *nextFrame)
+{
+}
+
+
+Frame* InnerActionFrame::clone()
+{
+    InnerActionFrame* frame = InnerActionFrame::create();
+    frame->setInnerActionType(_innerActionType);
+    frame->setStartFrameIndex(_startFrameIndex);
+
+    frame->cloneProperty(this);
+
+    return frame;
+}
+
+
+// ColorFrame
+ColorFrame* ColorFrame::create()
+{
+    ColorFrame* frame = new ColorFrame();
+    if (frame)
+    {
+        frame->autorelease();
+        return frame;
+    }
+    CC_SAFE_DELETE(frame);
+    return NULL;
+}
+
+ColorFrame::ColorFrame()
+    : _alpha(255)
+    , _color(ccc3(255, 255, 255))
+{
+}
+
+void ColorFrame::onEnter(Frame *nextFrame)
+{
+    CCRGBAProtocol *rgbaProtocaol = dynamic_cast<CCRGBAProtocol *>(_node);
+
+    if(!rgbaProtocaol)
+        return;
+
+    if (!_tween || nextFrame == this)
+    {
+        if(_alpha != rgbaProtocaol->getOpacity())
+            rgbaProtocaol->setOpacity(_alpha);
+
+        ccColor3B color = rgbaProtocaol->getColor();
+        if((color.r != _color.r) || (color.g != _color.g) || (color.b != _color.b))
+            rgbaProtocaol->setColor(_color);
+    }
+    
+    if(_tween)
+    {
+        _betweenAlpha = static_cast<ColorFrame*>(nextFrame)->_alpha - _alpha;
+
+        const cocos2d::ccColor3B& color = static_cast<ColorFrame*>(nextFrame)->_color;
+        _betweenRed   = color.r - _color.r;
+        _betweenGreen = color.g - _color.g;
+        _betweenBlue  = color.b - _color.b;
+    }
+
+    rgbaProtocaol->setCascadeColorEnabled(true);
+    rgbaProtocaol->setCascadeOpacityEnabled(true);
+
+}
+
+void ColorFrame::apply(float percent)
+{
+    if (_tween && (_betweenAlpha != 0 || _betweenRed != 0 || _betweenGreen != 0 || _betweenBlue != 0))
+    {
+        CCRGBAProtocol *rgbaProtocaol = dynamic_cast<CCRGBAProtocol *>(_node);
+
+        if(!rgbaProtocaol)
+            return;
+
+        GLubyte alpha = _alpha + _betweenAlpha * percent;
+
+        cocos2d::ccColor3B color;
+        color.r = _color.r+ _betweenRed   * percent;
+        color.g = _color.g+ _betweenGreen * percent;
+        color.b = _color.b+ _betweenBlue  * percent;
+
+        rgbaProtocaol->setOpacity(alpha);
+        rgbaProtocaol->setColor(color);
+    }
+}
+
+Frame* ColorFrame::clone()
+{
+    ColorFrame* frame = ColorFrame::create();
+    frame->setAlpha(_alpha);
+    frame->setColor(_color);
+
+    frame->cloneProperty(this);
+
+    return frame;
+}
+
+
+
+// EventFrame
+EventFrame* EventFrame::create()
+{
+    EventFrame* frame = new EventFrame();
+    if (frame)
+    {
+        frame->autorelease();
+        return frame;
+    }
+    CC_SAFE_DELETE(frame);
+    return NULL;
+}
+
+EventFrame::EventFrame()
+    : _event("")
+{
+}
+
+void EventFrame::onEnter(Frame *nextFrame)
+{
+    emitEvent();
+}
+
+
+Frame* EventFrame::clone()
+{
+    EventFrame* frame = EventFrame::create();
+    frame->setEvent(_event);
+
+    frame->cloneProperty(this);
+
+    return frame;
+}
+
+
+// ZOrderFrame
+ZOrderFrame* ZOrderFrame::create()
+{
+    ZOrderFrame* frame = new ZOrderFrame();
+    if (frame)
+    {
+        frame->autorelease();
+        return frame;
+    }
+    CC_SAFE_DELETE(frame);
+    return NULL;
+}
+
+ZOrderFrame::ZOrderFrame()
+    : _zorder(0)
+{
+}
+
+void ZOrderFrame::onEnter(Frame *nextFrame)
+{
+    if(_node)
+        _node->setZOrder(_zorder);
+}
+
+
+Frame* ZOrderFrame::clone()
+{
+    ZOrderFrame* frame = ZOrderFrame::create();
+    frame->setZOrder(_zorder);
+
+    frame->cloneProperty(this);
+
+    return frame;
+}
+
+NS_TIMELINE_END

--- a/extensions/CocoStudio/ActionTimeline/CCFrame.h
+++ b/extensions/CocoStudio/ActionTimeline/CCFrame.h
@@ -27,6 +27,7 @@ THE SOFTWARE.
 
 #include "cocos2d.h"
 #include "CCTimelineMacro.h"
+#include "ExtensionExport.h"
 
 NS_TIMELINE_BEGIN
 class Timeline;

--- a/extensions/CocoStudio/ActionTimeline/CCFrame.h
+++ b/extensions/CocoStudio/ActionTimeline/CCFrame.h
@@ -1,0 +1,331 @@
+/****************************************************************************
+Copyright (c) 2013 cocos2d-x.org
+
+http://www.cocos2d-x.org
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+****************************************************************************/
+
+#ifndef __CCFRAME_H__
+#define __CCFRAME_H__
+
+#include "cocos2d.h"
+#include "CCTimelineMacro.h"
+
+NS_TIMELINE_BEGIN
+class Timeline;
+
+class CC_EX_DLL Frame : public cocos2d::CCObject
+{
+public:
+
+    virtual void setFrameIndex(unsigned int frameIndex) { _frameIndex = frameIndex; }
+    virtual unsigned int getFrameIndex()const { return _frameIndex; }
+
+    virtual void setTimeline(Timeline* timeline) { _timeline = timeline; }
+    virtual Timeline* getTimeline() const { return _timeline; }
+
+    virtual void setNode(cocos2d::CCNode* node) { _node = node; }
+    virtual cocos2d::CCNode* getNode() const { return _node; }
+
+    virtual void setTween(bool tween) { _tween = tween; }
+    virtual bool isTween() const { return _tween; }
+
+    virtual void onEnter(Frame *nextFrame) = 0;
+    virtual void apply(float percent) {}
+
+    virtual Frame* clone() = 0;
+protected:
+    Frame();
+    virtual ~Frame();
+
+    virtual void emitEvent();
+    void cloneProperty(Frame* frame);
+protected:
+    friend class Timeline;
+
+    unsigned int    _frameIndex;
+    bool            _tween;
+
+    Timeline* _timeline;
+    cocos2d::CCNode*  _node;
+};
+
+
+class CC_EX_DLL VisibleFrame : public Frame
+{
+public:
+    static VisibleFrame* create();
+
+    VisibleFrame();
+
+    virtual void onEnter(Frame *nextFrame) override;
+    virtual Frame* clone() override;
+
+    inline void setVisible(bool visible) { _visible = visible;}
+    inline bool isVisible() const { return _visible; }
+
+protected:
+    bool _visible;
+};
+
+
+class CC_EX_DLL TextureFrame : public Frame
+{
+public:
+    static TextureFrame* create();
+
+    TextureFrame();
+
+    virtual void setNode(cocos2d::CCNode* node);
+
+    virtual void onEnter(Frame *nextFrame) override;
+    virtual Frame* clone() override;
+
+    inline void setTextureName(std::string textureName) { _textureName = textureName;}
+    inline std::string getTextureName() const { return _textureName; }
+
+protected:
+    cocos2d::CCSprite* _sprite;
+    std::string _textureName;
+};
+
+
+
+class CC_EX_DLL RotationFrame : public Frame
+{
+public:
+    static RotationFrame* create();
+
+    RotationFrame();
+
+    virtual void onEnter(Frame *nextFrame) override;
+    virtual void apply(float percent) override;
+    virtual Frame* clone() override;
+
+    inline void  setRotation(float rotation) { _rotation = rotation; }
+    inline float getRotation() const { return _rotation; }
+
+protected:
+    float _rotation;
+    float _betwennRotation;
+};
+
+class CC_EX_DLL SkewFrame : public Frame
+{
+public:
+    static SkewFrame* create();
+
+    SkewFrame();
+
+    virtual void onEnter(Frame *nextFrame) override;
+    virtual void apply(float percent) override;
+    virtual Frame* clone() override;
+
+    inline void  setSkewX(float skewx) { _skewX = skewx; }
+    inline float getSkewX() const { return _skewX; }
+
+    inline void  setSkewY(float skewy) { _skewY = skewy; }
+    inline float getSkewY() const { return _skewY; }
+
+protected:
+    float _skewX;
+    float _skewY;
+    float _betweenSkewX;
+    float _betweenSkewY;
+};
+
+
+class CC_EX_DLL RotationSkewFrame : public SkewFrame
+{
+public:
+    static RotationSkewFrame* create();
+
+    RotationSkewFrame();
+
+    virtual void onEnter(Frame *nextFrame) override;
+    virtual void apply(float percent) override;
+    virtual Frame* clone() override;
+};
+
+
+class CC_EX_DLL PositionFrame : public Frame
+{
+public:
+    static PositionFrame* create();
+
+    PositionFrame();
+
+    virtual void onEnter(Frame *nextFrame) override;
+    virtual void apply(float percent) override;
+    virtual Frame* clone() override;
+
+    inline void setPosition(const cocos2d::CCPoint& position) { _position = position; }
+    inline cocos2d::CCPoint getPosition() const { return _position; }
+
+    inline void setX(float x) { _position.x = x; }
+    inline void setY(float y) { _position.y = y; }
+
+    inline float getX() const { return _position.x; }
+    inline float getY() const { return _position.y; }
+protected:
+    cocos2d::CCPoint _position;
+    float _betweenX;
+    float _betweenY;
+};
+
+
+class CC_EX_DLL ScaleFrame : public Frame
+{
+public:
+    static ScaleFrame* create();
+
+    ScaleFrame();
+
+    virtual void onEnter(Frame *nextFrame) override;
+    virtual void apply(float percent) override;
+    virtual Frame* clone() override;
+
+    inline void  setScale(float scale) { _scaleX = scale; _scaleY = scale; }
+
+    inline void  setScaleX(float scaleX) { _scaleX = scaleX; }
+    inline float getScaleX() const { return _scaleX; }
+
+    inline void  setScaleY(float scaleY) { _scaleY = scaleY;}
+    inline float getScaleY() const { return _scaleY; }
+
+protected:
+    float _scaleX;
+    float _scaleY;
+    float _betweenScaleX;
+    float _betweenScaleY;
+};
+
+
+class CC_EX_DLL AnchorPointFrame : public Frame
+{
+public:
+    static AnchorPointFrame* create();
+
+    AnchorPointFrame();
+
+    virtual void onEnter(Frame *nextFrame) override;
+    virtual Frame* clone() override;
+
+    inline void setAnchorPoint(const cocos2d::CCPoint& point) { _anchorPoint = point; }
+    inline cocos2d::CCPoint getAnchorPoint() const { return _anchorPoint; }
+
+protected:
+    cocos2d::CCPoint _anchorPoint;
+};
+
+
+
+enum InnerActionType
+{
+    LoopAction,
+    NoLoopAction,
+    SingleFrame
+};
+
+class CC_EX_DLL InnerActionFrame : public Frame
+{
+public:
+    static InnerActionFrame* create();
+    InnerActionFrame();
+
+    virtual void onEnter(Frame *nextFrame) override;
+    virtual Frame* clone() override;
+
+    inline void setInnerActionType(InnerActionType type) { _innerActionType = type; }
+    inline InnerActionType getInnerActionType() const { return _innerActionType; }
+
+    inline void setStartFrameIndex(int frameIndex) { _startFrameIndex = frameIndex; }
+    inline int  getStartFrameIndex() const { return _startFrameIndex; }
+
+protected:
+    InnerActionType _innerActionType;
+    int _startFrameIndex;
+};
+
+
+class CC_EX_DLL ColorFrame : public Frame
+{
+public:
+    static ColorFrame* create();
+    ColorFrame();
+
+    virtual void onEnter(Frame *nextFrame) override;
+    virtual void apply(float percent) override;
+    virtual Frame* clone() override;
+
+    inline void    setAlpha(GLubyte alpha) { _alpha = alpha; }
+    inline GLubyte getAlpha() const { return _alpha; }
+
+    inline void    setColor(const cocos2d::ccColor3B& color) { _color = color; }
+    inline cocos2d::ccColor3B getColor() const { return _color; }
+
+protected:
+    GLubyte _alpha;
+    cocos2d::ccColor3B _color;
+
+    int _betweenAlpha;
+    int _betweenRed;
+    int _betweenGreen;
+    int _betweenBlue;
+};
+
+class CC_EX_DLL EventFrame : public Frame
+{
+public:
+    static EventFrame* create();
+
+    EventFrame();
+
+    virtual void onEnter(Frame *nextFrame) override;
+    virtual Frame* clone() override;
+
+    inline void setEvent(std::string event) { _event = event;}
+    inline std::string getEvent() const { return _event; }
+
+protected:
+    std::string _event;
+};
+
+class CC_EX_DLL ZOrderFrame : public Frame
+{
+public:
+    static ZOrderFrame* create();
+
+    ZOrderFrame();
+
+    virtual void onEnter(Frame *nextFrame) override;
+    virtual Frame* clone() override;
+
+    inline void setZOrder(int zorder) { _zorder = zorder;}
+    inline int getZOrder() const { return _zorder; }
+
+protected:
+    int _zorder;
+};
+
+NS_TIMELINE_END
+
+
+#endif /*__CCFRAME_H__*/

--- a/extensions/CocoStudio/ActionTimeline/CCNodeCache.cpp
+++ b/extensions/CocoStudio/ActionTimeline/CCNodeCache.cpp
@@ -1,0 +1,492 @@
+/****************************************************************************
+Copyright (c) 2013 cocos2d-x.org
+
+http://www.cocos2d-x.org
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+****************************************************************************/
+
+#include "CCNodeCache.h"
+#include "CCActionTimelineCache.h"
+#include "CCFrame.h"
+#include "../Reader/GUIReader.h"
+#include "../GUI/BaseClasses/UIWidget.h"
+
+using namespace cocos2d;
+using namespace cocos2d::extension;
+
+NS_TIMELINE_BEGIN
+
+
+static const char* ClassName_Node     = "Node";
+static const char* ClassName_Sprite   = "Sprite";
+static const char* ClassName_Particle = "Particle";
+
+static const char* ClassName_Button     = "Button";
+static const char* ClassName_CheckBox   = "CheckBox";
+static const char* ClassName_ImageView  = "ImageView";
+static const char* ClassName_LabelAtlas = "LabelAtlas";
+static const char* ClassName_LabelBMFont= "LabelBMFont";
+static const char* ClassName_Text       = "Text";
+static const char* ClassName_LoadingBar = "LoadingBar";
+static const char* ClassName_TextField  = "TextField";
+static const char* ClassName_Slider     = "Slider";
+static const char* ClassName_Layout     = "Layout";
+static const char* ClassName_ScrollView = "ScrollView";
+static const char* ClassName_ListView   = "ListView";
+static const char* ClassName_PageView   = "PageView";
+static const char* ClassName_Widget     = "Widget";
+static const char* ClassName_Panel      = "Panel";
+static const char* ClassName_Label      = "Label";
+
+
+
+static const char* NODE        = "nodeTree";
+static const char* CHILDREN    = "children";
+static const char* NODETYPE    = "classname";
+static const char* FILE_PATH   = "fileName";
+static const char* PLIST_FILE  = "plistFile";
+static const char* ACTION_TAG  = "actionTag";
+static const char* TAG         = "tag";
+
+static const char* OPTIONS     = "options";
+
+static const char* X                = "x";
+static const char* Y                = "y";
+static const char* SCALE_X          = "scaleX";
+static const char* SCALE_Y          = "scaleY";
+static const char* SKEW_X           = "skewX";
+static const char* SKEW_Y           = "skewY";
+static const char* ROTATION         = "rotation";
+static const char* ROTATION_SKEW_X  = "rotationSkewX";
+static const char* ROTATION_SKEW_Y  = "rotationSkewY";
+static const char* ANCHOR_X         = "anchorPointX";
+static const char* ANCHOR_Y         = "anchorPointY";
+static const char* ALPHA            = "alpha";
+static const char* RED              = "red";
+static const char* GREEN            = "green";
+static const char* BLUE             = "blue";
+
+static const char* TEXTURES     = "textures";
+static const char* TEXTURES_PNG = "texturesPng";
+
+// NodeCreateCallFunc
+NodeCreateCallFunc* NodeCreateCallFunc::create(CCObject* target, NodeCreateCallback callback)
+{
+    NodeCreateCallFunc* func = new NodeCreateCallFunc();
+    if (func && func->init(target, callback))
+    {
+        func->autorelease();
+        return func;
+    }
+    CC_SAFE_DELETE(func);
+    return NULL;
+}
+
+NodeCreateCallFunc::NodeCreateCallFunc()
+    : _target(NULL)
+    , _callback(NULL)
+{
+}
+
+NodeCreateCallFunc::~NodeCreateCallFunc()
+{
+    CC_SAFE_RELEASE_NULL(_target);
+}
+
+bool NodeCreateCallFunc::init(CCObject* target, NodeCreateCallback callback)
+{
+    if(target == NULL)
+        return false;
+
+    _target = target;
+    _target->retain();
+    _callback = callback;
+
+    return true;
+}
+
+CCNode* NodeCreateCallFunc::excute(const rapidjson::Value& json, cocos2d::CCNode* parent)
+{
+    return (_target->*_callback)(json, parent);
+}
+
+
+
+// TimelineActionData
+TimelineActionData* TimelineActionData::create(int actionTag)
+{
+    TimelineActionData * ret = new TimelineActionData();
+    if (ret && ret->init(actionTag))
+    {
+        ret->autorelease();
+    }
+    else
+    {
+        CC_SAFE_DELETE(ret);
+    }
+    return ret;
+}
+
+TimelineActionData::TimelineActionData()
+    : _actionTag(0)
+{
+}
+
+bool TimelineActionData::init(int actionTag)
+{
+    _actionTag = actionTag;
+    return true;
+}
+
+
+
+// NodeCache
+
+static NodeCache* _sharedNodeCache = NULL;
+
+NodeCache* NodeCache::getInstance()
+{
+    if (! _sharedNodeCache)
+    {
+        _sharedNodeCache = new NodeCache();
+        _sharedNodeCache->init();
+    }
+
+    return _sharedNodeCache;
+}
+
+void NodeCache::destroyInstance()
+{
+    CC_SAFE_DELETE(_sharedNodeCache);
+}
+
+NodeCache::NodeCache()
+    : _recordJsonPath(true)
+    , _jsonPath("")
+{
+}
+
+NodeCache::~NodeCache()
+{
+    CC_SAFE_DELETE(_funcs);
+}
+
+void NodeCache::purge()
+{
+}
+
+void NodeCache::init()
+{
+    _funcs = new cocos2d::CCDictionary();
+    
+    _funcs->setObject(NodeCreateCallFunc::create(this, NodeCreateCallback_selector(NodeCache::loadSimpleNode)), ClassName_Node);
+    _funcs->setObject(NodeCreateCallFunc::create(this, NodeCreateCallback_selector(NodeCache::loadSprite)),     ClassName_Sprite);
+    _funcs->setObject(NodeCreateCallFunc::create(this, NodeCreateCallback_selector(NodeCache::loadParticle)),   ClassName_Particle);
+
+
+	_funcs->setObject(NodeCreateCallFunc::create(this, NodeCreateCallback_selector(NodeCache::loadWidget)),   ClassName_Button);
+	_funcs->setObject(NodeCreateCallFunc::create(this, NodeCreateCallback_selector(NodeCache::loadWidget)),   ClassName_CheckBox);
+	_funcs->setObject(NodeCreateCallFunc::create(this, NodeCreateCallback_selector(NodeCache::loadWidget)),   ClassName_ImageView);
+	_funcs->setObject(NodeCreateCallFunc::create(this, NodeCreateCallback_selector(NodeCache::loadWidget)),   ClassName_LabelAtlas);
+	_funcs->setObject(NodeCreateCallFunc::create(this, NodeCreateCallback_selector(NodeCache::loadWidget)),   ClassName_LabelBMFont);
+	_funcs->setObject(NodeCreateCallFunc::create(this, NodeCreateCallback_selector(NodeCache::loadWidget)),   ClassName_Text);
+	_funcs->setObject(NodeCreateCallFunc::create(this, NodeCreateCallback_selector(NodeCache::loadWidget)),   ClassName_LoadingBar);
+	_funcs->setObject(NodeCreateCallFunc::create(this, NodeCreateCallback_selector(NodeCache::loadWidget)),   ClassName_Slider);
+	_funcs->setObject(NodeCreateCallFunc::create(this, NodeCreateCallback_selector(NodeCache::loadWidget)),   ClassName_Layout);
+	_funcs->setObject(NodeCreateCallFunc::create(this, NodeCreateCallback_selector(NodeCache::loadWidget)),   ClassName_ScrollView);
+	_funcs->setObject(NodeCreateCallFunc::create(this, NodeCreateCallback_selector(NodeCache::loadWidget)),   ClassName_ListView);
+	_funcs->setObject(NodeCreateCallFunc::create(this, NodeCreateCallback_selector(NodeCache::loadWidget)),   ClassName_PageView);
+	_funcs->setObject(NodeCreateCallFunc::create(this, NodeCreateCallback_selector(NodeCache::loadWidget)),   ClassName_Widget);
+	_funcs->setObject(NodeCreateCallFunc::create(this, NodeCreateCallback_selector(NodeCache::loadWidget)),   ClassName_Panel);
+	_funcs->setObject(NodeCreateCallFunc::create(this, NodeCreateCallback_selector(NodeCache::loadWidget)),   ClassName_Label);
+	_funcs->setObject(NodeCreateCallFunc::create(this, NodeCreateCallback_selector(NodeCache::loadWidget)),   ClassName_TextField);
+	
+
+	_guiReader = new WidgetPropertiesReader0300();
+}
+
+cocos2d::CCNode* NodeCache::createNode(const std::string& filename)
+{
+    if(_recordJsonPath)
+    {
+        std::string jsonPath = filename.substr(0, filename.find_last_of('/') + 1);
+        GUIReader::shareReader()->setFilePath(jsonPath);
+
+        _jsonPath = jsonPath;
+    }
+    else
+    {
+        GUIReader::shareReader()->setFilePath("");
+        _jsonPath = "";
+    }
+
+    cocos2d::CCNode* node = loadNodeWithFile(filename);
+
+    return node;
+}
+
+cocos2d::CCNode* NodeCache::loadNodeWithFile(const std::string& fileName)
+{
+    // Read content from file
+    std::string fullPath = CCFileUtils::sharedFileUtils()->fullPathForFilename(fileName.c_str());
+    unsigned long size;
+    const char* data = (const char*)CCFileUtils::sharedFileUtils()->getFileData(fullPath.c_str() , "r", &size);
+    std::string contentStr(data, size);
+
+    cocos2d::CCNode* node = loadNodeWithContent(contentStr);
+
+    // Load animation data from file
+    TimelineActionCache::getInstance()->loadAnimationActionWithContent(fileName, contentStr);
+
+    return node;
+}
+
+cocos2d::CCNode* NodeCache::loadNodeWithContent(const std::string& content)
+{
+    rapidjson::Document doc;
+    doc.Parse<0>(content.c_str());
+    if (doc.HasParseError()) 
+    {
+        CCLOG("GetParseError %s\n", doc.GetParseError());
+    }
+    
+    // decode plist 
+    int length = DICTOOL->getArrayCount_json(doc, TEXTURES);
+    for(int i=0; i<length; i++)
+    {
+        std::string plist = DICTOOL->getStringValueFromArray_json(doc, TEXTURES, i);
+        std::string png   = DICTOOL->getStringValueFromArray_json(doc, TEXTURES_PNG, i);
+        plist = _jsonPath + plist;
+        png   = _jsonPath + png;
+        CCSpriteFrameCache::sharedSpriteFrameCache()->addSpriteFramesWithFile(plist.c_str(), png.c_str());
+    }
+
+    // decode node tree
+    const rapidjson::Value& subJson = DICTOOL->getSubDictionary_json(doc, NODE);
+    return loadNode(subJson);
+}
+
+cocos2d::CCNode* NodeCache::loadNode(const rapidjson::Value& json, cocos2d::CCNode* parent)
+{
+    cocos2d::CCNode* node = NULL;
+
+    std::string nodeType = DICTOOL->getStringValue_json(json, NODETYPE);
+
+    NodeCreateCallFunc* func = static_cast<NodeCreateCallFunc*>(_funcs->objectForKey(nodeType));
+    if (func != NULL)
+    {
+        if (isUiWidget(nodeType))
+        {
+            node = func->excute(json, parent);
+        }
+        else
+        {
+            const rapidjson::Value& options = DICTOOL->getSubDictionary_json(json, OPTIONS);
+            node = func->excute(options, parent);
+        }
+    }
+
+    if (node)
+    {
+        cocos2d::ui::Widget* widget = dynamic_cast<cocos2d::ui::Widget*>(node);
+        if (widget)
+        {
+            if (!parent)
+            {
+                return widget;
+            }
+            else
+            {
+                cocos2d::ui::TouchGroup* group = cocos2d::ui::TouchGroup::create();
+                group->addWidget(widget);
+                parent->addChild(group);
+            }
+        }
+        else
+        {
+            int length = DICTOOL->getArrayCount_json(json, CHILDREN, 0);
+            for (int i = 0; i < length; i++)
+            {
+                const rapidjson::Value &dic = DICTOOL->getSubDictionary_json(json, CHILDREN, i);
+                cocos2d::CCNode* child = loadNode(dic, node);
+                if (child && child->getParent() == NULL)
+                {
+                    node->addChild(child);
+                }
+            }
+        }
+    }
+    else
+    {
+        CCLOG("Not supported NodeType: %s", nodeType.c_str());
+    }
+
+    return node;
+}
+
+void NodeCache::initNode(cocos2d::CCNode* node, const rapidjson::Value& json)
+{
+    float x             = DICTOOL->getFloatValue_json(json, X);
+    float y             = DICTOOL->getFloatValue_json(json, Y);
+    float scalex        = DICTOOL->getFloatValue_json(json, SCALE_X, 1);
+    float scaley        = DICTOOL->getFloatValue_json(json, SCALE_Y, 1);
+    float rotation      = DICTOOL->getFloatValue_json(json, ROTATION);
+    float rotationSkewX = DICTOOL->getFloatValue_json(json, ROTATION_SKEW_X);
+    float rotationSkewY = DICTOOL->getFloatValue_json(json, ROTATION_SKEW_X);
+    float skewx         = DICTOOL->getFloatValue_json(json, SKEW_X);
+    float skewy         = DICTOOL->getFloatValue_json(json, SKEW_Y);
+    float anchorx       = DICTOOL->getFloatValue_json(json, ANCHOR_X, 0.5f);
+    float anchory       = DICTOOL->getFloatValue_json(json, ANCHOR_Y, 0.5f);
+    GLubyte alpha       = (GLubyte)DICTOOL->getIntValue_json(json, ALPHA, 255);
+    GLubyte red         = (GLubyte)DICTOOL->getIntValue_json(json, RED, 255);
+    GLubyte green       = (GLubyte)DICTOOL->getIntValue_json(json, GREEN, 255);
+    GLubyte blue        = (GLubyte)DICTOOL->getIntValue_json(json, BLUE, 255);
+	int tag				= DICTOOL->getIntValue_json(json, TAG);
+    int actionTag		= DICTOOL->getIntValue_json(json, ACTION_TAG);
+
+    if(x != 0 || y != 0)
+        node->setPosition(CCPoint(x, y));
+    if(scalex != 1)
+        node->setScaleX(scalex);
+    if(scaley != 1)
+        node->setScaleY(scaley);
+    if (rotation != 0)
+        node->setRotation(rotation);
+    if(rotationSkewX != 0)
+        node->setRotationX(rotationSkewX);
+    if(rotationSkewY != 0)
+        node->setRotationY(rotationSkewY);
+    if(skewx != 0)
+        node->setSkewX(skewx);
+    if(skewy != 0)
+        node->setSkewY(skewy);
+    if(anchorx != 0.5f || anchory != 0.5f)
+        node->setAnchorPoint(CCPoint(anchorx, anchory));
+
+    CCRGBAProtocol *rgbaProtocaol = dynamic_cast<CCRGBAProtocol *>(node);
+    if(rgbaProtocaol)
+    {
+        if(alpha != 255)
+        {
+            rgbaProtocaol->setOpacity(alpha); 
+            rgbaProtocaol->setCascadeOpacityEnabled(true);
+        }
+        if(red != 255 || green != 255 || blue != 255)
+        {
+            rgbaProtocaol->setColor(ccc3(red, green, blue));
+            rgbaProtocaol->setCascadeColorEnabled(true);
+        }
+    }
+
+	node->setUserObject(TimelineActionData::create(actionTag));
+}
+
+
+CCNode* NodeCache::loadSimpleNode(const rapidjson::Value& json, cocos2d::CCNode* parent)
+{
+    const char* filePath = DICTOOL->getStringValue_json(json, FILE_PATH);
+
+    CCNode* node = NULL;
+    if(filePath)
+    {
+        node = createNode(filePath);
+    }
+    else
+    {
+        node = CCNodeRGBA::create();
+    }
+
+    initNode(node, json);
+
+    return node;
+}
+
+CCNode* NodeCache::loadSprite(const rapidjson::Value& json, cocos2d::CCNode* parent)
+{
+    const char* filePath = DICTOOL->getStringValue_json(json, FILE_PATH);
+
+    CCSprite *sprite = NULL;
+
+	if(filePath != NULL)
+	{
+        std::string path = filePath;
+		CCSpriteFrame* spriteFrame = CCSpriteFrameCache::sharedSpriteFrameCache()->spriteFrameByName(path.c_str());
+		if(!spriteFrame)
+        {
+            path = _jsonPath + path;
+			sprite = CCSprite::create(path.c_str());
+		}
+		else
+		{
+			sprite = CCSprite::createWithSpriteFrame(spriteFrame);
+		}
+
+		if(sprite == NULL)
+			CCLOG("create sprite with file name : %s  failed.", filePath);
+	}
+	else
+	{
+		sprite = CCSprite::create();
+	}
+
+    initNode(sprite, json);
+
+    return sprite;
+}
+
+CCNode* NodeCache::loadParticle(const rapidjson::Value& json, cocos2d::CCNode* parent)
+{
+	const char* filePath = DICTOOL->getStringValue_json(json, PLIST_FILE);
+
+	CCParticleSystemQuad* particle = CCParticleSystemQuad::create(filePath);
+
+	initNode(particle, json);
+
+	return particle;
+}
+
+CCNode* NodeCache::loadWidget(const rapidjson::Value& json, cocos2d::CCNode* parent)
+{
+    WidgetPropertiesReader* pReader = new WidgetPropertiesReader0300();
+    cocos2d::ui::Widget* widget = pReader->widgetFromJsonDictionary(json);
+
+    return widget;
+}
+
+bool NodeCache::isUiWidget(const std::string &type)
+{    
+    return (type == ClassName_Button
+        || type == ClassName_CheckBox
+        || type == ClassName_ImageView
+        || type == ClassName_LabelAtlas
+        || type == ClassName_LabelBMFont
+        || type == ClassName_LoadingBar
+        || type == ClassName_TextField
+        || type == ClassName_Slider
+        || type == ClassName_Layout
+        || type == ClassName_ScrollView
+        || type == ClassName_ListView        
+        || type == ClassName_PageView
+        || type == ClassName_Widget
+        || type == ClassName_Panel
+        || type == ClassName_Label);
+}
+
+NS_TIMELINE_END

--- a/extensions/CocoStudio/ActionTimeline/CCNodeCache.h
+++ b/extensions/CocoStudio/ActionTimeline/CCNodeCache.h
@@ -1,0 +1,121 @@
+/****************************************************************************
+Copyright (c) 2013 cocos2d-x.org
+
+http://www.cocos2d-x.org
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+****************************************************************************/
+
+#ifndef __CC_NODE_CACHE_H__
+#define __CC_NODE_CACHE_H__
+
+#include "CCTimeLine.h"
+#include "../Json/DictionaryHelper.h"
+
+namespace cocos2d
+{
+	namespace extension
+	{
+		class WidgetPropertiesReader0300;
+	}
+}
+
+NS_TIMELINE_BEGIN
+
+
+typedef cocos2d::CCNode* (cocos2d::CCObject::*NodeCreateCallback)(const rapidjson::Value& json, cocos2d::CCNode* parent);
+#define NodeCreateCallback_selector(_SELECTOR) (NodeCreateCallback)(&_SELECTOR)
+
+class CC_EX_DLL NodeCreateCallFunc : public cocos2d::CCObject
+{
+public:
+    static NodeCreateCallFunc* create(CCObject* target, NodeCreateCallback callback);
+
+    NodeCreateCallFunc();
+    ~NodeCreateCallFunc();
+    bool init(CCObject* target, NodeCreateCallback callback);
+    cocos2d::CCNode* excute(const rapidjson::Value& json, cocos2d::CCNode* parent);
+    
+protected:
+    CCObject* _target;
+    NodeCreateCallback _callback;
+};
+
+
+class TimelineActionData : public cocos2d::CCObject
+{
+public:
+    static TimelineActionData* create(int actionTag);
+
+    virtual void setActionTag(int actionTag) { _actionTag = actionTag; }
+    virtual int getActionTag() const { return _actionTag; }
+protected:
+    TimelineActionData();
+    virtual bool init(int actionTag);
+
+    int _actionTag;
+};
+
+class CC_EX_DLL NodeCache : public cocos2d::CCObject
+{
+public:
+    static NodeCache* getInstance();
+    static void destroyInstance();
+    
+    NodeCache();
+    virtual ~NodeCache();
+    void purge();
+
+    void init();
+
+    cocos2d::CCNode* createNode(const std::string& filename);
+
+    cocos2d::CCNode* loadNodeWithFile(const std::string& fileName);
+    cocos2d::CCNode* loadNodeWithContent(const std::string& content);
+
+    void setRecordJsonPath(bool record) { _recordJsonPath = record; }
+    bool isRecordJsonPath() const { return _recordJsonPath; }
+
+    void setJsonPath(std::string jsonPath) { _jsonPath = jsonPath; }
+    std::string getJsonPath() const { return _jsonPath; }
+protected:
+
+    cocos2d::CCNode* loadNode(const rapidjson::Value& json, cocos2d::CCNode* parent = NULL);
+
+    void initNode(cocos2d::CCNode* node, const rapidjson::Value& json);
+
+    cocos2d::CCNode* loadSimpleNode(const rapidjson::Value& json, cocos2d::CCNode* parent);
+    cocos2d::CCNode* loadSprite(const rapidjson::Value& json, cocos2d::CCNode* parent);
+    cocos2d::CCNode* loadParticle(const rapidjson::Value& json, cocos2d::CCNode* parent);
+	cocos2d::CCNode* loadWidget(const rapidjson::Value& json, cocos2d::CCNode* parent);
+
+    bool isUiWidget(const std::string& type);
+
+    cocos2d::CCDictionary* _funcs;  // <std::string, NodeCreateCallFunc*>
+
+	cocos2d::extension::WidgetPropertiesReader0300* _guiReader;
+
+    bool _recordJsonPath;
+    std::string _jsonPath;
+};
+
+NS_TIMELINE_END
+
+
+#endif /*__CC_NODE_CACHE_H__*/

--- a/extensions/CocoStudio/ActionTimeline/CCNodeReader.cpp
+++ b/extensions/CocoStudio/ActionTimeline/CCNodeReader.cpp
@@ -22,7 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 ****************************************************************************/
 
-#include "CCNodeCache.h"
+#include "CCNodeReader.h"
 #include "CCActionTimelineCache.h"
 #include "CCFrame.h"
 #include "../Reader/GUIReader.h"
@@ -157,72 +157,72 @@ bool TimelineActionData::init(int actionTag)
 
 
 
-// NodeCache
+// NodeReader
 
-static NodeCache* _sharedNodeCache = NULL;
+static NodeReader* _sharedNodeReader = NULL;
 
-NodeCache* NodeCache::getInstance()
+NodeReader* NodeReader::getInstance()
 {
-    if (! _sharedNodeCache)
+    if (! _sharedNodeReader)
     {
-        _sharedNodeCache = new NodeCache();
-        _sharedNodeCache->init();
+        _sharedNodeReader = new NodeReader();
+        _sharedNodeReader->init();
     }
 
-    return _sharedNodeCache;
+    return _sharedNodeReader;
 }
 
-void NodeCache::destroyInstance()
+void NodeReader::destroyInstance()
 {
-    CC_SAFE_DELETE(_sharedNodeCache);
+    CC_SAFE_DELETE(_sharedNodeReader);
 }
 
-NodeCache::NodeCache()
+NodeReader::NodeReader()
     : _recordJsonPath(true)
     , _jsonPath("")
 {
 }
 
-NodeCache::~NodeCache()
+NodeReader::~NodeReader()
 {
     CC_SAFE_DELETE(_funcs);
 }
 
-void NodeCache::purge()
+void NodeReader::purge()
 {
 }
 
-void NodeCache::init()
+void NodeReader::init()
 {
     _funcs = new cocos2d::CCDictionary();
     
-    _funcs->setObject(NodeCreateCallFunc::create(this, NodeCreateCallback_selector(NodeCache::loadSimpleNode)), ClassName_Node);
-    _funcs->setObject(NodeCreateCallFunc::create(this, NodeCreateCallback_selector(NodeCache::loadSprite)),     ClassName_Sprite);
-    _funcs->setObject(NodeCreateCallFunc::create(this, NodeCreateCallback_selector(NodeCache::loadParticle)),   ClassName_Particle);
+    _funcs->setObject(NodeCreateCallFunc::create(this, NodeCreateCallback_selector(NodeReader::loadSimpleNode)), ClassName_Node);
+    _funcs->setObject(NodeCreateCallFunc::create(this, NodeCreateCallback_selector(NodeReader::loadSprite)),     ClassName_Sprite);
+    _funcs->setObject(NodeCreateCallFunc::create(this, NodeCreateCallback_selector(NodeReader::loadParticle)),   ClassName_Particle);
 
 
-	_funcs->setObject(NodeCreateCallFunc::create(this, NodeCreateCallback_selector(NodeCache::loadWidget)),   ClassName_Button);
-	_funcs->setObject(NodeCreateCallFunc::create(this, NodeCreateCallback_selector(NodeCache::loadWidget)),   ClassName_CheckBox);
-	_funcs->setObject(NodeCreateCallFunc::create(this, NodeCreateCallback_selector(NodeCache::loadWidget)),   ClassName_ImageView);
-	_funcs->setObject(NodeCreateCallFunc::create(this, NodeCreateCallback_selector(NodeCache::loadWidget)),   ClassName_LabelAtlas);
-	_funcs->setObject(NodeCreateCallFunc::create(this, NodeCreateCallback_selector(NodeCache::loadWidget)),   ClassName_LabelBMFont);
-	_funcs->setObject(NodeCreateCallFunc::create(this, NodeCreateCallback_selector(NodeCache::loadWidget)),   ClassName_Text);
-	_funcs->setObject(NodeCreateCallFunc::create(this, NodeCreateCallback_selector(NodeCache::loadWidget)),   ClassName_LoadingBar);
-	_funcs->setObject(NodeCreateCallFunc::create(this, NodeCreateCallback_selector(NodeCache::loadWidget)),   ClassName_Slider);
-	_funcs->setObject(NodeCreateCallFunc::create(this, NodeCreateCallback_selector(NodeCache::loadWidget)),   ClassName_Layout);
-	_funcs->setObject(NodeCreateCallFunc::create(this, NodeCreateCallback_selector(NodeCache::loadWidget)),   ClassName_ScrollView);
-	_funcs->setObject(NodeCreateCallFunc::create(this, NodeCreateCallback_selector(NodeCache::loadWidget)),   ClassName_ListView);
-	_funcs->setObject(NodeCreateCallFunc::create(this, NodeCreateCallback_selector(NodeCache::loadWidget)),   ClassName_PageView);
-	_funcs->setObject(NodeCreateCallFunc::create(this, NodeCreateCallback_selector(NodeCache::loadWidget)),   ClassName_Widget);
-	_funcs->setObject(NodeCreateCallFunc::create(this, NodeCreateCallback_selector(NodeCache::loadWidget)),   ClassName_Panel);
-	_funcs->setObject(NodeCreateCallFunc::create(this, NodeCreateCallback_selector(NodeCache::loadWidget)),   ClassName_Label);
-	_funcs->setObject(NodeCreateCallFunc::create(this, NodeCreateCallback_selector(NodeCache::loadWidget)),   ClassName_TextField);
+	_funcs->setObject(NodeCreateCallFunc::create(this, NodeCreateCallback_selector(NodeReader::loadWidget)),   ClassName_Button);
+	_funcs->setObject(NodeCreateCallFunc::create(this, NodeCreateCallback_selector(NodeReader::loadWidget)),   ClassName_CheckBox);
+	_funcs->setObject(NodeCreateCallFunc::create(this, NodeCreateCallback_selector(NodeReader::loadWidget)),   ClassName_ImageView);
+	_funcs->setObject(NodeCreateCallFunc::create(this, NodeCreateCallback_selector(NodeReader::loadWidget)),   ClassName_LabelAtlas);
+	_funcs->setObject(NodeCreateCallFunc::create(this, NodeCreateCallback_selector(NodeReader::loadWidget)),   ClassName_LabelBMFont);
+	_funcs->setObject(NodeCreateCallFunc::create(this, NodeCreateCallback_selector(NodeReader::loadWidget)),   ClassName_Text);
+	_funcs->setObject(NodeCreateCallFunc::create(this, NodeCreateCallback_selector(NodeReader::loadWidget)),   ClassName_LoadingBar);
+	_funcs->setObject(NodeCreateCallFunc::create(this, NodeCreateCallback_selector(NodeReader::loadWidget)),   ClassName_Slider);
+	_funcs->setObject(NodeCreateCallFunc::create(this, NodeCreateCallback_selector(NodeReader::loadWidget)),   ClassName_Layout);
+	_funcs->setObject(NodeCreateCallFunc::create(this, NodeCreateCallback_selector(NodeReader::loadWidget)),   ClassName_ScrollView);
+	_funcs->setObject(NodeCreateCallFunc::create(this, NodeCreateCallback_selector(NodeReader::loadWidget)),   ClassName_ListView);
+	_funcs->setObject(NodeCreateCallFunc::create(this, NodeCreateCallback_selector(NodeReader::loadWidget)),   ClassName_PageView);
+	_funcs->setObject(NodeCreateCallFunc::create(this, NodeCreateCallback_selector(NodeReader::loadWidget)),   ClassName_Widget);
+	_funcs->setObject(NodeCreateCallFunc::create(this, NodeCreateCallback_selector(NodeReader::loadWidget)),   ClassName_Panel);
+	_funcs->setObject(NodeCreateCallFunc::create(this, NodeCreateCallback_selector(NodeReader::loadWidget)),   ClassName_Label);
+	_funcs->setObject(NodeCreateCallFunc::create(this, NodeCreateCallback_selector(NodeReader::loadWidget)),   ClassName_TextField);
 	
 
 	_guiReader = new WidgetPropertiesReader0300();
 }
 
-cocos2d::CCNode* NodeCache::createNode(const std::string& filename)
+cocos2d::CCNode* NodeReader::createNode(const std::string& filename)
 {
     if(_recordJsonPath)
     {
@@ -242,7 +242,7 @@ cocos2d::CCNode* NodeCache::createNode(const std::string& filename)
     return node;
 }
 
-cocos2d::CCNode* NodeCache::loadNodeWithFile(const std::string& fileName)
+cocos2d::CCNode* NodeReader::loadNodeWithFile(const std::string& fileName)
 {
     // Read content from file
     std::string fullPath = CCFileUtils::sharedFileUtils()->fullPathForFilename(fileName.c_str());
@@ -253,12 +253,12 @@ cocos2d::CCNode* NodeCache::loadNodeWithFile(const std::string& fileName)
     cocos2d::CCNode* node = loadNodeWithContent(contentStr);
 
     // Load animation data from file
-    TimelineActionCache::getInstance()->loadAnimationActionWithContent(fileName, contentStr);
+    ActionTimelineCache::getInstance()->loadAnimationActionWithContent(fileName, contentStr);
 
     return node;
 }
 
-cocos2d::CCNode* NodeCache::loadNodeWithContent(const std::string& content)
+cocos2d::CCNode* NodeReader::loadNodeWithContent(const std::string& content)
 {
     rapidjson::Document doc;
     doc.Parse<0>(content.c_str());
@@ -283,7 +283,7 @@ cocos2d::CCNode* NodeCache::loadNodeWithContent(const std::string& content)
     return loadNode(subJson);
 }
 
-cocos2d::CCNode* NodeCache::loadNode(const rapidjson::Value& json, cocos2d::CCNode* parent)
+cocos2d::CCNode* NodeReader::loadNode(const rapidjson::Value& json, cocos2d::CCNode* parent)
 {
     cocos2d::CCNode* node = NULL;
 
@@ -341,7 +341,7 @@ cocos2d::CCNode* NodeCache::loadNode(const rapidjson::Value& json, cocos2d::CCNo
     return node;
 }
 
-void NodeCache::initNode(cocos2d::CCNode* node, const rapidjson::Value& json)
+void NodeReader::initNode(cocos2d::CCNode* node, const rapidjson::Value& json)
 {
     float x             = DICTOOL->getFloatValue_json(json, X);
     float y             = DICTOOL->getFloatValue_json(json, Y);
@@ -399,7 +399,7 @@ void NodeCache::initNode(cocos2d::CCNode* node, const rapidjson::Value& json)
 }
 
 
-CCNode* NodeCache::loadSimpleNode(const rapidjson::Value& json, cocos2d::CCNode* parent)
+CCNode* NodeReader::loadSimpleNode(const rapidjson::Value& json, cocos2d::CCNode* parent)
 {
     const char* filePath = DICTOOL->getStringValue_json(json, FILE_PATH);
 
@@ -418,7 +418,7 @@ CCNode* NodeCache::loadSimpleNode(const rapidjson::Value& json, cocos2d::CCNode*
     return node;
 }
 
-CCNode* NodeCache::loadSprite(const rapidjson::Value& json, cocos2d::CCNode* parent)
+CCNode* NodeReader::loadSprite(const rapidjson::Value& json, cocos2d::CCNode* parent)
 {
     const char* filePath = DICTOOL->getStringValue_json(json, FILE_PATH);
 
@@ -451,7 +451,7 @@ CCNode* NodeCache::loadSprite(const rapidjson::Value& json, cocos2d::CCNode* par
     return sprite;
 }
 
-CCNode* NodeCache::loadParticle(const rapidjson::Value& json, cocos2d::CCNode* parent)
+CCNode* NodeReader::loadParticle(const rapidjson::Value& json, cocos2d::CCNode* parent)
 {
 	const char* filePath = DICTOOL->getStringValue_json(json, PLIST_FILE);
 
@@ -462,7 +462,7 @@ CCNode* NodeCache::loadParticle(const rapidjson::Value& json, cocos2d::CCNode* p
 	return particle;
 }
 
-CCNode* NodeCache::loadWidget(const rapidjson::Value& json, cocos2d::CCNode* parent)
+CCNode* NodeReader::loadWidget(const rapidjson::Value& json, cocos2d::CCNode* parent)
 {
     WidgetPropertiesReader* pReader = new WidgetPropertiesReader0300();
     cocos2d::ui::Widget* widget = pReader->widgetFromJsonDictionary(json);
@@ -470,7 +470,7 @@ CCNode* NodeCache::loadWidget(const rapidjson::Value& json, cocos2d::CCNode* par
     return widget;
 }
 
-bool NodeCache::isUiWidget(const std::string &type)
+bool NodeReader::isUiWidget(const std::string &type)
 {    
     return (type == ClassName_Button
         || type == ClassName_CheckBox

--- a/extensions/CocoStudio/ActionTimeline/CCNodeReader.h
+++ b/extensions/CocoStudio/ActionTimeline/CCNodeReader.h
@@ -22,8 +22,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 ****************************************************************************/
 
-#ifndef __CC_NODE_CACHE_H__
-#define __CC_NODE_CACHE_H__
+#ifndef __CC_NODE_READER_H__
+#define __CC_NODE_READER_H__
 
 #include "CCTimeLine.h"
 #include "../Json/DictionaryHelper.h"
@@ -72,14 +72,14 @@ protected:
     int _actionTag;
 };
 
-class CC_EX_DLL NodeCache : public cocos2d::CCObject
+class CC_EX_DLL NodeReader : public cocos2d::CCObject
 {
 public:
-    static NodeCache* getInstance();
+    static NodeReader* getInstance();
     static void destroyInstance();
     
-    NodeCache();
-    virtual ~NodeCache();
+    NodeReader();
+    virtual ~NodeReader();
     void purge();
 
     void init();
@@ -118,4 +118,4 @@ protected:
 NS_TIMELINE_END
 
 
-#endif /*__CC_NODE_CACHE_H__*/
+#endif /*__CC_NODE_READER_H__*/

--- a/extensions/CocoStudio/ActionTimeline/CCTimeLine.cpp
+++ b/extensions/CocoStudio/ActionTimeline/CCTimeLine.cpp
@@ -1,0 +1,268 @@
+/****************************************************************************
+Copyright (c) 2013 cocos2d-x.org
+
+http://www.cocos2d-x.org
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+****************************************************************************/
+
+#include "CCTimeLine.h"
+#include "CCActionTimeline.h"
+#include "CCFrame.h"
+
+using namespace cocos2d;
+
+NS_TIMELINE_BEGIN
+
+Timeline* Timeline::create()
+{
+    Timeline* object = new Timeline();
+    if (object && object->init())
+    {
+        object->autorelease();
+        return object;
+    }
+    CC_SAFE_DELETE(object);
+    return NULL;
+}
+
+Timeline::Timeline()
+    : _frames(NULL)
+    , _currentKeyFrame(NULL)
+    , _currentKeyFrameIndex(0)
+    , _fromIndex(0)
+    , _toIndex(0)
+    , _betweenDuration(0)
+    , _actionTag(0)
+    , _timelineAction(NULL)
+    , _node(NULL)
+{
+}
+
+Timeline::~Timeline()
+{
+    CC_SAFE_DELETE(_frames);
+}
+
+bool Timeline::init()
+{
+    _frames = new cocos2d::CCArray();
+    return _frames->init();
+}
+
+void Timeline::gotoFrame(int frameIndex)
+{
+    if(_frames->count() == 0)
+        return;
+
+    binarySearchKeyFrame(frameIndex);
+    apply(frameIndex);
+}
+
+void Timeline::stepToFrame(int frameIndex)
+{
+    if(_frames->count() == 0)
+        return;
+
+    updateCurrentKeyFrame(frameIndex);
+    apply(frameIndex);
+}
+
+Timeline* Timeline::clone()
+{
+    Timeline* timeline = Timeline::create();
+    timeline->_actionTag = _actionTag;
+
+    CCObject* object = NULL;
+    CCARRAY_FOREACH(_frames, object)
+    {
+        Frame* frame = static_cast<Frame*>(object);
+        Frame* newFrame = frame->clone();
+        timeline->addFrame(newFrame);
+    }
+
+    return timeline;
+}
+
+void Timeline::addFrame(Frame* frame)
+{
+    _frames->addObject(frame);
+    frame->setTimeline(this);
+}
+
+void Timeline::insertFrame(Frame* frame, int index)
+{
+    _frames->insertObject(frame, index);
+    frame->setTimeline(this);
+}
+
+void Timeline::removeFrame(Frame* frame)
+{
+    _frames->removeObject(frame);
+    frame->setTimeline(NULL);
+}
+
+void Timeline::setNode(cocos2d::CCNode* node)
+{
+    CCObject* object = NULL;
+    CCARRAY_FOREACH(_frames, object)
+    {
+        Frame* frame = static_cast<Frame*>(object);
+        frame->setNode(node);
+    }
+}
+
+cocos2d::CCNode* Timeline::getNode() const 
+{
+    return _node;
+}
+
+void Timeline::apply(int frameIndex)
+{
+    if (_currentKeyFrame)
+    {
+        float currentPercent = _betweenDuration == 0 ? 0 : (frameIndex - _currentKeyFrameIndex) / (float)_betweenDuration;
+        _currentKeyFrame->apply(currentPercent);
+    }
+}
+
+void Timeline::binarySearchKeyFrame(int frameIndex)
+{
+    Frame *from = NULL;
+    Frame *to   = NULL;
+
+    int step = 2;
+    int target = 0;
+    long length = _frames->count();
+    Frame **frames = (Frame **)_frames->data->arr;
+
+    bool needEnterFrame = false;
+
+    do 
+    {
+        if (frameIndex < frames[0]->getFrameIndex())
+        {
+            if(_currentKeyFrameIndex >= frames[0]->getFrameIndex())
+                needEnterFrame = true;
+
+            from = to = frames[0];
+            _currentKeyFrameIndex = 0;
+            _betweenDuration = frames[0]->getFrameIndex();
+            break;
+        }
+        else if(frameIndex >= frames[length - 1]->getFrameIndex())
+        {
+            from = to = frames[length - 1]; 
+            _currentKeyFrameIndex = frames[length - 1]->getFrameIndex();
+            _betweenDuration = 0;
+            break;
+        }
+
+        int target = -1;
+        int low=0,high=length-1,mid;
+        while(low<=high){ 
+            mid=(low+high)/2;
+            if(frameIndex >= frames[mid]->getFrameIndex() && frameIndex < frames[mid+1]->getFrameIndex()) 
+            {
+                target = mid;
+                break;
+            }
+            if(frames[mid]->getFrameIndex()>frameIndex)
+                high=mid-1; 
+            else
+                low=mid+1;
+        }
+
+        from = frames[target];
+        to   = frames[target+1];
+
+        if(target == 0 && _currentKeyFrameIndex<from->getFrameIndex())
+            needEnterFrame = true;
+
+        _currentKeyFrameIndex = from->getFrameIndex();
+        _betweenDuration = to->getFrameIndex() - from->getFrameIndex();
+    } while (0);
+
+    if(needEnterFrame || _currentKeyFrame != from)
+    {
+        _currentKeyFrame = from;
+        _currentKeyFrame->onEnter(to);
+    }
+}
+
+void Timeline::updateCurrentKeyFrame(int frameIndex)
+{
+    //! If play to current frame's front or back, then find current frame again
+    if (frameIndex < _currentKeyFrameIndex || frameIndex >= _currentKeyFrameIndex + _betweenDuration)
+    {
+        Frame *from = NULL;
+        Frame *to   = NULL;
+
+        do 
+        {
+            Frame **frames = (Frame **)_frames->data->arr;
+
+            long length = _frames->count();
+
+            if (frameIndex < frames[0]->getFrameIndex())
+            {
+                from = to = frames[0];
+                _currentKeyFrameIndex = 0;
+                _betweenDuration = frames[0]->getFrameIndex();
+                break;
+            }
+            else if(frameIndex >= frames[length - 1]->getFrameIndex())
+            {
+                from = to = frames[length - 1];
+                _currentKeyFrameIndex = frames[length - 1]->getFrameIndex();
+                _betweenDuration = 0;
+                break;
+            }
+
+            do
+            {
+                _fromIndex = _toIndex;
+                from = frames[_fromIndex];
+                _currentKeyFrameIndex  = from->getFrameIndex();
+
+                _toIndex = _fromIndex + 1;
+                if (_toIndex >= length)
+                {
+                    _toIndex = 0;
+                }
+
+                to = frames[_toIndex];
+
+                if (frameIndex == from->getFrameIndex())
+                {
+                    break;
+                }
+            }
+            while (frameIndex < from->getFrameIndex() || frameIndex >= to->getFrameIndex());
+
+            _betweenDuration = to->getFrameIndex() - from->getFrameIndex();
+
+        } while (0);
+
+        _currentKeyFrame = from;
+        _currentKeyFrame->onEnter(to);
+    }
+}
+
+NS_TIMELINE_END

--- a/extensions/CocoStudio/ActionTimeline/CCTimeLine.h
+++ b/extensions/CocoStudio/ActionTimeline/CCTimeLine.h
@@ -1,0 +1,86 @@
+/****************************************************************************
+Copyright (c) 2013 cocos2d-x.org
+
+http://www.cocos2d-x.org
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+****************************************************************************/
+
+#ifndef __CCTIMELINE_H__
+#define __CCTIMELINE_H__
+
+#include "CCFrame.h"
+#include "ExtensionExport.h"
+
+NS_TIMELINE_BEGIN
+
+class ActionTimeline;
+
+class CC_EX_DLL Timeline : public cocos2d::CCObject
+{
+public:
+    static Timeline* create();
+
+    Timeline();
+    virtual ~Timeline();
+
+    virtual bool init();
+
+    virtual void gotoFrame  (int frameIndex);
+    virtual void stepToFrame(int frameIndex);
+
+    virtual const cocos2d::CCArray* getFrames() { return _frames; }
+    virtual void addFrame(Frame* frame);
+    virtual void insertFrame(Frame* frame, int index);
+    virtual void removeFrame(Frame* frame);
+
+    virtual void setActionTag(int tag) { _actionTag = tag; }
+    virtual int  getActionTag() const { return _actionTag; }
+
+    virtual void setNode(cocos2d::CCNode* node);
+    virtual cocos2d::CCNode* getNode() const;
+
+    virtual void setActionTimeline(ActionTimeline* action) { _timelineAction = action; }
+    virtual ActionTimeline* getActionTimeline() const { return _timelineAction; }
+
+    virtual Timeline* clone();
+
+protected:
+    virtual void apply(int frameIndex);
+
+    virtual void binarySearchKeyFrame (int frameIndex);
+    virtual void updateCurrentKeyFrame(int frameIndex);
+
+    cocos2d::CCArray* _frames; // <Frame*>
+    Frame* _currentKeyFrame;
+    int _currentKeyFrameIndex;
+
+    int _fromIndex;
+    int _toIndex;
+    int _betweenDuration;
+    int _actionTag;
+
+    ActionTimeline*  _timelineAction;
+    cocos2d::CCNode* _node;
+};
+
+NS_TIMELINE_END
+
+
+#endif /*__CCTIMELINE_H__*/

--- a/extensions/CocoStudio/ActionTimeline/CCTimelineMacro.h
+++ b/extensions/CocoStudio/ActionTimeline/CCTimelineMacro.h
@@ -1,0 +1,38 @@
+/****************************************************************************
+Copyright (c) 2010-2012 cocos2d-x.org
+Copyright (c) 2013-2014 Chukong Technologies
+ 
+ http://www.cocos2d-x.org
+ 
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+ 
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+ 
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+ ****************************************************************************/
+#ifndef __CC_TIMELINE_MACROS_H__
+#define __CC_TIMELINE_MACROS_H__
+
+#ifdef __cplusplus
+#define NS_TIMELINE_BEGIN                     namespace cocostudio { namespace timeline{
+#define NS_TIMELINE_END                       }}
+#define USING_NS_TIMELINE                     using namespace cocostudio::timeline;
+#else
+#define NS_TIMELINE_BEGIN 
+#define NS_TIMELINE_END 
+#define USING_NS_TIMELINE 
+#endif 
+
+#endif

--- a/extensions/CocoStudio/Reader/GUIReader.h
+++ b/extensions/CocoStudio/Reader/GUIReader.h
@@ -66,6 +66,7 @@ public:
     void storeFileDesignSize(const char* fileName, const cocos2d::CCSize &size);
     const cocos2d::CCSize getFileDesignSize(const char* fileName) const;
     
+    void setFilePath(const std::string& strFilePath) { m_strFilePath = strFilePath; }
     const std::string& getFilePath() const { return m_strFilePath; };
     
     void registerTypeAndCallBack(const std::string& classType,

--- a/extensions/cocos-ext.h
+++ b/extensions/cocos-ext.h
@@ -55,6 +55,13 @@
 #include "CocoStudio/Armature/utils/CCTweenFunction.h"
 #include "CocoStudio/Armature/external_tool/sigslot.h"
 
+#include "CocoStudio/ActionTimeline/CCActionTimeline.h"
+#include "CocoStudio/ActionTimeline/CCActionTimelineCache.h"
+#include "CocoStudio/ActionTimeline/CCFrame.h"
+#include "CocoStudio/ActionTimeline/CCNodeReader.h"
+#include "CocoStudio/ActionTimeline/CCTimeLine.h"
+#include "CocoStudio/ActionTimeline/CCTimelineMacro.h"
+
 #include "CocoStudio/Trigger/TriggerBase.h"
 
 #include "CocoStudio/Components/CCComBase.h"

--- a/extensions/proj.linux/Makefile
+++ b/extensions/proj.linux/Makefile
@@ -101,6 +101,11 @@ SOURCES = ../CCBReader/CCBFileLoader.cpp \
 ../CocoStudio/Armature/utils/CCTransformHelp.cpp \
 ../CocoStudio/Armature/utils/CCTweenFunction.cpp \
 ../CocoStudio/Armature/utils/CCUtilMath.cpp \
+../CocoStudio/ActionTimeline/CCActionTimeline.cpp \
+../CocoStudio/ActionTimeline/CCActionTimelineCache.cpp \
+../CocoStudio/ActionTimeline/CCFrame.cpp \
+../CocoStudio/ActionTimeline/CCNodeReader.cpp \
+../CocoStudio/ActionTimeline/CCTimeLine.cpp \
 ../CocoStudio/GUI/BaseClasses/UIWidget.cpp \
 ../CocoStudio/GUI/Layouts/UILayout.cpp \
 ../CocoStudio/GUI/Layouts/UILayoutParameter.cpp \

--- a/extensions/proj.win32/libExtensions.vcxproj
+++ b/extensions/proj.win32/libExtensions.vcxproj
@@ -146,7 +146,7 @@ xcopy /Y /Q "$(ProjectDir)..\..\external\sqlite3\libraries\win32\*.*" "$(OutDir)
     <ClCompile Include="..\CocoStudio\ActionTimeline\CCActionTimeline.cpp" />
     <ClCompile Include="..\CocoStudio\ActionTimeline\CCActionTimelineCache.cpp" />
     <ClCompile Include="..\CocoStudio\ActionTimeline\CCFrame.cpp" />
-    <ClCompile Include="..\CocoStudio\ActionTimeline\CCNodeCache.cpp" />
+    <ClCompile Include="..\CocoStudio\ActionTimeline\CCNodeReader.cpp" />
     <ClCompile Include="..\CocoStudio\ActionTimeline\CCTimeLine.cpp" />
     <ClCompile Include="..\CocoStudio\Action\CCActionEaseEx.cpp" />
     <ClCompile Include="..\CocoStudio\Action\CCActionFrame.cpp" />
@@ -304,7 +304,7 @@ xcopy /Y /Q "$(ProjectDir)..\..\external\sqlite3\libraries\win32\*.*" "$(OutDir)
     <ClInclude Include="..\CocoStudio\ActionTimeline\CCActionTimeline.h" />
     <ClInclude Include="..\CocoStudio\ActionTimeline\CCActionTimelineCache.h" />
     <ClInclude Include="..\CocoStudio\ActionTimeline\CCFrame.h" />
-    <ClInclude Include="..\CocoStudio\ActionTimeline\CCNodeCache.h" />
+    <ClInclude Include="..\CocoStudio\ActionTimeline\CCNodeReader.h" />
     <ClInclude Include="..\CocoStudio\ActionTimeline\CCTimeLine.h" />
     <ClInclude Include="..\CocoStudio\ActionTimeline\CCTimelineMacro.h" />
     <ClInclude Include="..\CocoStudio\Action\CCActionEaseEx.h" />

--- a/extensions/proj.win32/libExtensions.vcxproj
+++ b/extensions/proj.win32/libExtensions.vcxproj
@@ -143,6 +143,11 @@ xcopy /Y /Q "$(ProjectDir)..\..\external\sqlite3\libraries\win32\*.*" "$(OutDir)
     <ClCompile Include="..\CCBReader\CCScale9SpriteLoader.cpp" />
     <ClCompile Include="..\CCBReader\CCScrollViewLoader.cpp" />
     <ClCompile Include="..\CCBReader\CCSpriteLoader.cpp" />
+    <ClCompile Include="..\CocoStudio\ActionTimeline\CCActionTimeline.cpp" />
+    <ClCompile Include="..\CocoStudio\ActionTimeline\CCActionTimelineCache.cpp" />
+    <ClCompile Include="..\CocoStudio\ActionTimeline\CCFrame.cpp" />
+    <ClCompile Include="..\CocoStudio\ActionTimeline\CCNodeCache.cpp" />
+    <ClCompile Include="..\CocoStudio\ActionTimeline\CCTimeLine.cpp" />
     <ClCompile Include="..\CocoStudio\Action\CCActionEaseEx.cpp" />
     <ClCompile Include="..\CocoStudio\Action\CCActionFrame.cpp" />
     <ClCompile Include="..\CocoStudio\Action\CCActionFrameEasing.cpp" />
@@ -296,6 +301,12 @@ xcopy /Y /Q "$(ProjectDir)..\..\external\sqlite3\libraries\win32\*.*" "$(OutDir)
     <ClInclude Include="..\CCBReader\CCScale9SpriteLoader.h" />
     <ClInclude Include="..\CCBReader\CCScrollViewLoader.h" />
     <ClInclude Include="..\CCBReader\CCSpriteLoader.h" />
+    <ClInclude Include="..\CocoStudio\ActionTimeline\CCActionTimeline.h" />
+    <ClInclude Include="..\CocoStudio\ActionTimeline\CCActionTimelineCache.h" />
+    <ClInclude Include="..\CocoStudio\ActionTimeline\CCFrame.h" />
+    <ClInclude Include="..\CocoStudio\ActionTimeline\CCNodeCache.h" />
+    <ClInclude Include="..\CocoStudio\ActionTimeline\CCTimeLine.h" />
+    <ClInclude Include="..\CocoStudio\ActionTimeline\CCTimelineMacro.h" />
     <ClInclude Include="..\CocoStudio\Action\CCActionEaseEx.h" />
     <ClInclude Include="..\CocoStudio\Action\CCActionFrame.h" />
     <ClInclude Include="..\CocoStudio\Action\CCActionFrameEasing.h" />

--- a/extensions/proj.win32/libExtensions.vcxproj.filters
+++ b/extensions/proj.win32/libExtensions.vcxproj.filters
@@ -538,10 +538,10 @@
     <ClCompile Include="..\CocoStudio\ActionTimeline\CCFrame.cpp">
       <Filter>CocoStudio\ActionTimeline</Filter>
     </ClCompile>
-    <ClCompile Include="..\CocoStudio\ActionTimeline\CCNodeCache.cpp">
+    <ClCompile Include="..\CocoStudio\ActionTimeline\CCTimeLine.cpp">
       <Filter>CocoStudio\ActionTimeline</Filter>
     </ClCompile>
-    <ClCompile Include="..\CocoStudio\ActionTimeline\CCTimeLine.cpp">
+    <ClCompile Include="..\CocoStudio\ActionTimeline\CCNodeReader.cpp">
       <Filter>CocoStudio\ActionTimeline</Filter>
     </ClCompile>
   </ItemGroup>
@@ -985,13 +985,13 @@
     <ClInclude Include="..\CocoStudio\ActionTimeline\CCFrame.h">
       <Filter>CocoStudio\ActionTimeline</Filter>
     </ClInclude>
-    <ClInclude Include="..\CocoStudio\ActionTimeline\CCNodeCache.h">
-      <Filter>CocoStudio\ActionTimeline</Filter>
-    </ClInclude>
     <ClInclude Include="..\CocoStudio\ActionTimeline\CCTimeLine.h">
       <Filter>CocoStudio\ActionTimeline</Filter>
     </ClInclude>
     <ClInclude Include="..\CocoStudio\ActionTimeline\CCTimelineMacro.h">
+      <Filter>CocoStudio\ActionTimeline</Filter>
+    </ClInclude>
+    <ClInclude Include="..\CocoStudio\ActionTimeline\CCNodeReader.h">
       <Filter>CocoStudio\ActionTimeline</Filter>
     </ClInclude>
   </ItemGroup>

--- a/extensions/proj.win32/libExtensions.vcxproj.filters
+++ b/extensions/proj.win32/libExtensions.vcxproj.filters
@@ -100,6 +100,9 @@
     <Filter Include="CocoStudio\Reader\WidgetReader">
       <UniqueIdentifier>{d0949a0d-a150-443d-9b5a-84d8e367d5e0}</UniqueIdentifier>
     </Filter>
+    <Filter Include="CocoStudio\ActionTimeline">
+      <UniqueIdentifier>{106a267f-faac-4b7f-92a9-fa7eb1ea0abd}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\GUI\CCScrollView\CCScrollView.cpp">
@@ -526,6 +529,21 @@
       <Filter>CocoStudio\GUI\UIWidgets</Filter>
     </ClCompile>
     <ClCompile Include="pch.cpp" />
+    <ClCompile Include="..\CocoStudio\ActionTimeline\CCActionTimeline.cpp">
+      <Filter>CocoStudio\ActionTimeline</Filter>
+    </ClCompile>
+    <ClCompile Include="..\CocoStudio\ActionTimeline\CCActionTimelineCache.cpp">
+      <Filter>CocoStudio\ActionTimeline</Filter>
+    </ClCompile>
+    <ClCompile Include="..\CocoStudio\ActionTimeline\CCFrame.cpp">
+      <Filter>CocoStudio\ActionTimeline</Filter>
+    </ClCompile>
+    <ClCompile Include="..\CocoStudio\ActionTimeline\CCNodeCache.cpp">
+      <Filter>CocoStudio\ActionTimeline</Filter>
+    </ClCompile>
+    <ClCompile Include="..\CocoStudio\ActionTimeline\CCTimeLine.cpp">
+      <Filter>CocoStudio\ActionTimeline</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\GUI\CCScrollView\CCScrollView.h">
@@ -958,6 +976,24 @@
     </ClInclude>
     <ClInclude Include="..\ExtensionExport.h" />
     <ClInclude Include="pch.h" />
+    <ClInclude Include="..\CocoStudio\ActionTimeline\CCActionTimeline.h">
+      <Filter>CocoStudio\ActionTimeline</Filter>
+    </ClInclude>
+    <ClInclude Include="..\CocoStudio\ActionTimeline\CCActionTimelineCache.h">
+      <Filter>CocoStudio\ActionTimeline</Filter>
+    </ClInclude>
+    <ClInclude Include="..\CocoStudio\ActionTimeline\CCFrame.h">
+      <Filter>CocoStudio\ActionTimeline</Filter>
+    </ClInclude>
+    <ClInclude Include="..\CocoStudio\ActionTimeline\CCNodeCache.h">
+      <Filter>CocoStudio\ActionTimeline</Filter>
+    </ClInclude>
+    <ClInclude Include="..\CocoStudio\ActionTimeline\CCTimeLine.h">
+      <Filter>CocoStudio\ActionTimeline</Filter>
+    </ClInclude>
+    <ClInclude Include="..\CocoStudio\ActionTimeline\CCTimelineMacro.h">
+      <Filter>CocoStudio\ActionTimeline</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\spine\Animation.h">

--- a/samples/Cpp/TestCpp/Android.mk
+++ b/samples/Cpp/TestCpp/Android.mk
@@ -60,6 +60,7 @@ Classes/ExtensionsTest/EditBoxTest/EditBoxTest.cpp \
 Classes/ExtensionsTest/TableViewTest/TableViewTestScene.cpp \
 Classes/ExtensionsTest/TableViewTest/CustomTableViewCell.cpp \
 Classes/ExtensionsTest/CocoStudioArmatureTest/ArmatureScene.cpp \
+Classes/ExtensionsTest/CocoStudioActionTimelineTest/ActionTimelineTestScene.cpp \
 Classes/ExtensionsTest/CocoStudioComponentsTest/ComponentsTestScene.cpp \
 Classes/ExtensionsTest/CocoStudioComponentsTest/EnemyController.cpp \
 Classes/ExtensionsTest/CocoStudioComponentsTest/GameOverScene.cpp \

--- a/samples/Cpp/TestCpp/Classes/ExtensionsTest/CocoStudioActionTimelineTest/ActionTimelineTestScene.cpp
+++ b/samples/Cpp/TestCpp/Classes/ExtensionsTest/CocoStudioActionTimelineTest/ActionTimelineTestScene.cpp
@@ -1,0 +1,184 @@
+#include "ActionTimelineTestScene.h"
+#include "../../testResource.h"
+
+using namespace cocos2d;
+using namespace cocos2d::extension;
+
+CCLayer *NextTimelineTest();
+CCLayer *BackTimelineTest();
+CCLayer *RestartTimelineTest();
+
+static int s_nActionIdx = -1;
+
+
+CCLayer *CreateTimelineLayer(int index)
+{
+    CCLayer *pLayer = NULL;
+    switch(index)
+    {
+    case TEST_ACTION_TIMELINE:
+        pLayer = new TestActionTimeline();
+        break;
+    default:
+        break;
+    }
+
+    return pLayer;
+}
+
+
+CCLayer *NextTimelineTest()
+{
+    ++s_nActionIdx;
+    s_nActionIdx = s_nActionIdx % TEST_ACTION_LAYER_COUNT;
+
+    CCLayer *pLayer = CreateTimelineLayer(s_nActionIdx);
+    pLayer->autorelease();
+
+    return pLayer;
+}
+
+CCLayer *BackTimelineTest()
+{
+    --s_nActionIdx;
+    if( s_nActionIdx < 0 )
+        s_nActionIdx += TEST_ACTION_LAYER_COUNT;
+
+    CCLayer *pLayer = CreateTimelineLayer(s_nActionIdx);
+    pLayer->autorelease();
+
+    return pLayer;
+}
+
+CCLayer *RestartTimelineTest()
+{
+    CCLayer *pLayer = CreateTimelineLayer(s_nActionIdx);
+    pLayer->autorelease();
+
+    return pLayer;
+}
+
+
+TimelineTestScene::TimelineTestScene(bool bPortrait)
+{
+    TestScene::init();
+
+    CCSprite *bg = CCSprite::create("armature/bg.jpg");
+    bg->setPosition(VisibleRect::center());
+
+    float scaleX = VisibleRect::getVisibleRect().size.width / bg->getContentSize().width;
+    float scaleY = VisibleRect::getVisibleRect().size.height / bg->getContentSize().height;
+
+    bg->setScaleX(scaleX);
+    bg->setScaleY(scaleY);
+
+    addChild(bg);
+}
+void TimelineTestScene::runThisTest()
+{
+    s_nActionIdx = -1;
+    addChild(NextTimelineTest());
+
+    CCDirector::sharedDirector()->replaceScene(this);
+}
+void TimelineTestScene::MainMenuCallback(CCObject *pSender)
+{
+    TestScene::MainMenuCallback(pSender);
+
+    removeAllChildren();
+    CCArmatureDataManager::purge();
+}
+
+
+
+void TimelineTestLayer::onEnter()
+{
+    CCLayer::onEnter();
+
+    // add title and subtitle
+    std::string str = title();
+    const char *pTitle = str.c_str();
+    CCLabelTTF *label = CCLabelTTF::create(pTitle, "Arial", 18);
+    label->setColor(ccc3(0, 0, 0));
+    addChild(label, 1, 10000);
+    label->setPosition( ccp(VisibleRect::center().x, VisibleRect::top().y - 30) );
+
+    std::string strSubtitle = subtitle();
+    if( ! strSubtitle.empty() )
+    {
+        CCLabelTTF *l = CCLabelTTF::create(strSubtitle.c_str(), "Arial", 18);
+        l->setColor(ccc3(0, 0, 0));
+        addChild(l, 1, 10001);
+        l->setPosition( ccp(VisibleRect::center().x, VisibleRect::top().y - 60) );
+    }
+
+    // add menu
+    backItem = CCMenuItemImage::create(s_pPathB1, s_pPathB2, this, menu_selector(TimelineTestLayer::backCallback) );
+    restartItem = CCMenuItemImage::create(s_pPathR1, s_pPathR2, this, menu_selector(TimelineTestLayer::restartCallback) );
+    nextItem = CCMenuItemImage::create(s_pPathF1, s_pPathF2, this, menu_selector(TimelineTestLayer::nextCallback) );
+
+    CCMenu *menu = CCMenu::create(backItem, restartItem, nextItem, NULL);
+
+    menu->setPosition(CCPointZero);
+    backItem->setPosition(ccp(VisibleRect::center().x - restartItem->getContentSize().width * 2, VisibleRect::bottom().y + restartItem->getContentSize().height / 2));
+    restartItem->setPosition(ccp(VisibleRect::center().x, VisibleRect::bottom().y + restartItem->getContentSize().height / 2));
+    nextItem->setPosition(ccp(VisibleRect::center().x + restartItem->getContentSize().width * 2, VisibleRect::bottom().y + restartItem->getContentSize().height / 2));
+
+    addChild(menu, 100);
+
+    setShaderProgram(CCShaderCache::sharedShaderCache()->programForKey(kCCShader_PositionTextureColor));
+
+}
+void TimelineTestLayer::onExit()
+{
+    removeAllChildren();
+
+    backItem = restartItem = nextItem = NULL;
+}
+
+std::string TimelineTestLayer::title()
+{
+    return "CSArmature Test Bed";
+}
+std::string TimelineTestLayer::subtitle()
+{
+    return "";
+}
+
+void TimelineTestLayer::restartCallback(CCObject *pSender)
+{
+    CCScene *s = new TimelineTestScene();
+    s->addChild( RestartTimelineTest() );
+    CCDirector::sharedDirector()->replaceScene(s);
+    s->release();
+}
+void TimelineTestLayer::nextCallback(CCObject *pSender)
+{
+    CCScene *s = new TimelineTestScene();
+    s->addChild( NextTimelineTest() );
+    CCDirector::sharedDirector()->replaceScene(s);
+    s->release();
+}
+void TimelineTestLayer::backCallback(CCObject *pSender)
+{
+    CCScene *s = new TimelineTestScene();
+    s->addChild( BackTimelineTest() );
+    CCDirector::sharedDirector()->replaceScene(s);
+    s->release();
+}
+void TimelineTestLayer::draw()
+{
+    CCLayer::draw();
+}
+
+
+void TestActionTimeline::onEnter()
+{
+    TimelineTestLayer::onEnter();
+
+}
+
+std::string TestActionTimeline::title()
+{
+    return "Test Asynchronous Loading";
+}

--- a/samples/Cpp/TestCpp/Classes/ExtensionsTest/CocoStudioActionTimelineTest/ActionTimelineTestScene.cpp
+++ b/samples/Cpp/TestCpp/Classes/ExtensionsTest/CocoStudioActionTimelineTest/ActionTimelineTestScene.cpp
@@ -3,6 +3,7 @@
 
 using namespace cocos2d;
 using namespace cocos2d::extension;
+using namespace cocostudio::timeline;
 
 CCLayer *NextTimelineTest();
 CCLayer *BackTimelineTest();
@@ -176,9 +177,21 @@ void TestActionTimeline::onEnter()
 {
     TimelineTestLayer::onEnter();
 
+    CCSpriteFrameCache::sharedSpriteFrameCache()->addSpriteFramesWithFile("armature/Cowboy0.plist", "armature/Cowboy0.png");
+
+    CCNode* node = NodeReader::getInstance()->createNode("ActionTimeline/boy_1.ExportJson");
+    ActionTimeline* action = ActionTimelineCache::getInstance()->createAction("ActionTimeline/boy_1.ExportJson");
+
+    node->runAction(action);
+    action->gotoFrameAndPlay(0, 60, true);
+
+    node->setScale(0.4f);
+    node->setPosition(0,0);
+
+    addChild(node);
 }
 
 std::string TestActionTimeline::title()
 {
-    return "Test Asynchronous Loading";
+    return "Test ActionTimeline";
 }

--- a/samples/Cpp/TestCpp/Classes/ExtensionsTest/CocoStudioActionTimelineTest/ActionTimelineTestScene.h
+++ b/samples/Cpp/TestCpp/Classes/ExtensionsTest/CocoStudioActionTimelineTest/ActionTimelineTestScene.h
@@ -1,0 +1,55 @@
+#ifndef __ACTION_TIMELINE_SCENE_H__
+#define __ACTION_TIMELINE_SCENE_H__
+
+#include "cocos2d.h"
+#include "cocos-ext.h"
+#include "../../VisibleRect.h"
+#include "../../testBasic.h"
+
+class TimelineTestScene : public TestScene
+{
+public: 
+    TimelineTestScene(bool bPortrait = false);
+
+    virtual void runThisTest();
+
+    // The CallBack for back to the main menu scene
+    virtual void MainMenuCallback(CCObject* pSender);
+};
+
+enum {
+    TEST_ACTION_TIMELINE = 0,
+
+    TEST_ACTION_LAYER_COUNT
+};
+
+class TimelineTestLayer : public CCLayer
+{
+public:
+    virtual void onEnter();
+    virtual void onExit();
+
+    virtual std::string title();
+    virtual std::string subtitle();
+
+    virtual void restartCallback(CCObject* pSender);
+    virtual void nextCallback(CCObject* pSender);
+    virtual void backCallback(CCObject* pSender);
+
+    virtual void draw();
+
+protected:
+    CCMenuItemImage *restartItem;
+    CCMenuItemImage *nextItem;
+    CCMenuItemImage *backItem;
+};
+
+
+class TestActionTimeline : public TimelineTestLayer
+{
+public:
+    virtual void onEnter();
+    virtual std::string title();
+};
+
+#endif  // __ACTION_TIMELINE_SCENE_H__

--- a/samples/Cpp/TestCpp/Classes/ExtensionsTest/ExtensionsTest.cpp
+++ b/samples/Cpp/TestCpp/Classes/ExtensionsTest/ExtensionsTest.cpp
@@ -11,6 +11,7 @@
 #include "CocoStudioComponentsTest/ComponentsTestScene.h"
 #include "CocoStudioSceneTest/SceneEditorTest.h"
 #include "CocoStudioGUITest/CocoStudioGUITest.h"
+#include "CocoStudioActionTimelineTest/ActionTimelineTestScene.h"
 
 #if (CC_TARGET_PLATFORM == CC_PLATFORM_IOS) || (CC_TARGET_PLATFORM == CC_PLATFORM_ANDROID) || (CC_TARGET_PLATFORM == CC_PLATFORM_WIN32) || (CC_TARGET_PLATFORM == CC_PLATFORM_WP8)
 #include "NetworkTest/WebSocketTest.h"
@@ -43,6 +44,7 @@ enum
 	TEST_ARMATURE,
     TEST_SCENEEDITOR,
     TEST_COCOSGUI,
+    TEST_ACTIONTIMELINE,
     TEST_MAX_COUNT,
 };
 
@@ -64,7 +66,8 @@ static const std::string testsName[TEST_MAX_COUNT] =
     "CocoStudioComponentsTest",
 	"CocoStudioArmatureTest",
     "CocoStudioSceneTest",
-    "CocoStudioGUITest"
+    "CocoStudioGUITest",
+    "CocoStudioActionTimelineTest"
 };
 
 ////////////////////////////////////////////////////////
@@ -185,6 +188,12 @@ void ExtensionsMainLayer::menuCallback(CCObject* pSender)
             pScene->release();
 		}
             break;
+        case TEST_ACTIONTIMELINE:
+            {
+                TimelineTestScene* pScene = new TimelineTestScene();
+                pScene->runThisTest();
+                pScene->release();
+            }
     default:
         break;
     }

--- a/samples/Cpp/TestCpp/Resources/ActionTimeline/boy_1.ExportJson
+++ b/samples/Cpp/TestCpp/Resources/ActionTimeline/boy_1.ExportJson
@@ -1,0 +1,2112 @@
+{
+  "version": "1.3.0.1",
+  "designWidth": 1000,
+  "designHeight": 1024,
+  "dataScale": 1.0,
+  "textures": [
+    "boy0.plist"
+  ],
+  "texturesPng": [
+    "boy0.png"
+  ],
+  "nodeTree": {
+    "options": {
+      "$type": "EditorCommon.JsonModel.Component.GUI.RootGUISurrogate, EditorCommon",
+      "scaleX": 1.0,
+      "scaleY": 1.0,
+      "visible": true,
+      "width": 0.0,
+      "height": 0.0,
+      "name": "Scene",
+      "classname": "Node"
+    },
+    "children": [
+      {
+        "options": {
+          "$type": "EditorCommon.JsonModel.Component.GUI.SpriteSurrogate, EditorCommon",
+          "fileName": "testAnimationResource/6.png",
+          "fileNameData": {
+            "resourceType": 1,
+            "path": "testAnimationResource/6.png",
+            "plistFile": ""
+          },
+          "x": 601.0,
+          "y": 260.0,
+          "scaleX": 1.0,
+          "scaleY": 1.0,
+          "rotation": 0.0,
+          "flipX": false,
+          "flipY": false,
+          "colorR": 255,
+          "colorG": 255,
+          "colorB": 255,
+          "opacity": 255,
+          "visible": true,
+          "ZOrder": 0,
+          "classType": "Sprite",
+          "width": 0.0,
+          "height": 0.0,
+          "actionTag": 440279615,
+          "tag": 5,
+          "anchorPointX": 0.34,
+          "anchorPointY": 0.07,
+          "name": "Sprite_4",
+          "classname": "Sprite"
+        },
+        "children": [
+          {
+            "options": {
+              "$type": "EditorCommon.JsonModel.Component.GUI.SpriteSurrogate, EditorCommon",
+              "fileName": "testAnimationResource/8.png",
+              "fileNameData": {
+                "resourceType": 1,
+                "path": "testAnimationResource/8.png",
+                "plistFile": ""
+              },
+              "x": 73.0,
+              "y": 148.0,
+              "scaleX": 1.0,
+              "scaleY": 1.0,
+              "rotation": -5.71439838,
+              "flipX": false,
+              "flipY": false,
+              "colorR": 255,
+              "colorG": 255,
+              "colorB": 255,
+              "opacity": 255,
+              "visible": true,
+              "ZOrder": -2,
+              "classType": "Sprite",
+              "width": 0.0,
+              "height": 0.0,
+              "actionTag": 749769307,
+              "tag": 3,
+              "anchorPointX": 0.77,
+              "anchorPointY": 0.8,
+              "name": "Sprite_2",
+              "classname": "Sprite"
+            },
+            "children": [
+              {
+                "options": {
+                  "$type": "EditorCommon.JsonModel.Component.GUI.SpriteSurrogate, EditorCommon",
+                  "fileName": "testAnimationResource/3.png",
+                  "fileNameData": {
+                    "resourceType": 1,
+                    "path": "testAnimationResource/3.png",
+                    "plistFile": ""
+                  },
+                  "x": 31.0,
+                  "y": 26.0,
+                  "scaleX": 1.0,
+                  "scaleY": 1.0,
+                  "rotation": -4.085081,
+                  "flipX": false,
+                  "flipY": false,
+                  "colorR": 255,
+                  "colorG": 255,
+                  "colorB": 255,
+                  "opacity": 255,
+                  "visible": true,
+                  "ZOrder": 0,
+                  "classType": "Sprite",
+                  "width": 0.0,
+                  "height": 0.0,
+                  "actionTag": 1042971898,
+                  "tag": 8,
+                  "anchorPointX": 0.5,
+                  "anchorPointY": 0.11,
+                  "name": "Sprite_7",
+                  "classname": "Sprite"
+                },
+                "children": [],
+                "name": null,
+                "classname": "Sprite"
+              }
+            ],
+            "name": null,
+            "classname": "Sprite"
+          },
+          {
+            "options": {
+              "$type": "EditorCommon.JsonModel.Component.GUI.SpriteSurrogate, EditorCommon",
+              "fileName": "testAnimationResource/5.png",
+              "fileNameData": {
+                "resourceType": 1,
+                "path": "testAnimationResource/5.png",
+                "plistFile": ""
+              },
+              "x": 142.0,
+              "y": 56.0,
+              "scaleX": 1.0,
+              "scaleY": 1.0,
+              "rotation": 0.0,
+              "flipX": false,
+              "flipY": false,
+              "colorR": 255,
+              "colorG": 255,
+              "colorB": 255,
+              "opacity": 255,
+              "visible": true,
+              "ZOrder": -2,
+              "classType": "Sprite",
+              "width": 0.0,
+              "height": 0.0,
+              "actionTag": 718719067,
+              "tag": 6,
+              "anchorPointX": 0.7,
+              "anchorPointY": 0.79,
+              "name": "Sprite_5",
+              "classname": "Sprite"
+            },
+            "children": [
+              {
+                "options": {
+                  "$type": "EditorCommon.JsonModel.Component.GUI.SpriteSurrogate, EditorCommon",
+                  "fileName": "testAnimationResource/4.png",
+                  "fileNameData": {
+                    "resourceType": 1,
+                    "path": "testAnimationResource/4.png",
+                    "plistFile": ""
+                  },
+                  "x": 58.0,
+                  "y": 4.0,
+                  "scaleX": 1.0,
+                  "scaleY": 1.0,
+                  "rotation": -1.14092076,
+                  "flipX": false,
+                  "flipY": false,
+                  "colorR": 255,
+                  "colorG": 255,
+                  "colorB": 255,
+                  "opacity": 255,
+                  "visible": true,
+                  "ZOrder": 0,
+                  "classType": "Sprite",
+                  "width": 0.0,
+                  "height": 0.0,
+                  "actionTag": 426784833,
+                  "tag": 7,
+                  "anchorPointX": 0.67,
+                  "anchorPointY": 0.72,
+                  "name": "Sprite_6",
+                  "classname": "Sprite"
+                },
+                "children": [],
+                "name": null,
+                "classname": "Sprite"
+              }
+            ],
+            "name": null,
+            "classname": "Sprite"
+          },
+          {
+            "options": {
+              "$type": "EditorCommon.JsonModel.Component.GUI.SpriteSurrogate, EditorCommon",
+              "fileName": "testAnimationResource/2.png",
+              "fileNameData": {
+                "resourceType": 1,
+                "path": "testAnimationResource/2.png",
+                "plistFile": ""
+              },
+              "x": 194.0,
+              "y": 50.0,
+              "scaleX": 1.0,
+              "scaleY": 1.0,
+              "rotation": 0.0,
+              "flipX": false,
+              "flipY": false,
+              "colorR": 255,
+              "colorG": 255,
+              "colorB": 255,
+              "opacity": 255,
+              "visible": true,
+              "ZOrder": 0,
+              "classType": "Sprite",
+              "width": 0.0,
+              "height": 0.0,
+              "actionTag": 716668964,
+              "tag": 9,
+              "anchorPointX": 0.42,
+              "anchorPointY": 0.75,
+              "name": "Sprite_8",
+              "classname": "Sprite"
+            },
+            "children": [
+              {
+                "options": {
+                  "$type": "EditorCommon.JsonModel.Component.GUI.SpriteSurrogate, EditorCommon",
+                  "fileName": "testAnimationResource/7.png",
+                  "fileNameData": {
+                    "resourceType": 1,
+                    "path": "testAnimationResource/7.png",
+                    "plistFile": ""
+                  },
+                  "x": 165.0,
+                  "y": 12.0,
+                  "scaleX": 1.0,
+                  "scaleY": 1.0,
+                  "rotation": 2.00441027,
+                  "flipX": false,
+                  "flipY": false,
+                  "colorR": 255,
+                  "colorG": 255,
+                  "colorB": 255,
+                  "opacity": 255,
+                  "visible": true,
+                  "ZOrder": 0,
+                  "classType": "Sprite",
+                  "width": 0.0,
+                  "height": 0.0,
+                  "actionTag": 453863477,
+                  "tag": 4,
+                  "anchorPointX": 0.5,
+                  "anchorPointY": 0.77,
+                  "name": "Sprite_3",
+                  "classname": "Sprite"
+                },
+                "children": [],
+                "name": null,
+                "classname": "Sprite"
+              }
+            ],
+            "name": null,
+            "classname": "Sprite"
+          },
+          {
+            "options": {
+              "$type": "EditorCommon.JsonModel.Component.GUI.SpriteSurrogate, EditorCommon",
+              "fileName": "testAnimationResource/hat.png",
+              "fileNameData": {
+                "resourceType": 1,
+                "path": "testAnimationResource/hat.png",
+                "plistFile": ""
+              },
+              "x": 141.0,
+              "y": 297.0,
+              "scaleX": 1.0,
+              "scaleY": 1.0,
+              "rotation": 4.71490049,
+              "flipX": false,
+              "flipY": false,
+              "colorR": 255,
+              "colorG": 255,
+              "colorB": 255,
+              "opacity": 255,
+              "visible": true,
+              "ZOrder": 0,
+              "classType": "Sprite",
+              "width": 0.0,
+              "height": 0.0,
+              "actionTag": 729381978,
+              "tag": 10,
+              "anchorPointX": 0.77,
+              "anchorPointY": 0.25,
+              "name": "Sprite_9",
+              "classname": "Sprite"
+            },
+            "children": [],
+            "name": null,
+            "classname": "Sprite"
+          },
+          {
+            "options": {
+              "$type": "EditorCommon.JsonModel.Component.GUI.SpriteSurrogate, EditorCommon",
+              "fileName": "testAnimationResource/1.png",
+              "fileNameData": {
+                "resourceType": 1,
+                "path": "testAnimationResource/1.png",
+                "plistFile": ""
+              },
+              "x": 280.0,
+              "y": 148.0,
+              "scaleX": 1.0,
+              "scaleY": 1.0,
+              "rotation": 0.0,
+              "flipX": false,
+              "flipY": false,
+              "colorR": 255,
+              "colorG": 255,
+              "colorB": 255,
+              "opacity": 255,
+              "visible": true,
+              "ZOrder": 0,
+              "classType": "Sprite",
+              "width": 0.0,
+              "height": 0.0,
+              "actionTag": 647613269,
+              "tag": 2,
+              "anchorPointX": 0.22,
+              "anchorPointY": 0.86,
+              "name": "Sprite_1",
+              "classname": "Sprite"
+            },
+            "children": [],
+            "name": null,
+            "classname": "Sprite"
+          }
+        ],
+        "name": null,
+        "classname": "Sprite"
+      }
+    ],
+    "name": null,
+    "classname": "Node"
+  },
+  "action": {
+    "duration": 130,
+    "speed": 1.0,
+    "timelines": [
+      {
+        "frameType": "PositionFrame",
+        "actionTag": 440279615,
+        "frames": [
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 601.0,
+            "y": 260.0,
+            "frameIndex": 0,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 601.0,
+            "y": 260.0,
+            "frameIndex": 60,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 601.0,
+            "y": 302.0,
+            "frameIndex": 70,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 601.0,
+            "y": 276.0,
+            "frameIndex": 90,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 601.0,
+            "y": 302.0,
+            "frameIndex": 100,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 601.0,
+            "y": 266.0,
+            "frameIndex": 120,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 601.0,
+            "y": 302.0,
+            "frameIndex": 130,
+            "tween": true
+          }
+        ]
+      },
+      {
+        "frameType": "ScaleFrame",
+        "actionTag": 440279615,
+        "frames": [
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 1.0,
+            "y": 1.0,
+            "frameIndex": 0,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 1.0,
+            "y": 1.0,
+            "frameIndex": 60,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 1.0,
+            "y": 1.0,
+            "frameIndex": 100,
+            "tween": true
+          }
+        ]
+      },
+      {
+        "frameType": "RotationSkewFrame",
+        "actionTag": 440279615,
+        "frames": [
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 0.0,
+            "y": 0.0,
+            "frameIndex": 0,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 0.0,
+            "y": 0.0,
+            "frameIndex": 60,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 0.272187382,
+            "y": 0.272187382,
+            "frameIndex": 70,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": -3.800404,
+            "y": -3.800404,
+            "frameIndex": 80,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": -5.22106457,
+            "y": -5.22106457,
+            "frameIndex": 90,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 0.0,
+            "y": 0.0,
+            "frameIndex": 100,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 4.140224,
+            "y": 4.140224,
+            "frameIndex": 110,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 6.63524,
+            "y": 6.63524,
+            "frameIndex": 120,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 0.272187382,
+            "y": 0.272187382,
+            "frameIndex": 130,
+            "tween": true
+          }
+        ]
+      },
+      {
+        "frameType": "PositionFrame",
+        "actionTag": 749769307,
+        "frames": [
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 72.0,
+            "y": 143.0,
+            "frameIndex": 0,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 74.0,
+            "y": 150.0,
+            "frameIndex": 30,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 72.0,
+            "y": 143.0,
+            "frameIndex": 60,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 85.0,
+            "y": 143.0,
+            "frameIndex": 70,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 74.0,
+            "y": 133.0,
+            "frameIndex": 80,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 74.0,
+            "y": 133.0,
+            "frameIndex": 90,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 73.0,
+            "y": 135.0,
+            "frameIndex": 100,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 77.0,
+            "y": 136.0,
+            "frameIndex": 110,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 80.0,
+            "y": 141.0,
+            "frameIndex": 120,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 85.0,
+            "y": 143.0,
+            "frameIndex": 130,
+            "tween": true
+          }
+        ]
+      },
+      {
+        "frameType": "ScaleFrame",
+        "actionTag": 749769307,
+        "frames": [
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 1.0,
+            "y": 1.0,
+            "frameIndex": 0,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 1.0,
+            "y": 1.0,
+            "frameIndex": 60,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 1.0,
+            "y": 1.0,
+            "frameIndex": 80,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 1.0,
+            "y": 1.0,
+            "frameIndex": 90,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 1.0,
+            "y": 1.0,
+            "frameIndex": 100,
+            "tween": true
+          }
+        ]
+      },
+      {
+        "frameType": "RotationSkewFrame",
+        "actionTag": 749769307,
+        "frames": [
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 0.0,
+            "y": 0.0,
+            "frameIndex": 0,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": -7.453563,
+            "y": -7.453563,
+            "frameIndex": 30,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 0.0,
+            "y": 0.0,
+            "frameIndex": 60,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": -45.5398178,
+            "y": -45.5398178,
+            "frameIndex": 70,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": -32.180584,
+            "y": -32.180584,
+            "frameIndex": 80,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": -15.1353874,
+            "y": -15.1353874,
+            "frameIndex": 90,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": -28.6575718,
+            "y": -28.6575718,
+            "frameIndex": 100,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": -53.086937,
+            "y": -53.086937,
+            "frameIndex": 110,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": -84.56819,
+            "y": -84.56819,
+            "frameIndex": 120,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": -45.5398178,
+            "y": -45.5398178,
+            "frameIndex": 130,
+            "tween": true
+          }
+        ]
+      },
+      {
+        "frameType": "ZOrderFrame",
+        "actionTag": 749769307,
+        "frames": [
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLineIntFrameSurrogate, EditorCommon",
+            "value": -2,
+            "frameIndex": 0,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLineIntFrameSurrogate, EditorCommon",
+            "value": -2,
+            "frameIndex": 60,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLineIntFrameSurrogate, EditorCommon",
+            "value": -2,
+            "frameIndex": 70,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLineIntFrameSurrogate, EditorCommon",
+            "value": -2,
+            "frameIndex": 80,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLineIntFrameSurrogate, EditorCommon",
+            "value": -2,
+            "frameIndex": 90,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLineIntFrameSurrogate, EditorCommon",
+            "value": -2,
+            "frameIndex": 100,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLineIntFrameSurrogate, EditorCommon",
+            "value": -2,
+            "frameIndex": 130,
+            "tween": true
+          }
+        ]
+      },
+      {
+        "frameType": "PositionFrame",
+        "actionTag": 1042971898,
+        "frames": [
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 38.0,
+            "y": 20.0,
+            "frameIndex": 0,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 30.0,
+            "y": 28.0,
+            "frameIndex": 30,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 38.0,
+            "y": 20.0,
+            "frameIndex": 60,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 24.0,
+            "y": 46.0,
+            "frameIndex": 70,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 26.0,
+            "y": 39.0,
+            "frameIndex": 80,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 23.0,
+            "y": 35.0,
+            "frameIndex": 90,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 34.0,
+            "y": 34.0,
+            "frameIndex": 100,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 22.0,
+            "y": 43.0,
+            "frameIndex": 110,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 33.0,
+            "y": 33.0,
+            "frameIndex": 120,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 24.0,
+            "y": 46.0,
+            "frameIndex": 130,
+            "tween": true
+          }
+        ]
+      },
+      {
+        "frameType": "ScaleFrame",
+        "actionTag": 1042971898,
+        "frames": [
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 1.0,
+            "y": 1.0,
+            "frameIndex": 0,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 1.0,
+            "y": 1.0,
+            "frameIndex": 60,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 1.0,
+            "y": 1.0,
+            "frameIndex": 80,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 1.0,
+            "y": 1.0,
+            "frameIndex": 90,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 1.0,
+            "y": 1.0,
+            "frameIndex": 100,
+            "tween": true
+          }
+        ]
+      },
+      {
+        "frameType": "RotationSkewFrame",
+        "actionTag": 1042971898,
+        "frames": [
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 0.0,
+            "y": 0.0,
+            "frameIndex": 0,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": -5.32836628,
+            "y": -5.32836628,
+            "frameIndex": 30,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 0.0,
+            "y": 0.0,
+            "frameIndex": 60,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": -76.14927,
+            "y": -76.14927,
+            "frameIndex": 70,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": -79.7780762,
+            "y": -79.7780762,
+            "frameIndex": 80,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": -86.0518951,
+            "y": -86.0518951,
+            "frameIndex": 90,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": -88.36781,
+            "y": -88.36781,
+            "frameIndex": 100,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": -66.165184,
+            "y": -66.165184,
+            "frameIndex": 110,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": -39.37061,
+            "y": -39.37061,
+            "frameIndex": 120,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": -76.14927,
+            "y": -76.14927,
+            "frameIndex": 130,
+            "tween": true
+          }
+        ]
+      },
+      {
+        "frameType": "PositionFrame",
+        "actionTag": 718719067,
+        "frames": [
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 144.0,
+            "y": 50.0,
+            "frameIndex": 0,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 142.0,
+            "y": 59.0,
+            "frameIndex": 30,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 144.0,
+            "y": 50.0,
+            "frameIndex": 60,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 202.0,
+            "y": 37.0,
+            "frameIndex": 70,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 194.0,
+            "y": 23.0,
+            "frameIndex": 80,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 203.0,
+            "y": 7.0,
+            "frameIndex": 90,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 177.0,
+            "y": 80.0,
+            "frameIndex": 100,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 137.0,
+            "y": 82.0,
+            "frameIndex": 110,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 125.0,
+            "y": 22.0,
+            "frameIndex": 120,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 202.0,
+            "y": 37.0,
+            "frameIndex": 130,
+            "tween": true
+          }
+        ]
+      },
+      {
+        "frameType": "ScaleFrame",
+        "actionTag": 718719067,
+        "frames": [
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 1.0,
+            "y": 1.0,
+            "frameIndex": 0,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 1.0,
+            "y": 1.0,
+            "frameIndex": 60,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 1.0,
+            "y": 1.0,
+            "frameIndex": 80,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 1.0,
+            "y": 1.0,
+            "frameIndex": 90,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 1.0,
+            "y": 1.0,
+            "frameIndex": 100,
+            "tween": true
+          }
+        ]
+      },
+      {
+        "frameType": "RotationSkewFrame",
+        "actionTag": 718719067,
+        "frames": [
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 0.0,
+            "y": 0.0,
+            "frameIndex": 0,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 0.0,
+            "y": 0.0,
+            "frameIndex": 60,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": -30.4871216,
+            "y": -30.4871216,
+            "frameIndex": 70,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": -55.49503,
+            "y": -55.49503,
+            "frameIndex": 80,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": -65.75558,
+            "y": -65.75558,
+            "frameIndex": 90,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": -39.3511925,
+            "y": -39.3511925,
+            "frameIndex": 100,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": -3.07847571,
+            "y": -3.07847571,
+            "frameIndex": 110,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 12.323699,
+            "y": 12.323699,
+            "frameIndex": 120,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": -30.4871216,
+            "y": -30.4871216,
+            "frameIndex": 130,
+            "tween": true
+          }
+        ]
+      },
+      {
+        "frameType": "ZOrderFrame",
+        "actionTag": 718719067,
+        "frames": [
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLineIntFrameSurrogate, EditorCommon",
+            "value": -2,
+            "frameIndex": 0,
+            "tween": true
+          }
+        ]
+      },
+      {
+        "frameType": "PositionFrame",
+        "actionTag": 426784833,
+        "frames": [
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 60.0,
+            "y": -5.0,
+            "frameIndex": 0,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 58.0,
+            "y": 8.0,
+            "frameIndex": 30,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 60.0,
+            "y": -5.0,
+            "frameIndex": 60,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 44.0,
+            "y": -10.0,
+            "frameIndex": 70,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 36.0,
+            "y": 10.0,
+            "frameIndex": 80,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 42.0,
+            "y": 8.0,
+            "frameIndex": 90,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 63.0,
+            "y": 5.0,
+            "frameIndex": 100,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 79.0,
+            "y": 2.0,
+            "frameIndex": 110,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 77.0,
+            "y": -12.0,
+            "frameIndex": 120,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 44.0,
+            "y": -10.0,
+            "frameIndex": 130,
+            "tween": true
+          }
+        ]
+      },
+      {
+        "frameType": "ScaleFrame",
+        "actionTag": 426784833,
+        "frames": [
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 1.0,
+            "y": 1.0,
+            "frameIndex": 0,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 1.0,
+            "y": 1.0,
+            "frameIndex": 30,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 1.0,
+            "y": 1.0,
+            "frameIndex": 60,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 1.0,
+            "y": 1.0,
+            "frameIndex": 80,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 1.0,
+            "y": 1.0,
+            "frameIndex": 90,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 1.0,
+            "y": 1.0,
+            "frameIndex": 100,
+            "tween": true
+          }
+        ]
+      },
+      {
+        "frameType": "RotationSkewFrame",
+        "actionTag": 426784833,
+        "frames": [
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 0.0,
+            "y": 0.0,
+            "frameIndex": 0,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": -1.48815751,
+            "y": -1.48815751,
+            "frameIndex": 30,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 0.0,
+            "y": 0.0,
+            "frameIndex": 60,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 12.4439116,
+            "y": 12.4439116,
+            "frameIndex": 70,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 27.2269726,
+            "y": 27.2269726,
+            "frameIndex": 80,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 35.7791862,
+            "y": 35.7791862,
+            "frameIndex": 90,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 0.3896717,
+            "y": 0.3896717,
+            "frameIndex": 100,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": -19.0932655,
+            "y": -19.0932655,
+            "frameIndex": 110,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": -11.7843628,
+            "y": -11.7843628,
+            "frameIndex": 120,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 12.4439116,
+            "y": 12.4439116,
+            "frameIndex": 130,
+            "tween": true
+          }
+        ]
+      },
+      {
+        "frameType": "PositionFrame",
+        "actionTag": 716668964,
+        "frames": [
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 196.0,
+            "y": 44.0,
+            "frameIndex": 0,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 194.0,
+            "y": 53.0,
+            "frameIndex": 30,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 196.0,
+            "y": 44.0,
+            "frameIndex": 60,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 167.0,
+            "y": 31.0,
+            "frameIndex": 70,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 146.0,
+            "y": 8.0,
+            "frameIndex": 80,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 112.0,
+            "y": -6.0,
+            "frameIndex": 90,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 143.0,
+            "y": 10.0,
+            "frameIndex": 100,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 202.0,
+            "y": 32.0,
+            "frameIndex": 110,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 194.0,
+            "y": 28.0,
+            "frameIndex": 120,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 167.0,
+            "y": 31.0,
+            "frameIndex": 130,
+            "tween": true
+          }
+        ]
+      },
+      {
+        "frameType": "ScaleFrame",
+        "actionTag": 716668964,
+        "frames": [
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 1.0,
+            "y": 1.0,
+            "frameIndex": 0,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 1.0,
+            "y": 1.0,
+            "frameIndex": 60,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 1.0,
+            "y": 1.0,
+            "frameIndex": 80,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 1.0,
+            "y": 1.0,
+            "frameIndex": 90,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 1.0,
+            "y": 1.0,
+            "frameIndex": 100,
+            "tween": true
+          }
+        ]
+      },
+      {
+        "frameType": "RotationSkewFrame",
+        "actionTag": 716668964,
+        "frames": [
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 0.0,
+            "y": 0.0,
+            "frameIndex": 0,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 0.0,
+            "y": 0.0,
+            "frameIndex": 60,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 23.2254734,
+            "y": 23.2254734,
+            "frameIndex": 70,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 61.1631927,
+            "y": 61.1631927,
+            "frameIndex": 80,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 58.3439522,
+            "y": 58.3439522,
+            "frameIndex": 90,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 25.947691,
+            "y": 25.947691,
+            "frameIndex": 100,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": -2.07755661,
+            "y": -2.07755661,
+            "frameIndex": 110,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": -23.33069,
+            "y": -23.33069,
+            "frameIndex": 120,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 23.2254734,
+            "y": 23.2254734,
+            "frameIndex": 130,
+            "tween": true
+          }
+        ]
+      },
+      {
+        "frameType": "PositionFrame",
+        "actionTag": 453863477,
+        "frames": [
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 164.0,
+            "y": 9.0,
+            "frameIndex": 0,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 166.0,
+            "y": 14.0,
+            "frameIndex": 30,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 164.0,
+            "y": 9.0,
+            "frameIndex": 60,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 167.0,
+            "y": 41.0,
+            "frameIndex": 70,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 153.0,
+            "y": 49.0,
+            "frameIndex": 80,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 157.0,
+            "y": 44.0,
+            "frameIndex": 90,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 162.0,
+            "y": 19.0,
+            "frameIndex": 100,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 163.0,
+            "y": 15.0,
+            "frameIndex": 110,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 156.0,
+            "y": 13.0,
+            "frameIndex": 120,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 167.0,
+            "y": 41.0,
+            "frameIndex": 130,
+            "tween": true
+          }
+        ]
+      },
+      {
+        "frameType": "ScaleFrame",
+        "actionTag": 453863477,
+        "frames": [
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 1.0,
+            "y": 1.0,
+            "frameIndex": 0,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 1.0,
+            "y": 1.0,
+            "frameIndex": 30,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 1.0,
+            "y": 1.0,
+            "frameIndex": 60,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 1.0,
+            "y": 1.0,
+            "frameIndex": 80,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 1.0,
+            "y": 1.0,
+            "frameIndex": 90,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 1.0,
+            "y": 1.0,
+            "frameIndex": 100,
+            "tween": true
+          }
+        ]
+      },
+      {
+        "frameType": "RotationSkewFrame",
+        "actionTag": 453863477,
+        "frames": [
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 0.0,
+            "y": 0.0,
+            "frameIndex": 0,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 2.614448,
+            "y": 2.614448,
+            "frameIndex": 30,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 0.0,
+            "y": 0.0,
+            "frameIndex": 60,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": -47.04919,
+            "y": -47.04919,
+            "frameIndex": 70,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": -62.07396,
+            "y": -62.07396,
+            "frameIndex": 80,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": -33.3642273,
+            "y": -33.3642273,
+            "frameIndex": 90,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": -25.57315,
+            "y": -25.57315,
+            "frameIndex": 100,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": -19.1204987,
+            "y": -19.1204987,
+            "frameIndex": 110,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": -4.30311966,
+            "y": -4.30311966,
+            "frameIndex": 120,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": -47.04919,
+            "y": -47.04919,
+            "frameIndex": 130,
+            "tween": true
+          }
+        ]
+      },
+      {
+        "frameType": "PositionFrame",
+        "actionTag": 729381978,
+        "frames": [
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 137.0,
+            "y": 301.0,
+            "frameIndex": 0,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 143.0,
+            "y": 297.0,
+            "frameIndex": 30,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 137.0,
+            "y": 301.0,
+            "frameIndex": 60,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 146.0,
+            "y": 289.0,
+            "frameIndex": 70,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 149.0,
+            "y": 290.0,
+            "frameIndex": 80,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 146.0,
+            "y": 287.0,
+            "frameIndex": 90,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 148.0,
+            "y": 289.0,
+            "frameIndex": 100,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 147.0,
+            "y": 290.0,
+            "frameIndex": 110,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 148.0,
+            "y": 291.0,
+            "frameIndex": 120,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 146.0,
+            "y": 289.0,
+            "frameIndex": 130,
+            "tween": true
+          }
+        ]
+      },
+      {
+        "frameType": "ScaleFrame",
+        "actionTag": 729381978,
+        "frames": [
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 1.0,
+            "y": 1.0,
+            "frameIndex": 0,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 1.0,
+            "y": 1.0,
+            "frameIndex": 60,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 1.0,
+            "y": 1.0,
+            "frameIndex": 80,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 1.0,
+            "y": 1.0,
+            "frameIndex": 90,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 1.0,
+            "y": 1.0,
+            "frameIndex": 100,
+            "tween": true
+          }
+        ]
+      },
+      {
+        "frameType": "RotationSkewFrame",
+        "actionTag": 729381978,
+        "frames": [
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 0.0,
+            "y": 0.0,
+            "frameIndex": 0,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 6.1498704,
+            "y": 6.1498704,
+            "frameIndex": 30,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 0.0,
+            "y": 0.0,
+            "frameIndex": 60,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 11.1060257,
+            "y": 11.1060257,
+            "frameIndex": 70,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 11.1060257,
+            "y": 11.1060257,
+            "frameIndex": 80,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 11.1060257,
+            "y": 11.1060257,
+            "frameIndex": 90,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 11.1060257,
+            "y": 11.1060257,
+            "frameIndex": 100,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 11.1060257,
+            "y": 11.1060257,
+            "frameIndex": 130,
+            "tween": true
+          }
+        ]
+      },
+      {
+        "frameType": "PositionFrame",
+        "actionTag": 647613269,
+        "frames": [
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 282.0,
+            "y": 152.0,
+            "frameIndex": 0,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 280.0,
+            "y": 148.0,
+            "frameIndex": 30,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 282.0,
+            "y": 152.0,
+            "frameIndex": 60,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 287.0,
+            "y": 153.0,
+            "frameIndex": 70,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 277.0,
+            "y": 144.0,
+            "frameIndex": 80,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 274.0,
+            "y": 135.0,
+            "frameIndex": 90,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 279.0,
+            "y": 147.0,
+            "frameIndex": 100,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 281.0,
+            "y": 153.0,
+            "frameIndex": 110,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 288.0,
+            "y": 149.0,
+            "frameIndex": 120,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 287.0,
+            "y": 153.0,
+            "frameIndex": 130,
+            "tween": true
+          }
+        ]
+      },
+      {
+        "frameType": "ScaleFrame",
+        "actionTag": 647613269,
+        "frames": [
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 1.0,
+            "y": 1.0,
+            "frameIndex": 0,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 1.0,
+            "y": 1.0,
+            "frameIndex": 30,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 1.0,
+            "y": 1.0,
+            "frameIndex": 60,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 1.0,
+            "y": 1.0,
+            "frameIndex": 80,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 1.0,
+            "y": 1.0,
+            "frameIndex": 90,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 1.0,
+            "y": 1.0,
+            "frameIndex": 100,
+            "tween": true
+          }
+        ]
+      },
+      {
+        "frameType": "RotationSkewFrame",
+        "actionTag": 647613269,
+        "frames": [
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 0.0,
+            "y": 0.0,
+            "frameIndex": 0,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 0.0,
+            "y": 0.0,
+            "frameIndex": 30,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 0.0,
+            "y": 0.0,
+            "frameIndex": 60,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 20.6256847,
+            "y": 20.6256847,
+            "frameIndex": 70,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": -8.132871,
+            "y": -8.132871,
+            "frameIndex": 80,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": -17.91947,
+            "y": -17.91947,
+            "frameIndex": 90,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 3.91054678,
+            "y": 3.91054678,
+            "frameIndex": 100,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 15.3684883,
+            "y": 15.3684883,
+            "frameIndex": 110,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 34.9562759,
+            "y": 34.9562759,
+            "frameIndex": 120,
+            "tween": true
+          },
+          {
+            "$type": "EditorCommon.JsonModel.Animation.TimeLinePointFrameSurrogate, EditorCommon",
+            "x": 20.6256847,
+            "y": 20.6256847,
+            "frameIndex": 130,
+            "tween": true
+          }
+        ]
+      }
+    ]
+  },
+  "name": null,
+  "classname": null
+}

--- a/samples/Cpp/TestCpp/proj.emscripten/Makefile
+++ b/samples/Cpp/TestCpp/proj.emscripten/Makefile
@@ -50,6 +50,7 @@ SOURCES = ../Classes/AccelerometerTest/AccelerometerTest.cpp \
 	../Classes/ExtensionsTest/NotificationCenterTest/NotificationCenterTest.cpp \
 	../Classes/ExtensionsTest/NetworkTest/HttpClientTest.cpp \
 	../Classes/ExtensionsTest/CocoStudioArmatureTest/ArmatureScene.cpp \
+    ../Classes/ExtensionsTest/CocoStudioActionTimelineTest/ActionTimelineTestScene.cpp \
 	../Classes/ExtensionsTest/CocoStudioComponentsTest/ComponentsTestScene.cpp \
 	../Classes/ExtensionsTest/CocoStudioComponentsTest/EnemyController.cpp \
 	../Classes/ExtensionsTest/CocoStudioComponentsTest/GameOverScene.cpp \

--- a/samples/Cpp/TestCpp/proj.ios/TestCpp.xcodeproj/project.pbxproj
+++ b/samples/Cpp/TestCpp/proj.ios/TestCpp.xcodeproj/project.pbxproj
@@ -344,6 +344,13 @@
 		37CA1CFE17D87AC700A649D0 /* ProjectileController.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 37CA1CAC17D87AC700A649D0 /* ProjectileController.cpp */; };
 		37CA1CFF17D87AC700A649D0 /* SceneController.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 37CA1CAE17D87AC700A649D0 /* SceneController.cpp */; };
 		37CA1D1A17D87AC700A649D0 /* SceneEditorTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 37CA1CF717D87AC700A649D0 /* SceneEditorTest.cpp */; };
+		38FA2E90194E92F400FF2BE4 /* CCActionTimeline.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 38FA2E85194E92F400FF2BE4 /* CCActionTimeline.cpp */; };
+		38FA2E91194E92F400FF2BE4 /* CCActionTimelineCache.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 38FA2E87194E92F400FF2BE4 /* CCActionTimelineCache.cpp */; };
+		38FA2E92194E92F400FF2BE4 /* CCFrame.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 38FA2E89194E92F400FF2BE4 /* CCFrame.cpp */; };
+		38FA2E93194E92F400FF2BE4 /* CCNodeReader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 38FA2E8B194E92F400FF2BE4 /* CCNodeReader.cpp */; };
+		38FA2E94194E92F400FF2BE4 /* CCTimeLine.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 38FA2E8D194E92F400FF2BE4 /* CCTimeLine.cpp */; };
+		38FA2E98194E930700FF2BE4 /* ActionTimelineTestScene.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 38FA2E96194E930700FF2BE4 /* ActionTimelineTestScene.cpp */; };
+		38FA2E9A194E94FC00FF2BE4 /* ActionTimeline in Resources */ = {isa = PBXBuildFile; fileRef = 38FA2E99194E94FC00FF2BE4 /* ActionTimeline */; };
 		43B91ED81949B84200F7F815 /* CocoLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 43B91ED61949B84200F7F815 /* CocoLoader.cpp */; };
 		50181AE1185FEBAE0051CA1C /* CCActionEaseEx.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 50181ADF185FEBAE0051CA1C /* CCActionEaseEx.cpp */; };
 		50D36120186AED6100828878 /* UITouchGroup.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 50D3611E186AED6100828878 /* UITouchGroup.cpp */; };
@@ -1168,6 +1175,20 @@
 		37CA1CAF17D87AC700A649D0 /* SceneController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SceneController.h; sourceTree = "<group>"; };
 		37CA1CF717D87AC700A649D0 /* SceneEditorTest.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SceneEditorTest.cpp; sourceTree = "<group>"; };
 		37CA1CF817D87AC700A649D0 /* SceneEditorTest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SceneEditorTest.h; sourceTree = "<group>"; };
+		38FA2E85194E92F400FF2BE4 /* CCActionTimeline.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CCActionTimeline.cpp; sourceTree = "<group>"; };
+		38FA2E86194E92F400FF2BE4 /* CCActionTimeline.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CCActionTimeline.h; sourceTree = "<group>"; };
+		38FA2E87194E92F400FF2BE4 /* CCActionTimelineCache.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CCActionTimelineCache.cpp; sourceTree = "<group>"; };
+		38FA2E88194E92F400FF2BE4 /* CCActionTimelineCache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CCActionTimelineCache.h; sourceTree = "<group>"; };
+		38FA2E89194E92F400FF2BE4 /* CCFrame.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CCFrame.cpp; sourceTree = "<group>"; };
+		38FA2E8A194E92F400FF2BE4 /* CCFrame.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CCFrame.h; sourceTree = "<group>"; };
+		38FA2E8B194E92F400FF2BE4 /* CCNodeReader.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CCNodeReader.cpp; sourceTree = "<group>"; };
+		38FA2E8C194E92F400FF2BE4 /* CCNodeReader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CCNodeReader.h; sourceTree = "<group>"; };
+		38FA2E8D194E92F400FF2BE4 /* CCTimeLine.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CCTimeLine.cpp; sourceTree = "<group>"; };
+		38FA2E8E194E92F400FF2BE4 /* CCTimeLine.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CCTimeLine.h; sourceTree = "<group>"; };
+		38FA2E8F194E92F400FF2BE4 /* CCTimelineMacro.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CCTimelineMacro.h; sourceTree = "<group>"; };
+		38FA2E96194E930700FF2BE4 /* ActionTimelineTestScene.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ActionTimelineTestScene.cpp; sourceTree = "<group>"; };
+		38FA2E97194E930700FF2BE4 /* ActionTimelineTestScene.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ActionTimelineTestScene.h; sourceTree = "<group>"; };
+		38FA2E99194E94FC00FF2BE4 /* ActionTimeline */ = {isa = PBXFileReference; lastKnownFileType = folder; path = ActionTimeline; sourceTree = "<group>"; };
 		43B91ED61949B84200F7F815 /* CocoLoader.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CocoLoader.cpp; sourceTree = "<group>"; };
 		43B91ED71949B84200F7F815 /* CocoLoader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CocoLoader.h; sourceTree = "<group>"; };
 		50181ADF185FEBAE0051CA1C /* CCActionEaseEx.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CCActionEaseEx.cpp; sourceTree = "<group>"; };
@@ -2153,6 +2174,7 @@
 		15AA9CBB15B7EC460033D6C2 /* ExtensionsTest */ = {
 			isa = PBXGroup;
 			children = (
+				38FA2E95194E930700FF2BE4 /* CocoStudioActionTimelineTest */,
 				37CA1CA017D87AC700A649D0 /* CocoStudioArmatureTest */,
 				37CA1CA317D87AC700A649D0 /* CocoStudioComponentsTest */,
 				50F853FC18C581FB0019FBFB /* CocoStudioGUITest */,
@@ -2861,6 +2883,7 @@
 		37CA1B8117D87A3300A649D0 /* CocoStudio */ = {
 			isa = PBXGroup;
 			children = (
+				38FA2E84194E92F400FF2BE4 /* ActionTimeline */,
 				372902421867D36800B59D3A /* Trigger */,
 				37BB5ADD17E86BF1002746B4 /* Action */,
 				37CA1B8217D87A3300A649D0 /* Armature */,
@@ -3145,6 +3168,34 @@
 			);
 			name = CocoStudioSceneTest;
 			path = ../../Classes/ExtensionsTest/CocoStudioSceneTest;
+			sourceTree = "<group>";
+		};
+		38FA2E84194E92F400FF2BE4 /* ActionTimeline */ = {
+			isa = PBXGroup;
+			children = (
+				38FA2E85194E92F400FF2BE4 /* CCActionTimeline.cpp */,
+				38FA2E86194E92F400FF2BE4 /* CCActionTimeline.h */,
+				38FA2E87194E92F400FF2BE4 /* CCActionTimelineCache.cpp */,
+				38FA2E88194E92F400FF2BE4 /* CCActionTimelineCache.h */,
+				38FA2E89194E92F400FF2BE4 /* CCFrame.cpp */,
+				38FA2E8A194E92F400FF2BE4 /* CCFrame.h */,
+				38FA2E8B194E92F400FF2BE4 /* CCNodeReader.cpp */,
+				38FA2E8C194E92F400FF2BE4 /* CCNodeReader.h */,
+				38FA2E8D194E92F400FF2BE4 /* CCTimeLine.cpp */,
+				38FA2E8E194E92F400FF2BE4 /* CCTimeLine.h */,
+				38FA2E8F194E92F400FF2BE4 /* CCTimelineMacro.h */,
+			);
+			path = ActionTimeline;
+			sourceTree = "<group>";
+		};
+		38FA2E95194E930700FF2BE4 /* CocoStudioActionTimelineTest */ = {
+			isa = PBXGroup;
+			children = (
+				38FA2E96194E930700FF2BE4 /* ActionTimelineTestScene.cpp */,
+				38FA2E97194E930700FF2BE4 /* ActionTimelineTestScene.h */,
+			);
+			name = CocoStudioActionTimelineTest;
+			path = ../../Classes/ExtensionsTest/CocoStudioActionTimelineTest;
 			sourceTree = "<group>";
 		};
 		50E9124C18C8987500D07E0D /* UIRichTextTest */ = {
@@ -3548,6 +3599,7 @@
 		78C7DDAA14EBA5050085D0C2 /* Resources */ = {
 			isa = PBXGroup;
 			children = (
+				38FA2E99194E94FC00FF2BE4 /* ActionTimeline */,
 				37877486187A9002002578C7 /* animations */,
 				3787748D187A9002002578C7 /* ccb */,
 				1A16458A191B5178008C7C7F /* ccs-res */,
@@ -3701,6 +3753,7 @@
 				378774B5187A9002002578C7 /* configs in Resources */,
 				1A16458B191B5178008C7C7F /* ccs-res in Resources */,
 				378774A9187A9002002578C7 /* animations in Resources */,
+				38FA2E9A194E94FC00FF2BE4 /* ActionTimeline in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3719,6 +3772,7 @@
 				15AA9D5215B7EC460033D6C2 /* ActionManagerTest.cpp in Sources */,
 				50E9127B18C99AA600D07E0D /* CustomParticleWidgetTest.cpp in Sources */,
 				15AA9D5315B7EC460033D6C2 /* ActionsEaseTest.cpp in Sources */,
+				38FA2E98194E930700FF2BE4 /* ActionTimelineTestScene.cpp in Sources */,
 				15AA9D5415B7EC460033D6C2 /* ActionsProgressTest.cpp in Sources */,
 				15AA9D5515B7EC460033D6C2 /* ActionsTest.cpp in Sources */,
 				15AA9D5615B7EC460033D6C2 /* Box2dTest.cpp in Sources */,
@@ -3790,7 +3844,9 @@
 				15AA9D9015B7EC460033D6C2 /* SchedulerTest.cpp in Sources */,
 				15AA9D9115B7EC460033D6C2 /* ShaderTest.cpp in Sources */,
 				15AA9D9215B7EC460033D6C2 /* SpriteTest.cpp in Sources */,
+				38FA2E92194E92F400FF2BE4 /* CCFrame.cpp in Sources */,
 				15AA9D9315B7EC460033D6C2 /* testBasic.cpp in Sources */,
+				38FA2E90194E92F400FF2BE4 /* CCActionTimeline.cpp in Sources */,
 				15AA9D9415B7EC460033D6C2 /* TextInputTest.cpp in Sources */,
 				15AA9D9515B7EC460033D6C2 /* Texture2dTest.cpp in Sources */,
 				15AA9D9615B7EC460033D6C2 /* TextureCacheTest.cpp in Sources */,
@@ -3885,6 +3941,7 @@
 				15A3D99A1682F7F9002FB0C5 /* cpGearJoint.c in Sources */,
 				15A3D99B1682F7F9002FB0C5 /* cpGrooveJoint.c in Sources */,
 				15A3D99C1682F7F9002FB0C5 /* cpPinJoint.c in Sources */,
+				38FA2E91194E92F400FF2BE4 /* CCActionTimelineCache.cpp in Sources */,
 				15A3D99D1682F7F9002FB0C5 /* cpPivotJoint.c in Sources */,
 				15A3D99E1682F7F9002FB0C5 /* cpRatchetJoint.c in Sources */,
 				15A3D99F1682F7F9002FB0C5 /* cpRotaryLimitJoint.c in Sources */,
@@ -4064,7 +4121,9 @@
 				37CA1CF917D87AC700A649D0 /* ArmatureScene.cpp in Sources */,
 				37CA1CFA17D87AC700A649D0 /* ComponentsTestScene.cpp in Sources */,
 				372902F5186814E400B59D3A /* acts.cpp in Sources */,
+				38FA2E94194E92F400FF2BE4 /* CCTimeLine.cpp in Sources */,
 				50F8548218C581FB0019FBFB /* UITextFieldTest.cpp in Sources */,
+				38FA2E93194E92F400FF2BE4 /* CCNodeReader.cpp in Sources */,
 				37CA1CFB17D87AC700A649D0 /* EnemyController.cpp in Sources */,
 				37CA1CFC17D87AC700A649D0 /* GameOverScene.cpp in Sources */,
 				37CA1CFD17D87AC700A649D0 /* PlayerController.cpp in Sources */,

--- a/samples/Cpp/TestCpp/proj.linux/Makefile
+++ b/samples/Cpp/TestCpp/proj.linux/Makefile
@@ -51,6 +51,7 @@ SOURCES = ../Classes/AccelerometerTest/AccelerometerTest.cpp \
 	../Classes/ExtensionsTest/NotificationCenterTest/NotificationCenterTest.cpp \
 	../Classes/ExtensionsTest/NetworkTest/HttpClientTest.cpp \
     ../Classes/ExtensionsTest/CocoStudioArmatureTest/ArmatureScene.cpp \
+    ../Classes/ExtensionsTest/CocoStudioActionTimelineTest/ActionTimelineTestScene.cpp \
 	../Classes/ExtensionsTest/CocoStudioComponentsTest/ComponentsTestScene.cpp \
 	../Classes/ExtensionsTest/CocoStudioComponentsTest/EnemyController.cpp \
 	../Classes/ExtensionsTest/CocoStudioComponentsTest/GameOverScene.cpp \

--- a/samples/Cpp/TestCpp/proj.mac/TestCpp.xcodeproj/project.pbxproj
+++ b/samples/Cpp/TestCpp/proj.mac/TestCpp.xcodeproj/project.pbxproj
@@ -401,6 +401,13 @@
 		37CA26F217D87BB500A649D0 /* ProjectileController.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 37CA26A017D87BB500A649D0 /* ProjectileController.cpp */; };
 		37CA26F317D87BB500A649D0 /* SceneController.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 37CA26A217D87BB500A649D0 /* SceneController.cpp */; };
 		37CA270E17D87BB500A649D0 /* SceneEditorTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 37CA26EB17D87BB500A649D0 /* SceneEditorTest.cpp */; };
+		38FA2EC5194EB31B00FF2BE4 /* CCActionTimeline.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 38FA2EBA194EB31B00FF2BE4 /* CCActionTimeline.cpp */; };
+		38FA2EC6194EB31B00FF2BE4 /* CCActionTimelineCache.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 38FA2EBC194EB31B00FF2BE4 /* CCActionTimelineCache.cpp */; };
+		38FA2EC7194EB31B00FF2BE4 /* CCFrame.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 38FA2EBE194EB31B00FF2BE4 /* CCFrame.cpp */; };
+		38FA2EC8194EB31B00FF2BE4 /* CCNodeReader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 38FA2EC0194EB31B00FF2BE4 /* CCNodeReader.cpp */; };
+		38FA2EC9194EB31B00FF2BE4 /* CCTimeLine.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 38FA2EC2194EB31B00FF2BE4 /* CCTimeLine.cpp */; };
+		38FA2ECD194EB32600FF2BE4 /* ActionTimelineTestScene.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 38FA2ECB194EB32600FF2BE4 /* ActionTimelineTestScene.cpp */; };
+		38FA2ECF194EB33400FF2BE4 /* ActionTimeline in Resources */ = {isa = PBXBuildFile; fileRef = 38FA2ECE194EB33400FF2BE4 /* ActionTimeline */; };
 		3E9D2389192A31980008522D /* ccs-res in Resources */ = {isa = PBXBuildFile; fileRef = 3E9D2388192A31980008522D /* ccs-res */; };
 		41BC70E415BF81A5006A0A6C /* AppController.mm in Sources */ = {isa = PBXBuildFile; fileRef = 41BC70DA15BF81A5006A0A6C /* AppController.mm */; };
 		41BC70E515BF81A5006A0A6C /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 41BC70DC15BF81A5006A0A6C /* InfoPlist.strings */; };
@@ -1277,6 +1284,20 @@
 		37CA26A317D87BB500A649D0 /* SceneController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SceneController.h; sourceTree = "<group>"; };
 		37CA26EB17D87BB500A649D0 /* SceneEditorTest.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SceneEditorTest.cpp; sourceTree = "<group>"; };
 		37CA26EC17D87BB500A649D0 /* SceneEditorTest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SceneEditorTest.h; sourceTree = "<group>"; };
+		38FA2EBA194EB31B00FF2BE4 /* CCActionTimeline.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CCActionTimeline.cpp; sourceTree = "<group>"; };
+		38FA2EBB194EB31B00FF2BE4 /* CCActionTimeline.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CCActionTimeline.h; sourceTree = "<group>"; };
+		38FA2EBC194EB31B00FF2BE4 /* CCActionTimelineCache.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CCActionTimelineCache.cpp; sourceTree = "<group>"; };
+		38FA2EBD194EB31B00FF2BE4 /* CCActionTimelineCache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CCActionTimelineCache.h; sourceTree = "<group>"; };
+		38FA2EBE194EB31B00FF2BE4 /* CCFrame.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CCFrame.cpp; sourceTree = "<group>"; };
+		38FA2EBF194EB31B00FF2BE4 /* CCFrame.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CCFrame.h; sourceTree = "<group>"; };
+		38FA2EC0194EB31B00FF2BE4 /* CCNodeReader.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CCNodeReader.cpp; sourceTree = "<group>"; };
+		38FA2EC1194EB31B00FF2BE4 /* CCNodeReader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CCNodeReader.h; sourceTree = "<group>"; };
+		38FA2EC2194EB31B00FF2BE4 /* CCTimeLine.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CCTimeLine.cpp; sourceTree = "<group>"; };
+		38FA2EC3194EB31B00FF2BE4 /* CCTimeLine.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CCTimeLine.h; sourceTree = "<group>"; };
+		38FA2EC4194EB31B00FF2BE4 /* CCTimelineMacro.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CCTimelineMacro.h; sourceTree = "<group>"; };
+		38FA2ECB194EB32600FF2BE4 /* ActionTimelineTestScene.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ActionTimelineTestScene.cpp; sourceTree = "<group>"; };
+		38FA2ECC194EB32600FF2BE4 /* ActionTimelineTestScene.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ActionTimelineTestScene.h; sourceTree = "<group>"; };
+		38FA2ECE194EB33400FF2BE4 /* ActionTimeline */ = {isa = PBXFileReference; lastKnownFileType = folder; path = ActionTimeline; sourceTree = "<group>"; };
 		3E9D2388192A31980008522D /* ccs-res */ = {isa = PBXFileReference; lastKnownFileType = folder; path = "ccs-res"; sourceTree = "<group>"; };
 		41BC70D915BF81A5006A0A6C /* AppController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AppController.h; sourceTree = SOURCE_ROOT; };
 		41BC70DA15BF81A5006A0A6C /* AppController.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = AppController.mm; sourceTree = SOURCE_ROOT; };
@@ -1638,6 +1659,7 @@
 		15AA9CBB15B7EC460033D6C2 /* ExtensionsTest */ = {
 			isa = PBXGroup;
 			children = (
+				38FA2ECA194EB32600FF2BE4 /* CocoStudioActionTimelineTest */,
 				2961DFDB18C9B6B30017F5DB /* CocoStudioGUITest */,
 				37CA269417D87BB500A649D0 /* CocoStudioArmatureTest */,
 				37CA269717D87BB500A649D0 /* CocoStudioComponentsTest */,
@@ -3285,6 +3307,7 @@
 		37CA1D2417D87B5700A649D0 /* CocoStudio */ = {
 			isa = PBXGroup;
 			children = (
+				38FA2EB9194EB31B00FF2BE4 /* ActionTimeline */,
 				379369AF18686AF800E974DD /* Trigger */,
 				3793699C186869D300E974DD /* Action */,
 				37BB5AF617E86CEC002746B4 /* GUI */,
@@ -3473,6 +3496,34 @@
 			path = ../../Classes/ExtensionsTest/CocoStudioSceneTest;
 			sourceTree = "<group>";
 		};
+		38FA2EB9194EB31B00FF2BE4 /* ActionTimeline */ = {
+			isa = PBXGroup;
+			children = (
+				38FA2EBA194EB31B00FF2BE4 /* CCActionTimeline.cpp */,
+				38FA2EBB194EB31B00FF2BE4 /* CCActionTimeline.h */,
+				38FA2EBC194EB31B00FF2BE4 /* CCActionTimelineCache.cpp */,
+				38FA2EBD194EB31B00FF2BE4 /* CCActionTimelineCache.h */,
+				38FA2EBE194EB31B00FF2BE4 /* CCFrame.cpp */,
+				38FA2EBF194EB31B00FF2BE4 /* CCFrame.h */,
+				38FA2EC0194EB31B00FF2BE4 /* CCNodeReader.cpp */,
+				38FA2EC1194EB31B00FF2BE4 /* CCNodeReader.h */,
+				38FA2EC2194EB31B00FF2BE4 /* CCTimeLine.cpp */,
+				38FA2EC3194EB31B00FF2BE4 /* CCTimeLine.h */,
+				38FA2EC4194EB31B00FF2BE4 /* CCTimelineMacro.h */,
+			);
+			path = ActionTimeline;
+			sourceTree = "<group>";
+		};
+		38FA2ECA194EB32600FF2BE4 /* CocoStudioActionTimelineTest */ = {
+			isa = PBXGroup;
+			children = (
+				38FA2ECB194EB32600FF2BE4 /* ActionTimelineTestScene.cpp */,
+				38FA2ECC194EB32600FF2BE4 /* ActionTimelineTestScene.h */,
+			);
+			name = CocoStudioActionTimelineTest;
+			path = ../../Classes/ExtensionsTest/CocoStudioActionTimelineTest;
+			sourceTree = "<group>";
+		};
 		41BC70D815BF818D006A0A6C /* mac */ = {
 			isa = PBXGroup;
 			children = (
@@ -3510,6 +3561,7 @@
 		78C7DDAA14EBA5050085D0C2 /* Resources */ = {
 			isa = PBXGroup;
 			children = (
+				38FA2ECE194EB33400FF2BE4 /* ActionTimeline */,
 				3E9D2388192A31980008522D /* ccs-res */,
 				37C818FC1875C19600930C57 /* animations */,
 				37C819031875C19600930C57 /* ccb */,
@@ -3648,6 +3700,7 @@
 				37C819321875C19600930C57 /* fonts in Resources */,
 				1AFC8274191A453100E7C970 /* fps_images.png in Resources */,
 				37C819241875C19600930C57 /* background.ogg in Resources */,
+				38FA2ECF194EB33400FF2BE4 /* ActionTimeline in Resources */,
 				37C819301875C19600930C57 /* extensions in Resources */,
 				37C819251875C19600930C57 /* background.wav in Resources */,
 				37C8193F1875C19600930C57 /* spine in Resources */,
@@ -3713,6 +3766,7 @@
 				15AA9D5E15B7EC460033D6C2 /* Bug-422.cpp in Sources */,
 				15AA9D5F15B7EC460033D6C2 /* Bug-458.cpp in Sources */,
 				2961DFD318C9B4E80017F5DB /* PageViewReader.cpp in Sources */,
+				38FA2EC9194EB31B00FF2BE4 /* CCTimeLine.cpp in Sources */,
 				2961E05618C9B6B30017F5DB /* UIListViewTest.cpp in Sources */,
 				2961E06118C9B6B30017F5DB /* UIScrollViewTest.cpp in Sources */,
 				15AA9D6015B7EC460033D6C2 /* QuestionContainerSprite.cpp in Sources */,
@@ -3817,6 +3871,7 @@
 				2961E05218C9B6B30017F5DB /* UILabelTest.cpp in Sources */,
 				15C1574B1683159E00D239F2 /* b2ChainShape.cpp in Sources */,
 				15C1574C1683159E00D239F2 /* b2CircleShape.cpp in Sources */,
+				38FA2EC7194EB31B00FF2BE4 /* CCFrame.cpp in Sources */,
 				15C1574D1683159E00D239F2 /* b2EdgeShape.cpp in Sources */,
 				15C1574E1683159E00D239F2 /* b2PolygonShape.cpp in Sources */,
 				2961E05118C9B6B30017F5DB /* UILabelBMFontTest_Editor.cpp in Sources */,
@@ -3873,6 +3928,7 @@
 				2961DFCB18C9B4E80017F5DB /* CheckBoxReader.cpp in Sources */,
 				15C157E0168315B300D239F2 /* cpPinJoint.c in Sources */,
 				2961E05018C9B6B30017F5DB /* UILabelBMFontTest.cpp in Sources */,
+				38FA2EC5194EB31B00FF2BE4 /* CCActionTimeline.cpp in Sources */,
 				15C157E1168315B300D239F2 /* cpPivotJoint.c in Sources */,
 				379369B818686AF800E974DD /* ObjectFactory.cpp in Sources */,
 				15C157E2168315B300D239F2 /* cpRatchetJoint.c in Sources */,
@@ -3894,6 +3950,7 @@
 				15C157F2168315B300D239F2 /* cpSpaceQuery.c in Sources */,
 				15C157F3168315B300D239F2 /* cpSpaceStep.c in Sources */,
 				15C157F4168315B300D239F2 /* cpSpatialIndex.c in Sources */,
+				38FA2ECD194EB32600FF2BE4 /* ActionTimelineTestScene.cpp in Sources */,
 				15C157F5168315B300D239F2 /* cpSweep1D.c in Sources */,
 				15C157F6168315B300D239F2 /* cpVect.c in Sources */,
 				15C1591A168315E500D239F2 /* CCBAnimationManager.cpp in Sources */,
@@ -4030,6 +4087,7 @@
 				37CA26F117D87BB500A649D0 /* PlayerController.cpp in Sources */,
 				37CA26F217D87BB500A649D0 /* ProjectileController.cpp in Sources */,
 				37CA26F317D87BB500A649D0 /* SceneController.cpp in Sources */,
+				38FA2EC6194EB31B00FF2BE4 /* CCActionTimelineCache.cpp in Sources */,
 				37936A0B18686C4F00E974DD /* cons.cpp in Sources */,
 				2961DFCC18C9B4E80017F5DB /* ImageViewReader.cpp in Sources */,
 				37CA270E17D87BB500A649D0 /* SceneEditorTest.cpp in Sources */,
@@ -4045,6 +4103,7 @@
 				37BB5B3C17E86CEC002746B4 /* UIScrollView.cpp in Sources */,
 				37BB5B3D17E86CEC002746B4 /* UIButton.cpp in Sources */,
 				37BB5B3E17E86CEC002746B4 /* UICheckBox.cpp in Sources */,
+				38FA2EC8194EB31B00FF2BE4 /* CCNodeReader.cpp in Sources */,
 				37BB5B3F17E86CEC002746B4 /* UIImageView.cpp in Sources */,
 				37BB5B4017E86CEC002746B4 /* UILabel.cpp in Sources */,
 				37BB5B4117E86CEC002746B4 /* UILabelAtlas.cpp in Sources */,

--- a/samples/Cpp/TestCpp/proj.marmalade/TestCPP.mkb
+++ b/samples/Cpp/TestCpp/proj.marmalade/TestCPP.mkb
@@ -243,6 +243,11 @@ files
 	"*.cpp"
 	"*.h"
 	
+	[Test/ExtensionsTest/ActionTimelineTest]
+	(../Classes/ExtensionsTest/CocoStudioActionTimelineTest)
+	"*.cpp"
+	"*.h"
+
 	[Test/ExtensionsTest/ComponentsTest]
 	(../Classes/ExtensionsTest/CocoStudioComponentsTest)
 	"*.cpp"

--- a/samples/Cpp/TestCpp/proj.nacl/Makefile
+++ b/samples/Cpp/TestCpp/proj.nacl/Makefile
@@ -56,6 +56,7 @@ SOURCES = ../Classes/AccelerometerTest/AccelerometerTest.cpp \
 	../Classes/ExtensionsTest/ExtensionsTest.cpp \
 	../Classes/ExtensionsTest/NotificationCenterTest/NotificationCenterTest.cpp \
     ../Classes/ExtensionsTest/CocoStudioArmatureTest/ArmatureScene.cpp \
+    ../Classes/ExtensionsTest/CocoStudioActionTimelineTest/ActionTimelineTestScene.cpp \
 	../Classes/ExtensionsTest/CocoStudioComponentsTest/ComponentsTestScene.cpp \
 	../Classes/ExtensionsTest/CocoStudioComponentsTest/EnemyController.cpp \
 	../Classes/ExtensionsTest/CocoStudioComponentsTest/GameOverScene.cpp \

--- a/samples/Cpp/TestCpp/proj.win32/TestCpp.vcxproj
+++ b/samples/Cpp/TestCpp/proj.win32/TestCpp.vcxproj
@@ -141,6 +141,7 @@ xcopy /Y /Q "$(ProjectDir)..\..\..\..\external\libwebsockets\win32\lib\*.*" "$(O
     <ClCompile Include="..\Classes\DataVisitorTest\DataVisitorTest.cpp" />
     <ClCompile Include="..\Classes\ExtensionsTest\CocosBuilderTest\AnimationsTest\AnimationsTestLayer.cpp" />
     <ClCompile Include="..\Classes\ExtensionsTest\CocosBuilderTest\TimelineCallbackTest\TimelineCallbackTestLayer.cpp" />
+    <ClCompile Include="..\Classes\ExtensionsTest\CocoStudioActionTimelineTest\ActionTimelineTestScene.cpp" />
     <ClCompile Include="..\Classes\ExtensionsTest\CocoStudioArmatureTest\ArmatureScene.cpp" />
     <ClCompile Include="..\Classes\ExtensionsTest\CocoStudioComponentsTest\ComponentsTestScene.cpp" />
     <ClCompile Include="..\Classes\ExtensionsTest\CocoStudioComponentsTest\EnemyController.cpp" />
@@ -301,6 +302,7 @@ xcopy /Y /Q "$(ProjectDir)..\..\..\..\external\libwebsockets\win32\lib\*.*" "$(O
     <ClInclude Include="..\Classes\ExtensionsTest\CocosBuilderTest\AnimationsTest\AnimationsTestLayer.h" />
     <ClInclude Include="..\Classes\ExtensionsTest\CocosBuilderTest\TimelineCallbackTest\TimelineCallbackLayerLoader.h" />
     <ClInclude Include="..\Classes\ExtensionsTest\CocosBuilderTest\TimelineCallbackTest\TimelineCallbackTestLayer.h" />
+    <ClInclude Include="..\Classes\ExtensionsTest\CocoStudioActionTimelineTest\ActionTimelineTestScene.h" />
     <ClInclude Include="..\Classes\ExtensionsTest\CocoStudioArmatureTest\ArmatureScene.h" />
     <ClInclude Include="..\Classes\ExtensionsTest\CocoStudioComponentsTest\ComponentsTestScene.h" />
     <ClInclude Include="..\Classes\ExtensionsTest\CocoStudioComponentsTest\EnemyController.h" />

--- a/samples/Cpp/TestCpp/proj.win32/TestCpp.vcxproj.filters
+++ b/samples/Cpp/TestCpp/proj.win32/TestCpp.vcxproj.filters
@@ -298,6 +298,9 @@
     <Filter Include="Classes\ExtensionsTest\CocoStudioGUITest\CustomTest\CustomParticleWidgetTest">
       <UniqueIdentifier>{af497767-91b8-4628-ac6b-1783a98f7865}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Classes\ExtensionsTest\CocoStudioActionTimelineTest">
+      <UniqueIdentifier>{fe452434-cb7d-4889-ab4e-8baf50da570c}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="main.cpp">
@@ -751,6 +754,9 @@
       <Filter>Classes\ExtensionsTest\CocoStudioGUITest\CustomTest\CustomParticleWidgetTest</Filter>
     </ClCompile>
     <ClCompile Include="pch.cpp" />
+    <ClCompile Include="..\Classes\ExtensionsTest\CocoStudioActionTimelineTest\ActionTimelineTestScene.cpp">
+      <Filter>Classes\ExtensionsTest\CocoStudioActionTimelineTest</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="main.h">
@@ -1387,5 +1393,8 @@
       <Filter>Classes\ExtensionsTest\CocoStudioGUITest\CustomTest\CustomParticleWidgetTest</Filter>
     </ClInclude>
     <ClInclude Include="pch.h" />
+    <ClInclude Include="..\Classes\ExtensionsTest\CocoStudioActionTimelineTest\ActionTimelineTestScene.h">
+      <Filter>Classes\ExtensionsTest\CocoStudioActionTimelineTest</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>

--- a/template/multi-platform-cpp/proj.ios/HelloCpp.xcodeproj/project.pbxproj
+++ b/template/multi-platform-cpp/proj.ios/HelloCpp.xcodeproj/project.pbxproj
@@ -239,6 +239,11 @@
 		379BB9CB17F03F3700829B88 /* DictionaryHelper.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 379BB97C17F03F3700829B88 /* DictionaryHelper.cpp */; };
 		379BB9D317F03F3700829B88 /* GUIReader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 379BB99117F03F3700829B88 /* GUIReader.cpp */; };
 		379BB9D417F03F3700829B88 /* SceneReader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 379BB99317F03F3700829B88 /* SceneReader.cpp */; };
+		38FA2EB0194EA58000FF2BE4 /* CCActionTimeline.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 38FA2EA5194EA58000FF2BE4 /* CCActionTimeline.cpp */; };
+		38FA2EB1194EA58000FF2BE4 /* CCActionTimelineCache.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 38FA2EA7194EA58000FF2BE4 /* CCActionTimelineCache.cpp */; };
+		38FA2EB2194EA58000FF2BE4 /* CCFrame.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 38FA2EA9194EA58000FF2BE4 /* CCFrame.cpp */; };
+		38FA2EB3194EA58000FF2BE4 /* CCNodeReader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 38FA2EAB194EA58000FF2BE4 /* CCNodeReader.cpp */; };
+		38FA2EB4194EA58000FF2BE4 /* CCTimeLine.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 38FA2EAD194EA58000FF2BE4 /* CCTimeLine.cpp */; };
 		43B91F051949BAF100F7F815 /* CocoLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 43B91F031949BAF100F7F815 /* CocoLoader.cpp */; };
 		46513EB1187BFBA200B5ABE1 /* UITouchGroup.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 46513EAF187BFBA200B5ABE1 /* UITouchGroup.cpp */; };
 		7855E0E1153FEF240059DD9A /* Default.png in Resources */ = {isa = PBXBuildFile; fileRef = 7855E0DF153FEF240059DD9A /* Default.png */; };
@@ -758,6 +763,17 @@
 		379BB99317F03F3700829B88 /* SceneReader.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SceneReader.cpp; sourceTree = "<group>"; };
 		379BB99417F03F3700829B88 /* SceneReader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SceneReader.h; sourceTree = "<group>"; };
 		37C62C0718E156AE00D16FC4 /* ExtensionExport.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ExtensionExport.h; sourceTree = "<group>"; };
+		38FA2EA5194EA58000FF2BE4 /* CCActionTimeline.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CCActionTimeline.cpp; sourceTree = "<group>"; };
+		38FA2EA6194EA58000FF2BE4 /* CCActionTimeline.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CCActionTimeline.h; sourceTree = "<group>"; };
+		38FA2EA7194EA58000FF2BE4 /* CCActionTimelineCache.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CCActionTimelineCache.cpp; sourceTree = "<group>"; };
+		38FA2EA8194EA58000FF2BE4 /* CCActionTimelineCache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CCActionTimelineCache.h; sourceTree = "<group>"; };
+		38FA2EA9194EA58000FF2BE4 /* CCFrame.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CCFrame.cpp; sourceTree = "<group>"; };
+		38FA2EAA194EA58000FF2BE4 /* CCFrame.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CCFrame.h; sourceTree = "<group>"; };
+		38FA2EAB194EA58000FF2BE4 /* CCNodeReader.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CCNodeReader.cpp; sourceTree = "<group>"; };
+		38FA2EAC194EA58000FF2BE4 /* CCNodeReader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CCNodeReader.h; sourceTree = "<group>"; };
+		38FA2EAD194EA58000FF2BE4 /* CCTimeLine.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CCTimeLine.cpp; sourceTree = "<group>"; };
+		38FA2EAE194EA58000FF2BE4 /* CCTimeLine.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CCTimeLine.h; sourceTree = "<group>"; };
+		38FA2EAF194EA58000FF2BE4 /* CCTimelineMacro.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CCTimelineMacro.h; sourceTree = "<group>"; };
 		43B91F031949BAF100F7F815 /* CocoLoader.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CocoLoader.cpp; sourceTree = "<group>"; };
 		43B91F041949BAF100F7F815 /* CocoLoader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CocoLoader.h; sourceTree = "<group>"; };
 		46513EAF187BFBA200B5ABE1 /* UITouchGroup.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = UITouchGroup.cpp; sourceTree = "<group>"; };
@@ -1883,6 +1899,7 @@
 		37CA271817D87D7600A649D0 /* CocoStudio */ = {
 			isa = PBXGroup;
 			children = (
+				38FA2EA4194EA58000FF2BE4 /* ActionTimeline */,
 				375BD5011868454E0024609E /* Action */,
 				375BD4BA1868411B0024609E /* Trigger */,
 				379BB90617F03F3700829B88 /* Armature */,
@@ -1892,6 +1909,24 @@
 				379BB99017F03F3700829B88 /* Reader */,
 			);
 			path = CocoStudio;
+			sourceTree = "<group>";
+		};
+		38FA2EA4194EA58000FF2BE4 /* ActionTimeline */ = {
+			isa = PBXGroup;
+			children = (
+				38FA2EA5194EA58000FF2BE4 /* CCActionTimeline.cpp */,
+				38FA2EA6194EA58000FF2BE4 /* CCActionTimeline.h */,
+				38FA2EA7194EA58000FF2BE4 /* CCActionTimelineCache.cpp */,
+				38FA2EA8194EA58000FF2BE4 /* CCActionTimelineCache.h */,
+				38FA2EA9194EA58000FF2BE4 /* CCFrame.cpp */,
+				38FA2EAA194EA58000FF2BE4 /* CCFrame.h */,
+				38FA2EAB194EA58000FF2BE4 /* CCNodeReader.cpp */,
+				38FA2EAC194EA58000FF2BE4 /* CCNodeReader.h */,
+				38FA2EAD194EA58000FF2BE4 /* CCTimeLine.cpp */,
+				38FA2EAE194EA58000FF2BE4 /* CCTimeLine.h */,
+				38FA2EAF194EA58000FF2BE4 /* CCTimelineMacro.h */,
+			);
+			path = ActionTimeline;
 			sourceTree = "<group>";
 		};
 		78C7DDAA14EBA5050085D0C2 /* Resources */ = {
@@ -2025,6 +2060,7 @@
 				15A3D9101682F7D5002FB0C5 /* b2Timer.cpp in Sources */,
 				15A3D9111682F7D5002FB0C5 /* b2Body.cpp in Sources */,
 				15A3D9121682F7D5002FB0C5 /* b2ContactManager.cpp in Sources */,
+				38FA2EB0194EA58000FF2BE4 /* CCActionTimeline.cpp in Sources */,
 				15A3D9131682F7D5002FB0C5 /* b2Fixture.cpp in Sources */,
 				15A3D9141682F7D5002FB0C5 /* b2Island.cpp in Sources */,
 				15A3D9151682F7D5002FB0C5 /* b2World.cpp in Sources */,
@@ -2041,6 +2077,7 @@
 				15A3D91D1682F7D5002FB0C5 /* b2EdgeAndPolygonContact.cpp in Sources */,
 				15A3D91E1682F7D5002FB0C5 /* b2PolygonAndCircleContact.cpp in Sources */,
 				15A3D91F1682F7D5002FB0C5 /* b2PolygonContact.cpp in Sources */,
+				38FA2EB4194EA58000FF2BE4 /* CCTimeLine.cpp in Sources */,
 				15A3D9201682F7D5002FB0C5 /* b2DistanceJoint.cpp in Sources */,
 				298B29BD18D0668400C1920F /* LabelAtlasReader.cpp in Sources */,
 				15A3D9211682F7D5002FB0C5 /* b2FrictionJoint.cpp in Sources */,
@@ -2145,6 +2182,7 @@
 				15A3DAED1682F8A6002FB0C5 /* CocosDenshion.m in Sources */,
 				15A3DAEE1682F8A6002FB0C5 /* SimpleAudioEngine.mm in Sources */,
 				15A3DAEF1682F8A6002FB0C5 /* SimpleAudioEngine_objc.m in Sources */,
+				38FA2EB3194EA58000FF2BE4 /* CCNodeReader.cpp in Sources */,
 				1A27573F1697CF2B00504026 /* CCEditBoxImplAndroid.cpp in Sources */,
 				1AFAF8B716D35DE700DB1158 /* AppDelegate.cpp in Sources */,
 				1AFAF8B816D35DE700DB1158 /* HelloWorldScene.cpp in Sources */,
@@ -2176,6 +2214,7 @@
 				1A8F3B81175E05DA00049216 /* SlotData.cpp in Sources */,
 				1A8F3B82175E05DA00049216 /* spine-cocos2dx.cpp in Sources */,
 				298B29C418D0668400C1920F /* ScrollViewReader.cpp in Sources */,
+				38FA2EB1194EA58000FF2BE4 /* CCActionTimelineCache.cpp in Sources */,
 				1AB87035175E0A84005D39BF /* WebSocket.cpp in Sources */,
 				375BD4C51868411B0024609E /* TriggerMng.cpp in Sources */,
 				1A9CE8781765A12C000E3062 /* AssetsManager.cpp in Sources */,
@@ -2189,6 +2228,7 @@
 				379BB9A117F03F3700829B88 /* CCDecorativeDisplay.cpp in Sources */,
 				379BB9A217F03F3700829B88 /* CCDisplayFactory.cpp in Sources */,
 				379BB9A317F03F3700829B88 /* CCDisplayManager.cpp in Sources */,
+				38FA2EB2194EA58000FF2BE4 /* CCFrame.cpp in Sources */,
 				379BB9A417F03F3700829B88 /* CCSkin.cpp in Sources */,
 				298B29C518D0668400C1920F /* SliderReader.cpp in Sources */,
 				379BB9A517F03F3700829B88 /* CCColliderDetector.cpp in Sources */,


### PR DESCRIPTION
TimelineAction is used for decode exported data from CocoStudio mac version.
It's a better solution for Armature.

TimelineAction inherits from cocos2d:;Action, so it's more closed to cocos2d.
TimelineAction's struct is more flexible and clear than Armature.
Frame -> Timeline -> TimelineAction
Frame is easy to extend its type, you just need to inherit from Frame, and implement Frame::onEnter, Frame::apply.

TimelineActionCache will load data from json resource and cache it.
When creates a new TimelineAction, TimelineActionCache will clone one from cache.

NodeReader will create a node tree from json resourece.

To run a TimelineAction, you need to do like this:

Node\* node = NodeReader::getInstance()->createNode("TimelineAction/boy_1.ExportJson");
TimelineAction\* action = TimelineActionCache::getInstance()->createAction("TimelineAction/boy_1.ExportJson");

node->runAction(action);
action->gotoFrameAndPlay(0, 60, true);
