### PR TITLE
V3 winrt js keyboard support

### DIFF
--- a/cocos/scripting/js-bindings/script/jsb_boot.js
+++ b/cocos/scripting/js-bindings/script/jsb_boot.js
@@ -1477,12 +1477,15 @@ cc._initSys = function(config, CONFIG_KEY){
     if( locSys.isMobile ) {
         capabilities["accelerometer"] = true;
         capabilities["touches"] = true;
+        if (platform === locSys.WINRT || platform === locSys.WP8) {
+            capabilities["keyboard"] = true;
+        }
     } else {
         // desktop
         capabilities["keyboard"] = true;
         capabilities["mouse"] = true;
         // winrt can't suppot mouse in current version
-        if (platform === locSys.WINRT)
+        if (platform === locSys.WINRT || platform === locSys.WP8)
         {
             capabilities["touches"] = true;
             capabilities["mouse"] = false;


### PR DESCRIPTION
This pull requests enables keyboard support for WinRT platforms in cocos2d-js. We need to enable keyboard so the app can receive back button events on Windows Phones.
