### PR TITLE
Update CCBundleReader.h

### DIFF
--- a/cocos/3d/CCBundleReader.h
+++ b/cocos/3d/CCBundleReader.h
@@ -87,7 +87,7 @@ public:
     /**
      * Returns the position of the file pointer.
      */
-    long int tell();
+    ssize_t tell();
 
     /**
      * Sets the position of the file pointer.


### PR DESCRIPTION
Why is tell() declared as 'long int' but then subsequently defined as 'ssize_t'?

This breaks my build, hence this 'fix'
