### PR TITLE
fix linux linker error

### DIFF
--- a/cocos/CMakeLists.txt
+++ b/cocos/CMakeLists.txt
@@ -149,7 +149,8 @@ if(MINGW)
 elseif(WINDOWS)
   set(PLATFORM_SPECIFIC_LIBS libjpeg libpng libwebp libtiff libcurl_imp libwebsockets freetype250 glew32 opengl32 libiconv libzlib)
 elseif(LINUX)
-  set(PLATFORM_SPECIFIC_LIBS jpeg webp tiff freetype curl websockets ssl crypto fontconfig png pthread GLEW GL X11 rt z ${FMOD_LIB})
+  set(PLATFORM_SPECIFIC_LIBS jpeg webp tiff freetype curl websockets ssl crypto
+  fontconfig png pthread glfw GLEW GL X11 rt z ${FMOD_LIB})
 elseif(MACOSX OR APPLE)
  INCLUDE_DIRECTORIES ( /System/Library/Frameworks )
 


### PR DESCRIPTION
Fix Jenkins CI linux server compile error.  
The fix is not perfect, but it works. 
Note: if you want to change glfw link flag, be careful about the linker order.

For more info, please refer to : http://stackoverflow.com/questions/17768008/how-to-build-install-glfw-3-and-use-it-in-a-linux-project
