### PR TITLE
Removed ScrollView::_innerContainer pointer copy

### DIFF
--- a/cocos/ui/UIScrollView.cpp
+++ b/cocos/ui/UIScrollView.cpp
@@ -1342,8 +1342,8 @@ void ScrollView::copySpecialProperties(Widget *widget)
     if (scrollView)
     {
         Layout::copySpecialProperties(widget);
-        _innerContainer = scrollView->_innerContainer;
         setDirection(scrollView->_direction);
+        setInnerContainerPosition(scrollView->getInnerContainerPosition());
         setInnerContainerSize(scrollView->getInnerContainerSize());
         _topBoundary = scrollView->_topBoundary;
         _bottomBoundary = scrollView->_bottomBoundary;


### PR DESCRIPTION
Copied pointer becomes invalid when model widget destructs. Instead we simply copy the position.
