### PR TITLE
add virtual destructor

### DIFF
--- a/cocos/ui/UILayoutParameter.h
+++ b/cocos/ui/UILayoutParameter.h
@@ -132,10 +132,10 @@ protected:
     Type _layoutParameterType;
 };
     
-class LayoutParameterProtocol
+class CC_GUI_DLL LayoutParameterProtocol
 {
 public:
-    
+    virtual ~LayoutParameterProtocol(){}
     virtual LayoutParameter* getLayoutParameter() const= 0;
 };
 


### PR DESCRIPTION
If we don't add the virtual destructor, XCode will complains and generate many warnings.
