### PR TITLE
virtual Node::pause() / Node::resume()

### DIFF
--- a/cocos/2d/CCNode.h
+++ b/cocos/2d/CCNode.h
@@ -1284,12 +1284,12 @@ public:
      * Resumes all scheduled selectors, actions and event listeners.
      * This method is called internally by onEnter
      */
-    void resume(void);
+    virtual void resume(void);
     /**
      * Pauses all scheduled selectors, actions and event listeners..
      * This method is called internally by onExit
      */
-    void pause(void);
+    virtual void pause(void);
 
     /**
      * Resumes all scheduled selectors, actions and event listeners.


### PR DESCRIPTION
Add virtual modifier for Node::pause() / Node::resume()

This allows more versatility for derived classes to implement their own resume / pause mechanism. For example, one can implement a **Pause / Resume Scene** where all its children are paused / resumed.
Scene's children nodes would then also override behavior according to specific needs (eg. only some nodes will be paused, other may continue running etc.)
