### PR TITLE
Log message can't detect image format

### DIFF
--- a/cocos/platform/CCImage.cpp
+++ b/cocos/platform/CCImage.cpp
@@ -635,7 +635,6 @@ bool Image::isS3TC(const unsigned char * data, ssize_t dataLen)
     
     if (strncmp(header->fileCode, "DDS", 3) != 0)
     {
-        CCLOG("cocos2d: the file is not a dds file!");
         return false;
     }
     return true;
@@ -647,7 +646,6 @@ bool Image::isATITC(const unsigned char *data, ssize_t dataLen)
     
     if (strncmp(&header->identifier[1], "KTX", 3) != 0)
     {
-        CCLOG("cocos3d: the file is not a ktx file!");
         return false;
     }
     return true;
@@ -742,6 +740,7 @@ Image::Format Image::detectFormat(const unsigned char * data, ssize_t dataLen)
     }
     else
     {
+        CCLOG("cocos2d: can't detect image format");
         return Format::UNKNOWN;
     }
 }


### PR DESCRIPTION
Wrong log message DDS and KTX check image format(other format no log
message).
isS3TC and isATITC protected, no use dev code.

Log message if format unknown

https://github.com/cocos2d/cocos2d-js/issues/1391
