### PR TITLE
Fix UIButton Scale 9 Highlight

### DIFF
--- a/cocos/ui/UIButton.cpp
+++ b/cocos/ui/UIButton.cpp
@@ -374,11 +374,19 @@ void Button::onPressStateChangedToNormal()
     }
     else
     {
-        _buttonNormalRenderer->stopAllActions();
-        _buttonNormalRenderer->setScale(_normalTextureScaleXInSize, _normalTextureScaleYInSize);
-        _titleRenderer->stopAllActions();
-        _titleRenderer->setScaleX(_normalTextureScaleXInSize);
-        _titleRenderer->setScaleY(_normalTextureScaleYInSize);
+        if (_scale9Enabled)
+        {
+            _buttonNormalRenderer->setColor(Color3B::WHITE);
+        }
+        else
+        {
+            _buttonNormalRenderer->stopAllActions();
+            _buttonNormalRenderer->setScale(_normalTextureScaleXInSize, _normalTextureScaleYInSize);
+            
+            _titleRenderer->stopAllActions();
+            _titleRenderer->setScaleX(_normalTextureScaleXInSize);
+            _titleRenderer->setScaleY(_normalTextureScaleYInSize);
+        }
     }
 }
 


### PR DESCRIPTION
Currently, when you press a UIButton with Scale 9 enabled that doesn't have a pressed texture, the button is tinted gray. When you let go of the button, the button remains gray. This pull request reverts the tint.
