### PR TITLE
add new labelTTF enableShadow mehtod support to set shadow color

### DIFF
--- a/cocos/2d/CCLabelTTF.cpp
+++ b/cocos/2d/CCLabelTTF.cpp
@@ -186,6 +186,12 @@ void LabelTTF::setFontName(const std::string& fontName)
     _contentDirty = true;
 }
 
+void LabelTTF::enableShadow(const Color4B &shadowColor, const Size &shadowOffset, float shadowBlur)
+{
+    _renderLabel->enableShadow(shadowColor,shadowOffset,shadowBlur);
+    _contentDirty = true;
+}
+
 void LabelTTF::enableShadow(const Size &shadowOffset, float shadowOpacity, float shadowBlur, bool updateTexture)
 {
     Color4B temp(Color3B::BLACK);
@@ -195,6 +201,8 @@ void LabelTTF::enableShadow(const Size &shadowOffset, float shadowOpacity, float
 }
 
 void LabelTTF::disableShadow(bool updateTexture)
+
+
 {
     _renderLabel->disableEffect();
     _contentDirty = true;

--- a/cocos/2d/CCLabelTTF.cpp
+++ b/cocos/2d/CCLabelTTF.cpp
@@ -201,8 +201,6 @@ void LabelTTF::enableShadow(const Size &shadowOffset, float shadowOpacity, float
 }
 
 void LabelTTF::disableShadow(bool updateTexture)
-
-
 {
     _renderLabel->disableEffect();
     _contentDirty = true;

--- a/cocos/2d/CCLabelTTF.h
+++ b/cocos/2d/CCLabelTTF.h
@@ -102,7 +102,8 @@ public:
     /** get the text definition used by this label */
     const FontDefinition& getTextDefinition() const;
     
-    
+    /** enable or disable shadow for the label */
+    void enableShadow(const Color4B &shadowColor, const Size &shadowOffset, float shadowBlur);
     
     /** enable or disable shadow for the label */
     void enableShadow(const Size &shadowOffset, float shadowOpacity, float shadowBlur, bool mustUpdateTexture = true);


### PR DESCRIPTION
add new labelTTF enableShadow mehtod support to set shadow color 
the issues reference 
http://discuss.cocos2d-x.org/t/cc-labelttf-enableshadow-doesnt-work-in-native-builds/20747
