### PR TITLE
Animate3D Quality control

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,6 +9,7 @@ cocos2d-x-3.6  ??
     [NEW]           Vec3: added `Vec3::lerp()`
     [NEW]           WP8: remove WP8 support because Angle don't support WP8 any more
 
+    [FIX]           Animate3D: modify `Animate3D::setHighQuality()` Animate3D::setQuality(), add a new animation quality type none which means that will not update animation to the bone, it is useful when the Sprite3D is out of the screen, it can safe a lot of cpu time.
     [FIX]           JNI: JNI illegal start byte error which causes crashing error on Android 5.0
     [FIX]           UI:VideoPlayer: crashed when playing streamed MP4 file on iOS
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -10,7 +10,10 @@ cocos2d-x-3.6  ??
     [NEW]           WP8: remove WP8 support because Angle don't support WP8 any more
 
     [FIX]           Animate3D: modify `Animate3D::setHighQuality()` Animate3D::setQuality(), add a new animation quality type none which means that will not update animation to the bone, it is useful when the Sprite3D is out of the screen, it can safe a lot of cpu time.
+    [FIX]           AnimationCurve: memory leak
+    [FIX]           Bundle3D: memory leak when failed to load file
     [FIX]           JNI: JNI illegal start byte error which causes crashing error on Android 5.0
+    [FIX]           PUParticleSystem3D: refactoring create function using initWithXXX
     [FIX]           UI:VideoPlayer: crashed when playing streamed MP4 file on iOS
 
 cocos2d-x-3.6beta0 Apr.14 2015

--- a/cocos/3d/CCAnimate3D.cpp
+++ b/cocos/3d/CCAnimate3D.cpp
@@ -69,7 +69,7 @@ bool Animate3D::init(Animation3D* animation)
     animation->retain();
     setDuration(animation->getDuration());
     setOriginInterval(animation->getDuration());
-    setHighQuality(Configuration::getInstance()->isHighAnimate3DQuality());
+    setQuality(Configuration::getInstance()->getAnimate3DQuality());
     return true;
 }
 
@@ -85,7 +85,7 @@ bool Animate3D::init(Animation3D* animation, float fromTime, float duration)
     setOriginInterval(duration);
     _animation = animation;
     animation->retain();
-    setHighQuality(Configuration::getInstance()->isHighAnimate3DQuality());
+    setQuality(Configuration::getInstance()->getAnimate3DQuality());
     return true;
 }
 
@@ -312,58 +312,61 @@ void Animate3D::update(float t)
         }
         _lastTime = t;
         
-        if (_weight > 0.0f)
+        if (_quality != Animate3DQuality::QUALITY_NONE)
         {
-            float transDst[3], rotDst[4], scaleDst[3];
-            float* trans = nullptr, *rot = nullptr, *scale = nullptr;
-            if (_playReverse)
-                t = 1 - t;
-            
-            t = _start + t * _last;
- 
-            for (const auto& it : _boneCurves) {
-                auto bone = it.first;
-                auto curve = it.second;
-                if (curve->translateCurve)
-                {
-                    curve->translateCurve->evaluate(t, transDst, _translateEvaluate);
-                    trans = &transDst[0];
-                }
-                if (curve->rotCurve)
-                {
-                    curve->rotCurve->evaluate(t, rotDst, _roteEvaluate);
-                    rot = &rotDst[0];
-                }
-                if (curve->scaleCurve)
-                {
-                    curve->scaleCurve->evaluate(t, scaleDst, _scaleEvaluate);
-                    scale = &scaleDst[0];
-                }
-                bone->setAnimationValue(trans, rot, scale, this, _weight);
-            }
-            
-            for (const auto& it : _nodeCurves)
+            if (_weight > 0.0f)
             {
-                auto node = it.first;
-                auto curve = it.second;
-                Mat4 transform;
-                if (curve->translateCurve)
-                {
-                    curve->translateCurve->evaluate(t, transDst, _translateEvaluate);
-                    transform.translate(transDst[0], transDst[1], transDst[2]);
+                float transDst[3], rotDst[4], scaleDst[3];
+                float* trans = nullptr, *rot = nullptr, *scale = nullptr;
+                if (_playReverse)
+                    t = 1 - t;
+                
+                t = _start + t * _last;
+                
+                for (const auto& it : _boneCurves) {
+                    auto bone = it.first;
+                    auto curve = it.second;
+                    if (curve->translateCurve)
+                    {
+                        curve->translateCurve->evaluate(t, transDst, _translateEvaluate);
+                        trans = &transDst[0];
+                    }
+                    if (curve->rotCurve)
+                    {
+                        curve->rotCurve->evaluate(t, rotDst, _roteEvaluate);
+                        rot = &rotDst[0];
+                    }
+                    if (curve->scaleCurve)
+                    {
+                        curve->scaleCurve->evaluate(t, scaleDst, _scaleEvaluate);
+                        scale = &scaleDst[0];
+                    }
+                    bone->setAnimationValue(trans, rot, scale, this, _weight);
                 }
-                if (curve->rotCurve)
+                
+                for (const auto& it : _nodeCurves)
                 {
-                    curve->rotCurve->evaluate(t, rotDst, _roteEvaluate);
-                    Quaternion qua(rotDst[0], rotDst[1], rotDst[2], rotDst[3]);
-                    transform.rotate(qua);
+                    auto node = it.first;
+                    auto curve = it.second;
+                    Mat4 transform;
+                    if (curve->translateCurve)
+                    {
+                        curve->translateCurve->evaluate(t, transDst, _translateEvaluate);
+                        transform.translate(transDst[0], transDst[1], transDst[2]);
+                    }
+                    if (curve->rotCurve)
+                    {
+                        curve->rotCurve->evaluate(t, rotDst, _roteEvaluate);
+                        Quaternion qua(rotDst[0], rotDst[1], rotDst[2], rotDst[3]);
+                        transform.rotate(qua);
+                    }
+                    if (curve->scaleCurve)
+                    {
+                        curve->scaleCurve->evaluate(t, scaleDst, _scaleEvaluate);
+                        transform.scale(scaleDst[0], scaleDst[1], scaleDst[2]);
+                    }
+                    node->setAdditionalTransform(&transform);
                 }
-                if (curve->scaleCurve)
-                {
-                    curve->scaleCurve->evaluate(t, scaleDst, _scaleEvaluate);
-                    transform.scale(scaleDst[0], scaleDst[1], scaleDst[2]);
-                }
-                node->setAdditionalTransform(&transform);
             }
         }
     }
@@ -391,26 +394,26 @@ void Animate3D::setOriginInterval(float interval)
     _originInterval = interval;
 }
 
-void Animate3D::setHighQuality(bool isHighQuality)
+void Animate3D::setQuality(Animate3DQuality quality)
 {
-    if (isHighQuality)
+    if (quality == Animate3DQuality::QUALITY_HIGH)
     {
         _translateEvaluate = EvaluateType::INT_LINEAR;
         _roteEvaluate = EvaluateType::INT_QUAT_SLERP;
         _scaleEvaluate = EvaluateType::INT_LINEAR;
     }
-    else
+    else if(quality == Animate3DQuality::QUALITY_LOW)
     {
         _translateEvaluate = EvaluateType::INT_NEAR;
         _roteEvaluate = EvaluateType::INT_NEAR;
         _scaleEvaluate = EvaluateType::INT_NEAR;
     }
-    _isHighQuality = isHighQuality;
+    _quality = quality;
 }
 
-bool Animate3D::isHighQuality() const
+Animate3DQuality Animate3D::getQuality() const
 {
-    return _isHighQuality;
+    return _quality;
 }
 
 Animate3D::Animate3D()
@@ -425,7 +428,7 @@ Animate3D::Animate3D()
 , _lastTime(0.0f)
 , _originInterval(0.0f)
 {
-    setHighQuality(true);
+    setQuality(Animate3DQuality::QUALITY_HIGH);
 }
 Animate3D::~Animate3D()
 {

--- a/cocos/3d/CCAnimate3D.h
+++ b/cocos/3d/CCAnimate3D.h
@@ -38,6 +38,14 @@ NS_CC_BEGIN
 class Bone3D;
 class Sprite3D;
 
+
+enum class Animate3DQuality
+{
+    QUALITY_NONE = 0,          // it'll not to be calculate the animate.
+    QUALITY_LOW,               // low animation quality, it'll be more efficient.
+    QUALITY_HIGH,              // high animation quality.
+};
+
 /**
  * @addtogroup _3d
  * @{
@@ -105,16 +113,11 @@ public:
     CC_DEPRECATED_ATTRIBUTE bool getPlayBack() const { return _playReverse; }
     CC_DEPRECATED_ATTRIBUTE void setPlayBack(bool reverse) { _playReverse = reverse; }
     
-    /**set high quality
-     * The default value is based on Configuration::isHighAnimate3DQuality(). You can configure it in the config.plist. However, you can modify it using the following function
-     * @param true: is high quality, false: is low quality.
-     */
-    void setHighQuality(bool isHighQuality);
+    /**set animate quality*/
+    void setQuality(Animate3DQuality quality);
     
-    /**get high quality
-     * is it high quality
-     */
-    bool isHighQuality() const;
+    /**get animate quality*/
+    Animate3DQuality getQuality() const;
     
 CC_CONSTRUCTOR_ACCESS:
     
@@ -153,7 +156,7 @@ protected:
     EvaluateType _translateEvaluate;
     EvaluateType _roteEvaluate;
     EvaluateType _scaleEvaluate;
-    bool _isHighQuality;        //  true: is high quality, false: is low quality
+    Animate3DQuality _quality;
     
     std::unordered_map<Bone3D*, Animation3D::Curve*> _boneCurves; //weak ref
     std::unordered_map<Node*, Animation3D::Curve*> _nodeCurves;

--- a/cocos/3d/CCAnimate3D.h
+++ b/cocos/3d/CCAnimate3D.h
@@ -41,7 +41,7 @@ class Sprite3D;
 
 enum class Animate3DQuality
 {
-    QUALITY_NONE = 0,          // it'll not to be calculate the animate.
+    QUALITY_NONE = 0,          // it'll be ignore the curve-evaluating(the animation looks like stop), just acculate transition time.
     QUALITY_LOW,               // low animation quality, it'll be more efficient.
     QUALITY_HIGH,              // high animation quality.
 };

--- a/cocos/base/CCConfiguration.cpp
+++ b/cocos/base/CCConfiguration.cpp
@@ -50,7 +50,7 @@ Configuration::Configuration()
 , _maxDirLightInShader(1)
 , _maxPointLightInShader(1)
 , _maxSpotLightInShader(1)
-, _isAnimate3DHighQuality(true)
+, _animate3DQuality(Animate3DQuality::QUALITY_HIGH)
 {
 }
 
@@ -263,9 +263,9 @@ int Configuration::getMaxSupportSpotLightInShader() const
     return _maxSpotLightInShader;
 }
 
-bool Configuration::isHighAnimate3DQuality() const
+Animate3DQuality Configuration::getAnimate3DQuality() const
 {
-    return _isAnimate3DHighQuality;
+    return _animate3DQuality;
 }
 
 //
@@ -357,11 +357,11 @@ void Configuration::loadConfigFile(const std::string& filename)
     else
         _valueDict[name] = Value(_maxSpotLightInShader);
     
-    name = "cocos2d.x.3d.animate_high_quality";
+    name = "cocos2d.x.3d.animate_quality";
     if (_valueDict.find(name) != _valueDict.end())
-        _isAnimate3DHighQuality = _valueDict[name].asBool();
+        _animate3DQuality = (Animate3DQuality)_valueDict[name].asInt();
     else
-        _valueDict[name] = Value(_isAnimate3DHighQuality);
+        _valueDict[name] = Value((int)_animate3DQuality);
 }
 
 NS_CC_END

--- a/cocos/base/CCConfiguration.h
+++ b/cocos/base/CCConfiguration.h
@@ -32,6 +32,7 @@ THE SOFTWARE.
 #include "base/CCRef.h"
 #include "base/CCValue.h"
 #include "platform/CCGL.h"
+#include "3d/CCAnimate3D.h"
 
 /**
  * @addtogroup base
@@ -164,11 +165,8 @@ public:
      */
     int getMaxSupportSpotLightInShader() const;
 
-    /** is 3d animate quality? Configure it in the config.plist, the key is cocos2d.x.3d.animate_high_quality, it is true by default. 
-     * Animation quality of created Animate3D is based on the return value. However, animation quality of Animate3D can be modified by calling setHighQuality after it is created.
-     *  @return true: is high quality, false: is low quality
-     */
-    bool isHighAnimate3DQuality() const;
+    /** get 3d animate quality*/
+    Animate3DQuality getAnimate3DQuality() const;
     
     /** Returns whether or not an OpenGL is supported. 
      *
@@ -236,7 +234,7 @@ protected:
     int             _maxDirLightInShader; //max support directional light in shader
     int             _maxPointLightInShader; // max support point light in shader
     int             _maxSpotLightInShader; // max support spot light in shader
-    bool            _isAnimate3DHighQuality; // animation 3d quality, true: is high quality, false: is low quality
+    Animate3DQuality  _animate3DQuality; // animate 3d quality
 	
 	ValueMap        _valueDict;
 };

--- a/tests/cpp-tests/Classes/Sprite3DTest/Sprite3DTest.cpp
+++ b/tests/cpp-tests/Classes/Sprite3DTest/Sprite3DTest.cpp
@@ -1265,7 +1265,7 @@ Sprite3DWithSkinTest::Sprite3DWithSkinTest()
     _menuItem->setPosition(VisibleRect::left().x + 50, VisibleRect::top().y -70);
     addChild(menu, 1);
     
-    _highQuality = true;
+    _animateQuality = 2;
     _sprits.clear();
     
     auto s = Director::getInstance()->getWinSize();
@@ -1308,7 +1308,7 @@ void Sprite3DWithSkinTest::addNewSpriteWithCoords(Vec2 p)
         }
         animate->setSpeed(inverse ? -speed : speed);
         animate->setTag(110);
-        animate->setHighQuality(_highQuality);
+        animate->setQuality((Animate3DQuality)_animateQuality);
         auto repeate = RepeatForever::create(animate);
         repeate->setTag(110);
         sprite->runAction(repeate);
@@ -1317,18 +1317,22 @@ void Sprite3DWithSkinTest::addNewSpriteWithCoords(Vec2 p)
 
 void Sprite3DWithSkinTest::switchAnimationQualityCallback(Ref* sender)
 {
-    _highQuality = !_highQuality;
+    ++_animateQuality;
+    if (_animateQuality > (int)Animate3DQuality::QUALITY_HIGH)
+        _animateQuality = (int)Animate3DQuality::QUALITY_NONE;
     
-    if (_highQuality)
-        _menuItem->setString("High Quality");
-    else
+    if (_animateQuality == (int)Animate3DQuality::QUALITY_NONE)
+        _menuItem->setString("None Quality");
+    else if (_animateQuality == (int)Animate3DQuality::QUALITY_LOW)
         _menuItem->setString("Low Quality");
+    else if (_animateQuality == (int)Animate3DQuality::QUALITY_HIGH)
+        _menuItem->setString("High Quality");
     
     for (auto iter: _sprits)
     {
         RepeatForever* repAction = dynamic_cast<RepeatForever*>(iter->getActionByTag(110));
         Animate3D* animate3D = dynamic_cast<Animate3D*>(repAction->getInnerAction());
-        animate3D->setHighQuality(_highQuality);
+        animate3D->setQuality((Animate3DQuality)_animateQuality);
     }
 }
 

--- a/tests/cpp-tests/Classes/Sprite3DTest/Sprite3DTest.cpp
+++ b/tests/cpp-tests/Classes/Sprite3DTest/Sprite3DTest.cpp
@@ -1265,7 +1265,7 @@ Sprite3DWithSkinTest::Sprite3DWithSkinTest()
     _menuItem->setPosition(VisibleRect::left().x + 50, VisibleRect::top().y -70);
     addChild(menu, 1);
     
-    _animateQuality = 2;
+    _animateQuality = (int)Animate3DQuality::QUALITY_HIGH;
     _sprits.clear();
     
     auto s = Director::getInstance()->getWinSize();

--- a/tests/cpp-tests/Classes/Sprite3DTest/Sprite3DTest.h
+++ b/tests/cpp-tests/Classes/Sprite3DTest/Sprite3DTest.h
@@ -289,7 +289,7 @@ public:
     void onTouchesEnded(const std::vector<cocos2d::Touch*>& touches, cocos2d::Event* event);
 private:
     std::vector<cocos2d::Sprite3D*> _sprits;
-    bool _highQuality;
+    int _animateQuality;
     cocos2d::MenuItemFont* _menuItem;
 };
 

--- a/tests/cpp-tests/Resources/configs/config-example.plist
+++ b/tests/cpp-tests/Resources/configs/config-example.plist
@@ -22,8 +22,8 @@
 		<integer>1</integer>
 		<key>cocos2d.x.3d.max_spot_light_in_shader</key>
 		<integer>1</integer>
-		<key>cocos2d.x.3d.animate_high_quality</key>
-		<true/>
+		<key>cocos2d.x.3d.animate_quality</key>
+		<integer>2</integer>
 	</dict>
 	<key>metadata</key>
 	<dict>


### PR DESCRIPTION
Add new quality type none which means that will not update animation data to bone.
It is useful when the Sprite3D is out of the screen.
If you are sure the Sprite3D moves out you can set its animation quality to none, so that it can save cpu time.
