### PR TITLE
Fix for when cocos is included as a cmake subproject.

### DIFF
--- a/templates/cpp-template-default/CMakeLists.txt
+++ b/templates/cpp-template-default/CMakeLists.txt
@@ -85,7 +85,9 @@ set(GAME_SRC
 )
 endif()
 
-set(COCOS2D_ROOT ${CMAKE_SOURCE_DIR}/cocos2d)
+if (NOT COCOS2D_ROOT)
+	set(COCOS2D_ROOT ${CMAKE_SOURCE_DIR}/cocos2d)
+endif()
 if (WIN32)
 include_directories(
   ${COCOS2D_ROOT}

--- a/templates/lua-template-default/frameworks/CMakeLists.txt
+++ b/templates/lua-template-default/frameworks/CMakeLists.txt
@@ -34,7 +34,9 @@ set(GAME_SRC
   runtime-src/Classes/AppDelegate.cpp
 )
 
-set(COCOS2D_ROOT ${CMAKE_SOURCE_DIR}/cocos2d-x)
+if (NOT COCOS2D_ROOT)
+	set(COCOS2D_ROOT ${CMAKE_SOURCE_DIR}/cocos2d-x)
+endif()
 
 include_directories(
   /usr/include

--- a/tests/cpp-tests/CMakeLists.txt
+++ b/tests/cpp-tests/CMakeLists.txt
@@ -235,7 +235,7 @@ endif()
 
 include_directories(
   Classes
-  ${CMAKE_SOURCE_DIR}/cocos/editor-support
+  ${COCOS2D_ROOT}/cocos/editor-support
 )
 
 # add the executable


### PR DESCRIPTION
Projects seeking to include cocos2d-x as a subproject can now define COCOS2D_ROOT to enable this behaviour. For example my master cmake file:

```
cmake_minimum_required(VERSION 2.8 FATAL_ERROR)
project(game)

set(CMAKE_C_FLAGS_DEBUG   "-g -Wall -Werror -O0 -D_DEBUG -DCOCOS2D_DEBUG=1")
set(CMAKE_CXX_FLAGS_DEBUG "-std=c++11 -g -Wall -Werror -O0 -D_DEBUG -DCOCOS2D_DEBUG=1")
set(CMAKE_C_FLAGS_RELEASE   "-Wall -Werror -O3 -D_DEBUG -DCOCOS2D_DEBUG=0")
set(CMAKE_CXX_FLAGS_RELEASE "-std=c++11 -Wall -Werror -O3 -D_DEBUG -DCOCOS2D_DEBUG=0")

list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/lib/cocos2d-x/cmake/Modules")

set(ENV{COCOS_CONSOLE_ROOT} "${CMAKE_SOURCE_DIR}/lib/cocos2d-x/tools/cocos2d-console/bin")
set(ENV{COCOS_X_ROOT} "${CMAKE_SOURCE_DIR}/lib/cocos2d-x")
set(COCOS2D_ROOT "${CMAKE_SOURCE_DIR}/lib/cocos2d-x")

add_subdirectory(lib/cocos2d-x)
add_subdirectory(src/game)
```
