### PR TITLE
add needed link library for linux

### DIFF
--- a/cocos/CMakeLists.txt
+++ b/cocos/CMakeLists.txt
@@ -145,7 +145,7 @@ if(MINGW)
 elseif(WINDOWS)
   set(PLATFORM_SPECIFIC_LIBS libjpeg libpng libwebp libtiff libcurl_imp libwebsockets freetype250 glfw3 glew32 opengl32 libiconv libzlib)
 elseif(LINUX)
-  set(PLATFORM_SPECIFIC_LIBS jpeg webp tiff freetype curl websockets
+  set(PLATFORM_SPECIFIC_LIBS jpeg webp tiff freetype curl websockets ssl crypto
   fontconfig png pthread glfw GLEW GL X11 rt z protobuf ${FMOD_LIB})
 elseif(MACOSX OR APPLE)
  INCLUDE_DIRECTORIES ( /System/Library/Frameworks )


### PR DESCRIPTION
when i try to link with libcocos2d.a in linux , got this error

```
/usr/bin/ld: /home/joshua/github/cocos2d-js/frameworks/js-bindings/cocos2d-x/external/websockets/prebuilt/linux/64-bit/libwebsockets.a(client.c.o): undefined reference to symbol 'BIO_ctrl@@OPENSSL_1.0.0'
//lib/x86_64-linux-gnu/libcrypto.so.1.0.0: error adding symbols: DSO missing from command line
```

after adding ssl and crypto , everything turns ok
