### PR TITLE
MotionStreak opacity support

### DIFF
--- a/cocos/2d/CCMotionStreak.cpp
+++ b/cocos/2d/CCMotionStreak.cpp
@@ -51,6 +51,7 @@ MotionStreak::MotionStreak()
 , _vertices(nullptr)
 , _colorPointer(nullptr)
 , _texCoords(nullptr)
+, _opacity(0xFF)
 {
 }
 
@@ -126,7 +127,7 @@ bool MotionStreak::initWithFade(float fade, float minSeg, float stroke, const Co
     _blendFunc = BlendFunc::ALPHA_NON_PREMULTIPLIED;
 
     // shader state
-    setGLProgramState(GLProgramState::getOrCreateWithGLProgramName(GLProgram::SHADER_NAME_POSITION_TEXTURE_COLOR));
+    setGLProgramState(GLProgramState::getOrCreateWithGLProgramName(GLProgram::SHADER_NAME_POSITION_TEXTURE_A8_COLOR));
 
     setTexture(texture);
     setColor(color);
@@ -232,13 +233,12 @@ const BlendFunc& MotionStreak::getBlendFunc(void) const
 
 void MotionStreak::setOpacity(GLubyte opacity)
 {
-    CCASSERT(false, "Set opacity no supported");
+	_opacity = opacity;
 }
 
 GLubyte MotionStreak::getOpacity(void) const
 {
-    CCASSERT(false, "Opacity no supported");
-    return 0;
+	return _opacity;
 }
 
 void MotionStreak::setOpacityModifyRGB(bool bValue)
@@ -300,7 +300,7 @@ void MotionStreak::update(float delta)
             }else
                 newIdx2 = newIdx*8;
 
-            const GLubyte op = (GLubyte)(_pointState[newIdx] * 255.0f);
+            const GLubyte op = (GLubyte)(_pointState[newIdx] * _opacity);
             _colorPointer[newIdx2+3] = op;
             _colorPointer[newIdx2+7] = op;
         }
@@ -335,8 +335,8 @@ void MotionStreak::update(float delta)
         *((Color3B*)(_colorPointer + offset+4)) = _displayedColor;
 
         // Opacity
-        _colorPointer[offset+3] = 255;
-        _colorPointer[offset+7] = 255;
+        _colorPointer[offset+3] = _opacity;
+        _colorPointer[offset+7] = _opacity;
 
         // Generate polygon
         if(_nuPoints > 0 && _fastMode )

--- a/cocos/2d/CCMotionStreak.h
+++ b/cocos/2d/CCMotionStreak.h
@@ -173,6 +173,9 @@ protected:
     float _fadeDelta;
     float _minSeg;
 
+	//opacity
+	GLubyte _opacity;
+
     unsigned int _maxPoints;
     unsigned int _nuPoints;
     unsigned int _previousNuPoints;

--- a/tests/cpp-tests/Classes/MotionStreakTest/MotionStreakTest.cpp
+++ b/tests/cpp-tests/Classes/MotionStreakTest/MotionStreakTest.cpp
@@ -13,6 +13,7 @@ MotionStreakTests::MotionStreakTests()
 {
     ADD_TEST_CASE(MotionStreakTest1);
     ADD_TEST_CASE(MotionStreakTest2);
+	ADD_TEST_CASE(MotionStreakTest3);
     ADD_TEST_CASE(Issue1358);
 }
 
@@ -107,6 +108,72 @@ void MotionStreakTest2::onTouchesMoved(const std::vector<Touch*>& touches, Event
 std::string MotionStreakTest2::title() const
 {
     return "MotionStreak test";
+}
+
+//------------------------------------------------------------------
+//
+// MotionStreakTest3 - opacity
+//
+//------------------------------------------------------------------
+
+void MotionStreakTest3::onEnter()
+{
+	MotionStreakTest::onEnter();
+
+	auto s = Director::getInstance()->getWinSize();
+
+	_root = Sprite::create(s_pathR1);
+	addChild(_root, 1);
+	_root->setPosition(Vec2(s.width / 2, s.height / 2));
+
+	// the target object is offset from root, and the streak is moved to follow it
+	_target = Sprite::create(s_pathR1);
+	_root->addChild(_target);
+	_target->setPosition(Vec2(s.width / 4, 0));
+
+	// create the streak object and add it to the scene
+	streak = MotionStreak::create(2, 3, 32, Color3B::GREEN, s_streak);
+	addChild(streak);
+	// schedule an update on each frame so we can syncronize the streak with the target
+	schedule(CC_SCHEDULE_SELECTOR(MotionStreakTest3::onUpdate));
+
+	auto a1 = RotateBy::create(2, 360);
+
+	auto action1 = RepeatForever::create(a1);
+	auto motion = MoveBy::create(2, Vec2(100, 0));
+	_root->runAction(RepeatForever::create(Sequence::create(motion, motion->reverse(), nullptr)));
+	_root->runAction(action1);
+
+	auto colorAction = RepeatForever::create(Sequence::create(
+		TintTo::create(0.2f, 255, 0, 0),
+		TintTo::create(0.2f, 0, 255, 0),
+		TintTo::create(0.2f, 0, 0, 255),
+		TintTo::create(0.2f, 0, 255, 255),
+		TintTo::create(0.2f, 255, 255, 0),
+		TintTo::create(0.2f, 255, 0, 255),
+		TintTo::create(0.2f, 255, 255, 255),
+		nullptr));
+
+	streak->runAction(colorAction);
+
+	auto opacityAction = RepeatForever::create(Sequence::createWithTwoActions(FadeTo::create(3.0f, 0x00), FadeTo::create(3.0f, 0xFF)));
+
+	streak->runAction(opacityAction);
+}
+
+void MotionStreakTest3::onUpdate(float delta)
+{
+	streak->setPosition(_target->convertToWorldSpace(Vec2::ZERO));
+}
+
+std::string MotionStreakTest3::title() const
+{
+	return "MotionStreak opacity test";
+}
+
+std::string MotionStreakTest3::subtitle() const
+{
+	return "The tail should be fading in and out";
 }
 
 //------------------------------------------------------------------

--- a/tests/cpp-tests/Classes/MotionStreakTest/MotionStreakTest.h
+++ b/tests/cpp-tests/Classes/MotionStreakTest/MotionStreakTest.h
@@ -47,6 +47,20 @@ public:
     virtual std::string title() const override;
 };
 
+class MotionStreakTest3 : public MotionStreakTest
+{
+protected:
+	cocos2d::Node*        _root;
+	cocos2d::Node*        _target;
+
+public:
+	CREATE_FUNC(MotionStreakTest3);
+	virtual void onEnter() override;
+	void onUpdate(float delta);
+	virtual std::string title() const override;
+	virtual std::string subtitle() const override;
+};
+
 class Issue1358 : public MotionStreakTest
 {
 public:


### PR DESCRIPTION
SetOpacity support for MotionStreak, allowing use of FadeTo and such
actions to work with MotionStreak
