### PR TITLE
Fix loadHTMLString on Android

### DIFF
--- a/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxWebViewHelper.java
+++ b/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxWebViewHelper.java
@@ -137,13 +137,13 @@ public class Cocos2dxWebViewHelper {
     }
 
     @SuppressWarnings("unused")
-    public static void loadHTMLString(final int index, final String htmlString, final String mimeType, final String encoding) {
+    public static void loadHTMLString(final int index, final String htmlString, final String baseURL) {
         cocos2dxActivity.runOnUiThread(new Runnable() {
             @Override
             public void run() {
                 Cocos2dxWebView webView = webViews.get(index);
                 if (webView != null) {
-                    webView.loadData(htmlString, mimeType, encoding);
+                    webView.loadDataWithBaseURL(baseURL, htmlString, null, null, null);
                 }
             }
         });

--- a/cocos/ui/UIWebViewImpl-android.cpp
+++ b/cocos/ui/UIWebViewImpl-android.cpp
@@ -158,10 +158,10 @@ void loadDataJNI(const int index, const std::string &data, const std::string &MI
 void loadHTMLStringJNI(const int index, const std::string &string, const std::string &baseURL) {
     // LOGD("error: %s,%d",__func__,__LINE__);
     cocos2d::JniMethodInfo t;
-    if (cocos2d::JniHelper::getStaticMethodInfo(t, CLASS_NAME, "loadHTMLString", "(ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;)V")) {
+    if (cocos2d::JniHelper::getStaticMethodInfo(t, CLASS_NAME, "loadHTMLString", "(ILjava/lang/String;Ljava/lang/String;)V")) {
         jstring jString = t.env->NewStringUTF(string.c_str());
         jstring jBaseURL = t.env->NewStringUTF(baseURL.c_str());
-        t.env->CallStaticVoidMethod(t.classID, t.methodID, index, jString, jBaseURL,nullptr);
+        t.env->CallStaticVoidMethod(t.classID, t.methodID, index, jString, jBaseURL);
 
         t.env->DeleteLocalRef(jString);
         t.env->DeleteLocalRef(jBaseURL);


### PR DESCRIPTION
- Fix implementation to conform to API
- Use html string as html string, not mimetype!
- Correctly handle baseURL (like iOS) instead of just ignoring it (why completely ignore param?)

As discussed [here](https://github.com/cocos2d/cocos2d-x/issues/9155)
