### PR TITLE
fix crash when shader error on Win32

### DIFF
--- a/cocos/renderer/CCGLProgram.cpp
+++ b/cocos/renderer/CCGLProgram.cpp
@@ -602,8 +602,9 @@ std::string GLProgram::logForOpenGLObject(GLuint object, GLInfoFunction infoFunc
     if (logLength < 1)
         return "";
 
-    char *logBytes = (char*)malloc(logLength);
+    char *logBytes = (char*)malloc(logLength+1);
     logFunc(object, logLength, &charsWritten, logBytes);
+    logBytes[logLength] = '\0';
 
     ret = logBytes;
 
@@ -613,16 +614,61 @@ std::string GLProgram::logForOpenGLObject(GLuint object, GLInfoFunction infoFunc
 
 std::string GLProgram::getVertexShaderLog() const
 {
+    std::string ret;
+    GLint logLength = 0, charsWritten = 0;
+
+    glGetShaderiv(_vertShader, GL_INFO_LOG_LENGTH, &logLength);
+    if (logLength < 1)
+        return "";
+
+    char *logBytes = (char*)malloc(logLength+1);
+    glGetShaderInfoLog(_vertShader, logLength, &charsWritten, logBytes);
+    logBytes[logLength] = '\0';
+
+    ret = logBytes;
+
+    free(logBytes);
+    return ret;
     return this->logForOpenGLObject(_vertShader, (GLInfoFunction)&glGetShaderiv, (GLLogFunction)&glGetShaderInfoLog);
 }
 
 std::string GLProgram::getFragmentShaderLog() const
 {
+    std::string ret;
+    GLint logLength = 0, charsWritten = 0;
+
+    glGetShaderiv(_fragShader, GL_INFO_LOG_LENGTH, &logLength);
+    if (logLength < 1)
+        return "";
+
+    char *logBytes = (char*)malloc(logLength+1);
+    glGetShaderInfoLog(_fragShader, logLength, &charsWritten, logBytes);
+    logBytes[logLength] = '\0';
+
+    ret = logBytes;
+
+    free(logBytes);
+    return ret;
     return this->logForOpenGLObject(_fragShader, (GLInfoFunction)&glGetShaderiv, (GLLogFunction)&glGetShaderInfoLog);
 }
 
 std::string GLProgram::getProgramLog() const
 {
+    std::string ret;
+    GLint logLength = 0, charsWritten = 0;
+
+    glGetProgramiv(_program, GL_INFO_LOG_LENGTH, &logLength);
+    if (logLength < 1)
+        return "";
+
+    char *logBytes = (char*)malloc(logLength+1);
+    glGetProgramInfoLog(_fragShader, logLength, &charsWritten, logBytes);
+    logBytes[logLength] = '\0';
+
+    ret = logBytes;
+
+    free(logBytes);
+    return ret;
     return this->logForOpenGLObject(_program, (GLInfoFunction)&glGetProgramiv, (GLLogFunction)&glGetProgramInfoLog);
 }
 


### PR DESCRIPTION
现在在Windows上，一旦Shader编译错误，程序就会直接崩溃。因为在Windows上，诸如glGetShaderiv这种函数其实并不是函数，而是函数指针，因此取其指针得到的其实是指针的指针。而且它的调用方式并不是__cdecl，而是__stdcall，所以这里应该直接写，不能通过函数指针来统一处理。

不过，还是希望有一个两全其美的方法……
