### PR TITLE
handle controller events (Ouya, FireTV)

### DIFF
--- a/cocos2dx/keypad_dispatcher/CCKeypadDelegate.h
+++ b/cocos2dx/keypad_dispatcher/CCKeypadDelegate.h
@@ -45,6 +45,8 @@ public:
 
     // The menu key clicked. only available on wophone & android
     virtual void keyMenuClicked() {};
+
+	virtual void keypadDown(int keyCode) {};
 };
 
 /**

--- a/cocos2dx/keypad_dispatcher/CCKeypadDispatcher.cpp
+++ b/cocos2dx/keypad_dispatcher/CCKeypadDispatcher.cpp
@@ -173,4 +173,48 @@ bool CCKeypadDispatcher::dispatchKeypadMSG(ccKeypadMSGType nMsgType)
     return true;
 }
 
+bool CCKeypadDispatcher::dispatchKeypadDown(int keyCode)
+{
+	CCKeypadHandler*  pHandler = NULL;
+	CCKeypadDelegate* pDelegate = NULL;
+
+	m_bLocked = true;
+
+	if (m_pDelegates->count() > 0)
+	{
+		CCObject* pObj = NULL;
+		CCARRAY_FOREACH(m_pDelegates, pObj)
+		{
+			CC_BREAK_IF(!pObj);
+
+			pHandler = (CCKeypadHandler*)pObj;
+			pDelegate = pHandler->getDelegate();
+
+			pDelegate->keypadDown(keyCode);
+		}
+	}
+
+	m_bLocked = false;
+	if (m_bToRemove)
+	{
+		m_bToRemove = false;
+		for (unsigned int i = 0; i < m_pHandlersToRemove->num; ++i)
+		{
+			forceRemoveDelegate((CCKeypadDelegate*)m_pHandlersToRemove->arr[i]);
+		}
+		ccCArrayRemoveAllValues(m_pHandlersToRemove);
+	}
+
+	if (m_bToAdd)
+	{
+		m_bToAdd = false;
+		for (unsigned int i = 0; i < m_pHandlersToAdd->num; ++i)
+		{
+			forceAddDelegate((CCKeypadDelegate*)m_pHandlersToAdd->arr[i]);
+		}
+		ccCArrayRemoveAllValues(m_pHandlersToAdd);
+	}
+
+	return true;
+}
 NS_CC_END

--- a/cocos2dx/keypad_dispatcher/CCKeypadDispatcher.h
+++ b/cocos2dx/keypad_dispatcher/CCKeypadDispatcher.h
@@ -79,6 +79,11 @@ public:
     */
     bool dispatchKeypadMSG(ccKeypadMSGType nMsgType);
 
+	/**
+	@brief dispatch the keydown event
+	*/
+	bool dispatchKeypadDown(int keyCode);
+
 protected:
 
     CCArray* m_pDelegates;

--- a/cocos2dx/layers_scenes_transitions_nodes/CCLayer.cpp
+++ b/cocos2dx/layers_scenes_transitions_nodes/CCLayer.cpp
@@ -328,6 +328,10 @@ void CCLayer::keyMenuClicked(void)
     }
 }
 
+void CCLayer::keypadDown(int)
+{
+}
+
 /// Callbacks
 void CCLayer::onEnter()
 {

--- a/cocos2dx/layers_scenes_transitions_nodes/CCLayer.h
+++ b/cocos2dx/layers_scenes_transitions_nodes/CCLayer.h
@@ -165,6 +165,7 @@ public:
 
     virtual void keyBackClicked(void);
     virtual void keyMenuClicked(void);
+	virtual void keypadDown(int);
     
     inline CCTouchScriptHandlerEntry* getScriptTouchHandlerEntry() { return m_pScriptTouchHandlerEntry; };
     inline CCScriptHandlerEntry* getScriptKeypadHandlerEntry() { return m_pScriptKeypadHandlerEntry; };

--- a/cocos2dx/platform/android/java/src/org/cocos2dx/lib/Cocos2dxGLSurfaceView.java
+++ b/cocos2dx/platform/android/java/src/org/cocos2dx/lib/Cocos2dxGLSurfaceView.java
@@ -294,19 +294,14 @@ public class Cocos2dxGLSurfaceView extends GLSurfaceView {
 
 	@Override
 	public boolean onKeyDown(final int pKeyCode, final KeyEvent pKeyEvent) {
-		switch (pKeyCode) {
-			case KeyEvent.KEYCODE_BACK:
-			case KeyEvent.KEYCODE_MENU:
 				this.queueEvent(new Runnable() {
 					@Override
 					public void run() {
-						Cocos2dxGLSurfaceView.this.mCocos2dxRenderer.handleKeyDown(pKeyCode);
+				Cocos2dxGLSurfaceView.this.mCocos2dxRenderer
+						.handleKeyDown(pKeyCode);
 					}
 				});
 				return true;
-			default:
-				return super.onKeyDown(pKeyCode, pKeyEvent);
-		}
 	}
 
 	// ===========================================================

--- a/cocos2dx/platform/android/jni/TouchesJni.cpp
+++ b/cocos2dx/platform/android/jni/TouchesJni.cpp
@@ -83,6 +83,8 @@ extern "C" {
                     return JNI_TRUE;
                 break;
             default:
+				if (pDirector->getKeypadDispatcher()->dispatchKeypadDown(keyCode))
+					return JNI_TRUE;
                 return JNI_FALSE;
         }
         return JNI_FALSE;


### PR DESCRIPTION
Added forwarding of all keypad events (to handle DPAD, A,B,X,Y etc. keys in cocos2d-x)
See here for details:
http://discuss.cocos2d-x.org/t/ouya-support/3544/27

Tested with FireTV. Solution is for Android only.
