### PR TITLE
bugfix for UI animation playing crash if GUI JSON file is loaded again.

### DIFF
--- a/cocos/editor-support/cocostudio/CCActionManagerEx.cpp
+++ b/cocos/editor-support/cocostudio/CCActionManagerEx.cpp
@@ -73,7 +73,7 @@ void ActionManagerEx::initWithDictionary(const char* jsonName,const rapidjson::V
 		action->initWithDictionary(actionDic,root);
 		actionList.pushBack(action);
 	}
-	_actionDic.insert(std::pair<std::string, cocos2d::Vector<ActionObject*>>(fileName, actionList));
+	_actionDic[fileName] = actionList;
 }
     
     void ActionManagerEx::initWithBinary(const char* file,
@@ -108,7 +108,7 @@ void ActionManagerEx::initWithDictionary(const char* jsonName,const rapidjson::V
                 actionList.pushBack(action);
             }
         }
-        _actionDic.insert(std::pair<std::string, cocos2d::Vector<ActionObject*>>(fileName, actionList));
+        _actionDic[fileName] = actionList;
         
     }
 


### PR DESCRIPTION
_actionDic is a std::unordered_map, the insert() function will not work if the key is already existed. If a UI JSON file is loaded by GUIReader more than once, the animation information should update in the internal _actionDic map, as the rootWidget pointer is different.

Detail see: http://blog.segmentfault.com/hongliang/1190000000659937
