### PR TITLE
Adds `std::nothrow` to the `new` statements

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,20 +1,19 @@
 cocos2d-x-3.3alpha0  ??
-    [NEW]           Added UIScale9Sprite
-    [NEW]           Added Camera, AABB, OBB and Ray
-    [NEW]           Added render primitive and render primitive command, support passing point, line and triangle data
-    [NEW]           Added support for applicationDidEnterBackground / applicationWillEnterForeground on desktop
-    [NEW]           Added method for custom precompiled shader program loading on WP8
-    [NEW]           Added c++11 random support
-    [NEW]           Added better reskin model support 
-    [NEW]           Added consistent way to set GL context attributes
+    [NEW]           3D: Added Camera, AABB, OBB and Ray
+    [NEW]           3D: Added better reskin model support 
+    [NEW]           Core: c++11 random support
+    [NEW]	    Core: Using `(std::notrow)` for all the `new` statements
+    [NEW]           Desktop: Added support for applicationDidEnterBackground / applicationWillEnterForeground on desktop
     [NEW]           Device: added setKeepScreenOn() for iOS and Android
     [NEW]           EventMouse: support getDelta, getDeltaX, getDeltaY functions
-    [NEW]           FileUtils: add isDirectoryExist(), createDirectory(), removeDirectory(), removeFile(), renameFile()
-    getFileSize()
+    [NEW]           FileUtils: add isDirectoryExist(), createDirectory(), removeDirectory(), removeFile(), renameFile(), getFileSize()
     [NEW]           FileUtilsApple: allow setting bundle to use in file utils on iOS and Mac OS X
     [NEW]           Image: support of software PVRTC v1 decompression
     [NEW]           Lua-binding: added release_print that can print log even in release mode
     [NEW]           Physics Integration: can invoke update in demand
+    [NEW]           Renderer: Added primitive and render primitive command, support passing point, line and triangle data
+    [NEW]           Renderer: Added method for custom precompiled shader program loading on WP8
+    [NEW]           Renderer: Added consistent way to set GL context attributes
     [NEW]           RenderTexture: add a call back function for saveToFile()
     [NEW]           RotateTo: added 3D rotation support
     [NEW]           ScrollView: added `setMinScale()` and `setMaxScale()`
@@ -22,11 +21,12 @@ cocos2d-x-3.3alpha0  ??
     [NEW]           Sprite3D: added getBoundingBox() and getAABB()
     [NEW]           SpriteFrameCache: load from plist file content data
     [NEW]           utils: added gettime()
-    [NEW]           ui::Button: support customize how much zoom scale is when pressing a button
-    [NEW]           ui::PageView: added `customScrollThreshold`, could determine the swipe distance to trigger a PageView scroll event
-    [NEW]           ui::TextField: support utf8
-    [NEW]           ui::TextField: support set color and placehold color
-    [NEW]           ui::Widget: support swallowing touch events
+    [NEW]           UI: Added Added UIScale9Sprite
+    [NEW]           UI: ui::Button: support customize how much zoom scale is when pressing a button
+    [NEW]           UI: ui::PageView: added `customScrollThreshold`, could determine the swipe distance to trigger a PageView scroll event
+    [NEW]           UI: ui::TextField: support utf8
+    [NEW]           UI: ui::TextField: support set color and placehold color
+    [NEW]           UI: ui::Widget: support swallowing touch events
     [NEW]           Text: added getter and setter for TextColor
 
     [FIX]           EditBox: font size is not scaled when glview is scaled on Mac OS X

--- a/cocos/2d/CCAction.cpp
+++ b/cocos/2d/CCAction.cpp
@@ -96,7 +96,7 @@ Speed::~Speed()
 
 Speed* Speed::create(ActionInterval* action, float speed)
 {
-    Speed *ret = new Speed();
+    Speed *ret = new (std::nothrow) Speed();
     if (ret && ret->initWithAction(action, speed))
     {
         ret->autorelease();
@@ -118,7 +118,7 @@ bool Speed::initWithAction(ActionInterval *action, float speed)
 Speed *Speed::clone() const
 {
 	// no copy constructor
-	auto a = new Speed();
+	auto a = new (std::nothrow) Speed();
 	a->initWithAction(_innerAction->clone(), _speed);
 	a->autorelease();
 	return  a;
@@ -172,7 +172,7 @@ Follow::~Follow()
 
 Follow* Follow::create(Node *followedNode, const Rect& rect/* = Rect::ZERO*/)
 {
-    Follow *follow = new Follow();
+    Follow *follow = new (std::nothrow) Follow();
     if (follow && follow->initWithTarget(followedNode, rect))
     {
         follow->autorelease();
@@ -185,7 +185,7 @@ Follow* Follow::create(Node *followedNode, const Rect& rect/* = Rect::ZERO*/)
 Follow* Follow::clone() const
 {
 	// no copy constructor
-	auto a = new Follow();
+	auto a = new (std::nothrow) Follow();
 	a->initWithTarget(_followedNode, _worldRect);
 	a->autorelease();
 	return a;

--- a/cocos/2d/CCActionCamera.cpp
+++ b/cocos/2d/CCActionCamera.cpp
@@ -47,7 +47,7 @@ void ActionCamera::startWithTarget(Node *target)
 ActionCamera* ActionCamera::clone() const
 {
 	// no copy constructor
-	auto a = new ActionCamera();
+	auto a = new (std::nothrow) ActionCamera();
 	a->autorelease();
 	return a;
 }
@@ -148,7 +148,7 @@ OrbitCamera::~OrbitCamera()
 
 OrbitCamera * OrbitCamera::create(float t, float radius, float deltaRadius, float angleZ, float deltaAngleZ, float angleX, float deltaAngleX)
 {
-    OrbitCamera * obitCamera = new OrbitCamera();
+    OrbitCamera * obitCamera = new (std::nothrow) OrbitCamera();
     if(obitCamera->initWithDuration(t, radius, deltaRadius, angleZ, deltaAngleZ, angleX, deltaAngleX))
     {
         obitCamera->autorelease();
@@ -161,7 +161,7 @@ OrbitCamera * OrbitCamera::create(float t, float radius, float deltaRadius, floa
 OrbitCamera* OrbitCamera::clone() const
 {
 	// no copy constructor	
-	auto a = new OrbitCamera();
+	auto a = new (std::nothrow) OrbitCamera();
 	a->initWithDuration(_duration, _radius, _deltaRadius, _angleZ, _deltaAngleZ, _angleX, _deltaAngleX);
 	a->autorelease();
 	return a;

--- a/cocos/2d/CCActionCatmullRom.cpp
+++ b/cocos/2d/CCActionCatmullRom.cpp
@@ -43,7 +43,7 @@ NS_CC_BEGIN;
 
 PointArray* PointArray::create(ssize_t capacity)
 {
-    PointArray* pointArray = new PointArray();
+    PointArray* pointArray = new (std::nothrow) PointArray();
     if (pointArray)
     {
         if (pointArray->initWithCapacity(capacity))
@@ -77,7 +77,7 @@ PointArray* PointArray::clone() const
         newArray->push_back(new Vec2((*iter)->x, (*iter)->y));
     }
     
-    PointArray *points = new PointArray();
+    PointArray *points = new (std::nothrow) PointArray();
     points->initWithCapacity(10);
     points->setControlPoints(newArray);
 
@@ -126,7 +126,7 @@ void PointArray::addControlPoint(Vec2 controlPoint)
 
 void PointArray::insertControlPoint(Vec2 &controlPoint, ssize_t index)
 {
-    Vec2 *temp = new Vec2(controlPoint.x, controlPoint.y);
+    Vec2 *temp = new (std::nothrow) Vec2(controlPoint.x, controlPoint.y);
     _controlPoints->insert(_controlPoints->begin() + index, temp);
 }
 
@@ -222,7 +222,7 @@ Vec2 ccCardinalSplineAt(Vec2 &p0, Vec2 &p1, Vec2 &p2, Vec2 &p3, float tension, f
 
 CardinalSplineTo* CardinalSplineTo::create(float duration, cocos2d::PointArray *points, float tension)
 {
-    CardinalSplineTo *ret = new CardinalSplineTo();
+    CardinalSplineTo *ret = new (std::nothrow) CardinalSplineTo();
     if (ret)
     {
         if (ret->initWithDuration(duration, points, tension))
@@ -281,7 +281,7 @@ void CardinalSplineTo::startWithTarget(cocos2d::Node *target)
 CardinalSplineTo* CardinalSplineTo::clone() const
 {
 	// no copy constructor
-	auto a = new CardinalSplineTo();
+	auto a = new (std::nothrow) CardinalSplineTo();
 	a->initWithDuration(this->_duration, this->_points->clone(), this->_tension);
 	a->autorelease();
 	return a;
@@ -346,7 +346,7 @@ CardinalSplineTo* CardinalSplineTo::reverse() const
 
 CardinalSplineBy* CardinalSplineBy::create(float duration, cocos2d::PointArray *points, float tension)
 {
-    CardinalSplineBy *ret = new CardinalSplineBy();
+    CardinalSplineBy *ret = new (std::nothrow) CardinalSplineBy();
     if (ret)
     {
         if (ret->initWithDuration(duration, points, tension))
@@ -425,7 +425,7 @@ void CardinalSplineBy::startWithTarget(cocos2d::Node *target)
 CardinalSplineBy* CardinalSplineBy::clone() const
 {
 	// no copy constructor
-	auto a = new CardinalSplineBy();
+	auto a = new (std::nothrow) CardinalSplineBy();
 	a->initWithDuration(this->_duration, this->_points->clone(), this->_tension);
 	a->autorelease();
 	return a;
@@ -436,7 +436,7 @@ CardinalSplineBy* CardinalSplineBy::clone() const
 
 CatmullRomTo* CatmullRomTo::create(float dt, cocos2d::PointArray *points)
 {
-    CatmullRomTo *ret = new CatmullRomTo();
+    CatmullRomTo *ret = new (std::nothrow) CatmullRomTo();
     if (ret)
     {
         if (ret->initWithDuration(dt, points))
@@ -465,7 +465,7 @@ bool CatmullRomTo::initWithDuration(float dt, cocos2d::PointArray *points)
 CatmullRomTo* CatmullRomTo::clone() const
 {
 	// no copy constructor
-	auto a = new CatmullRomTo();
+	auto a = new (std::nothrow) CatmullRomTo();
 	a->initWithDuration(this->_duration, this->_points->clone());
 	a->autorelease();
 	return a;
@@ -483,7 +483,7 @@ CatmullRomTo* CatmullRomTo::reverse() const
 
 CatmullRomBy* CatmullRomBy::create(float dt, cocos2d::PointArray *points)
 {
-    CatmullRomBy *ret = new CatmullRomBy();
+    CatmullRomBy *ret = new (std::nothrow) CatmullRomBy();
     if (ret)
     {
         if (ret->initWithDuration(dt, points))
@@ -512,7 +512,7 @@ bool CatmullRomBy::initWithDuration(float dt, cocos2d::PointArray *points)
 CatmullRomBy* CatmullRomBy::clone() const
 {
 	// no copy constructor	
-	auto a = new CatmullRomBy();
+	auto a = new (std::nothrow) CatmullRomBy();
 	a->initWithDuration(this->_duration, this->_points->clone());
 	a->autorelease();
 	return a;

--- a/cocos/2d/CCActionEase.cpp
+++ b/cocos/2d/CCActionEase.cpp
@@ -111,7 +111,7 @@ EaseRateAction::~EaseRateAction()
 
 EaseIn* EaseIn::create(ActionInterval *action, float rate)
 {
-    EaseIn *easeIn = new EaseIn();
+    EaseIn *easeIn = new (std::nothrow) EaseIn();
     if (easeIn)
     {
         if (easeIn->initWithAction(action, rate))
@@ -130,7 +130,7 @@ EaseIn* EaseIn::create(ActionInterval *action, float rate)
 EaseIn* EaseIn::clone() const
 {
 	// no copy constructor
-	auto a = new EaseIn();
+	auto a = new (std::nothrow) EaseIn();
 	a->initWithAction(_inner->clone(), _rate);
 	a->autorelease();
 	return a;
@@ -151,7 +151,7 @@ EaseIn* EaseIn::reverse() const
 //
 EaseOut* EaseOut::create(ActionInterval *action, float rate)
 {
-    EaseOut *easeOut = new EaseOut();
+    EaseOut *easeOut = new (std::nothrow) EaseOut();
     if (easeOut)
     {
         if (easeOut->initWithAction(action, rate))
@@ -170,7 +170,7 @@ EaseOut* EaseOut::create(ActionInterval *action, float rate)
 EaseOut* EaseOut::clone() const
 {
 	// no copy constructor
-	auto a = new EaseOut();
+	auto a = new (std::nothrow) EaseOut();
 	a->initWithAction(_inner->clone(), _rate);
 	a->autorelease();
 	return a;
@@ -191,7 +191,7 @@ EaseOut* EaseOut::reverse() const
 //
 EaseInOut* EaseInOut::create(ActionInterval *action, float rate)
 {
-    EaseInOut *easeInOut = new EaseInOut();
+    EaseInOut *easeInOut = new (std::nothrow) EaseInOut();
     if (easeInOut)
     {
         if (easeInOut->initWithAction(action, rate))
@@ -210,7 +210,7 @@ EaseInOut* EaseInOut::create(ActionInterval *action, float rate)
 EaseInOut* EaseInOut::clone() const
 {
 	// no copy constructor
-	auto a = new EaseInOut();
+	auto a = new (std::nothrow) EaseInOut();
 	a->initWithAction(_inner->clone(), _rate);
 	a->autorelease();
 	return a;
@@ -232,7 +232,7 @@ EaseInOut* EaseInOut::reverse() const
 //
 EaseExponentialIn* EaseExponentialIn::create(ActionInterval* action)
 {
-    EaseExponentialIn *ret = new EaseExponentialIn();
+    EaseExponentialIn *ret = new (std::nothrow) EaseExponentialIn();
     if (ret)
     {
         if (ret->initWithAction(action))
@@ -251,7 +251,7 @@ EaseExponentialIn* EaseExponentialIn::create(ActionInterval* action)
 EaseExponentialIn* EaseExponentialIn::clone() const
 {
 	// no copy constructor
-	auto a = new EaseExponentialIn();
+	auto a = new (std::nothrow) EaseExponentialIn();
 	a->initWithAction(_inner->clone());
 	a->autorelease();
 	return a;
@@ -272,7 +272,7 @@ ActionEase * EaseExponentialIn::reverse() const
 //
 EaseExponentialOut* EaseExponentialOut::create(ActionInterval* action)
 {
-    EaseExponentialOut *ret = new EaseExponentialOut();
+    EaseExponentialOut *ret = new (std::nothrow) EaseExponentialOut();
     if (ret)
     {
         if (ret->initWithAction(action))
@@ -291,7 +291,7 @@ EaseExponentialOut* EaseExponentialOut::create(ActionInterval* action)
 EaseExponentialOut* EaseExponentialOut::clone() const
 {
 	// no copy constructor
-	auto a = new EaseExponentialOut();
+	auto a = new (std::nothrow) EaseExponentialOut();
 	a->initWithAction(_inner->clone());
 	a->autorelease();
 	return a;
@@ -313,7 +313,7 @@ ActionEase* EaseExponentialOut::reverse() const
 
 EaseExponentialInOut* EaseExponentialInOut::create(ActionInterval *action)
 {
-    EaseExponentialInOut *ret = new EaseExponentialInOut();
+    EaseExponentialInOut *ret = new (std::nothrow) EaseExponentialInOut();
     if (ret)
     {
         if (ret->initWithAction(action))
@@ -332,7 +332,7 @@ EaseExponentialInOut* EaseExponentialInOut::create(ActionInterval *action)
 EaseExponentialInOut* EaseExponentialInOut::clone() const
 {
 	// no copy constructor
-	auto a = new EaseExponentialInOut();
+	auto a = new (std::nothrow) EaseExponentialInOut();
 	a->initWithAction(_inner->clone());
 	a->autorelease();
 	return a;
@@ -354,7 +354,7 @@ EaseExponentialInOut* EaseExponentialInOut::reverse() const
 
 EaseSineIn* EaseSineIn::create(ActionInterval* action)
 {
-    EaseSineIn *ret = new EaseSineIn();
+    EaseSineIn *ret = new (std::nothrow) EaseSineIn();
     if (ret)
     {
         if (ret->initWithAction(action))
@@ -373,7 +373,7 @@ EaseSineIn* EaseSineIn::create(ActionInterval* action)
 EaseSineIn* EaseSineIn::clone() const
 {
 	// no copy constructor
-	auto a = new EaseSineIn();
+	auto a = new (std::nothrow) EaseSineIn();
 	a->initWithAction(_inner->clone());
 	a->autorelease();
 	return a;
@@ -395,7 +395,7 @@ ActionEase* EaseSineIn::reverse() const
 
 EaseSineOut* EaseSineOut::create(ActionInterval* action)
 {
-    EaseSineOut *ret = new EaseSineOut();
+    EaseSineOut *ret = new (std::nothrow) EaseSineOut();
     if (ret)
     {
         if (ret->initWithAction(action))
@@ -414,7 +414,7 @@ EaseSineOut* EaseSineOut::create(ActionInterval* action)
 EaseSineOut* EaseSineOut::clone() const
 {
 	// no copy constructor
-	auto a = new EaseSineOut();
+	auto a = new (std::nothrow) EaseSineOut();
 	a->initWithAction(_inner->clone());
 	a->autorelease();
 	return a;
@@ -436,7 +436,7 @@ ActionEase* EaseSineOut::reverse(void) const
 
 EaseSineInOut* EaseSineInOut::create(ActionInterval* action)
 {
-    EaseSineInOut *ret = new EaseSineInOut();
+    EaseSineInOut *ret = new (std::nothrow) EaseSineInOut();
     if (ret)
     {
         if (ret->initWithAction(action))
@@ -455,7 +455,7 @@ EaseSineInOut* EaseSineInOut::create(ActionInterval* action)
 EaseSineInOut* EaseSineInOut::clone() const
 {
 	// no copy constructor
-	auto a = new EaseSineInOut();
+	auto a = new (std::nothrow) EaseSineInOut();
 	a->initWithAction(_inner->clone());
 	a->autorelease();
 	return a;
@@ -497,7 +497,7 @@ EaseElasticIn* EaseElasticIn::create(ActionInterval *action)
 
 EaseElasticIn* EaseElasticIn::create(ActionInterval *action, float period/* = 0.3f*/)
 {
-    EaseElasticIn *ret = new EaseElasticIn();
+    EaseElasticIn *ret = new (std::nothrow) EaseElasticIn();
     if (ret)
     {
         if (ret->initWithAction(action, period))
@@ -516,7 +516,7 @@ EaseElasticIn* EaseElasticIn::create(ActionInterval *action, float period/* = 0.
 EaseElasticIn* EaseElasticIn::clone() const
 {
 	// no copy constructor
-	auto a = new EaseElasticIn();
+	auto a = new (std::nothrow) EaseElasticIn();
 	a->initWithAction(_inner->clone(), _period);
 	a->autorelease();
 	return a;
@@ -543,7 +543,7 @@ EaseElasticOut* EaseElasticOut::create(ActionInterval *action)
 
 EaseElasticOut* EaseElasticOut::create(ActionInterval *action, float period/* = 0.3f*/)
 {
-    EaseElasticOut *ret = new EaseElasticOut();
+    EaseElasticOut *ret = new (std::nothrow) EaseElasticOut();
     if (ret)
     {
         if (ret->initWithAction(action, period))
@@ -562,7 +562,7 @@ EaseElasticOut* EaseElasticOut::create(ActionInterval *action, float period/* = 
 EaseElasticOut* EaseElasticOut::clone() const
 {
 	// no copy constructor
-	auto a = new EaseElasticOut();
+	auto a = new (std::nothrow) EaseElasticOut();
 	a->initWithAction(_inner->clone(), _period);
 	a->autorelease();
 	return a;
@@ -589,7 +589,7 @@ EaseElasticInOut* EaseElasticInOut::create(ActionInterval *action)
 
 EaseElasticInOut* EaseElasticInOut::create(ActionInterval *action, float period/* = 0.3f*/)
 {
-    EaseElasticInOut *ret = new EaseElasticInOut();
+    EaseElasticInOut *ret = new (std::nothrow) EaseElasticInOut();
     if (ret)
     {
         if (ret->initWithAction(action, period))
@@ -608,7 +608,7 @@ EaseElasticInOut* EaseElasticInOut::create(ActionInterval *action, float period/
 EaseElasticInOut* EaseElasticInOut::clone() const
 {
 	// no copy constructor
-	auto a = new EaseElasticInOut();
+	auto a = new (std::nothrow) EaseElasticInOut();
 	a->initWithAction(_inner->clone(), _period);
 	a->autorelease();
 	return a;
@@ -634,7 +634,7 @@ EaseElasticInOut* EaseElasticInOut::reverse() const
 
 EaseBounceIn* EaseBounceIn::create(ActionInterval* action)
 {
-    EaseBounceIn *ret = new EaseBounceIn();
+    EaseBounceIn *ret = new (std::nothrow) EaseBounceIn();
     if (ret)
     {
         if (ret->initWithAction(action))
@@ -653,7 +653,7 @@ EaseBounceIn* EaseBounceIn::create(ActionInterval* action)
 EaseBounceIn* EaseBounceIn::clone() const
 {
 	// no copy constructor
-	auto a = new EaseBounceIn();
+	auto a = new (std::nothrow) EaseBounceIn();
 	a->initWithAction(_inner->clone());
 	a->autorelease();
 	return a;
@@ -675,7 +675,7 @@ EaseBounce* EaseBounceIn::reverse() const
 
 EaseBounceOut* EaseBounceOut::create(ActionInterval* action)
 {
-    EaseBounceOut *ret = new EaseBounceOut();
+    EaseBounceOut *ret = new (std::nothrow) EaseBounceOut();
     if (ret)
     {
         if (ret->initWithAction(action))
@@ -694,7 +694,7 @@ EaseBounceOut* EaseBounceOut::create(ActionInterval* action)
 EaseBounceOut* EaseBounceOut::clone() const
 {
 	// no copy constructor
-	auto a = new EaseBounceOut();
+	auto a = new (std::nothrow) EaseBounceOut();
 	a->initWithAction(_inner->clone());
 	a->autorelease();
 	return a;
@@ -716,7 +716,7 @@ EaseBounce* EaseBounceOut::reverse() const
 
 EaseBounceInOut* EaseBounceInOut::create(ActionInterval* action)
 {
-    EaseBounceInOut *ret = new EaseBounceInOut();
+    EaseBounceInOut *ret = new (std::nothrow) EaseBounceInOut();
     if (ret)
     {
         if (ret->initWithAction(action))
@@ -735,7 +735,7 @@ EaseBounceInOut* EaseBounceInOut::create(ActionInterval* action)
 EaseBounceInOut* EaseBounceInOut::clone() const
 {
 	// no copy constructor
-	auto a = new EaseBounceInOut();
+	auto a = new (std::nothrow) EaseBounceInOut();
 	a->initWithAction(_inner->clone());
 	a->autorelease();
 	return a;
@@ -757,7 +757,7 @@ EaseBounceInOut* EaseBounceInOut::reverse() const
 
 EaseBackIn* EaseBackIn::create(ActionInterval *action)
 {
-    EaseBackIn *ret = new EaseBackIn();
+    EaseBackIn *ret = new (std::nothrow) EaseBackIn();
     if (ret)
     {
         if (ret->initWithAction(action))
@@ -776,7 +776,7 @@ EaseBackIn* EaseBackIn::create(ActionInterval *action)
 EaseBackIn* EaseBackIn::clone() const
 {
 	// no copy constructor	
-	auto a = new EaseBackIn();
+	auto a = new (std::nothrow) EaseBackIn();
 	a->initWithAction(_inner->clone());
 	a->autorelease();
 	return a;
@@ -798,7 +798,7 @@ ActionEase* EaseBackIn::reverse() const
 
 EaseBackOut* EaseBackOut::create(ActionInterval* action)
 {
-    EaseBackOut *ret = new EaseBackOut();
+    EaseBackOut *ret = new (std::nothrow) EaseBackOut();
     if (ret)
     {
         if (ret->initWithAction(action))
@@ -817,7 +817,7 @@ EaseBackOut* EaseBackOut::create(ActionInterval* action)
 EaseBackOut* EaseBackOut::clone() const
 {
 	// no copy constructor	
-	auto a = new EaseBackOut();
+	auto a = new (std::nothrow) EaseBackOut();
 	a->initWithAction(_inner->clone());
 	a->autorelease();
 	return a;
@@ -839,7 +839,7 @@ ActionEase* EaseBackOut::reverse() const
 
 EaseBackInOut* EaseBackInOut::create(ActionInterval* action)
 {
-    EaseBackInOut *ret = new EaseBackInOut();
+    EaseBackInOut *ret = new (std::nothrow) EaseBackInOut();
     if (ret)
     {
         if (ret->initWithAction(action))
@@ -858,7 +858,7 @@ EaseBackInOut* EaseBackInOut::create(ActionInterval* action)
 EaseBackInOut* EaseBackInOut::clone() const
 {
 	// no copy constructor
-	auto a = new EaseBackInOut();
+	auto a = new (std::nothrow) EaseBackInOut();
 	a->initWithAction(_inner->clone());
 	a->autorelease();
 	return a;
@@ -879,7 +879,7 @@ EaseBackInOut* EaseBackInOut::reverse() const
 
 EaseBezierAction* EaseBezierAction::create(cocos2d::ActionInterval* action)
 {
-	EaseBezierAction *ret = new EaseBezierAction();
+	EaseBezierAction *ret = new (std::nothrow) EaseBezierAction();
 	if (ret)
 	{  
 		if (ret->initWithAction(action))
@@ -906,7 +906,7 @@ void EaseBezierAction::setBezierParamer( float p0, float p1, float p2, float p3)
 EaseBezierAction* EaseBezierAction::clone() const
 {
 	// no copy constructor
-	auto a = new EaseBezierAction();
+	auto a = new (std::nothrow) EaseBezierAction();
 	a->initWithAction(_inner->clone());
 	a->setBezierParamer(_p0,_p1,_p2,_p3);
 	a->autorelease();
@@ -931,7 +931,7 @@ EaseBezierAction* EaseBezierAction::reverse() const
 
 EaseQuadraticActionIn* EaseQuadraticActionIn::create(ActionInterval* action)
 {
-	EaseQuadraticActionIn *ret = new EaseQuadraticActionIn();
+	EaseQuadraticActionIn *ret = new (std::nothrow) EaseQuadraticActionIn();
 	if (ret)
 	{
 		if (ret->initWithAction(action))
@@ -950,7 +950,7 @@ EaseQuadraticActionIn* EaseQuadraticActionIn::create(ActionInterval* action)
 EaseQuadraticActionIn* EaseQuadraticActionIn::clone() const
 {
 	// no copy constructor
-	auto a = new EaseQuadraticActionIn();
+	auto a = new (std::nothrow) EaseQuadraticActionIn();
 	a->initWithAction(_inner->clone());
 	a->autorelease();
 	return a;
@@ -972,7 +972,7 @@ EaseQuadraticActionIn* EaseQuadraticActionIn::reverse() const
 
 EaseQuadraticActionOut* EaseQuadraticActionOut::create(ActionInterval* action)
 {
-	EaseQuadraticActionOut *ret = new EaseQuadraticActionOut();
+	EaseQuadraticActionOut *ret = new (std::nothrow) EaseQuadraticActionOut();
 	if (ret)
 	{
 		if (ret->initWithAction(action))
@@ -991,7 +991,7 @@ EaseQuadraticActionOut* EaseQuadraticActionOut::create(ActionInterval* action)
 EaseQuadraticActionOut* EaseQuadraticActionOut::clone() const
 {
 	// no copy constructor
-	auto a = new EaseQuadraticActionOut();
+	auto a = new (std::nothrow) EaseQuadraticActionOut();
 	a->initWithAction(_inner->clone());
 	a->autorelease();
 	return a;
@@ -1013,7 +1013,7 @@ EaseQuadraticActionOut* EaseQuadraticActionOut::reverse() const
 
 EaseQuadraticActionInOut* EaseQuadraticActionInOut::create(ActionInterval* action)
 {
-	EaseQuadraticActionInOut *ret = new EaseQuadraticActionInOut();
+	EaseQuadraticActionInOut *ret = new (std::nothrow) EaseQuadraticActionInOut();
 	if (ret)
 	{
 		if (ret->initWithAction(action))
@@ -1032,7 +1032,7 @@ EaseQuadraticActionInOut* EaseQuadraticActionInOut::create(ActionInterval* actio
 EaseQuadraticActionInOut* EaseQuadraticActionInOut::clone() const
 {
 	// no copy constructor
-	auto a = new EaseQuadraticActionInOut();
+	auto a = new (std::nothrow) EaseQuadraticActionInOut();
 	a->initWithAction(_inner->clone());
 	a->autorelease();
 	return a;
@@ -1054,7 +1054,7 @@ EaseQuadraticActionInOut* EaseQuadraticActionInOut::reverse() const
 
 EaseQuarticActionIn* EaseQuarticActionIn::create(ActionInterval* action)
 {
-	EaseQuarticActionIn *ret = new EaseQuarticActionIn();
+	EaseQuarticActionIn *ret = new (std::nothrow) EaseQuarticActionIn();
 	if (ret)
 	{
 		if (ret->initWithAction(action))
@@ -1073,7 +1073,7 @@ EaseQuarticActionIn* EaseQuarticActionIn::create(ActionInterval* action)
 EaseQuarticActionIn* EaseQuarticActionIn::clone() const
 {
 	// no copy constructor
-	auto a = new EaseQuarticActionIn();
+	auto a = new (std::nothrow) EaseQuarticActionIn();
 	a->initWithAction(_inner->clone());
 	a->autorelease();
 	return a;
@@ -1095,7 +1095,7 @@ EaseQuarticActionIn* EaseQuarticActionIn::reverse() const
 
 EaseQuarticActionOut* EaseQuarticActionOut::create(ActionInterval* action)
 {
-	EaseQuarticActionOut *ret = new EaseQuarticActionOut();
+	EaseQuarticActionOut *ret = new (std::nothrow) EaseQuarticActionOut();
 	if (ret)
 	{
 		if (ret->initWithAction(action))
@@ -1114,7 +1114,7 @@ EaseQuarticActionOut* EaseQuarticActionOut::create(ActionInterval* action)
 EaseQuarticActionOut* EaseQuarticActionOut::clone() const
 {
 	// no copy constructor
-	auto a = new EaseQuarticActionOut();
+	auto a = new (std::nothrow) EaseQuarticActionOut();
 	a->initWithAction(_inner->clone());
 	a->autorelease();
 	return a;
@@ -1136,7 +1136,7 @@ EaseQuarticActionOut* EaseQuarticActionOut::reverse() const
 
 EaseQuarticActionInOut* EaseQuarticActionInOut::create(ActionInterval* action)
 {
-	EaseQuarticActionInOut *ret = new EaseQuarticActionInOut();
+	EaseQuarticActionInOut *ret = new (std::nothrow) EaseQuarticActionInOut();
 	if (ret)
 	{
 		if (ret->initWithAction(action))
@@ -1155,7 +1155,7 @@ EaseQuarticActionInOut* EaseQuarticActionInOut::create(ActionInterval* action)
 EaseQuarticActionInOut* EaseQuarticActionInOut::clone() const
 {
 	// no copy constructor
-	auto a = new EaseQuarticActionInOut();
+	auto a = new (std::nothrow) EaseQuarticActionInOut();
 	a->initWithAction(_inner->clone());
 	a->autorelease();
 	return a;
@@ -1177,7 +1177,7 @@ EaseQuarticActionInOut* EaseQuarticActionInOut::reverse() const
 
 EaseQuinticActionIn* EaseQuinticActionIn::create(ActionInterval* action)
 {
-	EaseQuinticActionIn *ret = new EaseQuinticActionIn();
+	EaseQuinticActionIn *ret = new (std::nothrow) EaseQuinticActionIn();
 	if (ret)
 	{
 		if (ret->initWithAction(action))
@@ -1196,7 +1196,7 @@ EaseQuinticActionIn* EaseQuinticActionIn::create(ActionInterval* action)
 EaseQuinticActionIn* EaseQuinticActionIn::clone() const
 {
 	// no copy constructor
-	auto a = new EaseQuinticActionIn();
+	auto a = new (std::nothrow) EaseQuinticActionIn();
 	a->initWithAction(_inner->clone());
 	a->autorelease();
 	return a;
@@ -1218,7 +1218,7 @@ EaseQuinticActionIn* EaseQuinticActionIn::reverse() const
 
 EaseQuinticActionOut* EaseQuinticActionOut::create(ActionInterval* action)
 {
-	EaseQuinticActionOut *ret = new EaseQuinticActionOut();
+	EaseQuinticActionOut *ret = new (std::nothrow) EaseQuinticActionOut();
 	if (ret)
 	{
 		if (ret->initWithAction(action))
@@ -1237,7 +1237,7 @@ EaseQuinticActionOut* EaseQuinticActionOut::create(ActionInterval* action)
 EaseQuinticActionOut* EaseQuinticActionOut::clone() const
 {
 	// no copy constructor
-	auto a = new EaseQuinticActionOut();
+	auto a = new (std::nothrow) EaseQuinticActionOut();
 	a->initWithAction(_inner->clone());
 	a->autorelease();
 	return a;
@@ -1259,7 +1259,7 @@ EaseQuinticActionOut* EaseQuinticActionOut::reverse() const
 
 EaseQuinticActionInOut* EaseQuinticActionInOut::create(ActionInterval* action)
 {
-	EaseQuinticActionInOut *ret = new EaseQuinticActionInOut();
+	EaseQuinticActionInOut *ret = new (std::nothrow) EaseQuinticActionInOut();
 	if (ret)
 	{
 		if (ret->initWithAction(action))
@@ -1278,7 +1278,7 @@ EaseQuinticActionInOut* EaseQuinticActionInOut::create(ActionInterval* action)
 EaseQuinticActionInOut* EaseQuinticActionInOut::clone() const
 {
 	// no copy constructor
-	auto a = new EaseQuinticActionInOut();
+	auto a = new (std::nothrow) EaseQuinticActionInOut();
 	a->initWithAction(_inner->clone());
 	a->autorelease();
 	return a;
@@ -1300,7 +1300,7 @@ EaseQuinticActionInOut* EaseQuinticActionInOut::reverse() const
 
 EaseCircleActionIn* EaseCircleActionIn::create(ActionInterval* action)
 {
-	EaseCircleActionIn *ret = new EaseCircleActionIn();
+	EaseCircleActionIn *ret = new (std::nothrow) EaseCircleActionIn();
 	if (ret)
 	{
 		if (ret->initWithAction(action))
@@ -1319,7 +1319,7 @@ EaseCircleActionIn* EaseCircleActionIn::create(ActionInterval* action)
 EaseCircleActionIn* EaseCircleActionIn::clone() const
 {
 	// no copy constructor
-	auto a = new EaseCircleActionIn();
+	auto a = new (std::nothrow) EaseCircleActionIn();
 	a->initWithAction(_inner->clone());
 	a->autorelease();
 	return a;
@@ -1341,7 +1341,7 @@ EaseCircleActionIn* EaseCircleActionIn::reverse() const
 
 EaseCircleActionOut* EaseCircleActionOut::create(ActionInterval* action)
 {
-	EaseCircleActionOut *ret = new EaseCircleActionOut();
+	EaseCircleActionOut *ret = new (std::nothrow) EaseCircleActionOut();
 	if (ret)
 	{
 		if (ret->initWithAction(action))
@@ -1360,7 +1360,7 @@ EaseCircleActionOut* EaseCircleActionOut::create(ActionInterval* action)
 EaseCircleActionOut* EaseCircleActionOut::clone() const
 {
 	// no copy constructor
-	auto a = new EaseCircleActionOut();
+	auto a = new (std::nothrow) EaseCircleActionOut();
 	a->initWithAction(_inner->clone());
 	a->autorelease();
 	return a;
@@ -1382,7 +1382,7 @@ EaseCircleActionOut* EaseCircleActionOut::reverse() const
 
 EaseCircleActionInOut* EaseCircleActionInOut::create(ActionInterval* action)
 {
-	EaseCircleActionInOut *ret = new EaseCircleActionInOut();
+	EaseCircleActionInOut *ret = new (std::nothrow) EaseCircleActionInOut();
 	if (ret)
 	{
 		if (ret->initWithAction(action))
@@ -1401,7 +1401,7 @@ EaseCircleActionInOut* EaseCircleActionInOut::create(ActionInterval* action)
 EaseCircleActionInOut* EaseCircleActionInOut::clone() const
 {
 	// no copy constructor
-	auto a = new EaseCircleActionInOut();
+	auto a = new (std::nothrow) EaseCircleActionInOut();
 	a->initWithAction(_inner->clone());
 	a->autorelease();
 	return a;
@@ -1423,7 +1423,7 @@ EaseCircleActionInOut* EaseCircleActionInOut::reverse() const
 
 EaseCubicActionIn* EaseCubicActionIn::create(ActionInterval* action)
 {
-	EaseCubicActionIn *ret = new EaseCubicActionIn();
+	EaseCubicActionIn *ret = new (std::nothrow) EaseCubicActionIn();
 	if (ret)
 	{
 		if (ret->initWithAction(action))
@@ -1442,7 +1442,7 @@ EaseCubicActionIn* EaseCubicActionIn::create(ActionInterval* action)
 EaseCubicActionIn* EaseCubicActionIn::clone() const
 {
 	// no copy constructor
-	auto a = new EaseCubicActionIn();
+	auto a = new (std::nothrow) EaseCubicActionIn();
 	a->initWithAction(_inner->clone());
 	a->autorelease();
 	return a;
@@ -1464,7 +1464,7 @@ EaseCubicActionIn* EaseCubicActionIn::reverse() const
 
 EaseCubicActionOut* EaseCubicActionOut::create(ActionInterval* action)
 {
-	EaseCubicActionOut *ret = new EaseCubicActionOut();
+	EaseCubicActionOut *ret = new (std::nothrow) EaseCubicActionOut();
 	if (ret)
 	{
 		if (ret->initWithAction(action))
@@ -1483,7 +1483,7 @@ EaseCubicActionOut* EaseCubicActionOut::create(ActionInterval* action)
 EaseCubicActionOut* EaseCubicActionOut::clone() const
 {
 	// no copy constructor
-	auto a = new EaseCubicActionOut();
+	auto a = new (std::nothrow) EaseCubicActionOut();
 	a->initWithAction(_inner->clone());
 	a->autorelease();
 	return a;
@@ -1505,7 +1505,7 @@ EaseCubicActionOut* EaseCubicActionOut::reverse() const
 
 EaseCubicActionInOut* EaseCubicActionInOut::create(ActionInterval* action)
 {
-	EaseCubicActionInOut *ret = new EaseCubicActionInOut();
+	EaseCubicActionInOut *ret = new (std::nothrow) EaseCubicActionInOut();
 	if (ret)
 	{
 		if (ret->initWithAction(action))
@@ -1524,7 +1524,7 @@ EaseCubicActionInOut* EaseCubicActionInOut::create(ActionInterval* action)
 EaseCubicActionInOut* EaseCubicActionInOut::clone() const
 {
 	// no copy constructor
-	auto a = new EaseCubicActionInOut();
+	auto a = new (std::nothrow) EaseCubicActionInOut();
 	a->initWithAction(_inner->clone());
 	a->autorelease();
 	return a;

--- a/cocos/2d/CCActionGrid.cpp
+++ b/cocos/2d/CCActionGrid.cpp
@@ -152,7 +152,7 @@ void TiledGrid3DAction::setTile(const Vec2& pos, const Quad3& coords)
 
 AccelDeccelAmplitude* AccelDeccelAmplitude::create(Action *action, float duration)
 {
-    AccelDeccelAmplitude *ret = new AccelDeccelAmplitude();
+    AccelDeccelAmplitude *ret = new (std::nothrow) AccelDeccelAmplitude();
     if (ret)
     {
         if (ret->initWithAction(action, duration))
@@ -185,7 +185,7 @@ bool AccelDeccelAmplitude::initWithAction(Action *action, float duration)
 AccelDeccelAmplitude* AccelDeccelAmplitude::clone() const
 {
 	// no copy constructor
-	auto a = new AccelDeccelAmplitude();
+	auto a = new (std::nothrow) AccelDeccelAmplitude();
 	a->initWithAction(_other->clone(), _rate);
 	a->autorelease();
 	return a;
@@ -224,7 +224,7 @@ AccelDeccelAmplitude* AccelDeccelAmplitude::reverse() const
 
 AccelAmplitude* AccelAmplitude::create(Action *action, float duration)
 {
-    AccelAmplitude *ret = new AccelAmplitude();
+    AccelAmplitude *ret = new (std::nothrow) AccelAmplitude();
     if (ret)
     {
         if (ret->initWithAction(action, duration))
@@ -257,7 +257,7 @@ bool AccelAmplitude::initWithAction(Action *action, float duration)
 AccelAmplitude* AccelAmplitude::clone() const
 {
 	// no copy constructor
-	auto a = new AccelAmplitude();
+	auto a = new (std::nothrow) AccelAmplitude();
 	a->initWithAction(_other->clone(), _duration);
 	a->autorelease();
 	return a;
@@ -289,7 +289,7 @@ AccelAmplitude* AccelAmplitude::reverse() const
 
 DeccelAmplitude* DeccelAmplitude::create(Action *action, float duration)
 {
-    DeccelAmplitude *ret = new DeccelAmplitude();
+    DeccelAmplitude *ret = new (std::nothrow) DeccelAmplitude();
     if (ret)
     {
         if (ret->initWithAction(action, duration))
@@ -339,7 +339,7 @@ void DeccelAmplitude::update(float time)
 DeccelAmplitude* DeccelAmplitude::clone() const
 {
 	// no copy constructor	
-	auto a = new DeccelAmplitude();
+	auto a = new (std::nothrow) DeccelAmplitude();
 	a->initWithAction(_other->clone(), _duration);
 	a->autorelease();
 	return a;
@@ -371,7 +371,7 @@ void StopGrid::cacheTargetAsGridNode()
 
 StopGrid* StopGrid::create()
 {
-    StopGrid* pAction = new StopGrid();
+    StopGrid* pAction = new (std::nothrow) StopGrid();
     pAction->autorelease();
 
     return pAction;
@@ -392,7 +392,7 @@ StopGrid* StopGrid::reverse() const
 
 ReuseGrid* ReuseGrid::create(int times)
 {
-    ReuseGrid *action = new ReuseGrid();
+    ReuseGrid *action = new (std::nothrow) ReuseGrid();
     if (action)
     {
         if (action->initWithTimes(times))

--- a/cocos/2d/CCActionGrid3D.cpp
+++ b/cocos/2d/CCActionGrid3D.cpp
@@ -31,7 +31,7 @@ NS_CC_BEGIN
 
 Waves3D* Waves3D::create(float duration, const Size& gridSize, unsigned int waves, float amplitude)
 {
-    Waves3D *pAction = new Waves3D();
+    Waves3D *pAction = new (std::nothrow) Waves3D();
 
     if (pAction)
     {
@@ -65,7 +65,7 @@ bool Waves3D::initWithDuration(float duration, const Size& gridSize, unsigned in
 Waves3D* Waves3D::clone() const
 {
 	// no copy constructor
-	auto a = new Waves3D();
+	auto a = new (std::nothrow) Waves3D();
     a->initWithDuration(_duration, _gridSize, _waves, _amplitude);
 	a->autorelease();
 	return a;
@@ -90,7 +90,7 @@ void Waves3D::update(float time)
 
 FlipX3D* FlipX3D::create(float duration)
 {
-    FlipX3D *action = new FlipX3D();
+    FlipX3D *action = new (std::nothrow) FlipX3D();
 
     if (action)
     {
@@ -128,7 +128,7 @@ bool FlipX3D::initWithSize(const Size& gridSize, float duration)
 FlipX3D* FlipX3D::clone() const
 {
 	// no copy constructor	
-	auto a = new FlipX3D();
+	auto a = new (std::nothrow) FlipX3D();
     a->initWithSize(_gridSize, _duration);
 	a->autorelease();
 	return a;
@@ -203,7 +203,7 @@ void FlipX3D::update(float time)
 FlipY3D* FlipY3D::clone() const
 {
     // no copy constructor
-	auto a = new FlipY3D();
+	auto a = new (std::nothrow) FlipY3D();
     a->initWithSize(_gridSize, _duration);
 	a->autorelease();
 	return a;
@@ -211,7 +211,7 @@ FlipY3D* FlipY3D::clone() const
 
 FlipY3D* FlipY3D::create(float duration)
 {
-    FlipY3D *action = new FlipY3D();
+    FlipY3D *action = new (std::nothrow) FlipY3D();
 
     if (action)
     {
@@ -297,7 +297,7 @@ void FlipY3D::update(float time)
 
 Lens3D* Lens3D::create(float duration, const Size& gridSize, const Vec2& position, float radius)
 {
-    Lens3D *action = new Lens3D();
+    Lens3D *action = new (std::nothrow) Lens3D();
 
     if (action)
     {
@@ -334,7 +334,7 @@ bool Lens3D::initWithDuration(float duration, const Size& gridSize, const Vec2& 
 Lens3D* Lens3D::clone() const
 {
 	// no copy constructor
-	auto a = new Lens3D();
+	auto a = new (std::nothrow) Lens3D();
 	a->initWithDuration(_duration, _gridSize, _position, _radius);
 	a->autorelease();
 	return a;
@@ -396,7 +396,7 @@ void Lens3D::update(float time)
 
 Ripple3D* Ripple3D::create(float duration, const Size& gridSize, const Vec2& position, float radius, unsigned int waves, float amplitude)
 {
-    Ripple3D *action = new Ripple3D();
+    Ripple3D *action = new (std::nothrow) Ripple3D();
 
     if (action)
     {
@@ -438,7 +438,7 @@ void Ripple3D::setPosition(const Vec2& position)
 Ripple3D* Ripple3D::clone() const
 {
 	// no copy constructor
-	auto a = new Ripple3D();
+	auto a = new (std::nothrow) Ripple3D();
 	a->initWithDuration(_duration, _gridSize, _position, _radius, _waves, _amplitude);
 	a->autorelease();
 	return a;
@@ -472,7 +472,7 @@ void Ripple3D::update(float time)
 
 Shaky3D* Shaky3D::create(float duration, const Size& gridSize, int range, bool shakeZ)
 {
-    Shaky3D *action = new Shaky3D();
+    Shaky3D *action = new (std::nothrow) Shaky3D();
 
     if (action)
     {
@@ -505,7 +505,7 @@ bool Shaky3D::initWithDuration(float duration, const Size& gridSize, int range, 
 Shaky3D* Shaky3D::clone() const
 {
 	// no copy constructor
-	auto a = new Shaky3D();
+	auto a = new (std::nothrow) Shaky3D();
     a->initWithDuration(_duration, _gridSize, _randrange, _shakeZ);
 	a->autorelease();
 	return a;
@@ -537,7 +537,7 @@ void Shaky3D::update(float time)
 
 Liquid* Liquid::create(float duration, const Size& gridSize, unsigned int waves, float amplitude)
 {
-    Liquid *action = new Liquid();
+    Liquid *action = new (std::nothrow) Liquid();
 
     if (action)
     {
@@ -571,7 +571,7 @@ bool Liquid::initWithDuration(float duration, const Size& gridSize, unsigned int
 Liquid* Liquid::clone() const
 {
 	// no copy constructor
-	auto a = new Liquid();
+	auto a = new (std::nothrow) Liquid();
 	a->initWithDuration(_duration, _gridSize, _waves, _amplitude);
 	a->autorelease();
 	return a;
@@ -597,7 +597,7 @@ void Liquid::update(float time)
 
 Waves* Waves::create(float duration, const Size& gridSize, unsigned int waves, float amplitude, bool horizontal, bool vertical)
 {
-    Waves *action = new Waves();
+    Waves *action = new (std::nothrow) Waves();
 
     if (action)
     {
@@ -633,7 +633,7 @@ bool Waves::initWithDuration(float duration, const Size& gridSize, unsigned int 
 Waves* Waves::clone() const
 {
 	// no copy constructor
-	auto a = new Waves();
+	auto a = new (std::nothrow) Waves();
 	a->initWithDuration(_duration, _gridSize, _waves, _amplitude, _horizontal, _vertical);
 	a->autorelease();
 	return a;
@@ -668,7 +668,7 @@ void Waves::update(float time)
 
 Twirl* Twirl::create(float duration, const Size& gridSize, Vec2 position, unsigned int twirls, float amplitude)
 {
-    Twirl *action = new Twirl();
+    Twirl *action = new (std::nothrow) Twirl();
 
     if (action)
     {
@@ -708,7 +708,7 @@ void Twirl::setPosition(const Vec2& position)
 Twirl *Twirl::clone() const
 {
 	// no copy constructor	
-	auto a = new Twirl();
+	auto a = new (std::nothrow) Twirl();
 	a->initWithDuration(_duration, _gridSize, _position, _twirls, _amplitude);
 	a->autorelease();
 	return a;

--- a/cocos/2d/CCActionInstant.cpp
+++ b/cocos/2d/CCActionInstant.cpp
@@ -61,7 +61,7 @@ void ActionInstant::update(float time) {
 
 Show* Show::create() 
 {
-    Show* ret = new Show();
+    Show* ret = new (std::nothrow) Show();
 
     if (ret) {
         ret->autorelease();
@@ -83,7 +83,7 @@ ActionInstant* Show::reverse() const
 Show * Show::clone() const
 {
 	// no copy constructor
-	auto a = new Show();
+	auto a = new (std::nothrow) Show();
 	a->autorelease();
 	return a;
 }
@@ -93,7 +93,7 @@ Show * Show::clone() const
 //
 Hide * Hide::create() 
 {
-    Hide *ret = new Hide();
+    Hide *ret = new (std::nothrow) Hide();
 
     if (ret) {
         ret->autorelease();
@@ -115,7 +115,7 @@ ActionInstant *Hide::reverse() const
 Hide * Hide::clone() const
 {
 	// no copy constructor
-	auto a = new Hide();
+	auto a = new (std::nothrow) Hide();
 	a->autorelease();
 	return a;
 }
@@ -125,7 +125,7 @@ Hide * Hide::clone() const
 //
 ToggleVisibility * ToggleVisibility::create()
 {
-    ToggleVisibility *ret = new ToggleVisibility();
+    ToggleVisibility *ret = new (std::nothrow) ToggleVisibility();
 
     if (ret)
     {
@@ -149,7 +149,7 @@ ToggleVisibility * ToggleVisibility::reverse() const
 ToggleVisibility * ToggleVisibility::clone() const
 {
 	// no copy constructor
-	auto a = new ToggleVisibility();
+	auto a = new (std::nothrow) ToggleVisibility();
 	a->autorelease();
 	return a;
 }
@@ -159,7 +159,7 @@ ToggleVisibility * ToggleVisibility::clone() const
 //
 RemoveSelf * RemoveSelf::create(bool isNeedCleanUp /*= true*/) 
 {
-	RemoveSelf *ret = new RemoveSelf();
+	RemoveSelf *ret = new (std::nothrow) RemoveSelf();
 
 	if (ret && ret->init(isNeedCleanUp)) {
 		ret->autorelease();
@@ -186,7 +186,7 @@ RemoveSelf *RemoveSelf::reverse() const
 RemoveSelf * RemoveSelf::clone() const
 {
 	// no copy constructor
-	auto a = new RemoveSelf();
+	auto a = new (std::nothrow) RemoveSelf();
 	a->init(_isNeedCleanUp);
 	a->autorelease();
 	return a;
@@ -198,7 +198,7 @@ RemoveSelf * RemoveSelf::clone() const
 
 FlipX *FlipX::create(bool x)
 {
-    FlipX *ret = new FlipX();
+    FlipX *ret = new (std::nothrow) FlipX();
 
     if (ret && ret->initWithFlipX(x)) {
         ret->autorelease();
@@ -227,7 +227,7 @@ FlipX* FlipX::reverse() const
 FlipX * FlipX::clone() const
 {
 	// no copy constructor
-	auto a = new FlipX();
+	auto a = new (std::nothrow) FlipX();
 	a->initWithFlipX(_flipX);
 	a->autorelease();
 	return a;
@@ -238,7 +238,7 @@ FlipX * FlipX::clone() const
 
 FlipY * FlipY::create(bool y)
 {
-    FlipY *ret = new FlipY();
+    FlipY *ret = new (std::nothrow) FlipY();
 
     if (ret && ret->initWithFlipY(y)) {
         ret->autorelease();
@@ -267,7 +267,7 @@ FlipY* FlipY::reverse() const
 FlipY * FlipY::clone() const
 {
 	// no copy constructor
-	auto a = new FlipY();
+	auto a = new (std::nothrow) FlipY();
 	a->initWithFlipY(_flipY);
 	a->autorelease();
 	return a;
@@ -279,7 +279,7 @@ FlipY * FlipY::clone() const
 
 Place* Place::create(const Vec2& pos)
 {
-    Place *ret = new Place();
+    Place *ret = new (std::nothrow) Place();
 
     if (ret && ret->initWithPosition(pos)) {
         ret->autorelease();
@@ -298,7 +298,7 @@ bool Place::initWithPosition(const Vec2& pos) {
 Place * Place::clone() const
 {
 	// no copy constructor
-	auto a = new Place();
+	auto a = new (std::nothrow) Place();
 	a->initWithPosition(_position);
 	a->autorelease();
 	return a;
@@ -321,7 +321,7 @@ void Place::update(float time) {
 
 CallFunc * CallFunc::create(const std::function<void()> &func)
 {
-    CallFunc *ret = new CallFunc();
+    CallFunc *ret = new (std::nothrow) CallFunc();
 
     if (ret && ret->initWithFunction(func) ) {
         ret->autorelease();
@@ -334,7 +334,7 @@ CallFunc * CallFunc::create(const std::function<void()> &func)
 
 CallFunc * CallFunc::create(Ref* selectorTarget, SEL_CallFunc selector) 
 {
-    CallFunc *ret = new CallFunc();
+    CallFunc *ret = new (std::nothrow) CallFunc();
 
     if (ret && ret->initWithTarget(selectorTarget)) {
         ret->_callFunc = selector;
@@ -375,7 +375,7 @@ CallFunc::~CallFunc()
 CallFunc * CallFunc::clone() const
     {
     // no copy constructor
-    auto a = new CallFunc();
+    auto a = new (std::nothrow) CallFunc();
     if( _selectorTarget) {
         a->initWithTarget(_selectorTarget);
         a->_callFunc = _callFunc;
@@ -413,7 +413,7 @@ void CallFunc::execute() {
 
 CallFuncN * CallFuncN::create(const std::function<void(Node*)> &func)
 {
-    auto ret = new CallFuncN();
+    auto ret = new (std::nothrow) CallFuncN();
 
     if (ret && ret->initWithFunction(func) ) {
         ret->autorelease();
@@ -427,7 +427,7 @@ CallFuncN * CallFuncN::create(const std::function<void(Node*)> &func)
 // XXX deprecated
 CallFuncN * CallFuncN::create(Ref* selectorTarget, SEL_CallFuncN selector)
 {
-    CallFuncN *ret = new CallFuncN();
+    CallFuncN *ret = new (std::nothrow) CallFuncN();
 
     if (ret && ret->initWithTarget(selectorTarget, selector))
     {
@@ -467,7 +467,7 @@ bool CallFuncN::initWithTarget(Ref* selectorTarget, SEL_CallFuncN selector)
 CallFuncN * CallFuncN::clone() const
 {
 	// no copy constructor
-	auto a = new CallFuncN();
+	auto a = new (std::nothrow) CallFuncN();
 
     if( _selectorTarget) {
         a->initWithTarget(_selectorTarget, _callFuncN);

--- a/cocos/2d/CCActionInterval.cpp
+++ b/cocos/2d/CCActionInterval.cpp
@@ -52,7 +52,7 @@ public:
 
 ExtraAction* ExtraAction::create()
 {
-    ExtraAction* ret = new ExtraAction();
+    ExtraAction* ret = new (std::nothrow) ExtraAction();
     if (ret)
     {
         ret->autorelease();
@@ -62,7 +62,7 @@ ExtraAction* ExtraAction::create()
 ExtraAction* ExtraAction::clone() const
 {
 	// no copy constructor
-	auto a = new ExtraAction();
+	auto a = new (std::nothrow) ExtraAction();
 	a->autorelease();
 	return a;
 }
@@ -157,7 +157,7 @@ void ActionInterval::startWithTarget(Node *target)
 
 Sequence* Sequence::createWithTwoActions(FiniteTimeAction *actionOne, FiniteTimeAction *actionTwo)
 {
-    Sequence *sequence = new Sequence();
+    Sequence *sequence = new (std::nothrow) Sequence();
     sequence->initWithTwoActions(actionOne, actionTwo);
     sequence->autorelease();
 
@@ -265,7 +265,7 @@ bool Sequence::initWithTwoActions(FiniteTimeAction *actionOne, FiniteTimeAction 
 Sequence* Sequence::clone() const
 {
 	// no copy constructor
-	auto a = new Sequence();
+	auto a = new (std::nothrow) Sequence();
     a->initWithTwoActions(_actions[0]->clone(), _actions[1]->clone() );
 	a->autorelease();
 	return a;
@@ -368,7 +368,7 @@ Sequence* Sequence::reverse() const
 
 Repeat* Repeat::create(FiniteTimeAction *action, unsigned int times)
 {
-    Repeat* repeat = new Repeat();
+    Repeat* repeat = new (std::nothrow) Repeat();
     repeat->initWithAction(action, times);
     repeat->autorelease();
 
@@ -402,7 +402,7 @@ bool Repeat::initWithAction(FiniteTimeAction *action, unsigned int times)
 Repeat* Repeat::clone(void) const
 {
 	// no copy constructor
-	auto a = new Repeat();
+	auto a = new (std::nothrow) Repeat();
 	a->initWithAction( _innerAction->clone(), _times );
 	a->autorelease();
 	return a;
@@ -491,7 +491,7 @@ RepeatForever::~RepeatForever()
 
 RepeatForever *RepeatForever::create(ActionInterval *action)
 {
-    RepeatForever *ret = new RepeatForever();
+    RepeatForever *ret = new (std::nothrow) RepeatForever();
     if (ret && ret->initWithAction(action))
     {
         ret->autorelease();
@@ -512,7 +512,7 @@ bool RepeatForever::initWithAction(ActionInterval *action)
 RepeatForever *RepeatForever::clone() const
 {
 	// no copy constructor	
-	auto a = new RepeatForever();
+	auto a = new (std::nothrow) RepeatForever();
 	a->initWithAction(_innerAction->clone());
 	a->autorelease();
 	return a;
@@ -635,7 +635,7 @@ Spawn* Spawn::create(const Vector<FiniteTimeAction*>& arrayOfActions)
 
 Spawn* Spawn::createWithTwoActions(FiniteTimeAction *action1, FiniteTimeAction *action2)
 {
-    Spawn *spawn = new Spawn();
+    Spawn *spawn = new (std::nothrow) Spawn();
     spawn->initWithTwoActions(action1, action2);
     spawn->autorelease();
 
@@ -678,7 +678,7 @@ bool Spawn::initWithTwoActions(FiniteTimeAction *action1, FiniteTimeAction *acti
 Spawn* Spawn::clone(void) const
 {
 	// no copy constructor	
-	auto a = new Spawn();
+	auto a = new (std::nothrow) Spawn();
     a->initWithTwoActions(_one->clone(), _two->clone());
 
 	a->autorelease();
@@ -728,7 +728,7 @@ Spawn* Spawn::reverse() const
 
 RotateTo* RotateTo::create(float duration, float dstAngle)
 {
-    RotateTo* rotateTo = new RotateTo();
+    RotateTo* rotateTo = new (std::nothrow) RotateTo();
     rotateTo->initWithDuration(duration, dstAngle, dstAngle);
     rotateTo->autorelease();
 
@@ -737,7 +737,7 @@ RotateTo* RotateTo::create(float duration, float dstAngle)
 
 RotateTo* RotateTo::create(float duration, float dstAngleX, float dstAngleY)
 {
-    RotateTo* rotateTo = new RotateTo();
+    RotateTo* rotateTo = new (std::nothrow) RotateTo();
     rotateTo->initWithDuration(duration, dstAngleX, dstAngleY);
     rotateTo->autorelease();
     
@@ -746,7 +746,7 @@ RotateTo* RotateTo::create(float duration, float dstAngleX, float dstAngleY)
 
 RotateTo* RotateTo::create(float duration, const Vec3& dstAngle3D)
 {
-    RotateTo* rotateTo = new RotateTo();
+    RotateTo* rotateTo = new (std::nothrow) RotateTo();
     rotateTo->initWithDuration(duration, dstAngle3D);
     rotateTo->autorelease();
     
@@ -787,7 +787,7 @@ bool RotateTo::initWithDuration(float duration, const Vec3& dstAngle3D)
 RotateTo* RotateTo::clone(void) const
 {
 	// no copy constructor
-	auto a = new RotateTo();
+	auto a = new (std::nothrow) RotateTo();
     if(_is3D)
 	   a->initWithDuration(_duration, _dstAngle);
     else
@@ -887,7 +887,7 @@ RotateTo *RotateTo::reverse() const
 
 RotateBy* RotateBy::create(float duration, float deltaAngle)
 {
-    RotateBy *rotateBy = new RotateBy();
+    RotateBy *rotateBy = new (std::nothrow) RotateBy();
     rotateBy->initWithDuration(duration, deltaAngle);
     rotateBy->autorelease();
 
@@ -896,7 +896,7 @@ RotateBy* RotateBy::create(float duration, float deltaAngle)
 
 RotateBy* RotateBy::create(float duration, float deltaAngleX, float deltaAngleY)
 {
-    RotateBy *rotateBy = new RotateBy();
+    RotateBy *rotateBy = new (std::nothrow) RotateBy();
     rotateBy->initWithDuration(duration, deltaAngleX, deltaAngleY);
     rotateBy->autorelease();
     
@@ -905,7 +905,7 @@ RotateBy* RotateBy::create(float duration, float deltaAngleX, float deltaAngleY)
 
 RotateBy* RotateBy::create(float duration, const Vec3& deltaAngle3D)
 {
-    RotateBy *rotateBy = new RotateBy();
+    RotateBy *rotateBy = new (std::nothrow) RotateBy();
     rotateBy->initWithDuration(duration, deltaAngle3D);
     rotateBy->autorelease();
 
@@ -956,7 +956,7 @@ bool RotateBy::initWithDuration(float duration, const Vec3& deltaAngle3D)
 RotateBy* RotateBy::clone() const
 {
 	// no copy constructor
-	auto a = new RotateBy();
+	auto a = new (std::nothrow) RotateBy();
     if(_is3D)
         a->initWithDuration(_duration, _deltaAngle);
     else
@@ -1040,7 +1040,7 @@ RotateBy* RotateBy::reverse() const
 
 MoveBy* MoveBy::create(float duration, const Vec2& deltaPosition)
 {
-    MoveBy *ret = new MoveBy();
+    MoveBy *ret = new (std::nothrow) MoveBy();
     ret->initWithDuration(duration, deltaPosition);
     ret->autorelease();
 
@@ -1061,7 +1061,7 @@ bool MoveBy::initWithDuration(float duration, const Vec2& deltaPosition)
 MoveBy* MoveBy::clone() const
 {
 	// no copy constructor
-	auto a = new MoveBy();
+	auto a = new (std::nothrow) MoveBy();
     a->initWithDuration(_duration, _positionDelta);
 	a->autorelease();
 	return a;
@@ -1102,7 +1102,7 @@ void MoveBy::update(float t)
 
 MoveTo* MoveTo::create(float duration, const Vec2& position)
 {
-    MoveTo *ret = new MoveTo();
+    MoveTo *ret = new (std::nothrow) MoveTo();
     ret->initWithDuration(duration, position);
     ret->autorelease();
 
@@ -1123,7 +1123,7 @@ bool MoveTo::initWithDuration(float duration, const Vec2& position)
 MoveTo* MoveTo::clone() const
 {
 	// no copy constructor
-	auto a = new MoveTo();
+	auto a = new (std::nothrow) MoveTo();
     a->initWithDuration(_duration, _endPosition);
 	a->autorelease();
 	return a;
@@ -1141,7 +1141,7 @@ void MoveTo::startWithTarget(Node *target)
 //
 SkewTo* SkewTo::create(float t, float sx, float sy)
 {
-    SkewTo *skewTo = new SkewTo();
+    SkewTo *skewTo = new (std::nothrow) SkewTo();
     if (skewTo)
     {
         if (skewTo->initWithDuration(t, sx, sy))
@@ -1175,7 +1175,7 @@ bool SkewTo::initWithDuration(float t, float sx, float sy)
 SkewTo* SkewTo::clone() const
 {
 	// no copy constructor
-	auto a = new SkewTo();
+	auto a = new (std::nothrow) SkewTo();
 	a->initWithDuration(_duration, _endSkewX, _endSkewY);
 	a->autorelease();
 	return a;
@@ -1259,7 +1259,7 @@ SkewTo::SkewTo()
 //
 SkewBy* SkewBy::create(float t, float sx, float sy)
 {
-    SkewBy *skewBy = new SkewBy();
+    SkewBy *skewBy = new (std::nothrow) SkewBy();
     if (skewBy)
     {
         if (skewBy->initWithDuration(t, sx, sy))
@@ -1278,7 +1278,7 @@ SkewBy* SkewBy::create(float t, float sx, float sy)
 SkewBy * SkewBy::clone() const
 {
 	// no copy constructor
-	auto a = new SkewBy();
+	auto a = new (std::nothrow) SkewBy();
 	a->initWithDuration(_duration, _skewX, _skewY);
 	a->autorelease();
 	return a;
@@ -1319,7 +1319,7 @@ SkewBy* SkewBy::reverse() const
 
 JumpBy* JumpBy::create(float duration, const Vec2& position, float height, int jumps)
 {
-    JumpBy *jumpBy = new JumpBy();
+    JumpBy *jumpBy = new (std::nothrow) JumpBy();
     jumpBy->initWithDuration(duration, position, height, jumps);
     jumpBy->autorelease();
 
@@ -1345,7 +1345,7 @@ bool JumpBy::initWithDuration(float duration, const Vec2& position, float height
 JumpBy* JumpBy::clone() const
 {
 	// no copy constructor
-	auto a = new JumpBy();
+	auto a = new (std::nothrow) JumpBy();
 	a->initWithDuration(_duration, _delta, _height, _jumps);
 	a->autorelease();
 	return a;
@@ -1395,7 +1395,7 @@ JumpBy* JumpBy::reverse() const
 
 JumpTo* JumpTo::create(float duration, const Vec2& position, float height, int jumps)
 {
-    JumpTo *jumpTo = new JumpTo();
+    JumpTo *jumpTo = new (std::nothrow) JumpTo();
     jumpTo->initWithDuration(duration, position, height, jumps);
     jumpTo->autorelease();
 
@@ -1405,7 +1405,7 @@ JumpTo* JumpTo::create(float duration, const Vec2& position, float height, int j
 JumpTo* JumpTo::clone() const
 {
 	// no copy constructor
-	auto a = new JumpTo();
+	auto a = new (std::nothrow) JumpTo();
     a->initWithDuration(_duration, _delta, _height, _jumps);
 	a->autorelease();
 	return a;
@@ -1441,7 +1441,7 @@ static inline float bezierat( float a, float b, float c, float d, float t )
 
 BezierBy* BezierBy::create(float t, const ccBezierConfig& c)
 {
-    BezierBy *bezierBy = new BezierBy();
+    BezierBy *bezierBy = new (std::nothrow) BezierBy();
     bezierBy->initWithDuration(t, c);
     bezierBy->autorelease();
 
@@ -1468,7 +1468,7 @@ void BezierBy::startWithTarget(Node *target)
 BezierBy* BezierBy::clone() const
 {
 	// no copy constructor
-	auto a = new BezierBy();
+	auto a = new (std::nothrow) BezierBy();
 	a->initWithDuration(_duration, _config);
 	a->autorelease();
 	return a;
@@ -1524,7 +1524,7 @@ BezierBy* BezierBy::reverse() const
 
 BezierTo* BezierTo::create(float t, const ccBezierConfig& c)
 {
-    BezierTo *bezierTo = new BezierTo();
+    BezierTo *bezierTo = new (std::nothrow) BezierTo();
     bezierTo->initWithDuration(t, c);
     bezierTo->autorelease();
 
@@ -1545,7 +1545,7 @@ bool BezierTo::initWithDuration(float t, const ccBezierConfig &c)
 BezierTo* BezierTo::clone() const
 {
 	// no copy constructor
-	auto a = new BezierTo();
+	auto a = new (std::nothrow) BezierTo();
 	a->initWithDuration(_duration, _toConfig);
 	a->autorelease();
 	return a;
@@ -1571,7 +1571,7 @@ BezierTo* BezierTo::reverse() const
 //
 ScaleTo* ScaleTo::create(float duration, float s)
 {
-    ScaleTo *scaleTo = new ScaleTo();
+    ScaleTo *scaleTo = new (std::nothrow) ScaleTo();
     scaleTo->initWithDuration(duration, s);
     scaleTo->autorelease();
 
@@ -1580,7 +1580,7 @@ ScaleTo* ScaleTo::create(float duration, float s)
 
 ScaleTo* ScaleTo::create(float duration, float sx, float sy)
 {
-    ScaleTo *scaleTo = new ScaleTo();
+    ScaleTo *scaleTo = new (std::nothrow) ScaleTo();
     scaleTo->initWithDuration(duration, sx, sy);
     scaleTo->autorelease();
 
@@ -1589,7 +1589,7 @@ ScaleTo* ScaleTo::create(float duration, float sx, float sy)
 
 ScaleTo* ScaleTo::create(float duration, float sx, float sy, float sz)
 {
-    ScaleTo *scaleTo = new ScaleTo();
+    ScaleTo *scaleTo = new (std::nothrow) ScaleTo();
     scaleTo->initWithDuration(duration, sx, sy, sz);
     scaleTo->autorelease();
 
@@ -1641,7 +1641,7 @@ bool ScaleTo::initWithDuration(float duration, float sx, float sy, float sz)
 ScaleTo* ScaleTo::clone() const
 {
 	// no copy constructor
-	auto a = new ScaleTo();
+	auto a = new (std::nothrow) ScaleTo();
 	a->initWithDuration(_duration, _endScaleX, _endScaleY, _endScaleZ);
 	a->autorelease();
 	return a;
@@ -1681,7 +1681,7 @@ void ScaleTo::update(float time)
 
 ScaleBy* ScaleBy::create(float duration, float s)
 {
-    ScaleBy *scaleBy = new ScaleBy();
+    ScaleBy *scaleBy = new (std::nothrow) ScaleBy();
     scaleBy->initWithDuration(duration, s);
     scaleBy->autorelease();
 
@@ -1690,7 +1690,7 @@ ScaleBy* ScaleBy::create(float duration, float s)
 
 ScaleBy* ScaleBy::create(float duration, float sx, float sy)
 {
-    ScaleBy *scaleBy = new ScaleBy();
+    ScaleBy *scaleBy = new (std::nothrow) ScaleBy();
     scaleBy->initWithDuration(duration, sx, sy, 1.f);
     scaleBy->autorelease();
 
@@ -1699,7 +1699,7 @@ ScaleBy* ScaleBy::create(float duration, float sx, float sy)
 
 ScaleBy* ScaleBy::create(float duration, float sx, float sy, float sz)
 {
-    ScaleBy *scaleBy = new ScaleBy();
+    ScaleBy *scaleBy = new (std::nothrow) ScaleBy();
     scaleBy->initWithDuration(duration, sx, sy, sz);
     scaleBy->autorelease();
 
@@ -1709,7 +1709,7 @@ ScaleBy* ScaleBy::create(float duration, float sx, float sy, float sz)
 ScaleBy* ScaleBy::clone() const
 {
 	// no copy constructor
-	auto a = new ScaleBy();
+	auto a = new (std::nothrow) ScaleBy();
     a->initWithDuration(_duration, _endScaleX, _endScaleY, _endScaleZ);
 	a->autorelease();
 	return a;
@@ -1734,7 +1734,7 @@ ScaleBy* ScaleBy::reverse() const
 
 Blink* Blink::create(float duration, int blinks)
 {
-    Blink *blink = new Blink();
+    Blink *blink = new (std::nothrow) Blink();
     blink->initWithDuration(duration, blinks);
     blink->autorelease();
 
@@ -1769,7 +1769,7 @@ void Blink::startWithTarget(Node *target)
 Blink* Blink::clone(void) const
 {
 	// no copy constructor
-	auto a = new Blink();
+	auto a = new (std::nothrow) Blink();
 	a->initWithDuration(_duration, _times);
 	a->autorelease();
 	return a;
@@ -1796,7 +1796,7 @@ Blink* Blink::reverse() const
 
 FadeIn* FadeIn::create(float d)
 {
-    FadeIn* action = new FadeIn();
+    FadeIn* action = new (std::nothrow) FadeIn();
 
     action->initWithDuration(d,255.0f);
     action->autorelease();
@@ -1807,7 +1807,7 @@ FadeIn* FadeIn::create(float d)
 FadeIn* FadeIn::clone() const
 {
 	// no copy constructor
-	auto a = new FadeIn();
+	auto a = new (std::nothrow) FadeIn();
     a->initWithDuration(_duration,255.0f);
 	a->autorelease();
 	return a;
@@ -1850,7 +1850,7 @@ void FadeIn::startWithTarget(cocos2d::Node *target)
 
 FadeOut* FadeOut::create(float d)
 {
-    FadeOut* action = new FadeOut();
+    FadeOut* action = new (std::nothrow) FadeOut();
 
     action->initWithDuration(d,0.0f);
     action->autorelease();
@@ -1861,7 +1861,7 @@ FadeOut* FadeOut::create(float d)
 FadeOut* FadeOut::clone() const
 {
 	// no copy constructor
-	auto a = new FadeOut();
+	auto a = new (std::nothrow) FadeOut();
     a->initWithDuration(_duration,0.0f);
 	a->autorelease();
 	return a;
@@ -1901,7 +1901,7 @@ FadeTo* FadeOut::reverse() const
 
 FadeTo* FadeTo::create(float duration, GLubyte opacity)
 {
-    FadeTo *fadeTo = new FadeTo();
+    FadeTo *fadeTo = new (std::nothrow) FadeTo();
     fadeTo->initWithDuration(duration, opacity);
     fadeTo->autorelease();
 
@@ -1922,7 +1922,7 @@ bool FadeTo::initWithDuration(float duration, GLubyte opacity)
 FadeTo* FadeTo::clone() const
 {
 	// no copy constructor
-	auto a = new FadeTo();
+	auto a = new (std::nothrow) FadeTo();
 	a->initWithDuration(_duration, _toOpacity);
 	a->autorelease();
 	return a;
@@ -1959,7 +1959,7 @@ void FadeTo::update(float time)
 //
 TintTo* TintTo::create(float duration, GLubyte red, GLubyte green, GLubyte blue)
 {
-    TintTo *tintTo = new TintTo();
+    TintTo *tintTo = new (std::nothrow) TintTo();
     tintTo->initWithDuration(duration, red, green, blue);
     tintTo->autorelease();
 
@@ -1980,7 +1980,7 @@ bool TintTo::initWithDuration(float duration, GLubyte red, GLubyte green, GLubyt
 TintTo* TintTo::clone() const
 {
 	// no copy constructor
-	auto a = new TintTo();
+	auto a = new (std::nothrow) TintTo();
 	a->initWithDuration(_duration, _to.r, _to.g, _to.b);
 	a->autorelease();
 	return a;
@@ -2018,7 +2018,7 @@ void TintTo::update(float time)
 
 TintBy* TintBy::create(float duration, GLshort deltaRed, GLshort deltaGreen, GLshort deltaBlue)
 {
-    TintBy *tintBy = new TintBy();
+    TintBy *tintBy = new (std::nothrow) TintBy();
     tintBy->initWithDuration(duration, deltaRed, deltaGreen, deltaBlue);
     tintBy->autorelease();
 
@@ -2042,7 +2042,7 @@ bool TintBy::initWithDuration(float duration, GLshort deltaRed, GLshort deltaGre
 TintBy* TintBy::clone() const
 {
 	// no copy constructor
-	auto a = new TintBy();
+	auto a = new (std::nothrow) TintBy();
 	a->initWithDuration(_duration, (GLubyte)_deltaR, (GLubyte)_deltaG, (GLubyte)_deltaB);
 	a->autorelease();
 	return a;
@@ -2081,7 +2081,7 @@ TintBy* TintBy::reverse() const
 //
 DelayTime* DelayTime::create(float d)
 {
-    DelayTime* action = new DelayTime();
+    DelayTime* action = new (std::nothrow) DelayTime();
 
     action->initWithDuration(d);
     action->autorelease();
@@ -2092,7 +2092,7 @@ DelayTime* DelayTime::create(float d)
 DelayTime* DelayTime::clone() const
 {
 	// no copy constructor
-	auto a = new DelayTime();
+	auto a = new (std::nothrow) DelayTime();
     a->initWithDuration(_duration);
 	a->autorelease();
 	return a;
@@ -2116,7 +2116,7 @@ DelayTime* DelayTime::reverse() const
 ReverseTime* ReverseTime::create(FiniteTimeAction *action)
 {
     // casting to prevent warnings
-    ReverseTime *reverseTime = new ReverseTime();
+    ReverseTime *reverseTime = new (std::nothrow) ReverseTime();
     reverseTime->initWithAction( action->clone() );
     reverseTime->autorelease();
 
@@ -2145,7 +2145,7 @@ bool ReverseTime::initWithAction(FiniteTimeAction *action)
 ReverseTime* ReverseTime::clone() const
 {
 	// no copy constructor
-	auto a = new ReverseTime();
+	auto a = new (std::nothrow) ReverseTime();
 	a->initWithAction( _other->clone() );
 	a->autorelease();
 	return a;
@@ -2192,7 +2192,7 @@ ReverseTime* ReverseTime::reverse() const
 //
 Animate* Animate::create(Animation *animation)
 {
-    Animate *animate = new Animate();
+    Animate *animate = new (std::nothrow) Animate();
     animate->initWithAnimation(animation);
     animate->autorelease();
 
@@ -2262,7 +2262,7 @@ void Animate::setAnimation(cocos2d::Animation *animation)
 Animate* Animate::clone() const
 {
 	// no copy constructor
-	auto a = new Animate();
+	auto a = new (std::nothrow) Animate();
 	a->initWithAnimation(_animation->clone());
 	a->autorelease();
 	return a;
@@ -2327,7 +2327,7 @@ void Animate::update(float t)
             if ( !dict.empty() )
             {
                 if (_frameDisplayedEvent == nullptr)
-                    _frameDisplayedEvent = new EventCustom(AnimationFrameDisplayedNotification);
+                    _frameDisplayedEvent = new (std::nothrow) EventCustom(AnimationFrameDisplayedNotification);
                 
                 _frameDisplayedEventInfo.target = _target;
                 _frameDisplayedEventInfo.userInfo = &dict;
@@ -2384,7 +2384,7 @@ TargetedAction::~TargetedAction()
 
 TargetedAction* TargetedAction::create(Node* target, FiniteTimeAction* action)
 {
-    TargetedAction* p = new TargetedAction();
+    TargetedAction* p = new (std::nothrow) TargetedAction();
     p->initWithTarget(target, action);
     p->autorelease();
     return p;
@@ -2407,7 +2407,7 @@ bool TargetedAction::initWithTarget(Node* target, FiniteTimeAction* action)
 TargetedAction* TargetedAction::clone() const
 {
 	// no copy constructor	
-	auto a = new TargetedAction();
+	auto a = new (std::nothrow) TargetedAction();
     // win32 : use the _other's copy object.
 	a->initWithTarget(_forcedTarget, _action->clone());
 	a->autorelease();
@@ -2417,7 +2417,7 @@ TargetedAction* TargetedAction::clone() const
 TargetedAction* TargetedAction::reverse() const
 {
 	// just reverse the internal action
-	auto a = new TargetedAction();
+	auto a = new (std::nothrow) TargetedAction();
 	a->initWithTarget(_forcedTarget, _action->reverse());
 	a->autorelease();
 	return a;

--- a/cocos/2d/CCActionPageTurn3D.cpp
+++ b/cocos/2d/CCActionPageTurn3D.cpp
@@ -29,7 +29,7 @@ NS_CC_BEGIN
 
 PageTurn3D* PageTurn3D::create(float duration, const Size& gridSize)
 {
-    PageTurn3D *action = new PageTurn3D();
+    PageTurn3D *action = new (std::nothrow) PageTurn3D();
 
     if (action)
     {
@@ -49,7 +49,7 @@ PageTurn3D* PageTurn3D::create(float duration, const Size& gridSize)
 PageTurn3D *PageTurn3D::clone() const
 {
 	// no copy constructor	
-	auto a = new PageTurn3D();
+	auto a = new (std::nothrow) PageTurn3D();
 	a->initWithDuration(_duration, _gridSize);
 	a->autorelease();
 	return a;

--- a/cocos/2d/CCActionProgressTimer.cpp
+++ b/cocos/2d/CCActionProgressTimer.cpp
@@ -34,7 +34,7 @@ NS_CC_BEGIN
 
 ProgressTo* ProgressTo::create(float duration, float percent)
 {
-    ProgressTo *progressTo = new ProgressTo();
+    ProgressTo *progressTo = new (std::nothrow) ProgressTo();
     progressTo->initWithDuration(duration, percent);
     progressTo->autorelease();
 
@@ -56,7 +56,7 @@ bool ProgressTo::initWithDuration(float duration, float percent)
 ProgressTo* ProgressTo::clone() const
 {
 	// no copy constructor	
-	auto a = new ProgressTo();
+	auto a = new (std::nothrow) ProgressTo();
     a->initWithDuration(_duration, _to);
 	a->autorelease();
 	return a;
@@ -83,7 +83,7 @@ void ProgressTo::update(float time)
 
 ProgressFromTo* ProgressFromTo::create(float duration, float fromPercentage, float toPercentage)
 {
-    ProgressFromTo *progressFromTo = new ProgressFromTo();
+    ProgressFromTo *progressFromTo = new (std::nothrow) ProgressFromTo();
     progressFromTo->initWithDuration(duration, fromPercentage, toPercentage);
     progressFromTo->autorelease();
 
@@ -106,7 +106,7 @@ bool ProgressFromTo::initWithDuration(float duration, float fromPercentage, floa
 ProgressFromTo* ProgressFromTo::clone() const
 {
 	// no copy constructor	
-	auto a = new ProgressFromTo();
+	auto a = new (std::nothrow) ProgressFromTo();
 	a->initWithDuration(_duration, _from, _to);
 	a->autorelease();
 	return a;

--- a/cocos/2d/CCActionTiledGrid.cpp
+++ b/cocos/2d/CCActionTiledGrid.cpp
@@ -42,7 +42,7 @@ struct Tile
 
 ShakyTiles3D* ShakyTiles3D::create(float duration, const Size& gridSize, int range, bool shakeZ)
 {
-    ShakyTiles3D *action = new ShakyTiles3D();
+    ShakyTiles3D *action = new (std::nothrow) ShakyTiles3D();
 
     if (action)
     {
@@ -75,7 +75,7 @@ bool ShakyTiles3D::initWithDuration(float duration, const Size& gridSize, int ra
 ShakyTiles3D* ShakyTiles3D::clone() const
 {
 	// no copy constructor	
-	auto a = new ShakyTiles3D();
+	auto a = new (std::nothrow) ShakyTiles3D();
     a->initWithDuration(_duration, _gridSize, _randrange, _shakeZ);
 	a->autorelease();
 	return a;
@@ -121,7 +121,7 @@ void ShakyTiles3D::update(float time)
 
 ShatteredTiles3D* ShatteredTiles3D::create(float duration, const Size& gridSize, int range, bool shatterZ)
 {
-    ShatteredTiles3D *action = new ShatteredTiles3D();
+    ShatteredTiles3D *action = new (std::nothrow) ShatteredTiles3D();
 
     if (action)
     {
@@ -155,7 +155,7 @@ bool ShatteredTiles3D::initWithDuration(float duration, const Size& gridSize, in
 ShatteredTiles3D* ShatteredTiles3D::clone() const
 {
 	// no copy constructor	
-	auto a = new ShatteredTiles3D();
+	auto a = new (std::nothrow) ShatteredTiles3D();
 	a->initWithDuration(_duration, _gridSize, _randrange, _shatterZ);
 	a->autorelease();
 	return a;
@@ -206,7 +206,7 @@ void ShatteredTiles3D::update(float time)
 
 ShuffleTiles* ShuffleTiles::create(float duration, const Size& gridSize, unsigned int seed)
 {
-    ShuffleTiles *action = new ShuffleTiles();
+    ShuffleTiles *action = new (std::nothrow) ShuffleTiles();
 
     if (action)
     {
@@ -240,7 +240,7 @@ bool ShuffleTiles::initWithDuration(float duration, const Size& gridSize, unsign
 ShuffleTiles* ShuffleTiles::clone() const
 {
 	// no copy constructor
-	auto a = new ShuffleTiles();
+	auto a = new (std::nothrow) ShuffleTiles();
 	a->initWithDuration(_duration, _gridSize, _seed);
 	a->autorelease();
 	return a;
@@ -352,7 +352,7 @@ void ShuffleTiles::update(float time)
 
 FadeOutTRTiles* FadeOutTRTiles::create(float duration, const Size& gridSize)
 {
-    FadeOutTRTiles *action = new FadeOutTRTiles();
+    FadeOutTRTiles *action = new (std::nothrow) FadeOutTRTiles();
 
     if (action)
     {
@@ -372,7 +372,7 @@ FadeOutTRTiles* FadeOutTRTiles::create(float duration, const Size& gridSize)
 FadeOutTRTiles* FadeOutTRTiles::clone() const
 {
 	// no copy constructor
-	auto a = new FadeOutTRTiles();
+	auto a = new (std::nothrow) FadeOutTRTiles();
 	a->initWithDuration(_duration, _gridSize);
 	a->autorelease();
 	return a;
@@ -448,7 +448,7 @@ void FadeOutTRTiles::update(float time)
 
 FadeOutBLTiles* FadeOutBLTiles::create(float duration, const Size& gridSize)
 {
-    FadeOutBLTiles *action = new FadeOutBLTiles();
+    FadeOutBLTiles *action = new (std::nothrow) FadeOutBLTiles();
 
     if (action)
     {
@@ -468,7 +468,7 @@ FadeOutBLTiles* FadeOutBLTiles::create(float duration, const Size& gridSize)
 FadeOutBLTiles* FadeOutBLTiles::clone() const
 {
 	// no copy constructor
-	auto a = new FadeOutBLTiles();
+	auto a = new (std::nothrow) FadeOutBLTiles();
 	a->initWithDuration(_duration, _gridSize);
 	a->autorelease();
 	return a;
@@ -489,7 +489,7 @@ float FadeOutBLTiles::testFunc(const Size& pos, float time)
 
 FadeOutUpTiles* FadeOutUpTiles::create(float duration, const Size& gridSize)
 {
-    FadeOutUpTiles *action = new FadeOutUpTiles();
+    FadeOutUpTiles *action = new (std::nothrow) FadeOutUpTiles();
 
     if (action)
     {
@@ -509,7 +509,7 @@ FadeOutUpTiles* FadeOutUpTiles::create(float duration, const Size& gridSize)
 FadeOutUpTiles* FadeOutUpTiles::clone() const
 {
 	// no copy constructor
-	auto a = new FadeOutUpTiles();
+	auto a = new (std::nothrow) FadeOutUpTiles();
 	a->initWithDuration(_duration, _gridSize);
 	a->autorelease();
 	return a;
@@ -543,7 +543,7 @@ void FadeOutUpTiles::transformTile(const Vec2& pos, float distance)
 
 FadeOutDownTiles* FadeOutDownTiles::create(float duration, const Size& gridSize)
 {
-    FadeOutDownTiles *action = new FadeOutDownTiles();
+    FadeOutDownTiles *action = new (std::nothrow) FadeOutDownTiles();
 
     if (action)
     {
@@ -563,7 +563,7 @@ FadeOutDownTiles* FadeOutDownTiles::create(float duration, const Size& gridSize)
 FadeOutDownTiles* FadeOutDownTiles::clone() const
 {
 	// no copy constructor
-	auto a = new FadeOutDownTiles();
+	auto a = new (std::nothrow) FadeOutDownTiles();
 	a->initWithDuration(_duration, _gridSize);
 	a->autorelease();
 	return a;
@@ -584,7 +584,7 @@ float FadeOutDownTiles::testFunc(const Size& pos, float time)
 
 TurnOffTiles* TurnOffTiles::create(float duration, const Size& gridSize)
 {
-    TurnOffTiles* pAction = new TurnOffTiles();
+    TurnOffTiles* pAction = new (std::nothrow) TurnOffTiles();
     if (pAction->initWithDuration(duration, gridSize, 0))
     {
         pAction->autorelease();
@@ -598,7 +598,7 @@ TurnOffTiles* TurnOffTiles::create(float duration, const Size& gridSize)
 
 TurnOffTiles* TurnOffTiles::create(float duration, const Size& gridSize, unsigned int seed)
 {
-    TurnOffTiles *action = new TurnOffTiles();
+    TurnOffTiles *action = new (std::nothrow) TurnOffTiles();
 
     if (action)
     {
@@ -631,7 +631,7 @@ bool TurnOffTiles::initWithDuration(float duration, const Size& gridSize, unsign
 TurnOffTiles* TurnOffTiles::clone() const
 {
 	// no copy constructor
-	auto a = new TurnOffTiles();
+	auto a = new (std::nothrow) TurnOffTiles();
     a->initWithDuration(_duration, _gridSize, _seed );
 	a->autorelease();
 	return a;
@@ -711,7 +711,7 @@ void TurnOffTiles::update(float time)
 
 WavesTiles3D* WavesTiles3D::create(float duration, const Size& gridSize, unsigned int waves, float amplitude)
 {
-    WavesTiles3D *action = new WavesTiles3D();
+    WavesTiles3D *action = new (std::nothrow) WavesTiles3D();
 
     if (action)
     {
@@ -745,7 +745,7 @@ bool WavesTiles3D::initWithDuration(float duration, const Size& gridSize, unsign
 WavesTiles3D* WavesTiles3D::clone() const
 {
 	// no copy constructor
-	auto a = new WavesTiles3D();
+	auto a = new (std::nothrow) WavesTiles3D();
     a->initWithDuration(_duration, _gridSize, _waves, _amplitude);
 	a->autorelease();
 	return a;
@@ -774,7 +774,7 @@ void WavesTiles3D::update(float time)
 
 JumpTiles3D* JumpTiles3D::create(float duration, const Size& gridSize, unsigned int numberOfJumps, float amplitude)
 {
-    JumpTiles3D *action = new JumpTiles3D();
+    JumpTiles3D *action = new (std::nothrow) JumpTiles3D();
 
     if (action)
     {
@@ -808,7 +808,7 @@ bool JumpTiles3D::initWithDuration(float duration, const Size& gridSize, unsigne
 JumpTiles3D* JumpTiles3D::clone() const
 {
 	// no copy constructor
-	auto a = new JumpTiles3D();
+	auto a = new (std::nothrow) JumpTiles3D();
     a->initWithDuration(_duration, _gridSize, _jumps, _amplitude);
 	a->autorelease();
 	return a;
@@ -849,7 +849,7 @@ void JumpTiles3D::update(float time)
 
 SplitRows* SplitRows::create(float duration, unsigned int nRows)
 {
-    SplitRows *action = new SplitRows();
+    SplitRows *action = new (std::nothrow) SplitRows();
 
     if (action)
     {
@@ -876,7 +876,7 @@ bool SplitRows::initWithDuration(float duration, unsigned int rows)
 SplitRows* SplitRows::clone() const
 {
 	// no copy constructor
-	auto a = new SplitRows();
+	auto a = new (std::nothrow) SplitRows();
     a->initWithDuration(_duration, _rows);
 	a->autorelease();
 	return a;
@@ -913,7 +913,7 @@ void SplitRows::update(float time)
 
 SplitCols* SplitCols::create(float duration, unsigned int cols)
 {
-    SplitCols *action = new SplitCols();
+    SplitCols *action = new (std::nothrow) SplitCols();
 
     if (action)
     {
@@ -939,7 +939,7 @@ bool SplitCols::initWithDuration(float duration, unsigned int cols)
 SplitCols* SplitCols::clone() const
 {
 	// no copy constructor	
-	auto a = new SplitCols();
+	auto a = new (std::nothrow) SplitCols();
     a->initWithDuration(_duration, _cols);
 	a->autorelease();
 	return a;

--- a/cocos/2d/CCActionTween.cpp
+++ b/cocos/2d/CCActionTween.cpp
@@ -30,7 +30,7 @@ NS_CC_BEGIN
 
 ActionTween* ActionTween::create(float duration, const std::string& key, float from, float to)
 {
-    ActionTween* ret = new ActionTween();
+    ActionTween* ret = new (std::nothrow) ActionTween();
     if (ret && ret->initWithDuration(duration, key, from, to))
     {
         ret->autorelease();
@@ -58,7 +58,7 @@ bool ActionTween::initWithDuration(float duration, const std::string& key, float
 ActionTween *ActionTween::clone() const
 {
 	// no copy constructor	
-	auto a = new ActionTween();
+	auto a = new (std::nothrow) ActionTween();
 	a->initWithDuration(_duration, _key.c_str(), _from, _to);
 	a->autorelease();
 	return a;

--- a/cocos/2d/CCAnimation.cpp
+++ b/cocos/2d/CCAnimation.cpp
@@ -35,7 +35,7 @@ NS_CC_BEGIN
 
 AnimationFrame* AnimationFrame::create(SpriteFrame* spriteFrame, float delayUnits, const ValueMap& userInfo)
 {
-    auto ret = new AnimationFrame();
+    auto ret = new (std::nothrow) AnimationFrame();
     if (ret && ret->initWithSpriteFrame(spriteFrame, delayUnits, userInfo))
     {
         ret->autorelease();
@@ -73,7 +73,7 @@ AnimationFrame::~AnimationFrame()
 AnimationFrame* AnimationFrame::clone() const
 {
 	// no copy constructor
-	auto frame = new AnimationFrame();
+	auto frame = new (std::nothrow) AnimationFrame();
     frame->initWithSpriteFrame(_spriteFrame->clone(),
 							   _delayUnits,
 							   _userInfo);
@@ -86,7 +86,7 @@ AnimationFrame* AnimationFrame::clone() const
 
 Animation* Animation::create(void)
 {
-    Animation *animation = new Animation();
+    Animation *animation = new (std::nothrow) Animation();
     animation->init();
     animation->autorelease();
 
@@ -95,7 +95,7 @@ Animation* Animation::create(void)
 
 Animation* Animation::createWithSpriteFrames(const Vector<SpriteFrame*>& frames, float delay/* = 0.0f*/, unsigned int loops/* = 1*/)
 {
-    Animation *animation = new Animation();
+    Animation *animation = new (std::nothrow) Animation();
     animation->initWithSpriteFrames(frames, delay, loops);
     animation->autorelease();
 
@@ -104,7 +104,7 @@ Animation* Animation::createWithSpriteFrames(const Vector<SpriteFrame*>& frames,
 
 Animation* Animation::create(const Vector<AnimationFrame*>& arrayOfAnimationFrameNames, float delayPerUnit, unsigned int loops /* = 1 */)
 {
-    Animation *animation = new Animation();
+    Animation *animation = new (std::nothrow) Animation();
     animation->initWithAnimationFrames(arrayOfAnimationFrameNames, delayPerUnit, loops);
     animation->autorelease();
     return animation;
@@ -194,7 +194,7 @@ float Animation::getDuration(void) const
 Animation* Animation::clone() const
 {
 	// no copy constructor	
-	auto a = new Animation();
+	auto a = new (std::nothrow) Animation();
     a->initWithAnimationFrames(_frames, _delayPerUnit, _loops);
     a->setRestoreOriginalFrame(_restoreOriginalFrame);
 	a->autorelease();

--- a/cocos/2d/CCAnimationCache.cpp
+++ b/cocos/2d/CCAnimationCache.cpp
@@ -42,7 +42,7 @@ AnimationCache* AnimationCache::getInstance()
 {
     if (! s_sharedAnimationCache)
     {
-        s_sharedAnimationCache = new AnimationCache();
+        s_sharedAnimationCache = new (std::nothrow) AnimationCache();
         s_sharedAnimationCache->init();
     }
 

--- a/cocos/2d/CCAtlasNode.cpp
+++ b/cocos/2d/CCAtlasNode.cpp
@@ -59,7 +59,7 @@ AtlasNode::~AtlasNode()
 
 AtlasNode * AtlasNode::create(const std::string& tile, int tileWidth, int tileHeight, int itemsToRender)
 {
-	AtlasNode * ret = new AtlasNode();
+	AtlasNode * ret = new (std::nothrow) AtlasNode();
 	if (ret->initWithTileFile(tile, tileWidth, tileHeight, itemsToRender))
 	{
 		ret->autorelease();
@@ -86,7 +86,7 @@ bool AtlasNode::initWithTexture(Texture2D* texture, int tileWidth, int tileHeigh
 
     _blendFunc = BlendFunc::ALPHA_PREMULTIPLIED;
 
-    _textureAtlas = new TextureAtlas();
+    _textureAtlas = new (std::nothrow) TextureAtlas();
     _textureAtlas->initWithTexture(texture, itemsToRender);
 
     if (! _textureAtlas)

--- a/cocos/2d/CCClippingNode.cpp
+++ b/cocos/2d/CCClippingNode.cpp
@@ -84,7 +84,7 @@ ClippingNode::~ClippingNode()
 
 ClippingNode* ClippingNode::create()
 {
-    ClippingNode *ret = new ClippingNode();
+    ClippingNode *ret = new (std::nothrow) ClippingNode();
     if (ret && ret->init())
     {
         ret->autorelease();
@@ -99,7 +99,7 @@ ClippingNode* ClippingNode::create()
 
 ClippingNode* ClippingNode::create(Node *pStencil)
 {
-    ClippingNode *ret = new ClippingNode();
+    ClippingNode *ret = new (std::nothrow) ClippingNode();
     if (ret && ret->init(pStencil))
     {
         ret->autorelease();

--- a/cocos/2d/CCComponent.cpp
+++ b/cocos/2d/CCComponent.cpp
@@ -110,7 +110,7 @@ bool Component::serialize(void *ar)
 
 Component* Component::create(void)
 {
-    Component * ret = new Component();
+    Component * ret = new (std::nothrow) Component();
     if (ret != nullptr && ret->init())
     {
         ret->autorelease();

--- a/cocos/2d/CCComponentContainer.cpp
+++ b/cocos/2d/CCComponentContainer.cpp
@@ -60,7 +60,7 @@ bool ComponentContainer::add(Component *com)
     {
         if (_components == nullptr)
         {
-            _components = new Map<std::string, Component*>();
+            _components = new (std::nothrow) Map<std::string, Component*>();
         }
         Component *component = _components->at(com->getName());
         
@@ -135,7 +135,7 @@ void ComponentContainer::removeAll()
 
 void ComponentContainer::alloc(void)
 {
-    _components = new Map<std::string, Component*>();
+    _components = new (std::nothrow) Map<std::string, Component*>();
 }
 
 void ComponentContainer::visit(float delta)

--- a/cocos/2d/CCDrawNode.cpp
+++ b/cocos/2d/CCDrawNode.cpp
@@ -129,7 +129,7 @@ DrawNode::~DrawNode()
 
 DrawNode* DrawNode::create()
 {
-    DrawNode* ret = new DrawNode();
+    DrawNode* ret = new (std::nothrow) DrawNode();
     if (ret && ret->init())
     {
         ret->autorelease();

--- a/cocos/2d/CCDrawingPrimitives.cpp
+++ b/cocos/2d/CCDrawingPrimitives.cpp
@@ -158,7 +158,7 @@ void drawPoints( const Vec2 *points, unsigned int numberOfPoints )
     s_shader->setUniformLocationWith1f(s_pointSizeLocation, s_pointSize);
 
     // XXX: Mac OpenGL error. arrays can't go out of scope before draw is executed
-    Vec2* newPoints = new Vec2[numberOfPoints];
+    Vec2* newPoints = new (std::nothrow) Vec2[numberOfPoints];
 
     // iPhone and 32-bit machines optimization
     if( sizeof(Vec2) == sizeof(Vec2) )
@@ -269,7 +269,7 @@ void drawPoly(const Vec2 *poli, unsigned int numberOfPoints, bool closePolygon)
     {
         // Mac on 64-bit
         // XXX: Mac OpenGL error. arrays can't go out of scope before draw is executed
-        Vec2* newPoli = new Vec2[numberOfPoints];
+        Vec2* newPoli = new (std::nothrow) Vec2[numberOfPoints];
         for( unsigned int i=0; i<numberOfPoints;i++) {
             newPoli[i].x = poli[i].x;
             newPoli[i].y = poli[i].y;
@@ -303,7 +303,7 @@ void drawSolidPoly(const Vec2 *poli, unsigned int numberOfPoints, Color4F color)
     GL::enableVertexAttribs( GL::VERTEX_ATTRIB_FLAG_POSITION );
 
     // XXX: Mac OpenGL error. arrays can't go out of scope before draw is executed
-    Vec2* newPoli = new Vec2[numberOfPoints];
+    Vec2* newPoli = new (std::nothrow) Vec2[numberOfPoints];
 
     // iPhone and 32-bit machines optimization
     if (sizeof(Vec2) == sizeof(Vec2))
@@ -435,7 +435,7 @@ void drawQuadBezier(const Vec2& origin, const Vec2& control, const Vec2& destina
 {
     lazy_init();
 
-    Vec2* vertices = new Vec2[segments + 1];
+    Vec2* vertices = new (std::nothrow) Vec2[segments + 1];
 
     float t = 0.0f;
     for(unsigned int i = 0; i < segments; i++)
@@ -474,7 +474,7 @@ void drawCardinalSpline( PointArray *config, float tension,  unsigned int segmen
 {
     lazy_init();
 
-    Vec2* vertices = new Vec2[segments + 1];
+    Vec2* vertices = new (std::nothrow) Vec2[segments + 1];
 
     ssize_t p;
     float lt;
@@ -526,7 +526,7 @@ void drawCubicBezier(const Vec2& origin, const Vec2& control1, const Vec2& contr
 {
     lazy_init();
 
-    Vec2* vertices = new Vec2[segments + 1];
+    Vec2* vertices = new (std::nothrow) Vec2[segments + 1];
 
     float t = 0;
     for (unsigned int i = 0; i < segments; i++)

--- a/cocos/2d/CCFastTMXLayer.cpp
+++ b/cocos/2d/CCFastTMXLayer.cpp
@@ -59,7 +59,7 @@ const int TMXLayer::FAST_TMX_ORIENTATION_ISO = 2;
 // FastTMXLayer - init & alloc & dealloc
 TMXLayer * TMXLayer::create(TMXTilesetInfo *tilesetInfo, TMXLayerInfo *layerInfo, TMXMapInfo *mapInfo)
 {
-    TMXLayer *ret = new TMXLayer();
+    TMXLayer *ret = new (std::nothrow) TMXLayer();
     if (ret->initWithTilesetInfo(tilesetInfo, layerInfo, mapInfo))
     {
         ret->autorelease();

--- a/cocos/2d/CCFastTMXTiledMap.cpp
+++ b/cocos/2d/CCFastTMXTiledMap.cpp
@@ -40,7 +40,7 @@ namespace experimental {
 
 TMXTiledMap * TMXTiledMap::create(const std::string& tmxFile)
 {
-    TMXTiledMap *ret = new TMXTiledMap();
+    TMXTiledMap *ret = new (std::nothrow) TMXTiledMap();
     if (ret->initWithTMXFile(tmxFile))
     {
         ret->autorelease();
@@ -52,7 +52,7 @@ TMXTiledMap * TMXTiledMap::create(const std::string& tmxFile)
 
 TMXTiledMap* TMXTiledMap::createWithXML(const std::string& tmxString, const std::string& resourcePath)
 {
-    TMXTiledMap *ret = new TMXTiledMap();
+    TMXTiledMap *ret = new (std::nothrow) TMXTiledMap();
     if (ret->initWithXML(tmxString, resourcePath))
     {
         ret->autorelease();

--- a/cocos/2d/CCFontAtlas.cpp
+++ b/cocos/2d/CCFontAtlas.cpp
@@ -53,7 +53,7 @@ FontAtlas::FontAtlas(Font &theFont)
     {
         _commonLineHeight = _font->getFontMaxHeight();
         _fontAscender = fontTTf->getFontAscender();
-        auto texture = new Texture2D;
+        auto texture = new (std::nothrow) Texture2D;
         _currentPage = 0;
         _currentPageOrigX = 0;
         _currentPageOrigY = 0;
@@ -256,7 +256,7 @@ bool FontAtlas::prepareLetterDefinitions(const std::u16string& utf16String)
                         _currentPageOrigY = 0;
                         memset(_currentPageData, 0, _currentPageDataSize);
                         _currentPage++;
-                        auto tex = new Texture2D;
+                        auto tex = new (std::nothrow) Texture2D;
                         if (_antialiasEnabled)
                         {
                             tex->setAntiAliasTexParameters();

--- a/cocos/2d/CCFontCharMap.cpp
+++ b/cocos/2d/CCFontCharMap.cpp
@@ -119,7 +119,7 @@ int * FontCharMap::getHorizontalKerningForTextUTF16(const std::u16string& text, 
 
 FontAtlas * FontCharMap::createFontAtlas()
 {
-    FontAtlas *tempAtlas = new FontAtlas(*this);
+    FontAtlas *tempAtlas = new (std::nothrow) FontAtlas(*this);
     if (!tempAtlas)
         return nullptr;
     

--- a/cocos/2d/CCFontFNT.cpp
+++ b/cocos/2d/CCFontFNT.cpp
@@ -167,7 +167,7 @@ BMFontConfiguration* FNTConfigLoadFile(const std::string& fntFile)
 
     if( s_configurations == nullptr )
     {
-        s_configurations = new Map<std::string, BMFontConfiguration*>();
+        s_configurations = new (std::nothrow) Map<std::string, BMFontConfiguration*>();
     }
 
     ret = s_configurations->at(fntFile);
@@ -189,7 +189,7 @@ BMFontConfiguration* FNTConfigLoadFile(const std::string& fntFile)
 
 BMFontConfiguration * BMFontConfiguration::create(const std::string& FNTfile)
 {
-    BMFontConfiguration * ret = new BMFontConfiguration();
+    BMFontConfiguration * ret = new (std::nothrow) BMFontConfiguration();
     if (ret->initWithFNTfile(FNTfile))
     {
         ret->autorelease();
@@ -752,7 +752,7 @@ int  FontFNT::getHorizontalKerningForChars(unsigned short firstChar, unsigned sh
 
 FontAtlas * FontFNT::createFontAtlas()
 {
-    FontAtlas *tempAtlas = new FontAtlas(*this);
+    FontAtlas *tempAtlas = new (std::nothrow) FontAtlas(*this);
     if (!tempAtlas)
         return nullptr;
     

--- a/cocos/2d/CCFontFreeType.cpp
+++ b/cocos/2d/CCFontFreeType.cpp
@@ -172,7 +172,7 @@ FontFreeType::~FontFreeType()
 
 FontAtlas * FontFreeType::createFontAtlas()
 {
-    FontAtlas *atlas = new FontAtlas(*this);
+    FontAtlas *atlas = new (std::nothrow) FontAtlas(*this);
     if (_usedGlyphs != GlyphCollection::DYNAMIC)
     {
         std::u16string utf16;

--- a/cocos/2d/CCGrid.cpp
+++ b/cocos/2d/CCGrid.cpp
@@ -41,7 +41,7 @@ NS_CC_BEGIN
 
 GridBase* GridBase::create(const Size& gridSize)
 {
-    GridBase *pGridBase = new GridBase();
+    GridBase *pGridBase = new (std::nothrow) GridBase();
 
     if (pGridBase)
     {
@@ -60,7 +60,7 @@ GridBase* GridBase::create(const Size& gridSize)
 
 GridBase* GridBase::create(const Size& gridSize, Texture2D *texture, bool flipped)
 {
-    GridBase *pGridBase = new GridBase();
+    GridBase *pGridBase = new (std::nothrow) GridBase();
 
     if (pGridBase)
     {
@@ -93,7 +93,7 @@ bool GridBase::initWithSize(const Size& gridSize, Texture2D *texture, bool flipp
     _step.x = texSize.width / _gridSize.width;
     _step.y = texSize.height / _gridSize.height;
 
-    _grabber = new Grabber();
+    _grabber = new (std::nothrow) Grabber();
     if (_grabber)
     {
         _grabber->grab(_texture);
@@ -129,7 +129,7 @@ bool GridBase::initWithSize(const Size& gridSize)
         return false;
     }
 
-    Texture2D *texture = new Texture2D();
+    Texture2D *texture = new (std::nothrow) Texture2D();
     texture->initWithData(data, dataLen,  format, POTWide, POTHigh, s);
 
     free(data);
@@ -254,7 +254,7 @@ void GridBase::calculateVertexPoints(void)
 
 Grid3D* Grid3D::create(const Size& gridSize, Texture2D *texture, bool flipped)
 {
-    Grid3D *ret= new Grid3D();
+    Grid3D *ret= new (std::nothrow) Grid3D();
 
     if (ret)
     {
@@ -274,7 +274,7 @@ Grid3D* Grid3D::create(const Size& gridSize, Texture2D *texture, bool flipped)
 
 Grid3D* Grid3D::create(const Size& gridSize)
 {
-    Grid3D *ret= new Grid3D();
+    Grid3D *ret= new (std::nothrow) Grid3D();
 
     if (ret)
     {
@@ -471,7 +471,7 @@ TiledGrid3D::~TiledGrid3D(void)
 
 TiledGrid3D* TiledGrid3D::create(const Size& gridSize, Texture2D *texture, bool flipped)
 {
-    TiledGrid3D *ret= new TiledGrid3D();
+    TiledGrid3D *ret= new (std::nothrow) TiledGrid3D();
 
     if (ret)
     {
@@ -491,7 +491,7 @@ TiledGrid3D* TiledGrid3D::create(const Size& gridSize, Texture2D *texture, bool 
 
 TiledGrid3D* TiledGrid3D::create(const Size& gridSize)
 {
-    TiledGrid3D *ret= new TiledGrid3D();
+    TiledGrid3D *ret= new (std::nothrow) TiledGrid3D();
 
     if (ret)
     {

--- a/cocos/2d/CCLabel.cpp
+++ b/cocos/2d/CCLabel.cpp
@@ -45,7 +45,7 @@ const int Label::DistanceFieldFontSize = 50;
 
 Label* Label::create()
 {
-    auto ret = new Label();
+    auto ret = new (std::nothrow) Label();
 
     if (ret)
     {
@@ -69,7 +69,7 @@ Label* Label::create(const std::string& text, const std::string& font, float fon
 
 Label* Label::createWithSystemFont(const std::string& text, const std::string& font, float fontSize, const Size& dimensions /* = Size::ZERO */, TextHAlignment hAlignment /* = TextHAlignment::LEFT */, TextVAlignment vAlignment /* = TextVAlignment::TOP */)
 {
-    auto ret = new Label(nullptr,hAlignment,vAlignment);
+    auto ret = new (std::nothrow) Label(nullptr,hAlignment,vAlignment);
 
     if (ret)
     {
@@ -89,7 +89,7 @@ Label* Label::createWithSystemFont(const std::string& text, const std::string& f
 
 Label* Label::createWithTTF(const std::string& text, const std::string& fontFile, float fontSize, const Size& dimensions /* = Size::ZERO */, TextHAlignment hAlignment /* = TextHAlignment::LEFT */, TextVAlignment vAlignment /* = TextVAlignment::TOP */)
 {
-    auto ret = new Label(nullptr,hAlignment,vAlignment);
+    auto ret = new (std::nothrow) Label(nullptr,hAlignment,vAlignment);
 
     if (ret && FileUtils::getInstance()->isFileExist(fontFile))
     {
@@ -111,7 +111,7 @@ Label* Label::createWithTTF(const std::string& text, const std::string& fontFile
 
 Label* Label::createWithTTF(const TTFConfig& ttfConfig, const std::string& text, TextHAlignment alignment /* = TextHAlignment::CENTER */, int maxLineWidth /* = 0 */)
 {
-    auto ret = new Label(nullptr,alignment);
+    auto ret = new (std::nothrow) Label(nullptr,alignment);
 
     if (ret && FileUtils::getInstance()->isFileExist(ttfConfig.fontFilePath) && ret->setTTFConfig(ttfConfig))
     {
@@ -128,7 +128,7 @@ Label* Label::createWithTTF(const TTFConfig& ttfConfig, const std::string& text,
 
 Label* Label::createWithBMFont(const std::string& bmfontFilePath, const std::string& text,const TextHAlignment& alignment /* = TextHAlignment::LEFT */, int maxLineWidth /* = 0 */, const Vec2& imageOffset /* = Vec2::ZERO */)
 {
-    auto ret = new Label(nullptr,alignment);
+    auto ret = new (std::nothrow) Label(nullptr,alignment);
 
     if (ret && ret->setBMFontFilePath(bmfontFilePath,imageOffset))
     {
@@ -145,7 +145,7 @@ Label* Label::createWithBMFont(const std::string& bmfontFilePath, const std::str
 
 Label* Label::createWithCharMap(const std::string& plistFile)
 {
-    auto ret = new Label();
+    auto ret = new (std::nothrow) Label();
 
     if (ret && ret->setCharMap(plistFile))
     {
@@ -159,7 +159,7 @@ Label* Label::createWithCharMap(const std::string& plistFile)
 
 Label* Label::createWithCharMap(Texture2D* texture, int itemWidth, int itemHeight, int startCharMap)
 {
-    auto ret = new Label();
+    auto ret = new (std::nothrow) Label();
 
     if (ret && ret->setCharMap(texture,itemWidth,itemHeight,startCharMap))
     {
@@ -173,7 +173,7 @@ Label* Label::createWithCharMap(Texture2D* texture, int itemWidth, int itemHeigh
 
 Label* Label::createWithCharMap(const std::string& charMapFile, int itemWidth, int itemHeight, int startCharMap)
 {
-    auto ret = new Label();
+    auto ret = new (std::nothrow) Label();
 
     if (ret && ret->setCharMap(charMapFile,itemWidth,itemHeight,startCharMap))
     {
@@ -892,7 +892,7 @@ void Label::createSpriteWithFontDefinition()
 {
     _currentLabelType = LabelType::STRING_TEXTURE;
 
-    auto texture = new Texture2D;
+    auto texture = new (std::nothrow) Texture2D;
     texture->initWithString(_originalUTF8String.c_str(),_fontDefinition);
 
     _textSprite = Sprite::createWithTexture(texture);

--- a/cocos/2d/CCLabelAtlas.cpp
+++ b/cocos/2d/CCLabelAtlas.cpp
@@ -43,7 +43,7 @@ NS_CC_BEGIN
 
 LabelAtlas* LabelAtlas::create()
 {
-    LabelAtlas* ret = new LabelAtlas();
+    LabelAtlas* ret = new (std::nothrow) LabelAtlas();
     if (ret)
     {
         ret->autorelease();
@@ -58,7 +58,7 @@ LabelAtlas* LabelAtlas::create()
 
 LabelAtlas* LabelAtlas::create(const std::string& string, const std::string& charMapFile, int itemWidth, int itemHeight, int startCharMap)
 {
-    LabelAtlas* ret = new LabelAtlas();
+    LabelAtlas* ret = new (std::nothrow) LabelAtlas();
     if(ret && ret->initWithString(string, charMapFile, itemWidth, itemHeight, startCharMap))
     {
         ret->autorelease();
@@ -87,7 +87,7 @@ bool LabelAtlas::initWithString(const std::string& string, Texture2D* texture, i
 
 LabelAtlas* LabelAtlas::create(const std::string& string, const std::string& fntFile)
 {    
-    LabelAtlas *ret = new LabelAtlas();
+    LabelAtlas *ret = new (std::nothrow) LabelAtlas();
     if (ret)
     {
         if (ret->initWithString(string, fntFile))

--- a/cocos/2d/CCLabelBMFont.cpp
+++ b/cocos/2d/CCLabelBMFont.cpp
@@ -53,7 +53,7 @@ NS_CC_BEGIN
 
 LabelBMFont * LabelBMFont::create()
 {
-    LabelBMFont * pRet = new LabelBMFont();
+    LabelBMFont * pRet = new (std::nothrow) LabelBMFont();
     if (pRet)
     {
         pRet->autorelease();
@@ -66,7 +66,7 @@ LabelBMFont * LabelBMFont::create()
 //LabelBMFont - Creation & Init
 LabelBMFont *LabelBMFont::create(const std::string& str, const std::string& fntFile, float width /* = 0 */, TextHAlignment alignment /* = TextHAlignment::LEFT */,const Vec2& imageOffset /* = Vec2::ZERO */)
 {
-    LabelBMFont *ret = new LabelBMFont();
+    LabelBMFont *ret = new (std::nothrow) LabelBMFont();
     if(ret && ret->initWithString(str, fntFile, width, alignment,imageOffset))
     {
         ret->autorelease();

--- a/cocos/2d/CCLabelTTF.cpp
+++ b/cocos/2d/CCLabelTTF.cpp
@@ -54,7 +54,7 @@ LabelTTF::~LabelTTF()
 
 LabelTTF * LabelTTF::create()
 {
-    LabelTTF * ret = new LabelTTF();
+    LabelTTF * ret = new (std::nothrow) LabelTTF();
     if (ret)
     {
         ret->autorelease();
@@ -70,7 +70,7 @@ LabelTTF* LabelTTF::create(const std::string& string, const std::string& fontNam
                                const Size &dimensions, TextHAlignment hAlignment, 
                                TextVAlignment vAlignment)
 {
-    LabelTTF *ret = new LabelTTF();
+    LabelTTF *ret = new (std::nothrow) LabelTTF();
     if(ret && ret->initWithString(string, fontName, fontSize, dimensions, hAlignment, vAlignment))
     {
         ret->autorelease();
@@ -82,7 +82,7 @@ LabelTTF* LabelTTF::create(const std::string& string, const std::string& fontNam
 
 LabelTTF * LabelTTF::createWithFontDefinition(const std::string& string, FontDefinition &textDefinition)
 {
-    LabelTTF *ret = new LabelTTF();
+    LabelTTF *ret = new (std::nothrow) LabelTTF();
     if(ret && ret->initWithStringAndTextDefinition(string, textDefinition))
     {
         ret->autorelease();

--- a/cocos/2d/CCLayer.cpp
+++ b/cocos/2d/CCLayer.cpp
@@ -78,7 +78,7 @@ bool Layer::init()
 
 Layer *Layer::create()
 {
-    Layer *ret = new Layer();
+    Layer *ret = new (std::nothrow) Layer();
     if (ret && ret->init())
     {
         ret->autorelease();
@@ -459,7 +459,7 @@ void LayerColor::setBlendFunc(const BlendFunc &var)
 
 LayerColor* LayerColor::create()
 {
-    LayerColor* ret = new LayerColor();
+    LayerColor* ret = new (std::nothrow) LayerColor();
     if (ret && ret->init())
     {
         ret->autorelease();
@@ -473,7 +473,7 @@ LayerColor* LayerColor::create()
 
 LayerColor * LayerColor::create(const Color4B& color, GLfloat width, GLfloat height)
 {
-    LayerColor * layer = new LayerColor();
+    LayerColor * layer = new (std::nothrow) LayerColor();
     if( layer && layer->initWithColor(color,width,height))
     {
         layer->autorelease();
@@ -485,7 +485,7 @@ LayerColor * LayerColor::create(const Color4B& color, GLfloat width, GLfloat hei
 
 LayerColor * LayerColor::create(const Color4B& color)
 {
-    LayerColor * layer = new LayerColor();
+    LayerColor * layer = new (std::nothrow) LayerColor();
     if(layer && layer->initWithColor(color))
     {
         layer->autorelease();
@@ -641,7 +641,7 @@ LayerGradient::~LayerGradient()
 
 LayerGradient* LayerGradient::create(const Color4B& start, const Color4B& end)
 {
-    LayerGradient * layer = new LayerGradient();
+    LayerGradient * layer = new (std::nothrow) LayerGradient();
     if( layer && layer->initWithColor(start, end))
     {
         layer->autorelease();
@@ -653,7 +653,7 @@ LayerGradient* LayerGradient::create(const Color4B& start, const Color4B& end)
 
 LayerGradient* LayerGradient::create(const Color4B& start, const Color4B& end, const Vec2& v)
 {
-    LayerGradient * layer = new LayerGradient();
+    LayerGradient * layer = new (std::nothrow) LayerGradient();
     if( layer && layer->initWithColor(start, end, v))
     {
         layer->autorelease();
@@ -665,7 +665,7 @@ LayerGradient* LayerGradient::create(const Color4B& start, const Color4B& end, c
 
 LayerGradient* LayerGradient::create()
 {
-    LayerGradient* ret = new LayerGradient();
+    LayerGradient* ret = new (std::nothrow) LayerGradient();
     if (ret && ret->init())
     {
         ret->autorelease();
@@ -848,7 +848,7 @@ LayerMultiplex * LayerMultiplex::createVariadic(Layer * layer, ...)
     va_list args;
     va_start(args,layer);
 
-    LayerMultiplex * multiplexLayer = new LayerMultiplex();
+    LayerMultiplex * multiplexLayer = new (std::nothrow) LayerMultiplex();
     if(multiplexLayer && multiplexLayer->initWithLayers(layer, args))
     {
         multiplexLayer->autorelease();
@@ -865,7 +865,7 @@ LayerMultiplex * LayerMultiplex::create(Layer * layer, ...)
     va_list args;
     va_start(args,layer);
 
-    LayerMultiplex * multiplexLayer = new LayerMultiplex();
+    LayerMultiplex * multiplexLayer = new (std::nothrow) LayerMultiplex();
     if(multiplexLayer && multiplexLayer->initWithLayers(layer, args))
     {
         multiplexLayer->autorelease();
@@ -885,7 +885,7 @@ LayerMultiplex * LayerMultiplex::createWithLayer(Layer* layer)
 
 LayerMultiplex* LayerMultiplex::create()
 {
-    LayerMultiplex* ret = new LayerMultiplex();
+    LayerMultiplex* ret = new (std::nothrow) LayerMultiplex();
     if (ret && ret->init())
     {
         ret->autorelease();
@@ -899,7 +899,7 @@ LayerMultiplex* LayerMultiplex::create()
 
 LayerMultiplex* LayerMultiplex::createWithArray(const Vector<Layer*>& arrayOfLayers)
 {
-    LayerMultiplex* ret = new LayerMultiplex();
+    LayerMultiplex* ret = new (std::nothrow) LayerMultiplex();
     if (ret && ret->initWithArray(arrayOfLayers))
     {
         ret->autorelease();

--- a/cocos/2d/CCMenu.cpp
+++ b/cocos/2d/CCMenu.cpp
@@ -89,7 +89,7 @@ Menu * Menu::create(MenuItem* item, ...)
 
 Menu* Menu::createWithArray(const Vector<MenuItem*>& arrayOfItems)
 {
-    auto ret = new Menu();
+    auto ret = new (std::nothrow) Menu();
     if (ret && ret->initWithArray(arrayOfItems))
     {
         ret->autorelease();

--- a/cocos/2d/CCMenuItem.cpp
+++ b/cocos/2d/CCMenuItem.cpp
@@ -66,7 +66,7 @@ MenuItem* MenuItem::create()
 // XXX deprecated
 MenuItem* MenuItem::create(Ref *target, SEL_MenuHandler selector)
 {
-    MenuItem *ret = new MenuItem();
+    MenuItem *ret = new (std::nothrow) MenuItem();
     ret->initWithTarget(target, selector);
     ret->autorelease();
     return ret;
@@ -74,7 +74,7 @@ MenuItem* MenuItem::create(Ref *target, SEL_MenuHandler selector)
 
 MenuItem* MenuItem::create( const ccMenuCallback& callback)
 {
-    MenuItem *ret = new MenuItem();
+    MenuItem *ret = new (std::nothrow) MenuItem();
     ret->initWithCallback(callback);
     ret->autorelease();
     return ret;
@@ -195,7 +195,7 @@ void MenuItemLabel::setLabel(Node* var)
 // XXX: deprecated
 MenuItemLabel * MenuItemLabel::create(Node*label, Ref* target, SEL_MenuHandler selector)
 {
-    MenuItemLabel *ret = new MenuItemLabel();
+    MenuItemLabel *ret = new (std::nothrow) MenuItemLabel();
     ret->initWithLabel(label, target, selector);
     ret->autorelease();
     return ret;
@@ -203,7 +203,7 @@ MenuItemLabel * MenuItemLabel::create(Node*label, Ref* target, SEL_MenuHandler s
 
 MenuItemLabel * MenuItemLabel::create(Node*label, const ccMenuCallback& callback)
 {
-    MenuItemLabel *ret = new MenuItemLabel();
+    MenuItemLabel *ret = new (std::nothrow) MenuItemLabel();
     ret->initWithLabel(label, callback);
     ret->autorelease();
     return ret;
@@ -211,7 +211,7 @@ MenuItemLabel * MenuItemLabel::create(Node*label, const ccMenuCallback& callback
 
 MenuItemLabel* MenuItemLabel::create(Node *label)
 {
-    MenuItemLabel *ret = new MenuItemLabel();
+    MenuItemLabel *ret = new (std::nothrow) MenuItemLabel();
     ret->initWithLabel(label, (const ccMenuCallback&) nullptr);
     ret->autorelease();
     return ret;
@@ -325,7 +325,7 @@ MenuItemAtlasFont * MenuItemAtlasFont::create(const std::string& value, const st
 // XXX: deprecated
 MenuItemAtlasFont * MenuItemAtlasFont::create(const std::string& value, const std::string& charMapFile, int itemWidth, int itemHeight, char startCharMap, Ref* target, SEL_MenuHandler selector)
 {
-    MenuItemAtlasFont *ret = new MenuItemAtlasFont();
+    MenuItemAtlasFont *ret = new (std::nothrow) MenuItemAtlasFont();
     ret->initWithString(value, charMapFile, itemWidth, itemHeight, startCharMap, target, selector);
     ret->autorelease();
     return ret;
@@ -333,7 +333,7 @@ MenuItemAtlasFont * MenuItemAtlasFont::create(const std::string& value, const st
 
 MenuItemAtlasFont * MenuItemAtlasFont::create(const std::string& value, const std::string& charMapFile, int itemWidth, int itemHeight, char startCharMap, const ccMenuCallback& callback)
 {
-    MenuItemAtlasFont *ret = new MenuItemAtlasFont();
+    MenuItemAtlasFont *ret = new (std::nothrow) MenuItemAtlasFont();
     ret->initWithString(value, charMapFile, itemWidth, itemHeight, startCharMap, callback);
     ret->autorelease();
     return ret;
@@ -391,7 +391,7 @@ const std::string& MenuItemFont::getFontName()
 // XXX: deprecated
 MenuItemFont * MenuItemFont::create(const std::string& value, Ref* target, SEL_MenuHandler selector)
 {
-    MenuItemFont *ret = new MenuItemFont();
+    MenuItemFont *ret = new (std::nothrow) MenuItemFont();
     ret->initWithString(value, target, selector);
     ret->autorelease();
     return ret;
@@ -399,7 +399,7 @@ MenuItemFont * MenuItemFont::create(const std::string& value, Ref* target, SEL_M
 
 MenuItemFont * MenuItemFont::create(const std::string& value, const ccMenuCallback& callback)
 {
-    MenuItemFont *ret = new MenuItemFont();
+    MenuItemFont *ret = new (std::nothrow) MenuItemFont();
     ret->initWithString(value, callback);
     ret->autorelease();
     return ret;
@@ -408,7 +408,7 @@ MenuItemFont * MenuItemFont::create(const std::string& value, const ccMenuCallba
 
 MenuItemFont * MenuItemFont::create(const std::string& value)
 {
-    MenuItemFont *ret = new MenuItemFont();
+    MenuItemFont *ret = new (std::nothrow) MenuItemFont();
     ret->initWithString(value, (const ccMenuCallback&)nullptr);
     ret->autorelease();
     return ret;
@@ -560,7 +560,7 @@ MenuItemSprite * MenuItemSprite::create(Node* normalSprite, Node* selectedSprite
 // XXX deprecated
 MenuItemSprite * MenuItemSprite::create(Node *normalSprite, Node *selectedSprite, Node *disabledSprite, Ref *target, SEL_MenuHandler selector)
 {
-    MenuItemSprite *ret = new MenuItemSprite();
+    MenuItemSprite *ret = new (std::nothrow) MenuItemSprite();
     ret->initWithNormalSprite(normalSprite, selectedSprite, disabledSprite, target, selector); 
     ret->autorelease();
     return ret;
@@ -568,7 +568,7 @@ MenuItemSprite * MenuItemSprite::create(Node *normalSprite, Node *selectedSprite
 
 MenuItemSprite * MenuItemSprite::create(Node *normalSprite, Node *selectedSprite, Node *disabledSprite, const ccMenuCallback& callback)
 {
-    MenuItemSprite *ret = new MenuItemSprite();
+    MenuItemSprite *ret = new (std::nothrow) MenuItemSprite();
     ret->initWithNormalSprite(normalSprite, selectedSprite, disabledSprite, callback);
     ret->autorelease();
     return ret;
@@ -686,7 +686,7 @@ void MenuItemSprite::updateImagesVisibility()
 
 MenuItemImage* MenuItemImage::create()
 {
-    MenuItemImage *ret = new MenuItemImage();
+    MenuItemImage *ret = new (std::nothrow) MenuItemImage();
     if (ret && ret->init())
     {
         ret->autorelease();
@@ -720,7 +720,7 @@ MenuItemImage * MenuItemImage::create(const std::string& normalImage, const std:
 // XXX deprecated
 MenuItemImage * MenuItemImage::create(const std::string& normalImage, const std::string& selectedImage, const std::string& disabledImage, Ref* target, SEL_MenuHandler selector)
 {
-    MenuItemImage *ret = new MenuItemImage();
+    MenuItemImage *ret = new (std::nothrow) MenuItemImage();
     if (ret && ret->initWithNormalImage(normalImage, selectedImage, disabledImage, target, selector))
     {
         ret->autorelease();
@@ -732,7 +732,7 @@ MenuItemImage * MenuItemImage::create(const std::string& normalImage, const std:
 
 MenuItemImage * MenuItemImage::create(const std::string& normalImage, const std::string& selectedImage, const std::string& disabledImage, const ccMenuCallback& callback)
 {
-    MenuItemImage *ret = new MenuItemImage();
+    MenuItemImage *ret = new (std::nothrow) MenuItemImage();
     if (ret && ret->initWithNormalImage(normalImage, selectedImage, disabledImage, callback))
     {
         ret->autorelease();
@@ -744,7 +744,7 @@ MenuItemImage * MenuItemImage::create(const std::string& normalImage, const std:
 
 MenuItemImage * MenuItemImage::create(const std::string& normalImage, const std::string& selectedImage, const std::string& disabledImage)
 {
-    MenuItemImage *ret = new MenuItemImage();
+    MenuItemImage *ret = new (std::nothrow) MenuItemImage();
     if (ret && ret->initWithNormalImage(normalImage, selectedImage, disabledImage, (const ccMenuCallback&)nullptr))
     {
         ret->autorelease();
@@ -809,7 +809,7 @@ void MenuItemImage::setDisabledSpriteFrame(SpriteFrame * frame)
 // XXX: deprecated
 MenuItemToggle * MenuItemToggle::createWithTarget(Ref* target, SEL_MenuHandler selector, const Vector<MenuItem*>& menuItems)
 {
-    MenuItemToggle *ret = new MenuItemToggle();
+    MenuItemToggle *ret = new (std::nothrow) MenuItemToggle();
     ret->MenuItem::initWithTarget(target, selector);
     ret->_subItems = menuItems;
     ret->_selectedIndex = UINT_MAX;
@@ -819,7 +819,7 @@ MenuItemToggle * MenuItemToggle::createWithTarget(Ref* target, SEL_MenuHandler s
 
 MenuItemToggle * MenuItemToggle::createWithCallback(const ccMenuCallback &callback, const Vector<MenuItem*>& menuItems)
 {
-    MenuItemToggle *ret = new MenuItemToggle();
+    MenuItemToggle *ret = new (std::nothrow) MenuItemToggle();
     ret->MenuItem::initWithCallback(callback);
     ret->_subItems = menuItems;
     ret->_selectedIndex = UINT_MAX;
@@ -832,7 +832,7 @@ MenuItemToggle * MenuItemToggle::createWithTarget(Ref* target, SEL_MenuHandler s
 {
     va_list args;
     va_start(args, item);
-    MenuItemToggle *ret = new MenuItemToggle();
+    MenuItemToggle *ret = new (std::nothrow) MenuItemToggle();
     ret->initWithTarget(target, selector, item, args);
     ret->autorelease();
     va_end(args);
@@ -844,7 +844,7 @@ MenuItemToggle * MenuItemToggle::createWithCallbackVA(const ccMenuCallback &call
 {
     va_list args;
     va_start(args, item);
-    MenuItemToggle *ret = new MenuItemToggle();
+    MenuItemToggle *ret = new (std::nothrow) MenuItemToggle();
     ret->initWithCallback(callback, item, args);
     ret->autorelease();
     va_end(args);
@@ -855,7 +855,7 @@ MenuItemToggle * MenuItemToggle::createWithCallback(const ccMenuCallback &callba
 {
     va_list args;
     va_start(args, item);
-    MenuItemToggle *ret = new MenuItemToggle();
+    MenuItemToggle *ret = new (std::nothrow) MenuItemToggle();
     ret->initWithCallback(callback, item, args);
     ret->autorelease();
     va_end(args);
@@ -865,7 +865,7 @@ MenuItemToggle * MenuItemToggle::createWithCallback(const ccMenuCallback &callba
 
 MenuItemToggle * MenuItemToggle::create()
 {
-    MenuItemToggle *ret = new MenuItemToggle();
+    MenuItemToggle *ret = new (std::nothrow) MenuItemToggle();
     ret->initWithItem(nullptr);
     ret->autorelease();
     return ret;
@@ -898,7 +898,7 @@ bool MenuItemToggle::initWithCallback(const ccMenuCallback &callback, MenuItem *
 
 MenuItemToggle* MenuItemToggle::create(MenuItem *item)
 {
-    MenuItemToggle *ret = new MenuItemToggle();
+    MenuItemToggle *ret = new (std::nothrow) MenuItemToggle();
     ret->initWithItem(item);
     ret->autorelease();
     return ret;

--- a/cocos/2d/CCMotionStreak.cpp
+++ b/cocos/2d/CCMotionStreak.cpp
@@ -69,7 +69,7 @@ MotionStreak::~MotionStreak()
 
 MotionStreak* MotionStreak::create(float fade, float minSeg, float stroke, const Color3B& color, const std::string& path)
 {
-    MotionStreak *ret = new MotionStreak();
+    MotionStreak *ret = new (std::nothrow) MotionStreak();
     if (ret && ret->initWithFade(fade, minSeg, stroke, color, path))
     {
         ret->autorelease();
@@ -82,7 +82,7 @@ MotionStreak* MotionStreak::create(float fade, float minSeg, float stroke, const
 
 MotionStreak* MotionStreak::create(float fade, float minSeg, float stroke, const Color3B& color, Texture2D* texture)
 {
-    MotionStreak *ret = new MotionStreak();
+    MotionStreak *ret = new (std::nothrow) MotionStreak();
     if (ret && ret->initWithFade(fade, minSeg, stroke, color, texture))
     {
         ret->autorelease();

--- a/cocos/2d/CCNode.cpp
+++ b/cocos/2d/CCNode.cpp
@@ -757,7 +757,7 @@ Rect Node::getBoundingBox() const
 
 Node * Node::create()
 {
-	Node * ret = new Node();
+	Node * ret = new (std::nothrow) Node();
     if (ret && ret->init())
     {
         ret->autorelease();
@@ -1847,7 +1847,7 @@ bool Node::addComponent(Component *component)
 {
     // lazy alloc
     if( !_componentContainer )
-        _componentContainer = new ComponentContainer(this);
+        _componentContainer = new (std::nothrow) ComponentContainer(this);
     return _componentContainer->add(component);
 }
 

--- a/cocos/2d/CCNodeGrid.cpp
+++ b/cocos/2d/CCNodeGrid.cpp
@@ -34,7 +34,7 @@ NS_CC_BEGIN
 
 NodeGrid* NodeGrid::create()
 {
-    NodeGrid * ret = new NodeGrid();
+    NodeGrid * ret = new (std::nothrow) NodeGrid();
     if (ret && ret->init())
     {
         ret->autorelease();

--- a/cocos/2d/CCParallaxNode.cpp
+++ b/cocos/2d/CCParallaxNode.cpp
@@ -34,7 +34,7 @@ class PointObject : public Ref
 public:
     static PointObject * create(Vec2 ratio, Vec2 offset)
     {
-        PointObject *ret = new PointObject();
+        PointObject *ret = new (std::nothrow) PointObject();
         ret->initWithPoint(ratio, offset);
         ret->autorelease();
         return ret;
@@ -80,7 +80,7 @@ ParallaxNode::~ParallaxNode()
 
 ParallaxNode * ParallaxNode::create()
 {
-    ParallaxNode *ret = new ParallaxNode();
+    ParallaxNode *ret = new (std::nothrow) ParallaxNode();
     ret->autorelease();
     return ret;
 }

--- a/cocos/2d/CCParticleBatchNode.cpp
+++ b/cocos/2d/CCParticleBatchNode.cpp
@@ -65,7 +65,7 @@ ParticleBatchNode::~ParticleBatchNode()
 
 ParticleBatchNode* ParticleBatchNode::createWithTexture(Texture2D *tex, int capacity/* = kParticleDefaultCapacity*/)
 {
-    ParticleBatchNode * p = new ParticleBatchNode();
+    ParticleBatchNode * p = new (std::nothrow) ParticleBatchNode();
     if( p && p->initWithTexture(tex, capacity))
     {
         p->autorelease();
@@ -81,7 +81,7 @@ ParticleBatchNode* ParticleBatchNode::createWithTexture(Texture2D *tex, int capa
 
 ParticleBatchNode* ParticleBatchNode::create(const std::string& imageFile, int capacity/* = kParticleDefaultCapacity*/)
 {
-    ParticleBatchNode * p = new ParticleBatchNode();
+    ParticleBatchNode * p = new (std::nothrow) ParticleBatchNode();
     if( p && p->initWithFile(imageFile, capacity))
     {
         p->autorelease();
@@ -96,7 +96,7 @@ ParticleBatchNode* ParticleBatchNode::create(const std::string& imageFile, int c
  */
 bool ParticleBatchNode::initWithTexture(Texture2D *tex, int capacity)
 {
-    _textureAtlas = new TextureAtlas();
+    _textureAtlas = new (std::nothrow) TextureAtlas();
     _textureAtlas->initWithTexture(tex, capacity);
 
     _children.reserve(capacity);

--- a/cocos/2d/CCParticleExamples.cpp
+++ b/cocos/2d/CCParticleExamples.cpp
@@ -47,7 +47,7 @@ static Texture2D* getDefaultTexture()
         texture = Director::getInstance()->getTextureCache()->getTextureForKey(key);
         CC_BREAK_IF(texture != nullptr);
 
-        image = new Image();
+        image = new (std::nothrow) Image();
         CC_BREAK_IF(nullptr == image);
         ret = image->initWithImageData(__firePngData, sizeof(__firePngData));
         CC_BREAK_IF(!ret);
@@ -62,7 +62,7 @@ static Texture2D* getDefaultTexture()
 
 ParticleFire* ParticleFire::create()
 {
-    ParticleFire* ret = new ParticleFire();
+    ParticleFire* ret = new (std::nothrow) ParticleFire();
     if (ret && ret->init())
     {
         ret->autorelease();
@@ -76,7 +76,7 @@ ParticleFire* ParticleFire::create()
 
 ParticleFire* ParticleFire::createWithTotalParticles(int numberOfParticles)
 {
-    ParticleFire* ret = new ParticleFire();
+    ParticleFire* ret = new (std::nothrow) ParticleFire();
     if (ret && ret->initWithTotalParticles(numberOfParticles))
     {
         ret->autorelease();
@@ -167,7 +167,7 @@ bool ParticleFire::initWithTotalParticles(int numberOfParticles)
 
 ParticleFireworks* ParticleFireworks::create()
 {
-    ParticleFireworks* ret = new ParticleFireworks();
+    ParticleFireworks* ret = new (std::nothrow) ParticleFireworks();
     if (ret && ret->init())
     {
         ret->autorelease();
@@ -181,7 +181,7 @@ ParticleFireworks* ParticleFireworks::create()
 
 ParticleFireworks* ParticleFireworks::createWithTotalParticles(int numberOfParticles)
 {
-    ParticleFireworks* ret = new ParticleFireworks();
+    ParticleFireworks* ret = new (std::nothrow) ParticleFireworks();
     if (ret && ret->initWithTotalParticles(numberOfParticles))
     {
         ret->autorelease();
@@ -268,7 +268,7 @@ bool ParticleFireworks::initWithTotalParticles(int numberOfParticles)
 //
 ParticleSun* ParticleSun::create()
 {
-    ParticleSun* ret = new ParticleSun();
+    ParticleSun* ret = new (std::nothrow) ParticleSun();
     if (ret && ret->init())
     {
         ret->autorelease();
@@ -282,7 +282,7 @@ ParticleSun* ParticleSun::create()
 
 ParticleSun* ParticleSun::createWithTotalParticles(int numberOfParticles)
 {
-    ParticleSun* ret = new ParticleSun();
+    ParticleSun* ret = new (std::nothrow) ParticleSun();
     if (ret && ret->initWithTotalParticles(numberOfParticles))
     {
         ret->autorelease();
@@ -375,7 +375,7 @@ bool ParticleSun::initWithTotalParticles(int numberOfParticles)
 
 ParticleGalaxy* ParticleGalaxy::create()
 {
-    ParticleGalaxy* ret = new ParticleGalaxy();
+    ParticleGalaxy* ret = new (std::nothrow) ParticleGalaxy();
     if (ret && ret->init())
     {
         ret->autorelease();
@@ -389,7 +389,7 @@ ParticleGalaxy* ParticleGalaxy::create()
 
 ParticleGalaxy* ParticleGalaxy::createWithTotalParticles(int numberOfParticles)
 {
-    ParticleGalaxy* ret = new ParticleGalaxy();
+    ParticleGalaxy* ret = new (std::nothrow) ParticleGalaxy();
     if (ret && ret->initWithTotalParticles(numberOfParticles))
     {
         ret->autorelease();
@@ -484,7 +484,7 @@ bool ParticleGalaxy::initWithTotalParticles(int numberOfParticles)
 
 ParticleFlower* ParticleFlower::create()
 {
-    ParticleFlower* ret = new ParticleFlower();
+    ParticleFlower* ret = new (std::nothrow) ParticleFlower();
     if (ret && ret->init())
     {
         ret->autorelease();
@@ -498,7 +498,7 @@ ParticleFlower* ParticleFlower::create()
 
 ParticleFlower* ParticleFlower::createWithTotalParticles(int numberOfParticles)
 {
-    ParticleFlower* ret = new ParticleFlower();
+    ParticleFlower* ret = new (std::nothrow) ParticleFlower();
     if (ret && ret->initWithTotalParticles(numberOfParticles))
     {
         ret->autorelease();
@@ -592,7 +592,7 @@ bool ParticleFlower::initWithTotalParticles(int numberOfParticles)
 
 ParticleMeteor * ParticleMeteor::create()
 {
-    ParticleMeteor *ret = new ParticleMeteor();
+    ParticleMeteor *ret = new (std::nothrow) ParticleMeteor();
     if (ret && ret->init())
     {
         ret->autorelease();
@@ -606,7 +606,7 @@ ParticleMeteor * ParticleMeteor::create()
 
 ParticleMeteor* ParticleMeteor::createWithTotalParticles(int numberOfParticles)
 {
-    ParticleMeteor* ret = new ParticleMeteor();
+    ParticleMeteor* ret = new (std::nothrow) ParticleMeteor();
     if (ret && ret->initWithTotalParticles(numberOfParticles))
     {
         ret->autorelease();
@@ -701,7 +701,7 @@ bool ParticleMeteor::initWithTotalParticles(int numberOfParticles)
 
 ParticleSpiral* ParticleSpiral::create()
 {
-    ParticleSpiral* ret = new ParticleSpiral();
+    ParticleSpiral* ret = new (std::nothrow) ParticleSpiral();
     if (ret && ret->init())
     {
         ret->autorelease();
@@ -715,7 +715,7 @@ ParticleSpiral* ParticleSpiral::create()
 
 ParticleSpiral* ParticleSpiral::createWithTotalParticles(int numberOfParticles)
 {
-    ParticleSpiral* ret = new ParticleSpiral();
+    ParticleSpiral* ret = new (std::nothrow) ParticleSpiral();
     if (ret && ret->initWithTotalParticles(numberOfParticles))
     {
         ret->autorelease();
@@ -810,7 +810,7 @@ bool ParticleSpiral::initWithTotalParticles(int numberOfParticles)
 
 ParticleExplosion* ParticleExplosion::create()
 {
-    ParticleExplosion* ret = new ParticleExplosion();
+    ParticleExplosion* ret = new (std::nothrow) ParticleExplosion();
     if (ret && ret->init())
     {
         ret->autorelease();
@@ -824,7 +824,7 @@ ParticleExplosion* ParticleExplosion::create()
 
 ParticleExplosion* ParticleExplosion::createWithTotalParticles(int numberOfParticles)
 {
-    ParticleExplosion* ret = new ParticleExplosion();
+    ParticleExplosion* ret = new (std::nothrow) ParticleExplosion();
     if (ret && ret->initWithTotalParticles(numberOfParticles))
     {
         ret->autorelease();
@@ -918,7 +918,7 @@ bool ParticleExplosion::initWithTotalParticles(int numberOfParticles)
 
 ParticleSmoke* ParticleSmoke::create()
 {
-    ParticleSmoke* ret = new ParticleSmoke();
+    ParticleSmoke* ret = new (std::nothrow) ParticleSmoke();
     if (ret && ret->init())
     {
         ret->autorelease();
@@ -932,7 +932,7 @@ ParticleSmoke* ParticleSmoke::create()
 
 ParticleSmoke* ParticleSmoke::createWithTotalParticles(int numberOfParticles)
 {
-    ParticleSmoke* ret = new ParticleSmoke();
+    ParticleSmoke* ret = new (std::nothrow) ParticleSmoke();
     if (ret && ret->initWithTotalParticles(numberOfParticles))
     {
         ret->autorelease();
@@ -1023,7 +1023,7 @@ bool ParticleSmoke::initWithTotalParticles(int numberOfParticles)
 
 ParticleSnow* ParticleSnow::create()
 {
-    ParticleSnow* ret = new ParticleSnow();
+    ParticleSnow* ret = new (std::nothrow) ParticleSnow();
     if (ret && ret->init())
     {
         ret->autorelease();
@@ -1037,7 +1037,7 @@ ParticleSnow* ParticleSnow::create()
 
 ParticleSnow* ParticleSnow::createWithTotalParticles(int numberOfParticles)
 {
-    ParticleSnow* ret = new ParticleSnow();
+    ParticleSnow* ret = new (std::nothrow) ParticleSnow();
     if (ret && ret->initWithTotalParticles(numberOfParticles))
     {
         ret->autorelease();
@@ -1131,7 +1131,7 @@ bool ParticleSnow::initWithTotalParticles(int numberOfParticles)
 
 ParticleRain* ParticleRain::create()
 {
-    ParticleRain* ret = new ParticleRain();
+    ParticleRain* ret = new (std::nothrow) ParticleRain();
     if (ret && ret->init())
     {
         ret->autorelease();
@@ -1145,7 +1145,7 @@ ParticleRain* ParticleRain::create()
 
 ParticleRain* ParticleRain::createWithTotalParticles(int numberOfParticles)
 {
-    ParticleRain* ret = new ParticleRain();
+    ParticleRain* ret = new (std::nothrow) ParticleRain();
     if (ret && ret->initWithTotalParticles(numberOfParticles))
     {
         ret->autorelease();

--- a/cocos/2d/CCParticleSystem.cpp
+++ b/cocos/2d/CCParticleSystem.cpp
@@ -139,7 +139,7 @@ ParticleSystem::ParticleSystem()
 
 ParticleSystem * ParticleSystem::create(const std::string& plistFile)
 {
-    ParticleSystem *ret = new ParticleSystem();
+    ParticleSystem *ret = new (std::nothrow) ParticleSystem();
     if (ret && ret->initWithFile(plistFile))
     {
         ret->autorelease();
@@ -151,7 +151,7 @@ ParticleSystem * ParticleSystem::create(const std::string& plistFile)
 
 ParticleSystem* ParticleSystem::createWithTotalParticles(int numberOfParticles)
 {
-    ParticleSystem *ret = new ParticleSystem();
+    ParticleSystem *ret = new (std::nothrow) ParticleSystem();
     if (ret && ret->initWithTotalParticles(numberOfParticles))
     {
         ret->autorelease();
@@ -405,7 +405,7 @@ bool ParticleSystem::initWithDictionary(ValueMap& dictionary, const std::string&
                         CC_BREAK_IF(!deflated);
                         
                         // For android, we should retain it in VolatileTexture::addImage which invoked in Director::getInstance()->getTextureCache()->addUIImage()
-                        image = new Image();
+                        image = new (std::nothrow) Image();
                         bool isOK = image->initWithImageData(deflated, deflatedLen);
                         CCASSERT(isOK, "CCParticleSystem: error init image with Data");
                         CC_BREAK_IF(!isOK);

--- a/cocos/2d/CCParticleSystemQuad.cpp
+++ b/cocos/2d/CCParticleSystemQuad.cpp
@@ -75,7 +75,7 @@ ParticleSystemQuad::~ParticleSystemQuad()
 
 ParticleSystemQuad * ParticleSystemQuad::create(const std::string& filename)
 {
-    ParticleSystemQuad *ret = new ParticleSystemQuad();
+    ParticleSystemQuad *ret = new (std::nothrow) ParticleSystemQuad();
     if (ret && ret->initWithFile(filename))
     {
         ret->autorelease();
@@ -86,7 +86,7 @@ ParticleSystemQuad * ParticleSystemQuad::create(const std::string& filename)
 }
 
 ParticleSystemQuad * ParticleSystemQuad::createWithTotalParticles(int numberOfParticles) {
-    ParticleSystemQuad *ret = new ParticleSystemQuad();
+    ParticleSystemQuad *ret = new (std::nothrow) ParticleSystemQuad();
     if (ret && ret->initWithTotalParticles(numberOfParticles))
     {
         ret->autorelease();
@@ -597,7 +597,7 @@ void ParticleSystemQuad::setBatchNode(ParticleBatchNode * batchNode)
 }
 
 ParticleSystemQuad * ParticleSystemQuad::create() {
-    ParticleSystemQuad *particleSystemQuad = new ParticleSystemQuad();
+    ParticleSystemQuad *particleSystemQuad = new (std::nothrow) ParticleSystemQuad();
     if (particleSystemQuad && particleSystemQuad->init())
     {
         particleSystemQuad->autorelease();

--- a/cocos/2d/CCProgressTimer.cpp
+++ b/cocos/2d/CCProgressTimer.cpp
@@ -59,7 +59,7 @@ ProgressTimer::ProgressTimer()
 
 ProgressTimer* ProgressTimer::create(Sprite* sp)
 {
-    ProgressTimer *progressTimer = new ProgressTimer();
+    ProgressTimer *progressTimer = new (std::nothrow) ProgressTimer();
     if (progressTimer->initWithSprite(sp))
     {
         progressTimer->autorelease();

--- a/cocos/2d/CCProtectedNode.cpp
+++ b/cocos/2d/CCProtectedNode.cpp
@@ -49,7 +49,7 @@ ProtectedNode::~ProtectedNode()
 
 ProtectedNode * ProtectedNode::create(void)
 {
-	ProtectedNode * ret = new ProtectedNode();
+	ProtectedNode * ret = new (std::nothrow) ProtectedNode();
     if (ret && ret->init())
     {
         ret->autorelease();

--- a/cocos/2d/CCRenderTexture.cpp
+++ b/cocos/2d/CCRenderTexture.cpp
@@ -150,7 +150,7 @@ void RenderTexture::listenToForeground(EventCustom *event)
 
 RenderTexture * RenderTexture::create(int w, int h, Texture2D::PixelFormat eFormat)
 {
-    RenderTexture *ret = new RenderTexture();
+    RenderTexture *ret = new (std::nothrow) RenderTexture();
 
     if(ret && ret->initWithWidthAndHeight(w, h, eFormat))
     {
@@ -163,7 +163,7 @@ RenderTexture * RenderTexture::create(int w, int h, Texture2D::PixelFormat eForm
 
 RenderTexture * RenderTexture::create(int w ,int h, Texture2D::PixelFormat eFormat, GLuint uDepthStencilFormat)
 {
-    RenderTexture *ret = new RenderTexture();
+    RenderTexture *ret = new (std::nothrow) RenderTexture();
 
     if(ret && ret->initWithWidthAndHeight(w, h, eFormat, uDepthStencilFormat))
     {
@@ -176,7 +176,7 @@ RenderTexture * RenderTexture::create(int w ,int h, Texture2D::PixelFormat eForm
 
 RenderTexture * RenderTexture::create(int w, int h)
 {
-    RenderTexture *ret = new RenderTexture();
+    RenderTexture *ret = new (std::nothrow) RenderTexture();
 
     if(ret && ret->initWithWidthAndHeight(w, h, Texture2D::PixelFormat::RGBA8888, 0))
     {
@@ -231,7 +231,7 @@ bool RenderTexture::initWithWidthAndHeight(int w, int h, Texture2D::PixelFormat 
         memset(data, 0, dataLen);
         _pixelFormat = format;
 
-        _texture = new Texture2D();
+        _texture = new (std::nothrow) Texture2D();
         if (_texture)
         {
             _texture->initWithData(data, dataLen, (Texture2D::PixelFormat)_pixelFormat, powW, powH, Size((float)w, (float)h));
@@ -245,7 +245,7 @@ bool RenderTexture::initWithWidthAndHeight(int w, int h, Texture2D::PixelFormat 
         
         if (Configuration::getInstance()->checkForGLExtension("GL_QCOM"))
         {
-            _textureCopy = new Texture2D();
+            _textureCopy = new (std::nothrow) Texture2D();
             if (_textureCopy)
             {
                 _textureCopy->initWithData(data, dataLen, (Texture2D::PixelFormat)_pixelFormat, powW, powH, Size((float)w, (float)h));
@@ -488,13 +488,13 @@ Image* RenderTexture::newImage(bool fliimage)
 
     GLubyte *buffer = nullptr;
     GLubyte *tempData = nullptr;
-    Image *image = new Image();
+    Image *image = new (std::nothrow) Image();
 
     do
     {
-        CC_BREAK_IF(! (buffer = new GLubyte[savedBufferWidth * savedBufferHeight * 4]));
+        CC_BREAK_IF(! (buffer = new (std::nothrow) GLubyte[savedBufferWidth * savedBufferHeight * 4]));
 
-        if(! (tempData = new GLubyte[savedBufferWidth * savedBufferHeight * 4]))
+        if(! (tempData = new (std::nothrow) GLubyte[savedBufferWidth * savedBufferHeight * 4]))
         {
             delete[] buffer;
             buffer = nullptr;

--- a/cocos/2d/CCScene.cpp
+++ b/cocos/2d/CCScene.cpp
@@ -77,7 +77,7 @@ bool Scene::initWithSize(const Size& size)
 
 Scene* Scene::create()
 {
-    Scene *ret = new Scene();
+    Scene *ret = new (std::nothrow) Scene();
     if (ret && ret->init())
     {
         ret->autorelease();
@@ -92,7 +92,7 @@ Scene* Scene::create()
 
 Scene* Scene::createWithSize(const Size& size)
 {
-    Scene *ret = new Scene();
+    Scene *ret = new (std::nothrow) Scene();
     if (ret && ret->initWithSize(size))
     {
         ret->autorelease();
@@ -148,7 +148,7 @@ void Scene::update(float delta)
 
 Scene* Scene::createWithPhysics()
 {
-    Scene *ret = new Scene();
+    Scene *ret = new (std::nothrow) Scene();
     if (ret && ret->initWithPhysics())
     {
         ret->autorelease();

--- a/cocos/2d/CCSprite.cpp
+++ b/cocos/2d/CCSprite.cpp
@@ -292,7 +292,7 @@ Sprite::~Sprite(void)
  * It's used for creating a default texture when sprite's texture is set to nullptr.
  * Supposing codes as follows:
  *
- *   auto sp = new Sprite();
+ *   auto sp = new (std::nothrow) Sprite();
  *   sp->init();  // Texture was set to nullptr, in order to make opacity and color to work correctly, we need to create a 2x2 white texture.
  *
  * The test is in "TestCpp/SpriteTest/Sprite without texture".
@@ -332,7 +332,7 @@ void Sprite::setTexture(Texture2D *texture)
         // If texture wasn't in cache, create it from RAW data.
         if (texture == nullptr)
         {
-            Image* image = new Image();
+            Image* image = new (std::nothrow) Image();
             bool isOK = image->initWithRawData(cc_2x2_white_image, sizeof(cc_2x2_white_image), 2, 2, 8);
             CC_UNUSED_PARAM(isOK);
             CCASSERT(isOK, "The 2x2 empty texture was created unsuccessfully.");

--- a/cocos/2d/CCSpriteBatchNode.cpp
+++ b/cocos/2d/CCSpriteBatchNode.cpp
@@ -57,7 +57,7 @@ NS_CC_BEGIN
 
 SpriteBatchNode* SpriteBatchNode::createWithTexture(Texture2D* tex, ssize_t capacity/* = DEFAULT_CAPACITY*/)
 {
-    SpriteBatchNode *batchNode = new SpriteBatchNode();
+    SpriteBatchNode *batchNode = new (std::nothrow) SpriteBatchNode();
     batchNode->initWithTexture(tex, capacity);
     batchNode->autorelease();
 
@@ -70,7 +70,7 @@ SpriteBatchNode* SpriteBatchNode::createWithTexture(Texture2D* tex, ssize_t capa
 
 SpriteBatchNode* SpriteBatchNode::create(const std::string& fileImage, ssize_t capacity/* = DEFAULT_CAPACITY*/)
 {
-    SpriteBatchNode *batchNode = new SpriteBatchNode();
+    SpriteBatchNode *batchNode = new (std::nothrow) SpriteBatchNode();
     batchNode->initWithFile(fileImage, capacity);
     batchNode->autorelease();
 
@@ -89,7 +89,7 @@ bool SpriteBatchNode::initWithTexture(Texture2D *tex, ssize_t capacity)
     {
         _blendFunc = BlendFunc::ALPHA_NON_PREMULTIPLIED;
     }
-    _textureAtlas = new TextureAtlas();
+    _textureAtlas = new (std::nothrow) TextureAtlas();
 
     if (capacity == 0)
     {
@@ -110,7 +110,7 @@ bool SpriteBatchNode::initWithTexture(Texture2D *tex, ssize_t capacity)
 
 bool SpriteBatchNode::init()
 {
-    Texture2D * texture = new Texture2D();
+    Texture2D * texture = new (std::nothrow) Texture2D();
     texture->autorelease();
     return this->initWithTexture(texture, 0);
 }

--- a/cocos/2d/CCSpriteFrame.cpp
+++ b/cocos/2d/CCSpriteFrame.cpp
@@ -35,7 +35,7 @@ NS_CC_BEGIN
 
 SpriteFrame* SpriteFrame::create(const std::string& filename, const Rect& rect)
 {
-    SpriteFrame *spriteFrame = new SpriteFrame();
+    SpriteFrame *spriteFrame = new (std::nothrow) SpriteFrame();
     spriteFrame->initWithTextureFilename(filename, rect);
     spriteFrame->autorelease();
 
@@ -44,7 +44,7 @@ SpriteFrame* SpriteFrame::create(const std::string& filename, const Rect& rect)
 
 SpriteFrame* SpriteFrame::createWithTexture(Texture2D *texture, const Rect& rect)
 {
-    SpriteFrame *spriteFrame = new SpriteFrame();
+    SpriteFrame *spriteFrame = new (std::nothrow) SpriteFrame();
     spriteFrame->initWithTexture(texture, rect);
     spriteFrame->autorelease();
     
@@ -53,7 +53,7 @@ SpriteFrame* SpriteFrame::createWithTexture(Texture2D *texture, const Rect& rect
 
 SpriteFrame* SpriteFrame::createWithTexture(Texture2D* texture, const Rect& rect, bool rotated, const Vec2& offset, const Size& originalSize)
 {
-    SpriteFrame *spriteFrame = new SpriteFrame();
+    SpriteFrame *spriteFrame = new (std::nothrow) SpriteFrame();
     spriteFrame->initWithTexture(texture, rect, rotated, offset, originalSize);
     spriteFrame->autorelease();
 
@@ -62,7 +62,7 @@ SpriteFrame* SpriteFrame::createWithTexture(Texture2D* texture, const Rect& rect
 
 SpriteFrame* SpriteFrame::create(const std::string& filename, const Rect& rect, bool rotated, const Vec2& offset, const Size& originalSize)
 {
-    SpriteFrame *spriteFrame = new SpriteFrame();
+    SpriteFrame *spriteFrame = new (std::nothrow) SpriteFrame();
     spriteFrame->initWithTextureFilename(filename, rect, rotated, offset, originalSize);
     spriteFrame->autorelease();
 
@@ -132,7 +132,7 @@ SpriteFrame::~SpriteFrame(void)
 SpriteFrame* SpriteFrame::clone() const
 {
 	// no copy constructor	
-    SpriteFrame *copy = new SpriteFrame();
+    SpriteFrame *copy = new (std::nothrow) SpriteFrame();
     copy->initWithTextureFilename(_textureFilename.c_str(), _rectInPixels, _rotated, _offsetInPixels, _originalSizeInPixels);
     copy->setTexture(_texture);
     copy->autorelease();

--- a/cocos/2d/CCSpriteFrameCache.cpp
+++ b/cocos/2d/CCSpriteFrameCache.cpp
@@ -53,7 +53,7 @@ SpriteFrameCache* SpriteFrameCache::getInstance()
 {
     if (! _sharedSpriteFrameCache)
     {
-        _sharedSpriteFrameCache = new SpriteFrameCache();
+        _sharedSpriteFrameCache = new (std::nothrow) SpriteFrameCache();
         _sharedSpriteFrameCache->init();
     }
 

--- a/cocos/2d/CCTMXLayer.cpp
+++ b/cocos/2d/CCTMXLayer.cpp
@@ -45,7 +45,7 @@ NS_CC_BEGIN
 
 TMXLayer * TMXLayer::create(TMXTilesetInfo *tilesetInfo, TMXLayerInfo *layerInfo, TMXMapInfo *mapInfo)
 {
-    TMXLayer *ret = new TMXLayer();
+    TMXLayer *ret = new (std::nothrow) TMXLayer();
     if (ret->initWithTilesetInfo(tilesetInfo, layerInfo, mapInfo))
     {
         ret->autorelease();

--- a/cocos/2d/CCTMXTiledMap.cpp
+++ b/cocos/2d/CCTMXTiledMap.cpp
@@ -38,7 +38,7 @@ NS_CC_BEGIN
 
 TMXTiledMap * TMXTiledMap::create(const std::string& tmxFile)
 {
-    TMXTiledMap *ret = new TMXTiledMap();
+    TMXTiledMap *ret = new (std::nothrow) TMXTiledMap();
     if (ret->initWithTMXFile(tmxFile))
     {
         ret->autorelease();
@@ -50,7 +50,7 @@ TMXTiledMap * TMXTiledMap::create(const std::string& tmxFile)
 
 TMXTiledMap* TMXTiledMap::createWithXML(const std::string& tmxString, const std::string& resourcePath)
 {
-    TMXTiledMap *ret = new TMXTiledMap();
+    TMXTiledMap *ret = new (std::nothrow) TMXTiledMap();
     if (ret->initWithXML(tmxString, resourcePath))
     {
         ret->autorelease();

--- a/cocos/2d/CCTMXXMLParser.cpp
+++ b/cocos/2d/CCTMXXMLParser.cpp
@@ -100,7 +100,7 @@ Rect TMXTilesetInfo::getRectForGID(uint32_t gid)
 
 TMXMapInfo * TMXMapInfo::create(const std::string& tmxFile)
 {
-    TMXMapInfo *ret = new TMXMapInfo();
+    TMXMapInfo *ret = new (std::nothrow) TMXMapInfo();
     if(ret->initWithTMXFile(tmxFile))
     {
         ret->autorelease();
@@ -112,7 +112,7 @@ TMXMapInfo * TMXMapInfo::create(const std::string& tmxFile)
 
 TMXMapInfo * TMXMapInfo::createWithXML(const std::string& tmxString, const std::string& resourcePath)
 {
-    TMXMapInfo *ret = new TMXMapInfo();
+    TMXMapInfo *ret = new (std::nothrow) TMXMapInfo();
     if(ret->initWithXML(tmxString, resourcePath))
     {
         ret->autorelease();
@@ -278,7 +278,7 @@ void TMXMapInfo::startElement(void *ctx, const char *name, const char **atts)
         }
         else
         {
-            TMXTilesetInfo *tileset = new TMXTilesetInfo();
+            TMXTilesetInfo *tileset = new (std::nothrow) TMXTilesetInfo();
             tileset->_name = attributeDict["name"].asString();
             
             if (_recordFirstGID)
@@ -332,7 +332,7 @@ void TMXMapInfo::startElement(void *ctx, const char *name, const char **atts)
     }
     else if (elementName == "layer")
     {
-        TMXLayerInfo *layer = new TMXLayerInfo();
+        TMXLayerInfo *layer = new (std::nothrow) TMXLayerInfo();
         layer->_name = attributeDict["name"].asString();
 
         Size s;
@@ -359,7 +359,7 @@ void TMXMapInfo::startElement(void *ctx, const char *name, const char **atts)
     } 
     else if (elementName == "objectgroup")
     {
-        TMXObjectGroup *objectGroup = new TMXObjectGroup();
+        TMXObjectGroup *objectGroup = new (std::nothrow) TMXObjectGroup();
         objectGroup->setGroupName(attributeDict["name"].asString());
         Vec2 positionOffset;
         positionOffset.x = attributeDict["x"].asFloat() * tmxMapInfo->getTileSize().width;

--- a/cocos/2d/CCTextFieldTTF.cpp
+++ b/cocos/2d/CCTextFieldTTF.cpp
@@ -72,7 +72,7 @@ TextFieldTTF::~TextFieldTTF()
 
 TextFieldTTF * TextFieldTTF::textFieldWithPlaceHolder(const std::string& placeholder, const Size& dimensions, TextHAlignment alignment, const std::string& fontName, float fontSize)
 {
-    TextFieldTTF *ret = new TextFieldTTF();
+    TextFieldTTF *ret = new (std::nothrow) TextFieldTTF();
     if(ret && ret->initWithPlaceHolder("", dimensions, alignment, fontName, fontSize))
     {
         ret->autorelease();
@@ -88,7 +88,7 @@ TextFieldTTF * TextFieldTTF::textFieldWithPlaceHolder(const std::string& placeho
 
 TextFieldTTF * TextFieldTTF::textFieldWithPlaceHolder(const std::string& placeholder, const std::string& fontName, float fontSize)
 {
-    TextFieldTTF *ret = new TextFieldTTF();
+    TextFieldTTF *ret = new (std::nothrow) TextFieldTTF();
     if(ret && ret->initWithPlaceHolder("", fontName, fontSize))
     {
         ret->autorelease();

--- a/cocos/2d/CCTileMapAtlas.cpp
+++ b/cocos/2d/CCTileMapAtlas.cpp
@@ -39,7 +39,7 @@ NS_CC_BEGIN
 
 TileMapAtlas * TileMapAtlas::create(const std::string& tile, const std::string& mapFile, int tileWidth, int tileHeight)
 {
-    TileMapAtlas *ret = new TileMapAtlas();
+    TileMapAtlas *ret = new (std::nothrow) TileMapAtlas();
     if (ret->initWithTileFile(tile, mapFile, tileWidth, tileHeight))
     {
         ret->autorelease();

--- a/cocos/2d/CCTransition.cpp
+++ b/cocos/2d/CCTransition.cpp
@@ -59,7 +59,7 @@ TransitionScene::~TransitionScene()
 
 TransitionScene * TransitionScene::create(float t, Scene *scene)
 {
-    TransitionScene * pScene = new TransitionScene();
+    TransitionScene * pScene = new (std::nothrow) TransitionScene();
     if(pScene && pScene->initWithDuration(t,scene))
     {
         pScene->autorelease();
@@ -211,7 +211,7 @@ TransitionSceneOriented::~TransitionSceneOriented()
 
 TransitionSceneOriented * TransitionSceneOriented::create(float t, Scene *scene, Orientation orientation)
 {
-    TransitionSceneOriented * newScene = new TransitionSceneOriented();
+    TransitionSceneOriented * newScene = new (std::nothrow) TransitionSceneOriented();
     newScene->initWithDuration(t,scene,orientation);
     newScene->autorelease();
     return newScene;
@@ -235,7 +235,7 @@ TransitionRotoZoom::TransitionRotoZoom()
 
 TransitionRotoZoom* TransitionRotoZoom::create(float t, Scene* scene)                   
 {                                                               
-    TransitionRotoZoom* newScene = new TransitionRotoZoom();
+    TransitionRotoZoom* newScene = new (std::nothrow) TransitionRotoZoom();
     if(newScene && newScene->initWithDuration(t, scene))
     {                                                           
         newScene->autorelease();
@@ -295,7 +295,7 @@ TransitionJumpZoom::~TransitionJumpZoom()
 
 TransitionJumpZoom* TransitionJumpZoom::create(float t, Scene* scene)
 {
-    TransitionJumpZoom* newScene = new TransitionJumpZoom();
+    TransitionJumpZoom* newScene = new (std::nothrow) TransitionJumpZoom();
     if(newScene && newScene->initWithDuration(t, scene))
     {
         newScene->autorelease();
@@ -350,7 +350,7 @@ TransitionMoveInL::~TransitionMoveInL()
 
 TransitionMoveInL* TransitionMoveInL::create(float t, Scene* scene)
 {
-    TransitionMoveInL* newScene = new TransitionMoveInL();
+    TransitionMoveInL* newScene = new (std::nothrow) TransitionMoveInL();
     if(newScene && newScene->initWithDuration(t, scene))
     {
         newScene->autorelease();
@@ -407,7 +407,7 @@ TransitionMoveInR::~TransitionMoveInR()
 
 TransitionMoveInR* TransitionMoveInR::create(float t, Scene* scene)
 {
-    TransitionMoveInR* newScene = new TransitionMoveInR();
+    TransitionMoveInR* newScene = new (std::nothrow) TransitionMoveInR();
     if(newScene && newScene->initWithDuration(t, scene))
     {
         newScene->autorelease();
@@ -435,7 +435,7 @@ TransitionMoveInT::~TransitionMoveInT()
 
 TransitionMoveInT* TransitionMoveInT::create(float t, Scene* scene)
 {
-    TransitionMoveInT* newScene = new TransitionMoveInT();
+    TransitionMoveInT* newScene = new (std::nothrow) TransitionMoveInT();
     if(newScene && newScene->initWithDuration(t, scene))
     {
         newScene->autorelease();
@@ -463,7 +463,7 @@ TransitionMoveInB::~TransitionMoveInB()
 
 TransitionMoveInB* TransitionMoveInB::create(float t, Scene* scene)
 {
-    TransitionMoveInB* newScene = new TransitionMoveInB();
+    TransitionMoveInB* newScene = new (std::nothrow) TransitionMoveInB();
     if(newScene && newScene->initWithDuration(t, scene))
     {
         newScene->autorelease();
@@ -540,7 +540,7 @@ ActionInterval* TransitionSlideInL::easeActionWithAction(ActionInterval* action)
 
 TransitionSlideInL* TransitionSlideInL::create(float t, Scene* scene)
 {
-    TransitionSlideInL* newScene = new TransitionSlideInL();
+    TransitionSlideInL* newScene = new (std::nothrow) TransitionSlideInL();
     if(newScene && newScene->initWithDuration(t, scene))
     {
         newScene->autorelease();
@@ -562,7 +562,7 @@ TransitionSlideInR::~TransitionSlideInR()
 
 TransitionSlideInR* TransitionSlideInR::create(float t, Scene* scene)
 {
-    TransitionSlideInR* newScene = new TransitionSlideInR();
+    TransitionSlideInR* newScene = new (std::nothrow) TransitionSlideInR();
     if(newScene && newScene->initWithDuration(t, scene))
     {
         newScene->autorelease();
@@ -603,7 +603,7 @@ TransitionSlideInT::~TransitionSlideInT()
 
 TransitionSlideInT* TransitionSlideInT::create(float t, Scene* scene)
 {
-    TransitionSlideInT* newScene = new TransitionSlideInT();
+    TransitionSlideInT* newScene = new (std::nothrow) TransitionSlideInT();
     if(newScene && newScene->initWithDuration(t, scene))
     {
         newScene->autorelease();
@@ -643,7 +643,7 @@ TransitionSlideInB::~TransitionSlideInB()
 
 TransitionSlideInB* TransitionSlideInB::create(float t, Scene* scene)
 {
-    TransitionSlideInB* newScene = new TransitionSlideInB();
+    TransitionSlideInB* newScene = new (std::nothrow) TransitionSlideInB();
     if(newScene && newScene->initWithDuration(t, scene))
     {
         newScene->autorelease();
@@ -683,7 +683,7 @@ TransitionShrinkGrow::~TransitionShrinkGrow()
 
 TransitionShrinkGrow* TransitionShrinkGrow::create(float t, Scene* scene)
 {
-    TransitionShrinkGrow* newScene = new TransitionShrinkGrow();
+    TransitionShrinkGrow* newScene = new (std::nothrow) TransitionShrinkGrow();
     if(newScene && newScene->initWithDuration(t, scene))
     {
         newScene->autorelease();
@@ -781,7 +781,7 @@ void TransitionFlipX::onEnter()
 
 TransitionFlipX* TransitionFlipX::create(float t, Scene* s, Orientation o)
 {
-    TransitionFlipX* newScene = new TransitionFlipX();
+    TransitionFlipX* newScene = new (std::nothrow) TransitionFlipX();
     newScene->initWithDuration(t, s, o);
     newScene->autorelease();
 
@@ -851,7 +851,7 @@ void TransitionFlipY::onEnter()
 
 TransitionFlipY* TransitionFlipY::create(float t, Scene* s, Orientation o)
 {
-    TransitionFlipY* newScene = new TransitionFlipY();
+    TransitionFlipY* newScene = new (std::nothrow) TransitionFlipY();
     newScene->initWithDuration(t, s, o);
     newScene->autorelease();
 
@@ -921,7 +921,7 @@ void TransitionFlipAngular::onEnter()
 
 TransitionFlipAngular* TransitionFlipAngular::create(float t, Scene* s, Orientation o)
 {
-    TransitionFlipAngular* newScene = new TransitionFlipAngular();
+    TransitionFlipAngular* newScene = new (std::nothrow) TransitionFlipAngular();
     newScene->initWithDuration(t, s, o);
     newScene->autorelease();
 
@@ -999,7 +999,7 @@ void TransitionZoomFlipX::onEnter()
 
 TransitionZoomFlipX* TransitionZoomFlipX::create(float t, Scene* s, Orientation o)
 {
-    TransitionZoomFlipX* newScene = new TransitionZoomFlipX();
+    TransitionZoomFlipX* newScene = new (std::nothrow) TransitionZoomFlipX();
     newScene->initWithDuration(t, s, o);
     newScene->autorelease();
 
@@ -1078,7 +1078,7 @@ void TransitionZoomFlipY::onEnter()
 
 TransitionZoomFlipY* TransitionZoomFlipY::create(float t, Scene* s, Orientation o)
 {
-    TransitionZoomFlipY* newScene = new TransitionZoomFlipY();
+    TransitionZoomFlipY* newScene = new (std::nothrow) TransitionZoomFlipY();
     newScene->initWithDuration(t, s, o);
     newScene->autorelease();
 
@@ -1159,7 +1159,7 @@ void TransitionZoomFlipAngular::onEnter()
 
 TransitionZoomFlipAngular* TransitionZoomFlipAngular::create(float t, Scene* s, Orientation o)
 {
-    TransitionZoomFlipAngular* newScene = new TransitionZoomFlipAngular();
+    TransitionZoomFlipAngular* newScene = new (std::nothrow) TransitionZoomFlipAngular();
     newScene->initWithDuration(t, s, o);
     newScene->autorelease();
 
@@ -1183,7 +1183,7 @@ TransitionFade::~TransitionFade()
 
 TransitionFade * TransitionFade::create(float duration, Scene *scene, const Color3B& color)
 {
-    TransitionFade * transition = new TransitionFade();
+    TransitionFade * transition = new (std::nothrow) TransitionFade();
     transition->initWithDuration(duration, scene, color);
     transition->autorelease();
     return transition;
@@ -1252,7 +1252,7 @@ TransitionCrossFade::~TransitionCrossFade()
 
 TransitionCrossFade* TransitionCrossFade::create(float t, Scene* scene)
 {
-    TransitionCrossFade* newScene = new TransitionCrossFade();
+    TransitionCrossFade* newScene = new (std::nothrow) TransitionCrossFade();
     if(newScene && newScene->initWithDuration(t, scene))
     {
         newScene->autorelease();
@@ -1363,7 +1363,7 @@ TransitionTurnOffTiles::~TransitionTurnOffTiles()
 
 TransitionTurnOffTiles* TransitionTurnOffTiles::create(float t, Scene* scene)
 {
-    TransitionTurnOffTiles* newScene = new TransitionTurnOffTiles();
+    TransitionTurnOffTiles* newScene = new (std::nothrow) TransitionTurnOffTiles();
     if(newScene && newScene->initWithDuration(t, scene))
     {
         newScene->autorelease();
@@ -1448,7 +1448,7 @@ TransitionSplitCols::~TransitionSplitCols()
 
 TransitionSplitCols* TransitionSplitCols::create(float t, Scene* scene)
 {
-    TransitionSplitCols* newScene = new TransitionSplitCols();
+    TransitionSplitCols* newScene = new (std::nothrow) TransitionSplitCols();
     if(newScene && newScene->initWithDuration(t, scene))
     {
         newScene->autorelease();
@@ -1534,7 +1534,7 @@ ActionInterval* TransitionSplitRows::action()
 
 TransitionSplitRows* TransitionSplitRows::create(float t, Scene* scene)
 {
-    TransitionSplitRows* newScene = new TransitionSplitRows();
+    TransitionSplitRows* newScene = new (std::nothrow) TransitionSplitRows();
     if(newScene && newScene->initWithDuration(t, scene))
     {
         newScene->autorelease();
@@ -1559,7 +1559,7 @@ TransitionFadeTR::~TransitionFadeTR()
 
 TransitionFadeTR* TransitionFadeTR::create(float t, Scene* scene)
 {
-    TransitionFadeTR* newScene = new TransitionFadeTR();
+    TransitionFadeTR* newScene = new (std::nothrow) TransitionFadeTR();
     if(newScene && newScene->initWithDuration(t, scene))
     {
         newScene->autorelease();
@@ -1647,7 +1647,7 @@ TransitionFadeBL::~TransitionFadeBL()
 
 TransitionFadeBL* TransitionFadeBL::create(float t, Scene* scene)
 {
-    TransitionFadeBL* newScene = new TransitionFadeBL();
+    TransitionFadeBL* newScene = new (std::nothrow) TransitionFadeBL();
     if(newScene && newScene->initWithDuration(t, scene))
     {
         newScene->autorelease();
@@ -1675,7 +1675,7 @@ TransitionFadeUp::~TransitionFadeUp()
 
 TransitionFadeUp* TransitionFadeUp::create(float t, Scene* scene)
 {
-    TransitionFadeUp* newScene = new TransitionFadeUp();
+    TransitionFadeUp* newScene = new (std::nothrow) TransitionFadeUp();
     if(newScene && newScene->initWithDuration(t, scene))
     {
         newScene->autorelease();
@@ -1702,7 +1702,7 @@ TransitionFadeDown::~TransitionFadeDown()
 
 TransitionFadeDown* TransitionFadeDown::create(float t, Scene* scene)
 {
-    TransitionFadeDown* newScene = new TransitionFadeDown();
+    TransitionFadeDown* newScene = new (std::nothrow) TransitionFadeDown();
     if(newScene && newScene->initWithDuration(t, scene))
     {
         newScene->autorelease();

--- a/cocos/2d/CCTransitionPageTurn.cpp
+++ b/cocos/2d/CCTransitionPageTurn.cpp
@@ -53,7 +53,7 @@ TransitionPageTurn::~TransitionPageTurn()
 /** creates a base transition with duration and incoming scene */
 TransitionPageTurn * TransitionPageTurn::create(float t, Scene *scene, bool backwards)
 {
-    TransitionPageTurn * transition = new TransitionPageTurn();
+    TransitionPageTurn * transition = new (std::nothrow) TransitionPageTurn();
     transition->initWithDuration(t,scene,backwards);
     transition->autorelease();
     return transition;

--- a/cocos/2d/CCTransitionProgress.cpp
+++ b/cocos/2d/CCTransitionProgress.cpp
@@ -49,7 +49,7 @@ TransitionProgress::TransitionProgress()
 
 TransitionProgress* TransitionProgress::create(float t, Scene* scene)
 {
-    TransitionProgress* newScene = new TransitionProgress();
+    TransitionProgress* newScene = new (std::nothrow) TransitionProgress();
     if(newScene && newScene->initWithDuration(t, scene))
     {
         newScene->autorelease();
@@ -152,7 +152,7 @@ ProgressTimer* TransitionProgressRadialCCW::progressTimerNodeWithRenderTexture(R
 
 TransitionProgressRadialCCW* TransitionProgressRadialCCW::create(float t, Scene* scene)
 {
-    TransitionProgressRadialCCW* newScene = new TransitionProgressRadialCCW();
+    TransitionProgressRadialCCW* newScene = new (std::nothrow) TransitionProgressRadialCCW();
     if(newScene && newScene->initWithDuration(t, scene))
     {
         newScene->autorelease();
@@ -165,7 +165,7 @@ TransitionProgressRadialCCW* TransitionProgressRadialCCW::create(float t, Scene*
 // TransitionProgressRadialCW
 TransitionProgressRadialCW* TransitionProgressRadialCW::create(float t, Scene* scene)
 {
-    TransitionProgressRadialCW* newScene = new TransitionProgressRadialCW();
+    TransitionProgressRadialCW* newScene = new (std::nothrow) TransitionProgressRadialCW();
     if(newScene && newScene->initWithDuration(t, scene))
     {
         newScene->autorelease();
@@ -197,7 +197,7 @@ ProgressTimer* TransitionProgressRadialCW::progressTimerNodeWithRenderTexture(Re
 // TransitionProgressHorizontal
 TransitionProgressHorizontal* TransitionProgressHorizontal::create(float t, Scene* scene)
 {
-    TransitionProgressHorizontal* newScene = new TransitionProgressHorizontal();
+    TransitionProgressHorizontal* newScene = new (std::nothrow) TransitionProgressHorizontal();
     if(newScene && newScene->initWithDuration(t, scene))
     {
         newScene->autorelease();
@@ -230,7 +230,7 @@ ProgressTimer* TransitionProgressHorizontal::progressTimerNodeWithRenderTexture(
 // TransitionProgressVertical
 TransitionProgressVertical* TransitionProgressVertical::create(float t, Scene* scene)
 {
-    TransitionProgressVertical* newScene = new TransitionProgressVertical();
+    TransitionProgressVertical* newScene = new (std::nothrow) TransitionProgressVertical();
     if(newScene && newScene->initWithDuration(t, scene))
     {
         newScene->autorelease();
@@ -264,7 +264,7 @@ ProgressTimer* TransitionProgressVertical::progressTimerNodeWithRenderTexture(Re
 // TransitionProgressInOut
 TransitionProgressInOut* TransitionProgressInOut::create(float t, Scene* scene)
 {
-    TransitionProgressInOut* newScene = new TransitionProgressInOut();
+    TransitionProgressInOut* newScene = new (std::nothrow) TransitionProgressInOut();
     if(newScene && newScene->initWithDuration(t, scene))
     {
         newScene->autorelease();
@@ -310,7 +310,7 @@ ProgressTimer* TransitionProgressInOut::progressTimerNodeWithRenderTexture(Rende
 // TransitionProgressOutIn
 TransitionProgressOutIn* TransitionProgressOutIn::create(float t, Scene* scene)
 {
-    TransitionProgressOutIn* newScene = new TransitionProgressOutIn();
+    TransitionProgressOutIn* newScene = new (std::nothrow) TransitionProgressOutIn();
     if(newScene && newScene->initWithDuration(t, scene))
     {
         newScene->autorelease();

--- a/cocos/3d/CCAnimate3D.cpp
+++ b/cocos/3d/CCAnimate3D.cpp
@@ -36,7 +36,7 @@ NS_CC_BEGIN
 //create Animate3D using Animation.
 Animate3D* Animate3D::create(Animation3D* animation)
 {
-    auto animate = new Animate3D();
+    auto animate = new (std::nothrow) Animate3D();
     animate->_animation = animation;
     animation->retain();
     

--- a/cocos/3d/CCAnimation3D.cpp
+++ b/cocos/3d/CCAnimation3D.cpp
@@ -39,7 +39,7 @@ Animation3D* Animation3D::create(const std::string& fileName, const std::string&
         return animation;
     
     //load animation here
-    animation = new Animation3D();
+    animation = new (std::nothrow) Animation3D();
     auto bundle = Bundle3D::getInstance();
     Animation3DData animationdata;
     if (bundle->load(fullPath) && bundle->loadAnimationData(animationName, &animationdata) && animation->init(animationdata))
@@ -101,7 +101,7 @@ bool Animation3D::init(const Animation3DData &data)
         Curve* curve = _boneCurves[iter.first];
         if( curve == nullptr)
         {
-            curve = new Curve();
+            curve = new (std::nothrow) Curve();
             _boneCurves[iter.first] = curve;
         }
         
@@ -125,7 +125,7 @@ bool Animation3D::init(const Animation3DData &data)
         Curve* curve = _boneCurves[iter.first];
         if( curve == nullptr)
         {
-            curve = new Curve();
+            curve = new (std::nothrow) Curve();
             _boneCurves[iter.first] = curve;
         }
         
@@ -150,7 +150,7 @@ bool Animation3D::init(const Animation3DData &data)
         Curve* curve = _boneCurves[iter.first];
         if( curve == nullptr)
         {
-            curve = new Curve();
+            curve = new (std::nothrow) Curve();
             _boneCurves[iter.first] = curve;
         }
         
@@ -178,7 +178,7 @@ Animation3DCache* Animation3DCache::_cacheInstance = nullptr;
 Animation3DCache* Animation3DCache::getInstance()
 {
     if (_cacheInstance == nullptr)
-        _cacheInstance = new Animation3DCache();
+        _cacheInstance = new (std::nothrow) Animation3DCache();
     
     return _cacheInstance;
 }

--- a/cocos/3d/CCAnimationCurve.inl
+++ b/cocos/3d/CCAnimationCurve.inl
@@ -72,7 +72,7 @@ template <int componentSize>
 AnimationCurve<componentSize>* AnimationCurve<componentSize>::create(float* keytime, float* value, int count)
 {
     int floatSize = sizeof(float);
-    AnimationCurve* curve = new AnimationCurve();
+    AnimationCurve* curve = new (std::nothrow) AnimationCurve();
     curve->_keytime = new float[count];
     memcpy(curve->_keytime, keytime, count * floatSize);
     

--- a/cocos/3d/CCAttachNode.cpp
+++ b/cocos/3d/CCAttachNode.cpp
@@ -35,7 +35,7 @@ NS_CC_BEGIN
 
 AttachNode* AttachNode::create(Bone3D* attachBone)
 {
-    auto attachnode = new AttachNode();
+    auto attachnode = new (std::nothrow) AttachNode();
     attachnode->_attachBone = attachBone;
     attachnode->autorelease();
     

--- a/cocos/3d/CCBundle3D.cpp
+++ b/cocos/3d/CCBundle3D.cpp
@@ -157,7 +157,7 @@ void Bundle3D::setBundleInstance(Bundle3D* bundleInstance)
 Bundle3D* Bundle3D::getInstance()
 {
     if (_instance == nullptr)
-        _instance = new Bundle3D();
+        _instance = new (std::nothrow) Bundle3D();
     return _instance;
 }
 
@@ -220,7 +220,7 @@ bool Bundle3D::loadObj(MeshDatas& meshdatas, MaterialDatas& materialdatas, NodeD
     if (ret.empty())
     {
         //fill data
-        MeshData* meshdata = new MeshData();
+        MeshData* meshdata = new (std::nothrow) MeshData();
         MeshVertexAttrib attrib;
         attrib.size = 3;
         attrib.type = GL_FLOAT;
@@ -292,8 +292,8 @@ bool Bundle3D::loadObj(MeshDatas& meshdatas, MaterialDatas& materialdatas, NodeD
 
             meshdata->subMeshIndices.push_back(it.mesh.indices);
             meshdata->subMeshIds.push_back(str);
-            auto node = new NodeData();
-            auto modelnode = new ModelData();
+            auto node = new (std::nothrow) NodeData();
+            auto modelnode = new (std::nothrow) ModelData();
             modelnode->matrialId = str;
             modelnode->subMeshId = str;
             node->id = it.name;
@@ -410,7 +410,7 @@ bool  Bundle3D::loadMeshDatasBinary(MeshDatas& meshdatas)
     }
     for(int i = 0; i < meshSize ; i++ )
     {
-        MeshData*   meshData = new MeshData();
+        MeshData*   meshData = new (std::nothrow) MeshData();
          unsigned int attribSize=0;
         // read mesh data
         if (_binaryReader.read(&attribSize, 4, 1) != 1 || attribSize < 1)
@@ -486,7 +486,7 @@ bool Bundle3D::loadMeshDatasBinary_0_1(MeshDatas& meshdatas)
 
     meshdatas.resetData();
 
-    MeshData* meshdata = new MeshData();
+    MeshData* meshdata = new (std::nothrow) MeshData();
 
     // read mesh data
     unsigned int attribSize=0;
@@ -594,7 +594,7 @@ bool Bundle3D::loadMeshDatasBinary_0_2(MeshDatas& meshdatas)
 
     meshdatas.resetData();
 
-    MeshData* meshdata = new MeshData();
+    MeshData* meshdata = new (std::nothrow) MeshData();
 
     // read mesh data
     unsigned int attribSize=0;
@@ -706,7 +706,7 @@ bool  Bundle3D::loadMeshDatasJson(MeshDatas& meshdatas)
     const rapidjson::Value& mesh_data_array = _jsonReader[MESHES];
     for (rapidjson::SizeType index = 0; index < mesh_data_array.Size(); index++)
     {
-        MeshData*   meshData = new MeshData();
+        MeshData*   meshData = new (std::nothrow) MeshData();
         const rapidjson::Value& mesh_data = mesh_data_array[index];
         // mesh_vertex_attribute
         const rapidjson::Value& mesh_vertex_attribute = mesh_data[ATTRIBUTES];
@@ -761,19 +761,19 @@ bool Bundle3D::loadNodes(NodeDatas& nodedatas)
     {
         SkinData   skinData;
         loadSkinData("", &skinData);
-        auto nodeDatas = new NodeData*[skinData.skinBoneNames.size() + skinData.nodeBoneNames.size()];
+        auto nodeDatas = new (std::nothrow) NodeData*[skinData.skinBoneNames.size() + skinData.nodeBoneNames.size()];
         int index = 0;
         size_t i;
         for (i = 0; i < skinData.skinBoneNames.size(); i++)
         {
-            nodeDatas[index] = new NodeData();
+            nodeDatas[index] = new (std::nothrow) NodeData();
             nodeDatas[index]->id = skinData.skinBoneNames[i];
             nodeDatas[index]->transform = skinData.skinBoneOriginMatrices[i];
             index++;
         }
         for (i = 0; i < skinData.nodeBoneNames.size(); i++)
         {
-            nodeDatas[index] = new NodeData();
+            nodeDatas[index] = new (std::nothrow) NodeData();
             nodeDatas[index]->id = skinData.nodeBoneNames[i];
             nodeDatas[index]->transform = skinData.nodeBoneOriginMatrices[i];
             index++;
@@ -788,8 +788,8 @@ bool Bundle3D::loadNodes(NodeDatas& nodedatas)
             }
         }
         nodedatas.skeleton.push_back(nodeDatas[skinData.rootBoneIndex]);
-        auto node= new NodeData();
-        auto modelnode = new ModelData();
+        auto node= new (std::nothrow) NodeData();
+        auto modelnode = new (std::nothrow) ModelData();
         modelnode->matrialId = "";
         modelnode->subMeshId = "";
         modelnode->bones = skinData.skinBoneNames;
@@ -1246,7 +1246,7 @@ bool Bundle3D::loadBinary(const std::string& path)
 
     // get file data
     CC_SAFE_DELETE(_binaryBuffer);
-    _binaryBuffer = new Data();
+    _binaryBuffer = new (std::nothrow) Data();
     *_binaryBuffer = FileUtils::getInstance()->getDataFromFile(path);
     if (_binaryBuffer->isNull()) 
     {
@@ -1289,7 +1289,7 @@ bool Bundle3D::loadBinary(const std::string& path)
 
     // Read all refs
     CC_SAFE_DELETE_ARRAY(_references);
-    _references = new Reference[_referenceCount];
+    _references = new (std::nothrow) Reference[_referenceCount];
     for (ssize_t i = 0; i < _referenceCount; ++i)
     {
         if ((_references[i].id = _binaryReader.readString()).empty() ||
@@ -1696,11 +1696,11 @@ bool Bundle3D::loadNodesJson(NodeDatas& nodedatas)
 }
 NodeData* Bundle3D::parseNodesRecursivelyJson(const rapidjson::Value& jvalue)
 {
-    NodeData* nodedata = new NodeData();;
+    NodeData* nodedata = new (std::nothrow) NodeData();;
     //if (jvalue.HasMember(PARTS))
-       // nodedata = new ModelNodeData();
+       // nodedata = new (std::nothrow) ModelNodeData();
     //else
-     //nodedata = new NodeData();
+     //nodedata = new (std::nothrow) NodeData();
 
     // id
     nodedata->id = jvalue[ID].GetString();
@@ -1724,7 +1724,7 @@ NodeData* Bundle3D::parseNodesRecursivelyJson(const rapidjson::Value& jvalue)
 
         for (rapidjson::SizeType i = 0; i < parts.Size(); i++)
         {
-            auto modelnodedata = new ModelData();;
+            auto modelnodedata = new (std::nothrow) ModelData();;
             const rapidjson::Value& part = parts[i];
             modelnodedata->subMeshId = part[MESHPARTID].GetString();
             modelnodedata->matrialId = part[MATERIALID].GetString();
@@ -1837,14 +1837,14 @@ NodeData* Bundle3D::parseNodesRecursivelyBinary(bool& skeleton)
         return nullptr;
     }
 
-    NodeData* nodedata = new NodeData();
+    NodeData* nodedata = new (std::nothrow) NodeData();
     nodedata->id = id;
     nodedata->transform = transform;
     if (partsSize > 0)
     {
         for (rapidjson::SizeType i = 0; i < partsSize; i++)
         {
-            auto modelnodedata  = new ModelData();
+            auto modelnodedata  = new (std::nothrow) ModelData();
             modelnodedata->subMeshId = _binaryReader.readString();
             modelnodedata->matrialId = _binaryReader.readString();
 
@@ -1907,7 +1907,7 @@ NodeData* Bundle3D::parseNodesRecursivelyBinary(bool& skeleton)
     }
     //else
     //{
-    //    nodedata = new NodeData();
+    //    nodedata = new (std::nothrow) NodeData();
     //    nodedata->id = id;
     //    nodedata->transform = transform;
     //}

--- a/cocos/3d/CCMesh.cpp
+++ b/cocos/3d/CCMesh.cpp
@@ -166,7 +166,7 @@ Mesh* Mesh::create(const std::vector<float>& vertices, int perVertexSizeInFloat,
 
 Mesh* Mesh::create(const std::string& name, MeshIndexData* indexData, MeshSkin* skin)
 {
-    auto state = new Mesh();
+    auto state = new (std::nothrow) Mesh();
     state->autorelease();
     state->bindMeshCommand();
     state->_name = name;

--- a/cocos/3d/CCMeshSkin.cpp
+++ b/cocos/3d/CCMeshSkin.cpp
@@ -50,7 +50,7 @@ MeshSkin::~MeshSkin()
 
 MeshSkin* MeshSkin::create(Skeleton3D* skeleton, const std::vector<std::string>& boneNames, const std::vector<Mat4>& invBindPose)
 {
-    auto skin = new MeshSkin();
+    auto skin = new (std::nothrow) MeshSkin();
     skin->_skeleton = skeleton;
     skeleton->retain();
     
@@ -104,7 +104,7 @@ Vec4* MeshSkin::getMatrixPalette()
 {
     if (_matrixPalette == nullptr)
     {
-        _matrixPalette = new Vec4[_skinBones.size() * PALETTE_ROWS];
+        _matrixPalette = new (std::nothrow) Vec4[_skinBones.size() * PALETTE_ROWS];
     }
     int i = 0, paletteIndex = 0;
     static Mat4 t;

--- a/cocos/3d/CCMeshVertexIndexData.cpp
+++ b/cocos/3d/CCMeshVertexIndexData.cpp
@@ -49,7 +49,7 @@ NS_CC_BEGIN
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////
 MeshIndexData* MeshIndexData::create(const std::string& id, MeshVertexData* vertexData, IndexBuffer* indexbuffer, const AABB& aabb)
 {
-    auto meshindex = new MeshIndexData();
+    auto meshindex = new (std::nothrow) MeshIndexData();
     
     meshindex->_id = id;
     meshindex->_indexBuffer = indexbuffer;
@@ -82,7 +82,7 @@ MeshIndexData::~MeshIndexData()
 
 MeshVertexData* MeshVertexData::create(const MeshData& meshdata)
 {
-    auto vertexdata = new MeshVertexData();
+    auto vertexdata = new (std::nothrow) MeshVertexData();
     int pervertexsize = meshdata.getPerVertexSize();
     vertexdata->_vertexBuffer = VertexBuffer::create(pervertexsize, (int)(meshdata.vertex.size() / (pervertexsize / 4)));
     vertexdata->_vertexData = VertexData::create();

--- a/cocos/3d/CCSkeleton3D.cpp
+++ b/cocos/3d/CCSkeleton3D.cpp
@@ -137,7 +137,7 @@ void Bone3D::clearBoneBlendState()
  */
 Bone3D* Bone3D::create(const std::string& id)
 {
-    auto bone = new Bone3D(id);
+    auto bone = new (std::nothrow) Bone3D(id);
     bone->autorelease();
     return bone;
 }
@@ -260,7 +260,7 @@ Skeleton3D::~Skeleton3D()
 
 Skeleton3D* Skeleton3D::create(const std::vector<NodeData*>& skeletondata)
 {
-    auto skeleton = new Skeleton3D();
+    auto skeleton = new (std::nothrow) Skeleton3D();
     for (const auto& it : skeletondata) {
         auto bone = skeleton->createBone3D(*it);
         bone->resetPose();

--- a/cocos/3d/CCSprite3D.cpp
+++ b/cocos/3d/CCSprite3D.cpp
@@ -50,7 +50,7 @@ Sprite3D* Sprite3D::create(const std::string &modelPath)
     if (modelPath.length() < 4)
         CCASSERT(false, "improper name specified when creating Sprite3D");
     
-    auto sprite = new Sprite3D();
+    auto sprite = new (std::nothrow) Sprite3D();
     if (sprite && sprite->initWithFile(modelPath))
     {
         sprite->autorelease();
@@ -102,13 +102,13 @@ bool Sprite3D::loadFromObj(const std::string& path)
     std::string fullPath = FileUtils::getInstance()->fullPathForFilename(path);
     
     MeshDatas meshdatas;
-    MaterialDatas* materialdatas = new MaterialDatas();
-    NodeDatas*   nodeDatas = new NodeDatas();
+    MaterialDatas* materialdatas = new (std::nothrow) MaterialDatas();
+    NodeDatas*   nodeDatas = new (std::nothrow) NodeDatas();
     bool ret = Bundle3D::loadObj(meshdatas, *materialdatas, *nodeDatas, fullPath);
     if (ret && initFrom(*nodeDatas, meshdatas, *materialdatas))
     {
         //add to cache
-        auto data = new Sprite3DCache::Sprite3DData();
+        auto data = new (std::nothrow) Sprite3DCache::Sprite3DData();
         data->materialdatas = materialdatas;
         data->nodedatas = nodeDatas;
         data->meshVertexDatas = _meshVertexDatas;
@@ -130,15 +130,15 @@ bool Sprite3D::loadFromC3x(const std::string& path)
         return false;
     
     MeshDatas meshdatas;
-    MaterialDatas* materialdatas = new MaterialDatas();
-    NodeDatas*   nodeDatas = new NodeDatas();
+    MaterialDatas* materialdatas = new (std::nothrow) MaterialDatas();
+    NodeDatas*   nodeDatas = new (std::nothrow) NodeDatas();
     if (bundle->loadMeshDatas(meshdatas)
         && bundle->loadMaterials(*materialdatas)
         && bundle->loadNodes(*nodeDatas)
         && initFrom(*nodeDatas, meshdatas, *materialdatas))
     {
         //add to cache
-        auto data = new Sprite3DCache::Sprite3DData();
+        auto data = new (std::nothrow) Sprite3DCache::Sprite3DData();
         data->materialdatas = materialdatas;
         data->nodedatas = nodeDatas;
         data->meshVertexDatas = _meshVertexDatas;
@@ -228,7 +228,7 @@ bool Sprite3D::initFrom(const NodeDatas& nodeDatas, const MeshDatas& meshdatas, 
 }
 Sprite3D* Sprite3D::createSprite3DNode(NodeData* nodedata,ModelData* modeldata,const MaterialDatas& matrialdatas)
 {
-    auto sprite = new Sprite3D();
+    auto sprite = new (std::nothrow) Sprite3D();
     if (sprite)
     {
         auto mesh = Mesh::create(nodedata->id, getMeshIndexData(modeldata->subMeshId));
@@ -617,7 +617,7 @@ Sprite3DCache* Sprite3DCache::_cacheInstance = nullptr;
 Sprite3DCache* Sprite3DCache::getInstance()
 {
     if (_cacheInstance == nullptr)
-        _cacheInstance = new Sprite3DCache();
+        _cacheInstance = new (std::nothrow) Sprite3DCache();
     return _cacheInstance;
 }
 void Sprite3DCache::destroyInstance()

--- a/cocos/3d/CCSprite3DMaterial.cpp
+++ b/cocos/3d/CCSprite3DMaterial.cpp
@@ -50,7 +50,7 @@ Sprite3DMaterialCache* Sprite3DMaterialCache::getInstance()
 {
     if (! _cacheInstance)
     {
-        _cacheInstance = new Sprite3DMaterialCache();
+        _cacheInstance = new (std::nothrow) Sprite3DMaterialCache();
     }
     
     return _cacheInstance;

--- a/cocos/audio/ios/SimpleAudioEngine.mm
+++ b/cocos/audio/ios/SimpleAudioEngine.mm
@@ -157,7 +157,7 @@ SimpleAudioEngine* SimpleAudioEngine::getInstance()
 {
     if (! s_pEngine)
     {
-        s_pEngine = new SimpleAudioEngine();
+        s_pEngine = new (std::nothrow) SimpleAudioEngine();
     }
     
     return s_pEngine;

--- a/cocos/audio/mac/SimpleAudioEngine.mm
+++ b/cocos/audio/mac/SimpleAudioEngine.mm
@@ -159,7 +159,7 @@ SimpleAudioEngine* SimpleAudioEngine::getInstance()
 {
     if (! s_pEngine)
     {
-        s_pEngine = new SimpleAudioEngine();
+        s_pEngine = new (std::nothrow) SimpleAudioEngine();
     }
     
     return s_pEngine;

--- a/cocos/base/CCAutoreleasePool.cpp
+++ b/cocos/base/CCAutoreleasePool.cpp
@@ -109,7 +109,7 @@ PoolManager* PoolManager::getInstance()
 {
     if (s_singleInstance == nullptr)
     {
-        s_singleInstance = new PoolManager();
+        s_singleInstance = new (std::nothrow) PoolManager();
         // Add the first auto release pool
         new AutoreleasePool("cocos2d autorelease pool");
     }

--- a/cocos/base/CCCamera.cpp
+++ b/cocos/base/CCCamera.cpp
@@ -33,7 +33,7 @@ Camera* Camera::_visitingCamera = nullptr;
 
 Camera* Camera::create()
 {
-    Camera* camera = new Camera();
+    Camera* camera = new (std::nothrow) Camera();
     camera->initDefault();
     camera->autorelease();
     
@@ -42,7 +42,7 @@ Camera* Camera::create()
 
 Camera* Camera::createPerspective(float fieldOfView, float aspectRatio, float nearPlane, float farPlane)
 {
-    auto ret = new Camera();
+    auto ret = new (std::nothrow) Camera();
     if (ret)
     {
         ret->initPerspective(fieldOfView, aspectRatio, nearPlane, farPlane);
@@ -55,7 +55,7 @@ Camera* Camera::createPerspective(float fieldOfView, float aspectRatio, float ne
 
 Camera* Camera::createOrthographic(float zoomX, float zoomY, float nearPlane, float farPlane)
 {
-    auto ret = new Camera();
+    auto ret = new (std::nothrow) Camera();
     if (ret)
     {
         ret->initOrthographic(zoomX, zoomY, nearPlane, farPlane);

--- a/cocos/base/CCConfiguration.cpp
+++ b/cocos/base/CCConfiguration.cpp
@@ -149,7 +149,7 @@ Configuration* Configuration::getInstance()
 {
     if (! s_sharedConfiguration)
     {
-        s_sharedConfiguration = new Configuration();
+        s_sharedConfiguration = new (std::nothrow) Configuration();
         s_sharedConfiguration->init();
     }
     

--- a/cocos/base/CCController-iOS.mm
+++ b/cocos/base/CCController-iOS.mm
@@ -120,7 +120,7 @@ void Controller::startDiscoveryController()
     
     [[GCControllerConnectionEventHandler getInstance] observerConnection: ^(GCController* gcController) {
         
-        auto controller = new Controller();
+        auto controller = new (std::nothrow) Controller();
         controller->_impl->_gcController = gcController;
         controller->_deviceName = [gcController.vendorName UTF8String];
         

--- a/cocos/base/CCController.cpp
+++ b/cocos/base/CCController.cpp
@@ -61,9 +61,9 @@ void Controller::init()
     }
 
     _eventDispatcher = Director::getInstance()->getEventDispatcher();
-    _connectEvent = new EventController(EventController::ControllerEventType::CONNECTION, this, false);
-    _keyEvent = new EventController(EventController::ControllerEventType::BUTTON_STATUS_CHANGED, this, 0);
-    _axisEvent = new EventController(EventController::ControllerEventType::AXIS_STATUS_CHANGED, this, 0);
+    _connectEvent = new (std::nothrow) EventController(EventController::ControllerEventType::CONNECTION, this, false);
+    _keyEvent = new (std::nothrow) EventController(EventController::ControllerEventType::BUTTON_STATUS_CHANGED, this, 0);
+    _axisEvent = new (std::nothrow) EventController(EventController::ControllerEventType::AXIS_STATUS_CHANGED, this, 0);
 }
 
 const Controller::KeyStatus& Controller::getKeyStatus(int keyCode)

--- a/cocos/base/CCDirector.cpp
+++ b/cocos/base/CCDirector.cpp
@@ -137,19 +137,19 @@ bool Director::init(void)
     _contentScaleFactor = 1.0f;
 
     // scheduler
-    _scheduler = new Scheduler();
+    _scheduler = new (std::nothrow) Scheduler();
     // action manager
-    _actionManager = new ActionManager();
+    _actionManager = new (std::nothrow) ActionManager();
     _scheduler->scheduleUpdate(_actionManager, Scheduler::PRIORITY_SYSTEM, false);
 
-    _eventDispatcher = new EventDispatcher();
-    _eventAfterDraw = new EventCustom(EVENT_AFTER_DRAW);
+    _eventDispatcher = new (std::nothrow) EventDispatcher();
+    _eventAfterDraw = new (std::nothrow) EventCustom(EVENT_AFTER_DRAW);
     _eventAfterDraw->setUserData(this);
-    _eventAfterVisit = new EventCustom(EVENT_AFTER_VISIT);
+    _eventAfterVisit = new (std::nothrow) EventCustom(EVENT_AFTER_VISIT);
     _eventAfterVisit->setUserData(this);
-    _eventAfterUpdate = new EventCustom(EVENT_AFTER_UPDATE);
+    _eventAfterUpdate = new (std::nothrow) EventCustom(EVENT_AFTER_UPDATE);
     _eventAfterUpdate->setUserData(this);
-    _eventProjectionChanged = new EventCustom(EVENT_PROJECTION_CHANGED);
+    _eventProjectionChanged = new (std::nothrow) EventCustom(EVENT_PROJECTION_CHANGED);
     _eventProjectionChanged->setUserData(this);
 
 
@@ -157,10 +157,10 @@ bool Director::init(void)
     initTextureCache();
     initMatrixStack();
 
-    _renderer = new Renderer;
+    _renderer = new (std::nothrow) Renderer;
 
 #if (CC_TARGET_PLATFORM != CC_PLATFORM_WINRT)
-    _console = new Console;
+    _console = new (std::nothrow) Console;
 #endif
     return true;
 }
@@ -438,9 +438,9 @@ TextureCache* Director::getTextureCache() const
 void Director::initTextureCache()
 {
 #ifdef EMSCRIPTEN
-    _textureCache = new TextureCacheEmscripten();
+    _textureCache = new (std::nothrow) TextureCacheEmscripten();
 #else
-    _textureCache = new TextureCache();
+    _textureCache = new (std::nothrow) TextureCache();
 #endif // EMSCRIPTEN
 }
 
@@ -1188,7 +1188,7 @@ void Director::createStatsLabel()
     ssize_t dataLength = 0;
     getFPSImageData(&data, &dataLength);
 
-    Image* image = new Image();
+    Image* image = new (std::nothrow) Image();
     bool isOK = image->initWithImageData(data, dataLength);
     if (! isOK) {
         CCLOGERROR("%s", "Fails: init fps_images");

--- a/cocos/base/CCEventDispatcher.cpp
+++ b/cocos/base/CCEventDispatcher.cpp
@@ -461,7 +461,7 @@ void EventDispatcher::forceAddEventListener(EventListener* listener)
     if (itr == _listenerMap.end())
     {
         
-        listeners = new EventListenerVector();
+        listeners = new (std::nothrow) EventListenerVector();
         _listenerMap.insert(std::make_pair(listenerID, listeners));
     }
     else

--- a/cocos/base/CCEventListenerAcceleration.cpp
+++ b/cocos/base/CCEventListenerAcceleration.cpp
@@ -41,7 +41,7 @@ EventListenerAcceleration::~EventListenerAcceleration()
 
 EventListenerAcceleration* EventListenerAcceleration::create(const std::function<void(Acceleration*, Event*)>& callback)
 {
-    EventListenerAcceleration* ret = new EventListenerAcceleration();
+    EventListenerAcceleration* ret = new (std::nothrow) EventListenerAcceleration();
     if (ret && ret->init(callback))
     {
         ret->autorelease();
@@ -72,7 +72,7 @@ bool EventListenerAcceleration::init(const std::function<void(Acceleration*, Eve
 
 EventListenerAcceleration* EventListenerAcceleration::clone()
 {
-    auto ret = new EventListenerAcceleration();
+    auto ret = new (std::nothrow) EventListenerAcceleration();
     
     if (ret && ret->init(onAccelerationEvent))
     {

--- a/cocos/base/CCEventListenerController.cpp
+++ b/cocos/base/CCEventListenerController.cpp
@@ -34,7 +34,7 @@ const std::string EventListenerController::LISTENER_ID = "__cc_controller";
 
 EventListenerController* EventListenerController::create()
 {
-    auto ret = new EventListenerController();
+    auto ret = new (std::nothrow) EventListenerController();
     if (ret && ret->init())
     {
         ret->autorelease();

--- a/cocos/base/CCEventListenerCustom.cpp
+++ b/cocos/base/CCEventListenerCustom.cpp
@@ -34,7 +34,7 @@ EventListenerCustom::EventListenerCustom()
 
 EventListenerCustom* EventListenerCustom::create(const std::string& eventName, const std::function<void(EventCustom*)>& callback)
 {
-    EventListenerCustom* ret = new EventListenerCustom();
+    EventListenerCustom* ret = new (std::nothrow) EventListenerCustom();
     if (ret && ret->init(eventName, callback))
     {
         ret->autorelease();
@@ -68,7 +68,7 @@ bool EventListenerCustom::init(const ListenerID& listenerId, const std::function
 
 EventListenerCustom* EventListenerCustom::clone()
 {
-    EventListenerCustom* ret = new EventListenerCustom();
+    EventListenerCustom* ret = new (std::nothrow) EventListenerCustom();
     if (ret && ret->init(_listenerID, _onCustomEvent))
     {
         ret->autorelease();

--- a/cocos/base/CCEventListenerFocus.cpp
+++ b/cocos/base/CCEventListenerFocus.cpp
@@ -46,7 +46,7 @@ EventListenerFocus::~EventListenerFocus()
 
 EventListenerFocus* EventListenerFocus::create()
 {
-    EventListenerFocus* ret = new EventListenerFocus;
+    EventListenerFocus* ret = new (std::nothrow) EventListenerFocus;
     if (ret && ret->init()) {
         ret->autorelease();
         return ret;
@@ -57,7 +57,7 @@ EventListenerFocus* EventListenerFocus::create()
 
 EventListenerFocus* EventListenerFocus::clone()
 {
-    EventListenerFocus* ret = new EventListenerFocus;
+    EventListenerFocus* ret = new (std::nothrow) EventListenerFocus;
     if (ret && ret->init()) {
         ret->autorelease();
         

--- a/cocos/base/CCEventListenerKeyboard.cpp
+++ b/cocos/base/CCEventListenerKeyboard.cpp
@@ -44,7 +44,7 @@ bool EventListenerKeyboard::checkAvailable()
 
 EventListenerKeyboard* EventListenerKeyboard::create()
 {
-    auto ret = new EventListenerKeyboard();
+    auto ret = new (std::nothrow) EventListenerKeyboard();
     if (ret && ret->init())
     {
         ret->autorelease();
@@ -58,7 +58,7 @@ EventListenerKeyboard* EventListenerKeyboard::create()
 
 EventListenerKeyboard* EventListenerKeyboard::clone()
 {
-    auto ret = new EventListenerKeyboard();
+    auto ret = new (std::nothrow) EventListenerKeyboard();
     if (ret && ret->init())
     {
         ret->autorelease();

--- a/cocos/base/CCEventListenerMouse.cpp
+++ b/cocos/base/CCEventListenerMouse.cpp
@@ -36,7 +36,7 @@ bool EventListenerMouse::checkAvailable()
 
 EventListenerMouse* EventListenerMouse::create()
 {
-    auto ret = new EventListenerMouse();
+    auto ret = new (std::nothrow) EventListenerMouse();
     if (ret && ret->init())
     {
         ret->autorelease();
@@ -50,7 +50,7 @@ EventListenerMouse* EventListenerMouse::create()
 
 EventListenerMouse* EventListenerMouse::clone()
 {
-    auto ret = new EventListenerMouse();
+    auto ret = new (std::nothrow) EventListenerMouse();
     if (ret && ret->init())
     {
         ret->autorelease();

--- a/cocos/base/CCEventListenerTouch.cpp
+++ b/cocos/base/CCEventListenerTouch.cpp
@@ -68,7 +68,7 @@ bool EventListenerTouchOneByOne::isSwallowTouches()
 
 EventListenerTouchOneByOne* EventListenerTouchOneByOne::create()
 {
-    auto ret = new EventListenerTouchOneByOne();
+    auto ret = new (std::nothrow) EventListenerTouchOneByOne();
     if (ret && ret->init())
     {
         ret->autorelease();
@@ -95,7 +95,7 @@ bool EventListenerTouchOneByOne::checkAvailable()
 
 EventListenerTouchOneByOne* EventListenerTouchOneByOne::clone()
 {
-    auto ret = new EventListenerTouchOneByOne();
+    auto ret = new (std::nothrow) EventListenerTouchOneByOne();
     if (ret && ret->init())
     {
         ret->autorelease();
@@ -144,7 +144,7 @@ bool EventListenerTouchAllAtOnce::init()
 
 EventListenerTouchAllAtOnce* EventListenerTouchAllAtOnce::create()
 {
-    auto ret = new EventListenerTouchAllAtOnce();
+    auto ret = new (std::nothrow) EventListenerTouchAllAtOnce();
     if (ret && ret->init())
     {
         ret->autorelease();
@@ -170,7 +170,7 @@ bool EventListenerTouchAllAtOnce::checkAvailable()
 
 EventListenerTouchAllAtOnce* EventListenerTouchAllAtOnce::clone()
 {
-    auto ret = new EventListenerTouchAllAtOnce();
+    auto ret = new (std::nothrow) EventListenerTouchAllAtOnce();
     if (ret && ret->init())
     {
         ret->autorelease();

--- a/cocos/base/CCProfiling.cpp
+++ b/cocos/base/CCProfiling.cpp
@@ -44,7 +44,7 @@ Profiler* Profiler::getInstance()
 {
     if (! g_sSharedProfiler)
     {
-        g_sSharedProfiler = new Profiler();
+        g_sSharedProfiler = new (std::nothrow) Profiler();
         g_sSharedProfiler->init();
     }
 
@@ -59,7 +59,7 @@ Profiler* Profiler::sharedProfiler(void)
 
 ProfilingTimer* Profiler::createAndAddTimerWithName(const char* timerName)
 {
-    ProfilingTimer *t = new ProfilingTimer();
+    ProfilingTimer *t = new (std::nothrow) ProfilingTimer();
     t->initWithName(timerName);
     _activeTimers.insert(timerName, t);
     t->release();

--- a/cocos/base/CCScheduler.cpp
+++ b/cocos/base/CCScheduler.cpp
@@ -323,7 +323,7 @@ void Scheduler::schedule(const ccSchedulerFunc& callback, void *target, float in
         ccArrayEnsureExtraCapacity(element->timers, 1);
     }
 
-    TimerTargetCallback *timer = new TimerTargetCallback();
+    TimerTargetCallback *timer = new (std::nothrow) TimerTargetCallback();
     timer->initWithCallback(this, callback, target, key, interval, repeat, delay);
     ccArrayAppendObject(element->timers, timer);
     timer->release();
@@ -1023,7 +1023,7 @@ void Scheduler::schedule(SEL_SCHEDULE selector, Ref *target, float interval, uns
         ccArrayEnsureExtraCapacity(element->timers, 1);
     }
     
-    TimerTargetSelector *timer = new TimerTargetSelector();
+    TimerTargetSelector *timer = new (std::nothrow) TimerTargetSelector();
     timer->initWithSelector(this, selector, target, interval, repeat, delay);
     ccArrayAppendObject(element->timers, timer);
     timer->release();

--- a/cocos/base/CCScriptSupport.cpp
+++ b/cocos/base/CCScriptSupport.cpp
@@ -47,7 +47,7 @@ NS_CC_BEGIN
 
 ScriptHandlerEntry* ScriptHandlerEntry::create(int handler)
 {
-    ScriptHandlerEntry* entry = new ScriptHandlerEntry(handler);
+    ScriptHandlerEntry* entry = new (std::nothrow) ScriptHandlerEntry(handler);
     entry->autorelease();
     return entry;
 }
@@ -67,7 +67,7 @@ ScriptHandlerEntry::~ScriptHandlerEntry(void)
 
 SchedulerScriptHandlerEntry* SchedulerScriptHandlerEntry::create(int handler, float interval, bool paused)
 {
-    SchedulerScriptHandlerEntry* entry = new SchedulerScriptHandlerEntry(handler);
+    SchedulerScriptHandlerEntry* entry = new (std::nothrow) SchedulerScriptHandlerEntry(handler);
     entry->init(interval, paused);
     entry->autorelease();
     return entry;
@@ -75,7 +75,7 @@ SchedulerScriptHandlerEntry* SchedulerScriptHandlerEntry::create(int handler, fl
 
 bool SchedulerScriptHandlerEntry::init(float interval, bool paused)
 {
-    _timer = new TimerScriptHandler();
+    _timer = new (std::nothrow) TimerScriptHandler();
     _timer->initWithScriptHandler(_handler, interval);
     _paused = paused;
     LUALOG("[LUA] ADD script schedule: %d, entryID: %d", _handler, _entryId);
@@ -97,7 +97,7 @@ TouchScriptHandlerEntry* TouchScriptHandlerEntry::create(int handler,
                                                              int priority,
                                                              bool swallowsTouches)
 {
-    TouchScriptHandlerEntry* entry = new TouchScriptHandlerEntry(handler);
+    TouchScriptHandlerEntry* entry = new (std::nothrow) TouchScriptHandlerEntry(handler);
     entry->init(isMultiTouches, priority, swallowsTouches);
     entry->autorelease();
     return entry;
@@ -149,7 +149,7 @@ ScriptEngineManager* ScriptEngineManager::getInstance()
 {
     if (!s_pSharedScriptEngineManager)
     {
-        s_pSharedScriptEngineManager = new ScriptEngineManager();
+        s_pSharedScriptEngineManager = new (std::nothrow) ScriptEngineManager();
     }
     return s_pSharedScriptEngineManager;
 }

--- a/cocos/base/CCUserDefault.cpp
+++ b/cocos/base/CCUserDefault.cpp
@@ -417,7 +417,7 @@ UserDefault* UserDefault::getInstance()
 
     if (! _userDefault)
     {
-        _userDefault = new UserDefault();
+        _userDefault = new (std::nothrow) UserDefault();
     }
 
     return _userDefault;

--- a/cocos/base/CCUserDefault.mm
+++ b/cocos/base/CCUserDefault.mm
@@ -479,7 +479,7 @@ UserDefault* UserDefault::getInstance()
     
     if (! _userDefault)
     {
-        _userDefault = new UserDefault();
+        _userDefault = new (std::nothrow) UserDefault();
     }
     
     return _userDefault;

--- a/cocos/base/CCUserDefaultAndroid.cpp
+++ b/cocos/base/CCUserDefaultAndroid.cpp
@@ -482,7 +482,7 @@ UserDefault* UserDefault::getInstance()
     
     if (! _userDefault)
     {
-        _userDefault = new UserDefault();
+        _userDefault = new (std::nothrow) UserDefault();
     }
 
     return _userDefault;

--- a/cocos/base/CCValue.cpp
+++ b/cocos/base/CCValue.cpp
@@ -91,42 +91,42 @@ Value::Value(const std::string& v)
 Value::Value(const ValueVector& v)
 : _type(Type::VECTOR)
 {
-    _field.vectorVal = new ValueVector();
+    _field.vectorVal = new (std::nothrow) ValueVector();
     *_field.vectorVal = v;
 }
 
 Value::Value(ValueVector&& v)
 : _type(Type::VECTOR)
 {
-    _field.vectorVal = new ValueVector();
+    _field.vectorVal = new (std::nothrow) ValueVector();
     *_field.vectorVal = std::move(v);
 }
 
 Value::Value(const ValueMap& v)
 : _type(Type::MAP)
 {
-    _field.mapVal = new ValueMap();
+    _field.mapVal = new (std::nothrow) ValueMap();
     *_field.mapVal = v;
 }
 
 Value::Value(ValueMap&& v)
 : _type(Type::MAP)
 {
-    _field.mapVal = new ValueMap();
+    _field.mapVal = new (std::nothrow) ValueMap();
     *_field.mapVal = std::move(v);
 }
 
 Value::Value(const ValueMapIntKey& v)
 : _type(Type::INT_KEY_MAP)
 {
-    _field.intKeyMapVal = new ValueMapIntKey();
+    _field.intKeyMapVal = new (std::nothrow) ValueMapIntKey();
     *_field.intKeyMapVal = v;
 }
 
 Value::Value(ValueMapIntKey&& v)
 : _type(Type::INT_KEY_MAP)
 {
-    _field.intKeyMapVal = new ValueMapIntKey();
+    _field.intKeyMapVal = new (std::nothrow) ValueMapIntKey();
     *_field.intKeyMapVal = std::move(v);
 }
 
@@ -178,21 +178,21 @@ Value& Value::operator= (const Value& other)
             case Type::VECTOR:
                 if (_field.vectorVal == nullptr)
                 {
-                    _field.vectorVal = new ValueVector();
+                    _field.vectorVal = new (std::nothrow) ValueVector();
                 }
                 *_field.vectorVal = *other._field.vectorVal;
                 break;
             case Type::MAP:
                 if (_field.mapVal == nullptr)
                 {
-                    _field.mapVal = new ValueMap();
+                    _field.mapVal = new (std::nothrow) ValueMap();
                 }
                 *_field.mapVal = *other._field.mapVal;
                 break;
             case Type::INT_KEY_MAP:
                 if (_field.intKeyMapVal == nullptr)
                 {
-                    _field.intKeyMapVal = new ValueMapIntKey();
+                    _field.intKeyMapVal = new (std::nothrow) ValueMapIntKey();
                 }
                 *_field.intKeyMapVal = *other._field.intKeyMapVal;
                 break;
@@ -816,13 +816,13 @@ void Value::reset(Type type)
             _field.strVal = new std::string();
             break;
         case Type::VECTOR:
-            _field.vectorVal = new ValueVector();
+            _field.vectorVal = new (std::nothrow) ValueVector();
             break;
         case Type::MAP:
-            _field.mapVal = new ValueMap();
+            _field.mapVal = new (std::nothrow) ValueMap();
             break;
         case Type::INT_KEY_MAP:
-            _field.intKeyMapVal = new ValueMapIntKey();
+            _field.intKeyMapVal = new (std::nothrow) ValueMapIntKey();
             break;
         default:
             break;

--- a/cocos/base/ObjectFactory.cpp
+++ b/cocos/base/ObjectFactory.cpp
@@ -76,7 +76,7 @@ ObjectFactory* ObjectFactory::getInstance()
 {
     if ( nullptr == _sharedFactory)
     {
-        _sharedFactory = new ObjectFactory();
+        _sharedFactory = new (std::nothrow) ObjectFactory();
     }
     return _sharedFactory;
 }

--- a/cocos/deprecated/CCArray.h
+++ b/cocos/deprecated/CCArray.h
@@ -51,7 +51,7 @@ class RCPtr
 {
 public:
 	//Construct using a C pointer
-	//e.g. RCPtr< T > x = new T();
+	//e.g. RCPtr< T > x = new (std::nothrow) T();
 	RCPtr(T* ptr = nullptr)
     : _ptr(ptr)
 	{
@@ -81,7 +81,7 @@ public:
 	}
 
 	//Assign a pointer
-	//e.g. x = new T();
+	//e.g. x = new (std::nothrow) T();
 	RCPtr &operator=(T* ptr)
 	{
 //        printf("Array: operator= T*: %p\n", this);

--- a/cocos/deprecated/CCDictionary.cpp
+++ b/cocos/deprecated/CCDictionary.cpp
@@ -298,14 +298,14 @@ void __Dictionary::removeObjectForKey(intptr_t key)
 void __Dictionary::setObjectUnSafe(Ref* pObject, const std::string& key)
 {
     pObject->retain();
-    DictElement* pElement = new DictElement(key.c_str(), pObject);
+    DictElement* pElement = new (std::nothrow) DictElement(key.c_str(), pObject);
     HASH_ADD_STR(_elements, _strKey, pElement);
 }
 
 void __Dictionary::setObjectUnSafe(Ref* pObject, const intptr_t key)
 {
     pObject->retain();
-    DictElement* pElement = new DictElement(key, pObject);
+    DictElement* pElement = new (std::nothrow) DictElement(key, pObject);
     HASH_ADD_PTR(_elements, _intKey, pElement);
 }
 

--- a/cocos/deprecated/CCNotificationCenter.cpp
+++ b/cocos/deprecated/CCNotificationCenter.cpp
@@ -104,7 +104,7 @@ void __NotificationCenter::addObserver(Ref *target,
     if (this->observerExisted(target, name, sender))
         return;
     
-    NotificationObserver *observer = new NotificationObserver(target, selector, name, sender);
+    NotificationObserver *observer = new (std::nothrow) NotificationObserver(target, selector, name, sender);
     if (!observer)
         return;
     
@@ -156,7 +156,7 @@ void __NotificationCenter::registerScriptObserver(Ref *target, int handler,const
     if (this->observerExisted(target, name, nullptr))
         return;
     
-    NotificationObserver *observer = new NotificationObserver(target, nullptr, name, nullptr);
+    NotificationObserver *observer = new (std::nothrow) NotificationObserver(target, nullptr, name, nullptr);
     if (!observer)
         return;
     

--- a/cocos/editor-support/cocosbuilder/CCBAnimationManager.cpp
+++ b/cocos/editor-support/cocosbuilder/CCBAnimationManager.cpp
@@ -426,7 +426,7 @@ void CCBAnimationManager::setAnimatedProperty(const std::string& propName, Node 
     if (fTweenDuration > 0)
     {
         // Create a fake keyframe to generate the action from
-        CCBKeyframe *kf1 = new CCBKeyframe();
+        CCBKeyframe *kf1 = new (std::nothrow) CCBKeyframe();
         kf1->autorelease();
         
         kf1->setObject(obj);
@@ -957,7 +957,7 @@ void CCBAnimationManager::sequenceCompleted()
 
 CCBSetSpriteFrame* CCBSetSpriteFrame::create(SpriteFrame *pSpriteFrame)
 {
-    CCBSetSpriteFrame *ret = new CCBSetSpriteFrame();
+    CCBSetSpriteFrame *ret = new (std::nothrow) CCBSetSpriteFrame();
     if (ret)
     {
         if (ret->initWithSpriteFrame(pSpriteFrame))
@@ -989,7 +989,7 @@ CCBSetSpriteFrame::~CCBSetSpriteFrame()
 CCBSetSpriteFrame* CCBSetSpriteFrame::clone() const
 {
 	// no copy constructor
-	auto a = new CCBSetSpriteFrame();
+	auto a = new (std::nothrow) CCBSetSpriteFrame();
     a->initWithSpriteFrame(_spriteFrame);
 	a->autorelease();
 	return a;
@@ -1012,7 +1012,7 @@ void CCBSetSpriteFrame::update(float time)
  ************************************************************/
 
 CCBSoundEffect* CCBSoundEffect::actionWithSoundFile(const std::string &filename, float pitch, float pan, float gain) {
-  CCBSoundEffect* pRet = new CCBSoundEffect();
+  CCBSoundEffect* pRet = new (std::nothrow) CCBSoundEffect();
   if (pRet != nullptr && pRet->initWithSoundFile(filename, pitch, pan, gain))
     {
       pRet->autorelease();
@@ -1040,7 +1040,7 @@ bool CCBSoundEffect::initWithSoundFile(const std::string &filename, float pitch,
 CCBSoundEffect* CCBSoundEffect::clone() const
 {
 	// no copy constructor
-	auto a = new CCBSoundEffect();
+	auto a = new (std::nothrow) CCBSoundEffect();
     a->initWithSoundFile(_soundFile, _pitch, _pan, _gain);
 	a->autorelease();
 	return a;
@@ -1064,7 +1064,7 @@ void CCBSoundEffect::update(float time)
 
 CCBRotateTo* CCBRotateTo::create(float fDuration, float fAngle)
 {
-    CCBRotateTo *ret = new CCBRotateTo();
+    CCBRotateTo *ret = new (std::nothrow) CCBRotateTo();
     if (ret)
     {
         if (ret->initWithDuration(fDuration, fAngle))
@@ -1097,7 +1097,7 @@ bool CCBRotateTo::initWithDuration(float fDuration, float fAngle)
 CCBRotateTo* CCBRotateTo::clone() const
 {
 	// no copy constructor	
-	auto a = new CCBRotateTo();
+	auto a = new (std::nothrow) CCBRotateTo();
     a->initWithDuration(_duration, _dstAngle);
 	a->autorelease();
 	return a;
@@ -1132,7 +1132,7 @@ void CCBRotateTo::update(float time)
 
 CCBRotateXTo* CCBRotateXTo::create(float fDuration, float fAngle)
 {
-    CCBRotateXTo *ret = new CCBRotateXTo();
+    CCBRotateXTo *ret = new (std::nothrow) CCBRotateXTo();
     if (ret)
     {
         if (ret->initWithDuration(fDuration, fAngle))
@@ -1177,7 +1177,7 @@ void CCBRotateXTo::startWithTarget(Node *pNode)
 CCBRotateXTo* CCBRotateXTo::clone() const
 {
 	// no copy constructor
-	auto a = new CCBRotateXTo();
+	auto a = new (std::nothrow) CCBRotateXTo();
     a->initWithDuration(_duration, _dstAngle);
 	a->autorelease();
 	return a;
@@ -1204,7 +1204,7 @@ void CCBRotateXTo::update(float time)
 
 CCBRotateYTo* CCBRotateYTo::create(float fDuration, float fAngle)
 {
-    CCBRotateYTo *ret = new CCBRotateYTo();
+    CCBRotateYTo *ret = new (std::nothrow) CCBRotateYTo();
     if (ret)
     {
         if (ret->initWithDuration(fDuration, fAngle))
@@ -1237,7 +1237,7 @@ bool CCBRotateYTo::initWithDuration(float fDuration, float fAngle)
 CCBRotateYTo* CCBRotateYTo::clone() const
 {
 	// no copy constructor
-	auto a = new CCBRotateYTo();
+	auto a = new (std::nothrow) CCBRotateYTo();
     a->initWithDuration(_duration, _dstAngle);
 	a->autorelease();
 	return a;
@@ -1273,7 +1273,7 @@ void CCBRotateYTo::update(float time)
  ************************************************************/
 CCBEaseInstant* CCBEaseInstant::create(ActionInterval *pAction)
 {
-    CCBEaseInstant *pRet = new CCBEaseInstant();
+    CCBEaseInstant *pRet = new (std::nothrow) CCBEaseInstant();
     if (pRet && pRet->initWithAction(pAction))
     {
         pRet->autorelease();
@@ -1289,7 +1289,7 @@ CCBEaseInstant* CCBEaseInstant::create(ActionInterval *pAction)
 CCBEaseInstant* CCBEaseInstant::clone() const
 {
 	// no copy constructor	
-	auto a = new CCBEaseInstant();
+	auto a = new (std::nothrow) CCBEaseInstant();
     a->initWithAction(_inner);
 	a->autorelease();
 	return a;

--- a/cocos/editor-support/cocosbuilder/CCBReader.cpp
+++ b/cocos/editor-support/cocosbuilder/CCBReader.cpp
@@ -31,7 +31,7 @@ CCBFile::CCBFile():_CCBFileNode(nullptr) {}
 
 CCBFile* CCBFile::create()
 {
-    CCBFile *ret = new CCBFile();
+    CCBFile *ret = new (std::nothrow) CCBFile();
     
     if (ret)
     {
@@ -140,7 +140,7 @@ const std::string& CCBReader::getCCBRootPath() const
 bool CCBReader::init()
 {
     // Setup action manager
-    CCBAnimationManager *pActionManager = new CCBAnimationManager();
+    CCBAnimationManager *pActionManager = new (std::nothrow) CCBAnimationManager();
     setAnimationManager(pActionManager);
     pActionManager->release();
     
@@ -561,7 +561,7 @@ Node * CCBReader::readNodeGraph(Node * pParent)
         
         for (int j = 0; j < numProps; ++j)
         {
-            CCBSequenceProperty *seqProp = new CCBSequenceProperty();
+            CCBSequenceProperty *seqProp = new (std::nothrow) CCBSequenceProperty();
             seqProp->autorelease();
             
             seqProp->setName(readCachedString().c_str());
@@ -731,7 +731,7 @@ Node * CCBReader::readNodeGraph(Node * pParent)
 
 CCBKeyframe* CCBReader::readKeyframe(PropertyType type)
 {
-    CCBKeyframe *keyframe = new CCBKeyframe();
+    CCBKeyframe *keyframe = new (std::nothrow) CCBKeyframe();
     keyframe->autorelease();
     
     keyframe->setTime(readFloat());
@@ -835,7 +835,7 @@ bool CCBReader::readCallbackKeyframesForSeq(CCBSequence* seq)
     int numKeyframes = readInt(false);
     if(!numKeyframes) return true;
     
-    CCBSequenceProperty* channel = new CCBSequenceProperty();
+    CCBSequenceProperty* channel = new (std::nothrow) CCBSequenceProperty();
     channel->autorelease();
 
     for(int i = 0; i < numKeyframes; ++i) {
@@ -849,7 +849,7 @@ bool CCBReader::readCallbackKeyframesForSeq(CCBSequence* seq)
         valueVector.push_back(Value(callbackName));
         valueVector.push_back(Value(callbackType));
         
-        CCBKeyframe* keyframe = new CCBKeyframe();
+        CCBKeyframe* keyframe = new (std::nothrow) CCBKeyframe();
         keyframe->autorelease();
         
         keyframe->setTime(time);
@@ -874,7 +874,7 @@ bool CCBReader::readSoundKeyframesForSeq(CCBSequence* seq) {
     int numKeyframes = readInt(false);
     if(!numKeyframes) return true;
     
-    CCBSequenceProperty* channel = new CCBSequenceProperty();
+    CCBSequenceProperty* channel = new (std::nothrow) CCBSequenceProperty();
     channel->autorelease();
 
     for(int i = 0; i < numKeyframes; ++i) {
@@ -891,7 +891,7 @@ bool CCBReader::readSoundKeyframesForSeq(CCBSequence* seq) {
         vec.push_back(Value(pan));
         vec.push_back(Value(gain));
         
-        CCBKeyframe* keyframe = new CCBKeyframe();
+        CCBKeyframe* keyframe = new (std::nothrow) CCBKeyframe();
         keyframe->setTime(time);
         keyframe->setValue(Value(vec));
         channel->getKeyframes().pushBack(keyframe);
@@ -916,7 +916,7 @@ bool CCBReader::readSequences()
     
     for (int i = 0; i < numSeqs; i++)
     {
-        CCBSequence *seq = new CCBSequence();
+        CCBSequence *seq = new (std::nothrow) CCBSequence();
         seq->autorelease();
         
         seq->setDuration(readFloat());

--- a/cocos/editor-support/cocosbuilder/CCBReader.h
+++ b/cocos/editor-support/cocosbuilder/CCBReader.h
@@ -11,7 +11,7 @@
 #include "cocosbuilder/CCBAnimationManager.h"
 
 #define CCB_STATIC_NEW_AUTORELEASE_OBJECT_METHOD(T, METHOD) static T * METHOD() { \
-    T * ptr = new T(); \
+    T * ptr = new (std::nothrow) T(); \
     if(ptr != NULL) { \
         ptr->autorelease(); \
         return ptr; \
@@ -21,7 +21,7 @@
 }
 
 #define CCB_STATIC_NEW_AUTORELEASE_OBJECT_WITH_INIT_METHOD(T, METHOD) static T * METHOD() { \
-    T * ptr = new T(); \
+    T * ptr = new (std::nothrow) T(); \
     if(ptr != NULL && ptr->init()) { \
         ptr->autorelease(); \
         return ptr; \

--- a/cocos/editor-support/cocosbuilder/CCNodeLoader.cpp
+++ b/cocos/editor-support/cocosbuilder/CCNodeLoader.cpp
@@ -687,7 +687,7 @@ Color4F * NodeLoader::parsePropTypeColor4FVar(Node * pNode, Node * pParent, CCBR
     float blueVar = ccbReader->readFloat();
     float alphaVar = ccbReader->readFloat();
     
-    Color4F * colors = new Color4F[2];
+    Color4F * colors = new (std::nothrow) Color4F[2];
     colors[0].r = red;
     colors[0].g = green;
     colors[0].b = blue;
@@ -798,7 +798,7 @@ BlockData * NodeLoader::parsePropTypeBlock(Node * pNode, Node * pParent, CCBRead
                     if(selMenuHandler == 0) {
                         CCLOG("Skipping selector '%s' since no CCBSelectorResolver is present.", selectorName.c_str());
                     } else {
-                        BlockData * blockData = new BlockData();
+                        BlockData * blockData = new (std::nothrow) BlockData();
                         blockData->mSELMenuHandler = selMenuHandler;
                         
                         blockData->_target = target;
@@ -882,7 +882,7 @@ BlockControlData * NodeLoader::parsePropTypeBlockControl(Node * pNode, Node * pP
                     }
                     else
                     {
-                        BlockControlData * blockControlData = new BlockControlData();
+                        BlockControlData * blockControlData = new (std::nothrow) BlockControlData();
                         blockControlData->mSELControlHandler = selControlHandler;
                         
                         blockControlData->_target = target;
@@ -929,7 +929,7 @@ Node * NodeLoader::parsePropTypeCCBFile(Node * pNode, Node * pParent, CCBReader 
 
     auto dataPtr = std::make_shared<Data>(FileUtils::getInstance()->getDataFromFile(path));
     
-    CCBReader * reader = new CCBReader(pCCBReader);
+    CCBReader * reader = new (std::nothrow) CCBReader(pCCBReader);
     reader->autorelease();
     reader->getAnimationManager()->setRootContainerSize(pParent->getContentSize());
     

--- a/cocos/editor-support/cocosbuilder/CCNodeLoaderLibrary.cpp
+++ b/cocos/editor-support/cocosbuilder/CCNodeLoaderLibrary.cpp
@@ -83,7 +83,7 @@ static NodeLoaderLibrary * sSharedNodeLoaderLibrary = nullptr;
 
 NodeLoaderLibrary * NodeLoaderLibrary::getInstance() {
     if(sSharedNodeLoaderLibrary == nullptr) {
-        sSharedNodeLoaderLibrary = new NodeLoaderLibrary();
+        sSharedNodeLoaderLibrary = new (std::nothrow) NodeLoaderLibrary();
 
         sSharedNodeLoaderLibrary->registerDefaultNodeLoaders();
     }

--- a/cocos/editor-support/cocostudio/ActionTimeline/CCActionTimeline.cpp
+++ b/cocos/editor-support/cocostudio/ActionTimeline/CCActionTimeline.cpp
@@ -31,7 +31,7 @@ NS_TIMELINE_BEGIN
 // ActionTimelineData
 ActionTimelineData* ActionTimelineData::create(int actionTag)
 {
-    ActionTimelineData * ret = new ActionTimelineData();
+    ActionTimelineData * ret = new (std::nothrow) ActionTimelineData();
     if (ret && ret->init(actionTag))
     {
         ret->autorelease();
@@ -58,7 +58,7 @@ bool ActionTimelineData::init(int actionTag)
 // ActionTimeline
 ActionTimeline* ActionTimeline::create()
 {
-    ActionTimeline* object = new ActionTimeline();
+    ActionTimeline* object = new (std::nothrow) ActionTimeline();
     if (object && object->init())
     {
         object->autorelease();

--- a/cocos/editor-support/cocostudio/ActionTimeline/CCActionTimelineCache.cpp
+++ b/cocos/editor-support/cocostudio/ActionTimeline/CCActionTimelineCache.cpp
@@ -74,7 +74,7 @@ ActionTimelineCache* ActionTimelineCache::getInstance()
 {
     if (! _sharedActionCache)
     {
-        _sharedActionCache = new ActionTimelineCache();
+        _sharedActionCache = new (std::nothrow) ActionTimelineCache();
         _sharedActionCache->init();
     }
 

--- a/cocos/editor-support/cocostudio/ActionTimeline/CCFrame.cpp
+++ b/cocos/editor-support/cocostudio/ActionTimeline/CCFrame.cpp
@@ -61,7 +61,7 @@ void Frame::cloneProperty(Frame* frame)
 // VisibleFrame
 VisibleFrame* VisibleFrame::create()
 {
-    VisibleFrame* frame = new VisibleFrame();
+    VisibleFrame* frame = new (std::nothrow) VisibleFrame();
     if (frame)
     {
         frame->autorelease();
@@ -97,7 +97,7 @@ Frame* VisibleFrame::clone()
 // TextureFrame
 TextureFrame* TextureFrame::create()
 {
-    TextureFrame* frame = new TextureFrame();
+    TextureFrame* frame = new (std::nothrow) TextureFrame();
     if (frame)
     {
         frame->autorelease();
@@ -148,7 +148,7 @@ Frame* TextureFrame::clone()
 // RotationFrame
 RotationFrame* RotationFrame::create()
 {
-    RotationFrame* frame = new RotationFrame();
+    RotationFrame* frame = new (std::nothrow) RotationFrame();
     if (frame)
     {
         frame->autorelease();
@@ -197,7 +197,7 @@ Frame* RotationFrame::clone()
 // SkewFrame
 SkewFrame* SkewFrame::create()
 {
-    SkewFrame* frame = new SkewFrame();
+    SkewFrame* frame = new (std::nothrow) SkewFrame();
     if (frame)
     {
         frame->autorelease();
@@ -254,7 +254,7 @@ Frame* SkewFrame::clone()
 // RotationSkewFrame
 RotationSkewFrame* RotationSkewFrame::create()
 {
-    RotationSkewFrame* frame = new RotationSkewFrame();
+    RotationSkewFrame* frame = new (std::nothrow) RotationSkewFrame();
     if (frame)
     {
         frame->autorelease();
@@ -307,7 +307,7 @@ Frame* RotationSkewFrame::clone()
 // PositionFrame
 PositionFrame* PositionFrame::create()
 {
-    PositionFrame* frame = new PositionFrame();
+    PositionFrame* frame = new (std::nothrow) PositionFrame();
     if (frame)
     {
         frame->autorelease();
@@ -359,7 +359,7 @@ Frame* PositionFrame::clone()
 // ScaleFrame
 ScaleFrame* ScaleFrame::create()
 {
-    ScaleFrame* frame = new ScaleFrame();
+    ScaleFrame* frame = new (std::nothrow) ScaleFrame();
     if (frame)
     {
         frame->autorelease();
@@ -414,7 +414,7 @@ Frame* ScaleFrame::clone()
 // AnchorPointFrame
 AnchorPointFrame* AnchorPointFrame::create()
 {
-    AnchorPointFrame* frame = new AnchorPointFrame();
+    AnchorPointFrame* frame = new (std::nothrow) AnchorPointFrame();
     if (frame)
     {
         frame->autorelease();
@@ -450,7 +450,7 @@ Frame* AnchorPointFrame::clone()
 // InnerActionFrame
 InnerActionFrame* InnerActionFrame::create()
 {
-    InnerActionFrame* frame = new InnerActionFrame();
+    InnerActionFrame* frame = new (std::nothrow) InnerActionFrame();
     if (frame)
     {
         frame->autorelease();
@@ -486,7 +486,7 @@ Frame* InnerActionFrame::clone()
 // ColorFrame
 ColorFrame* ColorFrame::create()
 {
-    ColorFrame* frame = new ColorFrame();
+    ColorFrame* frame = new (std::nothrow) ColorFrame();
     if (frame)
     {
         frame->autorelease();
@@ -549,7 +549,7 @@ Frame* ColorFrame::clone()
 // EventFrame
 EventFrame* EventFrame::create()
 {
-    EventFrame* frame = new EventFrame();
+    EventFrame* frame = new (std::nothrow) EventFrame();
     if (frame)
     {
         frame->autorelease();
@@ -584,7 +584,7 @@ Frame* EventFrame::clone()
 // ZOrderFrame
 ZOrderFrame* ZOrderFrame::create()
 {
-    ZOrderFrame* frame = new ZOrderFrame();
+    ZOrderFrame* frame = new (std::nothrow) ZOrderFrame();
     if (frame)
     {
         frame->autorelease();

--- a/cocos/editor-support/cocostudio/ActionTimeline/CCNodeReader.cpp
+++ b/cocos/editor-support/cocostudio/ActionTimeline/CCNodeReader.cpp
@@ -104,7 +104,7 @@ NodeReader* NodeReader::getInstance()
 {
     if (! _sharedNodeReader)
     {
-        _sharedNodeReader = new NodeReader();
+        _sharedNodeReader = new (std::nothrow) NodeReader();
         _sharedNodeReader->init();
     }
 
@@ -457,7 +457,7 @@ Node* NodeReader::loadWidget(const rapidjson::Value& json)
 
     WidgetReaderProtocol* reader = dynamic_cast<WidgetReaderProtocol*>(ObjectFactory::getInstance()->createObject(readerName));
 
-    WidgetPropertiesReader0300* guiReader = new WidgetPropertiesReader0300();
+    WidgetPropertiesReader0300* guiReader = new (std::nothrow) WidgetPropertiesReader0300();
     guiReader->setPropsForAllWidgetFromJsonDictionary(reader, widget, json);
     CC_SAFE_DELETE(guiReader);
     

--- a/cocos/editor-support/cocostudio/ActionTimeline/CCTimeLine.cpp
+++ b/cocos/editor-support/cocostudio/ActionTimeline/CCTimeLine.cpp
@@ -31,7 +31,7 @@ NS_TIMELINE_BEGIN
 
 Timeline* Timeline::create()
 {
-    Timeline* object = new Timeline();
+    Timeline* object = new (std::nothrow) Timeline();
     if (object)
     {
         object->autorelease();

--- a/cocos/editor-support/cocostudio/CCActionManagerEx.cpp
+++ b/cocos/editor-support/cocostudio/CCActionManagerEx.cpp
@@ -35,7 +35,7 @@ static ActionManagerEx* sharedActionManager = nullptr;
 ActionManagerEx* ActionManagerEx::getInstance()
 {
 	if (!sharedActionManager) {
-		sharedActionManager = new ActionManagerEx();
+		sharedActionManager = new (std::nothrow) ActionManagerEx();
 	}
 	return sharedActionManager;
 }
@@ -68,7 +68,7 @@ void ActionManagerEx::initWithDictionary(const char* jsonName,const rapidjson::V
 	cocos2d::Vector<ActionObject*> actionList;
 	int actionCount = DICTOOL->getArrayCount_json(dic, "actionlist");
 	for (int i=0; i<actionCount; i++) {
-		ActionObject* action = new ActionObject();
+		ActionObject* action = new (std::nothrow) ActionObject();
 		action->autorelease();
 		const rapidjson::Value &actionDic = DICTOOL->getDictionaryFromArray_json(dic, "actionlist", i);
 		action->initWithDictionary(actionDic,root);
@@ -101,7 +101,7 @@ void ActionManagerEx::initWithDictionary(const char* jsonName,const rapidjson::V
         {
             int actionCount = actionNode->GetChildNum();
             for (int i = 0; i < actionCount; ++i) {
-                ActionObject* action = new ActionObject();
+                ActionObject* action = new (std::nothrow) ActionObject();
                 action->autorelease();
                 
                 action->initWithBinary(cocoLoader, actionNode->GetChildArray(cocoLoader), root);

--- a/cocos/editor-support/cocostudio/CCActionNode.cpp
+++ b/cocos/editor-support/cocostudio/CCActionNode.cpp
@@ -97,7 +97,7 @@ void ActionNode::initWithDictionary(const rapidjson::Value& dic, Ref* root)
         {
             float positionX = DICTOOL->getFloatValue_json(actionFrameDic, "positionx");
             float positionY = DICTOOL->getFloatValue_json(actionFrameDic, "positiony");
-            ActionMoveFrame* actionFrame = new ActionMoveFrame();
+            ActionMoveFrame* actionFrame = new (std::nothrow) ActionMoveFrame();
             actionFrame->setFrameIndex(frameInex);
             actionFrame->setEasingType(frameTweenType);
             actionFrame->setEasingParameter(frameTweenParameter);
@@ -112,7 +112,7 @@ void ActionNode::initWithDictionary(const rapidjson::Value& dic, Ref* root)
         {
             float scaleX = DICTOOL->getFloatValue_json(actionFrameDic, "scalex");
             float scaleY = DICTOOL->getFloatValue_json(actionFrameDic, "scaley");
-            ActionScaleFrame* actionFrame = new ActionScaleFrame();
+            ActionScaleFrame* actionFrame = new (std::nothrow) ActionScaleFrame();
             actionFrame->setFrameIndex(frameInex);
             actionFrame->setEasingType(frameTweenType);
             actionFrame->setEasingParameter(frameTweenParameter);
@@ -127,7 +127,7 @@ void ActionNode::initWithDictionary(const rapidjson::Value& dic, Ref* root)
         if (existRotation)
         {
             float rotation = DICTOOL->getFloatValue_json(actionFrameDic, "rotation");
-            ActionRotationFrame* actionFrame = new ActionRotationFrame();
+            ActionRotationFrame* actionFrame = new (std::nothrow) ActionRotationFrame();
             actionFrame->setFrameIndex(frameInex);
             actionFrame->setEasingType(frameTweenType);
             actionFrame->setEasingParameter(frameTweenParameter);
@@ -141,7 +141,7 @@ void ActionNode::initWithDictionary(const rapidjson::Value& dic, Ref* root)
         if (existOpacity)
         {
             int opacity = DICTOOL->getIntValue_json(actionFrameDic, "opacity");
-            ActionFadeFrame* actionFrame = new ActionFadeFrame();
+            ActionFadeFrame* actionFrame = new (std::nothrow) ActionFadeFrame();
             actionFrame->setFrameIndex(frameInex);
             actionFrame->setEasingType(frameTweenType);
             actionFrame->setEasingParameter(frameTweenParameter);
@@ -157,7 +157,7 @@ void ActionNode::initWithDictionary(const rapidjson::Value& dic, Ref* root)
             int colorR = DICTOOL->getIntValue_json(actionFrameDic, "colorr");
             int colorG = DICTOOL->getIntValue_json(actionFrameDic, "colorg");
             int colorB = DICTOOL->getIntValue_json(actionFrameDic, "colorb");
-            ActionTintFrame* actionFrame = new ActionTintFrame();
+            ActionTintFrame* actionFrame = new (std::nothrow) ActionTintFrame();
             actionFrame->setFrameIndex(frameInex);
             actionFrame->setEasingType(frameTweenType);
             actionFrame->setEasingParameter(frameTweenParameter);
@@ -248,7 +248,7 @@ void ActionNode::initWithDictionary(const rapidjson::Value& dic, Ref* root)
                     positionX = valueToFloat(value);
                 }else if (key == "positiony"){
                     positionY = valueToFloat(value);
-                    ActionMoveFrame* actionFrame = new ActionMoveFrame();
+                    ActionMoveFrame* actionFrame = new (std::nothrow) ActionMoveFrame();
                     actionFrame->autorelease();
                     actionFrame->setEasingType(frameTweenType);
                     actionFrame->setEasingParameter(frameTweenParameter);
@@ -260,7 +260,7 @@ void ActionNode::initWithDictionary(const rapidjson::Value& dic, Ref* root)
                     scaleX = valueToFloat(value);
                 }else if(key == "scaley"){
                     scaleY = valueToFloat(value);
-                    ActionScaleFrame* actionFrame = new ActionScaleFrame();
+                    ActionScaleFrame* actionFrame = new (std::nothrow) ActionScaleFrame();
                     actionFrame->autorelease();
                     actionFrame->setEasingType(frameTweenType);
                     actionFrame->setEasingParameter(frameTweenParameter);
@@ -271,7 +271,7 @@ void ActionNode::initWithDictionary(const rapidjson::Value& dic, Ref* root)
                     cActionArray->pushBack(actionFrame);
                 }else if (key == "rotation"){
                     rotation = valueToFloat(value);
-                    ActionRotationFrame* actionFrame = new ActionRotationFrame();
+                    ActionRotationFrame* actionFrame = new (std::nothrow) ActionRotationFrame();
                     actionFrame->autorelease();
                     actionFrame->setEasingType(frameTweenType);
                     actionFrame->setEasingParameter(frameTweenParameter);
@@ -281,7 +281,7 @@ void ActionNode::initWithDictionary(const rapidjson::Value& dic, Ref* root)
                     cActionArray->pushBack(actionFrame);
                 }else if (key == "opacity"){
                     opacity = valueToInt(value);
-                    ActionFadeFrame* actionFrame = new ActionFadeFrame();
+                    ActionFadeFrame* actionFrame = new (std::nothrow) ActionFadeFrame();
                     actionFrame->autorelease();
                     actionFrame->setEasingType(frameTweenType);
                     actionFrame->setEasingParameter(frameTweenParameter);
@@ -296,7 +296,7 @@ void ActionNode::initWithDictionary(const rapidjson::Value& dic, Ref* root)
                 }else if(key == "colorr"){
                     colorR = valueToInt(value);
                     
-                    ActionTintFrame* actionFrame = new ActionTintFrame();
+                    ActionTintFrame* actionFrame = new (std::nothrow) ActionTintFrame();
                     actionFrame->autorelease();
                     actionFrame->setEasingType(frameTweenType);
                     actionFrame->setEasingParameter(frameTweenParameter);

--- a/cocos/editor-support/cocostudio/CCActionObject.cpp
+++ b/cocos/editor-support/cocostudio/CCActionObject.cpp
@@ -115,7 +115,7 @@ void ActionObject::initWithDictionary(const rapidjson::Value& dic, Ref* root)
     int actionNodeCount = DICTOOL->getArrayCount_json(dic, "actionnodelist");
     int maxLength = 0;
     for (int i=0; i<actionNodeCount; i++) {
-        ActionNode* actionNode = new ActionNode();
+        ActionNode* actionNode = new (std::nothrow) ActionNode();
         actionNode->autorelease();
         const rapidjson::Value& actionNodeDic = DICTOOL->getDictionaryFromArray_json(dic, "actionnodelist", i);
         actionNode->initWithDictionary(actionNodeDic,root);
@@ -156,7 +156,7 @@ void ActionObject::initWithBinary(CocoLoader *cocoLoader,
         stExpCocoNode *actionNodeArray = actionNodeList->GetChildArray(cocoLoader);
         int maxLength = 0;
         for (int i=0; i<actionNodeCount; i++) {
-            ActionNode* actionNode = new ActionNode();
+            ActionNode* actionNode = new (std::nothrow) ActionNode();
             actionNode->autorelease();
             
             actionNode->initWithBinary(cocoLoader, &actionNodeArray[i] , root);

--- a/cocos/editor-support/cocostudio/CCArmature.cpp
+++ b/cocos/editor-support/cocostudio/CCArmature.cpp
@@ -48,7 +48,7 @@ namespace cocostudio {
 
 Armature *Armature::create()
 {
-    Armature *armature = new Armature();
+    Armature *armature = new (std::nothrow) Armature();
     if (armature && armature->init())
     {
         armature->autorelease();
@@ -61,7 +61,7 @@ Armature *Armature::create()
 
 Armature *Armature::create(const std::string& name)
 {
-    Armature *armature = new Armature();
+    Armature *armature = new (std::nothrow) Armature();
     if (armature && armature->init(name))
     {
         armature->autorelease();
@@ -73,7 +73,7 @@ Armature *Armature::create(const std::string& name)
 
 Armature *Armature::create(const std::string& name, Bone *parentBone)
 {
-    Armature *armature = new Armature();
+    Armature *armature = new (std::nothrow) Armature();
     if (armature && armature->init(name, parentBone))
     {
         armature->autorelease();
@@ -116,7 +116,7 @@ bool Armature::init(const std::string& name)
         removeAllChildren();
 
         CC_SAFE_DELETE(_animation);
-        _animation = new ArmatureAnimation();
+        _animation = new (std::nothrow) ArmatureAnimation();
         _animation->init(this);
 
         _boneDic.clear();
@@ -594,7 +594,7 @@ void CCArmature::drawContour()
             const std::vector<Vec2> &vertexList = body->getCalculatedVertexList();
 
             unsigned long length = vertexList.size();
-            Vec2 *points = new Vec2[length];
+            Vec2 *points = new (std::nothrow) Vec2[length];
             for (unsigned long i = 0; i<length; i++)
             {
                 Vec2 p = vertexList.at(i);

--- a/cocos/editor-support/cocostudio/CCArmatureAnimation.cpp
+++ b/cocos/editor-support/cocostudio/CCArmatureAnimation.cpp
@@ -36,7 +36,7 @@ namespace cocostudio {
 
 ArmatureAnimation *ArmatureAnimation::create(Armature *armature)
 {
-    ArmatureAnimation *pArmatureAnimation = new ArmatureAnimation();
+    ArmatureAnimation *pArmatureAnimation = new (std::nothrow) ArmatureAnimation();
     if (pArmatureAnimation && pArmatureAnimation->init(armature))
     {
         pArmatureAnimation->autorelease();
@@ -491,7 +491,7 @@ void ArmatureAnimation::frameEvent(Bone *bone, const std::string& frameEventName
 {
     if ((_frameEventTarget && _frameEventCallFunc) || _frameEventListener)
     {
-        FrameEvent *frameEvent = new FrameEvent();
+        FrameEvent *frameEvent = new (std::nothrow) FrameEvent();
         frameEvent->bone = bone;
         frameEvent->frameEventName = frameEventName;
         frameEvent->originFrameIndex = originFrameIndex;
@@ -506,7 +506,7 @@ void ArmatureAnimation::movementEvent(Armature *armature, MovementEventType move
 {
     if ((_movementEventTarget && _movementEventCallFunc) || _movementEventListener)
     {
-        MovementEvent *movementEvent = new MovementEvent();
+        MovementEvent *movementEvent = new (std::nothrow) MovementEvent();
         movementEvent->armature = armature;
         movementEvent->movementType = movementType;
         movementEvent->movementID = movementID;

--- a/cocos/editor-support/cocostudio/CCArmatureDataManager.cpp
+++ b/cocos/editor-support/cocostudio/CCArmatureDataManager.cpp
@@ -39,7 +39,7 @@ ArmatureDataManager *ArmatureDataManager::getInstance()
 {
     if (s_sharedArmatureDataManager == nullptr)
     {
-        s_sharedArmatureDataManager = new ArmatureDataManager();
+        s_sharedArmatureDataManager = new (std::nothrow) ArmatureDataManager();
         if (!s_sharedArmatureDataManager || !s_sharedArmatureDataManager->init())
         {
             CC_SAFE_DELETE(s_sharedArmatureDataManager);

--- a/cocos/editor-support/cocostudio/CCBatchNode.cpp
+++ b/cocos/editor-support/cocostudio/CCBatchNode.cpp
@@ -38,7 +38,7 @@ namespace cocostudio {
 
 BatchNode *BatchNode::create()
 {
-    BatchNode *batchNode = new BatchNode();
+    BatchNode *batchNode = new (std::nothrow) BatchNode();
     if (batchNode && batchNode->init())
     {
         batchNode->autorelease();
@@ -75,7 +75,7 @@ void BatchNode::addChild(Node *child, int zOrder, int tag)
         armature->setBatchNode(this);
         if (_groupCommand == nullptr)
         {
-            _groupCommand = new GroupCommand();
+            _groupCommand = new (std::nothrow) GroupCommand();
         }
     }
 }
@@ -89,7 +89,7 @@ void BatchNode::addChild(cocos2d::Node *child, int zOrder, const std::string &na
         armature->setBatchNode(this);
         if (_groupCommand == nullptr)
         {
-            _groupCommand = new GroupCommand();
+            _groupCommand = new (std::nothrow) GroupCommand();
         }
     }
 }

--- a/cocos/editor-support/cocostudio/CCBone.cpp
+++ b/cocos/editor-support/cocostudio/CCBone.cpp
@@ -36,7 +36,7 @@ namespace cocostudio {
 Bone *Bone::create()
 {
 
-    Bone *pBone = new Bone();
+    Bone *pBone = new (std::nothrow) Bone();
     if (pBone && pBone->init())
     {
         pBone->autorelease();
@@ -50,7 +50,7 @@ Bone *Bone::create()
 Bone *Bone::create(const std::string& name)
 {
 
-    Bone *pBone = new Bone();
+    Bone *pBone = new (std::nothrow) Bone();
     if (pBone && pBone->init(name))
     {
         pBone->autorelease();
@@ -110,21 +110,21 @@ bool Bone::init(const std::string& name)
         _name = name;
 
         CC_SAFE_DELETE(_tweenData);
-        _tweenData = new FrameData();
+        _tweenData = new (std::nothrow) FrameData();
 
         CC_SAFE_DELETE(_tween);
-        _tween = new Tween();
+        _tween = new (std::nothrow) Tween();
         _tween->init(this);
 
         CC_SAFE_DELETE(_displayManager);
-        _displayManager = new DisplayManager();
+        _displayManager = new (std::nothrow) DisplayManager();
         _displayManager->init(this);
 
         CC_SAFE_DELETE(_worldInfo);
-        _worldInfo = new BaseData();
+        _worldInfo = new (std::nothrow) BaseData();
 
         CC_SAFE_DELETE(_boneData);
-        _boneData  = new BoneData();
+        _boneData  = new (std::nothrow) BoneData();
 
         bRet = true;
     }

--- a/cocos/editor-support/cocostudio/CCColliderDetector.cpp
+++ b/cocos/editor-support/cocostudio/CCColliderDetector.cpp
@@ -70,7 +70,7 @@ ColliderBody::ColliderBody(ContourData *contourData)
     , _contourData(contourData)
 {
     CC_SAFE_RETAIN(_contourData);
-    _filter = new ColliderFilter();
+    _filter = new (std::nothrow) ColliderFilter();
 
 #if ENABLE_PHYSICS_SAVE_CALCULATED_VERTEX
     _calculatedVertexList = Array::create();
@@ -84,7 +84,7 @@ ColliderBody::ColliderBody(ContourData *contourData)
     , _contourData(contourData)
 {
     CC_SAFE_RETAIN(_contourData);
-    _filter = new ColliderFilter();
+    _filter = new (std::nothrow) ColliderFilter();
 
 #if ENABLE_PHYSICS_SAVE_CALCULATED_VERTEX
     _calculatedVertexList = Array::create();
@@ -123,7 +123,7 @@ ColliderFilter *ColliderBody::getColliderFilter()
 
 ColliderDetector *ColliderDetector::create()
 {
-    ColliderDetector *pColliderDetector = new ColliderDetector();
+    ColliderDetector *pColliderDetector = new (std::nothrow) ColliderDetector();
     if (pColliderDetector && pColliderDetector->init())
     {
         pColliderDetector->autorelease();
@@ -135,7 +135,7 @@ ColliderDetector *ColliderDetector::create()
 
 ColliderDetector *ColliderDetector::create(Bone *bone)
 {
-    ColliderDetector *pColliderDetector = new ColliderDetector();
+    ColliderDetector *pColliderDetector = new (std::nothrow) ColliderDetector();
     if (pColliderDetector && pColliderDetector->init(bone))
     {
         pColliderDetector->autorelease();
@@ -168,7 +168,7 @@ bool ColliderDetector::init()
     _colliderBodyList.clear();
 
 #if ENABLE_PHYSICS_BOX2D_DETECT || ENABLE_PHYSICS_CHIPMUNK_DETECT
-    _filter = new ColliderFilter();
+    _filter = new (std::nothrow) ColliderFilter();
 #endif
 
     return true;
@@ -184,7 +184,7 @@ bool ColliderDetector::init(Bone *bone)
 
 void ColliderDetector::addContourData(ContourData *contourData)
 {
-    ColliderBody *colliderBody = new ColliderBody(contourData);
+    ColliderBody *colliderBody = new (std::nothrow) ColliderBody(contourData);
     _colliderBodyList.pushBack(colliderBody);
     colliderBody->release();
 

--- a/cocos/editor-support/cocostudio/CCComAttribute.cpp
+++ b/cocos/editor-support/cocostudio/CCComAttribute.cpp
@@ -130,7 +130,7 @@ std::string ComAttribute::getString(const std::string& key, const std::string& d
 
 ComAttribute* ComAttribute::create(void)
 {
-	ComAttribute * pRet = new ComAttribute();
+	ComAttribute * pRet = new (std::nothrow) ComAttribute();
 	if (pRet && pRet->init())
 	{
 		pRet->autorelease();

--- a/cocos/editor-support/cocostudio/CCComAudio.cpp
+++ b/cocos/editor-support/cocostudio/CCComAudio.cpp
@@ -156,7 +156,7 @@ bool ComAudio::serialize(void* r)
 
 ComAudio* ComAudio::create(void)
 {
-    ComAudio * pRet = new ComAudio();
+    ComAudio * pRet = new (std::nothrow) ComAudio();
     if (pRet && pRet->init())
     {
         pRet->autorelease();

--- a/cocos/editor-support/cocostudio/CCComController.cpp
+++ b/cocos/editor-support/cocostudio/CCComController.cpp
@@ -70,7 +70,7 @@ void ComController::setEnabled(bool b)
 
 ComController* ComController::create(void)
 {
-    ComController * pRet = new ComController();
+    ComController * pRet = new (std::nothrow) ComController();
     if (pRet && pRet->init())
     {
         pRet->autorelease();

--- a/cocos/editor-support/cocostudio/CCComRender.cpp
+++ b/cocos/editor-support/cocostudio/CCComRender.cpp
@@ -345,7 +345,7 @@ bool ComRender::serialize(void* r)
 
 ComRender* ComRender::create(void)
 {
-    ComRender * ret = new ComRender();
+    ComRender * ret = new (std::nothrow) ComRender();
     if (ret != nullptr && ret->init())
     {
         ret->autorelease();
@@ -359,7 +359,7 @@ ComRender* ComRender::create(void)
 
 ComRender* ComRender::create(cocos2d::Node *node, const char *comName)
 {
-    ComRender * ret = new ComRender(node, comName);
+    ComRender * ret = new (std::nothrow) ComRender(node, comName);
     if (ret != nullptr && ret->init())
     {
         ret->autorelease();

--- a/cocos/editor-support/cocostudio/CCDataReaderHelper.cpp
+++ b/cocos/editor-support/cocostudio/CCDataReaderHelper.cpp
@@ -183,7 +183,7 @@ void DataReaderHelper::loadData()
         }
 
         // generate data info
-        DataInfo *pDataInfo = new DataInfo();
+        DataInfo *pDataInfo = new (std::nothrow) DataInfo();
         pDataInfo->asyncStruct = pAsyncStruct;
         pDataInfo->filename = pAsyncStruct->filename;
         pDataInfo->baseFilePath = pAsyncStruct->baseFilePath;
@@ -221,7 +221,7 @@ DataReaderHelper *DataReaderHelper::getInstance()
 {
     if(!_dataReaderHelper)
     {
-        _dataReaderHelper = new DataReaderHelper();
+        _dataReaderHelper = new (std::nothrow) DataReaderHelper();
     }
 
     return _dataReaderHelper;
@@ -398,7 +398,7 @@ void DataReaderHelper::addDataFromFileAsync(const std::string& imagePath, const 
     }
 
     // generate async struct
-    AsyncStruct *data = new AsyncStruct();
+    AsyncStruct *data = new (std::nothrow) AsyncStruct();
     data->filename = filePath;
     data->baseFilePath = basefilePath;
     data->target = target;
@@ -614,7 +614,7 @@ void DataReaderHelper::addDataFromCache(const std::string& pFileContent, DataInf
 
 ArmatureData *DataReaderHelper::decodeArmature(tinyxml2::XMLElement *armatureXML, DataInfo *dataInfo)
 {
-    ArmatureData *armatureData = new ArmatureData();
+    ArmatureData *armatureData = new (std::nothrow) ArmatureData();
     armatureData->init();
 
     armatureData->name = armatureXML->Attribute(A_NAME);
@@ -655,7 +655,7 @@ ArmatureData *DataReaderHelper::decodeArmature(tinyxml2::XMLElement *armatureXML
 
 BoneData *DataReaderHelper::decodeBone(tinyxml2::XMLElement *boneXML, tinyxml2::XMLElement *parentXml, DataInfo *dataInfo)
 {
-    BoneData *boneData = new BoneData();
+    BoneData *boneData = new (std::nothrow) BoneData();
     boneData->init();
 
     std::string name = boneXML->Attribute(A_NAME);
@@ -691,19 +691,19 @@ DisplayData *DataReaderHelper::decodeBoneDisplay(tinyxml2::XMLElement *displayXM
     {
         if(!_isArmature)
         {
-            displayData = new SpriteDisplayData();
+            displayData = new (std::nothrow) SpriteDisplayData();
             displayData->displayType  = CS_DISPLAY_SPRITE;
         }
         else
         {
-            displayData = new ArmatureDisplayData();
+            displayData = new (std::nothrow) ArmatureDisplayData();
             displayData->displayType  = CS_DISPLAY_ARMATURE;
         }
 
     }
     else
     {
-        displayData = new SpriteDisplayData();
+        displayData = new (std::nothrow) SpriteDisplayData();
         displayData->displayType  = CS_DISPLAY_SPRITE;
     }
 
@@ -751,7 +751,7 @@ AnimationData *DataReaderHelper::decodeAnimation(tinyxml2::XMLElement *animation
 
 MovementData *DataReaderHelper::decodeMovement(tinyxml2::XMLElement *movementXML, ArmatureData *armatureData, DataInfo *dataInfo)
 {
-    MovementData *movementData = new MovementData();
+    MovementData *movementData = new (std::nothrow) MovementData();
 
     const char *movName = movementXML->Attribute(A_NAME);
     movementData->name = movName;
@@ -838,7 +838,7 @@ MovementData *DataReaderHelper::decodeMovement(tinyxml2::XMLElement *movementXML
 
 MovementBoneData *DataReaderHelper::decodeMovementBone(tinyxml2::XMLElement *movBoneXml, tinyxml2::XMLElement *parentXml, BoneData *boneData, DataInfo *dataInfo)
 {
-    MovementBoneData *movBoneData = new MovementBoneData();
+    MovementBoneData *movBoneData = new (std::nothrow) MovementBoneData();
     movBoneData->init();
 
     float scale, delay;
@@ -945,7 +945,7 @@ MovementBoneData *DataReaderHelper::decodeMovementBone(tinyxml2::XMLElement *mov
 
 
     //
-    FrameData *frameData = new FrameData();
+    FrameData *frameData = new (std::nothrow) FrameData();
     frameData->copy((FrameData *)movBoneData->frameList.back());
     frameData->frameID = movBoneData->duration;
     movBoneData->addFrameData(frameData);
@@ -959,7 +959,7 @@ FrameData *DataReaderHelper::decodeFrame(tinyxml2::XMLElement *frameXML,  tinyxm
     float x = 0, y = 0, scale_x = 0, scale_y = 0, skew_x = 0, skew_y = 0, tweenRotate = 0;
     int duration = 0, displayIndex = 0, zOrder = 0, tweenEasing = 0, blendType = 0;
 
-    FrameData *frameData = new FrameData();
+    FrameData *frameData = new (std::nothrow) FrameData();
 
     if(frameXML->Attribute(A_MOVEMENT) != nullptr)
     {
@@ -1154,7 +1154,7 @@ FrameData *DataReaderHelper::decodeFrame(tinyxml2::XMLElement *frameXML,  tinyxm
 
 TextureData *DataReaderHelper::decodeTexture(tinyxml2::XMLElement *textureXML, DataInfo *dataInfo)
 {
-    TextureData *textureData = new TextureData();
+    TextureData *textureData = new (std::nothrow) TextureData();
     textureData->init();
 
     if( textureXML->Attribute(A_NAME) != nullptr)
@@ -1200,7 +1200,7 @@ TextureData *DataReaderHelper::decodeTexture(tinyxml2::XMLElement *textureXML, D
 
 ContourData *DataReaderHelper::decodeContour(tinyxml2::XMLElement *contourXML, DataInfo *dataInfo)
 {
-    ContourData *contourData = new ContourData();
+    ContourData *contourData = new (std::nothrow) ContourData();
     contourData->init();
 
     tinyxml2::XMLElement *vertexDataXML = contourXML->FirstChildElement(CONTOUR_VERTEX);
@@ -1339,7 +1339,7 @@ void DataReaderHelper::addDataFromJsonCache(const std::string& fileContent, Data
 
 ArmatureData *DataReaderHelper::decodeArmature(const rapidjson::Value& json, DataInfo *dataInfo)
 {
-    ArmatureData *armatureData = new ArmatureData();
+    ArmatureData *armatureData = new (std::nothrow) ArmatureData();
     armatureData->init();
 
 	const char *name = DICTOOL->getStringValue_json(json, A_NAME);
@@ -1365,7 +1365,7 @@ ArmatureData *DataReaderHelper::decodeArmature(const rapidjson::Value& json, Dat
 
 BoneData *DataReaderHelper::decodeBone(const rapidjson::Value& json, DataInfo *dataInfo)
 {
-    BoneData *boneData = new BoneData();
+    BoneData *boneData = new (std::nothrow) BoneData();
     boneData->init();
 
     decodeNode(boneData, json, dataInfo);
@@ -1406,7 +1406,7 @@ DisplayData *DataReaderHelper::decodeBoneDisplay(const rapidjson::Value& json, D
     {
     case CS_DISPLAY_SPRITE:
     {
-        displayData = new SpriteDisplayData();
+        displayData = new (std::nothrow) SpriteDisplayData();
 
 		const char *name =  DICTOOL->getStringValue_json(json, A_NAME);
         if(name != nullptr)
@@ -1437,7 +1437,7 @@ DisplayData *DataReaderHelper::decodeBoneDisplay(const rapidjson::Value& json, D
     break;
     case CS_DISPLAY_ARMATURE:
     {
-        displayData = new ArmatureDisplayData();
+        displayData = new (std::nothrow) ArmatureDisplayData();
 
         const char *name = DICTOOL->getStringValue_json(json, A_NAME);
         if(name != nullptr)
@@ -1448,7 +1448,7 @@ DisplayData *DataReaderHelper::decodeBoneDisplay(const rapidjson::Value& json, D
     break;
     case CS_DISPLAY_PARTICLE:
     {
-        displayData = new ParticleDisplayData();
+        displayData = new (std::nothrow) ParticleDisplayData();
 
         const char *plist = DICTOOL->getStringValue_json(json, A_PLIST);
         if(plist != nullptr)
@@ -1465,7 +1465,7 @@ DisplayData *DataReaderHelper::decodeBoneDisplay(const rapidjson::Value& json, D
     }
     break;
     default:
-        displayData = new SpriteDisplayData();
+        displayData = new (std::nothrow) SpriteDisplayData();
 
         break;
     }
@@ -1478,7 +1478,7 @@ DisplayData *DataReaderHelper::decodeBoneDisplay(const rapidjson::Value& json, D
 
 AnimationData *DataReaderHelper::decodeAnimation(const rapidjson::Value& json, DataInfo *dataInfo)
 {
-    AnimationData *aniData = new AnimationData();
+    AnimationData *aniData = new (std::nothrow) AnimationData();
 
     const char *name = DICTOOL->getStringValue_json(json, A_NAME);
     if(name != nullptr)
@@ -1502,7 +1502,7 @@ AnimationData *DataReaderHelper::decodeAnimation(const rapidjson::Value& json, D
 
 MovementData *DataReaderHelper::decodeMovement(const rapidjson::Value& json, DataInfo *dataInfo)
 {
-    MovementData *movementData = new MovementData();
+    MovementData *movementData = new (std::nothrow) MovementData();
 
 	movementData->loop = DICTOOL->getBooleanValue_json(json, A_LOOP, true);
 	movementData->durationTween = DICTOOL->getIntValue_json(json, A_DURATION_TWEEN, 0);
@@ -1538,7 +1538,7 @@ MovementData *DataReaderHelper::decodeMovement(const rapidjson::Value& json, Dat
 
 MovementBoneData *DataReaderHelper::decodeMovementBone(const rapidjson::Value& json, DataInfo *dataInfo)
 {
-    MovementBoneData *movementBoneData = new MovementBoneData();
+    MovementBoneData *movementBoneData = new (std::nothrow) MovementBoneData();
     movementBoneData->init();
 
 	movementBoneData->delay = DICTOOL->getFloatValue_json(json, A_MOVEMENT_DELAY);
@@ -1594,7 +1594,7 @@ MovementBoneData *DataReaderHelper::decodeMovementBone(const rapidjson::Value& j
     {
         if (movementBoneData->frameList.size() > 0)
         {
-            FrameData *frameData = new FrameData();
+            FrameData *frameData = new (std::nothrow) FrameData();
             frameData->copy((FrameData *)movementBoneData->frameList.back());
             movementBoneData->addFrameData(frameData);
             frameData->release();
@@ -1608,7 +1608,7 @@ MovementBoneData *DataReaderHelper::decodeMovementBone(const rapidjson::Value& j
 
 FrameData *DataReaderHelper::decodeFrame(const rapidjson::Value& json, DataInfo *dataInfo)
 {
-    FrameData *frameData = new FrameData();
+    FrameData *frameData = new (std::nothrow) FrameData();
 
     decodeNode(frameData, json, dataInfo);
 
@@ -1650,7 +1650,7 @@ FrameData *DataReaderHelper::decodeFrame(const rapidjson::Value& json, DataInfo 
 
 TextureData *DataReaderHelper::decodeTexture(const rapidjson::Value& json)
 {
-    TextureData *textureData = new TextureData();
+    TextureData *textureData = new (std::nothrow) TextureData();
     textureData->init();
 
 	const char *name = DICTOOL->getStringValue_json(json, A_NAME);
@@ -1678,7 +1678,7 @@ TextureData *DataReaderHelper::decodeTexture(const rapidjson::Value& json)
 
 ContourData *DataReaderHelper::decodeContour(const rapidjson::Value& json)
 {
-    ContourData *contourData = new ContourData();
+    ContourData *contourData = new (std::nothrow) ContourData();
 	contourData->init();
 
 	int length = DICTOOL->getArrayCount_json(json, VERTEX_POINT);
@@ -1871,7 +1871,7 @@ void DataReaderHelper::decodeNode(BaseData *node, const rapidjson::Value& json, 
     
     ArmatureData* DataReaderHelper::decodeArmature(CocoLoader *cocoLoader, stExpCocoNode *cocoNode, DataInfo *dataInfo)
     {
-        ArmatureData *armatureData = new ArmatureData();
+        ArmatureData *armatureData = new (std::nothrow) ArmatureData();
         armatureData->init();
         stExpCocoNode *pAramtureDataArray = cocoNode->GetChildArray(cocoLoader);
         const char *name = pAramtureDataArray[2].GetValue(cocoLoader); //DICTOOL->getStringValue_json(json, A_NAME);
@@ -1900,7 +1900,7 @@ void DataReaderHelper::decodeNode(BaseData *node, const rapidjson::Value& json, 
     
     BoneData* DataReaderHelper::decodeBone(CocoLoader *cocoLoader, stExpCocoNode *cocoNode, DataInfo *dataInfo)
     {
-        BoneData *boneData = new BoneData();
+        BoneData *boneData = new (std::nothrow) BoneData();
         boneData->init();
         
         decodeNode(boneData, cocoLoader, cocoNode, dataInfo);
@@ -1968,7 +1968,7 @@ void DataReaderHelper::decodeNode(BaseData *node, const rapidjson::Value& json, 
             {
                 case CS_DISPLAY_SPRITE:
                 {
-                    displayData = new SpriteDisplayData();
+                    displayData = new (std::nothrow) SpriteDisplayData();
                     
                     const char *name =  children[0].GetValue(cocoLoader);
                     if(name != nullptr)
@@ -2023,7 +2023,7 @@ void DataReaderHelper::decodeNode(BaseData *node, const rapidjson::Value& json, 
                     break;
                 case CS_DISPLAY_ARMATURE:
                 {
-                    displayData = new ArmatureDisplayData();
+                    displayData = new (std::nothrow) ArmatureDisplayData();
                     
                     const char *name = cocoNode[0].GetValue(cocoLoader);
                     if(name != nullptr)
@@ -2034,7 +2034,7 @@ void DataReaderHelper::decodeNode(BaseData *node, const rapidjson::Value& json, 
                     break;
                 case CS_DISPLAY_PARTICLE:
                 {
-                    displayData = new ParticleDisplayData();
+                    displayData = new (std::nothrow) ParticleDisplayData();
                     length = cocoNode->GetChildNum();
                     stExpCocoNode *pDisplayData = cocoNode->GetChildArray(cocoLoader);
                     for (int i = 0; i < length; ++i)
@@ -2060,7 +2060,7 @@ void DataReaderHelper::decodeNode(BaseData *node, const rapidjson::Value& json, 
                 }
                     break;
                 default:
-                    displayData = new SpriteDisplayData();
+                    displayData = new (std::nothrow) SpriteDisplayData();
                     
                     break;
             }
@@ -2071,7 +2071,7 @@ void DataReaderHelper::decodeNode(BaseData *node, const rapidjson::Value& json, 
     
     AnimationData* DataReaderHelper::decodeAnimation(CocoLoader *cocoLoader, stExpCocoNode *cocoNode, DataInfo *dataInfo)
     {
-        AnimationData *aniData = new AnimationData();
+        AnimationData *aniData = new (std::nothrow) AnimationData();
         
         int length = cocoNode->GetChildNum();
         stExpCocoNode *pAnimationData = cocoNode->GetChildArray(cocoLoader);
@@ -2108,7 +2108,7 @@ void DataReaderHelper::decodeNode(BaseData *node, const rapidjson::Value& json, 
 
     MovementData* DataReaderHelper::decodeMovement(CocoLoader *cocoLoader, stExpCocoNode *cocoNode, DataInfo *dataInfo)
     {
-        MovementData *movementData = new MovementData();
+        MovementData *movementData = new (std::nothrow) MovementData();
         movementData->scale = 1.0f;
         
         int length =  cocoNode->GetChildNum();
@@ -2198,7 +2198,7 @@ void DataReaderHelper::decodeNode(BaseData *node, const rapidjson::Value& json, 
     
     MovementBoneData* DataReaderHelper::decodeMovementBone(CocoLoader *cocoLoader, stExpCocoNode *cocoNode, DataInfo *dataInfo)
     {
-        MovementBoneData *movementBoneData = new MovementBoneData();
+        MovementBoneData *movementBoneData = new (std::nothrow) MovementBoneData();
         movementBoneData->init();
         
         int length = cocoNode->GetChildNum();
@@ -2279,7 +2279,7 @@ void DataReaderHelper::decodeNode(BaseData *node, const rapidjson::Value& json, 
         {
             if (movementBoneData->frameList.size() > 0)
             {
-                FrameData *frameData = new FrameData();
+                FrameData *frameData = new (std::nothrow) FrameData();
                 frameData = movementBoneData->frameList.at(framesizemusone);
                 movementBoneData->addFrameData(frameData);
                 frameData->release();
@@ -2292,7 +2292,7 @@ void DataReaderHelper::decodeNode(BaseData *node, const rapidjson::Value& json, 
     
     FrameData* DataReaderHelper::decodeFrame(CocoLoader *cocoLoader, stExpCocoNode *cocoNode, DataInfo *dataInfo)
     {
-        FrameData *frameData = new FrameData();
+        FrameData *frameData = new (std::nothrow) FrameData();
         
         decodeNode(frameData, cocoLoader, cocoNode, dataInfo);
         
@@ -2396,7 +2396,7 @@ void DataReaderHelper::decodeNode(BaseData *node, const rapidjson::Value& json, 
     
     TextureData* DataReaderHelper::decodeTexture(CocoLoader *cocoLoader, stExpCocoNode *cocoNode)
     {
-        TextureData *textureData = new TextureData();
+        TextureData *textureData = new (std::nothrow) TextureData();
         textureData->init();
         
         if(cocoNode == nullptr)
@@ -2463,7 +2463,7 @@ void DataReaderHelper::decodeNode(BaseData *node, const rapidjson::Value& json, 
     
     ContourData* DataReaderHelper::decodeContour(CocoLoader *cocoLoader, stExpCocoNode *cocoNode)
     {
-        ContourData *contourData = new ContourData();
+        ContourData *contourData = new (std::nothrow) ContourData();
         contourData->init();
         
         int length = cocoNode->GetChildNum();

--- a/cocos/editor-support/cocostudio/CCDecorativeDisplay.cpp
+++ b/cocos/editor-support/cocostudio/CCDecorativeDisplay.cpp
@@ -31,7 +31,7 @@ namespace cocostudio {
 
 DecorativeDisplay *DecorativeDisplay::create()
 {
-    DecorativeDisplay *pDisplay = new DecorativeDisplay();
+    DecorativeDisplay *pDisplay = new (std::nothrow) DecorativeDisplay();
     if (pDisplay && pDisplay->init())
     {
         pDisplay->autorelease();

--- a/cocos/editor-support/cocostudio/CCDisplayManager.cpp
+++ b/cocos/editor-support/cocostudio/CCDisplayManager.cpp
@@ -36,7 +36,7 @@ namespace cocostudio {
 
 DisplayManager *DisplayManager::create(Bone *bone)
 {
-    DisplayManager *pDisplayManager = new DisplayManager();
+    DisplayManager *pDisplayManager = new (std::nothrow) DisplayManager();
     if (pDisplayManager && pDisplayManager->init(bone))
     {
         pDisplayManager->autorelease();

--- a/cocos/editor-support/cocostudio/CCSGUIReader.cpp
+++ b/cocos/editor-support/cocostudio/CCSGUIReader.cpp
@@ -91,7 +91,7 @@ GUIReader* GUIReader::getInstance()
 {
     if (!sharedReader)
     {
-        sharedReader = new GUIReader();
+        sharedReader = new (std::nothrow) GUIReader();
     }
     return sharedReader;
 }
@@ -200,18 +200,18 @@ Widget* GUIReader::widgetFromJsonFile(const char *fileName)
         int versionInteger = getVersionInteger(fileVersion);
         if (versionInteger < 250)
         {
-            pReader = new WidgetPropertiesReader0250();
+            pReader = new (std::nothrow) WidgetPropertiesReader0250();
             widget = pReader->createWidget(jsonDict, m_strFilePath.c_str(), fileName);
         }
         else
         {
-            pReader = new WidgetPropertiesReader0300();
+            pReader = new (std::nothrow) WidgetPropertiesReader0300();
             widget = pReader->createWidget(jsonDict, m_strFilePath.c_str(), fileName);
         }
     }
     else
     {
-        pReader = new WidgetPropertiesReader0250();
+        pReader = new (std::nothrow) WidgetPropertiesReader0250();
         widget = pReader->createWidget(jsonDict, m_strFilePath.c_str(), fileName);
     }
     
@@ -379,18 +379,18 @@ Widget* GUIReader::widgetFromBinaryFile(const char *fileName)
                     if (versionInteger < 250)
                     {
                         CCASSERT(0, "You current studio doesn't support binary format, please upgrade to the latest version!");
-                        pReader = new WidgetPropertiesReader0250();
+                        pReader = new (std::nothrow) WidgetPropertiesReader0250();
                         widget = pReader->createWidgetFromBinary(&tCocoLoader, tpRootCocoNode, fileName);
                     }
                     else
                     {
-                        pReader = new WidgetPropertiesReader0300();
+                        pReader = new (std::nothrow) WidgetPropertiesReader0300();
                         widget = pReader->createWidgetFromBinary(&tCocoLoader, tpRootCocoNode, fileName);
                     }
                 }
                 else
                 {
-                    pReader = new WidgetPropertiesReader0250();
+                    pReader = new (std::nothrow) WidgetPropertiesReader0250();
                     widget = pReader->createWidgetFromBinary(&tCocoLoader, tpRootCocoNode, fileName);
                 }
                 

--- a/cocos/editor-support/cocostudio/CCSSceneReader.cpp
+++ b/cocos/editor-support/cocostudio/CCSSceneReader.cpp
@@ -103,7 +103,7 @@ cocos2d::Node* SceneReader::createNodeWithSceneFile(const std::string &fileName,
 						nCount = tpChildArray[15].GetChildNum();
 					}
 					stExpCocoNode *pComponents = tpChildArray[15].GetChildArray(&tCocoLoader);
-					SerData *data = new SerData();
+					SerData *data = new (std::nothrow) SerData();
 					for (int i = 0; i < nCount; i++)
 					{
 						stExpCocoNode *subDict = pComponents[i].GetChildArray(&tCocoLoader);
@@ -279,7 +279,7 @@ Node* SceneReader::createObject(const rapidjson::Value &dict, cocos2d::Node* par
             const char *comName = DICTOOL->getStringValue_json(subDict, "classname");
             Component *com = this->createComponent(comName);
             CCLOG("classname = %s", comName);
-            SerData *data = new SerData();
+            SerData *data = new (std::nothrow) SerData();
             if (com != nullptr)
             {
                 data->_rData = &subDict;
@@ -369,7 +369,7 @@ cocos2d::Node* SceneReader::createObject(CocoLoader *cocoLoader, stExpCocoNode *
             count = pNodeArray[13].GetChildNum();
         }
         stExpCocoNode *pComponents = pNodeArray[13].GetChildArray(cocoLoader);
-        SerData *data = new SerData();
+        SerData *data = new (std::nothrow) SerData();
         for (int i = 0; i < count; ++i)
         {
             stExpCocoNode *subDict = pComponents[i].GetChildArray(cocoLoader);
@@ -555,7 +555,7 @@ SceneReader* SceneReader::getInstance()
 {
     if (s_sharedReader == nullptr)
     {
-        s_sharedReader = new SceneReader();
+        s_sharedReader = new (std::nothrow) SceneReader();
     }
     return s_sharedReader;
 }

--- a/cocos/editor-support/cocostudio/CCSkin.cpp
+++ b/cocos/editor-support/cocostudio/CCSkin.cpp
@@ -47,7 +47,7 @@ namespace cocostudio {
 
 Skin *Skin::create()
 {
-    Skin *skin = new Skin();
+    Skin *skin = new (std::nothrow) Skin();
     if(skin && skin->init())
     {
         skin->autorelease();
@@ -59,7 +59,7 @@ Skin *Skin::create()
 
 Skin *Skin::createWithSpriteFrameName(const std::string& pszSpriteFrameName)
 {
-    Skin *skin = new Skin();
+    Skin *skin = new (std::nothrow) Skin();
     if(skin && skin->initWithSpriteFrameName(pszSpriteFrameName))
     {
         skin->autorelease();
@@ -71,7 +71,7 @@ Skin *Skin::createWithSpriteFrameName(const std::string& pszSpriteFrameName)
 
 Skin *Skin::create(const std::string& pszFileName)
 {
-    Skin *skin = new Skin();
+    Skin *skin = new (std::nothrow) Skin();
     if(skin && skin->initWithFile(pszFileName))
     {
         skin->autorelease();

--- a/cocos/editor-support/cocostudio/CCSpriteFrameCacheHelper.cpp
+++ b/cocos/editor-support/cocostudio/CCSpriteFrameCacheHelper.cpp
@@ -37,7 +37,7 @@ SpriteFrameCacheHelper *SpriteFrameCacheHelper::getInstance()
 {
     if(!_spriteFrameCacheHelper)
     {
-        _spriteFrameCacheHelper = new SpriteFrameCacheHelper();
+        _spriteFrameCacheHelper = new (std::nothrow) SpriteFrameCacheHelper();
     }
 
     return _spriteFrameCacheHelper;

--- a/cocos/editor-support/cocostudio/CCTween.cpp
+++ b/cocos/editor-support/cocostudio/CCTween.cpp
@@ -37,7 +37,7 @@ using cocos2d::tweenfunc::Linear;
 
 Tween *Tween::create(Bone *bone)
 {
-    Tween *pTween = new Tween();
+    Tween *pTween = new (std::nothrow) Tween();
     if (pTween && pTween->init(bone))
     {
         pTween->autorelease();
@@ -80,8 +80,8 @@ bool Tween::init(Bone *bone)
     bool bRet = false;
     do
     {
-        _from = new FrameData();
-        _between = new FrameData();
+        _from = new (std::nothrow) FrameData();
+        _between = new (std::nothrow) FrameData();
 
         _bone = bone;
         _tweenData = _bone->getTweenData();

--- a/cocos/editor-support/cocostudio/DictionaryHelper.cpp
+++ b/cocos/editor-support/cocostudio/DictionaryHelper.cpp
@@ -42,7 +42,7 @@ DictionaryHelper::~DictionaryHelper()
 DictionaryHelper* DictionaryHelper::getInstance()
 {
     if (!sharedHelper) {
-        sharedHelper = new DictionaryHelper();
+        sharedHelper = new (std::nothrow) DictionaryHelper();
     }
     return sharedHelper;
 }

--- a/cocos/editor-support/cocostudio/TriggerMng.cpp
+++ b/cocos/editor-support/cocostudio/TriggerMng.cpp
@@ -60,7 +60,7 @@ TriggerMng* TriggerMng::getInstance()
 {
     if (nullptr == _sharedTriggerMng)
     {
-        _sharedTriggerMng = new TriggerMng();
+        _sharedTriggerMng = new (std::nothrow) TriggerMng();
     }
     return _sharedTriggerMng;
 }
@@ -411,7 +411,7 @@ void TriggerMng::addArmatureMovementCallBack(Armature *pAr, Ref *pTarget, SEL_Mo
 	ArmatureMovementDispatcher *amd = nullptr;
 	if (iter == _movementDispatches->end())
 	{
-		amd = new ArmatureMovementDispatcher();
+		amd = new (std::nothrow) ArmatureMovementDispatcher();
         pAr->getAnimation()->setMovementEventCallFunc(CC_CALLBACK_0(ArmatureMovementDispatcher::animationEvent, amd, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
         amd->addAnimationEventCallBack(pTarget, mecf);
 		_movementDispatches->insert(std::make_pair(pAr, amd));

--- a/cocos/editor-support/cocostudio/TriggerObj.cpp
+++ b/cocos/editor-support/cocostudio/TriggerObj.cpp
@@ -105,7 +105,7 @@ bool TriggerObj::init()
 
 TriggerObj* TriggerObj::create()
 {
-    TriggerObj * pRet = new TriggerObj();
+    TriggerObj * pRet = new (std::nothrow) TriggerObj();
     if (pRet && pRet->init())
     {
         pRet->autorelease();

--- a/cocos/editor-support/cocostudio/WidgetReader/ButtonReader/ButtonReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/ButtonReader/ButtonReader.cpp
@@ -47,7 +47,7 @@ namespace cocostudio
     {
         if (!instanceButtonReader)
         {
-            instanceButtonReader = new ButtonReader();
+            instanceButtonReader = new (std::nothrow) ButtonReader();
         }
         return instanceButtonReader;
     }

--- a/cocos/editor-support/cocostudio/WidgetReader/CheckBoxReader/CheckBoxReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/CheckBoxReader/CheckBoxReader.cpp
@@ -33,7 +33,7 @@ namespace cocostudio
     {
         if (!instanceCheckBoxReader)
         {
-            instanceCheckBoxReader = new CheckBoxReader();
+            instanceCheckBoxReader = new (std::nothrow) CheckBoxReader();
         }
         return instanceCheckBoxReader;
     }

--- a/cocos/editor-support/cocostudio/WidgetReader/ImageViewReader/ImageViewReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/ImageViewReader/ImageViewReader.cpp
@@ -37,7 +37,7 @@ namespace cocostudio
     {
         if (!instanceImageViewReader)
         {
-            instanceImageViewReader = new ImageViewReader();
+            instanceImageViewReader = new (std::nothrow) ImageViewReader();
         }
         return instanceImageViewReader;
     }

--- a/cocos/editor-support/cocostudio/WidgetReader/LayoutReader/LayoutReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/LayoutReader/LayoutReader.cpp
@@ -52,7 +52,7 @@ namespace cocostudio
     {
         if (!instanceLayoutReader)
         {
-            instanceLayoutReader = new LayoutReader();
+            instanceLayoutReader = new (std::nothrow) LayoutReader();
         }
         return instanceLayoutReader;
     }

--- a/cocos/editor-support/cocostudio/WidgetReader/ListViewReader/ListViewReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/ListViewReader/ListViewReader.cpp
@@ -30,7 +30,7 @@ namespace cocostudio
     {
         if (!instanceListViewReader)
         {
-            instanceListViewReader = new ListViewReader();
+            instanceListViewReader = new (std::nothrow) ListViewReader();
         }
         return instanceListViewReader;
     }

--- a/cocos/editor-support/cocostudio/WidgetReader/LoadingBarReader/LoadingBarReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/LoadingBarReader/LoadingBarReader.cpp
@@ -37,7 +37,7 @@ namespace cocostudio
     {
         if (!instanceLoadingBar)
         {
-            instanceLoadingBar = new LoadingBarReader();
+            instanceLoadingBar = new (std::nothrow) LoadingBarReader();
         }
         return instanceLoadingBar;
     }

--- a/cocos/editor-support/cocostudio/WidgetReader/PageViewReader/PageViewReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/PageViewReader/PageViewReader.cpp
@@ -28,7 +28,7 @@ namespace cocostudio
     {
         if (!instancePageViewReader)
         {
-            instancePageViewReader = new PageViewReader();
+            instancePageViewReader = new (std::nothrow) PageViewReader();
         }
         return instancePageViewReader;
     }

--- a/cocos/editor-support/cocostudio/WidgetReader/ScrollViewReader/ScrollViewReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/ScrollViewReader/ScrollViewReader.cpp
@@ -32,7 +32,7 @@ namespace cocostudio
     {
         if (!instanceScrollViewReader)
         {
-            instanceScrollViewReader = new ScrollViewReader();
+            instanceScrollViewReader = new (std::nothrow) ScrollViewReader();
         }
         return instanceScrollViewReader;
     }

--- a/cocos/editor-support/cocostudio/WidgetReader/SliderReader/SliderReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/SliderReader/SliderReader.cpp
@@ -36,7 +36,7 @@ namespace cocostudio
     {
         if (!instanceSliderReader)
         {
-            instanceSliderReader = new SliderReader();
+            instanceSliderReader = new (std::nothrow) SliderReader();
         }
         return instanceSliderReader;
     }

--- a/cocos/editor-support/cocostudio/WidgetReader/TextAtlasReader/TextAtlasReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/TextAtlasReader/TextAtlasReader.cpp
@@ -33,7 +33,7 @@ namespace cocostudio
     {
         if (!instanceTextAtalsReader)
         {
-            instanceTextAtalsReader = new TextAtlasReader();
+            instanceTextAtalsReader = new (std::nothrow) TextAtlasReader();
         }
         return instanceTextAtalsReader;
     }

--- a/cocos/editor-support/cocostudio/WidgetReader/TextBMFontReader/TextBMFontReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/TextBMFontReader/TextBMFontReader.cpp
@@ -30,7 +30,7 @@ namespace cocostudio
     {
         if (!instanceTextBMFontReader)
         {
-            instanceTextBMFontReader = new TextBMFontReader();
+            instanceTextBMFontReader = new (std::nothrow) TextBMFontReader();
         }
         return instanceTextBMFontReader;
     }

--- a/cocos/editor-support/cocostudio/WidgetReader/TextFieldReader/TextFieldReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/TextFieldReader/TextFieldReader.cpp
@@ -38,7 +38,7 @@ namespace cocostudio
     {
         if (!instanceTextFieldReader)
         {
-            instanceTextFieldReader = new TextFieldReader();
+            instanceTextFieldReader = new (std::nothrow) TextFieldReader();
         }
         return instanceTextFieldReader;
     }

--- a/cocos/editor-support/cocostudio/WidgetReader/TextReader/TextReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/TextReader/TextReader.cpp
@@ -36,7 +36,7 @@ namespace cocostudio
     {
         if (!instanceTextReader)
         {
-            instanceTextReader = new TextReader();
+            instanceTextReader = new (std::nothrow) TextReader();
         }
         return instanceTextReader;
     }

--- a/cocos/editor-support/cocostudio/WidgetReader/WidgetReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/WidgetReader.cpp
@@ -101,7 +101,7 @@ namespace cocostudio
     {
         if (!instanceWidgetReader)
         {
-            instanceWidgetReader = new WidgetReader();
+            instanceWidgetReader = new (std::nothrow) WidgetReader();
         }
         return instanceWidgetReader;
     }

--- a/cocos/editor-support/spine/CCSkeleton.cpp
+++ b/cocos/editor-support/spine/CCSkeleton.cpp
@@ -41,19 +41,19 @@ using std::max;
 namespace spine {
 
 Skeleton* Skeleton::createWithData (spSkeletonData* skeletonData, bool isOwnsSkeletonData) {
-	Skeleton* node = new Skeleton(skeletonData, isOwnsSkeletonData);
+	Skeleton* node = new (std::nothrow) Skeleton(skeletonData, isOwnsSkeletonData);
 	node->autorelease();
 	return node;
 }
 
 Skeleton* Skeleton::createWithFile (const char* skeletonDataFile, spAtlas* atlas, float scale) {
-	Skeleton* node = new Skeleton(skeletonDataFile, atlas, scale);
+	Skeleton* node = new (std::nothrow) Skeleton(skeletonDataFile, atlas, scale);
 	node->autorelease();
 	return node;
 }
 
 Skeleton* Skeleton::createWithFile (const char* skeletonDataFile, const char* atlasFile, float scale) {
-	Skeleton* node = new Skeleton(skeletonDataFile, atlasFile, scale);
+	Skeleton* node = new (std::nothrow) Skeleton(skeletonDataFile, atlasFile, scale);
 	node->autorelease();
 	return node;
 }

--- a/cocos/editor-support/spine/CCSkeletonAnimation.cpp
+++ b/cocos/editor-support/spine/CCSkeletonAnimation.cpp
@@ -47,19 +47,19 @@ static void callback (spAnimationState* state, int trackIndex, spEventType type,
 }
 
 SkeletonAnimation* SkeletonAnimation::createWithData (spSkeletonData* skeletonData) {
-	SkeletonAnimation* node = new SkeletonAnimation(skeletonData);
+	SkeletonAnimation* node = new (std::nothrow) SkeletonAnimation(skeletonData);
 	node->autorelease();
 	return node;
 }
 
 SkeletonAnimation* SkeletonAnimation::createWithFile (const char* skeletonDataFile, spAtlas* atlas, float scale) {
-	SkeletonAnimation* node = new SkeletonAnimation(skeletonDataFile, atlas, scale);
+	SkeletonAnimation* node = new (std::nothrow) SkeletonAnimation(skeletonDataFile, atlas, scale);
 	node->autorelease();
 	return node;
 }
 
 SkeletonAnimation* SkeletonAnimation::createWithFile (const char* skeletonDataFile, const char* atlasFile, float scale) {
-	SkeletonAnimation* node = new SkeletonAnimation(skeletonDataFile, atlasFile, scale);
+	SkeletonAnimation* node = new (std::nothrow) SkeletonAnimation(skeletonDataFile, atlasFile, scale);
 	node->autorelease();
 	return node;
 }

--- a/cocos/network/HttpClient.cpp
+++ b/cocos/network/HttpClient.cpp
@@ -142,7 +142,7 @@ void HttpClient::networkThread()
         // step 2: libcurl sync access
         
         // Create a HttpResponse object, the default setting is http access failed
-        HttpResponse *response = new HttpResponse(request);
+        HttpResponse *response = new (std::nothrow) HttpResponse(request);
         
         processResponse(response, s_errorBuffer);
         
@@ -176,7 +176,7 @@ void HttpClient::networkThread()
 void HttpClient::networkThreadAlone(HttpRequest* request)
 {
     // Create a HttpResponse object, the default setting is http access failed
-    HttpResponse *response = new HttpResponse(request);
+    HttpResponse *response = new (std::nothrow) HttpResponse(request);
     char errorBuffer[CURL_ERROR_SIZE] = { 0 };
     processResponse(response, errorBuffer);
 
@@ -434,7 +434,7 @@ static void processResponse(HttpResponse* response, char* errorBuffer)
 HttpClient* HttpClient::getInstance()
 {
     if (s_pHttpClient == nullptr) {
-        s_pHttpClient = new HttpClient();
+        s_pHttpClient = new (std::nothrow) HttpClient();
     }
     
     return s_pHttpClient;
@@ -478,8 +478,8 @@ bool HttpClient::lazyInitThreadSemphore()
         return true;
     } else {
         
-        s_requestQueue = new Vector<HttpRequest*>();
-        s_responseQueue = new Vector<HttpResponse*>();
+        s_requestQueue = new (std::nothrow) Vector<HttpRequest*>();
+        s_responseQueue = new (std::nothrow) Vector<HttpResponse*>();
         
 		s_need_quit = false;
 		

--- a/cocos/network/SocketIO.cpp
+++ b/cocos/network/SocketIO.cpp
@@ -120,7 +120,7 @@ void SIOClientImpl::handshake()
     std::stringstream pre;
     pre << "http://" << _uri << "/socket.io/1";
 
-    HttpRequest* request = new HttpRequest();
+    HttpRequest* request = new (std::nothrow) HttpRequest();
     request->setUrl(pre.str().c_str());
     request->setRequestType(HttpRequest::Type::GET);
 
@@ -216,7 +216,7 @@ void SIOClientImpl::openSocket()
     std::stringstream s;
     s << _uri << "/socket.io/1/websocket/" << _sid;
 
-    _ws = new WebSocket();
+    _ws = new (std::nothrow) WebSocket();
     if (!_ws->init(*this, s.str()))
     {
         CC_SAFE_DELETE(_ws);
@@ -258,7 +258,7 @@ void SIOClientImpl::disconnect()
 
 SIOClientImpl* SIOClientImpl::create(const std::string& host, int port)
 {
-    SIOClientImpl *s = new SIOClientImpl(host, port);
+    SIOClientImpl *s = new (std::nothrow) SIOClientImpl(host, port);
 
     if (s && s->init())
     {
@@ -595,7 +595,7 @@ SocketIO::~SocketIO(void)
 SocketIO* SocketIO::getInstance()
 {
     if (nullptr == _inst)
-        _inst = new SocketIO();
+        _inst = new (std::nothrow) SocketIO();
 
     return _inst;
 }
@@ -660,7 +660,7 @@ SIOClient* SocketIO::connect(const std::string& uri, SocketIO::SIODelegate& dele
         //create a new socket, new client, connect
         socket = SIOClientImpl::create(host, port);
 
-        c = new SIOClient(host, port, path, socket, delegate);
+        c = new (std::nothrow) SIOClient(host, port, path, socket, delegate);
 
         socket->addClient(path, c);
 
@@ -673,7 +673,7 @@ SIOClient* SocketIO::connect(const std::string& uri, SocketIO::SIODelegate& dele
 
         if(c == nullptr)
         {
-            c = new SIOClient(host, port, path, socket, delegate);
+            c = new (std::nothrow) SIOClient(host, port, path, socket, delegate);
 
             socket->addClient(path, c);
 

--- a/cocos/network/WebSocket.cpp
+++ b/cocos/network/WebSocket.cpp
@@ -322,7 +322,7 @@ bool WebSocket::init(const Delegate& delegate,
     }
     
     // WebSocket thread needs to be invoked at the end of this method.
-    _wsHelper = new WsThreadHelper();
+    _wsHelper = new (std::nothrow) WsThreadHelper();
     ret = _wsHelper->createThread(*this);
     
     return ret;
@@ -333,9 +333,9 @@ void WebSocket::send(const std::string& message)
     if (_readyState == State::OPEN)
     {
         // In main thread
-        WsMessage* msg = new WsMessage();
+        WsMessage* msg = new (std::nothrow) WsMessage();
         msg->what = WS_MSG_TO_SUBTRHEAD_SENDING_STRING;
-        Data* data = new Data();
+        Data* data = new (std::nothrow) Data();
         data->bytes = new char[message.length()+1];
         strcpy(data->bytes, message.c_str());
         data->len = static_cast<ssize_t>(message.length());
@@ -351,9 +351,9 @@ void WebSocket::send(const unsigned char* binaryMsg, unsigned int len)
     if (_readyState == State::OPEN)
     {
         // In main thread
-        WsMessage* msg = new WsMessage();
+        WsMessage* msg = new (std::nothrow) WsMessage();
         msg->what = WS_MSG_TO_SUBTRHEAD_SENDING_BINARY;
-        Data* data = new Data();
+        Data* data = new (std::nothrow) Data();
         data->bytes = new char[len];
         memcpy((void*)data->bytes, (void*)binaryMsg, len);
         data->len = len;
@@ -446,7 +446,7 @@ void WebSocket::onSubThreadStarted()
                                              name.c_str(), -1);
                                              
         if(nullptr == _wsInstance) {
-            WsMessage* msg = new WsMessage();
+            WsMessage* msg = new (std::nothrow) WsMessage();
             msg->what = WS_MSG_TO_UITHREAD_ERROR;
             _readyState = State::CLOSING;
             _wsHelper->sendMessageToUIThread(msg);
@@ -481,13 +481,13 @@ int WebSocket::onSocketCallback(struct libwebsocket_context *ctx,
                     || (reason == LWS_CALLBACK_DEL_POLL_FD && _readyState == State::CONNECTING)
                     )
                 {
-                    msg = new WsMessage();
+                    msg = new (std::nothrow) WsMessage();
                     msg->what = WS_MSG_TO_UITHREAD_ERROR;
                     _readyState = State::CLOSING;
                 }
                 else if (reason == LWS_CALLBACK_PROTOCOL_DESTROY && _readyState == State::CLOSING)
                 {
-                    msg = new WsMessage();
+                    msg = new (std::nothrow) WsMessage();
                     msg->what = WS_MSG_TO_UITHREAD_CLOSE;
                 }
 
@@ -499,7 +499,7 @@ int WebSocket::onSocketCallback(struct libwebsocket_context *ctx,
             break;
         case LWS_CALLBACK_CLIENT_ESTABLISHED:
             {
-                WsMessage* msg = new WsMessage();
+                WsMessage* msg = new (std::nothrow) WsMessage();
                 msg->what = WS_MSG_TO_UITHREAD_OPEN;
                 _readyState = State::OPEN;
                 
@@ -603,7 +603,7 @@ int WebSocket::onSocketCallback(struct libwebsocket_context *ctx,
                 
                 if (_readyState != State::CLOSED)
                 {
-                    WsMessage* msg = new WsMessage();
+                    WsMessage* msg = new (std::nothrow) WsMessage();
                     _readyState = State::CLOSED;
                     msg->what = WS_MSG_TO_UITHREAD_CLOSE;
                     _wsHelper->sendMessageToUIThread(msg);
@@ -642,11 +642,11 @@ int WebSocket::onSocketCallback(struct libwebsocket_context *ctx,
                     // If no more data pending, send it to the client thread
                     if (_pendingFrameDataLen == 0)
                     {
-						WsMessage* msg = new WsMessage();
+						WsMessage* msg = new (std::nothrow) WsMessage();
 						msg->what = WS_MSG_TO_UITHREAD_MESSAGE;
 
 						char* bytes = nullptr;
-						Data* data = new Data();
+						Data* data = new (std::nothrow) Data();
 
 						if (lws_frame_is_binary(wsi))
 						{

--- a/cocos/physics/CCPhysicsBody.cpp
+++ b/cocos/physics/CCPhysicsBody.cpp
@@ -91,7 +91,7 @@ PhysicsBody::~PhysicsBody()
 
 PhysicsBody* PhysicsBody::create()
 {
-    PhysicsBody* body = new PhysicsBody();
+    PhysicsBody* body = new (std::nothrow) PhysicsBody();
     if (body && body->init())
     {
         body->autorelease();
@@ -104,7 +104,7 @@ PhysicsBody* PhysicsBody::create()
 
 PhysicsBody* PhysicsBody::create(float mass)
 {
-    PhysicsBody* body = new PhysicsBody();
+    PhysicsBody* body = new (std::nothrow) PhysicsBody();
     if (body)
     {
         body->_mass = mass;
@@ -122,7 +122,7 @@ PhysicsBody* PhysicsBody::create(float mass)
 
 PhysicsBody* PhysicsBody::create(float mass, float moment)
 {
-    PhysicsBody* body = new PhysicsBody();
+    PhysicsBody* body = new (std::nothrow) PhysicsBody();
     if (body)
     {
         body->_mass = mass;
@@ -143,7 +143,7 @@ PhysicsBody* PhysicsBody::create(float mass, float moment)
 
 PhysicsBody* PhysicsBody::createCircle(float radius, const PhysicsMaterial& material, const Vec2& offset)
 {
-    PhysicsBody* body = new PhysicsBody();
+    PhysicsBody* body = new (std::nothrow) PhysicsBody();
     if (body && body->init())
     {
         body->addShape(PhysicsShapeCircle::create(radius, material, offset));
@@ -157,7 +157,7 @@ PhysicsBody* PhysicsBody::createCircle(float radius, const PhysicsMaterial& mate
 
 PhysicsBody* PhysicsBody::createBox(const Size& size, const PhysicsMaterial& material, const Vec2& offset)
 {
-    PhysicsBody* body = new PhysicsBody();
+    PhysicsBody* body = new (std::nothrow) PhysicsBody();
     if (body && body->init())
     {
         body->addShape(PhysicsShapeBox::create(size, material, offset));
@@ -171,7 +171,7 @@ PhysicsBody* PhysicsBody::createBox(const Size& size, const PhysicsMaterial& mat
 
 PhysicsBody* PhysicsBody::createPolygon(const Vec2* points, int count, const PhysicsMaterial& material, const Vec2& offset)
 {
-    PhysicsBody* body = new PhysicsBody();
+    PhysicsBody* body = new (std::nothrow) PhysicsBody();
     if (body && body->init())
     {
         body->addShape(PhysicsShapePolygon::create(points, count, material, offset));
@@ -185,7 +185,7 @@ PhysicsBody* PhysicsBody::createPolygon(const Vec2* points, int count, const Phy
 
 PhysicsBody* PhysicsBody::createEdgeSegment(const Vec2& a, const Vec2& b, const PhysicsMaterial& material, float border/* = 1*/)
 {
-    PhysicsBody* body = new PhysicsBody();
+    PhysicsBody* body = new (std::nothrow) PhysicsBody();
     if (body && body->init())
     {
         body->addShape(PhysicsShapeEdgeSegment::create(a, b, material, border));
@@ -200,7 +200,7 @@ PhysicsBody* PhysicsBody::createEdgeSegment(const Vec2& a, const Vec2& b, const 
 
 PhysicsBody* PhysicsBody::createEdgeBox(const Size& size, const PhysicsMaterial& material, float border/* = 1*/, const Vec2& offset)
 {
-    PhysicsBody* body = new PhysicsBody();
+    PhysicsBody* body = new (std::nothrow) PhysicsBody();
     if (body && body->init())
     {
         body->addShape(PhysicsShapeEdgeBox::create(size, material, border, offset));
@@ -216,7 +216,7 @@ PhysicsBody* PhysicsBody::createEdgeBox(const Size& size, const PhysicsMaterial&
 
 PhysicsBody* PhysicsBody::createEdgePolygon(const Vec2* points, int count, const PhysicsMaterial& material, float border/* = 1*/)
 {
-    PhysicsBody* body = new PhysicsBody();
+    PhysicsBody* body = new (std::nothrow) PhysicsBody();
     if (body && body->init())
     {
         body->addShape(PhysicsShapeEdgePolygon::create(points, count, material, border));
@@ -232,7 +232,7 @@ PhysicsBody* PhysicsBody::createEdgePolygon(const Vec2* points, int count, const
 
 PhysicsBody* PhysicsBody::createEdgeChain(const Vec2* points, int count, const PhysicsMaterial& material, float border/* = 1*/)
 {
-    PhysicsBody* body = new PhysicsBody();
+    PhysicsBody* body = new (std::nothrow) PhysicsBody();
     if (body && body->init())
     {
         body->addShape(PhysicsShapeEdgeChain::create(points, count, material, border));
@@ -250,7 +250,7 @@ bool PhysicsBody::init()
 {
     do
     {
-        _info = new PhysicsBodyInfo();
+        _info = new (std::nothrow) PhysicsBodyInfo();
         CC_BREAK_IF(_info == nullptr);
         
         _info->setBody(cpBodyNew(PhysicsHelper::float2cpfloat(_mass), PhysicsHelper::float2cpfloat(_moment)));

--- a/cocos/physics/CCPhysicsContact.cpp
+++ b/cocos/physics/CCPhysicsContact.cpp
@@ -62,7 +62,7 @@ PhysicsContact::~PhysicsContact()
 
 PhysicsContact* PhysicsContact::construct(PhysicsShape* a, PhysicsShape* b)
 {
-    PhysicsContact * contact = new PhysicsContact();
+    PhysicsContact * contact = new (std::nothrow) PhysicsContact();
     if(contact && contact->init(a, b))
     {
         return contact;
@@ -78,7 +78,7 @@ bool PhysicsContact::init(PhysicsShape* a, PhysicsShape* b)
     {
         CC_BREAK_IF(a == nullptr || b == nullptr);
         
-        CC_BREAK_IF(!(_info = new PhysicsContactInfo(this)));
+        CC_BREAK_IF(!(_info = new (std::nothrow) PhysicsContactInfo(this)));
         
         _shapeA = a;
         _shapeB = b;
@@ -99,7 +99,7 @@ void PhysicsContact::generateContactData()
     cpArbiter* arb = static_cast<cpArbiter*>(_contactInfo);
     CC_SAFE_DELETE(_preContactData);
     _preContactData = _contactData;
-    _contactData = new PhysicsContactData();
+    _contactData = new (std::nothrow) PhysicsContactData();
     _contactData->count = cpArbiterGetCount(arb);
     for (int i=0; i<_contactData->count && i<PhysicsContactData::POINT_MAX; ++i)
     {
@@ -271,7 +271,7 @@ EventListenerPhysicsContact::~EventListenerPhysicsContact()
 
 EventListenerPhysicsContact* EventListenerPhysicsContact::create()
 {
-    EventListenerPhysicsContact* obj = new EventListenerPhysicsContact();
+    EventListenerPhysicsContact* obj = new (std::nothrow) EventListenerPhysicsContact();
     
     if (obj != nullptr && obj->init())
     {
@@ -322,7 +322,7 @@ EventListenerPhysicsContact* EventListenerPhysicsContact::clone()
 
 EventListenerPhysicsContactWithBodies* EventListenerPhysicsContactWithBodies::create(PhysicsBody* bodyA, PhysicsBody* bodyB)
 {
-    EventListenerPhysicsContactWithBodies* obj = new EventListenerPhysicsContactWithBodies();
+    EventListenerPhysicsContactWithBodies* obj = new (std::nothrow) EventListenerPhysicsContactWithBodies();
     
     if (obj != nullptr && obj->init())
     {
@@ -390,7 +390,7 @@ EventListenerPhysicsContactWithShapes::~EventListenerPhysicsContactWithShapes()
 
 EventListenerPhysicsContactWithShapes* EventListenerPhysicsContactWithShapes::create(PhysicsShape* shapeA, PhysicsShape* shapeB)
 {
-    EventListenerPhysicsContactWithShapes* obj = new EventListenerPhysicsContactWithShapes();
+    EventListenerPhysicsContactWithShapes* obj = new (std::nothrow) EventListenerPhysicsContactWithShapes();
     
     if (obj != nullptr && obj->init())
     {
@@ -444,7 +444,7 @@ EventListenerPhysicsContactWithGroup::~EventListenerPhysicsContactWithGroup()
 
 EventListenerPhysicsContactWithGroup* EventListenerPhysicsContactWithGroup::create(int group)
 {
-    EventListenerPhysicsContactWithGroup* obj = new EventListenerPhysicsContactWithGroup();
+    EventListenerPhysicsContactWithGroup* obj = new (std::nothrow) EventListenerPhysicsContactWithGroup();
     
     if (obj != nullptr && obj->init())
     {

--- a/cocos/physics/CCPhysicsJoint.cpp
+++ b/cocos/physics/CCPhysicsJoint.cpp
@@ -65,7 +65,7 @@ bool PhysicsJoint::init(cocos2d::PhysicsBody *a, cocos2d::PhysicsBody *b)
         CCASSERT(a != nullptr && b != nullptr, "the body passed in is nil");
         CCASSERT(a != b, "the two bodies are equal");
         
-        CC_BREAK_IF(!(_info = new PhysicsJointInfo(this)));
+        CC_BREAK_IF(!(_info = new (std::nothrow) PhysicsJointInfo(this)));
         
         _bodyA = a;
         _bodyA->_joints.push_back(this);
@@ -164,7 +164,7 @@ float PhysicsJoint::getMaxForce() const
 
 PhysicsJointFixed* PhysicsJointFixed::construct(PhysicsBody* a, PhysicsBody* b, const Vec2& anchr)
 {
-    PhysicsJointFixed* joint = new PhysicsJointFixed();
+    PhysicsJointFixed* joint = new (std::nothrow) PhysicsJointFixed();
     
     if (joint && joint->init(a, b, anchr))
     {
@@ -205,7 +205,7 @@ bool PhysicsJointFixed::init(PhysicsBody* a, PhysicsBody* b, const Vec2& anchr)
 
 PhysicsJointPin* PhysicsJointPin::construct(PhysicsBody* a, PhysicsBody* b, const Vec2& anchr)
 {
-    PhysicsJointPin* joint = new PhysicsJointPin();
+    PhysicsJointPin* joint = new (std::nothrow) PhysicsJointPin();
     
     if (joint && joint->init(a, b, anchr))
     {
@@ -236,7 +236,7 @@ bool PhysicsJointPin::init(PhysicsBody *a, PhysicsBody *b, const Vec2& anchr)
 
 PhysicsJointLimit* PhysicsJointLimit::construct(PhysicsBody* a, PhysicsBody* b, const Vec2& anchr1, const Vec2& anchr2, float min, float max)
 {
-    PhysicsJointLimit* joint = new PhysicsJointLimit();
+    PhysicsJointLimit* joint = new (std::nothrow) PhysicsJointLimit();
     
     if (joint && joint->init(a, b, anchr1, anchr2, min, max))
     {
@@ -316,7 +316,7 @@ void PhysicsJointLimit::setAnchr2(const Vec2& anchr)
 
 PhysicsJointDistance* PhysicsJointDistance::construct(PhysicsBody* a, PhysicsBody* b, const Vec2& anchr1, const Vec2& anchr2)
 {
-    PhysicsJointDistance* joint = new PhysicsJointDistance();
+    PhysicsJointDistance* joint = new (std::nothrow) PhysicsJointDistance();
     
     if (joint && joint->init(a, b, anchr1, anchr2))
     {
@@ -360,7 +360,7 @@ void PhysicsJointDistance::setDistance(float distance)
 
 PhysicsJointSpring* PhysicsJointSpring::construct(PhysicsBody* a, PhysicsBody* b, const Vec2& anchr1, const Vec2& anchr2, float stiffness, float damping)
 {
-    PhysicsJointSpring* joint = new PhysicsJointSpring();
+    PhysicsJointSpring* joint = new (std::nothrow) PhysicsJointSpring();
     
     if (joint && joint->init(a, b, anchr1, anchr2, stiffness, damping))
     {
@@ -446,7 +446,7 @@ void PhysicsJointSpring::setDamping(float damping)
 
 PhysicsJointGroove* PhysicsJointGroove::construct(PhysicsBody* a, PhysicsBody* b, const Vec2& grooveA, const Vec2& grooveB, const Vec2& anchr2)
 {
-    PhysicsJointGroove* joint = new PhysicsJointGroove();
+    PhysicsJointGroove* joint = new (std::nothrow) PhysicsJointGroove();
     
     if (joint && joint->init(a, b, grooveA, grooveB, anchr2))
     {
@@ -510,7 +510,7 @@ void PhysicsJointGroove::setAnchr2(const Vec2& anchr2)
 
 PhysicsJointRotarySpring* PhysicsJointRotarySpring::construct(PhysicsBody* a, PhysicsBody* b, float stiffness, float damping)
 {
-    PhysicsJointRotarySpring* joint = new PhysicsJointRotarySpring();
+    PhysicsJointRotarySpring* joint = new (std::nothrow) PhysicsJointRotarySpring();
     
     if (joint && joint->init(a, b, stiffness, damping))
     {
@@ -574,7 +574,7 @@ void PhysicsJointRotarySpring::setDamping(float damping)
 
 PhysicsJointRotaryLimit* PhysicsJointRotaryLimit::construct(PhysicsBody* a, PhysicsBody* b, float min, float max)
 {
-    PhysicsJointRotaryLimit* joint = new PhysicsJointRotaryLimit();
+    PhysicsJointRotaryLimit* joint = new (std::nothrow) PhysicsJointRotaryLimit();
     
     if (joint && joint->init(a, b, min, max))
     {
@@ -633,7 +633,7 @@ void PhysicsJointRotaryLimit::setMax(float max)
 
 PhysicsJointRatchet* PhysicsJointRatchet::construct(PhysicsBody* a, PhysicsBody* b, float phase, float ratchet)
 {
-    PhysicsJointRatchet* joint = new PhysicsJointRatchet();
+    PhysicsJointRatchet* joint = new (std::nothrow) PhysicsJointRatchet();
     
     if (joint && joint->init(a, b, phase, ratchet))
     {
@@ -697,7 +697,7 @@ void PhysicsJointRatchet::setRatchet(float ratchet)
 
 PhysicsJointGear* PhysicsJointGear::construct(PhysicsBody* a, PhysicsBody* b, float phase, float ratchet)
 {
-    PhysicsJointGear* joint = new PhysicsJointGear();
+    PhysicsJointGear* joint = new (std::nothrow) PhysicsJointGear();
     
     if (joint && joint->init(a, b, phase, ratchet))
     {
@@ -751,7 +751,7 @@ void PhysicsJointGear::setRatio(float ratio)
 
 PhysicsJointMotor* PhysicsJointMotor::construct(PhysicsBody* a, PhysicsBody* b, float rate)
 {
-    PhysicsJointMotor* joint = new PhysicsJointMotor();
+    PhysicsJointMotor* joint = new (std::nothrow) PhysicsJointMotor();
     
     if (joint && joint->init(a, b, rate))
     {

--- a/cocos/physics/CCPhysicsShape.cpp
+++ b/cocos/physics/CCPhysicsShape.cpp
@@ -68,7 +68,7 @@ PhysicsShape::~PhysicsShape()
 
 bool PhysicsShape::init(Type type)
 {
-    _info = new PhysicsShapeInfo(this);
+    _info = new (std::nothrow) PhysicsShapeInfo(this);
     if (_info == nullptr) return false;
     
     _type = type;
@@ -333,7 +333,7 @@ void PhysicsShape::setBody(PhysicsBody *body)
 // PhysicsShapeCircle
 PhysicsShapeCircle* PhysicsShapeCircle::create(float radius, const PhysicsMaterial& material/* = MaterialDefault*/, const Vec2& offset/* = Vec2(0, 0)*/)
 {
-    PhysicsShapeCircle* shape = new PhysicsShapeCircle();
+    PhysicsShapeCircle* shape = new (std::nothrow) PhysicsShapeCircle();
     if (shape && shape->init(radius, material, offset))
     {
         shape->autorelease();
@@ -470,7 +470,7 @@ void PhysicsShapeCircle::update(float delta)
 // PhysicsShapeEdgeSegment
 PhysicsShapeEdgeSegment* PhysicsShapeEdgeSegment::create(const Vec2& a, const Vec2& b, const PhysicsMaterial& material/* = MaterialDefault*/, float border/* = 1*/)
 {
-    PhysicsShapeEdgeSegment* shape = new PhysicsShapeEdgeSegment();
+    PhysicsShapeEdgeSegment* shape = new (std::nothrow) PhysicsShapeEdgeSegment();
     if (shape && shape->init(a, b, material, border))
     {
         shape->autorelease();
@@ -548,7 +548,7 @@ void PhysicsShapeEdgeSegment::update(float delta)
 // PhysicsShapeBox
 PhysicsShapeBox* PhysicsShapeBox::create(const Size& size, const PhysicsMaterial& material/* = MaterialDefault*/, const Vec2& offset/* = Vec2(0, 0)*/)
 {
-    PhysicsShapeBox* shape = new PhysicsShapeBox();
+    PhysicsShapeBox* shape = new (std::nothrow) PhysicsShapeBox();
     if (shape && shape->init(size, material, offset))
     {
         shape->autorelease();
@@ -599,7 +599,7 @@ Size PhysicsShapeBox::getSize() const
 // PhysicsShapePolygon
 PhysicsShapePolygon* PhysicsShapePolygon::create(const Vec2* points, int count, const PhysicsMaterial& material/* = MaterialDefault*/, const Vec2& offset/* = Vec2(0, 0)*/)
 {
-    PhysicsShapePolygon* shape = new PhysicsShapePolygon();
+    PhysicsShapePolygon* shape = new (std::nothrow) PhysicsShapePolygon();
     if (shape && shape->init(points, count, material, offset))
     {
         shape->autorelease();
@@ -736,7 +736,7 @@ void PhysicsShapePolygon::update(float delta)
 // PhysicsShapeEdgeBox
 PhysicsShapeEdgeBox* PhysicsShapeEdgeBox::create(const Size& size, const PhysicsMaterial& material/* = MaterialDefault*/, float border/* = 1*/, const Vec2& offset/* = Vec2(0, 0)*/)
 {
-    PhysicsShapeEdgeBox* shape = new PhysicsShapeEdgeBox();
+    PhysicsShapeEdgeBox* shape = new (std::nothrow) PhysicsShapeEdgeBox();
     if (shape && shape->init(size, material, border, offset))
     {
         shape->autorelease();
@@ -783,7 +783,7 @@ bool PhysicsShapeEdgeBox::init(const Size& size, const PhysicsMaterial& material
 // PhysicsShapeEdgeBox
 PhysicsShapeEdgePolygon* PhysicsShapeEdgePolygon::create(const Vec2* points, int count, const PhysicsMaterial& material/* = MaterialDefault*/, float border/* = 1*/)
 {
-    PhysicsShapeEdgePolygon* shape = new PhysicsShapeEdgePolygon();
+    PhysicsShapeEdgePolygon* shape = new (std::nothrow) PhysicsShapeEdgePolygon();
     if (shape && shape->init(points, count, material, border))
     {
         shape->autorelease();
@@ -864,7 +864,7 @@ int PhysicsShapeEdgePolygon::getPointsCount() const
 // PhysicsShapeEdgeChain
 PhysicsShapeEdgeChain* PhysicsShapeEdgeChain::create(const Vec2* points, int count, const PhysicsMaterial& material/* = MaterialDefault*/, float border/* = 1*/)
 {
-    PhysicsShapeEdgeChain* shape = new PhysicsShapeEdgeChain();
+    PhysicsShapeEdgeChain* shape = new (std::nothrow) PhysicsShapeEdgeChain();
     if (shape && shape->init(points, count, material, border))
     {
         shape->autorelease();

--- a/cocos/physics/CCPhysicsWorld.cpp
+++ b/cocos/physics/CCPhysicsWorld.cpp
@@ -197,7 +197,7 @@ void PhysicsWorld::debugDraw()
 {
     if (_debugDraw == nullptr)
     {
-        _debugDraw = new PhysicsDebugDraw(*this);
+        _debugDraw = new (std::nothrow) PhysicsDebugDraw(*this);
     }
     
     if (_debugDraw && !_bodies.empty())
@@ -418,7 +418,7 @@ PhysicsShape* PhysicsWorld::getShape(const Vec2& point) const
 
 PhysicsWorld* PhysicsWorld::construct(Scene& scene)
 {
-    PhysicsWorld * world = new PhysicsWorld();
+    PhysicsWorld * world = new (std::nothrow) PhysicsWorld();
     if(world && world->init(scene))
     {
         return world;
@@ -432,7 +432,7 @@ bool PhysicsWorld::init(Scene& scene)
 {
     do
     {
-        _info = new PhysicsWorldInfo();
+        _info = new (std::nothrow) PhysicsWorldInfo();
         CC_BREAK_IF(_info == nullptr);
         
         _scene = &scene;
@@ -1019,7 +1019,7 @@ void PhysicsDebugDraw::drawShape(PhysicsShape& shape)
             {
                 cpPolyShape* poly = (cpPolyShape*)subShape;
                 int num = poly->numVerts;
-                Vec2* seg = new Vec2[num];
+                Vec2* seg = new (std::nothrow) Vec2[num];
                 
                 PhysicsHelper::cpvs2points(poly->tVerts, seg, num);
                 

--- a/cocos/platform/CCGLView.cpp
+++ b/cocos/platform/CCGLView.cpp
@@ -278,7 +278,7 @@ void GLView::handleTouchesBegin(int num, intptr_t ids[], float xs[], float ys[])
                 continue;
             }
 
-            Touch* touch = g_touches[unusedIndex] = new Touch();
+            Touch* touch = g_touches[unusedIndex] = new (std::nothrow) Touch();
 			touch->setTouchInfo(unusedIndex, (x - _viewPortRect.origin.x) / _scaleX,
                                      (y - _viewPortRect.origin.y) / _scaleY);
             

--- a/cocos/platform/android/java/project.properties
+++ b/cocos/platform/android/java/project.properties
@@ -12,4 +12,4 @@
 
 android.library=true
 # Project target.
-target=android-10
+target=android-20

--- a/cocos/platform/android/java/project.properties
+++ b/cocos/platform/android/java/project.properties
@@ -12,4 +12,4 @@
 
 android.library=true
 # Project target.
-target=android-20
+target=android-10

--- a/cocos/platform/apple/CCFileUtilsApple.mm
+++ b/cocos/platform/apple/CCFileUtilsApple.mm
@@ -323,7 +323,7 @@ FileUtils* FileUtils::getInstance()
 {
     if (s_sharedFileUtils == nullptr)
     {
-        s_sharedFileUtils = new FileUtilsApple();
+        s_sharedFileUtils = new (std::nothrow) FileUtilsApple();
         if(!s_sharedFileUtils->init())
         {
           delete s_sharedFileUtils;

--- a/cocos/platform/desktop/CCGLViewImpl.cpp
+++ b/cocos/platform/desktop/CCGLViewImpl.cpp
@@ -295,7 +295,7 @@ GLViewImpl::~GLViewImpl()
 
 GLViewImpl* GLViewImpl::create(const std::string& viewName)
 {
-    auto ret = new GLViewImpl;
+    auto ret = new (std::nothrow) GLViewImpl;
     if(ret && ret->initWithRect(viewName, Rect(0, 0, 960, 640), 1)) {
         ret->autorelease();
         return ret;
@@ -306,7 +306,7 @@ GLViewImpl* GLViewImpl::create(const std::string& viewName)
 
 GLViewImpl* GLViewImpl::createWithRect(const std::string& viewName, Rect rect, float frameZoomFactor)
 {
-    auto ret = new GLViewImpl;
+    auto ret = new (std::nothrow) GLViewImpl;
     if(ret && ret->initWithRect(viewName, rect, frameZoomFactor)) {
         ret->autorelease();
         return ret;
@@ -317,7 +317,7 @@ GLViewImpl* GLViewImpl::createWithRect(const std::string& viewName, Rect rect, f
 
 GLViewImpl* GLViewImpl::createWithFullScreen(const std::string& viewName)
 {
-    auto ret = new GLViewImpl();
+    auto ret = new (std::nothrow) GLViewImpl();
     if(ret && ret->initWithFullScreen(viewName)) {
         ret->autorelease();
         return ret;
@@ -328,7 +328,7 @@ GLViewImpl* GLViewImpl::createWithFullScreen(const std::string& viewName)
 
 GLViewImpl* GLViewImpl::createWithFullScreen(const std::string& viewName, const GLFWvidmode &videoMode, GLFWmonitor *monitor)
 {
-    auto ret = new GLViewImpl();
+    auto ret = new (std::nothrow) GLViewImpl();
     if(ret && ret->initWithFullscreen(viewName, videoMode, monitor)) {
         ret->autorelease();
         return ret;

--- a/cocos/platform/ios/CCGLViewImpl.mm
+++ b/cocos/platform/ios/CCGLViewImpl.mm
@@ -41,7 +41,7 @@ int GLViewImpl::_depthFormat = GL_DEPTH_COMPONENT16;
 
 GLViewImpl* GLViewImpl::createWithEAGLView(void *eaglview)
 {
-    auto ret = new GLViewImpl;
+    auto ret = new (std::nothrow) GLViewImpl;
     if(ret && ret->initWithEAGLView(eaglview)) {
         ret->autorelease();
         return ret;
@@ -52,7 +52,7 @@ GLViewImpl* GLViewImpl::createWithEAGLView(void *eaglview)
 
 GLViewImpl* GLViewImpl::create(const std::string& viewName)
 {
-    auto ret = new GLViewImpl;
+    auto ret = new (std::nothrow) GLViewImpl;
     if(ret && ret->initWithFullScreen(viewName)) {
         ret->autorelease();
         return ret;
@@ -63,7 +63,7 @@ GLViewImpl* GLViewImpl::create(const std::string& viewName)
 
 GLViewImpl* GLViewImpl::createWithRect(const std::string& viewName, Rect rect, float frameZoomFactor)
 {
-    auto ret = new GLViewImpl;
+    auto ret = new (std::nothrow) GLViewImpl;
     if(ret && ret->initWithRect(viewName, rect, frameZoomFactor)) {
         ret->autorelease();
         return ret;
@@ -74,7 +74,7 @@ GLViewImpl* GLViewImpl::createWithRect(const std::string& viewName, Rect rect, f
 
 GLViewImpl* GLViewImpl::createWithFullScreen(const std::string& viewName)
 {
-    auto ret = new GLViewImpl();
+    auto ret = new (std::nothrow) GLViewImpl();
     if(ret && ret->initWithFullScreen(viewName)) {
         ret->autorelease();
         return ret;

--- a/cocos/renderer/CCGLProgramCache.cpp
+++ b/cocos/renderer/CCGLProgramCache.cpp
@@ -60,7 +60,7 @@ static GLProgramCache *_sharedGLProgramCache = 0;
 GLProgramCache* GLProgramCache::getInstance()
 {
     if (!_sharedGLProgramCache) {
-        _sharedGLProgramCache = new GLProgramCache();
+        _sharedGLProgramCache = new (std::nothrow) GLProgramCache();
         if (!_sharedGLProgramCache->init())
         {
             CC_SAFE_DELETE(_sharedGLProgramCache);
@@ -110,98 +110,98 @@ bool GLProgramCache::init()
 void GLProgramCache::loadDefaultGLPrograms()
 {
     // Position Texture Color shader
-    GLProgram *p = new GLProgram();
+    GLProgram *p = new (std::nothrow) GLProgram();
     loadDefaultGLProgram(p, kShaderType_PositionTextureColor);
     _programs.insert( std::make_pair( GLProgram::SHADER_NAME_POSITION_TEXTURE_COLOR, p ) );
 
     // Position Texture Color without MVP shader
-    p = new GLProgram();
+    p = new (std::nothrow) GLProgram();
     loadDefaultGLProgram(p, kShaderType_PositionTextureColor_noMVP);
     _programs.insert( std::make_pair( GLProgram::SHADER_NAME_POSITION_TEXTURE_COLOR_NO_MVP, p ) );
 
     // Position Texture Color alpha test
-    p = new GLProgram();
+    p = new (std::nothrow) GLProgram();
     loadDefaultGLProgram(p, kShaderType_PositionTextureColorAlphaTest);
     _programs.insert( std::make_pair(GLProgram::SHADER_NAME_POSITION_TEXTURE_ALPHA_TEST, p) );
 
     // Position Texture Color alpha test
-    p = new GLProgram();
+    p = new (std::nothrow) GLProgram();
     loadDefaultGLProgram(p, kShaderType_PositionTextureColorAlphaTestNoMV);
     _programs.insert( std::make_pair(GLProgram::SHADER_NAME_POSITION_TEXTURE_ALPHA_TEST_NO_MV, p) );
     //
     // Position, Color shader
     //
-    p = new GLProgram();
+    p = new (std::nothrow) GLProgram();
     loadDefaultGLProgram(p, kShaderType_PositionColor);
     _programs.insert( std::make_pair(GLProgram::SHADER_NAME_POSITION_COLOR, p) );
 
     //
     // Position, Color shader no MVP
     //
-    p = new GLProgram();
+    p = new (std::nothrow) GLProgram();
     loadDefaultGLProgram(p, kShaderType_PositionColor_noMVP);
     _programs.insert( std::make_pair(GLProgram::SHADER_NAME_POSITION_COLOR_NO_MVP, p) );
 
     //
     // Position Texture shader
     //
-    p = new GLProgram();
+    p = new (std::nothrow) GLProgram();
     loadDefaultGLProgram(p, kShaderType_PositionTexture);
     _programs.insert( std::make_pair( GLProgram::SHADER_NAME_POSITION_TEXTURE, p) );
 
     //
     // Position, Texture attribs, 1 Color as uniform shader
     //
-    p = new GLProgram();
+    p = new (std::nothrow) GLProgram();
     loadDefaultGLProgram(p, kShaderType_PositionTexture_uColor);
     _programs.insert( std::make_pair( GLProgram::SHADER_NAME_POSITION_TEXTURE_U_COLOR, p) );
 
     //
     // Position Texture A8 Color shader
     //
-    p = new GLProgram();
+    p = new (std::nothrow) GLProgram();
     loadDefaultGLProgram(p, kShaderType_PositionTextureA8Color);
     _programs.insert( std::make_pair(GLProgram::SHADER_NAME_POSITION_TEXTURE_A8_COLOR, p) );
 
     //
     // Position and 1 color passed as a uniform (to simulate glColor4ub )
     //
-    p = new GLProgram();
+    p = new (std::nothrow) GLProgram();
     loadDefaultGLProgram(p, kShaderType_Position_uColor);
     _programs.insert( std::make_pair(GLProgram::SHADER_NAME_POSITION_U_COLOR, p) );
     
     //
 	// Position, Legth(TexCoords, Color (used by Draw Node basically )
 	//
-    p = new GLProgram();
+    p = new (std::nothrow) GLProgram();
     loadDefaultGLProgram(p, kShaderType_PositionLengthTexureColor);
     _programs.insert( std::make_pair(GLProgram::SHADER_NAME_POSITION_LENGTH_TEXTURE_COLOR, p) );
 
-    p = new GLProgram();
+    p = new (std::nothrow) GLProgram();
     loadDefaultGLProgram(p, kShaderType_LabelDistanceFieldNormal);
     _programs.insert( std::make_pair(GLProgram::SHADER_NAME_LABEL_DISTANCEFIELD_NORMAL, p) );
 
-    p = new GLProgram();
+    p = new (std::nothrow) GLProgram();
     loadDefaultGLProgram(p, kShaderType_LabelDistanceFieldGlow);
     _programs.insert( std::make_pair(GLProgram::SHADER_NAME_LABEL_DISTANCEFIELD_GLOW, p) );
 
-    p = new GLProgram();
+    p = new (std::nothrow) GLProgram();
     loadDefaultGLProgram(p, kShaderType_LabelNormal);
     _programs.insert( std::make_pair(GLProgram::SHADER_NAME_LABEL_NORMAL, p) );
 
-    p = new GLProgram();
+    p = new (std::nothrow) GLProgram();
     loadDefaultGLProgram(p, kShaderType_LabelOutline);
     _programs.insert( std::make_pair(GLProgram::SHADER_NAME_LABEL_OUTLINE, p) );
     
-    p = new GLProgram();
+    p = new (std::nothrow) GLProgram();
     loadDefaultGLProgram(p, kShaderType_3DPosition);
     _programs.insert( std::make_pair(GLProgram::SHADER_3D_POSITION, p) );
 
-    p = new GLProgram();
+    p = new (std::nothrow) GLProgram();
     loadDefaultGLProgram(p, kShaderType_3DPositionTex);
     _programs.insert( std::make_pair(GLProgram::SHADER_3D_POSITION_TEXTURE, p) );
     
-    p = new GLProgram();
+    p = new (std::nothrow) GLProgram();
     loadDefaultGLProgram(p, kShaderType_3DSkinPositionTex);
     _programs.insert(std::make_pair(GLProgram::SHADER_3D_SKINPOSITION_TEXTURE, p));
 }

--- a/cocos/renderer/CCGLProgramStateCache.cpp
+++ b/cocos/renderer/CCGLProgramStateCache.cpp
@@ -44,7 +44,7 @@ GLProgramStateCache::~GLProgramStateCache()
 GLProgramStateCache* GLProgramStateCache::getInstance()
 {
     if (s_instance == nullptr)
-        s_instance = new GLProgramStateCache();
+        s_instance = new (std::nothrow) GLProgramStateCache();
     
     return s_instance;
 }

--- a/cocos/renderer/CCRenderCommandPool.h
+++ b/cocos/renderer/CCRenderCommandPool.h
@@ -84,7 +84,7 @@ private:
     void AllocateCommands()
     {
         static const int COMMANDS_ALLOCATE_BLOCK_SIZE = 32;
-        T* commands = new T[COMMANDS_ALLOCATE_BLOCK_SIZE];
+        T* commands = new (std::nothrow) T[COMMANDS_ALLOCATE_BLOCK_SIZE];
         _allocatedPoolBlocks.push_back(commands);
         for(int index = 0; index < COMMANDS_ALLOCATE_BLOCK_SIZE; ++index)
         {

--- a/cocos/renderer/CCRenderer.cpp
+++ b/cocos/renderer/CCRenderer.cpp
@@ -119,7 +119,7 @@ Renderer::Renderer()
 ,_cacheTextureListener(nullptr)
 #endif
 {
-    _groupCommandManager = new GroupCommandManager();
+    _groupCommandManager = new (std::nothrow) GroupCommandManager();
     
     _commandGroupStack.push(DEFAULT_RENDER_QUEUE);
     

--- a/cocos/renderer/CCTextureAtlas.cpp
+++ b/cocos/renderer/CCTextureAtlas.cpp
@@ -120,7 +120,7 @@ void TextureAtlas::setQuads(V3F_C4B_T2F_Quad* quads)
 
 TextureAtlas * TextureAtlas::create(const std::string& file, ssize_t capacity)
 {
-    TextureAtlas * textureAtlas = new TextureAtlas();
+    TextureAtlas * textureAtlas = new (std::nothrow) TextureAtlas();
     if(textureAtlas && textureAtlas->initWithFile(file, capacity))
     {
         textureAtlas->autorelease();
@@ -132,7 +132,7 @@ TextureAtlas * TextureAtlas::create(const std::string& file, ssize_t capacity)
 
 TextureAtlas * TextureAtlas::createWithTexture(Texture2D *texture, ssize_t capacity)
 {
-    TextureAtlas * textureAtlas = new TextureAtlas();
+    TextureAtlas * textureAtlas = new (std::nothrow) TextureAtlas();
     if (textureAtlas && textureAtlas->initWithTexture(texture, capacity))
     {
         textureAtlas->autorelease();

--- a/cocos/renderer/CCTextureCache.cpp
+++ b/cocos/renderer/CCTextureCache.cpp
@@ -131,7 +131,7 @@ void TextureCache::addImageAsync(const std::string &path, const std::function<vo
     ++_asyncRefCount;
 
     // generate async struct
-    AsyncStruct *data = new AsyncStruct(fullpath, callback);
+    AsyncStruct *data = new (std::nothrow) AsyncStruct(fullpath, callback);
 
     // add async struct into queue
     _asyncStructQueueMutex.lock();
@@ -218,7 +218,7 @@ void TextureCache::loadImage()
         {
             const std::string& filename = asyncStruct->filename;
             // generate image      
-            image = new Image();
+            image = new (std::nothrow) Image();
             if (image && !image->initWithImageFileThreadSafe(filename))
             {
                 CC_SAFE_RELEASE(image);
@@ -228,7 +228,7 @@ void TextureCache::loadImage()
         }    
 
         // generate image info
-        ImageInfo *imageInfo = new ImageInfo();
+        ImageInfo *imageInfo = new (std::nothrow) ImageInfo();
         imageInfo->asyncStruct = asyncStruct;
         imageInfo->image = image;
 
@@ -272,7 +272,7 @@ void TextureCache::addImageAsyncCallBack(float dt)
         if (image)
         {
             // generate texture in render thread
-            texture = new Texture2D();
+            texture = new (std::nothrow) Texture2D();
 
             texture->initWithImage(image);
 
@@ -335,13 +335,13 @@ Texture2D * TextureCache::addImage(const std::string &path)
         // all images are handled by UIImage except PVR extension that is handled by our own handler
         do 
         {
-            image = new Image();
+            image = new (std::nothrow) Image();
             CC_BREAK_IF(nullptr == image);
 
             bool bRet = image->initWithImageFile(fullpath);
             CC_BREAK_IF(!bRet);
 
-            texture = new Texture2D();
+            texture = new (std::nothrow) Texture2D();
 
             if( texture && texture->initWithImage(image) )
             {
@@ -379,7 +379,7 @@ Texture2D* TextureCache::addImage(Image *image, const std::string &key)
         }
 
         // prevents overloading the autorelease pool
-        texture = new Texture2D();
+        texture = new (std::nothrow) Texture2D();
         texture->initWithImage(image);
 
         if(texture)
@@ -426,7 +426,7 @@ bool TextureCache::reloadTexture(const std::string& fileName)
     else
     {
         do {
-            Image* image = new Image();
+            Image* image = new (std::nothrow) Image();
             CC_BREAK_IF(nullptr == image);
 
             bool bRet = image->initWithImageFile(fullpath);
@@ -630,7 +630,7 @@ VolatileTexture* VolatileTextureMgr::findVolotileTexture(Texture2D *tt)
     
     if (! vt)
     {
-        vt = new VolatileTexture(tt);
+        vt = new (std::nothrow) VolatileTexture(tt);
         _textures.push_back(vt);
     }
     
@@ -723,7 +723,7 @@ void VolatileTextureMgr::reloadAllTextures()
         {
         case VolatileTexture::kImageFile:
             {
-                Image* image = new Image();
+                Image* image = new (std::nothrow) Image();
                 
                 Data data = FileUtils::getInstance()->getDataFromFile(vt->_fileName);
                 

--- a/cocos/scripting/lua-bindings/manual/CCLuaEngine.cpp
+++ b/cocos/scripting/lua-bindings/manual/CCLuaEngine.cpp
@@ -41,7 +41,7 @@ LuaEngine* LuaEngine::getInstance(void)
 {
     if (!_defaultEngine)
     {
-        _defaultEngine = new LuaEngine();
+        _defaultEngine = new (std::nothrow) LuaEngine();
         _defaultEngine->init();
     }
     return _defaultEngine;

--- a/cocos/scripting/lua-bindings/manual/CCLuaStack.cpp
+++ b/cocos/scripting/lua-bindings/manual/CCLuaStack.cpp
@@ -153,7 +153,7 @@ LuaStack::~LuaStack()
 
 LuaStack *LuaStack::create(void)
 {
-    LuaStack *stack = new LuaStack();
+    LuaStack *stack = new (std::nothrow) LuaStack();
     stack->init();
     stack->autorelease();
     return stack;
@@ -161,7 +161,7 @@ LuaStack *LuaStack::create(void)
 
 LuaStack *LuaStack::attach(lua_State *L)
 {
-    LuaStack *stack = new LuaStack();
+    LuaStack *stack = new (std::nothrow) LuaStack();
     stack->initWithLuaState(L);
     stack->autorelease();
     return stack;

--- a/cocos/scripting/lua-bindings/manual/CCLuaValue.cpp
+++ b/cocos/scripting/lua-bindings/manual/CCLuaValue.cpp
@@ -72,7 +72,7 @@ const LuaValue LuaValue::dictValue(const LuaValueDict& dictValue)
 {
     LuaValue value;
     value._type = LuaValueTypeDict;
-    value._field.dictValue = new LuaValueDict(dictValue);
+    value._field.dictValue = new (std::nothrow) LuaValueDict(dictValue);
     return value;
 }
 
@@ -80,7 +80,7 @@ const LuaValue LuaValue::arrayValue(const LuaValueArray& arrayValue)
 {
     LuaValue value;
     value._type = LuaValueTypeArray;
-    value._field.arrayValue = new LuaValueArray(arrayValue);
+    value._field.arrayValue = new (std::nothrow) LuaValueArray(arrayValue);
     return value;
 }
 
@@ -141,11 +141,11 @@ void LuaValue::copy(const LuaValue& rhs)
     }
     else if (_type == LuaValueTypeDict)
     {
-        _field.dictValue = new LuaValueDict(*rhs._field.dictValue);
+        _field.dictValue = new (std::nothrow) LuaValueDict(*rhs._field.dictValue);
     }
     else if (_type == LuaValueTypeArray)
     {
-        _field.arrayValue = new LuaValueArray(*rhs._field.arrayValue);
+        _field.arrayValue = new (std::nothrow) LuaValueArray(*rhs._field.arrayValue);
     }
     else if (_type == LuaValueTypeObject)
     {

--- a/cocos/scripting/lua-bindings/manual/cocos2d/LuaOpengl.cpp
+++ b/cocos/scripting/lua-bindings/manual/cocos2d/LuaOpengl.cpp
@@ -93,7 +93,7 @@ static int tolua_Cocos2d_GLNode_create00(lua_State* tolua_S)
     else
 #endif
     {
-        GLNode *glNode = new GLNode();
+        GLNode *glNode = new (std::nothrow) GLNode();
         if (NULL != glNode)
         {
             glNode->autorelease();
@@ -161,7 +161,7 @@ static int tolua_Cocos2d_glGetSupportedExtensions00(lua_State* tolua_S)
     {
         const GLubyte* extensions = glGetString(GL_EXTENSIONS);
         size_t len  = strlen((const char*)extensions);
-        GLubyte* copy = new GLubyte[len+1];
+        GLubyte* copy = new (std::nothrow) GLubyte[len+1];
         strncpy((char*)copy, (const char*)extensions, len );
         
         int start_extension=0;
@@ -1879,7 +1879,7 @@ static int tolua_Cocos2d_glGetActiveAttrib00(lua_State* tolua_S)
         unsigned int arg1 = (unsigned int)tolua_tonumber(tolua_S, 2, 0);
         GLsizei length;
         glGetProgramiv(arg0, GL_ACTIVE_ATTRIBUTE_MAX_LENGTH, &length);
-        GLchar* buffer = new GLchar[length];
+        GLchar* buffer = new (std::nothrow) GLchar[length];
         GLint size = -1;
         GLenum type = -1;
         glGetActiveAttrib(arg0, arg1, length, NULL, &size, &type, buffer);
@@ -1918,7 +1918,7 @@ static int tolua_Cocos2d_glGetActiveUniform00(lua_State* tolua_S)
         unsigned int arg1 = (unsigned int)tolua_tonumber(tolua_S, 2, 0);
         GLsizei length;
         glGetProgramiv(arg0, GL_ACTIVE_ATTRIBUTE_MAX_LENGTH, &length);
-        GLchar* buffer = new GLchar[length];
+        GLchar* buffer = new (std::nothrow) GLchar[length];
         GLint size = -1;
         GLenum type = -1;
         glGetActiveUniform(arg0, arg1, length, NULL, &size, &type, buffer);
@@ -1955,7 +1955,7 @@ static int tolua_Cocos2d_glGetAttachedShaders00(lua_State* tolua_S)
         unsigned int arg0 = (unsigned int)tolua_tonumber(tolua_S, 1, 0);
         GLsizei length;
         glGetProgramiv(arg0, GL_ATTACHED_SHADERS, &length);
-        GLuint* buffer = new GLuint[length];
+        GLuint* buffer = new (std::nothrow) GLuint[length];
         memset(buffer, 0, length * sizeof(GLuint));
         //Fix bug 2448, it seems that glGetAttachedShaders will crash if we send NULL to the third parameter (eg Windows), same as in JS binding
         GLsizei realShaderCount = 0;
@@ -2051,7 +2051,7 @@ static int tolua_Cocos2d_glGetProgramInfoLog00(lua_State* tolua_S)
         unsigned int arg0  = (unsigned int)tolua_tonumber(tolua_S, 1, 0);
         GLsizei length;
         glGetProgramiv(arg0, GL_INFO_LOG_LENGTH, &length);
-        GLchar* src = new GLchar[length];
+        GLchar* src = new (std::nothrow) GLchar[length];
         glGetProgramInfoLog(arg0, length, NULL, src);
         lua_pushstring(tolua_S, src);
         CC_SAFE_DELETE_ARRAY(src);
@@ -2112,7 +2112,7 @@ static int tolua_Cocos2d_glGetShaderInfoLog00(lua_State* tolua_S)
         unsigned int arg0  = (unsigned int)tolua_tonumber(tolua_S, 1, 0);
         GLsizei length;
         glGetShaderiv(arg0, GL_INFO_LOG_LENGTH, &length);
-        GLchar* src = new GLchar[length];
+        GLchar* src = new (std::nothrow) GLchar[length];
         glGetShaderInfoLog(arg0, length, NULL, src);
         lua_pushstring(tolua_S, src);
         CC_SAFE_DELETE_ARRAY(src);
@@ -2143,7 +2143,7 @@ static int tolua_Cocos2d_glGetShaderSource00(lua_State* tolua_S)
         unsigned int arg0  = (unsigned int)tolua_tonumber(tolua_S, 1, 0);
         GLsizei length;
         glGetShaderiv(arg0, GL_SHADER_SOURCE_LENGTH, &length);
-        GLchar* src = new GLchar[length];
+        GLchar* src = new (std::nothrow) GLchar[length];
         glGetShaderSource(arg0, length, NULL, src);
         lua_pushstring(tolua_S, src);
         CC_SAFE_DELETE_ARRAY(src);
@@ -2268,7 +2268,7 @@ static int tolua_Cocos2d_glGetUniformfv00(lua_State* tolua_S)
         
         GLsizei length;
         glGetProgramiv(arg0, GL_ACTIVE_UNIFORM_MAX_LENGTH, &length);
-        GLchar* namebuffer = new GLchar[length];
+        GLchar* namebuffer = new (std::nothrow) GLchar[length];
         GLint size = -1;
         GLenum type = -1;
         
@@ -2334,7 +2334,7 @@ static int tolua_Cocos2d_glGetUniformfv00(lua_State* tolua_S)
                 break;
         }
         if( utype == GL_FLOAT) {
-            GLfloat* param = new GLfloat[usize];
+            GLfloat* param = new (std::nothrow) GLfloat[usize];
             glGetUniformfv(arg0, arg1, param);
             
             lua_newtable(tolua_S);                                        /* L: table */
@@ -2348,7 +2348,7 @@ static int tolua_Cocos2d_glGetUniformfv00(lua_State* tolua_S)
             CC_SAFE_DELETE_ARRAY(param);
             
         } else if( utype == GL_INT ) {
-            GLint* param = new GLint[usize];
+            GLint* param = new (std::nothrow) GLint[usize];
             glGetUniformiv(arg0, arg1, param);
             
             lua_newtable(tolua_S);                                        /* L: table */

--- a/cocos/scripting/lua-bindings/manual/cocos2d/LuaScriptHandlerMgr.cpp
+++ b/cocos/scripting/lua-bindings/manual/cocos2d/LuaScriptHandlerMgr.cpp
@@ -39,7 +39,7 @@ NS_CC_BEGIN
 
 ScheduleHandlerDelegate* ScheduleHandlerDelegate::create()
 {
-    ScheduleHandlerDelegate *ret = new ScheduleHandlerDelegate();
+    ScheduleHandlerDelegate *ret = new (std::nothrow) ScheduleHandlerDelegate();
     if (NULL != ret )
     {
         ret->autorelease();
@@ -65,7 +65,7 @@ void ScheduleHandlerDelegate::update(float elapse)
 
 LuaCallFunc * LuaCallFunc::create(const std::function<void(void* ,Node*)>& func)
 {
-    auto ret = new LuaCallFunc();
+    auto ret = new (std::nothrow) LuaCallFunc();
     
     if (ret && ret->initWithFunction(func) ) {
         ret->autorelease();
@@ -101,7 +101,7 @@ LuaCallFunc* LuaCallFunc::clone() const
     if (0 == handler)
         return NULL;
     
-    auto ret = new LuaCallFunc();
+    auto ret = new (std::nothrow) LuaCallFunc();
     
     if( _functionLua )
     {
@@ -132,7 +132,7 @@ ScriptHandlerMgr* ScriptHandlerMgr::getInstance()
 {
     if (NULL == _scriptHandlerMgr)
     {
-        _scriptHandlerMgr = new ScriptHandlerMgr();
+        _scriptHandlerMgr = new (std::nothrow) ScriptHandlerMgr();
         _scriptHandlerMgr->init();
     }
     return _scriptHandlerMgr;

--- a/cocos/scripting/lua-bindings/manual/cocos2d/lua_cocos2dx_manual.cpp
+++ b/cocos/scripting/lua-bindings/manual/cocos2d/lua_cocos2dx_manual.cpp
@@ -1818,7 +1818,7 @@ static int tolua_cocos2d_CallFunc_create(lua_State* tolua_S)
             ref = luaL_ref(tolua_S, LUA_REGISTRYINDEX);
             hasExtraData = true;
         }
-        LuaCallFunc* tolua_ret = new LuaCallFunc();
+        LuaCallFunc* tolua_ret = new (std::nothrow) LuaCallFunc();
         tolua_ret->initWithFunction([=](void* self,Node* target){
             int callbackHandler =  ScriptHandlerMgr::getInstance()->getObjectHandler((void*)tolua_ret, ScriptHandlerMgr::HandlerType::CALLFUNC);
             
@@ -2978,7 +2978,7 @@ static int tolua_cocos2dx_GLProgram_create(lua_State* tolua_S)
         std::string arg0_tmp; ok &= luaval_to_std_string(tolua_S, 2, &arg0_tmp, "cc.GLProgram:create"); arg0 = arg0_tmp.c_str();
         std::string arg1_tmp; ok &= luaval_to_std_string(tolua_S, 3, &arg1_tmp, "cc.GLProgram:create"); arg1 = arg1_tmp.c_str();
         
-        GLProgram* tolua_ret = new GLProgram();
+        GLProgram* tolua_ret = new (std::nothrow) GLProgram();
         if (nullptr == tolua_ret)
             return 0;        
 
@@ -3249,7 +3249,7 @@ int lua_cocos2dx_GLProgram_setUniformLocationWithMatrix2fv(lua_State* tolua_S)
         if (!tolua_istable(tolua_S, 3, 0, &tolua_err))
             goto tolua_lerror;
 #endif
-        arg1 = new GLfloat[sizeof(GLfloat) * 4 * arg2];
+        arg1 = new (std::nothrow) GLfloat[sizeof(GLfloat) * 4 * arg2];
         if (nullptr == arg1)
         {
             CCLOG("Allocate matrixArry in the lua_cocos2dx_GLProgram_setUniformLocationWithMatrix2fv failed!");
@@ -3322,7 +3322,7 @@ int lua_cocos2dx_GLProgram_setUniformLocationWithMatrix3fv(lua_State* tolua_S)
         if (!tolua_istable(tolua_S, 3, 0, &tolua_err))
             goto tolua_lerror;
 #endif
-        arg1 = new GLfloat[sizeof(GLfloat) * 9 * arg2];
+        arg1 = new (std::nothrow) GLfloat[sizeof(GLfloat) * 9 * arg2];
         if (nullptr == arg1)
         {
             CCLOG("Allocate matrixArry in the lua_cocos2dx_GLProgram_setUniformLocationWithMatrix3fv failed!");
@@ -3396,7 +3396,7 @@ int lua_cocos2dx_GLProgram_setUniformLocationWithMatrix4fv(lua_State* tolua_S)
         if (!tolua_istable(tolua_S, 3, 0, &tolua_err))
             goto tolua_lerror;
 #endif
-        arg1 = new GLfloat[sizeof(GLfloat) * 16 * arg2];
+        arg1 = new (std::nothrow) GLfloat[sizeof(GLfloat) * 16 * arg2];
         if (nullptr == arg1)
         {
             CCLOG("Allocate matrixArry in the lua_cocos2dx_GLProgram_setUniformLocationWithMatrix4fv failed!");
@@ -3468,7 +3468,7 @@ int lua_cocos2dx_GLProgram_setUniformLocationWith3iv(lua_State* tolua_S)
         if (!tolua_istable(tolua_S, 3, 0, &tolua_err))
             goto tolua_lerror;
 #endif
-        arg1 = new GLint[sizeof(GLint) * 3 * arg2];
+        arg1 = new (std::nothrow) GLint[sizeof(GLint) * 3 * arg2];
         if (nullptr == arg1)
         {
             CCLOG("Allocate intArray in the lua_cocos2dx_GLProgram_setUniformLocationWith3iv failed!");
@@ -3542,7 +3542,7 @@ int lua_cocos2dx_GLProgram_setUniformLocationWith4iv(lua_State* tolua_S)
         if (!tolua_istable(tolua_S, 3, 0, &tolua_err))
             goto tolua_lerror;
 #endif
-        arg1 = new GLint[sizeof(GLint) * 4 * arg2];
+        arg1 = new (std::nothrow) GLint[sizeof(GLint) * 4 * arg2];
         if (nullptr == arg1)
         {
             CCLOG("Allocate intArray in the lua_cocos2dx_GLProgram_setUniformLocationWith4iv failed!");
@@ -3614,7 +3614,7 @@ int lua_cocos2dx_GLProgram_setUniformLocationWith2iv(lua_State* tolua_S)
         if (!tolua_istable(tolua_S, 3, 0, &tolua_err))
             goto tolua_lerror;
 #endif
-        arg1 = new GLint[sizeof(GLint) * 2 * arg2];
+        arg1 = new (std::nothrow) GLint[sizeof(GLint) * 2 * arg2];
         if (nullptr == arg1)
         {
             CCLOG("Allocate intArray in the lua_cocos2dx_GLProgram_setUniformLocationWith2iv failed!");
@@ -4301,7 +4301,7 @@ static void extendParticleBatchNode(lua_State* tolua_S)
 NS_CC_BEGIN
 EventListenerAcceleration* LuaEventListenerAcceleration::create()
 {
-    EventListenerAcceleration* eventAcceleration = new EventListenerAcceleration();
+    EventListenerAcceleration* eventAcceleration = new (std::nothrow) EventListenerAcceleration();
     if (nullptr == eventAcceleration)
         return nullptr;
     
@@ -4322,7 +4322,7 @@ EventListenerAcceleration* LuaEventListenerAcceleration::create()
 
 EventListenerCustom* LuaEventListenerCustom::create(const std::string& eventName)
 {
-    EventListenerCustom* eventCustom = new EventListenerCustom();
+    EventListenerCustom* eventCustom = new (std::nothrow) EventListenerCustom();
     if (nullptr == eventCustom)
         return nullptr;
     
@@ -5934,7 +5934,7 @@ static int lua_cocos2dx_GLProgramState_setVertexAttribPointer(lua_State* tolua_S
             return 0;
         }
         
-        arg5 = new GLfloat[len];
+        arg5 = new (std::nothrow) GLfloat[len];
         for (int i = 0; i < len; i++)
         {
             lua_pushnumber(tolua_S,i + 1);

--- a/cocos/scripting/lua-bindings/manual/cocosbuilder/CCBProxy.cpp
+++ b/cocos/scripting/lua-bindings/manual/cocosbuilder/CCBProxy.cpp
@@ -28,7 +28,7 @@
 CCBReader* CCBProxy::createCCBReader()
 {
     NodeLoaderLibrary *ccNodeLoaderLibrary = NodeLoaderLibrary::getInstance();
-    CCBReader * pCCBReader = new CCBReader(ccNodeLoaderLibrary);
+    CCBReader * pCCBReader = new (std::nothrow) CCBReader(ccNodeLoaderLibrary);
     pCCBReader->autorelease();
     
     return pCCBReader;

--- a/cocos/scripting/lua-bindings/manual/cocostudio/lua_cocos2dx_coco_studio_manual.cpp
+++ b/cocos/scripting/lua-bindings/manual/cocostudio/lua_cocos2dx_coco_studio_manual.cpp
@@ -100,7 +100,7 @@ static int lua_cocos2dx_ArmatureAnimation_setMovementEventCallFunc(lua_State* L)
         
         LUA_FUNCTION handler = (  toluafix_ref_function(L,2,0));
         
-        LuaArmatureWrapper* wrapper = new LuaArmatureWrapper();
+        LuaArmatureWrapper* wrapper = new (std::nothrow) LuaArmatureWrapper();
         wrapper->autorelease();
         
         Vector<LuaArmatureWrapper*> vec;
@@ -169,7 +169,7 @@ static int lua_cocos2dx_ArmatureAnimation_setFrameEventCallFunc(lua_State* L)
         
         LUA_FUNCTION handler = (  toluafix_ref_function(L,2,0));
         
-        LuaArmatureWrapper* wrapper = new LuaArmatureWrapper();
+        LuaArmatureWrapper* wrapper = new (std::nothrow) LuaArmatureWrapper();
         wrapper->autorelease();
         
         Vector<LuaArmatureWrapper*> vec;
@@ -253,7 +253,7 @@ static int lua_cocos2dx_ArmatureDataManager_addArmatureFileInfoAsyncCallFunc(lua
         const char* configFilePath = tolua_tostring(L, 2, "");
         LUA_FUNCTION handler = (  toluafix_ref_function(L, 3, 0));
     
-        LuaArmatureWrapper* wrapper = new LuaArmatureWrapper();
+        LuaArmatureWrapper* wrapper = new (std::nothrow) LuaArmatureWrapper();
         wrapper->autorelease();
         
         ScriptHandlerMgr::getInstance()->addObjectHandler((void*)wrapper, handler, ScriptHandlerMgr::HandlerType::ARMATURE_EVENT);
@@ -279,7 +279,7 @@ static int lua_cocos2dx_ArmatureDataManager_addArmatureFileInfoAsyncCallFunc(lua
         
         LUA_FUNCTION handler = (  toluafix_ref_function(L,5,0));
         
-        LuaArmatureWrapper* wrapper = new LuaArmatureWrapper();
+        LuaArmatureWrapper* wrapper = new (std::nothrow) LuaArmatureWrapper();
         wrapper->autorelease();
         
         ScriptHandlerMgr::getInstance()->addObjectHandler((void*)wrapper, handler, ScriptHandlerMgr::HandlerType::ARMATURE_EVENT);

--- a/cocos/scripting/lua-bindings/manual/extension/lua_cocos2dx_extension_manual.cpp
+++ b/cocos/scripting/lua-bindings/manual/extension/lua_cocos2dx_extension_manual.cpp
@@ -96,7 +96,7 @@ static int tolua_cocos2dx_ScrollView_setDelegate(lua_State* tolua_S)
     
     if (0 == argc)
     {
-        LuaScrollViewDelegate* delegate = new LuaScrollViewDelegate();
+        LuaScrollViewDelegate* delegate = new (std::nothrow) LuaScrollViewDelegate();
         if (nullptr == delegate)
             return 0;
         
@@ -538,7 +538,7 @@ static int lua_cocos2dx_AssetsManager_setDelegate(lua_State* L)
         LuaAssetsManagerDelegateProtocol* delegate = dynamic_cast<LuaAssetsManagerDelegateProtocol*>( self->getDelegate());
         if (nullptr == delegate)
         {
-            delegate = new LuaAssetsManagerDelegateProtocol();
+            delegate = new (std::nothrow) LuaAssetsManagerDelegateProtocol();
             if (nullptr == delegate)
                 return 0;
             
@@ -698,7 +698,7 @@ static int lua_cocos2dx_TableView_setDelegate(lua_State* L)
     
     if (0 == argc)
     {
-        LUA_TableViewDelegate* delegate = new LUA_TableViewDelegate();
+        LUA_TableViewDelegate* delegate = new (std::nothrow) LUA_TableViewDelegate();
         if (nullptr == delegate)
             return 0;
         
@@ -835,7 +835,7 @@ static int lua_cocos2dx_TableView_setDataSource(lua_State* L)
     
     if (0 == argc)
     {
-        LUA_TableViewDataSource* dataSource = new LUA_TableViewDataSource();
+        LUA_TableViewDataSource* dataSource = new (std::nothrow) LUA_TableViewDataSource();
         if (nullptr == dataSource)
             return 0;
         
@@ -886,7 +886,7 @@ static int lua_cocos2dx_TableView_create(lua_State* L)
     
     if (2 == argc || 1 == argc)
     {
-        LUA_TableViewDataSource* dataSource = new LUA_TableViewDataSource();
+        LUA_TableViewDataSource* dataSource = new (std::nothrow) LUA_TableViewDataSource();
         Size size;
         ok &= luaval_to_size(L, 2, &size, "cc.TableView:create");
         

--- a/cocos/scripting/lua-bindings/manual/network/Lua_web_socket.cpp
+++ b/cocos/scripting/lua-bindings/manual/network/Lua_web_socket.cpp
@@ -174,7 +174,7 @@ static int tolua_Cocos2d_WebSocket_create00(lua_State* tolua_S)
 #endif
     {
             const char* urlName = ((const char*)  tolua_tostring(tolua_S,2,0));
-            LuaWebSocket *wSocket = new LuaWebSocket();
+            LuaWebSocket *wSocket = new (std::nothrow) LuaWebSocket();
             wSocket->init(*wSocket, urlName);
             tolua_pushusertype(tolua_S,(void*)wSocket,"cc.WebSocket");
             tolua_register_gc(tolua_S,lua_gettop(tolua_S));
@@ -208,7 +208,7 @@ static int tolua_Cocos2d_WebSocket_createByAProtocol00(lua_State* tolua_S)
         const char *protocol = ((const char*)  tolua_tostring(tolua_S,3,0));
         std::vector<std::string> protocols;
         protocols.push_back(protocol);
-        LuaWebSocket *wSocket = new LuaWebSocket();
+        LuaWebSocket *wSocket = new (std::nothrow) LuaWebSocket();
         wSocket->init(*wSocket, urlName,&protocols);
         tolua_pushusertype(tolua_S,(void*)wSocket,"cc.WebSocket");
         tolua_register_gc(tolua_S,lua_gettop(tolua_S));
@@ -251,7 +251,7 @@ static int tolua_Cocos2d_WebSocket_createByProtocolArray00(lua_State* tolua_S)
                 }
             }
         }
-        LuaWebSocket *wSocket = new LuaWebSocket();
+        LuaWebSocket *wSocket = new (std::nothrow) LuaWebSocket();
         wSocket->init(*wSocket, urlName,&protocols);
         tolua_pushusertype(tolua_S,(void*)wSocket,"cc.WebSocket");
         tolua_register_gc(tolua_S,lua_gettop(tolua_S));

--- a/cocos/scripting/lua-bindings/manual/network/lua_xml_http_request.cpp
+++ b/cocos/scripting/lua-bindings/manual/network/lua_xml_http_request.cpp
@@ -279,7 +279,7 @@ static int lua_cocos2dx_XMLHttpRequest_constructor(lua_State* L)
     argc = lua_gettop(L)-1;
     if (argc == 0)
     {
-        self = new LuaMinXmlHttpRequest();
+        self = new (std::nothrow) LuaMinXmlHttpRequest();
         self->autorelease();
         int ID =  self? (int)self->_ID : -1;
         int* luaID = self? &self->_luaID : NULL;

--- a/cocos/scripting/lua-bindings/manual/spine/LuaSkeletonAnimation.cpp
+++ b/cocos/scripting/lua-bindings/manual/spine/LuaSkeletonAnimation.cpp
@@ -109,7 +109,7 @@ LuaSkeletonAnimation::~LuaSkeletonAnimation()
 
 LuaSkeletonAnimation* LuaSkeletonAnimation::createWithFile (const char* skeletonDataFile, const char* atlasFile, float scale)
 {
-	LuaSkeletonAnimation* node = new LuaSkeletonAnimation(skeletonDataFile, atlasFile, scale);
+	LuaSkeletonAnimation* node = new (std::nothrow) LuaSkeletonAnimation(skeletonDataFile, atlasFile, scale);
 	node->autorelease();
 	return node;
 }

--- a/cocos/ui/UIButton.cpp
+++ b/cocos/ui/UIButton.cpp
@@ -84,7 +84,7 @@ Button::~Button()
 
 Button* Button::create()
 {
-    Button* widget = new Button();
+    Button* widget = new (std::nothrow) Button();
     if (widget && widget->init())
     {
         widget->autorelease();
@@ -99,7 +99,7 @@ Button* Button::create(const std::string &normalImage,
                        const std::string& disableImage,
                        TextureResType texType)
 {
-    Button *btn = new Button;
+    Button *btn = new (std::nothrow) Button;
     if (btn && btn->init(normalImage,selectedImage,disableImage,texType)) {
         btn->autorelease();
         return btn;

--- a/cocos/ui/UICheckBox.cpp
+++ b/cocos/ui/UICheckBox.cpp
@@ -72,7 +72,7 @@ CheckBox::~CheckBox()
 
 CheckBox* CheckBox::create()
 {
-    CheckBox* widget = new CheckBox();
+    CheckBox* widget = new (std::nothrow) CheckBox();
     if (widget && widget->init())
     {
         widget->autorelease();
@@ -89,7 +89,7 @@ CheckBox* CheckBox::create(const std::string& backGround,
                            const std::string& frontCrossDisabled,
                            TextureResType texType)
 {
-    CheckBox *pWidget = new CheckBox;
+    CheckBox *pWidget = new (std::nothrow) CheckBox;
     if (pWidget && pWidget->init(backGround,
                                  backGroundSeleted,
                                  cross,

--- a/cocos/ui/UIHBox.cpp
+++ b/cocos/ui/UIHBox.cpp
@@ -38,7 +38,7 @@ HBox::~HBox()
     
 HBox* HBox::create()
 {
-    HBox* widget = new HBox();
+    HBox* widget = new (std::nothrow) HBox();
     if (widget && widget->init())
     {
         widget->autorelease();
@@ -50,7 +50,7 @@ HBox* HBox::create()
     
 HBox* HBox::create(const cocos2d::Size &size)
 {
-    HBox* widget = new HBox();
+    HBox* widget = new (std::nothrow) HBox();
     if (widget && widget->initWithSize(size))
     {
         widget->autorelease();

--- a/cocos/ui/UIImageView.cpp
+++ b/cocos/ui/UIImageView.cpp
@@ -54,7 +54,7 @@ ImageView::~ImageView()
     
 ImageView* ImageView::create(const std::string &imageFileName, TextureResType texType)
 {
-    ImageView *widget = new ImageView;
+    ImageView *widget = new (std::nothrow) ImageView;
     if (widget && widget->init(imageFileName, texType)) {
         widget->autorelease();
         return widget;
@@ -65,7 +65,7 @@ ImageView* ImageView::create(const std::string &imageFileName, TextureResType te
 
 ImageView* ImageView::create()
 {
-    ImageView* widget = new ImageView();
+    ImageView* widget = new (std::nothrow) ImageView();
     if (widget && widget->init())
     {
         widget->autorelease();

--- a/cocos/ui/UILayout.cpp
+++ b/cocos/ui/UILayout.cpp
@@ -130,7 +130,7 @@ void Layout::onExit()
 
 Layout* Layout::create()
 {
-    Layout* layout = new Layout();
+    Layout* layout = new (std::nothrow) Layout();
     if (layout && layout->init())
     {
         layout->autorelease();

--- a/cocos/ui/UILayoutManager.cpp
+++ b/cocos/ui/UILayoutManager.cpp
@@ -31,7 +31,7 @@ namespace ui {
 
 LinearHorizontalLayoutManager* LinearHorizontalLayoutManager::create()
 {
-    LinearHorizontalLayoutManager* exe = new LinearHorizontalLayoutManager();
+    LinearHorizontalLayoutManager* exe = new (std::nothrow) LinearHorizontalLayoutManager();
     if (exe)
     {
         exe->autorelease();
@@ -88,7 +88,7 @@ void LinearHorizontalLayoutManager::doLayout(LayoutProtocol* layout)
 //LinearVerticalLayoutManager
 LinearVerticalLayoutManager* LinearVerticalLayoutManager::create()
 {
-    LinearVerticalLayoutManager* exe = new LinearVerticalLayoutManager();
+    LinearVerticalLayoutManager* exe = new (std::nothrow) LinearVerticalLayoutManager();
     if (exe)
     {
         exe->autorelease();
@@ -146,7 +146,7 @@ void LinearVerticalLayoutManager::doLayout(LayoutProtocol* layout)
 
 RelativeLayoutManager* RelativeLayoutManager::create()
 {
-    RelativeLayoutManager* exe = new RelativeLayoutManager();
+    RelativeLayoutManager* exe = new (std::nothrow) RelativeLayoutManager();
     if (exe)
     {
         exe->autorelease();

--- a/cocos/ui/UILayoutParameter.cpp
+++ b/cocos/ui/UILayoutParameter.cpp
@@ -65,7 +65,7 @@ bool Margin::equals(const Margin &target) const
 
 LayoutParameter* LayoutParameter::create()
 {
-    LayoutParameter* parameter = new LayoutParameter();
+    LayoutParameter* parameter = new (std::nothrow) LayoutParameter();
     if (parameter)
     {
         parameter->autorelease();
@@ -109,7 +109,7 @@ void LayoutParameter::copyProperties(LayoutParameter *model)
 
 LinearLayoutParameter* LinearLayoutParameter::create()
 {
-    LinearLayoutParameter* parameter = new LinearLayoutParameter();
+    LinearLayoutParameter* parameter = new (std::nothrow) LinearLayoutParameter();
     if (parameter)
     {
         parameter->autorelease();
@@ -146,7 +146,7 @@ void LinearLayoutParameter::copyProperties(LayoutParameter *model)
 
 RelativeLayoutParameter* RelativeLayoutParameter::create()
 {
-    RelativeLayoutParameter* parameter = new RelativeLayoutParameter();
+    RelativeLayoutParameter* parameter = new (std::nothrow) RelativeLayoutParameter();
     if (parameter)
     {
         parameter->autorelease();

--- a/cocos/ui/UIListView.cpp
+++ b/cocos/ui/UIListView.cpp
@@ -54,7 +54,7 @@ ListView::~ListView()
 
 ListView* ListView::create()
 {
-    ListView* widget = new ListView();
+    ListView* widget = new (std::nothrow) ListView();
     if (widget && widget->init())
     {
         widget->autorelease();

--- a/cocos/ui/UILoadingBar.cpp
+++ b/cocos/ui/UILoadingBar.cpp
@@ -56,7 +56,7 @@ LoadingBar::~LoadingBar()
 
 LoadingBar* LoadingBar::create()
 {
-    LoadingBar* widget = new LoadingBar();
+    LoadingBar* widget = new (std::nothrow) LoadingBar();
     if (widget && widget->init())
     {
         widget->autorelease();
@@ -68,7 +68,7 @@ LoadingBar* LoadingBar::create()
     
 LoadingBar* LoadingBar::create(const std::string &textureName, float percentage)
 {
-    LoadingBar* widget = new LoadingBar;
+    LoadingBar* widget = new (std::nothrow) LoadingBar;
     if (widget && widget->init()) {
         widget->autorelease();
         widget->loadTexture(textureName);

--- a/cocos/ui/UIPageView.cpp
+++ b/cocos/ui/UIPageView.cpp
@@ -59,7 +59,7 @@ PageView::~PageView()
 
 PageView* PageView::create()
 {
-    PageView* widget = new PageView();
+    PageView* widget = new (std::nothrow) PageView();
     if (widget && widget->init())
     {
         widget->autorelease();

--- a/cocos/ui/UIRelativeBox.cpp
+++ b/cocos/ui/UIRelativeBox.cpp
@@ -38,7 +38,7 @@ RelativeBox::~RelativeBox()
 
 RelativeBox* RelativeBox::create()
 {
-    RelativeBox* widget = new RelativeBox();
+    RelativeBox* widget = new (std::nothrow) RelativeBox();
     if (widget && widget->init())
     {
         widget->autorelease();
@@ -50,7 +50,7 @@ RelativeBox* RelativeBox::create()
 
 RelativeBox* RelativeBox::create(const cocos2d::Size &size)
 {
-    RelativeBox* widget = new RelativeBox();
+    RelativeBox* widget = new (std::nothrow) RelativeBox();
     if (widget && widget->initWithSize(size))
     {
         widget->autorelease();

--- a/cocos/ui/UIRichText.cpp
+++ b/cocos/ui/UIRichText.cpp
@@ -45,7 +45,7 @@ bool RichElement::init(int tag, const Color3B &color, GLubyte opacity)
     
 RichElementText* RichElementText::create(int tag, const Color3B &color, GLubyte opacity, const std::string& text, const std::string& fontName, float fontSize)
 {
-    RichElementText* element = new RichElementText();
+    RichElementText* element = new (std::nothrow) RichElementText();
     if (element && element->init(tag, color, opacity, text, fontName, fontSize))
     {
         element->autorelease();
@@ -69,7 +69,7 @@ bool RichElementText::init(int tag, const Color3B &color, GLubyte opacity, const
 
 RichElementImage* RichElementImage::create(int tag, const Color3B &color, GLubyte opacity, const std::string& filePath)
 {
-    RichElementImage* element = new RichElementImage();
+    RichElementImage* element = new (std::nothrow) RichElementImage();
     if (element && element->init(tag, color, opacity, filePath))
     {
         element->autorelease();
@@ -91,7 +91,7 @@ bool RichElementImage::init(int tag, const Color3B &color, GLubyte opacity, cons
 
 RichElementCustomNode* RichElementCustomNode::create(int tag, const Color3B &color, GLubyte opacity, cocos2d::Node *customNode)
 {
-    RichElementCustomNode* element = new RichElementCustomNode();
+    RichElementCustomNode* element = new (std::nothrow) RichElementCustomNode();
     if (element && element->init(tag, color, opacity, customNode))
     {
         element->autorelease();
@@ -128,7 +128,7 @@ RichText::~RichText()
     
 RichText* RichText::create()
 {
-    RichText* widget = new RichText();
+    RichText* widget = new (std::nothrow) RichText();
     if (widget && widget->init())
     {
         widget->autorelease();

--- a/cocos/ui/UIScale9Sprite.cpp
+++ b/cocos/ui/UIScale9Sprite.cpp
@@ -459,7 +459,7 @@ y+=ytranslate;                       \
     
     Scale9Sprite* Scale9Sprite::create(const std::string& file, const Rect& rect,  const Rect& capInsets)
     {
-        Scale9Sprite* pReturn = new Scale9Sprite();
+        Scale9Sprite* pReturn = new (std::nothrow) Scale9Sprite();
         if ( pReturn && pReturn->initWithFile(file, rect, capInsets) )
         {
             pReturn->autorelease();
@@ -477,7 +477,7 @@ y+=ytranslate;                       \
     
     Scale9Sprite* Scale9Sprite::create(const std::string& file, const Rect& rect)
     {
-        Scale9Sprite* pReturn = new Scale9Sprite();
+        Scale9Sprite* pReturn = new (std::nothrow) Scale9Sprite();
         if ( pReturn && pReturn->initWithFile(file, rect) )
         {
             pReturn->autorelease();
@@ -496,7 +496,7 @@ y+=ytranslate;                       \
     
     Scale9Sprite* Scale9Sprite::create(const Rect& capInsets, const std::string& file)
     {
-        Scale9Sprite* pReturn = new Scale9Sprite();
+        Scale9Sprite* pReturn = new (std::nothrow) Scale9Sprite();
         if ( pReturn && pReturn->initWithFile(capInsets, file) )
         {
             pReturn->autorelease();
@@ -515,7 +515,7 @@ y+=ytranslate;                       \
     
     Scale9Sprite* Scale9Sprite::create(const std::string& file)
     {
-        Scale9Sprite* pReturn = new Scale9Sprite();
+        Scale9Sprite* pReturn = new (std::nothrow) Scale9Sprite();
         if ( pReturn && pReturn->initWithFile(file) )
         {
             pReturn->autorelease();
@@ -539,7 +539,7 @@ y+=ytranslate;                       \
     
     Scale9Sprite* Scale9Sprite::createWithSpriteFrame(SpriteFrame* spriteFrame, const Rect& capInsets)
     {
-        Scale9Sprite* pReturn = new Scale9Sprite();
+        Scale9Sprite* pReturn = new (std::nothrow) Scale9Sprite();
         if ( pReturn && pReturn->initWithSpriteFrame(spriteFrame, capInsets) )
         {
             pReturn->autorelease();
@@ -557,7 +557,7 @@ y+=ytranslate;                       \
     
     Scale9Sprite* Scale9Sprite::createWithSpriteFrame(SpriteFrame* spriteFrame)
     {
-        Scale9Sprite* pReturn = new Scale9Sprite();
+        Scale9Sprite* pReturn = new (std::nothrow) Scale9Sprite();
         if ( pReturn && pReturn->initWithSpriteFrame(spriteFrame) )
         {
             pReturn->autorelease();
@@ -582,7 +582,7 @@ y+=ytranslate;                       \
     
     Scale9Sprite* Scale9Sprite::createWithSpriteFrameName(const std::string& spriteFrameName, const Rect& capInsets)
     {
-        Scale9Sprite* pReturn = new Scale9Sprite();
+        Scale9Sprite* pReturn = new (std::nothrow) Scale9Sprite();
         if ( pReturn && pReturn->initWithSpriteFrameName(spriteFrameName, capInsets) )
         {
             pReturn->autorelease();
@@ -600,7 +600,7 @@ y+=ytranslate;                       \
     
     Scale9Sprite* Scale9Sprite::createWithSpriteFrameName(const std::string& spriteFrameName)
     {
-        Scale9Sprite* pReturn = new Scale9Sprite();
+        Scale9Sprite* pReturn = new (std::nothrow) Scale9Sprite();
         if ( pReturn && pReturn->initWithSpriteFrameName(spriteFrameName) )
         {
             pReturn->autorelease();
@@ -615,7 +615,7 @@ y+=ytranslate;                       \
     
     Scale9Sprite* Scale9Sprite::resizableSpriteWithCapInsets(const Rect& capInsets)
     {
-        Scale9Sprite* pReturn = new Scale9Sprite();
+        Scale9Sprite* pReturn = new (std::nothrow) Scale9Sprite();
         if ( pReturn && pReturn->init(_scale9Image, _spriteRect, capInsets) )
         {
             pReturn->autorelease();
@@ -627,7 +627,7 @@ y+=ytranslate;                       \
     
     Scale9Sprite* Scale9Sprite::create()
     {
-        Scale9Sprite *pReturn = new Scale9Sprite();
+        Scale9Sprite *pReturn = new (std::nothrow) Scale9Sprite();
         if (pReturn && pReturn->init())
         {
             pReturn->autorelease();

--- a/cocos/ui/UIScrollView.cpp
+++ b/cocos/ui/UIScrollView.cpp
@@ -84,7 +84,7 @@ ScrollView::~ScrollView()
 
 ScrollView* ScrollView::create()
 {
-    ScrollView* widget = new ScrollView();
+    ScrollView* widget = new (std::nothrow) ScrollView();
     if (widget && widget->init())
     {
         widget->autorelease();

--- a/cocos/ui/UISlider.cpp
+++ b/cocos/ui/UISlider.cpp
@@ -77,7 +77,7 @@ Slider::~Slider()
 
 Slider* Slider::create()
 {
-    Slider* widget = new Slider();
+    Slider* widget = new (std::nothrow) Slider();
     if (widget && widget->init())
     {
         widget->autorelease();

--- a/cocos/ui/UIText.cpp
+++ b/cocos/ui/UIText.cpp
@@ -54,7 +54,7 @@ Text::~Text()
 
 Text* Text::create()
 {
-    Text* widget = new Text();
+    Text* widget = new (std::nothrow) Text();
     if (widget && widget->init())
     {
         widget->autorelease();
@@ -75,7 +75,7 @@ bool Text::init()
     
 Text* Text::create(const std::string &textContent, const std::string &fontName, int fontSize)
 {
-    Text *text = new Text;
+    Text *text = new (std::nothrow) Text;
     if (text && text->init(textContent, fontName, fontSize)) {
         text->autorelease();
         return text;

--- a/cocos/ui/UITextAtlas.cpp
+++ b/cocos/ui/UITextAtlas.cpp
@@ -51,7 +51,7 @@ TextAtlas::~TextAtlas()
 
 TextAtlas* TextAtlas::create()
 {
-    TextAtlas* widget = new TextAtlas();
+    TextAtlas* widget = new (std::nothrow) TextAtlas();
     if (widget && widget->init())
     {
         widget->autorelease();
@@ -74,7 +74,7 @@ TextAtlas* TextAtlas::create(const std::string &stringValue,
                              int itemHeight,
                              const std::string &startCharMap)
 {
-    TextAtlas* widget = new TextAtlas();
+    TextAtlas* widget = new (std::nothrow) TextAtlas();
     if (widget && widget->init())
     {
         widget->autorelease();

--- a/cocos/ui/UITextBMFont.cpp
+++ b/cocos/ui/UITextBMFont.cpp
@@ -49,7 +49,7 @@ TextBMFont::~TextBMFont()
 
 TextBMFont* TextBMFont::create()
 {
-    TextBMFont* widget = new TextBMFont();
+    TextBMFont* widget = new (std::nothrow) TextBMFont();
     if (widget && widget->init())
     {
         widget->autorelease();
@@ -61,7 +61,7 @@ TextBMFont* TextBMFont::create()
     
 TextBMFont* TextBMFont::create(const std::string &text, const std::string &filename)
 {
-    TextBMFont* widget = new TextBMFont();
+    TextBMFont* widget = new (std::nothrow) TextBMFont();
     if (widget && widget->init())
     {
         widget->setFntFile(filename);

--- a/cocos/ui/UITextField.cpp
+++ b/cocos/ui/UITextField.cpp
@@ -49,7 +49,7 @@ UICCTextField::~UICCTextField()
 
 UICCTextField * UICCTextField::create(const std::string& placeholder, const std::string& fontName, float fontSize)
 {
-    UICCTextField *pRet = new UICCTextField();
+    UICCTextField *pRet = new (std::nothrow) UICCTextField();
     
     if(pRet && pRet->initWithPlaceHolder("", fontName, fontSize))
     {
@@ -314,7 +314,7 @@ TextField::~TextField()
 
 TextField* TextField::create()
 {
-    TextField* widget = new TextField();
+    TextField* widget = new (std::nothrow) TextField();
     if (widget && widget->init())
     {
         widget->autorelease();
@@ -326,7 +326,7 @@ TextField* TextField::create()
     
 TextField* TextField::create(const std::string &placeholder, const std::string &fontName, int fontSize)
 {
-    TextField* widget = new TextField();
+    TextField* widget = new (std::nothrow) TextField();
     if (widget && widget->init())
     {
         widget->setPlaceHolder(placeholder);

--- a/cocos/ui/UIVBox.cpp
+++ b/cocos/ui/UIVBox.cpp
@@ -38,7 +38,7 @@ VBox::~VBox()
 
 VBox* VBox::create()
 {
-    VBox* widget = new VBox();
+    VBox* widget = new (std::nothrow) VBox();
     if (widget && widget->init())
     {
         widget->autorelease();
@@ -50,7 +50,7 @@ VBox* VBox::create()
 
 VBox* VBox::create(const cocos2d::Size &size)
 {
-    VBox* widget = new VBox();
+    VBox* widget = new (std::nothrow) VBox();
     if (widget && widget->initWithSize(size))
     {
         widget->autorelease();

--- a/cocos/ui/UIWidget.cpp
+++ b/cocos/ui/UIWidget.cpp
@@ -188,7 +188,7 @@ void Widget::cleanupWidget()
 
 Widget* Widget::create()
 {
-    Widget* widget = new Widget();
+    Widget* widget = new (std::nothrow) Widget();
     if (widget && widget->init())
     {
         widget->autorelease();
@@ -1259,7 +1259,7 @@ void Widget::enableDpadNavigation(bool enable)
     {
         if (nullptr == _focusNavigationController)
         {
-            _focusNavigationController = new FocusNavigationController;
+            _focusNavigationController = new (std::nothrow) FocusNavigationController;
             if (_focusedWidget) {
                 _focusNavigationController->setFirstFocsuedWidget(_focusedWidget);
             }

--- a/extensions/GUI/CCControlExtension/CCControl.cpp
+++ b/extensions/GUI/CCControlExtension/CCControl.cpp
@@ -50,7 +50,7 @@ Control::Control()
 
 Control* Control::create()
 {
-    Control* pRet = new Control();
+    Control* pRet = new (std::nothrow) Control();
     if (pRet && pRet->init())
     {
         pRet->autorelease();
@@ -264,7 +264,7 @@ Vector<Invocation*>& Control::dispatchListforControlEvent(EventType controlEvent
     // If the invocation list does not exist for the  dispatch table, we create it
     if (iter == _dispatchTable.end())
     {
-        invocationList = new Vector<Invocation*>();
+        invocationList = new (std::nothrow) Vector<Invocation*>();
         _dispatchTable[(int)controlEvent] = invocationList;
     }
     else

--- a/extensions/GUI/CCControlExtension/CCControlButton.cpp
+++ b/extensions/GUI/CCControlExtension/CCControlButton.cpp
@@ -123,7 +123,7 @@ bool ControlButton::initWithLabelAndBackgroundSprite(Node* node, Scale9Sprite* b
 
 ControlButton* ControlButton::create(Node* label, Scale9Sprite* backgroundSprite)
 {
-    ControlButton *pRet = new ControlButton();
+    ControlButton *pRet = new (std::nothrow) ControlButton();
     pRet->initWithLabelAndBackgroundSprite(label, backgroundSprite);
     pRet->autorelease();
     return pRet;
@@ -136,7 +136,7 @@ bool ControlButton::initWithTitleAndFontNameAndFontSize(const std::string& title
 
 ControlButton* ControlButton::create(const std::string& title, const std::string& fontName, float fontSize)
 {
-    ControlButton *pRet = new ControlButton();
+    ControlButton *pRet = new (std::nothrow) ControlButton();
     pRet->initWithTitleAndFontNameAndFontSize(title, fontName, fontSize);
     pRet->autorelease();
     return pRet;
@@ -150,7 +150,7 @@ bool ControlButton::initWithBackgroundSprite(Scale9Sprite* sprite)
 
 ControlButton* ControlButton::create(Scale9Sprite* sprite)
 {
-    ControlButton *pRet = new ControlButton();
+    ControlButton *pRet = new (std::nothrow) ControlButton();
     pRet->initWithBackgroundSprite(sprite);
     pRet->autorelease();
     return pRet;
@@ -723,7 +723,7 @@ void ControlButton::onTouchCancelled(Touch *pTouch, Event *pEvent)
 
 ControlButton* ControlButton::create()
 {
-    ControlButton *pControlButton = new ControlButton();
+    ControlButton *pControlButton = new (std::nothrow) ControlButton();
     if (pControlButton && pControlButton->init())
     {
         pControlButton->autorelease();

--- a/extensions/GUI/CCControlExtension/CCControlColourPicker.cpp
+++ b/extensions/GUI/CCControlExtension/CCControlColourPicker.cpp
@@ -86,9 +86,9 @@ bool ControlColourPicker::init()
         float hueShift                = 8;
         float colourShift             = 28;
         
-        _huePicker = new ControlHuePicker();
+        _huePicker = new (std::nothrow) ControlHuePicker();
         _huePicker->initWithTargetAndPos(spriteSheet, Vec2(backgroundPointZero.x + hueShift, backgroundPointZero.y + hueShift));
-        _colourPicker = new ControlSaturationBrightnessPicker();
+        _colourPicker = new (std::nothrow) ControlSaturationBrightnessPicker();
         _colourPicker->initWithTargetAndPos(spriteSheet, Vec2(backgroundPointZero.x + colourShift, backgroundPointZero.y + colourShift));
         
         // Setup events
@@ -110,7 +110,7 @@ bool ControlColourPicker::init()
 
 ControlColourPicker* ControlColourPicker::create()
 {
-    ControlColourPicker *pRet = new ControlColourPicker();
+    ControlColourPicker *pRet = new (std::nothrow) ControlColourPicker();
     pRet->init();
     pRet->autorelease();
     return pRet;

--- a/extensions/GUI/CCControlExtension/CCControlHuePicker.cpp
+++ b/extensions/GUI/CCControlExtension/CCControlHuePicker.cpp
@@ -51,7 +51,7 @@ ControlHuePicker::~ControlHuePicker()
 
 ControlHuePicker* ControlHuePicker::create(Node* target, Vec2 pos)
 {
-    ControlHuePicker *pRet = new ControlHuePicker();
+    ControlHuePicker *pRet = new (std::nothrow) ControlHuePicker();
     pRet->initWithTargetAndPos(target, pos);
     pRet->autorelease();
     return pRet;

--- a/extensions/GUI/CCControlExtension/CCControlPotentiometer.cpp
+++ b/extensions/GUI/CCControlExtension/CCControlPotentiometer.cpp
@@ -47,7 +47,7 @@ ControlPotentiometer::~ControlPotentiometer()
 
 ControlPotentiometer* ControlPotentiometer::create(const char* backgroundFile, const char* progressFile, const char* thumbFile)
 {
-    ControlPotentiometer* pRet = new ControlPotentiometer();
+    ControlPotentiometer* pRet = new (std::nothrow) ControlPotentiometer();
     if (pRet != nullptr)
     {
         // Prepare track for potentiometer

--- a/extensions/GUI/CCControlExtension/CCControlSaturationBrightnessPicker.cpp
+++ b/extensions/GUI/CCControlExtension/CCControlSaturationBrightnessPicker.cpp
@@ -79,7 +79,7 @@ bool ControlSaturationBrightnessPicker::initWithTargetAndPos(Node* target, Vec2 
 
 ControlSaturationBrightnessPicker* ControlSaturationBrightnessPicker::create(Node* target, Vec2 pos)
 {
-    ControlSaturationBrightnessPicker *pRet = new ControlSaturationBrightnessPicker();
+    ControlSaturationBrightnessPicker *pRet = new (std::nothrow) ControlSaturationBrightnessPicker();
     pRet->initWithTargetAndPos(target, pos);
     pRet->autorelease();
     return pRet;

--- a/extensions/GUI/CCControlExtension/CCControlSlider.cpp
+++ b/extensions/GUI/CCControlExtension/CCControlSlider.cpp
@@ -89,7 +89,7 @@ ControlSlider* ControlSlider::create(const char* bgFile, const char* progressFil
 
 ControlSlider* ControlSlider::create(Sprite * backgroundSprite, Sprite* pogressSprite, Sprite* thumbSprite)
 {
-    ControlSlider *pRet = new ControlSlider();
+    ControlSlider *pRet = new (std::nothrow) ControlSlider();
     pRet->initWithSprites(backgroundSprite, pogressSprite, thumbSprite);
     pRet->autorelease();
     return pRet;
@@ -98,7 +98,7 @@ ControlSlider* ControlSlider::create(Sprite * backgroundSprite, Sprite* pogressS
 ControlSlider* ControlSlider::create(Sprite * backgroundSprite, Sprite* pogressSprite, Sprite* thumbSprite,
         Sprite* selectedThumbSprite)
 {
-    ControlSlider *pRet = new ControlSlider();
+    ControlSlider *pRet = new (std::nothrow) ControlSlider();
     pRet->initWithSprites(backgroundSprite, pogressSprite, thumbSprite, selectedThumbSprite);
     pRet->autorelease();
     return pRet;

--- a/extensions/GUI/CCControlExtension/CCControlStepper.cpp
+++ b/extensions/GUI/CCControlExtension/CCControlStepper.cpp
@@ -117,7 +117,7 @@ bool ControlStepper::initWithMinusSpriteAndPlusSprite(Sprite *minusSprite, Sprit
 
 ControlStepper* ControlStepper::create(Sprite *minusSprite, Sprite *plusSprite)
 {
-    ControlStepper* pRet = new ControlStepper();
+    ControlStepper* pRet = new (std::nothrow) ControlStepper();
     if (pRet != nullptr && pRet->initWithMinusSpriteAndPlusSprite(minusSprite, plusSprite))
     {
         pRet->autorelease();

--- a/extensions/GUI/CCControlExtension/CCControlSwitch.cpp
+++ b/extensions/GUI/CCControlExtension/CCControlSwitch.cpp
@@ -129,7 +129,7 @@ ControlSwitchSprite* ControlSwitchSprite::create(Sprite *maskSprite,
                                             Label* onLabel,
                                             Label* offLabel)
 {
-    auto ret = new ControlSwitchSprite();
+    auto ret = new (std::nothrow) ControlSwitchSprite();
     ret->initWithMaskSprite(maskSprite, onSprite, offSprite, thumbSprite, onLabel, offLabel);
     ret->autorelease();
     return ret;
@@ -296,7 +296,7 @@ bool ControlSwitch::initWithMaskSprite(Sprite *maskSprite, Sprite * onSprite, Sp
 
 ControlSwitch* ControlSwitch::create(Sprite *maskSprite, Sprite * onSprite, Sprite * offSprite, Sprite * thumbSprite)
 {
-    ControlSwitch* pRet = new ControlSwitch();
+    ControlSwitch* pRet = new (std::nothrow) ControlSwitch();
     if (pRet && pRet->initWithMaskSprite(maskSprite, onSprite, offSprite, thumbSprite, nullptr, nullptr))
     {
         pRet->autorelease();
@@ -339,7 +339,7 @@ bool ControlSwitch::initWithMaskSprite(Sprite *maskSprite, Sprite * onSprite, Sp
 
 ControlSwitch* ControlSwitch::create(Sprite *maskSprite, Sprite * onSprite, Sprite * offSprite, Sprite * thumbSprite, Label* onLabel, Label* offLabel)
 {
-    ControlSwitch* pRet = new ControlSwitch();
+    ControlSwitch* pRet = new (std::nothrow) ControlSwitch();
     if (pRet && pRet->initWithMaskSprite(maskSprite, onSprite, offSprite, thumbSprite, onLabel, offLabel))
     {
         pRet->autorelease();

--- a/extensions/GUI/CCControlExtension/CCInvocation.cpp
+++ b/extensions/GUI/CCControlExtension/CCInvocation.cpp
@@ -30,7 +30,7 @@ NS_CC_EXT_BEGIN
 
 Invocation* Invocation::create(Ref* target, Control::Handler action, Control::EventType controlEvent)
 {
-    Invocation* pRet = new Invocation(target, action, controlEvent);
+    Invocation* pRet = new (std::nothrow) Invocation(target, action, controlEvent);
     if (pRet != nullptr)
     {
         pRet->autorelease();

--- a/extensions/GUI/CCControlExtension/CCScale9Sprite.cpp
+++ b/extensions/GUI/CCControlExtension/CCScale9Sprite.cpp
@@ -453,7 +453,7 @@ bool Scale9Sprite::initWithFile(const std::string& file, const Rect& rect,  cons
 
 Scale9Sprite* Scale9Sprite::create(const std::string& file, const Rect& rect,  const Rect& capInsets)
 {
-    Scale9Sprite* pReturn = new Scale9Sprite();
+    Scale9Sprite* pReturn = new (std::nothrow) Scale9Sprite();
     if ( pReturn && pReturn->initWithFile(file, rect, capInsets) )
     {
         pReturn->autorelease();
@@ -471,7 +471,7 @@ bool Scale9Sprite::initWithFile(const std::string& file, const Rect& rect)
 
 Scale9Sprite* Scale9Sprite::create(const std::string& file, const Rect& rect)
 {
-    Scale9Sprite* pReturn = new Scale9Sprite();
+    Scale9Sprite* pReturn = new (std::nothrow) Scale9Sprite();
     if ( pReturn && pReturn->initWithFile(file, rect) )
     {
         pReturn->autorelease();
@@ -490,7 +490,7 @@ bool Scale9Sprite::initWithFile(const Rect& capInsets, const std::string& file)
 
 Scale9Sprite* Scale9Sprite::create(const Rect& capInsets, const std::string& file)
 {
-    Scale9Sprite* pReturn = new Scale9Sprite();
+    Scale9Sprite* pReturn = new (std::nothrow) Scale9Sprite();
     if ( pReturn && pReturn->initWithFile(capInsets, file) )
     {
         pReturn->autorelease();
@@ -509,7 +509,7 @@ bool Scale9Sprite::initWithFile(const std::string& file)
 
 Scale9Sprite* Scale9Sprite::create(const std::string& file)
 {
-    Scale9Sprite* pReturn = new Scale9Sprite();
+    Scale9Sprite* pReturn = new (std::nothrow) Scale9Sprite();
     if ( pReturn && pReturn->initWithFile(file) )
     {
         pReturn->autorelease();
@@ -533,7 +533,7 @@ bool Scale9Sprite::initWithSpriteFrame(SpriteFrame* spriteFrame, const Rect& cap
 
 Scale9Sprite* Scale9Sprite::createWithSpriteFrame(SpriteFrame* spriteFrame, const Rect& capInsets)
 {
-    Scale9Sprite* pReturn = new Scale9Sprite();
+    Scale9Sprite* pReturn = new (std::nothrow) Scale9Sprite();
     if ( pReturn && pReturn->initWithSpriteFrame(spriteFrame, capInsets) )
     {
         pReturn->autorelease();
@@ -551,7 +551,7 @@ bool Scale9Sprite::initWithSpriteFrame(SpriteFrame* spriteFrame)
 
 Scale9Sprite* Scale9Sprite::createWithSpriteFrame(SpriteFrame* spriteFrame)
 {
-    Scale9Sprite* pReturn = new Scale9Sprite();
+    Scale9Sprite* pReturn = new (std::nothrow) Scale9Sprite();
     if ( pReturn && pReturn->initWithSpriteFrame(spriteFrame) )
     {
         pReturn->autorelease();
@@ -576,7 +576,7 @@ bool Scale9Sprite::initWithSpriteFrameName(const std::string& spriteFrameName, c
 
 Scale9Sprite* Scale9Sprite::createWithSpriteFrameName(const std::string& spriteFrameName, const Rect& capInsets)
 {
-    Scale9Sprite* pReturn = new Scale9Sprite();
+    Scale9Sprite* pReturn = new (std::nothrow) Scale9Sprite();
     if ( pReturn && pReturn->initWithSpriteFrameName(spriteFrameName, capInsets) )
     {
         pReturn->autorelease();
@@ -594,7 +594,7 @@ bool Scale9Sprite::initWithSpriteFrameName(const std::string& spriteFrameName)
 
 Scale9Sprite* Scale9Sprite::createWithSpriteFrameName(const std::string& spriteFrameName)
 {
-    Scale9Sprite* pReturn = new Scale9Sprite();
+    Scale9Sprite* pReturn = new (std::nothrow) Scale9Sprite();
     if ( pReturn && pReturn->initWithSpriteFrameName(spriteFrameName) )
     {
         pReturn->autorelease();
@@ -609,7 +609,7 @@ Scale9Sprite* Scale9Sprite::createWithSpriteFrameName(const std::string& spriteF
 
 Scale9Sprite* Scale9Sprite::resizableSpriteWithCapInsets(const Rect& capInsets)
 {
-    Scale9Sprite* pReturn = new Scale9Sprite();
+    Scale9Sprite* pReturn = new (std::nothrow) Scale9Sprite();
     if ( pReturn && pReturn->initWithBatchNode(_scale9Image, _spriteRect, capInsets) )
     {
         pReturn->autorelease();
@@ -621,7 +621,7 @@ Scale9Sprite* Scale9Sprite::resizableSpriteWithCapInsets(const Rect& capInsets)
 
 Scale9Sprite* Scale9Sprite::create()
 { 
-    Scale9Sprite *pReturn = new Scale9Sprite();
+    Scale9Sprite *pReturn = new (std::nothrow) Scale9Sprite();
     if (pReturn && pReturn->init())
     { 
         pReturn->autorelease();   

--- a/extensions/GUI/CCEditBox/CCEditBox.cpp
+++ b/extensions/GUI/CCEditBox/CCEditBox.cpp
@@ -64,7 +64,7 @@ void EditBox::touchDownAction(Ref *sender, Control::EventType controlEvent)
 
 EditBox* EditBox::create(const Size& size, Scale9Sprite* pNormal9SpriteBg, Scale9Sprite* pPressed9SpriteBg/* = nullptr*/, Scale9Sprite* pDisabled9SpriteBg/* = nullptr*/)
 {
-    EditBox* pRet = new EditBox();
+    EditBox* pRet = new (std::nothrow) EditBox();
     
     if (pRet != nullptr && pRet->initWithSizeAndBackgroundSprite(size, pNormal9SpriteBg))
     {

--- a/extensions/GUI/CCScrollView/CCScrollView.cpp
+++ b/extensions/GUI/CCScrollView/CCScrollView.cpp
@@ -75,7 +75,7 @@ ScrollView::~ScrollView()
 
 ScrollView* ScrollView::create(Size size, Node* container/* = nullptr*/)
 {
-    ScrollView* pRet = new ScrollView();
+    ScrollView* pRet = new (std::nothrow) ScrollView();
     if (pRet && pRet->initWithViewSize(size, container))
     {
         pRet->autorelease();
@@ -89,7 +89,7 @@ ScrollView* ScrollView::create(Size size, Node* container/* = nullptr*/)
 
 ScrollView* ScrollView::create()
 {
-    ScrollView* pRet = new ScrollView();
+    ScrollView* pRet = new (std::nothrow) ScrollView();
     if (pRet && pRet->init())
     {
         pRet->autorelease();

--- a/extensions/GUI/CCScrollView/CCTableView.cpp
+++ b/extensions/GUI/CCScrollView/CCTableView.cpp
@@ -40,7 +40,7 @@ TableView* TableView::create(TableViewDataSource* dataSource, Size size)
 
 TableView* TableView::create(TableViewDataSource* dataSource, Size size, Node *container)
 {
-    TableView *table = new TableView();
+    TableView *table = new (std::nothrow) TableView();
     table->initWithViewSize(size, container);
     table->autorelease();
     table->setDataSource(dataSource);

--- a/extensions/assets-manager/AssetsManager.cpp
+++ b/extensions/assets-manager/AssetsManager.cpp
@@ -624,8 +624,8 @@ AssetsManager* AssetsManager::create(const char* packageUrl, const char* version
         SuccessCallback successCallback;
     };
 
-    auto* manager = new AssetsManager(packageUrl,versionFileUrl,storagePath);
-    auto* delegate = new DelegateProtocolImpl(errorCallback,progressCallback,successCallback);
+    auto* manager = new (std::nothrow) AssetsManager(packageUrl,versionFileUrl,storagePath);
+    auto* delegate = new (std::nothrow) DelegateProtocolImpl(errorCallback,progressCallback,successCallback);
     manager->setDelegate(delegate);
     manager->_shouldDeleteDelegateWhenExit = true;
     manager->autorelease();

--- a/extensions/physics-nodes/CCPhysicsDebugNode.cpp
+++ b/extensions/physics-nodes/CCPhysicsDebugNode.cpp
@@ -71,7 +71,7 @@ static Vec2 cpVert2Point(const cpVect &vert)
 static Vec2* cpVertArray2ccpArrayN(const cpVect* cpVertArray, unsigned int count)
 {
     if (count == 0) return nullptr;
-    Vec2* pPoints = new Vec2[count];
+    Vec2* pPoints = new (std::nothrow) Vec2[count];
     
     for (unsigned int i = 0; i < count; ++i)
     {
@@ -205,7 +205,7 @@ PhysicsDebugNode::PhysicsDebugNode()
 
 PhysicsDebugNode* PhysicsDebugNode::create(cpSpace *space)
 {
-    PhysicsDebugNode *node = new PhysicsDebugNode();
+    PhysicsDebugNode *node = new (std::nothrow) PhysicsDebugNode();
     if (node)
     {
         node->init();

--- a/extensions/physics-nodes/CCPhysicsSprite.cpp
+++ b/extensions/physics-nodes/CCPhysicsSprite.cpp
@@ -43,7 +43,7 @@ PhysicsSprite::PhysicsSprite()
 
 PhysicsSprite* PhysicsSprite::create()
 {
-    PhysicsSprite* pRet = new PhysicsSprite();
+    PhysicsSprite* pRet = new (std::nothrow) PhysicsSprite();
     if (pRet && pRet->init())
     {
         pRet->autorelease();
@@ -58,7 +58,7 @@ PhysicsSprite* PhysicsSprite::create()
 
 PhysicsSprite* PhysicsSprite::createWithTexture(Texture2D *pTexture)
 {
-    PhysicsSprite* pRet = new PhysicsSprite();
+    PhysicsSprite* pRet = new (std::nothrow) PhysicsSprite();
     if (pRet && pRet->initWithTexture(pTexture))
     {
         pRet->autorelease();
@@ -73,7 +73,7 @@ PhysicsSprite* PhysicsSprite::createWithTexture(Texture2D *pTexture)
 
 PhysicsSprite* PhysicsSprite::createWithTexture(Texture2D *pTexture, const Rect& rect)
 {
-    PhysicsSprite* pRet = new PhysicsSprite();
+    PhysicsSprite* pRet = new (std::nothrow) PhysicsSprite();
     if (pRet && pRet->initWithTexture(pTexture, rect))
     {
         pRet->autorelease();
@@ -88,7 +88,7 @@ PhysicsSprite* PhysicsSprite::createWithTexture(Texture2D *pTexture, const Rect&
 
 PhysicsSprite* PhysicsSprite::createWithSpriteFrame(SpriteFrame *pSpriteFrame)
 {
-    PhysicsSprite* pRet = new PhysicsSprite();
+    PhysicsSprite* pRet = new (std::nothrow) PhysicsSprite();
     if (pRet && pRet->initWithSpriteFrame(pSpriteFrame))
     {
         pRet->autorelease();
@@ -103,7 +103,7 @@ PhysicsSprite* PhysicsSprite::createWithSpriteFrame(SpriteFrame *pSpriteFrame)
 
 PhysicsSprite* PhysicsSprite::createWithSpriteFrameName(const char *pszSpriteFrameName)
 {
-    PhysicsSprite* pRet = new PhysicsSprite();
+    PhysicsSprite* pRet = new (std::nothrow) PhysicsSprite();
     if (pRet && pRet->initWithSpriteFrameName(pszSpriteFrameName))
     {
         pRet->autorelease();
@@ -118,7 +118,7 @@ PhysicsSprite* PhysicsSprite::createWithSpriteFrameName(const char *pszSpriteFra
 
 PhysicsSprite* PhysicsSprite::create(const char *pszFileName)
 {
-    PhysicsSprite* pRet = new PhysicsSprite();
+    PhysicsSprite* pRet = new (std::nothrow) PhysicsSprite();
     if (pRet && pRet->initWithFile(pszFileName))
     {
         pRet->autorelease();
@@ -133,7 +133,7 @@ PhysicsSprite* PhysicsSprite::create(const char *pszFileName)
 
 PhysicsSprite* PhysicsSprite::create(const char *pszFileName, const Rect& rect)
 {
-    PhysicsSprite* pRet = new PhysicsSprite();
+    PhysicsSprite* pRet = new (std::nothrow) PhysicsSprite();
     if (pRet && pRet->initWithFile(pszFileName, rect))
     {
         pRet->autorelease();

--- a/tests/cpp-tests/Classes/ActionManagerTest/ActionManagerTest.cpp
+++ b/tests/cpp-tests/Classes/ActionManagerTest/ActionManagerTest.cpp
@@ -87,7 +87,7 @@ std::string ActionManagerTest::subtitle() const
 }
 void ActionManagerTest::restartCallback(Ref* sender)
 {
-    auto s = new ActionManagerTestScene();
+    auto s = new (std::nothrow) ActionManagerTestScene();
     s->addChild(restartActionManagerAction()); 
 
     Director::getInstance()->replaceScene(s);
@@ -96,7 +96,7 @@ void ActionManagerTest::restartCallback(Ref* sender)
 
 void ActionManagerTest::nextCallback(Ref* sender)
 {
-    auto s = new ActionManagerTestScene();
+    auto s = new (std::nothrow) ActionManagerTestScene();
     s->addChild( nextActionManagerAction() );
     Director::getInstance()->replaceScene(s);
     s->release();
@@ -104,7 +104,7 @@ void ActionManagerTest::nextCallback(Ref* sender)
 
 void ActionManagerTest::backCallback(Ref* sender)
 {
-    auto s = new ActionManagerTestScene();
+    auto s = new (std::nothrow) ActionManagerTestScene();
     s->addChild( backActionManagerAction() );
     Director::getInstance()->replaceScene(s);
     s->release();

--- a/tests/cpp-tests/Classes/ActionsEaseTest/ActionsEaseTest.cpp
+++ b/tests/cpp-tests/Classes/ActionsEaseTest/ActionsEaseTest.cpp
@@ -1097,7 +1097,7 @@ void EaseSpriteDemo::onEnter()
 
 void EaseSpriteDemo::restartCallback(Ref* sender)
 {
-    auto s = new ActionsEaseTestScene();//CCScene::create();
+    auto s = new (std::nothrow) ActionsEaseTestScene();//CCScene::create();
     s->addChild(restartEaseAction()); 
 
     Director::getInstance()->replaceScene(s);
@@ -1106,7 +1106,7 @@ void EaseSpriteDemo::restartCallback(Ref* sender)
 
 void EaseSpriteDemo::nextCallback(Ref* sender)
 {
-    auto s = new ActionsEaseTestScene();//CCScene::create();
+    auto s = new (std::nothrow) ActionsEaseTestScene();//CCScene::create();
     s->addChild( nextEaseAction() );
     Director::getInstance()->replaceScene(s);
     s->release();
@@ -1114,7 +1114,7 @@ void EaseSpriteDemo::nextCallback(Ref* sender)
 
 void EaseSpriteDemo::backCallback(Ref* sender)
 {
-    auto s = new ActionsEaseTestScene();//CCScene::create();
+    auto s = new (std::nothrow) ActionsEaseTestScene();//CCScene::create();
     s->addChild( backEaseAction() );
     Director::getInstance()->replaceScene(s);
     s->release();

--- a/tests/cpp-tests/Classes/ActionsProgressTest/ActionsProgressTest.cpp
+++ b/tests/cpp-tests/Classes/ActionsProgressTest/ActionsProgressTest.cpp
@@ -123,7 +123,7 @@ void SpriteDemo::onEnter()
 
 void SpriteDemo::restartCallback(Ref* sender)
 {
-    auto s = new ProgressActionsTestScene();
+    auto s = new (std::nothrow) ProgressActionsTestScene();
     s->addChild(restartAction()); 
 
     Director::getInstance()->replaceScene(s);
@@ -132,7 +132,7 @@ void SpriteDemo::restartCallback(Ref* sender)
 
 void SpriteDemo::nextCallback(Ref* sender)
 {
-    auto s = new ProgressActionsTestScene();
+    auto s = new (std::nothrow) ProgressActionsTestScene();
     s->addChild( nextAction() );
     Director::getInstance()->replaceScene(s);
     s->release();
@@ -140,7 +140,7 @@ void SpriteDemo::nextCallback(Ref* sender)
 
 void SpriteDemo::backCallback(Ref* sender)
 {
-    auto s = new ProgressActionsTestScene();
+    auto s = new (std::nothrow) ProgressActionsTestScene();
     s->addChild( backAction() );
     Director::getInstance()->replaceScene(s);
     s->release();

--- a/tests/cpp-tests/Classes/ActionsTest/ActionsTest.cpp
+++ b/tests/cpp-tests/Classes/ActionsTest/ActionsTest.cpp
@@ -167,7 +167,7 @@ void ActionsDemo::onExit()
 
 void ActionsDemo::restartCallback(Ref* sender)
 {
-    auto s = new ActionsTestScene();
+    auto s = new (std::nothrow) ActionsTestScene();
     s->addChild( restartAction() );
     Director::getInstance()->replaceScene(s);
     s->release();
@@ -175,7 +175,7 @@ void ActionsDemo::restartCallback(Ref* sender)
 
 void ActionsDemo::nextCallback(Ref* sender)
 {
-    auto s = new ActionsTestScene();
+    auto s = new (std::nothrow) ActionsTestScene();
     s->addChild( nextAction() );
     Director::getInstance()->replaceScene(s);
     s->release();
@@ -183,7 +183,7 @@ void ActionsDemo::nextCallback(Ref* sender)
 
 void ActionsDemo::backCallback(Ref* sender)
 {
-    auto s = new ActionsTestScene();
+    auto s = new (std::nothrow) ActionsTestScene();
     s->addChild( backAction() );
     Director::getInstance()->replaceScene(s);
     s->release();

--- a/tests/cpp-tests/Classes/AppDelegate.cpp
+++ b/tests/cpp-tests/Classes/AppDelegate.cpp
@@ -123,7 +123,7 @@ bool AppDelegate::applicationDidFinishLaunching()
 #endif
 
     auto scene = Scene::create();
-    auto layer = new TestController();
+    auto layer = new (std::nothrow) TestController();
 #if (CC_TARGET_PLATFORM != CC_PLATFORM_WP8) && (CC_TARGET_PLATFORM != CC_PLATFORM_WINRT)
     layer->addConsoleAutoTest();
 #endif

--- a/tests/cpp-tests/Classes/Box2DTest/Box2dTest.cpp
+++ b/tests/cpp-tests/Classes/Box2DTest/Box2dTest.cpp
@@ -78,7 +78,7 @@ void Box2DTestLayer::initPhysics()
 
     world->SetContinuousPhysics(true);
 
-//     _debugDraw = new GLESDebugDraw( PTM_RATIO );
+//     _debugDraw = new (std::nothrow) GLESDebugDraw( PTM_RATIO );
 //     world->SetDebugDraw(_debugDraw);
 
     uint32 flags = 0;
@@ -122,8 +122,8 @@ void Box2DTestLayer::initPhysics()
 void Box2DTestLayer::createResetButton()
 {
     auto reset = MenuItemImage::create("Images/r1.png", "Images/r2.png", [](Ref *sender) {
-		auto s = new Box2DTestScene();
-		auto child = new Box2DTestLayer();
+		auto s = new (std::nothrow) Box2DTestScene();
+		auto child = new (std::nothrow) Box2DTestLayer();
 		s->addChild(child);
 		child->release();
 		Director::getInstance()->replaceScene(s);
@@ -269,7 +269,7 @@ void Box2DTestLayer::accelerometer(UIAccelerometer* accelerometer, Acceleration*
 
 void Box2DTestScene::runThisTest()
 {
-    auto layer = new Box2DTestLayer();
+    auto layer = new (std::nothrow) Box2DTestLayer();
     addChild(layer);
     layer->release();
 

--- a/tests/cpp-tests/Classes/Box2DTestBed/Box2dView.cpp
+++ b/tests/cpp-tests/Classes/Box2DTestBed/Box2dView.cpp
@@ -39,7 +39,7 @@ MenuLayer::~MenuLayer(void)
 
 MenuLayer* MenuLayer::menuWithEntryID(int entryId)
 {
-    auto layer = new MenuLayer();
+    auto layer = new (std::nothrow) MenuLayer();
     layer->initWithEntryID(entryId);
     layer->autorelease();
 
@@ -92,7 +92,7 @@ bool MenuLayer::initWithEntryID(int entryId)
 
 void MenuLayer::restartCallback(Ref* sender)
 {
-    auto s = new Box2dTestBedScene();
+    auto s = new (std::nothrow) Box2dTestBedScene();
     auto box = MenuLayer::menuWithEntryID(m_entryID);
     s->addChild( box );
     Director::getInstance()->replaceScene( s );
@@ -101,7 +101,7 @@ void MenuLayer::restartCallback(Ref* sender)
 
 void MenuLayer::nextCallback(Ref* sender)
 {
-    auto s = new Box2dTestBedScene();
+    auto s = new (std::nothrow) Box2dTestBedScene();
     int next = m_entryID + 1;
     if( next >= g_totalEntries)
         next = 0;
@@ -113,7 +113,7 @@ void MenuLayer::nextCallback(Ref* sender)
 
 void MenuLayer::backCallback(Ref* sender)
 {
-    auto s = new Box2dTestBedScene();
+    auto s = new (std::nothrow) Box2dTestBedScene();
     int next = m_entryID - 1;
     if( next < 0 ) {
         next = g_totalEntries - 1;
@@ -164,7 +164,7 @@ Box2DView::Box2DView(void)
 
 Box2DView* Box2DView::viewWithEntryID(int entryId)
 {
-    Box2DView* pView = new Box2DView();
+    Box2DView* pView = new (std::nothrow) Box2DView();
     pView->initWithEntryID(entryId);
     pView->autorelease();
 

--- a/tests/cpp-tests/Classes/Box2DTestBed/GLES-Render.cpp
+++ b/tests/cpp-tests/Classes/Box2DTestBed/GLES-Render.cpp
@@ -107,7 +107,7 @@ void GLESDebugDraw::DrawCircle(const b2Vec2& center, float32 radius, const b2Col
     const float32 k_increment = 2.0f * b2_pi / k_segments;
     float32 theta = 0.0f;
     
-    GLfloat*    glVertices = new GLfloat[vertexCount*2];
+    GLfloat*    glVertices = new (std::nothrow) GLfloat[vertexCount*2];
     for (int i = 0; i < k_segments; ++i)
     {
         b2Vec2 v = center + radius * b2Vec2(cosf(theta), sinf(theta));
@@ -138,7 +138,7 @@ void GLESDebugDraw::DrawSolidCircle(const b2Vec2& center, float32 radius, const 
     const float32 k_increment = 2.0f * b2_pi / k_segments;
     float32 theta = 0.0f;
     
-    GLfloat*    glVertices = new GLfloat[vertexCount*2];
+    GLfloat*    glVertices = new (std::nothrow) GLfloat[vertexCount*2];
     for (int i = 0; i < k_segments; ++i)
     {
         b2Vec2 v = center + radius * b2Vec2(cosf(theta), sinf(theta));

--- a/tests/cpp-tests/Classes/BugsTest/Bug-458/Bug-458.cpp
+++ b/tests/cpp-tests/Classes/BugsTest/Bug-458/Bug-458.cpp
@@ -13,8 +13,8 @@ bool Bug458Layer::init()
         // ask director the the window size
         auto size = Director::getInstance()->getWinSize();
 
-        auto question = new QuestionContainerSprite();
-        auto question2 = new QuestionContainerSprite();
+        auto question = new (std::nothrow) QuestionContainerSprite();
+        auto question2 = new (std::nothrow) QuestionContainerSprite();
         question->init();
         question2->init();
 

--- a/tests/cpp-tests/Classes/BugsTest/BugsTest.cpp
+++ b/tests/cpp-tests/Classes/BugsTest/BugsTest.cpp
@@ -13,7 +13,7 @@
 #define TEST_BUG(__bug__)									\
 {															\
 	Scene* scene = Scene::create();					\
-	Bug##__bug__##Layer* layer = new Bug##__bug__##Layer();	\
+	Bug##__bug__##Layer* layer = new (std::nothrow) Bug##__bug__##Layer();	\
 	layer->init();                                         \
 	scene->addChild(layer);                               \
 	Director::getInstance()->replaceScene(scene);     \
@@ -128,7 +128,7 @@ void BugsTestBaseLayer::onEnter()
 void BugsTestBaseLayer::backCallback(Ref* sender)
 {
 //    Director::getInstance()->enableRetinaDisplay(false);
-    auto scene = new BugsTestScene();
+    auto scene = new (std::nothrow) BugsTestScene();
     scene->runThisTest();
     scene->autorelease();
 }
@@ -140,7 +140,7 @@ void BugsTestBaseLayer::backCallback(Ref* sender)
 ////////////////////////////////////////////////////////
 void BugsTestScene::runThisTest()
 {
-    auto layer = new BugsTestMainLayer();
+    auto layer = new (std::nothrow) BugsTestMainLayer();
     addChild(layer);
     layer->release();
 

--- a/tests/cpp-tests/Classes/Camera3DTest/Camera3DTest.cpp
+++ b/tests/cpp-tests/Classes/Camera3DTest/Camera3DTest.cpp
@@ -82,7 +82,7 @@ private:
 
 DrawLine3D* DrawLine3D::create()
 {
-    auto ret = new DrawLine3D();
+    auto ret = new (std::nothrow) DrawLine3D();
     if (ret && ret->init())
         return ret;
     CC_SAFE_DELETE(ret);
@@ -328,7 +328,7 @@ void Camera3DTestDemo::onExit()
 
 void Camera3DTestDemo::restartCallback(Ref* sender)
 {
-    auto s = new Camera3DTestScene();
+    auto s = new (std::nothrow) Camera3DTestScene();
     s->addChild(restartSpriteTestAction());
 
     Director::getInstance()->replaceScene(s);
@@ -337,14 +337,14 @@ void Camera3DTestDemo::restartCallback(Ref* sender)
 
 void Camera3DTestDemo::nextCallback(Ref* sender)
 {
-    auto s = new Camera3DTestScene();
+    auto s = new (std::nothrow) Camera3DTestScene();
     s->addChild( nextSpriteTestAction() );
     Director::getInstance()->replaceScene(s);
     s->release();
 }
 void Camera3DTestDemo::backCallback(Ref* sender)
 {
-    auto s = new Camera3DTestScene();
+    auto s = new (std::nothrow) Camera3DTestScene();
     s->addChild( backSpriteTestAction() );
     Director::getInstance()->replaceScene(s);
     s->release();

--- a/tests/cpp-tests/Classes/ChipmunkTest/ChipmunkTest.cpp
+++ b/tests/cpp-tests/Classes/ChipmunkTest/ChipmunkTest.cpp
@@ -166,8 +166,8 @@ void ChipmunkTestLayer::createResetButton()
 
 void ChipmunkTestLayer::reset(Ref* sender)
 {
-    auto s = new ChipmunkAccelTouchTestScene();
-    auto child = new ChipmunkTestLayer();
+    auto s = new (std::nothrow) ChipmunkAccelTouchTestScene();
+    auto child = new (std::nothrow) ChipmunkTestLayer();
     s->addChild(child);
     child->release();
     Director::getInstance()->replaceScene(s);
@@ -249,7 +249,7 @@ void ChipmunkTestLayer::onAcceleration(Acceleration* acc, Event* event)
 
 void ChipmunkAccelTouchTestScene::runThisTest()
 {
-    auto layer = new ChipmunkTestLayer();
+    auto layer = new (std::nothrow) ChipmunkTestLayer();
     addChild(layer);
     layer->release();
 

--- a/tests/cpp-tests/Classes/ClickAndMoveTest/ClickAndMoveTest.cpp
+++ b/tests/cpp-tests/Classes/ClickAndMoveTest/ClickAndMoveTest.cpp
@@ -8,7 +8,7 @@ enum
 
 void ClickAndMoveTestScene::runThisTest()
 {
-    auto layer = new MainLayer();
+    auto layer = new (std::nothrow) MainLayer();
     layer->autorelease();
 
     addChild(layer);

--- a/tests/cpp-tests/Classes/ClippingNodeTest/ClippingNodeTest.cpp
+++ b/tests/cpp-tests/Classes/ClippingNodeTest/ClippingNodeTest.cpp
@@ -103,7 +103,7 @@ std::string BaseClippingNodeTest::subtitle() const
 
 void BaseClippingNodeTest::restartCallback(Ref* sender)
 {
-	Scene *s = new ClippingNodeTestScene();
+	Scene *s = new (std::nothrow) ClippingNodeTestScene();
 	s->addChild(restartAction());
 	Director::getInstance()->replaceScene(s);
     s->release();
@@ -111,7 +111,7 @@ void BaseClippingNodeTest::restartCallback(Ref* sender)
 
 void BaseClippingNodeTest::nextCallback(Ref* sender)
 {
-	Scene *s = new ClippingNodeTestScene();
+	Scene *s = new (std::nothrow) ClippingNodeTestScene();
 	s->addChild(nextAction());
 	Director::getInstance()->replaceScene(s);
     s->release();
@@ -119,7 +119,7 @@ void BaseClippingNodeTest::nextCallback(Ref* sender)
 
 void BaseClippingNodeTest::backCallback(Ref* sender)
 {
-	Scene *s = new ClippingNodeTestScene();
+	Scene *s = new (std::nothrow) ClippingNodeTestScene();
 	s->addChild(backAction());
 	Director::getInstance()->replaceScene(s);
     s->release();

--- a/tests/cpp-tests/Classes/CocosDenshionTest/CocosDenshionTest.cpp
+++ b/tests/cpp-tests/Classes/CocosDenshionTest/CocosDenshionTest.cpp
@@ -33,7 +33,7 @@ class Button : public Node//, public TargetedTouchDelegate
 public:
     static Button *createWithSprite(const char *filePath)
     {
-        auto b = new Button();
+        auto b = new (std::nothrow) Button();
         if (b && !b->initSpriteButton(filePath)) {
             delete b;
             b = nullptr;
@@ -44,7 +44,7 @@ public:
 
     static Button *createWithText(const char *text)
     {
-        auto b = new Button();
+        auto b = new (std::nothrow) Button();
         if (b && !b->initTextButton(text)) {
             delete b;
             b = nullptr;
@@ -147,7 +147,7 @@ public:
 
     static AudioSlider *create(Direction direction)
     {
-        auto ret = new AudioSlider(direction);
+        auto ret = new (std::nothrow) AudioSlider(direction);
         if (ret && !ret->init()) {
             delete ret;
             ret = nullptr;
@@ -418,7 +418,7 @@ void CocosDenshionTest::updateVolumes(float)
 
 void CocosDenshionTestScene::runThisTest()
 {
-    auto layer = new CocosDenshionTest();
+    auto layer = new (std::nothrow) CocosDenshionTest();
     addChild(layer);
     layer->autorelease();
 

--- a/tests/cpp-tests/Classes/ConfigurationTest/ConfigurationTest.cpp
+++ b/tests/cpp-tests/Classes/ConfigurationTest/ConfigurationTest.cpp
@@ -71,7 +71,7 @@ void ConfigurationBase::onExit()
 
 void ConfigurationBase::restartCallback(Ref* sender)
 {
-    auto s = new ConfigurationTestScene();
+    auto s = new (std::nothrow) ConfigurationTestScene();
     s->addChild( restartAction() );
     Director::getInstance()->replaceScene(s);
     s->release();
@@ -79,7 +79,7 @@ void ConfigurationBase::restartCallback(Ref* sender)
 
 void ConfigurationBase::nextCallback(Ref* sender)
 {
-    auto s = new ConfigurationTestScene();
+    auto s = new (std::nothrow) ConfigurationTestScene();
     s->addChild( nextAction() );
     Director::getInstance()->replaceScene(s);
     s->release();
@@ -87,7 +87,7 @@ void ConfigurationBase::nextCallback(Ref* sender)
 
 void ConfigurationBase::backCallback(Ref* sender)
 {
-    auto s = new ConfigurationTestScene();
+    auto s = new (std::nothrow) ConfigurationTestScene();
     s->addChild( backAction() );
     Director::getInstance()->replaceScene(s);
     s->release();

--- a/tests/cpp-tests/Classes/ConsoleTest/ConsoleTest.cpp
+++ b/tests/cpp-tests/Classes/ConsoleTest/ConsoleTest.cpp
@@ -104,7 +104,7 @@ void BaseTestConsole::onEnter()
 
 void BaseTestConsole::restartCallback(Ref* sender)
 {
-    auto s = new ConsoleTestScene();
+    auto s = new (std::nothrow) ConsoleTestScene();
     s->addChild(restartConsoleTest());
 
     Director::getInstance()->replaceScene(s);
@@ -113,7 +113,7 @@ void BaseTestConsole::restartCallback(Ref* sender)
 
 void BaseTestConsole::nextCallback(Ref* sender)
 {
-    auto s = new ConsoleTestScene();
+    auto s = new (std::nothrow) ConsoleTestScene();
     s->addChild( nextConsoleTest() );
     Director::getInstance()->replaceScene(s);
     s->release();
@@ -121,7 +121,7 @@ void BaseTestConsole::nextCallback(Ref* sender)
 
 void BaseTestConsole::backCallback(Ref* sender)
 {
-    auto s = new ConsoleTestScene();
+    auto s = new (std::nothrow) ConsoleTestScene();
     s->addChild( backConsoleTest() );
     Director::getInstance()->replaceScene(s);
     s->release();

--- a/tests/cpp-tests/Classes/CurlTest/CurlTest.cpp
+++ b/tests/cpp-tests/Classes/CurlTest/CurlTest.cpp
@@ -60,7 +60,7 @@ CurlTest::~CurlTest()
 
 void CurlTestScene::runThisTest()
 {
-    auto layer = new CurlTest();
+    auto layer = new (std::nothrow) CurlTest();
     addChild(layer);
 
     Director::getInstance()->replaceScene(this);

--- a/tests/cpp-tests/Classes/CurrentLanguageTest/CurrentLanguageTest.cpp
+++ b/tests/cpp-tests/Classes/CurrentLanguageTest/CurrentLanguageTest.cpp
@@ -67,7 +67,7 @@ CurrentLanguageTest::CurrentLanguageTest()
 
 void CurrentLanguageTestScene::runThisTest()
 {
-    auto layer = new CurrentLanguageTest();
+    auto layer = new (std::nothrow) CurrentLanguageTest();
     addChild(layer);
 
     Director::getInstance()->replaceScene(this);

--- a/tests/cpp-tests/Classes/DataVisitorTest/DataVisitorTest.cpp
+++ b/tests/cpp-tests/Classes/DataVisitorTest/DataVisitorTest.cpp
@@ -78,7 +78,7 @@ void PrettyPrinterDemo::onEnter()
 
 void DataVisitorTestScene::runThisTest()
 {
-    auto layer = new PrettyPrinterDemo();
+    auto layer = new (std::nothrow) PrettyPrinterDemo();
     layer->autorelease();
     addChild(layer);
 

--- a/tests/cpp-tests/Classes/DrawPrimitivesTest/DrawPrimitivesTest.cpp
+++ b/tests/cpp-tests/Classes/DrawPrimitivesTest/DrawPrimitivesTest.cpp
@@ -73,7 +73,7 @@ void BaseLayer::onEnter()
 
 void BaseLayer::restartCallback(cocos2d::Ref *pSender)
 {
-    auto s = new DrawPrimitivesTestScene();
+    auto s = new (std::nothrow) DrawPrimitivesTestScene();
     s->addChild(restartAction());
     
     Director::getInstance()->replaceScene(s);
@@ -82,7 +82,7 @@ void BaseLayer::restartCallback(cocos2d::Ref *pSender)
 
 void BaseLayer::nextCallback(cocos2d::Ref *pSender)
 {
-    auto s = new DrawPrimitivesTestScene();;
+    auto s = new (std::nothrow) DrawPrimitivesTestScene();;
     s->addChild(nextAction());
     
     Director::getInstance()->replaceScene(s);
@@ -91,7 +91,7 @@ void BaseLayer::nextCallback(cocos2d::Ref *pSender)
 
 void BaseLayer::backCallback(cocos2d::Ref *pSender)
 {
-    auto s = new DrawPrimitivesTestScene();
+    auto s = new (std::nothrow) DrawPrimitivesTestScene();
     s->addChild(backAction());
     
     Director::getInstance()->replaceScene(s);

--- a/tests/cpp-tests/Classes/EffectsAdvancedTest/EffectsAdvancedTest.cpp
+++ b/tests/cpp-tests/Classes/EffectsAdvancedTest/EffectsAdvancedTest.cpp
@@ -137,7 +137,7 @@ public:
     
     static Lens3DTarget* create(Lens3D* pAction)
     {
-        Lens3DTarget* pRet = new Lens3DTarget();
+        Lens3DTarget* pRet = new (std::nothrow) Lens3DTarget();
         pRet->_lens3D = pAction;
         pRet->autorelease();
         return pRet;
@@ -387,7 +387,7 @@ std::string EffectAdvanceTextLayer::subtitle() const
 
 void EffectAdvanceTextLayer::restartCallback(Ref* sender)
 {
-    auto s = new EffectAdvanceScene();
+    auto s = new (std::nothrow) EffectAdvanceScene();
     s->addChild(restartEffectAdvanceAction()); 
 
     Director::getInstance()->replaceScene(s);
@@ -396,7 +396,7 @@ void EffectAdvanceTextLayer::restartCallback(Ref* sender)
 
 void EffectAdvanceTextLayer::nextCallback(Ref* sender)
 {
-    auto s = new EffectAdvanceScene();
+    auto s = new (std::nothrow) EffectAdvanceScene();
     s->addChild( nextEffectAdvanceAction() );
     Director::getInstance()->replaceScene(s);
 
@@ -405,7 +405,7 @@ void EffectAdvanceTextLayer::nextCallback(Ref* sender)
 
 void EffectAdvanceTextLayer::backCallback(Ref* sender)
 {
-    auto s = new EffectAdvanceScene();
+    auto s = new (std::nothrow) EffectAdvanceScene();
     s->addChild( backEffectAdvanceAction() );
     Director::getInstance()->replaceScene(s);
     s->release();

--- a/tests/cpp-tests/Classes/EffectsTest/EffectsTest.cpp
+++ b/tests/cpp-tests/Classes/EffectsTest/EffectsTest.cpp
@@ -394,7 +394,7 @@ TextLayer::~TextLayer(void)
 
 TextLayer* TextLayer::create()
 {
-    auto layer = new TextLayer();
+    auto layer = new (std::nothrow) TextLayer();
     layer->autorelease();
     
     return layer;
@@ -407,7 +407,7 @@ void TextLayer::onEnter()
 
 void TextLayer::newScene()
 {
-    auto s = new EffectTestScene();
+    auto s = new (std::nothrow) EffectTestScene();
     auto child = TextLayer::create();
     s->addChild(child);
     Director::getInstance()->replaceScene(s);

--- a/tests/cpp-tests/Classes/ExtensionsTest/CocoStudioActionTimelineTest/ActionTimelineTestScene.cpp
+++ b/tests/cpp-tests/Classes/ExtensionsTest/CocoStudioActionTimelineTest/ActionTimelineTestScene.cpp
@@ -20,16 +20,16 @@ Layer *CreateAnimationLayer(int index)
     switch(index)
     {
     case TEST_ANIMATIONELEMENT:
-        pLayer = new TestActionTimeline();
+        pLayer = new (std::nothrow) TestActionTimeline();
         break;
     case TEST_CHANGE_PLAY_SECTION:
-        pLayer = new TestChangePlaySection();
+        pLayer = new (std::nothrow) TestChangePlaySection();
         break;
     case TEST_TIMELINE_FRAME_EVENT:
-        pLayer = new TestTimelineFrameEvent();
+        pLayer = new (std::nothrow) TestTimelineFrameEvent();
         break;
     case TEST_TIMELINE_PERFORMACE:
-        pLayer = new TestTimelinePerformance();
+        pLayer = new (std::nothrow) TestTimelinePerformance();
         break;
     default:
         break;
@@ -166,7 +166,7 @@ std::string ActionTimelineTestLayer::subtitle() const
 
 void ActionTimelineTestLayer::restartCallback(Ref *pSender)
 {
-    Scene *s = new ActionTimelineTestScene();
+    Scene *s = new (std::nothrow) ActionTimelineTestScene();
     s->addChild( RestartAnimationTest() );
     Director::getInstance()->replaceScene(s);
     s->release();
@@ -174,14 +174,14 @@ void ActionTimelineTestLayer::restartCallback(Ref *pSender)
 
 void ActionTimelineTestLayer::nextCallback(Ref *pSender)
 {
-    Scene *s = new ActionTimelineTestScene();
+    Scene *s = new (std::nothrow) ActionTimelineTestScene();
     s->addChild( NextAnimationTest() );
     Director::getInstance()->replaceScene(s);
     s->release();
 }
 void ActionTimelineTestLayer::backCallback(Ref *pSender)
 {
-    Scene *s = new ActionTimelineTestScene();
+    Scene *s = new (std::nothrow) ActionTimelineTestScene();
     s->addChild( BackAnimationTest() );
     Director::getInstance()->replaceScene(s);
     s->release();

--- a/tests/cpp-tests/Classes/ExtensionsTest/CocoStudioArmatureTest/ArmatureScene.cpp
+++ b/tests/cpp-tests/Classes/ExtensionsTest/CocoStudioArmatureTest/ArmatureScene.cpp
@@ -19,64 +19,64 @@ Layer *CreateLayer(int index)
     switch(index)
     {
     case TEST_ASYNCHRONOUS_LOADING:
-        pLayer = new TestAsynchronousLoading();
+        pLayer = new (std::nothrow) TestAsynchronousLoading();
         break;
     case TEST_DIRECT_LOADING:
-        pLayer = new TestDirectLoading();
+        pLayer = new (std::nothrow) TestDirectLoading();
         break;
     case TEST_DRAGON_BONES_2_0:
-        pLayer = new TestDragonBones20();
+        pLayer = new (std::nothrow) TestDragonBones20();
         break;
     case TEST_COCOSTUDIO_WITH_SKELETON:
-        pLayer = new TestCSWithSkeleton();
+        pLayer = new (std::nothrow) TestCSWithSkeleton();
         break;
     case TEST_PERFORMANCE:
-        pLayer = new TestPerformance();
+        pLayer = new (std::nothrow) TestPerformance();
         break;
 //    case TEST_PERFORMANCE_BATCHNODE:
-//        pLayer = new TestPerformanceBatchNode();
+//        pLayer = new (std::nothrow) TestPerformanceBatchNode();
 //        break;
     case TEST_CHANGE_ZORDER:
-        pLayer = new TestChangeZorder();
+        pLayer = new (std::nothrow) TestChangeZorder();
         break;
     case TEST_ANIMATION_EVENT:
-        pLayer = new TestAnimationEvent();
+        pLayer = new (std::nothrow) TestAnimationEvent();
         break;
     case TEST_FRAME_EVENT:
-        pLayer = new TestFrameEvent();
+        pLayer = new (std::nothrow) TestFrameEvent();
         break;
     case  TEST_PARTICLE_DISPLAY:
-        pLayer = new TestParticleDisplay();
+        pLayer = new (std::nothrow) TestParticleDisplay();
         break;
     case TEST_USE_DIFFERENT_PICTURE:
-        pLayer = new TestUseMutiplePicture();
+        pLayer = new (std::nothrow) TestUseMutiplePicture();
         break;
     case TEST_COLLIDER_DETECTOR:
-        pLayer = new TestColliderDetector();
+        pLayer = new (std::nothrow) TestColliderDetector();
         break;
     case TEST_BOUDINGBOX:
-        pLayer = new TestBoundingBox();
+        pLayer = new (std::nothrow) TestBoundingBox();
         break;
     case TEST_ANCHORPOINT:
-        pLayer = new TestAnchorPoint();
+        pLayer = new (std::nothrow) TestAnchorPoint();
         break;
     case TEST_ARMATURE_NESTING:
-        pLayer = new TestArmatureNesting();
+        pLayer = new (std::nothrow) TestArmatureNesting();
         break;
     case TEST_ARMATURE_NESTING_2:
-        pLayer = new TestArmatureNesting2();
+        pLayer = new (std::nothrow) TestArmatureNesting2();
         break;
     case TEST_PLAY_SEVERAL_MOVEMENT:
-        pLayer = new TestPlaySeveralMovement();
+        pLayer = new (std::nothrow) TestPlaySeveralMovement();
         break;
     case TEST_EASING:
-        pLayer = new TestEasing();
+        pLayer = new (std::nothrow) TestEasing();
         break;
     case TEST_CHANGE_ANIMATION_INTERNAL:
-        pLayer = new TestChangeAnimationInternal();
+        pLayer = new (std::nothrow) TestChangeAnimationInternal();
         break;
     case TEST_DIRECT_FROM_BINARY:
-        pLayer = new TestLoadFromBinary();
+        pLayer = new (std::nothrow) TestLoadFromBinary();
         break;
     default:
         break;
@@ -211,21 +211,21 @@ std::string ArmatureTestLayer::subtitle() const
 
 void ArmatureTestLayer::restartCallback(Ref *pSender)
 {
-    Scene *s = new ArmatureTestScene();
+    Scene *s = new (std::nothrow) ArmatureTestScene();
     s->addChild( RestartTest() );
     Director::getInstance()->replaceScene(s);
     s->release();
 }
 void ArmatureTestLayer::nextCallback(Ref *pSender)
 {
-    Scene *s = new ArmatureTestScene();
+    Scene *s = new (std::nothrow) ArmatureTestScene();
     s->addChild( NextTest() );
     Director::getInstance()->replaceScene(s);
     s->release();
 }
 void ArmatureTestLayer::backCallback(Ref *pSender)
 {
-    Scene *s = new ArmatureTestScene();
+    Scene *s = new (std::nothrow) ArmatureTestScene();
     s->addChild( BackTest() );
     Director::getInstance()->replaceScene(s);
     s->release();
@@ -413,7 +413,7 @@ void TestPerformance::addArmature(int number)
         armatureCount++;
 
         Armature *armature = nullptr;
-        armature = new Armature();
+        armature = new (std::nothrow) Armature();
         armature->init("Cowboy");
         armature->getAnimation()->playWithIndex(0);
         armature->setPosition(50 + armatureCount * 2, 150);
@@ -877,10 +877,10 @@ void TestColliderDetector::initWorld()
     world = new b2World(noGravity);
     world->SetAllowSleeping(true);
 
-    listener = new ContactListener();
+    listener = new (std::nothrow) ContactListener();
     world->SetContactListener(listener);
 
-    debugDraw = new GLESDebugDraw( PT_RATIO );
+    debugDraw = new (std::nothrow) GLESDebugDraw( PT_RATIO );
     world->SetDebugDraw(debugDraw);
 
     uint32 flags = 0;
@@ -1198,7 +1198,7 @@ void TestArmatureNesting::onTouchesEnded(const std::vector<Touch*>& touches, Eve
 
 Hero *Hero::create(const char *name)
 {
-    Hero *hero = new Hero();
+    Hero *hero = new (std::nothrow) Hero();
     if (hero && hero->init(name))
     {
         hero->autorelease();

--- a/tests/cpp-tests/Classes/ExtensionsTest/CocoStudioComponentsTest/ComponentsTestScene.cpp
+++ b/tests/cpp-tests/Classes/ExtensionsTest/CocoStudioComponentsTest/ComponentsTestScene.cpp
@@ -81,7 +81,7 @@ cocos2d::Node* ComponentsTestLayer::createGameScene()
         
 
         auto itemBack = MenuItemFont::create("Back", [](Ref* sender){
-        	auto scene = new ExtensionsTestScene();
+        	auto scene = new (std::nothrow) ExtensionsTestScene();
             scene->runThisTest();
             scene->release();
         });

--- a/tests/cpp-tests/Classes/ExtensionsTest/CocoStudioComponentsTest/EnemyController.cpp
+++ b/tests/cpp-tests/Classes/ExtensionsTest/CocoStudioComponentsTest/EnemyController.cpp
@@ -63,7 +63,7 @@ void EnemyController::update(float delta)
 
 EnemyController* EnemyController::create(void)
 {
-    EnemyController * pRet = new EnemyController();
+    EnemyController * pRet = new (std::nothrow) EnemyController();
     if (pRet && pRet->init())
     {
         pRet->autorelease();

--- a/tests/cpp-tests/Classes/ExtensionsTest/CocoStudioComponentsTest/GameOverScene.cpp
+++ b/tests/cpp-tests/Classes/ExtensionsTest/CocoStudioComponentsTest/GameOverScene.cpp
@@ -73,7 +73,7 @@ bool GameOverLayer::init()
 		
         
         auto itemBack = MenuItemFont::create("Back", [](Ref* sender){
-            auto scene = new ExtensionsTestScene();
+            auto scene = new (std::nothrow) ExtensionsTestScene();
             scene->runThisTest();
             scene->release();
         });

--- a/tests/cpp-tests/Classes/ExtensionsTest/CocoStudioComponentsTest/PlayerController.cpp
+++ b/tests/cpp-tests/Classes/ExtensionsTest/CocoStudioComponentsTest/PlayerController.cpp
@@ -55,7 +55,7 @@ void PlayerController::onTouchesEnded(const std::vector<Touch*>& touches, Event 
 
 PlayerController* PlayerController::create(void)
 {
-    PlayerController * pRet = new PlayerController();
+    PlayerController * pRet = new (std::nothrow) PlayerController();
     if (pRet && pRet->init())
     {
         pRet->autorelease();

--- a/tests/cpp-tests/Classes/ExtensionsTest/CocoStudioComponentsTest/ProjectileController.cpp
+++ b/tests/cpp-tests/Classes/ExtensionsTest/CocoStudioComponentsTest/ProjectileController.cpp
@@ -78,7 +78,7 @@ void ProjectileController::update(float delta)
 
 ProjectileController* ProjectileController::create(void)
 {
-    ProjectileController * pRet = new ProjectileController();
+    ProjectileController * pRet = new (std::nothrow) ProjectileController();
     if (pRet && pRet->init())
     {
         pRet->autorelease();

--- a/tests/cpp-tests/Classes/ExtensionsTest/CocoStudioComponentsTest/SceneController.cpp
+++ b/tests/cpp-tests/Classes/ExtensionsTest/CocoStudioComponentsTest/SceneController.cpp
@@ -49,7 +49,7 @@ void SceneController::update(float delta)
 
 SceneController* SceneController::create(void)
 {
-    SceneController * pRet = new SceneController();
+    SceneController * pRet = new (std::nothrow) SceneController();
     if (pRet && pRet->init())
     {
         pRet->autorelease();

--- a/tests/cpp-tests/Classes/ExtensionsTest/CocoStudioSceneTest/SceneEditorTest.cpp
+++ b/tests/cpp-tests/Classes/ExtensionsTest/CocoStudioSceneTest/SceneEditorTest.cpp
@@ -23,34 +23,34 @@ Layer *createTests(int index)
     switch(index)
     {
     case TEST_LOADSCENEEDITORFILE:
-        layer = new LoadSceneEdtiorFileTest();
+        layer = new (std::nothrow) LoadSceneEdtiorFileTest();
         break;
     case TEST_SPIRTECOMPONENT:
-        layer = new SpriteComponentTest();
+        layer = new (std::nothrow) SpriteComponentTest();
         break;
     case TEST_ARMATURECOMPONENT:
-        layer = new ArmatureComponentTest();
+        layer = new (std::nothrow) ArmatureComponentTest();
         break;
     case TEST_UICOMPONENT:
-        layer = new UIComponentTest();
+        layer = new (std::nothrow) UIComponentTest();
         break;
     case TEST_TMXMAPCOMPONENT:
-        layer = new TmxMapComponentTest();
+        layer = new (std::nothrow) TmxMapComponentTest();
         break;
     case TEST_PARTICLECOMPONENT:
-        layer = new ParticleComponentTest();
+        layer = new (std::nothrow) ParticleComponentTest();
         break;
     case TEST_EFEECTCOMPONENT:
-        layer = new EffectComponentTest();
+        layer = new (std::nothrow) EffectComponentTest();
         break;
     case TEST_BACKGROUNDCOMPONENT:
-        layer = new BackgroundComponentTest();
+        layer = new (std::nothrow) BackgroundComponentTest();
         break;
     case TEST_ATTRIBUTECOMPONENT:
-        layer = new AttributeComponentTest();
+        layer = new (std::nothrow) AttributeComponentTest();
         break;
     case TEST_TRIGGER:
-        layer = new TriggerTest();
+        layer = new (std::nothrow) TriggerTest();
         break;
     default:
         break;
@@ -179,7 +179,7 @@ std::string SceneEditorTestLayer::subtitle()
 
 void SceneEditorTestLayer::restartCallback(Ref *pSender)
 {
-    Scene *s = new SceneEditorTestScene();
+    Scene *s = new (std::nothrow) SceneEditorTestScene();
     s->addChild(Restart());
     Director::getInstance()->replaceScene(s);
     s->release();
@@ -187,7 +187,7 @@ void SceneEditorTestLayer::restartCallback(Ref *pSender)
 
 void SceneEditorTestLayer::nextCallback(Ref *pSender)
 {
-    Scene *s = new SceneEditorTestScene();
+    Scene *s = new (std::nothrow) SceneEditorTestScene();
     s->addChild(Next());
     Director::getInstance()->replaceScene(s);
     s->release();
@@ -195,7 +195,7 @@ void SceneEditorTestLayer::nextCallback(Ref *pSender)
 
 void SceneEditorTestLayer::backCallback(Ref *pSender)
 {
-    Scene *s = new SceneEditorTestScene();
+    Scene *s = new (std::nothrow) SceneEditorTestScene();
     s->addChild(Back());
     Director::getInstance()->replaceScene(s);
     s->release();

--- a/tests/cpp-tests/Classes/ExtensionsTest/CocosBuilderTest/CocosBuilderTest.cpp
+++ b/tests/cpp-tests/Classes/ExtensionsTest/CocosBuilderTest/CocosBuilderTest.cpp
@@ -59,7 +59,7 @@ void CocosBuilderTestScene::runThisTest() {
 //    NodeLoaderLibrary * ccNodeLoaderLibrary = NodeLoaderLibrary::newDefaultNodeLoaderLibrary();
 //    
 //    /* Create an autorelease CCBReader. */
-//    CCBReader * ccbReader = new CCBReader(ccNodeLoaderLibrary, ccbiReaderLayer, ccbiReaderLayer);
+//    CCBReader * ccbReader = new (std::nothrow) CCBReader(ccNodeLoaderLibrary, ccbiReaderLayer, ccbiReaderLayer);
 //    ccbReader->autorelease();
 //    
 //    /* Read a ccbi file. */

--- a/tests/cpp-tests/Classes/ExtensionsTest/ControlExtensionTest/CCControlScene.cpp
+++ b/tests/cpp-tests/Classes/ExtensionsTest/ControlExtensionTest/CCControlScene.cpp
@@ -84,7 +84,7 @@ bool ControlScene::init()
 
 void ControlScene::toExtensionsMainLayer(Ref* sender)
 {
-    auto scene = new ExtensionsTestScene();
+    auto scene = new (std::nothrow) ExtensionsTestScene();
     scene->runThisTest();
     scene->release();
 }

--- a/tests/cpp-tests/Classes/ExtensionsTest/ControlExtensionTest/CCControlSceneManager.cpp
+++ b/tests/cpp-tests/Classes/ExtensionsTest/ControlExtensionTest/CCControlSceneManager.cpp
@@ -75,7 +75,7 @@ ControlSceneManager * ControlSceneManager::sharedControlSceneManager()
 {
     if (sharedInstance == nullptr)
     {
-        sharedInstance = new ControlSceneManager();
+        sharedInstance = new (std::nothrow) ControlSceneManager();
     }
     return sharedInstance;
 }

--- a/tests/cpp-tests/Classes/ExtensionsTest/EditBoxTest/EditBoxTest.cpp
+++ b/tests/cpp-tests/Classes/ExtensionsTest/EditBoxTest/EditBoxTest.cpp
@@ -85,7 +85,7 @@ EditBoxTest::~EditBoxTest()
 
 void EditBoxTest::toExtensionsMainLayer(cocos2d::Ref *sender)
 {
-    auto scene = new ExtensionsTestScene();
+    auto scene = new (std::nothrow) ExtensionsTestScene();
     scene->runThisTest();
     scene->release();
 }
@@ -126,7 +126,7 @@ void EditBoxTest::editBoxReturn(EditBox* editBox)
 void runEditBoxTest()
 {
     auto scene = Scene::create();
-    EditBoxTest *layer = new EditBoxTest();
+    EditBoxTest *layer = new (std::nothrow) EditBoxTest();
     scene->addChild(layer);
     
     Director::getInstance()->replaceScene(scene);

--- a/tests/cpp-tests/Classes/ExtensionsTest/ExtensionsTest.cpp
+++ b/tests/cpp-tests/Classes/ExtensionsTest/ExtensionsTest.cpp
@@ -37,7 +37,7 @@ static struct {
 	{ "NotificationCenterTest", [](Ref* sender) { runNotificationCenterTest(); }
 	},
     { "Scale9SpriteTest", [](Ref* sender) {
-            auto scene = new S9SpriteTestScene();
+            auto scene = new (std::nothrow) S9SpriteTestScene();
             if (scene)
             {
                 scene->runThisTest();
@@ -51,7 +51,7 @@ static struct {
 		Director::getInstance()->replaceScene(scene);
 	}},
 	{ "CocosBuilderTest", [](Ref *sender) {
-		auto scene = new CocosBuilderTestScene();
+		auto scene = new (std::nothrow) CocosBuilderTestScene();
 		if (scene)
 		{
 			scene->runThisTest();
@@ -74,19 +74,19 @@ static struct {
 #endif
 	{ "TableViewTest", [](Ref *sender){ runTableViewTest();}
 	},
-	{ "CocoStudioArmatureTest", [](Ref *sender) { ArmatureTestScene *scene = new ArmatureTestScene();
+	{ "CocoStudioArmatureTest", [](Ref *sender) { ArmatureTestScene *scene = new (std::nothrow) ArmatureTestScene();
 	                                       scene->runThisTest();
 	                                       scene->release();
 	}
 	},
-    { "CocoStudioActionTimelineTest", [](Ref *sender) { ActionTimelineTestScene *scene = new ActionTimelineTestScene();
+    { "CocoStudioActionTimelineTest", [](Ref *sender) { ActionTimelineTestScene *scene = new (std::nothrow) ActionTimelineTestScene();
     scene->runThisTest();
     scene->release();
     }
     },
     { "CocoStudioComponentsTest", [](Ref *sender) { runComponentsTestLayerTest(); }
     },
-	{ "CocoStudioSceneTest", [](Ref *sender) { SceneEditorTestScene *scene = new SceneEditorTestScene();
+	{ "CocoStudioSceneTest", [](Ref *sender) { SceneEditorTestScene *scene = new (std::nothrow) SceneEditorTestScene();
 	                                       scene->runThisTest();
 	                                       scene->release();
  }
@@ -200,7 +200,7 @@ void ExtensionsMainLayer::onMouseScroll(Event* event)
 
 void ExtensionsTestScene::runThisTest()
 {
-    auto layer = new ExtensionsMainLayer();
+    auto layer = new (std::nothrow) ExtensionsMainLayer();
     addChild(layer);
     layer->release();
     

--- a/tests/cpp-tests/Classes/ExtensionsTest/NetworkTest/HttpClientTest.cpp
+++ b/tests/cpp-tests/Classes/ExtensionsTest/NetworkTest/HttpClientTest.cpp
@@ -107,7 +107,7 @@ void HttpClientTest::onMenuGetTestClicked(cocos2d::Ref *sender, bool isImmediate
 {    
     // test 1
     {
-        HttpRequest* request = new HttpRequest();
+        HttpRequest* request = new (std::nothrow) HttpRequest();
         request->setUrl("http://just-make-this-request-failed.com");
         request->setRequestType(HttpRequest::Type::GET);
         request->setResponseCallback(CC_CALLBACK_2(HttpClientTest::onHttpRequestCompleted, this));
@@ -125,7 +125,7 @@ void HttpClientTest::onMenuGetTestClicked(cocos2d::Ref *sender, bool isImmediate
     
     // test 2
     {
-        HttpRequest* request = new HttpRequest();
+        HttpRequest* request = new (std::nothrow) HttpRequest();
         // required fields
         request->setUrl("http://httpbin.org/ip");
         request->setRequestType(HttpRequest::Type::GET);
@@ -145,7 +145,7 @@ void HttpClientTest::onMenuGetTestClicked(cocos2d::Ref *sender, bool isImmediate
     
     // test 3   
     {
-        HttpRequest* request = new HttpRequest();
+        HttpRequest* request = new (std::nothrow) HttpRequest();
         request->setUrl("https://httpbin.org/get");
         request->setRequestType(HttpRequest::Type::GET);
         request->setResponseCallback(CC_CALLBACK_2(HttpClientTest::onHttpRequestCompleted, this));
@@ -170,7 +170,7 @@ void HttpClientTest::onMenuPostTestClicked(cocos2d::Ref *sender, bool isImmediat
 {
     // test 1
     {
-        HttpRequest* request = new HttpRequest();
+        HttpRequest* request = new (std::nothrow) HttpRequest();
         request->setUrl("http://httpbin.org/post");
         request->setRequestType(HttpRequest::Type::POST);
         request->setResponseCallback(CC_CALLBACK_2(HttpClientTest::onHttpRequestCompleted, this));
@@ -192,7 +192,7 @@ void HttpClientTest::onMenuPostTestClicked(cocos2d::Ref *sender, bool isImmediat
     
     // test 2: set Content-Type
     {
-        HttpRequest* request = new HttpRequest();
+        HttpRequest* request = new (std::nothrow) HttpRequest();
         request->setUrl("http://httpbin.org/post");
         request->setRequestType(HttpRequest::Type::POST);
         std::vector<std::string> headers;
@@ -221,7 +221,7 @@ void HttpClientTest::onMenuPostTestClicked(cocos2d::Ref *sender, bool isImmediat
 
 void HttpClientTest::onMenuPostBinaryTestClicked(cocos2d::Ref *sender, bool isImmediate)
 {
-    HttpRequest* request = new HttpRequest();
+    HttpRequest* request = new (std::nothrow) HttpRequest();
     request->setUrl("http://httpbin.org/post");
     request->setRequestType(HttpRequest::Type::POST);
     request->setResponseCallback(CC_CALLBACK_2(HttpClientTest::onHttpRequestCompleted, this));
@@ -250,7 +250,7 @@ void HttpClientTest::onMenuPutTestClicked(Ref *sender, bool isImmediate)
 {
     // test 1
     {
-        HttpRequest* request = new HttpRequest();
+        HttpRequest* request = new (std::nothrow) HttpRequest();
         request->setUrl("http://httpbin.org/put");
         request->setRequestType(HttpRequest::Type::PUT);
         request->setResponseCallback(CC_CALLBACK_2(HttpClientTest::onHttpRequestCompleted, this));
@@ -272,7 +272,7 @@ void HttpClientTest::onMenuPutTestClicked(Ref *sender, bool isImmediate)
 
     // test 2: set Content-Type
     {
-        HttpRequest* request = new HttpRequest();
+        HttpRequest* request = new (std::nothrow) HttpRequest();
         request->setUrl("http://httpbin.org/put");
         request->setRequestType(HttpRequest::Type::PUT);
         std::vector<std::string> headers;
@@ -303,7 +303,7 @@ void HttpClientTest::onMenuDeleteTestClicked(Ref *sender, bool isImmediate)
 {
     // test 1
     {
-        HttpRequest* request = new HttpRequest();
+        HttpRequest* request = new (std::nothrow) HttpRequest();
         request->setUrl("http://just-make-this-request-failed.com");
         request->setRequestType(HttpRequest::Type::DELETE);
         request->setResponseCallback(CC_CALLBACK_2(HttpClientTest::onHttpRequestCompleted, this));
@@ -321,7 +321,7 @@ void HttpClientTest::onMenuDeleteTestClicked(Ref *sender, bool isImmediate)
 
     // test 2
     {
-        HttpRequest* request = new HttpRequest();
+        HttpRequest* request = new (std::nothrow) HttpRequest();
         request->setUrl("http://httpbin.org/delete");
         request->setRequestType(HttpRequest::Type::DELETE);
         request->setResponseCallback(CC_CALLBACK_2(HttpClientTest::onHttpRequestCompleted, this));
@@ -383,7 +383,7 @@ void HttpClientTest::onHttpRequestCompleted(HttpClient *sender, HttpResponse *re
 
 void HttpClientTest::toExtensionsMainLayer(cocos2d::Ref *sender)
 {
-    auto scene = new ExtensionsTestScene();
+    auto scene = new (std::nothrow) ExtensionsTestScene();
     scene->runThisTest();
     scene->release();
 }
@@ -391,7 +391,7 @@ void HttpClientTest::toExtensionsMainLayer(cocos2d::Ref *sender)
 void runHttpClientTest()
 {
     auto scene = Scene::create();
-    HttpClientTest *layer = new HttpClientTest();
+    HttpClientTest *layer = new (std::nothrow) HttpClientTest();
     scene->addChild(layer);
     
     Director::getInstance()->replaceScene(scene);

--- a/tests/cpp-tests/Classes/ExtensionsTest/NetworkTest/SocketIOTest.cpp
+++ b/tests/cpp-tests/Classes/ExtensionsTest/NetworkTest/SocketIOTest.cpp
@@ -126,7 +126,7 @@ void SocketIOTestLayer::echotest(SIOClient *client, const std::string& data) {
 
 void SocketIOTestLayer::toExtensionsMainLayer(cocos2d::Ref *sender)
 {
-	ExtensionsTestScene *scene = new ExtensionsTestScene();
+	ExtensionsTestScene *scene = new (std::nothrow) ExtensionsTestScene();
     scene->runThisTest();
     scene->release();
 
@@ -261,7 +261,7 @@ void SocketIOTestLayer::onError(network::SIOClient* client, const std::string& d
 void runSocketIOTest()
 {
     auto scene = Scene::create();
-    auto layer = new SocketIOTestLayer();
+    auto layer = new (std::nothrow) SocketIOTestLayer();
     scene->addChild(layer);
     
     Director::getInstance()->replaceScene(scene);

--- a/tests/cpp-tests/Classes/ExtensionsTest/NetworkTest/WebSocketTest.cpp
+++ b/tests/cpp-tests/Classes/ExtensionsTest/NetworkTest/WebSocketTest.cpp
@@ -193,7 +193,7 @@ void WebSocketTestLayer::onError(network::WebSocket* ws, const network::WebSocke
 
 void WebSocketTestLayer::toExtensionsMainLayer(cocos2d::Ref *sender)
 {
-    auto scene = new ExtensionsTestScene();
+    auto scene = new (std::nothrow) ExtensionsTestScene();
     scene->runThisTest();
     scene->release();
 }
@@ -242,7 +242,7 @@ void WebSocketTestLayer::onMenuSendBinaryClicked(cocos2d::Ref *sender)
 void runWebSocketTest()
 {
     auto scene = Scene::create();
-    auto layer = new WebSocketTestLayer();
+    auto layer = new (std::nothrow) WebSocketTestLayer();
     scene->addChild(layer);
     
     Director::getInstance()->replaceScene(scene);

--- a/tests/cpp-tests/Classes/ExtensionsTest/NotificationCenterTest/NotificationCenterTest.cpp
+++ b/tests/cpp-tests/Classes/ExtensionsTest/NotificationCenterTest/NotificationCenterTest.cpp
@@ -38,7 +38,7 @@ Light::~Light()
 
 Light* Light::lightWithFile(const char* name)
 {
-    Light* pLight = new Light();
+    Light* pLight = new (std::nothrow) Light();
     pLight->initWithFile(name);
     pLight->autorelease();
     return pLight;
@@ -139,7 +139,7 @@ void NotificationCenterTest::toExtensionsMainLayer(cocos2d::Ref* sender)
     int CC_UNUSED numObserversRemoved = NotificationCenter::getInstance()->removeAllObservers(this);
     CCASSERT(numObserversRemoved >= 3, "All observers were not removed!");
 
-    auto scene = new ExtensionsTestScene();
+    auto scene = new (std::nothrow) ExtensionsTestScene();
     scene->runThisTest();
     scene->release();
 }
@@ -167,7 +167,7 @@ void NotificationCenterTest::doNothing(cocos2d::Ref *sender)
 void runNotificationCenterTest()
 {
     auto scene = Scene::create();
-    NotificationCenterTest* layer = new NotificationCenterTest();
+    NotificationCenterTest* layer = new (std::nothrow) NotificationCenterTest();
     scene->addChild(layer);
     Director::getInstance()->replaceScene(scene);
     layer->release();

--- a/tests/cpp-tests/Classes/ExtensionsTest/Scale9SpriteTest/Scale9SpriteTest.cpp
+++ b/tests/cpp-tests/Classes/ExtensionsTest/Scale9SpriteTest/Scale9SpriteTest.cpp
@@ -103,7 +103,7 @@ void S9SpriteTestDemo::onEnter()
 
 void S9SpriteTestDemo::restartCallback(Ref* sender)
 {
-    auto s = new S9SpriteTestScene();
+    auto s = new (std::nothrow) S9SpriteTestScene();
     s->addChild( restartAction() );
     Director::getInstance()->replaceScene(s);
     s->release();
@@ -111,7 +111,7 @@ void S9SpriteTestDemo::restartCallback(Ref* sender)
 
 void S9SpriteTestDemo::nextCallback(Ref* sender)
 {
-    auto s = new S9SpriteTestScene();
+    auto s = new (std::nothrow) S9SpriteTestScene();
     s->addChild( nextAction() );
     Director::getInstance()->replaceScene(s);
     s->release();
@@ -119,7 +119,7 @@ void S9SpriteTestDemo::nextCallback(Ref* sender)
 
 void S9SpriteTestDemo::backCallback(Ref* sender)
 {
-    auto s = new S9SpriteTestScene();
+    auto s = new (std::nothrow) S9SpriteTestScene();
     s->addChild( backAction() );
     Director::getInstance()->replaceScene(s);
     s->release();

--- a/tests/cpp-tests/Classes/ExtensionsTest/TableViewTest/TableViewTestScene.cpp
+++ b/tests/cpp-tests/Classes/ExtensionsTest/TableViewTest/TableViewTestScene.cpp
@@ -50,7 +50,7 @@ bool TableViewTestLayer::init()
 
 void TableViewTestLayer::toExtensionsMainLayer(cocos2d::Ref *sender)
 {
-	ExtensionsTestScene *scene = new ExtensionsTestScene();
+	ExtensionsTestScene *scene = new (std::nothrow) ExtensionsTestScene();
 	scene->runThisTest();
 	scene->release();
 }
@@ -73,7 +73,7 @@ TableViewCell* TableViewTestLayer::tableCellAtIndex(TableView *table, ssize_t id
     auto string = String::createWithFormat("%ld", idx);
     TableViewCell *cell = table->dequeueCell();
     if (!cell) {
-        cell = new CustomTableViewCell();
+        cell = new (std::nothrow) CustomTableViewCell();
         cell->autorelease();
         auto sprite = Sprite::create("Images/Icon.png");
         sprite->setAnchorPoint(Vec2::ZERO);

--- a/tests/cpp-tests/Classes/FileUtilsTest/FileUtilsTest.cpp
+++ b/tests/cpp-tests/Classes/FileUtilsTest/FileUtilsTest.cpp
@@ -56,7 +56,7 @@ void FileUtilsDemo::onEnter()
 
 void FileUtilsDemo::backCallback(Ref* sender)
 {
-    auto scene = new FileUtilsTestScene();
+    auto scene = new (std::nothrow) FileUtilsTestScene();
     auto layer = backAction();
     
     scene->addChild(layer);
@@ -66,7 +66,7 @@ void FileUtilsDemo::backCallback(Ref* sender)
 
 void FileUtilsDemo::nextCallback(Ref* sender)
 {
-    auto scene = new FileUtilsTestScene();
+    auto scene = new (std::nothrow) FileUtilsTestScene();
     auto layer = nextAction();
     
     scene->addChild(layer);
@@ -76,7 +76,7 @@ void FileUtilsDemo::nextCallback(Ref* sender)
 
 void FileUtilsDemo::restartCallback(Ref* sender)
 {
-    auto scene = new FileUtilsTestScene();
+    auto scene = new (std::nothrow) FileUtilsTestScene();
     auto layer = restartAction();
     
     scene->addChild(layer);

--- a/tests/cpp-tests/Classes/InputTest/MouseTest.cpp
+++ b/tests/cpp-tests/Classes/InputTest/MouseTest.cpp
@@ -74,7 +74,7 @@ void MouseTest::onMouseScroll(Event *event)
 
 void MouseTestScene::runThisTest()
 {
-    auto layer = new MouseTest();
+    auto layer = new (std::nothrow) MouseTest();
     addChild(layer);
 
     Director::getInstance()->replaceScene(this);

--- a/tests/cpp-tests/Classes/IntervalTest/IntervalTest.cpp
+++ b/tests/cpp-tests/Classes/IntervalTest/IntervalTest.cpp
@@ -123,7 +123,7 @@ void IntervalLayer::step4(float dt)
 
 void IntervalTestScene::runThisTest()
 {
-    auto layer = new IntervalLayer();
+    auto layer = new (std::nothrow) IntervalLayer();
     addChild(layer);
     layer->release();
 

--- a/tests/cpp-tests/Classes/LabelTest/LabelTest.cpp
+++ b/tests/cpp-tests/Classes/LabelTest/LabelTest.cpp
@@ -138,7 +138,7 @@ void AtlasDemo::onEnter()
 
 void AtlasDemo::restartCallback(Ref* sender)
 {
-    auto s = new AtlasTestScene();
+    auto s = new (std::nothrow) AtlasTestScene();
     s->addChild(restartAtlasAction()); 
 
     Director::getInstance()->replaceScene(s);
@@ -147,7 +147,7 @@ void AtlasDemo::restartCallback(Ref* sender)
 
 void AtlasDemo::nextCallback(Ref* sender)
 {
-    auto s = new AtlasTestScene();
+    auto s = new (std::nothrow) AtlasTestScene();
     s->addChild( nextAtlasAction() );
     Director::getInstance()->replaceScene(s);
     s->release();
@@ -155,7 +155,7 @@ void AtlasDemo::nextCallback(Ref* sender)
 
 void AtlasDemo::backCallback(Ref* sender)
 {
-    auto s = new AtlasTestScene();
+    auto s = new (std::nothrow) AtlasTestScene();
     s->addChild( backAtlasAction() );
     Director::getInstance()->replaceScene(s);
     s->release();
@@ -1699,7 +1699,7 @@ void LabelBMFontCrashTest::onEnter()
     
     auto winSize = Director::getInstance()->getWinSize();
     //Create a label and add it
-    auto label1 = new LabelBMFont();
+    auto label1 = new (std::nothrow) LabelBMFont();
     label1->initWithString("test", "fonts/bitmapFontTest2.fnt");
     this->addChild(label1);
     // Visit will call draw where the function "ccGLBindVAO(m_uVAOname);" will be invoked.

--- a/tests/cpp-tests/Classes/LabelTest/LabelTestNew.cpp
+++ b/tests/cpp-tests/Classes/LabelTest/LabelTestNew.cpp
@@ -145,7 +145,7 @@ void AtlasDemoNew::onEnter()
 
 void AtlasDemoNew::restartCallback(Ref* sender)
 {
-    auto s = new AtlasTestSceneNew();
+    auto s = new (std::nothrow) AtlasTestSceneNew();
     s->addChild(restartAtlasActionNew()); 
 
     Director::getInstance()->replaceScene(s);
@@ -154,7 +154,7 @@ void AtlasDemoNew::restartCallback(Ref* sender)
 
 void AtlasDemoNew::nextCallback(Ref* sender)
 {
-    auto s = new AtlasTestSceneNew();
+    auto s = new (std::nothrow) AtlasTestSceneNew();
     s->addChild( nextAtlasActionNew() );
     Director::getInstance()->replaceScene(s);
     s->release();
@@ -162,7 +162,7 @@ void AtlasDemoNew::nextCallback(Ref* sender)
 
 void AtlasDemoNew::backCallback(Ref* sender)
 {
-    auto s = new AtlasTestSceneNew();
+    auto s = new (std::nothrow) AtlasTestSceneNew();
     s->addChild( backAtlasActionNew() );
     Director::getInstance()->replaceScene(s);
     s->release();

--- a/tests/cpp-tests/Classes/LayerTest/LayerTest.cpp
+++ b/tests/cpp-tests/Classes/LayerTest/LayerTest.cpp
@@ -88,7 +88,7 @@ void LayerTest::onEnter()
 
 void LayerTest::restartCallback(Ref* sender)
 {
-    auto s = new LayerTestScene();
+    auto s = new (std::nothrow) LayerTestScene();
     s->addChild(restartAction());
 
     Director::getInstance()->replaceScene(s);
@@ -97,7 +97,7 @@ void LayerTest::restartCallback(Ref* sender)
 
 void LayerTest::nextCallback(Ref* sender)
 {
-    auto s = new LayerTestScene();
+    auto s = new (std::nothrow) LayerTestScene();
     s->addChild( nextAction() );
     Director::getInstance()->replaceScene(s);
     s->release();
@@ -105,7 +105,7 @@ void LayerTest::nextCallback(Ref* sender)
 
 void LayerTest::backCallback(Ref* sender)
 {
-    auto s = new LayerTestScene();
+    auto s = new (std::nothrow) LayerTestScene();
     s->addChild( backAction() );
     Director::getInstance()->replaceScene(s);
     s->release();

--- a/tests/cpp-tests/Classes/MenuTest/MenuTest.cpp
+++ b/tests/cpp-tests/Classes/MenuTest/MenuTest.cpp
@@ -565,12 +565,12 @@ void MenuTestScene::runThisTest()
 {
     MenuItemFont::setFontSize(20);
     
-    auto layer1 = new MenuLayerMainMenu();
-    auto layer2 = new MenuLayer2();
-    auto layer3 = new MenuLayer3();
-    auto layer4 = new MenuLayer4();
-    auto layer5 = new BugsTest();
-    auto layer6 = new RemoveMenuItemWhenMove();
+    auto layer1 = new (std::nothrow) MenuLayerMainMenu();
+    auto layer2 = new (std::nothrow) MenuLayer2();
+    auto layer3 = new (std::nothrow) MenuLayer3();
+    auto layer4 = new (std::nothrow) MenuLayer4();
+    auto layer5 = new (std::nothrow) BugsTest();
+    auto layer6 = new (std::nothrow) RemoveMenuItemWhenMove();
 
     auto layer = LayerMultiplex::create(layer1, layer2, layer3, layer4, layer5, layer6, nullptr);
     addChild(layer, 0); 

--- a/tests/cpp-tests/Classes/MotionStreakTest/MotionStreakTest.cpp
+++ b/tests/cpp-tests/Classes/MotionStreakTest/MotionStreakTest.cpp
@@ -230,7 +230,7 @@ void MotionStreakTest::modeCallback(Ref *pSender)
 
 void MotionStreakTest::restartCallback(Ref* sender)
 {
-    auto s = new MotionStreakTestScene();//CCScene::create();
+    auto s = new (std::nothrow) MotionStreakTestScene();//CCScene::create();
     s->addChild(restartMotionAction()); 
 
     Director::getInstance()->replaceScene(s);
@@ -239,7 +239,7 @@ void MotionStreakTest::restartCallback(Ref* sender)
 
 void MotionStreakTest::nextCallback(Ref* sender)
 {
-    auto s = new MotionStreakTestScene();//CCScene::create();
+    auto s = new (std::nothrow) MotionStreakTestScene();//CCScene::create();
     s->addChild( nextMotionAction() );
     Director::getInstance()->replaceScene(s);
     s->release();
@@ -247,7 +247,7 @@ void MotionStreakTest::nextCallback(Ref* sender)
 
 void MotionStreakTest::backCallback(Ref* sender)
 {
-    auto s = new MotionStreakTestScene;//CCScene::create();
+    auto s = new (std::nothrow) MotionStreakTestScene;//CCScene::create();
     s->addChild( backMotionAction() );
     Director::getInstance()->replaceScene(s);
     s->release();

--- a/tests/cpp-tests/Classes/MutiTouchTest/MutiTouchTest.cpp
+++ b/tests/cpp-tests/Classes/MutiTouchTest/MutiTouchTest.cpp
@@ -40,7 +40,7 @@ public:
 
     static TouchPoint* touchPointWithParent(Node* pParent)
     {
-        auto pRet = new TouchPoint();
+        auto pRet = new (std::nothrow) TouchPoint();
         pRet->setContentSize(pParent->getContentSize());
         pRet->setAnchorPoint(Vec2(0.0f, 0.0f));
         pRet->autorelease();

--- a/tests/cpp-tests/Classes/NewEventDispatcherTest/NewEventDispatcherTest.cpp
+++ b/tests/cpp-tests/Classes/NewEventDispatcherTest/NewEventDispatcherTest.cpp
@@ -84,7 +84,7 @@ void EventDispatcherTestDemo::onEnter()
 
 void EventDispatcherTestDemo::backCallback(Ref* sender)
 {
-    auto scene = new EventDispatcherTestScene();
+    auto scene = new (std::nothrow) EventDispatcherTestScene();
     auto layer = backAction();
     
     scene->addChild(layer);
@@ -94,7 +94,7 @@ void EventDispatcherTestDemo::backCallback(Ref* sender)
 
 void EventDispatcherTestDemo::nextCallback(Ref* sender)
 {
-    auto scene = new EventDispatcherTestScene();
+    auto scene = new (std::nothrow) EventDispatcherTestScene();
     auto layer = nextAction();
     
     scene->addChild(layer);
@@ -104,7 +104,7 @@ void EventDispatcherTestDemo::nextCallback(Ref* sender)
 
 void EventDispatcherTestDemo::restartCallback(Ref* sender)
 {
-    auto scene = new EventDispatcherTestScene();
+    auto scene = new (std::nothrow) EventDispatcherTestScene();
     auto layer = restartAction();
     
     scene->addChild(layer);
@@ -233,7 +233,7 @@ class TouchableSprite : public Sprite
 public:
     static TouchableSprite* create(int priority = 0)
     {
-        auto ret = new TouchableSprite(priority);
+        auto ret = new (std::nothrow) TouchableSprite(priority);
         if (ret && ret->init())
         {
             ret->autorelease();
@@ -1298,7 +1298,7 @@ public:
     
     static DanglingNodePointersTestSprite * create(const TappedCallback & tappedCallback)
     {
-        auto ret = new DanglingNodePointersTestSprite(tappedCallback);
+        auto ret = new (std::nothrow) DanglingNodePointersTestSprite(tappedCallback);
         
         if (ret && ret->init())
         {

--- a/tests/cpp-tests/Classes/NewRendererTest/NewRendererTest.cpp
+++ b/tests/cpp-tests/Classes/NewRendererTest/NewRendererTest.cpp
@@ -108,7 +108,7 @@ void MultiSceneTest::onEnter()
 
 void MultiSceneTest::restartCallback(Ref *sender)
 {
-    auto s = new NewRendererTestScene();
+    auto s = new (std::nothrow) NewRendererTestScene();
     s->addChild(restartTest());
 
     Director::getInstance()->replaceScene(s);
@@ -117,7 +117,7 @@ void MultiSceneTest::restartCallback(Ref *sender)
 
 void MultiSceneTest::nextCallback(Ref *sender)
 {
-    auto s = new NewRendererTestScene();
+    auto s = new (std::nothrow) NewRendererTestScene();
     s->addChild(nextTest());
 
     Director::getInstance()->replaceScene(s);
@@ -126,7 +126,7 @@ void MultiSceneTest::nextCallback(Ref *sender)
 
 void MultiSceneTest::backCallback(Ref *sender)
 {
-    auto s = new NewRendererTestScene();
+    auto s = new (std::nothrow) NewRendererTestScene();
     s->addChild(prevTest());
 
     Director::getInstance()->replaceScene(s);
@@ -236,7 +236,7 @@ public:
 
 SpriteInGroupCommand* SpriteInGroupCommand::create(const std::string &filename)
 {
-    SpriteInGroupCommand* sprite = new SpriteInGroupCommand();
+    SpriteInGroupCommand* sprite = new (std::nothrow) SpriteInGroupCommand();
     sprite->initWithFile(filename);
     sprite->autorelease();
     return sprite;

--- a/tests/cpp-tests/Classes/NodeTest/NodeTest.cpp
+++ b/tests/cpp-tests/Classes/NodeTest/NodeTest.cpp
@@ -129,7 +129,7 @@ void TestCocosNodeDemo::onEnter()
 
 void TestCocosNodeDemo::restartCallback(Ref* sender)
 {
-    auto s = new CocosNodeTestScene();//CCScene::create();
+    auto s = new (std::nothrow) CocosNodeTestScene();//CCScene::create();
     s->addChild(restartCocosNodeAction()); 
 
     Director::getInstance()->replaceScene(s);
@@ -138,7 +138,7 @@ void TestCocosNodeDemo::restartCallback(Ref* sender)
 
 void TestCocosNodeDemo::nextCallback(Ref* sender)
 {
-    auto s = new CocosNodeTestScene();//CCScene::create();
+    auto s = new (std::nothrow) CocosNodeTestScene();//CCScene::create();
     s->addChild( nextCocosNodeAction() );
     Director::getInstance()->replaceScene(s);
     s->release();
@@ -146,7 +146,7 @@ void TestCocosNodeDemo::nextCallback(Ref* sender)
 
 void TestCocosNodeDemo::backCallback(Ref* sender)
 {
-    auto s = new CocosNodeTestScene();//CCScene::create();
+    auto s = new (std::nothrow) CocosNodeTestScene();//CCScene::create();
     s->addChild( backCocosNodeAction() );
     Director::getInstance()->replaceScene(s);
     s->release();
@@ -989,7 +989,7 @@ class MySprite : public Sprite
 public:
     static MySprite* create(const std::string &spritefilename)
     {
-        auto sprite = new MySprite;
+        auto sprite = new (std::nothrow) MySprite;
         sprite->initWithFile(spritefilename);
         sprite->autorelease();
 

--- a/tests/cpp-tests/Classes/ParallaxTest/ParallaxTest.cpp
+++ b/tests/cpp-tests/Classes/ParallaxTest/ParallaxTest.cpp
@@ -303,7 +303,7 @@ void ParallaxDemo::onEnter()
 
 void ParallaxDemo::restartCallback(Ref* sender)
 {
-    auto s = new ParallaxTestScene();
+    auto s = new (std::nothrow) ParallaxTestScene();
     s->addChild(restartParallaxAction()); 
 
     Director::getInstance()->replaceScene(s);
@@ -312,7 +312,7 @@ void ParallaxDemo::restartCallback(Ref* sender)
 
 void ParallaxDemo::nextCallback(Ref* sender)
 {
-    auto s = new ParallaxTestScene();
+    auto s = new (std::nothrow) ParallaxTestScene();
     s->addChild( nextParallaxAction() );
     Director::getInstance()->replaceScene(s);
     s->release();
@@ -320,7 +320,7 @@ void ParallaxDemo::nextCallback(Ref* sender)
 
 void ParallaxDemo::backCallback(Ref* sender)
 {
-    auto s = new ParallaxTestScene();
+    auto s = new (std::nothrow) ParallaxTestScene();
     s->addChild( backParallaxAction() );
     Director::getInstance()->replaceScene(s);
     s->release();

--- a/tests/cpp-tests/Classes/ParticleTest/ParticleTest.cpp
+++ b/tests/cpp-tests/Classes/ParticleTest/ParticleTest.cpp
@@ -1180,7 +1180,7 @@ void ParticleDemo::restartCallback(Ref* sender)
 
 void ParticleDemo::nextCallback(Ref* sender)
 {
-    auto s = new ParticleTestScene();
+    auto s = new (std::nothrow) ParticleTestScene();
     s->addChild( nextParticleAction() );
     Director::getInstance()->replaceScene(s);
     s->release();
@@ -1188,7 +1188,7 @@ void ParticleDemo::nextCallback(Ref* sender)
 
 void ParticleDemo::backCallback(Ref* sender)
 {
-    auto s = new ParticleTestScene();
+    auto s = new (std::nothrow) ParticleTestScene();
     s->addChild( backParticleAction() );
     Director::getInstance()->replaceScene(s);
     s->release();
@@ -1474,7 +1474,7 @@ void Issue1201::onEnter()
     removeChild(_background, true);
     _background = nullptr;
 
-    RainbowEffect *particle = new RainbowEffect();
+    RainbowEffect *particle = new (std::nothrow) RainbowEffect();
     particle->initWithTotalParticles(50);
 
     addChild(particle);

--- a/tests/cpp-tests/Classes/PerformanceTest/PerformanceAllocTest.cpp
+++ b/tests/cpp-tests/Classes/PerformanceTest/PerformanceAllocTest.cpp
@@ -147,7 +147,7 @@ void PerformceAllocScene::initWithQuantityOfNodes(unsigned int nNodes)
     infoLabel->setPosition(Vec2(s.width/2, s.height/2-15));
     addChild(infoLabel, 1, kTagInfoLayer);
 
-    auto menuLayer = new AllocBasicLayer(true, MAX_LAYER, g_curCase);
+    auto menuLayer = new (std::nothrow) AllocBasicLayer(true, MAX_LAYER, g_curCase);
     addChild(menuLayer);
     menuLayer->release();
 
@@ -239,7 +239,7 @@ void NodeCreateTest::update(float dt)
 {
     // iterate using fast enumeration protocol
 
-    Node **nodes = new Node*[quantityOfNodes];
+    Node **nodes = new (std::nothrow) Node*[quantityOfNodes];
 
     CC_PROFILER_START(this->profilerName());
     for( int i=0; i<quantityOfNodes; ++i)
@@ -287,7 +287,7 @@ void NodeDeallocTest::update(float dt)
 {
     // iterate using fast enumeration protocol
 
-    Node **nodes = new Node*[quantityOfNodes];
+    Node **nodes = new (std::nothrow) Node*[quantityOfNodes];
 
     for( int i=0; i<quantityOfNodes; ++i) {
         nodes[i] = Node::create();
@@ -340,7 +340,7 @@ void SpriteCreateEmptyTest::update(float dt)
 {
     // iterate using fast enumeration protocol
 
-    Sprite **sprites = new Sprite*[quantityOfNodes];
+    Sprite **sprites = new (std::nothrow) Sprite*[quantityOfNodes];
 
     Sprite::create("Images/grossini.png");
 
@@ -390,7 +390,7 @@ void SpriteCreateTest::update(float dt)
 {
     // iterate using fast enumeration protocol
 
-    Sprite **sprites = new Sprite*[quantityOfNodes];
+    Sprite **sprites = new (std::nothrow) Sprite*[quantityOfNodes];
 
     Sprite::create("Images/grossini.png");
     
@@ -440,7 +440,7 @@ void SpriteDeallocTest::update(float dt)
 {
     // iterate using fast enumeration protocol
 
-    Sprite **sprites = new Sprite*[quantityOfNodes];
+    Sprite **sprites = new (std::nothrow) Sprite*[quantityOfNodes];
 
     for( int i=0; i<quantityOfNodes; ++i) {
         sprites[i] = Sprite::create();

--- a/tests/cpp-tests/Classes/PerformanceTest/PerformanceCallbackTest.cpp
+++ b/tests/cpp-tests/Classes/PerformanceTest/PerformanceCallbackTest.cpp
@@ -82,7 +82,7 @@ void PerformanceCallbackScene::onEnter()
     
     auto s = Director::getInstance()->getWinSize();
     
-    auto menuLayer = new CallbackBasicLayer(true, MAX_LAYER, g_curCase);
+    auto menuLayer = new (std::nothrow) CallbackBasicLayer(true, MAX_LAYER, g_curCase);
     addChild(menuLayer);
     menuLayer->release();
     

--- a/tests/cpp-tests/Classes/PerformanceTest/PerformanceContainerTest.cpp
+++ b/tests/cpp-tests/Classes/PerformanceTest/PerformanceContainerTest.cpp
@@ -152,7 +152,7 @@ void PerformanceContainerScene::initWithQuantityOfNodes(unsigned int nNodes)
     infoLabel->setPosition(Vec2(s.width/2, s.height/2-15));
     addChild(infoLabel, 1, kTagInfoLayer);
 
-    auto menuLayer = new ContainerBasicLayer(true, MAX_LAYER, g_curCase);
+    auto menuLayer = new (std::nothrow) ContainerBasicLayer(true, MAX_LAYER, g_curCase);
     addChild(menuLayer);
     menuLayer->release();
 

--- a/tests/cpp-tests/Classes/PerformanceTest/PerformanceEventDispatcherTest.cpp
+++ b/tests/cpp-tests/Classes/PerformanceTest/PerformanceEventDispatcherTest.cpp
@@ -150,7 +150,7 @@ void PerformanceEventDispatcherScene::initWithQuantityOfNodes(unsigned int nNode
     infoLabel->setPosition(Vec2(s.width/2, s.height/2-15));
     addChild(infoLabel, 1, kTagInfoLayer);
     
-    auto menuLayer = new EventDispatcherBasicLayer(true, MAX_LAYER, g_curCase);
+    auto menuLayer = new (std::nothrow) EventDispatcherBasicLayer(true, MAX_LAYER, g_curCase);
     addChild(menuLayer);
     menuLayer->release();
     
@@ -344,7 +344,7 @@ void TouchEventDispatchingPerfTest::generateTestFunctions()
 
             for (int i = 0; i < 4; ++i)
             {
-                Touch* touch = new Touch();
+                Touch* touch = new (std::nothrow) Touch();
                 touch->autorelease();
                 touch->setTouchInfo(i, rand() % 200, rand() % 200);
                 touches.push_back(touch);
@@ -385,7 +385,7 @@ void TouchEventDispatchingPerfTest::generateTestFunctions()
             
             for (int i = 0; i < 4; ++i)
             {
-                Touch* touch = new Touch();
+                Touch* touch = new (std::nothrow) Touch();
                 touch->autorelease();
                 touch->setTouchInfo(i, rand() % 200, rand() % 200);
                 touches.push_back(touch);
@@ -426,7 +426,7 @@ void TouchEventDispatchingPerfTest::generateTestFunctions()
             
             for (int i = 0; i < 4; ++i)
             {
-                Touch* touch = new Touch();
+                Touch* touch = new (std::nothrow) Touch();
                 touch->autorelease();
                 touch->setTouchInfo(i, rand() % 200, rand() % 200);
                 touches.push_back(touch);
@@ -464,7 +464,7 @@ void TouchEventDispatchingPerfTest::generateTestFunctions()
             
             for (int i = 0; i < 4; ++i)
             {
-                Touch* touch = new Touch();
+                Touch* touch = new (std::nothrow) Touch();
                 touch->autorelease();
                 touch->setTouchInfo(i, rand() % 200, rand() % 200);
                 touches.push_back(touch);
@@ -523,7 +523,7 @@ void TouchEventDispatchingPerfTest::generateTestFunctions()
             
             for (int i = 0; i < 4; ++i)
             {
-                Touch* touch = new Touch();
+                Touch* touch = new (std::nothrow) Touch();
                 touch->autorelease();
                 touch->setTouchInfo(i, rand() % 200, rand() % 200);
                 touches.push_back(touch);
@@ -578,7 +578,7 @@ void TouchEventDispatchingPerfTest::generateTestFunctions()
             
             for (int i = 0; i < 4; ++i)
             {
-                Touch* touch = new Touch();
+                Touch* touch = new (std::nothrow) Touch();
                 touch->autorelease();
                 touch->setTouchInfo(i, rand() % 200, rand() % 200);
                 touches.push_back(touch);

--- a/tests/cpp-tests/Classes/PerformanceTest/PerformanceLabelTest.cpp
+++ b/tests/cpp-tests/Classes/PerformanceTest/PerformanceLabelTest.cpp
@@ -108,7 +108,7 @@ void LabelMainScene::initWithSubTest(int nodes)
     addChild(infoLabel, 1, kTagInfoLayer);
 
     // add menu
-    auto menuLayer = new LabelMenuLayer(true, TEST_COUNT, LabelMainScene::_s_labelCurCase);
+    auto menuLayer = new (std::nothrow) LabelMenuLayer(true, TEST_COUNT, LabelMainScene::_s_labelCurCase);
     addChild(menuLayer, 1, kTagMenuLayer);
     menuLayer->release();
     
@@ -441,7 +441,7 @@ void  LabelMainScene::onAutoTest(Ref* sender)
 void runLabelTest()
 {
     LabelMainScene::_s_autoTest = false;
-    auto scene = new LabelMainScene;
+    auto scene = new (std::nothrow) LabelMainScene;
     scene->initWithSubTest(LabelMainScene::AUTO_TEST_NODE_NUM);
     Director::getInstance()->replaceScene(scene);
     scene->release();

--- a/tests/cpp-tests/Classes/PerformanceTest/PerformanceNodeChildrenTest.cpp
+++ b/tests/cpp-tests/Classes/PerformanceTest/PerformanceNodeChildrenTest.cpp
@@ -176,7 +176,7 @@ void NodeChildrenMainScene::initWithQuantityOfNodes(unsigned int nNodes)
     infoLabel->setPosition(Vec2(s.width/2, s.height/2-15));
     addChild(infoLabel, 1, kTagInfoLayer);
 
-    auto menuLayer = new NodeChildrenMenuLayer(true, MAX_LAYER, g_curCase);
+    auto menuLayer = new (std::nothrow) NodeChildrenMenuLayer(true, MAX_LAYER, g_curCase);
     addChild(menuLayer);
     menuLayer->release();
 
@@ -487,7 +487,7 @@ void AddSprite::update(float dt)
 
     if( totalToAdd > 0 )
     {
-        Sprite **sprites = new Sprite*[totalToAdd];
+        Sprite **sprites = new (std::nothrow) Sprite*[totalToAdd];
         int *zs = new int[totalToAdd];
 
         // Don't include the sprite creation time and random as part of the profiling
@@ -550,7 +550,7 @@ void AddSpriteSheet::update(float dt)
 
     if( totalToAdd > 0 )
     {
-        Sprite **sprites = new Sprite*[totalToAdd];
+        Sprite **sprites = new (std::nothrow) Sprite*[totalToAdd];
         int *zs = new int[totalToAdd];
 
         // Don't include the sprite creation time and random as part of the profiling
@@ -613,7 +613,7 @@ void GetSpriteSheet::update(float dt)
 
     if( totalToAdd > 0 )
     {
-        Sprite **sprites = new Sprite*[totalToAdd];
+        Sprite **sprites = new (std::nothrow) Sprite*[totalToAdd];
         int *zs = new int[totalToAdd];
 
         // Don't include the sprite creation time and random as part of the profiling
@@ -678,7 +678,7 @@ void RemoveSprite::update(float dt)
 
     if( totalToAdd > 0 )
     {
-        Sprite **sprites = new Sprite*[totalToAdd];
+        Sprite **sprites = new (std::nothrow) Sprite*[totalToAdd];
 
         // Don't include the sprite creation time as part of the profiling
         for(int i=0;i<totalToAdd;i++)
@@ -733,7 +733,7 @@ void RemoveSpriteSheet::update(float dt)
 
     if( totalToAdd > 0 )
     {
-        Sprite **sprites = new Sprite*[totalToAdd];
+        Sprite **sprites = new (std::nothrow) Sprite*[totalToAdd];
 
         // Don't include the sprite creation time as part of the profiling
         for(int i=0;i<totalToAdd;i++)
@@ -788,7 +788,7 @@ void ReorderSpriteSheet::update(float dt)
 
     if( totalToAdd > 0 )
     {
-        Sprite **sprites = new Sprite*[totalToAdd];
+        Sprite **sprites = new (std::nothrow) Sprite*[totalToAdd];
 
         // Don't include the sprite creation time as part of the profiling
         for(int i=0; i<totalToAdd; i++)
@@ -851,7 +851,7 @@ void SortAllChildrenSpriteSheet::update(float dt)
 
     if( totalToAdd > 0 )
     {
-        Sprite **sprites = new Sprite*[totalToAdd];
+        Sprite **sprites = new (std::nothrow) Sprite*[totalToAdd];
 
         // Don't include the sprite's creation time as part of the profiling
         for(int i=0; i<totalToAdd; i++)

--- a/tests/cpp-tests/Classes/PerformanceTest/PerformanceParticleTest.cpp
+++ b/tests/cpp-tests/Classes/PerformanceTest/PerformanceParticleTest.cpp
@@ -40,16 +40,16 @@ void ParticleMenuLayer::showCurrentTest()
     switch (_curCase)
     {
     case 0:
-        pNewScene = new ParticlePerformTest1;
+        pNewScene = new (std::nothrow) ParticlePerformTest1;
         break;
     case 1:
-        pNewScene = new ParticlePerformTest2;
+        pNewScene = new (std::nothrow) ParticlePerformTest2;
         break;
     case 2:
-        pNewScene = new ParticlePerformTest3;
+        pNewScene = new (std::nothrow) ParticlePerformTest3;
         break;
     case 3:
-        pNewScene = new ParticlePerformTest4;
+        pNewScene = new (std::nothrow) ParticlePerformTest4;
         break;
     }
 
@@ -114,7 +114,7 @@ void ParticleMainScene::initWithSubTest(int asubtest, int particles)
     labelAtlas->setPosition(Vec2(s.width-66,50));
 
     // Next Prev Test
-    auto menuLayer = new ParticleMenuLayer(true, TEST_COUNT, s_nParCurIdx);
+    auto menuLayer = new (std::nothrow) ParticleMenuLayer(true, TEST_COUNT, s_nParCurIdx);
     addChild(menuLayer, 1, kTagMenuLayer);
     menuLayer->release();
 
@@ -191,7 +191,7 @@ void ParticleMainScene::createParticleSystem()
 
 //TODO:     if (subtestNumber <= 3)
 //     {
-//         particleSystem = new ParticleSystemPoint();
+//         particleSystem = new (std::nothrow) ParticleSystemPoint();
 //     }
 //     else
     {
@@ -550,7 +550,7 @@ void ParticlePerformTest4::doTest()
 
 void runParticleTest()
 {
-    auto scene = new ParticlePerformTest1;
+    auto scene = new (std::nothrow) ParticlePerformTest1;
     scene->initWithSubTest(1, kNodesIncrease);
 
     Director::getInstance()->replaceScene(scene);

--- a/tests/cpp-tests/Classes/PerformanceTest/PerformanceRendererTest.cpp
+++ b/tests/cpp-tests/Classes/PerformanceTest/PerformanceRendererTest.cpp
@@ -22,7 +22,7 @@ RenderTestLayer::~RenderTestLayer()
 Scene* RenderTestLayer::scene()
 {
     auto scene = Scene::create();
-    RenderTestLayer *layer = new RenderTestLayer();
+    RenderTestLayer *layer = new (std::nothrow) RenderTestLayer();
     scene->addChild(layer);
     layer->release();
     

--- a/tests/cpp-tests/Classes/PerformanceTest/PerformanceScenarioTest.cpp
+++ b/tests/cpp-tests/Classes/PerformanceTest/PerformanceScenarioTest.cpp
@@ -355,7 +355,7 @@ std::string ScenarioTest::title() const
 Scene* ScenarioTest::scene()
 {
     auto scene = Scene::create();
-    ScenarioTest *layer = new ScenarioTest(false, TEST_COUNT, s_nScenarioCurCase);
+    ScenarioTest *layer = new (std::nothrow) ScenarioTest(false, TEST_COUNT, s_nScenarioCurCase);
     scene->addChild(layer);
     layer->release();
 

--- a/tests/cpp-tests/Classes/PerformanceTest/PerformanceSpriteTest.cpp
+++ b/tests/cpp-tests/Classes/PerformanceTest/PerformanceSpriteTest.cpp
@@ -327,25 +327,25 @@ void SpriteMenuLayer::showCurrentTest()
     switch (_curCase)
     {
     case 0:
-        scene = new SpritePerformTest1;
+        scene = new (std::nothrow) SpritePerformTest1;
         break;
     case 1:
-        scene = new SpritePerformTest2;
+        scene = new (std::nothrow) SpritePerformTest2;
         break;
     case 2:
-        scene = new SpritePerformTest3;
+        scene = new (std::nothrow) SpritePerformTest3;
         break;
     case 3:
-        scene = new SpritePerformTest4;
+        scene = new (std::nothrow) SpritePerformTest4;
         break;
     case 4:
-        scene = new SpritePerformTest5;
+        scene = new (std::nothrow) SpritePerformTest5;
         break;
     case 5:
-        scene = new SpritePerformTest6;
+        scene = new (std::nothrow) SpritePerformTest6;
         break;
     case 6:
-        scene = new SpritePerformTest7;
+        scene = new (std::nothrow) SpritePerformTest7;
         break;
     }
     
@@ -372,7 +372,7 @@ void SpriteMainScene::initWithSubTest(int asubtest, int nNodes)
     //srandom(0);
 
     subtestNumber = asubtest;
-    _subTest = new SubTest;
+    _subTest = new (std::nothrow) SubTest;
     _subTest->initWithSubTest(asubtest, this);
 
     auto s = Director::getInstance()->getWinSize();
@@ -397,7 +397,7 @@ void SpriteMainScene::initWithSubTest(int asubtest, int nNodes)
     addChild(infoLabel, 1, kTagInfoLayer);
 
     // add menu
-    auto menuLayer = new SpriteMenuLayer(true, TEST_COUNT, SpriteMainScene::_s_nSpriteCurCase);
+    auto menuLayer = new (std::nothrow) SpriteMenuLayer(true, TEST_COUNT, SpriteMainScene::_s_nSpriteCurCase);
     addChild(menuLayer, 1, kTagMenuLayer);
     menuLayer->release();
     
@@ -622,25 +622,25 @@ void  SpriteMainScene::autoShowSpriteTests(int curCase, int subTest,int nodes)
     switch (curCase)
     {
         case 0:
-            scene = new SpritePerformTest1;
+            scene = new (std::nothrow) SpritePerformTest1;
             break;
         case 1:
-            scene = new SpritePerformTest2;
+            scene = new (std::nothrow) SpritePerformTest2;
             break;
         case 2:
-            scene = new SpritePerformTest3;
+            scene = new (std::nothrow) SpritePerformTest3;
             break;
         case 3:
-            scene = new SpritePerformTest4;
+            scene = new (std::nothrow) SpritePerformTest4;
             break;
         case 4:
-            scene = new SpritePerformTest5;
+            scene = new (std::nothrow) SpritePerformTest5;
             break;
         case 5:
-            scene = new SpritePerformTest6;
+            scene = new (std::nothrow) SpritePerformTest6;
             break;
         case 6:
-            scene = new SpritePerformTest7;
+            scene = new (std::nothrow) SpritePerformTest7;
             break;
     }
     
@@ -661,7 +661,7 @@ void SpriteMainScene::beginAutoTest()
         SpriteMainScene::_s_nSpriteCurCase = 0;
     }
     
-    auto scene = new SpritePerformTest1;
+    auto scene = new (std::nothrow) SpritePerformTest1;
     scene->initWithSubTest(1, 500);
     Director::getInstance()->replaceScene(scene);
     scene->release();
@@ -989,7 +989,7 @@ void SpritePerformTest7::doTest(Sprite* sprite)
 void runSpriteTest()
 {
     SpriteMainScene::_s_autoTest = false;
-    auto scene = new SpritePerformTest1;
+    auto scene = new (std::nothrow) SpritePerformTest1;
     scene->initWithSubTest(1, 50);
     Director::getInstance()->replaceScene(scene);
     scene->release();

--- a/tests/cpp-tests/Classes/PerformanceTest/PerformanceTest.cpp
+++ b/tests/cpp-tests/Classes/PerformanceTest/PerformanceTest.cpp
@@ -176,7 +176,7 @@ void PerformBasicLayer::onEnter()
 
 void PerformBasicLayer::toMainLayer(Ref* sender)
 {
-    auto scene = new PerformanceTestScene();
+    auto scene = new (std::nothrow) PerformanceTestScene();
     scene->runThisTest();
 
     scene->release();
@@ -212,7 +212,7 @@ void PerformBasicLayer::backCallback(Ref* sender)
 
 void PerformanceTestScene::runThisTest()
 {
-    auto layer = new PerformanceMainLayer();
+    auto layer = new (std::nothrow) PerformanceMainLayer();
     addChild(layer);
     layer->release();
 

--- a/tests/cpp-tests/Classes/PerformanceTest/PerformanceTextureTest.cpp
+++ b/tests/cpp-tests/Classes/PerformanceTest/PerformanceTextureTest.cpp
@@ -348,7 +348,7 @@ std::string TextureTest::subtitle() const
 Scene* TextureTest::scene()
 {
     auto scene = Scene::create();
-    TextureTest *layer = new TextureTest(false, TEST_COUNT, s_nTexCurCase);
+    TextureTest *layer = new (std::nothrow) TextureTest(false, TEST_COUNT, s_nTexCurCase);
     scene->addChild(layer);
     layer->release();
 

--- a/tests/cpp-tests/Classes/PerformanceTest/PerformanceTouchesTest.cpp
+++ b/tests/cpp-tests/Classes/PerformanceTest/PerformanceTouchesTest.cpp
@@ -45,13 +45,13 @@ void TouchesMainScene::showCurrentTest()
     switch (_curCase)
     {
     case 0:
-        layer = new TouchesPerformTest1(true, TEST_COUNT, _curCase);
+        layer = new (std::nothrow) TouchesPerformTest1(true, TEST_COUNT, _curCase);
         break;
     case 1:
-        layer = new TouchesPerformTest2(true, TEST_COUNT, _curCase);
+        layer = new (std::nothrow) TouchesPerformTest2(true, TEST_COUNT, _curCase);
         break;
     case 2:
-        layer = new TouchesPerformTest3(true, TEST_COUNT, _curCase);
+        layer = new (std::nothrow) TouchesPerformTest3(true, TEST_COUNT, _curCase);
         break;
     }
     s_nTouchCurCase = _curCase;
@@ -235,7 +235,7 @@ void TouchesPerformTest3::onEnter()
     for (int i = 0; i < TOUCHABLE_NODE_NUM; ++i)
     {
         int zorder = rand() % TOUCHABLE_NODE_NUM;
-        auto layer = new TouchableLayer();
+        auto layer = new (std::nothrow) TouchableLayer();
         
         auto listener = EventListenerTouchOneByOne::create();
         listener->onTouchBegan = CC_CALLBACK_2(TouchableLayer::onTouchBegan, layer);
@@ -256,7 +256,7 @@ void TouchesPerformTest3::onEnter()
         std::vector<Touch*> touches;
         for (int i = 0; i < EventTouch::MAX_TOUCHES; ++i)
         {
-            Touch* touch = new Touch();
+            Touch* touch = new (std::nothrow) Touch();
             touch->setTouchInfo(i, 10, (i+1) * 10);
             touches.push_back(touch);
         }
@@ -298,13 +298,13 @@ void TouchesPerformTest3::showCurrentTest()
     switch (_curCase)
     {
         case 0:
-            layer = new TouchesPerformTest1(true, TEST_COUNT, _curCase);
+            layer = new (std::nothrow) TouchesPerformTest1(true, TEST_COUNT, _curCase);
             break;
         case 1:
-            layer = new TouchesPerformTest2(true, TEST_COUNT, _curCase);
+            layer = new (std::nothrow) TouchesPerformTest2(true, TEST_COUNT, _curCase);
             break;
         case 2:
-            layer = new TouchesPerformTest3(true, TEST_COUNT, _curCase);
+            layer = new (std::nothrow) TouchesPerformTest3(true, TEST_COUNT, _curCase);
             break;
     }
     s_nTouchCurCase = _curCase;
@@ -323,7 +323,7 @@ void runTouchesTest()
 {
     s_nTouchCurCase = 0;
     auto scene = Scene::create();
-    auto layer = new TouchesPerformTest1(true, TEST_COUNT, s_nTouchCurCase);
+    auto layer = new (std::nothrow) TouchesPerformTest1(true, TEST_COUNT, s_nTouchCurCase);
 
     scene->addChild(layer);
     layer->release();

--- a/tests/cpp-tests/Classes/PhysicsTest/PhysicsTest.cpp
+++ b/tests/cpp-tests/Classes/PhysicsTest/PhysicsTest.cpp
@@ -123,7 +123,7 @@ std::string PhysicsDemo::subtitle() const
 
 void PhysicsDemo::restartCallback(Ref* sender)
 {
-    auto s = new PhysicsTestScene();
+    auto s = new (std::nothrow) PhysicsTestScene();
     s->addChild( restart() );
     Director::getInstance()->replaceScene(s);
     s->release();
@@ -131,7 +131,7 @@ void PhysicsDemo::restartCallback(Ref* sender)
 
 void PhysicsDemo::nextCallback(Ref* sender)
 {
-    auto s = new PhysicsTestScene();
+    auto s = new (std::nothrow) PhysicsTestScene();
     s->addChild( next() );
     Director::getInstance()->replaceScene(s);
     s->release();
@@ -139,7 +139,7 @@ void PhysicsDemo::nextCallback(Ref* sender)
 
 void PhysicsDemo::backCallback(Ref* sender)
 {
-    auto s = new PhysicsTestScene();
+    auto s = new (std::nothrow) PhysicsTestScene();
     s->addChild( back() );
     Director::getInstance()->replaceScene(s);
     s->release();
@@ -1215,7 +1215,7 @@ void PhysicsDemoSlice::clipPoly(PhysicsShapePolygon* shape, Vec2 normal, float d
     PhysicsBody* body = shape->getBody();
     int count = shape->getPointsCount();
     int pointsCount = 0;
-    Vec2* points = new Vec2[count + 1];
+    Vec2* points = new (std::nothrow) Vec2[count + 1];
     
     for (int i=0, j=count-1; i<count; j=i, ++i)
     {

--- a/tests/cpp-tests/Classes/ReleasePoolTest/ReleasePoolTest.cpp
+++ b/tests/cpp-tests/Classes/ReleasePoolTest/ReleasePoolTest.cpp
@@ -31,7 +31,7 @@ void ReleasePoolTestScene::runThisTest()
     
     // reference count should be added when added into auto release pool
     
-    TestObject *obj = new TestObject("testobj");
+    TestObject *obj = new (std::nothrow) TestObject("testobj");
     obj->autorelease();
     assert(obj->getReferenceCount() == 1);
     
@@ -69,7 +69,7 @@ void ReleasePoolTestScene::runThisTest()
         for (int i = 0; i < 100; ++i)
         {
             snprintf(name, 20, "object%d", i);
-            TestObject *tmpObj = new TestObject(name);
+            TestObject *tmpObj = new (std::nothrow) TestObject(name);
             tmpObj->autorelease();
         }
     }

--- a/tests/cpp-tests/Classes/RenderTextureTest/RenderTextureTest.cpp
+++ b/tests/cpp-tests/Classes/RenderTextureTest/RenderTextureTest.cpp
@@ -51,7 +51,7 @@ void RenderTextureTest::onEnter()
 
 void RenderTextureTest::restartCallback(Ref* sender)
 {
-    auto s = new RenderTextureScene();
+    auto s = new (std::nothrow) RenderTextureScene();
     s->addChild(restartTestCase()); 
 
     Director::getInstance()->replaceScene(s);
@@ -60,7 +60,7 @@ void RenderTextureTest::restartCallback(Ref* sender)
 
 void RenderTextureTest::nextCallback(Ref* sender)
 {
-    auto s = new RenderTextureScene();
+    auto s = new (std::nothrow) RenderTextureScene();
     s->addChild( nextTestCase() );
     Director::getInstance()->replaceScene(s);
     s->release();
@@ -68,7 +68,7 @@ void RenderTextureTest::nextCallback(Ref* sender)
 
 void RenderTextureTest::backCallback(Ref* sender)
 {
-    auto s = new RenderTextureScene();
+    auto s = new (std::nothrow) RenderTextureScene();
     s->addChild( backTestCase() );
     Director::getInstance()->replaceScene(s);
     s->release();
@@ -666,7 +666,7 @@ SpriteRenderTextureBug::SimpleSprite::~SimpleSprite()
 
 SpriteRenderTextureBug::SimpleSprite* SpriteRenderTextureBug::SimpleSprite::create(const char* filename, const Rect &rect)
 {
-    auto sprite = new SimpleSprite();
+    auto sprite = new (std::nothrow) SimpleSprite();
     if (sprite && sprite->initWithFile(filename, rect))
     {
         sprite->autorelease();

--- a/tests/cpp-tests/Classes/SceneTest/SceneTest.cpp
+++ b/tests/cpp-tests/Classes/SceneTest/SceneTest.cpp
@@ -62,8 +62,8 @@ SceneTestLayer1::~SceneTestLayer1()
 
 void SceneTestLayer1::onPushScene(Ref* sender)
 {
-    auto scene = new SceneTestScene();
-    auto layer = new SceneTestLayer2();
+    auto scene = new (std::nothrow) SceneTestScene();
+    auto layer = new (std::nothrow) SceneTestLayer2();
     scene->addChild( layer, 0 );
     Director::getInstance()->pushScene( scene );
     scene->release();
@@ -72,8 +72,8 @@ void SceneTestLayer1::onPushScene(Ref* sender)
 
 void SceneTestLayer1::onPushSceneTran(Ref* sender)
 {
-    auto scene = new SceneTestScene();
-    auto layer = new SceneTestLayer2();
+    auto scene = new (std::nothrow) SceneTestScene();
+    auto layer = new (std::nothrow) SceneTestLayer2();
     scene->addChild( layer, 0 );
 
     Director::getInstance()->pushScene( TransitionSlideInT::create(1, scene) );
@@ -137,7 +137,7 @@ void SceneTestLayer2::onGoBack(Ref* sender)
 
 void SceneTestLayer2::onReplaceScene(Ref* sender)
 {
-    auto scene = new SceneTestScene();
+    auto scene = new (std::nothrow) SceneTestScene();
     auto layer = SceneTestLayer3::create();
     scene->addChild( layer, 0 );
     Director::getInstance()->replaceScene( scene );
@@ -147,7 +147,7 @@ void SceneTestLayer2::onReplaceScene(Ref* sender)
 
 void SceneTestLayer2::onReplaceSceneTran(Ref* sender)
 {
-    auto scene = new SceneTestScene();
+    auto scene = new (std::nothrow) SceneTestScene();
     auto layer = SceneTestLayer3::create();
     scene->addChild( layer, 0 );
     Director::getInstance()->replaceScene( TransitionFlipX::create(2, scene) );
@@ -223,7 +223,7 @@ void SceneTestLayer3::item3Clicked(Ref* sender)
 
 void SceneTestScene::runThisTest()
 {
-    auto layer = new SceneTestLayer1();
+    auto layer = new (std::nothrow) SceneTestLayer1();
     addChild(layer);
     layer->release();
 

--- a/tests/cpp-tests/Classes/SchedulerTest/SchedulerTest.cpp
+++ b/tests/cpp-tests/Classes/SchedulerTest/SchedulerTest.cpp
@@ -72,7 +72,7 @@ void SchedulerTestLayer::onEnter()
 
 void SchedulerTestLayer::backCallback(Ref* sender)
 {
-    auto scene = new SchedulerTestScene();
+    auto scene = new (std::nothrow) SchedulerTestScene();
     auto layer = backSchedulerTest();
 
     scene->addChild(layer);
@@ -82,7 +82,7 @@ void SchedulerTestLayer::backCallback(Ref* sender)
 
 void SchedulerTestLayer::nextCallback(Ref* sender)
 {
-    auto scene = new SchedulerTestScene();
+    auto scene = new (std::nothrow) SchedulerTestScene();
     auto layer = nextSchedulerTest();
 
     scene->addChild(layer);
@@ -92,7 +92,7 @@ void SchedulerTestLayer::nextCallback(Ref* sender)
 
 void SchedulerTestLayer::restartCallback(Ref* sender)
 {
-    auto scene = new SchedulerTestScene();
+    auto scene = new (std::nothrow) SchedulerTestScene();
     auto layer = restartSchedulerTest();
 
     scene->addChild(layer);
@@ -616,32 +616,32 @@ void SchedulerUpdate::onEnter()
 {
     SchedulerTestLayer::onEnter();
 
-    auto d = new TestNode();
+    auto d = new (std::nothrow) TestNode();
     d->initWithString("---", 50);
     addChild(d);
     d->release();
 
-    auto b = new TestNode();
+    auto b = new (std::nothrow) TestNode();
     b->initWithString("3rd", 0);
     addChild(b);
     b->release();
 
-    auto a = new TestNode();
+    auto a = new (std::nothrow) TestNode();
     a->initWithString("1st", -10);
     addChild(a);
     a->release();
 
-    auto c = new TestNode();
+    auto c = new (std::nothrow) TestNode();
     c->initWithString("4th", 10);
     addChild(c);
     c->release();
 
-    auto e = new TestNode();
+    auto e = new (std::nothrow) TestNode();
     e->initWithString("5th", 20);
     addChild(e);
     e->release();
 
-    auto f = new TestNode();
+    auto f = new (std::nothrow) TestNode();
     f->initWithString("2nd", -5);
     addChild(f);
     f->release();
@@ -964,12 +964,12 @@ void TwoSchedulers::onEnter()
     //
 
     // Create a new scheduler, and link it to the main scheduler
-    sched1 = new Scheduler();
+    sched1 = new (std::nothrow) Scheduler();
 
     defaultScheduler->scheduleUpdate(sched1, 0, false);
 
     // Create a new ActionManager, and link it to the new scheudler
-    actionManager1 = new ActionManager();
+    actionManager1 = new (std::nothrow) ActionManager();
     sched1->scheduleUpdate(actionManager1, 0, false);
 
     for( unsigned int i=0; i < 10; i++ ) 
@@ -991,11 +991,11 @@ void TwoSchedulers::onEnter()
     //
 
     // Create a new scheduler, and link it to the main scheduler
-    sched2 = new Scheduler();;
+    sched2 = new (std::nothrow) Scheduler();;
     defaultScheduler->scheduleUpdate(sched2, 0, false);
 
     // Create a new ActionManager, and link it to the new scheudler
-    actionManager2 = new ActionManager();
+    actionManager2 = new (std::nothrow) ActionManager();
     sched2->scheduleUpdate(actionManager2, 0, false);
 
     for( unsigned int i=0; i < 10; i++ ) {

--- a/tests/cpp-tests/Classes/ShaderTest/ShaderTest.cpp
+++ b/tests/cpp-tests/Classes/ShaderTest/ShaderTest.cpp
@@ -65,7 +65,7 @@ ShaderTestDemo::ShaderTestDemo()
 
 void ShaderTestDemo::backCallback(Ref* sender)
 {
-    auto s = new ShaderTestScene();
+    auto s = new (std::nothrow) ShaderTestScene();
     s->addChild( backAction() );
     Director::getInstance()->replaceScene(s);
     s->release();
@@ -73,7 +73,7 @@ void ShaderTestDemo::backCallback(Ref* sender)
 
 void ShaderTestDemo::nextCallback(Ref* sender)
 {
-    auto s = new ShaderTestScene();//CCScene::create();
+    auto s = new (std::nothrow) ShaderTestScene();//CCScene::create();
     s->addChild( nextAction() );
     Director::getInstance()->replaceScene(s);
     s->release();
@@ -91,7 +91,7 @@ std::string ShaderTestDemo::subtitle() const
 
 void ShaderTestDemo::restartCallback(Ref* sender)
 {
-    auto s = new ShaderTestScene();
+    auto s = new (std::nothrow) ShaderTestScene();
     s->addChild(restartAction()); 
 
     Director::getInstance()->replaceScene(s);
@@ -122,7 +122,7 @@ ShaderNode::~ShaderNode()
 
 ShaderNode* ShaderNode::shaderNodeWithVertex(const std::string &vert, const std::string& frag)
 {
-    auto node = new ShaderNode();
+    auto node = new (std::nothrow) ShaderNode();
     node->initWithVertex(vert, frag);
     node->autorelease();
 
@@ -439,7 +439,7 @@ SpriteBlur::~SpriteBlur()
 
 SpriteBlur* SpriteBlur::create(const char *pszFileName)
 {
-    SpriteBlur* pRet = new SpriteBlur();
+    SpriteBlur* pRet = new (std::nothrow) SpriteBlur();
     if (pRet && pRet->initWithFile(pszFileName))
     {
         pRet->autorelease();

--- a/tests/cpp-tests/Classes/Sprite3DTest/DrawNode3D.cpp
+++ b/tests/cpp-tests/Classes/Sprite3DTest/DrawNode3D.cpp
@@ -66,7 +66,7 @@ DrawNode3D::~DrawNode3D()
 
 DrawNode3D* DrawNode3D::create()
 {
-    DrawNode3D* ret = new DrawNode3D();
+    DrawNode3D* ret = new (std::nothrow) DrawNode3D();
     if (ret && ret->init())
     {
         ret->autorelease();

--- a/tests/cpp-tests/Classes/Sprite3DTest/Sprite3DTest.cpp
+++ b/tests/cpp-tests/Classes/Sprite3DTest/Sprite3DTest.cpp
@@ -124,7 +124,7 @@ void Sprite3DTestDemo::onEnter()
 
 void Sprite3DTestDemo::restartCallback(Ref* sender)
 {
-    auto s = new Sprite3DTestScene();
+    auto s = new (std::nothrow) Sprite3DTestScene();
     s->addChild(restartSpriteTestAction());
     
     Director::getInstance()->replaceScene(s);
@@ -133,7 +133,7 @@ void Sprite3DTestDemo::restartCallback(Ref* sender)
 
 void Sprite3DTestDemo::nextCallback(Ref* sender)
 {
-    auto s = new Sprite3DTestScene();
+    auto s = new (std::nothrow) Sprite3DTestScene();
     s->addChild( nextSpriteTestAction() );
     Director::getInstance()->replaceScene(s);
     s->release();
@@ -141,7 +141,7 @@ void Sprite3DTestDemo::nextCallback(Ref* sender)
 
 void Sprite3DTestDemo::backCallback(Ref* sender)
 {
-    auto s = new Sprite3DTestScene();
+    auto s = new (std::nothrow) Sprite3DTestScene();
     s->addChild( backSpriteTestAction() );
     Director::getInstance()->replaceScene(s);
     s->release();
@@ -321,7 +321,7 @@ static int tuple_sort( const std::tuple<ssize_t,Effect3D*,CustomCommand> &tuple1
 
 EffectSprite3D* EffectSprite3D::createFromObjFileAndTexture(const std::string &objFilePath, const std::string &textureFilePath)
 {
-    auto sprite = new EffectSprite3D();
+    auto sprite = new (std::nothrow) EffectSprite3D();
     if (sprite && sprite->initWithFile(objFilePath))
     {
         sprite->autorelease();
@@ -338,7 +338,7 @@ EffectSprite3D* EffectSprite3D::create(const std::string &path)
     if (path.length() < 4)
         CCASSERT(false, "improper name specified when creating Sprite3D");
     
-    auto sprite = new EffectSprite3D();
+    auto sprite = new (std::nothrow) EffectSprite3D();
     if (sprite && sprite->initWithFile(path))
     {
         sprite->autorelease();
@@ -416,7 +416,7 @@ GLProgram* Effect3DOutline::getOrCreateProgram(bool isSkinned /* = false */ )
 
 Effect3DOutline* Effect3DOutline::create()
 {
-    Effect3DOutline* effect = new Effect3DOutline();
+    Effect3DOutline* effect = new (std::nothrow) Effect3DOutline();
     if(effect && effect->init())
     {
         effect->autorelease();

--- a/tests/cpp-tests/Classes/SpriteTest/SpriteTest.cpp
+++ b/tests/cpp-tests/Classes/SpriteTest/SpriteTest.cpp
@@ -195,7 +195,7 @@ void SpriteTestDemo::onEnter()
 
 void SpriteTestDemo::restartCallback(Ref* sender)
 {
-    auto s = new SpriteTestScene();
+    auto s = new (std::nothrow) SpriteTestScene();
     s->addChild(restartSpriteTestAction()); 
 
     Director::getInstance()->replaceScene(s);
@@ -204,7 +204,7 @@ void SpriteTestDemo::restartCallback(Ref* sender)
 
 void SpriteTestDemo::nextCallback(Ref* sender)
 {
-    auto s = new SpriteTestScene();
+    auto s = new (std::nothrow) SpriteTestScene();
     s->addChild( nextSpriteTestAction() );
     Director::getInstance()->replaceScene(s);
     s->release();
@@ -212,7 +212,7 @@ void SpriteTestDemo::nextCallback(Ref* sender)
 
 void SpriteTestDemo::backCallback(Ref* sender)
 {
-    auto s = new SpriteTestScene();
+    auto s = new (std::nothrow) SpriteTestScene();
     s->addChild( backSpriteTestAction() );
     Director::getInstance()->replaceScene(s);
     s->release();
@@ -1909,7 +1909,7 @@ void SpriteFramesFromFileContent::onEnter()
 
 	Image image;
 	image.initWithImageData((const uint8_t*)image_content.c_str(), image_content.size());
-	Texture2D* texture = new Texture2D();
+	Texture2D* texture = new (std::nothrow) Texture2D();
 	texture->initWithImage(&image);
 	texture->autorelease();
 
@@ -3509,7 +3509,7 @@ public:
 
 DoubleSprite* DoubleSprite::create(const std::string& filename)
 {
-    auto sprite = new DoubleSprite;
+    auto sprite = new (std::nothrow) DoubleSprite;
     sprite->initWithFile(filename);
     sprite->autorelease();
     return sprite;

--- a/tests/cpp-tests/Classes/TextInputTest/TextInputTest.cpp
+++ b/tests/cpp-tests/Classes/TextInputTest/TextInputTest.cpp
@@ -30,7 +30,7 @@ KeyboardNotificationLayer* createTextInputTest(int nIndex)
 
 Layer* restartTextInputTest()
 {
-    TextInputTest* pContainerLayer = new TextInputTest;
+    TextInputTest* pContainerLayer = new (std::nothrow) TextInputTest;
     pContainerLayer->autorelease();
 
     auto pTestLayer = createTextInputTest(testIdx);
@@ -80,7 +80,7 @@ TextInputTest::TextInputTest()
 
 void TextInputTest::restartCallback(Ref* sender)
 {
-    auto s = new TextInputTestScene();
+    auto s = new (std::nothrow) TextInputTestScene();
     s->addChild(restartTextInputTest()); 
 
     Director::getInstance()->replaceScene(s);
@@ -89,7 +89,7 @@ void TextInputTest::restartCallback(Ref* sender)
 
 void TextInputTest::nextCallback(Ref* sender)
 {
-    auto s = new TextInputTestScene();
+    auto s = new (std::nothrow) TextInputTestScene();
     s->addChild( nextTextInputTest() );
     Director::getInstance()->replaceScene(s);
     s->release();
@@ -97,7 +97,7 @@ void TextInputTest::nextCallback(Ref* sender)
 
 void TextInputTest::backCallback(Ref* sender)
 {
-    auto s = new TextInputTestScene();
+    auto s = new (std::nothrow) TextInputTestScene();
     s->addChild( backTextInputTest() );
     Director::getInstance()->replaceScene(s);
     s->release();

--- a/tests/cpp-tests/Classes/TextureCacheTest/TextureCacheTest.cpp
+++ b/tests/cpp-tests/Classes/TextureCacheTest/TextureCacheTest.cpp
@@ -130,7 +130,7 @@ void TextureCacheTest::addSprite()
 
 void TextureCacheTestScene::runThisTest()
 {
-    auto layer = new TextureCacheTest();
+    auto layer = new (std::nothrow) TextureCacheTest();
     addChild(layer);
 
     Director::getInstance()->replaceScene(this);

--- a/tests/cpp-tests/Classes/TexturePackerEncryptionTest/TextureAtlasEncryptionTest.cpp
+++ b/tests/cpp-tests/Classes/TexturePackerEncryptionTest/TextureAtlasEncryptionTest.cpp
@@ -71,7 +71,7 @@ void TextureAtlasEncryptionDemo::onEnter()
 
 void TextureAtlasEncryptionTestScene::runThisTest()
 {
-    auto layer = new TextureAtlasEncryptionDemo;
+    auto layer = new (std::nothrow) TextureAtlasEncryptionDemo;
     layer->autorelease();
     
     addChild(layer);

--- a/tests/cpp-tests/Classes/TileMapTest/TileMapTest.cpp
+++ b/tests/cpp-tests/Classes/TileMapTest/TileMapTest.cpp
@@ -123,7 +123,7 @@ void TileDemo::onExit()
 }
 void TileDemo::restartCallback(Ref* sender)
 {
-    auto s = new TileMapTestScene();
+    auto s = new (std::nothrow) TileMapTestScene();
     s->addChild(restartTileMapAction());
 
     Director::getInstance()->replaceScene(s);
@@ -132,7 +132,7 @@ void TileDemo::restartCallback(Ref* sender)
 
 void TileDemo::nextCallback(Ref* sender)
 {
-    auto s = new TileMapTestScene();
+    auto s = new (std::nothrow) TileMapTestScene();
     s->addChild( nextTileMapAction() );
     Director::getInstance()->replaceScene(s);
     s->release();
@@ -140,7 +140,7 @@ void TileDemo::nextCallback(Ref* sender)
 
 void TileDemo::backCallback(Ref* sender)
 {
-    auto s = new TileMapTestScene();
+    auto s = new (std::nothrow) TileMapTestScene();
     s->addChild( backTileMapAction() );
     Director::getInstance()->replaceScene(s);
     s->release();

--- a/tests/cpp-tests/Classes/TileMapTest/TileMapTest2.cpp
+++ b/tests/cpp-tests/Classes/TileMapTest/TileMapTest2.cpp
@@ -129,7 +129,7 @@ void TileDemoNew::onExit()
 }
 void TileDemoNew::restartCallback(Ref* sender)
 {
-    auto s = new TileMapTestSceneNew();
+    auto s = new (std::nothrow) TileMapTestSceneNew();
     s->addChild(restartTileMapAction());
 
     Director::getInstance()->replaceScene(s);
@@ -138,7 +138,7 @@ void TileDemoNew::restartCallback(Ref* sender)
 
 void TileDemoNew::nextCallback(Ref* sender)
 {
-    auto s = new TileMapTestSceneNew();
+    auto s = new (std::nothrow) TileMapTestSceneNew();
     s->addChild( nextTileMapAction() );
     Director::getInstance()->replaceScene(s);
     s->release();
@@ -146,7 +146,7 @@ void TileDemoNew::nextCallback(Ref* sender)
 
 void TileDemoNew::backCallback(Ref* sender)
 {
-    auto s = new TileMapTestSceneNew();
+    auto s = new (std::nothrow) TileMapTestSceneNew();
     s->addChild( backTileMapAction() );
     Director::getInstance()->replaceScene(s);
     s->release();

--- a/tests/cpp-tests/Classes/TouchesTest/Ball.cpp
+++ b/tests/cpp-tests/Classes/TouchesTest/Ball.cpp
@@ -17,7 +17,7 @@ float Ball::radius()
 
 Ball* Ball::ballWithTexture(Texture2D* aTexture)
 {
-    Ball* pBall = new Ball();
+    Ball* pBall = new (std::nothrow) Ball();
     pBall->initWithTexture(aTexture);
     pBall->autorelease();
 

--- a/tests/cpp-tests/Classes/TouchesTest/Paddle.cpp
+++ b/tests/cpp-tests/Classes/TouchesTest/Paddle.cpp
@@ -16,7 +16,7 @@ Rect Paddle::getRect()
 
 Paddle* Paddle::createWithTexture(Texture2D* aTexture)
 {
-    Paddle* pPaddle = new Paddle();
+    Paddle* pPaddle = new (std::nothrow) Paddle();
     pPaddle->initWithTexture(aTexture);
     pPaddle->autorelease();
 

--- a/tests/cpp-tests/Classes/TouchesTest/TouchesTest.cpp
+++ b/tests/cpp-tests/Classes/TouchesTest/TouchesTest.cpp
@@ -25,7 +25,7 @@ enum
 //------------------------------------------------------------------
 PongScene::PongScene()
 {
-    auto pongLayer = new PongLayer();//PongLayer::create();
+    auto pongLayer = new (std::nothrow) PongLayer();//PongLayer::create();
     addChild(pongLayer);
     pongLayer->release();
 }

--- a/tests/cpp-tests/Classes/TransitionsTest/TransitionsTest.cpp
+++ b/tests/cpp-tests/Classes/TransitionsTest/TransitionsTest.cpp
@@ -246,7 +246,7 @@ TransitionScene* createTransition(int index, float t, Scene* s)
 
 void TransitionsTestScene::runThisTest()
 {
-    auto layer = new TestLayer1();
+    auto layer = new (std::nothrow) TestLayer1();
     addChild(layer);
     layer->release();
 
@@ -299,9 +299,9 @@ TestLayer1::~TestLayer1(void)
 
 void TestLayer1::restartCallback(Ref* sender)
 {
-    auto s = new TransitionsTestScene();
+    auto s = new (std::nothrow) TransitionsTestScene();
 
-    auto layer = new TestLayer2();
+    auto layer = new (std::nothrow) TestLayer2();
     s->addChild(layer);
 
     auto scene = createTransition(s_nSceneIdx, TRANSITION_DURATION, s);
@@ -318,9 +318,9 @@ void TestLayer1::nextCallback(Ref* sender)
     s_nSceneIdx++;
     s_nSceneIdx = s_nSceneIdx % MAX_LAYER;
 
-    auto s = new TransitionsTestScene();
+    auto s = new (std::nothrow) TransitionsTestScene();
 
-    auto layer = new TestLayer2();
+    auto layer = new (std::nothrow) TestLayer2();
     s->addChild(layer);
 
     auto scene = createTransition(s_nSceneIdx, TRANSITION_DURATION, s);
@@ -339,9 +339,9 @@ void TestLayer1::backCallback(Ref* sender)
     if( s_nSceneIdx < 0 )
         s_nSceneIdx += total;    
 
-    auto s = new TransitionsTestScene();
+    auto s = new (std::nothrow) TransitionsTestScene();
 
-    auto layer = new TestLayer2();
+    auto layer = new (std::nothrow) TestLayer2();
     s->addChild(layer);
 
     auto scene = createTransition(s_nSceneIdx, TRANSITION_DURATION, s);
@@ -429,9 +429,9 @@ TestLayer2::~TestLayer2()
 
 void TestLayer2::restartCallback(Ref* sender)
 {
-    auto s = new TransitionsTestScene();
+    auto s = new (std::nothrow) TransitionsTestScene();
 
-    auto layer = new TestLayer1();
+    auto layer = new (std::nothrow) TestLayer1();
     s->addChild(layer);
 
     auto scene = createTransition(s_nSceneIdx, TRANSITION_DURATION, s);
@@ -448,9 +448,9 @@ void TestLayer2::nextCallback(Ref* sender)
     s_nSceneIdx++;
     s_nSceneIdx = s_nSceneIdx % MAX_LAYER;
 
-    auto s = new TransitionsTestScene();
+    auto s = new (std::nothrow) TransitionsTestScene();
 
-    auto layer = new TestLayer1();
+    auto layer = new (std::nothrow) TestLayer1();
     s->addChild(layer);
 
     auto scene = createTransition(s_nSceneIdx, TRANSITION_DURATION, s);
@@ -469,9 +469,9 @@ void TestLayer2::backCallback(Ref* sender)
     if( s_nSceneIdx < 0 )
         s_nSceneIdx += total;    
 
-    auto s = new TransitionsTestScene();
+    auto s = new (std::nothrow) TransitionsTestScene();
 
-    auto layer = new TestLayer1();
+    auto layer = new (std::nothrow) TestLayer1();
     s->addChild(layer);
 
     auto scene = createTransition(s_nSceneIdx, TRANSITION_DURATION, s);

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/CocoStudioGUITest.cpp
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/CocoStudioGUITest.cpp
@@ -26,7 +26,7 @@ g_guisTests[] =
         "GUI Dynamic Create Test",
         [](Ref* sender)
         {
-            CocosGUITestScene *scene = new CocosGUITestScene();
+            CocosGUITestScene *scene = new (std::nothrow) CocosGUITestScene();
 			scene->runThisTest();
 			scene->release();
         }
@@ -35,7 +35,7 @@ g_guisTests[] =
         "GUI Editor Test",
         [](Ref* sender)
         {
-            GUIEditorTestScene* scene = new GUIEditorTestScene();
+            GUIEditorTestScene* scene = new (std::nothrow) GUIEditorTestScene();
             scene->runThisTest();
             scene->release();
         }
@@ -44,7 +44,7 @@ g_guisTests[] =
         "Custom GUI Test",
         [](Ref* sender)
         {
-            CustomGUITestScene* scene = new CustomGUITestScene();
+            CustomGUITestScene* scene = new (std::nothrow) CustomGUITestScene();
             scene->runThisTest();
             scene->release();
         }
@@ -53,7 +53,7 @@ g_guisTests[] =
         "Cocostudio Parser Test",
         [](Ref* sender)
         {
-            CocostudioParserTestScene* scene = new CocostudioParserTestScene();
+            CocostudioParserTestScene* scene = new (std::nothrow) CocostudioParserTestScene();
             scene->runThisTest();
             scene->release();
         }
@@ -129,7 +129,7 @@ void CocoStudioGUITestScene::onEnter()
 
 void CocoStudioGUITestScene::runThisTest()
 {
-    Layer* pLayer = new CocoStudioGUIMainLayer();
+    Layer* pLayer = new (std::nothrow) CocoStudioGUIMainLayer();
     addChild(pLayer);
     pLayer->release();
     
@@ -140,7 +140,7 @@ void CocoStudioGUITestScene::BackCallback(Ref* pSender)
 {
     auto scene = Scene::create();
     
-    auto layer = new TestController();
+    auto layer = new (std::nothrow) TestController();
     scene->addChild(layer);
     layer->release();
     

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/CocosGUIScene.cpp
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/CocosGUIScene.cpp
@@ -332,7 +332,7 @@ void CocosGUITestScene::onEnter()
 
 void CocosGUITestScene::runThisTest()
 {
-    auto layer = new CocosGUITestMainLayer();
+    auto layer = new (std::nothrow) CocosGUITestMainLayer();
     addChild(layer);
     layer->release();
     
@@ -341,7 +341,7 @@ void CocosGUITestScene::runThisTest()
 
 void CocosGUITestScene::BackCallback(Ref* pSender)
 {
-    CocoStudioGUITestScene* pScene = new CocoStudioGUITestScene();
+    CocoStudioGUITestScene* pScene = new (std::nothrow) CocoStudioGUITestScene();
     pScene->runThisTest();
     pScene->release();
 }

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/CocostudioParserTest.cpp
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/CocostudioParserTest.cpp
@@ -44,7 +44,7 @@ g_guisTests[] =
         "cocostudio 1.3",
         [](Ref* sender)
         {
-            CocostudioParserJsonScene* pScene = new CocostudioParserJsonScene("cocosui/UIEditorTest/cocostudio1_3/CocostudioV1_3_1.ExportJson");
+            CocostudioParserJsonScene* pScene = new (std::nothrow) CocostudioParserJsonScene("cocosui/UIEditorTest/cocostudio1_3/CocostudioV1_3_1.ExportJson");
             pScene->runThisTest();
             pScene->release();
         }
@@ -53,7 +53,7 @@ g_guisTests[] =
         "cocostudio 1.4",
         [](Ref* sender)
         {
-            CocostudioParserJsonScene* pScene = new CocostudioParserJsonScene("cocosui/UIEditorTest/cocostudio1_4/Cocostudio1_4_1.ExportJson");
+            CocostudioParserJsonScene* pScene = new (std::nothrow) CocostudioParserJsonScene("cocosui/UIEditorTest/cocostudio1_4/Cocostudio1_4_1.ExportJson");
             pScene->runThisTest();
             pScene->release();
         }
@@ -62,7 +62,7 @@ g_guisTests[] =
         "cocostudio 1.5",
         [](Ref* sender)
         {
-            CocostudioParserJsonScene* pScene = new CocostudioParserJsonScene("cocosui/UIEditorTest/cocostudio1_5/Cocostudio1_5_1.ExportJson");
+            CocostudioParserJsonScene* pScene = new (std::nothrow) CocostudioParserJsonScene("cocosui/UIEditorTest/cocostudio1_5/Cocostudio1_5_1.ExportJson");
             pScene->runThisTest();
             pScene->release();
         }
@@ -140,7 +140,7 @@ void CocostudioParserTestScene::onEnter()
 
 void CocostudioParserTestScene::runThisTest()
 {
-    Layer* pLayer = new CocostudioParserTestMainLayer();
+    Layer* pLayer = new (std::nothrow) CocostudioParserTestMainLayer();
     addChild(pLayer);
     pLayer->release();
     
@@ -149,7 +149,7 @@ void CocostudioParserTestScene::runThisTest()
 
 void CocostudioParserTestScene::BackCallback(Ref* pSender)
 {
-    CocoStudioGUITestScene* pScene = new CocoStudioGUITestScene();
+    CocoStudioGUITestScene* pScene = new (std::nothrow) CocoStudioGUITestScene();
     pScene->runThisTest();
     pScene->release();
 }

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/CocostudioParserTest/CocostudioParserJsonTest.cpp
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/CocostudioParserTest/CocostudioParserJsonTest.cpp
@@ -86,7 +86,7 @@ void CocostudioParserJsonScene::onEnter()
 
 void CocostudioParserJsonScene::runThisTest()
 {
-    Layer* pLayer = new CocostudioParserJsonLayer(_jsonFile);
+    Layer* pLayer = new (std::nothrow) CocostudioParserJsonLayer(_jsonFile);
     addChild(pLayer);
     pLayer->release();
     
@@ -95,7 +95,7 @@ void CocostudioParserJsonScene::runThisTest()
 
 void CocostudioParserJsonScene::BackCallback(Ref* pSender)
 {
-    CocostudioParserTestScene* pScene = new CocostudioParserTestScene();
+    CocostudioParserTestScene* pScene = new (std::nothrow) CocostudioParserTestScene();
     pScene->runThisTest();
     pScene->release();
 }

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/CustomGUIScene.cpp
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/CustomGUIScene.cpp
@@ -23,7 +23,7 @@ g_guisTests[] =
         "custom gui image Test",
         [](Ref* sender)
         {
-            CustomImageScene* pScene = new CustomImageScene();
+            CustomImageScene* pScene = new (std::nothrow) CustomImageScene();
             pScene->runThisTest();
             pScene->release();
         }
@@ -32,7 +32,7 @@ g_guisTests[] =
         "custom gui particle widget Test",
         [](Ref* sender)
         {
-            CustomParticleWidgetScene* pScene = new CustomParticleWidgetScene();
+            CustomParticleWidgetScene* pScene = new (std::nothrow) CustomParticleWidgetScene();
             pScene->runThisTest();
             pScene->release();
         }
@@ -132,7 +132,7 @@ void CustomGUITestScene::onEnter()
 
 void CustomGUITestScene::runThisTest()
 {
-    Layer* pLayer = new CustomGUITestMainLayer();
+    Layer* pLayer = new (std::nothrow) CustomGUITestMainLayer();
     addChild(pLayer);
     pLayer->release();
     
@@ -141,7 +141,7 @@ void CustomGUITestScene::runThisTest()
 
 void CustomGUITestScene::BackCallback(Ref* pSender)
 {
-    CocoStudioGUITestScene* pScene = new CocoStudioGUITestScene();
+    CocoStudioGUITestScene* pScene = new (std::nothrow) CocoStudioGUITestScene();
     pScene->runThisTest();
     pScene->release();
 }

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/CustomTest/CustomImageTest/CustomImageTest.cpp
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/CustomTest/CustomImageTest/CustomImageTest.cpp
@@ -50,7 +50,7 @@ void CustomImageScene::onEnter()
 
 void CustomImageScene::runThisTest()
 {
-    Layer* pLayer = new CustomImageLayer();
+    Layer* pLayer = new (std::nothrow) CustomImageLayer();
     addChild(pLayer);
     pLayer->release();
     
@@ -59,7 +59,7 @@ void CustomImageScene::runThisTest()
 
 void CustomImageScene::BackCallback(Ref* pSender)
 {
-    CustomGUITestScene* pScene = new CustomGUITestScene();
+    CustomGUITestScene* pScene = new (std::nothrow) CustomGUITestScene();
     pScene->runThisTest();
     pScene->release();
 }

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/CustomTest/CustomParticleWidgetTest/CustomParticleWidgetTest.cpp
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/CustomTest/CustomParticleWidgetTest/CustomParticleWidgetTest.cpp
@@ -46,7 +46,7 @@ void CustomParticleWidgetScene::onEnter()
 {
     CCScene::onEnter();
     
-    Layer* pLayer = new CustomParticleWidgetLayer();
+    Layer* pLayer = new (std::nothrow) CustomParticleWidgetLayer();
     addChild(pLayer);
     pLayer->release();
     
@@ -64,7 +64,7 @@ void CustomParticleWidgetScene::onEnter()
 
 void CustomParticleWidgetScene::runThisTest()
 {
-    Layer* pLayer = new CustomParticleWidgetLayer();
+    Layer* pLayer = new (std::nothrow) CustomParticleWidgetLayer();
     addChild(pLayer);
     pLayer->release();
     
@@ -73,7 +73,7 @@ void CustomParticleWidgetScene::runThisTest()
 
 void CustomParticleWidgetScene::BackCallback(Ref* pSender)
 {
-    CustomGUITestScene* pScene = new CustomGUITestScene();
+    CustomGUITestScene* pScene = new (std::nothrow) CustomGUITestScene();
     pScene->runThisTest();
     pScene->release();
 }

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/CustomWidget/CustomImageView.cpp
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/CustomWidget/CustomImageView.cpp
@@ -24,7 +24,7 @@ Ref* CustomImageView::createInstance()
 
 CustomImageView* CustomImageView::create()
 {
-    CustomImageView* custom = new CustomImageView();
+    CustomImageView* custom = new (std::nothrow) CustomImageView();
     
     if (custom && custom->init())
     {

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/CustomWidget/CustomImageViewReader.cpp
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/CustomWidget/CustomImageViewReader.cpp
@@ -24,7 +24,7 @@ CustomImageViewReader* CustomImageViewReader::getInstance()
 {
     if (!_instanceCustomImageViewReader)
     {
-        _instanceCustomImageViewReader = new CustomImageViewReader();
+        _instanceCustomImageViewReader = new (std::nothrow) CustomImageViewReader();
     }
     return _instanceCustomImageViewReader;
 }

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/CustomWidget/CustomParticleWidget.cpp
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/CustomWidget/CustomParticleWidget.cpp
@@ -32,7 +32,7 @@ Ref* CustomParticleWidget::createInstance()
 
 CustomParticleWidget* CustomParticleWidget::create()
 {
-    CustomParticleWidget* custom = new CustomParticleWidget();
+    CustomParticleWidget* custom = new (std::nothrow) CustomParticleWidget();
     
     if (custom && custom->init())
     {

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/CustomWidget/CustomParticleWidgetReader.cpp
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/CustomWidget/CustomParticleWidgetReader.cpp
@@ -31,7 +31,7 @@ CustomParticleWidgetReader* CustomParticleWidgetReader::getInstance()
 {
     if (!_instanceCustomParticleWidgetReader)
     {
-        _instanceCustomParticleWidgetReader = new CustomParticleWidgetReader();
+        _instanceCustomParticleWidgetReader = new (std::nothrow) CustomParticleWidgetReader();
     }
     return _instanceCustomParticleWidgetReader;
 }

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/CustomWidget/CustomReader.cpp
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/CustomWidget/CustomReader.cpp
@@ -19,7 +19,7 @@ CustomReader* CustomReader::getInstance()
 {
     if (!_instanceCustomReader)
     {
-        _instanceCustomReader = new CustomReader();
+        _instanceCustomReader = new (std::nothrow) CustomReader();
     }
     return _instanceCustomReader;
 }

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/GUIEditorTest.cpp
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/GUIEditorTest.cpp
@@ -347,7 +347,7 @@ void GUIEditorTestScene::onEnter()
 
 void GUIEditorTestScene::runThisTest()
 {
-    auto layer = new GUIEditorMainLayer();
+    auto layer = new (std::nothrow) GUIEditorMainLayer();
     addChild(layer);
     layer->release();
     
@@ -356,7 +356,7 @@ void GUIEditorTestScene::runThisTest()
 
 void GUIEditorTestScene::BackCallback(Ref* pSender)
 {
-    CocoStudioGUITestScene* pScene = new CocoStudioGUITestScene();
+    CocoStudioGUITestScene* pScene = new (std::nothrow) CocoStudioGUITestScene();
     pScene->runThisTest();
     pScene->release();
 }

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIScene.cpp
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIScene.cpp
@@ -82,7 +82,7 @@ void UIScene::toCocosGUITestScene(Ref* sender, Widget::TouchEventType type)
     {
         UISceneManager::purgeUISceneManager();
         
-        CocosGUITestScene* pScene = new CocosGUITestScene();
+        CocosGUITestScene* pScene = new (std::nothrow) CocosGUITestScene();
         pScene->runThisTest();
         pScene->release();
     }

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIScene.h
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIScene.h
@@ -38,7 +38,7 @@ public: \
 static Scene* sceneWithTitle(const char * title) \
 { \
     Scene* pScene = Scene::create(); \
-    UIScene* uiLayer = new UIScene(); \
+    UIScene* uiLayer = new (std::nothrow) UIScene(); \
     if (uiLayer && uiLayer->init()) \
     { \
         uiLayer->autorelease(); \

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UISceneManager.cpp
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UISceneManager.cpp
@@ -134,7 +134,7 @@ UISceneManager * UISceneManager::sharedUISceneManager()
 {
     if (sharedInstance == nullptr)
     {
-        sharedInstance = new UISceneManager();
+        sharedInstance = new (std::nothrow) UISceneManager();
     }
     return sharedInstance;
 }

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UISceneManager_Editor.cpp
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UISceneManager_Editor.cpp
@@ -64,7 +64,7 @@ UISceneManager_Editor* UISceneManager_Editor::sharedUISceneManager_Editor()
 {
     if (sharedInstance == nullptr)
     {
-        sharedInstance = new UISceneManager_Editor();
+        sharedInstance = new (std::nothrow) UISceneManager_Editor();
     }
     return sharedInstance;
 }

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIScene_Editor.cpp
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIScene_Editor.cpp
@@ -91,7 +91,7 @@ void UIScene_Editor::toGUIEditorTestScene(Ref* sender, Widget::TouchEventType ev
         {
             UISceneManager_Editor::sharedUISceneManager_Editor()->purge();
             
-            GUIEditorTestScene* pScene = new GUIEditorTestScene();
+            GUIEditorTestScene* pScene = new (std::nothrow) GUIEditorTestScene();
             pScene->runThisTest();
             pScene->release();
         }

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIScene_Editor.h
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIScene_Editor.h
@@ -39,7 +39,7 @@ public: \
 static Scene* sceneWithTitle(const char * title) \
 { \
     Scene* pScene = Scene::create(); \
-    UIScene_Editor* uiLayer = new UIScene_Editor(); \
+    UIScene_Editor* uiLayer = new (std::nothrow) UIScene_Editor(); \
     if (uiLayer && uiLayer->init()) \
     { \
         uiLayer->autorelease(); \

--- a/tests/cpp-tests/Classes/UITest/UITest.cpp
+++ b/tests/cpp-tests/Classes/UITest/UITest.cpp
@@ -3,6 +3,6 @@
 
 void UITestScene::runThisTest()
 {
-    CocoStudioGUITestScene* pScene = new CocoStudioGUITestScene();
+    CocoStudioGUITestScene* pScene = new (std::nothrow) CocoStudioGUITestScene();
     pScene->runThisTest();
 }

--- a/tests/cpp-tests/Classes/UnitTest/UnitTest.cpp
+++ b/tests/cpp-tests/Classes/UnitTest/UnitTest.cpp
@@ -69,7 +69,7 @@ std::string UnitTestDemo::subtitle() const
 
 void UnitTestDemo::restartCallback(Ref* sender)
 {
-    auto s = new UnitTestScene();
+    auto s = new (std::nothrow) UnitTestScene();
     s->addChild( restartAction() );
     Director::getInstance()->replaceScene(s);
     s->release();
@@ -77,7 +77,7 @@ void UnitTestDemo::restartCallback(Ref* sender)
 
 void UnitTestDemo::nextCallback(Ref* sender)
 {
-    auto s = new UnitTestScene();
+    auto s = new (std::nothrow) UnitTestScene();
     s->addChild( nextAction() );
     Director::getInstance()->replaceScene(s);
     s->release();
@@ -85,7 +85,7 @@ void UnitTestDemo::nextCallback(Ref* sender)
 
 void UnitTestDemo::backCallback(Ref* sender)
 {
-    auto s = new UnitTestScene();
+    auto s = new (std::nothrow) UnitTestScene();
     s->addChild( backAction() );
     Director::getInstance()->replaceScene(s);
     s->release();

--- a/tests/cpp-tests/Classes/UserDefaultTest/UserDefaultTest.cpp
+++ b/tests/cpp-tests/Classes/UserDefaultTest/UserDefaultTest.cpp
@@ -97,7 +97,7 @@ UserDefaultTest::~UserDefaultTest()
 
 void UserDefaultTestScene::runThisTest()
 {
-    auto layer = new UserDefaultTest();
+    auto layer = new (std::nothrow) UserDefaultTest();
     addChild(layer);
 
     Director::getInstance()->replaceScene(this);

--- a/tests/cpp-tests/Classes/controller.cpp
+++ b/tests/cpp-tests/Classes/controller.cpp
@@ -362,7 +362,7 @@ void TestController::addConsoleAutoTest()
                 sched->performFunctionInCocosThread( [&]()
                 {
                     auto scene = Scene::create();
-                    auto layer = new TestController();
+                    auto layer = new (std::nothrow) TestController();
                     scene->addChild(layer);
                     layer->release();
                     Director::getInstance()->replaceScene(scene);

--- a/tests/cpp-tests/Classes/testBasic.cpp
+++ b/tests/cpp-tests/Classes/testBasic.cpp
@@ -23,7 +23,7 @@ void testScene_callback(Ref *sender )
 {
     auto scene = Scene::create();
 
-    auto layer = new TestController();
+    auto layer = new (std::nothrow) TestController();
     scene->addChild(layer);
     layer->release();
 

--- a/tests/lua-game-controller-test/project/proj.android/jni/main.cpp
+++ b/tests/lua-game-controller-test/project/proj.android/jni/main.cpp
@@ -11,5 +11,5 @@ using namespace cocos2d;
 
 void cocos_android_app_init (JNIEnv* env, jobject thiz) {
     LOGD("cocos_android_app_init");
-    AppDelegate *pAppDelegate = new AppDelegate();
+    AppDelegate *pAppDelegate = new (std::nothrow) AppDelegate();
 }


### PR DESCRIPTION
Since cocos2d-x doesn't support exceptions, it is important to add
`std::nothrow` to all the `new` statements
