### PR TITLE
Set DEBUG_MODE on or off based on CMAKE_BUILD_TYPE

### DIFF
--- a/templates/cpp-template-default/CMakeLists.txt
+++ b/templates/cpp-template-default/CMakeLists.txt
@@ -37,6 +37,11 @@ include(CocosBuildHelpers)
 set(BUILD_CPP_TESTS OFF CACHE BOOL "turn off build cpp-tests")
 set(BUILD_LUA_LIBS OFF CACHE BOOL "turn off build lua related targets")
 set(BUILD_JS_LIBS OFF CACHE BOOL "turn off build js related targets")
+if (CMAKE_BUILD_TYPE STREQUAL "Debug")
+  set(DEBUG_MODE ON CACHE BOOL "turn on debug mode")
+else()
+  set(DEBUG_MODE OFF CACHE BOOL "turn off debug mode")
+endif()
 add_subdirectory(${COCOS2D_ROOT})
 
 # Some macro definitions


### PR DESCRIPTION
When setting the CMAKE_BUILD_TYPE with Cmake parameter the setting gets overwritten by the option in cocos2d/CMakeLists.txt. With this, If the developer specifies that it should be a release build with `-DCMAKE_BUILD_TYPE=RelWithDebInfo` or `-DCMAKE_BUILD_TYPE=Release` DEBUG_MODE is set to OFF, other wise it stays on because it's the default value in cocos2d/CMakeLists.txt.
