### PR TITLE
[WP8] Fixed default search path

### DIFF
--- a/cocos/platform/winrt/CCFileUtilsWinRT.cpp
+++ b/cocos/platform/winrt/CCFileUtilsWinRT.cpp
@@ -53,7 +53,7 @@ static void _checkPath()
     if (s_pszResourcePath.empty())
     {
 		// TODO: needs to be tested
-		s_pszResourcePath = convertPathFormatToUnixStyle(CCFileUtilsWinRT::getAppPath() + '\\' + "Assets\\Resources" + '\\');
+		s_pszResourcePath = convertPathFormatToUnixStyle(CCFileUtilsWinRT::getAppPath() + '\\' + "Assets\\res" + '\\');
     }
 }
 


### PR DESCRIPTION
- [WP8] Fixed default search path: renamed "Assets\Resources" to "Assets\res"
