### PR TITLE
Fixed compile error with CC_REF_LEAK_DETECTION

### DIFF
--- a/cocos/base/CCRef.cpp
+++ b/cocos/base/CCRef.cpp
@@ -189,7 +189,7 @@ static void untrackRef(Ref* ref)
     __refAllocationList.erase(iter);
 }
 
-#endif // #if CC_USE_MEM_LEAK_DETECTION
+#endif // #if CC_REF_LEAK_DETECTION
 
 
 NS_CC_END

--- a/cocos/base/CCRef.h
+++ b/cocos/base/CCRef.h
@@ -146,8 +146,8 @@ public:
     void* _scriptObject;
 #endif
 
-    // Memory leak diagnostic data (only included when CC_USE_MEM_LEAK_DETECTION is defined and its value isn't zero)
-#if CC_USE_MEM_LEAK_DETECTION
+    // Memory leak diagnostic data (only included when CC_REF_LEAK_DETECTION is defined and its value isn't zero)
+#if CC_REF_LEAK_DETECTION
 public:
     static void printLeaks();
 #endif


### PR DESCRIPTION
If I set CC_REF_LEAK_DETECTION to 1, it errors with "CCRef::printLeaks()" (no declartion)

Renamed old stuff name CC_USE_MEM_LEAK_DETECTION to CC_REF_LEAK_DETECTION.
