### PR TITLE
Move constructor from private to public

### DIFF
--- a/cocos/platform/android/CCFileUtilsAndroid.h
+++ b/cocos/platform/android/CCFileUtilsAndroid.h
@@ -47,8 +47,8 @@ NS_CC_BEGIN
 class CC_DLL FileUtilsAndroid : public FileUtils
 {
     friend class FileUtils;
-    FileUtilsAndroid();
 public:
+    FileUtilsAndroid();
     /**
      * @js NA
      * @lua NA


### PR DESCRIPTION
In my project I want to add extra functionality to FileUtils. For security reasons I make FileUtils function that can extract encoded data directly to memory without storing it on disk. So I am trying to use FileUtilsAndroid as base class, but it is impossible as constructor is hidden as private member. I offer to move constructor to either public or protected to make it possible to use FileUtilsAndroid as base class.

Another way to solve the problem is to remove constructor as FileUtilsApple does not have a constructor.
