### PR TITLE
Fix Camera 

### DIFF
--- a/cocos/2d/CCScene.cpp
+++ b/cocos/2d/CCScene.cpp
@@ -54,16 +54,16 @@ Scene::~Scene()
 
 bool Scene::init()
 {
-    //create default camera
-    auto camera = Camera::create();
-    addChild(camera);
-    
     auto size = Director::getInstance()->getWinSize();
     return initWithSize(size);
 }
 
 bool Scene::initWithSize(const Size& size)
 {
+    //create default camera
+    auto camera = Camera::create();
+    addChild(camera);
+    
     setContentSize(size);
     return true;
 }

--- a/tests/cpp-tests/Classes/Camera3DTest/Camera3DTest.cpp
+++ b/tests/cpp-tests/Classes/Camera3DTest/Camera3DTest.cpp
@@ -179,6 +179,8 @@ static Layer* restartSpriteTestAction()
 Camera3DTestDemo::Camera3DTestDemo(void)
 : BaseTest()
 , _camera(nullptr)
+, _incRot(nullptr)
+, _decRot(nullptr)
 {
 }
 Camera3DTestDemo::~Camera3DTestDemo(void)
@@ -225,19 +227,25 @@ void Camera3DTestDemo::SwitchViewCallback(Ref* sender, CameraType cameraType)
     {
          _camera->setPosition3D(Vec3(0, 130, 130) + _sprite3D->getPosition3D());
          _camera->lookAt(_sprite3D->getPosition3D(), Vec3(0,1,0));
+        _incRot->setEnabled(true);
+        _decRot->setEnabled(true);
     }
     else if(_cameraType==CameraType::FirstCamera)
     {
-           Vec3 newFaceDir;
-           _sprite3D->getWorldToNodeTransform().getForwardVector(&newFaceDir);
-           newFaceDir.normalize();
-           _camera->setPosition3D(Vec3(0,35,0) + _sprite3D->getPosition3D());
-           _camera->lookAt(_sprite3D->getPosition3D() + newFaceDir*50, Vec3(0, 1, 0));
+        Vec3 newFaceDir;
+        _sprite3D->getWorldToNodeTransform().getForwardVector(&newFaceDir);
+        newFaceDir.normalize();
+        _camera->setPosition3D(Vec3(0,35,0) + _sprite3D->getPosition3D());
+        _camera->lookAt(_sprite3D->getPosition3D() + newFaceDir*50, Vec3(0, 1, 0));
+        _incRot->setEnabled(true);
+        _decRot->setEnabled(true);
     }
     else if(_cameraType==CameraType::ThirdCamera)
     {
-           _camera->setPosition3D(Vec3(0, 130, 130) + _sprite3D->getPosition3D());
-           _camera->lookAt(_sprite3D->getPosition3D(), Vec3(0,1,0));
+        _camera->setPosition3D(Vec3(0, 130, 130) + _sprite3D->getPosition3D());
+        _camera->lookAt(_sprite3D->getPosition3D(), Vec3(0,1,0));
+        _incRot->setEnabled(false);
+        _decRot->setEnabled(false);
     }
 }
 void Camera3DTestDemo::onEnter()
@@ -262,8 +270,10 @@ void Camera3DTestDemo::onEnter()
     auto menuItem2 = MenuItemLabel::create(label2, CC_CALLBACK_1(Camera3DTestDemo::scaleCameraCallback,this,-1));
     auto label3 = Label::createWithTTF(ttfConfig,"rotate+");
     auto menuItem3 = MenuItemLabel::create(label3, CC_CALLBACK_1(Camera3DTestDemo::rotateCameraCallback,this,10));
+    _incRot = menuItem3;
     auto label4 = Label::createWithTTF(ttfConfig,"rotate-");
     auto menuItem4 = MenuItemLabel::create(label4, CC_CALLBACK_1(Camera3DTestDemo::rotateCameraCallback,this,-10));
+    _decRot = menuItem4;
     auto label5 = Label::createWithTTF(ttfConfig,"free ");
     auto menuItem5 = MenuItemLabel::create(label5, CC_CALLBACK_1(Camera3DTestDemo::SwitchViewCallback,this,CameraType::FreeCamera));
     auto label6 = Label::createWithTTF(ttfConfig,"third person");

--- a/tests/cpp-tests/Classes/Camera3DTest/Camera3DTest.h
+++ b/tests/cpp-tests/Classes/Camera3DTest/Camera3DTest.h
@@ -83,6 +83,8 @@ protected:
     Sprite3D*      _sprite3D;
     Vec3           _targetPos;
     CameraType     _cameraType;
+    MenuItem*      _incRot;
+    MenuItem*      _decRot;
     unsigned int   _curState;
     Camera*      _camera;
     MoveTo* _moveAction;


### PR DESCRIPTION
move create default camera from Scene::init to Scene::initWithSize

CameraTest
Disable rotate menu when third camera is used.
