### PR TITLE
We can use C++11 random library

### DIFF
--- a/build/cocos2d_libs.xcodeproj/project.pbxproj
+++ b/build/cocos2d_libs.xcodeproj/project.pbxproj
@@ -568,7 +568,9 @@
 		1AD71EF6180E27CF00808F54 /* CCPhysicsSprite.h in Headers */ = {isa = PBXBuildFile; fileRef = 1AD71EEF180E27CF00808F54 /* CCPhysicsSprite.h */; };
 		1AD71EF7180E27CF00808F54 /* CCPhysicsSprite.h in Headers */ = {isa = PBXBuildFile; fileRef = 1AD71EEF180E27CF00808F54 /* CCPhysicsSprite.h */; };
 		1F36C031BE016A88AB195F1B /* ccRandom.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F36C53D12BFE7AD4C769D4D /* ccRandom.h */; };
+		1F36C5262E265FD5FFEA0D04 /* ccRandom.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1F36CB4D61681865AFA7E8DC /* ccRandom.cpp */; };
 		1F36C5F58B5642071337D8E2 /* ccRandom.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F36C53D12BFE7AD4C769D4D /* ccRandom.h */; };
+		1F36CBBF38533B59D96661B1 /* ccRandom.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1F36CB4D61681865AFA7E8DC /* ccRandom.cpp */; };
 		2958244B19873D8E00F9746D /* UIScale9Sprite.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2958244919873D8E00F9746D /* UIScale9Sprite.cpp */; };
 		2958244C19873D8E00F9746D /* UIScale9Sprite.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2958244919873D8E00F9746D /* UIScale9Sprite.cpp */; };
 		2958244D19873D8E00F9746D /* UIScale9Sprite.h in Headers */ = {isa = PBXBuildFile; fileRef = 2958244A19873D8E00F9746D /* UIScale9Sprite.h */; };
@@ -2396,6 +2398,7 @@
 		1AD71EEE180E27CF00808F54 /* CCPhysicsSprite.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CCPhysicsSprite.cpp; sourceTree = "<group>"; };
 		1AD71EEF180E27CF00808F54 /* CCPhysicsSprite.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CCPhysicsSprite.h; sourceTree = "<group>"; };
 		1F36C53D12BFE7AD4C769D4D /* ccRandom.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ccRandom.h; path = ../base/ccRandom.h; sourceTree = "<group>"; };
+		1F36CB4D61681865AFA7E8DC /* ccRandom.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ccRandom.cpp; path = ../base/ccRandom.cpp; sourceTree = "<group>"; };
 		2905F9E918CF08D000240AA3 /* CocosGUI.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CocosGUI.cpp; sourceTree = "<group>"; };
 		2905F9EA18CF08D000240AA3 /* CocosGUI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CocosGUI.h; sourceTree = "<group>"; };
 		2905F9EB18CF08D000240AA3 /* GUIDefine.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GUIDefine.h; sourceTree = "<group>"; };
@@ -3506,6 +3509,7 @@
 				50ABBE1C1925AB6F00A911A9 /* utlist.h */,
 				50ABBE1D1925AB6F00A911A9 /* ZipUtils.cpp */,
 				50ABBE1E1925AB6F00A911A9 /* ZipUtils.h */,
+				1F36CB4D61681865AFA7E8DC /* ccRandom.cpp */,
 			);
 			name = base;
 			path = ../cocos/2d;
@@ -6912,6 +6916,7 @@
 				B6ACD897193D6693005E0B8A /* CCMeshSkin.cpp in Sources */,
 				B6ACD89E193DC0CC005E0B8A /* CCAnimate3D.cpp in Sources */,
 				B6AAF84119404E0D0069DE01 /* CCBundle3D.cpp in Sources */,
+				1F36CBBF38533B59D96661B1 /* ccRandom.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -7244,6 +7249,7 @@
 				B6ACD898193D6693005E0B8A /* CCMeshSkin.cpp in Sources */,
 				B6ACD89F193DC0CC005E0B8A /* CCAnimate3D.cpp in Sources */,
 				B6AAF84219404E0D0069DE01 /* CCBundle3D.cpp in Sources */,
+				1F36C5262E265FD5FFEA0D04 /* ccRandom.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/build/cocos2d_libs.xcodeproj/project.pbxproj
+++ b/build/cocos2d_libs.xcodeproj/project.pbxproj
@@ -567,6 +567,8 @@
 		1AD71EF5180E27CF00808F54 /* CCPhysicsSprite.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1AD71EEE180E27CF00808F54 /* CCPhysicsSprite.cpp */; };
 		1AD71EF6180E27CF00808F54 /* CCPhysicsSprite.h in Headers */ = {isa = PBXBuildFile; fileRef = 1AD71EEF180E27CF00808F54 /* CCPhysicsSprite.h */; };
 		1AD71EF7180E27CF00808F54 /* CCPhysicsSprite.h in Headers */ = {isa = PBXBuildFile; fileRef = 1AD71EEF180E27CF00808F54 /* CCPhysicsSprite.h */; };
+		1F36C031BE016A88AB195F1B /* ccRandom.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F36C53D12BFE7AD4C769D4D /* ccRandom.h */; };
+		1F36C5F58B5642071337D8E2 /* ccRandom.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F36C53D12BFE7AD4C769D4D /* ccRandom.h */; };
 		2958244B19873D8E00F9746D /* UIScale9Sprite.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2958244919873D8E00F9746D /* UIScale9Sprite.cpp */; };
 		2958244C19873D8E00F9746D /* UIScale9Sprite.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2958244919873D8E00F9746D /* UIScale9Sprite.cpp */; };
 		2958244D19873D8E00F9746D /* UIScale9Sprite.h in Headers */ = {isa = PBXBuildFile; fileRef = 2958244A19873D8E00F9746D /* UIScale9Sprite.h */; };
@@ -2393,6 +2395,7 @@
 		1AD71EED180E27CF00808F54 /* CCPhysicsDebugNode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CCPhysicsDebugNode.h; sourceTree = "<group>"; };
 		1AD71EEE180E27CF00808F54 /* CCPhysicsSprite.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CCPhysicsSprite.cpp; sourceTree = "<group>"; };
 		1AD71EEF180E27CF00808F54 /* CCPhysicsSprite.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CCPhysicsSprite.h; sourceTree = "<group>"; };
+		1F36C53D12BFE7AD4C769D4D /* ccRandom.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ccRandom.h; path = ../base/ccRandom.h; sourceTree = "<group>"; };
 		2905F9E918CF08D000240AA3 /* CocosGUI.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CocosGUI.cpp; sourceTree = "<group>"; };
 		2905F9EA18CF08D000240AA3 /* CocosGUI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CocosGUI.h; sourceTree = "<group>"; };
 		2905F9EB18CF08D000240AA3 /* GUIDefine.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GUIDefine.h; sourceTree = "<group>"; };
@@ -3469,6 +3472,7 @@
 				50ABBDFB1925AB6E00A911A9 /* CCProfiling.cpp */,
 				50ABBDFC1925AB6E00A911A9 /* CCProfiling.h */,
 				50ABBDFD1925AB6E00A911A9 /* CCProtocols.h */,
+				1F36C53D12BFE7AD4C769D4D /* ccRandom.h */,
 				50ABBDFE1925AB6E00A911A9 /* CCRef.cpp */,
 				50ABBDFF1925AB6E00A911A9 /* CCRef.h */,
 				50ABBE001925AB6E00A911A9 /* CCRefPtr.h */,
@@ -5457,6 +5461,7 @@
 				B6ACD899193D6693005E0B8A /* CCMeshSkin.h in Headers */,
 				B6ACD8A0193DC0CC005E0B8A /* CCAnimate3D.h in Headers */,
 				B6AAF84319404E0D0069DE01 /* CCBundle3D.h in Headers */,
+				1F36C031BE016A88AB195F1B /* ccRandom.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -5833,6 +5838,7 @@
 				B6ACD89A193D6693005E0B8A /* CCMeshSkin.h in Headers */,
 				B6ACD8A1193DC0CC005E0B8A /* CCAnimate3D.h in Headers */,
 				B6AAF84419404E0D0069DE01 /* CCBundle3D.h in Headers */,
+				1F36C5F58B5642071337D8E2 /* ccRandom.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/cocos/Android.mk
+++ b/cocos/Android.mk
@@ -128,6 +128,7 @@ base/CCEventTouch.cpp \
 base/CCIMEDispatcher.cpp \
 base/CCNS.cpp \
 base/CCProfiling.cpp \
+base/ccRandom.cpp \
 base/CCRef.cpp \
 base/CCScheduler.cpp \
 base/CCScriptSupport.cpp \

--- a/cocos/base/CMakeLists.txt
+++ b/cocos/base/CMakeLists.txt
@@ -23,6 +23,7 @@ set(COCOS_BASE_SRC
   base/CCIMEDispatcher.cpp
   base/CCNS.cpp
   base/CCProfiling.cpp
+  base/ccRandom.cpp
   base/CCRef.cpp
   base/CCScheduler.cpp
   base/CCScriptSupport.cpp

--- a/cocos/base/ccMacros.h
+++ b/cocos/base/ccMacros.h
@@ -69,16 +69,17 @@ simple macro that swaps 2 variables
     x = y; y = temp;        \
 }
 
+#include "base/ccRandom.h"
 
 /** @def CCRANDOM_MINUS1_1
  returns a random float between -1 and 1
  */
-#define CCRANDOM_MINUS1_1() ((2.0f*((float)rand()/RAND_MAX))-1.0f)
+#define CCRANDOM_MINUS1_1() cocos2d::rand_minus1_1()
 
 /** @def CCRANDOM_0_1
  returns a random float between 0 and 1
  */
-#define CCRANDOM_0_1() ((float)rand()/RAND_MAX)
+#define CCRANDOM_0_1() cocos2d::rand_0_1()
 
 /** @def CC_DEGREES_TO_RADIANS
  converts degrees to radians

--- a/cocos/base/ccRandom.cpp
+++ b/cocos/base/ccRandom.cpp
@@ -1,0 +1,32 @@
+/****************************************************************************
+Copyright (c) 2010      cocos2d-x.org
+Copyright (c) 2013-2014 Chukong Technologies Inc.
+
+http://www.cocos2d-x.org
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+****************************************************************************/
+
+#include "ccRandom.h"
+
+std::mt19937 &cocos2d::RandomHelper::getEngine() {
+    static std::random_device seed_gen;
+    static std::mt19937 engine(seed_gen());
+    return engine;
+}

--- a/cocos/base/ccRandom.h
+++ b/cocos/base/ccRandom.h
@@ -1,0 +1,103 @@
+/****************************************************************************
+Copyright (c) 2010      cocos2d-x.org
+Copyright (c) 2013-2014 Chukong Technologies Inc.
+
+http://www.cocos2d-x.org
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+****************************************************************************/
+
+#ifndef __ccRandom_H_
+#define __ccRandom_H_
+
+#include "base/CCPlatformMacros.h"
+#include <random>
+
+
+NS_CC_BEGIN
+
+class RandomHelper {
+public:
+    template<typename T>
+    static inline T random_real(T min, T max) {
+        std::uniform_real_distribution<T> dist(min, max);
+        std::mt19937 mt = RandomHelper::getEngine();
+        return dist(mt);
+    }
+
+    template<typename T>
+    static inline T random_int(T min, T max) {
+        std::uniform_int_distribution<> dist(min, max);
+        std::mt19937 mt = RandomHelper::getEngine();
+        return dist(mt);
+    }
+private:
+    static std::mt19937 getEngine() {
+        static std::random_device seed_gen;
+        static std::mt19937 engine(seed_gen());
+        return engine;
+    }
+};
+
+/**
+* returns a random value between `min` and `max`
+*/
+template<typename T>
+inline T random(T min, T max) {
+    return RandomHelper::random_int(min, max);
+}
+
+template<>
+inline float random(float min, float max) {
+    return RandomHelper::random_real(min, max);
+}
+
+template<>
+inline long double random(long double min, long double max) {
+    return RandomHelper::random_real(min, max);
+}
+
+template<>
+inline double random(double min, double max) {
+    return RandomHelper::random_real(min, max);
+}
+
+/**
+* returns a random int between 0 and RAND_MAX
+*/
+inline int random() {
+    return cocos2d::random(0, RAND_MAX);
+};
+
+/**
+* returns a random float between -1 and 1
+*/
+inline float rand_minus1_1() {
+    return cocos2d::random(-1.f, 1.f);
+};
+
+/**
+* returns a random float between 0 and 1
+*/
+inline float rand_0_1() {
+    return cocos2d::random(0.f, 1.f);
+};
+
+NS_CC_END
+#endif //__ccRandom_H_

--- a/cocos/base/ccRandom.h
+++ b/cocos/base/ccRandom.h
@@ -37,18 +37,18 @@ public:
     template<typename T>
     static inline T random_real(T min, T max) {
         std::uniform_real_distribution<T> dist(min, max);
-        std::mt19937 mt = RandomHelper::getEngine();
+        auto &mt = RandomHelper::getEngine();
         return dist(mt);
     }
 
     template<typename T>
     static inline T random_int(T min, T max) {
         std::uniform_int_distribution<> dist(min, max);
-        std::mt19937 mt = RandomHelper::getEngine();
+        auto &mt = RandomHelper::getEngine();
         return dist(mt);
     }
 private:
-    static std::mt19937 getEngine() {
+    static std::mt19937 &getEngine() {
         static std::random_device seed_gen;
         static std::mt19937 engine(seed_gen());
         return engine;

--- a/cocos/base/ccRandom.h
+++ b/cocos/base/ccRandom.h
@@ -48,11 +48,7 @@ public:
         return dist(mt);
     }
 private:
-    static std::mt19937 &getEngine() {
-        static std::random_device seed_gen;
-        static std::mt19937 engine(seed_gen());
-        return engine;
-    }
+    static std::mt19937 &getEngine();
 };
 
 /**

--- a/templates/cocos2dx_files.json
+++ b/templates/cocos2dx_files.json
@@ -344,6 +344,7 @@
         "cocos/base/CCProfiling.cpp", 
         "cocos/base/CCProfiling.h", 
         "cocos/base/CCProtocols.h", 
+        "cocos/base/ccRanrom.h", 
         "cocos/base/CCRef.cpp", 
         "cocos/base/CCRef.h", 
         "cocos/base/CCRefPtr.h", 

--- a/templates/cocos2dx_files.json
+++ b/templates/cocos2dx_files.json
@@ -344,7 +344,7 @@
         "cocos/base/CCProfiling.cpp", 
         "cocos/base/CCProfiling.h", 
         "cocos/base/CCProtocols.h", 
-        "cocos/base/ccRanrom.h", 
+        "cocos/base/ccRandom.h", 
         "cocos/base/CCRef.cpp", 
         "cocos/base/CCRef.h", 
         "cocos/base/CCRefPtr.h", 

--- a/templates/cocos2dx_files.json
+++ b/templates/cocos2dx_files.json
@@ -344,6 +344,7 @@
         "cocos/base/CCProfiling.cpp", 
         "cocos/base/CCProfiling.h", 
         "cocos/base/CCProtocols.h", 
+        "cocos/base/ccRandom.cpp", 
         "cocos/base/ccRandom.h", 
         "cocos/base/CCRef.cpp", 
         "cocos/base/CCRef.h", 


### PR DESCRIPTION
`rand()` is poor random number generators than C++11 random library.
And `rand()%N` is not good.
`rand()%N` is used in various classes.
Please look this URL about it. http://c-faq.com/lib/randrange.html

I think, We need to use C++11 random library.
