### PR TITLE
fix sendPrompt()

### DIFF
--- a/cocos/base/CCConsole.cpp
+++ b/cocos/base/CCConsole.cpp
@@ -131,7 +131,7 @@ static ssize_t mydprintf(int sock, const char *format, ...)
 static void sendPrompt(int fd)
 {
     const char prompt[] = "> ";
-    send(fd, prompt, sizeof(prompt),0);
+    send(fd, prompt, strlen(prompt),0);
 }
 
 static int printSceneGraph(int fd, Node* node, int level)


### PR DESCRIPTION
a extra '\0' will be sent when sizeof() is used
