### PR TITLE
override addChild by name

### DIFF
--- a/cocos/2d/CCMenu.cpp
+++ b/cocos/2d/CCMenu.cpp
@@ -193,6 +193,12 @@ void Menu::addChild(Node * child, int zOrder, int tag)
     Layer::addChild(child, zOrder, tag);
 }
 
+void Menu::addChild(Node * child, int zOrder, const std::string &name)
+{
+    CCASSERT( dynamic_cast<MenuItem*>(child) != nullptr, "Menu only supports MenuItem objects as children");
+    Layer::addChild(child, zOrder, name);
+}
+
 void Menu::onEnter()
 {
     Layer::onEnter();

--- a/cocos/2d/CCMenu.h
+++ b/cocos/2d/CCMenu.h
@@ -132,6 +132,7 @@ public:
     virtual void addChild(Node * child) override;
     virtual void addChild(Node * child, int zOrder) override;
     virtual void addChild(Node * child, int zOrder, int tag) override;
+    virtual void addChild(Node * child, int zOrder, const std::string &name) override;
     
     virtual void onEnter() override;
     virtual void onExit() override;

--- a/cocos/2d/CCNode.h
+++ b/cocos/2d/CCNode.h
@@ -677,16 +677,31 @@ public:
      * @param child     A child node
      * @param zOrder    Z order for drawing priority. Please refer to `setLocalZOrder(int)`
      * @param tag       An integer to identify the node easily. Please refer to `setTag(int)`
+     * 
+     * Please use `addChild(Node* child, int localZOrder, const std::string &name)` instead.
      */
-    virtual void addChild(Node* child, int localZOrder, int tag);
+     virtual void addChild(Node* child, int localZOrder, int tag);
+    /**
+     * Adds a child to the container with z order and tag
+     *
+     * If the child is added to a 'running' node, then 'onEnter' and 'onEnterTransitionDidFinish' will be called immediately.
+     *
+     * @param child     A child node
+     * @param zOrder    Z order for drawing priority. Please refer to `setLocalZOrder(int)`
+     * @param name      A string to identify the node easily. Please refer to `setName(int)`
+     *
+     */
+    virtual void addChild(Node* child, int localZOrder, const std::string &name);
     /**
      * Gets a child from the container with its tag
      *
      * @param tag   An identifier to find the child node.
      *
      * @return a Node object whose tag equals to the input parameter
+     *
+     * Please use `getChildByName()` instead
      */
-    virtual Node * getChildByTag(int tag) const;
+     virtual Node * getChildByTag(int tag) const;
     /**
      * Gets a child from the container with its name
      *
@@ -791,8 +806,17 @@ public:
      *
      * @param tag       An interger number that identifies a child node
      * @param cleanup   true if all running actions and callbacks on the child node will be cleanup, false otherwise.
+     *
+     * Please use `removeChildByName` instead.
      */
-    virtual void removeChildByTag(int tag, bool cleanup = true);
+     virtual void removeChildByTag(int tag, bool cleanup = true);
+    /**
+     * Removes a child from the container by tag value. It will also cleanup all running actions depending on the cleanup parameter
+     *
+     * @param name       A string that identifies a child node
+     * @param cleanup   true if all running actions and callbacks on the child node will be cleanup, false otherwise.
+     */
+    virtual void removeChildByName(const std::string &name, bool cleanup = true);
     /**
      * Removes all children from the container with a cleanup.
      *
@@ -832,16 +856,20 @@ public:
      * Returns a tag that is used to identify the node easily.
      *
      * @return An integer that identifies the node.
+     *
+     * Please use `getTag()` instead.
      */
-    virtual int getTag() const;
+     virtual int getTag() const;
     /**
      * Changes the tag that is used to identify the node easily.
      *
      * Please refer to getTag for the sample code.
      *
      * @param tag   A integer that identifies the node.
+     *
+     * Please use `setName()` instead.
      */
-    virtual void setTag(int tag);
+     virtual void setTag(int tag);
     
     /** Returns a string that is used to identify the node.
      * @return A string that identifies the node.
@@ -1475,6 +1503,11 @@ protected:
     virtual void updatePhysicsBodyPosition(Scene* layer);
     virtual void updatePhysicsBodyRotation(Scene* layer);
 #endif // CC_USE_PHYSICS
+    
+private:
+    void addChildHelper(Node* child, int localZOrder, int tag, const std::string &name, bool setTag);
+    
+protected:
 
     float _rotationX;               ///< rotation on the X-axis
     float _rotationY;               ///< rotation on the Y-axis

--- a/cocos/2d/CCParallaxNode.cpp
+++ b/cocos/2d/CCParallaxNode.cpp
@@ -93,6 +93,14 @@ void ParallaxNode::addChild(Node * child, int zOrder, int tag)
     CCASSERT(0,"ParallaxNode: use addChild:z:parallaxRatio:positionOffset instead");
 }
 
+void ParallaxNode::addChild(Node * child, int zOrder, const std::string &name)
+{
+    CC_UNUSED_PARAM(zOrder);
+    CC_UNUSED_PARAM(child);
+    CC_UNUSED_PARAM(name);
+    CCASSERT(0,"ParallaxNode: use addChild:z:parallaxRatio:positionOffset instead");
+}
+
 void ParallaxNode::addChild(Node *child, int z, const Vec2& ratio, const Vec2& offset)
 {
     CCASSERT( child != nullptr, "Argument must be non-nil");
@@ -105,7 +113,7 @@ void ParallaxNode::addChild(Node *child, int z, const Vec2& ratio, const Vec2& o
     pos.y = -pos.y + pos.y * ratio.y + offset.y;
     child->setPosition(pos);
 
-    Node::addChild(child, z, child->getTag());
+    Node::addChild(child, z, child->getName());
 }
 
 void ParallaxNode::removeChild(Node* child, bool cleanup)

--- a/cocos/2d/CCParallaxNode.h
+++ b/cocos/2d/CCParallaxNode.h
@@ -65,6 +65,7 @@ public:
     // Overrides
     //
     virtual void addChild(Node * child, int zOrder, int tag) override;
+    virtual void addChild(Node * child, int zOrder, const std::string &name) override;
     virtual void removeChild(Node* child, bool cleanup) override;
     virtual void removeAllChildrenWithCleanup(bool cleanup) override;
     virtual void visit(Renderer *renderer, const Mat4 &parentTransform, uint32_t parentFlags) override;

--- a/cocos/2d/CCParticleBatchNode.h
+++ b/cocos/2d/CCParticleBatchNode.h
@@ -95,6 +95,7 @@ public:
 
     using Node::addChild;
     virtual void addChild(Node * child, int zOrder, int tag) override;
+    virtual void addChild(Node * child, int zOrder, const std::string &name) override;
     virtual void removeChild(Node* child, bool cleanup) override;
     virtual void reorderChild(Node * child, int zOrder) override;
     virtual void draw(Renderer *renderer, const Mat4 &transform, uint32_t flags) override;
@@ -136,7 +137,8 @@ private:
     void increaseAtlasCapacityTo(ssize_t quantity);
     int searchNewPositionInChildrenForZ(int z);
     void getCurrentIndex(int* oldIndex, int* newIndex, Node* child, int z);
-    int addChildHelper(ParticleSystem* child, int z, int aTag);
+    int addChildHelper(ParticleSystem* child, int z, int aTag, const std::string &name, bool setTag);
+    void addChildByTagOrName(ParticleSystem* child, int z, int tag, const std::string &name, bool setTag);
     void updateBlendFunc(void);
     /** the texture atlas used for drawing the quads */
     TextureAtlas* _textureAtlas;

--- a/cocos/2d/CCScene.cpp
+++ b/cocos/2d/CCScene.cpp
@@ -111,6 +111,12 @@ void Scene::addChild(Node* child, int zOrder, int tag)
     addChildToPhysicsWorld(child);
 }
 
+void Scene::addChild(Node* child, int zOrder, const std::string &name)
+{
+    Node::addChild(child, zOrder, name);
+    addChildToPhysicsWorld(child);
+}
+
 void Scene::update(float delta)
 {
     Node::update(delta);

--- a/cocos/2d/CCScene.h
+++ b/cocos/2d/CCScene.h
@@ -28,6 +28,7 @@ THE SOFTWARE.
 #ifndef __CCSCENE_H__
 #define __CCSCENE_H__
 
+#include <string>
 #include "2d/CCNode.h"
 #include "physics/CCPhysicsWorld.h"
 
@@ -81,6 +82,7 @@ private:
 #if CC_USE_PHYSICS
 public:
     virtual void addChild(Node* child, int zOrder, int tag) override;
+    virtual void addChild(Node* child, int zOrder, const std::string &name) override;
     virtual void update(float delta) override;
     inline PhysicsWorld* getPhysicsWorld() { return _physicsWorld; }
     static Scene *createWithPhysics();

--- a/cocos/2d/CCSprite.cpp
+++ b/cocos/2d/CCSprite.cpp
@@ -644,6 +644,27 @@ void Sprite::addChild(Node *child, int zOrder, int tag)
     Node::addChild(child, zOrder, tag);
 }
 
+void Sprite::addChild(Node *child, int zOrder, const std::string &name)
+{
+    CCASSERT(child != nullptr, "Argument must be non-nullptr");
+    
+    if (_batchNode)
+    {
+        Sprite* childSprite = dynamic_cast<Sprite*>(child);
+        CCASSERT( childSprite, "CCSprite only supports Sprites as children when using SpriteBatchNode");
+        CCASSERT(childSprite->getTexture()->getName() == _textureAtlas->getTexture()->getName(), "");
+        //put it in descendants array of batch node
+        _batchNode->appendChild(childSprite);
+        
+        if (!_reorderChildDirty)
+        {
+            setReorderChildDirtyRecursively();
+        }
+    }
+    //CCNode already sets isReorderChildDirty_ so this needs to be after batchNode check
+    Node::addChild(child, zOrder, name);
+}
+
 void Sprite::reorderChild(Node *child, int zOrder)
 {
     CCASSERT(child != nullptr, "child must be non null");

--- a/cocos/2d/CCSprite.h
+++ b/cocos/2d/CCSprite.h
@@ -414,6 +414,7 @@ public:
     virtual void reorderChild(Node *child, int zOrder) override;
     using Node::addChild;
     virtual void addChild(Node *child, int zOrder, int tag) override;
+    virtual void addChild(Node *child, int zOrder, const std::string &name) override;
     virtual void sortAllChildren() override;
     virtual void setScale(float scale) override;
     virtual void setPositionZ(float positionZ) override;

--- a/cocos/2d/CCSpriteBatchNode.cpp
+++ b/cocos/2d/CCSpriteBatchNode.cpp
@@ -182,6 +182,19 @@ void SpriteBatchNode::addChild(Node *child, int zOrder, int tag)
     appendChild(sprite);
 }
 
+void SpriteBatchNode::addChild(Node * child, int zOrder, const std::string &name)
+{
+    CCASSERT(child != nullptr, "child should not be null");
+    CCASSERT(dynamic_cast<Sprite*>(child) != nullptr, "CCSpriteBatchNode only supports Sprites as children");
+    Sprite *sprite = static_cast<Sprite*>(child);
+    // check Sprite is using the same texture id
+    CCASSERT(sprite->getTexture()->getName() == _textureAtlas->getTexture()->getName(), "CCSprite is not using the same texture id");
+    
+    Node::addChild(child, zOrder, name);
+    
+    appendChild(sprite);
+}
+
 // override reorderChild
 void SpriteBatchNode::reorderChild(Node *child, int zOrder)
 {

--- a/cocos/2d/CCSpriteBatchNode.h
+++ b/cocos/2d/CCSpriteBatchNode.h
@@ -138,6 +138,7 @@ public:
     
     using Node::addChild;
     virtual void addChild(Node * child, int zOrder, int tag) override;
+    virtual void addChild(Node * child, int zOrder, const std::string &name) override;
     virtual void reorderChild(Node *child, int zOrder) override;
         
     virtual void removeChild(Node *child, bool cleanup) override;

--- a/cocos/editor-support/cocostudio/CCBatchNode.cpp
+++ b/cocos/editor-support/cocostudio/CCBatchNode.cpp
@@ -66,19 +66,23 @@ bool BatchNode::init()
     return ret;
 }
 
-void BatchNode::addChild(Node *pChild)
-{
-    Node::addChild(pChild);
-}
-
-void BatchNode::addChild(Node *child, int zOrder)
-{
-    Node::addChild(child, zOrder);
-}
-
 void BatchNode::addChild(Node *child, int zOrder, int tag)
 {
     Node::addChild(child, zOrder, tag);
+    Armature *armature = dynamic_cast<Armature *>(child);
+    if (armature != nullptr)
+    {
+        armature->setBatchNode(this);
+        if (_groupCommand == nullptr)
+        {
+            _groupCommand = new GroupCommand();
+        }
+    }
+}
+
+void BatchNode::addChild(cocos2d::Node *child, int zOrder, const std::string &name)
+{
+    Node::addChild(child, zOrder, name);
     Armature *armature = dynamic_cast<Armature *>(child);
     if (armature != nullptr)
     {

--- a/cocos/editor-support/cocostudio/CCBatchNode.h
+++ b/cocos/editor-support/cocostudio/CCBatchNode.h
@@ -52,9 +52,9 @@ public:
      *  @js NA
      */
     virtual bool init() override;
-    virtual void addChild(cocos2d::Node *pChild) override;
-    virtual void addChild(cocos2d::Node *pChild, int zOrder) override;
+    using Node::addChild;
     virtual void addChild(cocos2d::Node *pChild, int zOrder, int tag) override;
+    virtual void addChild(cocos2d::Node *pChild, int zOrder, const std::string &name) override;
     virtual void removeChild(cocos2d::Node* child, bool cleanup) override;
     virtual void visit(cocos2d::Renderer *renderer, const cocos2d::Mat4 &parentTransform, uint32_t parentFlags) override;
     virtual void draw(cocos2d::Renderer *renderer, const cocos2d::Mat4 &transform, uint32_t flags) override;

--- a/cocos/ui/UILayout.cpp
+++ b/cocos/ui/UILayout.cpp
@@ -152,16 +152,6 @@ bool Layout::init()
     }
     return false;
 }
-    
-void Layout::addChild(Node *child)
-{
-    Layout::addChild(child, child->getZOrder(), child->getTag());
-}
-
-void Layout::addChild(Node * child, int zOrder)
-{
-    Layout::addChild(child, zOrder, child->getTag());
-}
 
 void Layout::addChild(Node *child, int zOrder, int tag)
 {
@@ -169,6 +159,15 @@ void Layout::addChild(Node *child, int zOrder, int tag)
         supplyTheLayoutParameterLackToChild(static_cast<Widget*>(child));
     }
     Widget::addChild(child, zOrder, tag);
+    _doLayoutDirty = true;
+}
+    
+void Layout::addChild(Node* child, int zOrder, const std::string &name)
+{
+    if (dynamic_cast<Widget*>(child)) {
+        supplyTheLayoutParameterLackToChild(static_cast<Widget*>(child));
+    }
+    Widget::addChild(child, zOrder, name);
     _doLayoutDirty = true;
 }
     

--- a/cocos/ui/UILayout.h
+++ b/cocos/ui/UILayout.h
@@ -232,16 +232,7 @@ public:
     
     virtual  Type getLayoutType() const;
 
-    virtual void addChild(Node * child) override;
-    /**
-     * Adds a child to the container with a z-order
-     *
-     * If the child is added to a 'running' node, then 'onEnter' and 'onEnterTransitionDidFinish' will be called immediately.
-     *
-     * @param child     A child node
-     * @param zOrder    Z order for drawing priority. Please refer to setLocalZOrder(int)
-     */
-    virtual void addChild(Node * child, int zOrder) override;
+    using Node::addChild;
     /**
      * Adds a child to the container with z order and tag
      *
@@ -252,6 +243,7 @@ public:
      * @param tag       A interger to identify the node easily. Please refer to setTag(int)
      */
     virtual void addChild(Node* child, int zOrder, int tag) override;
+    virtual void addChild(Node* child, int zOrder, const std::string &name) override;
     
     virtual void visit(Renderer *renderer, const Mat4 &parentTransform, uint32_t parentFlags) override;
 

--- a/cocos/ui/UIListView.cpp
+++ b/cocos/ui/UIListView.cpp
@@ -279,16 +279,6 @@ void ListView::pushBackCustomItem(Widget* item)
     _refreshViewDirty = true;
 }
     
-void ListView::addChild(cocos2d::Node *child)
-{
-    ListView::addChild(child, child->getZOrder(), child->getTag());
-}
-    
-void ListView::addChild(cocos2d::Node *child, int zOrder)
-{
-    ListView::addChild(child, zOrder, child->getTag());
-}
-    
 void ListView::addChild(cocos2d::Node *child, int zOrder, int tag)
 {
     ScrollView::addChild(child, zOrder, tag);
@@ -298,7 +288,17 @@ void ListView::addChild(cocos2d::Node *child, int zOrder, int tag)
     {
         _items.pushBack(widget);
     }
-
+}
+ 
+void ListView::addChild(Node* child, int zOrder, const std::string &name)
+{
+    ScrollView::addChild(child, zOrder, name);
+    
+    Widget* widget = dynamic_cast<Widget*>(child);
+    if (widget)
+    {
+        _items.pushBack(widget);
+    }
 }
     
 void ListView::removeChild(cocos2d::Node *child, bool cleaup)

--- a/cocos/ui/UIListView.h
+++ b/cocos/ui/UIListView.h
@@ -163,9 +163,9 @@ public:
     
     virtual void doLayout() override;
     
-    virtual void addChild(Node * child) override;
-    virtual void addChild(Node * child, int zOrder) override;
+    using ScrollView::addChild;
     virtual void addChild(Node* child, int zOrder, int tag) override;
+    virtual void addChild(Node* child, int zOrder, const std::string &name) override;
     virtual void removeAllChildren() override;
     virtual void removeAllChildrenWithCleanup(bool cleanup) override;
 	virtual void removeChild(Node* child, bool cleaup = true) override;

--- a/cocos/ui/UIRichText.cpp
+++ b/cocos/ui/UIRichText.cpp
@@ -371,7 +371,7 @@ void RichText::formarRenderers()
             Node* l = row->at(j);
             l->setAnchorPoint(Vec2::ZERO);
             l->setPosition(Vec2(nextPosX, 0.0f));
-            _elementRenderersContainer->addChild(l, 1, (int)j);
+            _elementRenderersContainer->addChild(l, 1);
             Size iSize = l->getContentSize();
             newContentSizeWidth += iSize.width;
             newContentSizeHeight = MAX(newContentSizeHeight, iSize.height);
@@ -410,7 +410,7 @@ void RichText::formarRenderers()
                 Node* l = row->at(j);
                 l->setAnchorPoint(Vec2::ZERO);
                 l->setPosition(Vec2(nextPosX, nextPosY));
-                _elementRenderersContainer->addChild(l, 1, (int)(i*10 + j));
+                _elementRenderersContainer->addChild(l, 1);
                 nextPosX += l->getContentSize().width;
             }
         }

--- a/cocos/ui/UIScrollView.cpp
+++ b/cocos/ui/UIScrollView.cpp
@@ -228,20 +228,15 @@ const Size& ScrollView::getInnerContainerSize() const
 {
 	return _innerContainer->getContentSize();
 }
-    
-void ScrollView::addChild(Node *child)
-{
-    ScrollView::addChild(child, child->getZOrder(), child->getTag());
-}
-
-void ScrollView::addChild(Node * child, int zOrder)
-{
-    ScrollView::addChild(child, zOrder, child->getTag());
-}
 
 void ScrollView::addChild(Node *child, int zOrder, int tag)
 {
     _innerContainer->addChild(child, zOrder, tag);
+}
+    
+void ScrollView::addChild(Node* child, int zOrder, const std::string &name)
+{
+    _innerContainer->addChild(child, zOrder, name);
 }
 
 void ScrollView::removeAllChildren()

--- a/cocos/ui/UIScrollView.h
+++ b/cocos/ui/UIScrollView.h
@@ -254,9 +254,9 @@ public:
     virtual void addEventListener(const ccScrollViewCallback& callback);
     
     //all of these functions are related to innerContainer.
-    virtual void addChild(Node * child) override;
-    virtual void addChild(Node * child, int zOrder) override;
+    using Layout::addChild;
     virtual void addChild(Node* child, int zOrder, int tag) override;
+    virtual void addChild(Node* child, int zOrder, const std::string &name) override;
     virtual void removeAllChildren() override;
     virtual void removeAllChildrenWithCleanup(bool cleanup) override;
 	virtual void removeChild(Node* child, bool cleaup = true) override;

--- a/extensions/GUI/CCControlExtension/CCScale9Sprite.cpp
+++ b/extensions/GUI/CCControlExtension/CCScale9Sprite.cpp
@@ -32,19 +32,6 @@ THE SOFTWARE.
 
 NS_CC_EXT_BEGIN
 
-enum positions
-{
-    pCentre = 0,
-    pTop,
-    pLeft,
-    pRight,
-    pBottom,
-    pTopRight,
-    pTopLeft,
-    pBottomRight,
-    pBottomLeft
-};
-
 Scale9Sprite::Scale9Sprite()
 : _spritesGenerated(false)
 , _spriteFrameRotated(false)
@@ -251,48 +238,48 @@ bool Scale9Sprite::updateWithBatchNode(SpriteBatchNode* batchnode, const Rect& o
         // Centre
         _centre = Sprite::createWithTexture(_scale9Image->getTexture(), centerbounds);
         _centre->retain();
-        this->addChild(_centre, 0, pCentre);
+        this->addChild(_centre, 0);
 
         
         // Top
         _top = Sprite::createWithTexture(_scale9Image->getTexture(), centertopbounds);
         _top->retain();
-        this->addChild(_top, 1, pTop);
+        this->addChild(_top, 1);
         
         // Bottom
         _bottom = Sprite::createWithTexture(_scale9Image->getTexture(), centerbottombounds);
         _bottom->retain();
-        this->addChild(_bottom, 1, pBottom);
+        this->addChild(_bottom, 1);
         
         // Left
         _left = Sprite::createWithTexture(_scale9Image->getTexture(), leftcenterbounds);
         _left->retain();
-        this->addChild(_left, 1, pLeft);
+        this->addChild(_left, 1);
         
         // Right
         _right = Sprite::createWithTexture(_scale9Image->getTexture(), rightcenterbounds);
         _right->retain();
-        this->addChild(_right, 1, pRight);
+        this->addChild(_right, 1);
         
         // Top left
         _topLeft = Sprite::createWithTexture(_scale9Image->getTexture(), lefttopbounds);
         _topLeft->retain();
-        this->addChild(_topLeft, 2, pTopLeft);
+        this->addChild(_topLeft, 2);
         
         // Top right
         _topRight = Sprite::createWithTexture(_scale9Image->getTexture(), righttopbounds);
         _topRight->retain();
-        this->addChild(_topRight, 2, pTopRight);
+        this->addChild(_topRight, 2);
         
         // Bottom left
         _bottomLeft = Sprite::createWithTexture(_scale9Image->getTexture(), leftbottombounds);
         _bottomLeft->retain();
-        this->addChild(_bottomLeft, 2, pBottomLeft);
+        this->addChild(_bottomLeft, 2);
         
         // Bottom right
         _bottomRight = Sprite::createWithTexture(_scale9Image->getTexture(), rightbottombounds);
         _bottomRight->retain();
-        this->addChild(_bottomRight, 2, pBottomRight);
+        this->addChild(_bottomRight, 2);
     } else {
         // set up transformation of coordinates
         // to handle the case where the sprite is stored rotated
@@ -337,47 +324,47 @@ bool Scale9Sprite::updateWithBatchNode(SpriteBatchNode* batchnode, const Rect& o
         // Centre
         _centre = Sprite::createWithTexture(_scale9Image->getTexture(), rotatedcenterbounds, true);
         _centre->retain();
-        this->addChild(_centre, 0, pCentre);
+        this->addChild(_centre, 0);
         
         // Top
         _top = Sprite::createWithTexture(_scale9Image->getTexture(), rotatedcentertopbounds, true);
         _top->retain();
-        this->addChild(_top, 1, pTop);
+        this->addChild(_top, 1);
         
         // Bottom
         _bottom = Sprite::createWithTexture(_scale9Image->getTexture(), rotatedcenterbottombounds, true);
         _bottom->retain();
-        this->addChild(_bottom, 1, pBottom);
+        this->addChild(_bottom, 1);
         
         // Left
         _left = Sprite::createWithTexture(_scale9Image->getTexture(), rotatedleftcenterbounds, true);
         _left->retain();
-        this->addChild(_left, 1, pLeft);
+        this->addChild(_left, 1);
         
         // Right
         _right = Sprite::createWithTexture(_scale9Image->getTexture(), rotatedrightcenterbounds, true);
         _right->retain();
-        this->addChild(_right, 1, pRight);
+        this->addChild(_right, 1);
         
         // Top left
         _topLeft = Sprite::createWithTexture(_scale9Image->getTexture(), rotatedlefttopbounds, true);
         _topLeft->retain();
-        this->addChild(_topLeft, 2, pTopLeft);
+        this->addChild(_topLeft, 2);
         
         // Top right
         _topRight = Sprite::createWithTexture(_scale9Image->getTexture(), rotatedrighttopbounds, true);
         _topRight->retain();
-        this->addChild(_topRight, 2, pTopRight);
+        this->addChild(_topRight, 2);
         
         // Bottom left
         _bottomLeft = Sprite::createWithTexture(_scale9Image->getTexture(), rotatedleftbottombounds, true);
         _bottomLeft->retain();
-        this->addChild(_bottomLeft, 2, pBottomLeft);
+        this->addChild(_bottomLeft, 2);
         
         // Bottom right
         _bottomRight = Sprite::createWithTexture(_scale9Image->getTexture(), rotatedrightbottombounds, true);
         _bottomRight->retain();
-        this->addChild(_bottomRight, 2, pBottomRight);
+        this->addChild(_bottomRight, 2);
     }
 
     this->setContentSize(rect.size);

--- a/extensions/GUI/CCScrollView/CCScrollView.cpp
+++ b/extensions/GUI/CCScrollView/CCScrollView.cpp
@@ -490,6 +490,18 @@ void ScrollView::addChild(Node * child, int zOrder, int tag)
     }
 }
 
+void ScrollView::addChild(Node * child, int zOrder, const std::string &name)
+{
+    if (_container != child)
+    {
+        _container->addChild(child, zOrder, name);
+    }
+    else
+    {
+        Layer::addChild(child, zOrder, name);
+    }
+}
+
 void ScrollView::beforeDraw()
 {
     _beforeDrawCommand.init(_globalZOrder);

--- a/extensions/GUI/CCScrollView/CCScrollView.h
+++ b/extensions/GUI/CCScrollView/CCScrollView.h
@@ -229,6 +229,7 @@ public:
     
     using Node::addChild;
     virtual void addChild(Node * child, int zOrder, int tag) override;
+    virtual void addChild(Node * child, int zOrder, const std::string &name) override;
 
     /**
      * CCActionTweenDelegate


### PR DESCRIPTION
`Node::addChild(Node* node, int localZOrder, const string& name)` is added, so its sub class that override `addChild(Node* node, int localZOrder, int tag)` should also override this function too.
