### PR TITLE
add libprotobuf-dev to build/install-linux-dep.sh

### DIFF
--- a/build/install-deps-linux.sh
+++ b/build/install-deps-linux.sh
@@ -21,6 +21,7 @@ DEPENDS+=' libfontconfig1-dev'
 DEPENDS+=' libsqlite3-dev'
 DEPENDS+=' libglew*-dev'
 DEPENDS+=' libssl-dev'
+DEPENDS+=' libprotobuf-dev'
 
 MISSING=
 echo "Checking for missing packages ..."


### PR DESCRIPTION
https://github.com/cocos2d/cocos2d-x/blob/v3/cocos/editor-support/cocostudio/CSParseBinary.pb.h 
This file include Protobuf Buffers headers file, project will build failure when missing libprotobuf-dev, add  libprotobuf-dev to fix it.
