### PR TITLE
issue #10302: Remove duplicated test cases

### DIFF
--- a/tests/cpp-tests/Classes/ActionsTest/ActionsTest.cpp
+++ b/tests/cpp-tests/Classes/ActionsTest/ActionsTest.cpp
@@ -35,7 +35,6 @@ USING_NS_CC;
 
 ActionsTests::ActionsTests()
 {
-    ADD_TEST_CASE(ActionManual);
     ADD_TEST_CASE(ActionMove);
     ADD_TEST_CASE(ActionMove3D);
     ADD_TEST_CASE(ActionRotate);
@@ -62,11 +61,9 @@ ActionsTests::ActionsTests()
     ADD_TEST_CASE(ActionRepeat);
     ADD_TEST_CASE(ActionRepeatForever);
     ADD_TEST_CASE(ActionRotateToRepeat);
-    ADD_TEST_CASE(ActionRotateJerk);
     ADD_TEST_CASE(ActionCallFunction);
     ADD_TEST_CASE(ActionCallFuncN);
     ADD_TEST_CASE(ActionCallFuncND);
-    ADD_TEST_CASE(ActionCallFuncO);
     ADD_TEST_CASE(ActionReverseSequence);
     ADD_TEST_CASE(ActionReverseSequence2);
     ADD_TEST_CASE(ActionOrbit);
@@ -178,35 +175,6 @@ void ActionsDemo::alignSpritesLeft(unsigned int numberOfSprites)
         _tamara->setPosition(60, 2*s.height/3);
         _kathia->setPosition(60, s.height/3);
     }
-}
-
-//------------------------------------------------------------------
-//
-// ActionManual
-//
-//------------------------------------------------------------------
-void ActionManual::onEnter()
-{
-    ActionsDemo::onEnter();
-
-    auto s = Director::getInstance()->getWinSize();
-
-    _tamara->setScaleX( 2.5f);
-    _tamara->setScaleY( -1.0f);
-    _tamara->setPosition(100,70);
-    _tamara->setOpacity( 128);
-
-    _grossini->setRotation( 120);
-    _grossini->setPosition(s.width/2, s.height/2);
-    _grossini->setColor( Color3B( 255,0,0));
-
-    _kathia->setPosition(s.width-100, s.height/2);
-    _kathia->setColor( Color3B::BLUE);
-}
-
-std::string ActionManual::subtitle() const
-{
-    return "Manual Transformation";
 }
 
 //------------------------------------------------------------------
@@ -879,40 +847,6 @@ void ActionCallFuncND::doRemoveFromParentAndCleanup(Node* sender, bool cleanup)
 
 //------------------------------------------------------------------
 //
-// ActionCallFuncO
-// CallFuncO is no longer needed. It can simulated with std::bind()
-//
-//------------------------------------------------------------------
-void ActionCallFuncO::onEnter()
-{
-    ActionsDemo::onEnter();
-
-    centerSprites(1);
-
-    auto action = Sequence::create(
-        MoveBy::create(2.0f, Vec2(200,0)),
-        CallFunc::create( CC_CALLBACK_0(ActionCallFuncO::callback, this, _grossini, true)),
-        nullptr);
-    _grossini->runAction(action);
-}
-
-std::string ActionCallFuncO::title() const
-{
-    return "CallFuncO + autoremove";
-}
-
-std::string ActionCallFuncO::subtitle() const
-{
-    return "simulates CallFuncO with std::bind()";
-}
-
-void ActionCallFuncO::callback(Node* node, bool cleanup)
-{
-    node->removeFromParentAndCleanup(cleanup);
-}
-
-//------------------------------------------------------------------
-//
 //    ActionCallFunction
 //
 //------------------------------------------------------------------
@@ -1070,35 +1004,6 @@ void ActionRotateToRepeat::onEnter()
 std::string ActionRotateToRepeat ::subtitle() const
 {
     return "Repeat/RepeatForever + RotateTo";
-}
-
-
-//------------------------------------------------------------------
-//
-// ActionRotateJerk
-//
-//------------------------------------------------------------------
-void ActionRotateJerk::onEnter()
-{
-    ActionsDemo::onEnter();
-
-    centerSprites(2);
-
-	auto seq = Sequence::create(
-        RotateTo::create(0.5f, -20),
-        RotateTo::create(0.5f, 20),
-        nullptr);
-
-	auto rep1 = Repeat::create(seq, 10);
-	auto rep2 = RepeatForever::create( seq->clone() );
-
-    _tamara->runAction(rep1);
-    _kathia->runAction(rep2);
-}
-
-std::string ActionRotateJerk::subtitle() const
-{
-    return "RepeatForever / Repeat + Rotate";
 }
 
 //------------------------------------------------------------------

--- a/tests/cpp-tests/Classes/ActionsTest/ActionsTest.h
+++ b/tests/cpp-tests/Classes/ActionsTest/ActionsTest.h
@@ -46,15 +46,6 @@ public:
     virtual std::string title() const override;
 };
 
-class ActionManual : public ActionsDemo
-{
-public:
-    CREATE_FUNC(ActionManual);
-
-    virtual void onEnter() override;
-    virtual std::string subtitle() const override;
-};
-
 class ActionMove : public ActionsDemo
 {
 public:
@@ -310,15 +301,6 @@ public:
     virtual std::string subtitle() const override;
 };
 
-class ActionRotateJerk : public ActionsDemo
-{
-public:
-    CREATE_FUNC(ActionRotateJerk);
-
-    virtual void onEnter() override;
-    virtual std::string subtitle() const override;
-};
-
 class ActionCallFuncN : public ActionsDemo
 {
 public:
@@ -339,17 +321,6 @@ public:
     virtual std::string title() const override;
     virtual std::string subtitle() const override;
     void doRemoveFromParentAndCleanup(Node* sender, bool cleanup);
-};
-
-class ActionCallFuncO : public ActionsDemo
-{
-public:
-    CREATE_FUNC(ActionCallFuncO);
-
-    virtual void onEnter() override;
-    virtual std::string title() const override;
-    virtual std::string subtitle() const override;
-    void callback(Node* object, bool cleanup);
 };
 
 class ActionCallFunction : public ActionsDemo

--- a/tests/cpp-tests/Classes/LayerTest/LayerTest.cpp
+++ b/tests/cpp-tests/Classes/LayerTest/LayerTest.cpp
@@ -21,7 +21,6 @@ LayerTests::LayerTests()
     ADD_TEST_CASE(LayerTestBlend);
     ADD_TEST_CASE(LayerGradientTest);
     ADD_TEST_CASE(LayerGradientTest2);
-    ADD_TEST_CASE(LayerGradientTest3);
     ADD_TEST_CASE(LayerIgnoreAnchorPointPos);
     ADD_TEST_CASE(LayerIgnoreAnchorPointRot);
     ADD_TEST_CASE(LayerIgnoreAnchorPointScale);
@@ -572,28 +571,6 @@ std::string LayerGradientTest2::title() const
 }
 
 std::string LayerGradientTest2::subtitle() const
-{
-    return "You should see a gradient";
-}
-
-
-//------------------------------------------------------------------
-//
-// LayerGradientTest3
-//
-//------------------------------------------------------------------
-LayerGradientTest3::LayerGradientTest3()
-{
-    auto layer1 = LayerGradient::create(Color4B(255,0,0,255), Color4B(255,255,0,255));
-    addChild(layer1);
-}
-
-std::string LayerGradientTest3::title() const
-{
-    return "LayerGradientTest 3";
-}
-
-std::string LayerGradientTest3::subtitle() const
 {
     return "You should see a gradient";
 }

--- a/tests/cpp-tests/Classes/LayerTest/LayerTest.h
+++ b/tests/cpp-tests/Classes/LayerTest/LayerTest.h
@@ -116,15 +116,6 @@ public:
     virtual std::string subtitle() const override;
 };
 
-class LayerGradientTest3 : public LayerTest
-{
-public:
-    CREATE_FUNC(LayerGradientTest3);
-    LayerGradientTest3();
-    virtual std::string title() const override;
-    virtual std::string subtitle() const override;
-};
-
 class LayerIgnoreAnchorPointPos : public LayerTest
 {
 public:

--- a/tests/cpp-tests/Classes/NewRendererTest/NewRendererTest.cpp
+++ b/tests/cpp-tests/Classes/NewRendererTest/NewRendererTest.cpp
@@ -29,7 +29,6 @@ USING_NS_CC;
 NewRendererTests::NewRendererTests()
 {
     ADD_TEST_CASE(NewSpriteTest);
-    ADD_TEST_CASE(NewSpriteBatchTest);
     ADD_TEST_CASE(GroupCommandTest);
     ADD_TEST_CASE(NewClippingNodeTest);
     ADD_TEST_CASE(NewDrawNodeTest);
@@ -187,76 +186,6 @@ std::string GroupCommandTest::title() const
 std::string GroupCommandTest::subtitle() const
 {
     return "GroupCommandTest: You should see a sprite";
-}
-
-//-------- New Sprite Batch Test
-
-NewSpriteBatchTest::NewSpriteBatchTest()
-{
-    auto touchListener = EventListenerTouchAllAtOnce::create();
-    touchListener->onTouchesEnded = CC_CALLBACK_2(NewSpriteBatchTest::onTouchesEnded, this);
-    _eventDispatcher->addEventListenerWithSceneGraphPriority(touchListener, this);
-
-    auto BatchNode = SpriteBatchNode::create("Images/grossini_dance_atlas.png", 50);
-    addChild(BatchNode, 0, kTagSpriteBatchNode);
-}
-
-NewSpriteBatchTest::~NewSpriteBatchTest()
-{
-
-}
-
-std::string NewSpriteBatchTest::title() const
-{
-    return "Renderer";
-}
-
-std::string NewSpriteBatchTest::subtitle() const
-{
-    return "SpriteBatchTest";
-}
-
-void NewSpriteBatchTest::onTouchesEnded(const std::vector<Touch *> &touches, Event *event)
-{
-    for (auto &touch : touches)
-    {
-        auto location = touch->getLocation();
-        addNewSpriteWithCoords(location);
-    }
-}
-
-void NewSpriteBatchTest::addNewSpriteWithCoords(Vec2 p)
-{
-    auto BatchNode = static_cast<SpriteBatchNode*>( getChildByTag(kTagSpriteBatchNode) );
-
-    int idx = (int) (CCRANDOM_0_1() * 1400 / 100);
-    int x = (idx%5) * 85;
-    int y = (idx/5) * 121;
-
-
-    auto sprite = Sprite::createWithTexture(BatchNode->getTexture(), Rect(x,y,85,121));
-    BatchNode->addChild(sprite);
-
-    sprite->setPosition( Vec2( p.x, p.y) );
-
-    ActionInterval* action;
-    float random = CCRANDOM_0_1();
-
-    if( random < 0.20 )
-        action = ScaleBy::create(3, 2);
-    else if(random < 0.40)
-        action = RotateBy::create(3, 360);
-    else if( random < 0.60)
-        action = Blink::create(1, 3);
-    else if( random < 0.8 )
-        action = TintBy::create(2, 0, -255, -255);
-    else
-        action = FadeOut::create(2);
-
-    auto action_back = action->reverse();
-    auto seq = Sequence::create(action, action_back, nullptr);
-
-    sprite->runAction( RepeatForever::create(seq));
 }
 
 NewClippingNodeTest::NewClippingNodeTest()

--- a/tests/cpp-tests/Classes/NewRendererTest/NewRendererTest.h
+++ b/tests/cpp-tests/Classes/NewRendererTest/NewRendererTest.h
@@ -50,22 +50,6 @@ protected:
     virtual ~GroupCommandTest();
 };
 
-class NewSpriteBatchTest : public MultiSceneTest
-{
-public:
-
-    CREATE_FUNC(NewSpriteBatchTest);
-    virtual std::string title() const override;
-    virtual std::string subtitle() const override;
-
-    void onTouchesEnded(const std::vector<cocos2d::Touch*>& touches, cocos2d::Event* event);
-    void addNewSpriteWithCoords(cocos2d::Vec2 p);
-
-protected:
-    NewSpriteBatchTest();
-    virtual ~NewSpriteBatchTest();
-};
-
 class NewClippingNodeTest : public MultiSceneTest
 {
 public:

--- a/tests/cpp-tests/Classes/Texture2dTest/Texture2dTest.cpp
+++ b/tests/cpp-tests/Classes/Texture2dTest/Texture2dTest.cpp
@@ -37,8 +37,6 @@ enum {
 
 Texture2DTests::Texture2DTests()
 {
-    ADD_TEST_CASE(TexturePVRv3Premult);
-
     ADD_TEST_CASE(TextureMipMap);
     ADD_TEST_CASE(TextureMemoryAlloc);
     ADD_TEST_CASE(TextureAlias);

--- a/tests/cpp-tests/Classes/controller.cpp
+++ b/tests/cpp-tests/Classes/controller.cpp
@@ -17,7 +17,6 @@ public:
     RootTests()
     {
         addTest("Node: Scene3D", [](){return new (std::nothrow) Scene3DTests(); });
-        addTest("SpritePolygon", [](){return new (std::nothrow) SpritePolygonTest(); });
         addTest("ActionManager", [](){return new (std::nothrow) ActionManagerTests(); });
         addTest("Actions - Basic", [](){ return new (std::nothrow) ActionsTests(); });
         addTest("Actions - Ease", [](){return new (std::nothrow) ActionsEaseTests(); });


### PR DESCRIPTION
This related issue is #10302.

1.Remove `Actions-Basic->ActionManual`, it only make sprite objects set the position,scale,and so on.It has nothing with action.
2.Remove `Actions-Basic->ActionRotateJerk`, Actions-Basic->ActionRotateToRepeat do the almost same tests except the duration and dstAngle for RotateTo.
3.Remove `Actions-Basic->ActionCallFuncO`, CallFuncO is deprecated and the test aspects has been tested in the other test.
4.Remove `Renderer->NewSpriteBatchTest`, Node:Sprite->Testing SpriteBatchNode do the same tests.
5.Remove `Node:Layer->LayerGradientTest3`, Node:Layer->LayerGradientTest3 do the same tests.
6.Remove `Texture2D-> TexturePVRv3Premult` and `SpritePolygon` Tests, because they run twice.
