### PR TITLE
Fix a texture problem when loading PVR image

### DIFF
--- a/cocos2dx/textures/CCTexturePVR.cpp
+++ b/cocos2dx/textures/CCTexturePVR.cpp
@@ -546,7 +546,7 @@ bool CCTexturePVR::createGLTexture()
         glPixelStorei(GL_UNPACK_ALIGNMENT,1);
         
         glGenTextures(1, &m_uName);
-        glBindTexture(GL_TEXTURE_2D, m_uName);
+        ccGLBindTexture2D(m_uName);
         
         // Default: Anti alias.
 		if (m_uNumberOfMipmaps == 1)


### PR DESCRIPTION
Fix a bug which causes current texture changed when loading a PVR image with GLStateCache enabled.
