### PR TITLE
TextureCache::getTextureForKey add param checkFullPath

### DIFF
--- a/cocos/2d/CCSprite.cpp
+++ b/cocos/2d/CCSprite.cpp
@@ -318,14 +318,14 @@ void Sprite::setTexture(const std::string &filename)
 void Sprite::setTexture(Texture2D *texture)
 {
     // If batchnode, then texture id should be the same
-    CCASSERT(! _batchNode || texture->getName() == _batchNode->getTexture()->getName(), "CCSprite: Batched sprites should use the same texture as the batchnode");
+    CCASSERT(!_batchNode || !texture || texture->getName() == _batchNode->getTexture()->getName(), "CCSprite: Batched sprites should use the same texture as the batchnode");
     // accept texture==nil as argument
-    CCASSERT( !texture || dynamic_cast<Texture2D*>(texture), "setTexture expects a Texture2D. Invalid argument");
+    CCASSERT(!texture || dynamic_cast<Texture2D*>(texture), "setTexture expects a Texture2D. Invalid argument");
 
     if (texture == nullptr)
     {
-        // Gets the texture by key firstly.
-        texture = Director::getInstance()->getTextureCache()->getTextureForKey(CC_2x2_WHITE_IMAGE_KEY);
+        // Gets the texture by key firstly. No check full path
+        texture = Director::getInstance()->getTextureCache()->getTextureForKey(CC_2x2_WHITE_IMAGE_KEY, false);
 
         // If texture wasn't in cache, create it from RAW data.
         if (texture == nullptr)

--- a/cocos/renderer/CCTextureCache.cpp
+++ b/cocos/renderer/CCTextureCache.cpp
@@ -501,12 +501,12 @@ void TextureCache::removeTextureForKey(const std::string &textureKeyName)
     }
 }
 
-Texture2D* TextureCache::getTextureForKey(const std::string &textureKeyName) const
+Texture2D* TextureCache::getTextureForKey(const std::string &textureKeyName, bool checkFullPath) const
 {
     std::string key = textureKeyName;
     auto it = _textures.find(key);
 
-    if( it == _textures.end() ) {
+    if (checkFullPath && it == _textures.end()) {
         key = FileUtils::getInstance()->fullPathForFilename(textureKeyName);
         it = _textures.find(key);
     }

--- a/cocos/renderer/CCTextureCache.h
+++ b/cocos/renderer/CCTextureCache.h
@@ -146,9 +146,10 @@ public:
 
     /** Returns an already created texture. Returns nil if the texture doesn't exist.
     @param key It's the related/absolute path of the file image.
+    @param checkFullPath If key not found, check key = fullPathForFilename(key). Default true
     @since v0.99.5
     */
-    Texture2D* getTextureForKey(const std::string& key) const;
+    Texture2D* getTextureForKey(const std::string& key, bool checkFullPath = true) const;
     CC_DEPRECATED_ATTRIBUTE Texture2D* textureForKey(const std::string& key) const { return getTextureForKey(key); }
 
     /** Reload texture from the image file.


### PR DESCRIPTION
Is not always necessary to check FullPath, if key not found. example
wrong message: "cocos2d: fullPathForFilename: No file found at
/cc_2x2_white_image. Possible missing file." #8328

Sprite::setTexture
CCASSERT add check texture not nullptr
#10086 First questions
