### PR TITLE
[ci skip]Fix some lua-tests bugs

### DIFF
--- a/tests/lua-tests/src/BillBoardTest/BillBoardTest.lua
+++ b/tests/lua-tests/src/BillBoardTest/BillBoardTest.lua
@@ -77,9 +77,9 @@ function BillBoardTest:init()
             cameraDir = cc.vec3normalize(cameraDir)
             cameraDir.y = 0
             transformMat = self._camera:getNodeToWorldTransform()
-            cameraRightDir.x = -transformMat[1]
-            cameraRightDir.y = -transformMat[2]
-            cameraRightDir.z = -transformMat[3]
+            cameraRightDir.x = transformMat[1]
+            cameraRightDir.y = transformMat[2]
+            cameraRightDir.z = transformMat[3]
             cameraRightDir = cc.vec3normalize(cameraRightDir)
             cameraRightDir.y=0
 

--- a/tests/lua-tests/src/CocoStudioTest/CocoStudioActionTimelineTest/CocoStudioActionTimelineTest.lua
+++ b/tests/lua-tests/src/CocoStudioTest/CocoStudioActionTimelineTest/CocoStudioActionTimelineTest.lua
@@ -243,9 +243,9 @@ function TestChangePlaySection:onEnter()
 
     local function onTouchesEnded(touches, event)
         if action:getStartFrame() == 0 then
-            action:gotoFrameAndPlay(70, action:getDuration(), true)
+            action:gotoFrameAndPlay(41, 81, true)
         else
-            action:gotoFrameAndPlay(0, 60, true)
+            action:gotoFrameAndPlay(0, 40, true)
         end
     end
 

--- a/tests/lua-tests/src/PhysicsTest/PhysicsTest.lua
+++ b/tests/lua-tests/src/PhysicsTest/PhysicsTest.lua
@@ -1246,7 +1246,7 @@ local function PhysicsPositionRotationTest()
       local leftBall = cc.Sprite:create("Images/ball.png");
       leftBall:setPosition(-30, 0);
       leftBall:setScale(2);
-      leftBall:setPhysicsBody(cc.PhysicsBody:createCircle(leftBall:getContentSize().width/4));
+      leftBall:setPhysicsBody(cc.PhysicsBody:createCircle(leftBall:getContentSize().width));
       leftBall:getPhysicsBody():setTag(DRAG_BODYS_TAG);
       parent:addChild(leftBall);
       

--- a/tests/lua-tests/src/VideoPlayerTest/VideoPlayerTest.lua
+++ b/tests/lua-tests/src/VideoPlayerTest/VideoPlayerTest.lua
@@ -1,6 +1,5 @@
 local visibleRect = cc.Director:getInstance():getOpenGLView():getVisibleRect()
 local centerPos   = cc.p(visibleRect.x + visibleRect.width / 2,visibleRect.y + visibleRect.height /2)
-local targetPlatform = cc.Application:getInstance():getTargetPlatform()
 
 local function VideoPlayerTest()
     local layer = cc.Layer:create() --createTestLayer("VideoPlayerTest", "")
@@ -94,11 +93,8 @@ local function VideoPlayerTest()
     ------------------------------------------------------------
     local function menuResourceVideoCallback(tag, sender)
         if nil ~= videoPlayer then
-            if cc.PLATFORM_OS_IPHONE == targetPlatform then
-                videoPlayer:setFileName("cocosvideo.mp4")
-            else
-                videoPlayer:setFileName("res/cocosvideo.mp4")
-            end    
+            local videoFullPath = cc.FileUtils:getInstance():fullPathForFilename("cocosvideo.mp4")
+            videoPlayer:setFileName(videoFullPath)   
             videoPlayer:play()
         end
     end

--- a/tests/lua-tests/src/VideoPlayerTest/VideoPlayerTest.lua
+++ b/tests/lua-tests/src/VideoPlayerTest/VideoPlayerTest.lua
@@ -1,5 +1,6 @@
 local visibleRect = cc.Director:getInstance():getOpenGLView():getVisibleRect()
 local centerPos   = cc.p(visibleRect.x + visibleRect.width / 2,visibleRect.y + visibleRect.height /2)
+local targetPlatform = cc.Application:getInstance():getTargetPlatform()
 
 local function VideoPlayerTest()
     local layer = cc.Layer:create() --createTestLayer("VideoPlayerTest", "")
@@ -93,7 +94,11 @@ local function VideoPlayerTest()
     ------------------------------------------------------------
     local function menuResourceVideoCallback(tag, sender)
         if nil ~= videoPlayer then
-            videoPlayer:setFileName("res/cocosvideo.mp4")
+            if cc.PLATFORM_OS_IPHONE == targetPlatform then
+                videoPlayer:setFileName("cocosvideo.mp4")
+            else
+                videoPlayer:setFileName("res/cocosvideo.mp4")
+            end    
             videoPlayer:play()
         end
     end


### PR DESCRIPTION
This pr is fix the lua-tests bugs as follow:
1.BillBoardTest:Move direction of BillBoardTest  display wrong, move right,but displaying move left
2.CocoStudioActionTimelineTest->Test Change Play Section:Show unusual behavior after multiple clicks.The related issue is #9891
3.PhysicsTest->Position/Rotation Test:PhysicsBody of ball was wrong
4.VideoPlayerTest:iOS device can't find the correct file path.
