### PR TITLE
Allow optional custom logging function.

### DIFF
--- a/cocos/base/CCConsole.cpp
+++ b/cocos/base/CCConsole.cpp
@@ -233,11 +233,24 @@ void SendLogToWindow(const char *log)
 // Free functions to log
 //
 
+static CC_LOG_FUNCPTR _customLogFunc = nullptr;
+
+void logSetCustomFunction(CC_LOG_FUNCPTR logFunc)
+{
+    _customLogFunc = logFunc;
+}
+
 static void _log(const char *format, va_list args)
 {
     char buf[MAX_LOG_LENGTH];
 
     vsnprintf(buf, MAX_LOG_LENGTH-3, format, args);
+    
+    if (_customLogFunc != nullptr) {
+        _customLogFunc(buf);
+        return;
+    }
+    
     strcat(buf, "\n");
 
 #if CC_TARGET_PLATFORM == CC_PLATFORM_ANDROID

--- a/cocos/base/CCConsole.h
+++ b/cocos/base/CCConsole.h
@@ -56,6 +56,9 @@ NS_CC_BEGIN
 /// The max length of CCLog message.
 static const int MAX_LOG_LENGTH = 16*1024;
 
+typedef void (*CC_LOG_FUNCPTR)(const char *message);
+void CC_DLL logSetCustomFunction(CC_LOG_FUNCPTR logFunc);
+
 /**
  @brief Output Debug message.
  */


### PR DESCRIPTION
Allowing the setting of an optional custom logging function means all cocos2d-x logging messages can be processed by the game, thereby allowing low-level errors to be visible to crash reporting frameworks, for example.
