### PR TITLE
Fix typo in Image::Format

### DIFF
--- a/cocos/editor-support/cocosbuilder/CCBAnimationManager.cpp
+++ b/cocos/editor-support/cocosbuilder/CCBAnimationManager.cpp
@@ -609,7 +609,7 @@ ActionInterval* CCBAnimationManager::getEaseAction(ActionInterval *pAction, CCBK
     }
     else
     {
-        log("CCBReader: Unkown easing type %d", static_cast<int>(easingType));
+        log("CCBReader: Unknown easing type %d", static_cast<int>(easingType));
         return pAction;
     }
 }

--- a/cocos/network/HttpClient-android.cpp
+++ b/cocos/network/HttpClient-android.cpp
@@ -646,7 +646,7 @@ static void processResponse(HttpResponse* response, std::string& responseMessage
         HttpRequest::Type::PUT != requestType &&
         HttpRequest::Type::DELETE != requestType)
     {
-        CCASSERT(true, "CCHttpClient: unkown request type, only GET、POST、PUT、DELETE are supported");
+        CCASSERT(true, "CCHttpClient: unknown request type, only GET、POST、PUT、DELETE are supported");
         return;
     }
 

--- a/cocos/network/HttpClient-ios.mm
+++ b/cocos/network/HttpClient-ios.mm
@@ -335,7 +335,7 @@ static void processResponse(HttpResponse* response, char* errorBuffer)
         break;
 
     default:
-        CCASSERT(true, "CCHttpClient: unkown request type, only GET and POSt are supported");
+        CCASSERT(true, "CCHttpClient: unknown request type, only GET and POSt are supported");
         break;
     }
     

--- a/cocos/network/HttpClient.cpp
+++ b/cocos/network/HttpClient.cpp
@@ -405,7 +405,7 @@ static void processResponse(HttpResponse* response, char* errorBuffer)
         break;
 
     default:
-        CCASSERT(true, "CCHttpClient: unkown request type, only GET and POSt are supported");
+        CCASSERT(true, "CCHttpClient: unknown request type, only GET and POSt are supported");
         break;
     }
 

--- a/cocos/platform/CCImage.cpp
+++ b/cocos/platform/CCImage.cpp
@@ -457,7 +457,7 @@ Image::Image()
 , _width(0)
 , _height(0)
 , _unpack(false)
-, _fileType(Format::UNKOWN)
+, _fileType(Format::UNKNOWN)
 , _renderFormat(Texture2D::PixelFormat::NONE)
 , _numberOfMipmaps(0)
 , _hasPremultipliedAlpha(true)
@@ -742,7 +742,7 @@ Image::Format Image::detectFormat(const unsigned char * data, ssize_t dataLen)
     }
     else
     {
-        return Format::UNKOWN;
+        return Format::UNKNOWN;
     }
 }
 

--- a/cocos/platform/CCImage.h
+++ b/cocos/platform/CCImage.h
@@ -92,7 +92,7 @@ public:
         //! Raw Data
         RAW_DATA,
         //! Unknown format
-        UNKOWN
+        UNKNOWN
     };
 
     /**


### PR DESCRIPTION
Fix typo in `Image::Format` and some error messages: unkown -> unknown
