### PR TITLE
Fix Bug on reading json file on PERCENT mode,and close Warning c4018 on windows

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1103,6 +1103,8 @@ Retired Core Developers:
     RongHong Huang (flyingpaper)
         Author of cocos2d-xna and spent all his time on wp7.
 
+lbfamous:
+forked in 2015-04-26 day
 Cocos2d-x can not grow so fast without the active community.
 Thanks to all developers who report & trace bugs, discuss the engine usage in forum & QQ groups!
 Special thanks to Ricardo Quesada for giving us lots of guidances & suggestions.

--- a/AUTHORS
+++ b/AUTHORS
@@ -1103,8 +1103,6 @@ Retired Core Developers:
     RongHong Huang (flyingpaper)
         Author of cocos2d-xna and spent all his time on wp7.
 
-lbfamous:
-forked in 2015-04-26 day
 Cocos2d-x can not grow so fast without the active community.
 Thanks to all developers who report & trace bugs, discuss the engine usage in forum & QQ groups!
 Special thanks to Ricardo Quesada for giving us lots of guidances & suggestions.

--- a/cocos/editor-support/cocostudio/CCSGUIReader.cpp
+++ b/cocos/editor-support/cocostudio/CCSGUIReader.cpp
@@ -1412,7 +1412,9 @@ Widget* WidgetPropertiesReader0300::widgetFromBinary(CocoLoader* cocoLoader,  st
                             }
                             else
                             {
-                                if (dynamic_cast<Layout*>(widget))
+								//- bug fix 3.3 version if (!dynamic_cast<Layout*>(widget)) 
+								//- same as 1508 
+                                if (nullptr == dynamic_cast<Layout*>(widget))
                                 {
                                     if (child->getPositionType() == ui::Widget::PositionType::PERCENT)
                                     {
@@ -1488,6 +1490,7 @@ Widget* WidgetPropertiesReader0300::widgetFromJsonDictionary(const rapidjson::Va
     {
         const rapidjson::Value& subData = DICTOOL->getDictionaryFromArray_json(data, "children", i);
         cocos2d::ui::Widget* child = widgetFromJsonDictionary(subData);
+
         if (child)
         {
             PageView* pageView = dynamic_cast<PageView*>(widget);
@@ -1504,7 +1507,10 @@ Widget* WidgetPropertiesReader0300::widgetFromJsonDictionary(const rapidjson::Va
                 }
                 else
                 {
-                    if (dynamic_cast<Layout*>(widget))
+					//- bug fix: from  3.3 version if (!dynamic_cast<Layout*>(widget)) to 3.5 -> if (dynamic_cast<Layout*>(widget)) 
+					//- and can not work successful on loading PERCENT mode
+					//- change it
+                    if (nullptr == dynamic_cast<Layout*>(widget))
                     {
                         if (child->getPositionType() == ui::Widget::PositionType::PERCENT)
                         {

--- a/cocos/platform/CCPlatformConfig.h
+++ b/cocos/platform/CCPlatformConfig.h
@@ -154,6 +154,7 @@ THE SOFTWARE.
 #if (CC_TARGET_PLATFORM == CC_PLATFORM_WIN32)
 #ifndef __MINGW32__
 #pragma warning (disable:4127) 
+#pragma warning (disable:4018)
 #endif 
 #endif  // CC_PLATFORM_WIN32
 


### PR DESCRIPTION
1. bug fix: 
   from  3.3 version if (!dynamic_cast<Layout*>(widget)) to 3.5 -> if (dynamic_cast<Layout*>(widget)) and can not work successful on loading PERCENT mode, I don't know why you change it. I change it back.
2. Close Warning C4018
