### PR TITLE
clear the particle pool when start

### DIFF
--- a/extensions/Particle3D/ParticleUniverse/CCPUParticleSystem3D.cpp
+++ b/extensions/Particle3D/ParticleUniverse/CCPUParticleSystem3D.cpp
@@ -198,6 +198,7 @@ PUParticleSystem3D* PUParticleSystem3D::create( const std::string &filePath )
 void PUParticleSystem3D::startParticleSystem()
 {
     stopParticleSystem();
+    _particlePool.lockAllParticles();
     if (!_emitters.empty()){
         if (_state != State::RUNNING)
         {


### PR DESCRIPTION
Fix bug,
particle->stopParticleSystem();
particle->startParticleSystem();

It did not clear the particle pool. So the particle emitted before did not disappear.
