### PR TITLE
Fixed the bug that texture size of string has unexpected padding on iOS7 later. 

### DIFF
--- a/cocos/platform/ios/CCDevice-ios.mm
+++ b/cocos/platform/ios/CCDevice-ios.mm
@@ -226,7 +226,7 @@ static CGSize _calculateStringSize(NSString *str, id font, CGSize *constrainSize
     CGSize dim;
     if(s_isIOS7OrHigher){
         NSDictionary *attibutes = @{NSFontAttributeName:font};
-        dim = [str boundingRectWithSize:textRect options:(NSStringDrawingOptions)(NSStringDrawingUsesLineFragmentOrigin|NSStringDrawingUsesFontLeading) attributes:attibutes context:nil].size;
+        dim = [str boundingRectWithSize:textRect options:(NSStringDrawingOptions)(NSStringDrawingUsesLineFragmentOrigin) attributes:attibutes context:nil].size;
     }
     else {
         dim = [str sizeWithFont:font constrainedToSize:textRect];


### PR DESCRIPTION
Since iOS7, `sizeWithFont:constrainedToSize:` function is deprecated, so `boundingRectWithSize:options:attributes:context` is used for iOS version higher than.
In the current code, `NSStringDrawingUsesLineFragmentOrigin` and
`NSStringDrawingUsesFontLeading` are passed as an option. However the result texture has unexpected padding on the bottom. The result size is differ from the size which actually strings are rendered.

I think the issue #9165 is caused by this bug. `initWithString` function on cocos2d::Texture2D is used on the cocos2d::Label class when system font is used. Therefore, I think this problem is serious one.

I tested same code and compared result texture on difference versions of iOS. These are tested on simulator.

This is the result on iOS6.1.
![iphone retina ios6 1 ios simulator screen shot 2015 02 06 12 09 32](https://cloud.githubusercontent.com/assets/249556/6075328/58d4ba3e-ae13-11e4-975a-6e780b398bb9.png)

This is the result on iOS7.1
![iphone5s 7 1 ios simulator screen shot 2015 02 06 11 38 04](https://cloud.githubusercontent.com/assets/249556/6075333/7f071d50-ae13-11e4-98af-1f14542559bf.png)

And this is the result on iOS8.1
![iphone5s 8 1 ios simulator screen shot 2015 02 06 11 38 35](https://cloud.githubusercontent.com/assets/249556/6075336/8fb0bada-ae13-11e4-8259-d52aa5c809fb.png)

The tested code is following,

``` cpp
#include "HelloWorldScene.h"

USING_NS_CC;

Scene* HelloWorld::createScene()
{
    auto scene = Scene::create();
    auto layer = HelloWorld::create();
    scene->addChild(layer);
    return scene;
}

bool HelloWorld::init()
{
    if ( !Layer::init() )
    {
        return false;
    }

    Size visibleSize = Director::getInstance()->getVisibleSize();
    Vec2 origin = Director::getInstance()->getVisibleOrigin();

    std::string testString =
    "11111111111111111111111111111111111111111"
    "11111111111111111111111111111111111111111"
    "11111111111111111111111111111111111111111"
    "11111111111111111111111111111111111111111"
    ;

    FontDefinition fontdef;
    fontdef._fontName = "HiraKakuProN-W6";
    fontdef._fontSize = 25;
    fontdef._alignment = TextHAlignment::LEFT;
    fontdef._vertAlignment = TextVAlignment::CENTER;
    fontdef._dimensions = Size{500, 0};

    auto texture = new (std::nothrow) Texture2D;
    texture->initWithString(testString.c_str(), fontdef);

    auto textSprite = cocos2d::Sprite::createWithTexture(texture);
    textSprite->setAnchorPoint(cocos2d::Vec2::ANCHOR_BOTTOM_LEFT);
    texture->release();

    auto texSize = textSprite->getContentSize();
    auto background = cocos2d::Sprite::create();
    background->setColor(cocos2d::Color3B::RED);
    background->setTextureRect(cocos2d::Rect(0, 0, texSize.width, texSize.height));
    background->setPosition(visibleSize.width / 2, visibleSize.height / 2);

    background->addChild(textSprite);
    this->addChild(background);

    return true;
}
```

After changed to the code I requested, the result will be as following,
![iphone5s 8 1 fixed](https://cloud.githubusercontent.com/assets/249556/6075365/03d20c02-ae14-11e4-8da5-78f7c333aa9b.png)
This is the result on iOS8.1
