### PR TITLE
Copy missing text color property of ui::Text.

### DIFF
--- a/cocos/ui/UIText.cpp
+++ b/cocos/ui/UIText.cpp
@@ -385,6 +385,7 @@ void Text::copySpecialProperties(Widget *widget)
     {
         setFontName(label->_fontName);
         setFontSize(label->getFontSize());
+        setTextColor(label->getTextColor());
         setString(label->getString());
         setTouchScaleChangeEnabled(label->_touchScaleChangeEnabled);
         setTextHorizontalAlignment(label->_labelRenderer->getHorizontalAlignment());


### PR DESCRIPTION
This PR fixed issue https://github.com/cocos2d/cocos2d-x/issues/11769
