### PR TITLE
FileUtils::fullPathForFilename should return "" if resource is not found.

### DIFF
--- a/cocos/platform/CCFileUtils.cpp
+++ b/cocos/platform/CCFileUtils.cpp
@@ -779,9 +779,8 @@ std::string FileUtils::fullPathForFilename(const std::string &filename)
         CCLOG("cocos2d: fullPathForFilename: No file found at %s. Possible missing file.", filename.c_str());
     }
 
-    // FIXME: Should it return nullptr ? or an empty string ?
-    // The file wasn't found, return the file name passed in.
-    return filename;
+    // The file wasn't found, return empty string.
+    return "";
 }
 
 std::string FileUtils::fullPathFromRelativeFile(const std::string &filename, const std::string &relativeFile)


### PR DESCRIPTION
I Think this method should return empty string when the resource is not found.
Because, I cannot check if the file found or not with current implementation.
