### PR TITLE
Permitted setting flags to action

### DIFF
--- a/cocos/2d/CCAction.cpp
+++ b/cocos/2d/CCAction.cpp
@@ -40,6 +40,7 @@ Action::Action()
 :_originalTarget(nullptr)
 ,_target(nullptr)
 ,_tag(Action::INVALID_TAG)
+,_flags(0)
 {
 }
 

--- a/cocos/2d/CCAction.h
+++ b/cocos/2d/CCAction.h
@@ -143,6 +143,16 @@ public:
      * @param tag Used to identify the action easily.
      */
     inline void setTag(int tag) { _tag = tag; }
+    /** Returns a flag field that is used to group the actions easily.
+     *
+     * @return A tag.
+     */
+    inline unsigned int getFlags() const { return _flags; }
+    /** Changes the flag field that is used to group the actions easily.
+     *
+     * @param tag Used to identify the action easily.
+     */
+    inline void setFlags(unsigned int flags) { _flags = flags; }
 
 CC_CONSTRUCTOR_ACCESS:
     Action();
@@ -159,6 +169,8 @@ protected:
     Node    *_target;
     /** The action tag. An identifier of the action. */
     int     _tag;
+    /** The action flag field. To categorize action into certain groups.*/
+    unsigned int _flags;
 
 private:
     CC_DISALLOW_COPY_AND_ASSIGN(Action);

--- a/cocos/2d/CCActionManager.cpp
+++ b/cocos/2d/CCActionManager.cpp
@@ -287,7 +287,7 @@ void ActionManager::removeActionByTag(int tag, Node *target)
     }
 }
 
-void ActionManager::removeAllActionsByTag(int tag, Node *target, bool bitwiseFilter)
+void ActionManager::removeAllActionsByTag(int tag, Node *target)
 {
     CCASSERT(tag != Action::INVALID_TAG, "");
     CCASSERT(target != nullptr, "");
@@ -302,7 +302,38 @@ void ActionManager::removeAllActionsByTag(int tag, Node *target, bool bitwiseFil
         {
             Action *action = (Action*)element->actions->arr[i];
             
-            if ((action->getTag() == (int)tag || (bitwiseFilter && action->getTag() != Action::INVALID_TAG && (action->getTag() & tag) != 0)) && action->getOriginalTarget() == target)
+            if (action->getTag() == (int)tag && action->getOriginalTarget() == target)
+            {
+                removeActionAtIndex(i, element);
+                --limit;
+            }
+            else
+            {
+                ++i;
+            }
+        }
+    }
+}
+
+void ActionManager::removeActionsByFlags(unsigned int flags, Node *target)
+{
+    if (flags == 0)
+    {
+        return;
+    }
+    CCASSERT(target != nullptr, "");
+
+    tHashElement *element = nullptr;
+    HASH_FIND_PTR(_targets, &target, element);
+
+    if (element)
+    {
+        auto limit = element->actions->num;
+        for (int i = 0; i < limit;)
+        {
+            Action *action = (Action*)element->actions->arr[i];
+
+            if ((action->getFlags() & flags) != 0 && action->getOriginalTarget() == target)
             {
                 removeActionAtIndex(i, element);
                 --limit;

--- a/cocos/2d/CCActionManager.cpp
+++ b/cocos/2d/CCActionManager.cpp
@@ -287,7 +287,7 @@ void ActionManager::removeActionByTag(int tag, Node *target)
     }
 }
 
-void ActionManager::removeAllActionsByTag(int tag, Node *target)
+void ActionManager::removeAllActionsByTag(int tag, Node *target, bool bitwiseFilter)
 {
     CCASSERT(tag != Action::INVALID_TAG, "");
     CCASSERT(target != nullptr, "");
@@ -302,7 +302,7 @@ void ActionManager::removeAllActionsByTag(int tag, Node *target)
         {
             Action *action = (Action*)element->actions->arr[i];
             
-            if (action->getTag() == (int)tag && action->getOriginalTarget() == target)
+            if ((action->getTag() == (int)tag || (bitwiseFilter && action->getTag() != Action::INVALID_TAG && (action->getTag() & tag) != 0)) && action->getOriginalTarget() == target)
             {
                 removeActionAtIndex(i, element);
                 --limit;

--- a/cocos/2d/CCActionManager.h
+++ b/cocos/2d/CCActionManager.h
@@ -110,9 +110,10 @@ public:
      *
      * @param tag       The actions' tag.
      * @param target    A certain target.
+     * @param bitwiseFilter If true, tag is used as a flag field using "bitwise AND"
      * @js NA
      */
-    void removeAllActionsByTag(int tag, Node *target);
+    void removeAllActionsByTag(int tag, Node *target, bool bitwiseFilter = false);
 
     /** Gets an action given its tag an a target.
      *

--- a/cocos/2d/CCActionManager.h
+++ b/cocos/2d/CCActionManager.h
@@ -110,10 +110,17 @@ public:
      *
      * @param tag       The actions' tag.
      * @param target    A certain target.
-     * @param bitwiseFilter If true, tag is used as a flag field using "bitwise AND"
      * @js NA
      */
-    void removeAllActionsByTag(int tag, Node *target, bool bitwiseFilter = false);
+    void removeAllActionsByTag(int tag, Node *target);
+
+    /** Removes all actions matching at least one bit in flags and the target.
+     *
+     * @param flags     The flag field to match the actions' flags based on bitwise AND.
+     * @param target    A certain target.
+     * @js NA
+     */
+    void removeActionsByFlags(unsigned int flags, Node *target);
 
     /** Gets an action given its tag an a target.
      *

--- a/cocos/2d/CCNode.cpp
+++ b/cocos/2d/CCNode.cpp
@@ -1563,10 +1563,18 @@ void Node::stopActionByTag(int tag)
     _actionManager->removeActionByTag(tag, this);
 }
 
-void Node::stopAllActionsByTag(int tag, bool bitwiseFilter)
+void Node::stopAllActionsByTag(int tag)
 {
     CCASSERT( tag != Action::INVALID_TAG, "Invalid tag");
-    _actionManager->removeAllActionsByTag(tag, this, bitwiseFilter);
+    _actionManager->removeAllActionsByTag(tag, this);
+}
+
+void Node::stopActionsByFlags(unsigned int flags)
+{
+    if (flags > 0)
+    {
+        _actionManager->removeActionsByFlags(flags, this);
+    }
 }
 
 Action * Node::getActionByTag(int tag)

--- a/cocos/2d/CCNode.cpp
+++ b/cocos/2d/CCNode.cpp
@@ -1563,10 +1563,10 @@ void Node::stopActionByTag(int tag)
     _actionManager->removeActionByTag(tag, this);
 }
 
-void Node::stopAllActionsByTag(int tag)
+void Node::stopAllActionsByTag(int tag, bool bitwiseFilter)
 {
     CCASSERT( tag != Action::INVALID_TAG, "Invalid tag");
-    _actionManager->removeAllActionsByTag(tag, this);
+    _actionManager->removeAllActionsByTag(tag, this, bitwiseFilter);
 }
 
 Action * Node::getActionByTag(int tag)

--- a/cocos/2d/CCNode.h
+++ b/cocos/2d/CCNode.h
@@ -1224,9 +1224,15 @@ public:
      * Removes all actions from the running action list by its tag.
      *
      * @param tag   A tag that indicates the action to be removed.
-     * @param bitwiseFilter  If true, tag is used as a flag field using "bitwise AND"
      */
-    void stopAllActionsByTag(int tag, bool bitwiseFilter = false);
+    void stopAllActionsByTag(int tag);
+
+    /**
+     * Removes all actions from the running action list by its flags.
+     *
+     * @param flags   A flag field that removes actions based on bitwise AND.
+     */
+    void stopActionsByFlags(unsigned int flags);
 
     /**
      * Gets an action from the running action list by its tag.

--- a/cocos/2d/CCNode.h
+++ b/cocos/2d/CCNode.h
@@ -1224,8 +1224,9 @@ public:
      * Removes all actions from the running action list by its tag.
      *
      * @param tag   A tag that indicates the action to be removed.
+     * @param bitwiseFilter  If true, tag is used as a flag field using "bitwise AND"
      */
-    void stopAllActionsByTag(int tag);
+    void stopAllActionsByTag(int tag, bool bitwiseFilter = false);
 
     /**
      * Gets an action from the running action list by its tag.

--- a/tests/cpp-tests/Classes/ActionManagerTest/ActionManagerTest.cpp
+++ b/tests/cpp-tests/Classes/ActionManagerTest/ActionManagerTest.cpp
@@ -18,6 +18,7 @@ ActionManagerTests::ActionManagerTests()
     ADD_TEST_CASE(PauseTest);
     ADD_TEST_CASE(StopActionTest);
     ADD_TEST_CASE(StopAllActionsTest);
+    ADD_TEST_CASE(StopActionsByFlagsTest);
     ADD_TEST_CASE(ResumeTest);
 }
 
@@ -290,4 +291,54 @@ void ResumeTest::resumeGrossini(float time)
     auto pGrossini = getChildByTag(kTagGrossini);
     auto director = Director::getInstance();
     director->getActionManager()->resumeTarget(pGrossini);
+}
+
+//------------------------------------------------------------------
+//
+// StopActionsByFlagsTest
+//
+//------------------------------------------------------------------
+void StopActionsByFlagsTest::onEnter()
+{
+    ActionManagerTest::onEnter();
+
+    auto l = Label::createWithTTF("Should stop scale & move after 4 seconds but keep rotate", "fonts/Thonburi.ttf", 16.0f);
+    addChild(l);
+    l->setPosition( Vec2(VisibleRect::center().x, VisibleRect::top().y - 75) );
+
+    auto pMove1 = MoveBy::create(2, Vec2(200, 0));
+    auto pMove2 = MoveBy::create(2, Vec2(-200, 0));
+    auto pSequenceMove = Sequence::createWithTwoActions(pMove1, pMove2);
+    auto pRepeatMove = RepeatForever::create(pSequenceMove);
+    pRepeatMove->setFlags(kMoveFlag | kRepeatForeverFlag);
+
+    auto pScale1 = ScaleBy::create(2, 1.5f);
+    auto pScale2 = ScaleBy::create(2, 1.0f/1.5f);
+    auto pSequenceScale = Sequence::createWithTwoActions(pScale1, pScale2);
+    auto pRepeatScale = RepeatForever::create(pSequenceScale);
+    pRepeatScale->setFlags(kScaleFlag | kRepeatForeverFlag);
+
+    auto pRotate = RotateBy::create(2, 360);
+    auto pRepeatRotate = RepeatForever::create(pRotate);
+    pRepeatRotate->setFlags(kRotateFlag | kRepeatForeverFlag);
+
+    auto pChild = Sprite::create(s_pathGrossini);
+    pChild->setPosition( VisibleRect::center() );
+
+    addChild(pChild, 1, kTagGrossini);
+    pChild->runAction(pRepeatMove);
+    pChild->runAction(pRepeatScale);
+    pChild->runAction(pRepeatRotate);
+    this->scheduleOnce((SEL_SCHEDULE)&StopActionsByFlagsTest::stopAction, 4);
+}
+
+void StopActionsByFlagsTest::stopAction(float time)
+{
+    auto sprite = getChildByTag(kTagGrossini);
+    sprite->stopActionsByFlags(kMoveFlag | kScaleFlag);
+}
+
+std::string StopActionsByFlagsTest::subtitle() const
+{
+    return "Stop All Actions By Flags Test";
 }

--- a/tests/cpp-tests/Classes/ActionManagerTest/ActionManagerTest.h
+++ b/tests/cpp-tests/Classes/ActionManagerTest/ActionManagerTest.h
@@ -81,4 +81,19 @@ public:
     void resumeGrossini(float time);
 };
 
+class StopActionsByFlagsTest : public ActionManagerTest
+{
+public:
+    CREATE_FUNC(StopActionsByFlagsTest);
+
+    virtual std::string subtitle() const override;
+    virtual void onEnter() override;
+    void stopAction(float time);
+protected:
+    const unsigned int kMoveFlag = 0x01;
+    const unsigned int kScaleFlag = 0x02;
+    const unsigned int kRotateFlag = 0x04;
+    const unsigned int kRepeatForeverFlag = 0x08; // You don't need this for the test, but it's for demonstration how to activate several flags on an action.
+};
+
 #endif


### PR DESCRIPTION
I would love if I could use Action::_tag as a flag field.
It's a very small change to the code but a very powerful tool...

Use case:

```
    enum Flags {
        FRAME = 1,
        COLOR = 2,
        OPACITY = 4,
        POSITION = 8,
        SCALE = 16,
        ROTATION = 32,
        SKEW = 64
    };

    auto action1 = RepeatForever::create(Sequence::create(FadeTo::create( 0.1f, 155), 
                                                          TintTo::create(0.1f, 255,0,0),
                                                          nullptr));
    action1->setTag(Flags::OPACITY|Flags::COLOR);
    sprite->runAction(action1);

    auto action2 = RepeatForever::create(Sequence::create(Animate::create(idleAnimation),
                                                          MoveBy::create(0.3f, Vec2(5, 0)),
                                                          nullptr));
    action2->setTag(Flags::FRAME|Flags::POSITION);
    sprite->runAction(action2);

    // stop all actions that change position or opacity
    sprite->stopAllActionsByTag(Flags::OPACITY|Flags::POSITION, true); 
```
