### PR TITLE
fix scale9Sprite anchorPoint bug when switch anchor point and scale9Enabled

### DIFF
--- a/cocos/ui/UIScale9Sprite.cpp
+++ b/cocos/ui/UIScale9Sprite.cpp
@@ -62,7 +62,7 @@ namespace ui {
     
     void Scale9Sprite::cleanupSlicedSprites()
     {
-        if (_topLeft && _top->isRunning())
+        if (_topLeft && _topLeft->isRunning())
         {
             _topLeft->onExit();
         }
@@ -70,37 +70,37 @@ namespace ui {
         {
             _top->onExit();
         }
-        if (_topRight && _top->isRunning())
+        if (_topRight && _topRight->isRunning())
         {
             _topRight->onExit();
         }
         
-        if (_left && _top->isRunning())
+        if (_left && _left->isRunning())
         {
             _left->onExit();
         }
         
-        if (_centre && _top->isRunning())
+        if (_centre && _centre->isRunning())
         {
             _centre->onExit();
         }
         
-        if (_right && _top->isRunning())
+        if (_right && _right->isRunning())
         {
             _right->onExit();
         }
         
-        if (_bottomLeft && _top->isRunning())
+        if (_bottomLeft && _bottomLeft->isRunning())
         {
             _bottomLeft->onExit();
         }
         
-        if (_bottomRight && _top->isRunning())
+        if (_bottomRight && _bottomRight->isRunning())
         {
             _bottomRight->onExit();
         }
         
-        if (_bottom && _top->isRunning())
+        if (_bottom && _bottom->isRunning())
         {
             _bottom->onExit();
         }
@@ -153,10 +153,8 @@ y+=ytranslate;                       \
         Rect rect(originalRect);
         
         // Release old sprites
-        _protectedChildren.clear();
-        
         this->cleanupSlicedSprites();
-        
+        _protectedChildren.clear();
         
         if(this->_scale9Image != sprite)
         {
@@ -188,7 +186,8 @@ y+=ytranslate;                       \
         _preferredSize = _originalSize;
         _capInsetsInternal = capInsets;
         
-        if (_scale9Enabled) {
+        if (_scale9Enabled)
+        {
             this->createSlicedSprites(rect, rotated);
         }
         
@@ -286,8 +285,8 @@ y+=ytranslate;                       \
         Rect rotatedcenterbottombounds = centerbottombounds;
         Rect rotatedcentertopbounds = centertopbounds;
         
-        if (!rotated) {
-            // log("!rotated");
+        if (!rotated)
+        {
             
             AffineTransform t = AffineTransform::IDENTITY;
             t = AffineTransformTranslate(t, rect.origin.x, rect.origin.y);
@@ -391,25 +390,6 @@ y+=ytranslate;                       \
         this->_positionsAreDirty = true;
     }
     
-    void Scale9Sprite::setAnchorPoint(const cocos2d::Vec2 &anchorPoint)
-    {
-        Node::setAnchorPoint(anchorPoint);
-        
-        if (_scale9Enabled) {
-            for(const auto& node : _protectedChildren)
-            {
-                node->setAnchorPoint(anchorPoint);
-            }
-        }
-        else
-        {
-            if (_scale9Image) {
-                _scale9Image->setAnchorPoint(anchorPoint);
-            }
-            
-        }
-    }
-    
     void Scale9Sprite::updatePositions()
     {
         // Check that instances are non-NULL
@@ -417,7 +397,8 @@ y+=ytranslate;                       \
              (_topRight) &&
              (_bottomRight) &&
              (_bottomLeft) &&
-             (_centre))) {
+             (_centre)))
+        {
             // if any of the above sprites are NULL, return
             return;
         }
@@ -769,7 +750,9 @@ y+=ytranslate;                       \
             else
                 break;
         }
-        if (_scale9Enabled) {
+        
+        if (_scale9Enabled)
+        {
             for( ; j < _protectedChildren.size(); j++ )
             {
                 auto node = _protectedChildren.at(j);
@@ -779,8 +762,11 @@ y+=ytranslate;                       \
                 else
                     break;
             }
-        }else{
-            if (_scale9Image) {
+        }
+        else
+        {
+            if (_scale9Image)
+            {
                 _scale9Image->visit(renderer, _modelViewTransform, flags);
             }
         }
@@ -793,11 +779,15 @@ y+=ytranslate;                       \
         //
         // draw children and protectedChildren zOrder >= 0
         //
-        if (_scale9Enabled) {
+        if (_scale9Enabled)
+        {
             for(auto it=_protectedChildren.cbegin()+j; it != _protectedChildren.cend(); ++it)
                 (*it)->visit(renderer, _modelViewTransform, flags);
-        }else{
-            if (_scale9Image) {
+        }
+        else
+        {
+            if (_scale9Image)
+            {
                 _scale9Image->visit(renderer, _modelViewTransform, flags);
             }
         }
@@ -852,11 +842,25 @@ y+=ytranslate;                       \
     
     void Scale9Sprite::setScale9Enabled(bool enabled)
     {
-        _scale9Enabled = enabled;
-        if (!_scale9Enabled) {
-            this->cleanupSlicedSprites();
+        if (_scale9Enabled == enabled)
+        {
+            return;
         }
-        _reorderProtectedChildDirty = true;
+        _scale9Enabled = enabled;
+        
+        this->cleanupSlicedSprites();
+        _protectedChildren.clear();
+        
+        if (_scale9Enabled)
+        {
+            if (_scale9Image)
+            {
+                this->updateWithSprite(this->_scale9Image,
+                                       this->_spriteRect,
+                                       _spriteFrameRotated, _capInsets);
+            }
+        }
+        _positionsAreDirty = true;
     }
     
     bool Scale9Sprite::isScale9Enabled() const
@@ -875,12 +879,11 @@ y+=ytranslate;                       \
         if(this->_positionsAreDirty)
         {
             this->updatePositions();
+            this->adjustScale9ImagePosition();
             this->_positionsAreDirty = false;
         }
-        if( _reorderProtectedChildDirty ) {
-            if (!_scale9Enabled) {
-                this->adjustScale9ImagePosition();
-            }
+        if( _reorderProtectedChildDirty )
+        {
             std::sort( std::begin(_protectedChildren), std::end(_protectedChildren), nodeComparisonLess );
             _reorderProtectedChildDirty = false;
         }
@@ -888,9 +891,23 @@ y+=ytranslate;                       \
     
     void Scale9Sprite::adjustScale9ImagePosition()
     {
-        if (_scale9Image) {
-            _scale9Image->setPosition(Vec2(_contentSize.width * _anchorPoint.x,
-                                                                         _contentSize.height * _anchorPoint.y));
+        if (_scale9Image)
+        {
+            _scale9Image->setPosition(Vec2(_contentSize.width * _scale9Image->getAnchorPoint().x,
+                                           _contentSize.height * _scale9Image->getAnchorPoint().y));
+        }
+    }
+    
+    void Scale9Sprite::setAnchorPoint(const cocos2d::Vec2 &position)
+    {
+        Node::setAnchorPoint(position);
+        if (!_scale9Enabled)
+        {
+            if (_scale9Image)
+            {
+                _scale9Image->setAnchorPoint(position);
+                _positionsAreDirty = true;
+            }
         }
     }
     

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/CocosGUIScene.cpp
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/CocosGUIScene.cpp
@@ -50,7 +50,7 @@ g_guisTests[] =
             UISceneManager* sceneManager = UISceneManager::sharedUISceneManager();
             sceneManager->setCurrentUISceneId(kUIScale9SpriteTest);
             sceneManager->setMinUISceneId(kUIScale9SpriteTest);
-            sceneManager->setMaxUISceneId(kUIS9Flip);
+            sceneManager->setMaxUISceneId(kUIS9ChangeAnchorPoint);
             Scene* scene = sceneManager->currentUIScene();
             Director::getInstance()->replaceScene(scene);
         }

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIButtonTest/UIButtonTest.cpp
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIButtonTest/UIButtonTest.cpp
@@ -219,6 +219,11 @@ bool UIButtonTest_PressedAction::init()
         button->setName("button");
         _uiLayer->addChild(button);
         
+        Button* button2 = Button::create("cocosui/animationbuttonnormal.png", "cocosui/animationbuttonpressed.png");
+        button2->setPosition(button->getPosition() + Vec2(100,0));
+        button2->setName("button2");
+        _uiLayer->addChild(button2);
+        
         return true;
     }
     return false;
@@ -241,6 +246,9 @@ void UIButtonTest_PressedAction::touchEvent(Ref *pSender, Widget::TouchEventType
             _displayValueLabel->setString(String::createWithFormat("Touch Up")->getCString());
             Button* btn = (Button*)_uiLayer->getChildByName("button");
             btn->loadTextureNormal("cocosui/animationbuttonnormal.png");
+            
+            Button* btn2 = (Button*)_uiLayer->getChildByName("button2");
+            btn2->setAnchorPoint(Vec2(0,0.5));
         }
             break;
             

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIScale9SpriteTest.cpp
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIScale9SpriteTest.cpp
@@ -659,3 +659,68 @@ bool UIS9Flip::init()
     }
     return false;
 }
+
+bool UIS9ChangeAnchorPoint::init()
+{
+    if (UIScene::init()) {
+        SpriteFrameCache::getInstance()->addSpriteFramesWithFile(s_s9s_blocks9_plist);
+        
+        auto winSize = Director::getInstance()->getWinSize();
+        float x = winSize.width / 2;
+        float y = 0 + (winSize.height / 2 + 50);
+        
+        
+        auto normalSprite = ui::Scale9Sprite::createWithSpriteFrameName("blocks9r.png");
+        normalSprite->setPosition(Vec2(x, y ));
+//        normalSprite->setScale9Enabled(false);
+//        normalSprite->setAnchorPoint(Vec2::ANCHOR_TOP_RIGHT);
+
+        this->addChild(normalSprite);
+        
+        
+        Button* button1 = Button::create("cocosui/animationbuttonnormal.png", "cocosui/animationbuttonpressed.png");
+        button1->setPosition(Vec2(winSize.width/2 - 100,winSize.height/2 - 50));
+        button1->setName("button2");
+        button1->setTitleText("Vec(0,0)");
+        button1->addTouchEventListener([=](Ref*, Widget::TouchEventType type)
+                                       {
+                                           if (type == Widget::TouchEventType::ENDED) {
+                                               normalSprite->setAnchorPoint(Vec2::ZERO);
+                                               normalSprite->setScale9Enabled(true);
+                                               CCLOG("position = %f, %f,  anchor point = %f, %f", normalSprite->getPosition().x,
+                                                     normalSprite->getPosition().y,
+                                                     normalSprite->getAnchorPoint().x,
+                                                     normalSprite->getAnchorPoint().y);
+                                               CCLOG("tests:content size : width = %f, height = %f",
+                                                     normalSprite->getContentSize().width,
+                                                     normalSprite->getContentSize().height);
+                                           }
+                                       });
+        this->addChild(button1);
+        
+        Button* button2 = Button::create("cocosui/animationbuttonnormal.png", "cocosui/animationbuttonpressed.png");
+        button2->setPosition(Vec2(winSize.width/2 + 100,winSize.height/2 - 50));
+        button2->setName("button2");
+        button2->setTitleText("Vec(1,1)");
+        button2->addTouchEventListener([=](Ref*, Widget::TouchEventType type)
+                                       {
+                                           if (type == Widget::TouchEventType::ENDED) {
+                                               normalSprite->setAnchorPoint(Vec2::ANCHOR_TOP_RIGHT);
+                                               normalSprite->setScale9Enabled(false);
+                                               CCLOG("position = %f, %f,  anchor point = %f, %f", normalSprite->getPosition().x,
+                                                     normalSprite->getPosition().y,
+                                                     normalSprite->getAnchorPoint().x,
+                                                     normalSprite->getAnchorPoint().y);
+                                               CCLOG("tests:content size : width = %f, height = %f",
+                                                     normalSprite->getContentSize().width,
+                                                     normalSprite->getContentSize().height);
+                                               
+                                           }
+                                       });
+        this->addChild(button2);
+        
+        
+        return true;
+    }
+    return false;
+}

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIScale9SpriteTest.h
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIScale9SpriteTest.h
@@ -255,5 +255,14 @@ protected:
     UI_SCENE_CREATE_FUNC(UIS9Flip)
 };
 
+class UIS9ChangeAnchorPoint : public UIScene
+{
+public:
+    CREATE_FUNC(UIS9ChangeAnchorPoint);
+    
+    bool init();
+protected:
+    UI_SCENE_CREATE_FUNC(UIS9ChangeAnchorPoint)
+};
 
 #endif /* defined(__cocos2d_tests__UIScale9SpriteTest__) */

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UISceneManager.cpp
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UISceneManager.cpp
@@ -109,6 +109,7 @@ static const char* s_testArray[] =
     "UIS9CascadeOpacityAndColor",
     "UIS9ZOrder",
     "UIS9Flip",
+    "UIS9ChangeAnchorPoint",
 };
 
 static UISceneManager *sharedInstance = nullptr;
@@ -352,6 +353,8 @@ Scene *UISceneManager::currentUIScene()
             return UIS9ZOrder::sceneWithTitle(s_testArray[_currentUISceneId]);
         case kUIS9Flip:
             return UIS9Flip::sceneWithTitle(s_testArray[_currentUISceneId]);
+        case kUIS9ChangeAnchorPoint:
+            return UIS9ChangeAnchorPoint::sceneWithTitle(s_testArray[_currentUISceneId]);
     }
     return nullptr;
 }

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UISceneManager.h
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UISceneManager.h
@@ -107,6 +107,7 @@ enum
     kUIS9CascadeOpacityAndColor,
     kUIS9ZOrder,
     kUIS9Flip,
+    kUIS9ChangeAnchorPoint,
     kUITestMax
 };
 


### PR DESCRIPTION
1. fixed issue when we change ui::Scale9Sprite's anchor point and scale9Enabled at the same time, it will not behavior correctly.
2. add tests to prove this fix
3. refactor: improve indent to meet our coding style and fixes some typo.
