### PR TITLE
iOS OpenGL refactoring

### DIFF
--- a/cocos/base/CCDirector.cpp
+++ b/cocos/base/CCDirector.cpp
@@ -258,6 +258,7 @@ void Director::drawScene()
 
     if (_openGLView)
     {
+        _openGLView->setBuffers();
         _openGLView->pollEvents();
     }
 

--- a/cocos/platform/CCGLView.cpp
+++ b/cocos/platform/CCGLView.cpp
@@ -119,6 +119,10 @@ void GLView::pollEvents()
 {
 }
 
+void GLView::setBuffers()
+{
+}
+
 void GLView::updateDesignResolutionSize()
 {
     if (_screenSize.width > 0 && _screenSize.height > 0

--- a/cocos/platform/CCGLView.h
+++ b/cocos/platform/CCGLView.h
@@ -124,6 +124,12 @@ public:
     CC_DEPRECATED_ATTRIBUTE virtual void pollInputEvents();
 
     virtual void pollEvents();
+    
+    /**
+     * Called before draw. Subclass must implement methods if platform
+     * need some additional steps before draw.
+     */
+    virtual void setBuffers();
 
     /**
      * Get the frame size of EGL view.

--- a/cocos/platform/ios/CCEAGLView-ios.h
+++ b/cocos/platform/ios/CCEAGLView-ios.h
@@ -144,6 +144,7 @@ Copyright (C) 2008 Apple Inc. All Rights Reserved.
 
 
 /** CCEAGLView uses double-buffer. This method swaps the buffers */
+-(void) setBuffers;
 -(void) swapBuffers;
 
 - (CGRect) convertRectFromViewToSurface:(CGRect)rect;

--- a/cocos/platform/ios/CCEAGLView-ios.mm
+++ b/cocos/platform/ios/CCEAGLView-ios.mm
@@ -93,6 +93,7 @@ Copyright (C) 2008 Apple Inc. All Rights Reserved.
 @synthesize multiSampling=multiSampling_;
 @synthesize isKeyboardShown=isKeyboardShown_;
 @synthesize keyboardShowNotification = keyboardShowNotification_;
+
 + (Class) layerClass
 {
     return [CAEAGLLayer class];
@@ -253,20 +254,12 @@ Copyright (C) 2008 Apple Inc. All Rights Reserved.
 
 - (void) layoutSubviews
 {
-    [renderer_ resizeFromLayer:(CAEAGLLayer*)self.layer];
-    size_ = [renderer_ backingSize];
+    [renderer_ deleteFramebuffer];
+}
 
-    // Issue #914 #924
-//     Director *director = [Director sharedDirector];
-//     [director reshapeProjection:size_];
-    cocos2d::Size size;
-    size.width = size_.width;
-    size.height = size_.height;
-    //cocos2d::Director::getInstance()->reshapeProjection(size);
-
-    // Avoid flicker. Issue #350
-    //[director performSelectorOnMainThread:@selector(drawScene) withObject:nil waitUntilDone:YES];
-    cocos2d::Director::getInstance()->drawScene();
+-(void) setBuffers
+{
+    [renderer_ setFramebuffer:(CAEAGLLayer*)self.layer];
 }
 
 - (void) swapBuffers

--- a/cocos/platform/ios/CCES2Renderer-ios.h
+++ b/cocos/platform/ios/CCES2Renderer-ios.h
@@ -78,7 +78,9 @@
 /** EAGLContext */
 @property (nonatomic,readonly) EAGLContext* context;
 
-- (BOOL)resizeFromLayer:(CAEAGLLayer *)layer;
+- (void)deleteFramebuffer;
+- (void)setFramebuffer:(CAEAGLLayer *)layer;
+
 @end
 
 

--- a/cocos/platform/ios/CCESRenderer-ios.h
+++ b/cocos/platform/ios/CCESRenderer-ios.h
@@ -41,7 +41,8 @@
 
 - (id) initWithDepthFormat:(unsigned int)depthFormat withPixelFormat:(unsigned int)pixelFormat withSharegroup:(EAGLSharegroup*)sharegroup withMultiSampling:(BOOL) multiSampling withNumberOfSamples:(unsigned int) requestedSamples;
 
-- (BOOL) resizeFromLayer:(CAEAGLLayer *)layer;
+- (void) deleteFramebuffer;
+- (void) setFramebuffer:(CAEAGLLayer *)layer;
 
 - (EAGLContext*) context;
 - (CGSize) backingSize;

--- a/cocos/platform/ios/CCGLViewImpl-ios.h
+++ b/cocos/platform/ios/CCGLViewImpl-ios.h
@@ -73,6 +73,7 @@ public:
     virtual bool isOpenGLReady() override;
     virtual void end() override;
     virtual void swapBuffers() override;
+    virtual void setBuffers() override;
     virtual void setIMEKeyboardState(bool bOpen) override;
 
 protected:

--- a/cocos/platform/ios/CCGLViewImpl-ios.mm
+++ b/cocos/platform/ios/CCGLViewImpl-ios.mm
@@ -191,6 +191,11 @@ void GLViewImpl::end()
     release();
 }
 
+void GLView::setBuffers()
+{
+    CCEAGLView *eaglview = (CCEAGLView*) _eaglview;
+    [eaglview setBuffers];
+}
 
 void GLViewImpl::swapBuffers()
 {

--- a/cocos/platform/ios/CCGLViewImpl-ios.mm
+++ b/cocos/platform/ios/CCGLViewImpl-ios.mm
@@ -191,7 +191,7 @@ void GLViewImpl::end()
     release();
 }
 
-void GLView::setBuffers()
+void GLViewImpl::setBuffers()
 {
     CCEAGLView *eaglview = (CCEAGLView*) _eaglview;
     [eaglview setBuffers];


### PR DESCRIPTION
in apple documentation written that OpenGL buffers must cleared on layoutSubview but created only on next frame layoutSubview can call several time on one frame and sometimes [context_ renderbufferStorage:GL_RENDERBUFFER fromDrawable:layer] return false and picture freeze.
For example if you game is landscape, and you use banner or interstitials user click on it, StoreWindows opens(on iPhone it is only portrait) after go back picture freeze on last frame.
