### PR TITLE
Use GL_GENERATE_MIPMAP for OpenGL version less 3.0

### DIFF
--- a/cocos/3d/CCTerrain.cpp
+++ b/cocos/3d/CCTerrain.cpp
@@ -858,8 +858,8 @@ bool Terrain::initTextures()
         auto textImage = new (std::nothrow)Image();
         textImage->initWithImageFile(_terrainData._detailMaps[0]._detailMapSrc);
         auto texture = new (std::nothrow)Texture2D();
+        texture->setAutoGenerateMipmap(true);
         texture->initWithImage(textImage);
-        texture->generateMipmap();
         _detailMapTextures[0] = texture;
         texParam.minFilter = GL_LINEAR_MIPMAP_LINEAR;
         texParam.magFilter = GL_LINEAR;
@@ -884,9 +884,9 @@ bool Terrain::initTextures()
             auto textImage = new (std::nothrow)Image();
             textImage->initWithImageFile(_terrainData._detailMaps[i]._detailMapSrc);
             auto texture = new (std::nothrow)Texture2D();
+            texture->setAutoGenerateMipmap(true);
             texture->initWithImage(textImage);
             delete textImage;
-            texture->generateMipmap();
             _detailMapTextures[i] = texture;
 
             texParam.wrapS = GL_REPEAT;

--- a/cocos/base/CCConfiguration.cpp
+++ b/cocos/base/CCConfiguration.cpp
@@ -49,6 +49,7 @@ Configuration::Configuration()
 , _supportsBGRA8888(false)
 , _supportsDiscardFramebuffer(false)
 , _supportsShareableVAO(false)
+, _supportsGenerateMipmap(false)
 , _maxSamplesAllowed(0)
 , _maxTextureUnits(0)
 , _glExtensions(nullptr)
@@ -148,7 +149,22 @@ void Configuration::gatherGPUInfo()
 	_valueDict["gl.supports_discard_framebuffer"] = Value(_supportsDiscardFramebuffer);
 
     _supportsShareableVAO = checkForGLExtension("vertex_array_object");
-	_valueDict["gl.supports_vertex_array_object"] = Value(_supportsShareableVAO);
+    _valueDict["gl.supports_vertex_array_object"] = Value(_supportsShareableVAO);
+
+    _supportsGenerateMipmap = true;
+
+#ifndef GL_ES_VERSION_2_0
+    // glGenerateMipmap supports:
+    // OpenGL ES 2.0 or greater https://www.khronos.org/opengles/sdk/docs/man3/html/glGenerateMipmap.xhtml
+    // OpenGL 3.0 or greater https://www.opengl.org/sdk/docs/man/html/glGenerateMipmap.xhtml
+
+    float glVersion = _valueDict["gl.version"].asFloat();
+    if (glVersion < 3.0)
+    {
+        _supportsGenerateMipmap = false;
+    }
+#endif
+    _valueDict["gl.supports_generate_mipmap"] = Value(_supportsGenerateMipmap);
 
     CHECK_GL_ERROR_DEBUG();
 }
@@ -257,6 +273,11 @@ bool Configuration::supportsShareableVAO() const
 #else
     return false;
 #endif
+}
+
+bool Configuration::supportsGenerateMipmap() const
+{
+    return _supportsGenerateMipmap;
 }
 
 int Configuration::getMaxSupportDirLightInShader() const

--- a/cocos/base/CCConfiguration.h
+++ b/cocos/base/CCConfiguration.h
@@ -144,7 +144,14 @@ public:
      * @return Is true if supports shareable VAOs.
      * @since v2.0.0
      */
-	bool supportsShareableVAO() const;
+    bool supportsShareableVAO() const;
+
+    /** Whether or not glGenerateMipmap are supported.
+    *
+    * @return Is true if glGenerateMipmap.
+    * @since v3.8.0
+    */
+    bool supportsGenerateMipmap() const;
     
     /** Max support directional light in shader, for Sprite3D.
      *
@@ -232,6 +239,7 @@ protected:
     bool            _supportsBGRA8888;
     bool            _supportsDiscardFramebuffer;
     bool            _supportsShareableVAO;
+    bool            _supportsGenerateMipmap;
     GLint           _maxSamplesAllowed;
     GLint           _maxTextureUnits;
     char *          _glExtensions;

--- a/cocos/renderer/CCMaterial.cpp
+++ b/cocos/renderer/CCMaterial.cpp
@@ -221,7 +221,15 @@ bool Material::parseSampler(GLProgramState* glProgramState, Properties* samplerP
     // required
     auto filename = samplerProperties->getString("path");
 
-    auto texture = Director::getInstance()->getTextureCache()->addImage(filename);
+    // mipmap
+    bool generateMipMap = false;
+    const char* mipmap = getOptionalString(samplerProperties, "mipmap", "false");
+    if (mipmap && strcasecmp(mipmap, "true") == 0) 
+    {
+        generateMipMap = true;
+    }
+
+    auto texture = Director::getInstance()->getTextureCache()->addImage(filename, generateMipMap);
     if (!texture) {
         CCLOG("Invalid filepath");
         return false;
@@ -231,14 +239,6 @@ bool Material::parseSampler(GLProgramState* glProgramState, Properties* samplerP
 
     {
         Texture2D::TexParams texParams;
-
-        // mipmap
-        bool usemipmap = false;
-        const char* mipmap = getOptionalString(samplerProperties, "mipmap", "false");
-        if (mipmap && strcasecmp(mipmap, "true")==0) {
-            texture->generateMipmap();
-            usemipmap = true;
-        }
 
         // valid options: REPEAT, CLAMP
         const char* wrapS = getOptionalString(samplerProperties, "wrapS", "CLAMP_TO_EDGE");
@@ -261,7 +261,7 @@ bool Material::parseSampler(GLProgramState* glProgramState, Properties* samplerP
 
 
         // valid options: NEAREST, LINEAR, NEAREST_MIPMAP_NEAREST, LINEAR_MIPMAP_NEAREST, NEAREST_MIPMAP_LINEAR, LINEAR_MIPMAP_LINEAR
-        const char* minFilter = getOptionalString(samplerProperties, "minFilter", usemipmap ? "LINEAR_MIPMAP_NEAREST" : "LINEAR");
+        const char* minFilter = getOptionalString(samplerProperties, "minFilter", generateMipMap ? "LINEAR_MIPMAP_NEAREST" : "LINEAR");
         if (strcasecmp(minFilter, "NEAREST")==0)
             texParams.minFilter = GL_NEAREST;
         else if(strcasecmp(minFilter, "LINEAR")==0)

--- a/cocos/renderer/CCTexture2D.cpp
+++ b/cocos/renderer/CCTexture2D.cpp
@@ -433,6 +433,7 @@ Texture2D::Texture2D()
 , _maxT(0.0)
 , _hasPremultipliedAlpha(false)
 , _hasMipmaps(false)
+, _generateMipmaps(false)
 , _shaderProgram(nullptr)
 , _antialiasEnabled(true)
 , _ninePatchInfo(nullptr)
@@ -550,8 +551,6 @@ bool Texture2D::initWithData(const void *data, ssize_t dataLen, Texture2D::Pixel
 
 bool Texture2D::initWithMipmaps(MipmapInfo* mipmaps, int mipmapsNum, PixelFormat pixelFormat, int pixelsWide, int pixelsHigh)
 {
-
-
     //the pixelFormat must be a certain value 
     CCASSERT(pixelFormat != PixelFormat::NONE && pixelFormat != PixelFormat::AUTO, "the \"pixelFormat\" param must be a certain value!");
     CCASSERT(pixelsWide>0 && pixelsHigh>0, "Invalid size");
@@ -627,6 +626,15 @@ bool Texture2D::initWithMipmaps(MipmapInfo* mipmaps, int mipmapsNum, PixelFormat
     glTexParameteri( GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE );
     glTexParameteri( GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE );
 
+#ifndef GL_ES_VERSION_2_0
+    if (mipmapsNum == 1 && _generateMipmaps && !Configuration::getInstance()->supportsGenerateMipmap())
+    {
+        // glGenerateMipmap supports: OpenGL ES 2.0 or greater and OpenGL 3.0 or greater
+        // https://www.opengl.org/wiki/Common_Mistakes#Automatic_mipmap_generation
+        glTexParameteri(GL_TEXTURE_2D, GL_GENERATE_MIPMAP, GL_TRUE); 
+    }
+#endif
+
 #if CC_ENABLE_CACHE_TEXTURE_DATA
     if (_antialiasEnabled)
     {
@@ -689,7 +697,12 @@ bool Texture2D::initWithMipmaps(MipmapInfo* mipmaps, int mipmapsNum, PixelFormat
     _maxT = 1;
 
     _hasPremultipliedAlpha = false;
-    _hasMipmaps = mipmapsNum > 1;
+    _hasMipmaps = mipmapsNum > 1 || _generateMipmaps;
+
+    if (_generateMipmaps)
+    {
+        generateMipmapInternal();
+    }
 
     // shader
     setGLProgram(GLProgramCache::getInstance()->getGLProgram(GLProgram::SHADER_NAME_POSITION_TEXTURE));
@@ -1205,15 +1218,22 @@ void Texture2D::PVRImagesHavePremultipliedAlpha(bool haveAlphaPremultiplied)
 //
 // implementation Texture2D (GLFilter)
 
-void Texture2D::generateMipmap()
+void Texture2D::generateMipmapInternal()
 {
-    CCASSERT(_pixelsWide == ccNextPOT(_pixelsWide) && _pixelsHigh == ccNextPOT(_pixelsHigh), "Mipmap texture only works in POT textures");
-    GL::bindTexture2D( _name );
-    glGenerateMipmap(GL_TEXTURE_2D);
-    _hasMipmaps = true;
+    if (Configuration::getInstance()->supportsGenerateMipmap())
+    {
+        CCASSERT(_pixelsWide == ccNextPOT(_pixelsWide) && _pixelsHigh == ccNextPOT(_pixelsHigh), "Mipmap texture only works in POT textures");
+        GL::bindTexture2D( _name );
+        glGenerateMipmap(GL_TEXTURE_2D);
+        _hasMipmaps = true;
 #if CC_ENABLE_CACHE_TEXTURE_DATA
-    VolatileTextureMgr::setHasMipmaps(this, _hasMipmaps);
+        VolatileTextureMgr::setHasMipmaps(this, _hasMipmaps);
 #endif
+    }
+    else
+    {
+        CCLOG("glGenerateMipmap required OpenGL 3.0 or OpenGL ES 2.0 or greater");
+    }
 }
 
 bool Texture2D::hasMipmaps() const
@@ -1434,6 +1454,11 @@ void Texture2D::removeSpriteFrameCapInset(SpriteFrame* spriteFrame)
             capInsetMap.erase(spriteFrame);
         }
     }
+}
+
+void Texture2D::setAutoGenerateMipmap(bool generateMipmaps)
+{
+    _generateMipmaps = generateMipmaps;
 }
 
 NS_CC_END

--- a/cocos/renderer/CCTexture2D.cpp
+++ b/cocos/renderer/CCTexture2D.cpp
@@ -699,7 +699,7 @@ bool Texture2D::initWithMipmaps(MipmapInfo* mipmaps, int mipmapsNum, PixelFormat
     _hasPremultipliedAlpha = false;
     _hasMipmaps = mipmapsNum > 1 || _generateMipmaps;
 
-    if (_generateMipmaps)
+    if (mipmapsNum == 1 && _generateMipmaps && Configuration::getInstance()->supportsGenerateMipmap())
     {
         generateMipmapInternal();
     }

--- a/cocos/renderer/CCTexture2D.h
+++ b/cocos/renderer/CCTexture2D.h
@@ -339,11 +339,19 @@ public:
     void setAliasTexParameters();
 
 
-    /** Generates mipmap images for the texture.
+    /** DEPRECATED, use setAutoGenerateMipmap(before call init)
+    Generates mipmap images for the texture.
     It only works if the texture size is POT (power of 2).
     @since v0.99.0
     */
-    void generateMipmap();
+    CC_DEPRECATED_ATTRIBUTE void generateMipmap(){ generateMipmapInternal(); }
+
+    /** Need generate mipmap images for the texture.
+    Call before init
+    It only works if the texture size is POT (power of 2).
+    @since v3.8.0
+    */
+    void setAutoGenerateMipmap(bool generateMipmaps);
 
     /** Returns the pixel format.
      @since v2.0
@@ -429,6 +437,12 @@ private:
      * @return True is Texture contains a 9-patch info, false otherwise.
      */
     bool isContain9PatchInfo()const;
+
+    /** Generates mipmap images for the texture.
+    It only works if the texture size is POT (power of 2).
+    @since v0.99.0
+    */
+    void generateMipmapInternal();
 
     /**
      * Get spriteFrame capInset, If spriteFrame can't be found in 9-patch info map,
@@ -529,6 +543,9 @@ protected:
     
     /** whether or not the texture has mip maps*/
     bool _hasMipmaps;
+
+    /** whether or not generate the texture mip maps*/
+    bool _generateMipmaps;
 
     /** shader program used by drawAtPoint and drawInRect */
     GLProgram* _shaderProgram;

--- a/cocos/renderer/CCTextureCache.h
+++ b/cocos/renderer/CCTextureCache.h
@@ -107,9 +107,10 @@ public:
     * Object and it will return it. It will use the filename as a key.
     * Otherwise it will return a reference of a previously loaded image.
     * Supported image extensions: .png, .bmp, .tiff, .jpeg, .pvr.
-     @param filepath A null terminated string.
+    @param filepath A null terminated string.
+    @param generateMipMap need generate mipmap levels(if image does not contain).
     */
-    Texture2D* addImage(const std::string &filepath);
+    Texture2D* addImage(const std::string &filepath, bool generateMipMap = false);
 
     /** Returns a Texture2D object given a file image.
     * If the file image was not previously loaded, it will create a new Texture2D object and it will return it.
@@ -118,9 +119,10 @@ public:
     * Supported image extensions: .png, .jpg
      @param filepath A null terminated string.
      @param callback A callback function would be inovked after the image is loaded.
+     @param generateMipMap need generate mipmap levels(if image does not contain).
      @since v0.8
     */
-    virtual void addImageAsync(const std::string &filepath, const std::function<void(Texture2D*)>& callback);
+    virtual void addImageAsync(const std::string &filepath, const std::function<void(Texture2D*)>& callback, bool generateMipMap = false);
     
     /** Unbind a specified bound image asynchronous callback.
      * In the case an object who was bound to an image asynchronous callback was destroyed before the callback is invoked,
@@ -139,9 +141,10 @@ public:
     * If the image was not previously loaded, it will create a new Texture2D object and it will return it.
     * Otherwise it will return a reference of a previously loaded image.
     * @param key The "key" parameter will be used as the "key" for the cache.
+    @param generateMipMap need generate mipmap levels(if image does not contain).
     * If "key" is nil, then a new texture will be created each time.
     */
-    Texture2D* addImage(Image *image, const std::string &key);
+    Texture2D* addImage(Image *image, const std::string &key, bool generateMipMap = false);
     CC_DEPRECATED_ATTRIBUTE Texture2D* addUIImage(Image *image, const std::string& key) { return addImage(image,key); }
 
     /** Returns an already created texture. Returns nil if the texture doesn't exist.


### PR DESCRIPTION
glGenerateMipmap supports:
OpenGL ES 2.0 or greater
https://www.khronos.org/opengles/sdk/docs/man3/html/glGenerateMipmap.xhtml
OpenGL 3.0 or greater
https://www.opengl.org/sdk/docs/man/html/glGenerateMipmap.xhtml

Add Configuration::supportsGenerateMipmap() for check it
Add Texture2D::setAutoGenerateMipmap for use old GL_GENERATE_MIPMAP (
need set before glTexImage2D ), and use it any initWithImage

GL_GENERATE_MIPMAP  -
https://www.opengl.org/wiki/Common_Mistakes#Automatic_mipmap_generation
