### PR TITLE
Fix an issue with iOS HTTP Request code

### DIFF
--- a/cocos/network/HttpAsynConnection.m
+++ b/cocos/network/HttpAsynConnection.m
@@ -88,11 +88,10 @@
     | “206”  ; Partial Content
     */
     if (responseCode < 200 || responseCode >= 300)
-    {// something went wrong, abort the whole thing
-        
-        [connection cancel];
-        finish = true;
-        return;
+    {// something went wrong, record a response error
+        self.responseError = [NSError errorWithDomain:@"CCBackendDomain"
+                                                 code:responseCode
+                                             userInfo:@{NSLocalizedDescriptionKey: @"Bad HTTP Response Code"}];
     }
     
     [responseData setLength:0];


### PR DESCRIPTION
Background:
When the server returns a response code greater than 300, it may return a JSON or some data to explain the error.
I have made sure this is a standard by asking on StackOverflow: http://stackoverflow.com/q/28662167/456434

Thanks,
Maz
