### PR TITLE
cmake: cleanups

### DIFF
--- a/cmake/Modules/FindJPEG.cmake
+++ b/cmake/Modules/FindJPEG.cmake
@@ -31,26 +31,6 @@
 # (To distribute this file outside of CMake, substitute the full
 #  License text for the above reference.)
 
-if(USE_PREBUILT_LIBS)
-  find_path(JPEG_INCLUDE_DIR jpeglib.h
-    PATH_SUFFIXES include/${PLATFORM_FOLDER} include
-    PATHS ${COCOS_EXTERNAL_DIR}/jpeg
-    NO_DEFAULT_PATH
-    )
-  find_library(JPEG_LIBRARY NAMES jpeg
-    PATH_SUFFIXES
-      prebuilt/${PLATFORM_FOLDER}/${ARCH_DIR}
-      prebuilt/${PLATFORM_FOLDER}
-    PATHS ${COCOS_EXTERNAL_DIR}/jpeg
-    NO_DEFAULT_PATH
-    )
-  # cleanup if not found (prevent from mix prebuilt include paths and system installed libraries)
-  if(NOT JPEG_INCLUDE_DIR OR NOT JPEG_LIBRARY)
-    unset(JPEG_INCLUDE_DIR CACHE)
-    unset(JPEG_LIBRARY CACHE)
-  endif()
-endif()
-
 find_path(JPEG_INCLUDE_DIR jpeglib.h)
 
 set(JPEG_NAMES ${JPEG_NAMES} jpeg)

--- a/cmake/Modules/FindPNG.cmake
+++ b/cmake/Modules/FindPNG.cmake
@@ -48,24 +48,6 @@ if(PNG_FIND_QUIETLY)
 endif()
 find_package(ZLIB ${_FIND_ZLIB_ARG})
 
-if(USE_PREBUILT_LIBS)
-  find_path(PNG_PNG_INCLUDE_DIR png.h
-    PATH_SUFFIXES include/${PLATFORM_FOLDER} include
-    PATHS ${COCOS_EXTERNAL_DIR}/png NO_DEFAULT_PATH
-    )
-  find_library(PNG_LIBRARY NAMES png libpng
-    PATH_SUFFIXES
-      prebuilt/${PLATFORM_FOLDER}/${ARCH_DIR}
-      prebuilt/${PLATFORM_FOLDER}
-    PATHS ${COCOS_EXTERNAL_DIR}/png NO_DEFAULT_PATH
-    )
-  # cleanup if not found (prevent from mix prebuilt include paths and system installed libraries)
-  if(NOT PNG_PNG_INCLUDE_DIR OR NOT PNG_LIBRARY)
-    unset(PNG_PNG_INCLUDE_DIR CACHE)
-    unset(PNG_LIBRARY CACHE)
-  endif()
-endif()
-
 if(ZLIB_FOUND)
   find_path(PNG_PNG_INCLUDE_DIR png.h
     HINTS ENV PNG_DIR

--- a/cmake/Modules/FindTIFF.cmake
+++ b/cmake/Modules/FindTIFF.cmake
@@ -33,24 +33,6 @@
 
 set(TIFF_NAMES ${TIFF_NAMES} tiff libtiff tiff3 libtiff3)
 
-if(USE_PREBUILT_LIBS)
-  find_path(TIFF_INCLUDE_DIR tiff.h
-    PATH_SUFFIXES include/${PLATFORM_FOLDER} include
-    PATHS ${COCOS_EXTERNAL_DIR}/tiff NO_DEFAULT_PATH
-    )
-  find_library(TIFF_LIBRARY NAMES ${TIFF_NAMES}
-    PATH_SUFFIXES
-      prebuilt/${PLATFORM_FOLDER}/${ARCH_DIR}
-      prebuilt/${PLATFORM_FOLDER}
-    PATHS ${COCOS_EXTERNAL_DIR}/tiff NO_DEFAULT_PATH
-    )
-  # cleanup if not found (prevent from mix prebuilt include paths and system installed libraries)
-  if(NOT TIFF_INCLUDE_DIR OR NOT TIFF_LIBRARY)
-    unset(TIFF_INCLUDE_DIR CACHE)
-    unset(TIFF_LIBRARY CACHE)
-  endif()
-endif()
-
 find_path(TIFF_INCLUDE_DIR tiff.h
     HINTS ENV TIFF_DIR
     PATH_SUFFIXES include/libtiff include

--- a/cmake/Modules/FindTinyXML2.cmake
+++ b/cmake/Modules/FindTinyXML2.cmake
@@ -13,29 +13,6 @@
 #   TINYXML2_INCLUDE_DIRS, where to find headers.
 #
 
-# Try find tinyxml for our arch in external folder
-if(USE_PREBUILT_LIBS)
-  find_path(TinyXML2_INCLUDE_DIR tinyxml2.h
-    PATH_SUFFIXES
-      include/tinyxml2
-      include
-    PATHS ${COCOS_EXTERNAL_DIR}/tinyxml2
-    NO_DEFAULT_PATH
-    )
-  find_library(TinyXML2_LIBRARY NAMES tinyxml2 libtinyxml2
-    PATH_SUFFIXES
-      prebuilt/${PLATFORM_FOLDER}/${ARCH_DIR}
-      prebuilt/${PLATFORM_FOLDER}
-    PATHS ${COCOS_EXTERNAL_DIR}/tinyxml2
-    NO_DEFAULT_PATH
-    )
-  # cleanup if not found (prevent from mix prebuilt include paths and system installed libraries)
-  if(NOT TinyXML2_INCLUDE_DIR OR NOT TinyXML2_LIBRARY)
-    unset(TinyXML2_INCLUDE_DIR CACHE)
-    unset(TinyXML2_LIBRARY CACHE)
-  endif()
-endif(USE_PREBUILT_LIBS)
-
 find_path(TinyXML2_INCLUDE_DIR tinyxml2.h
   HINTS ENV TinyXML2_DIR
   PATH_SUFFIXES include/tinyxml2 include

--- a/cmake/Modules/FindWEBSOCKETS.cmake
+++ b/cmake/Modules/FindWEBSOCKETS.cmake
@@ -11,26 +11,6 @@
 #   WEBSOCKETS_FOUND, If false, do not try to use WEBSOCKETS.
 #
 
-if(USE_PREBUILT_LIBS)
-  find_path(WEBSOCKETS_INCLUDE_DIR libwebsockets.h
-    PATH_SUFFIXES include/${PLATFORM_FOLDER} include
-    PATHS ${COCOS_EXTERNAL_DIR}/websockets
-    NO_DEFAULT_PATH
-    )
-  find_library(WEBSOCKETS_LIBRARY NAMES websockets libwebsockets
-    PATH_SUFFIXES
-      prebuilt/${PLATFORM_FOLDER}/${ARCH_DIR}
-      prebuilt/${PLATFORM_FOLDER}
-    PATHS ${COCOS_EXTERNAL_DIR}/websockets
-    NO_DEFAULT_PATH
-    )
-  # cleanup if not found (prevent from mix prebuilt include paths and system installed libraries)
-  if(NOT WEBSOCKETS_INCLUDE_DIR OR NOT WEBSOCKETS_LIBRARY)
-    unset(WEBSOCKETS_INCLUDE_DIR CACHE)
-    unset(WEBSOCKETS_LIBRARY CACHE)
-  endif()
-endif()
-
 find_path(WEBSOCKETS_INCLUDE_DIR libwebsockets.h
   HINTS ENV WEBSOCKETS_DIR
   PATH_SUFFIXES include/websockets include/libwebsockets include

--- a/cmake/Modules/FindWebP.cmake
+++ b/cmake/Modules/FindWebP.cmake
@@ -27,27 +27,6 @@
 # (To distribute this file outside of CMake, substitute the full
 #  License text for the above reference.)
 
-# Try find WebP for our arch in external folder
-if(USE_PREBUILT_LIBS)
-  find_path(WEBP_INCLUDE_DIR decode.h
-    PATH_SUFFIXES include/${PLATFORM_FOLDER} include
-    PATHS ${COCOS_EXTERNAL_DIR}/webp
-    NO_DEFAULT_PATH
-    )
-  find_library(WEBP_LIBRARY NAMES webp libwebp
-    PATH_SUFFIXES
-      prebuilt/${PLATFORM_FOLDER}/${ARCH_DIR}
-      prebuilt/${PLATFORM_FOLDER}
-    PATHS ${COCOS_EXTERNAL_DIR}/webp
-    NO_DEFAULT_PATH
-    )
-  # cleanup if not found (prevent from mix prebuilt include paths and system installed libraries)
-  if(NOT WEBP_INCLUDE_DIR OR NOT WEBP_LIBRARY)
-    unset(WEBP_INCLUDE_DIR CACHE)
-    unset(WEBP_LIBRARY CACHE)
-  endif()
-endif(USE_PREBUILT_LIBS)
-
 FIND_PATH(WEBP_INCLUDE_DIR decode.h
   HINTS
   ENV WEBP_DIR


### PR DESCRIPTION
Remove unused code from Find*.cmake modules. All logic with `USE_PREBUILT_LIBS` are handled in `cmake/Modules/CocosUsePrebuiltLibs.cmake`
