### PR TITLE
Remove use of autorelease NSString and NSURL

### DIFF
--- a/cocos/audio/apple/AudioCache.mm
+++ b/cocos/audio/apple/AudioCache.mm
@@ -99,8 +99,10 @@ void AudioCache::readDataTask()
     AudioBufferList theDataBuffer;
     ExtAudioFileRef extRef = nullptr;
     
-    auto fileURL = (CFURLRef)[[NSURL fileURLWithPath:[NSString stringWithCString:_fileFullPath.c_str() encoding:[NSString defaultCStringEncoding]]] retain];
-    
+    NSString *fileFullPath = [[NSString alloc] initWithCString:_fileFullPath.c_str() encoding:[NSString defaultCStringEncoding]];
+    auto fileURL = (CFURLRef)[[NSURL alloc] initFileURLWithPath:fileFullPath];
+    [fileFullPath release];
+
     auto error = ExtAudioFileOpenURL(fileURL, &extRef);
     if(error) {
         printf("%s: ExtAudioFileOpenURL FAILED, Error = %ld\n", __PRETTY_FUNCTION__, (long)error);


### PR DESCRIPTION
Since there is no autorelease pool, these were leaking.
