### PR TITLE
Update CCSpriteBatchNode.cpp

### DIFF
--- a/cocos/2d/CCSpriteBatchNode.cpp
+++ b/cocos/2d/CCSpriteBatchNode.cpp
@@ -85,7 +85,7 @@ bool SpriteBatchNode::initWithTexture(Texture2D *tex, ssize_t capacity)
     CCASSERT(capacity>=0, "Capacity must be >= 0");
     
     _blendFunc = BlendFunc::ALPHA_PREMULTIPLIED;
-    if(tex->hasPremultipliedAlpha())
+    if(!tex->hasPremultipliedAlpha())
     {
         _blendFunc = BlendFunc::ALPHA_NON_PREMULTIPLIED;
     }


### PR DESCRIPTION
Setting opacity of a sprite (via setOpacity or FadeOut/In action) has the sprite turning black, it should simply be opaque.  

Cause is in bool SpriteBatchNode::initWithTexture, third line, "if(tex->hasPremultipliedAlpha())" 
Fix is making it "!if(!tex->hasPremultipliedAlpha())"

Discussed here on the forums: http://discuss.cocos2d-x.org/t/in-cocos2dx-3-2final-sprite-become-black-when-the-opacity-is-less-than-255/16096
