### PR TITLE
Update CCArmatureAnimation.cpp

### DIFF
--- a/cocos/editor-support/cocostudio/CCArmatureAnimation.cpp
+++ b/cocos/editor-support/cocostudio/CCArmatureAnimation.cpp
@@ -337,6 +337,10 @@ void ArmatureAnimation::update(float dt)
 {
     ProcessBase::update(dt);
     
+    //支持在用户回调中移除当前armature。
+	_armature->retain();
+	_armature->autorelease();
+	
     for (const auto &tween : _tweenList)
     {
         tween->update(dt);


### PR DESCRIPTION
防止armature使用者在接受到回调时（一般在frameEvent的complete事件中）执行removeFromParent等操作导致当前ArmatureAnimation销毁，导致内存访问出错
