### PR TITLE
fix a bug where LabelTTF::setFontFillColor() won't work as expected

### DIFF
--- a/cocos/platform/ios/CCDevice.mm
+++ b/cocos/platform/ios/CCDevice.mm
@@ -456,13 +456,13 @@ Data Device::getTextureDataForText(const char * text, const FontDefinition& text
         info.shadowBlur             = textDefinition._shadow._shadowBlur;
         info.shadowOpacity          = textDefinition._shadow._shadowOpacity;
         info.hasStroke              = textDefinition._stroke._strokeEnabled;
-        info.strokeColorR           = textDefinition._stroke._strokeColor.r;
-        info.strokeColorG           = textDefinition._stroke._strokeColor.g;
-        info.strokeColorB           = textDefinition._stroke._strokeColor.b;
+        info.strokeColorR           = textDefinition._stroke._strokeColor.r / 255.0f;
+        info.strokeColorG           = textDefinition._stroke._strokeColor.g / 255.0f;
+        info.strokeColorB           = textDefinition._stroke._strokeColor.b / 255.0f;
         info.strokeSize             = textDefinition._stroke._strokeSize;
-        info.tintColorR             = textDefinition._fontFillColor.r;
-        info.tintColorG             = textDefinition._fontFillColor.g;
-        info.tintColorB             = textDefinition._fontFillColor.b;
+        info.tintColorR             = textDefinition._fontFillColor.r / 255.0f;
+        info.tintColorG             = textDefinition._fontFillColor.g / 255.0f;
+        info.tintColorB             = textDefinition._fontFillColor.b / 255.0f;
         
         if (! _initWithString(text, align, textDefinition._fontName.c_str(), textDefinition._fontSize, &info))
         {


### PR DESCRIPTION
In CCDevice.mm, Device::getTextureDataForText() function, info.strokeColorX and info.tintColorX are float type (0-1), which are assigned the value of GLubyte (0-255). The values need to be converted.
LabelTTF::setFontFillColor() will work properly once the fixes are made.
