### PR TITLE
Make the scrollView delegate methods optional

### DIFF
--- a/extensions/GUI/CCScrollView/CCScrollView.h
+++ b/extensions/GUI/CCScrollView/CCScrollView.h
@@ -52,12 +52,12 @@ public:
      * @js NA
      * @lua NA
      */
-    virtual void scrollViewDidScroll(ScrollView* view) = 0;
+    virtual void scrollViewDidScroll(ScrollView* view) {};
     /**
      * @js NA
      * @lua NA
      */
-    virtual void scrollViewDidZoom(ScrollView* view) = 0;
+    virtual void scrollViewDidZoom(ScrollView* view) {};
 };
 
 


### PR DESCRIPTION
Context:

When using the `extension::TableView` class and extending the `TableViewDelegate` to respond to touches, you also have to implement `ScrollViewDelegate` methods:

``` cpp
    /**
     * @js NA
     * @lua NA
     */
    virtual void scrollViewDidScroll(ScrollView* view) = 0;
    /**
     * @js NA
     * @lua NA
     */
    virtual void scrollViewDidZoom(ScrollView* view) = 0;
```

This is really annoying, as I am simply not interesting in these methods, I just need to implement the `TableViewDelegate` methods. This also doesn't comply with CocoaTouch, since these methods are optional in CocoaTouch.

Think of it this way, there is absolutely no harm if the delegate doesn't implement those methods, hence they should be optional.

Thanks,
