### PR TITLE
fix bug: cut inner timeline action as outer timeline action's length

### DIFF
--- a/cocos/editor-support/cocostudio/ActionTimeline/CCFrame.cpp
+++ b/cocos/editor-support/cocostudio/ActionTimeline/CCFrame.cpp
@@ -508,6 +508,13 @@ void InnerActionFrame::onEnter(Frame *nextFrame, int currentFrameIndex)
         }
     }
     
+    int duration = _timeline->getActionTimeline()->getDuration();
+    int odddiff = duration - _frameIndex - end + start;
+    if(odddiff < 0)
+    {
+        end += odddiff;
+    }
+    
     if (InnerActionType::NoLoopAction == _innerActionType)
     {
         actiontimeline->gotoFrameAndPlay(start, end, false);


### PR DESCRIPTION
fix bug: cut inner timeline action as outer timeline action's length
