### PR TITLE
comment line 83

### DIFF
--- a/cocos/renderer/CCGLProgramStateCache.cpp
+++ b/cocos/renderer/CCGLProgramStateCache.cpp
@@ -80,7 +80,7 @@ void GLProgramStateCache::removeUnusedGLProgramState()
         if( value->getReferenceCount() == 1 ) {
             CCLOG("cocos2d: GLProgramStateCache: removing unused GLProgramState");
 
-            value->release();
+            //value->release();
             _glProgramStates.erase(it++);
         } else {
             ++it;


### PR DESCRIPTION
As known,  _glProgramStates is a cocos2d::Map container,it will call object->retain() when insert, and call position->second->release() when erase, so the statement of line 83 is redundant.
If i don't comment line 83, the application will crash when GLProgramStateCache::removeUnusedGLProgramState() is called.
