### PR TITLE
Simplify Widget ContentSize cascade change algorithm

### DIFF
--- a/cocos/ui/UIWidget.cpp
+++ b/cocos/ui/UIWidget.cpp
@@ -319,7 +319,6 @@ void Widget::setSizePercent(const Vec2 &percent)
         this->setContentSize(cSize);
     }
     _customSize = cSize;
-    onSizeChanged();
 }
 
 void Widget::updateSizeAndPosition()
@@ -373,7 +372,8 @@ void Widget::updateSizeAndPosition(const cocos2d::Size &parentSize)
         default:
             break;
     }
-    onSizeChanged();
+    
+    //update position & position percent
     Vec2 absPos = getPosition();
     switch (_positionType)
     {
@@ -426,7 +426,6 @@ void Widget::ignoreContentAdaptWithSize(bool ignore)
     {
         this->setContentSize(_customSize);
     }
-    onSizeChanged();
 }
 
 bool Widget::isIgnoreContentAdaptWithSize() const
@@ -486,7 +485,6 @@ void Widget::updateContentSizeWithTextureSize(const cocos2d::Size &size)
     {
         this->setContentSize(_customSize);
     }
-    onSizeChanged();
 }
 
 void Widget::setTouchEnabled(bool enable)
@@ -1036,7 +1034,6 @@ void Widget::copyProperties(Widget *widget)
     {
         setLayoutParameter(iter->second->clone());
     }
-    onSizeChanged();
 }
     
 void Widget::setFlippedX(bool flippedX)

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/CocosGUIScene.cpp
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/CocosGUIScene.cpp
@@ -87,7 +87,7 @@ g_guisTests[] =
             UISceneManager* sceneManager = UISceneManager::sharedUISceneManager();
             sceneManager->setCurrentUISceneId(kUIImageViewTest);
             sceneManager->setMinUISceneId(kUIImageViewTest);
-            sceneManager->setMaxUISceneId(kUIImageViewTest_Scale9);
+            sceneManager->setMaxUISceneId(kUIImageViewTest_ContentSize);
             Scene* scene = sceneManager->currentUIScene();
             Director::getInstance()->replaceScene(scene);
         }

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIImageViewTest/UIImageViewTest.cpp
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIImageViewTest/UIImageViewTest.cpp
@@ -61,3 +61,71 @@ bool UIImageViewTest_Scale9::init()
     }
     return false;
 }
+
+// UIImageViewTest_ContentSize
+
+bool UIImageViewTest_ContentSize::init()
+{
+    if (UIScene::init())
+    {
+        Size widgetSize = _widget->getContentSize();
+        
+        Text* alert = Text::create("ImageView ContentSize Change", "fonts/Marker Felt.ttf", 26);
+        alert->setColor(Color3B(159, 168, 176));
+        alert->setPosition(Vec2(widgetSize.width / 2.0f,
+                                widgetSize.height / 2.0f - alert->getContentSize().height * 2.125f));
+        
+        _uiLayer->addChild(alert);
+        
+        Text *status = Text::create("child ImageView position percent", "fonts/Marker Felt.ttf", 16);
+        status->setColor(Color3B::RED);
+        status->setPosition(Vec2(widgetSize.width/2, widgetSize.height/2 + 80));
+        _uiLayer->addChild(status,20);
+        
+        // Create the imageview
+        ImageView* imageView = ImageView::create("cocosui/buttonHighlighted.png");
+        imageView->setScale9Enabled(true);
+        imageView->setContentSize(Size(200, 80));
+        imageView->setPosition(Vec2(widgetSize.width / 2.0f,
+                                    widgetSize.height / 2.0f ));
+       
+        
+        ImageView* imageViewChild = ImageView::create("cocosui/buttonHighlighted.png");
+        imageViewChild->setScale9Enabled(true);
+        imageViewChild->setSizeType(Widget::SizeType::PERCENT);
+        imageViewChild->setPositionType(Widget::PositionType::PERCENT);
+        imageViewChild->setSizePercent(Vec2::ANCHOR_MIDDLE);
+        imageViewChild->setPositionPercent(Vec2::ANCHOR_MIDDLE);
+        imageViewChild->setPosition(Vec2(widgetSize.width / 2.0f,
+                                    widgetSize.height / 2.0f));
+        
+        ImageView* imageViewChild2 = ImageView::create("cocosui/buttonHighlighted.png");
+        imageViewChild2->setScale9Enabled(true);
+        imageViewChild2->setSizeType(Widget::SizeType::PERCENT);
+        imageViewChild2->setPositionType(Widget::PositionType::PERCENT);
+        imageViewChild2->setSizePercent(Vec2::ANCHOR_MIDDLE);
+        imageViewChild2->setPositionPercent(Vec2::ANCHOR_MIDDLE);
+        imageViewChild->addChild(imageViewChild2);
+        
+        
+        imageView->addChild(imageViewChild);
+        
+        imageView->setTouchEnabled(true);
+        imageView->addTouchEventListener([=](Ref* sender, Widget::TouchEventType type){
+            if (type == Widget::TouchEventType::ENDED) {
+                float width = CCRANDOM_0_1() * 200 + 50;
+                float height = CCRANDOM_0_1() * 80 + 30;
+                imageView->setContentSize(Size(width, height));
+                
+                imageViewChild->setPositionPercent(Vec2(CCRANDOM_0_1(), CCRANDOM_0_1()));
+                status->setString(StringUtils::format("child ImageView position percent: %f, %f",
+                                                      imageViewChild->getPositionPercent().x, imageViewChild->getPositionPercent().y));
+            }
+        });
+        
+        _uiLayer->addChild(imageView);
+        
+        return true;
+    }
+    return false;
+}

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIImageViewTest/UIImageViewTest.h
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIImageViewTest/UIImageViewTest.h
@@ -45,4 +45,13 @@ protected:
     UI_SCENE_CREATE_FUNC(UIImageViewTest_Scale9)
 };
 
+class UIImageViewTest_ContentSize : public UIScene
+{
+public:
+    bool init();
+    
+protected:
+    UI_SCENE_CREATE_FUNC(UIImageViewTest_ContentSize)
+};
+
 #endif /* defined(__TestCpp__UIImageViewTest__) */

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UISceneManager.cpp
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UISceneManager.cpp
@@ -58,6 +58,7 @@ static const char* s_testArray[] =
      */
     "UIImageViewTest",
     "UIImageViewTest_Scale9",
+    "UIImageViewTest_ContentSize",
     "UILoadingBarTest_Left",
     "UILoadingBarTest_Right",
     "UILoadingBarTest_Left_Scale9",
@@ -205,7 +206,8 @@ Scene *UISceneManager::currentUIScene()
             
         case kUIImageViewTest_Scale9:
             return UIImageViewTest_Scale9::sceneWithTitle(s_testArray[_currentUISceneId]);
-            
+        case kUIImageViewTest_ContentSize:
+            return UIImageViewTest_ContentSize::sceneWithTitle(s_testArray[_currentUISceneId]);
         case kUILoadingBarTest_Left:
             return UILoadingBarTest_Left::sceneWithTitle(s_testArray[_currentUISceneId]);
             

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UISceneManager.h
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UISceneManager.h
@@ -48,6 +48,7 @@ enum
      */
     kUIImageViewTest,
     kUIImageViewTest_Scale9,
+    kUIImageViewTest_ContentSize,
     kUILoadingBarTest_Left,
     kUILoadingBarTest_Right,
     kUILoadingBarTest_Left_Scale9,


### PR DESCRIPTION
This PR removed all the redundant calling of  `onSizeChanged` method,
Since we have already called it at the end of `setContentSize` method in Widget class.
And also I added some tests to verify this refactor code.
