### PR TITLE
fix UIScale9Sprite setFlipped bug

### DIFF
--- a/cocos/ui/UIScale9Sprite.cpp
+++ b/cocos/ui/UIScale9Sprite.cpp
@@ -1211,7 +1211,9 @@ y+=ytranslate;         \
         _flippedX = flippedX;
         if (_scale9Enabled)
         {
-            this->setScaleX(-1);
+            if (_flippedX) {
+                this->setScaleX(-1);
+            }
         }
         else
         {
@@ -1227,7 +1229,9 @@ y+=ytranslate;         \
         _flippedY = flippedY;
         if (_scale9Enabled)
         {
-            this->setScaleY(-1);
+            if (_flippedY) {
+                this->setScaleY(-1);
+            }
         }
         else
         {


### PR DESCRIPTION
Currently a Scale9Sprite in 3.3RC0 will be flipped even if `_flippedX` or `_flippedY` is set to false, which is a bug.
