### PR TITLE
Clang static analyzer crash fix

### DIFF
--- a/cocos/base/CCDirector.cpp
+++ b/cocos/base/CCDirector.cpp
@@ -971,6 +971,7 @@ void Director::purgeDirector()
 #pragma warning (push)
 #pragma warning (disable: 4996)
 #endif
+//it will crash clang static analyzer so hide it if __clang_analyzer__ defined
 #ifndef __clang_analyzer__
     DrawPrimitives::free();
 #endif

--- a/cocos/base/CCDirector.cpp
+++ b/cocos/base/CCDirector.cpp
@@ -971,7 +971,9 @@ void Director::purgeDirector()
 #pragma warning (push)
 #pragma warning (disable: 4996)
 #endif
+#ifndef __clang_analyzer__
     DrawPrimitives::free();
+#endif
 #if defined(__GNUC__) && ((__GNUC__ >= 4) || ((__GNUC__ == 3) && (__GNUC_MINOR__ >= 1)))
 #pragma GCC diagnostic warning "-Wdeprecated-declarations"
 #elif _MSC_VER >= 1400 //vs 2005 or higher

--- a/cocos/deprecated/CCDeprecated.cpp
+++ b/cocos/deprecated/CCDeprecated.cpp
@@ -87,6 +87,7 @@ void ccDrawInit()
 
 void ccDrawFree()
 {
+//it will crash clang static analyzer so hide it if __clang_analyzer__ defined
 #ifndef __clang_analyzer__
     DrawPrimitives::free();
 #endif

--- a/cocos/deprecated/CCDeprecated.cpp
+++ b/cocos/deprecated/CCDeprecated.cpp
@@ -87,7 +87,9 @@ void ccDrawInit()
 
 void ccDrawFree()
 {
+#ifndef __clang_analyzer__
     DrawPrimitives::free();
+#endif
 }
 
 void ccDrawPoint( const Vec2& point )


### PR DESCRIPTION
Clang static analyzer crash on this two lines
just ignore it in analyzer
