### PR TITLE
为RichText加入自动设置ContentSize的height功能

### DIFF
--- a/cocos/ui/UIRichText.cpp
+++ b/cocos/ui/UIRichText.cpp
@@ -382,7 +382,14 @@ void RichText::formarRenderers()
             maxHeights[i] = maxHeight;
             newContentSizeHeight += maxHeights[i];
         }
-        
+        /*
+         *如果 用户设置 txt:setContentSize(460, 0)，height设置为0，视为自动适应大小的RichText
+         *亦可单独弄一个方法用于设置是”否自动设置RichText的高度“，但是，我觉得ContentSize的hight设置为0，就自动设置高度是蛮合理的。与Label的setDimensions用法相似
+         */
+        if(_customSize.height == 0)
+        {
+            _customSize.height =newContentSizeHeight;
+        }
         
         float nextPosY = _customSize.height;
         for (size_t i=0; i<_elementRenders.size(); i++)
@@ -400,7 +407,7 @@ void RichText::formarRenderers()
                 nextPosX += l->getContentSize().width;
             }
         }
-        _elementRenderersContainer->setContentSize(_contentSize);
+        _elementRenderersContainer->setContentSize(_customSize);//这里改成使用_customSize
         delete [] maxHeights;
     }
     


### PR DESCRIPTION
 *如果 用户设置 txt:setContentSize(460, 0)，height设置为0，视为自动适应大小的RichText
 *亦可单独弄一个方法用于设置是”否自动设置RichText的高度“，但是，我觉得ContentSize的hight设置为0，就自动设置高度是蛮合理的。与Label的setDimensions用法相似
 *自动设置高度这个功能在开发过程中经常需要用到。例如：开发聊天系统的时候，自动设置高度可以很方便的用于各条消息之间的位置设置
