### PR TITLE
add utf8 support for TextField widget

### DIFF
--- a/cocos/ui/UIHelper.cpp
+++ b/cocos/ui/UIHelper.cpp
@@ -108,6 +108,43 @@ Widget* Helper::seekActionWidgetByActionTag(Widget* root, int tag)
 	}
 	return nullptr;
 }
+    
+std::string Helper::utf8_substr(const std::string& str, unsigned long start, unsigned long length)
+{
+    if (length==0)
+    {
+        return "";
+    }
+    unsigned long c, i, ix, q, min=std::string::npos, max=std::string::npos;
+    for (q=0, i=0, ix=str.length(); i < ix; i++, q++)
+    {
+        if (q==start)
+        {
+            min = i;
+        }
+        if (q <= start+length || length==std::string::npos)
+        {
+            max = i;
+        }
+        
+        c = (unsigned char) str[i];
+        
+        if      (c<=127) i+=0;
+        else if ((c & 0xE0) == 0xC0) i+=1;
+        else if ((c & 0xF0) == 0xE0) i+=2;
+        else if ((c & 0xF8) == 0xF0) i+=3;
+        else return "";//invalid utf8
+    }
+    if (q <= start+length || length == std::string::npos)
+    {
+        max = i;
+    }
+    if (min==std::string::npos || max==std::string::npos)
+    {
+        return "";
+    }
+    return str.substr(min,max);
+}
 
 }
 

--- a/cocos/ui/UIHelper.cpp
+++ b/cocos/ui/UIHelper.cpp
@@ -109,7 +109,7 @@ Widget* Helper::seekActionWidgetByActionTag(Widget* root, int tag)
 	return nullptr;
 }
     
-std::string Helper::utf8_substr(const std::string& str, std::string::size_type start, std::string::size_type length)
+std::string Helper::getSubStringOfUTF8String(const std::string& str, std::string::size_type start, std::string::size_type length)
 {
     if (length==0)
     {

--- a/cocos/ui/UIHelper.cpp
+++ b/cocos/ui/UIHelper.cpp
@@ -109,13 +109,13 @@ Widget* Helper::seekActionWidgetByActionTag(Widget* root, int tag)
 	return nullptr;
 }
     
-std::string Helper::utf8_substr(const std::string& str, unsigned long start, unsigned long length)
+std::string Helper::utf8_substr(const std::string& str, std::string::size_type start, std::string::size_type length)
 {
     if (length==0)
     {
         return "";
     }
-    unsigned long c, i, ix, q, min=std::string::npos, max=std::string::npos;
+    std::string::size_type c, i, ix, q, min=std::string::npos, max=std::string::npos;
     for (q=0, i=0, ix=str.length(); i < ix; i++, q++)
     {
         if (q==start)

--- a/cocos/ui/UIHelper.h
+++ b/cocos/ui/UIHelper.h
@@ -66,6 +66,18 @@ public:
     
     /*temp action*/
     static Widget* seekActionWidgetByActionTag(Widget* root, int tag);
+    
+    /**
+     * @brief Get a utf8 substring from a std::string with a given start position and length
+     *  Sample:  std::string str = "中国中国中国”;  substr = utf8_substr(str,0,2) will = "中国"
+     * @param start The start position of the substring.
+     * @param length The length of the substring in utf8 count
+     * @return a utf8 substring
+     */
+    static std::string utf8_substr(const std::string& str,
+                                   unsigned long start,
+                                   unsigned long length);
+
 };
 }
 

--- a/cocos/ui/UIHelper.h
+++ b/cocos/ui/UIHelper.h
@@ -68,13 +68,13 @@ public:
     static Widget* seekActionWidgetByActionTag(Widget* root, int tag);
     
     /**
-     * @brief Get a utf8 substring from a std::string with a given start position and length
-     *  Sample:  std::string str = "中国中国中国”;  substr = utf8_substr(str,0,2) will = "中国"
+     * @brief Get a UTF8 substring from a std::string with a given start position and length
+     *  Sample:  std::string str = "中国中国中国”;  substr = getSubStringOfUTF8String(str,0,2) will = "中国"
      * @param start The start position of the substring.
-     * @param length The length of the substring in utf8 count
-     * @return a utf8 substring
+     * @param length The length of the substring in UTF8 count
+     * @return a UTF8 substring
      */
-    static std::string utf8_substr(const std::string& str,
+    static std::string getSubStringOfUTF8String(const std::string& str,
                                    std::string::size_type start,
                                    std::string::size_type length);
 

--- a/cocos/ui/UIHelper.h
+++ b/cocos/ui/UIHelper.h
@@ -75,8 +75,8 @@ public:
      * @return a utf8 substring
      */
     static std::string utf8_substr(const std::string& str,
-                                   unsigned long start,
-                                   unsigned long length);
+                                   std::string::size_type start,
+                                   std::string::size_type length);
 
 };
 }

--- a/cocos/ui/UIRichText.cpp
+++ b/cocos/ui/UIRichText.cpp
@@ -27,47 +27,12 @@
 #include "2d/CCLabel.h"
 #include "2d/CCSprite.h"
 #include "base/ccUTF8.h"
+#include "ui/UIHelper.h"
 
 NS_CC_BEGIN
 
 namespace ui {
-    
-static std::string utf8_substr(const std::string& str, unsigned long start, unsigned long leng)
-{
-    if (leng==0)
-    {
-        return "";
-    }
-    unsigned long c, i, ix, q, min=std::string::npos, max=std::string::npos;
-    for (q=0, i=0, ix=str.length(); i < ix; i++, q++)
-    {
-        if (q==start)
-        {
-            min = i;
-        }
-        if (q <= start+leng || leng==std::string::npos)
-        {
-            max = i;
-        }
-        
-        c = (unsigned char) str[i];
-        
-        if      (c<=127) i+=0;
-        else if ((c & 0xE0) == 0xC0) i+=1;
-        else if ((c & 0xF0) == 0xE0) i+=2;
-        else if ((c & 0xF8) == 0xF0) i+=3;
-        else return "";//invalid utf8
-    }
-    if (q <= start+leng || leng == std::string::npos)
-    {
-        max = i;
-    }
-    if (min==std::string::npos || max==std::string::npos)
-    {
-        return "";
-    }
-    return str.substr(min,max);
-}
+
     
 bool RichElement::init(int tag, const Color3B &color, GLubyte opacity)
 {
@@ -318,18 +283,18 @@ void RichText::handleTextRenderer(const std::string& text, const std::string& fo
         std::string curText = text;
         size_t stringLength = StringUtils::getCharacterCountInUTF8String(text);
         int leftLength = stringLength * (1.0f - overstepPercent);
-        std::string leftWords = utf8_substr(curText,0,leftLength);
-        std::string cutWords = utf8_substr(curText, leftLength, stringLength - leftLength);
+        std::string leftWords = Helper::utf8_substr(curText,0,leftLength);
+        std::string cutWords = Helper::utf8_substr(curText, leftLength, stringLength - leftLength);
         if (leftLength > 0)
         {
             Label* leftRenderer = nullptr;
             if (fileExist)
             {
-                leftRenderer = Label::createWithTTF(utf8_substr(leftWords, 0, leftLength), fontName, fontSize);
+                leftRenderer = Label::createWithTTF(Helper::utf8_substr(leftWords, 0, leftLength), fontName, fontSize);
             }
             else
             {
-                leftRenderer = Label::createWithSystemFont(utf8_substr(leftWords, 0, leftLength), fontName, fontSize);
+                leftRenderer = Label::createWithSystemFont(Helper::utf8_substr(leftWords, 0, leftLength), fontName, fontSize);
             }
             if (leftRenderer)
             {

--- a/cocos/ui/UIRichText.cpp
+++ b/cocos/ui/UIRichText.cpp
@@ -283,18 +283,18 @@ void RichText::handleTextRenderer(const std::string& text, const std::string& fo
         std::string curText = text;
         size_t stringLength = StringUtils::getCharacterCountInUTF8String(text);
         int leftLength = stringLength * (1.0f - overstepPercent);
-        std::string leftWords = Helper::utf8_substr(curText,0,leftLength);
-        std::string cutWords = Helper::utf8_substr(curText, leftLength, stringLength - leftLength);
+        std::string leftWords = Helper::getSubStringOfUTF8String(curText,0,leftLength);
+        std::string cutWords = Helper::getSubStringOfUTF8String(curText, leftLength, stringLength - leftLength);
         if (leftLength > 0)
         {
             Label* leftRenderer = nullptr;
             if (fileExist)
             {
-                leftRenderer = Label::createWithTTF(Helper::utf8_substr(leftWords, 0, leftLength), fontName, fontSize);
+                leftRenderer = Label::createWithTTF(Helper::getSubStringOfUTF8String(leftWords, 0, leftLength), fontName, fontSize);
             }
             else
             {
-                leftRenderer = Label::createWithSystemFont(Helper::utf8_substr(leftWords, 0, leftLength), fontName, fontSize);
+                leftRenderer = Label::createWithSystemFont(Helper::getSubStringOfUTF8String(leftWords, 0, leftLength), fontName, fontSize);
             }
             if (leftRenderer)
             {

--- a/cocos/ui/UITextField.cpp
+++ b/cocos/ui/UITextField.cpp
@@ -133,7 +133,7 @@ void UICCTextField::insertText(const char*  text, size_t len)
             {
                 long length = _maxLength - text_count;
                 
-                input_text = Helper::utf8_substr(input_text, 0, length);
+                input_text = Helper::getSubStringOfUTF8String(input_text, 0, length);
                 len  = input_text.length();
             }
         }
@@ -415,7 +415,7 @@ void TextField::setText(const std::string& text)
         long total = text_count + StringUtils::getCharacterCountInUTF8String(getStringValue());
         if (total > max)
         {
-            strText = Helper::utf8_substr(strText, 0, max);
+            strText = Helper::getSubStringOfUTF8String(strText, 0, max);
         }
     }
     

--- a/cocos/ui/UITextField.cpp
+++ b/cocos/ui/UITextField.cpp
@@ -24,27 +24,12 @@ THE SOFTWARE.
 
 #include "ui/UITextField.h"
 #include "platform/CCFileUtils.h"
+#include "ui/UIHelper.h"
+#include "base/ccUTF8.h"
 
 NS_CC_BEGIN
 
 namespace ui {
-    
-static int _calcCharCount(const char * pszText)
-{
-    int n = 0;
-    char ch = 0;
-    while ((ch = *pszText))
-    {
-        CC_BREAK_IF(! ch);
-        
-        if (0x80 != (0xC0 & ch))
-        {
-            ++n;
-        }
-        ++pszText;
-    }
-    return n;
-}
 
 UICCTextField::UICCTextField()
 : _maxLengthEnabled(false)
@@ -130,7 +115,7 @@ void UICCTextField::insertText(const char*  text, size_t len)
     {
         if (_maxLengthEnabled)
         {
-            int text_count = _calcCharCount(getString().c_str());
+            long text_count = StringUtils::getCharacterCountInUTF8String(getString());
             if (text_count >= _maxLength)
             {
                 // password
@@ -141,69 +126,16 @@ void UICCTextField::insertText(const char*  text, size_t len)
                 return;
             }
             
-#if ((CC_TARGET_PLATFORM == CC_PLATFORM_IOS) || (CC_TARGET_PLATFORM == CC_PLATFORM_MAC) || (CC_TARGET_PLATFORM == CC_PLATFORM_WIN32))
-            int input_count = _calcCharCount(text);
-            int total = total = text_count + input_count;
+            long input_count = StringUtils::getCharacterCountInUTF8String(text);
+            long total = text_count + input_count;
             
             if (total > _maxLength)
             {
-                int end = 0;
-                int length = _maxLength - text_count;
+                long length = _maxLength - text_count;
                 
-                for (int i = 0; i < length; ++i)
-                {
-                    char value = text[i];
-                    
-                    if (value >= 0 && value <= 127) // ascii
-                    {
-                        end++;
-                    }
-                    else
-                    {
-                        end += 3;
-                    }
-                }
-                input_text = input_text.substr(0, end);
-                len  = end;
+                input_text = Helper::utf8_substr(input_text, 0, length);
+                len  = input_text.length();
             }
-#elif (CC_TARGET_PLATFORM == CC_PLATFORM_ANDROID)
-            int input_count = _calcCharCount(text);
-            int total = text_count + input_count;
-            if (total > _maxLength)
-            {
-                int ascii = 0;
-                int unicode = 0;
-                int end = 0;
-                int count = 0;
-                
-                for (int i = 0; i < total * 3; ++i)
-                {
-                    char value = text[i];
-                    
-                    if (value >= 0 && value <= 127) // ascii
-                    {
-                        ascii++;
-                        count++;
-                    }
-                    else
-                    {
-                        unicode++;
-                        if (unicode % 3 == 0)
-                        {
-                            count++;
-                        }
-                    }
-                    
-                    if (count == _maxLength)
-                    {
-                        break;
-                    }
-                }
-                end = ascii + unicode;
-                input_text = input_text.substr(0, end);
-                len  = end;
-            }
-#endif
         }
     }
     TextFieldTTF::insertText(input_text.c_str(), len);
@@ -294,8 +226,8 @@ void UICCTextField::setPasswordStyleText(const std::string& styleText)
 void UICCTextField::setPasswordText(const std::string& text)
 {
     std::string tempStr = "";
-    int text_count = _calcCharCount(text.c_str());
-    int max = text_count;
+    long text_count = StringUtils::getCharacterCountInUTF8String(text);
+    long max = text_count;
     
     if (_maxLengthEnabled)
     {
@@ -479,40 +411,11 @@ void TextField::setText(const std::string& text)
     if (isMaxLengthEnabled())
     {
         int max = _textFieldRenderer->getMaxLength();
-        int text_count = _calcCharCount(text.c_str());
-        int total = text_count + _calcCharCount(getStringValue().c_str());
+        long text_count = StringUtils::getCharacterCountInUTF8String(text);
+        long total = text_count + StringUtils::getCharacterCountInUTF8String(getStringValue());
         if (total > max)
         {
-            int ascii = 0;
-            int unicode = 0;
-            int end = 0;
-            int count = 0;
-            
-            for (int i = 0; i < total * 3; ++i)
-            {
-                char value = text[i];
-                
-                if (value >= 0 && value <= 127) // ascii
-                {
-                    ascii++;
-                    count++;
-                }
-                else
-                {
-                    unicode++;
-                    if (unicode % 3 == 0)
-                    {
-                        count++;
-                    }
-                }
-                
-                if (count == max)
-                {
-                    break;
-                }
-            }
-            end = ascii + unicode;
-            strText = strText.substr(0, end);
+            strText = Helper::utf8_substr(strText, 0, max);
         }
     }
     

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIRichTextTest/UIRichTextTest.cpp
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIRichTextTest/UIRichTextTest.cpp
@@ -20,6 +20,19 @@ bool UIRichTextTest::init()
     {
         Size widgetSize = _widget->getContentSize();
         
+        std::string str1 = "中国中国中";
+        std::string str2 = "ご静聴ありがとうございました！！ご静聴ありがとうございました！！";
+        CCLOG("str1:%s ascii length = %ld, utf8 length = %ld, substr = %s",
+              str1.c_str(),
+              str1.length(),
+              StringUtils::getCharacterCountInUTF8String(str1),
+              Helper::utf8_substr(str1, 0, 5).c_str());
+        CCLOG("str2:%s ascii length = %ld, utf8 length = %ld, substr = %s",
+              str2.c_str(),
+              str2.length(),
+              StringUtils::getCharacterCountInUTF8String(str2),
+              Helper::utf8_substr(str2, 0, 2).c_str());
+        
         // Add the alert
         Text *alert = Text::create("RichText", "fonts/Marker Felt.ttf", 30);
         alert->setColor(Color3B(159, 168, 176));
@@ -31,7 +44,6 @@ bool UIRichTextTest::init()
         button->setTouchEnabled(true);
         button->setTitleText("switch");
         button->setPosition(Vec2(widgetSize.width / 2.0f, widgetSize.height / 2.0f + button->getContentSize().height * 2.5));
-//        button->addTouchEventListener(this, toucheventselector(UIRichTextTest::touchEvent));
         button->addTouchEventListener(CC_CALLBACK_2(UIRichTextTest::touchEvent, this));
         button->setLocalZOrder(10);
         _widget->addChild(button);
@@ -45,7 +57,7 @@ bool UIRichTextTest::init()
         RichElementText* re1 = RichElementText::create(1, Color3B::WHITE, 255, "中国中国中国中国中国中国中国中国中国中国", "Marker Felt", 10);
         RichElementText* re2 = RichElementText::create(2, Color3B::YELLOW, 255, "And this is yellow. ", "Helvetica", 10);
         RichElementText* re3 = RichElementText::create(3, Color3B::GRAY, 255, "ご静聴ありがとうございました！！ご静聴ありがとうございました！！", "Helvetica", 10);
-        RichElementText* re4 = RichElementText::create(4, Color3B::GREEN, 255, "And green. ", "Helvetica", 10);
+        RichElementText* re4 = RichElementText::create(4, Color3B::GREEN, 255, "And green with TTF support. ", "fonts/Marker Felt.ttf", 10);
         RichElementText* re5 = RichElementText::create(5, Color3B::RED, 255, "Last one is red ", "Helvetica", 10);
         
         RichElementImage* reimg = RichElementImage::create(6, Color3B::WHITE, 255, "cocosui/sliderballnormal.png");

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIRichTextTest/UIRichTextTest.cpp
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIRichTextTest/UIRichTextTest.cpp
@@ -26,12 +26,12 @@ bool UIRichTextTest::init()
               str1.c_str(),
               str1.length(),
               StringUtils::getCharacterCountInUTF8String(str1),
-              Helper::utf8_substr(str1, 0, 5).c_str());
+              Helper::getSubStringOfUTF8String(str1, 0, 5).c_str());
         CCLOG("str2:%s ascii length = %ld, utf8 length = %ld, substr = %s",
               str2.c_str(),
               str2.length(),
               StringUtils::getCharacterCountInUTF8String(str2),
-              Helper::utf8_substr(str2, 0, 2).c_str());
+              Helper::getSubStringOfUTF8String(str2, 0, 2).c_str());
         
         // Add the alert
         Text *alert = Text::create("RichText", "fonts/Marker Felt.ttf", 30);

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UITextFieldTest/UITextFieldTest.cpp
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UITextFieldTest/UITextFieldTest.cpp
@@ -32,7 +32,7 @@ bool UITextFieldTest::init()
         _uiLayer->addChild(alert);
         
         // Create the textfield
-        TextField* textField = TextField::create("input words here","fonts/Marker Felt.ttf",30);
+        TextField* textField = TextField::create("input words here","Arial",30);
 
         textField->setPosition(Vec2(widgetSize.width / 2.0f, widgetSize.height / 2.0f));
         textField->addEventListener(CC_CALLBACK_2(UITextFieldTest::textFieldEvent, this));
@@ -110,7 +110,7 @@ bool UITextFieldTest_MaxLength::init()
         _uiLayer->addChild(alert);
         
         // Create the textfield
-        TextField* textField = TextField::create("input words here","fonts/Marker Felt.ttf",30);
+        TextField* textField = TextField::create("input words here","Arial",30);
         textField->setMaxLengthEnabled(true);
         textField->setMaxLength(3);
         textField->setPosition(Vec2(screenSize.width / 2.0f, screenSize.height / 2.0f));
@@ -194,7 +194,7 @@ bool UITextFieldTest_Password::init()
         _uiLayer->addChild(alert);
         
         // Create the textfield
-        TextField* textField = TextField::create("input password here","fonts/Marker Felt.ttf",30);
+        TextField* textField = TextField::create("input password here","Arial",30);
         textField->setPasswordEnabled(true);
         textField->setPasswordStyleText("*");
         textField->setPosition(Vec2(screenSize.width / 2.0f, screenSize.height / 2.0f));
@@ -276,7 +276,8 @@ bool UITextFieldTest_LineWrap::init()
         TextField* textField = TextField::create("input words here","fonts/Marker Felt.ttf",30);
         textField->ignoreContentAdaptWithSize(false);
         ((Label*)(textField->getVirtualRenderer()))->setLineBreakWithoutSpace(true);
-        textField->setContentSize(Size(240, 70));
+        textField->setContentSize(Size(240, 170));
+        textField->setText("input words hereinput words hereinput words hereinput words hereinput words hereinput words here");
         textField->setTextHorizontalAlignment(TextHAlignment::CENTER);
         textField->setTextVerticalAlignment(TextVAlignment::CENTER);
         textField->setPosition(Vec2(widgetSize.width / 2.0f, widgetSize.height / 2.0f));
@@ -297,7 +298,7 @@ void UITextFieldTest_LineWrap::textFieldEvent(Ref *pSender, TextField::EventType
             TextField* textField = dynamic_cast<TextField*>(pSender);
             Size widgetSize = _widget->getContentSize();
             textField->runAction(CCMoveTo::create(0.225f,
-                                                  Vec2(widgetSize.width / 2.0f, widgetSize.height / 2.0f + textField->getContentSize().height / 2)));
+                                                  Vec2(widgetSize.width / 2.0f, widgetSize.height / 2.0f + 30)));
             textField->setTextHorizontalAlignment(TextHAlignment::LEFT);
             textField->setTextVerticalAlignment(TextVAlignment::TOP);
             

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UITextFieldTest/UITextFieldTest.cpp
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UITextFieldTest/UITextFieldTest.cpp
@@ -277,7 +277,7 @@ bool UITextFieldTest_LineWrap::init()
         textField->ignoreContentAdaptWithSize(false);
         ((Label*)(textField->getVirtualRenderer()))->setLineBreakWithoutSpace(true);
         textField->setContentSize(Size(240, 170));
-        textField->setText("input words hereinput words hereinput words hereinput words hereinput words hereinput words here");
+        textField->setText("input words here");
         textField->setTextHorizontalAlignment(TextHAlignment::CENTER);
         textField->setTextVerticalAlignment(TextVAlignment::CENTER);
         textField->setPosition(Vec2(widgetSize.width / 2.0f, widgetSize.height / 2.0f));


### PR DESCRIPTION
1. refactor utf8_substr method to ui::Helper class
2. add utf8 support for TextField
