### PR TITLE
FIX BUG:  animationinfos lost after actiontimeline clone

### DIFF
--- a/cocos/editor-support/cocostudio/ActionTimeline/CCActionTimeline.cpp
+++ b/cocos/editor-support/cocostudio/ActionTimeline/CCActionTimeline.cpp
@@ -181,7 +181,11 @@ ActionTimeline* ActionTimeline::clone() const
             newAction->addTimeline(newTimeline);
         }
     }
-
+    
+    for( auto info : _animationInfos)
+    {
+        newAction->addAnimationInfo(info.second);
+    }
     return newAction;
 }
 


### PR DESCRIPTION
FIX animationfio lost after actiontimeline clone
