### PR TITLE
fixed #11821, after release StateBlock::_defaultState, set it to null.

### DIFF
--- a/cocos/renderer/CCRenderState.cpp
+++ b/cocos/renderer/CCRenderState.cpp
@@ -83,7 +83,7 @@ void RenderState::initialize()
 
 void RenderState::finalize()
 {
-    CC_SAFE_RELEASE(StateBlock::_defaultState);
+    CC_SAFE_RELEASE_NULL(StateBlock::_defaultState);
 }
 
 bool RenderState::init(RenderState* parent)


### PR DESCRIPTION
issue #11821 . Developers may reconstruct it, and we adjudge if _defaultState == null in init function.
