### PR TITLE
remove Clear Stencil

### DIFF
--- a/cocos2dx/misc_nodes/CCClippingNode.cpp
+++ b/cocos2dx/misc_nodes/CCClippingNode.cpp
@@ -228,7 +228,7 @@ void CCClippingNode::visit()
     // this means that operation like glClear or glStencilOp will be masked with this value
     glStencilMask(mask_layer);
     
-	glClear(GL_STENCIL_BUFFER_BIT);
+    //glClear(GL_STENCIL_BUFFER_BIT);
     // manually save the depth test state
     //GLboolean currentDepthTestEnabled = GL_TRUE;
     GLboolean currentDepthWriteMask = GL_TRUE;


### PR DESCRIPTION
remove Clear Stencil to avoid double clear of ClippingNode(clear will discard buffer masks on some android device)
