### PR TITLE
Users new `// MARK: ` feature to mark sections

### DIFF
--- a/cocos/2d/CCNode.cpp
+++ b/cocos/2d/CCNode.cpp
@@ -71,6 +71,8 @@ bool nodeComparisonLess(Node* n1, Node* n2)
 // XXX: Yes, nodes might have a sort problem once every 15 days if the game runs at 60 FPS and each frame sprites are reordered.
 int Node::s_globalOrderOfArrival = 1;
 
+// MARK: Constructor, Destructor, Init
+
 Node::Node(void)
 : _rotationX(0.0f)
 , _rotationY(0.0f)
@@ -143,6 +145,20 @@ Node::Node(void)
     _transform = _inverse = _additionalTransform = Mat4::IDENTITY;
 }
 
+Node * Node::create()
+{
+    Node * ret = new (std::nothrow) Node();
+    if (ret && ret->init())
+    {
+        ret->autorelease();
+    }
+    else
+    {
+        CC_SAFE_DELETE(ret);
+    }
+    return ret;
+}
+
 Node::~Node()
 {
     CCLOGINFO( "deallocing Node: %p - tag: %i", this, _tag );
@@ -192,6 +208,34 @@ bool Node::init()
 {
     return true;
 }
+
+void Node::cleanup()
+{
+    // actions
+    this->stopAllActions();
+    this->unscheduleAllSelectors();
+
+#if CC_ENABLE_SCRIPT_BINDING
+    if ( _scriptType != kScriptTypeNone)
+    {
+        int action = kNodeOnCleanup;
+        BasicScriptData data(this,(void*)&action);
+        ScriptEvent scriptEvent(kNodeEvent,(void*)&data);
+        ScriptEngineManager::getInstance()->getScriptEngine()->sendEvent(&scriptEvent);
+    }
+#endif // #if CC_ENABLE_SCRIPT_BINDING
+
+    // timers
+    for( const auto &child: _children)
+        child->cleanup();
+}
+
+std::string Node::getDescription() const
+{
+    return StringUtils::format("<Node | Tag = %d", _tag);
+}
+
+// MARK: getters / setters
 
 float Node::getSkewX() const
 {
@@ -757,46 +801,7 @@ Rect Node::getBoundingBox() const
     return RectApplyAffineTransform(rect, getNodeToParentAffineTransform());
 }
 
-Node * Node::create()
-{
-	Node * ret = new (std::nothrow) Node();
-    if (ret && ret->init())
-    {
-        ret->autorelease();
-    }
-    else
-    {
-        CC_SAFE_DELETE(ret);
-    }
-	return ret;
-}
-
-void Node::cleanup()
-{
-    // actions
-    this->stopAllActions();
-    this->unscheduleAllSelectors();
-    
-#if CC_ENABLE_SCRIPT_BINDING
-    if ( _scriptType != kScriptTypeNone)
-    {
-        int action = kNodeOnCleanup;
-        BasicScriptData data(this,(void*)&action);
-        ScriptEvent scriptEvent(kNodeEvent,(void*)&data);
-        ScriptEngineManager::getInstance()->getScriptEngine()->sendEvent(&scriptEvent);
-    }
-#endif // #if CC_ENABLE_SCRIPT_BINDING
-    
-    // timers
-    for( const auto &child: _children)
-        child->cleanup();
-}
-
-
-std::string Node::getDescription() const
-{
-    return StringUtils::format("<Node | Tag = %d", _tag);
-}
+// MARK: Children logic
 
 // lazy allocs
 void Node::childrenAlloc()
@@ -1183,6 +1188,8 @@ void Node::sortAllChildren()
     }
 }
 
+// MARK: draw / visit
+
 void Node::draw()
 {
     auto renderer = Director::getInstance()->getRenderer();
@@ -1290,6 +1297,8 @@ Mat4 Node::transform(const Mat4& parentTransform)
     ret  = parentTransform * ret;
     return ret;
 }
+
+// MARK: events
 
 void Node::onEnter()
 {
@@ -1419,6 +1428,8 @@ void Node::setActionManager(ActionManager* actionManager)
     }
 }
 
+// MARK: actions
+
 Action * Node::runAction(Action* action)
 {
     CCASSERT( action != nullptr, "Argument must be non-nil");
@@ -1459,7 +1470,7 @@ ssize_t Node::getNumberOfRunningActions() const
     return _actionManager->getNumberOfRunningActionsInTarget(this);
 }
 
-// Node - Callbacks
+// MARK: Callbacks
 
 void Node::setScheduler(Scheduler* scheduler)
 {
@@ -1589,6 +1600,8 @@ void Node::update(float fDelta)
         _componentContainer->visit(fDelta);
     }
 }
+
+// MARK: coordinates
 
 AffineTransform Node::getNodeToParentAffineTransform() const
 {
@@ -1844,6 +1857,8 @@ void Node::updateTransform()
         child->updateTransform();
 }
 
+// MARK: components
+
 Component* Node::getComponent(const std::string& name)
 {
     if( _componentContainer )
@@ -1881,6 +1896,9 @@ void Node::removeAllComponents()
 }
 
 #if CC_USE_PHYSICS
+
+// MARK: Physics
+
 void Node::updatePhysicsBodyTransform(Scene* scene)
 {
     updatePhysicsBodyScale(scene);
@@ -2034,6 +2052,8 @@ PhysicsBody* Node::getPhysicsBody() const
 }
 #endif //CC_USE_PHYSICS
 
+// MARK: Opacity and Color
+
 GLubyte Node::getOpacity(void) const
 {
 	return _realOpacity;
@@ -2183,6 +2203,7 @@ void Node::disableCascadeColor()
     }
 }
 
+// MARK: Camera
 void Node::setCameraMask(unsigned short mask, bool applyChildren)
 {
     _cameraMask = mask;
@@ -2193,6 +2214,8 @@ void Node::setCameraMask(unsigned short mask, bool applyChildren)
         }
     }
 }
+
+// MARK: Deprecated
 
 __NodeRGBA::__NodeRGBA()
 {


### PR DESCRIPTION
Instead of using `#praga mark` which was not compatible with other
compilers, it uses the `// MARK:` which is compatible with all compilers
