### PR TITLE
fix replaceAll()

### DIFF
--- a/templates/lua-template-runtime/frameworks/runtime-src/Classes/runtime/Runtime.cpp
+++ b/templates/lua-template-runtime/frameworks/runtime-src/Classes/runtime/Runtime.cpp
@@ -72,11 +72,14 @@ const char* getRuntimeVersion()
 
 static string& replaceAll(string& str,const string& old_value,const string& new_value)
 {
+    int start = 0;
     while(true)
     {
         int pos=0;
-        if((pos=str.find(old_value,0))!=string::npos)
+        if((pos=str.find(old_value,start))!=string::npos) {
             str.replace(pos,old_value.length(),new_value);
+            start = pos + new_value.length();
+        }
         else break;
     }
     return str;


### PR DESCRIPTION
This function will never return if new_value contains old_value.
For example, old_value = "'", new_value = "''".
