### PR TITLE
Added LongPressed touch event to ui::Widget.

### DIFF
--- a/cocos/ui/UIWidget.cpp
+++ b/cocos/ui/UIWidget.cpp
@@ -143,6 +143,7 @@ _brightStyle(BrightStyle::NONE),
 _touchBeganPosition(Vec2::ZERO),
 _touchMovePosition(Vec2::ZERO),
 _touchEndPosition(Vec2::ZERO),
+_longPressTime(0.0f),
 _touchEventListener(nullptr),
 _touchEventSelector(nullptr),
 _actionTag(0),
@@ -680,6 +681,16 @@ bool Widget::isSwallowTouches()const
     return false;
 }
 
+void Widget::setLongPressTime(float time)
+{
+    if (time <= 0.0f )
+    {
+        unschedule(schedule_selector(Widget::checkLongPress));
+    }
+
+    _longPressTime = time;
+}
+
 bool Widget::onTouchBegan(Touch *touch, Event *unusedEvent)
 {
     _hitted = false;
@@ -706,9 +717,24 @@ bool Widget::onTouchBegan(Touch *touch, Event *unusedEvent)
     }
   
     pushDownEvent();
+
+    if (_longPressTime > 0.0f)
+    {
+        scheduleOnce(schedule_selector(Widget::checkLongPress), _longPressTime);
+    }
     return true;
 }
     
+void Widget::checkLongPress(float dt)
+{
+    if (!_hitted)
+    {
+        return;
+    }
+
+    longPressEvent();
+}
+
 void Widget::propagateTouchEvent(cocos2d::ui::Widget::TouchEventType event, cocos2d::ui::Widget *sender, cocos2d::Touch *touch)
 {
     Widget* widgetParent = getWidgetParent();
@@ -722,7 +748,8 @@ void Widget::onTouchMoved(Touch *touch, Event *unusedEvent)
 {
     _touchMovePosition = touch->getLocation();
     
-    setHighlighted(hitTest(_touchMovePosition));
+    _hitted = hitTest(_touchMovePosition);
+    setHighlighted(_hitted);
     
     /*
      * Propagate touch events to its parents
@@ -749,7 +776,10 @@ void Widget::onTouchEnded(Touch *touch, Event *unusedEvent)
     
     bool highlight = _highlight;
     setHighlighted(false);
-    
+ 
+    unschedule(schedule_selector(Widget::checkLongPress));
+    _hitted = false;
+
     if (highlight)
     {
         releaseUpEvent();
@@ -764,6 +794,9 @@ void Widget::onTouchCancelled(Touch *touch, Event *unusedEvent)
 {
     setHighlighted(false);
     cancelUpEvent();
+
+    unschedule(schedule_selector(Widget::checkLongPress));
+    _hitted = false;
 }
 
 void Widget::pushDownEvent()
@@ -792,6 +825,21 @@ void Widget::moveEvent()
     if (_touchEventListener && _touchEventSelector)
     {
         (_touchEventListener->*_touchEventSelector)(this,TOUCH_EVENT_MOVED);
+    }
+    this->release();
+}
+
+void Widget::longPressEvent()
+{
+    this->retain();
+    if (_touchEventCallback)
+    {
+        _touchEventCallback(this, TouchEventType::LONGPRESSED);
+    }
+    
+    if (_touchEventListener && _touchEventSelector)
+    {
+        (_touchEventListener->*_touchEventSelector)(this,TOUCH_EVENT_LONGPRESSED);
     }
     this->release();
 }

--- a/cocos/ui/UIWidget.cpp
+++ b/cocos/ui/UIWidget.cpp
@@ -144,6 +144,7 @@ _touchBeganPosition(Vec2::ZERO),
 _touchMovePosition(Vec2::ZERO),
 _touchEndPosition(Vec2::ZERO),
 _longPressTime(0.0f),
+_longPressedTouch(false),
 _touchEventListener(nullptr),
 _touchEventSelector(nullptr),
 _actionTag(0),
@@ -691,9 +692,15 @@ void Widget::setLongPressTime(float time)
     _longPressTime = time;
 }
 
+bool Widget::isLongPressedTouch()const
+{
+    return _longPressedTouch;
+}
+
 bool Widget::onTouchBegan(Touch *touch, Event *unusedEvent)
 {
     _hitted = false;
+    _longPressedTouch = false;
     if (isVisible() && isEnabled() && isAncestorsEnabled() && isAncestorsVisible(this) )
     {
         _touchBeganPosition = touch->getLocation();
@@ -732,6 +739,7 @@ void Widget::checkLongPress(float dt)
         return;
     }
 
+    _longPressedTouch = true;
     longPressEvent();
 }
 

--- a/cocos/ui/UIWidget.h
+++ b/cocos/ui/UIWidget.h
@@ -544,6 +544,12 @@ public:
     void setLongPressTime(float time);
 
     /**
+     * @return  wheather this touch is long-pressed or not.
+     * It only works if you set _longPressTime >= 0, by calling setLongPressTime(time).
+     */
+    bool isLongPressedTouch() const;
+
+    /**
      *@return  whether the widget is focused or not
      */
     bool isFocused()const;
@@ -710,6 +716,7 @@ protected:
     Vec2 _touchEndPosition;
 
     float _longPressTime;
+    bool _longPressedTouch;
 
     bool _flippedX;
     bool _flippedY;

--- a/cocos/ui/UIWidget.h
+++ b/cocos/ui/UIWidget.h
@@ -43,7 +43,8 @@ typedef enum
     TOUCH_EVENT_BEGAN,
     TOUCH_EVENT_MOVED,
     TOUCH_EVENT_ENDED,
-    TOUCH_EVENT_CANCELED
+    TOUCH_EVENT_CANCELED,
+    TOUCH_EVENT_LONGPRESSED,
 }TouchEventType;
     
 typedef void (Ref::*SEL_TouchEvent)(Ref*,TouchEventType);
@@ -90,7 +91,8 @@ public:
         BEGAN,
         MOVED,
         ENDED,
-        CANCELED
+        CANCELED,
+        LONGPRESSED
     };
     
     enum class TextureResType
@@ -432,6 +434,8 @@ public:
     virtual void onTouchEnded(Touch *touch, Event *unusedEvent);
     virtual void onTouchCancelled(Touch *touch, Event *unusedEvent);
 
+    void checkLongPress(float dt);
+
     /**
      * Sets a LayoutParameter to widget.
      *
@@ -534,6 +538,11 @@ public:
      */
     bool isSwallowTouches()const;
     
+    /**
+     * @brief Specify long press time
+     */
+    void setLongPressTime(float time);
+
     /**
      *@return  whether the widget is focused or not
      */
@@ -649,6 +658,7 @@ protected:
 
     void pushDownEvent();
     void moveEvent();
+    void longPressEvent();
 
     virtual void releaseUpEvent();
     virtual void cancelUpEvent();
@@ -698,6 +708,8 @@ protected:
     Vec2 _touchBeganPosition;
     Vec2 _touchMovePosition;
     Vec2 _touchEndPosition;
+
+    float _longPressTime;
 
     bool _flippedX;
     bool _flippedY;

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIButtonTest/UIButtonTest.cpp
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIButtonTest/UIButtonTest.cpp
@@ -74,14 +74,14 @@ void UIButtonTest::touchEvent(Ref *pSender, Widget::TouchEventType type)
             
         case Widget::TouchEventType::ENDED:
         {
-            _displayValueLabel->setString(String::createWithFormat("Touch Up")->getCString());
+            Button *btn = (Button*)pSender;
+            _displayValueLabel->setString(String::createWithFormat(btn->isLongPressedTouch() ? "Touch Up (LongPressed)" : "Touch Up")->getCString());
             ImageView* imageView = (ImageView*)_uiLayer->getChildByTag(12);
             imageView->setVisible(false);
             imageView->loadTexture("cocosui/ccicon.png");
             imageView->setOpacity(0);
             imageView->setVisible(true);
             imageView->runAction(Sequence::create(FadeIn::create(0.5),DelayTime::create(1.0),FadeOut::create(0.5), nullptr));
-            Button *btn = (Button*)pSender;
             btn->loadTextureNormal("cocosui/animationbuttonnormal.png");
         }
             break;
@@ -170,11 +170,12 @@ void UIButtonTest_Scale9::touchEvent(Ref *pSender, Widget::TouchEventType type)
             
         case Widget::TouchEventType::ENDED:
         {
-            _displayValueLabel->setString(String::createWithFormat("Touch Up")->getCString());
-            Button *btn = (Button*)_uiLayer->getChildByName("normal");
-            btn->loadTextureNormal("cocosui/animationbuttonnormal.png");
-            btn->loadTexturePressed("cocosui/animationbuttonpressed.png");
-            btn->runAction(Sequence::create(FadeIn::create(0.5),DelayTime::create(1.0),FadeOut::create(0.5), nullptr));
+            Button *btn = (Button*)pSender;
+            _displayValueLabel->setString(String::createWithFormat(btn->isLongPressedTouch() ? "Touch Up (LongPressed)" : "Touch Up")->getCString());
+            Button *btn2 = (Button*)_uiLayer->getChildByName("normal");
+            btn2->loadTextureNormal("cocosui/animationbuttonnormal.png");
+            btn2->loadTexturePressed("cocosui/animationbuttonpressed.png");
+            btn2->runAction(Sequence::create(FadeIn::create(0.5),DelayTime::create(1.0),FadeOut::create(0.5), nullptr));
         }
             break;
             

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIButtonTest/UIButtonTest.cpp
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIButtonTest/UIButtonTest.cpp
@@ -41,6 +41,7 @@ bool UIButtonTest::init()
         button->addTouchEventListener(CC_CALLBACK_2(UIButtonTest::touchEvent, this));
         button->setZoomScale(0.4);
         button->setPressedActionEnabled(true);
+        button->setLongPressTime(1.0f);
         _uiLayer->addChild(button);
         button->setOpacity(100);
         // Create the imageview
@@ -89,6 +90,10 @@ void UIButtonTest::touchEvent(Ref *pSender, Widget::TouchEventType type)
             _displayValueLabel->setString(String::createWithFormat("Touch Cancelled")->getCString());
             break;
             
+        case Widget::TouchEventType::LONGPRESSED:
+            _displayValueLabel->setString(String::createWithFormat("Touch LongPressed")->getCString());
+            break;
+            
         default:
             break;
     }
@@ -133,6 +138,7 @@ bool UIButtonTest_Scale9::init()
         button->setPosition(Vec2(widgetSize.width / 2.0f, widgetSize.height / 2.0f));
         button->setContentSize(Size(150, 70));
         button->setPressedActionEnabled(true);
+        button->setLongPressTime(1.0f);
         button->addTouchEventListener(CC_CALLBACK_2(UIButtonTest_Scale9::touchEvent, this));
         _uiLayer->addChild(button);
         
@@ -174,6 +180,10 @@ void UIButtonTest_Scale9::touchEvent(Ref *pSender, Widget::TouchEventType type)
             
         case Widget::TouchEventType::CANCELED:
             _displayValueLabel->setString(String::createWithFormat("Touch Cancelled")->getCString());
+            break;
+            
+        case Widget::TouchEventType::LONGPRESSED:
+            _displayValueLabel->setString(String::createWithFormat("Touch LongPressed")->getCString());
             break;
             
         default:


### PR DESCRIPTION
Many games(mostly on Japanese - Puzzle & Dragons, ..) are using
LongPressed touch action. (to show information?)

It only works if Widget::setLongPressTime(time) is set.
