### PR TITLE
Refactor scroll view bar

### DIFF
--- a/cocos/ui/UIScrollView.cpp
+++ b/cocos/ui/UIScrollView.cpp
@@ -1149,6 +1149,33 @@ const Color3B& ScrollView::getScrollBarColor() const
     return Color3B::WHITE;
 }
 
+void ScrollView::setScrollBarOpacity(GLubyte opacity)
+{
+    CCASSERT(_scrollBarEnabled, "Scroll bar should be enabled!");
+    if(_verticalScrollBar != nullptr)
+    {
+        _verticalScrollBar->setOpacity(opacity);
+    }
+    if(_horizontalScrollBar != nullptr)
+    {
+        _horizontalScrollBar->setOpacity(opacity);
+    }
+}
+
+GLubyte ScrollView::getScrollBarOpacity() const
+{
+    CCASSERT(_scrollBarEnabled, "Scroll bar should be enabled!");
+    if(_verticalScrollBar != nullptr)
+    {
+        return _verticalScrollBar->getOpacity();
+    }
+    else if(_horizontalScrollBar != nullptr)
+    {
+        return _horizontalScrollBar->getOpacity();
+    }
+    return -1;
+}
+
 void ScrollView::setScrollBarAutoHideEnabled(bool autoHideEnabled)
 {
     CCASSERT(_scrollBarEnabled, "Scroll bar should be enabled!");

--- a/cocos/ui/UIScrollView.cpp
+++ b/cocos/ui/UIScrollView.cpp
@@ -603,7 +603,9 @@ bool ScrollView::scrollChildren(float touchOffsetX, float touchOffsetY)
         processScrollEvent(MoveDirection::RIGHT, false);
     }
     
-    return !scrolledToBottom && !scrolledToTop && !scrolledToLeft && !scrolledToRight;
+    bool scrollEnabledUpDown = (!scrolledToBottom && !scrolledToTop);
+    bool scrollEnabledLeftRight = (!scrolledToLeft && !scrolledToRight);
+    return scrollEnabledUpDown || scrollEnabledLeftRight;
 }
 
 void ScrollView::scrollToBottom(float second, bool attenuated)

--- a/cocos/ui/UIScrollView.h
+++ b/cocos/ui/UIScrollView.h
@@ -99,7 +99,8 @@ public:
         BOUNCE_TOP,
         BOUNCE_BOTTOM,
         BOUNCE_LEFT,
-        BOUNCE_RIGHT
+        BOUNCE_RIGHT,
+        CONTAINER_MOVED
     };
 
     /**
@@ -308,6 +309,20 @@ public:
      * @return The inner container size.
      */
     const Size& getInnerContainerSize() const;
+    
+    /**
+     * Set inner container position
+     *
+     * @param position Inner container position.
+     */
+    void setInnerContainerPosition(const Vec2 &pos);
+    
+    /**
+     * Get inner container position
+     *
+     * @return The inner container position.
+     */
+    const Vec2 getInnerContainerPosition() const;
 
     /**
      * Add callback function which will be called  when scrollview event triggered.

--- a/cocos/ui/UIScrollView.h
+++ b/cocos/ui/UIScrollView.h
@@ -313,7 +313,7 @@ public:
     /**
      * Set inner container position
      *
-     * @param position Inner container position.
+     * @param pos Inner container position.
      */
     void setInnerContainerPosition(const Vec2 &pos);
     

--- a/cocos/ui/UIScrollView.h
+++ b/cocos/ui/UIScrollView.h
@@ -450,6 +450,20 @@ public:
     const Color3B& getScrollBarColor() const;
     
     /**
+     * @brief Set the scroll bar's opacity
+     *
+     * @param the scroll bar's opacity
+     */
+    void setScrollBarOpacity(GLubyte opacity);
+    
+    /**
+     * @brief Get the scroll bar's opacity
+     *
+     * @return the scroll bar's opacity
+     */
+    GLubyte getScrollBarOpacity() const;
+    
+    /**
      * @brief Set scroll bar auto hide state
      *
      * @param scroll bar auto hide state

--- a/cocos/ui/UIScrollViewBar.cpp
+++ b/cocos/ui/UIScrollViewBar.cpp
@@ -103,16 +103,16 @@ bool ScrollViewBar::init()
     
     _upperHalfCircle = createSpriteFromBase64(HALF_CIRCLE_IMAGE);
     _upperHalfCircle->setAnchorPoint(Vec2::ANCHOR_MIDDLE_BOTTOM);
-    addChild(_upperHalfCircle);
+    addProtectedChild(_upperHalfCircle);
     
     _lowerHalfCircle = Sprite::createWithTexture(_upperHalfCircle->getTexture(), _upperHalfCircle->getTextureRect(), _upperHalfCircle->isTextureRectRotated());
     _lowerHalfCircle->setScaleY(-1);
     _lowerHalfCircle->setAnchorPoint(Vec2::ANCHOR_MIDDLE_BOTTOM);
-    addChild(_lowerHalfCircle);
+    addProtectedChild(_lowerHalfCircle);
     
     _body = createSpriteFromBase64(BODY_IMAGE_1_PIXEL_HEIGHT);
     _body->setAnchorPoint(Vec2::ANCHOR_MIDDLE_BOTTOM);
-    addChild(_body);
+    addProtectedChild(_body);
     
     setColor(DEFAULT_COLOR);
     

--- a/cocos/ui/UIScrollViewBar.cpp
+++ b/cocos/ui/UIScrollViewBar.cpp
@@ -31,8 +31,8 @@ NS_CC_BEGIN
 
 namespace ui {
     
-static const char* HALF_CIRCLE_IMAGE = "iVBORw0KGgoAAAANSUhEUgAAAAwAAAAGCAMAAADAMI+zAAAAIVBMVEX///////////////////////////////////////////9/gMdvAAAAC3RSTlMAAgMLLFBTYWNkZuZhN4QAAAAvSURBVAjXRchBDgAgCAPBIi0q/3+wxBiZU7cAjJpTNBSPvMLrf7tqgPkR6hB2xzpFkgIfM9q/8QAAAABJRU5ErkJggg==";
-static const char* BODY_IMAGE_1_PIXEL_HEIGHT = "iVBORw0KGgoAAAANSUhEUgAAAAwAAAABCAMAAADdNb8LAAAAA1BMVEX///+nxBvIAAAAAXRSTlNm5DccCwAAAApJREFUeAFjQAYAAA0AAWHNnKQAAAAASUVORK5CYII=";
+static const char* HALF_CIRCLE_IMAGE = "iVBORw0KGgoAAAANSUhEUgAAAAwAAAAGCAMAAADAMI+zAAAAJ1BMVEX///////////////////////////////////////////////////9Ruv0SAAAADHRSTlMABgcbbW7Hz9Dz+PmlcJP5AAAAMElEQVR4AUXHwQ2AQAhFwYcLH1H6r1djzDK3ASxUpTBeK/uTCyz7dx54b44m4p5cD1MwAooEJyk3AAAAAElFTkSuQmCC";
+static const char* BODY_IMAGE_1_PIXEL_HEIGHT = "iVBORw0KGgoAAAANSUhEUgAAAAwAAAABCAMAAADdNb8LAAAAA1BMVEX///+nxBvIAAAACklEQVR4AWNABgAADQABYc2cpAAAAABJRU5ErkJggg==";
 
 static const Color3B DEFAULT_COLOR(52, 65, 87);
 static const float DEFAULT_MARGIN = 20;
@@ -65,6 +65,7 @@ _direction(direction),
 _upperHalfCircle(nullptr),
 _lowerHalfCircle(nullptr),
 _body(nullptr),
+_opacity(100),
 _marginFromBoundary(DEFAULT_MARGIN),
 _marginForLength(DEFAULT_MARGIN),
 _touching(false),
@@ -123,7 +124,7 @@ bool ScrollViewBar::init()
     
     if(_autoHideEnabled)
     {
-        setOpacity(0);
+        ProtectedNode::setOpacity(0);
     }
     return true;
 }
@@ -165,7 +166,7 @@ void ScrollViewBar::setWidth(float width)
 void ScrollViewBar::setAutoHideEnabled(bool autoHideEnabled)
 {
     _autoHideEnabled = autoHideEnabled;
-    setOpacity(255);
+    ProtectedNode::setOpacity(_opacity);
 }
 
 float ScrollViewBar::getWidth() const
@@ -202,7 +203,7 @@ void ScrollViewBar::update(float deltaTime)
     if(_autoHideRemainingTime <= _autoHideTime)
     {
         _autoHideRemainingTime = MAX(0, _autoHideRemainingTime);
-        this->setOpacity(255 * (_autoHideRemainingTime / _autoHideTime));
+        ProtectedNode::setOpacity(_opacity * (_autoHideRemainingTime / _autoHideTime));
     }
 }
 
@@ -236,7 +237,7 @@ void ScrollViewBar::onScrolled(const Vec2& outOfBoundary)
     if(_autoHideEnabled)
     {
         _autoHideRemainingTime = _autoHideTime;
-        setOpacity(255);
+        ProtectedNode::setOpacity(_opacity);
     }
     
     Layout* innerContainer = _parent->getInnerContainer();

--- a/cocos/ui/UIScrollViewBar.h
+++ b/cocos/ui/UIScrollViewBar.h
@@ -130,6 +130,8 @@ public:
     /**
      * @lua NA
      */
+    virtual void setOpacity(GLubyte opacity) override { _opacity = opacity; }
+    virtual GLubyte getOpacity() const override { return _opacity; }
     virtual void onEnter() override;
     virtual void update(float deltaTime) override;
     
@@ -158,6 +160,8 @@ private:
     Sprite* _upperHalfCircle;
     Sprite* _lowerHalfCircle;
     Sprite* _body;
+    
+    GLubyte _opacity;
 	
     float _marginFromBoundary;
     float _marginForLength;


### PR DESCRIPTION
Refactor scroll view and scroll bar
- Added methods to manipulate scroll bar's opacity
- Refined scroll event dispatching.
  - Previously, scroll events were dispatched BEFORE the container moved. It caused that event listener has no way to know how much scrolled and where the inner container is now. It is changed to be dispatched AFTER the container moved.
  - Added an event which informs the inner container is moved. It is dispatched whenever the inner container's position is changed even without scroll like jump or direct changing.
