### PR TITLE
Remove use of autorelease NSString and NSURL

### DIFF
--- a/cocos/audio/apple/AudioPlayer.mm
+++ b/cocos/audio/apple/AudioPlayer.mm
@@ -116,7 +116,9 @@ void AudioPlayer::rotateBufferThread(int offsetFrame)
     ALint bufferProcessed = 0;
     ExtAudioFileRef extRef = nullptr;
     
-    auto fileURL = (CFURLRef)[[NSURL fileURLWithPath:[NSString stringWithCString:_audioCache->_fileFullPath.c_str() encoding:[NSString defaultCStringEncoding]]] retain];
+    NSString *fileFullPath = [[NSString alloc] initWithCString:_audioCache->_fileFullPath.c_str() encoding:[NSString defaultCStringEncoding]];
+    auto fileURL = (CFURLRef)[[NSURL alloc] initFileURLWithPath:fileFullPath];
+    [fileFullPath release];
     char* tmpBuffer = (char*)malloc(_audioCache->_queBufferBytes);
     auto frames = _audioCache->_queBufferFrames;
     


### PR DESCRIPTION
Since there is no autorelease pool, these were leaking.
