### PR TITLE
V3: Fix Windows 10 UWP build by adding missing external/clipper files

### DIFF
--- a/cocos/2d/libcocos2d_8_1/libcocos2d_8_1/libcocos2d_8_1.Shared/libcocos2d_8_1.Shared.vcxitems.filters
+++ b/cocos/2d/libcocos2d_8_1/libcocos2d_8_1/libcocos2d_8_1.Shared/libcocos2d_8_1.Shared.vcxitems.filters
@@ -1836,8 +1836,10 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\..\..\physics3d\CCPhysicsSprite3D.h">
       <Filter>physics3d</Filter>
     </ClInclude>
-    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\..\..\..\external\clipper\clipper.hpp" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\..\CCAutoPolygon.h" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\..\..\..\external\clipper\clipper.hpp">
+      <Filter>external\clipper</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\..\..\cocos2d.cpp">
@@ -3501,8 +3503,10 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\..\..\base\CCUserDefault-winrt.cpp">
       <Filter>base</Filter>
     </ClCompile>
-    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\..\..\..\external\clipper\clipper.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\..\CCAutoPolygon.cpp" />
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\..\..\..\external\clipper\clipper.cpp">
+      <Filter>external\clipper</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="2d">

--- a/cocos/2d/libcocos2d_win10/libcocos2d.vcxproj
+++ b/cocos/2d/libcocos2d_win10/libcocos2d.vcxproj
@@ -195,6 +195,7 @@
     <ClCompile Include="..\..\..\extensions\Particle3D\PU\CCPUVortexAffectorTranslator.cpp" />
     <ClCompile Include="..\..\..\extensions\physics-nodes\CCPhysicsDebugNode.cpp" />
     <ClCompile Include="..\..\..\extensions\physics-nodes\CCPhysicsSprite.cpp" />
+    <ClCompile Include="..\..\..\external\clipper\clipper.cpp" />
     <ClCompile Include="..\..\..\external\ConvertUTF\ConvertUTF.c">
       <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">false</CompileAsWinRT>
       <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">false</CompileAsWinRT>
@@ -662,6 +663,7 @@
     <ClCompile Include="..\CCAnimation.cpp" />
     <ClCompile Include="..\CCAnimationCache.cpp" />
     <ClCompile Include="..\CCAtlasNode.cpp" />
+    <ClCompile Include="..\CCAutoPolygon.cpp" />
     <ClCompile Include="..\CCCamera.cpp" />
     <ClCompile Include="..\CCClippingNode.cpp" />
     <ClCompile Include="..\CCClippingRectangleNode.cpp" />
@@ -715,9 +717,6 @@
     <ClCompile Include="..\CCTransitionPageTurn.cpp" />
     <ClCompile Include="..\CCTransitionProgress.cpp" />
     <ClCompile Include="..\CCTweenFunction.cpp" />
-    <ClCompile Include="..\MarchingSquare.cpp" />
-    <ClCompile Include="..\SpritePolygon.cpp" />
-    <ClCompile Include="..\SpritePolygonCache.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\..\extensions\cocos-ext.h" />
@@ -892,6 +891,7 @@
     <ClInclude Include="..\..\..\extensions\Particle3D\PU\CCPUVortexAffectorTranslator.h" />
     <ClInclude Include="..\..\..\extensions\physics-nodes\CCPhysicsDebugNode.h" />
     <ClInclude Include="..\..\..\extensions\physics-nodes\CCPhysicsSprite.h" />
+    <ClInclude Include="..\..\..\external\clipper\clipper.hpp" />
     <ClInclude Include="..\..\..\external\ConvertUTF\ConvertUTF.h" />
     <ClInclude Include="..\..\..\external\edtaa3func\edtaa3func.h" />
     <ClInclude Include="..\..\..\external\flatbuffers\flatbuffers.h" />
@@ -1203,6 +1203,7 @@
     <ClInclude Include="..\..\platform\winrt\WICImageLoader-winrt.h" />
     <ClInclude Include="..\..\renderer\CCBatchCommand.h" />
     <ClInclude Include="..\..\renderer\CCCustomCommand.h" />
+    <ClInclude Include="..\CCAutoPolygon.h" />
     <ClInclude Include="..\renderer\CCFrameBuffer.h" />
     <ClInclude Include="..\..\renderer\CCGLProgram.h" />
     <ClInclude Include="..\..\renderer\CCGLProgramCache.h" />
@@ -1328,9 +1329,6 @@
     <ClInclude Include="..\CCTransitionPageTurn.h" />
     <ClInclude Include="..\CCTransitionProgress.h" />
     <ClInclude Include="..\CCTweenFunction.h" />
-    <ClInclude Include="..\MarchingSquare.h" />
-    <ClInclude Include="..\SpritePolygon.h" />
-    <ClInclude Include="..\SpritePolygonCache.h" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\base\CCController-iOS.mm" />

--- a/cocos/2d/libcocos2d_win10/libcocos2d.vcxproj.filters
+++ b/cocos/2d/libcocos2d_win10/libcocos2d.vcxproj.filters
@@ -251,6 +251,9 @@
     <Filter Include="navmesh">
       <UniqueIdentifier>{cc4f6ca9-4231-479d-8e19-ede4dff3382e}</UniqueIdentifier>
     </Filter>
+    <Filter Include="external\clipper">
+      <UniqueIdentifier>{e3a5fe25-a92e-4c98-9026-782b2b5b1388}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\cocos2d.cpp" />
@@ -1797,15 +1800,6 @@
     <ClCompile Include="..\..\platform\winrt\WICImageLoader-winrt.cpp">
       <Filter>platform\winrt</Filter>
     </ClCompile>
-    <ClCompile Include="..\MarchingSquare.cpp">
-      <Filter>2d</Filter>
-    </ClCompile>
-    <ClCompile Include="..\SpritePolygon.cpp">
-      <Filter>2d</Filter>
-    </ClCompile>
-    <ClCompile Include="..\SpritePolygonCache.cpp">
-      <Filter>2d</Filter>
-    </ClCompile>
     <ClCompile Include="..\..\..\external\poly2tri\common\shapes.cc">
       <Filter>external\poly2tri\common</Filter>
     </ClCompile>
@@ -1902,6 +1896,12 @@
     </ClCompile>
     <ClCompile Include="..\..\navmesh\CCNavMeshUtils.cpp">
       <Filter>navmesh</Filter>
+    </ClCompile>
+    <ClCompile Include="..\CCAutoPolygon.cpp">
+      <Filter>2d</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\external\clipper\clipper.cpp">
+      <Filter>external\clipper</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
@@ -3629,15 +3629,6 @@
     <ClInclude Include="..\..\platform\winrt\WICImageLoader-winrt.h">
       <Filter>platform\winrt</Filter>
     </ClInclude>
-    <ClInclude Include="..\MarchingSquare.h">
-      <Filter>2d</Filter>
-    </ClInclude>
-    <ClInclude Include="..\SpritePolygon.h">
-      <Filter>2d</Filter>
-    </ClInclude>
-    <ClInclude Include="..\SpritePolygonCache.h">
-      <Filter>2d</Filter>
-    </ClInclude>
     <ClInclude Include="..\..\..\external\poly2tri\poly2tri.h">
       <Filter>external\poly2tri</Filter>
     </ClInclude>
@@ -3733,6 +3724,12 @@
     </ClInclude>
     <ClInclude Include="..\..\navmesh\CCNavMeshUtils.h">
       <Filter>navmesh</Filter>
+    </ClInclude>
+    <ClInclude Include="..\CCAutoPolygon.h">
+      <Filter>2d</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\external\clipper\clipper.hpp">
+      <Filter>external\clipper</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
This pull request fixes the Windows 10 UWP build by adding the missing external/clipper files and removing some obsolete files from the solution..
