### PR TITLE
Fix android VideoPlayer size calculation when keepRatio == true.

### DIFF
--- a/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxVideoView.java
+++ b/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxVideoView.java
@@ -331,15 +331,11 @@ public class Cocos2dxVideoView extends SurfaceView implements MediaPlayerControl
     public void fixSize(int left,int top,int width,int height) {
     	if (width != 0 && height != 0) {
     		if (mKeepRatio) {
-    			if ( mVideoWidth * height  > width * mVideoHeight ) {
-    				mVisibleWidth = width;
-    				mVisibleHeight = width * mVideoHeight / mVideoWidth;
-                } else if ( mVideoWidth * height  < width * mVideoHeight ) {
-                	mVisibleWidth = height * mVideoWidth / mVideoHeight;
-                	mVisibleHeight = height;
-                }
-    			mVisibleLeft = left + (width - mVisibleWidth) / 2;
-    			mVisibleTop = top + (height - mVisibleHeight) / 2;
+    		    float sizeFixRatio = (mViewWidth > mViewHeight) ? (mViewHeight / mVideoHeight) : (mViewWidth / mVideoWidth);
+    		    mVisibleWidth = (int)(mVideoWidth * sizeFixRatio);
+    		    mVisibleHeight = (int)(mVideoHeight * sizeFixRatio);
+    		    mVisibleLeft = (Math.max(mViewWidth, mVisibleWidth) - Math.min(mViewWidth, mVisibleWidth)) / 2;
+    		    mVisibleTop = (Math.max(mViewHeight, mVisibleHeight) - Math.min(mViewHeight, mVisibleHeight)) / 2;
 			} else {
 				mVisibleLeft = left;
 	    		mVisibleTop = top;


### PR DESCRIPTION
Cocos2dxVideoView has problem when `videoPlayer->setKeepAspectRatioEnabled(true);`
# reproduce step
## modify code
1. Please Go `UIVideoPlayerTest.cpp` -> `VideoPlayerTest::createVideo()`
2. modify code same as ↓this.

This code want to show video that fit screen.

``` cpp
void VideoPlayerTest::createVideo()
{
    auto centerPos = Vec2(_visibleRect.origin.x + _visibleRect.size.width / 2,_visibleRect.origin.y + _visibleRect.size.height /2);

    auto widgetSize = _widget->getContentSize();

    _videoPlayer = VideoPlayer::create();
    _videoPlayer->setPosition(centerPos);
    _videoPlayer->setAnchorPoint(Vec2::ANCHOR_MIDDLE);
    // I modify this line.
    _videoPlayer->setContentSize(Director::getInstance()->getVisibleSize());
    _videoPlayer->setKeepAspectRatioEnabled(true);

    _uiLayer->addChild(_videoPlayer);

    _videoPlayer->addEventListener(CC_CALLBACK_2(VideoPlayerTest::videoEventCallback, this));
}
 _videoPlayer->addEventListener(CC_CALLBACK_2(VideoPlayerTest::videoEventCallback, this));
```
## run android cpp-tests
1. Run `cpp-tests`.
2. Go to `Node::UI -> GUI Dynamic Create Test -> VideoPlayerTest`
3. Tap `Play resource video` label
4. problem reproduce
5. Tap `KeepRationSwitch`
6. Another problem reproduce
