### PR TITLE
add port to host string in websocket

### DIFF
--- a/cocos/network/WebSocket.cpp
+++ b/cocos/network/WebSocket.cpp
@@ -442,8 +442,11 @@ void WebSocket::onSubThreadStarted()
             
             if (_wsProtocols[i+1].callback != nullptr) name += ", ";
         }
+        
+        // Should append :<port> to the string if port!=80, otherwise it does not work properly.
+        std::string hostWithPort = _host + ":" + std::to_string(_port);
         _wsInstance = libwebsocket_client_connect(_wsContext, _host.c_str(), _port, _SSLConnection,
-                                             _path.c_str(), _host.c_str(), _host.c_str(),
+                                             _path.c_str(), hostWithPort.c_str(), _host.c_str(),
                                              name.c_str(), -1);
                                              
         if(nullptr == _wsInstance) {


### PR DESCRIPTION
if the port is no default(80), the host string must contain the port. eg: www.host.com:8888
