### PR TITLE
default support curl gzip. and add the gzip test in xmlhttprequest Issue1756

### DIFF
--- a/cocos/network/HttpClient.cpp
+++ b/cocos/network/HttpClient.cpp
@@ -202,7 +202,7 @@ static bool configureCURL(HttpClient* client, CURL* handle, char* errorBuffer)
     // Document is here: http://curl.haxx.se/libcurl/c/curl_easy_setopt.html#CURLOPTNOSIGNAL 
     curl_easy_setopt(handle, CURLOPT_NOSIGNAL, 1L);
 
-	curl_easy_setopt(handle, CURLOPT_ACCEPT_ENCODING, "");
+    curl_easy_setopt(handle, CURLOPT_ACCEPT_ENCODING, "");
 
     return true;
 }

--- a/cocos/network/HttpClient.cpp
+++ b/cocos/network/HttpClient.cpp
@@ -202,6 +202,8 @@ static bool configureCURL(HttpClient* client, CURL* handle, char* errorBuffer)
     // Document is here: http://curl.haxx.se/libcurl/c/curl_easy_setopt.html#CURLOPTNOSIGNAL 
     curl_easy_setopt(handle, CURLOPT_NOSIGNAL, 1L);
 
+	curl_easy_setopt(handle, CURLOPT_ACCEPT_ENCODING, "");
+
     return true;
 }
 

--- a/tests/js-tests/src/XHRTest/XHRTest.js
+++ b/tests/js-tests/src/XHRTest/XHRTest.js
@@ -127,8 +127,9 @@ var XHRTestLayer = cc.Layer.extend({
         
         var xhr = cc.loader.getXMLHttpRequest();
         streamXHREventsToLabel(xhr, statusPostLabel, responseLabel, "POST");
+        xhr.setRequestHeader("Accept-Encoding","gzip,deflate");
+        xhr.open("POST", "http://httpbin.org/post", true);
 
-        xhr.open("POST", "http://httpbin.org/post");
         //set Content-type "text/plain;charset=UTF-8" to post plain text
         xhr.setRequestHeader("Content-Type","text/plain;charset=UTF-8");
         xhr.send("plain text message");

--- a/tests/js-tests/src/XHRTest/XHRTest.js
+++ b/tests/js-tests/src/XHRTest/XHRTest.js
@@ -103,9 +103,12 @@ var XHRTestLayer = cc.Layer.extend({
         streamXHREventsToLabel(xhr, statusGetLabel, responseLabel, "GET");
         // 5 seconds for timeout
         xhr.timeout = 5000;
-        
+
+        xhr.setRequestHeader("Accept-Encoding","gzip,deflate");
+
         //set arguments with <URL>?xxx=xxx&yyy=yyy
-        xhr.open("GET", "http://httpbin.org/get?show_env=1", true);
+        xhr.open("GET", "http://geek.csdn.net/news/detail/33683", true);
+
         xhr.send();
     },
 
@@ -127,8 +130,8 @@ var XHRTestLayer = cc.Layer.extend({
         
         var xhr = cc.loader.getXMLHttpRequest();
         streamXHREventsToLabel(xhr, statusPostLabel, responseLabel, "POST");
-        xhr.setRequestHeader("Accept-Encoding","gzip,deflate");
-        xhr.open("POST", "http://httpbin.org/post", true);
+
+        xhr.open("POST", "http://httpbin.org/post");
 
         //set Content-type "text/plain;charset=UTF-8" to post plain text
         xhr.setRequestHeader("Content-Type","text/plain;charset=UTF-8");


### PR DESCRIPTION
default support curl gzip. and add the gzip test in xmlhttprequest, relate issue:https://github.com/cocos2d/cocos2d-js/issues/1756
