### PR TITLE
fixed crack on android when schedule mixed with "TimerTargetCallback" and other “Timer”

### DIFF
--- a/cocos/base/CCScheduler.cpp
+++ b/cocos/base/CCScheduler.cpp
@@ -311,8 +311,11 @@ void Scheduler::schedule(const ccSchedulerFunc& callback, void *target, float in
     {
         for (int i = 0; i < element->timers->num; ++i)
         {
-            TimerTargetCallback *timer = static_cast<TimerTargetCallback*>(element->timers->arr[i]);
-
+            TimerTargetCallback *timer = dynamic_cast<TimerTargetCallback*>(element->timers->arr[i]);
+            if (!timer)
+            {
+                continue;
+            }
             if (key == timer->getKey())
             {
                 CCLOG("CCScheduler#scheduleSelector. Selector already scheduled. Updating interval from: %.4f to %.4f", timer->getInterval(), interval);


### PR DESCRIPTION
when a node was scheduled with same “Timer” that is not "TimerTargetCallback", call "schedule" method with parameter "key", it will crack on same android devices at line "if (key == timer->getKey())".  
"static_cast" is an unsafe conversion from a pointer of a base class to a pointer of a derived class, timer->getKey() will access over range , so i think it should replace with "dynamic_cast".
