### PR TITLE
Adding GLProgramState::setUniformFloatArray().

### DIFF
--- a/cocos/renderer/CCGLProgramState.cpp
+++ b/cocos/renderer/CCGLProgramState.cpp
@@ -51,6 +51,7 @@ UniformValue::UniformValue()
 : _uniform(nullptr)
 , _glprogram(nullptr)
 , _useCallback(false)
+, _arrayCount(0)
 {
 }
 
@@ -58,6 +59,7 @@ UniformValue::UniformValue(Uniform *uniform, GLProgram* glprogram)
 : _uniform(uniform)
 , _glprogram(glprogram)
 , _useCallback(false)
+, _arrayCount(0)
 {
 }
 
@@ -85,7 +87,10 @@ void UniformValue::apply()
                 break;
 
             case GL_FLOAT:
-                _glprogram->setUniformLocationWith1f(_uniform->location, _value.floatValue);
+                if (_arrayCount > 0)
+                    _glprogram->setUniformLocationWith1fv(_uniform->location, _value.floatArray, _arrayCount);
+                else
+                    _glprogram->setUniformLocationWith1f(_uniform->location, _value.floatValue);
                 break;
 
             case GL_FLOAT_VEC2:
@@ -130,6 +135,14 @@ void UniformValue::setFloat(float value)
 {
     CCASSERT (_uniform->type == GL_FLOAT, "");
     _value.floatValue = value;
+    _useCallback = false;
+}
+
+void UniformValue::setFloatArray(float* array, int count)
+{
+    CCASSERT (_uniform->type == GL_FLOAT, "");
+    _value.floatArray = array;
+	_arrayCount = count;
     _useCallback = false;
 }
 
@@ -494,6 +507,24 @@ void GLProgramState::setUniformFloat(GLint uniformLocation, float value)
     auto v = getUniformValue(uniformLocation);
     if (v)
         v->setFloat(value);
+    else
+        CCLOG("cocos2d: warning: Uniform at location not found: %i", uniformLocation);
+}
+
+void GLProgramState::setUniformFloatArray(const std::string &uniformName, float* array, int count)
+{
+    auto v = getUniformValue(uniformName);
+    if (v)
+        v->setFloatArray(array, count);
+    else
+        CCLOG("cocos2d: warning: Uniform not found: %s", uniformName.c_str());
+}
+
+void GLProgramState::setUniformFloatArray(GLint uniformLocation, float* array, int count)
+{
+    auto v = getUniformValue(uniformLocation);
+    if (v)
+        v->setFloatArray(array, count);
     else
         CCLOG("cocos2d: warning: Uniform at location not found: %i", uniformLocation);
 }

--- a/cocos/renderer/CCGLProgramState.h
+++ b/cocos/renderer/CCGLProgramState.h
@@ -57,6 +57,7 @@ public:
     ~UniformValue();
 
     void setFloat(float value);
+    void setFloatArray(float* array, int count);
     void setInt(int value);
     void setVec2(const Vec2& value);
     void setVec3(const Vec3& value);
@@ -71,9 +72,11 @@ protected:
 	Uniform* _uniform;  // weak ref
     GLProgram* _glprogram; // weak ref
     bool _useCallback;
+    int _arrayCount;
 
     union U{
         float floatValue;
+        float* floatArray;
         int intValue;
         float v2Value[2];
         float v3Value[3];
@@ -181,6 +184,7 @@ public:
     ssize_t getUniformCount() const { return _uniforms.size(); }
     void setUniformInt(const std::string &uniformName, int value);
     void setUniformFloat(const std::string &uniformName, float value);
+    void setUniformFloatArray(const std::string &uniformName, float* array, int count);
     void setUniformVec2(const std::string &uniformName, const Vec2& value);
     void setUniformVec3(const std::string &uniformName, const Vec3& value);
     void setUniformVec4(const std::string &uniformName, const Vec4& value);
@@ -191,6 +195,7 @@ public:
 
     void setUniformInt(GLint uniformLocation, int value);
     void setUniformFloat(GLint uniformLocation, float value);
+    void setUniformFloatArray(GLint uniformLocation, float* array, int count);
     void setUniformVec2(GLint uniformLocation, const Vec2& value);
     void setUniformVec3(GLint uniformLocation, const Vec3& value);
     void setUniformVec4(GLint uniformLocation, const Vec4& value);


### PR DESCRIPTION
GLProgramState currently lacks a method to set a float array. This can be very useful in many ways for shader development. This pull request adds GLProgramState::setUniformFloatArray().
