### PR TITLE
Fixed a compile error when CC_SPRITE_DEBUG_DRAW is on

### DIFF
--- a/cocos/2d/CCSprite.cpp
+++ b/cocos/2d/CCSprite.cpp
@@ -294,7 +294,7 @@ Sprite::Sprite(void)
 , _insideBounds(true)
 {
 #if CC_SPRITE_DEBUG_DRAW
-    debugDraw(true)
+    debugDraw(true);
 #endif //CC_SPRITE_DEBUG_DRAW
 }
 


### PR DESCRIPTION
There was a missing semi-colon after debugDraw(true)
