### PR TITLE
Fix typo: "angel" to "angle"

### DIFF
--- a/cocos/2d/CCActionCamera.h
+++ b/cocos/2d/CCActionCamera.h
@@ -125,9 +125,9 @@ public:
      * @param t Duration in seconds.
      * @param radius The start radius.
      * @param deltaRadius The delta radius.
-     * @param angleZ The start Angel in Z.
+     * @param angleZ The start angle in Z.
      * @param deltaAngleZ The delta angle in Z.
-     * @param angleX The start Angel in X.
+     * @param angleX The start angle in X.
      * @param deltaAngleX The delta angle in X.
      * @return An OrbitCamera.
      */

--- a/cocos/2d/CCDrawNode.h
+++ b/cocos/2d/CCDrawNode.h
@@ -118,7 +118,7 @@ public:
      *
      * @param center The circle center point.
      * @param radius The circle rotate of radius.
-     * @param angle  The circle angel.
+     * @param angle  The circle angle.
      * @param segments The number of segments.
      * @param drawLineToCenter Whether or not draw the line from the origin to center.
      * @param scaleX The scale value in x.
@@ -131,7 +131,7 @@ public:
      *
      * @param center The circle center point.
      * @param radius The circle rotate of radius.
-     * @param angle  The circle angel.
+     * @param angle  The circle angle.
      * @param segments The number of segments.
      * @param drawLineToCenter Whether or not draw the line from the origin to center.
      * @param color Set the circle color.
@@ -216,7 +216,7 @@ public:
     /** Draws a solid circle given the center, radius and number of segments.
      * @param center The circle center point.
      * @param radius The circle rotate of radius.
-     * @param angle  The circle angel.
+     * @param angle  The circle angle.
      * @param segments The number of segments.
      * @param scaleX The scale value in x.
      * @param scaleY The scale value in y.
@@ -228,7 +228,7 @@ public:
     /** Draws a solid circle given the center, radius and number of segments.
      * @param center The circle center point.
      * @param radius The circle rotate of radius.
-     * @param angle  The circle angel.
+     * @param angle  The circle angle.
      * @param segments The number of segments.
      * @param color The solid circle color.
      * @js NA

--- a/cocos/2d/CCDrawingPrimitives.h
+++ b/cocos/2d/CCDrawingPrimitives.h
@@ -153,7 +153,7 @@ namespace DrawPrimitives
      *
      * @param center The circle center point.
      * @param radius The circle rotate of radius.
-     * @param angle  The circle angel.
+     * @param angle  The circle angle.
      * @param segments The number of segments.
      * @param drawLineToCenter Whether or not draw the line from the origin to center.
      * @param scaleX The scale value in x.
@@ -165,7 +165,7 @@ namespace DrawPrimitives
      *
      * @param center The circle center point.
      * @param radius The circle rotate of radius.
-     * @param angle  The circle angel.
+     * @param angle  The circle angle.
      * @param segments The number of segments.
      * @param drawLineToCenter Whether or not draw the line from the origin to center.
      */
@@ -174,7 +174,7 @@ namespace DrawPrimitives
     /** Draws a solid circle given the center, radius and number of segments.
      * @param center The circle center point.
      * @param radius The circle rotate of radius.
-     * @param angle  The circle angel.
+     * @param angle  The circle angle.
      * @param segments The number of segments.
      * @param scaleX The scale value in x.
      * @param scaleY The scale value in y.
@@ -185,7 +185,7 @@ namespace DrawPrimitives
     /** Draws a solid circle given the center, radius and number of segments.
      * @param center The circle center point.
      * @param radius The circle rotate of radius.
-     * @param angle  The circle angel.
+     * @param angle  The circle angle.
      * @param segments The number of segments.
      * @js NA
      */


### PR DESCRIPTION
Fixed typo "angel" to "angle" in comments.
