### PR TITLE
Finish http request even if status code is not between 200 and 300

### DIFF
--- a/cocos/network/HttpAsynConnection.m
+++ b/cocos/network/HttpAsynConnection.m
@@ -98,23 +98,6 @@
     if(responseCode == 200)
         self.statusString = @"OK";
  
-    /*The individual values of the numeric status codes defined for HTTP/1.1
-    | “200”  ; OK
-    | “201”  ; Created
-    | “202”  ; Accepted
-    | “203”  ; Non-Authoritative Information
-    | “204”  ; No Content
-    | “205”  ; Reset Content
-    | “206”  ; Partial Content
-    */
-    if (responseCode < 200 || responseCode >= 300)
-    {// something went wrong, abort the whole thing
-        
-        [connection cancel];
-        finish = true;
-        return;
-    }
-    
     [responseData setLength:0];
 }
 


### PR DESCRIPTION
HTTP request must not be cancelled even if received status code is not between 200 and 300. Most of times status code indicating error contains additional information in their body. 

For example, you can curl facebook api like the below, which returns 400 status code and detailed information as their response text.

```
[-:] redism@~: curl -i -XGET https://graph.facebook.com/me?access_token=INVALID_TOKEN
HTTP/1.1 400 Bad Request
Content-Type: application/json; charset=UTF-8
WWW-Authenticate: OAuth "Facebook Platform" "invalid_token" "Invalid OAuth access token."
Access-Control-Allow-Origin: *
X-FB-Rev: 1633075
Pragma: no-cache
Cache-Control: no-store
Expires: Sat, 01 Jan 2000 00:00:00 GMT
X-FB-Debug: Zckv+9Ei2aav58QDANhhMwpmdNEVVUEE5lAHoB9KEIMuCUnTRjKlslhdHL8rCmvoOLe8bGNMwTAogFW0zM5jJg==
Date: Tue, 10 Mar 2015 15:29:12 GMT
Connection: keep-alive
Content-Length: 86

{"error":{"message":"Invalid OAuth access token.","type":"OAuthException","code":190}}
```

Current code always returns empty string as response text if status code is not between 200 and 300, and this PR fixes it.
