### PR TITLE
TextFieldTTF support text cursor

### DIFF
--- a/cocos/2d/CCLabel.cpp
+++ b/cocos/2d/CCLabel.cpp
@@ -1497,7 +1497,7 @@ void Label::computeStringNumLines()
     size_t stringLen = _utf16Text.length();
     for (size_t i = 0; i < stringLen - 1; ++i)
     {
-        if (_utf16Text[i] == '\n')
+        if (_utf16Text[i] == (char16_t)TextFormatter::NewLine)
         {
             quantityOfLines++;
         }

--- a/cocos/2d/CCLabel.h
+++ b/cocos/2d/CCLabel.h
@@ -71,6 +71,13 @@ typedef struct _ttfConfig
     }
 }TTFConfig;
 
+enum class TextFormatter : char
+{
+    NewLine = '\n',
+    CarriageReturn = '\r',
+    NextCharNoChangeX = '\b'
+};
+
 class Sprite;
 class SpriteBatchNode;
 class DrawNode;

--- a/cocos/2d/CCTextFieldTTF.h
+++ b/cocos/2d/CCTextFieldTTF.h
@@ -195,6 +195,12 @@ public:
     virtual void setString(const std::string& text) override;
 
     /**
+    * Append to input text of TextField.
+    *@param text The append text of TextField.
+    */
+    virtual void appendString(const std::string& text);
+
+    /**
      * Query the input text of TextField.
      *@return Get the input text of TextField.
      */
@@ -230,6 +236,32 @@ public:
 
     virtual void visit(Renderer *renderer, const Mat4 &parentTransform, uint32_t parentFlags) override;
 
+    virtual void update(float delta) override;
+
+    /**
+    * Set enable cursor use.
+    * @js NA
+    */
+    void setCursorUse(bool value);
+
+    /**
+    * Set char showing cursor.
+    * @js NA
+    */
+    void setCursorChar(char cursor);
+
+    /**
+    * Set cursor position, if enabled
+    * @js NA
+    */
+    void setCursorPosition(std::size_t cursorPosition);
+
+    /**
+    * Set cursor position to hit letter, if enabled
+    * @js NA
+    */
+    void setCursorFromPoint(const Vec2 &point, const Camera* camera);
+
 protected:
     //////////////////////////////////////////////////////////////////////////
     // IMEDelegate interface
@@ -237,9 +269,12 @@ protected:
 
     virtual bool canAttachWithIME() override;
     virtual bool canDetachWithIME() override;
+    virtual void didAttachWithIME() override;
+    virtual void didDetachWithIME() override;
     virtual void insertText(const char * text, size_t len) override;
     virtual void deleteBackward() override;
     virtual const std::string& getContentText() override;
+    virtual void controlKey(EventKeyboard::KeyCode keyCode) override;
 
     TextFieldDelegate * _delegate;
     int _charCount;
@@ -251,6 +286,21 @@ protected:
     Color4B _colorText;
 
     bool _secureTextEntry;
+
+    // Need use cursor
+    bool _cursorUse;
+    // Current position cursor
+    std::size_t _cursorPosition;
+    // Char showing cursor
+    char _cursorChar;
+    // >0 - show, <0 - hide
+    float _cursorShowingTime;
+
+    bool _isAttachWithIME;
+
+    void makeStringSupportCursor(std::string& displayText);
+    void updateCursorDisplayText();
+    void setAttachWithIME(bool isAttachWithIME);
 
 private:
     class LengthStack;

--- a/cocos/base/CCIMEDelegate.h
+++ b/cocos/base/CCIMEDelegate.h
@@ -28,6 +28,7 @@ THE SOFTWARE.
 
 #include <string>
 #include "math/CCGeometry.h"
+#include "base/CCEventKeyboard.h"
 
 /**
  * @addtogroup base
@@ -123,6 +124,13 @@ protected:
     * @lua NA
     */
     virtual void deleteBackward() {}
+
+    /**
+    @brief    Called by IMEDispatcher after the user press control key.
+    * @js NA
+    * @lua NA
+    */
+    virtual void controlKey(EventKeyboard::KeyCode keyCode) {}
 
     /**
     @brief    Called by IMEDispatcher for text stored in delegate.

--- a/cocos/base/CCIMEDispatcher.cpp
+++ b/cocos/base/CCIMEDispatcher.cpp
@@ -144,19 +144,22 @@ bool IMEDispatcher::attachDelegateWithIME(IMEDelegate * delegate)
 
         if (_impl->_delegateWithIme)
         {
-            // if old delegate canDetachWithIME return false 
-            // or pDelegate canAttachWithIME return false,
-            // do nothing.
-            CC_BREAK_IF(! _impl->_delegateWithIme->canDetachWithIME()
-                || ! delegate->canAttachWithIME());
+            if (_impl->_delegateWithIme != delegate)
+            {
+                // if old delegate canDetachWithIME return false 
+                // or pDelegate canAttachWithIME return false,
+                // do nothing.
+                CC_BREAK_IF(!_impl->_delegateWithIme->canDetachWithIME()
+                    || !delegate->canAttachWithIME());
 
-            // detach first
-            IMEDelegate * oldDelegate = _impl->_delegateWithIme;
-            _impl->_delegateWithIme = 0;
-            oldDelegate->didDetachWithIME();
+                // detach first
+                IMEDelegate * oldDelegate = _impl->_delegateWithIme;
+                _impl->_delegateWithIme = 0;
+                oldDelegate->didDetachWithIME();
 
-            _impl->_delegateWithIme = *iter;
-            delegate->didAttachWithIME();
+                _impl->_delegateWithIme = *iter;
+                delegate->didAttachWithIME();
+            }
             ret = true;
             break;
         }
@@ -237,6 +240,19 @@ void IMEDispatcher::dispatchDeleteBackward()
         CC_BREAK_IF(! _impl->_delegateWithIme);
 
         _impl->_delegateWithIme->deleteBackward();
+    } while (0);
+}
+
+void IMEDispatcher::dispatchControlKey(EventKeyboard::KeyCode keyCode)
+{
+    do
+    {
+        CC_BREAK_IF(!_impl);
+
+        // there is no delegate attached to IME
+        CC_BREAK_IF(!_impl->_delegateWithIme);
+
+        _impl->_delegateWithIme->controlKey(keyCode);
     } while (0);
 }
 

--- a/cocos/base/CCIMEDispatcher.h
+++ b/cocos/base/CCIMEDispatcher.h
@@ -67,6 +67,12 @@ public:
     void dispatchDeleteBackward();
 
     /**
+    * @brief Dispatches the press control key operation.
+    * @lua NA
+    */
+    void dispatchControlKey(EventKeyboard::KeyCode keyCode);
+
+    /**
      * @brief Get the content text from IMEDelegate, retrieved previously from IME.
      * @lua NA
      */

--- a/cocos/base/ccUTF8.cpp
+++ b/cocos/base/ccUTF8.cpp
@@ -213,6 +213,106 @@ long getCharacterCountInUTF8String(const std::string& utf8)
     return getUTF8StringLength((const UTF8*)utf8.c_str());
 }
 
+
+StringUTF8::StringUTF8()
+{
+
+}
+
+StringUTF8::StringUTF8(const std::string& newStr)
+{
+    set(newStr);
+}
+
+StringUTF8::StringUTF8(const StringUTF8& copyStrUtf8)
+{
+    _str = copyStrUtf8._str;
+}
+
+StringUTF8::~StringUTF8()
+{
+
+}
+
+std::size_t StringUTF8::length() const
+{
+    return _str.size();
+}
+
+void StringUTF8::set(const std::string& newStr)
+{
+    _str.clear();
+    if (!newStr.empty())
+    {
+        UTF8* sequenceUtf8 = (UTF8*)newStr.c_str();
+
+        int lengthString = getUTF8StringLength(sequenceUtf8);
+
+        if (lengthString == 0)
+        {
+            CCLOG("Bad utf-8 set string: %s", newStr.c_str());
+            return;
+        }
+
+        while (*sequenceUtf8)
+        {
+            std::size_t lengthChar = getNumBytesForUTF8(*sequenceUtf8);
+
+            CharUTF8 charUTF8;
+            charUTF8._char.append((char*)sequenceUtf8, lengthChar);
+            sequenceUtf8 += lengthChar;
+
+            _str.push_back(charUTF8);
+        }
+    }
+}
+
+std::string StringUTF8::getAsCharSequence() const
+{
+    std::string charSequence;
+
+    for (auto& charUtf8 : _str)
+    {
+        charSequence.append(charUtf8._char);
+    }
+
+    return charSequence;
+}
+
+bool StringUTF8::deleteChar(std::size_t pos)
+{
+    if (pos < _str.size())
+    {
+        _str.erase(_str.begin() + pos);
+        return true;
+    }
+    else
+    {
+        return false;
+    }
+}
+
+bool StringUTF8::insert(std::size_t pos, const std::string& insertStr)
+{
+    StringUTF8 utf8(insertStr);
+
+    return insert(pos, utf8);
+}
+
+bool StringUTF8::insert(std::size_t pos, const StringUTF8& insertStr)
+{
+    if (pos <= _str.size())
+    {
+        _str.insert(_str.begin() + pos, insertStr._str.begin(), insertStr._str.end());
+
+        return true;
+    }
+    else
+    {
+        return false;
+    }
+}
+
 } //namespace StringUtils {
 
 

--- a/cocos/base/ccUTF8.h
+++ b/cocos/base/ccUTF8.h
@@ -142,6 +142,43 @@ CC_DLL unsigned int getIndexOfLastNotChar16(const std::vector<char16_t>& str, ch
  */
 CC_DLL std::vector<char16_t> getChar16VectorFromUTF16String(const std::u16string& utf16);
 
+
+
+/**
+* Utf8 sequence
+* Store all utf8 chars as std::string
+* Build from std::string
+*/
+class CC_DLL StringUTF8
+{
+public:
+    struct CharUTF8
+    {
+        std::string _char;
+        bool isAnsi() { return _char.size() == 1; }
+    };
+    typedef std::vector<CharUTF8> CharUTF8Store;
+
+    StringUTF8();
+    StringUTF8(const std::string& newStr);
+    explicit StringUTF8(const StringUTF8& copyStrUtf8);
+    ~StringUTF8();
+
+    std::size_t length() const;
+    void set(const std::string& newStr);
+
+    std::string getAsCharSequence() const;
+
+    bool deleteChar(std::size_t pos);
+    bool insert(std::size_t pos, const std::string& insertStr);
+    bool insert(std::size_t pos, const StringUTF8& insertStr);
+
+    CharUTF8Store& getString() { return _str; }
+
+private:
+    CharUTF8Store _str;
+};
+
 } // namespace StringUtils {
 
 /**

--- a/cocos/platform/desktop/CCGLViewImpl-desktop.cpp
+++ b/cocos/platform/desktop/CCGLViewImpl-desktop.cpp
@@ -712,9 +712,26 @@ void GLViewImpl::onGLFWKeyCallback(GLFWwindow *window, int key, int scancode, in
         dispatcher->dispatchEvent(&event);
     }
     
-    if (GLFW_RELEASE != action && g_keyCodeMap[key] == EventKeyboard::KeyCode::KEY_BACKSPACE)
+    if (GLFW_RELEASE != action)
     {
-        IMEDispatcher::sharedDispatcher()->dispatchDeleteBackward();
+        switch (g_keyCodeMap[key])
+        {
+        case EventKeyboard::KeyCode::KEY_BACKSPACE:
+            IMEDispatcher::sharedDispatcher()->dispatchDeleteBackward();
+            break;
+        case EventKeyboard::KeyCode::KEY_HOME:
+        case EventKeyboard::KeyCode::KEY_KP_HOME:
+        case EventKeyboard::KeyCode::KEY_DELETE:
+        case EventKeyboard::KeyCode::KEY_KP_DELETE:
+        case EventKeyboard::KeyCode::KEY_END:
+        case EventKeyboard::KeyCode::KEY_LEFT_ARROW:
+        case EventKeyboard::KeyCode::KEY_RIGHT_ARROW:
+        case EventKeyboard::KeyCode::KEY_ESCAPE:
+            IMEDispatcher::sharedDispatcher()->dispatchControlKey(g_keyCodeMap[key]);
+            break;
+        default:
+            break;
+        }
     }
 }
 

--- a/cocos/platform/winrt/Keyboard-winrt.cpp
+++ b/cocos/platform/winrt/Keyboard-winrt.cpp
@@ -266,33 +266,47 @@ void KeyBoardWinRT::OnWinRTKeyboardEvent(WinRTKeyboardEventType type, KeyEventAr
 {
     bool pressed = (type == WinRTKeyboardEventType::KeyPressed);
 
-    // don't allow key repeats
-    if (pressed && args->KeyStatus.WasKeyDown)
-    {
-        return;
-    }
+    // Is key repeats
+    bool repeat = pressed && args->KeyStatus.WasKeyDown;
 
     int key = static_cast<int>(args->VirtualKey);
     auto it = g_keyCodeMap.find(key);
     if (it != g_keyCodeMap.end())
     {
-        switch (it->second)
+
+        EventKeyboard::KeyCode keyCode = it->second;
+
+        EventKeyboard event(keyCode, pressed);
+        if (!repeat)
         {
-        case EventKeyboard::KeyCode::KEY_BACKSPACE:
-            if (pressed)
-            {
-                IMEDispatcher::sharedDispatcher()->dispatchDeleteBackward();
-            }
-            break;
-        default:
-            EventKeyboard event(it->second, pressed);
             auto dispatcher = Director::getInstance()->getEventDispatcher();
             dispatcher->dispatchEvent(&event);
-            if (it->second == EventKeyboard::KeyCode::KEY_ENTER)
+            if (keyCode == EventKeyboard::KeyCode::KEY_ENTER)
             {
                 IMEDispatcher::sharedDispatcher()->dispatchInsertText("\n", 1);
-                }
-            break;
+            }
+        }
+
+        if (pressed && !event.isStopped())
+        {
+            switch (keyCode)
+            {
+            case EventKeyboard::KeyCode::KEY_BACKSPACE:
+                IMEDispatcher::sharedDispatcher()->dispatchDeleteBackward();
+                break;
+            case EventKeyboard::KeyCode::KEY_HOME:
+            case EventKeyboard::KeyCode::KEY_KP_HOME:
+            case EventKeyboard::KeyCode::KEY_DELETE:
+            case EventKeyboard::KeyCode::KEY_KP_DELETE:
+            case EventKeyboard::KeyCode::KEY_END:
+            case EventKeyboard::KeyCode::KEY_LEFT_ARROW:
+            case EventKeyboard::KeyCode::KEY_RIGHT_ARROW:
+            case EventKeyboard::KeyCode::KEY_ESCAPE:
+                IMEDispatcher::sharedDispatcher()->dispatchControlKey(keyCode);
+                break;
+            default:
+                break;
+            }
         }
     }
     else

--- a/templates/cpp-template-default/proj.win10/App/Cocos2dEngine/OpenGLESPage.xaml.cpp
+++ b/templates/cpp-template-default/proj.win10/App/Cocos2dEngine/OpenGLESPage.xaml.cpp
@@ -172,15 +172,13 @@ void OpenGLESPage::OnPointerReleased(Object^ sender, PointerEventArgs^ e)
 
 void OpenGLESPage::OnKeyPressed(CoreWindow^ sender, KeyEventArgs^ e)
 {
-	if (!e->KeyStatus.WasKeyDown)
-	{
-		//log("OpenGLESPage::OnKeyPressed %d", e->VirtualKey);
-		if (mRenderer)
-		{
-			mRenderer->QueueKeyboardEvent(WinRTKeyboardEventType::KeyPressed, e);
-		}
-	}
+    //log("OpenGLESPage::OnKeyPressed %d", e->VirtualKey);
+    if (mRenderer)
+    {
+        mRenderer->QueueKeyboardEvent(WinRTKeyboardEventType::KeyPressed, e);
+    }
 }
+
 
 void OpenGLESPage::OnCharacterReceived(CoreWindow^ sender, CharacterReceivedEventArgs^ e)
 {


### PR DESCRIPTION
Add StringUtils::StringUTF8 for easy manipulate utf8 string.
If TextField active(focused input text) show text cursor( default '|',
change TextFieldTTF::setCursorChar ).
Show/Hide interval CURSOR_TIME_SHOW_HIDE
Change position text cursor control key: KEY_HOME, KEY_END,
KEY_LEFT_ARROW, KEY_RIGHT_ARROW
CC_PLATFORM_MAC,  CC_PLATFORM_WIN32, CC_PLATFORM_LINUX default use
cursor( For change state TextFieldTTF::setCursorUse )
Desktop implement dispatchControlKey
WinRT support key repeat and implement dispatchControlKey
