### PR TITLE
fix Editbox lua binding

### DIFF
--- a/cocos/editor-support/cocostudio/CCSGUIReader.cpp
+++ b/cocos/editor-support/cocostudio/CCSGUIReader.cpp
@@ -1097,7 +1097,7 @@ void WidgetPropertiesReader0250::setPropsForTextFieldFromJsonDictionary(Widget*w
     {
         textField->setPlaceHolder(DICTOOL->getStringValue_json(options, "placeHolder"));
     }
-    textField->setText(DICTOOL->getStringValue_json(options, "text"));
+    textField->setString(DICTOOL->getStringValue_json(options, "text"));
     bool fs = DICTOOL->checkObjectExist_json(options, "fontSize");
     if (fs)
     {

--- a/cocos/editor-support/cocostudio/WidgetReader/TextFieldReader/TextFieldReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/TextFieldReader/TextFieldReader.cpp
@@ -63,7 +63,7 @@ namespace cocostudio
             else if(key == P_PlaceHolder){
                 textField->setPlaceHolder(value);
             }else if(key == P_Text){
-                textField->setText(value);
+                textField->setString(value);
             }else if(key == P_FontSize){
                 textField->setFontSize(valueToInt(value));
             }else if(key == P_FontName){
@@ -96,7 +96,7 @@ namespace cocostudio
         {
             textField->setPlaceHolder(DICTOOL->getStringValue_json(options, P_PlaceHolder,"input words here"));
         }
-        textField->setText(DICTOOL->getStringValue_json(options, P_Text,"Text Tield"));
+        textField->setString(DICTOOL->getStringValue_json(options, P_Text,"Text Tield"));
        
         textField->setFontSize(DICTOOL->getIntValue_json(options, P_FontSize,20));
     

--- a/cocos/scripting/lua-bindings/manual/cocosbuilder/CCBProxy.cpp
+++ b/cocos/scripting/lua-bindings/manual/cocosbuilder/CCBProxy.cpp
@@ -77,7 +77,7 @@ const char* CCBProxy::getNodeTypeName(Node* pNode)
         return "cc.LayerColor";
     }
     
-    if (NULL != dynamic_cast<Scale9Sprite*>(pNode)) {
+    if (NULL != dynamic_cast<ui::Scale9Sprite*>(pNode)) {
         return "cc.LayerGradient";
     }
     

--- a/cocos/scripting/lua-bindings/manual/extension/lua_cocos2dx_extension_manual.cpp
+++ b/cocos/scripting/lua-bindings/manual/extension/lua_cocos2dx_extension_manual.cpp
@@ -356,110 +356,7 @@ static void extendControl(lua_State* tolua_S)
     lua_pop(tolua_S, 1);
 }
 
-static int tolua_cocos2d_EditBox_registerScriptEditBoxHandler(lua_State* tolua_S)
-{
-    if (NULL == tolua_S)
-        return 0;
-    
-    int argc = 0;
-    EditBox* self = nullptr;
-    
-#if COCOS2D_DEBUG >= 1
-    tolua_Error tolua_err;
-	if (!tolua_isusertype(tolua_S,1,"cc.EditBox",0,&tolua_err)) goto tolua_lerror;
-#endif
-    
-    self = static_cast<EditBox*>(tolua_tousertype(tolua_S,1,0));
-    
-#if COCOS2D_DEBUG >= 1
-	if (nullptr == self) {
-		tolua_error(tolua_S,"invalid 'self' in function 'tolua_cocos2d_EditBox_registerScriptEditBoxHandler'\n", NULL);
-		return 0;
-	}
-#endif
-    
-    argc = lua_gettop(tolua_S) - 1;
-    
-    if (1 == argc)
-    {
-#if COCOS2D_DEBUG >= 1
-        if (!toluafix_isfunction(tolua_S,2,"LUA_FUNCTION",0,&tolua_err))
-        {
-            goto tolua_lerror;
-        }
-#endif
-        LUA_FUNCTION handler = (  toluafix_ref_function(tolua_S,2,0));
-        self->registerScriptEditBoxHandler(handler);
-        return 0;
-    }
-    
-    CCLOG("%s function of EditBox  has wrong number of arguments: %d, was expecting %d\n", "cc.EditBox:registerScriptEditBoxHandler", argc, 1);
-    return 0;
-    
-#if COCOS2D_DEBUG >= 1
-tolua_lerror:
-    tolua_error(tolua_S,"#ferror in function 'tolua_cocos2d_EditBox_registerScriptEditBoxHandler'.",&tolua_err);
-    return 0;
-#endif
 
-}
-
-static int tolua_cocos2d_EditBox_unregisterScriptEditBoxHandler(lua_State* tolua_S)
-{
-    
-    if (NULL == tolua_S)
-        return 0;
-    
-    int argc = 0;
-    EditBox* self = nullptr;
-    
-#if COCOS2D_DEBUG >= 1
-    tolua_Error tolua_err;
-	if (!tolua_isusertype(tolua_S,1,"cc.EditBox",0,&tolua_err)) goto tolua_lerror;
-#endif
-    
-    self = static_cast<EditBox*>(tolua_tousertype(tolua_S,1,0));
-    
-#if COCOS2D_DEBUG >= 1
-	if (nullptr == self) {
-		tolua_error(tolua_S,"invalid 'self' in function 'tolua_cocos2d_EditBox_unregisterScriptEditBoxHandler'\n", NULL);
-		return 0;
-	}
-#endif
-    
-    argc = lua_gettop(tolua_S) - 1;
-    
-    if (0 == argc)
-    {
-        self->unregisterScriptEditBoxHandler();
-        return 0;
-    }
-    
-    CCLOG("%s function of EditBox  has wrong number of arguments: %d, was expecting %d\n", "cc.EditBox:unregisterScriptEditBoxHandler", argc, 0);
-    return 0;
-    
-#if COCOS2D_DEBUG >= 1
-tolua_lerror:
-    tolua_error(tolua_S,"#ferror in function 'tolua_cocos2d_EditBox_unregisterScriptEditBoxHandler'.",&tolua_err);
-    return 0;
-#endif
-}
-
-static void extendEditBox(lua_State* tolua_S)
-{
-    lua_pushstring(tolua_S, "cc.EditBox");
-    lua_rawget(tolua_S, LUA_REGISTRYINDEX);
-    if (lua_istable(tolua_S,-1))
-    {
-        lua_pushstring(tolua_S,"registerScriptEditBoxHandler");
-        lua_pushcfunction(tolua_S,tolua_cocos2d_EditBox_registerScriptEditBoxHandler );
-        lua_rawset(tolua_S,-3);
-        lua_pushstring(tolua_S,"unregisterScriptEditBoxHandler");
-        lua_pushcfunction(tolua_S,tolua_cocos2d_EditBox_unregisterScriptEditBoxHandler );
-        lua_rawset(tolua_S,-3);
-    }
-    lua_pop(tolua_S, 1);
-}
 
 class LuaAssetsManagerDelegateProtocol:public Ref, public AssetsManagerDelegateProtocol
 {
@@ -1045,7 +942,6 @@ static void extendTableView(lua_State* L)
 int register_all_cocos2dx_extension_manual(lua_State* tolua_S)
 {
     extendControl(tolua_S);
-    /* extendEditBox(tolua_S); */
     extendAssetsManager(tolua_S);
     extendScrollView(tolua_S);
     extendTableView(tolua_S);

--- a/cocos/scripting/lua-bindings/manual/ui/lua_cocos2dx_ui_manual.cpp
+++ b/cocos/scripting/lua-bindings/manual/ui/lua_cocos2dx_ui_manual.cpp
@@ -671,6 +671,112 @@ static void extendLayoutParameter(lua_State* L)
     lua_pop(L, 1);
 }
 
+
+static int tolua_cocos2d_EditBox_registerScriptEditBoxHandler(lua_State* tolua_S)
+{
+    if (NULL == tolua_S)
+        return 0;
+    
+    int argc = 0;
+    EditBox* self = nullptr;
+    
+#if COCOS2D_DEBUG >= 1
+    tolua_Error tolua_err;
+	if (!tolua_isusertype(tolua_S,1,"ccui.EditBox",0,&tolua_err)) goto tolua_lerror;
+#endif
+    
+    self = static_cast<EditBox*>(tolua_tousertype(tolua_S,1,0));
+    
+#if COCOS2D_DEBUG >= 1
+	if (nullptr == self) {
+		tolua_error(tolua_S,"invalid 'self' in function 'tolua_cocos2d_EditBox_registerScriptEditBoxHandler'\n", NULL);
+		return 0;
+	}
+#endif
+    
+    argc = lua_gettop(tolua_S) - 1;
+    
+    if (1 == argc)
+    {
+#if COCOS2D_DEBUG >= 1
+        if (!toluafix_isfunction(tolua_S,2,"LUA_FUNCTION",0,&tolua_err))
+        {
+            goto tolua_lerror;
+        }
+#endif
+        LUA_FUNCTION handler = (  toluafix_ref_function(tolua_S,2,0));
+        self->registerScriptEditBoxHandler(handler);
+        return 0;
+    }
+    
+    CCLOG("%s function of EditBox  has wrong number of arguments: %d, was expecting %d\n", "ccui.EditBox:registerScriptEditBoxHandler", argc, 1);
+    return 0;
+    
+#if COCOS2D_DEBUG >= 1
+tolua_lerror:
+    tolua_error(tolua_S,"#ferror in function 'tolua_cocos2d_EditBox_registerScriptEditBoxHandler'.",&tolua_err);
+    return 0;
+#endif
+    
+}
+
+static int tolua_cocos2d_EditBox_unregisterScriptEditBoxHandler(lua_State* tolua_S)
+{
+    
+    if (NULL == tolua_S)
+        return 0;
+    
+    int argc = 0;
+    EditBox* self = nullptr;
+    
+#if COCOS2D_DEBUG >= 1
+    tolua_Error tolua_err;
+	if (!tolua_isusertype(tolua_S,1,"ccui.EditBox",0,&tolua_err)) goto tolua_lerror;
+#endif
+    
+    self = static_cast<EditBox*>(tolua_tousertype(tolua_S,1,0));
+    
+#if COCOS2D_DEBUG >= 1
+	if (nullptr == self) {
+		tolua_error(tolua_S,"invalid 'self' in function 'tolua_cocos2d_EditBox_unregisterScriptEditBoxHandler'\n", NULL);
+		return 0;
+	}
+#endif
+    
+    argc = lua_gettop(tolua_S) - 1;
+    
+    if (0 == argc)
+    {
+        self->unregisterScriptEditBoxHandler();
+        return 0;
+    }
+    
+    CCLOG("%s function of EditBox  has wrong number of arguments: %d, was expecting %d\n", "ccui.EditBox:unregisterScriptEditBoxHandler", argc, 0);
+    return 0;
+    
+#if COCOS2D_DEBUG >= 1
+tolua_lerror:
+    tolua_error(tolua_S,"#ferror in function 'tolua_cocos2d_EditBox_unregisterScriptEditBoxHandler'.",&tolua_err);
+    return 0;
+#endif
+}
+
+static void extendEditBox(lua_State* tolua_S)
+{
+    lua_pushstring(tolua_S, "ccui.EditBox");
+    lua_rawget(tolua_S, LUA_REGISTRYINDEX);
+    if (lua_istable(tolua_S,-1))
+    {
+        lua_pushstring(tolua_S,"registerScriptEditBoxHandler");
+        lua_pushcfunction(tolua_S,tolua_cocos2d_EditBox_registerScriptEditBoxHandler );
+        lua_rawset(tolua_S,-3);
+        lua_pushstring(tolua_S,"unregisterScriptEditBoxHandler");
+        lua_pushcfunction(tolua_S,tolua_cocos2d_EditBox_unregisterScriptEditBoxHandler );
+        lua_rawset(tolua_S,-3);
+    }
+    lua_pop(tolua_S, 1);
+}
+
 int register_all_cocos2dx_ui_manual(lua_State* L)
 {
     if (nullptr == L)
@@ -683,7 +789,8 @@ int register_all_cocos2dx_ui_manual(lua_State* L)
     extendScrollView(L);
     extendListView(L);
     extendLayoutParameter(L);
-    
+    extendEditBox(L);
+
     return 0;
 }
 

--- a/cocos/scripting/lua-bindings/script/extension/DeprecatedExtensionClass.lua
+++ b/cocos/scripting/lua-bindings/script/extension/DeprecatedExtensionClass.lua
@@ -17,10 +17,17 @@ _G["CCControl"] = DeprecatedExtensionClass.CCControl()
 
 --CCEditBox class will be Deprecated,begin
 function DeprecatedExtensionClass.CCEditBox()
-    deprecatedTip("CCEditBox","cc.EditBox")
-    return cc.EditBox
+    deprecatedTip("CCEditBox","ccui.EditBox")
+    return ccui.EditBox
 end
 _G["CCEditBox"] = DeprecatedExtensionClass.CCEditBox()
+
+function DeprecatedExtensionClass.CCUIEditBox()
+    deprecatedTip("cc.EditBox","ccui.EditBox")
+    return ccui.EditBox
+end
+_G["cc"]["EditBox"] = DeprecatedExtensionClass.CCUIEditBox()
+
 --CCEditBox class will be Deprecated,end
 
 --CCScrollView class will be Deprecated,begin
@@ -97,10 +104,16 @@ _G["CCControlButton"] = DeprecatedExtensionClass.CCControlButton()
 
 --CCScale9Sprite class will be Deprecated,begin
 function DeprecatedExtensionClass.CCScale9Sprite()
-    deprecatedTip("CCScale9Sprite","cc.Scale9Sprite")
-    return cc.Scale9Sprite
+    deprecatedTip("CCScale9Sprite","ccui.Scale9Sprite")
+    return ccui.Scale9Sprite
 end
 _G["CCScale9Sprite"] = DeprecatedExtensionClass.CCScale9Sprite()
+
+function DeprecatedExtensionClass.UIScale9Sprite()
+    deprecatedTip("cc.Scale9Sprite","ccui.Scale9Sprite")
+    return ccui.Scale9Sprite
+end
+_G["cc"]["Scale9Sprite"] = DeprecatedExtensionClass.UIScale9Sprite()
 --CCScale9Sprite class will be Deprecated,end
 
 --CCControlColourPicker class will be Deprecated,begin

--- a/tests/lua-tests/project/Classes/lua_module_register.h
+++ b/tests/lua-tests/project/Classes/lua_module_register.h
@@ -14,10 +14,11 @@
 
 int lua_module_register(lua_State* L)
 {
+    register_ui_moudle(L);
+    //extension module must be registed after ui module
     register_extension_module(L);
     register_cocostudio_module(L);
     register_cocosbuilder_module(L);
-    register_ui_moudle(L);
     register_spine_module(L);
     register_network_module(L);
     register_cocosdenshion_module(L);

--- a/tools/tolua/cocos2dx_ui.ini
+++ b/tools/tolua/cocos2dx_ui.ini
@@ -30,7 +30,7 @@ headers = %(cocosdir)s/cocos/ui/CocosGUI.h
 
 # what classes to produce code for. You can use regular expressions here. When testing the regular
 # expression, it will be enclosed in "^$", like this: "^Menu*$".
-classes = Helper Widget Layer Layout RootWidget Button CheckBox ImageView Text TextAtlas TextBMFont LoadingBar Slider Switch TextField ScrollView ListView PageView LayoutParameter LinearLayoutParameter RelativeLayoutParameter Rich.* HBox VBox RelativeBox Scale9Sprite
+classes = Helper Widget Layer Layout RootWidget Button CheckBox ImageView Text TextAtlas TextBMFont LoadingBar Slider Switch TextField ScrollView ListView PageView LayoutParameter LinearLayoutParameter RelativeLayoutParameter Rich.* HBox VBox RelativeBox Scale9Sprite EditBox
 
 # what should we skip? in the format ClassName::[function function]
 # ClassName is a regular expression, but will be used like this: "^ClassName$" functions are also
@@ -39,7 +39,7 @@ classes = Helper Widget Layer Layout RootWidget Button CheckBox ImageView Text T
 # will apply to all class names. This is a convenience wildcard to be able to skip similar named
 # functions from all classes.
 
-skip = *::[^visit$ copyWith.* onEnter.* onExit.* ^description$ getObjectType .*HSV onTouch.* onAcc.* onKey.* onRegisterTouchListener (s|g)etBlendFunc ccTouch.*],
+skip = *::[^visit$ copyWith.* onEnter.* onExit.* ^description$ getObjectType .*HSV onTouch.* onAcc.* onKey.* onRegisterTouchListener (s|g)etBlendFunc ccTouch.* (g|s)etDelegate],
         Widget::[(s|g)etUserObject],
         Layer::[getInputManager],
         LayoutParameter::[(s|g)etMargin],


### PR DESCRIPTION
1. add ui::EditBox Lua binding, deprecated cc.EditBox, please use ccui.EditBox instead
2. remove deprecated warnings
3. There is one caution about Lua module register order : 

```
 int lua_module_register(lua_State* L)
 {
      register_ui_moudle(L);
     register_extension_module(L);
    // other Lua modules
}
```

The `register_ui_module` must comes before the `resigter_extension_module`.
