### PR TITLE
refactor ui::widgets to use ui::Scale9Sprite instead of extension::Scale9Sprite

### DIFF
--- a/cocos/ui/UIButton.cpp
+++ b/cocos/ui/UIButton.cpp
@@ -505,8 +505,9 @@ void Button::normalTextureScaleChangedWithSize()
     {
         if (_scale9Enabled)
         {
-            static_cast<Scale9Sprite*>(_buttonNormalRenderer)->setPreferredSize(_contentSize);
+            _buttonNormalRenderer->setPreferredSize(_contentSize);
             _normalTextureScaleXInSize = _normalTextureScaleYInSize = 1.0f;
+            _buttonNormalRenderer->setScale(_normalTextureScaleXInSize,_normalTextureScaleYInSize);
         }
         else
         {
@@ -541,8 +542,9 @@ void Button::pressedTextureScaleChangedWithSize()
     {
         if (_scale9Enabled)
         {
-            static_cast<Scale9Sprite*>(_buttonClickedRenderer)->setPreferredSize(_contentSize);
+            _buttonClickedRenderer->setPreferredSize(_contentSize);
             _pressedTextureScaleXInSize = _pressedTextureScaleYInSize = 1.0f;
+            _buttonClickedRenderer->setScale(_pressedTextureScaleXInSize,_pressedTextureScaleYInSize);
         }
         else
         {
@@ -576,7 +578,8 @@ void Button::disabledTextureScaleChangedWithSize()
     {
         if (_scale9Enabled)
         {
-            static_cast<Scale9Sprite*>(_buttonDisableRenderer)->setPreferredSize(_contentSize);
+            _buttonDisableRenderer->setScale(1.0);
+            _buttonDisableRenderer->setPreferredSize(_contentSize);
         }
         else
         {

--- a/cocos/ui/UIButton.cpp
+++ b/cocos/ui/UIButton.cpp
@@ -135,9 +135,13 @@ bool Button::init()
 
 void Button::initRenderer()
 {
-    _buttonNormalRenderer = Sprite::create();
-    _buttonClickedRenderer = Sprite::create();
-    _buttonDisableRenderer = Sprite::create();
+    _buttonNormalRenderer = Scale9Sprite::create();
+    _buttonClickedRenderer = Scale9Sprite::create();
+    _buttonDisableRenderer = Scale9Sprite::create();
+    _buttonClickedRenderer->setScale9Enabled(false);
+    _buttonNormalRenderer->setScale9Enabled(false);
+    _buttonDisableRenderer->setScale9Enabled(false);
+    
     _titleRenderer = Label::create();
     _titleRenderer->setAnchorPoint(Vec2::ANCHOR_MIDDLE);
 
@@ -153,33 +157,13 @@ void Button::setScale9Enabled(bool able)
     {
         return;
     }
-    _brightStyle = BrightStyle::NONE;
+    
     _scale9Enabled = able;
-    removeProtectedChild(_buttonNormalRenderer);
-    removeProtectedChild(_buttonClickedRenderer);
-    removeProtectedChild(_buttonDisableRenderer);
-    _buttonNormalRenderer = nullptr;
-    _buttonClickedRenderer = nullptr;
-    _buttonDisableRenderer = nullptr;
-    if (_scale9Enabled)
-    {
-        _buttonNormalRenderer = Scale9Sprite::create();
-        _buttonClickedRenderer = Scale9Sprite::create();
-        _buttonDisableRenderer = Scale9Sprite::create();
-    }
-    else
-    {
-        _buttonNormalRenderer = Sprite::create();
-        _buttonClickedRenderer = Sprite::create();
-        _buttonDisableRenderer = Sprite::create();
-    }
-
-    loadTextureNormal(_normalFileName, _normalTexType);
-    loadTexturePressed(_clickedFileName, _pressedTexType);
-    loadTextureDisabled(_disabledFileName, _disabledTexType);
-    addProtectedChild(_buttonNormalRenderer, NORMAL_RENDERER_Z, -1);
-    addProtectedChild(_buttonClickedRenderer, PRESSED_RENDERER_Z, -1);
-    addProtectedChild(_buttonDisableRenderer, DISABLED_RENDERER_Z, -1);
+    
+    _buttonNormalRenderer->setScale9Enabled(_scale9Enabled);
+    _buttonClickedRenderer->setScale9Enabled(_scale9Enabled);
+    _buttonDisableRenderer->setScale9Enabled(_scale9Enabled);
+   
     if (_scale9Enabled)
     {
         bool ignoreBefore = _ignoreSize;
@@ -190,9 +174,12 @@ void Button::setScale9Enabled(bool able)
     {
         ignoreContentAdaptWithSize(_prevIgnoreSize);
     }
+    
     setCapInsetsNormalRenderer(_capInsetsNormal);
     setCapInsetsPressedRenderer(_capInsetsPressed);
     setCapInsetsDisabledRenderer(_capInsetsDisabled);
+    
+    _brightStyle = BrightStyle::NONE;
     setBright(_bright);
 }
 
@@ -228,37 +215,19 @@ void Button::loadTextureNormal(const std::string& normal,TextureResType texType)
     }
     _normalFileName = normal;
     _normalTexType = texType;
-    if (_scale9Enabled)
+    
+    switch (_normalTexType)
     {
-        Scale9Sprite* normalRendererScale9 = static_cast<Scale9Sprite*>(_buttonNormalRenderer);
-        switch (_normalTexType)
-        {
-            case TextureResType::LOCAL:
-                normalRendererScale9->initWithFile(normal);
-                break;
-            case TextureResType::PLIST:
-                normalRendererScale9->initWithSpriteFrameName(normal);
-                break;
-            default:
-                break;
-        }
-        normalRendererScale9->setCapInsets(_capInsetsNormal);
+        case TextureResType::LOCAL:
+            _buttonNormalRenderer->initWithFile(normal);
+            break;
+        case TextureResType::PLIST:
+            _buttonNormalRenderer->initWithSpriteFrameName(normal);
+            break;
+        default:
+            break;
     }
-    else
-    {
-        Sprite* normalRenderer = static_cast<Sprite*>(_buttonNormalRenderer);
-        switch (_normalTexType)
-        {
-            case TextureResType::LOCAL:
-                normalRenderer->setTexture(normal);
-                break;
-            case TextureResType::PLIST:
-                normalRenderer->setSpriteFrame(normal);
-                break;
-            default:
-                break;
-        }
-    }
+    
     _normalTextureSize = _buttonNormalRenderer->getContentSize();
     updateFlippedX();
     updateFlippedY();
@@ -276,38 +245,21 @@ void Button::loadTexturePressed(const std::string& selected,TextureResType texTy
     }
     _clickedFileName = selected;
     _pressedTexType = texType;
-    if (_scale9Enabled)
+
+    switch (_pressedTexType)
     {
-        Scale9Sprite* clickedRendererScale9 = static_cast<Scale9Sprite*>(_buttonClickedRenderer);
-        switch (_pressedTexType)
-        {
-            case TextureResType::LOCAL:
-                clickedRendererScale9->initWithFile(selected);
-                break;
-            case TextureResType::PLIST:
-                clickedRendererScale9->initWithSpriteFrameName(selected);
-                break;
-            default:
-                break;
-        }
-        clickedRendererScale9->setCapInsets(_capInsetsPressed);
+        case TextureResType::LOCAL:
+            _buttonClickedRenderer->initWithFile(selected);
+            break;
+        case TextureResType::PLIST:
+            _buttonClickedRenderer->initWithSpriteFrameName(selected);
+            break;
+        default:
+            break;
     }
-    else
-    {
-        Sprite* clickedRenderer = static_cast<Sprite*>(_buttonClickedRenderer);
-        switch (_pressedTexType)
-        {
-            case TextureResType::LOCAL:
-                clickedRenderer->setTexture(selected);
-                break;
-            case TextureResType::PLIST:
-                clickedRenderer->setSpriteFrame(selected);
-                break;
-            default:
-                break;
-        }
-    }
+    
     _pressedTextureSize = _buttonClickedRenderer->getContentSize();
+    //TODO: mark as dirty
     updateFlippedX();
     updateFlippedY();
     
@@ -323,37 +275,19 @@ void Button::loadTextureDisabled(const std::string& disabled,TextureResType texT
     }
     _disabledFileName = disabled;
     _disabledTexType = texType;
-    if (_scale9Enabled)
+
+    switch (_disabledTexType)
     {
-        Scale9Sprite* disabledScale9 = static_cast<Scale9Sprite*>(_buttonDisableRenderer);
-        switch (_disabledTexType)
-        {
-            case TextureResType::LOCAL:
-                disabledScale9->initWithFile(disabled);
-                break;
-            case TextureResType::PLIST:
-                disabledScale9->initWithSpriteFrameName(disabled);
-                break;
-            default:
-                break;
-        }
-        disabledScale9->setCapInsets(_capInsetsDisabled);
+        case TextureResType::LOCAL:
+            _buttonDisableRenderer->initWithFile(disabled);
+            break;
+        case TextureResType::PLIST:
+            _buttonDisableRenderer->initWithSpriteFrameName(disabled);
+            break;
+        default:
+            break;
     }
-    else
-    {
-        Sprite* disabledRenderer = static_cast<Sprite*>(_buttonDisableRenderer);
-        switch (_disabledTexType)
-        {
-            case TextureResType::LOCAL:
-                disabledRenderer->setTexture(disabled);
-                break;
-            case TextureResType::PLIST:
-                disabledRenderer->setSpriteFrame(disabled);
-                break;
-            default:
-                break;
-        }
-    }
+
     _disabledTextureSize = _buttonDisableRenderer->getContentSize();
     updateFlippedX();
     updateFlippedY();
@@ -376,7 +310,7 @@ void Button::setCapInsetsNormalRenderer(const Rect &capInsets)
     {
         return;
     }
-    static_cast<Scale9Sprite*>(_buttonNormalRenderer)->setCapInsets(capInsets);
+    _buttonNormalRenderer->setCapInsets(capInsets);
 }
 
 const Rect& Button::getCapInsetsNormalRenderer()const
@@ -391,7 +325,7 @@ void Button::setCapInsetsPressedRenderer(const Rect &capInsets)
     {
         return;
     }
-    static_cast<Scale9Sprite*>(_buttonClickedRenderer)->setCapInsets(capInsets);
+    _buttonClickedRenderer->setCapInsets(capInsets);
 }
 
 const Rect& Button::getCapInsetsPressedRenderer()const
@@ -406,7 +340,7 @@ void Button::setCapInsetsDisabledRenderer(const Rect &capInsets)
     {
         return;
     }
-    static_cast<Scale9Sprite*>(_buttonDisableRenderer)->setCapInsets(capInsets);
+    _buttonDisableRenderer->setCapInsets(capInsets);
 }
 
 const Rect& Button::getCapInsetsDisabledRenderer()const
@@ -432,27 +366,9 @@ void Button::onPressStateChangedToNormal()
     }
     else
     {
-        if (_scale9Enabled)
-        {
-            updateTexturesRGBA();
-        }
-        else
-        {
-            _buttonNormalRenderer->stopAllActions();
-            _buttonNormalRenderer->setScale(_normalTextureScaleXInSize, _normalTextureScaleYInSize);
-        }
+        _buttonNormalRenderer->stopAllActions();
+        _buttonNormalRenderer->setScale(_normalTextureScaleXInSize, _normalTextureScaleYInSize);
     }
-}
-    
-void Button::updateTexturesRGBA()
-{
-    _buttonNormalRenderer->setColor(this->getColor());
-    _buttonClickedRenderer->setColor(this->getColor());
-    _buttonDisableRenderer->setColor(this->getColor());
-
-    _buttonNormalRenderer->setOpacity(this->getOpacity());
-    _buttonClickedRenderer->setOpacity(this->getOpacity());
-    _buttonDisableRenderer->setOpacity(this->getOpacity());
 }
 
 void Button::onPressStateChangedToPressed()
@@ -462,6 +378,7 @@ void Button::onPressStateChangedToPressed()
         _buttonNormalRenderer->setVisible(false);
         _buttonClickedRenderer->setVisible(true);
         _buttonDisableRenderer->setVisible(false);
+        
         if (_pressedActionEnabled)
         {
             _buttonNormalRenderer->stopAllActions();
@@ -501,36 +418,19 @@ void Button::updateFlippedX()
 {
     float flip = _flippedX ? -1.0f : 1.0f;
     _titleRenderer->setScaleX(flip);
-    if (_scale9Enabled)
-    {
-        _buttonNormalRenderer->setScaleX(flip);
-        _buttonClickedRenderer->setScaleX(flip);
-        _buttonDisableRenderer->setScaleX(flip);
-    }
-    else
-    {
-        static_cast<Sprite*>(_buttonNormalRenderer)->setFlippedX(_flippedX);
-        static_cast<Sprite*>(_buttonClickedRenderer)->setFlippedX(_flippedX);
-        static_cast<Sprite*>(_buttonDisableRenderer)->setFlippedX(_flippedX);
-    }
+
+    _buttonNormalRenderer->setFlippedX(_flippedX);
+    _buttonClickedRenderer->setFlippedX(_flippedX);
+    _buttonDisableRenderer->setFlippedX(_flippedX);
 }
     
 void Button::updateFlippedY()
 {
     float flip = _flippedY ? -1.0f : 1.0f;
     _titleRenderer->setScaleY(flip);
-    if (_scale9Enabled)
-    {
-        _buttonNormalRenderer->setScaleY(flip);
-        _buttonClickedRenderer->setScaleY(flip);
-        _buttonDisableRenderer->setScaleY(flip);
-    }
-    else
-    {
-        static_cast<Sprite*>(_buttonNormalRenderer)->setFlippedY(_flippedY);
-        static_cast<Sprite*>(_buttonClickedRenderer)->setFlippedY(_flippedY);
-        static_cast<Sprite*>(_buttonDisableRenderer)->setFlippedY(_flippedY);
-    }
+    _buttonNormalRenderer->setFlippedY(_flippedY);
+    _buttonClickedRenderer->setFlippedY(_flippedY);
+    _buttonDisableRenderer->setFlippedY(_flippedY);
 }
     
 void Button::updateTitleLocation()

--- a/cocos/ui/UIButton.h
+++ b/cocos/ui/UIButton.h
@@ -33,7 +33,8 @@ NS_CC_BEGIN
 class Label;
 
 namespace ui{
-
+    
+    class Scale9Sprite;
 /**
 *   @js NA
 *   @lua NA
@@ -205,9 +206,7 @@ protected:
   
     virtual void updateFlippedX() override;
     virtual void updateFlippedY() override;
-    
-    void updateTexturesRGBA();
-    
+        
     void normalTextureScaleChangedWithSize();
     void pressedTextureScaleChangedWithSize();
     void disabledTextureScaleChangedWithSize();
@@ -219,10 +218,11 @@ protected:
     virtual void copySpecialProperties(Widget* model) override;
    
 protected:
-    Node* _buttonNormalRenderer;
-    Node* _buttonClickedRenderer;
-    Node* _buttonDisableRenderer;
+    Scale9Sprite* _buttonNormalRenderer;
+    Scale9Sprite* _buttonClickedRenderer;
+    Scale9Sprite* _buttonDisableRenderer;
     Label* _titleRenderer;
+    
     std::string _normalFileName;
     std::string _clickedFileName;
     std::string _disabledFileName;

--- a/cocos/ui/UIImageView.cpp
+++ b/cocos/ui/UIImageView.cpp
@@ -105,6 +105,8 @@ bool ImageView::init(const std::string &imageFileName, TextureResType texType)
 void ImageView::initRenderer()
 {
     _imageRenderer = Scale9Sprite::create();
+    _imageRenderer->setScale9Enabled(false);
+    
     addProtectedChild(_imageRenderer, IMAGE_RENDERER_Z, -1);
 }
 

--- a/cocos/ui/UIImageView.cpp
+++ b/cocos/ui/UIImageView.cpp
@@ -146,7 +146,15 @@ void ImageView::setTextureRect(const Rect &rect)
     }
     else
     {
-       _imageRenderer->getSprite()->setTextureRect(rect);
+        auto sprite = _imageRenderer->getSprite();
+        if (sprite)
+        {
+            sprite->setTextureRect(rect);
+        }
+        else
+        {
+            CCLOG("Warning!! you should load texture before set the texture's rect!");
+        }
     }
 }
     

--- a/cocos/ui/UIImageView.cpp
+++ b/cocos/ui/UIImageView.cpp
@@ -29,10 +29,6 @@ THE SOFTWARE.
 NS_CC_BEGIN
 
 namespace ui {
-
-
-#define STATIC_CAST_CCSPRITE static_cast<Sprite*>(_imageRenderer)
-#define STATIC_CAST_SCALE9SPRITE static_cast<Scale9Sprite*>(_imageRenderer)
     
 static const int IMAGE_RENDERER_Z = (-1);
     
@@ -108,7 +104,7 @@ bool ImageView::init(const std::string &imageFileName, TextureResType texType)
 
 void ImageView::initRenderer()
 {
-    _imageRenderer = Sprite::create();
+    _imageRenderer = Scale9Sprite::create();
     addProtectedChild(_imageRenderer, IMAGE_RENDERER_Z, -1);
 }
 
@@ -123,34 +119,15 @@ void ImageView::loadTexture(const std::string& fileName, TextureResType texType)
     switch (_imageTexType)
     {
         case TextureResType::LOCAL:
-            if (_scale9Enabled)
-            {
-                Scale9Sprite* imageRendererScale9 = STATIC_CAST_SCALE9SPRITE;
-                imageRendererScale9->initWithFile(fileName);
-                imageRendererScale9->setCapInsets(_capInsets);
-            }
-            else
-            {
-                Sprite* imageRenderer = STATIC_CAST_CCSPRITE;
-                imageRenderer->setTexture(fileName);
-            }
+            _imageRenderer->initWithFile(fileName);
             break;
         case TextureResType::PLIST:
-            if (_scale9Enabled)
-            {
-                Scale9Sprite* imageRendererScale9 = STATIC_CAST_SCALE9SPRITE;
-                imageRendererScale9->initWithSpriteFrameName(fileName);
-                imageRendererScale9->setCapInsets(_capInsets);
-            }
-            else
-            {
-                Sprite* imageRenderer = STATIC_CAST_CCSPRITE;
-                imageRenderer->setSpriteFrame(fileName);
-            }
+            _imageRenderer->initWithSpriteFrameName(fileName);
             break;
         default:
             break;
     }
+    
     _imageTextureSize = _imageRenderer->getContentSize();
     updateFlippedX();
     updateFlippedY();
@@ -161,39 +138,24 @@ void ImageView::loadTexture(const std::string& fileName, TextureResType texType)
 
 void ImageView::setTextureRect(const Rect &rect)
 {
+    //This API should be refactor
     if (_scale9Enabled)
     {
     }
     else
     {
-        STATIC_CAST_CCSPRITE->setTextureRect(rect);
+       _imageRenderer->getSprite()->setTextureRect(rect);
     }
 }
     
 void ImageView::updateFlippedX()
 {
-    if (_scale9Enabled)
-    {
-        int flip = _flippedX ? -1 : 1;
-        STATIC_CAST_SCALE9SPRITE->setScaleX(flip);
-    }
-    else
-    {
-        STATIC_CAST_CCSPRITE->setFlippedX(_flippedX);
-    }
+    _imageRenderer->setFlippedX(_flippedX);
 }
     
 void ImageView::updateFlippedY()
 {
-    if (_scale9Enabled)
-    {
-        int flip = _flippedY ? -1 : 1;
-        STATIC_CAST_SCALE9SPRITE->setScaleY(flip);
-    }
-    else
-    {
-        STATIC_CAST_CCSPRITE->setFlippedY(_flippedY);
-    }
+    _imageRenderer->setFlippedY(_flippedY);
 
 }
 
@@ -206,18 +168,8 @@ void ImageView::setScale9Enabled(bool able)
     
     
     _scale9Enabled = able;
-    removeProtectedChild(_imageRenderer);
-    _imageRenderer = nullptr;
-    if (_scale9Enabled)
-    {
-        _imageRenderer = Scale9Sprite::create();
-    }
-    else
-    {
-        _imageRenderer = Sprite::create();
-    }
-    loadTexture(_textureFile,_imageTexType);
-    addProtectedChild(_imageRenderer, IMAGE_RENDERER_Z, -1);
+    _imageRenderer->setScale9Enabled(_scale9Enabled);
+    
     if (_scale9Enabled)
     {
         bool ignoreBefore = _ignoreSize;
@@ -252,7 +204,7 @@ void ImageView::setCapInsets(const Rect &capInsets)
     {
         return;
     }
-    STATIC_CAST_SCALE9SPRITE->setCapInsets(capInsets);
+    _imageRenderer->setCapInsets(capInsets);
 }
 
 const Rect& ImageView::getCapInsets()const
@@ -298,7 +250,7 @@ void ImageView::imageTextureScaleChangedWithSize()
     {
         if (_scale9Enabled)
         {
-            static_cast<Scale9Sprite*>(_imageRenderer)->setPreferredSize(_contentSize);
+            _imageRenderer->setPreferredSize(_contentSize);
         }
         else
         {

--- a/cocos/ui/UIImageView.h
+++ b/cocos/ui/UIImageView.h
@@ -31,7 +31,7 @@ THE SOFTWARE.
 NS_CC_BEGIN
 
 namespace ui {
-
+    class Scale9Sprite;
 /**
 *   @js NA
 *   @lua NA
@@ -132,7 +132,7 @@ protected:
     bool _scale9Enabled;
     bool _prevIgnoreSize;
     Rect _capInsets;
-    Node* _imageRenderer;
+    Scale9Sprite* _imageRenderer;
     std::string _textureFile;
     TextureResType _imageTexType;
     Size _imageTextureSize;

--- a/cocos/ui/UILayout.cpp
+++ b/cocos/ui/UILayout.cpp
@@ -577,7 +577,7 @@ void Layout::onSizeChanged()
         _backGroundImage->setPosition(Vec2(_contentSize.width/2.0f, _contentSize.height/2.0f));
         if (_backGroundScale9Enabled && _backGroundImage)
         {
-            static_cast<Scale9Sprite*>(_backGroundImage)->setPreferredSize(_contentSize);
+            _backGroundImage->setPreferredSize(_contentSize);
         }
     }
     if (_colorRender)
@@ -596,11 +596,13 @@ void Layout::setBackGroundImageScale9Enabled(bool able)
     {
         return;
     }
-    removeProtectedChild(_backGroundImage);
-    _backGroundImage = nullptr;
     _backGroundScale9Enabled = able;
-    addBackGroundImage();
-    setBackGroundImage(_backGroundImageFileName,_bgImageTexType);
+    if (nullptr == _backGroundImage)
+    {
+        addBackGroundImage();
+        setBackGroundImage(_backGroundImageFileName,_bgImageTexType);
+    }
+    _backGroundImage->setScale9Enabled(_backGroundScale9Enabled);
     setBackGroundImageCapInsets(_backGroundImageCapInsets);
 }
     
@@ -621,36 +623,22 @@ void Layout::setBackGroundImage(const std::string& fileName,TextureResType texTy
     }
     _backGroundImageFileName = fileName;
     _bgImageTexType = texType;
-    if (_backGroundScale9Enabled)
+   
+    switch (_bgImageTexType)
     {
-        Scale9Sprite* bgiScale9 = static_cast<Scale9Sprite*>(_backGroundImage);
-        switch (_bgImageTexType)
-        {
-            case TextureResType::LOCAL:
-                bgiScale9->initWithFile(fileName);
-                break;
-            case TextureResType::PLIST:
-                bgiScale9->initWithSpriteFrameName(fileName);
-                break;
-            default:
-                break;
-        }
-        bgiScale9->setPreferredSize(_contentSize);
+        case TextureResType::LOCAL:
+            _backGroundImage->initWithFile(fileName);
+            break;
+        case TextureResType::PLIST:
+            _backGroundImage->initWithSpriteFrameName(fileName);
+            break;
+        default:
+            break;
     }
-    else
-    {
-        switch (_bgImageTexType)
-        {
-            case TextureResType::LOCAL:
-                static_cast<Sprite*>(_backGroundImage)->setTexture(fileName);
-                break;
-            case TextureResType::PLIST:
-                static_cast<Sprite*>(_backGroundImage)->setSpriteFrame(fileName);
-                break;
-            default:
-                break;
-        }
+    if (_backGroundScale9Enabled) {
+        _backGroundImage->setPreferredSize(_contentSize);
     }
+    
     _backGroundImageTextureSize = _backGroundImage->getContentSize();
     _backGroundImage->setPosition(Vec2(_contentSize.width/2.0f, _contentSize.height/2.0f));
     updateBackGroundImageRGBA();
@@ -661,7 +649,7 @@ void Layout::setBackGroundImageCapInsets(const Rect &capInsets)
     _backGroundImageCapInsets = capInsets;
     if (_backGroundScale9Enabled && _backGroundImage)
     {
-        static_cast<Scale9Sprite*>(_backGroundImage)->setCapInsets(capInsets);
+        _backGroundImage->setCapInsets(capInsets);
     }
 }
     
@@ -706,17 +694,11 @@ void Layout::supplyTheLayoutParameterLackToChild(Widget *child)
 
 void Layout::addBackGroundImage()
 {
-    if (_backGroundScale9Enabled)
-    {
-        _backGroundImage = Scale9Sprite::create();
-        addProtectedChild(_backGroundImage, BACKGROUNDIMAGE_Z, -1);
-        static_cast<Scale9Sprite*>(_backGroundImage)->setPreferredSize(_contentSize);
-    }
-    else
-    {
-        _backGroundImage = Sprite::create();
-        addProtectedChild(_backGroundImage, BACKGROUNDIMAGE_Z, -1);
-    }
+    _backGroundImage = Scale9Sprite::create();
+    _backGroundImage->setScale9Enabled(false);
+    
+    addProtectedChild(_backGroundImage, BACKGROUNDIMAGE_Z, -1);
+   
     _backGroundImage->setPosition(Vec2(_contentSize.width/2.0f, _contentSize.height/2.0f));
 }
 

--- a/cocos/ui/UILayout.h
+++ b/cocos/ui/UILayout.h
@@ -36,10 +36,11 @@ class DrawNode;
 class LayerColor;
 class LayerGradient;
 
+
 namespace ui {
     
 class LayoutManager;
-
+class Scale9Sprite;
 
 class CC_GUI_DLL LayoutProtocol
 {
@@ -466,7 +467,7 @@ protected:
     
     //background
     bool _backGroundScale9Enabled;
-    Node* _backGroundImage;
+    Scale9Sprite* _backGroundImage;
     std::string _backGroundImageFileName;
     Rect _backGroundImageCapInsets;
     BackGroundColorType _colorType;

--- a/cocos/ui/UIListView.cpp
+++ b/cocos/ui/UIListView.cpp
@@ -24,7 +24,6 @@ THE SOFTWARE.
 
 #include "ui/UIListView.h"
 #include "ui/UIHelper.h"
-#include "ui/UIScale9Sprite.h"
 
 NS_CC_BEGIN
 

--- a/cocos/ui/UILoadingBar.cpp
+++ b/cocos/ui/UILoadingBar.cpp
@@ -81,7 +81,8 @@ LoadingBar* LoadingBar::create(const std::string &textureName, float percentage)
 
 void LoadingBar::initRenderer()
 {
-    _barRenderer = Sprite::create();
+    _barRenderer = Scale9Sprite::create();
+    _barRenderer->setScale9Enabled(false);
     addProtectedChild(_barRenderer, BAR_RENDERER_Z, -1);
     _barRenderer->setAnchorPoint(Vec2(0.0,0.5));
 }
@@ -100,17 +101,15 @@ void LoadingBar::setDirection(cocos2d::ui::LoadingBar::Direction direction)
         case Direction::LEFT:
             _barRenderer->setAnchorPoint(Vec2(0.0f,0.5f));
             _barRenderer->setPosition(Vec2(-_totalLength*0.5f,0.0f));
-            if (!_scale9Enabled)
-            {
-                static_cast<Sprite*>(_barRenderer)->setFlippedX(false);
+            if (!_scale9Enabled) {
+                _barRenderer->setFlippedX(false);
             }
             break;
         case Direction::RIGHT:
             _barRenderer->setAnchorPoint(Vec2(1.0f,0.5f));
             _barRenderer->setPosition(Vec2(_totalLength*0.5f,0.0f));
-            if (!_scale9Enabled)
-            {
-                static_cast<Sprite*>(_barRenderer)->setFlippedX(true);
+            if (!_scale9Enabled) {
+                _barRenderer->setFlippedX(true);
             }
             break;
     }
@@ -134,28 +133,10 @@ void LoadingBar::loadTexture(const std::string& texture,TextureResType texType)
     switch (_renderBarTexType)
     {
         case TextureResType::LOCAL:
-            if (_scale9Enabled)
-            {
-                Scale9Sprite* barRendererScale9 = static_cast<Scale9Sprite*>(_barRenderer);
-                barRendererScale9->initWithFile(texture);
-                barRendererScale9->setCapInsets(_capInsets);
-            }
-            else
-            {
-                static_cast<Sprite*>(_barRenderer)->setTexture(texture);
-            }
+            _barRenderer->initWithFile(texture);
             break;
         case TextureResType::PLIST:
-            if (_scale9Enabled)
-            {
-                Scale9Sprite* barRendererScale9 = static_cast<Scale9Sprite*>(_barRenderer);
-                barRendererScale9->initWithSpriteFrameName(texture);
-                barRendererScale9->setCapInsets(_capInsets);
-            }
-            else
-            {
-                static_cast<Sprite*>(_barRenderer)->setSpriteFrame(texture);
-            }
+            _barRenderer->initWithSpriteFrameName(texture);
             break;
         default:
             break;
@@ -167,19 +148,19 @@ void LoadingBar::loadTexture(const std::string& texture,TextureResType texType)
     {
         case Direction::LEFT:
             _barRenderer->setAnchorPoint(Vec2(0.0f,0.5f));
-            if (!_scale9Enabled)
-            {
-                static_cast<Sprite*>(_barRenderer)->setFlippedX(false);
+            if (!_scale9Enabled) {
+                _barRenderer->setFlippedX(false);
             }
             break;
         case Direction::RIGHT:
             _barRenderer->setAnchorPoint(Vec2(1.0f,0.5f));
-            if (!_scale9Enabled)
-            {
-                static_cast<Sprite*>(_barRenderer)->setFlippedX(true);
+            if (!_scale9Enabled) {
+                _barRenderer->setFlippedX(true);
             }
             break;
     }
+    _barRenderer->setCapInsets(_capInsets);
+
     barRendererScaleChangedWithSize();
     updateContentSizeWithTextureSize(_barRendererTextureSize);
     _barRendererAdaptDirty = true;
@@ -192,18 +173,8 @@ void LoadingBar::setScale9Enabled(bool enabled)
         return;
     }
     _scale9Enabled = enabled;
-    removeProtectedChild(_barRenderer);
-    _barRenderer = nullptr;
-    if (_scale9Enabled)
-    {
-        _barRenderer = Scale9Sprite::create();
-    }
-    else
-    {
-        _barRenderer = Sprite::create();
-    }
-    loadTexture(_textureFile,_renderBarTexType);
-    addProtectedChild(_barRenderer, BAR_RENDERER_Z, -1);
+    _barRenderer->setScale9Enabled(_scale9Enabled);
+    
     if (_scale9Enabled)
     {
         bool ignoreBefore = _ignoreSize;
@@ -230,7 +201,7 @@ void LoadingBar::setCapInsets(const Rect &capInsets)
     {
         return;
     }
-    static_cast<Scale9Sprite*>(_barRenderer)->setCapInsets(capInsets);
+    _barRenderer->setCapInsets(capInsets);
 }
 
 const Rect& LoadingBar::getCapInsets()const
@@ -257,7 +228,7 @@ void LoadingBar::setPercent(float percent)
     }
     else
     {
-        Sprite* spriteRenderer = static_cast<Sprite*>(_barRenderer);
+        Sprite* spriteRenderer = _barRenderer->getSprite();
         Rect rect = spriteRenderer->getTextureRect();
         rect.size.width = _barRendererTextureSize.width * res;
         spriteRenderer->setTextureRect(rect, spriteRenderer->isTextureRectRotated(), rect.size);
@@ -351,7 +322,7 @@ void LoadingBar::barRendererScaleChangedWithSize()
 void LoadingBar::setScale9Scale()
 {
     float width = (float)(_percent) / 100.0f * _totalLength;
-    static_cast<Scale9Sprite*>(_barRenderer)->setPreferredSize(Size(width, _contentSize.height));
+    _barRenderer->setPreferredSize(Size(width, _contentSize.height));
 }
 
 std::string LoadingBar::getDescription() const

--- a/cocos/ui/UILoadingBar.h
+++ b/cocos/ui/UILoadingBar.h
@@ -31,7 +31,7 @@ THE SOFTWARE.
 NS_CC_BEGIN
 
 namespace ui {
-
+    class Scale9Sprite;
 /**
 *   @js NA
 *   @lua NA
@@ -154,7 +154,7 @@ protected:
     Direction _direction;
     float _percent;
     float _totalLength;
-    Node* _barRenderer;
+    Scale9Sprite* _barRenderer;
     TextureResType _renderBarTexType;
     Size _barRendererTextureSize;
     bool _scale9Enabled;

--- a/cocos/ui/UIScale9Sprite.cpp
+++ b/cocos/ui/UIScale9Sprite.cpp
@@ -62,6 +62,49 @@ namespace ui {
     
     void Scale9Sprite::cleanupSlicedSprites()
     {
+        if (_topLeft)
+        {
+            _topLeft->onExit();
+        }
+        if (_top)
+        {
+            _top->onExit();
+        }
+        if (_topRight)
+        {
+            _topRight->onExit();
+        }
+        
+        if (_left)
+        {
+            _left->onExit();
+        }
+        
+        if (_centre)
+        {
+            _centre->onExit();
+        }
+        
+        if (_right)
+        {
+            _right->onExit();
+        }
+        
+        if (_bottomLeft)
+        {
+            _bottomLeft->onExit();
+        }
+        
+        if (_bottomRight)
+        {
+            _bottomRight->onExit();
+        }
+        
+        if (_bottom)
+        {
+            _bottom->onExit();
+        }
+        
         CC_SAFE_RELEASE(_topLeft);
         CC_SAFE_RELEASE(_top);
         CC_SAFE_RELEASE(_topRight);
@@ -722,10 +765,6 @@ y+=ytranslate;                       \
             }
         }
         
-        
-        
-        
-        
         //
         // draw self
         //
@@ -742,7 +781,6 @@ y+=ytranslate;                       \
                 _scale9Image->visit(renderer, _modelViewTransform, flags);
             }
         }
-        
         
         
         for(auto it=_children.cbegin()+i; it != _children.cend(); ++it)
@@ -882,21 +920,22 @@ y+=ytranslate;                       \
         _displayedColor.b = _realColor.b * parentColor.b/255.0;
         updateColor();
         
-        if (_scale9Image) {
+        if (_scale9Image)
+        {
             _scale9Image->updateDisplayedColor(_displayedColor);
         }
         
-        for(const auto &child : _protectedChildren){
+        for(const auto &child : _protectedChildren)
+        {
             child->updateDisplayedColor(_displayedColor);
         }
         
         if (_cascadeColorEnabled)
         {
-            for(const auto &child : _children){
+            for(const auto &child : _children)
+            {
                 child->updateDisplayedColor(_displayedColor);
             }
-            
-            
         }
     }
     
@@ -905,33 +944,37 @@ y+=ytranslate;                       \
         _displayedOpacity = _realOpacity * parentOpacity/255.0;
         updateColor();
         
-        if (_scale9Image) {
+        if (_scale9Image)
+        {
             _scale9Image->updateDisplayedOpacity(_displayedOpacity);
         }
         
-        for(auto child : _protectedChildren){
+        for(auto child : _protectedChildren)
+        {
             child->updateDisplayedOpacity(_displayedOpacity);
         }
         
         if (_cascadeOpacityEnabled)
         {
-            for(auto child : _children){
+            for(auto child : _children)
+            {
                 child->updateDisplayedOpacity(_displayedOpacity);
             }
-            
-            
         }
     }
     
     void Scale9Sprite::disableCascadeColor()
     {
-        for(auto child : _children){
+        for(auto child : _children)
+        {
             child->updateDisplayedColor(Color3B::WHITE);
         }
-        for(auto child : _protectedChildren){
+        for(auto child : _protectedChildren)
+        {
             child->updateDisplayedColor(Color3B::WHITE);
         }
-        if (_scale9Image) {
+        if (_scale9Image)
+        {
             _scale9Image->updateDisplayedColor(Color3B::WHITE);
         }
     }
@@ -944,20 +987,32 @@ y+=ytranslate;                       \
     void Scale9Sprite::setFlippedX(bool flippedX)
     {
         _flippedX = flippedX;
-        if (_scale9Enabled) {
+        if (_scale9Enabled)
+        {
             this->setScaleX(-1);
-        }else{
-            _scale9Image->setFlippedX(flippedX);
+        }
+        else
+        {
+            if (_scale9Image)
+            {
+                _scale9Image->setFlippedX(flippedX);
+            }
         }
     }
     
     void Scale9Sprite::setFlippedY(bool flippedY)
     {
         _flippedY = flippedY;
-        if (_scale9Enabled) {
+        if (_scale9Enabled)
+        {
             this->setScaleY(-1);
-        }else{
-            _scale9Image->setFlippedY(flippedY);
+        }
+        else
+        {
+            if (_scale9Image)
+            {
+                _scale9Image->setFlippedY(flippedY);
+            }
         }
     }
     

--- a/cocos/ui/UIScale9Sprite.cpp
+++ b/cocos/ui/UIScale9Sprite.cpp
@@ -798,7 +798,7 @@ y+=ytranslate;                       \
         _reorderProtectedChildDirty = true;
     }
     
-    bool Scale9Sprite::getScale9Enabled() const
+    bool Scale9Sprite::isScale9Enabled() const
     {
         return _scale9Enabled;
     }

--- a/cocos/ui/UIScale9Sprite.cpp
+++ b/cocos/ui/UIScale9Sprite.cpp
@@ -62,58 +62,58 @@ namespace ui {
     
     void Scale9Sprite::cleanupSlicedSprites()
     {
-        if (_topLeft)
+        if (_topLeft && _top->isRunning())
         {
             _topLeft->onExit();
         }
-        if (_top)
+        if (_top && _top->isRunning())
         {
             _top->onExit();
         }
-        if (_topRight)
+        if (_topRight && _top->isRunning())
         {
             _topRight->onExit();
         }
         
-        if (_left)
+        if (_left && _top->isRunning())
         {
             _left->onExit();
         }
         
-        if (_centre)
+        if (_centre && _top->isRunning())
         {
             _centre->onExit();
         }
         
-        if (_right)
+        if (_right && _top->isRunning())
         {
             _right->onExit();
         }
         
-        if (_bottomLeft)
+        if (_bottomLeft && _top->isRunning())
         {
             _bottomLeft->onExit();
         }
         
-        if (_bottomRight)
+        if (_bottomRight && _top->isRunning())
         {
             _bottomRight->onExit();
         }
         
-        if (_bottom)
+        if (_bottom && _top->isRunning())
         {
             _bottom->onExit();
         }
         
-        CC_SAFE_RELEASE(_topLeft);
-        CC_SAFE_RELEASE(_top);
-        CC_SAFE_RELEASE(_topRight);
-        CC_SAFE_RELEASE(_left);
-        CC_SAFE_RELEASE(_centre);
-        CC_SAFE_RELEASE(_right);
-        CC_SAFE_RELEASE(_bottomLeft);
-        CC_SAFE_RELEASE(_bottom);
-        CC_SAFE_RELEASE(_bottomRight);
+        CC_SAFE_RELEASE_NULL(_topLeft);
+        CC_SAFE_RELEASE_NULL(_top);
+        CC_SAFE_RELEASE_NULL(_topRight);
+        CC_SAFE_RELEASE_NULL(_left);
+        CC_SAFE_RELEASE_NULL(_centre);
+        CC_SAFE_RELEASE_NULL(_right);
+        CC_SAFE_RELEASE_NULL(_bottomLeft);
+        CC_SAFE_RELEASE_NULL(_bottom);
+        CC_SAFE_RELEASE_NULL(_bottomRight);
     }
     
     bool Scale9Sprite::init()
@@ -188,8 +188,9 @@ y+=ytranslate;                       \
         _preferredSize = _originalSize;
         _capInsetsInternal = capInsets;
         
-        
-        this->createSlicedSprites(rect, rotated);
+        if (_scale9Enabled) {
+            this->createSlicedSprites(rect, rotated);
+        }
         
         this->setContentSize(rect.size);
         
@@ -852,6 +853,9 @@ y+=ytranslate;                       \
     void Scale9Sprite::setScale9Enabled(bool enabled)
     {
         _scale9Enabled = enabled;
+        if (!_scale9Enabled) {
+            this->cleanupSlicedSprites();
+        }
         _reorderProtectedChildDirty = true;
     }
     
@@ -885,8 +889,8 @@ y+=ytranslate;                       \
     void Scale9Sprite::adjustScale9ImagePosition()
     {
         if (_scale9Image) {
-            _scale9Image->setPosition(_scale9Image->getPosition() + Vec2(_originalSize.width * _anchorPoint.x,
-                                                                         _originalSize.height * _anchorPoint.y));
+            _scale9Image->setPosition(Vec2(_contentSize.width * _anchorPoint.x,
+                                                                         _contentSize.height * _anchorPoint.y));
         }
     }
     

--- a/cocos/ui/UIScale9Sprite.cpp
+++ b/cocos/ui/UIScale9Sprite.cpp
@@ -390,6 +390,25 @@ y+=ytranslate;                       \
         this->_positionsAreDirty = true;
     }
     
+    void Scale9Sprite::setAnchorPoint(const cocos2d::Vec2 &anchorPoint)
+    {
+        Node::setAnchorPoint(anchorPoint);
+        
+        if (_scale9Enabled) {
+            for(const auto& node : _protectedChildren)
+            {
+                node->setAnchorPoint(anchorPoint);
+            }
+        }
+        else
+        {
+            if (_scale9Image) {
+                _scale9Image->setAnchorPoint(anchorPoint);
+            }
+            
+        }
+    }
+    
     void Scale9Sprite::updatePositions()
     {
         // Check that instances are non-NULL
@@ -866,7 +885,8 @@ y+=ytranslate;                       \
     void Scale9Sprite::adjustScale9ImagePosition()
     {
         if (_scale9Image) {
-            _scale9Image->setPosition(_scale9Image->getPosition() + Vec2(_originalSize.width/2, _originalSize.height/2));
+            _scale9Image->setPosition(_scale9Image->getPosition() + Vec2(_originalSize.width * _anchorPoint.x,
+                                                                         _originalSize.height * _anchorPoint.y));
         }
     }
     

--- a/cocos/ui/UIScale9Sprite.h
+++ b/cocos/ui/UIScale9Sprite.h
@@ -246,7 +246,7 @@ namespace ui {
         
         // overrides
         virtual void setContentSize(const Size & size) override;
-        
+
         
         Size getOriginalSize() const;
         void setPreferredSize(const Size& size);

--- a/cocos/ui/UIScale9Sprite.h
+++ b/cocos/ui/UIScale9Sprite.h
@@ -41,6 +41,8 @@ namespace ui {
      * to specific areas of a sprite. With 9-slice scaling (3x3 grid),
      * you can ensure that the sprite does not become distorted when
      * scaled.
+     *  Note: When you set _scale9Enabled to false, then you could call scale9Sprite->getSprite() to return a new Sprite pointer.
+     *         Then you could call any methods of Sprite class with the return pointers.
      *
      */
     class CC_GUI_DLL Scale9Sprite : public Node

--- a/cocos/ui/UIScale9Sprite.h
+++ b/cocos/ui/UIScale9Sprite.h
@@ -262,7 +262,7 @@ namespace ui {
         void setInsetBottom(float bottomInset);
         float getInsetBottom()const;
         void setScale9Enabled(bool enabled);
-        bool getScale9Enabled()const;
+        bool isScale9Enabled()const;
         
         
         

--- a/cocos/ui/UIScale9Sprite.h
+++ b/cocos/ui/UIScale9Sprite.h
@@ -246,7 +246,7 @@ namespace ui {
         
         // overrides
         virtual void setContentSize(const Size & size) override;
-
+        virtual void setAnchorPoint(const Vec2& anchorPoint) override;
         
         Size getOriginalSize() const;
         void setPreferredSize(const Size& size);

--- a/cocos/ui/UISlider.cpp
+++ b/cocos/ui/UISlider.cpp
@@ -339,9 +339,12 @@ void Slider::setPercent(int percent)
     else
     {
         Sprite* spriteRenderer = _progressBarRenderer->getSprite();
-        Rect rect = spriteRenderer->getTextureRect();
-        rect.size.width = _progressBarTextureSize.width * res;
-        spriteRenderer->setTextureRect(rect, spriteRenderer->isTextureRectRotated(), rect.size);
+        
+        if (nullptr != spriteRenderer) {
+            Rect rect = spriteRenderer->getTextureRect();
+            rect.size.width = _progressBarTextureSize.width * res;
+            spriteRenderer->setTextureRect(rect, spriteRenderer->isTextureRectRotated(), rect.size);
+        }
     }
 }
     

--- a/cocos/ui/UISlider.cpp
+++ b/cocos/ui/UISlider.cpp
@@ -98,20 +98,28 @@ bool Slider::init()
 
 void Slider::initRenderer()
 {
-    _barRenderer = Sprite::create();
-    _progressBarRenderer = Sprite::create();
+    _barRenderer = Scale9Sprite::create();
+    _progressBarRenderer = Scale9Sprite::create();
+    _barRenderer->setScale9Enabled(false);
+    _progressBarRenderer->setScale9Enabled(false);
+    
     _progressBarRenderer->setAnchorPoint(Vec2(0.0f, 0.5f));
+    
     addProtectedChild(_barRenderer, BASEBAR_RENDERER_Z, -1);
     addProtectedChild(_progressBarRenderer, PROGRESSBAR_RENDERER_Z, -1);
+    
     _slidBallNormalRenderer = Sprite::create();
     _slidBallPressedRenderer = Sprite::create();
     _slidBallPressedRenderer->setVisible(false);
     _slidBallDisabledRenderer = Sprite::create();
     _slidBallDisabledRenderer->setVisible(false);
+    
     _slidBallRenderer = Node::create();
+    
     _slidBallRenderer->addChild(_slidBallNormalRenderer);
     _slidBallRenderer->addChild(_slidBallPressedRenderer);
     _slidBallRenderer->addChild(_slidBallDisabledRenderer);
+    
     addProtectedChild(_slidBallRenderer, SLIDBALL_RENDERER_Z, -1);
 }
 
@@ -126,24 +134,10 @@ void Slider::loadBarTexture(const std::string& fileName, TextureResType texType)
     switch (_barTexType)
     {
         case TextureResType::LOCAL:
-            if (_scale9Enabled)
-            {
-                static_cast<Scale9Sprite*>(_barRenderer)->initWithFile(fileName);
-            }
-            else
-            {
-                static_cast<Sprite*>(_barRenderer)->setTexture(fileName);
-            }
+            _barRenderer->initWithFile(fileName);
             break;
         case TextureResType::PLIST:
-            if (_scale9Enabled)
-            {
-                static_cast<Scale9Sprite*>(_barRenderer)->initWithSpriteFrameName(fileName);
-            }
-            else
-            {
-                static_cast<Sprite*>(_barRenderer)->setSpriteFrame(fileName);
-            }
+            _barRenderer->initWithSpriteFrameName(fileName);
             break;
         default:
             break;
@@ -165,24 +159,10 @@ void Slider::loadProgressBarTexture(const std::string& fileName, TextureResType 
     switch (_progressBarTexType)
     {
         case TextureResType::LOCAL:
-            if (_scale9Enabled)
-            {
-                static_cast<Scale9Sprite*>(_progressBarRenderer)->initWithFile(fileName);
-            }
-            else
-            {
-                static_cast<Sprite*>(_progressBarRenderer)->setTexture(fileName);
-            }
+            _progressBarRenderer->initWithFile(fileName);
             break;
         case TextureResType::PLIST:
-            if (_scale9Enabled)
-            {
-                static_cast<Scale9Sprite*>(_progressBarRenderer)->initWithSpriteFrameName(fileName);
-            }
-            else
-            {
-                static_cast<Sprite*>(_progressBarRenderer)->setSpriteFrame(fileName);
-            }
+            _progressBarRenderer->initWithSpriteFrameName(fileName);
             break;
         default:
             break;
@@ -201,24 +181,9 @@ void Slider::setScale9Enabled(bool able)
     }
     
     _scale9Enabled = able;
-    removeProtectedChild(_barRenderer);
-    removeProtectedChild(_progressBarRenderer);
-    _barRenderer = nullptr;
-    _progressBarRenderer = nullptr;
-    if (_scale9Enabled)
-    {
-        _barRenderer = Scale9Sprite::create();
-        _progressBarRenderer = Scale9Sprite::create();
-    }
-    else
-    {
-        _barRenderer = Sprite::create();
-        _progressBarRenderer = Sprite::create();
-    }
-    loadBarTexture(_textureFile, _barTexType);
-    loadProgressBarTexture(_progressBarTextureFile, _progressBarTexType);
-    addProtectedChild(_barRenderer, BASEBAR_RENDERER_Z, -1);
-    addProtectedChild(_progressBarRenderer, PROGRESSBAR_RENDERER_Z, -1);
+    _barRenderer->setScale9Enabled(_scale9Enabled);
+    _progressBarRenderer->setScale9Enabled(_scale9Enabled);
+    
     if (_scale9Enabled)
     {
         bool ignoreBefore = _ignoreSize;
@@ -260,7 +225,7 @@ void Slider::setCapInsetsBarRenderer(const Rect &capInsets)
     {
         return;
     }
-    static_cast<Scale9Sprite*>(_barRenderer)->setCapInsets(capInsets);
+    _barRenderer->setCapInsets(capInsets);
 }
     
 const Rect& Slider::getCapInsetsBarRenderer()const
@@ -275,7 +240,7 @@ void Slider::setCapInsetProgressBarRebderer(const Rect &capInsets)
     {
         return;
     }
-    static_cast<Scale9Sprite*>(_progressBarRenderer)->setCapInsets(capInsets);
+    _progressBarRenderer->setCapInsets(capInsets);
 }
     
 const Rect& Slider::getCapInsetsProgressBarRebderer()const
@@ -369,11 +334,11 @@ void Slider::setPercent(int percent)
     _slidBallRenderer->setPosition(Vec2(dis, _contentSize.height / 2.0f));
     if (_scale9Enabled)
     {
-        static_cast<Scale9Sprite*>(_progressBarRenderer)->setPreferredSize(Size(dis,_progressBarTextureSize.height));
+        _progressBarRenderer->setPreferredSize(Size(dis,_progressBarTextureSize.height));
     }
     else
     {
-        Sprite* spriteRenderer = static_cast<Sprite*>(_progressBarRenderer);
+        Sprite* spriteRenderer = _progressBarRenderer->getSprite();
         Rect rect = spriteRenderer->getTextureRect();
         rect.size.width = _progressBarTextureSize.width * res;
         spriteRenderer->setTextureRect(rect, spriteRenderer->isTextureRectRotated(), rect.size);
@@ -497,7 +462,7 @@ void Slider::barRendererScaleChangedWithSize()
         _barLength = _contentSize.width;
         if (_scale9Enabled)
         {
-            static_cast<Scale9Sprite*>(_barRenderer)->setPreferredSize(_contentSize);
+            _barRenderer->setPreferredSize(_contentSize);
         }
         else
         {
@@ -534,7 +499,7 @@ void Slider::progressBarRendererScaleChangedWithSize()
     {
         if (_scale9Enabled)
         {
-            static_cast<Scale9Sprite*>(_progressBarRenderer)->setPreferredSize(_contentSize);
+            _progressBarRenderer->setPreferredSize(_contentSize);
             _progressBarTextureSize = _progressBarRenderer->getContentSize();
         }
         else

--- a/cocos/ui/UISlider.h
+++ b/cocos/ui/UISlider.h
@@ -33,7 +33,8 @@ NS_CC_BEGIN
 class Sprite;
 
 namespace ui {
-
+    class Scale9Sprite;
+    
 typedef enum
 {
     SLIDER_PERCENTCHANGED
@@ -226,8 +227,8 @@ protected:
     virtual void copySpecialProperties(Widget* model) override;
     virtual void adaptRenderers() override;
 protected:
-    Node*  _barRenderer;
-    Node* _progressBarRenderer;
+    Scale9Sprite*  _barRenderer;
+    Scale9Sprite* _progressBarRenderer;
     Size _progressBarTextureSize;
     
     Sprite* _slidBallNormalRenderer;

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/CocosGUIScene.cpp
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/CocosGUIScene.cpp
@@ -63,7 +63,7 @@ g_guisTests[] =
             UISceneManager* sceneManager = UISceneManager::sharedUISceneManager();
             sceneManager->setCurrentUISceneId(kUIButtonTest);
             sceneManager->setMinUISceneId(kUIButtonTest);
-            sceneManager->setMaxUISceneId(kUIButtonTest_RemoveSelf);
+            sceneManager->setMaxUISceneId(kUIButtonTestSwitchScale9);
             Scene* scene = sceneManager->currentUIScene();
             Director::getInstance()->replaceScene(scene);
         }

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIButtonTest/UIButtonTest.cpp
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIButtonTest/UIButtonTest.cpp
@@ -378,13 +378,23 @@ bool UIButtonTestRemoveSelf::init()
         
         _uiLayer->addChild(alert);
         
+        Layout *layout = Layout::create();
+        layout->setContentSize(widgetSize * 0.6);
+        layout->setBackGroundColor(Color3B::GREEN);
+        layout->setBackGroundColorType(Layout::BackGroundColorType::SOLID);
+        layout->setBackGroundColorOpacity(100);
+        layout->setPosition(Size(widgetSize.width/2, widgetSize.height/2));
+        layout->setAnchorPoint(Vec2::ANCHOR_MIDDLE);
+        layout->setTag(12);
+        _uiLayer->addChild(layout);
+        
         // Create the button
         Button* button = Button::create("cocosui/animationbuttonnormal.png",
                                         "cocosui/animationbuttonpressed.png");
-        button->setPosition(Vec2(widgetSize.width / 2.0f, widgetSize.height / 2.0f));
+        button->setPosition(Vec2(layout->getContentSize().width / 2.0f, layout->getContentSize().height / 2.0f));
         //        button->addTouchEventListener(this, toucheventselector(UIButtonTest::touchEvent));
         button->addTouchEventListener(CC_CALLBACK_2(UIButtonTestRemoveSelf::touchEvent, this));
-        _uiLayer->addChild(button);
+        layout->addChild(button);
         
         
         
@@ -408,8 +418,86 @@ void UIButtonTestRemoveSelf::touchEvent(Ref *pSender, Widget::TouchEventType typ
         case Widget::TouchEventType::ENDED:
         {
             _displayValueLabel->setString(String::createWithFormat("Touch Up")->getCString());
+            auto layout = _uiLayer->getChildByTag(12);
+            layout->removeFromParentAndCleanup(true);
+        }
+            break;
             
-            _uiLayer->removeFromParentAndCleanup(true);
+        case Widget::TouchEventType::CANCELED:
+            _displayValueLabel->setString(String::createWithFormat("Touch Cancelled")->getCString());
+            break;
+            
+        default:
+            break;
+    }
+}
+
+// UIButtonTestSwitchScale9
+UIButtonTestSwitchScale9::UIButtonTestSwitchScale9()
+: _displayValueLabel(nullptr)
+{
+    
+}
+
+UIButtonTestSwitchScale9::~UIButtonTestSwitchScale9()
+{
+}
+
+bool UIButtonTestSwitchScale9::init()
+{
+    if (UIScene::init())
+    {
+        Size widgetSize = _widget->getContentSize();
+        
+        // Add a label in which the button events will be displayed
+        _displayValueLabel = Text::create("No Event", "fonts/Marker Felt.ttf",32);
+        _displayValueLabel->setAnchorPoint(Vec2(0.5f, -1.0f));
+        _displayValueLabel->setPosition(Vec2(widgetSize.width / 2.0f, widgetSize.height / 2.0f));
+        _uiLayer->addChild(_displayValueLabel);
+        
+        // Add the alert
+        Text* alert = Text::create("Button","fonts/Marker Felt.ttf",30);
+        alert->setColor(Color3B(159, 168, 176));
+        
+        alert->setPosition(Vec2(widgetSize.width / 2.0f,
+                                widgetSize.height / 2.0f - alert->getContentSize().height * 1.75f));
+        
+        _uiLayer->addChild(alert);
+        
+        // Create the button
+        Button* button = Button::create("cocosui/animationbuttonnormal.png",
+                                        "cocosui/animationbuttonpressed.png");
+        button->setPosition(Vec2(widgetSize.width / 2.0f, widgetSize.height / 2.0f));
+        button->addTouchEventListener(CC_CALLBACK_2(UIButtonTestSwitchScale9::touchEvent, this));
+        button->ignoreContentAdaptWithSize(false);
+
+        _uiLayer->addChild(button);
+        
+        
+        
+        return true;
+    }
+    return false;
+}
+
+void UIButtonTestSwitchScale9::touchEvent(Ref *pSender, Widget::TouchEventType type)
+{
+    switch (type)
+    {
+        case Widget::TouchEventType::BEGAN:
+            _displayValueLabel->setString(String::createWithFormat("Touch Down")->getCString());
+            break;
+            
+        case Widget::TouchEventType::MOVED:
+            _displayValueLabel->setString(String::createWithFormat("Touch Move")->getCString());
+            break;
+            
+        case Widget::TouchEventType::ENDED:
+        {
+            _displayValueLabel->setString(String::createWithFormat("Touch Up")->getCString());
+            auto btn = ((Button*)pSender);
+            btn->setScale9Enabled(!btn->isScale9Enabled());
+            btn->setContentSize(Size(200,100));
         }
             break;
             

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIButtonTest/UIButtonTest.h
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIButtonTest/UIButtonTest.h
@@ -92,4 +92,17 @@ protected:
     Text* _displayValueLabel;
 };
 
+class UIButtonTestSwitchScale9 : public UIScene
+{
+public:
+    UIButtonTestSwitchScale9();
+    ~UIButtonTestSwitchScale9();
+    bool init();
+    void touchEvent(Ref *pSender, Widget::TouchEventType type);
+    
+protected:
+    UI_SCENE_CREATE_FUNC(UIButtonTestSwitchScale9)
+    Text* _displayValueLabel;
+};
+
 #endif /* defined(__TestCpp__UIButtonTest__) */

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UISceneManager.cpp
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UISceneManager.cpp
@@ -22,21 +22,7 @@
 #include "UIVideoPlayerTest/UIVideoPlayerTest.h"
 #endif
 #include "UIScale9SpriteTest.h"
-/*
-#include "UISwitchTest/UISwitchTest.h"
- */
- /*
-#include "UIProgressTimerTest/UIProgressTimerTest.h"
- */
-/*
-#include "UIPotentiometerTest/UIPotentiometerTest.h"
- */
-/*
-#include "UIGridViewTest/UIGridViewTest.h"
- */
-/*
-#include "UIPickerViewTest/UIPickerViewTest.h"
- */
+
 
 USING_NS_CC;
 
@@ -47,17 +33,11 @@ static const char* s_testArray[] =
     "UIButtonTest_PressedAction",
     "UIButtonTest_Title",
     "UIButtonTest_RemoveSelf",
+    "UIButtonTestSwitchScale9",
     "UICheckBoxTest",
     "UISliderTest",
     "UISliderTest_Scale9",
-    /*
-    "UIPotentiometerTest",
-     */
-    /*
-    "UISwitchTest_Horizontal",
-    "UISwitchTest_Vertical",
-    "UISwitchTest_VerticalAndTitleVertical",
-     */
+  
     "UIImageViewTest",
     "UIImageViewTest_Scale9",
     "UIImageViewTest_ContentSize",
@@ -65,15 +45,7 @@ static const char* s_testArray[] =
     "UILoadingBarTest_Right",
     "UILoadingBarTest_Left_Scale9",
     "UILoadingBarTest_Right_Scale9",
-    /*
-    "UIProgressTimerTest_Radial",
-    "UIProgressTimerTest_Horizontal",
-    "UIProgressTimerTest_Vertical",
-    "UIProgressTimerTest_RadialMidpointChanged",
-    "UIProgressTimerTest_BarVarious",
-    "UIProgressTimerTest_BarTintAndFade",
-    "UIProgressTimerTest_WithSpriteFrame",
-     */
+  
     "UITextAtlasTest",
     "UITextTest",
     "UITextTest_LineWrap",
@@ -96,9 +68,7 @@ static const char* s_testArray[] =
     "UILayoutTest_Layout_Linear_Horizontal",
     "UILayoutTest_Layout_Relative_Align_Parent",
     "UILayoutTest_Layout_Relative_Location",
-    /*
-    "UILayoutTest_Layout_Grid",
-     */
+   
     "UIScrollViewTest_Vertical",
     "UIScrollViewTest_Horizontal",
     "UIScrollViewTest_Both",
@@ -108,14 +78,7 @@ static const char* s_testArray[] =
     "UIPageViewButtonTest",
     "UIListViewTest_Vertical",
     "UIListViewTest_Horizontal",
-    /*
-    "UIGridViewTest_Mode_Column",
-    "UIGridViewTest_Mode_Row",
-     */
-    /*
-    "UIPickerViewTest_Vertical",
-    "UIPickerViewTest_Horizontal",
-     */
+   
     "UIWidgetAddNodeTest",
     "UIRichTextTest",
     "UIFocusTest-HBox",
@@ -214,6 +177,8 @@ Scene *UISceneManager::currentUIScene()
             return UIButtonTest_Title::sceneWithTitle(s_testArray[_currentUISceneId]);
         case kUIButtonTest_RemoveSelf:
             return UIButtonTestRemoveSelf::sceneWithTitle(s_testArray[_currentUISceneId]);
+        case kUIButtonTestSwitchScale9:
+            return UIButtonTestSwitchScale9::sceneWithTitle(s_testArray[_currentUISceneId]);
         case kUICheckBoxTest:
             return UICheckBoxTest::sceneWithTitle(s_testArray[_currentUISceneId]);
             

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UISceneManager.h
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UISceneManager.h
@@ -36,6 +36,7 @@ enum
     kUIButtonTest_PressedAction,
     kUIButtonTest_Title,
     kUIButtonTest_RemoveSelf,
+    kUIButtonTestSwitchScale9,
     kUICheckBoxTest,
     kUISliderTest,
     kUISliderTest_Scale9,


### PR DESCRIPTION
1. Since many Widget classes use Sprite & Scale9Sprite at the same time, when the user change Scale9Enabled properties, we removed the previous added sprites and re-added them again. Now the ui::Scale9Sprite supports `setScale9Enabled` method, so I changed the old implementation.
2. In this PR, I also had fixed some minor bugs of ui::Scale9Sprite and added the tests
