### PR TITLE
added 'cocos2d' namespace for macros

### DIFF
--- a/cocos/base/ccMacros.h
+++ b/cocos/base/ccMacros.h
@@ -260,7 +260,7 @@ It should work same as apples CFSwapInt32LittleToHost(..)
 #define CC_INCREMENT_GL_DRAWS(__n__) Director::getInstance()->getRenderer()->addDrawnBatches(__n__)
 #define CC_INCREMENT_GL_DRAWN_BATCHES_AND_VERTICES(__drawcalls__, __vertices__) \
     do {                                                                \
-        auto __renderer__ = Director::getInstance()->getRenderer();     \
+        auto __renderer__ = cocos2d::Director::getInstance()->getRenderer();     \
         __renderer__->addDrawnBatches(__drawcalls__);                   \
         __renderer__->addDrawnVertices(__vertices__);                   \
     } while(0)

--- a/cocos/base/ccMacros.h
+++ b/cocos/base/ccMacros.h
@@ -124,7 +124,7 @@ do { \
   */
 #define CC_DIRECTOR_END()                                       \
 do {                                                            \
-    Director *__director = Director::getInstance();             \
+    Director *__director = cocos2d::Director::getInstance();             \
     __director->end();                                          \
 } while(0)
 
@@ -132,7 +132,7 @@ do {                                                            \
 On Mac it returns 1;
 On iPhone it returns 2 if RetinaDisplay is On. Otherwise it returns 1
 */
-#define CC_CONTENT_SCALE_FACTOR() Director::getInstance()->getContentScaleFactor()
+#define CC_CONTENT_SCALE_FACTOR() cocos2d::Director::getInstance()->getContentScaleFactor()
 
 /****************************/
 /** RETINA DISPLAY ENABLED **/
@@ -257,7 +257,7 @@ It should work same as apples CFSwapInt32LittleToHost(..)
  Increments the GL Draws counts by one.
  The number of calls per frame are displayed on the screen when the Director's stats are enabled.
  */
-#define CC_INCREMENT_GL_DRAWS(__n__) Director::getInstance()->getRenderer()->addDrawnBatches(__n__)
+#define CC_INCREMENT_GL_DRAWS(__n__) cocos2d::Director::getInstance()->getRenderer()->addDrawnBatches(__n__)
 #define CC_INCREMENT_GL_DRAWN_BATCHES_AND_VERTICES(__drawcalls__, __vertices__) \
     do {                                                                \
         auto __renderer__ = cocos2d::Director::getInstance()->getRenderer();     \


### PR DESCRIPTION
this change allows the macros to be called from outside of the cocos2d namespace.
