### PR TITLE
Lua load chunks from zip supports folder structured lua

### DIFF
--- a/cocos/scripting/lua-bindings/manual/CCLuaStack.cpp
+++ b/cocos/scripting/lua-bindings/manual/CCLuaStack.cpp
@@ -842,6 +842,19 @@ int LuaStack::luaLoadChunksFromZIP(lua_State *L)
                 ssize_t bufferSize = 0;
                 unsigned char *zbuffer = zip->getFileData(filename.c_str(), &bufferSize);
                 if (bufferSize) {
+                    // remove extension
+                    std::size_t found = filename.rfind(".lua");
+                    if (found != std::string::npos)
+                    {
+                        filename.erase(found)
+                    }
+                    // replace path seperator '/' '\' to '.'
+                    for (int i=0; i<filename.size(); i++) {
+                        if (filename[i] == '/' || filename[i] == '\\') {
+                            filename[i] = '.';
+                        }
+                    }
+                    CCLOG("[luaLoadChunksFromZIP] add %s to preload", filename.c_str());
                     if (stack->luaLoadBuffer(L, (char*)zbuffer, (int)bufferSize, filename.c_str()) == 0) {
                         lua_setfield(L, -2, filename.c_str());
                         ++count;

--- a/cocos/scripting/lua-bindings/manual/CCLuaStack.cpp
+++ b/cocos/scripting/lua-bindings/manual/CCLuaStack.cpp
@@ -846,7 +846,7 @@ int LuaStack::luaLoadChunksFromZIP(lua_State *L)
                     std::size_t found = filename.rfind(".lua");
                     if (found != std::string::npos)
                     {
-                        filename.erase(found)
+                        filename.erase(found);
                     }
                     // replace path seperator '/' '\' to '.'
                     for (int i=0; i<filename.size(); i++) {


### PR DESCRIPTION
suppose the lua files was in following structure:

folderA/sample.lua

and package with zip command as normal zip file.
Current luaLoadChunksFromZIP will load it into _G['preload'] as 'folderA/sample.lua', it will fail to be require with require('folderA.sample').

this patch will remove the extension name (.lua & .luac), and replace folder seperator ('/' '\') with '.' .
So 'folderA/sample.lua' is changed to 'folderA.sample'.
