### PR TITLE
[ci skip] Solve the error in lua template.

### DIFF
--- a/templates/lua-template-default/frameworks/runtime-src/proj.win32/HelloLua.vcxproj
+++ b/templates/lua-template-default/frameworks/runtime-src/proj.win32/HelloLua.vcxproj
@@ -159,7 +159,6 @@ xcopy "$(ProjectDir)..\..\..\src" "$(LocalDebuggerWorkingDirectory)\src" /D /E /
       <AdditionalDependencies>libcurl_imp.lib;websockets.lib;%(AdditionalDependencies);$(_COCOS_LIB_WIN32_BEGIN);$(_COCOS_LIB_WIN32_END)</AdditionalDependencies>
       <IgnoreSpecificDefaultLibraries>libcmt.lib</IgnoreSpecificDefaultLibraries>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <OutputFile>$(ProjectDir)../../../simulator/win32/$(TargetName)$(TargetExt)</OutputFile>
     </Link>
     <ResourceCompile>
       <Culture>0x0409</Culture>


### PR DESCRIPTION
The VS release configuration of lua template cause `cocos run` error.
