### PR TITLE
avoid to trigger touch event multiple times

### DIFF
--- a/tests/cpp-tests/Classes/Physics3DTest/Physics3DTest.cpp
+++ b/tests/cpp-tests/Classes/Physics3DTest/Physics3DTest.cpp
@@ -137,6 +137,7 @@ bool Physics3DTestDemo::init()
 void Physics3DTestDemo::onTouchesBegan(const std::vector<Touch*>& touches, cocos2d::Event  *event)
 {
     _needShootBox = true;
+    event->stopPropagation();
 }
 
 void Physics3DTestDemo::onTouchesMoved(const std::vector<Touch*>& touches, cocos2d::Event  *event)
@@ -154,6 +155,7 @@ void Physics3DTestDemo::onTouchesMoved(const std::vector<Touch*>& touches, cocos
         {
             _needShootBox = false;
         }
+        event->stopPropagation();
     }
 }
 
@@ -169,6 +171,7 @@ void Physics3DTestDemo::onTouchesEnded(const std::vector<Touch*>& touches, cocos
         farP = _camera->unproject(farP);
         Vec3 dir(farP - nearP);
         shootBox(_camera->getPosition3D() + dir * 10.0f);
+        event->stopPropagation();
     }
 }
 
@@ -530,6 +533,7 @@ void Physics3DConstraintDemo::onTouchesBegan(const std::vector<cocos2d::Touch*>&
             _constraint = Physics3DPointToPointConstraint::create(static_cast<Physics3DRigidBody*>(result.hitObj), position);
             physicsScene->getPhysics3DWorld()->addPhysics3DConstraint(_constraint, true);
             _pickingDistance = (result.hitPosition - nearP).length();
+            event->stopPropagation();
             return;
         }
     }
@@ -551,6 +555,7 @@ void Physics3DConstraintDemo::onTouchesMoved(const std::vector<cocos2d::Touch*>&
         _camera->unproject(size, &farP, &farP);
         auto dir = (farP - nearP).getNormalized();
         p2pConstraint->setPivotPointInB(nearP + dir * _pickingDistance);
+        event->stopPropagation();
         return;
     }
     Physics3DTestDemo::onTouchesMoved(touches, event);
@@ -561,6 +566,7 @@ void Physics3DConstraintDemo::onTouchesEnded(const std::vector<cocos2d::Touch*>&
     {
         physicsScene->getPhysics3DWorld()->removePhysics3DConstraint(_constraint);
         _constraint = nullptr;
+        event->stopPropagation();
         return;
     }
     Physics3DTestDemo::onTouchesEnded(touches, event);


### PR DESCRIPTION
Bug: 
Physics3D Test shoot two box
Physics3D Constraint Test, the boxes fixed after a few draw.
