### PR TITLE
decrease logging verbosity - CCFileUtils-android

### DIFF
--- a/cocos/platform/android/CCFileUtils-android.cpp
+++ b/cocos/platform/android/CCFileUtils-android.cpp
@@ -208,7 +208,7 @@ Data FileUtilsAndroid::getData(const std::string& filename, bool forString)
         } else {
             relativePath += fullPath;
         }
-        LOGD("relative path = %s", relativePath.c_str());
+        CCLOGINFO("relative path = %s", relativePath.c_str());
 
         if (nullptr == FileUtilsAndroid::assetmanager) {
             LOGD("... FileUtilsAndroid::assetmanager is nullptr");


### PR DESCRIPTION
Currently there's a LogCat message for each resource loaded on Android, which can't be disabled via compiler switches.
Solution - replace LOGD with CCLOGINFO for this.
