### PR TITLE
JumpTo::clone() results in incorrect end position

### DIFF
--- a/cocos/2d/CCActionInterval.cpp
+++ b/cocos/2d/CCActionInterval.cpp
@@ -1464,7 +1464,7 @@ JumpTo* JumpTo::clone() const
 {
     // no copy constructor
     auto a = new (std::nothrow) JumpTo();
-    a->initWithDuration(_duration, _delta, _height, _jumps);
+    a->initWithDuration(_duration, _endPosition, _height, _jumps);
     a->autorelease();
     return a;
 }


### PR DESCRIPTION
JumpTo::clone() passes incorrect value to (_delta) to create() rather than _endPosition
