### PR TITLE
Change the method for getting executable file path

### DIFF
--- a/cocos/platform/win32/CCFileUtils-win32.cpp
+++ b/cocos/platform/win32/CCFileUtils-win32.cpp
@@ -136,8 +136,14 @@ static void _checkPath()
 {
     if (0 == s_resourcePath.length())
     {
-        WCHAR *pUtf16ExePath = nullptr;
-        _get_wpgmptr(&pUtf16ExePath);
+        wchar_t pUtf16ExePath[MAX_PATH];
+        // Will contain exe path
+        HMODULE hModule = GetModuleHandle(NULL);
+        if (hModule != NULL)
+        {
+            // When passing NULL to GetModuleHandle, it returns handle of exe itself
+            GetModuleFileName(hModule, pUtf16ExePath, (sizeof(pUtf16ExePath)));
+        }
 
         // We need only directory part without exe
         WCHAR *pUtf16DirEnd = wcsrchr(pUtf16ExePath, L'\\');


### PR DESCRIPTION
After I downloaded v3.7.1 I couldn't run the game because I got `_wpgmptr != NULL` error. I searched the forums but I couldn't find anything so I made this patch that changes the method for getting executable file path and fixes that problem.
