### PR TITLE
TMX: Added support for reading the object.rotation attribute

### DIFF
--- a/cocos/2d/CCTMXXMLParser.cpp
+++ b/cocos/2d/CCTMXXMLParser.cpp
@@ -466,6 +466,8 @@ void TMXMapInfo::startElement(void *ctx, const char *name, const char **atts)
         dict["width"] = Value(s.width);
         dict["height"] = Value(s.height);
 
+        dict["rotation"] = attributeDict["rotation"].asDouble();
+
         // Add the object to the objectGroup
         objectGroup->getObjects().push_back(Value(dict));
 


### PR DESCRIPTION
Introduced with Tiled 0.10, this attribute stores the rotation of an object in degrees clockwise.

Closes bjorn/tiled#921
