### PR TITLE
Remove duplicate function definition, Add function adaptation

### DIFF
--- a/cocos/scripting/js-bindings/manual/cocos2d_specifics.cpp
+++ b/cocos/scripting/js-bindings/manual/cocos2d_specifics.cpp
@@ -2702,30 +2702,6 @@ bool js_cocos2dx_CCNode_convertToWorldSpaceAR(JSContext *cx, uint32_t argc, jsva
     return true;
 }
 
-bool js_cocos2dx_CCTMXLayer_tileFlagsAt(JSContext *cx, uint32_t argc, jsval *vp)
-{
-    JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
-    JSObject *obj;
-    bool ok = true;
-    cocos2d::TMXLayer* cobj;
-    obj = JS_THIS_OBJECT(cx, vp);
-    js_proxy_t *proxy = jsb_get_js_proxy(obj);
-    cobj = (cocos2d::TMXLayer *)(proxy ? proxy->ptr : NULL);
-    TEST_NATIVE_OBJECT(cx, cobj)
-    
-    if (argc == 1) {
-        cocos2d::Point arg0;
-        ok &= jsval_to_ccpoint(cx, args.get(0), &arg0);
-        cocos2d::TMXTileFlags flags = kTMXTileHorizontalFlag;
-        jsval jsret;
-        jsret = UINT_TO_JSVAL((uint32_t)flags);
-        args.rval().set(jsret);
-        return true;
-    }
-    JS_ReportError(cx, "wrong number of arguments");
-    return false;
-}
-
 bool js_cocos2dx_CCTMXLayer_getTiles(JSContext *cx, uint32_t argc, jsval *vp)
 {
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
@@ -6314,7 +6290,6 @@ void register_cocos2dx_js_core(JSContext* cx, JS::HandleObject global)
     tmpObj.set(jsb_cocos2d_MenuItem_prototype);
     JS_DefineFunction(cx, tmpObj, "setCallback", js_cocos2dx_MenuItem_setCallback, 2, JSPROP_ENUMERATE | JSPROP_PERMANENT);
     tmpObj.set(jsb_cocos2d_TMXLayer_prototype);
-    JS_DefineFunction(cx, tmpObj, "getTileFlagsAt", js_cocos2dx_CCTMXLayer_tileFlagsAt, 2, JSPROP_ENUMERATE | JSPROP_PERMANENT);
     JS_DefineFunction(cx, tmpObj, "getTiles", js_cocos2dx_CCTMXLayer_getTiles, 0, JSPROP_ENUMERATE | JSPROP_PERMANENT);
     
     tmpObj.set(jsb_cocos2d_ActionInterval_prototype);

--- a/cocos/scripting/js-bindings/script/jsb_create_apis.js
+++ b/cocos/scripting/js-bindings/script/jsb_create_apis.js
@@ -1196,3 +1196,5 @@ cc.Menu.create = function(menuItems) {
     }
     return cc.Menu._create.apply(null, items);
 };
+
+cc.TMXLayer.prototype.tileFlagsAt = cc.TMXLayer.prototype.getTileFlagsAt;


### PR DESCRIPTION
Remove duplicate function definition, Add function adaptation

relate pr:https://github.com/cocos2d/bindings-generator/pull/188
add the conversion for tmxTileFlags,
because the default data type of tmxTileFlag is int, but the value beyond int type range. so we need use uint to save it.
