### PR TITLE
fix loading bar display bug when sprite frame is trimmed

### DIFF
--- a/cocos/base/CCScheduler.cpp
+++ b/cocos/base/CCScheduler.cpp
@@ -447,6 +447,7 @@ void Scheduler::appendIn(_listEntry **list, const ccSchedulerFunc& callback, voi
     listElement->callback = callback;
     listElement->target = target;
     listElement->paused = paused;
+    listElement->priority = 0;
     listElement->markedForDeletion = false;
 
     DL_APPEND(*list, listElement);

--- a/cocos/renderer/CCTextureCache.cpp
+++ b/cocos/renderer/CCTextureCache.cpp
@@ -433,6 +433,8 @@ bool TextureCache::reloadTexture(const std::string& fileName)
             CC_BREAK_IF(!bRet);
             
             ret = texture->initWithImage(image);
+            
+            CC_SAFE_RELEASE(image);
         } while (0);
     }
 

--- a/cocos/ui/UILoadingBar.cpp
+++ b/cocos/ui/UILoadingBar.cpp
@@ -25,6 +25,7 @@ THE SOFTWARE.
 #include "ui/UILoadingBar.h"
 #include "ui/UIScale9Sprite.h"
 #include "2d/CCSprite.h"
+#include "2d/CCSpriteFrameCache.h"
 
 NS_CC_BEGIN
 
@@ -41,6 +42,7 @@ _totalLength(0),
 _barRenderer(nullptr),
 _renderBarTexType(TextureResType::LOCAL),
 _barRendererTextureSize(Size::ZERO),
+_barRendererTextureRect(Rect::ZERO),
 _scale9Enabled(false),
 _prevIgnoreSize(true),
 _capInsets(Rect::ZERO),
@@ -143,6 +145,14 @@ void LoadingBar::loadTexture(const std::string& texture,TextureResType texType)
     }
     
     _barRendererTextureSize = _barRenderer->getContentSize();
+
+    SpriteFrameCache *cache = SpriteFrameCache::getInstance();
+    SpriteFrame *spriteFrame = cache->getSpriteFrameByName(texture);
+
+    if (spriteFrame)
+    {
+        _barRendererTextureRect = spriteFrame->getRect();
+    }
     
     switch (_direction)
     {
@@ -231,8 +241,11 @@ void LoadingBar::setPercent(float percent)
     {
         Sprite* spriteRenderer = _barRenderer->getSprite();
         Rect rect = spriteRenderer->getTextureRect();
-        rect.size.width = _barRendererTextureSize.width * res;
-        spriteRenderer->setTextureRect(rect, spriteRenderer->isTextureRectRotated(), rect.size);
+        rect.size = _barRendererTextureRect.size;
+        rect.size.width *= res;
+        Size size = _barRendererTextureSize;
+        size.width = rect.size.width + _barRendererTextureSize.width - _barRendererTextureRect.size.width;
+        spriteRenderer->setTextureRect(rect, spriteRenderer->isTextureRectRotated(), size);
     }
 }
 

--- a/cocos/ui/UILoadingBar.h
+++ b/cocos/ui/UILoadingBar.h
@@ -157,6 +157,7 @@ protected:
     Scale9Sprite* _barRenderer;
     TextureResType _renderBarTexType;
     Size _barRendererTextureSize;
+    Rect _barRendererTextureRect;
     bool _scale9Enabled;
     bool _prevIgnoreSize;
     Rect _capInsets;


### PR DESCRIPTION
there is a display bug when sprite frame texture rect size not equal to
the origion size.
