### PR TITLE
skybox should not be transparent

### DIFF
--- a/cocos/3d/CCSkybox.cpp
+++ b/cocos/3d/CCSkybox.cpp
@@ -148,6 +148,8 @@ void Skybox::draw(Renderer* renderer, const Mat4& transform, uint32_t flags)
 {
     _customCommand.init(_globalZOrder);
     _customCommand.func = CC_CALLBACK_0(Skybox::onDraw, this, transform, flags);
+    _customCommand.setTransparent(false);
+    _customCommand.set3D(true);
     renderer->addCommand(&_customCommand);
 }
 


### PR DESCRIPTION
Default transparent value of rendercommand is true.
It should be opaque. So that it can be drawn before transparent objects.
