### PR TITLE
Clean possible GL error init Texture2D

### DIFF
--- a/cocos/renderer/CCTexture2D.cpp
+++ b/cocos/renderer/CCTexture2D.cpp
@@ -637,7 +637,12 @@ bool Texture2D::initWithMipmaps(MipmapInfo* mipmaps, int mipmapsNum, PixelFormat
     }
 #endif
 
-    CHECK_GL_ERROR_DEBUG(); // clean possible GL error
+    // clean possible GL error
+    GLenum err = glGetError();
+    if (err != GL_NO_ERROR)
+    {
+        cocos2d::log("OpenGL error 0x%04X in %s %s %d\n", err, __FILE__, __FUNCTION__, __LINE__);
+    }
     
     // Specify OpenGL texture image
     int width = pixelsWide;


### PR DESCRIPTION
CHECK_GL_ERROR_DEBUG work debug only.
Clean need for correct check glTexImage2D and glCompressedTexImage2D

Release now work: If gl error before any code, initWithMipmaps return
false always
