### PR TITLE
V3 winrt fix to update Angle and correctly handle App termination

### DIFF
--- a/cocos/platform/win8.1-universal/Cocos2dRenderer.cpp
+++ b/cocos/platform/win8.1-universal/Cocos2dRenderer.cpp
@@ -114,27 +114,33 @@ void Cocos2dRenderer::DeviceLost()
 
 void Cocos2dRenderer::Draw(GLsizei width, GLsizei height, float dpi, DisplayOrientations orientation)
 {
+    auto glView = GLViewImpl::sharedOpenGLView();
+
     if (orientation != m_orientation)
     {
         m_orientation = orientation;
-        GLViewImpl::sharedOpenGLView()->UpdateOrientation(orientation);
+        glView->UpdateOrientation(orientation);
     }
 
     if (width != m_width || height != m_height)
     {
         m_width = width;
         m_height = height;
-        GLViewImpl::sharedOpenGLView()->UpdateForWindowSizeChange(static_cast<float>(width), static_cast<float>(height));
+        glView->UpdateForWindowSizeChange(static_cast<float>(width), static_cast<float>(height));
     }
 
     if (dpi != m_dpi)
     {
         m_dpi = dpi;
-        GLViewImpl::sharedOpenGLView()->SetDPI(m_dpi);
+        glView->SetDPI(m_dpi);
     }
 
-    GLViewImpl::sharedOpenGLView()->ProcessEvents();
-    GLViewImpl::sharedOpenGLView()->Render();
+    glView->ProcessEvents();
+
+    if (!(glView->AppShouldExit()))
+    {
+        glView->Render();
+    }
 }
 
 void Cocos2dRenderer::QueuePointerEvent(cocos2d::PointerEventType type, Windows::UI::Core::PointerEventArgs^ args)

--- a/cocos/platform/win8.1-universal/Cocos2dRenderer.cpp
+++ b/cocos/platform/win8.1-universal/Cocos2dRenderer.cpp
@@ -136,11 +136,7 @@ void Cocos2dRenderer::Draw(GLsizei width, GLsizei height, float dpi, DisplayOrie
     }
 
     glView->ProcessEvents();
-
-    if (!(glView->AppShouldExit()))
-    {
-        glView->Render();
-    }
+    glView->Render();
 }
 
 void Cocos2dRenderer::QueuePointerEvent(cocos2d::PointerEventType type, Windows::UI::Core::PointerEventArgs^ args)

--- a/cocos/platform/win8.1-universal/OpenGLES.cpp
+++ b/cocos/platform/win8.1-universal/OpenGLES.cpp
@@ -62,7 +62,12 @@ void OpenGLES::Initialize()
 
         // EGL_ANGLE_DISPLAY_ALLOW_RENDER_TO_BACK_BUFFER is an optimization that can have large performance benefits on mobile devices.
         // Its syntax is subject to change, though. Please update your Visual Studio templates if you experience compilation issues with it.
-        EGL_ANGLE_DISPLAY_ALLOW_RENDER_TO_BACK_BUFFER, EGL_TRUE, 
+        EGL_ANGLE_DISPLAY_ALLOW_RENDER_TO_BACK_BUFFER, EGL_TRUE,
+
+        // EGL_PLATFORM_ANGLE_ENABLE_AUTOMATIC_TRIM_ANGLE is an option that enables ANGLE to automatically call 
+        // the IDXGIDevice3::Trim method on behalf of the application when it gets suspended. 
+        // Calling IDXGIDevice3::Trim when an application is suspended is a Windows Store application certification requirement.
+        EGL_PLATFORM_ANGLE_ENABLE_AUTOMATIC_TRIM_ANGLE, EGL_TRUE,
         EGL_NONE,
     };
     
@@ -74,6 +79,7 @@ void OpenGLES::Initialize()
         EGL_PLATFORM_ANGLE_MAX_VERSION_MAJOR_ANGLE, 9,
         EGL_PLATFORM_ANGLE_MAX_VERSION_MINOR_ANGLE, 3,
         EGL_ANGLE_DISPLAY_ALLOW_RENDER_TO_BACK_BUFFER, EGL_TRUE, 
+        EGL_PLATFORM_ANGLE_ENABLE_AUTOMATIC_TRIM_ANGLE, EGL_TRUE,
         EGL_NONE,
     };
 
@@ -84,6 +90,7 @@ void OpenGLES::Initialize()
         EGL_PLATFORM_ANGLE_TYPE_ANGLE, EGL_PLATFORM_ANGLE_TYPE_D3D11_ANGLE,
         EGL_PLATFORM_ANGLE_DEVICE_TYPE_ANGLE, EGL_PLATFORM_ANGLE_DEVICE_TYPE_WARP_ANGLE,
         EGL_ANGLE_DISPLAY_ALLOW_RENDER_TO_BACK_BUFFER, EGL_TRUE, 
+        EGL_PLATFORM_ANGLE_ENABLE_AUTOMATIC_TRIM_ANGLE, EGL_TRUE,
         EGL_NONE,
     };
     

--- a/cocos/platform/win8.1-universal/OpenGLES.h
+++ b/cocos/platform/win8.1-universal/OpenGLES.h
@@ -39,10 +39,10 @@ public:
     void MakeCurrent(const EGLSurface surface);
     EGLBoolean SwapBuffers(const EGLSurface surface);
     void Reset();
+    void Cleanup();
 
 private:
     void Initialize();
-    void Cleanup();
 
 private:
     EGLDisplay mEglDisplay;

--- a/external/config.json
+++ b/external/config.json
@@ -1,5 +1,5 @@
 {
-    "version":"v3-deps-43",
+    "version":"v3-deps-44",
     "zip_file_size":"74127526",
     "repo_name":"cocos2d-x-3rd-party-libs-bin",
     "repo_parent":"https://github.com/cocos2d/",

--- a/templates/cpp-template-default/Classes/HelloWorldScene.cpp
+++ b/templates/cpp-template-default/Classes/HelloWorldScene.cpp
@@ -78,11 +78,6 @@ bool HelloWorld::init()
 
 void HelloWorld::menuCloseCallback(Ref* pSender)
 {
-#if (CC_TARGET_PLATFORM == CC_PLATFORM_WP8) || (CC_TARGET_PLATFORM == CC_PLATFORM_WINRT)
-	MessageBox("You pressed the close button. Windows Store Apps do not implement a close button.","Alert");
-    return;
-#endif
-
     Director::getInstance()->end();
 
 #if (CC_TARGET_PLATFORM == CC_PLATFORM_IOS)

--- a/templates/cpp-template-default/proj.win8.1-universal/App.Shared/Cocos2dRenderer.cpp
+++ b/templates/cpp-template-default/proj.win8.1-universal/App.Shared/Cocos2dRenderer.cpp
@@ -114,27 +114,29 @@ void Cocos2dRenderer::DeviceLost()
 
 void Cocos2dRenderer::Draw(GLsizei width, GLsizei height, float dpi, DisplayOrientations orientation)
 {
+    auto glView = GLViewImpl::sharedOpenGLView();
+
     if (orientation != m_orientation)
     {
         m_orientation = orientation;
-        GLViewImpl::sharedOpenGLView()->UpdateOrientation(orientation);
+        glView->UpdateOrientation(orientation);
     }
 
     if (width != m_width || height != m_height)
     {
         m_width = width;
         m_height = height;
-        GLViewImpl::sharedOpenGLView()->UpdateForWindowSizeChange(static_cast<float>(width), static_cast<float>(height));
+        glView->UpdateForWindowSizeChange(static_cast<float>(width), static_cast<float>(height));
     }
 
     if (dpi != m_dpi)
     {
         m_dpi = dpi;
-        GLViewImpl::sharedOpenGLView()->SetDPI(m_dpi);
+        glView->SetDPI(m_dpi);
     }
 
-    GLViewImpl::sharedOpenGLView()->ProcessEvents();
-    GLViewImpl::sharedOpenGLView()->Render();
+    glView->ProcessEvents();
+    glView->Render();
 }
 
 void Cocos2dRenderer::QueuePointerEvent(cocos2d::PointerEventType type, Windows::UI::Core::PointerEventArgs^ args)

--- a/templates/cpp-template-default/proj.win8.1-universal/App.Shared/OpenGLES.cpp
+++ b/templates/cpp-template-default/proj.win8.1-universal/App.Shared/OpenGLES.cpp
@@ -62,7 +62,12 @@ void OpenGLES::Initialize()
 
         // EGL_ANGLE_DISPLAY_ALLOW_RENDER_TO_BACK_BUFFER is an optimization that can have large performance benefits on mobile devices.
         // Its syntax is subject to change, though. Please update your Visual Studio templates if you experience compilation issues with it.
-        EGL_ANGLE_DISPLAY_ALLOW_RENDER_TO_BACK_BUFFER, EGL_TRUE, 
+        EGL_ANGLE_DISPLAY_ALLOW_RENDER_TO_BACK_BUFFER, EGL_TRUE,
+
+        // EGL_PLATFORM_ANGLE_ENABLE_AUTOMATIC_TRIM_ANGLE is an option that enables ANGLE to automatically call 
+        // the IDXGIDevice3::Trim method on behalf of the application when it gets suspended. 
+        // Calling IDXGIDevice3::Trim when an application is suspended is a Windows Store application certification requirement.
+        EGL_PLATFORM_ANGLE_ENABLE_AUTOMATIC_TRIM_ANGLE, EGL_TRUE,
         EGL_NONE,
     };
     
@@ -74,6 +79,7 @@ void OpenGLES::Initialize()
         EGL_PLATFORM_ANGLE_MAX_VERSION_MAJOR_ANGLE, 9,
         EGL_PLATFORM_ANGLE_MAX_VERSION_MINOR_ANGLE, 3,
         EGL_ANGLE_DISPLAY_ALLOW_RENDER_TO_BACK_BUFFER, EGL_TRUE, 
+        EGL_PLATFORM_ANGLE_ENABLE_AUTOMATIC_TRIM_ANGLE, EGL_TRUE,
         EGL_NONE,
     };
 
@@ -84,6 +90,7 @@ void OpenGLES::Initialize()
         EGL_PLATFORM_ANGLE_TYPE_ANGLE, EGL_PLATFORM_ANGLE_TYPE_D3D11_ANGLE,
         EGL_PLATFORM_ANGLE_DEVICE_TYPE_ANGLE, EGL_PLATFORM_ANGLE_DEVICE_TYPE_WARP_ANGLE,
         EGL_ANGLE_DISPLAY_ALLOW_RENDER_TO_BACK_BUFFER, EGL_TRUE, 
+        EGL_PLATFORM_ANGLE_ENABLE_AUTOMATIC_TRIM_ANGLE, EGL_TRUE,
         EGL_NONE,
     };
     

--- a/templates/cpp-template-default/proj.win8.1-universal/App.Shared/OpenGLES.h
+++ b/templates/cpp-template-default/proj.win8.1-universal/App.Shared/OpenGLES.h
@@ -39,10 +39,10 @@ public:
     void MakeCurrent(const EGLSurface surface);
     EGLBoolean SwapBuffers(const EGLSurface surface);
     void Reset();
+    void Cleanup();
 
 private:
     void Initialize();
-    void Cleanup();
 
 private:
     EGLDisplay mEglDisplay;


### PR DESCRIPTION
This pull request does the following:
1. Updates the Windows 8.1 Universal App cpp-templates to not display the MessageBox when the close button is press.
2. Updates the app termination code to call Cleanup() on the Angle OpenGLES context. This correctly shuts down the Windows Store App.
3. Updates external/config.json version to version to v3-deps-44
4. Updated to correctly configure Angle to automatically call Trim() on the DirectX device when the app is suspended. This is a requirement to pass Windows App Certification testing.

**This pull request depends upon the pull request https://github.com/cocos2d/cocos2d-x-3rd-party-libs-bin/pull/130. This pull request will not build until the cocos2d-x-3rd-party-libs-bin request is pulled.**
