### PR TITLE
Update CCEventTouch.h

### DIFF
--- a/cocos/base/CCEventTouch.h
+++ b/cocos/base/CCEventTouch.h
@@ -36,7 +36,7 @@ NS_CC_BEGIN
 class CC_DLL EventTouch : public Event
 {
 public:
-    static const int MAX_TOUCHES = 5;
+    static const int MAX_TOUCHES = 15;
     
     enum class EventCode
     {


### PR DESCRIPTION
MAX_TOUCHES=5 is less than most touch devices, iPad/Android tablets can almost all handle all 10-11 touches. Perhaps a value of 15 would be better? 

Note: There is a #define IOS_MAX_TOUCHES_COUNT 10 in CCEAGLView.mm already for this, but multitouch fails on touch 5 in "void GLViewProtocol::handleTouchesBegin" at the code:- 
            // The touches is more than MAX_TOUCHES ?
            if (unusedIndex == -1) {
                CCLOG("The touches is more than MAX_TOUCHES, unusedIndex = %d", unusedIndex);
                continue;
            }
