### PR TITLE
remove system zlib dependency since we use our own prebuilt version

### DIFF
--- a/cocos/platform/android/Android.mk
+++ b/cocos/platform/android/Android.mk
@@ -33,7 +33,6 @@ LOCAL_EXPORT_LDLIBS := -lGLESv1_CM \
                        -lGLESv2 \
                        -lEGL \
                        -llog \
-                       -lz \
                        -landroid
 
 LOCAL_CPPFLAGS := -Wno-extern-c-compat

--- a/cocos/scripting/lua-bindings/proj.android/Android.mk
+++ b/cocos/scripting/lua-bindings/proj.android/Android.mk
@@ -17,7 +17,6 @@ LOCAL_C_INCLUDES := $(LOCAL_PATH)/../../.. \
 
 LOCAL_EXPORT_LDLIBS := -lGLESv2 \
                        -llog \
-                       -lz \
                        -landroid
 
 LOCAL_STATIC_LIBRARIES := luajit_static


### PR DESCRIPTION
This PR doesn't do anything useful but make the code and intent cleaner.
