### PR TITLE
Made SocketIO client compatible with SocketIO version 1.x

### DIFF
--- a/cocos/network/SocketIO.cpp
+++ b/cocos/network/SocketIO.cpp
@@ -606,8 +606,10 @@ void SIOClientImpl::onClose(WebSocket* ws)
         {
             iter->second->receivedDisconnect();
         }
+        _clients.clear();
     }
-
+    _connected = false;
+    
     this->release();
 }
 

--- a/cocos/network/SocketIO.cpp
+++ b/cocos/network/SocketIO.cpp
@@ -135,6 +135,10 @@ public:
 
     std::string getUri();
     std::string getSid();
+    
+    inline bool isConnected() {
+        return _connected;
+    }
 };
 
 
@@ -858,6 +862,10 @@ SIOClient* SocketIO::connect(const std::string& uri, SocketIO::SIODelegate& dele
             socket->addClient(path, c);
 
             socket->connectToEndpoint(path);
+        }
+        
+        if (!socket->isConnected()) {
+            socket->connect();
         }
     }
 

--- a/cocos/network/SocketIO.cpp
+++ b/cocos/network/SocketIO.cpp
@@ -175,8 +175,9 @@ void SIOClientImpl::handshake()
     HttpRequest* request = new (std::nothrow) HttpRequest();
     request->setUrl(pre.str().c_str());
     request->setRequestType(HttpRequest::Type::GET);
-
-    request->setResponseCallback(CC_CALLBACK_2(SIOClientImpl::handshakeResponse, this));
+    request->setResponseCallback([&](HttpClient* client, HttpResponse* response) {
+        handshakeResponse(client, response);
+    });
     request->setTag("handshake");
 
     log("SIOClientImpl::handshake() waiting");

--- a/cocos/network/SocketIO.cpp
+++ b/cocos/network/SocketIO.cpp
@@ -307,12 +307,13 @@ void SIOClientImpl::disconnect()
 
         _ws->close();
     }
+    else {
+        Director::getInstance()->getScheduler()->unscheduleAllForTarget(this);
 
-    Director::getInstance()->getScheduler()->unscheduleAllForTarget(this);
+        _connected = false;
 
-    _connected = false;
-
-    SocketIO::getInstance()->removeSocket(_uri);
+        SocketIO::getInstance()->removeSocket(_uri);
+    }
 }
 
 SIOClientImpl* SIOClientImpl::create(const std::string& host, int port)
@@ -412,7 +413,12 @@ void SIOClientImpl::emit(std::string endpoint, std::string eventname, std::strin
     {
         pre << callbackNumber;
     }
-    pre << "[\"" << eventname << "\"," << args << "]";
+    if (args.length() == 0) {
+        pre << "[\"" << eventname << "\"]";
+    }
+    else {
+        pre << "[\"" << eventname << "\"," << args << "]";
+    }
 
     std::string msg = pre.str();
 
@@ -611,6 +617,9 @@ void SIOClientImpl::onClose(WebSocket* ws)
     }
     _connected = false;
     
+    Director::getInstance()->getScheduler()->unscheduleAllForTarget(this);
+
+    SocketIO::getInstance()->removeSocket(_uri);
     this->release();
 }
 

--- a/cocos/network/SocketIO.cpp
+++ b/cocos/network/SocketIO.cpp
@@ -40,6 +40,47 @@ NS_CC_BEGIN
 namespace network {
 
 //class declarations
+    
+    /*
+    https://github.com/Automattic/engine.io-protocol
+    ENGINE.IO packets:
+    0 open
+    1 close
+    2 ping
+    3 pong
+    4 message
+    5 upgrade
+    6 noop
+    
+    https://github.com/automattic/socket.io-protocol
+    SOCKET.IO packets:
+    Packet#CONNECT (0)
+    Packet#DISCONNECT (1)
+    Packet#EVENT (2)
+    Packet#ACK (3) (callback)
+    Packet#ERROR (4)
+    Packet#BINARY_EVENT (5)
+    Packet#BINARY_ACK (6)
+     */
+    
+enum class EngineIOPacket {
+    EIO_OPEN,
+    EIO_CLOSE,
+    EIO_PING,
+    EIO_PONG,
+    EIO_MESSAGE,
+    EIO_UPGRADE,
+    EIO_NOOP
+};
+enum class SocketIOPacket {
+    SIO_CONNECT,
+    SIO_DISCONNECT,
+    SIO_EVENT,
+    SIO_ACK,
+    SIO_ERROR,
+    SIO_BINARY_EVENT,
+    SIO_BINARY_ACK
+};
 
 /**
  *  @brief The implementation of the socket.io connection
@@ -69,6 +110,12 @@ public:
     virtual void onClose(WebSocket* ws);
     virtual void onError(WebSocket* ws, const WebSocket::ErrorCode& error);
 
+    void handleSocketIOPacket(SocketIOPacket packet, std::string& payload);
+    SIOClient* getClientFromPayload(std::string& payload);
+    std::string getEventNameFromPayload(std::string& payload);
+    int getCallbackNumberFromPayload(std::string& payload);
+
+    void upgrade();
     void connect();
     void disconnect();
     bool init();
@@ -84,9 +131,10 @@ public:
     void disconnectFromEndpoint(const std::string& endpoint);
 
     void send(std::string endpoint, std::string s);
-    void emit(std::string endpoint, std::string eventname, std::string args);
+    void emit(std::string endpoint, std::string eventname, std::string args, int callbackNumber = -1);
 
-
+    std::string getUri();
+    std::string getSid();
 };
 
 
@@ -118,7 +166,7 @@ void SIOClientImpl::handshake()
     log("SIOClientImpl::handshake() called");
 
     std::stringstream pre;
-    pre << "http://" << _uri << "/socket.io/1";
+    pre << "http://" << _uri << "/socket.io/?EIO=3&transport=polling&b64=0";
 
     HttpRequest* request = new (std::nothrow) HttpRequest();
     request->setUrl(pre.str().c_str());
@@ -180,41 +228,46 @@ void SIOClientImpl::handshakeResponse(HttpClient *sender, HttpResponse *response
     size_t pos = 0;
     int heartbeat = 0, timeout = 0;
 
-    pos = res.find(":");
+    pos = res.find("\"sid\":\"");
     if(pos != std::string::npos)
     {
+        res.erase(0, pos+7);
+        pos = res.find("\"");
         sid = res.substr(0, pos);
-        res.erase(0, pos+1);
     }
 
-    pos = res.find(":");
+    pos = res.find("\"pingInterval\":");
     if(pos != std::string::npos)
     {
-        heartbeat = atoi(res.substr(pos+1, res.size()).c_str());
+        res.erase(0, pos+15);
+        pos = res.find(",");
+        heartbeat = atoi(res.substr(0, pos).c_str());
     }
 
-    pos = res.find(":");
+    pos = res.find("\"pingTimeout\":");
     if(pos != std::string::npos)
     {
-        timeout = atoi(res.substr(pos+1, res.size()).c_str());
+        res.erase(0, pos+14);
+        pos = res.find("}");
+        timeout = atoi(res.substr(0, pos).c_str());
     }
 
     _sid = sid;
-    _heartbeat = heartbeat;
-    _timeout = timeout;
+    _heartbeat = heartbeat * 0.001;
+    _timeout = timeout * 0.001;
+
 
     openSocket();
 
     return;
 
 }
-
 void SIOClientImpl::openSocket()
 {
     log("SIOClientImpl::openSocket() called");
 
     std::stringstream s;
-    s << _uri << "/socket.io/1/websocket/" << _sid;
+    s << _uri << "/socket.io/?EIO=3&transport=websocket&b64=0&sid=" << _sid;
 
     _ws = new (std::nothrow) WebSocket();
     if (!_ws->init(*this, s.str()))
@@ -240,9 +293,10 @@ void SIOClientImpl::disconnect()
 {
     if(_ws->getReadyState() == WebSocket::State::OPEN)
     {
-        std::string s = "0::";
+        std::stringstream s;
+        s << (int)EngineIOPacket::EIO_CLOSE;
 
-        _ws->send(s);
+        _ws->send(s.str());
 
         log("Disconnect sent");
 
@@ -280,11 +334,15 @@ void SIOClientImpl::addClient(const std::string& endpoint, SIOClient* client)
 
 void SIOClientImpl::connectToEndpoint(const std::string& endpoint)
 {
-    std::string path = endpoint == "/" ? "" : endpoint;
+    if (endpoint == "/" || !_connected)
+    {
+        return;
+    }
 
-    std::string s = "1::" + path;
+    std::stringstream s;
+    s << (int)EngineIOPacket::EIO_MESSAGE << (int)SocketIOPacket::SIO_CONNECT << endpoint;
 
-    _ws->send(s);
+    _ws->send(s.str());
 }
 
 void SIOClientImpl::disconnectFromEndpoint(const std::string& endpoint)
@@ -302,15 +360,16 @@ void SIOClientImpl::disconnectFromEndpoint(const std::string& endpoint)
     {
         std::string path = endpoint == "/" ? "" : endpoint;
 
-        std::string s = "0::" + path;
+        std::stringstream s;
+        s << (int)EngineIOPacket::EIO_MESSAGE << (int)SocketIOPacket::SIO_DISCONNECT << path;
 
-        _ws->send(s);
+        _ws->send(s.str());
     }
 }
 
 void SIOClientImpl::heartbeat(float dt)
 {
-    std::string s = "2::";
+    std::string s = "2";
 
     _ws->send(s);
 
@@ -324,7 +383,7 @@ void SIOClientImpl::send(std::string endpoint, std::string s)
 
     std::string path = endpoint == "/" ? "" : endpoint;
 
-    pre << "3::" << path << ":" << s;
+    pre << "42" << path << (path == "" ? "" : ",") << "[\"message\",\"" << s << "]";
 
     std::string msg = pre.str();
 
@@ -333,13 +392,22 @@ void SIOClientImpl::send(std::string endpoint, std::string s)
     _ws->send(msg);
 }
 
-void SIOClientImpl::emit(std::string endpoint, std::string eventname, std::string args)
+void SIOClientImpl::emit(std::string endpoint, std::string eventname, std::string args, int callbackNumber)
 {
     std::stringstream pre;
 
     std::string path = endpoint == "/" ? "" : endpoint;
 
-    pre << "5::" << path << ":{\"name\":\"" << eventname << "\",\"args\":" << args << "}";
+    pre << "42" << path;
+    if (path != "")
+    {
+        pre << ",";
+    }
+    if (callbackNumber != -1)
+    {
+        pre << callbackNumber;
+    }
+    pre << "[\"" << eventname << "\"," << args << "]";
 
     std::string msg = pre.str();
 
@@ -352,112 +420,177 @@ void SIOClientImpl::onOpen(WebSocket* ws)
 {
     _connected = true;
 
-    SocketIO::getInstance()->addSocket(_uri, this);
-
-    for (auto iter = _clients.begin(); iter != _clients.end(); ++iter)
-    {
-        iter->second->onOpen();
-    }
+    std::stringstream s;
+    s << (int)EngineIOPacket::EIO_PING << "probe";
+    _ws->send(s.str());
 
     Director::getInstance()->getScheduler()->schedule(CC_SCHEDULE_SELECTOR(SIOClientImpl::heartbeat), this, (_heartbeat * .9f), false);
 
     log("SIOClientImpl::onOpen socket connected!");
 }
 
+
+
 void SIOClientImpl::onMessage(WebSocket* ws, const WebSocket::Data& data)
 {
     log("SIOClientImpl::onMessage received: %s", data.bytes);
 
-    int control = atoi(&data.bytes[0]);
-
-    std::string payload, msgid, endpoint, s_data, eventname;
+    std::string payload;
     payload = data.bytes;
-
-    size_t pos, pos2;
-
-    pos = payload.find(":");
-    if(pos != std::string::npos ) {
-        payload.erase(0, pos+1);
-    }
-
-    pos = payload.find(":");
-    if(pos != std::string::npos ) {
-        msgid = atoi(payload.substr(0, pos+1).c_str());
-    }
-    payload.erase(0, pos+1);
-
-    pos = payload.find(":");
-    if(pos != std::string::npos)
+    
+    EngineIOPacket engineIOPacket = (EngineIOPacket) atoi(payload.substr(0, 1).c_str());
+    switch (engineIOPacket)
     {
-        endpoint = payload.substr(0, pos);
-        payload.erase(0, pos+1);
-    }
-    else
-    {
-        endpoint = payload;
-    }
-
-    if (endpoint == "") endpoint = "/";
-
-
-    s_data = payload;
-    SIOClient *c = nullptr;
-    c = getClient(endpoint);
-    if (c == nullptr) log("SIOClientImpl::onMessage client lookup returned nullptr");
-
-    switch(control)
-    {
-        case 0:
-            log("Received Disconnect Signal for Endpoint: %s\n", endpoint.c_str());
-            if(c) c->receivedDisconnect();
-            disconnectFromEndpoint(endpoint);
-            break;
-        case 1:
-            log("Connected to endpoint: %s \n",endpoint.c_str());
-            if(c) c->onConnect();
-            break;
-        case 2:
-            log("Heartbeat received\n");
-            break;
-        case 3:
-            log("Message received: %s \n", s_data.c_str());
-            if(c) c->getDelegate()->onMessage(c, s_data);
-            break;
-        case 4:
-            log("JSON Message Received: %s \n", s_data.c_str());
-            if(c) c->getDelegate()->onMessage(c, s_data);
-            break;
-        case 5:
-            log("Event Received with data: %s \n", s_data.c_str());
-
-            if(c)
+        case EngineIOPacket::EIO_PONG:
+            //if the string contains "probe", it should send the upgrade packet
+            if (payload.substr(1,5) == "probe")
             {
-                eventname = "";
-                pos = s_data.find(":");
-                pos2 = s_data.find(",");
-                if(pos2 > pos)
-                {
-                    s_data = s_data.substr(pos+1, pos2-pos-1);
-                    std::remove_copy(s_data.begin(), s_data.end(),
-                         std::back_inserter(eventname), '"');
-                }
+                //send upgrade packages
+                upgrade();
+            }
+            break;
+        case EngineIOPacket::EIO_MESSAGE:
+            //a message, parse socketio packet
+            SocketIOPacket socketIOPacket = (SocketIOPacket) atoi(payload.substr(1, 1).c_str());
+            payload.erase(0,2);
+            handleSocketIOPacket(socketIOPacket, payload);
+            break;
+    }
+}
+    
+void SIOClientImpl::upgrade() {
+    std::stringstream s;
+    s << (int)EngineIOPacket::EIO_UPGRADE;
+    _ws->send(s.str());
+}
 
-                c->fireEvent(eventname, payload);
+SIOClient* SIOClientImpl::getClientFromPayload(std::string& payload)
+{
+    std::string endpoint;
+    size_t pos;
+
+    if (payload.find("/") == 0)
+    {
+        pos = payload.find(",");
+        if (pos != std::string::npos)
+        {
+            endpoint = payload.substr(0, pos);
+            payload.erase(0, pos + 1);
+        }
+        else
+        {
+            endpoint = payload.c_str();
+        }
+    }
+    else 
+    {
+        endpoint = "/";
+    }
+
+    return getClient(endpoint);
+}
+
+std::string SIOClientImpl::getEventNameFromPayload(std::string& payload) {
+    std::string eventName = "";
+    size_t pos;
+
+    pos = payload.find("\"");
+    if (pos != std::string::npos)
+    {
+        payload.erase(0, pos + 1);
+        pos = payload.find("\"");
+        if (pos != std::string::npos)
+        {
+            eventName = payload.substr(0, pos);
+            payload.erase(0, pos + 2);
+            if (payload.size() > 0)
+            {
+                payload.erase(payload.size() - 1, 1);
+            }
+        }
+    }
+    return eventName;
+}
+
+int SIOClientImpl::getCallbackNumberFromPayload(std::string& payload)
+{
+    int callbackNumber = -1;
+    size_t pos;
+
+    pos = payload.find("[");
+    if (pos != std::string::npos)
+    {
+        callbackNumber = atoi(payload.substr(0, pos).c_str());
+        payload.erase(0, pos + 1);
+        if (payload.size() > 0) 
+        {
+            payload.erase(payload.size() - 1, 1);
+        }
+    }
+    return callbackNumber;
+}
+
+void SIOClientImpl::handleSocketIOPacket(SocketIOPacket socketIOPacket, std::string& payload)
+{
+    std::string eventName;
+    int callbackNumber;
+    SIOClient* c  = nullptr;
+
+    switch (socketIOPacket) {
+        case SocketIOPacket::SIO_CONNECT:
+            if (payload == "")
+            {
+                //loop through all clients (so that other endpoints also have the same connection with the same _sid) and notify them the connection has been made
+                for (const auto& client : _clients) {
+                    client.second->onOpen();
+                }
+            }
+            c = getClientFromPayload(payload);
+            if (c == nullptr)
+            {
+                log("SIOClientImpl no client found for endpoint: %s", payload.c_str());
+            }
+            else
+            {
+                log("SIOClientImpl connected to endpoint: %s", payload.c_str());
+                c->onConnect();
             }
 
             break;
-        case 6:
-            log("Message Ack\n");
+        case SocketIOPacket::SIO_DISCONNECT:
+            log("SIOClientImpl disconnect received for: %s", payload.c_str());
             break;
-        case 7:
-            log("Error\n");
-            if(c) c->getDelegate()->onError(c, s_data);
+        case SocketIOPacket::SIO_EVENT:
+            log("SIOClientImpl event received with data %s", payload.c_str());
+
+            c = getClientFromPayload(payload);
+            if (c) {
+                eventName = getEventNameFromPayload(payload);
+                if (eventName == "") {
+                    c->getDelegate()->onMessage(c, payload);
+                }
+                else
+                {
+                    c->fireEvent(eventName, payload);
+                }
+            }
+
             break;
-        case 8:
-            log("Noop\n");
+        case SocketIOPacket::SIO_ACK:
+            log("SIOClientImpl event with callback received %s", payload.c_str());
+            c = getClientFromPayload(payload);
+            if (c)
+            {
+                callbackNumber = getCallbackNumberFromPayload(payload);
+                if (callbackNumber != -1)
+                {
+                    c->fireCallback(callbackNumber, payload);
+                }
+            }
+
             break;
     }
-
+    
     return;
 }
 
@@ -478,9 +611,20 @@ void SIOClientImpl::onError(WebSocket* ws, const WebSocket::ErrorCode& error)
 {
 }
 
+std::string SIOClientImpl::getUri()
+{
+    return _uri;
+}
+
+std::string SIOClientImpl::getSid()
+{
+    return _sid;
+}
+
 //begin SIOClient methods
 SIOClient::SIOClient(const std::string& host, int port, const std::string& path, SIOClientImpl* impl, SocketIO::SIODelegate& delegate)
     : _port(port)
+    , _callbackNumber(0)
     , _host(host)
     , _path(path)
     , _connected(false)
@@ -514,15 +658,14 @@ void SIOClient::onConnect()
 
 void SIOClient::send(std::string s)
 {
-    if (_connected)
+    if (_connected) 
     {
         _socket->send(_path, s);
     }
-    else
+    else 
     {
         _delegate->onError(this, "Client not yet connected");
     }
-
 }
 
 void SIOClient::emit(std::string eventname, std::string args)
@@ -531,11 +674,25 @@ void SIOClient::emit(std::string eventname, std::string args)
     {
         _socket->emit(_path, eventname, args);
     }
+    else 
+    {
+        _delegate->onError(this, "Client not yet connected");
+    }
+}
+
+void SIOClient::emit(std::string eventname, std::string args, SIOEvent callback)
+{
+    if (_connected)
+    {
+        _callbackRegistry[_callbackNumber] = callback;
+        _socket->emit(_path, eventname, args, _callbackNumber);
+
+        _callbackNumber++;
+    }
     else
     {
         _delegate->onError(this, "Client not yet connected");
     }
-
 }
 
 void SIOClient::disconnect()
@@ -579,6 +736,24 @@ void SIOClient::fireEvent(const std::string& eventName, const std::string& data)
     }
 
     log("SIOClient::fireEvent no native event with name %s found", eventName.c_str());
+}
+
+void SIOClient::fireCallback(const int callbackNumber, const std::string& data)
+{
+    log("SIOClient::fireCallback called with callbackNumber: %d and data: %s", callbackNumber, data.c_str());
+
+    if (_callbackRegistry[callbackNumber])
+    {
+        SIOEvent e = _callbackRegistry[callbackNumber];
+
+        e(this, data);
+
+        _callbackRegistry.erase(callbackNumber);
+
+        return;
+    }
+
+    log("SIOClient::fireCallback no callback with callbackNumber: %d found", callbackNumber);
 }
 
 //begin SocketIO methods
@@ -650,6 +825,8 @@ SIOClient* SocketIO::connect(const std::string& uri, SocketIO::SIODelegate& dele
     std::stringstream s;
     s << host << ":" << port;
 
+    log("Connect to host: %s\n", s.str().c_str());
+
     SIOClientImpl* socket = nullptr;
     SIOClient *c = nullptr;
 
@@ -659,6 +836,9 @@ SIOClient* SocketIO::connect(const std::string& uri, SocketIO::SIODelegate& dele
     {
         //create a new socket, new client, connect
         socket = SIOClientImpl::create(host, port);
+
+        //register socket
+        SocketIO::getInstance()->addSocket(socket->getUri(), socket);
 
         c = new (std::nothrow) SIOClient(host, port, path, socket, delegate);
 

--- a/cocos/network/SocketIO.h
+++ b/cocos/network/SocketIO.h
@@ -40,6 +40,12 @@ emitting an event to be handled by the server, argument json formatting is up to
 
     client->emit("eventname", "[{\"arg\":\"value\"}]");
 
+emitting an event with direct callback to be handled by the server, argument json formatting is up to you
+
+    client->emit("eventname", "[{\"arg\":\"value\"}]",  [](network::SIOClient* c, const std::string& data) {
+        
+    });
+
 registering an event callback, target should be a member function in a subclass of SIODelegate
 CC_CALLBACK_2 is used to wrap the callback with std::bind and store as an SIOEvent
 
@@ -127,6 +133,7 @@ private:
 typedef std::function<void(SIOClient*, const std::string&)> SIOEvent;
 //c++11 map to callbacks
 typedef std::unordered_map<std::string, SIOEvent> EventRegistry;
+typedef std::unordered_map<int, SIOEvent> CallbackRegistry;
 
 /**
      *  @brief A single connection to a socket.io endpoint
@@ -135,7 +142,7 @@ class CC_DLL SIOClient
     : public cocos2d::Ref
 {
 private:
-    int _port;
+    int _port, _callbackNumber;
     std::string _host, _path, _tag;
     bool _connected;
     SIOClientImpl* _socket;
@@ -143,8 +150,10 @@ private:
     SocketIO::SIODelegate* _delegate;
 
     EventRegistry _eventRegistry;
+    CallbackRegistry _callbackRegistry;
 
     void fireEvent(const std::string& eventName, const std::string& data);
+    void fireCallback(const int callbackNumber, const std::string& data);
 
     void onOpen();
     void onConnect();
@@ -170,11 +179,15 @@ public:
      */
     void send(std::string s);
     /**
-     *  @brief The delegate class to process socket.io events
+     *  @brief Emits an event to the socket.io server
      */
     void emit(std::string eventname, std::string args);
     /**
-     *  @brief Used to register a socket.io event callback
+     *  @brief Emits an event to the socket.io server with a callback method
+     */
+    void emit(std::string eventname, std::string args, SIOEvent e);
+    /**
+     *  @brief Used to register a socket.io event
      *         Event argument should be passed using CC_CALLBACK2(&Base::function, this)
      */
     void on(const std::string& eventName, SIOEvent e);


### PR DESCRIPTION
For our indie gamedev studio Toothpaste & Bubblegum we wanted to use the newest socket.io version, but we discovered the 1.x version has a different protocol and didn't work with the client shipped with cocos2d-x. That's why we have rewritten the client for socketio version 1.x. We have tested the client on socket.io version 1.2.1.
