### PR TITLE
Adds lambda support in node

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,9 +1,10 @@
-cocos2d-x-3.3
+cocos2d-x-3.3-beta1
     [NEW]           3d: added light support: direction light, point light, spot light and ambient light
     [NEW]           Audio: new audio supports Mac OS X and Windows
     [NEW]           Application: added openUrl()
     [NEW]           Armature: added getOffsetPoints()
     [NEW]           Lua-binding: added Camera3DTest ,BillBoradTest
+    [NEW]           Node: schedule/unschedule lambda functions
     [NEW]           Rect: added merge()
     [NEW]           Utils: added getCascadeBoundingBox()
     [NEW]           UI: `WebView` support on windows
@@ -19,7 +20,7 @@ cocos2d-x-3.3
     [FIX]           New audio: can not play audio after playing some times on Android
     [FIX]           TextFieldTTF: will get wrong characters if using Chinese input method on WP8
 
-cocos2d-x-3.3  Sep.20 2014
+cocos2d-x-3.3-beta0  Sep.20 2014
     [NEW]           3d: added `BillBoard`
     [NEW]           ActionManager: added removeAllActionsByTag()
     [NEW]           Audio: added new audio system for iOS and Android

--- a/cocos/2d/CCNode.cpp
+++ b/cocos/2d/CCNode.cpp
@@ -1493,6 +1493,11 @@ bool Node::isScheduled(SEL_SCHEDULE selector)
     return _scheduler->isScheduled(selector, this);
 }
 
+bool Node::isScheduled(const std::string &key)
+{
+    return _scheduler->isScheduled(key, this);
+}
+
 void Node::scheduleUpdate()
 {
     scheduleUpdateWithPriority(0);
@@ -1545,9 +1550,24 @@ void Node::schedule(SEL_SCHEDULE selector, float interval, unsigned int repeat, 
     _scheduler->schedule(selector, this, interval , repeat, delay, !_running);
 }
 
+void Node::schedule(const std::function<void(float)> &callback, float interval, const std::string &key)
+{
+    _scheduler->schedule(callback, this, interval, !_running, key);
+}
+
+void Node::schedule(const std::function<void(float)>& callback, float interval, unsigned int repeat, float delay, const std::string &key)
+{
+    _scheduler->schedule(callback, this, interval, repeat, delay, !_running, key);
+}
+
 void Node::scheduleOnce(SEL_SCHEDULE selector, float delay)
 {
     this->schedule(selector, 0.0f, 0, delay);
+}
+
+void Node::scheduleOnce(const std::function<void(float)> &callback, float delay, const std::string &key)
+{
+    _scheduler->schedule(callback, this, 0, 0, delay, !_running, key);
 }
 
 void Node::unschedule(SEL_SCHEDULE selector)
@@ -1557,6 +1577,11 @@ void Node::unschedule(SEL_SCHEDULE selector)
         return;
     
     _scheduler->unschedule(selector, this);
+}
+
+void Node::unschedule(const std::string &key)
+{
+    _scheduler->unschedule(key, this);
 }
 
 void Node::unscheduleAllSelectors()

--- a/cocos/2d/CCNode.h
+++ b/cocos/2d/CCNode.h
@@ -1195,6 +1195,16 @@ public:
     bool isScheduled(SEL_SCHEDULE selector);
 
     /**
+     * Checks whether a lambda function is scheduled.
+     *
+     * @param key      key of the callback
+     * @return Whether the lambda function selector is scheduled.
+     * @js NA
+     * @lua NA
+     */
+    bool isScheduled(const std::string &key);
+
+    /**
      * Schedules the "update" method.
      *
      * It will use the order number 0. This method will be called every frame.
@@ -1262,6 +1272,16 @@ public:
     void scheduleOnce(SEL_SCHEDULE selector, float delay);
 
     /**
+     * Schedules a lambda function that runs only once, with a delay of 0 or larger
+     *
+     * @param callback      The lambda function to be scheduled
+     * @param delay         The amount of time that the first tick will wait before execution.
+     * @param key           The key of the lambda function. To be used if you want to unschedule it
+     * @lua NA
+     */
+    void scheduleOnce(const std::function<void(float)>& callback, float delay, const std::string &key);
+
+    /**
      * Schedules a custom selector, the scheduled selector will be ticked every frame
      * @see schedule(SEL_SCHEDULE, float, unsigned int, float)
      *
@@ -1269,6 +1289,28 @@ public:
      * @lua NA
      */
     void schedule(SEL_SCHEDULE selector);
+
+    /**
+     * Schedules a lambda function. The scheduled lambda function will be called every frame
+     *
+     * @param callback      The lambda function to be scheduled
+     * @param interval      Callback interval time in seconds. 0 means every frame,
+     * @param key           The key of the lambda function. To be used if you want to unschedule it
+     * @lua NA
+     */
+    void schedule(const std::function<void(float)>& callback, float interval, const std::string &key);
+
+    /**
+     * Schedules a lambda function.
+     *
+     * @param callback  The lambda function to be schedule
+     * @param interval  Tick interval in seconds. 0 means tick every frame. If interval = 0, it's recommended to use scheduleUpdate() instead.
+     * @param repeat    The selector will be excuted (repeat + 1) times, you can use kRepeatForever for tick infinitely.
+     * @param delay     The amount of time that the first tick will wait before execution.
+     * @param key       The key of the lambda function. To be used if you want to unschedule it
+     * @lua NA
+     */
+    void schedule(const std::function<void(float)>& callback, float interval, unsigned int repeat, float delay, const std::string &key);
 
     /**
      * Unschedules a custom selector.
@@ -1280,7 +1322,15 @@ public:
     void unschedule(SEL_SCHEDULE selector);
 
     /**
-     * Unschedule all scheduled selectors: custom selectors, and the 'update' selector.
+     * Unschedules a lambda function
+     *
+     * @param key      The key of the lambda function to be unscheduled
+     * @lua NA
+     */
+    void unschedule(const std::string &key);
+
+    /**
+     * Unschedule all scheduled selectors and lambda functions: custom selectors, and the 'update' selector and lambda functions
      * Actions are not affected by this method.
      * @lua NA
      */

--- a/tests/cpp-tests/Classes/NodeTest/NodeTest.cpp
+++ b/tests/cpp-tests/Classes/NodeTest/NodeTest.cpp
@@ -64,6 +64,7 @@ static std::function<Layer*()> createFunctions[] =
     CL(NodeToWorld),
     CL(NodeToWorld3D),
     CL(SchedulerTest1),
+    CL(SchedulerCallbackTest),
     CL(CameraOrbitTest),
     // TODO: Camera has been removed from CCNode, add new feature to support it
     //CL(CameraZoomTest),
@@ -75,6 +76,8 @@ static std::function<Layer*()> createFunctions[] =
     CL(NodeNormalizedPositionTest2),
     CL(NodeNormalizedPositionBugTest),
     CL(NodeNameTest),
+
+    CL(SchedulerCallbackTest),
 };
 
 #define MAX_LAYER    (sizeof(createFunctions) / sizeof(createFunctions[0]))
@@ -487,6 +490,46 @@ void SchedulerTest1::doSomething(float dt)
 std::string SchedulerTest1::subtitle() const
 {
     return "cocosnode scheduler test #1";
+}
+
+//------------------------------------------------------------------
+//
+// SchedulerCallbackTest
+//
+//------------------------------------------------------------------
+SchedulerCallbackTest::SchedulerCallbackTest()
+{
+    auto node = Node::create();
+    addChild(node, 0);
+    node->setName("a node");
+
+    _total = 0;
+    node->schedule([&](float dt) {
+        _total += dt;
+        log("hello world: %f - total: %f", dt, _total);
+    }
+                   ,0.5
+                   ,"some_key");
+
+
+    node->scheduleOnce([&](float dt) {
+        // the local variable "node" will go out of scope, so I have to get it from "this"
+        auto anode = this->getChildByName("a node");
+        anode->unschedule("some_key");
+    }
+                       ,5
+                       ,"ignore_key");
+}
+
+void SchedulerCallbackTest::onEnter()
+{
+    TestCocosNodeDemo::onEnter();
+    log("--onEnter-- Must be called before the scheduled lambdas");
+}
+
+std::string SchedulerCallbackTest::subtitle() const
+{
+    return "Node scheduler with lambda";
 }
 
 //------------------------------------------------------------------

--- a/tests/cpp-tests/Classes/NodeTest/NodeTest.h
+++ b/tests/cpp-tests/Classes/NodeTest/NodeTest.h
@@ -128,6 +128,19 @@ protected:
     SchedulerTest1();
 };
 
+class SchedulerCallbackTest : public TestCocosNodeDemo
+{
+public:
+    CREATE_FUNC(SchedulerCallbackTest);
+    virtual std::string subtitle() const override;
+    virtual void onEnter() override;
+
+protected:
+    float _total;
+    SchedulerCallbackTest();
+};
+
+
 class NodeToWorld : public TestCocosNodeDemo
 {
 public:


### PR DESCRIPTION
It is now possible to schedule lambda functions in Node::schedule()
No need to subclass
