### PR TITLE
add cocos2d::Vector constructor with initializer_list

### DIFF
--- a/cocos/base/CCVector.h
+++ b/cocos/base/CCVector.h
@@ -32,7 +32,7 @@ THE SOFTWARE.
 #include <functional>
 #include <algorithm> // for std::find
 
-#if _MSC_VER >= 1800
+#if !define(_MSC_VER) || _MSC_VER >= 1800
 #include <initializer_list>
 #endif
 
@@ -86,7 +86,7 @@ public:
     }
     
     /** Constructor with a initializer_list */
-#if _MSC_VER >= 1800
+#if !define(_MSC_VER) || _MSC_VER >= 1800
     Vector<T>(std::initializer_list<T> list)
       : _data(list)
     {

--- a/cocos/base/CCVector.h
+++ b/cocos/base/CCVector.h
@@ -31,7 +31,10 @@ THE SOFTWARE.
 #include <vector>
 #include <functional>
 #include <algorithm> // for std::find
+
+#if _MSC_VER >= 1800
 #include <initializer_list>
+#endif
 
 NS_CC_BEGIN
 
@@ -83,12 +86,14 @@ public:
     }
     
     /** Constructor with a initializer_list */
+#if _MSC_VER >= 1800
     Vector<T>(std::initializer_list<T> list)
       : _data(list)
     {
         static_assert(std::is_convertible<T, Ref*>::value, "Invalid Type for cocos2d::Vector<T>!");
         addRefForAllObjects();
     }
+#endif
 
     /** Destructor */
     ~Vector<T>()

--- a/cocos/base/CCVector.h
+++ b/cocos/base/CCVector.h
@@ -32,8 +32,18 @@ THE SOFTWARE.
 #include <functional>
 #include <algorithm> // for std::find
 
-#if !define(_MSC_VER) || _MSC_VER >= 1800
+#ifdef _MSC_VER
+
+#if _MSC_VER >= 1800
 #include <initializer_list>
+#define __CCVECTOR_ENABLE_INITIALIZER_LIST
+#endif
+
+#else
+
+#include <initializer_list>
+#define __CCVECTOR_ENABLE_INITIALIZER_LIST
+
 #endif
 
 NS_CC_BEGIN
@@ -86,7 +96,7 @@ public:
     }
     
     /** Constructor with a initializer_list */
-#if !define(_MSC_VER) || _MSC_VER >= 1800
+#ifdef __CCVECTOR_ENABLE_INITIALIZER_LIST
     Vector<T>(std::initializer_list<T> list)
       : _data(list)
     {

--- a/cocos/base/CCVector.h
+++ b/cocos/base/CCVector.h
@@ -31,6 +31,7 @@ THE SOFTWARE.
 #include <vector>
 #include <functional>
 #include <algorithm> // for std::find
+#include <initializer_list>
 
 NS_CC_BEGIN
 
@@ -79,6 +80,14 @@ public:
         static_assert(std::is_convertible<T, Ref*>::value, "Invalid Type for cocos2d::Vector<T>!");
         CCLOGINFO("In the default constructor with capacity of Vector.");
         reserve(capacity);
+    }
+    
+    /** Constructor with a initializer_list */
+    Vector<T>(std::initializer_list<T> list)
+      : _data(list)
+    {
+        static_assert(std::is_convertible<T, Ref*>::value, "Invalid Type for cocos2d::Vector<T>!");
+        addRefForAllObjects();
     }
 
     /** Destructor */


### PR DESCRIPTION
cocos2d::Vector is now able to create with initializer_list like this:

``` cpp
  auto *cache = cocos2d::SpriteFrameCache::getInstance();

  cocos2d::Vector<cocos2d::SpriteFrame*> frame{
      cache->getSpriteFrameByName("foo"),
      cache->getSpriteFrameByName("bar"),
      cache->getSpriteFrameByName("buz"),
      // ...
  };

  mySprite->setSpriteFrame(frame.at(0));
```
