### PR TITLE
Fixed HttpClient-ios request to work when the data is started by 0x00.

### DIFF
--- a/cocos/network/HttpClient-ios.mm
+++ b/cocos/network/HttpClient-ios.mm
@@ -192,7 +192,7 @@ static int processTask(HttpRequest *request, NSString* requestType, void *stream
         }
         
         char* requestDataBuffer = request->getRequestData();
-        if (nullptr !=  requestDataBuffer && 0 != strlen(requestDataBuffer))
+        if (nullptr !=  requestDataBuffer && 0 != request->getRequestDataSize())
         {
             NSData *postData = [NSData dataWithBytes:requestDataBuffer length:request->getRequestDataSize()];
             [nsrequest setHTTPBody:postData];


### PR DESCRIPTION
Fixed a bug in HttpClient-ios.mm.
If the request data is started by a null character, it does not fill http body because of using strlen that leads to a wrong condition check.
