### PR TITLE
Add the feature that CCSSceneReader can load name properties as node names.

### DIFF
--- a/cocos/editor-support/cocostudio/CCSSceneReader.cpp
+++ b/cocos/editor-support/cocostudio/CCSSceneReader.cpp
@@ -493,6 +493,9 @@ void SceneReader::setPropertyFromJsonDict(const rapidjson::Value &root, cocos2d:
     
     float fRotationZ = DICTOOL->getFloatValue_json(root, "rotation"); 
     node->setRotation(fRotationZ);
+    
+    const char *sName = DICTOOL->getStringValue_json(root, "name", "");
+    node->setName(sName);
 }
     
     
@@ -501,6 +504,7 @@ void SceneReader::setPropertyFromJsonDict(CocoLoader *cocoLoader, stExpCocoNode 
     stExpCocoNode *stChildArray = cocoNode->GetChildArray(cocoLoader);
     float x = 0.0f, y = 0.0f, fScaleX = 1.0f, fScaleY = 1.0f, fRotationZ = 1.0f;
     bool bVisible = false;
+    const char *sName = "";
     int nTag = 0, nZorder = -1;
     
     for (int i = 0; i < cocoNode->GetChildNum(); ++i)
@@ -547,6 +551,11 @@ void SceneReader::setPropertyFromJsonDict(CocoLoader *cocoLoader, stExpCocoNode 
         {
             fRotationZ = utils::atof(value.c_str());
             node->setRotation(fRotationZ);
+        }
+        else if(key == "name")
+        {
+            sName = value.c_str();
+            node->setName(sName);
         }
     }
 }


### PR DESCRIPTION
When name property of objects on CocosStudio Scene are set.
They will be loaded and set as Node::name property.

Thanks to this commit. We are enable to access to each nodes on scene via its names.

``` cpp
auto scene = cocos2d::cocostudio::SceneReader::getInstance()->createNodeWithSceneFile("Scene.json");
auto object = scene->getChildByName<cocos2d::Sprite *>("objectName");
```
