### PR TITLE
Fix NodeReader crash

### DIFF
--- a/cocos/editor-support/cocostudio/ActionTimeline/CCNodeReader.cpp
+++ b/cocos/editor-support/cocostudio/ActionTimeline/CCNodeReader.cpp
@@ -220,7 +220,7 @@ Node* NodeReader::loadNode(const rapidjson::Value& json)
     Node* node = nullptr;
     std::string nodeType = DICTOOL->getStringValue_json(json, CLASSNAME);
 
-    NodeCreateFunc func = _funcs.at(nodeType);
+    NodeCreateFunc func = _funcs[nodeType];
     if (func != nullptr)
     {
         const rapidjson::Value& options = DICTOOL->getSubDictionary_json(json, OPTIONS);


### PR DESCRIPTION
Fix NodeReader will crash when encountered unknown NodeType
