### PR TITLE
Avoid crash during parse .csd file.

### DIFF
--- a/cocos/editor-support/cocostudio/ActionTimeline/CSLoader.cpp
+++ b/cocos/editor-support/cocostudio/ActionTimeline/CSLoader.cpp
@@ -1276,7 +1276,10 @@ Node* CSLoader::nodeWithFlatBuffersForSimulator(const flatbuffers::NodeTree *nod
         readername.append("Reader");
         
         NodeReaderProtocol* reader = dynamic_cast<NodeReaderProtocol*>(ObjectFactory::getInstance()->createObject(readername));
-        node = reader->createNodeWithFlatBuffers(options->data());
+        if (reader)
+        {
+            node = reader->createNodeWithFlatBuffers(options->data());
+        }
         
         Widget* widget = dynamic_cast<Widget*>(node);
         if (widget)


### PR DESCRIPTION
Avoid crash for creating reader object during parse .csd file.
