### PR TITLE
V4 added _LITTLE_ENDIAN to preprocessor defines to fix rapidjson for WinRT arm builds

### DIFF
--- a/cocos/2d/winrt_8.1_props/cocos2d_winrt_8.1.props
+++ b/cocos/2d/winrt_8.1_props/cocos2d_winrt_8.1.props
@@ -10,7 +10,7 @@
       <AdditionalIncludeDirectories>$(EngineRoot)cocos\platform\winrt;$(EngineRoot)cocos\platform;$(EngineRoot)cocos\editor-support;$(EngineRoot)cocos\audio\include;$(EngineRoot)cocos;$(EngineRoot)extensions;$(EngineRoot)external\$(COCOS2D_PLATFORM)\$(PLATFORM)\include\zlib;$(EngineRoot)external\$(COCOS2D_PLATFORM)\$(PLATFORM)\include\angle;$(EngineRoot)external\$(COCOS2D_PLATFORM)\$(PLATFORM)\include\freetype;$(EngineRoot)external\$(COCOS2D_PLATFORM)\$(PLATFORM)\include;$(EngineRoot);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <ClCompile>
-      <PreprocessorDefinitions>WINRT;_VARIADIC_MAX=10;NOMINMAX;GL_GLEXT_PROTOTYPES;_CRT_SECURE_NO_WARNINGS;_SCL_SECURE_NO_WARNINGS;_UNICODE;UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WINRT;_VARIADIC_MAX=10;NOMINMAX;GL_GLEXT_PROTOTYPES;_CRT_SECURE_NO_WARNINGS;_SCL_SECURE_NO_WARNINGS;_UNICODE;UNICODE;_LITTLE_ENDIAN;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <CompileAsWinRT>true</CompileAsWinRT>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <MinimalRebuild>false</MinimalRebuild>


### PR DESCRIPTION
V4 added _LITTLE_ENDIAN to preprocessor defines to fix rapidjson for WinRT arm builds.

Note: this problem didn't show up on the cocos2d Jenkins build system because it only builds Win32 Debug versions of the Universal App project. ARM builds will fail because rapidjson.h does not check for _M_ARM. However, adding _LITTLE_ENDIAN to the preprocessor defines in the property sheet fixes the build.
