### PR TITLE
EditBox now calls EditBoxDelegate::editBoxReturn only when return button is pressed on iOS and OS X

### DIFF
--- a/cocos/ui/UIEditBox/UIEditBox.h
+++ b/cocos/ui/UIEditBox/UIEditBox.h
@@ -75,7 +75,7 @@ namespace ui {
         virtual void editBoxTextChanged(EditBox* editBox, const std::string& text) {};
             
         /**
-         * This method is called when the return button was pressed or the outside area of keyboard was touched.
+         * This method is called when the return button was pressed.
          * @param editBox The edit box object that generated the event.
          */
         virtual void editBoxReturn(EditBox* editBox) = 0;

--- a/cocos/ui/UIEditBox/UIEditBoxImpl-ios.mm
+++ b/cocos/ui/UIEditBox/UIEditBoxImpl-ios.mm
@@ -136,6 +136,11 @@ static const int CC_EDIT_BOX_PADDING = 5;
 - (BOOL)textFieldShouldReturn:(UITextField *)sender
 {
     if (sender == textField_) {
+        cocos2d::ui::EditBoxDelegate* pDelegate = getEditBoxImplIOS()->getDelegate();
+        if (pDelegate != NULL)
+        {
+            pDelegate->editBoxReturn(getEditBoxImplIOS()->getEditBox());
+        }
         [sender resignFirstResponder];
     }
     return NO;
@@ -189,7 +194,6 @@ static const int CC_EDIT_BOX_PADDING = 5;
     if (pDelegate != NULL)
     {
         pDelegate->editBoxEditingDidEnd(getEditBoxImplIOS()->getEditBox());
-        pDelegate->editBoxReturn(getEditBoxImplIOS()->getEditBox());
     }
     
 #if CC_ENABLE_SCRIPT_BINDING

--- a/cocos/ui/UIEditBox/UIEditBoxImpl-mac.mm
+++ b/cocos/ui/UIEditBox/UIEditBoxImpl-mac.mm
@@ -222,6 +222,11 @@
 - (BOOL)textFieldShouldReturn:(NSTextField *)sender
 {
     if (sender == textField_ || sender == secureTextField_) {
+        cocos2d::ui::EditBoxDelegate* pDelegate = getEditBoxImplMac()->getDelegate();
+        if (pDelegate != NULL)
+        {
+            pDelegate->editBoxReturn(getEditBoxImplMac()->getEditBox());
+        }
         [sender resignFirstResponder];
     }
     return NO;
@@ -258,7 +263,6 @@
     if (pDelegate != NULL)
     {
         pDelegate->editBoxEditingDidEnd(getEditBoxImplMac()->getEditBox());
-        pDelegate->editBoxReturn(getEditBoxImplMac()->getEditBox());
     }
     
 #if CC_ENABLE_SCRIPT_BINDING


### PR DESCRIPTION
Right now, the `editBoxEditingDidEnd` and `editBoxReturn` methods are called simultaneously.
This pull request makes `editBoxReturn` be called only after `return` button is pressed on iOS and OS X.
