### PR TITLE
add chipmunk sensor

### DIFF
--- a/cocos/physics/CCPhysicsBody.cpp
+++ b/cocos/physics/CCPhysicsBody.cpp
@@ -68,6 +68,7 @@ PhysicsBody::PhysicsBody()
 , _isDamping(false)
 , _linearDamping(0.0f)
 , _angularDamping(0.0f)
+, _sensor(false)
 , _tag(0)
 , _categoryBitmask(UINT_MAX)
 , _collisionBitmask(0)
@@ -341,6 +342,17 @@ void PhysicsBody::setGravityEnable(bool enable)
             {
                 applyForce(-_world->getGravity() * _mass);
             }
+        }
+    }
+}
+
+void PhysicsBody::setSensor(bool enable)
+{
+    for (auto& shapeInfo : _shapes)
+    {
+        for (auto shape : shapeInfo->_info->getShapes())
+        {
+            cpShapeSetSensor(shape, enable);
         }
     }
 }

--- a/cocos/physics/CCPhysicsBody.h
+++ b/cocos/physics/CCPhysicsBody.h
@@ -287,6 +287,17 @@ public:
     /** set the body is affected by the physics world's gravitational force or not. */
     void setGravityEnable(bool enable);
     
+    /**
+     *  Is this body a sensor? A sensor will call a collision delegate but does not physically cause collisions between bodies.
+     *  Defaults to false
+     */
+    inline bool isSensor() const { return _sensor; }
+    /**
+     *  Set this body as a sensor. A sensor will call a collision delegate but does not physically cause collisions between bodies.
+     *  Defaults to false
+     */
+    void setSensor(bool enable);
+    
     /** get the body's tag */
     inline int getTag() const { return _tag; }
     /** set the body's tag */
@@ -333,6 +344,7 @@ protected:
     bool _isDamping;
     float _linearDamping;
     float _angularDamping;
+    bool _sensor;
     int _tag;
     
     int _categoryBitmask;

--- a/cocos/physics/CCPhysicsShape.cpp
+++ b/cocos/physics/CCPhysicsShape.cpp
@@ -51,6 +51,7 @@ PhysicsShape::PhysicsShape()
 , _collisionBitmask(UINT_MAX)
 , _contactTestBitmask(0)
 , _group(0)
+, _sensor(false)
 {
     
 }
@@ -275,6 +276,14 @@ void PhysicsShape::setBody(PhysicsBody *body)
     {
         _info->setBody(body->_info->getBody());
         _body = body;
+    }
+}
+
+void PhysicsShape::setSensor(bool enable)
+{
+    for (auto shape : _info->getShapes())
+    {
+        cpShapeSetSensor(shape, enable);
     }
 }
 

--- a/cocos/physics/CCPhysicsShape.h
+++ b/cocos/physics/CCPhysicsShape.h
@@ -143,6 +143,18 @@ public:
     void setGroup(int group);
     inline int getGroup() { return _group; }
     
+    /**
+     *  Is this body a sensor? A sensor will call a collision delegate but does not physically cause collisions between bodies.
+     *  Defaults to false
+     */
+    inline bool isSensor() const { return _sensor; }
+    /**
+     *  Set this body as a sensor. A sensor will call a collision delegate but does not physically cause collisions between bodies.
+     *  Defaults to false
+     */
+    void setSensor(bool enable);
+    
+    
 protected:
     bool init(Type type);
     
@@ -173,6 +185,7 @@ protected:
     int    _collisionBitmask;
     int    _contactTestBitmask;
     int    _group;
+    bool _sensor;
     
     friend class PhysicsWorld;
     friend class PhysicsBody;


### PR DESCRIPTION
Add support for Chipmunk sensors. From Chipmunk manual:

"A boolean value if this shape is a sensor or not. Sensors only call collision callbacks, and never generate real collisions"

Sensors are integrated in cocos2d-iphone v3.
