### PR TITLE
issue cocos2d/cocos2d-js #2563 : cccomrender  constructor

### DIFF
--- a/cocos/editor-support/cocostudio/CCComRender.h
+++ b/cocos/editor-support/cocostudio/CCComRender.h
@@ -34,7 +34,7 @@ namespace cocostudio {
 class CC_STUDIO_DLL ComRender : public cocos2d::Component
 {
     DECLARE_CLASS_COMPONENT_INFO
-protected:
+CC_CONSTRUCTOR_ACCESS:
     /**
      *  @js ctor
      */


### PR DESCRIPTION
issue cocos2d/cocos2d-js #2563 : cccomrender need to use its constructor in jsb code. So i modify the constructor to public
