### PR TITLE
Fix AssetsManager crash by protecting Downloader with shared_ptr

### DIFF
--- a/cocos/platform/mac/CCDevice-mac.mm
+++ b/cocos/platform/mac/CCDevice-mac.mm
@@ -39,8 +39,7 @@ int Device::getDPI()
     NSScreen *screen = [NSScreen mainScreen];
     NSDictionary *description = [screen deviceDescription];
     NSSize displayPixelSize = [[description objectForKey:NSDeviceSize] sizeValue];
-    CGSize displayPhysicalSize = CGDisplayScreenSize(
-                                                     [[description objectForKey:@"NSScreenNumber"] unsignedIntValue]);
+    CGSize displayPhysicalSize = CGDisplayScreenSize([[description objectForKey:@"NSScreenNumber"] unsignedIntValue]);
        
     return ((displayPixelSize.width / displayPhysicalSize.width) * 25.4f);
 }

--- a/extensions/assets-manager/AssetsManagerEx.cpp
+++ b/extensions/assets-manager/AssetsManagerEx.cpp
@@ -81,7 +81,7 @@ AssetsManagerEx::AssetsManagerEx(const std::string& manifestUrl, const std::stri
     _fileUtils = FileUtils::getInstance();
     _updateState = State::UNCHECKED;
 
-    _downloader = std::make_shared<Downloader>();
+    _downloader = std::shared_ptr<Downloader>(new Downloader);
     _downloader->setConnectionTimeout(DEFAULT_CONNECTION_TIMEOUT);
     _downloader->_onError = std::bind(&AssetsManagerEx::onError, this, std::placeholders::_1);
     _downloader->_onProgress = std::bind(&AssetsManagerEx::onProgress,

--- a/extensions/assets-manager/Downloader.cpp
+++ b/extensions/assets-manager/Downloader.cpp
@@ -392,6 +392,7 @@ void Downloader::downloadToBufferSync(const std::string &srcUrl, unsigned char *
 void Downloader::downloadToBuffer(const std::string &srcUrl, const std::string &customId, const StreamData &buffer, const ProgressData &data)
 {
     std::weak_ptr<Downloader> ptr = shared_from_this();
+    std::shared_ptr<Downloader> shared = ptr.lock();
     CURL *curl = curl_easy_init();
     if (!curl)
     {
@@ -463,6 +464,7 @@ void Downloader::downloadSync(const std::string &srcUrl, const std::string &stor
 void Downloader::download(const std::string &srcUrl, const std::string &customId, const FileDescriptor &fDesc, const ProgressData &data)
 {
     std::weak_ptr<Downloader> ptr = shared_from_this();
+    std::shared_ptr<Downloader> shared = ptr.lock();
     CURL *curl = curl_easy_init();
     if (!curl)
     {
@@ -524,6 +526,7 @@ void Downloader::batchDownloadSync(const DownloadUnits &units, const std::string
 {
     // Make sure downloader won't be released
     std::weak_ptr<Downloader> ptr = shared_from_this();
+    std::shared_ptr<Downloader> shared = ptr.lock();
     
     if (units.size() != 0)
     {


### PR DESCRIPTION
Fix for https://github.com/cocos2d/cocos2d-x/issues/9061
