### PR TITLE
[ci skip]Fix z-fighting error by using setDepthTest of cc.Director

### DIFF
--- a/tests/lua-tests/src/BugsTest/BugsTest.lua
+++ b/tests/lua-tests/src/BugsTest/BugsTest.lua
@@ -356,8 +356,6 @@ end
 --BugTest1159
 local function BugTest1159()
     local pLayer = cc.Layer:create()
-    
-    cc.Director:getInstance():setDepthTest(true)
 
     local background = cc.LayerColor:create(cc.c4b(255, 0, 255, 255))
     pLayer:addChild(background)
@@ -398,7 +396,6 @@ local function BugTest1159()
                 scheduler:unscheduleScriptEntry(schedulerEntry)
             end
             ]]--
-            cc.Director:getInstance():setDepthTest(false)
         end
     end
 

--- a/tests/lua-tests/src/ParallaxTest/ParallaxTest.lua
+++ b/tests/lua-tests/src/ParallaxTest/ParallaxTest.lua
@@ -145,7 +145,6 @@ end
 function ParallaxTestMain()
     cclog("ParallaxMain")
     Helper.index = 1
-    cc.Director:getInstance():setDepthTest(true)
     local scene = cc.Scene:create()
 
     Helper.createFunctionTable = {


### PR DESCRIPTION
This pr fix the #10283.
