### PR TITLE
Fixed: #12097 VideoPlayer on Android ignores search paths

### DIFF
--- a/cocos/ui/UIVideoPlayer-android.cpp
+++ b/cocos/ui/UIVideoPlayer-android.cpp
@@ -32,6 +32,7 @@
 #include "jni/JniHelper.h"
 #include "base/CCDirector.h"
 #include "base/CCEventListenerKeyboard.h"
+#include "platform/CCFileUtils.h"
 
 //-----------------------------------------------------------------------------------------------------------
 #define  CLASS_NAME "org/cocos2dx/lib/Cocos2dxVideoHelper"
@@ -193,7 +194,7 @@ VideoPlayer::~VideoPlayer()
 
 void VideoPlayer::setFileName(const std::string& fileName)
 {
-    _videoURL = fileName;
+    _videoURL = FileUtils::getInstance()->fullPathForFilename(fileName);
     _videoSource = VideoPlayer::Source::FILENAME;
     setVideoURLJNI(_videoPlayerIndex, (int)Source::FILENAME,_videoURL);
 }

--- a/cocos/ui/UIVideoPlayer-ios.mm
+++ b/cocos/ui/UIVideoPlayer-ios.mm
@@ -55,7 +55,6 @@ using namespace cocos2d::experimental::ui;
 -(void) videoFinished:(NSNotification*) notification;
 -(void) playStateChange;
 
-+(NSString*) fullPathFromRelativePath:(NSString*) relPath;
 
 @end
 
@@ -138,8 +137,7 @@ using namespace cocos2d::experimental::ui;
         self.moviePlayer.movieSourceType = MPMovieSourceTypeStreaming;
         [self.moviePlayer setContentURL:[NSURL URLWithString:@(videoUrl.c_str())]];
     } else {
-        NSString *path = [UIVideoViewWrapperIos fullPathFromRelativePath:@(videoUrl.c_str())];
-        self.moviePlayer = [[[MPMoviePlayerController alloc] initWithContentURL:[NSURL fileURLWithPath:path]] autorelease];
+        self.moviePlayer = [[[MPMoviePlayerController alloc] initWithContentURL:[NSURL fileURLWithPath:@(videoUrl.c_str())]] autorelease];
         self.moviePlayer.movieSourceType = MPMovieSourceTypeFile;
     }
     self.moviePlayer.allowsAirPlay = false;
@@ -260,10 +258,6 @@ using namespace cocos2d::experimental::ui;
     }
 }
 
-+(NSString*) fullPathFromRelativePath:(NSString*) relPath
-{
-    return [NSString stringWithCString: cocos2d::FileUtils::getInstance()->fullPathForFilename(std::string([relPath UTF8String])).c_str() encoding: [NSString defaultCStringEncoding]];
-}
 @end
 //------------------------------------------------------------------------------------------------------------
 
@@ -293,7 +287,7 @@ VideoPlayer::~VideoPlayer()
 
 void VideoPlayer::setFileName(const std::string& fileName)
 {
-    _videoURL = fileName;
+    _videoURL = FileUtils::getInstance()->fullPathForFilename(fileName);
     _videoSource = VideoPlayer::Source::FILENAME;
     [((UIVideoViewWrapperIos*)_videoView) setURL:(int)_videoSource :_videoURL];
 }


### PR DESCRIPTION
https://github.com/cocos2d/cocos2d-x/issues/12097
- fix for android
- make iOS/Android to work the same
