### PR TITLE
Cmake fix modules include path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ project (Cocos2d-X)
 set(COCOS2D_X_VERSION 3.3.0-beta0)
 
 include(cmake/BuildHelpers.CMakeLists.txt)
-set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/Modules/")
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${PROJECT_SOURCE_DIR}/cmake/Modules/")
 
 message(${BUILDING_STRING})
 


### PR DESCRIPTION
This change allow to include cocos project directory from another CMakeFiles.txt (with add_subdirectory). And allow to us connect cocos as submodule in our own projects and build it with projects itself.
