### PR TITLE
Fix Sprite3D not rendering 2d child correctly

### DIFF
--- a/cocos/3d/CCSprite3D.cpp
+++ b/cocos/3d/CCSprite3D.cpp
@@ -630,7 +630,7 @@ void Sprite3D::visit(cocos2d::Renderer *renderer, const cocos2d::Mat4 &parentTra
     }
     
     uint32_t flags = processParentFlags(parentTransform, parentFlags);
-    flags &= FLAGS_RENDER_AS_3D;
+    flags |= FLAGS_RENDER_AS_3D;
     
     //
     Director* director = Director::getInstance();

--- a/tests/cpp-tests/Classes/Camera3DTest/Camera3DTest.cpp
+++ b/tests/cpp-tests/Classes/Camera3DTest/Camera3DTest.cpp
@@ -128,6 +128,14 @@ CameraRotationTest::CameraRotationTest()
     _camNode->setPositionZ(Camera::getDefaultCamera()->getPosition3D().z);
     _camControlNode->addChild(_camNode);
 
+    auto sp3d = Sprite3D::create();
+    sp3d->setPosition(s.width/2, s.height/2);
+    addChild(sp3d);
+    
+    auto lship = Label::create();
+    lship->setString("Ship");
+    lship->setPosition(0, 20);
+    sp3d->addChild(lship);
     
     //Billboards
     //Yellow is at the back


### PR DESCRIPTION
1. Fix Sprite3D not cascading 3D flag
2. Update camera test to reflect the change
