### PR TITLE
fixed Scale9Sprite gray state issue.

### DIFF
--- a/cocos/ui/UIScale9Sprite.cpp
+++ b/cocos/ui/UIScale9Sprite.cpp
@@ -58,6 +58,7 @@ namespace ui {
         ,_flippedX(false)
         ,_flippedY(false)
         ,_isPatch9(false)
+        ,_brightState(State::NORMAL)
 
     {
         this->setAnchorPoint(Vec2(0.5,0.5));
@@ -556,6 +557,7 @@ namespace ui {
         }
 
         applyBlendFunc();
+        this->setState(_brightState);
         if(this->_isPatch9)
         {
             size.width = size.width - 2;
@@ -1051,7 +1053,11 @@ namespace ui {
         CC_SAFE_DELETE(pReturn);
         return NULL;
     }
-
+    
+    Scale9Sprite::State Scale9Sprite::getState()const
+    {
+        return _brightState;
+    }
 
     void Scale9Sprite::setState(cocos2d::ui::Scale9Sprite::State state)
     {
@@ -1070,7 +1076,7 @@ namespace ui {
         default:
             break;
         }
-
+        
         if (nullptr != _scale9Image)
         {
             _scale9Image->setGLProgramState(glState);
@@ -1083,6 +1089,7 @@ namespace ui {
                 sp->setGLProgramState(glState);
             }
         }
+        _brightState = state;
     }
 
 /** sets the opacity.

--- a/cocos/ui/UIScale9Sprite.h
+++ b/cocos/ui/UIScale9Sprite.h
@@ -467,6 +467,13 @@ namespace ui {
         void setState(State state);
         
         /**
+         * Query the current bright state.
+         * @return @see `State`
+         * @since v3.7
+         */
+        State getState()const;
+        
+        /**
          * @brief Query the sprite's original size.
          *
          * @return Sprite size.
@@ -743,6 +750,7 @@ namespace ui {
         bool _flippedX;
         bool _flippedY;
         bool _isPatch9;
+        State _brightState;
     };
     
 }}  //end of namespace

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIButtonTest/UIButtonTest.cpp
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIButtonTest/UIButtonTest.cpp
@@ -1009,6 +1009,8 @@ bool UIButtonDisableDefaultTest::init()
         button->setZoomScale(0.4f);
         button->setPressedActionEnabled(true);
         button->setBright(false);
+        button->setScale9Enabled(true);
+        button->setCapInsets(Rect(3,3,5,5));
         button->addClickEventListener([=](Ref*){
             button->setBright(true);
         });


### PR DESCRIPTION
When call `setCapInsets`, the Scale9Sprite's inner sprite will be
rebuild and it's state will be lose.

This commit reset the shader state.
