### PR TITLE
[CCLabel] Apply updateContent() for getStringNumLines() when Label is dirty

### DIFF
--- a/cocos/2d/CCLabel.cpp
+++ b/cocos/2d/CCLabel.cpp
@@ -1226,6 +1226,15 @@ void Label::computeStringNumLines()
     _currNumLines = quantityOfLines;
 }
 
+int Label::getStringNumLines() const {
+    if (_contentDirty)
+    {
+        const_cast<Label*>(this)->updateContent();
+    }
+
+    return _currNumLines;
+}
+
 int Label::getStringLength() const
 {
     return static_cast<int>(_currentUTF16String.length());

--- a/cocos/2d/CCLabel.h
+++ b/cocos/2d/CCLabel.h
@@ -235,7 +235,7 @@ public:
     float getAdditionalKerning() const;
 
     // string related stuff
-    int getStringNumLines() const { return _currNumLines;}
+    int getStringNumLines() const;
     int getStringLength() const;
 
     FontAtlas* getFontAtlas() { return _fontAtlas; }


### PR DESCRIPTION
getStringNumLines() does only returning _currNumLines, so, It will return incorrect value right after Label is changed.
To avoid above, if Label is dirty, call updateContent() before return _currNumLines.

Test:
This is tested on Mac
