### PR TITLE
set default priority to avoid warning

### DIFF
--- a/cocos/base/CCScheduler.cpp
+++ b/cocos/base/CCScheduler.cpp
@@ -447,6 +447,7 @@ void Scheduler::appendIn(_listEntry **list, const ccSchedulerFunc& callback, voi
     listElement->callback = callback;
     listElement->target = target;
     listElement->paused = paused;
+    listElement->priority = 0;
     listElement->markedForDeletion = false;
 
     DL_APPEND(*list, listElement);


### PR DESCRIPTION
when call 'scheduleUpdate' and 'unscheuleUpdate' several times in one frame, it will get warning "warning: you CANNOT change update priority in scheduled function"
