### PR TITLE
Correct use and convert unicode from utf8. WinRT

### DIFF
--- a/cocos/audio/winrt/Audio.cpp
+++ b/cocos/audio/winrt/Audio.cpp
@@ -472,53 +472,6 @@ bool Audio::IsSoundEffectStarted(unsigned int sound)
     return m_soundEffects[sound].m_soundEffectStarted;
 }
 
-std::wstring CCUtf8ToUnicode(const char * pszUtf8Str)
-{
-    std::wstring ret;
-    do
-    {
-        if (! pszUtf8Str) break;
-        size_t len = strlen(pszUtf8Str);
-        if (len <= 0) break;
-		++len;
-        wchar_t * pwszStr = new wchar_t[len];
-        if (! pwszStr) break;
-        pwszStr[len - 1] = 0;
-        MultiByteToWideChar(CP_UTF8, 0, pszUtf8Str, len, pwszStr, len);
-        ret = pwszStr;
-
-		if(pwszStr) { 
-			delete[] (pwszStr); 
-			(pwszStr) = 0; 
-		}
-
-
-    } while (0);
-    return ret;
-}
-
-std::string CCUnicodeToUtf8(const wchar_t* pwszStr)
-{
-	std::string ret;
-	do
-	{
-		if(! pwszStr) break;
-		size_t len = wcslen(pwszStr);
-		if (len <= 0) break;
-		
-		char * pszUtf8Str = new char[len*3 + 1];
-		WideCharToMultiByte(CP_UTF8, 0, pwszStr, len+1, pszUtf8Str, len*3 + 1, 0, 0);
-		ret = pszUtf8Str;
-				
-		if(pszUtf8Str) { 
-			delete[] (pszUtf8Str); 
-			(pszUtf8Str) = 0; 
-		}
-	}while(0);
-
-	return ret;
-}
-
 void Audio::PreloadSoundEffect(const char* pszFilePath, bool isMusic)
 {
     if (m_engineExperiencedCriticalError) {

--- a/cocos/audio/winrt/AudioCachePlayer.cpp
+++ b/cocos/audio/winrt/AudioCachePlayer.cpp
@@ -64,8 +64,6 @@ void AudioCache::readDataTask()
         return;
     }
 
-    std::wstring path(_fileFullPath.begin(), _fileFullPath.end());
-
     if (nullptr != _srcReader) {
         delete _srcReader;
         _srcReader = nullptr;

--- a/cocos/audio/winrt/AudioSourceReader.cpp
+++ b/cocos/audio/winrt/AudioSourceReader.cpp
@@ -97,7 +97,8 @@ bool WAVReader::initialize(const std::string& filePath)
         flushChunks();
 
         _streamer = ref new MediaStreamer;
-        _streamer->Initialize(std::wstring(_filePath.begin(), _filePath.end()).c_str(), true);
+
+        _streamer->Initialize(StringUtf8ToWideChar(_filePath).c_str(), true);
         _wfx = _streamer->GetOutputWaveFormatEx();
         UINT32 dataSize = _streamer->GetMaxStreamLengthInBytes();
 
@@ -204,7 +205,7 @@ bool MP3Reader::initialize(const std::string& filePath)
         ComPtr<IMFSourceReader> pReader;
         ComPtr<IMFMediaType> ppDecomprsdAudioType;
 
-        if (FAILED(hr = MFCreateSourceReaderFromURL(std::wstring(_filePath.begin(), _filePath.end()).c_str(), NULL, &pReader))) {
+        if (FAILED(hr = MFCreateSourceReaderFromURL(StringUtf8ToWideChar(_filePath).c_str(), NULL, &pReader))) {
             break;
         }
         
@@ -483,7 +484,7 @@ void MP3Reader::readFromMappedWavFile(BYTE *data, size_t offset, int size, UINT 
     } while (false);
 }
 
-Wrappers::FileHandle MP3Reader::openFile(const std::string& path, bool append)
+Wrappers::FileHandle MP3Reader::openFile(const std::string& filePath, bool append)
 {
     CREATEFILE2_EXTENDED_PARAMETERS extParams = { 0 };
     extParams.dwFileAttributes = FILE_ATTRIBUTE_NORMAL;
@@ -495,7 +496,7 @@ Wrappers::FileHandle MP3Reader::openFile(const std::string& path, bool append)
 
     DWORD access = append ? GENERIC_WRITE : GENERIC_READ;
     DWORD creation = append ? OPEN_ALWAYS : OPEN_EXISTING;
-    return Microsoft::WRL::Wrappers::FileHandle(CreateFile2(std::wstring(path.begin(), path.end()).c_str(), access, FILE_SHARE_READ, creation, &extParams));
+    return Microsoft::WRL::Wrappers::FileHandle(CreateFile2(StringUtf8ToWideChar(filePath).c_str(), access, FILE_SHARE_READ, creation, &extParams));
 }
 
 

--- a/cocos/platform/winrt/CCApplication.cpp
+++ b/cocos/platform/winrt/CCApplication.cpp
@@ -116,7 +116,7 @@ const char * Application::getCurrentLanguageCode()
         result = GetUserPreferredUILanguages(MUI_LANGUAGE_NAME, &numLanguages, pwszLanguagesBuffer, &cchLanguagesBuffer);
         if (result) {
 
-            code = CCUnicodeToUtf8(pwszLanguagesBuffer);
+            code = StringWideCharToUtf8(pwszLanguagesBuffer);
         }
 
         if (pwszLanguagesBuffer)

--- a/cocos/platform/winrt/CCCommon.cpp
+++ b/cocos/platform/winrt/CCCommon.cpp
@@ -35,10 +35,10 @@ NS_CC_BEGIN
 
 void MessageBox(const char * pszMsg, const char * pszTitle)
 {
-    // Create the message dialog and set its content
-    Platform::String^ message = ref new Platform::String(CCUtf8ToUnicode(pszMsg, -1).c_str());
-    Platform::String^ title = ref new Platform::String(CCUtf8ToUnicode(pszTitle, -1).c_str());
 #ifndef WP8_SHADER_COMPILER
+    // Create the message dialog and set its content
+    Platform::String^ message = PlatformStringFromString(pszMsg);
+    Platform::String^ title = PlatformStringFromString(pszTitle);
     GLViewImpl::sharedOpenGLView()->ShowMessageBox(title, message);
 #endif
 }

--- a/cocos/platform/winrt/CCFileUtilsWinRT.cpp
+++ b/cocos/platform/winrt/CCFileUtilsWinRT.cpp
@@ -153,7 +153,7 @@ bool CCFileUtilsWinRT::isFileExistInternal(const std::string& strFilePath) const
 bool CCFileUtilsWinRT::isDirectoryExistInternal(const std::string& dirPath) const
 {
     WIN32_FILE_ATTRIBUTE_DATA wfad;
-    std::wstring wdirPath(dirPath.begin(), dirPath.end());
+    std::wstring wdirPath = StringUtf8ToWideChar(dirPath);
     if (GetFileAttributesEx(wdirPath.c_str(), GetFileExInfoStandard, &wfad))
     {
         return true;

--- a/cocos/platform/winrt/CCFileUtilsWinRT.cpp
+++ b/cocos/platform/winrt/CCFileUtilsWinRT.cpp
@@ -47,55 +47,6 @@ static inline std::string convertPathFormatToUnixStyle(const std::string& path)
     return ret;
 }
 
-static std::wstring StringUtf8ToWideChar(const std::string& strUtf8)
-{
-    std::wstring ret;
-    if (!strUtf8.empty())
-    {
-        int nNum = MultiByteToWideChar(CP_UTF8, 0, strUtf8.c_str(), -1, nullptr, 0);
-        if (nNum)
-        {
-            WCHAR* wideCharString = new WCHAR[nNum + 1];
-            wideCharString[0] = 0;
-
-            nNum = MultiByteToWideChar(CP_UTF8, 0, strUtf8.c_str(), -1, wideCharString, nNum + 1);
-
-            ret = wideCharString;
-            delete[] wideCharString;
-        }
-        else
-        {
-            CCLOG("Wrong convert to WideChar code:0x%x", GetLastError());
-        }
-    }
-    return ret;
-}
-
-static std::string StringWideCharToUtf8(const std::wstring& strWideChar)
-{
-    std::string ret;
-    if (!strWideChar.empty())
-    {
-        int nNum = WideCharToMultiByte(CP_UTF8, 0, strWideChar.c_str(), -1, nullptr, 0, nullptr, FALSE);
-        if (nNum)
-        {
-            char* utf8String = new char[nNum + 1];
-            utf8String[0] = 0;
-
-            nNum = WideCharToMultiByte(CP_UTF8, 0, strWideChar.c_str(), -1, utf8String, nNum + 1, nullptr, FALSE);
-
-            ret = utf8String;
-            delete[] utf8String;
-        }
-        else
-        {
-            CCLOG("Wrong convert to Utf8 code:0x%x", GetLastError());
-        }
-    }
-
-    return ret;
-}
-
 static std::string UTF8StringToMultiByte(const std::string& strUtf8)
 {
     std::string ret;
@@ -244,8 +195,8 @@ bool CCFileUtilsWinRT::createDirectory(const std::string& path)
     }
 
     WIN32_FILE_ATTRIBUTE_DATA wfad;
-    std::wstring wpath(path.begin(), path.end());
-    if (!(GetFileAttributesEx(wpath.c_str(), GetFileExInfoStandard, &wfad)))
+    
+    if (!(GetFileAttributesEx(StringUtf8ToWideChar(path).c_str(), GetFileExInfoStandard, &wfad)))
     {
         subpath = "";
         for (unsigned int i = 0; i < dirs.size(); ++i)
@@ -253,8 +204,7 @@ bool CCFileUtilsWinRT::createDirectory(const std::string& path)
             subpath += dirs[i];
             if (i > 0 && !isDirectoryExist(subpath))
             {
-                std::wstring wsubpath(subpath.begin(), subpath.end());
-                BOOL ret = CreateDirectory(wsubpath.c_str(), NULL);
+                BOOL ret = CreateDirectory(StringUtf8ToWideChar(subpath).c_str(), NULL);
                 if (!ret && ERROR_ALREADY_EXISTS != GetLastError())
                 {
                     return false;
@@ -267,7 +217,7 @@ bool CCFileUtilsWinRT::createDirectory(const std::string& path)
 
 bool CCFileUtilsWinRT::removeDirectory(const std::string& path)
 {
-    std::wstring wpath = std::wstring(path.begin(), path.end());
+    std::wstring wpath = StringUtf8ToWideChar(path);
     std::wstring files = wpath + L"*.*";
     WIN32_FIND_DATA wfd;
     HANDLE  search = FindFirstFileEx(files.c_str(), FindExInfoStandard, &wfd, FindExSearchNameMatch, NULL, 0);
@@ -316,12 +266,16 @@ bool CCFileUtilsWinRT::isAbsolutePath(const std::string& strPath) const
 
 bool CCFileUtilsWinRT::removeFile(const std::string &path)
 {
-    std::wstring wpath(path.begin(), path.end());
+    std::wstring wpath = StringUtf8ToWideChar(path);
     if (DeleteFile(wpath.c_str()))
     {
         return true;
     }
-    return false;
+    else
+    {
+        CCLOG("Remove file failed with error: %d", GetLastError());
+        return false;
+    }
 }
 
 bool CCFileUtilsWinRT::renameFile(const std::string &oldfullpath, const std::string& newfullpath)
@@ -329,16 +283,30 @@ bool CCFileUtilsWinRT::renameFile(const std::string &oldfullpath, const std::str
     CCASSERT(!oldfullpath.empty(), "Invalid path");
     CCASSERT(!newfullpath.empty(), "Invalid path");
 
-    std::wstring oldfile(oldfullpath.begin(), oldfullpath.end());
-    std::wstring newfile(newfullpath.begin(), newfullpath.end());
+    std::regex pat("\\/");
+    std::string _oldfullpath = std::regex_replace(oldfullpath, pat, "\\");
+    std::string _newfullpath = std::regex_replace(newfullpath, pat, "\\");
 
-    if (MoveFileEx(oldfile.c_str(), newfile.c_str(),
-        MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH))
+    std::wstring _wNewfullpath = StringUtf8ToWideChar(_newfullpath);
+
+    if (FileUtils::getInstance()->isFileExist(_newfullpath))
+    {
+        if (!DeleteFile(_wNewfullpath.c_str()))
+        {
+            CCLOGERROR("Fail to delete file %s !Error code is 0x%x", newfullpath.c_str(), GetLastError());
+        }
+    }
+
+    if (MoveFileEx(StringUtf8ToWideChar(_oldfullpath).c_str(), _wNewfullpath.c_str(),
+        MOVEFILE_REPLACE_EXISTING & MOVEFILE_WRITE_THROUGH))
     {
         return true;
     }
-    CCLOG("Rename failed with error: %d", GetLastError());
-    return false;
+    else
+    {
+        CCLOGERROR("Fail to rename file %s to %s !Error code is 0x%x", oldfullpath.c_str(), newfullpath.c_str(), GetLastError());
+        return false;
+    }
 }
 
 bool CCFileUtilsWinRT::renameFile(const std::string &path, const std::string &oldname, const std::string &name)
@@ -347,71 +315,17 @@ bool CCFileUtilsWinRT::renameFile(const std::string &path, const std::string &ol
     std::string oldPath = path + oldname;
     std::string newPath = path + name;
 
-    std::regex pat("\\/");
-    std::string _old = std::regex_replace(oldPath, pat, "\\");
-    std::string _new = std::regex_replace(newPath, pat, "\\");
-    return renameFile(_old, _new);
-}
-
-static Data getData(const std::string& filename, bool forString)
-{
-    if (filename.empty())
-    {
-        CCASSERT(!filename.empty(), "Invalid filename!");
-    }
-
-    Data ret;
-    unsigned char* buffer = nullptr;
-    ssize_t size = 0;
-    const char* mode = nullptr;
-    mode = "rb";
-
-    do
-    {
-        // Read the file from hardware
-        std::string fullPath = FileUtils::getInstance()->fullPathForFilename(filename);
-        FILE *fp = fopen(fullPath.c_str(), mode);
-        CC_BREAK_IF(!fp);
-        fseek(fp,0,SEEK_END);
-        size = ftell(fp);
-        fseek(fp,0,SEEK_SET);
-
-        if (forString)
-        {
-            buffer = (unsigned char*)malloc(sizeof(unsigned char) * (size + 1));
-            buffer[size] = '\0';
-        }
-        else
-        {
-            buffer = (unsigned char*)malloc(sizeof(unsigned char) * size);
-        }
-
-        size = fread(buffer, sizeof(unsigned char), size, fp);
-        fclose(fp);
-    } while (0);
-
-    if (nullptr == buffer || 0 == size)
-    {
-        std::string msg = "Get data from file(";
-        msg.append(filename).append(") failed!");
-        CCLOG("%s", msg.c_str());
-    }
-    else
-    {
-        ret.fastSet(buffer, size);
-    }
-
-    return ret;
+    return renameFile(oldPath, newPath);
 }
 
 std::string CCFileUtilsWinRT::getStringFromFile(const std::string& filename)
 {
-    Data data = getData(filename, true);
+    Data data = getDataFromFile(filename);
     if (data.isNull())
     {
         return "";
     }
-    std::string ret((const char*)data.getBytes());
+    std::string ret((const char*)data.getBytes(), data.getSize());
     return ret;
 }
 

--- a/cocos/platform/winrt/CCPrecompiledShaders.cpp
+++ b/cocos/platform/winrt/CCPrecompiledShaders.cpp
@@ -210,7 +210,7 @@ void CCPrecompiledShaders::savePrecompiledPrograms(Windows::Storage::StorageFold
         for (auto iter = m_programs.begin(); iter != m_programs.end(); ++iter) 
         {
             CompiledProgram* p = (CompiledProgram*)iter->second;
-            Platform::String^ keyName =  ref new Platform::String(CCUtf8ToUnicode(p->key.c_str()).c_str());
+            Platform::String^ keyName = PlatformStringFromString(p->key);
             Platform::String^ programName = SHADER_NAME_PREFIX + keyName;
 
             dataWriter->WriteString("const unsigned char ");
@@ -225,12 +225,12 @@ void CCPrecompiledShaders::savePrecompiledPrograms(Windows::Storage::StorageFold
                 if(i % 8 == 0)
                     dataWriter->WriteString("\n");
                 sprintf_s(temp, "%3i, ", buffer[i]);
-                dataWriter->WriteString(ref new Platform::String(CCUtf8ToUnicode(temp).c_str()));
+                dataWriter->WriteString(PlatformStringFromString(temp));
             }
             if((p->length - 1) % 8 == 0)
                 dataWriter->WriteString("\n");
             sprintf_s(temp, "%3i, ", buffer[p->length - 1]);
-            dataWriter->WriteString(ref new Platform::String(CCUtf8ToUnicode(temp).c_str()));
+            dataWriter->WriteString(PlatformStringFromString(temp));
             dataWriter->WriteString("\n};\n\n");
 
             if(numPrograms != 0)

--- a/cocos/platform/winrt/CCWinRTUtils.cpp
+++ b/cocos/platform/winrt/CCWinRTUtils.cpp
@@ -47,61 +47,62 @@ using namespace Windows::Storage::Pickers;
 using namespace Windows::Storage::Streams;
 using namespace Windows::Networking::Connectivity;
 
-std::wstring CCUtf8ToUnicode(const char * pszUtf8Str, unsigned len/* = -1*/)
+std::wstring StringUtf8ToWideChar(const std::string& strUtf8)
 {
     std::wstring ret;
-    do
+    if (!strUtf8.empty())
     {
-        if (! pszUtf8Str) break;
-		// get UTF8 string length
-		if (-1 == len)
-		{
-			len = strlen(pszUtf8Str);
-		}
-        if (len <= 0) break;
+        int nNum = MultiByteToWideChar(CP_UTF8, 0, strUtf8.c_str(), -1, nullptr, 0);
+        if (nNum)
+        {
+            WCHAR* wideCharString = new WCHAR[nNum + 1];
+            wideCharString[0] = 0;
 
-		// get UTF16 string length
-		int wLen = MultiByteToWideChar(CP_UTF8, 0, pszUtf8Str, len, 0, 0);
-		if (0 == wLen || 0xFFFD == wLen) break;
-		
-		// convert string  
-        wchar_t * pwszStr = new wchar_t[wLen + 1];
-        if (! pwszStr) break;
-        pwszStr[wLen] = 0;
-        MultiByteToWideChar(CP_UTF8, 0, pszUtf8Str, len, pwszStr, wLen + 1);
-        ret = pwszStr;
-        CC_SAFE_DELETE_ARRAY(pwszStr);
-    } while (0);
+            nNum = MultiByteToWideChar(CP_UTF8, 0, strUtf8.c_str(), -1, wideCharString, nNum + 1);
+
+            ret = wideCharString;
+            delete[] wideCharString;
+        }
+        else
+        {
+            CCLOG("Wrong convert to WideChar code:0x%x", GetLastError());
+        }
+    }
     return ret;
 }
 
-std::string CCUnicodeToUtf8(const wchar_t* pwszStr)
+std::string StringWideCharToUtf8(const std::wstring& strWideChar)
 {
-	std::string ret;
-	do
-	{
-		if(! pwszStr) break;
-		size_t len = wcslen(pwszStr);
-		if (len <= 0) break;
-		
-		size_t convertedChars = 0;
-		char * pszUtf8Str = new char[len*3 + 1];
-		WideCharToMultiByte(CP_UTF8, 0, pwszStr, len+1, pszUtf8Str, len*3 + 1, 0, 0);
-		ret = pszUtf8Str;
-		CC_SAFE_DELETE_ARRAY(pszUtf8Str);
-	}while(0);
+    std::string ret;
+    if (!strWideChar.empty())
+    {
+        int nNum = WideCharToMultiByte(CP_UTF8, 0, strWideChar.c_str(), -1, nullptr, 0, nullptr, FALSE);
+        if (nNum)
+        {
+            char* utf8String = new char[nNum + 1];
+            utf8String[0] = 0;
 
-	return ret;
+            nNum = WideCharToMultiByte(CP_UTF8, 0, strWideChar.c_str(), -1, utf8String, nNum + 1, nullptr, FALSE);
+
+            ret = utf8String;
+            delete[] utf8String;
+        }
+        else
+        {
+            CCLOG("Wrong convert to Utf8 code:0x%x", GetLastError());
+        }
+    }
+
+    return ret;
 }
 
 std::string PlatformStringToString(Platform::String^ s) {
-	std::wstring t = std::wstring(s->Data());
-	return std::string(t.begin(),t.end());
+	return StringWideCharToUtf8(std::wstring(s->Data()));
 }
 
 Platform::String^ PlatformStringFromString(const std::string& s)
 {
-    std::wstring ws(CCUtf8ToUnicode(s.c_str()));
+    std::wstring ws = StringUtf8ToWideChar(s);
     return ref new Platform::String(ws.data(), ws.length());
 }
 

--- a/cocos/platform/winrt/CCWinRTUtils.cpp
+++ b/cocos/platform/winrt/CCWinRTUtils.cpp
@@ -47,6 +47,42 @@ using namespace Windows::Storage::Pickers;
 using namespace Windows::Storage::Streams;
 using namespace Windows::Networking::Connectivity;
 
+
+CC_DEPRECATED_ATTRIBUTE std::wstring CC_DLL CCUtf8ToUnicode(const char * pszUtf8Str, unsigned len /*= -1*/)
+{
+    if (len == -1)
+    {
+        return StringUtf8ToWideChar(pszUtf8Str);
+    }
+    else
+    {
+        std::wstring ret;
+        do
+        {
+            if (!pszUtf8Str || !len) break;
+
+            // get UTF16 string length
+            int wLen = MultiByteToWideChar(CP_UTF8, 0, pszUtf8Str, len, 0, 0);
+            if (0 == wLen || 0xFFFD == wLen) break;
+
+            // convert string  
+            wchar_t * pwszStr = new wchar_t[wLen + 1];
+            if (!pwszStr) break;
+            pwszStr[wLen] = 0;
+            MultiByteToWideChar(CP_UTF8, 0, pszUtf8Str, len, pwszStr, wLen + 1);
+            ret = pwszStr;
+            CC_SAFE_DELETE_ARRAY(pwszStr);
+        } while (0);
+        return ret;
+    }
+}
+
+CC_DEPRECATED_ATTRIBUTE std::string CC_DLL CCUnicodeToUtf8(const wchar_t* pwszStr)
+{
+    return StringWideCharToUtf8(pwszStr);
+}
+
+
 std::wstring StringUtf8ToWideChar(const std::string& strUtf8)
 {
     std::wstring ret;

--- a/cocos/platform/winrt/CCWinRTUtils.h
+++ b/cocos/platform/winrt/CCWinRTUtils.h
@@ -38,8 +38,11 @@ NS_CC_BEGIN
 
 
 
-std::wstring CC_DLL CCUtf8ToUnicode(const char * pszUtf8Str, unsigned len = -1);
-std::string CC_DLL CCUnicodeToUtf8(const wchar_t* pwszStr);
+
+
+std::wstring CC_DLL StringUtf8ToWideChar(const std::string& strUtf8);
+std::string CC_DLL StringWideCharToUtf8(const std::wstring& strWideChar);
+
 Platform::Object^ findXamlElement(Platform::Object^ parent, Platform::String^ name);
 bool removeXamlElement(Platform::Object^ parent, Platform::Object^ element);
 bool replaceXamlElement(Platform::Object^ parent, Platform::Object^ add, Platform::Object^ remove);

--- a/cocos/platform/winrt/CCWinRTUtils.h
+++ b/cocos/platform/winrt/CCWinRTUtils.h
@@ -38,7 +38,8 @@ NS_CC_BEGIN
 
 
 
-
+CC_DEPRECATED_ATTRIBUTE std::wstring CC_DLL CCUtf8ToUnicode(const char * pszUtf8Str, unsigned len = -1);
+CC_DEPRECATED_ATTRIBUTE std::string CC_DLL CCUnicodeToUtf8(const wchar_t* pwszStr);
 
 std::wstring CC_DLL StringUtf8ToWideChar(const std::string& strUtf8);
 std::string CC_DLL StringWideCharToUtf8(const std::wstring& strWideChar);

--- a/cocos/platform/winrt/InputEvent.cpp
+++ b/cocos/platform/winrt/InputEvent.cpp
@@ -84,10 +84,7 @@ void KeyboardEvent::execute()
     {
     case Cocos2dKeyEvent::Text:
     {
-        std::wstring w(m_text.Get()->Data());
-        std::u16string  s16(w.begin(),w.end());
-        std::string utf8String;
-        StringUtils::UTF16ToUTF8(s16, utf8String);
+        std::string utf8String = PlatformStringToString(m_text.Get());
         IMEDispatcher::sharedDispatcher()->dispatchInsertText(utf8String.c_str(), utf8String.size());
         break;
     }

--- a/cocos/platform/winrt/WICImageLoader-winrt.cpp
+++ b/cocos/platform/winrt/WICImageLoader-winrt.cpp
@@ -25,6 +25,7 @@ Based upon code from the DirectX Tool Kit by Microsoft Corporation,
 obtained from https://directxtk.codeplex.com
 ****************************************************************************/
 #include "WICImageLoader-winrt.h"
+#include "CCWinRTUtils.h"
 
 NS_CC_BEGIN
 
@@ -321,9 +322,7 @@ bool WICImageLoader::encodeImageData(std::string path, const unsigned char* data
 	}
 
 	if (SUCCEEDED(hr)) {
-		std::wstring wpath;
-		wpath.assign(path.begin(), path.end());
-		hr = pStream->InitializeFromFilename(wpath.c_str(), GENERIC_WRITE);
+		hr = pStream->InitializeFromFilename(StringUtf8ToWideChar(path).c_str(), GENERIC_WRITE);
 	}
 
 	IWICBitmapEncoder* pEnc = NULL;

--- a/cocos/ui/UIEditBox/UIEditBoxImpl-winrt.cpp
+++ b/cocos/ui/UIEditBox/UIEditBoxImpl-winrt.cpp
@@ -354,7 +354,7 @@ void UIEditBoxImplWinrt::openKeyboard()
         Windows::Foundation::EventHandler<Platform::String^>^ receiveHandler = ref new Windows::Foundation::EventHandler<Platform::String^>(
             [this](Platform::Object^ sender, Platform::String^ arg)
         {
-            setText(PlatformStringTostring(arg).c_str());
+            setText(PlatformStringToString(arg).c_str());
             if (_delegate != NULL) {
                 _delegate->editBoxTextChanged(_editBox, getText());
                 _delegate->editBoxEditingDidEnd(_editBox);
@@ -362,10 +362,10 @@ void UIEditBoxImplWinrt::openKeyboard()
             }
         });
 
-        m_editBoxWinrt = ref new EditBoxWinRT(stringToPlatformString(placeHolder), stringToPlatformString(getText()), m_nMaxLength, m_eEditBoxInputMode, m_eEditBoxInputFlag, receiveHandler);
+        m_editBoxWinrt = ref new EditBoxWinRT(PlatformStringFromString(placeHolder), PlatformStringFromString(getText()), m_nMaxLength, m_eEditBoxInputMode, m_eEditBoxInputFlag, receiveHandler);
     }
 
-    m_editBoxWinrt->OpenXamlEditBox(stringToPlatformString(getText()));
+    m_editBoxWinrt->OpenXamlEditBox(PlatformStringFromString(getText()));
 }
 
 bool UIEditBoxImplWinrt::initWithSize( const Size& size )
@@ -568,32 +568,6 @@ void UIEditBoxImplWinrt::closeKeyboard()
 void UIEditBoxImplWinrt::onEnter( void )
 {
 
-}
-
-Platform::String^ UIEditBoxImplWinrt::stringToPlatformString( std::string strSrc )
-{
-    // to wide char
-    int nStrLen = MultiByteToWideChar(CP_UTF8, 0, strSrc.c_str(), -1, NULL, 0);  
-    wchar_t* pWStr = new wchar_t[nStrLen + 1];  
-    memset(pWStr, 0, nStrLen + 1);  
-    MultiByteToWideChar(CP_UTF8, 0, strSrc.c_str(), -1, pWStr, nStrLen);  
-    Platform::String^ strDst = ref new Platform::String(pWStr);
-    delete[] pWStr;
-    return strDst;
-}
-
-std::string UIEditBoxImplWinrt::PlatformStringTostring( Platform::String^ strSrc )
-{
-    const wchar_t* pWStr = strSrc->Data();
-    int nStrLen = WideCharToMultiByte(CP_UTF8, 0, pWStr, -1, NULL, 0, NULL, NULL);  
-    char* pStr = new char[nStrLen + 1];  
-    memset(pStr, 0, nStrLen + 1);  
-    WideCharToMultiByte(CP_UTF8, 0, pWStr, -1, pStr, nStrLen, NULL, NULL);  ;  
-
-    std::string strDst = std::string(pStr);
-
-    delete[] pStr;
-    return strDst;
 }
 
 }

--- a/cocos/ui/UIEditBox/UIEditBoxImpl-winrt.h
+++ b/cocos/ui/UIEditBox/UIEditBoxImpl-winrt.h
@@ -116,9 +116,6 @@ namespace ui {
         virtual void closeKeyboard();
         virtual void onEnter(void);
     private:
-        Platform::String^ stringToPlatformString(std::string strSrc);
-        std::string PlatformStringTostring(Platform::String^ strSrc);
-    private:
         
         EditBoxWinRT^ m_editBoxWinrt;
 


### PR DESCRIPTION
Move StringUtf8ToWideChar and StringWideCharToUtf8 to CCWinRTUtils(
Replace CCUtf8ToUnicode)
Use StringUtf8ToWideChar for convert utf8 to unicode
Use StringWideCharToUtf8 for convert unicode to utf8
CCUtf8ToUnicode and CCUnicodeToUtf8 deprecated
