### PR TITLE
Solve the environment conflict with Cocos.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -483,28 +483,6 @@ class SetEnvVar(object):
 
             self._force_update_env(COCOS_CONSOLE_ROOT, cocos_consle_root)
 
-    def set_cocos_x_root(self):
-        print("->Check environment variable %s" % COCOS_X_ROOT)
-        cocos_x_root = self.current_absolute_path
-        old_dir = self._find_environment_variable(COCOS_X_ROOT)
-        if old_dir is None:
-            # add environment variable
-            if self._isWindows():
-                self.set_windows_path(cocos_x_root)
-
-            self._set_environment_variable(COCOS_X_ROOT, cocos_x_root)
-        else:
-            if old_dir == cocos_x_root:
-                # is same with before, nothing to do
-                return
-
-            # update the environment variable
-            if self._isWindows():
-                self.remove_dir_from_win_path(old_dir)
-                self.set_windows_path(cocos_x_root)
-
-            self._force_update_env(COCOS_X_ROOT, cocos_x_root)
-
     def set_templates_root(self):
         print("->Check environment variable %s" % COCOS_TEMPLATES_ROOT)
         cocos_templates_root = os.path.join(self.current_absolute_path, 'templates')
@@ -685,7 +663,6 @@ class SetEnvVar(object):
         self.file_used_for_setup = self._get_filepath_for_setup()
 
         self.set_console_root()
-        self.set_cocos_x_root()
         self.set_templates_root()
 
         if self._isWindows():


### PR DESCRIPTION
@ricardoquesada, @minggo 
Please review this PR. I removed the logic of write environment `COCOS_X_ROOT` in `setup.py`.

Because `Cocos` depends on the environment to finding the prebuilt libs. Developers will encountered problems when they following these steps:
1. Download & Install Cocos.
2. Create a project from Cocos.
3. Download & Install cocos2d-x.
4. Invoke `setup.py` in cocos2d-x.
5. The project created from Cocos CAN NOT build on platforms: Android & Win32.

So I think the `setup.py` of cocos2d-x should not write the environment `COCOS_X_ROOT`.
