### PR TITLE
Serialize attribute "InnerActionSpeed" during create from .csd file.

### DIFF
--- a/cocos/editor-support/cocostudio/FlatBuffersSerialize.cpp
+++ b/cocos/editor-support/cocostudio/FlatBuffersSerialize.cpp
@@ -1359,7 +1359,22 @@ Offset<ProjectNodeOptions> FlatBuffersSerialize::createProjectNodeOptionsForSimu
     auto nodeOptions = *(Offset<WidgetOptions>*)(&temp);
 
     std::string filename = "";
-
+    float innerspeed = 1.0f;
+    
+    const tinyxml2::XMLAttribute* objattri = objectData->FirstAttribute();
+    // inneraction speed
+    while (objattri)
+    {
+        std::string name = objattri->Name();
+        std::string value = objattri->Value();
+        if (name == "InnerActionSpeed")
+        {
+            innerspeed = atof(objattri->Value());
+            break;
+        }
+        objattri = objattri->Next();
+    }
+    
     // FileData
     const tinyxml2::XMLElement* child = objectData->FirstChildElement();
     while (child)


### PR DESCRIPTION
Serialize attribute "InnerActionSpeed" during create nest node from .csd file for cocosstudio simulator.
