### PR TITLE
V3: Removed obsolete winrt override of setViewPortInPoints

### DIFF
--- a/cocos/platform/winrt/CCGLViewImpl-winrt.cpp
+++ b/cocos/platform/winrt/CCGLViewImpl-winrt.cpp
@@ -470,22 +470,6 @@ Vec2 GLViewImpl::GetPoint(PointerEventArgs^ args) {
 }
 
 
-void GLViewImpl::setViewPortInPoints(float x , float y , float w , float h)
-{
-    glViewport((GLint) (x * _scaleX + _viewPortRect.origin.x),
-        (GLint) (y * _scaleY + _viewPortRect.origin.y),
-        (GLsizei) (w * _scaleX),
-        (GLsizei) (h * _scaleY));
-}
-
-void GLViewImpl::setScissorInPoints(float x , float y , float w , float h)
-{
-    glScissor((GLint) (x * _scaleX + _viewPortRect.origin.x),
-        (GLint) (y * _scaleY + _viewPortRect.origin.y),
-        (GLsizei) (w * _scaleX),
-        (GLsizei) (h * _scaleY));
-}
-
 void GLViewImpl::QueueBackKeyPress()
 {
     std::shared_ptr<BackButtonEvent> e(new BackButtonEvent());

--- a/cocos/platform/winrt/CCGLViewImpl-winrt.h
+++ b/cocos/platform/winrt/CCGLViewImpl-winrt.h
@@ -52,8 +52,6 @@ public:
     virtual bool isOpenGLReady();
     virtual void end();
     virtual void swapBuffers();
-    virtual void setViewPortInPoints(float x , float y , float w , float h);
-    virtual void setScissorInPoints(float x , float y , float w , float h);
 
     Windows::Graphics::Display::DisplayOrientations getDeviceOrientation() {return m_orientation;};
     Size getRenerTargetSize() const { return Size(m_width, m_height); }


### PR DESCRIPTION
This pull request fixed the broken rendering in Windows Universal Apps caused by the recent updates to the Frame Buffer (https://github.com/cocos2d/cocos2d-x/pull/11892) GLViewImpl::setViewPortInPoints() in CCGLViewImpl-winrt.cpp was using obsolete code. The method was removed so the correct base implementation will be used.

The Universal Apps will not render without this fix.
