### PR TITLE
CCClippingRectangleNode add to a scale parent bug

### DIFF
--- a/cocos/2d/CCClippingRectangleNode.cpp
+++ b/cocos/2d/CCClippingRectangleNode.cpp
@@ -53,8 +53,8 @@ void ClippingRectangleNode::onBeforeVisitScissor()
         
         const Point pos = convertToWorldSpace(Point(_clippingRegion.origin.x, _clippingRegion.origin.y));
         GLView* glView = Director::getInstance()->getOpenGLView();
-        glView->setScissorInPoints(pos.x * scaleX,
-                                   pos.y * scaleY,
+        glView->setScissorInPoints(pos.x,
+                                   pos.y,
                                    _clippingRegion.size.width * scaleX,
                                    _clippingRegion.size.height * scaleY);
     }


### PR DESCRIPTION
don't need to scale the point since it is a world coordinate
