### PR TITLE
Fix crash in web view if illegal character in url (Android only)

### DIFF
--- a/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxWebView.java
+++ b/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxWebView.java
@@ -58,11 +58,16 @@ public class Cocos2dxWebView extends WebView {
     class Cocos2dxWebViewClient extends WebViewClient {
         @Override
         public boolean shouldOverrideUrlLoading(WebView view, String urlString) {
-            URI uri = URI.create(urlString);
-            if (uri != null && uri.getScheme().equals(mJSScheme)) {
-                Cocos2dxWebViewHelper._onJsCallback(mViewTag, urlString);
-                return true;
+            try {
+                URI uri = URI.create(urlString);
+                if (uri != null && uri.getScheme().equals(mJSScheme)) {
+                    Cocos2dxWebViewHelper._onJsCallback(mViewTag, urlString);
+                    return true;
+                }
+            } catch (Exception e) {
+                Log.d(TAG, "Failed to create URI from url");
             }
+
             return Cocos2dxWebViewHelper._shouldStartLoading(mViewTag, urlString);
         }
 


### PR DESCRIPTION
URI.create can throw exceptions, in my case was IllegalArgumentException. We should handle it.
