### PR TITLE
release old program with the same key before adding glprogram

### DIFF
--- a/cocos/renderer/CCGLProgramCache.cpp
+++ b/cocos/renderer/CCGLProgramCache.cpp
@@ -433,9 +433,9 @@ GLProgram* GLProgramCache::getGLProgram(const std::string &key)
 void GLProgramCache::addGLProgram(GLProgram* program, const std::string &key)
 {
     // release old one
-	auto prev = getProgram(key);
+    auto prev = getProgram(key);
     if( prev == program )
-	    return;
+        return;
 
     _programs.erase(key);
     CC_SAFE_RELEASE_NULL(prev);

--- a/cocos/renderer/CCGLProgramCache.cpp
+++ b/cocos/renderer/CCGLProgramCache.cpp
@@ -432,9 +432,16 @@ GLProgram* GLProgramCache::getGLProgram(const std::string &key)
 
 void GLProgramCache::addGLProgram(GLProgram* program, const std::string &key)
 {
+	// release old one
+	auto prev = getProgram(key);
+	if( prev == program )
+		return;
+
+	_programs.erase(key);
+	CC_SAFE_RELEASE_NULL(prev);
+
     if (program)
-        program->retain();
-    
+        program->retain();    
     _programs[key] = program;
 }
 

--- a/cocos/renderer/CCGLProgramCache.cpp
+++ b/cocos/renderer/CCGLProgramCache.cpp
@@ -432,13 +432,13 @@ GLProgram* GLProgramCache::getGLProgram(const std::string &key)
 
 void GLProgramCache::addGLProgram(GLProgram* program, const std::string &key)
 {
-	// release old one
+    // release old one
 	auto prev = getProgram(key);
-	if( prev == program )
-		return;
+    if( prev == program )
+	    return;
 
-	_programs.erase(key);
-	CC_SAFE_RELEASE_NULL(prev);
+    _programs.erase(key);
+    CC_SAFE_RELEASE_NULL(prev);
 
     if (program)
         program->retain();    


### PR DESCRIPTION
this fixes a memory leak when adding a program twice or more times. (eg. we might add a custom program at game start, and later downloaded a newer version then add it again).
