### PR TITLE
Add code to change press state of widgets

### DIFF
--- a/cocos/ui/UIWidget.cpp
+++ b/cocos/ui/UIWidget.cpp
@@ -246,6 +246,11 @@ Widget* Widget::getWidgetParent()
 void Widget::setEnabled(bool enabled)
 {
     _enabled = enabled;
+    if (_enabled){
+        onPressStateChangedToNormal();
+    } else {
+        onPressStateChangedToDisabled();
+    }
 }
     
 void Widget::initRenderer()


### PR DESCRIPTION
UIButton class has onPressStateChanged methods that would never actually be called.
Fixed the setEnabled function in the UI Widget base so that these methods are called.
No other Widget classes override setEnabled so this shouldn't introduce any other issues.
