### PR TITLE
SpriteFrameCache support async load

### DIFF
--- a/cocos/2d/CCSpriteFrameCache.cpp
+++ b/cocos/2d/CCSpriteFrameCache.cpp
@@ -39,6 +39,7 @@ THE SOFTWARE.
 #include "base/CCDirector.h"
 #include "renderer/CCTexture2D.h"
 #include "renderer/CCTextureCache.h"
+#include "base/CCAsyncTaskPool.h"
 
 
 #include "deprecated/CCString.h"
@@ -433,6 +434,90 @@ SpriteFrame* SpriteFrameCache::getSpriteFrameByName(const std::string& name)
         }
     }
     return frame;
+}
+
+void SpriteFrameCache::addSpriteFramesWithFileAsync(const std::string& plist, const std::string& textureFileName, const std::function<void(void*, bool)>& callback, void* callbackparam)
+{
+
+	AsyncLoadParam* asyncLoadParam = new (std::nothrow) AsyncLoadParam();
+
+	if (_loadedFileNames->find(plist) != _loadedFileNames->end())
+	{
+		// We already added it
+		callback(callbackparam, true);
+	}
+	else
+	{
+		asyncLoadParam->afterLoadCallback = callback;
+		asyncLoadParam->callbackParam = callbackparam;
+		asyncLoadParam->plist = plist;
+		asyncLoadParam->textureFileName = textureFileName;
+		asyncLoadParam->texture = nullptr;
+		asyncLoadParam->image = nullptr;
+		asyncLoadParam->resultTexture = false;
+		asyncLoadParam->resultPList = false;
+
+
+		AsyncTaskPool::getInstance()->enqueue(AsyncTaskPool::TaskType::TASK_IO, CC_CALLBACK_1(SpriteFrameCache::afterAsyncLoad, this), (void*)(asyncLoadParam), [asyncLoadParam]()
+		{
+			// AsyncLoad call TASK_IO thread
+			std::string fullPathPList = FileUtils::getInstance()->fullPathForFilename(asyncLoadParam->plist);
+			std::string fullpathTexture = FileUtils::getInstance()->fullPathForFilename(asyncLoadParam->textureFileName);
+
+			// Exists files
+			if (!fullPathPList.empty() && !fullpathTexture.empty())
+			{
+				asyncLoadParam->dictionary = FileUtils::getInstance()->getValueMapFromFile(fullPathPList);
+
+				asyncLoadParam->resultPList = !asyncLoadParam->dictionary.empty();
+
+				if (asyncLoadParam->resultPList)
+				{
+					// generate image      
+					auto image = new (std::nothrow) Image();
+					if (image && image->initWithImageFileThreadSafe(fullpathTexture))
+					{
+						asyncLoadParam->image = image;
+					}
+					else
+					{
+						CC_SAFE_RELEASE(image);
+						CCLOG("can not load %s", asyncLoadParam->textureFileName.c_str());
+					}
+				}
+			}
+
+		});
+	}
+
+}
+
+void SpriteFrameCache::afterAsyncLoad(void* param)
+{
+	// afterAsyncLoad, call main thread
+	AsyncLoadParam* asyncLoadParam = (AsyncLoadParam*)param;
+
+	if (asyncLoadParam->image)
+	{
+		asyncLoadParam->texture = cocos2d::Director::getInstance()->getTextureCache()->addImage(asyncLoadParam->image, asyncLoadParam->textureFileName);
+		if (asyncLoadParam->texture)
+		{
+			asyncLoadParam->resultTexture = true;
+		}
+		asyncLoadParam->image->release();
+	}
+
+	bool allOk = asyncLoadParam->resultTexture && asyncLoadParam->resultPList;
+	if (allOk)
+	{
+		addSpriteFramesWithDictionary(asyncLoadParam->dictionary, asyncLoadParam->texture);
+
+		_loadedFileNames->insert(asyncLoadParam->plist);
+	}
+
+	asyncLoadParam->afterLoadCallback(asyncLoadParam->callbackParam, allOk);
+
+	delete asyncLoadParam;
 }
 
 NS_CC_END

--- a/cocos/2d/CCSpriteFrameCache.h
+++ b/cocos/2d/CCSpriteFrameCache.h
@@ -90,7 +90,17 @@ public:
      * @js addSpriteFrames
      * @lua addSpriteFrames
      */
-    void addSpriteFramesWithFile(const std::string& plist, const std::string& textureFileName);
+	void addSpriteFramesWithFile(const std::string& plist, const std::string& textureFileName);
+
+	/** Adds multiple Sprite Frames from a plist file asynchronously. The texture will be associated with the created sprite frames.
+	* Otherwise it will load the plist file in a new thread, and when the plist and texture is loaded, the callback will be called with the userdefined parameter.
+	* The callback will be called from the main thread, so it is safe to create any cocos2d object from the callback.
+	* @param plist file to be loaded
+	* @param textureFileName texture file to be loaded
+	* @param callback callback after loading
+	* @param callbackparam user defined parameter for the callback
+	*/
+	void addSpriteFramesWithFileAsync(const std::string& plist, const std::string& textureFileName, const std::function<void(void*, bool)>& callback, void* callbackparam);
 
     /** Adds multiple Sprite Frames from a plist file. The texture will be associated with the created sprite frames. 
      * @js addSpriteFrames
@@ -154,7 +164,7 @@ public:
     SpriteFrame* getSpriteFrameByName(const std::string& name);
 
     /** @deprecated use getSpriteFrameByName() instead */
-    CC_DEPRECATED_ATTRIBUTE SpriteFrame* spriteFrameByName(const std::string&name) { return getSpriteFrameByName(name); }
+	CC_DEPRECATED_ATTRIBUTE SpriteFrame* spriteFrameByName(const std::string&name) { return getSpriteFrameByName(name); }
 
 protected:
     // MARMALADE: Made this protected not private, as deriving from this class is pretty useful
@@ -169,10 +179,25 @@ protected:
     */
     void removeSpriteFramesFromDictionary(ValueMap& dictionary);
 
+	void afterAsyncLoad(void* param);
 
     Map<std::string, SpriteFrame*> _spriteFrames;
     ValueMap _spriteFramesAliases;
     std::set<std::string>*  _loadedFileNames;
+
+	struct AsyncLoadParam
+	{
+		std::function<void(void*, bool)> afterLoadCallback; // callback after load
+		void*                           callbackParam;
+		bool                            resultTexture; // texture load result
+		bool                            resultPList; // plist load result
+		std::string                     plist;
+		std::string                     textureFileName;
+
+		cocos2d::ValueMap               dictionary;
+		cocos2d::Texture2D*             texture;
+		Image*                          image;
+	};
 };
 
 // end of sprite_nodes group

--- a/cocos/base/CCDirector.cpp
+++ b/cocos/base/CCDirector.cpp
@@ -145,6 +145,8 @@ bool Director::init(void)
 
     _contentScaleFactor = 1.0f;
 
+    _console = new (std::nothrow) Console;
+
     // scheduler
     _scheduler = new (std::nothrow) Scheduler();
     // action manager
@@ -167,8 +169,6 @@ bool Director::init(void)
     initMatrixStack();
 
     _renderer = new (std::nothrow) Renderer;
-
-    _console = new (std::nothrow) Console;
 
     return true;
 }

--- a/cocos/platform/CCImage.h
+++ b/cocos/platform/CCImage.h
@@ -58,6 +58,7 @@ class CC_DLL Image : public Ref
 {
 public:
     friend class TextureCache;
+	friend class SpriteFrameCache;
     /**
      * @js ctor
      */


### PR DESCRIPTION
Async based on Sprite3D and TextureCache.
Load image and plist file in AsyncTaskPool TASK_IO thread.
Add TextureCache image and generate Sprite Frames in main thread.

Callback send: user param and result correct load.
