### PR TITLE
Fixed mainloop paused when slide webview on the iOS.

### DIFF
--- a/cocos/platform/ios/CCDirectorCaller-ios.mm
+++ b/cocos/platform/ios/CCDirectorCaller-ios.mm
@@ -83,6 +83,7 @@ static id s_sharedDirectorCaller;
     displayLink = [NSClassFromString(@"CADisplayLink") displayLinkWithTarget:self selector:@selector(doCaller:)];
     [displayLink setFrameInterval: self.interval];
     [displayLink addToRunLoop:[NSRunLoop currentRunLoop] forMode:NSDefaultRunLoopMode];
+    [displayLink addToRunLoop:[NSRunLoop currentRunLoop] forMode:UITrackingRunLoopMode];
 }
 
 -(void) stopMainLoop
@@ -101,6 +102,7 @@ static id s_sharedDirectorCaller;
     displayLink = [NSClassFromString(@"CADisplayLink") displayLinkWithTarget:self selector:@selector(doCaller:)];
     [displayLink setFrameInterval: self.interval];
     [displayLink addToRunLoop:[NSRunLoop currentRunLoop] forMode:NSDefaultRunLoopMode];
+    [displayLink addToRunLoop:[NSRunLoop currentRunLoop] forMode:UITrackingRunLoopMode];
 }
                       
 -(void) doCaller: (id) sender


### PR DESCRIPTION
To fix #10847 .

Add `UITrackingRunLoopMode` mode, so that when the user to drag the UITableView/UIWebView/UIScrollView in UITrackingRunLoopMode mode, the mainloop of Cocos2d-x still goes on.
