### PR TITLE
Fix clone URL in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ cocos2d-x is:
 Git user attention
 -----------------------
 
-1. clone the repo from GitHub.
+1. Clone the repo from GitHub.
 
-         $ git clone git@github.com:cocos2d/cocos2d-x.git
+         $ git clone https://github.com/cocos2d/cocos2d-x.git
 
 2. After cloning the repo, please execute `download-deps.py` to download and install dependencies.
 


### PR DESCRIPTION
At least for me, I can't clone using the URL in the README.md:

```
oscr@oscr-VirtualBox:~/source$ git clone git@github.com:cocos2d/cocos2d-x.git
Cloning into 'cocos2d-x'...
The authenticity of host 'github.com (192.30.252.130)' can't be established.
RSA key fingerprint is 16:27:ac:a5:76:28:2d:36:63:1b:56:4d:eb:df:a6:48.
Are you sure you want to continue connecting (yes/no)? yes
Warning: Permanently added 'github.com,192.30.252.130' (RSA) to the list of known hosts.
Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
```

Using `https` is recommended by GitHub [here](https://help.github.com/articles/which-remote-url-should-i-use/).
