### PR TITLE
Add applicationWillTerminate to CCApplicationProtocol

### DIFF
--- a/cocos/platform/CCApplicationProtocol.h
+++ b/cocos/platform/CCApplicationProtocol.h
@@ -93,6 +93,13 @@ public:
     * @lua NA
     */
     virtual void applicationWillEnterForeground() = 0;
+    
+    /**
+     @brief  This function will be called when the application terminates.
+     * @js NA
+     * @lua NA
+     */
+    virtual void applicationWillTerminate() = 0;
 
     /**
     @brief    Callback by Director for limit FPS.

--- a/cocos/platform/CCApplicationProtocol.h
+++ b/cocos/platform/CCApplicationProtocol.h
@@ -99,7 +99,7 @@ public:
      * @js NA
      * @lua NA
      */
-    virtual void applicationWillTerminate() = 0;
+    virtual void applicationWillTerminate() {};
 
     /**
     @brief    Callback by Director for limit FPS.

--- a/templates/cpp-template-default/Classes/AppDelegate.cpp
+++ b/templates/cpp-template-default/Classes/AppDelegate.cpp
@@ -61,3 +61,8 @@ void AppDelegate::applicationWillEnterForeground() {
     // if you use SimpleAudioEngine, it must resume here
     // SimpleAudioEngine::getInstance()->resumeBackgroundMusic();
 }
+
+// this function will be called when the app will terminate
+void AppDelegate::applicationWillTerminate() {
+
+}

--- a/templates/cpp-template-default/Classes/AppDelegate.h
+++ b/templates/cpp-template-default/Classes/AppDelegate.h
@@ -34,6 +34,12 @@ public:
     @param  the pointer of the application
     */
     virtual void applicationWillEnterForeground();
+    
+    /**
+     @brief  The function be called when the application enter foreground
+     @param  the pointer of the application
+     */
+    virtual void applicationWillTerminate();
 };
 
 #endif // _APP_DELEGATE_H_

--- a/templates/cpp-template-default/proj.ios_mac/ios/AppController.mm
+++ b/templates/cpp-template-default/proj.ios_mac/ios/AppController.mm
@@ -124,6 +124,8 @@ static AppDelegate s_sharedApplication;
      Called when the application is about to terminate.
      See also applicationDidEnterBackground:.
      */
+    
+    cocos2d::Application::getInstance()->applicationWillTerminate();
 }
 
 


### PR DESCRIPTION
I added the applicationWillTerminate method to CCApplicationProtocol for completeness. I use it in my games to upload any final analytics before the apps close so it would be great to add this to the cocos2dx source.
