### PR TITLE
Update extension.h, amend a really  dangerous macros that may cause memory allocation error

### DIFF
--- a/cocos/editor-support/spine/extension.h
+++ b/cocos/editor-support/spine/extension.h
@@ -32,7 +32,7 @@
 #define SPINE_EXTENSION_H_
 
 /* All allocation uses these. */
-#define MALLOC(TYPE,COUNT) ((TYPE*)_malloc(sizeof(TYPE) * COUNT, __FILE__, __LINE__))
+#define MALLOC(TYPE,COUNT) ((TYPE*)_malloc(sizeof(TYPE) * (COUNT), __FILE__, __LINE__))
 #define CALLOC(TYPE,COUNT) ((TYPE*)_calloc(COUNT, sizeof(TYPE), __FILE__, __LINE__))
 #define NEW(TYPE) CALLOC(TYPE,1)
 


### PR DESCRIPTION
# define MALLOC(TYPE,COUNT) ((TYPE*)_malloc(sizeof(TYPE) \* COUNT, __FILE__, **LINE**))

It is a really dangerous macros here.
If use it like this "MALLOC(Type, n+2)", it will alloc sizeof(TYPE) \* COUNT + 2 byte memory.but I want it alloc sizeof(TYPE) \* (COUNT + 2) byte. It is a typical macro unwind error.
