### PR TITLE
add click event listener to all Widget classes

### DIFF
--- a/cocos/editor-support/cocostudio/CCActionManagerEx.cpp
+++ b/cocos/editor-support/cocostudio/CCActionManagerEx.cpp
@@ -159,8 +159,8 @@ void ActionManagerEx::releaseActions()
     for (iter = _actionDic.begin(); iter != _actionDic.end(); iter++)
     {
         cocos2d::Vector<ActionObject*> objList = iter->second;
-        int listCount = objList.size();
-        for (int i = 0; i < listCount; i++) {
+        ssize_t listCount = objList.size();
+        for (ssize_t i = 0; i < listCount; i++) {
             ActionObject* action = objList.at(i);
             if (action != nullptr) {
                 action->stop();

--- a/cocos/editor-support/cocostudio/CCSGUIReader.cpp
+++ b/cocos/editor-support/cocostudio/CCSGUIReader.cpp
@@ -781,7 +781,7 @@ void WidgetPropertiesReader0250::setPropsForCheckBoxFromJsonDictionary(Widget*wi
     {
         checkBox->loadTextures(backGroundFileName_tp, backGroundSelectedFileName_tp, frontCrossFileName_tp,backGroundDisabledFileName_tp,frontCrossDisabledFileName_tp);
     }
-    checkBox->setSelectedState(DICTOOL->getBooleanValue_json(options, "selectedState"));
+    checkBox->setSelected(DICTOOL->getBooleanValue_json(options, "selectedState"));
     setColorPropsForWidgetFromJsonDictionary(widget,options);
 }
 

--- a/cocos/ui/UICheckBox.cpp
+++ b/cocos/ui/UICheckBox.cpp
@@ -118,7 +118,7 @@ bool CheckBox::init(const std::string& backGround,
             break;
         }
         
-        setSelectedState(false);
+        setSelected(false);
         loadTextures(backGround, backGroundSeleted, cross, backGroundDisabled, frontCrossDisabled,texType);
     } while (0);
     return ret;
@@ -128,7 +128,7 @@ bool CheckBox::init()
 {
     if (Widget::init())
     {
-        setSelectedState(false);
+        setSelected(false);
         return true;
     }
     return false;
@@ -300,12 +300,12 @@ void CheckBox::releaseUpEvent()
     Widget::releaseUpEvent();
     
     if (_isSelected){
-        setSelectedState(false);
+        setSelected(false);
         unSelectedEvent();
     }
     else
     {
-        setSelectedState(true);
+        setSelected(true);
         selectedEvent();
     }
 }
@@ -590,7 +590,7 @@ void CheckBox::copySpecialProperties(Widget *widget)
         loadTextureFrontCross(checkBox->_frontCrossFileName, checkBox->_frontCrossTexType);
         loadTextureBackGroundDisabled(checkBox->_backGroundDisabledFileName, checkBox->_backGroundDisabledTexType);
         loadTextureFrontCrossDisabled(checkBox->_frontCrossDisabledFileName, checkBox->_frontCrossDisabledTexType);
-        setSelectedState(checkBox->_isSelected);
+        setSelected(checkBox->_isSelected);
         _checkBoxEventListener = checkBox->_checkBoxEventListener;
         _checkBoxEventSelector = checkBox->_checkBoxEventSelector;
         _checkBoxEventCallback = checkBox->_checkBoxEventCallback;

--- a/cocos/ui/UIWidget.cpp
+++ b/cocos/ui/UIWidget.cpp
@@ -807,6 +807,10 @@ void Widget::releaseUpEvent()
     {
         (_touchEventListener->*_touchEventSelector)(this,TOUCH_EVENT_ENDED);
     }
+    
+    if (_clickEventListener) {
+        _clickEventListener(this);
+    }
     this->release();
 }
 
@@ -831,9 +835,14 @@ void Widget::addTouchEventListener(Ref *target, SEL_TouchEvent selector)
     _touchEventSelector = selector;
 }
     
-void Widget::addTouchEventListener(Widget::ccWidgetTouchCallback callback)
+void Widget::addTouchEventListener(const ccWidgetTouchCallback& callback)
 {
     this->_touchEventCallback = callback;
+}
+    
+void Widget::addClickEventListener(const ccWidgetClickCallback &callback)
+{
+    this->_clickEventListener = callback;
 }
 
 bool Widget::hitTest(const Vec2 &pt)
@@ -1083,6 +1092,7 @@ void Widget::copyProperties(Widget *widget)
     _touchEventCallback = widget->_touchEventCallback;
     _touchEventListener = widget->_touchEventListener;
     _touchEventSelector = widget->_touchEventSelector;
+    _clickEventListener = widget->_clickEventListener;
     _focused = widget->_focused;
     _focusEnabled = widget->_focusEnabled;
     _propagateTouchEvents = widget->_propagateTouchEvents;

--- a/cocos/ui/UIWidget.h
+++ b/cocos/ui/UIWidget.h
@@ -108,6 +108,7 @@ public:
 
     
     typedef std::function<void(Ref*,Widget::TouchEventType)> ccWidgetTouchCallback;
+    typedef std::function<void(Ref*)> ccWidgetClickCallback;
     /**
      * Default constructor
      */
@@ -232,11 +233,14 @@ public:
     virtual void visit(cocos2d::Renderer *renderer, const Mat4 &parentTransform, uint32_t parentFlags) override;
 
     /**
-     * Sets the touch event target/selector of the menu item
+     * Sets the touch event target/selector to the widget
      */
     CC_DEPRECATED_ATTRIBUTE void addTouchEventListener(Ref* target,SEL_TouchEvent selector);
-    void addTouchEventListener(ccWidgetTouchCallback callback);
-
+    void addTouchEventListener(const ccWidgetTouchCallback& callback);
+    /**
+     * Set a click event handler to the widget
+     */
+    void addClickEventListener(const ccWidgetClickCallback& callback);
 
     /**
      * Changes the position (x,y) of the widget in OpenGL coordinates
@@ -709,6 +713,7 @@ protected:
     #pragma warning (pop)
     #endif
     ccWidgetTouchCallback _touchEventCallback;
+    ccWidgetClickCallback _clickEventListener;
 private:
     class FocusNavigationController;
     static FocusNavigationController* _focusNavigationController;

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIButtonTest/UIButtonTest.cpp
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIButtonTest/UIButtonTest.cpp
@@ -301,7 +301,6 @@ bool UIButtonTest_Title::init()
         button->setPosition(Vec2(widgetSize.width / 2.0f, widgetSize.height / 2.0f));
         button->setTitleColor(Color3B::YELLOW);
         CCASSERT(button->getTitleColor() == Color3B::YELLOW, "Button setTitleColotr & getTitleColor not match!");
-//        button->addTouchEventListener(this, toucheventselector(UIButtonTest_Title::touchEvent));
         button->addTouchEventListener(CC_CALLBACK_2(UIButtonTest_Title::touchEvent, this));
         _uiLayer->addChild(button);
         
@@ -481,7 +480,7 @@ bool UIButtonTestSwitchScale9::init()
         button->setPosition(Vec2(widgetSize.width / 2.0f, widgetSize.height / 2.0f));
         button->addTouchEventListener(CC_CALLBACK_2(UIButtonTestSwitchScale9::touchEvent, this));
         button->ignoreContentAdaptWithSize(false);
-
+        
         _uiLayer->addChild(button);
         
         
@@ -559,6 +558,11 @@ bool UIButtonTestZoomScale::init()
                                         "cocosui/animationbuttonpressed.png");
         button->setPosition(Vec2(widgetSize.width / 2.0f, widgetSize.height / 2.0f + 20));
         button->setPressedActionEnabled(true);
+        button->addClickEventListener([=](Ref* sender){
+            CCLOG("Button clicked, position = (%f, %f)", button->getPosition().x,
+                  button->getPosition().y);
+            
+        });
         button->setName("button");
         _uiLayer->addChild(button);
         button->setZoomScale(-0.5);


### PR DESCRIPTION
1. Add a handy method to register click event on widget class,so we don't need to check the event type manually any more.
2. remove compile warnings
