### PR TITLE
Unregister spine event lua event handler should set listener to null.

### DIFF
--- a/cocos/scripting/lua-bindings/manual/spine/lua_cocos2dx_spine_manual.cpp
+++ b/cocos/scripting/lua-bindings/manual/spine/lua_cocos2dx_spine_manual.cpp
@@ -295,15 +295,19 @@ int tolua_Cocos2d_CCSkeletonAnimation_unregisterSpineEventHandler00(lua_State* t
             switch (eventType) {
                 case spEventType::SP_ANIMATION_START:
                     handlerType = ScriptHandlerMgr::HandlerType::EVENT_SPINE_ANIMATION_START;
+                    self->setStartListener(nullptr);
                     break;
                 case spEventType::SP_ANIMATION_END:
                     handlerType = ScriptHandlerMgr::HandlerType::EVENT_SPINE_ANIMATION_END;
+                    self->setEndListener(nullptr);
                     break;
                 case spEventType::SP_ANIMATION_COMPLETE:
                     handlerType = ScriptHandlerMgr::HandlerType::EVENT_SPINE_ANIMATION_COMPLETE;
+                    self->setCompleteListener(nullptr);
                     break;
                 case spEventType::SP_ANIMATION_EVENT:
                     handlerType = ScriptHandlerMgr::HandlerType::EVENT_SPINE_ANIMATION_EVENT;
+                    self->setEventListener(nullptr);
                     break;
                     
                 default:


### PR DESCRIPTION
if do not set listener to null, it will continue be called, but failed.
