### PR TITLE
Fixed some compiler warnings

### DIFF
--- a/cocos/2d/CCFastTMXLayer.cpp
+++ b/cocos/2d/CCFastTMXLayer.cpp
@@ -154,7 +154,7 @@ void TMXLayer::draw(Renderer *renderer, const Mat4& transform, uint32_t flags)
         _dirty = false;
     }
     
-    if(_renderCommands.size() < _primitives.size())
+    if(_renderCommands.size() < static_cast<size_t>(_primitives.size()))
     {
         _renderCommands.resize(_primitives.size());
     }

--- a/cocos/2d/CCGrid.cpp
+++ b/cocos/2d/CCGrid.cpp
@@ -317,10 +317,10 @@ void Grid3D::beforeBlit()
 {
     if(_needDepthTestForBlit)
     {
-        _oldDepthTestValue = glIsEnabled(GL_DEPTH_TEST);
+        _oldDepthTestValue = glIsEnabled(GL_DEPTH_TEST) != GL_FALSE;
         GLboolean depthWriteMask;
         glGetBooleanv(GL_DEPTH_WRITEMASK, &depthWriteMask);
-        _oldDepthWriteValue = depthWriteMask;
+		_oldDepthWriteValue = depthWriteMask != GL_FALSE;
         CHECK_GL_ERROR_DEBUG();
         glEnable(GL_DEPTH_TEST);
         glDepthMask(true);

--- a/cocos/2d/CCNode.cpp
+++ b/cocos/2d/CCNode.cpp
@@ -1280,7 +1280,7 @@ uint32_t Node::processParentFlags(const Mat4& parentTransform, uint32_t parentFl
 bool Node::isVisitableByVisitingCamera() const
 {
     auto camera = Camera::getVisitingCamera();
-    bool visibleByCamera = camera ? (unsigned short)camera->getCameraFlag() & _cameraMask : true;
+    bool visibleByCamera = camera ? ((unsigned short)camera->getCameraFlag() & _cameraMask) != 0 : true;
     return visibleByCamera;
 }
 

--- a/cocos/3d/CCBundle3D.cpp
+++ b/cocos/3d/CCBundle3D.cpp
@@ -1791,7 +1791,7 @@ NodeData* Bundle3D::parseNodesRecursivelyBinary(bool& skeleton)
                 CCLOG("warning: Failed to read nodedata: uvMapping '%s'.", _path.c_str());
                 return nullptr;
             }
-            for( int j = 0 ;j < uvMapping ; j++ )
+            for(int j = 0 ; j < uvMapping ; j++)
             {
                 unsigned int textureIndexSize=0;
                 if (_binaryReader.read(&textureIndexSize, 4, 1) != 1)
@@ -1799,7 +1799,7 @@ NodeData* Bundle3D::parseNodesRecursivelyBinary(bool& skeleton)
                     CCLOG("warning: Failed to read meshdata: attribCount '%s'.", _path.c_str());
                     return nullptr;
                 }
-                for(int k =0; k < textureIndexSize ; k++ )
+                for(unsigned int k = 0; k < textureIndexSize ; k++)
                 {
                     unsigned int index=0;
                     if (_binaryReader.read(&index, 4, 1) != 1)

--- a/cocos/3d/CCObjLoader.cpp
+++ b/cocos/3d/CCObjLoader.cpp
@@ -161,7 +161,7 @@ static ssize_t updateVertex( std::map<vertex_index, ssize_t>& vertexCache, std::
         return it->second;
     }
     
-    assert(in_positions.size() > (3*i.v_idx+2));
+    assert(in_positions.size() > static_cast<size_t>(3*i.v_idx+2));
     
     positions.push_back(in_positions[3*i.v_idx+0]);
     positions.push_back(in_positions[3*i.v_idx+1]);

--- a/cocos/3d/CCSkeleton3D.cpp
+++ b/cocos/3d/CCSkeleton3D.cpp
@@ -275,7 +275,7 @@ ssize_t Skeleton3D::getBoneCount() const
 //get bone
 Bone3D* Skeleton3D::getBoneByIndex(unsigned int index) const
 {
-    if (index < _bones.size())
+    if (index < static_cast<unsigned int>(_bones.size()))
         return _bones.at(index);
     
     return nullptr;

--- a/cocos/audio/AudioEngine.cpp
+++ b/cocos/audio/AudioEngine.cpp
@@ -54,7 +54,7 @@ const float AudioEngine::TIME_UNKNOWN = -1.0f;
 std::unordered_map<std::string,std::list<int>> AudioEngine::_audioPathIDMap;
 //profileName,ProfileHelper
 std::unordered_map<std::string, AudioEngine::ProfileHelper> AudioEngine::_audioPathProfileHelperMap;
-int AudioEngine::_maxInstances = MAX_AUDIOINSTANCES;
+unsigned int AudioEngine::_maxInstances = MAX_AUDIOINSTANCES;
 AudioEngine::ProfileHelper* AudioEngine::_defaultProfileHelper = nullptr;
 std::unordered_map<int, AudioEngine::AudioInfo> AudioEngine::_audioIDInfoMap;
 AudioEngineImpl* AudioEngine::_audioEngineImpl = nullptr;

--- a/cocos/audio/include/AudioEngine.h
+++ b/cocos/audio/include/AudioEngine.h
@@ -262,7 +262,7 @@ protected:
     //profileName,ProfileHelper
     static std::unordered_map<std::string, ProfileHelper> _audioPathProfileHelperMap;
     
-    static int _maxInstances;
+    static unsigned int _maxInstances;
     
     static ProfileHelper* _defaultProfileHelper;
     

--- a/cocos/base/CCEventType.h
+++ b/cocos/base/CCEventType.h
@@ -36,7 +36,7 @@
 // The renderer[android:GLSurfaceView.Renderer  WP8:Cocos2dRenderer] was recreated.
 // This message is used for reloading resources before renderer is recreated on Android/WP8.
 // This message is posted in cocos/platform/android/javaactivity.cpp and cocos\platform\wp8-xaml\cpp\Cocos2dRenderer.cpp.
-#define EVENT_RENDERER_RECREATED "event_renderer_recreated"
+#define EVENT_RENDERER_RECREATED    "event_renderer_recreated"
 
 // The application will come to background.
 // This message is used for doing something before coming to background, such as save RenderTexture.

--- a/cocos/base/allocator/CCAllocatorStrategyFixedBlock.h
+++ b/cocos/base/allocator/CCAllocatorStrategyFixedBlock.h
@@ -249,7 +249,7 @@ protected:
         _allocated += _pageSize;
         size_t aligned_size = AllocatorBase::nextPow2BlockSize(block_size);
         uint8_t* block = (uint8_t*)p;
-        for (int i = 0; i < _pageSize; ++i, block += aligned_size)
+        for (unsigned int i = 0; i < _pageSize; ++i, block += aligned_size)
         {
             push_front(block);
         }

--- a/cocos/editor-support/cocostudio/ActionTimeline/CCActionTimelineCache.cpp
+++ b/cocos/editor-support/cocostudio/ActionTimeline/CCActionTimelineCache.cpp
@@ -566,14 +566,14 @@ Frame* ActionTimelineCache::loadVisibleFrameWithFlatBuffers(const flatbuffers::B
 {
     VisibleFrame* frame = VisibleFrame::create();
     
-    bool visible = flatbuffers->value();
+    bool visible = flatbuffers->value() != 0;
     
     frame->setVisible(visible);
     
     int frameIndex = flatbuffers->frameIndex();
     frame->setFrameIndex(frameIndex);
     
-    bool tween = flatbuffers->tween();
+    bool tween = flatbuffers->tween() != 0;
     frame->setTween(tween);
     
     return frame;
@@ -590,7 +590,7 @@ Frame* ActionTimelineCache::loadPositionFrameWithFlatBuffers(const flatbuffers::
     int frameIndex = flatbuffers->frameIndex();
     frame->setFrameIndex(frameIndex);
     
-    bool tween = flatbuffers->tween();
+    bool tween = flatbuffers->tween() != 0;
     frame->setTween(tween);
     
     return frame;
@@ -608,7 +608,7 @@ Frame* ActionTimelineCache::loadScaleFrameWithFlatBuffers(const flatbuffers::Sca
     int frameIndex = flatbuffers->frameIndex();
     frame->setFrameIndex(frameIndex);
     
-    bool tween = flatbuffers->tween();
+    bool tween = flatbuffers->tween() != 0;
     frame->setTween(tween);
     
     return frame;
@@ -626,7 +626,7 @@ Frame* ActionTimelineCache::loadRotationSkewFrameWithFlatBuffers(const flatbuffe
     int frameIndex = flatbuffers->frameIndex();
     frame->setFrameIndex(frameIndex);
     
-    bool tween = flatbuffers->tween();
+    bool tween = flatbuffers->tween() != 0;
     frame->setTween(tween);
     
     return frame;
@@ -643,7 +643,7 @@ Frame* ActionTimelineCache::loadColorFrameWithFlatBuffers(const flatbuffers::Col
     int frameIndex = flatbuffers->frameIndex();
     frame->setFrameIndex(frameIndex);
     
-    bool tween = flatbuffers->tween();
+    bool tween = flatbuffers->tween() != 0;
     frame->setTween(tween);
     
     return frame;
@@ -700,7 +700,7 @@ Frame* ActionTimelineCache::loadTextureFrameWithFlatBuffers(const flatbuffers::T
     int frameIndex = flatbuffers->frameIndex();
     frame->setFrameIndex(frameIndex);
     
-    bool tween = flatbuffers->tween();
+    bool tween = flatbuffers->tween() != 0;
     frame->setTween(tween);
     
     return frame;
@@ -720,7 +720,7 @@ Frame* ActionTimelineCache::loadEventFrameWithFlatBuffers(const flatbuffers::Eve
     int frameIndex = flatbuffers->frameIndex();
     frame->setFrameIndex(frameIndex);
     
-    bool tween = flatbuffers->tween();
+    bool tween = flatbuffers->tween() != 0;
     frame->setTween(tween);
     
     return frame;
@@ -737,7 +737,7 @@ Frame* ActionTimelineCache::loadAlphaFrameWithFlatBuffers(const flatbuffers::Int
     int frameIndex = flatbuffers->frameIndex();
     frame->setFrameIndex(frameIndex);
     
-    bool tween = flatbuffers->tween();
+    bool tween = flatbuffers->tween() != 0;
     frame->setTween(tween);
     
     return frame;
@@ -754,7 +754,7 @@ Frame* ActionTimelineCache::loadAlphaFrameWithFlatBuffers(const flatbuffers::Int
         int frameIndex = flatbuffers->frameIndex();
         frame->setFrameIndex(frameIndex);
         
-        bool tween = flatbuffers->tween();
+        bool tween = flatbuffers->tween() != 0;
         frame->setTween(tween);
         
         return frame;
@@ -771,7 +771,7 @@ Frame* ActionTimelineCache::loadZOrderFrameWithFlatBuffers(const flatbuffers::In
     int frameIndex = flatbuffers->frameIndex();
     frame->setFrameIndex(frameIndex);
     
-    bool tween = flatbuffers->tween();
+    bool tween = flatbuffers->tween() != 0;
     frame->setTween(tween);
     
     return frame;
@@ -790,7 +790,7 @@ Frame* ActionTimelineCache::loadInnerActionFrameWithFlatBuffers(const flatbuffer
     int frameIndex = flatbuffers->frameIndex();
     frame->setFrameIndex(frameIndex);
     
-    bool tween = flatbuffers->tween();
+    bool tween = flatbuffers->tween() != 0;
     frame->setTween(tween);
     
     frame->setInnerActionType(innerActionType);

--- a/cocos/editor-support/cocostudio/ActionTimeline/CCFrame.cpp
+++ b/cocos/editor-support/cocostudio/ActionTimeline/CCFrame.cpp
@@ -525,7 +525,7 @@ void InnerActionFrame::onEnter(Frame *nextFrame, int currentFrameIndex)
     }
 }
 
-void InnerActionFrame::setStartFrameIndex(int frameIndex) throw()
+void InnerActionFrame::setStartFrameIndex(int frameIndex)
 {
     if(_enterWithName)
     {
@@ -536,7 +536,7 @@ void InnerActionFrame::setStartFrameIndex(int frameIndex) throw()
 }
 
 
-void InnerActionFrame::setEndFrameIndex(int frameIndex) throw()
+void InnerActionFrame::setEndFrameIndex(int frameIndex)
 {
     if(_enterWithName)
     {
@@ -546,7 +546,7 @@ void InnerActionFrame::setEndFrameIndex(int frameIndex) throw()
     _endFrameIndex = frameIndex;
 }
 
-void InnerActionFrame::setAnimationName(const std::string& animationName) throw()
+void InnerActionFrame::setAnimationName(const std::string& animationName)
 {
     if(!_enterWithName)
     {

--- a/cocos/editor-support/cocostudio/ActionTimeline/CCFrame.h
+++ b/cocos/editor-support/cocostudio/ActionTimeline/CCFrame.h
@@ -268,13 +268,13 @@ public:
     
     inline void setEnterWithName(bool isEnterWithName) { _enterWithName = isEnterWithName;}
     
-    void setStartFrameIndex(int frameIndex)  throw();
+	void setStartFrameIndex(int frameIndex);
     inline int  getStartFrameIndex() const { return _startFrameIndex; }
 
-    void setEndFrameIndex(int frameIndex)  throw();
+	void setEndFrameIndex(int frameIndex);
     inline int  getEndFrameIndex() const { return _endFrameIndex; }
     
-    void setAnimationName(const std::string& animationNamed)  throw();
+	void setAnimationName(const std::string& animationNamed);
     
     inline void setSingleFrameIndex(int frameIndex) { _singleFrameIndex = frameIndex;}
     inline int  getSingleFrameIndex() const { return _singleFrameIndex;}

--- a/cocos/editor-support/cocostudio/WidgetReader/ButtonReader/ButtonReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/ButtonReader/ButtonReader.cpp
@@ -544,7 +544,7 @@ namespace cocostudio
         Button* button = static_cast<Button*>(node);
         auto options = (ButtonOptions*)buttonOptions;
         
-        bool scale9Enabled = options->scale9Enabled();
+        bool scale9Enabled = options->scale9Enabled() != 0;
         button->setScale9Enabled(scale9Enabled);
         
         bool normalFileExist = false;
@@ -777,7 +777,7 @@ namespace cocostudio
             }
         }
         
-        bool displaystate = options->displaystate();
+        bool displaystate = options->displaystate() != 0;
         button->setBright(displaystate);
         button->setEnabled(displaystate);
         

--- a/cocos/editor-support/cocostudio/WidgetReader/CheckBoxReader/CheckBoxReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/CheckBoxReader/CheckBoxReader.cpp
@@ -753,10 +753,10 @@ namespace cocostudio
             checkBox->addChild(label);
         }
         
-        bool selectedstate = options->selectedState();
+        bool selectedstate = options->selectedState() != 0;
         checkBox->setSelected(selectedstate);
         
-        bool displaystate = options->displaystate();
+        bool displaystate = options->displaystate() != 0;
         checkBox->setBright(displaystate);
         checkBox->setEnabled(displaystate);
         

--- a/cocos/editor-support/cocostudio/WidgetReader/ComAudioReader/ComAudioReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/ComAudioReader/ComAudioReader.cpp
@@ -181,11 +181,10 @@ namespace cocostudio
                 break;
         }
         
-        bool loop = options->loop();
+        bool loop = options->loop() != 0;
         audio->setLoop(loop);
         
         audio->setName(options->name()->c_str());
-        audio->setLoop(options->loop());
         
         return component;
     }

--- a/cocos/editor-support/cocostudio/WidgetReader/ImageViewReader/ImageViewReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/ImageViewReader/ImageViewReader.cpp
@@ -355,7 +355,7 @@ namespace cocostudio
             imageView->addChild(label);
         }
         
-        bool scale9Enabled = options->scale9Enabled();
+        bool scale9Enabled = options->scale9Enabled() != 0;
         imageView->setScale9Enabled(scale9Enabled);
         
         auto widgetReader = WidgetReader::getInstance();

--- a/cocos/editor-support/cocostudio/WidgetReader/LayoutReader/LayoutReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/LayoutReader/LayoutReader.cpp
@@ -570,10 +570,10 @@ namespace cocostudio
         Layout* panel = static_cast<Layout*>(node);
         auto options = (PanelOptions*)layoutOptions;
         
-        bool clipEnabled = options->clipEnabled();
+        bool clipEnabled = options->clipEnabled() != 0;
         panel->setClippingEnabled(clipEnabled);
         
-        bool backGroundScale9Enabled = options->backGroundScale9Enabled();
+        bool backGroundScale9Enabled = options->backGroundScale9Enabled() != 0;
         panel->setBackGroundImageScale9Enabled(backGroundScale9Enabled);
         
         

--- a/cocos/editor-support/cocostudio/WidgetReader/ListViewReader/ListViewReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/ListViewReader/ListViewReader.cpp
@@ -398,10 +398,10 @@ namespace cocostudio
         ListView* listView = static_cast<ListView*>(node);
         auto options = (ListViewOptions*)listViewOptions;
         
-        bool clipEnabled = options->clipEnabled();
+        bool clipEnabled = options->clipEnabled() != 0;
         listView->setClippingEnabled(clipEnabled);
         
-        bool backGroundScale9Enabled = options->backGroundScale9Enabled();
+        bool backGroundScale9Enabled = options->backGroundScale9Enabled() != 0;
         listView->setBackGroundImageScale9Enabled(backGroundScale9Enabled);
         
         
@@ -506,7 +506,7 @@ namespace cocostudio
         listView->setInnerContainerSize(innerSize);
         //         int direction = options->direction();
         //         listView->setDirection((ScrollView::Direction)direction);
-        bool bounceEnabled = options->bounceEnabled();
+        bool bounceEnabled = options->bounceEnabled() != 0;
         listView->setBounceEnabled(bounceEnabled);
         
         //         int gravityValue = options->gravity();

--- a/cocos/editor-support/cocostudio/WidgetReader/NodeReader/NodeReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/NodeReader/NodeReader.cpp
@@ -472,7 +472,7 @@ namespace cocostudio
         int zorder		    = options->zOrder();
         int tag             = options->tag();
         int actionTag       = options->actionTag();
-        bool visible        = options->visible();
+        bool visible        = options->visible() != 0;
         float w             = options->size()->width();
         float h             = options->size()->height();
         int alpha           = options->alpha();
@@ -521,16 +521,16 @@ namespace cocostudio
 
         auto layoutComponent = ui::LayoutComponent::bindLayoutComponent(node);
 
-        bool positionXPercentEnabled = layoutComponentTable->positionXPercentEnabled();
-        bool positionYPercentEnabled = layoutComponentTable->positionYPercentEnabled();
+        bool positionXPercentEnabled = layoutComponentTable->positionXPercentEnabled() != 0;
+        bool positionYPercentEnabled = layoutComponentTable->positionYPercentEnabled() != 0;
         float positionXPercent = layoutComponentTable->positionXPercent();
         float positionYPercent = layoutComponentTable->positionYPercent();
-        bool sizeXPercentEnable = layoutComponentTable->sizeXPercentEnable();
-        bool sizeYPercentEnable = layoutComponentTable->sizeYPercentEnable();
+        bool sizeXPercentEnable = layoutComponentTable->sizeXPercentEnable() != 0;
+        bool sizeYPercentEnable = layoutComponentTable->sizeYPercentEnable() != 0;
         float sizeXPercent = layoutComponentTable->sizeXPercent();
         float sizeYPercent = layoutComponentTable->sizeYPercent();
-        bool stretchHorizontalEnabled = layoutComponentTable->stretchHorizontalEnabled();
-        bool stretchVerticalEnabled = layoutComponentTable->stretchVerticalEnabled();
+        bool stretchHorizontalEnabled = layoutComponentTable->stretchHorizontalEnabled() != 0;
+        bool stretchVerticalEnabled = layoutComponentTable->stretchVerticalEnabled() != 0;
         std::string horizontalEdge = layoutComponentTable->horizontalEdge()->c_str();
         std::string verticalEdge = layoutComponentTable->verticalEdge()->c_str();
         float leftMargin = layoutComponentTable->leftMargin();

--- a/cocos/editor-support/cocostudio/WidgetReader/PageViewReader/PageViewReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/PageViewReader/PageViewReader.cpp
@@ -311,10 +311,10 @@ namespace cocostudio
         PageView* pageView = static_cast<PageView*>(node);
         auto options = (PageViewOptions*)pageViewOptions;
         
-        bool clipEnabled = options->clipEnabled();
+        bool clipEnabled = options->clipEnabled() != 0;
         pageView->setClippingEnabled(clipEnabled);
         
-        bool backGroundScale9Enabled = options->backGroundScale9Enabled();
+        bool backGroundScale9Enabled = options->backGroundScale9Enabled() != 0;
         pageView->setBackGroundImageScale9Enabled(backGroundScale9Enabled);
         
         

--- a/cocos/editor-support/cocostudio/WidgetReader/ScrollViewReader/ScrollViewReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/ScrollViewReader/ScrollViewReader.cpp
@@ -397,10 +397,10 @@ namespace cocostudio
         ScrollView* scrollView = static_cast<ScrollView*>(node);
         auto options = (ScrollViewOptions*)scrollViewOptions;
         
-        bool clipEnabled = options->clipEnabled();
+        bool clipEnabled = options->clipEnabled() != 0;
         scrollView->setClippingEnabled(clipEnabled);
         
-        bool backGroundScale9Enabled = options->backGroundScale9Enabled();
+        bool backGroundScale9Enabled = options->backGroundScale9Enabled() != 0;
         scrollView->setBackGroundImageScale9Enabled(backGroundScale9Enabled);
         
         
@@ -505,7 +505,7 @@ namespace cocostudio
         scrollView->setInnerContainerSize(innerSize);
         int direction = options->direction();
         scrollView->setDirection((ScrollView::Direction)direction);
-        bool bounceEnabled = options->bounceEnabled();
+        bool bounceEnabled = options->bounceEnabled() != 0;
         scrollView->setBounceEnabled(bounceEnabled);
         
         

--- a/cocos/editor-support/cocostudio/WidgetReader/SliderReader/SliderReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/SliderReader/SliderReader.cpp
@@ -787,7 +787,7 @@ namespace cocostudio
             slider->addChild(label);
         }
         
-        bool displaystate = options->displaystate();
+        bool displaystate = options->displaystate() != 0;
         slider->setBright(displaystate);
         slider->setEnabled(displaystate);
         

--- a/cocos/editor-support/cocostudio/WidgetReader/SpriteReader/SpriteReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/SpriteReader/SpriteReader.cpp
@@ -224,8 +224,8 @@ namespace cocostudio
             sprite->setColor(Color3B(red, green, blue));
         }
         
-        bool flipX   = nodeOptions->flipX();
-        bool flipY   = nodeOptions->flipY();
+        bool flipX   = nodeOptions->flipX() != 0;
+        bool flipY   = nodeOptions->flipY() != 0;
         
         if(flipX != false)
             sprite->setFlippedX(flipX);

--- a/cocos/editor-support/cocostudio/WidgetReader/TextFieldReader/TextFieldReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/TextFieldReader/TextFieldReader.cpp
@@ -291,7 +291,7 @@ namespace cocostudio
         std::string fontName = options->fontName()->c_str();
         textField->setFontName(fontName);
         
-        bool maxLengthEnabled = options->maxLengthEnabled();
+        bool maxLengthEnabled = options->maxLengthEnabled() != 0;
         textField->setMaxLengthEnabled(maxLengthEnabled);
         
         if (maxLengthEnabled)
@@ -299,7 +299,7 @@ namespace cocostudio
             int maxLength = options->maxLength();
             textField->setMaxLength(maxLength);
         }
-        bool passwordEnabled = options->passwordEnabled();
+        bool passwordEnabled = options->passwordEnabled() != 0;
         textField->setPasswordEnabled(passwordEnabled);
         if (passwordEnabled)
         {

--- a/cocos/editor-support/cocostudio/WidgetReader/TextReader/TextReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/TextReader/TextReader.cpp
@@ -292,7 +292,7 @@ namespace cocostudio
         Text* label = static_cast<Text*>(node);
         auto options = (TextOptions*)textOptions;
         
-        bool touchScaleEnabled = options->touchScaleEnable();
+        bool touchScaleEnabled = options->touchScaleEnable() != 0;
         label->setTouchScaleChangeEnabled(touchScaleEnabled);
         
         std::string text = options->text()->c_str();
@@ -348,7 +348,7 @@ namespace cocostudio
         
         label->setUnifySizeEnabled(false);
         
-        bool IsCustomSize = options->isCustomSize();
+        bool IsCustomSize = options->isCustomSize() != 0;
         label->ignoreContentAdaptWithSize(!IsCustomSize);
         
         auto widgetOptions = options->widgetOptions();

--- a/cocos/editor-support/cocostudio/WidgetReader/WidgetReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/WidgetReader.cpp
@@ -772,7 +772,7 @@ namespace cocostudio
         widget->setAnchorPoint(Vec2::ZERO);
         
         widget->setUnifySizeEnabled(true);
-        bool ignoreSize = options->ignoreSize();
+        bool ignoreSize = options->ignoreSize() != 0;
         widget->ignoreContentAdaptWithSize(ignoreSize);
 
         widget->setUnifySizeEnabled(false);
@@ -788,7 +788,7 @@ namespace cocostudio
         widget->setActionTag(actionTag);
         widget->setUserObject(timeline::ActionTimelineData::create(actionTag));
         
-        bool touchEnabled = options->touchEnabled();
+        bool touchEnabled = options->touchEnabled() != 0;
         widget->setTouchEnabled(touchEnabled);
         
         std::string name = options->name()->c_str();
@@ -807,7 +807,7 @@ namespace cocostudio
         float rotationSkewY = options->rotationSkew()->rotationSkewY();
         widget->setRotationSkewY(rotationSkewY);
         
-        bool visible = options->visible();
+        bool visible = options->visible() != 0;
         widget->setVisible(visible);
         
         int zOrder = options->zOrder();
@@ -824,9 +824,9 @@ namespace cocostudio
         Vec2 anchorPoint(f_anchorPoint->scaleX(), f_anchorPoint->scaleY());
         widget->setAnchorPoint(anchorPoint);
         
-        bool flippedX = options->flipX();
+        bool flippedX = options->flipX() != 0;
         widget->setFlippedX(flippedX);
-        bool flippedY = options->flipY();
+        bool flippedY = options->flipY() != 0;
         widget->setFlippedY(flippedY);
         
         std::string callbackType = options->callBackType()->c_str();
@@ -844,16 +844,16 @@ namespace cocostudio
 
         auto layoutComponent = ui::LayoutComponent::bindLayoutComponent(node);
 
-        bool positionXPercentEnabled = layoutComponentTable->positionXPercentEnabled();
-        bool positionYPercentEnabled = layoutComponentTable->positionYPercentEnabled();
+        bool positionXPercentEnabled = layoutComponentTable->positionXPercentEnabled() != 0;
+        bool positionYPercentEnabled = layoutComponentTable->positionYPercentEnabled() != 0;
         float positionXPercent = layoutComponentTable->positionXPercent();
         float positionYPercent = layoutComponentTable->positionYPercent();
-        bool sizeXPercentEnable = layoutComponentTable->sizeXPercentEnable();
-        bool sizeYPercentEnable = layoutComponentTable->sizeYPercentEnable();
+        bool sizeXPercentEnable = layoutComponentTable->sizeXPercentEnable() != 0;
+        bool sizeYPercentEnable = layoutComponentTable->sizeYPercentEnable() != 0;
         float sizeXPercent = layoutComponentTable->sizeXPercent();
         float sizeYPercent = layoutComponentTable->sizeYPercent();
-        bool stretchHorizontalEnabled = layoutComponentTable->stretchHorizontalEnabled();
-        bool stretchVerticalEnabled = layoutComponentTable->stretchVerticalEnabled();
+        bool stretchHorizontalEnabled = layoutComponentTable->stretchHorizontalEnabled() != 0;
+        bool stretchVerticalEnabled = layoutComponentTable->stretchVerticalEnabled() != 0;
         std::string horizontalEdge = layoutComponentTable->horizontalEdge()->c_str();
         std::string verticalEdge = layoutComponentTable->verticalEdge()->c_str();
         float leftMargin = layoutComponentTable->leftMargin();

--- a/cocos/platform/CCFileUtils.cpp
+++ b/cocos/platform/CCFileUtils.cpp
@@ -1103,7 +1103,7 @@ bool FileUtils::createDirectory(const std::string& path)
     if ((GetFileAttributesA(path.c_str())) == INVALID_FILE_ATTRIBUTES)
     {
 		subpath = "";
-		for (int i = 0; i < dirs.size(); ++i)
+		for (unsigned int i = 0; i < dirs.size(); ++i)
 		{
 			subpath += dirs[i];
 			if (!isDirectoryExist(subpath))

--- a/cocos/renderer/ccGLStateCache.cpp
+++ b/cocos/renderer/ccGLStateCache.cpp
@@ -222,8 +222,8 @@ void enableVertexAttribs(uint32_t flags)
     // hardcoded!
     for(int i=0; i < MAX_ATTRIBUTES; i++) {
         unsigned int bit = 1 << i;
-        bool enabled = flags & bit;
-        bool enabledBefore = s_attributeFlags & bit;
+        bool enabled = (flags & bit) != 0;
+        bool enabledBefore = (s_attributeFlags & bit) != 0;
         if(enabled != enabledBefore) {
             if( enabled )
                 glEnableVertexAttribArray(i);

--- a/extensions/assets-manager/Downloader.cpp
+++ b/extensions/assets-manager/Downloader.cpp
@@ -52,7 +52,7 @@ size_t bufferWriteFunc(void *ptr, size_t size, size_t nmemb, void *userdata)
     Downloader::StreamData *streamBuffer = (Downloader::StreamData *)userdata;
     size_t written = size * nmemb;
     // Avoid pointer overflow
-    if (streamBuffer->offset + written <= streamBuffer->total)
+	if (streamBuffer->offset + written <= static_cast<size_t>(streamBuffer->total))
     {
         memcpy(streamBuffer->buffer + streamBuffer->offset, ptr, written);
         streamBuffer->offset += written;

--- a/extensions/assets-manager/Manifest.cpp
+++ b/extensions/assets-manager/Manifest.cpp
@@ -144,7 +144,7 @@ bool Manifest::versionEquals(const Manifest *b) const
             return false;
         
         // Check groups version
-        for (int i = 0; i < _groups.size(); ++i) {
+        for (unsigned int i = 0; i < _groups.size(); ++i) {
             std::string gid =_groups[i];
             // Check group name
             if (gid != bGroups[i])


### PR DESCRIPTION
As a response to #9564, i started for fix some of the many warnings where i was confident it would not impact functionality.
- signed / unsigned mismatches
- using int as bool
- Removed throw() from CCFrame.h, why is explained here: http://www.gotw.ca/publications/mill22.htm
