### PR TITLE
Fix cocos reader bug.

### DIFF
--- a/cocos/editor-support/cocostudio/WidgetReader/GameMapReader/GameMapReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/GameMapReader/GameMapReader.cpp
@@ -238,15 +238,12 @@ namespace cocostudio
                 setPropsWithFlatBuffers(tmx, (Table*)gameMapOptions);
             }
         }
-        //else
-        //{
-        //    Node* node = Node::create();
-        //    setPropsWithFlatBuffers(node, (Table*)gameMapOptions);
-        //    auto label = Label::create();
-        //    label->setString(__String::createWithFormat("%s missed", errorFilePath.c_str())->getCString());
-        //    node->addChild(label);
-        //    return node;
-        //}
+        else
+        {
+            Node* node = Node::create();
+            setPropsWithFlatBuffers(node, (Table*)gameMapOptions);
+            return node;
+        }
         
         return tmx;
     }

--- a/cocos/editor-support/cocostudio/WidgetReader/ParticleReader/ParticleReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/ParticleReader/ParticleReader.cpp
@@ -153,11 +153,11 @@ namespace cocostudio
     void ParticleReader::setPropsWithFlatBuffers(cocos2d::Node *node,
                                                  const flatbuffers::Table *particleOptions)
     {
-        auto particle = static_cast<ParticleSystemQuad*>(node);
+        auto particle = dynamic_cast<ParticleSystemQuad*>(node);
         auto options = (ParticleSystemOptions*)particleOptions;
         
         auto f_blendFunc = options->blendFunc();
-        if (f_blendFunc)
+        if (particle && f_blendFunc)
         {
             cocos2d::BlendFunc blendFunc = cocos2d::BlendFunc::ALPHA_PREMULTIPLIED;
             blendFunc.src = f_blendFunc->src();
@@ -208,15 +208,12 @@ namespace cocostudio
                 particle->setPositionType(ParticleSystem::PositionType::GROUPED);
             }
         }
-        //else
-        //{
-        //    Node* node = Node::create();
-        //    setPropsWithFlatBuffers(node, (Table*)particleOptions);
-        //    auto label = Label::create();
-        //    label->setString(__String::createWithFormat("%s missed", errorFilePath.c_str())->getCString());
-        //    node->addChild(label);
-        //    return node;
-        //}
+        else
+        {
+            Node* node = Node::create();
+            setPropsWithFlatBuffers(node, (Table*)particleOptions);
+            return node;
+        }
         
         return particle;
     }


### PR DESCRIPTION
Fixes child nodes can't be rendered when particle and TiledMap as parent node and their resource have been removed from disk.
