### PR TITLE
Fix drawLine & drawPoints won't use blendFunc bug

### DIFF
--- a/build/cocos2d_tests.xcodeproj/project.pbxproj
+++ b/build/cocos2d_tests.xcodeproj/project.pbxproj
@@ -814,6 +814,10 @@
 		688669711AE8E8B500C2CFD9 /* SpritePolygonTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 6886696F1AE8E8B500C2CFD9 /* SpritePolygonTest.cpp */; };
 		688669721AE8E8B500C2CFD9 /* SpritePolygonTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 6886696F1AE8E8B500C2CFD9 /* SpritePolygonTest.cpp */; };
 		826294431AAF071500CB7CF7 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 826294421AAF071500CB7CF7 /* Security.framework */; };
+		94D793D91B4B7A3600F60F10 /* Bug-CCDrawNode.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 94D793D51B4B7A3600F60F10 /* Bug-CCDrawNode.cpp */; };
+		94D793DA1B4B7A3600F60F10 /* Bug-CCDrawNode.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 94D793D51B4B7A3600F60F10 /* Bug-CCDrawNode.cpp */; };
+		94D793DB1B4B7A3600F60F10 /* Bug-PageViewLayout.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 94D793D71B4B7A3600F60F10 /* Bug-PageViewLayout.cpp */; };
+		94D793DC1B4B7A3600F60F10 /* Bug-PageViewLayout.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 94D793D71B4B7A3600F60F10 /* Bug-PageViewLayout.cpp */; };
 		A05FCACA177C124500BE600E /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 15C64822165F391E007D4F18 /* Cocoa.framework */; };
 		A07A521E1783A1D20073F6A7 /* libz.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 15C6482E165F399D007D4F18 /* libz.dylib */; };
 		A07A521F1783A1D20073F6A7 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 15C64832165F3AFD007D4F18 /* Foundation.framework */; };
@@ -1774,6 +1778,10 @@
 		70A7F72D191D3E4900F0F206 /* shaderTest.psh.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = shaderTest.psh.h; sourceTree = "<group>"; };
 		70A7F730191D421B00F0F206 /* ShaderTest.vsh.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ShaderTest.vsh.h; sourceTree = "<group>"; };
 		826294421AAF071500CB7CF7 /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = System/Library/Frameworks/Security.framework; sourceTree = SDKROOT; };
+		94D793D51B4B7A3600F60F10 /* Bug-CCDrawNode.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = "Bug-CCDrawNode.cpp"; sourceTree = "<group>"; };
+		94D793D61B4B7A3600F60F10 /* Bug-CCDrawNode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "Bug-CCDrawNode.h"; sourceTree = "<group>"; };
+		94D793D71B4B7A3600F60F10 /* Bug-PageViewLayout.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = "Bug-PageViewLayout.cpp"; sourceTree = "<group>"; };
+		94D793D81B4B7A3600F60F10 /* Bug-PageViewLayout.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "Bug-PageViewLayout.h"; sourceTree = "<group>"; };
 		A035A71117822E9E00987F6C /* libsqlite3.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libsqlite3.dylib; path = usr/lib/libsqlite3.dylib; sourceTree = SDKROOT; };
 		A07A52291783A1D20073F6A7 /* cpp-tests iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "cpp-tests iOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		A07A52B71783AE6D0073F6A7 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS6.1.sdk/System/Library/Frameworks/UIKit.framework; sourceTree = DEVELOPER_DIR; };
@@ -2427,6 +2435,10 @@
 		1AC3597618CECF0B00F37B72 /* BugsTest */ = {
 			isa = PBXGroup;
 			children = (
+				94D793D51B4B7A3600F60F10 /* Bug-CCDrawNode.cpp */,
+				94D793D61B4B7A3600F60F10 /* Bug-CCDrawNode.h */,
+				94D793D71B4B7A3600F60F10 /* Bug-PageViewLayout.cpp */,
+				94D793D81B4B7A3600F60F10 /* Bug-PageViewLayout.h */,
 				1AC3597718CECF0B00F37B72 /* Bug-1159.cpp */,
 				1AC3597818CECF0B00F37B72 /* Bug-1159.h */,
 				1AC3597918CECF0B00F37B72 /* Bug-1174.cpp */,
@@ -4904,6 +4916,7 @@
 				1AC35BEB18CECF0C00F37B72 /* CCControlSliderTest.cpp in Sources */,
 				1AC35C4D18CECF0C00F37B72 /* SpineTest.cpp in Sources */,
 				3E92EA821921A1400094CD21 /* Sprite3DTest.cpp in Sources */,
+				94D793DB1B4B7A3600F60F10 /* Bug-PageViewLayout.cpp in Sources */,
 				1AC35C1D18CECF0C00F37B72 /* NewRendererTest.cpp in Sources */,
 				1AC35B6718CECF0C00F37B72 /* AnimationsTestLayer.cpp in Sources */,
 				29080DB7191B595E0066F8DF /* UIListViewTest_Editor.cpp in Sources */,
@@ -5047,6 +5060,7 @@
 				1AC35B2518CECF0C00F37B72 /* ActionsProgressTest.cpp in Sources */,
 				1AC35B6518CECF0C00F37B72 /* EffectsTest.cpp in Sources */,
 				1AC35B7118CECF0C00F37B72 /* TestHeaderLayer.cpp in Sources */,
+				94D793D91B4B7A3600F60F10 /* Bug-CCDrawNode.cpp in Sources */,
 				29080D93191B595E0066F8DF /* CustomImageTest.cpp in Sources */,
 				1AC35B2118CECF0C00F37B72 /* ActionManagerTest.cpp in Sources */,
 				1AC35C3D18CECF0C00F37B72 /* PhysicsTest.cpp in Sources */,
@@ -5185,6 +5199,7 @@
 				1AC35B2818CECF0C00F37B72 /* ActionsTest.cpp in Sources */,
 				1AC35C4A18CECF0C00F37B72 /* ShaderTest.cpp in Sources */,
 				B609E67419C18DAD003D0074 /* BillBoardTest.cpp in Sources */,
+				94D793DC1B4B7A3600F60F10 /* Bug-PageViewLayout.cpp in Sources */,
 				C04F935B1941B05400E9FEAB /* TileMapTest2.cpp in Sources */,
 				1AC35B4418CECF0C00F37B72 /* Bug-624.cpp in Sources */,
 				1AC35BF818CECF0C00F37B72 /* SocketIOTest.cpp in Sources */,
@@ -5293,6 +5308,7 @@
 				1AC35BEA18CECF0C00F37B72 /* CCControlSceneManager.cpp in Sources */,
 				182C5CBB1A95B30500C30D34 /* CocosStudio3DTest.cpp in Sources */,
 				1AC35B7418CECF0C00F37B72 /* TimelineCallbackTestLayer.cpp in Sources */,
+				94D793DA1B4B7A3600F60F10 /* Bug-CCDrawNode.cpp in Sources */,
 				29080D9E191B595E0066F8DF /* CustomParticleWidgetReader.cpp in Sources */,
 				1AC35BFC18CECF0C00F37B72 /* NotificationCenterTest.cpp in Sources */,
 				29FBBBFF196A9ECD00E65826 /* CocostudioParserJsonTest.cpp in Sources */,

--- a/cocos/2d/CCDrawNode.cpp
+++ b/cocos/2d/CCDrawNode.cpp
@@ -371,7 +371,9 @@ void DrawNode::onDrawGLLine(const Mat4 &transform, uint32_t flags)
     auto glProgram = GLProgramCache::getInstance()->getGLProgram(GLProgram::SHADER_NAME_POSITION_LENGTH_TEXTURE_COLOR);
     glProgram->use();
     glProgram->setUniformsForBuiltins(transform);
-    
+
+    GL::blendFunc(_blendFunc.src, _blendFunc.dst);
+
     if (_dirtyGLLine)
     {
         glBindBuffer(GL_ARRAY_BUFFER, _vboGLLine);
@@ -412,7 +414,9 @@ void DrawNode::onDrawGLPoint(const Mat4 &transform, uint32_t flags)
     auto glProgram = GLProgramCache::getInstance()->getGLProgram(GLProgram::SHADER_NAME_POSITION_COLOR_TEXASPOINTSIZE);
     glProgram->use();
     glProgram->setUniformsForBuiltins(transform);
-    
+
+    GL::blendFunc(_blendFunc.src, _blendFunc.dst);
+
     if (_dirtyGLPoint)
     {
         glBindBuffer(GL_ARRAY_BUFFER, _vboGLPoint);

--- a/cocos/editor-support/cocostudio/WidgetReader/UserCameraReader/UserCameraReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/UserCameraReader/UserCameraReader.cpp
@@ -125,6 +125,7 @@ namespace cocostudio
                 else if(value == "USER1") cameraFlag = 1 << 1;
                 else if(value == "USER2") cameraFlag = 1 << 2;
                 else if(value == "USER3") cameraFlag = 1 << 3;
+                else if(value == "USER4") cameraFlag = 1 << 4;
             }
             
             attribute = attribute->Next();

--- a/cocos/ui/UILayoutComponent.cpp
+++ b/cocos/ui/UILayoutComponent.cpp
@@ -21,7 +21,7 @@
  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  THE SOFTWARE.
  ****************************************************************************/
-
+#include "UIPageView.h"
 #include "UILayoutComponent.h"
 #include "2d/CCNode.h"
 #include "GUIDefine.h"
@@ -667,7 +667,23 @@ namespace ui {
         _owner->setPosition(ownerPosition);
         _owner->setContentSize(ownerSize);
 
-        ui::Helper::doLayout(_owner);
+        if (typeid(*_owner) == typeid(PageView))
+        {
+            PageView* page = static_cast<PageView*>(_owner);
+            page->forceDoLayout();
+
+            Vector<Layout*> _layoutVector = page->getPages();
+            Vector<Layout*>::iterator iter = _layoutVector.begin();
+            while (iter != _layoutVector.end())
+            {
+                ui::Helper::doLayout(*(iter));
+                iter++;
+            }
+        }
+        else
+        {
+            ui::Helper::doLayout(_owner);
+        }
     }
 
     void LayoutComponent::setActiveEnabled(bool enable)

--- a/cocos/ui/UILayoutComponent.cpp
+++ b/cocos/ui/UILayoutComponent.cpp
@@ -673,11 +673,9 @@ namespace ui {
             page->forceDoLayout();
 
             Vector<Layout*> _layoutVector = page->getPages();
-            Vector<Layout*>::iterator iter = _layoutVector.begin();
-            while (iter != _layoutVector.end())
+            for each (auto item in _layoutVector)
             {
-                ui::Helper::doLayout(*(iter));
-                iter++;
+                ui::Helper::doLayout(item);
             }
         }
         else

--- a/cocos/ui/UILayoutComponent.cpp
+++ b/cocos/ui/UILayoutComponent.cpp
@@ -673,7 +673,7 @@ namespace ui {
             page->forceDoLayout();
 
             Vector<Layout*> _layoutVector = page->getPages();
-            for each (auto item in _layoutVector)
+            for(auto& item : _layoutVector)
             {
                 ui::Helper::doLayout(item);
             }

--- a/tests/cpp-tests/CMakeLists.txt
+++ b/tests/cpp-tests/CMakeLists.txt
@@ -29,6 +29,8 @@ set(TESTS_SRC
   Classes/AppDelegate.cpp
   Classes/BaseTest.cpp
   Classes/BillBoardTest/BillBoardTest.cpp
+  Classes/BugsTest/Bug-CCDrawNode.cpp
+  Classes/BugsTest/Bug-PageViewLayout.cpp
   Classes/BugsTest/Bug-1159.cpp
   Classes/BugsTest/Bug-1174.cpp
   Classes/BugsTest/Bug-350.cpp

--- a/tests/cpp-tests/Classes/BugsTest/Bug-CCDrawNode.cpp
+++ b/tests/cpp-tests/Classes/BugsTest/Bug-CCDrawNode.cpp
@@ -25,10 +25,12 @@ bool BugDrawNodeLayer::init()
 
         auto drawNode = DrawNode::create();
         drawNode->drawLine(Vec2(0, 0), Vec2(size.width, size.height), Color4F(1, 0, 0, 0.5f));
+        Vec2 point = Vec2(size.width / 2, size.height / 2);
+        drawNode->drawPoint(point, 8, Color4F(1, 0, 0, 0.5f));
         addChild(drawNode);
 
         auto label = Label::create();
-        label->setString(std::string("If you see a red line, the bug is fixed!"));
+        label->setString(std::string("If you see a red line with a block at center, the bug is fixed!"));
         label->setPosition(size.width / 2, size.height / 4);
         label->setTextColor(Color4B::ORANGE);
         addChild(label);

--- a/tests/cpp-tests/Classes/BugsTest/Bug-CCDrawNode.cpp
+++ b/tests/cpp-tests/Classes/BugsTest/Bug-CCDrawNode.cpp
@@ -1,0 +1,40 @@
+//
+// CCDrawNode::onDrawGLPoint & CCDrawNode::onDrawGLLine miss
+//  calling GL::blendFunc, so when a sprite set blendFunc, these
+//  function will get a wrong result.
+// In this test, see a red line when bug resolved.
+//
+
+#include "Bug-CCDrawNode.h"
+
+USING_NS_CC;
+
+bool BugDrawNodeLayer::init()
+{
+    if (BugsTestBase::init())
+    {
+        auto size = Director::getInstance()->getWinSize();
+        auto testSprite = Sprite::create("cocosui/CloseNormal.png");
+        BlendFunc blend;
+        blend.src = GL_ZERO;
+        blend.dst = GL_ONE_MINUS_SRC_ALPHA;
+        testSprite->setBlendFunc(blend);
+        testSprite->setPosition(Vec2(size.width / 2, size.height / 2));
+        testSprite->setScale(10);
+        addChild(testSprite);
+
+        auto drawNode = DrawNode::create();
+        drawNode->drawLine(Vec2(0, 0), Vec2(size.width, size.height), Color4F(1, 0, 0, 0.5f));
+        addChild(drawNode);
+
+        auto label = Label::create();
+        label->setString(std::string("If you see a red line, the bug is fixed!"));
+        label->setPosition(size.width / 2, size.height / 4);
+        label->setTextColor(Color4B::ORANGE);
+        addChild(label);
+
+        return true;
+    }
+
+    return false;
+}

--- a/tests/cpp-tests/Classes/BugsTest/Bug-CCDrawNode.h
+++ b/tests/cpp-tests/Classes/BugsTest/Bug-CCDrawNode.h
@@ -1,0 +1,14 @@
+#ifndef __BUG_CCDRAWNODE_H__
+#define __BUG_CCDRAWNODE_H__
+
+#include "BugsTest.h"
+
+class BugDrawNodeLayer : public BugsTestBase
+{
+public:
+    CREATE_FUNC(BugDrawNodeLayer);
+
+    virtual bool init() override;
+};
+
+#endif

--- a/tests/cpp-tests/Classes/BugsTest/Bug-PageViewLayout.cpp
+++ b/tests/cpp-tests/Classes/BugsTest/Bug-PageViewLayout.cpp
@@ -1,0 +1,41 @@
+//
+// When a pageview set to relative position & size, if it
+//  has child widget set to relative position & size either,
+//  when change layer size, relayout won't correctly effect
+//  to the child.
+// In this test, if button at the center of panel, bug is fixed!
+//
+
+#include "Bug-PageViewLayout.h"
+#include "cocostudio/CocoStudio.h"
+#include "ui/CocosGUI.h"
+#include "CCFileUtils.h"
+
+USING_NS_CC;
+using namespace ui;
+
+bool BugPageViewLayer::init()
+{
+    if (BugsTestBase::init())
+    {
+        auto size = Director::getInstance()->getWinSize();
+
+        FileUtils::getInstance()->addSearchPath("ccs-res/cocosui/CustomTest/CustomWidgetCallbackBindTest");
+        FileUtils::getInstance()->addSearchPath("ccs-res/cocosui/CustomTest/CustomWidgetCallbackBindTest/Default", true);
+        auto rootNode = CSLoader::createNode("cocosui/CustomTest/CustomWidgetCallbackBindTest/PageViewBugScene.csb");
+        auto child = rootNode->getChildByName("ProjectNode_1");
+        child->setContentSize(Size(480, 320));
+        Helper::doLayout(child);
+        addChild(rootNode);
+
+        auto label = Label::create();
+        label->setString(std::string("If button is at the center of panel, the bug is fixed!"));
+        label->setPosition(size.width / 2, size.height / 4);
+        label->setTextColor(Color4B::ORANGE);
+        this->addChild(label);
+
+        return true;
+    }
+
+    return false;
+}

--- a/tests/cpp-tests/Classes/BugsTest/Bug-PageViewLayout.cpp
+++ b/tests/cpp-tests/Classes/BugsTest/Bug-PageViewLayout.cpp
@@ -9,7 +9,7 @@
 #include "Bug-PageViewLayout.h"
 #include "cocostudio/CocoStudio.h"
 #include "ui/CocosGUI.h"
-#include "CCFileUtils.h"
+#include "platform/CCFileUtils.h"
 
 USING_NS_CC;
 using namespace ui;
@@ -21,7 +21,6 @@ bool BugPageViewLayer::init()
         auto size = Director::getInstance()->getWinSize();
 
         FileUtils::getInstance()->addSearchPath("ccs-res/cocosui/CustomTest/CustomWidgetCallbackBindTest");
-        FileUtils::getInstance()->addSearchPath("ccs-res/cocosui/CustomTest/CustomWidgetCallbackBindTest/Default", true);
         auto rootNode = CSLoader::createNode("cocosui/CustomTest/CustomWidgetCallbackBindTest/PageViewBugScene.csb");
         auto child = rootNode->getChildByName("ProjectNode_1");
         child->setContentSize(Size(480, 320));

--- a/tests/cpp-tests/Classes/BugsTest/Bug-PageViewLayout.h
+++ b/tests/cpp-tests/Classes/BugsTest/Bug-PageViewLayout.h
@@ -1,0 +1,14 @@
+#ifndef __BUG_PAGEVIEWLAYOUT_H__
+#define __BUG_PAGEVIEWLAYOUT_H__
+
+#include "BugsTest.h"
+
+class BugPageViewLayer : public BugsTestBase
+{
+public:
+    CREATE_FUNC(BugPageViewLayer);
+
+    virtual bool init() override;
+};
+
+#endif // !__BUG_PAGEVIEWLAYOUT_H__

--- a/tests/cpp-tests/Classes/BugsTest/BugsTest.cpp
+++ b/tests/cpp-tests/Classes/BugsTest/BugsTest.cpp
@@ -9,6 +9,8 @@
 #include "Bug-1159.h"
 #include "Bug-1174.h"
 #include "Bug-Child.h"
+#include "Bug-CCDrawNode.h"
+#include "Bug-PageViewLayout.h"
 
 BugsTests::BugsTests()
 {
@@ -23,4 +25,6 @@ BugsTests::BugsTests()
     ADD_TEST_CASE(Bug1174Layer);
     ADD_TEST_CASE(BugChild);
     ADD_TEST_CASE(BugCameraMask);
+    ADD_TEST_CASE(BugDrawNodeLayer);
+    ADD_TEST_CASE(BugPageViewLayer);
 }

--- a/tests/cpp-tests/proj.android-studio/app/jni/Android.mk
+++ b/tests/cpp-tests/proj.android-studio/app/jni/Android.mk
@@ -20,6 +20,8 @@ LOCAL_SRC_FILES := main.cpp \
 ../../../Classes/Box2DTestBed/GLES-Render.cpp \
 ../../../Classes/Box2DTestBed/Test.cpp \
 ../../../Classes/Box2DTestBed/TestEntries.cpp \
+../../../Classes/BugsTest/Bug-CCDrawNode.cpp \
+../../../Classes/BugsTest/Bug-PageViewLayout.cpp \
 ../../../Classes/BugsTest/Bug-1159.cpp \
 ../../../Classes/BugsTest/Bug-1174.cpp \
 ../../../Classes/BugsTest/Bug-350.cpp \

--- a/tests/cpp-tests/proj.android/jni/Android.mk
+++ b/tests/cpp-tests/proj.android/jni/Android.mk
@@ -20,6 +20,8 @@ LOCAL_SRC_FILES := main.cpp \
 ../../Classes/Box2DTestBed/GLES-Render.cpp \
 ../../Classes/Box2DTestBed/Test.cpp \
 ../../Classes/Box2DTestBed/TestEntries.cpp \
+../../Classes/BugsTest/Bug-CCDrawNode.cpp \
+../../Classes/BugsTest/Bug-PageViewLayout.cpp \
 ../../Classes/BugsTest/Bug-1159.cpp \
 ../../Classes/BugsTest/Bug-1174.cpp \
 ../../Classes/BugsTest/Bug-350.cpp \

--- a/tests/cpp-tests/proj.win10/cpp-tests.vcxproj
+++ b/tests/cpp-tests/proj.win10/cpp-tests.vcxproj
@@ -298,6 +298,8 @@
     <ClInclude Include="..\Classes\Box2DTestBed\Tests\VerticalStack.h" />
     <ClInclude Include="..\Classes\Box2DTestBed\Tests\Web.h" />
     <ClInclude Include="..\Classes\Box2DTest\Box2dTest.h" />
+    <ClInclude Include="..\Classes\BugsTest\Bug-CCDrawNode.h" />
+    <ClInclude Include="..\Classes\BugsTest\Bug-PageViewLayout.h" />
     <ClInclude Include="..\Classes\BugsTest\Bug-1159.h" />
     <ClInclude Include="..\Classes\BugsTest\Bug-1174.h" />
     <ClInclude Include="..\Classes\BugsTest\Bug-350.h" />
@@ -546,6 +548,8 @@
     <ClCompile Include="..\Classes\Box2DTestBed\Test.cpp" />
     <ClCompile Include="..\Classes\Box2DTestBed\TestEntries.cpp" />
     <ClCompile Include="..\Classes\Box2DTest\Box2dTest.cpp" />
+    <ClCompile Include="..\Classes\BugsTest\Bug-CCDrawNode.cpp" />
+    <ClCompile Include="..\Classes\BugsTest\Bug-PageViewLayout.cpp" />
     <ClCompile Include="..\Classes\BugsTest\Bug-1159.cpp" />
     <ClCompile Include="..\Classes\BugsTest\Bug-1174.cpp" />
     <ClCompile Include="..\Classes\BugsTest\Bug-350.cpp" />

--- a/tests/cpp-tests/proj.win10/cpp-tests.vcxproj.filters
+++ b/tests/cpp-tests/proj.win10/cpp-tests.vcxproj.filters
@@ -467,6 +467,12 @@
     <ClCompile Include="..\Classes\BugsTest\Bug-1174.cpp">
       <Filter>Classes\BugsTest</Filter>
     </ClCompile>
+    <ClCompile Include="..\Classes\BugsTest\Bug-CCDrawNode.cpp">
+      <Filter>Classes\BugsTest</Filter>
+    </ClCompile>
+    <ClCompile Include="..\Classes\BugsTest\Bug-PageViewLayout.cpp">
+      <Filter>Classes\BugsTest</Filter>
+    </ClCompile>
     <ClCompile Include="..\Classes\BugsTest\Bug-Child.cpp">
       <Filter>Classes\BugsTest</Filter>
     </ClCompile>
@@ -1204,6 +1210,12 @@
       <Filter>Classes\BugsTest</Filter>
     </ClInclude>
     <ClInclude Include="..\Classes\BugsTest\Bug-1174.h">
+      <Filter>Classes\BugsTest</Filter>
+    </ClInclude>
+    <ClInclude Include="..\Classes\BugsTest\Bug-CCDrawNode.h">
+      <Filter>Classes\BugsTest</Filter>
+    </ClInclude>
+    <ClInclude Include="..\Classes\BugsTest\Bug-PageViewLayout.h">
       <Filter>Classes\BugsTest</Filter>
     </ClInclude>
     <ClInclude Include="..\Classes\BugsTest\Bug-Child.h">

--- a/tests/cpp-tests/proj.win32/cpp-tests.vcxproj
+++ b/tests/cpp-tests/proj.win32/cpp-tests.vcxproj
@@ -151,7 +151,9 @@ xcopy "$(OutDir)..\*.dll" "$(OutDir)" /D /Y</Command>
     <ClCompile Include="..\Classes\AllocatorTest\AllocatorTest.cpp" />
     <ClCompile Include="..\Classes\BaseTest.cpp" />
     <ClCompile Include="..\Classes\BillBoardTest\BillBoardTest.cpp" />
+    <ClCompile Include="..\Classes\BugsTest\Bug-CCDrawNode.cpp" />
     <ClCompile Include="..\Classes\BugsTest\Bug-Child.cpp" />
+    <ClCompile Include="..\Classes\BugsTest\Bug-PageViewLayout.cpp" />
     <ClCompile Include="..\Classes\Camera3DTest\Camera3DTest.cpp" />
     <ClCompile Include="..\Classes\ChipmunkTest\ChipmunkTest.cpp" />
     <ClCompile Include="..\Classes\ClippingNodeTest\ClippingNodeTest.cpp" />
@@ -354,7 +356,9 @@ xcopy "$(OutDir)..\*.dll" "$(OutDir)" /D /Y</Command>
     <ClInclude Include="..\Classes\Box2DTestBed\Tests\Mobile.h" />
     <ClInclude Include="..\Classes\Box2DTestBed\Tests\MobileBalanced.h" />
     <ClInclude Include="..\Classes\Box2DTestBed\Tests\MotorJoint.h" />
+    <ClInclude Include="..\Classes\BugsTest\Bug-CCDrawNode.h" />
     <ClInclude Include="..\Classes\BugsTest\Bug-Child.h" />
+    <ClInclude Include="..\Classes\BugsTest\Bug-PageViewLayout.h" />
     <ClInclude Include="..\Classes\Camera3DTest\Camera3DTest.h" />
     <ClInclude Include="..\Classes\ChipmunkTest\ChipmunkTest.h" />
     <ClInclude Include="..\Classes\ClippingNodeTest\ClippingNodeTest.h" />

--- a/tests/cpp-tests/proj.win32/cpp-tests.vcxproj.filters
+++ b/tests/cpp-tests/proj.win32/cpp-tests.vcxproj.filters
@@ -960,6 +960,12 @@
     <ClCompile Include="..\Classes\Scene3DTest\Scene3DTest.cpp">
       <Filter>Classes\Scene3DTest</Filter>
     </ClCompile>
+    <ClCompile Include="..\Classes\BugsTest\Bug-CCDrawNode.cpp">
+      <Filter>Classes\BugsTest</Filter>
+    </ClCompile>
+    <ClCompile Include="..\Classes\BugsTest\Bug-PageViewLayout.cpp">
+      <Filter>Classes\BugsTest</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="main.h">
@@ -1747,6 +1753,12 @@
     </ClInclude>
     <ClInclude Include="..\Classes\Scene3DTest\Scene3DTest.h">
       <Filter>Classes\Scene3DTest</Filter>
+    </ClInclude>
+    <ClInclude Include="..\Classes\BugsTest\Bug-CCDrawNode.h">
+      <Filter>Classes\BugsTest</Filter>
+    </ClInclude>
+    <ClInclude Include="..\Classes\BugsTest\Bug-PageViewLayout.h">
+      <Filter>Classes\BugsTest</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>

--- a/tests/cpp-tests/proj.win8.1-universal/cpp-tests.Shared/cpp-tests.Shared.vcxitems
+++ b/tests/cpp-tests/proj.win8.1-universal/cpp-tests.Shared/cpp-tests.Shared.vcxitems
@@ -38,8 +38,6 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Classes\Box2DTestBed\Test.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Classes\Box2DTestBed\TestEntries.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Classes\Box2DTest\Box2dTest.cpp" />
-    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Classes\BugsTest\Bug-CCDrawNode.cpp" />
-    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Classes\BugsTest\Bug-PageViewLayout.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Classes\BugsTest\Bug-1159.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Classes\BugsTest\Bug-1174.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Classes\BugsTest\Bug-350.cpp" />
@@ -50,7 +48,9 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Classes\BugsTest\Bug-886.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Classes\BugsTest\Bug-899.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Classes\BugsTest\Bug-914.cpp" />
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Classes\BugsTest\Bug-CCDrawNode.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Classes\BugsTest\Bug-Child.cpp" />
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Classes\BugsTest\Bug-PageViewLayout.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Classes\BugsTest\BugsTest.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Classes\Camera3DTest\Camera3DTest.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Classes\ChipmunkTest\ChipmunkTest.cpp" />
@@ -293,8 +293,6 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Classes\Box2DTestBed\Tests\VerticalStack.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Classes\Box2DTestBed\Tests\Web.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Classes\Box2DTest\Box2dTest.h" />
-    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Classes\BugsTest\Bug-CCDrawNode.h" />
-    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Classes\BugsTest\Bug-PageViewLayout.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Classes\BugsTest\Bug-1159.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Classes\BugsTest\Bug-1174.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Classes\BugsTest\Bug-350.h" />
@@ -305,7 +303,9 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Classes\BugsTest\Bug-886.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Classes\BugsTest\Bug-899.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Classes\BugsTest\Bug-914.h" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Classes\BugsTest\Bug-CCDrawNode.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Classes\BugsTest\Bug-Child.h" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Classes\BugsTest\Bug-PageViewLayout.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Classes\BugsTest\BugsTest.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Classes\Camera3DTest\Camera3DTest.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Classes\ChipmunkTest\ChipmunkTest.h" />

--- a/tests/cpp-tests/proj.win8.1-universal/cpp-tests.Shared/cpp-tests.Shared.vcxitems
+++ b/tests/cpp-tests/proj.win8.1-universal/cpp-tests.Shared/cpp-tests.Shared.vcxitems
@@ -38,6 +38,8 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Classes\Box2DTestBed\Test.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Classes\Box2DTestBed\TestEntries.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Classes\Box2DTest\Box2dTest.cpp" />
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Classes\BugsTest\Bug-CCDrawNode.cpp" />
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Classes\BugsTest\Bug-PageViewLayout.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Classes\BugsTest\Bug-1159.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Classes\BugsTest\Bug-1174.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Classes\BugsTest\Bug-350.cpp" />
@@ -291,6 +293,8 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Classes\Box2DTestBed\Tests\VerticalStack.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Classes\Box2DTestBed\Tests\Web.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Classes\Box2DTest\Box2dTest.h" />
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Classes\BugsTest\Bug-CCDrawNode.h" />
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Classes\BugsTest\Bug-PageViewLayout.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Classes\BugsTest\Bug-1159.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Classes\BugsTest\Bug-1174.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Classes\BugsTest\Bug-350.h" />

--- a/tests/cpp-tests/proj.win8.1-universal/cpp-tests.Shared/cpp-tests.Shared.vcxitems.filters
+++ b/tests/cpp-tests/proj.win8.1-universal/cpp-tests.Shared/cpp-tests.Shared.vcxitems.filters
@@ -222,12 +222,6 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Classes\BugsTest\Bug-1174.h">
       <Filter>Classes\BugsTest</Filter>
     </ClInclude>
-    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Classes\BugsTest\Bug-CCDrawNode.h">
-      <Filter>Classes\BugsTest</Filter>
-    </ClInclude>
-    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Classes\BugsTest\Bug-PageViewLayout.h">
-      <Filter>Classes\BugsTest</Filter>
-    </ClInclude>
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Classes\BugsTest\Bug-Child.h">
       <Filter>Classes\BugsTest</Filter>
     </ClInclude>
@@ -802,6 +796,12 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Classes\NavMeshTest\NavMeshTest.cpp">
       <Filter>Classes\NavMeshTest</Filter>
     </ClCompile>
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Classes\BugsTest\Bug-CCDrawNode.cpp">
+      <Filter>Classes\BugsTest</Filter>
+    </ClCompile>
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Classes\BugsTest\Bug-PageViewLayout.cpp">
+      <Filter>Classes\BugsTest</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Classes\ActionManagerTest\ActionManagerTest.cpp">
@@ -871,12 +871,6 @@
       <Filter>Classes\BugsTest</Filter>
     </ClCompile>
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Classes\BugsTest\Bug-1174.cpp">
-      <Filter>Classes\BugsTest</Filter>
-    </ClCompile>
-    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Classes\BugsTest\Bug-CCDrawNode.cpp">
-      <Filter>Classes\BugsTest</Filter>
-    </ClCompile>
-    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Classes\BugsTest\Bug-PageViewLayout.cpp">
       <Filter>Classes\BugsTest</Filter>
     </ClCompile>
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Classes\BugsTest\Bug-Child.cpp">
@@ -1778,6 +1772,12 @@
     </ClInclude>
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Classes\NavMeshTest\NavMeshTest.h">
       <Filter>Classes\NavMeshTest</Filter>
+    </ClInclude>
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Classes\BugsTest\Bug-CCDrawNode.h">
+      <Filter>Classes\BugsTest</Filter>
+    </ClInclude>
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Classes\BugsTest\Bug-PageViewLayout.h">
+      <Filter>Classes\BugsTest</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>

--- a/tests/cpp-tests/proj.win8.1-universal/cpp-tests.Shared/cpp-tests.Shared.vcxitems.filters
+++ b/tests/cpp-tests/proj.win8.1-universal/cpp-tests.Shared/cpp-tests.Shared.vcxitems.filters
@@ -222,6 +222,12 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Classes\BugsTest\Bug-1174.h">
       <Filter>Classes\BugsTest</Filter>
     </ClInclude>
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Classes\BugsTest\Bug-CCDrawNode.h">
+      <Filter>Classes\BugsTest</Filter>
+    </ClInclude>
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Classes\BugsTest\Bug-PageViewLayout.h">
+      <Filter>Classes\BugsTest</Filter>
+    </ClInclude>
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Classes\BugsTest\Bug-Child.h">
       <Filter>Classes\BugsTest</Filter>
     </ClInclude>
@@ -865,6 +871,12 @@
       <Filter>Classes\BugsTest</Filter>
     </ClCompile>
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Classes\BugsTest\Bug-1174.cpp">
+      <Filter>Classes\BugsTest</Filter>
+    </ClCompile>
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Classes\BugsTest\Bug-CCDrawNode.cpp">
+      <Filter>Classes\BugsTest</Filter>
+    </ClCompile>
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Classes\BugsTest\Bug-PageViewLayout.cpp">
       <Filter>Classes\BugsTest</Filter>
     </ClCompile>
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Classes\BugsTest\Bug-Child.cpp">


### PR DESCRIPTION
CCDrawNode only call GL::blendFunc in onDraw, but miss calling GL::blendFunc in onDrawGLLine and onDrawGLPoint
