### PR TITLE
fix side effect of ui::button clone

### DIFF
--- a/cocos/ui/UIButton.cpp
+++ b/cocos/ui/UIButton.cpp
@@ -899,10 +899,13 @@ void Button::copySpecialProperties(Widget *widget)
         setCapInsetsNormalRenderer(button->_capInsetsNormal);
         setCapInsetsPressedRenderer(button->_capInsetsPressed);
         setCapInsetsDisabledRenderer(button->_capInsetsDisabled);
-        setTitleText(button->getTitleText());
-        setTitleFontName(button->getTitleFontName());
-        setTitleFontSize(button->getTitleFontSize());
-        setTitleColor(button->getTitleColor());
+        if(nullptr != button->getTitleRenderer())
+        {
+            setTitleText(button->getTitleText());
+            setTitleFontName(button->getTitleFontName());
+            setTitleFontSize(button->getTitleFontSize());
+            setTitleColor(button->getTitleColor());
+        }
         setPressedActionEnabled(button->_pressedActionEnabled);
         setZoomScale(button->_zoomScale);
     }

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIButtonTest/UIButtonTest.cpp
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIButtonTest/UIButtonTest.cpp
@@ -19,13 +19,14 @@ UIButtonTests::UIButtonTests()
     ADD_TEST_CASE(UIButtonFlipTest);
     ADD_TEST_CASE(UIButtonNormalDefaultTest);
     ADD_TEST_CASE(UIButtonDisableDefaultTest);
+    ADD_TEST_CASE(UIButtonCloneTest);
 }
 
 // UIButtonTest
 UIButtonTest::UIButtonTest()
 : _displayValueLabel(nullptr)
 {
-    
+
 }
 
 UIButtonTest::~UIButtonTest()
@@ -37,22 +38,22 @@ bool UIButtonTest::init()
     if (UIScene::init())
     {
         Size widgetSize = _widget->getContentSize();
-        
+
         // Add a label in which the button events will be displayed
         _displayValueLabel = Text::create("No Event", "fonts/Marker Felt.ttf",32);
         _displayValueLabel->setAnchorPoint(Vec2(0.5f, -1.0f));
         _displayValueLabel->setPosition(Vec2(widgetSize.width / 2.0f, widgetSize.height / 2.0f));
-        _uiLayer->addChild(_displayValueLabel);        
-        
+        _uiLayer->addChild(_displayValueLabel);
+
         // Add the alert
         Text* alert = Text::create("Button","fonts/Marker Felt.ttf",30);
-        alert->setColor(Color3B(159, 168, 176));                
-        
+        alert->setColor(Color3B(159, 168, 176));
+
         alert->setPosition(Vec2(widgetSize.width / 2.0f,
                                  widgetSize.height / 2.0f - alert->getContentSize().height * 1.75f));
-        
-        _uiLayer->addChild(alert);        
-        
+
+        _uiLayer->addChild(alert);
+
         // Create the button
         Button* button = Button::create("cocosui/animationbuttonnormal.png",
                                         "cocosui/animationbuttonpressed.png");
@@ -66,14 +67,14 @@ bool UIButtonTest::init()
         button->setOpacity(100);
         // Create the imageview
         ImageView* imageView = ImageView::create();
-    
+
         imageView->setPosition(Vec2(widgetSize.width / 2.0f + 50+ button->getContentSize().width/2,
                                     widgetSize.height / 2.0f));
         imageView->setTag(12);
-        
+
         _uiLayer->addChild(imageView);
-        
-        
+
+
 
         return true;
     }
@@ -87,11 +88,11 @@ void UIButtonTest::touchEvent(Ref *pSender, Widget::TouchEventType type)
         case Widget::TouchEventType::BEGAN:
             _displayValueLabel->setString(String::createWithFormat("Touch Down")->getCString());
             break;
-            
+
         case Widget::TouchEventType::MOVED:
             _displayValueLabel->setString(String::createWithFormat("Touch Move")->getCString());
             break;
-            
+
         case Widget::TouchEventType::ENDED:
         {
             _displayValueLabel->setString(String::createWithFormat("Touch Up")->getCString());
@@ -105,11 +106,11 @@ void UIButtonTest::touchEvent(Ref *pSender, Widget::TouchEventType type)
             btn->loadTextureNormal("cocosui/animationbuttonnormal.png");
         }
             break;
-            
+
         case Widget::TouchEventType::CANCELED:
             _displayValueLabel->setString(String::createWithFormat("Touch Cancelled")->getCString());
             break;
-            
+
         default:
             break;
     }
@@ -120,12 +121,12 @@ void UIButtonTest::touchEvent(Ref *pSender, Widget::TouchEventType type)
 UIButtonTest_Scale9::UIButtonTest_Scale9()
 : _displayValueLabel(nullptr)
 {
-    
+
 }
 
 UIButtonTest_Scale9::~UIButtonTest_Scale9()
 {
-    
+
 }
 
 bool UIButtonTest_Scale9::init()
@@ -133,20 +134,20 @@ bool UIButtonTest_Scale9::init()
     if (UIScene::init())
     {
         Size widgetSize = _widget->getContentSize();
-        
+
         // Add a label in which the button events will be displayed
         _displayValueLabel = Text::create("No Event", "fonts/Marker Felt.ttf", 32);
         _displayValueLabel->setAnchorPoint(Vec2(0.5f, -1.0f));
         _displayValueLabel->setPosition(Vec2(widgetSize.width / 2.0f, widgetSize.height / 2.0f));
         _uiLayer->addChild(_displayValueLabel);
-        
+
         // Add the alert
         Text* alert = Text::create("Button scale9 render", "fonts/Marker Felt.ttf",30);
         alert->setColor(Color3B(159, 168, 176));
         alert->setPosition(Vec2(widgetSize.width / 2.0f,
                                  widgetSize.height / 2.0f - alert->getContentSize().height * 1.75f));
-        _uiLayer->addChild(alert);        
-        
+        _uiLayer->addChild(alert);
+
         // Create the button
         Button* button = Button::create("cocosui/button.png", "cocosui/buttonHighlighted.png");
         // open scale9 render
@@ -156,16 +157,16 @@ bool UIButtonTest_Scale9::init()
         button->setPressedActionEnabled(true);
         button->addTouchEventListener(CC_CALLBACK_2(UIButtonTest_Scale9::touchEvent, this));
         _uiLayer->addChild(button);
-        
+
         // Create the imageview
         Button* button2 = Button::create();
         button2->setPosition(Vec2(widgetSize.width / 2.0f + button->getContentSize().width + 20, widgetSize.height / 2.0f));
         button2->setName("normal");
         _uiLayer->addChild(button2);
-        
+
         Sprite *sprite = Sprite::create("cocosui/animationbuttonnormal.png");
         button2->addChild(sprite);
-        
+
         return true;
     }
     return false;
@@ -178,11 +179,11 @@ void UIButtonTest_Scale9::touchEvent(Ref *pSender, Widget::TouchEventType type)
         case Widget::TouchEventType::BEGAN:
             _displayValueLabel->setString(String::createWithFormat("Touch Down")->getCString());
             break;
-            
+
         case Widget::TouchEventType::MOVED:
             _displayValueLabel->setString(String::createWithFormat("Touch Move")->getCString());
             break;
-            
+
         case Widget::TouchEventType::ENDED:
         {
             _displayValueLabel->setString(String::createWithFormat("Touch Up")->getCString());
@@ -192,11 +193,11 @@ void UIButtonTest_Scale9::touchEvent(Ref *pSender, Widget::TouchEventType type)
             btn->runAction(Sequence::create(FadeIn::create(0.5),DelayTime::create(1.0),FadeOut::create(0.5), nullptr));
         }
             break;
-            
+
         case Widget::TouchEventType::CANCELED:
             _displayValueLabel->setString(String::createWithFormat("Touch Cancelled")->getCString());
             break;
-            
+
         default:
             break;
     }
@@ -309,22 +310,22 @@ bool UIButtonTest_PressedAction::init()
     if (UIScene::init())
     {
         Size widgetSize = _widget->getContentSize();
-        
+
         // Add a label in which the button events will be displayed
         _displayValueLabel = Text::create("No Event", "fonts/Marker Felt.ttf",32);
         _displayValueLabel->setAnchorPoint(Vec2(0.5f, -1.0f));
         _displayValueLabel->setPosition(Vec2(widgetSize.width / 2.0f, widgetSize.height / 2.0f));
         _uiLayer->addChild(_displayValueLabel);
-        
+
         // Add the alert
         Text* alert = Text::create("Button Pressed Action", "fonts/Marker Felt.ttf", 30);
         alert->setColor(Color3B(159, 168, 176));
-        
+
         alert->setPosition(Vec2(widgetSize.width / 2.0f,
                                  widgetSize.height / 2.0f - alert->getContentSize().height * 1.75f));
-        
+
         _uiLayer->addChild(alert);
-        
+
         // Create the button
         Button* button = Button::create("cocosui/animationbuttonnormal.png", "cocosui/animationbuttonpressed.png");
         button->setPressedActionEnabled(true);
@@ -334,12 +335,12 @@ bool UIButtonTest_PressedAction::init()
         button->addTouchEventListener(CC_CALLBACK_2(UIButtonTest_PressedAction::touchEvent, this));
         button->setName("button");
         _uiLayer->addChild(button);
-        
+
         Button* button2 = Button::create("cocosui/animationbuttonnormal.png", "cocosui/animationbuttonpressed.png");
         button2->setPosition(button->getPosition() + Vec2(100,0));
         button2->setName("button2");
         _uiLayer->addChild(button2);
-        
+
         return true;
     }
     return false;
@@ -352,26 +353,26 @@ void UIButtonTest_PressedAction::touchEvent(Ref *pSender, Widget::TouchEventType
         case Widget::TouchEventType::BEGAN:
             _displayValueLabel->setString(String::createWithFormat("Touch Down")->getCString());
             break;
-            
+
         case Widget::TouchEventType::MOVED:
             _displayValueLabel->setString(String::createWithFormat("Touch Move")->getCString());
             break;
-            
+
         case Widget::TouchEventType::ENDED:
         {
             _displayValueLabel->setString(String::createWithFormat("Touch Up")->getCString());
             Button* btn = (Button*)_uiLayer->getChildByName("button");
             btn->loadTextureNormal("cocosui/animationbuttonnormal.png");
-            
+
             Button* btn2 = (Button*)_uiLayer->getChildByName("button2");
             btn2->setAnchorPoint(Vec2(0,0.5));
         }
             break;
-            
+
         case Widget::TouchEventType::CANCELED:
             _displayValueLabel->setString(String::createWithFormat("Touch Cancelled")->getCString());
             break;
-            
+
         default:
             break;
     }
@@ -381,7 +382,7 @@ void UIButtonTest_PressedAction::touchEvent(Ref *pSender, Widget::TouchEventType
 UIButtonTest_Title::UIButtonTest_Title()
 : _displayValueLabel(nullptr)
 {
-    
+
 }
 
 UIButtonTest_Title::~UIButtonTest_Title()
@@ -393,21 +394,21 @@ bool UIButtonTest_Title::init()
     if (UIScene::init())
     {
         Size widgetSize = _widget->getContentSize();
-        
+
         // Add a label in which the text button events will be displayed
         _displayValueLabel = Text::create("No Event", "fonts/Marker Felt.ttf", 32);
         _displayValueLabel->setAnchorPoint(Vec2(0.5f, -1));
         _displayValueLabel->setPosition(Vec2(widgetSize.width / 2.0f, widgetSize.height / 2.0f));
         _uiLayer->addChild(_displayValueLabel);
-        
+
         // Add the alert
         Text* alert = Text::create("Button with title, title should be flipped!", "fonts/Marker Felt.ttf", 30);
         alert->setColor(Color3B(159, 168, 176));
         alert->setPosition(Vec2(widgetSize.width / 2.0f,
                                  widgetSize.height / 2.0f - alert->getContentSize().height * 1.75f));
-        
+
         _uiLayer->addChild(alert);
-        
+
         // Create the button with title
         Button* button = Button::create("cocosui/backtotoppressed.png", "cocosui/backtotopnormal.png");
         button->setTitleText("Title Button!");
@@ -421,8 +422,8 @@ bool UIButtonTest_Title::init()
         label->setScale(4.0);
         button->runAction(RepeatForever::create(Sequence::create(ScaleTo::create(1.0f, 1.2f),
                                                                  ScaleTo::create(1.0f, 1.0f),nullptr)));
-        
-        
+
+
         TextBMFont *text = TextBMFont::create("BMFont", "cocosui/bitmapFontTest2.fnt");
         text->setPosition(button->getPosition() + Vec2(button->getContentSize().width/2 + 50,0));
         text->setColor(Color3B::YELLOW);
@@ -431,7 +432,7 @@ bool UIButtonTest_Title::init()
 
 
         _uiLayer->addChild(text);
-        
+
         return true;
     }
     return false;
@@ -445,11 +446,11 @@ void UIButtonTest_Title::touchEvent(Ref *pSender, Widget::TouchEventType type)
         case Widget::TouchEventType::BEGAN:
             _displayValueLabel->setString(String::createWithFormat("Touch Down")->getCString());
             break;
-            
+
         case Widget::TouchEventType::MOVED:
             _displayValueLabel->setString(String::createWithFormat("Touch Move")->getCString());
             break;
-            
+
         case Widget::TouchEventType::ENDED:
         {
             _displayValueLabel->setString(String::createWithFormat("Touch Up")->getCString());
@@ -463,11 +464,11 @@ void UIButtonTest_Title::touchEvent(Ref *pSender, Widget::TouchEventType type)
             }
         }
             break;
-            
+
         case Widget::TouchEventType::CANCELED:
             _displayValueLabel->setString(String::createWithFormat("Touch Cancelled")->getCString());
             break;
-            
+
         default:
             break;
     }
@@ -478,7 +479,7 @@ void UIButtonTest_Title::touchEvent(Ref *pSender, Widget::TouchEventType type)
 UIButtonTestRemoveSelf::UIButtonTestRemoveSelf()
 : _displayValueLabel(nullptr)
 {
-    
+
 }
 
 UIButtonTestRemoveSelf::~UIButtonTestRemoveSelf()
@@ -490,22 +491,22 @@ bool UIButtonTestRemoveSelf::init()
     if (UIScene::init())
     {
         Size widgetSize = _widget->getContentSize();
-        
+
         // Add a label in which the button events will be displayed
         _displayValueLabel = Text::create("No Event", "fonts/Marker Felt.ttf",32);
         _displayValueLabel->setAnchorPoint(Vec2(0.5f, -1.0f));
         _displayValueLabel->setPosition(Vec2(widgetSize.width / 2.0f, widgetSize.height / 2.0f));
         _uiLayer->addChild(_displayValueLabel);
-        
+
         // Add the alert
         Text* alert = Text::create("Remove Self in the Button's Callback shouldn't cause crash!","fonts/Marker Felt.ttf",10);
         alert->setColor(Color3B(159, 168, 176));
-        
+
         alert->setPosition(Vec2(widgetSize.width / 2.0f,
                                 widgetSize.height / 2.0f - alert->getContentSize().height * 2.75f));
-        
+
         _uiLayer->addChild(alert);
-        
+
         Layout *layout = Layout::create();
         layout->setContentSize(widgetSize * 0.6f);
         layout->setBackGroundColor(Color3B::GREEN);
@@ -515,7 +516,7 @@ bool UIButtonTestRemoveSelf::init()
         layout->setAnchorPoint(Vec2::ANCHOR_MIDDLE);
         layout->setTag(12);
         _uiLayer->addChild(layout);
-        
+
         // Create the button
         Button* button = Button::create("cocosui/animationbuttonnormal.png",
                                         "cocosui/animationbuttonpressed.png");
@@ -523,9 +524,9 @@ bool UIButtonTestRemoveSelf::init()
         //        button->addTouchEventListener(this, toucheventselector(UIButtonTest::touchEvent));
         button->addTouchEventListener(CC_CALLBACK_2(UIButtonTestRemoveSelf::touchEvent, this));
         layout->addChild(button);
-        
-        
-        
+
+
+
         return true;
     }
     return false;
@@ -538,11 +539,11 @@ void UIButtonTestRemoveSelf::touchEvent(Ref *pSender, Widget::TouchEventType typ
         case Widget::TouchEventType::BEGAN:
             _displayValueLabel->setString(String::createWithFormat("Touch Down")->getCString());
             break;
-            
+
         case Widget::TouchEventType::MOVED:
             _displayValueLabel->setString(String::createWithFormat("Touch Move")->getCString());
             break;
-            
+
         case Widget::TouchEventType::ENDED:
         {
             _displayValueLabel->setString(String::createWithFormat("Touch Up")->getCString());
@@ -550,11 +551,11 @@ void UIButtonTestRemoveSelf::touchEvent(Ref *pSender, Widget::TouchEventType typ
             layout->removeFromParentAndCleanup(true);
         }
             break;
-            
+
         case Widget::TouchEventType::CANCELED:
             _displayValueLabel->setString(String::createWithFormat("Touch Cancelled")->getCString());
             break;
-            
+
         default:
             break;
     }
@@ -564,7 +565,7 @@ void UIButtonTestRemoveSelf::touchEvent(Ref *pSender, Widget::TouchEventType typ
 UIButtonTestSwitchScale9::UIButtonTestSwitchScale9()
 : _displayValueLabel(nullptr)
 {
-    
+
 }
 
 UIButtonTestSwitchScale9::~UIButtonTestSwitchScale9()
@@ -576,14 +577,14 @@ bool UIButtonTestSwitchScale9::init()
     if (UIScene::init())
     {
         Size widgetSize = _widget->getContentSize();
-        
+
         // Add a label in which the button events will be displayed
         _displayValueLabel = Text::create("No Event", "fonts/Marker Felt.ttf",32);
         _displayValueLabel->setAnchorPoint(Vec2(0.5f, -1.0f));
         _displayValueLabel->setPosition(Vec2(widgetSize.width / 2.0f, widgetSize.height / 2.0f));
         _uiLayer->addChild(_displayValueLabel);
-        
-        
+
+
         // Create the button
         Button* button = Button::create("cocosui/animationbuttonnormal.png",
                                         "cocosui/animationbuttonpressed.png");
@@ -591,11 +592,11 @@ bool UIButtonTestSwitchScale9::init()
         button->addTouchEventListener(CC_CALLBACK_2(UIButtonTestSwitchScale9::touchEvent, this));
         button->setTitleText("Button Title");
         button->ignoreContentAdaptWithSize(false);
-        
+
         _uiLayer->addChild(button);
-        
-        
-        
+
+
+
         return true;
     }
     return false;
@@ -608,11 +609,11 @@ void UIButtonTestSwitchScale9::touchEvent(Ref *pSender, Widget::TouchEventType t
         case Widget::TouchEventType::BEGAN:
             _displayValueLabel->setString(String::createWithFormat("Touch Down")->getCString());
             break;
-            
+
         case Widget::TouchEventType::MOVED:
             _displayValueLabel->setString(String::createWithFormat("Touch Move")->getCString());
             break;
-            
+
         case Widget::TouchEventType::ENDED:
         {
             _displayValueLabel->setString(String::createWithFormat("Touch Up")->getCString());
@@ -621,11 +622,11 @@ void UIButtonTestSwitchScale9::touchEvent(Ref *pSender, Widget::TouchEventType t
             btn->setContentSize(Size(200,100));
         }
             break;
-            
+
         case Widget::TouchEventType::CANCELED:
             _displayValueLabel->setString(String::createWithFormat("Touch Cancelled")->getCString());
             break;
-            
+
         default:
             break;
     }
@@ -636,7 +637,7 @@ void UIButtonTestSwitchScale9::touchEvent(Ref *pSender, Widget::TouchEventType t
 UIButtonTestZoomScale::UIButtonTestZoomScale()
 : _displayValueLabel(nullptr)
 {
-    
+
 }
 
 UIButtonTestZoomScale::~UIButtonTestZoomScale()
@@ -648,14 +649,14 @@ bool UIButtonTestZoomScale::init()
     if (UIScene::init())
     {
         Size widgetSize = _widget->getContentSize();
-        
+
         // Add a label in which the button events will be displayed
         _displayValueLabel = Text::create("Zoom Scale: -0.5", "fonts/Marker Felt.ttf",32);
         _displayValueLabel->setAnchorPoint(Vec2(0.5f, -1.0f));
         _displayValueLabel->setPosition(Vec2(widgetSize.width / 2.0f, widgetSize.height / 2.0f + 20));
         _uiLayer->addChild(_displayValueLabel);
-        
-        
+
+
         // Create the button
         Button* button = Button::create("cocosui/animationbuttonnormal.png",
                                         "cocosui/animationbuttonpressed.png");
@@ -664,12 +665,12 @@ bool UIButtonTestZoomScale::init()
         button->addClickEventListener([=](Ref* sender){
             CCLOG("Button clicked, position = (%f, %f)", button->getPosition().x,
                   button->getPosition().y);
-            
+
         });
         button->setName("button");
         _uiLayer->addChild(button);
         button->setZoomScale(-0.5);
-        
+
         Slider* slider = Slider::create();
         slider->loadBarTexture("cocosui/sliderTrack.png");
         slider->loadSlidBallTextures("cocosui/sliderThumb.png", "cocosui/sliderThumb.png", "");
@@ -700,7 +701,7 @@ void UIButtonTestZoomScale::sliderEvent(Ref *pSender, Slider::EventType type)
 UIButtonTextOnly::UIButtonTextOnly()
 : _displayValueLabel(nullptr)
 {
-    
+
 }
 
 UIButtonTextOnly::~UIButtonTextOnly()
@@ -712,18 +713,18 @@ bool UIButtonTextOnly::init()
     if (UIScene::init())
     {
         Size widgetSize = _widget->getContentSize();
-        
+
         // Add a label in which the button events will be displayed
         _displayValueLabel = Text::create("Text Only Button", "fonts/Marker Felt.ttf",32);
         _displayValueLabel->setAnchorPoint(Vec2(0.5f, -1.0f));
         _displayValueLabel->setPosition(Vec2(widgetSize.width / 2.0f, widgetSize.height / 2.0f + 20));
         _uiLayer->addChild(_displayValueLabel);
-        
-        
+
+
         // Create the button
         auto button = Button::create();
         button->setNormalizedPosition(Vec2(0.5f, 0.5f));
-       
+
         button->setTitleText("PLAY GAME");
         CCLOG("content size should be greater than 0:  width = %f, height = %f", button->getContentSize().width,
               button->getContentSize().height);
@@ -733,7 +734,7 @@ bool UIButtonTextOnly::init()
             CCLOG("clicked!");
         });
         _uiLayer->addChild(button);
-        
+
         return true;
     }
     return false;
@@ -743,7 +744,7 @@ bool UIButtonTextOnly::init()
 UIButtonIgnoreContentSizeTest::UIButtonIgnoreContentSizeTest()
 : _displayValueLabel(nullptr)
 {
-    
+
 }
 
 UIButtonIgnoreContentSizeTest::~UIButtonIgnoreContentSizeTest()
@@ -755,14 +756,14 @@ bool UIButtonIgnoreContentSizeTest::init()
     if (UIScene::init())
     {
         Size widgetSize = _widget->getContentSize();
-        
+
         // Add a label in which the button events will be displayed
         _displayValueLabel = Text::create("Button IgnoreContent Size Test", "fonts/Marker Felt.ttf",32);
         _displayValueLabel->setAnchorPoint(Vec2(0.5f, -1.0f));
         _displayValueLabel->setPosition(Vec2(widgetSize.width / 2.0f, widgetSize.height / 2.0f + 20));
         _uiLayer->addChild(_displayValueLabel);
-        
-        
+
+
         // Create the button
         auto button = Button::create("cocosui/animationbuttonnormal.png",
                                      "cocosui/animationbuttonpressed.png");
@@ -777,7 +778,7 @@ bool UIButtonIgnoreContentSizeTest::init()
             button->setScale(1.2f);
         });
         _uiLayer->addChild(button);
-        
+
         // Create the button
         auto button2 = Button::create("cocosui/animationbuttonnormal.png",
                                      "cocosui/animationbuttonpressed.png");
@@ -792,7 +793,7 @@ bool UIButtonIgnoreContentSizeTest::init()
             CCLOG("clicked!");
         });
         _uiLayer->addChild(button2);
-        
+
         return true;
     }
     return false;
@@ -803,7 +804,7 @@ bool UIButtonIgnoreContentSizeTest::init()
 UIButtonTitleEffectTest::UIButtonTitleEffectTest()
 : _displayValueLabel(nullptr)
 {
-    
+
 }
 
 UIButtonTitleEffectTest::~UIButtonTitleEffectTest()
@@ -815,14 +816,14 @@ bool UIButtonTitleEffectTest::init()
     if (UIScene::init())
     {
         Size widgetSize = _widget->getContentSize();
-        
+
         // Add a label in which the button events will be displayed
         _displayValueLabel = Text::create("Button Title Effect", "fonts/Marker Felt.ttf",32);
         _displayValueLabel->setAnchorPoint(Vec2(0.5f, -1.0f));
         _displayValueLabel->setPosition(Vec2(widgetSize.width / 2.0f, widgetSize.height / 2.0f + 20));
         _uiLayer->addChild(_displayValueLabel);
-        
-        
+
+
         // Create the button
         auto button = Button::create("cocosui/animationbuttonnormal.png",
                                      "cocosui/animationbuttonpressed.png");
@@ -836,9 +837,9 @@ bool UIButtonTitleEffectTest::init()
         button->setTitleColor(Color3B::RED);
         title->enableShadow(Color4B::BLACK,Size(2,-2));
 
-        
+
         _uiLayer->addChild(button);
-        
+
         // Create the button
         auto button2 = Button::create("cocosui/animationbuttonnormal.png",
                                       "cocosui/animationbuttonpressed.png");
@@ -847,7 +848,7 @@ bool UIButtonTitleEffectTest::init()
         auto title2 = button2->getTitleRenderer();
         title2->enableOutline(Color4B::GREEN, 3);
         _uiLayer->addChild(button2);
-        
+
         return true;
     }
     return false;
@@ -856,7 +857,7 @@ bool UIButtonTitleEffectTest::init()
 UIButtonFlipTest::UIButtonFlipTest()
 : _displayValueLabel(nullptr)
 {
-    
+
 }
 
 UIButtonFlipTest::~UIButtonFlipTest()
@@ -868,13 +869,13 @@ bool UIButtonFlipTest::init()
     if (UIScene::init())
     {
         Size widgetSize = _widget->getContentSize();
-        
+
         // Add a label in which the button events will be displayed
         _displayValueLabel = Text::create("Button X Flipped", "fonts/Marker Felt.ttf",20);
         _displayValueLabel->setNormalizedPosition(Vec2(0.3f, 0.7f));
         _uiLayer->addChild(_displayValueLabel);
-        
-        
+
+
         // Create the button
         auto button = Button::create("cocosui/animationbuttonnormal.png",
                                      "cocosui/animationbuttonpressed.png");
@@ -885,10 +886,10 @@ bool UIButtonFlipTest::init()
         button->setScale(2.0f);
         button->setFlippedX(true);
         button->setPressedActionEnabled(true);
-        
-        
+
+
         _uiLayer->addChild(button);
-        
+
         // Create the button
         auto button2 = Button::create("cocosui/animationbuttonnormal.png",
                                       "cocosui/animationbuttonpressed.png");
@@ -896,11 +897,11 @@ bool UIButtonFlipTest::init()
         button2->setTitleText("PLAY GAME");
         button2->setFlippedY(true);
         _uiLayer->addChild(button2);
-        
+
         auto titleLabel = Text::create("Button Y flipped", "Arial", 20);
         titleLabel->setNormalizedPosition(Vec2(0.8f, 0.7f));
         this->addChild(titleLabel);
-        
+
         return true;
     }
     return false;
@@ -910,7 +911,7 @@ bool UIButtonFlipTest::init()
 UIButtonNormalDefaultTest::UIButtonNormalDefaultTest()
 : _displayValueLabel(nullptr)
 {
-    
+
 }
 
 UIButtonNormalDefaultTest::~UIButtonNormalDefaultTest()
@@ -922,29 +923,29 @@ bool UIButtonNormalDefaultTest::init()
     if (UIScene::init())
     {
         Size widgetSize = _widget->getContentSize();
-        
+
         // Add a label in which the button events will be displayed
         _displayValueLabel = Text::create("", "fonts/Marker Felt.ttf",32);
         _displayValueLabel->setAnchorPoint(Vec2(0.5f, -1.0f));
         _displayValueLabel->setPosition(Vec2(widgetSize.width / 2.0f, widgetSize.height / 2.0f));
         _uiLayer->addChild(_displayValueLabel);
-        
+
         // Add the alert
         Text* alert = Text::create("Button should scale when clicked","fonts/Marker Felt.ttf",20);
         alert->setColor(Color3B(159, 168, 176));
-        
+
         alert->setPosition(Vec2(widgetSize.width / 2.0f,
                                 widgetSize.height / 2.0f - alert->getContentSize().height * 1.75f));
-        
+
         _uiLayer->addChild(alert);
-        
+
         // Create the button
         Button* button = Button::create("cocosui/animationbuttonnormal.png");
         button->setPosition(Vec2(widgetSize.width / 2.0f - 80, widgetSize.height / 2.0f + 40));
         button->setZoomScale(0.4f);
         button->setPressedActionEnabled(true);
         _uiLayer->addChild(button);
-        
+
         // Create the button
         Button* buttonScale9 = Button::create("cocosui/button.png");
         // open scale9 render
@@ -954,9 +955,9 @@ bool UIButtonNormalDefaultTest::init()
         buttonScale9->setPressedActionEnabled(true);
         _uiLayer->addChild(buttonScale9);
 
-        
-        
-        
+
+
+
         return true;
     }
     return false;
@@ -967,7 +968,7 @@ bool UIButtonNormalDefaultTest::init()
 UIButtonDisableDefaultTest::UIButtonDisableDefaultTest()
 : _displayValueLabel(nullptr)
 {
-    
+
 }
 
 UIButtonDisableDefaultTest::~UIButtonDisableDefaultTest()
@@ -979,22 +980,22 @@ bool UIButtonDisableDefaultTest::init()
     if (UIScene::init())
     {
         Size widgetSize = _widget->getContentSize();
-        
+
         // Add a label in which the button events will be displayed
         _displayValueLabel = Text::create("", "fonts/Marker Felt.ttf",32);
         _displayValueLabel->setAnchorPoint(Vec2(0.5f, -1.0f));
         _displayValueLabel->setPosition(Vec2(widgetSize.width / 2.0f, widgetSize.height / 2.0f));
         _uiLayer->addChild(_displayValueLabel);
-        
+
         // Add the alert
         Text* alert = Text::create("Left button will turn normal when clicked","fonts/Marker Felt.ttf",20);
         alert->setColor(Color3B(159, 168, 176));
-        
+
         alert->setPosition(Vec2(widgetSize.width / 2.0f,
                                 widgetSize.height / 2.0f - alert->getContentSize().height * 1.75f));
-        
+
         _uiLayer->addChild(alert);
-        
+
         // Create the button
         Button* button = Button::create("cocosui/animationbuttonnormal.png");
         button->setPosition(Vec2(widgetSize.width / 2.0f - 80, widgetSize.height / 2.0f + 40));
@@ -1005,7 +1006,7 @@ bool UIButtonDisableDefaultTest::init()
             button->setBright(true);
         });
         _uiLayer->addChild(button);
-        
+
         // Create the button
         Button* buttonScale9 = Button::create("cocosui/button.png");
         // open scale9 render
@@ -1016,10 +1017,71 @@ bool UIButtonDisableDefaultTest::init()
         buttonScale9->setEnabled(false);
         buttonScale9->setBright(false);
         _uiLayer->addChild(buttonScale9);
-        
-        
-        
-        
+
+
+
+
+        return true;
+    }
+    return false;
+}
+
+// UIButtonCloneTest
+UIButtonCloneTest::UIButtonCloneTest()
+: _displayValueLabel(nullptr)
+{
+
+}
+
+UIButtonCloneTest::~UIButtonCloneTest()
+{
+}
+
+bool UIButtonCloneTest::init()
+{
+    if (UIScene::init())
+    {
+        Size widgetSize = _widget->getContentSize();
+
+        // Add a label in which the button events will be displayed
+        _displayValueLabel = Text::create("", "fonts/Marker Felt.ttf",32);
+        _displayValueLabel->setAnchorPoint(Vec2(0.5f, -1.0f));
+        _displayValueLabel->setPosition(Vec2(widgetSize.width / 2.0f,
+                                             widgetSize.height / 2.0f));
+        _uiLayer->addChild(_displayValueLabel);
+
+        // Add the alert
+        Text* alert = Text::create("This test case shouldn't trigger the Assertion!",
+                                   "fonts/Marker Felt.ttf",20);
+        alert->setColor(Color3B(159, 168, 176));
+
+        alert->setPosition(Vec2(widgetSize.width / 2.0f,
+                                widgetSize.height / 2.0f
+                                - alert->getContentSize().height * 1.75f));
+
+        _uiLayer->addChild(alert);
+
+        // Create the button
+        Button* button = Button::create("cocosui/animationbuttonnormal.png");
+        button->setPosition(Vec2(widgetSize.width / 2.0f - 80,
+                                 widgetSize.height / 2.0f + 40));
+        _uiLayer->addChild(button);
+
+
+        CCASSERT(button->getTitleRenderer() == nullptr,
+                 "Button title render must be nullptr ");
+
+        auto buttonCopy = (Button*)button->clone();
+        buttonCopy->setPosition(Vec2(widgetSize.width / 2.0f + 80,
+                                     widgetSize.height / 2.0f + 40));
+        this->addChild(buttonCopy);
+
+        CCASSERT(button->getTitleRenderer() == nullptr,
+                 "Original Button title render must be nullptr ");
+
+        CCASSERT(buttonCopy->getTitleRenderer() == nullptr,
+                 "Copied Button title render must be nullptr ");
+
         return true;
     }
     return false;

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIButtonTest/UIButtonTest.h
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIButtonTest/UIButtonTest.h
@@ -1,18 +1,18 @@
 /****************************************************************************
  Copyright (c) 2013 cocos2d-x.org
- 
+
  http://www.cocos2d-x.org
- 
+
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal
  in the Software without restriction, including without limitation the rights
  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  copies of the Software, and to permit persons to whom the Software is
  furnished to do so, subject to the following conditions:
- 
+
  The above copyright notice and this permission notice shall be included in
  all copies or substantial portions of the Software.
- 
+
  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -54,7 +54,7 @@ public:
 
     virtual bool init() override;
     void touchEvent(cocos2d::Ref* sender, cocos2d::ui::Widget::TouchEventType type);
-    
+
 protected:
     cocos2d::ui::Text* _displayValueLabel;
 };
@@ -84,7 +84,7 @@ public:
 
     virtual bool init() override;
     void touchEvent(cocos2d::Ref* sender, cocos2d::ui::Widget::TouchEventType type);
-    
+
 protected:
     cocos2d::ui::Text* _displayValueLabel;
 };
@@ -99,7 +99,7 @@ public:
 
     virtual bool init() override;
     void touchEvent(cocos2d::Ref* sender, cocos2d::ui::Widget::TouchEventType type);
-    
+
 protected:
     cocos2d::ui::Text* _displayValueLabel;
 };
@@ -114,7 +114,7 @@ public:
 
     virtual bool init() override;
     void touchEvent(cocos2d::Ref* sender, cocos2d::ui::Widget::TouchEventType type);
-    
+
 protected:
     cocos2d::ui::Text* _displayValueLabel;
 };
@@ -129,7 +129,7 @@ public:
 
     virtual bool init() override;
     void touchEvent(cocos2d::Ref* sender, cocos2d::ui::Widget::TouchEventType type);
-    
+
 protected:
     cocos2d::ui::Text* _displayValueLabel;
 };
@@ -172,7 +172,7 @@ public:
     ~UIButtonIgnoreContentSizeTest();
 
     virtual bool init() override;
-    
+
 protected:
     cocos2d::ui::Text* _displayValueLabel;
 };
@@ -186,7 +186,7 @@ public:
     ~UIButtonTitleEffectTest();
 
     virtual bool init() override;
-    
+
 protected:
     cocos2d::ui::Text* _displayValueLabel;
 };
@@ -200,7 +200,7 @@ public:
     ~UIButtonFlipTest();
 
     virtual bool init() override;
-    
+
 protected:
     cocos2d::ui::Text* _displayValueLabel;
 };
@@ -214,7 +214,7 @@ public:
     ~UIButtonNormalDefaultTest();
 
     virtual bool init() override;
-    
+
 protected:
     cocos2d::ui::Text* _displayValueLabel;
 };
@@ -228,7 +228,21 @@ public:
     ~UIButtonDisableDefaultTest();
 
     virtual bool init() override;
-    
+
+protected:
+    cocos2d::ui::Text* _displayValueLabel;
+};
+
+class UIButtonCloneTest : public UIScene
+{
+public:
+    CREATE_FUNC(UIButtonCloneTest);
+
+    UIButtonCloneTest();
+    ~UIButtonCloneTest();
+
+    virtual bool init() override;
+
 protected:
     cocos2d::ui::Text* _displayValueLabel;
 };


### PR DESCRIPTION
In the previous PR https://github.com/cocos2d/cocos2d-x/pull/11429, 
I have optimized the memory consumption. 

Now the title of button will be created on demand. But in the previous PR, the clone method couldn't clone a exactly copy of the original one. 

When the original button doesn't have title renderer, we shouldn't create the title renderer for the cloned copy.

So this PR fix this issue and a test case also be added.
