### PR TITLE
[ci skip] Fixed #12918 : TMXXMLParser.cpp -- In the function getRectForGID have…

### DIFF
--- a/cocos/2d/CCTMXXMLParser.cpp
+++ b/cocos/2d/CCTMXXMLParser.cpp
@@ -88,8 +88,13 @@ Rect TMXTilesetInfo::getRectForGID(uint32_t gid)
     rect.size = _tileSize;
     gid &= kTMXFlippedMask;
     gid = gid - _firstGid;
-    int max_x = (int)((_imageSize.width - _margin*2 + _spacing) / (_tileSize.width + _spacing));
-    //    int max_y = (imageSize.height - margin*2 + spacing) / (tileSize.height + spacing);
+    // max_x means the colum count in tile map
+    // in the origin:
+    // max_x = (int)((_imageSize.width - _margin*2 + _spacing) / (_tileSize.width + _spacing));
+    // but in editor "Tield", _margin variable only effect the left side
+    // for compatible with "Tield", change the max_x calculation
+    int max_x = (int)((_imageSize.width - _margin + _spacing) / (_tileSize.width + _spacing));
+    
     rect.origin.x = (gid % max_x) * (_tileSize.width + _spacing) + _margin;
     rect.origin.y = (gid / max_x) * (_tileSize.height + _spacing) + _margin;
     return rect;


### PR DESCRIPTION
… small errors

related issue: #12918 

the code changes only _margin*2 -> _margin 
so ci skip
