### PR TITLE
fix warning Uniform is struct, not class.

### DIFF
--- a/cocos/renderer/CCMeshCommand.h
+++ b/cocos/renderer/CCMeshCommand.h
@@ -34,7 +34,7 @@ NS_CC_BEGIN
 
 class GLProgramState;
 class GLProgram;
-class Uniform;
+struct Uniform;
 
 //it is a common mesh
 class MeshCommand : public RenderCommand


### PR DESCRIPTION
fix warning:

`renderer/CCMeshCommand.h(37): warning C4099: 'cocos2d::Uniform' : type name first seen using 'struct' now seen using 'class' (..\3d\CCAnimate3D.cpp)
see declaration of 'cocos2d::Uniform'
`
