### PR TITLE
GlStateCache no correct reset Director matrix

### DIFF
--- a/cocos/base/CCDirector.cpp
+++ b/cocos/base/CCDirector.cpp
@@ -1002,6 +1002,8 @@ void Director::reset()
     
     GL::invalidateStateCache();
     
+    resetMatrixStack();
+    
     destroyTextureCache();
 }
 

--- a/cocos/renderer/ccGLStateCache.cpp
+++ b/cocos/renderer/ccGLStateCache.cpp
@@ -61,7 +61,6 @@ namespace GL {
 
 void invalidateStateCache( void )
 {
-    Director::getInstance()->resetMatrixStack();
     s_currentProjectionMatrix = -1;
     s_attributeFlags = 0;
 


### PR DESCRIPTION
Use other OpenGL code in render frame cocos2d.
Need reset cocos 2d GL state, and continue render use cocos2d.
render Cocos -> render Other GL -> render Cocos.
