### PR TITLE
Update CCArmatureAnimation.cpp

### DIFF
--- a/cocos/editor-support/cocostudio/CCArmatureAnimation.cpp
+++ b/cocos/editor-support/cocostudio/CCArmatureAnimation.cpp
@@ -337,11 +337,14 @@ void ArmatureAnimation::update(float dt)
 {
     ProcessBase::update(dt);
     
-    for (const auto &tween : _tweenList)
+    if (!_isComplete && !_isPause)
     {
-        tween->update(dt);
+        for (const auto &tween : _tweenList)
+        {
+            tween->update(dt);
+        }
     }
-
+    
     if(_frameEventQueue.size() > 0 || _movementEventQueue.size() > 0)
     {
         _armature->retain();


### PR DESCRIPTION
it's for animation "broken body" problem.when ths animation completed , but the update of animation is still running,because of the single frame special case.we should set a condition that the animation has completed couldn't run again.
