### PR TITLE
[Don't merge this PR]Fix loading bar scale9 issue

### DIFF
--- a/cocos/ui/UILoadingBar.cpp
+++ b/cocos/ui/UILoadingBar.cpp
@@ -195,6 +195,11 @@ bool LoadingBar::isScale9Enabled()const
     return _scale9Enabled;
 }
     
+void LoadingBar::toggleScale9CornerSpriteVisibility(bool visible)
+{
+    _barRenderer->toggleCornerSpritesVisibility(visible);
+}
+    
 void LoadingBar::setCapInsets(const Rect &capInsets)
 {
     _capInsets = capInsets;

--- a/cocos/ui/UILoadingBar.h
+++ b/cocos/ui/UILoadingBar.h
@@ -114,6 +114,7 @@ public:
      * @param enabled true that using scale9 renderer, false otherwise.
      */
     void setScale9Enabled(bool enabled);
+    void toggleScale9CornerSpriteVisibility(bool visible);
     
     bool isScale9Enabled()const;
     

--- a/cocos/ui/UIScale9Sprite.cpp
+++ b/cocos/ui/UIScale9Sprite.cpp
@@ -551,7 +551,7 @@ y+=ytranslate;         \
         
         this->toggleSlicedSpriteVisibility(true);
         
-        if (sizableWidth < 0.0f || sizableHeight < 0.0f)
+        if ((size.width == 0 || size.height == 0) && (sizableWidth < 0.0f || sizableHeight < 0.0f))
         {
             CCLOG("Invalid capInset size");
             this->toggleSlicedSpriteVisibility(false);

--- a/cocos/ui/UIScale9Sprite.cpp
+++ b/cocos/ui/UIScale9Sprite.cpp
@@ -265,7 +265,8 @@ y+=ytranslate;         \
         float w = _originalSize.width;
         float h = _originalSize.height;
         
-        Vec2 offsetPosition(ceil(_offset.x + (_originalSize.width - _spriteRect.size.width) / 2), ceil(_offset.y + (_originalSize.height - _spriteRect.size.height) / 2));
+        Vec2 offsetPosition(ceil(_offset.x + (_originalSize.width - _spriteRect.size.width) / 2),
+                            ceil(_offset.y + (_originalSize.height - _spriteRect.size.height) / 2));
         
         // If there is no specified center region
         if ( _capInsetsInternal.equals(Rect::ZERO) )
@@ -276,9 +277,19 @@ y+=ytranslate;         \
         
         Rect originalRect;
         if(_spriteFrameRotated)
-            originalRect = Rect(_spriteRect.origin.x - offsetPosition.y, _spriteRect.origin.y - offsetPosition.x, _originalSize.width, _originalSize.height);
+        {
+            originalRect = Rect(_spriteRect.origin.x - offsetPosition.y,
+                                _spriteRect.origin.y - offsetPosition.x,
+                                _originalSize.width,
+                                _originalSize.height);
+        }
         else
-            originalRect = Rect(_spriteRect.origin.x - offsetPosition.x, _spriteRect.origin.y - offsetPosition.y, _originalSize.width, _originalSize.height);
+        {
+            originalRect = Rect(_spriteRect.origin.x - offsetPosition.x,
+                                _spriteRect.origin.y - offsetPosition.y,
+                                _originalSize.width,
+                                _originalSize.height);
+        }
         
         float left_w = _capInsetsInternal.origin.x;
         float center_w = _capInsetsInternal.size.width;
@@ -294,6 +305,7 @@ y+=ytranslate;         \
         float x = 0.0;
         float y = 0.0;
         
+        //pixelRect is the real size of the spriteFrame, when the spriteFrame is croped, the real size is smaller than the originalRect
         Rect pixelRect = Rect(offsetPosition.x, offsetPosition.y, _spriteRect.size.width, _spriteRect.size.height);
         
         // top left
@@ -527,6 +539,29 @@ y+=ytranslate;         \
             _bottomRight = Sprite::createWithTexture(_scale9Image->getTexture(), rotatedrightbottombounds, _spriteFrameRotated);
             _bottomRight->retain();
             this->addProtectedChild(_bottomRight);
+        }
+    }
+    
+    void Scale9Sprite::handleCapInsetSizeExceedContentSize()
+    {
+        Size size = this->_contentSize;
+        
+        float sizableWidth = size.width - _topLeftSize.width - _bottomRightSize.width;
+        float sizableHeight = size.height - _topLeftSize.height - _bottomRightSize.height;
+        
+        this->toggleSlicedSpriteVisibility(true);
+        
+        if (sizableWidth < 0.0f || sizableHeight < 0.0f)
+        {
+            CCLOG("Invalid capInset size");
+            this->toggleSlicedSpriteVisibility(false);
+        }
+    }
+    
+    void Scale9Sprite::toggleSlicedSpriteVisibility(bool visible)
+    {
+        for (const auto& sp : _protectedChildren) {
+            sp->setVisible(visible);
         }
     }
     
@@ -804,13 +839,6 @@ y+=ytranslate;         \
         return NULL;
     }
     
-    /** sets the opacity.
-     @warning If the the texture has premultiplied alpha then, the R, G and B channels will be modifed.
-     Values goes from 0 to 255, where 255 means fully opaque.
-     */
-    
-    
-    
     void Scale9Sprite::updateCapInset()
     {
         Rect insets;
@@ -1052,6 +1080,7 @@ y+=ytranslate;         \
     {
         if(this->_positionsAreDirty)
         {
+            this->handleCapInsetSizeExceedContentSize();
             this->updatePositions();
             this->adjustScale9ImagePosition();
             this->_positionsAreDirty = false;

--- a/cocos/ui/UIScale9Sprite.cpp
+++ b/cocos/ui/UIScale9Sprite.cpp
@@ -566,28 +566,6 @@ y+=ytranslate;         \
         
     }
     
-    void Scale9Sprite::handleCapInsetSizeExceedContentSize()
-    {
-        Size size = this->_contentSize;
-        
-        float sizableWidth = size.width - _topLeftSize.width - _bottomRightSize.width;
-        float sizableHeight = size.height - _topLeftSize.height - _bottomRightSize.height;
-        
-        this->toggleSlicedSpriteVisibility(true);
-        
-        if ((size.width == 0 || size.height == 0) && (sizableWidth < 0.0f || sizableHeight < 0.0f))
-        {
-            CCLOG("Invalid capInset size");
-            this->toggleSlicedSpriteVisibility(false);
-        }
-    }
-    
-    void Scale9Sprite::toggleSlicedSpriteVisibility(bool visible)
-    {
-        for (const auto& sp : _protectedChildren) {
-            sp->setVisible(visible);
-        }
-    }
     
     void Scale9Sprite::setContentSize(const Size &size)
     {
@@ -602,13 +580,12 @@ y+=ytranslate;         \
         float sizableWidth = size.width - _topLeftSize.width - _bottomRightSize.width;
         float sizableHeight = size.height - _topLeftSize.height - _bottomRightSize.height;
         
-        if (sizableHeight < 0) {
+        this->toggleCornerSpritesVisibility(true);
+        if (sizableHeight < 0 || sizableWidth < 0) {
             sizableHeight = 0;
             sizableWidth = 0;
-        }
-        if (sizableWidth < 0) {
-            sizableWidth = 0;
-            sizableHeight = 0;
+            CCLOG("Warning: invalid capInset size!");
+            this->toggleCornerSpritesVisibility(false);
         }
         
         float horizontalScale = sizableWidth/_centerSize.width;

--- a/cocos/ui/UIScale9Sprite.cpp
+++ b/cocos/ui/UIScale9Sprite.cpp
@@ -542,6 +542,30 @@ y+=ytranslate;         \
         }
     }
     
+    void Scale9Sprite::toggleCornerSpritesVisibility(bool visible)
+    {
+        if (_topLeft)
+        {
+            _topLeft->setVisible(visible);
+        }
+        
+        if (_topRight)
+        {
+            _topRight->setVisible(visible);
+        }
+        
+        if (_bottomLeft)
+        {
+            _bottomLeft->setVisible(visible);
+        }
+        
+        if (_bottomRight)
+        {
+            _bottomRight->setVisible(visible);
+        }
+        
+    }
+    
     void Scale9Sprite::handleCapInsetSizeExceedContentSize()
     {
         Size size = this->_contentSize;
@@ -577,6 +601,15 @@ y+=ytranslate;         \
         
         float sizableWidth = size.width - _topLeftSize.width - _bottomRightSize.width;
         float sizableHeight = size.height - _topLeftSize.height - _bottomRightSize.height;
+        
+        if (sizableHeight < 0) {
+            sizableHeight = 0;
+            sizableWidth = 0;
+        }
+        if (sizableWidth < 0) {
+            sizableWidth = 0;
+            sizableHeight = 0;
+        }
         
         float horizontalScale = sizableWidth/_centerSize.width;
         float verticalScale = sizableHeight/_centerSize.height;
@@ -1080,7 +1113,6 @@ y+=ytranslate;         \
     {
         if(this->_positionsAreDirty)
         {
-            this->handleCapInsetSizeExceedContentSize();
             this->updatePositions();
             this->adjustScale9ImagePosition();
             this->_positionsAreDirty = false;

--- a/cocos/ui/UIScale9Sprite.h
+++ b/cocos/ui/UIScale9Sprite.h
@@ -370,6 +370,8 @@ namespace ui {
         void createSlicedSprites();
         void cleanupSlicedSprites();
         void adjustScale9ImagePosition();
+        void handleCapInsetSizeExceedContentSize();
+        void toggleSlicedSpriteVisibility(bool visible);
         /**
          * Sorts the children array once before drawing, instead of every time when a child is added or reordered.
          * This appraoch can improves the performance massively.

--- a/cocos/ui/UIScale9Sprite.h
+++ b/cocos/ui/UIScale9Sprite.h
@@ -273,7 +273,7 @@ namespace ui {
         void setScale9Enabled(bool enabled);
         bool isScale9Enabled()const;
         
-        
+        void toggleCornerSpritesVisibility(bool visible);
         
         /// @} end of Children and Parent
         

--- a/cocos/ui/UIScale9Sprite.h
+++ b/cocos/ui/UIScale9Sprite.h
@@ -370,8 +370,6 @@ namespace ui {
         void createSlicedSprites();
         void cleanupSlicedSprites();
         void adjustScale9ImagePosition();
-        void handleCapInsetSizeExceedContentSize();
-        void toggleSlicedSpriteVisibility(bool visible);
         /**
          * Sorts the children array once before drawing, instead of every time when a child is added or reordered.
          * This appraoch can improves the performance massively.

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/CocosGUIScene.cpp
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/CocosGUIScene.cpp
@@ -139,7 +139,7 @@ g_guisTests[] =
             UISceneManager* sceneManager = UISceneManager::sharedUISceneManager();
             sceneManager->setCurrentUISceneId(kUILoadingBarTest_Left);
             sceneManager->setMinUISceneId(kUILoadingBarTest_Left);
-            sceneManager->setMaxUISceneId(kUILoadingBarTest_Right_Scale9);
+            sceneManager->setMaxUISceneId(kUILoadingBarTest_Issue9091);
             Scene* scene = sceneManager->currentUIScene();
             Director::getInstance()->replaceScene(scene);
         }

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UILoadingBarTest/UILoadingBarTest.cpp
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UILoadingBarTest/UILoadingBarTest.cpp
@@ -339,3 +339,51 @@ void UILoadingBarTest_Right_Scale9::nextCallback(Ref* sender, Widget::TouchEvent
         UIScene::nextCallback(sender, type);
     }
 }
+
+// UILoadingBarTest_Issue9091
+
+UILoadingBarTest_Issue9091::UILoadingBarTest_Issue9091()
+{
+    
+}
+
+UILoadingBarTest_Issue9091::~UILoadingBarTest_Issue9091()
+{
+}
+
+bool UILoadingBarTest_Issue9091::init()
+{
+    if (UIScene::init())
+    {
+        
+        Size widgetSize = _widget->getContentSize();
+        
+        // Add the alert
+        Text *alert = Text::create("LoadingBar should be invisible here", "fonts/Marker Felt.ttf", 20);
+        alert->setColor(Color3B(159, 168, 176));
+        alert->setPosition(Vec2(widgetSize.width / 2.0f,
+                                widgetSize.height / 2.0f ));
+        _uiLayer->addChild(alert);
+        
+        // Create the loading bar
+        LoadingBar* loadingBar = LoadingBar::create("cocosui/slider_bar_active_9patch.png");
+        loadingBar->setTag(0);
+        loadingBar->setScale9Enabled(true);
+        loadingBar->setCapInsets(Rect(0, 0, 0, 0));
+        loadingBar->setContentSize(Size(300, 13));
+        loadingBar->setDirection(LoadingBar::Direction::RIGHT);
+        loadingBar->setPercent(0);
+        
+        loadingBar->setPosition(Vec2(widgetSize.width / 2.0f - loadingBar->getContentSize().width/2,
+                                     widgetSize.height / 2.0f - 50 ));
+        
+        _uiLayer->addChild(loadingBar);
+        
+        return true;
+    }
+    return false;
+}
+
+
+
+

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UILoadingBarTest/UILoadingBarTest.cpp
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UILoadingBarTest/UILoadingBarTest.cpp
@@ -365,14 +365,25 @@ bool UILoadingBarTest_Issue9091::init()
                                 widgetSize.height / 2.0f ));
         _uiLayer->addChild(alert);
         
+        auto scale9Sprite = Scale9Sprite::create("cocosui/slider_bar_active_9patch.png");
+        scale9Sprite->setPosition(Vec2(widgetSize.width/2,
+                                       widgetSize.height/2 + 50));
+        scale9Sprite->setPreferredSize(Size(0,0));
+        scale9Sprite->setInsetLeft(0);
+        scale9Sprite->setInsetBottom(0);
+        scale9Sprite->setInsetRight(0);
+        scale9Sprite->setInsetTop(0);
+        _uiLayer->addChild(scale9Sprite);
+        
         // Create the loading bar
         LoadingBar* loadingBar = LoadingBar::create("cocosui/slider_bar_active_9patch.png");
         loadingBar->setTag(0);
-        loadingBar->setScale9Enabled(true);
         loadingBar->setCapInsets(Rect(0, 0, 0, 0));
+        
         loadingBar->setContentSize(Size(300, 13));
         loadingBar->setDirection(LoadingBar::Direction::RIGHT);
         loadingBar->setPercent(0);
+        loadingBar->setScale9Enabled(true);
         
         loadingBar->setPosition(Vec2(widgetSize.width / 2.0f - loadingBar->getContentSize().width/2,
                                      widgetSize.height / 2.0f - 50 ));

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UILoadingBarTest/UILoadingBarTest.cpp
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UILoadingBarTest/UILoadingBarTest.cpp
@@ -291,7 +291,7 @@ bool UILoadingBarTest_Right_Scale9::init()
         loadingBar->setCapInsets(Rect(0, 0, 0, 0));
         loadingBar->setContentSize(Size(300, 13));
         loadingBar->setDirection(LoadingBar::Direction::RIGHT);
-        
+        loadingBar->toggleScale9CornerSpriteVisibility(false);
         loadingBar->setPosition(Vec2(widgetSize.width / 2.0f,
                                       widgetSize.height / 2.0f + loadingBar->getContentSize().height / 4.0f));
         
@@ -373,22 +373,26 @@ bool UILoadingBarTest_Issue9091::init()
         scale9Sprite->setInsetBottom(0);
         scale9Sprite->setInsetRight(0);
         scale9Sprite->setInsetTop(0);
+        scale9Sprite->toggleCornerSpritesVisibility(false);
         _uiLayer->addChild(scale9Sprite);
         
         // Create the loading bar
         LoadingBar* loadingBar = LoadingBar::create("cocosui/slider_bar_active_9patch.png");
         loadingBar->setTag(0);
         loadingBar->setCapInsets(Rect(0, 0, 0, 0));
-        
         loadingBar->setContentSize(Size(300, 13));
         loadingBar->setDirection(LoadingBar::Direction::RIGHT);
         loadingBar->setPercent(0);
         loadingBar->setScale9Enabled(true);
+        loadingBar->toggleScale9CornerSpriteVisibility(false);
+        
         
         loadingBar->setPosition(Vec2(widgetSize.width / 2.0f - loadingBar->getContentSize().width/2,
                                      widgetSize.height / 2.0f - 50 ));
         
         _uiLayer->addChild(loadingBar);
+        
+        
         
         return true;
     }

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UILoadingBarTest/UILoadingBarTest.cpp
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UILoadingBarTest/UILoadingBarTest.cpp
@@ -365,7 +365,7 @@ bool UILoadingBarTest_Issue9091::init()
                                 widgetSize.height / 2.0f ));
         _uiLayer->addChild(alert);
         
-        auto scale9Sprite = Scale9Sprite::create("cocosui/slider_bar_active_9patch.png");
+        auto scale9Sprite = ui::Scale9Sprite::create("cocosui/slider_bar_active_9patch.png");
         scale9Sprite->setPosition(Vec2(widgetSize.width/2,
                                        widgetSize.height/2 + 50));
         scale9Sprite->setPreferredSize(Size(0,0));

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UILoadingBarTest/UILoadingBarTest.h
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UILoadingBarTest/UILoadingBarTest.h
@@ -95,4 +95,16 @@ protected:
     int _count;
 };
 
+class UILoadingBarTest_Issue9091 : public UIScene
+{
+public:
+    UILoadingBarTest_Issue9091();
+    ~UILoadingBarTest_Issue9091();
+    bool init();
+ 
+    
+protected:
+    UI_SCENE_CREATE_FUNC(UILoadingBarTest_Issue9091)
+};
+
 #endif /* defined(__TestCpp__UILoadingBarTest__) */

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UISceneManager.cpp
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UISceneManager.cpp
@@ -62,6 +62,7 @@ static const char* s_testArray[] =
     "UILoadingBarTest_Right",
     "UILoadingBarTest_Left_Scale9",
     "UILoadingBarTest_Right_Scale9",
+    "UILoadingBarTest_Issue9091",
   
     "UITextAtlasTest",
     "UITextTest",
@@ -252,6 +253,9 @@ Scene *UISceneManager::currentUIScene()
             
         case kUILoadingBarTest_Right_Scale9:
             return UILoadingBarTest_Right_Scale9::sceneWithTitle(s_testArray[_currentUISceneId]);
+            
+        case kUILoadingBarTest_Issue9091:
+            return UILoadingBarTest_Issue9091::sceneWithTitle(s_testArray[_currentUISceneId]);
             
         case kUITextAtlasTest:
             return UITextAtlasTest::sceneWithTitle(s_testArray[_currentUISceneId]);

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UISceneManager.h
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UISceneManager.h
@@ -57,6 +57,7 @@ enum
     kUILoadingBarTest_Right,
     kUILoadingBarTest_Left_Scale9,
     kUILoadingBarTest_Right_Scale9,
+    kUILoadingBarTest_Issue9091,
     kUITextAtlasTest,
     kUITextTest,
     kUITextTest_LineWrap,


### PR DESCRIPTION
When the capInset size of Scale9Sprite exceed the limit of sprite contentSize, the display will be wrong.

Now my solution is invisible the wrong displayed scale9sprite.

I will make more test to verify this patch.
