### PR TITLE
fix rapidjson assert and game controller include path

### DIFF
--- a/build/cocos2d_tests.xcodeproj/project.pbxproj
+++ b/build/cocos2d_tests.xcodeproj/project.pbxproj
@@ -678,7 +678,7 @@
 		52B47A351A53A43A004E4C60 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 52B47A331A534B2B004E4C60 /* Security.framework */; };
 		59620E8F1921E5CF002021B6 /* Bug-Child.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 59620E8D1921E5CF002021B6 /* Bug-Child.cpp */; };
 		59620E901921E5CF002021B6 /* Bug-Child.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 59620E8D1921E5CF002021B6 /* Bug-Child.cpp */; };
-		59E170151AB42EB10007F2BF /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 826294421AAF071500CB7CF7 /* Security.framework */; };
+		59E170151AB42EB10007F2BF /* (null) in Frameworks */ = {isa = PBXBuildFile; };
 		5EBEECB01995247000429821 /* DrawNode3D.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5EBEECAE1995247000429821 /* DrawNode3D.cpp */; };
 		5EBEECB11995247000429821 /* DrawNode3D.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5EBEECAE1995247000429821 /* DrawNode3D.cpp */; };
 		A05FCACA177C124500BE600E /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 15C64822165F391E007D4F18 /* Cocoa.framework */; };
@@ -1783,7 +1783,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				59E170151AB42EB10007F2BF /* Security.framework in Frameworks */,
+				59E170151AB42EB10007F2BF /* (null) in Frameworks */,
 				15EFA273198B265A000C57D3 /* libluacocos2d Mac.a in Frameworks */,
 				1ABCA2C318CD92420087CE3A /* libcocos2d Mac.a in Frameworks */,
 				1ABCA36118CD9AC00087CE3A /* libz.dylib in Frameworks */,
@@ -5159,7 +5159,7 @@
 				PRODUCT_NAME = "lua-game-controller-test iOS";
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				USER_HEADER_SEARCH_PATHS = "$(inherited) $(SRCROOT)/.. $(SRCROOT)/../cocos/platform/ios $(SRCROOT)/../external/ios/include/luajit $(SRCROOT)/../cocos/scripting/lua-bindings/manual $(SRCROOT)/../cocos/scripting/lua-bindings/auto $(SRCROOT)/../cocos/base $(SRCROOT)/../cocos/scripting/lua-bindings/manual/tolua";
+				USER_HEADER_SEARCH_PATHS = "$(inherited) $(SRCROOT)/.. $(SRCROOT)/../cocos/platform $(SRCROOT)/../external/ios/include/luajit $(SRCROOT)/../cocos/scripting/lua-bindings/manual $(SRCROOT)/../cocos/scripting/lua-bindings/auto $(SRCROOT)/../cocos/base $(SRCROOT)/../cocos/scripting/lua-bindings/manual/tolua";
 				VALID_ARCHS = "arm64 armv7";
 			};
 			name = Debug;
@@ -5185,7 +5185,7 @@
 				PRODUCT_NAME = "lua-game-controller-test iOS";
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				USER_HEADER_SEARCH_PATHS = "$(inherited) $(SRCROOT)/.. $(SRCROOT)/../cocos/platform/ios $(SRCROOT)/../external/ios/include/luajit $(SRCROOT)/../cocos/scripting/lua-bindings/manual $(SRCROOT)/../cocos/scripting/lua-bindings/auto $(SRCROOT)/../cocos/base $(SRCROOT)/../cocos/scripting/lua-bindings/manual/tolua";
+				USER_HEADER_SEARCH_PATHS = "$(inherited) $(SRCROOT)/.. $(SRCROOT)/../cocos/platform $(SRCROOT)/../external/ios/include/luajit $(SRCROOT)/../cocos/scripting/lua-bindings/manual $(SRCROOT)/../cocos/scripting/lua-bindings/auto $(SRCROOT)/../cocos/base $(SRCROOT)/../cocos/scripting/lua-bindings/manual/tolua";
 				VALIDATE_PRODUCT = YES;
 				VALID_ARCHS = "arm64 armv7";
 			};
@@ -5474,7 +5474,7 @@
 				PRODUCT_NAME = "game-controller-test IOS";
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				USER_HEADER_SEARCH_PATHS = "$(inherited) $(SRCROOT)/../cocos/platform/ios $(SRCROOT)/../cocos/platform/ios/Simulation $(SRCROOT)/../external/curl/include/ios";
+				USER_HEADER_SEARCH_PATHS = "$(inherited) $(SRCROOT)/../cocos/platform $(SRCROOT)/../cocos/platform/ios/Simulation $(SRCROOT)/../external/curl/include/ios";
 				VALID_ARCHS = "arm64 armv7";
 			};
 			name = Debug;
@@ -5493,7 +5493,7 @@
 				PRODUCT_NAME = "game-controller-test IOS";
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				USER_HEADER_SEARCH_PATHS = "$(inherited) $(SRCROOT)/../cocos/platform/ios $(SRCROOT)/../cocos/platform/ios/Simulation $(SRCROOT)/../external/curl/include/ios";
+				USER_HEADER_SEARCH_PATHS = "$(inherited) $(SRCROOT)/../cocos/platform $(SRCROOT)/../cocos/platform/ios/Simulation $(SRCROOT)/../external/curl/include/ios";
 				VALIDATE_PRODUCT = YES;
 				VALID_ARCHS = "arm64 armv7";
 			};

--- a/cocos/3d/CCBundle3D.cpp
+++ b/cocos/3d/CCBundle3D.cpp
@@ -733,18 +733,22 @@ bool  Bundle3D::loadMeshDatasJson(MeshDatas& meshdatas)
             meshData->subMeshIndices.push_back(indexArray);
             meshData->numIndex = (int)meshData->subMeshIndices.size();
 
-            //meshData->subMeshAABB.push_back(calculateAABB(meshData->vertex, meshData->getPerVertexSize(), indexArray));
-            const rapidjson::Value& mesh_part_aabb = mesh_part[AABBS];
-            if (mesh_part.HasMember(AABBS) && mesh_part_aabb.Size() == 6)
+            if (mesh_part.HasMember(AABBS))
             {
-                Vec3 min = Vec3(mesh_part_aabb[(rapidjson::SizeType)0].GetDouble(), mesh_part_aabb[(rapidjson::SizeType)1].GetDouble(), mesh_part_aabb[(rapidjson::SizeType)2].GetDouble());
-                Vec3 max = Vec3(mesh_part_aabb[(rapidjson::SizeType)3].GetDouble(), mesh_part_aabb[(rapidjson::SizeType)4].GetDouble(), mesh_part_aabb[(rapidjson::SizeType)5].GetDouble());
-                meshData->subMeshAABB.push_back(AABB(min, max));
+                const rapidjson::Value& mesh_part_aabb = mesh_part[AABBS];
+                
+                if (mesh_part_aabb.Size() == 6)
+                {
+                    Vec3 min = Vec3(mesh_part_aabb[(rapidjson::SizeType)0].GetDouble(), mesh_part_aabb[(rapidjson::SizeType)1].GetDouble(), mesh_part_aabb[(rapidjson::SizeType)2].GetDouble());
+                    Vec3 max = Vec3(mesh_part_aabb[(rapidjson::SizeType)3].GetDouble(), mesh_part_aabb[(rapidjson::SizeType)4].GetDouble(), mesh_part_aabb[(rapidjson::SizeType)5].GetDouble());
+                    meshData->subMeshAABB.push_back(AABB(min, max));
+                }
+                else
+                {
+                    meshData->subMeshAABB.push_back(calculateAABB(meshData->vertex, meshData->getPerVertexSize(), indexArray));
+                }
             }
-            else
-            {
-                meshData->subMeshAABB.push_back(calculateAABB(meshData->vertex, meshData->getPerVertexSize(), indexArray));
-            }
+         
         }
         meshdatas.meshDatas.push_back(meshData);
     }

--- a/cocos/3d/CCBundle3D.cpp
+++ b/cocos/3d/CCBundle3D.cpp
@@ -748,6 +748,10 @@ bool  Bundle3D::loadMeshDatasJson(MeshDatas& meshdatas)
                     meshData->subMeshAABB.push_back(calculateAABB(meshData->vertex, meshData->getPerVertexSize(), indexArray));
                 }
             }
+            else
+            {
+                meshData->subMeshAABB.push_back(calculateAABB(meshData->vertex, meshData->getPerVertexSize(), indexArray));
+            }
          
         }
         meshdatas.meshDatas.push_back(meshData);

--- a/tests/cpp-tests/Classes/Camera3DTest/Camera3DTest.cpp
+++ b/tests/cpp-tests/Classes/Camera3DTest/Camera3DTest.cpp
@@ -909,10 +909,11 @@ void CameraCullingDemo::update(float dt)
 void CameraCullingDemo::reachEndCallBack()
 {
     _cameraFirst->stopActionByTag(100);
-    auto inverse = (MoveTo*)_moveAction->reverse();
-    inverse->retain();
+    auto inverse = _moveAction->reverse();
     _moveAction->release();
     _moveAction = inverse;
+    _moveAction->retain();
+    
     auto rot = RotateBy::create(1.f, Vec3(0.f, 180.f, 0.f));
     auto seq = Sequence::create(rot, _moveAction, CallFunc::create(CC_CALLBACK_0(CameraCullingDemo::reachEndCallBack, this)), nullptr);
     seq->setTag(100);
@@ -929,7 +930,7 @@ void CameraCullingDemo::switchViewCallback(Ref* sender)
         _cameraFirst->setCameraFlag(CameraFlag::USER8);
         _cameraFirst->setPosition3D(Vec3(-100,0,0));
         _cameraFirst->lookAt(Vec3(1000,0,0));
-        _moveAction = MoveTo::create(4.f, Vec2(100, 0));
+        _moveAction = MoveBy::create(4.f, Vec2(100, 0));
         _moveAction->retain();
         auto seq = Sequence::create(_moveAction, CallFunc::create(CC_CALLBACK_0(CameraCullingDemo::reachEndCallBack, this)), nullptr);
         seq->setTag(100);

--- a/tests/cpp-tests/Classes/Camera3DTest/Camera3DTest.h
+++ b/tests/cpp-tests/Classes/Camera3DTest/Camera3DTest.h
@@ -145,7 +145,7 @@ protected:
     MenuItem*      _decRot;
     unsigned int   _curState;
     Camera*      _camera;
-    MoveTo* _moveAction;
+    MoveBy* _moveAction;
     bool _bZoomOut;
     bool _bZoomIn;
     bool _bRotateLeft;

--- a/tests/cpp-tests/Classes/Sprite3DTest/Sprite3DTest.cpp
+++ b/tests/cpp-tests/Classes/Sprite3DTest/Sprite3DTest.cpp
@@ -1533,7 +1533,7 @@ void Animate3DTest::addSprite3D()
         _state = State::SWIMMING;
     }
     
-    _moveAction = MoveTo::create(4.f, Vec2(s.width / 5.f, s.height / 2.f));
+    _moveAction = MoveBy::create(4.f, Vec2( - s.width * 3.0f /5, 0));
     _moveAction->retain();
     auto seq = Sequence::create(_moveAction, CallFunc::create(CC_CALLBACK_0(Animate3DTest::reachEndCallBack, this)), nullptr);
     seq->setTag(100);
@@ -1543,12 +1543,13 @@ void Animate3DTest::addSprite3D()
 void Animate3DTest::reachEndCallBack()
 {
     _sprite->stopActionByTag(100);
-    auto inverse = (MoveTo*)_moveAction->reverse();
-    inverse->retain();
+    auto inverse = _moveAction->reverse();
     _moveAction->release();
     _moveAction = inverse;
+    _moveAction->retain();
+
     auto rot = RotateBy::create(1.f, Vec3(0.f, 180.f, 0.f));
-    auto seq = Sequence::create(rot, _moveAction, CallFunc::create(CC_CALLBACK_0(Animate3DTest::reachEndCallBack, this)), nullptr);
+    auto seq = Sequence::create(rot, inverse, CallFunc::create(CC_CALLBACK_0(Animate3DTest::reachEndCallBack, this)), nullptr);
     seq->setTag(100);
     _sprite->runAction(seq);
 }
@@ -1924,7 +1925,7 @@ void Sprite3DWithOBBPerformanceTest::addNewSpriteWithCoords(Vec2 p)
         sprite->runAction(RepeatForever::create(animate));
     }
     
-    _moveAction = MoveTo::create(4.f, Vec2(s.width / 5.f, s.height / 2.f));
+    _moveAction = MoveBy::create(4.f, Vec2(-s.width * 3 / 5.f, 0));
     _moveAction->retain();
     auto seq = Sequence::create(_moveAction, CallFunc::create(CC_CALLBACK_0(Sprite3DWithOBBPerformanceTest::reachEndCallBack, this)), nullptr);
     seq->setTag(100);
@@ -1940,10 +1941,11 @@ void Sprite3DWithOBBPerformanceTest::addNewSpriteWithCoords(Vec2 p)
 void Sprite3DWithOBBPerformanceTest::reachEndCallBack()
 {
     _sprite->stopActionByTag(100);
-    auto inverse = (MoveTo*)_moveAction->reverse();
-    inverse->retain();
+    auto inverse = _moveAction->reverse();
     _moveAction->release();
     _moveAction = inverse;
+    _moveAction->retain();
+    
     auto rot = RotateBy::create(1.0f, Vec3(0.f, 180.f, 0.f));
     auto seq = Sequence::create(rot, _moveAction, CallFunc::create(CC_CALLBACK_0(Sprite3DWithOBBPerformanceTest::reachEndCallBack, this)), nullptr);
     seq->setTag(100);

--- a/tests/cpp-tests/Classes/Sprite3DTest/Sprite3DTest.cpp
+++ b/tests/cpp-tests/Classes/Sprite3DTest/Sprite3DTest.cpp
@@ -1549,7 +1549,7 @@ void Animate3DTest::reachEndCallBack()
     _moveAction->retain();
 
     auto rot = RotateBy::create(1.f, Vec3(0.f, 180.f, 0.f));
-    auto seq = Sequence::create(rot, inverse, CallFunc::create(CC_CALLBACK_0(Animate3DTest::reachEndCallBack, this)), nullptr);
+    auto seq = Sequence::create(rot, _moveAction, CallFunc::create(CC_CALLBACK_0(Animate3DTest::reachEndCallBack, this)), nullptr);
     seq->setTag(100);
     _sprite->runAction(seq);
 }

--- a/tests/cpp-tests/Classes/Sprite3DTest/Sprite3DTest.h
+++ b/tests/cpp-tests/Classes/Sprite3DTest/Sprite3DTest.h
@@ -346,7 +346,7 @@ protected:
     
     State   _state;
     
-    MoveTo* _moveAction;
+    MoveBy* _moveAction;
 };
 
 class AttachmentTest : public Sprite3DTestDemo
@@ -418,7 +418,7 @@ protected:
     std::vector<OBB>          _obb;
     DrawNode3D*               _drawOBB;
     Label*                    _labelCubeCount;
-    MoveTo*                   _moveAction;
+    MoveBy*                   _moveAction;
     OBB                       _obbt;
     DrawNode3D*               _drawDebug;
     bool                      _hasCollider;


### PR DESCRIPTION
This PR mainly does the following things:
1. fix rapidJson asset error in CCBundle3D
2. fix game controller test include path compile issue
3. fix Sprit3D, camera3D test movTo action's reverse assert issue
