### PR TITLE
AudioEngine-win32.ccp: Switch OpenAL include paths based on OPENAL_PLAINS_INCLUDES.

### DIFF
--- a/cocos/audio/win32/AudioEngine-win32.cpp
+++ b/cocos/audio/win32/AudioEngine-win32.cpp
@@ -27,8 +27,13 @@
 
 #include "AudioEngine-win32.h"
 #include <condition_variable>
+#ifdef OPENAL_PLAIN_INCLUDES
+#include "alc.h"
+#include "alext.h"
+#else
 #include "AL/alc.h"
 #include "AL/alext.h"
+#endif
 #include "audio/include/AudioEngine.h"
 #include "base/CCDirector.h"
 #include "base/CCScheduler.h"


### PR DESCRIPTION
Win32 cmake build fails when OPENAL_PLAINS_INCLUDES is true (which it is by default). Fixed by removing "AL/" when defined.
