### PR TITLE
Fix EditBox turning black when soft keyboard hide.

### DIFF
--- a/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxActivity.java
+++ b/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxActivity.java
@@ -348,7 +348,6 @@ public abstract class Cocos2dxActivity extends Activity implements Cocos2dxHelpe
         if (hasFocus) {
             Cocos2dxHelper.onResume();
             mGLSurfaceView.onResume();
-            mGLSurfaceView.requestFocus();
         }
     }
 
@@ -357,7 +356,6 @@ public abstract class Cocos2dxActivity extends Activity implements Cocos2dxHelpe
         super.onPause();
         Cocos2dxHelper.onPause();
         mGLSurfaceView.onPause();
-        mGLSurfaceView.setSoftKeyboardShown(false);
     }
     
     @Override

--- a/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxEditBox.java
+++ b/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxEditBox.java
@@ -204,11 +204,17 @@ public class Cocos2dxEditBox extends EditText {
         switch (pKeyCode) {
             case KeyEvent.KEYCODE_BACK:
                 Cocos2dxActivity activity = (Cocos2dxActivity)this.getContext();
+                //To prevent program from going to background
                 activity.getGLSurfaceView().requestFocus();
                 return true;
             default:
                 return super.onKeyDown(pKeyCode, pKeyEvent);
         }
+    }
+
+    @Override
+    public boolean onKeyPreIme(int keyCode, KeyEvent event) {
+        return super.onKeyPreIme(keyCode, event);
     }
 
     public void setInputFlag(int inputFlag) {

--- a/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxEditBoxHelper.java
+++ b/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxEditBoxHelper.java
@@ -101,7 +101,9 @@ public class Cocos2dxEditBoxHelper {
 
                     @Override
                     public void onTextChanged(final CharSequence s, int start, int before, int count) {
-                        mFrameLayout.setEnableForceDoLayout(false);
+                        //The optimization can't be turn on due to unknown keyboard hide in some custom keyboard
+//                        mFrameLayout.setEnableForceDoLayout(false);
+
                         mCocos2dxActivity.runOnGLThread(new Runnable() {
                             @Override
                             public void run() {


### PR DESCRIPTION
I disable a optimization when users start to type, the resize layout's
doLayout event should be stoped.

But it has bugs. If we could find a reliable way to detect soft keyboard show/hide
event, we could enable this optimization again.
