### PR TITLE
improve rendering of letter's inner shapes when outline is used

### DIFF
--- a/cocos/renderer/ccShader_Label_outline.frag
+++ b/cocos/renderer/ccShader_Label_outline.frag
@@ -17,7 +17,7 @@ void main()
     vec4 sample = texture2D(CC_Texture0, v_texCoord);
     float fontAlpha = sample.a; 
     float outlineAlpha = sample.r; 
-    if (outlineAlpha > 0.0){ 
+    if ((fontAlpha + outlineAlpha) > 0.0){
         vec4 color = u_textColor * fontAlpha + u_effectColor * (1.0 - fontAlpha);
         gl_FragColor = v_fragmentColor * vec4( color.rgb,max(fontAlpha,outlineAlpha)*color.a);
     }


### PR DESCRIPTION
Fixes "dirty" holes in letters, when outline is used 
![outline_frag_fix](https://cloud.githubusercontent.com/assets/327778/8032342/0e3e8a74-0dde-11e5-83fc-d2eafc78c203.png)
