### PR TITLE
V4 Added Windows Image Component support for Windows 8.1 Universal Apps

### DIFF
--- a/cocos/2d/libcocos2d_8_1/libcocos2d_8_1/libcocos2d_8_1.Shared/libcocos2d_8_1.Shared.vcxitems
+++ b/cocos/2d/libcocos2d_8_1/libcocos2d_8_1/libcocos2d_8_1.Shared/libcocos2d_8_1.Shared.vcxitems
@@ -200,6 +200,7 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\..\..\platform\winrt\Keyboard-winrt.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\..\..\platform\winrt\pch.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\..\..\platform\winrt\sha1.h" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\..\..\platform\winrt\WICImageLoader-win.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\..\..\renderer\CCBatchCommand.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\..\..\renderer\CCCustomCommand.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\..\..\renderer\CCGLProgram.h" />
@@ -485,6 +486,7 @@
       </ForcedIncludeFiles>
     </ClCompile>
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\..\..\platform\winrt\sha1.cpp" />
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\..\..\platform\winrt\WICImageLoader-win.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\..\..\renderer\CCBatchCommand.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\..\..\renderer\CCCustomCommand.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\..\..\renderer\CCGLProgram.cpp" />

--- a/cocos/2d/libcocos2d_8_1/libcocos2d_8_1/libcocos2d_8_1.Shared/libcocos2d_8_1.Shared.vcxitems.filters
+++ b/cocos/2d/libcocos2d_8_1/libcocos2d_8_1/libcocos2d_8_1.Shared/libcocos2d_8_1.Shared.vcxitems.filters
@@ -922,6 +922,9 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\..\..\renderer\CCStencilCommand.h">
       <Filter>renderer</Filter>
     </ClInclude>
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\..\..\platform\winrt\WICImageLoader-win.h">
+      <Filter>platform\winrt</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\..\..\cocos2d.cpp" />
@@ -1693,6 +1696,9 @@
     </ClCompile>
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\..\..\renderer\CCStencilCommand.cpp">
       <Filter>renderer</Filter>
+    </ClCompile>
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\..\..\platform\winrt\WICImageLoader-win.cpp">
+      <Filter>platform\winrt</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/cocos/2d/winrt_8.1_props/cocos2d_winrt_8.1.props
+++ b/cocos/2d/winrt_8.1_props/cocos2d_winrt_8.1.props
@@ -18,7 +18,7 @@
       <DisableSpecificWarnings>4056;4244;4251;4756;28204;4453;</DisableSpecificWarnings>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>libGLESv2.lib;libEGL.lib;ws2_32.lib;libwebsockets.lib;libcurl.lib;libchipmunk.lib;zlib.lib;libpng.lib;libjpeg.lib;libtiff.lib;freetype250.lib;sqlite3.lib;d2d1.lib;d3d11.lib;dxgi.lib;windowscodecs.lib;dwrite.lib;dxguid.lib;xaudio2.lib;mfcore.lib;mfplat.lib;mfreadwrite.lib;mfuuid.lib;xxhash.lib;tinyxml2.lib;convertutf.lib;edtaa3.lib;minizip.lib;box2d.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>libGLESv2.lib;libEGL.lib;ws2_32.lib;libwebsockets.lib;libcurl.lib;libchipmunk.lib;zlib.lib;freetype250.lib;sqlite3.lib;d2d1.lib;d3d11.lib;dxgi.lib;windowscodecs.lib;dwrite.lib;dxguid.lib;xaudio2.lib;mfcore.lib;mfplat.lib;mfreadwrite.lib;mfuuid.lib;xxhash.lib;tinyxml2.lib;convertutf.lib;edtaa3.lib;minizip.lib;box2d.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <AdditionalOptions>/IGNORE:4264 %(AdditionalOptions)</AdditionalOptions>
     </Link>

--- a/cocos/base/ccConfig.h
+++ b/cocos/base/ccConfig.h
@@ -274,6 +274,12 @@ To enable set it to a value different than 0. Disabled by default.
 #define CC_USE_CULLING 1
 #endif
 
+/** Support PNG or not. If your application don't use png format picture, you can undefine this macro to save package size.
+*/
+#ifndef CC_USE_PNG
+#define CC_USE_PNG  1
+#endif // CC_USE_PNG
+
 /** Support JPEG or not. If your application don't use jpeg format picture, you can undefine this macro to save package size.
  */
 #ifndef CC_USE_JPEG
@@ -293,6 +299,17 @@ To enable set it to a value different than 0. Disabled by default.
 #define CC_USE_WEBP  1
 #endif
 #endif // CC_USE_WEBP
+
+/** Support WIC (Windows Image Component) or not. Replaces PNG, TIFF and JPEG
+*/
+#ifndef CC_USE_WIC
+#if (CC_TARGET_PLATFORM == CC_PLATFORM_WINRT)
+#define CC_USE_WIC  1
+#undef CC_USE_TIFF
+#undef CC_USE_JPEG
+#undef CC_USE_PNG
+#endif
+#endif // CC_USE_WIC
 
 /** Enable Script binding */
 #ifndef CC_ENABLE_SCRIPT_BINDING

--- a/cocos/platform/CCImage.cpp
+++ b/cocos/platform/CCImage.cpp
@@ -54,8 +54,11 @@ extern "C"
     }
 #endif
 #endif
+
+#if CC_USE_PNG
 #include "png/png.h"
-    
+#endif //CC_USE_PNG
+
 #if CC_USE_TIFF
 #include "tiff/tiffio.h"
 #endif //CC_USE_TIFF
@@ -409,7 +412,8 @@ namespace
         ssize_t size;
         int offset;
     }tImageSource;
-    
+ 
+#ifdef CC_USE_PNG
     static void pngReadCallback(png_structp png_ptr, png_bytep data, png_size_t length)
     {
         tImageSource* isource = (tImageSource*)png_get_io_ptr(png_ptr);
@@ -424,6 +428,7 @@ namespace
             png_error(png_ptr, "pngReaderCallback failed");
         }
     }
+#endif //CC_USE_PNG
 }
 
 Texture2D::PixelFormat getDevicePixelFormat(Texture2D::PixelFormat format)
@@ -799,9 +804,75 @@ namespace
 #endif // CC_USE_JPEG
 }
 
+#ifdef CC_USE_WIC
+bool Image::decodeWithWIC(const unsigned char *data, ssize_t dataLen)
+{
+    bool bRet = false;
+    WICImageLoader img;
+
+    if (img.decodeImageData(data, dataLen))
+    {
+        _width = img.getWidth();
+        _height = img.getHeight();
+        _hasPremultipliedAlpha = false;
+
+        WICPixelFormatGUID format = img.getPixelFormat();
+
+        if (memcmp(&format, &GUID_WICPixelFormat8bppGray, sizeof(WICPixelFormatGUID)) == 0)
+        {
+            _renderFormat = Texture2D::PixelFormat::I8;
+        }
+
+        if (memcmp(&format, &GUID_WICPixelFormat8bppAlpha, sizeof(WICPixelFormatGUID)) == 0)
+        {
+            _renderFormat = Texture2D::PixelFormat::AI88;
+        }
+
+        if (memcmp(&format, &GUID_WICPixelFormat24bppRGB, sizeof(WICPixelFormatGUID)) == 0)
+        {
+            _renderFormat = Texture2D::PixelFormat::RGB888;
+        }
+
+        if (memcmp(&format, &GUID_WICPixelFormat32bppRGBA, sizeof(WICPixelFormatGUID)) == 0)
+        {
+            _renderFormat = Texture2D::PixelFormat::RGBA8888;
+        }
+
+        if (memcmp(&format, &GUID_WICPixelFormat32bppBGRA, sizeof(WICPixelFormatGUID)) == 0)
+        {
+            _renderFormat = Texture2D::PixelFormat::BGRA8888;
+        }
+
+        _dataLen = img.getImageDataSize();
+
+        CCAssert(_dataLen > 0, "Image: Decompressed data length is invalid");
+
+        _data = new (std::nothrow) unsigned char[_dataLen];
+        bRet = (img.getImageData(_data, _dataLen) > 0);
+
+        if (_renderFormat == Texture2D::PixelFormat::RGBA8888) {
+            premultipliedAlpha();
+        }
+    }
+
+    return bRet;
+}
+
+bool Image::encodeWithWIC(const std::string& filePath, bool isToRGB, GUID containerFormat)
+{
+    WICPixelFormatGUID format = isToRGB ? GUID_WICPixelFormat24bppRGB : GUID_WICPixelFormat32bppRGBA;
+
+    WICImageLoader img;
+    return img.encodeImageData(filePath, _data, _dataLen, format, _width, _height, containerFormat);
+}
+
+#endif //CC_USE_WIC
+
 bool Image::initWithJpgData(const unsigned char * data, ssize_t dataLen)
 {
-#if CC_USE_JPEG
+#if defined(CC_USE_WIC)
+    return decodeWithWIC(data, dataLen);
+#elif defined(CC_USE_JPEG)
     /* these are standard libjpeg structures for reading(decompression) */
     struct jpeg_decompress_struct cinfo;
     /* We use our private extension JPEG error handler.
@@ -894,6 +965,9 @@ bool Image::initWithJpgData(const unsigned char * data, ssize_t dataLen)
 
 bool Image::initWithPngData(const unsigned char * data, ssize_t dataLen)
 {
+#if defined(CC_USE_WIC)
+    return decodeWithWIC(data, dataLen);
+#elif defined(CC_USE_PNG)
     // length of bytes to check if it is a valid png file
 #define PNGSIGSIZE  8
     bool ret = false;
@@ -1040,6 +1114,7 @@ bool Image::initWithPngData(const unsigned char * data, ssize_t dataLen)
         png_destroy_read_struct(&png_ptr, (info_ptr) ? &info_ptr : 0, 0);
     }
     return ret;
+#endif // CC_USE_PNG
 }
 
 #if CC_USE_TIFF
@@ -1156,7 +1231,9 @@ namespace
 
 bool Image::initWithTiffData(const unsigned char * data, ssize_t dataLen)
 {
-#if CC_USE_TIFF
+#if defined(CC_USE_WIC)
+    return decodeWithWIC(data, dataLen);
+#elif defined(CC_USE_TIFF)
     bool ret = false;
     do 
     {
@@ -2119,8 +2196,11 @@ bool Image::saveToFile(const std::string& filename, bool isToRGB)
 
 bool Image::saveImageToPNG(const std::string& filePath, bool isToRGB)
 {
+#if defined(CC_USE_WIC)
+    return encodeWithWIC(filePath, isToRGB, GUID_ContainerFormatPng);
+#elif defined(CC_USE_PNG)
     bool ret = false;
-    do 
+    do
     {
         FILE *fp;
         png_structp png_ptr;
@@ -2260,10 +2340,17 @@ bool Image::saveImageToPNG(const std::string& filePath, bool isToRGB)
         ret = true;
     } while (0);
     return ret;
+#else
+    CCLOG("png is not enabled, please enable it in ccConfig.h");
+    return false;
+#endif // CC_USE_PNG
 }
+
 bool Image::saveImageToJPG(const std::string& filePath)
 {
-#if CC_USE_JPEG
+#if defined(CC_USE_WIC)
+    return encodeWithWIC(filePath, false, GUID_ContainerFormatJpeg);
+#elif defined(CC_USE_JPEG)
     bool ret = false;
     do 
     {

--- a/cocos/platform/CCImage.cpp
+++ b/cocos/platform/CCImage.cpp
@@ -959,6 +959,7 @@ bool Image::initWithJpgData(const unsigned char * data, ssize_t dataLen)
 
     return ret;
 #else
+    CCLOG("jpeg is not enabled, please enable it in ccConfig.h");
     return false;
 #endif // CC_USE_JPEG
 }
@@ -1114,7 +1115,10 @@ bool Image::initWithPngData(const unsigned char * data, ssize_t dataLen)
         png_destroy_read_struct(&png_ptr, (info_ptr) ? &info_ptr : 0, 0);
     }
     return ret;
-#endif // CC_USE_PNG
+#else
+    CCLOG("png is not enabled, please enable it in ccConfig.h");
+    return false;
+#endif //CC_USE_PNG
 }
 
 #if CC_USE_TIFF
@@ -1292,9 +1296,9 @@ bool Image::initWithTiffData(const unsigned char * data, ssize_t dataLen)
     } while (0);
     return ret;
 #else
-    CCLOG("tiff is not enabled, please enalbe it in ccConfig.h");
+    CCLOG("tiff is not enabled, please enable it in ccConfig.h");
     return false;
-#endif
+#endif //CC_USE_TIFF
 }
 
 namespace

--- a/cocos/platform/CCImage.h
+++ b/cocos/platform/CCImage.h
@@ -29,6 +29,10 @@ THE SOFTWARE.
 #include "base/CCRef.h"
 #include "renderer/CCTexture2D.h"
 
+#if defined(CC_USE_WIC)
+#include "WICImageLoader-win.h"
+#endif
+
 // premultiply alpha, or the effect will wrong when want to use other pixel format in Texture2D,
 // such as RGB888, RGB5A1
 #define CC_RGB_PREMULTIPLY_ALPHA(vr, vg, vb, va) \
@@ -149,6 +153,10 @@ public:
     static void setPVRImagesHavePremultipliedAlpha(bool haveAlphaPremultiplied);
 
 protected:
+#if defined(CC_USE_WIC)
+	bool encodeWithWIC(const std::string& filePath, bool isToRGB, GUID containerFormat);
+	bool decodeWithWIC(const unsigned char *data, ssize_t dataLen);
+#endif
     bool initWithJpgData(const unsigned char *  data, ssize_t dataLen);
     bool initWithPngData(const unsigned char * data, ssize_t dataLen);
     bool initWithTiffData(const unsigned char * data, ssize_t dataLen);
@@ -214,6 +222,7 @@ protected:
 
 // end of platform group
 /// @}
+
 
 NS_CC_END
 

--- a/cocos/platform/winrt/WICImageLoader-win.cpp
+++ b/cocos/platform/winrt/WICImageLoader-win.cpp
@@ -1,0 +1,433 @@
+/****************************************************************************
+Copyright (c) Microsoft Open Technologies, Inc.  All rights reserved.
+
+The MIT License (MIT)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+Based upon code from the DirectX Tool Kit by Microsoft Corporation,
+obtained from https://directxtk.codeplex.com
+****************************************************************************/
+#include "WICImageLoader-win.h"
+
+NS_CC_BEGIN
+
+#if defined(CC_USE_WIC)
+
+	IWICImagingFactory* WICImageLoader::_wicFactory = NULL;
+
+static WICConvert g_WICConvert[] = 
+{
+	// Note target GUID in this conversion table must be one of those directly supported formats (above).
+
+	{ GUID_WICPixelFormatBlackWhite,            GUID_WICPixelFormat8bppGray }, // DXGI_FORMAT_R8_UNORM
+
+	{ GUID_WICPixelFormat1bppIndexed,           GUID_WICPixelFormat32bppRGBA }, // DXGI_FORMAT_R8G8B8A8_UNORM 
+	{ GUID_WICPixelFormat2bppIndexed,           GUID_WICPixelFormat32bppRGBA }, // DXGI_FORMAT_R8G8B8A8_UNORM 
+	{ GUID_WICPixelFormat4bppIndexed,           GUID_WICPixelFormat32bppRGBA }, // DXGI_FORMAT_R8G8B8A8_UNORM 
+	{ GUID_WICPixelFormat8bppIndexed,           GUID_WICPixelFormat32bppRGBA }, // DXGI_FORMAT_R8G8B8A8_UNORM 
+
+	{ GUID_WICPixelFormat2bppGray,              GUID_WICPixelFormat8bppGray }, // DXGI_FORMAT_R8_UNORM 
+	{ GUID_WICPixelFormat4bppGray,              GUID_WICPixelFormat8bppGray }, // DXGI_FORMAT_R8_UNORM 
+
+	{ GUID_WICPixelFormat16bppGrayFixedPoint,   GUID_WICPixelFormat16bppGrayHalf }, // DXGI_FORMAT_R16_FLOAT 
+	{ GUID_WICPixelFormat32bppGrayFixedPoint,   GUID_WICPixelFormat32bppGrayFloat }, // DXGI_FORMAT_R32_FLOAT 
+
+	{ GUID_WICPixelFormat16bppBGR555,           GUID_WICPixelFormat16bppBGRA5551 }, // DXGI_FORMAT_B5G5R5A1_UNORM
+
+	{ GUID_WICPixelFormat32bppBGR101010,        GUID_WICPixelFormat32bppRGBA1010102 }, // DXGI_FORMAT_R10G10B10A2_UNORM
+
+	{ GUID_WICPixelFormat24bppBGR,              GUID_WICPixelFormat32bppRGBA }, // DXGI_FORMAT_R8G8B8A8_UNORM 
+	{ GUID_WICPixelFormat24bppRGB,              GUID_WICPixelFormat32bppRGBA }, // DXGI_FORMAT_R8G8B8A8_UNORM 
+	{ GUID_WICPixelFormat32bppPBGRA,            GUID_WICPixelFormat32bppRGBA }, // DXGI_FORMAT_R8G8B8A8_UNORM 
+	{ GUID_WICPixelFormat32bppPRGBA,            GUID_WICPixelFormat32bppRGBA }, // DXGI_FORMAT_R8G8B8A8_UNORM 
+
+	{ GUID_WICPixelFormat48bppRGB,              GUID_WICPixelFormat64bppRGBA }, // DXGI_FORMAT_R16G16B16A16_UNORM
+	{ GUID_WICPixelFormat48bppBGR,              GUID_WICPixelFormat64bppRGBA }, // DXGI_FORMAT_R16G16B16A16_UNORM
+	{ GUID_WICPixelFormat64bppBGRA,             GUID_WICPixelFormat64bppRGBA }, // DXGI_FORMAT_R16G16B16A16_UNORM
+	{ GUID_WICPixelFormat64bppPRGBA,            GUID_WICPixelFormat64bppRGBA }, // DXGI_FORMAT_R16G16B16A16_UNORM
+	{ GUID_WICPixelFormat64bppPBGRA,            GUID_WICPixelFormat64bppRGBA }, // DXGI_FORMAT_R16G16B16A16_UNORM
+
+	{ GUID_WICPixelFormat48bppRGBFixedPoint,    GUID_WICPixelFormat64bppRGBAHalf }, // DXGI_FORMAT_R16G16B16A16_FLOAT 
+	{ GUID_WICPixelFormat48bppBGRFixedPoint,    GUID_WICPixelFormat64bppRGBAHalf }, // DXGI_FORMAT_R16G16B16A16_FLOAT 
+	{ GUID_WICPixelFormat64bppRGBAFixedPoint,   GUID_WICPixelFormat64bppRGBAHalf }, // DXGI_FORMAT_R16G16B16A16_FLOAT 
+	{ GUID_WICPixelFormat64bppBGRAFixedPoint,   GUID_WICPixelFormat64bppRGBAHalf }, // DXGI_FORMAT_R16G16B16A16_FLOAT 
+	{ GUID_WICPixelFormat64bppRGBFixedPoint,    GUID_WICPixelFormat64bppRGBAHalf }, // DXGI_FORMAT_R16G16B16A16_FLOAT 
+	{ GUID_WICPixelFormat64bppRGBHalf,          GUID_WICPixelFormat64bppRGBAHalf }, // DXGI_FORMAT_R16G16B16A16_FLOAT 
+	{ GUID_WICPixelFormat48bppRGBHalf,          GUID_WICPixelFormat64bppRGBAHalf }, // DXGI_FORMAT_R16G16B16A16_FLOAT 
+
+	{ GUID_WICPixelFormat128bppPRGBAFloat,      GUID_WICPixelFormat128bppRGBAFloat }, // DXGI_FORMAT_R32G32B32A32_FLOAT 
+	{ GUID_WICPixelFormat128bppRGBFloat,        GUID_WICPixelFormat128bppRGBAFloat }, // DXGI_FORMAT_R32G32B32A32_FLOAT 
+	{ GUID_WICPixelFormat128bppRGBAFixedPoint,  GUID_WICPixelFormat128bppRGBAFloat }, // DXGI_FORMAT_R32G32B32A32_FLOAT 
+	{ GUID_WICPixelFormat128bppRGBFixedPoint,   GUID_WICPixelFormat128bppRGBAFloat }, // DXGI_FORMAT_R32G32B32A32_FLOAT 
+	{ GUID_WICPixelFormat32bppRGBE,             GUID_WICPixelFormat128bppRGBAFloat }, // DXGI_FORMAT_R32G32B32A32_FLOAT 
+
+	{ GUID_WICPixelFormat32bppCMYK,             GUID_WICPixelFormat32bppRGBA }, // DXGI_FORMAT_R8G8B8A8_UNORM 
+	{ GUID_WICPixelFormat64bppCMYK,             GUID_WICPixelFormat64bppRGBA }, // DXGI_FORMAT_R16G16B16A16_UNORM
+	{ GUID_WICPixelFormat40bppCMYKAlpha,        GUID_WICPixelFormat64bppRGBA }, // DXGI_FORMAT_R16G16B16A16_UNORM
+	{ GUID_WICPixelFormat80bppCMYKAlpha,        GUID_WICPixelFormat64bppRGBA }, // DXGI_FORMAT_R16G16B16A16_UNORM
+
+	//#if (_WIN32_WINNT >= _WIN32_WINNT_WIN8) || defined(_WIN7_PLATFORM_UPDATE)
+	//    { GUID_WICPixelFormat32bppRGB,              GUID_WICPixelFormat32bppRGBA }, // DXGI_FORMAT_R8G8B8A8_UNORM
+	//    { GUID_WICPixelFormat64bppRGB,              GUID_WICPixelFormat64bppRGBA }, // DXGI_FORMAT_R16G16B16A16_UNORM
+	//    { GUID_WICPixelFormat64bppPRGBAHalf,        GUID_WICPixelFormat64bppRGBAHalf }, // DXGI_FORMAT_R16G16B16A16_FLOAT 
+	//#endif
+
+	// We don't support n-channel formats
+};
+
+WICImageLoader::WICImageLoader() :
+	_width(0),
+	_height(0),
+	_dataLen(0),
+	_bpp(0),
+	_data(0)
+{
+	memset((void*)&_format, 0, sizeof(_format));
+}
+
+WICImageLoader::~WICImageLoader()
+{
+	if(_data != NULL && _dataLen > 0) {
+		delete[] _data;
+		_data = NULL;
+	}
+}
+
+bool WICImageLoader::decodeImageData(ImageBlob blob, size_t size)
+{
+	bool bRet = false;
+	HRESULT hr = S_FALSE;
+
+	IWICStream* pWicStream = NULL;
+	IWICImagingFactory* pWicFactory = getWICFactory();
+
+	if(NULL != pWicFactory)
+	{
+		hr = pWicFactory->CreateStream(&pWicStream);
+	}
+
+	if(SUCCEEDED(hr))
+	{
+		hr = pWicStream->InitializeFromMemory((BYTE*)blob, size);
+	}
+
+	IWICBitmapDecoder* pDecoder = NULL;
+
+	if(SUCCEEDED(hr))
+	{
+		hr = pWicFactory->CreateDecoderFromStream(pWicStream, NULL, WICDecodeMetadataCacheOnLoad, &pDecoder);
+	}
+
+	bRet = processImage(pDecoder);
+
+	SafeRelease(&pWicStream);
+	SafeRelease(&pDecoder);
+
+	return bRet;
+}
+
+bool WICImageLoader::processImage(IWICBitmapDecoder* pDecoder)
+{
+	HRESULT hr = S_FALSE;
+	IWICBitmapFrameDecode* pFrame = NULL;
+
+	if(NULL != pDecoder)
+	{
+		hr = pDecoder->GetFrame(0, &pFrame);
+	}
+
+	if(SUCCEEDED(hr))
+	{
+		hr = pFrame->GetPixelFormat(&_format);
+	}
+
+	IWICFormatConverter* pConv = NULL;
+
+	if(SUCCEEDED(hr))
+	{
+		hr = convertFormatIfRequired(pFrame, &pConv);
+	}
+
+	if(SUCCEEDED(hr))
+	{
+		_bpp = getBitsPerPixel(_format); 
+
+		if(NULL != pConv) 
+		{
+			hr = pConv->GetSize((UINT*)&_width, (UINT*)&_height);
+		}
+		else
+		{
+			hr = pFrame->GetSize((UINT*)&_width, (UINT*)&_height);
+		}
+	}
+
+	assert(_bpp > 0);
+	assert(_width > 0 && _height > 0);
+
+	if(SUCCEEDED(hr))
+	{
+		size_t rowPitch = (_width * _bpp + 7) / 8;
+		_dataLen = rowPitch * _height;
+		_data = new (std::nothrow) BYTE[_dataLen];
+
+		if(NULL != pConv)
+		{
+			hr = pConv->CopyPixels(NULL, rowPitch, _dataLen, _data);
+		}
+		else
+		{
+			hr = pFrame->CopyPixels(NULL, rowPitch, _dataLen, _data);
+		}
+	}
+
+	SafeRelease(&pFrame);
+	SafeRelease(&pConv);
+	return SUCCEEDED(hr);
+}
+
+HRESULT WICImageLoader::convertFormatIfRequired(IWICBitmapFrameDecode* pFrame, IWICFormatConverter** ppConv)
+{
+	*ppConv = NULL;
+
+	if(	(memcmp(&_format, &GUID_WICPixelFormat8bppGray, sizeof(WICPixelFormatGUID)) == 0) ||
+		(memcmp(&_format, &GUID_WICPixelFormat8bppAlpha, sizeof(WICPixelFormatGUID)) == 0) ||
+		(memcmp(&_format, &GUID_WICPixelFormat24bppRGB, sizeof(WICPixelFormatGUID)) == 0) ||
+		(memcmp(&_format, &GUID_WICPixelFormat32bppRGBA, sizeof(WICPixelFormatGUID)) == 0) ||
+		(memcmp(&_format, &GUID_WICPixelFormat32bppBGRA, sizeof(WICPixelFormatGUID)) == 0))
+	{
+		return S_OK;
+	}
+
+	HRESULT hr = E_FAIL;
+	IWICImagingFactory* pFactory = getWICFactory();
+	IWICFormatConverter* pConv = NULL;
+
+	if(NULL != pFactory)
+	{
+		hr = pFactory->CreateFormatConverter(&pConv);
+	}
+
+	WICPixelFormatGUID destFormat = GUID_WICPixelFormat32bppRGBA; // Fallback to RGBA 32-bit format which is supported by all devices
+
+	for( size_t i=0; i < _countof(g_WICConvert); ++i )
+	{
+		if ( memcmp( &g_WICConvert[i].source, &_format, sizeof(WICPixelFormatGUID) ) == 0 )
+		{
+			memcpy( &destFormat, &g_WICConvert[i].target, sizeof(WICPixelFormatGUID) );
+			break;
+		}
+	}
+
+	BOOL bCanConv = FALSE;
+
+	if(SUCCEEDED(hr))
+	{
+		hr = pConv->CanConvert(_format, destFormat, &bCanConv);
+	}
+
+	if(SUCCEEDED(hr) && bCanConv == TRUE)
+	{
+		hr = pConv->Initialize(pFrame, destFormat, WICBitmapDitherTypeErrorDiffusion, 0, 0, WICBitmapPaletteTypeCustom);
+	}
+
+	if(SUCCEEDED(hr))
+	{
+		memcpy(&_format, &destFormat, sizeof(WICPixelFormatGUID));
+		*ppConv = pConv;
+	}
+
+	return SUCCEEDED(hr);
+}
+
+size_t WICImageLoader::getBitsPerPixel(WICPixelFormatGUID format)
+{
+	HRESULT hr = S_FALSE;
+
+	IWICImagingFactory* pfactory = getWICFactory();
+
+	IWICComponentInfo* pCInfo = NULL;
+
+	if(pfactory != NULL)
+	{
+		hr = pfactory->CreateComponentInfo(format, &pCInfo);
+	}
+
+	WICComponentType cType;
+
+	if(SUCCEEDED(hr))
+	{
+		hr = pCInfo->GetComponentType(&cType);
+	}
+
+	IWICPixelFormatInfo* pPInfo = NULL;
+
+	if(SUCCEEDED(hr) && cType == WICPixelFormat)
+	{
+		hr = pCInfo->QueryInterface(IID_IWICPixelFormatInfo, (void**)&pPInfo);
+	}
+
+	UINT bpp = 0;
+
+	if(SUCCEEDED(hr))
+	{
+		hr = pPInfo->GetBitsPerPixel(&bpp);
+	}
+
+	SafeRelease(&pCInfo);
+	SafeRelease(&pPInfo);
+	return bpp;
+}
+
+int WICImageLoader::getHeight()
+{
+	return _height;
+}
+
+int WICImageLoader::getWidth()
+{
+	return _width;
+}
+
+int WICImageLoader::getImageData(ImageBlob rawData, size_t dataLen)
+{
+	if(dataLen < _dataLen)
+		return 0;
+
+	memcpy((void*)rawData, _data, _dataLen);
+
+	return _dataLen;
+}
+
+int WICImageLoader::getImageDataSize()
+{
+	return _dataLen;
+}
+
+WICPixelFormatGUID WICImageLoader::getPixelFormat()
+{
+	return _format;
+}
+
+bool WICImageLoader::encodeImageData(std::string path, ImageBlob data, size_t dataLen, WICPixelFormatGUID pixelFormat, int width, int height, GUID containerFormat)
+{
+	assert(data != NULL);
+	assert(dataLen > 0 && width > 0 && height > 0);
+
+	IWICImagingFactory* pFact = getWICFactory();
+
+	HRESULT hr = S_FALSE;
+	IWICStream* pStream = NULL;
+
+	if(NULL != pFact)
+	{
+		hr = pFact->CreateStream(&pStream);
+	}
+
+	if(SUCCEEDED(hr))
+	{
+		std::wstring wpath;
+		wpath.assign(path.begin(), path.end());
+		hr = pStream->InitializeFromFilename(wpath.c_str(), GENERIC_WRITE);
+	}
+
+	IWICBitmapEncoder* pEnc = NULL;
+
+	if(SUCCEEDED(hr))
+	{
+		hr = pFact->CreateEncoder(containerFormat, NULL, &pEnc);
+	}
+
+	if(SUCCEEDED(hr))
+	{
+		hr = pEnc->Initialize(pStream, WICBitmapEncoderNoCache);
+	}
+
+	IWICBitmapFrameEncode* pFrame = NULL;
+	IPropertyBag2* pProp = NULL;
+
+	if(SUCCEEDED(hr))
+	{
+		hr = pEnc->CreateNewFrame(&pFrame, &pProp);
+	}
+
+	if(SUCCEEDED(hr))
+	{
+		hr = pFrame->Initialize(pProp);
+	}
+
+	if(SUCCEEDED(hr))
+	{
+		hr = pFrame->SetSize(width, height);
+	}
+
+	if(SUCCEEDED(hr))
+	{
+		hr = pFrame->SetPixelFormat(&pixelFormat);
+	}
+
+	if(SUCCEEDED(hr))
+	{
+		size_t bpp = getBitsPerPixel(pixelFormat);
+		size_t stride = (width * bpp + 7) / 8;
+
+		hr = pFrame->WritePixels(height, stride, dataLen, (BYTE*)data);
+	}
+
+	if(SUCCEEDED(hr))
+	{
+		hr = pFrame->Commit();
+	}
+
+	if(SUCCEEDED(hr))
+	{
+		hr = pEnc->Commit();
+	}
+
+	SafeRelease(&pStream);
+	SafeRelease(&pEnc);
+	SafeRelease(&pFrame);
+	SafeRelease(&pProp);
+	return SUCCEEDED(hr);
+}
+
+IWICImagingFactory* WICImageLoader::getWICFactory()
+{
+	if(NULL == _wicFactory)
+	{
+		HRESULT hr = CoInitializeEx(NULL, COINIT_MULTITHREADED);
+
+		if(SUCCEEDED(hr))
+		{
+			hr = CoCreateInstance(CLSID_WICImagingFactory, NULL, CLSCTX_INPROC_SERVER, IID_IWICImagingFactory, (LPVOID*)&_wicFactory);
+		}
+
+		if(FAILED(hr))
+		{
+			SafeRelease(&_wicFactory);
+		}
+	}
+
+	return _wicFactory;	
+}
+
+#endif
+
+NS_CC_END

--- a/cocos/platform/winrt/WICImageLoader-win.cpp
+++ b/cocos/platform/winrt/WICImageLoader-win.cpp
@@ -210,8 +210,7 @@ HRESULT WICImageLoader::convertFormatIfRequired(IWICBitmapFrameDecode* pFrame, I
 	if(	(memcmp(&_format, &GUID_WICPixelFormat8bppGray, sizeof(WICPixelFormatGUID)) == 0) ||
 		(memcmp(&_format, &GUID_WICPixelFormat8bppAlpha, sizeof(WICPixelFormatGUID)) == 0) ||
 		(memcmp(&_format, &GUID_WICPixelFormat24bppRGB, sizeof(WICPixelFormatGUID)) == 0) ||
-		(memcmp(&_format, &GUID_WICPixelFormat32bppRGBA, sizeof(WICPixelFormatGUID)) == 0) ||
-		(memcmp(&_format, &GUID_WICPixelFormat32bppBGRA, sizeof(WICPixelFormatGUID)) == 0))
+		(memcmp(&_format, &GUID_WICPixelFormat32bppRGBA, sizeof(WICPixelFormatGUID)) == 0))
 	{
 		return S_OK;
 	}

--- a/cocos/platform/winrt/WICImageLoader-win.h
+++ b/cocos/platform/winrt/WICImageLoader-win.h
@@ -1,0 +1,98 @@
+/****************************************************************************
+Copyright (c) Microsoft Open Technologies, Inc.  All rights reserved.
+
+The MIT License (MIT)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+Based upon code from the DirectX Tool Kit by Microsoft Corporation, 
+obtained from https://directxtk.codeplex.com
+****************************************************************************/
+
+#ifndef __WIC_IMAGE_LOADER_H__
+#define __WIC_IMAGE_LOADER_H__
+
+#if defined(CC_USE_WIC)
+
+#include <memory>
+#include <string>
+#include <wincodec.h>
+#include "CCPlatformMacros.h"
+
+NS_CC_BEGIN
+
+
+	typedef const unsigned char* ImageBlob;
+
+struct WICConvert
+{
+	WICPixelFormatGUID source;
+	WICPixelFormatGUID target;
+};
+
+class WICImageLoader
+{
+public:
+
+	WICImageLoader();
+	~WICImageLoader();
+
+	int getWidth();
+	int getHeight();
+	int getImageDataSize();
+	WICPixelFormatGUID getPixelFormat();
+	int getImageData(ImageBlob rawData, size_t dataLen);
+	bool decodeImageData(ImageBlob data, size_t dataLen);
+	bool encodeImageData(std::string path, ImageBlob data, size_t dataLen, WICPixelFormatGUID pixelFormat, int width, int height, GUID containerFormat);
+
+protected:
+	bool processImage(IWICBitmapDecoder* decoder);
+	size_t getBitsPerPixel(WICPixelFormatGUID format); 
+	HRESULT convertFormatIfRequired(IWICBitmapFrameDecode* pFrame, IWICFormatConverter** ppConv);
+
+	static IWICImagingFactory* getWICFactory();
+
+private:
+	int _height;
+	int _width;
+	size_t _dataLen;
+	UINT _bpp;
+	WICPixelFormatGUID _format;
+	BYTE* _data;
+
+
+	static IWICImagingFactory* _wicFactory;
+};
+
+template<typename T>
+void SafeRelease(T **ppObj)
+{
+	if(*ppObj != NULL)
+	{
+		(*ppObj)->Release();
+		*ppObj = NULL;
+	}
+}
+
+
+NS_CC_END
+
+#endif
+#endif    // #ifndef __WIC_IMAGE_LOADER_H__
+


### PR DESCRIPTION
This pull request modifies CCImage.cpp/.h to add Windows Image Component support for Windows 8.1 Universal Apps. This removes the need for libpng, libjpeg, and libtiff for Windows 8.1 Store and Phone apps. This will help reduce the size of the zip file for the external dependencies as these libs have been removed from the download.

CC_USE_WIC and CC_USE_PNG were added to base/ccConfig.h to support this feature. 

This pull request is supported by the following pull request

https://github.com/cocos2d/cocos2d-x-3rd-party-libs-bin/pull/107

Please note that it will be very easy to add WIC support to the Win32 version of cocos2d-x. This would remove all of the png tiff and jpeg libs for the win32 version.
