### PR TITLE
V4 removed libspline project from Universal App cpp template

### DIFF
--- a/templates/cpp-template-default/proj.win8.1-universal/App.Windows/HelloCpp.Windows.vcxproj
+++ b/templates/cpp-template-default/proj.win8.1-universal/App.Windows/HelloCpp.Windows.vcxproj
@@ -203,9 +203,6 @@
     <ProjectReference Include="..\..\cocos2d\cocos\2d\libcocos2d_8_1\libcocos2d_8_1\libcocos2d_8_1.Windows\libcocos2d_8_1.Windows.vcxproj">
       <Project>{9335005f-678e-4e8e-9b84-50037216aec8}</Project>
     </ProjectReference>
-    <ProjectReference Include="..\..\cocos2d\cocos\editor-support\spine\proj.win8.1-universal\libSpine.Windows\libSpine.Windows.vcxproj">
-      <Project>{f3550fe0-c795-44f6-8feb-093eb68143ae}</Project>
-    </ProjectReference>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/templates/cpp-template-default/proj.win8.1-universal/App.WindowsPhone/HelloCpp.WindowsPhone.vcxproj
+++ b/templates/cpp-template-default/proj.win8.1-universal/App.WindowsPhone/HelloCpp.WindowsPhone.vcxproj
@@ -147,9 +147,6 @@
     <ProjectReference Include="..\..\cocos2d\cocos\2d\libcocos2d_8_1\libcocos2d_8_1\libcocos2d_8_1.WindowsPhone\libcocos2d_8_1.WindowsPhone.vcxproj">
       <Project>{22f3b9df-1209-4574-8331-003966f562bf}</Project>
     </ProjectReference>
-    <ProjectReference Include="..\..\cocos2d\cocos\editor-support\spine\proj.win8.1-universal\libSpine.WindowsPhone\libSpine.WindowsPhone.vcxproj">
-      <Project>{cc1da216-a80d-4be4-b309-acb6af313aff}</Project>
-    </ProjectReference>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/templates/cpp-template-default/proj.win8.1-universal/HelloCpp.sln
+++ b/templates/cpp-template-default/proj.win8.1-universal/HelloCpp.sln
@@ -1,26 +1,16 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 2013
-VisualStudioVersion = 12.0.30723.0
+VisualStudioVersion = 12.0.31101.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "HelloCpp", "HelloCpp", "{36AFDE04-D127-4D84-9730-D84E3E51EAA7}"
 EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "App.Shared", "App.Shared\HelloCpp.Shared.vcxitems", "{A3AD93E4-0B2F-4C58-9181-69BED2E42E3E}"
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "HelloCpp.Shared", "App.Shared\HelloCpp.Shared.vcxitems", "{A3AD93E4-0B2F-4C58-9181-69BED2E42E3E}"
 EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "App.Windows", "App.Windows\HelloCpp.Windows.vcxproj", "{79A8FCDA-4B12-4DD1-B676-FF148D651638}"
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "HelloCpp.Windows", "App.Windows\HelloCpp.Windows.vcxproj", "{79A8FCDA-4B12-4DD1-B676-FF148D651638}"
 EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "App.WindowsPhone", "App.WindowsPhone\HelloCpp.WindowsPhone.vcxproj", "{396FE85E-BB05-4B92-BCCB-F89AED4EA41A}"
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "HelloCpp.WindowsPhone", "App.WindowsPhone\HelloCpp.WindowsPhone.vcxproj", "{396FE85E-BB05-4B92-BCCB-F89AED4EA41A}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "libcocos2d", "libcocos2d", "{80DA05C1-6532-4D2A-8606-EF02079B1373}"
-EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "External", "External", "{F13CB4F7-BEE5-4368-A815-A971797387D8}"
-EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "libSpine", "libSpine", "{D0E32B77-3B4F-44F8-AEBC-12EE8BBF1783}"
-EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "libSpine.Shared", "..\cocos2d\cocos\editor-support\spine\proj.win8.1-universal\libSpine.Shared\libSpine.Shared.vcxitems", "{ADAFD00D-A0D6-46EF-9F0B-EA2880BFE1DE}"
-EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "libSpine.Windows", "..\cocos2d\cocos\editor-support\spine\proj.win8.1-universal\libSpine.Windows\libSpine.Windows.vcxproj", "{F3550FE0-C795-44F6-8FEB-093EB68143AE}"
-EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "libSpine.WindowsPhone", "..\cocos2d\cocos\editor-support\spine\proj.win8.1-universal\libSpine.WindowsPhone\libSpine.WindowsPhone.vcxproj", "{CC1DA216-A80D-4BE4-B309-ACB6AF313AFF}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "libcocos2d_8_1.Shared", "..\cocos2d\cocos\2d\libcocos2d_8_1\libcocos2d_8_1\libcocos2d_8_1.Shared\libcocos2d_8_1.Shared.vcxitems", "{5D6F020F-7E72-4494-90A0-2DF11D235DF9}"
 EndProject
@@ -32,12 +22,9 @@ Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		..\cocos2d\cocos\2d\libcocos2d_8_1\libcocos2d_8_1\libcocos2d_8_1.Shared\libcocos2d_8_1.Shared.vcxitems*{9335005f-678e-4e8e-9b84-50037216aec8}*SharedItemsImports = 4
 		App.Shared\HelloCpp.Shared.vcxitems*{a3ad93e4-0b2f-4c58-9181-69bed2e42e3e}*SharedItemsImports = 9
-		..\cocos2d\cocos\editor-support\spine\proj.win8.1-universal\libSpine.Shared\libSpine.Shared.vcxitems*{cc1da216-a80d-4be4-b309-acb6af313aff}*SharedItemsImports = 4
 		App.Shared\HelloCpp.Shared.vcxitems*{79a8fcda-4b12-4dd1-b676-ff148d651638}*SharedItemsImports = 4
-		..\cocos2d\cocos\editor-support\spine\proj.win8.1-universal\libSpine.Shared\libSpine.Shared.vcxitems*{adafd00d-a0d6-46ef-9f0b-ea2880bfe1de}*SharedItemsImports = 9
 		..\cocos2d\cocos\2d\libcocos2d_8_1\libcocos2d_8_1\libcocos2d_8_1.Shared\libcocos2d_8_1.Shared.vcxitems*{5d6f020f-7e72-4494-90a0-2df11d235df9}*SharedItemsImports = 9
 		..\cocos2d\cocos\2d\libcocos2d_8_1\libcocos2d_8_1\libcocos2d_8_1.Shared\libcocos2d_8_1.Shared.vcxitems*{22f3b9df-1209-4574-8331-003966f562bf}*SharedItemsImports = 4
-		..\cocos2d\cocos\editor-support\spine\proj.win8.1-universal\libSpine.Shared\libSpine.Shared.vcxitems*{f3550fe0-c795-44f6-8feb-093eb68143ae}*SharedItemsImports = 4
 		App.Shared\HelloCpp.Shared.vcxitems*{396fe85e-bb05-4b92-bccb-f89aed4ea41a}*SharedItemsImports = 4
 	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -81,28 +68,6 @@ Global
 		{396FE85E-BB05-4B92-BCCB-F89AED4EA41A}.Release|Win32.Build.0 = Release|Win32
 		{396FE85E-BB05-4B92-BCCB-F89AED4EA41A}.Release|Win32.Deploy.0 = Release|Win32
 		{396FE85E-BB05-4B92-BCCB-F89AED4EA41A}.Release|x64.ActiveCfg = Release|Win32
-		{F3550FE0-C795-44F6-8FEB-093EB68143AE}.Debug|ARM.ActiveCfg = Debug|ARM
-		{F3550FE0-C795-44F6-8FEB-093EB68143AE}.Debug|ARM.Build.0 = Debug|ARM
-		{F3550FE0-C795-44F6-8FEB-093EB68143AE}.Debug|Win32.ActiveCfg = Debug|Win32
-		{F3550FE0-C795-44F6-8FEB-093EB68143AE}.Debug|Win32.Build.0 = Debug|Win32
-		{F3550FE0-C795-44F6-8FEB-093EB68143AE}.Debug|x64.ActiveCfg = Debug|x64
-		{F3550FE0-C795-44F6-8FEB-093EB68143AE}.Debug|x64.Build.0 = Debug|x64
-		{F3550FE0-C795-44F6-8FEB-093EB68143AE}.Release|ARM.ActiveCfg = Release|ARM
-		{F3550FE0-C795-44F6-8FEB-093EB68143AE}.Release|ARM.Build.0 = Release|ARM
-		{F3550FE0-C795-44F6-8FEB-093EB68143AE}.Release|Win32.ActiveCfg = Release|Win32
-		{F3550FE0-C795-44F6-8FEB-093EB68143AE}.Release|Win32.Build.0 = Release|Win32
-		{F3550FE0-C795-44F6-8FEB-093EB68143AE}.Release|x64.ActiveCfg = Release|x64
-		{F3550FE0-C795-44F6-8FEB-093EB68143AE}.Release|x64.Build.0 = Release|x64
-		{CC1DA216-A80D-4BE4-B309-ACB6AF313AFF}.Debug|ARM.ActiveCfg = Debug|ARM
-		{CC1DA216-A80D-4BE4-B309-ACB6AF313AFF}.Debug|ARM.Build.0 = Debug|ARM
-		{CC1DA216-A80D-4BE4-B309-ACB6AF313AFF}.Debug|Win32.ActiveCfg = Debug|Win32
-		{CC1DA216-A80D-4BE4-B309-ACB6AF313AFF}.Debug|Win32.Build.0 = Debug|Win32
-		{CC1DA216-A80D-4BE4-B309-ACB6AF313AFF}.Debug|x64.ActiveCfg = Debug|Win32
-		{CC1DA216-A80D-4BE4-B309-ACB6AF313AFF}.Release|ARM.ActiveCfg = Release|ARM
-		{CC1DA216-A80D-4BE4-B309-ACB6AF313AFF}.Release|ARM.Build.0 = Release|ARM
-		{CC1DA216-A80D-4BE4-B309-ACB6AF313AFF}.Release|Win32.ActiveCfg = Release|Win32
-		{CC1DA216-A80D-4BE4-B309-ACB6AF313AFF}.Release|Win32.Build.0 = Release|Win32
-		{CC1DA216-A80D-4BE4-B309-ACB6AF313AFF}.Release|x64.ActiveCfg = Release|Win32
 		{9335005F-678E-4E8E-9B84-50037216AEC8}.Debug|ARM.ActiveCfg = Debug|ARM
 		{9335005F-678E-4E8E-9B84-50037216AEC8}.Debug|ARM.Build.0 = Debug|ARM
 		{9335005F-678E-4E8E-9B84-50037216AEC8}.Debug|Win32.ActiveCfg = Debug|Win32
@@ -133,10 +98,6 @@ Global
 		{A3AD93E4-0B2F-4C58-9181-69BED2E42E3E} = {36AFDE04-D127-4D84-9730-D84E3E51EAA7}
 		{79A8FCDA-4B12-4DD1-B676-FF148D651638} = {36AFDE04-D127-4D84-9730-D84E3E51EAA7}
 		{396FE85E-BB05-4B92-BCCB-F89AED4EA41A} = {36AFDE04-D127-4D84-9730-D84E3E51EAA7}
-		{D0E32B77-3B4F-44F8-AEBC-12EE8BBF1783} = {F13CB4F7-BEE5-4368-A815-A971797387D8}
-		{ADAFD00D-A0D6-46EF-9F0B-EA2880BFE1DE} = {D0E32B77-3B4F-44F8-AEBC-12EE8BBF1783}
-		{F3550FE0-C795-44F6-8FEB-093EB68143AE} = {D0E32B77-3B4F-44F8-AEBC-12EE8BBF1783}
-		{CC1DA216-A80D-4BE4-B309-ACB6AF313AFF} = {D0E32B77-3B4F-44F8-AEBC-12EE8BBF1783}
 		{5D6F020F-7E72-4494-90A0-2DF11D235DF9} = {80DA05C1-6532-4D2A-8606-EF02079B1373}
 		{9335005F-678E-4E8E-9B84-50037216AEC8} = {80DA05C1-6532-4D2A-8606-EF02079B1373}
 		{22F3B9DF-1209-4574-8331-003966F562BF} = {80DA05C1-6532-4D2A-8606-EF02079B1373}


### PR DESCRIPTION
This pull request fixes the Universal App cpp template broken by the removal of libspline.
