### PR TITLE
issue #10323: Fix the compile error when COCOS2D_DEBUG>=2.

### DIFF
--- a/cocos/base/CCData.cpp
+++ b/cocos/base/CCData.cpp
@@ -24,6 +24,7 @@
  ****************************************************************************/
 
 #include "base/CCData.h"
+#include "base/CCConsole.h"
 
 NS_CC_BEGIN
 

--- a/cocos/base/CCEventListener.cpp
+++ b/cocos/base/CCEventListener.cpp
@@ -23,6 +23,7 @@
  ****************************************************************************/
 
 #include "base/CCEventListener.h"
+#include "base/CCConsole.h"
 
 NS_CC_BEGIN
 

--- a/cocos/base/CCEventListenerAcceleration.cpp
+++ b/cocos/base/CCEventListenerAcceleration.cpp
@@ -24,6 +24,7 @@
 
 #include "base/CCEventListenerAcceleration.h"
 #include "base/CCEventAcceleration.h"
+#include "base/CCConsole.h"
 
 NS_CC_BEGIN
 


### PR DESCRIPTION
The related issue is #10323
