### PR TITLE
Fix radio button group clear issue

### DIFF
--- a/cocos/ui/UIRadioButton.cpp
+++ b/cocos/ui/UIRadioButton.cpp
@@ -270,7 +270,7 @@ void RadioButtonGroup::setSelectedButton(RadioButton* radioButton)
     {
         return;
     }
-    if(!_radioButtons.contains(radioButton))
+    if(radioButton != nullptr && !_radioButtons.contains(radioButton))
     {
         CCLOGERROR("The radio button does not belong to this group!");
         return;


### PR DESCRIPTION
Fixed a bug that allowing non-selection `RadioButtonGroup` cannot be cleared.
