### PR TITLE
added 3D rotation support to the RotateTo action

### DIFF
--- a/cocos/2d/CCActionInterval.cpp
+++ b/cocos/2d/CCActionInterval.cpp
@@ -919,7 +919,7 @@ bool RotateBy::initWithDuration(float duration, float deltaAngle)
 {
     if (ActionInterval::initWithDuration(duration))
     {
-        _angleZ_X = _angleZ_Y = deltaAngle;
+        _deltaAngle.x = _deltaAngle.y = deltaAngle;
         return true;
     }
 
@@ -930,8 +930,8 @@ bool RotateBy::initWithDuration(float duration, float deltaAngleX, float deltaAn
 {
     if (ActionInterval::initWithDuration(duration))
     {
-        _angleZ_X = deltaAngleX;
-        _angleZ_Y = deltaAngleY;
+        _deltaAngle.x = deltaAngleX;
+        _deltaAngle.y = deltaAngleY;
         return true;
     }
     
@@ -942,7 +942,7 @@ bool RotateBy::initWithDuration(float duration, const Vec3& deltaAngle3D)
 {
     if (ActionInterval::initWithDuration(duration))
     {
-        _angle3D = deltaAngle3D;
+        _deltaAngle = deltaAngle3D;
         _is3D = true;
         return true;
     }
@@ -956,9 +956,9 @@ RotateBy* RotateBy::clone() const
 	// no copy constructor
 	auto a = new RotateBy();
     if(_is3D)
-        a->initWithDuration(_duration, _angle3D);
+        a->initWithDuration(_duration, _deltaAngle);
     else
-        a->initWithDuration(_duration, _angleZ_X, _angleZ_Y);
+        a->initWithDuration(_duration, _deltaAngle.x, _deltaAngle.y);
 	a->autorelease();
 	return a;
 }
@@ -968,12 +968,12 @@ void RotateBy::startWithTarget(Node *target)
     ActionInterval::startWithTarget(target);
     if(_is3D)
     {
-        _startAngle3D = target->getRotation3D();
+        _startAngle = target->getRotation3D();
     }
     else
     {
-        _startAngleZ_X = target->getRotationSkewX();
-        _startAngleZ_Y = target->getRotationSkewY();
+        _startAngle.x = target->getRotationSkewX();
+        _startAngle.y = target->getRotationSkewY();
     }
 }
 
@@ -985,32 +985,32 @@ void RotateBy::update(float time)
         if(_is3D)
         {
             Vec3 v;
-            v.x = _startAngle3D.x + _angle3D.x * time;
-            v.y = _startAngle3D.y + _angle3D.y * time;
-            v.z = _startAngle3D.z + _angle3D.z * time;
+            v.x = _startAngle.x + _deltaAngle.x * time;
+            v.y = _startAngle.y + _deltaAngle.y * time;
+            v.z = _startAngle.z + _deltaAngle.z * time;
             _target->setRotation3D(v);
         }
         else
         {
 #if CC_USE_PHYSICS
-            if (_startAngleZ_X == _startAngleZ_Y && _angleZ_X == _angleZ_Y)
+            if (_startAngle.x == _startAngle.y && _deltaAngle.x == _deltaAngle.y)
             {
-                _target->setRotation(_startAngleZ_X + _angleZ_X * time);
+                _target->setRotation(_startAngle.x + _deltaAngle.x * time);
             }
             else
             {
-                // _startAngleZ_X != _startAngleZ_Y || _angleZ_X != _angleZ_Y
+                // _startAngle.x != _startAngle.y || _deltaAngle.x != _deltaAngle.y
                 if (_target->getPhysicsBody() != nullptr)
                 {
                     CCLOG("RotateBy WARNING: PhysicsBody doesn't support skew rotation");
                 }
                 
-                _target->setRotationSkewX(_startAngleZ_X + _angleZ_X * time);
-                _target->setRotationSkewY(_startAngleZ_Y + _angleZ_Y * time);
+                _target->setRotationSkewX(_startAngle.x + _deltaAngle.x * time);
+                _target->setRotationSkewY(_startAngle.y + _deltaAngle.y * time);
             }
 #else
-            _target->setRotationSkewX(_startAngleZ_X + _angleZ_X * time);
-            _target->setRotationSkewY(_startAngleZ_Y + _angleZ_Y * time);
+            _target->setRotationSkewX(_startAngle.x + _deltaAngle.x * time);
+            _target->setRotationSkewY(_startAngle.y + _deltaAngle.y * time);
 #endif // CC_USE_PHYSICS
         }
     }
@@ -1021,12 +1021,15 @@ RotateBy* RotateBy::reverse() const
     if(_is3D)
     {
         Vec3 v;
-        v.x = - _angle3D.x;
-        v.y = - _angle3D.y;
-        v.z = - _angle3D.z;
+        v.x = - _deltaAngle.x;
+        v.y = - _deltaAngle.y;
+        v.z = - _deltaAngle.z;
         return RotateBy::create(_duration, v);
     }
-    return RotateBy::create(_duration, -_angleZ_X, -_angleZ_Y);
+    else
+    {
+        return RotateBy::create(_duration, -_deltaAngle.x, -_deltaAngle.y);
+    }
 }
 
 //

--- a/cocos/2d/CCActionInterval.h
+++ b/cocos/2d/CCActionInterval.h
@@ -344,6 +344,9 @@ public:
     /** creates the action */
     static RotateTo* create(float duration, float deltaAngle);
 
+    /** creates the action with 3D rotation angles */
+    static RotateTo* create(float duration, const Vec3& deltaAngle3D);
+
     //
     // Overrides
     //
@@ -353,12 +356,16 @@ public:
     virtual void update(float time) override;
     
 CC_CONSTRUCTOR_ACCESS:
-    RotateTo() {}
+    RotateTo();
     virtual ~RotateTo() {}
 
     /** initializes the action */
     bool initWithDuration(float duration, float deltaAngle);
     bool initWithDuration(float duration, float deltaAngleX, float deltaAngleY);
+    bool initWithDuration(float duration, const Vec3& deltaAngle3D);
+
+    /** calculates the start and diff angles */
+    void calculateAngles(float &startAngle, float &diffAngle, float dstAngle);
     
 protected:
     float _dstAngleX;
@@ -368,6 +375,11 @@ protected:
     float _dstAngleY;
     float _startAngleY;
     float _diffAngleY;
+
+    bool _is3D;
+    Vec3 _dstAngle3D;
+    Vec3 _startAngle3D;
+    Vec3 _diffAngle3D;
 
 private:
     CC_DISALLOW_COPY_AND_ASSIGN(RotateTo);

--- a/cocos/2d/CCActionInterval.h
+++ b/cocos/2d/CCActionInterval.h
@@ -406,14 +406,9 @@ CC_CONSTRUCTOR_ACCESS:
     bool initWithDuration(float duration, const Vec3& deltaAngle3D);
     
 protected:
-    float _angleZ_X;
-    float _startAngleZ_X;
-    float _angleZ_Y;
-    float _startAngleZ_Y;
-
     bool _is3D;
-    Vec3 _angle3D;
-    Vec3 _startAngle3D;
+    Vec3 _deltaAngle;
+    Vec3 _startAngle;
 
 private:
     CC_DISALLOW_COPY_AND_ASSIGN(RotateBy);

--- a/cocos/2d/CCActionInterval.h
+++ b/cocos/2d/CCActionInterval.h
@@ -339,13 +339,13 @@ class CC_DLL RotateTo : public ActionInterval
 {
 public:
     /** creates the action with separate rotation angles */
-    static RotateTo* create(float duration, float deltaAngleX, float deltaAngleY);
+    static RotateTo* create(float duration, float dstAngleX, float dstAngleY);
 
     /** creates the action */
-    static RotateTo* create(float duration, float deltaAngle);
+    static RotateTo* create(float duration, float dstAngle);
 
     /** creates the action with 3D rotation angles */
-    static RotateTo* create(float duration, const Vec3& deltaAngle3D);
+    static RotateTo* create(float duration, const Vec3& dstAngle3D);
 
     //
     // Overrides
@@ -360,26 +360,17 @@ CC_CONSTRUCTOR_ACCESS:
     virtual ~RotateTo() {}
 
     /** initializes the action */
-    bool initWithDuration(float duration, float deltaAngle);
-    bool initWithDuration(float duration, float deltaAngleX, float deltaAngleY);
-    bool initWithDuration(float duration, const Vec3& deltaAngle3D);
+    bool initWithDuration(float duration, float dstAngleX, float dstAngleY);
+    bool initWithDuration(float duration, const Vec3& dstAngle3D);
 
     /** calculates the start and diff angles */
     void calculateAngles(float &startAngle, float &diffAngle, float dstAngle);
     
 protected:
-    float _dstAngleX;
-    float _startAngleX;
-    float _diffAngleX;
-    
-    float _dstAngleY;
-    float _startAngleY;
-    float _diffAngleY;
-
     bool _is3D;
-    Vec3 _dstAngle3D;
-    Vec3 _startAngle3D;
-    Vec3 _diffAngle3D;
+    Vec3 _dstAngle;
+    Vec3 _startAngle;
+    Vec3 _diffAngle;
 
 private:
     CC_DISALLOW_COPY_AND_ASSIGN(RotateTo);


### PR DESCRIPTION
Currently the _RotateTo_ action does not work for 3D rotations. This commit adds a new static _create()_ method that accepts a _Vec3()_ as input to enable animated rotations in 3D.
