### PR TITLE
add method setEnabledEventListenersForTarget

### DIFF
--- a/cocos/base/CCEventDispatcher.cpp
+++ b/cocos/base/CCEventDispatcher.cpp
@@ -287,6 +287,36 @@ void EventDispatcher::visitTarget(Node* node, bool isRootNode)
     }
 }
 
+void EventDispatcher::setEnabledEventListenersForTarget(Node* target, bool isEnabled, bool recursive/* = false */)
+{
+    auto listenerIter = _nodeListenersMap.find(target);
+    if (listenerIter != _nodeListenersMap.end())
+    {
+        auto listeners = listenerIter->second;
+        for (auto& l : *listeners)
+        {
+            l->setEnabled(isEnabled);
+        }
+    }
+    
+    for (auto& listener : _toAddedListeners)
+    {
+        if (listener->getAssociatedNode() == target)
+        {
+            listener->setEnabled(isEnabled);
+        }
+    }
+    
+    if (recursive)
+    {
+        const auto& children = target->getChildren();
+        for (const auto& child : children)
+        {
+            setEnabledEventListenersForTarget(child, isEnabled, true);
+        }
+    }
+}
+
 void EventDispatcher::pauseEventListenersForTarget(Node* target, bool recursive/* = false */)
 {
     auto listenerIter = _nodeListenersMap.find(target);

--- a/cocos/base/CCEventDispatcher.h
+++ b/cocos/base/CCEventDispatcher.h
@@ -104,6 +104,7 @@ public:
     /////////////////////////////////////////////
     
     // Pauses / Resumes event listener
+    void setEnabledEventListenersForTarget(Node* target, bool isEnabled, bool recursive/* = false */);
     
     /** Pauses all listeners which are associated the specified target. */
     void pauseEventListenersForTarget(Node* target, bool recursive = false);


### PR DESCRIPTION
AddEventListenerしたあとのリスナーに対して個別にsetEnabledできる機能がなかったため、作りました。

Because I couldn't "setEnabled" of EventListener instance  that executed "addEventListenerWithSceneGraphPriority", I wrote this method.
