### PR TITLE
Warning use deprecated setResponseCallback

### DIFF
--- a/cocos/network/HttpRequest.h
+++ b/cocos/network/HttpRequest.h
@@ -242,7 +242,13 @@ public:
      */
     CC_DEPRECATED_ATTRIBUTE inline void setResponseCallback(Ref* pTarget, SEL_CallFuncND pSelector)
     {
-        setResponseCallback(pTarget, (SEL_HttpResponse) pSelector);
+        _pTarget = pTarget;
+        _pSelector = (SEL_HttpResponse)pSelector;
+
+        if (_pTarget)
+        {
+            _pTarget->retain();
+        }
     }
     
     /**


### PR DESCRIPTION
One deprecated method uses other deprecated method. It show as warning
compilation
