### PR TITLE
fix a bug that Node::setScale(float) may not work properly

### DIFF
--- a/cocos/2d/CCNode.cpp
+++ b/cocos/2d/CCNode.cpp
@@ -347,7 +347,7 @@ float Node::getScale(void) const
 /// scale setter
 void Node::setScale(float scale)
 {
-    if (_scaleX == scale)
+    if (_scaleX == scale && _scaleY == scale && _scaleZ == scale)
         return;
 
     _scaleX = _scaleY = _scaleZ = scale;


### PR DESCRIPTION
fix a bug that Node::setScale(float) may not work properly if (_scaleX != _scaleY || _scaleX != _scaleZ)
