### PR TITLE
Specify default capacity for sprite batch node

### DIFF
--- a/cocos/2d/CCSpriteBatchNode.cpp
+++ b/cocos/2d/CCSpriteBatchNode.cpp
@@ -67,7 +67,7 @@ SpriteBatchNode* SpriteBatchNode::create(const std::string& fileImage, ssize_t c
 /*
 * init with Texture2D
 */
-bool SpriteBatchNode::initWithTexture(Texture2D *tex, ssize_t capacity)
+bool SpriteBatchNode::initWithTexture(Texture2D *tex, ssize_t capacity/* = DEFAULT_CAPACITY*/)
 {
     CCASSERT(capacity>=0, "Capacity must be >= 0");
     
@@ -105,7 +105,7 @@ bool SpriteBatchNode::init()
 /*
 * init with FileImage
 */
-bool SpriteBatchNode::initWithFile(const std::string& fileImage, ssize_t capacity)
+bool SpriteBatchNode::initWithFile(const std::string& fileImage, ssize_t capacity/* = DEFAULT_CAPACITY*/)
 {
     Texture2D *texture2D = Director::getInstance()->getTextureCache()->addImage(fileImage);
     return initWithTexture(texture2D, capacity);

--- a/cocos/2d/CCSpriteBatchNode.h
+++ b/cocos/2d/CCSpriteBatchNode.h
@@ -67,12 +67,12 @@ class CC_DLL SpriteBatchNode : public Node, public TextureProtocol
 
 public:
     /** creates a SpriteBatchNode with a texture2d and capacity of children.
-     The capacity will be increased in 33% in runtime if it run out of space.
+     The capacity will be increased in 33% in runtime if it runs out of space.
      */
     static SpriteBatchNode* createWithTexture(Texture2D* tex, ssize_t capacity = DEFAULT_CAPACITY);
 
     /** creates a SpriteBatchNode with a file image (.png, .jpeg, .pvr, etc) and capacity of children.
-     The capacity will be increased in 33% in runtime if it run out of space.
+     The capacity will be increased in 33% in runtime if it runs out of space.
      The file will be loaded using the TextureMgr.
      */
     static SpriteBatchNode* create(const std::string& fileImage, ssize_t capacity = DEFAULT_CAPACITY);
@@ -168,11 +168,11 @@ CC_CONSTRUCTOR_ACCESS:
     virtual ~SpriteBatchNode();
     
     /** initializes a SpriteBatchNode with a texture2d and capacity of children.
-     The capacity will be increased in 33% in runtime if it run out of space.
+     The capacity will be increased in 33% in runtime if it runs out of space.
      */
     bool initWithTexture(Texture2D *tex, ssize_t capacity = DEFAULT_CAPACITY);
     /** initializes a SpriteBatchNode with a file image (.png, .jpeg, .pvr, etc) and a capacity of children.
-     The capacity will be increased in 33% in runtime if it run out of space.
+     The capacity will be increased in 33% in runtime if it runs out of space.
      The file will be loaded using the TextureMgr.
      * @js init
      * @lua init

--- a/cocos/2d/CCSpriteBatchNode.h
+++ b/cocos/2d/CCSpriteBatchNode.h
@@ -170,14 +170,14 @@ CC_CONSTRUCTOR_ACCESS:
     /** initializes a SpriteBatchNode with a texture2d and capacity of children.
      The capacity will be increased in 33% in runtime if it run out of space.
      */
-    bool initWithTexture(Texture2D *tex, ssize_t capacity);
+    bool initWithTexture(Texture2D *tex, ssize_t capacity = DEFAULT_CAPACITY);
     /** initializes a SpriteBatchNode with a file image (.png, .jpeg, .pvr, etc) and a capacity of children.
      The capacity will be increased in 33% in runtime if it run out of space.
      The file will be loaded using the TextureMgr.
      * @js init
      * @lua init
      */
-    bool initWithFile(const std::string& fileImage, ssize_t capacity);
+    bool initWithFile(const std::string& fileImage, ssize_t capacity = DEFAULT_CAPACITY);
     bool init();
     
 protected:


### PR DESCRIPTION
I think the application code will look better if we have these default arguments.
With the current code, we need to specify the default capacity like so : 

``` cpp
spriteBatchNode->initWithFile("someFile", 29);
```

even though 29 is the default capacity ---
we can't even access it from derived classes since `CCSpriteBatchNode::DEFAULT_CAPACITY` is private.
