### PR TITLE
refresh the search paths

### DIFF
--- a/cocos/platform/CCFileUtils.cpp
+++ b/cocos/platform/CCFileUtils.cpp
@@ -846,6 +846,7 @@ void FileUtils::setWritablePath(const std::string& writablePath)
 void FileUtils::setDefaultResourceRootPath(const std::string& path)
 {
     _defaultResRootPath = path;
+    setSearchPaths(_searchPathArray);
 }
 
 void FileUtils::setSearchPaths(const std::vector<std::string>& searchPaths)


### PR DESCRIPTION
When I set the workdir in the command line on mac platform, it not affect the search paths, because the search paths set first, _defaultResRootPath is null string, so refresh the search paths can solve it.
