### PR TITLE
Fixes bug when set new string with \n to CCLabelBMFont may make more new line.

### DIFF
--- a/cocos2dx/label_nodes/CCLabelBMFont.cpp
+++ b/cocos2dx/label_nodes/CCLabelBMFont.cpp
@@ -617,6 +617,8 @@ void CCLabelBMFont::createFontChars()
         {
             nextFontPositionX = 0;
             nextFontPositionY -= m_pConfiguration->m_nCommonHeight;
+            if (getChildByTag(i)) // CCLabelBMFont::updateLabel() assumes tags for '\n' don't have a char sprite
+                removeChildByTag(i);
             continue;
         }
         


### PR DESCRIPTION
`CCLabelBMFont::updateLabel()` assumes tags for '\n' don't have sprites.

But the code for `CCLabelBMFont::createFontChars()` does not keeps that promise. This may cause when set new string with `\n` to label may cause 2 new line. Test case:

``` C++
CCLabelBMFont * label =  CCLabelBMFont::create("sssssssssssss", "my.fnt", 20);
label->setString("a\n\b");
```
