### PR TITLE
closed #8843: Fixes DrawNode::drawPoint crash and uses VAO if it's available when draw points.

### DIFF
--- a/cocos/scripting/lua-bindings/manual/LuaBasicConversions.cpp
+++ b/cocos/scripting/lua-bindings/manual/LuaBasicConversions.cpp
@@ -2922,7 +2922,7 @@ void ccvector_std_string_to_luaval(lua_State* L, const std::vector<std::string>&
     
     int index = 1;
     
-    for (const std::string value : inValue)
+    for (const std::string& value : inValue)
     {
         lua_pushnumber(L, (lua_Number)index);
         lua_pushstring(L, value.c_str());

--- a/tests/cpp-tests/Classes/DrawPrimitivesTest/DrawPrimitivesTest.cpp
+++ b/tests/cpp-tests/Classes/DrawPrimitivesTest/DrawPrimitivesTest.cpp
@@ -375,6 +375,10 @@ DrawNodeTest::DrawNodeTest()
 
 	// Draw triangle
     draw->drawTriangle(Vec2(10, 10), Vec2(70, 30), Vec2(100, 140), Color4F(CCRANDOM_0_1(), CCRANDOM_0_1(), CCRANDOM_0_1(), 0.5));
+    
+    for (int i = 0; i < 100; i++) {
+        draw->drawPoint(Vec2(i*7, 5), 5, Color4F(CCRANDOM_0_1(), CCRANDOM_0_1(), CCRANDOM_0_1(), 1));
+    }
 }
 
 string DrawNodeTest::title() const

--- a/tests/cpp-tests/Classes/Sprite3DTest/Sprite3DTest.cpp
+++ b/tests/cpp-tests/Classes/Sprite3DTest/Sprite3DTest.cpp
@@ -1259,7 +1259,7 @@ void Sprite3DWithOBBPerfromanceTest::addNewOBBWithCoords(Vec2 p)
 
 void Sprite3DWithOBBPerfromanceTest::onTouchesBegan(const std::vector<Touch*>& touches, Event* event)
 {
-    for (auto touch: touches)
+    for (const auto& touch: touches)
     {
         auto location = touch->getLocationInView();
         auto obbSize = _obb.size();
@@ -1287,7 +1287,7 @@ void Sprite3DWithOBBPerfromanceTest::onTouchesEnded(const std::vector<Touch*>& t
 
 void Sprite3DWithOBBPerfromanceTest::onTouchesMoved(const std::vector<Touch*>& touches, Event* event)
 {
-    for (auto touch: touches)
+    for (const auto& touch: touches)
     {
         auto location = touch->getLocation();       
         auto obbSize = _obb.size();
@@ -1447,8 +1447,7 @@ void Sprite3DWithOBBPerfromanceTest::calculateRayByLocationInView(Ray* ray, cons
 {
     auto dir = Director::getInstance();
     auto view = dir->getWinSize();
-    Mat4 mat = dir->getMatrix(MATRIX_STACK_TYPE::MATRIX_STACK_MODELVIEW);
-    mat = dir->getMatrix(MATRIX_STACK_TYPE::MATRIX_STACK_PROJECTION);
+    Mat4 mat = dir->getMatrix(MATRIX_STACK_TYPE::MATRIX_STACK_PROJECTION);
     
     Vec3 src = Vec3(location.x, location.y, -1);
     Vec3 nearPoint;


### PR DESCRIPTION
Fixed issue #8843 
