### PR TITLE
Fixed every node of UI animation(json) is starting at frame 0.

### DIFF
--- a/cocos/editor-support/cocostudio/CCActionNode.cpp
+++ b/cocos/editor-support/cocostudio/CCActionNode.cpp
@@ -440,6 +440,12 @@ Spawn * ActionNode::refreshActionProperty()
             auto frame = cArray->at(i);
             if (i == 0)
             {
+				if (frame->getFrameIndex() > 0)
+				{
+					DelayTime* cDelayTime = DelayTime::create(frame->getFrameIndex() * getUnitTime());
+					if (cDelayTime != nullptr)
+						cSequenceArray.pushBack(static_cast<FiniteTimeAction*>(cDelayTime));
+				}
             }
             else
             {
@@ -447,7 +453,7 @@ Spawn * ActionNode::refreshActionProperty()
                 float duration = (frame->getFrameIndex() - srcFrame->getFrameIndex()) * getUnitTime();
                 Action* cAction = frame->getAction(duration);
                 if(cAction != nullptr)
-                cSequenceArray.pushBack(static_cast<FiniteTimeAction*>(cAction));
+	                cSequenceArray.pushBack(static_cast<FiniteTimeAction*>(cAction));
             }
         }
         Sequence* cSequence = Sequence::create(cSequenceArray);


### PR DESCRIPTION
I'm using both CocosStudio 1.6 and 2.1.5.
( Because CocosStudio 2.1.5 doesn't support opacity and visible
animation, we're using CocosStudio 1.6 for some UI animation. )

With 1.6 json file, we have some action nodes with non-zero startframe.
But non-zero startframe node run from zero-frame.

![missing_start_frame](https://cloud.githubusercontent.com/assets/10286139/6847318/fab37366-d408-11e4-86e3-a710991acbcc.png)
