### PR TITLE
bug fix for LabelBMFont::getBoundingBox()

### DIFF
--- a/cocos/2d/CCLabelBMFont.cpp
+++ b/cocos/2d/CCLabelBMFont.cpp
@@ -204,7 +204,7 @@ const Size& LabelBMFont::getContentSize() const
 
 Rect LabelBMFont::getBoundingBox() const
 {
-    return _label->getBoundingBox();
+    return Node::getBoundingBox();
 }
 #if CC_LABELBMFONT_DEBUG_DRAW
 void LabelBMFont::draw(Renderer *renderer, const Mat4 &transform, uint32_t flags)


### PR DESCRIPTION
`LabelBMFont::getBoundingBox()` is the bounding box of LabelBMFont relative to its parent.

while `_label->getBoundingBox()` is the bounding box of _label relative to LabelBMFont.

Although the size of the above 2 boxes are the same, their offset are not necessarily the same.

(`_label` is always positioned at `Point::ZERO` of `LabelBMFont`, which is not necessarily the case for `LabelBMFont`)

This bug can cause that we can't correctly detect whether a `LabelBMFont` is clicked or not:http://www.cocoachina.com/bbs/read.php?tid=209406
