### PR TITLE
remove uneeded function

### DIFF
--- a/cocos/platform/CCFileUtils.cpp
+++ b/cocos/platform/CCFileUtils.cpp
@@ -942,23 +942,6 @@ std::string FileUtils::getFullPathForDirectoryAndFilename(const std::string& dir
     return ret;
 }
 
-std::string FileUtils::searchFullPathForFilename(const std::string& filename) const
-{
-    if (isAbsolutePath(filename))
-    {
-        return filename;
-    }
-    std::string path = fullPathForFilename(filename);
-    if (0 == path.compare(filename))
-    {
-        return "";
-    }
-    else
-    {
-        return path;
-    }
-}
-
 bool FileUtils::isFileExist(const std::string& filename) const
 {
     if (isAbsolutePath(filename))
@@ -967,7 +950,7 @@ bool FileUtils::isFileExist(const std::string& filename) const
     }
     else
     {
-        std::string fullpath = searchFullPathForFilename(filename);
+        std::string fullpath = fullPathForFilename(filename);
         if (fullpath.empty())
             return false;
         else
@@ -1328,7 +1311,7 @@ long FileUtils::getFileSize(const std::string &filepath)
     std::string fullpath = filepath;
     if (!isAbsolutePath(filepath))
     {
-        fullpath = searchFullPathForFilename(filepath);
+        fullpath = fullPathForFilename(filepath);
         if (fullpath.empty())
             return 0;
     }

--- a/cocos/platform/CCFileUtils.h
+++ b/cocos/platform/CCFileUtils.h
@@ -478,16 +478,6 @@ protected:
      */
     virtual std::string getFullPathForDirectoryAndFilename(const std::string& directory, const std::string& filename) const;
     
-    /** 
-     *  Returns the fullpath for a given filename.
-     *  This is an alternative for fullPathForFilename
-     *  It returns empty string instead of the original filename when no file found for the given name.
-     *  @param filename The file name to look up for
-     *  @return The full path for the file, if not found, the return value will be an empty string
-     */
-    virtual std::string searchFullPathForFilename(const std::string& filename) const;
-    
-    
     /** Dictionary used to lookup filenames based on a key.
      *  It is used internally by the following methods:
      *


### PR DESCRIPTION
fullPathForFilename() now will return empty string when a file can not be found.
So searchFullPathForFilename() is not needed any more.
And searchFullPathForFilename() is only used in FileUtils.
