### PR TITLE
Fixed inconsistent time-scale in Httpclient.

### DIFF
--- a/cocos/network/HttpClient-android.cpp
+++ b/cocos/network/HttpClient-android.cpp
@@ -577,7 +577,7 @@ private:
         if(nullptr == instnace)
             return false;
 
-        setReadAndConnectTimeout(instnace->getTimeoutForRead(), instnace->getTimeoutForConnect());
+        setReadAndConnectTimeout(instnace->getTimeoutForRead() * 1000, instnace->getTimeoutForConnect() * 1000);
 
         setVerifySSL();
 
@@ -851,8 +851,8 @@ void HttpClient::setSSLVerification(const std::string& caFile)
 }
 
 HttpClient::HttpClient()
-: _timeoutForConnect(30*1000)
-, _timeoutForRead(60*1000)
+: _timeoutForConnect(30)
+, _timeoutForRead(60)
 {
 }
 


### PR DESCRIPTION
If I use "cocos2d::network::HttpClient::getInstance()->setTimeoutForRead( 60 )" (or setTimeoutForConnect),
it means 60 milli-seconds on Android platforms, while other platforms says 60 seconds.
