### PR TITLE
Fix NotificationNode event listeners priority

### DIFF
--- a/cocos/base/CCEventDispatcher.cpp
+++ b/cocos/base/CCEventDispatcher.cpp
@@ -1185,15 +1185,34 @@ void EventDispatcher::sortEventListenersOfSceneGraphPriority(const EventListener
     
     if (sceneGraphListeners == nullptr)
         return;
-
     // Reset priority index
     _nodePriorityIndex = 0;
     _nodePriorityMap.clear();
-
-    Node *notificationNode = Director::getInstance()->getNotificationNode();
+    
+    Node* notificationNode = Director::getInstance()->getNotificationNode();
     if(notificationNode) {
         visitTarget(notificationNode, true);
-        visitTarget(rootNode, false);
+        
+        // save result in temp variable for later use
+        std::unordered_map<Node*, int> notificationNodePriorityMap; // = _nodePriorityMap
+        for(auto kv : _nodePriorityMap) {
+            notificationNodePriorityMap[kv.first] = kv.second;
+        }
+        int notificationNodePriorityIndex = _nodePriorityIndex;
+        
+        // reset
+        _nodePriorityIndex = 0;
+        _nodePriorityMap.clear();
+        
+        // visit rootNode
+        visitTarget(rootNode, true);
+        
+        // update priority map
+        for(auto kv : notificationNodePriorityMap) {
+            _nodePriorityMap[kv.first] = notificationNodePriorityMap[kv.first] + _nodePriorityIndex;
+        }
+        // update index
+        _nodePriorityIndex += notificationNodePriorityIndex;
     } else {
         visitTarget(rootNode, true);
     }

--- a/cocos/base/CCEventDispatcher.cpp
+++ b/cocos/base/CCEventDispatcher.cpp
@@ -1190,7 +1190,13 @@ void EventDispatcher::sortEventListenersOfSceneGraphPriority(const EventListener
     _nodePriorityIndex = 0;
     _nodePriorityMap.clear();
 
-    visitTarget(rootNode, true);
+    Node *notificationNode = Director::getInstance()->getNotificationNode();
+    if(notificationNode) {
+        visitTarget(notificationNode, true);
+        visitTarget(rootNode, false);
+    } else {
+        visitTarget(rootNode, true);
+    }
     
     // After sort: priority < 0, > 0
     std::sort(sceneGraphListeners->begin(), sceneGraphListeners->end(), [this](const EventListener* l1, const EventListener* l2) {


### PR DESCRIPTION
**Problem:**
When notification node is used event listeners are not getting sorted for it and its child nodes.

**Solution:**
If notification node is available consider it as a root and calculate scene graph priority for it first.
If notification node is not available consider scene as a root.

**cocos2d-html5 related pull request:**
https://github.com/cocos2d/cocos2d-html5/pull/2809
