### PR TITLE
fixed bounding box error

### DIFF
--- a/extensions/CocoStudio/Armature/CCArmature.cpp
+++ b/extensions/CocoStudio/Armature/CCArmature.cpp
@@ -616,6 +616,8 @@ CCRect CCArmature::boundingBox()
         if (CCBone *bone = dynamic_cast<CCBone *>(object))
         {
             CCRect r = bone->getDisplayManager()->getBoundingBox();
+            if (r.size.width == 0 || r.size.height == 0) 
+                continue;
 
             if(first)
             {


### PR DESCRIPTION
1.fixed bounding box error. If a bone's bounding box is empty, it should not be calculated.
