### PR TITLE
Set the texture format on the specified image file

### DIFF
--- a/cocos/renderer/CCTextureCache.cpp
+++ b/cocos/renderer/CCTextureCache.cpp
@@ -219,17 +219,7 @@ void TextureCache::loadImage()
             const std::string& filename = asyncStruct->filename;
             // generate image      
             image = new (std::nothrow) Image();
-            
-            Texture2D::PixelFormat oldformat = Texture2D::getDefaultAlphaPixelFormat();
-            auto formatit = _fileTextureFormat.find(filename);
-            if( formatit != _fileTextureFormat.end()){
-                Texture2D::setDefaultAlphaPixelFormat(formatit->second);
-            }
-            
-            bool ret = image->initWithImageFileThreadSafe(filename);
-            
-            Texture2D::setDefaultAlphaPixelFormat(oldformat);
-            if (image && !ret)
+            if (image && !image->initWithImageFileThreadSafe(filename))
             {
                 CC_SAFE_RELEASE(image);
                 CCLOG("can not load %s", filename.c_str());

--- a/cocos/renderer/CCTextureCache.cpp
+++ b/cocos/renderer/CCTextureCache.cpp
@@ -563,7 +563,7 @@ void TextureCache::waitForQuit()
 
 void TextureCache::setFileTextureFormat(std::string path, Texture2D::PixelFormat format)
 {
-    std::string key = FileUtils::getInstance()->fullPathForFilename(path);;
+    std::string key = FileUtils::getInstance()->fullPathForFilename(path);
     auto it = _fileTextureFormat.find(key);
     if( it != _fileTextureFormat.end() )
         _fileTextureFormat.erase(it);

--- a/cocos/renderer/CCTextureCache.h
+++ b/cocos/renderer/CCTextureCache.h
@@ -194,6 +194,10 @@ public:
     //Wait for texture cahe to quit befor destroy instance.
     /**Called by director, please do not called outside.*/
     void waitForQuit();
+    
+    /** Set the texture format for image file.
+     */
+    void setFileTextureFormat(std::string path, Texture2D::PixelFormat format);
 
 private:
     void addImageAsyncCallBack(float dt);
@@ -232,6 +236,7 @@ protected:
     int _asyncRefCount;
 
     std::unordered_map<std::string, Texture2D*> _textures;
+    std::unordered_map<std::string, Texture2D::PixelFormat> _fileTextureFormat;
 };
 
 #if CC_ENABLE_CACHE_TEXTURE_DATA

--- a/cocos/scripting/lua-bindings/auto/lua_cocos2dx_auto.cpp
+++ b/cocos/scripting/lua-bindings/auto/lua_cocos2dx_auto.cpp
@@ -65444,6 +65444,59 @@ static int lua_cocos2dx_TextureCache_finalize(lua_State* tolua_S)
     return 0;
 }
 
+int lua_cocos2dx_TextureCache_setFileTextureFormat(lua_State* tolua_S)
+{
+    int argc = 0;
+    cocos2d::TextureCache* cobj = nullptr;
+    bool ok  = true;
+    
+#if COCOS2D_DEBUG >= 1
+    tolua_Error tolua_err;
+#endif
+    
+    
+#if COCOS2D_DEBUG >= 1
+    if (!tolua_isusertype(tolua_S,1,"cc.TextureCache",0,&tolua_err)) goto tolua_lerror;
+#endif
+    
+    cobj = (cocos2d::TextureCache*)tolua_tousertype(tolua_S,1,0);
+    
+#if COCOS2D_DEBUG >= 1
+    if (!cobj)
+    {
+        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_cocos2dx_TextureCache_setFileTextureFormat'", nullptr);
+        return 0;
+    }
+#endif
+    
+    argc = lua_gettop(tolua_S) - 1;
+    
+    if (argc == 2)
+    {
+        std::string arg0;
+        
+        ok &= luaval_to_std_string(tolua_S, 2,&arg0, "cc.TextureCache:setFileTextureFormat");
+        
+        cocos2d::Texture2D::PixelFormat arg1;
+        ok &= luaval_to_int32(tolua_S, 3,(int *)&arg1, "cc.TextureCache:setFileTextureFormat");
+        if(!ok)
+        {
+            tolua_error(tolua_S,"invalid arguments in function 'lua_cocos2dx_TextureCache_setFileTextureFormat'", nullptr);
+            return 0;
+        }
+        cobj->setFileTextureFormat(arg0, arg1);
+        lua_settop(tolua_S, 1);
+        return 1;
+    }
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d\n ", "lua_cocos2dx_TextureCache_setFileTextureFormat",argc, 1);
+    return 0;
+#if COCOS2D_DEBUG >= 1
+tolua_lerror:
+    tolua_error(tolua_S,"#ferror in function 'lua_cocos2dx_TextureCache_setFileTextureFormat'.",&tolua_err);
+#endif
+    return 0;
+}
+
 int lua_register_cocos2dx_TextureCache(lua_State* tolua_S)
 {
     tolua_usertype(tolua_S,"cc.TextureCache");
@@ -65463,6 +65516,7 @@ int lua_register_cocos2dx_TextureCache(lua_State* tolua_S)
         tolua_function(tolua_S,"removeUnusedTextures",lua_cocos2dx_TextureCache_removeUnusedTextures);
         tolua_function(tolua_S,"removeTexture",lua_cocos2dx_TextureCache_removeTexture);
         tolua_function(tolua_S,"waitForQuit",lua_cocos2dx_TextureCache_waitForQuit);
+        tolua_function(tolua_S,"setFileTextureFormat",lua_cocos2dx_TextureCache_setFileTextureFormat);
     tolua_endmodule(tolua_S);
     std::string typeName = typeid(cocos2d::TextureCache).name();
     g_luaType[typeName] = "cc.TextureCache";


### PR DESCRIPTION
We need to set the texture format  when the asynchronous loading resource, and change back to default in callbacks, so,  if when the asynchronous loading and synchronous loading in the same time, the texture format settings will not get the result we wanted, so the increase or the set of texture format of the specified file is necessary.

当前在异步加载的时候设置纹理需要在回调的时候才能改回默认值，如果在异步加载的时候又去同步加载，那么纹理格式的设置将得不到我们想要的结果，所以增加这种对指定文件进行设置纹理格式是很有必要的，否则，异步加载将形同虚设。
