### PR TITLE
restrict capInsets of ui::ImageView, ui::Slider and ui::LoadinbBar

### DIFF
--- a/cocos/ui/UIHelper.h
+++ b/cocos/ui/UIHelper.h
@@ -83,9 +83,14 @@ public:
 
     static void changeLayoutSystemActiveState(bool bActive);
     
-private:
+    /**
+     *@brief  restrict capInsetSize, when the capInsets's width is larger than the textureSize, it will restrict to 0,
+     *        the height goes the same way as width.
+     *@param  capInsets A user defined capInsets.
+     *@param  textureSize  The size of a scale9enabled texture
+     *@return a restricted capInset.
+     */
     static Rect restrictCapInsetRect(const Rect& capInsets, const Size& textureSize);
-    friend class Button;
 };
 }
 

--- a/cocos/ui/UIImageView.cpp
+++ b/cocos/ui/UIImageView.cpp
@@ -24,6 +24,7 @@ THE SOFTWARE.
 
 #include "ui/UIImageView.h"
 #include "ui/UIScale9Sprite.h"
+#include "ui/UIHelper.h"
 #include "2d/CCSprite.h"
 
 NS_CC_BEGIN
@@ -203,12 +204,12 @@ void ImageView::ignoreContentAdaptWithSize(bool ignore)
 
 void ImageView::setCapInsets(const Rect &capInsets)
 {
-    _capInsets = capInsets;
+    _capInsets = ui::Helper::restrictCapInsetRect(capInsets, _imageTextureSize);
     if (!_scale9Enabled)
     {
         return;
     }
-    _imageRenderer->setCapInsets(capInsets);
+    _imageRenderer->setCapInsets(_capInsets);
 }
 
 const Rect& ImageView::getCapInsets()const

--- a/cocos/ui/UILoadingBar.cpp
+++ b/cocos/ui/UILoadingBar.cpp
@@ -23,6 +23,7 @@ THE SOFTWARE.
 ****************************************************************************/
 
 #include "ui/UILoadingBar.h"
+#include "ui/UIHelper.h"
 #include "ui/UIScale9Sprite.h"
 #include "2d/CCSprite.h"
 
@@ -225,12 +226,12 @@ bool LoadingBar::isScale9Enabled()const
     
 void LoadingBar::setCapInsets(const Rect &capInsets)
 {
-    _capInsets = capInsets;
+    _capInsets = ui::Helper::restrictCapInsetRect(capInsets, _barRendererTextureSize);
     if (!_scale9Enabled)
     {
         return;
     }
-    _barRenderer->setCapInsets(capInsets);
+    _barRenderer->setCapInsets(_capInsets);
 }
 
 const Rect& LoadingBar::getCapInsets()const

--- a/cocos/ui/UISlider.cpp
+++ b/cocos/ui/UISlider.cpp
@@ -24,6 +24,7 @@ THE SOFTWARE.
 
 #include "ui/UISlider.h"
 #include "ui/UIScale9Sprite.h"
+#include "ui/UIHelper.h"
 #include "2d/CCSprite.h"
 
 NS_CC_BEGIN
@@ -222,12 +223,12 @@ void Slider::setCapInsets(const Rect &capInsets)
 
 void Slider::setCapInsetsBarRenderer(const Rect &capInsets)
 {
-    _capInsetsBarRenderer = capInsets;
+    _capInsetsBarRenderer = ui::Helper::restrictCapInsetRect(capInsets, _barRenderer->getContentSize());
     if (!_scale9Enabled)
     {
         return;
     }
-    _barRenderer->setCapInsets(capInsets);
+    _barRenderer->setCapInsets(_capInsetsBarRenderer);
 }
     
 const Rect& Slider::getCapInsetsBarRenderer()const
@@ -237,12 +238,13 @@ const Rect& Slider::getCapInsetsBarRenderer()const
 
 void Slider::setCapInsetProgressBarRebderer(const Rect &capInsets)
 {
-    _capInsetsProgressBarRenderer = capInsets;
+    _capInsetsProgressBarRenderer = ui::Helper::restrictCapInsetRect(capInsets, _progressBarRenderer->getContentSize());
+    
     if (!_scale9Enabled)
     {
         return;
     }
-    _progressBarRenderer->setCapInsets(capInsets);
+    _progressBarRenderer->setCapInsets(_capInsetsProgressBarRenderer);
 }
     
 const Rect& Slider::getCapInsetsProgressBarRebderer()const


### PR DESCRIPTION
@chengstory 
Please help me to test it.
I found in the previous version, you guys add this check to ui::Button, but you forget to add it to all other scale9enabled widgets. 

So this PR was proposed to resolve this issue.

Thanks.
