### PR TITLE
Allow setting bundle to use in file utils

### DIFF
--- a/cocos/platform/apple/CCFileUtilsApple.h
+++ b/cocos/platform/apple/CCFileUtilsApple.h
@@ -2,19 +2,19 @@
  Copyright (c) 2010-2012 cocos2d-x.org
  Copyright (c) 2011      Zynga Inc.
  Copyright (c) 2013-2014 Chukong Technologies Inc.
- 
+
  http://www.cocos2d-x.org
- 
+
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal
  in the Software without restriction, including without limitation the rights
  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  copies of the Software, and to permit persons to whom the Software is
  furnished to do so, subject to the following conditions:
- 
+
  The above copyright notice and this permission notice shall be included in
  all copies or substantial portions of the Software.
- 
+
  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -43,16 +43,20 @@ NS_CC_BEGIN
 class CC_DLL FileUtilsApple : public FileUtils
 {
 public:
+    FileUtilsApple();
     /* override funtions */
     virtual std::string getWritablePath() const override;
     virtual std::string getFullPathForDirectoryAndFilename(const std::string& directory, const std::string& filename) override;
-    
+
     virtual ValueMap getValueMapFromFile(const std::string& filename) override;
     virtual bool writeToFile(ValueMap& dict, const std::string& fullPath) override;
-    
+
     virtual ValueVector getValueVectorFromFile(const std::string& filename) override;
+    void setBundle(NSBundle* bundle);
 private:
     virtual bool isFileExistInternal(const std::string& filePath) const override;
+    NSBundle* getBundle() const;
+    NSBundle* _bundle;
 };
 
 // end of platform group

--- a/cocos/platform/apple/CCFileUtilsApple.mm
+++ b/cocos/platform/apple/CCFileUtilsApple.mm
@@ -49,7 +49,7 @@ static void addItemToArray(id item, ValueVector& array)
         array.push_back(Value([item UTF8String]));
         return;
     }
-    
+
     // add number value into array(such as int, float, bool and so on)
     // the value is a number
     if ([item isKindOfClass:[NSNumber class]])
@@ -74,7 +74,7 @@ static void addItemToArray(id item, ValueVector& array)
         return;
     }
 
-    
+
     // add dictionary value into array
     if ([item isKindOfClass:[NSDictionary class]])
     {
@@ -84,11 +84,11 @@ static void addItemToArray(id item, ValueVector& array)
             id subValue = [item objectForKey:subKey];
             addValueToDict(subKey, subValue, dict);
         }
-        
+
         array.push_back(Value(dict));
         return;
     }
-    
+
     // add array value into array
     if ([item isKindOfClass:[NSArray class]])
     {
@@ -111,48 +111,48 @@ static void addObjectToNSArray(const Value& value, NSMutableArray *array)
         [array addObject:element];
         return;
     }
-    
+
     //add float  into array
     if (value.getType() == Value::Type::FLOAT) {
         NSNumber *number = [NSNumber numberWithFloat:value.asFloat()];
         [array addObject:number];
     }
-    
+
     //add double into array
     if (value.getType() == Value::Type::DOUBLE) {
         NSNumber *number = [NSNumber numberWithDouble:value.asDouble()];
         [array addObject:number];
     }
-    
+
     //add boolean into array
     if (value.getType() == Value::Type::BOOLEAN) {
         NSNumber *element = [NSNumber numberWithBool:value.asBool()];
         [array addObject:element];
     }
-    
+
     if (value.getType() == Value::Type::INTEGER) {
         NSNumber *element = [NSNumber numberWithInt:value.asInt()];
         [array addObject:element];
     }
-    
+
     //todo: add date and data support
-    
+
     // add array into array
     if (value.getType() == Value::Type::VECTOR)
     {
         NSMutableArray *element = [NSMutableArray array];
-        
+
         ValueVector valueArray = value.asValueVector();
-        
+
         for (const auto &e : valueArray)
         {
             addObjectToNSArray(e, element);
         }
-        
+
         [array addObject:element];
         return;
     }
-    
+
     // add dictionary value into array
     if (value.getType() == Value::Type::MAP)
     {
@@ -163,7 +163,7 @@ static void addObjectToNSArray(const Value& value, NSMutableArray *array)
         {
             addObjectToNSDict(iter->first, iter->second, element);
         }
-        
+
         [array addObject:element];
     }
 }
@@ -173,14 +173,14 @@ static void addValueToDict(id nsKey, id nsValue, ValueMap& dict)
     // the key must be a string
     CCASSERT([nsKey isKindOfClass:[NSString class]], "The key should be a string!");
     std::string key = [nsKey UTF8String];
-    
+
     // the value is a string
     if ([nsValue isKindOfClass:[NSString class]])
     {
         dict[key] = Value([nsValue UTF8String]);
         return;
     }
-    
+
     // the value is a number
     if ([nsValue isKindOfClass:[NSNumber class]])
     {
@@ -204,12 +204,12 @@ static void addValueToDict(id nsKey, id nsValue, ValueMap& dict)
         return;
     }
 
-    
+
     // the value is a new dictionary
     if ([nsValue isKindOfClass:[NSDictionary class]])
     {
         ValueMap subDict;
-        
+
         for (id subKey in [nsValue allKeys])
         {
             id subValue = [nsValue objectForKey:subKey];
@@ -218,7 +218,7 @@ static void addValueToDict(id nsKey, id nsValue, ValueMap& dict)
         dict[key] = Value(subDict);
         return;
     }
-    
+
     // the value is a array
     if ([nsValue isKindOfClass:[NSArray class]])
     {
@@ -231,13 +231,13 @@ static void addValueToDict(id nsKey, id nsValue, ValueMap& dict)
         dict[key] = Value(valueArray);
         return;
     }
-    
+
 }
 
 static void addObjectToNSDict(const std::string& key, const Value& value, NSMutableDictionary *dict)
 {
     NSString *NSkey = [NSString stringWithCString:key.c_str() encoding:NSUTF8StringEncoding];
-    
+
     // the object is a Dictionary
     if (value.getType() == Value::Type::MAP)
     {
@@ -247,35 +247,35 @@ static void addObjectToNSDict(const std::string& key, const Value& value, NSMuta
         {
             addObjectToNSDict(iter->first, iter->second, dictElement);
         }
-        
+
         [dict setObject:dictElement forKey:NSkey];
         return;
     }
-    
+
     //add float  into dict
     if (value.getType() == Value::Type::FLOAT) {
         NSNumber *number = [NSNumber numberWithFloat:value.asFloat()];
         [dict setObject:number forKey:NSkey];
     }
-    
+
     //add double into dict
     if (value.getType() == Value::Type::DOUBLE) {
         NSNumber *number = [NSNumber numberWithDouble:value.asDouble()];
         [dict setObject:number forKey:NSkey];
     }
-    
+
     //add boolean into dict
     if (value.getType() == Value::Type::BOOLEAN) {
         NSNumber *element = [NSNumber numberWithBool:value.asBool()];
         [dict setObject:element forKey:NSkey];
     }
-    
+
     //add integer into dict
     if (value.getType() == Value::Type::INTEGER) {
         NSNumber *element = [NSNumber numberWithInt:value.asInt()];
         [dict setObject:element forKey:NSkey];
     }
-    
+
     // the object is a String
     if (value.getType() == Value::Type::STRING)
     {
@@ -283,14 +283,14 @@ static void addObjectToNSDict(const std::string& key, const Value& value, NSMuta
         [dict setObject:strElement forKey:NSkey];
         return;
     }
-    
+
     // the object is a Array
     if (value.getType() == Value::Type::VECTOR)
     {
         NSMutableArray *arrElement = [NSMutableArray array];
-        
+
         ValueVector array = value.asValueVector();
-        
+
         for(const auto& v : array)
         {
             addObjectToNSArray(v, arrElement);
@@ -299,6 +299,19 @@ static void addObjectToNSDict(const std::string& key, const Value& value, NSMuta
         [dict setObject:arrElement forKey:NSkey];
         return;
     }
+}
+
+FileUtilsApple::FileUtilsApple() {
+    _bundle = [NSBundle mainBundle];
+}
+
+
+void FileUtilsApple::setBundle(NSBundle* bundle) {
+    _bundle = bundle;
+}
+
+NSBundle* FileUtilsApple::getBundle() const {
+    return _bundle;
 }
 
 
@@ -340,7 +353,7 @@ bool FileUtilsApple::isFileExistInternal(const std::string& filePath) const
     }
 
     bool ret = false;
-    
+
     if (filePath[0] != '/')
     {
         std::string path;
@@ -355,8 +368,8 @@ bool FileUtilsApple::isFileExistInternal(const std::string& filePath) const
         {
             file = filePath;
         }
-        
-        NSString* fullpath = [[NSBundle mainBundle] pathForResource:[NSString stringWithUTF8String:file.c_str()]
+
+        NSString* fullpath = [getBundle() pathForResource:[NSString stringWithUTF8String:file.c_str()]
                                                              ofType:nil
                                                         inDirectory:[NSString stringWithUTF8String:path.c_str()]];
         if (fullpath != nil) {
@@ -370,7 +383,7 @@ bool FileUtilsApple::isFileExistInternal(const std::string& filePath) const
             ret = true;
         }
     }
-    
+
     return ret;
 }
 
@@ -378,7 +391,7 @@ std::string FileUtilsApple::getFullPathForDirectoryAndFilename(const std::string
 {
     if (directory[0] != '/')
     {
-        NSString* fullpath = [[NSBundle mainBundle] pathForResource:[NSString stringWithUTF8String:filename.c_str()]
+        NSString* fullpath = [getBundle() pathForResource:[NSString stringWithUTF8String:filename.c_str()]
                                                              ofType:nil
                                                         inDirectory:[NSString stringWithUTF8String:directory.c_str()]];
         if (fullpath != nil) {
@@ -401,9 +414,9 @@ ValueMap FileUtilsApple::getValueMapFromFile(const std::string& filename)
     std::string fullPath = fullPathForFilename(filename);
     NSString* path = [NSString stringWithUTF8String:fullPath.c_str()];
     NSDictionary* dict = [NSDictionary dictionaryWithContentsOfFile:path];
-    
+
     ValueMap ret;
-    
+
     if (dict != nil)
     {
         for (id key in [dict allKeys])
@@ -419,16 +432,16 @@ bool FileUtilsApple::writeToFile(ValueMap& dict, const std::string &fullPath)
 {
     //CCLOG("iOS||Mac Dictionary %d write to file %s", dict->_ID, fullPath.c_str());
     NSMutableDictionary *nsDict = [NSMutableDictionary dictionary];
-    
+
     for (auto iter = dict.begin(); iter != dict.end(); ++iter)
     {
         addObjectToNSDict(iter->first, iter->second, nsDict);
     }
-    
+
     NSString *file = [NSString stringWithUTF8String:fullPath.c_str()];
     // do it atomically
     [nsDict writeToFile:file atomically:YES];
-    
+
     return true;
 }
 
@@ -442,14 +455,14 @@ ValueVector FileUtilsApple::getValueVectorFromFile(const std::string& filename)
     std::string fullPath = fullPathForFilename(filename);
     NSString* path = [NSString stringWithUTF8String:fullPath.c_str()];
     NSArray* array = [NSArray arrayWithContentsOfFile:path];
-    
+
     ValueVector ret;
-    
+
     for (id value in array)
     {
         addItemToArray(value, ret);
     }
-    
+
     return ret;
 }
 


### PR DESCRIPTION
Our cocos app has an apparently uncommon use case where we need to be able to download non-essential assets for our app.  The best solution (for ios) I've been able to come up with is to download a bundle and load it for the cocos environment, but it doesn't currently support using any bundle other than the main one from what I've seen. 

This PR adds the ability to do just that, allowing the client code to call something like this to set it:

```
((cocos2d::FileUtilsApple*)(cocos2d::FileUtils::getInstance()))->setBundle(bundle);
```

As it is something specific to apple, I added the change to the FileUtilsApple, which forces you to cast the FileUtils to the subclass for apple. I'm not a big fan of this, so I'd welcome ideas to avoid having to do it.

This is an uncommon use case, but I've seen other people trying to do the same thing online, so I thought it'd be interesting to get it on the main repository. Let me know if there is any changes/improvements needed to get this  merged.
