### PR TITLE
fix Sprite::setColor() not working with AutoPolygon

### DIFF
--- a/cocos/2d/CCSprite.cpp
+++ b/cocos/2d/CCSprite.cpp
@@ -948,6 +948,8 @@ void Sprite::updateColor(void)
     _quad.tl.colors = color4;
     _quad.tr.colors = color4;
 
+    _polyInfo.setQuad(&_quad);
+
     // renders using batch node
     if (_batchNode)
     {


### PR DESCRIPTION
When setting the color on a Sprite initialized with a PolygonInfo, the internal Sprite _polyInfo is not updated from the _quad. Therefore, it has no effect when the sprite is drawn.
