### PR TITLE
EventListenerMouse will dispatch EventMouse events

### DIFF
--- a/cocos/base/CCEventListenerMouse.cpp
+++ b/cocos/base/CCEventListenerMouse.cpp
@@ -82,19 +82,19 @@ bool EventListenerMouse::init()
         {
             case EventMouse::MouseEventType::MOUSE_DOWN:
                 if(onMouseDown != nullptr)
-                    onMouseDown(event);
+                    onMouseDown(mouseEvent);
                 break;
             case EventMouse::MouseEventType::MOUSE_UP:
                 if(onMouseUp != nullptr)
-                    onMouseUp(event);
+                    onMouseUp(mouseEvent);
                 break;
             case EventMouse::MouseEventType::MOUSE_MOVE:
                 if(onMouseMove != nullptr)
-                    onMouseMove(event);
+                    onMouseMove(mouseEvent);
                 break;
             case EventMouse::MouseEventType::MOUSE_SCROLL:
                 if(onMouseScroll != nullptr)
-                    onMouseScroll(event);
+                    onMouseScroll(mouseEvent);
                 break;
             default:
                 break;

--- a/cocos/base/CCEventListenerMouse.h
+++ b/cocos/base/CCEventListenerMouse.h
@@ -57,10 +57,10 @@ public:
     virtual EventListenerMouse* clone() override;
     virtual bool checkAvailable() override;
 
-    std::function<void(Event* event)> onMouseDown;
-    std::function<void(Event* event)> onMouseUp;
-    std::function<void(Event* event)> onMouseMove;
-    std::function<void(Event* event)> onMouseScroll;
+    std::function<void(EventMouse* event)> onMouseDown;
+    std::function<void(EventMouse* event)> onMouseUp;
+    std::function<void(EventMouse* event)> onMouseMove;
+    std::function<void(EventMouse* event)> onMouseScroll;
 
 CC_CONSTRUCTOR_ACCESS:
     EventListenerMouse();


### PR DESCRIPTION
If you use an EventListenerMouse you want to know the coordinates for onMouseMove.
You don't get that with normal Event object, but through EventMouse.

The header was included, I suspect someone forgot to use it in the callbacks for the new model on handling touch/mouse.
