### PR TITLE
refresh attributes and uniforms in glprogramstate

### DIFF
--- a/cocos/renderer/CCGLProgramState.cpp
+++ b/cocos/renderer/CCGLProgramState.cpp
@@ -375,6 +375,7 @@ void GLProgramState::applyAttributes(bool applyAttribFlags)
 {
     // Don't set attributes if they weren't set
     // Use Case: Auto-batching
+    updateUniformsAndAttributes();
     if(_vertexAttribsFlags) {
         // enable/disable vertex attribs
         if (applyAttribFlags)
@@ -389,6 +390,7 @@ void GLProgramState::applyAttributes(bool applyAttribFlags)
 void GLProgramState::applyUniforms()
 {
     // set uniforms
+    updateUniformsAndAttributes();
     for(auto& uniform : _uniforms) {
         uniform.second.apply();
     }


### PR DESCRIPTION
Fix #9806 
@maltium, Could you please review this pull request? The GL_INVALID_VALUE error is because `GLProgramstate::applyAttributes` and `GLProgramState::applyUniforms` is used separately, and the uniform and attributes is not refreshed yet.
