### PR TITLE
Using std::swap instead of CC_SWAP

### DIFF
--- a/cocos/2d/CCParticleSystemQuad.cpp
+++ b/cocos/2d/CCParticleSystemQuad.cpp
@@ -28,6 +28,9 @@ THE SOFTWARE.
 
 
 #include "2d/CCParticleSystemQuad.h"
+
+#include <algorithm>
+
 #include "2d/CCSpriteFrame.h"
 #include "2d/CCParticleBatchNode.h"
 #include "renderer/CCTextureAtlas.h"
@@ -172,7 +175,7 @@ void ParticleSystemQuad::initTexCoordsWithRect(const Rect& pointRect)
 #endif // ! CC_FIX_ARTIFACTS_BY_STRECHING_TEXEL
 
     // Important. Texture in cocos2d are inverted, so the Y component should be inverted
-    CC_SWAP( top, bottom, float);
+    std::swap(top, bottom);
 
     V3F_C4B_T2F_Quad *quads = nullptr;
     unsigned int start = 0, end = 0;

--- a/cocos/2d/CCProgressTimer.cpp
+++ b/cocos/2d/CCProgressTimer.cpp
@@ -25,6 +25,8 @@ THE SOFTWARE.
 ****************************************************************************/
 #include "2d/CCProgressTimer.h"
 
+#include <algorithm>
+
 #include "base/ccMacros.h"
 #include "base/CCDirector.h"
 #include "2d/CCSprite.h"
@@ -159,7 +161,7 @@ Tex2F ProgressTimer::textureCoordFromAlphaPoint(Vec2 alpha)
     Vec2 max = Vec2(quad.tr.texCoords.u,quad.tr.texCoords.v);
     //  Fix bug #1303 so that progress timer handles sprite frame texture rotation
     if (_sprite->isTextureRectRotated()) {
-        CC_SWAP(alpha.x, alpha.y, float);
+        std::swap(alpha.x, alpha.y);
     }
     return Tex2F(min.x * (1.f - alpha.x) + max.x * alpha.x, min.y * (1.f - alpha.y) + max.y * alpha.y);
 }

--- a/cocos/2d/CCSprite.cpp
+++ b/cocos/2d/CCSprite.cpp
@@ -27,6 +27,8 @@ THE SOFTWARE.
 
 #include "2d/CCSprite.h"
 
+#include <algorithm>
+
 #include "2d/CCSpriteBatchNode.h"
 #include "2d/CCAnimationCache.h"
 #include "2d/CCSpriteFrame.h"
@@ -438,12 +440,12 @@ void Sprite::setTextureCoords(Rect rect)
 
         if (_flippedX)
         {
-            CC_SWAP(top, bottom, float);
+            std::swap(top, bottom);
         }
 
         if (_flippedY)
         {
-            CC_SWAP(left, right, float);
+            std::swap(left, right);
         }
 
         _quad.bl.texCoords.u = left;
@@ -471,12 +473,12 @@ void Sprite::setTextureCoords(Rect rect)
 
         if(_flippedX)
         {
-            CC_SWAP(left,right,float);
+            std::swap(left, right);
         }
 
         if(_flippedY)
         {
-            CC_SWAP(top,bottom,float);
+            std::swap(top, bottom);
         }
 
         _quad.bl.texCoords.u = left;

--- a/cocos/base/ccMacros.h
+++ b/cocos/base/ccMacros.h
@@ -63,6 +63,7 @@ THE SOFTWARE.
 
 /** @def CC_SWAP
 simple macro that swaps 2 variables
+ @deprecated use std::swap() instead
 */
 #define CC_SWAP(x, y, type)    \
 {    type temp = (x);        \

--- a/download-deps.py
+++ b/download-deps.py
@@ -3,10 +3,12 @@
 #
 # ./download-deps.py
 #
-# Download Cocos2D-X resources from github (https://github.com/cocos2d/cocos2d-x-3rd-party-libs-bin) and extract from ZIP
+# Downloads Cocos2D-x 3rd party dependencies from github:
+# https://github.com/cocos2d/cocos2d-x-3rd-party-libs-bin) and extracts the zip
+# file
 #
-# Helps prevent repo bloat due to large binary files since they can
-# be hosted separately.
+# Having the dependencies outside the official cocos2d-x repo helps prevent
+# bloating the repo.
 #
 
 """****************************************************************************
@@ -183,7 +185,7 @@ class CocosZipInstaller(object):
                 else:
                     # file
                     data = z.read(info.filename)
-                    f = open(target,'wb')
+                    f = open(target, 'wb')
                     try:
                         f.write(data)
                     finally:

--- a/tests/cpp-tests/Classes/SpriteTest/SpriteTest.cpp
+++ b/tests/cpp-tests/Classes/SpriteTest/SpriteTest.cpp
@@ -2403,7 +2403,7 @@ void SpriteHybrid::reparentSprite(float dt)
     Vector<Node*> retArray(250);
 
     if( _usingSpriteBatchNode )
-        CC_SWAP(p1,p2, Node*);
+        std::swap(p1, p2);
 
     ////----CCLOG("New parent is: %x", p2);
     


### PR DESCRIPTION
CC_SWAP is deprecated. Use `std::swap` instead.
