### PR TITLE
V3 WinRT fixes for WIC image encode

### DIFF
--- a/cocos/platform/win8.1-universal/OpenGLESPage.xaml.cpp
+++ b/cocos/platform/win8.1-universal/OpenGLESPage.xaml.cpp
@@ -283,6 +283,11 @@ void OpenGLESPage::StartRenderLoop()
             {
                 m_deviceLost = true;
 
+                if (m_renderer)
+                {
+                    m_renderer->Pause();
+                }
+
                 // XAML objects like the SwapChainPanel must only be manipulated on the UI thread.
                 swapChainPanel->Dispatcher->RunAsync(Windows::UI::Core::CoreDispatcherPriority::High, ref new Windows::UI::Core::DispatchedHandler([=]()
                 {
@@ -291,6 +296,11 @@ void OpenGLESPage::StartRenderLoop()
 
                 return;
             }
+        }
+
+        if (m_renderer)
+        {
+            m_renderer->Pause();
         }
     });
 
@@ -304,10 +314,5 @@ void OpenGLESPage::StopRenderLoop()
     {
         mRenderLoopWorker->Cancel();
         mRenderLoopWorker = nullptr;
-    }
-
-    if (m_renderer)
-    {
-        m_renderer->Pause();
     }
 }

--- a/cocos/platform/win8.1-universal/OpenGLESPage.xaml.cpp
+++ b/cocos/platform/win8.1-universal/OpenGLESPage.xaml.cpp
@@ -36,6 +36,10 @@ using namespace Windows::UI::Xaml::Input;
 using namespace Windows::UI::Xaml::Media;
 using namespace Windows::UI::Xaml::Navigation;
 
+#if (WINAPI_FAMILY == WINAPI_FAMILY_PHONE_APP)
+using namespace Windows::Phone::UI::Input;
+#endif
+
 OpenGLESPage::OpenGLESPage() :
     OpenGLESPage(nullptr)
 {
@@ -76,6 +80,7 @@ OpenGLESPage::OpenGLESPage(OpenGLES* openGLES) :
 
 #if (WINAPI_FAMILY == WINAPI_FAMILY_PHONE_APP)
     Windows::UI::ViewManagement::StatusBar::GetForCurrentView()->HideAsync();
+    HardwareButtons::BackPressed += ref new EventHandler<BackPressedEventArgs^>(this, &OpenGLESPage::OnBackButtonPressed);
 #else
     // Disable all pointer visual feedback for better performance when touching.
     // This is not supported on Windows Phone applications.
@@ -162,6 +167,21 @@ void OpenGLESPage::OnVisibilityChanged(Windows::UI::Core::CoreWindow^ sender, Wi
         StopRenderLoop();
     }
 }
+
+#if (WINAPI_FAMILY == WINAPI_FAMILY_PHONE_APP)
+void OpenGLESPage::OnBackButtonPressed(Object^ sender, BackPressedEventArgs^ args)
+{
+    bool myAppCanNavigate = false;
+    if (myAppCanNavigate)
+    {
+        args->Handled = true;
+    }
+    else {
+        // Do nothing. Leave args->Handled set to the current value, false.
+    }
+}
+#endif
+
 
 void OpenGLESPage::OnSwapChainPanelSizeChanged(Object^ sender, Windows::UI::Xaml::SizeChangedEventArgs^ e)
 {

--- a/cocos/platform/win8.1-universal/OpenGLESPage.xaml.h
+++ b/cocos/platform/win8.1-universal/OpenGLESPage.xaml.h
@@ -39,6 +39,9 @@ namespace cocos2d
         void OnPageLoaded(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e);
         void OnVisibilityChanged(Windows::UI::Core::CoreWindow^ sender, Windows::UI::Core::VisibilityChangedEventArgs^ args);
         void OnSwapChainPanelSizeChanged(Platform::Object^ sender, Windows::UI::Xaml::SizeChangedEventArgs^ e);
+#if (WINAPI_FAMILY == WINAPI_FAMILY_PHONE_APP)
+        void OnBackButtonPressed(Platform::Object^ sender, Windows::Phone::UI::Input::BackPressedEventArgs^ args);
+#endif
         void GetSwapChainPanelSize(GLsizei* width, GLsizei* height);
         void CreateRenderSurface();
         void DestroyRenderSurface();

--- a/cocos/platform/winrt/WICImageLoader-win.cpp
+++ b/cocos/platform/winrt/WICImageLoader-win.cpp
@@ -325,23 +325,21 @@ WICPixelFormatGUID WICImageLoader::getPixelFormat()
 	return _format;
 }
 
-bool WICImageLoader::encodeImageData(std::string path, ImageBlob data, size_t dataLen, WICPixelFormatGUID pixelFormat, int width, int height, GUID containerFormat)
+bool WICImageLoader::encodeImageData(std::string path, const unsigned char* data, size_t dataLen, WICPixelFormatGUID pixelFormat, int width, int height, GUID containerFormat)
 {
 	assert(data != NULL);
 	assert(dataLen > 0 && width > 0 && height > 0);
 
 	IWICImagingFactory* pFact = getWICFactory();
 
-	HRESULT hr = S_FALSE;
+	HRESULT hr = E_FAIL;
 	IWICStream* pStream = NULL;
 
-	if(NULL != pFact)
-	{
+	if (NULL != pFact) {
 		hr = pFact->CreateStream(&pStream);
 	}
 
-	if(SUCCEEDED(hr))
-	{
+	if (SUCCEEDED(hr)) {
 		std::wstring wpath;
 		wpath.assign(path.begin(), path.end());
 		hr = pStream->InitializeFromFilename(wpath.c_str(), GENERIC_WRITE);
@@ -349,54 +347,50 @@ bool WICImageLoader::encodeImageData(std::string path, ImageBlob data, size_t da
 
 	IWICBitmapEncoder* pEnc = NULL;
 
-	if(SUCCEEDED(hr))
-	{
+	if (SUCCEEDED(hr)) {
 		hr = pFact->CreateEncoder(containerFormat, NULL, &pEnc);
 	}
 
-	if(SUCCEEDED(hr))
-	{
+	if (SUCCEEDED(hr)) {
 		hr = pEnc->Initialize(pStream, WICBitmapEncoderNoCache);
 	}
 
 	IWICBitmapFrameEncode* pFrame = NULL;
 	IPropertyBag2* pProp = NULL;
 
-	if(SUCCEEDED(hr))
-	{
+	if (SUCCEEDED(hr)) {
 		hr = pEnc->CreateNewFrame(&pFrame, &pProp);
 	}
 
-	if(SUCCEEDED(hr))
-	{
+	if (SUCCEEDED(hr)) {
 		hr = pFrame->Initialize(pProp);
 	}
 
-	if(SUCCEEDED(hr))
-	{
+	if (SUCCEEDED(hr)) {
 		hr = pFrame->SetSize(width, height);
 	}
 
-	if(SUCCEEDED(hr))
-	{
-		hr = pFrame->SetPixelFormat(&pixelFormat);
+	if (SUCCEEDED(hr)) {
+		WICPixelFormatGUID targetFormat = pixelFormat;
+		hr = pFrame->SetPixelFormat(&targetFormat);
+
+		if (targetFormat != pixelFormat) {
+			hr = E_INVALIDARG;
+		}
 	}
 
-	if(SUCCEEDED(hr))
-	{
+	if (SUCCEEDED(hr)) {
 		size_t bpp = getBitsPerPixel(pixelFormat);
 		size_t stride = (width * bpp + 7) / 8;
 
 		hr = pFrame->WritePixels(height, stride, dataLen, (BYTE*)data);
 	}
 
-	if(SUCCEEDED(hr))
-	{
+	if (SUCCEEDED(hr)) {
 		hr = pFrame->Commit();
 	}
 
-	if(SUCCEEDED(hr))
-	{
+	if (SUCCEEDED(hr)) {
 		hr = pEnc->Commit();
 	}
 

--- a/cocos/platform/winrt/WICImageLoader-win.h
+++ b/cocos/platform/winrt/WICImageLoader-win.h
@@ -59,7 +59,7 @@ public:
 	WICPixelFormatGUID getPixelFormat();
 	int getImageData(ImageBlob rawData, size_t dataLen);
 	bool decodeImageData(ImageBlob data, size_t dataLen);
-	bool encodeImageData(std::string path, ImageBlob data, size_t dataLen, WICPixelFormatGUID pixelFormat, int width, int height, GUID containerFormat);
+    bool encodeImageData(std::string path, const unsigned char* data, size_t dataLen, WICPixelFormatGUID pixelFormat, int width, int height, GUID containerFormat);
 
 protected:
 	bool processImage(IWICBitmapDecoder* decoder);

--- a/templates/cpp-template-default/proj.win8.1-universal/App.Shared/OpenGLESPage.xaml.h
+++ b/templates/cpp-template-default/proj.win8.1-universal/App.Shared/OpenGLESPage.xaml.h
@@ -39,6 +39,9 @@ namespace cocos2d
         void OnPageLoaded(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e);
         void OnVisibilityChanged(Windows::UI::Core::CoreWindow^ sender, Windows::UI::Core::VisibilityChangedEventArgs^ args);
         void OnSwapChainPanelSizeChanged(Platform::Object^ sender, Windows::UI::Xaml::SizeChangedEventArgs^ e);
+#if (WINAPI_FAMILY == WINAPI_FAMILY_PHONE_APP)
+        void OnBackButtonPressed(Platform::Object^ sender, Windows::Phone::UI::Input::BackPressedEventArgs^ args);
+#endif
         void GetSwapChainPanelSize(GLsizei* width, GLsizei* height);
         void CreateRenderSurface();
         void DestroyRenderSurface();


### PR DESCRIPTION
This pull request fixes a problem with the new WIC image code for WinRT. Capture image in the Renderer > New Renderer test is now working correctly.

This pull request also adds the method to handle the back button press on Windows Phone. Another pull request will add back button support to cocos2d-x.
