### PR TITLE
Added support for Universal App device orientation change

### DIFF
--- a/cocos/platform/win8.1-universal/Cocos2dRenderer.cpp
+++ b/cocos/platform/win8.1-universal/Cocos2dRenderer.cpp
@@ -36,13 +36,14 @@ using namespace Windows::Graphics::Display;
 USING_NS_CC;
 
 
-Cocos2dRenderer::Cocos2dRenderer(int width, int height, float dpi, CoreDispatcher^ dispatcher, Panel^ panel)
+Cocos2dRenderer::Cocos2dRenderer(int width, int height, float dpi, DisplayOrientations orientation, CoreDispatcher^ dispatcher, Panel^ panel)
     : m_app(nullptr)
     , m_width(width)
     , m_height(height)
     , m_dpi(dpi)
     , m_dispatcher(dispatcher)
     , m_panel(panel)
+    , m_orientation(orientation)
 {
     m_app = new AppDelegate();
 }
@@ -62,7 +63,7 @@ void Cocos2dRenderer::Resume()
         GLViewImpl* glview = GLViewImpl::create("Test Cpp");
         glview->setDispatcher(m_dispatcher.Get());
         glview->setPanel(m_panel.Get());
-        glview->Create(static_cast<float>(m_width), static_cast<float>(m_height), m_dpi, DisplayOrientations::Landscape);
+        glview->Create(static_cast<float>(m_width), static_cast<float>(m_height), m_dpi, m_orientation);
         director->setOpenGLView(glview);
         CCApplication::getInstance()->run();
     }
@@ -104,8 +105,14 @@ void Cocos2dRenderer::DeviceLost()
 
 
 
-void Cocos2dRenderer::Draw(GLsizei width, GLsizei height, float dpi)
+void Cocos2dRenderer::Draw(GLsizei width, GLsizei height, float dpi, DisplayOrientations orientation)
 {
+    if (orientation != m_orientation)
+    {
+        m_orientation = orientation;
+        GLViewImpl::sharedOpenGLView()->UpdateOrientation(orientation);
+    }
+
     if (width != m_width || height != m_height)
     {
         m_width = width;

--- a/cocos/platform/win8.1-universal/Cocos2dRenderer.h
+++ b/cocos/platform/win8.1-universal/Cocos2dRenderer.h
@@ -29,9 +29,11 @@ namespace cocos2d
     class Cocos2dRenderer
     {
     public:
-        Cocos2dRenderer( int width, int height, float dpi, Windows::UI::Core::CoreDispatcher^ dispathcer, Windows::UI::Xaml::Controls::Panel^ panel);
+        Cocos2dRenderer(int width, int height, float dpi, 
+            Windows::Graphics::Display::DisplayOrientations orientation, 
+            Windows::UI::Core::CoreDispatcher^ dispathcer, Windows::UI::Xaml::Controls::Panel^ panel);
         ~Cocos2dRenderer();
-        void Draw(GLsizei width, GLsizei height, float dpi);
+        void Draw(GLsizei width, GLsizei height, float dpi, Windows::Graphics::Display::DisplayOrientations orientation);
         void QueuePointerEvent(PointerEventType type, Windows::UI::Core::PointerEventArgs^ args);
         void QueueKeyBoardEvent(Cocos2dKeyEvent type, Windows::UI::Core::KeyEventArgs^ e);
         void Pause();
@@ -48,5 +50,6 @@ namespace cocos2d
         AppDelegate* m_app;
         Platform::Agile<Windows::UI::Core::CoreDispatcher> m_dispatcher;
         Platform::Agile<Windows::UI::Xaml::Controls::Panel> m_panel;
+        Windows::Graphics::Display::DisplayOrientations m_orientation;
     };
 }

--- a/cocos/platform/win8.1-universal/OpenGLESPage.xaml.h
+++ b/cocos/platform/win8.1-universal/OpenGLESPage.xaml.h
@@ -68,8 +68,11 @@ namespace cocos2d
         void OnPointerMoved(Platform::Object^ sender, Windows::UI::Core::PointerEventArgs^ e);
         void OnPointerReleased(Platform::Object^ sender, Windows::UI::Core::PointerEventArgs^ e);
 
+        void OnOrientationChanged(Windows::Graphics::Display::DisplayInformation^ sender, Platform::Object^ args);
+
         float m_dpi;
         bool m_deviceLost;
+        Windows::Graphics::Display::DisplayOrientations m_orientation;
 
     };
 }

--- a/cocos/platform/winrt/CCDevice.cpp
+++ b/cocos/platform/winrt/CCDevice.cpp
@@ -120,7 +120,7 @@ void Device::setAccelerometerEnabled(bool isEnabled)
                 
             case DisplayOrientations::LandscapeFlipped:
  				acc.x = reading->AccelerationY;
-				acc.y = reading->AccelerationX;
+				acc.y = -reading->AccelerationX;
                     break;
               
             default:
@@ -148,8 +148,8 @@ void Device::setAccelerometerEnabled(bool isEnabled)
                 break;
 
             case DisplayOrientations::LandscapeFlipped:
-                acc.x = -reading->AccelerationY;
-                acc.y = reading->AccelerationX;
+                acc.x = -reading->AccelerationX;
+                acc.y = -reading->AccelerationY;
                 break;
 
             default:

--- a/templates/cpp-template-default/proj.win8.1-universal/App.Shared/Cocos2dRenderer.cpp
+++ b/templates/cpp-template-default/proj.win8.1-universal/App.Shared/Cocos2dRenderer.cpp
@@ -36,13 +36,14 @@ using namespace Windows::Graphics::Display;
 USING_NS_CC;
 
 
-Cocos2dRenderer::Cocos2dRenderer(int width, int height, float dpi, CoreDispatcher^ dispatcher, Panel^ panel)
+Cocos2dRenderer::Cocos2dRenderer(int width, int height, float dpi, DisplayOrientations orientation, CoreDispatcher^ dispatcher, Panel^ panel)
     : m_app(nullptr)
     , m_width(width)
     , m_height(height)
     , m_dpi(dpi)
     , m_dispatcher(dispatcher)
     , m_panel(panel)
+    , m_orientation(orientation)
 {
     m_app = new AppDelegate();
 }
@@ -62,7 +63,7 @@ void Cocos2dRenderer::Resume()
         GLViewImpl* glview = GLViewImpl::create("Test Cpp");
         glview->setDispatcher(m_dispatcher.Get());
         glview->setPanel(m_panel.Get());
-        glview->Create(static_cast<float>(m_width), static_cast<float>(m_height), m_dpi, DisplayOrientations::Landscape);
+        glview->Create(static_cast<float>(m_width), static_cast<float>(m_height), m_dpi, m_orientation);
         director->setOpenGLView(glview);
         CCApplication::getInstance()->run();
     }
@@ -104,8 +105,14 @@ void Cocos2dRenderer::DeviceLost()
 
 
 
-void Cocos2dRenderer::Draw(GLsizei width, GLsizei height, float dpi)
+void Cocos2dRenderer::Draw(GLsizei width, GLsizei height, float dpi, DisplayOrientations orientation)
 {
+    if (orientation != m_orientation)
+    {
+        m_orientation = orientation;
+        GLViewImpl::sharedOpenGLView()->UpdateOrientation(orientation);
+    }
+
     if (width != m_width || height != m_height)
     {
         m_width = width;

--- a/templates/cpp-template-default/proj.win8.1-universal/App.Shared/Cocos2dRenderer.h
+++ b/templates/cpp-template-default/proj.win8.1-universal/App.Shared/Cocos2dRenderer.h
@@ -29,9 +29,11 @@ namespace cocos2d
     class Cocos2dRenderer
     {
     public:
-        Cocos2dRenderer( int width, int height, float dpi, Windows::UI::Core::CoreDispatcher^ dispathcer, Windows::UI::Xaml::Controls::Panel^ panel);
+        Cocos2dRenderer(int width, int height, float dpi, 
+            Windows::Graphics::Display::DisplayOrientations orientation, 
+            Windows::UI::Core::CoreDispatcher^ dispathcer, Windows::UI::Xaml::Controls::Panel^ panel);
         ~Cocos2dRenderer();
-        void Draw(GLsizei width, GLsizei height, float dpi);
+        void Draw(GLsizei width, GLsizei height, float dpi, Windows::Graphics::Display::DisplayOrientations orientation);
         void QueuePointerEvent(PointerEventType type, Windows::UI::Core::PointerEventArgs^ args);
         void QueueKeyBoardEvent(Cocos2dKeyEvent type, Windows::UI::Core::KeyEventArgs^ e);
         void Pause();
@@ -48,5 +50,6 @@ namespace cocos2d
         AppDelegate* m_app;
         Platform::Agile<Windows::UI::Core::CoreDispatcher> m_dispatcher;
         Platform::Agile<Windows::UI::Xaml::Controls::Panel> m_panel;
+        Windows::Graphics::Display::DisplayOrientations m_orientation;
     };
 }

--- a/templates/cpp-template-default/proj.win8.1-universal/App.Shared/OpenGLESPage.xaml.h
+++ b/templates/cpp-template-default/proj.win8.1-universal/App.Shared/OpenGLESPage.xaml.h
@@ -68,8 +68,11 @@ namespace cocos2d
         void OnPointerMoved(Platform::Object^ sender, Windows::UI::Core::PointerEventArgs^ e);
         void OnPointerReleased(Platform::Object^ sender, Windows::UI::Core::PointerEventArgs^ e);
 
+        void OnOrientationChanged(Windows::Graphics::Display::DisplayInformation^ sender, Platform::Object^ args);
+
         float m_dpi;
         bool m_deviceLost;
+        Windows::Graphics::Display::DisplayOrientations m_orientation;
 
     };
 }


### PR DESCRIPTION
This pull request updates the device orientation when orientation changes (Windows Phone 8.1 and Windows Store 8.1 apps). Gravity is also fixed for Windows Store Apps in Landscape flipped orientation.
