### PR TITLE
Made SocketIO events correctly fired when compile in release mode

### DIFF
--- a/cocos/scripting/js-bindings/manual/extension/jsb_cocos2dx_extension_manual.cpp
+++ b/cocos/scripting/js-bindings/manual/extension/jsb_cocos2dx_extension_manual.cpp
@@ -535,7 +535,6 @@ static bool js_cocos2dx_CCTableView_init(JSContext *cx, uint32_t argc, jsval *vp
             cocos2d::Node* arg2;
             do 
             {
-                js_proxy_t *proxy;
                 JSObject *tmpObj = args.get(2).toObjectOrNull();
                 proxy = jsb_get_js_proxy(tmpObj);
                 arg2 = (cocos2d::Node*)(proxy ? proxy->ptr : NULL);
@@ -567,22 +566,19 @@ class JSB_ControlButtonTarget : public Ref
 {
 public:
     JSB_ControlButtonTarget()
-    : _jsFunc(nullptr),
+    : _callback(nullptr),
+      _jsFunc(nullptr),
       _type(Control::EventType::TOUCH_DOWN),
-      _jsTarget(nullptr),
       _needUnroot(false)
     {}
     
     virtual ~JSB_ControlButtonTarget()
     {
         CCLOGINFO("In the destruction of JSB_ControlButtonTarget ...");
-        JSContext* cx = ScriptingCore::getInstance()->getGlobalContext();
-        if (_needUnroot)
+        if (_callback != nullptr)
         {
-            JS::RemoveObjectRoot(cx, &_jsTarget);
+            CC_SAFE_DELETE(_callback);
         }
-        
-        JS::RemoveObjectRoot(cx, &_jsFunc);
 
         for (auto iter = _jsNativeTargetMap.begin(); iter != _jsNativeTargetMap.end(); ++iter)
         {
@@ -604,36 +600,26 @@ public:
             return;
         }
         
+        JSContext* cx = ScriptingCore::getInstance()->getGlobalContext();
+        
         jsval dataVal[2];
         dataVal[0] = OBJECT_TO_JSVAL(p->obj);
         int arg1 = (int)event;
         dataVal[1] = INT_TO_JSVAL(arg1);
-
-        JSContext* cx = ScriptingCore::getInstance()->getGlobalContext();
         JS::RootedValue jsRet(cx);
-
-        ScriptingCore::getInstance()->executeJSFunctionWithThisObj(JS::RootedValue(cx, OBJECT_TO_JSVAL(_jsTarget)), JS::RootedValue(cx, OBJECT_TO_JSVAL(_jsFunc)), JS::HandleValueArray::fromMarkedLocation(2, dataVal), &jsRet);
-    }
-    
-    void setJSTarget(JSObject* pJSTarget)
-    {
-        _jsTarget = pJSTarget;
         
-        js_proxy_t* p = jsb_get_js_proxy(_jsTarget);
-        if (!p)
-        {
-            JSContext* cx = ScriptingCore::getInstance()->getGlobalContext();
-            JS::AddNamedObjectRoot(cx, &_jsTarget, "JSB_ControlButtonTarget, target");
-            _needUnroot = true;
-        }
+        _callback->invoke(2, dataVal, &jsRet);
     }
     
-    void setJSAction(JSObject* jsFunc)
+    void setJSCallback(jsval jsFunc, JSObject* jsTarget)
     {
-        _jsFunc = jsFunc;
-
+        if (_callback != nullptr)
+        {
+            CC_SAFE_DELETE(_callback);
+        }
         JSContext* cx = ScriptingCore::getInstance()->getGlobalContext();
-        JS::AddNamedObjectRoot(cx, &_jsFunc, "JSB_ControlButtonTarget, func");
+        _callback = new JSFunctionWrapper(cx, jsTarget, jsFunc);
+        _jsFunc = jsFunc.toObjectOrNull();
     }
     
     void setEventType(Control::EventType type)
@@ -643,10 +629,10 @@ public:
 public:
     
     static std::multimap<JSObject*, JSB_ControlButtonTarget*> _jsNativeTargetMap;
-    JS::Heap<JSObject*> _jsFunc;
+    JSFunctionWrapper *_callback;
     Control::EventType _type;
+    JSObject *_jsFunc;
 private:
-    JS::Heap<JSObject*> _jsTarget;
     bool _needUnroot;
 };
 
@@ -684,8 +670,7 @@ static bool js_cocos2dx_CCControl_addTargetWithActionForControlEvents(JSContext 
         // save the delegate
         JSB_ControlButtonTarget* nativeDelegate = new JSB_ControlButtonTarget();
         
-        nativeDelegate->setJSTarget(jsDelegate);
-        nativeDelegate->setJSAction(jsFunc);
+        nativeDelegate->setJSCallback(args.get(1), jsDelegate);
         nativeDelegate->setEventType(arg2);
 
         __Array* nativeDelegateArray = static_cast<__Array*>(cobj->getUserObject());

--- a/cocos/scripting/js-bindings/manual/network/jsb_socketio.cpp
+++ b/cocos/scripting/js-bindings/manual/network/jsb_socketio.cpp
@@ -32,84 +32,45 @@
 
 using namespace cocos2d::network;
 
-class JSB_SIOEvent : public cocos2d::Object {
-public:
-    JSB_SIOEvent();
-    virtual ~JSB_SIOEvent();
-    void setJSCallbackFunc(jsval obj);
-    const jsval& getJSCallbackFunc() const;
-    
-private:
-    JS::Heap<jsval> _jsCallback;
-    JS::Heap<jsval> _extraData;
-
-};
-
-JSB_SIOEvent::JSB_SIOEvent()
-: _jsCallback(JSVAL_VOID), _extraData(JSVAL_VOID)
-{
-
-}
-
-JSB_SIOEvent::~JSB_SIOEvent()
-{
-    JSContext* cx = ScriptingCore::getInstance()->getGlobalContext();
-    JS::RemoveValueRoot(cx, &_jsCallback);
-}
-
-void JSB_SIOEvent::setJSCallbackFunc(jsval func) {
-    _jsCallback = func;
-    JSContext* cx = ScriptingCore::getInstance()->getGlobalContext();
-    // Root the callback function.
-    JS::AddNamedValueRoot(cx, &_jsCallback, "JSB_SIOEvent_callback_func");
-}
-
-const jsval& JSB_SIOEvent::getJSCallbackFunc() const
-{
-    return _jsCallback;
-}
-
 //c++11 map to callbacks
-typedef std::unordered_map<std::string, JSB_SIOEvent> JSB_SIOEventRegistry;
+typedef std::unordered_map<std::string, std::shared_ptr<JSFunctionWrapper>> JSB_SIOCallbackRegistry;
 
-class JSB_SocketIODelegate : public SocketIO::SIODelegate {
+class JSB_SocketIODelegate : public SocketIO::SIODelegate
+{
 public:
 
-    JSB_SocketIODelegate() {
-        JSB_SIOEvent tmp;
+    JSB_SocketIODelegate()
+    {
         std::string s = "default";
-        _eventRegistry[s] = tmp;
+        _eventRegistry[s] = nullptr;
     }
     
-    virtual void onConnect(SIOClient* client) {
+    virtual void onConnect(SIOClient* client)
+    {
         CCLOG("JSB SocketIO::SIODelegate->onConnect method called from native");
-
         this->fireEventToScript(client, "connect", "");
-
     }
 
-    virtual void onMessage(SIOClient* client, const std::string& data) {
+    virtual void onMessage(SIOClient* client, const std::string& data)
+    {
         CCLOG("JSB SocketIO::SIODelegate->onMessage method called from native with data: %s", data.c_str());
-        
         this->fireEventToScript(client, "message", data);
-
     }
 
-    virtual void onClose(SIOClient* client) {
+    virtual void onClose(SIOClient* client)
+    {
         CCLOG("JSB SocketIO::SIODelegate->onClose method called from native");
-        
         this->fireEventToScript(client, "disconnect", "");
-
     }
 
-    virtual void onError(SIOClient* client, const std::string& data) {
+    virtual void onError(SIOClient* client, const std::string& data)
+    {
         CCLOG("JSB SocketIO::SIODelegate->onError method called from native with data: %s", data.c_str());
-
         this->fireEventToScript(client, "error", data);
-
     }
 
-    virtual void fireEventToScript(SIOClient* client, const std::string& eventName, const std::string& data) {
+    virtual void fireEventToScript(SIOClient* client, const std::string& eventName, const std::string& data)
+    {
         CCLOG("JSB SocketIO::SIODelegate->fireEventToScript method called from native with name '%s' data: %s", eventName.c_str(), data.c_str());
 
         js_proxy_t * p = jsb_get_native_proxy(client);
@@ -118,63 +79,71 @@ public:
         JSContext* cx = ScriptingCore::getInstance()->getGlobalContext();
 
         jsval args;
-        if(data == "") {
+        if(data == "")
+        {
             args = JSVAL_NULL;
-        } else {
+        } else
+        {
             args = std_string_to_jsval(cx, data);
         }
 
         //ScriptingCore::getInstance()->executeFunctionWithOwner(OBJECT_TO_JSVAL(_JSDelegate), eventName.c_str(), 1, &args);
         
-        JSB_SIOEventRegistry::iterator it = _eventRegistry.find(eventName);
+        JSB_SIOCallbackRegistry::iterator it = _eventRegistry.find(eventName);
         
-        if(it != _eventRegistry.end()) {
-            JSB_SIOEvent e = it->second;
-            JS::RootedValue rval(cx);
-            ScriptingCore::getInstance()->executeJSFunctionWithThisObj(JS::RootedValue(cx, OBJECT_TO_JSVAL(p->obj)), JS::RootedValue(cx, e.getJSCallbackFunc()), JS::HandleValueArray::fromMarkedLocation(1, &args), &rval);
+        if(it != _eventRegistry.end())
+        {
+            std::shared_ptr<JSFunctionWrapper> callback = it->second;
+            if (callback != nullptr)
+            {
+                JS::RootedValue rval(cx);
+                callback->invoke(1, &args, &rval);
+            }
         }
         
     }
 
-    void setJSDelegate(JSObject* pJSDelegate) {
+    void setJSDelegate(JSObject* pJSDelegate)
+    {
         _JSDelegate = pJSDelegate;
     }
 
-    void addEvent(const std::string& eventName, JSB_SIOEvent jsevent) {
-        _eventRegistry[eventName] = jsevent;
+    void addEvent(const std::string& eventName, std::shared_ptr<JSFunctionWrapper> callback)
+    {
+        _eventRegistry[eventName] = callback;
     }
 
 private:
     JS::Heap<JSObject*> _JSDelegate;
-
-    JSB_SIOEventRegistry _eventRegistry;
+    JSB_SIOCallbackRegistry _eventRegistry;
 
 };
 
 JSClass  *js_cocos2dx_socketio_class;
 JSObject *js_cocos2dx_socketio_prototype;
 
-void js_cocos2dx_SocketIO_finalize(JSFreeOp *fop, JSObject *obj) {
+void js_cocos2dx_SocketIO_finalize(JSFreeOp *fop, JSObject *obj)
+{
     CCLOG("jsbindings: finalizing JS object %p (SocketIO)", obj);
 }
 
 bool js_cocos2dx_SocketIO_constructor(JSContext *cx, uint32_t argc, jsval *vp)
 {
     JS_ReportError(cx, "SocketIO isn't meant to be instantiated, use SocketIO.connect() instead");
-
     return false;
 }
 
-bool js_cocos2dx_SocketIO_connect(JSContext* cx, uint32_t argc, jsval* vp){
+bool js_cocos2dx_SocketIO_connect(JSContext* cx, uint32_t argc, jsval* vp)
+{
     CCLOG("JSB SocketIO.connect method called");
 
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
-
-    if (argc == 1 || argc == 2) {
-        
+    if (argc == 1 || argc == 2)
+    {
         std::string url;
         
-        do {
+        do
+        {
             bool ok = jsval_to_std_string(cx, args.get(0), &url);
             JSB_PRECONDITION2( ok, cx, false, "Error processing arguments");
         } while (0);
@@ -182,41 +151,41 @@ bool js_cocos2dx_SocketIO_connect(JSContext* cx, uint32_t argc, jsval* vp){
         JSB_SocketIODelegate* siodelegate = new JSB_SocketIODelegate();
         
         CCLOG("Calling native SocketIO.connect method");
-        SIOClient* ret = SocketIO::connect(*siodelegate, url);
+        SIOClient* ret = SocketIO::connect(url, *siodelegate);
         
         jsval jsret;
-        do{
-            if (ret) {
+        do
+        {
+            if (ret)
+            {
                 // link the native object with the javascript object
                 js_proxy_t *p;
                 HASH_FIND_PTR(_native_js_global_ht, &ret, p);
-                if(!p) {
+                if(!p)
+                {
                     //previous connection not found, create a new one
                     JSObject *obj = JS_NewObject(cx, js_cocos2dx_socketio_class, JS::RootedObject(cx, js_cocos2dx_socketio_prototype), JS::NullPtr());
                     p = jsb_new_proxy(ret, obj);
                     JS::AddNamedObjectRoot(cx, &p->obj, "SocketIO");
                     siodelegate->setJSDelegate(p->obj);
                 }
-                                
                 jsret = OBJECT_TO_JSVAL(p->obj);
-                
             }
-            else{
+            else
+            {
                 jsret = JSVAL_NULL;
             }
         } while(0);
 
         args.rval().set(jsret);
-
         return true;
-
     }
-
     JS_ReportError(cx, "JSB SocketIO.connect: Wrong number of arguments");
     return false;
 }
 
-bool js_cocos2dx_SocketIO_send(JSContext* cx, uint32_t argc, jsval* vp){
+bool js_cocos2dx_SocketIO_send(JSContext* cx, uint32_t argc, jsval* vp)
+{
     CCLOG("JSB SocketIO.send method called");
 
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
@@ -225,11 +194,12 @@ bool js_cocos2dx_SocketIO_send(JSContext* cx, uint32_t argc, jsval* vp){
     SIOClient* cobj = (SIOClient *)(proxy ? proxy->ptr : NULL);
     JSB_PRECONDITION2( cobj, cx, false, "Invalid Native Object");
 
-    if (argc == 1) {
-
+    if (argc == 1)
+    {
         std::string payload;
         
-        do {
+        do
+        {
             bool ok = jsval_to_std_string(cx, args.get(0), &payload);
             JSB_PRECONDITION2( ok, cx, false, "Error processing arguments");
         } while (0);
@@ -237,17 +207,15 @@ bool js_cocos2dx_SocketIO_send(JSContext* cx, uint32_t argc, jsval* vp){
         CCLOG("JSB SocketIO send mesage: %s", payload.c_str());
 
         cobj->send(payload);
-
         return true;
 
     }
-
     JS_ReportError(cx, "Wrong number of arguments");
     return false;
-
 }
 
-bool js_cocos2dx_SocketIO_emit(JSContext* cx, uint32_t argc, jsval* vp){
+bool js_cocos2dx_SocketIO_emit(JSContext* cx, uint32_t argc, jsval* vp)
+{
     CCLOG("JSB SocketIO.emit method called");
 
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
@@ -256,17 +224,16 @@ bool js_cocos2dx_SocketIO_emit(JSContext* cx, uint32_t argc, jsval* vp){
     SIOClient* cobj = (SIOClient *)(proxy ? proxy->ptr : NULL);
     JSB_PRECONDITION2( cobj, cx, false, "Invalid Native Object");
 
-    if (argc == 2) {
-
+    if (argc == 2)
+    {
         std::string eventName;
-        
-        do {
+        do
+        {
             bool ok = jsval_to_std_string(cx, args.get(0), &eventName);
             JSB_PRECONDITION2( ok, cx, false, "Error processing arguments");
         } while (0);
         
         std::string payload;
-        
         do {
             bool ok = jsval_to_std_string(cx, args.get(1), &payload);
             JSB_PRECONDITION2( ok, cx, false, "Error processing arguments");
@@ -275,17 +242,14 @@ bool js_cocos2dx_SocketIO_emit(JSContext* cx, uint32_t argc, jsval* vp){
         CCLOG("JSB SocketIO emit event '%s' with payload: %s", eventName.c_str(), payload.c_str());
 
         cobj->emit(eventName, payload);
-
         return true;
-
     }
-
     JS_ReportError(cx, "JSB SocketIO.emit: Wrong number of arguments");
     return false;
-
 }
 
-bool js_cocos2dx_SocketIO_disconnect(JSContext* cx, uint32_t argc, jsval* vp){
+bool js_cocos2dx_SocketIO_disconnect(JSContext* cx, uint32_t argc, jsval* vp)
+{
     CCLOG("JSB SocketIO.disconnect method called");
 
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
@@ -294,8 +258,8 @@ bool js_cocos2dx_SocketIO_disconnect(JSContext* cx, uint32_t argc, jsval* vp){
     SIOClient* cobj = (SIOClient *)(proxy ? proxy->ptr : NULL);
     JSB_PRECONDITION2( cobj, cx, false, "Invalid Native Object");
 
-    if(argc == 0) {
-
+    if(argc == 0)
+    {
         cobj->disconnect();
         args.rval().setUndefined();
         return true;
@@ -303,13 +267,14 @@ bool js_cocos2dx_SocketIO_disconnect(JSContext* cx, uint32_t argc, jsval* vp){
 
     JS_ReportError(cx, "JSB SocketIO.disconnect: Wrong number of arguments");
     return false;
-
 }
 
-bool js_cocos2dx_SocketIO_close(JSContext* cx, uint32_t argc, jsval* vp){
+bool js_cocos2dx_SocketIO_close(JSContext* cx, uint32_t argc, jsval* vp)
+{
     CCLOG("JSB SocketIO.close method called");
 
-    if(argc == 0) {
+    if(argc == 0)
+    {
 
         //This method was previously implemented to take care of the HTTPClient instance not being destroyed properly
         //SocketIO::close();
@@ -320,7 +285,6 @@ bool js_cocos2dx_SocketIO_close(JSContext* cx, uint32_t argc, jsval* vp){
 
     JS_ReportError(cx, "JSB SocketIO.close: Wrong number of arguments");
     return false;
-
 }
 
 static bool _js_set_SIOClient_tag(JSContext* cx, uint32_t argc, jsval* vp)
@@ -332,17 +296,18 @@ static bool _js_set_SIOClient_tag(JSContext* cx, uint32_t argc, jsval* vp)
     SIOClient* cobj = (SIOClient *)(proxy ? proxy->ptr : NULL);
     JSB_PRECONDITION2( cobj, cx, false, "Invalid Native Object");
     
-    if (cobj) {
+    if (cobj)
+    {
         std::string out = "";
 
         jsval_to_std_string(cx, args.get(0), &out);
         cobj->setTag(out.c_str());
         return true;
-    } else {
+    } else
+    {
         JS_ReportError(cx, "Error: SocketIO instance is invalid.");
         return false;
     }
-
 }
 
 static bool _js_get_SIOClient_tag(JSContext* cx, uint32_t argc, jsval* vp)
@@ -354,18 +319,20 @@ static bool _js_get_SIOClient_tag(JSContext* cx, uint32_t argc, jsval* vp)
     SIOClient* cobj = (SIOClient *)(proxy ? proxy->ptr : NULL);
     JSB_PRECONDITION2( cobj, cx, false, "Invalid Native Object");
     
-    if (cobj) {
+    if (cobj)
+    {
         args.rval().set(std_string_to_jsval(cx, cobj->getTag()));
         return true;
-    } else {
+    } else
+    {
         JS_ReportError(cx, "Error: SocketIO instance is invalid.");
         return false;
     }
-
 }
 
 
-bool js_cocos2dx_SocketIO_on(JSContext* cx, uint32_t argc, jsval* vp){
+bool js_cocos2dx_SocketIO_on(JSContext* cx, uint32_t argc, jsval* vp)
+{
     CCLOG("JSB SocketIO.on method called");
 
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
@@ -374,36 +341,31 @@ bool js_cocos2dx_SocketIO_on(JSContext* cx, uint32_t argc, jsval* vp){
     SIOClient* cobj = (SIOClient *)(proxy ? proxy->ptr : NULL);
     JSB_PRECONDITION2( cobj, cx, false, "Invalid Native Object");
 
-    if(argc == 2) {
-
+    if(argc == 2)
+    {
         std::string eventName;
-        
-        do {
+        do
+        {
             bool ok = jsval_to_std_string(cx, args.get(0), &eventName);
             JSB_PRECONDITION2( ok, cx, false, "Error processing arguments");
         } while (0);
 
         CCLOG("JSB SocketIO eventName to: '%s'", eventName.c_str());
+        
+        std::shared_ptr<JSFunctionWrapper> callback(new JSFunctionWrapper(cx, JS_THIS_OBJECT(cx, vp), args.get(1)));
 
-        JSB_SIOEvent tmpCobj; 
-        tmpCobj.setJSCallbackFunc(args.get(1));
-
-        ((JSB_SocketIODelegate *)cobj->getDelegate())->addEvent(eventName, tmpCobj);
+        ((JSB_SocketIODelegate *)cobj->getDelegate())->addEvent(eventName, callback);
 
         args.rval().set(OBJECT_TO_JSVAL(proxy->obj));
-
         JS_SetReservedSlot(proxy->obj, 0, args.get(1));
-            
         return true;
     }
-
     JS_ReportError(cx, "JSB SocketIO.close: Wrong number of arguments");
     return false;
-
 }
 
-void register_jsb_socketio(JSContext *cx, JS::HandleObject global) {
-
+void register_jsb_socketio(JSContext *cx, JS::HandleObject global)
+{
     js_cocos2dx_socketio_class = (JSClass *)calloc(1, sizeof(JSClass));
     js_cocos2dx_socketio_class->name = "SocketIO";
     js_cocos2dx_socketio_class->addProperty = JS_PropertyStub;
@@ -416,12 +378,14 @@ void register_jsb_socketio(JSContext *cx, JS::HandleObject global) {
     js_cocos2dx_socketio_class->finalize = js_cocos2dx_SocketIO_finalize;
     js_cocos2dx_socketio_class->flags = JSCLASS_HAS_RESERVED_SLOTS(2);
 
-    static JSPropertySpec properties[] = {
+    static JSPropertySpec properties[] =
+    {
         JS_PSGS("tag", _js_get_SIOClient_tag, _js_set_SIOClient_tag, JSPROP_PERMANENT | JSPROP_ENUMERATE),
         JS_PS_END
     };
 
-    static JSFunctionSpec funcs[] = {
+    static JSFunctionSpec funcs[] =
+    {
         JS_FN("send", js_cocos2dx_SocketIO_send, 1, JSPROP_PERMANENT | JSPROP_ENUMERATE),
         JS_FN("emit", js_cocos2dx_SocketIO_emit, 2, JSPROP_PERMANENT | JSPROP_ENUMERATE),
         JS_FN("disconnect", js_cocos2dx_SocketIO_disconnect, 0, JSPROP_PERMANENT | JSPROP_ENUMERATE),
@@ -429,7 +393,8 @@ void register_jsb_socketio(JSContext *cx, JS::HandleObject global) {
         JS_FS_END
     };
     
-    static JSFunctionSpec st_funcs[] = {
+    static JSFunctionSpec st_funcs[] =
+    {
         JS_FN("connect", js_cocos2dx_SocketIO_connect, 1, JSPROP_PERMANENT | JSPROP_ENUMERATE),
         JS_FN("close", js_cocos2dx_SocketIO_close, 0, JSPROP_PERMANENT | JSPROP_ENUMERATE),
         JS_FS_END
@@ -442,10 +407,9 @@ void register_jsb_socketio(JSContext *cx, JS::HandleObject global) {
                                                 js_cocos2dx_SocketIO_constructor, 0, // constructor
                                                 nullptr,
                                                 funcs,
-                                                nullptr, // no static properties
+                                                properties,
                                                 st_funcs);
     
-    JSObject* jsclassObj = anonEvaluate(cx, global, "(function () { return SocketIO; })()").toObjectOrNull();
-
+    anonEvaluate(cx, global, "(function () { return SocketIO; })()").toObjectOrNull();
 }
 

--- a/cocos/scripting/js-bindings/proj.ios_mac/cocos2d_js_bindings.xcodeproj/project.pbxproj
+++ b/cocos/scripting/js-bindings/proj.ios_mac/cocos2d_js_bindings.xcodeproj/project.pbxproj
@@ -226,7 +226,6 @@
 		1A119E5418BDF19200352BAA /* js_bindings_ccbreader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = js_bindings_ccbreader.h; sourceTree = "<group>"; };
 		1A119E5718BDF19200352BAA /* jsb_cocos2dx_studio_manual.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = jsb_cocos2dx_studio_manual.cpp; sourceTree = "<group>"; };
 		1A119E5818BDF19200352BAA /* jsb_cocos2dx_studio_manual.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = jsb_cocos2dx_studio_manual.h; sourceTree = "<group>"; };
-		1A119E5A18BDF19200352BAA /* Android.mk */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = Android.mk; sourceTree = "<group>"; };
 		1A119E5B18BDF19200352BAA /* jsb_cocos2dx_extension_manual.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = jsb_cocos2dx_extension_manual.cpp; sourceTree = "<group>"; };
 		1A119E5C18BDF19200352BAA /* jsb_cocos2dx_extension_manual.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = jsb_cocos2dx_extension_manual.h; sourceTree = "<group>"; };
 		1A119E6118BDF19200352BAA /* js_bindings_config.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = js_bindings_config.h; sourceTree = "<group>"; };
@@ -249,7 +248,6 @@
 		1A119E7318BDF19200352BAA /* js_bindings_system_functions_registration.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = js_bindings_system_functions_registration.h; sourceTree = "<group>"; };
 		1A119E7418BDF19200352BAA /* js_bindings_system_registration.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = js_bindings_system_registration.cpp; sourceTree = "<group>"; };
 		1A119E7518BDF19200352BAA /* js_bindings_system_registration.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = js_bindings_system_registration.h; sourceTree = "<group>"; };
-		1A119E7718BDF19200352BAA /* Android.mk */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = Android.mk; sourceTree = "<group>"; };
 		1A119E7818BDF19200352BAA /* jsb_websocket.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = jsb_websocket.cpp; sourceTree = "<group>"; };
 		1A119E7918BDF19200352BAA /* jsb_websocket.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = jsb_websocket.h; sourceTree = "<group>"; };
 		1A119E7A18BDF19200352BAA /* XMLHTTPRequest.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = XMLHTTPRequest.cpp; sourceTree = "<group>"; };
@@ -463,7 +461,6 @@
 		1A119E5918BDF19200352BAA /* extension */ = {
 			isa = PBXGroup;
 			children = (
-				1A119E5A18BDF19200352BAA /* Android.mk */,
 				1A119E5B18BDF19200352BAA /* jsb_cocos2dx_extension_manual.cpp */,
 				1A119E5C18BDF19200352BAA /* jsb_cocos2dx_extension_manual.h */,
 			);
@@ -486,7 +483,6 @@
 		1A119E7618BDF19200352BAA /* network */ = {
 			isa = PBXGroup;
 			children = (
-				1A119E7718BDF19200352BAA /* Android.mk */,
 				83A5661718DA878400FC31A0 /* jsb_socketio.cpp */,
 				83A5661818DA878400FC31A0 /* jsb_socketio.h */,
 				1A119E7818BDF19200352BAA /* jsb_websocket.cpp */,


### PR DESCRIPTION
Fixed https://github.com/cocos2d/cocos2d-x/issues/13248

Reason: `ScriptingCore::executeJSFunctionWithThisObj` is somehow broken in release mode.

Solution: Use `JSFunctionWrapper` to manage callbacks instead of managing JS values manually.

I also did the following in this commit:
- Correct the coding style in jsb_socketio.cpp
- Remove android.mk in the Xcode project
