### PR TITLE
Download jobs should all follow http redirect

### DIFF
--- a/extensions/assets-manager/Downloader.cpp
+++ b/extensions/assets-manager/Downloader.cpp
@@ -361,6 +361,8 @@ void Downloader::downloadToBuffer(const std::string &srcUrl, const std::string &
     curl_easy_setopt(curl, CURLOPT_NOSIGNAL, 1L);
     curl_easy_setopt(curl, CURLOPT_LOW_SPEED_LIMIT, LOW_SPEED_LIMIT);
     curl_easy_setopt(curl, CURLOPT_LOW_SPEED_TIME, LOW_SPEED_TIME);
+    curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, true);
+    curl_easy_setopt(curl, CURLOPT_MAXREDIRS, MAX_REDIRS);
     
     CURLcode res = curl_easy_perform(curl);
     if (res != CURLE_OK)
@@ -431,6 +433,8 @@ void Downloader::download(const std::string &srcUrl, const std::string &customId
     curl_easy_setopt(curl, CURLOPT_NOSIGNAL, 1L);
     curl_easy_setopt(curl, CURLOPT_LOW_SPEED_LIMIT, LOW_SPEED_LIMIT);
     curl_easy_setopt(curl, CURLOPT_LOW_SPEED_TIME, LOW_SPEED_TIME);
+    curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, true);
+    curl_easy_setopt(curl, CURLOPT_MAXREDIRS, MAX_REDIRS);
     
     CURLcode res = curl_easy_perform(curl);
     if (res != CURLE_OK)


### PR DESCRIPTION
`groupBatchDownload()` has this curl option on already, so as do`downloadToBuffer()` and `download()`. It's important to support a redirect download sometimes.
