### PR TITLE
Fix Desktop app crash upon exit when NotificationNode exists

### DIFF
--- a/cocos/base/CCDirector.cpp
+++ b/cocos/base/CCDirector.cpp
@@ -957,6 +957,15 @@ void Director::reset()
     _runningScene = nullptr;
     _nextScene = nullptr;
     
+    if(_notificationNode)
+    {
+        _notificationNode->onExit();
+        _notificationNode->cleanup();
+        _notificationNode->release();
+    }
+    
+    _notificationNode = nullptr;
+    
     // remove all objects, but don't release it.
     // runWithScene might be executed after 'end'.
     _scenesStack.clear();


### PR DESCRIPTION
**Problem:**
When CCDirector contains NotificationNode and user tries to close the desktop app - it crashes.

**Solution:**
If notification node exists - destroy it inside _cc::Director->reset_ function.
