### PR TITLE
Fixing crash in Allocator if there are no allocated pages

### DIFF
--- a/cocos/base/allocator/CCAllocatorStrategyFixedBlock.h
+++ b/cocos/base/allocator/CCAllocatorStrategyFixedBlock.h
@@ -89,14 +89,13 @@ public:
         AllocatorDiagnostics::instance()->untrackAllocator(this);
 #endif
 
-        do
+        while (_pages)
         {
             intptr_t* page = (intptr_t*)_pages;
             intptr_t* next = (intptr_t*)*page;
             ccAllocatorGlobal.deallocate(page);
             _pages = (void*)next;
         }
-        while (_pages);
     }
     
     // @brief


### PR DESCRIPTION
This issue happens when _pages are null, trying to get item from it will cause a crash. 
