### PR TITLE
-Cocos2d-x used a deprecated method to get the content size of a CCLabel...

### DIFF
--- a/cocos2dx/platform/ios/CCImage.mm
+++ b/cocos2dx/platform/ios/CCImage.mm
@@ -174,14 +174,22 @@ static CGSize _calculateStringSize(NSString *str, id font, CGSize *constrainSize
     textRect.height = constrainSize->height > 0 ? constrainSize->height
                                               : 0x7fffffff;
     
-    
+
     for (NSString *s in listItems)
     {
-        CGSize tmp = [s sizeWithFont:font constrainedToSize:textRect];
+        CGSize tmp;
+        
+        // Method only exists on iOS6+.
+        if([s respondsToSelector:@selector(boundingRectWithSize:options:attributes:context:)]){
+            NSDictionary *attributes = @{NSFontAttributeName: font};
+            tmp = [s boundingRectWithSize:textRect options:(NSStringDrawingOptions)(NSStringDrawingUsesLineFragmentOrigin|NSStringDrawingUsesFontLeading) attributes:attributes context:nil].size;
+        } else {
+            tmp = [s sizeWithFont:font constrainedToSize:textRect];
+        }
         
         if (tmp.width > dim.width)
         {
-           dim.width = tmp.width; 
+            dim.width = tmp.width;
         }
         
         dim.height += tmp.height;


### PR DESCRIPTION
Cocos2d-x used a deprecated method to get the content size of a CCLabelTTF on iOS 7. 

It did not work correctly on iOS7,  If a CCLabelTTF was created with 0 height, it resized itself to contain its contents, but the calculated size was smaller than the real size of what the label required. This caused letters like 'J' to be cropped.

 The problem was the deprecated sizeWithFont method in CCImage calculateStringSize. This worked correctly until iOS6, but gives bad results on iOS7.

In this fix on iOS6+ boundingRectWithSize is used instead of sizeWithFont in CCImage.mm. CCLabelTTF height is now calculated correctly.

See: http://stackoverflow.com/questions/22537998/cclabelttf-contentsize-different-in-ios-6-and-ios-7-cocos2d-x/24364262#24364262
