### PR TITLE
Dispatch EVENT_RENDERER_RECREATED event when renderer was recreated on android/wp8.

### DIFF
--- a/cocos/2d/CCDrawNode.cpp
+++ b/cocos/2d/CCDrawNode.cpp
@@ -194,8 +194,8 @@ bool DrawNode::init()
     
 #if CC_ENABLE_CACHE_TEXTURE_DATA
     // Need to listen the event only when not use batchnode, because it will use VBO
-    auto listener = EventListenerCustom::create(EVENT_COME_TO_FOREGROUND, [this](EventCustom* event){
-    /** listen the event that coming to foreground on Android */
+    auto listener = EventListenerCustom::create(EVENT_RENDERER_RECREATED, [this](EventCustom* event){
+   /** listen the event that renderer was recreated on Android/WP8 */
         this->init();
     });
 

--- a/cocos/2d/CCFontAtlas.h
+++ b/cocos/2d/CCFontAtlas.h
@@ -84,15 +84,10 @@ public:
     Texture2D* getTexture(int slot);
     const Font* getFont() const;
 
-    /** Listen "come to background" message, and clear the texture atlas.
-     It only has effect on Android.
+    /** listen the event that renderer was recreated on Android/WP8
+     It only has effect on Android and WP8.
      */
-    void listenToBackground(EventCustom *event);
-
-    /** Listen "come to foreground" message and restore the texture atlas.
-     It only has effect on Android.
-     */
-    void listenToForeground(EventCustom *event);
+    void listenRendererRecreated(EventCustom *event);
     
     /** Removes textures atlas.
      It will purge the textures atlas and if multiple texture exist in the FontAtlas.
@@ -129,9 +124,9 @@ private:
     bool  _makeDistanceMap;
 
     int _fontAscender;
-    EventListenerCustom* _toBackgroundListener;
-    EventListenerCustom* _toForegroundListener;
+    EventListenerCustom* _rendererRecreatedListener;
     bool _antialiasEnabled;
+    bool _rendererRecreate;
 };
 
 

--- a/cocos/2d/CCLabel.cpp
+++ b/cocos/2d/CCLabel.cpp
@@ -266,20 +266,13 @@ Label::Label(FontAtlas *atlas /* = nullptr */, TextHAlignment hAlignment /* = Te
     setAnchorPoint(Vec2::ANCHOR_MIDDLE);
     reset();
 
-#if CC_ENABLE_CACHE_TEXTURE_DATA
-    auto toBackgroundListener = EventListenerCustom::create(EVENT_COME_TO_BACKGROUND, [this](EventCustom* event){
-        if (_fontAtlas && _currentLabelType == LabelType::TTF)
-        {
-            _batchNodes.clear();
-            _batchNodes.push_back(this);
-            Node::removeAllChildrenWithCleanup(true);
-        }
-    });
-    _eventDispatcher->addEventListenerWithSceneGraphPriority(toBackgroundListener, this);
-#endif
     auto purgeTextureListener = EventListenerCustom::create(FontAtlas::EVENT_PURGE_TEXTURES, [this](EventCustom* event){
         if (_fontAtlas && _currentLabelType == LabelType::TTF && event->getUserData() == _fontAtlas)
         {
+            Node::removeAllChildrenWithCleanup(true);
+            _batchNodes.clear();
+            _batchNodes.push_back(this);
+
             alignText();
         }
     });

--- a/cocos/2d/CCParticleSystemQuad.cpp
+++ b/cocos/2d/CCParticleSystemQuad.cpp
@@ -135,7 +135,7 @@ bool ParticleSystemQuad::initWithTotalParticles(int numberOfParticles)
 
 #if CC_ENABLE_CACHE_TEXTURE_DATA
         // Need to listen the event only when not use batchnode, because it will use VBO
-        auto listener = EventListenerCustom::create(EVENT_COME_TO_FOREGROUND, CC_CALLBACK_1(ParticleSystemQuad::listenBackToForeground, this));
+        auto listener = EventListenerCustom::create(EVENT_RENDERER_RECREATED, CC_CALLBACK_1(ParticleSystemQuad::listenRendererRecreated, this));
         _eventDispatcher->addEventListenerWithSceneGraphPriority(listener, this);
 #endif
 
@@ -509,7 +509,7 @@ void ParticleSystemQuad::setupVBO()
     CHECK_GL_ERROR_DEBUG();
 }
 
-void ParticleSystemQuad::listenBackToForeground(EventCustom* event)
+void ParticleSystemQuad::listenRendererRecreated(EventCustom* event)
 {
     if (Configuration::getInstance()->supportsShareableVAO())
     {

--- a/cocos/2d/CCParticleSystemQuad.h
+++ b/cocos/2d/CCParticleSystemQuad.h
@@ -81,11 +81,11 @@ public:
      */
     void setTextureWithRect(Texture2D *texture, const Rect& rect);
 
-    /** listen the event that coming to foreground on Android
+    /** listen the event that renderer was recreated on Android/WP8
      * @js NA
      * @lua NA
      */
-    void listenBackToForeground(EventCustom* event);
+    void listenRendererRecreated(EventCustom* event);
 
     /**
      * @js NA

--- a/cocos/3d/CCMesh.cpp
+++ b/cocos/3d/CCMesh.cpp
@@ -322,22 +322,22 @@ void MeshCache::removeUnusedMesh()
 
 MeshCache::MeshCache()
 {
-#if (CC_TARGET_PLATFORM == CC_PLATFORM_ANDROID)
-    // listen the event when app go to foreground
-    _backToForegroundlistener = EventListenerCustom::create(EVENT_COME_TO_FOREGROUND, CC_CALLBACK_1(MeshCache::listenBackToForeground, this));
-    Director::getInstance()->getEventDispatcher()->addEventListenerWithFixedPriority(_backToForegroundlistener, -1);
+#if (CC_TARGET_PLATFORM == CC_PLATFORM_ANDROID || CC_TARGET_PLATFORM == CC_PLATFORM_WP8)
+    // listen the event that renderer was recreated on Android/WP8
+    _rendererRecreatedListener = EventListenerCustom::create(EVENT_RENDERER_RECREATED, CC_CALLBACK_1(MeshCache::listenRendererRecreated, this));
+    Director::getInstance()->getEventDispatcher()->addEventListenerWithFixedPriority(_rendererRecreatedListener, -1);
 #endif
 }
 MeshCache::~MeshCache()
 {
     removeAllMeshes();
-#if (CC_TARGET_PLATFORM == CC_PLATFORM_ANDROID)
-    Director::getInstance()->getEventDispatcher()->removeEventListener(_backToForegroundlistener);
+#if (CC_TARGET_PLATFORM == CC_PLATFORM_ANDROID || CC_TARGET_PLATFORM == CC_PLATFORM_WP8)
+    Director::getInstance()->getEventDispatcher()->removeEventListener(_rendererRecreatedListener);
 #endif
 }
 
-#if (CC_TARGET_PLATFORM == CC_PLATFORM_ANDROID)
-void MeshCache::listenBackToForeground(EventCustom* event)
+#if (CC_TARGET_PLATFORM == CC_PLATFORM_ANDROID || CC_TARGET_PLATFORM == CC_PLATFORM_WP8)
+void MeshCache::listenRendererRecreated(EventCustom* event)
 {
     for (auto iter = _meshes.begin(); iter != _meshes.end(); ++iter)
     {

--- a/cocos/3d/CCMesh.h
+++ b/cocos/3d/CCMesh.h
@@ -163,8 +163,8 @@ public:
     /**remove unused meshes*/
     void removeUnusedMesh();
     
-#if (CC_TARGET_PLATFORM == CC_PLATFORM_ANDROID)
-    void listenBackToForeground(EventCustom* event);
+#if (CC_TARGET_PLATFORM == CC_PLATFORM_ANDROID || CC_TARGET_PLATFORM == CC_PLATFORM_WP8)
+    void listenRendererRecreated(EventCustom* event);
 #endif
     
 CC_CONSTRUCTOR_ACCESS:
@@ -178,8 +178,8 @@ protected:
     
     std::unordered_map<std::string, Mesh*> _meshes; //cached meshes
     
-#if (CC_TARGET_PLATFORM == CC_PLATFORM_ANDROID)
-    EventListenerCustom* _backToForegroundlistener;
+#if (CC_TARGET_PLATFORM == CC_PLATFORM_ANDROID || CC_TARGET_PLATFORM == CC_PLATFORM_WP8)
+    EventListenerCustom* _rendererRecreatedListener;
 #endif
 };
 

--- a/cocos/base/CCEventDispatcher.cpp
+++ b/cocos/base/CCEventDispatcher.cpp
@@ -211,6 +211,7 @@ EventDispatcher::EventDispatcher()
     // Therefore, internal listeners would not be cleaned when removeAllEventListeners is invoked.
     _internalCustomListenerIDs.insert(EVENT_COME_TO_FOREGROUND);
     _internalCustomListenerIDs.insert(EVENT_COME_TO_BACKGROUND);
+    _internalCustomListenerIDs.insert(EVENT_RENDERER_RECREATED);
 }
 
 EventDispatcher::~EventDispatcher()

--- a/cocos/base/CCEventType.h
+++ b/cocos/base/CCEventType.h
@@ -30,13 +30,17 @@
  */
 
 // The application will come to foreground.
-// This message is used for reloading resources before come to foreground on Android.
-// This message is posted in main.cpp.
+// This message is posted in cocos/platform/android/jni/Java_org_cocos2dx_lib_Cocos2dxRenderer.cpp.
 #define EVENT_COME_TO_FOREGROUND    "event_come_to_foreground"
+
+// The renderer[android:GLSurfaceView.Renderer  WP8:Cocos2dRenderer] was recreated.
+// This message is used for reloading resources before renderer is recreated on Android/WP8.
+// This message is posted in cocos/platform/android/javaactivity.cpp and cocos\platform\wp8-xaml\cpp\Cocos2dRenderer.cpp.
+#define EVENT_RENDERER_RECREATED "event_renderer_recreated"
 
 // The application will come to background.
 // This message is used for doing something before coming to background, such as save RenderTexture.
-// This message is posted in cocos2dx/platform/android/jni/MessageJni.cpp.
+// This message is posted in cocos/platform/android/jni/Java_org_cocos2dx_lib_Cocos2dxRenderer.cpp and cocos\platform\wp8-xaml\cpp\Cocos2dRenderer.cpp.
 #define EVENT_COME_TO_BACKGROUND    "event_come_to_background"
 
 #endif // __CCEVENT_TYPE_H__

--- a/cocos/platform/android/javaactivity.cpp
+++ b/cocos/platform/android/javaactivity.cpp
@@ -75,8 +75,8 @@ void Java_org_cocos2dx_lib_Cocos2dxRenderer_nativeInit(JNIEnv*  env, jobject thi
         cocos2d::DrawPrimitives::init();
         cocos2d::VolatileTextureMgr::reloadAllTextures();
 
-        cocos2d::EventCustom foregroundEvent(EVENT_COME_TO_FOREGROUND);
-        director->getEventDispatcher()->dispatchEvent(&foregroundEvent);
+        cocos2d::EventCustom recreatedEvent(EVENT_RENDERER_RECREATED);
+        director->getEventDispatcher()->dispatchEvent(&recreatedEvent);
         director->setGLDefaultValues();
     }
 

--- a/cocos/platform/android/jni/Java_org_cocos2dx_lib_Cocos2dxRenderer.cpp
+++ b/cocos/platform/android/jni/Java_org_cocos2dx_lib_Cocos2dxRenderer.cpp
@@ -24,6 +24,8 @@ extern "C" {
     JNIEXPORT void JNICALL Java_org_cocos2dx_lib_Cocos2dxRenderer_nativeOnResume() {
         if (Director::getInstance()->getOpenGLView()) {
             Application::getInstance()->applicationWillEnterForeground();
+            cocos2d::EventCustom foregroundEvent(EVENT_COME_TO_FOREGROUND);
+            cocos2d::Director::getInstance()->getEventDispatcher()->dispatchEvent(&foregroundEvent);
         }
     }
 

--- a/cocos/platform/wp8-xaml/cpp/Cocos2dRenderer.cpp
+++ b/cocos/platform/wp8-xaml/cpp/Cocos2dRenderer.cpp
@@ -67,8 +67,8 @@ void Cocos2dRenderer::CreateGLResources()
         cocos2d::ShaderCache::getInstance()->reloadDefaultGLPrograms();
         cocos2d::DrawPrimitives::init();
         cocos2d::VolatileTextureMgr::reloadAllTextures();
-        cocos2d::EventCustom foregroundEvent(EVENT_COME_TO_FOREGROUND);
-        director->getEventDispatcher()->dispatchEvent(&foregroundEvent);
+        cocos2d::EventCustom recreatedEvent(EVENT_RENDERER_RECREATED);
+        director->getEventDispatcher()->dispatchEvent(&recreatedEvent);
         cocos2d::Application::getInstance()->applicationWillEnterForeground();
         director->setGLDefaultValues();
   }

--- a/cocos/renderer/CCGLProgramState.cpp
+++ b/cocos/renderer/CCGLProgramState.cpp
@@ -279,9 +279,9 @@ GLProgramState::GLProgramState()
 , _uniformAttributeValueDirty(true)
 {
 #if (CC_TARGET_PLATFORM == CC_PLATFORM_ANDROID)
-    // listen the event when app go to foreground
-    CCLOG("create _backToForegroundlistener for GLProgramState");
-    _backToForegroundlistener = EventListenerCustom::create(EVENT_COME_TO_FOREGROUND, [this](EventCustom*) { _uniformAttributeValueDirty = true; });
+    /** listen the event that renderer was recreated on Android/WP8 */
+    CCLOG("create rendererRecreatedListener for GLProgramState");
+    _backToForegroundlistener = EventListenerCustom::create(EVENT_RENDERER_RECREATED, [this](EventCustom*) { _uniformAttributeValueDirty = true; });
     Director::getInstance()->getEventDispatcher()->addEventListenerWithFixedPriority(_backToForegroundlistener, -1);
 #endif
 }

--- a/cocos/renderer/CCMeshCommand.cpp
+++ b/cocos/renderer/CCMeshCommand.cpp
@@ -56,10 +56,10 @@ MeshCommand::MeshCommand()
 , _vao(0)
 {
     _type = RenderCommand::Type::MESH_COMMAND;
-#if (CC_TARGET_PLATFORM == CC_PLATFORM_ANDROID)
-    // listen the event when app go to foreground
-    _backToForegroundlistener = EventListenerCustom::create(EVENT_COME_TO_FOREGROUND, CC_CALLBACK_1(MeshCommand::listenBackToForeground, this));
-    Director::getInstance()->getEventDispatcher()->addEventListenerWithFixedPriority(_backToForegroundlistener, -1);
+#if (CC_TARGET_PLATFORM == CC_PLATFORM_ANDROID || CC_TARGET_PLATFORM == CC_PLATFORM_WP8)
+    // listen the event that renderer was recreated on Android/WP8
+    _rendererRecreatedListener = EventListenerCustom::create(EVENT_RENDERER_RECREATED, CC_CALLBACK_1(MeshCommand::listenRendererRecreated, this));
+    Director::getInstance()->getEventDispatcher()->addEventListenerWithFixedPriority(_rendererRecreatedListener, -1);
 #endif
 }
 
@@ -117,8 +117,8 @@ void MeshCommand::setDisplayColor(const Vec4& color)
 MeshCommand::~MeshCommand()
 {
     releaseVAO();
-#if (CC_TARGET_PLATFORM == CC_PLATFORM_ANDROID)
-    Director::getInstance()->getEventDispatcher()->removeEventListener(_backToForegroundlistener);
+#if (CC_TARGET_PLATFORM == CC_PLATFORM_ANDROID || CC_TARGET_PLATFORM == CC_PLATFORM_WP8)
+    Director::getInstance()->getEventDispatcher()->removeEventListener(_rendererRecreatedListener);
 #endif
 }
 
@@ -297,7 +297,7 @@ void MeshCommand::releaseVAO()
 }
 
 #if (CC_TARGET_PLATFORM == CC_PLATFORM_ANDROID)
-void MeshCommand::listenBackToForeground(EventCustom* event)
+void MeshCommand::listenRendererRecreated(EventCustom* event)
 {
     releaseVAO();
 }

--- a/cocos/renderer/CCMeshCommand.h
+++ b/cocos/renderer/CCMeshCommand.h
@@ -75,7 +75,7 @@ public:
     uint32_t getMaterialID() const { return _materialID; }
     
 #if (CC_TARGET_PLATFORM == CC_PLATFORM_ANDROID)
-    void listenBackToForeground(EventCustom* event);
+    void listenRendererRecreated(EventCustom* event);
 #endif
 
 protected:
@@ -122,8 +122,8 @@ protected:
     // ModelView transform
     Mat4 _mv;
     
-#if (CC_TARGET_PLATFORM == CC_PLATFORM_ANDROID)
-    EventListenerCustom* _backToForegroundlistener;
+#if (CC_TARGET_PLATFORM == CC_PLATFORM_ANDROID || CC_TARGET_PLATFORM == CC_PLATFORM_WP8)
+    EventListenerCustom* _rendererRecreatedListener;
 #endif
 };
 

--- a/cocos/renderer/CCRenderer.cpp
+++ b/cocos/renderer/CCRenderer.cpp
@@ -145,8 +145,8 @@ Renderer::~Renderer()
 void Renderer::initGLView()
 {
 #if CC_ENABLE_CACHE_TEXTURE_DATA
-    _cacheTextureListener = EventListenerCustom::create(EVENT_COME_TO_FOREGROUND, [this](EventCustom* event){
-        /** listen the event that coming to foreground on Android */
+    _cacheTextureListener = EventListenerCustom::create(EVENT_RENDERER_RECREATED, [this](EventCustom* event){
+        /** listen the event that renderer was recreated on Android/WP8 */
         this->setupBuffer();
     });
     

--- a/cocos/renderer/CCTextureAtlas.cpp
+++ b/cocos/renderer/CCTextureAtlas.cpp
@@ -57,7 +57,7 @@ TextureAtlas::TextureAtlas()
     ,_texture(nullptr)
     ,_quads(nullptr)
 #if CC_ENABLE_CACHE_TEXTURE_DATA
-    ,_backToForegroundlistener(nullptr)
+    ,_rendererRecreatedListener(nullptr)
 #endif
 {}
 
@@ -78,7 +78,7 @@ TextureAtlas::~TextureAtlas()
     CC_SAFE_RELEASE(_texture);
     
 #if CC_ENABLE_CACHE_TEXTURE_DATA
-    Director::getInstance()->getEventDispatcher()->removeEventListener(_backToForegroundlistener);
+    Director::getInstance()->getEventDispatcher()->removeEventListener(_rendererRecreatedListener);
 #endif
 }
 
@@ -192,9 +192,9 @@ bool TextureAtlas::initWithTexture(Texture2D *texture, ssize_t capacity)
     memset( _indices, 0, _capacity * 6 * sizeof(GLushort) );
     
 #if CC_ENABLE_CACHE_TEXTURE_DATA
-    // listen the event when app go to background
-    _backToForegroundlistener = EventListenerCustom::create(EVENT_COME_TO_FOREGROUND, CC_CALLBACK_1(TextureAtlas::listenBackToForeground, this));
-    Director::getInstance()->getEventDispatcher()->addEventListenerWithFixedPriority(_backToForegroundlistener, -1);
+    /** listen the event that renderer was recreated on Android/WP8 */
+    _rendererRecreatedListener = EventListenerCustom::create(EVENT_RENDERER_RECREATED, CC_CALLBACK_1(TextureAtlas::listenRendererRecreated, this));
+    Director::getInstance()->getEventDispatcher()->addEventListenerWithFixedPriority(_rendererRecreatedListener, -1);
 #endif
     
     this->setupIndices();
@@ -213,7 +213,7 @@ bool TextureAtlas::initWithTexture(Texture2D *texture, ssize_t capacity)
     return true;
 }
 
-void TextureAtlas::listenBackToForeground(EventCustom* event)
+void TextureAtlas::listenRendererRecreated(EventCustom* event)
 {  
     if (Configuration::getInstance()->supportsShareableVAO())
     {

--- a/cocos/renderer/CCTextureAtlas.h
+++ b/cocos/renderer/CCTextureAtlas.h
@@ -189,9 +189,9 @@ public:
     /** draws all the Atlas's Quads
     */
     void drawQuads();
-    /** listen the event that coming to foreground on Android
+    /** listen the event that renderer was recreated on Android
      */
-    void listenBackToForeground(EventCustom* event);
+    void listenRendererRecreated(EventCustom* event);
 
     /** whether or not the array buffer of the VBO needs to be updated*/
     inline bool isDirty(void) { return _dirty; }
@@ -244,7 +244,7 @@ protected:
     V3F_C4B_T2F_Quad* _quads;
     
 #if CC_ENABLE_CACHE_TEXTURE_DATA
-    EventListenerCustom* _backToForegroundlistener;
+    EventListenerCustom* _rendererRecreatedListener;
 #endif
 };
 

--- a/tests/cpp-tests/Classes/ShaderTest/ShaderTest.cpp
+++ b/tests/cpp-tests/Classes/ShaderTest/ShaderTest.cpp
@@ -132,7 +132,7 @@ ShaderNode* ShaderNode::shaderNodeWithVertex(const std::string &vert, const std:
 bool ShaderNode::initWithVertex(const std::string &vert, const std::string &frag)
 {
 #if CC_ENABLE_CACHE_TEXTURE_DATA
-    auto listener = EventListenerCustom::create(EVENT_COME_TO_FOREGROUND, [this](EventCustom* event){
+    auto listener = EventListenerCustom::create(EVENT_RENDERER_RECREATED, [this](EventCustom* event){
             this->setGLProgramState(nullptr);
             loadShaderVertex(_vertFileName, _fragFileName);
         });
@@ -458,7 +458,7 @@ bool SpriteBlur::initWithTexture(Texture2D* texture, const Rect& rect)
     if( Sprite::initWithTexture(texture, rect) ) 
     {
 #if CC_ENABLE_CACHE_TEXTURE_DATA
-        auto listener = EventListenerCustom::create(EVENT_COME_TO_FOREGROUND, [this](EventCustom* event){
+        auto listener = EventListenerCustom::create(EVENT_RENDERER_RECREATED, [this](EventCustom* event){
                 setGLProgram(nullptr);
                 initGLProgram();
             });

--- a/tests/cpp-tests/Classes/ShaderTest/ShaderTest2.cpp
+++ b/tests/cpp-tests/Classes/ShaderTest/ShaderTest2.cpp
@@ -222,7 +222,7 @@ Effect::Effect()
 : _glprogramstate(nullptr)
 {
 #if (CC_TARGET_PLATFORM == CC_PLATFORM_ANDROID)
-    _backgroundListener = EventListenerCustom::create(EVENT_COME_TO_FOREGROUND,
+    _backgroundListener = EventListenerCustom::create(EVENT_RENDERER_RECREATED,
                                                       [this](EventCustom*)
                                                       {
                                                           auto glProgram = _glprogramstate->getGLProgram();

--- a/tests/cpp-tests/Classes/Sprite3DTest/Sprite3DTest.cpp
+++ b/tests/cpp-tests/Classes/Sprite3DTest/Sprite3DTest.cpp
@@ -325,7 +325,7 @@ Effect3DOutline::Effect3DOutline()
 , _sprite(nullptr)
 {
 #if (CC_TARGET_PLATFORM == CC_PLATFORM_ANDROID)
-    _backToForegroundListener = EventListenerCustom::create(EVENT_COME_TO_FOREGROUND,
+    _backToForegroundListener = EventListenerCustom::create(EVENT_RENDERER_RECREATED,
                                                           [this](EventCustom*)
                                                           {
                                                               auto glProgram = _glProgramState->getGLProgram();


### PR DESCRIPTION
1.Dispatch EVENT_RENDERER_RECREATED event when renderer was recreated on android/wp8
2:Make clear EVENT_COME_TO_FOREGROUND event.
3.fixed label displaying incorrectly when ‘Don't keep activities’ is enabled.
