### PR TITLE
Implement CCDirector#getScreenCenter

### DIFF
--- a/cocos/base/CCDirector.cpp
+++ b/cocos/base/CCDirector.cpp
@@ -761,6 +761,18 @@ Size Director::getWinSizeInPixels() const
     return Size(_winSizeInPoints.width * _contentScaleFactor, _winSizeInPoints.height * _contentScaleFactor);
 }
 
+Vec2 Director::getScreenCenter() const
+{
+    Size screenSize = this->getWinSize();
+    return Vec2(screenSize.width * 0.5f, screenSize.height * 0.5f);
+}
+
+Vec2 Director::getScreenCenterInPixels() const
+{
+    Size screenSize = this->getWinSizeInPixels();
+    return Vec2(screenSize.width * 0.5f, screenSize.height * 0.5f);
+}
+
 Size Director::getVisibleSize() const
 {
     if (_openGLView)

--- a/cocos/base/CCDirector.h
+++ b/cocos/base/CCDirector.h
@@ -237,6 +237,12 @@ public:
     /** Returns the size of the OpenGL view in pixels. */
     Size getWinSizeInPixels() const;
     
+    /** Returns the center coordinate of the OpenGL view in points. */
+    Vec2 getScreenCenter() const;
+    
+    /** Returns the center coordinate of the OpenGL view in pixels. */
+    Vec2 getScreenCenterInPixels() const;
+    
     /** 
      * Returns visible size of the OpenGL view in points.
      * The value is equal to `Director::getWinSize()` if don't invoke `GLView::setDesignResolutionSize()`.


### PR DESCRIPTION
We often use center coordinates  of screen. For example drawing the background image.

This PR provides the way to get screen center easily.

These methods are inspired by on Kobold2D. (It is an extension of cocos2d-iPhone.)

https://github.com/kobold2d/kobold2d/blob/master/Kobold2D/__Kobold2D__/kobold2d/cocos2d-ext/CCDirectorExtensions.m#L16
