### PR TITLE
Added method for custom precompiled shader program loading in WP8

### DIFF
--- a/cocos/platform/winrt/CCPrecompiledShaders.cpp
+++ b/cocos/platform/winrt/CCPrecompiledShaders.cpp
@@ -135,6 +135,25 @@ void CCPrecompiledShaders::loadPrecompiledPrograms()
 #endif
 }
 
+void CCPrecompiledShaders::addPrecompiledProgram(const char* key, const unsigned char* program, int programLength)
+{
+    std::string id = key;
+    PrecompiledProgram* p = nullptr;
+    auto it = m_precompiledPrograms.find(id);
+    if (it != m_precompiledPrograms.end())
+    {
+        p = it->second;
+    }
+    else
+    {
+        p = new PrecompiledProgram();
+        m_precompiledPrograms[id] = p;
+    }
+    p->key = key;
+    p->program = program;
+    p->length = programLength;
+}
+
 bool CCPrecompiledShaders::loadProgram(GLuint program, const GLchar* vShaderByteArray, const GLchar* fShaderByteArray)
 {
     std::string id = computeHash(vShaderByteArray, fShaderByteArray);

--- a/cocos/platform/winrt/CCPrecompiledShaders.h
+++ b/cocos/platform/winrt/CCPrecompiledShaders.h
@@ -70,6 +70,7 @@ public:
     */
     static CCPrecompiledShaders* getInstance();
 
+    void addPrecompiledProgram(const char* key, const unsigned char* program, int programLength);
     std::string addShaders(const GLchar* vShaderByteArray, const GLchar* fShaderByteArray);
     bool addProgram(GLuint program, const std::string& id);
 


### PR DESCRIPTION
Here is straightforward solution for custom precompiled shaders loading in WP8
