### PR TITLE
Updates socket.io network extension to correctly detect and manage connection to socket.io server versions 0.9.x - 1.x

### DIFF
--- a/cocos/network/SocketIO.cpp
+++ b/cocos/network/SocketIO.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
- Copyright (c) 2013      Chris Hannon
- Copyright (c) 2013-2014 Chukong Technologies Inc.
+ Copyright (c) 2013-2015 Chris Hannon http://www.channon.us
+ Copyright (c) 2013-2015 Chukong Technologies Inc.
 
  http://www.cocos2d-x.org
 
@@ -35,11 +35,318 @@
 #include <algorithm>
 #include <sstream>
 
+#include "rapidjson/rapidjson.h"
+#include "rapidjson/document.h"
+#include "rapidjson/stringbuffer.h"
+#include "rapidjson/writer.h"
+
 NS_CC_BEGIN
 
 namespace network {
 
 //class declarations
+
+class SocketIOPacketV10x;
+
+class SocketIOPacket
+{
+public:
+	typedef enum
+	{
+		V09x,
+		V10x
+	}SocketIOVersion;
+
+	SocketIOPacket();
+	virtual ~SocketIOPacket();
+	void initWithType(std::string packetType);
+	void initWithTypeIndex(int index);
+
+	std::string toString();
+	virtual int typeAsNumber();
+	std::string typeForIndex(int index);
+
+	void setEndpoint(std::string endpoint){ _endpoint = endpoint; };
+	std::string getEndpoint(){ return _endpoint; };
+	void setEvent(std::string event){ _name = event; };
+	std::string getEvent(){ return _name; };
+
+	void addData(std::string data);
+	std::vector<std::string> getData(){ return _args; };
+	virtual std::string stringify();
+
+	static SocketIOPacket * createPacketWithType(std::string type, SocketIOPacket::SocketIOVersion version);
+	static SocketIOPacket * createPacketWithTypeIndex(int type, SocketIOPacket::SocketIOVersion version);
+protected:
+	std::string _pId;//id message
+	std::string _ack;//
+	std::string _name;//event name
+	std::vector<std::string> _args;//we will be using a vector of strings to store multiple data
+	std::string _endpoint;//
+	std::string _endpointseperator;//socket.io 1.x requires a ',' between endpoint and payload
+	std::string _type;//message type
+	std::string _separator;//for stringify the object
+	std::vector<std::string> _types;//types of messages
+};
+
+class SocketIOPacketV10x : public SocketIOPacket
+{
+public:
+	SocketIOPacketV10x();
+	virtual ~SocketIOPacketV10x();
+	int typeAsNumber();
+	std::string stringify();
+private:
+	std::vector<std::string> _typesMessage;
+};
+
+SocketIOPacket::SocketIOPacket()
+{
+	_type = "";//message type
+	_separator = ":";//for stringify the object
+	_endpointseperator = "";//socket.io 1.x requires a ',' between endpoint and payload
+	_pId = "";//id message
+	_ack = "";//
+	_name = "";//event name
+	_endpoint = "";//
+	_types.push_back("disconnect");
+	_types.push_back("connect");
+	_types.push_back("heartbeat");
+	_types.push_back("message");
+	_types.push_back("json");
+	_types.push_back("event");
+	_types.push_back("ack");
+	_types.push_back("error");
+	_types.push_back("noop");
+}
+
+SocketIOPacket::~SocketIOPacket()
+{
+	_types.clear();
+	_type = "";
+	_pId = "";
+	_name = "";
+	_ack = "";
+	_endpoint = "";
+}
+
+void SocketIOPacket::initWithType(std::string packetType)
+{
+	_type = packetType;
+}
+void SocketIOPacket::initWithTypeIndex(int index)
+{
+	_type = _types.at(index);
+}
+
+std::string SocketIOPacket::toString()
+{
+	std::stringstream encoded;
+	encoded << this->typeAsNumber();
+	encoded << this->_separator;
+
+	std::string pIdL = _pId;
+	if (_ack == "data")
+	{
+		pIdL += "+";
+	}
+
+	// Do not write pid for acknowledgements
+	if (_type != "ack")
+	{
+		encoded << pIdL;
+	}
+	encoded << this->_separator;
+
+	// Add the endpoint for the namespace to be used if not the default namespace "" or "/", and as long as it is not an ACK, heartbeat, or disconnect packet
+	if (_endpoint != "/" && _endpoint != "" && _type != "ack" && _type != "heartbeat" && _type != "disconnect") {
+		encoded << _endpoint << _endpointseperator;
+	}
+	encoded << this->_separator;
+
+	
+	if (_args.size() != 0)
+	{
+		std::string ackpId = "";
+		// This is an acknowledgement packet, so, prepend the ack pid to the data
+		if (_type == "ack")
+		{
+			ackpId += pIdL + "+";
+		}
+
+		encoded << ackpId << this->stringify();
+	}
+	
+	return encoded.str();
+}
+int SocketIOPacket::typeAsNumber()
+{
+	int num = 0;
+	std::vector<std::string>::iterator item = std::find(_types.begin(), _types.end(), _type);
+	if (item != _types.end())
+	{
+		num = item - _types.begin();
+	}
+	return num;
+}
+std::string SocketIOPacket::typeForIndex(int index)
+{
+	return _types.at(index);
+}
+
+void SocketIOPacket::addData(std::string data)
+{
+	
+	this->_args.push_back(data);
+
+}
+
+std::string SocketIOPacket::stringify()
+{
+
+std::string outS;
+if (_type == "message") {
+	outS = _args[0];
+}
+else {
+
+	rapidjson::StringBuffer s;
+	rapidjson::Writer<rapidjson::StringBuffer> writer(s);
+
+	writer.StartObject();
+	writer.Key("name");
+	writer.String(_name.c_str());
+	
+	writer.Key("args");
+
+	writer.StartArray();
+		
+	for (int i = 0; i < _args.size(); i++) {
+		writer.String(_args[i].c_str());
+	}
+
+	writer.EndArray();
+	writer.EndObject();
+
+	outS = s.GetString();
+
+	log("create args object: %s:", outS.c_str());
+}
+
+return outS;
+}
+
+SocketIOPacketV10x::SocketIOPacketV10x()
+{
+	_separator = ":";
+	_type = "";//message type
+	_separator = "";//for stringify the object
+	_endpointseperator = ",";
+	_pId = "";//id message
+	_ack = "";//
+	_name = "";//event name
+	_endpoint = "";//
+	_types.push_back("disconnected");
+	_types.push_back("connected");
+	_types.push_back("heartbeat");
+	_types.push_back("pong");
+	_types.push_back("message");
+	_types.push_back("upgrade");
+	_types.push_back("noop");
+	_typesMessage.push_back("connect");
+	_typesMessage.push_back("disconnect");
+	_typesMessage.push_back("event");
+	_typesMessage.push_back("ack");
+	_typesMessage.push_back("error");
+	_typesMessage.push_back("binarevent");
+	_typesMessage.push_back("binaryack");
+}
+
+int SocketIOPacketV10x::typeAsNumber()
+{
+	int num = 0;
+	std::vector<std::string>::iterator item = std::find(_typesMessage.begin(), _typesMessage.end(), _type);
+	if (item != _typesMessage.end())
+	{//it's a message
+		num = item - _typesMessage.begin();
+		num += 40;
+	}
+	else
+	{
+		item = std::find(_types.begin(), _types.end(), _type);
+		num += item - _types.begin();
+	}
+	return num;
+}
+
+std::string SocketIOPacketV10x::stringify()
+{
+
+	std::string outS;
+	
+	rapidjson::StringBuffer s;
+	rapidjson::Writer<rapidjson::StringBuffer> writer(s);
+
+	writer.StartArray();
+	writer.String(_name.c_str());
+
+	for (int i = 0; i < _args.size(); i++) {
+		writer.String(_args[i].c_str());
+	}
+
+	writer.EndArray();
+
+	outS = s.GetString();
+
+	log("create args object: %s:", outS.c_str());
+
+	return outS;
+
+}
+
+SocketIOPacketV10x::~SocketIOPacketV10x()
+{
+	_types.clear();
+	_typesMessage.clear();
+	_type = "";
+	_pId = "";
+	_name = "";
+	_ack = "";
+	_endpoint = "";
+}
+
+SocketIOPacket * SocketIOPacket::createPacketWithType(std::string type, SocketIOPacket::SocketIOVersion version)
+{
+	SocketIOPacket *ret;
+	switch (version)
+	{
+	case SocketIOPacket::V09x:
+		ret = new SocketIOPacket;
+		break;
+	case SocketIOPacket::V10x:
+		ret = new SocketIOPacketV10x;
+		break;
+	}
+	ret->initWithType(type);
+	return ret;
+}
+
+
+SocketIOPacket * SocketIOPacket::createPacketWithTypeIndex(int type, SocketIOPacket::SocketIOVersion version)
+{
+	SocketIOPacket *ret;
+	switch (version)
+	{
+	case SocketIOPacket::V09x:
+		ret = new SocketIOPacket;
+		break;
+	case SocketIOPacket::V10x:
+		return new SocketIOPacketV10x;
+		break;
+	}
+	ret->initWithTypeIndex(type);
+	return ret;
+}
 
 /**
  *  @brief The implementation of the socket.io connection
@@ -53,6 +360,7 @@ private:
     int _port, _heartbeat, _timeout;
     std::string _host, _sid, _uri;
     bool _connected;
+	SocketIOPacket::SocketIOVersion _version;
 
     WebSocket *_ws;
 
@@ -84,6 +392,7 @@ public:
     void disconnectFromEndpoint(const std::string& endpoint);
 
     void send(std::string endpoint, std::string s);
+	void send(SocketIOPacket *packet);
     void emit(std::string endpoint, std::string eventname, std::string args);
 
 
@@ -118,13 +427,13 @@ void SIOClientImpl::handshake()
     log("SIOClientImpl::handshake() called");
 
     std::stringstream pre;
-    pre << "http://" << _uri << "/socket.io/1";
+    pre << "http://" << _uri << "/socket.io/1/?EIO=2&transport=polling&b64=true";
 
     HttpRequest* request = new (std::nothrow) HttpRequest();
     request->setUrl(pre.str().c_str());
     request->setRequestType(HttpRequest::Type::GET);
-
-    request->setResponseCallback(CC_CALLBACK_2(SIOClientImpl::handshakeResponse, this));
+	
+	request->setResponseCallback(CC_CALLBACK_2(SIOClientImpl::handshakeResponse, this));
     request->setTag("handshake");
 
     log("SIOClientImpl::handshake() waiting");
@@ -138,67 +447,116 @@ void SIOClientImpl::handshake()
 
 void SIOClientImpl::handshakeResponse(HttpClient *sender, HttpResponse *response)
 {
-    log("SIOClientImpl::handshakeResponse() called");
+	log("SIOClientImpl::handshakeResponse() called");
 
-    if (0 != strlen(response->getHttpRequest()->getTag()))
-    {
-        log("%s completed", response->getHttpRequest()->getTag());
-    }
+	if (0 != strlen(response->getHttpRequest()->getTag()))
+	{
+		log("%s completed", response->getHttpRequest()->getTag());
+	}
 
-    long statusCode = response->getResponseCode();
-    char statusString[64] = {};
-    sprintf(statusString, "HTTP Status Code: %ld, tag = %s", statusCode, response->getHttpRequest()->getTag());
-    log("response code: %ld", statusCode);
+	long statusCode = response->getResponseCode();
+	char statusString[64] = {};
+	sprintf(statusString, "HTTP Status Code: %ld, tag = %s", statusCode, response->getHttpRequest()->getTag());
+	log("response code: %ld", statusCode);
 
-    if (!response->isSucceed())
-    {
-        log("SIOClientImpl::handshake() failed");
-        log("error buffer: %s", response->getErrorBuffer());
+	if (!response->isSucceed())
+	{
+		log("SIOClientImpl::handshake() failed");
+		log("error buffer: %s", response->getErrorBuffer());
 
-        for (auto iter = _clients.begin(); iter != _clients.end(); ++iter)
-        {
-            iter->second->getDelegate()->onError(iter->second, response->getErrorBuffer());
-        }
+		for (auto iter = _clients.begin(); iter != _clients.end(); ++iter)
+		{
+			iter->second->getDelegate()->onError(iter->second, response->getErrorBuffer());
+		}
 
-        return;
-    }
+		return;
+	}
 
-    log("SIOClientImpl::handshake() succeeded");
+	log("SIOClientImpl::handshake() succeeded");
 
-    std::vector<char> *buffer = response->getResponseData();
-    std::stringstream s;
+	std::vector<char> *buffer = response->getResponseData();
+	std::stringstream s;
+	s.str("");
 
-    for (unsigned int i = 0; i < buffer->size(); i++)
-    {
-        s << (*buffer)[i];
-    }
+	for (unsigned int i = 0; i < buffer->size(); i++)
+	{
+		s << (*buffer)[i];
+	}
 
-    log("SIOClientImpl::handshake() dump data: %s", s.str().c_str());
+	log("SIOClientImpl::handshake() dump data: %s", s.str().c_str());
 
-    std::string res = s.str();
-    std::string sid;
-    size_t pos = 0;
-    int heartbeat = 0, timeout = 0;
+	std::string res = s.str();
+	std::string sid = "";
+	int heartbeat = 0, timeout = 0;
 
-    pos = res.find(":");
-    if(pos != std::string::npos)
-    {
-        sid = res.substr(0, pos);
-        res.erase(0, pos+1);
-    }
+	if (res.at(res.size() - 1) == '}') {
 
-    pos = res.find(":");
-    if(pos != std::string::npos)
-    {
-        heartbeat = atoi(res.substr(pos+1, res.size()).c_str());
-    }
+		log("SIOClientImpl::handshake() Socket.IO 1.x detected");
+		_version = SocketIOPacket::V10x;
+		// sample: 97:0{"sid":"GMkL6lzCmgMvMs9bAAAA","upgrades":["websocket"],"pingInterval":25000,"pingTimeout":60000}
 
-    pos = res.find(":");
-    if(pos != std::string::npos)
-    {
-        timeout = atoi(res.substr(pos+1, res.size()).c_str());
-    }
+		int a, b;
+		a = res.find('{');
+		std::string temp = res.substr(a, res.size() - a);
 
+		// find the sid
+		a = temp.find(":");
+		b = temp.find(",");
+
+		sid = temp.substr(a + 2, b - (a + 3));
+
+		temp = temp.erase(0, b + 1);
+
+		// chomp past the upgrades
+		a = temp.find(":");
+		b = temp.find(",");
+
+		temp = temp.erase(0, b + 1);
+
+		// get the pingInterval / heartbeat
+		a = temp.find(":");
+		b = temp.find(",");
+
+		std::string heartbeat_str = temp.substr(a + 1, b - a);
+		heartbeat = atoi(heartbeat_str.c_str()) / 1000;
+		temp = temp.erase(0, b + 1);
+		
+		// get the timeout
+		a = temp.find(":");
+		b = temp.find("}");
+
+		std::string timeout_str = temp.substr(a + 1, b - a);
+		timeout = atoi(timeout_str.c_str()) / 1000;
+		log("done parsing 1.x");
+
+	} else {
+	
+		log("SIOClientImpl::handshake() Socket.IO 0.9.x detected");
+		_version = SocketIOPacket::V09x;
+		// sample: 3GYzE9md2Ig-lm3cf8Rv:60:60:websocket,htmlfile,xhr-polling,jsonp-polling
+		size_t pos = 0;
+
+		pos = res.find(":");
+		if (pos != std::string::npos)
+		{
+			sid = res.substr(0, pos);
+			res.erase(0, pos + 1);
+		}
+
+		pos = res.find(":");
+		if (pos != std::string::npos)
+		{
+			heartbeat = atoi(res.substr(pos + 1, res.size()).c_str());
+		}
+
+		pos = res.find(":");
+		if (pos != std::string::npos)
+		{
+			timeout = atoi(res.substr(pos + 1, res.size()).c_str());
+		}
+	
+	}
+    
     _sid = sid;
     _heartbeat = heartbeat;
     _timeout = timeout;
@@ -214,9 +572,18 @@ void SIOClientImpl::openSocket()
     log("SIOClientImpl::openSocket() called");
 
     std::stringstream s;
-    s << _uri << "/socket.io/1/websocket/" << _sid;
 
-    _ws = new (std::nothrow) WebSocket();
+	switch (_version)
+	{
+	case SocketIOPacket::V09x:
+		s << _uri << "/socket.io/1/websocket/" << _sid;
+		break;
+	case SocketIOPacket::V10x:
+		s << _uri << "/socket.io/1/websocket/?EIO=2&transport=websocket&sid=" << _sid;
+		break;
+	}
+
+	_ws = new (std::nothrow) WebSocket();
     if (!_ws->init(*this, s.str()))
     {
         CC_SAFE_DELETE(_ws);
@@ -240,16 +607,22 @@ void SIOClientImpl::disconnect()
 {
     if(_ws->getReadyState() == WebSocket::State::OPEN)
     {
-        std::string s = "0::";
 
-        _ws->send(s);
+		std::string s, endpoint;
+		s = "";
+		endpoint = "";
 
-        log("Disconnect sent");
+		if (_version == SocketIOPacket::V09x)
+			s = "0::" + endpoint;
+		else
+			s = "41" + endpoint;
+		_ws->send(s);
 
-        _ws->close();
     }
 
     Director::getInstance()->getScheduler()->unscheduleAllForTarget(this);
+
+	_ws->close();
 
     _connected = false;
 
@@ -280,11 +653,11 @@ void SIOClientImpl::addClient(const std::string& endpoint, SIOClient* client)
 
 void SIOClientImpl::connectToEndpoint(const std::string& endpoint)
 {
-    std::string path = endpoint == "/" ? "" : endpoint;
 
-    std::string s = "1::" + path;
+	SocketIOPacket *packet = SocketIOPacket::createPacketWithType("connect", _version);
+	packet->setEndpoint(endpoint);
+	this->send(packet);
 
-    _ws->send(s);
 }
 
 void SIOClientImpl::disconnectFromEndpoint(const std::string& endpoint)
@@ -310,9 +683,10 @@ void SIOClientImpl::disconnectFromEndpoint(const std::string& endpoint)
 
 void SIOClientImpl::heartbeat(float dt)
 {
-    std::string s = "2::";
 
-    _ws->send(s);
+	SocketIOPacket *packet = SocketIOPacket::createPacketWithType("heartbeat", _version);
+    
+	this->send(packet);
 
     log("Heartbeat sent");
 }
@@ -320,32 +694,45 @@ void SIOClientImpl::heartbeat(float dt)
 
 void SIOClientImpl::send(std::string endpoint, std::string s)
 {
-    std::stringstream pre;
 
-    std::string path = endpoint == "/" ? "" : endpoint;
+	switch (_version) {
+		case SocketIOPacket::V09x:
+		{
+			SocketIOPacket *packet = SocketIOPacket::createPacketWithType("message", _version);
+			packet->setEndpoint(endpoint);
+			packet->addData(s);
+			this->send(packet);
+			break;
+		}
+		case SocketIOPacket::V10x:
+		{
+			this->emit(endpoint, "message", s);
+			break;
+		}
+	}
+    
+}
 
-    pre << "3::" << path << ":" << s;
-
-    std::string msg = pre.str();
-
-    log("sending message: %s", msg.c_str());
-
-    _ws->send(msg);
+void SIOClientImpl::send(SocketIOPacket *packet)
+{
+	std::string req = packet->toString();
+	if (_connected)
+	{
+		log("-->SEND:%s", req.data());
+		_ws->send(req.data());
+	}
+	else
+		log("Cant send the message (%s) because disconnected", req);
 }
 
 void SIOClientImpl::emit(std::string endpoint, std::string eventname, std::string args)
 {
-    std::stringstream pre;
-
-    std::string path = endpoint == "/" ? "" : endpoint;
-
-    pre << "5::" << path << ":{\"name\":\"" << eventname << "\",\"args\":" << args << "}";
-
-    std::string msg = pre.str();
-
-    log("emitting event with data: %s", msg.c_str());
-
-    _ws->send(msg);
+	log("Emitting event \"%s\"", eventname);
+	SocketIOPacket *packet = SocketIOPacket::createPacketWithType("event", _version);
+	packet->setEndpoint(endpoint == "/" ? "" : endpoint);
+	packet->setEvent(eventname);
+	packet->addData(args);
+	this->send(packet);
 }
 
 void SIOClientImpl::onOpen(WebSocket* ws)
@@ -354,12 +741,18 @@ void SIOClientImpl::onOpen(WebSocket* ws)
 
     SocketIO::getInstance()->addSocket(_uri, this);
 
+	if (_version == SocketIOPacket::V10x)
+	{
+		std::string s = "5";//That's a ping https://github.com/Automattic/engine.io-parser/blob/1b8e077b2218f4947a69f5ad18be2a512ed54e93/lib/index.js#L21
+		_ws->send(s.data());
+	}
+
+	Director::getInstance()->getScheduler()->schedule(CC_SCHEDULE_SELECTOR(SIOClientImpl::heartbeat), this, (_heartbeat * .9f), false);
+
     for (auto iter = _clients.begin(); iter != _clients.end(); ++iter)
     {
         iter->second->onOpen();
     }
-
-    Director::getInstance()->getScheduler()->schedule(CC_SCHEDULE_SELECTOR(SIOClientImpl::heartbeat), this, (_heartbeat * .9f), false);
 
     log("SIOClientImpl::onOpen socket connected!");
 }
@@ -368,95 +761,224 @@ void SIOClientImpl::onMessage(WebSocket* ws, const WebSocket::Data& data)
 {
     log("SIOClientImpl::onMessage received: %s", data.bytes);
 
-    int control = atoi(&data.bytes[0]);
+	std::string payload = data.bytes;
+	int control = atoi(payload.substr(0, 1).c_str());
+	payload = payload.substr(1, payload.size() - 1);
 
-    std::string payload, msgid, endpoint, s_data, eventname;
-    payload = data.bytes;
+	SIOClient *c = nullptr;
+	
+	switch (_version)
+	{
+		case SocketIOPacket::V09x:
+		{	
+			std::string msgid, endpoint, s_data, eventname;
+			
+			size_t pos, pos2;
 
-    size_t pos, pos2;
+			pos = payload.find(":");
+			if (pos != std::string::npos) {
+				payload.erase(0, pos + 1);
+			}
 
-    pos = payload.find(":");
-    if(pos != std::string::npos ) {
-        payload.erase(0, pos+1);
-    }
+			pos = payload.find(":");
+			if (pos != std::string::npos) {
+				msgid = atoi(payload.substr(0, pos + 1).c_str());
+			}
+			payload.erase(0, pos + 1);
 
-    pos = payload.find(":");
-    if(pos != std::string::npos ) {
-        msgid = atoi(payload.substr(0, pos+1).c_str());
-    }
-    payload.erase(0, pos+1);
+			pos = payload.find(":");
+			if (pos != std::string::npos)
+			{
+				endpoint = payload.substr(0, pos);
+				payload.erase(0, pos + 1);
+			}
+			else
+			{
+				endpoint = payload;
+			}
 
-    pos = payload.find(":");
-    if(pos != std::string::npos)
-    {
-        endpoint = payload.substr(0, pos);
-        payload.erase(0, pos+1);
-    }
-    else
-    {
-        endpoint = payload;
-    }
+			if (endpoint == "") endpoint = "/";
 
-    if (endpoint == "") endpoint = "/";
+			c = getClient(endpoint);
 
+			s_data = payload;
+			
+			if (c == nullptr) log("SIOClientImpl::onMessage client lookup returned nullptr");
 
-    s_data = payload;
-    SIOClient *c = nullptr;
-    c = getClient(endpoint);
-    if (c == nullptr) log("SIOClientImpl::onMessage client lookup returned nullptr");
+			switch (control)
+			{
+			case 0:
+				log("Received Disconnect Signal for Endpoint: %s\n", endpoint.c_str());
+				disconnectFromEndpoint(endpoint);
+				c->fireEvent("disconnect", payload);
+				break;
+			case 1:
+				log("Connected to endpoint: %s \n", endpoint.c_str());
+				if (c) {
+					c->onConnect();
+					c->fireEvent("connect", payload);
+				}
+				break;
+			case 2:
+				log("Heartbeat received\n");
+				break;
+			case 3:
+				log("Message received: %s \n", s_data.c_str());
+				if (c) c->getDelegate()->onMessage(c, s_data);
+				if (c) c->fireEvent("message", s_data);
+				break;
+			case 4:
+				log("JSON Message Received: %s \n", s_data.c_str());
+				if (c) c->getDelegate()->onMessage(c, s_data);
+				if (c) c->fireEvent("json", s_data);
+				break;
+			case 5:
+				log("Event Received with data: %s \n", s_data.c_str());
 
-    switch(control)
-    {
-        case 0:
-            log("Received Disconnect Signal for Endpoint: %s\n", endpoint.c_str());
-            if(c) c->receivedDisconnect();
-            disconnectFromEndpoint(endpoint);
-            break;
-        case 1:
-            log("Connected to endpoint: %s \n",endpoint.c_str());
-            if(c) c->onConnect();
-            break;
-        case 2:
-            log("Heartbeat received\n");
-            break;
-        case 3:
-            log("Message received: %s \n", s_data.c_str());
-            if(c) c->getDelegate()->onMessage(c, s_data);
-            break;
-        case 4:
-            log("JSON Message Received: %s \n", s_data.c_str());
-            if(c) c->getDelegate()->onMessage(c, s_data);
-            break;
-        case 5:
-            log("Event Received with data: %s \n", s_data.c_str());
+				if (c)
+				{
+					eventname = "";
+					pos = s_data.find(":");
+					pos2 = s_data.find(",");
+					if (pos2 > pos)
+					{
+						eventname = s_data.substr(pos + 2, pos2 - (pos + 3));
+						s_data = s_data.substr(pos2 + 9, s_data.size() - (pos2 + 11));
+					}
 
-            if(c)
-            {
-                eventname = "";
-                pos = s_data.find(":");
-                pos2 = s_data.find(",");
-                if(pos2 > pos)
-                {
-                    s_data = s_data.substr(pos+1, pos2-pos-1);
-                    std::remove_copy(s_data.begin(), s_data.end(),
-                         std::back_inserter(eventname), '"');
-                }
+					c->fireEvent(eventname, s_data);
+				}
 
-                c->fireEvent(eventname, payload);
-            }
+				break;
+			case 6:
+				log("Message Ack\n");
+				break;
+			case 7:
+				log("Error\n");
+				//if (c) c->getDelegate()->onError(c, s_data);
+				if (c) c->fireEvent("error", s_data);
+				break;
+			case 8:
+				log("Noop\n");
+				break;
+			}
+		}
+		break;
+		case SocketIOPacket::V10x:
+		{				
+			switch (control)
+			{
+			case 0:
+				log("Not supposed to receive control 0 for websocket");
+				log("That's not good");
+				break;
+			case 1:
+				log("Not supposed to receive control 1 for websocket");
+				break;
+			case 2:
+				log("Ping received, send pong");
+				payload = "3" + payload;
+				_ws->send(payload.c_str());
+				break;
+			case 3:
+				log("Pong received");
+				if (payload == "probe")
+				{
+					log("Request Update");
+					_ws->send("5");
+				}
+				break;
+			case 4:
 
-            break;
-        case 6:
-            log("Message Ack\n");
-            break;
-        case 7:
-            log("Error\n");
-            if(c) c->getDelegate()->onError(c, s_data);
-            break;
-        case 8:
-            log("Noop\n");
-            break;
-    }
+				const char second = payload.at(0);
+				int control2 = atoi(&second);
+				log("Message code: [%i]", control);
+
+				SocketIOPacket *packetOut = SocketIOPacket::createPacketWithType("event", _version);
+				std::string endpoint = "";
+
+				int a = payload.find("/");
+				int b = payload.find("[");
+
+				if (b != std::string::npos) {
+					if (a != std::string::npos && a < b) {
+						//we have an endpoint and a payload
+						endpoint = payload.substr(a, b - (a + 1));
+					}
+				}
+				else if (a != std::string::npos) {
+					//we have an endpoint with no payload
+					endpoint = payload.substr(a, payload.size() - a);
+				}
+				
+				// we didn't find and endpoint and we are in the default namespace
+				if (endpoint == "") endpoint = "/";
+
+				packetOut->setEndpoint(endpoint);				
+
+				c = getClient(endpoint);
+
+				payload = payload.substr(1);
+
+				if (endpoint != "/") payload = payload.substr(endpoint.size());
+				if (endpoint != "/" && payload != "") payload = payload.substr(1);
+				
+				switch (control2)
+				{
+				case 0:
+					log("Socket Connected");
+					if (c) {
+						c->onConnect();
+						c->fireEvent("connect", payload);
+					}
+					break;
+				case 1:
+					log("Socket Disconnected");
+					disconnectFromEndpoint(endpoint);
+					c->fireEvent("disconnect", payload);
+					break;
+				case 2:
+				{
+					log("Event Received (%s)", payload.c_str());
+
+					int a = payload.find("\"");
+					int b = payload.substr(a+1).find("\"");
+
+					std::string eventname = payload.substr(a + 1, b - a + 1);
+					log("event name %s between %i and %i", eventname.c_str(), a, b);
+
+					payload = payload.substr(b + 4, payload.size() - (b + 5));
+
+					if(c) c->fireEvent(eventname, payload);
+					if (c) c->getDelegate()->onMessage(c, payload);
+
+				}	
+				break;
+				case 3:
+					log("Message Ack");
+					break;
+				case 4:
+					log("Error");
+					if (c) c->fireEvent("error", payload);
+					break;
+				case 5:
+					log("Binary Event");
+					break;
+				case 6:
+					log("Binary Ack");
+					break;
+				}
+			}
+				break;
+			case 5:
+				log("Upgrade required");
+				break;
+			case 6:
+				log("Noop\n");
+				break;
+		}
+		break;
+	}
 
     return;
 }
@@ -467,7 +989,7 @@ void SIOClientImpl::onClose(WebSocket* ws)
     {
         for (auto iter = _clients.begin(); iter != _clients.end(); ++iter)
         {
-            iter->second->receivedDisconnect();
+			iter->second->socketClosed();
         }
     }
 
@@ -476,6 +998,7 @@ void SIOClientImpl::onClose(WebSocket* ws)
 
 void SIOClientImpl::onError(WebSocket* ws, const WebSocket::ErrorCode& error)
 {
+	log("Websocket error received: %s", error);
 }
 
 //begin SIOClient methods
@@ -509,7 +1032,6 @@ void SIOClient::onOpen()
 void SIOClient::onConnect()
 {
     _connected = true;
-    _delegate->onConnect(this);
 }
 
 void SIOClient::send(std::string s)
@@ -544,12 +1066,12 @@ void SIOClient::disconnect()
 
     _socket->disconnectFromEndpoint(_path);
 
-    _delegate->onClose(this);
+    //_delegate->onClose(this);
 
     this->release();
 }
 
-void SIOClient::receivedDisconnect()
+void SIOClient::socketClosed()
 {
     _connected = false;
 
@@ -631,7 +1153,7 @@ SIOClient* SocketIO::connect(const std::string& uri, SocketIO::SIODelegate& dele
     }
 
     pos = host.find("/", 0);
-    std::string path = "/";
+	std::string path = "/";
     if (pos != std::string::npos)
     {
         path += host.substr(pos + 1, host.size());

--- a/cocos/network/SocketIO.cpp
+++ b/cocos/network/SocketIO.cpp
@@ -229,8 +229,8 @@ else {
 	writer.EndObject();
 
 	outS = s.GetString();
-
-	log("create args object: %s:", outS.c_str());
+	
+	CCLOGINFO("create args object: %s:", outS.c_str());
 }
 
 return outS;
@@ -298,8 +298,8 @@ std::string SocketIOPacketV10x::stringify()
 
 	outS = s.GetString();
 
-	log("create args object: %s:", outS.c_str());
-
+	CCLOGINFO("create args object: %s:", outS.c_str());
+	
 	return outS;
 
 }
@@ -424,7 +424,7 @@ SIOClientImpl::~SIOClientImpl()
 
 void SIOClientImpl::handshake()
 {
-    log("SIOClientImpl::handshake() called");
+    CCLOGINFO("SIOClientImpl::handshake() called");
 
     std::stringstream pre;
     pre << "http://" << _uri << "/socket.io/1/?EIO=2&transport=polling&b64=true";
@@ -436,7 +436,7 @@ void SIOClientImpl::handshake()
 	request->setResponseCallback(CC_CALLBACK_2(SIOClientImpl::handshakeResponse, this));
     request->setTag("handshake");
 
-    log("SIOClientImpl::handshake() waiting");
+    CCLOGINFO("SIOClientImpl::handshake() waiting");
 
     HttpClient::getInstance()->send(request);
 
@@ -447,22 +447,22 @@ void SIOClientImpl::handshake()
 
 void SIOClientImpl::handshakeResponse(HttpClient *sender, HttpResponse *response)
 {
-	log("SIOClientImpl::handshakeResponse() called");
+	CCLOGINFO("SIOClientImpl::handshakeResponse() called");
 
 	if (0 != strlen(response->getHttpRequest()->getTag()))
 	{
-		log("%s completed", response->getHttpRequest()->getTag());
+		CCLOGINFO("%s completed", response->getHttpRequest()->getTag());
 	}
 
 	long statusCode = response->getResponseCode();
 	char statusString[64] = {};
 	sprintf(statusString, "HTTP Status Code: %ld, tag = %s", statusCode, response->getHttpRequest()->getTag());
-	log("response code: %ld", statusCode);
+	CCLOGINFO("response code: %ld", statusCode);
 
 	if (!response->isSucceed())
 	{
-		log("SIOClientImpl::handshake() failed");
-		log("error buffer: %s", response->getErrorBuffer());
+		CCLOGERROR("SIOClientImpl::handshake() failed");
+		CCLOGERROR("error buffer: %s", response->getErrorBuffer());
 
 		for (auto iter = _clients.begin(); iter != _clients.end(); ++iter)
 		{
@@ -472,7 +472,7 @@ void SIOClientImpl::handshakeResponse(HttpClient *sender, HttpResponse *response
 		return;
 	}
 
-	log("SIOClientImpl::handshake() succeeded");
+	CCLOGINFO("SIOClientImpl::handshake() succeeded");
 
 	std::vector<char> *buffer = response->getResponseData();
 	std::stringstream s;
@@ -483,7 +483,7 @@ void SIOClientImpl::handshakeResponse(HttpClient *sender, HttpResponse *response
 		s << (*buffer)[i];
 	}
 
-	log("SIOClientImpl::handshake() dump data: %s", s.str().c_str());
+	CCLOGINFO("SIOClientImpl::handshake() dump data: %s", s.str().c_str());
 
 	std::string res = s.str();
 	std::string sid = "";
@@ -491,7 +491,7 @@ void SIOClientImpl::handshakeResponse(HttpClient *sender, HttpResponse *response
 
 	if (res.at(res.size() - 1) == '}') {
 
-		log("SIOClientImpl::handshake() Socket.IO 1.x detected");
+		CCLOGINFO("SIOClientImpl::handshake() Socket.IO 1.x detected");
 		_version = SocketIOPacket::V10x;
 		// sample: 97:0{"sid":"GMkL6lzCmgMvMs9bAAAA","upgrades":["websocket"],"pingInterval":25000,"pingTimeout":60000}
 
@@ -527,11 +527,11 @@ void SIOClientImpl::handshakeResponse(HttpClient *sender, HttpResponse *response
 
 		std::string timeout_str = temp.substr(a + 1, b - a);
 		timeout = atoi(timeout_str.c_str()) / 1000;
-		log("done parsing 1.x");
+		CCLOGINFO("done parsing 1.x");
 
 	} else {
 	
-		log("SIOClientImpl::handshake() Socket.IO 0.9.x detected");
+		CCLOGINFO("SIOClientImpl::handshake() Socket.IO 0.9.x detected");
 		_version = SocketIOPacket::V09x;
 		// sample: 3GYzE9md2Ig-lm3cf8Rv:60:60:websocket,htmlfile,xhr-polling,jsonp-polling
 		size_t pos = 0;
@@ -569,7 +569,7 @@ void SIOClientImpl::handshakeResponse(HttpClient *sender, HttpResponse *response
 
 void SIOClientImpl::openSocket()
 {
-    log("SIOClientImpl::openSocket() called");
+	CCLOGINFO("SIOClientImpl::openSocket() called");
 
     std::stringstream s;
 
@@ -594,7 +594,7 @@ void SIOClientImpl::openSocket()
 
 bool SIOClientImpl::init()
 {
-    log("SIOClientImpl::init() successful");
+	CCLOGINFO("SIOClientImpl::init() successful");
     return true;
 }
 
@@ -666,7 +666,7 @@ void SIOClientImpl::disconnectFromEndpoint(const std::string& endpoint)
 
     if (_clients.empty() || endpoint == "/")
     {
-        log("SIOClientImpl::disconnectFromEndpoint out of endpoints, checking for disconnect");
+		CCLOGINFO("SIOClientImpl::disconnectFromEndpoint out of endpoints, checking for disconnect");
 
         if(_connected)
             this->disconnect();
@@ -688,7 +688,7 @@ void SIOClientImpl::heartbeat(float dt)
     
 	this->send(packet);
 
-    log("Heartbeat sent");
+	CCLOGINFO("Heartbeat sent");
 }
 
 
@@ -718,16 +718,16 @@ void SIOClientImpl::send(SocketIOPacket *packet)
 	std::string req = packet->toString();
 	if (_connected)
 	{
-		log("-->SEND:%s", req.data());
+		CCLOGINFO("-->SEND:%s", req.data());
 		_ws->send(req.data());
 	}
 	else
-		log("Cant send the message (%s) because disconnected", req);
+		CCLOGERROR("Cant send the message (%s) because disconnected", req.c_str());
 }
 
 void SIOClientImpl::emit(std::string endpoint, std::string eventname, std::string args)
 {
-	log("Emitting event \"%s\"", eventname);
+	CCLOGINFO("Emitting event \"%s\"", eventname.c_str());
 	SocketIOPacket *packet = SocketIOPacket::createPacketWithType("event", _version);
 	packet->setEndpoint(endpoint == "/" ? "" : endpoint);
 	packet->setEvent(eventname);
@@ -754,12 +754,12 @@ void SIOClientImpl::onOpen(WebSocket* ws)
         iter->second->onOpen();
     }
 
-    log("SIOClientImpl::onOpen socket connected!");
+	CCLOGINFO("SIOClientImpl::onOpen socket connected!");
 }
 
 void SIOClientImpl::onMessage(WebSocket* ws, const WebSocket::Data& data)
 {
-    log("SIOClientImpl::onMessage received: %s", data.bytes);
+	CCLOGINFO("SIOClientImpl::onMessage received: %s", data.bytes);
 
 	std::string payload = data.bytes;
 	int control = atoi(payload.substr(0, 1).c_str());
@@ -803,37 +803,37 @@ void SIOClientImpl::onMessage(WebSocket* ws, const WebSocket::Data& data)
 
 			s_data = payload;
 			
-			if (c == nullptr) log("SIOClientImpl::onMessage client lookup returned nullptr");
+			if (c == nullptr) CCLOGINFO("SIOClientImpl::onMessage client lookup returned nullptr");
 
 			switch (control)
 			{
 			case 0:
-				log("Received Disconnect Signal for Endpoint: %s\n", endpoint.c_str());
+				CCLOGINFO("Received Disconnect Signal for Endpoint: %s\n", endpoint.c_str());
 				disconnectFromEndpoint(endpoint);
 				c->fireEvent("disconnect", payload);
 				break;
 			case 1:
-				log("Connected to endpoint: %s \n", endpoint.c_str());
+				CCLOGINFO("Connected to endpoint: %s \n", endpoint.c_str());
 				if (c) {
 					c->onConnect();
 					c->fireEvent("connect", payload);
 				}
 				break;
 			case 2:
-				log("Heartbeat received\n");
+				CCLOGINFO("Heartbeat received\n");
 				break;
 			case 3:
-				log("Message received: %s \n", s_data.c_str());
+				CCLOGINFO("Message received: %s \n", s_data.c_str());
 				if (c) c->getDelegate()->onMessage(c, s_data);
 				if (c) c->fireEvent("message", s_data);
 				break;
 			case 4:
-				log("JSON Message Received: %s \n", s_data.c_str());
+				CCLOGINFO("JSON Message Received: %s \n", s_data.c_str());
 				if (c) c->getDelegate()->onMessage(c, s_data);
 				if (c) c->fireEvent("json", s_data);
 				break;
 			case 5:
-				log("Event Received with data: %s \n", s_data.c_str());
+				CCLOGINFO("Event Received with data: %s \n", s_data.c_str());
 
 				if (c)
 				{
@@ -851,15 +851,15 @@ void SIOClientImpl::onMessage(WebSocket* ws, const WebSocket::Data& data)
 
 				break;
 			case 6:
-				log("Message Ack\n");
+				CCLOGINFO("Message Ack\n");
 				break;
 			case 7:
-				log("Error\n");
+				CCLOGINFO("Error\n");
 				//if (c) c->getDelegate()->onError(c, s_data);
 				if (c) c->fireEvent("error", s_data);
 				break;
 			case 8:
-				log("Noop\n");
+				CCLOGINFO("Noop\n");
 				break;
 			}
 		}
@@ -869,22 +869,22 @@ void SIOClientImpl::onMessage(WebSocket* ws, const WebSocket::Data& data)
 			switch (control)
 			{
 			case 0:
-				log("Not supposed to receive control 0 for websocket");
-				log("That's not good");
+				CCLOGINFO("Not supposed to receive control 0 for websocket");
+				CCLOGINFO("That's not good");
 				break;
 			case 1:
-				log("Not supposed to receive control 1 for websocket");
+				CCLOGINFO("Not supposed to receive control 1 for websocket");
 				break;
 			case 2:
-				log("Ping received, send pong");
+				CCLOGINFO("Ping received, send pong");
 				payload = "3" + payload;
 				_ws->send(payload.c_str());
 				break;
 			case 3:
-				log("Pong received");
+				CCLOGINFO("Pong received");
 				if (payload == "probe")
 				{
-					log("Request Update");
+					CCLOGINFO("Request Update");
 					_ws->send("5");
 				}
 				break;
@@ -892,7 +892,7 @@ void SIOClientImpl::onMessage(WebSocket* ws, const WebSocket::Data& data)
 
 				const char second = payload.at(0);
 				int control2 = atoi(&second);
-				log("Message code: [%i]", control);
+				CCLOGINFO("Message code: [%i]", control);
 
 				SocketIOPacket *packetOut = SocketIOPacket::createPacketWithType("event", _version);
 				std::string endpoint = "";
@@ -926,26 +926,26 @@ void SIOClientImpl::onMessage(WebSocket* ws, const WebSocket::Data& data)
 				switch (control2)
 				{
 				case 0:
-					log("Socket Connected");
+					CCLOGINFO("Socket Connected");
 					if (c) {
 						c->onConnect();
 						c->fireEvent("connect", payload);
 					}
 					break;
 				case 1:
-					log("Socket Disconnected");
+					CCLOGINFO("Socket Disconnected");
 					disconnectFromEndpoint(endpoint);
 					c->fireEvent("disconnect", payload);
 					break;
 				case 2:
 				{
-					log("Event Received (%s)", payload.c_str());
+					CCLOGINFO("Event Received (%s)", payload.c_str());
 
 					int a = payload.find("\"");
 					int b = payload.substr(a+1).find("\"");
 
 					std::string eventname = payload.substr(a + 1, b - a + 1);
-					log("event name %s between %i and %i", eventname.c_str(), a, b);
+					CCLOGINFO("event name %s between %i and %i", eventname.c_str(), a, b);
 
 					payload = payload.substr(b + 4, payload.size() - (b + 5));
 
@@ -955,26 +955,26 @@ void SIOClientImpl::onMessage(WebSocket* ws, const WebSocket::Data& data)
 				}	
 				break;
 				case 3:
-					log("Message Ack");
+					CCLOGINFO("Message Ack");
 					break;
 				case 4:
-					log("Error");
+					CCLOGERROR("Error");
 					if (c) c->fireEvent("error", payload);
 					break;
 				case 5:
-					log("Binary Event");
+					CCLOGINFO("Binary Event");
 					break;
 				case 6:
-					log("Binary Ack");
+					CCLOGINFO("Binary Ack");
 					break;
 				}
 			}
 				break;
 			case 5:
-				log("Upgrade required");
+				CCLOGINFO("Upgrade required");
 				break;
 			case 6:
-				log("Noop\n");
+				CCLOGINFO("Noop\n");
 				break;
 		}
 		break;
@@ -998,7 +998,7 @@ void SIOClientImpl::onClose(WebSocket* ws)
 
 void SIOClientImpl::onError(WebSocket* ws, const WebSocket::ErrorCode& error)
 {
-	log("Websocket error received: %s", error);
+	CCLOGERROR("Websocket error received: %d", error);
 }
 
 //begin SIOClient methods
@@ -1087,7 +1087,7 @@ void SIOClient::on(const std::string& eventName, SIOEvent e)
 
 void SIOClient::fireEvent(const std::string& eventName, const std::string& data)
 {
-    log("SIOClient::fireEvent called with event name: %s and data: %s", eventName.c_str(), data.c_str());
+	CCLOGINFO("SIOClient::fireEvent called with event name: %s and data: %s", eventName.c_str(), data.c_str());
 
     _delegate->fireEventToScript(this, eventName, data);
 
@@ -1100,7 +1100,7 @@ void SIOClient::fireEvent(const std::string& eventName, const std::string& data)
         return;
     }
 
-    log("SIOClient::fireEvent no native event with name %s found", eventName.c_str());
+	CCLOGINFO("SIOClient::fireEvent no native event with name %s found", eventName.c_str());
 }
 
 //begin SocketIO methods

--- a/tests/cpp-tests/Classes/ExtensionsTest/ExtensionsTest.cpp
+++ b/tests/cpp-tests/Classes/ExtensionsTest/ExtensionsTest.cpp
@@ -35,7 +35,9 @@ static struct {
 #if (CC_TARGET_PLATFORM == CC_PLATFORM_IOS) || (CC_TARGET_PLATFORM == CC_PLATFORM_ANDROID) || (CC_TARGET_PLATFORM == CC_PLATFORM_MAC) || (CC_TARGET_PLATFORM == CC_PLATFORM_WIN32) || (CC_TARGET_PLATFORM == CC_PLATFORM_WINRT)
 	{ "WebSocketTest", [](Ref *sender){ runWebSocketTest();}
 	},
-	{ "SocketIOTest", [](Ref *sender){ runSocketIOTest();}
+	{ "SocketIOTest v0.9.x", [](Ref *sender){ runSocketIOTest("09");}
+	},
+	{ "SocketIOTest v1.x", [](Ref *sender){ runSocketIOTest("10"); }
 	},
 #endif
 

--- a/tests/cpp-tests/Classes/ExtensionsTest/NetworkTest/SocketIOTest.cpp
+++ b/tests/cpp-tests/Classes/ExtensionsTest/NetworkTest/SocketIOTest.cpp
@@ -1,10 +1,28 @@
-//
-//  SocketIOTest.cpp
-//  TestCpp
-//
-//  Created by Chris Hannon on 6/26/13.
-//
-//
+/****************************************************************************
+Copyright (c) 2013-2015 Chris Hannon http://www.channon.us
+Copyright (c) 2013-2015 Chukong Technologies Inc.
+
+http://www.cocos2d-x.org
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+****************************************************************************/
 
 
 #include "SocketIOTest.h"
@@ -14,18 +32,23 @@ USING_NS_CC;
 USING_NS_CC_EXT;
 using namespace  cocos2d::network;
 
-SocketIOTestLayer::SocketIOTestLayer(void)
+SocketIOTestLayer::SocketIOTestLayer()
+	: SocketIOTestLayer("09") {
+}
+
+SocketIOTestLayer::SocketIOTestLayer(std::string version)
 	: _sioClient(nullptr)
 	, _sioEndpoint(nullptr)
-{
-	//set the clients to nullptr until we are ready to connect
+	, _sioClientStatus(nullptr)
+	, _sioVersion(version)
+{//set the clients to nullptr until we are ready to connect
 
 	Size winSize = Director::getInstance()->getWinSize();
     
     const int MARGIN = 40;
     const int SPACE = 35;
     
-    auto label = Label::createWithTTF("SocketIO Extension Test", "fonts/arial.ttf", 28);
+    auto label = Label::createWithTTF("SocketIO Extension Test for v" + this->getSIOVersion(), "fonts/arial.ttf", 28);
     label->setPosition(Vec2(winSize.width / 2, winSize.height - MARGIN));
     addChild(label, 0);
     	
@@ -124,6 +147,64 @@ void SocketIOTestLayer::echotest(SIOClient *client, const std::string& data) {
 
 }
 
+// onMessage is no longer a required override from the delegate class
+// 'message' events and handlers are now registered in the same way that other events are
+void SocketIOTestLayer::message(network::SIOClient* client, const std::string& data)
+{
+	log("SocketIOTestLayer::message received: %s", data.c_str());
+
+	std::stringstream s;
+	s << client->getTag() << " received message with content: " << data.c_str();
+	_sioClientStatus->setString(s.str().c_str());
+
+}
+
+void SocketIOTestLayer::json(network::SIOClient* client, const std::string& data)
+{
+	log("SocketIOTestLayer::json received: %s", data.c_str());
+
+	std::stringstream s;
+	s << client->getTag() << " received json message with content: " << data.c_str();
+	_sioClientStatus->setString(s.str().c_str());
+
+}
+
+void SocketIOTestLayer::connect(network::SIOClient* client, const std::string& data)
+{
+	log("SocketIOTestLayer::connect called");
+
+	std::stringstream s;
+	s << client->getTag() << " connected!";
+	_sioClientStatus->setString(s.str().c_str());
+
+}
+
+void SocketIOTestLayer::disconnect(network::SIOClient* client, const std::string& data)
+{
+	log("SocketIOTestLayer::disconnect called");
+
+	std::stringstream s;
+	s << client->getTag() << " disconnected by server!";
+	_sioClientStatus->setString(s.str().c_str());
+
+	this->closedSocketAction(client);
+
+}
+
+void SocketIOTestLayer::closedSocketAction(network::SIOClient* client)
+{
+	//set the local pointer to nullptr or connect to another client
+	//the client object will be released on its own after this method completes
+	if (client == _sioClient) {
+
+		_sioClient = nullptr;
+	}
+	else if (client == _sioEndpoint) {
+
+		_sioEndpoint = nullptr;
+	}
+}
+
 void SocketIOTestLayer::toExtensionsMainLayer(cocos2d::Ref *sender)
 {
 	ExtensionsTestScene *scene = new (std::nothrow) ExtensionsTestScene();
@@ -138,26 +219,35 @@ void SocketIOTestLayer::toExtensionsMainLayer(cocos2d::Ref *sender)
 void SocketIOTestLayer::onMenuSIOClientClicked(cocos2d::Ref *sender)
 {
 	//create a client by using this static method, url does not need to contain the protocol
-	_sioClient = SocketIO::connect("ws://channon.us:3000", *this);
+	_sioClient = SocketIO::connect("ws://dev.channon.us:30" + this->getSIOVersion(), *this);
 	//you may set a tag for the client for reference in callbacks
 	_sioClient->setTag("Test Client");
 
 	//register event callbacks using the CC_CALLBACK_2() macro and passing the instance of the target class
 	_sioClient->on("testevent", CC_CALLBACK_2(SocketIOTestLayer::testevent, this));
 	_sioClient->on("echotest", CC_CALLBACK_2(SocketIOTestLayer::echotest, this));
+	_sioClient->on("message", CC_CALLBACK_2(SocketIOTestLayer::message, this));
+	_sioClient->on("json", CC_CALLBACK_2(SocketIOTestLayer::json, this));
+	_sioClient->on("connect", CC_CALLBACK_2(SocketIOTestLayer::connect, this));
+	_sioClient->on("disconnect", CC_CALLBACK_2(SocketIOTestLayer::disconnect, this));
 
 }
 
 void SocketIOTestLayer::onMenuSIOEndpointClicked(cocos2d::Ref *sender)
 {
 	//repeat the same connection steps for the namespace "testpoint"
-	_sioEndpoint = SocketIO::connect("ws://channon.us:3000/testpoint", *this);
+	_sioEndpoint = SocketIO::connect("ws://dev.channon.us:30" + this->getSIOVersion() + "/testpoint", *this);
 	//a tag to differentiate in shared callbacks
 	_sioEndpoint->setTag("Test Endpoint");	
 
 	//demonstrating how callbacks can be shared within a delegate
 	_sioEndpoint->on("testevent", CC_CALLBACK_2(SocketIOTestLayer::testevent, this));
 	_sioEndpoint->on("echotest", CC_CALLBACK_2(SocketIOTestLayer::echotest, this));
+	_sioEndpoint->on("message", CC_CALLBACK_2(SocketIOTestLayer::message, this));
+	_sioEndpoint->on("json", CC_CALLBACK_2(SocketIOTestLayer::json, this));
+	_sioEndpoint->on("connect", CC_CALLBACK_2(SocketIOTestLayer::connect, this));
+	_sioEndpoint->on("disconnect", CC_CALLBACK_2(SocketIOTestLayer::disconnect, this));
+
 
 }
 
@@ -180,52 +270,53 @@ void SocketIOTestLayer::onMenuTestEventClicked(cocos2d::Ref *sender)
 {
 	//check that the socket is != nullptr before sending or emitting events
 	//the client should be nullptr either before initialization and connection or after disconnect
-	if(_sioClient != nullptr) _sioClient->emit("echotest","[{\"name\":\"myname\",\"type\":\"mytype\"}]");
+	if(_sioClient != nullptr) _sioClient->emit("echotest","{\"name\":\"myname\",\"type\":\"mytype\"}");
 
 }
 
 void SocketIOTestLayer::onMenuTestEventEndpointClicked(cocos2d::Ref *sender)
 {
 
-	if(_sioEndpoint != nullptr) _sioEndpoint->emit("echotest","[{\"name\":\"myname\",\"type\":\"mytype\"}]");
+	if(_sioEndpoint != nullptr) _sioEndpoint->emit("echotest","{\"name\":\"myname\",\"type\":\"mytype\"}");
 
 }
 
 void SocketIOTestLayer::onMenuTestClientDisconnectClicked(cocos2d::Ref *sender)
 {
+	// Disconnecting from the default namespace "" or "/" will also disconnect all other endpoints
+	std::stringstream s;
 
-	if(_sioClient != nullptr) _sioClient->disconnect();
+	if (_sioClient != nullptr) {
+		s << _sioClient->getTag() << " manually closed!";
+		_sioClient->disconnect();
+		_sioClient = nullptr;
+	}
+	else {
+		s << "Socket.io Test Client not initialized!";
+	}
+
+	_sioClientStatus->setString(s.str().c_str());
 
 }
 
 void SocketIOTestLayer::onMenuTestEndpointDisconnectClicked(cocos2d::Ref *sender)
 {
-
-	if(_sioEndpoint != nullptr) _sioEndpoint->disconnect();
-
-}
-
-// Delegate methods
-
-void SocketIOTestLayer::onConnect(network::SIOClient* client)
-{
-	log("SocketIOTestLayer::onConnect called");
-
 	std::stringstream s;
-	s << client->getTag() << " connected!";	
-	_sioClientStatus->setString(s.str().c_str());
-
-}
-
-void SocketIOTestLayer::onMessage(network::SIOClient* client, const std::string& data)
-{
-	log("SocketIOTestLayer::onMessage received: %s", data.c_str());
 	
-	std::stringstream s;
-	s << client->getTag() << " received message with content: " << data.c_str();	
+	if (_sioEndpoint != nullptr) {
+		s << _sioEndpoint->getTag() << " manually closed!";
+		_sioEndpoint->disconnect();		
+		_sioEndpoint = nullptr;
+	}
+	else {
+		s << "Socket.io Test Endpoint not initialized!";
+	}
+
 	_sioClientStatus->setString(s.str().c_str());
 
 }
+
+// SIODelegate methods to catch network/socket level events outside of the socket.io events
 
 void SocketIOTestLayer::onClose(network::SIOClient* client)
 {
@@ -235,15 +326,7 @@ void SocketIOTestLayer::onClose(network::SIOClient* client)
 	s << client->getTag() << " closed!";	
 	_sioClientStatus->setString(s.str().c_str());
 
-	//set the local pointer to nullptr or connect to another client
-	//the client object will be released on its own after this method completes
-	if(client == _sioClient) {
-		
-		_sioClient = nullptr;
-	} else if(client == _sioEndpoint) {
-		
-		_sioEndpoint = nullptr;
-	}
+	this->closedSocketAction(client);
 	
 }
 
@@ -256,12 +339,10 @@ void SocketIOTestLayer::onError(network::SIOClient* client, const std::string& d
 	_sioClientStatus->setString(s.str().c_str());
 }
 
-
-
-void runSocketIOTest()
+void runSocketIOTest(std::string sioversion)
 {
     auto scene = Scene::create();
-    auto layer = new (std::nothrow) SocketIOTestLayer();
+    auto layer = new (std::nothrow) SocketIOTestLayer(sioversion);
     scene->addChild(layer);
     
     Director::getInstance()->replaceScene(scene);

--- a/tests/cpp-tests/Classes/ExtensionsTest/NetworkTest/SocketIOTest.cpp
+++ b/tests/cpp-tests/Classes/ExtensionsTest/NetworkTest/SocketIOTest.cpp
@@ -127,7 +127,7 @@ SocketIOTestLayer::~SocketIOTestLayer(void)
 //test event callback handlers, these will be registered with socket.io
 void SocketIOTestLayer::testevent(SIOClient *client, const std::string& data) {
 
-	log("SocketIOTestLayer::testevent called with data: %s", data.c_str());
+	CCLOGINFO("SocketIOTestLayer::testevent called with data: %s", data.c_str());
 
 	std::stringstream s;
 	s << client->getTag() << " received event testevent with data: " << data.c_str();	
@@ -138,7 +138,7 @@ void SocketIOTestLayer::testevent(SIOClient *client, const std::string& data) {
 
 void SocketIOTestLayer::echotest(SIOClient *client, const std::string& data) {
 
-	log("SocketIOTestLayer::echotest called with data: %s", data.c_str());
+	CCLOGINFO("SocketIOTestLayer::echotest called with data: %s", data.c_str());
 
 	std::stringstream s;
 	s << client->getTag() << " received event echotest with data: " << data.c_str();	
@@ -151,7 +151,7 @@ void SocketIOTestLayer::echotest(SIOClient *client, const std::string& data) {
 // 'message' events and handlers are now registered in the same way that other events are
 void SocketIOTestLayer::message(network::SIOClient* client, const std::string& data)
 {
-	log("SocketIOTestLayer::message received: %s", data.c_str());
+	CCLOGINFO("SocketIOTestLayer::message received: %s", data.c_str());
 
 	std::stringstream s;
 	s << client->getTag() << " received message with content: " << data.c_str();
@@ -161,7 +161,7 @@ void SocketIOTestLayer::message(network::SIOClient* client, const std::string& d
 
 void SocketIOTestLayer::json(network::SIOClient* client, const std::string& data)
 {
-	log("SocketIOTestLayer::json received: %s", data.c_str());
+	CCLOGINFO("SocketIOTestLayer::json received: %s", data.c_str());
 
 	std::stringstream s;
 	s << client->getTag() << " received json message with content: " << data.c_str();
@@ -171,7 +171,7 @@ void SocketIOTestLayer::json(network::SIOClient* client, const std::string& data
 
 void SocketIOTestLayer::connect(network::SIOClient* client, const std::string& data)
 {
-	log("SocketIOTestLayer::connect called");
+	CCLOGINFO("SocketIOTestLayer::connect called");
 
 	std::stringstream s;
 	s << client->getTag() << " connected!";
@@ -181,7 +181,7 @@ void SocketIOTestLayer::connect(network::SIOClient* client, const std::string& d
 
 void SocketIOTestLayer::disconnect(network::SIOClient* client, const std::string& data)
 {
-	log("SocketIOTestLayer::disconnect called");
+	CCLOGINFO("SocketIOTestLayer::disconnect called");
 
 	std::stringstream s;
 	s << client->getTag() << " disconnected by server!";
@@ -320,7 +320,7 @@ void SocketIOTestLayer::onMenuTestEndpointDisconnectClicked(cocos2d::Ref *sender
 
 void SocketIOTestLayer::onClose(network::SIOClient* client)
 {
-	log("SocketIOTestLayer::onClose called");
+	CCLOGINFO("SocketIOTestLayer::onClose called");
 
 	std::stringstream s;
 	s << client->getTag() << " closed!";	
@@ -332,7 +332,7 @@ void SocketIOTestLayer::onClose(network::SIOClient* client)
 
 void SocketIOTestLayer::onError(network::SIOClient* client, const std::string& data)
 {
-	log("SocketIOTestLayer::onError received: %s", data.c_str());
+	CCLOGINFO("SocketIOTestLayer::onError received: %s", data.c_str());
 
 	std::stringstream s;
 	s << client->getTag() << " received error with content: " << data.c_str();	

--- a/tests/cpp-tests/Classes/ExtensionsTest/NetworkTest/SocketIOTest.h
+++ b/tests/cpp-tests/Classes/ExtensionsTest/NetworkTest/SocketIOTest.h
@@ -1,10 +1,29 @@
-//
-//  SocketIOTest.h
-//  TestCpp
-//
-//  Created by Chris Hannon on 6/26/13.
-//
-//
+/****************************************************************************
+Copyright (c) 2013-2015 Chris Hannon http://www.channon.us
+Copyright (c) 2013-2015 Chukong Technologies Inc.
+
+http://www.cocos2d-x.org
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+****************************************************************************/
+
 #ifndef __TestCpp__SocketIOTest__
 #define __TestCpp__SocketIOTest__
 
@@ -12,40 +31,85 @@
 #include "extensions/cocos-ext.h"
 #include "network/SocketIO.h"
 
+/**
+*  @brief Layer for socket.io test, implements SIODelegate for network level socket events such as disconnect and close
+*/
 class SocketIOTestLayer
 	: public cocos2d::Layer
 	, public cocos2d::network::SocketIO::SIODelegate
 {
 public:
 	SocketIOTestLayer(void);
+	SocketIOTestLayer(std::string);
 	virtual ~SocketIOTestLayer(void);
 
-	virtual void onConnect(cocos2d::network::SIOClient* client);
-    virtual void onMessage(cocos2d::network::SIOClient* client, const std::string& data);
-    virtual void onClose(cocos2d::network::SIOClient* client);
-    virtual void onError(cocos2d::network::SIOClient* client, const std::string& data);
+	/**
+	*  @brief Used for network level socket close (not for disconnect from the socket.io server)
+	*/
+	virtual void onClose(cocos2d::network::SIOClient* client);
+	/**
+	*  @brief Used for network level socket error (not for disconnect from the socket.io server)
+	**/
+	virtual void onError(cocos2d::network::SIOClient* client, const std::string& data);
+	/**
+	*  @brief Common function to call on both socket.io disconnect and websocket close
+	**/
+	void closedSocketAction(cocos2d::network::SIOClient* client);
 
 	void toExtensionsMainLayer(cocos2d::Ref *sender);
 	
+	// test action handlers for main Test Client that connects to defaul namespace "" or "/"
 	void onMenuSIOClientClicked(cocos2d::Ref *sender);
 	void onMenuTestMessageClicked(cocos2d::Ref *sender);
 	void onMenuTestEventClicked(cocos2d::Ref *sender);
 	void onMenuTestClientDisconnectClicked(cocos2d::Ref *sender);
 
+	// test action handlers for Test Endpoint that connects to /testpoint endpoint
 	void onMenuSIOEndpointClicked(cocos2d::Ref *sender);
 	void onMenuTestMessageEndpointClicked(cocos2d::Ref *sender);
 	void onMenuTestEventEndpointClicked(cocos2d::Ref *sender);
 	void onMenuTestEndpointDisconnectClicked(cocos2d::Ref *sender);
 
+	// handlers for socket.io related events
 
+	/**
+	*  @brief Socket.io event handler for custom event "testevent"
+	**/
 	void testevent(cocos2d::network::SIOClient *client, const std::string& data);
+	/**
+	*  @brief Socket.io event handler for custom event "echoevent"
+	**/
 	void echotest(cocos2d::network::SIOClient *client, const std::string& data);
+	/**
+	*  @brief Socket.io event handler for event "connect"
+	**/
+	void connect(cocos2d::network::SIOClient* client, const std::string& data);
+	/**
+	*  @brief Socket.io event handler for event "disconnect"
+	**/
+	void disconnect(cocos2d::network::SIOClient* client, const std::string& data);
+	/**
+	*  @brief Socket.io event handler for event "message"
+	**/
+	void message(cocos2d::network::SIOClient* client, const std::string& data);
+	/**
+	*  @brief Socket.io event handler for event "json"
+	*         This is only used in v 0.9.x, in 1.x this is handled as a "message" event
+	**/
+	void json(cocos2d::network::SIOClient* client, const std::string& data);
+	
+	virtual void setSIOVersion(std::string v) { _sioVersion = v; };
+	virtual std::string getSIOVersion() { return _sioVersion; };
 
+protected:
 	cocos2d::network::SIOClient *_sioClient, *_sioEndpoint;
 
 	cocos2d::Label *_sioClientStatus;
+
+	std::string _sioVersion;
+
 };
 
-void runSocketIOTest();
+void runSocketIOTest(std::string);
 
 #endif /* defined(__TestCpp__SocketIOTest__) */


### PR DESCRIPTION
This commit is a combination of the following commits:
-update handshake and handshakeResponse methods to work with both 0.9.x and 1.x socket.io versions, successfully parsing session id, heartbeat and timeout
-adds SocketIOPacket class and updates socket send, disconnect and emit methods
-update the receive / onMessage method, seperate for v0.9 and 1.0
-implements simple string packets, disconnect call, event name detection
-correctly parse endpoint and event names from the payload for socket.io 1.x
-implement json writing for socket.io 1.x message and event sending
-fixes endpoint handling between .9 and 1, cleans up some codes
-safeguard against non-existing clients
    -this occurs when you connect to an endpoint without connecting to the default namespace "" or "/" first
-onMessage and onConnect are no longer required to be overridden and should be deprecated in the future
    -onError and onClose will still be used to communicate network level issues, but seperate socket.io event handlers should be created
-socket.io connect, errors and disconnects are now handled as socket.io events, while network layer error and close are still implemented by the delegate
-update comments and license header
-fix event name and payload parsing for 0.9 method
-update tests with separate tests for socket.io 0.9.x and 1.x using the same test layer and a version initializer
-add missing register call for json message handler
-add constructor to take version as argument, update host used for tests to dev.channon.us

Signed-off-by: Chris Hannon himynameschris@gmail.com
