### PR TITLE
MeshCommand uses StateBlock

### DIFF
--- a/cocos/renderer/CCMeshCommand.h
+++ b/cocos/renderer/CCMeshCommand.h
@@ -28,6 +28,7 @@
 #include <unordered_map>
 #include "renderer/CCRenderCommand.h"
 #include "renderer/CCGLProgram.h"
+#include "renderer/CCRenderState.h"
 #include "math/CCMath.h"
 
 NS_CC_BEGIN
@@ -93,11 +94,9 @@ protected:
     
     // apply renderstate, not used when using material
     void applyRenderState();
-    void restoreRenderState();
 
     GLuint _textureID;
     GLProgramState* _glProgramState;
-    BlendFunc _blendType;
     
     Vec4 _displayColor; // in order to support tint and fade in fade out
     
@@ -116,16 +115,8 @@ protected:
     ssize_t _indexCount;
     
     // States, default value all false
-    bool _cullFaceEnabled;
-    GLenum _cullFace;
-    bool _depthTestEnabled;
-    bool _depthWriteEnabled;
     bool _forceDepthWrite;
-    
-    bool _renderStateCullFaceEnabled;
-    bool _renderStateDepthTest;
-    GLboolean _renderStateDepthWrite;
-    GLenum    _renderStateCullFace;
+    RenderState::StateBlock* _stateBlock;
 
     // ModelView transform
     Mat4 _mv;

--- a/cocos/renderer/CCRenderState.cpp
+++ b/cocos/renderer/CCRenderState.cpp
@@ -749,26 +749,8 @@ void RenderState::StateBlock::setBlend(bool enabled)
 
 void RenderState::StateBlock::setBlendFunc(const BlendFunc& blendFunc)
 {
-    if (blendFunc == BlendFunc::DISABLE)
-    {
-        setBlendSrc(BLEND_ONE);
-        setBlendDst(BLEND_ZERO);
-    }
-    else if (blendFunc == BlendFunc::ALPHA_PREMULTIPLIED)
-    {
-        setBlendSrc(BLEND_ONE);
-        setBlendDst(BLEND_ONE_MINUS_SRC_ALPHA);
-    }
-    else if (blendFunc == BlendFunc::ALPHA_NON_PREMULTIPLIED)
-    {
-        setBlendSrc(BLEND_SRC_ALPHA);
-        setBlendDst(BLEND_ONE_MINUS_SRC_ALPHA);
-    }
-    else if (blendFunc == BlendFunc::ADDITIVE)
-    {
-        setBlendSrc(BLEND_SRC_ALPHA);
-        setBlendDst(BLEND_ONE);
-    }
+    setBlendSrc((RenderState::Blend)blendFunc.src);
+    setBlendDst((RenderState::Blend)blendFunc.dst);
 }
 
 void RenderState::StateBlock::setBlendSrc(Blend blend)

--- a/cocos/renderer/CCRenderState.h
+++ b/cocos/renderer/CCRenderState.h
@@ -352,6 +352,8 @@ public:
         uint32_t getHash() const;
         bool isDirty() const;
 
+        static StateBlock* _defaultState;
+
     protected:
         StateBlock();
         ~StateBlock();
@@ -381,8 +383,6 @@ public:
         StencilOperation _stencilOpDppass;
 
         long _bits;
-
-        static StateBlock* _defaultState;
 
         mutable uint32_t _hash;
         mutable bool _hashDirty;

--- a/cocos/renderer/ccGLStateCache.cpp
+++ b/cocos/renderer/ccGLStateCache.cpp
@@ -28,6 +28,7 @@ THE SOFTWARE.
 #include "renderer/ccGLStateCache.h"
 
 #include "renderer/CCGLProgram.h"
+#include "renderer/CCRenderState.h"
 #include "base/CCDirector.h"
 #include "base/ccConfig.h"
 #include "base/CCConfiguration.h"
@@ -109,12 +110,17 @@ static void SetBlending(GLenum sfactor, GLenum dfactor)
 	if (sfactor == GL_ONE && dfactor == GL_ZERO)
     {
 		glDisable(GL_BLEND);
+        RenderState::StateBlock::_defaultState->setBlend(false);
 	}
     else
     {
 		glEnable(GL_BLEND);
 		glBlendFunc(sfactor, dfactor);
-	}
+
+        RenderState::StateBlock::_defaultState->setBlend(true);
+        RenderState::StateBlock::_defaultState->setBlendSrc((RenderState::Blend)sfactor);
+        RenderState::StateBlock::_defaultState->setBlendSrc((RenderState::Blend)dfactor);
+    }
 }
 
 void blendFunc(GLenum sfactor, GLenum dfactor)


### PR DESCRIPTION
When MeshCommand is used with GLProgramState, it will use the StateBlock
internally, instead of the manual and error prone way of keeping state
