### PR TITLE
Sprite3D Clipping

### DIFF
--- a/cocos/2d/CCCamera.cpp
+++ b/cocos/2d/CCCamera.cpp
@@ -474,7 +474,7 @@ void Camera::clearBackground(float depth)
          The other values don't need to be updated since they were restored to their original values
          */
         glStencilMask(0xFFFFF);
-        RenderState::StateBlock::_defaultState->setStencilWrite(0xFFFFF);
+//        RenderState::StateBlock::_defaultState->setStencilWrite(0xFFFFF);
 
         /* BUG: RenderState does not support glColorMask yet. */
         glColorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);

--- a/cocos/2d/CCClippingNode.cpp
+++ b/cocos/2d/CCClippingNode.cpp
@@ -396,7 +396,7 @@ void ClippingNode::onBeforeVisit()
 
     // enable stencil use
     glEnable(GL_STENCIL_TEST);
-    RenderState::StateBlock::_defaultState->setStencilTest(true);
+//    RenderState::StateBlock::_defaultState->setStencilTest(true);
 
     // check for OpenGL error while enabling stencil test
     CHECK_GL_ERROR_DEBUG();
@@ -404,7 +404,7 @@ void ClippingNode::onBeforeVisit()
     // all bits on the stencil buffer are readonly, except the current layer bit,
     // this means that operation like glClear or glStencilOp will be masked with this value
     glStencilMask(mask_layer);
-    RenderState::StateBlock::_defaultState->setStencilWrite(mask_layer);
+//    RenderState::StateBlock::_defaultState->setStencilWrite(mask_layer);
 
     // manually save the depth test state
 
@@ -444,13 +444,13 @@ void ClippingNode::onBeforeVisit()
     //     if not in inverted mode: set the current layer value to 1 in the stencil buffer
     //     if in inverted mode: set the current layer value to 0 in the stencil buffer
     glStencilFunc(GL_NEVER, mask_layer, mask_layer);
-    RenderState::StateBlock::_defaultState->setStencilFunction(RenderState::STENCIL_NEVER, mask_layer, mask_layer);
+//    RenderState::StateBlock::_defaultState->setStencilFunction(RenderState::STENCIL_NEVER, mask_layer, mask_layer);
 
     glStencilOp(!_inverted ? GL_REPLACE : GL_ZERO, GL_KEEP, GL_KEEP);
-    RenderState::StateBlock::_defaultState->setStencilOperation(
-                                                                !_inverted ? RenderState::STENCIL_OP_REPLACE : RenderState::STENCIL_OP_ZERO,
-                                                                RenderState::STENCIL_OP_KEEP,
-                                                                RenderState::STENCIL_OP_KEEP);
+//    RenderState::StateBlock::_defaultState->setStencilOperation(
+//                                                                !_inverted ? RenderState::STENCIL_OP_REPLACE : RenderState::STENCIL_OP_ZERO,
+//                                                                RenderState::STENCIL_OP_KEEP,
+//                                                                RenderState::STENCIL_OP_KEEP);
 
 
     // enable alpha test only if the alpha threshold < 1,
@@ -508,10 +508,10 @@ void ClippingNode::onAfterDrawStencil()
     //     else
     //         do not draw the pixel but keep the current layer in the stencil buffer
     glStencilFunc(GL_EQUAL, _mask_layer_le, _mask_layer_le);
-    RenderState::StateBlock::_defaultState->setStencilFunction(RenderState::STENCIL_EQUAL, _mask_layer_le, _mask_layer_le);
+//    RenderState::StateBlock::_defaultState->setStencilFunction(RenderState::STENCIL_EQUAL, _mask_layer_le, _mask_layer_le);
 
     glStencilOp(GL_KEEP, GL_KEEP, GL_KEEP);
-    RenderState::StateBlock::_defaultState->setStencilOperation(RenderState::STENCIL_OP_KEEP, RenderState::STENCIL_OP_KEEP, RenderState::STENCIL_OP_KEEP);
+//    RenderState::StateBlock::_defaultState->setStencilOperation(RenderState::STENCIL_OP_KEEP, RenderState::STENCIL_OP_KEEP, RenderState::STENCIL_OP_KEEP);
 
     // draw (according to the stencil test func) this node and its childs
 }
@@ -524,18 +524,18 @@ void ClippingNode::onAfterVisit()
 
     // manually restore the stencil state
     glStencilFunc(_currentStencilFunc, _currentStencilRef, _currentStencilValueMask);
-    RenderState::StateBlock::_defaultState->setStencilFunction((RenderState::StencilFunction)_currentStencilFunc, _currentStencilRef, _currentStencilValueMask);
+//    RenderState::StateBlock::_defaultState->setStencilFunction((RenderState::StencilFunction)_currentStencilFunc, _currentStencilRef, _currentStencilValueMask);
 
     glStencilOp(_currentStencilFail, _currentStencilPassDepthFail, _currentStencilPassDepthPass);
-    RenderState::StateBlock::_defaultState->setStencilOperation((RenderState::StencilOperation)_currentStencilFail,
-                                                                (RenderState::StencilOperation)_currentStencilPassDepthFail,
-                                                                (RenderState::StencilOperation)_currentStencilPassDepthPass);
+//    RenderState::StateBlock::_defaultState->setStencilOperation((RenderState::StencilOperation)_currentStencilFail,
+//                                                                (RenderState::StencilOperation)_currentStencilPassDepthFail,
+//                                                                (RenderState::StencilOperation)_currentStencilPassDepthPass);
 
     glStencilMask(_currentStencilWriteMask);
     if (!_currentStencilEnabled)
     {
         glDisable(GL_STENCIL_TEST);
-        RenderState::StateBlock::_defaultState->setStencilTest(false);
+//        RenderState::StateBlock::_defaultState->setStencilTest(false);
     }
 
     // we are done using this layer, decrement

--- a/cocos/3d/CCMesh.cpp
+++ b/cocos/3d/CCMesh.cpp
@@ -127,6 +127,7 @@ Mesh::Mesh()
 , _blend(BlendFunc::ALPHA_NON_PREMULTIPLIED)
 , _visibleChanged(nullptr)
 , _blendDirty(true)
+, _force2DQueue(false)
 {
     
 }
@@ -354,6 +355,7 @@ void Mesh::draw(Renderer* renderer, float globalZOrder, const Mat4& transform, u
 
     _meshCommand.setSkipBatching(isTransparent);
     _meshCommand.setTransparent(isTransparent);
+    _meshCommand.set3D(!_force2DQueue);
 
     // set default uniforms for Mesh
     // 'u_color' and others

--- a/cocos/3d/CCMesh.h
+++ b/cocos/3d/CCMesh.h
@@ -189,6 +189,10 @@ public:
      */
     void calculateAABB();
     
+    /**
+     * force set this Sprite3D to 2D render queue
+     */
+    void setForce2DQueue(bool force2D) { _force2DQueue = force2D; }
 
 CC_CONSTRUCTOR_ACCESS:
 
@@ -203,6 +207,7 @@ protected:
     MeshSkin*           _skin;     //skin
     bool                _visible; // is the submesh visible
     bool                _isTransparent; // is this mesh transparent, it is a property of material in fact
+    bool                _force2DQueue; // add this mesh to 2D render queue
     
     std::string         _name;
     MeshCommand         _meshCommand;

--- a/cocos/3d/CCSprite3D.cpp
+++ b/cocos/3d/CCSprite3D.cpp
@@ -882,6 +882,13 @@ MeshSkin* Sprite3D::getSkin() const
     return nullptr;
 }
 
+void Sprite3D::setForce2DQueue(bool force2D)
+{
+    for (const auto &mesh : _meshes) {
+        mesh->setForce2DQueue(force2D);
+    }
+}
+
 ///////////////////////////////////////////////////////////////////////////////////
 Sprite3DCache* Sprite3DCache::_cacheInstance = nullptr;
 Sprite3DCache* Sprite3DCache::getInstance()

--- a/cocos/3d/CCSprite3D.h
+++ b/cocos/3d/CCSprite3D.h
@@ -194,6 +194,11 @@ public:
      if meshIndex == -1, then it will be applied to all the meshes that belong to the sprite.
      */
     Material* getMaterial(int meshIndex) const;
+    
+    /**
+    * force set this Sprite3D to 2D render queue
+    */
+    void setForce2DQueue(bool force2D);
 
 CC_CONSTRUCTOR_ACCESS:
     

--- a/cocos/renderer/CCRenderState.cpp
+++ b/cocos/renderer/CCRenderState.cpp
@@ -277,37 +277,37 @@ void RenderState::StateBlock::bindNoRestore()
         glDepthFunc((GLenum)_depthFunction);
         _defaultState->_depthFunction = _depthFunction;
     }
-    if ((_bits & RS_STENCIL_TEST) && (_stencilTestEnabled != _defaultState->_stencilTestEnabled))
-    {
-        if (_stencilTestEnabled)
-            glEnable(GL_STENCIL_TEST);
-        else
-            glDisable(GL_STENCIL_TEST);
-        _defaultState->_stencilTestEnabled = _stencilTestEnabled;
-    }
-    if ((_bits & RS_STENCIL_WRITE) && (_stencilWrite != _defaultState->_stencilWrite))
-    {
-        glStencilMask(_stencilWrite);
-        _defaultState->_stencilWrite = _stencilWrite;
-    }
-    if ((_bits & RS_STENCIL_FUNC) && (_stencilFunction != _defaultState->_stencilFunction ||
-                                      _stencilFunctionRef != _defaultState->_stencilFunctionRef ||
-                                      _stencilFunctionMask != _defaultState->_stencilFunctionMask))
-    {
-        glStencilFunc((GLenum)_stencilFunction, _stencilFunctionRef, _stencilFunctionMask);
-        _defaultState->_stencilFunction = _stencilFunction;
-        _defaultState->_stencilFunctionRef = _stencilFunctionRef;
-        _defaultState->_stencilFunctionMask = _stencilFunctionMask;
-    }
-    if ((_bits & RS_STENCIL_OP) && (_stencilOpSfail != _defaultState->_stencilOpSfail ||
-                                    _stencilOpDpfail != _defaultState->_stencilOpDpfail ||
-                                    _stencilOpDppass != _defaultState->_stencilOpDppass))
-    {
-        glStencilOp((GLenum)_stencilOpSfail, (GLenum)_stencilOpDpfail, (GLenum)_stencilOpDppass);
-        _defaultState->_stencilOpSfail = _stencilOpSfail;
-        _defaultState->_stencilOpDpfail = _stencilOpDpfail;
-        _defaultState->_stencilOpDppass = _stencilOpDppass;
-    }
+//    if ((_bits & RS_STENCIL_TEST) && (_stencilTestEnabled != _defaultState->_stencilTestEnabled))
+//    {
+//        if (_stencilTestEnabled)
+//            glEnable(GL_STENCIL_TEST);
+//        else
+//            glDisable(GL_STENCIL_TEST);
+//        _defaultState->_stencilTestEnabled = _stencilTestEnabled;
+//    }
+//    if ((_bits & RS_STENCIL_WRITE) && (_stencilWrite != _defaultState->_stencilWrite))
+//    {
+//        glStencilMask(_stencilWrite);
+//        _defaultState->_stencilWrite = _stencilWrite;
+//    }
+//    if ((_bits & RS_STENCIL_FUNC) && (_stencilFunction != _defaultState->_stencilFunction ||
+//                                      _stencilFunctionRef != _defaultState->_stencilFunctionRef ||
+//                                      _stencilFunctionMask != _defaultState->_stencilFunctionMask))
+//    {
+//        glStencilFunc((GLenum)_stencilFunction, _stencilFunctionRef, _stencilFunctionMask);
+//        _defaultState->_stencilFunction = _stencilFunction;
+//        _defaultState->_stencilFunctionRef = _stencilFunctionRef;
+//        _defaultState->_stencilFunctionMask = _stencilFunctionMask;
+//    }
+//    if ((_bits & RS_STENCIL_OP) && (_stencilOpSfail != _defaultState->_stencilOpSfail ||
+//                                    _stencilOpDpfail != _defaultState->_stencilOpDpfail ||
+//                                    _stencilOpDppass != _defaultState->_stencilOpDppass))
+//    {
+//        glStencilOp((GLenum)_stencilOpSfail, (GLenum)_stencilOpDpfail, (GLenum)_stencilOpDppass);
+//        _defaultState->_stencilOpSfail = _stencilOpSfail;
+//        _defaultState->_stencilOpDpfail = _stencilOpDpfail;
+//        _defaultState->_stencilOpDppass = _stencilOpDppass;
+//    }
 
     _defaultState->_bits |= _bits;
 }
@@ -373,34 +373,34 @@ void RenderState::StateBlock::restore(long stateOverrideBits)
         _defaultState->_bits &= ~RS_DEPTH_FUNC;
         _defaultState->_depthFunction = RenderState::DEPTH_LESS;
     }
-    if (!(stateOverrideBits & RS_STENCIL_TEST) && (_defaultState->_bits & RS_STENCIL_TEST))
-    {
-        glDisable(GL_STENCIL_TEST);
-        _defaultState->_bits &= ~RS_STENCIL_TEST;
-        _defaultState->_stencilTestEnabled = false;
-    }
-    if (!(stateOverrideBits & RS_STENCIL_WRITE) && (_defaultState->_bits & RS_STENCIL_WRITE))
-    {
-        glStencilMask(RS_ALL_ONES);
-        _defaultState->_bits &= ~RS_STENCIL_WRITE;
-        _defaultState->_stencilWrite = RS_ALL_ONES;
-    }
-    if (!(stateOverrideBits & RS_STENCIL_FUNC) && (_defaultState->_bits & RS_STENCIL_FUNC))
-    {
-        glStencilFunc((GLenum)RenderState::STENCIL_ALWAYS, 0, RS_ALL_ONES);
-        _defaultState->_bits &= ~RS_STENCIL_FUNC;
-        _defaultState->_stencilFunction = RenderState::STENCIL_ALWAYS;
-        _defaultState->_stencilFunctionRef = 0;
-        _defaultState->_stencilFunctionMask = RS_ALL_ONES;
-    }
-    if (!(stateOverrideBits & RS_STENCIL_OP) && (_defaultState->_bits & RS_STENCIL_OP))
-    {
-        glStencilOp((GLenum)RenderState::STENCIL_OP_KEEP, (GLenum)RenderState::STENCIL_OP_KEEP, (GLenum)RenderState::STENCIL_OP_KEEP);
-        _defaultState->_bits &= ~RS_STENCIL_OP;
-        _defaultState->_stencilOpSfail = RenderState::STENCIL_OP_KEEP;
-        _defaultState->_stencilOpDpfail = RenderState::STENCIL_OP_KEEP;
-        _defaultState->_stencilOpDppass = RenderState::STENCIL_OP_KEEP;
-    }
+//    if (!(stateOverrideBits & RS_STENCIL_TEST) && (_defaultState->_bits & RS_STENCIL_TEST))
+//    {
+//        glDisable(GL_STENCIL_TEST);
+//        _defaultState->_bits &= ~RS_STENCIL_TEST;
+//        _defaultState->_stencilTestEnabled = false;
+//    }
+//    if (!(stateOverrideBits & RS_STENCIL_WRITE) && (_defaultState->_bits & RS_STENCIL_WRITE))
+//    {
+//        glStencilMask(RS_ALL_ONES);
+//        _defaultState->_bits &= ~RS_STENCIL_WRITE;
+//        _defaultState->_stencilWrite = RS_ALL_ONES;
+//    }
+//    if (!(stateOverrideBits & RS_STENCIL_FUNC) && (_defaultState->_bits & RS_STENCIL_FUNC))
+//    {
+//        glStencilFunc((GLenum)RenderState::STENCIL_ALWAYS, 0, RS_ALL_ONES);
+//        _defaultState->_bits &= ~RS_STENCIL_FUNC;
+//        _defaultState->_stencilFunction = RenderState::STENCIL_ALWAYS;
+//        _defaultState->_stencilFunctionRef = 0;
+//        _defaultState->_stencilFunctionMask = RS_ALL_ONES;
+//    }
+//    if (!(stateOverrideBits & RS_STENCIL_OP) && (_defaultState->_bits & RS_STENCIL_OP))
+//    {
+//        glStencilOp((GLenum)RenderState::STENCIL_OP_KEEP, (GLenum)RenderState::STENCIL_OP_KEEP, (GLenum)RenderState::STENCIL_OP_KEEP);
+//        _defaultState->_bits &= ~RS_STENCIL_OP;
+//        _defaultState->_stencilOpSfail = RenderState::STENCIL_OP_KEEP;
+//        _defaultState->_stencilOpDpfail = RenderState::STENCIL_OP_KEEP;
+//        _defaultState->_stencilOpDppass = RenderState::STENCIL_OP_KEEP;
+//    }
 }
 
 void RenderState::StateBlock::enableDepthWrite()
@@ -662,38 +662,38 @@ void RenderState::StateBlock::setState(const std::string& name, const std::strin
     {
         setDepthFunction(parseDepthFunc(value));
     }
-    else if (name.compare("stencilTest") == 0)
-    {
-        setStencilTest(parseBoolean(value));
-    }
-    else if (name.compare("stencilWrite") == 0)
-    {
-        setStencilWrite(parseUInt(value));
-    }
-    else if (name.compare("stencilFunc") == 0)
-    {
-        setStencilFunction(parseStencilFunc(value), _stencilFunctionRef, _stencilFunctionMask);
-    }
-    else if (name.compare("stencilFuncRef") == 0)
-    {
-        setStencilFunction(_stencilFunction, parseInt(value), _stencilFunctionMask);
-    }
-    else if (name.compare("stencilFuncMask") == 0)
-    {
-        setStencilFunction(_stencilFunction, _stencilFunctionRef, parseUInt(value));
-    }
-    else if (name.compare("stencilOpSfail") == 0)
-    {
-        setStencilOperation(parseStencilOp(value), _stencilOpDpfail, _stencilOpDppass);
-    }
-    else if (name.compare("stencilOpDpfail") == 0)
-    {
-        setStencilOperation(_stencilOpSfail, parseStencilOp(value), _stencilOpDppass);
-    }
-    else if (name.compare("stencilOpDppass") == 0)
-    {
-        setStencilOperation(_stencilOpSfail, _stencilOpDpfail, parseStencilOp(value));
-    }
+//    else if (name.compare("stencilTest") == 0)
+//    {
+//        setStencilTest(parseBoolean(value));
+//    }
+//    else if (name.compare("stencilWrite") == 0)
+//    {
+//        setStencilWrite(parseUInt(value));
+//    }
+//    else if (name.compare("stencilFunc") == 0)
+//    {
+//        setStencilFunction(parseStencilFunc(value), _stencilFunctionRef, _stencilFunctionMask);
+//    }
+//    else if (name.compare("stencilFuncRef") == 0)
+//    {
+//        setStencilFunction(_stencilFunction, parseInt(value), _stencilFunctionMask);
+//    }
+//    else if (name.compare("stencilFuncMask") == 0)
+//    {
+//        setStencilFunction(_stencilFunction, _stencilFunctionRef, parseUInt(value));
+//    }
+//    else if (name.compare("stencilOpSfail") == 0)
+//    {
+//        setStencilOperation(parseStencilOp(value), _stencilOpDpfail, _stencilOpDppass);
+//    }
+//    else if (name.compare("stencilOpDpfail") == 0)
+//    {
+//        setStencilOperation(_stencilOpSfail, parseStencilOp(value), _stencilOpDppass);
+//    }
+//    else if (name.compare("stencilOpDppass") == 0)
+//    {
+//        setStencilOperation(_stencilOpSfail, _stencilOpDpfail, parseStencilOp(value));
+//    }
     else
     {
         CCLOG("Unsupported render state string '%s'.", name.c_str());
@@ -848,63 +848,63 @@ void RenderState::StateBlock::setDepthFunction(DepthFunction func)
     }
 }
 
-void RenderState::StateBlock::setStencilTest(bool enabled)
-{
-    _stencilTestEnabled = enabled;
-    if (!enabled)
-    {
-        _bits &= ~RS_STENCIL_TEST;
-    }
-    else
-    {
-        _bits |= RS_STENCIL_TEST;
-    }
-}
-
-void RenderState::StateBlock::setStencilWrite(unsigned int mask)
-{
-    _stencilWrite = mask;
-    if (mask == RS_ALL_ONES)
-    {
-        // Default stencil write
-        _bits &= ~RS_STENCIL_WRITE;
-    }
-    else
-    {
-        _bits |= RS_STENCIL_WRITE;
-    }
-}
-
-void RenderState::StateBlock::setStencilFunction(StencilFunction func, int ref, unsigned int mask)
-{
-    _stencilFunction = func;
-    _stencilFunctionRef = ref;
-    _stencilFunctionMask = mask;
-    if (func == STENCIL_ALWAYS && ref == 0 && mask == RS_ALL_ONES)
-    {
-        // Default stencil function
-        _bits &= ~RS_STENCIL_FUNC;
-    }
-    else
-    {
-        _bits |= RS_STENCIL_FUNC;
-    }
-}
-
-void RenderState::StateBlock::setStencilOperation(StencilOperation sfail, StencilOperation dpfail, StencilOperation dppass)
-{
-    _stencilOpSfail = sfail;
-    _stencilOpDpfail = dpfail;
-    _stencilOpDppass = dppass;
-    if (sfail == STENCIL_OP_KEEP && dpfail == STENCIL_OP_KEEP && dppass == STENCIL_OP_KEEP)
-    {
-        // Default stencil operation
-        _bits &= ~RS_STENCIL_OP;
-    }
-    else
-    {
-        _bits |= RS_STENCIL_OP;
-    }
-}
+//void RenderState::StateBlock::setStencilTest(bool enabled)
+//{
+//    _stencilTestEnabled = enabled;
+//    if (!enabled)
+//    {
+//        _bits &= ~RS_STENCIL_TEST;
+//    }
+//    else
+//    {
+//        _bits |= RS_STENCIL_TEST;
+//    }
+//}
+//
+//void RenderState::StateBlock::setStencilWrite(unsigned int mask)
+//{
+//    _stencilWrite = mask;
+//    if (mask == RS_ALL_ONES)
+//    {
+//        // Default stencil write
+//        _bits &= ~RS_STENCIL_WRITE;
+//    }
+//    else
+//    {
+//        _bits |= RS_STENCIL_WRITE;
+//    }
+//}
+//
+//void RenderState::StateBlock::setStencilFunction(StencilFunction func, int ref, unsigned int mask)
+//{
+//    _stencilFunction = func;
+//    _stencilFunctionRef = ref;
+//    _stencilFunctionMask = mask;
+//    if (func == STENCIL_ALWAYS && ref == 0 && mask == RS_ALL_ONES)
+//    {
+//        // Default stencil function
+//        _bits &= ~RS_STENCIL_FUNC;
+//    }
+//    else
+//    {
+//        _bits |= RS_STENCIL_FUNC;
+//    }
+//}
+//
+//void RenderState::StateBlock::setStencilOperation(StencilOperation sfail, StencilOperation dpfail, StencilOperation dppass)
+//{
+//    _stencilOpSfail = sfail;
+//    _stencilOpDpfail = dpfail;
+//    _stencilOpDppass = dppass;
+//    if (sfail == STENCIL_OP_KEEP && dpfail == STENCIL_OP_KEEP && dppass == STENCIL_OP_KEEP)
+//    {
+//        // Default stencil operation
+//        _bits &= ~RS_STENCIL_OP;
+//    }
+//    else
+//    {
+//        _bits |= RS_STENCIL_OP;
+//    }
+//}
 
 NS_CC_END

--- a/cocos/renderer/CCRenderState.h
+++ b/cocos/renderer/CCRenderState.h
@@ -301,45 +301,45 @@ public:
          */
         void setDepthFunction(DepthFunction func);
 
-        /**
-         * Toggles stencil testing.
-         *
-         * By default, stencil testing is disabled.
-         *
-         * @param enabled true to enable, false to disable.
-         */
-        void setStencilTest(bool enabled);
-
-        /**
-         * Sets the stencil writing mask.
-         *
-         * By default, the stencil writing mask is all 1's.
-         *
-         * @param mask Bit mask controlling writing to individual stencil planes.
-         */
-        void setStencilWrite(unsigned int mask);
-
-        /**
-         * Sets the stencil function.
-         *
-         * By default, the function is set to STENCIL_ALWAYS, the reference value is 0, and the mask is all 1's.
-         *
-         * @param func The stencil function.
-         * @param ref The stencil reference value.
-         * @param mask The stencil mask.
-         */
-        void setStencilFunction(StencilFunction func, int ref, unsigned int mask);
-
-        /**
-         * Sets the stencil operation.
-         *
-         * By default, stencil fail, stencil pass/depth fail, and stencil and depth pass are set to STENCIL_OP_KEEP.
-         *
-         * @param sfail The stencil operation if the stencil test fails.
-         * @param dpfail The stencil operation if the stencil test passes, but the depth test fails.
-         * @param dppass The stencil operation if both the stencil test and depth test pass.
-         */
-        void setStencilOperation(StencilOperation sfail, StencilOperation dpfail, StencilOperation dppass);
+//        /**
+//         * Toggles stencil testing.
+//         *
+//         * By default, stencil testing is disabled.
+//         *
+//         * @param enabled true to enable, false to disable.
+//         */
+//        void setStencilTest(bool enabled);
+//
+//        /**
+//         * Sets the stencil writing mask.
+//         *
+//         * By default, the stencil writing mask is all 1's.
+//         *
+//         * @param mask Bit mask controlling writing to individual stencil planes.
+//         */
+//        void setStencilWrite(unsigned int mask);
+//
+//        /**
+//         * Sets the stencil function.
+//         *
+//         * By default, the function is set to STENCIL_ALWAYS, the reference value is 0, and the mask is all 1's.
+//         *
+//         * @param func The stencil function.
+//         * @param ref The stencil reference value.
+//         * @param mask The stencil mask.
+//         */
+//        void setStencilFunction(StencilFunction func, int ref, unsigned int mask);
+//
+//        /**
+//         * Sets the stencil operation.
+//         *
+//         * By default, stencil fail, stencil pass/depth fail, and stencil and depth pass are set to STENCIL_OP_KEEP.
+//         *
+//         * @param sfail The stencil operation if the stencil test fails.
+//         * @param dpfail The stencil operation if the stencil test passes, but the depth test fails.
+//         * @param dppass The stencil operation if both the stencil test and depth test pass.
+//         */
+//        void setStencilOperation(StencilOperation sfail, StencilOperation dpfail, StencilOperation dppass);
 
         /**
          * Sets a render state from the given name and value strings.
@@ -366,10 +366,10 @@ public:
             RS_DEPTH_WRITE = (1 << 4),
             RS_DEPTH_FUNC = (1 << 5),
             RS_CULL_FACE_SIDE = (1 << 6),
-            RS_STENCIL_TEST = (1 << 7),
-            RS_STENCIL_WRITE = (1 << 8),
-            RS_STENCIL_FUNC = (1 << 9),
-            RS_STENCIL_OP = (1 << 10),
+//            RS_STENCIL_TEST = (1 << 7),
+//            RS_STENCIL_WRITE = (1 << 8),
+//            RS_STENCIL_FUNC = (1 << 9),
+//            RS_STENCIL_OP = (1 << 10),
             RS_FRONT_FACE = (1 << 11),
             
             RS_ALL_ONES = 0xFFFFFFFF,

--- a/cocos/ui/UILayout.cpp
+++ b/cocos/ui/UILayout.cpp
@@ -336,11 +336,11 @@ void Layout::onBeforeVisitStencil()
     glGetIntegerv(GL_STENCIL_PASS_DEPTH_PASS, (GLint *)&_currentStencilPassDepthPass);
     
     glEnable(GL_STENCIL_TEST);
-    RenderState::StateBlock::_defaultState->setStencilTest(true);
+//    RenderState::StateBlock::_defaultState->setStencilTest(true);
 
     CHECK_GL_ERROR_DEBUG();
     glStencilMask(mask_layer);
-    RenderState::StateBlock::_defaultState->setStencilWrite(mask_layer);
+//    RenderState::StateBlock::_defaultState->setStencilWrite(mask_layer);
 
     glGetBooleanv(GL_DEPTH_WRITEMASK, &_currentDepthWriteMask);
 
@@ -354,16 +354,16 @@ void Layout::onBeforeVisitStencil()
     this->drawFullScreenQuadClearStencil();
     
     glStencilFunc(GL_NEVER, mask_layer, mask_layer);
-    RenderState::StateBlock::_defaultState->setStencilFunction(
-                                                               RenderState::STENCIL_NEVER,
-                                                               mask_layer,
-                                                               mask_layer);
+//    RenderState::StateBlock::_defaultState->setStencilFunction(
+//                                                               RenderState::STENCIL_NEVER,
+//                                                               mask_layer,
+//                                                               mask_layer);
 
     glStencilOp(GL_REPLACE, GL_KEEP, GL_KEEP);
-    RenderState::StateBlock::_defaultState->setStencilOperation(
-                                                                RenderState::STENCIL_OP_REPLACE,
-                                                                RenderState::STENCIL_OP_KEEP,
-                                                                RenderState::STENCIL_OP_KEEP);
+//    RenderState::StateBlock::_defaultState->setStencilOperation(
+//                                                                RenderState::STENCIL_OP_REPLACE,
+//                                                                RenderState::STENCIL_OP_KEEP,
+//                                                                RenderState::STENCIL_OP_KEEP);
 }
     
 void Layout::drawFullScreenQuadClearStencil()
@@ -413,16 +413,16 @@ void Layout::onAfterDrawStencil()
     RenderState::StateBlock::_defaultState->setDepthWrite(_currentDepthWriteMask);
 
     glStencilFunc(GL_EQUAL, _mask_layer_le, _mask_layer_le);
-    RenderState::StateBlock::_defaultState->setStencilFunction(
-                                                                RenderState::STENCIL_EQUAL,
-                                                               _mask_layer_le,
-                                                               _mask_layer_le);
+//    RenderState::StateBlock::_defaultState->setStencilFunction(
+//                                                                RenderState::STENCIL_EQUAL,
+//                                                               _mask_layer_le,
+//                                                               _mask_layer_le);
 
     glStencilOp(GL_KEEP, GL_KEEP, GL_KEEP);
-    RenderState::StateBlock::_defaultState->setStencilOperation(
-                                                                RenderState::STENCIL_OP_KEEP,
-                                                                RenderState::STENCIL_OP_KEEP,
-                                                                RenderState::STENCIL_OP_KEEP);
+//    RenderState::StateBlock::_defaultState->setStencilOperation(
+//                                                                RenderState::STENCIL_OP_KEEP,
+//                                                                RenderState::STENCIL_OP_KEEP,
+//                                                                RenderState::STENCIL_OP_KEEP);
 
 }
 
@@ -430,22 +430,22 @@ void Layout::onAfterDrawStencil()
 void Layout::onAfterVisitStencil()
 {
     glStencilFunc(_currentStencilFunc, _currentStencilRef, _currentStencilValueMask);
-    RenderState::StateBlock::_defaultState->setStencilFunction(
-                                                               (RenderState::StencilFunction)_currentStencilFunc,
-                                                               _currentStencilRef,
-                                                               _currentStencilValueMask);
+//    RenderState::StateBlock::_defaultState->setStencilFunction(
+//                                                               (RenderState::StencilFunction)_currentStencilFunc,
+//                                                               _currentStencilRef,
+//                                                               _currentStencilValueMask);
 
     glStencilOp(_currentStencilFail, _currentStencilPassDepthFail, _currentStencilPassDepthPass);
-    RenderState::StateBlock::_defaultState->setStencilOperation(
-                                                                (RenderState::StencilOperation)_currentStencilFail,
-                                                                (RenderState::StencilOperation)_currentStencilPassDepthFail,
-                                                                (RenderState::StencilOperation)_currentStencilPassDepthPass);
+//    RenderState::StateBlock::_defaultState->setStencilOperation(
+//                                                                (RenderState::StencilOperation)_currentStencilFail,
+//                                                                (RenderState::StencilOperation)_currentStencilPassDepthFail,
+//                                                                (RenderState::StencilOperation)_currentStencilPassDepthPass);
 
     glStencilMask(_currentStencilWriteMask);
     if (!_currentStencilEnabled)
     {
         glDisable(GL_STENCIL_TEST);
-        RenderState::StateBlock::_defaultState->setStencilTest(false);
+//        RenderState::StateBlock::_defaultState->setStencilTest(false);
     }
     s_layer--;
 }

--- a/tests/cpp-tests/Classes/RenderTextureTest/RenderTextureTest.cpp
+++ b/tests/cpp-tests/Classes/RenderTextureTest/RenderTextureTest.cpp
@@ -465,7 +465,7 @@ void RenderTextureTestDepthStencil::onBeforeClear()
 
     // Since cocos2d-x v3.7, users should avoid calling GL directly because it will break the internal GL state
     // But if users must call GL directly, they should update the state manually,
-    RenderState::StateBlock::_defaultState->setStencilWrite(0xFF);
+//    RenderState::StateBlock::_defaultState->setStencilWrite(0xFF);
 }
 
 void RenderTextureTestDepthStencil::onBeforeStencil()
@@ -477,9 +477,9 @@ void RenderTextureTestDepthStencil::onBeforeStencil()
 
     // Since cocos2d-x v3.7, users should avoid calling GL directly because it will break the internal GL state
     // But if users must call GL directly, they should update the state manually,
-    RenderState::StateBlock::_defaultState->setStencilTest(true);
-    RenderState::StateBlock::_defaultState->setStencilFunction(RenderState::STENCIL_NEVER, 1, 0xFF);
-    RenderState::StateBlock::_defaultState->setStencilOperation(RenderState::STENCIL_OP_REPLACE, RenderState::STENCIL_OP_REPLACE, RenderState::STENCIL_OP_REPLACE);
+//    RenderState::StateBlock::_defaultState->setStencilTest(true);
+//    RenderState::StateBlock::_defaultState->setStencilFunction(RenderState::STENCIL_NEVER, 1, 0xFF);
+//    RenderState::StateBlock::_defaultState->setStencilOperation(RenderState::STENCIL_OP_REPLACE, RenderState::STENCIL_OP_REPLACE, RenderState::STENCIL_OP_REPLACE);
 }
 
 void RenderTextureTestDepthStencil::onBeforDraw()
@@ -488,7 +488,7 @@ void RenderTextureTestDepthStencil::onBeforDraw()
 
     // Since cocos2d-x v3.7, users should avoid calling GL directly because it will break the internal GL state
     // But if users must call GL directly, they should update the state manually,
-    RenderState::StateBlock::_defaultState->setStencilFunction(RenderState::STENCIL_NOTEQUAL, 1, 0xFF);
+//    RenderState::StateBlock::_defaultState->setStencilFunction(RenderState::STENCIL_NOTEQUAL, 1, 0xFF);
 }
 
 void RenderTextureTestDepthStencil::onAfterDraw()
@@ -497,7 +497,7 @@ void RenderTextureTestDepthStencil::onAfterDraw()
 
     // Since cocos2d-x v3.7, users should avoid calling GL directly because it will break the internal GL state
     // But if users must call GL directly, they should update the state manually,
-    RenderState::StateBlock::_defaultState->setStencilTest(false);
+//    RenderState::StateBlock::_defaultState->setStencilTest(false);
 }
 
 std::string RenderTextureTestDepthStencil::title() const

--- a/tests/cpp-tests/Classes/Sprite3DTest/Sprite3DTest.cpp
+++ b/tests/cpp-tests/Classes/Sprite3DTest/Sprite3DTest.cpp
@@ -56,6 +56,7 @@ Sprite3DTests::Sprite3DTests()
     ADD_TEST_CASE(Sprite3DCubeMapTest);
     ADD_TEST_CASE(NodeAnimationTest);
     ADD_TEST_CASE(Issue9767);
+    ADD_TEST_CASE(Sprite3DClippingTest);
 };
 
 //------------------------------------------------------------------
@@ -2570,3 +2571,41 @@ std::string Issue9767::subtitle() const
     return "";
 }
 
+Sprite3DClippingTest::Sprite3DClippingTest()
+{
+    auto size = Director::getInstance()->getWinSize();
+    auto stencil = Sprite::create("Images/close.png");
+    auto clipSprite3D = ClippingNode::create();
+    clipSprite3D->setStencil(stencil);
+    this->addChild(clipSprite3D);
+    clipSprite3D->setScale(3.0f);
+    
+    auto sprite3D = Sprite3D::create("Sprite3DTest/orc.c3b");
+    sprite3D->setScale(1.0f);
+    sprite3D->setRotation3D(Vec3(0.0f, 180.0f, 0.0f));
+    clipSprite3D->addChild(sprite3D);//5
+    
+    clipSprite3D->setPosition(Vec2(size.width / 2, size.height / 2));
+    
+    auto seq = Sequence::create(ScaleTo::create(2.f, 3), ScaleTo::create(2.f, 0.5f), NULL);
+    sprite3D->runAction(RepeatForever::create(seq));
+    auto animation = Animation3D::create("Sprite3DTest/orc.c3b");
+    auto animate = Animate3D::create(animation);
+    sprite3D->runAction(RepeatForever::create(animate));
+    sprite3D->setForce2DQueue(true);
+}
+
+Sprite3DClippingTest::~Sprite3DClippingTest()
+{
+    
+}
+
+std::string Sprite3DClippingTest::title() const
+{
+    return "Sprite3D Clipping Test";
+}
+
+std::string Sprite3DClippingTest::subtitle() const
+{
+    return "";
+}

--- a/tests/cpp-tests/Classes/Sprite3DTest/Sprite3DTest.h
+++ b/tests/cpp-tests/Classes/Sprite3DTest/Sprite3DTest.h
@@ -554,4 +554,15 @@ protected:
     cocos2d::Sprite3D*  _sprite;
 };
 
+/// Clipping Sprite3D
+class Sprite3DClippingTest : public Sprite3DTestDemo
+{
+public:
+    CREATE_FUNC(Sprite3DClippingTest);
+    Sprite3DClippingTest();
+    ~Sprite3DClippingTest();
+    virtual std::string title() const override;
+    virtual std::string subtitle() const override;
+};
+
 #endif


### PR DESCRIPTION
1. Remove stencil from Renderstate.
2. Add clippingnode test for sprite3d.
