### PR TITLE
Fix Sprite3DCache crash/cleanup

### DIFF
--- a/cocos/base/CCDirector.cpp
+++ b/cocos/base/CCDirector.cpp
@@ -60,6 +60,7 @@ THE SOFTWARE.
 #include "base/CCAsyncTaskPool.h"
 #include "platform/CCApplication.h"
 //#include "platform/CCGLViewImpl.h"
+#include "3d/CCSprite3D.h"
 
 #if CC_ENABLE_SCRIPT_BINDING
 #include "CCScriptSupport.h"
@@ -996,12 +997,13 @@ void Director::reset()
     GLProgramStateCache::destroyInstance();
     FileUtils::destroyInstance();
     AsyncTaskPool::destoryInstance();
-    
+    Sprite3DCache::destroyInstance();
+
     // cocos2d-x specific data structures
     UserDefault::destroyInstance();
-    
+
     GL::invalidateStateCache();
-    
+
     destroyTextureCache();
 }
 


### PR DESCRIPTION
`Sprite3DCache` is not being cleaned up properly, so it is possible to create
an instance of it and if you then destroy the Director and try to create
a new one, the new one will use the same `Sprite3DCache` which has
dangling references to the old Director, causing a crash as soon as the
application starts (with the second Director) in this case.

This fixes it by destroying the Sprite3DCache when the director is
purged.
