### PR TITLE
Introduce touch down event support for CCMenu

### DIFF
--- a/cocos/2d/CCMenu.cpp
+++ b/cocos/2d/CCMenu.cpp
@@ -134,6 +134,7 @@ bool Menu::initWithArray(const Vector<MenuItem*>& arrayOfItems)
     if (Layer::init())
     {
         _enabled = true;
+        _eventType = EventType::TOUCH_UP;
         // menu in the center of the screen
         Size s = Director::getInstance()->getWinSize();
 
@@ -273,7 +274,11 @@ bool Menu::onTouchBegan(Touch* touch, Event* event)
         _state = Menu::State::TRACKING_TOUCH;
         _selectedWithCamera = camera;
         _selectedItem->selected();
-        
+        if (_eventType == EventType::TOUCH_DOWN) 
+        {
+            _selectedItem->activate();
+        }
+
         return true;
     }
     
@@ -287,7 +292,10 @@ void Menu::onTouchEnded(Touch* touch, Event* event)
     if (_selectedItem)
     {
         _selectedItem->unselected();
-        _selectedItem->activate();
+        if (_eventType == EventType::TOUCH_UP) 
+        {
+            _selectedItem->activate();
+        }
     }
     _state = Menu::State::WAITING;
     _selectedWithCamera = nullptr;

--- a/cocos/2d/CCMenu.h
+++ b/cocos/2d/CCMenu.h
@@ -59,6 +59,15 @@ public:
     };
     
     /**
+     * Event type
+     */
+    enum class EventType
+    {
+        TOUCH_UP,
+        TOUCH_DOWN
+    };
+    
+    /**
      *@brief Creates an empty Menu.
      */
     static Menu* create();
@@ -155,6 +164,20 @@ public:
      */
     virtual void setEnabled(bool value) { _enabled = value; };
 
+    /**
+     * Determines how to activate callback
+     * @return Event Type to activate callback
+     */
+    virtual EventType getEventType() const { return _eventType; }
+    
+    /**
+     * Set event type to activate callback.
+     * The default value is TOUCH_UP, a callback function will be activated
+     * when menu items are released.
+     *@param event type what activates callback.
+     */
+    virtual void setEventType(EventType value) { _eventType = value; }; 
+    
     virtual bool onTouchBegan(Touch* touch, Event* event) override;
     virtual void onTouchEnded(Touch* touch, Event* event) override;
     virtual void onTouchCancelled(Touch* touch, Event* event) override;
@@ -194,6 +217,9 @@ protected:
 
     /** whether or not the menu will receive events */
     bool _enabled;
+    
+    /** event type to activate callback **/
+    EventType _eventType;
 
     virtual MenuItem* getItemForTouch(Touch * touch, const Camera *camera);
     State _state;


### PR DESCRIPTION
We can't activate callback functions when `MenuItem`s are pressed down.

This PR make it to enable to handle touch down event on `Menu`.

``` cpp
auto menuItem = cocos2d::MenuItemImage::create("button.png", "button.png", [](Ref *button) {
    cocos2d::log("touch down event");
});
auto menu = cocos2d::Menu::create(menuItem, nullptr);
menu->setEventType(cocos2d::Menu::EventType::TOUCH_DOWN);
```
