### PR TITLE
Fixed `Scheduler::update(float dt)` can lead to an infinite loop when the value of `dt` is zero.

### DIFF
--- a/cocos/base/CCScheduler.cpp
+++ b/cocos/base/CCScheduler.cpp
@@ -129,12 +129,17 @@ void Timer::update(float dt)
     {
         trigger(interval);
         _elapsed -= interval;
+        _timesExecuted += 1;
+        if (_elapsed <= 0.f)
+        {
+            break;
+        }
 
         if (_runForever)
         {
             continue;
         }
-        _timesExecuted += 1;
+        
         if (_timesExecuted > _repeat)
         {    //unschedule timer
             cancel();


### PR DESCRIPTION
Test Case:Cpp Tests-->Actions - Basic
