### PR TITLE
SpriteFrameCache support async load

### DIFF
--- a/cocos/2d/CCSpriteFrameCache.cpp
+++ b/cocos/2d/CCSpriteFrameCache.cpp
@@ -188,7 +188,7 @@ void SpriteFrameCache::addSpriteFramesWithDictionary(ValueMap& dictionary, Textu
 
                 _spriteFramesAliases[oneAlias] = Value(spriteFrameName);
             }
-
+            
             // create frame
             spriteFrame = SpriteFrame::createWithTexture(texture,
                                                          Rect(textureRect.origin.x, textureRect.origin.y, spriteSize.width, spriteSize.height),
@@ -339,14 +339,14 @@ void SpriteFrameCache::removeUnusedSpriteFrames()
         if( spriteFrame->getReferenceCount() == 1 )
         {
             toRemoveFrames.push_back(iter->first);
-            spriteFrame->getTexture()->removeSpriteFrameCapInset(spriteFrame);
+           spriteFrame->getTexture()->removeSpriteFrameCapInset(spriteFrame);
             CCLOG("cocos2d: SpriteFrameCache: removing unused frame: %s", iter->first.c_str());
             removed = true;
         }
     }
 
     _spriteFrames.erase(toRemoveFrames);
-
+    
     // FIXME:. Since we don't know the .plist file that originated the frame, we must remove all .plist from the cache
     if( removed )
     {
@@ -460,6 +460,19 @@ SpriteFrame* SpriteFrameCache::getSpriteFrameByName(const std::string& name)
     return frame;
 }
 
+struct AsyncLoadParam
+{
+    std::function<void(void*, bool)> afterLoadCallback; // callback after load
+    void*                           callbackParam;
+    bool                            resultTexture; // texture load result
+    bool                            resultPList; // plist load result
+    std::string                     plist;
+    std::string                     textureFileName;
+
+    cocos2d::ValueMap               dictionary;
+    cocos2d::Texture2D*             texture;
+    Image*                          image;
+};
 void SpriteFrameCache::addSpriteFramesWithFileAsync(const std::string& plist, const std::string& textureFileName, const std::function<void(void*, bool)>& callback, void* callbackparam)
 {
     if (_loadedFileNames->find(plist) != _loadedFileNames->end())

--- a/cocos/2d/CCSpriteFrameCache.h
+++ b/cocos/2d/CCSpriteFrameCache.h
@@ -114,6 +114,16 @@ public:
      */
     void addSpriteFramesWithFile(const std::string& plist, const std::string& textureFileName);
 
+    /** Adds multiple Sprite Frames from a plist file asynchronously. The texture will be associated with the created sprite frames.
+    * Otherwise it will load the plist file in a new thread, and when the plist and texture is loaded, the callback will be called with the userdefined parameter.
+    * The callback will be called from the main thread, so it is safe to create any cocos2d object from the callback.
+    * @param plist file to be loaded
+    * @param textureFileName texture file to be loaded
+    * @param callback callback after loading
+    * @param callbackparam user defined parameter for the callback
+    */
+    void addSpriteFramesWithFileAsync(const std::string& plist, const std::string& textureFileName, const std::function<void(void*, bool)>& callback, void* callbackparam);
+
     /** Adds multiple Sprite Frames from a plist file. The texture will be associated with the created sprite frames. 
      * @js addSpriteFrames
      * @lua addSpriteFrames
@@ -223,10 +233,25 @@ protected:
     */
     void removeSpriteFramesFromDictionary(ValueMap& dictionary);
 
+    void afterAsyncLoad(void* param);
 
     Map<std::string, SpriteFrame*> _spriteFrames;
     ValueMap _spriteFramesAliases;
     std::set<std::string>*  _loadedFileNames;
+
+    struct AsyncLoadParam
+    {
+        std::function<void(void*, bool)> afterLoadCallback; // callback after load
+        void*                           callbackParam;
+        bool                            resultTexture; // texture load result
+        bool                            resultPList; // plist load result
+        std::string                     plist;
+        std::string                     textureFileName;
+
+        cocos2d::ValueMap               dictionary;
+        cocos2d::Texture2D*             texture;
+        Image*                          image;
+    };
 };
 
 // end of _2d group

--- a/cocos/2d/CCSpriteFrameCache.h
+++ b/cocos/2d/CCSpriteFrameCache.h
@@ -218,7 +218,7 @@ public:
     SpriteFrame* getSpriteFrameByName(const std::string& name);
 
     /** @deprecated use getSpriteFrameByName() instead */
-    CC_DEPRECATED_ATTRIBUTE SpriteFrame* spriteFrameByName(const std::string&name) { return getSpriteFrameByName(name); }
+	CC_DEPRECATED_ATTRIBUTE SpriteFrame* spriteFrameByName(const std::string&name) { return getSpriteFrameByName(name); }
 
 protected:
     // MARMALADE: Made this protected not private, as deriving from this class is pretty useful
@@ -238,20 +238,6 @@ protected:
     Map<std::string, SpriteFrame*> _spriteFrames;
     ValueMap _spriteFramesAliases;
     std::set<std::string>*  _loadedFileNames;
-
-    struct AsyncLoadParam
-    {
-        std::function<void(void*, bool)> afterLoadCallback; // callback after load
-        void*                           callbackParam;
-        bool                            resultTexture; // texture load result
-        bool                            resultPList; // plist load result
-        std::string                     plist;
-        std::string                     textureFileName;
-
-        cocos2d::ValueMap               dictionary;
-        cocos2d::Texture2D*             texture;
-        Image*                          image;
-    };
 };
 
 // end of _2d group

--- a/cocos/platform/CCImage.h
+++ b/cocos/platform/CCImage.h
@@ -63,6 +63,7 @@ class CC_DLL Image : public Ref
 {
 public:
     friend class TextureCache;
+    friend class SpriteFrameCache;
     /**
      * @js ctor
      */


### PR DESCRIPTION
Async based on Sprite3D and TextureCache.
Load texture and plist file in AsyncTaskPool TASK_IO thread.
Add TextureCache image and generate Sprite Frames in main thread.

update it: #10911
