### PR TITLE
add callback for RenderTexture::saveToFile

### DIFF
--- a/cocos/2d/CCRenderTexture.cpp
+++ b/cocos/2d/CCRenderTexture.cpp
@@ -67,6 +67,7 @@ RenderTexture::RenderTexture()
 , _rtTextureRect(Rect::ZERO)
 , _fullRect(Rect::ZERO)
 , _fullviewPort(Rect::ZERO)
+, _saveFileCallback(nullptr)
 {
 #if CC_ENABLE_CACHE_TEXTURE_DATA
     // Listen this event to save render texture before come to background.
@@ -415,32 +416,35 @@ void RenderTexture::visit(Renderer *renderer, const Mat4 &parentTransform, uint3
     _orderOfArrival = 0;
 }
 
-bool RenderTexture::saveToFile(const std::string& filename, bool isRGBA)
+bool RenderTexture::saveToFile(const std::string& filename, bool isRGBA, std::function<void (RenderTexture*, const std::string&)> callback)
 {
     std::string basename(filename);
     std::transform(basename.begin(), basename.end(), basename.begin(), ::tolower);
     
     if (basename.find(".png") != std::string::npos)
     {
-        return saveToFile(filename, Image::Format::PNG, isRGBA);
+        return saveToFile(filename, Image::Format::PNG, isRGBA, callback);
     }
     else if (basename.find(".jpg") != std::string::npos)
     {
         if (isRGBA) CCLOG("RGBA is not supported for JPG format.");
-        return saveToFile(filename, Image::Format::JPG, false);
+        return saveToFile(filename, Image::Format::JPG, false, callback);
     }
     else
     {
         CCLOG("Only PNG and JPG format are supported now!");
     }
     
-    return saveToFile(filename, Image::Format::JPG, false);
+    return saveToFile(filename, Image::Format::JPG, false, callback);
 }
-bool RenderTexture::saveToFile(const std::string& fileName, Image::Format format, bool isRGBA)
+
+bool RenderTexture::saveToFile(const std::string& fileName, Image::Format format, bool isRGBA, std::function<void (RenderTexture*, const std::string&)> callback)
 {
     CCASSERT(format == Image::Format::JPG || format == Image::Format::PNG,
              "the image can only be saved as JPG or PNG format");
     if (isRGBA && format == Image::Format::JPG) CCLOG("RGBA is not supported for JPG format");
+    
+    _saveFileCallback = callback;
     
     std::string fullpath = FileUtils::getInstance()->getWritablePath() + fileName;
     _saveToFileCommand.init(_globalZOrder);
@@ -457,7 +461,10 @@ void RenderTexture::onSaveToFile(const std::string& filename, bool isRGBA)
     {
         image->saveToFile(filename.c_str(), !isRGBA);
     }
-
+    if(_saveFileCallback)
+    {
+        _saveFileCallback(this, filename);
+    }
     CC_SAFE_DELETE(image);
 }
 

--- a/cocos/2d/CCRenderTexture.h
+++ b/cocos/2d/CCRenderTexture.h
@@ -103,12 +103,12 @@ public:
     /** saves the texture into a file using JPEG format. The file will be saved in the Documents folder.
         Returns true if the operation is successful.
      */
-    bool saveToFile(const std::string& filename, bool isRGBA = true);
+    bool saveToFile(const std::string& filename, bool isRGBA = true, std::function<void (RenderTexture*, const std::string&)> callback = nullptr);
 
     /** saves the texture into a file. The format could be JPG or PNG. The file will be saved in the Documents folder.
         Returns true if the operation is successful.
      */
-    bool saveToFile(const std::string& filename, Image::Format format, bool isRGBA = true);
+    bool saveToFile(const std::string& filename, Image::Format format, bool isRGBA = true, std::function<void (RenderTexture*, const std::string&)> callback = nullptr);
     
     /** Listen "come to background" message, and save render texture.
      It only has effect on Android.
@@ -214,6 +214,7 @@ protected:
     CustomCommand _beginCommand;
     CustomCommand _endCommand;
     CustomCommand _saveToFileCommand;
+    std::function<void (RenderTexture*, const std::string&)> _saveFileCallback;
 protected:
     //renderer caches and callbacks
     void onBegin();

--- a/tests/cpp-tests/Classes/RenderTextureTest/RenderTextureTest.cpp
+++ b/tests/cpp-tests/Classes/RenderTextureTest/RenderTextureTest.cpp
@@ -135,25 +135,19 @@ void RenderTextureSave::saveImage(cocos2d::Ref *sender)
 
     char png[20];
     sprintf(png, "image-%d.png", counter);
-    char jpg[20];
-    sprintf(jpg, "image-%d.jpg", counter);
-
-    _target->saveToFile(png, Image::Format::PNG);
-    _target->saveToFile(jpg, Image::Format::JPG);
     
-    std::string fileName = FileUtils::getInstance()->getWritablePath() + jpg;
-    auto action1 = DelayTime::create(1);
-    auto func = [&,fileName]()
+    auto callback = [&](RenderTexture* rt, const std::string& path)
     {
-        auto sprite = Sprite::create(fileName);
+        auto sprite = Sprite::create(path);
         addChild(sprite);
         sprite->setScale(0.3f);
         sprite->setPosition(Vec2(40, 40));
         sprite->setRotation(counter * 3);
     };
-    runAction(Sequence::create(action1, CallFunc::create(func), nullptr));
+    
+    _target->saveToFile(png, Image::Format::PNG, true, callback);
 
-    CCLOG("Image saved %s and %s", png, jpg);
+    CCLOG("Image saved %s", png);
 
     counter++;
 }


### PR DESCRIPTION
changes in this pull request:
1. add callback function for RenderTexture::saveToFile()
2. using callback to create sprite in test case `cpptests->Node:RenderTexture->RenderTexture File Save`
