### PR TITLE
Add getFileExtension to FileUtils

### DIFF
--- a/cocos/3d/CCBundle3D.cpp
+++ b/cocos/3d/CCBundle3D.cpp
@@ -182,8 +182,7 @@ bool Bundle3D::load(const std::string& path)
     getModelRelativePath(path);
 
     bool ret = false;
-    std::string ext = path.substr(path.length() - 4, 4);
-    std::transform(ext.begin(), ext.end(), ext.begin(), tolower);
+    std::string ext = FileUtils::getInstance()->getFileExtension(path);
     if (ext == ".c3t")
     {
         _isBinary = false;
@@ -2151,8 +2150,7 @@ std::vector<Vec3> Bundle3D::getTrianglesList(const std::string& path)
         return trianglesList;
     
     auto bundle = Bundle3D::createBundle();
-    std::string ext = path.substr(path.length() - 4, 4);
-    std::transform(ext.begin(), ext.end(), ext.begin(), tolower);
+    std::string ext = FileUtils::getInstance()->getFileExtension(path);
     MeshDatas meshs;
     if (ext == ".obj")
     {

--- a/cocos/3d/CCSprite3D.cpp
+++ b/cocos/3d/CCSprite3D.cpp
@@ -231,8 +231,7 @@ bool Sprite3D::loadFromFile(const std::string& path, NodeDatas* nodedatas, MeshD
 {
     std::string fullPath = FileUtils::getInstance()->fullPathForFilename(path);
     
-    std::string ext = path.substr(path.length() - 4, 4);
-    std::transform(ext.begin(), ext.end(), ext.begin(), tolower);
+    std::string ext = FileUtils::getInstance()->getFileExtension(path);
     if (ext == ".obj")
     {
         return Bundle3D::loadObj(*meshdatas, *materialdatas, *nodedatas, fullPath);

--- a/cocos/audio/win32/AudioEngine-win32.cpp
+++ b/cocos/audio/win32/AudioEngine-win32.cpp
@@ -120,28 +120,34 @@ AudioCache* AudioEngineImpl::preload(const std::string& filePath, std::function<
             break;
         }
 
-        auto ext = strchr(filePath.c_str(), '.');
         AudioCache::FileFormat fileFormat = AudioCache::FileFormat::UNKNOWN;
 
-        if (_stricmp(ext, ".ogg") == 0){
+        std::string fileExtension = FileUtils::getInstance()->getFileExtension(filePath);
+        if (fileExtension == ".ogg")
+        {
             fileFormat = AudioCache::FileFormat::OGG;
         }
-        else if (_stricmp(ext, ".mp3") == 0){
+        else if (fileExtension == ".mp3")
+        {
             fileFormat = AudioCache::FileFormat::MP3;
 
-            if (MPG123_LAZYINIT){
+            if (MPG123_LAZYINIT)
+            {
                 auto error = mpg123_init();
-                if (error == MPG123_OK){
+                if (error == MPG123_OK)
+                {
                     MPG123_LAZYINIT = false;
                 }
-                else{
+                else
+                {
                     log("Basic setup goes wrong: %s", mpg123_plain_strerror(error));
                     break;
                 }
             }
         }
-        else{
-            log("unsupported media type:%s\n", ext);
+        else
+        {
+            log("Unsupported media type file: %s\n", filePath.c_str());
             break;
         }
 

--- a/cocos/audio/win32/MciPlayer.cpp
+++ b/cocos/audio/win32/MciPlayer.cpp
@@ -1,5 +1,6 @@
 #include "MciPlayer.h"
 #include <tchar.h>
+#include "platform/CCFileUtils.h"
 
 #define WIN_CLASS_NAME        "CocosDenshionCallbackWnd"
 #define BREAK_IF(cond)      if (cond) break;
@@ -79,10 +80,8 @@ void MciPlayer::Open(const char* pFileName, UINT uId)
 //         pBuf = new WCHAR[nLen + 1];
 //         BREAK_IF(! pBuf);
 //         MultiByteToWideChar(CP_ACP, 0, pFileName, nLen + 1, pBuf, nLen + 1);
-        
-        std::string strFile(pFileName);
-        int nPos = strFile.rfind(".") + 1;
-        strExt = strFile.substr(nPos, strFile.length() - nPos);
+
+        strExt = cocos2d::FileUtils::getInstance()->getFileExtension(pFileName);
 
         Close();
 
@@ -141,7 +140,7 @@ void MciPlayer::Pause()
 
 void MciPlayer::Resume()
 {
-    if (strExt == "mid" || strExt == "MID")
+    if (strExt == ".mid")
     {
         // midi not supprt MCI_RESUME, should get the position and use MCI_FROM
         MCI_STATUS_PARMS mciStatusParms;

--- a/cocos/audio/winrt/AudioEngine-winrt.cpp
+++ b/cocos/audio/winrt/AudioEngine-winrt.cpp
@@ -54,20 +54,23 @@ AudioCache* AudioEngineImpl::preload(const std::string& filePath, std::function<
         if (it == _audioCaches.end()) {
             FileFormat fileFormat = FileFormat::UNKNOWN;
 
-            auto ext = filePath.substr(filePath.rfind('.'));
-            transform(ext.begin(), ext.end(), ext.begin(), tolower);
+            std::string fileExtension = FileUtils::getInstance()->getFileExtension(filePath);
 
-            if (ext.compare(".wav") == 0){
+            if (fileExtension == ".wav")
+            {
                 fileFormat = FileFormat::WAV;
             }
-            else if (ext.compare(".ogg") == 0){
+            else if (fileExtension == ".ogg")
+            {
                 fileFormat = FileFormat::OGG;
             }
-            else if (ext.compare(".mp3") == 0){
+            else if (fileExtension == ".mp3")
+            {
                 fileFormat = FileFormat::MP3;
             }
-            else{
-                log("unsupported media type:%s\n", ext.c_str());
+            else
+            {
+                log("Unsupported media type file: %s\n", filePath.c_str());
                 break;
             }
 
@@ -78,7 +81,8 @@ AudioCache* AudioEngineImpl::preload(const std::string& filePath, std::function<
             audioCache->_fileFullPath = fullPath;
             AudioEngine::addTask(std::bind(&AudioCache::readDataTask, audioCache));
         }
-        else {
+        else 
+        {
             audioCache = &it->second;
         }
     } while (false);

--- a/cocos/editor-support/cocostudio/CCComRender.cpp
+++ b/cocos/editor-support/cocostudio/CCComRender.cpp
@@ -189,14 +189,8 @@ bool ComRender::serialize(void* r)
             }
             else if(strcmp(className, "CCArmature") == 0)
             {
-                std::string file_extension = filePath;
-                size_t pos = filePath.find_last_of('.');
-                if (pos != std::string::npos)
-                {
-                    file_extension = filePath.substr(pos, filePath.length());
-                    std::transform(file_extension.begin(),file_extension.end(), file_extension.begin(), (int(*)(int))toupper);
-                }
-                if (file_extension == ".JSON" || file_extension == ".EXPORTJSON")
+                std::string fileExtension = FileUtils::getInstance()->getFileExtension(filePath);
+                if (fileExtension == ".json" || fileExtension == ".exportjson")
                 {
                     rapidjson::Document doc;
                     if(!readJson(filePath.c_str(), doc))
@@ -225,7 +219,7 @@ bool ComRender::serialize(void* r)
                     }
                     ret = true;
                 }
-                else if (file_extension == ".CSB")
+                else if (fileExtension == ".csb")
                 {
                     std::string binaryFilePath = FileUtils::getInstance()->fullPathForFilename(filePath.c_str());
                     auto fileData = FileUtils::getInstance()->getDataFromFile(binaryFilePath);
@@ -299,14 +293,8 @@ bool ComRender::serialize(void* r)
             }
             else if(strcmp(className, "GUIComponent") == 0)
             {
-                std::string file_extension = filePath;
-                size_t pos = filePath.find_last_of('.');
-                if (pos != std::string::npos)
-                {
-                    file_extension = filePath.substr(pos, filePath.length());
-                    std::transform(file_extension.begin(),file_extension.end(), file_extension.begin(), (int(*)(int))toupper);
-                }
-                if (file_extension == ".JSON" || file_extension == ".EXPORTJSON")
+                std::string fileExtension = FileUtils::getInstance()->getFileExtension(filePath);
+                if (fileExtension == ".json" || fileExtension == ".exportjson")
                 {
                     cocos2d::ui::Widget* widget = GUIReader::getInstance()->widgetFromJsonFile(filePath.c_str());
                     _render = widget;
@@ -314,7 +302,7 @@ bool ComRender::serialize(void* r)
                     
                     ret = true;
                 }
-                else if (file_extension == ".CSB")
+                else if (fileExtension == ".csb")
                 {
                     cocos2d::ui::Widget* widget = GUIReader::getInstance()->widgetFromBinaryFile(filePath.c_str());
                     _render = widget;

--- a/cocos/editor-support/cocostudio/CCDataReaderHelper.cpp
+++ b/cocos/editor-support/cocostudio/CCDataReaderHelper.cpp
@@ -295,14 +295,11 @@ void DataReaderHelper::addDataFromFile(const std::string& filePath)
         basefilePath = "";
     }
 
-
-    std::string filePathStr =  filePath;
-    size_t startPos = filePathStr.find_last_of(".");
-    std::string str = &filePathStr[startPos];
+    std::string fileExtension = cocos2d::FileUtils::getInstance()->getFileExtension(filePath);
 
     // Read content from file
     std::string fullPath = FileUtils::getInstance()->fullPathForFilename(filePath);
-    bool isbinaryfilesrc = str==".csb";
+    bool isbinaryfilesrc = fileExtension == ".csb";
     std::string filemode("r");
     if(isbinaryfilesrc)
         filemode += "b";
@@ -314,14 +311,14 @@ void DataReaderHelper::addDataFromFile(const std::string& filePath)
     _dataReaderHelper->_getFileMutex.unlock();
     
     DataInfo dataInfo;
-    dataInfo.filename = filePathStr;
+    dataInfo.filename = filePath;
     dataInfo.asyncStruct = nullptr;
     dataInfo.baseFilePath = basefilePath;
-    if (str == ".xml")
+    if (fileExtension == ".xml")
     {
         DataReaderHelper::addDataFromCache(contentStr, &dataInfo);
     }
-    else if(str == ".json" || str == ".ExportJson")
+    else if(fileExtension == ".json" || fileExtension == ".exportjson")
     {
         DataReaderHelper::addDataFromJsonCache(contentStr, &dataInfo);
     }
@@ -408,13 +405,10 @@ void DataReaderHelper::addDataFromFileAsync(const std::string& imagePath, const 
     data->imagePath = imagePath;
     data->plistPath = plistPath;
 
-    std::string filePathStr =  filePath;
-    size_t startPos = filePathStr.find_last_of(".");
-    std::string str = &filePathStr[startPos];
-
+    std::string fileExtension = cocos2d::FileUtils::getInstance()->getFileExtension(filePath);
     std::string fullPath = FileUtils::getInstance()->fullPathForFilename(filePath);
 
-    bool isbinaryfilesrc = str==".csb";
+    bool isbinaryfilesrc = fileExtension == ".csb";
     std::string filereadmode("r");
     if (isbinaryfilesrc) {
         filereadmode += "b";
@@ -435,11 +429,11 @@ void DataReaderHelper::addDataFromFileAsync(const std::string& imagePath, const 
     // fix memory leak for v3.3
     free(pBytes);
     
-    if (str == ".xml")
+    if (fileExtension == ".xml")
     {
         data->configType = DragonBone_XML;
     }
-    else if(str == ".json" || str == ".ExportJson")
+    else if(fileExtension == ".json" || fileExtension == ".exportjson")
     {
         data->configType = CocoStudio_JSON;
     }

--- a/cocos/editor-support/cocostudio/CCSSceneReader.cpp
+++ b/cocos/editor-support/cocostudio/CCSSceneReader.cpp
@@ -56,15 +56,8 @@ const char* SceneReader::sceneReaderVersion()
 
 cocos2d::Node* SceneReader::createNodeWithSceneFile(const std::string &fileName, AttachComponentType attachComponent /*= AttachComponentType::EMPTY_NODE*/)
 {
-    std::string reDir = fileName;
-    std::string file_extension = "";
-    size_t pos = reDir.find_last_of('.');
-    if (pos != std::string::npos)
-    {
-        file_extension = reDir.substr(pos, reDir.length());
-        std::transform(file_extension.begin(),file_extension.end(), file_extension.begin(), (int(*)(int))toupper);
-    }
-    if (file_extension == ".JSON")
+    std::string fileExtension = cocos2d::FileUtils::getInstance()->getFileExtension(fileName);
+    if (fileExtension == ".json")
     {
         _node = nullptr;
         rapidjson::Document jsonDict;
@@ -76,7 +69,7 @@ cocos2d::Node* SceneReader::createNodeWithSceneFile(const std::string &fileName,
         
         return _node;
     }
-    else if(file_extension == ".CSB")
+    else if(fileExtension == ".csb")
     {
         do {
             std::string binaryFilePath = FileUtils::getInstance()->fullPathForFilename(fileName);

--- a/cocos/platform/CCFileUtils.cpp
+++ b/cocos/platform/CCFileUtils.cpp
@@ -1267,5 +1267,19 @@ bool FileUtils::isPopupNotify() const
     return s_popupNotify;
 }
 
+std::string FileUtils::getFileExtension(const std::string& filePath) const
+{
+    std::string fileExtension;
+    size_t pos = filePath.find_last_of('.');
+    if (pos != std::string::npos)
+    {
+        fileExtension = filePath.substr(pos, filePath.length());
+
+        std::transform(fileExtension.begin(), fileExtension.end(), fileExtension.begin(), ::tolower);
+    }
+
+    return fileExtension;
+}
+
 NS_CC_END
 

--- a/cocos/platform/CCFileUtils.h
+++ b/cocos/platform/CCFileUtils.h
@@ -396,6 +396,14 @@ public:
     virtual bool isFileExist(const std::string& filename) const;
 
     /**
+    *  Gets filename extension is a suffix (separated from the base filename by a dot) in lower case.
+    *  Examples of filename extensions are .png, .jpeg, .exe, .dmg and .txt.
+    *  @param filePath The path of the file, it could be a relative or absolute path.
+    *  @return suffix for filename in lower case or empty if a dot not found.
+    */
+    virtual std::string getFileExtension(const std::string& filePath) const;
+
+    /**
      *  Checks whether the path is an absolute path.
      *
      *  @note On Android, if the parameter passed in is relative to "assets/", this method will treat it as an absolute path.

--- a/cocos/platform/CCImage.cpp
+++ b/cocos/platform/CCImage.cpp
@@ -1817,17 +1817,9 @@ bool Image::initWithTGAData(tImageTGA* tgaData)
     
     if (ret)
     {
-        if (_filePath.length() > 0)
+        if (FileUtils::getInstance()->getFileExtension(_filePath) != ".tga")
         {
-            const unsigned char tgaSuffix [] = ".tga";
-            for (int i = 0; i < 4; ++i)
-            {
-                if (tolower(_filePath[_filePath.length() - i - 1]) != tgaSuffix[3 - i])
-                {
                     CCLOG("Image WARNING: the image file suffix is not tga, but parsed as a tga image file. FILE: %s", _filePath.c_str());
-                    break;
-                };
-            }
         }
     }
     else
@@ -2197,36 +2189,21 @@ bool Image::saveToFile(const std::string& filename, bool isToRGB)
         return false;
     }
 
-    bool ret = false;
+    std::string fileExtension = FileUtils::getInstance()->getFileExtension(filename);
 
-    do 
+    if (fileExtension == ".png")
     {
-
-        CC_BREAK_IF(filename.size() <= 4);
-
-        std::string strLowerCasePath(filename);
-        for (unsigned int i = 0; i < strLowerCasePath.length(); ++i)
-        {
-            strLowerCasePath[i] = tolower(filename[i]);
-        }
-
-        if (std::string::npos != strLowerCasePath.find(".png"))
-        {
-            CC_BREAK_IF(!saveImageToPNG(filename, isToRGB));
-        }
-        else if (std::string::npos != strLowerCasePath.find(".jpg"))
-        {
-            CC_BREAK_IF(!saveImageToJPG(filename));
-        }
-        else
-        {
-            break;
-        }
-
-        ret = true;
-    } while (0);
-
-    return ret;
+        return saveImageToPNG(filename, isToRGB);
+    }
+    else if (fileExtension == ".jpg")
+    {
+        return saveImageToJPG(filename);
+    }
+    else
+    {
+        CCLOG("cocos2d: Image: saveToFile no support file extension(only .png or .jpg) for file: %s", filename.c_str());
+        return false;
+    }
 }
 #endif
 

--- a/cocos/platform/win32/CCDevice-win32.cpp
+++ b/cocos/platform/win32/CCDevice-win32.cpp
@@ -113,9 +113,7 @@ public:
             if (fontName.c_str())
             {
                 // create font from ttf file
-                int nFindttf = fontName.find(".ttf");
-                int nFindTTF = fontName.find(".TTF");
-                if (nFindttf >= 0 || nFindTTF >= 0)
+                if (FileUtils::getInstance()->getFileExtension(fontName) == ".ttf")
                 {
                     fontPath = FileUtils::getInstance()->fullPathForFilename(fontName.c_str());
                     int nFindPos = fontName.rfind("/");


### PR DESCRIPTION
Gets filename extension is a suffix (separated from the base filename by
a dot) in lower case.

More code need get filename extension, everyone does it differently.
use check UPPER and lower case, use . and no(example ".csb", ".CSB",
"csb" )

And bag in AudioEngineImpl: find point from left( ext =
strchr(filePath.c_str(), '.'); )
If file path contains point. always unsupported media type
