### PR TITLE
fixes how to check for CPU in android-build

### DIFF
--- a/build/android-build.py
+++ b/build/android-build.py
@@ -15,15 +15,8 @@ def get_num_of_cpu():
     ''' The build process can be accelerated by running multiple concurrent job processes using the -j-option.
     '''
     try:
-        platform = sys.platform
-        if platform == 'win32':
-            if 'NUMBER_OF_PROCESSORS' in os.environ:
-                return int(os.environ['NUMBER_OF_PROCESSORS'])
-            else:
-                return 1
-        else:
-            from numpy.distutils import cpuinfo
-            return cpuinfo.cpu._getNCPUs()
+        import multiprocessing
+        return multiprocessing.cpu_count()
     except Exception:
         print "Can't know cpuinfo, use default 1 cpu"
         return 1


### PR DESCRIPTION
it was broken on Mac Yosemite
