### PR TITLE
Fix compile errors with recent mingw.

### DIFF
--- a/cocos/audio/win32/AudioCache.cpp
+++ b/cocos/audio/win32/AudioCache.cpp
@@ -51,7 +51,7 @@ AudioCache::AudioCache()
     
 }
 
-AudioCache::AudioCache(AudioCache& cache)
+AudioCache::AudioCache(const AudioCache& cache)
 {
     _pcmData = cache._pcmData;
     _pcmDataSize = cache._pcmDataSize;

--- a/cocos/audio/win32/AudioCache.h
+++ b/cocos/audio/win32/AudioCache.h
@@ -53,7 +53,7 @@ public:
     };
 
     AudioCache();
-    AudioCache(AudioCache&);
+    AudioCache(const AudioCache&);
     ~AudioCache();
 
     void addCallbacks(const std::function<void()> &callback);

--- a/cocos/audio/win32/AudioPlayer.cpp
+++ b/cocos/audio/win32/AudioPlayer.cpp
@@ -45,7 +45,7 @@ AudioPlayer::AudioPlayer()
 
 }
 
-AudioPlayer::AudioPlayer(AudioPlayer& player)
+AudioPlayer::AudioPlayer(const AudioPlayer& player)
 {
     _exitThread = player._exitThread;
     _timeDirty = player._timeDirty;

--- a/cocos/audio/win32/AudioPlayer.h
+++ b/cocos/audio/win32/AudioPlayer.h
@@ -44,7 +44,7 @@ class CC_DLL AudioPlayer
 {
 public:
     AudioPlayer();
-    AudioPlayer(AudioPlayer&);
+    AudioPlayer(const AudioPlayer&);
     ~AudioPlayer();
     
     //queue buffer related stuff


### PR DESCRIPTION
Constify arguments to copy constuctors. Without this gcc fail to compile if classes used inside containers.
Error message is rather cryptic: 

```
error: 'constexpr std::pair<_T1, _T2>::pair(const std::pair<_T1, _T2>&) [with _T1 = const int; _T2 = cocos2d::experimental::AudioPlayer]' declared to take const reference, but implicit declaration would take non-const
```

I test this:
1. With mingw by successfully create package from MSYS package source [PKGBUILD](https://github.com/Alexpux/MINGW-packages/blob/master/mingw-w64-cocos2dx-git/PKGBUILD)
2. With recent Microsoft Visual Studio Community 2013 (build success, test applications runnable)
