### PR TITLE
Dynamic change the root node's size when changing the resolusion of the simulator

### DIFF
--- a/tools/simulator/libsimulator/lib/runtime/RuntimeCCSImpl.cpp
+++ b/tools/simulator/libsimulator/lib/runtime/RuntimeCCSImpl.cpp
@@ -2,6 +2,7 @@
 #include "RuntimeCCSImpl.h"
 #include "ConfigParser.h"
 #include "cocostudio/CocoStudio.h"
+#include "ui/UIHelper.h"
 
 ////////////////////////////////////////
 
@@ -53,6 +54,10 @@ void RuntimeCCSImpl::loadCSDProject(const std::string& file)
     
     if (node)
     {
+        Size frameSize = Director::getInstance()->getVisibleSize();
+        node->setContentSize(frameSize);
+        ui::Helper::doLayout(node);
+
         if (Director::getInstance()->getRunningScene())
         {
             auto scene = Scene::create();
@@ -78,6 +83,10 @@ void RuntimeCCSImpl::loadCSBProject(const std::string& file)
     auto node = CSLoader::getInstance()->createNode(file);
     if (node)
     {
+        Size frameSize = Director::getInstance()->getVisibleSize();
+        node->setContentSize(frameSize);
+        ui::Helper::doLayout(node);
+
         if (Director::getInstance()->getRunningScene())
         {
             auto scene = Scene::create();


### PR DESCRIPTION
When reading csd/csb and the simulator's resolution is changed, change the root node's size to fit the simulator windows size. It will make sure the layout component feature works and simulator will show its effect.
