### PR TITLE
Fix a bug: to handle big frame packet

### DIFF
--- a/cocos/network/WebSocket.cpp
+++ b/cocos/network/WebSocket.cpp
@@ -647,9 +647,11 @@ int WebSocket::onSocketCallback(struct libwebsocket_context *ctx,
                     {
                         //CCLOG("%ld bytes of pending data to receive, consider increasing the libwebsocket rx_buffer_size value.", _pendingFrameDataLen);
                     }
+                    //to handle big frame packet
+                    bool isfinal = libwebsocket_is_final_fragment(wsi);
                     
                     // If no more data pending, send it to the client thread
-                    if (_pendingFrameDataLen == 0)
+                    if (_pendingFrameDataLen == 0 && isfinal )
                     {
 						WsMessage* msg = new (std::nothrow) WsMessage();
 						msg->what = WS_MSG_TO_UITHREAD_MESSAGE;


### PR DESCRIPTION
Ensure trigger message read event after got whole frame packet.
