### PR TITLE
Fix the bug in ui::LoadingBar->setProgress()

### DIFF
--- a/cocos/ui/UILoadingBar.cpp
+++ b/cocos/ui/UILoadingBar.cpp
@@ -194,7 +194,7 @@ void LoadingBar::loadTexture(const std::string& texture,TextureResType texType)
     barRendererScaleChangedWithSize();
     updateContentSizeWithTextureSize(_barRendererTextureSize);
     _barRendererAdaptDirty = true;
-    _percent = 100;
+    setPercent(_percent);
 }
 
 void LoadingBar::setScale9Enabled(bool enabled)
@@ -251,7 +251,7 @@ void LoadingBar::setPercent(float percent)
     {
         percent = 0;
     }
-    if (_percent == percent)
+    if (_percent == percent && !_barRendererAdaptDirty)
     {
         return;
     }

--- a/cocos/ui/UILoadingBar.cpp
+++ b/cocos/ui/UILoadingBar.cpp
@@ -194,6 +194,7 @@ void LoadingBar::loadTexture(const std::string& texture,TextureResType texType)
     barRendererScaleChangedWithSize();
     updateContentSizeWithTextureSize(_barRendererTextureSize);
     _barRendererAdaptDirty = true;
+    _percent = 100;
 }
 
 void LoadingBar::setScale9Enabled(bool enabled)

--- a/cocos/ui/UILoadingBar.cpp
+++ b/cocos/ui/UILoadingBar.cpp
@@ -194,7 +194,26 @@ void LoadingBar::loadTexture(const std::string& texture,TextureResType texType)
     barRendererScaleChangedWithSize();
     updateContentSizeWithTextureSize(_barRendererTextureSize);
     _barRendererAdaptDirty = true;
-    setPercent(_percent);
+
+    do
+    {
+        if (_percent == 100.0f)
+            break;
+
+        float res = _percent / 100.0f;
+
+        if (_scale9Enabled)
+        {
+            setScale9Scale();
+        }
+        else
+        {
+            Sprite* spriteRenderer = _barRenderer->getSprite();
+            Rect rect = spriteRenderer->getTextureRect();
+            rect.size.width = _barRendererTextureSize.width * res;
+            spriteRenderer->setTextureRect(rect, spriteRenderer->isTextureRectRotated(), rect.size);
+        }
+    } while (0);
 }
 
 void LoadingBar::setScale9Enabled(bool enabled)
@@ -251,7 +270,7 @@ void LoadingBar::setPercent(float percent)
     {
         percent = 0;
     }
-    if (_percent == percent && !_barRendererAdaptDirty)
+    if (_percent == percent)
     {
         return;
     }


### PR DESCRIPTION
Think about this code:

```
auto bar = ui::LoadingBar::create("1.png");  //create the bar
bar->setPercent(80); //set to 80%
bar->loadTexture("2.jpg"); //change the bar's background to another image, and it is reverted to 100%
bar->setPercent(80); //BUG: This will not work, because the same percent, it is returnd in setPercent()
```

@andyque 
Please have a look.
