### PR TITLE
Add CREATE_SCENE_FUNC Macro

### DIFF
--- a/cocos/platform/CCPlatformMacros.h
+++ b/cocos/platform/CCPlatformMacros.h
@@ -78,6 +78,30 @@ CC_DEPRECATED_ATTRIBUTE static __TYPE__* node() \
     } \
 }
 
+/** @def CREATE_SCENE_FUNC(__TYPE__)
+ * Define a createScene function for a specific node, such as Layer.
+ *
+ * @param __TYPE__  class type to add createScene(), such as Layer.
+ */
+#define CREATE_SCENE_FUNC(__TYPE__) \
+static cocos2d::Scene* createScene() \
+{ \
+__TYPE__ *pRet = new(std::nothrow) __TYPE__(); \
+if (pRet && pRet->init()) \
+{ \
+pRet->autorelease(); \
+cocos2d::Scene * scene = cocos2d::Scene::create(); \
+scene->addChild(pRet); \
+return scene; \
+} \
+else \
+{ \
+delete pRet; \
+pRet = NULL; \
+return NULL; \
+} \
+}
+
 /** @def CC_ENABLE_CACHE_TEXTURE_DATA
  * Enable it if you want to cache the texture data.
  * Not enabling for Emscripten any more -- doesn't seem necessary and don't want

--- a/templates/cpp-template-default/Classes/HelloWorldScene.cpp
+++ b/templates/cpp-template-default/Classes/HelloWorldScene.cpp
@@ -2,21 +2,6 @@
 
 USING_NS_CC;
 
-Scene* HelloWorld::createScene()
-{
-    // 'scene' is an autorelease object
-    auto scene = Scene::create();
-    
-    // 'layer' is an autorelease object
-    auto layer = HelloWorld::create();
-
-    // add layer as a child to scene
-    scene->addChild(layer);
-
-    // return the scene
-    return scene;
-}
-
 // on "init" you need to initialize your instance
 bool HelloWorld::init()
 {

--- a/templates/cpp-template-default/Classes/HelloWorldScene.h
+++ b/templates/cpp-template-default/Classes/HelloWorldScene.h
@@ -6,9 +6,6 @@
 class HelloWorld : public cocos2d::Layer
 {
 public:
-    // there's no 'id' in cpp, so we recommend returning the class instance pointer
-    static cocos2d::Scene* createScene();
-
     // Here's a difference. Method 'init' in cocos2d-x returns bool, instead of returning 'id' in cocos2d-iphone
     virtual bool init();
     
@@ -17,6 +14,8 @@ public:
     
     // implement the "static create()" method manually
     CREATE_FUNC(HelloWorld);
+    // Implement the "static createScene()" method manually
+    CREATE_SCENE_FUNC(HelloWorld);
 };
 
 #endif // __HELLOWORLD_SCENE_H__


### PR DESCRIPTION
In common way, we implement `createScene` method for `Layer` classes.

This Macro implements the method to get the specific Node as wrapped Scene automatically.

``` cpp
class YourLayer :public cocos2d::Scene
{
  public:
    bool init() override;
    CREATE_SCENE_FUNC(YourLayer);
}
```

``` cpp
auto scene = YourLayer::createScene();
Director::getIntance()->replaceScene(scene);
```
