### PR TITLE
SpriteFrameCache support async load

### DIFF
--- a/cocos/2d/CCSpriteFrameCache.cpp
+++ b/cocos/2d/CCSpriteFrameCache.cpp
@@ -39,6 +39,7 @@ THE SOFTWARE.
 #include "base/CCDirector.h"
 #include "renderer/CCTexture2D.h"
 #include "renderer/CCTextureCache.h"
+#include "base/CCAsyncTaskPool.h"
 
 
 #include "deprecated/CCString.h"
@@ -433,6 +434,90 @@ SpriteFrame* SpriteFrameCache::getSpriteFrameByName(const std::string& name)
         }
     }
     return frame;
+}
+
+void SpriteFrameCache::addSpriteFramesWithFileAsync(const std::string& plist, const std::string& textureFileName, const std::function<void(void*, bool)>& callback, void* callbackparam)
+{
+
+	AsyncLoadParam* asyncLoadParam = new (std::nothrow) AsyncLoadParam();
+
+	if (_loadedFileNames->find(plist) != _loadedFileNames->end())
+	{
+		// We already added it
+		callback(callbackparam, true);
+	}
+	else
+	{
+		asyncLoadParam->afterLoadCallback = callback;
+		asyncLoadParam->callbackParam = callbackparam;
+		asyncLoadParam->plist = plist;
+		asyncLoadParam->textureFileName = textureFileName;
+		asyncLoadParam->texture = nullptr;
+		asyncLoadParam->image = nullptr;
+		asyncLoadParam->resultTexture = false;
+		asyncLoadParam->resultPList = false;
+
+
+		AsyncTaskPool::getInstance()->enqueue(AsyncTaskPool::TaskType::TASK_IO, CC_CALLBACK_1(SpriteFrameCache::afterAsyncLoad, this), (void*)(asyncLoadParam), [asyncLoadParam]()
+		{
+			// AsyncLoad call TASK_IO thread
+			std::string fullPathPList = FileUtils::getInstance()->fullPathForFilename(asyncLoadParam->plist);
+			std::string fullpathTexture = FileUtils::getInstance()->fullPathForFilename(asyncLoadParam->textureFileName);
+
+			// Exists files
+			if (!fullPathPList.empty() && !fullpathTexture.empty())
+			{
+				asyncLoadParam->dictionary = FileUtils::getInstance()->getValueMapFromFile(fullPathPList);
+
+				asyncLoadParam->resultPList = !asyncLoadParam->dictionary.empty();
+
+				if (asyncLoadParam->resultPList)
+				{
+					// generate image      
+					auto image = new (std::nothrow) Image();
+					if (image && image->initWithImageFileThreadSafe(fullpathTexture))
+					{
+						asyncLoadParam->image = image;
+					}
+					else
+					{
+						CC_SAFE_RELEASE(image);
+						CCLOG("can not load %s", asyncLoadParam->textureFileName.c_str());
+					}
+				}
+			}
+
+		});
+	}
+
+}
+
+void SpriteFrameCache::afterAsyncLoad(void* param)
+{
+	// afterAsyncLoad, call main thread
+	AsyncLoadParam* asyncLoadParam = (AsyncLoadParam*)param;
+
+	if (asyncLoadParam->image)
+	{
+		asyncLoadParam->texture = cocos2d::Director::getInstance()->getTextureCache()->addImage(asyncLoadParam->image, asyncLoadParam->textureFileName);
+		if (asyncLoadParam->texture)
+		{
+			asyncLoadParam->resultTexture = true;
+		}
+		asyncLoadParam->image->release();
+	}
+
+	bool allOk = asyncLoadParam->resultTexture && asyncLoadParam->resultPList;
+	if (allOk)
+	{
+		addSpriteFramesWithDictionary(asyncLoadParam->dictionary, asyncLoadParam->texture);
+
+		_loadedFileNames->insert(asyncLoadParam->plist);
+	}
+
+	asyncLoadParam->afterLoadCallback(asyncLoadParam->callbackParam, allOk);
+
+	delete asyncLoadParam;
 }
 
 NS_CC_END

--- a/cocos/2d/CCSpriteFrameCache.cpp
+++ b/cocos/2d/CCSpriteFrameCache.cpp
@@ -438,86 +438,85 @@ SpriteFrame* SpriteFrameCache::getSpriteFrameByName(const std::string& name)
 
 void SpriteFrameCache::addSpriteFramesWithFileAsync(const std::string& plist, const std::string& textureFileName, const std::function<void(void*, bool)>& callback, void* callbackparam)
 {
+    if (_loadedFileNames->find(plist) != _loadedFileNames->end())
+    {
+        // We already added it
+        callback(callbackparam, true);
+        return;
+    }
+    else
+    {
+        std::string fullPathPList = FileUtils::getInstance()->fullPathForFilename(plist);
+        std::string fullpathTexture = FileUtils::getInstance()->fullPathForFilename(textureFileName);
 
-	AsyncLoadParam* asyncLoadParam = new (std::nothrow) AsyncLoadParam();
+        if (fullPathPList.empty() || fullpathTexture.empty())
+        {
+            // File(s) not found
+            callback(callbackparam, false);
+            return;
+        }
 
-	if (_loadedFileNames->find(plist) != _loadedFileNames->end())
-	{
-		// We already added it
-		callback(callbackparam, true);
-	}
-	else
-	{
-		asyncLoadParam->afterLoadCallback = callback;
-		asyncLoadParam->callbackParam = callbackparam;
-		asyncLoadParam->plist = plist;
-		asyncLoadParam->textureFileName = textureFileName;
-		asyncLoadParam->texture = nullptr;
-		asyncLoadParam->image = nullptr;
-		asyncLoadParam->resultTexture = false;
-		asyncLoadParam->resultPList = false;
+        AsyncLoadParam* asyncLoadParam = new (std::nothrow) AsyncLoadParam();
+        asyncLoadParam->afterLoadCallback = callback;
+        asyncLoadParam->callbackParam = callbackparam;
+        asyncLoadParam->plist = plist;
+        asyncLoadParam->textureFileName = textureFileName;
+        asyncLoadParam->texture = nullptr;
+        asyncLoadParam->image = nullptr;
+        asyncLoadParam->resultTexture = false;
+        asyncLoadParam->resultPList = false;
 
+        AsyncTaskPool::getInstance()->enqueue(AsyncTaskPool::TaskType::TASK_IO, CC_CALLBACK_1(SpriteFrameCache::afterAsyncLoad, this), (void*)asyncLoadParam, [asyncLoadParam, fullPathPList, fullpathTexture]()
+        {
+            // AsyncLoad call TASK_IO thread
+            asyncLoadParam->dictionary = FileUtils::getInstance()->getValueMapFromFile(fullPathPList);
 
-		AsyncTaskPool::getInstance()->enqueue(AsyncTaskPool::TaskType::TASK_IO, CC_CALLBACK_1(SpriteFrameCache::afterAsyncLoad, this), (void*)(asyncLoadParam), [asyncLoadParam]()
-		{
-			// AsyncLoad call TASK_IO thread
-			std::string fullPathPList = FileUtils::getInstance()->fullPathForFilename(asyncLoadParam->plist);
-			std::string fullpathTexture = FileUtils::getInstance()->fullPathForFilename(asyncLoadParam->textureFileName);
-
-			// Exists files
-			if (!fullPathPList.empty() && !fullpathTexture.empty())
-			{
-				asyncLoadParam->dictionary = FileUtils::getInstance()->getValueMapFromFile(fullPathPList);
-
-				asyncLoadParam->resultPList = !asyncLoadParam->dictionary.empty();
-
-				if (asyncLoadParam->resultPList)
-				{
-					// generate image      
-					auto image = new (std::nothrow) Image();
-					if (image && image->initWithImageFileThreadSafe(fullpathTexture))
-					{
-						asyncLoadParam->image = image;
-					}
-					else
-					{
-						CC_SAFE_RELEASE(image);
-						CCLOG("can not load %s", asyncLoadParam->textureFileName.c_str());
-					}
-				}
-			}
-
-		});
-	}
+            asyncLoadParam->resultPList = !asyncLoadParam->dictionary.empty();
+            if (asyncLoadParam->resultPList)
+            {
+                // generate image      
+                auto image = new (std::nothrow) Image();
+                if (image && image->initWithImageFileThreadSafe(fullpathTexture))
+                {
+                    asyncLoadParam->image = image;
+                }
+                else
+                {
+                    CC_SAFE_RELEASE(image);
+                    CCLOG("can not load %s", asyncLoadParam->textureFileName.c_str());
+                }
+            }
+        });
+    }
 
 }
 
 void SpriteFrameCache::afterAsyncLoad(void* param)
 {
-	// afterAsyncLoad, call main thread
-	AsyncLoadParam* asyncLoadParam = (AsyncLoadParam*)param;
+    // afterAsyncLoad, call main thread
+    AsyncLoadParam* asyncLoadParam = (AsyncLoadParam*)param;
 
-	if (asyncLoadParam->image)
-	{
-		asyncLoadParam->texture = cocos2d::Director::getInstance()->getTextureCache()->addImage(asyncLoadParam->image, asyncLoadParam->textureFileName);
-		if (asyncLoadParam->texture)
-		{
-			asyncLoadParam->resultTexture = true;
-		}
-		asyncLoadParam->image->release();
-	}
+    if (asyncLoadParam->image)
+    {
+        asyncLoadParam->texture = cocos2d::Director::getInstance()->getTextureCache()->addImage(asyncLoadParam->image, asyncLoadParam->textureFileName);
+        if (asyncLoadParam->texture)
+        {
+            asyncLoadParam->resultTexture = true;
+        }
+        asyncLoadParam->image->release();
+    }
 
-	bool allOk = asyncLoadParam->resultTexture && asyncLoadParam->resultPList;
-	if (allOk)
-	{
-		addSpriteFramesWithDictionary(asyncLoadParam->dictionary, asyncLoadParam->texture);
+    bool allOk = asyncLoadParam->resultTexture && asyncLoadParam->resultPList;
+    if (allOk)
+    {
+        addSpriteFramesWithDictionary(asyncLoadParam->dictionary, asyncLoadParam->texture);
 
-		_loadedFileNames->insert(asyncLoadParam->plist);
-	}
+        _loadedFileNames->insert(asyncLoadParam->plist);
+    }
 
-	asyncLoadParam->afterLoadCallback(asyncLoadParam->callbackParam, allOk);
+    asyncLoadParam->afterLoadCallback(asyncLoadParam->callbackParam, allOk);
 
-	delete asyncLoadParam;
+    delete asyncLoadParam;
 }
 
 NS_CC_END

--- a/cocos/2d/CCSpriteFrameCache.h
+++ b/cocos/2d/CCSpriteFrameCache.h
@@ -92,6 +92,16 @@ public:
      */
     void addSpriteFramesWithFile(const std::string& plist, const std::string& textureFileName);
 
+    /** Adds multiple Sprite Frames from a plist file asynchronously. The texture will be associated with the created sprite frames.
+    * Otherwise it will load the plist file in a new thread, and when the plist and texture is loaded, the callback will be called with the userdefined parameter.
+    * The callback will be called from the main thread, so it is safe to create any cocos2d object from the callback.
+    * @param plist file to be loaded
+    * @param textureFileName texture file to be loaded
+    * @param callback callback after loading
+    * @param callbackparam user defined parameter for the callback
+    */
+    void addSpriteFramesWithFileAsync(const std::string& plist, const std::string& textureFileName, const std::function<void(void*, bool)>& callback, void* callbackparam);
+
     /** Adds multiple Sprite Frames from a plist file. The texture will be associated with the created sprite frames. 
      * @js addSpriteFrames
      * @lua addSpriteFrames
@@ -169,10 +179,25 @@ protected:
     */
     void removeSpriteFramesFromDictionary(ValueMap& dictionary);
 
+    void afterAsyncLoad(void* param);
 
     Map<std::string, SpriteFrame*> _spriteFrames;
     ValueMap _spriteFramesAliases;
     std::set<std::string>*  _loadedFileNames;
+
+    struct AsyncLoadParam
+    {
+        std::function<void(void*, bool)> afterLoadCallback; // callback after load
+        void*                           callbackParam;
+        bool                            resultTexture; // texture load result
+        bool                            resultPList; // plist load result
+        std::string                     plist;
+        std::string                     textureFileName;
+
+        cocos2d::ValueMap               dictionary;
+        cocos2d::Texture2D*             texture;
+        Image*                          image;
+    };
 };
 
 // end of sprite_nodes group

--- a/cocos/platform/CCImage.h
+++ b/cocos/platform/CCImage.h
@@ -57,7 +57,8 @@ typedef struct _MipmapInfo
 class CC_DLL Image : public Ref
 {
 public:
-    friend class TextureCache;
+	friend class TextureCache;
+	friend class SpriteFrameCache;
     /**
      * @js ctor
      */


### PR DESCRIPTION
Async based on Sprite3D and TextureCache.
Load texture and plist file in AsyncTaskPool TASK_IO thread.
Add TextureCache image and generate Sprite Frames in main thread.
