### PR TITLE
b2World::DrawDebugData shows contacts in red

### DIFF
--- a/external/Box2D/Dynamics/b2World.cpp
+++ b/external/Box2D/Dynamics/b2World.cpp
@@ -1146,6 +1146,12 @@ void b2World::DrawDebugData()
 		for (b2Body* b = m_bodyList; b; b = b->GetNext())
 		{
 			const b2Transform& xf = b->GetTransform();
+			
+			bool hasContacts = false;
+			for (b2ContactEdge* edge = b->GetContactList(); edge; edge = edge->next)
+				if (edge->contact->IsEnabled() && edge->contact->IsTouching())
+					{hasContacts = true; break;}
+			
 			for (b2Fixture* f = b->GetFixtureList(); f; f = f->GetNext())
 			{
 				if (b->IsActive() == false)
@@ -1154,7 +1160,10 @@ void b2World::DrawDebugData()
 				}
 				else if (b->GetType() == b2_staticBody)
 				{
-					DrawShape(f, xf, b2Color(0.5f, 0.9f, 0.5f));
+					if (hasContacts)
+						DrawShape(f, xf, b2Color(0.9f, 0.1f, 0.1f));
+					else
+						DrawShape(f, xf, b2Color(0.5f, 0.9f, 0.5f));
 				}
 				else if (b->GetType() == b2_kinematicBody)
 				{


### PR DESCRIPTION
This pull request adds the ability for static bodies to be drawn in red when they have active contacts.

It was so helpful in my latest project I decided to share.
