### PR TITLE
Fixed jni illegal start byte error.

### DIFF
--- a/cocos/platform/android/CCDevice-android.cpp
+++ b/cocos/platform/android/CCDevice-android.cpp
@@ -88,7 +88,7 @@ public:
     {
            JniMethodInfo methodInfo;
            if (! JniHelper::getStaticMethodInfo(methodInfo, "org/cocos2dx/lib/Cocos2dxBitmap", "createTextBitmapShadowStroke",
-               "(Ljava/lang/String;Ljava/lang/String;IIIIIIIIZFFFFZIIIIF)Z"))
+               "([BLjava/lang/String;IIIIIIIIZFFFFZIIIIF)Z"))
            {
                CCLOG("%s %d: error to get methodInfo", __FILE__, __LINE__);
                return false;
@@ -111,10 +111,12 @@ public:
             * and data.
             * use this approach to decrease the jni call number
            */
-           jstring jstrText = methodInfo.env->NewStringUTF(text);
+           int count = strlen(text);
+           jbyteArray strArray = methodInfo.env->NewByteArray(count);
+           methodInfo.env->SetByteArrayRegion(strArray, 0, count, reinterpret_cast<const jbyte*>(text));
            jstring jstrFont = methodInfo.env->NewStringUTF(fullPathOrFontName.c_str());
 
-           if(!methodInfo.env->CallStaticBooleanMethod(methodInfo.classID, methodInfo.methodID, jstrText,
+           if(!methodInfo.env->CallStaticBooleanMethod(methodInfo.classID, methodInfo.methodID, strArray,
                jstrFont, textDefinition._fontSize, textDefinition._fontFillColor.r, textDefinition._fontFillColor.g, 
                textDefinition._fontFillColor.b, textDefinition._fontAlpha,
                eAlignMask, nWidth, nHeight, 
@@ -126,7 +128,7 @@ public:
                 return false;
            }
 
-           methodInfo.env->DeleteLocalRef(jstrText);
+           methodInfo.env->DeleteLocalRef(strArray);
            methodInfo.env->DeleteLocalRef(jstrFont);
            methodInfo.env->DeleteLocalRef(methodInfo.classID);
 

--- a/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxBitmap.java
+++ b/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxBitmap.java
@@ -93,19 +93,24 @@ public class Cocos2dxBitmap {
             final int fontSize, final int alignment, final int width,
             final int height) {
         
-        createTextBitmapShadowStroke( string, fontName, fontSize, 255, 255, 255, 255,   // text font and color
+        createTextBitmapShadowStroke( string.getBytes(), fontName, fontSize, 255, 255, 255, 255,   // text font and color
                                       alignment, width, height,                         // alignment and size
                                       false, 0.0f, 0.0f, 0.0f, 0.0f,                    // no shadow
                                       false, 255, 255, 255, 255, 0.0f);                   // no stroke
                                      
     }
 
-    public static boolean createTextBitmapShadowStroke(String string,  final String fontName, int fontSize,
+    public static boolean createTextBitmapShadowStroke(byte[] bytes,  final String fontName, int fontSize,
                                                     int fontTintR, int fontTintG, int fontTintB, int fontTintA,
                                                     int alignment, int width, int height, 
                                                     boolean shadow, float shadowDX, float shadowDY, float shadowBlur, float shadowOpacity, 
                                                     boolean stroke, int strokeR, int strokeG, int strokeB, int strokeA, float strokeSize) {
-
+        String string;
+        if (bytes == null || bytes.length == 0) {
+          string = "";
+        } else {
+          string = new String(bytes);
+        }
         
         final int horizontalAlignment = alignment & 0x0F;
         final int verticalAlignment   = (alignment >> 4) & 0x0F;


### PR DESCRIPTION
In JNI,  `methodInfo.env->NewStringUTF(text);` method happens `JNI DETECTED ERROR IN APPLICATION: input is not valid Modified UTF-8: illegal start byte` when we input Emoji such as "🍣".
Then, I Fixed that using the byte array instead of String.
And creating the text String in Java runtime.

And, I searched the depending to [createTextBitmap](https://github.com/cocos2d/cocos2d-x/blob/2b77006d1c5505865d3d1f87690ddb1ec8612fcb/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxBitmap.java#L92) method,  but it is not used anywhere. But I fixed too for complie.

Thank you for your working! :smile: 
