### PR TITLE
fix RichText visit issue

### DIFF
--- a/cocos/ui/UIRichText.cpp
+++ b/cocos/ui/UIRichText.cpp
@@ -461,6 +461,11 @@ void RichText::formarRenderers()
     _elementRenderersContainer->setPosition(_contentSize.width / 2.0f, _contentSize.height / 2.0f);
 }
     
+void RichText::adaptRenderers()
+{
+    this->formatText();
+}
+    
 void RichText::pushToContainer(cocos2d::Node *renderer)
 {
     if (_elementRenders.size() <= 0)
@@ -468,15 +473,6 @@ void RichText::pushToContainer(cocos2d::Node *renderer)
         return;
     }
     _elementRenders[_elementRenders.size()-1]->pushBack(renderer);
-}
-
-void RichText::visit(cocos2d::Renderer *renderer, const Mat4 &parentTransform, uint32_t parentFlags)
-{
-    if (_enabled)
-    {
-        formatText();
-        Widget::visit(renderer, parentTransform, parentFlags);
-    }
 }
     
 void RichText::setVerticalSpace(float space)

--- a/cocos/ui/UIRichText.h
+++ b/cocos/ui/UIRichText.h
@@ -103,7 +103,7 @@ public:
     void pushBackElement(RichElement* element);
     void removeElement(int index);
     void removeElement(RichElement* element);
-    virtual void visit(cocos2d::Renderer *renderer, const Mat4 &parentTransform, uint32_t parentFlags) override;
+
     void setVerticalSpace(float space);
     virtual void setAnchorPoint(const Vec2 &pt);
     virtual const Size& getVirtualRendererSize() const override;
@@ -115,6 +115,8 @@ CC_CONSTRUCTOR_ACCESS:
     virtual bool init() override;
     
 protected:
+    virtual void adaptRenderers();
+
     virtual void initRenderer();
     void pushToContainer(Node* renderer);
     void handleTextRenderer(const std::string& text, const std::string& fontName, float fontSize, const Color3B& color, GLubyte opacity);


### PR DESCRIPTION
In our UI framework, we use `_visible` property to determine whether to draw the control or not.
The `enable` property is used for handling touch event. So I removed the wrongly visit method.

Another change is the removal of visit method in RichText, We should reuse the mechanism of the Widget class. All the other controls also did it the same way.
