### PR TITLE
fix memory leak when use menu_selector.

### DIFF
--- a/cocos/2d/CCMenuItem.cpp
+++ b/cocos/2d/CCMenuItem.cpp
@@ -97,6 +97,11 @@ bool MenuItem::initWithCallback(const ccMenuCallback& callback)
 
 MenuItem::~MenuItem()
 {
+}
+
+void MenuItem::onExit()
+{
+	Node::onExit();
 	CC_SAFE_RELEASE(_target);
 }
 

--- a/cocos/2d/CCMenuItem.h
+++ b/cocos/2d/CCMenuItem.h
@@ -81,6 +81,8 @@ public:
     /** returns whether or not the item is selected */
     virtual bool isSelected() const;
 
+	virtual void onExit() override;
+
     /** set the callback to the menu item
     * @code
     * In js,can contain two params,the second param is jsptr


### PR DESCRIPTION
1.MenuItemFont::create("reset", this, menu_selector(UpdateLayer::reset ));
2.MenuItemFont::create("reset", CC_CALLBACK_1(UpdateLayer::reset, this));

The first old style will cause memory leak:
the menuitem(child) owns the parent("this")'s reference,
the parent(this) owns the menuitem's reference.
At last they both can not release.

we can not release the target's reference in the menuitem's deconstructor.
or there is no need to retain the target when initialize the menuitem with menu_selector.
