### PR TITLE
Fix copy files in cpp-empty-test in MSVC build

### DIFF
--- a/tests/cpp-empty-test/CMakeLists.txt
+++ b/tests/cpp-empty-test/CMakeLists.txt
@@ -52,12 +52,12 @@ if(MSVC)
   #get our dlls
   add_custom_command(TARGET ${APP_NAME} PRE_BUILD
                      COMMAND ${CMAKE_COMMAND} -E copy
-                     ${CMAKE_CURRENT_SOURCE_DIR}/../../../external/win32-specific/gles/prebuilt/glew32.dll 
+                     ${CMAKE_CURRENT_SOURCE_DIR}/../../external/win32-specific/gles/prebuilt/glew32.dll 
 					 ${CMAKE_CURRENT_BINARY_DIR})
 
   add_custom_command(TARGET ${APP_NAME} PRE_BUILD
                      COMMAND ${CMAKE_COMMAND} -E copy
-                     ${CMAKE_CURRENT_SOURCE_DIR}/../../../external/win32-specific/zlib/prebuilt/zlib1.dll 
+                     ${CMAKE_CURRENT_SOURCE_DIR}/../../external/win32-specific/zlib/prebuilt/zlib1.dll 
 					 ${CMAKE_CURRENT_BINARY_DIR}/Debug)
 
   #Visual Studio Defaults to wrong type


### PR DESCRIPTION
I had problems when compiling cpp-tests with MSVC. And I spotted one mistake here.
Must change from

```
${CMAKE_CURRENT_SOURCE_DIR}/../../../external/<.........>
```

to

```
${CMAKE_CURRENT_SOURCE_DIR}/../../external/<.........>
```

because `${CMAKE_CURRENT_SOURCE_DIR}` is `<cocos2d>/tests/cpp-empty-test/`. 
