### PR TITLE
V3: updates to app.xaml code to correctly support touches on Microsoft Ads

### DIFF
--- a/templates/cpp-template-default/proj.win8.1-universal/App.Shared/App.xaml.cpp
+++ b/templates/cpp-template-default/proj.win8.1-universal/App.Shared/App.xaml.cpp
@@ -1,21 +1,128 @@
 ﻿#include "App.xaml.h"
 #include "OpenGLESPage.xaml.h"
 
+using namespace Platform;
+using namespace Windows::ApplicationModel;
+using namespace Windows::ApplicationModel::Activation;
+using namespace Windows::Foundation;
+using namespace Windows::Foundation::Collections;
+using namespace Windows::UI::Xaml::Media::Animation;
+using namespace Windows::UI::Xaml;
+using namespace Windows::UI::Xaml::Controls;
+using namespace Windows::UI::Xaml::Controls::Primitives;
+using namespace Windows::UI::Xaml::Data;
+using namespace Windows::UI::Xaml::Input;
+using namespace Windows::UI::Xaml::Interop;
+using namespace Windows::UI::Xaml::Media;
+using namespace Windows::UI::Xaml::Navigation;
 using namespace cocos2d;
 
 App::App()
 {
     InitializeComponent();
+    Suspending += ref new SuspendingEventHandler(this, &App::OnSuspending);
 }
 
-void App::OnLaunched(Windows::ApplicationModel::Activation::LaunchActivatedEventArgs^ e)
+/// <summary>
+/// Invoked when the application is launched normally by the end user.  Other entry points
+/// will be used when the application is launched to open a specific file, to display
+/// search results, and so forth.
+/// </summary>
+/// <param name="e">Details about the launch request and process.</param>
+void App::OnLaunched(LaunchActivatedEventArgs^ e)
 {
-    if (mPage == nullptr)
+    auto rootFrame = dynamic_cast<Frame^>(Window::Current->Content);
+
+    // Do not repeat app initialization when the Window already has content,
+    // just ensure that the window is active.
+    if (rootFrame == nullptr)
     {
-        mPage = ref new OpenGLESPage(&mOpenGLES);
+        // Create a Frame to act as the navigation context and associate it with
+        // a SuspensionManager key
+        rootFrame = ref new Frame();
+
+        // TODO: Change this value to a cache size that is appropriate for your application.
+        rootFrame->CacheSize = 1;
+
+        if (e->PreviousExecutionState == ApplicationExecutionState::Terminated)
+        {
+            // TODO: Restore the saved session state only when appropriate, scheduling the
+            // final launch steps after the restore is complete.
+        }
+
+        // Place the frame in the current Window
+        Window::Current->Content = rootFrame;
     }
 
-    // Place the page in the current window and ensure that it is active.
-    Windows::UI::Xaml::Window::Current->Content = mPage;
-    Windows::UI::Xaml::Window::Current->Activate();
+    if (rootFrame->Content == nullptr)
+    {
+#if WINAPI_FAMILY==WINAPI_FAMILY_PHONE_APP
+        // Removes the turnstile navigation for startup.
+        if (rootFrame->ContentTransitions != nullptr)
+        {
+            _transitions = ref new TransitionCollection();
+            for (auto transition : rootFrame->ContentTransitions)
+            {
+                _transitions->Append(transition);
+            }
+        }
+
+        rootFrame->ContentTransitions = nullptr;
+        _firstNavigatedToken = rootFrame->Navigated += ref new NavigatedEventHandler(this, &App::RootFrame_FirstNavigated);
+#endif
+
+        // When the navigation stack isn't restored navigate to the first page,
+        // configuring the new page by passing required information as a navigation
+        // parameter.
+
+        rootFrame->Content = mPage = ref new OpenGLESPage(&mOpenGLES);
+
+#if 0
+        if (!rootFrame->Navigate(OpenGLESPage::typeid, e->Arguments))
+        {
+            throw ref new FailureException("Failed to create initial page");
+        }
+#endif
+    }
+
+    // Ensure the current window is active
+    Window::Current->Activate();
+}
+
+#if WINAPI_FAMILY==WINAPI_FAMILY_PHONE_APP
+/// <summary>
+/// Restores the content transitions after the app has launched.
+/// </summary>
+void App::RootFrame_FirstNavigated(Object^ sender, NavigationEventArgs^ e)
+{
+    auto rootFrame = safe_cast<Frame^>(sender);
+
+    TransitionCollection^ newTransitions;
+    if (_transitions == nullptr)
+    {
+        newTransitions = ref new TransitionCollection();
+        newTransitions->Append(ref new NavigationThemeTransition());
+    }
+    else
+    {
+        newTransitions = _transitions;
+    }
+
+    rootFrame->ContentTransitions = newTransitions;
+
+    rootFrame->Navigated -= _firstNavigatedToken;
+}
+#endif
+
+/// <summary>
+/// Invoked when application execution is being suspended. Application state is saved
+/// without knowing whether the application will be terminated or resumed with the contents
+/// of memory still intact.
+/// </summary>
+void App::OnSuspending(Object^ sender, SuspendingEventArgs^ e)
+{
+    (void) sender;	// Unused parameter
+    (void) e;		// Unused parameter
+
+    // TODO: Save application state and stop any background activity
 }

--- a/templates/cpp-template-default/proj.win8.1-universal/App.Shared/App.xaml.h
+++ b/templates/cpp-template-default/proj.win8.1-universal/App.Shared/App.xaml.h
@@ -13,6 +13,16 @@ namespace cocos2d
         virtual void OnLaunched(Windows::ApplicationModel::Activation::LaunchActivatedEventArgs^ e) override;
 
     private:
+
+#if WINAPI_FAMILY==WINAPI_FAMILY_PHONE_APP
+        Windows::UI::Xaml::Media::Animation::TransitionCollection^ _transitions;
+        Windows::Foundation::EventRegistrationToken _firstNavigatedToken;
+
+        void RootFrame_FirstNavigated(Platform::Object^ sender, Windows::UI::Xaml::Navigation::NavigationEventArgs^ e);
+#endif
+
+        void OnSuspending(Platform::Object^ sender, Windows::ApplicationModel::SuspendingEventArgs^ e);
+
         OpenGLESPage^ mPage;
         OpenGLES mOpenGLES;
     };

--- a/tests/cpp-empty-test/proj.win8.1-universal/HelloCpp.Shared/App.xaml.cpp
+++ b/tests/cpp-empty-test/proj.win8.1-universal/HelloCpp.Shared/App.xaml.cpp
@@ -1,21 +1,128 @@
 ﻿#include "App.xaml.h"
 #include "OpenGLESPage.xaml.h"
 
+using namespace Platform;
+using namespace Windows::ApplicationModel;
+using namespace Windows::ApplicationModel::Activation;
+using namespace Windows::Foundation;
+using namespace Windows::Foundation::Collections;
+using namespace Windows::UI::Xaml::Media::Animation;
+using namespace Windows::UI::Xaml;
+using namespace Windows::UI::Xaml::Controls;
+using namespace Windows::UI::Xaml::Controls::Primitives;
+using namespace Windows::UI::Xaml::Data;
+using namespace Windows::UI::Xaml::Input;
+using namespace Windows::UI::Xaml::Interop;
+using namespace Windows::UI::Xaml::Media;
+using namespace Windows::UI::Xaml::Navigation;
 using namespace cocos2d;
 
 App::App()
 {
     InitializeComponent();
+    Suspending += ref new SuspendingEventHandler(this, &App::OnSuspending);
 }
 
-void App::OnLaunched(Windows::ApplicationModel::Activation::LaunchActivatedEventArgs^ e)
+/// <summary>
+/// Invoked when the application is launched normally by the end user.  Other entry points
+/// will be used when the application is launched to open a specific file, to display
+/// search results, and so forth.
+/// </summary>
+/// <param name="e">Details about the launch request and process.</param>
+void App::OnLaunched(LaunchActivatedEventArgs^ e)
 {
-    if (mPage == nullptr)
+    auto rootFrame = dynamic_cast<Frame^>(Window::Current->Content);
+
+    // Do not repeat app initialization when the Window already has content,
+    // just ensure that the window is active.
+    if (rootFrame == nullptr)
     {
-        mPage = ref new OpenGLESPage(&mOpenGLES);
+        // Create a Frame to act as the navigation context and associate it with
+        // a SuspensionManager key
+        rootFrame = ref new Frame();
+
+        // TODO: Change this value to a cache size that is appropriate for your application.
+        rootFrame->CacheSize = 1;
+
+        if (e->PreviousExecutionState == ApplicationExecutionState::Terminated)
+        {
+            // TODO: Restore the saved session state only when appropriate, scheduling the
+            // final launch steps after the restore is complete.
+        }
+
+        // Place the frame in the current Window
+        Window::Current->Content = rootFrame;
     }
 
-    // Place the page in the current window and ensure that it is active.
-    Windows::UI::Xaml::Window::Current->Content = mPage;
-    Windows::UI::Xaml::Window::Current->Activate();
+    if (rootFrame->Content == nullptr)
+    {
+#if WINAPI_FAMILY==WINAPI_FAMILY_PHONE_APP
+        // Removes the turnstile navigation for startup.
+        if (rootFrame->ContentTransitions != nullptr)
+        {
+            _transitions = ref new TransitionCollection();
+            for (auto transition : rootFrame->ContentTransitions)
+            {
+                _transitions->Append(transition);
+            }
+        }
+
+        rootFrame->ContentTransitions = nullptr;
+        _firstNavigatedToken = rootFrame->Navigated += ref new NavigatedEventHandler(this, &App::RootFrame_FirstNavigated);
+#endif
+
+        // When the navigation stack isn't restored navigate to the first page,
+        // configuring the new page by passing required information as a navigation
+        // parameter.
+
+        rootFrame->Content = mPage = ref new OpenGLESPage(&mOpenGLES);
+
+#if 0
+        if (!rootFrame->Navigate(OpenGLESPage::typeid, e->Arguments))
+        {
+            throw ref new FailureException("Failed to create initial page");
+        }
+#endif
+    }
+
+    // Ensure the current window is active
+    Window::Current->Activate();
+}
+
+#if WINAPI_FAMILY==WINAPI_FAMILY_PHONE_APP
+/// <summary>
+/// Restores the content transitions after the app has launched.
+/// </summary>
+void App::RootFrame_FirstNavigated(Object^ sender, NavigationEventArgs^ e)
+{
+    auto rootFrame = safe_cast<Frame^>(sender);
+
+    TransitionCollection^ newTransitions;
+    if (_transitions == nullptr)
+    {
+        newTransitions = ref new TransitionCollection();
+        newTransitions->Append(ref new NavigationThemeTransition());
+    }
+    else
+    {
+        newTransitions = _transitions;
+    }
+
+    rootFrame->ContentTransitions = newTransitions;
+
+    rootFrame->Navigated -= _firstNavigatedToken;
+}
+#endif
+
+/// <summary>
+/// Invoked when application execution is being suspended. Application state is saved
+/// without knowing whether the application will be terminated or resumed with the contents
+/// of memory still intact.
+/// </summary>
+void App::OnSuspending(Object^ sender, SuspendingEventArgs^ e)
+{
+    (void) sender;	// Unused parameter
+    (void) e;		// Unused parameter
+
+    // TODO: Save application state and stop any background activity
 }

--- a/tests/cpp-empty-test/proj.win8.1-universal/HelloCpp.Shared/App.xaml.h
+++ b/tests/cpp-empty-test/proj.win8.1-universal/HelloCpp.Shared/App.xaml.h
@@ -13,6 +13,16 @@ namespace cocos2d
         virtual void OnLaunched(Windows::ApplicationModel::Activation::LaunchActivatedEventArgs^ e) override;
 
     private:
+
+#if WINAPI_FAMILY==WINAPI_FAMILY_PHONE_APP
+        Windows::UI::Xaml::Media::Animation::TransitionCollection^ _transitions;
+        Windows::Foundation::EventRegistrationToken _firstNavigatedToken;
+
+        void RootFrame_FirstNavigated(Platform::Object^ sender, Windows::UI::Xaml::Navigation::NavigationEventArgs^ e);
+#endif
+
+        void OnSuspending(Platform::Object^ sender, Windows::ApplicationModel::SuspendingEventArgs^ e);
+
         OpenGLESPage^ mPage;
         OpenGLES mOpenGLES;
     };

--- a/tests/cpp-tests/proj.win8.1-universal/cpp-tests.Shared/App.xaml.cpp
+++ b/tests/cpp-tests/proj.win8.1-universal/cpp-tests.Shared/App.xaml.cpp
@@ -1,21 +1,128 @@
 ﻿#include "App.xaml.h"
 #include "OpenGLESPage.xaml.h"
 
+using namespace Platform;
+using namespace Windows::ApplicationModel;
+using namespace Windows::ApplicationModel::Activation;
+using namespace Windows::Foundation;
+using namespace Windows::Foundation::Collections;
+using namespace Windows::UI::Xaml::Media::Animation;
+using namespace Windows::UI::Xaml;
+using namespace Windows::UI::Xaml::Controls;
+using namespace Windows::UI::Xaml::Controls::Primitives;
+using namespace Windows::UI::Xaml::Data;
+using namespace Windows::UI::Xaml::Input;
+using namespace Windows::UI::Xaml::Interop;
+using namespace Windows::UI::Xaml::Media;
+using namespace Windows::UI::Xaml::Navigation;
 using namespace cocos2d;
 
 App::App()
 {
     InitializeComponent();
+    Suspending += ref new SuspendingEventHandler(this, &App::OnSuspending);
 }
 
-void App::OnLaunched(Windows::ApplicationModel::Activation::LaunchActivatedEventArgs^ e)
+/// <summary>
+/// Invoked when the application is launched normally by the end user.  Other entry points
+/// will be used when the application is launched to open a specific file, to display
+/// search results, and so forth.
+/// </summary>
+/// <param name="e">Details about the launch request and process.</param>
+void App::OnLaunched(LaunchActivatedEventArgs^ e)
 {
-    if (mPage == nullptr)
+    auto rootFrame = dynamic_cast<Frame^>(Window::Current->Content);
+
+    // Do not repeat app initialization when the Window already has content,
+    // just ensure that the window is active.
+    if (rootFrame == nullptr)
     {
-        mPage = ref new OpenGLESPage(&mOpenGLES);
+        // Create a Frame to act as the navigation context and associate it with
+        // a SuspensionManager key
+        rootFrame = ref new Frame();
+
+        // TODO: Change this value to a cache size that is appropriate for your application.
+        rootFrame->CacheSize = 1;
+
+        if (e->PreviousExecutionState == ApplicationExecutionState::Terminated)
+        {
+            // TODO: Restore the saved session state only when appropriate, scheduling the
+            // final launch steps after the restore is complete.
+        }
+
+        // Place the frame in the current Window
+        Window::Current->Content = rootFrame;
     }
 
-    // Place the page in the current window and ensure that it is active.
-    Windows::UI::Xaml::Window::Current->Content = mPage;
-    Windows::UI::Xaml::Window::Current->Activate();
+    if (rootFrame->Content == nullptr)
+    {
+#if WINAPI_FAMILY==WINAPI_FAMILY_PHONE_APP
+        // Removes the turnstile navigation for startup.
+        if (rootFrame->ContentTransitions != nullptr)
+        {
+            _transitions = ref new TransitionCollection();
+            for (auto transition : rootFrame->ContentTransitions)
+            {
+                _transitions->Append(transition);
+            }
+        }
+
+        rootFrame->ContentTransitions = nullptr;
+        _firstNavigatedToken = rootFrame->Navigated += ref new NavigatedEventHandler(this, &App::RootFrame_FirstNavigated);
+#endif
+
+        // When the navigation stack isn't restored navigate to the first page,
+        // configuring the new page by passing required information as a navigation
+        // parameter.
+
+        rootFrame->Content = mPage = ref new OpenGLESPage(&mOpenGLES);
+
+#if 0
+        if (!rootFrame->Navigate(OpenGLESPage::typeid, e->Arguments))
+        {
+            throw ref new FailureException("Failed to create initial page");
+        }
+#endif
+    }
+
+    // Ensure the current window is active
+    Window::Current->Activate();
+}
+
+#if WINAPI_FAMILY==WINAPI_FAMILY_PHONE_APP
+/// <summary>
+/// Restores the content transitions after the app has launched.
+/// </summary>
+void App::RootFrame_FirstNavigated(Object^ sender, NavigationEventArgs^ e)
+{
+    auto rootFrame = safe_cast<Frame^>(sender);
+
+    TransitionCollection^ newTransitions;
+    if (_transitions == nullptr)
+    {
+        newTransitions = ref new TransitionCollection();
+        newTransitions->Append(ref new NavigationThemeTransition());
+    }
+    else
+    {
+        newTransitions = _transitions;
+    }
+
+    rootFrame->ContentTransitions = newTransitions;
+
+    rootFrame->Navigated -= _firstNavigatedToken;
+}
+#endif
+
+/// <summary>
+/// Invoked when application execution is being suspended. Application state is saved
+/// without knowing whether the application will be terminated or resumed with the contents
+/// of memory still intact.
+/// </summary>
+void App::OnSuspending(Object^ sender, SuspendingEventArgs^ e)
+{
+    (void) sender;	// Unused parameter
+    (void) e;		// Unused parameter
+
+    // TODO: Save application state and stop any background activity
 }

--- a/tests/cpp-tests/proj.win8.1-universal/cpp-tests.Shared/App.xaml.h
+++ b/tests/cpp-tests/proj.win8.1-universal/cpp-tests.Shared/App.xaml.h
@@ -13,6 +13,16 @@ namespace cocos2d
         virtual void OnLaunched(Windows::ApplicationModel::Activation::LaunchActivatedEventArgs^ e) override;
 
     private:
+
+#if WINAPI_FAMILY==WINAPI_FAMILY_PHONE_APP
+        Windows::UI::Xaml::Media::Animation::TransitionCollection^ _transitions;
+        Windows::Foundation::EventRegistrationToken _firstNavigatedToken;
+
+        void RootFrame_FirstNavigated(Platform::Object^ sender, Windows::UI::Xaml::Navigation::NavigationEventArgs^ e);
+#endif
+
+        void OnSuspending(Platform::Object^ sender, Windows::ApplicationModel::SuspendingEventArgs^ e);
+
         OpenGLESPage^ mPage;
         OpenGLES mOpenGLES;
     };


### PR DESCRIPTION
The pull request fixes issue https://github.com/MSOpenTech/cocos2d-x/issues/141. Touch events on Ads were not causing a click through on the ad. The code in app.xaml.cpp needed to be updated as recommended in the issue.
