### PR TITLE
V4 renderer buffer refactor

### DIFF
--- a/cocos/renderer/CCRenderer.cpp
+++ b/cocos/renderer/CCRenderer.cpp
@@ -182,9 +182,6 @@ Renderer::Renderer()
     ,_glViewAssigned(false)
     ,_isRendering(false)
     ,_isDepthTestFor2D(false)
-#if CC_ENABLE_CACHE_TEXTURE_DATA
-    ,_cacheTextureListener(nullptr)
-#endif
 {
     _groupCommandManager = new (std::nothrow) GroupCommandManager();
     
@@ -206,10 +203,6 @@ Renderer::~Renderer()
     CC_SAFE_RELEASE(_vao);
     CC_SAFE_RELEASE(_vbo);
     CC_SAFE_RELEASE(_ibo);
-    
-#if CC_ENABLE_CACHE_TEXTURE_DATA
-    Director::getInstance()->getEventDispatcher()->removeEventListener(_cacheTextureListener);
-#endif
 }
 
 void Renderer::initGLView()
@@ -219,15 +212,6 @@ void Renderer::initGLView()
 
 void Renderer::initBuffers()
 {
-#if CC_ENABLE_CACHE_TEXTURE_DATA
-    _cacheTextureListener = EventListenerCustom::create(EVENT_RENDERER_RECREATED, [this](EventCustom* event){
-        /** listen the event that renderer was recreated on Android/WP8 */
-        this->setupBuffer();
-    });
-    
-    Director::getInstance()->getEventDispatcher()->addEventListenerWithFixedPriority(_cacheTextureListener, -1);
-#endif
-    
     _vao = VertexData::create(VertexData::Primitive::Triangles);
     _vbo = VertexBuffer::create(sizeof(V3F_C4B_T2F), VBO_SIZE, VertexBuffer::ArrayType::All, VertexBuffer::ArrayMode::Dynamic);
     _ibo = IndexBuffer::create(IndexBuffer::IndexType::INDEX_TYPE_SHORT_16, INDEX_VBO_SIZE, IndexBuffer::ArrayType::All);

--- a/cocos/renderer/CCRenderer.cpp
+++ b/cocos/renderer/CCRenderer.cpp
@@ -307,7 +307,7 @@ void Renderer::processRenderCommand(RenderCommand* command)
         {
             CCASSERT(cmd->getQuadCount()>= 0 && cmd->getQuadCount() * 4 < VBO_SIZE, "VBO for vertex is not big enough, please break the data down or use customized render command");
             //Draw batched quads if VBO is full
-            drawBatchedGeometry();
+            drawBatchedQuads();
         }
         
         //Batch Quads
@@ -317,7 +317,7 @@ void Renderer::processRenderCommand(RenderCommand* command)
         
         if(cmd->isSkipBatching())
         {
-            drawBatchedGeometry();
+            drawBatchedQuads();
         }
     }
     else if (RenderCommand::Type::MESH_COMMAND == commandType)
@@ -574,7 +574,7 @@ void Renderer::insertQuads(const QuadCommand* cmd)
     }
 }
 
-void Renderer::drawBatchedGeometry()
+void Renderer::drawBatchedQuads()
 {
     int indexToDraw = 0;
     int startIndex = 0;
@@ -626,7 +626,7 @@ void Renderer::flush2D()
 {
     if (!_vao->empty())
     {
-        drawBatchedGeometry();
+        drawBatchedQuads();
         _lastMaterialID = 0;
     }
 }

--- a/cocos/renderer/CCRenderer.h
+++ b/cocos/renderer/CCRenderer.h
@@ -210,10 +210,6 @@ protected:
     bool _isDepthTestFor2D;
     
     GroupCommandManager* _groupCommandManager;
-    
-#if CC_ENABLE_CACHE_TEXTURE_DATA
-    EventListenerCustom* _cacheTextureListener;
-#endif
 };
 
 NS_CC_END

--- a/cocos/renderer/CCRenderer.h
+++ b/cocos/renderer/CCRenderer.h
@@ -40,6 +40,9 @@ class EventListenerCustom;
 class QuadCommand;
 class TrianglesCommand;
 class MeshCommand;
+class VertexData;
+class VertexBuffer;
+class IndexBuffer;
 
 /** Class that knows how to sort `RenderCommand` objects.
  Since the commands that have `z == 0` are "pushed back" in
@@ -109,7 +112,7 @@ public:
     ~Renderer();
 
     //TODO: manage GLView inside Render itself
-    void initGLView();
+    CC_DEPRECATED(v4) void initGLView();
 
     /** Adds a `RenderComamnd` into the renderer */
     void addCommand(RenderCommand* command);
@@ -162,13 +165,9 @@ public:
 
 protected:
 
-    //Setup VBO or VAO based on OpenGL extensions
-    void setupBuffer();
-    void setupVBOAndVAO();
-    void setupVBO();
-    void mapBuffers();
-    void drawBatchedTriangles();
-    void drawBatchedQuads();
+    void initBuffers();
+    
+    void drawBatchedGeometry();
 
     //Draw the previews queued quads and flush previous context
     void flush();
@@ -177,14 +176,12 @@ protected:
     
     void flush3D();
 
-    void flushQuads();
-    void flushTriangles();
-
+    void flushGeometry();
+    
     void processRenderCommand(RenderCommand* command);
     void visitRenderQueue(RenderQueue& queue);
 
-    void fillVerticesAndIndices(const TrianglesCommand* cmd);
-    void fillQuads(const QuadCommand* cmd);
+    void insertQuads(const QuadCommand* cmd);
 
     /* clear color set outside be used in setGLDefaultValues() */
     Color4F _clearColor;
@@ -196,24 +193,11 @@ protected:
     uint32_t _lastMaterialID;
 
     MeshCommand*              _lastBatchedMeshCommand;
-    std::vector<TrianglesCommand*> _batchedCommands;
     std::vector<QuadCommand*> _batchQuadCommands;
-
-    //for TrianglesCommand
-    V3F_C4B_T2F _verts[VBO_SIZE];
-    GLushort _indices[INDEX_VBO_SIZE];
-    GLuint _buffersVAO;
-    GLuint _buffersVBO[2]; //0: vertex  1: indices
-
-    int _filledVertex;
-    int _filledIndex;
     
-    //for QuadCommand
-    V3F_C4B_T2F _quadVerts[VBO_SIZE];
-    GLushort _quadIndices[INDEX_VBO_SIZE];
-    GLuint _quadVAO;
-    GLuint _quadbuffersVBO[2]; //0: vertex  1: indices
-    int _numberQuads;
+    VertexData* _vao;
+    VertexBuffer* _vbo;
+    IndexBuffer* _ibo;
     
     bool _glViewAssigned;
 

--- a/cocos/renderer/CCRenderer.h
+++ b/cocos/renderer/CCRenderer.h
@@ -167,7 +167,7 @@ protected:
 
     void initBuffers();
     
-    void drawBatchedGeometry();
+    void drawBatchedQuads();
 
     //Draw the previews queued quads and flush previous context
     void flush();

--- a/cocos/renderer/CCRenderer.h
+++ b/cocos/renderer/CCRenderer.h
@@ -105,7 +105,7 @@ public:
     static const int VBO_SIZE = 65536;
     static const int INDEX_VBO_SIZE = VBO_SIZE * 6 / 4;
     
-    static const int BATCH_QUADCOMMAND_RESEVER_SIZE = 64;
+    static const int BATCH_QUADCOMMAND_RESERVE_SIZE = 64;
     static const int MATERIAL_ID_DO_NOT_BATCH = 0;
     
     Renderer();

--- a/cocos/renderer/CCTrianglesCommand.h
+++ b/cocos/renderer/CCTrianglesCommand.h
@@ -29,7 +29,7 @@
 #include "renderer/CCGLProgramState.h"
 
 NS_CC_BEGIN
-class CC_DLL TrianglesCommand : public RenderCommand
+CC_DEPRECATED(v4) class CC_DLL TrianglesCommand : public RenderCommand
 {
 public:
     struct Triangles

--- a/cocos/renderer/CCVertexIndexData.cpp
+++ b/cocos/renderer/CCVertexIndexData.cpp
@@ -239,6 +239,8 @@ void VertexData::clear()
     _dirty = true;
     for (auto& b : _buffers)
         b->clear();
+    if (_indices)
+        _indices->clear();
 }
 
 bool VertexData::isDirty() const
@@ -248,6 +250,8 @@ bool VertexData::isDirty() const
     for (auto b : _buffers)
         if (b->isDirty())
             return true;
+    if (_indices && _indices->isDirty())
+        return true;
     return false;
 }
 
@@ -256,6 +260,8 @@ void VertexData::setDirty(bool dirty)
     _dirty = dirty;
     for (auto b : _buffers)
         b->setDirty(dirty);
+    if (_indices)
+        _indices->setDirty(dirty);
 }
 
 ssize_t VertexData::getCount() const


### PR DESCRIPTION
This replaces the native opengl code in Renderer with VertexData/VertexBuffer/IndexBuffer so that it will use the abstracted version in the Metal dev branch.

This also removes TriangleCommand which is not used or referenced anywhere.
