### PR TITLE
Update CCDevice-ios.mm

### DIFF
--- a/cocos/platform/ios/CCDevice-ios.mm
+++ b/cocos/platform/ios/CCDevice-ios.mm
@@ -479,7 +479,7 @@ Data Device::getTextureDataForText(const char * text, const FontDefinition& text
 
 void Device::setKeepScreenOn(bool value)
 {
-    [[UIApplication sharedApplication] setIdleTimerDisabled:YES];
+    [[UIApplication sharedApplication] setIdleTimerDisabled:(BOOL)value];
 }
 
 NS_CC_END


### PR DESCRIPTION
On iOS, Device::setKeepScreenOn(bool value) was ignoring the value and simply always disabling the timer.
