### PR TITLE
fix scale9sprite flip issue

### DIFF
--- a/cocos/ui/UILoadingBar.cpp
+++ b/cocos/ui/UILoadingBar.cpp
@@ -102,14 +102,14 @@ void LoadingBar::setDirection(cocos2d::ui::LoadingBar::Direction direction)
             _barRenderer->setAnchorPoint(Vec2(0.0f,0.5f));
             _barRenderer->setPosition(Vec2(0,_contentSize.height*0.5f));
             if (!_scale9Enabled) {
-                _barRenderer->setFlippedX(false);
+                _barRenderer->getSprite()->setFlippedX(false);
             }
             break;
         case Direction::RIGHT:
             _barRenderer->setAnchorPoint(Vec2(1.0f,0.5f));
             _barRenderer->setPosition(Vec2(_totalLength,_contentSize.height*0.5f));
             if (!_scale9Enabled) {
-                _barRenderer->setFlippedX(true);
+                _barRenderer->getSprite()->setFlippedX(true);
             }
             break;
     }

--- a/cocos/ui/UIScale9Sprite.cpp
+++ b/cocos/ui/UIScale9Sprite.cpp
@@ -50,6 +50,9 @@ namespace ui {
     , _insetTop(0)
     , _insetRight(0)
     , _insetBottom(0)
+    ,_flippedX(false)
+    ,_flippedY(false)
+
     {
         this->setAnchorPoint(Vec2(0.5,0.5));
     }
@@ -1021,6 +1024,9 @@ y+=ytranslate;         \
         this->cleanupSlicedSprites();
         _protectedChildren.clear();
         
+        //we must invalide the transform when toggling scale9enabled
+        _transformUpdated = _transformDirty = _inverseDirty = true;
+        
         if (_scale9Enabled)
         {
             if (_scale9Image)
@@ -1208,34 +1214,17 @@ y+=ytranslate;         \
     
     void Scale9Sprite::setFlippedX(bool flippedX)
     {
+     
+        float realScale = this->getScaleX();
         _flippedX = flippedX;
-        if (_scale9Enabled)
-        {
-            this->setScaleX(-1);
-        }
-        else
-        {
-            if (_scale9Image)
-            {
-                _scale9Image->setFlippedX(flippedX);
-            }
-        }
+        this->setScaleX(realScale);
     }
     
     void Scale9Sprite::setFlippedY(bool flippedY)
     {
+        float realScale = this->getScaleY();
         _flippedY = flippedY;
-        if (_scale9Enabled)
-        {
-            this->setScaleY(-1);
-        }
-        else
-        {
-            if (_scale9Image)
-            {
-                _scale9Image->setFlippedY(flippedY);
-            }
-        }
+        this->setScaleY(realScale);
     }
     
     bool Scale9Sprite::isFlippedX()const
@@ -1247,4 +1236,60 @@ y+=ytranslate;         \
     {
         return _flippedY;
     }
+    
+    void Scale9Sprite::setScaleX(float scaleX)
+    {
+        if (_flippedX) {
+            scaleX = scaleX * -1;
+        }
+        Node::setScaleX(scaleX);
+    }
+    
+    void Scale9Sprite::setScaleY(float scaleY)
+    {
+        if (_flippedY) {
+            scaleY = scaleY * -1;
+        }
+        Node::setScaleY(scaleY);
+    }
+    
+    void Scale9Sprite::setScale(float scale)
+    {
+        this->setScaleX(scale);
+        this->setScaleY(scale);
+        this->setScaleZ(scale);
+    }
+    
+    void Scale9Sprite::setScale(float scaleX, float scaleY)
+    {
+        this->setScaleX(scaleX);
+        this->setScaleY(scaleY);
+    }
+    
+    float Scale9Sprite::getScaleX()const
+    {
+        float originalScale = Node::getScaleX();
+        if (_flippedX)
+        {
+            originalScale = originalScale * -1.0;
+        }
+        return originalScale;
+    }
+    
+    float Scale9Sprite::getScaleY()const
+    {
+        float originalScale = Node::getScaleY();
+        if (_flippedY)
+        {
+            originalScale = originalScale * -1.0;
+        }
+        return originalScale;
+    }
+    
+    float Scale9Sprite::getScale()const
+    {
+        CCASSERT(this->getScaleX() == this->getScaleY(), "Scale9Sprite#scale. ScaleX != ScaleY. Don't know which one to return");
+        return this->getScaleX();
+    }
+    
 }}

--- a/cocos/ui/UIScale9Sprite.h
+++ b/cocos/ui/UIScale9Sprite.h
@@ -354,6 +354,16 @@ namespace ui {
          */
         virtual bool isFlippedY()const;
         
+        //override the setScale function of Node
+        virtual void setScaleX(float scaleX) override;
+        virtual void setScaleY(float scaleY) override;
+        virtual void setScale(float scale) override;
+        virtual void setScale(float scalex, float scaley) override;
+        using Node::setScaleZ;
+        virtual float getScaleX() const override;
+        virtual float getScaleY() const override;
+        virtual float getScale() const override;
+        using Node::getScaleZ;
     protected:
         void updateCapInset();
         void updatePositions();

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIScale9SpriteTest.cpp
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIScale9SpriteTest.cpp
@@ -44,13 +44,14 @@ bool UIScale9SpriteTest::init()
         auto moveTo = MoveBy::create(1.0, Vec2(30,0));
         auto moveBack = moveTo->reverse();
         auto rotateBy = RotateBy::create(1.0, 180);
-        auto action = Sequence::create(moveTo,moveBack, rotateBy, NULL);
+        auto scaleBy = ScaleTo::create(1.0, -2.0);
+        auto action = Sequence::create(moveTo,moveBack, rotateBy,scaleBy, NULL);
 
         
         Sprite *normalSprite1 = Sprite::create("cocosui/animationbuttonnormal.png");
         normalSprite1->setPosition(100, 270);
-//        normalSprite1->setAnchorPoint(Vec2(0.5,0.5));
-//        normalSprite1->setContentSize(Size(100,100));
+        normalSprite1->setFlippedY(true);
+        
 
         this->addChild(normalSprite1);
         normalSprite1->runAction((FiniteTimeAction*)action->clone());
@@ -107,7 +108,8 @@ bool UIScale9SpriteHierarchialTest::init()
         auto moveBack = moveTo->reverse();
         auto rotateBy = RotateBy::create(1.0f, 180);
         auto fadeOut = FadeOut::create(2.0f);
-        auto action = Sequence::create(moveTo,moveBack, rotateBy,fadeOut, NULL);
+        auto scaleTo = ScaleTo::create(1.0, 2.0);
+        auto action = Sequence::create(moveTo,moveBack, rotateBy,fadeOut,scaleTo, NULL);
         
         Sprite *normalSprite1 = Sprite::create("cocosui/animationbuttonnormal.png");
         normalSprite1->setPosition(100, 270);
@@ -135,6 +137,7 @@ bool UIScale9SpriteHierarchialTest::init()
         cocos2d::ui::Scale9Sprite *sp2 = ui::Scale9Sprite::create("cocosui/animationbuttonnormal.png");
         sp2->setPreferredSize(sp1->getContentSize() * 1.2f);
         sp2->setColor(Color3B::GREEN);
+        sp2->setFlippedX(true);
         sp2->setContentSize(Size(100,100));
         
         sp1->addChild(sp2);
@@ -163,15 +166,13 @@ bool UIScale9SpriteTouchTest::init()
         
         auto containerForSprite1 = Node::create();
         auto sprite1 = cocos2d::ui::Scale9Sprite::create("Images/CyanSquare.png");
-//        sprite1->setScale9Enabled(false);
         sprite1->setPosition(origin+Vec2(size.width/2, size.height/2) + Vec2(-80, 80));
         containerForSprite1->addChild(sprite1);
         addChild(containerForSprite1, 10);
         
         auto sprite2 = ui::Scale9Sprite::create("Images/MagentaSquare.png");
         sprite2->setPosition(origin+Vec2(size.width/2, size.height/2));
-//        sprite2->setCascadeOpacityEnabled(false);
-//        sprite2->setScale9Enabled(false);
+
 
         addChild(sprite2, 20);
         
@@ -179,7 +180,6 @@ bool UIScale9SpriteTouchTest::init()
         sprite3->setPosition(Vec2(0, 0));
         sprite3->setCascadeOpacityEnabled(false);
         sprite2->addChild(sprite3, 1);
-//        sprite3->setScale9Enabled(false);
 
         
         // Make sprite1 touchable
@@ -647,6 +647,9 @@ bool UIS9Flip::init()
         float x = winSize.width / 2;
         float y = 0 + (winSize.height / 2);
         
+        auto statusLabel = Label::createWithSystemFont("Scale9Enabled", "Arial", 10);
+        statusLabel->setPosition(Vec2(x, winSize.height - statusLabel->getContentSize().height - 40));
+        this->addChild(statusLabel);
         
         auto normalSprite = ui::Scale9Sprite::createWithSpriteFrameName("blocks9r.png");
         
@@ -663,11 +666,11 @@ bool UIS9Flip::init()
         auto flipXSprite = ui::Scale9Sprite::createWithSpriteFrameName("blocks9r.png");
         
         flipXSprite->setPosition(Vec2(x - 120, y ));
+        flipXSprite->setScale(1.2);
         this->addChild(flipXSprite);
+        flipXSprite->setFlippedX(false);
         
-        flipXSprite->setFlippedX(true);
-        
-        auto flipXLabel = Label::createWithSystemFont("Sprite FlipX","Airal",10);
+        auto flipXLabel = Label::createWithSystemFont("sprite is not flipped!","Airal",10);
         flipXLabel->setPosition(flipXSprite->getPosition() + Vec2(0, flipXSprite->getContentSize().height/2 + 10));
         this->addChild(flipXLabel);
         
@@ -677,11 +680,79 @@ bool UIS9Flip::init()
         flipYSprite->setPosition(Vec2(x + 120, y));
         this->addChild(flipYSprite);
         
+        flipYSprite->setScale(0.8);
         flipYSprite->setFlippedY(true);
         
-        auto flipYLabel = Label::createWithSystemFont("Sprite FlipY","Airal",10);
+        auto flipYLabel = Label::createWithSystemFont("sprite is flipped!","Airal",10);
         flipYLabel->setPosition(flipYSprite->getPosition() + Vec2(0, flipYSprite->getContentSize().height/2 + 10));
         this->addChild(flipYLabel);
+        
+        
+        auto toggleFlipXButton = Button::create();
+        toggleFlipXButton->setTitleText("Toggle FlipX");
+        toggleFlipXButton->setPosition(flipXSprite->getPosition() + Vec2(0, - 20 - flipXSprite->getContentSize().height/2));
+        toggleFlipXButton->addClickEventListener([=](Ref*){
+            flipXSprite->setFlippedX(! flipXSprite->isFlippedX());
+            if (flipXSprite->isFlippedX()) {
+                flipXLabel->setString("sprite is flipped!");
+            }
+            else{
+                flipXLabel->setString("sprite is not flipped!");
+            }
+        });
+        this->addChild(toggleFlipXButton);
+        
+        auto toggleFlipYButton = Button::create();
+        toggleFlipYButton->setTitleText("Toggle FlipY");
+        toggleFlipYButton->setPosition(flipYSprite->getPosition() + Vec2(0, -20 - flipYSprite->getContentSize().height/2));
+        toggleFlipYButton->addClickEventListener([=](Ref*){
+            flipYSprite->setFlippedY(!flipYSprite->isFlippedY());
+            if (flipYSprite->isFlippedY()) {
+                flipYLabel->setString("sprite is flipped!");
+            }
+            else{
+                flipYLabel->setString("sprpite is not flipped!");
+            }
+        });
+        this->addChild(toggleFlipYButton);
+        
+        auto toggleScale9Button = Button::create();
+        toggleScale9Button->setTitleText("Toggle Scale9");
+        toggleScale9Button->setPosition(normalSprite->getPosition() + Vec2(0, -20 - normalSprite->getContentSize().height/2));
+        toggleScale9Button->addClickEventListener([=](Ref*){
+            flipXSprite->setScale9Enabled(!flipXSprite->isScale9Enabled());
+            flipYSprite->setScale9Enabled(!flipYSprite->isScale9Enabled());
+            if (flipXSprite->isScale9Enabled()) {
+                statusLabel->setString("Scale9Enabled");
+            }else{
+                statusLabel->setString("Scale9Disabled");
+            }
+            
+            CCLOG("scaleX = %f", flipXSprite->getScaleX());
+            CCLOG("scaleY = %f", flipYSprite->getScale());
+            if (flipXSprite->isFlippedX()) {
+                CCLOG("xxxxxxx");
+            }
+            if (flipYSprite->isFlippedY()) {
+                CCLOG("YYYYYY");
+            }
+            
+            if (flipXSprite->isFlippedX()) {
+                flipXLabel->setString("sprite is flipped!");
+            }
+            else{
+                flipXLabel->setString("sprite is not flipped!");
+            }
+            
+            if (flipYSprite->isFlippedY()) {
+                flipYLabel->setString("sprite is flipped!");
+            }
+            else{
+                flipYLabel->setString("sprpite is not flipped!");
+            }
+            
+        });
+        this->addChild(toggleScale9Button);
         
         return true;
     }


### PR DESCRIPTION
### Problem description.:
- When set Scale9Sprite's setFlippedX(false) and setFlippedY(false), the scale9Sprite will be flipped.
- When settings the scale and flip property at the same time, the result would be wrong.
### After apply this patch
- It shouldn't be flipped when set flip to false.
- And it also fix the the scale and flip conflict issue.
