### PR TITLE
Properties fixes

### DIFF
--- a/cocos/base/CCProperties.cpp
+++ b/cocos/base/CCProperties.cpp
@@ -85,7 +85,7 @@ Properties::Properties(Data* data, ssize_t* dataIdx, const std::string& name, co
     rewind();
 }
 
-Properties* Properties::createWithoutAutorelease(const std::string& url)
+Properties* Properties::createNonRefCounted(const std::string& url)
 {
     if (url.size() == 0)
     {
@@ -419,24 +419,25 @@ signed char Properties::readChar()
 
 char* Properties::readLine(char* output, int num)
 {
-    int idx=0;
-
     if (eof())
         return nullptr;
 
     // little optimization: avoid uneeded dereferences
-    ssize_t dataIdx = *_dataIdx;
+    const ssize_t dataIdx = *_dataIdx;
+    int i;
 
-    while (dataIdx<_data->_size && _data->_bytes[dataIdx]!='\n' && idx-1<num)
+    for (i=0; i<num && dataIdx+i < _data->_size; i++)
     {
-        dataIdx++; idx++;
+        auto c = _data->_bytes[dataIdx+i];
+        if (c == '\n')
+            break;
+        output[i] = c;
     }
 
-    memcpy(output, &_data->_bytes[*_dataIdx], idx);
-    output[idx] = '\0';
+    output[i] = '\0';
 
     // restore value
-    *_dataIdx = dataIdx;
+    *_dataIdx = dataIdx+i;
 
     return output;
 }

--- a/cocos/base/CCProperties.h
+++ b/cocos/base/CCProperties.h
@@ -105,7 +105,7 @@ class Data;
  
  @verbatim
     // Create the top-level Properties object.
-    Properties* properties = Properties::createWithoutAutorelease("example.properties");
+    Properties* properties = Properties::createNonRefCounted("example.properties");
     // Retrieve the "spriteTexture" namespace.
     Properties* spriteTexture = properties->getNamespace("spriteTexture");
  
@@ -187,7 +187,7 @@ public:
      * @return The created Properties or NULL if there was an error.
      * @script{create}
      */
-    static Properties* createWithoutAutorelease(const std::string& url);
+    static Properties* createNonRefCounted(const std::string& url);
 
     /**
      * Destructor.
@@ -579,7 +579,7 @@ private:
     bool seekFromCurrent(int offset);
     bool eof();
 
-    // Called after createWithoutAutorelease(); copies info from parents into derived namespaces.
+    // Called after createNonRefCounted(); copies info from parents into derived namespaces.
     void resolveInheritance(const char* id = NULL);
 
     // Called by resolveInheritance().

--- a/cocos/renderer/CCMaterial.cpp
+++ b/cocos/renderer/CCMaterial.cpp
@@ -110,7 +110,7 @@ bool Material::initWithFile(const std::string& validfilename)
     bytes[data.getSize()-1]='\0';
 
     // Warning: properties is not a "Ref" object, must be manually deleted
-    Properties* properties = Properties::createWithoutAutorelease(validfilename);
+    Properties* properties = Properties::createNonRefCounted(validfilename);
 
     // get the first material
     parseProperties((strlen(properties->getNamespace()) > 0) ? properties : properties->getNextNamespace());

--- a/tests/cpp-tests/Classes/MaterialSystemTest/MaterialSystemTest.cpp
+++ b/tests/cpp-tests/Classes/MaterialSystemTest/MaterialSystemTest.cpp
@@ -111,7 +111,7 @@ void Material_2DEffects::onEnter()
 {
     MaterialSystemBaseTest::onEnter();
 
-    auto properties = Properties::createWithoutAutorelease("Materials/2d_effects.material#sample");
+    auto properties = Properties::createNonRefCounted("Materials/2d_effects.material#sample");
 
     // Print the properties of every namespace within this one.
     printProperties(properties, 0);


### PR DESCRIPTION
`createNonRefCounted` instead of `CrateWithoutAutorelease`
`readlines()` code is easier to read. Same performance
