### PR TITLE
RenderQueue command buffer optimisation

### DIFF
--- a/cocos/renderer/CCRenderer.cpp
+++ b/cocos/renderer/CCRenderer.cpp
@@ -57,6 +57,10 @@ static bool compare3DCommand(RenderCommand* a, RenderCommand* b)
 }
 
 // queue
+RenderQueue::RenderQueue()
+{
+    
+}
 
 void RenderQueue::push_back(RenderCommand* command)
 {
@@ -128,10 +132,18 @@ RenderCommand* RenderQueue::operator[](ssize_t index) const
 
 void RenderQueue::clear()
 {
-    _commands.clear();
-    for(int index = 0; index < QUEUE_COUNT; ++index)
+    for(int i = 0; i < QUEUE_COUNT; ++i)
     {
-        _commands.push_back(std::vector<RenderCommand*>());
+        _commands[i].clear();
+    }
+}
+
+void RenderQueue::realloc(size_t reserveSize)
+{
+    for(int i = 0; i < QUEUE_COUNT; ++i)
+    {
+        _commands[i] = std::vector<RenderCommand*>();
+        _commands[i].reserve(reserveSize);
     }
 }
 

--- a/cocos/renderer/CCRenderer.h
+++ b/cocos/renderer/CCRenderer.h
@@ -73,10 +73,7 @@ public:
 
 public:
     /**Constructor.*/
-    RenderQueue()
-    {
-        clear();
-    }
+    RenderQueue();
     /**Push a renderCommand into current renderqueue.*/
     void push_back(RenderCommand* command);
     /**Return the number of render commands.*/
@@ -87,6 +84,8 @@ public:
     RenderCommand* operator[](ssize_t index) const;
     /**Clear all rendered commands.*/
     void clear();
+    /**Realloc command queues and reserve with given size. Note: this clears any existing commands.*/
+    void realloc(size_t reserveSize);
     /**Get a sub group of the render queue.*/
     inline std::vector<RenderCommand*>& getSubQueue(QUEUE_GROUP group) { return _commands[group]; }
     /**Get the number of render commands contained in a subqueue.*/
@@ -99,7 +98,7 @@ public:
     
 protected:
     /**The commands in the render queue.*/
-    std::vector<std::vector<RenderCommand*>> _commands;
+    std::vector<RenderCommand*> _commands[QUEUE_COUNT];
     
     /**Cull state.*/
     bool _isCullEnabled;


### PR DESCRIPTION
Made _commands an array of vectors that is no longer reallocated every frame
Provided method to reallocate queues manually and reserve memory in order to minimise std::vector dynamic reallocation
