### PR TITLE
Automatically customize ContentSize for RichText. 

### DIFF
--- a/cocos/ui/UIRichText.cpp
+++ b/cocos/ui/UIRichText.cpp
@@ -116,6 +116,8 @@ RichText::RichText():
 _formatTextDirty(true),
 _leftSpaceWidth(0.0f),
 _verticalSpace(0.0f),
+_isAutoReSizeWidth(false),
+_isAutoReSizeHeight(true),
 _elementRenderersContainer(nullptr)
 {
     
@@ -382,21 +384,22 @@ void RichText::formarRenderers()
             maxHeights[i] = maxHeight;
             newContentSizeHeight += maxHeights[i];
         }
-        if(_isAutoReSize)
+        if(_isAutoReSizeHeight)
         {
             _customSize.height =newContentSizeHeight;
-            if(_elementRenders.size()==1)
-            {
-                Vector<Node*>* row = (_elementRenders[0]);
-                float maxWidth = 0.0f;
-                for (ssize_t j=0; j<row->size(); j++)
-                {
-                    Node* l = row->at(j);
-                    maxWidth += l->getContentSize().width;
-                }
-                _customSize.width = maxWidth;
-            }
         }
+        if(_isAutoReSizeWidth && _elementRenders.size()==1)
+        {
+            Vector<Node*>* row = (_elementRenders[0]);
+            float maxWidth = 0.0f;
+            for (ssize_t j=0; j<row->size(); j++)
+            {
+                Node* l = row->at(j);
+                maxWidth += l->getContentSize().width;
+            }
+            _customSize.width = maxWidth;
+        }
+
         
         float nextPosY = _customSize.height;
         for (size_t i=0; i<_elementRenders.size(); i++)

--- a/cocos/ui/UIRichText.cpp
+++ b/cocos/ui/UIRichText.cpp
@@ -382,7 +382,21 @@ void RichText::formarRenderers()
             maxHeights[i] = maxHeight;
             newContentSizeHeight += maxHeights[i];
         }
-        
+        if(_isAutoReSize)
+        {
+            _customSize.height =newContentSizeHeight;
+            if(_elementRenders.size()==1)
+            {
+                Vector<Node*>* row = (_elementRenders[0]);
+                float maxWidth = 0.0f;
+                for (ssize_t j=0; j<row->size(); j++)
+                {
+                    Node* l = row->at(j);
+                    maxWidth += l->getContentSize().width;
+                }
+                _customSize.width = maxWidth;
+            }
+        }
         
         float nextPosY = _customSize.height;
         for (size_t i=0; i<_elementRenders.size(); i++)
@@ -400,7 +414,7 @@ void RichText::formarRenderers()
                 nextPosX += l->getContentSize().width;
             }
         }
-        _elementRenderersContainer->setContentSize(_contentSize);
+        _elementRenderersContainer->setContentSize(_customSize);
         delete [] maxHeights;
     }
     

--- a/cocos/ui/UIRichText.h
+++ b/cocos/ui/UIRichText.h
@@ -343,6 +343,7 @@ protected:
     float _leftSpaceWidth;
     float _verticalSpace;
     Node* _elementRenderersContainer;
+    bool  _isAutoReSize;
 };
     
 }

--- a/cocos/ui/UIRichText.h
+++ b/cocos/ui/UIRichText.h
@@ -313,7 +313,10 @@ public:
      * It's usually called internally.
      */
     void formatText();
-
+   
+    void setAutoReSize(bool isAutoReSize){_isAutoReSize = isAutoReSize;}
+    bool isAutoReSize() const{ return _isAutoReSize;}
+    
     //override functions.
     virtual void setAnchorPoint(const Vec2 &pt) override;
     virtual Size getVirtualRendererSize() const override;

--- a/cocos/ui/UIRichText.h
+++ b/cocos/ui/UIRichText.h
@@ -314,8 +314,10 @@ public:
      */
     void formatText();
    
-    void setAutoReSize(bool isAutoReSize){_isAutoReSize = isAutoReSize;}
-    bool isAutoReSize() const{ return _isAutoReSize;}
+    void setAutoReSize(bool isAutoReSizeHeight,bool isAutoReSizeWidth = false){_isAutoReSizeHeight=isAutoReSizeHeight;_isAutoReSizeWidth = isAutoReSizeWidth;}
+    bool isAutoReSizeBothWidthAndHeight() const{ return _isAutoReSizeWidth&&_isAutoReSizeHeight;}
+    bool isAutoReSizeWidth() const{ return _isAutoReSizeWidth;}
+    bool isAutoReSizeHeight() const{ return _isAutoReSizeHeight;}
     
     //override functions.
     virtual void setAnchorPoint(const Vec2 &pt) override;
@@ -343,7 +345,8 @@ protected:
     float _leftSpaceWidth;
     float _verticalSpace;
     Node* _elementRenderersContainer;
-    bool  _isAutoReSize;
+    bool  _isAutoReSizeWidth;
+    bool  _isAutoReSizeHeight;
 };
     
 }


### PR DESCRIPTION
- Added four methods 
  void setAutoReSize(bool,bool = false)
  bool isAutoReSizeBothWidthAndHeight() const
  bool isAutoReSizeWidth()
  bool isAutoReSizeHeight()
  (Please help me will this some function change a name! thx!)
- Automatically adjust row height of ContextSize; automatically adjust row height and column width of a single row. 
- Satisfy developer’s needs. Automatically size adjustment is a convenient function for easily aligning text. 
