### PR TITLE
SpriteFrameCache support async load

### DIFF
--- a/cocos/2d/CCSpriteFrameCache.h
+++ b/cocos/2d/CCSpriteFrameCache.h
@@ -114,6 +114,16 @@ public:
      */
     void addSpriteFramesWithFile(const std::string& plist, const std::string& textureFileName);
 
+    /** Adds multiple Sprite Frames from a plist file asynchronously. The texture will be associated with the created sprite frames.
+    * Otherwise it will load the plist file in a new thread, and when the plist and texture is loaded, the callback will be called with the userdefined parameter.
+    * The callback will be called from the main thread, so it is safe to create any cocos2d object from the callback.
+    * @param plist file to be loaded
+    * @param textureFileName texture file to be loaded
+    * @param callback callback after loading
+    * @param callbackparam user defined parameter for the callback
+    */
+    void addSpriteFramesWithFileAsync(const std::string& plist, const std::string& textureFileName, const std::function<void(void*, bool)>& callback, void* callbackparam);
+
     /** Adds multiple Sprite Frames from a plist file. The texture will be associated with the created sprite frames. 
      * @js addSpriteFrames
      * @lua addSpriteFrames
@@ -223,10 +233,25 @@ protected:
     */
     void removeSpriteFramesFromDictionary(ValueMap& dictionary);
 
+    void afterAsyncLoad(void* param);
 
     Map<std::string, SpriteFrame*> _spriteFrames;
     ValueMap _spriteFramesAliases;
     std::set<std::string>*  _loadedFileNames;
+
+    struct AsyncLoadParam
+    {
+        std::function<void(void*, bool)> afterLoadCallback; // callback after load
+        void*                           callbackParam;
+        bool                            resultTexture; // texture load result
+        bool                            resultPList; // plist load result
+        std::string                     plist;
+        std::string                     textureFileName;
+
+        cocos2d::ValueMap               dictionary;
+        cocos2d::Texture2D*             texture;
+        Image*                          image;
+    };
 };
 
 // end of _2d group

--- a/cocos/platform/CCImage.h
+++ b/cocos/platform/CCImage.h
@@ -63,6 +63,7 @@ class CC_DLL Image : public Ref
 {
 public:
     friend class TextureCache;
+    friend class SpriteFrameCache;
     /**
      * @js ctor
      */


### PR DESCRIPTION
Async based on Sprite3D and TextureCache.
Load texture and plist file in AsyncTaskPool TASK_IO thread.
Add TextureCache image and generate Sprite Frames in main thread.

update it: #12367
