### PR TITLE
Added an option to create resizable windows on desktop.

### DIFF
--- a/cocos/platform/CCGLView.cpp
+++ b/cocos/platform/CCGLView.cpp
@@ -197,14 +197,10 @@ void GLView::setFrameSize(float width, float height)
     {
        director->_winSizeInPoints = _designResolutionSize;
 
-       //auto ds = isDisplayStats();
-       //director->setDefaultValues();
        director->setGLDefaultValues();
        director->setProjection(director->_projection);
-       //director->createStatsLabel();
-       //director->setDisplayStats(ds);
 
-       // It seems the scene content size doews not matter in most cases but just to be on the safe side.
+       // It seems that the scene content size does not matter in most cases but just to be on the safe side.
        auto scene = director->getRunningScene();
        if (scene)
           scene->setContentSize(_designResolutionSize);
@@ -476,7 +472,7 @@ float GLView::getScaleY() const
     return _scaleY;
 }
 
-void GLViewProtocol::addResizeCalback(const std::function<void(const Size&)>& callback)
+void GLView::addResizeCalback(const std::function<void(const Size&)>& callback)
 {
    _resizeCallbacks.push_back(callback);
 }

--- a/cocos/platform/CCGLView.cpp
+++ b/cocos/platform/CCGLView.cpp
@@ -29,6 +29,8 @@ THE SOFTWARE.
 #include "base/CCDirector.h"
 #include "base/CCEventDispatcher.h"
 
+#include "2d/CCScene.h"
+
 NS_CC_BEGIN
 
 namespace {
@@ -189,6 +191,24 @@ const Size& GLView::getFrameSize() const
 void GLView::setFrameSize(float width, float height)
 {
     _designResolutionSize = _screenSize = Size(width, height);
+
+    auto director = Director::getInstance();
+    if (director->getOpenGLView() != NULL)
+    {
+       director->_winSizeInPoints = _designResolutionSize;
+
+       //auto ds = isDisplayStats();
+       //director->setDefaultValues();
+       director->setGLDefaultValues();
+       director->setProjection(director->_projection);
+       //director->createStatsLabel();
+       //director->setDisplayStats(ds);
+
+       // It seems the scene content size doews not matter in most cases but just to be on the safe side.
+       auto scene = director->getRunningScene();
+       if (scene)
+          scene->setContentSize(_designResolutionSize);
+    }
 }
 
 Rect GLView::getVisibleRect() const

--- a/cocos/platform/CCGLView.cpp
+++ b/cocos/platform/CCGLView.cpp
@@ -208,6 +208,9 @@ void GLView::setFrameSize(float width, float height)
        auto scene = director->getRunningScene();
        if (scene)
           scene->setContentSize(_designResolutionSize);
+
+       for (auto &rcb : _resizeCallbacks)
+          rcb(_designResolutionSize);
     }
 }
 
@@ -471,6 +474,11 @@ float GLView::getScaleX() const
 float GLView::getScaleY() const
 {
     return _scaleY;
+}
+
+void GLViewProtocol::addResizeCalback(const std::function<void(const Size&)>& callback)
+{
+   _resizeCallbacks.push_back(callback);
 }
 
 NS_CC_END

--- a/cocos/platform/CCGLView.h
+++ b/cocos/platform/CCGLView.h
@@ -243,6 +243,11 @@ public:
     /** returns the current Resolution policy */
     ResolutionPolicy getResolutionPolicy() const { return _resolutionPolicy; }
 
+    /**
+     * Adds a callback function executed when the window size changes
+     */
+    void addResizeCalback(const std::function<void(const Size&)>& callback);
+
 #if (CC_TARGET_PLATFORM == CC_PLATFORM_WIN32)
     virtual HWND getWin32Window() = 0;
 #endif /* (CC_TARGET_PLATFORM == CC_PLATFORM_WIN32) */
@@ -268,6 +273,8 @@ protected:
     float _scaleX;
     float _scaleY;
     ResolutionPolicy _resolutionPolicy;
+
+    std::vector<std::function<void(const Size&)>> _resizeCallbacks;
 };
 
 // end of platform group

--- a/cocos/platform/android/CCGLViewImpl-android.cpp
+++ b/cocos/platform/android/CCGLViewImpl-android.cpp
@@ -51,7 +51,7 @@ void initExtensions() {
 
 NS_CC_BEGIN
 
-GLViewImpl* GLViewImpl::createWithRect(const std::string& viewName, Rect rect, float frameZoomFactor)
+GLViewImpl* GLViewImpl::createWithRect(const std::string& viewName, Rect rect, float frameZoomFactor, bool _ignored_resizable)
 {
     auto ret = new GLViewImpl;
     if(ret && ret->initWithRect(viewName, rect, frameZoomFactor)) {

--- a/cocos/platform/android/CCGLViewImpl-android.h
+++ b/cocos/platform/android/CCGLViewImpl-android.h
@@ -41,7 +41,7 @@ public:
 
     // static function
     static GLViewImpl* create(const std::string &viewname);
-    static GLViewImpl* createWithRect(const std::string& viewName, Rect rect, float frameZoomFactor = 1.0f
+    static GLViewImpl* createWithRect(const std::string& viewName, Rect rect, float frameZoomFactor = 1.0f,
                                       bool _ignored_resizable = false);
     static GLViewImpl* createWithFullScreen(const std::string& viewName);
 

--- a/cocos/platform/android/CCGLViewImpl-android.h
+++ b/cocos/platform/android/CCGLViewImpl-android.h
@@ -41,7 +41,8 @@ public:
 
     // static function
     static GLViewImpl* create(const std::string &viewname);
-    static GLViewImpl* createWithRect(const std::string& viewName, Rect rect, float frameZoomFactor = 1.0f);
+    static GLViewImpl* createWithRect(const std::string& viewName, Rect rect, float frameZoomFactor = 1.0f
+                                      bool _ignored_resizable = false);
     static GLViewImpl* createWithFullScreen(const std::string& viewName);
 
     bool isOpenGLReady() override;

--- a/cocos/platform/desktop/CCGLViewImpl-desktop.cpp
+++ b/cocos/platform/desktop/CCGLViewImpl-desktop.cpp
@@ -306,10 +306,10 @@ GLViewImpl* GLViewImpl::create(const std::string& viewName)
     return nullptr;
 }
 
-GLViewImpl* GLViewImpl::createWithRect(const std::string& viewName, Rect rect, float frameZoomFactor)
+GLViewImpl* GLViewImpl::createWithRect(const std::string& viewName, Rect rect, float frameZoomFactor, bool resizable)
 {
     auto ret = new (std::nothrow) GLViewImpl;
-    if(ret && ret->initWithRect(viewName, rect, frameZoomFactor)) {
+    if(ret && ret->initWithRect(viewName, rect, frameZoomFactor, resizable)) {
         ret->autorelease();
         return ret;
     }
@@ -339,13 +339,13 @@ GLViewImpl* GLViewImpl::createWithFullScreen(const std::string& viewName, const 
     return nullptr;
 }
 
-bool GLViewImpl::initWithRect(const std::string& viewName, Rect rect, float frameZoomFactor)
+bool GLViewImpl::initWithRect(const std::string& viewName, Rect rect, float frameZoomFactor, bool resizable)
 {
     setViewName(viewName);
 
     _frameZoomFactor = frameZoomFactor;
 
-    glfwWindowHint(GLFW_RESIZABLE,GL_FALSE);
+    glfwWindowHint(GLFW_RESIZABLE, resizable ? GL_TRUE : GL_FALSE);
     glfwWindowHint(GLFW_RED_BITS,_glContextAttrs.redBits);
     glfwWindowHint(GLFW_GREEN_BITS,_glContextAttrs.greenBits);
     glfwWindowHint(GLFW_BLUE_BITS,_glContextAttrs.blueBits);
@@ -715,6 +715,9 @@ void GLViewImpl::onGLFWframebuffersize(GLFWwindow* window, int w, int h)
         _retinaFactor = 1;
         glfwSetWindowSize(window, static_cast<int>(frameSizeW * _retinaFactor * _frameZoomFactor), static_cast<int>(frameSizeH * _retinaFactor * _frameZoomFactor));
     }
+
+    setFrameSize(w, h);
+    Director::getInstance()->drawScene();
 }
 
 void GLViewImpl::onGLFWWindowSizeFunCallback(GLFWwindow *window, int width, int height)

--- a/cocos/platform/desktop/CCGLViewImpl-desktop.h
+++ b/cocos/platform/desktop/CCGLViewImpl-desktop.h
@@ -57,7 +57,8 @@ class CC_DLL GLViewImpl : public GLView
 {
 public:
     static GLViewImpl* create(const std::string& viewName);
-    static GLViewImpl* createWithRect(const std::string& viewName, Rect size, float frameZoomFactor = 1.0f);
+    static GLViewImpl* createWithRect(const std::string& viewName, Rect size, float frameZoomFactor = 1.0f,
+                                      bool resizable = false);
     static GLViewImpl* createWithFullScreen(const std::string& viewName);
     static GLViewImpl* createWithFullScreen(const std::string& viewName, const GLFWvidmode &videoMode, GLFWmonitor *monitor);
 
@@ -112,7 +113,7 @@ protected:
     GLViewImpl();
     virtual ~GLViewImpl();
 
-    bool initWithRect(const std::string& viewName, Rect rect, float frameZoomFactor);
+    bool initWithRect(const std::string& viewName, Rect rect, float frameZoomFactor, bool resizable = false);
     bool initWithFullScreen(const std::string& viewName);
     bool initWithFullscreen(const std::string& viewname, const GLFWvidmode &videoMode, GLFWmonitor *monitor);
 

--- a/cocos/platform/ios/CCGLViewImpl-ios.h
+++ b/cocos/platform/ios/CCGLViewImpl-ios.h
@@ -48,7 +48,8 @@ public:
     static GLViewImpl* create(const std::string& viewName);
 
     /** creates a GLViewImpl with a title name, a rect and the zoom factor */
-    static GLViewImpl* createWithRect(const std::string& viewName, Rect rect, float frameZoomFactor = 1.0f);
+    static GLViewImpl* createWithRect(const std::string& viewName, Rect rect, float frameZoomFactor = 1.0f,
+                                      bool _ignored_resizable = false);
 
     /** creates a GLViewImpl with a name in fullscreen mode */
     static GLViewImpl* createWithFullScreen(const std::string& viewName);

--- a/cocos/platform/ios/CCGLViewImpl-ios.mm
+++ b/cocos/platform/ios/CCGLViewImpl-ios.mm
@@ -62,7 +62,7 @@ GLViewImpl* GLViewImpl::create(const std::string& viewName)
 }
 
 GLViewImpl* GLViewImpl::createWithRect(const std::string& viewName, Rect rect, float frameZoomFactor,
-                                       bool _ignored_resizable))
+                                       bool _ignored_resizable)
 {
     auto ret = new (std::nothrow) GLViewImpl;
     if(ret && ret->initWithRect(viewName, rect, frameZoomFactor)) {

--- a/cocos/platform/ios/CCGLViewImpl-ios.mm
+++ b/cocos/platform/ios/CCGLViewImpl-ios.mm
@@ -61,7 +61,8 @@ GLViewImpl* GLViewImpl::create(const std::string& viewName)
     return nullptr;
 }
 
-GLViewImpl* GLViewImpl::createWithRect(const std::string& viewName, Rect rect, float frameZoomFactor)
+GLViewImpl* GLViewImpl::createWithRect(const std::string& viewName, Rect rect, float frameZoomFactor,
+                                       bool _ignored_resizable))
 {
     auto ret = new (std::nothrow) GLViewImpl;
     if(ret && ret->initWithRect(viewName, rect, frameZoomFactor)) {

--- a/cocos/scripting/lua-bindings/auto/api/GLViewImpl.lua
+++ b/cocos/scripting/lua-bindings/auto/api/GLViewImpl.lua
@@ -11,6 +11,7 @@
 -- @param #string viewName
 -- @param #rect_table rect
 -- @param #float frameZoomFactor
+-- @param #bool resizable
 -- @return GLViewImpl#GLViewImpl ret (return value: cc.GLViewImpl)
         
 --------------------------------

--- a/cocos/scripting/lua-bindings/auto/lua_cocos2dx_auto.cpp
+++ b/cocos/scripting/lua-bindings/auto/lua_cocos2dx_auto.cpp
@@ -64656,6 +64656,25 @@ int lua_cocos2dx_GLViewImpl_createWithRect(lua_State* tolua_S)
         object_to_luaval<cocos2d::GLViewImpl>(tolua_S, "cc.GLViewImpl",(cocos2d::GLViewImpl*)ret);
         return 1;
     }
+    if (argc == 4)
+    {
+        std::string arg0;
+        cocos2d::Rect arg1;
+        double arg2;
+        bool arg3;
+        ok &= luaval_to_std_string(tolua_S, 2,&arg0, "cc.GLViewImpl:createWithRect");
+        ok &= luaval_to_rect(tolua_S, 3, &arg1, "cc.GLViewImpl:createWithRect");
+        ok &= luaval_to_number(tolua_S, 4,&arg2, "cc.GLViewImpl:createWithRect");
+        ok &= luaval_to_boolean(tolua_S, 5,&arg3, "cc.GLViewImpl:createWithRect");
+        if(!ok)
+        {
+            tolua_error(tolua_S,"invalid arguments in function 'lua_cocos2dx_GLViewImpl_createWithRect'", nullptr);
+            return 0;
+        }
+        cocos2d::GLViewImpl* ret = cocos2d::GLViewImpl::createWithRect(arg0, arg1, arg2, arg3);
+        object_to_luaval<cocos2d::GLViewImpl>(tolua_S, "cc.GLViewImpl",(cocos2d::GLViewImpl*)ret);
+        return 1;
+    }
     luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d\n ", "cc.GLViewImpl:createWithRect",argc, 2);
     return 0;
 #if COCOS2D_DEBUG >= 1

--- a/cocos/scripting/lua-bindings/auto/lua_cocos2dx_auto.cpp
+++ b/cocos/scripting/lua-bindings/auto/lua_cocos2dx_auto.cpp
@@ -64656,25 +64656,6 @@ int lua_cocos2dx_GLViewImpl_createWithRect(lua_State* tolua_S)
         object_to_luaval<cocos2d::GLViewImpl>(tolua_S, "cc.GLViewImpl",(cocos2d::GLViewImpl*)ret);
         return 1;
     }
-    if (argc == 4)
-    {
-        std::string arg0;
-        cocos2d::Rect arg1;
-        double arg2;
-        bool arg3;
-        ok &= luaval_to_std_string(tolua_S, 2,&arg0, "cc.GLViewImpl:createWithRect");
-        ok &= luaval_to_rect(tolua_S, 3, &arg1, "cc.GLViewImpl:createWithRect");
-        ok &= luaval_to_number(tolua_S, 4,&arg2, "cc.GLViewImpl:createWithRect");
-        ok &= luaval_to_boolean(tolua_S, 5,&arg3, "cc.GLViewImpl:createWithRect");
-        if(!ok)
-        {
-            tolua_error(tolua_S,"invalid arguments in function 'lua_cocos2dx_GLViewImpl_createWithRect'", nullptr);
-            return 0;
-        }
-        cocos2d::GLViewImpl* ret = cocos2d::GLViewImpl::createWithRect(arg0, arg1, arg2, arg3);
-        object_to_luaval<cocos2d::GLViewImpl>(tolua_S, "cc.GLViewImpl",(cocos2d::GLViewImpl*)ret);
-        return 1;
-    }
     luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d\n ", "cc.GLViewImpl:createWithRect",argc, 2);
     return 0;
 #if COCOS2D_DEBUG >= 1


### PR DESCRIPTION
You can also add callbacks that inform the application that the window was resized using GLView::addResizeCalback.
A dummy parameter was added to createWithRect in mobile mobile versions to keep them in sync.
Tested on Windows and iOS.
This is my first official contribution to this project - hope I did not break to many guidelines ;)
