### PR TITLE
Fixed inertial scrolling for `CCScrollView`

### DIFF
--- a/extensions/GUI/CCScrollView/CCScrollView.cpp
+++ b/extensions/GUI/CCScrollView/CCScrollView.cpp
@@ -436,8 +436,8 @@ void ScrollView::deaccelerateScrolling(float dt)
     
     if ((fabsf(_scrollDistance.x) <= SCROLL_DEACCEL_DIST &&
          fabsf(_scrollDistance.y) <= SCROLL_DEACCEL_DIST) ||
-        newY >= maxInset.y || newY <= minInset.y ||
-        newX >= maxInset.x || newX <= minInset.x)
+        ((_direction == Direction::BOTH || _direction == Direction::VERTICAL) && (newY >= maxInset.y || newY <= minInset.y)) ||
+        ((_direction == Direction::BOTH || _direction == Direction::HORIZONTAL) && (newX >= maxInset.x || newX <= minInset.x)))
     {
         this->unschedule(CC_SCHEDULE_SELECTOR(ScrollView::deaccelerateScrolling));
         this->relocateContainer(true);


### PR DESCRIPTION
The inertial scrolling in `CCScrollView` usually works only if you're using the `Direction::BOTH` direction, and if there's enough scrolling space **both** on the X and the Y axis. But when you use the `Direction::HORIZONTAL` or `Direction::VERTICAL` directions you usually have 0px of available space on the Y or X axis respectively, so it won't work.
This change enables you to scroll the view just on the X or on the Y axis using `Direction::HORIZONTAL` or `Direction::VERTICAL` and to use the inertial scroll accordingly.
