### PR TITLE
Support Color4B for editbox text

### DIFF
--- a/cocos/ui/UIEditBox/UIEditBox.cpp
+++ b/cocos/ui/UIEditBox/UIEditBox.cpp
@@ -234,6 +234,11 @@ void EditBox::setFontSize(int fontSize)
 
 void EditBox::setFontColor(const Color3B& color)
 {
+    setFontColor(Color4B(color));
+}
+
+void EditBox::setFontColor(const Color4B& color)
+{
     _colText = color;
     if (_editBoxImpl != nullptr)
     {
@@ -274,7 +279,12 @@ void EditBox::setPlaceholderFontSize(int fontSize)
 
 void EditBox::setPlaceholderFontColor(const Color3B& color)
 {
-    _colText = color;
+    setPlaceholderFontColor(Color4B(color));
+}
+
+void EditBox::setPlaceholderFontColor(const Color4B& color)
+{
+    _colPlaceHolder = color;
     if (_editBoxImpl != nullptr)
     {
         _editBoxImpl->setPlaceholderFontColor(color);

--- a/cocos/ui/UIEditBox/UIEditBox.h
+++ b/cocos/ui/UIEditBox/UIEditBox.h
@@ -316,6 +316,7 @@ namespace ui {
              * Set the font color of the widget's text.
              */
             void setFontColor(const Color3B& color);
+            void setFontColor(const Color4B& color);
             
             /**
              * Set the placeholder's font.
@@ -338,9 +339,9 @@ namespace ui {
             
             /**
              * Set the font color of the placeholder text when the edit box is empty.
-             * Not supported on IOS.
              */
             void setPlaceholderFontColor(const Color3B& color);
+            void setPlaceholderFontColor(const Color4B& color);
             
             /**
              * Set a text in the edit box that acts as a placeholder when an
@@ -463,8 +464,8 @@ namespace ui {
             int _fontSize;
             int _placeholderFontSize;
             
-            Color3B _colText;
-            Color3B _colPlaceHolder;
+            Color4B _colText;
+            Color4B _colPlaceHolder;
             
             int   _maxLength;
             float _adjustHeight;

--- a/cocos/ui/UIEditBox/UIEditBoxImpl-android.cpp
+++ b/cocos/ui/UIEditBox/UIEditBoxImpl-android.cpp
@@ -105,10 +105,10 @@ void EditBoxImplAndroid::setFont(const char* pFontName, int fontSize)
 	}
 }
 
-void EditBoxImplAndroid::setFontColor(const Color3B& color)
+void EditBoxImplAndroid::setFontColor(const Color4B& color)
 {
     _colText = color;
-    _label->setColor(color);
+    _label->setTextColor(color);
 }
 
 void EditBoxImplAndroid::setPlaceholderFont(const char* pFontName, int fontSize)
@@ -119,10 +119,10 @@ void EditBoxImplAndroid::setPlaceholderFont(const char* pFontName, int fontSize)
 	}
 }
 
-void EditBoxImplAndroid::setPlaceholderFontColor(const Color3B& color)
+void EditBoxImplAndroid::setPlaceholderFontColor(const Color4B& color)
 {
     _colPlaceHolder = color;
-    _labelPlaceHolder->setColor(color);
+    _labelPlaceHolder->setTextColor(color);
 }
 
 void EditBoxImplAndroid::setInputMode(EditBox::InputMode inputMode)

--- a/cocos/ui/UIEditBox/UIEditBoxImpl-android.cpp
+++ b/cocos/ui/UIEditBox/UIEditBoxImpl-android.cpp
@@ -76,7 +76,7 @@ bool EditBoxImplAndroid::initWithSize(const Size& size)
 	// align the text vertically center
     _label->setAnchorPoint(Vec2(0, 0.5f));
     _label->setPosition(Vec2(CC_EDIT_BOX_PADDING, size.height / 2.0f));
-    _label->setColor(_colText);
+    _label->setTextColor(_colText);
     _editBox->addChild(_label);
 	
     _labelPlaceHolder = Label::create();
@@ -85,7 +85,7 @@ bool EditBoxImplAndroid::initWithSize(const Size& size)
     _labelPlaceHolder->setAnchorPoint(Vec2(0, 0.5f));
     _labelPlaceHolder->setPosition(CC_EDIT_BOX_PADDING, size.height / 2.0f);
     _labelPlaceHolder->setVisible(false);
-    _labelPlaceHolder->setColor(_colPlaceHolder);
+    _labelPlaceHolder->setTextColor(_colPlaceHolder);
     _editBox->addChild(_labelPlaceHolder);
     
     _editSize = size;

--- a/cocos/ui/UIEditBox/UIEditBoxImpl-android.h
+++ b/cocos/ui/UIEditBox/UIEditBoxImpl-android.h
@@ -55,9 +55,9 @@ public:
     
     virtual bool initWithSize(const Size& size);
     virtual void setFont(const char* pFontName, int fontSize);
-    virtual void setFontColor(const Color3B& color);
+    virtual void setFontColor(const Color4B& color);
     virtual void setPlaceholderFont(const char* pFontName, int fontSize);
-    virtual void setPlaceholderFontColor(const Color3B& color);
+    virtual void setPlaceholderFontColor(const Color4B& color);
     virtual void setInputMode(EditBox::InputMode inputMode);
     virtual void setInputFlag(EditBox::InputFlag inputFlag);
     virtual void setMaxLength(int maxLength);
@@ -96,8 +96,8 @@ private:
     std::string _text;
     std::string _placeHolder;
     
-    Color3B _colText;
-    Color3B _colPlaceHolder;
+    Color4B _colText;
+    Color4B _colPlaceHolder;
 
     int   _maxLength;
     Size _editSize;

--- a/cocos/ui/UIEditBox/UIEditBoxImpl-ios.h
+++ b/cocos/ui/UIEditBox/UIEditBoxImpl-ios.h
@@ -85,9 +85,9 @@ public:
     
     virtual bool initWithSize(const Size& size);
     virtual void setFont(const char* pFontName, int fontSize);
-    virtual void setFontColor(const Color3B& color);
+    virtual void setFontColor(const Color4B& color);
     virtual void setPlaceholderFont(const char* pFontName, int fontSize);
-    virtual void setPlaceholderFontColor(const Color3B& color);
+    virtual void setPlaceholderFontColor(const Color4B& color);
     virtual void setInputMode(EditBox::InputMode inputMode);
     virtual void setInputFlag(EditBox::InputFlag inputFlag);
     virtual void setMaxLength(int maxLength);

--- a/cocos/ui/UIEditBox/UIEditBoxImpl-ios.mm
+++ b/cocos/ui/UIEditBox/UIEditBoxImpl-ios.mm
@@ -396,10 +396,10 @@ void EditBoxImplIOS::setFont(const char* pFontName, int fontSize)
 	_label->setSystemFontSize(fontSize);
 }
 
-void EditBoxImplIOS::setFontColor(const Color3B& color)
+void EditBoxImplIOS::setFontColor(const Color4B& color)
 {
-    _systemControl.textField.textColor = [UIColor colorWithRed:color.r / 255.0f green:color.g / 255.0f blue:color.b / 255.0f alpha:1.0f];
-	_label->setColor(color);
+    _systemControl.textField.textColor = [UIColor colorWithRed:color.r / 255.0f green:color.g / 255.0f blue:color.b / 255.0f alpha:color.a / 255.f];
+	_label->setTextColor(color);
 }
 
 void EditBoxImplIOS::setPlaceholderFont(const char* pFontName, int fontSize)
@@ -407,10 +407,10 @@ void EditBoxImplIOS::setPlaceholderFont(const char* pFontName, int fontSize)
 	_labelPlaceHolder->setSystemFontName(pFontName);
 	_labelPlaceHolder->setSystemFontSize(fontSize);
 }
-
-void EditBoxImplIOS::setPlaceholderFontColor(const Color3B& color)
+    
+void EditBoxImplIOS::setPlaceholderFontColor(const Color4B &color)
 {
-	_labelPlaceHolder->setColor(color);
+    _labelPlaceHolder->setTextColor(color);
 }
 
 void EditBoxImplIOS::setInputMode(EditBox::InputMode inputMode)

--- a/cocos/ui/UIEditBox/UIEditBoxImpl-mac.h
+++ b/cocos/ui/UIEditBox/UIEditBoxImpl-mac.h
@@ -83,9 +83,9 @@ public:
     
     virtual bool initWithSize(const Size& size);
     virtual void setFont(const char* pFontName, int fontSize);
-    virtual void setFontColor(const Color3B& color);
+    virtual void setFontColor(const Color4B& color);
     virtual void setPlaceholderFont(const char* pFontName, int fontSize);
-    virtual void setPlaceholderFontColor(const Color3B& color);
+    virtual void setPlaceholderFontColor(const Color4B& color);
     virtual void setInputMode(EditBox::InputMode inputMode);
     virtual void setInputFlag(EditBox::InputFlag inputFlag);
     virtual void setMaxLength(int maxLength);

--- a/cocos/ui/UIEditBox/UIEditBoxImpl-mac.mm
+++ b/cocos/ui/UIEditBox/UIEditBoxImpl-mac.mm
@@ -370,16 +370,16 @@ void EditBoxImplMac::setPlaceholderFont(const char* pFontName, int fontSize)
     }
 }
 
-void EditBoxImplMac::setFontColor(const Color3B& color)
+void EditBoxImplMac::setFontColor(const Color4B& color)
 {
-    NSColor *newColor = [NSColor colorWithCalibratedRed:color.r / 255.0f green:color.g / 255.0f blue:color.b / 255.0f alpha:1.0f];
+    NSColor *newColor = [NSColor colorWithCalibratedRed:color.r / 255.0f green:color.g / 255.0f blue:color.b / 255.0f alpha:color.a / 255.f];
     _sysEdit.textField.textColor = newColor;
     _sysEdit.secureTextField.textColor = newColor;
 }
-
-void EditBoxImplMac::setPlaceholderFontColor(const Color3B& color)
+    
+void EditBoxImplMac::setPlaceholderFontColor(const Color4B& color)
 {
-    NSColor *nsColor = [NSColor colorWithCalibratedRed:color.r/255.f green:color.g / 255.f blue:color.b / 255.f alpha:1.0f];
+    NSColor *nsColor = [NSColor colorWithCalibratedRed:color.r/255.f green:color.g / 255.f blue:color.b / 255.f alpha:color.a / 255.f];
     [_sysEdit.placeholderAttributes setObject:nsColor forKey:NSForegroundColorAttributeName];
     
     /* reload placeholder */

--- a/cocos/ui/UIEditBox/UIEditBoxImpl-win32.cpp
+++ b/cocos/ui/UIEditBox/UIEditBoxImpl-win32.cpp
@@ -527,7 +527,7 @@ bool EditBoxImplWin::initWithSize(const Size& size)
 	// align the text vertically center
     _label->setAnchorPoint(Vec2(0, 0.5f));
     _label->setPosition(Vec2(CC_EDIT_BOX_PADDING, size.height / 2.0f));
-    _label->setColor(_colText);
+    _label->setTextColor(_colText);
     _editBox->addChild(_label);
 
     _labelPlaceHolder = Label::create();
@@ -536,7 +536,7 @@ bool EditBoxImplWin::initWithSize(const Size& size)
     _labelPlaceHolder->setAnchorPoint(Vec2(0, 0.5f));
     _labelPlaceHolder->setPosition(CC_EDIT_BOX_PADDING, size.height / 2.0f);
     _labelPlaceHolder->setVisible(false);
-    _labelPlaceHolder->setColor(_colPlaceHolder);
+    _labelPlaceHolder->setTextColor(_colPlaceHolder);
     _editBox->addChild(_labelPlaceHolder);
     
     _editSize = size;

--- a/cocos/ui/UIEditBox/UIEditBoxImpl-win32.cpp
+++ b/cocos/ui/UIEditBox/UIEditBoxImpl-win32.cpp
@@ -556,10 +556,10 @@ void EditBoxImplWin::setFont(const char* pFontName, int fontSize)
 	}
 }
 
-void EditBoxImplWin::setFontColor(const Color3B& color)
+void EditBoxImplWin::setFontColor(const Color4B& color)
 {
     _colText = color;
-    _label->setColor(color);
+    _label->setTextColor(color);
 }
 
 void EditBoxImplWin::setPlaceholderFont(const char* pFontName, int fontSize)
@@ -570,10 +570,10 @@ void EditBoxImplWin::setPlaceholderFont(const char* pFontName, int fontSize)
 	}
 }
 
-void EditBoxImplWin::setPlaceholderFontColor(const Color3B& color)
+void EditBoxImplWin::setPlaceholderFontColor(const Color4B& color)
 {
     _colPlaceHolder = color;
-    _labelPlaceHolder->setColor(color);
+    _labelPlaceHolder->setTextColor(color);
 }
 
 void EditBoxImplWin::setInputMode(EditBox::InputMode inputMode)

--- a/cocos/ui/UIEditBox/UIEditBoxImpl-win32.h
+++ b/cocos/ui/UIEditBox/UIEditBoxImpl-win32.h
@@ -53,9 +53,9 @@ public:
     
     virtual bool initWithSize(const Size& size);
 	virtual void setFont(const char* pFontName, int fontSize);
-    virtual void setFontColor(const Color3B& color);
+    virtual void setFontColor(const Color4B& color);
     virtual void setPlaceholderFont(const char* pFontName, int fontSize);
-    virtual void setPlaceholderFontColor(const Color3B& color);
+    virtual void setPlaceholderFontColor(const Color4B& color);
     virtual void setInputMode(EditBox::InputMode inputMode);
     virtual void setInputFlag(EditBox::InputFlag inputFlag);
     virtual void setMaxLength(int maxLength);
@@ -94,8 +94,8 @@ private:
     std::string _text;
     std::string _placeHolder;
     
-    Color3B _colText;
-    Color3B _colPlaceHolder;
+    Color4B _colText;
+    Color4B _colPlaceHolder;
 
     int   _maxLength;
     Size _editSize;

--- a/cocos/ui/UIEditBox/UIEditBoxImpl-wp8.cpp
+++ b/cocos/ui/UIEditBox/UIEditBoxImpl-wp8.cpp
@@ -105,7 +105,7 @@ bool UIEditBoxImplWp8::initWithSize( const Size& size )
 	// align the text vertically center
 	m_pLabel->setAnchorPoint(Vec2(0.0f, 0.5f));
 	m_pLabel->setPosition(Vec2(5.0, size.height / 2.0f));
-	m_pLabel->setColor(m_colText);
+	m_pLabel->setTextColor(m_colText);
 	_editBox->addChild(m_pLabel);
 
 	m_pLabelPlaceHolder = Label::createWithSystemFont("", "", size.height-12);
@@ -113,7 +113,7 @@ bool UIEditBoxImplWp8::initWithSize( const Size& size )
 	m_pLabelPlaceHolder->setAnchorPoint(Vec2(0.0f, 0.5f));
 	m_pLabelPlaceHolder->setPosition(Vec2(5.0f, size.height / 2.0f));
 	m_pLabelPlaceHolder->setVisible(false);
-	m_pLabelPlaceHolder->setColor(m_colPlaceHolder);
+	m_pLabelPlaceHolder->setTextColor(m_colPlaceHolder);
 	_editBox->addChild(m_pLabelPlaceHolder);
 
 	m_EditSize = size;

--- a/cocos/ui/UIEditBox/UIEditBoxImpl-wp8.cpp
+++ b/cocos/ui/UIEditBox/UIEditBoxImpl-wp8.cpp
@@ -133,10 +133,10 @@ void UIEditBoxImplWp8::setFont( const char* pFontName, int fontSize )
 	}
 }
 
-void UIEditBoxImplWp8::setFontColor( const Color3B& color )
+void UIEditBoxImplWp8::setFontColor( const Color4B& color )
 {
 	m_colText = color;
-	m_pLabel->setColor(color);
+	m_pLabel->setTextColor(color);
 }
 
 void UIEditBoxImplWp8::setPlaceholderFont( const char* pFontName, int fontSize )
@@ -147,10 +147,10 @@ void UIEditBoxImplWp8::setPlaceholderFont( const char* pFontName, int fontSize )
 	}
 }
 
-void UIEditBoxImplWp8::setPlaceholderFontColor( const Color3B& color )
+void UIEditBoxImplWp8::setPlaceholderFontColor( const Color4B& color )
 {
 	m_colPlaceHolder = color;
-	m_pLabelPlaceHolder->setColor(color);
+	m_pLabelPlaceHolder->setTextColor(color);
 }
 
 void UIEditBoxImplWp8::setInputMode( EditBox::InputMode inputMode )

--- a/cocos/ui/UIEditBox/UIEditBoxImpl-wp8.h
+++ b/cocos/ui/UIEditBox/UIEditBoxImpl-wp8.h
@@ -42,9 +42,9 @@ namespace ui {
         
         virtual bool initWithSize(const Size& size);
         virtual void setFont(const char* pFontName, int fontSize);
-        virtual void setFontColor(const Color3B& color);
+        virtual void setFontColor(const Color4B& color);
         virtual void setPlaceholderFont(const char* pFontName, int fontSize);
-        virtual void setPlaceholderFontColor(const Color3B& color);
+        virtual void setPlaceholderFontColor(const Color4B& color);
         virtual void setInputMode(EditBox::InputMode inputMode);
         virtual void setInputFlag(EditBox::InputFlag inputFlag);
         virtual void setMaxLength(int maxLength);
@@ -78,8 +78,8 @@ namespace ui {
          std::string m_strText;
          std::string m_strPlaceHolder;
          
-         Color3B m_colText;
-         Color3B m_colPlaceHolder;
+         Color4B m_colText;
+         Color4B m_colPlaceHolder;
          
          int   m_nMaxLength;
          Size m_EditSize;

--- a/cocos/ui/UIEditBox/UIEditBoxImpl.h
+++ b/cocos/ui/UIEditBox/UIEditBoxImpl.h
@@ -47,9 +47,9 @@ namespace cocos2d {
             
             virtual bool initWithSize(const Size& size) = 0;
             virtual void setFont(const char* pFontName, int fontSize) = 0;
-            virtual void setFontColor(const Color3B& color) = 0;
+            virtual void setFontColor(const Color4B& color) = 0;
             virtual void setPlaceholderFont(const char* pFontName, int fontSize) = 0;
-            virtual void setPlaceholderFontColor(const Color3B& color) = 0;
+            virtual void setPlaceholderFontColor(const Color4B& color) = 0;
             virtual void setInputMode(EditBox::InputMode inputMode) = 0;
             virtual void setInputFlag(EditBox::InputFlag inputFlag) = 0;
             virtual void setMaxLength(int maxLength) = 0;


### PR DESCRIPTION
`EditBox` can easily support `Color4B`, to show translucent placeholders and text, so I created this PR to change `Label` from `setColor` to `setTextColor`, which supports `Color4B`.

To maintain backward compatibility, I provided an overloaded `setFontColor` and `setPlaceholderFontColor`.

Tested on Mac and iOS.
