### PR TITLE
FIX - Button color not applied on binary Cocos Studio files

### DIFF
--- a/cocos/editor-support/cocostudio/WidgetReader/ButtonReader/ButtonReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/ButtonReader/ButtonReader.cpp
@@ -156,6 +156,7 @@ namespace cocostudio
             button->setContentSize(Size(scale9Width, scale9Height));
         }
         
+        button->setColor(_color);
         button->setTitleColor(Color3B(cri, cgi, cbi));
         
 


### PR DESCRIPTION
Test case (Cocos Studio 1.6)
- use 9Scale image for button in Cocos Studio
- set Button text color in Cocos Studio
- set Button color in Cocos Studio 
- export binary CSB

Result (runtime)
- Button text color applied
- Button color not applied
