### PR TITLE
Update CCImage.cpp

### DIFF
--- a/cocos/platform/CCImage.cpp
+++ b/cocos/platform/CCImage.cpp
@@ -576,7 +576,7 @@ bool Image::initWithImageData(const unsigned char * data, ssize_t dataLen)
                 }
                 else
                 {
-                    CCAssert(false, "unsupport image format!");
+                    ret = false;
                 }
                 
                 free(tgaData);


### PR DESCRIPTION
When you're creating a sprite (e.g. with Sprite\* Sprite::create(filename)) with content from the internet, there's no way to test the file before, without getting "a unsupport image format!" thrown.
