### PR TITLE
Fix when picture file used by TMX map file missing or broken, create TMX object will cause program crashed

### DIFF
--- a/cocos/2d/CCTMXLayer.cpp
+++ b/cocos/2d/CCTMXLayer.cpp
@@ -61,6 +61,9 @@ bool TMXLayer::initWithTilesetInfo(TMXTilesetInfo *tilesetInfo, TMXLayerInfo *la
         texture = Director::getInstance()->getTextureCache()->addImage(tilesetInfo->_sourceImage.c_str());
     }
 
+    if (nullptr == texture)
+        return false;
+
     if (SpriteBatchNode::initWithTexture(texture, static_cast<ssize_t>(capacity)))
     {
         // layerInfo

--- a/cocos/2d/CCTMXTiledMap.cpp
+++ b/cocos/2d/CCTMXTiledMap.cpp
@@ -107,9 +107,12 @@ TMXLayer * TMXTiledMap::parseLayer(TMXLayerInfo *layerInfo, TMXMapInfo *mapInfo)
     
     TMXLayer *layer = TMXLayer::create(tileset, layerInfo, mapInfo);
 
-    // tell the layerinfo to release the ownership of the tiles map.
-    layerInfo->_ownTiles = false;
-    layer->setupTiles();
+    if (nullptr != layer)
+    {
+        // tell the layerinfo to release the ownership of the tiles map.
+        layerInfo->_ownTiles = false;
+        layer->setupTiles();
+    }
 
     return layer;
 }


### PR DESCRIPTION
@jun-bing This pr fix bug #22273 on redmine
