### PR TITLE
Add ui scale9 sprite

### DIFF
--- a/build/cocos2d_libs.xcodeproj/project.pbxproj
+++ b/build/cocos2d_libs.xcodeproj/project.pbxproj
@@ -4202,6 +4202,8 @@
 		29CB8F511929D64500C841D6 /* base */ = {
 			isa = PBXGroup;
 			children = (
+				2958244919873D8E00F9746D /* UIScale9Sprite.cpp */,
+				2958244A19873D8E00F9746D /* UIScale9Sprite.h */,
 				29080DEB191B82CE0066F8DF /* UIDeprecated.h */,
 				29BDBA52195D597A003225C9 /* UIDeprecated.cpp */,
 				2905FA1318CF08D100240AA3 /* UIWidget.cpp */,
@@ -4253,8 +4255,6 @@
 				2905F9F318CF08D000240AA3 /* UICheckBox.h */,
 				2905F9F618CF08D000240AA3 /* UIImageView.cpp */,
 				2905F9F718CF08D000240AA3 /* UIImageView.h */,
-				2958244919873D8E00F9746D /* UIScale9Sprite.cpp */,
-				2958244A19873D8E00F9746D /* UIScale9Sprite.h */,
 			);
 			name = widgets;
 			sourceTree = "<group>";

--- a/build/cocos2d_libs.xcodeproj/project.pbxproj
+++ b/build/cocos2d_libs.xcodeproj/project.pbxproj
@@ -553,6 +553,10 @@
 		1AD71EF5180E27CF00808F54 /* CCPhysicsSprite.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1AD71EEE180E27CF00808F54 /* CCPhysicsSprite.cpp */; };
 		1AD71EF6180E27CF00808F54 /* CCPhysicsSprite.h in Headers */ = {isa = PBXBuildFile; fileRef = 1AD71EEF180E27CF00808F54 /* CCPhysicsSprite.h */; };
 		1AD71EF7180E27CF00808F54 /* CCPhysicsSprite.h in Headers */ = {isa = PBXBuildFile; fileRef = 1AD71EEF180E27CF00808F54 /* CCPhysicsSprite.h */; };
+		2958244B19873D8E00F9746D /* UIScale9Sprite.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2958244919873D8E00F9746D /* UIScale9Sprite.cpp */; };
+		2958244C19873D8E00F9746D /* UIScale9Sprite.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2958244919873D8E00F9746D /* UIScale9Sprite.cpp */; };
+		2958244D19873D8E00F9746D /* UIScale9Sprite.h in Headers */ = {isa = PBXBuildFile; fileRef = 2958244A19873D8E00F9746D /* UIScale9Sprite.h */; };
+		2958244E19873D8E00F9746D /* UIScale9Sprite.h in Headers */ = {isa = PBXBuildFile; fileRef = 2958244A19873D8E00F9746D /* UIScale9Sprite.h */; };
 		2986667F18B1B246000E39CA /* CCTweenFunction.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2986667818B1B079000E39CA /* CCTweenFunction.cpp */; };
 		299754F4193EC95400A54AC3 /* ObjectFactory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 299754F2193EC95400A54AC3 /* ObjectFactory.cpp */; };
 		299754F5193EC95400A54AC3 /* ObjectFactory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 299754F2193EC95400A54AC3 /* ObjectFactory.cpp */; };
@@ -2329,6 +2333,8 @@
 		2905FA1318CF08D100240AA3 /* UIWidget.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = UIWidget.cpp; sourceTree = "<group>"; };
 		2905FA1418CF08D100240AA3 /* UIWidget.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = UIWidget.h; sourceTree = "<group>"; };
 		29080DEB191B82CE0066F8DF /* UIDeprecated.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = UIDeprecated.h; sourceTree = "<group>"; };
+		2958244919873D8E00F9746D /* UIScale9Sprite.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = UIScale9Sprite.cpp; sourceTree = "<group>"; };
+		2958244A19873D8E00F9746D /* UIScale9Sprite.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = UIScale9Sprite.h; sourceTree = "<group>"; };
 		2986667818B1B079000E39CA /* CCTweenFunction.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CCTweenFunction.cpp; sourceTree = "<group>"; };
 		2986667918B1B079000E39CA /* CCTweenFunction.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CCTweenFunction.h; sourceTree = "<group>"; };
 		299754F2193EC95400A54AC3 /* ObjectFactory.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ObjectFactory.cpp; path = ../base/ObjectFactory.cpp; sourceTree = "<group>"; };
@@ -4247,6 +4253,8 @@
 				2905F9F318CF08D000240AA3 /* UICheckBox.h */,
 				2905F9F618CF08D000240AA3 /* UIImageView.cpp */,
 				2905F9F718CF08D000240AA3 /* UIImageView.h */,
+				2958244919873D8E00F9746D /* UIScale9Sprite.cpp */,
+				2958244A19873D8E00F9746D /* UIScale9Sprite.h */,
 			);
 			name = widgets;
 			sourceTree = "<group>";
@@ -5853,6 +5861,7 @@
 				B2DB4767197664EE00411E16 /* CCProtectedNode.h in Headers */,
 				B2DB47861976662D00411E16 /* UILoadingBar.h in Headers */,
 				B2DB47681976650A00411E16 /* UIWidget.h in Headers */,
+				2958244D19873D8E00F9746D /* UIScale9Sprite.h in Headers */,
 				B2DB47691976651E00411E16 /* UIHBox.h in Headers */,
 				B2DB478F1976666100411E16 /* UIText.h in Headers */,
 				B2DB47901976666100411E16 /* UITextAtlas.h in Headers */,
@@ -5897,6 +5906,7 @@
 				B2C59A4719777ECF00B452DF /* UIHBox.h in Headers */,
 				B2C59A4819777ECF00B452DF /* UIRelativeBox.h in Headers */,
 				B2C59A4919777ECF00B452DF /* UIVBox.h in Headers */,
+				2958244E19873D8E00F9746D /* UIScale9Sprite.h in Headers */,
 				B2C59A4A19777ECF00B452DF /* UILayout.h in Headers */,
 				B2C59A4B19777ECF00B452DF /* UILayoutParameter.h in Headers */,
 				B2C59A4C19777ECF00B452DF /* UILayoutManager.h in Headers */,
@@ -7248,6 +7258,7 @@
 				B2DB47711976657A00411E16 /* UIVBox.cpp in Sources */,
 				B2DB47731976658E00411E16 /* CocosGUI.cpp in Sources */,
 				B2DB4775197665A500411E16 /* UIDeprecated.cpp in Sources */,
+				2958244B19873D8E00F9746D /* UIScale9Sprite.cpp in Sources */,
 				B2DB47891976664200411E16 /* UISlider.cpp in Sources */,
 				B2DB4779197665CD00411E16 /* UIListView.cpp in Sources */,
 				B2DB47851976662B00411E16 /* UILoadingBar.cpp in Sources */,
@@ -7268,6 +7279,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				B2C59A1C19777E7500B452DF /* UIListView.cpp in Sources */,
+				2958244C19873D8E00F9746D /* UIScale9Sprite.cpp in Sources */,
 				B2C59A1D19777E7500B452DF /* UILoadingBar.cpp in Sources */,
 				B2C59A1E19777E7500B452DF /* UIPageView.cpp in Sources */,
 				B2C59A1F19777E7500B452DF /* UIRichText.cpp in Sources */,

--- a/build/cocos2d_tests.xcodeproj/project.pbxproj
+++ b/build/cocos2d_tests.xcodeproj/project.pbxproj
@@ -112,8 +112,8 @@
 		15CBA9B8196EE8D9005877BB /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 15CBA54C196EE671005877BB /* main.m */; };
 		15CBA9B9196EE8D9005877BB /* RootViewController.mm in Sources */ = {isa = PBXBuildFile; fileRef = 15CBA54E196EE671005877BB /* RootViewController.mm */; };
 		15CBA9BB196EE910005877BB /* libchipmunk iOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 46A15FC21807A4F9005B8026 /* libchipmunk iOS.a */; };
-		15CBA9BD196EE910005877BB /* libcocos2dx-extensions iOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 46A15FC01807A4F9005B8026 /* libcocos2dx-extensions iOS.a */; };
-		15CBA9BE196EE910005877BB /* libCocosDenshion iOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 46A15FC61807A4F9005B8026 /* libCocosDenshion iOS.a */; };
+		15CBA9BD196EE910005877BB /* libextension iOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 46A15FC01807A4F9005B8026 /* libextension iOS.a */; };
+		15CBA9BE196EE910005877BB /* libcocosdenshion iOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 46A15FC61807A4F9005B8026 /* libcocosdenshion iOS.a */; };
 		15CBA9BF196EE910005877BB /* libluabindings iOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 1ABCA28018CD90A50087CE3A /* libluabindings iOS.a */; };
 		15CBA9CF196EE9FB005877BB /* AVFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 15CBA9C2196EE951005877BB /* AVFoundation.framework */; };
 		15CBA9D0196EEA05005877BB /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 15CBA9C4196EE962005877BB /* UIKit.framework */; };
@@ -126,7 +126,7 @@
 		15CBA9DB196EEA90005877BB /* CoreMotion.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 15CBA9DA196EEA90005877BB /* CoreMotion.framework */; };
 		15CBA9DD196EEAA6005877BB /* libz.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 15CBA9DC196EEAA6005877BB /* libz.dylib */; };
 		15CBA9DE196EEAF8005877BB /* GameController.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3E61773C1960FBD100DE83F5 /* GameController.framework */; };
-		15CBA9DF196EEBB3005877BB /* libcocos2dx iOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 46A15FBE1807A4F9005B8026 /* libcocos2dx iOS.a */; };
+		15CBA9DF196EEBB3005877BB /* libcocos2d iOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 46A15FBE1807A4F9005B8026 /* libcocos2d iOS.a */; };
 		15CBA9E0196EEBD4005877BB /* MediaPlayer.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3EA0FB65191B933000B170C8 /* MediaPlayer.framework */; };
 		15CBA9ED196F7BD8005877BB /* lua_cocos2dx_controller_auto.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 15CBA9EB196F7BD8005877BB /* lua_cocos2dx_controller_auto.cpp */; };
 		15CBA9F0196F7BEC005877BB /* lua_cocos2dx_controller_manual.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 15CBA9EE196F7BEC005877BB /* lua_cocos2dx_controller_manual.cpp */; };
@@ -135,8 +135,8 @@
 		15E66FC8192D957100C20A52 /* Sprite3DTest in Resources */ = {isa = PBXBuildFile; fileRef = 3E92EA841921A7720094CD21 /* Sprite3DTest */; };
 		15E66FD6192DC8C700C20A52 /* Sprite3DTest in Resources */ = {isa = PBXBuildFile; fileRef = 3E92EA841921A7720094CD21 /* Sprite3DTest */; };
 		1A0EE2A118CDF6DA004CD58F /* libchipmunk Mac.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 46A15FB41807A4F9005B8026 /* libchipmunk Mac.a */; };
-		1A0EE2A218CDF6DA004CD58F /* libcocos2dx Mac.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 46A15FB01807A4F9005B8026 /* libcocos2dx Mac.dylib */; };
-		1A0EE2A418CDF6DA004CD58F /* libCocosDenshion Mac.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 46A15FB81807A4F9005B8026 /* libCocosDenshion Mac.a */; };
+		1A0EE2A218CDF6DA004CD58F /* libcocos2d Mac.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 46A15FB01807A4F9005B8026 /* libcocos2d Mac.a */; };
+		1A0EE2A418CDF6DA004CD58F /* libcocosdenshion Mac.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 46A15FB81807A4F9005B8026 /* libcocosdenshion Mac.a */; };
 		1A0EE2A518CDF6DA004CD58F /* IOKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EDCC747E17C455FD007B692C /* IOKit.framework */; };
 		1A0EE2A618CDF6DA004CD58F /* libcurl.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 1A9F808C177E98A600D9A1CB /* libcurl.dylib */; };
 		1A0EE2A718CDF6DA004CD58F /* libz.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 15C6482E165F399D007D4F18 /* libz.dylib */; };
@@ -157,14 +157,14 @@
 		1A0EE2D018CDF733004CD58F /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1ABCA35618CD9A890087CE3A /* QuartzCore.framework */; };
 		1A0EE2D118CDF733004CD58F /* OpenGL.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1ABCA35418CD9A820087CE3A /* OpenGL.framework */; };
 		1A0EE2D218CDF733004CD58F /* libchipmunk Mac.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 46A15FB41807A4F9005B8026 /* libchipmunk Mac.a */; };
-		1A0EE2D318CDF733004CD58F /* libcocos2dx Mac.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 46A15FB01807A4F9005B8026 /* libcocos2dx Mac.dylib */; };
-		1A0EE2D418CDF733004CD58F /* libcocos2dx-extensions Mac.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 46A15FB21807A4F9005B8026 /* libcocos2dx-extensions Mac.a */; };
-		1A0EE2D518CDF733004CD58F /* libCocosDenshion Mac.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 46A15FB81807A4F9005B8026 /* libCocosDenshion Mac.a */; };
+		1A0EE2D318CDF733004CD58F /* libcocos2d Mac.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 46A15FB01807A4F9005B8026 /* libcocos2d Mac.a */; };
+		1A0EE2D418CDF733004CD58F /* libextension Mac.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 46A15FB21807A4F9005B8026 /* libextension Mac.a */; };
+		1A0EE2D518CDF733004CD58F /* libcocosdenshion Mac.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 46A15FB81807A4F9005B8026 /* libcocosdenshion Mac.a */; };
 		1A0EE2D618CDF733004CD58F /* libluabindings Mac.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 1ABCA27E18CD90A50087CE3A /* libluabindings Mac.a */; };
 		1A0EE2D718CDF733004CD58F /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 15C64822165F391E007D4F18 /* Cocoa.framework */; };
 		1A0EE40218CDF775004CD58F /* libchipmunk iOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 46A15FC21807A4F9005B8026 /* libchipmunk iOS.a */; };
-		1A0EE40318CDF775004CD58F /* libcocos2dx iOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 46A15FBE1807A4F9005B8026 /* libcocos2dx iOS.a */; };
-		1A0EE40518CDF775004CD58F /* libCocosDenshion iOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 46A15FC61807A4F9005B8026 /* libCocosDenshion iOS.a */; };
+		1A0EE40318CDF775004CD58F /* libcocos2d iOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 46A15FBE1807A4F9005B8026 /* libcocos2d iOS.a */; };
+		1A0EE40518CDF775004CD58F /* libcocosdenshion iOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 46A15FC61807A4F9005B8026 /* libcocosdenshion iOS.a */; };
 		1A0EE40618CDF775004CD58F /* CoreMotion.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D60AE43317F7FFE100757E4B /* CoreMotion.framework */; };
 		1A0EE40718CDF775004CD58F /* libz.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 15C6482E165F399D007D4F18 /* libz.dylib */; };
 		1A0EE40818CDF775004CD58F /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 15C64832165F3AFD007D4F18 /* Foundation.framework */; };
@@ -186,9 +186,9 @@
 		1A0EE43418CDF799004CD58F /* AVFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1ABCA39C18CD9ED80087CE3A /* AVFoundation.framework */; };
 		1A0EE43518CDF799004CD58F /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 15C64832165F3AFD007D4F18 /* Foundation.framework */; };
 		1A0EE43618CDF799004CD58F /* libchipmunk iOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 46A15FC21807A4F9005B8026 /* libchipmunk iOS.a */; };
-		1A0EE43718CDF799004CD58F /* libcocos2dx iOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 46A15FBE1807A4F9005B8026 /* libcocos2dx iOS.a */; };
-		1A0EE43818CDF799004CD58F /* libcocos2dx-extensions iOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 46A15FC01807A4F9005B8026 /* libcocos2dx-extensions iOS.a */; };
-		1A0EE43918CDF799004CD58F /* libCocosDenshion iOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 46A15FC61807A4F9005B8026 /* libCocosDenshion iOS.a */; };
+		1A0EE43718CDF799004CD58F /* libcocos2d iOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 46A15FBE1807A4F9005B8026 /* libcocos2d iOS.a */; };
+		1A0EE43818CDF799004CD58F /* libextension iOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 46A15FC01807A4F9005B8026 /* libextension iOS.a */; };
+		1A0EE43918CDF799004CD58F /* libcocosdenshion iOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 46A15FC61807A4F9005B8026 /* libcocosdenshion iOS.a */; };
 		1A0EE43A18CDF799004CD58F /* libluabindings iOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 1ABCA28018CD90A50087CE3A /* libluabindings iOS.a */; };
 		1A0EE55C18CDFBBD004CD58F /* AudioEngine.lua in Resources */ = {isa = PBXBuildFile; fileRef = 1ABCA36618CD9E180087CE3A /* AudioEngine.lua */; };
 		1A0EE55D18CDFBBD004CD58F /* CCBReaderLoad.lua in Resources */ = {isa = PBXBuildFile; fileRef = 1ABCA36718CD9E180087CE3A /* CCBReaderLoad.lua */; };
@@ -233,25 +233,25 @@
 		1A9F808D177E98A600D9A1CB /* libcurl.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 1A9F808C177E98A600D9A1CB /* libcurl.dylib */; };
 		1AAF534B180E2F4E000584C8 /* libbox2d Mac.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 46A15FB61807A4F9005B8026 /* libbox2d Mac.a */; };
 		1AAF534C180E2F4E000584C8 /* libchipmunk Mac.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 46A15FB41807A4F9005B8026 /* libchipmunk Mac.a */; };
-		1AAF534D180E2F4E000584C8 /* libcocos2dx Mac.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 46A15FB01807A4F9005B8026 /* libcocos2dx Mac.dylib */; };
-		1AAF534E180E2F4E000584C8 /* libcocos2dx-extensions Mac.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 46A15FB21807A4F9005B8026 /* libcocos2dx-extensions Mac.a */; };
-		1AAF534F180E2F4E000584C8 /* libCocosDenshion Mac.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 46A15FB81807A4F9005B8026 /* libCocosDenshion Mac.a */; };
+		1AAF534D180E2F4E000584C8 /* libcocos2d Mac.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 46A15FB01807A4F9005B8026 /* libcocos2d Mac.a */; };
+		1AAF534E180E2F4E000584C8 /* libextension Mac.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 46A15FB21807A4F9005B8026 /* libextension Mac.a */; };
+		1AAF534F180E2F4E000584C8 /* libcocosdenshion Mac.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 46A15FB81807A4F9005B8026 /* libcocosdenshion Mac.a */; };
 		1AAF53FE180E39D4000584C8 /* libbox2d iOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 46A15FC41807A4F9005B8026 /* libbox2d iOS.a */; };
 		1AAF53FF180E39D4000584C8 /* libchipmunk iOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 46A15FC21807A4F9005B8026 /* libchipmunk iOS.a */; };
-		1AAF5400180E39D4000584C8 /* libcocos2dx iOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 46A15FBE1807A4F9005B8026 /* libcocos2dx iOS.a */; };
-		1AAF5401180E39D4000584C8 /* libcocos2dx-extensions iOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 46A15FC01807A4F9005B8026 /* libcocos2dx-extensions iOS.a */; };
-		1AAF5402180E39D4000584C8 /* libCocosDenshion iOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 46A15FC61807A4F9005B8026 /* libCocosDenshion iOS.a */; };
+		1AAF5400180E39D4000584C8 /* libcocos2d iOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 46A15FBE1807A4F9005B8026 /* libcocos2d iOS.a */; };
+		1AAF5401180E39D4000584C8 /* libextension iOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 46A15FC01807A4F9005B8026 /* libextension iOS.a */; };
+		1AAF5402180E39D4000584C8 /* libcocosdenshion iOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 46A15FC61807A4F9005B8026 /* libcocosdenshion iOS.a */; };
 		1ABCA28718CD91510087CE3A /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 15C64822165F391E007D4F18 /* Cocoa.framework */; };
 		1ABCA2C218CD92420087CE3A /* libchipmunk Mac.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 46A15FB41807A4F9005B8026 /* libchipmunk Mac.a */; };
-		1ABCA2C318CD92420087CE3A /* libcocos2dx Mac.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 46A15FB01807A4F9005B8026 /* libcocos2dx Mac.dylib */; };
-		1ABCA2C418CD92420087CE3A /* libcocos2dx-extensions Mac.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 46A15FB21807A4F9005B8026 /* libcocos2dx-extensions Mac.a */; };
-		1ABCA2C518CD92420087CE3A /* libCocosDenshion Mac.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 46A15FB81807A4F9005B8026 /* libCocosDenshion Mac.a */; };
+		1ABCA2C318CD92420087CE3A /* libcocos2d Mac.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 46A15FB01807A4F9005B8026 /* libcocos2d Mac.a */; };
+		1ABCA2C418CD92420087CE3A /* libextension Mac.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 46A15FB21807A4F9005B8026 /* libextension Mac.a */; };
+		1ABCA2C518CD92420087CE3A /* libcocosdenshion Mac.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 46A15FB81807A4F9005B8026 /* libcocosdenshion Mac.a */; };
 		1ABCA2C618CD92420087CE3A /* libluabindings Mac.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 1ABCA27E18CD90A50087CE3A /* libluabindings Mac.a */; };
 		1ABCA2CE18CD93580087CE3A /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 15C64832165F3AFD007D4F18 /* Foundation.framework */; };
 		1ABCA30118CD93940087CE3A /* libchipmunk iOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 46A15FC21807A4F9005B8026 /* libchipmunk iOS.a */; };
-		1ABCA30218CD93940087CE3A /* libcocos2dx iOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 46A15FBE1807A4F9005B8026 /* libcocos2dx iOS.a */; };
-		1ABCA30318CD93940087CE3A /* libcocos2dx-extensions iOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 46A15FC01807A4F9005B8026 /* libcocos2dx-extensions iOS.a */; };
-		1ABCA30418CD93940087CE3A /* libCocosDenshion iOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 46A15FC61807A4F9005B8026 /* libCocosDenshion iOS.a */; };
+		1ABCA30218CD93940087CE3A /* libcocos2d iOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 46A15FBE1807A4F9005B8026 /* libcocos2d iOS.a */; };
+		1ABCA30318CD93940087CE3A /* libextension iOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 46A15FC01807A4F9005B8026 /* libextension iOS.a */; };
+		1ABCA30418CD93940087CE3A /* libcocosdenshion iOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 46A15FC61807A4F9005B8026 /* libcocosdenshion iOS.a */; };
 		1ABCA30518CD93940087CE3A /* libluabindings iOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 1ABCA28018CD90A50087CE3A /* libluabindings iOS.a */; };
 		1ABCA35518CD9A820087CE3A /* OpenGL.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1ABCA35418CD9A820087CE3A /* OpenGL.framework */; };
 		1ABCA35718CD9A890087CE3A /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1ABCA35618CD9A890087CE3A /* QuartzCore.framework */; };
@@ -853,6 +853,8 @@
 		29080DE6191B595E0066F8DF /* UIWidgetAddNodeTest_Editor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 29080D8B191B595E0066F8DF /* UIWidgetAddNodeTest_Editor.cpp */; };
 		290E94B5196FC16900694919 /* CocostudioParserTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 290E94B3196FC16900694919 /* CocostudioParserTest.cpp */; };
 		290E94B6196FC16900694919 /* CocostudioParserTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 290E94B3196FC16900694919 /* CocostudioParserTest.cpp */; };
+		295824591987415900F9746D /* UIScale9SpriteTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 295824571987415900F9746D /* UIScale9SpriteTest.cpp */; };
+		2958245A1987415900F9746D /* UIScale9SpriteTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 295824571987415900F9746D /* UIScale9SpriteTest.cpp */; };
 		29FBBBFE196A9ECD00E65826 /* CocostudioParserJsonTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 29FBBBFC196A9ECD00E65826 /* CocostudioParserJsonTest.cpp */; };
 		29FBBBFF196A9ECD00E65826 /* CocostudioParserJsonTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 29FBBBFC196A9ECD00E65826 /* CocostudioParserJsonTest.cpp */; };
 		38FA2E73194AEBE100FF2BE4 /* ActionTimelineTestScene.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 38FA2E71194AEBE100FF2BE4 /* ActionTimelineTestScene.cpp */; };
@@ -860,7 +862,7 @@
 		38FA2E76194AECF800FF2BE4 /* ActionTimeline in Resources */ = {isa = PBXBuildFile; fileRef = 38FA2E75194AECF800FF2BE4 /* ActionTimeline */; };
 		38FA2E77194AECF800FF2BE4 /* ActionTimeline in Resources */ = {isa = PBXBuildFile; fileRef = 38FA2E75194AECF800FF2BE4 /* ActionTimeline */; };
 		3E6177211960FAED00DE83F5 /* libchipmunk iOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 46A15FC21807A4F9005B8026 /* libchipmunk iOS.a */; };
-		3E6177221960FAED00DE83F5 /* libcocos2dx iOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 46A15FBE1807A4F9005B8026 /* libcocos2dx iOS.a */; };
+		3E6177221960FAED00DE83F5 /* libcocos2d iOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 46A15FBE1807A4F9005B8026 /* libcocos2d iOS.a */; };
 		3E6177241960FAED00DE83F5 /* CoreMotion.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D60AE43317F7FFE100757E4B /* CoreMotion.framework */; };
 		3E6177251960FAED00DE83F5 /* libz.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 15C6482E165F399D007D4F18 /* libz.dylib */; };
 		3E6177261960FAED00DE83F5 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 15C64832165F3AFD007D4F18 /* Foundation.framework */; };
@@ -914,47 +916,47 @@
 		A07A52BF1783AF210073F6A7 /* OpenGLES.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A07A52B91783AE900073F6A7 /* OpenGLES.framework */; };
 		A07A52C01783AF250073F6A7 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A07A52B71783AE6D0073F6A7 /* UIKit.framework */; };
 		A07A52C31783B02C0073F6A7 /* AVFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A07A52C11783B01F0073F6A7 /* AVFoundation.framework */; };
-		B24024DB1978DE1000FDE433 /* libcocos2dx Mac.dylib in CopyFiles */ = {isa = PBXBuildFile; fileRef = 46A15FB01807A4F9005B8026 /* libcocos2dx Mac.dylib */; };
-		B24024DD1978EC0700FDE433 /* libcocos2dx Mac.dylib in CopyFiles */ = {isa = PBXBuildFile; fileRef = 46A15FB01807A4F9005B8026 /* libcocos2dx Mac.dylib */; };
-		B24024E31978ED5200FDE433 /* libcocos2dx Mac.dylib in CopyFiles */ = {isa = PBXBuildFile; fileRef = 46A15FB01807A4F9005B8026 /* libcocos2dx Mac.dylib */; };
-		B24024E51978ED5F00FDE433 /* libcocos2dx Mac.dylib in CopyFiles */ = {isa = PBXBuildFile; fileRef = 46A15FB01807A4F9005B8026 /* libcocos2dx Mac.dylib */; };
-		B2411C9E19822FBD00E093E2 /* libcocosStudio iOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B2CC503B197763A20041958E /* libcocosStudio iOS.a */; };
-		B2411CA119822FDD00E093E2 /* libcocosBuilder iOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B2CC503D197763A20041958E /* libcocosBuilder iOS.a */; };
-		B2411CA419822FF100E093E2 /* libcocosSpine iOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B2CC503F197763A20041958E /* libcocosSpine iOS.a */; };
-		B2411CA71982301400E093E2 /* libcocosGUI iOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B2CC5039197763A20041958E /* libcocosGUI iOS.a */; };
-		B2411CAA1982302700E093E2 /* libcocosNetwork iOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B2CC5041197763A20041958E /* libcocosNetwork iOS.a */; };
-		B244F3171976878E00ED1926 /* libcocosNetwork Mac.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B244F3161976878700ED1926 /* libcocosNetwork Mac.a */; };
+		B24024DB1978DE1000FDE433 /* libcocos2d Mac.a in CopyFiles */ = {isa = PBXBuildFile; fileRef = 46A15FB01807A4F9005B8026 /* libcocos2d Mac.a */; };
+		B24024DD1978EC0700FDE433 /* libcocos2d Mac.a in CopyFiles */ = {isa = PBXBuildFile; fileRef = 46A15FB01807A4F9005B8026 /* libcocos2d Mac.a */; };
+		B24024E31978ED5200FDE433 /* libcocos2d Mac.a in CopyFiles */ = {isa = PBXBuildFile; fileRef = 46A15FB01807A4F9005B8026 /* libcocos2d Mac.a */; };
+		B24024E51978ED5F00FDE433 /* libcocos2d Mac.a in CopyFiles */ = {isa = PBXBuildFile; fileRef = 46A15FB01807A4F9005B8026 /* libcocos2d Mac.a */; };
+		B2411C9E19822FBD00E093E2 /* libcocostudio iOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B2CC503B197763A20041958E /* libcocostudio iOS.a */; };
+		B2411CA119822FDD00E093E2 /* libcocosbuilder iOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B2CC503D197763A20041958E /* libcocosbuilder iOS.a */; };
+		B2411CA419822FF100E093E2 /* libspine iOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B2CC503F197763A20041958E /* libspine iOS.a */; };
+		B2411CA71982301400E093E2 /* libui iOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B2CC5039197763A20041958E /* libui iOS.a */; };
+		B2411CAA1982302700E093E2 /* libnetwork iOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B2CC5041197763A20041958E /* libnetwork iOS.a */; };
+		B244F3171976878E00ED1926 /* libnetwork Mac.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B244F3161976878700ED1926 /* libnetwork Mac.a */; };
 		B2507B6B192589AF00FA4972 /* Shaders3D in Resources */ = {isa = PBXBuildFile; fileRef = B2507B6A192589AF00FA4972 /* Shaders3D */; };
 		B2507B6C192589AF00FA4972 /* Shaders3D in Resources */ = {isa = PBXBuildFile; fileRef = B2507B6A192589AF00FA4972 /* Shaders3D */; };
-		B27AEE0719768950008BD575 /* libcocosNetwork Mac.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B244F3161976878700ED1926 /* libcocosNetwork Mac.a */; };
-		B27AEE0A1976896B008BD575 /* libcocosNetwork Mac.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B244F3161976878700ED1926 /* libcocosNetwork Mac.a */; };
-		B2C59AC8197782B900B452DF /* libcocosBuilder iOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B2CC503D197763A20041958E /* libcocosBuilder iOS.a */; };
-		B2C59AC9197782B900B452DF /* libcocosGUI iOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B2CC5039197763A20041958E /* libcocosGUI iOS.a */; };
-		B2C59ACA197782B900B452DF /* libcocosStudio iOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B2CC503B197763A20041958E /* libcocosStudio iOS.a */; };
-		B2C59AD619779CEB00B452DF /* libcocosBuilder iOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B2CC503D197763A20041958E /* libcocosBuilder iOS.a */; };
-		B2C59AD719779CEB00B452DF /* libcocosGUI iOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B2CC5039197763A20041958E /* libcocosGUI iOS.a */; };
-		B2C59AD819779CEB00B452DF /* libcocosNetwork iOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B2CC5041197763A20041958E /* libcocosNetwork iOS.a */; };
-		B2C59AD919779CEB00B452DF /* libcocosSpine iOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B2CC503F197763A20041958E /* libcocosSpine iOS.a */; };
-		B2C59ADA19779CEB00B452DF /* libcocosStudio iOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B2CC503B197763A20041958E /* libcocosStudio iOS.a */; };
-		B2C59AE519779D5D00B452DF /* libcocosBuilder iOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B2CC503D197763A20041958E /* libcocosBuilder iOS.a */; };
-		B2C59AE619779D5D00B452DF /* libcocosGUI iOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B2CC5039197763A20041958E /* libcocosGUI iOS.a */; };
-		B2C59AE719779D5D00B452DF /* libcocosNetwork iOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B2CC5041197763A20041958E /* libcocosNetwork iOS.a */; };
-		B2C59AE819779D5D00B452DF /* libcocosSpine iOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B2CC503F197763A20041958E /* libcocosSpine iOS.a */; };
-		B2C59AE919779D5D00B452DF /* libcocosStudio iOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B2CC503B197763A20041958E /* libcocosStudio iOS.a */; };
-		B2CC5045197766F70041958E /* libcocosNetwork iOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B2CC5041197763A20041958E /* libcocosNetwork iOS.a */; };
-		B2CC507B19776D8B0041958E /* libcocosSpine iOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B2CC503F197763A20041958E /* libcocosSpine iOS.a */; };
-		B2DB479A197668D500411E16 /* libcocosGUI Mac.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B2DB4799197668CA00411E16 /* libcocosGUI Mac.a */; };
-		B2DB480919766E4800411E16 /* libcocosBuilder Mac.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B2DB480819766E3C00411E16 /* libcocosBuilder Mac.a */; };
-		B2DB480E197670F500411E16 /* libcocosBuilder Mac.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B2DB480819766E3C00411E16 /* libcocosBuilder Mac.a */; };
-		B2DB480F197670F500411E16 /* libcocosGUI Mac.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B2DB4799197668CA00411E16 /* libcocosGUI Mac.a */; };
-		B2DB48141976711A00411E16 /* libcocosBuilder Mac.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B2DB480819766E3C00411E16 /* libcocosBuilder Mac.a */; };
-		B2DB48151976711A00411E16 /* libcocosGUI Mac.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B2DB4799197668CA00411E16 /* libcocosGUI Mac.a */; };
-		B2DB48C319767D3D00411E16 /* libcocosStudio Mac.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B2DB48C219767D3600411E16 /* libcocosStudio Mac.a */; };
-		B2DB48C619767DAC00411E16 /* libcocosStudio Mac.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B2DB48C219767D3600411E16 /* libcocosStudio Mac.a */; };
-		B2DB48C919767EB700411E16 /* libcocosStudio Mac.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B2DB48C219767D3600411E16 /* libcocosStudio Mac.a */; };
-		B2DB493A197681E500411E16 /* libcocosSpine Mac.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B2DB49391976819900411E16 /* libcocosSpine Mac.a */; };
-		B2DB49401976826000411E16 /* libcocosSpine Mac.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B2DB49391976819900411E16 /* libcocosSpine Mac.a */; };
-		B2DB49431976826E00411E16 /* libcocosSpine Mac.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B2DB49391976819900411E16 /* libcocosSpine Mac.a */; };
+		B27AEE0719768950008BD575 /* libnetwork Mac.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B244F3161976878700ED1926 /* libnetwork Mac.a */; };
+		B27AEE0A1976896B008BD575 /* libnetwork Mac.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B244F3161976878700ED1926 /* libnetwork Mac.a */; };
+		B2C59AC8197782B900B452DF /* libcocosbuilder iOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B2CC503D197763A20041958E /* libcocosbuilder iOS.a */; };
+		B2C59AC9197782B900B452DF /* libui iOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B2CC5039197763A20041958E /* libui iOS.a */; };
+		B2C59ACA197782B900B452DF /* libcocostudio iOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B2CC503B197763A20041958E /* libcocostudio iOS.a */; };
+		B2C59AD619779CEB00B452DF /* libcocosbuilder iOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B2CC503D197763A20041958E /* libcocosbuilder iOS.a */; };
+		B2C59AD719779CEB00B452DF /* libui iOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B2CC5039197763A20041958E /* libui iOS.a */; };
+		B2C59AD819779CEB00B452DF /* libnetwork iOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B2CC5041197763A20041958E /* libnetwork iOS.a */; };
+		B2C59AD919779CEB00B452DF /* libspine iOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B2CC503F197763A20041958E /* libspine iOS.a */; };
+		B2C59ADA19779CEB00B452DF /* libcocostudio iOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B2CC503B197763A20041958E /* libcocostudio iOS.a */; };
+		B2C59AE519779D5D00B452DF /* libcocosbuilder iOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B2CC503D197763A20041958E /* libcocosbuilder iOS.a */; };
+		B2C59AE619779D5D00B452DF /* libui iOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B2CC5039197763A20041958E /* libui iOS.a */; };
+		B2C59AE719779D5D00B452DF /* libnetwork iOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B2CC5041197763A20041958E /* libnetwork iOS.a */; };
+		B2C59AE819779D5D00B452DF /* libspine iOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B2CC503F197763A20041958E /* libspine iOS.a */; };
+		B2C59AE919779D5D00B452DF /* libcocostudio iOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B2CC503B197763A20041958E /* libcocostudio iOS.a */; };
+		B2CC5045197766F70041958E /* libnetwork iOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B2CC5041197763A20041958E /* libnetwork iOS.a */; };
+		B2CC507B19776D8B0041958E /* libspine iOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B2CC503F197763A20041958E /* libspine iOS.a */; };
+		B2DB479A197668D500411E16 /* libui Mac.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B2DB4799197668CA00411E16 /* libui Mac.a */; };
+		B2DB480919766E4800411E16 /* libcocosbuilder Mac.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B2DB480819766E3C00411E16 /* libcocosbuilder Mac.a */; };
+		B2DB480E197670F500411E16 /* libcocosbuilder Mac.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B2DB480819766E3C00411E16 /* libcocosbuilder Mac.a */; };
+		B2DB480F197670F500411E16 /* libui Mac.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B2DB4799197668CA00411E16 /* libui Mac.a */; };
+		B2DB48141976711A00411E16 /* libcocosbuilder Mac.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B2DB480819766E3C00411E16 /* libcocosbuilder Mac.a */; };
+		B2DB48151976711A00411E16 /* libui Mac.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B2DB4799197668CA00411E16 /* libui Mac.a */; };
+		B2DB48C319767D3D00411E16 /* libcocostudio Mac.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B2DB48C219767D3600411E16 /* libcocostudio Mac.a */; };
+		B2DB48C619767DAC00411E16 /* libcocostudio Mac.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B2DB48C219767D3600411E16 /* libcocostudio Mac.a */; };
+		B2DB48C919767EB700411E16 /* libcocostudio Mac.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B2DB48C219767D3600411E16 /* libcocostudio Mac.a */; };
+		B2DB493A197681E500411E16 /* libspine Mac.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B2DB49391976819900411E16 /* libspine Mac.a */; };
+		B2DB49401976826000411E16 /* libspine Mac.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B2DB49391976819900411E16 /* libspine Mac.a */; };
+		B2DB49431976826E00411E16 /* libspine Mac.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B2DB49391976819900411E16 /* libspine Mac.a */; };
 		C04F935A1941B05400E9FEAB /* TileMapTest2.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C04F93581941B05400E9FEAB /* TileMapTest2.cpp */; };
 		C04F935B1941B05400E9FEAB /* TileMapTest2.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C04F93581941B05400E9FEAB /* TileMapTest2.cpp */; };
 		C08689C118D370C90093E810 /* background.caf in Resources */ = {isa = PBXBuildFile; fileRef = C08689C018D370C90093E810 /* background.caf */; };
@@ -1731,7 +1733,7 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				B24024DB1978DE1000FDE433 /* libcocos2dx Mac.dylib in CopyFiles */,
+				B24024DB1978DE1000FDE433 /* libcocos2d Mac.a in CopyFiles */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1741,7 +1743,7 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				B24024DD1978EC0700FDE433 /* libcocos2dx Mac.dylib in CopyFiles */,
+				B24024DD1978EC0700FDE433 /* libcocos2d Mac.a in CopyFiles */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1751,7 +1753,7 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				B24024E31978ED5200FDE433 /* libcocos2dx Mac.dylib in CopyFiles */,
+				B24024E31978ED5200FDE433 /* libcocos2d Mac.a in CopyFiles */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1761,7 +1763,7 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				B24024E51978ED5F00FDE433 /* libcocos2dx Mac.dylib in CopyFiles */,
+				B24024E51978ED5F00FDE433 /* libcocos2d Mac.a in CopyFiles */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3500,6 +3502,8 @@
 		29080D8C191B595E0066F8DF /* UIWidgetAddNodeTest_Editor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = UIWidgetAddNodeTest_Editor.h; sourceTree = "<group>"; };
 		290E94B3196FC16900694919 /* CocostudioParserTest.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CocostudioParserTest.cpp; path = ../CocostudioParserTest.cpp; sourceTree = "<group>"; };
 		290E94B4196FC16900694919 /* CocostudioParserTest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = CocostudioParserTest.h; path = ../CocostudioParserTest.h; sourceTree = "<group>"; };
+		295824571987415900F9746D /* UIScale9SpriteTest.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = UIScale9SpriteTest.cpp; sourceTree = "<group>"; };
+		295824581987415900F9746D /* UIScale9SpriteTest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = UIScale9SpriteTest.h; sourceTree = "<group>"; };
 		29FBBBFC196A9ECD00E65826 /* CocostudioParserJsonTest.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CocostudioParserJsonTest.cpp; sourceTree = "<group>"; };
 		29FBBBFD196A9ECD00E65826 /* CocostudioParserJsonTest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CocostudioParserJsonTest.h; sourceTree = "<group>"; };
 		38FA2E71194AEBE100FF2BE4 /* ActionTimelineTestScene.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ActionTimelineTestScene.cpp; sourceTree = "<group>"; };
@@ -3569,11 +3573,11 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				B2411CAA1982302700E093E2 /* libcocosNetwork iOS.a in Frameworks */,
-				B2411CA71982301400E093E2 /* libcocosGUI iOS.a in Frameworks */,
-				B2411CA419822FF100E093E2 /* libcocosSpine iOS.a in Frameworks */,
-				B2411CA119822FDD00E093E2 /* libcocosBuilder iOS.a in Frameworks */,
-				B2411C9E19822FBD00E093E2 /* libcocosStudio iOS.a in Frameworks */,
+				B2411CAA1982302700E093E2 /* libnetwork iOS.a in Frameworks */,
+				B2411CA71982301400E093E2 /* libui iOS.a in Frameworks */,
+				B2411CA419822FF100E093E2 /* libspine iOS.a in Frameworks */,
+				B2411CA119822FDD00E093E2 /* libcocosbuilder iOS.a in Frameworks */,
+				B2411C9E19822FBD00E093E2 /* libcocostudio iOS.a in Frameworks */,
 				15CBA9E0196EEBD4005877BB /* MediaPlayer.framework in Frameworks */,
 				15CBA9DE196EEAF8005877BB /* GameController.framework in Frameworks */,
 				15CBA9DD196EEAA6005877BB /* libz.dylib in Frameworks */,
@@ -3587,9 +3591,9 @@
 				15CBA9CF196EE9FB005877BB /* AVFoundation.framework in Frameworks */,
 				15CBA9D1196EEA1D005877BB /* Foundation.framework in Frameworks */,
 				15CBA9BB196EE910005877BB /* libchipmunk iOS.a in Frameworks */,
-				15CBA9DF196EEBB3005877BB /* libcocos2dx iOS.a in Frameworks */,
-				15CBA9BD196EE910005877BB /* libcocos2dx-extensions iOS.a in Frameworks */,
-				15CBA9BE196EE910005877BB /* libCocosDenshion iOS.a in Frameworks */,
+				15CBA9DF196EEBB3005877BB /* libcocos2d iOS.a in Frameworks */,
+				15CBA9BD196EE910005877BB /* libextension iOS.a in Frameworks */,
+				15CBA9BE196EE910005877BB /* libcocosdenshion iOS.a in Frameworks */,
 				15CBA9BF196EE910005877BB /* libluabindings iOS.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -3599,8 +3603,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				1A0EE2A118CDF6DA004CD58F /* libchipmunk Mac.a in Frameworks */,
-				1A0EE2A218CDF6DA004CD58F /* libcocos2dx Mac.dylib in Frameworks */,
-				1A0EE2A418CDF6DA004CD58F /* libCocosDenshion Mac.a in Frameworks */,
+				1A0EE2A218CDF6DA004CD58F /* libcocos2d Mac.a in Frameworks */,
+				1A0EE2A418CDF6DA004CD58F /* libcocosdenshion Mac.a in Frameworks */,
 				1A0EE2A518CDF6DA004CD58F /* IOKit.framework in Frameworks */,
 				1A0EE2A618CDF6DA004CD58F /* libcurl.dylib in Frameworks */,
 				1A0EE2A718CDF6DA004CD58F /* libz.dylib in Frameworks */,
@@ -3618,11 +3622,11 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				B27AEE0A1976896B008BD575 /* libcocosNetwork Mac.a in Frameworks */,
-				B2DB49431976826E00411E16 /* libcocosSpine Mac.a in Frameworks */,
-				B2DB48C919767EB700411E16 /* libcocosStudio Mac.a in Frameworks */,
-				B2DB480E197670F500411E16 /* libcocosBuilder Mac.a in Frameworks */,
-				B2DB480F197670F500411E16 /* libcocosGUI Mac.a in Frameworks */,
+				B27AEE0A1976896B008BD575 /* libnetwork Mac.a in Frameworks */,
+				B2DB49431976826E00411E16 /* libspine Mac.a in Frameworks */,
+				B2DB48C919767EB700411E16 /* libcocostudio Mac.a in Frameworks */,
+				B2DB480E197670F500411E16 /* libcocosbuilder Mac.a in Frameworks */,
+				B2DB480F197670F500411E16 /* libui Mac.a in Frameworks */,
 				1A0EE2C918CDF733004CD58F /* libcurl.dylib in Frameworks */,
 				1A0EE2CA18CDF733004CD58F /* libz.dylib in Frameworks */,
 				1A0EE2CB18CDF733004CD58F /* IOKit.framework in Frameworks */,
@@ -3633,9 +3637,9 @@
 				1A0EE2D018CDF733004CD58F /* QuartzCore.framework in Frameworks */,
 				1A0EE2D118CDF733004CD58F /* OpenGL.framework in Frameworks */,
 				1A0EE2D218CDF733004CD58F /* libchipmunk Mac.a in Frameworks */,
-				1A0EE2D318CDF733004CD58F /* libcocos2dx Mac.dylib in Frameworks */,
-				1A0EE2D418CDF733004CD58F /* libcocos2dx-extensions Mac.a in Frameworks */,
-				1A0EE2D518CDF733004CD58F /* libCocosDenshion Mac.a in Frameworks */,
+				1A0EE2D318CDF733004CD58F /* libcocos2d Mac.a in Frameworks */,
+				1A0EE2D418CDF733004CD58F /* libextension Mac.a in Frameworks */,
+				1A0EE2D518CDF733004CD58F /* libcocosdenshion Mac.a in Frameworks */,
 				1A0EE2D618CDF733004CD58F /* libluabindings Mac.a in Frameworks */,
 				1A0EE2D718CDF733004CD58F /* Cocoa.framework in Frameworks */,
 			);
@@ -3646,8 +3650,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				1A0EE40218CDF775004CD58F /* libchipmunk iOS.a in Frameworks */,
-				1A0EE40318CDF775004CD58F /* libcocos2dx iOS.a in Frameworks */,
-				1A0EE40518CDF775004CD58F /* libCocosDenshion iOS.a in Frameworks */,
+				1A0EE40318CDF775004CD58F /* libcocos2d iOS.a in Frameworks */,
+				1A0EE40518CDF775004CD58F /* libcocosdenshion iOS.a in Frameworks */,
 				1A0EE40618CDF775004CD58F /* CoreMotion.framework in Frameworks */,
 				1A0EE40718CDF775004CD58F /* libz.dylib in Frameworks */,
 				1A0EE40818CDF775004CD58F /* Foundation.framework in Frameworks */,
@@ -3665,11 +3669,11 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				B2C59AD619779CEB00B452DF /* libcocosBuilder iOS.a in Frameworks */,
-				B2C59AD719779CEB00B452DF /* libcocosGUI iOS.a in Frameworks */,
-				B2C59AD819779CEB00B452DF /* libcocosNetwork iOS.a in Frameworks */,
-				B2C59AD919779CEB00B452DF /* libcocosSpine iOS.a in Frameworks */,
-				B2C59ADA19779CEB00B452DF /* libcocosStudio iOS.a in Frameworks */,
+				B2C59AD619779CEB00B452DF /* libcocosbuilder iOS.a in Frameworks */,
+				B2C59AD719779CEB00B452DF /* libui iOS.a in Frameworks */,
+				B2C59AD819779CEB00B452DF /* libnetwork iOS.a in Frameworks */,
+				B2C59AD919779CEB00B452DF /* libspine iOS.a in Frameworks */,
+				B2C59ADA19779CEB00B452DF /* libcocostudio iOS.a in Frameworks */,
 				15AECE25195D467D00907DB0 /* MediaPlayer.framework in Frameworks */,
 				1A0EE42C18CDF799004CD58F /* libz.dylib in Frameworks */,
 				1A0EE42D18CDF799004CD58F /* CoreMotion.framework in Frameworks */,
@@ -3682,9 +3686,9 @@
 				1A0EE43418CDF799004CD58F /* AVFoundation.framework in Frameworks */,
 				1A0EE43518CDF799004CD58F /* Foundation.framework in Frameworks */,
 				1A0EE43618CDF799004CD58F /* libchipmunk iOS.a in Frameworks */,
-				1A0EE43718CDF799004CD58F /* libcocos2dx iOS.a in Frameworks */,
-				1A0EE43818CDF799004CD58F /* libcocos2dx-extensions iOS.a in Frameworks */,
-				1A0EE43918CDF799004CD58F /* libCocosDenshion iOS.a in Frameworks */,
+				1A0EE43718CDF799004CD58F /* libcocos2d iOS.a in Frameworks */,
+				1A0EE43818CDF799004CD58F /* libextension iOS.a in Frameworks */,
+				1A0EE43918CDF799004CD58F /* libcocosdenshion iOS.a in Frameworks */,
 				1A0EE43A18CDF799004CD58F /* libluabindings iOS.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -3693,11 +3697,11 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				B27AEE0719768950008BD575 /* libcocosNetwork Mac.a in Frameworks */,
-				B2DB49401976826000411E16 /* libcocosSpine Mac.a in Frameworks */,
-				B2DB48C319767D3D00411E16 /* libcocosStudio Mac.a in Frameworks */,
-				B2DB48141976711A00411E16 /* libcocosBuilder Mac.a in Frameworks */,
-				B2DB48151976711A00411E16 /* libcocosGUI Mac.a in Frameworks */,
+				B27AEE0719768950008BD575 /* libnetwork Mac.a in Frameworks */,
+				B2DB49401976826000411E16 /* libspine Mac.a in Frameworks */,
+				B2DB48C319767D3D00411E16 /* libcocostudio Mac.a in Frameworks */,
+				B2DB48141976711A00411E16 /* libcocosbuilder Mac.a in Frameworks */,
+				B2DB48151976711A00411E16 /* libui Mac.a in Frameworks */,
 				1ABCA36218CD9AC60087CE3A /* libcurl.dylib in Frameworks */,
 				1ABCA36118CD9AC00087CE3A /* libz.dylib in Frameworks */,
 				1ABCA35F18CD9AAE0087CE3A /* IOKit.framework in Frameworks */,
@@ -3708,9 +3712,9 @@
 				1ABCA35718CD9A890087CE3A /* QuartzCore.framework in Frameworks */,
 				1ABCA35518CD9A820087CE3A /* OpenGL.framework in Frameworks */,
 				1ABCA2C218CD92420087CE3A /* libchipmunk Mac.a in Frameworks */,
-				1ABCA2C318CD92420087CE3A /* libcocos2dx Mac.dylib in Frameworks */,
-				1ABCA2C418CD92420087CE3A /* libcocos2dx-extensions Mac.a in Frameworks */,
-				1ABCA2C518CD92420087CE3A /* libCocosDenshion Mac.a in Frameworks */,
+				1ABCA2C318CD92420087CE3A /* libcocos2d Mac.a in Frameworks */,
+				1ABCA2C418CD92420087CE3A /* libextension Mac.a in Frameworks */,
+				1ABCA2C518CD92420087CE3A /* libcocosdenshion Mac.a in Frameworks */,
 				1ABCA2C618CD92420087CE3A /* libluabindings Mac.a in Frameworks */,
 				1ABCA28718CD91510087CE3A /* Cocoa.framework in Frameworks */,
 			);
@@ -3720,11 +3724,11 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				B2C59AE519779D5D00B452DF /* libcocosBuilder iOS.a in Frameworks */,
-				B2C59AE619779D5D00B452DF /* libcocosGUI iOS.a in Frameworks */,
-				B2C59AE719779D5D00B452DF /* libcocosNetwork iOS.a in Frameworks */,
-				B2C59AE819779D5D00B452DF /* libcocosSpine iOS.a in Frameworks */,
-				B2C59AE919779D5D00B452DF /* libcocosStudio iOS.a in Frameworks */,
+				B2C59AE519779D5D00B452DF /* libcocosbuilder iOS.a in Frameworks */,
+				B2C59AE619779D5D00B452DF /* libui iOS.a in Frameworks */,
+				B2C59AE719779D5D00B452DF /* libnetwork iOS.a in Frameworks */,
+				B2C59AE819779D5D00B452DF /* libspine iOS.a in Frameworks */,
+				B2C59AE919779D5D00B452DF /* libcocostudio iOS.a in Frameworks */,
 				15AECE0B195C0F8A00907DB0 /* MediaPlayer.framework in Frameworks */,
 				1ABCA3B018CDA06D0087CE3A /* libz.dylib in Frameworks */,
 				1ABCA3AA18CD9F1A0087CE3A /* CoreMotion.framework in Frameworks */,
@@ -3737,9 +3741,9 @@
 				1ABCA39D18CD9ED80087CE3A /* AVFoundation.framework in Frameworks */,
 				1ABCA2CE18CD93580087CE3A /* Foundation.framework in Frameworks */,
 				1ABCA30118CD93940087CE3A /* libchipmunk iOS.a in Frameworks */,
-				1ABCA30218CD93940087CE3A /* libcocos2dx iOS.a in Frameworks */,
-				1ABCA30318CD93940087CE3A /* libcocos2dx-extensions iOS.a in Frameworks */,
-				1ABCA30418CD93940087CE3A /* libCocosDenshion iOS.a in Frameworks */,
+				1ABCA30218CD93940087CE3A /* libcocos2d iOS.a in Frameworks */,
+				1ABCA30318CD93940087CE3A /* libextension iOS.a in Frameworks */,
+				1ABCA30418CD93940087CE3A /* libcocosdenshion iOS.a in Frameworks */,
 				1ABCA30518CD93940087CE3A /* libluabindings iOS.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -3748,16 +3752,16 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				B244F3171976878E00ED1926 /* libcocosNetwork Mac.a in Frameworks */,
-				B2DB493A197681E500411E16 /* libcocosSpine Mac.a in Frameworks */,
-				B2DB48C619767DAC00411E16 /* libcocosStudio Mac.a in Frameworks */,
-				B2DB480919766E4800411E16 /* libcocosBuilder Mac.a in Frameworks */,
-				B2DB479A197668D500411E16 /* libcocosGUI Mac.a in Frameworks */,
+				B244F3171976878E00ED1926 /* libnetwork Mac.a in Frameworks */,
+				B2DB493A197681E500411E16 /* libspine Mac.a in Frameworks */,
+				B2DB48C619767DAC00411E16 /* libcocostudio Mac.a in Frameworks */,
+				B2DB480919766E4800411E16 /* libcocosbuilder Mac.a in Frameworks */,
+				B2DB479A197668D500411E16 /* libui Mac.a in Frameworks */,
 				1AAF534B180E2F4E000584C8 /* libbox2d Mac.a in Frameworks */,
 				1AAF534C180E2F4E000584C8 /* libchipmunk Mac.a in Frameworks */,
-				1AAF534D180E2F4E000584C8 /* libcocos2dx Mac.dylib in Frameworks */,
-				1AAF534E180E2F4E000584C8 /* libcocos2dx-extensions Mac.a in Frameworks */,
-				1AAF534F180E2F4E000584C8 /* libCocosDenshion Mac.a in Frameworks */,
+				1AAF534D180E2F4E000584C8 /* libcocos2d Mac.a in Frameworks */,
+				1AAF534E180E2F4E000584C8 /* libextension Mac.a in Frameworks */,
+				1AAF534F180E2F4E000584C8 /* libcocosdenshion Mac.a in Frameworks */,
 				EDCC747F17C455FD007B692C /* IOKit.framework in Frameworks */,
 				1A9F808D177E98A600D9A1CB /* libcurl.dylib in Frameworks */,
 				15C6482F165F399D007D4F18 /* libz.dylib in Frameworks */,
@@ -3777,7 +3781,7 @@
 			files = (
 				3E61773D1960FBD200DE83F5 /* GameController.framework in Frameworks */,
 				3E6177211960FAED00DE83F5 /* libchipmunk iOS.a in Frameworks */,
-				3E6177221960FAED00DE83F5 /* libcocos2dx iOS.a in Frameworks */,
+				3E6177221960FAED00DE83F5 /* libcocos2d iOS.a in Frameworks */,
 				3E6177241960FAED00DE83F5 /* CoreMotion.framework in Frameworks */,
 				3E6177251960FAED00DE83F5 /* libz.dylib in Frameworks */,
 				3E6177261960FAED00DE83F5 /* Foundation.framework in Frameworks */,
@@ -3795,17 +3799,17 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				B2C59AC8197782B900B452DF /* libcocosBuilder iOS.a in Frameworks */,
-				B2C59AC9197782B900B452DF /* libcocosGUI iOS.a in Frameworks */,
-				B2C59ACA197782B900B452DF /* libcocosStudio iOS.a in Frameworks */,
-				B2CC507B19776D8B0041958E /* libcocosSpine iOS.a in Frameworks */,
-				B2CC5045197766F70041958E /* libcocosNetwork iOS.a in Frameworks */,
+				B2C59AC8197782B900B452DF /* libcocosbuilder iOS.a in Frameworks */,
+				B2C59AC9197782B900B452DF /* libui iOS.a in Frameworks */,
+				B2C59ACA197782B900B452DF /* libcocostudio iOS.a in Frameworks */,
+				B2CC507B19776D8B0041958E /* libspine iOS.a in Frameworks */,
+				B2CC5045197766F70041958E /* libnetwork iOS.a in Frameworks */,
 				3EA0FB66191B933000B170C8 /* MediaPlayer.framework in Frameworks */,
 				1AAF53FE180E39D4000584C8 /* libbox2d iOS.a in Frameworks */,
 				1AAF53FF180E39D4000584C8 /* libchipmunk iOS.a in Frameworks */,
-				1AAF5400180E39D4000584C8 /* libcocos2dx iOS.a in Frameworks */,
-				1AAF5401180E39D4000584C8 /* libcocos2dx-extensions iOS.a in Frameworks */,
-				1AAF5402180E39D4000584C8 /* libCocosDenshion iOS.a in Frameworks */,
+				1AAF5400180E39D4000584C8 /* libcocos2d iOS.a in Frameworks */,
+				1AAF5401180E39D4000584C8 /* libextension iOS.a in Frameworks */,
+				1AAF5402180E39D4000584C8 /* libcocosdenshion iOS.a in Frameworks */,
 				D60AE43417F7FFE100757E4B /* CoreMotion.framework in Frameworks */,
 				A07A521E1783A1D20073F6A7 /* libz.dylib in Frameworks */,
 				A07A521F1783A1D20073F6A7 /* Foundation.framework in Frameworks */,
@@ -7639,6 +7643,8 @@
 		29FBBC00196A9F0D00E65826 /* UIAndEditorTests */ = {
 			isa = PBXGroup;
 			children = (
+				295824571987415900F9746D /* UIScale9SpriteTest.cpp */,
+				295824581987415900F9746D /* UIScale9SpriteTest.h */,
 				29080D1F191B595E0066F8DF /* CocosGUIScene.cpp */,
 				29080D20191B595E0066F8DF /* CocosGUIScene.h */,
 				29080D37191B595E0066F8DF /* GUIEditorTest.cpp */,
@@ -7763,26 +7769,26 @@
 		46A15F9D1807A4F8005B8026 /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				46A15FB01807A4F9005B8026 /* libcocos2dx Mac.dylib */,
-				46A15FB21807A4F9005B8026 /* libcocos2dx-extensions Mac.a */,
-				B2DB4799197668CA00411E16 /* libcocosGUI Mac.a */,
-				B2DB48C219767D3600411E16 /* libcocosStudio Mac.a */,
-				B2DB480819766E3C00411E16 /* libcocosBuilder Mac.a */,
-				B2DB49391976819900411E16 /* libcocosSpine Mac.a */,
-				B244F3161976878700ED1926 /* libcocosNetwork Mac.a */,
+				46A15FB01807A4F9005B8026 /* libcocos2d Mac.a */,
+				46A15FB21807A4F9005B8026 /* libextension Mac.a */,
+				B2DB4799197668CA00411E16 /* libui Mac.a */,
+				B2DB48C219767D3600411E16 /* libcocostudio Mac.a */,
+				B2DB480819766E3C00411E16 /* libcocosbuilder Mac.a */,
+				B2DB49391976819900411E16 /* libspine Mac.a */,
+				B244F3161976878700ED1926 /* libnetwork Mac.a */,
 				46A15FB41807A4F9005B8026 /* libchipmunk Mac.a */,
 				46A15FB61807A4F9005B8026 /* libbox2d Mac.a */,
-				46A15FB81807A4F9005B8026 /* libCocosDenshion Mac.a */,
-				46A15FBE1807A4F9005B8026 /* libcocos2dx iOS.a */,
-				46A15FC01807A4F9005B8026 /* libcocos2dx-extensions iOS.a */,
+				46A15FB81807A4F9005B8026 /* libcocosdenshion Mac.a */,
+				46A15FBE1807A4F9005B8026 /* libcocos2d iOS.a */,
+				46A15FC01807A4F9005B8026 /* libextension iOS.a */,
 				46A15FC21807A4F9005B8026 /* libchipmunk iOS.a */,
 				46A15FC41807A4F9005B8026 /* libbox2d iOS.a */,
-				46A15FC61807A4F9005B8026 /* libCocosDenshion iOS.a */,
-				B2CC5039197763A20041958E /* libcocosGUI iOS.a */,
-				B2CC503B197763A20041958E /* libcocosStudio iOS.a */,
-				B2CC503D197763A20041958E /* libcocosBuilder iOS.a */,
-				B2CC503F197763A20041958E /* libcocosSpine iOS.a */,
-				B2CC5041197763A20041958E /* libcocosNetwork iOS.a */,
+				46A15FC61807A4F9005B8026 /* libcocosdenshion iOS.a */,
+				B2CC5039197763A20041958E /* libui iOS.a */,
+				B2CC503B197763A20041958E /* libcocostudio iOS.a */,
+				B2CC503D197763A20041958E /* libcocosbuilder iOS.a */,
+				B2CC503F197763A20041958E /* libspine iOS.a */,
+				B2CC5041197763A20041958E /* libnetwork iOS.a */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -8107,17 +8113,17 @@
 			remoteRef = 1ABCA27F18CD90A50087CE3A /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		46A15FB01807A4F9005B8026 /* libcocos2dx Mac.dylib */ = {
+		46A15FB01807A4F9005B8026 /* libcocos2d Mac.a */ = {
 			isa = PBXReferenceProxy;
 			fileType = archive.ar;
-			path = "libcocos2dx Mac.dylib";
+			path = "libcocos2d Mac.a";
 			remoteRef = 46A15FAF1807A4F9005B8026 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		46A15FB21807A4F9005B8026 /* libcocos2dx-extensions Mac.a */ = {
+		46A15FB21807A4F9005B8026 /* libextension Mac.a */ = {
 			isa = PBXReferenceProxy;
 			fileType = archive.ar;
-			path = "libcocos2dx-extensions Mac.a";
+			path = "libextension Mac.a";
 			remoteRef = 46A15FB11807A4F9005B8026 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
@@ -8135,24 +8141,24 @@
 			remoteRef = 46A15FB51807A4F9005B8026 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		46A15FB81807A4F9005B8026 /* libCocosDenshion Mac.a */ = {
+		46A15FB81807A4F9005B8026 /* libcocosdenshion Mac.a */ = {
 			isa = PBXReferenceProxy;
 			fileType = archive.ar;
-			path = "libCocosDenshion Mac.a";
+			path = "libcocosdenshion Mac.a";
 			remoteRef = 46A15FB71807A4F9005B8026 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		46A15FBE1807A4F9005B8026 /* libcocos2dx iOS.a */ = {
+		46A15FBE1807A4F9005B8026 /* libcocos2d iOS.a */ = {
 			isa = PBXReferenceProxy;
 			fileType = archive.ar;
-			path = "libcocos2dx iOS.a";
+			path = "libcocos2d iOS.a";
 			remoteRef = 46A15FBD1807A4F9005B8026 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		46A15FC01807A4F9005B8026 /* libcocos2dx-extensions iOS.a */ = {
+		46A15FC01807A4F9005B8026 /* libextension iOS.a */ = {
 			isa = PBXReferenceProxy;
 			fileType = archive.ar;
-			path = "libcocos2dx-extensions iOS.a";
+			path = "libextension iOS.a";
 			remoteRef = 46A15FBF1807A4F9005B8026 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
@@ -8170,80 +8176,80 @@
 			remoteRef = 46A15FC31807A4F9005B8026 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		46A15FC61807A4F9005B8026 /* libCocosDenshion iOS.a */ = {
+		46A15FC61807A4F9005B8026 /* libcocosdenshion iOS.a */ = {
 			isa = PBXReferenceProxy;
 			fileType = archive.ar;
-			path = "libCocosDenshion iOS.a";
+			path = "libcocosdenshion iOS.a";
 			remoteRef = 46A15FC51807A4F9005B8026 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		B244F3161976878700ED1926 /* libcocosNetwork Mac.a */ = {
+		B244F3161976878700ED1926 /* libnetwork Mac.a */ = {
 			isa = PBXReferenceProxy;
 			fileType = archive.ar;
-			path = "libcocosNetwork Mac.a";
+			path = "libnetwork Mac.a";
 			remoteRef = B244F3151976878700ED1926 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		B2CC5039197763A20041958E /* libcocosGUI iOS.a */ = {
+		B2CC5039197763A20041958E /* libui iOS.a */ = {
 			isa = PBXReferenceProxy;
 			fileType = archive.ar;
-			path = "libcocosGUI iOS.a";
+			path = "libui iOS.a";
 			remoteRef = B2CC5038197763A20041958E /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		B2CC503B197763A20041958E /* libcocosStudio iOS.a */ = {
+		B2CC503B197763A20041958E /* libcocostudio iOS.a */ = {
 			isa = PBXReferenceProxy;
 			fileType = archive.ar;
-			path = "libcocosStudio iOS.a";
+			path = "libcocostudio iOS.a";
 			remoteRef = B2CC503A197763A20041958E /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		B2CC503D197763A20041958E /* libcocosBuilder iOS.a */ = {
+		B2CC503D197763A20041958E /* libcocosbuilder iOS.a */ = {
 			isa = PBXReferenceProxy;
 			fileType = archive.ar;
-			path = "libcocosBuilder iOS.a";
+			path = "libcocosbuilder iOS.a";
 			remoteRef = B2CC503C197763A20041958E /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		B2CC503F197763A20041958E /* libcocosSpine iOS.a */ = {
+		B2CC503F197763A20041958E /* libspine iOS.a */ = {
 			isa = PBXReferenceProxy;
 			fileType = archive.ar;
-			path = "libcocosSpine iOS.a";
+			path = "libspine iOS.a";
 			remoteRef = B2CC503E197763A20041958E /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		B2CC5041197763A20041958E /* libcocosNetwork iOS.a */ = {
+		B2CC5041197763A20041958E /* libnetwork iOS.a */ = {
 			isa = PBXReferenceProxy;
 			fileType = archive.ar;
-			path = "libcocosNetwork iOS.a";
+			path = "libnetwork iOS.a";
 			remoteRef = B2CC5040197763A20041958E /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		B2DB4799197668CA00411E16 /* libcocosGUI Mac.a */ = {
+		B2DB4799197668CA00411E16 /* libui Mac.a */ = {
 			isa = PBXReferenceProxy;
 			fileType = archive.ar;
-			path = "libcocosGUI Mac.a";
+			path = "libui Mac.a";
 			remoteRef = B2DB4798197668CA00411E16 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		B2DB480819766E3C00411E16 /* libcocosBuilder Mac.a */ = {
+		B2DB480819766E3C00411E16 /* libcocosbuilder Mac.a */ = {
 			isa = PBXReferenceProxy;
 			fileType = archive.ar;
-			path = "libcocosBuilder Mac.a";
+			path = "libcocosbuilder Mac.a";
 			remoteRef = B2DB480719766E3C00411E16 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		B2DB48C219767D3600411E16 /* libcocosStudio Mac.a */ = {
+		B2DB48C219767D3600411E16 /* libcocostudio Mac.a */ = {
 			isa = PBXReferenceProxy;
 			fileType = archive.ar;
-			path = "libcocosStudio Mac.a";
+			path = "libcocostudio Mac.a";
 			remoteRef = B2DB48C119767D3600411E16 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		B2DB49391976819900411E16 /* libcocosSpine Mac.a */ = {
+		B2DB49391976819900411E16 /* libspine Mac.a */ = {
 			isa = PBXReferenceProxy;
 			fileType = archive.ar;
-			path = "libcocosSpine Mac.a";
+			path = "libspine Mac.a";
 			remoteRef = B2DB49381976819900411E16 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
@@ -8880,6 +8886,7 @@
 				1AC35B8118CECF0C00F37B72 /* SceneController.cpp in Sources */,
 				1AC35B3318CECF0C00F37B72 /* Test.cpp in Sources */,
 				1AC35C2318CECF0C00F37B72 /* ParticleTest.cpp in Sources */,
+				295824591987415900F9746D /* UIScale9SpriteTest.cpp in Sources */,
 				1AC35C6118CECF0C00F37B72 /* TouchesTest.cpp in Sources */,
 				1AC35C6318CECF0C00F37B72 /* TransitionsTest.cpp in Sources */,
 				29080DB3191B595E0066F8DF /* UILayoutTest_Editor.cpp in Sources */,
@@ -8962,6 +8969,7 @@
 				1AC35BFA18CECF0C00F37B72 /* WebSocketTest.cpp in Sources */,
 				1AC35BF218CECF0C00F37B72 /* EditBoxTest.cpp in Sources */,
 				38FA2E74194AEBE100FF2BE4 /* ActionTimelineTestScene.cpp in Sources */,
+				2958245A1987415900F9746D /* UIScale9SpriteTest.cpp in Sources */,
 				1AC35B3A18CECF0C00F37B72 /* Bug-1174.cpp in Sources */,
 				1AC35BE418CECF0C00F37B72 /* CCControlColourPickerTest.cpp in Sources */,
 				29080DD4191B595E0066F8DF /* UITextAtlasTest.cpp in Sources */,

--- a/cocos/ui/Android.mk
+++ b/cocos/ui/Android.mk
@@ -31,6 +31,7 @@ UIVBox.cpp \
 UIRelativeBox.cpp \
 UIVideoPlayerAndroid.cpp \
 UIDeprecated.cpp \
+UIScale9Sprite.cpp \
 
 LOCAL_EXPORT_C_INCLUDES := $(LOCAL_PATH)/.. \
 $(LOCAL_PATH)/../editor-support

--- a/cocos/ui/CMakeLists.txt
+++ b/cocos/ui/CMakeLists.txt
@@ -23,5 +23,6 @@ set(COCOS_UI_SRC
   ui/UIVBox.cpp
   ui/UIWidget.cpp
   ui/UIDeprecated.cpp
+  ui/UIScale9Sprite.cpp
 )
 

--- a/cocos/ui/CocosGUI.h
+++ b/cocos/ui/CocosGUI.h
@@ -50,6 +50,7 @@ THE SOFTWARE.
 #endif
 #include "ui/UIDeprecated.h"
 #include "ui/GUIExport.h"
+#include "ui/UIScale9Sprite.h"
 
 
 NS_CC_BEGIN

--- a/cocos/ui/UIButton.cpp
+++ b/cocos/ui/UIButton.cpp
@@ -23,7 +23,7 @@ THE SOFTWARE.
 ****************************************************************************/
 
 #include "ui/UIButton.h"
-#include "extensions/GUI/CCControlExtension/CCScale9Sprite.h"
+#include "ui/UIScale9Sprite.h"
 #include "2d/CCLabel.h"
 #include "2d/CCSprite.h"
 #include "2d/CCActionInterval.h"
@@ -163,9 +163,9 @@ void Button::setScale9Enabled(bool able)
     _buttonDisableRenderer = nullptr;
     if (_scale9Enabled)
     {
-        _buttonNormalRenderer = extension::Scale9Sprite::create();
-        _buttonClickedRenderer = extension::Scale9Sprite::create();
-        _buttonDisableRenderer = extension::Scale9Sprite::create();
+        _buttonNormalRenderer = Scale9Sprite::create();
+        _buttonClickedRenderer = Scale9Sprite::create();
+        _buttonDisableRenderer = Scale9Sprite::create();
     }
     else
     {
@@ -230,7 +230,7 @@ void Button::loadTextureNormal(const std::string& normal,TextureResType texType)
     _normalTexType = texType;
     if (_scale9Enabled)
     {
-        extension::Scale9Sprite* normalRendererScale9 = static_cast<extension::Scale9Sprite*>(_buttonNormalRenderer);
+        Scale9Sprite* normalRendererScale9 = static_cast<Scale9Sprite*>(_buttonNormalRenderer);
         switch (_normalTexType)
         {
             case TextureResType::LOCAL:
@@ -278,7 +278,7 @@ void Button::loadTexturePressed(const std::string& selected,TextureResType texTy
     _pressedTexType = texType;
     if (_scale9Enabled)
     {
-        extension::Scale9Sprite* clickedRendererScale9 = static_cast<extension::Scale9Sprite*>(_buttonClickedRenderer);
+        Scale9Sprite* clickedRendererScale9 = static_cast<Scale9Sprite*>(_buttonClickedRenderer);
         switch (_pressedTexType)
         {
             case TextureResType::LOCAL:
@@ -325,7 +325,7 @@ void Button::loadTextureDisabled(const std::string& disabled,TextureResType texT
     _disabledTexType = texType;
     if (_scale9Enabled)
     {
-        extension::Scale9Sprite* disabledScale9 = static_cast<extension::Scale9Sprite*>(_buttonDisableRenderer);
+        Scale9Sprite* disabledScale9 = static_cast<Scale9Sprite*>(_buttonDisableRenderer);
         switch (_disabledTexType)
         {
             case TextureResType::LOCAL:
@@ -376,7 +376,7 @@ void Button::setCapInsetsNormalRenderer(const Rect &capInsets)
     {
         return;
     }
-    static_cast<extension::Scale9Sprite*>(_buttonNormalRenderer)->setCapInsets(capInsets);
+    static_cast<Scale9Sprite*>(_buttonNormalRenderer)->setCapInsets(capInsets);
 }
 
 const Rect& Button::getCapInsetsNormalRenderer()const
@@ -391,7 +391,7 @@ void Button::setCapInsetsPressedRenderer(const Rect &capInsets)
     {
         return;
     }
-    static_cast<extension::Scale9Sprite*>(_buttonClickedRenderer)->setCapInsets(capInsets);
+    static_cast<Scale9Sprite*>(_buttonClickedRenderer)->setCapInsets(capInsets);
 }
 
 const Rect& Button::getCapInsetsPressedRenderer()const
@@ -406,7 +406,7 @@ void Button::setCapInsetsDisabledRenderer(const Rect &capInsets)
     {
         return;
     }
-    static_cast<extension::Scale9Sprite*>(_buttonDisableRenderer)->setCapInsets(capInsets);
+    static_cast<Scale9Sprite*>(_buttonDisableRenderer)->setCapInsets(capInsets);
 }
 
 const Rect& Button::getCapInsetsDisabledRenderer()const
@@ -605,7 +605,7 @@ void Button::normalTextureScaleChangedWithSize()
     {
         if (_scale9Enabled)
         {
-            static_cast<extension::Scale9Sprite*>(_buttonNormalRenderer)->setPreferredSize(_contentSize);
+            static_cast<Scale9Sprite*>(_buttonNormalRenderer)->setPreferredSize(_contentSize);
             _normalTextureScaleXInSize = _normalTextureScaleYInSize = 1.0f;
         }
         else
@@ -641,7 +641,7 @@ void Button::pressedTextureScaleChangedWithSize()
     {
         if (_scale9Enabled)
         {
-            static_cast<extension::Scale9Sprite*>(_buttonClickedRenderer)->setPreferredSize(_contentSize);
+            static_cast<Scale9Sprite*>(_buttonClickedRenderer)->setPreferredSize(_contentSize);
             _pressedTextureScaleXInSize = _pressedTextureScaleYInSize = 1.0f;
         }
         else
@@ -676,7 +676,7 @@ void Button::disabledTextureScaleChangedWithSize()
     {
         if (_scale9Enabled)
         {
-            static_cast<extension::Scale9Sprite*>(_buttonDisableRenderer)->setPreferredSize(_contentSize);
+            static_cast<Scale9Sprite*>(_buttonDisableRenderer)->setPreferredSize(_contentSize);
         }
         else
         {

--- a/cocos/ui/UIImageView.cpp
+++ b/cocos/ui/UIImageView.cpp
@@ -23,7 +23,7 @@ THE SOFTWARE.
 ****************************************************************************/
 
 #include "ui/UIImageView.h"
-#include "extensions/GUI/CCControlExtension/CCScale9Sprite.h"
+#include "ui/UIScale9Sprite.h"
 #include "2d/CCSprite.h"
 
 NS_CC_BEGIN
@@ -32,7 +32,7 @@ namespace ui {
 
 
 #define STATIC_CAST_CCSPRITE static_cast<Sprite*>(_imageRenderer)
-#define STATIC_CAST_SCALE9SPRITE static_cast<extension::Scale9Sprite*>(_imageRenderer)
+#define STATIC_CAST_SCALE9SPRITE static_cast<Scale9Sprite*>(_imageRenderer)
     
 static const int IMAGE_RENDERER_Z = (-1);
     
@@ -125,7 +125,7 @@ void ImageView::loadTexture(const std::string& fileName, TextureResType texType)
         case TextureResType::LOCAL:
             if (_scale9Enabled)
             {
-                extension::Scale9Sprite* imageRendererScale9 = STATIC_CAST_SCALE9SPRITE;
+                Scale9Sprite* imageRendererScale9 = STATIC_CAST_SCALE9SPRITE;
                 imageRendererScale9->initWithFile(fileName);
                 imageRendererScale9->setCapInsets(_capInsets);
             }
@@ -138,7 +138,7 @@ void ImageView::loadTexture(const std::string& fileName, TextureResType texType)
         case TextureResType::PLIST:
             if (_scale9Enabled)
             {
-                extension::Scale9Sprite* imageRendererScale9 = STATIC_CAST_SCALE9SPRITE;
+                Scale9Sprite* imageRendererScale9 = STATIC_CAST_SCALE9SPRITE;
                 imageRendererScale9->initWithSpriteFrameName(fileName);
                 imageRendererScale9->setCapInsets(_capInsets);
             }
@@ -210,7 +210,7 @@ void ImageView::setScale9Enabled(bool able)
     _imageRenderer = nullptr;
     if (_scale9Enabled)
     {
-        _imageRenderer = extension::Scale9Sprite::create();
+        _imageRenderer = Scale9Sprite::create();
     }
     else
     {
@@ -298,7 +298,7 @@ void ImageView::imageTextureScaleChangedWithSize()
     {
         if (_scale9Enabled)
         {
-            static_cast<extension::Scale9Sprite*>(_imageRenderer)->setPreferredSize(_contentSize);
+            static_cast<Scale9Sprite*>(_imageRenderer)->setPreferredSize(_contentSize);
         }
         else
         {

--- a/cocos/ui/UILayout.cpp
+++ b/cocos/ui/UILayout.cpp
@@ -24,7 +24,7 @@ THE SOFTWARE.
 
 #include "ui/UILayout.h"
 #include "ui/UIHelper.h"
-#include "extensions/GUI/CCControlExtension/CCScale9Sprite.h"
+#include "ui/UIScale9Sprite.h"
 #include "renderer/CCGLProgram.h"
 #include "renderer/CCGLProgramCache.h"
 #include "base/CCDirector.h"
@@ -577,7 +577,7 @@ void Layout::onSizeChanged()
         _backGroundImage->setPosition(Vec2(_contentSize.width/2.0f, _contentSize.height/2.0f));
         if (_backGroundScale9Enabled && _backGroundImage)
         {
-            static_cast<extension::Scale9Sprite*>(_backGroundImage)->setPreferredSize(_contentSize);
+            static_cast<Scale9Sprite*>(_backGroundImage)->setPreferredSize(_contentSize);
         }
     }
     if (_colorRender)
@@ -623,7 +623,7 @@ void Layout::setBackGroundImage(const std::string& fileName,TextureResType texTy
     _bgImageTexType = texType;
     if (_backGroundScale9Enabled)
     {
-        extension::Scale9Sprite* bgiScale9 = static_cast<extension::Scale9Sprite*>(_backGroundImage);
+        Scale9Sprite* bgiScale9 = static_cast<Scale9Sprite*>(_backGroundImage);
         switch (_bgImageTexType)
         {
             case TextureResType::LOCAL:
@@ -661,7 +661,7 @@ void Layout::setBackGroundImageCapInsets(const Rect &capInsets)
     _backGroundImageCapInsets = capInsets;
     if (_backGroundScale9Enabled && _backGroundImage)
     {
-        static_cast<extension::Scale9Sprite*>(_backGroundImage)->setCapInsets(capInsets);
+        static_cast<Scale9Sprite*>(_backGroundImage)->setCapInsets(capInsets);
     }
 }
     
@@ -708,9 +708,9 @@ void Layout::addBackGroundImage()
 {
     if (_backGroundScale9Enabled)
     {
-        _backGroundImage = extension::Scale9Sprite::create();
+        _backGroundImage = Scale9Sprite::create();
         addProtectedChild(_backGroundImage, BACKGROUNDIMAGE_Z, -1);
-        static_cast<extension::Scale9Sprite*>(_backGroundImage)->setPreferredSize(_contentSize);
+        static_cast<Scale9Sprite*>(_backGroundImage)->setPreferredSize(_contentSize);
     }
     else
     {

--- a/cocos/ui/UIListView.cpp
+++ b/cocos/ui/UIListView.cpp
@@ -24,7 +24,7 @@ THE SOFTWARE.
 
 #include "ui/UIListView.h"
 #include "ui/UIHelper.h"
-#include "extensions/GUI/CCControlExtension/CCScale9Sprite.h"
+#include "ui/UIScale9Sprite.h"
 
 NS_CC_BEGIN
 

--- a/cocos/ui/UILoadingBar.cpp
+++ b/cocos/ui/UILoadingBar.cpp
@@ -23,7 +23,7 @@ THE SOFTWARE.
 ****************************************************************************/
 
 #include "ui/UILoadingBar.h"
-#include "extensions/GUI/CCControlExtension/CCScale9Sprite.h"
+#include "ui/UIScale9Sprite.h"
 #include "2d/CCSprite.h"
 
 NS_CC_BEGIN
@@ -136,7 +136,7 @@ void LoadingBar::loadTexture(const std::string& texture,TextureResType texType)
         case TextureResType::LOCAL:
             if (_scale9Enabled)
             {
-                extension::Scale9Sprite* barRendererScale9 = static_cast<extension::Scale9Sprite*>(_barRenderer);
+                Scale9Sprite* barRendererScale9 = static_cast<Scale9Sprite*>(_barRenderer);
                 barRendererScale9->initWithFile(texture);
                 barRendererScale9->setCapInsets(_capInsets);
             }
@@ -148,7 +148,7 @@ void LoadingBar::loadTexture(const std::string& texture,TextureResType texType)
         case TextureResType::PLIST:
             if (_scale9Enabled)
             {
-                extension::Scale9Sprite* barRendererScale9 = static_cast<extension::Scale9Sprite*>(_barRenderer);
+                Scale9Sprite* barRendererScale9 = static_cast<Scale9Sprite*>(_barRenderer);
                 barRendererScale9->initWithSpriteFrameName(texture);
                 barRendererScale9->setCapInsets(_capInsets);
             }
@@ -196,7 +196,7 @@ void LoadingBar::setScale9Enabled(bool enabled)
     _barRenderer = nullptr;
     if (_scale9Enabled)
     {
-        _barRenderer = extension::Scale9Sprite::create();
+        _barRenderer = Scale9Sprite::create();
     }
     else
     {
@@ -230,7 +230,7 @@ void LoadingBar::setCapInsets(const Rect &capInsets)
     {
         return;
     }
-    static_cast<extension::Scale9Sprite*>(_barRenderer)->setCapInsets(capInsets);
+    static_cast<Scale9Sprite*>(_barRenderer)->setCapInsets(capInsets);
 }
 
 const Rect& LoadingBar::getCapInsets()const
@@ -351,7 +351,7 @@ void LoadingBar::barRendererScaleChangedWithSize()
 void LoadingBar::setScale9Scale()
 {
     float width = (float)(_percent) / 100.0f * _totalLength;
-    static_cast<extension::Scale9Sprite*>(_barRenderer)->setPreferredSize(Size(width, _contentSize.height));
+    static_cast<Scale9Sprite*>(_barRenderer)->setPreferredSize(Size(width, _contentSize.height));
 }
 
 std::string LoadingBar::getDescription() const

--- a/cocos/ui/UIScale9Sprite.cpp
+++ b/cocos/ui/UIScale9Sprite.cpp
@@ -1,0 +1,25 @@
+/****************************************************************************
+ Copyright (c) 2013-2014 Chukong Technologies Inc.
+ 
+ http://www.cocos2d-x.org
+ 
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+ 
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+ 
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+ ****************************************************************************/
+
+#include "UIScale9Sprite.h"

--- a/cocos/ui/UIScale9Sprite.cpp
+++ b/cocos/ui/UIScale9Sprite.cpp
@@ -23,3 +23,921 @@
  ****************************************************************************/
 
 #include "UIScale9Sprite.h"
+#include "2d/CCSprite.h"
+#include "2d/CCSpriteFrameCache.h"
+#include "base/CCVector.h"
+#include "base/CCDirector.h"
+
+NS_CC_BEGIN
+namespace ui {
+    
+    Scale9Sprite::Scale9Sprite()
+    : _spritesGenerated(false)
+    , _spriteFrameRotated(false)
+    , _positionsAreDirty(false)
+    , _scale9Image(nullptr)
+    , _topLeft(nullptr)
+    , _top(nullptr)
+    , _topRight(nullptr)
+    , _left(nullptr)
+    , _centre(nullptr)
+    , _right(nullptr)
+    , _bottomLeft(nullptr)
+    , _bottom(nullptr)
+    , _bottomRight(nullptr)
+    , _insetLeft(0)
+    , _insetTop(0)
+    , _insetRight(0)
+    , _insetBottom(0),
+    _scale9Enabled(true)
+    {
+        this->setAnchorPoint(Vec2(0.5,0.5));
+    }
+    
+    Scale9Sprite::~Scale9Sprite()
+    {
+        this->cleanupSlicedSprites();
+        CC_SAFE_RELEASE(_scale9Image);
+    }
+    
+    void Scale9Sprite::cleanupSlicedSprites()
+    {
+        CC_SAFE_RELEASE(_topLeft);
+        CC_SAFE_RELEASE(_top);
+        CC_SAFE_RELEASE(_topRight);
+        CC_SAFE_RELEASE(_left);
+        CC_SAFE_RELEASE(_centre);
+        CC_SAFE_RELEASE(_right);
+        CC_SAFE_RELEASE(_bottomLeft);
+        CC_SAFE_RELEASE(_bottom);
+        CC_SAFE_RELEASE(_bottomRight);
+    }
+    
+    bool Scale9Sprite::init()
+    {
+        return this->init(NULL, Rect::ZERO, Rect::ZERO);
+    }
+    
+    bool Scale9Sprite::init(Sprite* sprite, const Rect& rect, const Rect& capInsets)
+    {
+        return this->init(sprite, rect, false, capInsets);
+    }
+    
+    bool Scale9Sprite::init(Sprite* sprite, const Rect& rect, bool rotated, const Rect& capInsets)
+    {
+        if(sprite)
+        {
+            this->updateWithSprite(sprite, rect, rotated, capInsets);
+        }
+        this->setCascadeColorEnabled(true);
+        this->setCascadeOpacityEnabled(true);
+        this->setAnchorPoint(Vec2(0.5f, 0.5f));
+        this->_positionsAreDirty = true;
+        
+        return true;
+    }
+    
+#define    TRANSLATE_X(x, y, xtranslate) \
+x+=xtranslate;                       \
+
+#define    TRANSLATE_Y(x, y, ytranslate) \
+y+=ytranslate;                       \
+
+    bool Scale9Sprite::updateWithSprite(Sprite* sprite, const Rect& originalRect, bool rotated, const Rect& capInsets)
+    {
+        GLubyte opacity = getOpacity();
+        Color3B color = getColor();
+        Rect rect(originalRect);
+        
+        // Release old sprites
+        _protectedChildren.clear();
+        
+        this->cleanupSlicedSprites();
+        
+        
+        if(this->_scale9Image != sprite)
+        {
+            CC_SAFE_RELEASE(this->_scale9Image);
+            _scale9Image = sprite;
+            CC_SAFE_RETAIN(_scale9Image);
+        }
+        
+        if (!_scale9Image)
+        {
+            return false;
+        }
+        
+        _capInsets = capInsets;
+        _spriteFrameRotated = rotated;
+        
+        // If there is no given rect
+        if ( rect.equals(Rect::ZERO) )
+        {
+            // Get the texture size as original
+            Size textureSize = _scale9Image->getTexture()->getContentSize();
+            
+            rect = Rect(0, 0, textureSize.width, textureSize.height);
+        }
+        
+        // Set the given rect's size as original size
+        _spriteRect = rect;
+        _originalSize = rect.size;
+        _preferredSize = _originalSize;
+        _capInsetsInternal = capInsets;
+        
+        
+        this->createSlicedSprites(rect, rotated);
+        
+        this->setContentSize(rect.size);
+        
+        if (_spritesGenerated)
+        {
+            // Restore color and opacity
+            this->setOpacity(opacity);
+            this->setColor(color);
+        }
+        _spritesGenerated = true;
+        
+        return true;
+    }
+    
+    void Scale9Sprite::createSlicedSprites(const Rect& rect, bool rotated)
+    {
+        float w = rect.size.width;
+        float h = rect.size.height;
+        
+        // If there is no specified center region
+        if ( _capInsetsInternal.equals(Rect::ZERO) )
+        {
+            // log("... cap insets not specified : using default cap insets ...");
+            _capInsetsInternal = Rect(w/3, h/3, w/3, h/3);
+        }
+        
+        float left_w = _capInsetsInternal.origin.x;
+        float center_w = _capInsetsInternal.size.width;
+        float right_w = rect.size.width - (left_w + center_w);
+        
+        float top_h = _capInsetsInternal.origin.y;
+        float center_h = _capInsetsInternal.size.height;
+        float bottom_h = rect.size.height - (top_h + center_h);
+        
+        // calculate rects
+        
+        // ... top row
+        float x = 0.0;
+        float y = 0.0;
+        
+        // top left
+        Rect lefttopbounds = Rect(x, y, left_w, top_h);
+        
+        // top center
+        TRANSLATE_X(x, y, left_w);
+        Rect centertopbounds = Rect(x, y, center_w, top_h);
+        
+        // top right
+        TRANSLATE_X(x, y, center_w);
+        Rect righttopbounds = Rect(x, y, right_w, top_h);
+        
+        // ... center row
+        x = 0.0;
+        y = 0.0;
+        TRANSLATE_Y(x, y, top_h);
+        
+        // center left
+        Rect leftcenterbounds = Rect(x, y, left_w, center_h);
+        
+        // center center
+        TRANSLATE_X(x, y, left_w);
+        Rect centerbounds = Rect(x, y, center_w, center_h);
+        
+        // center right
+        TRANSLATE_X(x, y, center_w);
+        Rect rightcenterbounds = Rect(x, y, right_w, center_h);
+        
+        // ... bottom row
+        x = 0.0;
+        y = 0.0;
+        TRANSLATE_Y(x, y, top_h);
+        TRANSLATE_Y(x, y, center_h);
+        
+        // bottom left
+        Rect leftbottombounds = Rect(x, y, left_w, bottom_h);
+        
+        // bottom center
+        TRANSLATE_X(x, y, left_w);
+        Rect centerbottombounds = Rect(x, y, center_w, bottom_h);
+        
+        // bottom right
+        TRANSLATE_X(x, y, center_w);
+        Rect rightbottombounds = Rect(x, y, right_w, bottom_h);
+        
+        
+        Rect rotatedcenterbounds = centerbounds;
+        Rect rotatedrightbottombounds = rightbottombounds;
+        Rect rotatedleftbottombounds = leftbottombounds;
+        Rect rotatedrighttopbounds = righttopbounds;
+        Rect rotatedlefttopbounds = lefttopbounds;
+        Rect rotatedrightcenterbounds = rightcenterbounds;
+        Rect rotatedleftcenterbounds = leftcenterbounds;
+        Rect rotatedcenterbottombounds = centerbottombounds;
+        Rect rotatedcentertopbounds = centertopbounds;
+        
+        if (!rotated) {
+            // log("!rotated");
+            
+            AffineTransform t = AffineTransform::IDENTITY;
+            t = AffineTransformTranslate(t, rect.origin.x, rect.origin.y);
+            
+            rotatedcenterbounds = RectApplyAffineTransform(rotatedcenterbounds, t);
+            rotatedrightbottombounds = RectApplyAffineTransform(rotatedrightbottombounds, t);
+            rotatedleftbottombounds = RectApplyAffineTransform(rotatedleftbottombounds, t);
+            rotatedrighttopbounds = RectApplyAffineTransform(rotatedrighttopbounds, t);
+            rotatedlefttopbounds = RectApplyAffineTransform(rotatedlefttopbounds, t);
+            rotatedrightcenterbounds = RectApplyAffineTransform(rotatedrightcenterbounds, t);
+            rotatedleftcenterbounds = RectApplyAffineTransform(rotatedleftcenterbounds, t);
+            rotatedcenterbottombounds = RectApplyAffineTransform(rotatedcenterbottombounds, t);
+            rotatedcentertopbounds = RectApplyAffineTransform(rotatedcentertopbounds, t);
+            
+            
+        } else {
+            // set up transformation of coordinates
+            // to handle the case where the sprite is stored rotated
+            // in the spritesheet
+            // log("rotated");
+            
+            AffineTransform t = AffineTransform::IDENTITY;
+            
+            t = AffineTransformTranslate(t, rect.size.height+rect.origin.x, rect.origin.y);
+            t = AffineTransformRotate(t, 1.57079633f);
+            
+            centerbounds = RectApplyAffineTransform(centerbounds, t);
+            rightbottombounds = RectApplyAffineTransform(rightbottombounds, t);
+            leftbottombounds = RectApplyAffineTransform(leftbottombounds, t);
+            righttopbounds = RectApplyAffineTransform(righttopbounds, t);
+            lefttopbounds = RectApplyAffineTransform(lefttopbounds, t);
+            rightcenterbounds = RectApplyAffineTransform(rightcenterbounds, t);
+            leftcenterbounds = RectApplyAffineTransform(leftcenterbounds, t);
+            centerbottombounds = RectApplyAffineTransform(centerbottombounds, t);
+            centertopbounds = RectApplyAffineTransform(centertopbounds, t);
+            
+            rotatedcenterbounds.origin = centerbounds.origin;
+            rotatedrightbottombounds.origin = rightbottombounds.origin;
+            rotatedleftbottombounds.origin = leftbottombounds.origin;
+            rotatedrighttopbounds.origin = righttopbounds.origin;
+            rotatedlefttopbounds.origin = lefttopbounds.origin;
+            rotatedrightcenterbounds.origin = rightcenterbounds.origin;
+            rotatedleftcenterbounds.origin = leftcenterbounds.origin;
+            rotatedcenterbottombounds.origin = centerbottombounds.origin;
+            rotatedcentertopbounds.origin = centertopbounds.origin;
+            
+            
+        }
+        
+        
+        // Centre
+        _centre = Sprite::createWithTexture(_scale9Image->getTexture(), rotatedcenterbounds, rotated);
+        _centre->retain();
+        this->addProtectedChild(_centre);
+        
+        
+        // Top
+        _top = Sprite::createWithTexture(_scale9Image->getTexture(), rotatedcentertopbounds, rotated);
+        _top->retain();
+        this->addProtectedChild(_top);
+        
+        // Bottom
+        _bottom = Sprite::createWithTexture(_scale9Image->getTexture(), rotatedcenterbottombounds, rotated);
+        _bottom->retain();
+        this->addProtectedChild(_bottom);
+        
+        // Left
+        _left = Sprite::createWithTexture(_scale9Image->getTexture(), rotatedleftcenterbounds, rotated);
+        _left->retain();
+        this->addProtectedChild(_left);
+        
+        // Right
+        _right = Sprite::createWithTexture(_scale9Image->getTexture(), rotatedrightcenterbounds, rotated);
+        _right->retain();
+        this->addProtectedChild(_right);
+        
+        // Top left
+        _topLeft = Sprite::createWithTexture(_scale9Image->getTexture(), rotatedlefttopbounds, rotated);
+        _topLeft->retain();
+        this->addProtectedChild(_topLeft);
+        
+        // Top right
+        _topRight = Sprite::createWithTexture(_scale9Image->getTexture(), rotatedrighttopbounds, rotated);
+        _topRight->retain();
+        this->addProtectedChild(_topRight);
+        
+        // Bottom left
+        _bottomLeft = Sprite::createWithTexture(_scale9Image->getTexture(), rotatedleftbottombounds, rotated);
+        _bottomLeft->retain();
+        this->addProtectedChild(_bottomLeft);
+        
+        // Bottom right
+        _bottomRight = Sprite::createWithTexture(_scale9Image->getTexture(), rotatedrightbottombounds, rotated);
+        _bottomRight->retain();
+        this->addProtectedChild(_bottomRight);
+    }
+    
+    void Scale9Sprite::setContentSize(const Size &size)
+    {
+        Node::setContentSize(size);
+        this->_positionsAreDirty = true;
+    }
+    
+    void Scale9Sprite::updatePositions()
+    {
+        // Check that instances are non-NULL
+        if(!((_topLeft) &&
+             (_topRight) &&
+             (_bottomRight) &&
+             (_bottomLeft) &&
+             (_centre))) {
+            // if any of the above sprites are NULL, return
+            return;
+        }
+        
+        Size size = this->_contentSize;
+        
+        float sizableWidth = size.width - _topLeft->getContentSize().width - _topRight->getContentSize().width;
+        float sizableHeight = size.height - _topLeft->getContentSize().height - _bottomRight->getContentSize().height;
+        
+        float horizontalScale = sizableWidth/_centre->getContentSize().width;
+        float verticalScale = sizableHeight/_centre->getContentSize().height;
+        
+        _centre->setScaleX(horizontalScale);
+        _centre->setScaleY(verticalScale);
+        
+        float rescaledWidth = _centre->getContentSize().width * horizontalScale;
+        float rescaledHeight = _centre->getContentSize().height * verticalScale;
+        
+        float leftWidth = _bottomLeft->getContentSize().width;
+        float bottomHeight = _bottomLeft->getContentSize().height;
+        
+        _bottomLeft->setAnchorPoint(Vec2(0,0));
+        _bottomRight->setAnchorPoint(Vec2(0,0));
+        _topLeft->setAnchorPoint(Vec2(0,0));
+        _topRight->setAnchorPoint(Vec2(0,0));
+        _left->setAnchorPoint(Vec2(0,0));
+        _right->setAnchorPoint(Vec2(0,0));
+        _top->setAnchorPoint(Vec2(0,0));
+        _bottom->setAnchorPoint(Vec2(0,0));
+        _centre->setAnchorPoint(Vec2(0,0));
+        
+        // Position corners
+        _bottomLeft->setPosition(Vec2(0,0));
+        _bottomRight->setPosition(Vec2(leftWidth+rescaledWidth,0));
+        _topLeft->setPosition(Vec2(0, bottomHeight+rescaledHeight));
+        _topRight->setPosition(Vec2(leftWidth+rescaledWidth, bottomHeight+rescaledHeight));
+        
+        // Scale and position borders
+        _left->setPosition(Vec2(0, bottomHeight));
+        _left->setScaleY(verticalScale);
+        _right->setPosition(Vec2(leftWidth+rescaledWidth,bottomHeight));
+        _right->setScaleY(verticalScale);
+        _bottom->setPosition(Vec2(leftWidth,0));
+        _bottom->setScaleX(horizontalScale);
+        _top->setPosition(Vec2(leftWidth,bottomHeight+rescaledHeight));
+        _top->setScaleX(horizontalScale);
+        
+        // Position centre
+        _centre->setPosition(Vec2(leftWidth, bottomHeight));
+    }
+    
+    bool Scale9Sprite::initWithFile(const std::string& file, const Rect& rect,  const Rect& capInsets)
+    {
+        Sprite *sprite = Sprite::create(file);
+        bool pReturn = this->init(sprite, rect, capInsets);
+        return pReturn;
+    }
+    
+    Scale9Sprite* Scale9Sprite::create(const std::string& file, const Rect& rect,  const Rect& capInsets)
+    {
+        Scale9Sprite* pReturn = new Scale9Sprite();
+        if ( pReturn && pReturn->initWithFile(file, rect, capInsets) )
+        {
+            pReturn->autorelease();
+            return pReturn;
+        }
+        CC_SAFE_DELETE(pReturn);
+        return NULL;
+    }
+    
+    bool Scale9Sprite::initWithFile(const std::string& file, const Rect& rect)
+    {
+        bool pReturn = this->initWithFile(file, rect, Rect::ZERO);
+        return pReturn;
+    }
+    
+    Scale9Sprite* Scale9Sprite::create(const std::string& file, const Rect& rect)
+    {
+        Scale9Sprite* pReturn = new Scale9Sprite();
+        if ( pReturn && pReturn->initWithFile(file, rect) )
+        {
+            pReturn->autorelease();
+            return pReturn;
+        }
+        CC_SAFE_DELETE(pReturn);
+        return NULL;
+    }
+    
+    
+    bool Scale9Sprite::initWithFile(const Rect& capInsets, const std::string& file)
+    {
+        bool pReturn = this->initWithFile(file, Rect::ZERO, capInsets);
+        return pReturn;
+    }
+    
+    Scale9Sprite* Scale9Sprite::create(const Rect& capInsets, const std::string& file)
+    {
+        Scale9Sprite* pReturn = new Scale9Sprite();
+        if ( pReturn && pReturn->initWithFile(capInsets, file) )
+        {
+            pReturn->autorelease();
+            return pReturn;
+        }
+        CC_SAFE_DELETE(pReturn);
+        return NULL;
+    }
+    
+    bool Scale9Sprite::initWithFile(const std::string& file)
+    {
+        bool pReturn = this->initWithFile(file, Rect::ZERO);
+        return pReturn;
+        
+    }
+    
+    Scale9Sprite* Scale9Sprite::create(const std::string& file)
+    {
+        Scale9Sprite* pReturn = new Scale9Sprite();
+        if ( pReturn && pReturn->initWithFile(file) )
+        {
+            pReturn->autorelease();
+            return pReturn;
+        }
+        CC_SAFE_DELETE(pReturn);
+        return NULL;
+    }
+    
+    bool Scale9Sprite::initWithSpriteFrame(SpriteFrame* spriteFrame, const Rect& capInsets)
+    {
+        Texture2D* texture = spriteFrame->getTexture();
+        CCASSERT(texture != NULL, "CCTexture must be not nil");
+        
+        Sprite *sprite = Sprite::createWithSpriteFrame(spriteFrame);
+        CCASSERT(sprite != NULL, "sprite must be not nil");
+        
+        bool pReturn = this->init(sprite, spriteFrame->getRect(), spriteFrame->isRotated(), capInsets);
+        return pReturn;
+    }
+    
+    Scale9Sprite* Scale9Sprite::createWithSpriteFrame(SpriteFrame* spriteFrame, const Rect& capInsets)
+    {
+        Scale9Sprite* pReturn = new Scale9Sprite();
+        if ( pReturn && pReturn->initWithSpriteFrame(spriteFrame, capInsets) )
+        {
+            pReturn->autorelease();
+            return pReturn;
+        }
+        CC_SAFE_DELETE(pReturn);
+        return NULL;
+    }
+    bool Scale9Sprite::initWithSpriteFrame(SpriteFrame* spriteFrame)
+    {
+        CCASSERT(spriteFrame != NULL, "Invalid spriteFrame for sprite");
+        bool pReturn = this->initWithSpriteFrame(spriteFrame, Rect::ZERO);
+        return pReturn;
+    }
+    
+    Scale9Sprite* Scale9Sprite::createWithSpriteFrame(SpriteFrame* spriteFrame)
+    {
+        Scale9Sprite* pReturn = new Scale9Sprite();
+        if ( pReturn && pReturn->initWithSpriteFrame(spriteFrame) )
+        {
+            pReturn->autorelease();
+            return pReturn;
+        }
+        CC_SAFE_DELETE(pReturn);
+        return NULL;
+    }
+    
+    bool Scale9Sprite::initWithSpriteFrameName(const std::string& spriteFrameName, const Rect& capInsets)
+    {
+        CCASSERT((SpriteFrameCache::getInstance()) != NULL, "SpriteFrameCache::getInstance() must be non-NULL");
+        
+        SpriteFrame *frame = SpriteFrameCache::getInstance()->getSpriteFrameByName(spriteFrameName);
+        CCASSERT(frame != NULL, "CCSpriteFrame must be non-NULL");
+        
+        if (NULL == frame) return false;
+        
+        bool pReturn = this->initWithSpriteFrame(frame, capInsets);
+        return pReturn;
+    }
+    
+    Scale9Sprite* Scale9Sprite::createWithSpriteFrameName(const std::string& spriteFrameName, const Rect& capInsets)
+    {
+        Scale9Sprite* pReturn = new Scale9Sprite();
+        if ( pReturn && pReturn->initWithSpriteFrameName(spriteFrameName, capInsets) )
+        {
+            pReturn->autorelease();
+            return pReturn;
+        }
+        CC_SAFE_DELETE(pReturn);
+        return NULL;
+    }
+    
+    bool Scale9Sprite::initWithSpriteFrameName(const std::string& spriteFrameName)
+    {
+        bool pReturn = this->initWithSpriteFrameName(spriteFrameName, Rect::ZERO);
+        return pReturn;
+    }
+    
+    Scale9Sprite* Scale9Sprite::createWithSpriteFrameName(const std::string& spriteFrameName)
+    {
+        Scale9Sprite* pReturn = new Scale9Sprite();
+        if ( pReturn && pReturn->initWithSpriteFrameName(spriteFrameName) )
+        {
+            pReturn->autorelease();
+            return pReturn;
+        }
+        CC_SAFE_DELETE(pReturn);
+        
+        log("Could not allocate Scale9Sprite()");
+        return NULL;
+        
+    }
+    
+    Scale9Sprite* Scale9Sprite::resizableSpriteWithCapInsets(const Rect& capInsets)
+    {
+        Scale9Sprite* pReturn = new Scale9Sprite();
+        if ( pReturn && pReturn->init(_scale9Image, _spriteRect, capInsets) )
+        {
+            pReturn->autorelease();
+            return pReturn;
+        }
+        CC_SAFE_DELETE(pReturn);
+        return NULL;
+    }
+    
+    Scale9Sprite* Scale9Sprite::create()
+    {
+        Scale9Sprite *pReturn = new Scale9Sprite();
+        if (pReturn && pReturn->init())
+        {
+            pReturn->autorelease();
+            return pReturn;
+        }
+        CC_SAFE_DELETE(pReturn);
+        return NULL;
+    }
+    
+    /** sets the opacity.
+     @warning If the the texture has premultiplied alpha then, the R, G and B channels will be modifed.
+     Values goes from 0 to 255, where 255 means fully opaque.
+     */
+    
+    
+    
+    void Scale9Sprite::updateCapInset()
+    {
+        Rect insets;
+        if (this->_insetLeft == 0 && this->_insetTop == 0 && this->_insetRight == 0 && this->_insetBottom == 0)
+        {
+            insets = Rect::ZERO;
+        }
+        else
+        {
+            insets = Rect(_insetLeft,
+                          _insetTop,
+                          _spriteRect.size.width-_insetLeft-_insetRight,
+                          _spriteRect.size.height-_insetTop-_insetBottom);
+        }
+        this->setCapInsets(insets);
+    }
+    
+    
+    void Scale9Sprite::setSpriteFrame(SpriteFrame * spriteFrame)
+    {
+        Sprite * sprite = Sprite::createWithTexture(spriteFrame->getTexture());
+        this->updateWithSprite(sprite, spriteFrame->getRect(), spriteFrame->isRotated(), Rect::ZERO);
+        
+        // Reset insets
+        this->_insetLeft = 0;
+        this->_insetTop = 0;
+        this->_insetRight = 0;
+        this->_insetBottom = 0;
+    }
+    
+    void Scale9Sprite::setPreferredSize(const Size& preferedSize)
+    {
+        this->setContentSize(preferedSize);
+        this->_preferredSize = preferedSize;
+    }
+    
+    
+    void Scale9Sprite::setCapInsets(const Rect& capInsets)
+    {
+        Size contentSize = this->_contentSize;
+        this->updateWithSprite(this->_scale9Image, this->_spriteRect, _spriteFrameRotated, capInsets);
+        this->setContentSize(contentSize);
+    }
+    
+    
+    void Scale9Sprite::setInsetLeft(float insetLeft)
+    {
+        this->_insetLeft = insetLeft;
+        this->updateCapInset();
+    }
+    
+    void Scale9Sprite::setInsetTop(float insetTop)
+    {
+        this->_insetTop = insetTop;
+        this->updateCapInset();
+    }
+    
+    void Scale9Sprite::setInsetRight(float insetRight)
+    {
+        this->_insetRight = insetRight;
+        this->updateCapInset();
+    }
+    
+    void Scale9Sprite::setInsetBottom(float insetBottom)
+    {
+        this->_insetBottom = insetBottom;
+        this->updateCapInset();
+    }
+    
+    void Scale9Sprite::visit(Renderer *renderer, const Mat4 &parentTransform, uint32_t parentFlags)
+    {
+        
+        // quick return if not visible. children won't be drawn.
+        if (!_visible)
+        {
+            return;
+        }
+        
+        uint32_t flags = processParentFlags(parentTransform, parentFlags);
+        
+        // IMPORTANT:
+        // To ease the migration to v3.0, we still support the Mat4 stack,
+        // but it is deprecated and your code should not rely on it
+        Director* director = Director::getInstance();
+        CCASSERT(nullptr != director, "Director is null when seting matrix stack");
+        director->pushMatrix(MATRIX_STACK_TYPE::MATRIX_STACK_MODELVIEW);
+        director->loadMatrix(MATRIX_STACK_TYPE::MATRIX_STACK_MODELVIEW, _modelViewTransform);
+        
+        int i = 0;      // used by _children
+        int j = 0;      // used by _protectedChildren
+        
+        sortAllChildren();
+        sortAllProtectedChildren();
+        
+        //
+        // draw children and protectedChildren zOrder < 0
+        //
+        for( ; i < _children.size(); i++ )
+        {
+            auto node = _children.at(i);
+            
+            if ( node && node->getLocalZOrder() < 0 )
+                node->visit(renderer, _modelViewTransform, flags);
+            else
+                break;
+        }
+        if (_scale9Enabled) {
+            for( ; j < _protectedChildren.size(); j++ )
+            {
+                auto node = _protectedChildren.at(j);
+                
+                if ( node && node->getLocalZOrder() < 0 )
+                    node->visit(renderer, _modelViewTransform, flags);
+                else
+                    break;
+            }
+        }else{
+            if (_scale9Image) {
+                _scale9Image->visit(renderer, _modelViewTransform, flags);
+            }
+        }
+        
+        
+        
+        
+        
+        //
+        // draw self
+        //
+        this->draw(renderer, _modelViewTransform, flags);
+        
+        //
+        // draw children and protectedChildren zOrder >= 0
+        //
+        if (_scale9Enabled) {
+            for(auto it=_protectedChildren.cbegin()+j; it != _protectedChildren.cend(); ++it)
+                (*it)->visit(renderer, _modelViewTransform, flags);
+        }else{
+            if (_scale9Image) {
+                _scale9Image->visit(renderer, _modelViewTransform, flags);
+            }
+        }
+        
+        
+        
+        for(auto it=_children.cbegin()+i; it != _children.cend(); ++it)
+            (*it)->visit(renderer, _modelViewTransform, flags);
+        
+        // reset for next frame
+        _orderOfArrival = 0;
+        
+        director->popMatrix(MATRIX_STACK_TYPE::MATRIX_STACK_MODELVIEW);
+        
+    }
+    
+    Size Scale9Sprite::getOriginalSize()const
+    {
+        return _originalSize;
+    }
+    
+    
+    Size Scale9Sprite::getPreferredSize() const
+    {
+        return _preferredSize;
+    }
+    
+    Rect Scale9Sprite::getCapInsets()const
+    {
+        return _capInsets;
+    }
+    
+    
+    float Scale9Sprite::getInsetLeft()const
+    {
+        return this->_insetLeft;
+    }
+    
+    float Scale9Sprite::getInsetTop()const
+    {
+        return this->_insetTop;
+    }
+    
+    float Scale9Sprite::getInsetRight()const
+    {
+        return this->_insetRight;
+    }
+    
+    float Scale9Sprite::getInsetBottom()const
+    {
+        return this->_insetBottom;
+    }
+    
+    void Scale9Sprite::setScale9Enabled(bool enabled)
+    {
+        _scale9Enabled = enabled;
+        _reorderProtectedChildDirty = true;
+    }
+    
+    bool Scale9Sprite::getScale9Enabled() const
+    {
+        return _scale9Enabled;
+    }
+    
+    void Scale9Sprite::addProtectedChild(cocos2d::Node *child)
+    {
+        _reorderProtectedChildDirty = true;
+        _protectedChildren.pushBack(child);
+    }
+    
+    void Scale9Sprite::sortAllProtectedChildren()
+    {
+        if(this->_positionsAreDirty)
+        {
+            this->updatePositions();
+            this->_positionsAreDirty = false;
+        }
+        if( _reorderProtectedChildDirty ) {
+            if (!_scale9Enabled) {
+                this->adjustScale9ImagePosition();
+            }
+            std::sort( std::begin(_protectedChildren), std::end(_protectedChildren), nodeComparisonLess );
+            _reorderProtectedChildDirty = false;
+        }
+    }
+    
+    void Scale9Sprite::adjustScale9ImagePosition()
+    {
+        if (_scale9Image) {
+            _scale9Image->setPosition(_scale9Image->getPosition() + Vec2(_originalSize.width/2, _originalSize.height/2));
+        }
+    }
+    
+    void Scale9Sprite::cleanup()
+    {
+        Node::cleanup();
+        // timers
+        for( const auto &child: _protectedChildren)
+            child->cleanup();
+    }
+    
+    void Scale9Sprite::onEnter()
+    {
+#if CC_ENABLE_SCRIPT_BINDING
+        if (_scriptType == kScriptTypeJavascript)
+        {
+            if (ScriptEngineManager::sendNodeEventToJSExtended(this, kNodeOnEnter))
+                return;
+        }
+#endif
+        Node::onEnter();
+        for( const auto &child: _protectedChildren)
+            child->onEnter();
+    }
+    
+    void Scale9Sprite::onExit()
+    {
+        Node::onExit();
+        for( const auto &child: _protectedChildren)
+            child->onExit();
+    }
+    
+    void Scale9Sprite::onEnterTransitionDidFinish()
+    {
+        Node::onEnterTransitionDidFinish();
+        for( const auto &child: _protectedChildren)
+            child->onEnterTransitionDidFinish();
+    }
+    
+    void Scale9Sprite::onExitTransitionDidStart()
+    {
+        Node::onExitTransitionDidStart();
+        for( const auto &child: _protectedChildren)
+            child->onExitTransitionDidStart();
+    }
+    
+    void Scale9Sprite::updateDisplayedColor(const cocos2d::Color3B &parentColor)
+    {
+        _displayedColor.r = _realColor.r * parentColor.r/255.0;
+        _displayedColor.g = _realColor.g * parentColor.g/255.0;
+        _displayedColor.b = _realColor.b * parentColor.b/255.0;
+        updateColor();
+        
+        if (_scale9Image) {
+            _scale9Image->updateDisplayedColor(_displayedColor);
+        }
+        
+        for(const auto &child : _protectedChildren){
+            child->updateDisplayedColor(_displayedColor);
+        }
+        
+        if (_cascadeColorEnabled)
+        {
+            for(const auto &child : _children){
+                child->updateDisplayedColor(_displayedColor);
+            }
+            
+            
+        }
+    }
+    
+    void Scale9Sprite::updateDisplayedOpacity(GLubyte parentOpacity)
+    {
+        _displayedOpacity = _realOpacity * parentOpacity/255.0;
+        updateColor();
+        
+        if (_scale9Image) {
+            _scale9Image->updateDisplayedOpacity(_displayedOpacity);
+        }
+        
+        for(auto child : _protectedChildren){
+            child->updateDisplayedOpacity(_displayedOpacity);
+        }
+        
+        if (_cascadeOpacityEnabled)
+        {
+            for(auto child : _children){
+                child->updateDisplayedOpacity(_displayedOpacity);
+            }
+            
+            
+        }
+    }
+    
+    void Scale9Sprite::disableCascadeColor()
+    {
+        for(auto child : _children){
+            child->updateDisplayedColor(Color3B::WHITE);
+        }
+        for(auto child : _protectedChildren){
+            child->updateDisplayedColor(Color3B::WHITE);
+        }
+        if (_scale9Image) {
+            _scale9Image->updateDisplayedColor(Color3B::WHITE);
+        }
+    }
+    
+    Sprite* Scale9Sprite::getSprite()const
+    {
+        return _scale9Image;
+    }
+}}

--- a/cocos/ui/UIScale9Sprite.cpp
+++ b/cocos/ui/UIScale9Sprite.cpp
@@ -940,4 +940,34 @@ y+=ytranslate;                       \
     {
         return _scale9Image;
     }
+    
+    void Scale9Sprite::setFlippedX(bool flippedX)
+    {
+        _flippedX = flippedX;
+        if (_scale9Enabled) {
+            this->setScaleX(-1);
+        }else{
+            _scale9Image->setFlippedX(flippedX);
+        }
+    }
+    
+    void Scale9Sprite::setFlippedY(bool flippedY)
+    {
+        _flippedY = flippedY;
+        if (_scale9Enabled) {
+            this->setScaleY(-1);
+        }else{
+            _scale9Image->setFlippedY(flippedY);
+        }
+    }
+    
+    bool Scale9Sprite::isFlippedX()const
+    {
+        return _flippedX;
+    }
+    
+    bool Scale9Sprite::isFlippedY()const
+    {
+        return _flippedY;
+    }
 }}

--- a/cocos/ui/UIScale9Sprite.h
+++ b/cocos/ui/UIScale9Sprite.h
@@ -305,6 +305,43 @@ namespace ui {
         
         Sprite* getSprite()const;
         
+        /**
+         * Sets whether the widget should be flipped horizontally or not.
+         *
+         * @param bFlippedX true if the widget should be flipped horizaontally, false otherwise.
+         */
+        virtual void setFlippedX(bool flippedX);
+        
+        /**
+         * Returns the flag which indicates whether the widget is flipped horizontally or not.
+         *
+         * It only flips the texture of the widget, and not the texture of the widget's children.
+         * Also, flipping the texture doesn't alter the anchorPoint.
+         * If you want to flip the anchorPoint too, and/or to flip the children too use:
+         * widget->setScaleX(sprite->getScaleX() * -1);
+         *
+         * @return true if the widget is flipped horizaontally, false otherwise.
+         */
+        virtual bool isFlippedX()const;
+        
+        /**
+         * Sets whether the widget should be flipped vertically or not.
+         *
+         * @param bFlippedY true if the widget should be flipped vertically, flase otherwise.
+         */
+        virtual void setFlippedY(bool flippedY);
+
+        /**
+         * Return the flag which indicates whether the widget is flipped vertically or not.
+         *
+         * It only flips the texture of the widget, and not the texture of the widget's children.
+         * Also, flipping the texture doesn't alter the anchorPoint.
+         * If you want to flip the anchorPoint too, and/or to flip the children too use:
+         * widget->setScaleY(widget->getScaleY() * -1);
+         *
+         * @return true if the widget is flipped vertically, flase otherwise.
+         */
+        virtual bool isFlippedY()const;
         
     protected:
         void updateCapInset();
@@ -364,6 +401,9 @@ namespace ui {
         
         Vector<Node*> _protectedChildren;        ///holds the 9 sprites
         bool _reorderProtectedChildDirty;
+        
+        bool _flippedX;
+        bool _flippedY;
     };
     
 }}  //end of namespace

--- a/cocos/ui/UIScale9Sprite.h
+++ b/cocos/ui/UIScale9Sprite.h
@@ -29,6 +29,7 @@
 #include "2d/CCSpriteFrame.h"
 #include "2d/CCSpriteBatchNode.h"
 #include "base/CCPlatformMacros.h"
+#include "ui/GUIExport.h"
 
 NS_CC_BEGIN
 namespace ui {
@@ -42,7 +43,7 @@ namespace ui {
      * scaled.
      *
      */
-    class Scale9Sprite : public Node
+    class CC_GUI_DLL Scale9Sprite : public Node
     {
     public:
         /**

--- a/cocos/ui/UIScale9Sprite.h
+++ b/cocos/ui/UIScale9Sprite.h
@@ -25,6 +25,347 @@
 #ifndef __cocos2d_libs__UIScale9Sprite__
 #define __cocos2d_libs__UIScale9Sprite__
 
-#include <iostream>
+#include "2d/CCNode.h"
+#include "2d/CCSpriteFrame.h"
+#include "2d/CCSpriteBatchNode.h"
+#include "base/CCPlatformMacros.h"
+
+NS_CC_BEGIN
+namespace ui {
+    
+    /**
+     * A 9-slice sprite for cocos2d.
+     *
+     * 9-slice scaling allows you to specify how scaling is applied
+     * to specific areas of a sprite. With 9-slice scaling (3x3 grid),
+     * you can ensure that the sprite does not become distorted when
+     * scaled.
+     *
+     */
+    class Scale9Sprite : public Node
+    {
+    public:
+        /**
+         * @js ctor
+         */
+        Scale9Sprite();
+        /**
+         * @js NA
+         * @lua NA
+         */
+        virtual ~Scale9Sprite();
+        
+    public:
+        static Scale9Sprite* create();
+        
+        /**
+         * Creates a 9-slice sprite with a texture file, a delimitation zone and
+         * with the specified cap insets.
+         *
+         * @see initWithFile(const char *file, const Rect& rect, const Rect& capInsets)
+         */
+        static Scale9Sprite* create(const std::string& file, const Rect& rect,  const Rect& capInsets);
+        
+        /**
+         * Creates a 9-slice sprite with a texture file. The whole texture will be
+         * broken down into a 3×3 grid of equal blocks.
+         *
+         * @see initWithFile(const Rect& capInsets, const char *file)
+         */
+        static Scale9Sprite* create(const Rect& capInsets, const std::string& file);
+        
+        /**
+         * Creates a 9-slice sprite with a texture file and a delimitation zone. The
+         * texture will be broken down into a 3×3 grid of equal blocks.
+         *
+         * @see initWithFile(const char *file, const Rect& rect)
+         */
+        static Scale9Sprite* create(const std::string& file, const Rect& rect);
+        
+        /**
+         * Creates a 9-slice sprite with a texture file. The whole texture will be
+         * broken down into a 3×3 grid of equal blocks.
+         *
+         * @see initWithFile(const char *file)
+         */
+        static Scale9Sprite* create(const std::string& file);
+        
+        /**
+         * Creates a 9-slice sprite with an sprite frame.
+         * Once the sprite is created, you can then call its "setContentSize:" method
+         * to resize the sprite will all it's 9-slice goodness intract.
+         * It respects the anchorPoint too.
+         *
+         * @see initWithSpriteFrame(SpriteFrame *spriteFrame)
+         */
+        static Scale9Sprite* createWithSpriteFrame(SpriteFrame* spriteFrame);
+        
+        /**
+         * Creates a 9-slice sprite with an sprite frame and the centre of its zone.
+         * Once the sprite is created, you can then call its "setContentSize:" method
+         * to resize the sprite will all it's 9-slice goodness intract.
+         * It respects the anchorPoint too.
+         *
+         * @see initWithSpriteFrame(SpriteFrame *spriteFrame, const Rect& capInsets)
+         */
+        static Scale9Sprite* createWithSpriteFrame(SpriteFrame* spriteFrame, const Rect& capInsets);
+        
+        /**
+         * Creates a 9-slice sprite with an sprite frame name.
+         * Once the sprite is created, you can then call its "setContentSize:" method
+         * to resize the sprite will all it's 9-slice goodness intract.
+         * It respects the anchorPoint too.
+         *
+         * @see initWithSpriteFrameName(const char *spriteFrameName)
+         */
+        static Scale9Sprite* createWithSpriteFrameName(const std::string& spriteFrameName);
+        
+        /**
+         * Creates a 9-slice sprite with an sprite frame name and the centre of its
+         * zone.
+         * Once the sprite is created, you can then call its "setContentSize:" method
+         * to resize the sprite will all it's 9-slice goodness intract.
+         * It respects the anchorPoint too.
+         *
+         * @see initWithSpriteFrameName(const char *spriteFrameName, const Rect& capInsets)
+         */
+        static Scale9Sprite* createWithSpriteFrameName(const std::string& spriteFrameName, const Rect& capInsets);
+        
+        /**
+         * Initializes a 9-slice sprite with a texture file, a delimitation zone and
+         * with the specified cap insets.
+         * Once the sprite is created, you can then call its "setContentSize:" method
+         * to resize the sprite will all it's 9-slice goodness intract.
+         * It respects the anchorPoint too.
+         *
+         * @param file The name of the texture file.
+         * @param rect The rectangle that describes the sub-part of the texture that
+         * is the whole image. If the shape is the whole texture, set this to the
+         * texture's full rect.
+         * @param capInsets The values to use for the cap insets.
+         */
+        virtual bool initWithFile(const std::string& file, const Rect& rect,  const Rect& capInsets);
+        
+        /**
+         * Initializes a 9-slice sprite with a texture file and a delimitation zone. The
+         * texture will be broken down into a 3×3 grid of equal blocks.
+         * Once the sprite is created, you can then call its "setContentSize:" method
+         * to resize the sprite will all it's 9-slice goodness intract.
+         * It respects the anchorPoint too.
+         *
+         * @param file The name of the texture file.
+         * @param rect The rectangle that describes the sub-part of the texture that
+         * is the whole image. If the shape is the whole texture, set this to the
+         * texture's full rect.
+         */
+        virtual bool initWithFile(const std::string& file, const Rect& rect);
+        
+        /**
+         * Initializes a 9-slice sprite with a texture file and with the specified cap
+         * insets.
+         * Once the sprite is created, you can then call its "setContentSize:" method
+         * to resize the sprite will all it's 9-slice goodness intract.
+         * It respects the anchorPoint too.
+         *
+         * @param file The name of the texture file.
+         * @param capInsets The values to use for the cap insets.
+         */
+        virtual bool initWithFile(const Rect& capInsets, const std::string& file);
+        
+        /**
+         * Initializes a 9-slice sprite with a texture file. The whole texture will be
+         * broken down into a 3×3 grid of equal blocks.
+         * Once the sprite is created, you can then call its "setContentSize:" method
+         * to resize the sprite will all it's 9-slice goodness intract.
+         * It respects the anchorPoint too.
+         *
+         * @param file The name of the texture file.
+         */
+        virtual bool initWithFile(const std::string& file);
+        
+        /**
+         * Initializes a 9-slice sprite with an sprite frame and with the specified
+         * cap insets.
+         * Once the sprite is created, you can then call its "setContentSize:" method
+         * to resize the sprite will all it's 9-slice goodness intract.
+         * It respects the anchorPoint too.
+         *
+         * @param spriteFrame The sprite frame object.
+         * @param capInsets The values to use for the cap insets.
+         */
+        virtual bool initWithSpriteFrame(SpriteFrame* spriteFrame, const Rect& capInsets);
+        
+        /**
+         * Initializes a 9-slice sprite with an sprite frame.
+         * Once the sprite is created, you can then call its "setContentSize:" method
+         * to resize the sprite will all it's 9-slice goodness intract.
+         * It respects the anchorPoint too.
+         *
+         * @param spriteFrame The sprite frame object.
+         */
+        virtual bool initWithSpriteFrame(SpriteFrame* spriteFrame);
+        
+        /**
+         * Initializes a 9-slice sprite with an sprite frame name and with the specified
+         * cap insets.
+         * Once the sprite is created, you can then call its "setContentSize:" method
+         * to resize the sprite will all it's 9-slice goodness intract.
+         * It respects the anchorPoint too.
+         *
+         * @param spriteFrameName The sprite frame name.
+         * @param capInsets The values to use for the cap insets.
+         */
+        virtual bool initWithSpriteFrameName(const std::string& spriteFrameName, const Rect& capInsets);
+        
+        /**
+         * Initializes a 9-slice sprite with an sprite frame name.
+         * Once the sprite is created, you can then call its "setContentSize:" method
+         * to resize the sprite will all it's 9-slice goodness intract.
+         * It respects the anchorPoint too.
+         *
+         * @param spriteFrameName The sprite frame name.
+         */
+        virtual bool initWithSpriteFrameName(const std::string& spriteFrameName);
+        
+        virtual bool init();
+        virtual bool init(Sprite* sprite, const Rect& rect, bool rotated, const Rect& capInsets);
+        virtual bool init(Sprite* sprite, const Rect& rect, const Rect& capInsets);
+        /**
+         * Creates and returns a new sprite object with the specified cap insets.
+         * You use this method to add cap insets to a sprite or to change the existing
+         * cap insets of a sprite. In both cases, you get back a new image and the
+         * original sprite remains untouched.
+         *
+         * @param capInsets The values to use for the cap insets.
+         */
+        Scale9Sprite* resizableSpriteWithCapInsets(const Rect& capInsets);
+        
+        virtual bool updateWithSprite(Sprite* sprite, const Rect& rect, bool rotated, const Rect& capInsets);
+        virtual void setSpriteFrame(SpriteFrame * spriteFrame);
+        
+        // overrides
+        virtual void setContentSize(const Size & size) override;
+        
+        
+        Size getOriginalSize() const;
+        void setPreferredSize(const Size& size);
+        Size getPreferredSize() const;
+        void setCapInsets(const Rect& rect);
+        Rect getCapInsets()const;
+        void setInsetLeft(float leftInset);
+        float getInsetLeft()const;
+        void setInsetTop(float topInset);
+        float getInsetTop()const;
+        void setInsetRight(float rightInset);
+        float getInsetRight()const;
+        void setInsetBottom(float bottomInset);
+        float getInsetBottom()const;
+        void setScale9Enabled(bool enabled);
+        bool getScale9Enabled()const;
+        
+        
+        
+        /// @} end of Children and Parent
+        
+        virtual void visit(Renderer *renderer, const Mat4 &parentTransform, uint32_t parentFlags) override;
+        
+        virtual void cleanup() override;
+        
+        virtual void onEnter() override;
+        
+        /** Event callback that is invoked when the Node enters in the 'stage'.
+         * If the Node enters the 'stage' with a transition, this event is called when the transition finishes.
+         * If you override onEnterTransitionDidFinish, you shall call its parent's one, e.g. Node::onEnterTransitionDidFinish()
+         * @js NA
+         * @lua NA
+         */
+        virtual void onEnterTransitionDidFinish() override;
+        
+        /**
+         * Event callback that is invoked every time the Node leaves the 'stage'.
+         * If the Node leaves the 'stage' with a transition, this event is called when the transition finishes.
+         * During onExit you can't access a sibling node.
+         * If you override onExit, you shall call its parent's one, e.g., Node::onExit().
+         * @js NA
+         * @lua NA
+         */
+        virtual void onExit() override;
+        
+        /**
+         * Event callback that is called every time the Node leaves the 'stage'.
+         * If the Node leaves the 'stage' with a transition, this callback is called when the transition starts.
+         * @js NA
+         * @lua NA
+         */
+        virtual void onExitTransitionDidStart() override;
+        
+        virtual void updateDisplayedOpacity(GLubyte parentOpacity) override;
+        virtual void updateDisplayedColor(const Color3B& parentColor) override;
+        virtual void disableCascadeColor() override;
+        
+        Sprite* getSprite()const;
+        
+        
+    protected:
+        void updateCapInset();
+        void updatePositions();
+        void createSlicedSprites(const Rect& rect, bool rotated);
+        void cleanupSlicedSprites();
+        void adjustScale9ImagePosition();
+        /**
+         * Sorts the children array once before drawing, instead of every time when a child is added or reordered.
+         * This appraoch can improves the performance massively.
+         * @note Don't call this manually unless a child added needs to be removed in the same frame
+         */
+        virtual void sortAllProtectedChildren();
+        
+        bool _spritesGenerated;
+        Rect _spriteRect;
+        bool   _spriteFrameRotated;
+        Rect _capInsetsInternal;
+        bool _positionsAreDirty;
+        
+        Sprite* _scale9Image; //the original sprite
+        Sprite* _topLeft;
+        Sprite* _top;
+        Sprite* _topRight;
+        Sprite* _left;
+        Sprite* _centre;
+        Sprite* _right;
+        Sprite* _bottomLeft;
+        Sprite* _bottom;
+        Sprite* _bottomRight;
+        
+        bool _scale9Enabled;
+        
+        /** Original sprite's size. */
+        Size _originalSize;
+        /** Prefered sprite's size. By default the prefered size is the original size. */
+        
+        //if the preferredSize component is given as -1, it is ignored
+        Size _preferredSize;
+        /**
+         * The end-cap insets.
+         * On a non-resizeable sprite, this property is set to CGRect::ZERO; the sprite
+         * does not use end caps and the entire sprite is subject to stretching.
+         */
+        Rect _capInsets;
+        /** Sets the left side inset */
+        float _insetLeft;
+        /** Sets the top side inset */
+        float _insetTop;
+        /** Sets the right side inset */
+        float _insetRight;
+        /** Sets the bottom side inset */
+        float _insetBottom;
+        
+        /// helper that reorder a child
+        void addProtectedChild(Node* child);
+        
+        Vector<Node*> _protectedChildren;        ///holds the 9 sprites
+        bool _reorderProtectedChildDirty;
+    };
+    
+}}  //end of namespace
 
 #endif /* defined(__cocos2d_libs__UIScale9Sprite__) */

--- a/cocos/ui/UIScale9Sprite.h
+++ b/cocos/ui/UIScale9Sprite.h
@@ -1,0 +1,30 @@
+/****************************************************************************
+ Copyright (c) 2013-2014 Chukong Technologies Inc.
+ 
+ http://www.cocos2d-x.org
+ 
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+ 
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+ 
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+ ****************************************************************************/
+
+#ifndef __cocos2d_libs__UIScale9Sprite__
+#define __cocos2d_libs__UIScale9Sprite__
+
+#include <iostream>
+
+#endif /* defined(__cocos2d_libs__UIScale9Sprite__) */

--- a/cocos/ui/UISlider.cpp
+++ b/cocos/ui/UISlider.cpp
@@ -23,7 +23,7 @@ THE SOFTWARE.
 ****************************************************************************/
 
 #include "ui/UISlider.h"
-#include "extensions/GUI/CCControlExtension/CCScale9Sprite.h"
+#include "ui/UIScale9Sprite.h"
 #include "2d/CCSprite.h"
 
 NS_CC_BEGIN
@@ -128,7 +128,7 @@ void Slider::loadBarTexture(const std::string& fileName, TextureResType texType)
         case TextureResType::LOCAL:
             if (_scale9Enabled)
             {
-                static_cast<extension::Scale9Sprite*>(_barRenderer)->initWithFile(fileName);
+                static_cast<Scale9Sprite*>(_barRenderer)->initWithFile(fileName);
             }
             else
             {
@@ -138,7 +138,7 @@ void Slider::loadBarTexture(const std::string& fileName, TextureResType texType)
         case TextureResType::PLIST:
             if (_scale9Enabled)
             {
-                static_cast<extension::Scale9Sprite*>(_barRenderer)->initWithSpriteFrameName(fileName);
+                static_cast<Scale9Sprite*>(_barRenderer)->initWithSpriteFrameName(fileName);
             }
             else
             {
@@ -167,7 +167,7 @@ void Slider::loadProgressBarTexture(const std::string& fileName, TextureResType 
         case TextureResType::LOCAL:
             if (_scale9Enabled)
             {
-                static_cast<extension::Scale9Sprite*>(_progressBarRenderer)->initWithFile(fileName);
+                static_cast<Scale9Sprite*>(_progressBarRenderer)->initWithFile(fileName);
             }
             else
             {
@@ -177,7 +177,7 @@ void Slider::loadProgressBarTexture(const std::string& fileName, TextureResType 
         case TextureResType::PLIST:
             if (_scale9Enabled)
             {
-                static_cast<extension::Scale9Sprite*>(_progressBarRenderer)->initWithSpriteFrameName(fileName);
+                static_cast<Scale9Sprite*>(_progressBarRenderer)->initWithSpriteFrameName(fileName);
             }
             else
             {
@@ -207,8 +207,8 @@ void Slider::setScale9Enabled(bool able)
     _progressBarRenderer = nullptr;
     if (_scale9Enabled)
     {
-        _barRenderer = extension::Scale9Sprite::create();
-        _progressBarRenderer = extension::Scale9Sprite::create();
+        _barRenderer = Scale9Sprite::create();
+        _progressBarRenderer = Scale9Sprite::create();
     }
     else
     {
@@ -260,7 +260,7 @@ void Slider::setCapInsetsBarRenderer(const Rect &capInsets)
     {
         return;
     }
-    static_cast<extension::Scale9Sprite*>(_barRenderer)->setCapInsets(capInsets);
+    static_cast<Scale9Sprite*>(_barRenderer)->setCapInsets(capInsets);
 }
     
 const Rect& Slider::getCapInsetsBarRenderer()const
@@ -275,7 +275,7 @@ void Slider::setCapInsetProgressBarRebderer(const Rect &capInsets)
     {
         return;
     }
-    static_cast<extension::Scale9Sprite*>(_progressBarRenderer)->setCapInsets(capInsets);
+    static_cast<Scale9Sprite*>(_progressBarRenderer)->setCapInsets(capInsets);
 }
     
 const Rect& Slider::getCapInsetsProgressBarRebderer()const
@@ -369,7 +369,7 @@ void Slider::setPercent(int percent)
     _slidBallRenderer->setPosition(Vec2(dis, _contentSize.height / 2.0f));
     if (_scale9Enabled)
     {
-        static_cast<extension::Scale9Sprite*>(_progressBarRenderer)->setPreferredSize(Size(dis,_progressBarTextureSize.height));
+        static_cast<Scale9Sprite*>(_progressBarRenderer)->setPreferredSize(Size(dis,_progressBarTextureSize.height));
     }
     else
     {
@@ -497,7 +497,7 @@ void Slider::barRendererScaleChangedWithSize()
         _barLength = _contentSize.width;
         if (_scale9Enabled)
         {
-            static_cast<extension::Scale9Sprite*>(_barRenderer)->setPreferredSize(_contentSize);
+            static_cast<Scale9Sprite*>(_barRenderer)->setPreferredSize(_contentSize);
         }
         else
         {
@@ -534,7 +534,7 @@ void Slider::progressBarRendererScaleChangedWithSize()
     {
         if (_scale9Enabled)
         {
-            static_cast<extension::Scale9Sprite*>(_progressBarRenderer)->setPreferredSize(_contentSize);
+            static_cast<Scale9Sprite*>(_progressBarRenderer)->setPreferredSize(_contentSize);
             _progressBarTextureSize = _progressBarRenderer->getContentSize();
         }
         else

--- a/cocos/ui/proj.win32/libui.vcxproj
+++ b/cocos/ui/proj.win32/libui.vcxproj
@@ -28,6 +28,7 @@
     <ClInclude Include="..\UIPageView.h" />
     <ClInclude Include="..\UIRelativeBox.h" />
     <ClInclude Include="..\UIRichText.h" />
+    <ClInclude Include="..\UIScale9Sprite.h" />
     <ClInclude Include="..\UIScrollView.h" />
     <ClInclude Include="..\UISlider.h" />
     <ClInclude Include="..\UIText.h" />
@@ -54,6 +55,7 @@
     <ClCompile Include="..\UIPageView.cpp" />
     <ClCompile Include="..\UIRelativeBox.cpp" />
     <ClCompile Include="..\UIRichText.cpp" />
+    <ClCompile Include="..\UIScale9Sprite.cpp" />
     <ClCompile Include="..\UIScrollView.cpp" />
     <ClCompile Include="..\UISlider.cpp" />
     <ClCompile Include="..\UIText.cpp" />

--- a/cocos/ui/proj.win32/libui.vcxproj.filters
+++ b/cocos/ui/proj.win32/libui.vcxproj.filters
@@ -93,6 +93,9 @@
     <ClInclude Include="..\GUIExport.h">
       <Filter>System</Filter>
     </ClInclude>
+    <ClInclude Include="..\UIScale9Sprite.h">
+      <Filter>BaseClasses</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\UIScrollView.cpp">
@@ -166,6 +169,9 @@
     </ClCompile>
     <ClCompile Include="..\UIDeprecated.cpp">
       <Filter>System</Filter>
+    </ClCompile>
+    <ClCompile Include="..\UIScale9Sprite.cpp">
+      <Filter>BaseClasses</Filter>
     </ClCompile>
   </ItemGroup>
 </Project>

--- a/cocos/ui/proj.wp8/libGUI.vcxproj
+++ b/cocos/ui/proj.wp8/libGUI.vcxproj
@@ -188,6 +188,7 @@
     <ClInclude Include="..\UIHBox.h" />
     <ClInclude Include="..\UILayoutManager.h" />
     <ClInclude Include="..\UIRelativeBox.h" />
+    <ClInclude Include="..\UIScale9Sprite.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\ui\CCProtectedNode.cpp" />
@@ -214,5 +215,6 @@
     <ClCompile Include="..\UIHBox.cpp" />
     <ClCompile Include="..\UILayoutManager.cpp" />
     <ClCompile Include="..\UIRelativeBox.cpp" />
+    <ClCompile Include="..\UIScale9Sprite.cpp" />
   </ItemGroup>
 </Project>

--- a/cocos/ui/proj.wp8/libGUI.vcxproj.filters
+++ b/cocos/ui/proj.wp8/libGUI.vcxproj.filters
@@ -87,6 +87,9 @@
     <ClInclude Include="..\UIDeprecated.h">
       <Filter>System</Filter>
     </ClInclude>
+    <ClInclude Include="..\UIScale9Sprite.h">
+      <Filter>BaseClasses</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\ui\UILayout.cpp">
@@ -160,6 +163,9 @@
     </ClCompile>
     <ClCompile Include="..\UIDeprecated.cpp">
       <Filter>System</Filter>
+    </ClCompile>
+    <ClCompile Include="..\UIScale9Sprite.cpp">
+      <Filter>BaseClasses</Filter>
     </ClCompile>
   </ItemGroup>
 </Project>

--- a/tests/cpp-tests/Android.mk
+++ b/tests/cpp-tests/Android.mk
@@ -68,6 +68,7 @@ Classes/UITest/CocoStudioGUITest/CocostudioParserTest.cpp \
 Classes/UITest/CocoStudioGUITest/GUIEditorTest.cpp \
 Classes/UITest/CocoStudioGUITest/CustomGUIScene.cpp \
 Classes/UITest/CocoStudioGUITest/UIScene.cpp \
+Classes/UITest/CocoStudioGUITest/UIScale9SpriteTest.cpp \
 Classes/UITest/CocoStudioGUITest/UISceneManager.cpp \
 Classes/UITest/CocoStudioGUITest/UIButtonTest/UIButtonTest.cpp \
 Classes/UITest/CocoStudioGUITest/UIFocusTest/UIFocusTest.cpp \

--- a/tests/cpp-tests/CMakeLists.txt
+++ b/tests/cpp-tests/CMakeLists.txt
@@ -80,6 +80,7 @@ set(SAMPLE_SRC
   Classes/UITest/CocoStudioGUITest/GUIEditorTest.cpp
   Classes/UITest/CocoStudioGUITest/CustomGUIScene.cpp
   Classes/UITest/CocoStudioGUITest/UIScene.cpp
+  Classes/UITest/CocoStudioGUITest/UIScale9SpriteTest.cpp
   Classes/UITest/CocoStudioGUITest/UISceneManager.cpp
   Classes/UITest/CocoStudioGUITest/CocostudioParserTest/CocostudioParserJsonTest.cpp
   Classes/UITest/CocoStudioGUITest/CocostudioParserTest.cpp 

--- a/tests/cpp-tests/Classes/AppDelegate.cpp
+++ b/tests/cpp-tests/Classes/AppDelegate.cpp
@@ -108,7 +108,7 @@ bool AppDelegate::applicationDidFinishLaunching()
     // a bug in DirectX 11 level9-x on the device prevents ResolutionPolicy::NO_BORDER from working correctly
     glview->setDesignResolutionSize(designSize.width, designSize.height, ResolutionPolicy::SHOW_ALL);
 #else
-    glview->setDesignResolutionSize(designSize.width, designSize.height, ResolutionPolicy::NO_BORDER);
+    glview->setDesignResolutionSize(designSize.width, designSize.height, ResolutionPolicy::SHOW_ALL);
 #endif
 
     auto scene = Scene::create();

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/CocosGUIScene.cpp
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/CocosGUIScene.cpp
@@ -43,6 +43,18 @@ g_guisTests[] =
             Director::getInstance()->replaceScene(scene);
         }
     },
+    {
+        "Scale9 Sprite Test",
+        [](Ref* sender)
+        {
+            UISceneManager* sceneManager = UISceneManager::sharedUISceneManager();
+            sceneManager->setCurrentUISceneId(kUIScale9SpriteTest);
+            sceneManager->setMinUISceneId(kUIScale9SpriteTest);
+            sceneManager->setMaxUISceneId(kUIS9Flip);
+            Scene* scene = sceneManager->currentUIScene();
+            Director::getInstance()->replaceScene(scene);
+        }
+    },
 	{
         
         "ButtonTest",

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIScale9SpriteTest.cpp
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIScale9SpriteTest.cpp
@@ -1,0 +1,661 @@
+/****************************************************************************
+ Copyright (c) 2013-2014 Chukong Technologies Inc.
+ 
+ http://www.cocos2d-x.org
+ 
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+ 
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+ 
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+ ****************************************************************************/
+
+#include "UIScale9SpriteTest.h"
+#include "testResource.h"
+
+// UIScale9SpriteTest
+UIScale9SpriteTest::UIScale9SpriteTest()
+{
+    
+}
+
+UIScale9SpriteTest::~UIScale9SpriteTest()
+{
+}
+
+bool UIScale9SpriteTest::init()
+{
+    if (UIScene::init())
+    {
+        Size widgetSize = _widget->getContentSize();
+        
+        auto moveTo = MoveBy::create(1.0, Vec2(30,0));
+        auto moveBack = moveTo->reverse();
+        auto rotateBy = RotateBy::create(1.0, 180);
+        auto action = Sequence::create(moveTo,moveBack, rotateBy, NULL);
+
+        
+        Sprite *normalSprite1 = Sprite::create("cocosui/animationbuttonnormal.png");
+        normalSprite1->setPosition(100, 270);
+//        normalSprite1->setAnchorPoint(Vec2(0.5,0.5));
+//        normalSprite1->setContentSize(Size(100,100));
+
+        this->addChild(normalSprite1);
+        normalSprite1->runAction((FiniteTimeAction*)action->clone());
+        
+        ui::Scale9Sprite *normalSprite2 = ui::Scale9Sprite::create("cocosui/animationbuttonnormal.png");
+        normalSprite2->setPosition(120, 270);
+        normalSprite2->setScale9Enabled(false);
+//        normalSprite2->setContentSize(Size(100,100));
+//        normalSprite2->setAnchorPoint(Vec2(0.5,0.5));
+        normalSprite2->setOpacity(100);
+        this->addChild(normalSprite2);
+        normalSprite2->setColor(Color3B::GREEN);
+        normalSprite2->runAction(action);
+        
+        auto action2 = action->clone();
+        ui::Scale9Sprite *sp1 = ui::Scale9Sprite::create("cocosui/animationbuttonnormal.png");
+        sp1->setPosition(100, 160);
+        sp1->setScale(1.2);
+        sp1->setContentSize(Size(100,100));
+        sp1->setColor(Color3B::GREEN);
+//        sp1->setScale9Enabled(false);
+        this->addChild(sp1);
+        sp1->runAction((FiniteTimeAction*)action2);
+        
+        cocos2d::ui::Scale9Sprite *sp2 = ui::Scale9Sprite::create("cocosui/animationbuttonnormal.png");
+        sp2->setPosition(350, 160);
+        sp2->setPreferredSize(sp1->getContentSize() * 1.2);
+        sp2->setColor(Color3B::GREEN);
+        sp2->setContentSize(Size(100,100));
+
+        this->addChild(sp2);
+        auto action3 = action->clone();
+        sp2->runAction((FiniteTimeAction*)action3);
+               
+        return true;
+    }
+    return false;
+}
+
+
+UIScale9SpriteHierarchialTest::UIScale9SpriteHierarchialTest()
+{
+    
+}
+
+UIScale9SpriteHierarchialTest::~UIScale9SpriteHierarchialTest()
+{
+}
+
+bool UIScale9SpriteHierarchialTest::init()
+{
+    if (UIScene::init())
+    {
+        Size widgetSize = _widget->getContentSize();
+        
+        auto moveTo = MoveBy::create(1.0, Vec2(30,0));
+        auto moveBack = moveTo->reverse();
+        auto rotateBy = RotateBy::create(1.0, 180);
+        auto fadeOut = FadeOut::create(2.0);
+        auto action = Sequence::create(moveTo,moveBack, rotateBy,fadeOut, NULL);
+        
+        
+        Sprite *normalSprite1 = Sprite::create("cocosui/animationbuttonnormal.png");
+        normalSprite1->setPosition(100, 270);
+        //        normalSprite1->setAnchorPoint(Vec2(0.5,0.5));
+        //        normalSprite1->setContentSize(Size(100,100));
+        
+//        Sprite *childSprite = Sprite::create("cocosui/animationbuttonnormal.png");
+        normalSprite1->setCascadeColorEnabled(true);
+        normalSprite1->setCascadeOpacityEnabled(true);
+        normalSprite1->setColor(Color3B::GREEN);
+
+        
+        
+        this->addChild(normalSprite1);
+        normalSprite1->runAction((FiniteTimeAction*)action->clone());
+        
+        ui::Scale9Sprite *normalSprite2 = ui::Scale9Sprite::create("cocosui/animationbuttonnormal.png");
+//        normalSprite2->setPosition(120, 270);
+        normalSprite2->setScale9Enabled(false);
+        //        normalSprite2->setContentSize(Size(100,100));
+        //        normalSprite2->setAnchorPoint(Vec2(0.5,0.5));
+        normalSprite2->setOpacity(100);
+        normalSprite1->addChild(normalSprite2);
+        
+        auto action2 = action->clone();
+        ui::Scale9Sprite *sp1 = ui::Scale9Sprite::create("cocosui/animationbuttonnormal.png");
+        sp1->setPosition(200, 160);
+        sp1->setScale(1.2);
+        sp1->setContentSize(Size(100,100));
+        sp1->setColor(Color3B::GREEN);
+        //        sp1->setScale9Enabled(false);
+        this->addChild(sp1);
+        sp1->runAction((FiniteTimeAction*)action2);
+        
+        cocos2d::ui::Scale9Sprite *sp2 = ui::Scale9Sprite::create("cocosui/animationbuttonnormal.png");
+//        sp2->setPosition(350, 160);
+        sp2->setPreferredSize(sp1->getContentSize() * 1.2);
+        sp2->setColor(Color3B::GREEN);
+        sp2->setContentSize(Size(100,100));
+        
+        sp1->addChild(sp2);
+//        auto action3 = action->clone();
+//        sp2->runAction((FiniteTimeAction*)action3);
+        
+        return true;
+    }
+    return false;
+}
+
+UIScale9SpriteTouchTest::UIScale9SpriteTouchTest()
+{
+    
+}
+
+UIScale9SpriteTouchTest::~UIScale9SpriteTouchTest()
+{
+}
+
+bool UIScale9SpriteTouchTest::init()
+{
+    if (UIScene::init())
+    {
+    
+        Vec2 origin = Director::getInstance()->getVisibleOrigin();
+        Size size = Director::getInstance()->getVisibleSize();
+        
+        auto containerForSprite1 = Node::create();
+        auto sprite1 = cocos2d::ui::Scale9Sprite::create("Images/CyanSquare.png");
+//        sprite1->setScale9Enabled(false);
+        sprite1->setPosition(origin+Vec2(size.width/2, size.height/2) + Vec2(-80, 80));
+        containerForSprite1->addChild(sprite1);
+        addChild(containerForSprite1, 10);
+        
+        auto sprite2 = ui::Scale9Sprite::create("Images/MagentaSquare.png");
+        sprite2->setPosition(origin+Vec2(size.width/2, size.height/2));
+//        sprite2->setCascadeOpacityEnabled(false);
+//        sprite2->setScale9Enabled(false);
+
+        addChild(sprite2, 20);
+        
+        auto sprite3 = ui::Scale9Sprite::create("Images/YellowSquare.png");
+        sprite3->setPosition(Vec2(0, 0));
+        sprite3->setCascadeOpacityEnabled(false);
+        sprite2->addChild(sprite3, 1);
+//        sprite3->setScale9Enabled(false);
+
+        
+        // Make sprite1 touchable
+        auto listener1 = EventListenerTouchOneByOne::create();
+        listener1->setSwallowTouches(true);
+        
+        listener1->onTouchBegan = [](Touch* touch, Event* event){
+            auto target = static_cast<Sprite*>(event->getCurrentTarget());
+            
+            Vec2 locationInNode = target->convertToNodeSpace(touch->getLocation());
+            Size s = target->getContentSize();
+            Rect rect = Rect(0, 0, s.width, s.height);
+            
+            if (rect.containsPoint(locationInNode))
+            {
+                log("sprite began... x = %f, y = %f", locationInNode.x, locationInNode.y);
+                target->setOpacity(180);
+                return true;
+            }
+            return false;
+        };
+        
+        listener1->onTouchMoved = [](Touch* touch, Event* event){
+            auto target = static_cast<Sprite*>(event->getCurrentTarget());
+            target->setPosition(target->getPosition() + touch->getDelta());
+        };
+        
+        listener1->onTouchEnded = [=](Touch* touch, Event* event){
+            auto target = static_cast<ui::Scale9Sprite*>(event->getCurrentTarget());
+            log("sprite onTouchesEnded.. ");
+            target->setOpacity(255);
+            if (target == sprite2)
+            {
+                containerForSprite1->setLocalZOrder(100);
+            }
+            else if(target == sprite1)
+            {
+                containerForSprite1->setLocalZOrder(0);
+            }
+        };
+        
+        _eventDispatcher->addEventListenerWithSceneGraphPriority(listener1, sprite1);
+        _eventDispatcher->addEventListenerWithSceneGraphPriority(listener1->clone(), sprite2);
+        _eventDispatcher->addEventListenerWithSceneGraphPriority(listener1->clone(), sprite3);
+        
+        return true;
+    }
+    return false;
+}
+
+bool UIS9BatchNodeBasic::init()
+{
+    if (UIScene::init()) {
+        auto winSize = Director::getInstance()->getWinSize();
+        float x = winSize.width / 2;
+        float y = 0 + (winSize.height / 2);
+        
+        
+        auto sprite = Sprite::create("Images/blocks9.png");
+        
+        auto blocks = ui::Scale9Sprite::create();
+        
+        blocks->updateWithSprite(sprite, Rect(0, 0, 96, 96), false, Rect(0, 0, 96, 96));
+        
+        blocks->setPosition(Vec2(x, y));
+        
+        this->addChild(blocks);
+        
+        
+        return true;
+    }
+
+    
+    return false;
+}
+
+bool UIS9FrameNameSpriteSheet::init()
+{
+    if (UIScene::init()) {
+        auto winSize = Director::getInstance()->getWinSize();
+        float x = winSize.width / 2;
+        float y = 0 + (winSize.height / 2);
+        
+        SpriteFrameCache::getInstance()->addSpriteFramesWithFile(s_s9s_blocks9_plist);
+
+        
+        auto blocks = ui::Scale9Sprite::createWithSpriteFrameName("blocks9.png");
+        
+        blocks->setPosition(Vec2(x, y));
+        
+        this->addChild(blocks);
+
+        
+        return true;
+    }
+    
+    return false;
+}
+
+
+bool UIS9FrameNameSpriteSheetRotated::init()
+{
+    if (UIScene::init()) {
+        auto winSize = Director::getInstance()->getWinSize();
+        float x = winSize.width / 2;
+        float y = 0 + (winSize.height / 2);
+        
+        SpriteFrameCache::getInstance()->addSpriteFramesWithFile(s_s9s_blocks9_plist);
+
+        auto blocks = ui::Scale9Sprite::createWithSpriteFrameName("blocks9r.png");
+        
+        blocks->setPosition(Vec2(x, y));
+        
+        this->addChild(blocks);
+        
+        return true;
+    }
+    
+    return false;
+}
+
+
+bool UIS9BatchNodeScaledNoInsets::init()
+{
+    if (UIScene::init()) {
+        auto winSize = Director::getInstance()->getWinSize();
+        float x = winSize.width / 2;
+        float y = 0 + (winSize.height / 2);
+        
+        // scaled without insets
+        auto sprite_scaled = Sprite::create("Images/blocks9.png");
+        
+        auto blocks_scaled = ui::Scale9Sprite::create();
+        blocks_scaled->updateWithSprite(sprite_scaled, Rect(0, 0, 96, 96), false, Rect(0, 0, 96, 96));
+        
+        blocks_scaled->setPosition(Vec2(x, y));
+        
+        blocks_scaled->setContentSize(Size(96 * 4, 96*2));
+        
+        this->addChild(blocks_scaled);
+        return true;
+    }
+    return false;
+}
+
+bool UIS9FrameNameSpriteSheetScaledNoInsets::init()
+{
+    if (UIScene::init()) {
+        auto winSize = Director::getInstance()->getWinSize();
+        float x = winSize.width / 2;
+        float y = 0 + (winSize.height / 2);
+        SpriteFrameCache::getInstance()->addSpriteFramesWithFile(s_s9s_blocks9_plist);
+        
+        auto blocks_scaled = ui::Scale9Sprite::createWithSpriteFrameName("blocks9.png");
+        
+        blocks_scaled->setPosition(Vec2(x, y));
+        
+        blocks_scaled->setContentSize(Size(96 * 4, 96*2));
+        
+        this->addChild(blocks_scaled);
+        return true;
+    }
+    return false;
+}
+
+bool UIS9FrameNameSpriteSheetRotatedScaledNoInsets::init()
+{
+    if (UIScene::init()) {
+        SpriteFrameCache::getInstance()->addSpriteFramesWithFile(s_s9s_blocks9_plist);
+
+        auto winSize = Director::getInstance()->getWinSize();
+        float x = winSize.width / 2;
+        float y = 0 + (winSize.height / 2);
+        
+        
+        auto blocks_scaled = ui::Scale9Sprite::createWithSpriteFrameName("blocks9r.png");
+        
+        blocks_scaled->setPosition(Vec2(x, y));
+        
+        blocks_scaled->setContentSize(Size(96 * 4, 96*2));
+        
+        this->addChild(blocks_scaled);
+        
+        return true;
+    }
+    return false;
+}
+
+
+bool UIS9BatchNodeScaleWithCapInsets::init()
+{
+    if (UIScene::init()) {
+        auto winSize = Director::getInstance()->getWinSize();
+        float x = winSize.width / 2;
+        float y = 0 + (winSize.height / 2);
+        
+        
+        auto sprite_scaled_with_insets = Sprite::create("Images/blocks9.png");
+        
+        auto blocks_scaled_with_insets = ui::Scale9Sprite::create();
+        
+        blocks_scaled_with_insets->updateWithSprite(sprite_scaled_with_insets, Rect(0, 0, 96, 96), false, Rect(32, 32, 32, 32));
+        
+        blocks_scaled_with_insets->setContentSize(Size(96 * 4.5, 96 * 2.5));
+        
+        blocks_scaled_with_insets->setPosition(Vec2(x, y));
+        
+        this->addChild(blocks_scaled_with_insets);
+        return true;
+    }
+    return false;
+}
+
+bool UIS9FrameNameSpriteSheetInsets::init()
+{
+    if (UIScene::init()) {
+        SpriteFrameCache::getInstance()->addSpriteFramesWithFile(s_s9s_blocks9_plist);
+
+        
+        auto winSize = Director::getInstance()->getWinSize();
+        float x = winSize.width / 2;
+        float y = 0 + (winSize.height / 2);
+        
+        
+        auto blocks_with_insets = ui::Scale9Sprite::createWithSpriteFrameName("blocks9.png", Rect(32, 32, 32, 32));
+        
+        blocks_with_insets->setPosition(Vec2(x, y));
+        
+        this->addChild(blocks_with_insets);
+        return true;
+    }
+    return false;
+}
+
+bool UIS9FrameNameSpriteSheetInsetsScaled::init()
+{
+    if (UIScene::init()) {
+        SpriteFrameCache::getInstance()->addSpriteFramesWithFile(s_s9s_blocks9_plist);
+
+        auto winSize = Director::getInstance()->getWinSize();
+        float x = winSize.width / 2;
+        float y = 0 + (winSize.height / 2);
+        
+        auto blocks_scaled_with_insets = ui::Scale9Sprite::createWithSpriteFrameName("blocks9.png", Rect(32, 32, 32, 32));
+        
+        blocks_scaled_with_insets->setContentSize(Size(96 * 4.5, 96 * 2.5));
+        
+        blocks_scaled_with_insets->setPosition(Vec2(x, y));
+        
+        this->addChild(blocks_scaled_with_insets);
+        return true;
+    }
+    return false;
+}
+
+bool UIS9FrameNameSpriteSheetRotatedInsets::init()
+{
+    if (UIScene::init()) {
+        SpriteFrameCache::getInstance()->addSpriteFramesWithFile(s_s9s_blocks9_plist);
+        auto winSize = Director::getInstance()->getWinSize();
+        float x = winSize.width / 2;
+        float y = 0 + (winSize.height / 2);
+        
+        auto blocks_with_insets = ui::Scale9Sprite::createWithSpriteFrameName("blocks9r.png", Rect(32, 32, 32, 32));
+        
+        blocks_with_insets->setPosition(Vec2(x, y));
+        
+        this->addChild(blocks_with_insets);
+        return true;
+    }
+    return false;
+}
+
+bool UIS9_TexturePacker::init()
+{
+    if (UIScene::init()) {
+        SpriteFrameCache::getInstance()->addSpriteFramesWithFile(s_s9s_blocks9_plist);
+
+        auto winSize = Director::getInstance()->getWinSize();
+        SpriteFrameCache::getInstance()->addSpriteFramesWithFile(s_s9s_ui_plist);
+        
+        float x = winSize.width / 4;
+        float y = 0 + (winSize.height / 2);
+        
+        auto s = ui::Scale9Sprite::createWithSpriteFrameName("button_normal.png");
+        
+        s->setPosition(Vec2(x, y));
+        
+        s->setContentSize(Size(14 * 16, 10 * 16));
+        
+        this->addChild(s);
+        
+        x = winSize.width * 3/4;
+        
+        auto s2 = ui::Scale9Sprite::createWithSpriteFrameName("button_actived.png");
+        
+        s2->setPosition(Vec2(x, y));
+        
+        s2->setContentSize(Size(14 * 16, 10 * 16));
+        
+        this->addChild(s2);
+        return true;
+    }
+    return false;
+}
+
+bool UIS9FrameNameSpriteSheetRotatedInsetsScaled::init()
+{
+    if (UIScene::init()) {
+        SpriteFrameCache::getInstance()->addSpriteFramesWithFile(s_s9s_blocks9_plist);
+
+        auto winSize = Director::getInstance()->getWinSize();
+        float x = winSize.width / 2;
+        float y = 0 + (winSize.height / 2);
+        
+        auto blocks_scaled_with_insets = ui::Scale9Sprite::createWithSpriteFrameName("blocks9.png", Rect(32, 32, 32, 32));
+
+        blocks_scaled_with_insets->setContentSize(Size(96 * 4.5, 96 * 2.5));
+        
+        blocks_scaled_with_insets->setPosition(Vec2(x, y));
+        
+        this->addChild(blocks_scaled_with_insets);
+        return true;
+    }
+    return false;
+}
+
+bool UIS9FrameNameSpriteSheetRotatedSetCapInsetLater::init()
+{
+    if (UIScene::init()) {
+        SpriteFrameCache::getInstance()->addSpriteFramesWithFile(s_s9s_blocks9_plist);
+
+        auto winSize = Director::getInstance()->getWinSize();
+        float x = winSize.width / 2;
+        float y = 0 + (winSize.height / 2);
+        
+        auto blocks_scaled_with_insets = ui::Scale9Sprite::createWithSpriteFrameName("blocks9r.png");
+        
+        blocks_scaled_with_insets->setInsetLeft(32);
+        blocks_scaled_with_insets->setInsetRight(32);
+        
+        blocks_scaled_with_insets->setPreferredSize(Size(32*5.5f, 32*4));
+        blocks_scaled_with_insets->setPosition(Vec2(x, y));
+        
+        this->addChild(blocks_scaled_with_insets);
+        return true;
+    }
+    return false;
+}
+
+bool UIS9CascadeOpacityAndColor::init()
+{
+    if (UIScene::init()) {
+        SpriteFrameCache::getInstance()->addSpriteFramesWithFile(s_s9s_blocks9_plist);
+
+        auto winSize = Director::getInstance()->getWinSize();
+        float x = winSize.width / 2;
+        float y = 0 + (winSize.height / 2);
+        auto rgba = Layer::create();
+        rgba->setCascadeColorEnabled(true);
+        rgba->setCascadeOpacityEnabled(true);
+        this->addChild(rgba);
+        
+        
+        auto blocks_scaled_with_insets = ui::Scale9Sprite::createWithSpriteFrameName("blocks9r.png");
+        
+        blocks_scaled_with_insets->setPosition(Vec2(x, y));
+        
+        rgba->addChild(blocks_scaled_with_insets);
+        auto actions = Sequence::create(FadeIn::create(1),
+                                        TintTo::create(1, 0, 255, 0),
+                                        TintTo::create(1, 255, 255, 255),
+                                        FadeOut::create(1),
+                                        nullptr);
+        auto repeat = RepeatForever::create(actions);
+        rgba->runAction(repeat);
+        return true;
+    }
+    return false;
+}
+
+bool UIS9ZOrder::init()
+{
+    if (UIScene::init()) {
+        SpriteFrameCache::getInstance()->addSpriteFramesWithFile(s_s9s_blocks9_plist);
+
+        auto winSize = Director::getInstance()->getWinSize();
+        float x = winSize.width / 2;
+        float y = 0 + (winSize.height / 2);
+        
+        auto blocks_scaled_with_insets = ui::Scale9Sprite::createWithSpriteFrameName("blocks9r.png");
+        
+        blocks_scaled_with_insets->setPosition(Vec2(x, y));
+        this->addChild(blocks_scaled_with_insets);
+        
+        Sprite *normalSprite = Sprite::createWithSpriteFrameName("blocks9r.png");
+        normalSprite->setColor(Color3B::RED);
+        blocks_scaled_with_insets->addChild(normalSprite);
+        
+        auto topLabel = Label::createWithSystemFont("I Must be On the Top", "Arial", 15);
+        topLabel->setPosition(Vec2(20,20));
+        blocks_scaled_with_insets->addChild(topLabel);
+        
+        auto bottomLabel = Label::createWithSystemFont("I Must be On the Bottom", "Arial", 15);
+        bottomLabel->setPosition(Vec2(80,80));
+        bottomLabel->setColor(Color3B::BLUE);
+        blocks_scaled_with_insets->addChild(bottomLabel,-1);
+        
+        return true;
+    }
+    return false;
+}
+
+bool UIS9Flip::init()
+{
+    if (UIScene::init()) {
+        SpriteFrameCache::getInstance()->addSpriteFramesWithFile(s_s9s_blocks9_plist);
+
+        auto winSize = Director::getInstance()->getWinSize();
+        float x = winSize.width / 2;
+        float y = 0 + (winSize.height / 2);
+        
+        
+        auto normalSprite = ui::Scale9Sprite::createWithSpriteFrameName("blocks9r.png");
+        
+        normalSprite->setPosition(Vec2(x, y ));
+        this->addChild(normalSprite);
+        
+        
+        auto normalLabel = Label::createWithSystemFont("Normal Sprite","Airal",10);
+        normalLabel->setPosition(normalSprite->getPosition() + Vec2(0, normalSprite->getContentSize().height/2 + 10));
+        this->addChild(normalLabel);
+        
+        
+        
+        auto flipXSprite = ui::Scale9Sprite::createWithSpriteFrameName("blocks9r.png");
+        
+        flipXSprite->setPosition(Vec2(x - 120, y ));
+        this->addChild(flipXSprite);
+        
+        flipXSprite->setFlippedX(true);
+        
+        auto flipXLabel = Label::createWithSystemFont("Sprite FlipX","Airal",10);
+        flipXLabel->setPosition(flipXSprite->getPosition() + Vec2(0, flipXSprite->getContentSize().height/2 + 10));
+        this->addChild(flipXLabel);
+        
+        
+        auto flipYSprite = ui::Scale9Sprite::createWithSpriteFrameName("blocks9r.png");
+        
+        flipYSprite->setPosition(Vec2(x + 120, y));
+        this->addChild(flipYSprite);
+        
+        flipYSprite->setFlippedY(true);
+        
+        auto flipYLabel = Label::createWithSystemFont("Sprite FlipY","Airal",10);
+        flipYLabel->setPosition(flipYSprite->getPosition() + Vec2(0, flipYSprite->getContentSize().height/2 + 10));
+        this->addChild(flipYLabel);
+        
+        return true;
+    }
+    return false;
+}

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIScale9SpriteTest.h
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIScale9SpriteTest.h
@@ -1,0 +1,259 @@
+/****************************************************************************
+ Copyright (c) 2013-2014 Chukong Technologies Inc.
+ 
+ http://www.cocos2d-x.org
+ 
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+ 
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+ 
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+ ****************************************************************************/
+
+#ifndef __cocos2d_tests__UIScale9SpriteTest__
+#define __cocos2d_tests__UIScale9SpriteTest__
+#include "UIScene.h"
+
+class UIScale9SpriteTest : public UIScene
+{
+public:
+    UIScale9SpriteTest();
+    ~UIScale9SpriteTest();
+    bool init();
+    
+protected:
+    UI_SCENE_CREATE_FUNC(UIScale9SpriteTest)
+};
+
+class UIScale9SpriteHierarchialTest : public UIScene
+{
+public:
+    UIScale9SpriteHierarchialTest();
+    ~UIScale9SpriteHierarchialTest();
+    bool init();
+    
+protected:
+    UI_SCENE_CREATE_FUNC(UIScale9SpriteHierarchialTest)
+};
+
+class UIScale9SpriteTouchTest : public UIScene
+{
+public:
+    UIScale9SpriteTouchTest();
+    ~UIScale9SpriteTouchTest();
+    bool init();
+    
+protected:
+    UI_SCENE_CREATE_FUNC(UIScale9SpriteTouchTest)
+};
+
+// S9BatchNodeBasic
+
+class UIS9BatchNodeBasic : public UIScene
+{
+public:
+    CREATE_FUNC(UIS9BatchNodeBasic);
+    
+    bool init();
+protected:
+    UI_SCENE_CREATE_FUNC(UIS9BatchNodeBasic)
+};
+
+// S9FrameNameSpriteSheet
+
+class UIS9FrameNameSpriteSheet : public UIScene
+{
+public:
+    CREATE_FUNC(UIS9FrameNameSpriteSheet);
+    
+    bool init();
+protected:
+    UI_SCENE_CREATE_FUNC(UIS9FrameNameSpriteSheet)
+
+};
+
+// S9FrameNameSpriteSheetRotated
+
+class UIS9FrameNameSpriteSheetRotated : public UIScene
+{
+public:
+    CREATE_FUNC(UIS9FrameNameSpriteSheetRotated);
+    
+    bool init();
+protected:
+    UI_SCENE_CREATE_FUNC(UIS9FrameNameSpriteSheetRotated)
+};
+
+// S9BatchNodeScaledNoInsets
+
+class UIS9BatchNodeScaledNoInsets : public UIScene
+{
+public:
+    CREATE_FUNC(UIS9BatchNodeScaledNoInsets);
+    
+    bool init();
+protected:
+    UI_SCENE_CREATE_FUNC(UIS9BatchNodeScaledNoInsets)
+};
+
+// S9FrameNameSpriteSheetScaledNoInsets
+
+class UIS9FrameNameSpriteSheetScaledNoInsets : public UIScene
+{
+public:
+    CREATE_FUNC(UIS9FrameNameSpriteSheetScaledNoInsets);
+    
+    bool init();
+protected:
+    UI_SCENE_CREATE_FUNC(UIS9FrameNameSpriteSheetScaledNoInsets)
+};
+
+// S9FrameNameSpriteSheetRotatedScaledNoInsets
+
+class UIS9FrameNameSpriteSheetRotatedScaledNoInsets : public UIScene
+{
+public:
+    CREATE_FUNC(UIS9FrameNameSpriteSheetRotatedScaledNoInsets);
+    
+    bool init();
+protected:
+    UI_SCENE_CREATE_FUNC(UIS9FrameNameSpriteSheetRotatedScaledNoInsets)
+};
+
+
+// S9BatchNodeScaleWithCapInsets
+
+class UIS9BatchNodeScaleWithCapInsets : public UIScene
+{
+public:
+    CREATE_FUNC(UIS9BatchNodeScaleWithCapInsets);
+    
+    bool init();
+protected:
+    UI_SCENE_CREATE_FUNC(UIS9BatchNodeScaleWithCapInsets)
+};
+
+// S9FrameNameSpriteSheetInsets
+
+class UIS9FrameNameSpriteSheetInsets : public UIScene
+{
+public:
+    CREATE_FUNC(UIS9FrameNameSpriteSheetInsets);
+    
+    bool init();
+protected:
+    UI_SCENE_CREATE_FUNC(UIS9FrameNameSpriteSheetInsets)
+};
+
+// S9FrameNameSpriteSheetInsetsScaled
+
+class UIS9FrameNameSpriteSheetInsetsScaled : public UIScene
+{
+public:
+    CREATE_FUNC(UIS9FrameNameSpriteSheetInsetsScaled);
+    
+    bool init();
+protected:
+    UI_SCENE_CREATE_FUNC(UIS9FrameNameSpriteSheetInsetsScaled)
+};
+
+// S9FrameNameSpriteSheetRotatedInsets
+
+class UIS9FrameNameSpriteSheetRotatedInsets : public UIScene
+{
+public:
+    CREATE_FUNC(UIS9FrameNameSpriteSheetRotatedInsets);
+    
+    bool init();
+protected:
+    UI_SCENE_CREATE_FUNC(UIS9FrameNameSpriteSheetRotatedInsets)
+};
+
+// S9_TexturePacker
+
+class UIS9_TexturePacker : public UIScene
+{
+public:
+    CREATE_FUNC(UIS9_TexturePacker);
+    
+    bool init();
+protected:
+    UI_SCENE_CREATE_FUNC(UIS9_TexturePacker)
+
+};
+
+// S9FrameNameSpriteSheetRotatedInsetsScaled
+
+class UIS9FrameNameSpriteSheetRotatedInsetsScaled : public UIScene
+{
+public:
+    CREATE_FUNC(UIS9FrameNameSpriteSheetRotatedInsetsScaled);
+    
+    bool init();
+protected:
+    UI_SCENE_CREATE_FUNC(UIS9FrameNameSpriteSheetRotatedInsetsScaled)
+};
+
+// S9FrameNameSpriteSheetRotatedInsetsScaled
+
+class UIS9FrameNameSpriteSheetRotatedSetCapInsetLater : public UIScene
+{
+public:
+    CREATE_FUNC(UIS9FrameNameSpriteSheetRotatedSetCapInsetLater);
+    
+    bool init();
+protected:
+    UI_SCENE_CREATE_FUNC(UIS9FrameNameSpriteSheetRotatedSetCapInsetLater)
+};
+
+// S9CascadeOpacityAndColor
+
+class UIS9CascadeOpacityAndColor : public UIScene
+{
+public:
+    CREATE_FUNC(UIS9CascadeOpacityAndColor);
+    
+    bool init();
+protected:
+    UI_SCENE_CREATE_FUNC(UIS9CascadeOpacityAndColor)
+};
+
+// Scale9Sprite ZOrder
+
+class UIS9ZOrder : public UIScene
+{
+public:
+    CREATE_FUNC(UIS9ZOrder);
+    
+    bool init();
+protected:
+    UI_SCENE_CREATE_FUNC(UIS9ZOrder)
+
+};
+
+// Scale9Sprite Flip
+
+class UIS9Flip : public UIScene
+{
+public:
+    CREATE_FUNC(UIS9Flip);
+    
+    bool init();
+protected:
+    UI_SCENE_CREATE_FUNC(UIS9Flip)
+};
+
+
+#endif /* defined(__cocos2d_tests__UIScale9SpriteTest__) */

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UISceneManager.cpp
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UISceneManager.cpp
@@ -21,6 +21,7 @@
 #if (CC_TARGET_PLATFORM == CC_PLATFORM_ANDROID || CC_TARGET_PLATFORM == CC_PLATFORM_IOS)
 #include "UIVideoPlayerTest/UIVideoPlayerTest.h"
 #endif
+#include "UIScale9SpriteTest.h"
 /*
 #include "UISwitchTest/UISwitchTest.h"
  */
@@ -126,6 +127,25 @@ static const char* s_testArray[] =
 #if (CC_TARGET_PLATFORM == CC_PLATFORM_ANDROID || CC_TARGET_PLATFORM == CC_PLATFORM_IOS)
     "UIVideoPlayerTest"
 #endif
+    "UIScale9SpriteTest",
+    "UIScale9SpriteHierarchialTest",
+    "UIScale9SpriteTouchTest",
+    "UIS9BatchNodeBasic",
+    "UIS9FrameNameSpriteSheet",
+    "UIS9FrameNameSpriteSheetRotated",
+    "UIS9BatchNodeScaledNoInsets",
+    "UIS9FrameNameSpriteSheetScaledNoInsets",
+    "UIS9FrameNameSpriteSheetRotatedScaledNoInsets",
+    "UIS9BatchNodeScaleWithCapInsets",
+    "UIS9FrameNameSpriteSheetInsets",
+    "UIS9FrameNameSpriteSheetInsetsScaled",
+    "UIS9FrameNameSpriteSheetRotatedInsets",
+    "UIS9_TexturePacker",
+    "UIS9FrameNameSpriteSheetRotatedInsetsScaled",
+    "UIS9FrameNameSpriteSheetRotatedSetCapInsetLater",
+    "UIS9CascadeOpacityAndColor",
+    "UIS9ZOrder",
+    "UIS9Flip",
 };
 
 static UISceneManager *sharedInstance = nullptr;
@@ -329,6 +349,44 @@ Scene *UISceneManager::currentUIScene()
         case kUIVideoPlayerTest:
             return VideoPlayerTest::sceneWithTitle(s_testArray[_currentUISceneId]);
 #endif
+        case kUIScale9SpriteTest:
+            return UIScale9SpriteTest::sceneWithTitle(s_testArray[_currentUISceneId]);
+        case kUIScale9SpriteHierarchialTest:
+            return UIScale9SpriteHierarchialTest::sceneWithTitle(s_testArray[_currentUISceneId]);
+        case kUIScale9SpriteTouchTest:
+            return UIScale9SpriteTouchTest::sceneWithTitle(s_testArray[_currentUISceneId]);
+        case kUIS9BatchNodeBasic:
+            return UIS9BatchNodeBasic::sceneWithTitle(s_testArray[_currentUISceneId]);
+        case kUIS9FrameNameSpriteSheet:
+            return UIS9FrameNameSpriteSheet::sceneWithTitle(s_testArray[_currentUISceneId]);
+        case kUIS9FrameNameSpriteSheetRotated:
+            return UIS9FrameNameSpriteSheetRotated::sceneWithTitle(s_testArray[_currentUISceneId]);
+        case kUIS9BatchNodeScaledNoInsets:
+            return UIS9BatchNodeScaledNoInsets::sceneWithTitle(s_testArray[_currentUISceneId]);
+        case kUIS9FrameNameSpriteSheetScaledNoInsets:
+            return UIS9FrameNameSpriteSheetScaledNoInsets::sceneWithTitle(s_testArray[_currentUISceneId]);
+        case kUIS9FrameNameSpriteSheetRotatedScaledNoInsets:
+            return UIS9FrameNameSpriteSheetRotatedScaledNoInsets::sceneWithTitle(s_testArray[_currentUISceneId]);
+        case kUIS9BatchNodeScaleWithCapInsets:
+            return UIS9BatchNodeScaleWithCapInsets::sceneWithTitle(s_testArray[_currentUISceneId]);
+        case kUIS9FrameNameSpriteSheetInsets:
+            return UIS9FrameNameSpriteSheetInsets::sceneWithTitle(s_testArray[_currentUISceneId]);
+        case kUIS9FrameNameSpriteSheetInsetsScaled:
+            return UIS9FrameNameSpriteSheetInsetsScaled::sceneWithTitle(s_testArray[_currentUISceneId]);
+        case kUIS9FrameNameSpriteSheetRotatedInsets:
+            return UIS9FrameNameSpriteSheetRotatedInsets::sceneWithTitle(s_testArray[_currentUISceneId]);
+        case kUIS9_TexturePacker:
+            return UIS9_TexturePacker::sceneWithTitle(s_testArray[_currentUISceneId]);
+        case kUIS9FrameNameSpriteSheetRotatedInsetsScaled:
+            return UIS9FrameNameSpriteSheetRotatedInsetsScaled::sceneWithTitle(s_testArray[_currentUISceneId]);
+        case kUIS9FrameNameSpriteSheetRotatedSetCapInsetLater:
+            return UIS9FrameNameSpriteSheetRotatedSetCapInsetLater::sceneWithTitle(s_testArray[_currentUISceneId]);
+        case kUIS9CascadeOpacityAndColor:
+            return UIS9CascadeOpacityAndColor::sceneWithTitle(s_testArray[_currentUISceneId]);
+        case kUIS9ZOrder:
+            return UIS9ZOrder::sceneWithTitle(s_testArray[_currentUISceneId]);
+        case kUIS9Flip:
+            return UIS9Flip::sceneWithTitle(s_testArray[_currentUISceneId]);
     }
     return nullptr;
 }

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UISceneManager.cpp
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UISceneManager.cpp
@@ -125,7 +125,7 @@ static const char* s_testArray[] =
     "UIFocusTest-NestedLayout3",
     "UIFocusTest-ListView",
 #if (CC_TARGET_PLATFORM == CC_PLATFORM_ANDROID || CC_TARGET_PLATFORM == CC_PLATFORM_IOS)
-    "UIVideoPlayerTest"
+    "UIVideoPlayerTest",
 #endif
     "UIScale9SpriteTest",
     "UIScale9SpriteHierarchialTest",

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UISceneManager.h
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UISceneManager.h
@@ -113,6 +113,25 @@ enum
 #if (CC_TARGET_PLATFORM == CC_PLATFORM_ANDROID || CC_TARGET_PLATFORM == CC_PLATFORM_IOS)
     kUIVideoPlayerTest,
 #endif
+    kUIScale9SpriteTest,
+    kUIScale9SpriteHierarchialTest,
+    kUIScale9SpriteTouchTest,
+    kUIS9BatchNodeBasic,
+    kUIS9FrameNameSpriteSheet,
+    kUIS9FrameNameSpriteSheetRotated,
+    kUIS9BatchNodeScaledNoInsets,
+    kUIS9FrameNameSpriteSheetScaledNoInsets,
+    kUIS9FrameNameSpriteSheetRotatedScaledNoInsets,
+    kUIS9BatchNodeScaleWithCapInsets,
+    kUIS9FrameNameSpriteSheetInsets,
+    kUIS9FrameNameSpriteSheetInsetsScaled,
+    kUIS9FrameNameSpriteSheetRotatedInsets,
+    kUIS9_TexturePacker,
+    kUIS9FrameNameSpriteSheetRotatedInsetsScaled,
+    kUIS9FrameNameSpriteSheetRotatedSetCapInsetLater,
+    kUIS9CascadeOpacityAndColor,
+    kUIS9ZOrder,
+    kUIS9Flip,
     kUITestMax
 };
 

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UISceneManager.h
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UISceneManager.h
@@ -39,14 +39,6 @@ enum
     kUICheckBoxTest,
     kUISliderTest,
     kUISliderTest_Scale9,
-    /*
-    kUIPotentiometerTest,
-     */
-    /*
-    kUISwitchTest_Horizontal,
-    kUISwitchTest_Vertical,
-    kUISwitchTest_VerticalAndTitleVertical,
-     */
     kUIImageViewTest,
     kUIImageViewTest_Scale9,
     kUIImageViewTest_ContentSize,
@@ -54,15 +46,6 @@ enum
     kUILoadingBarTest_Right,
     kUILoadingBarTest_Left_Scale9,
     kUILoadingBarTest_Right_Scale9,
-    /*
-    kUIProgressTimerTest_Radial,
-    kUIProgressTimerTest_Horizontal,
-    kUIProgressTimerTest_Vertical,
-    kUIProgressTimerTest_RadialMidpointChanged,
-    kUIProgressTimerTest_BarVarious,
-    kUIProgressTimerTest_BarTintAndFade,
-    kUIProgressTimerTest_WithSpriteFrame,
-     */
     kUITextAtlasTest,
     kUITextTest,
     kUITextTest_LineWrap,
@@ -84,9 +67,6 @@ enum
     kUILayoutTest_Layout_Linear_Horizontal,
     kUILayoutTest_Layout_Relative_Align_Parent,
     kUILayoutTest_Layout_Relative_Location,
-    /*
-    kUILayoutTest_Layout_Grid,
-     */
     kUIScrollViewTest_Vertical,
     kUIScrollViewTest_Horizontal,
     kUIScrollViewTest_Both,
@@ -96,12 +76,6 @@ enum
     kUIPageViewButtonTest,
     kUIListViewTest_Vertical,
     kUIListViewTest_Horizontal,
-    /*
-    kUIGridViewTest_Mode_Column,
-    kUIGridViewTest_Mode_Row,
-    kUIPickerViewTest_Vertical,
-    kUIPickerViewTest_Horizontal,
-     */
     kUIWidgetAddNodeTest,
     kUIRichTextTest,
     KUIFocusTest_HBox,

--- a/tests/cpp-tests/proj.win32/cpp-tests.vcxproj
+++ b/tests/cpp-tests/proj.win32/cpp-tests.vcxproj
@@ -214,6 +214,7 @@
     <ClCompile Include="..\Classes\UITest\CocoStudioGUITest\UIPageViewTest\UIPageViewTest.cpp" />
     <ClCompile Include="..\Classes\UITest\CocoStudioGUITest\UIPageViewTest\UIPageViewTest_Editor.cpp" />
     <ClCompile Include="..\Classes\UITest\CocoStudioGUITest\UIRichTextTest\UIRichTextTest.cpp" />
+    <ClCompile Include="..\Classes\UITest\CocoStudioGUITest\UIScale9SpriteTest.cpp" />
     <ClCompile Include="..\Classes\UITest\CocoStudioGUITest\UIScene.cpp" />
     <ClCompile Include="..\Classes\UITest\CocoStudioGUITest\UISceneManager.cpp" />
     <ClCompile Include="..\Classes\UITest\CocoStudioGUITest\UISceneManager_Editor.cpp" />
@@ -399,6 +400,7 @@
     <ClInclude Include="..\Classes\UITest\CocoStudioGUITest\UIPageViewTest\UIPageViewTest.h" />
     <ClInclude Include="..\Classes\UITest\CocoStudioGUITest\UIPageViewTest\UIPageViewTest_Editor.h" />
     <ClInclude Include="..\Classes\UITest\CocoStudioGUITest\UIRichTextTest\UIRichTextTest.h" />
+    <ClInclude Include="..\Classes\UITest\CocoStudioGUITest\UIScale9SpriteTest.h" />
     <ClInclude Include="..\Classes\UITest\CocoStudioGUITest\UIScene.h" />
     <ClInclude Include="..\Classes\UITest\CocoStudioGUITest\UISceneManager.h" />
     <ClInclude Include="..\Classes\UITest\CocoStudioGUITest\UISceneManager_Editor.h" />

--- a/tests/cpp-tests/proj.win32/cpp-tests.vcxproj.filters
+++ b/tests/cpp-tests/proj.win32/cpp-tests.vcxproj.filters
@@ -855,6 +855,9 @@
     <ClCompile Include="..\Classes\UITest\CocoStudioGUITest\CustomWidget\CustomReader.cpp">
       <Filter>Classes\UITest\CocostudioGUISceneTest\CustomWidget</Filter>
     </ClCompile>
+    <ClCompile Include="..\Classes\UITest\CocoStudioGUITest\UIScale9SpriteTest.cpp">
+      <Filter>Classes\UITest\CocostudioGUISceneTest</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="main.h">
@@ -1579,6 +1582,9 @@
     </ClInclude>
     <ClInclude Include="..\Classes\UITest\CocoStudioGUITest\CustomWidget\CustomReader.h">
       <Filter>Classes\UITest\CocostudioGUISceneTest\CustomWidget</Filter>
+    </ClInclude>
+    <ClInclude Include="..\Classes\UITest\CocoStudioGUITest\UIScale9SpriteTest.h">
+      <Filter>Classes\UITest\CocostudioGUISceneTest</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>

--- a/tests/cpp-tests/proj.wp8-xaml/cpp-testsComponent/cpp-testsComponent.vcxproj
+++ b/tests/cpp-tests/proj.wp8-xaml/cpp-testsComponent/cpp-testsComponent.vcxproj
@@ -260,6 +260,7 @@
     <ClCompile Include="..\..\Classes\UITest\CocoStudioGUITest\UIPageViewTest\UIPageViewTest.cpp" />
     <ClCompile Include="..\..\Classes\UITest\CocoStudioGUITest\UIPageViewTest\UIPageViewTest_Editor.cpp" />
     <ClCompile Include="..\..\Classes\UITest\CocoStudioGUITest\UIRichTextTest\UIRichTextTest.cpp" />
+    <ClCompile Include="..\..\Classes\UITest\CocoStudioGUITest\UIScale9SpriteTest.cpp" />
     <ClCompile Include="..\..\Classes\UITest\CocoStudioGUITest\UIScene.cpp" />
     <ClCompile Include="..\..\Classes\UITest\CocoStudioGUITest\UISceneManager.cpp" />
     <ClCompile Include="..\..\Classes\UITest\CocoStudioGUITest\UISceneManager_Editor.cpp" />
@@ -460,6 +461,7 @@
     <ClInclude Include="..\..\Classes\UITest\CocoStudioGUITest\UIPageViewTest\UIPageViewTest.h" />
     <ClInclude Include="..\..\Classes\UITest\CocoStudioGUITest\UIPageViewTest\UIPageViewTest_Editor.h" />
     <ClInclude Include="..\..\Classes\UITest\CocoStudioGUITest\UIRichTextTest\UIRichTextTest.h" />
+    <ClInclude Include="..\..\Classes\UITest\CocoStudioGUITest\UIScale9SpriteTest.h" />
     <ClInclude Include="..\..\Classes\UITest\CocoStudioGUITest\UIScene.h" />
     <ClInclude Include="..\..\Classes\UITest\CocoStudioGUITest\UISceneManager.h" />
     <ClInclude Include="..\..\Classes\UITest\CocoStudioGUITest\UISceneManager_Editor.h" />

--- a/tests/cpp-tests/proj.wp8-xaml/cpp-testsComponent/cpp-testsComponent.vcxproj.filters
+++ b/tests/cpp-tests/proj.wp8-xaml/cpp-testsComponent/cpp-testsComponent.vcxproj.filters
@@ -855,6 +855,9 @@
     <ClCompile Include="..\..\Classes\UITest\CocoStudioGUITest\CocostudioParserTest.cpp">
       <Filter>Classes\UITest\CocosStudioGUITest</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\Classes\UITest\CocoStudioGUITest\UIScale9SpriteTest.cpp">
+      <Filter>Classes\UITest\CocosStudioGUITest</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\Classes\AppDelegate.h">
@@ -1582,6 +1585,9 @@
       <Filter>Classes\UITest\CocosStudioGUITest</Filter>
     </ClInclude>
     <ClInclude Include="..\..\Classes\UITest\CocoStudioGUITest\CocostudioParserTest.h">
+      <Filter>Classes\UITest\CocosStudioGUITest</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Classes\UITest\CocoStudioGUITest\UIScale9SpriteTest.h">
       <Filter>Classes\UITest\CocosStudioGUITest</Filter>
     </ClInclude>
   </ItemGroup>


### PR DESCRIPTION
1. Add UIScale9Sprite  to mimic the function of extension::Scale9Sprite and enhance the Scale9Sprite class.
2. Make all the UI classes which used extension::Scale9Sprite now uses ui::Scale9Sprite instead.
3. add UIScale9Sprite Tests 
4. fix platform related compile errors
