### PR TITLE
Unignore libs dir and fix Travis script to descend into included directories. (follows #9108)

### DIFF
--- a/tools/travis-scripts/config.gitingore
+++ b/tools/travis-scripts/config.gitingore
@@ -115,6 +115,7 @@ tags
 !/cocos/2d/platform/android/java/res/
 # Permit plugins to ship third-party libraries.
 !/plugin/plugins/*/proj.android/libs/*.jar
+!/plugin/plugins/*/proj.android/libs
 
 v*-deps-*.zip
 v*-lua-runtime-*.zip

--- a/tools/travis-scripts/generate-template-files.py
+++ b/tools/travis-scripts/generate-template-files.py
@@ -97,6 +97,7 @@ class CocosFileList:
                             self.fileList_lua.append("%s/" %relativePath)
                         else:
                             self.fileList_com.append("%s/" %relativePath)
+                        self.__parseFileList(path)
                         continue
                 if (
                      self.__bExclude("/%s" %relativePath) or


### PR DESCRIPTION
Both commits follow #9108, which un-ignored jar files but unfortunately only
worked locally due to these changes, so here's a couple additional patches
to make the "gitingore" file not ignore the libs directories in Android plugins
and to get the Travis template file list script to actually record the contents
of included directories, since it previously would not (it'd record the directory
but ignore the contents, so you'd just end up with empty stub directories,
which isn't very useful).

Sorry that the first pull request didn't nail this immediately, but it was at least
a building block.
#### 4102746 Descend into included directories to check for file inclusion.

Only applies to directories that are marked as unignored, since the
travis script has the odd problem of not descending into those
directories and, as a result, not recording the files in them.

I'm assuming the failure to descend into included directories is
unintended.
#### 590975d Also un-ignore libs dir under plugins.

The configure script isn't smart enough to check if there are
un-ignored files in a directory, so this fixes that.
