### PR TITLE
Don't remove eaglView from superview on CCGLViewImpl

### DIFF
--- a/cocos/platform/ios/CCGLViewImpl-ios.mm
+++ b/cocos/platform/ios/CCGLViewImpl-ios.mm
@@ -186,8 +186,6 @@ void GLViewImpl::end()
     // destroy EAGLView
     CCEAGLView *eaglview = (CCEAGLView*) _eaglview;
 
-    [eaglview removeFromSuperview];
-    //[eaglview release];
     release();
 }
 


### PR DESCRIPTION
CCGLViewImpl doesn't add the view on the superview, but it is removing it. This is causing issues on our code, and I think it's wrong.

This PR is not really finished as I bet some code for the samples and templates needs to be updated so that it removes that view, but I thought this is easier to start a discussion and find out if there is a good reason why CCGLViewImpl is removing this. 

As far as I can tell, on every sample code it's the AppController that is adding the view to the superview, in which case CCGLViewImpl shouldn't be the one removing it, but rather AppController. I'd like someone to tell me if I'm right and should take this further, or explain why I'm wrong if possible.
