### PR TITLE
* change default opacity value

### DIFF
--- a/cocos/2d/CCLayer.cpp
+++ b/cocos/2d/CCLayer.cpp
@@ -499,7 +499,7 @@ LayerColor * LayerColor::create(const Color4B& color)
 bool LayerColor::init()
 {
     Size s = Director::getInstance()->getWinSize();
-    return initWithColor(Color4B(0,0,0,0), s.width, s.height);
+    return initWithColor(Color4B(0,0,0,255), s.width, s.height);
 }
 
 bool LayerColor::initWithColor(const Color4B& color, GLfloat w, GLfloat h)


### PR DESCRIPTION
If the default opacity value is 0 and you don't change it, when you want to set another color by calling setColor(const Color3B&), you must call setOpacity(GLubyte) also to set another non-zero opacity value, otherwise, you still have a black LayerColor. Sometime, it can make someone confused.
