### PR TITLE
fix scrollview crashes on win32 because of variable returned without ini...

### DIFF
--- a/cocos/ui/UIScrollView.cpp
+++ b/cocos/ui/UIScrollView.cpp
@@ -894,7 +894,7 @@ bool ScrollView::scrollChildrenVertical(float touchOffsetX, float touchOffsetY)
     
 bool ScrollView::scrollChildrenHorizontal(float touchOffsetX, float touchOffestY)
 {
-    bool scrollenabled;
+    bool scrollenabled = false;
     float realOffset = touchOffsetX;
     if (_bounceEnabled)
     {


### PR DESCRIPTION
...tialization
