### PR TITLE
use fileName for _actionDic key

### DIFF
--- a/cocos/editor-support/cocostudio/CCActionManagerEx.cpp
+++ b/cocos/editor-support/cocostudio/CCActionManagerEx.cpp
@@ -116,7 +116,11 @@ void ActionManagerEx::initWithDictionary(const char* jsonName,const rapidjson::V
 
 ActionObject* ActionManagerEx::getActionByName(const char* jsonName,const char* actionName)
 {
-	auto iterator = _actionDic.find(jsonName);
+	std::string path = jsonName;
+	ssize_t pos = path.find_last_of("/");
+	std::string fileName = path.substr(pos+1,path.length());
+	CCLOG("find filename == %s",fileName.c_str());
+	auto iterator = _actionDic.find(fileName);
 	if (iterator == _actionDic.end())
 	{
 		return nullptr;


### PR DESCRIPTION
./cocos/editor-support/cocostudio/CCActionManagerEx.cpp

cant use jsonName for  _actionDic key
