### PR TITLE
fix bug - potential memory leak.

### DIFF
--- a/cocos/platform/CCFileUtils.cpp
+++ b/cocos/platform/CCFileUtils.cpp
@@ -309,7 +309,7 @@ public:
         }
 
         SAXState curState = _stateStack.empty() ? SAX_DICT : _stateStack.top();
-        const std::string text = std::string((char*)ch,0,len);
+        const std::string text = std::string((char*)ch,len);
 
         switch(_state)
         {


### PR DESCRIPTION
const std::string text = std::string((char*)ch,0,len); is using next
string constructor.
string (const string& str, size_t pos, size_t len = npos);
memory leak can occur while type converting char to string.

So we have to use next string constructor.
string (const char\* s, size_t n);

http://www.cplusplus.com/reference/string/string/string/
