### PR TITLE
[ci skip]Fix Jenins pull request build script

### DIFF
--- a/tools/jenkins-scripts/pull-request-builder.py
+++ b/tools/jenkins-scripts/pull-request-builder.py
@@ -256,7 +256,7 @@ def main():
             save_build_stats(db, pr_num, 'libcpp_empty_test', filesize/1024)
           ret = os.system("python build/android-build.py -p 10 -b release lua-empty-test")
           if(ret == 0):
-            _path = 'tests/lua-empty-test/proj.android/libs/armeabi/liblua_empty_test.so'
+            _path = 'tests/lua-empty-test/project/proj.android/libs/armeabi/liblua_empty_test.so'
             filesize = os.path.getsize(_path)
             pr_desc = pr_desc + '<h3>size of liblua_empty_test.so is:' + str(filesize/1024) + 'kb</h3>'
             set_description(pr_desc, target_url)


### PR DESCRIPTION
1. Android build always fails because it's trying find a invalid file path
   `tests/lua-empty-test/proj.android/libs/armeabi/liblua_empty_test.so`
