### PR TITLE
Updated AudioEngine to enable setting pitch of a playing sound file.

### DIFF
--- a/cocos/audio/AudioEngine.cpp
+++ b/cocos/audio/AudioEngine.cpp
@@ -181,6 +181,24 @@ void AudioEngine::setVolume(int audioID, float volume)
     }
 }
 
+void AudioEngine::setPitch(int audioID, float pitch)
+{
+    auto it = _audioIDInfoMap.find(audioID);
+    if (it != _audioIDInfoMap.end()){
+        if (pitch < 0.5f) {
+            pitch = 0.5f;
+        }
+        else if (pitch > 2.0f){
+            pitch = 2.0f;
+        }
+        
+        if (it->second.pitch != pitch){
+            _audioEngineImpl->setPitch(audioID, pitch);
+            it->second.pitch = pitch;
+        }
+    }
+}
+
 void AudioEngine::pause(int audioID)
 {
     auto it = _audioIDInfoMap.find(audioID);

--- a/cocos/audio/android/AudioEngine-inl.cpp
+++ b/cocos/audio/android/AudioEngine-inl.cpp
@@ -161,7 +161,7 @@ bool AudioPlayer::init(SLEngineItf engineEngine, SLObjectItf outputMixObject,con
         SLuint32 numSupportedInterfaces = 0;
         result = slQueryNumSupportedEngineInterfaces(&numSupportedInterfaces);
         if (numSupportedInterfaces < OPEN_SL_REQUIRED_INTERFACE_COUNT) {
-            ERRORLOG("Warning: AudioEngine OpenSL numSupportedInterfaces:%d is less than OPEN_SL_REQUIRED_INTERFACE_COUNT:%d",
+            log("Warning: AudioEngine OpenSL numSupportedInterfaces:%d is less than OPEN_SL_REQUIRED_INTERFACE_COUNT:%d",
                 numSupportedInterfaces, OPEN_SL_REQUIRED_INTERFACE_COUNT);
         }
         
@@ -349,12 +349,12 @@ void AudioEngineImpl::setPitch(int audioID,float pitch)
     
     if (playbackRate < player._minRate)
     {
-        ERRORLOG("Warning: AudioEngine attempting to set rate:%d which is lower than minRate=%d.", playbackRate, player._minRate);
+        log("Warning: AudioEngine attempting to set rate:%d which is lower than minRate=%d.", playbackRate, player._minRate);
         playbackRate = player._minRate;
     }
     else if (playbackRate > player._maxRate)
     {
-        ERRORLOG("Warning: AudioEngine attempting to set rate:%d which is higher than maxRate=%d.", playbackRate, player._maxRate);
+        log("Warning: AudioEngine attempting to set rate:%d which is higher than maxRate=%d.", playbackRate, player._maxRate);
         playbackRate = player._maxRate;
     }
     

--- a/cocos/audio/android/AudioEngine-inl.cpp
+++ b/cocos/audio/android/AudioEngine-inl.cpp
@@ -144,7 +144,7 @@ bool AudioPlayer::init(SLEngineItf engineEngine, SLObjectItf outputMixObject,con
 
         // create audio player
         const SLInterfaceID ids[4] = {SL_IID_SEEK, SL_IID_PREFETCHSTATUS, SL_IID_VOLUME, SL_IID_PLAYBACKRATE};
-        const SLboolean req[4] = {SL_BOOLEAN_TRUE, SL_BOOLEAN_TRUE, SL_BOOLEAN_TRUE};
+        const SLboolean req[4] = {SL_BOOLEAN_TRUE, SL_BOOLEAN_TRUE, SL_BOOLEAN_TRUE, SL_BOOLEAN_TRUE};
         auto result = (*engineEngine)->CreateAudioPlayer(engineEngine, &_fdPlayerObject, &audioSrc, &audioSnk, 4, ids, req);
         if(SL_RESULT_SUCCESS != result){ ERRORLOG("create audio player fail"); break; }
 

--- a/cocos/audio/android/AudioEngine-inl.cpp
+++ b/cocos/audio/android/AudioEngine-inl.cpp
@@ -44,6 +44,7 @@ using namespace cocos2d;
 using namespace cocos2d::experimental;
 
 #define DELAY_TIME_TO_REMOVE 0.5f
+#define OPEN_SL_REQUIRED_INTERFACE_COUNT 4
 
 void PlayOverEvent(SLPlayItf caller, void* context, SLuint32 playEvent)
 {
@@ -69,6 +70,8 @@ AudioPlayer::AudioPlayer()
     , _playOver(false)
     , _loop(false)
     , _assetFd(0)
+    , _minRate(1000)
+    , _maxRate(1000)
     , _delayTimeToRemove(-1.f)
 {
 
@@ -143,15 +146,25 @@ bool AudioPlayer::init(SLEngineItf engineEngine, SLObjectItf outputMixObject,con
         SLDataSink audioSnk = {&loc_outmix, NULL};
 
         // create audio player
-        const SLInterfaceID ids[4] = {SL_IID_SEEK, SL_IID_PREFETCHSTATUS, SL_IID_VOLUME, SL_IID_PLAYBACKRATE};
-        const SLboolean req[4] = {SL_BOOLEAN_TRUE, SL_BOOLEAN_TRUE, SL_BOOLEAN_TRUE, SL_BOOLEAN_TRUE};
-        auto result = (*engineEngine)->CreateAudioPlayer(engineEngine, &_fdPlayerObject, &audioSrc, &audioSnk, 4, ids, req);
+        const SLInterfaceID ids[OPEN_SL_REQUIRED_INTERFACE_COUNT] = {SL_IID_SEEK, SL_IID_PREFETCHSTATUS,
+                                                                     SL_IID_VOLUME, SL_IID_PLAYBACKRATE};
+        const SLboolean req[OPEN_SL_REQUIRED_INTERFACE_COUNT] = {SL_BOOLEAN_TRUE, SL_BOOLEAN_TRUE, SL_BOOLEAN_TRUE,
+                                                                 SL_BOOLEAN_TRUE};
+        auto result = (*engineEngine)->CreateAudioPlayer(engineEngine, &_fdPlayerObject, &audioSrc, &audioSnk,
+                                                         OPEN_SL_REQUIRED_INTERFACE_COUNT, ids, req);
         if(SL_RESULT_SUCCESS != result){ ERRORLOG("create audio player fail"); break; }
 
         // realize the player
         result = (*_fdPlayerObject)->Realize(_fdPlayerObject, SL_BOOLEAN_FALSE);
         if(SL_RESULT_SUCCESS != result){ ERRORLOG("realize the player fail"); break; }
 
+        SLuint32 numSupportedInterfaces = 0;
+        result = slQueryNumSupportedEngineInterfaces(&numSupportedInterfaces);
+        if (numSupportedInterfaces < OPEN_SL_REQUIRED_INTERFACE_COUNT) {
+            ERRORLOG("Warning: AudioEngine OpenSL numSupportedInterfaces:%d is less than OPEN_SL_REQUIRED_INTERFACE_COUNT:%d",
+                numSupportedInterfaces, OPEN_SL_REQUIRED_INTERFACE_COUNT);
+        }
+        
         // get the play interface
         result = (*_fdPlayerObject)->GetInterface(_fdPlayerObject, SL_IID_PLAY, &_fdPlayerPlay);
         if(SL_RESULT_SUCCESS != result){ ERRORLOG("get the play interface fail"); break; }
@@ -167,6 +180,14 @@ bool AudioPlayer::init(SLEngineItf engineEngine, SLObjectItf outputMixObject,con
         // get the pitch interface
         result = (*_fdPlayerObject)->GetInterface(_fdPlayerObject, SL_IID_PLAYBACKRATE, &_fdPlayerPlaybackRate);
         if(SL_RESULT_SUCCESS != result){ ERRORLOG("get the pitch interface fail"); break; }
+        
+        SLpermille stepSize;
+        SLuint32 capabilities;
+        auto rangeResult = (*_fdPlayerPlaybackRate)->GetRateRange(_fdPlayerPlaybackRate, 0, &_minRate, &_maxRate, &stepSize, &capabilities);
+        if(SL_RESULT_SUCCESS != rangeResult)
+        {
+            log("%s error:%u",__func__, rangeResult);
+        }
 
         _loop = loop;
         if (loop){
@@ -326,17 +347,20 @@ void AudioEngineImpl::setPitch(int audioID,float pitch)
     
     SLpermille playbackRate = (SLpermille)1000 * pitch;
     
-    if (playbackRate < 500)
+    if (playbackRate < player._minRate)
     {
-        playbackRate = 500;
+        ERRORLOG("Warning: AudioEngine attempting to set rate:%d which is lower than minRate=%d.", playbackRate, player._minRate);
+        playbackRate = player._minRate;
     }
-    else if (playbackRate > 2000)
+    else if (playbackRate > player._maxRate)
     {
-        playbackRate = 2000;
+        ERRORLOG("Warning: AudioEngine attempting to set rate:%d which is higher than maxRate=%d.", playbackRate, player._maxRate);
+        playbackRate = player._maxRate;
     }
     
     auto result = (*player._fdPlayerPlaybackRate)->SetRate(player._fdPlayerPlaybackRate, playbackRate);
-    if(SL_RESULT_SUCCESS != result){
+    if(SL_RESULT_SUCCESS != result)
+    {
         log("%s error:%u",__func__, result);
     }
 }

--- a/cocos/audio/android/AudioEngine-inl.h
+++ b/cocos/audio/android/AudioEngine-inl.h
@@ -62,7 +62,8 @@ private:
     int _audioID;
     int _assetFd;
     float _delayTimeToRemove;
-
+    SLpermille _minRate, _maxRate;
+    
     std::function<void (int, const std::string &)> _finishCallback;
 
     friend class AudioEngineImpl;

--- a/cocos/audio/android/AudioEngine-inl.h
+++ b/cocos/audio/android/AudioEngine-inl.h
@@ -56,6 +56,7 @@ private:
     SLObjectItf _fdPlayerObject;
     SLSeekItf _fdPlayerSeek;
     SLVolumeItf _fdPlayerVolume;
+    SLPlaybackRateItf _fdPlayerPlaybackRate;
 
     float _duration;
     int _audioID;
@@ -76,6 +77,7 @@ public:
     bool init();
     int play2d(const std::string &fileFullPath ,bool loop ,float volume);
     void setVolume(int audioID,float volume);
+    void setPitch(int audioID,float pitch);
     void setLoop(int audioID, bool loop);
     void pause(int audioID);
     void resume(int audioID);

--- a/cocos/audio/apple/AudioEngine-inl.h
+++ b/cocos/audio/apple/AudioEngine-inl.h
@@ -49,6 +49,7 @@ public:
     bool init();
     int play2d(const std::string &fileFullPath ,bool loop ,float volume);
     void setVolume(int audioID,float volume);
+    void setPitch(int audioID,float pitch);
     void setLoop(int audioID, bool loop);
     bool pause(int audioID);
     bool resume(int audioID);

--- a/cocos/audio/apple/AudioEngine-inl.mm
+++ b/cocos/audio/apple/AudioEngine-inl.mm
@@ -319,6 +319,7 @@ int AudioEngineImpl::play2d(const std::string &filePath ,bool loop ,float volume
     player->_alSource = alSource;
     player->_loop = loop;
     player->_volume = volume;
+    player->_pitch = 1.0;
     audioCache->addCallbacks(std::bind(&AudioEngineImpl::_play2d,this,audioCache,_currentAudioID));
     
     _alSourceUsed[alSource] = true;
@@ -353,6 +354,23 @@ void AudioEngineImpl::_play2d(AudioCache *cache, int audioID)
         _toRemoveCaches.push_back(cache);
         _toRemoveAudioIDs.push_back(audioID);
         _threadMutex.unlock();
+    }
+}
+
+void AudioEngineImpl::setPitch(int audioID,float pitch)
+{
+    auto& player = _audioPlayers[audioID];
+    player._pitch = pitch;
+
+    if (player._ready)
+    {
+        alSourcef(_audioPlayers[audioID]._alSource, AL_PITCH, pitch);
+        
+        auto error = alGetError();
+        if (error != AL_NO_ERROR)
+        {
+            printf("%s: audio id = %d, error = %x\n", __PRETTY_FUNCTION__,audioID,error);
+        }
     }
 }
 

--- a/cocos/audio/apple/AudioPlayer.h
+++ b/cocos/audio/apple/AudioPlayer.h
@@ -59,6 +59,7 @@ protected:
     AudioCache* _audioCache;
     
     float _volume;
+    float _pitch;
     bool _loop;
     std::function<void (int, const std::string &)> _finishCallbak;
     

--- a/cocos/audio/apple/AudioPlayer.mm
+++ b/cocos/audio/apple/AudioPlayer.mm
@@ -66,7 +66,7 @@ bool AudioPlayer::play2d(AudioCache* cache)
     _audioCache = cache;
     
     alSourcei(_alSource, AL_BUFFER, 0);
-    alSourcef(_alSource, AL_PITCH, 1.0f);
+    alSourcef(_alSource, AL_PITCH, _pitch);
     alSourcef(_alSource, AL_GAIN, _volume);
     alSourcei(_alSource, AL_LOOPING, AL_FALSE);
     

--- a/cocos/audio/include/AudioEngine.h
+++ b/cocos/audio/include/AudioEngine.h
@@ -166,7 +166,15 @@ public:
      */
     static float getVolume(int audioID);
 
-    /** 
+    /**
+     * Sets pitch for an audio instance.
+     *
+     * @param audioID An audioID returned by the play2d function.
+     * @param pitch Pitch value (range from 0.5 to 2.0).
+     */
+    static void setPitch(int audioID, float pitch);
+    
+    /**
      * Pause an audio instance.
      *
      * @param audioID An audioID returned by the play2d function.
@@ -306,6 +314,7 @@ protected:
         ProfileHelper* profileHelper;
         
         float volume;
+        float pitch;
         bool loop;
         float duration;
         AudioState state;

--- a/cocos/audio/win32/AudioEngine-win32.cpp
+++ b/cocos/audio/win32/AudioEngine-win32.cpp
@@ -257,6 +257,7 @@ int AudioEngineImpl::play2d(const std::string &filePath ,bool loop ,float volume
     player->_alSource = alSource;
     player->_loop = loop;
     player->_volume = volume;
+    player->_pitch = 1.0;
     audioCache->addCallbacks(std::bind(&AudioEngineImpl::_play2d,this,audioCache,_currentAudioID));
     
     _alSourceUsed[alSource] = true;
@@ -301,6 +302,21 @@ void AudioEngineImpl::setVolume(int audioID,float volume)
     
     if (player._ready) {
         alSourcef(_audioPlayers[audioID]._alSource, AL_GAIN, volume);
+        
+        auto error = alGetError();
+        if (error != AL_NO_ERROR) {
+            log("%s: audio id = %d, error = %x\n", __FUNCTION__,audioID,error);
+        }
+    }
+}
+
+void AudioEngineImpl::setPitch(int audioID,float pitch)
+{
+    auto& player = _audioPlayers[audioID];
+    player._pitch = pitch;
+    
+    if (player._ready) {
+        alSourcef(_audioPlayers[audioID]._alSource, AL_PITCH, pitch);
         
         auto error = alGetError();
         if (error != AL_NO_ERROR) {

--- a/cocos/audio/win32/AudioEngine-win32.h
+++ b/cocos/audio/win32/AudioEngine-win32.h
@@ -49,6 +49,7 @@ public:
     bool init();
     int play2d(const std::string &fileFullPath ,bool loop ,float volume);
     void setVolume(int audioID,float volume);
+    void setPitch(int audioID,float pitch);
     void setLoop(int audioID, bool loop);
     bool pause(int audioID);
     bool resume(int audioID);

--- a/cocos/audio/win32/AudioPlayer.cpp
+++ b/cocos/audio/win32/AudioPlayer.cpp
@@ -82,7 +82,7 @@ bool AudioPlayer::play2d(AudioCache* cache)
     _audioCache = cache;
 
     alSourcei(_alSource, AL_BUFFER, NULL);
-    alSourcef(_alSource, AL_PITCH, 1.0f);
+    alSourcef(_alSource, AL_PITCH, _pitch);
     alSourcef(_alSource, AL_GAIN, _volume);
 
     if (_audioCache->_queBufferFrames == 0) {

--- a/cocos/audio/win32/AudioPlayer.h
+++ b/cocos/audio/win32/AudioPlayer.h
@@ -65,6 +65,7 @@ protected:
     AudioCache* _audioCache;
     
     float _volume;
+    float _pitch;
     bool _loop;
     std::function<void (int, const std::string &)> _finishCallbak;
     

--- a/cocos/audio/winrt/AudioCachePlayer.cpp
+++ b/cocos/audio/winrt/AudioCachePlayer.cpp
@@ -172,6 +172,7 @@ AudioPlayer::AudioPlayer()
     , _ready(false)
     , _current(0.0)
     , _volume(0.0)
+    , _pitch(1.0)
     , _duration(0.0)
     , _cache(nullptr)
     , _totalSamples(0)
@@ -308,6 +309,19 @@ void AudioPlayer::setVolume(float volume)
     }
 }
 
+void AudioPlayer::setPitch(float pitch)
+{
+    if (_xaSourceVoice != nullptr){
+        
+        if (FAILED(_xaSourceVoice->SetFrequencyRatio(pitch))) {
+            error();
+        }
+        else {
+            _pitch = pitch;
+        }
+    }
+}
+
 bool AudioPlayer::play2d(AudioCache* cache)
 {
     bool ret = false;
@@ -324,7 +338,7 @@ bool AudioPlayer::play2d(AudioCache* cache)
             XAUDIO2_VOICE_SENDS sends = { 0 };
             sends.SendCount = 1;
             sends.pSends = descriptors;
-            hr = _xaEngine->CreateSourceVoice(&_xaSourceVoice, &cache->_audInfo._wfx, 0, 1.0, this, &sends);
+            hr = _xaEngine->CreateSourceVoice(&_xaSourceVoice, &cache->_audInfo._wfx, 0, 2.0, this, &sends);
         }
 
         if (SUCCEEDED(hr)) {

--- a/cocos/audio/winrt/AudioCachePlayer.h
+++ b/cocos/audio/winrt/AudioCachePlayer.h
@@ -95,6 +95,7 @@ private:
      float getCurrentTime();
      bool setTime(float time);
      void setVolume(float volume);
+     void setPitch(float pitch);
      bool play2d(AudioCache* cache);
      AudioPlayerState getState() { return _state; }
 
@@ -132,6 +133,7 @@ private:
      bool _loop;
      bool _ready;
      float _volume;
+     float _pitch;
      float _current;
      float _duration;
      bool _criticalError;

--- a/cocos/audio/winrt/AudioEngine-winrt.cpp
+++ b/cocos/audio/winrt/AudioEngine-winrt.cpp
@@ -234,6 +234,19 @@ void AudioEngineImpl::setVolume(int audioID, float volume)
     }
 }
 
+void AudioEngineImpl::setPitch(int audioID, float pitch)
+{
+    auto& player = _audioPlayers[audioID];
+    
+    if (player._ready){
+        player.setPitch(pitch);
+    }
+    
+    if (player.isInError()) {
+        log("%s: audio id = %d, error.\n", __FUNCTION__, audioID);
+    }
+}
+
 void AudioEngineImpl::setLoop(int audioID, bool loop)
 {
     auto& player = _audioPlayers[audioID];

--- a/cocos/audio/winrt/AudioEngine-winrt.h
+++ b/cocos/audio/winrt/AudioEngine-winrt.h
@@ -47,6 +47,7 @@ NS_CC_BEGIN
      bool init();
      int play2d(const std::string &fileFullPath, bool loop, float volume);
      void setVolume(int audioID, float volume);
+     void setPitch(int audioID, float pitch);
      void setLoop(int audioID, bool loop);
      bool pause(int audioID);
      bool resume(int audioID);


### PR DESCRIPTION
Updated AudioEngine to enable setting pitch of a playing effect. Updated applied to iOS, Mac, Android, WinRT and Win32.

Valid pitch range is [0.5,2.0]. 

Setting pitch on all platforms affects the playback speed and effective pitch of the audio file.

Demo Video: http://youtu.be/4iX9gct5kvM

This is a great feature to simulate a motor sound, or many other effects.

The pitch/rate changing behavior, as designed and tested, seems to be identical across Mac, iOS, Android, WinRT and Win32. 

Tested on Macbook Pro, iOS iPhone 5 device, Android 4.4.4 Nexus 7 2012, WinRT Nokia Lumina 928W and Win32 simulator.

The test project that I used is located here. It is mostly the same code from the New Audio Engine test case. https://github.com/jimrange/AudioEnginePitchTest
