### PR TITLE
Implement Rect::intersectsCircle

### DIFF
--- a/cocos/math/CCGeometry.cpp
+++ b/cocos/math/CCGeometry.cpp
@@ -188,6 +188,40 @@ bool Rect::intersectsRect(const Rect& rect) const
              rect.getMaxY() <      getMinY());
 }
 
+bool Rect::intersectsCircle(const cocos2d::Vec2 &center, float radius) const
+{
+    Vec2 rectangleCenter((origin.x + size.width / 2),
+                         (origin.y + size.height / 2));
+    
+    float w = size.width / 2;
+    float h = size.height / 2;
+    
+    float dx = fabs(center.x - rectangleCenter.x);
+    float dy = fabs(center.y - rectangleCenter.y);
+    
+    if (dx > (radius + w) || dy > (radius + h))
+    {
+        return false;
+    }
+    
+    Vec2 circleDistance(fabs(center.x - origin.x - w),
+                        fabs(center.y - origin.y - h));
+    
+    if (circleDistance.x <= (w))
+    {
+        return true;
+    }
+    
+    if (circleDistance.y <= (h))
+    {
+        return true;
+    }
+    
+    float cornerDistanceSq = powf(circleDistance.x - w, 2) + powf(circleDistance.y - h, 2);
+    
+    return (cornerDistanceSq <= (powf(radius, 2)));
+}
+
 void Rect::merge(const Rect& rect)
 {
     float top1    = getMaxY();

--- a/cocos/math/CCGeometry.h
+++ b/cocos/math/CCGeometry.h
@@ -196,6 +196,11 @@ public:
      */
     bool intersectsRect(const Rect& rect) const;
     /**
+    Check the intersect status of the rect and a circle.
+     * @js NA
+     */
+    bool intersectsCircle(const Vec2& center, float radius) const;
+    /**
     Get the min rect which can contain this and rect.
      * @js NA
      * @lua NA


### PR DESCRIPTION
I implement Rect::intersectsCircle.

This method makes enable to check the intersect status between the rect and a circle.

``` cpp
cocos2d::Rect rect = Rect(0, 0, 100, 100);
cocos2d::Vec2 center = Vec2(20, 20);
float radius = 10;
rect.intersectsCircle(center, radius); // => true
```
