### PR TITLE
Fix typo in AUTHORS.txt

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,6 +1,6 @@
 cocos2d-x authors & contributors
 
-(ordered by the join in time)
+(ordered by join time)
 
 Core Developers:
     Ricardo Quesada


### PR DESCRIPTION
Altered sentence explaining how authors were ordered so as to fix its grammar and more clearly convey its meaning.
