### PR TITLE
Fixed error for importing project

### DIFF
--- a/templates/cpp-template-default/proj.android/.project
+++ b/templates/cpp-template-default/proj.android/.project
@@ -121,7 +121,7 @@
 		<link>
 			<name>libcocos2d</name>
 			<type>2</type>
-			<locationURI>PARENT-1-PROJECT_LOC/cocos2d/cocos/2d/platform/android/java/src</locationURI>
+			<locationURI>PARENT-1-PROJECT_LOC/cocos2d/cocos/platform/android/java/src</locationURI>
 		</link>
 	</linkedResources>
 </projectDescription>


### PR DESCRIPTION
fixed error for importing android project to Eclipse

```
The import org.cocos2dx.lib cannot be resolved ...
```
