### PR TITLE
Fix iOS VideoPlayer memory leak.

### DIFF
--- a/cocos/ui/UIVideoPlayerIOS.mm
+++ b/cocos/ui/UIVideoPlayerIOS.mm
@@ -133,11 +133,11 @@ using namespace cocos2d::experimental::ui;
     }
     
     if (videoSource == 1) {
-        self.moviePlayer = [[MPMoviePlayerController alloc] initWithContentURL:[NSURL URLWithString:@(videoUrl.c_str())]];
+        self.moviePlayer = [[[MPMoviePlayerController alloc] initWithContentURL:[NSURL URLWithString:@(videoUrl.c_str())]] autorelease];
         self.moviePlayer.movieSourceType = MPMovieSourceTypeStreaming;
     } else {
         NSString *path = [UIVideoViewWrapperIos fullPathFromRelativePath:@(videoUrl.c_str())];
-        self.moviePlayer = [[MPMoviePlayerController alloc] initWithContentURL:[NSURL fileURLWithPath:path]];
+        self.moviePlayer = [[[MPMoviePlayerController alloc] initWithContentURL:[NSURL fileURLWithPath:path]] autorelease];
         self.moviePlayer.movieSourceType = MPMovieSourceTypeFile;
     }
     self.moviePlayer.allowsAirPlay = false;


### PR DESCRIPTION
# Before
- `MPMoviePlayerController alloc] init~~` -> retain count equal 1.
- set to `strong` property  -> retain count to 2.
- set nullptr to `self.moviePlayer` -> retain count to 1.
- **Leak!**
# After
- `MPMoviePlayerController alloc] init~~` -> retain count equal 1.
- call `autorelease` -> retain count equal 0 when out of autoReleasePool.
- set to `strong` property  -> retain count to 1.
- set nullptr to `self.moviePlayer` -> retain count to 0.
- **MemFree**
