### PR TITLE
RotateBy and RotateTo add new create method for 3d action

### DIFF
--- a/cocos/2d/CCActionInterval.cpp
+++ b/cocos/2d/CCActionInterval.cpp
@@ -745,6 +745,15 @@ RotateTo* RotateTo::create(float duration, float dstAngleX, float dstAngleY)
     return rotateTo;
 }
 
+RotateTo* RotateTo::create(float duration, float dstAngleX, float dstAngleY, float dstAngleZ)
+{
+    RotateTo* rotateTo = new (std::nothrow) RotateTo();
+    rotateTo->initWithDuration(duration, dstAngleX, dstAngleY, dstAngleZ);
+    rotateTo->autorelease();
+    
+    return rotateTo;
+}
+
 RotateTo* RotateTo::create(float duration, const Vec3& dstAngle3D)
 {
     RotateTo* rotateTo = new (std::nothrow) RotateTo();
@@ -765,6 +774,21 @@ bool RotateTo::initWithDuration(float duration, float dstAngleX, float dstAngleY
     {
         _dstAngle.x = dstAngleX;
         _dstAngle.y = dstAngleY;
+        
+        return true;
+    }
+    
+    return false;
+}
+
+bool RotateTo::initWithDuration(float duration, float dstAngleX, float dstAngleY, float dstAngleZ)
+{
+    if (ActionInterval::initWithDuration(duration))
+    {
+        _dstAngle.x = dstAngleX;
+        _dstAngle.y = dstAngleY;
+        _dstAngle.z = dstAngleZ;
+        _is3D = true;
         
         return true;
     }
@@ -898,6 +922,15 @@ RotateBy* RotateBy::create(float duration, float deltaAngleX, float deltaAngleY)
     return rotateBy;
 }
 
+RotateBy* RotateBy::create(float duration, float deltaAngleX, float deltaAngleY, float deltaAngleZ)
+{
+    RotateBy *rotateBy = new (std::nothrow) RotateBy();
+    rotateBy->initWithDuration(duration, deltaAngleX, deltaAngleY, deltaAngleZ);
+    rotateBy->autorelease();
+    
+    return rotateBy;
+}
+
 RotateBy* RotateBy::create(float duration, const Vec3& deltaAngle3D)
 {
     RotateBy *rotateBy = new (std::nothrow) RotateBy();
@@ -932,6 +965,20 @@ bool RotateBy::initWithDuration(float duration, float deltaAngleX, float deltaAn
         return true;
     }
     
+    return false;
+}
+
+bool RotateBy::initWithDuration(float duration, float deltaAngleX, float deltaAngleY, float deltaAngleZ)
+{
+    if (ActionInterval::initWithDuration(duration))
+    {
+        _deltaAngle.x = deltaAngleX;
+        _deltaAngle.y = deltaAngleY;
+        _deltaAngle.z = deltaAngleZ;
+        _is3D = true;
+        return true;
+    }
+
     return false;
 }
 

--- a/cocos/2d/CCActionInterval.h
+++ b/cocos/2d/CCActionInterval.h
@@ -347,6 +347,7 @@ public:
     static RotateTo* create(float duration, float dstAngle);
 
     /** creates the action with 3D rotation angles */
+    static RotateTo* create(float duration, float dstAngle3D_X, float dstAngle3D_Y, float dstAngle3D_Z);
     static RotateTo* create(float duration, const Vec3& dstAngle3D);
 
     //
@@ -363,6 +364,7 @@ CC_CONSTRUCTOR_ACCESS:
 
     /** initializes the action */
     bool initWithDuration(float duration, float dstAngleX, float dstAngleY);
+    bool initWithDuration(float duration, float dstAngle3D_X, float dstAngle3D_Y, float dstAngle3D_Z);
     bool initWithDuration(float duration, const Vec3& dstAngle3D);
 
     /** calculates the start and diff angles */
@@ -387,6 +389,7 @@ public:
     static RotateBy* create(float duration, float deltaAngle);
     /** @warning The physics body contained in Node doesn't support rotate with different x and y angle. */
     static RotateBy* create(float duration, float deltaAngleZ_X, float deltaAngleZ_Y);
+    static RotateBy* create(float duration, float deltaAngle3D_X, float deltaAngle3D_Y, float deltaAngle3D_Z);
     static RotateBy* create(float duration, const Vec3& deltaAngle3D);
 
     //
@@ -405,6 +408,7 @@ CC_CONSTRUCTOR_ACCESS:
     bool initWithDuration(float duration, float deltaAngle);
     /** @warning The physics body contained in Node doesn't support rotate with different x and y angle. */
     bool initWithDuration(float duration, float deltaAngleZ_X, float deltaAngleZ_Y);
+    bool initWithDuration(float duration, float deltaAngle3D_X, float deltaAngle3D_Y, float deltaAngle3D_Z);
     bool initWithDuration(float duration, const Vec3& deltaAngle3D);
     
 protected:


### PR DESCRIPTION
Because "create(float duration, const Vec3& deltaAngle3D)" and "create(float duration, float dstAngle)" have same arguments, in lua if use RotateBy/To 3d action, it will cause error in luabinding method "luaval_to_number". Add new create method to avoid this.
