### PR TITLE
fix bug: crash when use bone after erase it form Vector.

### DIFF
--- a/cocos/editor-support/cocostudio/ActionTimeline/CCBoneNode.cpp
+++ b/cocos/editor-support/cocostudio/ActionTimeline/CCBoneNode.cpp
@@ -111,24 +111,24 @@ void BoneNode::removeChild(Node* child, bool cleanup /* = true */)
 
 void BoneNode::removeFromBoneList(BoneNode* bone)
 {
-    _childBones.eraseObject(bone);
     auto skeletonNode = dynamic_cast<SkeletonNode*>(bone);
-    if (skeletonNode != nullptr) // nested skeleton
-        return;
-
-    bone->_rootSkeleton = nullptr;
-    auto subBones = bone->getAllSubBones();
-    subBones.pushBack(bone);
-    for (auto &subBone : subBones)
+    if (skeletonNode == nullptr) //not a nested skeleton
     {
-        subBone->_rootSkeleton = nullptr;
-        _rootSkeleton->_subBonesMap.erase(subBone->getName());
-        if (bone->_isRackShow && bone->_visible)
+        bone->_rootSkeleton = nullptr;
+        auto subBones = bone->getAllSubBones();
+        subBones.pushBack(bone);
+        for (auto &subBone : subBones)
         {
-            _rootSkeleton->_subDrawBonesDirty = true;
-            _rootSkeleton->_subDrawBonesOrderDirty = true;
+            subBone->_rootSkeleton = nullptr;
+            _rootSkeleton->_subBonesMap.erase(subBone->getName());
+            if (bone->_isRackShow && bone->_visible)
+            {
+                _rootSkeleton->_subDrawBonesDirty = true;
+                _rootSkeleton->_subDrawBonesOrderDirty = true;
+            }
         }
     }
+    _childBones.eraseObject(bone);
 }
 
 void BoneNode::addToBoneList(BoneNode* bone)
@@ -375,8 +375,8 @@ void BoneNode::onDraw(const cocos2d::Mat4 &transform, uint32_t flags)
     glDrawArrays(GL_TRIANGLE_FAN, 0, 4);
 
 #ifdef CC_STUDIO_ENABLED_VIEW
-    glVertexAttribPointer(GLProgram::VERTEX_ATTRIB_POSITION, 3, GL_FLOAT, GL_FALSE, 0, _noMVPVertices);
-    glVertexAttribPointer(GLProgram::VERTEX_ATTRIB_COLOR, 4, GL_FLOAT, GL_FALSE, 0, _squareColors);
+    glVertexAttribPointer(cocos2d::GLProgram::VERTEX_ATTRIB_POSITION, 3, GL_FLOAT, GL_FALSE, 0, _noMVPVertices);
+    glVertexAttribPointer(cocos2d::GLProgram::VERTEX_ATTRIB_COLOR, 4, GL_FLOAT, GL_FALSE, 0, _squareColors);
     
     glEnable(GL_LINE_SMOOTH);
     glHint(GL_LINE_SMOOTH_HINT, GL_DONT_CARE);

--- a/cocos/editor-support/cocostudio/ActionTimeline/CCSkeletonNode.cpp
+++ b/cocos/editor-support/cocostudio/ActionTimeline/CCSkeletonNode.cpp
@@ -275,10 +275,10 @@ void SkeletonNode::onDraw(const cocos2d::Mat4 &transform, uint32_t flags)
     //
 #ifdef EMSCRIPTEN
     setGLBufferData(_noMVPVertices, 8 * sizeof(Vec3), 0);
-    glVertexAttribPointer(GLProgram::VERTEX_ATTRIB_POSITION, 3, GL_FLOAT, GL_FALSE, 0, 0);
+    glVertexAttribPointer(cocos2d::GLProgram::VERTEX_ATTRIB_POSITION, 3, GL_FLOAT, GL_FALSE, 0, 0);
 
     setGLBufferData(_squareColors, 8 * sizeof(Color4F), 1);
-    glVertexAttribPointer(GLProgram::VERTEX_ATTRIB_COLOR, 4, GL_FLOAT, GL_FALSE, 0, 0);
+    glVertexAttribPointer(cocos2d::GLProgram::VERTEX_ATTRIB_COLOR, 4, GL_FLOAT, GL_FALSE, 0, 0);
 #else
     glBindBuffer(GL_ARRAY_BUFFER, 0);
     glVertexAttribPointer(cocos2d::GLProgram::VERTEX_ATTRIB_POSITION, 3, GL_FLOAT, GL_FALSE, 0, _noMVPVertices);

--- a/cocos/editor-support/cocostudio/ActionTimeline/CCSkeletonNode.cpp
+++ b/cocos/editor-support/cocostudio/ActionTimeline/CCSkeletonNode.cpp
@@ -270,20 +270,9 @@ void SkeletonNode::onDraw(const cocos2d::Mat4 &transform, uint32_t flags)
 
     cocos2d::GL::enableVertexAttribs(cocos2d::GL::VERTEX_ATTRIB_FLAG_POSITION | cocos2d::GL::VERTEX_ATTRIB_FLAG_COLOR);
 
-    //
-    // Attributes
-    //
-#ifdef EMSCRIPTEN
-    setGLBufferData(_noMVPVertices, 8 * sizeof(Vec3), 0);
-    glVertexAttribPointer(cocos2d::GLProgram::VERTEX_ATTRIB_POSITION, 3, GL_FLOAT, GL_FALSE, 0, 0);
-
-    setGLBufferData(_squareColors, 8 * sizeof(Color4F), 1);
-    glVertexAttribPointer(cocos2d::GLProgram::VERTEX_ATTRIB_COLOR, 4, GL_FLOAT, GL_FALSE, 0, 0);
-#else
     glBindBuffer(GL_ARRAY_BUFFER, 0);
     glVertexAttribPointer(cocos2d::GLProgram::VERTEX_ATTRIB_POSITION, 3, GL_FLOAT, GL_FALSE, 0, _noMVPVertices);
     glVertexAttribPointer(cocos2d::GLProgram::VERTEX_ATTRIB_COLOR, 4, GL_FLOAT, GL_FALSE, 0, _squareColors);
-#endif // EMSCRIPTEN
 
     cocos2d::GL::blendFunc(_blendFunc.src, _blendFunc.dst);
 

--- a/tests/cpp-tests/Classes/ExtensionsTest/CocoStudioActionTimelineTest/ActionTimelineTestScene.cpp
+++ b/tests/cpp-tests/Classes/ExtensionsTest/CocoStudioActionTimelineTest/ActionTimelineTestScene.cpp
@@ -545,7 +545,6 @@ void TestActionTimelineSkeleton::onEnter()
         {
             nestSkeleton->removeFromParentAndCleanup(false);
         }
-        // bug fixed while leftleg's child hide with leftleg's visible
     });
 }
 


### PR DESCRIPTION
fix bug: crash when use bone after erase it form Vector. move the operation before erase, make sure bone ref\* is not realeaed
