### PR TITLE
Fix warnings in v3.

### DIFF
--- a/cocos/2d/CCClippingNode.cpp
+++ b/cocos/2d/CCClippingNode.cpp
@@ -32,6 +32,11 @@
 #include "renderer/CCRenderer.h"
 #include "base/CCDirector.h"
 
+#if (CC_TARGET_PLATFORM == CC_PLATFORM_MAC || CC_TARGET_PLATFORM == CC_PLATFORM_WIN32 || CC_TARGET_PLATFORM == CC_PLATFORM_LINUX)
+#define CC_CLIPPING_NODE_OPENGLES 0
+#else
+#define CC_CLIPPING_NODE_OPENGLES 1
+#endif
 
 NS_CC_BEGIN
 
@@ -41,6 +46,7 @@ static GLint g_sStencilBits = -1;
 // where n is the number of bits of the stencil buffer.
 static GLint s_layer = -1;
 
+#if CC_CLIPPING_NODE_OPENGLES
 static void setProgram(Node *n, GLProgram *p)
 {
     n->setGLProgram(p);
@@ -50,6 +56,7 @@ static void setProgram(Node *n, GLProgram *p)
         setProgram(child, p);
     }
 }
+#endif
 
 ClippingNode::ClippingNode()
 : _stencil(nullptr)
@@ -257,8 +264,7 @@ void ClippingNode::visit(Renderer *renderer, const Mat4 &parentTransform, uint32
     renderer->addCommand(&_beforeVisitCmd);
     if (_alphaThreshold < 1)
     {
-#if (CC_TARGET_PLATFORM == CC_PLATFORM_MAC || CC_TARGET_PLATFORM == CC_PLATFORM_WIN32 || CC_TARGET_PLATFORM == CC_PLATFORM_LINUX)
-#else
+#if CC_CLIPPING_NODE_OPENGLES
         // since glAlphaTest do not exists in OES, use a shader that writes
         // pixel only if greater than an alpha threshold
         GLProgram *program = GLProgramCache::getInstance()->getGLProgram(GLProgram::SHADER_NAME_POSITION_TEXTURE_ALPHA_TEST_NO_MV);
@@ -438,7 +444,7 @@ void ClippingNode::onBeforeVisit()
     // enable alpha test only if the alpha threshold < 1,
     // indeed if alpha threshold == 1, every pixel will be drawn anyways
     if (_alphaThreshold < 1) {
-#if (CC_TARGET_PLATFORM == CC_PLATFORM_MAC || CC_TARGET_PLATFORM == CC_PLATFORM_WIN32 || CC_TARGET_PLATFORM == CC_PLATFORM_LINUX)
+#if !CC_CLIPPING_NODE_OPENGLES
         // manually save the alpha test state
         _currentAlphaTestEnabled = glIsEnabled(GL_ALPHA_TEST);
         glGetIntegerv(GL_ALPHA_TEST_FUNC, (GLint *)&_currentAlphaTestFunc);
@@ -449,8 +455,6 @@ void ClippingNode::onBeforeVisit()
         CHECK_GL_ERROR_DEBUG();
         // pixel will be drawn only if greater than an alpha threshold
         glAlphaFunc(GL_GREATER, _alphaThreshold);
-#else
-        
 #endif
     }
 
@@ -462,15 +466,15 @@ void ClippingNode::onAfterDrawStencil()
     // restore alpha test state
     if (_alphaThreshold < 1)
     {
-#if (CC_TARGET_PLATFORM == CC_PLATFORM_MAC || CC_TARGET_PLATFORM == CC_PLATFORM_WIN32 || CC_TARGET_PLATFORM == CC_PLATFORM_LINUX)
+#if CC_CLIPPING_NODE_OPENGLES
+        // FIXME: we need to find a way to restore the shaders of the stencil node and its childs
+#else
         // manually restore the alpha test state
         glAlphaFunc(_currentAlphaTestFunc, _currentAlphaTestRef);
         if (!_currentAlphaTestEnabled)
         {
             glDisable(GL_ALPHA_TEST);
         }
-#else
-// FIXME: we need to find a way to restore the shaders of the stencil node and its childs
 #endif
     }
 

--- a/cocos/base/CCUserDefault.h
+++ b/cocos/base/CCUserDefault.h
@@ -245,7 +245,7 @@ public:
 
 protected:
     UserDefault();
-    ~UserDefault();
+    virtual ~UserDefault();
     
 private:
     

--- a/cocos/editor-support/cocostudio/ActionTimeline/CCFrame.cpp
+++ b/cocos/editor-support/cocostudio/ActionTimeline/CCFrame.cpp
@@ -38,8 +38,8 @@ NS_TIMELINE_BEGIN
 Frame::Frame()
     : _frameIndex(0)
     , _tween(true)
-    , _tweenType(tweenfunc::TweenType::Linear)
     , _enterWhenPassed(false)
+    , _tweenType(tweenfunc::TweenType::Linear)
     , _timeline(nullptr)
     , _node(nullptr)
 {
@@ -282,7 +282,7 @@ void SkewFrame::onEnter(Frame *nextFrame, int currentFrameIndex)
 
 void SkewFrame::onApply(float percent)
 {
-    if (nullptr != _node && _betweenSkewX != 0 || _betweenSkewY != 0)
+    if ((nullptr != _node && _betweenSkewX != 0) || _betweenSkewY != 0)
     {
         float skewx = _skewX + percent * _betweenSkewX;
         float skewy = _skewY + percent * _betweenSkewY;
@@ -342,7 +342,7 @@ void RotationSkewFrame::onEnter(Frame *nextFrame, int currentFrameIndex)
 
 void RotationSkewFrame::onApply(float percent)
 {
-    if (nullptr != _node && _betweenSkewX != 0 || _betweenSkewY != 0)
+    if ((nullptr != _node && _betweenSkewX != 0) || _betweenSkewY != 0)
     {
         float skewx = _skewX + percent * _betweenSkewX;
         float skewy = _skewY + percent * _betweenSkewY;
@@ -460,7 +460,7 @@ void ScaleFrame::onEnter(Frame *nextFrame, int currentFrameIndex)
 
 void ScaleFrame::onApply(float percent)
 {
-    if (nullptr != _node && _betweenScaleX != 0 || _betweenScaleY != 0)
+    if ((nullptr != _node && _betweenScaleX != 0) || _betweenScaleY != 0)
     {
         float scaleX = _scaleX + _betweenScaleX * percent;
         float scaleY = _scaleY + _betweenScaleY * percent;
@@ -694,7 +694,7 @@ void ColorFrame::onEnter(Frame *nextFrame, int currentFrameIndex)
 
 void ColorFrame::onApply(float percent)
 {
-    if (nullptr != _node && _betweenRed != 0 || _betweenGreen != 0 || _betweenBlue != 0)
+    if ((nullptr != _node && _betweenRed != 0) || _betweenGreen != 0 || _betweenBlue != 0)
     {
         Color3B color;
         color.r = _color.r+ _betweenRed   * percent;

--- a/cocos/editor-support/spine/Slot.h
+++ b/cocos/editor-support/spine/Slot.h
@@ -53,7 +53,7 @@ typedef struct spSlot {
 	spSlot() :
 		data(0),
 		bone(0),
-		r(0), b(0), g(0), a(0),
+		r(0), g(0), b(0), a(0),
 		attachment(0),
 		attachmentVerticesCapacity(0),
 		attachmentVerticesCount(0),

--- a/cocos/physics/CCPhysicsWorld.cpp
+++ b/cocos/physics/CCPhysicsWorld.cpp
@@ -879,10 +879,10 @@ PhysicsWorld::PhysicsWorld()
 , _updateTime(0.0f)
 , _substeps(1)
 , _cpSpace(nullptr)
+, _updateBodyTransform(false)
 , _scene(nullptr)
 , _autoStep(true)
 , _debugDraw(nullptr)
-, _updateBodyTransform(false)
 , _debugDrawMask(DEBUGDRAW_NONE)
 {
     

--- a/extensions/Particle3D/PU/CCPUDoPlacementParticleEventHandler.cpp
+++ b/extensions/Particle3D/PU/CCPUDoPlacementParticleEventHandler.cpp
@@ -37,10 +37,11 @@ PUDoPlacementParticleEventHandler::PUDoPlacementParticleEventHandler(void) :
     PUEventHandler(),
     PUListener(),
     _numberOfParticles(DEFAULT_NUMBER_OF_PARTICLES),
+    _system(0),
+    _emitter(0),
     _found(false),
     _alwaysUsePosition(true),
-    _emitter(0),
-    _system(0),
+    _baseParticle(0),
     _inheritPosition(true),
     _inheritDirection(false),
     _inheritOrientation(false),
@@ -50,8 +51,7 @@ PUDoPlacementParticleEventHandler::PUDoPlacementParticleEventHandler(void) :
     _inheritColour(false),
     _inheritParticleWidth(false),
     _inheritParticleHeight(false),
-    _inheritParticleDepth(false),
-    _baseParticle(0)
+    _inheritParticleDepth(false)
 {
 }
 //-----------------------------------------------------------------------

--- a/extensions/Particle3D/PU/CCPUObserver.cpp
+++ b/extensions/Particle3D/PU/CCPUObserver.cpp
@@ -43,14 +43,14 @@ PUObserver::PUObserver(void) :
     _originalEnabled(DEFAULT_ENABLED),
     _originalEnabledSet(false),
     _observe(true),
+    _observeUntilEvent(DEFAULT_UNTIL_EVENT),
+    _eventHandlersExecuted(false),
+    _observerScale(Vec3::ONE),
     _particleTypeToObserve(DEFAULT_PARTICLE_TYPE),
     _particleTypeToObserveSet(false),
-    _observerScale(Vec3::ONE),
     _observerInterval(DEFAULT_INTERVAL),
     _observerIntervalRemainder(0.0),
-    _observerIntervalSet(false),
-    _observeUntilEvent(DEFAULT_UNTIL_EVENT),
-    _eventHandlersExecuted(false)
+    _observerIntervalSet(false)
 {
     //mAliasType = AT_OBSERVER;
 }

--- a/extensions/Particle3D/PU/CCPUOnPositionObserver.cpp
+++ b/extensions/Particle3D/PU/CCPUOnPositionObserver.cpp
@@ -37,12 +37,12 @@ PUOnPositionObserver::PUOnPositionObserver(void) :
     _positionXThreshold(DEFAULT_POSITION_THRESHOLD.x),
     _positionYThreshold(DEFAULT_POSITION_THRESHOLD.y),
     _positionZThreshold(DEFAULT_POSITION_THRESHOLD.z),
-    _comparePositionX(CO_LESS_THAN),
-    _comparePositionY(CO_LESS_THAN),
-    _comparePositionZ(CO_LESS_THAN),
     _positionXThresholdSet(false),
     _positionYThresholdSet(false),
-    _positionZThresholdSet(false)
+    _positionZThresholdSet(false),
+    _comparePositionX(CO_LESS_THAN),
+    _comparePositionY(CO_LESS_THAN),
+    _comparePositionZ(CO_LESS_THAN)
 {
 }
 //-----------------------------------------------------------------------

--- a/extensions/Particle3D/PU/CCPUParticleSystem3D.cpp
+++ b/extensions/Particle3D/PU/CCPUParticleSystem3D.cpp
@@ -110,26 +110,26 @@ void PUParticle3D::process( float timeElapsed )
 
 PUParticle3D::PUParticle3D():
     particleEntityPtr(nullptr),
+    parentEmitter(nullptr),
     visualData(nullptr),
     particleType(PT_VISUAL),
-    timeToLive(DEFAULT_TTL),
-    totalTimeToLive(DEFAULT_TTL),
-    timeFraction(0.0f),
-    mass(DEFAULT_MASS),
-    eventFlags(0),
-    freezed(false),
     originalDirectionLength(0.0f),
-    originalScaledDirectionLength(0.0f),
     originalVelocity(0.0f),
-    parentEmitter(nullptr),
+    originalScaledDirectionLength(0.0f),
+    rotationAxis(Vec3::UNIT_Z),
     //color(Vec4::ONE),
     originalColor(Vec4::ONE),
     //zRotation(0.0f),
     zRotationSpeed(0.0f),
     rotationSpeed(0.0f),
-    rotationAxis(Vec3::UNIT_Z),
-    ownDimensions(false),
     radius(0.87f),
+    ownDimensions(false),
+    eventFlags(0),
+    freezed(false),
+    timeToLive(DEFAULT_TTL),
+    totalTimeToLive(DEFAULT_TTL),
+    timeFraction(0.0f),
+    mass(DEFAULT_MASS),
     textureAnimationTimeStep(0.1f),
     textureAnimationTimeStepCount(0.0f),
     textureCoordsCurrent(0),
@@ -176,13 +176,13 @@ PUParticleSystem3D::PUParticleSystem3D()
 , _prepared(false)
 , _poolPrepared(false)
 , _particleSystemScaleVelocity(1.0f)
+, _timeElapsedSinceStart(0.0f)
 , _defaultWidth(DEFAULT_WIDTH)
 , _defaultHeight(DEFAULT_HEIGHT)
 , _defaultDepth(DEFAULT_DEPTH)
 , _maxVelocity(DEFAULT_MAX_VELOCITY)
 , _maxVelocitySet(false)
 , _isMarkedForEmission(false)
-, _timeElapsedSinceStart(0.0f)
 , _parentParticleSystem(nullptr)
 {
     _particleQuota = DEFAULT_PARTICLE_QUOTA;

--- a/extensions/Particle3D/PU/CCPURender.cpp
+++ b/extensions/Particle3D/PU/CCPURender.cpp
@@ -514,8 +514,8 @@ PUParticle3DEntityRender::PUParticle3DEntityRender()
     : _meshCommand(nullptr)
     , _texture(nullptr)
     , _glProgramState(nullptr)
-    , _vertexBuffer(nullptr)
     , _indexBuffer(nullptr)
+    , _vertexBuffer(nullptr)
 {
 
 }

--- a/extensions/Particle3D/PU/CCPURender.cpp
+++ b/extensions/Particle3D/PU/CCPURender.cpp
@@ -50,10 +50,10 @@ void PURender::copyAttributesTo( PURender *render )
     render->_renderType = _renderType;
 }
 
-static bool compareParticle3D(PUParticle3D* left, PUParticle3D* right)
-{
-    return left->depthInView > right->depthInView;
-}
+//static bool compareParticle3D(PUParticle3D* left, PUParticle3D* right)
+//{
+//    return left->depthInView > right->depthInView;
+//}
 
 PUParticle3DQuadRender* PUParticle3DQuadRender::create(const std::string& texFile)
 {

--- a/extensions/Particle3D/PU/CCPURibbonTrailRender.cpp
+++ b/extensions/Particle3D/PU/CCPURibbonTrailRender.cpp
@@ -95,11 +95,11 @@ PURibbonTrailRender::PURibbonTrailRender() :
     _trail(0),
     _useVertexColours(DEFAULT_USE_VERTEX_COLOURS),
     _maxChainElements(DEFAULT_MAX_ELEMENTS),
-    _setLength(false),
     _trailLength(DEFAULT_LENGTH),
-    _setWidth(false),
     _trailWidth(DEFAULT_WIDTH),
     _randomInitialColor(DEFAULT_RANDOM_INITIAL_COLOUR),
+    _setLength(false),
+    _setWidth(false),
     _initialColor(DEFAULT_INITIAL_COLOUR),
     _colorChange(DEFAULT_COLOUR_CHANGE),
     _childNode(0)

--- a/extensions/Particle3D/PU/CCPURibbonTrailRender.h
+++ b/extensions/Particle3D/PU/CCPURibbonTrailRender.h
@@ -44,8 +44,8 @@ public:
     //Constructor
     PURibbonTrailVisualData (Node* sceneNode, PURibbonTrail* ribbonTrail) : 
         node(sceneNode),
-        trail(ribbonTrail),
         addedToTrail(false),
+        trail(ribbonTrail),
         index(0){};
 
     Node* node;

--- a/tests/cpp-tests/Classes/NewAudioEngineTest/NewAudioEngineTest.cpp
+++ b/tests/cpp-tests/Classes/NewAudioEngineTest/NewAudioEngineTest.cpp
@@ -78,8 +78,8 @@ namespace {
         
     private:
         TextButton()
-        : _enabled(true)
-        , _onTriggered(nullptr)
+        : _onTriggered(nullptr)
+        , _enabled(true)
         {
             auto listener = EventListenerTouchOneByOne::create();
             listener->setSwallowTouches(true);

--- a/tests/cpp-tests/Classes/ParticleTest/ParticleTest.h
+++ b/tests/cpp-tests/Classes/ParticleTest/ParticleTest.h
@@ -287,8 +287,6 @@ public:
     virtual void update(float dt) override;
     virtual std::string title() const override;
     virtual std::string subtitle() const override;
-private:
-    cocos2d::ParticleBatchNode* _batchNode;
 };
 
 class AddAndDeleteParticleSystems : public ParticleDemo

--- a/tests/cpp-tests/Classes/PhysicsTest/PhysicsTest.cpp
+++ b/tests/cpp-tests/Classes/PhysicsTest/PhysicsTest.cpp
@@ -54,9 +54,9 @@ void PhysicsDemoDisabled::onEnter()
 #else
 
 PhysicsDemo::PhysicsDemo()
-: _debugDraw(false)
-, _spriteTexture(nullptr)
+: _spriteTexture(nullptr)
 , _ball(nullptr)
+, _debugDraw(false)
 {
 }
 

--- a/tests/cpp-tests/Classes/SpriteTest/SpriteTest.cpp
+++ b/tests/cpp-tests/Classes/SpriteTest/SpriteTest.cpp
@@ -3332,32 +3332,26 @@ class MySprite1 : public Sprite
 {
 public:
     CREATE_FUNC(MySprite1);
-    MySprite1() : ivar(10) {}
+    MySprite1() {}
     static MySprite1* createWithSpriteFrameName(const std::string& spriteFrameName)
     {
         auto sprite = MySprite1::create();
         sprite->setSpriteFrame(spriteFrameName);
         return sprite;
     }
-
-private:
-    int ivar;
 };
 
 class MySprite2 : public Sprite
 {
 public:
     CREATE_FUNC(MySprite2);
-    MySprite2() : ivar(10) {}
+    MySprite2() {}
     static MySprite2* create(const std::string& name)
     {
         auto sprite = MySprite2::create();
         sprite ->setTexture(name);
         return sprite;
     }
-
-private:
-    int ivar;
 };
 
 //------------------------------------------------------------------


### PR DESCRIPTION
Fix most warnings that reported by Xcode. Most of them are incorrect field initialization order. But some of them is about unused entities.

After that changes, a project generated by cmake has these warnings count:
cocos2d - 16 (before was more 50. Remain warnings are hard to fix quickly.)
luacocos2d - 411 (i did not fix these warnings because there are autogenerated files)
cpp-empty-test - 0
cpp-tests - 0
lua-empty-test - 0
lua-tests - 1
