### PR TITLE
Android: Video player stability

### DIFF
--- a/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxVideoView.java
+++ b/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxVideoView.java
@@ -352,12 +352,14 @@ public class Cocos2dxVideoView extends SurfaceView implements MediaPlayerControl
     public void fixSize(int left, int top, int width, int height) {
         if (width != 0 && height != 0) {
             if (mKeepRatio) {
-                if ( mVideoWidth * height  >= width * mVideoHeight ) {
-                    mVisibleWidth = width;
-                    mVisibleHeight = width * mVideoHeight / mVideoWidth;
-                } else if ( mVideoWidth * height  < width * mVideoHeight ) {
-                    mVisibleWidth = height * mVideoWidth / mVideoHeight;
-                    mVisibleHeight = height;
+                if ( (mVideoWidth != 0) && (mVideoHeight != 0) ) {      // have we got video size already?
+                    if ( mVideoWidth * height  >= width * mVideoHeight ) {
+                        mVisibleWidth = width;
+                        mVisibleHeight = width * mVideoHeight / mVideoWidth;
+                    } else if ( mVideoWidth * height  < width * mVideoHeight ) {
+                        mVisibleWidth = height * mVideoWidth / mVideoHeight;
+                        mVisibleHeight = height;
+                    }
                 }
                 mVisibleLeft = left + (width - mVisibleWidth) / 2;
                 mVisibleTop = top + (height - mVisibleHeight) / 2;

--- a/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxVideoView.java
+++ b/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxVideoView.java
@@ -114,8 +114,8 @@ public class Cocos2dxVideoView extends SurfaceView implements MediaPlayerControl
     protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
         // do we know view size? video is loaded already or video rect was set
         if (mVisibleWidth != 0 && mVisibleHeight != 0) {
-            setMeasuredDimension(mViewWidth, mViewHeight);
-            Log.i(TAG, "Measured: " + mViewWidth + ":" + mViewHeight);
+            setMeasuredDimension(mVisibleWidth, mVisibleHeight);
+            Log.d(TAG, "Measured: " + mVisibleWidth + ":" + mVisibleHeight);
         } else {
             // sometimes we're not fast enough. fallback
             setMeasuredDimension(mDisplayMetrics.widthPixels, mDisplayMetrics.heightPixels);

--- a/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxVideoView.java
+++ b/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxVideoView.java
@@ -26,6 +26,7 @@ import android.media.AudioManager;
 import android.media.MediaPlayer;
 import android.media.MediaPlayer.OnErrorListener;
 import android.net.Uri;
+import android.util.DisplayMetrics;
 import android.util.Log;
 import android.view.Gravity;
 import android.view.MotionEvent;
@@ -80,6 +81,8 @@ public class Cocos2dxVideoView extends SurfaceView implements MediaPlayerControl
 
     protected Cocos2dxActivity mCocos2dxActivity = null;
     
+    private DisplayMetrics mDisplayMetrics = null; 
+
     protected int mViewLeft = 0;
     protected int mViewTop = 0;
     protected int mViewWidth = 0;
@@ -99,6 +102,9 @@ public class Cocos2dxVideoView extends SurfaceView implements MediaPlayerControl
     public Cocos2dxVideoView(Cocos2dxActivity activity,int tag) {
         super(activity);
         
+        mDisplayMetrics = new DisplayMetrics();
+        activity.getWindowManager().getDefaultDisplay().getMetrics(mDisplayMetrics);
+
         mViewTag = tag;
         mCocos2dxActivity = activity;
         initVideoView();
@@ -106,15 +112,16 @@ public class Cocos2dxVideoView extends SurfaceView implements MediaPlayerControl
 
     @Override
     protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
-        if (mVideoWidth == 0 || mVideoHeight == 0) {
+        // do we know view size? video is loaded already or video rect was set
+        if (mVisibleWidth != 0 && mVisibleHeight != 0) {
             setMeasuredDimension(mViewWidth, mViewHeight);
-            Log.i(TAG, ""+mViewWidth+ ":" +mViewHeight);
-        }
-        else {
-            setMeasuredDimension(mVisibleWidth, mVisibleHeight);
-            Log.i(TAG, ""+mVisibleWidth+ ":" +mVisibleHeight);
-        }
-        
+            Log.i(TAG, "Measured: " + mViewWidth + ":" + mViewHeight);
+        } else {
+            // sometimes we're not fast enough. fallback
+            setMeasuredDimension(mDisplayMetrics.widthPixels, mDisplayMetrics.heightPixels);
+            Log.i(TAG, "Measured: " + 
+                    mDisplayMetrics.widthPixels + ":" + mDisplayMetrics.heightPixels);
+        }        
     }
     
     public void setVideoRect(int left, int top, int maxWidth, int maxHeight) {

--- a/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxVideoView.java
+++ b/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxVideoView.java
@@ -345,7 +345,7 @@ public class Cocos2dxVideoView extends SurfaceView implements MediaPlayerControl
     public void fixSize(int left, int top, int width, int height) {
         if (width != 0 && height != 0) {
             if (mKeepRatio) {
-                if ( mVideoWidth * height  > width * mVideoHeight ) {
+                if ( mVideoWidth * height  >= width * mVideoHeight ) {
                     mVisibleWidth = width;
                     mVisibleHeight = width * mVideoHeight / mVideoWidth;
                 } else if ( mVideoWidth * height  < width * mVideoHeight ) {


### PR DESCRIPTION
fixes:
- if video has same aspect ratio as android device's screen - it won't be displayed properly
- sometime video isn't visible

Second issue is race condition, if `onMeasure` is called before video is loaded or rect is sent view's size will be 0x0

Related discussion: http://discuss.cocos2d-x.org/t/videoplayer-bug-with-android/17072/6
