### PR TITLE
V3.8: Win10 UWP platform fixes

### DIFF
--- a/cocos/base/CCDirector.cpp
+++ b/cocos/base/CCDirector.cpp
@@ -1305,9 +1305,7 @@ void DisplayLinkDirector::startAnimation()
 
     _cocos2d_thread_id = std::this_thread::get_id();
 
-#ifndef WP8_SHADER_COMPILER
     Application::getInstance()->setAnimationInterval(_animationInterval);
-#endif
 
     // fix issue #3509, skip one fps to avoid incorrect time calculation.
     setNextDeltaTimeZero(true);

--- a/cocos/editor-support/spine/proj.win10/libSpine.vcxproj
+++ b/cocos/editor-support/spine/proj.win10/libSpine.vcxproj
@@ -383,7 +383,7 @@
       <DisableSpecificWarnings>4458;4456;4996;%(DisableSpecificWarnings)</DisableSpecificWarnings>
       <AdditionalIncludeDirectories>$(EngineRoot)external\win10-specific\angle\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-      <ProgramDataBaseFileName>$(OutDir)$(TargetName).pdb</ProgramDataBaseFileName>
+      <ProgramDataBaseFileName>$(IntDir)$(ProjectName).pdb</ProgramDataBaseFileName>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -402,7 +402,7 @@
       <WholeProgramOptimization>false</WholeProgramOptimization>
       <DisableSpecificWarnings>4458;4456;4996;%(DisableSpecificWarnings)</DisableSpecificWarnings>
       <AdditionalIncludeDirectories>$(EngineRoot)external\win10-specific\angle\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <ProgramDataBaseFileName>$(OutDir)$(TargetName).pdb</ProgramDataBaseFileName>
+      <ProgramDataBaseFileName>$(IntDir)$(ProjectName).pdb</ProgramDataBaseFileName>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
@@ -423,7 +423,7 @@
       <DisableSpecificWarnings>4458;4456;4996;%(DisableSpecificWarnings)</DisableSpecificWarnings>
       <AdditionalIncludeDirectories>$(EngineRoot)external\win10-specific\angle\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-      <ProgramDataBaseFileName>$(OutDir)$(TargetName).pdb</ProgramDataBaseFileName>
+      <ProgramDataBaseFileName>$(IntDir)$(ProjectName).pdb</ProgramDataBaseFileName>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -443,7 +443,7 @@
       <DisableSpecificWarnings>4458;4456;4996;%(DisableSpecificWarnings)</DisableSpecificWarnings>
       <AdditionalIncludeDirectories>$(EngineRoot)external\win10-specific\angle\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-      <ProgramDataBaseFileName>$(OutDir)$(TargetName).pdb</ProgramDataBaseFileName>
+      <ProgramDataBaseFileName>$(IntDir)$(ProjectName).pdb</ProgramDataBaseFileName>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -463,7 +463,7 @@
       <DisableSpecificWarnings>4458;4456;4996;%(DisableSpecificWarnings)</DisableSpecificWarnings>
       <AdditionalIncludeDirectories>$(EngineRoot)external\win10-specific\angle\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-      <ProgramDataBaseFileName>$(OutDir)$(TargetName).pdb</ProgramDataBaseFileName>
+      <ProgramDataBaseFileName>$(IntDir)$(ProjectName).pdb</ProgramDataBaseFileName>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -482,7 +482,7 @@
       <WholeProgramOptimization>false</WholeProgramOptimization>
       <DisableSpecificWarnings>4458;4456;4996;%(DisableSpecificWarnings)</DisableSpecificWarnings>
       <AdditionalIncludeDirectories>$(EngineRoot)external\win10-specific\angle\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <ProgramDataBaseFileName>$(OutDir)$(TargetName).pdb</ProgramDataBaseFileName>
+      <ProgramDataBaseFileName>$(IntDir)$(ProjectName).pdb</ProgramDataBaseFileName>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>

--- a/cocos/platform/winrt/CCApplication.cpp
+++ b/cocos/platform/winrt/CCApplication.cpp
@@ -214,11 +214,14 @@ LanguageType Application::getCurrentLanguage()
 
 Application::Platform  Application::getTargetPlatform()
 {
-#if (WINAPI_FAMILY == WINAPI_FAMILY_PHONE_APP)
-    return Platform::OS_WP8;
-#else
-    return Platform::OS_WINRT;
-#endif
+    if (isWindowsPhone())
+    {
+        return Platform::OS_WP8;
+    }
+    else
+    {
+        return Platform::OS_WINRT;
+    }
 }
 
 bool Application::openURL(const std::string &url)

--- a/cocos/platform/winrt/CCCommon.cpp
+++ b/cocos/platform/winrt/CCCommon.cpp
@@ -38,9 +38,7 @@ void MessageBox(const char * pszMsg, const char * pszTitle)
     // Create the message dialog and set its content
     Platform::String^ message = ref new Platform::String(CCUtf8ToUnicode(pszMsg, -1).c_str());
     Platform::String^ title = ref new Platform::String(CCUtf8ToUnicode(pszTitle, -1).c_str());
-#ifndef WP8_SHADER_COMPILER
     GLViewImpl::sharedOpenGLView()->ShowMessageBox(title, message);
-#endif
 }
 
 

--- a/cocos/platform/winrt/CCDevice.cpp
+++ b/cocos/platform/winrt/CCDevice.cpp
@@ -30,6 +30,7 @@ THE SOFTWARE.
 #include "platform/CCDevice.h"
 #include "platform/CCFileUtils.h"
 #include "platform/winrt/CCFreeTypeFont.h"
+#include "platform/winrt/CCWinRTUtils.h"
 #include "platform/CCStdC.h"
 
 using namespace Windows::Graphics::Display;
@@ -97,64 +98,68 @@ void Device::setAccelerometerEnabled(bool isEnabled)
 
             auto orientation = GLViewImpl::sharedOpenGLView()->getDeviceOrientation();
 
-#if (WINAPI_FAMILY == WINAPI_FAMILY_PHONE_APP)
-            switch (orientation)
+            if (isWindowsPhone())
             {
-            case DisplayOrientations::Portrait:
-                acc.x = reading->AccelerationX;
-                acc.y = reading->AccelerationY;
-                break;
-
-            case DisplayOrientations::Landscape:
-                acc.x = -reading->AccelerationY;
-                acc.y = reading->AccelerationX;
-                break;
-
-            case DisplayOrientations::PortraitFlipped:
-                acc.x = -reading->AccelerationX;
-                acc.y = reading->AccelerationY;
-                break;
-
-            case DisplayOrientations::LandscapeFlipped:
-                acc.x = reading->AccelerationY;
-                acc.y = -reading->AccelerationX;
+                switch (orientation)
+                {
+                case DisplayOrientations::Portrait:
+                    acc.x = reading->AccelerationX;
+                    acc.y = reading->AccelerationY;
                     break;
 
-            default:
-                acc.x = reading->AccelerationX;
-                acc.y = reading->AccelerationY;
-                break;
+                case DisplayOrientations::Landscape:
+                    acc.x = -reading->AccelerationY;
+                    acc.y = reading->AccelerationX;
+                    break;
+
+                case DisplayOrientations::PortraitFlipped:
+                    acc.x = -reading->AccelerationX;
+                    acc.y = reading->AccelerationY;
+                    break;
+
+                case DisplayOrientations::LandscapeFlipped:
+                    acc.x = reading->AccelerationY;
+                    acc.y = -reading->AccelerationX;
+                    break;
+
+                default:
+                    acc.x = reading->AccelerationX;
+                    acc.y = reading->AccelerationY;
+                    break;
+                }
             }
-#else // Windows Store App
-            // from http://msdn.microsoft.com/en-us/library/windows/apps/dn440593
-            switch (orientation)
+            else // Windows Store App
             {
-            case DisplayOrientations::Portrait:
-                acc.x = reading->AccelerationY;
-                acc.y = -reading->AccelerationX;
-                break;
+                // from http://msdn.microsoft.com/en-us/library/windows/apps/dn440593
+                switch (orientation)
+                {
+                case DisplayOrientations::Portrait:
+                    acc.x = reading->AccelerationY;
+                    acc.y = -reading->AccelerationX;
+                    break;
 
-            case DisplayOrientations::Landscape:
-                acc.x = reading->AccelerationX;
-                acc.y = reading->AccelerationY;
-                break;
+                case DisplayOrientations::Landscape:
+                    acc.x = reading->AccelerationX;
+                    acc.y = reading->AccelerationY;
+                    break;
 
-            case DisplayOrientations::PortraitFlipped:
-                acc.x = -reading->AccelerationY;
-                acc.y = reading->AccelerationX;
-                break;
+                case DisplayOrientations::PortraitFlipped:
+                    acc.x = -reading->AccelerationY;
+                    acc.y = reading->AccelerationX;
+                    break;
 
-            case DisplayOrientations::LandscapeFlipped:
-                acc.x = -reading->AccelerationX;
-                acc.y = -reading->AccelerationY;
-                break;
+                case DisplayOrientations::LandscapeFlipped:
+                    acc.x = -reading->AccelerationX;
+                    acc.y = -reading->AccelerationY;
+                    break;
 
-            default:
-                acc.x = reading->AccelerationY;
-                acc.y = -reading->AccelerationX;
-                break;
+                default:
+                    acc.x = reading->AccelerationY;
+                    acc.y = -reading->AccelerationX;
+                    break;
+                }
             }
-#endif
+
             std::shared_ptr<cocos2d::InputEvent> event(new AccelerometerEvent(acc));
             cocos2d::GLViewImpl::sharedOpenGLView()->QueueEvent(event);
         });

--- a/cocos/platform/winrt/CCDevice.cpp
+++ b/cocos/platform/winrt/CCDevice.cpp
@@ -53,7 +53,6 @@ static Accelerometer^ sAccelerometer = nullptr;
 
 void Device::setAccelerometerEnabled(bool isEnabled)
 {
-#ifndef WP8_SHADER_COMPILER
     static Windows::Foundation::EventRegistrationToken sToken;
     static bool sEnabled = false;
 
@@ -160,7 +159,6 @@ void Device::setAccelerometerEnabled(bool isEnabled)
             cocos2d::GLViewImpl::sharedOpenGLView()->QueueEvent(event);
         });
     }
-#endif
 }
 
 void Device::setAccelerometerInterval(float interval)

--- a/cocos/platform/winrt/CCGL.h
+++ b/cocos/platform/winrt/CCGL.h
@@ -30,7 +30,7 @@ THE SOFTWARE.
 #define	glClearDepth				glClearDepthf
 #define GL_WRITE_ONLY				GL_WRITE_ONLY_OES
 
-#if CC_TARGET_PLATFORM == CC_PLATFORM_WINRT && !defined(WP8_SHADER_COMPILER)
+#if CC_TARGET_PLATFORM == CC_PLATFORM_WINRT
 #include "EGL/egl.h"
 #include "EGL/eglext.h"
 #include "EGL/eglplatform.h"

--- a/cocos/platform/winrt/CCPrecompiledShaders.cpp
+++ b/cocos/platform/winrt/CCPrecompiledShaders.cpp
@@ -185,7 +185,7 @@ bool CCPrecompiledShaders::addProgram(GLuint program, const std::string& id)
     return true;
 }
 
-#if (CC_TARGET_PLATFORM == CC_PLATFORM_WINRT) && defined(WP8_SHADER_COMPILER)
+#if (CC_TARGET_PLATFORM == CC_PLATFORM_WINRT)
 
 void CCPrecompiledShaders::savePrecompiledPrograms(Windows::Storage::StorageFolder^ folder)
 {

--- a/cocos/platform/winrt/CCPrecompiledShaders.h
+++ b/cocos/platform/winrt/CCPrecompiledShaders.h
@@ -68,7 +68,7 @@ public:
     bool loadProgram(GLuint program, const GLchar* vShaderByteArray, const GLchar* fShaderByteArray);
 
 
-#if (CC_TARGET_PLATFORM == CC_PLATFORM_WINRT) && defined(WP8_SHADER_COMPILER)
+#if (CC_TARGET_PLATFORM == CC_PLATFORM_WINRT)
     void savePrecompiledShaders();
 #endif
 

--- a/cocos/platform/winrt/CCWinRTUtils.cpp
+++ b/cocos/platform/winrt/CCWinRTUtils.cpp
@@ -121,7 +121,6 @@ float getScaledDPIValue(float v) {
 
 void CC_DLL CCLogIPAddresses()
 {
-#ifndef WP8_SHADER_COMPILER
     auto hostnames = NetworkInformation::GetHostNames();
     int length = hostnames->Size;
 
@@ -134,7 +133,6 @@ void CC_DLL CCLogIPAddresses()
             log("IP Address: %s:", s.c_str());
         }
     }
-#endif
 }
 
 std::string CC_DLL getDeviceIPAddresses()

--- a/cocos/platform/winrt/CCWinRTUtils.cpp
+++ b/cocos/platform/winrt/CCWinRTUtils.cpp
@@ -47,6 +47,20 @@ using namespace Windows::Storage::Pickers;
 using namespace Windows::Storage::Streams;
 using namespace Windows::Networking::Connectivity;
 
+bool isWindowsPhone()
+{
+#if _MSC_VER >= 1900
+    if (Windows::Foundation::Metadata::ApiInformation::IsTypePresent("Windows.Phone.UI.Input.HardwareButtons"))
+    {
+        return true;
+    }
+#elif (WINAPI_FAMILY == WINAPI_FAMILY_PHONE_APP)
+    return true;
+#else
+    return false;
+#endif
+}
+
 std::wstring CCUtf8ToUnicode(const char * pszUtf8Str, unsigned len/* = -1*/)
 {
     std::wstring ret;

--- a/cocos/platform/winrt/CCWinRTUtils.h
+++ b/cocos/platform/winrt/CCWinRTUtils.h
@@ -37,7 +37,7 @@ THE SOFTWARE.
 NS_CC_BEGIN
 
 
-
+bool isWindowsPhone();
 std::wstring CC_DLL CCUtf8ToUnicode(const char * pszUtf8Str, unsigned len = -1);
 std::string CC_DLL CCUnicodeToUtf8(const wchar_t* pwszStr);
 Platform::Object^ findXamlElement(Platform::Object^ parent, Platform::String^ name);


### PR DESCRIPTION
This pull request makes some minor changes to the Windows 10 UWP version of cocos2d-x.
1. isWindowsPhone() check was added to help identify Windows 10 Phone
2. fixed pdb file output for Win10 UWP libspline project to remove compiler warnings in ARM builds.
