### PR TITLE
mLastTickInNanoSeconds is the renderStart

### DIFF
--- a/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxRenderer.java
+++ b/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxRenderer.java
@@ -100,11 +100,8 @@ public class Cocos2dxRenderer implements GLSurfaceView.Renderer {
 			/*
 			 * Render time MUST be counted in, or the FPS will slower than appointed.
 			*/
-			final long renderStart = System.nanoTime();
+			this.mLastTickInNanoSeconds = System.nanoTime();
 			Cocos2dxRenderer.nativeRender();
-			final long renderEnd = System.nanoTime();
-			final long renderInterval = renderEnd - renderStart;
-			this.mLastTickInNanoSeconds = renderEnd - renderInterval;
 		}
 	}
 


### PR DESCRIPTION
because:
this.mLastTickInNanoSeconds = renderEnd - renderInterval;
renderInterval = renderEnd - renderStart
so:
this.mLastTickInNanoSeconds = renderEnd - ( renderEnd - renderStart );
so:
this.mLastTickInNanoSeconds = renderStart ;

so:
no need nanoTime() twice
