### PR TITLE
Label:Fixed crash.

### DIFF
--- a/cocos/2d/CCLabel.cpp
+++ b/cocos/2d/CCLabel.cpp
@@ -616,7 +616,8 @@ void Label::alignText()
         int strLen = static_cast<int>(_currentUTF16String.length());
         Rect uvRect;
         Sprite* letterSprite;
-        for (const auto &child : _children) {
+        for (auto index = 0; index < _children.size();) {
+            auto child = _children.at(index);
             int tag = child->getTag();
             if (tag >= strLen)
             {
@@ -635,6 +636,11 @@ void Label::alignText()
                     letterSprite->setTexture(textures.at(_lettersInfo[tag].def.textureID));
                     letterSprite->setTextureRect(uvRect);
                 }
+                ++index;
+            }
+            else
+            {
+                ++index;
             }
         }
     }

--- a/cocos/2d/CCLabel.cpp
+++ b/cocos/2d/CCLabel.cpp
@@ -591,10 +591,6 @@ void Label::alignText()
         return;
     }
 
-    for (const auto& batchNode:_batchNodes)
-    {
-        batchNode->getTextureAtlas()->removeAllQuads();
-    }
     _fontAtlas->prepareLetterDefinitions(_currentUTF16String);
     auto& textures = _fontAtlas->getTextures();
     if (textures.size() > _batchNodes.size())
@@ -615,29 +611,37 @@ void Label::alignText()
     if(_labelWidth > 0 || (_currNumLines > 1 && _hAlignment != TextHAlignment::LEFT))
         LabelTextFormatter::alignText(this);
 
-    int strLen = static_cast<int>(_currentUTF16String.length());
-    Rect uvRect;
-    Sprite* letterSprite;
-    for(const auto &child : _children) {
-        int tag = child->getTag();
-        if(tag >= strLen)
-        {
-            SpriteBatchNode::removeChild(child, true);
-        }
-        else if(tag >= 0)
-        {
-            letterSprite = dynamic_cast<Sprite*>(child);
-            if (letterSprite)
+    if (!_children.empty())
+    {
+        int strLen = static_cast<int>(_currentUTF16String.length());
+        Rect uvRect;
+        Sprite* letterSprite;
+        for (const auto &child : _children) {
+            int tag = child->getTag();
+            if (tag >= strLen)
             {
-                uvRect.size.height = _lettersInfo[tag].def.height;
-                uvRect.size.width  = _lettersInfo[tag].def.width;
-                uvRect.origin.x    = _lettersInfo[tag].def.U;
-                uvRect.origin.y    = _lettersInfo[tag].def.V;
+                SpriteBatchNode::removeChild(child, true);
+            }
+            else if (tag >= 0)
+            {
+                letterSprite = dynamic_cast<Sprite*>(child);
+                if (letterSprite)
+                {
+                    uvRect.size.height = _lettersInfo[tag].def.height;
+                    uvRect.size.width = _lettersInfo[tag].def.width;
+                    uvRect.origin.x = _lettersInfo[tag].def.U;
+                    uvRect.origin.y = _lettersInfo[tag].def.V;
 
-                letterSprite->setTexture(textures.at(_lettersInfo[tag].def.textureID));
-                letterSprite->setTextureRect(uvRect);
+                    letterSprite->setTexture(textures.at(_lettersInfo[tag].def.textureID));
+                    letterSprite->setTextureRect(uvRect);
+                }
             }
         }
+    }
+
+    for (const auto& batchNode : _batchNodes)
+    {
+        batchNode->getTextureAtlas()->removeAllQuads();
     }
 
     updateQuads();

--- a/tests/cpp-tests/Classes/LabelTest/LabelTestNew.cpp
+++ b/tests/cpp-tests/Classes/LabelTest/LabelTestNew.cpp
@@ -75,6 +75,7 @@ NewLabelTests::NewLabelTests()
     ADD_TEST_CASE(LabelSmallDimensionsTest);
     ADD_TEST_CASE(LabelIssue10089Test);
     ADD_TEST_CASE(LabelSystemFontColor);
+    ADD_TEST_CASE(LabelIssue10773Test);
 };
 
 LabelTTFAlignmentNew::LabelTTFAlignmentNew()
@@ -1861,4 +1862,25 @@ std::string LabelSystemFontColor::title() const
 std::string LabelSystemFontColor::subtitle() const
 {
     return "Testing text color of system font";
+}
+
+LabelIssue10773Test::LabelIssue10773Test()
+{
+    auto center = VisibleRect::center();
+
+    auto label = Label::createWithTTF("create label with TTF", "fonts/arial.ttf", 24);
+    label->getLetter(5);
+    label->setString("Hi");
+    label->setPosition(center.x, center.y);
+    addChild(label);
+}
+
+std::string LabelIssue10773Test::title() const
+{
+    return "Test for Issue #10773";
+}
+
+std::string LabelIssue10773Test::subtitle() const
+{
+    return "Should not crash!";
 }

--- a/tests/cpp-tests/Classes/LabelTest/LabelTestNew.h
+++ b/tests/cpp-tests/Classes/LabelTest/LabelTestNew.h
@@ -554,4 +554,15 @@ public:
     virtual std::string subtitle() const override;
 };
 
+class LabelIssue10773Test : public AtlasDemoNew
+{
+public:
+    CREATE_FUNC(LabelIssue10773Test);
+
+    LabelIssue10773Test();
+
+    virtual std::string title() const override;
+    virtual std::string subtitle() const override;
+};
+
 #endif


### PR DESCRIPTION
When you invoking `getLetter(letterIndex)` and `setString(text)` in sequence, and `letterIndex` greater than the length of `text`, it might crash your program.
