### PR TITLE
FIX: make sure TableView parents are visible before handling touch

### DIFF
--- a/extensions/GUI/CCScrollView/CCTableView.cpp
+++ b/extensions/GUI/CCScrollView/CCTableView.cpp
@@ -591,9 +591,12 @@ void TableView::onTouchEnded(Touch *pTouch, Event *pEvent)
 
 bool TableView::onTouchBegan(Touch *pTouch, Event *pEvent)
 {
-    if (!this->isVisible())
+    for (Node *c = this; c != nullptr; c = c->getParent())
     {
-        return false;
+        if (!c->isVisible())
+        {
+            return false;
+        }
     }
 
     bool touchResult = ScrollView::onTouchBegan(pTouch, pEvent);


### PR DESCRIPTION
Context:

After having issues with a `TableView` instance receiving touches even though the parent is not visible, I found some code in the `Menu` class that checks if parent is visible before handling touches, so I ported that code to the `TableView` class.
