### PR TITLE
Fix label crashed on android #9255

### DIFF
--- a/cocos/2d/CCLabel.cpp
+++ b/cocos/2d/CCLabel.cpp
@@ -270,7 +270,14 @@ Label::Label(FontAtlas *atlas /* = nullptr */, TextHAlignment hAlignment /* = Te
             _batchNodes.clear();
             _batchNodes.push_back(this);
 
-            alignText();
+            if (_contentDirty)
+            {
+                updateContent();
+            }
+            else
+            {
+                alignText();
+            }
         }
     });
     _eventDispatcher->addEventListenerWithSceneGraphPriority(purgeTextureListener, this);

--- a/cocos/2d/CCLabelTextFormatter.cpp
+++ b/cocos/2d/CCLabelTextFormatter.cpp
@@ -314,6 +314,7 @@ bool LabelTextFormatter::createStringSprites(Label *theLabel)
     FontLetterDefinition tempDefinition;
     Vec2 letterPosition;
     const auto& kernings = theLabel->_horizontalKernings;
+    CCASSERT(kernings, "kernings must's be nullptr!!!");
 
     float clipTop = 0;
     float clipBottom = 0;

--- a/tests/cpp-tests/Classes/LabelTest/LabelTestNew.cpp
+++ b/tests/cpp-tests/Classes/LabelTest/LabelTestNew.cpp
@@ -82,7 +82,8 @@ static std::function<Layer*()> createFunctions[] =
     CL(LabelLineHeightTest),
     CL(LabelAdditionalKerningTest),
     CL(LabelIssue8492Test),
-    CL(LabelMultilineWithOutline)
+    CL(LabelMultilineWithOutline),
+    CL(LabelIssue9255Test)
 };
 
 #define MAX_LAYER    (sizeof(createFunctions) / sizeof(createFunctions[0]))
@@ -1851,4 +1852,28 @@ std::string LabelMultilineWithOutline::title() const
 std::string LabelMultilineWithOutline::subtitle() const
 {
     return "end in string 'outline feature'";
+}
+
+
+LabelIssue9255Test::LabelIssue9255Test()
+{
+    Size s = Director::getInstance()->getWinSize();
+    auto parent = Node::create();
+    parent->setPosition(s.width/2, s.height/2);
+    parent->setVisible(false);
+    this->addChild(parent);
+
+    auto label =  Label::createWithTTF("Crashed!!!", "fonts/HKYuanMini.ttf", 24);
+    label->setPosition(VisibleRect::center());
+    parent->addChild(label);
+}
+
+std::string LabelIssue9255Test::title() const
+{
+    return "Test for Issue #9255";
+}
+
+std::string LabelIssue9255Test::subtitle() const
+{
+    return "switch to desktop and switch back. Crashed!!!";
 }

--- a/tests/cpp-tests/Classes/LabelTest/LabelTestNew.h
+++ b/tests/cpp-tests/Classes/LabelTest/LabelTestNew.h
@@ -533,4 +533,16 @@ public:
 
 // we don't support linebreak mode
 
+class LabelIssue9255Test : public AtlasDemoNew
+{
+public:
+    CREATE_FUNC(LabelIssue9255Test);
+
+    LabelIssue9255Test();
+
+    virtual std::string title() const override;
+    virtual std::string subtitle() const override;
+};
+
+
 #endif


### PR DESCRIPTION
fixed issue #9255 

when a label instance add to a invisibility parent node, app switch to home/desktop,  switch back.
CRASHED!!!
