### PR TITLE
Fixed accelerometer for windows store apps device orientation

### DIFF
--- a/cocos/platform/winrt/CCDevice.cpp
+++ b/cocos/platform/winrt/CCDevice.cpp
@@ -100,6 +100,7 @@ void Device::setAccelerometerEnabled(bool isEnabled)
 
             auto orientation = GLViewImpl::sharedOpenGLView()->getDeviceOrientation();
 
+#if (WINAPI_FAMILY == WINAPI_FAMILY_PHONE_APP)
             switch (orientation)
             {
             case DisplayOrientations::Portrait:
@@ -127,7 +128,36 @@ void Device::setAccelerometerEnabled(bool isEnabled)
 				acc.y = reading->AccelerationY;
                 break;
             }
+#else // Windows Store App
+            // from http://msdn.microsoft.com/en-us/library/windows/apps/dn440593
+            switch (orientation)
+            {
+            case DisplayOrientations::Portrait:
+                acc.x = reading->AccelerationY;
+                acc.y = -reading->AccelerationX;
+                break;
 
+            case DisplayOrientations::Landscape:
+                acc.x = reading->AccelerationX;
+                acc.y = reading->AccelerationY;
+                break;
+
+            case DisplayOrientations::PortraitFlipped:
+                acc.x = -reading->AccelerationY;
+                acc.y = reading->AccelerationX;
+                break;
+
+            case DisplayOrientations::LandscapeFlipped:
+                acc.x = -reading->AccelerationY;
+                acc.y = reading->AccelerationX;
+                break;
+
+            default:
+                acc.x = reading->AccelerationY;
+                acc.y = -reading->AccelerationX;
+                break;
+            }
+#endif
 	        std::shared_ptr<cocos2d::InputEvent> event(new AccelerometerEvent(acc));
             cocos2d::GLViewImpl::sharedOpenGLView()->QueueEvent(event);
 		});


### PR DESCRIPTION
Fixed accelerometer for windows store apps device orientation. Windows Phone 8.1 and Windows Store 8.1 require different handling of x and y values from the accelerometer based on the device orientation.
