### PR TITLE
[Director FIX]: Clean all schedulers and remove all eventlisteners after exiting scene

### DIFF
--- a/cocos/base/CCDirector.cpp
+++ b/cocos/base/CCDirector.cpp
@@ -937,16 +937,7 @@ void Director::restart()
 }
 
 void Director::reset()
-{
-    // cleanup scheduler
-    getScheduler()->unscheduleAll();
-    
-    // Remove all events
-    if (_eventDispatcher)
-    {
-        _eventDispatcher->removeAllEventListeners();
-    }
-    
+{    
     if (_runningScene)
     {
         _runningScene->onExit();
@@ -956,6 +947,15 @@ void Director::reset()
     
     _runningScene = nullptr;
     _nextScene = nullptr;
+
+    // cleanup scheduler
+    getScheduler()->unscheduleAll();
+    
+    // Remove all events
+    if (_eventDispatcher)
+    {
+        _eventDispatcher->removeAllEventListeners();
+    }
     
     // remove all objects, but don't release it.
     // runWithScene might be executed after 'end'.


### PR DESCRIPTION
In Cocos2d-JS: If we have the following usage in games, when exiting game, it will cause `Invalid Native Object` issue.

``` javascript
var MyNode = cc.Node.extend({
    _touchListener: null,

    onEnter:function()
    {
        this._super();
        var listener = cc.EventListener.create({
            event: cc.EventListener.TOUCH_ONE_BY_ONE,
            swallowTouches: false,
            onTouchBegan:function(touch, event)
            {
                ......
                return true;
            }
        })
        cc.eventManager.addListener(listener, this);
        this._touchListener = listener;
    },
    onExit:function(){
        this._super();
        cc.eventManager.removeListener(this._touchListener);
    }
}
```

Because in `Director::reset()`,  all event listeners will be removed before current scene exits,
and the `listener` in c++ will be removed, but JS don't know that, `cc.eventManager.removeListener(this._touchListener);` will cause the issue.
