### PR TITLE
Add more include files in config.gitingore for generating templates/cocos2dx_files.json

### DIFF
--- a/tools/travis-scripts/config.gitingore
+++ b/tools/travis-scripts/config.gitingore
@@ -114,6 +114,7 @@ tags
 # Permit plugins to ship third-party libraries.
 !/plugin/plugins/*/proj.android/libs/*.jar
 !/plugin/plugins/*/proj.android/libs
+!/tools/bindings-generator/tools/win32/*
 
 v*-deps-*.zip
 v*-lua-runtime-*.zip


### PR DESCRIPTION
In current mechanism,it would exclude `tools/bindings-generator/tools/win32/dos2unix.exe` to templates/cocos2dx_files.json. .It would trigger the project created by the template can't use bindings-generator on the windows platform.
