### PR TITLE
add clear pressed & disabled texture to UIButton

### DIFF
--- a/cocos/ui/UIButton.cpp
+++ b/cocos/ui/UIButton.cpp
@@ -854,6 +854,25 @@ Size Button::getNormalSize() const
     return Size(width,height);
 }
 
+void Button::clearPressedTexture()
+{
+    CCLOG("[Button::clearPressedTexture] disable pressed texture");
+    this->removeProtectedChild(_buttonClickedRenderer);
+    _buttonClickedRenderer = Scale9Sprite::create();
+    _buttonClickedRenderer->setScale9Enabled(_scale9Enabled);
+    addProtectedChild(_buttonClickedRenderer, PRESSED_RENDERER_Z, -1);
+    _pressedTextureLoaded = false;
+}
+
+void Button::clearDisabledTexture()
+{
+    this->removeProtectedChild(_buttonDisableRenderer);
+    _buttonDisableRenderer = Scale9Sprite::create();
+    _buttonDisableRenderer->setScale9Enabled(_scale9Enabled);
+    addProtectedChild(_buttonDisableRenderer, PRESSED_RENDERER_Z, -1);
+    _disabledTextureLoaded = false;
+}
+
 }
 
 NS_CC_END

--- a/cocos/ui/UIButton.h
+++ b/cocos/ui/UIButton.h
@@ -204,6 +204,9 @@ public:
      * @since v3.3
      */
     float getZoomScale()const;
+
+    void clearPressedTexture();
+    void clearDisabledTexture();
     
 CC_CONSTRUCTOR_ACCESS:
     virtual bool init() override;


### PR DESCRIPTION
UIButton can be created with only normal image, and it will auto scale for pressed state, auto grey for disabled state. This handy feature is saving the effort for graphics-making.

But CocoStudio Editor force you provide 3 images (normal, pressed, disabled) for a button widget. I don't think it is a good design. I have raised this problem in Chinese Forum in several times since 2.0beta. unfortunately, no any improve so far.

Adding this two new workaround functions clearPressedTexture and clear DisabledTexture to UIButton, It is very useful when you have only one normal image using CocoStudio.

Usage (in lua, cpp is the same): 
-- load the scene
local ui = cc.CSLoader:createNode('SampleScene.csb')
-- get the root panel (with default name 'Panel_1' in CocoStudio)
local rootPanel = ui:getChildByName('Panel_1')
-- get the button (suppose button_1)
local button = tolua.cast(ccui.Helper:seekWidgetByName(rootPanel, 'button_1'), 'ccui.Button')
button:clearPressedTexture()
button:clearDisabledTexture()

-- another egg-pain thing for UIButton is, if u want the button disabled (grey and without touch response), you have to 
button:setEnabled(false) -- disable touch ...
button:setBright(false) -- show in grey
