### PR TITLE
fixed compile error.

### DIFF
--- a/cocos/3d/CCBundleReader.h
+++ b/cocos/3d/CCBundleReader.h
@@ -87,7 +87,7 @@ public:
     /**
      * Returns the position of the file pointer.
      */
-    long int tell();
+    ssize_t tell();
 
     /**
      * Sets the position of the file pointer.

--- a/templates/cpp-template-default/proj.android/.project
+++ b/templates/cpp-template-default/proj.android/.project
@@ -121,7 +121,7 @@
 		<link>
 			<name>libcocos2d</name>
 			<type>2</type>
-			<locationURI>PARENT-1-PROJECT_LOC/cocos2d/cocos/2d/platform/android/java/src</locationURI>
+			<locationURI>PARENT-1-PROJECT_LOC/cocos2d/cocos/platform/android/java/src</locationURI>
 		</link>
 	</linkedResources>
 </projectDescription>


### PR DESCRIPTION
``` bash
# compile for android.
$ ./build_native.py
```

Error message as follow:

```
ssize_tjni/../../cocos2d/cocos/./3d/CCBundleReader.cpp:94:23: error: return type of out-of-line
      definition of 'cocos2d::BundleReader::tell' differs from that in the declaration
ssize_t BundleReader::tell()
                      ^
jni/../../cocos2d/cocos/./3d/CCBundleReader.h:90:14: note: previous declaration is here
    long int tell();
             ^
1 error generated.
```
