### PR TITLE
Fix Material clone Bug

### DIFF
--- a/cocos/renderer/CCMaterial.cpp
+++ b/cocos/renderer/CCMaterial.cpp
@@ -442,6 +442,10 @@ Material* Material::clone() const
         for (const auto& technique: _techniques)
         {
             auto t = technique->clone();
+            t->setParent(material);
+            for (ssize_t i = 0; i < t->getPassCount(); i++) {
+                t->getPassByIndex(i)->setParent(t);
+            }
             material->_techniques.pushBack(t);
         }
 

--- a/cocos/renderer/CCRenderState.h
+++ b/cocos/renderer/CCRenderState.h
@@ -84,6 +84,12 @@ public:
      * Returns the topmost RenderState in the hierarchy below the given RenderState.
      */
     RenderState* getTopmost(RenderState* below);
+    
+    /**
+     * Set parent RenderState
+     * @param parent Parent RenderState
+     */
+    void setParent(RenderState* parent) { _parent = parent; }
 
     enum Blend
     {


### PR DESCRIPTION
Material::clone doesn't set the parent correctly.
