### PR TITLE
Fix setRotation3D

### DIFF
--- a/cocos/2d/CCNode.cpp
+++ b/cocos/2d/CCNode.cpp
@@ -1638,7 +1638,6 @@ const Mat4& Node::getNodeToParentTransform() const
             y += sy * -_anchorPointInPoints.x * _scaleX +  cx * -_anchorPointInPoints.y * _scaleY;
         }
 
-
         // Build Transform Matrix
         // Adjusted transform calculation for rotational skew
         float mat[] = {
@@ -1649,6 +1648,11 @@ const Mat4& Node::getNodeToParentTransform() const
         
         _transform.set(mat);
 
+        if(!_ignoreAnchorPointForPosition)
+        {
+            _transform.translate(_anchorPointInPoints.x * _scaleX, _anchorPointInPoints.y * _scaleY, 0);
+        }
+        
         // XXX
         // FIX ME: Expensive operation.
         // FIX ME: It should be done together with the rotationZ
@@ -1663,6 +1667,11 @@ const Mat4& Node::getNodeToParentTransform() const
             _transform = _transform * rotX;
         }
 
+        if(!_ignoreAnchorPointForPosition)
+        {
+            _transform.translate(-_anchorPointInPoints.x * _scaleX, -_anchorPointInPoints.y * _scaleY, 0);
+        }
+        
         // XXX: Try to inline skew
         // If skew is needed, apply skew and then anchor point
         if (needsSkewMatrix)

--- a/cocos/2d/CCNode.cpp
+++ b/cocos/2d/CCNode.cpp
@@ -1628,14 +1628,17 @@ const Mat4& Node::getNodeToParentTransform() const
 
         bool needsSkewMatrix = ( _skewX || _skewY );
 
+        Vec2 anchorPoint;
+        anchorPoint.x = _anchorPointInPoints.x * _scaleX;
+        anchorPoint.y = _anchorPointInPoints.y * _scaleY;
 
         // optimization:
         // inline anchor point calculation if skew is not needed
         // Adjusted transform calculation for rotational skew
         if (! needsSkewMatrix && !_anchorPointInPoints.equals(Vec2::ZERO))
         {
-            x += cy * -_anchorPointInPoints.x * _scaleX + -sx * -_anchorPointInPoints.y * _scaleY;
-            y += sy * -_anchorPointInPoints.x * _scaleX +  cx * -_anchorPointInPoints.y * _scaleY;
+            x += cy * -anchorPoint.x + -sx * -anchorPoint.y;
+            y += sy * -anchorPoint.x +  cx * -anchorPoint.y;
         }
 
         // Build Transform Matrix
@@ -1650,7 +1653,7 @@ const Mat4& Node::getNodeToParentTransform() const
 
         if(!_ignoreAnchorPointForPosition)
         {
-            _transform.translate(_anchorPointInPoints.x * _scaleX, _anchorPointInPoints.y * _scaleY, 0);
+            _transform.translate(anchorPoint.x, anchorPoint.y, 0);
         }
         
         // XXX
@@ -1669,7 +1672,7 @@ const Mat4& Node::getNodeToParentTransform() const
 
         if(!_ignoreAnchorPointForPosition)
         {
-            _transform.translate(-_anchorPointInPoints.x * _scaleX, -_anchorPointInPoints.y * _scaleY, 0);
+            _transform.translate(-anchorPoint.x, -anchorPoint.y, 0);
         }
         
         // XXX: Try to inline skew

--- a/tests/cpp-tests/Classes/SpriteTest/SpriteTest.cpp
+++ b/tests/cpp-tests/Classes/SpriteTest/SpriteTest.cpp
@@ -131,6 +131,7 @@ static std::function<Layer*()> createFunctions[] =
 	CL(AnimationCacheFile),
 	CL(SpriteCullTest1),
 	CL(SpriteCullTest2),
+    CL(Sprite3DRotationTest),
 };
 
 #define MAX_LAYER    (sizeof(createFunctions) / sizeof(createFunctions[0]))
@@ -4995,3 +4996,48 @@ std::string SpriteCullTest2::subtitle() const
 {
     return "Look at the GL calls";
 }
+
+//------------------------------------------------------------------
+//
+// Sprite 3D rotation test
+//
+//------------------------------------------------------------------
+Sprite3DRotationTest::Sprite3DRotationTest()
+{
+    Size s = Director::getInstance()->getWinSize();
+    
+    //Create reference sprite that's rotating based on there anchor point
+    auto s1 = Sprite::create("Images/grossini.png");
+    s1->setPosition(s.width/4, s.height/4 * 3);
+    s1->setAnchorPoint(Vec2(0, 0));
+    s1->runAction(RepeatForever::create(RotateBy::create(6, 360)));
+    addChild(s1);
+    
+    auto s2 = Sprite::create("Images/grossini.png");
+    s2->setPosition(s.width/4 * 3, s.height/4 * 3);
+    s2->runAction(RepeatForever::create(RotateBy::create(6, 360)));
+    addChild(s2);
+    
+    sprite1 = Sprite::create("Images/grossini.png");
+    sprite1->setPosition(s.width/4, s.height/4);
+    sprite1->setAnchorPoint(Vec2(0,0));
+    
+    addChild(sprite1);
+    
+    sprite2 = Sprite::create("Images/grossini.png");
+    sprite2->setPosition(s.width/4 * 3, s.height/4);
+    
+    addChild(sprite2);
+    
+    scheduleUpdate();
+}
+
+void Sprite3DRotationTest::update(float delta)
+{
+    rotation.y += 1;
+    sprite1->setRotation3D(rotation);
+    sprite2->setRotation3D(rotation);
+}
+
+
+

--- a/tests/cpp-tests/Classes/SpriteTest/SpriteTest.h
+++ b/tests/cpp-tests/Classes/SpriteTest/SpriteTest.h
@@ -749,6 +749,22 @@ public:
     virtual std::string subtitle() const override;
 };
 
+class Sprite3DRotationTest : public SpriteTestDemo
+{
+public:
+    CREATE_FUNC(Sprite3DRotationTest);
+    Sprite3DRotationTest();
+    virtual std::string title() const override { return "3D Rotation Test"; };
+    virtual std::string subtitle() const override { return "Rotation should based on the anchor point"; };
+    virtual void update(float delta) override;
+    
+protected:
+    Sprite* sprite1;
+    Sprite* sprite2;
+    
+    Vec3 rotation;
+};
+
 class SpriteTestScene : public TestScene
 {
 public:


### PR DESCRIPTION
The `Node::setRotation3D` was not based on AnchorPoint.
Since `Node::setRotation` was based on anchor point, I think `Node::setRotation3D` should behave the same

`Sprite3DRotationTest` was created under `SpriteTest.cpp`
