### PR TITLE
stopAllActionsByTag && removeAllActionsByTag

### DIFF
--- a/cocos/2d/CCActionManager.cpp
+++ b/cocos/2d/CCActionManager.cpp
@@ -286,6 +286,34 @@ void ActionManager::removeActionByTag(int tag, Node *target)
     }
 }
 
+void ActionManager::removeAllActionsByTag(int tag, Node *target)
+{
+    CCASSERT(tag != Action::INVALID_TAG, "");
+    CCASSERT(target != nullptr, "");
+    
+    tHashElement *element = nullptr;
+    HASH_FIND_PTR(_targets, &target, element);
+    
+    if (element)
+    {
+        auto limit = element->actions->num;
+        for (int i = 0; i < limit;)
+        {
+            Action *action = (Action*)element->actions->arr[i];
+            
+            if (action->getTag() == (int)tag && action->getOriginalTarget() == target)
+            {
+                removeActionAtIndex(i, element);
+                --limit;
+            }
+            else
+            {
+                ++i;
+            }
+        }
+    }
+}
+
 // get
 
 // XXX: Passing "const O *" instead of "const O&" because HASH_FIND_IT requries the address of a pointer

--- a/cocos/2d/CCActionManager.h
+++ b/cocos/2d/CCActionManager.h
@@ -90,6 +90,9 @@ public:
 
     /** Removes an action given its tag and the target */
     void removeActionByTag(int tag, Node *target);
+    
+    /** Removes all actions given its tag and the target */
+    void removeAllActionsByTag(int tag, Node *target);
 
     /** Gets an action given its tag an a target
      @return the Action the with the given tag

--- a/cocos/2d/CCNode.cpp
+++ b/cocos/2d/CCNode.cpp
@@ -1432,6 +1432,12 @@ void Node::stopActionByTag(int tag)
     _actionManager->removeActionByTag(tag, this);
 }
 
+void Node::stopAllActionsByTag(int tag)
+{
+    CCASSERT( tag != Action::INVALID_TAG, "Invalid tag");
+    _actionManager->removeAllActionsByTag(tag, this);
+}
+
 Action * Node::getActionByTag(int tag)
 {
     CCASSERT( tag != Action::INVALID_TAG, "Invalid tag");

--- a/cocos/2d/CCNode.h
+++ b/cocos/2d/CCNode.h
@@ -1130,6 +1130,13 @@ public:
      * @param tag   A tag that indicates the action to be removed.
      */
     void stopActionByTag(int tag);
+    
+    /**
+     * Removes all actions from the running action list by its tag.
+     *
+     * @param tag   A tag that indicates the action to be removed.
+     */
+    void stopAllActionsByTag(int tag);
 
     /**
      * Gets an action from the running action list by its tag.

--- a/tests/cpp-tests/Classes/ActionManagerTest/ActionManagerTest.cpp
+++ b/tests/cpp-tests/Classes/ActionManagerTest/ActionManagerTest.cpp
@@ -15,7 +15,7 @@ Layer* restartActionManagerAction();
 
 static int sceneIdx = -1; 
 
-#define MAX_LAYER    5
+#define MAX_LAYER    6
 
 Layer* createActionManagerLayer(int nIndex)
 {
@@ -25,7 +25,8 @@ Layer* createActionManagerLayer(int nIndex)
         case 1: return new LogicTest();
         case 2: return new PauseTest();
         case 3: return new StopActionTest();
-        case 4: return new ResumeTest();
+        case 4: return new StopAllActionsTest();
+        case 5: return new ResumeTest();
     }
 
     return nullptr;
@@ -266,6 +267,56 @@ std::string StopActionTest::subtitle() const
 {
     return "Stop Action Test";
 }
+
+//------------------------------------------------------------------
+//
+// RemoveTest
+//
+//------------------------------------------------------------------
+void StopAllActionsTest::onEnter()
+{
+    ActionManagerTest::onEnter();
+    
+    auto l = Label::createWithTTF("Should stop scale & move after 4 seconds but keep rotate", "fonts/Thonburi.ttf", 16.0f);
+    addChild(l);
+    l->setPosition( Vec2(VisibleRect::center().x, VisibleRect::top().y - 75) );
+    
+    auto pMove1 = MoveBy::create(2, Vec2(200, 0));
+    auto pMove2 = MoveBy::create(2, Vec2(-200, 0));
+    auto pSequenceMove = Sequence::createWithTwoActions(pMove1, pMove2);
+    auto pRepeatMove = RepeatForever::create(pSequenceMove);
+    pRepeatMove->setTag(kTagSequence);
+    
+    auto pScale1 = ScaleBy::create(2, 1.5);
+    auto pScale2 = ScaleBy::create(2, 1.0/1.5);
+    auto pSequenceScale = Sequence::createWithTwoActions(pScale1, pScale2);
+    auto pRepeatScale = RepeatForever::create(pSequenceScale);
+    pRepeatScale->setTag(kTagSequence);
+    
+    auto pRotate = RotateBy::create(2, 360);
+    auto pRepeatRotate = RepeatForever::create(pRotate);
+    
+    auto pChild = Sprite::create(s_pathGrossini);
+    pChild->setPosition( VisibleRect::center() );
+    
+    addChild(pChild, 1, kTagGrossini);
+    pChild->runAction(pRepeatMove);
+    pChild->runAction(pRepeatScale);
+    pChild->runAction(pRepeatRotate);
+    this->scheduleOnce((SEL_SCHEDULE)&StopAllActionsTest::stopAction, 4);
+}
+
+void StopAllActionsTest::stopAction(float time)
+{
+    auto sprite = getChildByTag(kTagGrossini);
+    sprite->stopAllActionsByTag(kTagSequence);
+}
+
+std::string StopAllActionsTest::subtitle() const
+{
+    return "Stop All Action Test";
+}
+
 
 //------------------------------------------------------------------
 //

--- a/tests/cpp-tests/Classes/ActionManagerTest/ActionManagerTest.h
+++ b/tests/cpp-tests/Classes/ActionManagerTest/ActionManagerTest.h
@@ -54,6 +54,14 @@ public:
     void stopAction();
 };
 
+class StopAllActionsTest : public ActionManagerTest
+{
+public:
+    virtual std::string subtitle() const override;
+    virtual void onEnter() override;
+    void stopAction(float time);
+};
+
 class ResumeTest : public ActionManagerTest
 {
 public:


### PR DESCRIPTION
It is not possible to remove all actions by tugs 
this pull request add this 2 methods and give ability to make it faster.
