### PR TITLE
In Android, when EditBox is released, callback should not be called from...

### DIFF
--- a/cocos/platform/android/jni/Java_org_cocos2dx_lib_Cocos2dxHelper.cpp
+++ b/cocos/platform/android/jni/Java_org_cocos2dx_lib_Cocos2dxHelper.cpp
@@ -132,6 +132,11 @@ void showEditTextDialogJNI(const char* title, const char* message, int inputMode
     }
 }
 
+void notifyEditTextDialogIsReleased() {
+    s_editTextCallback = nullptr;
+    s_ctx = nullptr;
+}
+
 void terminateProcessJNI() {
     JniMethodInfo t;
 

--- a/cocos/platform/android/jni/Java_org_cocos2dx_lib_Cocos2dxHelper.h
+++ b/cocos/platform/android/jni/Java_org_cocos2dx_lib_Cocos2dxHelper.h
@@ -32,6 +32,7 @@ typedef void (*EditTextCallback)(const char* text, void* ctx);
 extern const char * getApkPath();
 extern void showDialogJNI(const char * message, const char * title);
 extern void showEditTextDialogJNI(const char* title, const char* content, int inputMode, int inputFlag, int returnType, int maxLength, EditTextCallback callback, void* ctx);
+extern void notifyEditTextDialogIsReleased();
 extern void terminateProcessJNI();
 extern std::string getCurrentLanguageJNI();
 extern std::string getPackageNameJNI();

--- a/cocos/ui/UIEditBox/UIEditBoxImpl-android.cpp
+++ b/cocos/ui/UIEditBox/UIEditBoxImpl-android.cpp
@@ -58,7 +58,7 @@ EditBoxImplAndroid::EditBoxImplAndroid(EditBox* pEditText)
 
 EditBoxImplAndroid::~EditBoxImplAndroid()
 {
-	
+    notifyEditTextDialogIsReleased();
 }
 
 void EditBoxImplAndroid::doAnimationWhenKeyboardMove(float duration, float distance)


### PR DESCRIPTION
... Java.

When EditBoxDialog is closed, editBoxCallbackFunc is called.
However, if the instance of EditBoxImplAndroid has been removed at that time, thiz is already released.
