### PR TITLE
call setTransparent

### DIFF
--- a/cocos/3d/CCMesh.cpp
+++ b/cocos/3d/CCMesh.cpp
@@ -350,6 +350,7 @@ void Mesh::draw(Renderer* renderer, float globalZOrder, const Mat4& transform, u
 
 
     _meshCommand.setSkipBatching(isTransparent);
+    _meshCommand.setTransparent(isTransparent);
 
     // set default uniforms for Mesh
     // 'u_color' and others


### PR DESCRIPTION
setTransparent is called.
Because the default value from RenderCommand is true. 
