### PR TITLE
Fix warning log when loading sphere.c3b

### DIFF
--- a/cocos/3d/CCBundle3D.cpp
+++ b/cocos/3d/CCBundle3D.cpp
@@ -1227,6 +1227,10 @@ bool Bundle3D::loadSkinDataBinary(SkinData* skindata)
         return false;
     }
     
+    // Fix bug: check if the bone number is 0.
+    if (boneNum == 0)
+        return false;
+    
     // bone names and bind pos
     float bindpos[16];
     for (unsigned int i = 0; i < boneNum; i++)


### PR DESCRIPTION
Fix warning log when load sphere.c3b which is a static model with skin
