### PR TITLE
fix transition scene stencil buffer

### DIFF
--- a/cocos/2d/CCTransition.cpp
+++ b/cocos/2d/CCTransition.cpp
@@ -1278,7 +1278,7 @@ void TransitionCrossFade::onEnter()
     LayerColor* layer = LayerColor::create(color);
 
     // create the first render texture for inScene
-    RenderTexture* inTexture = RenderTexture::create((int)size.width, (int)size.height);
+    RenderTexture* inTexture = RenderTexture::create((int)size.width, (int)size.height,Texture2D::PixelFormat::RGBA8888,GL_DEPTH24_STENCIL8);
 
     if (nullptr == inTexture)
     {
@@ -1295,7 +1295,7 @@ void TransitionCrossFade::onEnter()
     inTexture->end();
 
     // create the second render texture for outScene
-    RenderTexture* outTexture = RenderTexture::create((int)size.width, (int)size.height);
+    RenderTexture* outTexture = RenderTexture::create((int)size.width, (int)size.height,Texture2D::PixelFormat::RGBA8888,GL_DEPTH24_STENCIL8);
     outTexture->getSprite()->setAnchorPoint( Vec2(0.5f,0.5f) );
     outTexture->setPosition(size.width/2, size.height/2);
     outTexture->setAnchorPoint( Vec2(0.5f,0.5f) );

--- a/cocos/2d/CCTransitionProgress.cpp
+++ b/cocos/2d/CCTransitionProgress.cpp
@@ -71,7 +71,7 @@ void TransitionProgress::onEnter()
     Size size = Director::getInstance()->getWinSize();
 
     // create the second render texture for outScene
-    RenderTexture *texture = RenderTexture::create((int)size.width, (int)size.height);
+    RenderTexture *texture = RenderTexture::create((int)size.width, (int)size.height,Texture2D::PixelFormat::RGBA8888,GL_DEPTH24_STENCIL8);
     texture->getSprite()->setAnchorPoint(Vec2(0.5f,0.5f));
     texture->setPosition(size.width/2, size.height/2);
     texture->setAnchorPoint(Vec2(0.5f,0.5f));


### PR DESCRIPTION
When a scene transition contains ScrollView or ListView, the effect will be wrong. We should enable the stencil buffer when scene transition happens.
