### PR TITLE
Fix usage of tinyxml2 in cocostudio code

### DIFF
--- a/cocos/editor-support/cocostudio/ActionTimeline/CCActionTimelineCache.cpp
+++ b/cocos/editor-support/cocostudio/ActionTimeline/CCActionTimelineCache.cpp
@@ -33,7 +33,7 @@ THE SOFTWARE.
 
 #include "cocostudio/CSParseBinary_generated.h"
 
-#include "tinyxml2/tinyxml2.h"
+#include "tinyxml2.h"
 #include "flatbuffers/flatbuffers.h"
 #include "flatbuffers/util.h"
 

--- a/cocos/editor-support/cocostudio/ActionTimeline/CCActionTimelineCache.h
+++ b/cocos/editor-support/cocostudio/ActionTimeline/CCActionTimelineCache.h
@@ -34,7 +34,7 @@ THE SOFTWARE.
 
 namespace flatbuffers
 {
-    struct FlatBufferBuilder;
+    class FlatBufferBuilder;
     
     struct NodeAction;
     struct TimeLine;

--- a/cocos/editor-support/cocostudio/ActionTimeline/CSLoader.h
+++ b/cocos/editor-support/cocostudio/ActionTimeline/CSLoader.h
@@ -32,7 +32,7 @@
 
 namespace flatbuffers
 {
-    struct FlatBufferBuilder;
+    class FlatBufferBuilder;
     
     struct NodeTree;
     

--- a/cocos/editor-support/cocostudio/FlatBuffersSerialize.cpp
+++ b/cocos/editor-support/cocostudio/FlatBuffersSerialize.cpp
@@ -54,7 +54,7 @@
 #include "WidgetReader/PageViewReader/PageViewReader.h"
 #include "WidgetReader/ListViewReader/ListViewReader.h"
 
-#include "tinyxml2/tinyxml2.h"
+#include "tinyxml2.h"
 #include "flatbuffers/flatbuffers.h"
 #include "flatbuffers/util.h"
 

--- a/cocos/editor-support/cocostudio/FlatBuffersSerialize.h
+++ b/cocos/editor-support/cocostudio/FlatBuffersSerialize.h
@@ -28,7 +28,6 @@
 #include "cocos2d.h"
 #include "ExtensionMacros.h"
 #include "cocostudio/CocosStudioExport.h"
-#include "tinyxml2.h"
 
 namespace flatbuffers
 {

--- a/cocos/editor-support/cocostudio/FlatBuffersSerialize.h
+++ b/cocos/editor-support/cocostudio/FlatBuffersSerialize.h
@@ -28,7 +28,7 @@
 #include "cocos2d.h"
 #include "ExtensionMacros.h"
 #include "cocostudio/CocosStudioExport.h"
-#include "tinyxml2/tinyxml2.h"
+#include "tinyxml2.h"
 
 namespace flatbuffers
 {

--- a/cocos/editor-support/cocostudio/WidgetReader/ButtonReader/ButtonReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/ButtonReader/ButtonReader.cpp
@@ -7,7 +7,7 @@
 #include "cocostudio/CSParseBinary_generated.h"
 #include "cocostudio/FlatBuffersSerialize.h"
 
-#include "tinyxml2/tinyxml2.h"
+#include "tinyxml2.h"
 #include "flatbuffers/flatbuffers.h"
 
 USING_NS_CC;

--- a/cocos/editor-support/cocostudio/WidgetReader/CheckBoxReader/CheckBoxReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/CheckBoxReader/CheckBoxReader.cpp
@@ -7,7 +7,7 @@
 #include "cocostudio/CSParseBinary_generated.h"
 #include "cocostudio/FlatBuffersSerialize.h"
 
-#include "tinyxml2/tinyxml2.h"
+#include "tinyxml2.h"
 #include "flatbuffers/flatbuffers.h"
 
 USING_NS_CC;

--- a/cocos/editor-support/cocostudio/WidgetReader/ComAudioReader/ComAudioReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/ComAudioReader/ComAudioReader.cpp
@@ -28,7 +28,7 @@
 #include "cocostudio/CSParseBinary_generated.h"
 #include "cocostudio/WidgetReader/NodeReader/NodeReader.h"
 
-#include "tinyxml2/tinyxml2.h"
+#include "tinyxml2.h"
 #include "flatbuffers/flatbuffers.h"
 
 USING_NS_CC;

--- a/cocos/editor-support/cocostudio/WidgetReader/GameMapReader/GameMapReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/GameMapReader/GameMapReader.cpp
@@ -27,7 +27,7 @@
 #include "cocostudio/CSParseBinary_generated.h"
 #include "cocostudio/WidgetReader/NodeReader/NodeReader.h"
 
-#include "tinyxml2/tinyxml2.h"
+#include "tinyxml2.h"
 #include "flatbuffers/flatbuffers.h"
 
 USING_NS_CC;

--- a/cocos/editor-support/cocostudio/WidgetReader/ImageViewReader/ImageViewReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/ImageViewReader/ImageViewReader.cpp
@@ -7,7 +7,7 @@
 #include "cocostudio/CSParseBinary_generated.h"
 #include "cocostudio/FlatBuffersSerialize.h"
 
-#include "tinyxml2/tinyxml2.h"
+#include "tinyxml2.h"
 #include "flatbuffers/flatbuffers.h"
 
 USING_NS_CC;

--- a/cocos/editor-support/cocostudio/WidgetReader/LayoutReader/LayoutReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/LayoutReader/LayoutReader.cpp
@@ -10,7 +10,7 @@
 #include "cocostudio/CSParseBinary_generated.h"
 #include "cocostudio/FlatBuffersSerialize.h"
 
-#include "tinyxml2/tinyxml2.h"
+#include "tinyxml2.h"
 #include "flatbuffers/flatbuffers.h"
 
 USING_NS_CC;

--- a/cocos/editor-support/cocostudio/WidgetReader/ListViewReader/ListViewReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/ListViewReader/ListViewReader.cpp
@@ -7,7 +7,7 @@
 #include "cocostudio/CSParseBinary_generated.h"
 #include "cocostudio/FlatBuffersSerialize.h"
 
-#include "tinyxml2/tinyxml2.h"
+#include "tinyxml2.h"
 #include "flatbuffers/flatbuffers.h"
 
 USING_NS_CC;

--- a/cocos/editor-support/cocostudio/WidgetReader/LoadingBarReader/LoadingBarReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/LoadingBarReader/LoadingBarReader.cpp
@@ -7,7 +7,7 @@
 #include "cocostudio/CSParseBinary_generated.h"
 #include "cocostudio/FlatBuffersSerialize.h"
 
-#include "tinyxml2/tinyxml2.h"
+#include "tinyxml2.h"
 #include "flatbuffers/flatbuffers.h"
 
 USING_NS_CC;

--- a/cocos/editor-support/cocostudio/WidgetReader/NodeReader/NodeReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/NodeReader/NodeReader.cpp
@@ -27,7 +27,7 @@
 #include "cocostudio/CSParseBinary_generated.h"
 #include "cocostudio/ActionTimeline/CCActionTimeline.h"
 
-#include "tinyxml2/tinyxml2.h"
+#include "tinyxml2.h"
 #include "flatbuffers/flatbuffers.h"
 
 

--- a/cocos/editor-support/cocostudio/WidgetReader/PageViewReader/PageViewReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/PageViewReader/PageViewReader.cpp
@@ -8,7 +8,7 @@
 #include "cocostudio/CSParseBinary_generated.h"
 #include "cocostudio/FlatBuffersSerialize.h"
 
-#include "tinyxml2/tinyxml2.h"
+#include "tinyxml2.h"
 #include "flatbuffers/flatbuffers.h"
 
 USING_NS_CC;

--- a/cocos/editor-support/cocostudio/WidgetReader/ParticleReader/ParticleReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/ParticleReader/ParticleReader.cpp
@@ -27,7 +27,7 @@
 #include "cocostudio/CSParseBinary_generated.h"
 #include "cocostudio/WidgetReader/NodeReader/NodeReader.h"
 
-#include "tinyxml2/tinyxml2.h"
+#include "tinyxml2.h"
 #include "flatbuffers/flatbuffers.h"
 
 USING_NS_CC;

--- a/cocos/editor-support/cocostudio/WidgetReader/ProjectNodeReader/ProjectNodeReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/ProjectNodeReader/ProjectNodeReader.cpp
@@ -27,7 +27,7 @@
 #include "cocostudio/CSParseBinary_generated.h"
 #include "cocostudio/WidgetReader/NodeReader/NodeReader.h"
 
-#include "tinyxml2/tinyxml2.h"
+#include "tinyxml2.h"
 #include "flatbuffers/flatbuffers.h"
 
 USING_NS_CC;

--- a/cocos/editor-support/cocostudio/WidgetReader/ScrollViewReader/ScrollViewReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/ScrollViewReader/ScrollViewReader.cpp
@@ -7,7 +7,7 @@
 #include "cocostudio/CSParseBinary_generated.h"
 #include "cocostudio/FlatBuffersSerialize.h"
 
-#include "tinyxml2/tinyxml2.h"
+#include "tinyxml2.h"
 #include "flatbuffers/flatbuffers.h"
 
 USING_NS_CC;

--- a/cocos/editor-support/cocostudio/WidgetReader/SingleNodeReader/SingleNodeReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/SingleNodeReader/SingleNodeReader.cpp
@@ -28,7 +28,7 @@
 #include "cocostudio/ActionTimeline/CCActionTimeline.h"
 #include "cocostudio/WidgetReader/NodeReader/NodeReader.h"
 
-#include "tinyxml2/tinyxml2.h"
+#include "tinyxml2.h"
 #include "flatbuffers/flatbuffers.h"
 
 

--- a/cocos/editor-support/cocostudio/WidgetReader/SliderReader/SliderReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/SliderReader/SliderReader.cpp
@@ -7,7 +7,7 @@
 #include "cocostudio/CSParseBinary_generated.h"
 #include "cocostudio/FlatBuffersSerialize.h"
 
-#include "tinyxml2/tinyxml2.h"
+#include "tinyxml2.h"
 #include "flatbuffers/flatbuffers.h"
 
 USING_NS_CC;

--- a/cocos/editor-support/cocostudio/WidgetReader/SpriteReader/SpriteReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/SpriteReader/SpriteReader.cpp
@@ -28,7 +28,7 @@
 #include "cocostudio/FlatBuffersSerialize.h"
 #include "cocostudio/WidgetReader/NodeReader/NodeReader.h"
 
-#include "tinyxml2/tinyxml2.h"
+#include "tinyxml2.h"
 #include "flatbuffers/flatbuffers.h"
 
 USING_NS_CC;

--- a/cocos/editor-support/cocostudio/WidgetReader/TextAtlasReader/TextAtlasReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/TextAtlasReader/TextAtlasReader.cpp
@@ -7,7 +7,7 @@
 #include "cocostudio/CSParseBinary_generated.h"
 #include "cocostudio/FlatBuffersSerialize.h"
 
-#include "tinyxml2/tinyxml2.h"
+#include "tinyxml2.h"
 #include "flatbuffers/flatbuffers.h"
 
 USING_NS_CC;

--- a/cocos/editor-support/cocostudio/WidgetReader/TextBMFontReader/TextBMFontReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/TextBMFontReader/TextBMFontReader.cpp
@@ -6,7 +6,7 @@
 #include "cocostudio/CocoLoader.h"
 #include "cocostudio/CSParseBinary_generated.h"
 
-#include "tinyxml2/tinyxml2.h"
+#include "tinyxml2.h"
 #include "flatbuffers/flatbuffers.h"
 
 USING_NS_CC;

--- a/cocos/editor-support/cocostudio/WidgetReader/TextFieldReader/TextFieldReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/TextFieldReader/TextFieldReader.cpp
@@ -6,7 +6,7 @@
 #include "cocostudio/CocoLoader.h"
 #include "cocostudio/CSParseBinary_generated.h"
 
-#include "tinyxml2/tinyxml2.h"
+#include "tinyxml2.h"
 #include "flatbuffers/flatbuffers.h"
 
 USING_NS_CC;

--- a/cocos/editor-support/cocostudio/WidgetReader/TextReader/TextReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/TextReader/TextReader.cpp
@@ -6,7 +6,7 @@
 #include "cocostudio/CocoLoader.h"
 #include "cocostudio/CSParseBinary_generated.h"
 
-#include "tinyxml2/tinyxml2.h"
+#include "tinyxml2.h"
 #include "flatbuffers/flatbuffers.h"
 
 USING_NS_CC;

--- a/cocos/editor-support/cocostudio/WidgetReader/WidgetReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/WidgetReader.cpp
@@ -7,7 +7,7 @@
 #include "../ActionTimeline/CCActionTimeline.h"
 #include "cocostudio/CSParseBinary_generated.h"
 
-#include "tinyxml2/tinyxml2.h"
+#include "tinyxml2.h"
 #include "flatbuffers/flatbuffers.h"
 
 USING_NS_CC;


### PR DESCRIPTION
Replace `#include "tinyxml2/tinyxml2.h"` with `#include "tinyxml2.h"` in new cocostudio code.
This change fix build with cmake when system installed libraries are used (`-DUSE_PREBUILT_LIBS=NO`).

Some systems may install `tinyxml2` includes without special prefix directory, so `FindTinyXML2.cmake` was written to find include directory that directly contains `tinyxml2.h` header (without prefix dir). Moreover, official install script in [tinyxml2 project](https://github.com/leethomason/tinyxml2/blob/master/CMakeLists.txt#L67) install header to `<prefix>/include/tinyxml2.h`

Also fix some warnings in code. And remove unneeded inclusion of `tinyxml2.h` from user visible header file (`cocos/editor-support/cocostudio/FlatBuffersSerialize.h`), as a result usage of tinyxml in cocos may be "private" for user project.
