### PR TITLE
Accelerometer polling for iOS

### DIFF
--- a/cocos/platform/CCDevice.h
+++ b/cocos/platform/CCDevice.h
@@ -32,6 +32,7 @@ THE SOFTWARE.
 
 NS_CC_BEGIN
 
+class Acceleration;
 struct FontDefinition;
 
 /**
@@ -75,6 +76,12 @@ public:
      *  Sets the interval of accelerometer.
      */
     static void setAccelerometerInterval(float interval);
+    
+    /**
+     * Polls the current values of the accelerometer. You should enable the accelerometer prior to calling this function.
+     * For devices or platforms which this is not implemented or supported for, will return a null Acceleration object.
+     */
+    static Acceleration * pollAccelerometer();
 
     /**
      * Controls whether the screen should remain on.

--- a/cocos/platform/android/CCDevice-android.cpp
+++ b/cocos/platform/android/CCDevice-android.cpp
@@ -65,6 +65,12 @@ void Device::setAccelerometerInterval(float interval)
 	setAccelerometerIntervalJni(interval);
 }
 
+Acceleration * Device::pollAccelerometer()
+{
+    // TODO: implement me for Android
+    return nullptr;
+}
+
 class BitmapDC
 {
 public:

--- a/cocos/platform/linux/CCDevice-linux.cpp
+++ b/cocos/platform/linux/CCDevice-linux.cpp
@@ -112,6 +112,11 @@ void Device::setAccelerometerInterval(float interval)
 
 }
 
+Acceleration * Device::pollAccelerometer()
+{
+    return nullptr;
+}
+
 class BitmapDC
 {
 public:

--- a/cocos/platform/mac/CCDevice-mac.mm
+++ b/cocos/platform/mac/CCDevice-mac.mm
@@ -50,6 +50,11 @@ void Device::setAccelerometerInterval(float interval)
 
 }
 
+Acceleration * Device::pollAccelerometer()
+{
+    return nullptr;
+}
+
 typedef struct
 {
     int height;

--- a/cocos/platform/win32/CCDevice-win32.cpp
+++ b/cocos/platform/win32/CCDevice-win32.cpp
@@ -52,6 +52,11 @@ void Device::setAccelerometerEnabled(bool isEnabled)
 void Device::setAccelerometerInterval(float interval)
 {}
 
+Acceleration * Device::pollAccelerometer()
+{
+    return nullptr;
+}
+
 class BitmapDC
 {
 public:

--- a/cocos/platform/winrt/CCDevice.cpp
+++ b/cocos/platform/winrt/CCDevice.cpp
@@ -185,7 +185,11 @@ void Device::setAccelerometerInterval(float interval)
     }
 }
 
-
+Acceleration * Device::pollAccelerometer()
+{
+    // TOOD: implement for Windows
+    return nullptr;
+}
 
 Data Device::getTextureDataForText(const char * text, const FontDefinition& textDefinition, TextAlign align, int &width, int &height, bool& hasPremultipliedAlpha)
 {

--- a/tests/cpp-tests/Classes/NewEventDispatcherTest/NewEventDispatcherTest.cpp
+++ b/tests/cpp-tests/Classes/NewEventDispatcherTest/NewEventDispatcherTest.cpp
@@ -575,7 +575,17 @@ _pos = _max;        \
         
         auto ptNow  = sprite->getPosition();
         
-        log("acc: x = %lf, y = %lf", acc->x, acc->y);
+        log("acc: x = %lf, y = %lf, z = %lf", acc->x, acc->y, acc->z);
+        
+        Acceleration * polledAcceleration = Device::pollAccelerometer();
+        
+        if (polledAcceleration)
+        {
+            log("acc polled: x = %lf, y = %lf, z = %lf",
+                polledAcceleration->x,
+                polledAcceleration->y,
+                polledAcceleration->z);
+        }
         
         ptNow.x += acc->x * 9.81f;
         ptNow.y += acc->y * 9.81f;


### PR DESCRIPTION
Add the ability to poll the accelerometer on iOS. Implement accelerometer polling to allow the acceleration data to be more easily used in update loops (rather than event driven input) and to workaround issues with lag on accelerometer events described here: http://discuss.cocos2d-x.org/t/accelerometer-data-lagging/16105

Note: Polling can also be implemented for Android and Windows phone, but currently stubbed out for those platforms.
