### PR TITLE
Fix crash in FrameBuffer if no DepthStencil

### DIFF
--- a/cocos/renderer/CCFrameBuffer.cpp
+++ b/cocos/renderer/CCFrameBuffer.cpp
@@ -456,7 +456,7 @@ void FrameBuffer::applyFBO()
         CHECK_GL_ERROR_DEBUG();
         glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_STENCIL_ATTACHMENT, GL_RENDERBUFFER, nullptr == _rtDepthStencil ? 0 : _rtDepthStencil->getBuffer());
         CHECK_GL_ERROR_DEBUG();
-        CCLOG("FBO is %d _fbo %d color, %d ds", _fbo, RenderTargetBase::Type::Texture2D == _rt->getType() ? _rt->getTexture()->getName() : _rt->getBuffer(), _rtDepthStencil->getBuffer());
+        CCLOG("FBO is %d _fbo %d color, %d ds", _fbo, RenderTargetBase::Type::Texture2D == _rt->getType() ? _rt->getTexture()->getName() : _rt->getBuffer(), nullptr == _rtDepthStencil ? 0 : _rtDepthStencil->getBuffer());
         _fboBindingDirty = false;
     }
     if(GL_FRAMEBUFFER_COMPLETE != glCheckFramebufferStatus(GL_FRAMEBUFFER))


### PR DESCRIPTION
This fixes a debug-config crash if a `FrameBuffer` has no `RenderTargetDepthStencil`.
