### PR TITLE
fixed bug of definition of utils:: getCascadeBoundingBox()

### DIFF
--- a/cocos/base/ccUtils.h
+++ b/cocos/base/ccUtils.h
@@ -86,7 +86,7 @@ namespace utils
     /**
      * calculate all children's boundingBox
      */
-    Rect getCascadeBoundingBox(Node *node);
+    Rect CC_DLL getCascadeBoundingBox(Node *node);
 }
 
 NS_CC_END


### PR DESCRIPTION
"CC_DLL" is needed in VS
