### PR TITLE
Fix when button reader bug

### DIFF
--- a/cocos/editor-support/cocostudio/WidgetReader/ButtonReader/ButtonReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/ButtonReader/ButtonReader.cpp
@@ -929,6 +929,8 @@ namespace cocostudio
             Size contentSize(options->widgetOptions()->size()->width(), options->widgetOptions()->size()->height());
             button->setContentSize(contentSize);
         }
+
+        button->setBright(displaystate);
     }
     
     Node* ButtonReader::createNodeWithFlatBuffers(const flatbuffers::Table *buttonOptions)


### PR DESCRIPTION
Fix when button set to disabled mode and won't have a disable texture will cause simulator won't show button in disabled gray mode
