### PR TITLE
Fix setup.py can't resolve symlink

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -218,7 +218,7 @@ class SetEnvVar(object):
         return ret
 
     def _find_environment_variable(self, var):
-        print("  ->Find environment variable %s..." % var)
+        print("  ->Search for environment variable %s..." % var)
         ret = None
         try:
             ret = os.environ[var]
@@ -529,52 +529,31 @@ class SetEnvVar(object):
         return ret
 
     def _get_ant_path(self):
-        print("  ->Find command ant in system...")
-        ret = None
-        if not self._isWindows():
-            import commands
-            state, result = commands.getstatusoutput("which ant")
-            if state == 0:
-                ret = os.path.realpath(result)
-                ret = os.path.dirname(ret)
-
-        if ret is not None:
-            print("    ->Path \"%s\" was found\n" % ret)
-        else:
-            print("    ->Command ant not found\n")
-        return ret
+        return self._get_sdkpath_for_cmd("ant", False)
 
     def _get_androidsdk_path(self):
-        print("  ->Find command android in system...")
-        ret = None
-        if not self._isWindows():
-            import commands
-            state, result = commands.getstatusoutput("which android")
-            if state == 0:
-                ret = os.path.realpath(result)
-                ret = os.path.dirname(ret)
-
-        if ret is not None:
-            ret = os.path.abspath(os.path.join(ret,os.pardir))
-            print("    ->Path \"%s\" was found\n" % ret)
-        else:
-            print("    ->Command android not found\n")
-        return ret
+        return self._get_sdkpath_for_cmd("android")
 
     def _get_ndkbuild_path(self):
-        print("  ->Find command ndk-build in system...")
+        return self._get_sdkpath_for_cmd("ndk-build", False)
+
+    def _get_sdkpath_for_cmd(self, cmd, has_bin_folder=True):
         ret = None
+        print("  ->Search for command " + cmd + " in system...")
         if not self._isWindows():
             import commands
-            state, result = commands.getstatusoutput("which ndk-build")
+            state, result = commands.getstatusoutput("which " + cmd)
             if state == 0:
                 ret = os.path.realpath(result)
                 ret = os.path.dirname(ret)
+                # Use parent folder if has_bin_folder was set
+                if has_bin_folder:
+                    ret = os.path.dirname(ret)
 
         if ret is not None:
-            print("    ->Path \"%s\" was found\n" % ret)
+            print("    ->Path " + ret + " was found\n")
         else:
-            print("    ->Command ndk-build not found\n")
+            print("    ->Command " + ret + " not found\n")
         return ret
 
     def _find_value_from_sys(self, var_name):

--- a/setup.py
+++ b/setup.py
@@ -535,7 +535,8 @@ class SetEnvVar(object):
             import commands
             state, result = commands.getstatusoutput("which ant")
             if state == 0:
-                ret = os.path.dirname(result)
+                ret = os.path.realpath(result)
+                ret = os.path.dirname(ret)
 
         if ret is not None:
             print("    ->Path \"%s\" was found\n" % ret)
@@ -550,7 +551,8 @@ class SetEnvVar(object):
             import commands
             state, result = commands.getstatusoutput("which android")
             if state == 0:
-                ret = os.path.dirname(result)
+                ret = os.path.realpath(result)
+                ret = os.path.dirname(ret)
 
         if ret is not None:
             ret = os.path.abspath(os.path.join(ret,os.pardir))
@@ -566,7 +568,8 @@ class SetEnvVar(object):
             import commands
             state, result = commands.getstatusoutput("which ndk-build")
             if state == 0:
-                ret = os.path.dirname(result)
+                ret = os.path.realpath(result)
+                ret = os.path.dirname(ret)
 
         if ret is not None:
             print("    ->Path \"%s\" was found\n" % ret)


### PR DESCRIPTION
If you use symlink to setup your ndk, android-sdk, for example, use [homebrew](http://brew.sh), `setup.py` will fail to find the correct path.
