### PR TITLE
 Fixed multitouch not enabled for iOS in Cpp template

### DIFF
--- a/templates/cpp-template-default/proj.ios_mac/ios/AppController.mm
+++ b/templates/cpp-template-default/proj.ios_mac/ios/AppController.mm
@@ -52,6 +52,8 @@ static AppDelegate s_sharedApplication;
                                    multiSampling: NO
                                  numberOfSamples: 0];
 
+    [eaglView setMultipleTouchEnabled:YES];
+
     // Use RootViewController manage CCEAGLView 
     _viewController = [[RootViewController alloc] initWithNibName:nil bundle:nil];
     _viewController.wantsFullScreenLayout = YES;


### PR DESCRIPTION
  It seems that the C++ template is missing setMultipleTouchEnabled for the eaglView in AppController.mm. So the multi-touches does not work for iOS when I create new project with cocos-console.
