### PR TITLE
bug cocosstudio2.2 fill background color to none #9067

### DIFF
--- a/cocos/editor-support/cocostudio/WidgetReader/LayoutReader/LayoutReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/LayoutReader/LayoutReader.cpp
@@ -401,7 +401,7 @@ namespace cocostudio
         
         int co = options.has_bgcoloropacity() ? options.bgcoloropacity() : 100;
         
-        int colorType = options.has_colortype() ? options.colortype() : 1;
+        int colorType = options.has_colortype() ? options.colortype() : 0;
         panel->setBackGroundColorType(Layout::BackGroundColorType(colorType));
         
         panel->setBackGroundColor(Color3B(scr, scg, scb),Color3B(ecr, ecg, ecb));

--- a/cocos/editor-support/cocostudio/WidgetReader/ListViewReader/ListViewReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/ListViewReader/ListViewReader.cpp
@@ -125,7 +125,7 @@ namespace cocostudio
         
         int co = options.has_bgcoloropacity() ? options.bgcoloropacity() : 100;
         
-        int colorType = options.has_colortype() ? options.colortype() : 1;
+        int colorType = options.has_colortype() ? options.colortype() : 0;
         listView->setBackGroundColorType(Layout::BackGroundColorType(colorType));
         
         listView->setBackGroundColor(Color3B(scr, scg, scb),Color3B(ecr, ecg, ecb));

--- a/cocos/editor-support/cocostudio/WidgetReader/PageViewReader/PageViewReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/PageViewReader/PageViewReader.cpp
@@ -98,7 +98,7 @@ namespace cocostudio
         
         int co = options.has_bgcoloropacity() ? options.bgcoloropacity() : 100;
         
-        int colorType = options.has_colortype() ? options.colortype() : 1;
+        int colorType = options.has_colortype() ? options.colortype() : 0;
         pageView->setBackGroundColorType(Layout::BackGroundColorType(colorType));
         
         pageView->setBackGroundColor(Color3B(scr, scg, scb),Color3B(ecr, ecg, ecb));

--- a/cocos/editor-support/cocostudio/WidgetReader/ScrollViewReader/ScrollViewReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/ScrollViewReader/ScrollViewReader.cpp
@@ -139,7 +139,7 @@ namespace cocostudio
         
         int co = options.has_bgcoloropacity() ? options.bgcoloropacity() : 100;
         
-        int colorType = options.has_colortype() ? options.colortype() : 1;
+        int colorType = options.has_colortype() ? options.colortype() : 0;
         scrollView->setBackGroundColorType(Layout::BackGroundColorType(colorType));
         
         scrollView->setBackGroundColor(Color3B(scr, scg, scb),Color3B(ecr, ecg, ecb));


### PR DESCRIPTION
the default value of  background color should be 0, when set fill is none in cocosstudio 2.2 
