### PR TITLE
[bugfix] SimpleAudioEngine misreporting whether music is playing when paused/resumed

### DIFF
--- a/cocos/audio/win32/MciPlayer.cpp
+++ b/cocos/audio/win32/MciPlayer.cpp
@@ -136,6 +136,7 @@ void MciPlayer::Close()
 void MciPlayer::Pause()
 {
     _SendGenericCommand(MCI_PAUSE);
+	_playing = false;
 }
 
 void MciPlayer::Resume()
@@ -153,6 +154,7 @@ void MciPlayer::Resume()
     else
     {
         _SendGenericCommand(MCI_RESUME);
+		_playing = true;
     }   
 }
 

--- a/cocos/audio/win32/MciPlayer.cpp
+++ b/cocos/audio/win32/MciPlayer.cpp
@@ -136,7 +136,7 @@ void MciPlayer::Close()
 void MciPlayer::Pause()
 {
     _SendGenericCommand(MCI_PAUSE);
-	_playing = false;
+    _playing = false;
 }
 
 void MciPlayer::Resume()
@@ -154,7 +154,7 @@ void MciPlayer::Resume()
     else
     {
         _SendGenericCommand(MCI_RESUME);
-		_playing = true;
+        _playing = true;
     }   
 }
 


### PR DESCRIPTION
Issue #13254 

Flag was not being changed when background music was paused or resumed on Windows
