### PR TITLE
Blink::stop() access violation

### DIFF
--- a/cocos/2d/CCActionInterval.cpp
+++ b/cocos/2d/CCActionInterval.cpp
@@ -1814,7 +1814,8 @@ bool Blink::initWithDuration(float duration, int blinks)
 
 void Blink::stop()
 {
-    _target->setVisible(_originalState);
+    if(NULL != _target)
+        _target->setVisible(_originalState);
     ActionInterval::stop();
 }
 


### PR DESCRIPTION
Blink::stop() is called twice when inside a Repeat action. This results in an access violation
