### PR TITLE
add disableEffect API for ui::Text

### DIFF
--- a/cocos/2d/CCLabel.h
+++ b/cocos/2d/CCLabel.h
@@ -1,7 +1,7 @@
 /****************************************************************************
  Copyright (c) 2013      Zynga Inc.
  Copyright (c) 2013-2015 Chukong Technologies Inc.
- 
+
  http://www.cocos2d-x.org
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -29,6 +29,7 @@
 #include "2d/CCSpriteBatchNode.h"
 #include "renderer/CCCustomCommand.h"
 #include "2d/CCFontAtlas.h"
+#include "base/ccTypes.h"
 
 NS_CC_BEGIN
 
@@ -50,16 +51,6 @@ enum class GlyphCollection {
     CUSTOM
 };
 
-/**
- * @brief Possible LabelEffect used by Label.
- *
- */
-enum class LabelEffect {
-    NORMAL,
-    OUTLINE,
-    SHADOW,
-    GLOW
-};
 
 /**
  * @struct TTFConfig
@@ -70,9 +61,9 @@ typedef struct _ttfConfig
     std::string fontFilePath;
     int fontSize;
 
-    GlyphCollection glyphs; 
+    GlyphCollection glyphs;
     const char *customGlyphs;
-    
+
     bool distanceFieldEnabled;
     int outlineSize;
 
@@ -94,7 +85,7 @@ typedef struct _ttfConfig
 
 /**
  * @brief Label is a subclass of SpriteBatchNode that knows how to render text labels.
- * 
+ *
  * Label can be created with:
  * - A true type font file.
  * - A bitmap font file.
@@ -123,13 +114,13 @@ public:
     */
     static Label* create();
 
-    /** 
+    /**
      * Allocates and initializes a Label, base on platform-dependent API.
      *
      * @param text The initial text.
      * @param font A font file or a font family name.
      * @param fontSize The font size. This value must be > 0.
-     * @param dimensions 
+     * @param dimensions
      * @param hAlignment The text horizontal alignment.
      * @param vAlignment The text vertical alignment.
      *
@@ -147,7 +138,7 @@ public:
     * @param text The initial text.
     * @param fontFilePath A font file.
     * @param fontSize The font size. This value must be > 0.
-    * @param dimensions 
+    * @param dimensions
     * @param hAlignment The text horizontal alignment.
     * @param vAlignment The text vertical alignment.
     *
@@ -169,7 +160,7 @@ public:
     * @see TTFConfig setTTFConfig setMaxLineWidth
     */
     static Label* createWithTTF(const TTFConfig& ttfConfig, const std::string& text, TextHAlignment hAlignment = TextHAlignment::LEFT, int maxLineWidth = 0);
-    
+
     /**
     * Allocates and initializes a Label, with a bitmap font file.
     *
@@ -177,7 +168,7 @@ public:
     * @param text The initial text.
     * @param hAlignment Text horizontal alignment.
     * @param maxLineWidth The max line width.
-    * @param imageOffset 
+    * @param imageOffset
     *
     * @return An automatically released Label object.
     * @see setBMFontFilePath setMaxLineWidth
@@ -185,7 +176,7 @@ public:
     static Label* createWithBMFont(const std::string& bmfontPath, const std::string& text,
         const TextHAlignment& hAlignment = TextHAlignment::LEFT, int maxLineWidth = 0,
         const Vec2& imageOffset = Vec2::ZERO);
-    
+
     /**
     * Allocates and initializes a Label, with char map configuration.
     *
@@ -258,7 +249,7 @@ public:
     virtual bool setCharMap(Texture2D* texture, int itemWidth, int itemHeight, int startCharMap);
 
     /**
-     * Sets a new char map configuration to Label. 
+     * Sets a new char map configuration to Label.
      *
      * @see `createWithCharMap(const std::string&)`
      */
@@ -299,12 +290,12 @@ public:
 
     int getStringLength() const;
 
-    /** 
+    /**
      * Sets the text color of Label.
      *
      * The text color is different from the color of Node.
-     * 
-     * @warning Limiting use to only when the Label created with true type font or system font. 
+     *
+     * @warning Limiting use to only when the Label created with true type font or system font.
      */
     virtual void setTextColor(const Color4B &color);
 
@@ -365,19 +356,19 @@ public:
 
     /**
      * Specify what happens when a line is too long for Label.
-     * 
+     *
      * @param breakWithoutSpace Lines are automatically broken between words if this value is false.
      */
     void setLineBreakWithoutSpace(bool breakWithoutSpace);
 
-    /** 
+    /**
      * Makes the Label at most this line untransformed width.
      * The Label's max line width be used for force line breaks if the value not equal zero.
      */
     void setMaxLineWidth(float maxLineWidth);
     float getMaxLineWidth() { return _maxLineWidth; }
 
-    /** 
+    /**
      * Makes the Label exactly this untransformed width.
      *
      * The Label's width be used for text align if the value not equal zero.
@@ -418,14 +409,14 @@ public:
      */
     void setLineHeight(float height);
 
-    /** 
+    /**
      * Returns the line height of this Label.
      * @warning Not support system font.
      * @since v3.2.0
      */
     float getLineHeight() const;
 
-    /** 
+    /**
      * Sets the additional kerning of the Label.
      *
      * @warning Not support system font.
@@ -433,7 +424,7 @@ public:
      */
     void setAdditionalKerning(float space);
 
-    /** 
+    /**
      * Returns the additional kerning of the Label.
      *
      * @warning Not support system font.
@@ -442,7 +433,7 @@ public:
     float getAdditionalKerning() const;
 
     FontAtlas* getFontAtlas() { return _fontAtlas; }
-    
+
     virtual void setBlendFunc(const BlendFunc &blendFunc) override;
 
     virtual bool isOpacityModifyRGB() const override;
@@ -522,9 +513,9 @@ protected:
     bool recordPlaceholderInfo(int spriteIndex);
 
     void setFontScale(float fontScale);
-    
+
     virtual void alignText();
-    
+
     bool computeHorizontalKernings(const std::u16string& stringToRender);
 
     void computeStringNumLines();
@@ -594,7 +585,7 @@ protected:
 
     GLuint _uniformEffectColor;
     GLuint _uniformTextColor;
-    CustomCommand _customCommand;   
+    CustomCommand _customCommand;
 
     bool    _shadowDirty;
     bool    _shadowEnabled;

--- a/cocos/base/ccTypes.h
+++ b/cocos/base/ccTypes.h
@@ -45,7 +45,7 @@ NS_CC_BEGIN
 struct Color4B;
 struct Color4F;
 
-/** 
+/**
  * RGB color composed of bytes 3 bytes.
  * @since v3.0
  */
@@ -71,7 +71,7 @@ struct CC_DLL Color3B
     GLubyte r;
     GLubyte g;
     GLubyte b;
-    
+
     static const Color3B WHITE;
     static const Color3B YELLOW;
     static const Color3B BLUE;
@@ -83,7 +83,7 @@ struct CC_DLL Color3B
     static const Color3B GRAY;
 };
 
-/** 
+/**
  * RGBA color composed of 4 bytes.
  * @since v3.0
  */
@@ -118,7 +118,7 @@ struct CC_DLL Color4B
 };
 
 
-/** 
+/**
  * RGBA color composed of 4 floats.
  * @since v3.0
  */
@@ -140,7 +140,7 @@ struct CC_DLL Color4F
     {
         return (*this == other);
     }
-    
+
     GLfloat r;
     GLfloat g;
     GLfloat b;
@@ -163,9 +163,9 @@ struct CC_DLL Color4F
 // struct Vertex2F
 // {
 //     Vertex2F(float _x, float _y) :x(_x), y(_y) {}
-    
+
 //     Vertex2F(): x(0.f), y(0.f) {}
-    
+
 //     GLfloat x;
 //     GLfloat y;
 // };
@@ -181,23 +181,23 @@ struct CC_DLL Color4F
 //         , y(_y)
 //         , z(_z)
 //     {}
-    
+
 //     Vertex3F(): x(0.f), y(0.f), z(0.f) {}
-    
+
 //     GLfloat x;
 //     GLfloat y;
 //     GLfloat z;
 // };
-        
+
 /** @struct Tex2F
  * A TEXCOORD composed of 2 floats: u, y
  * @since v3.0
  */
 struct CC_DLL Tex2F {
     Tex2F(float _u, float _v): u(_u), v(_v) {}
-    
+
     Tex2F(): u(0.f), v(0.f) {}
-    
+
     GLfloat u;
     GLfloat v;
 };
@@ -222,7 +222,7 @@ struct CC_DLL Quad2
     Vec2        bl;
     Vec2        br;
 };
-   
+
 /** @struct Quad3
  * A 3D Quad. 4 * 3 floats.
  */
@@ -307,7 +307,7 @@ struct CC_DLL V2F_C4B_T2F_Triangle
 	V2F_C4B_T2F b;
 	V2F_C4B_T2F c;
 };
- 
+
 /** @struct V2F_C4B_T2F_Quad
  * A Quad of V2F_C4B_T2F.
  */
@@ -354,7 +354,7 @@ struct CC_DLL V2F_C4F_T2F_Quad
 };
 
 /** @struct V3F_T2F_Quad
- * 
+ *
  */
 struct CC_DLL V3F_T2F_Quad
 {
@@ -451,7 +451,7 @@ struct CC_DLL AnimationFrameData
 {
     T2F_Quad texCoords;
     float delay;
-    Size size; 
+    Size size;
 };
 
 /**
@@ -464,7 +464,7 @@ struct CC_DLL AnimationFrameData
 struct CC_DLL FontShadow
 {
 public:
-    
+
     // shadow is not enabled by default
     FontShadow()
         : _shadowEnabled(false)
@@ -488,7 +488,7 @@ public:
 struct CC_DLL FontStroke
 {
 public:
-    
+
     // stroke is disabled by default
     FontStroke()
 	    : _strokeEnabled(false)
@@ -496,7 +496,7 @@ public:
         , _strokeAlpha(255)
         , _strokeSize(0)
     {}
-    
+
     /// true if stroke enabled
     bool      _strokeEnabled;
     /// stroke color
@@ -505,7 +505,7 @@ public:
     GLubyte   _strokeAlpha;
     /// stroke size
     float     _strokeSize;
-    
+
 };
 
 /** @struct FontDefinition
@@ -526,7 +526,7 @@ public:
         , _fontFillColor(Color3B::WHITE)
         , _fontAlpha(255)
     {}
-    
+
     /// font name
     std::string           _fontName;
     /// font size
@@ -545,7 +545,18 @@ public:
     FontShadow            _shadow;
     /// font stroke
     FontStroke            _stroke;
-    
+
+};
+
+/**
+ * @brief Possible LabelEffect used by Label.
+ *
+ */
+enum class LabelEffect {
+    NORMAL,
+    OUTLINE,
+    SHADOW,
+    GLOW
 };
 
 /** @struct Acceleration
@@ -558,9 +569,9 @@ public:
     double x;
     double y;
     double z;
-    
+
     double timestamp;
-    
+
     Acceleration(): x(0), y(0), z(0), timestamp(0) {}
 };
 

--- a/cocos/ui/UIText.cpp
+++ b/cocos/ui/UIText.cpp
@@ -31,7 +31,7 @@ NS_CC_BEGIN
 namespace ui {
 
 static const int LABEL_RENDERER_Z = (-1);
-    
+
 IMPLEMENT_CLASS_GUI_INFO(Text)
 
 Text::Text():
@@ -49,7 +49,7 @@ _type(Type::SYSTEM)
 
 Text::~Text()
 {
-    
+
 }
 
 Text* Text::create()
@@ -72,7 +72,7 @@ bool Text::init()
     }
     return false;
 }
-    
+
 Text* Text::create(const std::string &textContent, const std::string &fontName, int fontSize)
 {
     Text *text = new (std::nothrow) Text;
@@ -84,7 +84,7 @@ Text* Text::create(const std::string &textContent, const std::string &fontName, 
     CC_SAFE_DELETE(text);
     return nullptr;
 }
-    
+
 bool Text::init(const std::string &textContent, const std::string &fontName, int fontSize)
 {
     bool ret = true;
@@ -108,7 +108,7 @@ void Text::initRenderer()
     addProtectedChild(_labelRenderer, LABEL_RENDERER_Z, -1);
 }
 
-    
+
 void Text::setString(const std::string &text)
 {
     if (text == _labelRenderer->getString())
@@ -119,7 +119,7 @@ void Text::setString(const std::string &text)
     updateContentSizeWithTextureSize(_labelRenderer->getContentSize());
     _labelRendererAdaptDirty = true;
 }
-    
+
 const std::string& Text::getString() const
 {
     return _labelRenderer->getString();
@@ -146,7 +146,7 @@ void Text::setFontSize(int size)
     updateContentSizeWithTextureSize(_labelRenderer->getContentSize());
     _labelRendererAdaptDirty = true;
 }
-    
+
 int Text::getFontSize()const
 {
     return _fontSize;
@@ -175,12 +175,12 @@ void Text::setFontName(const std::string& name)
     updateContentSizeWithTextureSize(_labelRenderer->getContentSize());
     _labelRendererAdaptDirty = true;
 }
-    
+
 const std::string& Text::getFontName()const
 {
     return _fontName;
 }
-    
+
 Text::Type Text::getType() const
 {
     return _type;
@@ -196,7 +196,7 @@ void Text::setTextAreaSize(const Size &size)
     updateContentSizeWithTextureSize(_labelRenderer->getContentSize());
     _labelRendererAdaptDirty = true;
 }
-    
+
 const Size& Text::getTextAreaSize()const
 {
     return _labelRenderer->getDimensions();
@@ -206,7 +206,7 @@ void Text::setTextHorizontalAlignment(TextHAlignment alignment)
 {
     _labelRenderer->setHorizontalAlignment(alignment);
 }
-    
+
 TextHAlignment Text::getTextHorizontalAlignment()const
 {
     return _labelRenderer->getHorizontalAlignment();
@@ -216,17 +216,17 @@ void Text::setTextVerticalAlignment(TextVAlignment alignment)
 {
     _labelRenderer->setVerticalAlignment(alignment);
 }
-    
+
 TextVAlignment Text::getTextVerticalAlignment()const
 {
     return _labelRenderer->getVerticalAlignment();
 }
-    
+
 void Text::setTextColor(const Color4B color)
 {
     _labelRenderer->setTextColor(color);
 }
-    
+
 const Color4B& Text::getTextColor() const
 {
     return _labelRenderer->getTextColor();
@@ -236,7 +236,7 @@ void Text::setTouchScaleChangeEnabled(bool enable)
 {
     _touchScaleChangeEnabled = enable;
 }
-    
+
 bool Text::isTouchScaleChangeEnabled()const
 {
     return _touchScaleChangeEnabled;
@@ -264,7 +264,7 @@ void Text::onPressStateChangedToPressed()
 
 void Text::onPressStateChangedToDisabled()
 {
-    
+
 }
 
 void Text::onSizeChanged()
@@ -272,7 +272,7 @@ void Text::onSizeChanged()
     Widget::onSizeChanged();
     _labelRendererAdaptDirty = true;
 }
-    
+
 void Text::adaptRenderers()
 {
     if (_labelRendererAdaptDirty)
@@ -336,7 +336,7 @@ std::string Text::getDescription() const
 {
     return "Label";
 }
-    
+
 void Text::enableShadow(const Color4B& shadowColor,const Size &offset, int blurRadius)
 {
     _labelRenderer->enableShadow(shadowColor, offset, blurRadius);
@@ -346,7 +346,7 @@ void Text::enableOutline(const Color4B& outlineColor,int outlineSize)
 {
     _labelRenderer->enableOutline(outlineColor, outlineSize);
 }
-    
+
 void Text::enableGlow(const Color4B& glowColor)
 {
     if (_type == Type::TTF)
@@ -356,6 +356,11 @@ void Text::enableGlow(const Color4B& glowColor)
 void Text::disableEffect()
 {
     _labelRenderer->disableEffect();
+}
+
+void Text::disableEffect(LabelEffect effect)
+{
+    _labelRenderer->disableEffect(effect);
 }
 
 Widget* Text::createCloneInstance()

--- a/cocos/ui/UIText.h
+++ b/cocos/ui/UIText.h
@@ -27,6 +27,7 @@ THE SOFTWARE.
 
 #include "ui/UIWidget.h"
 #include "ui/GUIExport.h"
+#include "base/ccTypes.h"
 
 /**
  * @addtogroup ui
@@ -44,9 +45,9 @@ namespace ui {
  */
 class CC_GUI_DLL Text : public Widget
 {
-    
+
     DECLARE_CLASS_GUI_INFO
-    
+
 public:
     /** Type Text type.
      */
@@ -75,7 +76,7 @@ public:
      * @return An autoreleased Text object.
      */
     static Text* create();
-    
+
     /**
      *  Create a Text object with textContent, fontName and fontSize.
      *  The fontName could be a system font name or a TTF file path.
@@ -146,7 +147,7 @@ public:
      * @return Font name.
      */
     const std::string& getFontName()const;
-    
+
     /** Gets the font type.
      * @return The font type.
      */
@@ -222,19 +223,19 @@ public:
      * @return Vertical text alignment type
      */
     TextVAlignment getTextVerticalAlignment()const;
-    
+
     /** Sets text color.
      *
      * @param color Text color.
      */
     void setTextColor(const Color4B color);
-    
+
     /** Gets text color.
      *
      * @return Text color.
      */
     const Color4B& getTextColor() const;
-    
+
     /**
      * Enable shadow for the label.
      *
@@ -245,26 +246,34 @@ public:
      * @param blurRadius The blur radius of shadow effect.
      */
     void enableShadow(const Color4B& shadowColor = Color4B::BLACK,const Size &offset = Size(2,-2), int blurRadius = 0);
-    
+
     /**
      * Enable outline for the label.
      * It only works on IOS and Android when you use System fonts.
      *
      * @param outlineColor The color of outline.
      * @param outlineSize The size of outline.
-     */ 
+     */
     void enableOutline(const Color4B& outlineColor,int outlineSize = 1);
-    
+
     /** Only support for TTF.
      *
      * @param glowColor The color of glow.
      */
     void enableGlow(const Color4B& glowColor);
-    
-    /** Disable shadow/outline/glow rendering.
+
+    /** Disable all text effects, including shadow, outline and glow.
      */
     void disableEffect();
-    
+
+    /**
+     * Disable specific text effect.
+     * Use LabelEffect parameter to specify which effect should be disabled.
+     *
+     * @see `LabelEffect`
+     */
+    void disableEffect(LabelEffect effect);
+
 CC_CONSTRUCTOR_ACCESS:
     virtual bool init() override;
     virtual bool init(const std::string& textContent,
@@ -277,7 +286,7 @@ protected:
     virtual void onPressStateChangedToPressed() override;
     virtual void onPressStateChangedToDisabled() override;
     virtual void onSizeChanged() override;
-   
+
     void labelScaleChangedWithSize();
     virtual Widget* createCloneInstance() override;
     virtual void copySpecialProperties(Widget* model) override;

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UITextTest/UITextTest.cpp
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UITextTest/UITextTest.cpp
@@ -20,17 +20,21 @@ bool UITextTest::init()
     if (UIScene::init())
     {
         Size widgetSize = _widget->getContentSize();
-        
+
         Text* alert = Text::create("Text","fonts/Marker Felt.ttf", 30);
         alert->setColor(Color3B(159, 168, 176));
-        alert->setPosition(Vec2(widgetSize.width / 2.0f, widgetSize.height / 2.0f - alert->getContentSize().height * 1.75f));
-        _uiLayer->addChild(alert);        
-        
+        alert->setPosition(Vec2(widgetSize.width / 2.0f,
+                                widgetSize.height / 2.0f
+                                - alert->getContentSize().height * 1.75f));
+        _uiLayer->addChild(alert);
+
         // Create the text
         Text* text = Text::create("Text", "AmericanTypewriter", 30);
-        text->setPosition(Vec2(widgetSize.width / 2.0f, widgetSize.height / 2.0f + text->getContentSize().height / 4.0f));
+        text->setPosition(Vec2(widgetSize.width / 2.0f,
+                               widgetSize.height / 2.0f
+                               + text->getContentSize().height / 4.0f));
         _uiLayer->addChild(text);
-        
+
         return true;
     }
     return false;
@@ -43,14 +47,17 @@ bool UITextTest_LineWrap::init()
     if (UIScene::init())
     {
         Size widgetSize = _widget->getContentSize();
-        
+
         Text* alert = Text::create("Text line wrap","fonts/Marker Felt.ttf",30);
         alert->setColor(Color3B(159, 168, 176));
-        alert->setPosition(Vec2(widgetSize.width / 2.0f, widgetSize.height / 2.0f - alert->getContentSize().height * 1.75f));
+        alert->setPosition(Vec2(widgetSize.width / 2.0f,
+                                widgetSize.height / 2.0f
+                                - alert->getContentSize().height * 1.75f));
         _uiLayer->addChild(alert);
-        
+
         // Create the line wrap
-        Text* text = Text::create("TextArea Widget can line wrap","AmericanTypewriter",32);
+        Text* text = Text::create("TextArea Widget can line wrap",
+                                  "AmericanTypewriter",32);
         text->ignoreContentAdaptWithSize(false);
         text->setContentSize(Size(280, 150));
         text->setTextHorizontalAlignment(TextHAlignment::CENTER);
@@ -69,9 +76,11 @@ bool UITextTest_LineWrap::init()
                 }
             }
         });
-        text->setPosition(Vec2(widgetSize.width / 2.0f, widgetSize.height / 2.0f - text->getContentSize().height / 8.0f));
+        text->setPosition(Vec2(widgetSize.width / 2.0f,
+                               widgetSize.height / 2.0f
+                               - text->getContentSize().height / 8.0f));
         _uiLayer->addChild(text);
-        
+
         return true;
     }
     return false;
@@ -85,48 +94,87 @@ bool UILabelTest_Effect::init()
     if (UIScene::init())
     {
         Size widgetSize = _widget->getContentSize();
-        
+
         Text* alert = Text::create();
         alert->setString("Label Effect");
         alert->setFontName("fonts/Marker Felt.ttf");
         alert->setFontSize(30);
         alert->setColor(Color3B(159, 168, 176));
-        alert->setPosition(Vec2(widgetSize.width / 2.0f, widgetSize.height / 2.0f - alert->getContentSize().height * 3.05f));
+        alert->setPosition(Vec2(widgetSize.width / 2.0f,
+                                widgetSize.height / 2.0f
+                                - alert->getContentSize().height * 3.05f));
         _uiLayer->addChild(alert);
-        
-        
+
+
         // create the shadow only label
         Text* shadow_label = Text::create();
-        
+
         shadow_label->enableShadow();
         shadow_label->setString("Shadow");
-        shadow_label->setPosition(Vec2(widgetSize.width / 2.0f, widgetSize.height / 2.0f + shadow_label->getContentSize().height));
-        
+        shadow_label->setFontName("fonts/Marker Felt.ttf");
+        shadow_label->setPosition(Vec2(widgetSize.width / 2.0f,
+                                       widgetSize.height / 2.0f
+                                      + shadow_label->getContentSize().height + 20));
+
         _uiLayer->addChild(shadow_label);
-        
-        
+
+
         // create the stroke only label
         Text* glow_label = Text::create();
         glow_label->setFontName("fonts/Marker Felt.ttf");
-
         glow_label->setString("Glow");
         glow_label->enableGlow(Color4B::RED);
 
-        
-        glow_label->setPosition(Vec2(widgetSize.width / 2.0f, widgetSize.height / 2.0f));
-        
+
+        glow_label->setPosition(Vec2(widgetSize.width / 2.0f,
+                                     widgetSize.height / 2.0f - 20));
+
         _uiLayer->addChild(glow_label);
-        
-        
+
+
         // create the label stroke and shadow
         Text* outline_label = Text::create();
-        outline_label->enableOutline(Color4B::BLUE, 2);
+        outline_label->enableOutline(Color4B::GREEN, 4);
         outline_label->setString("Outline");
-        outline_label->setPosition(Vec2(widgetSize.width / 2.0f, widgetSize.height / 2.0f - shadow_label->getContentSize().height));
-        
+        outline_label->setPosition(Vec2(widgetSize.width / 2.0f,
+                                        widgetSize.height / 2.0f
+                                      - shadow_label->getContentSize().height - 50));
+
         _uiLayer->addChild(outline_label);
-        
-        
+
+        //create buttons to disable effect and add
+        auto disableOutlineBtn= Button::create();
+        disableOutlineBtn->setTitleText("Disable outline");
+        disableOutlineBtn->setTitleFontName("fonts/Marker Felt.ttf");
+        disableOutlineBtn->setPosition(Vec2(widgetSize.width * 0.3,
+                                 widgetSize.height * 0.7));
+        disableOutlineBtn->setPressedActionEnabled(true);
+        disableOutlineBtn->addClickEventListener([=](Ref*){
+            outline_label->disableEffect(LabelEffect::OUTLINE);
+        });
+        this->addChild(disableOutlineBtn);
+
+        auto buttonWidth = disableOutlineBtn->getContentSize().width;
+
+        auto disableGlowBtn = (Button*)disableOutlineBtn->clone();
+        disableGlowBtn->setPosition(disableOutlineBtn->getPosition()
+                                    + Vec2(buttonWidth + 40,0));
+        disableGlowBtn->setTitleText("Disable Glow");
+        disableGlowBtn->addClickEventListener([=](Ref*){
+            glow_label->disableEffect(LabelEffect::GLOW);
+        });
+        this->addChild(disableGlowBtn);
+
+        auto disableShadowBtn = (Button*)disableGlowBtn->clone();
+        disableShadowBtn->setPosition(disableGlowBtn->getPosition()
+                                      + Vec2(buttonWidth + 40,0));
+        disableShadowBtn->setTitleText("Disable Shadow");
+        disableShadowBtn->addClickEventListener([=](Ref*){
+            shadow_label->disableEffect(LabelEffect::SHADOW);
+        });
+        this->addChild(disableShadowBtn);
+
+
         return true;
     }
     return false;
@@ -140,17 +188,22 @@ bool UITextTest_TTF::init()
     if (UIScene::init())
     {
         Size widgetSize = _widget->getContentSize();
-        
-        Text* alert = Text::create("Text set TTF font","fonts/Marker Felt.ttf",30);
+
+        Text* alert = Text::create("Text set TTF font",
+                                   "fonts/Marker Felt.ttf",30);
         alert->setColor(Color3B(159, 168, 176));
-        alert->setPosition(Vec2(widgetSize.width / 2.0f, widgetSize.height / 2.0f - alert->getContentSize().height * 1.75f));
+        alert->setPosition(Vec2(widgetSize.width / 2.0f,
+                                widgetSize.height / 2.0f
+                                - alert->getContentSize().height * 1.75f));
         _uiLayer->addChild(alert);
-        
+
         // Create the text, and set font with .ttf
         Text* text = Text::create("Text","fonts/A Damn Mess.ttf",30);
-        text->setPosition(Vec2(widgetSize.width / 2.0f, widgetSize.height / 2.0f + text->getContentSize().height / 4.0f));
+        text->setPosition(Vec2(widgetSize.width / 2.0f,
+                               widgetSize.height / 2.0f
+                               + text->getContentSize().height / 4.0f));
         _uiLayer->addChild(text);
-        
+
         return true;
     }
     return false;
@@ -163,30 +216,32 @@ bool UITextTest_IgnoreConentSize::init()
     if (UIScene::init())
     {
         Size widgetSize = _widget->getContentSize();
-        
+
         Text* leftText = Text::create("ignore conent",
                                    "fonts/Marker Felt.ttf",10);
         leftText->setPosition(Vec2(widgetSize.width / 2.0f - 50,
                                 widgetSize.height / 2.0f));
         leftText->ignoreContentAdaptWithSize(false);
         leftText->setTextAreaSize(Size(60,60));
-        leftText->setString("Text line with break\nText line with break\nText line with break\nText line with break\n");
+        leftText->setString("Text line with break\nText line \
+                   with break\nText line with break\nText line with break\n");
         leftText->setTouchScaleChangeEnabled(true);
         leftText->setTouchEnabled(true);
         _uiLayer->addChild(leftText);
-        
-        
+
+
         Text* rightText = Text::create("ignore conent",
                                       "fonts/Marker Felt.ttf",10);
         rightText->setPosition(Vec2(widgetSize.width / 2.0f + 50,
                                    widgetSize.height / 2.0f));
-        rightText->setString("Text line with break\nText line with break\nText line with break\nText line with break\n");
-        //note: setTextAreaSize must be used with ignoreContentAdaptWithSize(false)
+        rightText->setString("Text line with break\nText line  \
+                    with break\nText line with break\nText line with break\n");
+        //note:setTextAreaSize must be used with ignoreContentAdaptWithSize(false)
         rightText->setTextAreaSize(Size(100,30));
         rightText->ignoreContentAdaptWithSize(false);
         _uiLayer->addChild(rightText);
-        
-        
+
+
         auto halighButton = Button::create();
         halighButton->setTitleText("Alignment Right");
         halighButton->addClickEventListener([=](Ref*){
@@ -196,8 +251,9 @@ bool UITextTest_IgnoreConentSize::init()
         halighButton->setPosition(Vec2(widgetSize.width/2 - 50,
                                        widgetSize.height/2 - 50));
         _uiLayer->addChild(halighButton);
-        
-        
+
+
+
         return true;
     }
     return false;


### PR DESCRIPTION
In this PR, it also deletes all the the empty space in source code.
In some  languages, like Python, the extra white space would consider to be a warning according to PEP8.
