### PR TITLE
 trace() does not default to cocos2d::Rect::Zero

### DIFF
--- a/cocos/2d/CCAutoPolygon.h
+++ b/cocos/2d/CCAutoPolygon.h
@@ -152,7 +152,7 @@ public:
      * std::vector<Vec2> points = ap.trace();//default to size of the image and threshold 0.0
      * @endcode
      */
-     std::vector<Vec2> trace(const cocos2d::Rect& rect, const float& threshold = 0.0);
+     std::vector<Vec2> trace(const cocos2d::Rect& rect = cocos2d::Rect::ZERO, const float& threshold = 0.0);
     
     /**
      * reduce the ammount of points so its faster for GPU to process and draw


### PR DESCRIPTION
The comments/docs state this   

```
@param   rect    a texture rect for specify an area of the image, use Rect::Zero for the size of the image, default to Rect::Zero
```

Which wasn't accurate. Now it is :+1: 
