### PR TITLE
Remove cancel connection when http response 20x.

### DIFF
--- a/cocos/network/HttpAsynConnection.m
+++ b/cocos/network/HttpAsynConnection.m
@@ -78,23 +78,6 @@
     if(responseCode == 200)
         statusString = @"OK";
  
-    /*The individual values of the numeric status codes defined for HTTP/1.1
-    | “200”  ; OK
-    | “201”  ; Created
-    | “202”  ; Accepted
-    | “203”  ; Non-Authoritative Information
-    | “204”  ; No Content
-    | “205”  ; Reset Content
-    | “206”  ; Partial Content
-    */
-    if (responseCode >= 200 && responseCode < 300)
-    {// something went wrong, abort the whole thing
-        
-        [connection cancel];
-        finish = true;
-        return;
-    }
-    
     [responseData setLength:0];
 }
 


### PR DESCRIPTION
Hi.

Almost of http success (code 20x) response has response body(JSON or XML).
The connection cancel is wrong  especially HTTP 200 I think.

Thanks.
