### PR TITLE
-String size should be calculated correctly on iOS7+ now.

### DIFF
--- a/cocos/platform/ios/CCDevice.mm
+++ b/cocos/platform/ios/CCDevice.mm
@@ -215,14 +215,34 @@ static inline void lazyCheckIOS7()
 
 static CGSize _calculateStringSize(NSString *str, id font, CGSize *constrainSize)
 {
+    NSArray *listItems = [str componentsSeparatedByString: @"\n"];
+    CGSize dim = CGSizeZero;
     CGSize textRect = CGSizeZero;
     textRect.width = constrainSize->width > 0 ? constrainSize->width
     : 0x7fffffff;
     textRect.height = constrainSize->height > 0 ? constrainSize->height
     : 0x7fffffff;
     
-    CGSize dim = [str sizeWithFont:font constrainedToSize:textRect];
-
+    for (NSString *s in listItems)
+    {
+        CGSize tmp;
+        
+        // Method only exists on iOS6+.
+        if([s respondsToSelector:@selector(boundingRectWithSize:options:attributes:context:)]){
+            NSDictionary *attributes = @{NSFontAttributeName: font};
+            tmp = [s boundingRectWithSize:textRect options:(NSStringDrawingOptions)(NSStringDrawingUsesLineFragmentOrigin|NSStringDrawingUsesFontLeading) attributes:attributes context:nil].size;
+        } else {
+            tmp = [s sizeWithFont:font constrainedToSize:textRect];
+        }
+        
+        if (tmp.width > dim.width)
+        {
+            dim.width = tmp.width;
+        }
+        
+        dim.height += tmp.height;
+    }
+    
     dim.width = ceilf(dim.width);
     dim.height = ceilf(dim.height);
     


### PR DESCRIPTION
It is the same issue with the same solution, but for cocos2d-x 3.

https://github.com/cocos2d/cocos2d-x/pull/7179
