### PR TITLE
Ron

### DIFF
--- a/cocos/base/CCScheduler.h
+++ b/cocos/base/CCScheduler.h
@@ -365,8 +365,11 @@ public:
      */
     void performFunctionInCocosThread( const std::function<void()> &function);
     /**
-    calls a function on the cocos2d thread.Useful when you need to call a cocos2d function from another thread. Note that return value indicate function running state in cocos2d thread.
+    calls a function on the cocos2d thread.Useful when you need to call a cocos2d function from another thread. 
+    Note that return value indicate function running state in cocos2d thread.
+    because of Microsoft bug https://connect.microsoft.com/VisualStudio/feedback/details/791185/std-packaged-task-t-where-t-is-void-or-a-reference-class-are-not-movable,at current,we must need function returning a value like 'bool'.  
     This function is thread safe.
+    @since v3.3+
     */
     std::future<bool> performTaskInCocosThread(const std::function<bool()> &function);
     /////////////////////////////////////

--- a/cocos/base/CCScheduler.h
+++ b/cocos/base/CCScheduler.h
@@ -31,6 +31,7 @@ THE SOFTWARE.
 #include <functional>
 #include <mutex>
 #include <set>
+#include <future>
 
 #include "base/CCRef.h"
 #include "base/CCVector.h"
@@ -363,7 +364,11 @@ public:
      @since v3.0
      */
     void performFunctionInCocosThread( const std::function<void()> &function);
-    
+    /**
+    calls a function on the cocos2d thread.Useful when you need to call a cocos2d function from another thread. Note that return value indicate function running state in cocos2d thread.
+    This function is thread safe.
+    */
+    std::future<bool> performTaskInCocosThread(const std::function<bool()> &function);
     /////////////////////////////////////
     
     // Deprecated methods:
@@ -460,6 +465,8 @@ protected:
     
     // Used for "perform Function"
     std::vector<std::function<void()>> _functionsToPerform;
+    // Used for "perform packaged_task"
+    std::vector<std::packaged_task<bool()>> _tasksToPerform;
     std::mutex _performMutex;
 };
 

--- a/tools/tolua/cocos2dx.ini
+++ b/tools/tolua/cocos2dx.ini
@@ -98,7 +98,7 @@ skip = Node::[setGLServerState description getUserObject .*UserData getGLServerS
         CatmullRom.*::[create actionWithDuration],
         Bezier.*::[create actionWithDuration],
         CardinalSpline.*::[create actionWithDuration setPoints],
-        Scheduler::[pause resume unschedule schedule update isTargetPaused isScheduled performFunctionInCocosThread],
+        Scheduler::[pause resume unschedule schedule update isTargetPaused isScheduled performFunctionInCocosThread performTaskInCocosThread],
         TextureCache::[addPVRTCImage addImageAsync],
         Timer::[getSelector createWithScriptHandler],
         *::[copyWith.* onEnter.* onExit.* ^description$ getObjectType (g|s)etDelegate onTouch.* onAcc.* onKey.* onRegisterTouchListener],


### PR DESCRIPTION
performTaskInCocosThread and performFunctionInCocosThread difference is that we can use performTaskInCocosThread return-value to determine , whether submitted to CocosThread function is finished, and get submitted to CocosThread function's return-value .
When we need to perform some operations in other threads , these thread need wait for cocos thread update over, this method provides convenience.
why our function return 'bool',because of Microsoft bug https://connect.microsoft.com/VisualStudio/feedback/details/791185/std-packaged-task-t-where-t-is-void-or-a-reference-class-are-not-movable,at current,we must need function returning a value like 'bool'.
It is ok in ubuntu 12.04 and window 7,other platform not test.

performTaskInCocosThread与performFunctionInCocosThread区别在于，我们可以通过performTaskInCocosThread返回值确定，提交给CocosThread的函数是否执行完毕，并获取提交给CocosThread函数的返回值。为什么提交函数要返回bool，因为Microsoft的bug，https://connect.microsoft.com/VisualStudio/feedback/details/791185/std-packaged-task-t-where-t-is-void-or-a-reference-class-are-not-movable。暂时我们需要返回值
当我们需要在其他线程执行一些操作，并且要等待cocosThread更新完成时，此方法提供便利。在ubuntu和window下测试正常，其他平台未测试。
