### PR TITLE
Support DOT syntax for getChildByName

### DIFF
--- a/cocos/2d/CCNode.cpp
+++ b/cocos/2d/CCNode.cpp
@@ -822,24 +822,24 @@ Node* Node::getChildByName(const std::string& name) const
 {
     CCASSERT(name.length() != 0, "Invalid name");
 
-    std::string first_name = name;
-    std::string suffix = "";
+    std::string head = name;
+    std::string tail = "";
 
     int dotpos = name.find('.');
     if (dotpos > 0)
     {
-        first_name = name.substr(0, dotpos);
-        suffix = name.substr(dotpos+1);
+        head = name.substr(0, dotpos);
+        tail = name.substr(dotpos+1);
     }
     
     std::hash<std::string> h;
-    size_t hash = h(first_name);
+    size_t hash = h(head);
     
     for (const auto& child : _children)
     {
         // Different strings may have the same hash code, but can use it to compare first for speed
-        if(child->_hashOfName == hash && child->_name.compare(first_name) == 0)
-            return suffix.empty() ? child : child->getChildByName(suffix);
+        if(child->_hashOfName == hash && child->_name.compare(head) == 0)
+            return tail.empty() ? child : child->getChildByName(tail);
     }
     return nullptr;
 }

--- a/cocos/2d/CCNode.cpp
+++ b/cocos/2d/CCNode.cpp
@@ -821,6 +821,16 @@ Node* Node::getChildByTag(int tag) const
 Node* Node::getChildByName(const std::string& name) const
 {
     CCASSERT(name.length() != 0, "Invalid name");
+
+    std::string first_name = name;
+    std::string suffix = "";
+
+    int dotpos = name.find('.');
+    if (dotpos > 0)
+    {
+        first_name = name.substr(0, dotpos);
+        suffix = name.substr(dotpos+1);
+    }
     
     std::hash<std::string> h;
     size_t hash = h(name);
@@ -829,7 +839,7 @@ Node* Node::getChildByName(const std::string& name) const
     {
         // Different strings may have the same hash code, but can use it to compare first for speed
         if(child->_hashOfName == hash && child->_name.compare(name) == 0)
-            return child;
+            return suffix.empty() ? child : child->getChildByName(suffix);
     }
     return nullptr;
 }

--- a/cocos/2d/CCNode.cpp
+++ b/cocos/2d/CCNode.cpp
@@ -833,12 +833,12 @@ Node* Node::getChildByName(const std::string& name) const
     }
     
     std::hash<std::string> h;
-    size_t hash = h(name);
+    size_t hash = h(first_name);
     
     for (const auto& child : _children)
     {
         // Different strings may have the same hash code, but can use it to compare first for speed
-        if(child->_hashOfName == hash && child->_name.compare(name) == 0)
+        if(child->_hashOfName == hash && child->_name.compare(first_name) == 0)
             return suffix.empty() ? child : child->getChildByName(suffix);
     }
     return nullptr;

--- a/cocos/2d/CCNode.h
+++ b/cocos/2d/CCNode.h
@@ -706,7 +706,14 @@ public:
      * Gets a child from the container with its name
      *
      * @param name   An identifier to find the child node.
-     *
+     * 
+     * Support DOT syntax for index grandchild.
+     * @code
+     * getChildByName("cat")
+     * getChildByName("cat.apple")
+     * removeChildByName("cat.apple")
+     * @endcode
+     * 
      * @return a Node object whose name equals to the input parameter
      *
      * @since v3.2


### PR DESCRIPTION
When I load GUI from Cocos Studio directly, it is not very easy to get deeply widget.

So, how about this:
layer->getChildByName("root.panel.button")
layer->removeChildByName("root.panel.button")
