### PR TITLE
Fixed: when body mass infinity, setGravityEnable(false) does not work

### DIFF
--- a/cocos/physics/CCPhysicsBody.cpp
+++ b/cocos/physics/CCPhysicsBody.cpp
@@ -324,7 +324,7 @@ void PhysicsBody::setGravityEnable(bool enable)
     if (_gravityEnabled != enable)
     {
         _gravityEnabled = enable;
-        _info->getBody()->gravity_enable = enable;
+        _info->getBody()->gravity_enable = enable ? cpTrue : cpFalse;
     }
 }
 

--- a/cocos/physics/CCPhysicsBody.cpp
+++ b/cocos/physics/CCPhysicsBody.cpp
@@ -289,13 +289,6 @@ void PhysicsBody::setDynamic(bool dynamic)
             
             if (_world != nullptr)
             {
-                // reset the gravity enable
-                if (isGravityEnabled())
-                {
-                    _gravityEnabled = false;
-                    setGravityEnable(true);
-                }
-                
                 cpSpaceAddBody(_world->_info->getSpace(), _info->getBody());
             }
         }
@@ -331,17 +324,7 @@ void PhysicsBody::setGravityEnable(bool enable)
     if (_gravityEnabled != enable)
     {
         _gravityEnabled = enable;
-        
-        if (_world != nullptr)
-        {
-            if (enable)
-            {
-                applyForce(_world->getGravity() * _mass);
-            }else
-            {
-                applyForce(-_world->getGravity() * _mass);
-            }
-        }
+        _info->getBody()->gravity_enable = enable;
     }
 }
 
@@ -448,12 +431,6 @@ void PhysicsBody::applyForce(const Vect& force, const Vec2& offset)
 void PhysicsBody::resetForces()
 {
     cpBodyResetForces(_info->getBody());
-    
-    // if _gravityEnabled is false, add a reverse of gravity force to body
-    if (_world != nullptr && _dynamic && !_gravityEnabled && _mass != PHYSICS_INFINITY)
-    {
-        applyForce(-_world->getGravity() * _mass);
-    }
 }
 
 void PhysicsBody::applyImpulse(const Vect& impulse)
@@ -907,17 +884,7 @@ Vec2 PhysicsBody::local2World(const Vec2& point)
 
 void PhysicsBody::updateMass(float oldMass, float newMass)
 {
-    if (_dynamic && !_gravityEnabled && _world != nullptr && oldMass != PHYSICS_INFINITY)
-    {
-        applyForce(_world->getGravity() * oldMass);
-    }
-    
     cpBodySetMass(_info->getBody(), newMass);
-    
-    if (_dynamic && !_gravityEnabled && _world != nullptr && newMass != PHYSICS_INFINITY)
-    {
-        applyForce(-_world->getGravity() * newMass);
-    }
 }
 
 NS_CC_END

--- a/cocos/physics/CCPhysicsWorld.cpp
+++ b/cocos/physics/CCPhysicsWorld.cpp
@@ -475,12 +475,6 @@ void PhysicsWorld::doAddBody(PhysicsBody* body)
 {
     if (body->isEnabled())
     {
-        //is gravity enable
-        if (!body->isGravityEnabled())
-        {
-            body->applyForce(-_gravity * body->getMass());
-        }
-        
         // add body to space
         if (body->isDynamic())
         {
@@ -801,12 +795,6 @@ void PhysicsWorld::doRemoveBody(PhysicsBody* body)
 {
     CCASSERT(body != nullptr, "the body can not be nullptr");
     
-    // reset the gravity
-    if (!body->isGravityEnabled())
-    {
-        body->applyForce(_gravity * body->getMass());
-    }
-    
     // remove shaps
     for (auto& shape : body->getShapes())
     {
@@ -863,18 +851,6 @@ PhysicsBody* PhysicsWorld::getBody(int tag) const
 
 void PhysicsWorld::setGravity(const Vect& gravity)
 {
-    if (!_bodies.empty())
-    {
-        for (auto& body : _bodies)
-        {
-            // reset gravity for body
-            if (!body->isGravityEnabled())
-            {
-                body->applyForce((_gravity - gravity) * body->getMass());
-            }
-        }
-    }
-    
     _gravity = gravity;
     _info->setGravity(gravity);
 }

--- a/external/chipmunk/include/chipmunk/cpBody.h
+++ b/external/chipmunk/include/chipmunk/cpBody.h
@@ -86,7 +86,10 @@ struct cpBody {
 	cpFloat v_limit;
 	/// Maximum rotational rate (in radians/second) allowed when updating the angular velocity.
 	cpFloat w_limit;
-	
+
+	/// Whether the body is affected by the gravity.
+	cpBool gravity_enable;
+
 	CP_PRIVATE(cpVect v_bias);
 	CP_PRIVATE(cpFloat w_bias);
 	

--- a/external/chipmunk/src/cpBody.c
+++ b/external/chipmunk/src/cpBody.c
@@ -60,6 +60,8 @@ cpBodyInit(cpBody *body, cpFloat m, cpFloat i)
 	body->v_limit = (cpFloat)INFINITY;
 	body->w_limit = (cpFloat)INFINITY;
 	
+	body->gravity_enable = cpTrue;
+
 	body->data = NULL;
 	
 	// Setters must be called after full initialization so the sanity checks don't assert on garbage data.

--- a/external/chipmunk/src/cpSpaceStep.c
+++ b/external/chipmunk/src/cpSpaceStep.c
@@ -393,7 +393,7 @@ cpSpaceStep(cpSpace *space, cpFloat dt)
 		cpVect gravity = space->gravity;
 		for(int i=0; i<bodies->num; i++){
 			cpBody *body = (cpBody *)bodies->arr[i];
-			body->velocity_func(body, gravity, damping, dt);
+			body->velocity_func(body, body->gravity_enable ? gravity : cpvzero, damping, dt);
 		}
 		
 		// Apply cached impulses

--- a/tests/cpp-tests/Classes/PhysicsTest/PhysicsTest.cpp
+++ b/tests/cpp-tests/Classes/PhysicsTest/PhysicsTest.cpp
@@ -396,7 +396,7 @@ bool PhysicsDemo::onTouchBegan(Touch* touch, Event* event)
         }
     }
     
-    if (body != nullptr)
+    if (body != nullptr && body->getMass() != PHYSICS_INFINITY)
     {
         Node* mouse = Node::create();
         mouse->setPhysicsBody(PhysicsBody::create(PHYSICS_INFINITY, PHYSICS_INFINITY));
@@ -1636,6 +1636,14 @@ void PhysicsSetGravityEnableTest::onEnter()
     auto commonBox = makeBox(Vec2(100, 100), Size(50, 50), 1);
     commonBox->getPhysicsBody()->setTag(DRAG_BODYS_TAG);
     addChild(commonBox);
+
+    // infinity box
+    auto infinityBox = makeBox(Vec2(300, 100), Size(50, 50), 1);
+    infinityBox->setTag(3);
+    infinityBox->getPhysicsBody()->setMass(PHYSICS_INFINITY);
+    infinityBox->getPhysicsBody()->setTag(DRAG_BODYS_TAG);
+    infinityBox->getPhysicsBody()->setGravityEnable(false);
+    addChild(infinityBox);
     
     auto box = makeBox(Vec2(200, 100), Size(50, 50), 2);
     box->getPhysicsBody()->setMass(20);


### PR DESCRIPTION
Fixed: when body mass infinity, function PhysicsBody::setGravityEnable(false) does not work
