### PR TITLE
Use TextBMFont when text is updated from slider for faster performance

### DIFF
--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UISliderTest/UISliderTest.cpp
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UISliderTest/UISliderTest.cpp
@@ -31,7 +31,7 @@ bool UISliderTest::init()
         Size widgetSize = _widget->getContentSize();
         
         // Add a label in which the slider alert will be displayed
-        _displayValueLabel = Text::create("Move the slider thumb","Move the slider thumb",32);
+        _displayValueLabel = TextBMFont::create("Move the slider thumb", "ccb/markerfelt24shadow.fnt");
         _displayValueLabel->setAnchorPoint(Vec2(0.5f, -1));
         _displayValueLabel->setPosition(Vec2(widgetSize.width / 2.0f, widgetSize.height / 2.0f));
         _uiLayer->addChild(_displayValueLabel);

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UISliderTest/UISliderTest.h
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UISliderTest/UISliderTest.h
@@ -40,7 +40,7 @@ public:
     void sliderEvent(cocos2d::Ref* sender, cocos2d::ui::Slider::EventType type);
     
 protected:
-    cocos2d::ui::Text* _displayValueLabel;
+    cocos2d::ui::TextBMFont* _displayValueLabel;
 };
 
 class UISliderTest_Scale9 : public UIScene


### PR DESCRIPTION
This pull request replaces the use of ui::Text with ui::TextBMFont for the text field updated by the slider. ui::Text is too slow to handle all of the update events from the Slider.

ui::Text should not be used for text fields that need to be updated in real time.
