### PR TITLE
Fix modules include path to be relative project directory.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@ project (Cocos2d-X)
 # The version number
 set(COCOS2D_X_VERSION 3.3.0-rc1)
 
-set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/Modules/")
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${PROJECT_SOURCE_DIR}/cmake/Modules/")
 include(CocosBuildHelpers)
 
 message(${BUILDING_STRING})


### PR DESCRIPTION
This change allow to include cocos project directory from another CMakeFiles.txt (with add_subdirectory). And will allow anyone to connect cocos as submodule to their project easily.

I can't easily fix config agains current 'v3' in #8902 , sorry. And just created this pull request instead.
Old #8902 can be closed now.
