### PR TITLE
WP8 v3 fix for cpp template

### DIFF
--- a/cocos/editor-support/cocostudio/proj.wp8/libCocosStudio.vcxproj
+++ b/cocos/editor-support/cocostudio/proj.wp8/libCocosStudio.vcxproj
@@ -274,7 +274,6 @@
     <ClInclude Include="..\CCUtilMath.h" />
     <ClInclude Include="..\CocoLoader.h" />
     <ClInclude Include="..\DictionaryHelper.h" />
-    <ClInclude Include="..\ObjectFactory.h" />
     <ClInclude Include="..\TriggerBase.h" />
     <ClInclude Include="..\TriggerMng.h" />
     <ClInclude Include="..\TriggerObj.h" />

--- a/cocos/editor-support/cocostudio/proj.wp8/libCocosStudio.vcxproj.filters
+++ b/cocos/editor-support/cocostudio/proj.wp8/libCocosStudio.vcxproj.filters
@@ -375,9 +375,6 @@
     <ClInclude Include="..\CCActionObject.h">
       <Filter>action</Filter>
     </ClInclude>
-    <ClInclude Include="..\ObjectFactory.h">
-      <Filter>trigger</Filter>
-    </ClInclude>
     <ClInclude Include="..\TriggerBase.h">
       <Filter>trigger</Filter>
     </ClInclude>

--- a/cocos/platform/wp8-xaml/CopyTemplateFiles.vcxproj
+++ b/cocos/platform/wp8-xaml/CopyTemplateFiles.vcxproj
@@ -73,7 +73,8 @@ xcopy "xaml\App.xaml.cs" "..\..\..\templates\cpp-template-default\proj.wp8-xaml\
 xcopy "xaml\MainPage.xaml" "..\..\..\templates\cpp-template-default\proj.wp8-xaml\App\*" /eiycq
 xcopy "xaml\MainPage.xaml.cs" "..\..\..\templates\cpp-template-default\proj.wp8-xaml\App\*" /eiycq
 xcopy "xaml\EditBox.xaml" "..\..\..\templates\cpp-template-default\proj.wp8-xaml\App\*" /eiycq
-xcopy "xaml\EditBox.xaml.cs" "..\..\..\templates\cpp-template-default\proj.wp8-xaml\App\*" /eiycq</Command>
+xcopy "xaml\EditBox.xaml.cs" "..\..\..\templates\cpp-template-default\proj.wp8-xaml\App\*" /eiycq
+xcopy "cpp" "..\..\..\templates\cpp-template-default\proj.wp8-xaml\AppComponent\src\" /eiycq</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -94,7 +95,8 @@ xcopy "xaml\App.xaml.cs" "..\..\..\templates\cpp-template-default\proj.wp8-xaml\
 xcopy "xaml\MainPage.xaml" "..\..\..\templates\cpp-template-default\proj.wp8-xaml\App\*" /eiycq
 xcopy "xaml\MainPage.xaml.cs" "..\..\..\templates\cpp-template-default\proj.wp8-xaml\App\*" /eiycq
 xcopy "xaml\EditBox.xaml" "..\..\..\templates\cpp-template-default\proj.wp8-xaml\App\*" /eiycq
-xcopy "xaml\EditBox.xaml.cs" "..\..\..\templates\cpp-template-default\proj.wp8-xaml\App\*" /eiycq</Command>
+xcopy "xaml\EditBox.xaml.cs" "..\..\..\templates\cpp-template-default\proj.wp8-xaml\App\*" /eiycq
+xcopy "cpp" "..\..\..\templates\cpp-template-default\proj.wp8-xaml\AppComponent\src\" /eiycq</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
@@ -115,7 +117,8 @@ xcopy "xaml\App.xaml.cs" "..\..\..\templates\cpp-template-default\proj.wp8-xaml\
 xcopy "xaml\MainPage.xaml" "..\..\..\templates\cpp-template-default\proj.wp8-xaml\App\*" /eiycq
 xcopy "xaml\MainPage.xaml.cs" "..\..\..\templates\cpp-template-default\proj.wp8-xaml\App\*" /eiycq
 xcopy "xaml\EditBox.xaml" "..\..\..\templates\cpp-template-default\proj.wp8-xaml\App\*" /eiycq
-xcopy "xaml\EditBox.xaml.cs" "..\..\..\templates\cpp-template-default\proj.wp8-xaml\App\*" /eiycq</Command>
+xcopy "xaml\EditBox.xaml.cs" "..\..\..\templates\cpp-template-default\proj.wp8-xaml\App\*" /eiycq
+xcopy "cpp" "..\..\..\templates\cpp-template-default\proj.wp8-xaml\AppComponent\src\" /eiycq</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
@@ -136,7 +139,8 @@ xcopy "xaml\App.xaml.cs" "..\..\..\templates\cpp-template-default\proj.wp8-xaml\
 xcopy "xaml\MainPage.xaml" "..\..\..\templates\cpp-template-default\proj.wp8-xaml\App\*" /eiycq
 xcopy "xaml\MainPage.xaml.cs" "..\..\..\templates\cpp-template-default\proj.wp8-xaml\App\*" /eiycq
 xcopy "xaml\EditBox.xaml" "..\..\..\templates\cpp-template-default\proj.wp8-xaml\App\*" /eiycq
-xcopy "xaml\EditBox.xaml.cs" "..\..\..\templates\cpp-template-default\proj.wp8-xaml\App\*" /eiycq</Command>
+xcopy "xaml\EditBox.xaml.cs" "..\..\..\templates\cpp-template-default\proj.wp8-xaml\App\*" /eiycq
+xcopy "cpp" "..\..\..\templates\cpp-template-default\proj.wp8-xaml\AppComponent\src\" /eiycq</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/templates/cpp-template-default/proj.wp8-xaml/AppComponent/HelloCppComponent.vcxproj
+++ b/templates/cpp-template-default/proj.wp8-xaml/AppComponent/HelloCppComponent.vcxproj
@@ -203,11 +203,6 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="..\..\cocos2d\cocos\platform\wp8-xaml\cpp\Cocos2dRenderer.cpp" />
-    <ClCompile Include="..\..\cocos2d\cocos\platform\wp8-xaml\cpp\Direct3DContentProvider.cpp" />
-    <ClCompile Include="..\..\cocos2d\cocos\platform\wp8-xaml\cpp\Direct3DInterop.cpp" />
-    <ClCompile Include="..\..\cocos2d\cocos\platform\wp8-xaml\cpp\DirectXBase.cpp" />
-    <ClCompile Include="..\..\cocos2d\cocos\platform\wp8-xaml\cpp\EditBoxEvent.cpp" />
     <ClCompile Include="..\..\Classes\AppDelegate.cpp" />
     <ClCompile Include="..\..\Classes\HelloWorldScene.cpp" />
     <ClCompile Include="pch.cpp">
@@ -216,17 +211,22 @@
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Create</PrecompiledHeader>
     </ClCompile>
+    <ClCompile Include="src\Cocos2dRenderer.cpp" />
+    <ClCompile Include="src\Direct3DContentProvider.cpp" />
+    <ClCompile Include="src\Direct3DInterop.cpp" />
+    <ClCompile Include="src\DirectXBase.cpp" />
+    <ClCompile Include="src\EditBoxEvent.cpp" />
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="..\..\cocos2d\cocos\platform\wp8-xaml\cpp\Cocos2dRenderer.h" />
-    <ClInclude Include="..\..\cocos2d\cocos\platform\wp8-xaml\cpp\Direct3DContentProvider.h" />
-    <ClInclude Include="..\..\cocos2d\cocos\platform\wp8-xaml\cpp\Direct3DInterop.h" />
-    <ClInclude Include="..\..\cocos2d\cocos\platform\wp8-xaml\cpp\DirectXBase.h" />
-    <ClInclude Include="..\..\cocos2d\cocos\platform\wp8-xaml\cpp\DirectXHelper.h" />
-    <ClInclude Include="..\..\cocos2d\cocos\platform\wp8-xaml\cpp\EditBoxEvent.h" />
     <ClInclude Include="..\..\Classes\AppDelegate.h" />
     <ClInclude Include="..\..\Classes\HelloWorldScene.h" />
     <ClInclude Include="pch.h" />
+    <ClInclude Include="src\Cocos2dRenderer.h" />
+    <ClInclude Include="src\Direct3DContentProvider.h" />
+    <ClInclude Include="src\Direct3DInterop.h" />
+    <ClInclude Include="src\DirectXBase.h" />
+    <ClInclude Include="src\DirectXHelper.h" />
+    <ClInclude Include="src\EditBoxEvent.h" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\cocos2d\external\curl\prebuilt\wp8\arm\libcurl.dll">

--- a/templates/cpp-template-default/proj.wp8-xaml/AppComponent/HelloCppComponent.vcxproj.filters
+++ b/templates/cpp-template-default/proj.wp8-xaml/AppComponent/HelloCppComponent.vcxproj.filters
@@ -1,11 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <ClCompile Include="..\..\cocos2d\cocos\platform\wp8-xaml\cpp\Cocos2dRenderer.cpp" />
-    <ClCompile Include="..\..\cocos2d\cocos\platform\wp8-xaml\cpp\Direct3DContentProvider.cpp" />
-    <ClCompile Include="..\..\cocos2d\cocos\platform\wp8-xaml\cpp\Direct3DInterop.cpp" />
-    <ClCompile Include="..\..\cocos2d\cocos\platform\wp8-xaml\cpp\DirectXBase.cpp" />
-    <ClCompile Include="..\..\cocos2d\cocos\platform\wp8-xaml\cpp\EditBoxEvent.cpp" />
     <ClCompile Include="pch.cpp" />
     <ClCompile Include="..\..\Classes\AppDelegate.cpp">
       <Filter>Classes</Filter>
@@ -13,14 +8,23 @@
     <ClCompile Include="..\..\Classes\HelloWorldScene.cpp">
       <Filter>Classes</Filter>
     </ClCompile>
+    <ClCompile Include="src\Cocos2dRenderer.cpp">
+      <Filter>src</Filter>
+    </ClCompile>
+    <ClCompile Include="src\Direct3DContentProvider.cpp">
+      <Filter>src</Filter>
+    </ClCompile>
+    <ClCompile Include="src\Direct3DInterop.cpp">
+      <Filter>src</Filter>
+    </ClCompile>
+    <ClCompile Include="src\DirectXBase.cpp">
+      <Filter>src</Filter>
+    </ClCompile>
+    <ClCompile Include="src\EditBoxEvent.cpp">
+      <Filter>src</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="..\..\cocos2d\cocos\platform\wp8-xaml\cpp\Cocos2dRenderer.h" />
-    <ClInclude Include="..\..\cocos2d\cocos\platform\wp8-xaml\cpp\Direct3DContentProvider.h" />
-    <ClInclude Include="..\..\cocos2d\cocos\platform\wp8-xaml\cpp\Direct3DInterop.h" />
-    <ClInclude Include="..\..\cocos2d\cocos\platform\wp8-xaml\cpp\DirectXBase.h" />
-    <ClInclude Include="..\..\cocos2d\cocos\platform\wp8-xaml\cpp\DirectXHelper.h" />
-    <ClInclude Include="..\..\cocos2d\cocos\platform\wp8-xaml\cpp\EditBoxEvent.h" />
     <ClInclude Include="pch.h" />
     <ClInclude Include="..\..\Classes\AppDelegate.h">
       <Filter>Classes</Filter>
@@ -28,10 +32,31 @@
     <ClInclude Include="..\..\Classes\HelloWorldScene.h">
       <Filter>Classes</Filter>
     </ClInclude>
+    <ClInclude Include="src\Cocos2dRenderer.h">
+      <Filter>src</Filter>
+    </ClInclude>
+    <ClInclude Include="src\Direct3DContentProvider.h">
+      <Filter>src</Filter>
+    </ClInclude>
+    <ClInclude Include="src\Direct3DInterop.h">
+      <Filter>src</Filter>
+    </ClInclude>
+    <ClInclude Include="src\DirectXBase.h">
+      <Filter>src</Filter>
+    </ClInclude>
+    <ClInclude Include="src\DirectXHelper.h">
+      <Filter>src</Filter>
+    </ClInclude>
+    <ClInclude Include="src\EditBoxEvent.h">
+      <Filter>src</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Classes">
       <UniqueIdentifier>{facbd0ff-d271-46ef-8324-beff0cbcb424}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="src">
+      <UniqueIdentifier>{6fcff44b-bb9f-4ed9-8553-558855bc91e3}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
   <ItemGroup>

--- a/templates/cpp-template-default/proj.wp8-xaml/AppComponent/src/Cocos2dRenderer.cpp
+++ b/templates/cpp-template-default/proj.wp8-xaml/AppComponent/src/Cocos2dRenderer.cpp
@@ -1,0 +1,187 @@
+﻿/****************************************************************************
+Copyright (c) 2013 cocos2d-x.org
+Copyright (c) Microsoft Open Technologies, Inc.
+
+http://www.cocos2d-x.org
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+****************************************************************************/
+
+#include "Cocos2dRenderer.h"
+#include "cocos2d.h"
+#include "CCApplication.h"
+#include "CCGLView.h"
+#include "AppDelegate.h"
+#include <ppltasks.h>
+
+using namespace Concurrency;
+using namespace DirectX;
+using namespace Microsoft::WRL;
+using namespace Windows::Foundation;
+using namespace Windows::UI::Core;
+using namespace PhoneDirect3DXamlAppComponent;
+
+USING_NS_CC;
+
+Cocos2dRenderer::Cocos2dRenderer(Windows::Graphics::Display::DisplayOrientations orientation): mInitialized(false), m_loadingComplete(false), m_delegate(nullptr), m_messageBoxDelegate(nullptr)
+{
+    mApp = new AppDelegate();
+    m_orientation = orientation;
+}
+
+// Creates and restores Cocos2d-x after DirectX and Angle contexts are created or updated
+void Cocos2dRenderer::CreateGLResources()
+{
+    auto director = cocos2d::Director::getInstance();
+
+    if(!mInitialized)
+    {
+        mInitialized = true;
+        GLView* glview = GLView::create("Test Cpp");
+	    glview->Create(m_eglDisplay, m_eglContext, m_eglSurface, m_renderTargetSize.Width, m_renderTargetSize.Height,m_orientation);
+        director->setOpenGLView(glview);
+        CCApplication::getInstance()->run();
+        glview->SetXamlEventDelegate(m_delegate);
+        glview->SetXamlMessageBoxDelegate(m_messageBoxDelegate);
+        glview->SetXamlEditBoxDelegate(m_editBoxDelegate);
+   }
+    else
+    {
+        cocos2d::GL::invalidateStateCache();
+        cocos2d::ShaderCache::getInstance()->reloadDefaultGLPrograms();
+        cocos2d::DrawPrimitives::init();
+        cocos2d::VolatileTextureMgr::reloadAllTextures();
+        cocos2d::EventCustom foregroundEvent(EVENT_COME_TO_FOREGROUND);
+        director->getEventDispatcher()->dispatchEvent(&foregroundEvent);
+        cocos2d::Application::getInstance()->applicationWillEnterForeground();
+        director->setGLDefaultValues();
+  }
+
+    m_loadingComplete = true;
+}
+
+void Cocos2dRenderer::Connect()
+{
+
+}
+
+// purge Cocos2d-x gl GL resourses since the DirectX/Angle Context has been lost 
+void Cocos2dRenderer::Disconnect()
+{
+    Application::getInstance()->applicationDidEnterBackground();
+    cocos2d::EventCustom backgroundEvent(EVENT_COME_TO_BACKGROUND);
+    cocos2d::Director::getInstance()->getEventDispatcher()->dispatchEvent(&backgroundEvent); 
+    CloseAngle();
+    m_loadingComplete = false;
+}
+
+// save your game state here
+IAsyncAction^ Cocos2dRenderer::OnSuspending()
+{
+    return create_async([]() { 
+        // save your game state here
+    });
+}
+
+
+void Cocos2dRenderer::OnUpdateDevice()
+{
+    GLView* glview = GLView::sharedOpenGLView();
+    glview->UpdateDevice(m_eglDisplay, m_eglContext, m_eglSurface);
+}
+
+void Cocos2dRenderer::OnOrientationChanged(Windows::Graphics::Display::DisplayOrientations orientation)
+{
+	DirectXBase::OnOrientationChanged(orientation);
+    GLView::sharedOpenGLView()->UpdateOrientation(orientation);
+}
+
+// return true if eglSwapBuffers was called by OnRender()
+bool Cocos2dRenderer::OnRender()
+{
+    if(m_loadingComplete)
+    {
+        GLView* glview = GLView::sharedOpenGLView();
+        glview->Render();
+        return true; // eglSwapBuffers was called by glview->Render();
+    }
+    return false;
+}
+
+void Cocos2dRenderer::OnKeyPressed(Platform::String^ text)
+{
+    char szUtf8[8] = {0};
+    int nLen = WideCharToMultiByte(CP_UTF8, 0, (LPCWSTR)text->Data(), 1, szUtf8, sizeof(szUtf8), NULL, NULL);
+    IMEDispatcher::sharedDispatcher()->dispatchInsertText(szUtf8, nLen);
+}
+
+void Cocos2dRenderer::OnCocos2dKeyEvent(Cocos2dKeyEvent event)
+{
+    switch(event)
+    {
+    case Cocos2dKeyEvent::Escape:
+        //Director::getInstance()()->getKeypadDispatcher()->dispatchKeypadMSG(kTypeBackClicked);
+        break;
+	case Cocos2dKeyEvent::Back:
+        IMEDispatcher::sharedDispatcher()->dispatchDeleteBackward();
+        break;
+    case Cocos2dKeyEvent::Enter:
+		//SetFocus(false);
+        IMEDispatcher::sharedDispatcher()->dispatchInsertText("\n", 1);
+        break;
+    default:
+        break;
+    }
+
+}
+
+void Cocos2dRenderer::SetXamlEventDelegate(PhoneDirect3DXamlAppComponent::Cocos2dEventDelegate^ delegate)
+{
+    m_delegate = delegate;
+    GLView* eglView = GLView::sharedOpenGLView();
+    if(eglView)
+    {
+        eglView->SetXamlEventDelegate(delegate);
+    }
+}
+
+void Cocos2dRenderer::SetXamlMessageBoxDelegate(PhoneDirect3DXamlAppComponent::Cocos2dMessageBoxDelegate^ delegate)
+{
+    m_messageBoxDelegate = delegate;
+    GLView* eglView = GLView::sharedOpenGLView();
+    if(eglView)
+    {
+        eglView->SetXamlMessageBoxDelegate(delegate);
+    }
+}
+
+void Cocos2dRenderer::SetXamlEditBoxDelegate(PhoneDirect3DXamlAppComponent::Cocos2dEditBoxDelegate^ delegate)
+{
+    m_editBoxDelegate = delegate;
+    GLView* eglView = GLView::sharedOpenGLView();
+    if(eglView)
+    {
+        eglView->SetXamlEditBoxDelegate(delegate);
+    }
+}
+
+
+
+
+

--- a/templates/cpp-template-default/proj.wp8-xaml/AppComponent/src/Cocos2dRenderer.h
+++ b/templates/cpp-template-default/proj.wp8-xaml/AppComponent/src/Cocos2dRenderer.h
@@ -1,0 +1,68 @@
+﻿/****************************************************************************
+Copyright (c) 2013 cocos2d-x.org
+Copyright (c) Microsoft Open Technologies, Inc.
+
+http://www.cocos2d-x.org
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+****************************************************************************/
+#pragma once
+
+#include "InputEvent.h"
+#include "DirectXBase.h"
+
+class AppDelegate;
+ 
+ref class Cocos2dRenderer sealed : public DirectXBase
+{
+public:
+	Cocos2dRenderer(Windows::Graphics::Display::DisplayOrientations orientation);
+
+	// Direct3DBase methods.
+	virtual void OnOrientationChanged(Windows::Graphics::Display::DisplayOrientations orientation) override;
+	virtual bool OnRender() override;
+    virtual void CreateGLResources() override;
+
+    void OnBackButton();
+    void OnKeyPressed(Platform::String^ text);
+    void OnCocos2dKeyEvent(PhoneDirect3DXamlAppComponent::Cocos2dKeyEvent event);
+    void SetXamlEventDelegate(PhoneDirect3DXamlAppComponent::Cocos2dEventDelegate^ delegate);
+    void SetXamlMessageBoxDelegate(PhoneDirect3DXamlAppComponent::Cocos2dMessageBoxDelegate^ delegate);
+    void SetXamlEditBoxDelegate(PhoneDirect3DXamlAppComponent::Cocos2dEditBoxDelegate^ delegate);
+
+    Windows::Foundation::IAsyncAction^ OnSuspending();
+    void Connect();
+    void Disconnect();
+
+protected:
+    virtual void OnUpdateDevice() override;
+
+private:
+
+    bool m_loadingComplete;
+    bool mInitialized;
+
+    PhoneDirect3DXamlAppComponent::Cocos2dEventDelegate^ m_delegate;
+    PhoneDirect3DXamlAppComponent::Cocos2dMessageBoxDelegate^ m_messageBoxDelegate;
+    PhoneDirect3DXamlAppComponent::Cocos2dEditBoxDelegate^ m_editBoxDelegate;
+
+	// The AppDelegate for the Cocos2D app
+	AppDelegate* mApp;
+    Windows::Graphics::Display::DisplayOrientations m_orientation;
+};

--- a/templates/cpp-template-default/proj.wp8-xaml/AppComponent/src/Direct3DContentProvider.cpp
+++ b/templates/cpp-template-default/proj.wp8-xaml/AppComponent/src/Direct3DContentProvider.cpp
@@ -1,0 +1,65 @@
+/****************************************************************************
+Copyright (c) 2013 cocos2d-x.org
+Copyright (c) Microsoft Open Technologies, Inc.
+
+http://www.cocos2d-x.org
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+****************************************************************************/
+
+#include "Direct3DContentProvider.h"
+#include "Direct3DInterop.h"
+
+using namespace PhoneDirect3DXamlAppComponent;
+
+Direct3DContentProvider::Direct3DContentProvider(Direct3DInterop^ controller) :
+	m_controller(controller)
+{
+	m_controller->RequestAdditionalFrame += ref new RequestAdditionalFrameHandler([=] ()
+		{
+			if (m_host)
+			{
+				m_host->RequestAdditionalFrame();
+			}
+		});
+}
+
+// IDrawingSurfaceContentProviderNative interface
+HRESULT Direct3DContentProvider::Connect(_In_ IDrawingSurfaceRuntimeHostNative* host, _In_ ID3D11Device1* device)
+{
+	m_host = host;
+
+	return m_controller->Connect(host, device);
+}
+
+void Direct3DContentProvider::Disconnect()
+{
+	m_controller->Disconnect();
+	m_host = nullptr;
+}
+
+HRESULT Direct3DContentProvider::PrepareResources(_In_ const LARGE_INTEGER* presentTargetTime, _Inout_ DrawingSurfaceSizeF* desiredRenderTargetSize)
+{
+	return m_controller->PrepareResources(presentTargetTime, desiredRenderTargetSize);
+}
+
+HRESULT Direct3DContentProvider::Draw(_In_ ID3D11Device1* device, _In_ ID3D11DeviceContext1* context, _In_ ID3D11RenderTargetView* renderTargetView)
+{
+    return m_controller->Draw(device, context, renderTargetView);
+}

--- a/templates/cpp-template-default/proj.wp8-xaml/AppComponent/src/Direct3DContentProvider.h
+++ b/templates/cpp-template-default/proj.wp8-xaml/AppComponent/src/Direct3DContentProvider.h
@@ -1,0 +1,52 @@
+/****************************************************************************
+Copyright (c) 2013 cocos2d-x.org
+Copyright (c) Microsoft Open Technologies, Inc.
+
+http://www.cocos2d-x.org
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+****************************************************************************/
+
+#pragma once
+
+#include <wrl/module.h>
+#include <Windows.Phone.Graphics.Interop.h>
+#include <DrawingSurfaceNative.h>
+
+#include "Direct3DInterop.h"
+
+class Direct3DContentProvider : public Microsoft::WRL::RuntimeClass<
+		Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::WinRtClassicComMix>,
+		ABI::Windows::Phone::Graphics::Interop::IDrawingSurfaceBackgroundContentProvider,
+		IDrawingSurfaceBackgroundContentProviderNative>
+{
+public:
+	Direct3DContentProvider(PhoneDirect3DXamlAppComponent::Direct3DInterop^ controller);
+
+	// IDrawingSurfaceContentProviderNative
+	HRESULT STDMETHODCALLTYPE Connect(_In_ IDrawingSurfaceRuntimeHostNative* host, _In_ ID3D11Device1* device);
+	void STDMETHODCALLTYPE Disconnect();
+
+	HRESULT STDMETHODCALLTYPE PrepareResources(_In_ const LARGE_INTEGER* presentTargetTime, _Inout_ DrawingSurfaceSizeF* desiredRenderTargetSize);
+	HRESULT STDMETHODCALLTYPE Draw(_In_ ID3D11Device1* device, _In_ ID3D11DeviceContext1* context, _In_ ID3D11RenderTargetView* renderTargetView);
+
+private:
+	PhoneDirect3DXamlAppComponent::Direct3DInterop^ m_controller;
+	Microsoft::WRL::ComPtr<IDrawingSurfaceRuntimeHostNative> m_host;
+};

--- a/templates/cpp-template-default/proj.wp8-xaml/AppComponent/src/Direct3DInterop.cpp
+++ b/templates/cpp-template-default/proj.wp8-xaml/AppComponent/src/Direct3DInterop.cpp
@@ -1,0 +1,188 @@
+/****************************************************************************
+Copyright (c) 2013 cocos2d-x.org
+Copyright (c) Microsoft Open Technologies, Inc.
+
+http://www.cocos2d-x.org
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+****************************************************************************/
+#include "Direct3DInterop.h"
+#include "Direct3DContentProvider.h"
+#include "EditBoxEvent.h"
+#include "cocos2d.h"
+
+using namespace Windows::Foundation;
+using namespace Windows::UI::Core;
+using namespace Windows::UI::Input;
+using namespace Microsoft::WRL;
+using namespace Windows::Phone::Graphics::Interop;
+using namespace Windows::Phone::Input::Interop;
+using namespace Windows::Graphics::Display;
+using namespace DirectX;
+using namespace PhoneDirect3DXamlAppComponent;
+
+namespace PhoneDirect3DXamlAppComponent
+{
+
+Direct3DInterop::Direct3DInterop(Windows::Graphics::Display::DisplayOrientations orientation) 
+    : mCurrentOrientation(orientation), m_delegate(nullptr)
+{
+    m_renderer = ref new Cocos2dRenderer(mCurrentOrientation);
+}
+
+IDrawingSurfaceBackgroundContentProvider^ Direct3DInterop::CreateContentProvider()
+{
+	ComPtr<Direct3DContentProvider> provider = Make<Direct3DContentProvider>(this);
+	return reinterpret_cast<IDrawingSurfaceBackgroundContentProvider^>(provider.Get());
+}
+
+
+// Interface With Direct3DContentProvider
+HRESULT Direct3DInterop::Connect(_In_ IDrawingSurfaceRuntimeHostNative* host, _In_ ID3D11Device1* device)
+{
+    return S_OK;
+}
+
+void Direct3DInterop::Disconnect()
+{
+    m_renderer->Disconnect();  
+}
+
+// IDrawingSurfaceManipulationHandler
+void Direct3DInterop::SetManipulationHost(DrawingSurfaceManipulationHost^ manipulationHost)
+{
+    manipulationHost->PointerPressed +=
+        ref new TypedEventHandler<DrawingSurfaceManipulationHost^, PointerEventArgs^>(this, &Direct3DInterop::OnPointerPressed);
+
+    manipulationHost->PointerMoved +=
+        ref new TypedEventHandler<DrawingSurfaceManipulationHost^, PointerEventArgs^>(this, &Direct3DInterop::OnPointerMoved);
+
+    manipulationHost->PointerReleased +=
+        ref new TypedEventHandler<DrawingSurfaceManipulationHost^, PointerEventArgs^>(this, &Direct3DInterop::OnPointerReleased);
+}
+
+void Direct3DInterop::UpdateForWindowSizeChange(float width, float height)
+{
+    m_renderer->UpdateForWindowSizeChange(width, height);
+}
+
+
+IAsyncAction^ Direct3DInterop::OnSuspending()
+{
+    return m_renderer->OnSuspending();
+}
+
+void Direct3DInterop::OnBackKeyPress()
+{
+    cocos2d::GLView::sharedOpenGLView()->QueueBackKeyPress();
+}
+
+// Pointer Event Handlers. We need to queue up pointer events to pass them to the drawing thread
+void Direct3DInterop::OnPointerPressed(DrawingSurfaceManipulationHost^ sender, PointerEventArgs^ args)
+{
+    cocos2d::GLView::sharedOpenGLView()->QueuePointerEvent(cocos2d::PointerEventType::PointerPressed, args);
+}
+
+void Direct3DInterop::OnPointerMoved(DrawingSurfaceManipulationHost^ sender, PointerEventArgs^ args)
+{
+    cocos2d::GLView::sharedOpenGLView()->QueuePointerEvent(cocos2d::PointerEventType::PointerMoved, args);
+}
+
+void Direct3DInterop::OnPointerReleased(DrawingSurfaceManipulationHost^ sender, PointerEventArgs^ args)
+{
+    cocos2d::GLView::sharedOpenGLView()->QueuePointerEvent(cocos2d::PointerEventType::PointerReleased, args);
+}
+
+void Direct3DInterop::OnCocos2dKeyEvent(Cocos2dKeyEvent key)
+{
+    std::shared_ptr<cocos2d::InputEvent> e(new cocos2d::KeyboardEvent(key));
+    cocos2d::GLView::sharedOpenGLView()->QueueEvent(e);
+}
+
+
+void Direct3DInterop::OnCocos2dKeyEvent(Cocos2dKeyEvent key, Platform::String^ text)
+{
+    std::shared_ptr<cocos2d::InputEvent> e(new cocos2d::KeyboardEvent(key,text));
+    cocos2d::GLView::sharedOpenGLView()->QueueEvent(e);
+}
+
+
+void Direct3DInterop::OnCocos2dEditboxEvent(Object^ sender, Platform::String^ args, Windows::Foundation::EventHandler<Platform::String^>^ handler)
+{
+	std::shared_ptr<cocos2d::InputEvent> e(new EditBoxEvent(sender, args, handler));
+    cocos2d::GLView::sharedOpenGLView()->QueueEvent(e);
+}
+
+
+
+
+HRESULT Direct3DInterop::PrepareResources(_In_ const LARGE_INTEGER* presentTargetTime, _Inout_ DrawingSurfaceSizeF* desiredRenderTargetSize)
+{
+	desiredRenderTargetSize->width = WindowBounds.Width;
+	desiredRenderTargetSize->height = WindowBounds.Height;
+	return S_OK;
+}
+
+HRESULT Direct3DInterop::Draw(_In_ ID3D11Device1* device, _In_ ID3D11DeviceContext1* context, _In_ ID3D11RenderTargetView* renderTargetView)
+{
+    m_renderer->UpdateDevice(device, context, renderTargetView);
+#if 0
+    if(mCurrentOrientation != WindowOrientation)
+    {
+        mCurrentOrientation = WindowOrientation;
+        m_renderer->OnOrientationChanged(mCurrentOrientation);
+    }  
+#endif // 0
+
+    cocos2d::GLView::sharedOpenGLView()->ProcessEvents();
+    m_renderer->Render();
+	RequestAdditionalFrame();
+	return S_OK;
+}
+
+void Direct3DInterop::SetCocos2dEventDelegate(Cocos2dEventDelegate^ delegate) 
+{ 
+    m_delegate = delegate; 
+    m_renderer->SetXamlEventDelegate(delegate);
+}
+
+void Direct3DInterop::SetCocos2dMessageBoxDelegate(Cocos2dMessageBoxDelegate ^ delegate)
+{
+    m_messageBoxDelegate = delegate;
+    m_renderer->SetXamlMessageBoxDelegate(delegate);
+}
+
+void Direct3DInterop::SetCocos2dEditBoxDelegate(Cocos2dEditBoxDelegate ^ delegate)
+{
+    m_editBoxDelegate = delegate;
+    m_renderer->SetXamlEditBoxDelegate(delegate);
+}
+
+
+bool Direct3DInterop::SendCocos2dEvent(Cocos2dEvent event)
+{
+    if(m_delegate)
+    {
+        m_delegate->Invoke(event);
+        return true;
+    }
+    return false;
+}
+
+}

--- a/templates/cpp-template-default/proj.wp8-xaml/AppComponent/src/Direct3DInterop.h
+++ b/templates/cpp-template-default/proj.wp8-xaml/AppComponent/src/Direct3DInterop.h
@@ -1,0 +1,96 @@
+/****************************************************************************
+Copyright (c) 2013 cocos2d-x.org
+Copyright (c) Microsoft Open Technologies, Inc.
+
+http://www.cocos2d-x.org
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+****************************************************************************/
+
+#pragma once
+
+#include <wrl/client.h>
+#include <mutex>
+#include <queue>
+#include <memory>
+#include "Cocos2dRenderer.h"
+#include "InputEvent.h"
+#include <DrawingSurfaceNative.h>
+
+
+namespace PhoneDirect3DXamlAppComponent
+{
+
+public delegate void RequestAdditionalFrameHandler();
+
+[Windows::Foundation::Metadata::WebHostHidden]
+public ref class Direct3DInterop sealed : public Windows::Phone::Input::Interop::IDrawingSurfaceManipulationHandler
+{
+public:
+    Direct3DInterop(Windows::Graphics::Display::DisplayOrientations orientation);
+
+	Windows::Phone::Graphics::Interop::IDrawingSurfaceBackgroundContentProvider^ CreateContentProvider();
+
+    // IDrawingSurfaceManipulationHandler
+    virtual void SetManipulationHost(Windows::Phone::Input::Interop::DrawingSurfaceManipulationHost^ manipulationHost);
+
+	event RequestAdditionalFrameHandler^ RequestAdditionalFrame;
+
+
+    void UpdateForWindowSizeChange(float width, float height);
+    Windows::Foundation::IAsyncAction^ OnSuspending();
+
+    void OnBackKeyPress();
+    void OnCocos2dKeyEvent(Cocos2dKeyEvent key);
+    void OnCocos2dKeyEvent(Cocos2dKeyEvent key, Platform::String^ text);
+    void OnCocos2dEditboxEvent(Platform::Object^ sender, Platform::String^ args, Windows::Foundation::EventHandler<Platform::String^>^ handler);
+
+    property Windows::Graphics::Display::DisplayOrientations WindowOrientation;
+    property Windows::Foundation::Size WindowBounds;
+
+    void SetCocos2dEventDelegate(Cocos2dEventDelegate^ delegate);
+    void SetCocos2dMessageBoxDelegate(Cocos2dMessageBoxDelegate ^ delegate);
+    void SetCocos2dEditBoxDelegate(Cocos2dEditBoxDelegate ^ delegate);
+
+
+protected:
+    // Event Handlers
+    void OnPointerPressed(Windows::Phone::Input::Interop::DrawingSurfaceManipulationHost^ sender, Windows::UI::Core::PointerEventArgs^ args);
+    void OnPointerMoved(Windows::Phone::Input::Interop::DrawingSurfaceManipulationHost^ sender, Windows::UI::Core::PointerEventArgs^ args);
+    void OnPointerReleased(Windows::Phone::Input::Interop::DrawingSurfaceManipulationHost^ sender, Windows::UI::Core::PointerEventArgs^ args);
+
+internal:
+	HRESULT Connect(_In_ IDrawingSurfaceRuntimeHostNative* host, _In_ ID3D11Device1* device);
+    void Disconnect();
+	HRESULT PrepareResources(_In_ const LARGE_INTEGER* presentTargetTime, _Inout_ DrawingSurfaceSizeF* desiredRenderTargetSize);
+    HRESULT Draw(_In_ ID3D11Device1* device, _In_ ID3D11DeviceContext1* context, _In_ ID3D11RenderTargetView* renderTargetView);
+    bool SendCocos2dEvent(Cocos2dEvent event);
+
+private:
+    Cocos2dRenderer^ m_renderer;
+    Windows::Graphics::Display::DisplayOrientations mCurrentOrientation;
+
+
+    Cocos2dEventDelegate^ m_delegate;
+    Cocos2dMessageBoxDelegate^ m_messageBoxDelegate;
+    Cocos2dEditBoxDelegate^ m_editBoxDelegate;
+
+};
+
+}

--- a/templates/cpp-template-default/proj.wp8-xaml/AppComponent/src/DirectXBase.cpp
+++ b/templates/cpp-template-default/proj.wp8-xaml/AppComponent/src/DirectXBase.cpp
@@ -1,0 +1,321 @@
+/****************************************************************************
+Copyright (c) 2013 cocos2d-x.org
+Copyright (c) Microsoft Open Technologies, Inc.
+
+http://www.cocos2d-x.org
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+****************************************************************************/
+
+#include "DirectXBase.h"
+#include "DirectXHelper.h"
+
+using namespace DirectX;
+using namespace Microsoft::WRL;
+using namespace Windows::Foundation;
+using namespace Windows::Graphics::Display;
+
+// Constructor.
+DirectXBase::DirectXBase()
+    : m_bAngleInitialized(false)
+    , m_eglDisplay(nullptr)
+    , m_eglSurface(nullptr)
+    , m_eglContext(nullptr)
+    , m_eglWindow(nullptr)
+    , m_eglPhoneWindow(nullptr)
+    , m_device(nullptr)
+{
+}
+
+// Initialize the Direct3D resources required to run.
+void DirectXBase::Initialize()
+{
+}
+
+// These are the resources that depend on the device.
+void DirectXBase::CreateDeviceResources()
+{
+}
+
+void DirectXBase::SetDevice(ID3D11Device1* device)
+{
+    if(m_device)
+    {
+        m_device->Release();
+        m_device = nullptr;
+    }
+
+    m_device = nullptr;
+}
+
+void DirectXBase::UpdateDevice(ID3D11Device1* device, ID3D11DeviceContext1* context, ID3D11RenderTargetView* renderTargetView)
+{
+    if (m_device != device)
+    {
+        CloseAngle();
+        device->AddRef();
+        m_device = device;
+
+        CreateDeviceResources();
+
+        // Force call to CreateWindowSizeDependentResources
+        m_renderTargetSize.Width  = -1;
+        m_renderTargetSize.Height = -1;
+    }
+
+    m_featureLevel = device->GetFeatureLevel();
+
+
+    ComPtr<ID3D11Resource> renderTargetViewResource;
+    renderTargetView->GetResource(&renderTargetViewResource);
+
+    ComPtr<ID3D11Texture2D> backBuffer;
+    DX::ThrowIfFailed(
+        renderTargetViewResource.As(&backBuffer)
+        );
+
+    // Cache the rendertarget dimensions in our helper class for convenient use.
+    D3D11_TEXTURE2D_DESC backBufferDesc;
+    backBuffer->GetDesc(&backBufferDesc);
+
+    if (m_renderTargetSize.Width  != static_cast<float>(backBufferDesc.Width) ||
+        m_renderTargetSize.Height != static_cast<float>(backBufferDesc.Height))
+    {
+        m_renderTargetSize.Width  = static_cast<float>(backBufferDesc.Width);
+        m_renderTargetSize.Height = static_cast<float>(backBufferDesc.Height);
+        CreateWindowSizeDependentResources();
+    }
+
+    if(!m_bAngleInitialized)
+    {
+        InitializeAngle(device, context, renderTargetView);
+        CreateGLResources();
+    }
+    else
+    {
+        m_eglPhoneWindow->Update(device, context, renderTargetView);
+    }
+
+    OnUpdateDevice();
+}
+
+
+void DirectXBase::UpdateForWindowSizeChange(float width, float height)
+{
+    if (width != m_windowBounds.Width || height != m_windowBounds.Height)
+    {
+        m_windowBounds.Width  = width;
+        m_windowBounds.Height = height;
+    }
+}
+
+// Allocate all memory resources that depend on the window size.
+void DirectXBase::CreateWindowSizeDependentResources()
+{
+
+
+}
+
+void DirectXBase::OnOrientationChanged(DisplayOrientations orientation)
+{
+	switch(orientation)
+	{
+		case DisplayOrientations::Portrait:
+			m_orientationMatrix = XMMatrixIdentity();
+            m_aspectRatio = m_renderTargetSize.Width / m_renderTargetSize.Height;
+			break;
+
+		case DisplayOrientations::PortraitFlipped:
+			m_orientationMatrix = XMMatrixRotationZ(XM_PI);
+            m_aspectRatio = m_renderTargetSize.Width / m_renderTargetSize.Height;
+			break;
+
+		case DisplayOrientations::Landscape:
+			m_orientationMatrix = XMMatrixRotationZ(-XM_PIDIV2);
+            m_aspectRatio = m_renderTargetSize.Height / m_renderTargetSize.Width;
+			break;
+			
+		case DisplayOrientations::LandscapeFlipped:
+			m_orientationMatrix = XMMatrixRotationZ(XM_PIDIV2);
+            m_aspectRatio = m_renderTargetSize.Height / m_renderTargetSize.Width;
+			break;
+	}
+}
+
+void DirectXBase::Render()
+{
+    if(!OnRender())
+    {
+        eglSwapBuffers(m_eglDisplay, m_eglSurface);
+    }
+}
+
+void DirectXBase::CloseAngle()
+{
+    eglMakeCurrent(NULL, NULL, NULL, NULL);
+
+    if(m_eglPhoneWindow != nullptr)
+    {
+        m_eglPhoneWindow->Update(nullptr, nullptr, nullptr);
+    }  
+
+	if(m_eglDisplay && m_eglContext)
+    {
+        eglDestroyContext(m_eglDisplay, m_eglContext);
+        m_eglContext = nullptr;
+    }    
+
+	if(m_eglDisplay && m_eglSurface)
+    {
+        eglDestroySurface(m_eglDisplay, m_eglSurface);
+        m_eglSurface = nullptr;
+    }
+
+    if(m_eglDisplay)
+    {
+        eglTerminate(m_eglDisplay);
+        m_eglDisplay = nullptr;
+    }  
+
+    if(m_device)
+    {
+        m_device->Release();
+        m_device = nullptr;
+    }
+
+    m_eglPhoneWindow = nullptr;
+    m_eglWindow = nullptr;  
+
+    m_bAngleInitialized = false;
+}
+
+bool DirectXBase::InitializeAngle(ID3D11Device1* d3dDevice, ID3D11DeviceContext1* d3dContext, ID3D11RenderTargetView* d3dRenderTargetView)
+{
+	// setup EGL
+	EGLint configAttribList[] = {
+		EGL_RED_SIZE,       8,
+		EGL_GREEN_SIZE,     8,
+		EGL_BLUE_SIZE,      8,
+		EGL_ALPHA_SIZE,     8,
+		EGL_DEPTH_SIZE,     8,
+		EGL_STENCIL_SIZE,   8,
+		EGL_SAMPLE_BUFFERS, 0,
+		EGL_NONE
+	};
+	EGLint surfaceAttribList[] = {
+		EGL_NONE, EGL_NONE
+	};
+
+	EGLint numConfigs;
+	EGLint majorVersion;
+	EGLint minorVersion;
+	EGLDisplay display;
+	EGLContext context;
+	EGLSurface surface;
+	EGLConfig config;
+	EGLint contextAttribs[] = { EGL_CONTEXT_CLIENT_VERSION, 2, EGL_NONE, EGL_NONE };
+
+    // we need to select the correct DirectX feature level depending on the platform
+    // default is D3D_FEATURE_LEVEL_9_3 Windows Phone 8.0
+    ANGLE_D3D_FEATURE_LEVEL featureLevel = ANGLE_D3D_FEATURE_LEVEL::ANGLE_D3D_FEATURE_LEVEL_9_3;
+
+	switch(m_featureLevel)
+	{
+	case ANGLE_D3D_FEATURE_LEVEL_9_3:
+		featureLevel = ANGLE_D3D_FEATURE_LEVEL::ANGLE_D3D_FEATURE_LEVEL_9_3;
+		break;
+				
+	case ANGLE_D3D_FEATURE_LEVEL_9_2:
+		featureLevel = ANGLE_D3D_FEATURE_LEVEL::ANGLE_D3D_FEATURE_LEVEL_9_2;
+		break;
+					
+	case ANGLE_D3D_FEATURE_LEVEL_9_1:
+		featureLevel = ANGLE_D3D_FEATURE_LEVEL::ANGLE_D3D_FEATURE_LEVEL_9_1;
+		break;
+	}		
+
+    if(m_eglPhoneWindow == nullptr)
+    {
+	    DX::ThrowIfFailed(
+            CreateWinPhone8XamlWindow(&m_eglPhoneWindow)
+            );
+    }
+
+    m_eglPhoneWindow->Update(d3dDevice, d3dContext, d3dRenderTargetView);
+
+    ComPtr<IUnknown> u;
+    HRESULT r = m_eglPhoneWindow.As(&u);
+
+    if(m_eglWindow == nullptr)
+    { 	DX::ThrowIfFailed(
+        CreateWinrtEglWindow(u.Get(), featureLevel, m_eglWindow.GetAddressOf())
+        );
+    }
+
+
+	display = eglGetDisplay(m_eglWindow);
+	if(display == EGL_NO_DISPLAY){
+		//ofLogError("ofAppWinRTWindow") << "couldn't get EGL display";
+		return false;
+	}
+
+	if(!eglInitialize(display, &majorVersion, &minorVersion)){
+		//ofLogError("ofAppWinRTWindow") << "failed to initialize EGL";
+		return false;
+	}
+
+	// Get configs
+	if ( !eglGetConfigs(display, NULL, 0, &numConfigs) ){
+		//ofLogError("ofAppWinRTWindow") << "failed to get configurations";
+		return false;
+	}
+
+	// Choose config
+	if(!eglChooseConfig(display, configAttribList, &config, 1, &numConfigs)){
+		//ofLogError("ofAppWinRTWindow") << "failed to choose configuration";
+		return false;
+	}
+
+    // Create a surface
+    surface = eglCreateWindowSurface(display, config, m_eglWindow, surfaceAttribList);
+    if(surface == EGL_NO_SURFACE){
+        //ofLogError("ofAppWinRTWindow") << "failed to create EGL window surface";
+        return false;
+    }  
+
+	// Create a GL context
+	context = eglCreateContext(display, config, EGL_NO_CONTEXT, contextAttribs);
+	if(context == EGL_NO_CONTEXT){
+		//ofLogError("ofAppWinRTWindow") << "failed to create EGL context";
+		return false;
+	}   
+
+	// Make the context current
+	if (!eglMakeCurrent(display, surface, surface, context)){
+		//ofLogError("ofAppWinRTWindow") << "failed to make EGL context current";
+		return false;
+	}
+
+	m_eglDisplay = display;
+	m_eglSurface = surface;
+	m_eglContext = context;
+
+    m_bAngleInitialized = true;
+    return true;
+}

--- a/templates/cpp-template-default/proj.wp8-xaml/AppComponent/src/DirectXBase.h
+++ b/templates/cpp-template-default/proj.wp8-xaml/AppComponent/src/DirectXBase.h
@@ -1,0 +1,84 @@
+/****************************************************************************
+Copyright (c) 2013 cocos2d-x.org
+Copyright (c) Microsoft Open Technologies, Inc.
+
+http://www.cocos2d-x.org
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+****************************************************************************/
+
+#pragma once
+
+#include <d3d11_1.h>
+#include <DirectXMath.h>
+#include "EGL/egl.h"
+#include "EGL/eglext.h"
+#include "EGL/eglplatform.h"
+#include "GLES2/gl2.h"
+#include "GLES2/gl2ext.h"
+#include "winrtangle.h"
+
+// Helper class that initializes DirectX APIs for 3D rendering.
+ref class DirectXBase abstract
+{
+internal:
+    DirectXBase();
+
+    virtual void Initialize();
+    virtual void CreateDeviceResources();
+    virtual void SetDevice(ID3D11Device1* device);
+    virtual void UpdateDevice(ID3D11Device1* device, ID3D11DeviceContext1* context, ID3D11RenderTargetView* renderTargetView);
+    virtual void UpdateForWindowSizeChange(float width, float height);
+    virtual void CreateWindowSizeDependentResources();
+	virtual void OnOrientationChanged(Windows::Graphics::Display::DisplayOrientations orientation);
+
+    virtual void CreateGLResources() = 0;
+
+    void Render();
+
+protected:
+
+    // return true if eglSwapBuffers was called by OnRender
+	virtual bool OnRender() = 0;
+    virtual void OnUpdateDevice() = 0;
+    void CloseAngle();
+
+protected private:
+    // Direct3D Objects.
+    ID3D11Device1* m_device;
+
+    D3D_FEATURE_LEVEL m_featureLevel;
+
+    bool InitializeAngle(ID3D11Device1* device, ID3D11DeviceContext1* context, ID3D11RenderTargetView* renderTargetView);
+
+     // Cached renderer properties.
+    Windows::Foundation::Size m_renderTargetSize;
+    Windows::Foundation::Rect m_windowBounds;
+	Windows::Graphics::Display::DisplayOrientations m_orientation;
+
+    // Angle EGL 
+    bool m_bAngleInitialized;
+	EGLDisplay m_eglDisplay;
+	EGLContext m_eglContext;
+	EGLSurface m_eglSurface;
+	Microsoft::WRL::ComPtr<IWinrtEglWindow> m_eglWindow;
+	Microsoft::WRL::ComPtr<IWinPhone8XamlD3DWindow> m_eglPhoneWindow;
+    DirectX::XMMATRIX m_orientationMatrix;
+    float m_aspectRatio;
+};

--- a/templates/cpp-template-default/proj.wp8-xaml/AppComponent/src/DirectXHelper.h
+++ b/templates/cpp-template-default/proj.wp8-xaml/AppComponent/src/DirectXHelper.h
@@ -1,0 +1,47 @@
+/****************************************************************************
+Copyright (c) 2013 cocos2d-x.org
+Copyright (c) Microsoft Open Technologies, Inc.
+
+http://www.cocos2d-x.org
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+****************************************************************************/
+
+//// THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF
+//// ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+//// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A
+//// PARTICULAR PURPOSE.
+////
+//// Copyright (c) Microsoft Corporation. All rights reserved
+
+#pragma once
+
+
+// This header defines helper utilities to make DirectX APIs work with exceptions.
+namespace DX
+{
+    inline void ThrowIfFailed(HRESULT hr)
+    {
+        if (FAILED(hr))
+        {
+            // Set a breakpoint on this line to catch DX API errors.
+            throw Platform::Exception::CreateException(hr);
+        }
+    }
+}

--- a/templates/cpp-template-default/proj.wp8-xaml/AppComponent/src/EditBoxEvent.cpp
+++ b/templates/cpp-template-default/proj.wp8-xaml/AppComponent/src/EditBoxEvent.cpp
@@ -1,0 +1,48 @@
+/****************************************************************************
+Copyright (c) 2014 cocos2d-x.org
+
+http://www.cocos2d-x.org
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+****************************************************************************/
+
+#include "EditBoxEvent.h"
+
+using namespace Platform;
+
+namespace PhoneDirect3DXamlAppComponent
+{
+	EditBoxEvent::EditBoxEvent( Object^ sender, Platform::String^ arg, Windows::Foundation::EventHandler<Platform::String^>^ handle ):
+		m_sender(sender),
+		m_args(arg),
+		m_handler(handle)
+	{
+
+	}
+
+	void EditBoxEvent::execute()
+	{
+        if(m_handler.Get())
+        {
+		    m_handler.Get()->Invoke(m_sender.Get(), m_args.Get());
+        }
+	}
+
+
+}

--- a/templates/cpp-template-default/proj.wp8-xaml/AppComponent/src/EditBoxEvent.h
+++ b/templates/cpp-template-default/proj.wp8-xaml/AppComponent/src/EditBoxEvent.h
@@ -1,0 +1,48 @@
+/****************************************************************************
+Copyright (c) 2014 cocos2d-x.org
+
+http://www.cocos2d-x.org
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+****************************************************************************/
+
+#ifndef __EditBoxEVENT_H__
+#define __EditBoxEVENT_H__
+
+#include "InputEvent.h"
+#include <agile.h>
+
+
+namespace PhoneDirect3DXamlAppComponent
+{
+	class EditBoxEvent : public cocos2d::InputEvent
+	{
+	public:
+		EditBoxEvent(Platform::Object^ sender, Platform::String^ arg, Windows::Foundation::EventHandler<Platform::String^>^ handle);
+
+		virtual void execute();
+
+	private:
+		Platform::Agile<Platform::Object^> m_sender;
+		Platform::Agile<Platform::String^> m_args;
+		Platform::Agile<Windows::Foundation::EventHandler<Platform::String^>^> m_handler;
+	};
+}
+
+#endif


### PR DESCRIPTION
This pull request fixes the broken path to cpp files used by the wp8-xaml template. The cpp files are now part of the template package (similar to the other platforms).
