### PR TITLE
Added functionality to AttachNode

### DIFF
--- a/cocos/3d/CCAttachNode.cpp
+++ b/cocos/3d/CCAttachNode.cpp
@@ -79,6 +79,11 @@ Mat4 AttachNode::getFullAttachTransform() const
   }
 }
 
+void AttachNode::setOffsetTransform(const Mat4& offset)
+{
+  _attachOffset = offset;
+}
+
 Mat4 AttachNode::getNodeToWorldTransform() const
 {
     return Node::getNodeToWorldTransform();

--- a/cocos/3d/CCAttachNode.h
+++ b/cocos/3d/CCAttachNode.h
@@ -47,10 +47,33 @@ class CC_DLL AttachNode : public Node
 public:
     /** 
      * creates an AttachNode
-     * @param attachBone The bone to which the AttachNode is going to attach, the attacheBone must be a bone of the AttachNode's parent
+     * @param attachBone The bone to which the AttachNode is going to attach, the attacheBone must be a bone of the AttachNode's parent.
      */
     static AttachNode* create(Bone3D* attachBone);
-    
+  
+    /**
+     * creates an AttachNode
+     * @param attachBone The bone to which the AttachNode is going to attach, the attacheBone must be a bone of the AttachNode's parent.
+     * @param offset an additional transform between this node and the children
+     *
+     */
+    static AttachNode* create(Bone3D* attachBone, const Mat4& offset);
+  
+    /**
+     * creates an AttachNode that doesn't require a bone. Useful for attaching nodes to each other for relative positioning.
+     * @param offset an additional transform between this node and the children
+     *
+     */
+    static AttachNode* create(const Mat4& offset);
+  
+    /**
+    * sets the transform offset between this node and the children
+    * @param offset the transform value that gets applied
+    */
+    void setOffsetTransform(const Mat4& offset);
+  
+
+  
     //override
     virtual Mat4 getWorldToNodeTransform() const override;
     virtual Mat4 getNodeToWorldTransform() const override;
@@ -64,7 +87,10 @@ CC_CONSTRUCTOR_ACCESS:
     
 
 protected:
+    Mat4 getFullAttachTransform() const;
+  
     Bone3D* _attachBone;
+    mutable Mat4    _attachOffset;
     mutable Mat4    _transformToParent;
 };
 


### PR DESCRIPTION
AttachNode can now be used as a hierarchal transform between 2 nodes even without a bone reference. Useful for those that want to treat the node hierarchy as a more traditional transform scene graph.

Example usage:

```
    // create a fixed translation offset
    Mat4 offset;
    Mat4::createTranslation(Vec3(-15.0f, 15.0f, 0.0f), &offset);
    auto attachNode = AttachNode::create(offset);

    // create a sprite to attach to main sprite
    auto subSprite = Sprite3D::create("Sprite3DTest/axe.c3b");
    subSprite->runAction(RepeatForever::create(RotateBy::create(10.0f, Vec3::UNIT_Z * 360.0f)));

    // attach sub sprite to the other sprite with the offset
    attachNode->addChild(subSprite);
    sprite->addChild(attachNode);
    sprite->runAction(RepeatForever::create(RotateBy::create(10.0f, Vec3::UNIT_Y * 360.0f)));
```
