### PR TITLE
Fix one memory leak of removeFromParentAndCleanup in cocos2dx 2.x

### DIFF
--- a/extensions/CocoStudio/GUI/BaseClasses/UIWidget.cpp
+++ b/extensions/CocoStudio/GUI/BaseClasses/UIWidget.cpp
@@ -228,8 +228,21 @@ void Widget::removeChild(CCNode *child)
 
 void Widget::removeChild(CCNode *child, bool cleanup)
 {
+    Widget* pChildWidget = dynamic_cast<Widget*>(child); //check if the child is a Widget?
     CCNode::removeChild(child, cleanup);
     _widgetChildren->removeObject(child);
+    if(pChildWidget) 
+    {
+        _widgetChildren->removeObject(child);   
+    } 
+    else 
+    {
+        //Because Widget only supports Widgets as children, 
+        //so if child is not a widget, this will lead to memory leak!!!
+        //For example,when you call child->removeFromParentAndCleanup()
+        //neilwu (wuyupeng2007(AT)gmail.com) modify
+        _nodes->removeObject(child); 
+    }
 }
 
 void Widget::removeChildByTag(int tag, bool cleanup)


### PR DESCRIPTION
//neilwu (wuyupeng2007(AT)gmail.com) modify
Because Widget only supports Widgets as children, so if child is not a widget, 
when you call child->removeFromParentAndCleanup(), this will lead to memory leak!!! 

The following code show detail info about this bug:
    //....(TODO:load armature res)
    UIImageView\* pbg = UIImageView::create();
    pbg->loadTexture("CloseNormal.png");
    pbg->setPosition(ccp(200, 100));
    addChild(pbg);
    CCArmature\* armature = CCArmature::create("demo_armature"); //TODO:you need preload som demo res
    pbg->addNode(armature, 1, 111);

```
//check this:
armature->removeFromParentAndCleanup(true); //This will lead the bug.
```
