### PR TITLE
Changed deprecated LabelTTF::create() to Label::createWithTTF() in the H...

### DIFF
--- a/templates/cpp-template-default/Classes/HelloWorldScene.cpp
+++ b/templates/cpp-template-default/Classes/HelloWorldScene.cpp
@@ -54,7 +54,7 @@ bool HelloWorld::init()
     // add a label shows "Hello World"
     // create and initialize a label
     
-    auto label = LabelTTF::create("Hello World", "Arial", 24);
+    auto label = Label::createWithTTF("Hello World", "Arial", 24);
     
     // position the label on the center of the screen
     label->setPosition(Vec2(origin.x + visibleSize.width/2,

--- a/templates/cpp-template-default/Classes/HelloWorldScene.h
+++ b/templates/cpp-template-default/Classes/HelloWorldScene.h
@@ -10,7 +10,7 @@ public:
     static cocos2d::Scene* createScene();
 
     // Here's a difference. Method 'init' in cocos2d-x returns bool, instead of returning 'id' in cocos2d-iphone
-    virtual bool init();  
+    virtual bool init();
     
     // a selector callback
     void menuCloseCallback(cocos2d::Ref* pSender);


### PR DESCRIPTION
...elloWorld

The `HelloWorldScene.cpp` was still using `LabelTTF` which was marked as deprecated in #6039.
It has been changed to `Label::createWithTTF()`.
