### PR TITLE
deprecated ui::TextField getStringValue and setText, use getString and

### DIFF
--- a/cocos/scripting/lua-bindings/script/ui/DeprecatedUIFunc.lua
+++ b/cocos/scripting/lua-bindings/script/ui/DeprecatedUIFunc.lua
@@ -137,6 +137,18 @@ function UITextFieldDeprecated.addEventListenerTextField(self,handler)
     return self:addEventListener(handler)
 end
 rawset(ccui.TextField,"addEventListenerTextField", UITextFieldDeprecated.addEventListenerTextField)
+
+function UITextFieldDeprecated.setText(self, str)
+    deprecatedTip("ccui.TextField:setText","ccui.TextField:setString")
+    return self:setString(str)
+end
+rawset(ccui.TextField,"setText", UITextFieldDeprecated.setText)
+
+function UITextFieldDeprecated.getStringValue(self)
+    deprecatedTip("ccui.TextField:getStringValue","ccui.TextField:getString")
+    return self:getString()
+end
+rawset(ccui.TextField,"getStringValue", UITextFieldDeprecated.getStringValue)
 --functions of ccui.TextField will be deprecated end
 
 --functions of ccui.PageView will be deprecated begin

--- a/cocos/ui/UITextField.cpp
+++ b/cocos/ui/UITextField.cpp
@@ -404,7 +404,7 @@ Size TextField::getTouchSize()const
     return Size(_touchWidth, _touchHeight);
 }
 
-void TextField::setText(const std::string& text)
+void TextField::setString(const std::string& text)
 {
     std::string strText(text);
     
@@ -412,7 +412,7 @@ void TextField::setText(const std::string& text)
     {
         int max = _textFieldRenderer->getMaxLength();
         long text_count = StringUtils::getCharacterCountInUTF8String(text);
-        long total = text_count + StringUtils::getCharacterCountInUTF8String(getStringValue());
+        long total = text_count + StringUtils::getCharacterCountInUTF8String(getString());
         if (total > max)
         {
             strText = Helper::getSubStringOfUTF8String(strText, 0, max);
@@ -513,7 +513,7 @@ void TextField::didNotSelectSelf()
     _textFieldRenderer->detachWithIME();
 }
 
-const std::string& TextField::getStringValue()const
+const std::string& TextField::getString()const
 {
     return _textFieldRenderer->getString();
 }
@@ -549,7 +549,7 @@ void TextField::setMaxLength(int length)
 {
     _textFieldRenderer->setMaxLength(length);
     
-    setText(getStringValue());
+    setString(getString());
 }
 
 int TextField::getMaxLength()const
@@ -572,7 +572,7 @@ void TextField::setPasswordStyleText(const char *styleText)
     _textFieldRenderer->setPasswordStyleText(styleText);
     _passwordStyleText = styleText;
     
-    setText(getStringValue());
+    setString(getString());
 }
     
 const char* TextField::getPasswordStyleText()const
@@ -767,8 +767,8 @@ void TextField::copySpecialProperties(Widget *widget)
     TextField* textField = dynamic_cast<TextField*>(widget);
     if (textField)
     {
-        setText(textField->_textFieldRenderer->getString());
-        setPlaceHolder(textField->getStringValue());
+        setString(textField->_textFieldRenderer->getString());
+        setPlaceHolder(textField->getString());
         setFontSize(textField->_fontSize);
         setFontName(textField->_fontName);
         setMaxLengthEnabled(textField->isMaxLengthEnabled());

--- a/cocos/ui/UITextField.h
+++ b/cocos/ui/UITextField.h
@@ -147,8 +147,11 @@ public:
     
     virtual void didNotSelectSelf();
     
-    void setText(const std::string& text);
-    const std::string& getStringValue()const;
+    CC_DEPRECATED_ATTRIBUTE void setText(const std::string& text){this->setString(text);}
+    CC_DEPRECATED_ATTRIBUTE const std::string& getStringValue()const{return this->getString();}
+    
+    void setString(const std::string& text);
+    const std::string& getString()const;
     
     virtual bool onTouchBegan(Touch *touch, Event *unusedEvent) override;
     


### PR DESCRIPTION
deprecated ui::TextField setText & getStrinValue
use getString & setString instead

it also marks deprecated in Lua binding.
