### PR TITLE
javaactivity-android.cpp needs JNIEXPORT for -fvisibility=hidden

### DIFF
--- a/cocos/platform/android/javaactivity-android.cpp
+++ b/cocos/platform/android/javaactivity-android.cpp
@@ -49,14 +49,14 @@ using namespace cocos2d;
 extern "C"
 {
 
-jint JNI_OnLoad(JavaVM *vm, void *reserved)
+JNIEXPORT jint JNI_OnLoad(JavaVM *vm, void *reserved)
 {
     JniHelper::setJavaVM(vm);
 
     return JNI_VERSION_1_4;
 }
 
-void Java_org_cocos2dx_lib_Cocos2dxRenderer_nativeInit(JNIEnv*  env, jobject thiz, jint w, jint h)
+JNIEXPORT void Java_org_cocos2dx_lib_Cocos2dxRenderer_nativeInit(JNIEnv*  env, jobject thiz, jint w, jint h)
 {
     auto director = cocos2d::Director::getInstance();
     auto glview = director->getOpenGLView();
@@ -83,7 +83,7 @@ void Java_org_cocos2dx_lib_Cocos2dxRenderer_nativeInit(JNIEnv*  env, jobject thi
     }
 }
 
-jintArray Java_org_cocos2dx_lib_Cocos2dxActivity_getGLContextAttrs(JNIEnv*  env, jobject thiz)
+JNIEXPORT jintArray Java_org_cocos2dx_lib_Cocos2dxActivity_getGLContextAttrs(JNIEnv*  env, jobject thiz)
 {
     cocos_android_app_init(env, thiz);
     cocos2d::Application::getInstance()->initGLContextAttrs(); 
@@ -99,7 +99,7 @@ jintArray Java_org_cocos2dx_lib_Cocos2dxActivity_getGLContextAttrs(JNIEnv*  env,
     return glContextAttrsJava;
 }
 
-void Java_org_cocos2dx_lib_Cocos2dxRenderer_nativeOnSurfaceChanged(JNIEnv*  env, jobject thiz, jint w, jint h)
+JNIEXPORT void Java_org_cocos2dx_lib_Cocos2dxRenderer_nativeOnSurfaceChanged(JNIEnv*  env, jobject thiz, jint w, jint h)
 {
     cocos2d::Application::getInstance()->applicationScreenSizeChanged(w, h);
 }


### PR DESCRIPTION
javaactivity-android.cpp file needs JNIEXPORT macro for who use -fvisibility=hidden in their make file.
