### PR TITLE
fix Cocos2dxSound.java  thread safety problem and unable stop some sounds  bug in coco2dX 2.x

### DIFF
--- a/cocos2dx/platform/android/java/src/org/cocos2dx/lib/Cocos2dxSound.java
+++ b/cocos2dx/platform/android/java/src/org/cocos2dx/lib/Cocos2dxSound.java
@@ -104,8 +104,11 @@ public class Cocos2dxSound {
 	// ===========================================================
 	// Methods
 	// ===========================================================
-
 	public int preloadEffect(final String pPath) {
+		return preloadEffect(pPath, true);
+	}
+
+	public int preloadEffect(final String pPath, final boolean isWaitLoaded) {
 		Integer soundID = this.mPathSoundIDMap.get(pPath);
 
 		if (soundID == null) {
@@ -113,6 +116,18 @@ public class Cocos2dxSound {
 			// save value just in case if file is really loaded
 			if (soundID != Cocos2dxSound.INVALID_SOUND_ID) {
 				this.mPathSoundIDMap.put(pPath, soundID);
+				if (isWaitLoaded) {
+					// preload one file at a time, or will cause some
+					// thread safety problem.
+					synchronized(this.mSoundPool) {
+						try {
+							// wait OnloadedCompleteListener
+							this.mSemaphore.acquire();
+						} catch(Exception e) {
+							return Cocos2dxSound.INVALID_SOUND_ID;
+						}
+					}
+				}
 			}
 		}
 
@@ -146,7 +161,7 @@ public class Cocos2dxSound {
 			streamID = this.doPlayEffect(pPath, soundID.intValue(), pLoop);
 		} else {
 			// the effect is not prepared
-			soundID = this.preloadEffect(pPath);
+			soundID = this.preloadEffect(pPath, false);
 			if (soundID == Cocos2dxSound.INVALID_SOUND_ID) {
 				// can not preload effect
 				return Cocos2dxSound.INVALID_SOUND_ID;


### PR DESCRIPTION
call "preloadEffect" will release the mSemaphore also, so if you call "preloadEffect" first, and then call "playEffect" to play some unloaded sound, the mSemaphore's acquire will return immediately,  and gain a wrong streamID, so you can't stop the sound later. also, it will be possible to  cause the "ConcurrentModificationException".
