### PR TITLE
V4 winrt fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -167,3 +167,4 @@ tests/cpp-tests/Resources/audio
 /external/winrt-8.1/
 /external/winrt_8.1/
 /external/wp_8.1/
+/external/fbx-conv/

--- a/cocos/editor-support/spine/proj.win8.1-universal/libSpine.Windows/libSpine.Windows.vcxproj
+++ b/cocos/editor-support/spine/proj.win8.1-universal/libSpine.Windows/libSpine.Windows.vcxproj
@@ -55,19 +55,19 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <WholeProgramOptimization>false</WholeProgramOptimization>
     <PlatformToolset>v120</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <WholeProgramOptimization>false</WholeProgramOptimization>
     <PlatformToolset>v120</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <WholeProgramOptimization>false</WholeProgramOptimization>
     <PlatformToolset>v120</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />


### PR DESCRIPTION
This pull request removes the Link Time Code Generation from winrt 8.1 libspline project to speed up release builds.

Added external/fbx-conv to .gitignore
