### PR TITLE
mingw64: mirgrate to upstream minizip

### DIFF
--- a/cocos/base/ZipUtils.cpp
+++ b/cocos/base/ZipUtils.cpp
@@ -36,6 +36,12 @@
 #include "platform/CCFileUtils.h"
 #include <map>
 
+// FIXME: Other platforms should use upstream minizip like mingw-w64  
+#ifdef __MINGW32__
+#define unzGoToFirstFile64(A,B,C,D) unzGoToFirstFile2(A,B,C,D, NULL, 0, NULL, 0)
+#define unzGoToNextFile64(A,B,C,D) unzGoToNextFile2(A,B,C,D, NULL, 0, NULL, 0)
+#endif
+
 NS_CC_BEGIN
 
 unsigned int ZipUtils::s_uEncryptedPvrKeyParts[4] = {0,0,0,0};

--- a/cocos/platform/CCFileUtils.cpp
+++ b/cocos/platform/CCFileUtils.cpp
@@ -648,7 +648,12 @@ unsigned char* FileUtils::getFileDataFromZip(const std::string& zipFilePath, con
         file = unzOpen(zipFilePath.c_str());
         CC_BREAK_IF(!file);
 
+        // FIXME: Other platforms should use upstream minizip like mingw-w64  
+        #ifdef __MINGW32__
+        int ret = unzLocateFile(file, filename.c_str(), NULL);
+        #else
         int ret = unzLocateFile(file, filename.c_str(), 1);
+        #endif
         CC_BREAK_IF(UNZ_OK != ret);
 
         char filePathA[260];


### PR DESCRIPTION
This is to add support for upstream minizip located here
https://github.com/nmoinvaz/minizip
I added a FIXME note for other platforms.
So that this must be added to cocos3 3rd party sources and bins for them

I have submitted a PR to this repo to add support for a function only in the cocos
https://github.com/nmoinvaz/minizip/pull/17

Hopefully when that is merged we can use this as our upstream :)
