### PR TITLE
Wp8 v3 rendertexture fix

### DIFF
--- a/cocos/2d/CCRenderTexture.cpp
+++ b/cocos/2d/CCRenderTexture.cpp
@@ -99,8 +99,7 @@ void RenderTexture::listenToBackground(EventCustom *event)
     int count = 0;
     count++;
 
-#if 1
-#if CC_ENABLE_CACHE_TEXTURE_DATA
+#if CC_ENABLE_CACHE_TEXTURE_DATA && (CC_TARGET_PLATFORM == CC_PLATFORM_WP8)
     CC_SAFE_DELETE(_UITextureImage);
     
     // to get the rendered texture data
@@ -124,13 +123,11 @@ void RenderTexture::listenToBackground(EventCustom *event)
     glDeleteFramebuffers(1, &_FBO);
     _FBO = 0;
 #endif
-#endif
 }
 
 void RenderTexture::listenToForeground(EventCustom *event)
 {
-#if 1
-#if CC_ENABLE_CACHE_TEXTURE_DATA
+#if CC_ENABLE_CACHE_TEXTURE_DATA && (CC_TARGET_PLATFORM == CC_PLATFORM_WP8)
     // -- regenerate frame buffer object and attach the texture
     glGetIntegerv(GL_FRAMEBUFFER_BINDING, &_oldFBO);
     
@@ -146,7 +143,6 @@ void RenderTexture::listenToForeground(EventCustom *event)
     
     glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, _texture->getName(), 0);
     glBindFramebuffer(GL_FRAMEBUFFER, _oldFBO);
-#endif
 #endif
 }
 

--- a/cocos/2d/CCRenderTexture.cpp
+++ b/cocos/2d/CCRenderTexture.cpp
@@ -96,7 +96,10 @@ void RenderTexture::listenToBackground(EventCustom *event)
 {
     // We have not found a way to dispatch the enter background message before the texture data are destroyed.
     // So we disable this pair of message handler at present.
-#if 0
+    int count = 0;
+    count++;
+
+#if 1
 #if CC_ENABLE_CACHE_TEXTURE_DATA
     CC_SAFE_DELETE(_UITextureImage);
     
@@ -126,7 +129,7 @@ void RenderTexture::listenToBackground(EventCustom *event)
 
 void RenderTexture::listenToForeground(EventCustom *event)
 {
-#if 0
+#if 1
 #if CC_ENABLE_CACHE_TEXTURE_DATA
     // -- regenerate frame buffer object and attach the texture
     glGetIntegerv(GL_FRAMEBUFFER_BINDING, &_oldFBO);
@@ -241,8 +244,10 @@ bool RenderTexture::initWithWidthAndHeight(int w, int h, Texture2D::PixelFormat 
         }
         GLint oldRBO;
         glGetIntegerv(GL_RENDERBUFFER_BINDING, &oldRBO);
-        
+  
+#if CC_TARGET_PLATFORM != CC_PLATFORM_WP8
         if (Configuration::getInstance()->checkForGLExtension("GL_QCOM"))
+#endif
         {
             _textureCopy = new Texture2D();
             if (_textureCopy)

--- a/cocos/platform/wp8-xaml/cpp/Cocos2dRenderer.cpp
+++ b/cocos/platform/wp8-xaml/cpp/Cocos2dRenderer.cpp
@@ -70,6 +70,8 @@ void Cocos2dRenderer::CreateGLResources()
         cocos2d::EventCustom recreatedEvent(EVENT_RENDERER_RECREATED);
         director->getEventDispatcher()->dispatchEvent(&recreatedEvent);
         cocos2d::Application::getInstance()->applicationWillEnterForeground();
+        cocos2d::EventCustom event(EVENT_COME_TO_FOREGROUND);
+        cocos2d::Director::getInstance()->getEventDispatcher()->dispatchEvent(&event);
         director->setGLDefaultValues();
   }
 


### PR DESCRIPTION
I looked at the CCRenderTexture.cpp code and found this around line 249:

```
    if (Configuration::getInstance()->checkForGLExtension("GL_QCOM"))
```

What is the GL_QCOM extension? Since this is not supported on WP8, I changed the line to:
# if CC_TARGET_PLATFORM != CC_PLATFORM_WP8

```
    if (Configuration::getInstance()->checkForGLExtension("GL_QCOM"))
```
# endif

This will allow the texture to be copied.

I also made changes to Cocos2dRenderer.cpp at line 72 to send the EVENT_COME_TO_FOREGROUND event.

There are still problems with the RenderTextureTests. Several tests are not listening for the EVENT_RENDERER_RECREATED event and are not recreating the sprites. Also, some of the rendertextures are not getting the EVENT_COME_TO_BACKGROUND/FOREGROUND events which seems to be a bug/bugs in the tests.
