### PR TITLE
fix #10767

### DIFF
--- a/cocos/3d/CCSprite3D.cpp
+++ b/cocos/3d/CCSprite3D.cpp
@@ -701,7 +701,7 @@ void Sprite3D::draw(Renderer *renderer, const Mat4 &transform, uint32_t flags)
 {
 #if CC_USE_CULLING
     // camera clipping
-    if(!Camera::getVisitingCamera()->isVisibleInFrustum(&this->getAABB()))
+    if(Camera::getVisitingCamera() && !Camera::getVisitingCamera()->isVisibleInFrustum(&this->getAABB()))
         return;
 #endif
     


### PR DESCRIPTION
fix #10767

Transition breaks when there is a Sprite3D in the scene

Reason is that there is no visiting camera when transition occurs.
