### PR TITLE
don't define static variable in header file or each dynamic lib will have a copy

### DIFF
--- a/cocos/scripting/js-bindings/manual/ScriptingCore.cpp
+++ b/cocos/scripting/js-bindings/manual/ScriptingCore.cpp
@@ -452,6 +452,14 @@ static const JSClass global_class = {
     JS_GlobalObjectTraceHook
 };
 
+ScriptingCore* ScriptingCore::getInstance()
+{
+    static ScriptingCore* instance = nullptr;
+    if (instance == nullptr)
+        instance = new ScriptingCore();
+
+    return instance;
+}
 
 ScriptingCore::ScriptingCore()
 : _rt(nullptr)

--- a/cocos/scripting/js-bindings/manual/ScriptingCore.h
+++ b/cocos/scripting/js-bindings/manual/ScriptingCore.h
@@ -70,13 +70,7 @@ private:
 public:
     ~ScriptingCore();
 
-    static ScriptingCore *getInstance() {
-        static ScriptingCore* pInstance = NULL;
-        if (pInstance == NULL) {
-            pInstance = new ScriptingCore();
-        }
-        return pInstance;
-    };
+    static ScriptingCore *getInstance();
 
     virtual cocos2d::ccScriptType getScriptType() { return cocos2d::kScriptTypeJavascript; };
 


### PR DESCRIPTION
If using cocos2d-x as a dynamic library, then game codes and cocos2d-x will each have a copy of ScriptingCore instance.

For example, there are two libs: libcocos2dx.so an libgame.so, and libgame.so depends on libcocos2dx.so, then libcocos2dx.so and libgame.so will each have a copy of ScriptingCore instance. This means that, there are two instances of `ScriptingCore` created, one is created and used in libcocos2dx, another one is created and used in libgame.so. This will cause problems, because we want these two .so share the same instance.
