### PR TITLE
Fix memory leak

### DIFF
--- a/cocos/editor-support/cocostudio/FlatBuffersSerialize.cpp
+++ b/cocos/editor-support/cocostudio/FlatBuffersSerialize.cpp
@@ -150,8 +150,8 @@ std::string FlatBuffersSerialize::serializeFlatBuffersWithXMLFile(const std::str
         return ".csd file doesn not exists ";
     }
     
-    ssize_t size;
-    std::string content =(char*)FileUtils::getInstance()->getFileData(inFullpath, "r", &size);
+    std::string content = FileUtils::getInstance()->getStringFromFile(inFullpath);
+    FileUtils::getInstance()->purgeCachedEntries();
     
     // xml parse
     tinyxml2::XMLDocument* document = new tinyxml2::XMLDocument();
@@ -1124,8 +1124,8 @@ FlatBufferBuilder* FlatBuffersSerialize::createFlatBuffersWithXMLFileForSimulato
 //        CCLOG(".csd file doesn not exists ");
     }
     
-    ssize_t size;
-    std::string content =(char*)FileUtils::getInstance()->getFileData(inFullpath, "r", &size);
+    std::string content = FileUtils::getInstance()->getStringFromFile(inFullpath);
+    FileUtils::getInstance()->purgeCachedEntries();
     
     // xml parse
     tinyxml2::XMLDocument* document = new tinyxml2::XMLDocument();

--- a/cocos/editor-support/cocostudio/FlatBuffersSerialize.cpp
+++ b/cocos/editor-support/cocostudio/FlatBuffersSerialize.cpp
@@ -151,7 +151,6 @@ std::string FlatBuffersSerialize::serializeFlatBuffersWithXMLFile(const std::str
     }
     
     std::string content = FileUtils::getInstance()->getStringFromFile(inFullpath);
-    FileUtils::getInstance()->purgeCachedEntries();
     
     // xml parse
     tinyxml2::XMLDocument* document = new tinyxml2::XMLDocument();
@@ -1125,7 +1124,6 @@ FlatBufferBuilder* FlatBuffersSerialize::createFlatBuffersWithXMLFileForSimulato
     }
     
     std::string content = FileUtils::getInstance()->getStringFromFile(inFullpath);
-    FileUtils::getInstance()->purgeCachedEntries();
     
     // xml parse
     tinyxml2::XMLDocument* document = new tinyxml2::XMLDocument();


### PR DESCRIPTION
1. Fixes memory leak when calling FileUtils::getInstance()->getFileData().
2. Calling FileUtils::getInstance()->getStringFromFile() instead of the deprecated method FileUtils::getInstance()->getFileData().
