### PR TITLE
Avoid crash during parse TextAtlas.

### DIFF
--- a/cocos/editor-support/cocostudio/WidgetReader/TextAtlasReader/TextAtlasReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/TextAtlasReader/TextAtlasReader.cpp
@@ -247,19 +247,42 @@ namespace cocostudio
             case 0:
             {
                 const char* cmfPath = cmftDic->path()->c_str();
-                std::string stringValue = options->stringValue()->c_str();
-                int itemWidth = options->itemWidth();
-                int itemHeight = options->itemHeight();
-                labelAtlas->setProperty(stringValue,
-                                        cmfPath,
-                                        itemWidth,
-                                        itemHeight,
-                                        options->startCharMap()->c_str());
+                
+                bool fileExist = false;
+                std::string errorFilePath = "";
+                
+                if (FileUtils::getInstance()->isFileExist(cmfPath))
+                {
+                    fileExist = true;
+                    
+                    std::string stringValue = options->stringValue()->c_str();
+                    int itemWidth = options->itemWidth();
+                    int itemHeight = options->itemHeight();
+                    labelAtlas->setProperty(stringValue,
+                                            cmfPath,
+                                            itemWidth,
+                                            itemHeight,
+                                            options->startCharMap()->c_str());
+                }
+                else
+                {
+                    errorFilePath = cmfPath;
+                    fileExist = false;
+                }
+                
+                if (!fileExist)
+                {
+                    auto label = Label::create();
+                    label->setString(__String::createWithFormat("%s missed", errorFilePath.c_str())->getCString());
+                    labelAtlas->addChild(label);
+                }
                 break;
             }
+                
             case 1:
                 CCLOG("Wrong res type of LabelAtlas!");
                 break;
+                
             default:
                 break;
         }


### PR DESCRIPTION
Check whether resources of TextAtlas is exist in order to avoid crash during parse .csb and .csd file.
