### PR TITLE
remove redundant namespace in wp8 platform

### DIFF
--- a/cocos/platform/wp8/CCGLView.cpp
+++ b/cocos/platform/wp8/CCGLView.cpp
@@ -47,7 +47,6 @@ using namespace Windows::ApplicationModel;
 using namespace Windows::ApplicationModel::Core;
 using namespace Windows::ApplicationModel::Activation;
 using namespace Windows::Phone::UI::Core;
-using namespace Platform;
 using namespace Microsoft::WRL;
 using namespace PhoneDirect3DXamlAppComponent;
 


### PR DESCRIPTION
there is one more Platform namespace in WP8 platform's CCGLView.cpp file , that seems redundant.
