### PR TITLE
Don't clear depth between queues

### DIFF
--- a/cocos/3d/CCBillBoard.cpp
+++ b/cocos/3d/CCBillBoard.cpp
@@ -193,19 +193,9 @@ bool BillBoard::calculateBillbaordTransform()
         Quaternion rotationQuaternion;
         this->getNodeToWorldTransform().getRotation(&rotationQuaternion);
         
-        
         Mat4 rotationMatrix;
         rotationMatrix.setIdentity();
-        ///FIXME: maybe should keep rotation along z axis
-//        if (rotationQuaternion.z > 0)
-//        {
-//            //rotate z only, keep it
-//            // fetch the rotation angle of z
-//            float rotationZ = atan2(2*(rotationQuaternion.w*rotationQuaternion.z + rotationQuaternion.x*rotationQuaternion.y),
-//                                    (1 - 2* (rotationQuaternion.y*rotationQuaternion.y + rotationQuaternion.z *rotationQuaternion.z)));
-//            rotationMatrix.rotateZ(rotationZ);
-//        }
-        
+
         Vec3 upAxis = Vec3(rotationMatrix.m[4],rotationMatrix.m[5],rotationMatrix.m[6]);
         Vec3 x, y;
         camWorldMat.transformVector(upAxis, &y);

--- a/cocos/renderer/CCRenderer.cpp
+++ b/cocos/renderer/CCRenderer.cpp
@@ -539,7 +539,6 @@ void Renderer::visitRenderQueue(RenderQueue& queue)
     {
         //Clear depth to achieve layered rendering
         glDepthMask(true);
-        glClear(GL_DEPTH_BUFFER_BIT);
         glEnable(GL_DEPTH_TEST);
         
         for (auto it = opaqueQueue.cbegin(); it != opaqueQueue.cend(); ++it)
@@ -586,10 +585,6 @@ void Renderer::visitRenderQueue(RenderQueue& queue)
             processRenderCommand(*it);
         }
         flush();
-        
-        glDepthMask(true);
-        glClear(GL_DEPTH_BUFFER_BIT);
-        glDepthMask(false);
     }
     
     //


### PR DESCRIPTION
Don't clear depth between render queues, necessary for Fantasy Warrior to work correctly.
