### PR TITLE
Fix setSprite never updating progress on ProgressTimer

### DIFF
--- a/cocos/2d/CCProgressTimer.cpp
+++ b/cocos/2d/CCProgressTimer.cpp
@@ -115,6 +115,8 @@ void ProgressTimer::setSprite(Sprite *sprite)
             CC_SAFE_FREE(_vertexData);
             _vertexDataCount = 0;
         }
+        
+        updateProgress();
     }        
 }
 


### PR DESCRIPTION
Basically whenever you set a new sprite on a ProgressTimer, the new sprite is hidden.

 Calling setPercentage once with the same value doesn't work because the new percentage is the same as the old one. I've got a workaround setting the percentage to 0 and then back to the old value, but this change seems to solve that issue entirely.
