### PR TITLE
Fix/Optimisation of TextReader

### DIFF
--- a/cocos/editor-support/cocostudio/WidgetReader/TextReader/TextReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/TextReader/TextReader.cpp
@@ -400,9 +400,6 @@ namespace cocostudio
         bool touchScaleEnabled = options->touchScaleEnable() != 0;
         label->setTouchScaleChangeEnabled(touchScaleEnabled);
         
-        std::string text = options->text()->c_str();
-        label->setString(text);
-        
         int fontSize = options->fontSize();
         label->setFontSize(fontSize);
         
@@ -469,6 +466,11 @@ namespace cocostudio
                 label->enableShadow(shadowColor, Size(options->shadowOffsetX(), options->shadowOffsetY()), options->shadowBlurRadius());
             }
         }
+        
+        //Set the text content last to minimise overhead of recalculating/rerendering text.
+        //Also helps to avoid max texture size issue caused by large text rendered with system font before fontResource is set.
+        std::string text = options->text()->c_str();
+        label->setString(text);
 
         // Save node color before set widget properties
         auto oldColor = node->getColor();


### PR DESCRIPTION
If a long piece of text is defined in cocosStudio with a custom font, TextReader will unnecessarily (and implicitly) build the label with the default system font first. It will also trigger repeat recalculations of the label's size, atlas and system font texture via the setFontName() and setFontSize() calls.

By setting the text content last we can drastically minimise this overhead.

Furthermore if the text content is large the system font renderer will potentially produce a texture wider than the maximum texture size of the device. This is avoided with the given change for custom fonts but will still pose an issue for large labels relying on the default system font.
