### PR TITLE
Add more useful trace back info when got invalid arguments by calling functions

### DIFF
--- a/cocos/scripting/lua-bindings/manual/3d/lua_cocos2dx_3d_manual.cpp
+++ b/cocos/scripting/lua-bindings/manual/3d/lua_cocos2dx_3d_manual.cpp
@@ -64,7 +64,7 @@ int lua_cocos2dx_3d_Sprite3D_setBlendFunc(lua_State* L)
         cobj->setBlendFunc(blendFunc);
         return 0;
     }
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d \n", "cc.Sprite3D:setBlendFunc",argc, 2);
+    luaL_error(L, "%s has wrong number of arguments: %d, was expecting %d \n", "cc.Sprite3D:setBlendFunc",argc, 2);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -105,7 +105,7 @@ int lua_cocos2dx_3d_Sprite3D_getAABB(lua_State* L)
         object_to_luaval<cocos2d::AABB>(L, "cc.AABB",(cocos2d::AABB*)ret);
         return 1;
     }
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d \n", "cc.Sprite3D:getAABB",argc, 0);
+    luaL_error(L, "%s has wrong number of arguments: %d, was expecting %d \n", "cc.Sprite3D:getAABB",argc, 0);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -169,7 +169,7 @@ int lua_cocos2dx_3d_AABB_reset(lua_State* L)
         cobj->reset();
         return 0;
     }
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d \n", "cc.AABB:reset",argc, 0);
+    luaL_error(L, "%s has wrong number of arguments: %d, was expecting %d \n", "cc.AABB:reset",argc, 0);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -218,7 +218,7 @@ int lua_cocos2dx_3d_AABB_set(lua_State* L)
         cobj->set(arg0, arg1);
         return 0;
     }
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d \n", "cc.AABB:set",argc, 2);
+    luaL_error(L, "%s has wrong number of arguments: %d, was expecting %d \n", "cc.AABB:set",argc, 2);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -264,7 +264,7 @@ int lua_cocos2dx_3d_AABB_transform(lua_State* L)
         cobj->transform(arg0);
         return 0;
     }
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d \n", "cc.AABB:transform",argc, 1);
+    luaL_error(L, "%s has wrong number of arguments: %d, was expecting %d \n", "cc.AABB:transform",argc, 1);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -308,7 +308,7 @@ int lua_cocos2dx_3d_AABB_getCenter(lua_State* L)
         vec3_to_luaval(L, ret);
         return 1;
     }
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d \n", "cc.AABB:getCenter",argc, 0);
+    luaL_error(L, "%s has wrong number of arguments: %d, was expecting %d \n", "cc.AABB:getCenter",argc, 0);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -352,7 +352,7 @@ int lua_cocos2dx_3d_AABB_isEmpty(lua_State* L)
         tolua_pushboolean(L,(bool)ret);
         return 1;
     }
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d \n", "cc.AABB:isEmpty",argc, 0);
+    luaL_error(L, "%s has wrong number of arguments: %d, was expecting %d \n", "cc.AABB:isEmpty",argc, 0);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -398,7 +398,7 @@ int lua_cocos2dx_3d_AABB_getCorners(lua_State* L)
         cobj->getCorners(arg0);
         return 0;
     }
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d \n", "cc.AABB:getCorners",argc, 1);
+    luaL_error(L, "%s has wrong number of arguments: %d, was expecting %d \n", "cc.AABB:getCorners",argc, 1);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -447,7 +447,7 @@ int lua_cocos2dx_3d_AABB_updateMinMax(lua_State* L)
         cobj->updateMinMax(arg0, arg1);
         return 0;
     }
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d \n", "cc.AABB:updateMinMax",argc, 2);
+    luaL_error(L, "%s has wrong number of arguments: %d, was expecting %d \n", "cc.AABB:updateMinMax",argc, 2);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -494,7 +494,7 @@ int lua_cocos2dx_3d_AABB_containPoint(lua_State* L)
         tolua_pushboolean(L,(bool)ret);
         return 1;
     }
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d \n", "cc.AABB:containPoint",argc, 1);
+    luaL_error(L, "%s has wrong number of arguments: %d, was expecting %d \n", "cc.AABB:containPoint",argc, 1);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -540,7 +540,7 @@ int lua_cocos2dx_3d_AABB_constructor(lua_State* L)
         }
     }while(0);
     ok  = true;
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d \n",  "cc.AABB:AABB",argc, 0);
+    luaL_error(L, "%s has wrong number of arguments: %d, was expecting %d \n",  "cc.AABB:AABB",argc, 0);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -748,7 +748,7 @@ int lua_cocos2dx_3d_OBB_reset(lua_State* L)
         cobj->reset();
         return 0;
     }
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d \n", "cc.OBB:reset",argc, 0);
+    luaL_error(L, "%s has wrong number of arguments: %d, was expecting %d \n", "cc.OBB:reset",argc, 0);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -806,7 +806,7 @@ int lua_cocos2dx_3d_OBB_set(lua_State* L)
         cobj->set(arg0, arg1, arg2, arg3, arg4);
         return 0;
     }
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d \n", "cc.OBB:set",argc, 5);
+    luaL_error(L, "%s has wrong number of arguments: %d, was expecting %d \n", "cc.OBB:set",argc, 5);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -852,7 +852,7 @@ int lua_cocos2dx_3d_OBB_transform(lua_State* L)
         cobj->transform(arg0);
         return 0;
     }
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d \n", "cc.OBB:transform",argc, 1);
+    luaL_error(L, "%s has wrong number of arguments: %d, was expecting %d \n", "cc.OBB:transform",argc, 1);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -900,7 +900,7 @@ int lua_cocos2dx_3d_OBB_containPoint(lua_State* L)
         tolua_pushboolean(L,(bool)ret);
         return 1;
     }
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d \n", "cc.OBB:containPoint",argc, 1);
+    luaL_error(L, "%s has wrong number of arguments: %d, was expecting %d \n", "cc.OBB:containPoint",argc, 1);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -960,7 +960,7 @@ int lua_cocos2dx_3d_OBB_constructor(lua_State* L)
         }
     }while(0);
     ok  = true;
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d \n",  "cc.OBB:OBB",argc, 2);
+    luaL_error(L, "%s has wrong number of arguments: %d, was expecting %d \n",  "cc.OBB:OBB",argc, 2);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -1001,7 +1001,7 @@ int lua_cocos2dx_3d_OBB_intersects(lua_State* L)
         tolua_pushboolean(L, ret);
         return 1;
     }
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d \n",  "cc.OBB:intersects",argc, 1);
+    luaL_error(L, "%s has wrong number of arguments: %d, was expecting %d \n",  "cc.OBB:intersects",argc, 1);
     return 0;
 #if COCOS2D_DEBUG >= 1
 tolua_lerror:
@@ -1381,7 +1381,7 @@ int lua_cocos2dx_3d_OBB_getCorners(lua_State* L)
         size_t len = lua_objlen(L, 2);
         if (len == 0 )
         {
-            CCLOG("Table's len equal 0");
+            luaL_error(L, "Table's len equal 0");
             return 0;
         }
         
@@ -1389,7 +1389,7 @@ int lua_cocos2dx_3d_OBB_getCorners(lua_State* L)
         
         if (nullptr == arg0)
         {
-            CCLOG("Allocate cocos2d::Vec3 array in the lua_cocos2dx_3d_OBB_getCorners failed!");
+            luaL_error(L, "Allocate cocos2d::Vec3 array in the lua_cocos2dx_3d_OBB_getCorners failed!");
             return 0;
         }
         
@@ -1422,7 +1422,7 @@ int lua_cocos2dx_3d_OBB_getCorners(lua_State* L)
         
         return 1;
     }
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d \n", "cc.OBB:getCorners",argc, 1);
+    luaL_error(L, "%s has wrong number of arguments: %d, was expecting %d \n", "cc.OBB:getCorners",argc, 1);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -1504,7 +1504,7 @@ int lua_cocos2dx_3d_Ray_set(lua_State* L)
         cobj->set(arg0, arg1);
         return 0;
     }
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d \n", "cc.Ray:set",argc, 2);
+    luaL_error(L, "%s has wrong number of arguments: %d, was expecting %d \n", "cc.Ray:set",argc, 2);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -1550,7 +1550,7 @@ int lua_cocos2dx_3d_Ray_transform(lua_State* L)
         cobj->transform(arg0);
         return 0;
     }
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d \n", "cc.Ray:transform",argc, 1);
+    luaL_error(L, "%s has wrong number of arguments: %d, was expecting %d \n", "cc.Ray:transform",argc, 1);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -1592,7 +1592,7 @@ int lua_cocos2dx_3d_Ray_intersects(lua_State* L)
         tolua_pushboolean(L, ret);
         return 1;
     }
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d \n",  "cc.Ray:intersects",argc, 1);
+    luaL_error(L, "%s has wrong number of arguments: %d, was expecting %d \n",  "cc.Ray:intersects",argc, 1);
     return 0;
 #if COCOS2D_DEBUG >= 1
 tolua_lerror:
@@ -1637,7 +1637,7 @@ int lua_cocos2dx_3d_Ray_constructor(lua_State* L)
         }
     }while(0);
     ok  = true;
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d \n",  "cc.Ray:Ray",argc, 0);
+    luaL_error(L, "%s has wrong number of arguments: %d, was expecting %d \n",  "cc.Ray:Ray",argc, 0);
     return 0;
     
 #if COCOS2D_DEBUG >= 1

--- a/cocos/scripting/lua-bindings/manual/audioengine/lua_cocos2dx_audioengine_manual.cpp
+++ b/cocos/scripting/lua-bindings/manual/audioengine/lua_cocos2dx_audioengine_manual.cpp
@@ -279,7 +279,7 @@ int lua_cocos2dx_audioengine_AudioEngine_setFinishCallback(lua_State* tolua_S)
     
         return 0;
     }
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d\n ", "ccexp.AudioEngine:setFinishCallback",argc, 2);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d\n ", "ccexp.AudioEngine:setFinishCallback",argc, 2);
     return 0;
 #if COCOS2D_DEBUG >= 1
 tolua_lerror:

--- a/cocos/scripting/lua-bindings/manual/cocos2d/lua_cocos2dx_deprecated.cpp
+++ b/cocos/scripting/lua-bindings/manual/cocos2d/lua_cocos2dx_deprecated.cpp
@@ -2000,7 +2000,7 @@ static int lua_cocos2dx_LabelBMFont_setLineBreakWithoutSpace(lua_State* tolua_S)
         cobj->setLineBreakWithoutSpace(arg0);
         return 0;
     }
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d \n", "cc.LabelBMFont:setLineBreakWithoutSpace",argc, 1);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "cc.LabelBMFont:setLineBreakWithoutSpace",argc, 1);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -2044,7 +2044,7 @@ static int lua_cocos2dx_LabelBMFont_getBlendFunc(lua_State* tolua_S)
         blendfunc_to_luaval(tolua_S, ret);
         return 1;
     }
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d \n", "cc.LabelBMFont:getBlendFunc",argc, 0);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "cc.LabelBMFont:getBlendFunc",argc, 0);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -2088,7 +2088,7 @@ static int lua_cocos2dx_LabelBMFont_isOpacityModifyRGB(lua_State* tolua_S)
         tolua_pushboolean(tolua_S,(bool)ret);
         return 1;
     }
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d \n", "cc.LabelBMFont:isOpacityModifyRGB",argc, 0);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "cc.LabelBMFont:isOpacityModifyRGB",argc, 0);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -2135,7 +2135,7 @@ static int lua_cocos2dx_LabelBMFont_getLetter(lua_State* tolua_S)
         object_to_luaval<cocos2d::Sprite>(tolua_S, "cc.Sprite",(cocos2d::Sprite*)ret);
         return 1;
     }
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d \n", "cc.LabelBMFont:getLetter",argc, 1);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "cc.LabelBMFont:getLetter",argc, 1);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -2179,7 +2179,7 @@ static int lua_cocos2dx_LabelBMFont_getString(lua_State* tolua_S)
         tolua_pushcppstring(tolua_S,ret);
         return 1;
     }
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d \n", "cc.LabelBMFont:getString",argc, 0);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "cc.LabelBMFont:getString",argc, 0);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -2225,7 +2225,7 @@ static int lua_cocos2dx_LabelBMFont_setBlendFunc(lua_State* tolua_S)
         cobj->setBlendFunc(arg0);
         return 0;
     }
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d \n", "cc.LabelBMFont:setBlendFunc",argc, 1);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "cc.LabelBMFont:setBlendFunc",argc, 1);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -2271,7 +2271,7 @@ static int lua_cocos2dx_LabelBMFont_setString(lua_State* tolua_S)
         cobj->setString(arg0);
         return 0;
     }
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d \n", "cc.LabelBMFont:setString",argc, 1);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "cc.LabelBMFont:setString",argc, 1);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -2381,7 +2381,7 @@ static int lua_cocos2dx_LabelBMFont_initWithString(lua_State* tolua_S)
         tolua_pushboolean(tolua_S,(bool)ret);
         return 1;
     }
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d \n", "cc.LabelBMFont:initWithString",argc, 2);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "cc.LabelBMFont:initWithString",argc, 2);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -2427,7 +2427,7 @@ static int lua_cocos2dx_LabelBMFont_setOpacityModifyRGB(lua_State* tolua_S)
         cobj->setOpacityModifyRGB(arg0);
         return 0;
     }
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d \n", "cc.LabelBMFont:setOpacityModifyRGB",argc, 1);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "cc.LabelBMFont:setOpacityModifyRGB",argc, 1);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -2471,7 +2471,7 @@ static int lua_cocos2dx_LabelBMFont_getFntFile(lua_State* tolua_S)
         tolua_pushcppstring(tolua_S,ret);
         return 1;
     }
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d \n", "cc.LabelBMFont:getFntFile",argc, 0);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "cc.LabelBMFont:getFntFile",argc, 0);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -2530,7 +2530,7 @@ static int lua_cocos2dx_LabelBMFont_setFntFile(lua_State* tolua_S)
         cobj->setFntFile(arg0, arg1);
         return 0;
     }
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d \n", "cc.LabelBMFont:setFntFile",argc, 1);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "cc.LabelBMFont:setFntFile",argc, 1);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -2576,7 +2576,7 @@ static int lua_cocos2dx_LabelBMFont_setAlignment(lua_State* tolua_S)
         cobj->setAlignment(arg0);
         return 0;
     }
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d \n", "cc.LabelBMFont:setAlignment",argc, 1);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "cc.LabelBMFont:setAlignment",argc, 1);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -2622,7 +2622,7 @@ static int lua_cocos2dx_LabelBMFont_setWidth(lua_State* tolua_S)
         cobj->setWidth(arg0);
         return 0;
     }
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d \n", "cc.LabelBMFont:setWidth",argc, 1);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "cc.LabelBMFont:setWidth",argc, 1);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -2738,7 +2738,7 @@ static int lua_cocos2dx_LabelBMFont_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d", "cc.LabelBMFont:create",argc, 2);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d", "cc.LabelBMFont:create",argc, 2);
     return 0;
 #if COCOS2D_DEBUG >= 1
 tolua_lerror:
@@ -2770,7 +2770,7 @@ static int lua_cocos2dx_LabelBMFont_constructor(lua_State* tolua_S)
         toluafix_pushusertype_ccobject(tolua_S, ID, luaID, (void*)cobj,"cc.LabelBMFont");
         return 1;
     }
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d \n", "cc.LabelBMFont:new",argc, 0);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "cc.LabelBMFont:new",argc, 0);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -2878,7 +2878,7 @@ static int lua_cocos2dx_LabelTTF_enableShadow(lua_State* tolua_S)
         cobj->enableShadow(arg0, arg1, arg2, arg3);
         return 0;
     }
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d \n", "cc.LabelTTF:enableShadow",argc, 3);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "cc.LabelTTF:enableShadow",argc, 3);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -2924,7 +2924,7 @@ static int lua_cocos2dx_LabelTTF_setDimensions(lua_State* tolua_S)
         cobj->setDimensions(arg0);
         return 0;
     }
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d \n", "cc.LabelTTF:setDimensions",argc, 1);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "cc.LabelTTF:setDimensions",argc, 1);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -2968,7 +2968,7 @@ static int lua_cocos2dx_LabelTTF_getFontSize(lua_State* tolua_S)
         tolua_pushnumber(tolua_S,(lua_Number)ret);
         return 1;
     }
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d \n", "cc.LabelTTF:getFontSize",argc, 0);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "cc.LabelTTF:getFontSize",argc, 0);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -3012,7 +3012,7 @@ static int lua_cocos2dx_LabelTTF_getString(lua_State* tolua_S)
         tolua_pushcppstring(tolua_S,ret);
         return 1;
     }
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d \n", "cc.LabelTTF:getString",argc, 0);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "cc.LabelTTF:getString",argc, 0);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -3058,7 +3058,7 @@ static int lua_cocos2dx_LabelTTF_setFlippedY(lua_State* tolua_S)
         cobj->setFlippedY(arg0);
         return 0;
     }
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d \n", "cc.LabelTTF:setFlippedY",argc, 1);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "cc.LabelTTF:setFlippedY",argc, 1);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -3104,7 +3104,7 @@ static int lua_cocos2dx_LabelTTF_setFlippedX(lua_State* tolua_S)
         cobj->setFlippedX(arg0);
         return 0;
     }
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d \n", "cc.LabelTTF:setFlippedX",argc, 1);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "cc.LabelTTF:setFlippedX",argc, 1);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -3150,7 +3150,7 @@ static int lua_cocos2dx_LabelTTF_setTextDefinition(lua_State* tolua_S)
         cobj->setTextDefinition(arg0);
         return 0;
     }
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d \n", "cc.LabelTTF:setTextDefinition",argc, 1);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "cc.LabelTTF:setTextDefinition",argc, 1);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -3196,7 +3196,7 @@ static int lua_cocos2dx_LabelTTF_setFontName(lua_State* tolua_S)
         cobj->setFontName(arg0);
         return 0;
     }
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d \n", "cc.LabelTTF:setFontName",argc, 1);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "cc.LabelTTF:setFontName",argc, 1);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -3240,7 +3240,7 @@ static int lua_cocos2dx_LabelTTF_getHorizontalAlignment(lua_State* tolua_S)
         tolua_pushnumber(tolua_S,(lua_Number)ret);
         return 1;
     }
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d \n", "cc.LabelTTF:getHorizontalAlignment",argc, 0);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "cc.LabelTTF:getHorizontalAlignment",argc, 0);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -3290,7 +3290,7 @@ static int lua_cocos2dx_LabelTTF_initWithStringAndTextDefinition(lua_State* tolu
         tolua_pushboolean(tolua_S,(bool)ret);
         return 1;
     }
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d \n", "cc.LabelTTF:initWithStringAndTextDefinition",argc, 2);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "cc.LabelTTF:initWithStringAndTextDefinition",argc, 2);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -3336,7 +3336,7 @@ static int lua_cocos2dx_LabelTTF_setString(lua_State* tolua_S)
         cobj->setString(arg0);
         return 0;
     }
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d \n", "cc.LabelTTF:setString",argc, 1);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "cc.LabelTTF:setString",argc, 1);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -3458,7 +3458,7 @@ static int lua_cocos2dx_LabelTTF_initWithString(lua_State* tolua_S)
         tolua_pushboolean(tolua_S,(bool)ret);
         return 1;
     }
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d \n", "cc.LabelTTF:initWithString",argc, 3);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "cc.LabelTTF:initWithString",argc, 3);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -3517,7 +3517,7 @@ static int lua_cocos2dx_LabelTTF_setFontFillColor(lua_State* tolua_S)
         cobj->setFontFillColor(arg0, arg1);
         return 0;
     }
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d \n", "cc.LabelTTF:setFontFillColor",argc, 1);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "cc.LabelTTF:setFontFillColor",argc, 1);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -3561,7 +3561,7 @@ static int lua_cocos2dx_LabelTTF_getBlendFunc(lua_State* tolua_S)
         blendfunc_to_luaval(tolua_S, ret);
         return 1;
     }
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d \n", "cc.LabelTTF:getBlendFunc",argc, 0);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "cc.LabelTTF:getBlendFunc",argc, 0);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -3626,7 +3626,7 @@ static int lua_cocos2dx_LabelTTF_enableStroke(lua_State* tolua_S)
         cobj->enableStroke(arg0, arg1, arg2);
         return 0;
     }
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d \n", "cc.LabelTTF:enableStroke",argc, 2);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "cc.LabelTTF:enableStroke",argc, 2);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -3670,7 +3670,7 @@ static int lua_cocos2dx_LabelTTF_getDimensions(lua_State* tolua_S)
         size_to_luaval(tolua_S, ret);
         return 1;
     }
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d \n", "cc.LabelTTF:getDimensions",argc, 0);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "cc.LabelTTF:getDimensions",argc, 0);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -3716,7 +3716,7 @@ static int lua_cocos2dx_LabelTTF_setVerticalAlignment(lua_State* tolua_S)
         cobj->setVerticalAlignment(arg0);
         return 0;
     }
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d \n", "cc.LabelTTF:setVerticalAlignment",argc, 1);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "cc.LabelTTF:setVerticalAlignment",argc, 1);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -3762,7 +3762,7 @@ static int lua_cocos2dx_LabelTTF_setFontSize(lua_State* tolua_S)
         cobj->setFontSize(arg0);
         return 0;
     }
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d \n", "cc.LabelTTF:setFontSize",argc, 1);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "cc.LabelTTF:setFontSize",argc, 1);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -3806,7 +3806,7 @@ static int lua_cocos2dx_LabelTTF_getVerticalAlignment(lua_State* tolua_S)
         tolua_pushnumber(tolua_S,(lua_Number)ret);
         return 1;
     }
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d \n", "cc.LabelTTF:getVerticalAlignment",argc, 0);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "cc.LabelTTF:getVerticalAlignment",argc, 0);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -3850,7 +3850,7 @@ static int lua_cocos2dx_LabelTTF_getTextDefinition(lua_State* tolua_S)
         fontdefinition_to_luaval(tolua_S, ret);
         return 1;
     }
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d \n", "cc.LabelTTF:getTextDefinition",argc, 0);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "cc.LabelTTF:getTextDefinition",argc, 0);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -3896,7 +3896,7 @@ static int lua_cocos2dx_LabelTTF_setBlendFunc(lua_State* tolua_S)
         cobj->setBlendFunc(arg0);
         return 0;
     }
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d \n", "cc.LabelTTF:setBlendFunc",argc, 1);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "cc.LabelTTF:setBlendFunc",argc, 1);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -3940,7 +3940,7 @@ static int lua_cocos2dx_LabelTTF_getFontName(lua_State* tolua_S)
         tolua_pushcppstring(tolua_S,ret);
         return 1;
     }
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d \n", "cc.LabelTTF:getFontName",argc, 0);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "cc.LabelTTF:getFontName",argc, 0);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -3986,7 +3986,7 @@ static int lua_cocos2dx_LabelTTF_setHorizontalAlignment(lua_State* tolua_S)
         cobj->setHorizontalAlignment(arg0);
         return 0;
     }
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d \n", "cc.LabelTTF:setHorizontalAlignment",argc, 1);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "cc.LabelTTF:setHorizontalAlignment",argc, 1);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -4039,7 +4039,7 @@ static int lua_cocos2dx_LabelTTF_disableShadow(lua_State* tolua_S)
         cobj->disableShadow(arg0);
         return 0;
     }
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d \n", "cc.LabelTTF:disableShadow",argc, 0);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "cc.LabelTTF:disableShadow",argc, 0);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -4092,7 +4092,7 @@ static int lua_cocos2dx_LabelTTF_disableStroke(lua_State* tolua_S)
         cobj->disableStroke(arg0);
         return 0;
     }
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d \n", "cc.LabelTTF:disableStroke",argc, 0);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "cc.LabelTTF:disableStroke",argc, 0);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -4220,7 +4220,7 @@ static int lua_cocos2dx_LabelTTF_create(lua_State* tolua_S)
         }
     } while (0);
     ok  = true;
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d", "cc.LabelTTF:create",argc, 3);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d", "cc.LabelTTF:create",argc, 3);
     return 0;
 #if COCOS2D_DEBUG >= 1
 tolua_lerror:
@@ -4255,7 +4255,7 @@ static int lua_cocos2dx_LabelTTF_createWithFontDefinition(lua_State* tolua_S)
         object_to_luaval<cocos2d::LabelTTF>(tolua_S, "cc.LabelTTF",(cocos2d::LabelTTF*)ret);
         return 1;
     }
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d\n ", "cc.LabelTTF:createWithFontDefinition",argc, 2);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d\n ", "cc.LabelTTF:createWithFontDefinition",argc, 2);
     return 0;
 #if COCOS2D_DEBUG >= 1
 tolua_lerror:
@@ -4287,7 +4287,7 @@ static int lua_cocos2dx_LabelTTF_constructor(lua_State* tolua_S)
         toluafix_pushusertype_ccobject(tolua_S, ID, luaID, (void*)cobj,"cc.LabelTTF");
         return 1;
     }
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d \n", "cc.LabelTTF:new",argc, 0);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "cc.LabelTTF:new",argc, 0);
     return 0;
     
 #if COCOS2D_DEBUG >= 1

--- a/cocos/scripting/lua-bindings/manual/cocos2d/lua_cocos2dx_experimental_manual.cpp
+++ b/cocos/scripting/lua-bindings/manual/cocos2d/lua_cocos2dx_experimental_manual.cpp
@@ -58,7 +58,7 @@ static int lua_cocos2dx_experimental_TMXLayer_getTileGIDAt(lua_State* tolua_S)
         tolua_pushnumber(tolua_S,(lua_Number)arg1);
         return 2;
     }
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d \n", "ccexp.TMXLayer:getTileGIDAt",argc, 1);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ccexp.TMXLayer:getTileGIDAt",argc, 1);
     return 0;
     
 #if COCOS2D_DEBUG >= 1

--- a/cocos/scripting/lua-bindings/manual/cocos2d/lua_cocos2dx_manual.cpp
+++ b/cocos/scripting/lua-bindings/manual/cocos2d/lua_cocos2dx_manual.cpp
@@ -105,7 +105,7 @@ static int tolua_cocos2d_MenuItemImage_create(lua_State* tolua_S)
         }
     } while (0);
     
-	CCLOG("%s has wrong number of arguments: %d, was expecting %d\n", "cc.MenuItemImage:create",argc, 0);
+	luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d\n", "cc.MenuItemImage:create",argc, 0);
 	return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -146,7 +146,7 @@ static int tolua_cocos2d_MenuItemLabel_create(lua_State* tolua_S)
         return 1;
     }
     
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d\n", "cc.MenuItemLabel:create", argc, 1);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d\n", "cc.MenuItemLabel:create", argc, 1);
 	return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -186,7 +186,7 @@ static int tolua_cocos2d_MenuItemFont_create(lua_State* tolua_S)
         return 1;
     }
     
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d\n", "cc.MenuItemFont:create", argc, 1);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d\n", "cc.MenuItemFont:create", argc, 1);
 	return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -240,7 +240,7 @@ static int tolua_cocos2d_MenuItemSprite_create(lua_State* tolua_S)
         return 1;
     }
     
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d\n", "cc.MenuItemSprite:create",argc, 3);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d\n", "cc.MenuItemSprite:create",argc, 3);
 	return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -298,7 +298,7 @@ static int tolua_cocos2d_Menu_create(lua_State* tolua_S)
         return 1;
     }
     
-    CCLOG("create wrong number of arguments: %d, was expecting %d\n", argc, 0);
+    luaL_error(tolua_S, "create wrong number of arguments: %d, was expecting %d\n", argc, 0);
 	return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -342,7 +342,7 @@ static int tolua_cocos2dx_Menu_alignItemsInRows(lua_State* tolua_S)
         return 0;
     }
     
-    CCLOG("'alignItemsInRows' has wrong number of arguments in tolua_cocos2dx_Menu_alignItemsInRows: %d, was expecting %d\n", argc, 1);
+    luaL_error(tolua_S, "'alignItemsInRows' has wrong number of arguments in tolua_cocos2dx_Menu_alignItemsInRows: %d, was expecting %d\n", argc, 1);
 	return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -385,7 +385,7 @@ static int tolua_cocos2dx_Menu_alignItemsInColumns(lua_State* tolua_S)
         return 0;
     }
     
-    CCLOG("'alignItemsInColumns' has wrong number of arguments in tolua_cocos2dx_Menu_alignItemsInColumns: %d, was expecting %d\n", argc, 1);
+    luaL_error(tolua_S, "'alignItemsInColumns' has wrong number of arguments in tolua_cocos2dx_Menu_alignItemsInColumns: %d, was expecting %d\n", argc, 1);
 	return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -435,7 +435,7 @@ static int tolua_cocos2d_MenuItemToggle_create(lua_State* tolua_S)
         return 1;
     }
     
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d\n", "cc.MenuItemToggle:create",argc, 1);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d\n", "cc.MenuItemToggle:create",argc, 1);
 	return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -476,7 +476,7 @@ static int tolua_cocos2d_MenuItem_registerScriptTapHandler(lua_State* tolua_S)
         return 0;
     }
     
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d\n", "cc.MenuItem:registerScriptTapHandler",argc, 1);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d\n", "cc.MenuItem:registerScriptTapHandler",argc, 1);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -516,7 +516,7 @@ static int tolua_cocos2d_MenuItem_unregisterScriptTapHandler(lua_State* tolua_S)
         return 0;
     }
     
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d\n", "cc.MenuItem:unregisterScriptTapHandler", argc, 0);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d\n", "cc.MenuItem:unregisterScriptTapHandler", argc, 0);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -676,7 +676,7 @@ static int lua_cocos2dx_Layer_setTouchEnabled(lua_State* L)
         return 0;
     }
     
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d\n", "cc.Layer:setTouchEnabled", argc, 1);
+    luaL_error(L, "%s has wrong number of arguments: %d, was expecting %d\n", "cc.Layer:setTouchEnabled", argc, 1);
     return 0;
 #if COCOS2D_DEBUG >= 1
 tolua_lerror:
@@ -723,7 +723,7 @@ static int lua_cocos2dx_Layer_isTouchEnabled(lua_State* L)
         return 0;
     }
     
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d\n", "cc.Layer:isTouchEnabled", argc, 0);
+    luaL_error(L, "%s has wrong number of arguments: %d, was expecting %d\n", "cc.Layer:isTouchEnabled", argc, 0);
     return 0;
 #if COCOS2D_DEBUG >= 1
 tolua_lerror:
@@ -790,7 +790,7 @@ static int lua_cocos2dx_Layer_setTouchMode(lua_State* L)
         return 0;
     }
     
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d\n", "cc.Layer:setTouchMode", argc, 1);
+    luaL_error(L, "%s has wrong number of arguments: %d, was expecting %d\n", "cc.Layer:setTouchMode", argc, 1);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -838,7 +838,7 @@ static int lua_cocos2dx_Layer_getTouchMode(lua_State* L)
         return 0;
     }
     
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d\n", "cc.Layer:getTouchMode", argc, 0);
+    luaL_error(L, "%s has wrong number of arguments: %d, was expecting %d\n", "cc.Layer:getTouchMode", argc, 0);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -905,7 +905,7 @@ static int lua_cocos2dx_Layer_setSwallowsTouches(lua_State* L)
         return 0;
     }
     
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d\n", "cc.Layer:setSwallowsTouches", argc, 1);
+    luaL_error(L, "%s has wrong number of arguments: %d, was expecting %d\n", "cc.Layer:setSwallowsTouches", argc, 1);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -951,7 +951,7 @@ static int lua_cocos2dx_Layer_isSwallowsTouches(lua_State* L)
         return 0;
     }
     
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d\n", "cc.Layer:isSwallowsTouches", argc, 0);
+    luaL_error(L, "%s has wrong number of arguments: %d, was expecting %d\n", "cc.Layer:isSwallowsTouches", argc, 0);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -1023,7 +1023,7 @@ static int lua_cocos2dx_Layer_setKeyboardEnabled(lua_State* L)
         return 0;
     }
     
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d\n", "cc.Layer:setKeyboardEnabled", argc, 1);
+    luaL_error(L, "%s has wrong number of arguments: %d, was expecting %d\n", "cc.Layer:setKeyboardEnabled", argc, 1);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -1070,7 +1070,7 @@ static int lua_cocos2dx_Layer_isKeyboardEnabled(lua_State* L)
         return 0;
     }
     
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d\n", "cc.Layer:isKeyboardEnabled", argc, 0);
+    luaL_error(L, "%s has wrong number of arguments: %d, was expecting %d\n", "cc.Layer:isKeyboardEnabled", argc, 0);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -1143,7 +1143,7 @@ static int lua_cocos2dx_Layer_setAccelerometerEnabled(lua_State* L)
         return 0;
     }
     
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d\n", "cc.Layer:setAccelerometerEnabled", argc, 1);
+    luaL_error(L, "%s has wrong number of arguments: %d, was expecting %d\n", "cc.Layer:setAccelerometerEnabled", argc, 1);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -1192,7 +1192,7 @@ static int lua_cocos2dx_Layer_isAccelerometerEnabled(lua_State* L)
     }
     
     
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d\n", "cc.Layer:isAccelerometerEnabled", argc, 0);
+    luaL_error(L, "%s has wrong number of arguments: %d, was expecting %d\n", "cc.Layer:isAccelerometerEnabled", argc, 0);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -1237,7 +1237,7 @@ static int lua_cocos2dx_Layer_setAccelerometerInterval(lua_State* L)
         return 0;
     }
     
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d\n", "cc.Layer:setAccelerometerInterval",argc, 1);
+    luaL_error(L, "%s has wrong number of arguments: %d, was expecting %d\n", "cc.Layer:setAccelerometerInterval",argc, 1);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -1367,7 +1367,7 @@ static int tolua_cocos2d_Layer_registerScriptTouchHandler(lua_State* tolua_S)
         return 0;
     }
     
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d\n", "cc.Layer:registerScriptTouchHandler", argc, 1);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d\n", "cc.Layer:registerScriptTouchHandler", argc, 1);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -1420,7 +1420,7 @@ static int tolua_cocos2d_Layer_unregisterScriptTouchHandler(lua_State* tolua_S)
         return 0;
     }
     
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d\n", "cc.Layer:unregisterScriptTouchHandler", argc, 0);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d\n", "cc.Layer:unregisterScriptTouchHandler", argc, 0);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -1467,7 +1467,7 @@ static int tolua_cocos2d_Layer_registerScriptKeypadHandler(lua_State* tolua_S)
         return 0;
     }
     
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d\n", "cc.Layer:registerScriptKeypadHandler", argc, 1);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d\n", "cc.Layer:registerScriptKeypadHandler", argc, 1);
     return 0;
 
 #if COCOS2D_DEBUG >= 1
@@ -1520,7 +1520,7 @@ static int tolua_cocos2d_Layer_unregisterScriptKeypadHandler(lua_State* tolua_S)
         return 0;
     }
 
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d\n", "cc.Layer:unregisterScriptKeypadHandler", argc, 0);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d\n", "cc.Layer:unregisterScriptKeypadHandler", argc, 0);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -1566,7 +1566,7 @@ static int tolua_cocos2d_Layer_registerScriptAccelerateHandler(lua_State* tolua_
         return 0;
     }
     
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d\n", "cc.Layer:registerScriptAccelerateHandler", argc, 1);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d\n", "cc.Layer:registerScriptAccelerateHandler", argc, 1);
     return 0;
 #if COCOS2D_DEBUG >= 1
 tolua_lerror:
@@ -1617,7 +1617,7 @@ static int tolua_cocos2d_Layer_unregisterScriptAccelerateHandler(lua_State* tolu
         return 0;
     }
     
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d\n", "cc.Layer:unregisterScriptAccelerateHandler", argc, 0);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d\n", "cc.Layer:unregisterScriptAccelerateHandler", argc, 0);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -1667,7 +1667,7 @@ static int tolua_cocos2d_Scheduler_scheduleScriptFunc(lua_State* tolua_S)
         return 1;
     }
     
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d\n", "cc.Scheduler:scheduleScriptFunc",  argc, 3);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d\n", "cc.Scheduler:scheduleScriptFunc",  argc, 3);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -1714,7 +1714,7 @@ static int tolua_cocos2d_Scheduler_unscheduleScriptEntry(lua_State* tolua_S)
         return 0;
     }
     
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d\n", "cc.Scheduler:unscheduleScriptEntry",argc, 1);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d\n", "cc.Scheduler:unscheduleScriptEntry",argc, 1);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -1772,7 +1772,7 @@ int tolua_cocos2d_Sequence_create(lua_State* tolua_S)
         toluafix_pushusertype_ccobject(tolua_S, nID, pLuaID, (void*)tolua_ret,"cc.Sequence");
         return 1;
     }
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d\n", "cc.Sequence:create", argc, 1);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d\n", "cc.Sequence:create", argc, 1);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -1863,7 +1863,7 @@ static int tolua_cocos2d_CallFunc_create(lua_State* tolua_S)
         return 1;
     }
     
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d\n", "cc.CallFunc:create", argc, 1);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d\n", "cc.CallFunc:create", argc, 1);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -1910,7 +1910,7 @@ static int tolua_cocos2d_Node_registerScriptHandler(lua_State* tolua_S)
         return 0;
     }
     
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d\n", "cc.Node:registerScriptHandler",argc, 1);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d\n", "cc.Node:registerScriptHandler",argc, 1);
     return 0;
 
 #if COCOS2D_DEBUG >= 1
@@ -1949,7 +1949,7 @@ static int tolua_cocos2d_Node_unregisterScriptHandler(lua_State* tolua_S)
         return 0;
     }
     
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d\n", "cc.Node:unregisterScriptHandler", argc, 0);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d\n", "cc.Node:unregisterScriptHandler", argc, 0);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -1999,7 +1999,7 @@ static int tolua_Cocos2d_Node_scheduleUpdateWithPriorityLua(lua_State* tolua_S)
         return 0;
     }
     
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d\n","cc.Node:scheduleUpdateWithPriorityLua",  argc, 2);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d\n","cc.Node:scheduleUpdateWithPriorityLua",  argc, 2);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -2038,7 +2038,7 @@ static int tolua_cocos2d_Node_unscheduleUpdate(lua_State* tolua_S)
         return 0;
     }
     
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d\n", "cc.Node:unscheduleUpdate", argc, 0);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d\n", "cc.Node:unscheduleUpdate", argc, 0);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -2097,7 +2097,7 @@ int tolua_cocos2d_Node_setContentSize(lua_State* tolua_S)
         return 0;
     }
     
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d \n", "cc.Node:setContentSize",argc, 1);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "cc.Node:setContentSize",argc, 1);
     return 0;
 #if COCOS2D_DEBUG >= 1
 tolua_lerror:
@@ -2155,7 +2155,7 @@ int tolua_cocos2d_Node_setAnchorPoint(lua_State* tolua_S)
         return 0;
     }
     
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d \n", "cc.Node:setAnchorPoint",argc, 1);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "cc.Node:setAnchorPoint",argc, 1);
     return 0;
 #if COCOS2D_DEBUG >= 1
 tolua_lerror:
@@ -2204,7 +2204,7 @@ static int tolua_cocos2d_Node_getPosition(lua_State* tolua_S)
         return 2;
     }
     
-    CCLOG("%s function in Node has wrong number of arguments: %d, was expecting %d\n", "cc.Node:getPosition",argc, 0);
+    luaL_error(tolua_S, "%s function in Node has wrong number of arguments: %d, was expecting %d\n", "cc.Node:getPosition",argc, 0);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -2263,7 +2263,7 @@ static int lua_cocos2dx_Node_enumerateChildren(lua_State* tolua_S)
         
         return 0;
     }
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d \n", "enumerateChildren",argc, 2);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "enumerateChildren",argc, 2);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -2317,7 +2317,7 @@ int lua_cocos2dx_Node_setAdditionalTransform(lua_State* tolua_S)
         }
     }while(0);
     ok  = true;
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d \n",  "cc.Node:setAdditionalTransform",argc, 1);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n",  "cc.Node:setAdditionalTransform",argc, 1);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -2376,7 +2376,7 @@ static int tolua_cocos2d_Spawn_create(lua_State* tolua_S)
         return 1;
     }
     
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d\n", "cc.Spawn:create", argc, 1);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d\n", "cc.Spawn:create", argc, 1);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -2448,7 +2448,7 @@ int lua_cocos2d_CardinalSplineBy_create(lua_State* tolua_S)
         }
     }
     
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d\n", "cc.CardinalSplineBy:create", argc, 3);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d\n", "cc.CardinalSplineBy:create", argc, 3);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -2512,7 +2512,7 @@ int tolua_cocos2d_CatmullRomBy_create(lua_State* tolua_S)
         }
     }
     
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d\n", "cc.CatmullRomBy:create", argc, 2);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d\n", "cc.CatmullRomBy:create", argc, 2);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -2576,7 +2576,7 @@ int tolua_cocos2d_CatmullRomTo_create(lua_State* tolua_S)
         }
     }
     
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d\n", "cc.CatmullRomTo:create", argc, 2);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d\n", "cc.CatmullRomTo:create", argc, 2);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -2636,7 +2636,7 @@ int tolua_cocos2d_BezierBy_create(lua_State* tolua_S)
         }
     }
     
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d\n", "cc.BezierBy:create",argc, 2);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d\n", "cc.BezierBy:create",argc, 2);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -2696,7 +2696,7 @@ int tolua_cocos2d_BezierTo_create(lua_State* tolua_S)
         }
     }
     
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d\n", "cc.BezierTo:create", argc, 2);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d\n", "cc.BezierTo:create", argc, 2);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -2791,7 +2791,7 @@ static int tolua_cocos2dx_DrawNode_drawPolygon(lua_State* tolua_S)
         }        
     }
     
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d\n", "cc.DrawNode:drawPolygon", argc, 5);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d\n", "cc.DrawNode:drawPolygon", argc, 5);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -2866,7 +2866,7 @@ int tolua_cocos2dx_DrawNode_drawSolidPoly(lua_State* tolua_S)
         }
     }
     
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d \n", "cc.DrawNode:drawSolidPoly",argc, 3);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "cc.DrawNode:drawSolidPoly",argc, 3);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -2949,7 +2949,7 @@ int tolua_cocos2dx_DrawNode_drawPoly(lua_State* tolua_S)
         }
     }
     
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d \n", "cc.DrawNode:drawPoly",argc, 4);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "cc.DrawNode:drawPoly",argc, 4);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -3015,7 +3015,7 @@ int tolua_cocos2dx_DrawNode_drawCardinalSpline(lua_State* tolua_S)
         self->drawCardinalSpline(config, arg1, arg2, arg3);
         return 0;
     }
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d \n", "cc.DrawNode:drawCardinalSpline",argc, 4);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "cc.DrawNode:drawCardinalSpline",argc, 4);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -3079,7 +3079,7 @@ int tolua_cocos2dx_DrawNode_drawCatmullRom(lua_State* tolua_S)
         return 0;
     }
     
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d \n", "cc.DrawNode:drawCatmullRom",argc, 3);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "cc.DrawNode:drawCatmullRom",argc, 3);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -3154,7 +3154,7 @@ int tolua_cocos2dx_DrawNode_drawPoints(lua_State* tolua_S)
         }
     }
     
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d \n", "cc.DrawNode:drawPoints",argc, 3);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "cc.DrawNode:drawPoints",argc, 3);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -3198,7 +3198,7 @@ static int tolua_cocos2dx_setBlendFunc(lua_State* tolua_S,const char* className)
     }
 
     
-    CCLOG("'setBlendFunc' has wrong number of arguments: %d, was expecting %d\n", argc, 2);
+    luaL_error(tolua_S, "'setBlendFunc' has wrong number of arguments: %d, was expecting %d\n", argc, 2);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -3275,12 +3275,12 @@ static int tolua_cocos2dx_LayerMultiplex_create(lua_State* tolua_S)
         }
         else
         {
-            CCLOG("error in tolua_cocos2dx_LayerMultiplex_create \n");
+            luaL_error(tolua_S, "error in tolua_cocos2dx_LayerMultiplex_create \n");
             return 0;
         }
     }
     
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d\n", "cc.LayerMultiplex:create", argc, 1);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d\n", "cc.LayerMultiplex:create", argc, 1);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -3333,7 +3333,7 @@ static int tolua_cocos2dx_FileUtils_getStringFromFile(lua_State* tolua_S)
         }
     }
     
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d\n", "cc.FileUtils:getStringFromFile", argc, 1);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d\n", "cc.FileUtils:getStringFromFile", argc, 1);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -3364,7 +3364,7 @@ static int tolua_cocos2dx_UserDefault_getInstance(lua_State* tolua_S)
         return 1;
     }
     
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d\n", "cc.UserDefault:getInstance",argc, 0);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d\n", "cc.UserDefault:getInstance",argc, 0);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -3408,7 +3408,7 @@ static int tolua_cocos2dx_GLProgram_create(lua_State* tolua_S)
         
     }
     
-    CCLOG("%s wrong number of arguments: %d, was expecting %d\n", "cc.GLProgram:create", argc, 2);
+    luaL_error(tolua_S, "%s wrong number of arguments: %d, was expecting %d\n", "cc.GLProgram:create", argc, 2);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -3449,7 +3449,7 @@ static int tolua_cocos2d_GLProgram_getProgram(lua_State* tolua_S)
         return 1;
     }
     
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d\n", "cc.GLProgram:getProgram",argc, 0);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d\n", "cc.GLProgram:getProgram",argc, 0);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -3554,7 +3554,7 @@ static int tolua_cocos2dx_GLProgram_setUniformLocationF32(lua_State* tolua_S)
         }
     }
     
-    CCLOG(" %s has wrong number of arguments: %d, was expecting %d\n", "cc.GLProgram:setUniformLocationF32",argc, 2);
+    luaL_error(tolua_S, " %s has wrong number of arguments: %d, was expecting %d\n", "cc.GLProgram:setUniformLocationF32",argc, 2);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -3609,7 +3609,7 @@ static int lua_cocos2dx_GLProgram_getUniform(lua_State* tolua_S)
         }
         return 1;
     }
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d \n", "cc.GLProgram:getUniform:getUniform",argc, 1);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "cc.GLProgram:getUniform:getUniform",argc, 1);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -3658,7 +3658,7 @@ int lua_cocos2dx_GLProgram_setUniformLocationWithMatrix2fv(lua_State* tolua_S)
         
         if(!ok)
         {
-            CCLOG("Parse params error in the lua_cocos2dx_GLProgram_setUniformLocationWithMatrix2fv");
+            luaL_error(tolua_S, "Parse params error in the lua_cocos2dx_GLProgram_setUniformLocationWithMatrix2fv");
             return 0;
         }
         
@@ -3669,7 +3669,7 @@ int lua_cocos2dx_GLProgram_setUniformLocationWithMatrix2fv(lua_State* tolua_S)
         arg1 = new (std::nothrow) GLfloat[sizeof(GLfloat) * 4 * arg2];
         if (nullptr == arg1)
         {
-            CCLOG("Allocate matrixArry in the lua_cocos2dx_GLProgram_setUniformLocationWithMatrix2fv failed!");
+            luaL_error(tolua_S, "Allocate matrixArry in the lua_cocos2dx_GLProgram_setUniformLocationWithMatrix2fv failed!");
             return 0;
         }
         
@@ -3682,7 +3682,7 @@ int lua_cocos2dx_GLProgram_setUniformLocationWithMatrix2fv(lua_State* tolua_S)
         CC_SAFE_DELETE_ARRAY(arg1);
         return 0;
     }
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d \n", "cc.GLProgram:setUniformLocationWithMatrix2fv",argc, 3);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "cc.GLProgram:setUniformLocationWithMatrix2fv",argc, 3);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -3731,7 +3731,7 @@ int lua_cocos2dx_GLProgram_setUniformLocationWithMatrix3fv(lua_State* tolua_S)
         
         if(!ok)
         {
-            CCLOG("Parse params error in the lua_cocos2dx_GLProgram_setUniformLocationWithMatrix3fv");
+            luaL_error(tolua_S, "Parse params error in the lua_cocos2dx_GLProgram_setUniformLocationWithMatrix3fv");
             return 0;
         }
         
@@ -3742,7 +3742,7 @@ int lua_cocos2dx_GLProgram_setUniformLocationWithMatrix3fv(lua_State* tolua_S)
         arg1 = new (std::nothrow) GLfloat[sizeof(GLfloat) * 9 * arg2];
         if (nullptr == arg1)
         {
-            CCLOG("Allocate matrixArry in the lua_cocos2dx_GLProgram_setUniformLocationWithMatrix3fv failed!");
+            luaL_error(tolua_S, "Allocate matrixArry in the lua_cocos2dx_GLProgram_setUniformLocationWithMatrix3fv failed!");
             return 0;
         }
         
@@ -3756,7 +3756,7 @@ int lua_cocos2dx_GLProgram_setUniformLocationWithMatrix3fv(lua_State* tolua_S)
         
         return 0;
     }
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d \n", "cc.GLProgram:setUniformLocationWithMatrix3fv",argc, 3);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "cc.GLProgram:setUniformLocationWithMatrix3fv",argc, 3);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -3805,7 +3805,7 @@ int lua_cocos2dx_GLProgram_setUniformLocationWithMatrix4fv(lua_State* tolua_S)
         
         if(!ok)
         {
-            CCLOG("Parse params error in the lua_cocos2dx_GLProgram_setUniformLocationWithMatrix4fv");
+            luaL_error(tolua_S, "Parse params error in the lua_cocos2dx_GLProgram_setUniformLocationWithMatrix4fv");
             return 0;
         }
         
@@ -3816,7 +3816,7 @@ int lua_cocos2dx_GLProgram_setUniformLocationWithMatrix4fv(lua_State* tolua_S)
         arg1 = new (std::nothrow) GLfloat[sizeof(GLfloat) * 16 * arg2];
         if (nullptr == arg1)
         {
-            CCLOG("Allocate matrixArry in the lua_cocos2dx_GLProgram_setUniformLocationWithMatrix4fv failed!");
+            luaL_error(tolua_S, "Allocate matrixArry in the lua_cocos2dx_GLProgram_setUniformLocationWithMatrix4fv failed!");
             return 0;
         }
         
@@ -3830,7 +3830,7 @@ int lua_cocos2dx_GLProgram_setUniformLocationWithMatrix4fv(lua_State* tolua_S)
         CC_SAFE_DELETE_ARRAY(arg1);
         return 0;
     }
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d \n", "cc.GLProgram:setUniformLocationWithMatrix4fv",argc, 3);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "cc.GLProgram:setUniformLocationWithMatrix4fv",argc, 3);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -3877,7 +3877,7 @@ int lua_cocos2dx_GLProgram_setUniformLocationWith3iv(lua_State* tolua_S)
         ok &= luaval_to_uint32(tolua_S, 4,&arg2, "cc.GLProgram:setUniformLocationWith3iv");
         if(!ok)
         {
-            CCLOG("Parse params error in the lua_cocos2dx_GLProgram_setUniformLocationWith3iv");
+            luaL_error(tolua_S, "Parse params error in the lua_cocos2dx_GLProgram_setUniformLocationWith3iv");
             return 0;
         }
         
@@ -3888,7 +3888,7 @@ int lua_cocos2dx_GLProgram_setUniformLocationWith3iv(lua_State* tolua_S)
         arg1 = new (std::nothrow) GLint[sizeof(GLint) * 3 * arg2];
         if (nullptr == arg1)
         {
-            CCLOG("Allocate intArray in the lua_cocos2dx_GLProgram_setUniformLocationWith3iv failed!");
+            luaL_error(tolua_S, "Allocate intArray in the lua_cocos2dx_GLProgram_setUniformLocationWith3iv failed!");
             return 0;
         }
         
@@ -3902,7 +3902,7 @@ int lua_cocos2dx_GLProgram_setUniformLocationWith3iv(lua_State* tolua_S)
         CC_SAFE_DELETE_ARRAY(arg1);
         return 0;
     }
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d \n", "cc.GLProgram:setUniformLocationWith3iv",argc, 3);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "cc.GLProgram:setUniformLocationWith3iv",argc, 3);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -3951,7 +3951,7 @@ int lua_cocos2dx_GLProgram_setUniformLocationWith4iv(lua_State* tolua_S)
         
         if(!ok)
         {
-            CCLOG("Parse params error in the lua_cocos2dx_GLProgram_setUniformLocationWith4iv");
+            luaL_error(tolua_S, "Parse params error in the lua_cocos2dx_GLProgram_setUniformLocationWith4iv");
             return 0;
         }
         
@@ -3962,7 +3962,7 @@ int lua_cocos2dx_GLProgram_setUniformLocationWith4iv(lua_State* tolua_S)
         arg1 = new (std::nothrow) GLint[sizeof(GLint) * 4 * arg2];
         if (nullptr == arg1)
         {
-            CCLOG("Allocate intArray in the lua_cocos2dx_GLProgram_setUniformLocationWith4iv failed!");
+            luaL_error(tolua_S, "Allocate intArray in the lua_cocos2dx_GLProgram_setUniformLocationWith4iv failed!");
             return 0;
         }
         
@@ -3974,7 +3974,7 @@ int lua_cocos2dx_GLProgram_setUniformLocationWith4iv(lua_State* tolua_S)
         CC_SAFE_DELETE_ARRAY(arg1);
         return 0;
     }
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d \n", "cc.GLProgram:setUniformLocationWith4iv",argc, 3);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "cc.GLProgram:setUniformLocationWith4iv",argc, 3);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -4023,7 +4023,7 @@ int lua_cocos2dx_GLProgram_setUniformLocationWith2iv(lua_State* tolua_S)
         
         if(!ok)
         {
-            CCLOG("Parse params error in the lua_cocos2dx_GLProgram_setUniformLocationWith2iv");
+            luaL_error(tolua_S, "Parse params error in the lua_cocos2dx_GLProgram_setUniformLocationWith2iv");
             return 0;
         }
         
@@ -4034,7 +4034,7 @@ int lua_cocos2dx_GLProgram_setUniformLocationWith2iv(lua_State* tolua_S)
         arg1 = new (std::nothrow) GLint[sizeof(GLint) * 2 * arg2];
         if (nullptr == arg1)
         {
-            CCLOG("Allocate intArray in the lua_cocos2dx_GLProgram_setUniformLocationWith2iv failed!");
+            luaL_error(tolua_S, "Allocate intArray in the lua_cocos2dx_GLProgram_setUniformLocationWith2iv failed!");
             return 0;
         }
         
@@ -4043,7 +4043,7 @@ int lua_cocos2dx_GLProgram_setUniformLocationWith2iv(lua_State* tolua_S)
         CC_SAFE_DELETE_ARRAY(arg1);
         return 0;
     }
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d \n", "cc.GLProgram:setUniformLocationWith2iv",argc, 3);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "cc.GLProgram:setUniformLocationWith2iv",argc, 3);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -4098,7 +4098,7 @@ int lua_cocos2dx_GLProgram_getVertexAttrib(lua_State* tolua_S)
         }
         return 1;
     }
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d \n", "cc.GLProgram:getVertexAttrib",argc, 1);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "cc.GLProgram:getVertexAttrib",argc, 1);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -4183,7 +4183,7 @@ static int tolua_cocos2dx_Texture2D_setTexParameters(lua_State* tolua_S)
         return 0;
     }
     
-    CCLOG("'setTexParameters' function of Texture2D wrong number of arguments: %d, was expecting %d\n", argc,4);
+    luaL_error(tolua_S, "'setTexParameters' function of Texture2D wrong number of arguments: %d, was expecting %d\n", argc,4);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -4248,7 +4248,7 @@ static int tolua_cocos2dx_SpriteBatchNode_getDescendants(lua_State* tolua_S)
         
         return 1;
     }
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d \n", "cc.SpriteBatchNode:getDescendants",argc, 0);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "cc.SpriteBatchNode:getDescendants",argc, 0);
     return 0;
 #if COCOS2D_DEBUG >= 1
 tolua_lerror:
@@ -4811,7 +4811,7 @@ static int tolua_cocos2dx_LuaEventListenerAcceleration_create(lua_State* tolua_S
         return 1;
     }
     
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d\n", "cc.EventListenerAcceleration:create",argc, 1);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d\n", "cc.EventListenerAcceleration:create",argc, 1);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -4855,7 +4855,7 @@ static int tolua_cocos2d_LuaEventListenerCustom_create(lua_State* tolua_S)
         return 1;
     }
     
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d\n", "cc.EventListenerCustom:create", argc, 2);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d\n", "cc.EventListenerCustom:create", argc, 2);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -4913,7 +4913,7 @@ static int tolua_cocos2dx_EventListenerKeyboard_create(lua_State* tolua_S)
         return 1;
     }
     
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d\n", "cc.EventListenerKeyboard:create", argc, 1);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d\n", "cc.EventListenerKeyboard:create", argc, 1);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -4998,7 +4998,7 @@ static int tolua_cocos2dx_EventListenerKeyboard_clone(lua_State* tolua_S)
         return 1;
     }
     
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d\n", "cc.EventListenerKeyboard:clone",argc, 0);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d\n", "cc.EventListenerKeyboard:clone",argc, 0);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -5070,7 +5070,7 @@ static int tolua_cocos2dx_EventListenerKeyboard_registerScriptHandler(lua_State*
         return 0;
     }
     
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d\n", "cc.EventListenerKeyboard:registerScriptHandler", argc, 2);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d\n", "cc.EventListenerKeyboard:registerScriptHandler", argc, 2);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -5119,7 +5119,7 @@ static int tolua_cocos2dx_EventListenerTouchOneByOne_create(lua_State* tolua_S)
         return 1;
     }
     
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d\n", "cc.EventListenerTouchOneByOne:create",argc, 0);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d\n", "cc.EventListenerTouchOneByOne:create",argc, 0);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -5225,7 +5225,7 @@ static int tolua_cocos2dx_EventListenerTouchOneByOne_clone(lua_State* tolua_S)
         return 1;
     }
     
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d\n", "cc.EventListenerTouchOneByOne:create", argc, 0);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d\n", "cc.EventListenerTouchOneByOne:create", argc, 0);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -5319,7 +5319,7 @@ static int tolua_cocos2dx_EventListenerTouchOneByOne_registerScriptHandler(lua_S
         return 0;
     }
     
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d\n", "cc.EventListenerTouchOneByOne:registerScriptHandler", argc, 2);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d\n", "cc.EventListenerTouchOneByOne:registerScriptHandler", argc, 2);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -5368,7 +5368,7 @@ static int tolua_cocos2dx_EventListenerTouchAllAtOnce_create(lua_State* tolua_S)
         return 1;
     }
     
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d\n", "cc.EventListenerTouchAllAtOnce:registerScriptHandler",argc, 1);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d\n", "cc.EventListenerTouchAllAtOnce:registerScriptHandler",argc, 1);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -5473,7 +5473,7 @@ static int tolua_cocos2dx_EventListenerTouchAllAtOnce_clone(lua_State* tolua_S)
         return 1;
     }
     
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d\n", "cc.EventListenerTouchAllAtOnce:clone", argc, 0);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d\n", "cc.EventListenerTouchAllAtOnce:clone", argc, 0);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -5567,7 +5567,7 @@ static int tolua_cocos2dx_EventListenerTouchAllAtOnce_registerScriptHandler(lua_
         return 0;
     }
     
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d\n", "cc.EventListenerTouchAllAtOnce:registerScriptHandler",argc, 2);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d\n", "cc.EventListenerTouchAllAtOnce:registerScriptHandler",argc, 2);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -5616,7 +5616,7 @@ static int tolua_cocos2dx_EventListenerMouse_create(lua_State* tolua_S)
         return 1;
     }
     
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d\n", "cc.EventListenerMouse:create",argc, 0);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d\n", "cc.EventListenerMouse:create",argc, 0);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -5721,7 +5721,7 @@ static int tolua_cocos2dx_EventListenerMouse_clone(lua_State* tolua_S)
         return 1;
     }
     
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d\n", "cc.EventListenerMouse:clone", argc, 0);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d\n", "cc.EventListenerMouse:clone", argc, 0);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -5817,7 +5817,7 @@ static int tolua_cocos2dx_EventListenerMouse_registerScriptHandler(lua_State* to
         return 0;
     }
     
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d\n", "cc.EventListenerMouse:registerScriptHandler",argc, 2);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d\n", "cc.EventListenerMouse:registerScriptHandler",argc, 2);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -5873,7 +5873,7 @@ static int tolua_cocos2dx_ActionCamera_reverse(lua_State* tolua_S)
         toluafix_pushusertype_ccobject(tolua_S, reverse->_ID, &(reverse->_luaID), (void*)(reverse),"cc.ActionCamera");
         return 1;
     }
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d \n", "cc.ActionCamera:reverse",argc, 0);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "cc.ActionCamera:reverse",argc, 0);
     return 0;
 #if COCOS2D_DEBUG >= 1
 tolua_lerror:
@@ -5926,7 +5926,7 @@ static int tolua_cocos2dx_GridAction_reverse(lua_State* tolua_S)
         toluafix_pushusertype_ccobject(tolua_S, reverse->_ID, &(reverse->_luaID), (void*)(reverse),"cc.GridAction");
         return 1;
     }
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d \n", "cc.GridAction:reverse",argc, 0);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "cc.GridAction:reverse",argc, 0);
     return 0;
 #if COCOS2D_DEBUG >= 1
 tolua_lerror:
@@ -5993,7 +5993,7 @@ static int lua_cocos2dx_Label_createWithTTF00(lua_State* L)
         toluafix_pushusertype_ccobject(L,ID, luaID, (void*)ret,"cc.Label");
         return 1;
     }
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d\n ", "cc.Label:createWithTTF",argc, 2);
+    luaL_error(L, "%s has wrong number of arguments: %d, was expecting %d\n ", "cc.Label:createWithTTF",argc, 2);
     return 0;
 #if COCOS2D_DEBUG >= 1
 tolua_lerror:
@@ -6096,7 +6096,7 @@ static int lua_cocos2dx_TMXTiledMap_getPropertiesForGID(lua_State* tolua_S)
         ccvalue_to_luaval(tolua_S, ret);
         return 1;
     }
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d \n", "cc.TMXTiledMap:getPropertiesForGID",argc, 1);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "cc.TMXTiledMap:getPropertiesForGID",argc, 1);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -6154,7 +6154,7 @@ static int lua_cocos2dx_Console_send(lua_State* tolua_S)
         return 0;
     }
     ok  = true;
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d", "cc.Console:send",argc, 2);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d", "cc.Console:send",argc, 2);
     return 0;
 #if COCOS2D_DEBUG >= 1
 tolua_lerror:
@@ -6199,7 +6199,7 @@ static int lua_cocos2dx_Console_wait(lua_State* tolua_S)
         return 0;
     }
     ok  = true;
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d", "cc.Console:wait",argc, 2);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d", "cc.Console:wait",argc, 2);
     return 0;
 #if COCOS2D_DEBUG >= 1
 tolua_lerror:
@@ -6268,7 +6268,7 @@ static int lua_cocos2dx_Console_addCommand(lua_State* tolua_S)
         }
         return 0;
     }
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d", "cc.Console:addCommand",argc, 2);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d", "cc.Console:addCommand",argc, 2);
     return 0;
 #if COCOS2D_DEBUG >= 1
 tolua_lerror:
@@ -6370,7 +6370,7 @@ static int lua_cocos2dx_GLProgramState_setVertexAttribPointer(lua_State* tolua_S
         
         if (len != arg6)
         {
-            CCLOG("table size is  %zu,but input size is %d \n", len, arg6);
+            luaL_error(tolua_S, "table size is  %zu,but input size is %d \n", len, arg6);
             return 0;
         }
         
@@ -6403,7 +6403,7 @@ static int lua_cocos2dx_GLProgramState_setVertexAttribPointer(lua_State* tolua_S
         
         return 0;
     }
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d \n", "cc.GLProgramState:setVertexAttribPointer",argc, 6);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "cc.GLProgramState:setVertexAttribPointer",argc, 6);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -6473,7 +6473,7 @@ static int lua_cocos2dx_OrbitCamera_sphericalRadius(lua_State* tolua_S)
         
         return 3;
     }
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d \n", "cc.OrbitCamera:sphericalRadius",argc, 3);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "cc.OrbitCamera:sphericalRadius",argc, 3);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -6549,7 +6549,7 @@ int lua_cocos2dx_TMXLayer_getTileGIDAt(lua_State* tolua_S)
         tolua_pushnumber(tolua_S,(lua_Number)arg1);
         return 2;
     }
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d \n", "cc.TMXLayer:getTileGIDAt",argc, 1);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "cc.TMXLayer:getTileGIDAt",argc, 1);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -6596,14 +6596,14 @@ int lua_cocos2dx_TMXLayer_setTiles(lua_State* tolua_S)
         size_t len = lua_objlen(tolua_S, 2);
         if (len == 0 )
         {
-            CCLOG("Table's len equal 0");
+            luaL_error(tolua_S, "Table's len equal 0");
             return 0;
         }
         arg0 = new uint32_t[len];
         
         if (nullptr == arg0)
         {
-            CCLOG("Allocate uint32_t array in the lua_cocos2dx_TMXLayer_setTiles failed!");
+            luaL_error(tolua_S, "Allocate uint32_t array in the lua_cocos2dx_TMXLayer_setTiles failed!");
             return 0;
         }
         
@@ -6617,7 +6617,7 @@ int lua_cocos2dx_TMXLayer_setTiles(lua_State* tolua_S)
         CC_SAFE_DELETE_ARRAY(arg0);
         return 0;
     }
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d \n", "cc.TMXLayer:setTiles",argc, 1);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "cc.TMXLayer:setTiles",argc, 1);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -6680,7 +6680,7 @@ int lua_cocos2dx_Application_isIOS64bit(lua_State* tolua_S)
         tolua_pushboolean(tolua_S, isIOS64bit);
         return 1;
     }
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d \n", "cc.Application:isIOS64bit",argc, 0);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "cc.Application:isIOS64bit",argc, 0);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -6749,7 +6749,7 @@ static int lua_cocos2dx_TextureCache_addImageAsync(lua_State* tolua_S)
         return 0;
     }
     
-    CCLOG("%s function of TextureCache has wrong number of arguments: %d, was expecting %d\n", "cc.TextureCache:addImageAsync", argc, 1);
+    luaL_error(tolua_S, "%s function of TextureCache has wrong number of arguments: %d, was expecting %d\n", "cc.TextureCache:addImageAsync", argc, 1);
     
 #if COCOS2D_DEBUG >= 1
 tolua_lerror:
@@ -6821,7 +6821,7 @@ int lua_cocos2dx_GLView_getAllTouches(lua_State* tolua_S)
 
         return 1;
     }
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d \n", "cc.GLView:getAllTouches",argc, 0);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "cc.GLView:getAllTouches",argc, 0);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -6887,7 +6887,7 @@ int lua_cocos2dx_Camera_unproject(lua_State* tolua_S)
         vec3_to_luaval(tolua_S, arg2);
         return 1;
     }
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d \n", "cc.Camera:unproject",argc, 3);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "cc.Camera:unproject",argc, 3);
     return 0;
     
 #if COCOS2D_DEBUG >= 1

--- a/cocos/scripting/lua-bindings/manual/cocos2d/lua_cocos2dx_physics_manual.cpp
+++ b/cocos/scripting/lua-bindings/manual/cocos2d/lua_cocos2dx_physics_manual.cpp
@@ -63,7 +63,7 @@ int lua_cocos2dx_physics_PhysicsBody_getJoints(lua_State* tolua_S)
         } while (0);
         return 1;
     }
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d \n", "getJoints",argc, 0);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "getJoints",argc, 0);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -122,7 +122,7 @@ int lua_cocos2dx_physics_PhysicsWorld_getScene(lua_State* tolua_S)
         }while (0);
         return 1;
     }
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d \n", "getScene",argc, 0);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "getScene",argc, 0);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -182,7 +182,7 @@ int lua_cocos2dx_physics_PhysicsWorld_rayCast(lua_State* tolua_S)
         toluafix_remove_function_by_refid(tolua_S, handler);
         return 0;
     }
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d \n", "rayCast",argc, 4);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "rayCast",argc, 4);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -238,7 +238,7 @@ int lua_cocos2dx_physics_PhysicsWorld_queryRect(lua_State* tolua_S)
         toluafix_remove_function_by_refid(tolua_S, handler);
         return 0;
     }
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d \n", "queryRect",argc, 3);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "queryRect",argc, 3);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -297,7 +297,7 @@ int lua_cocos2dx_physics_PhysicsWorld_queryPoint(lua_State* tolua_S)
         toluafix_remove_function_by_refid(tolua_S, handler);
         return 0;
     }
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d \n", "queryPoint",argc, 3);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "queryPoint",argc, 3);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -420,7 +420,7 @@ int lua_cocos2dx_physics_PhysicsBody_createPolygon(lua_State* tolua_S)
         } while (0);
         return 1;
     }
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d\n ", "createPolygon",argc, 2);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d\n ", "createPolygon",argc, 2);
     return 0;
 #if COCOS2D_DEBUG >= 1
 tolua_lerror:
@@ -540,7 +540,7 @@ int lua_cocos2dx_physics_PhysicsBody_createEdgePolygon(lua_State* tolua_S)
         } while (0);
         return 1;
     }
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d\n ", "createEdgePolygon",argc, 2);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d\n ", "createEdgePolygon",argc, 2);
     return 0;
 #if COCOS2D_DEBUG >= 1
 tolua_lerror:
@@ -660,7 +660,7 @@ int lua_cocos2dx_physics_PhysicsBody_createEdgeChain(lua_State* tolua_S)
         } while (0);
         return 1;
     }
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d\n ", "createEdgeChain",argc, 2);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d\n ", "createEdgeChain",argc, 2);
     return 0;
 #if COCOS2D_DEBUG >= 1
 tolua_lerror:
@@ -725,7 +725,7 @@ int lua_cocos2dx_physics_PhysicsShape_recenterPoints(lua_State* tolua_S)
         CC_SAFE_DELETE_ARRAY(arg0);
         return 0;
     }
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d\n ", "recenterPoints",argc, 2);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d\n ", "recenterPoints",argc, 2);
     return 0;
 #if COCOS2D_DEBUG >= 1
 tolua_lerror:
@@ -768,7 +768,7 @@ int lua_cocos2dx_physics_PhysicsShape_getPolyonCenter(lua_State* tolua_S)
         vec2_to_luaval(tolua_S, ret);
         return 1;
     }
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d\n ", "getPolyonCenter",argc, 2);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d\n ", "getPolyonCenter",argc, 2);
     return 0;
 #if COCOS2D_DEBUG >= 1
 tolua_lerror:
@@ -808,7 +808,7 @@ int lua_cocos2dx_physics_PhysicsShapeBox_getPoints(lua_State* tolua_S)
         vec2_array_to_luaval(tolua_S, arg0, 4);
         return 0;
     }
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d \n", "getPoints",argc, 1);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "getPoints",argc, 1);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -852,7 +852,7 @@ int lua_cocos2dx_physics_PhysicsShapePolygon_getPoints(lua_State* tolua_S)
         CC_SAFE_DELETE_ARRAY(arg0);
         return 0;
     }
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d \n", "getPoints",argc, 1);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "getPoints",argc, 1);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -942,7 +942,7 @@ int lua_cocos2dx_physics_PhysicsShapePolygon_create(lua_State* tolua_S)
         object_to_luaval<cocos2d::PhysicsShapePolygon>(tolua_S, "cc.PhysicsShapePolygon",(cocos2d::PhysicsShapePolygon*)ret);
         return 1;
     }
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d\n ", "create",argc, 2);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d\n ", "create",argc, 2);
     return 0;
 #if COCOS2D_DEBUG >= 1
 tolua_lerror:
@@ -984,7 +984,7 @@ int lua_cocos2dx_physics_PhysicsShapePolygon_calculateArea(lua_State* tolua_S)
         tolua_pushnumber(tolua_S,(lua_Number)ret);
         return 1;
     }
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d\n ", "calculateArea",argc, 2);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d\n ", "calculateArea",argc, 2);
     return 0;
 #if COCOS2D_DEBUG >= 1
 tolua_lerror:
@@ -1051,7 +1051,7 @@ int lua_cocos2dx_physics_PhysicsShapePolygon_calculateMoment(lua_State* tolua_S)
         tolua_pushnumber(tolua_S,(lua_Number)ret);
         return 1;
     }
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d\n ", "calculateMoment",argc, 3);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d\n ", "calculateMoment",argc, 3);
     return 0;
 #if COCOS2D_DEBUG >= 1
 tolua_lerror:
@@ -1093,7 +1093,7 @@ int lua_cocos2dx_physics_PhysicsShapeEdgeBox_getPoints(lua_State* tolua_S)
         CC_SAFE_DELETE_ARRAY(arg0);
         return 0;
     }
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d \n", "getPoints",argc, 1);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "getPoints",argc, 1);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -1137,7 +1137,7 @@ int lua_cocos2dx_physics_PhysicsShapeEdgePolygon_getPoints(lua_State* tolua_S)
         CC_SAFE_DELETE_ARRAY(arg0);
         return 0;
     }
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d \n", "getPoints",argc, 1);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "getPoints",argc, 1);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -1181,7 +1181,7 @@ int lua_cocos2dx_physics_PhysicsShapeEdgeChain_getPoints(lua_State* tolua_S)
         CC_SAFE_DELETE_ARRAY(arg0);
         return 0;
     }
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d \n", "getPoints",argc, 1);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "getPoints",argc, 1);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -1286,7 +1286,7 @@ static int tolua_cocos2dx_EventListenerPhysicsContact_registerScriptHandler(lua_
         return 0;
     }
     
-    CCLOG("'registerScriptHandler' has wrong number of arguments: %d, was expecting %d\n", argc, 2);
+    luaL_error(tolua_S, "'registerScriptHandler' has wrong number of arguments: %d, was expecting %d\n", argc, 2);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -1374,7 +1374,7 @@ int lua_cocos2dx_physics_PhysicsShapeEdgePolygon_create(lua_State* tolua_S)
         object_to_luaval<cocos2d::PhysicsShapeEdgePolygon>(tolua_S, "cc.PhysicsShapeEdgePolygon",(cocos2d::PhysicsShapeEdgePolygon*)ret);
         return 1;
     }
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d\n ", "create",argc, 2);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d\n ", "create",argc, 2);
     return 0;
 #if COCOS2D_DEBUG >= 1
 tolua_lerror:
@@ -1461,7 +1461,7 @@ int lua_cocos2dx_physics_PhysicsShapeEdgeChain_create(lua_State* tolua_S)
         object_to_luaval<cocos2d::PhysicsShapeEdgeChain>(tolua_S, "cc.PhysicsShapeEdgeChain",(cocos2d::PhysicsShapeEdgeChain*)ret);
         return 1;
     }
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d\n ", "create",argc, 2);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d\n ", "create",argc, 2);
     return 0;
 #if COCOS2D_DEBUG >= 1
 tolua_lerror:

--- a/cocos/scripting/lua-bindings/manual/cocosbuilder/lua_cocos2dx_cocosbuilder_manual.cpp
+++ b/cocos/scripting/lua-bindings/manual/cocosbuilder/lua_cocos2dx_cocosbuilder_manual.cpp
@@ -56,7 +56,7 @@ static int tolua_cocos2d_CCBProxy_create(lua_State* tolua_S)
         return 1;
     }
     
-    CCLOG("%s function of CCBProxy has wrong number of arguments: %d, was expecting %d\n", "cc.CCBProxy:create", argc, 0);
+    luaL_error(tolua_S, "%s function of CCBProxy has wrong number of arguments: %d, was expecting %d\n", "cc.CCBProxy:create", argc, 0);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -100,7 +100,7 @@ static int tolua_cocos2d_CCBProxy_createCCBReader(lua_State* tolua_S)
         return 1;
     }
     
-    CCLOG("%s function of CCBProxy  has wrong number of arguments: %d, was expecting %d\n", "cc.CCBProxy:createCCBReader", argc, 0);
+    luaL_error(tolua_S, "%s function of CCBProxy  has wrong number of arguments: %d, was expecting %d\n", "cc.CCBProxy:createCCBReader", argc, 0);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -160,7 +160,7 @@ static int tolua_cocos2d_CCBProxy_readCCBFromFile(lua_State* tolua_S)
         return 1;
     }
     
-    CCLOG("%s function of CCBProxy  has wrong number of arguments: %d, was expecting %d\n", "cc.CCBReader:readCCBFromFile", argc, 2);
+    luaL_error(tolua_S, "%s function of CCBProxy  has wrong number of arguments: %d, was expecting %d\n", "cc.CCBReader:readCCBFromFile", argc, 2);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -207,7 +207,7 @@ static int tolua_cocos2d_CCBProxy_getNodeTypeName(lua_State* tolua_S)
         return 1;
     }
     
-    CCLOG(" %s has wrong number of arguments: %d, was expecting %d\n", "cc.CCBProxy:getNodeTypeName", argc, 1);
+    luaL_error(tolua_S, " %s has wrong number of arguments: %d, was expecting %d\n", "cc.CCBProxy:getNodeTypeName", argc, 1);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -257,7 +257,7 @@ static int tolua_cocos2d_CCBProxy_setCallback(lua_State* tolua_S)
         return 0;
     }
     
-    CCLOG(" %s has wrong number of arguments: %d, was expecting %d\n", "cc.CCBProxy:setCallback", argc, 2);
+    luaL_error(tolua_S, " %s has wrong number of arguments: %d, was expecting %d\n", "cc.CCBProxy:setCallback", argc, 2);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -357,7 +357,7 @@ static int tolua_cocos2d_CCBReader_load(lua_State* tolua_S)
         
     }
     
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d\n", "cc.CCBReader:load",argc, 1);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d\n", "cc.CCBReader:load",argc, 1);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -424,7 +424,7 @@ static int tolua_cocos2d_CCBAnimationManager_setCallFuncForLuaCallbackNamed(lua_
         return 0;
     }
     
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d\n", "cc.CCBAnimationManager:setCallFuncForLuaCallbackNamed",argc, 1);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d\n", "cc.CCBAnimationManager:setCallFuncForLuaCallbackNamed",argc, 1);
     return 0;
     
 #if COCOS2D_DEBUG >= 1

--- a/cocos/scripting/lua-bindings/manual/cocostudio/lua_cocos2dx_coco_studio_manual.cpp
+++ b/cocos/scripting/lua-bindings/manual/cocostudio/lua_cocos2dx_coco_studio_manual.cpp
@@ -127,7 +127,7 @@ static int lua_cocos2dx_ArmatureAnimation_setMovementEventCallFunc(lua_State* L)
         return 0;
     }
     
-    CCLOG("'setMovementEventCallFunc' function of ArmatureAnimation has wrong number of arguments: %d, was expecting %d\n", argc, 1);
+    luaL_error(L, "'setMovementEventCallFunc' function of ArmatureAnimation has wrong number of arguments: %d, was expecting %d\n", argc, 1);
     
     return 0;
     
@@ -200,7 +200,7 @@ static int lua_cocos2dx_ArmatureAnimation_setFrameEventCallFunc(lua_State* L)
     }
     
     
-    CCLOG("'setFrameEventCallFunc' function of ArmatureAnimation has wrong number of arguments: %d, was expecting %d\n", argc, 1);
+    luaL_error(L, "'setFrameEventCallFunc' function of ArmatureAnimation has wrong number of arguments: %d, was expecting %d\n", argc, 1);
     
 #if COCOS2D_DEBUG >= 1
 tolua_lerror:
@@ -292,7 +292,7 @@ static int lua_cocos2dx_ArmatureDataManager_addArmatureFileInfoAsyncCallFunc(lua
         return 0;
     }
     
-    CCLOG("'addArmatureFileInfoAsync' function of ArmatureDataManager has wrong number of arguments: %d, was expecting %d\n", argc, 1);
+    luaL_error(L, "'addArmatureFileInfoAsync' function of ArmatureDataManager has wrong number of arguments: %d, was expecting %d\n", argc, 1);
     
 #if COCOS2D_DEBUG >= 1
 tolua_lerror:
@@ -347,7 +347,7 @@ static int lua_cocos2dx_extension_Bone_setIgnoreMovementBoneData(lua_State* L)
         return 0;
     }
     
-    CCLOG("'setIgnoreMovementBoneData' function of Bone  has wrong number of arguments: %d, was expecting %d\n", argc, 0);
+    luaL_error(L, "'setIgnoreMovementBoneData' function of Bone  has wrong number of arguments: %d, was expecting %d\n", argc, 0);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -387,7 +387,7 @@ static int lua_cocos2dx_extension_Bone_getIgnoreMovementBoneData(lua_State* L)
         return 1;
     }
     
-    CCLOG("'getIgnoreMovementBoneData' function of Bone  has wrong number of arguments: %d, was expecting %d\n", argc, 0);
+    luaL_error(L, "'getIgnoreMovementBoneData' function of Bone  has wrong number of arguments: %d, was expecting %d\n", argc, 0);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -432,7 +432,7 @@ int lua_cocos2dx_studio_ActionTimelineCache_getInstance(lua_State* L)
         tolua_pushusertype(L,(void*)ret, "ccs.ActionTimelineCache");
         return 1;
     }
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d\n ", "ccs.ActionTimelineCache:getInstance",argc, 0);
+    luaL_error(L, "%s has wrong number of arguments: %d, was expecting %d\n ", "ccs.ActionTimelineCache:getInstance",argc, 0);
     return 0;
 #if COCOS2D_DEBUG >= 1
 tolua_lerror:
@@ -494,7 +494,7 @@ static int lua_cocos2dx_ActionTimeline_setFrameEventCallFunc(lua_State* L)
     }
     
     
-    CCLOG("'setFrameEventCallFunc' function of ActionTimeline has wrong number of arguments: %d, was expecting %d\n", argc, 1);
+    luaL_error(L, "'setFrameEventCallFunc' function of ActionTimeline has wrong number of arguments: %d, was expecting %d\n", argc, 1);
     
 #if COCOS2D_DEBUG >= 1
 tolua_lerror:
@@ -514,7 +514,7 @@ static void extendActionTimeline(lua_State* L)
     lua_pop(L, 1);
 }
 
-int lua_cocos2dx_CustomGUIReader_create(lua_State* tolua_S)
+int lua_cocos2dx_CustomGUIReader_create(lua_State* L)
 {
     int argc = 0;
     bool ok  = true;
@@ -523,41 +523,41 @@ int lua_cocos2dx_CustomGUIReader_create(lua_State* tolua_S)
 #endif
 
 #if COCOS2D_DEBUG >= 1
-    if (!tolua_isusertable(tolua_S,1,"ccs.CustomGUIReader",0,&tolua_err)) goto tolua_lerror;
+    if (!tolua_isusertable(L,1,"ccs.CustomGUIReader",0,&tolua_err)) goto tolua_lerror;
 #endif
 
-    argc = lua_gettop(tolua_S)-1;
+    argc = lua_gettop(L)-1;
 
     do 
     {
         if (argc == 3)
         {
             std::string arg0;
-            ok &= luaval_to_std_string(tolua_S, 2,&arg0, "ccs.CustomGUIReader:create");
+            ok &= luaval_to_std_string(L, 2,&arg0, "ccs.CustomGUIReader:create");
             if (!ok) { break; }
 #if COCOS2D_DEBUG >= 1
-            if (!toluafix_isfunction(tolua_S,3,"LUA_FUNCTION",0,&tolua_err)) {
+            if (!toluafix_isfunction(L,3,"LUA_FUNCTION",0,&tolua_err)) {
                 goto tolua_lerror;
             }
 #endif
-            LUA_FUNCTION arg1 = toluafix_ref_function(tolua_S,3,0);
+            LUA_FUNCTION arg1 = toluafix_ref_function(L,3,0);
 #if COCOS2D_DEBUG >= 1
-            if (!toluafix_isfunction(tolua_S,4,"LUA_FUNCTION",0,&tolua_err)) {
+            if (!toluafix_isfunction(L,4,"LUA_FUNCTION",0,&tolua_err)) {
                 goto tolua_lerror;
             }
 #endif
-            LUA_FUNCTION arg2 = toluafix_ref_function(tolua_S,4,0);
+            LUA_FUNCTION arg2 = toluafix_ref_function(L,4,0);
 
             cocostudio::CustomGUIReader* ret = cocostudio::CustomGUIReader::create(arg0, arg1, arg2);
-            object_to_luaval<cocostudio::CustomGUIReader>(tolua_S, "ccs.CustomGUIReader",(cocostudio::CustomGUIReader*)ret);
+            object_to_luaval<cocostudio::CustomGUIReader>(L, "ccs.CustomGUIReader",(cocostudio::CustomGUIReader*)ret);
             return 1;
         }
     } while (0);
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d", "ccs.CustomGUIReader:create",argc, 1);
+    luaL_error(L, "%s has wrong number of arguments: %d, was expecting %d", "ccs.CustomGUIReader:create",argc, 1);
     return 0;
 #if COCOS2D_DEBUG >= 1
 tolua_lerror:
-    tolua_error(tolua_S,"#ferror in function 'lua_cocos2dx_CustomGUIReader_create'.",&tolua_err);
+    tolua_error(L,"#ferror in function 'lua_cocos2dx_CustomGUIReader_create'.",&tolua_err);
 #endif
     return 0;
 }
@@ -575,23 +575,23 @@ int register_all_cocos2dx_coco_studio_manual(lua_State* L)
     return 0;
 }
 
-int lua_register_cocos2dx_coco_studio_CustomGUIReader(lua_State* tolua_S)
+int lua_register_cocos2dx_coco_studio_CustomGUIReader(lua_State* L)
 {
-    tolua_module(tolua_S,"ccs",0);
-    tolua_beginmodule(tolua_S,"ccs");
+    tolua_module(L,"ccs",0);
+    tolua_beginmodule(L,"ccs");
     
 
-    tolua_usertype(tolua_S,"ccs.CustomGUIReader");
-    tolua_cclass(tolua_S,"CustomGUIReader","ccs.CustomGUIReader","cc.Ref",nullptr);
+    tolua_usertype(L,"ccs.CustomGUIReader");
+    tolua_cclass(L,"CustomGUIReader","ccs.CustomGUIReader","cc.Ref",nullptr);
 
-    tolua_beginmodule(tolua_S,"CustomGUIReader");
-        tolua_function(tolua_S,"create",lua_cocos2dx_CustomGUIReader_create);
-    tolua_endmodule(tolua_S);
+    tolua_beginmodule(L,"CustomGUIReader");
+        tolua_function(L,"create",lua_cocos2dx_CustomGUIReader_create);
+    tolua_endmodule(L);
     std::string typeName = typeid(cocostudio::CustomGUIReader).name();
     g_luaType[typeName] = "ccs.CustomGUIReader";
     g_typeCast["CustomGUIReader"] = "ccs.CustomGUIReader";
 
-    tolua_endmodule(tolua_S);
+    tolua_endmodule(L);
     return 1;
 }
 

--- a/cocos/scripting/lua-bindings/manual/cocostudio/lua_cocos2dx_csloader_manual.cpp
+++ b/cocos/scripting/lua-bindings/manual/cocostudio/lua_cocos2dx_csloader_manual.cpp
@@ -54,7 +54,7 @@ int lua_cocos2dx_csloader_CSLoader_createTimeline(lua_State* tolua_S)
         object_to_luaval<cocostudio::timeline::ActionTimeline>(tolua_S, "ccs.ActionTimeline",(cocostudio::timeline::ActionTimeline*)ret);
         return 1;
     }
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d\n ", "cc.CSLoader:createTimeline",argc, 1);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d\n ", "cc.CSLoader:createTimeline",argc, 1);
     return 0;
 #if COCOS2D_DEBUG >= 1
 tolua_lerror:

--- a/cocos/scripting/lua-bindings/manual/extension/lua_cocos2dx_extension_manual.cpp
+++ b/cocos/scripting/lua-bindings/manual/extension/lua_cocos2dx_extension_manual.cpp
@@ -108,7 +108,7 @@ static int tolua_cocos2dx_ScrollView_setDelegate(lua_State* tolua_S)
         return 0;
     }
     
-    CCLOG("'setDelegate' function of ScrollView wrong number of arguments: %d, was expecting %d\n", argc, 0);
+    luaL_error(tolua_S, "'setDelegate' function of ScrollView wrong number of arguments: %d, was expecting %d\n", argc, 0);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -156,7 +156,7 @@ static int tolua_cocos2d_ScrollView_registerScriptHandler(lua_State* tolua_S)
         return 0;
     }
     
-    CCLOG("%s function of ScrollView has wrong number of arguments: %d, was expecting %d\n", "cc.ScrollView:registerScriptHandler",argc, 2);
+    luaL_error(tolua_S, "%s function of ScrollView has wrong number of arguments: %d, was expecting %d\n", "cc.ScrollView:registerScriptHandler",argc, 2);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -201,7 +201,7 @@ static int tolua_cocos2d_ScrollView_unregisterScriptHandler(lua_State* tolua_S)
         return 0;
     }
     
-    CCLOG("%s function of ScrollView  has wrong number of arguments: %d, was expecting %d\n", "cc.ScrollView:unregisterScriptHandler", argc, 1);
+    luaL_error(tolua_S, "%s function of ScrollView  has wrong number of arguments: %d, was expecting %d\n", "cc.ScrollView:unregisterScriptHandler", argc, 1);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -277,7 +277,7 @@ static int tolua_cocos2d_Control_registerControlEventHandler(lua_State* tolua_S)
         return 0;
     }
     
-    CCLOG("%s function of Control has wrong number of arguments: %d, was expecting %d\n", "cc.Control:registerControlEventHandler", argc, 2);
+    luaL_error(tolua_S, "%s function of Control has wrong number of arguments: %d, was expecting %d\n", "cc.Control:registerControlEventHandler", argc, 2);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -330,7 +330,7 @@ static int tolua_cocos2d_control_unregisterControlEventHandler(lua_State* tolua_
         return 0;
     }
     
-    CCLOG("%s function of Control  has wrong number of arguments: %d, was expecting %d\n", "cc.Control:unregisterControlEventHandler", argc, 1);
+    luaL_error(tolua_S, "%s function of Control  has wrong number of arguments: %d, was expecting %d\n", "cc.Control:unregisterControlEventHandler", argc, 1);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -451,7 +451,7 @@ static int lua_cocos2dx_AssetsManager_setDelegate(lua_State* L)
         return 0;
     }
     
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d\n", "cc.AssetsManager:setDelegate", argc, 2);
+    luaL_error(L, "%s has wrong number of arguments: %d, was expecting %d\n", "cc.AssetsManager:setDelegate", argc, 2);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -617,7 +617,7 @@ static int lua_cocos2dx_TableView_setDelegate(lua_State* L)
         return 0;
     }
     
-    CCLOG("'setDelegate' function of TableView wrong number of arguments: %d, was expecting %d\n", argc, 0);
+    luaL_error(L, "'setDelegate' function of TableView wrong number of arguments: %d, was expecting %d\n", argc, 0);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -756,7 +756,7 @@ static int lua_cocos2dx_TableView_setDataSource(lua_State* L)
         return 0;
     }
     
-    CCLOG("'setDataSource' function of TableView wrong number of arguments: %d, was expecting %d\n", argc, 0);
+    luaL_error(L, "'setDataSource' function of TableView wrong number of arguments: %d, was expecting %d\n", argc, 0);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -821,7 +821,7 @@ static int lua_cocos2dx_TableView_create(lua_State* L)
         
         return 1;
     }
-    CCLOG("'create' function of TableView wrong number of arguments: %d, was expecting %d\n", argc, 1);
+    luaL_error(L, "'create' function of TableView wrong number of arguments: %d, was expecting %d\n", argc, 1);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -869,7 +869,7 @@ static int lua_cocos2d_TableView_registerScriptHandler(lua_State* L)
         return 0;
     }
     
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d\n", "cc.TableView:registerScriptHandler",argc, 2);
+    luaL_error(L, "%s has wrong number of arguments: %d, was expecting %d\n", "cc.TableView:registerScriptHandler",argc, 2);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -914,7 +914,7 @@ static int lua_cocos2d_TableView_unregisterScriptHandler(lua_State* L)
         return 0;
     }
     
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d\n", "cc.TableView:unregisterScriptHandler", argc, 0);
+    luaL_error(L, "%s has wrong number of arguments: %d, was expecting %d\n", "cc.TableView:unregisterScriptHandler", argc, 0);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -985,7 +985,7 @@ static int lua_cocos2dx_Extension_EventListenerAssetsManagerEx_create(lua_State*
         return 1;
     }
     
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d \n", "create",argc, 2);
+    luaL_error(L, "%s has wrong number of arguments: %d, was expecting %d \n", "create",argc, 2);
     return 0;
     
 #if COCOS2D_DEBUG >= 1

--- a/cocos/scripting/lua-bindings/manual/network/lua_xml_http_request.cpp
+++ b/cocos/scripting/lua-bindings/manual/network/lua_xml_http_request.cpp
@@ -309,7 +309,7 @@ static int lua_cocos2dx_XMLHttpRequest_constructor(lua_State* L)
         return 1;
     }
     
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d \n", "XMLHttpRequest",argc, 0);
+    luaL_error(L, "%s has wrong number of arguments: %d, was expecting %d \n", "XMLHttpRequest",argc, 0);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -381,7 +381,7 @@ static int lua_set_XMLHttpRequest_responseType(lua_State* L)
         return 0;
     }
     
-    CCLOG("'setResponseType' function of XMLHttpRequest wrong number of arguments: %d, was expecting %d\n", argc, 1);
+    luaL_error(L, "'setResponseType' function of XMLHttpRequest wrong number of arguments: %d, was expecting %d\n", argc, 1);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -450,7 +450,7 @@ static int lua_set_XMLHttpRequest_withCredentials(lua_State* L)
         return 0;
     }
     
-    CCLOG("'setWithCredentials' function of XMLHttpRequest wrong number of arguments: %d, was expecting %d\n", argc, 1);
+    luaL_error(L, "'setWithCredentials' function of XMLHttpRequest wrong number of arguments: %d, was expecting %d\n", argc, 1);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -519,7 +519,7 @@ static int lua_set_XMLHttpRequest_timeout(lua_State* L)
         return 0;
     }
     
-    CCLOG("'setTimeout' function of XMLHttpRequest wrong number of arguments: %d, was expecting %d\n", argc, 1);
+    luaL_error(L, "'setTimeout' function of XMLHttpRequest wrong number of arguments: %d, was expecting %d\n", argc, 1);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -804,7 +804,7 @@ static int lua_cocos2dx_XMLHttpRequest_open(lua_State* L)
         return 0;
     }
     
-    CCLOG("'open' function of XMLHttpRequest wrong number of arguments: %d, was expecting %d\n", argc, 2);
+    luaL_error(L, "'open' function of XMLHttpRequest wrong number of arguments: %d, was expecting %d\n", argc, 2);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -944,7 +944,7 @@ static int lua_cocos2dx_XMLHttpRequest_setRequestHeader(lua_State* L)
         return 0;
     }
     
-    CCLOG("'setRequestHeader' function of XMLHttpRequest wrong number of arguments: %d, was expecting %d\n", argc, 2);
+    luaL_error(L, "'setRequestHeader' function of XMLHttpRequest wrong number of arguments: %d, was expecting %d\n", argc, 2);
     return 0;
 #if COCOS2D_DEBUG >= 1
 tolua_lerror:
@@ -991,7 +991,7 @@ static int lua_cocos2dx_XMLHttpRequest_getAllResponseHeaders(lua_State* L)
         return 1;
     }
     
-    CCLOG("'getAllResponseHeaders' function of XMLHttpRequest wrong number of arguments: %d, was expecting %d\n", argc, 0);
+    luaL_error(L, "'getAllResponseHeaders' function of XMLHttpRequest wrong number of arguments: %d, was expecting %d\n", argc, 0);
     return 0;
 #if COCOS2D_DEBUG >= 1
 tolua_lerror:
@@ -1045,7 +1045,7 @@ static int lua_cocos2dx_XMLHttpRequest_getResponseHeader(lua_State* L)
         }
     }
     
-    CCLOG("'getResponseHeader' function of XMLHttpRequest wrong number of arguments: %d, was expecting %d\n", argc, 1);
+    luaL_error(L, "'getResponseHeader' function of XMLHttpRequest wrong number of arguments: %d, was expecting %d\n", argc, 1);
     return 0;
 #if COCOS2D_DEBUG >= 1
 tolua_lerror:
@@ -1089,7 +1089,7 @@ static int lua_cocos2dx_XMLHttpRequest_registerScriptHandler(lua_State* L)
         return 0;
     }
     
-    CCLOG("'registerScriptHandler' function of XMLHttpRequest wrong number of arguments: %d, was expecting %d\n", argc, 1);
+    luaL_error(L, "'registerScriptHandler' function of XMLHttpRequest wrong number of arguments: %d, was expecting %d\n", argc, 1);
     return 0;
 #if COCOS2D_DEBUG >= 1
 tolua_lerror:
@@ -1128,7 +1128,7 @@ static int lua_cocos2dx_XMLHttpRequest_unregisterScriptHandler(lua_State* L)
         return 0;
     }
     
-    CCLOG("'unregisterScriptHandler' function of XMLHttpRequest wrong number of arguments: %d, was expecting %d\n", argc, 0);
+    luaL_error(L, "'unregisterScriptHandler' function of XMLHttpRequest wrong number of arguments: %d, was expecting %d\n", argc, 0);
     return 0;
 #if COCOS2D_DEBUG >= 1
 tolua_lerror:

--- a/cocos/scripting/lua-bindings/manual/spine/lua_cocos2dx_spine_manual.cpp
+++ b/cocos/scripting/lua-bindings/manual/spine/lua_cocos2dx_spine_manual.cpp
@@ -68,7 +68,7 @@ static int tolua_cocos2dx_setBlendFunc(lua_State* tolua_S,const char* className)
     }
 
 
-    CCLOG("'setBlendFunc' has wrong number of arguments: %d, was expecting %d\n", argc, 2);
+    luaL_error(tolua_S, "'setBlendFunc' has wrong number of arguments: %d, was expecting %d\n", argc, 2);
     return 0;
 
 #if COCOS2D_DEBUG >= 1
@@ -133,7 +133,7 @@ static int lua_cocos2dx_CCSkeletonAnimation_createWithFile(lua_State* L)
         return 1;
     }
     
-    CCLOG("'createWithFile' function of SkeletonAnimation has wrong number of arguments: %d, was expecting %d\n", argc, 2);
+    luaL_error(L, "'createWithFile' function of SkeletonAnimation has wrong number of arguments: %d, was expecting %d\n", argc, 2);
     
 #if COCOS2D_DEBUG >= 1
 tolua_lerror:
@@ -387,7 +387,7 @@ static int lua_cocos2dx_spine_SkeletonAnimation_addAnimation(lua_State* tolua_S)
 
         return 0;
     }
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d \n", "addAnimation",argc, 3);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "addAnimation",argc, 3);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -442,7 +442,7 @@ static int lua_cocos2dx_spine_SkeletonAnimation_setAnimation(lua_State* tolua_S)
         
         return 0;
     }
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d \n", "setAnimation",argc, 3);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "setAnimation",argc, 3);
     return 0;
     
 #if COCOS2D_DEBUG >= 1

--- a/cocos/scripting/lua-bindings/manual/ui/lua_cocos2dx_experimental_video_manual.cpp
+++ b/cocos/scripting/lua-bindings/manual/ui/lua_cocos2dx_experimental_video_manual.cpp
@@ -54,7 +54,7 @@ static int lua_cocos2dx_experimental_video_VideoPlayer_addEventListener(lua_Stat
         
         return 0;
     }
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d\n ", "ccexp.VideoPlayer:addEventListener",argc, 0);
+    luaL_error(L, "%s has wrong number of arguments: %d, was expecting %d\n ", "ccexp.VideoPlayer:addEventListener",argc, 0);
     return 0;
 #if COCOS2D_DEBUG >= 1
     tolua_lerror:

--- a/cocos/scripting/lua-bindings/manual/ui/lua_cocos2dx_ui_manual.cpp
+++ b/cocos/scripting/lua-bindings/manual/ui/lua_cocos2dx_ui_manual.cpp
@@ -93,7 +93,7 @@ static int lua_cocos2dx_Widget_addTouchEventListener(lua_State* L)
         return 0;
     }
     
-    CCLOG("'addTouchEventListener' function of Widget has wrong number of arguments: %d, was expecting %d\n", argc, 1);
+    luaL_error(L, "'addTouchEventListener' function of Widget has wrong number of arguments: %d, was expecting %d\n", argc, 1);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -154,7 +154,7 @@ static int lua_cocos2dx_CheckBox_addEventListener(lua_State* L)
         return 0;
     }
     
-    CCLOG("'addEventListener' function of CheckBox has wrong number of arguments: %d, was expecting %d\n", argc, 1);
+    luaL_error(L, "'addEventListener' function of CheckBox has wrong number of arguments: %d, was expecting %d\n", argc, 1);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -216,7 +216,7 @@ static int lua_cocos2dx_Slider_addEventListener(lua_State* L)
         return 0;
     }
     
-    CCLOG("'addEventListener' function of Slider has wrong number of arguments: %d, was expecting %d\n", argc, 1);
+    luaL_error(L, "'addEventListener' function of Slider has wrong number of arguments: %d, was expecting %d\n", argc, 1);
     
     return 0;
     
@@ -278,7 +278,7 @@ static int lua_cocos2dx_TextField_addEventListener(lua_State* L)
         return 0;
     }
     
-    CCLOG("'addEventListener' function of TextField has wrong number of arguments: %d, was expecting %d\n", argc, 1);
+    luaL_error(L, "'addEventListener' function of TextField has wrong number of arguments: %d, was expecting %d\n", argc, 1);
     
     return 0;
     
@@ -340,7 +340,7 @@ static int lua_cocos2dx_PageView_addEventListener(lua_State* L)
         return 0;
     }
     
-    CCLOG("'addEventListener' function of PageView has wrong number of arguments: %d, was expecting %d\n", argc, 1);
+    luaL_error(L, "'addEventListener' function of PageView has wrong number of arguments: %d, was expecting %d\n", argc, 1);
     
     return 0;
     
@@ -402,7 +402,7 @@ static int lua_cocos2dx_ScrollView_addEventListener(lua_State* L)
         return 0;
     }
     
-    CCLOG("'addEventListener' function of ScrollView has wrong number of arguments: %d, was expecting %d\n", argc, 1);
+    luaL_error(L, "'addEventListener' function of ScrollView has wrong number of arguments: %d, was expecting %d\n", argc, 1);
     
     return 0;
     
@@ -465,7 +465,7 @@ static int lua_cocos2dx_ListView_addEventListener(lua_State* L)
         return 0;
     }
     
-    CCLOG("'addEventListener' function of ListView has wrong number of arguments: %d, was expecting %d\n", argc, 1);
+    luaL_error(L, "'addEventListener' function of ListView has wrong number of arguments: %d, was expecting %d\n", argc, 1);
     
     return 0;
     
@@ -517,7 +517,7 @@ static int lua_cocos2dx_ListView_addScrollViewEventListener(lua_State* L)
         return 0;
     }
     
-    CCLOG("'addScrollViewEventListener' function of ListView has wrong number of arguments: %d, was expecting %d\n", argc, 1);
+    luaL_error(L, "'addScrollViewEventListener' function of ListView has wrong number of arguments: %d, was expecting %d\n", argc, 1);
     
     return 0;
     
@@ -597,7 +597,7 @@ static int lua_cocos2dx_LayoutParameter_setMargin(lua_State* L)
         return 0;
     }
     
-    CCLOG("'setMargin' function of LayoutParameter has wrong number of arguments: %d, was expecting %d\n", argc, 1);
+    luaL_error(L, "'setMargin' function of LayoutParameter has wrong number of arguments: %d, was expecting %d\n", argc, 1);
     
     return 0;
     
@@ -656,7 +656,7 @@ static int lua_cocos2dx_LayoutParameter_getMargin(lua_State* L)
         return 1;
     }
     
-    CCLOG("'getMargin' function of LayoutParameter has wrong number of arguments: %d, was expecting %d\n", argc, 0);
+    luaL_error(L, "'getMargin' function of LayoutParameter has wrong number of arguments: %d, was expecting %d\n", argc, 0);
     
     return 0;
     
@@ -717,7 +717,7 @@ static int tolua_cocos2d_EditBox_registerScriptEditBoxHandler(lua_State* L)
         return 0;
     }
     
-    CCLOG("%s function of EditBox  has wrong number of arguments: %d, was expecting %d\n", "ccui.EditBox:registerScriptEditBoxHandler", argc, 1);
+    luaL_error(L, "%s function of EditBox  has wrong number of arguments: %d, was expecting %d\n", "ccui.EditBox:registerScriptEditBoxHandler", argc, 1);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -759,7 +759,7 @@ static int tolua_cocos2d_EditBox_unregisterScriptEditBoxHandler(lua_State* L)
         return 0;
     }
     
-    CCLOG("%s function of EditBox  has wrong number of arguments: %d, was expecting %d\n", "ccui.EditBox:unregisterScriptEditBoxHandler", argc, 0);
+    luaL_error(L, "%s function of EditBox  has wrong number of arguments: %d, was expecting %d\n", "ccui.EditBox:unregisterScriptEditBoxHandler", argc, 0);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -828,7 +828,7 @@ static int tolua_cocos2dx_EventListenerFocus_create(lua_State* L)
         return 1;
     }
     
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d\n", "cc.EventListenerFocus:create", argc, 1);
+    luaL_error(L, "%s has wrong number of arguments: %d, was expecting %d\n", "cc.EventListenerFocus:create", argc, 1);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -899,7 +899,7 @@ static int tolua_cocos2dx_EventListenerFocus_clone(lua_State* L)
         return 1;
     }
     
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d\n", "cc.EventListenerFocus:clone", argc, 0);
+    luaL_error(L, "%s has wrong number of arguments: %d, was expecting %d\n", "cc.EventListenerFocus:clone", argc, 0);
     return 0;
     
 #if COCOS2D_DEBUG >= 1
@@ -955,7 +955,7 @@ static int tolua_cocos2dx_EventListenerFocus_registerScriptHandler(lua_State* L)
         return 0;
     }
     
-    CCLOG("%s has wrong number of arguments: %d, was expecting %d\n", "cc.EventListenerFocus:registerScriptHandler", argc, 1);
+    luaL_error(L, "%s has wrong number of arguments: %d, was expecting %d\n", "cc.EventListenerFocus:registerScriptHandler", argc, 1);
     return 0;
     
 #if COCOS2D_DEBUG >= 1


### PR DESCRIPTION
eg:
ccexp.AudioEngine:setFinishCallback(AudioControlTest._audioID,finishCallback, 5)

error msg in the old mechanism:

```
ccexp.AudioEngine:setFinishCallback has wrong number of arguments: 3, was expecting 2
```

error msg in the new mechanism:

```
[LUA ERROR] [string "NewAudioEngineTest/NewAudioEngineTest.lua"]:136: ccexp.AudioEngine:setFinishCallback has wrong number of arguments: 3, was expecting 2
```
