### PR TITLE
Fix bugs of skeleton animation

### DIFF
--- a/cocos/editor-support/cocostudio/ActionTimeline/CCBoneNode.cpp
+++ b/cocos/editor-support/cocostudio/ActionTimeline/CCBoneNode.cpp
@@ -390,6 +390,9 @@ void BoneNode::draw(cocos2d::Renderer *renderer, const cocos2d::Mat4 &transform,
 
 BoneNode::~BoneNode()
 {
+    _boneSkins.clear();
+    _childBones.clear();
+    _rootSkeleton = nullptr;
 }
 
 bool BoneNode::init()
@@ -458,7 +461,7 @@ void BoneNode::onDraw(const cocos2d::Mat4 &transform, uint32_t flags)
 
 }
 
-cocos2d::Vector<BoneNode*> BoneNode::getAllSubBones() const
+const cocos2d::Vector<BoneNode*>& BoneNode::getAllSubBones() const
 {
     cocos2d::Vector<BoneNode*> allBones;
     std::stack<BoneNode*> boneStack; // for avoid recursive
@@ -481,7 +484,7 @@ cocos2d::Vector<BoneNode*> BoneNode::getAllSubBones() const
     return allBones;
 }
 
-cocos2d::Vector<SkinNode*> BoneNode::getAllSubSkins() const
+const cocos2d::Vector<SkinNode*>& BoneNode::getAllSubSkins() const
 {
     auto allbones = getAllSubBones();
     cocos2d::Vector<SkinNode*> allskins;

--- a/cocos/editor-support/cocostudio/ActionTimeline/CCBoneNode.cpp
+++ b/cocos/editor-support/cocostudio/ActionTimeline/CCBoneNode.cpp
@@ -116,7 +116,8 @@ void BoneNode::removeChild(Node* child, bool cleanup /* = true */)
 void BoneNode::removeFromBoneList(BoneNode* bone)
 {
     auto skeletonNode = dynamic_cast<SkeletonNode*>(bone);
-    if (skeletonNode == nullptr) // is not a nested skeleton
+    if (_rootSkeleton != nullptr &&
+        skeletonNode == nullptr && bone->_rootSkeleton == _rootSkeleton)  // is not a nested skeleton, and it is in skeleton tree
     {
         bone->_rootSkeleton = nullptr;
         auto subBones = bone->getAllSubBones();

--- a/cocos/editor-support/cocostudio/ActionTimeline/CCBoneNode.cpp
+++ b/cocos/editor-support/cocostudio/ActionTimeline/CCBoneNode.cpp
@@ -330,15 +330,17 @@ void BoneNode::visit(cocos2d::Renderer *renderer, const cocos2d::Mat4& parentTra
 
     int i = 0;
 
-    if (!_childBones.empty())
+    if (!_children.empty())
     {
         sortAllChildren();
         // draw children zOrder < 0
-        for (; i < _childBones.size(); i++)
+        for (; i < _children.size(); i++)
         {
-            auto bone = _childBones.at(i);
-            if (bone && bone->getZOrder() < 0)
-                bone->visit(renderer, _modelViewTransform, flags);
+            auto node = _children.at(i);
+            if (_rootSkeleton != nullptr && _boneSkins.contains(node)) // skip skin when bone is in a skeleton
+                continue;
+            if (node && node->getLocalZOrder() < 0)
+                node->visit(renderer, _modelViewTransform, flags);
             else
                 break;
         }
@@ -346,8 +348,13 @@ void BoneNode::visit(cocos2d::Renderer *renderer, const cocos2d::Mat4& parentTra
         if (visibleByCamera)
             this->draw(renderer, _modelViewTransform, flags);
 
-        for (auto it = _childBones.cbegin() + i; it != _childBones.cend(); ++it)
-            (*it)->visit(renderer, _modelViewTransform, flags);
+        for (auto it = _children.cbegin() + i; it != _children.cend(); ++it)
+        {
+            auto node = (*it);
+            if (_rootSkeleton != nullptr && _boneSkins.contains(node)) // skip skin when bone is in a skeleton
+                continue;
+            node->visit(renderer, _modelViewTransform, flags);
+        }
     }
     else if (visibleByCamera)
     {

--- a/cocos/editor-support/cocostudio/ActionTimeline/CCBoneNode.cpp
+++ b/cocos/editor-support/cocostudio/ActionTimeline/CCBoneNode.cpp
@@ -301,11 +301,6 @@ void BoneNode::setDebugDrawEnabled(bool isDebugDraw)
     if (_isRackShow == isDebugDraw)
         return;
     _isRackShow = isDebugDraw;
-    if (_visible && nullptr != _rootSkeleton)
-    {
-        _rootSkeleton->_subBonesDirty = true;
-        _rootSkeleton->_subBonesOrderDirty = true;
-    }
 }
 
 void BoneNode::setDebugDrawColor(const cocos2d::Color4F &color)
@@ -331,7 +326,7 @@ void BoneNode::visit(cocos2d::Renderer *renderer, const cocos2d::Mat4& parentTra
     _director->loadMatrix(cocos2d::MATRIX_STACK_TYPE::MATRIX_STACK_MODELVIEW, _modelViewTransform);
 
     bool visibleByCamera = isVisitableByVisitingCamera();
-
+    bool isdebugdraw = visibleByCamera && _isRackShow && nullptr != _rootSkeleton;
     int i = 0;
 
     if (!_children.empty())
@@ -349,7 +344,7 @@ void BoneNode::visit(cocos2d::Renderer *renderer, const cocos2d::Mat4& parentTra
                 break;
         }
         // self draw
-        if (visibleByCamera)
+        if (isdebugdraw)
             this->draw(renderer, _modelViewTransform, flags);
 
         for (auto it = _children.cbegin() + i; it != _children.cend(); ++it)
@@ -360,7 +355,7 @@ void BoneNode::visit(cocos2d::Renderer *renderer, const cocos2d::Mat4& parentTra
             node->visit(renderer, _modelViewTransform, flags);
         }
     }
-    else if (visibleByCamera)
+    else if (isdebugdraw)
     {
         this->draw(renderer, _modelViewTransform, flags);
     }
@@ -375,9 +370,6 @@ void BoneNode::visit(cocos2d::Renderer *renderer, const cocos2d::Mat4& parentTra
 
 void BoneNode::draw(cocos2d::Renderer *renderer, const cocos2d::Mat4 &transform, uint32_t flags)
 {
-    if (!_isRackShow || nullptr != _rootSkeleton)
-        return;
-
     _customCommand.init(_globalZOrder, transform, flags);
     _customCommand.func = CC_CALLBACK_0(BoneNode::onDraw, this, transform, flags);
     renderer->addCommand(&_customCommand);

--- a/cocos/editor-support/cocostudio/ActionTimeline/CCBoneNode.cpp
+++ b/cocos/editor-support/cocostudio/ActionTimeline/CCBoneNode.cpp
@@ -326,7 +326,7 @@ void BoneNode::visit(cocos2d::Renderer *renderer, const cocos2d::Mat4& parentTra
     _director->loadMatrix(cocos2d::MATRIX_STACK_TYPE::MATRIX_STACK_MODELVIEW, _modelViewTransform);
 
     bool visibleByCamera = isVisitableByVisitingCamera();
-    bool isdebugdraw = visibleByCamera && _isRackShow && nullptr != _rootSkeleton;
+    bool isdebugdraw = visibleByCamera && _isRackShow && nullptr == _rootSkeleton;
     int i = 0;
 
     if (!_children.empty())

--- a/cocos/editor-support/cocostudio/ActionTimeline/CCBoneNode.cpp
+++ b/cocos/editor-support/cocostudio/ActionTimeline/CCBoneNode.cpp
@@ -608,7 +608,7 @@ void BoneNode::visitSkins(cocos2d::Renderer* renderer, BoneNode* bone) const
 
 void BoneNode::setRootSkeleton(BoneNode* bone, SkeletonNode* skeleton) const
 {
-    bone->_rootSkeleton = nullptr;
+    bone->_rootSkeleton = skeleton;
 }
 
 void BoneNode::setLocalZOrder(int localZOrder)

--- a/cocos/editor-support/cocostudio/ActionTimeline/CCBoneNode.h
+++ b/cocos/editor-support/cocostudio/ActionTimeline/CCBoneNode.h
@@ -195,7 +195,11 @@ protected:
 
     // a help funciton for SkeletonNode
     // @param bone, visit bone's skins
-    virtual void visitSkins(cocos2d::Renderer* renderer, BoneNode* bone);
+    virtual void visitSkins(cocos2d::Renderer* renderer, BoneNode* bone) const;
+
+    // a help function for SkeletonNode
+    // set bone's rootSkeleton = skeleton
+    void setRootSkeleton(BoneNode* bone, SkeletonNode* skeleton) const;
 protected:
     cocos2d::CustomCommand _customCommand;
     cocos2d::BlendFunc     _blendFunc;

--- a/cocos/editor-support/cocostudio/ActionTimeline/CCBoneNode.h
+++ b/cocos/editor-support/cocostudio/ActionTimeline/CCBoneNode.h
@@ -109,7 +109,8 @@ public:
     virtual void setBlendFunc(const cocos2d::BlendFunc &blendFunc) override;
     virtual const cocos2d::BlendFunc & getBlendFunc() const override { return _blendFunc; }
 
-    // debug draw show, bone's debugdraw can be draw when bone is visible && enable debug draw
+    // debug draw show, bone's debugdraw can be draw when bone is visible
+    // when bone's added to skeleton, DebugDrawEnabled controled by skeleton's DebugDrawEnabled
     virtual void setDebugDrawEnabled(bool isDebugDraw);
     virtual bool isDebugDrawEnabled() const { return _isRackShow; }
 

--- a/cocos/editor-support/cocostudio/ActionTimeline/CCSkeletonNode.cpp
+++ b/cocos/editor-support/cocostudio/ActionTimeline/CCSkeletonNode.cpp
@@ -109,6 +109,8 @@ SkeletonNode::SkeletonNode()
 
 SkeletonNode::~SkeletonNode()
 {
+    _subOrderedAllBones.clear();
+    _subBonesMap.clear();
 }
 
 void SkeletonNode::updateVertices()

--- a/cocos/editor-support/cocostudio/ActionTimeline/CCSkeletonNode.cpp
+++ b/cocos/editor-support/cocostudio/ActionTimeline/CCSkeletonNode.cpp
@@ -190,12 +190,14 @@ void SkeletonNode::visit(cocos2d::Renderer *renderer, const cocos2d::Mat4& paren
         visitSkins(renderer, bone);
     }
 
-    this->draw(renderer, _modelViewTransform, flags);
-    // batch draw all sub bones
-    _batchBoneCommand.init(_globalZOrder, _modelViewTransform, parentFlags);
-    _batchBoneCommand.func = CC_CALLBACK_0(SkeletonNode::batchDrawAllSubBones, this, _modelViewTransform);
-    renderer->addCommand(&_batchBoneCommand);
-
+    if (_isRackShow)
+    {
+        this->draw(renderer, _modelViewTransform, flags);
+        // batch draw all sub bones
+        _batchBoneCommand.init(_globalZOrder, _modelViewTransform, parentFlags);
+        _batchBoneCommand.func = CC_CALLBACK_0(SkeletonNode::batchDrawAllSubBones, this, _modelViewTransform);
+        renderer->addCommand(&_batchBoneCommand);
+    }
     _director->popMatrix(cocos2d::MATRIX_STACK_TYPE::MATRIX_STACK_MODELVIEW);
     // FIX ME: Why need to set _orderOfArrival to 0??
     // Please refer to https://github.com/cocos2d/cocos2d-x/pull/6920
@@ -205,9 +207,6 @@ void SkeletonNode::visit(cocos2d::Renderer *renderer, const cocos2d::Mat4& paren
 
 void SkeletonNode::draw(cocos2d::Renderer *renderer, const cocos2d::Mat4 &transform, uint32_t flags)
 {
-    if (!_isRackShow)
-        return;
-
     _customCommand.init(_globalZOrder, transform, flags);
     _customCommand.func = CC_CALLBACK_0(SkeletonNode::onDraw, this, transform, flags);
     renderer->addCommand(&_customCommand);
@@ -228,9 +227,9 @@ void SkeletonNode::batchDrawAllSubBones(const cocos2d::Mat4 &transform)
     _batchedVeticesCount = 0;
     for (const auto& bone : _subOrderedAllBones)
     {
-        if (bone->isDebugDrawEnabled())
-            batchBoneDrawToSkeleton(bone);
+        batchBoneDrawToSkeleton(bone);
     }
+
     cocos2d::Vec3* vetices = _batchedBoneVetices.data();
     cocos2d::Color4F* veticesColor = _batchedBoneColors.data();
     getGLProgram()->use();

--- a/cocos/editor-support/cocostudio/ActionTimeline/CCSkeletonNode.cpp
+++ b/cocos/editor-support/cocostudio/ActionTimeline/CCSkeletonNode.cpp
@@ -109,8 +109,10 @@ SkeletonNode::SkeletonNode()
 
 SkeletonNode::~SkeletonNode()
 {
-    _subOrderedAllBones.clear();
-    _subBonesMap.clear();
+    for (auto &bonepair : _subBonesMap)
+    {
+        setRootSkeleton(bonepair.second, nullptr);
+    }
 }
 
 void SkeletonNode::updateVertices()

--- a/tests/cpp-tests/Classes/ExtensionsTest/CocoStudioActionTimelineTest/ActionTimelineTestScene.cpp
+++ b/tests/cpp-tests/Classes/ExtensionsTest/CocoStudioActionTimelineTest/ActionTimelineTestScene.cpp
@@ -343,14 +343,10 @@ void TestActionTimelineSkeleton::onEnter()
     boneDrawsBtn->setPosition(Vec2(VisibleRect::right().x - 30, VisibleRect::top().y - 30));
     boneDrawsBtn->setTitleText("Draw bone");
 
-    _isAllBonesDraw = true;
-    skeletonNode->setDebugDrawEnabled(_isAllBonesDraw);
-    setAllSubBonesDebugDraw(skeletonNode, _isAllBonesDraw);
+    skeletonNode->setDebugDrawEnabled(true);
     boneDrawsBtn->addClickEventListener([skeletonNode, this](Ref* sender)
     {
-        _isAllBonesDraw = !_isAllBonesDraw;
-        skeletonNode->setDebugDrawEnabled(_isAllBonesDraw);
-        setAllSubBonesDebugDraw(skeletonNode, _isAllBonesDraw);
+        skeletonNode->setDebugDrawEnabled(!skeletonNode->isDebugDrawEnabled());
     });
 
 
@@ -552,16 +548,6 @@ std::string TestActionTimelineSkeleton::title() const
 {
     return "Test ActionTimeline Skeleton";
 }
-
-void TestActionTimelineSkeleton::setAllSubBonesDebugDraw(SkeletonNode* rootSkeleton, bool isShow)
-{
-    auto boneMap = rootSkeleton->getAllSubBonesMap();
-    for (auto& bonePair : boneMap)
-    {
-        bonePair.second->setDebugDrawEnabled(isShow);
-    }
-}
-
 
 // TestTimelineExtensionData
 void TestTimelineExtensionData::onEnter()

--- a/tests/cpp-tests/Classes/ExtensionsTest/CocoStudioActionTimelineTest/ActionTimelineTestScene.h
+++ b/tests/cpp-tests/Classes/ExtensionsTest/CocoStudioActionTimelineTest/ActionTimelineTestScene.h
@@ -127,11 +127,8 @@ public:
     virtual std::string title() const override;
 
 private:
-    void setAllSubBonesDebugDraw(cocostudio::timeline::SkeletonNode* rootSkeleton, bool isShow);
-
     bool _changedDisplay;
     bool _changedDisplays;
-    bool _isAllBonesDraw;
 };
 
 class TestTimelineExtensionData : public ActionTimelineBaseTest


### PR DESCRIPTION
1. fix:  draw node which in skeleton but it is not a BoneNode or SkinNode. see changes in `BoneNode::visit`
2. fix crash when BoneNode destruct after skeleton destructed. see chagnes in `SkeletonNode::~SkeletonNode`
