### PR TITLE
WP8 added missing CocosStudio3DTest files

### DIFF
--- a/tests/cpp-tests/proj.win8.1-universal/cpp-tests.Shared/cpp-tests.Shared.vcxitems
+++ b/tests/cpp-tests/proj.win8.1-universal/cpp-tests.Shared/cpp-tests.Shared.vcxitems
@@ -55,6 +55,7 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Classes\ClickAndMoveTest\ClickAndMoveTest.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Classes\ClippingNodeTest\ClippingNodeTest.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Classes\CocosDenshionTest\CocosDenshionTest.cpp" />
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Classes\CocosStudio3DTest\CocosStudio3DTest.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Classes\ConfigurationTest\ConfigurationTest.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Classes\ConsoleTest\ConsoleTest.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Classes\controller.cpp" />
@@ -299,6 +300,7 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Classes\ClickAndMoveTest\ClickAndMoveTest.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Classes\ClippingNodeTest\ClippingNodeTest.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Classes\CocosDenshionTest\CocosDenshionTest.h" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Classes\CocosStudio3DTest\CocosStudio3DTest.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Classes\ConfigurationTest\ConfigurationTest.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Classes\ConsoleTest\ConsoleTest.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Classes\controller.h" />

--- a/tests/cpp-tests/proj.win8.1-universal/cpp-tests.Shared/cpp-tests.Shared.vcxitems.filters
+++ b/tests/cpp-tests/proj.win8.1-universal/cpp-tests.Shared/cpp-tests.Shared.vcxitems.filters
@@ -769,6 +769,9 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Classes\Particle3DTest\Particle3DTest.cpp">
       <Filter>Classes\Particle3DTest</Filter>
     </ClCompile>
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Classes\CocosStudio3DTest\CocosStudio3DTest.cpp">
+      <Filter>Classes\CocosStudio3DTest</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Classes\ActionManagerTest\ActionManagerTest.cpp">
@@ -1668,6 +1671,9 @@
     <Filter Include="Classes\Particle3DTest">
       <UniqueIdentifier>{65d0f12d-321a-41f7-99af-de609183f206}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Classes\CocosStudio3DTest">
+      <UniqueIdentifier>{3aa426b9-e37f-4882-a332-a7f787b4174d}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <Page Include="$(MSBuildThisFileDirectory)..\..\..\..\cocos\platform\win8.1-universal\OpenGLESPage.xaml" />
@@ -1691,6 +1697,9 @@
     </ClInclude>
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Classes\Particle3DTest\Particle3DTest.h">
       <Filter>Classes\Particle3DTest</Filter>
+    </ClInclude>
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Classes\CocosStudio3DTest\CocosStudio3DTest.h">
+      <Filter>Classes\CocosStudio3DTest</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>

--- a/tests/cpp-tests/proj.wp8-xaml/cpp-testsComponent/cpp-testsComponent.vcxproj
+++ b/tests/cpp-tests/proj.wp8-xaml/cpp-testsComponent/cpp-testsComponent.vcxproj
@@ -200,6 +200,7 @@
     <ClCompile Include="..\..\Classes\Camera3DTest\Camera3DTest.cpp" />
     <ClCompile Include="..\..\Classes\ChipmunkTest\ChipmunkTest.cpp" />
     <ClCompile Include="..\..\Classes\ClippingNodeTest\ClippingNodeTest.cpp" />
+    <ClCompile Include="..\..\Classes\CocosStudio3DTest\CocosStudio3DTest.cpp" />
     <ClCompile Include="..\..\Classes\ConfigurationTest\ConfigurationTest.cpp" />
     <ClCompile Include="..\..\Classes\ConsoleTest\ConsoleTest.cpp" />
     <ClCompile Include="..\..\Classes\CurlTest\CurlTest.cpp" />
@@ -400,6 +401,7 @@
     <ClInclude Include="..\..\Classes\Camera3DTest\Camera3DTest.h" />
     <ClInclude Include="..\..\Classes\ChipmunkTest\ChipmunkTest.h" />
     <ClInclude Include="..\..\Classes\ClippingNodeTest\ClippingNodeTest.h" />
+    <ClInclude Include="..\..\Classes\CocosStudio3DTest\CocosStudio3DTest.h" />
     <ClInclude Include="..\..\Classes\ConfigurationTest\ConfigurationTest.h" />
     <ClInclude Include="..\..\Classes\ConsoleTest\ConsoleTest.h" />
     <ClInclude Include="..\..\Classes\CurlTest\CurlTest.h" />

--- a/tests/cpp-tests/proj.wp8-xaml/cpp-testsComponent/cpp-testsComponent.vcxproj.filters
+++ b/tests/cpp-tests/proj.wp8-xaml/cpp-testsComponent/cpp-testsComponent.vcxproj.filters
@@ -346,6 +346,9 @@
     <Filter Include="Classes\Particle3DTest">
       <UniqueIdentifier>{65f864c8-5b02-4c44-ab8b-a8e7289e5c7a}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Classes\CocosStudio3DTest">
+      <UniqueIdentifier>{0066fcd2-a181-400f-a030-f5ec6230b303}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\Classes\AppDelegate.cpp">
@@ -911,6 +914,9 @@
     </ClCompile>
     <ClCompile Include="..\..\Classes\Particle3DTest\Particle3DTest.cpp">
       <Filter>Classes\Particle3DTest</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Classes\CocosStudio3DTest\CocosStudio3DTest.cpp">
+      <Filter>Classes\CocosStudio3DTest</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
@@ -1676,6 +1682,9 @@
     </ClInclude>
     <ClInclude Include="..\..\Classes\Particle3DTest\Particle3DTest.h">
       <Filter>Classes\Particle3DTest</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Classes\CocosStudio3DTest\CocosStudio3DTest.h">
+      <Filter>Classes\CocosStudio3DTest</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
This pull request adds the missing CocosStudio3DTest files to the WP8 and Universal App test projects.
