### PR TITLE
fix LabelTTF::getBoundingBox() position error

### DIFF
--- a/cocos/2d/CCLabelTTF.cpp
+++ b/cocos/2d/CCLabelTTF.cpp
@@ -280,7 +280,9 @@ const Size& LabelTTF::getContentSize() const
 
 Rect LabelTTF::getBoundingBox() const
 {
-    return _renderLabel->getBoundingBox();
+    Size size = getContentSize();
+    Rect rect = Node::getBoundingBox();
+    return rect;
 }
 
 #if defined(__GNUC__) && ((__GNUC__ >= 4) || ((__GNUC__ == 3) && (__GNUC_MINOR__ >= 1)))

--- a/cocos/2d/CCLabelTTF.cpp
+++ b/cocos/2d/CCLabelTTF.cpp
@@ -280,8 +280,8 @@ const Size& LabelTTF::getContentSize() const
 
 Rect LabelTTF::getBoundingBox() const
 {
-	const_cast<LabelTTF*>(this)->setContentSize(_renderLabel->getContentSize());
-	return Node::getBoundingBox();
+    const_cast<LabelTTF*>(this)->setContentSize(_renderLabel->getContentSize());
+    return Node::getBoundingBox();
 }
 
 #if defined(__GNUC__) && ((__GNUC__ >= 4) || ((__GNUC__ == 3) && (__GNUC_MINOR__ >= 1)))

--- a/cocos/2d/CCLabelTTF.cpp
+++ b/cocos/2d/CCLabelTTF.cpp
@@ -280,9 +280,8 @@ const Size& LabelTTF::getContentSize() const
 
 Rect LabelTTF::getBoundingBox() const
 {
-    Size size = getContentSize();
-    Rect rect = Node::getBoundingBox();
-    return rect;
+	const_cast<LabelTTF*>(this)->setContentSize(_renderLabel->getContentSize());
+	return Node::getBoundingBox();
 }
 
 #if defined(__GNUC__) && ((__GNUC__ >= 4) || ((__GNUC__ == 3) && (__GNUC_MINOR__ >= 1)))


### PR DESCRIPTION
this is because getContentSize() is required to refresh the position first.
