### PR TITLE
refactor Button restrict capInsetSize logic and cleanup ui coding style

### DIFF
--- a/cocos/ui/UIButton.cpp
+++ b/cocos/ui/UIButton.cpp
@@ -24,6 +24,7 @@ THE SOFTWARE.
 
 #include "ui/UIButton.h"
 #include "ui/UIScale9Sprite.h"
+#include "ui/UIHelper.h"
 #include "2d/CCLabel.h"
 #include "2d/CCSprite.h"
 #include "2d/CCActionInterval.h"
@@ -101,7 +102,8 @@ Button* Button::create(const std::string &normalImage,
                        TextureResType texType)
 {
     Button *btn = new (std::nothrow) Button;
-    if (btn && btn->init(normalImage,selectedImage,disableImage,texType)) {
+    if (btn && btn->init(normalImage,selectedImage,disableImage,texType))
+    {
         btn->autorelease();
         return btn;
     }
@@ -115,8 +117,10 @@ bool Button::init(const std::string &normalImage,
                   TextureResType texType)
 {
     bool ret = true;
-    do {
-        if (!Widget::init()) {
+    do
+    {
+        if (!Widget::init())
+        {
             ret = false;
             break;
         }
@@ -197,6 +201,7 @@ void Button::ignoreContentAdaptWithSize(bool ignore)
         this->updateContentSize();
         return;
     }
+    
     if (!_scale9Enabled || (_scale9Enabled && !ignore))
     {
         Widget::ignoreContentAdaptWithSize(ignore);
@@ -319,97 +324,54 @@ void Button::setCapInsets(const Rect &capInsets)
     setCapInsetsDisabledRenderer(capInsets);
 }
 
+
+
 void Button::setCapInsetsNormalRenderer(const Rect &capInsets)
 {
-    float x = capInsets.origin.x;
-    float y = capInsets.origin.y;
-    float width = capInsets.size.width;
-    float height = capInsets.size.height;
+    _capInsetsNormal = Helper::restrictCapInsetRect(capInsets, this->_normalTextureSize);
     
-    if (_normalTextureSize.width < width)
-    {
-        x = 0.0f;
-        width = 0.0f;
-    }
-    if (_normalTextureSize.height < height)
-    {
-        y = 0.0f;
-        height = 0.0f;
-    }
-    Rect rect(x, y, width, height);
-    
-    _capInsetsNormal = rect;
+    //for performance issue
     if (!_scale9Enabled)
     {
         return;
     }
-    _buttonNormalRenderer->setCapInsets(rect);
+    _buttonNormalRenderer->setCapInsets(_capInsetsNormal);
+}
+
+void Button::setCapInsetsPressedRenderer(const Rect &capInsets)
+{
+    _capInsetsPressed = Helper::restrictCapInsetRect(capInsets, this->_pressedTextureSize);
+    
+    //for performance issue
+    if (!_scale9Enabled)
+    {
+        return;
+    }
+    _buttonClickedRenderer->setCapInsets(_capInsetsPressed);
+}
+
+void Button::setCapInsetsDisabledRenderer(const Rect &capInsets)
+{
+    _capInsetsDisabled = Helper::restrictCapInsetRect(capInsets, this->_disabledTextureSize);
+    
+    //for performance issue
+    if (!_scale9Enabled)
+    {
+        return;
+    }
+    _buttonDisableRenderer->setCapInsets(_capInsetsDisabled);
 }
 
 const Rect& Button::getCapInsetsNormalRenderer()const
 {
     return _capInsetsNormal;
 }
-
-void Button::setCapInsetsPressedRenderer(const Rect &capInsets)
-{
-    float x = capInsets.origin.x;
-    float y = capInsets.origin.y;
-    float width = capInsets.size.width;
-    float height = capInsets.size.height;
     
-    if (_pressedTextureSize.width < width)
-    {
-        x = 0.0f;
-        width = 0.0f;
-    }
-    if (_pressedTextureSize.height < height)
-    {
-        y = 0.0f;
-        height = 0.0f;
-    }
-    Rect rect(x, y, width, height);
-    
-    _capInsetsPressed = rect;
-    if (!_scale9Enabled)
-    {
-        return;
-    }
-    _buttonClickedRenderer->setCapInsets(rect);
-}
-
 const Rect& Button::getCapInsetsPressedRenderer()const
 {
     return _capInsetsPressed;
 }
-
-void Button::setCapInsetsDisabledRenderer(const Rect &capInsets)
-{
-    float x = capInsets.origin.x;
-    float y = capInsets.origin.y;
-    float width = capInsets.size.width;
-    float height = capInsets.size.height;
     
-    if (_disabledTextureSize.width < width)
-    {
-        x = 0.0f;
-        width = 0.0f;
-    }
-    if (_disabledTextureSize.height < height)
-    {
-        y = 0.0f;
-        height = 0.0f;
-    }
-    Rect rect(x, y, width, height);
-    
-    _capInsetsDisabled = rect;
-    if (!_scale9Enabled)
-    {
-        return;
-    }
-    _buttonDisableRenderer->setCapInsets(rect);
-}
-
 const Rect& Button::getCapInsetsDisabledRenderer()const
 {
     return _capInsetsDisabled;
@@ -557,7 +519,9 @@ void Button::updateContentSize()
         onSizeChanged();
         return;
     }
-    if (_ignoreSize) {
+    
+    if (_ignoreSize)
+    {
         this->setContentSize(getVirtualRendererSize());
     }
 }
@@ -578,11 +542,13 @@ void Button::adaptRenderers()
         normalTextureScaleChangedWithSize();
         _normalTextureAdaptDirty = false;
     }
+    
     if (_pressedTextureAdaptDirty)
     {
         pressedTextureScaleChangedWithSize();
         _pressedTextureAdaptDirty = false;
     }
+    
     if (_disabledTextureAdaptDirty)
     {
         disabledTextureScaleChangedWithSize();
@@ -596,8 +562,10 @@ Size Button::getVirtualRendererSize() const
     {
         return this->getNormalSize();
     }
+    
     Size titleSize = _titleRenderer->getContentSize();
-    if (!_normalTextureLoaded && _titleRenderer->getString().size() > 0) {
+    if (!_normalTextureLoaded && _titleRenderer->getString().size() > 0)
+    {
         return titleSize;
     }
     return _normalTextureSize;
@@ -766,10 +734,12 @@ const Color3B& Button::getTitleColor() const
 
 void Button::setTitleFontSize(float size)
 {
-    if (_type == FontType::SYSTEM) {
+    if (_type == FontType::SYSTEM)
+    {
         _titleRenderer->setSystemFontSize(size);
     }
-    else{
+    else
+    {
         TTFConfig config = _titleRenderer->getTTFConfig();
         config.fontSize = size;
         _titleRenderer->setTTFConfig(config);
@@ -802,7 +772,9 @@ void Button::setTitleFontName(const std::string& fontName)
         config.fontSize = _fontSize;
         _titleRenderer->setTTFConfig(config);
         _type = FontType::TTF;
-    } else{
+    }
+    else
+    {
         _titleRenderer->setSystemFontName(fontName);
         if (_type == FontType::TTF)
         {
@@ -864,6 +836,7 @@ Size Button::getNormalSize() const
     {
         titleSize = _titleRenderer->getContentSize();
     }
+    
     Size imageSize;
     if (_buttonNormalRenderer != nullptr)
     {

--- a/cocos/ui/UICheckBox.cpp
+++ b/cocos/ui/UICheckBox.cpp
@@ -112,8 +112,10 @@ bool CheckBox::init(const std::string& backGround,
                     TextureResType texType)
 {
     bool ret = true;
-    do {
-        if (!Widget::init()) {
+    do
+    {
+        if (!Widget::init())
+        {
             ret = false;
             break;
         }
@@ -191,10 +193,12 @@ void CheckBox::loadTextureBackGround(const std::string& backGround,TextureResTyp
 
 void CheckBox::loadTextureBackGroundSelected(const std::string& backGroundSelected,TextureResType texType)
 {
-    if (backGroundSelected.empty() || (_backGroundSelectedFileName == backGroundSelected && _backGroundSelectedTexType == texType))
+    if (backGroundSelected.empty() ||
+        (_backGroundSelectedFileName == backGroundSelected && _backGroundSelectedTexType == texType))
     {
         return;
     }
+    
     _backGroundSelectedFileName = backGroundSelected;
     _backGroundSelectedTexType = texType;
     switch (_backGroundSelectedTexType)
@@ -241,7 +245,8 @@ void CheckBox::loadTextureFrontCross(const std::string& cross,TextureResType tex
 
 void CheckBox::loadTextureBackGroundDisabled(const std::string& backGroundDisabled,TextureResType texType)
 {
-    if (backGroundDisabled.empty() || (_backGroundDisabledFileName == backGroundDisabled && _backGroundDisabledTexType == texType))
+    if (backGroundDisabled.empty() ||
+        (_backGroundDisabledFileName == backGroundDisabled && _backGroundDisabledTexType == texType))
     {
         return;
     }
@@ -266,7 +271,8 @@ void CheckBox::loadTextureBackGroundDisabled(const std::string& backGroundDisabl
 
 void CheckBox::loadTextureFrontCrossDisabled(const std::string& frontCrossDisabled,TextureResType texType)
 {
-    if (frontCrossDisabled.empty() || (_frontCrossDisabledFileName == frontCrossDisabled && _frontCrossDisabledTexType == texType))
+    if (frontCrossDisabled.empty() ||
+        (_frontCrossDisabledFileName == frontCrossDisabled && _frontCrossDisabledTexType == texType))
     {
         return;
     }
@@ -294,7 +300,8 @@ void CheckBox::releaseUpEvent()
 {
     Widget::releaseUpEvent();
     
-    if (_isSelected){
+    if (_isSelected)
+    {
         setSelected(false);
         unSelectedEvent();
     }
@@ -312,6 +319,7 @@ void CheckBox::onPressStateChangedToNormal()
     _backGroundSelectedBoxRenderer->setVisible(false);
     _backGroundBoxDisabledRenderer->setVisible(false);
     _frontCrossDisabledRenderer->setVisible(false);
+    
     if (_isSelected)
     {
         _frontCrossRenderer->setVisible(true);
@@ -375,7 +383,8 @@ void CheckBox::selectedEvent()
 void CheckBox::unSelectedEvent()
 {
     this->retain();
-    if (_checkBoxEventCallback) {
+    if (_checkBoxEventCallback)
+    {
         _checkBoxEventCallback(this, EventType::UNSELECTED);
     }
     if (_ccEventCallback)

--- a/cocos/ui/UIHelper.cpp
+++ b/cocos/ui/UIHelper.cpp
@@ -183,6 +183,26 @@ void Helper::doLayout(cocos2d::Node *rootNode)
         }
     }
 }
+    
+Rect Helper::restrictCapInsetRect(const cocos2d::Rect &capInsets, const Size& textureSize )
+{
+    float x = capInsets.origin.x;
+    float y = capInsets.origin.y;
+    float width = capInsets.size.width;
+    float height = capInsets.size.height;
+    
+    if (textureSize.width < width)
+    {
+        x = 0.0f;
+        width = 0.0f;
+    }
+    if (textureSize.height < height)
+    {
+        y = 0.0f;
+        height = 0.0f;
+    }
+    return Rect(x, y, width, height);
+}
 }
 
 NS_CC_END

--- a/cocos/ui/UIHelper.h
+++ b/cocos/ui/UIHelper.h
@@ -82,6 +82,10 @@ public:
     static void doLayout(Node *rootNode);
 
     static void changeLayoutSystemActiveState(bool bActive);
+    
+private:
+    static Rect restrictCapInsetRect(const Rect& capInsets, const Size& textureSize);
+    friend class Button;
 };
 }
 

--- a/cocos/ui/UIImageView.cpp
+++ b/cocos/ui/UIImageView.cpp
@@ -55,7 +55,8 @@ ImageView::~ImageView()
 ImageView* ImageView::create(const std::string &imageFileName, TextureResType texType)
 {
     ImageView *widget = new (std::nothrow) ImageView;
-    if (widget && widget->init(imageFileName, texType)) {
+    if (widget && widget->init(imageFileName, texType))
+    {
         widget->autorelease();
         return widget;
     }
@@ -78,8 +79,10 @@ ImageView* ImageView::create()
 bool ImageView::init()
 {
     bool ret = true;
-    do {
-        if (!Widget::init()) {
+    do
+    {
+        if (!Widget::init())
+        {
             ret = false;
             break;
         }
@@ -91,8 +94,10 @@ bool ImageView::init()
 bool ImageView::init(const std::string &imageFileName, TextureResType texType)
 {
     bool bRet = true;
-    do {
-        if (!Widget::init()) {
+    do
+    {
+        if (!Widget::init())
+        {
             bRet = false;
             break;
         }

--- a/cocos/ui/UILayout.cpp
+++ b/cocos/ui/UILayout.cpp
@@ -359,7 +359,8 @@ void Layout::drawFullScreenQuadClearStencil()
     director->pushMatrix(MATRIX_STACK_TYPE::MATRIX_STACK_PROJECTION);
     director->loadIdentityMatrix(MATRIX_STACK_TYPE::MATRIX_STACK_PROJECTION);
     
-    Vec2 vertices[] = {
+    Vec2 vertices[] =
+    {
         Vec2(-1, -1),
         Vec2(1, -1),
         Vec2(1, 1),
@@ -1128,25 +1129,30 @@ float Layout::calculateNearestDistance(Widget* baseWidget)
     
     Vec2 widgetPosition =  this->getWorldCenterPoint(baseWidget);
     
-    for (Node* node : _children) {
+    for (Node* node : _children)
+    {
         Layout *layout = dynamic_cast<Layout*>(node);
         int length;
-        if (layout) {
+        if (layout)
+        {
             length = layout->calculateNearestDistance(baseWidget);
         }
         else
         {
             Widget* w = dynamic_cast<Widget*>(node);
-            if (w && w->isFocusEnabled()) {
+            if (w && w->isFocusEnabled())
+            {
                 Vec2 wPosition = this->getWorldCenterPoint(w);
                 length = (wPosition - widgetPosition).length();
             }
-            else {
+            else
+            {
                 continue;
             }
         }
         
-        if (length < distance) {
+        if (length < distance)
+        {
             distance = length;
         }
         
@@ -1161,10 +1167,12 @@ float Layout::calculateFarthestDistance(cocos2d::ui::Widget *baseWidget)
     
     Vec2 widgetPosition =  this->getWorldCenterPoint(baseWidget);
     
-    for (Node* node : _children) {
+    for (Node* node : _children)
+    {
         Layout *layout = dynamic_cast<Layout*>(node);
         int length;
-        if (layout) {
+        if (layout)
+        {
             length = layout->calculateFarthestDistance(baseWidget);
         }
         else
@@ -1174,12 +1182,14 @@ float Layout::calculateFarthestDistance(cocos2d::ui::Widget *baseWidget)
                 Vec2 wPosition = this->getWorldCenterPoint(w);
                 length = (wPosition - widgetPosition).length();
             }
-            else {
+            else
+            {
                 continue;
             }
         }
         
-        if (length > distance) {
+        if (length > distance)
+        {
             distance = length;
         }
     }
@@ -1190,9 +1200,11 @@ int Layout::findFirstFocusEnabledWidgetIndex()
 {
     ssize_t index = 0;
     ssize_t count = this->getChildren().size();
-    while (index < count) {
+    while (index < count)
+    {
         Widget* w =  dynamic_cast<Widget*>(_children.at(index));
-        if (w && w->isFocusEnabled()) {
+        if (w && w->isFocusEnabled())
+        {
             return (int)index;
         }
         index++;
@@ -1321,15 +1333,19 @@ Widget *Layout::findFirstNonLayoutWidget()
     for(Node *node : _children)
     {
         Layout* layout = dynamic_cast<Layout*>(node);
-        if (layout) {
+        if (layout)
+        {
             widget = layout->findFirstNonLayoutWidget();
-            if (widget != nullptr) {
+            if (widget != nullptr)
+            {
                 return widget;
             }
         }
-        else{
+        else
+        {
             Widget *w = dynamic_cast<Widget*>(node);
-            if (w) {
+            if (w)
+            {
                 widget = w;
                 break;
             }
@@ -1342,7 +1358,8 @@ Widget *Layout::findFirstNonLayoutWidget()
     
 void Layout::findProperSearchingFunctor(FocusDirection dir, Widget* baseWidget)
 {
-    if (baseWidget == nullptr) {
+    if (baseWidget == nullptr)
+    {
         return;
     }
     
@@ -1350,33 +1367,52 @@ void Layout::findProperSearchingFunctor(FocusDirection dir, Widget* baseWidget)
     
     Vec2 widgetPosition = this->getWorldCenterPoint(this->findFirstNonLayoutWidget());
     
-    if (dir == FocusDirection::LEFT) {
-        if (previousWidgetPosition.x > widgetPosition.x) {
+    if (dir == FocusDirection::LEFT)
+    {
+        if (previousWidgetPosition.x > widgetPosition.x)
+        {
             onPassFocusToChild = CC_CALLBACK_2(Layout::findNearestChildWidgetIndex, this);
         }
-        else{
+        else
+        {
             onPassFocusToChild = CC_CALLBACK_2(Layout::findFarthestChildWidgetIndex, this);
         }
-    }else if(dir == FocusDirection::RIGHT){
-        if (previousWidgetPosition.x > widgetPosition.x) {
+    }
+    else if(dir == FocusDirection::RIGHT)
+    {
+        if (previousWidgetPosition.x > widgetPosition.x)
+        {
             onPassFocusToChild = CC_CALLBACK_2(Layout::findFarthestChildWidgetIndex, this);
         }
-        else{
+        else
+        {
             onPassFocusToChild = CC_CALLBACK_2(Layout::findNearestChildWidgetIndex, this);
         }
-    }else if(dir == FocusDirection::DOWN){
-        if (previousWidgetPosition.y > widgetPosition.y) {
+    }
+    else if(dir == FocusDirection::DOWN)
+    {
+        if (previousWidgetPosition.y > widgetPosition.y)
+        {
             onPassFocusToChild = CC_CALLBACK_2(Layout::findNearestChildWidgetIndex, this);
-        }else{
+        }
+        else
+        {
             onPassFocusToChild = CC_CALLBACK_2(Layout::findFarthestChildWidgetIndex, this);
         }
-    }else if(dir == FocusDirection::UP){
-        if (previousWidgetPosition.y < widgetPosition.y) {
+    }
+    else if(dir == FocusDirection::UP)
+    {
+        if (previousWidgetPosition.y < widgetPosition.y)
+        {
             onPassFocusToChild = CC_CALLBACK_2(Layout::findNearestChildWidgetIndex, this);
-        }else{
+        }
+        else
+        {
             onPassFocusToChild = CC_CALLBACK_2(Layout::findFarthestChildWidgetIndex, this);
         }
-    }else{
+    }
+    else
+    {
         CCASSERT(0, "invalid direction!");
     }
 
@@ -1476,8 +1512,6 @@ Widget* Layout::getPreviousFocusedWidget(FocusDirection direction, Widget *curre
         nextWidget = this->getChildWidgetByIndex(previousWidgetPos);
         if (nextWidget->isFocusEnabled())
         {
-            
-            
             Layout* layout = dynamic_cast<Layout*>(nextWidget);
             if (layout)
             {
@@ -1492,7 +1526,8 @@ Widget* Layout::getPreviousFocusedWidget(FocusDirection direction, Widget *curre
             //handling the disabled widget, there is no actual focus lose or get, so we don't need any envet
             return this->getPreviousFocusedWidget(direction, nextWidget);
         }
-    }else
+    }
+    else
     {
         if (_loopFocus)
         {
@@ -1521,7 +1556,8 @@ Widget* Layout::getPreviousFocusedWidget(FocusDirection direction, Widget *curre
             }
             else
             {
-                if (dynamic_cast<Layout*>(current)) {
+                if (dynamic_cast<Layout*>(current))
+                {
                     return current;
                 }
                 else
@@ -1538,7 +1574,8 @@ Widget* Layout::getPreviousFocusedWidget(FocusDirection direction, Widget *curre
                 {
                     return Widget::findNextFocusedWidget(direction, this);
                 }
-                if (dynamic_cast<Layout*>(current)) {
+                if (dynamic_cast<Layout*>(current))
+                {
                     return current;
                 }
                 else
@@ -1567,7 +1604,6 @@ Widget* Layout::getNextFocusedWidget(FocusDirection direction, Widget *current)
         {
             if (nextWidget->isFocusEnabled())
             {
-                
                 Layout* layout = dynamic_cast<Layout*>(nextWidget);
                 if (layout)
                 {
@@ -1589,7 +1625,8 @@ Widget* Layout::getNextFocusedWidget(FocusDirection direction, Widget *current)
         {
             return current;
         }
-    }else
+    }
+    else
     {
         if (_loopFocus)
         {
@@ -1599,7 +1636,6 @@ Widget* Layout::getNextFocusedWidget(FocusDirection direction, Widget *current)
                 nextWidget = this->getChildWidgetByIndex(previousWidgetPos);
                 if (nextWidget->isFocusEnabled())
                 {
-                    
                     Layout* layout = dynamic_cast<Layout*>(nextWidget);
                     if (layout)
                     {
@@ -1628,7 +1664,8 @@ Widget* Layout::getNextFocusedWidget(FocusDirection direction, Widget *current)
                 }
             }
         }
-        else{
+        else
+        {
             if (isLastWidgetInContainer(current, direction))
             {
                 if (isWidgetAncestorSupportLoopFocus(this, direction))
@@ -1663,7 +1700,8 @@ bool  Layout::isLastWidgetInContainer(Widget* widget, FocusDirection direction)c
     ssize_t index = container.getIndex(widget);
     if (parent->getLayoutType() == Type::HORIZONTAL)
     {
-        if (direction == FocusDirection::LEFT) {
+        if (direction == FocusDirection::LEFT)
+        {
             if (index == 0)
             {
                 return isLastWidgetInContainer(parent, direction);
@@ -1673,7 +1711,8 @@ bool  Layout::isLastWidgetInContainer(Widget* widget, FocusDirection direction)c
                 return false;
             }
         }
-        if (direction == FocusDirection::RIGHT) {
+        if (direction == FocusDirection::RIGHT)
+        {
             if (index == container.size()-1)
             {
                 return isLastWidgetInContainer(parent, direction);
@@ -1791,8 +1830,10 @@ Widget* Layout::findNextFocusedWidget(FocusDirection direction, Widget* current)
         if (_passFocusToChild)
         {
             Widget * w = this->passFocusToChild(direction, current);
-            if (dynamic_cast<Layout*>(w)) {
-                if (parent) {
+            if (dynamic_cast<Layout*>(w))
+            {
+                if (parent)
+                {
                     parent->_isFocusPassing = true;
                     return parent->findNextFocusedWidget(direction, this);
                 }
@@ -1800,7 +1841,8 @@ Widget* Layout::findNextFocusedWidget(FocusDirection direction, Widget* current)
             return w;
         }
         
-        if (nullptr == parent) {
+        if (nullptr == parent)
+        {
             return this;
         }
         parent->_isFocusPassing = true;
@@ -1832,7 +1874,8 @@ Widget* Layout::findNextFocusedWidget(FocusDirection direction, Widget* current)
                         }
                         return current;
                     }
-                    else{
+                    else
+                    {
                         return Widget::findNextFocusedWidget(direction, this);
                     }
                 }break;

--- a/cocos/ui/UIListView.cpp
+++ b/cocos/ui/UIListView.cpp
@@ -126,14 +126,16 @@ void ListView::remedyLayoutParameter(Widget *item)
     {
         return;
     }
-    switch (_direction) {
+    switch (_direction)
+    {
         case Direction::VERTICAL:
         {
             LinearLayoutParameter* llp = (LinearLayoutParameter*)(item->getLayoutParameter());
             if (!llp)
             {
                 LinearLayoutParameter* defaultLp = LinearLayoutParameter::create();
-                switch (_gravity) {
+                switch (_gravity)
+                {
                     case Gravity::LEFT:
                         defaultLp->setGravity(LinearLayoutParameter::LinearGravity::LEFT);
                         break;
@@ -166,7 +168,8 @@ void ListView::remedyLayoutParameter(Widget *item)
                 {
                     llp->setMargin(Margin(0.0f, _itemsMargin, 0.0f, 0.0f));
                 }
-                switch (_gravity) {
+                switch (_gravity)
+                {
                     case Gravity::LEFT:
                         llp->setGravity(LinearLayoutParameter::LinearGravity::LEFT);
                         break;
@@ -188,7 +191,8 @@ void ListView::remedyLayoutParameter(Widget *item)
             if (!llp)
             {
                 LinearLayoutParameter* defaultLp = LinearLayoutParameter::create();
-                switch (_gravity) {
+                switch (_gravity)
+                {
                     case Gravity::TOP:
                         defaultLp->setGravity(LinearLayoutParameter::LinearGravity::TOP);
                         break;
@@ -221,7 +225,8 @@ void ListView::remedyLayoutParameter(Widget *item)
                 {
                     llp->setMargin(Margin(_itemsMargin, 0.0f, 0.0f, 0.0f));
                 }
-                switch (_gravity) {
+                switch (_gravity)
+                {
                     case Gravity::TOP:
                         llp->setGravity(LinearLayoutParameter::LinearGravity::TOP);
                         break;
@@ -314,7 +319,8 @@ void ListView::addChild(Node* child, int zOrder, const std::string &name)
 void ListView::removeChild(cocos2d::Node *child, bool cleaup)
 {
     Widget* widget = dynamic_cast<Widget*>(child);
-    if (widget) {
+    if (widget)
+    {
         _items.eraseObject(widget);
     }
    

--- a/cocos/ui/UILoadingBar.cpp
+++ b/cocos/ui/UILoadingBar.cpp
@@ -69,7 +69,8 @@ LoadingBar* LoadingBar::create()
 LoadingBar* LoadingBar::create(const std::string &textureName, float percentage)
 {
     LoadingBar* widget = new (std::nothrow) LoadingBar;
-    if (widget && widget->init()) {
+    if (widget && widget->init())
+    {
         widget->autorelease();
         widget->loadTexture(textureName);
         widget->setPercent(percentage);

--- a/cocos/ui/UIPageView.cpp
+++ b/cocos/ui/UIPageView.cpp
@@ -570,7 +570,8 @@ void PageView::pageTurningEvent()
     {
         (_pageViewEventListener->*_pageViewEventSelector)(this, PAGEVIEW_EVENT_TURNING);
     }
-    if (_eventCallback) {
+    if (_eventCallback)
+    {
         _eventCallback(this,EventType::TURNING);
     }
     if (_ccEventCallback)

--- a/cocos/ui/UIScrollView.cpp
+++ b/cocos/ui/UIScrollView.cpp
@@ -703,7 +703,7 @@ bool ScrollView::checkCustomScrollDestination(float* touchOffsetX, float* touchO
     bool scrollenabled = true;
     switch (_direction)
     {
-        case Direction::VERTICAL: // vertical
+        case Direction::VERTICAL:
         {
             if (_autoScrollDir.y > 0)
             {
@@ -725,7 +725,7 @@ bool ScrollView::checkCustomScrollDestination(float* touchOffsetX, float* touchO
             }
             break;
         }
-        case Direction::HORIZONTAL: // horizontal
+        case Direction::HORIZONTAL:
         {
             if (_autoScrollDir.x > 0)
             {
@@ -1612,7 +1612,8 @@ void ScrollView::scrollToTopEvent()
     {
         (_scrollViewEventListener->*_scrollViewEventSelector)(this, SCROLLVIEW_EVENT_SCROLL_TO_TOP);
     }
-    if (_eventCallback) {
+    if (_eventCallback)
+    {
         _eventCallback(this,EventType::SCROLL_TO_TOP);
     }
     if (_ccEventCallback)
@@ -1629,7 +1630,8 @@ void ScrollView::scrollToBottomEvent()
     {
         (_scrollViewEventListener->*_scrollViewEventSelector)(this, SCROLLVIEW_EVENT_SCROLL_TO_BOTTOM);
     }
-    if (_eventCallback) {
+    if (_eventCallback)
+    {
         _eventCallback(this,EventType::SCROLL_TO_BOTTOM);
     }
     if (_ccEventCallback)
@@ -1646,7 +1648,8 @@ void ScrollView::scrollToLeftEvent()
     {
         (_scrollViewEventListener->*_scrollViewEventSelector)(this, SCROLLVIEW_EVENT_SCROLL_TO_LEFT);
     }
-    if (_eventCallback) {
+    if (_eventCallback)
+    {
         _eventCallback(this,EventType::SCROLL_TO_LEFT);
     }
     if (_ccEventCallback)
@@ -1663,7 +1666,8 @@ void ScrollView::scrollToRightEvent()
     {
         (_scrollViewEventListener->*_scrollViewEventSelector)(this, SCROLLVIEW_EVENT_SCROLL_TO_RIGHT);
     }
-    if (_eventCallback) {
+    if (_eventCallback)
+    {
         _eventCallback(this,EventType::SCROLL_TO_RIGHT);
     }
     if (_ccEventCallback)
@@ -1680,7 +1684,8 @@ void ScrollView::scrollingEvent()
     {
         (_scrollViewEventListener->*_scrollViewEventSelector)(this, SCROLLVIEW_EVENT_SCROLLING);
     }
-    if (_eventCallback) {
+    if (_eventCallback)
+    {
         _eventCallback(this,EventType::SCROLLING);
     }
     if (_ccEventCallback)
@@ -1697,7 +1702,8 @@ void ScrollView::bounceTopEvent()
     {
         (_scrollViewEventListener->*_scrollViewEventSelector)(this, SCROLLVIEW_EVENT_BOUNCE_TOP);
     }
-    if (_eventCallback) {
+    if (_eventCallback)
+    {
         _eventCallback(this,EventType::BOUNCE_TOP);
     }
     if (_ccEventCallback)
@@ -1714,7 +1720,8 @@ void ScrollView::bounceBottomEvent()
     {
         (_scrollViewEventListener->*_scrollViewEventSelector)(this, SCROLLVIEW_EVENT_BOUNCE_BOTTOM);
     }
-    if (_eventCallback) {
+    if (_eventCallback)
+    {
         _eventCallback(this,EventType::BOUNCE_BOTTOM);
     }
     if (_ccEventCallback)
@@ -1731,7 +1738,8 @@ void ScrollView::bounceLeftEvent()
     {
         (_scrollViewEventListener->*_scrollViewEventSelector)(this, SCROLLVIEW_EVENT_BOUNCE_LEFT);
     }
-    if (_eventCallback) {
+    if (_eventCallback)
+    {
         _eventCallback(this,EventType::BOUNCE_LEFT);
     }
     if (_ccEventCallback)
@@ -1748,7 +1756,8 @@ void ScrollView::bounceRightEvent()
     {
         (_scrollViewEventListener->*_scrollViewEventSelector)(this, SCROLLVIEW_EVENT_BOUNCE_RIGHT);
     }
-    if (_eventCallback) {
+    if (_eventCallback)
+    {
         _eventCallback(this,EventType::BOUNCE_RIGHT);
     }
     if (_ccEventCallback)
@@ -1858,7 +1867,8 @@ void ScrollView::copySpecialProperties(Widget *widget)
 Widget* ScrollView::findNextFocusedWidget(cocos2d::ui::Widget::FocusDirection direction, cocos2d::ui::Widget *current)
 {
     if (this->getLayoutType() == Layout::Type::VERTICAL
-        || this->getLayoutType() == Layout::Type::HORIZONTAL) {
+        || this->getLayoutType() == Layout::Type::HORIZONTAL)
+    {
         return _innerContainer->findNextFocusedWidget(direction, current);
     }
     else

--- a/cocos/ui/UISlider.cpp
+++ b/cocos/ui/UISlider.cpp
@@ -250,7 +250,10 @@ const Rect& Slider::getCapInsetsProgressBarRebderer()const
     return _capInsetsProgressBarRenderer;
 }
 
-    void Slider::loadSlidBallTextures(const std::string& normal,const std::string& pressed,const std::string& disabled,TextureResType texType)
+void Slider::loadSlidBallTextures(const std::string& normal,
+                                      const std::string& pressed,
+                                      const std::string& disabled,
+                                      TextureResType texType)
 {
     loadSlidBallTextureNormal(normal, texType);
     loadSlidBallTexturePressed(pressed,texType);
@@ -358,7 +361,8 @@ bool Slider::hitTest(const cocos2d::Vec2 &pt)
     Vec2 nsp = this->_slidBallNormalRenderer->convertToNodeSpace(pt);
     Size ballSize = this->_slidBallNormalRenderer->getContentSize();
     Rect ballRect = Rect(0,0, ballSize.width, ballSize.height);
-    if (ballRect.containsPoint(nsp)) {
+    if (ballRect.containsPoint(nsp))
+    {
         return true;
     }
     return false;
@@ -417,7 +421,8 @@ void Slider::percentChangedEvent()
     {
         (_sliderEventListener->*_sliderEventSelector)(this,SLIDER_PERCENTCHANGED);
     }
-    if (_eventCallback) {
+    if (_eventCallback)
+    {
         _eventCallback(this, EventType::ON_PERCENTAGE_CHANGED);
     }
     if (_ccEventCallback)

--- a/cocos/ui/UIText.cpp
+++ b/cocos/ui/UIText.cpp
@@ -324,22 +324,24 @@ std::string Text::getDescription() const
     return "Label";
 }
     
-
-    
-void Text::enableShadow(const Color4B& shadowColor,const Size &offset, int blurRadius) {
+void Text::enableShadow(const Color4B& shadowColor,const Size &offset, int blurRadius)
+{
     _labelRenderer->enableShadow(shadowColor, offset, blurRadius);
 }
 
-void Text::enableOutline(const Color4B& outlineColor,int outlineSize) {
+void Text::enableOutline(const Color4B& outlineColor,int outlineSize)
+{
     _labelRenderer->enableOutline(outlineColor, outlineSize);
 }
     
-void Text::enableGlow(const Color4B& glowColor) {
+void Text::enableGlow(const Color4B& glowColor)
+{
     if (_type == Type::TTF)
         _labelRenderer->enableGlow(glowColor);
 }
 
-void Text::disableEffect() {
+void Text::disableEffect()
+{
     _labelRenderer->disableEffect();
 }
 

--- a/cocos/ui/UITextField.cpp
+++ b/cocos/ui/UITextField.cpp
@@ -386,7 +386,8 @@ bool TextField::hitTest(const Vec2 &pt)
     {
         Vec2 nsp = convertToNodeSpace(pt);
         Rect bb = Rect(-_touchWidth * _anchorPoint.x, -_touchHeight * _anchorPoint.y, _touchWidth, _touchHeight);
-        if (nsp.x >= bb.origin.x && nsp.x <= bb.origin.x + bb.size.width && nsp.y >= bb.origin.y && nsp.y <= bb.origin.y + bb.size.height)
+        if (nsp.x >= bb.origin.x && nsp.x <= bb.origin.x + bb.size.width
+            && nsp.y >= bb.origin.y && nsp.y <= bb.origin.y + bb.size.height)
         {
             return true;
         }
@@ -468,9 +469,12 @@ void TextField::setTextColor(const cocos2d::Color4B &textColor)
 
 void TextField::setFontSize(int size)
 {
-    if (_fontType == FontType::SYSTEM) {
+    if (_fontType == FontType::SYSTEM)
+    {
         _textFieldRenderer->setSystemFontSize(size);
-    } else {
+    }
+    else
+    {
         TTFConfig config = _textFieldRenderer->getTTFConfig();
         config.fontSize = size;
         _textFieldRenderer->setTTFConfig(config);
@@ -494,7 +498,9 @@ void TextField::setFontName(const std::string& name)
         config.fontSize = _fontSize;
         _textFieldRenderer->setTTFConfig(config);
         _fontType = FontType::TTF;
-    } else {
+    }
+    else
+    {
         _textFieldRenderer->setSystemFontName(name);
         if (_fontType == FontType::TTF)
         {
@@ -533,7 +539,9 @@ bool TextField::onTouchBegan(Touch *touch, Event *unusedEvent)
     if (_hitted)
     {
         _textFieldRenderer->attachWithIME();
-    } else {
+    }
+    else
+    {
         this->didNotSelectSelf();
     }
     return pass;
@@ -678,7 +686,8 @@ void TextField::detachWithIMEEvent()
     {
         (_textFieldEventListener->*_textFieldEventSelector)(this, TEXTFIELD_EVENT_DETACH_WITH_IME);
     }
-    if (_eventCallback) {
+    if (_eventCallback)
+    {
         _eventCallback(this, EventType::DETACH_WITH_IME);
     }
     if (_ccEventCallback)
@@ -695,7 +704,8 @@ void TextField::insertTextEvent()
     {
         (_textFieldEventListener->*_textFieldEventSelector)(this, TEXTFIELD_EVENT_INSERT_TEXT);
     }
-    if (_eventCallback) {
+    if (_eventCallback)
+    {
         _eventCallback(this, EventType::INSERT_TEXT);
     }
     if (_ccEventCallback)
@@ -712,7 +722,8 @@ void TextField::deleteBackwardEvent()
     {
         (_textFieldEventListener->*_textFieldEventSelector)(this, TEXTFIELD_EVENT_DELETE_BACKWARD);
     }
-    if (_eventCallback) {
+    if (_eventCallback)
+    {
         _eventCallback(this, EventType::DELETE_BACKWARD);
     }
     if (_ccEventCallback)


### PR DESCRIPTION
This PR mainly focus on refactoring.
The method of restricting capInsetSize of scale9 renderer are duplicated, I have merged them in this PR.

And I also unified brackets style of all UI code.

And we should add the check in other Scale9Enabled widgets, I will do it in another PR after merging this PR.
