### PR TITLE
fix random int overflow

### DIFF
--- a/cocos/base/ccRandom.h
+++ b/cocos/base/ccRandom.h
@@ -44,7 +44,7 @@ public:
 
     template<typename T>
     static inline T random_int(T min, T max) {
-        std::uniform_int_distribution<> dist(min, max);
+        std::uniform_int_distribution<T> dist(min, max);
         auto &mt = RandomHelper::getEngine();
         return dist(mt);
     }
@@ -57,7 +57,7 @@ private:
 */
 template<typename T>
 inline T random(T min, T max) {
-    return RandomHelper::random_int(min, max);
+    return RandomHelper::random_int<T>(min, max);
 }
 
 template<>


### PR DESCRIPTION
before:

```
random(2147483648, 2147483649): -2147483648
```

after:

```
random(2147483648, 2147483649): 2147483649
```

code:

```
int64_t min = int64_t(INT_MAX) + 1;
int64_t max = int64_t(INT_MAX) + 2;
auto rand = cocos2d::random(min, max);
CCLOG("random(%lld, %lld): %lld", min, max, rand);
```
