### PR TITLE
optimize memory usage of ui::Button

### DIFF
--- a/cocos/ui/UIButton.cpp
+++ b/cocos/ui/UIButton.cpp
@@ -845,15 +845,22 @@ Label* Button::getTitleRenderer()const
     return _titleRenderer;
 }
 
-const std::string& Button::getTitleFontName() const
+const std::string Button::getTitleFontName() const
 {
-    if(this->_type == FontType::SYSTEM)
+    if (nullptr != _titleRenderer)
     {
-        return _titleRenderer->getSystemFontName();
+        if(this->_type == FontType::SYSTEM)
+        {
+            return _titleRenderer->getSystemFontName();
+        }
+        else
+        {
+            return  _titleRenderer->getTTFConfig().fontFilePath;
+        }
     }
     else
     {
-        return  _titleRenderer->getTTFConfig().fontFilePath;
+        return "";
     }
 }
 
@@ -874,9 +881,21 @@ void Button::copySpecialProperties(Widget *widget)
     {
         _prevIgnoreSize = button->_prevIgnoreSize;
         setScale9Enabled(button->_scale9Enabled);
-        loadTextureNormal(button->_buttonNormalRenderer->getSprite()->getSpriteFrame());
-        loadTexturePressed(button->_buttonClickedRenderer->getSprite()->getSpriteFrame());
-        loadTextureDisabled(button->_buttonDisableRenderer->getSprite()->getSpriteFrame());
+        auto normalSprite = button->_buttonNormalRenderer->getSprite();
+        if (nullptr != normalSprite)
+        {
+            loadTextureNormal(normalSprite->getSpriteFrame());
+        }
+        auto clickedSprite = button->_buttonClickedRenderer->getSprite();
+        if (nullptr != clickedSprite)
+        {
+            loadTexturePressed(clickedSprite->getSpriteFrame());
+        }
+        auto disabledSprite = button->_buttonDisableRenderer->getSprite();
+        if (nullptr != disabledSprite)
+        {
+            loadTextureDisabled(disabledSprite->getSpriteFrame());
+        }
         setCapInsetsNormalRenderer(button->_capInsetsNormal);
         setCapInsetsPressedRenderer(button->_capInsetsPressed);
         setCapInsetsDisabledRenderer(button->_capInsetsDisabled);

--- a/cocos/ui/UIButton.cpp
+++ b/cocos/ui/UIButton.cpp
@@ -39,30 +39,24 @@ static const int PRESSED_RENDERER_Z = (-2);
 static const int DISABLED_RENDERER_Z = (-2);
 static const int TITLE_RENDERER_Z = (-1);
 static const float ZOOM_ACTION_TIME_STEP = 0.05f;
-    
+
 IMPLEMENT_CLASS_GUI_INFO(Button)
-    
+
 Button::Button():
 _buttonNormalRenderer(nullptr),
 _buttonClickedRenderer(nullptr),
 _buttonDisableRenderer(nullptr),
 _titleRenderer(nullptr),
 _zoomScale(0.1f),
-_normalFileName(""),
-_clickedFileName(""),
-_disabledFileName(""),
 _prevIgnoreSize(true),
 _scale9Enabled(false),
+_pressedActionEnabled(false),
 _capInsetsNormal(Rect::ZERO),
 _capInsetsPressed(Rect::ZERO),
 _capInsetsDisabled(Rect::ZERO),
-_normalTexType(TextureResType::LOCAL),
-_pressedTexType(TextureResType::LOCAL),
-_disabledTexType(TextureResType::LOCAL),
 _normalTextureSize(_contentSize),
 _pressedTextureSize(_contentSize),
 _disabledTextureSize(_contentSize),
-_pressedActionEnabled(false),
 _normalTextureScaleXInSize(1.0f),
 _normalTextureScaleYInSize(1.0f),
 _pressedTextureScaleXInSize(1.0f),
@@ -73,7 +67,6 @@ _disabledTextureLoaded(false),
 _normalTextureAdaptDirty(true),
 _pressedTextureAdaptDirty(true),
 _disabledTextureAdaptDirty(true),
-_fontName("Thonburi"),
 _fontSize(10),
 _type(FontType::SYSTEM)
 {
@@ -95,7 +88,7 @@ Button* Button::create()
     CC_SAFE_DELETE(widget);
     return nullptr;
 }
-    
+
 Button* Button::create(const std::string &normalImage,
                        const std::string& selectedImage ,
                        const std::string& disableImage,
@@ -110,7 +103,7 @@ Button* Button::create(const std::string &normalImage,
     CC_SAFE_DELETE(btn);
     return nullptr;
 }
-    
+
 bool Button::init(const std::string &normalImage,
                   const std::string& selectedImage ,
                   const std::string& disableImage,
@@ -124,7 +117,7 @@ bool Button::init(const std::string &normalImage,
             ret = false;
             break;
         }
-        
+
         this->loadTextures(normalImage, selectedImage, disableImage,texType);
     } while (0);
     return ret;
@@ -147,13 +140,16 @@ void Button::initRenderer()
     _buttonClickedRenderer->setScale9Enabled(false);
     _buttonNormalRenderer->setScale9Enabled(false);
     _buttonDisableRenderer->setScale9Enabled(false);
-    
-    _titleRenderer = Label::create();
-    _titleRenderer->setAnchorPoint(Vec2::ANCHOR_MIDDLE);
 
     addProtectedChild(_buttonNormalRenderer, NORMAL_RENDERER_Z, -1);
     addProtectedChild(_buttonClickedRenderer, PRESSED_RENDERER_Z, -1);
     addProtectedChild(_buttonDisableRenderer, DISABLED_RENDERER_Z, -1);
+}
+
+void Button::createTitleRenderer()
+{
+    _titleRenderer = Label::create();
+    _titleRenderer->setAnchorPoint(Vec2::ANCHOR_MIDDLE);
     addProtectedChild(_titleRenderer, TITLE_RENDERER_Z, -1);
 }
 
@@ -163,13 +159,13 @@ void Button::setScale9Enabled(bool able)
     {
         return;
     }
-    
+
     _scale9Enabled = able;
-    
+
     _buttonNormalRenderer->setScale9Enabled(_scale9Enabled);
     _buttonClickedRenderer->setScale9Enabled(_scale9Enabled);
     _buttonDisableRenderer->setScale9Enabled(_scale9Enabled);
-   
+
     if (_scale9Enabled)
     {
         bool ignoreBefore = _ignoreSize;
@@ -180,11 +176,11 @@ void Button::setScale9Enabled(bool able)
     {
         ignoreContentAdaptWithSize(_prevIgnoreSize);
     }
-    
+
     setCapInsetsNormalRenderer(_capInsetsNormal);
     setCapInsetsPressedRenderer(_capInsetsPressed);
     setCapInsetsDisabledRenderer(_capInsetsDisabled);
-    
+
     _brightStyle = BrightStyle::NONE;
     setBright(_bright);
 
@@ -205,7 +201,7 @@ void Button::ignoreContentAdaptWithSize(bool ignore)
         this->updateContentSize();
         return;
     }
-    
+
     if (!_scale9Enabled || (_scale9Enabled && !ignore))
     {
         Widget::ignoreContentAdaptWithSize(ignore);
@@ -225,14 +221,11 @@ void Button::loadTextures(const std::string& normal,
 
 void Button::loadTextureNormal(const std::string& normal,TextureResType texType)
 {
-    if (normal.empty() || (_normalFileName == normal && _normalTexType == texType))
+    if(normal.empty())
     {
         return;
     }
-    _normalFileName = normal;
-    _normalTexType = texType;
-    
-    switch (_normalTexType)
+    switch (texType)
     {
         case TextureResType::LOCAL:
             _buttonNormalRenderer->initWithFile(normal);
@@ -243,11 +236,16 @@ void Button::loadTextureNormal(const std::string& normal,TextureResType texType)
         default:
             break;
     }
-    
+    this->setupNormalTexture();
+
+}
+
+void Button::setupNormalTexture()
+{
     _normalTextureSize = _buttonNormalRenderer->getContentSize();
-   
+
     this->updateChildrenDisplayedRGBA();
-    
+
     if (_unifySize )
     {
         if (!_scale9Enabled)
@@ -263,16 +261,20 @@ void Button::loadTextureNormal(const std::string& normal,TextureResType texType)
     _normalTextureAdaptDirty = true;
 }
 
+void Button::loadTextureNormal(SpriteFrame* normalSpriteFrame)
+{
+    _buttonNormalRenderer->initWithSpriteFrame(normalSpriteFrame);
+    this->setupNormalTexture();
+}
+
 void Button::loadTexturePressed(const std::string& selected,TextureResType texType)
 {
-    if (selected.empty() || (_clickedFileName == selected && _pressedTexType == texType))
+    if (selected.empty())
     {
         return;
     }
-    _clickedFileName = selected;
-    _pressedTexType = texType;
 
-    switch (_pressedTexType)
+    switch (texType)
     {
         case TextureResType::LOCAL:
             _buttonClickedRenderer->initWithFile(selected);
@@ -283,25 +285,34 @@ void Button::loadTexturePressed(const std::string& selected,TextureResType texTy
         default:
             break;
     }
-    
+
+    this->setupPressedTexture();
+}
+
+void Button::setupPressedTexture()
+{
     _pressedTextureSize = _buttonClickedRenderer->getContentSize();
-  
+
     this->updateChildrenDisplayedRGBA();
 
     _pressedTextureLoaded = true;
     _pressedTextureAdaptDirty = true;
 }
 
+void Button::loadTexturePressed(SpriteFrame* pressedSpriteFrame)
+{
+    _buttonClickedRenderer->initWithSpriteFrame(pressedSpriteFrame);
+    this->setupPressedTexture();
+}
+
 void Button::loadTextureDisabled(const std::string& disabled,TextureResType texType)
 {
-    if (disabled.empty() || (_disabledFileName == disabled && _disabledTexType == texType))
+    if (disabled.empty())
     {
         return;
     }
-    _disabledFileName = disabled;
-    _disabledTexType = texType;
 
-    switch (_disabledTexType)
+    switch (texType)
     {
         case TextureResType::LOCAL:
             _buttonDisableRenderer->initWithFile(disabled);
@@ -312,13 +323,23 @@ void Button::loadTextureDisabled(const std::string& disabled,TextureResType texT
         default:
             break;
     }
+    this->setupDisabledTexture();
+}
 
+void Button::setupDisabledTexture()
+{
     _disabledTextureSize = _buttonDisableRenderer->getContentSize();
-   
+
     this->updateChildrenDisplayedRGBA();
 
     _disabledTextureLoaded = true;
     _disabledTextureAdaptDirty = true;
+}
+
+void Button::loadTextureDisabled(SpriteFrame* disabledSpriteFrame)
+{
+    _buttonDisableRenderer->initWithSpriteFrame(disabledSpriteFrame);
+    this->setupDisabledTexture();
 }
 
 void Button::setCapInsets(const Rect &capInsets)
@@ -329,11 +350,10 @@ void Button::setCapInsets(const Rect &capInsets)
 }
 
 
-
 void Button::setCapInsetsNormalRenderer(const Rect &capInsets)
 {
     _capInsetsNormal = Helper::restrictCapInsetRect(capInsets, this->_normalTextureSize);
-    
+
     //for performance issue
     if (!_scale9Enabled)
     {
@@ -345,7 +365,7 @@ void Button::setCapInsetsNormalRenderer(const Rect &capInsets)
 void Button::setCapInsetsPressedRenderer(const Rect &capInsets)
 {
     _capInsetsPressed = Helper::restrictCapInsetRect(capInsets, this->_pressedTextureSize);
-    
+
     //for performance issue
     if (!_scale9Enabled)
     {
@@ -357,7 +377,7 @@ void Button::setCapInsetsPressedRenderer(const Rect &capInsets)
 void Button::setCapInsetsDisabledRenderer(const Rect &capInsets)
 {
     _capInsetsDisabled = Helper::restrictCapInsetRect(capInsets, this->_disabledTextureSize);
-    
+
     //for performance issue
     if (!_scale9Enabled)
     {
@@ -370,12 +390,12 @@ const Rect& Button::getCapInsetsNormalRenderer()const
 {
     return _capInsetsNormal;
 }
-    
+
 const Rect& Button::getCapInsetsPressedRenderer()const
 {
     return _capInsetsPressed;
 }
-    
+
 const Rect& Button::getCapInsetsDisabledRenderer()const
 {
     return _capInsetsDisabled;
@@ -387,29 +407,32 @@ void Button::onPressStateChangedToNormal()
     _buttonClickedRenderer->setVisible(false);
     _buttonDisableRenderer->setVisible(false);
     _buttonNormalRenderer->setState(Scale9Sprite::State::NORMAL);
-    
+
     if (_pressedTextureLoaded)
     {
         if (_pressedActionEnabled)
         {
             _buttonNormalRenderer->stopAllActions();
             _buttonClickedRenderer->stopAllActions();
-            
+
 //            Action *zoomAction = ScaleTo::create(ZOOM_ACTION_TIME_STEP, _normalTextureScaleXInSize, _normalTextureScaleYInSize);
             //fixme: the zoomAction will run in the next frame which will cause the _buttonNormalRenderer to a wrong scale
             _buttonNormalRenderer->setScale(_normalTextureScaleXInSize, _normalTextureScaleYInSize);
             _buttonClickedRenderer->setScale(_pressedTextureScaleXInSize, _pressedTextureScaleYInSize);
-            
-            _titleRenderer->stopAllActions();
-            if (_unifySize)
+
+            if(nullptr != _titleRenderer)
             {
-                Action *zoomTitleAction = ScaleTo::create(ZOOM_ACTION_TIME_STEP, 1.0f, 1.0f);
-                _titleRenderer->runAction(zoomTitleAction);
-            }
-            else
-            {
-                _titleRenderer->setScaleX(1.0f);
-                _titleRenderer->setScaleY(1.0f);
+                _titleRenderer->stopAllActions();
+                if (_unifySize)
+                {
+                    Action *zoomTitleAction = ScaleTo::create(ZOOM_ACTION_TIME_STEP, 1.0f, 1.0f);
+                    _titleRenderer->runAction(zoomTitleAction);
+                }
+                else
+                {
+                    _titleRenderer->setScaleX(1.0f);
+                    _titleRenderer->setScaleY(1.0f);
+                }
             }
         }
     }
@@ -417,41 +440,47 @@ void Button::onPressStateChangedToNormal()
     {
         _buttonNormalRenderer->stopAllActions();
         _buttonNormalRenderer->setScale(_normalTextureScaleXInSize, _normalTextureScaleYInSize);
-        
-        _titleRenderer->stopAllActions();
-        
-        _titleRenderer->setScaleX(1.0f);
-        _titleRenderer->setScaleY(1.0f);
-     
+
+        if(nullptr != _titleRenderer)
+        {
+            _titleRenderer->stopAllActions();
+            _titleRenderer->setScaleX(1.0f);
+            _titleRenderer->setScaleY(1.0f);
+        }
+
     }
 }
 
 void Button::onPressStateChangedToPressed()
 {
     _buttonNormalRenderer->setState(Scale9Sprite::State::NORMAL);
-    
+
     if (_pressedTextureLoaded)
     {
         _buttonNormalRenderer->setVisible(false);
         _buttonClickedRenderer->setVisible(true);
         _buttonDisableRenderer->setVisible(false);
-        
+
         if (_pressedActionEnabled)
         {
             _buttonNormalRenderer->stopAllActions();
             _buttonClickedRenderer->stopAllActions();
-            
+
             Action *zoomAction = ScaleTo::create(ZOOM_ACTION_TIME_STEP,
                                                  _pressedTextureScaleXInSize + _zoomScale,
                                                  _pressedTextureScaleYInSize + _zoomScale);
             _buttonClickedRenderer->runAction(zoomAction);
-            
-            _buttonNormalRenderer->setScale(_pressedTextureScaleXInSize + _zoomScale, _pressedTextureScaleYInSize + _zoomScale);
-            
-            _titleRenderer->stopAllActions();
-            
-            Action *zoomTitleAction = ScaleTo::create(ZOOM_ACTION_TIME_STEP, 1.0f + _zoomScale, 1.0f + _zoomScale);
-            _titleRenderer->runAction(zoomTitleAction);
+
+            _buttonNormalRenderer->setScale(_pressedTextureScaleXInSize + _zoomScale,
+                                            _pressedTextureScaleYInSize + _zoomScale);
+
+            if(nullptr != _titleRenderer)
+            {
+                _titleRenderer->stopAllActions();
+                Action *zoomTitleAction = ScaleTo::create(ZOOM_ACTION_TIME_STEP,
+                                                          1.0f + _zoomScale, 1.0f + _zoomScale);
+                _titleRenderer->runAction(zoomTitleAction);
+            }
         }
     }
     else
@@ -459,14 +488,16 @@ void Button::onPressStateChangedToPressed()
         _buttonNormalRenderer->setVisible(true);
         _buttonClickedRenderer->setVisible(true);
         _buttonDisableRenderer->setVisible(false);
-        
+
         _buttonNormalRenderer->stopAllActions();
         _buttonNormalRenderer->setScale(_normalTextureScaleXInSize +_zoomScale, _normalTextureScaleYInSize + _zoomScale);
-        
-        _titleRenderer->stopAllActions();
-        
-        _titleRenderer->setScaleX(1.0f + _zoomScale);
-        _titleRenderer->setScaleY(1.0f + _zoomScale);
+
+        if(nullptr != _titleRenderer)
+        {
+            _titleRenderer->stopAllActions();
+            _titleRenderer->setScaleX(1.0f + _zoomScale);
+            _titleRenderer->setScaleY(1.0f + _zoomScale);
+        }
     }
 }
 
@@ -485,12 +516,12 @@ void Button::onPressStateChangedToDisabled()
         _buttonNormalRenderer->setVisible(false);
         _buttonDisableRenderer->setVisible(true);
     }
-    
+
     _buttonClickedRenderer->setVisible(false);
     _buttonNormalRenderer->setScale(_normalTextureScaleXInSize, _normalTextureScaleYInSize);
     _buttonClickedRenderer->setScale(_pressedTextureScaleXInSize, _pressedTextureScaleYInSize);
 }
-    
+
 void Button::updateTitleLocation()
 {
     _titleRenderer->setPosition(_contentSize.width * 0.5f, _contentSize.height * 0.5f);
@@ -512,7 +543,7 @@ void Button::updateContentSize()
         onSizeChanged();
         return;
     }
-    
+
     if (_ignoreSize)
     {
         this->setContentSize(getVirtualRendererSize());
@@ -522,12 +553,15 @@ void Button::updateContentSize()
 void Button::onSizeChanged()
 {
     Widget::onSizeChanged();
-    updateTitleLocation();
+    if(nullptr != _titleRenderer)
+    {
+        updateTitleLocation();
+    }
     _normalTextureAdaptDirty = true;
     _pressedTextureAdaptDirty = true;
     _disabledTextureAdaptDirty = true;
 }
-    
+
 void Button::adaptRenderers()
 {
     if (_normalTextureAdaptDirty)
@@ -535,13 +569,13 @@ void Button::adaptRenderers()
         normalTextureScaleChangedWithSize();
         _normalTextureAdaptDirty = false;
     }
-    
+
     if (_pressedTextureAdaptDirty)
     {
         pressedTextureScaleChangedWithSize();
         _pressedTextureAdaptDirty = false;
     }
-    
+
     if (_disabledTextureAdaptDirty)
     {
         disabledTextureScaleChangedWithSize();
@@ -555,11 +589,14 @@ Size Button::getVirtualRendererSize() const
     {
         return this->getNormalSize();
     }
-    
-    Size titleSize = _titleRenderer->getContentSize();
-    if (!_normalTextureLoaded && _titleRenderer->getString().size() > 0)
+
+    if(nullptr != _titleRenderer)
     {
-        return titleSize;
+        Size titleSize = _titleRenderer->getContentSize();
+        if (!_normalTextureLoaded && _titleRenderer->getString().size() > 0)
+        {
+            return titleSize;
+        }
     }
     return _normalTextureSize;
 }
@@ -706,27 +743,47 @@ void Button::setTitleText(const std::string& text)
     {
         return;
     }
+    if(nullptr == _titleRenderer)
+    {
+        this->createTitleRenderer();
+    }
     _titleRenderer->setString(text);
     updateContentSize();
 }
 
-const std::string& Button::getTitleText() const
+const std::string Button::getTitleText() const
 {
+    if(nullptr == _titleRenderer)
+    {
+        return "";
+    }
     return _titleRenderer->getString();
 }
 
 void Button::setTitleColor(const Color3B& color)
 {
+    if(nullptr == _titleRenderer)
+    {
+        this->createTitleRenderer();
+    }
     _titleRenderer->setTextColor(Color4B(color));
 }
 
 Color3B Button::getTitleColor() const
 {
+    if(nullptr == _titleRenderer)
+    {
+        return Color3B::WHITE;
+    }
     return Color3B(_titleRenderer->getTextColor());
 }
 
 void Button::setTitleFontSize(float size)
 {
+    if(nullptr == _titleRenderer)
+    {
+        this->createTitleRenderer();
+    }
     if (_type == FontType::SYSTEM)
     {
         _titleRenderer->setSystemFontSize(size);
@@ -745,12 +802,12 @@ float Button::getTitleFontSize() const
 {
     return _fontSize;
 }
-    
+
 void Button::setZoomScale(float scale)
 {
     _zoomScale = scale;
 }
-    
+
 float Button::getZoomScale()const
 {
     return _zoomScale;
@@ -758,6 +815,10 @@ float Button::getZoomScale()const
 
 void Button::setTitleFontName(const std::string& fontName)
 {
+    if(nullptr == _titleRenderer)
+    {
+        this->createTitleRenderer();
+    }
     if(FileUtils::getInstance()->isFileExist(fontName))
     {
         TTFConfig config = _titleRenderer->getTTFConfig();
@@ -776,10 +837,9 @@ void Button::setTitleFontName(const std::string& fontName)
         _titleRenderer->setSystemFontSize(_fontSize);
         _type = FontType::SYSTEM;
     }
-    _fontName = fontName;
-	this->updateContentSize();
+    this->updateContentSize();
 }
-    
+
 Label* Button::getTitleRenderer()const
 {
     return _titleRenderer;
@@ -787,9 +847,16 @@ Label* Button::getTitleRenderer()const
 
 const std::string& Button::getTitleFontName() const
 {
-    return _fontName;
+    if(this->_type == FontType::SYSTEM)
+    {
+        return _titleRenderer->getSystemFontName();
+    }
+    else
+    {
+        return  _titleRenderer->getTTFConfig().fontFilePath;
+    }
 }
-    
+
 std::string Button::getDescription() const
 {
     return "Button";
@@ -807,9 +874,9 @@ void Button::copySpecialProperties(Widget *widget)
     {
         _prevIgnoreSize = button->_prevIgnoreSize;
         setScale9Enabled(button->_scale9Enabled);
-        loadTextureNormal(button->_normalFileName, button->_normalTexType);
-        loadTexturePressed(button->_clickedFileName, button->_pressedTexType);
-        loadTextureDisabled(button->_disabledFileName, button->_disabledTexType);
+        loadTextureNormal(button->_buttonNormalRenderer->getSprite()->getSpriteFrame());
+        loadTexturePressed(button->_buttonClickedRenderer->getSprite()->getSpriteFrame());
+        loadTextureDisabled(button->_buttonDisableRenderer->getSprite()->getSpriteFrame());
         setCapInsetsNormalRenderer(button->_capInsetsNormal);
         setCapInsetsPressedRenderer(button->_capInsetsPressed);
         setCapInsetsDisabledRenderer(button->_capInsetsDisabled);
@@ -820,7 +887,7 @@ void Button::copySpecialProperties(Widget *widget)
         setPressedActionEnabled(button->_pressedActionEnabled);
         setZoomScale(button->_zoomScale);
     }
-	
+
 }
 Size Button::getNormalSize() const
 {

--- a/cocos/ui/UIButton.h
+++ b/cocos/ui/UIButton.h
@@ -35,18 +35,20 @@ THE SOFTWARE.
 NS_CC_BEGIN
 
 class Label;
+class SpriteFrame;
 
 namespace ui{
-    
+
     class Scale9Sprite;
 /**
- * Represents a push-button widget. Push-buttons can be pressed, or clicked, by the user to perform an action.
+ * Represents a push-button widget.
+ * Push-buttons can be pressed, or clicked, by the user to perform an action.
  */
 class CC_GUI_DLL Button : public Widget
 {
-    
+
     DECLARE_CLASS_GUI_INFO
-    
+
 public:
 
     /**
@@ -66,7 +68,7 @@ public:
      *@return A empty Button instance.
      */
     static Button* create();
-    
+
     /**
      * Create a button with custom textures.
      * @param normalImage normal state texture name.
@@ -79,7 +81,7 @@ public:
                           const std::string& selectedImage = "",
                           const std::string& disableImage = "",
                           TextureResType texType = TextureResType::LOCAL);
-    
+
     /**
      * Load textures for button.
      *
@@ -189,7 +191,7 @@ public:
     virtual Size getVirtualRendererSize() const override;
     virtual Node* getVirtualRenderer() override;
     virtual std::string getDescription() const override;
-    
+
     /**
      * Return the inner title renderer of Button.
      * @return The button title.
@@ -207,7 +209,7 @@ public:
      * Query the button title content.
      *@return Get the button's title content.
      */
-    const std::string& getTitleText() const;
+    const std::string getTitleText() const;
 
     /**
      * Change the color of button's title.
@@ -252,12 +254,12 @@ public:
     void setZoomScale(float scale);
 
     /**
-     * @brief Return a zoom scale 
+     * @brief Return a zoom scale
      * @return the zoom scale in float
      * @since v3.3
      */
     float getZoomScale()const;
-    
+
 CC_CONSTRUCTOR_ACCESS:
     virtual bool init() override;
     virtual bool init(const std::string& normalImage,
@@ -273,45 +275,51 @@ protected:
     virtual void onPressStateChangedToPressed() override;
     virtual void onPressStateChangedToDisabled() override;
     virtual void onSizeChanged() override;
-  
+
+    void loadTextureNormal(SpriteFrame* normalSpriteFrame);
+    void setupNormalTexture();
+    void loadTexturePressed(SpriteFrame* pressedSpriteFrame);
+    void setupPressedTexture();
+    void loadTextureDisabled(SpriteFrame* disabledSpriteFrame);
+    void setupDisabledTexture();
+
     void normalTextureScaleChangedWithSize();
     void pressedTextureScaleChangedWithSize();
     void disabledTextureScaleChangedWithSize();
-    
+
     virtual void adaptRenderers() override;
     void updateTitleLocation();
     void updateContentSize();
-    
+    void createTitleRenderer();
+
     virtual Widget* createCloneInstance() override;
     virtual void copySpecialProperties(Widget* model) override;
-   
+
     virtual Size getNormalSize() const;
 protected:
     Scale9Sprite* _buttonNormalRenderer;
     Scale9Sprite* _buttonClickedRenderer;
     Scale9Sprite* _buttonDisableRenderer;
     Label* _titleRenderer;
-   
+
     float _zoomScale;
-    std::string _normalFileName;
-    std::string _clickedFileName;
-    std::string _disabledFileName;
     bool _prevIgnoreSize;
     bool _scale9Enabled;
+    bool _pressedActionEnabled;
+
     Rect _capInsetsNormal;
     Rect _capInsetsPressed;
     Rect _capInsetsDisabled;
-    TextureResType _normalTexType;
-    TextureResType _pressedTexType;
-    TextureResType _disabledTexType;
+
     Size _normalTextureSize;
     Size _pressedTextureSize;
     Size _disabledTextureSize;
-    bool _pressedActionEnabled;
+
     float _normalTextureScaleXInSize;
     float _normalTextureScaleYInSize;
     float _pressedTextureScaleXInSize;
     float _pressedTextureScaleYInSize;
+
     bool _normalTextureLoaded;
     bool _pressedTextureLoaded;
     bool _disabledTextureLoaded;
@@ -326,7 +334,6 @@ private:
         TTF
     };
 
-    std::string _fontName;
     int _fontSize;
     FontType _type;
 };

--- a/cocos/ui/UIButton.h
+++ b/cocos/ui/UIButton.h
@@ -245,7 +245,7 @@ public:
      * Query the font name of button's title
      *@return font name in std::string
      */
-    const std::string& getTitleFontName() const;
+    const std::string getTitleFontName() const;
 
     /** @brief When user pressed the button, the button will zoom to a scale.
      * The final scale of the button  equals (button original scale + _zoomScale)


### PR DESCRIPTION
I use Cpp-empty-test  to verify this optimization, here is the result:

I use "normalClosed.png" to create some buttons and record the memory usage with XCode.

```
Empty cpp test:
ios platform:

Before optimization：
1000 72.2M
500   67.1M
200 61.9M
100  61M

After optimization：
1000 67.9M
500 66M
200 61.1M
100 60.7M

Mac platform:
Before optimization:
1000 35.4M
500  33.2M
200   27.1M
100   26.8M

After optimization：
1000  32.4M
500 28M
200 25.9M
100 25.1M
```
