### PR TITLE
Update CCLabel.cpp

### DIFF
--- a/cocos/2d/CCLabel.cpp
+++ b/cocos/2d/CCLabel.cpp
@@ -871,7 +871,7 @@ void Label::setFontScale(float fontScale)
 void Label::onDraw(const Mat4& transform, bool transformUpdated)
 {
     // Optimization: Fast Dispatch
-    if( _batchNodes.size() == 1 && _textureAtlas->getTotalQuads() == 0 )
+    if( _textureAtlas == NULL || (_batchNodes.size() == 1 && _textureAtlas->getTotalQuads() == 0) )
     {
         return;
     }


### PR DESCRIPTION
in rare case, the texture atlas becomes NULL. Added an additional check to make sure it won't crash here.
