### PR TITLE
fix lua http download binary data's bug

### DIFF
--- a/cocos/scripting/lua-bindings/manual/network/lua_xml_http_request.cpp
+++ b/cocos/scripting/lua-bindings/manual/network/lua_xml_http_request.cpp
@@ -244,16 +244,13 @@ void LuaMinXmlHttpRequest::_sendRequest()
         
         /** get the response data **/
         std::vector<char> *buffer = response->getResponseData();
-        char* concatenated = (char*) malloc(buffer->size() + 1);
-        std::string s2(buffer->begin(), buffer->end());
-        strcpy(concatenated, s2.c_str());
         
         if (statusCode == 200)
         {
             //Succeeded
             _status = 200;
             _readyState = DONE;
-            _data << concatenated;
+            _data.assign(buffer->begin(), buffer->end());
             _dataSize = buffer->size();
         }
         else
@@ -262,7 +259,6 @@ void LuaMinXmlHttpRequest::_sendRequest()
         }
         // Free Memory.
         free((void*) concatHeader);
-        free((void*) concatenated);
         
         // TODO: call back lua function
         int handler = cocos2d::ScriptHandlerMgr::getInstance()->getObjectHandler((void*)this, cocos2d::ScriptHandlerMgr::HandlerType::XMLHTTPREQUEST_READY_STATE_CHANGE );
@@ -282,7 +278,7 @@ void LuaMinXmlHttpRequest::_sendRequest()
 
 void LuaMinXmlHttpRequest::getByteData(unsigned char* byteData)
 {
-    _data.read((char*)byteData, _dataSize);
+    memcpy((char*)byteData, _data.c_str(), _dataSize);
 }
 
 /* function to regType */

--- a/cocos/scripting/lua-bindings/manual/network/lua_xml_http_request.h
+++ b/cocos/scripting/lua-bindings/manual/network/lua_xml_http_request.h
@@ -94,7 +94,7 @@ public:
     
     void getByteData(unsigned char* byteData);
     
-    inline std::string getDataStr() { return _data.str(); }
+    inline std::string getDataStr() { return _data; }
     
     inline size_t getDataSize() {   return _dataSize; }
     
@@ -111,7 +111,7 @@ private:
     std::string                          _url;
     std::string                          _meth;
     std::string                          _type;
-    std::stringstream                    _data;
+    std::string                          _data;
     size_t                               _dataSize;
     int                                  _readyState;
     int                                  _status;


### PR DESCRIPTION
官方代码里面，将二进制数据当作字符串处理了，使用strcpy函数，这个会导致遇到0截断，而之后的数据都是错乱的。
