### PR TITLE
issue cocos2d/cocos2d-js #2563 : ActionTimelineData constructor

### DIFF
--- a/cocos/editor-support/cocostudio/ActionTimeline/CCActionTimeline.h
+++ b/cocos/editor-support/cocostudio/ActionTimeline/CCActionTimeline.h
@@ -45,10 +45,10 @@ public:
 
     virtual void setActionTag(int actionTag) { _actionTag = actionTag; }
     virtual int getActionTag() const { return _actionTag; }
-protected:
+CC_CONSTRUCTOR_ACCESS:
     ActionTimelineData();
     virtual bool init(int actionTag);
-
+protected:
     int _actionTag;
 };
 


### PR DESCRIPTION
ActionTimelineData need to use its constructor in jsb code. So i modify the constructor to public
