### PR TITLE
Fails if file does not exist

### DIFF
--- a/cocos/renderer/CCTextureCache.cpp
+++ b/cocos/renderer/CCTextureCache.cpp
@@ -102,6 +102,12 @@ void TextureCache::addImageAsync(const std::string &path, const std::function<vo
 
     std::string fullpath = FileUtils::getInstance()->fullPathForFilename(path);
 
+    // check if file exists
+    if (! FileUtils::getInstance()->isFileExist( fullpath )) {
+        callback(nullptr);
+        return;
+    }
+    
     auto it = _textures.find(fullpath);
     if( it != _textures.end() )
         texture = it->second;
@@ -111,6 +117,8 @@ void TextureCache::addImageAsync(const std::string &path, const std::function<vo
         callback(texture);
         return;
     }
+
+    // ALTERNATIVE: insert file exists check here to allow loading cached but deleted file
 
     // lazy init
     if (_asyncStructQueue == nullptr)

--- a/cocos/renderer/CCTextureCache.cpp
+++ b/cocos/renderer/CCTextureCache.cpp
@@ -103,7 +103,7 @@ void TextureCache::addImageAsync(const std::string &path, const std::function<vo
     std::string fullpath = FileUtils::getInstance()->fullPathForFilename(path);
 
     // check if file exists
-    if (! FileUtils::getInstance()->isFileExist( fullpath )) {
+    if ( fullpath.empty() || ! FileUtils::getInstance()->isFileExist( fullpath ) ) {
         callback(nullptr);
         return;
     }

--- a/cocos/renderer/CCTextureCache.cpp
+++ b/cocos/renderer/CCTextureCache.cpp
@@ -108,13 +108,13 @@ void TextureCache::addImageAsync(const std::string &path, const std::function<vo
 
     if (texture != nullptr)
     {
-        callback(texture);
+        if (callback) callback(texture);
         return;
     }
 
     // check if file exists
     if ( fullpath.empty() || ! FileUtils::getInstance()->isFileExist( fullpath ) ) {
-        callback(nullptr);
+        if (callback) callback(nullptr);
         return;
     }
 

--- a/cocos/renderer/CCTextureCache.cpp
+++ b/cocos/renderer/CCTextureCache.cpp
@@ -102,12 +102,6 @@ void TextureCache::addImageAsync(const std::string &path, const std::function<vo
 
     std::string fullpath = FileUtils::getInstance()->fullPathForFilename(path);
 
-    // check if file exists
-    if ( fullpath.empty() || ! FileUtils::getInstance()->isFileExist( fullpath ) ) {
-        callback(nullptr);
-        return;
-    }
-    
     auto it = _textures.find(fullpath);
     if( it != _textures.end() )
         texture = it->second;
@@ -118,7 +112,11 @@ void TextureCache::addImageAsync(const std::string &path, const std::function<vo
         return;
     }
 
-    // ALTERNATIVE: insert file exists check here to allow loading cached but deleted file
+    // check if file exists
+    if ( fullpath.empty() || ! FileUtils::getInstance()->isFileExist( fullpath ) ) {
+        callback(nullptr);
+        return;
+    }
 
     // lazy init
     if (_asyncStructQueue == nullptr)


### PR DESCRIPTION
This adds a callback with nullptr if the file does not exists.  Checking this before checking cache means that if a file is cached then deleted, the async call will fail.  To allow a cached but deleted file to return the texture, move the isFileExist check to ALTERNATIVE.

If leaving check where it is, on failure should it also check if the file was cached and remove it?
