### PR TITLE
SceneReader sets contentSize by canvasSize.

### DIFF
--- a/cocos/editor-support/cocostudio/CCSSceneReader.cpp
+++ b/cocos/editor-support/cocostudio/CCSSceneReader.cpp
@@ -341,6 +341,14 @@ Node* SceneReader::createObject(const rapidjson::Value &dict, cocos2d::Node* par
             createObject(subDict, gb, attachComponent);
         }
         
+        const rapidjson::Value &canvasSizeDict = DICTOOL->getSubDictionary_json(dict, "CanvasSize");
+        if (DICTOOL->checkObjectExist_json(canvasSizeDict))
+        {
+            int width = DICTOOL->getIntValue_json(canvasSizeDict, "_width");
+            int height = DICTOOL->getIntValue_json(canvasSizeDict, "_height");
+            gb->setContentSize(Size(width, height));
+        }
+        
         return gb;
     }
     


### PR DESCRIPTION
We could not get the canvas size of the scene which created on CocosStudio.

Thanks to this commit, we can get scene's canvas size by Node::getContentSize()

``` cpp
auto scene = cocos2d::cocostudio::SceneReader::getInstance()->createNodeWithSceneFile("Scene.json");
int width = scene->getContentSize().width;
int height = scene->getContentSize().height;
cocos2d::log("canvasSize = %d, %d", width, height);
```
