### PR TITLE
fix light uniform array errors, and using shader without light by defaul...

### DIFF
--- a/cocos/3d/CCSprite3D.cpp
+++ b/cocos/3d/CCSprite3D.cpp
@@ -300,15 +300,10 @@ void Sprite3D::createAttachSprite3DNode(NodeData* nodedata,const MaterialDatas& 
         createAttachSprite3DNode(it,matrialdatas);
     }
 }
-void Sprite3D::genGLProgramState()
+void Sprite3D::genGLProgramState(bool useLight)
 {
-    const auto& lights = Director::getInstance()->getRunningScene()->getLights();
-    _shaderUsingLight = false;
-    for (const auto light : lights) {
-        _shaderUsingLight = ((unsigned int)light->getLightFlag() & _lightMask) > 0;
-        if (_shaderUsingLight)
-            break;
-    }
+    _shaderUsingLight = useLight;
+    
     std::unordered_map<const MeshVertexData*, GLProgramState*> glProgramestates;
     for(auto& mesh : _meshVertexDatas)
     {
@@ -532,7 +527,7 @@ void Sprite3D::draw(Renderer *renderer, const Mat4 &transform, uint32_t flags)
             break;
     }
     if (usingLight != _shaderUsingLight)
-        genGLProgramState();
+        genGLProgramState(usingLight);
     
     int i = 0;
     for (auto& mesh : _meshes) {

--- a/cocos/3d/CCSprite3D.h
+++ b/cocos/3d/CCSprite3D.h
@@ -137,7 +137,7 @@ CC_CONSTRUCTOR_ACCESS:
     virtual void draw(Renderer *renderer, const Mat4 &transform, uint32_t flags) override;
     
     /**generate default GLProgramState*/
-    void genGLProgramState();
+    void genGLProgramState(bool useLight = false);
 
     void createNode(NodeData* nodedata, Node* root, const MaterialDatas& matrialdatas, bool singleSprite);
     void createAttachSprite3DNode(NodeData* nodedata,const MaterialDatas& matrialdatas);

--- a/cocos/renderer/CCGLProgram.cpp
+++ b/cocos/renderer/CCGLProgram.cpp
@@ -360,7 +360,7 @@ void GLProgram::parseUniforms()
                 if(strncmp("CC_", uniformName, 3) != 0) {
 
                     // remove possible array '[]' from uniform name
-                    if(uniform.size > 1 && length > 3)
+                    if(length > 3)
                     {
                         char* c = strrchr(uniformName, '[');
                         if(c)

--- a/cocos/renderer/CCMeshCommand.h
+++ b/cocos/renderer/CCMeshCommand.h
@@ -94,7 +94,7 @@ protected:
     
     void MatrixPalleteCallBack( GLProgram* glProgram, Uniform* uniform);
 
-    void setLightUniformNames();
+    void resetLightUniformValues();
 
     GLuint _textureID;
     GLProgramState* _glProgramState;


### PR DESCRIPTION
...t fix #8612 
1. light using uniform array bugs.
   GLProgram parse uniform array error, failed to parse array with one elements.
   Set uniform array values use the method from GLPrgram instead.
2. Sprite3D uses shader without light by default.
   So that fix issue #8612 
