### PR TITLE
eaglview release leak in CCEAGLViewImpl-ios

### DIFF
--- a/cocos/platform/ios/CCGLViewImpl-ios.mm
+++ b/cocos/platform/ios/CCGLViewImpl-ios.mm
@@ -187,7 +187,8 @@ void GLViewImpl::end()
     CCEAGLView *eaglview = (CCEAGLView*) _eaglview;
 
     [eaglview removeFromSuperview];
-    [eaglview release];
+    //[eaglview release];
+    release();
 }
 
 

--- a/cocos/platform/ios/CCGLViewImpl-ios.mm
+++ b/cocos/platform/ios/CCGLViewImpl-ios.mm
@@ -128,7 +128,7 @@ bool GLViewImpl::initWithRect(const std::string& viewName, Rect rect, float fram
                                         sharegroup: nil
                                      multiSampling: NO
                                    numberOfSamples: 0];
-    
+
     [eaglview setMultipleTouchEnabled:YES];
 
     _screenSize.width = _designResolutionSize.width = [eaglview getWidth];
@@ -182,12 +182,12 @@ float GLViewImpl::getContentScaleFactor() const
 void GLViewImpl::end()
 {
     [CCDirectorCaller destroy];
-    
+
     // destroy EAGLView
     CCEAGLView *eaglview = (CCEAGLView*) _eaglview;
 
     [eaglview removeFromSuperview];
-    //[eaglview release];
+    [eaglview release];
 }
 
 


### PR DESCRIPTION
This is leaking the eaglview when the Director is purged.

In our case, we are leaving the cocos environment on some views which
are implemented with cocoa, and because this eaglview is not being
released, it is getting notifications for keyboard events, and trying to
access stuff on the NULL eaglview, crashing our app.
