### PR TITLE
- Optimization in CCClippingNode.

### DIFF
--- a/cocos/2d/CCClippingNode.cpp
+++ b/cocos/2d/CCClippingNode.cpp
@@ -231,7 +231,7 @@ void ClippingNode::drawFullScreenQuadClearStencil()
 
 void ClippingNode::visit(Renderer *renderer, const Mat4 &parentTransform, uint32_t parentFlags)
 {
-    if(!_visible)
+    if (!_visible || !hasContent())
         return;
     
     uint32_t flags = processParentFlags(parentTransform, parentFlags);
@@ -325,6 +325,11 @@ void ClippingNode::setStencil(Node *stencil)
     CC_SAFE_RETAIN(stencil);
     CC_SAFE_RELEASE(_stencil);
     _stencil = stencil;
+}
+
+bool ClippingNode::hasContent()
+{
+    return _children.size() > 0;
 }
 
 GLfloat ClippingNode::getAlphaThreshold() const

--- a/cocos/2d/CCClippingNode.cpp
+++ b/cocos/2d/CCClippingNode.cpp
@@ -327,7 +327,7 @@ void ClippingNode::setStencil(Node *stencil)
     _stencil = stencil;
 }
 
-bool ClippingNode::hasContent()
+bool ClippingNode::hasContent() const
 {
     return _children.size() > 0;
 }

--- a/cocos/2d/CCClippingNode.h
+++ b/cocos/2d/CCClippingNode.h
@@ -64,7 +64,7 @@ public:
     then this method should return true every time you wish stencil to be visited.
     By default returns true if has any children attached.
     */
-    virtual bool hasContent();
+    virtual bool hasContent() const;
 
     /** The alpha threshold.
      The content is drawn only where the stencil have pixel with alpha greater than the alphaThreshold.

--- a/cocos/2d/CCClippingNode.h
+++ b/cocos/2d/CCClippingNode.h
@@ -58,7 +58,14 @@ public:
      */
     Node* getStencil() const;
     void setStencil(Node *stencil);
-    
+
+    /** If stencil has no childre it will not be drawn.
+    If you have custom stencil-based node with stencil drawing mechanics other then children-based,
+    then this method should return true every time you wish stencil to be visited.
+    By default returns true if has any children attached.
+    */
+    virtual bool hasContent();
+
     /** The alpha threshold.
      The content is drawn only where the stencil have pixel with alpha greater than the alphaThreshold.
      Should be a float between 0 and 1.


### PR DESCRIPTION
Disable visiting when no objects has to be drawn under stencil.
