### PR TITLE
remove interlevel argument of "Application" class.

### DIFF
--- a/cocos/platform/ios/CCApplication-ios.mm
+++ b/cocos/platform/ios/CCApplication-ios.mm
@@ -104,67 +104,27 @@ LanguageType Application::getCurrentLanguage()
     NSDictionary* temp = [NSLocale componentsFromLocaleIdentifier:currentLanguage];
     NSString * languageCode = [temp objectForKey:NSLocaleLanguageCode];
     
-    LanguageType ret = LanguageType::ENGLISH;
-    if ([languageCode isEqualToString:@"zh"])
-    {
-        ret = LanguageType::CHINESE;
-    }
-    else if ([languageCode isEqualToString:@"en"])
-    {
-        ret = LanguageType::ENGLISH;
-    }
-    else if ([languageCode isEqualToString:@"fr"]){
-        ret = LanguageType::FRENCH;
-    }
-    else if ([languageCode isEqualToString:@"it"]){
-        ret = LanguageType::ITALIAN;
-    }
-    else if ([languageCode isEqualToString:@"de"]){
-        ret = LanguageType::GERMAN;
-    }
-    else if ([languageCode isEqualToString:@"es"]){
-        ret = LanguageType::SPANISH;
-    }
-    else if ([languageCode isEqualToString:@"nl"]){
-        ret = LanguageType::DUTCH;
-    }
-    else if ([languageCode isEqualToString:@"ru"]){
-        ret = LanguageType::RUSSIAN;
-    }
-    else if ([languageCode isEqualToString:@"ko"]){
-        ret = LanguageType::KOREAN;
-    }
-    else if ([languageCode isEqualToString:@"ja"]){
-        ret = LanguageType::JAPANESE;
-    }
-    else if ([languageCode isEqualToString:@"hu"]){
-        ret = LanguageType::HUNGARIAN;
-    }
-    else if ([languageCode isEqualToString:@"pt"]){
-        ret = LanguageType::PORTUGUESE;
-    }
-    else if ([languageCode isEqualToString:@"ar"]){
-        ret = LanguageType::ARABIC;
-    }
-    else if ([languageCode isEqualToString:@"nb"]){
-        ret = LanguageType::NORWEGIAN;
-    }
-    else if ([languageCode isEqualToString:@"pl"]){
-        ret = LanguageType::POLISH;
-    }
-    else if ([languageCode isEqualToString:@"tr"]){
-        ret = LanguageType::TURKISH;
-    }
-    else if ([languageCode isEqualToString:@"uk"]){
-        ret = LanguageType::UKRAINIAN;
-    }
-    else if ([languageCode isEqualToString:@"ro"]){
-        ret = LanguageType::ROMANIAN;
-    }
-    else if ([languageCode isEqualToString:@"bg"]){
-        ret = LanguageType::BULGARIAN;
-    }
-    return ret;
+    if ([languageCode isEqualToString:@"zh"]) return LanguageType::CHINESE;
+    if ([languageCode isEqualToString:@"en"]) return LanguageType::ENGLISH;
+    if ([languageCode isEqualToString:@"fr"]) return LanguageType::FRENCH;
+    if ([languageCode isEqualToString:@"it"]) return LanguageType::ITALIAN;
+    if ([languageCode isEqualToString:@"de"]) return LanguageType::GERMAN;
+    if ([languageCode isEqualToString:@"es"]) return LanguageType::SPANISH;
+    if ([languageCode isEqualToString:@"nl"]) return LanguageType::DUTCH;
+    if ([languageCode isEqualToString:@"ru"]) return LanguageType::RUSSIAN;
+    if ([languageCode isEqualToString:@"ko"]) return LanguageType::KOREAN;
+    if ([languageCode isEqualToString:@"ja"]) return LanguageType::JAPANESE;
+    if ([languageCode isEqualToString:@"hu"]) return LanguageType::HUNGARIAN;
+    if ([languageCode isEqualToString:@"pt"]) return LanguageType::PORTUGUESE;
+    if ([languageCode isEqualToString:@"ar"]) return LanguageType::ARABIC;
+    if ([languageCode isEqualToString:@"nb"]) return LanguageType::NORWEGIAN;
+    if ([languageCode isEqualToString:@"pl"]) return LanguageType::POLISH;
+    if ([languageCode isEqualToString:@"tr"]) return LanguageType::TURKISH;
+    if ([languageCode isEqualToString:@"uk"]) return LanguageType::UKRAINIAN;
+    if ([languageCode isEqualToString:@"ro"]) return LanguageType::ROMANIAN;
+    if ([languageCode isEqualToString:@"bg"]) return LanguageType::BULGARIAN;
+    return LanguageType::ENGLISH;
+
 }
 
 Application::Platform Application::getTargetPlatform()

--- a/cocos/platform/mac/CCApplication-mac.mm
+++ b/cocos/platform/mac/CCApplication-mac.mm
@@ -160,65 +160,27 @@ LanguageType Application::getCurrentLanguage()
     NSDictionary* temp = [NSLocale componentsFromLocaleIdentifier:currentLanguage];
     NSString * languageCode = [temp objectForKey:NSLocaleLanguageCode];
     
-    LanguageType ret = LanguageType::ENGLISH;
-    if ([languageCode isEqualToString:@"zh"]){
-        ret = LanguageType::CHINESE;
-    }
-    else if ([languageCode isEqualToString:@"en"]){
-        ret = LanguageType::ENGLISH;
-    }
-    else if ([languageCode isEqualToString:@"fr"]){
-        ret = LanguageType::FRENCH;
-    }
-    else if ([languageCode isEqualToString:@"it"]){
-        ret = LanguageType::ITALIAN;
-    }
-    else if ([languageCode isEqualToString:@"de"]){
-        ret = LanguageType::GERMAN;
-    }
-    else if ([languageCode isEqualToString:@"es"]){
-        ret = LanguageType::SPANISH;
-    }
-    else if ([languageCode isEqualToString:@"nl"]){
-        ret = LanguageType::DUTCH;
-    }
-    else if ([languageCode isEqualToString:@"ru"]){
-        ret = LanguageType::RUSSIAN;
-    }
-    else if ([languageCode isEqualToString:@"ko"]){
-        ret = LanguageType::KOREAN;
-    }
-    else if ([languageCode isEqualToString:@"ja"]){
-        ret = LanguageType::JAPANESE;
-    }
-    else if ([languageCode isEqualToString:@"hu"]){
-        ret = LanguageType::HUNGARIAN;
-    }
-    else if ([languageCode isEqualToString:@"pt"]){
-        ret = LanguageType::PORTUGUESE;
-    }
-    else if ([languageCode isEqualToString:@"ar"]){
-        ret = LanguageType::ARABIC;
-    }
-    else if ([languageCode isEqualToString:@"nb"]){
-        ret = LanguageType::NORWEGIAN;
-    }
-    else if ([languageCode isEqualToString:@"pl"]){
-        ret = LanguageType::POLISH;
-    }
-    else if ([languageCode isEqualToString:@"tr"]){
-        ret = LanguageType::TURKISH;
-    }
-    else if ([languageCode isEqualToString:@"uk"]){
-        ret = LanguageType::UKRAINIAN;
-    }
-    else if ([languageCode isEqualToString:@"ro"]){
-        ret = LanguageType::ROMANIAN;
-    }
-    else if ([languageCode isEqualToString:@"bg"]){
-        ret = LanguageType::BULGARIAN;
-    }
-    return ret;
+    if ([languageCode isEqualToString:@"zh"]) return LanguageType::CHINESE;
+    if ([languageCode isEqualToString:@"en"]) return LanguageType::ENGLISH;
+    if ([languageCode isEqualToString:@"fr"]) return LanguageType::FRENCH;
+    if ([languageCode isEqualToString:@"it"]) return LanguageType::ITALIAN;
+    if ([languageCode isEqualToString:@"de"]) return LanguageType::GERMAN;
+    if ([languageCode isEqualToString:@"es"]) return LanguageType::SPANISH;
+    if ([languageCode isEqualToString:@"nl"]) return LanguageType::DUTCH;
+    if ([languageCode isEqualToString:@"ru"]) return LanguageType::RUSSIAN;
+    if ([languageCode isEqualToString:@"ko"]) return LanguageType::KOREAN;
+    if ([languageCode isEqualToString:@"ja"]) return LanguageType::JAPANESE;
+    if ([languageCode isEqualToString:@"hu"]) return LanguageType::HUNGARIAN;
+    if ([languageCode isEqualToString:@"pt"]) return LanguageType::PORTUGUESE;
+    if ([languageCode isEqualToString:@"ar"]) return LanguageType::ARABIC;
+    if ([languageCode isEqualToString:@"nb"]) return LanguageType::NORWEGIAN;
+    if ([languageCode isEqualToString:@"pl"]) return LanguageType::POLISH;
+    if ([languageCode isEqualToString:@"tr"]) return LanguageType::TURKISH;
+    if ([languageCode isEqualToString:@"uk"]) return LanguageType::UKRAINIAN;
+    if ([languageCode isEqualToString:@"ro"]) return LanguageType::ROMANIAN;
+    if ([languageCode isEqualToString:@"bg"]) return LanguageType::BULGARIAN;
+    return LanguageType::ENGLISH;
+
 }
 
 bool Application::openURL(const std::string &url)


### PR DESCRIPTION
## Problem:
### "LanguageType Application::getCurrentLanguage" method has unnecessary interlevel argument "ret";

This argument makes this method more complex than its process.
## Solution:
### I've deleted this "ret" argument.

This method will return correct LanguageType and no more unnecessary comparison!
Thanks.
