### PR TITLE
Feature of version check. 

### DIFF
--- a/cocos/editor-support/cocostudio/ActionTimeline/CSLoader.cpp
+++ b/cocos/editor-support/cocostudio/ActionTimeline/CSLoader.cpp
@@ -181,6 +181,7 @@ CSLoader::CSLoader()
 , _jsonPath("")
 , _monoCocos2dxVersion("")
 , _rootNode(nullptr)
+, _csBuildID("2.0.8.0")
 {
     CREATE_CLASS_NODE_READER_INFO(NodeReader);
     CREATE_CLASS_NODE_READER_INFO(SingleNodeReader);
@@ -782,6 +783,21 @@ Node* CSLoader::nodeWithFlatBuffersFile(const std::string &fileName)
     Data buf = FileUtils::getInstance()->getDataFromFile(fullPath);
     
     auto csparsebinary = GetCSParseBinary(buf.getBytes());
+
+    auto csBuildId = csparsebinary->version();
+    if (csBuildId)
+    {
+        CCASSERT(strcmp(_csBuildID.c_str(), csBuildId->c_str()) == 0,
+            String::createWithFormat("%s%s%s%s%s%s%s%s",
+            "The build id of your CocosStudio exported file(",
+            csBuildId->c_str(),
+            ") and the build id of your cocos reader(",
+            _csBuildID.c_str(),
+            ") are not match.\n",
+            "Please get the correct cocos reader from ",
+            "https://github.com/chukong/cocos-reader",
+            " and replace the reader in your Cocos2d-x")->getCString());
+    }
     
     // decode plist
     auto textures = csparsebinary->textures();
@@ -791,9 +807,6 @@ Node* CSLoader::nodeWithFlatBuffersFile(const std::string &fileName)
     {
         SpriteFrameCache::getInstance()->addSpriteFramesWithFile(textures->Get(i)->c_str());        
     }
-    
-    auto v = csparsebinary->version();
-    if (v) _csdVersion = v->c_str();
        
     Node* node = nodeWithFlatBuffers(csparsebinary->nodeTree());
     
@@ -1136,9 +1149,6 @@ Node* CSLoader::createNodeWithFlatBuffersForSimulator(const std::string& filenam
     }
     
     auto nodeTree = csparsebinary->nodeTree();
-
-    auto v = csparsebinary->version();
-    if (v) _csdVersion = v->c_str();
 
     Node* node = nodeWithFlatBuffersForSimulator(nodeTree);
     

--- a/cocos/editor-support/cocostudio/ActionTimeline/CSLoader.h
+++ b/cocos/editor-support/cocostudio/ActionTimeline/CSLoader.h
@@ -104,7 +104,6 @@ public:
     
     cocos2d::Node* createNodeWithFlatBuffersForSimulator(const std::string& filename);
     cocos2d::Node* nodeWithFlatBuffersForSimulator(const flatbuffers::NodeTree* nodetree);
-    std::string getCsdVersion() { return _csdVersion; }
 
 protected:
     
@@ -151,8 +150,7 @@ protected:
     std::string _monoCocos2dxVersion;
     
     Node* _rootNode;
-//    std::vector<Node*> _loadingNodeParentHierarchy;
-    std::string _csdVersion;
+    std::string _csBuildID;
 };
 
 NS_CC_END

--- a/cocos/editor-support/cocostudio/WidgetReader/NodeReader/NodeReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/NodeReader/NodeReader.cpp
@@ -517,6 +517,7 @@ namespace cocostudio
     void NodeReader::setLayoutComponentPropsWithFlatBuffers(cocos2d::Node* node, const flatbuffers::Table* nodeOptions)
     {
         auto layoutComponentTable = ((WidgetOptions*)nodeOptions)->layoutComponent();
+        if (!layoutComponentTable) return;
 
         auto layoutComponent = ui::LayoutComponent::bindLayoutComponent(node);
 

--- a/cocos/editor-support/cocostudio/WidgetReader/NodeReader/NodeReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/NodeReader/NodeReader.cpp
@@ -517,7 +517,6 @@ namespace cocostudio
     void NodeReader::setLayoutComponentPropsWithFlatBuffers(cocos2d::Node* node, const flatbuffers::Table* nodeOptions)
     {
         auto layoutComponentTable = ((WidgetOptions*)nodeOptions)->layoutComponent();
-        if (!layoutComponentTable) return;
 
         auto layoutComponent = ui::LayoutComponent::bindLayoutComponent(node);
 

--- a/cocos/editor-support/cocostudio/WidgetReader/WidgetReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/WidgetReader.cpp
@@ -771,41 +771,11 @@ namespace cocostudio
         widget->setCascadeOpacityEnabled(true);
         widget->setAnchorPoint(Vec2::ZERO);
         
-        widget->setUnifySizeEnabled(true);
-        bool ignoreSize = options->ignoreSize();
-        widget->ignoreContentAdaptWithSize(ignoreSize);
-
-        std::string versionString = CSLoader::getInstance()->getCsdVersion();
-        //assume versionString is like "2.0.6.0"
-        if (versionString.length() > 0)
-        {
-            int p1, p2, p3, v1, v2, v3;
-            p1 = p2 = p3 = v1 = v2 = v3 = 0;
-            p1 = versionString.find('.');
-            if (p1 > 0)
-            {
-                p2 = versionString.find('.', p1 + 1);
-                v1 = atoi(versionString.substr(0, p1).c_str());
-            }
-            if (p2 > p1)
-            {
-                p3 = versionString.find('.', p2 + 1);
-                v2 = atoi(versionString.substr(p1 + 1, p2 - p1 - 1).c_str());
-            }
-            if (p3 > p2)
-            {
-                v3 = atoi(versionString.substr(p2 + 1, p3 - p2 - 1).c_str());
-            }
-
-            if (!(v1 <= 2 && v2 == 0 && v3 <= 6))
-            {
-                widget->setUnifySizeEnabled(false);
-                widget->setLayoutComponentEnabled(true);
-                widget->ignoreContentAdaptWithSize(false);
-                Size contentSize(options->size()->width(), options->size()->height());
-                widget->setContentSize(contentSize);
-            }
-        }
+        widget->setUnifySizeEnabled(false);
+        widget->setLayoutComponentEnabled(true);
+        widget->ignoreContentAdaptWithSize(false);
+        Size contentSize(options->size()->width(), options->size()->height());
+        widget->setContentSize(contentSize);
         
         int tag = options->tag();
         widget->setTag(tag);
@@ -866,7 +836,6 @@ namespace cocostudio
     void WidgetReader::setLayoutComponentPropsWithFlatBuffers(cocos2d::Node* node, const flatbuffers::Table* nodeOptions)
     {
         auto layoutComponentTable = ((WidgetOptions*)nodeOptions)->layoutComponent();
-        if (!layoutComponentTable) return;
 
         auto layoutComponent = ui::LayoutComponent::bindLayoutComponent(node);
 

--- a/cocos/editor-support/cocostudio/WidgetReader/WidgetReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/WidgetReader.cpp
@@ -838,6 +838,7 @@ namespace cocostudio
         auto layoutComponentTable = ((WidgetOptions*)nodeOptions)->layoutComponent();
 
         auto layoutComponent = ui::LayoutComponent::bindLayoutComponent(node);
+        if (!layoutComponentTable) return;
 
         bool positionXPercentEnabled = layoutComponentTable->positionXPercentEnabled();
         bool positionYPercentEnabled = layoutComponentTable->positionYPercentEnabled();

--- a/cocos/editor-support/cocostudio/WidgetReader/WidgetReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/WidgetReader.cpp
@@ -836,9 +836,9 @@ namespace cocostudio
     void WidgetReader::setLayoutComponentPropsWithFlatBuffers(cocos2d::Node* node, const flatbuffers::Table* nodeOptions)
     {
         auto layoutComponentTable = ((WidgetOptions*)nodeOptions)->layoutComponent();
+        if (!layoutComponentTable) return;
 
         auto layoutComponent = ui::LayoutComponent::bindLayoutComponent(node);
-        if (!layoutComponentTable) return;
 
         bool positionXPercentEnabled = layoutComponentTable->positionXPercentEnabled();
         bool positionYPercentEnabled = layoutComponentTable->positionYPercentEnabled();


### PR DESCRIPTION
When reading a csb file, if the engine's reader version dismatch the version saved in the csb file, an assert will be triggered. User must go to a website to get a reader to match the csb file.

Removed the version compatible control code before.
