### PR TITLE
Fixed compile error with CC_ENABLE_SCRIPT_BINDING=0

### DIFF
--- a/cocos/base/CCScriptSupport.h
+++ b/cocos/base/CCScriptSupport.h
@@ -27,8 +27,6 @@
 #define __SCRIPT_SUPPORT_H__
 
 #include "base/ccConfig.h"
-#if CC_ENABLE_SCRIPT_BINDING
-
 #include "platform/CCCommon.h"
 #include "base/CCTouch.h"
 #include "base/CCEventTouch.h"
@@ -36,6 +34,8 @@
 #include <map>
 #include <string>
 #include <list>
+
+#if CC_ENABLE_SCRIPT_BINDING
 
 typedef struct lua_State lua_State;
 


### PR DESCRIPTION
There are too much compile error if I set EE_ENABLE_SCRIPT_BINDING=0.

CCEventTouch, CCTouch, std::list related things...
This is temporary fix... Many source/header files must be patched for the right way..
