### PR TITLE
Fix visiting scene error with multiple camera

### DIFF
--- a/cocos/2d/CCNode.cpp
+++ b/cocos/2d/CCNode.cpp
@@ -1314,9 +1314,12 @@ uint32_t Node::processParentFlags(const Mat4& parentTransform, uint32_t parentFl
             _normalizedPositionDirty = false;
         }
     }
+
+    //remove this two line given that isVisitableByVisitingCamera should not affect the calculation of transform given that we are visiting scene
+    //without involving view and projection matrix.
     
-    if (!isVisitableByVisitingCamera())
-        return parentFlags;
+//    if (!isVisitableByVisitingCamera())
+//        return parentFlags;
     
     uint32_t flags = parentFlags;
     flags |= (_transformUpdated ? FLAGS_TRANSFORM_DIRTY : 0);


### PR DESCRIPTION
this pull request is used to fix issue #11948 
isVisitableByVisitingCamera should not affect the calculation of _transform, given that the view and projection matrix are not involved in visiting scene.
