### PR TITLE
Fix Jenkins Xcode build return value

### DIFF
--- a/tools/jenkins-scripts/slave-scripts/ios-build.sh
+++ b/tools/jenkins-scripts/slave-scripts/ios-build.sh
@@ -3,3 +3,5 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 COCOS2DX_ROOT="$DIR"/../../..
 xcodebuild -project "$COCOS2DX_ROOT"/build/cocos2d_tests.xcodeproj -scheme "build all tests iOS"  -destination "platform=iOS Simulator,name=iPhone Retina (4-inch)" clean | xcpretty
 xcodebuild -project "$COCOS2DX_ROOT"/build/cocos2d_tests.xcodeproj -scheme "build all tests iOS"  -destination "platform=iOS Simulator,name=iPhone Retina (4-inch)" build | xcpretty
+#the following commands must not be removed
+xcodebuild -project "$COCOS2DX_ROOT"/build/cocos2d_tests.xcodeproj -scheme "build all tests iOS"  -destination "platform=iOS Simulator,name=iPhone Retina (4-inch)" build

--- a/tools/jenkins-scripts/slave-scripts/mac-build.sh
+++ b/tools/jenkins-scripts/slave-scripts/mac-build.sh
@@ -18,3 +18,5 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 COCOS2DX_ROOT="$DIR"/../../..
 xcodebuild -project "$COCOS2DX_ROOT"/build/cocos2d_tests.xcodeproj -scheme "build all tests Mac" clean | xcpretty
 xcodebuild -project "$COCOS2DX_ROOT"/build/cocos2d_tests.xcodeproj -scheme "build all tests Mac" build | xcpretty
+#xcpretty has a bug, some xcodebuid fails return value would be treated as 0.
+xcodebuild -project "$COCOS2DX_ROOT"/build/cocos2d_tests.xcodeproj -scheme "build all tests Mac" build


### PR DESCRIPTION
xcpretty command line tool has a bug... So I add another extra xcodebuild . Since Xcode will cache the previous build result, so the second xcodebuild command just to verify the build result.
