### PR TITLE
Ensure CCLabel atlases are purged before resetting

### DIFF
--- a/cocos/2d/CCLabel.cpp
+++ b/cocos/2d/CCLabel.cpp
@@ -262,7 +262,7 @@ Label::Label(FontAtlas *atlas /* = nullptr */, TextHAlignment hAlignment /* = Te
     setAnchorPoint(Vec2::ANCHOR_MIDDLE);
     reset();
 
-    auto purgeTextureListener = EventListenerCustom::create(FontAtlas::CMD_PURGE_FONTATLAS, [this](EventCustom* event){
+    _purgeTextureListener = EventListenerCustom::create(FontAtlas::CMD_PURGE_FONTATLAS, [this](EventCustom* event){
         if (_fontAtlas && _currentLabelType == LabelType::TTF && event->getUserData() == _fontAtlas)
         {
             Node::removeAllChildrenWithCleanup(true);
@@ -275,16 +275,16 @@ Label::Label(FontAtlas *atlas /* = nullptr */, TextHAlignment hAlignment /* = Te
             }
         }
     });
-    _eventDispatcher->addEventListenerWithSceneGraphPriority(purgeTextureListener, this);
+    _eventDispatcher->addEventListenerWithFixedPriority(_purgeTextureListener, 1);
     
-    auto resetTextureListener = EventListenerCustom::create(FontAtlas::CMD_RESET_FONTATLAS, [this](EventCustom* event){
+    _resetTextureListener = EventListenerCustom::create(FontAtlas::CMD_RESET_FONTATLAS, [this](EventCustom* event){
         if (_fontAtlas && _currentLabelType == LabelType::TTF && event->getUserData() == _fontAtlas)
         {
             _fontAtlas = nullptr;
             this->setTTFConfig(_fontConfig);
         }
     });
-    _eventDispatcher->addEventListenerWithSceneGraphPriority(resetTextureListener, this);
+    _eventDispatcher->addEventListenerWithFixedPriority(_resetTextureListener, 2);
 }
 
 Label::~Label()
@@ -294,6 +294,9 @@ Label::~Label()
     if (_fontAtlas)
     {
         FontAtlasCache::releaseFontAtlas(_fontAtlas);
+
+        _eventDispatcher->removeEventListener(_purgeTextureListener);
+        _eventDispatcher->removeEventListener(_resetTextureListener);
     }
 
     CC_SAFE_RELEASE_NULL(_reusedLetter);

--- a/cocos/2d/CCLabel.cpp
+++ b/cocos/2d/CCLabel.cpp
@@ -294,10 +294,9 @@ Label::~Label()
     if (_fontAtlas)
     {
         FontAtlasCache::releaseFontAtlas(_fontAtlas);
-
-        _eventDispatcher->removeEventListener(_purgeTextureListener);
-        _eventDispatcher->removeEventListener(_resetTextureListener);
     }
+    _eventDispatcher->removeEventListener(_purgeTextureListener);
+    _eventDispatcher->removeEventListener(_resetTextureListener);
 
     CC_SAFE_RELEASE_NULL(_reusedLetter);
 }

--- a/cocos/2d/CCLabel.h
+++ b/cocos/2d/CCLabel.h
@@ -546,6 +546,8 @@ protected:
     std::vector<SpriteBatchNode*> _batchNodes;
     FontAtlas *                   _fontAtlas;
     std::vector<LetterInfo>       _lettersInfo;
+    EventListenerCustom* _purgeTextureListener;
+    EventListenerCustom* _resetTextureListener;
 
     TTFConfig _fontConfig;
 


### PR DESCRIPTION
This is a fix for Github issue #8305

The current purge->reset behavior occurs per label according to scene
graph priority.  This has two disadvanages; firstly, any labels that are
initialized but not part of the scene graph will not be reset.
Secondly, any labels which share atlases in the FontAtlasCache may not
be reset since each label will call releaseFontAtlas individually before
resetting its fontConfig.  This means that any shared atlases may not be
released all the way to a reference count of 0 and the invalid atlas
will not be deleted and reset from scratch.

By putting a fixed priority on both the purge and reset steps we can
ensure that firstly: all labels will be reset regardless of whether they
have been added to the scene-graph.  Secondly, ALL labels with the same
atlas must call releaseFontAtlas before any others are allowed to
rebuild their textures.  This will prevent any old atlases from sticking
around after a new GL context is created.
