### PR TITLE
Webview ios load data fix

### DIFF
--- a/cocos/ui/UIWebViewImpl-ios.mm
+++ b/cocos/ui/UIWebViewImpl-ios.mm
@@ -164,6 +164,7 @@ static std::string getFixedBaseUrl(const std::string& baseUrl)
 }
 
 - (void)loadHTMLString:(const std::string &)string baseURL:(const std::string &)baseURL {
+	if (!self.uiWebView) {[self setupWebView];}
     [self.uiWebView loadHTMLString:@(string.c_str()) baseURL:[NSURL URLWithString:@(getFixedBaseUrl(baseURL).c_str())]];
 }
 
@@ -211,6 +212,7 @@ static std::string getFixedBaseUrl(const std::string& baseUrl)
 }
 
 - (void)setScalesPageToFit:(const bool)scalesPageToFit {
+	if (!self.uiWebView) {[self setupWebView];}
     self.uiWebView.scalesPageToFit = scalesPageToFit;
 }
 

--- a/cocos/ui/UIWebViewImpl-ios.mm
+++ b/cocos/ui/UIWebViewImpl-ios.mm
@@ -164,7 +164,7 @@ static std::string getFixedBaseUrl(const std::string& baseUrl)
 }
 
 - (void)loadHTMLString:(const std::string &)string baseURL:(const std::string &)baseURL {
-	if (!self.uiWebView) {[self setupWebView];}
+    if (!self.uiWebView) {[self setupWebView];}
     [self.uiWebView loadHTMLString:@(string.c_str()) baseURL:[NSURL URLWithString:@(getFixedBaseUrl(baseURL).c_str())]];
 }
 
@@ -212,7 +212,7 @@ static std::string getFixedBaseUrl(const std::string& baseUrl)
 }
 
 - (void)setScalesPageToFit:(const bool)scalesPageToFit {
-	if (!self.uiWebView) {[self setupWebView];}
+    if (!self.uiWebView) {[self setupWebView];}
     self.uiWebView.scalesPageToFit = scalesPageToFit;
 }
 


### PR DESCRIPTION
Fix loadHTMLString on iOS. Your test works bacause you load website (call `loadUrl(...)` ) at the first time and init `self.uiWebView` using `setupWebView`.
But when you call `loadHTMLString` first you didn't initialize webView and call method on `nil`.
Same issue is when calling `setScalesPageToFit(...)` befor first draw.

Example:

```
auto webView = WebView::create();
webView->loadHTMLString("<body>Hello World</body>", "");
addChild(webView);
```
