### PR TITLE
Remove warn error on Exit

### DIFF
--- a/cocos/platform/linux/CCApplication-linux.cpp
+++ b/cocos/platform/linux/CCApplication-linux.cpp
@@ -104,7 +104,7 @@ int Application::run()
         director = nullptr;
     }
     glview->release();
-    return -1;
+    return EXIT_SUCCESS;
 }
 
 void Application::setAnimationInterval(double interval)


### PR DESCRIPTION
Change the return error on Linux to  -1  to  standard EXIT_SUCCESS value.
