### PR TITLE
Disable write to depth buffer for transparent objects

### DIFF
--- a/cocos/renderer/CCRenderer.cpp
+++ b/cocos/renderer/CCRenderer.cpp
@@ -321,10 +321,8 @@ void Renderer::addCommand(RenderCommand* command, int renderQueue)
     CCASSERT(!_isRendering, "Cannot add command while rendering");
     CCASSERT(renderQueue >=0, "Invalid render queue");
     CCASSERT(command->getType() != RenderCommand::Type::UNKNOWN_COMMAND, "Invalid Command Type");
-    if (command->isTransparent())
-        _transparentRenderGroups.push_back(command);
-    else
-        _renderGroups[renderQueue].push_back(command);
+    
+    _renderGroups[renderQueue].push_back(command);
 }
 
 void Renderer::pushGroup(int renderQueueID)
@@ -823,10 +821,23 @@ void Renderer::flush()
 
 void Renderer::flush2D()
 {
+    //Check depth write
+    GLboolean depthWirte;
+    glGetBooleanv(GL_DEPTH_WRITEMASK, &depthWirte);
+    //Turn depth write off if necessary
+    if(depthWirte)
+    {
+        glDepthMask(false);
+    }
     drawBatchedQuads();
     _lastMaterialID = 0;
     drawBatchedTriangles();
     _lastMaterialID = 0;
+    //Turn depth write on if necessary
+    if(depthWirte)
+    {
+        glDepthMask(true);
+    }
 }
 
 void Renderer::flush3D()

--- a/cocos/renderer/CCTextureAtlas.cpp
+++ b/cocos/renderer/CCTextureAtlas.cpp
@@ -605,7 +605,16 @@ void TextureAtlas::drawNumberOfQuads(ssize_t numberOfQuads, ssize_t start)
 
     if(!numberOfQuads)
         return;
-
+    
+    //Check depth write
+    GLboolean depthWirte;
+    glGetBooleanv(GL_DEPTH_WRITEMASK, &depthWirte);
+    //Turn depth write off if necessary
+    if(depthWirte)
+    {
+        glDepthMask(false);
+    }
+    
     GL::bindTexture2D(_texture->getName());
 
     if (Configuration::getInstance()->supportsShareableVAO())
@@ -686,6 +695,12 @@ void TextureAtlas::drawNumberOfQuads(ssize_t numberOfQuads, ssize_t start)
 
     CC_INCREMENT_GL_DRAWN_BATCHES_AND_VERTICES(1,numberOfQuads*6);
 
+    //Turn depth write on if necessary
+    if(depthWirte)
+    {
+        glDepthMask(true);
+    }
+    
     CHECK_GL_ERROR_DEBUG();
 }
 


### PR DESCRIPTION
- Disable writing to depth buffer for transparent and 2D objects
- Depth test will be added later with some performance test
- A better solution is still under development
- [Fantasy Warrior](https://github.com/darkdukey/FantasyWarrior3D/tree/originalCocos) should be rendering correctly with unmodified engine
