### PR TITLE
Added a low-pass-filter to the PhysicsWorld::update method.

### DIFF
--- a/cocos/physics/CCPhysicsWorld.cpp
+++ b/cocos/physics/CCPhysicsWorld.cpp
@@ -803,6 +803,20 @@ void PhysicsWorld::setSubsteps(int steps)
     }
 }
 
+void PhysicsWorld::setUpdateFilterFactor(float filterFactor)
+{
+    if (filterFactor < FLT_EPSILON)
+    {
+        filterFactor = FLT_EPSILON;
+    }
+    else if(filterFactor > 1.0)
+    {
+        filterFactor = 1.0;
+    }
+    _updateFilterFactor = filterFactor;
+}
+
+
 void PhysicsWorld::step(float delta)
 {
     if (_autoStep)
@@ -852,12 +866,21 @@ void PhysicsWorld::update(float delta, bool userCall/* = false*/)
         if (++_updateRateCount >= _updateRate)
         {
             const float dt = _updateTime * _speed / _substeps;
+            if (dt > FLT_EPSILON)
+            {
+                _updateFilteredDelta = _updateFilterFactor * dt +  (1 - _updateFilterFactor)  * _updateFilteredDelta;
+            }
+            else
+            {
+                _updateFilteredDelta = 0.0;
+            }
+            
             for (int i = 0; i < _substeps; ++i)
             {
-                cpSpaceStep(_cpSpace, dt);
+                cpSpaceStep(_cpSpace, _updateFilteredDelta);
                 for (auto& body : _bodies)
                 {
-                    body->update(dt);
+                    body->update(_updateFilteredDelta);
                 }
             }
             _updateRateCount = 0;
@@ -884,6 +907,8 @@ PhysicsWorld::PhysicsWorld()
 , _autoStep(true)
 , _debugDraw(nullptr)
 , _debugDrawMask(DEBUGDRAW_NONE)
+, _updateFilteredDelta(0.0)
+, _updateFilterFactor(1.0)
 {
     
 }

--- a/cocos/physics/CCPhysicsWorld.h
+++ b/cocos/physics/CCPhysicsWorld.h
@@ -286,6 +286,14 @@ public:
     inline int getSubsteps() const { return _substeps; }
 
     /**
+     * Set the update filter factor.
+     *
+     * Value must be between FLT_EPSILON and 1.0, where 1.0 applies no filter to dt and FLT_EPSILON applies maximum filter to dt. The filterFactor is a parameter for a low-pass-filter that is used to smooth out the dt of the physics update loop. Setting this valuie to 1.0 will turn the filter off. Setting the value to less than 1.0 will turn the filter on. e.g. Setting filterFactor to 0.15 will apply a significant low-pass-filter to smooth out the delta time step dt and as a result smooth out the phyiscs simulation.
+     * @param filterFactor A float number, default value is 1.0. Valid values are between FLT_EPSILON and 1.0.
+     */
+    void setUpdateFilterFactor(float filterFactor);
+    
+    /**
     * Set the debug draw mask of this physics world.
     * 
     * This physics world will draw shapes and joints by DrawNode acoording to mask.
@@ -358,6 +366,8 @@ protected:
     float _updateTime;
     int _substeps;
     cpSpace* _cpSpace;
+    float _updateFilteredDelta;
+    float _updateFilterFactor;
     
     bool _updateBodyTransform;
     Vector<PhysicsBody*> _bodies;


### PR DESCRIPTION
Added a low-pass-filter to the PhysicsWorld::update method to make the physics simulation run more smoothly.

The filter is by default turned off, due to the default value of _updateFilterFactor being 1.0 in the PhysicsWorld  constructor.

The filter can be turned on by setting the filter value like this:

```
float filterFactor = 0.1;
currentScene->getPhysicsWorld()->setUpdateFilterFactor(filterFactor);
```

This has been tested on Android 4.4.3 Nexus 7, iOS 8.1.3 Ipad Mini Retina, iOS 8.3 iPhone 5.
Without the low-pass-filter, a fast paced 2D side scrolling racing game physics simulation using the built-in physics might see a jerky or jittery sprite movement of sprites controlled by physics bodies.

The jittery simulation is a result of the physics update loop having variable dt values.

More info about this proposed fix: http://discuss.cocos2d-x.org/t/why-jitter-jerk-when-following-sprite-with-layer-video-included/16799/15

More info about a discussion about alternative fixes should this patch not be applied: http://discuss.cocos2d-x.org/t/does-the-built-in-physics-engine-physicsworld-update-need-a-low-pass-filter-for-dt/21534
