### PR TITLE
Fix Label Kerning on Single Characters Cocos2d-X3.3Beta0

### DIFF
--- a/cocos/2d/CCLabelTextFormatter.cpp
+++ b/cocos/2d/CCLabelTextFormatter.cpp
@@ -390,15 +390,13 @@ bool LabelTextFormatter::createStringSprites(Label *theLabel)
         
         nextFontPositionX += charAdvance + kernings[i];
         
-        // only apply kerning shift if string contains more than 1 character
-        if (stringLen > 1) {
-            nextFontPositionX += theLabel->_additionalKerning;
-        }
-        
         if (longestLine < nextFontPositionX)
         {
             longestLine = nextFontPositionX;
         }
+        
+        // check longest line before adding additional kerning
+        nextFontPositionX += theLabel->_additionalKerning;
     }
     
     float lastCharWidth = tempDefinition.width * contentScaleFactor;

--- a/cocos/2d/CCLabelTextFormatter.cpp
+++ b/cocos/2d/CCLabelTextFormatter.cpp
@@ -387,8 +387,13 @@ bool LabelTextFormatter::createStringSprites(Label *theLabel)
             log("WARNING: can't find letter definition in font file for letter: %c", c);
             continue;
         }
-
-        nextFontPositionX += charAdvance + kernings[i] + theLabel->_additionalKerning;
+        
+        nextFontPositionX += charAdvance + kernings[i];
+        
+        // only apply kerning shift if string contains more than 1 character
+        if (stringLen > 1) {
+            nextFontPositionX += theLabel->_additionalKerning;
+        }
         
         if (longestLine < nextFontPositionX)
         {


### PR DESCRIPTION
When applying additionalKerning to a Label that displays a string with only 1 character, the character is shifted.

![error](https://cloud.githubusercontent.com/assets/1441263/4765096/264df822-5b35-11e4-84c0-bc72b0db03ce.jpg)
