### PR TITLE
CCPhysicsWorld.cpp Remove cpArbiterIgnore call from collisionPreSolveCallback

### DIFF
--- a/cocos/physics/CCPhysicsWorld.cpp
+++ b/cocos/physics/CCPhysicsWorld.cpp
@@ -299,7 +299,6 @@ int PhysicsWorld::collisionPreSolveCallback(PhysicsContact& contact)
 {
     if (!contact.isNotificationEnabled())
     {
-        cpArbiterIgnore(static_cast<cpArbiter*>(contact._contactInfo));
         return true;
     }
     


### PR DESCRIPTION
In the function collisionPreSolveCallbackfunction  I think we just want to prevent the event notification to be dispatched in cocos2d.
cpArbiterIgnore() prevents the collision response between two objects to be computed.
If the collision response still works in this case for al the example tests is just because for Chipmunk in the collisionPreSolveCallbackFunc() it's too late to ignore the arbiter. This should be done in collisionBeginCallbackFunc() that is called before in the collision pipeline.

So the arbiter is processed anyway in Chipmunk and the cpArbiterIgnore() doesn't have any effects called in collisionPreSolveCallbackfunction() function  and I think can be removed
