### PR TITLE
the android library path in proj.andriod/project.properties file is wrong

### DIFF
--- a/templates/cpp-template-default/proj.android/project.properties
+++ b/templates/cpp-template-default/proj.android/project.properties
@@ -10,4 +10,4 @@
 # Project target.
 target=android-10
 
-android.library.reference.1=../../../cocos/platform/android/java
+android.library.reference.1=../cocos2d/cocos/platform/android/java


### PR DESCRIPTION
if you run the following command in your game forder 

cocos run -p android

it will give you the following error since the path is wrong

BUILD FAILED
/Users/lifeng/dev/adt_bundle_mac/sdk/tools/ant/build.xml:459: ../../../cocos/platform/android/java resolve to a path with no project.properties file for project /Users/lifeng/study/cosco2dx/MyFirstGame/proj.android
