### PR TITLE
Fix bug: #21796 [Android 5.0][Cpp-Tests] Node::Scene3D menu unusable.

### DIFF
--- a/cocos/2d/CCMenu.cpp
+++ b/cocos/2d/CCMenu.cpp
@@ -253,7 +253,8 @@ void Menu::removeChild(Node* child, bool cleanup)
 
 bool Menu::onTouchBegan(Touch* touch, Event* event)
 {
-    if (_state != Menu::State::WAITING || ! _visible || !_enabled)
+    auto camera = Camera::getVisitingCamera();
+    if (_state != Menu::State::WAITING || ! _visible || !_enabled || !camera)
     {
         return false;
     }
@@ -266,10 +267,11 @@ bool Menu::onTouchBegan(Touch* touch, Event* event)
         }
     }
     
-    _selectedItem = this->getItemForTouch(touch);
+    _selectedItem = this->getItemForTouch(touch, camera);
     if (_selectedItem)
     {
         _state = Menu::State::TRACKING_TOUCH;
+        _selectedWithCamera = camera;
         _selectedItem->selected();
         
         return true;
@@ -288,6 +290,7 @@ void Menu::onTouchEnded(Touch* touch, Event* event)
         _selectedItem->activate();
     }
     _state = Menu::State::WAITING;
+    _selectedWithCamera = nullptr;
     this->release();
 }
 
@@ -306,7 +309,7 @@ void Menu::onTouchCancelled(Touch* touch, Event* event)
 void Menu::onTouchMoved(Touch* touch, Event* event)
 {
     CCASSERT(_state == Menu::State::TRACKING_TOUCH, "[Menu ccTouchMoved] -- invalid state");
-    MenuItem *currentItem = this->getItemForTouch(touch);
+    MenuItem *currentItem = this->getItemForTouch(touch, _selectedWithCamera);
     if (currentItem != _selectedItem)
     {
         if (_selectedItem)
@@ -553,12 +556,10 @@ void Menu::alignItemsInRowsWithArray(const ValueVector& columns)
     }
 }
 
-MenuItem* Menu::getItemForTouch(Touch *touch)
+MenuItem* Menu::getItemForTouch(Touch *touch, const Camera *camera)
 {
     Vec2 touchLocation = touch->getLocation();
-    auto camera = Camera::getVisitingCamera();
-    
-    if (!_children.empty() && nullptr != camera)
+    if (!_children.empty())
     {
         for (auto iter = _children.crbegin(); iter != _children.crend(); ++iter)
         {

--- a/cocos/2d/CCMenu.h
+++ b/cocos/2d/CCMenu.h
@@ -179,7 +179,7 @@ CC_CONSTRUCTOR_ACCESS:
     /**
      * @js ctor
      */
-    Menu() : _selectedItem(nullptr) {}
+    Menu() : _selectedItem(nullptr), _selectedWithCamera(nullptr) {}
     virtual ~Menu();
 
     /** initializes an empty Menu */
@@ -195,10 +195,10 @@ protected:
     /** whether or not the menu will receive events */
     bool _enabled;
 
-    virtual MenuItem* getItemForTouch(Touch * touch);
+    virtual MenuItem* getItemForTouch(Touch * touch, const Camera *camera);
     State _state;
     MenuItem *_selectedItem;
-
+    const Camera *_selectedWithCamera;
 private:
     CC_DISALLOW_COPY_AND_ASSIGN(Menu);
 };


### PR DESCRIPTION
related bug:
http://punchbox.info:3000/issues/21796
