### PR TITLE
Reconstruct ColorFrame.

### DIFF
--- a/cocos/editor-support/cocostudio/ActionTimeline/CCActionTimelineCache.cpp
+++ b/cocos/editor-support/cocostudio/ActionTimeline/CCActionTimelineCache.cpp
@@ -350,12 +350,10 @@ Frame* ActionTimelineCache::loadColorFrame(const rapidjson::Value& json)
 {
     ColorFrame* frame = ColorFrame::create();
 
-    GLubyte alpha = (GLubyte)DICTOOL->getIntValue_json(json, ALPHA);
     GLubyte red   = (GLubyte)DICTOOL->getIntValue_json(json, RED);
     GLubyte green = (GLubyte)DICTOOL->getIntValue_json(json, GREEN);
     GLubyte blue  = (GLubyte)DICTOOL->getIntValue_json(json, BLUE);
 
-    frame->setAlpha(alpha);
     frame->setColor(Color3B(red, green, blue));
 
     return frame;

--- a/cocos/editor-support/cocostudio/ActionTimeline/CCFrame.cpp
+++ b/cocos/editor-support/cocostudio/ActionTimeline/CCFrame.cpp
@@ -595,20 +595,16 @@ ColorFrame* ColorFrame::create()
 }
 
 ColorFrame::ColorFrame()
-    : _alpha(255)
-    , _color(Color3B(255, 255, 255))
+: _color(Color3B(255, 255, 255))
 {
 }
 
 void ColorFrame::onEnter(Frame *nextFrame, int currentFrameIndex)
 {
-    _node->setOpacity(_alpha);
     _node->setColor(_color);
 
     if(_tween)
     {
-        _betweenAlpha = static_cast<ColorFrame*>(nextFrame)->_alpha - _alpha;
-
         const Color3B& color = static_cast<ColorFrame*>(nextFrame)->_color;
         _betweenRed   = color.r - _color.r;
         _betweenGreen = color.g - _color.g;
@@ -618,16 +614,13 @@ void ColorFrame::onEnter(Frame *nextFrame, int currentFrameIndex)
 
 void ColorFrame::apply(float percent)
 {
-    if (_tween && (_betweenAlpha !=0 || _betweenRed != 0 || _betweenGreen != 0 || _betweenBlue != 0))
+    if (_tween && (_betweenRed != 0 || _betweenGreen != 0 || _betweenBlue != 0))
     {
-        GLubyte alpha = _alpha + _betweenAlpha * percent;
-
         Color3B color;
         color.r = _color.r+ _betweenRed   * percent;
         color.g = _color.g+ _betweenGreen * percent;
         color.b = _color.b+ _betweenBlue  * percent;
 
-        _node->setOpacity(alpha);
         _node->setColor(color);
     }
 }
@@ -635,7 +628,6 @@ void ColorFrame::apply(float percent)
 Frame* ColorFrame::clone()
 {
     ColorFrame* frame = ColorFrame::create();
-    frame->setAlpha(_alpha);
     frame->setColor(_color);
 
     frame->cloneProperty(this);

--- a/cocos/editor-support/cocostudio/ActionTimeline/CCFrame.h
+++ b/cocos/editor-support/cocostudio/ActionTimeline/CCFrame.h
@@ -299,10 +299,15 @@ public:
     virtual void apply(float percent) override;
     virtual Frame* clone() override;
 
+    /** @deprecated Use method setAlpha() and getAlpha() of AlphaFrame instead */
+    CC_DEPRECATED_ATTRIBUTE inline void    setAlpha(GLubyte alpha) { _alpha = alpha; }
+    CC_DEPRECATED_ATTRIBUTE inline GLubyte getAlpha() const { return _alpha; }
+
     inline void    setColor(const cocos2d::Color3B& color) { _color = color; }
     inline cocos2d::Color3B getColor() const { return _color; }
 
 protected:
+    GLubyte _alpha;
     cocos2d::Color3B _color;
 
     int _betweenRed;

--- a/cocos/editor-support/cocostudio/ActionTimeline/CCFrame.h
+++ b/cocos/editor-support/cocostudio/ActionTimeline/CCFrame.h
@@ -299,17 +299,12 @@ public:
     virtual void apply(float percent) override;
     virtual Frame* clone() override;
 
-    inline void    setAlpha(GLubyte alpha) { _alpha = alpha; }
-    inline GLubyte getAlpha() const { return _alpha; }
-
     inline void    setColor(const cocos2d::Color3B& color) { _color = color; }
     inline cocos2d::Color3B getColor() const { return _color; }
 
 protected:
-    GLubyte _alpha;
     cocos2d::Color3B _color;
 
-    int _betweenAlpha;
     int _betweenRed;
     int _betweenGreen;
     int _betweenBlue;


### PR DESCRIPTION
1. Make property _alpha of ColorFrame become deprecated.
2. Use method setAlpha() and getAlpha() of AlphaFrame instead. 
