### PR TITLE
Update README.md: Initialize all submodules after cloning

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,16 +27,12 @@ Git user attention
 
 1. Clone the repo from GitHub.
 
-         $ git clone https://github.com/cocos2d/cocos2d-x.git
+         $ git clone --recurse-submodules https://github.com/cocos2d/cocos2d-x.git
 
 2. After cloning the repo, please execute `download-deps.py` to download and install dependencies.
 
          $ cd cocos2d-x
          cocos2d-x $ python download-deps.py
-
-3. After running `download-deps.py`.
-
-         cocos2d-x $ git submodule update --init
 
 How to start a new game
 -----------------------


### PR DESCRIPTION
This change allows the user to clone and initialize the submodules in one step instead of two separate. 

**man git-clone**

```
--recursive, --recurse-submodules
       After the clone is created, initialize all submodules within, using their default settings. This is equivalent to running git submodule update --init --recursive immediately after the clone is finished. 
```
