### PR TITLE
make CCTMXObjectGroup::getGroupName const

### DIFF
--- a/cocos/2d/CCTMXObjectGroup.h
+++ b/cocos/2d/CCTMXObjectGroup.h
@@ -55,7 +55,7 @@ public:
      */
     virtual ~TMXObjectGroup();
 
-    inline const std::string& getGroupName(){ return _groupName; }
+    inline const std::string& getGroupName() const { return _groupName; }
     inline void setGroupName(const std::string& groupName){ _groupName = groupName; }
 
     /** return the value for the specific property name */


### PR DESCRIPTION
Hi,

I came across a build error here with an instance of CCTMXObjectGroup that I wanted to make const.
All of the other getters are marked const and I just couldn't figure out why only this method is left non-const.

Hope this helps :)
