### PR TITLE
Fix ClippingRectangleNode scissor positioning

### DIFF
--- a/cocos/2d/CCClippingRectangleNode.cpp
+++ b/cocos/2d/CCClippingRectangleNode.cpp
@@ -42,11 +42,21 @@ void ClippingRectangleNode::onBeforeVisitScissor()
     if (_clippingEnabled) {
         glEnable(GL_SCISSOR_TEST);
 
+        float scaleX = _scaleX;
+        float scaleY = _scaleY;
+        Node *parent = this->getParent();
+        while (parent) {
+            scaleX *= parent->getScaleX();
+            scaleY *= parent->getScaleY();
+            parent = parent->getParent();
+        }
+
+        const Point pos = convertToWorldSpace(Point(_clippingRegion.origin.x, _clippingRegion.origin.y));
         GLView* glView = Director::getInstance()->getOpenGLView();
-        glView->setScissorInPoints(_clippingRegion.origin.x,
-                                   _clippingRegion.origin.y,
-                                   _clippingRegion.size.width,
-                                   _clippingRegion.size.height);
+        glView->setScissorInPoints(pos.x,
+                                   pos.y,
+                                   _clippingRegion.size.width * scaleX,
+                                   _clippingRegion.size.height * scaleY);
     }
 }
 


### PR DESCRIPTION
Currently, `onBeforeVisitScissor` function scales BOTH the position and
size by the nodes world scale.  The position, however, is already in
world coordinates since it is passed through `convertToWorldSpace`. This
change ensures that a rectangle in the local space of the node which
is passed into `setClippingRegion` is correctly converted to GL coords
before it is passed to `glScissor`.
