### PR TITLE
Fix editbox on Mac

### DIFF
--- a/cocos/ui/UIEditBox/UIEditBoxImpl-mac.h
+++ b/cocos/ui/UIEditBox/UIEditBoxImpl-mac.h
@@ -50,6 +50,7 @@
 @property(nonatomic, retain) NSMutableDictionary* placeholderAttributes;
 @property(nonatomic, readonly, getter = isEditState) BOOL editState;
 @property(nonatomic, assign) void* editBox;
+@property(nonatomic, assign, getter = isSecure) BOOL secure;
 
 -(id) initWithFrame: (NSRect) frameRect editBox: (void*) editBox;
 -(void) doAnimationWhenKeyboardMoveWithDuration:(float)duration distance:(float)distance;

--- a/cocos/ui/UIEditBox/UIEditBoxImpl-mac.mm
+++ b/cocos/ui/UIEditBox/UIEditBoxImpl-mac.mm
@@ -97,6 +97,7 @@
 @synthesize placeholderAttributes = placeholderAttributes_;
 @synthesize editState = editState_;
 @synthesize editBox = editBox_;
+@synthesize secure = secure_;
 
 - (id) getNSWindow
 {
@@ -125,6 +126,7 @@
     if (self)
     {
         editState_ = NO;
+        secure_ = NO;
         self.textField = [[[NSTextField alloc] initWithFrame:frameRect] autorelease];
         self.secureTextField = [[[NSSecureTextField alloc] initWithFrame:frameRect] autorelease];
 
@@ -163,6 +165,16 @@
     [[[self getNSWindow] contentView] doAnimationWhenKeyboardMoveWithDuration:duration distance:distance];
 }
 
+-(void) setSecure:(BOOL)secure
+{
+    NSAssert(secure, @"Can only set this flag to true");
+    
+    secure_ = secure;
+        
+    [textField_.superview addSubview:secureTextField_];
+    [textField_ removeFromSuperview];
+}
+
 -(void) setPosition:(NSPoint) pos
 {
     NSRect frame = [textField_ frame];
@@ -183,10 +195,14 @@
 
 -(void) openKeyboard
 {
-    if ([textField_ superview]) {
+    NSView *contentView = [[self getNSWindow] contentView];
+    
+    if (!secure_) {
+        [contentView addSubview:textField_];
         [textField_ becomeFirstResponder];
     }
     else {
+        [contentView addSubview:secureTextField_];
         [secureTextField_ becomeFirstResponder];
     }
 }
@@ -412,8 +428,7 @@ void EditBoxImplMac::setInputFlag(EditBox::InputFlag inputFlag)
     switch (inputFlag)
     {
         case EditBox::InputFlag::PASSWORD:
-            [_sysEdit.textField.superview addSubview:_sysEdit.secureTextField];
-            [_sysEdit.textField removeFromSuperview];
+            _sysEdit.secure = YES;
             break;
         case EditBox::InputFlag::INITIAL_CAPS_WORD:
             CCLOGWARN("INITIAL_CAPS_WORD not implemented");


### PR DESCRIPTION
**Brief**:

Editbox on iOS removes the native textfield in `closeKeyboard`, and the adds the textfield again in `openKeyboard`:
https://github.com/cocos2d/cocos2d-x/blob/v3/cocos/ui/UIEditBox/UIEditBoxImpl-ios.mm#L121

But, in Mac OS, the editbox is removed in `closeKeyboard`, and never added back in `openKeyboard`. This causes the textfield to disappear once it's removed from the scene, even if you try to add it back in:
https://github.com/cocos2d/cocos2d-x/blob/v3/cocos/ui/UIEditBox/UIEditBoxImpl-mac.mm#L184

This PR fixes this issue, by tracking which textfield is being used, then adds the textfield back to the view hierarchy as appropriate.

Tested on my game.

Thanks,
Maz
