### PR TITLE
bug fix in CCAutoreleasePool.cpp

### DIFF
--- a/cocos/base/CCAutoreleasePool.cpp
+++ b/cocos/base/CCAutoreleasePool.cpp
@@ -134,7 +134,8 @@ PoolManager::~PoolManager()
     while (!_releasePoolStack.empty())
     {
         AutoreleasePool* pool = _releasePoolStack.back();
-        
+        _releasePoolStack.pop_back();
+
         delete pool;
     }
 }


### PR DESCRIPTION
pointer to deleted pool need to be popped or it will become dangling and the loop will be endless 
