### PR TITLE
Add getter and setter for TextColor to Text Widget

### DIFF
--- a/cocos/ui/UIText.cpp
+++ b/cocos/ui/UIText.cpp
@@ -208,7 +208,7 @@ TextVAlignment Text::getTextVerticalAlignment()const
     return _labelRenderer->getVerticalAlignment();
 }
     
-void Text::setTextColor(Color4B color)
+void Text::setTextColor(const Color4B color)
 {
     _labelRenderer->setTextColor(color);
 }

--- a/cocos/ui/UIText.cpp
+++ b/cocos/ui/UIText.cpp
@@ -213,7 +213,7 @@ void Text::setTextColor(Color4B color)
     _labelRenderer->setTextColor(color);
 }
     
-const Color4B& Text::getTextColor()const
+const Color4B& Text::getTextColor() const
 {
     return _labelRenderer->getTextColor();
 }

--- a/cocos/ui/UIText.cpp
+++ b/cocos/ui/UIText.cpp
@@ -211,8 +211,6 @@ TextVAlignment Text::getTextVerticalAlignment()const
 void Text::setTextColor(Color4B color)
 {
     _labelRenderer->setTextColor(color);
-    updateContentSizeWithTextureSize(_labelRenderer->getContentSize());
-    _labelRendererAdaptDirty = true;
 }
     
 const Color4B& Text::getTextColor()const

--- a/cocos/ui/UIText.cpp
+++ b/cocos/ui/UIText.cpp
@@ -207,6 +207,18 @@ TextVAlignment Text::getTextVerticalAlignment()const
 {
     return _labelRenderer->getVerticalAlignment();
 }
+    
+void Text::setTextColor(Color4B color)
+{
+    _labelRenderer->setTextColor(color);
+    updateContentSizeWithTextureSize(_labelRenderer->getContentSize());
+    _labelRendererAdaptDirty = true;
+}
+    
+const Color4B& Text::getTextColor()const
+{
+    return _labelRenderer->getTextColor();
+}
 
 void Text::setTouchScaleChangeEnabled(bool enable)
 {

--- a/cocos/ui/UIText.h
+++ b/cocos/ui/UIText.h
@@ -161,6 +161,10 @@ public:
 
     TextVAlignment getTextVerticalAlignment()const;
     
+    void setTextColor(Color4B color);
+    
+    const Color4B& getTextColor()const;
+    
     /**
      * Enable shadow for the label
      *

--- a/cocos/ui/UIText.h
+++ b/cocos/ui/UIText.h
@@ -161,9 +161,9 @@ public:
 
     TextVAlignment getTextVerticalAlignment()const;
     
-    void setTextColor(Color4B color);
+    void setTextColor(const Color4B color);
     
-    const Color4B& getTextColor()const;
+    const Color4B& getTextColor() const;
     
     /**
      * Enable shadow for the label


### PR DESCRIPTION
Add a function to set text color property for label inside Text widgets.
The "Color Tint" option in CocoStudio sets the color for the entire widget (setColor method); setting text color this way will cause outline colors for Text widget to be incorrect.
