### PR TITLE
Removes state from MeshCommand.

### DIFF
--- a/cocos/renderer/CCMeshCommand.cpp
+++ b/cocos/renderer/CCMeshCommand.cpp
@@ -56,19 +56,8 @@ MeshCommand::MeshCommand()
 , _vao(0)
 , _material(nullptr)
 , _stateBlock(nullptr)
-, _forceDepthWrite(false)
 {
     _type = RenderCommand::Type::MESH_COMMAND;
-
-    _stateBlock = RenderState::StateBlock::create();
-    CC_SAFE_RETAIN(_stateBlock);
-
-    _stateBlock->setCullFace(false);
-    _stateBlock->setCullFaceSide(RenderState::CULL_FACE_SIDE_BACK);
-    _stateBlock->setDepthTest(false);
-    _stateBlock->setDepthWrite(false);
-    _stateBlock->setBlend(true);
-
 
 #if (CC_TARGET_PLATFORM == CC_PLATFORM_ANDROID || CC_TARGET_PLATFORM == CC_PLATFORM_WINRT)
     // listen the event that renderer was recreated on Android/WP8
@@ -104,24 +93,10 @@ void MeshCommand::init(float globalZOrder,
     _is3D = true;
 }
 
-void MeshCommand::init(float globalOrder,
-                       GLuint textureID,
-                       GLProgramState* glProgramState,
-                       BlendFunc blendType,
-                       GLuint vertexBuffer,
-                       GLuint indexBuffer,
-                       GLenum primitive,
-                       GLenum indexFormat,
-                       ssize_t indexCount,
-                       const Mat4 &mv)
-{
-    init(globalOrder, textureID, glProgramState, blendType, vertexBuffer, indexBuffer, primitive, indexFormat, indexCount, mv, 0);
-}
-
 void MeshCommand::init(float globalZOrder,
                        GLuint textureID,
-                       cocos2d::GLProgramState* glProgramState,
-                       cocos2d::BlendFunc blendType,
+                       GLProgramState* glProgramState,
+                       RenderState::StateBlock* stateBlock,
                        GLuint vertexBuffer,
                        GLuint indexBuffer,
                        GLenum primitive,
@@ -131,13 +106,17 @@ void MeshCommand::init(float globalZOrder,
                        uint32_t flags)
 {
     CCASSERT(glProgramState, "GLProgramState cannot be nill");
+    CCASSERT(stateBlock, "StateBlock cannot be nill");
     CCASSERT(!_material, "cannot init with GLProgramState if previously inited without GLProgramState");
 
     RenderCommand::init(globalZOrder, mv, flags);
     
     _globalOrder = globalZOrder;
     _textureID = textureID;
+
+    // weak ref
     _glProgramState = glProgramState;
+    _stateBlock = stateBlock;
     
     _vertexBuffer = vertexBuffer;
     _indexBuffer = indexBuffer;
@@ -148,42 +127,8 @@ void MeshCommand::init(float globalZOrder,
     
     _is3D = true;
 
-    if (!_stateBlock) {
-        _stateBlock = RenderState::StateBlock::create();
-        CC_SAFE_RETAIN(_stateBlock);
-    }
-
-    _stateBlock->setBlendFunc(blendType);
 }
 
-void MeshCommand::setCullFaceEnabled(bool enable)
-{
-    CCASSERT(!_material, "If using material, you should call material->setCullFace()");
-
-    _stateBlock->setCullFace(enable);
-}
-
-void MeshCommand::setCullFace(GLenum cullFace)
-{
-    CCASSERT(!_material, "If using material, you should call material->setCullFaceSide()");
-
-    _stateBlock->setCullFaceSide((RenderState::CullFaceSide)cullFace);
-}
-
-void MeshCommand::setDepthTestEnabled(bool enable)
-{
-    CCASSERT(!_material, "If using material, you should call material->setDepthTest()");
-
-    _stateBlock->setDepthTest(enable);
-}
-
-void MeshCommand::setDepthWriteEnabled(bool enable)
-{
-    CCASSERT(!_material, "If using material, you should call material->setDepthWrite()");
-
-    _forceDepthWrite = enable;
-    _stateBlock->setDepthWrite(enable);
-}
 
 void MeshCommand::setDisplayColor(const Vec4& color)
 {
@@ -206,28 +151,8 @@ void MeshCommand::setMatrixPaletteSize(int size)
     _matrixPaletteSize = size;
 }
 
-void MeshCommand::setTransparent(bool value)
-{
-    CCASSERT(!_material, "If using material, you shouldn't call setTransparent.");
-
-    _isTransparent = value;
-    //Skip batching for transparent mesh
-    _skipBatching = value;
-    
-    if (_isTransparent && !_forceDepthWrite)
-    {
-        _stateBlock->setDepthWrite(false);
-    }
-    else
-    {
-        _stateBlock->setDepthWrite(true);
-    }
-}
-
 MeshCommand::~MeshCommand()
 {
-    CC_SAFE_RELEASE(_stateBlock);
-
     releaseVAO();
 #if (CC_TARGET_PLATFORM == CC_PLATFORM_ANDROID || CC_TARGET_PLATFORM == CC_PLATFORM_WINRT)
     Director::getInstance()->getEventDispatcher()->removeEventListener(_rendererRecreatedListener);
@@ -237,6 +162,7 @@ MeshCommand::~MeshCommand()
 void MeshCommand::applyRenderState()
 {
     CCASSERT(!_material, "Must not be called when using materials");
+    CCASSERT(_stateBlock, "StateBlock must be non null");
 
     // blend and texture
     GL::bindTexture2D(_textureID);

--- a/cocos/renderer/CCMeshCommand.h
+++ b/cocos/renderer/CCMeshCommand.h
@@ -34,8 +34,6 @@
 NS_CC_BEGIN
 
 class GLProgramState;
-class GLProgram;
-struct Uniform;
 class EventListenerCustom;
 class EventCustom;
 class Material;
@@ -46,32 +44,17 @@ class CC_DLL MeshCommand : public RenderCommand
 public:
 
     MeshCommand();
-    ~MeshCommand();
+    virtual ~MeshCommand();
 
     void init(float globalZOrder, Material* material, GLuint vertexBuffer, GLuint indexBuffer, GLenum primitive, GLenum indexFormat, ssize_t indexCount, const Mat4 &mv, uint32_t flags);
 
-    void init(float globalZOrder, GLuint textureID, GLProgramState* glProgramState, BlendFunc blendType, GLuint vertexBuffer, GLuint indexBuffer, GLenum primitive, GLenum indexFormat, ssize_t indexCount, const Mat4 &mv, uint32_t flags);
-    
-    CC_DEPRECATED_ATTRIBUTE void init(float globalZOrder, GLuint textureID, GLProgramState* glProgramState, BlendFunc blendType, GLuint vertexBuffer, GLuint indexBuffer, GLenum primitive, GLenum indexType, ssize_t indexCount, const Mat4 &mv);
-    
-    void setCullFaceEnabled(bool enable);
-    
-    void setCullFace(GLenum cullFace);
-    
-    void setDepthTestEnabled(bool enable);
-    
-    void setDepthWriteEnabled(bool enable);
-    
-    void setDisplayColor(const Vec4& color);
-    
-    void setMatrixPalette(const Vec4* matrixPalette);
-    
-    void setMatrixPaletteSize(int size);
+    void init(float globalZOrder, GLuint textureID, GLProgramState* glProgramState, RenderState::StateBlock* stateBlock, GLuint vertexBuffer, GLuint indexBuffer, GLenum primitive, GLenum indexFormat, ssize_t indexCount, const Mat4 &mv, uint32_t flags);
 
+    void setDisplayColor(const Vec4& color);
+    void setMatrixPalette(const Vec4* matrixPalette);
+    void setMatrixPaletteSize(int size);
     void setLightMask(unsigned int lightmask);
-    
-    void setTransparent(bool value);
-    
+
     void execute();
     
     //used for batch
@@ -95,9 +78,7 @@ protected:
     // apply renderstate, not used when using material
     void applyRenderState();
 
-    GLuint _textureID;
-    GLProgramState* _glProgramState;
-    
+
     Vec4 _displayColor; // in order to support tint and fade in fade out
     
     // used for skin
@@ -115,14 +96,21 @@ protected:
     ssize_t _indexCount;
     
     // States, default value all false
-    bool _forceDepthWrite;
-    RenderState::StateBlock* _stateBlock;
+
 
     // ModelView transform
     Mat4 _mv;
 
+    // Mode A: Material
     // weak ref
     Material* _material;
+
+    // Mode B: StateBlock
+    // weak ref
+    GLProgramState* _glProgramState;
+    RenderState::StateBlock* _stateBlock;
+    GLuint _textureID;
+
 
 #if (CC_TARGET_PLATFORM == CC_PLATFORM_ANDROID || CC_TARGET_PLATFORM == CC_PLATFORM_WINRT)
     EventListenerCustom* _rendererRecreatedListener;

--- a/cocos/renderer/CCRenderState.cpp
+++ b/cocos/renderer/CCRenderState.cpp
@@ -340,7 +340,8 @@ void RenderState::StateBlock::restore(long stateOverrideBits)
     CC_ASSERT(_defaultState);
 
     // If there is no state to restore (i.e. no non-default state), do nothing.
-    if (_defaultState->_bits == 0)
+//    if (_defaultState->_bits == 0)
+    if ( (stateOverrideBits | _defaultState->_bits) == stateOverrideBits)
     {
         return;
     }

--- a/extensions/Particle3D/CCParticle3DRender.h
+++ b/extensions/Particle3D/CCParticle3DRender.h
@@ -25,9 +25,12 @@
 #ifndef __CC_PARTICLE_3D_RENDER_H__
 #define __CC_PARTICLE_3D_RENDER_H__
 
+#include <vector>
+
+#include "renderer/CCRenderState.h"
 #include "base/CCRef.h"
 #include "math/CCMath.h"
-#include <vector>
+
 
 NS_CC_BEGIN
 
@@ -64,21 +67,19 @@ public:
     
     bool isVisible() const { return _isVisible; }
 
-    virtual void setDepthTest(bool isDepthTest) { _depthTest = isDepthTest; }
-    virtual void setDepthWrite(bool isDepthWrite) {_depthWrite = isDepthWrite; }
-    
+    void setDepthTest(bool isDepthTest);
+    void setDepthWrite(bool isDepthWrite);
+    void setBlendFunc(const BlendFunc& blendFunc);
+
+    void copyAttributesTo (Particle3DRender *render);
+
 CC_CONSTRUCTOR_ACCESS:
-    Particle3DRender()
-        : _particleSystem(nullptr)
-        , _isVisible(true)
-        , _rendererScale(Vec3::ONE)
-        , _depthTest(true)
-        , _depthWrite(false)
-    {};
-    virtual ~Particle3DRender(){};
+    Particle3DRender();
+    virtual ~Particle3DRender();
     
 protected:
     ParticleSystem3D *_particleSystem;
+    RenderState::StateBlock* _stateBlock;
     bool  _isVisible;
     Vec3 _rendererScale;
     bool _depthTest;
@@ -93,9 +94,6 @@ public:
     
     virtual void render(Renderer* renderer, const Mat4 &transform, ParticleSystem3D* particleSystem) override;
 
-    virtual void setDepthTest(bool isDepthTest) override;
-    virtual void setDepthWrite(bool isDepthWrite) override;
-    
 CC_CONSTRUCTOR_ACCESS:
     Particle3DQuadRender();
     virtual ~Particle3DQuadRender();
@@ -105,7 +103,7 @@ protected:
     bool initQuadRender(const std::string& texFile);
     
 protected:
-    MeshCommand* _meshCommand;
+    MeshCommand*           _meshCommand;
     Texture2D*             _texture;
     GLProgramState*        _glProgramState;
     IndexBuffer*           _indexBuffer; //index buffer

--- a/extensions/Particle3D/PU/CCPUBeamRender.cpp
+++ b/extensions/Particle3D/PU/CCPUBeamRender.cpp
@@ -357,10 +357,9 @@ PUBeamRender* PUBeamRender::clone()
     return br;
 }
 
-void PUBeamRender::copyAttributesTo( PURender *render )
+void PUBeamRender::copyAttributesTo(PUBeamRender *beamRender)
 {
-    PURender::copyAttributesTo(render);
-    PUBeamRender *beamRender = static_cast<PUBeamRender*>(render);
+    PURender::copyAttributesTo(beamRender);
     beamRender->setUseVertexColours(_useVertexColours);
     beamRender->setMaxChainElements(_maxChainElements);
     beamRender->setUpdateInterval(_updateInterval);

--- a/extensions/Particle3D/PU/CCPUBeamRender.h
+++ b/extensions/Particle3D/PU/CCPUBeamRender.h
@@ -127,7 +127,7 @@ public:
     void destroyAll(void);
 
     virtual PUBeamRender* clone() override;
-    virtual void copyAttributesTo (PURender *render) override;
+    void copyAttributesTo(PUBeamRender *render);
 
 CC_CONSTRUCTOR_ACCESS:
     PUBeamRender();

--- a/extensions/Particle3D/PU/CCPUBillboardChain.h
+++ b/extensions/Particle3D/PU/CCPUBillboardChain.h
@@ -26,9 +26,11 @@
 #ifndef __CC_PU_PARTICLE_3D_BILLBOARD_CHAIN_H__
 #define __CC_PU_PARTICLE_3D_BILLBOARD_CHAIN_H__
 
+#include <vector>
+#include "renderer/CCRenderState.h"
 #include "base/CCRef.h"
 #include "math/CCMath.h"
-#include <vector>
+
 
 NS_CC_BEGIN
 
@@ -54,11 +56,11 @@ public:
 
         Element();
 
-        Element(const Vec3 &position,
+        Element(const Vec3& position,
             float width,
             float texCoord,
-            const Vec4 &colour,
-            const Quaternion &orientation);
+            const Vec4& colour,
+            const Quaternion& orientation);
 
         Vec3 position;
         float width;
@@ -79,7 +81,7 @@ public:
     @param useVertexColours If true, use vertex colours from the chain elements
     @param dynamic If true, buffers are created with the intention of being updated
     */
-    PUBillboardChain(const std::string& name, const std::string &texFile = "", size_t maxElements = 20, size_t numberOfChains = 1, 
+    PUBillboardChain(const std::string& name, const std::string& texFile = "", size_t maxElements = 20, size_t numberOfChains = 1,
         bool useTextureCoords = true, bool useColours = true, bool dynamic = true);
     /// destructor
     virtual ~PUBillboardChain();
@@ -217,18 +219,19 @@ public:
     matrix, the segment corresponding to that point will be facing towards UNIT_Z
     This vector is internally normalized.
     */
-    void setFaceCamera( bool faceCamera, const Vec3 &normalVector=Vec3::UNIT_X );
+    void setFaceCamera( bool faceCamera, const Vec3& normalVector=Vec3::UNIT_X );
 
-    virtual void setDepthTest(bool isDepthTest);
-    virtual void setDepthWrite(bool isDepthWrite);
+    void setDepthTest(bool isDepthTest);
+    void setDepthWrite(bool isDepthWrite);
+    void setBlendFunc(const BlendFunc& blendFunc);
 
-    void render(Renderer* renderer, const Mat4 &transform, ParticleSystem3D* particleSystem);
+    void render(Renderer* renderer, const Mat4& transform, ParticleSystem3D* particleSystem);
 
     // Overridden members follow
-    //void _updateRenderQueue(RenderQueue *);
-    //void getRenderOperation(RenderOperation &);
+    //void _updateRenderQueue(RenderQueue*);
+    //void getRenderOperation(RenderOperation&);
     //virtual bool preRender(SceneManager* sm, RenderSystem* rsys);
-    //void getWorldTransforms(Matrix4 *) const;
+    //void getWorldTransforms(Matrix4*) const;
     /// @copydoc MovableObject::visitRenderables
 
 protected:
@@ -240,11 +243,11 @@ protected:
     // Setup buffers
     virtual void setupBuffers(void);
     /// Update the contents of the vertex buffer
-    virtual void updateVertexBuffer(const Mat4 &camMat);
+    virtual void updateVertexBuffer(const Mat4& camMat);
     /// Update the contents of the index buffer
     virtual void updateIndexBuffer(void);
 
-    void init(const std::string &texFile);
+    void init(const std::string& texFile);
 
 protected:
 
@@ -312,11 +315,12 @@ protected:
         Vec2 uv;
         Vec4 color;
     };
-    MeshCommand* _meshCommand;
-    Texture2D*             _texture;
-    GLProgramState*        _glProgramState;
-    IndexBuffer*           _indexBuffer; //index buffer
-    VertexBuffer*          _vertexBuffer; // vertex buffer
+    MeshCommand*            _meshCommand;
+    RenderState::StateBlock* _stateBlock;
+    Texture2D*              _texture;
+    GLProgramState*         _glProgramState;
+    IndexBuffer*            _indexBuffer; //index buffer
+    VertexBuffer*           _vertexBuffer; // vertex buffer
 
     std::vector<VertexInfo> _vertices;
     std::vector<unsigned short> _indices;

--- a/extensions/Particle3D/PU/CCPUParticleSystem3D.cpp
+++ b/extensions/Particle3D/PU/CCPUParticleSystem3D.cpp
@@ -1056,7 +1056,7 @@ void PUParticleSystem3D::clearAllParticles()
     }
 }
 
-void PUParticleSystem3D::copyAttributesTo( PUParticleSystem3D* system )
+void PUParticleSystem3D::copyAttributesTo(PUParticleSystem3D* system )
 {
     system->removeAllEmitter();
     system->removeAllAffector();
@@ -1171,7 +1171,8 @@ void PUParticleSystem3D::draw( Renderer *renderer, const Mat4 &transform, uint32
 
     if (!_emittedSystemParticlePool.empty())
     {
-        for (auto iter : _emittedSystemParticlePool){
+        for (auto iter : _emittedSystemParticlePool)
+        {
             PUParticle3D *particle = static_cast<PUParticle3D *>(iter.second.getFirst());
             while (particle)
             {

--- a/extensions/Particle3D/PU/CCPUParticleSystem3D.h
+++ b/extensions/Particle3D/PU/CCPUParticleSystem3D.h
@@ -351,7 +351,7 @@ public:
     void calulateRotationOffset(void);
 
     virtual PUParticleSystem3D* clone();
-    virtual void copyAttributesTo (PUParticleSystem3D* system);
+    virtual void copyAttributesTo(PUParticleSystem3D* system);
 
 CC_CONSTRUCTOR_ACCESS:
     PUParticleSystem3D();

--- a/extensions/Particle3D/PU/CCPURender.cpp
+++ b/extensions/Particle3D/PU/CCPURender.cpp
@@ -43,11 +43,8 @@ NS_CC_BEGIN
 
 void PURender::copyAttributesTo( PURender *render )
 {
-    render->_particleSystem = _particleSystem;
-    render->_isVisible = _isVisible;
-    render->_rendererScale = _rendererScale;
-    render->_depthTest = _depthTest;
-    render->_depthWrite = _depthWrite;
+    Particle3DRender::copyAttributesTo(render);
+
     render->_renderType = _renderType;
 }
 
@@ -243,8 +240,21 @@ void PUParticle3DQuadRender::render(Renderer* renderer, const Mat4 &transform, P
         _vertexBuffer->updateVertices(&_vertices[0], vertexindex/* * sizeof(_posuvcolors[0])*/, 0);
         _indexBuffer->updateIndices(&_indices[0], index/* * sizeof(unsigned short)*/, 0);
 
+        _stateBlock->setBlendFunc(particleSystem->getBlendFunc());
+        
         GLuint texId = (_texture ? _texture->getName() : 0);
-        _meshCommand->init(0, texId, _glProgramState, particleSystem->getBlendFunc(), _vertexBuffer->getVBO(), _indexBuffer->getVBO(), GL_TRIANGLES, GL_UNSIGNED_SHORT, index, transform, Node::FLAGS_RENDER_AS_3D);
+        _meshCommand->init(0,
+                           texId,
+                           _glProgramState,
+                           _stateBlock,
+                           _vertexBuffer->getVBO(),
+                           _indexBuffer->getVBO(),
+                           GL_TRIANGLES,
+                           GL_UNSIGNED_SHORT,
+                           index,
+                           transform,
+                           Node::FLAGS_RENDER_AS_3D);
+        _meshCommand->setSkipBatching(true);
         _meshCommand->setTransparent(true);
         _glProgramState->setUniformVec4("u_color", Vec4(1,1,1,1));
         renderer->addCommand(_meshCommand);
@@ -267,7 +277,6 @@ PUParticle3DQuadRender::PUParticle3DQuadRender()
 
 PUParticle3DQuadRender::~PUParticle3DQuadRender()
 {
-
 }
 
 void PUParticle3DQuadRender::getOriginOffset( int &offsetX, int &offsetY )
@@ -396,16 +405,15 @@ void PUParticle3DQuadRender::setType( Type type )
 {
     _type = type;
     if (_type == PERPENDICULAR_COMMON || _type == PERPENDICULAR_SELF){
-        _meshCommand->setCullFaceEnabled(false);
+        _stateBlock->setCullFace(false);
     }else{
-        _meshCommand->setCullFaceEnabled(true);
+        _stateBlock->setCullFace(true);
     }
 }
 
-void PUParticle3DQuadRender::copyAttributesTo( PURender *render )
+void PUParticle3DQuadRender::copyAttributesTo(PUParticle3DQuadRender *quadRender)
 {
-    PURender::copyAttributesTo(render);
-    PUParticle3DQuadRender *quadRender = static_cast<PUParticle3DQuadRender *>(render);
+    PURender::copyAttributesTo(quadRender);
     quadRender->_type = _type;
     quadRender->_origin = _origin;
     quadRender->_rotateType = _rotateType;
@@ -499,7 +507,7 @@ PUParticle3DModelRender::~PUParticle3DModelRender()
     }
 }
 
-void PUParticle3DModelRender::copyAttributesTo( PURender *render )
+void PUParticle3DModelRender::copyAttributesTo(PUParticle3DModelRender *render)
 {
     PURender::copyAttributesTo(render);
 }
@@ -519,12 +527,20 @@ PUParticle3DEntityRender::PUParticle3DEntityRender()
     , _indexBuffer(nullptr)
     , _vertexBuffer(nullptr)
 {
+    _stateBlock = RenderState::StateBlock::create();
+    CC_SAFE_RETAIN(_stateBlock);
 
+    _stateBlock->setCullFace(false);
+    _stateBlock->setCullFaceSide(RenderState::CULL_FACE_SIDE_BACK);
+    _stateBlock->setDepthTest(false);
+    _stateBlock->setDepthWrite(false);
+    _stateBlock->setBlend(true);
 }
 
 PUParticle3DEntityRender::~PUParticle3DEntityRender()
 {
     CC_SAFE_DELETE(_meshCommand);
+    CC_SAFE_RELEASE(_stateBlock);
     //CC_SAFE_RELEASE(_texture);
     CC_SAFE_RELEASE(_glProgramState);
     CC_SAFE_RELEASE(_vertexBuffer);
@@ -556,27 +572,17 @@ bool PUParticle3DEntityRender::initRender( const std::string &texFile )
     _glProgramState = glProgramState;
 
     _meshCommand = new (std::nothrow) MeshCommand();
+    _meshCommand->setSkipBatching(true);
     _meshCommand->setTransparent(true);
-    _meshCommand->setDepthTestEnabled(_depthTest);
-    _meshCommand->setDepthWriteEnabled(_depthWrite);
-    _meshCommand->setCullFace(GL_BACK);
-    _meshCommand->setCullFaceEnabled(true);
+
+    _stateBlock->setDepthTest(_depthTest);
+    _stateBlock->setDepthWrite(_depthWrite);
+    _stateBlock->setCullFaceSide(RenderState::CULL_FACE_SIDE_BACK);
+    _stateBlock->setCullFace(true);
     return true;
 }
 
-void PUParticle3DEntityRender::setDepthTest( bool isDepthTest )
-{
-    Particle3DRender::setDepthTest(isDepthTest);
-    _meshCommand->setDepthTestEnabled(_depthTest);
-}
-
-void PUParticle3DEntityRender::setDepthWrite( bool isDepthWrite )
-{
-    Particle3DRender::setDepthWrite(isDepthWrite);
-    _meshCommand->setDepthWriteEnabled(_depthWrite);
-}
-
-void PUParticle3DEntityRender::copyAttributesTo( PURender *render )
+void PUParticle3DEntityRender::copyAttributesTo(PUParticle3DEntityRender *render)
 {
     PURender::copyAttributesTo(render);
 }
@@ -691,8 +697,21 @@ void PUParticle3DBoxRender::render( Renderer* renderer, const Mat4 &transform, P
         _indexBuffer->updateIndices(&_indices[0], index/* * sizeof(unsigned short)*/, 0);
 
         GLuint texId = (_texture ? _texture->getName() : 0);
-        _meshCommand->init(0, texId, _glProgramState, particleSystem->getBlendFunc(), _vertexBuffer->getVBO(), _indexBuffer->getVBO(), GL_TRIANGLES, GL_UNSIGNED_SHORT, index, transform, Node::FLAGS_RENDER_AS_3D);
+        _stateBlock->setBlendFunc(_particleSystem->getBlendFunc());
+        _meshCommand->init(0,
+                           texId,
+                           _glProgramState,
+                           _stateBlock,
+                           _vertexBuffer->getVBO(),
+                           _indexBuffer->getVBO(),
+                           GL_TRIANGLES,
+                           GL_UNSIGNED_SHORT,
+                           index,
+                           transform,
+                           Node::FLAGS_RENDER_AS_3D);
+        _meshCommand->setSkipBatching(true);
         _meshCommand->setTransparent(true);
+
         _glProgramState->setUniformVec4("u_color", Vec4(1,1,1,1));
         renderer->addCommand(_meshCommand);
     }
@@ -842,9 +861,24 @@ void PUSphereRender::render( Renderer* renderer, const Mat4 &transform, Particle
         _indexBuffer->updateIndices(&_indices[0], index/* * sizeof(unsigned short)*/, 0);
 
         GLuint texId = (_texture ? _texture->getName() : 0);
-        _meshCommand->init(0, texId, _glProgramState, particleSystem->getBlendFunc(), _vertexBuffer->getVBO(), _indexBuffer->getVBO(), GL_TRIANGLES, GL_UNSIGNED_SHORT, index, transform, Node::FLAGS_RENDER_AS_3D);
+
+        _stateBlock->setBlendFunc(particleSystem->getBlendFunc());
+        _meshCommand->init(
+                           0,
+                           texId,
+                           _glProgramState,
+                           _stateBlock,
+                           _vertexBuffer->getVBO(),
+                           _indexBuffer->getVBO(),
+                           GL_TRIANGLES,
+                           GL_UNSIGNED_SHORT,
+                           index,
+                           transform,
+                           Node::FLAGS_RENDER_AS_3D);
+        _meshCommand->setSkipBatching(true);
         _meshCommand->setTransparent(true);
-        _glProgramState->setUniformVec4("u_color", Vec4(1,1,1,1));        
+
+        _glProgramState->setUniformVec4("u_color", Vec4(1,1,1,1));
         renderer->addCommand(_meshCommand);
     }
 }
@@ -908,10 +942,9 @@ PUSphereRender::~PUSphereRender()
 
 }
 
-void PUSphereRender::copyAttributesTo( PURender *render )
+void PUSphereRender::copyAttributesTo(PUSphereRender *sphereRender)
 {
-    PURender::copyAttributesTo(render);
-    PUSphereRender *sphereRender = static_cast<PUSphereRender *>(render);
+    PURender::copyAttributesTo(sphereRender);
     sphereRender->_numberOfRings = _numberOfRings;
     sphereRender->_numberOfSegments = _numberOfSegments;
 }

--- a/extensions/Particle3D/PU/CCPURender.h
+++ b/extensions/Particle3D/PU/CCPURender.h
@@ -26,10 +26,12 @@
 #ifndef __CC_PU_PARTICLE_3D_RENDER_H__
 #define __CC_PU_PARTICLE_3D_RENDER_H__
 
+#include <vector>
+
 #include "base/CCRef.h"
 #include "math/CCMath.h"
 #include "extensions/Particle3D/CCParticle3DRender.h"
-#include <vector>
+#include "renderer/CCRenderState.h"
 
 NS_CC_BEGIN
 
@@ -48,7 +50,7 @@ public:
     void setRenderType(const std::string& observerType) {_renderType = observerType;};
 
     virtual PURender* clone() = 0;
-    virtual void copyAttributesTo (PURender *render);
+    void copyAttributesTo(PURender* render);
 
 public:
 
@@ -62,11 +64,7 @@ protected:
 class CC_DLL PUParticle3DEntityRender : public PURender
 {
 public:
-
-    virtual void setDepthTest(bool isDepthTest) override;
-    virtual void setDepthWrite(bool isDepthWrite) override;
-
-    virtual void copyAttributesTo (PURender *render) override;
+    void copyAttributesTo(PUParticle3DEntityRender *render);
 
 CC_CONSTRUCTOR_ACCESS:
     PUParticle3DEntityRender();
@@ -85,6 +83,7 @@ protected:
         Vec4 color;
     };
     MeshCommand* _meshCommand;
+    RenderState::StateBlock* _stateBlock;
     Texture2D*             _texture;
     GLProgramState*        _glProgramState;
     IndexBuffer*           _indexBuffer; //index buffer
@@ -151,7 +150,7 @@ public:
     virtual void render(Renderer* renderer, const Mat4 &transform, ParticleSystem3D* particleSystem) override;
 
     virtual PUParticle3DQuadRender* clone() override;
-    virtual void copyAttributesTo (PURender *render) override;
+    void copyAttributesTo(PUParticle3DQuadRender *render);
     
 CC_CONSTRUCTOR_ACCESS:
     PUParticle3DQuadRender();
@@ -187,7 +186,7 @@ public:
     virtual void render(Renderer* renderer, const Mat4 &transform, ParticleSystem3D* particleSystem) override;
 
     virtual PUParticle3DModelRender* clone() override;
-    virtual void copyAttributesTo (PURender *render) override;
+    void copyAttributesTo(PUParticle3DModelRender *render);
 
 CC_CONSTRUCTOR_ACCESS:
     PUParticle3DModelRender();
@@ -229,7 +228,7 @@ public:
     virtual void render(Renderer* renderer, const Mat4 &transform, ParticleSystem3D* particleSystem) override;
 
     virtual PUSphereRender* clone() override;
-    virtual void copyAttributesTo (PURender *render) override;
+    void copyAttributesTo(PUSphereRender *render);
 
 CC_CONSTRUCTOR_ACCESS:
     PUSphereRender();

--- a/extensions/Particle3D/PU/CCPURendererTranslator.cpp
+++ b/extensions/Particle3D/PU/CCPURendererTranslator.cpp
@@ -602,6 +602,7 @@ void PURendererTranslator::translate(PUScriptCompiler* compiler, PUAbstractNode 
             if (material){
                 _renderer->setDepthTest(material->depthTest);
                 _renderer->setDepthWrite(material->depthWrite);
+                _renderer->setBlendFunc(material->blendFunc);
                 static_cast<PURender *>(_renderer)->setRenderType(type);
             }
             system->setRender(_renderer);

--- a/extensions/Particle3D/PU/CCPURibbonTrail.h
+++ b/extensions/Particle3D/PU/CCPURibbonTrail.h
@@ -77,7 +77,7 @@ public:
     /** @copydoc BillboardChain::setMaxChainElements */
     void setMaxChainElements(size_t maxElements);
     /** @copydoc BillboardChain::setNumberOfChains */
-    void setNumberOfChains(size_t numChains);
+    virtual void setNumberOfChains(size_t numChains) override;
     /** @copydoc BillboardChain::clearChain */
     void clearChain(size_t chainIndex);
 

--- a/extensions/Particle3D/PU/CCPURibbonTrailRender.cpp
+++ b/extensions/Particle3D/PU/CCPURibbonTrailRender.cpp
@@ -369,10 +369,9 @@ PURibbonTrailRender* PURibbonTrailRender::clone()
     return tr;
 }
 
-void PURibbonTrailRender::copyAttributesTo( PURender *render )
+void PURibbonTrailRender::copyAttributesTo(PURibbonTrailRender *trailRender)
 {
-    PURender::copyAttributesTo(render);
-    PURibbonTrailRender *trailRender = static_cast<PURibbonTrailRender*>(render);
+    PURender::copyAttributesTo(trailRender);
     trailRender->setUseVertexColors(_useVertexColours);
     trailRender->setMaxChainElements(_maxChainElements);
     trailRender->setTrailLength(_trailLength);

--- a/extensions/Particle3D/PU/CCPURibbonTrailRender.h
+++ b/extensions/Particle3D/PU/CCPURibbonTrailRender.h
@@ -126,7 +126,7 @@ public:
     void destroyAll(void);
 
     virtual PURibbonTrailRender* clone() override;
-    virtual void copyAttributesTo (PURender *render) override;
+    void copyAttributesTo(PURibbonTrailRender *render);
 
 CC_CONSTRUCTOR_ACCESS:
     PURibbonTrailRender();


### PR DESCRIPTION
MeshCommand can be reused from other objects either by passing a
`Material` or a `RenderState::StateBlock`
