### PR TITLE
fixes warnings on Xcode 6.3

### DIFF
--- a/cocos/2d/CCTMXLayer.cpp
+++ b/cocos/2d/CCTMXLayer.cpp
@@ -621,7 +621,7 @@ Vec2 TMXLayer::calculateLayerOffset(const Vec2& pos)
     case TMXOrientationStaggered:
         {
             float diffX = 0;
-            if ((int)abs(pos.y) % 2 == 1)
+            if ((int)std::abs(pos.y) % 2 == 1)
             {
                 diffX = _mapTileSize.width/2;
             }

--- a/extensions/Particle3D/PU/CCPUDynamicAttribute.cpp
+++ b/extensions/Particle3D/PU/CCPUDynamicAttribute.cpp
@@ -423,7 +423,7 @@ float PUDynamicAttributeOscillate::getValue (float x)
     case OSCT_SQUARE:
         {
             float val = sin(_phase + _frequency * x * M_PI * 2.0f);
-            if (abs(val) < 0.00001f)
+            if (std::abs(val) < 0.00001f)
                 val = val >0? 1: -1;
             return _base + _amplitude * val;
         }

--- a/extensions/Particle3D/PU/CCPUInterParticleCollider.cpp
+++ b/extensions/Particle3D/PU/CCPUInterParticleCollider.cpp
@@ -108,8 +108,8 @@ bool PUParticle3DInterParticleCollider::validateAndExecuteSphereCollision (PUPar
                 // The new velocity is based on the angle between original direction and new direction.
                 // Note, that this usually means that the velocity decreases.
 
-                float velocity1 = Vec3(abs(vp1->direction.x), abs(vp1->direction.y), abs(vp1->direction.z)).dot(n);
-                float velocity2 = Vec3(abs(vp2->direction.x), abs(vp2->direction.y), abs(vp2->direction.z)).dot(n);
+                float velocity1 = Vec3(std::abs(vp1->direction.x), std::abs(vp1->direction.y), std::abs(vp1->direction.z)).dot(n);
+                float velocity2 = Vec3(std::abs(vp2->direction.x), std::abs(vp2->direction.y), std::abs(vp2->direction.z)).dot(n);
                 vp1->direction = velocity1 * vp2->mass * n;
                 vp2->direction = velocity2 * vp1->mass * -n;
             }

--- a/extensions/Particle3D/PU/CCPUMeshSurfaceEmitter.cpp
+++ b/extensions/Particle3D/PU/CCPUMeshSurfaceEmitter.cpp
@@ -209,7 +209,7 @@ inline float MeshInfo::getGaussianRandom (float high, float cutoff)
     } while (w >= 1.0f);
     
     w = sqrt((-2.0f * ::log(w)) / w);
-    y1 = abs(x1 * w);
+    y1 = std::abs(x1 * w);
     y1 = y1 > cutoff ? cutoff : y1;
     y1 *= high / cutoff;
     return y1;

--- a/tests/cpp-tests/Classes/ExtensionsTest/CocoStudioSceneTest/TriggerCode/cons.cpp
+++ b/tests/cpp-tests/Classes/ExtensionsTest/CocoStudioSceneTest/TriggerCode/cons.cpp
@@ -233,7 +233,7 @@ bool NodeInRect::init()
 bool NodeInRect::detect()
 {
 	Node *pNode = SceneReader::getInstance()->getNodeByTag(_tag);
-	if (pNode != nullptr && abs(pNode->getPositionX() - _origin.x) <= _size.width && abs(pNode->getPositionY() - _origin.y) <= _size.height)
+	if (pNode != nullptr && std::abs(pNode->getPositionX() - _origin.x) <= _size.width && std::abs(pNode->getPositionY() - _origin.y) <= _size.height)
 	{
 		return true;
 	}

--- a/tests/cpp-tests/Classes/TextInputTest/TextInputTest.cpp
+++ b/tests/cpp-tests/Classes/TextInputTest/TextInputTest.cpp
@@ -95,8 +95,8 @@ void KeyboardNotificationLayer::onTouchEnded(Touch  *touch, Event  *event)
     auto endPos = touch->getLocation();    
 
     float delta = 5.0f;
-    if (::abs(endPos.x - _beginPos.x) > delta
-        || ::abs(endPos.y - _beginPos.y) > delta)
+    if (std::abs(endPos.x - _beginPos.x) > delta
+        || std::abs(endPos.y - _beginPos.y) > delta)
     {
         // not click
         _beginPos.x = _beginPos.y = -1;


### PR DESCRIPTION
instead of using `abs()` it uses `std::abs()`
