### PR TITLE
fix loading bar switch loading method issue

### DIFF
--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UILoadingBarTest/UILoadingBarTest_Editor.cpp
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UILoadingBarTest/UILoadingBarTest_Editor.cpp
@@ -19,6 +19,7 @@ UILoadingBarTest_Editor::~UILoadingBarTest_Editor()
 void UILoadingBarTest_Editor::switchLoadMethod(cocos2d::Ref *pSender)
 {
     MenuItemToggle *item = (MenuItemToggle*)pSender;
+    _count = 0;
     
     if (item->getSelectedIndex() == 0){
         _layout->removeFromParentAndCleanup(true);


### PR DESCRIPTION
When switch loading method from json to csb, the loading bar don't reset its percentage
