### PR TITLE
AudioEngine:Fixed program may freeze if `AudioEngine::stop` or `AudioEngine::stopAll()` is invoked frequently on Android.

### DIFF
--- a/cocos/audio/android/AudioEngine-inl.cpp
+++ b/cocos/audio/android/AudioEngine-inl.cpp
@@ -365,7 +365,11 @@ void AudioEngineImpl::stop(int audioID)
         log("%s error:%u",__func__, result);
     }
 
-    //If destroy openSL object immediately,it may cause dead lock.
+    /*If destroy openSL object immediately,it may cause dead lock.
+     *It's a system issue.For more information:
+     *    https://github.com/cocos2d/cocos2d-x/issues/11697
+     *    https://groups.google.com/forum/#!msg/android-ndk/zANdS2n2cQI/AT6q1F3nNGIJ
+     */
     player._delayTimeToRemove = DELAY_TIME_TO_REMOVE;
     //_audioPlayers.erase(audioID);
 }

--- a/cocos/audio/android/AudioEngine-inl.h
+++ b/cocos/audio/android/AudioEngine-inl.h
@@ -60,6 +60,7 @@ private:
     float _duration;
     int _audioID;
     int _assetFd;
+    float _delayTimeToRemove;
 
     std::function<void (int, const std::string &)> _finishCallback;
 


### PR DESCRIPTION
This solution is not perfect, by this method the probability of `freeze` is greatly reduced.
