### PR TITLE
Improve Widget setEnabled method

### DIFF
--- a/cocos/ui/UIText.cpp
+++ b/cocos/ui/UIText.cpp
@@ -211,8 +211,6 @@ TextVAlignment Text::getTextVerticalAlignment()const
 void Text::setTextColor(Color4B color)
 {
     _labelRenderer->setTextColor(color);
-    updateContentSizeWithTextureSize(_labelRenderer->getContentSize());
-    _labelRendererAdaptDirty = true;
 }
     
 const Color4B& Text::getTextColor()const

--- a/cocos/ui/UIText.cpp
+++ b/cocos/ui/UIText.cpp
@@ -207,6 +207,18 @@ TextVAlignment Text::getTextVerticalAlignment()const
 {
     return _labelRenderer->getVerticalAlignment();
 }
+    
+void Text::setTextColor(Color4B color)
+{
+    _labelRenderer->setTextColor(color);
+    updateContentSizeWithTextureSize(_labelRenderer->getContentSize());
+    _labelRendererAdaptDirty = true;
+}
+    
+const Color4B& Text::getTextColor()const
+{
+    return _labelRenderer->getTextColor();
+}
 
 void Text::setTouchScaleChangeEnabled(bool enable)
 {

--- a/cocos/ui/UIText.h
+++ b/cocos/ui/UIText.h
@@ -161,6 +161,10 @@ public:
 
     TextVAlignment getTextVerticalAlignment()const;
     
+    void setTextColor(Color4B color);
+    
+    const Color4B& getTextColor()const;
+    
     /**
      * Enable shadow for the label
      *

--- a/cocos/ui/UIWidget.cpp
+++ b/cocos/ui/UIWidget.cpp
@@ -246,6 +246,11 @@ Widget* Widget::getWidgetParent()
 void Widget::setEnabled(bool enabled)
 {
     _enabled = enabled;
+    if (_enabled) {
+        onPressStateChangedToNormal();
+    } else {
+        onPressStateChangedToDisabled();
+    }
 }
     
 void Widget::initRenderer()


### PR DESCRIPTION
UIButton class has onPressStateChanged methods that would never actually be called.
Fixed the setEnabled function in the UI Widget base so that these methods are called.  
No other Widget classes override setEnabled so this shouldn't introduce any other issues.
