### PR TITLE
improve ui::Text and ui::TextField creation performance

### DIFF
--- a/cocos/ui/UIText.cpp
+++ b/cocos/ui/UIText.cpp
@@ -95,9 +95,9 @@ bool Text::init(const std::string &textContent, const std::string &fontName, int
             ret = false;
             break;
         }
-        this->setString(textContent);
         this->setFontName(fontName);
         this->setFontSize(fontSize);
+        this->setString(textContent);
     } while (0);
     return ret;
 }

--- a/cocos/ui/UITextField.cpp
+++ b/cocos/ui/UITextField.cpp
@@ -329,9 +329,9 @@ TextField* TextField::create(const std::string &placeholder, const std::string &
     TextField* widget = new (std::nothrow) TextField();
     if (widget && widget->init())
     {
-        widget->setPlaceHolder(placeholder);
         widget->setFontName(fontName);
         widget->setFontSize(fontSize);
+        widget->setPlaceHolder(placeholder);
         widget->autorelease();
         return widget;
     }


### PR DESCRIPTION
When call setTTFConfig function with long strings, the creation of ui::Text and ui::TextField is very flow.

Both the `setFontName` and `setFontSize` method call `setTTFConfig` method of Label which is very time consuming when the label string is long.

Try to delay the string assignment could improve the performance significant.

This PR fix issue https://github.com/cocos2d/cocos2d-x/issues/9849
