### PR TITLE
fix nine patch image parser error on Windows.

### DIFF
--- a/cocos/renderer/CCTexture2D.cpp
+++ b/cocos/renderer/CCTexture2D.cpp
@@ -1427,7 +1427,7 @@ const Rect& Texture2D::getSpriteFrameCapInset( cocos2d::SpriteFrame *spriteFrame
     }
     else
     {
-        auto capInsetMap = this->_ninePatchInfo->capInsetMap;
+        auto &capInsetMap = this->_ninePatchInfo->capInsetMap;
         if(capInsetMap.find(spriteFrame) != capInsetMap.end())
         {
             return capInsetMap.at(spriteFrame);

--- a/cocos/ui/UIScale9Sprite.cpp
+++ b/cocos/ui/UIScale9Sprite.cpp
@@ -151,7 +151,7 @@ namespace ui {
             auto spriteFrame = sprite->getSpriteFrame();
             if (texture->isContain9PatchInfo())
             {
-                auto parsedCapInset = texture->getSpriteFrameCapInset(spriteFrame);
+                auto& parsedCapInset = texture->getSpriteFrameCapInset(spriteFrame);
                 if(!parsedCapInset.equals(Rect::ZERO))
                 {
                     this->_isPatch9 = true;


### PR DESCRIPTION
fix NinePatchImage missing two images on Windows 
