### PR TITLE
fixed bug which caused crash when display FPS

### DIFF
--- a/cocos/base/CCDirector.cpp
+++ b/cocos/base/CCDirector.cpp
@@ -120,6 +120,7 @@ bool Director::init(void)
     _FPSLabel = _drawnBatchesLabel = _drawnVerticesLabel = nullptr;
     _totalFrames = 0;
     _lastUpdate = new struct timeval;
+    _secondsPerFrame = 1.0f;
 
     // paused ?
     _paused = false;


### PR DESCRIPTION
fixed bug which caused crash when display FPS: the value of "_secondsPerFrame" of Director was not be Initialized
