### PR TITLE
解决RichText中文换行乱码问题和android下中文断行问题

### DIFF
--- a/extensions/Android.mk
+++ b/extensions/Android.mk
@@ -103,7 +103,7 @@ CocoStudio/ActionTimeline/CCActionTimeline.cpp \
 CocoStudio/ActionTimeline/CCActionTimelineCache.cpp \
 CocoStudio/ActionTimeline/CCFrame.cpp \
 CocoStudio/ActionTimeline/CCNodeReader.cpp \
-CocoStudio/ActionTimeline/CCTimeline.cpp \
+CocoStudio/ActionTimeline/CCTimeLine.cpp \
 CocoStudio/Reader/SceneReader.cpp \
 CocoStudio/Reader/GUIReader.cpp \
 CocoStudio/Reader/WidgetReader/WidgetReader.cpp \

--- a/extensions/CocoStudio/GUI/UIWidgets/UIRichText.cpp
+++ b/extensions/CocoStudio/GUI/UIWidgets/UIRichText.cpp
@@ -281,8 +281,16 @@ void RichText::handleTextRenderer(const char *text, const char *fontName, float 
     {
         float overstepPercent = (-_leftSpaceWidth) / textRendererWidth;
         std::string curText = text;
-        int stringLength = _calcCharCount(text);;
+        int stringLength = curText.length(); //_calcCharCount(text);;
         int leftLength = stringLength * (1.0f - overstepPercent);
+
+        while(leftLength < stringLength){
+            if(0x80 != (0xC0 & curText[leftLength])){
+                break;
+            }
+            leftLength++;
+        }
+
         std::string leftWords = curText.substr(0, leftLength);
         std::string cutWords = curText.substr(leftLength, curText.length()-1);
         if (leftLength > 0)


### PR DESCRIPTION
RichText 在换行时候遇到中文时错把中文截断了变成乱码，同时在UTF-8编码下字符长度计算前后冲突，导致Android和Linux下输出中文时候换行错误
