### PR TITLE
HttpResponse reference counting bug fixed

### DIFF
--- a/cocos/network/HttpClient-android.cpp
+++ b/cocos/network/HttpClient-android.cpp
@@ -795,10 +795,8 @@ void HttpClient::networkThread()
 }
 
 // Worker thread
-void HttpClient::networkThreadAlone(HttpRequest* request)
+void HttpClient::networkThreadAlone(HttpRequest* request, HttpResponse* response)
 {
-    // Create a HttpResponse object, the default setting is http access failed
-    HttpResponse *response = new (std::nothrow) HttpResponse(request);
     std::string responseMessage = "";
     processResponse(response, responseMessage);
 
@@ -920,7 +918,10 @@ void HttpClient::sendImmediate(HttpRequest* request)
     }
 
     request->retain();
-    auto t = std::thread(&HttpClient::networkThreadAlone, this, request);
+    // Create a HttpResponse object, the default setting is http access failed
+    HttpResponse *response = new (std::nothrow) HttpResponse(request);
+
+    auto t = std::thread(&HttpClient::networkThreadAlone, this, request, response);
     t.detach();
 }
 

--- a/cocos/network/HttpClient-ios.mm
+++ b/cocos/network/HttpClient-ios.mm
@@ -126,10 +126,8 @@ void HttpClient::networkThread()
 }
 
 // Worker thread
-void HttpClient::networkThreadAlone(HttpRequest* request)
+void HttpClient::networkThreadAlone(HttpRequest* request, HttpResponse* response)
 {
-    // Create a HttpResponse object, the default setting is http access failed
-    HttpResponse *response = new (std::nothrow) HttpResponse(request);
     char errorBuffer[ERROR_SIZE] = { 0 };
     processResponse(response, errorBuffer);
 
@@ -470,7 +468,10 @@ void HttpClient::sendImmediate(HttpRequest* request)
     }
 
     request->retain();
-    auto t = std::thread(&HttpClient::networkThreadAlone, this, request);
+    // Create a HttpResponse object, the default setting is http access failed
+    HttpResponse *response = new (std::nothrow) HttpResponse(request);
+
+    auto t = std::thread(&HttpClient::networkThreadAlone, this, request, response);
     t.detach();
 }
 

--- a/cocos/network/HttpClient.cpp
+++ b/cocos/network/HttpClient.cpp
@@ -160,10 +160,8 @@ void HttpClient::networkThread()
 }
 
 // Worker thread
-void HttpClient::networkThreadAlone(HttpRequest* request)
+void HttpClient::networkThreadAlone(HttpRequest* request, HttpResponse* response)
 {
-    // Create a HttpResponse object, the default setting is http access failed
-    HttpResponse *response = new (std::nothrow) HttpResponse(request);
     char errorBuffer[CURL_ERROR_SIZE] = { 0 };
     processResponse(response, errorBuffer);
 
@@ -521,7 +519,10 @@ void HttpClient::sendImmediate(HttpRequest* request)
     }
 
     request->retain();
-    auto t = std::thread(&HttpClient::networkThreadAlone, this, request);
+    // Create a HttpResponse object, the default setting is http access failed
+    HttpResponse *response = new (std::nothrow) HttpResponse(request);
+
+    auto t = std::thread(&HttpClient::networkThreadAlone, this, request, response);
     t.detach();
 }
 

--- a/cocos/network/HttpClient.h
+++ b/cocos/network/HttpClient.h
@@ -115,7 +115,7 @@ private:
      */
     bool lazyInitThreadSemphore();
     void networkThread();
-    void networkThreadAlone(HttpRequest* request);
+    void networkThreadAlone(HttpRequest* request, HttpResponse* response);
     /** Poll function called from main thread to dispatch callbacks when http requests finished **/
     void dispatchResponseCallbacks();
     


### PR DESCRIPTION
Hi.
This is a bug fix branch.
Recently I merged cocos2d-x engine, And I got assertion error from about 1% of HttpRequest (Using XmlHttpRequest)
The assertion failing occurs on the HttpRequest's last release phase in the HttpClient.
The reason of this bug is that, HttpResponse retain/release the HttpRequest and this job is done in worker thread.
The Ref object's are not thread-safe so, should be retain/released in the one thread (which is the main thread)
