### PR TITLE
Added font fallback for WP8 & WinRT

### DIFF
--- a/cocos2dx/platform/winrt/CCFreeTypeFont.h
+++ b/cocos2dx/platform/winrt/CCFreeTypeFont.h
@@ -93,10 +93,94 @@ public:
         int* outHeight
     );
 
-private:
-	unsigned char* loadFont(const char *pFontName, unsigned long *size);
+#if CC_TARGET_PLATFORM == CC_PLATFORM_WP8
 
-    unsigned char* CCFreeTypeFont::loadSystemFont(const char *pFontName, unsigned long *size);
+    /// <summary>
+    /// These are the officially supported WP8 fonts listed at:
+    /// http://msdn.microsoft.com/en-us/library/windows/apps/hh202920(v=vs.105).aspx
+    /// </summary>
+    enum class SystemFont
+    {
+        /* UI Fonts */
+        SEGOE_WP,               // Latin, Cyrillic, Greek, Arabic, and Hebrew–based languages
+        DENG_XIAN,              // Chinese (Simplified)
+        MICROSOFT_MHEI,         // Chinese (Traditional)
+        YU_GOTHIC,              // Japanese
+        MICROSOFT_NEO_GOTHIC,   // Korean
+        SEGOE_UI,               // Latin, Cyrillic, Greek, Arabic, and Hebrew–based languages
+        NIRMALA_UI,             // India languages
+        LEELAWADEE,             // Thai
+        SEGOE_UI_SYMBOL,        // Supports various Unicode symbols, including emoji symbols added in Unicode 6.0.
+
+        /* Text display fonts */
+        EBRIMA,                 // Nko, Ethiopic, Tifinagh, Vai, and Osmanya
+        ESTRANGELO_EDESSA,      // Syriac
+        GADUGI,                 // Cherokee, and Unified Canadian Aboriginal Syllabics
+        KHMER_UI,               // Khmer
+        LAO_UI,                 // Lao
+        MICROSOFT_HIMALAYA,     // Tibetan
+        MICROSOFT_NEW_TAI_LUE,  // New Tai Lue
+        MICROSOFT_TAI_LE,       // Tai Le
+        MICROSOFT_UIGHUR,       // Uighur
+        MICROSOFT_YI_BAITI,     // Yi
+        MONGOLIAN_BAITI,        // Mongolian
+        MV_BOLI,                // Thaana
+        PHAGS_PA,               // Phags-pa
+        SIM_SUN,                // Chinese (Simplified)
+        URDU_TYPESETTING,       // Arabic
+
+        /* Additional fonts */
+        ARIAL,
+        ARIAL_BLACK,
+        CALIBRI,
+        CALIBRI_LIGHT,
+        COMIC_SANS_MS,
+        COURIER_NEW,
+        GEORGIA,
+        LUCIDA_SANS_UNICODE,
+        TAHOMA,
+        TIMES_NEW_ROMAN,
+        TREBUCHET_MS,
+        VERDANA,
+
+        /* Mathematical and symbol fonts */
+        CAMBRIA_AND_CAMBRIA_MATH,
+        WINGDINGS,
+        WEBDINGS
+    };
+
+    /// <summary>Return the corresponding file name for the requested system font.</summary>
+    /// <param name="systemFont">The requested system font.</param>
+    /// <returns>The name of the curresponding system font.</returns>
+    static const char* getSystemFontFileName(SystemFont systemFont);
+
+#endif
+
+    /// <summary>
+    /// Strings is drawn one glyph at a time. If no glyph can be found for a given font then it normally prints out a square.
+    /// The fallback fonts are used when a glyph cannot be found for a string.
+    /// Setting the fallback fonts loads them to be used as fallbacks in case a glyph can't be found in the otherwise provided fonts.
+    /// E.g. When trying to print a chinese character when using Arial.
+    /// </summary>
+    /// <param name="fonts">These fonts will be used as fallback.</param>
+    /// <example> On Windows Phone 8 you could set fallback fonts like this:
+    /// <code>
+    /// std::vector&lt;const char*&gt; systemFonts;
+    /// systemFonts.push_back(CCFreeTypeFont::getSystemFontFileName(CCFreeTypeFont::SystemFont::MICROSOFT_NEO_GOTHIC));
+    /// systemFonts.push_back(CCFreeTypeFont::getSystemFontFileName(CCFreeTypeFont::SystemFont::DENG_XIAN));
+    /// systemFonts.push_back(CCFreeTypeFont::getSystemFontFileName(CCFreeTypeFont::SystemFont::MICROSOFT_MHEI));
+    /// systemFonts.push_back(CCFreeTypeFont::getSystemFontFileName(CCFreeTypeFont::SystemFont::YU_GOTHIC));
+    /// CCFreeTypeFont::setFallbackFonts(systemFonts);
+    /// </code>
+    /// Note that to include CCFreeTypeFont.h you will need to add the following to your C++ Include Directories:
+    /// $(ProjectDir)..\..\..\cocos2d-x\cocos2dx\platform\third_party\winrt\freetype\include;
+    /// </example>
+    static void setFallbackFonts(const std::vector<const char*>& fonts);
+
+private:
+	static unsigned char* loadFont(const char *pFontName, unsigned long *size);
+
+    static unsigned char* CCFreeTypeFont::loadSystemFont(const char *pFontName, unsigned long *size);
 
     FT_Error CCFreeTypeFont::initGlyphs(const char* text);
     FT_Error CCFreeTypeFont::initWordGlyphs(std::vector<TGlyph>& glyphs, const std::string& text, FT_Vector& pen);


### PR DESCRIPTION
Added the ability to add fallback fonts so that characters from different languages can be displayed on WP8/WinRT.

Implemented loading system fonts for WP8/WinRT.

Windows Phone 8 has a specific list of officially supported system fonts, and an `enum` has been created for each one so that they can be loaded.
