### PR TITLE
Fix UIText miss copy contentSize for clone

### DIFF
--- a/cocos/ui/UIText.cpp
+++ b/cocos/ui/UIText.cpp
@@ -360,6 +360,7 @@ void Text::copySpecialProperties(Widget *widget)
         setTextHorizontalAlignment(label->_labelRenderer->getHorizontalAlignment());
         setTextVerticalAlignment(label->_labelRenderer->getVerticalAlignment());
         setTextAreaSize(label->_labelRenderer->getDimensions());
+        setContentSize(label->getContentSize());
     }
 }
 


### PR DESCRIPTION
when cloning Text Widget, it should copy content size as well. or, the new copy will get wrong display.
