### PR TITLE
Fix warnings

### DIFF
--- a/cocos/3d/CCFrustum.h
+++ b/cocos/3d/CCFrustum.h
@@ -41,7 +41,7 @@ public:
     /**
      * Constructor & Destructor.
      */
-    Frustum(): _initialized(false), _clipZ(true){}
+    Frustum(): _clipZ(true), _initialized(false) {}
     ~Frustum(){}
 
     /**

--- a/cocos/base/CCConsole.cpp
+++ b/cocos/base/CCConsole.cpp
@@ -202,10 +202,10 @@ static const char* inet_ntop(int af, const void* src, char* dst, int cnt)
 }
 #endif
 
+#if (CC_TARGET_PLATFORM == CC_PLATFORM_WIN32)
 static const int CCLOG_STRING_TAG = 1;
 void SendLogToWindow(const char *log)
 {
-#if (CC_TARGET_PLATFORM == CC_PLATFORM_WIN32)
     // Send data as a message
     COPYDATASTRUCT myCDS;
     myCDS.dwData = CCLOG_STRING_TAG;
@@ -219,8 +219,12 @@ void SendLogToWindow(const char *log)
             (WPARAM)(HWND)hwnd,
             (LPARAM)(LPVOID)&myCDS);
     }
-#endif
 }
+#elseif
+void SendLogToWindow(const char *log)
+{
+}
+#endif
 
 //
 // Free functions to log

--- a/cocos/base/CCConsole.cpp
+++ b/cocos/base/CCConsole.cpp
@@ -220,7 +220,7 @@ void SendLogToWindow(const char *log)
             (LPARAM)(LPVOID)&myCDS);
     }
 }
-#elseif
+#else
 void SendLogToWindow(const char *log)
 {
 }

--- a/cocos/physics/CCPhysicsBody.cpp
+++ b/cocos/physics/CCPhysicsBody.cpp
@@ -68,11 +68,11 @@ PhysicsBody::PhysicsBody()
 , _linearDamping(0.0f)
 , _angularDamping(0.0f)
 , _tag(0)
-, _rotationOffset(0)
+, _positionInitDirty(true)
 , _recordedPosition(Vec2::ZERO)
+, _rotationOffset(0)
 , _recordedRotation(0.0f)
 , _recordedAngle(0.0)
-, _positionInitDirty(true)
 {
 }
 

--- a/cocos/physics/CCPhysicsJoint.cpp
+++ b/cocos/physics/CCPhysicsJoint.cpp
@@ -40,9 +40,9 @@ PhysicsJoint::PhysicsJoint()
 , _enable(false)
 , _collisionEnable(true)
 , _destoryMark(false)
-, _initDirty(true)
 , _tag(0)
 , _maxForce(PHYSICS_INFINITY)
+, _initDirty(true)
 {
 
 }


### PR DESCRIPTION
Fix some warnings in Xcode:
- Fix "field 'XXX' will be initialized after 'YYY'" warning in Xcode by reorder initialization sentences.
- Fix warning: CCLOG_STRING_TAG not used by enclosing it in platform ifdef. Provide empty SendLogToWindow implementation by default.
