### PR TITLE
fixing label being missaligned after glow effect applied (bug 10688)

### DIFF
--- a/cocos/2d/CCLabel.cpp
+++ b/cocos/2d/CCLabel.cpp
@@ -40,7 +40,7 @@
 
 NS_CC_BEGIN
 
-const int Label::DistanceFieldFontSize = 50;
+const int Label::DistanceFieldFontSize = 100;
 
 Label* Label::create()
 {


### PR DESCRIPTION
Due to DistanceFieldFontSize being set to 50 during creating font atlas for label with glow effect 
label size is wrongly calculated. After applying 100 value all effects on label seems to work fine,
so do the correct allignment, please reffer to bug  #10688 for details 
(https://github.com/cocos2d/cocos2d-x/issues/10688)
