### PR TITLE
GLViewImpl initWithRect bug size

### DIFF
--- a/cocos/platform/desktop/CCGLViewImpl-desktop.cpp
+++ b/cocos/platform/desktop/CCGLViewImpl-desktop.cpp
@@ -353,11 +353,32 @@ bool GLViewImpl::initWithRect(const std::string& viewName, Rect rect, float fram
     glfwWindowHint(GLFW_DEPTH_BITS,_glContextAttrs.depthBits);
     glfwWindowHint(GLFW_STENCIL_BITS,_glContextAttrs.stencilBits);
 
-    _mainWindow = glfwCreateWindow(rect.size.width * _frameZoomFactor,
-                                   rect.size.height * _frameZoomFactor,
-                                   _viewName.c_str(),
-                                   _monitor,
-                                   nullptr);
+    int needWidth = rect.size.width * _frameZoomFactor;
+    int neeHeight = rect.size.height * _frameZoomFactor;
+
+    _mainWindow = glfwCreateWindow(needWidth, neeHeight, _viewName.c_str(), _monitor, nullptr);
+
+    /*
+    *  Note that the created window and context may differ from what you requested,
+    *  as not all parameters and hints are
+    *  [hard constraints](@ref window_hints_hard).  This includes the size of the
+    *  window, especially for full screen windows.  To retrieve the actual
+    *  attributes of the created window and context, use queries like @ref
+    *  glfwGetWindowAttrib and @ref glfwGetWindowSize.
+    *
+    *  see declaration glfwCreateWindow
+    */
+    int realW = 0, realH = 0;
+    glfwGetWindowSize(_mainWindow, &realW, &realH);
+    if (realW != needWidth)
+    {
+        rect.size.width = realW / _frameZoomFactor;
+    }
+    if (realH != neeHeight)
+    {
+        rect.size.height = realH / _frameZoomFactor;
+    }
+
     glfwMakeContextCurrent(_mainWindow);
 
     glfwSetMouseButtonCallback(_mainWindow, GLFWEventHandler::onGLFWMouseCallBack);


### PR DESCRIPTION
glfwCreateWindow not guarantees create windows need size, watch real
create size and change setFrameSize( see declaration glfwCreateWindow)

Example Windows 7, if request height size > Desktop height make window
size: Desktop height - height Caption.
