### PR TITLE
UISlider update

### DIFF
--- a/cocos/ui/UISlider.cpp
+++ b/cocos/ui/UISlider.cpp
@@ -640,6 +640,7 @@ void Slider::onPressStateChangedToDisabled()
     if (!_isSliderBallDisabledTexturedLoaded)
     {
         _slidBallNormalRenderer->setGLProgramState(this->getGrayGLProgramState());
+        _slidBallNormalRenderer->setVisible(true);
     }
     else
     {


### PR DESCRIPTION
Fix when slider set to disable mode then clean slider ball disable texture, normal texture won't show
