### PR TITLE
Fix parser compatible for layer project file

### DIFF
--- a/cocos/editor-support/cocostudio/FlatBuffersSerialize.cpp
+++ b/cocos/editor-support/cocostudio/FlatBuffersSerialize.cpp
@@ -269,7 +269,7 @@ std::string FlatBuffersSerialize::serializeFlatBuffersWithXMLFile(const std::str
                     else
                         nameElem = nameElem->Next();
                 }
-                if (rootType == "GameNodeObjectData")  // for adaptate old version
+                if (rootType == "GameNodeObjectData" || rootType == "GameLayerObjectData")  // for adaptate old version
                     rootType = "NodeObjectData";
 
                 nodeTree = createNodeTree(objectData, rootType);
@@ -1318,7 +1318,7 @@ FlatBufferBuilder* FlatBuffersSerialize::createFlatBuffersWithXMLFileForSimulato
                     else
                         nameElem = nameElem->Next();
                 }
-                if (rootType == "GameNodeObjectData")  // for adaptate old version
+                if (rootType == "GameNodeObjectData" || rootType == "GameLayerObjectData")  // for adaptate old version
                     rootType = "NodeObjectData";
                 nodeTree = createNodeTreeForSimulator(objectData, rootType);
             }


### PR DESCRIPTION
The new reader update for bone animation cause a layer csb file parse issue, scene embed layer will cause simulator crash
