### PR TITLE
Add destroyCocosStudio()

### DIFF
--- a/build/cocos2d_libs.xcodeproj/project.pbxproj
+++ b/build/cocos2d_libs.xcodeproj/project.pbxproj
@@ -1282,6 +1282,8 @@
 		38B8E2E219E671D2002D7CE7 /* UILayoutComponent.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 38B8E2DF19E671D2002D7CE7 /* UILayoutComponent.cpp */; };
 		38B8E2E319E671D2002D7CE7 /* UILayoutComponent.h in Headers */ = {isa = PBXBuildFile; fileRef = 38B8E2E019E671D2002D7CE7 /* UILayoutComponent.h */; };
 		38B8E2E419E671D2002D7CE7 /* UILayoutComponent.h in Headers */ = {isa = PBXBuildFile; fileRef = 38B8E2E019E671D2002D7CE7 /* UILayoutComponent.h */; };
+		38D9629D1ACA9721007C6FAF /* CocoStudio.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 38D9629C1ACA9721007C6FAF /* CocoStudio.cpp */; };
+		38D9629E1ACA9721007C6FAF /* CocoStudio.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 38D9629C1ACA9721007C6FAF /* CocoStudio.cpp */; };
 		38F5263E1A48363B000DB7F7 /* ArmatureNodeReader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 38F5263B1A48363B000DB7F7 /* ArmatureNodeReader.cpp */; };
 		38F5263F1A48363B000DB7F7 /* ArmatureNodeReader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 38F5263B1A48363B000DB7F7 /* ArmatureNodeReader.cpp */; };
 		38F526401A48363B000DB7F7 /* ArmatureNodeReader.h in Headers */ = {isa = PBXBuildFile; fileRef = 38F5263C1A48363B000DB7F7 /* ArmatureNodeReader.h */; };
@@ -3109,6 +3111,7 @@
 		38B8E2D419E66581002D7CE7 /* CSLoader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CSLoader.h; sourceTree = "<group>"; };
 		38B8E2DF19E671D2002D7CE7 /* UILayoutComponent.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = UILayoutComponent.cpp; sourceTree = "<group>"; };
 		38B8E2E019E671D2002D7CE7 /* UILayoutComponent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = UILayoutComponent.h; sourceTree = "<group>"; };
+		38D9629C1ACA9721007C6FAF /* CocoStudio.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CocoStudio.cpp; sourceTree = "<group>"; };
 		38F5263B1A48363B000DB7F7 /* ArmatureNodeReader.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ArmatureNodeReader.cpp; sourceTree = "<group>"; };
 		38F5263C1A48363B000DB7F7 /* ArmatureNodeReader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ArmatureNodeReader.h; sourceTree = "<group>"; };
 		38F5263D1A48363B000DB7F7 /* CSArmatureNode_generated.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CSArmatureNode_generated.h; sourceTree = "<group>"; };
@@ -4868,6 +4871,7 @@
 				1A8C5984180E930E00EF57C3 /* CCUtilMath.cpp */,
 				1A8C5985180E930E00EF57C3 /* CCUtilMath.h */,
 				1A8C5986180E930E00EF57C3 /* CocoStudio.h */,
+				38D9629C1ACA9721007C6FAF /* CocoStudio.cpp */,
 				1A8C5989180E930E00EF57C3 /* DictionaryHelper.cpp */,
 				1A8C598A180E930E00EF57C3 /* DictionaryHelper.h */,
 			);
@@ -8602,6 +8606,7 @@
 				B665E2561AA80A6500DDB1C5 /* CCPUDoAffectorEventHandlerTranslator.cpp in Sources */,
 				15AE18A419AAD33D00C27E9E /* CCScale9SpriteLoader.cpp in Sources */,
 				182C5CD61A98F30500C30D34 /* Sprite3DReader.cpp in Sources */,
+				38D9629D1ACA9721007C6FAF /* CocoStudio.cpp in Sources */,
 				B665E3D61AA80A6600DDB1C5 /* CCPUScriptParser.cpp in Sources */,
 				15AE1B5719AADA9900C27E9E /* UISlider.cpp in Sources */,
 				B665E2F61AA80A6500DDB1C5 /* CCPUListener.cpp in Sources */,
@@ -9044,6 +9049,7 @@
 				B665E3AF1AA80A6500DDB1C5 /* CCPURender.cpp in Sources */,
 				382383FB1A258FA7002C4610 /* idl_gen_go.cpp in Sources */,
 				B665E2EF1AA80A6500DDB1C5 /* CCPULineEmitter.cpp in Sources */,
+				38D9629E1ACA9721007C6FAF /* CocoStudio.cpp in Sources */,
 				50ABBDBA1925AB4100A911A9 /* CCTextureAtlas.cpp in Sources */,
 				1A5702FB180BCE750088DEC7 /* CCTMXXMLParser.cpp in Sources */,
 				B665E40B1AA80A6600DDB1C5 /* CCPUSphereSurfaceEmitterTranslator.cpp in Sources */,

--- a/cocos/2d/libcocos2d.vcxproj
+++ b/cocos/2d/libcocos2d.vcxproj
@@ -514,6 +514,7 @@ xcopy /Y /Q "$(ProjectDir)..\..\external\chipmunk\prebuilt\win32\release-lib\*.*
     <ClCompile Include="..\editor-support\cocostudio\CCTween.cpp" />
     <ClCompile Include="..\editor-support\cocostudio\CCUtilMath.cpp" />
     <ClCompile Include="..\editor-support\cocostudio\CocoLoader.cpp" />
+    <ClCompile Include="..\editor-support\cocostudio\CocoStudio.cpp" />
     <ClCompile Include="..\editor-support\cocostudio\DictionaryHelper.cpp" />
     <ClCompile Include="..\editor-support\cocostudio\FlatBuffersSerialize.cpp" />
     <ClCompile Include="..\editor-support\cocostudio\TriggerBase.cpp" />

--- a/cocos/2d/libcocos2d.vcxproj.filters
+++ b/cocos/2d/libcocos2d.vcxproj.filters
@@ -1795,6 +1795,9 @@
     <ClCompile Include="..\editor-support\cocostudio\CCObjectExtensionData.cpp">
       <Filter>cocostudio\json</Filter>
     </ClCompile>
+    <ClCompile Include="..\editor-support\cocostudio\CocoStudio.cpp">
+      <Filter>cocostudio\json</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\physics\CCPhysicsBody.h">

--- a/cocos/2d/libcocos2d_8_1/libcocos2d_8_1/libcocos2d_8_1.Shared/libcocos2d_8_1.Shared.vcxitems
+++ b/cocos/2d/libcocos2d_8_1/libcocos2d_8_1/libcocos2d_8_1.Shared/libcocos2d_8_1.Shared.vcxitems
@@ -947,6 +947,7 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\..\..\editor-support\cocostudio\CCTween.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\..\..\editor-support\cocostudio\CCUtilMath.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\..\..\editor-support\cocostudio\CocoLoader.cpp" />
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\..\..\editor-support\cocostudio\CocoStudio.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\..\..\editor-support\cocostudio\DictionaryHelper.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\..\..\editor-support\cocostudio\FlatBuffersSerialize.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\..\..\editor-support\cocostudio\TriggerBase.cpp" />

--- a/cocos/2d/libcocos2d_8_1/libcocos2d_8_1/libcocos2d_8_1.Shared/libcocos2d_8_1.Shared.vcxitems.filters
+++ b/cocos/2d/libcocos2d_8_1/libcocos2d_8_1/libcocos2d_8_1.Shared/libcocos2d_8_1.Shared.vcxitems.filters
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <ClInclude Include="$(MSBuildThisFileDirectory)targetver.h" />
@@ -3311,6 +3311,9 @@
     </ClCompile>
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\..\..\3d\CCTextureCube.cpp">
       <Filter>3d</Filter>
+    </ClCompile>
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\..\..\editor-support\cocostudio\CocoStudio.cpp">
+      <Filter>cocostudio\json</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/cocos/2d/libcocos2d_wp8.vcxproj
+++ b/cocos/2d/libcocos2d_wp8.vcxproj
@@ -538,6 +538,7 @@
     <ClInclude Include="..\editor-support\cocostudio\CCTween.h" />
     <ClInclude Include="..\editor-support\cocostudio\CCUtilMath.h" />
     <ClInclude Include="..\editor-support\cocostudio\CocoLoader.h" />
+    <ClInclude Include="..\editor-support\cocostudio\CocoStudio.h" />
     <ClInclude Include="..\editor-support\cocostudio\CSParseBinary_generated.h" />
     <ClInclude Include="..\editor-support\cocostudio\CSParse3DBinary_generated.h" />
     <ClInclude Include="..\editor-support\cocostudio\DictionaryHelper.h" />
@@ -1179,6 +1180,7 @@
     <ClCompile Include="..\editor-support\cocostudio\CCTween.cpp" />
     <ClCompile Include="..\editor-support\cocostudio\CCUtilMath.cpp" />
     <ClCompile Include="..\editor-support\cocostudio\CocoLoader.cpp" />
+    <ClCompile Include="..\editor-support\cocostudio\CocoStudio.cpp" />
     <ClCompile Include="..\editor-support\cocostudio\DictionaryHelper.cpp" />
     <ClCompile Include="..\editor-support\cocostudio\FlatBuffersSerialize.cpp" />
     <ClCompile Include="..\editor-support\cocostudio\TriggerBase.cpp" />

--- a/cocos/2d/libcocos2d_wp8.vcxproj.filters
+++ b/cocos/2d/libcocos2d_wp8.vcxproj.filters
@@ -1815,6 +1815,9 @@
     <ClCompile Include="..\3d\CCTextureCube.cpp">
       <Filter>3d</Filter>
     </ClCompile>
+    <ClCompile Include="..\editor-support\cocostudio\CocoStudio.cpp">
+      <Filter>cocostudio\json</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="CCAction.h">
@@ -3527,6 +3530,9 @@
     </ClInclude>
     <ClInclude Include="..\3d\CCTextureCube.h">
       <Filter>3d</Filter>
+    </ClInclude>
+    <ClInclude Include="..\editor-support\cocostudio\CocoStudio.h">
+      <Filter>cocostudio\json</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/cocos/editor-support/cocostudio/ActionTimeline/CSLoader.cpp
+++ b/cocos/editor-support/cocostudio/ActionTimeline/CSLoader.cpp
@@ -214,10 +214,6 @@ CSLoader::CSLoader()
     CREATE_CLASS_NODE_READER_INFO(Particle3DReader);
 }
 
-void CSLoader::purge()
-{
-}
-
 void CSLoader::destroyCocosStudio()
 {
     NodeReader::destroyInstance();

--- a/cocos/editor-support/cocostudio/ActionTimeline/CSLoader.cpp
+++ b/cocos/editor-support/cocostudio/ActionTimeline/CSLoader.cpp
@@ -218,6 +218,36 @@ void CSLoader::purge()
 {
 }
 
+void CSLoader::destroyCocosStudio()
+{
+    NodeReader::destroyInstance();
+    SingleNodeReader::destroyInstance();
+    SpriteReader::destroyInstance();
+    ParticleReader::destroyInstance();
+    
+    ButtonReader::destroyInstance();
+    CheckBoxReader::destroyInstance();
+    ImageViewReader::destroyInstance();
+    TextBMFontReader::destroyInstance();
+    TextReader::destroyInstance();
+    TextFieldReader::destroyInstance();
+    TextAtlasReader::destroyInstance();
+    LoadingBarReader::destroyInstance();
+    SliderReader::destroyInstance();
+    LayoutReader::destroyInstance();
+    ScrollViewReader::destroyInstance();
+    PageViewReader::destroyInstance();
+    ListViewReader::destroyInstance();
+    
+    ArmatureNodeReader::destroyInstance();
+    Node3DReader::destroyInstance();
+    Sprite3DReader::destroyInstance();
+    UserCameraReader::destroyInstance();
+    Particle3DReader::destroyInstance();
+    
+    destroyInstance();
+}
+
 void CSLoader::init()
 {
     using namespace std::placeholders;

--- a/cocos/editor-support/cocostudio/ActionTimeline/CSLoader.cpp
+++ b/cocos/editor-support/cocostudio/ActionTimeline/CSLoader.cpp
@@ -218,40 +218,6 @@ void CSLoader::purge()
 {
 }
 
-void CSLoader::destroyCocosStudio()
-{
-    NodeReader::destroyInstance();
-    SingleNodeReader::destroyInstance();
-    SpriteReader::destroyInstance();
-    ParticleReader::destroyInstance();
-    GameMapReader::destroyInstance();
-    ProjectNodeReader::destroyInstance();
-    ComAudioReader::destroyInstance();
-    
-    WidgetReader::destroyInstance();
-    ButtonReader::destroyInstance();
-    CheckBoxReader::destroyInstance();
-    ImageViewReader::destroyInstance();
-    TextBMFontReader::destroyInstance();
-    TextReader::destroyInstance();
-    TextFieldReader::destroyInstance();
-    TextAtlasReader::destroyInstance();
-    LoadingBarReader::destroyInstance();
-    SliderReader::destroyInstance();
-    LayoutReader::destroyInstance();
-    ScrollViewReader::destroyInstance();
-    PageViewReader::destroyInstance();
-    ListViewReader::destroyInstance();
-    
-    ArmatureNodeReader::destroyInstance();
-    Node3DReader::destroyInstance();
-    Sprite3DReader::destroyInstance();
-    UserCameraReader::destroyInstance();
-    Particle3DReader::destroyInstance();
-    
-    destroyInstance();
-}
-
 void CSLoader::init()
 {
     using namespace std::placeholders;

--- a/cocos/editor-support/cocostudio/ActionTimeline/CSLoader.cpp
+++ b/cocos/editor-support/cocostudio/ActionTimeline/CSLoader.cpp
@@ -214,6 +214,10 @@ CSLoader::CSLoader()
     CREATE_CLASS_NODE_READER_INFO(Particle3DReader);
 }
 
+void CSLoader::purge()
+{
+}
+
 void CSLoader::destroyCocosStudio()
 {
     NodeReader::destroyInstance();

--- a/cocos/editor-support/cocostudio/ActionTimeline/CSLoader.cpp
+++ b/cocos/editor-support/cocostudio/ActionTimeline/CSLoader.cpp
@@ -224,7 +224,11 @@ void CSLoader::destroyCocosStudio()
     SingleNodeReader::destroyInstance();
     SpriteReader::destroyInstance();
     ParticleReader::destroyInstance();
+    GameMapReader::destroyInstance();
+    ProjectNodeReader::destroyInstance();
+    ComAudioReader::destroyInstance();
     
+    WidgetReader::destroyInstance();
     ButtonReader::destroyInstance();
     CheckBoxReader::destroyInstance();
     ImageViewReader::destroyInstance();

--- a/cocos/editor-support/cocostudio/ActionTimeline/CSLoader.h
+++ b/cocos/editor-support/cocostudio/ActionTimeline/CSLoader.h
@@ -73,9 +73,7 @@ public:
     
     CSLoader();
     /** @deprecated Use method destroyInstance() instead */
-    CC_DEPRECATED_ATTRIBUTE void purge();
-    
-    static void destroyCocosStudio();
+    CC_DEPRECATED_ATTRIBUTE void purge();    
     
     void init();
     

--- a/cocos/editor-support/cocostudio/ActionTimeline/CSLoader.h
+++ b/cocos/editor-support/cocostudio/ActionTimeline/CSLoader.h
@@ -72,7 +72,8 @@ public:
     static void destroyInstance();
     
     CSLoader();
-    void purge();
+    /** @deprecated Use method destroyInstance() instead */
+    CC_DEPRECATED_ATTRIBUTE void purge();
     
     static void destroyCocosStudio();
     

--- a/cocos/editor-support/cocostudio/ActionTimeline/CSLoader.h
+++ b/cocos/editor-support/cocostudio/ActionTimeline/CSLoader.h
@@ -74,6 +74,8 @@ public:
     CSLoader();
     void purge();
     
+    static void destroyCocosStudio();
+    
     void init();
     
     static cocos2d::Node* createNode(const std::string& filename);

--- a/cocos/editor-support/cocostudio/Android.mk
+++ b/cocos/editor-support/cocostudio/Android.mk
@@ -75,7 +75,8 @@ ActionTimeline/CSLoader.cpp \
 FlatBuffersSerialize.cpp \
 WidgetCallBackHandlerProtocol.cpp \
 WidgetReader/ArmatureNodeReader/ArmatureNodeReader.cpp \
-CCObjectExtensionData.cpp
+CCObjectExtensionData.cpp \
+CocoStudio.cpp
 
 
 LOCAL_EXPORT_C_INCLUDES := $(LOCAL_PATH)/..

--- a/cocos/editor-support/cocostudio/CMakeLists.txt
+++ b/cocos/editor-support/cocostudio/CMakeLists.txt
@@ -44,6 +44,7 @@ set(COCOS_CS_SRC
   editor-support/cocostudio/TriggerObj.cpp
   editor-support/cocostudio/FlatBuffersSerialize.cpp
   editor-support/cocostudio/CCObjectExtensionData.cpp
+  editor-support/cocostudio/CocoStudio.cpp
   editor-support/cocostudio/WidgetReader/NodeReader/NodeReader.cpp
   editor-support/cocostudio/WidgetReader/SingleNodeReader/SingleNodeReader.cpp
   editor-support/cocostudio/WidgetReader/SpriteReader/SpriteReader.cpp 

--- a/cocos/editor-support/cocostudio/CocoStudio.cpp
+++ b/cocos/editor-support/cocostudio/CocoStudio.cpp
@@ -1,0 +1,67 @@
+
+#include "CocoStudio.h"
+
+#include "cocostudio/WidgetReader/NodeReader/NodeReader.h"
+#include "cocostudio/WidgetReader/SingleNodeReader/SingleNodeReader.h"
+#include "cocostudio/WidgetReader/SpriteReader/SpriteReader.h"
+#include "cocostudio/WidgetReader/ParticleReader/ParticleReader.h"
+#include "cocostudio/WidgetReader/GameMapReader/GameMapReader.h"
+#include "cocostudio/WidgetReader/ProjectNodeReader/ProjectNodeReader.h"
+#include "cocostudio/WidgetReader/ComAudioReader/ComAudioReader.h"
+
+#include "cocostudio/WidgetReader/ButtonReader/ButtonReader.h"
+#include "cocostudio/WidgetReader/CheckBoxReader/CheckBoxReader.h"
+#include "cocostudio/WidgetReader/ImageViewReader/ImageViewReader.h"
+#include "cocostudio/WidgetReader/TextBMFontReader/TextBMFontReader.h"
+#include "cocostudio/WidgetReader/TextReader/TextReader.h"
+#include "cocostudio/WidgetReader/TextFieldReader/TextFieldReader.h"
+#include "cocostudio/WidgetReader/TextAtlasReader/TextAtlasReader.h"
+#include "cocostudio/WidgetReader/LoadingBarReader/LoadingBarReader.h"
+#include "cocostudio/WidgetReader/SliderReader/SliderReader.h"
+#include "cocostudio/WidgetReader/LayoutReader/LayoutReader.h"
+#include "cocostudio/WidgetReader/ScrollViewReader/ScrollViewReader.h"
+#include "cocostudio/WidgetReader/PageViewReader/PageViewReader.h"
+#include "cocostudio/WidgetReader/ListViewReader/ListViewReader.h"
+#include "cocostudio/WidgetReader/ArmatureNodeReader/ArmatureNodeReader.h"
+#include "cocostudio/WidgetReader/Node3DReader/Node3DReader.h"
+#include "cocostudio/WidgetReader/Sprite3DReader/Sprite3DReader.h"
+#include "cocostudio/WidgetReader/UserCameraReader/UserCameraReader.h"
+#include "cocostudio/WidgetReader/Particle3DReader/Particle3DReader.h"
+
+
+namespace cocostudio
+{
+    void destroyCocosStudio()
+    {        
+        NodeReader::destroyInstance();
+        SingleNodeReader::destroyInstance();
+        SpriteReader::destroyInstance();
+        ParticleReader::destroyInstance();
+        GameMapReader::destroyInstance();
+        ProjectNodeReader::destroyInstance();
+        ComAudioReader::destroyInstance();
+        
+        WidgetReader::destroyInstance();
+        ButtonReader::destroyInstance();
+        CheckBoxReader::destroyInstance();
+        ImageViewReader::destroyInstance();
+        TextBMFontReader::destroyInstance();
+        TextReader::destroyInstance();
+        TextFieldReader::destroyInstance();
+        TextAtlasReader::destroyInstance();
+        LoadingBarReader::destroyInstance();
+        SliderReader::destroyInstance();
+        LayoutReader::destroyInstance();
+        ScrollViewReader::destroyInstance();
+        PageViewReader::destroyInstance();
+        ListViewReader::destroyInstance();
+        
+        ArmatureNodeReader::destroyInstance();
+        Node3DReader::destroyInstance();
+        Sprite3DReader::destroyInstance();
+        UserCameraReader::destroyInstance();
+        Particle3DReader::destroyInstance();
+        
+        cocos2d::CSLoader::destroyInstance();
+    }
+}

--- a/cocos/editor-support/cocostudio/CocoStudio.h
+++ b/cocos/editor-support/cocostudio/CocoStudio.h
@@ -65,4 +65,11 @@ THE SOFTWARE.
 #include "cocostudio/CocosStudioExport.h"
 #include "cocostudio/ActionTimeline/CSLoader.h"
 
+#include "cocostudio/CocosStudioExport.h"
+
+namespace cocostudio
+{
+    void CC_STUDIO_DLL destroyCocosStudio();
+}
+
 #endif

--- a/cocos/editor-support/cocostudio/FlatBuffersSerialize.cpp
+++ b/cocos/editor-support/cocostudio/FlatBuffersSerialize.cpp
@@ -111,7 +111,7 @@ FlatBuffersSerialize::FlatBuffersSerialize()
 
 FlatBuffersSerialize::~FlatBuffersSerialize()
 {
-    purge();
+    
 }
 
 FlatBuffersSerialize* FlatBuffersSerialize::getInstance()
@@ -124,7 +124,7 @@ FlatBuffersSerialize* FlatBuffersSerialize::getInstance()
     return _instanceFlatBuffersSerialize;
 }
 
-void FlatBuffersSerialize::purge()
+void FlatBuffersSerialize::destroyInstance()
 {
     CC_SAFE_DELETE(_instanceFlatBuffersSerialize);
 	

--- a/cocos/editor-support/cocostudio/FlatBuffersSerialize.cpp
+++ b/cocos/editor-support/cocostudio/FlatBuffersSerialize.cpp
@@ -123,6 +123,12 @@ FlatBuffersSerialize* FlatBuffersSerialize::getInstance()
     
     return _instanceFlatBuffersSerialize;
 }
+    
+void FlatBuffersSerialize::purge()
+{
+    CC_SAFE_DELETE(_instanceFlatBuffersSerialize);
+    
+}
 
 void FlatBuffersSerialize::destroyInstance()
 {

--- a/cocos/editor-support/cocostudio/FlatBuffersSerialize.h
+++ b/cocos/editor-support/cocostudio/FlatBuffersSerialize.h
@@ -91,6 +91,8 @@ class CC_STUDIO_DLL FlatBuffersSerialize
     
 public:
     static FlatBuffersSerialize* getInstance();
+    /** @deprecated Use method destroyInstance() instead */
+    CC_DEPRECATED_ATTRIBUTE static void purge();
     static void destroyInstance();
     
     FlatBuffersSerialize();

--- a/cocos/editor-support/cocostudio/FlatBuffersSerialize.h
+++ b/cocos/editor-support/cocostudio/FlatBuffersSerialize.h
@@ -91,7 +91,7 @@ class CC_STUDIO_DLL FlatBuffersSerialize
     
 public:
     static FlatBuffersSerialize* getInstance();
-    static void purge();
+    static void destroyInstance();
     
     FlatBuffersSerialize();
     ~FlatBuffersSerialize();

--- a/cocos/editor-support/cocostudio/WidgetReader/ArmatureNodeReader/ArmatureNodeReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/ArmatureNodeReader/ArmatureNodeReader.cpp
@@ -34,6 +34,11 @@ ArmatureNodeReader* ArmatureNodeReader::getInstance()
 	return _instanceArmatureNodeReader;
 }
 
+void ArmatureNodeReader::destroyInstance()
+{
+    CC_SAFE_DELETE(_instanceArmatureNodeReader);
+}
+
 Offset<Table> ArmatureNodeReader::createOptionsWithFlatBuffers(const tinyxml2::XMLElement *objectData,
 	flatbuffers::FlatBufferBuilder *builder)
 {

--- a/cocos/editor-support/cocostudio/WidgetReader/ArmatureNodeReader/ArmatureNodeReader.h
+++ b/cocos/editor-support/cocostudio/WidgetReader/ArmatureNodeReader/ArmatureNodeReader.h
@@ -26,7 +26,6 @@ THE SOFTWARE.
 #define __ARMATURENODEREADER_H_
 
 #include "cocos2d.h"
-#include "cocostudio/FlatBuffersSerialize.h"
 #include "cocostudio/WidgetReader/NodeReaderProtocol.h"
 #include "cocostudio/WidgetReader/NodeReaderDefine.h"
 

--- a/cocos/editor-support/cocostudio/WidgetReader/ArmatureNodeReader/ArmatureNodeReader.h
+++ b/cocos/editor-support/cocostudio/WidgetReader/ArmatureNodeReader/ArmatureNodeReader.h
@@ -50,7 +50,7 @@ public:
 	~ArmatureNodeReader();
 
 	static ArmatureNodeReader* getInstance();
-	static void purge();
+	static void destroyInstance();
 
 	flatbuffers::Offset<flatbuffers::Table> createOptionsWithFlatBuffers(const tinyxml2::XMLElement* objectData,
 		flatbuffers::FlatBufferBuilder* builder) override;

--- a/cocos/editor-support/cocostudio/WidgetReader/ArmatureNodeReader/ArmatureNodeReader.h
+++ b/cocos/editor-support/cocostudio/WidgetReader/ArmatureNodeReader/ArmatureNodeReader.h
@@ -50,6 +50,8 @@ public:
 	~ArmatureNodeReader();
 
 	static ArmatureNodeReader* getInstance();
+    /** @deprecated Use method destroyInstance() instead */
+    CC_DEPRECATED_ATTRIBUTE static void purge();
 	static void destroyInstance();
 
 	flatbuffers::Offset<flatbuffers::Table> createOptionsWithFlatBuffers(const tinyxml2::XMLElement* objectData,

--- a/cocos/editor-support/cocostudio/WidgetReader/ButtonReader/ButtonReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/ButtonReader/ButtonReader.cpp
@@ -59,6 +59,11 @@ namespace cocostudio
         return instanceButtonReader;
     }
     
+    void ButtonReader::purge()
+    {
+        CC_SAFE_DELETE(instanceButtonReader);
+    }
+    
     void ButtonReader::destroyInstance()
     {
         CC_SAFE_DELETE(instanceButtonReader);

--- a/cocos/editor-support/cocostudio/WidgetReader/ButtonReader/ButtonReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/ButtonReader/ButtonReader.cpp
@@ -59,7 +59,7 @@ namespace cocostudio
         return instanceButtonReader;
     }
     
-    void ButtonReader::purge()
+    void ButtonReader::destroyInstance()
     {
         CC_SAFE_DELETE(instanceButtonReader);
     }

--- a/cocos/editor-support/cocostudio/WidgetReader/ButtonReader/ButtonReader.h
+++ b/cocos/editor-support/cocostudio/WidgetReader/ButtonReader/ButtonReader.h
@@ -39,6 +39,8 @@ namespace cocostudio
         virtual ~ButtonReader();
         
         static ButtonReader* getInstance();
+        /** @deprecated Use method destroyInstance() instead */
+        CC_DEPRECATED_ATTRIBUTE static void purge();
         static void destroyInstance();
         
         virtual void setPropsFromJsonDictionary(cocos2d::ui::Widget* widget,

--- a/cocos/editor-support/cocostudio/WidgetReader/ButtonReader/ButtonReader.h
+++ b/cocos/editor-support/cocostudio/WidgetReader/ButtonReader/ButtonReader.h
@@ -39,7 +39,7 @@ namespace cocostudio
         virtual ~ButtonReader();
         
         static ButtonReader* getInstance();
-        static void purge();
+        static void destroyInstance();
         
         virtual void setPropsFromJsonDictionary(cocos2d::ui::Widget* widget,
                                                 const rapidjson::Value& options);

--- a/cocos/editor-support/cocostudio/WidgetReader/CheckBoxReader/CheckBoxReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/CheckBoxReader/CheckBoxReader.cpp
@@ -45,6 +45,11 @@ namespace cocostudio
         return instanceCheckBoxReader;
     }
     
+    void CheckBoxReader::destroyInstance()
+    {
+        CC_SAFE_DELETE(instanceCheckBoxReader);
+    }
+    
     void CheckBoxReader::setPropsFromBinary(cocos2d::ui::Widget *widget, CocoLoader *cocoLoader, stExpCocoNode *cocoNode)
     {
         

--- a/cocos/editor-support/cocostudio/WidgetReader/CheckBoxReader/CheckBoxReader.h
+++ b/cocos/editor-support/cocostudio/WidgetReader/CheckBoxReader/CheckBoxReader.h
@@ -39,7 +39,7 @@ namespace cocostudio
         virtual ~CheckBoxReader();
         
         static CheckBoxReader* getInstance();
-        static void purge();
+        static void destroyInstance();
         
         virtual void setPropsFromJsonDictionary(cocos2d::ui::Widget* widget, const rapidjson::Value& options);
         virtual void setPropsFromBinary(cocos2d::ui::Widget* widget, CocoLoader* cocoLoader,  stExpCocoNode*	pCocoNode);        

--- a/cocos/editor-support/cocostudio/WidgetReader/CheckBoxReader/CheckBoxReader.h
+++ b/cocos/editor-support/cocostudio/WidgetReader/CheckBoxReader/CheckBoxReader.h
@@ -39,6 +39,8 @@ namespace cocostudio
         virtual ~CheckBoxReader();
         
         static CheckBoxReader* getInstance();
+        /** @deprecated Use method destroyInstance() instead */
+        CC_DEPRECATED_ATTRIBUTE static void purge();
         static void destroyInstance();
         
         virtual void setPropsFromJsonDictionary(cocos2d::ui::Widget* widget, const rapidjson::Value& options);

--- a/cocos/editor-support/cocostudio/WidgetReader/ComAudioReader/ComAudioReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/ComAudioReader/ComAudioReader.cpp
@@ -58,6 +58,11 @@ namespace cocostudio
         return _instanceComAudioReader;
     }
     
+    void ComAudioReader::purge()
+    {
+        CC_SAFE_DELETE(_instanceComAudioReader);
+    }
+    
     void ComAudioReader::destroyInstance()
     {
         CC_SAFE_DELETE(_instanceComAudioReader);

--- a/cocos/editor-support/cocostudio/WidgetReader/ComAudioReader/ComAudioReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/ComAudioReader/ComAudioReader.cpp
@@ -58,7 +58,7 @@ namespace cocostudio
         return _instanceComAudioReader;
     }
     
-    void ComAudioReader::purge()
+    void ComAudioReader::destroyInstance()
     {
         CC_SAFE_DELETE(_instanceComAudioReader);
     }

--- a/cocos/editor-support/cocostudio/WidgetReader/ComAudioReader/ComAudioReader.h
+++ b/cocos/editor-support/cocostudio/WidgetReader/ComAudioReader/ComAudioReader.h
@@ -40,7 +40,7 @@ namespace cocostudio
         ~ComAudioReader();
         
         static ComAudioReader* getInstance();
-        static void purge();
+        static void destroyInstance();
         
         flatbuffers::Offset<flatbuffers::Table> createOptionsWithFlatBuffers(const tinyxml2::XMLElement* objectData,
                                                                              flatbuffers::FlatBufferBuilder* builder);

--- a/cocos/editor-support/cocostudio/WidgetReader/ComAudioReader/ComAudioReader.h
+++ b/cocos/editor-support/cocostudio/WidgetReader/ComAudioReader/ComAudioReader.h
@@ -40,6 +40,8 @@ namespace cocostudio
         ~ComAudioReader();
         
         static ComAudioReader* getInstance();
+        /** @deprecated Use method destroyInstance() instead */
+        CC_DEPRECATED_ATTRIBUTE static void purge();
         static void destroyInstance();
         
         flatbuffers::Offset<flatbuffers::Table> createOptionsWithFlatBuffers(const tinyxml2::XMLElement* objectData,

--- a/cocos/editor-support/cocostudio/WidgetReader/GameMapReader/GameMapReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/GameMapReader/GameMapReader.cpp
@@ -61,7 +61,7 @@ namespace cocostudio
         return _instanceTMXTiledMapReader;
     }
     
-    void GameMapReader::purge()
+    void GameMapReader::destroyInstance()
     {
         CC_SAFE_DELETE(_instanceTMXTiledMapReader);
     }

--- a/cocos/editor-support/cocostudio/WidgetReader/GameMapReader/GameMapReader.h
+++ b/cocos/editor-support/cocostudio/WidgetReader/GameMapReader/GameMapReader.h
@@ -42,7 +42,7 @@ namespace cocostudio
         ~GameMapReader();
         
         static GameMapReader* getInstance();
-        static void purge();
+        static void destroyInstance();
         
         flatbuffers::Offset<flatbuffers::Table> createOptionsWithFlatBuffers(const tinyxml2::XMLElement* objectData,
                                                                              flatbuffers::FlatBufferBuilder* builder);

--- a/cocos/editor-support/cocostudio/WidgetReader/GameMapReader/GameMapReader.h
+++ b/cocos/editor-support/cocostudio/WidgetReader/GameMapReader/GameMapReader.h
@@ -42,6 +42,8 @@ namespace cocostudio
         ~GameMapReader();
         
         static GameMapReader* getInstance();
+        /** @deprecated Use method destroyInstance() instead */
+        CC_DEPRECATED_ATTRIBUTE static void purge();
         static void destroyInstance();
         
         flatbuffers::Offset<flatbuffers::Table> createOptionsWithFlatBuffers(const tinyxml2::XMLElement* objectData,

--- a/cocos/editor-support/cocostudio/WidgetReader/ImageViewReader/ImageViewReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/ImageViewReader/ImageViewReader.cpp
@@ -49,6 +49,11 @@ namespace cocostudio
         return instanceImageViewReader;
     }
     
+    void ImageViewReader::destroyInstance()
+    {
+        CC_SAFE_DELETE(instanceImageViewReader);
+    }
+    
     void ImageViewReader::setPropsFromBinary(cocos2d::ui::Widget *widget, CocoLoader *cocoLoader, stExpCocoNode *cocoNode)
     {
         WidgetReader::setPropsFromBinary(widget, cocoLoader, cocoNode);

--- a/cocos/editor-support/cocostudio/WidgetReader/ImageViewReader/ImageViewReader.h
+++ b/cocos/editor-support/cocostudio/WidgetReader/ImageViewReader/ImageViewReader.h
@@ -41,6 +41,8 @@ namespace cocostudio
         virtual ~ImageViewReader();
         
         static ImageViewReader* getInstance();
+        /** @deprecated Use method destroyInstance() instead */
+        CC_DEPRECATED_ATTRIBUTE static void purge();
         static void destroyInstance();
         
         virtual void setPropsFromJsonDictionary(cocos2d::ui::Widget* widget, const rapidjson::Value& options);

--- a/cocos/editor-support/cocostudio/WidgetReader/ImageViewReader/ImageViewReader.h
+++ b/cocos/editor-support/cocostudio/WidgetReader/ImageViewReader/ImageViewReader.h
@@ -41,7 +41,7 @@ namespace cocostudio
         virtual ~ImageViewReader();
         
         static ImageViewReader* getInstance();
-        static void purge();
+        static void destroyInstance();
         
         virtual void setPropsFromJsonDictionary(cocos2d::ui::Widget* widget, const rapidjson::Value& options);
         virtual void setPropsFromBinary(cocos2d::ui::Widget* widget, CocoLoader* cocoLoader,  stExpCocoNode*	pCocoNode);        

--- a/cocos/editor-support/cocostudio/WidgetReader/LayoutReader/LayoutReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/LayoutReader/LayoutReader.cpp
@@ -64,6 +64,11 @@ namespace cocostudio
         return instanceLayoutReader;
     }
     
+    void LayoutReader::destroyInstance()
+    {
+        CC_SAFE_DELETE(instanceLayoutReader);
+    }
+    
     void LayoutReader::setPropsFromBinary(cocos2d::ui::Widget *widget, CocoLoader *cocoLoader, stExpCocoNode *cocoNode)
     {
         WidgetReader::setPropsFromBinary(widget, cocoLoader, cocoNode);

--- a/cocos/editor-support/cocostudio/WidgetReader/LayoutReader/LayoutReader.h
+++ b/cocos/editor-support/cocostudio/WidgetReader/LayoutReader/LayoutReader.h
@@ -40,7 +40,7 @@ namespace cocostudio
         virtual ~LayoutReader();
         
         static LayoutReader* getInstance();
-        static void purge();
+        static void destroyInstance();
         
         virtual void setPropsFromJsonDictionary(cocos2d::ui::Widget* widget, const rapidjson::Value& options);
         virtual void setPropsFromBinary(cocos2d::ui::Widget* widget, CocoLoader* cocoLoader,  stExpCocoNode*	pCocoNode) ;        

--- a/cocos/editor-support/cocostudio/WidgetReader/LayoutReader/LayoutReader.h
+++ b/cocos/editor-support/cocostudio/WidgetReader/LayoutReader/LayoutReader.h
@@ -40,6 +40,8 @@ namespace cocostudio
         virtual ~LayoutReader();
         
         static LayoutReader* getInstance();
+        /** @deprecated Use method destroyInstance() instead */
+        CC_DEPRECATED_ATTRIBUTE static void purge();
         static void destroyInstance();
         
         virtual void setPropsFromJsonDictionary(cocos2d::ui::Widget* widget, const rapidjson::Value& options);

--- a/cocos/editor-support/cocostudio/WidgetReader/ListViewReader/ListViewReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/ListViewReader/ListViewReader.cpp
@@ -42,6 +42,11 @@ namespace cocostudio
         return instanceListViewReader;
     }
     
+    void ListViewReader::destroyInstance()
+    {
+        CC_SAFE_DELETE(instanceListViewReader);
+    }
+    
     void ListViewReader::setPropsFromBinary(cocos2d::ui::Widget *widget, CocoLoader *cocoLoader, stExpCocoNode* cocoNode)
     {
         ScrollViewReader::setPropsFromBinary(widget, cocoLoader, cocoNode);

--- a/cocos/editor-support/cocostudio/WidgetReader/ListViewReader/ListViewReader.h
+++ b/cocos/editor-support/cocostudio/WidgetReader/ListViewReader/ListViewReader.h
@@ -39,7 +39,7 @@ namespace cocostudio
         virtual ~ListViewReader();
         
         static ListViewReader* getInstance();
-        static void purge();
+        static void destroyInstance();
         
         virtual void setPropsFromJsonDictionary(cocos2d::ui::Widget* widget, const rapidjson::Value& options);
         virtual void setPropsFromBinary(cocos2d::ui::Widget* widget, CocoLoader* cocoLoader,  stExpCocoNode*	pCocoNode) ;        

--- a/cocos/editor-support/cocostudio/WidgetReader/ListViewReader/ListViewReader.h
+++ b/cocos/editor-support/cocostudio/WidgetReader/ListViewReader/ListViewReader.h
@@ -39,6 +39,8 @@ namespace cocostudio
         virtual ~ListViewReader();
         
         static ListViewReader* getInstance();
+        /** @deprecated Use method destroyInstance() instead */
+        CC_DEPRECATED_ATTRIBUTE static void purge();
         static void destroyInstance();
         
         virtual void setPropsFromJsonDictionary(cocos2d::ui::Widget* widget, const rapidjson::Value& options);

--- a/cocos/editor-support/cocostudio/WidgetReader/LoadingBarReader/LoadingBarReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/LoadingBarReader/LoadingBarReader.cpp
@@ -48,6 +48,11 @@ namespace cocostudio
         return instanceLoadingBar;
     }
     
+    void LoadingBarReader::destroyInstance()
+    {
+        CC_SAFE_DELETE(instanceLoadingBar);
+    }
+    
     void LoadingBarReader::setPropsFromBinary(cocos2d::ui::Widget *widget, CocoLoader *cocoLoader, stExpCocoNode *cocoNode)
     {
         WidgetReader::setPropsFromBinary(widget, cocoLoader, cocoNode);

--- a/cocos/editor-support/cocostudio/WidgetReader/LoadingBarReader/LoadingBarReader.h
+++ b/cocos/editor-support/cocostudio/WidgetReader/LoadingBarReader/LoadingBarReader.h
@@ -39,7 +39,7 @@ namespace cocostudio
         virtual ~LoadingBarReader();
         
         static LoadingBarReader* getInstance();
-        static void purge();
+        static void destroyInstance();
         
         virtual void setPropsFromJsonDictionary(cocos2d::ui::Widget* widget, const rapidjson::Value& options);
         virtual void setPropsFromBinary(cocos2d::ui::Widget* widget, CocoLoader* cocoLoader,  stExpCocoNode*	pCocoNode) ;        

--- a/cocos/editor-support/cocostudio/WidgetReader/LoadingBarReader/LoadingBarReader.h
+++ b/cocos/editor-support/cocostudio/WidgetReader/LoadingBarReader/LoadingBarReader.h
@@ -39,6 +39,8 @@ namespace cocostudio
         virtual ~LoadingBarReader();
         
         static LoadingBarReader* getInstance();
+        /** @deprecated Use method destroyInstance() instead */
+        CC_DEPRECATED_ATTRIBUTE static void purge();
         static void destroyInstance();
         
         virtual void setPropsFromJsonDictionary(cocos2d::ui::Widget* widget, const rapidjson::Value& options);

--- a/cocos/editor-support/cocostudio/WidgetReader/Node3DReader/Node3DReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/Node3DReader/Node3DReader.cpp
@@ -62,7 +62,7 @@ namespace cocostudio
         return _instanceNode3DReader;
     }
     
-    void Node3DReader::purge()
+    void Node3DReader::destroyInstance()
     {
         CC_SAFE_DELETE(_instanceNode3DReader);
     }

--- a/cocos/editor-support/cocostudio/WidgetReader/Node3DReader/Node3DReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/Node3DReader/Node3DReader.cpp
@@ -62,6 +62,11 @@ namespace cocostudio
         return _instanceNode3DReader;
     }
     
+    void Node3DReader::purge()
+    {
+        CC_SAFE_DELETE(_instanceNode3DReader);
+    }
+    
     void Node3DReader::destroyInstance()
     {
         CC_SAFE_DELETE(_instanceNode3DReader);

--- a/cocos/editor-support/cocostudio/WidgetReader/Node3DReader/Node3DReader.h
+++ b/cocos/editor-support/cocostudio/WidgetReader/Node3DReader/Node3DReader.h
@@ -46,6 +46,8 @@ namespace cocostudio
         ~Node3DReader();
         
         static Node3DReader* getInstance();
+        /** @deprecated Use method destroyInstance() instead */
+        CC_DEPRECATED_ATTRIBUTE static void purge();
         static void destroyInstance();
         
         flatbuffers::Offset<flatbuffers::Table> createOptionsWithFlatBuffers(const tinyxml2::XMLElement* objectData,

--- a/cocos/editor-support/cocostudio/WidgetReader/Node3DReader/Node3DReader.h
+++ b/cocos/editor-support/cocostudio/WidgetReader/Node3DReader/Node3DReader.h
@@ -46,7 +46,7 @@ namespace cocostudio
         ~Node3DReader();
         
         static Node3DReader* getInstance();
-        static void purge();
+        static void destroyInstance();
         
         flatbuffers::Offset<flatbuffers::Table> createOptionsWithFlatBuffers(const tinyxml2::XMLElement* objectData,
                                                                              flatbuffers::FlatBufferBuilder* builder);

--- a/cocos/editor-support/cocostudio/WidgetReader/NodeReader/NodeReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/NodeReader/NodeReader.cpp
@@ -79,7 +79,7 @@ namespace cocostudio
         return _instanceNodeReader;
     }
     
-    void NodeReader::purge()
+    void NodeReader::destroyInstance()
     {
         CC_SAFE_DELETE(_instanceNodeReader);
     }

--- a/cocos/editor-support/cocostudio/WidgetReader/NodeReader/NodeReader.h
+++ b/cocos/editor-support/cocostudio/WidgetReader/NodeReader/NodeReader.h
@@ -41,6 +41,8 @@ namespace cocostudio
         ~NodeReader();
         
         static NodeReader* getInstance();
+        /** @deprecated Use method destroyInstance() instead */
+        CC_DEPRECATED_ATTRIBUTE static void purge();
         static void destroyInstance();
         
         flatbuffers::Offset<flatbuffers::Table> createOptionsWithFlatBuffers(const tinyxml2::XMLElement* objectData,

--- a/cocos/editor-support/cocostudio/WidgetReader/NodeReader/NodeReader.h
+++ b/cocos/editor-support/cocostudio/WidgetReader/NodeReader/NodeReader.h
@@ -41,7 +41,7 @@ namespace cocostudio
         ~NodeReader();
         
         static NodeReader* getInstance();
-        static void purge();
+        static void destroyInstance();
         
         flatbuffers::Offset<flatbuffers::Table> createOptionsWithFlatBuffers(const tinyxml2::XMLElement* objectData,
                                                                              flatbuffers::FlatBufferBuilder* builder);

--- a/cocos/editor-support/cocostudio/WidgetReader/PageViewReader/PageViewReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/PageViewReader/PageViewReader.cpp
@@ -40,6 +40,11 @@ namespace cocostudio
         return instancePageViewReader;
     }
     
+    void PageViewReader::destroyInstance()
+    {
+        CC_SAFE_DELETE(instancePageViewReader);
+    }
+    
     void PageViewReader::setPropsFromBinary(cocos2d::ui::Widget *widget, CocoLoader *cocoLoader, stExpCocoNode *cocoNode)
 	{
 		LayoutReader::setPropsFromBinary(widget, cocoLoader, cocoNode);

--- a/cocos/editor-support/cocostudio/WidgetReader/PageViewReader/PageViewReader.h
+++ b/cocos/editor-support/cocostudio/WidgetReader/PageViewReader/PageViewReader.h
@@ -39,7 +39,7 @@ namespace cocostudio
         virtual ~PageViewReader();
         
         static PageViewReader* getInstance();
-        static void purge();
+        static void destroyInstance();
         
         virtual void setPropsFromJsonDictionary(cocos2d::ui::Widget* widget, const rapidjson::Value& options);
         virtual void setPropsFromBinary(cocos2d::ui::Widget* widget, CocoLoader* cocoLoader,  stExpCocoNode* cocoNode) ;        

--- a/cocos/editor-support/cocostudio/WidgetReader/PageViewReader/PageViewReader.h
+++ b/cocos/editor-support/cocostudio/WidgetReader/PageViewReader/PageViewReader.h
@@ -39,6 +39,8 @@ namespace cocostudio
         virtual ~PageViewReader();
         
         static PageViewReader* getInstance();
+        /** @deprecated Use method destroyInstance() instead */
+        CC_DEPRECATED_ATTRIBUTE static void purge();
         static void destroyInstance();
         
         virtual void setPropsFromJsonDictionary(cocos2d::ui::Widget* widget, const rapidjson::Value& options);

--- a/cocos/editor-support/cocostudio/WidgetReader/Particle3DReader/Particle3DReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/Particle3DReader/Particle3DReader.cpp
@@ -63,6 +63,11 @@ namespace cocostudio
         return _instanceParticle3DReader;
     }
     
+    void Particle3DReader::purge()
+    {
+        CC_SAFE_DELETE(_instanceParticle3DReader);
+    }
+    
     void Particle3DReader::destroyInstance()
     {
         CC_SAFE_DELETE(_instanceParticle3DReader);

--- a/cocos/editor-support/cocostudio/WidgetReader/Particle3DReader/Particle3DReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/Particle3DReader/Particle3DReader.cpp
@@ -63,7 +63,7 @@ namespace cocostudio
         return _instanceParticle3DReader;
     }
     
-    void Particle3DReader::purge()
+    void Particle3DReader::destroyInstance()
     {
         CC_SAFE_DELETE(_instanceParticle3DReader);
     }

--- a/cocos/editor-support/cocostudio/WidgetReader/Particle3DReader/Particle3DReader.h
+++ b/cocos/editor-support/cocostudio/WidgetReader/Particle3DReader/Particle3DReader.h
@@ -41,6 +41,8 @@ namespace cocostudio
         ~Particle3DReader();
         
         static Particle3DReader* getInstance();
+        /** @deprecated Use method destroyInstance() instead */
+        CC_DEPRECATED_ATTRIBUTE static void purge();
         static void destroyInstance();
         
         flatbuffers::Offset<flatbuffers::Table> createOptionsWithFlatBuffers(const tinyxml2::XMLElement* objectData,

--- a/cocos/editor-support/cocostudio/WidgetReader/Particle3DReader/Particle3DReader.h
+++ b/cocos/editor-support/cocostudio/WidgetReader/Particle3DReader/Particle3DReader.h
@@ -41,7 +41,7 @@ namespace cocostudio
         ~Particle3DReader();
         
         static Particle3DReader* getInstance();
-        static void purge();
+        static void destroyInstance();
         
         flatbuffers::Offset<flatbuffers::Table> createOptionsWithFlatBuffers(const tinyxml2::XMLElement* objectData,
                                                                              flatbuffers::FlatBufferBuilder* builder);

--- a/cocos/editor-support/cocostudio/WidgetReader/ParticleReader/ParticleReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/ParticleReader/ParticleReader.cpp
@@ -59,6 +59,11 @@ namespace cocostudio
         return _instanceParticleReader;
     }
     
+    void ParticleReader::purge()
+    {
+        CC_SAFE_DELETE(_instanceParticleReader);
+    }
+    
     void ParticleReader::destroyInstance()
     {
         CC_SAFE_DELETE(_instanceParticleReader);

--- a/cocos/editor-support/cocostudio/WidgetReader/ParticleReader/ParticleReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/ParticleReader/ParticleReader.cpp
@@ -59,7 +59,7 @@ namespace cocostudio
         return _instanceParticleReader;
     }
     
-    void ParticleReader::purge()
+    void ParticleReader::destroyInstance()
     {
         CC_SAFE_DELETE(_instanceParticleReader);
     }

--- a/cocos/editor-support/cocostudio/WidgetReader/ParticleReader/ParticleReader.h
+++ b/cocos/editor-support/cocostudio/WidgetReader/ParticleReader/ParticleReader.h
@@ -42,7 +42,7 @@ namespace cocostudio
         ~ParticleReader();
         
         static ParticleReader* getInstance();
-        static void purge();
+        static void destroyInstance();
         
         flatbuffers::Offset<flatbuffers::Table> createOptionsWithFlatBuffers(const tinyxml2::XMLElement* objectData,
                                                                              flatbuffers::FlatBufferBuilder* builder);

--- a/cocos/editor-support/cocostudio/WidgetReader/ParticleReader/ParticleReader.h
+++ b/cocos/editor-support/cocostudio/WidgetReader/ParticleReader/ParticleReader.h
@@ -42,6 +42,8 @@ namespace cocostudio
         ~ParticleReader();
         
         static ParticleReader* getInstance();
+        /** @deprecated Use method destroyInstance() instead */
+        CC_DEPRECATED_ATTRIBUTE static void purge();
         static void destroyInstance();
         
         flatbuffers::Offset<flatbuffers::Table> createOptionsWithFlatBuffers(const tinyxml2::XMLElement* objectData,

--- a/cocos/editor-support/cocostudio/WidgetReader/ProjectNodeReader/ProjectNodeReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/ProjectNodeReader/ProjectNodeReader.cpp
@@ -57,6 +57,11 @@ namespace cocostudio
         return _instanceProjectNodeReader;
     }
     
+    void ProjectNodeReader::purge()
+    {
+        CC_SAFE_DELETE(_instanceProjectNodeReader);
+    }
+    
     void ProjectNodeReader::destroyInstance()
     {
         CC_SAFE_DELETE(_instanceProjectNodeReader);

--- a/cocos/editor-support/cocostudio/WidgetReader/ProjectNodeReader/ProjectNodeReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/ProjectNodeReader/ProjectNodeReader.cpp
@@ -57,7 +57,7 @@ namespace cocostudio
         return _instanceProjectNodeReader;
     }
     
-    void ProjectNodeReader::purge()
+    void ProjectNodeReader::destroyInstance()
     {
         CC_SAFE_DELETE(_instanceProjectNodeReader);
     }

--- a/cocos/editor-support/cocostudio/WidgetReader/ProjectNodeReader/ProjectNodeReader.h
+++ b/cocos/editor-support/cocostudio/WidgetReader/ProjectNodeReader/ProjectNodeReader.h
@@ -40,6 +40,8 @@ namespace cocostudio
         ~ProjectNodeReader();
         
         static ProjectNodeReader* getInstance();
+        /** @deprecated Use method destroyInstance() instead */
+        CC_DEPRECATED_ATTRIBUTE static void purge();
         static void destroyInstance();
         
         flatbuffers::Offset<flatbuffers::Table> createOptionsWithFlatBuffers(const tinyxml2::XMLElement* objectData,

--- a/cocos/editor-support/cocostudio/WidgetReader/ProjectNodeReader/ProjectNodeReader.h
+++ b/cocos/editor-support/cocostudio/WidgetReader/ProjectNodeReader/ProjectNodeReader.h
@@ -40,7 +40,7 @@ namespace cocostudio
         ~ProjectNodeReader();
         
         static ProjectNodeReader* getInstance();
-        static void purge();
+        static void destroyInstance();
         
         flatbuffers::Offset<flatbuffers::Table> createOptionsWithFlatBuffers(const tinyxml2::XMLElement* objectData,
                                                                              flatbuffers::FlatBufferBuilder* builder);

--- a/cocos/editor-support/cocostudio/WidgetReader/ScrollViewReader/ScrollViewReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/ScrollViewReader/ScrollViewReader.cpp
@@ -44,6 +44,11 @@ namespace cocostudio
         return instanceScrollViewReader;
     }
     
+    void ScrollViewReader::destroyInstance()
+    {
+        CC_SAFE_DELETE(instanceScrollViewReader);
+    }
+    
     void ScrollViewReader::setPropsFromBinary(cocos2d::ui::Widget *widget, CocoLoader *cocoLoader, stExpCocoNode* cocoNode)
     {
         //TODO: need to refactor...

--- a/cocos/editor-support/cocostudio/WidgetReader/ScrollViewReader/ScrollViewReader.h
+++ b/cocos/editor-support/cocostudio/WidgetReader/ScrollViewReader/ScrollViewReader.h
@@ -39,6 +39,8 @@ namespace cocostudio
         virtual ~ScrollViewReader();
         
         static ScrollViewReader* getInstance();
+        /** @deprecated Use method destroyInstance() instead */
+        CC_DEPRECATED_ATTRIBUTE static void purge();
         static void destroyInstance();
         
         virtual void setPropsFromJsonDictionary(cocos2d::ui::Widget* widget, const rapidjson::Value& options);

--- a/cocos/editor-support/cocostudio/WidgetReader/ScrollViewReader/ScrollViewReader.h
+++ b/cocos/editor-support/cocostudio/WidgetReader/ScrollViewReader/ScrollViewReader.h
@@ -39,7 +39,7 @@ namespace cocostudio
         virtual ~ScrollViewReader();
         
         static ScrollViewReader* getInstance();
-        static void purge();
+        static void destroyInstance();
         
         virtual void setPropsFromJsonDictionary(cocos2d::ui::Widget* widget, const rapidjson::Value& options);
         virtual void setPropsFromBinary(cocos2d::ui::Widget* widget, CocoLoader* cocoLoader,  stExpCocoNode*	pCocoNode) ;        

--- a/cocos/editor-support/cocostudio/WidgetReader/SingleNodeReader/SingleNodeReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/SingleNodeReader/SingleNodeReader.cpp
@@ -62,7 +62,7 @@ namespace cocostudio
         return _instanceSingleNodeReader;
     }
     
-    void SingleNodeReader::purge()
+    void SingleNodeReader::destroyInstance()
     {
         CC_SAFE_DELETE(_instanceSingleNodeReader);
     }

--- a/cocos/editor-support/cocostudio/WidgetReader/SingleNodeReader/SingleNodeReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/SingleNodeReader/SingleNodeReader.cpp
@@ -62,6 +62,11 @@ namespace cocostudio
         return _instanceSingleNodeReader;
     }
     
+    void SingleNodeReader::purge()
+    {
+        CC_SAFE_DELETE(_instanceSingleNodeReader);
+    }
+    
     void SingleNodeReader::destroyInstance()
     {
         CC_SAFE_DELETE(_instanceSingleNodeReader);

--- a/cocos/editor-support/cocostudio/WidgetReader/SingleNodeReader/SingleNodeReader.h
+++ b/cocos/editor-support/cocostudio/WidgetReader/SingleNodeReader/SingleNodeReader.h
@@ -42,6 +42,8 @@ namespace cocostudio
         ~SingleNodeReader();
         
         static SingleNodeReader* getInstance();
+        /** @deprecated Use method destroyInstance() instead */
+        CC_DEPRECATED_ATTRIBUTE static void purge();
         static void destroyInstance();
         
         flatbuffers::Offset<flatbuffers::Table> createOptionsWithFlatBuffers(const tinyxml2::XMLElement* objectData,

--- a/cocos/editor-support/cocostudio/WidgetReader/SingleNodeReader/SingleNodeReader.h
+++ b/cocos/editor-support/cocostudio/WidgetReader/SingleNodeReader/SingleNodeReader.h
@@ -42,7 +42,7 @@ namespace cocostudio
         ~SingleNodeReader();
         
         static SingleNodeReader* getInstance();
-        static void purge();
+        static void destroyInstance();
         
         flatbuffers::Offset<flatbuffers::Table> createOptionsWithFlatBuffers(const tinyxml2::XMLElement* objectData,
                                                                              flatbuffers::FlatBufferBuilder* builder);

--- a/cocos/editor-support/cocostudio/WidgetReader/SliderReader/SliderReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/SliderReader/SliderReader.cpp
@@ -48,6 +48,11 @@ namespace cocostudio
         return instanceSliderReader;
     }
     
+    void SliderReader::destroyInstance()
+    {
+        CC_SAFE_DELETE(instanceSliderReader);
+    }
+    
     void SliderReader::setPropsFromBinary(cocos2d::ui::Widget *widget, CocoLoader *cocoLoader, stExpCocoNode* cocoNode)
     {
         this->beginSetBasicProperties(widget);

--- a/cocos/editor-support/cocostudio/WidgetReader/SliderReader/SliderReader.h
+++ b/cocos/editor-support/cocostudio/WidgetReader/SliderReader/SliderReader.h
@@ -39,6 +39,8 @@ namespace cocostudio
         virtual ~SliderReader();
         
         static SliderReader* getInstance();
+        /** @deprecated Use method destroyInstance() instead */
+        CC_DEPRECATED_ATTRIBUTE static void purge();
         static void destroyInstance();
         
         virtual void setPropsFromJsonDictionary(cocos2d::ui::Widget* widget, const rapidjson::Value& options);

--- a/cocos/editor-support/cocostudio/WidgetReader/SliderReader/SliderReader.h
+++ b/cocos/editor-support/cocostudio/WidgetReader/SliderReader/SliderReader.h
@@ -39,7 +39,7 @@ namespace cocostudio
         virtual ~SliderReader();
         
         static SliderReader* getInstance();
-        static void purge();
+        static void destroyInstance();
         
         virtual void setPropsFromJsonDictionary(cocos2d::ui::Widget* widget, const rapidjson::Value& options);
         virtual void setPropsFromBinary(cocos2d::ui::Widget* widget, CocoLoader* cocoLoader,  stExpCocoNode*	pCocoNode) ;        

--- a/cocos/editor-support/cocostudio/WidgetReader/Sprite3DReader/Sprite3DReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/Sprite3DReader/Sprite3DReader.cpp
@@ -62,6 +62,11 @@ namespace cocostudio
         return _instanceSprite3DReader;
     }
     
+    void Sprite3DReader::purge()
+    {
+        CC_SAFE_DELETE(_instanceSprite3DReader);
+    }
+    
     void Sprite3DReader::destroyInstance()
     {
         CC_SAFE_DELETE(_instanceSprite3DReader);

--- a/cocos/editor-support/cocostudio/WidgetReader/Sprite3DReader/Sprite3DReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/Sprite3DReader/Sprite3DReader.cpp
@@ -62,7 +62,7 @@ namespace cocostudio
         return _instanceSprite3DReader;
     }
     
-    void Sprite3DReader::purge()
+    void Sprite3DReader::destroyInstance()
     {
         CC_SAFE_DELETE(_instanceSprite3DReader);
     }

--- a/cocos/editor-support/cocostudio/WidgetReader/Sprite3DReader/Sprite3DReader.h
+++ b/cocos/editor-support/cocostudio/WidgetReader/Sprite3DReader/Sprite3DReader.h
@@ -46,6 +46,8 @@ namespace cocostudio
         ~Sprite3DReader();
         
         static Sprite3DReader* getInstance();
+        /** @deprecated Use method destroyInstance() instead */
+        CC_DEPRECATED_ATTRIBUTE static void purge();
         static void destroyInstance();
         
         flatbuffers::Offset<flatbuffers::Table> createOptionsWithFlatBuffers(const tinyxml2::XMLElement* objectData,

--- a/cocos/editor-support/cocostudio/WidgetReader/Sprite3DReader/Sprite3DReader.h
+++ b/cocos/editor-support/cocostudio/WidgetReader/Sprite3DReader/Sprite3DReader.h
@@ -46,7 +46,7 @@ namespace cocostudio
         ~Sprite3DReader();
         
         static Sprite3DReader* getInstance();
-        static void purge();
+        static void destroyInstance();
         
         flatbuffers::Offset<flatbuffers::Table> createOptionsWithFlatBuffers(const tinyxml2::XMLElement* objectData,
                                                                              flatbuffers::FlatBufferBuilder* builder);

--- a/cocos/editor-support/cocostudio/WidgetReader/SpriteReader/SpriteReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/SpriteReader/SpriteReader.cpp
@@ -60,6 +60,11 @@ namespace cocostudio
         return _instanceSpriteReader;
     }
     
+    void SpriteReader::purge()
+    {
+        CC_SAFE_DELETE(_instanceSpriteReader);
+    }
+    
     void SpriteReader::destroyInstance()
     {
         CC_SAFE_DELETE(_instanceSpriteReader);

--- a/cocos/editor-support/cocostudio/WidgetReader/SpriteReader/SpriteReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/SpriteReader/SpriteReader.cpp
@@ -60,7 +60,7 @@ namespace cocostudio
         return _instanceSpriteReader;
     }
     
-    void SpriteReader::purge()
+    void SpriteReader::destroyInstance()
     {
         CC_SAFE_DELETE(_instanceSpriteReader);
     }

--- a/cocos/editor-support/cocostudio/WidgetReader/SpriteReader/SpriteReader.h
+++ b/cocos/editor-support/cocostudio/WidgetReader/SpriteReader/SpriteReader.h
@@ -42,6 +42,8 @@ namespace cocostudio
         ~SpriteReader();
         
         static SpriteReader* getInstance();
+        /** @deprecated Use method destroyInstance() instead */
+        CC_DEPRECATED_ATTRIBUTE static void purge();
         static void destroyInstance();
         
         flatbuffers::Offset<flatbuffers::Table> createOptionsWithFlatBuffers(const tinyxml2::XMLElement* objectData,

--- a/cocos/editor-support/cocostudio/WidgetReader/SpriteReader/SpriteReader.h
+++ b/cocos/editor-support/cocostudio/WidgetReader/SpriteReader/SpriteReader.h
@@ -42,7 +42,7 @@ namespace cocostudio
         ~SpriteReader();
         
         static SpriteReader* getInstance();
-        static void purge();
+        static void destroyInstance();
         
         flatbuffers::Offset<flatbuffers::Table> createOptionsWithFlatBuffers(const tinyxml2::XMLElement* objectData,
                                                                              flatbuffers::FlatBufferBuilder* builder);

--- a/cocos/editor-support/cocostudio/WidgetReader/TextAtlasReader/TextAtlasReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/TextAtlasReader/TextAtlasReader.cpp
@@ -45,6 +45,11 @@ namespace cocostudio
         return instanceTextAtalsReader;
     }
     
+    void TextAtlasReader::destroyInstance()
+    {
+        CC_SAFE_DELETE(instanceTextAtalsReader);
+    }
+    
     void TextAtlasReader::setPropsFromBinary(cocos2d::ui::Widget *widget, CocoLoader *cocoLoader, stExpCocoNode *cocoNode)
     {
         this->beginSetBasicProperties(widget);

--- a/cocos/editor-support/cocostudio/WidgetReader/TextAtlasReader/TextAtlasReader.h
+++ b/cocos/editor-support/cocostudio/WidgetReader/TextAtlasReader/TextAtlasReader.h
@@ -39,6 +39,8 @@ namespace cocostudio
         virtual ~TextAtlasReader();
         
         static TextAtlasReader* getInstance();
+        /** @deprecated Use method destroyInstance() instead */
+        CC_DEPRECATED_ATTRIBUTE static void purge();
         static void destroyInstance();
         
         virtual void setPropsFromJsonDictionary(cocos2d::ui::Widget* widget, const rapidjson::Value& options);

--- a/cocos/editor-support/cocostudio/WidgetReader/TextAtlasReader/TextAtlasReader.h
+++ b/cocos/editor-support/cocostudio/WidgetReader/TextAtlasReader/TextAtlasReader.h
@@ -39,6 +39,7 @@ namespace cocostudio
         virtual ~TextAtlasReader();
         
         static TextAtlasReader* getInstance();
+        static void destroyInstance();
         
         virtual void setPropsFromJsonDictionary(cocos2d::ui::Widget* widget, const rapidjson::Value& options);
         virtual void setPropsFromBinary(cocos2d::ui::Widget* widget, CocoLoader* cocoLoader,  stExpCocoNode*	pCocoNode) ;

--- a/cocos/editor-support/cocostudio/WidgetReader/TextBMFontReader/TextBMFontReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/TextBMFontReader/TextBMFontReader.cpp
@@ -42,6 +42,11 @@ namespace cocostudio
         return instanceTextBMFontReader;
     }
     
+    void TextBMFontReader::destroyInstance()
+    {
+        CC_SAFE_DELETE(instanceTextBMFontReader);
+    }
+    
     void TextBMFontReader::setPropsFromBinary(cocos2d::ui::Widget *widget, CocoLoader *cocoLoader, stExpCocoNode *cocoNode)
     {
         this->beginSetBasicProperties(widget);

--- a/cocos/editor-support/cocostudio/WidgetReader/TextBMFontReader/TextBMFontReader.h
+++ b/cocos/editor-support/cocostudio/WidgetReader/TextBMFontReader/TextBMFontReader.h
@@ -39,7 +39,7 @@ namespace cocostudio
         virtual ~TextBMFontReader();
         
         static TextBMFontReader* getInstance();
-        static void purge();
+        static void destroyInstance();
         
         virtual void setPropsFromJsonDictionary(cocos2d::ui::Widget* widget, const rapidjson::Value& options);
         virtual void setPropsFromBinary(cocos2d::ui::Widget* widget, CocoLoader* cocoLoader,  stExpCocoNode*	pCocoNode) ;

--- a/cocos/editor-support/cocostudio/WidgetReader/TextBMFontReader/TextBMFontReader.h
+++ b/cocos/editor-support/cocostudio/WidgetReader/TextBMFontReader/TextBMFontReader.h
@@ -39,6 +39,8 @@ namespace cocostudio
         virtual ~TextBMFontReader();
         
         static TextBMFontReader* getInstance();
+        /** @deprecated Use method destroyInstance() instead */
+        CC_DEPRECATED_ATTRIBUTE static void purge();
         static void destroyInstance();
         
         virtual void setPropsFromJsonDictionary(cocos2d::ui::Widget* widget, const rapidjson::Value& options);

--- a/cocos/editor-support/cocostudio/WidgetReader/TextFieldReader/TextFieldReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/TextFieldReader/TextFieldReader.cpp
@@ -49,6 +49,11 @@ namespace cocostudio
         return instanceTextFieldReader;
     }
     
+    void TextFieldReader::destroyInstance()
+    {
+        CC_SAFE_DELETE(instanceTextFieldReader);
+    }
+    
     void TextFieldReader::setPropsFromBinary(cocos2d::ui::Widget *widget, CocoLoader *cocoLoader, stExpCocoNode* cocoNode)
     {
         this->beginSetBasicProperties(widget);

--- a/cocos/editor-support/cocostudio/WidgetReader/TextFieldReader/TextFieldReader.h
+++ b/cocos/editor-support/cocostudio/WidgetReader/TextFieldReader/TextFieldReader.h
@@ -39,7 +39,7 @@ namespace cocostudio
         virtual ~TextFieldReader();
         
         static TextFieldReader* getInstance();
-        static void purge();
+        static void destroyInstance();
         
         virtual void setPropsFromJsonDictionary(cocos2d::ui::Widget* widget, const rapidjson::Value& options);
         virtual void setPropsFromBinary(cocos2d::ui::Widget* widget, CocoLoader* cocoLoader,  stExpCocoNode*	pCocoNode) ;        

--- a/cocos/editor-support/cocostudio/WidgetReader/TextFieldReader/TextFieldReader.h
+++ b/cocos/editor-support/cocostudio/WidgetReader/TextFieldReader/TextFieldReader.h
@@ -39,6 +39,8 @@ namespace cocostudio
         virtual ~TextFieldReader();
         
         static TextFieldReader* getInstance();
+        /** @deprecated Use method destroyInstance() instead */
+        CC_DEPRECATED_ATTRIBUTE static void purge();
         static void destroyInstance();
         
         virtual void setPropsFromJsonDictionary(cocos2d::ui::Widget* widget, const rapidjson::Value& options);

--- a/cocos/editor-support/cocostudio/WidgetReader/TextReader/TextReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/TextReader/TextReader.cpp
@@ -47,6 +47,11 @@ namespace cocostudio
         return instanceTextReader;
     }
     
+    void TextReader::destroyInstance()
+    {
+        CC_SAFE_DELETE(instanceTextReader);
+    }
+    
     void TextReader::setPropsFromBinary(cocos2d::ui::Widget *widget, CocoLoader *cocoLoader, stExpCocoNode *cocoNode)
     {
         this->beginSetBasicProperties(widget);

--- a/cocos/editor-support/cocostudio/WidgetReader/TextReader/TextReader.h
+++ b/cocos/editor-support/cocostudio/WidgetReader/TextReader/TextReader.h
@@ -39,6 +39,8 @@ namespace cocostudio
         virtual ~TextReader();
         
         static TextReader* getInstance();
+        /** @deprecated Use method destroyInstance() instead */
+        CC_DEPRECATED_ATTRIBUTE static void purge();
         static void destroyInstance();
         
         virtual void setPropsFromJsonDictionary(cocos2d::ui::Widget* widget, const rapidjson::Value& options);

--- a/cocos/editor-support/cocostudio/WidgetReader/TextReader/TextReader.h
+++ b/cocos/editor-support/cocostudio/WidgetReader/TextReader/TextReader.h
@@ -39,7 +39,7 @@ namespace cocostudio
         virtual ~TextReader();
         
         static TextReader* getInstance();
-        static void purge();
+        static void destroyInstance();
         
         virtual void setPropsFromJsonDictionary(cocos2d::ui::Widget* widget, const rapidjson::Value& options);
         virtual void setPropsFromBinary(cocos2d::ui::Widget* widget, CocoLoader* cocoLoader,  stExpCocoNode*	pCocoNode);        

--- a/cocos/editor-support/cocostudio/WidgetReader/UserCameraReader/UserCameraReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/UserCameraReader/UserCameraReader.cpp
@@ -61,6 +61,11 @@ namespace cocostudio
         return _instanceUserCameraReader;
     }
     
+    void UserCameraReader::purge()
+    {
+        CC_SAFE_DELETE(_instanceUserCameraReader);
+    }
+    
     void UserCameraReader::destroyInstance()
     {
         CC_SAFE_DELETE(_instanceUserCameraReader);

--- a/cocos/editor-support/cocostudio/WidgetReader/UserCameraReader/UserCameraReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/UserCameraReader/UserCameraReader.cpp
@@ -61,7 +61,7 @@ namespace cocostudio
         return _instanceUserCameraReader;
     }
     
-    void UserCameraReader::purge()
+    void UserCameraReader::destroyInstance()
     {
         CC_SAFE_DELETE(_instanceUserCameraReader);
     }

--- a/cocos/editor-support/cocostudio/WidgetReader/UserCameraReader/UserCameraReader.h
+++ b/cocos/editor-support/cocostudio/WidgetReader/UserCameraReader/UserCameraReader.h
@@ -46,6 +46,8 @@ namespace cocostudio
         ~UserCameraReader();
         
         static UserCameraReader* getInstance();
+        /** @deprecated Use method destroyInstance() instead */
+        CC_DEPRECATED_ATTRIBUTE static void purge();
         static void destroyInstance();
         
         flatbuffers::Offset<flatbuffers::Table> createOptionsWithFlatBuffers(const tinyxml2::XMLElement* objectData,

--- a/cocos/editor-support/cocostudio/WidgetReader/UserCameraReader/UserCameraReader.h
+++ b/cocos/editor-support/cocostudio/WidgetReader/UserCameraReader/UserCameraReader.h
@@ -46,7 +46,7 @@ namespace cocostudio
         ~UserCameraReader();
         
         static UserCameraReader* getInstance();
-        static void purge();
+        static void destroyInstance();
         
         flatbuffers::Offset<flatbuffers::Table> createOptionsWithFlatBuffers(const tinyxml2::XMLElement* objectData,
                                                                              flatbuffers::FlatBufferBuilder* builder);

--- a/cocos/editor-support/cocostudio/WidgetReader/WidgetReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/WidgetReader.cpp
@@ -134,6 +134,11 @@ namespace cocostudio
         return instanceWidgetReader;
     }
     
+    void WidgetReader::purge()
+    {
+        CC_SAFE_DELETE(instanceWidgetReader);
+    }
+    
     void WidgetReader::destroyInstance()
     {
         CC_SAFE_DELETE(instanceWidgetReader);

--- a/cocos/editor-support/cocostudio/WidgetReader/WidgetReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/WidgetReader.cpp
@@ -134,7 +134,7 @@ namespace cocostudio
         return instanceWidgetReader;
     }
     
-    void WidgetReader::purge()
+    void WidgetReader::destroyInstance()
     {
         CC_SAFE_DELETE(instanceWidgetReader);
     }

--- a/cocos/editor-support/cocostudio/WidgetReader/WidgetReader.h
+++ b/cocos/editor-support/cocostudio/WidgetReader/WidgetReader.h
@@ -46,6 +46,8 @@ namespace cocostudio
         virtual ~WidgetReader();
         
         static WidgetReader* getInstance();
+        /** @deprecated Use method destroyInstance() instead */
+        CC_DEPRECATED_ATTRIBUTE static void purge();
         static void destroyInstance();
         
         virtual void setPropsFromJsonDictionary(cocos2d::ui::Widget* widget,

--- a/cocos/editor-support/cocostudio/WidgetReader/WidgetReader.h
+++ b/cocos/editor-support/cocostudio/WidgetReader/WidgetReader.h
@@ -46,7 +46,7 @@ namespace cocostudio
         virtual ~WidgetReader();
         
         static WidgetReader* getInstance();
-        static void purge();
+        static void destroyInstance();
         
         virtual void setPropsFromJsonDictionary(cocos2d::ui::Widget* widget,
                                                 const rapidjson::Value& options);

--- a/tests/cpp-tests/Classes/CocosStudio3DTest/CocosStudio3DTest.cpp
+++ b/tests/cpp-tests/Classes/CocosStudio3DTest/CocosStudio3DTest.cpp
@@ -104,7 +104,7 @@ void CocosStudio3DTestDemo::onEnter()
 
 void CocosStudio3DTestDemo::onExit()
 {
-    CSLoader::destroyCocosStudio();
+    cocostudio::destroyCocosStudio();
     
     BaseTest::onExit();
 }

--- a/tests/cpp-tests/Classes/CocosStudio3DTest/CocosStudio3DTest.cpp
+++ b/tests/cpp-tests/Classes/CocosStudio3DTest/CocosStudio3DTest.cpp
@@ -102,6 +102,13 @@ void CocosStudio3DTestDemo::onEnter()
     BaseTest::onEnter();
 }
 
+void CocosStudio3DTestDemo::onExit()
+{
+    CSLoader::destroyCocosStudio();
+    
+    BaseTest::onExit();
+}
+
 void CocosStudio3DTestDemo::restartCallback(Ref* sender)
 {
     auto s = new (std::nothrow) CS3DTestScene();

--- a/tests/cpp-tests/Classes/CocosStudio3DTest/CocosStudio3DTest.h
+++ b/tests/cpp-tests/Classes/CocosStudio3DTest/CocosStudio3DTest.h
@@ -47,6 +47,7 @@ public:
     virtual std::string title() const override;
     virtual std::string subtitle() const override;
     virtual void onEnter() override;
+    virtual void onExit() override;
 };
 
 class CSNode3DTest : public CocosStudio3DTestDemo

--- a/tests/cpp-tests/Classes/ExtensionsTest/CocoStudioActionTimelineTest/ActionTimelineTestScene.cpp
+++ b/tests/cpp-tests/Classes/ExtensionsTest/CocoStudioActionTimelineTest/ActionTimelineTestScene.cpp
@@ -165,7 +165,7 @@ void ActionTimelineTestLayer::onExit()
 
     backItem = restartItem = nextItem = nullptr;
     
-    CSLoader::destroyCocosStudio();
+    cocostudio::destroyCocosStudio();
 
     Layer::onExit();
 }

--- a/tests/cpp-tests/Classes/ExtensionsTest/CocoStudioActionTimelineTest/ActionTimelineTestScene.cpp
+++ b/tests/cpp-tests/Classes/ExtensionsTest/CocoStudioActionTimelineTest/ActionTimelineTestScene.cpp
@@ -164,9 +164,8 @@ void ActionTimelineTestLayer::onExit()
     removeAllChildren();
 
     backItem = restartItem = nextItem = nullptr;
-
-    ActionTimelineCache::getInstance()->purge();
-    CSLoader::getInstance()->purge();
+    
+    CSLoader::destroyCocosStudio();
 
     Layer::onExit();
 }

--- a/tests/cpp-tests/Classes/ExtensionsTest/CocoStudioArmatureTest/ArmatureScene.cpp
+++ b/tests/cpp-tests/Classes/ExtensionsTest/CocoStudioArmatureTest/ArmatureScene.cpp
@@ -199,6 +199,8 @@ void ArmatureTestLayer::onExit()
     removeAllChildren();
 
     backItem = restartItem = nextItem = nullptr;
+    
+    CSLoader::destroyCocosStudio();
 
     Layer::onExit();
 }

--- a/tests/cpp-tests/Classes/ExtensionsTest/CocoStudioArmatureTest/ArmatureScene.cpp
+++ b/tests/cpp-tests/Classes/ExtensionsTest/CocoStudioArmatureTest/ArmatureScene.cpp
@@ -200,7 +200,7 @@ void ArmatureTestLayer::onExit()
 
     backItem = restartItem = nextItem = nullptr;
     
-    CSLoader::destroyCocosStudio();
+    cocostudio::destroyCocosStudio();
 
     Layer::onExit();
 }

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/CustomTest/CustomWidgetCallbackBindTest/CustomWidgetCallbackBindTest.cpp
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/CustomTest/CustomWidgetCallbackBindTest/CustomWidgetCallbackBindTest.cpp
@@ -31,6 +31,13 @@ void CustomWidgetCallbackBindScene::onEnter()
     addChild(pMenu, 1);
 }
 
+void CustomWidgetCallbackBindScene::onExit()
+{
+    CSLoader::destroyCocosStudio();
+    
+    Scene::onExit();
+}
+
 void CustomWidgetCallbackBindScene::runThisTest()
 {
     CSLoader* instance = CSLoader::getInstance();

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/CustomTest/CustomWidgetCallbackBindTest/CustomWidgetCallbackBindTest.cpp
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/CustomTest/CustomWidgetCallbackBindTest/CustomWidgetCallbackBindTest.cpp
@@ -4,6 +4,7 @@
 
 #include "../../CustomGUIScene.h"
 #include "cocostudio/ActionTimeline/CSLoader.h"
+#include "cocostudio/CocoStudio.h"
 
 #include "base/ObjectFactory.h"
 
@@ -33,7 +34,7 @@ void CustomWidgetCallbackBindScene::onEnter()
 
 void CustomWidgetCallbackBindScene::onExit()
 {
-    CSLoader::destroyCocosStudio();
+    cocostudio::destroyCocosStudio();
     
     Scene::onExit();
 }

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/CustomTest/CustomWidgetCallbackBindTest/CustomWidgetCallbackBindTest.h
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/CustomTest/CustomWidgetCallbackBindTest/CustomWidgetCallbackBindTest.h
@@ -10,6 +10,7 @@ class CustomWidgetCallbackBindScene : public TestScene
 {
 public:
     virtual void onEnter() override;
+    virtual void onExit() override;
     virtual void runThisTest();
     void BackCallback(cocos2d::Ref* pSender);
 };

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIScene_Editor.cpp
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIScene_Editor.cpp
@@ -19,6 +19,13 @@ UIScene_Editor::~UIScene_Editor()
     
 }
 
+void UIScene_Editor::onExit()
+{
+    CSLoader::destroyCocosStudio();
+    
+    Layer::onExit();
+}
+
 bool UIScene_Editor::init()
 {
     if (CCLayer::init())

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIScene_Editor.cpp
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIScene_Editor.cpp
@@ -21,7 +21,7 @@ UIScene_Editor::~UIScene_Editor()
 
 void UIScene_Editor::onExit()
 {
-    CSLoader::destroyCocosStudio();
+    cocostudio::destroyCocosStudio();
     
     Layer::onExit();
 }

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIScene_Editor.h
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIScene_Editor.h
@@ -59,6 +59,8 @@ public:
     UIScene_Editor();
     ~UIScene_Editor();
     
+    virtual void onExit() override;
+    
     bool init();
     virtual void previousCallback(Ref* sender, Widget::TouchEventType event);
     virtual void nextCallback(Ref* sender, Widget::TouchEventType event);


### PR DESCRIPTION
Unified all singleton class cleanup function to destroyInstance(), and add destroyCocosStudio() to provide cocos reader related resource cleanup function.
