### PR TITLE
Fix Z-Order Bug SpriteBatchNode

### DIFF
--- a/cocos/2d/CCNode.cpp
+++ b/cocos/2d/CCNode.cpp
@@ -286,10 +286,13 @@ void Node::setLocalZOrder(int z)
     if (_localZOrder == z)
         return;
     
-    _localZOrder = z;
     if (_parent)
     {
         _parent->reorderChild(this, z);
+    }
+    else
+    {
+      _localZOrder = z;
     }
 
     _eventDispatcher->setDirtyForNode(this);

--- a/cocos/2d/CCSprite.cpp
+++ b/cocos/2d/CCSprite.cpp
@@ -1010,6 +1010,8 @@ void Sprite::setBatchNode(SpriteBatchNode *spriteBatchNode)
         // using batch
         _transformToBatch = Mat4::IDENTITY;
         setTextureAtlas(_batchNode->getTextureAtlas()); // weak ref
+        
+        _reorderChildDirty = true; // force reorder
     }
 }
 


### PR DESCRIPTION
Fixes Z-ORder bug for SpriteBatchNode. Previously, setting the zOrder on childs of SpriteBatchNode would not reorder the children. The reason is that Node::setLocalZOrder would set _localZOrder = z before the parent would check zOrder == child->getLocalZOrder() causing the reorderChild methods to return without reordering the children.

Please refer to https://github.com/cocos2d/cocos2d-swift/issues/598 for additional information.
