### PR TITLE
Fix a potential crash in Scheduler

### DIFF
--- a/cocos/base/CCScheduler.cpp
+++ b/cocos/base/CCScheduler.cpp
@@ -311,9 +311,9 @@ void Scheduler::schedule(const ccSchedulerFunc& callback, void *target, float in
     {
         for (int i = 0; i < element->timers->num; ++i)
         {
-            TimerTargetCallback *timer = static_cast<TimerTargetCallback*>(element->timers->arr[i]);
+            TimerTargetCallback *timer = dynamic_cast<TimerTargetCallback*>(element->timers->arr[i]);
 
-            if (key == timer->getKey())
+            if (timer != nullptr && key == timer->getKey())
             {
                 CCLOG("CCScheduler#scheduleSelector. Selector already scheduled. Updating interval from: %.4f to %.4f", timer->getInterval(), interval);
                 timer->setInterval(interval);
@@ -347,9 +347,9 @@ void Scheduler::unschedule(const std::string &key, void *target)
     {
         for (int i = 0; i < element->timers->num; ++i)
         {
-            TimerTargetCallback *timer = static_cast<TimerTargetCallback*>(element->timers->arr[i]);
+            TimerTargetCallback *timer = dynamic_cast<TimerTargetCallback*>(element->timers->arr[i]);
 
-            if (key == timer->getKey())
+            if (timer != nullptr && key == timer->getKey())
             {
                 if (timer == element->currentTimer && (! element->currentTimerSalvaged))
                 {
@@ -527,9 +527,9 @@ bool Scheduler::isScheduled(const std::string& key, void *target)
     {
         for (int i = 0; i < element->timers->num; ++i)
         {
-            TimerTargetCallback *timer = static_cast<TimerTargetCallback*>(element->timers->arr[i]);
-            
-            if (key == timer->getKey())
+            TimerTargetCallback *timer = dynamic_cast<TimerTargetCallback*>(element->timers->arr[i]);
+
+            if (timer != nullptr && key == timer->getKey())
             {
                 return true;
             }
@@ -1011,9 +1011,9 @@ void Scheduler::schedule(SEL_SCHEDULE selector, Ref *target, float interval, uns
     {
         for (int i = 0; i < element->timers->num; ++i)
         {
-            TimerTargetSelector *timer = static_cast<TimerTargetSelector*>(element->timers->arr[i]);
-            
-            if (selector == timer->getSelector())
+            TimerTargetSelector *timer = dynamic_cast<TimerTargetSelector*>(element->timers->arr[i]);
+
+            if (timer != nullptr && selector == timer->getSelector())
             {
                 CCLOG("CCScheduler#scheduleSelector. Selector already scheduled. Updating interval from: %.4f to %.4f", timer->getInterval(), interval);
                 timer->setInterval(interval);
@@ -1055,9 +1055,9 @@ bool Scheduler::isScheduled(SEL_SCHEDULE selector, Ref *target)
     {
         for (int i = 0; i < element->timers->num; ++i)
         {
-            TimerTargetSelector *timer = static_cast<TimerTargetSelector*>(element->timers->arr[i]);
-            
-            if (selector == timer->getSelector())
+            TimerTargetSelector *timer = dynamic_cast<TimerTargetSelector*>(element->timers->arr[i]);
+
+            if (timer != nullptr && selector == timer->getSelector())
             {
                 return true;
             }
@@ -1087,9 +1087,9 @@ void Scheduler::unschedule(SEL_SCHEDULE selector, Ref *target)
     {
         for (int i = 0; i < element->timers->num; ++i)
         {
-            TimerTargetSelector *timer = static_cast<TimerTargetSelector*>(element->timers->arr[i]);
-            
-            if (selector == timer->getSelector())
+            TimerTargetSelector *timer = dynamic_cast<TimerTargetSelector*>(element->timers->arr[i]);
+
+            if (timer != nullptr && selector == timer->getSelector())
             {
                 if (timer == element->currentTimer && (! element->currentTimerSalvaged))
                 {

--- a/tests/cpp-tests/Classes/SchedulerTest/SchedulerTest.cpp
+++ b/tests/cpp-tests/Classes/SchedulerTest/SchedulerTest.cpp
@@ -29,7 +29,8 @@ static std::function<Layer*()> createFunctions[] = {
     CL(SchedulerDelayAndRepeat),
     CL(SchedulerIssue2268),
     CL(ScheduleCallbackTest),
-    CL(ScheduleUpdatePriority)
+    CL(ScheduleUpdatePriority),
+    CL(SchedulerMultipleFuncTypes)
 };
 
 #define MAX_LAYER (sizeof(createFunctions) / sizeof(createFunctions[0]))
@@ -852,9 +853,9 @@ void SchedulerTimeScale::onEnter()
     auto rot1 = RotateBy::create(4, 360*2);
     auto rot2 = rot1->reverse();
 
-    auto seq3_1 = Sequence::create(jump2, jump1, NULL);
-    auto seq3_2 = Sequence::create(rot1, rot2, NULL);
-    auto spawn = Spawn::create(seq3_1, seq3_2, NULL);
+    auto seq3_1 = Sequence::create(jump2, jump1, nullptr);
+    auto seq3_2 = Sequence::create(rot1, rot2, nullptr);
+    auto spawn = Spawn::create(seq3_1, seq3_2, nullptr);
     auto action = Repeat::create(spawn, 50);
 
     auto action2 = action->clone();
@@ -946,7 +947,7 @@ void TwoSchedulers::onEnter()
     auto jump1 = JumpBy::create(4, Vec2(0,0), 100, 4);
     auto jump2 = jump1->reverse();
 
-    auto seq = Sequence::create(jump2, jump1, NULL);
+    auto seq = Sequence::create(jump2, jump1, nullptr);
     auto action = RepeatForever::create(seq);
 
         //
@@ -1189,6 +1190,87 @@ void ScheduleUpdatePriority::onExit()
 
 void ScheduleUpdatePriority::update(float dt)
 {
+}
+
+//------------------------------------------------------------------
+//
+// SchedulerMultipleFuncTypes
+//
+//------------------------------------------------------------------
+std::string SchedulerMultipleFuncTypes::title() const
+{
+    return "Scheduler with different call types";
+}
+
+std::string SchedulerMultipleFuncTypes::subtitle() const
+{
+    return "Using both SEL_SCHEDULE and ccSchedulerFunc in one scheduler.\n"
+        "Should not crash. Tap on items and see console";
+}
+
+void SchedulerMultipleFuncTypes::onEnter()
+{
+    SchedulerTestLayer::onEnter();
+    auto scheduler = Director::getInstance()->getScheduler();
+
+    // Use ccSchedulerFunc
+    scheduler->schedule(
+        CC_CALLBACK_1(SchedulerMultipleFuncTypes::call_1, this),
+        this, 1, kRepeatForever, 0.5f, false, "key_of_call_1");
+    // Use SEL_SCHEDULE
+    scheduler->schedule(
+        SEL_SCHEDULE(&SchedulerMultipleFuncTypes::call_2), this, 1, false);
+
+    // A menu to check
+    MenuItemFont::setFontSize(20);
+    auto item_check = MenuItemFont::create("Check isScheduled", [this, scheduler](Ref *sender) {
+        CCLOG("====================================");
+        CCLOG("Results should be \'true true false false\' before unscheduling");
+        CCLOG("and \'false false false false\' after unscheduling");
+        CCLOG(scheduler->isScheduled(SEL_SCHEDULE(&SchedulerMultipleFuncTypes::call_2), this) ?
+            "true" : "false");
+        CCLOG(this->getScheduler()->isScheduled("key_of_call_1", this) ?
+            "true" : "false");
+        CCLOG(this->getScheduler()->isScheduled("key_of_call_2", this) ?
+            "true" : "false");
+        // functions that are scheduled using CC_CALLBACKs can'e be detected
+        // using isScheduled(SEL_SCHEDULE, Ref *)
+        CCLOG(scheduler->isScheduled(SEL_SCHEDULE(&SchedulerMultipleFuncTypes::call_1), this) ?
+            "true" : "false");
+        CCLOG("====================================");
+    });
+    item_check->setNormalizedPosition(Vec2(0.5, 0.55));
+    // A menu to unschedule both
+    auto item_unschedule = MenuItemFont::create("Unschedule all", [this, scheduler](Ref *sender) {
+        CCLOG("Unscheduling. Should not crash");
+        scheduler->unschedule("key_of_call_1", this);
+        scheduler->unschedule("key_of_call_2", this);   // not found
+        scheduler->unschedule(SEL_SCHEDULE(&SchedulerMultipleFuncTypes::call_2), this);
+        scheduler->unschedule(SEL_SCHEDULE(&SchedulerMultipleFuncTypes::call_1), this); // not found
+        CCLOG("Finished");
+    });
+    item_unschedule->setNormalizedPosition(Vec2(0.5, 0.45));
+    auto menu = Menu::create(item_check, item_unschedule, nullptr);
+    menu->setPosition(Vec2::ZERO);
+    this->addChild(menu);
+
+    CCLOG("Starting schedulers. Two methods are called every second.");
+
+}
+
+void SchedulerMultipleFuncTypes::onExit()
+{
+    Node::onExit();
+}
+
+void SchedulerMultipleFuncTypes::call_1(float dt)
+{
+    CCLOG("called ccSchedulerFunc");
+}
+
+void SchedulerMultipleFuncTypes::call_2(float dt)
+{
+    CCLOG("called SEL_SCHEDULE");
 }
 
 //------------------------------------------------------------------

--- a/tests/cpp-tests/Classes/SchedulerTest/SchedulerTest.h
+++ b/tests/cpp-tests/Classes/SchedulerTest/SchedulerTest.h
@@ -317,6 +317,20 @@ public:
     bool onTouchBegan(Touch* touch, Event* event);
 };
 
+class SchedulerMultipleFuncTypes : public SchedulerTestLayer
+{
+public:
+    CREATE_FUNC(SchedulerMultipleFuncTypes);
+
+    virtual std::string title() const override;
+    virtual std::string subtitle() const override;
+    void onEnter();
+    void onExit();
+
+    void call_1(float dt);
+    void call_2(float dt);
+};
+
 class SchedulerTestScene : public TestScene
 {
 public:


### PR DESCRIPTION
Sometimes the program crashes if we use `ccSchedulerFunc` together with `SEL_SCHEDULE` in one scheduler.
The crash is caused by invalid `static_cast`, and now it's fixed by using `dynamic_cast`.

I'm not sure whether to add a test case for this. Please tell me. Thanks!
