### PR TITLE
Permit plugin-x plugins to ship third-party libraries.

### DIFF
--- a/tools/travis-scripts/config.gitingore
+++ b/tools/travis-scripts/config.gitingore
@@ -113,6 +113,8 @@ tags
 !/tools/cocos2d-console/console/bin/
 !/plugin-x/plugin-x_ios.xcworkspace/
 !/cocos/2d/platform/android/java/res/
+# Permit plugins to ship third-party libraries.
+!/plugin/plugins/*/proj.android/libs/*.jar
 
 v*-deps-*.zip
 v*-lua-runtime-*.zip


### PR DESCRIPTION
This is intended to simplify the build process for plugins shipped as part of plugin-x. I'm not sure it's either necessary or a good idea to block the entire libs directory when it's the standard directory to place external jar dependencies in. I'm assuming this is an oversight.

For now, this commit only unblocks a limited subset of files — specifically the .jar files under an Android plugin library project's libs/ directory. Further-nested jar files and libs directories are not covered, inner projects aren't covered, etc. The script generating the file list may need to be updated to behave more intelligently than just using a gitignore file to determine which files are ignored, as convenient as it sounds at first.
#### Commit Message

---

Ignoring the libs directory's .jar files is strange. I'm not sure
whoever put the total block over libs/ knew that this is the standard
Android library directory and not just for NDK-compiled assets.

More granular ignores over libs/ contents would be better in the
future, but this fixes the odd sdk/ directory hack plugins currently
use and lets the Android build system auto-link libraries that're
shipped with plugins instead of forcing Cocos developers to manually
sift through a plugin's Android dependencies and include them by hand.
