### PR TITLE
Fix CCDevice-ios.mm to have the right alpha color for a stroke effect.

### DIFF
--- a/cocos/platform/ios/CCDevice-ios.mm
+++ b/cocos/platform/ios/CCDevice-ios.mm
@@ -471,7 +471,7 @@ Data Device::getTextureDataForText(const char * text, const FontDefinition& text
         info.strokeColorR           = textDefinition._stroke._strokeColor.r / 255.0f;
         info.strokeColorG           = textDefinition._stroke._strokeColor.g / 255.0f;
         info.strokeColorB           = textDefinition._stroke._strokeColor.b / 255.0f;
-        info.strokeColorB           = textDefinition._stroke._strokeAlpha / 255.0f;
+        info.strokeColorA           = textDefinition._stroke._strokeAlpha / 255.0f;
         info.strokeSize             = textDefinition._stroke._strokeSize;
         info.tintColorR             = textDefinition._fontFillColor.r / 255.0f;
         info.tintColorG             = textDefinition._fontFillColor.g / 255.0f;


### PR DESCRIPTION
There is a typo in CCDevice-ios.mm while handling a stroke alpha color.
