### PR TITLE
Fixed retina/contentScale position errors for iPhone 6+ devices in EditBox

### DIFF
--- a/cocos/ui/UIEditBox/UIEditBoxImpl-ios.h
+++ b/cocos/ui/UIEditBox/UIEditBoxImpl-ios.h
@@ -132,7 +132,6 @@ private:
     Vec2         _anchorPoint;
     UIEditBoxImplIOS_objc* _systemControl;
     int             _maxTextLength;
-    bool            _inRetinaMode;
 };
 
 


### PR DESCRIPTION
Problem is that factor was 1.0 or 2.0 until iOS 8 introduced 3.0.

I've replaced everything that depended on dividing by 2 for contentScaleFactor. 
