### PR TITLE
fix serious performance problem of Animate.

### DIFF
--- a/cocos/2d/CCActionInterval.cpp
+++ b/cocos/2d/CCActionInterval.cpp
@@ -2346,7 +2346,7 @@ void Animate::update(float t)
 
 Animate* Animate::reverse() const
 {
-    auto oldArray = _animation->getFrames();
+    auto& oldArray = _animation->getFrames();
     Vector<AnimationFrame*> newArray(oldArray.size());
    
     if (oldArray.size() > 0)

--- a/cocos/2d/CCActionInterval.cpp
+++ b/cocos/2d/CCActionInterval.cpp
@@ -2237,7 +2237,7 @@ bool Animate::initWithAnimation(Animation* animation)
         float accumUnitsOfTime = 0;
         float newUnitOfTimeValue = singleDuration / animation->getTotalDelayUnits();
 
-        auto frames = animation->getFrames();
+        auto& frames = animation->getFrames();
 
         for (auto& frame : frames)
         {
@@ -2312,7 +2312,7 @@ void Animate::update(float t)
         t = fmodf(t, 1.0f);
     }
 
-    auto frames = _animation->getFrames();
+    auto& frames = _animation->getFrames();
     auto numberOfFrames = frames.size();
     SpriteFrame *frameToDisplay = nullptr;
 

--- a/cocos/2d/CCLabel.cpp
+++ b/cocos/2d/CCLabel.cpp
@@ -591,7 +591,7 @@ void Label::alignText()
         batchNode->getTextureAtlas()->removeAllQuads();
     }
     _fontAtlas->prepareLetterDefinitions(_currentUTF16String);
-    auto textures = _fontAtlas->getTextures();
+    auto& textures = _fontAtlas->getTextures();
     if (textures.size() > _batchNodes.size())
     {
         for (auto index = _batchNodes.size(); index < textures.size(); ++index)

--- a/cocos/2d/CCLabel.cpp
+++ b/cocos/2d/CCLabel.cpp
@@ -591,12 +591,12 @@ void Label::alignText()
         batchNode->getTextureAtlas()->removeAllQuads();
     }
     _fontAtlas->prepareLetterDefinitions(_currentUTF16String);
-    auto textures = _fontAtlas->getTextures();
+    auto& textures = _fontAtlas->getTextures();
     if (textures.size() > _batchNodes.size())
     {
         for (auto index = _batchNodes.size(); index < textures.size(); ++index)
         {
-            auto batchNode = SpriteBatchNode::createWithTexture(textures[index]);
+            auto batchNode = SpriteBatchNode::createWithTexture(textures.at(index));
             batchNode->setAnchorPoint(Vec2::ANCHOR_TOP_LEFT);
             batchNode->setPosition(Vec2::ZERO);
             Node::addChild(batchNode,0,Node::INVALID_TAG);
@@ -629,9 +629,9 @@ void Label::alignText()
                 uvRect.origin.x    = _lettersInfo[tag].def.U;
                 uvRect.origin.y    = _lettersInfo[tag].def.V;
 
-                letterSprite->setTexture(textures[_lettersInfo[tag].def.textureID]);
+                letterSprite->setTexture(textures.at(_lettersInfo[tag].def.textureID));
                 letterSprite->setTextureRect(uvRect);
-            }          
+            }
         }
     }
 

--- a/cocos/2d/CCLabel.cpp
+++ b/cocos/2d/CCLabel.cpp
@@ -591,7 +591,7 @@ void Label::alignText()
         batchNode->getTextureAtlas()->removeAllQuads();
     }
     _fontAtlas->prepareLetterDefinitions(_currentUTF16String);
-    auto& textures = _fontAtlas->getTextures();
+    auto textures = _fontAtlas->getTextures();
     if (textures.size() > _batchNodes.size())
     {
         for (auto index = _batchNodes.size(); index < textures.size(); ++index)

--- a/cocos/base/CCConsole.cpp
+++ b/cocos/base/CCConsole.cpp
@@ -160,14 +160,14 @@ static void printFileUtils(int fd)
     FileUtils* fu = FileUtils::getInstance();
 
     mydprintf(fd, "\nSearch Paths:\n");
-    auto list = fu->getSearchPaths();
+    auto& list = fu->getSearchPaths();
     for( const auto &item : list) {
         mydprintf(fd, "%s\n", item.c_str());
     }
 
     mydprintf(fd, "\nResolution Order:\n");
-    list = fu->getSearchResolutionsOrder();
-    for( const auto &item : list) {
+    auto& list1 = fu->getSearchResolutionsOrder();
+    for( const auto &item : list1) {
         mydprintf(fd, "%s\n", item.c_str());
     }
 
@@ -175,7 +175,7 @@ static void printFileUtils(int fd)
     mydprintf(fd, "%s\n", fu->getWritablePath().c_str());
 
     mydprintf(fd, "\nFull Path Cache:\n");
-    auto cache = fu->getFullPathCache();
+    auto& cache = fu->getFullPathCache();
     for( const auto &item : cache) {
         mydprintf(fd, "%s -> %s\n", item.first.c_str(), item.second.c_str());
     }

--- a/cocos/editor-support/cocostudio/ActionTimeline/CCActionTimeline.cpp
+++ b/cocos/editor-support/cocostudio/ActionTimeline/CCActionTimeline.cpp
@@ -204,7 +204,7 @@ void foreachNodeDescendant(Node* parent, tCallBack callback)
 {
     callback(parent);
 
-    auto children = parent->getChildren();
+    auto& children = parent->getChildren();
     for (auto child : children)
     {
         foreachNodeDescendant(child, callback);

--- a/cocos/ui/UILayout.cpp
+++ b/cocos/ui/UILayout.cpp
@@ -1659,7 +1659,7 @@ bool  Layout::isLastWidgetInContainer(Widget* widget, FocusDirection direction)c
         return true;
     }
     
-    auto container = parent->getChildren();
+    auto& container = parent->getChildren();
     ssize_t index = container.getIndex(widget);
     if (parent->getLayoutType() == Type::HORIZONTAL)
     {


### PR DESCRIPTION
this is a serious bug, it cause massive cpu consume.
if we have 1000 animate in active scene, this pr can raise 5% performance globally, raise about 70% performance locally of Animate!!!!!!!!!!!! .
because it have massive calls cocos2d::Vector constructor and de-constructor. 
Vector's constructor will also call "addRefForAllObjects"(for loop)!!!!!

This problem is very, very serious,  and still has many similar errors in cocos2d-x.

we must use "auto&" sometimes, especially in update per frame. 
