### PR TITLE
fix script binding code generation

### DIFF
--- a/cocos/cocos2d.h
+++ b/cocos/cocos2d.h
@@ -254,14 +254,14 @@ THE SOFTWARE.
 #include "renderer/CCTextureAtlas.h"
 
 // tilemap_parallax_nodes
-#include "2d/CCFastTMXLayer.h"
-#include "2d/CCFastTMXTiledMap.h"
 #include "2d/CCParallaxNode.h"
 #include "2d/CCTMXLayer.h"
 #include "2d/CCTMXObjectGroup.h"
 #include "2d/CCTMXTiledMap.h"
 #include "2d/CCTMXXMLParser.h"
 #include "2d/CCTileMapAtlas.h"
+#include "2d/CCFastTMXLayer.h"
+#include "2d/CCFastTMXTiledMap.h"
 
 // component
 #include "2d/CCComponent.h"


### PR DESCRIPTION
I know it may looks stupid, but it does fixed js compilation.

In fact, this pr also fixed lua binding.The binding code of TMXLayer for lua is not correct now, it uses `experimental::TMXLayer`. @samuele3hu 
