### PR TITLE
Making the context current before rendering

### DIFF
--- a/cocos/2d/CCLabel.cpp
+++ b/cocos/2d/CCLabel.cpp
@@ -898,7 +898,7 @@ void Label::draw(Renderer *renderer, const Mat4 &transform, uint32_t flags)
     // Don't do calculate the culling if the transform was not updated
     bool transformUpdated = flags & FLAGS_TRANSFORM_DIRTY;
 #if CC_USE_CULLING
-    _insideBounds = transformUpdated ? renderer->checkVisibility(transform, _contentSize) : _insideBounds;
+    _insideBounds = renderer->checkVisibility(transform, _contentSize);
 
     if(_insideBounds)
 #endif

--- a/cocos/2d/CCSprite.cpp
+++ b/cocos/2d/CCSprite.cpp
@@ -589,7 +589,7 @@ void Sprite::draw(Renderer *renderer, const Mat4 &transform, uint32_t flags)
 {
 #if CC_USE_CULLING
     // Don't do calculate the culling if the transform was not updated
-    _insideBounds = (flags & FLAGS_TRANSFORM_DIRTY) ? renderer->checkVisibility(transform, _contentSize) : _insideBounds;
+    _insideBounds = renderer->checkVisibility(transform, _contentSize);
 
     if(_insideBounds)
 #endif

--- a/cocos/base/CCDirector.cpp
+++ b/cocos/base/CCDirector.cpp
@@ -270,6 +270,8 @@ void Director::drawScene()
         _eventDispatcher->dispatchEvent(_eventAfterUpdate);
     }
 
+    _openGLView->makeContextCurrent();
+    
     _renderer->clear();
 
     /* to avoid flickr, nextScene MUST be here: after tick and before draw.

--- a/cocos/base/CCDirector.cpp
+++ b/cocos/base/CCDirector.cpp
@@ -270,7 +270,10 @@ void Director::drawScene()
         _eventDispatcher->dispatchEvent(_eventAfterUpdate);
     }
 
-    _openGLView->makeContextCurrent();
+    if (_openGLView)
+    {
+        _openGLView->makeContextCurrent();
+    }
     
     _renderer->clear();
 

--- a/cocos/platform/CCGLView.cpp
+++ b/cocos/platform/CCGLView.cpp
@@ -453,4 +453,9 @@ float GLView::getScaleY() const
     return _scaleY;
 }
 
+void GLView::makeContextCurrent()
+{
+    
+}
+
 NS_CC_END

--- a/cocos/platform/CCGLView.cpp
+++ b/cocos/platform/CCGLView.cpp
@@ -453,9 +453,4 @@ float GLView::getScaleY() const
     return _scaleY;
 }
 
-void GLView::makeContextCurrent()
-{
-    
-}
-
 NS_CC_END

--- a/cocos/platform/CCGLView.h
+++ b/cocos/platform/CCGLView.h
@@ -383,6 +383,8 @@ public:
     virtual id getCocoaWindow() = 0;
 #endif /* (CC_TARGET_PLATFORM == CC_PLATFORM_MAC) */
     
+    virtual void makeContextCurrent();
+    
 protected:
     void updateDesignResolutionSize();
     

--- a/cocos/platform/CCGLView.h
+++ b/cocos/platform/CCGLView.h
@@ -383,7 +383,7 @@ public:
     virtual id getCocoaWindow() = 0;
 #endif /* (CC_TARGET_PLATFORM == CC_PLATFORM_MAC) */
     
-    virtual void makeContextCurrent();
+    virtual void makeContextCurrent() {}
     
 protected:
     void updateDesignResolutionSize();

--- a/cocos/platform/desktop/CCGLViewImpl-desktop.cpp
+++ b/cocos/platform/desktop/CCGLViewImpl-desktop.cpp
@@ -855,4 +855,10 @@ bool GLViewImpl::initGlew()
     return true;
 }
 
+void GLViewImpl::makeContextCurrent()
+{
+    glfwMakeContextCurrent(nullptr); 
+    glfwMakeContextCurrent(_mainWindow);
+}
+
 NS_CC_END // end of namespace cocos2d;

--- a/cocos/platform/desktop/CCGLViewImpl-desktop.cpp
+++ b/cocos/platform/desktop/CCGLViewImpl-desktop.cpp
@@ -274,6 +274,7 @@ GLViewImpl::GLViewImpl()
 , _monitor(nullptr)
 , _mouseX(0.0f)
 , _mouseY(0.0f)
+, _resizable(false)
 {
     _viewName = "cocos2dx";
     g_keyCodeMap.clear();
@@ -295,10 +296,10 @@ GLViewImpl::~GLViewImpl()
     glfwTerminate();
 }
 
-GLViewImpl* GLViewImpl::create(const std::string& viewName)
+GLViewImpl* GLViewImpl::create(const std::string& viewName, bool resizable)
 {
     auto ret = new (std::nothrow) GLViewImpl;
-    if(ret && ret->initWithRect(viewName, Rect(0, 0, 960, 640), 1)) {
+    if(ret && ret->initWithRect(viewName, Rect(0, 0, 960, 640), 1, resizable)) {
         ret->autorelease();
         return ret;
     }
@@ -306,10 +307,10 @@ GLViewImpl* GLViewImpl::create(const std::string& viewName)
     return nullptr;
 }
 
-GLViewImpl* GLViewImpl::createWithRect(const std::string& viewName, Rect rect, float frameZoomFactor)
+GLViewImpl* GLViewImpl::createWithRect(const std::string& viewName, Rect rect, float frameZoomFactor, bool resizable)
 {
     auto ret = new (std::nothrow) GLViewImpl;
-    if(ret && ret->initWithRect(viewName, rect, frameZoomFactor)) {
+    if(ret && ret->initWithRect(viewName, rect, frameZoomFactor, resizable)) {
         ret->autorelease();
         return ret;
     }
@@ -339,13 +340,14 @@ GLViewImpl* GLViewImpl::createWithFullScreen(const std::string& viewName, const 
     return nullptr;
 }
 
-bool GLViewImpl::initWithRect(const std::string& viewName, Rect rect, float frameZoomFactor)
+bool GLViewImpl::initWithRect(const std::string& viewName, Rect rect, float frameZoomFactor, bool resizable)
 {
     setViewName(viewName);
 
     _frameZoomFactor = frameZoomFactor;
+    _resizable = resizable;
 
-    glfwWindowHint(GLFW_RESIZABLE,GL_FALSE);
+    glfwWindowHint(GLFW_RESIZABLE,_resizable ? GL_TRUE : GL_FALSE);
     glfwWindowHint(GLFW_RED_BITS,_glContextAttrs.redBits);
     glfwWindowHint(GLFW_GREEN_BITS,_glContextAttrs.greenBits);
     glfwWindowHint(GLFW_BLUE_BITS,_glContextAttrs.blueBits);
@@ -401,7 +403,7 @@ bool GLViewImpl::initWithFullScreen(const std::string& viewName)
         return false;
 
     const GLFWvidmode* videoMode = glfwGetVideoMode(_monitor);
-    return initWithRect(viewName, Rect(0, 0, videoMode->width, videoMode->height), 1.0f);
+    return initWithRect(viewName, Rect(0, 0, videoMode->width, videoMode->height), 1.0f, false);
 }
 
 bool GLViewImpl::initWithFullscreen(const std::string &viewname, const GLFWvidmode &videoMode, GLFWmonitor *monitor)
@@ -417,7 +419,7 @@ bool GLViewImpl::initWithFullscreen(const std::string &viewname, const GLFWvidmo
     glfwWindowHint(GLFW_BLUE_BITS, videoMode.blueBits);
     glfwWindowHint(GLFW_GREEN_BITS, videoMode.greenBits);
     
-    return initWithRect(viewname, Rect(0, 0, videoMode.width, videoMode.height), 1.0f);
+    return initWithRect(viewname, Rect(0, 0, videoMode.width, videoMode.height), 1.0f, false);
 }
 
 bool GLViewImpl::isOpenGLReady()
@@ -730,11 +732,8 @@ void GLViewImpl::onGLFWframebuffersize(GLFWwindow* window, int w, int h)
 
 void GLViewImpl::onGLFWWindowSizeFunCallback(GLFWwindow *window, int width, int height)
 {
-    if (_resolutionPolicy != ResolutionPolicy::UNKNOWN)
-    {
-        updateDesignResolutionSize();
-        Director::getInstance()->setViewport();
-    }
+    updateDesignResolutionSize();
+    Director::getInstance()->setViewport();
 }
 
 void GLViewImpl::onGLFWWindowIconifyCallback(GLFWwindow* window, int iconified)

--- a/cocos/platform/desktop/CCGLViewImpl-desktop.cpp
+++ b/cocos/platform/desktop/CCGLViewImpl-desktop.cpp
@@ -732,9 +732,10 @@ void GLViewImpl::onGLFWframebuffersize(GLFWwindow* window, int w, int h)
 
 void GLViewImpl::onGLFWWindowSizeFunCallback(GLFWwindow *window, int width, int height)
 {
+    GLView::setFrameSize(width, height);
+    
     updateDesignResolutionSize();
     Director::getInstance()->setViewport();
-    Director::getInstance()->drawScene();
 }
 
 void GLViewImpl::onGLFWWindowIconifyCallback(GLFWwindow* window, int iconified)

--- a/cocos/platform/desktop/CCGLViewImpl-desktop.cpp
+++ b/cocos/platform/desktop/CCGLViewImpl-desktop.cpp
@@ -734,6 +734,7 @@ void GLViewImpl::onGLFWWindowSizeFunCallback(GLFWwindow *window, int width, int 
 {
     updateDesignResolutionSize();
     Director::getInstance()->setViewport();
+    Director::getInstance()->drawScene();
 }
 
 void GLViewImpl::onGLFWWindowIconifyCallback(GLFWwindow* window, int iconified)

--- a/cocos/platform/desktop/CCGLViewImpl-desktop.h
+++ b/cocos/platform/desktop/CCGLViewImpl-desktop.h
@@ -56,8 +56,8 @@ NS_CC_BEGIN
 class CC_DLL GLViewImpl : public GLView
 {
 public:
-    static GLViewImpl* create(const std::string& viewName);
-    static GLViewImpl* createWithRect(const std::string& viewName, Rect size, float frameZoomFactor = 1.0f);
+    static GLViewImpl* create(const std::string& viewName, bool resizable = false);
+    static GLViewImpl* createWithRect(const std::string& viewName, Rect size, float frameZoomFactor = 1.0f, bool resizable = false);
     static GLViewImpl* createWithFullScreen(const std::string& viewName);
     static GLViewImpl* createWithFullScreen(const std::string& viewName, const GLFWvidmode &videoMode, GLFWmonitor *monitor);
 
@@ -113,11 +113,13 @@ public:
 
     virtual void makeContextCurrent() override;
 
+    virtual bool isResizable() const { return _resizable; }
+
 protected:
     GLViewImpl();
     virtual ~GLViewImpl();
 
-    bool initWithRect(const std::string& viewName, Rect rect, float frameZoomFactor);
+    bool initWithRect(const std::string& viewName, Rect rect, float frameZoomFactor, bool resizable);
     bool initWithFullScreen(const std::string& viewName);
     bool initWithFullscreen(const std::string& viewname, const GLFWvidmode &videoMode, GLFWmonitor *monitor);
 
@@ -152,6 +154,8 @@ protected:
     float _mouseY;
 
     friend class GLFWEventHandler;
+
+    bool _resizable;
 
 private:
     CC_DISALLOW_COPY_AND_ASSIGN(GLViewImpl);

--- a/cocos/platform/desktop/CCGLViewImpl-desktop.h
+++ b/cocos/platform/desktop/CCGLViewImpl-desktop.h
@@ -111,6 +111,8 @@ public:
     id getCocoaWindow() { return glfwGetCocoaWindow(_mainWindow); }
 #endif // #if (CC_TARGET_PLATFORM == CC_PLATFORM_MAC)
 
+    virtual void makeContextCurrent() override;
+
 protected:
     GLViewImpl();
     virtual ~GLViewImpl();

--- a/cocos/renderer/CCRenderer.cpp
+++ b/cocos/renderer/CCRenderer.cpp
@@ -983,8 +983,8 @@ bool Renderer::checkVisibility(const Mat4 &transform, const Size &size)
     transform.transformVector(v4local, &v4world);
 
     // center of screen is (0,0)
-    v4world.x -= screen_half.width;
-    v4world.y -= screen_half.height;
+    v4world.x -= scene->_defaultCamera->getPosition().x;
+    v4world.y -= scene->_defaultCamera->getPosition().y;
 
     // convert content size to world coordinates
     float wshw = std::max(fabsf(hSizeX * transform.m[0] + hSizeY * transform.m[4]), fabsf(hSizeX * transform.m[0] - hSizeY * transform.m[4]));

--- a/cocos/renderer/CCRenderer.cpp
+++ b/cocos/renderer/CCRenderer.cpp
@@ -969,32 +969,27 @@ bool Renderer::checkVisibility(const Mat4 &transform, const Size &size)
     // only cull the default camera. The culling algorithm is valid for default camera.
     if (scene && scene->_defaultCamera != Camera::getVisitingCamera())
         return true;
-    
-    // half size of the screen
-    Size screen_half = Director::getInstance()->getWinSize();
-    screen_half.width /= 2;
-    screen_half.height /= 2;
 
+    auto director = Director::getInstance();
+    Rect visiableRect(director->getVisibleOrigin(), director->getVisibleSize());
+    
+    // transform center point to screen space
     float hSizeX = size.width/2;
     float hSizeY = size.height/2;
-
-    Vec4 v4world, v4local;
-    v4local.set(hSizeX, hSizeY, 0, 1);
-    transform.transformVector(v4local, &v4world);
-
-    // center of screen is (0,0)
-    v4world.x -= scene->_defaultCamera->getPosition().x;
-    v4world.y -= scene->_defaultCamera->getPosition().y;
+    Vec3 v3p(hSizeX, hSizeY, 0);
+    transform.transformPoint(&v3p);
+    Vec2 v2p = Camera::getVisitingCamera()->projectGL(v3p);
 
     // convert content size to world coordinates
     float wshw = std::max(fabsf(hSizeX * transform.m[0] + hSizeY * transform.m[4]), fabsf(hSizeX * transform.m[0] - hSizeY * transform.m[4]));
     float wshh = std::max(fabsf(hSizeX * transform.m[1] + hSizeY * transform.m[5]), fabsf(hSizeX * transform.m[1] - hSizeY * transform.m[5]));
-
-    // compare if it in the positive quadrant of the screen
-    float tmpx = (fabsf(v4world.x)-wshw);
-    float tmpy = (fabsf(v4world.y)-wshh);
-    bool ret = (tmpx < screen_half.width && tmpy < screen_half.height);
-
+    
+    // enlarge visable rect half size in screen coord
+    visiableRect.origin.x -= wshw;
+    visiableRect.origin.y -= wshh;
+    visiableRect.size.width += wshw * 2;
+    visiableRect.size.height += wshh * 2;
+    bool ret = visiableRect.containsPoint(v2p);
     return ret;
 }
 


### PR DESCRIPTION
Context can be changed when using GUI components on OSX. This pull request makes the glfw make it's context current.
The following code is used, because of a bug in GLFW that does not change the current context if the internal pointer to window is the same (although the actual context has changed), so I set it first to nullptr and then to the main window pointer:

```
glfwMakeContextCurrent(nullptr);
glfwMakeContextCurrent(_mainWindow);
```
