### PR TITLE
Fix container view's anchor point problem.

### DIFF
--- a/extensions/GUI/CCScrollView/CCScrollView.cpp
+++ b/extensions/GUI/CCScrollView/CCScrollView.cpp
@@ -388,13 +388,20 @@ void ScrollView::relocateContainer(bool animated)
 
 Vec2 ScrollView::maxContainerOffset()
 {
-    return Vec2(0.0f, 0.0f);
+    Point anchorPoint = _container->isIgnoreAnchorPointForPosition()?Point::ZERO:_container->getAnchorPoint();
+    float contW       = _container->getContentSize().width * _container->getScaleX();
+    float contH       = _container->getContentSize().height * _container->getScaleY();
+    
+    return Vec2(anchorPoint.x * contW, anchorPoint.y * contH);
 }
 
 Vec2 ScrollView::minContainerOffset()
 {
-    return Vec2(_viewSize.width - _container->getContentSize().width*_container->getScaleX(), 
-               _viewSize.height - _container->getContentSize().height*_container->getScaleY());
+    Point anchorPoint = _container->isIgnoreAnchorPointForPosition()?Point::ZERO:_container->getAnchorPoint();
+    float contW       = _container->getContentSize().width * _container->getScaleX();
+    float contH       = _container->getContentSize().height * _container->getScaleY();
+    
+    return Vec2(_viewSize.width - (1 - anchorPoint.x) * contW, _viewSize.height - (1 - anchorPoint.y) * contH);
 }
 
 void ScrollView::deaccelerateScrolling(float dt)


### PR DESCRIPTION
I found it anchorPoint of container of ScrollView must be (0, 0);
Otherwise, container will be scrolled to wrong offset by 'void ScrollView::relocateContainer(bool animated)';
So, I fixed this issue.
Thanks.
