### PR TITLE
Fix text-only button can't be touched issue

### DIFF
--- a/cocos/ui/UIButton.cpp
+++ b/cocos/ui/UIButton.cpp
@@ -37,6 +37,7 @@ static const int NORMAL_RENDERER_Z = (-2);
 static const int PRESSED_RENDERER_Z = (-2);
 static const int DISABLED_RENDERER_Z = (-2);
 static const int TITLE_RENDERER_Z = (-1);
+static const float ZOOM_ACTION_TIME_STEP = 0.05;
     
 IMPLEMENT_CLASS_GUI_INFO(Button)
     
@@ -361,17 +362,15 @@ void Button::onPressStateChangedToNormal()
     {
         if (_pressedActionEnabled)
         {
-            _buttonNormalRenderer->stopAllActions();
-            _buttonClickedRenderer->stopAllActions();
-            Action *zoomAction = ScaleTo::create(0.05f, _normalTextureScaleXInSize, _normalTextureScaleYInSize);
-            _buttonNormalRenderer->runAction(zoomAction);
-            _buttonClickedRenderer->setScale(_pressedTextureScaleXInSize, _pressedTextureScaleYInSize);
+            this->stopAllActions();
+            Action *zoomAction = ScaleTo::create(ZOOM_ACTION_TIME_STEP, 1.0, 1.0);
+            this->runAction(zoomAction);
         }
     }
     else
     {
-        _buttonNormalRenderer->stopAllActions();
-        _buttonNormalRenderer->setScale(_normalTextureScaleXInSize, _normalTextureScaleYInSize);
+        this->stopAllActions();
+        this->setScale(1.0, 1.0);
     }
 }
 
@@ -385,11 +384,9 @@ void Button::onPressStateChangedToPressed()
         
         if (_pressedActionEnabled)
         {
-            _buttonNormalRenderer->stopAllActions();
-            _buttonClickedRenderer->stopAllActions();
-            Action *zoomAction = ScaleTo::create(0.05f, _pressedTextureScaleXInSize + _zoomScale, _pressedTextureScaleYInSize + _zoomScale);
-            _buttonClickedRenderer->runAction(zoomAction);
-            _buttonNormalRenderer->setScale(_pressedTextureScaleXInSize + _zoomScale, _pressedTextureScaleYInSize + _zoomScale);
+            this->stopAllActions();
+            Action *zoomAction = ScaleTo::create(ZOOM_ACTION_TIME_STEP, 1.0 + _zoomScale, 1.0 + _zoomScale);
+            this->runAction(zoomAction);
         }
     }
     else
@@ -403,8 +400,8 @@ void Button::onPressStateChangedToPressed()
         }
         else
         {
-            _buttonNormalRenderer->stopAllActions();
-            _buttonNormalRenderer->setScale(_normalTextureScaleXInSize +_zoomScale, _normalTextureScaleYInSize + _zoomScale);
+            this->stopAllActions();
+            this->setScale(1.0 +_zoomScale, 1.0 + _zoomScale);
         }
     }
 }
@@ -414,8 +411,6 @@ void Button::onPressStateChangedToDisabled()
     _buttonNormalRenderer->setVisible(false);
     _buttonClickedRenderer->setVisible(false);
     _buttonDisableRenderer->setVisible(true);
-    _buttonNormalRenderer->setScale(_normalTextureScaleXInSize, _normalTextureScaleYInSize);
-    _buttonClickedRenderer->setScale(_pressedTextureScaleXInSize, _pressedTextureScaleYInSize);
 }
 
 void Button::updateFlippedX()
@@ -473,7 +468,7 @@ void Button::adaptRenderers()
 const Size Button::getVirtualRendererSize() const
 {
     Size titleSize = _titleRenderer->getContentSize();
-    if (titleSize.width > _normalTextureSize.width) {
+    if (!_normalTextureLoaded && _titleRenderer->getString().size() > 0) {
         return titleSize;
     }
     return _normalTextureSize;

--- a/cocos/ui/UIButton.cpp
+++ b/cocos/ui/UIButton.cpp
@@ -470,8 +470,12 @@ void Button::adaptRenderers()
     }
 }
 
-const Size& Button::getVirtualRendererSize() const
+const Size Button::getVirtualRendererSize() const
 {
+    Size titleSize = _titleRenderer->getContentSize();
+    if (titleSize.width > _normalTextureSize.width) {
+        return titleSize;
+    }
     return _normalTextureSize;
 }
 

--- a/cocos/ui/UIButton.cpp
+++ b/cocos/ui/UIButton.cpp
@@ -465,7 +465,7 @@ void Button::adaptRenderers()
     }
 }
 
-const Size Button::getVirtualRendererSize() const
+Size Button::getVirtualRendererSize() const
 {
     Size titleSize = _titleRenderer->getContentSize();
     if (!_normalTextureLoaded && _titleRenderer->getString().size() > 0) {

--- a/cocos/ui/UIButton.h
+++ b/cocos/ui/UIButton.h
@@ -170,7 +170,7 @@ public:
     virtual void ignoreContentAdaptWithSize(bool ignore) override;
 
     //override "getVirtualRendererSize" method of widget.
-    virtual const Size getVirtualRendererSize() const override;
+    virtual Size getVirtualRendererSize() const override;
 
     //override "getVirtualRenderer" method of widget.
     virtual Node* getVirtualRenderer() override;

--- a/cocos/ui/UIButton.h
+++ b/cocos/ui/UIButton.h
@@ -170,7 +170,7 @@ public:
     virtual void ignoreContentAdaptWithSize(bool ignore) override;
 
     //override "getVirtualRendererSize" method of widget.
-    virtual const Size& getVirtualRendererSize() const override;
+    virtual const Size getVirtualRendererSize() const override;
 
     //override "getVirtualRenderer" method of widget.
     virtual Node* getVirtualRenderer() override;

--- a/cocos/ui/UICheckBox.cpp
+++ b/cocos/ui/UICheckBox.cpp
@@ -450,7 +450,7 @@ void CheckBox::adaptRenderers()
     }
 }
 
-const Size& CheckBox::getVirtualRendererSize() const
+const Size CheckBox::getVirtualRendererSize() const
 {
     return _backGroundBoxRenderer->getContentSize();
 }

--- a/cocos/ui/UICheckBox.cpp
+++ b/cocos/ui/UICheckBox.cpp
@@ -450,7 +450,7 @@ void CheckBox::adaptRenderers()
     }
 }
 
-const Size CheckBox::getVirtualRendererSize() const
+Size CheckBox::getVirtualRendererSize() const
 {
     return _backGroundBoxRenderer->getContentSize();
 }

--- a/cocos/ui/UICheckBox.h
+++ b/cocos/ui/UICheckBox.h
@@ -184,7 +184,7 @@ public:
 
 
     //override "getVirtualRendererSize" method of widget.
-    virtual const Size getVirtualRendererSize() const override;
+    virtual Size getVirtualRendererSize() const override;
 
     //override "getVirtualRenderer" method of widget.
     virtual Node* getVirtualRenderer() override;

--- a/cocos/ui/UICheckBox.h
+++ b/cocos/ui/UICheckBox.h
@@ -184,7 +184,7 @@ public:
 
 
     //override "getVirtualRendererSize" method of widget.
-    virtual const Size& getVirtualRendererSize() const override;
+    virtual const Size getVirtualRendererSize() const override;
 
     //override "getVirtualRenderer" method of widget.
     virtual Node* getVirtualRenderer() override;

--- a/cocos/ui/UIImageView.cpp
+++ b/cocos/ui/UIImageView.cpp
@@ -238,7 +238,7 @@ void ImageView::adaptRenderers()
     }
 }
 
-const Size ImageView::getVirtualRendererSize() const
+Size ImageView::getVirtualRendererSize() const
 {
     return _imageTextureSize;
 }

--- a/cocos/ui/UIImageView.cpp
+++ b/cocos/ui/UIImageView.cpp
@@ -238,7 +238,7 @@ void ImageView::adaptRenderers()
     }
 }
 
-const Size& ImageView::getVirtualRendererSize() const
+const Size ImageView::getVirtualRendererSize() const
 {
     return _imageTextureSize;
 }

--- a/cocos/ui/UIImageView.h
+++ b/cocos/ui/UIImageView.h
@@ -108,7 +108,7 @@ public:
      */
     virtual std::string getDescription() const override;
 
-    virtual const Size& getVirtualRendererSize() const override;
+    virtual const Size getVirtualRendererSize() const override;
     virtual Node* getVirtualRenderer() override;
     
 CC_CONSTRUCTOR_ACCESS:

--- a/cocos/ui/UIImageView.h
+++ b/cocos/ui/UIImageView.h
@@ -108,7 +108,7 @@ public:
      */
     virtual std::string getDescription() const override;
 
-    virtual const Size getVirtualRendererSize() const override;
+    virtual Size getVirtualRendererSize() const override;
     virtual Node* getVirtualRenderer() override;
     
 CC_CONSTRUCTOR_ACCESS:

--- a/cocos/ui/UILoadingBar.cpp
+++ b/cocos/ui/UILoadingBar.cpp
@@ -265,7 +265,7 @@ void LoadingBar::ignoreContentAdaptWithSize(bool ignore)
     }
 }
 
-const Size LoadingBar::getVirtualRendererSize() const
+Size LoadingBar::getVirtualRendererSize() const
 {
     return _barRendererTextureSize;
 }

--- a/cocos/ui/UILoadingBar.cpp
+++ b/cocos/ui/UILoadingBar.cpp
@@ -265,7 +265,7 @@ void LoadingBar::ignoreContentAdaptWithSize(bool ignore)
     }
 }
 
-const Size& LoadingBar::getVirtualRendererSize() const
+const Size LoadingBar::getVirtualRendererSize() const
 {
     return _barRendererTextureSize;
 }

--- a/cocos/ui/UILoadingBar.h
+++ b/cocos/ui/UILoadingBar.h
@@ -130,7 +130,7 @@ public:
     virtual void ignoreContentAdaptWithSize(bool ignore) override;
     
     //override "getVirtualRendererSize" method of widget.
-    virtual const Size getVirtualRendererSize() const override;
+    virtual Size getVirtualRendererSize() const override;
     
     //override "getVirtualRenderer" method of widget.
     virtual Node* getVirtualRenderer() override;

--- a/cocos/ui/UILoadingBar.h
+++ b/cocos/ui/UILoadingBar.h
@@ -130,7 +130,7 @@ public:
     virtual void ignoreContentAdaptWithSize(bool ignore) override;
     
     //override "getVirtualRendererSize" method of widget.
-    virtual const Size& getVirtualRendererSize() const override;
+    virtual const Size getVirtualRendererSize() const override;
     
     //override "getVirtualRenderer" method of widget.
     virtual Node* getVirtualRenderer() override;

--- a/cocos/ui/UIRichText.cpp
+++ b/cocos/ui/UIRichText.cpp
@@ -451,7 +451,7 @@ void RichText::setAnchorPoint(const Vec2 &pt)
     _elementRenderersContainer->setAnchorPoint(pt);
 }
     
-const Size& RichText::getVirtualRendererSize() const
+const Size RichText::getVirtualRendererSize() const
 {
     return _elementRenderersContainer->getContentSize();
 }

--- a/cocos/ui/UIRichText.cpp
+++ b/cocos/ui/UIRichText.cpp
@@ -451,7 +451,7 @@ void RichText::setAnchorPoint(const Vec2 &pt)
     _elementRenderersContainer->setAnchorPoint(pt);
 }
     
-const Size RichText::getVirtualRendererSize() const
+Size RichText::getVirtualRendererSize() const
 {
     return _elementRenderersContainer->getContentSize();
 }

--- a/cocos/ui/UIRichText.h
+++ b/cocos/ui/UIRichText.h
@@ -106,7 +106,7 @@ public:
 
     void setVerticalSpace(float space);
     virtual void setAnchorPoint(const Vec2 &pt);
-    virtual const Size getVirtualRendererSize() const override;
+    virtual Size getVirtualRendererSize() const override;
     void formatText();
     virtual void ignoreContentAdaptWithSize(bool ignore);
     virtual std::string getDescription() const override;

--- a/cocos/ui/UIRichText.h
+++ b/cocos/ui/UIRichText.h
@@ -106,7 +106,7 @@ public:
 
     void setVerticalSpace(float space);
     virtual void setAnchorPoint(const Vec2 &pt);
-    virtual const Size& getVirtualRendererSize() const override;
+    virtual const Size getVirtualRendererSize() const override;
     void formatText();
     virtual void ignoreContentAdaptWithSize(bool ignore);
     virtual std::string getDescription() const override;

--- a/cocos/ui/UISlider.cpp
+++ b/cocos/ui/UISlider.cpp
@@ -449,7 +449,7 @@ void Slider::adaptRenderers()
     }
 }
 
-const Size Slider::getVirtualRendererSize() const
+Size Slider::getVirtualRendererSize() const
 {
     return _barRenderer->getContentSize();
 }

--- a/cocos/ui/UISlider.cpp
+++ b/cocos/ui/UISlider.cpp
@@ -449,7 +449,7 @@ void Slider::adaptRenderers()
     }
 }
 
-const Size& Slider::getVirtualRendererSize() const
+const Size Slider::getVirtualRendererSize() const
 {
     return _barRenderer->getContentSize();
 }

--- a/cocos/ui/UISlider.h
+++ b/cocos/ui/UISlider.h
@@ -194,7 +194,7 @@ public:
     virtual void onTouchCancelled(Touch *touch, Event *unusedEvent) override;
     
     //override "getVirtualRendererSize" method of widget.
-    virtual const Size getVirtualRendererSize() const override;
+    virtual Size getVirtualRendererSize() const override;
     
     //override "getVirtualRenderer" method of widget.
     virtual Node* getVirtualRenderer() override;

--- a/cocos/ui/UISlider.h
+++ b/cocos/ui/UISlider.h
@@ -194,7 +194,7 @@ public:
     virtual void onTouchCancelled(Touch *touch, Event *unusedEvent) override;
     
     //override "getVirtualRendererSize" method of widget.
-    virtual const Size& getVirtualRendererSize() const override;
+    virtual const Size getVirtualRendererSize() const override;
     
     //override "getVirtualRenderer" method of widget.
     virtual Node* getVirtualRenderer() override;

--- a/cocos/ui/UIText.cpp
+++ b/cocos/ui/UIText.cpp
@@ -292,7 +292,7 @@ void Text::adaptRenderers()
     }
 }
 
-const Size Text::getVirtualRendererSize() const
+Size Text::getVirtualRendererSize() const
 {
     return _labelRenderer->getContentSize();
 }

--- a/cocos/ui/UIText.cpp
+++ b/cocos/ui/UIText.cpp
@@ -292,7 +292,7 @@ void Text::adaptRenderers()
     }
 }
 
-const Size& Text::getVirtualRendererSize() const
+const Size Text::getVirtualRendererSize() const
 {
     return _labelRenderer->getContentSize();
 }

--- a/cocos/ui/UIText.h
+++ b/cocos/ui/UIText.h
@@ -139,7 +139,7 @@ public:
     bool isTouchScaleChangeEnabled()const;
 
     //override "getVirtualRendererSize" method of widget.
-    virtual const Size getVirtualRendererSize() const override;
+    virtual Size getVirtualRendererSize() const override;
 
     //override "getVirtualRenderer" method of widget.
     virtual Node* getVirtualRenderer() override;

--- a/cocos/ui/UIText.h
+++ b/cocos/ui/UIText.h
@@ -139,7 +139,7 @@ public:
     bool isTouchScaleChangeEnabled()const;
 
     //override "getVirtualRendererSize" method of widget.
-    virtual const Size& getVirtualRendererSize() const override;
+    virtual const Size getVirtualRendererSize() const override;
 
     //override "getVirtualRenderer" method of widget.
     virtual Node* getVirtualRenderer() override;

--- a/cocos/ui/UITextAtlas.cpp
+++ b/cocos/ui/UITextAtlas.cpp
@@ -135,7 +135,7 @@ void TextAtlas::adaptRenderers()
     }
 }
 
-const Size& TextAtlas::getVirtualRendererSize() const
+const Size TextAtlas::getVirtualRendererSize() const
 {
     return _labelAtlasRenderer->getContentSize();
 }

--- a/cocos/ui/UITextAtlas.cpp
+++ b/cocos/ui/UITextAtlas.cpp
@@ -135,7 +135,7 @@ void TextAtlas::adaptRenderers()
     }
 }
 
-const Size TextAtlas::getVirtualRendererSize() const
+Size TextAtlas::getVirtualRendererSize() const
 {
     return _labelAtlasRenderer->getContentSize();
 }

--- a/cocos/ui/UITextAtlas.h
+++ b/cocos/ui/UITextAtlas.h
@@ -93,7 +93,7 @@ public:
     ssize_t getStringLength()const;
     
     //override "getVirtualRendererSize" method of widget.
-    virtual const Size getVirtualRendererSize() const override;
+    virtual Size getVirtualRendererSize() const override;
     
     //override "getVirtualRenderer" method of widget.
     virtual Node* getVirtualRenderer() override;

--- a/cocos/ui/UITextAtlas.h
+++ b/cocos/ui/UITextAtlas.h
@@ -93,7 +93,7 @@ public:
     ssize_t getStringLength()const;
     
     //override "getVirtualRendererSize" method of widget.
-    virtual const Size& getVirtualRendererSize() const override;
+    virtual const Size getVirtualRendererSize() const override;
     
     //override "getVirtualRenderer" method of widget.
     virtual Node* getVirtualRenderer() override;

--- a/cocos/ui/UITextBMFont.cpp
+++ b/cocos/ui/UITextBMFont.cpp
@@ -129,7 +129,7 @@ void TextBMFont::adaptRenderers()
     }
 }
 
-const Size& TextBMFont::getVirtualRendererSize() const
+const Size TextBMFont::getVirtualRendererSize() const
 {
     return _labelBMFontRenderer->getContentSize();
 }

--- a/cocos/ui/UITextBMFont.cpp
+++ b/cocos/ui/UITextBMFont.cpp
@@ -129,7 +129,7 @@ void TextBMFont::adaptRenderers()
     }
 }
 
-const Size TextBMFont::getVirtualRendererSize() const
+Size TextBMFont::getVirtualRendererSize() const
 {
     return _labelBMFontRenderer->getContentSize();
 }

--- a/cocos/ui/UITextBMFont.h
+++ b/cocos/ui/UITextBMFont.h
@@ -81,7 +81,7 @@ public:
      */
     ssize_t getStringLength()const;
 
-    virtual const Size& getVirtualRendererSize() const override;
+    virtual const Size getVirtualRendererSize() const override;
     virtual Node* getVirtualRenderer() override;
     /**
      * Returns the "class name" of widget.

--- a/cocos/ui/UITextBMFont.h
+++ b/cocos/ui/UITextBMFont.h
@@ -81,7 +81,7 @@ public:
      */
     ssize_t getStringLength()const;
 
-    virtual const Size getVirtualRendererSize() const override;
+    virtual Size getVirtualRendererSize() const override;
     virtual Node* getVirtualRenderer() override;
     /**
      * Returns the "class name" of widget.

--- a/cocos/ui/UITextField.cpp
+++ b/cocos/ui/UITextField.cpp
@@ -737,7 +737,7 @@ void TextField::textfieldRendererScaleChangedWithSize()
     _textFieldRenderer->setPosition(_contentSize.width / 2.0f, _contentSize.height / 2.0f);
 }
 
-const Size& TextField::getVirtualRendererSize() const
+const Size TextField::getVirtualRendererSize() const
 {
     return _textFieldRenderer->getContentSize();
 }

--- a/cocos/ui/UITextField.cpp
+++ b/cocos/ui/UITextField.cpp
@@ -737,7 +737,7 @@ void TextField::textfieldRendererScaleChangedWithSize()
     _textFieldRenderer->setPosition(_contentSize.width / 2.0f, _contentSize.height / 2.0f);
 }
 
-const Size TextField::getVirtualRendererSize() const
+Size TextField::getVirtualRendererSize() const
 {
     return _textFieldRenderer->getContentSize();
 }

--- a/cocos/ui/UITextField.h
+++ b/cocos/ui/UITextField.h
@@ -187,7 +187,7 @@ public:
      */
     virtual std::string getDescription() const override;
 
-    virtual const Size getVirtualRendererSize() const override;
+    virtual Size getVirtualRendererSize() const override;
     virtual Node* getVirtualRenderer() override;
     void attachWithIME();
     virtual void onEnter() override;

--- a/cocos/ui/UITextField.h
+++ b/cocos/ui/UITextField.h
@@ -187,7 +187,7 @@ public:
      */
     virtual std::string getDescription() const override;
 
-    virtual const Size& getVirtualRendererSize() const override;
+    virtual const Size getVirtualRendererSize() const override;
     virtual Node* getVirtualRenderer() override;
     void attachWithIME();
     virtual void onEnter() override;

--- a/cocos/ui/UIWidget.cpp
+++ b/cocos/ui/UIWidget.cpp
@@ -468,7 +468,7 @@ void Widget::onSizeChanged()
     }
 }
 
-const Size Widget::getVirtualRendererSize() const
+Size Widget::getVirtualRendererSize() const
 {
     return _contentSize;
 }

--- a/cocos/ui/UIWidget.cpp
+++ b/cocos/ui/UIWidget.cpp
@@ -468,7 +468,7 @@ void Widget::onSizeChanged()
     }
 }
 
-const Size& Widget::getVirtualRendererSize() const
+const Size Widget::getVirtualRendererSize() const
 {
     return _contentSize;
 }

--- a/cocos/ui/UIWidget.h
+++ b/cocos/ui/UIWidget.h
@@ -489,7 +489,7 @@ public:
     virtual Node* getVirtualRenderer();
 
 
-    virtual const Size getVirtualRendererSize() const;
+    virtual Size getVirtualRendererSize() const;
     
 
     /**

--- a/cocos/ui/UIWidget.h
+++ b/cocos/ui/UIWidget.h
@@ -489,7 +489,7 @@ public:
     virtual Node* getVirtualRenderer();
 
 
-    virtual const Size& getVirtualRendererSize() const;
+    virtual const Size getVirtualRendererSize() const;
     
 
     /**

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/CocosGUIScene.cpp
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/CocosGUIScene.cpp
@@ -89,7 +89,7 @@ g_guisTests[] =
             UISceneManager* sceneManager = UISceneManager::sharedUISceneManager();
             sceneManager->setCurrentUISceneId(kUIButtonTest);
             sceneManager->setMinUISceneId(kUIButtonTest);
-            sceneManager->setMaxUISceneId(kUIButtonTextOnly);
+            sceneManager->setMaxUISceneId(kUIButtonIgnoreContentSizeTest);
             Scene* scene = sceneManager->currentUIScene();
             Director::getInstance()->replaceScene(scene);
         }

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/CocosGUIScene.cpp
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/CocosGUIScene.cpp
@@ -89,7 +89,7 @@ g_guisTests[] =
             UISceneManager* sceneManager = UISceneManager::sharedUISceneManager();
             sceneManager->setCurrentUISceneId(kUIButtonTest);
             sceneManager->setMinUISceneId(kUIButtonTest);
-            sceneManager->setMaxUISceneId(kUIButtonTestZoomScale);
+            sceneManager->setMaxUISceneId(kUIButtonTextOnly);
             Scene* scene = sceneManager->currentUIScene();
             Director::getInstance()->replaceScene(scene);
         }

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIButtonTest/UIButtonTest.cpp
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIButtonTest/UIButtonTest.cpp
@@ -297,7 +297,7 @@ bool UIButtonTest_Title::init()
         
         // Create the button with title
         Button* button = Button::create("cocosui/backtotoppressed.png", "cocosui/backtotopnormal.png");
-        button->setTitleText("Title Button");
+        button->setTitleText("Title Button Large than button!");
         button->setPosition(Vec2(widgetSize.width / 2.0f, widgetSize.height / 2.0f));
         button->setTitleColor(Color3B::YELLOW);
         CCASSERT(button->getTitleColor() == Color3B::YELLOW, "Button setTitleColotr & getTitleColor not match!");
@@ -592,3 +592,51 @@ void UIButtonTestZoomScale::sliderEvent(Ref *pSender, Slider::EventType type)
         _displayValueLabel->setString(String::createWithFormat("Zoom Scale: %f", zoomScale)->getCString());
     }
 }
+
+// UIButtonTestZoomScale
+UIButtonTextOnly::UIButtonTextOnly()
+: _displayValueLabel(nullptr)
+{
+    
+}
+
+UIButtonTextOnly::~UIButtonTextOnly()
+{
+}
+
+bool UIButtonTextOnly::init()
+{
+    if (UIScene::init())
+    {
+        Size widgetSize = _widget->getContentSize();
+        
+        // Add a label in which the button events will be displayed
+        _displayValueLabel = Text::create("Text Only Button", "fonts/Marker Felt.ttf",32);
+        _displayValueLabel->setAnchorPoint(Vec2(0.5f, -1.0f));
+        _displayValueLabel->setPosition(Vec2(widgetSize.width / 2.0f, widgetSize.height / 2.0f + 20));
+        _uiLayer->addChild(_displayValueLabel);
+        
+        // Add the alert
+        Text* alert = Text::create("Button","fonts/Marker Felt.ttf",30);
+        alert->setColor(Color3B(159, 168, 176));
+        
+        alert->setPosition(Vec2(widgetSize.width / 2.0f,
+                                widgetSize.height / 2.0f - alert->getContentSize().height * 1.75f));
+        
+        _uiLayer->addChild(alert);
+        
+        // Create the button
+        auto button = Button::create();
+        button->setNormalizedPosition(Vec2(0.5, 0.5));
+        button->setTitleText("PLAY GAME");
+        button->setPressedActionEnabled(true);
+        button->addClickEventListener([this](Ref* sender) {
+            CCLOG("touched!");
+        });
+        _uiLayer->addChild(button);
+        
+        return true;
+    }
+    return false;
+}
+

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIButtonTest/UIButtonTest.cpp
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIButtonTest/UIButtonTest.cpp
@@ -36,13 +36,12 @@ bool UIButtonTest::init()
         _uiLayer->addChild(alert);        
         
         // Create the button
-        Button* button = Button::create("cocosui/animationbuttonnormal.png",
-                                        "cocosui/animationbuttonpressed.png");
+        Button* button = Button::create("cocosui/animationbuttonnormal.png");
         button->setPosition(Vec2(widgetSize.width / 2.0f, widgetSize.height / 2.0f));
-//        button->addTouchEventListener(this, toucheventselector(UIButtonTest::touchEvent));
         button->addTouchEventListener(CC_CALLBACK_2(UIButtonTest::touchEvent, this));
+        button->setZoomScale(0.4);
+        button->setPressedActionEnabled(true);
         _uiLayer->addChild(button);
-//        button->setColor(Color3B::RED);
         button->setOpacity(100);
         // Create the imageview
         ImageView* imageView = ImageView::create();
@@ -133,6 +132,7 @@ bool UIButtonTest_Scale9::init()
         button->setScale9Enabled(true);
         button->setPosition(Vec2(widgetSize.width / 2.0f, widgetSize.height / 2.0f));
         button->setContentSize(Size(150, 70));
+        button->setPressedActionEnabled(true);
         button->addTouchEventListener(CC_CALLBACK_2(UIButtonTest_Scale9::touchEvent, this));
         _uiLayer->addChild(button);
         
@@ -297,7 +297,7 @@ bool UIButtonTest_Title::init()
         
         // Create the button with title
         Button* button = Button::create("cocosui/backtotoppressed.png", "cocosui/backtotopnormal.png");
-        button->setTitleText("Title Button Large than button!");
+        button->setTitleText("Title Button!");
         button->setPosition(Vec2(widgetSize.width / 2.0f, widgetSize.height / 2.0f));
         button->setTitleColor(Color3B::YELLOW);
         CCASSERT(button->getTitleColor() == Color3B::YELLOW, "Button setTitleColotr & getTitleColor not match!");
@@ -539,7 +539,7 @@ bool UIButtonTestZoomScale::init()
         Size widgetSize = _widget->getContentSize();
         
         // Add a label in which the button events will be displayed
-        _displayValueLabel = Text::create("Zoom Scale: 0.1", "fonts/Marker Felt.ttf",32);
+        _displayValueLabel = Text::create("Zoom Scale: -0.5", "fonts/Marker Felt.ttf",32);
         _displayValueLabel->setAnchorPoint(Vec2(0.5f, -1.0f));
         _displayValueLabel->setPosition(Vec2(widgetSize.width / 2.0f, widgetSize.height / 2.0f + 20));
         _uiLayer->addChild(_displayValueLabel);
@@ -593,7 +593,7 @@ void UIButtonTestZoomScale::sliderEvent(Ref *pSender, Slider::EventType type)
     }
 }
 
-// UIButtonTestZoomScale
+// UIButtonTextOnly
 UIButtonTextOnly::UIButtonTextOnly()
 : _displayValueLabel(nullptr)
 {
@@ -629,6 +629,58 @@ bool UIButtonTextOnly::init()
         auto button = Button::create();
         button->setNormalizedPosition(Vec2(0.5, 0.5));
         button->setTitleText("PLAY GAME");
+        button->setZoomScale(0.3);
+        button->setPressedActionEnabled(true);
+        button->addClickEventListener([this](Ref* sender) {
+            CCLOG("clicked!");
+        });
+        _uiLayer->addChild(button);
+        
+        return true;
+    }
+    return false;
+}
+
+// UIButtonIgnoreContentSizeTest
+UIButtonIgnoreContentSizeTest::UIButtonIgnoreContentSizeTest()
+: _displayValueLabel(nullptr)
+{
+    
+}
+
+UIButtonIgnoreContentSizeTest::~UIButtonIgnoreContentSizeTest()
+{
+}
+
+bool UIButtonIgnoreContentSizeTest::init()
+{
+    if (UIScene::init())
+    {
+        Size widgetSize = _widget->getContentSize();
+        
+        // Add a label in which the button events will be displayed
+        _displayValueLabel = Text::create("Button IgnoreContent Size Test", "fonts/Marker Felt.ttf",32);
+        _displayValueLabel->setAnchorPoint(Vec2(0.5f, -1.0f));
+        _displayValueLabel->setPosition(Vec2(widgetSize.width / 2.0f, widgetSize.height / 2.0f + 20));
+        _uiLayer->addChild(_displayValueLabel);
+        
+        // Add the alert
+        Text* alert = Text::create("Button","fonts/Marker Felt.ttf",30);
+        alert->setColor(Color3B(159, 168, 176));
+        
+        alert->setPosition(Vec2(widgetSize.width / 2.0f,
+                                widgetSize.height / 2.0f - alert->getContentSize().height * 1.75f));
+        
+        _uiLayer->addChild(alert);
+        
+        // Create the button
+        auto button = Button::create("cocosui/animationbuttonnormal.png",
+                                     "cocosui/animationbuttonpressed.png");
+        button->ignoreContentAdaptWithSize(false);
+        button->setContentSize(Size(200,100));
+        button->setNormalizedPosition(Vec2(0.5, 0.5));
+        button->setTitleText("PLAY GAME");
+        button->setZoomScale(0.3);
         button->setPressedActionEnabled(true);
         button->addClickEventListener([this](Ref* sender) {
             CCLOG("touched!");

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIButtonTest/UIButtonTest.h
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIButtonTest/UIButtonTest.h
@@ -129,4 +129,16 @@ protected:
     UI_SCENE_CREATE_FUNC(UIButtonTextOnly)
     Text* _displayValueLabel;
 };
+
+class UIButtonIgnoreContentSizeTest : public UIScene
+{
+public:
+    UIButtonIgnoreContentSizeTest();
+    ~UIButtonIgnoreContentSizeTest();
+    bool init();
+    
+protected:
+    UI_SCENE_CREATE_FUNC(UIButtonIgnoreContentSizeTest)
+    Text* _displayValueLabel;
+};
 #endif /* defined(__TestCpp__UIButtonTest__) */

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIButtonTest/UIButtonTest.h
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIButtonTest/UIButtonTest.h
@@ -118,4 +118,15 @@ protected:
     Text* _displayValueLabel;
 };
 
+class UIButtonTextOnly : public UIScene
+{
+public:
+    UIButtonTextOnly();
+    ~UIButtonTextOnly();
+    bool init();
+
+protected:
+    UI_SCENE_CREATE_FUNC(UIButtonTextOnly)
+    Text* _displayValueLabel;
+};
 #endif /* defined(__TestCpp__UIButtonTest__) */

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UISceneManager.cpp
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UISceneManager.cpp
@@ -39,6 +39,7 @@ static const char* s_testArray[] =
     "UIButtonTest_RemoveSelf",
     "UIButtonTestSwitchScale9",
     "UIButtonTestZoomScale",
+    "UIButtonTextOnly",
 #if (CC_TARGET_PLATFORM == CC_PLATFORM_IOS) || (CC_TARGET_PLATFORM == CC_PLATFORM_ANDROID) || (CC_TARGET_PLATFORM == CC_PLATFORM_MAC) || (CC_TARGET_PLATFORM == CC_PLATFORM_WIN32) || (CC_TARGET_PLATFORM == CC_PLATFORM_TIZEN) || (CC_TARGET_PLATFORM == CC_PLATFORM_WP8)
     "UIEditBoxTest",
 #endif
@@ -195,6 +196,8 @@ Scene *UISceneManager::currentUIScene()
             return UIButtonTestSwitchScale9::sceneWithTitle(s_testArray[_currentUISceneId]);
         case kUIButtonTestZoomScale:
             return UIButtonTestZoomScale::sceneWithTitle(s_testArray[_currentUISceneId]);
+        case kUIButtonTextOnly:
+            return UIButtonTextOnly::sceneWithTitle(s_testArray[_currentUISceneId]);
         case kUICheckBoxTest:
             return UICheckBoxTest::sceneWithTitle(s_testArray[_currentUISceneId]);
             

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UISceneManager.cpp
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UISceneManager.cpp
@@ -40,6 +40,8 @@ static const char* s_testArray[] =
     "UIButtonTestSwitchScale9",
     "UIButtonTestZoomScale",
     "UIButtonTextOnly",
+    "UIButtonIgnoreContentSizeTest",
+    
 #if (CC_TARGET_PLATFORM == CC_PLATFORM_IOS) || (CC_TARGET_PLATFORM == CC_PLATFORM_ANDROID) || (CC_TARGET_PLATFORM == CC_PLATFORM_MAC) || (CC_TARGET_PLATFORM == CC_PLATFORM_WIN32) || (CC_TARGET_PLATFORM == CC_PLATFORM_TIZEN) || (CC_TARGET_PLATFORM == CC_PLATFORM_WP8)
     "UIEditBoxTest",
 #endif
@@ -198,6 +200,9 @@ Scene *UISceneManager::currentUIScene()
             return UIButtonTestZoomScale::sceneWithTitle(s_testArray[_currentUISceneId]);
         case kUIButtonTextOnly:
             return UIButtonTextOnly::sceneWithTitle(s_testArray[_currentUISceneId]);
+        case kUIButtonIgnoreContentSizeTest:
+            return UIButtonIgnoreContentSizeTest::sceneWithTitle(s_testArray[_currentUISceneId]);
+            
         case kUICheckBoxTest:
             return UICheckBoxTest::sceneWithTitle(s_testArray[_currentUISceneId]);
             

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UISceneManager.h
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UISceneManager.h
@@ -38,6 +38,7 @@ enum
     kUIButtonTest_RemoveSelf,
     kUIButtonTestSwitchScale9,
     kUIButtonTestZoomScale,
+    kUIButtonTextOnly,
     kUIEditBoxTest,
     kUICheckBoxTest,
     kUISliderTest,

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UISceneManager.h
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UISceneManager.h
@@ -39,6 +39,7 @@ enum
     kUIButtonTestSwitchScale9,
     kUIButtonTestZoomScale,
     kUIButtonTextOnly,
+    kUIButtonIgnoreContentSizeTest,
     kUIEditBoxTest,
     kUICheckBoxTest,
     kUISliderTest,


### PR DESCRIPTION
1. Fix text only button can't be touched issue, the original issue was reported [here](https://github.com/cocos2d/cocos2d-x/issues/7960)
2. Fix button title doesn't zoom when the button is zooming.
