### PR TITLE
Fix WP8 app exit with back button

### DIFF
--- a/cocos2dx/platform/wp8-xaml/Cocos2dRenderer.cpp
+++ b/cocos2dx/platform/wp8-xaml/Cocos2dRenderer.cpp
@@ -97,17 +97,18 @@ IAsyncAction^ Cocos2dRenderer::OnSuspending()
 // user pressed the Back Key on the phone
 void Cocos2dRenderer::OnBackKeyPress()
 {
-    // handle the backkey in your app here.
-    // call Cocos2dEvent::TerminateApp if it is time to exit your app.
-    // ie. the user is on your first page and wishes to exit your app.
-    // uncomment next line and comment TerminateApp to respond with keyBackClicked() in layers, remember to add init layer use setKeypadEnabled(true)
-    // CCDirector::sharedDirector()->getKeypadDispatcher()->dispatchKeypadMSG( ccKeypadMSGType::kTypeBackClicked );
-    m_delegate->Invoke(Cocos2dEvent::TerminateApp);
+    CCDirector::sharedDirector()->getKeypadDispatcher()->dispatchKeypadMSG(ccKeypadMSGType::kTypeBackClicked);
 }
 
 void Cocos2dRenderer::OnUpdateDevice()
 {
     CCEGLView* pEGLView = CCEGLView::sharedOpenGLView();
+
+    if (pEGLView->HasEnded())
+    {
+        m_delegate->Invoke(Cocos2dEvent::TerminateApp);
+    }
+
     pEGLView->UpdateDevice(m_eglDisplay, m_eglContext, m_eglSurface);
 }
 

--- a/cocos2dx/platform/wp8/CCEGLView.cpp
+++ b/cocos2dx/platform/wp8/CCEGLView.cpp
@@ -597,5 +597,9 @@ void CCEGLView::setScissorInPoints(float x , float y , float w , float h)
 	}
 }
 
+bool CCEGLView::HasEnded()
+{
+    return m_windowClosed;
+}
 
 NS_CC_END

--- a/cocos2dx/platform/wp8/CCEGLView.h
+++ b/cocos2dx/platform/wp8/CCEGLView.h
@@ -116,6 +116,7 @@ public:
 	
 	int Run();
 	void Render();
+    bool HasEnded();
 
     void resize(int width, int height);
     /* 


### PR DESCRIPTION
CEGLView end() is called from the CCDirector's
end() method, so we should terminate the app then.
