### PR TITLE
[ci skip] Solve the error in templates.

### DIFF
--- a/templates/cpp-template-default/cocos-project-template.json
+++ b/templates/cpp-template-default/cocos-project-template.json
@@ -49,6 +49,7 @@
                "proj.android/build.xml",
                "proj.android/res/values/strings.xml",
                "proj.android-studio/settings.gradle",
+               "proj.android-studio/app/res/values/strings.xml",
                "proj.ios_mac/ios/main.m",
                "proj.ios_mac/ios/Prefix.pch",
                "proj.ios_mac/PROJECT_NAME.xcodeproj/project.pbxproj",

--- a/templates/js-template-default/cocos-project-template.json
+++ b/templates/js-template-default/cocos-project-template.json
@@ -66,6 +66,7 @@
                "frameworks/runtime-src/proj.android/build.xml",
                "frameworks/runtime-src/proj.android/res/values/strings.xml",
                "frameworks/runtime-src/proj.android-studio/settings.gradle",
+               "frameworks/runtime-src/proj.android-studio/app/res/values/strings.xml",
                "frameworks/runtime-src/proj.ios_mac/ios/main.m",
                "frameworks/runtime-src/proj.ios_mac/ios/Prefix.pch",
                "frameworks/runtime-src/proj.ios_mac/PROJECT_NAME.xcodeproj/project.pbxproj",

--- a/templates/lua-template-default/cocos-project-template.json
+++ b/templates/lua-template-default/cocos-project-template.json
@@ -174,6 +174,7 @@
                 "frameworks/runtime-src/proj.android/build.xml",
                 "frameworks/runtime-src/proj.android/res/values/strings.xml",
                 "frameworks/runtime-src/proj.android-studio/settings.gradle",
+                "frameworks/runtime-src/proj.android-studio/app/res/values/strings.xml",
                 "frameworks/runtime-src/proj.ios_mac/ios/main.m",
                 "frameworks/runtime-src/proj.ios_mac/ios/Prefix.pch",
                 "frameworks/runtime-src/proj.ios_mac/mac/SimulatorApp.mm",

--- a/templates/lua-template-runtime/cocos-project-template.json
+++ b/templates/lua-template-runtime/cocos-project-template.json
@@ -174,6 +174,7 @@
                 "frameworks/runtime-src/proj.android/build.xml",
                 "frameworks/runtime-src/proj.android/res/values/strings.xml",
                 "frameworks/runtime-src/proj.android-studio/settings.gradle",
+                "frameworks/runtime-src/proj.android-studio/app/res/values/strings.xml",
                 "frameworks/runtime-src/proj.ios_mac/ios/main.m",
                 "frameworks/runtime-src/proj.ios_mac/ios/Prefix.pch",
                 "frameworks/runtime-src/proj.ios_mac/mac/SimulatorApp.mm",


### PR DESCRIPTION
When creating project from template, the app name of android-studio project is not changed.
