### PR TITLE
- Due to the fact that map::insert doesn't allow to insert an element by...

### DIFF
--- a/cocos/renderer/CCGLProgramCache.cpp
+++ b/cocos/renderer/CCGLProgramCache.cpp
@@ -387,8 +387,10 @@ GLProgram* GLProgramCache::getGLProgram(const std::string &key)
 
 void GLProgramCache::addGLProgram(GLProgram* program, const std::string &key)
 {
-    program->retain();
-    _programs.insert( std::make_pair( key, program) );
+    if (program)
+        program->retain();
+    
+    _programs[key] = program;
 }
 
 NS_CC_END


### PR DESCRIPTION
Due to the fact that map::insert doesn't allow to insert an element by existing key, I suggest to use operator []. It allows to change the cached value, very helpful on Android platform: when context is lost, the application will reset - rebuild - recache all it's shaders.
