### PR TITLE
[FIX]: copied data should be const

### DIFF
--- a/cocos/base/CCData.cpp
+++ b/cocos/base/CCData.cpp
@@ -100,7 +100,7 @@ ssize_t Data::getSize() const
     return _size;
 }
 
-void Data::copy(unsigned char* bytes, const ssize_t size)
+void Data::copy(const unsigned char* bytes, const ssize_t size)
 {
     clear();
     

--- a/cocos/base/CCData.h
+++ b/cocos/base/CCData.h
@@ -63,7 +63,7 @@ public:
      *        Developer should free the pointer after invoking this method.
      *  @see Data::fastSet
      */
-    void copy(unsigned char* bytes, const ssize_t size);
+    void copy(const unsigned char* bytes, const ssize_t size);
     
     /** Fast set the buffer pointer and its size. Please use it carefully.
      *  @param bytes The buffer pointer, note that it have to be allocated by 'malloc' or 'calloc',


### PR DESCRIPTION
Context:

In order to store data in `UserDefault`, I use this:

``` cpp
data.copy(reinterpret_cast<const unsigned char *>(this), sizeof(User));
```

Since `this` is a const pointer, I either have to use `const_cast` with the current API, which is bad, or change it, so I decided to change it.

Note, this only makes the API more strict within the method, so of course it is compatible with non const values.

Thanks,
