### PR TITLE
[ci skip]fix the node color property can not use

### DIFF
--- a/cocos/scripting/js-bindings/script/jsb_property_apis.js
+++ b/cocos/scripting/js-bindings/script/jsb_property_apis.js
@@ -165,8 +165,6 @@ cc.defineGetterSetter(_proto, "glServerState", _proto.getGLServerState, _proto.s
 cc.defineGetterSetter(_proto, "tag", _proto.getTag, _proto.setTag);
 cc.defineGetterSetter(_proto, "userObject", _proto.getUserObject, _proto.setUserObject);
 cc.defineGetterSetter(_proto, "arrivalOrder", _proto.getArrivalOrder, _proto.setArrivalOrder);
-
-_proto = cc.NodeRGBA.prototype;
 cc.defineGetterSetter(_proto, "opacity", _proto.getOpacity, _proto.setOpacity);
 cc.defineGetterSetter(_proto, "opacityModifyRGB", _proto.isOpacityModifyRGB, _proto.setOpacityModifyRGB);
 cc.defineGetterSetter(_proto, "cascadeOpacity", _proto.isCascadeOpacityEnabled, _proto.setCascadeOpacityEnabled);


### PR DESCRIPTION
code example:

```
node.color = xxxx // fix it
```
