### PR TITLE
AudioEngine:Fixed play audio may fail(error code:-1) on iOS

### DIFF
--- a/cocos/audio/apple/AudioEngine-inl.h
+++ b/cocos/audio/apple/AudioEngine-inl.h
@@ -36,7 +36,7 @@
 
 NS_CC_BEGIN
     namespace experimental{
-#define MAX_AUDIOINSTANCES 32
+#define MAX_AUDIOINSTANCES 24
 
 class AudioEngineThreadPool;
 


### PR DESCRIPTION
Tested iPhone 4s(iOS 7.1.2) 
Tested iPhone 5s(iOS 8.3)
Tested iPhone 6s(iOS 8.3)
