### PR TITLE
use platform/CCPlatformMacros.h for CC_DEPRECATED

### DIFF
--- a/cocos/audio/include/SimpleAudioEngine.h
+++ b/cocos/audio/include/SimpleAudioEngine.h
@@ -28,14 +28,7 @@ THE SOFTWARE.
 #define _SIMPLE_AUDIO_ENGINE_H_
 
 #include "Export.h"
-
-#if defined(__GNUC__) && ((__GNUC__ >= 4) || ((__GNUC__ == 3) && (__GNUC_MINOR__ >= 1)))
-#define CC_DEPRECATED(v3) __attribute__((deprecated))
-#elif _MSC_VER >= 1400 //vs 2005 or higher
-#define CC_DEPRECATED(v3) __declspec(deprecated)
-#else
-#define CC_DEPRECATED(v3)
-#endif
+#include "platform/CCPlatformMacros.h"
 
 namespace CocosDenshion {
 


### PR DESCRIPTION
This pull request uses #include platform/CCPlatformMacros.h to define  CC_DEPRECATED in SimpleAudioEngine.h.

CC_DEPRECATED was defined in two places 

In SimpleAudioEngine.h
# if defined(**GNUC**) && ((**GNUC** >= 4) || ((**GNUC** == 3) && (**GNUC_MINOR** >= 1)))
# define CC_DEPRECATED(v3) **attribute**((deprecated))
# elif _MSC_VER >= 1400 //vs 2005 or higher
# define CC_DEPRECATED(v3) __declspec(deprecated)
# else
# define CC_DEPRECATED(v3)
# endif

And in platform /CCPlatformMacros.h
# if defined(**GNUC**) && ((**GNUC** >= 4) || ((**GNUC** == 3) && (**GNUC_MINOR** >= 1)))

```
#define CC_DEPRECATED_ATTRIBUTE __attribute__((deprecated))
```
# elif _MSC_VER >= 1400 //vs 2005 or higher

```
#define CC_DEPRECATED_ATTRIBUTE __declspec(deprecated) 
```
# else

```
#define CC_DEPRECATED_ATTRIBUTE
```
# endif

/*
- macro to mark things deprecated as of a particular version
- can be used with artibrary parameters which are thrown away
- e.g. CC_DEPRECATED(4.0) or CC_DEPRECATED(4.0, "not going to need this anymore") etc.
  */
  #define CC_DEPRECATED(...) CC_DEPRECATED_ATTRIBUTE

This leads to the following warning in Win32, WinRT and WP8.1 builds

2>D:\GitHub\cocos2d-x-v4\cocos\audio/include/SimpleAudioEngine.h(35): warning C4005: 'CC_DEPRECATED' : macro redefinition (D:\GitHub\cocos2d-x-v4\cocos\2d\libcocos2d_8_1\libcocos2d_8_1\libcocos2d_8_1.Shared........\editor-support\cocosbuilder\CCBAnimationManager.cpp)
