### PR TITLE
Fixes compiler warnings

### DIFF
--- a/external/Box2D/Common/b2Draw.h
+++ b/external/Box2D/Common/b2Draw.h
@@ -25,7 +25,7 @@
 struct b2Color
 {
 	b2Color() {}
-	b2Color(float32 r, float32 g, float32 b) : r(r), g(g), b(b) {}
+	b2Color(float32 r_, float32 g_, float32 b_) : r(r_), g(g_), b(b_) {}
 	void Set(float32 ri, float32 gi, float32 bi) { r = ri; g = gi; b = bi; }
 	float32 r, g, b;
 };


### PR DESCRIPTION
Fixes compiler warnings due to shadowing a member variable.
