### PR TITLE
Bug fix:When parsing a plist file as image mergin, if in fact the plist ...

### DIFF
--- a/cocos/editor-support/cocostudio/CCDataReaderHelper.cpp
+++ b/cocos/editor-support/cocostudio/CCDataReaderHelper.cpp
@@ -1332,6 +1332,8 @@ void DataReaderHelper::addDataFromJsonCache(const std::string& fileContent, Data
             {
                 std::string plistPath = filePath + ".plist";
                 std::string pngPath =  filePath + ".png";
+                ValueMap dict = FileUtils::getInstance()->getValueMapFromFile(dataInfo->baseFilePath + plistPath);
+                if (dict.find("particleLifespan") != dict.end()) continue;
 
                 ArmatureDataManager::getInstance()->addSpriteFrameFromFile((dataInfo->baseFilePath + plistPath).c_str(), (dataInfo->baseFilePath + pngPath).c_str(), dataInfo->filename.c_str());
             }


### PR DESCRIPTION
Bug fix:When parsing a plist file as image mergin, if in fact the plist file is a particle, a crush will occur.

Now it's fixed.
