### PR TITLE
Fixed crash cause by the case of file name on WIN32.

### DIFF
--- a/cocos/platform/win32/CCFileUtils-win32.cpp
+++ b/cocos/platform/win32/CCFileUtils-win32.cpp
@@ -159,10 +159,9 @@ static bool checkFileName(const std::string& fullPath, const std::string& filena
                 std::string msg = "File path error: \"";
                 msg.append(filename).append("\" the real name is: ").append(realName);
             
-                CCLOG("%s", msg.c_str());
+                log("%s", msg.c_str());
                 return false;
             }
-
         }
         else
         {
@@ -193,7 +192,7 @@ static Data getData(const std::string& filename, bool forString)
         std::string fullPath = FileUtils::getInstance()->fullPathForFilename(filename);
 
         // check if the filename uses correct case characters
-        CC_BREAK_IF(!checkFileName(fullPath, filename));
+        checkFileName(fullPath, filename);
 
         WCHAR wszBuf[CC_MAX_PATH] = {0};
         MultiByteToWideChar(CP_UTF8, 0, fullPath.c_str(), -1, wszBuf, sizeof(wszBuf)/sizeof(wszBuf[0]));
@@ -278,7 +277,7 @@ unsigned char* FileUtilsWin32::getFileData(const std::string& filename, const ch
         std::string fullPath = fullPathForFilename(filename);
 
          // check if the filename uses correct case characters
-        CC_BREAK_IF(!checkFileName(fullPath, filename));
+        checkFileName(fullPath, filename);
 
         WCHAR wszBuf[CC_MAX_PATH] = {0};
         MultiByteToWideChar(CP_UTF8, 0, fullPath.c_str(), -1, wszBuf, sizeof(wszBuf)/sizeof(wszBuf[0]));


### PR DESCRIPTION
We will  rollback changes in the future.
