### PR TITLE
Camera mask for label

### DIFF
--- a/cocos/2d/CCLabel.cpp
+++ b/cocos/2d/CCLabel.cpp
@@ -932,6 +932,7 @@ void Label::createSpriteWithFontDefinition()
     texture->initWithString(_originalUTF8String.c_str(),_fontDefinition);
 
     _textSprite = Sprite::createWithTexture(texture);
+    //set camera mask using label's camera mask, because _textSprite may be null when setting camera mask to label
     _textSprite->setCameraMask(getCameraMask());
     _textSprite->setAnchorPoint(Vec2::ANCHOR_BOTTOM_LEFT);
     this->setContentSize(_textSprite->getContentSize());
@@ -1074,6 +1075,7 @@ void Label::drawTextSprite(Renderer *renderer, uint32_t parentFlags)
             {
                 _shadowNode->setBlendFunc(_blendFunc);
             }
+            //set camera mask using label's mask. Because _shadowNode may be null when setting the label's camera mask
             _shadowNode->setCameraMask(getCameraMask());
             _shadowNode->setAnchorPoint(Vec2::ANCHOR_BOTTOM_LEFT);
             _shadowNode->setColor(_shadowColor);

--- a/cocos/2d/CCLabel.cpp
+++ b/cocos/2d/CCLabel.cpp
@@ -932,6 +932,7 @@ void Label::createSpriteWithFontDefinition()
     texture->initWithString(_originalUTF8String.c_str(),_fontDefinition);
 
     _textSprite = Sprite::createWithTexture(texture);
+    _textSprite->setCameraMask(getCameraMask());
     _textSprite->setAnchorPoint(Vec2::ANCHOR_BOTTOM_LEFT);
     this->setContentSize(_textSprite->getContentSize());
     texture->release();
@@ -1073,6 +1074,7 @@ void Label::drawTextSprite(Renderer *renderer, uint32_t parentFlags)
             {
                 _shadowNode->setBlendFunc(_blendFunc);
             }
+            _shadowNode->setCameraMask(getCameraMask());
             _shadowNode->setAnchorPoint(Vec2::ANCHOR_BOTTOM_LEFT);
             _shadowNode->setColor(_shadowColor);
             _shadowNode->setOpacity(_shadowOpacity * _displayedOpacity);


### PR DESCRIPTION
To make sure label's member has correct camera mask

set camera mask when member created
