### PR TITLE
Fix Chipmunk setCollisionType issue by initializing variables

### DIFF
--- a/cocos/scripting/js-bindings/manual/chipmunk/js_bindings_chipmunk_auto_classes.cpp
+++ b/cocos/scripting/js-bindings/manual/chipmunk/js_bindings_chipmunk_auto_classes.cpp
@@ -82,7 +82,7 @@ bool JSB_cpConstraint_getA(JSContext *cx, uint32_t argc, jsval *vp) {
     JSObject* jsthis = (JSObject *)JS_THIS_OBJECT(cx, vp);
     struct jsb_c_proxy_s *proxy = jsb_get_c_proxy_for_jsobject(jsthis);
     cpConstraint* arg0 = (cpConstraint*) proxy->handle;
-    cpBody* ret_val;
+    cpBody* ret_val = nullptr;
 
     ret_val = cpConstraintGetA((cpConstraint*)arg0  );
 
@@ -100,7 +100,7 @@ bool JSB_cpConstraint_getB(JSContext *cx, uint32_t argc, jsval *vp) {
     JSObject* jsthis = (JSObject *)JS_THIS_OBJECT(cx, vp);
     struct jsb_c_proxy_s *proxy = jsb_get_c_proxy_for_jsobject(jsthis);
     cpConstraint* arg0 = (cpConstraint*) proxy->handle;
-    cpBody* ret_val;
+    cpBody* ret_val = nullptr;
 
     ret_val = cpConstraintGetB((cpConstraint*)arg0  );
 
@@ -118,7 +118,7 @@ bool JSB_cpConstraint_getErrorBias(JSContext *cx, uint32_t argc, jsval *vp) {
     JSObject* jsthis = (JSObject *)JS_THIS_OBJECT(cx, vp);
     struct jsb_c_proxy_s *proxy = jsb_get_c_proxy_for_jsobject(jsthis);
     cpConstraint* arg0 = (cpConstraint*) proxy->handle;
-    cpFloat ret_val;
+    cpFloat ret_val = 0;
 
     ret_val = cpConstraintGetErrorBias((cpConstraint*)arg0  );
     args.rval().set(DOUBLE_TO_JSVAL(ret_val));
@@ -133,7 +133,7 @@ bool JSB_cpConstraint_getImpulse(JSContext *cx, uint32_t argc, jsval *vp) {
     JSObject* jsthis = (JSObject *)JS_THIS_OBJECT(cx, vp);
     struct jsb_c_proxy_s *proxy = jsb_get_c_proxy_for_jsobject(jsthis);
     cpConstraint* arg0 = (cpConstraint*) proxy->handle;
-    cpFloat ret_val;
+    cpFloat ret_val = 0;
 
     ret_val = cpConstraintGetImpulse((cpConstraint*)arg0  );
     args.rval().set(DOUBLE_TO_JSVAL(ret_val));
@@ -148,7 +148,7 @@ bool JSB_cpConstraint_getMaxBias(JSContext *cx, uint32_t argc, jsval *vp) {
     JSObject* jsthis = (JSObject *)JS_THIS_OBJECT(cx, vp);
     struct jsb_c_proxy_s *proxy = jsb_get_c_proxy_for_jsobject(jsthis);
     cpConstraint* arg0 = (cpConstraint*) proxy->handle;
-    cpFloat ret_val;
+    cpFloat ret_val = 0;
 
     ret_val = cpConstraintGetMaxBias((cpConstraint*)arg0  );
     args.rval().set(DOUBLE_TO_JSVAL(ret_val));
@@ -163,7 +163,7 @@ bool JSB_cpConstraint_getMaxForce(JSContext *cx, uint32_t argc, jsval *vp) {
     JSObject* jsthis = (JSObject *)JS_THIS_OBJECT(cx, vp);
     struct jsb_c_proxy_s *proxy = jsb_get_c_proxy_for_jsobject(jsthis);
     cpConstraint* arg0 = (cpConstraint*) proxy->handle;
-    cpFloat ret_val;
+    cpFloat ret_val = 0;
 
     ret_val = cpConstraintGetMaxForce((cpConstraint*)arg0  );
     args.rval().set(DOUBLE_TO_JSVAL(ret_val));
@@ -178,7 +178,7 @@ bool JSB_cpConstraint_getSpace(JSContext *cx, uint32_t argc, jsval *vp) {
     JSObject* jsthis = (JSObject *)JS_THIS_OBJECT(cx, vp);
     struct jsb_c_proxy_s *proxy = jsb_get_c_proxy_for_jsobject(jsthis);
     cpConstraint* arg0 = (cpConstraint*) proxy->handle;
-    cpSpace* ret_val;
+    cpSpace* ret_val = nullptr;
 
     ret_val = cpConstraintGetSpace((cpConstraint*)arg0  );
 
@@ -304,7 +304,7 @@ bool JSB_cpGrooveJoint_constructor(JSContext *cx, uint32_t argc, jsval *vp)
     JSObject *jsobj = JS_NewObject(cx, JSB_cpGrooveJoint_class, JS::RootedObject(cx, JSB_cpGrooveJoint_object), JS::NullPtr());
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpBody* arg0; cpBody* arg1; cpVect arg2; cpVect arg3; cpVect arg4; 
+    cpBody* arg0 = nullptr; cpBody* arg1 = nullptr; cpVect arg2; cpVect arg3; cpVect arg4; 
 
     ok &= jsval_to_c_class( cx, args.get(0), (void**)&arg0, NULL );
     ok &= jsval_to_c_class( cx, args.get(1), (void**)&arg1, NULL );
@@ -501,7 +501,7 @@ bool JSB_cpSimpleMotor_constructor(JSContext *cx, uint32_t argc, jsval *vp)
     JSObject *jsobj = JS_NewObject(cx, JSB_cpSimpleMotor_class, JS::RootedObject(cx, JSB_cpSimpleMotor_object), JS::NullPtr());
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpBody* arg0; cpBody* arg1; double arg2; 
+    cpBody* arg0 = nullptr; cpBody* arg1 = nullptr; double arg2 = 0; 
 
     ok &= jsval_to_c_class( cx, args.get(0), (void**)&arg0, NULL );
     ok &= jsval_to_c_class( cx, args.get(1), (void**)&arg1, NULL );
@@ -540,7 +540,7 @@ bool JSB_cpSimpleMotor_getRate(JSContext *cx, uint32_t argc, jsval *vp) {
     JSObject* jsthis = (JSObject *)JS_THIS_OBJECT(cx, vp);
     struct jsb_c_proxy_s *proxy = jsb_get_c_proxy_for_jsobject(jsthis);
     cpSimpleMotor* arg0 = (cpSimpleMotor*) proxy->handle;
-    cpFloat ret_val;
+    cpFloat ret_val = 0;
 
     ret_val = cpSimpleMotorGetRate((cpConstraint*)arg0  );
     args.rval().set(DOUBLE_TO_JSVAL(ret_val));
@@ -613,7 +613,7 @@ bool JSB_cpPivotJoint_constructor(JSContext *cx, uint32_t argc, jsval *vp)
     JSObject *jsobj = JS_NewObject(cx, JSB_cpPivotJoint_class, JS::RootedObject(cx, JSB_cpPivotJoint_object), JS::NullPtr());
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpBody* arg0; cpBody* arg1; cpVect arg2; cpVect arg3; void *ret_val;
+    cpBody* arg0 = nullptr; cpBody* arg1 = nullptr; cpVect arg2; cpVect arg3; void *ret_val = nullptr;
 
     ok &= jsval_to_c_class( cx, args.get(0), (void**)&arg0, NULL );
     ok &= jsval_to_c_class( cx, args.get(1), (void**)&arg1, NULL );
@@ -773,7 +773,7 @@ bool JSB_cpPinJoint_constructor(JSContext *cx, uint32_t argc, jsval *vp)
     JSObject *jsobj = JS_NewObject(cx, JSB_cpPinJoint_class, JS::RootedObject(cx, JSB_cpPinJoint_object), JS::NullPtr());
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpBody* arg0; cpBody* arg1; cpVect arg2; cpVect arg3; 
+    cpBody* arg0 = nullptr; cpBody* arg1 = nullptr; cpVect arg2; cpVect arg3; 
 
     ok &= jsval_to_c_class( cx, args.get(0), (void**)&arg0, NULL );
     ok &= jsval_to_c_class( cx, args.get(1), (void**)&arg1, NULL );
@@ -849,7 +849,7 @@ bool JSB_cpPinJoint_getDist(JSContext *cx, uint32_t argc, jsval *vp) {
     JSObject* jsthis = (JSObject *)JS_THIS_OBJECT(cx, vp);
     struct jsb_c_proxy_s *proxy = jsb_get_c_proxy_for_jsobject(jsthis);
     cpPinJoint* arg0 = (cpPinJoint*) proxy->handle;
-    cpFloat ret_val;
+    cpFloat ret_val = 0;
 
     ret_val = cpPinJointGetDist((cpConstraint*)arg0  );
     args.rval().set(DOUBLE_TO_JSVAL(ret_val));
@@ -906,7 +906,7 @@ bool JSB_cpPinJoint_setDist(JSContext *cx, uint32_t argc, jsval *vp) {
     cpPinJoint* arg0 = (cpPinJoint*) proxy->handle;
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    double arg1; 
+    double arg1 = 0; 
 
     ok &= JS::ToNumber( cx, args.get(0), &arg1 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
@@ -966,7 +966,7 @@ bool JSB_cpSlideJoint_constructor(JSContext *cx, uint32_t argc, jsval *vp)
     JSObject *jsobj = JS_NewObject(cx, JSB_cpSlideJoint_class, JS::RootedObject(cx, JSB_cpSlideJoint_object), JS::NullPtr());
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpBody* arg0; cpBody* arg1; cpVect arg2; cpVect arg3; double arg4; double arg5; 
+    cpBody* arg0 = nullptr; cpBody* arg1 = nullptr; cpVect arg2; cpVect arg3; double arg4 = 0; double arg5 = 0; 
 
     ok &= jsval_to_c_class( cx, args.get(0), (void**)&arg0, NULL );
     ok &= jsval_to_c_class( cx, args.get(1), (void**)&arg1, NULL );
@@ -1044,7 +1044,7 @@ bool JSB_cpSlideJoint_getMax(JSContext *cx, uint32_t argc, jsval *vp) {
     JSObject* jsthis = (JSObject *)JS_THIS_OBJECT(cx, vp);
     struct jsb_c_proxy_s *proxy = jsb_get_c_proxy_for_jsobject(jsthis);
     cpSlideJoint* arg0 = (cpSlideJoint*) proxy->handle;
-    cpFloat ret_val;
+    cpFloat ret_val = 0;
 
     ret_val = cpSlideJointGetMax((cpConstraint*)arg0  );
     args.rval().set(DOUBLE_TO_JSVAL(ret_val));
@@ -1059,7 +1059,7 @@ bool JSB_cpSlideJoint_getMin(JSContext *cx, uint32_t argc, jsval *vp) {
     JSObject* jsthis = (JSObject *)JS_THIS_OBJECT(cx, vp);
     struct jsb_c_proxy_s *proxy = jsb_get_c_proxy_for_jsobject(jsthis);
     cpSlideJoint* arg0 = (cpSlideJoint*) proxy->handle;
-    cpFloat ret_val;
+    cpFloat ret_val = 0;
 
     ret_val = cpSlideJointGetMin((cpConstraint*)arg0  );
     args.rval().set(DOUBLE_TO_JSVAL(ret_val));
@@ -1116,7 +1116,7 @@ bool JSB_cpSlideJoint_setMax(JSContext *cx, uint32_t argc, jsval *vp) {
     cpSlideJoint* arg0 = (cpSlideJoint*) proxy->handle;
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    double arg1; 
+    double arg1 = 0; 
 
     ok &= JS::ToNumber( cx, args.get(0), &arg1 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
@@ -1136,7 +1136,7 @@ bool JSB_cpSlideJoint_setMin(JSContext *cx, uint32_t argc, jsval *vp) {
     cpSlideJoint* arg0 = (cpSlideJoint*) proxy->handle;
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    double arg1; 
+    double arg1 = 0; 
 
     ok &= JS::ToNumber( cx, args.get(0), &arg1 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
@@ -1198,7 +1198,7 @@ bool JSB_cpGearJoint_constructor(JSContext *cx, uint32_t argc, jsval *vp)
     JSObject *jsobj = JS_NewObject(cx, JSB_cpGearJoint_class, JS::RootedObject(cx, JSB_cpGearJoint_object), JS::NullPtr());
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpBody* arg0; cpBody* arg1; double arg2; double arg3; 
+    cpBody* arg0 = nullptr; cpBody* arg1 = nullptr; double arg2 = 0; double arg3 = 0; 
 
     ok &= jsval_to_c_class( cx, args.get(0), (void**)&arg0, NULL );
     ok &= jsval_to_c_class( cx, args.get(1), (void**)&arg1, NULL );
@@ -1238,7 +1238,7 @@ bool JSB_cpGearJoint_getPhase(JSContext *cx, uint32_t argc, jsval *vp) {
     JSObject* jsthis = (JSObject *)JS_THIS_OBJECT(cx, vp);
     struct jsb_c_proxy_s *proxy = jsb_get_c_proxy_for_jsobject(jsthis);
     cpGearJoint* arg0 = (cpGearJoint*) proxy->handle;
-    cpFloat ret_val;
+    cpFloat ret_val = 0;
 
     ret_val = cpGearJointGetPhase((cpConstraint*)arg0  );
     args.rval().set(DOUBLE_TO_JSVAL(ret_val));
@@ -1253,7 +1253,7 @@ bool JSB_cpGearJoint_getRatio(JSContext *cx, uint32_t argc, jsval *vp) {
     JSObject* jsthis = (JSObject *)JS_THIS_OBJECT(cx, vp);
     struct jsb_c_proxy_s *proxy = jsb_get_c_proxy_for_jsobject(jsthis);
     cpGearJoint* arg0 = (cpGearJoint*) proxy->handle;
-    cpFloat ret_val;
+    cpFloat ret_val = 0;
 
     ret_val = cpGearJointGetRatio((cpConstraint*)arg0  );
     args.rval().set(DOUBLE_TO_JSVAL(ret_val));
@@ -1270,7 +1270,7 @@ bool JSB_cpGearJoint_setPhase(JSContext *cx, uint32_t argc, jsval *vp) {
     cpGearJoint* arg0 = (cpGearJoint*) proxy->handle;
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    double arg1; 
+    double arg1 = 0; 
 
     ok &= JS::ToNumber( cx, args.get(0), &arg1 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
@@ -1290,7 +1290,7 @@ bool JSB_cpGearJoint_setRatio(JSContext *cx, uint32_t argc, jsval *vp) {
     cpGearJoint* arg0 = (cpGearJoint*) proxy->handle;
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    double arg1; 
+    double arg1 = 0; 
 
     ok &= JS::ToNumber( cx, args.get(0), &arg1 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
@@ -1348,7 +1348,7 @@ bool JSB_cpDampedRotarySpring_constructor(JSContext *cx, uint32_t argc, jsval *v
     JSObject *jsobj = JS_NewObject(cx, JSB_cpDampedRotarySpring_class, JS::RootedObject(cx, JSB_cpDampedRotarySpring_object), JS::NullPtr());
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpBody* arg0; cpBody* arg1; double arg2; double arg3; double arg4; 
+    cpBody* arg0 = nullptr; cpBody* arg1 = nullptr; double arg2 = 0; double arg3 = 0; double arg4 = 0; 
 
     ok &= jsval_to_c_class( cx, args.get(0), (void**)&arg0, NULL );
     ok &= jsval_to_c_class( cx, args.get(1), (void**)&arg1, NULL );
@@ -1389,7 +1389,7 @@ bool JSB_cpDampedRotarySpring_getDamping(JSContext *cx, uint32_t argc, jsval *vp
     JSObject* jsthis = (JSObject *)JS_THIS_OBJECT(cx, vp);
     struct jsb_c_proxy_s *proxy = jsb_get_c_proxy_for_jsobject(jsthis);
     cpDampedRotarySpring* arg0 = (cpDampedRotarySpring*) proxy->handle;
-    cpFloat ret_val;
+    cpFloat ret_val = 0;
 
     ret_val = cpDampedRotarySpringGetDamping((cpConstraint*)arg0  );
     args.rval().set(DOUBLE_TO_JSVAL(ret_val));
@@ -1404,7 +1404,7 @@ bool JSB_cpDampedRotarySpring_getRestAngle(JSContext *cx, uint32_t argc, jsval *
     JSObject* jsthis = (JSObject *)JS_THIS_OBJECT(cx, vp);
     struct jsb_c_proxy_s *proxy = jsb_get_c_proxy_for_jsobject(jsthis);
     cpDampedRotarySpring* arg0 = (cpDampedRotarySpring*) proxy->handle;
-    cpFloat ret_val;
+    cpFloat ret_val = 0;
 
     ret_val = cpDampedRotarySpringGetRestAngle((cpConstraint*)arg0  );
     args.rval().set(DOUBLE_TO_JSVAL(ret_val));
@@ -1419,7 +1419,7 @@ bool JSB_cpDampedRotarySpring_getStiffness(JSContext *cx, uint32_t argc, jsval *
     JSObject* jsthis = (JSObject *)JS_THIS_OBJECT(cx, vp);
     struct jsb_c_proxy_s *proxy = jsb_get_c_proxy_for_jsobject(jsthis);
     cpDampedRotarySpring* arg0 = (cpDampedRotarySpring*) proxy->handle;
-    cpFloat ret_val;
+    cpFloat ret_val = 0;
 
     ret_val = cpDampedRotarySpringGetStiffness((cpConstraint*)arg0  );
     args.rval().set(DOUBLE_TO_JSVAL(ret_val));
@@ -1436,7 +1436,7 @@ bool JSB_cpDampedRotarySpring_setDamping(JSContext *cx, uint32_t argc, jsval *vp
     cpDampedRotarySpring* arg0 = (cpDampedRotarySpring*) proxy->handle;
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    double arg1; 
+    double arg1 = 0; 
 
     ok &= JS::ToNumber( cx, args.get(0), &arg1 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
@@ -1456,7 +1456,7 @@ bool JSB_cpDampedRotarySpring_setRestAngle(JSContext *cx, uint32_t argc, jsval *
     cpDampedRotarySpring* arg0 = (cpDampedRotarySpring*) proxy->handle;
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    double arg1; 
+    double arg1 = 0; 
 
     ok &= JS::ToNumber( cx, args.get(0), &arg1 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
@@ -1476,7 +1476,7 @@ bool JSB_cpDampedRotarySpring_setStiffness(JSContext *cx, uint32_t argc, jsval *
     cpDampedRotarySpring* arg0 = (cpDampedRotarySpring*) proxy->handle;
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    double arg1; 
+    double arg1 = 0; 
 
     ok &= JS::ToNumber( cx, args.get(0), &arg1 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
@@ -1536,7 +1536,7 @@ bool JSB_cpDampedSpring_constructor(JSContext *cx, uint32_t argc, jsval *vp)
     JSObject *jsobj = JS_NewObject(cx, JSB_cpDampedSpring_class, JS::RootedObject(cx, JSB_cpDampedSpring_object), JS::NullPtr());
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpBody* arg0; cpBody* arg1; cpVect arg2; cpVect arg3; double arg4; double arg5; double arg6; 
+    cpBody* arg0 = nullptr; cpBody* arg1 = nullptr; cpVect arg2; cpVect arg3; double arg4 = 0; double arg5 = 0; double arg6 = 0; 
 
     ok &= jsval_to_c_class( cx, args.get(0), (void**)&arg0, NULL );
     ok &= jsval_to_c_class( cx, args.get(1), (void**)&arg1, NULL );
@@ -1615,7 +1615,7 @@ bool JSB_cpDampedSpring_getDamping(JSContext *cx, uint32_t argc, jsval *vp) {
     JSObject* jsthis = (JSObject *)JS_THIS_OBJECT(cx, vp);
     struct jsb_c_proxy_s *proxy = jsb_get_c_proxy_for_jsobject(jsthis);
     cpDampedSpring* arg0 = (cpDampedSpring*) proxy->handle;
-    cpFloat ret_val;
+    cpFloat ret_val = 0;
 
     ret_val = cpDampedSpringGetDamping((cpConstraint*)arg0  );
     args.rval().set(DOUBLE_TO_JSVAL(ret_val));
@@ -1630,7 +1630,7 @@ bool JSB_cpDampedSpring_getRestLength(JSContext *cx, uint32_t argc, jsval *vp) {
     JSObject* jsthis = (JSObject *)JS_THIS_OBJECT(cx, vp);
     struct jsb_c_proxy_s *proxy = jsb_get_c_proxy_for_jsobject(jsthis);
     cpDampedSpring* arg0 = (cpDampedSpring*) proxy->handle;
-    cpFloat ret_val;
+    cpFloat ret_val = 0;
 
     ret_val = cpDampedSpringGetRestLength((cpConstraint*)arg0  );
     args.rval().set(DOUBLE_TO_JSVAL(ret_val));
@@ -1645,7 +1645,7 @@ bool JSB_cpDampedSpring_getStiffness(JSContext *cx, uint32_t argc, jsval *vp) {
     JSObject* jsthis = (JSObject *)JS_THIS_OBJECT(cx, vp);
     struct jsb_c_proxy_s *proxy = jsb_get_c_proxy_for_jsobject(jsthis);
     cpDampedSpring* arg0 = (cpDampedSpring*) proxy->handle;
-    cpFloat ret_val;
+    cpFloat ret_val = 0;
 
     ret_val = cpDampedSpringGetStiffness((cpConstraint*)arg0  );
     args.rval().set(DOUBLE_TO_JSVAL(ret_val));
@@ -1702,7 +1702,7 @@ bool JSB_cpDampedSpring_setDamping(JSContext *cx, uint32_t argc, jsval *vp) {
     cpDampedSpring* arg0 = (cpDampedSpring*) proxy->handle;
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    double arg1; 
+    double arg1 = 0; 
 
     ok &= JS::ToNumber( cx, args.get(0), &arg1 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
@@ -1722,7 +1722,7 @@ bool JSB_cpDampedSpring_setRestLength(JSContext *cx, uint32_t argc, jsval *vp) {
     cpDampedSpring* arg0 = (cpDampedSpring*) proxy->handle;
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    double arg1; 
+    double arg1 = 0; 
 
     ok &= JS::ToNumber( cx, args.get(0), &arg1 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
@@ -1742,7 +1742,7 @@ bool JSB_cpDampedSpring_setStiffness(JSContext *cx, uint32_t argc, jsval *vp) {
     cpDampedSpring* arg0 = (cpDampedSpring*) proxy->handle;
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    double arg1; 
+    double arg1 = 0; 
 
     ok &= JS::ToNumber( cx, args.get(0), &arg1 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
@@ -1806,7 +1806,7 @@ bool JSB_cpRatchetJoint_constructor(JSContext *cx, uint32_t argc, jsval *vp)
     JSObject *jsobj = JS_NewObject(cx, JSB_cpRatchetJoint_class, JS::RootedObject(cx, JSB_cpRatchetJoint_object), JS::NullPtr());
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpBody* arg0; cpBody* arg1; double arg2; double arg3; 
+    cpBody* arg0 = nullptr; cpBody* arg1 = nullptr; double arg2 = 0; double arg3 = 0; 
 
     ok &= jsval_to_c_class( cx, args.get(0), (void**)&arg0, NULL );
     ok &= jsval_to_c_class( cx, args.get(1), (void**)&arg1, NULL );
@@ -1846,7 +1846,7 @@ bool JSB_cpRatchetJoint_getAngle(JSContext *cx, uint32_t argc, jsval *vp) {
     JSObject* jsthis = (JSObject *)JS_THIS_OBJECT(cx, vp);
     struct jsb_c_proxy_s *proxy = jsb_get_c_proxy_for_jsobject(jsthis);
     cpRatchetJoint* arg0 = (cpRatchetJoint*) proxy->handle;
-    cpFloat ret_val;
+    cpFloat ret_val = 0;
 
     ret_val = cpRatchetJointGetAngle((cpConstraint*)arg0  );
     args.rval().set(DOUBLE_TO_JSVAL(ret_val));
@@ -1861,7 +1861,7 @@ bool JSB_cpRatchetJoint_getPhase(JSContext *cx, uint32_t argc, jsval *vp) {
     JSObject* jsthis = (JSObject *)JS_THIS_OBJECT(cx, vp);
     struct jsb_c_proxy_s *proxy = jsb_get_c_proxy_for_jsobject(jsthis);
     cpRatchetJoint* arg0 = (cpRatchetJoint*) proxy->handle;
-    cpFloat ret_val;
+    cpFloat ret_val = 0;
 
     ret_val = cpRatchetJointGetPhase((cpConstraint*)arg0  );
     args.rval().set(DOUBLE_TO_JSVAL(ret_val));
@@ -1876,7 +1876,7 @@ bool JSB_cpRatchetJoint_getRatchet(JSContext *cx, uint32_t argc, jsval *vp) {
     JSObject* jsthis = (JSObject *)JS_THIS_OBJECT(cx, vp);
     struct jsb_c_proxy_s *proxy = jsb_get_c_proxy_for_jsobject(jsthis);
     cpRatchetJoint* arg0 = (cpRatchetJoint*) proxy->handle;
-    cpFloat ret_val;
+    cpFloat ret_val = 0;
 
     ret_val = cpRatchetJointGetRatchet((cpConstraint*)arg0  );
     args.rval().set(DOUBLE_TO_JSVAL(ret_val));
@@ -1893,7 +1893,7 @@ bool JSB_cpRatchetJoint_setAngle(JSContext *cx, uint32_t argc, jsval *vp) {
     cpRatchetJoint* arg0 = (cpRatchetJoint*) proxy->handle;
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    double arg1; 
+    double arg1 = 0; 
 
     ok &= JS::ToNumber( cx, args.get(0), &arg1 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
@@ -1913,7 +1913,7 @@ bool JSB_cpRatchetJoint_setPhase(JSContext *cx, uint32_t argc, jsval *vp) {
     cpRatchetJoint* arg0 = (cpRatchetJoint*) proxy->handle;
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    double arg1; 
+    double arg1 = 0; 
 
     ok &= JS::ToNumber( cx, args.get(0), &arg1 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
@@ -1933,7 +1933,7 @@ bool JSB_cpRatchetJoint_setRatchet(JSContext *cx, uint32_t argc, jsval *vp) {
     cpRatchetJoint* arg0 = (cpRatchetJoint*) proxy->handle;
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    double arg1; 
+    double arg1 = 0; 
 
     ok &= JS::ToNumber( cx, args.get(0), &arg1 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
@@ -1993,7 +1993,7 @@ bool JSB_cpRotaryLimitJoint_constructor(JSContext *cx, uint32_t argc, jsval *vp)
     JSObject *jsobj = JS_NewObject(cx, JSB_cpRotaryLimitJoint_class, JS::RootedObject(cx, JSB_cpRotaryLimitJoint_object), JS::NullPtr());
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpBody* arg0; cpBody* arg1; double arg2; double arg3; 
+    cpBody* arg0 = nullptr; cpBody* arg1 = nullptr; double arg2 = 0; double arg3 = 0; 
 
     ok &= jsval_to_c_class( cx, args.get(0), (void**)&arg0, NULL );
     ok &= jsval_to_c_class( cx, args.get(1), (void**)&arg1, NULL );
@@ -2033,7 +2033,7 @@ bool JSB_cpRotaryLimitJoint_getMax(JSContext *cx, uint32_t argc, jsval *vp) {
     JSObject* jsthis = (JSObject *)JS_THIS_OBJECT(cx, vp);
     struct jsb_c_proxy_s *proxy = jsb_get_c_proxy_for_jsobject(jsthis);
     cpRotaryLimitJoint* arg0 = (cpRotaryLimitJoint*) proxy->handle;
-    cpFloat ret_val;
+    cpFloat ret_val = 0;
 
     ret_val = cpRotaryLimitJointGetMax((cpConstraint*)arg0  );
     args.rval().set(DOUBLE_TO_JSVAL(ret_val));
@@ -2048,7 +2048,7 @@ bool JSB_cpRotaryLimitJoint_getMin(JSContext *cx, uint32_t argc, jsval *vp) {
     JSObject* jsthis = (JSObject *)JS_THIS_OBJECT(cx, vp);
     struct jsb_c_proxy_s *proxy = jsb_get_c_proxy_for_jsobject(jsthis);
     cpRotaryLimitJoint* arg0 = (cpRotaryLimitJoint*) proxy->handle;
-    cpFloat ret_val;
+    cpFloat ret_val = 0;
 
     ret_val = cpRotaryLimitJointGetMin((cpConstraint*)arg0  );
     args.rval().set(DOUBLE_TO_JSVAL(ret_val));
@@ -2065,7 +2065,7 @@ bool JSB_cpRotaryLimitJoint_setMax(JSContext *cx, uint32_t argc, jsval *vp) {
     cpRotaryLimitJoint* arg0 = (cpRotaryLimitJoint*) proxy->handle;
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    double arg1; 
+    double arg1 = 0; 
 
     ok &= JS::ToNumber( cx, args.get(0), &arg1 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
@@ -2085,7 +2085,7 @@ bool JSB_cpRotaryLimitJoint_setMin(JSContext *cx, uint32_t argc, jsval *vp) {
     cpRotaryLimitJoint* arg0 = (cpRotaryLimitJoint*) proxy->handle;
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    double arg1; 
+    double arg1 = 0; 
 
     ok &= JS::ToNumber( cx, args.get(0), &arg1 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
@@ -2169,7 +2169,7 @@ bool JSB_cpArbiter_getCount(JSContext *cx, uint32_t argc, jsval *vp) {
     JSObject* jsthis = (JSObject *)JS_THIS_OBJECT(cx, vp);
     struct jsb_c_proxy_s *proxy = jsb_get_c_proxy_for_jsobject(jsthis);
     cpArbiter* arg0 = (cpArbiter*) proxy->handle;
-    int ret_val;
+    int ret_val = 0;
 
     ret_val = cpArbiterGetCount((cpArbiter*)arg0  );
     args.rval().set(INT_TO_JSVAL((int32_t)ret_val));
@@ -2186,11 +2186,11 @@ bool JSB_cpArbiter_getDepth(JSContext *cx, uint32_t argc, jsval *vp) {
     cpArbiter* arg0 = (cpArbiter*) proxy->handle;
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    int32_t arg1; 
+    int32_t arg1 = 0; 
 
     ok &= jsval_to_int32( cx, args.get(0), &arg1 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
-    cpFloat ret_val;
+    cpFloat ret_val = 0;
 
     ret_val = cpArbiterGetDepth((cpArbiter*)arg0 , (int)arg1  );
     args.rval().set(DOUBLE_TO_JSVAL(ret_val));
@@ -2205,7 +2205,7 @@ bool JSB_cpArbiter_getElasticity(JSContext *cx, uint32_t argc, jsval *vp) {
     JSObject* jsthis = (JSObject *)JS_THIS_OBJECT(cx, vp);
     struct jsb_c_proxy_s *proxy = jsb_get_c_proxy_for_jsobject(jsthis);
     cpArbiter* arg0 = (cpArbiter*) proxy->handle;
-    cpFloat ret_val;
+    cpFloat ret_val = 0;
 
     ret_val = cpArbiterGetElasticity((cpArbiter*)arg0  );
     args.rval().set(DOUBLE_TO_JSVAL(ret_val));
@@ -2220,7 +2220,7 @@ bool JSB_cpArbiter_getFriction(JSContext *cx, uint32_t argc, jsval *vp) {
     JSObject* jsthis = (JSObject *)JS_THIS_OBJECT(cx, vp);
     struct jsb_c_proxy_s *proxy = jsb_get_c_proxy_for_jsobject(jsthis);
     cpArbiter* arg0 = (cpArbiter*) proxy->handle;
-    cpFloat ret_val;
+    cpFloat ret_val = 0;
 
     ret_val = cpArbiterGetFriction((cpArbiter*)arg0  );
     args.rval().set(DOUBLE_TO_JSVAL(ret_val));
@@ -2237,7 +2237,7 @@ bool JSB_cpArbiter_getNormal(JSContext *cx, uint32_t argc, jsval *vp) {
     cpArbiter* arg0 = (cpArbiter*) proxy->handle;
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    int32_t arg1; 
+    int32_t arg1 = 0; 
 
     ok &= jsval_to_int32( cx, args.get(0), &arg1 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
@@ -2261,7 +2261,7 @@ bool JSB_cpArbiter_getPoint(JSContext *cx, uint32_t argc, jsval *vp) {
     cpArbiter* arg0 = (cpArbiter*) proxy->handle;
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    int32_t arg1; 
+    int32_t arg1 = 0; 
 
     ok &= jsval_to_int32( cx, args.get(0), &arg1 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
@@ -2332,7 +2332,7 @@ bool JSB_cpArbiter_setElasticity(JSContext *cx, uint32_t argc, jsval *vp) {
     cpArbiter* arg0 = (cpArbiter*) proxy->handle;
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    double arg1; 
+    double arg1 = 0; 
 
     ok &= JS::ToNumber( cx, args.get(0), &arg1 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
@@ -2352,7 +2352,7 @@ bool JSB_cpArbiter_setFriction(JSContext *cx, uint32_t argc, jsval *vp) {
     cpArbiter* arg0 = (cpArbiter*) proxy->handle;
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    double arg1; 
+    double arg1 = 0; 
 
     ok &= JS::ToNumber( cx, args.get(0), &arg1 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
@@ -2426,7 +2426,7 @@ bool JSB_cpArbiter_totalKE(JSContext *cx, uint32_t argc, jsval *vp) {
     JSObject* jsthis = (JSObject *)JS_THIS_OBJECT(cx, vp);
     struct jsb_c_proxy_s *proxy = jsb_get_c_proxy_for_jsobject(jsthis);
     cpArbiter* arg0 = (cpArbiter*) proxy->handle;
-    cpFloat ret_val;
+    cpFloat ret_val = 0;
 
     ret_val = cpArbiterTotalKE((cpArbiter*)arg0  );
     args.rval().set(DOUBLE_TO_JSVAL(ret_val));
@@ -2577,7 +2577,7 @@ bool JSB_cpSpace_activateShapesTouchingShape(JSContext *cx, uint32_t argc, jsval
     cpSpace* arg0 = (cpSpace*) proxy->handle;
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpShape* arg1; 
+    cpShape* arg1 = nullptr; 
 
     ok &= jsval_to_c_class( cx, args.get(0), (void**)&arg1, NULL );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
@@ -2597,7 +2597,7 @@ bool JSB_cpSpace_containsBody(JSContext *cx, uint32_t argc, jsval *vp) {
     cpSpace* arg0 = (cpSpace*) proxy->handle;
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpBody* arg1; 
+    cpBody* arg1 = nullptr; 
 
     ok &= jsval_to_c_class( cx, args.get(0), (void**)&arg1, NULL );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
@@ -2618,7 +2618,7 @@ bool JSB_cpSpace_containsConstraint(JSContext *cx, uint32_t argc, jsval *vp) {
     cpSpace* arg0 = (cpSpace*) proxy->handle;
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpConstraint* arg1; 
+    cpConstraint* arg1 = nullptr; 
 
     ok &= jsval_to_c_class( cx, args.get(0), (void**)&arg1, NULL );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
@@ -2639,7 +2639,7 @@ bool JSB_cpSpace_containsShape(JSContext *cx, uint32_t argc, jsval *vp) {
     cpSpace* arg0 = (cpSpace*) proxy->handle;
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpShape* arg1; 
+    cpShape* arg1 = nullptr; 
 
     ok &= jsval_to_c_class( cx, args.get(0), (void**)&arg1, NULL );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
@@ -2672,7 +2672,7 @@ bool JSB_cpSpace_getCollisionBias(JSContext *cx, uint32_t argc, jsval *vp) {
     JSObject* jsthis = (JSObject *)JS_THIS_OBJECT(cx, vp);
     struct jsb_c_proxy_s *proxy = jsb_get_c_proxy_for_jsobject(jsthis);
     cpSpace* arg0 = (cpSpace*) proxy->handle;
-    cpFloat ret_val;
+    cpFloat ret_val = 0;
 
     ret_val = cpSpaceGetCollisionBias((cpSpace*)arg0  );
     args.rval().set(DOUBLE_TO_JSVAL(ret_val));
@@ -2687,7 +2687,7 @@ bool JSB_cpSpace_getCollisionPersistence(JSContext *cx, uint32_t argc, jsval *vp
     JSObject* jsthis = (JSObject *)JS_THIS_OBJECT(cx, vp);
     struct jsb_c_proxy_s *proxy = jsb_get_c_proxy_for_jsobject(jsthis);
     cpSpace* arg0 = (cpSpace*) proxy->handle;
-    cpTimestamp ret_val;
+    cpTimestamp ret_val = 0;
 
     ret_val = cpSpaceGetCollisionPersistence((cpSpace*)arg0  );
     args.rval().set(UINT_TO_JSVAL((uint32_t)ret_val));
@@ -2702,7 +2702,7 @@ bool JSB_cpSpace_getCollisionSlop(JSContext *cx, uint32_t argc, jsval *vp) {
     JSObject* jsthis = (JSObject *)JS_THIS_OBJECT(cx, vp);
     struct jsb_c_proxy_s *proxy = jsb_get_c_proxy_for_jsobject(jsthis);
     cpSpace* arg0 = (cpSpace*) proxy->handle;
-    cpFloat ret_val;
+    cpFloat ret_val = 0;
 
     ret_val = cpSpaceGetCollisionSlop((cpSpace*)arg0  );
     args.rval().set(DOUBLE_TO_JSVAL(ret_val));
@@ -2717,7 +2717,7 @@ bool JSB_cpSpace_getCurrentTimeStep(JSContext *cx, uint32_t argc, jsval *vp) {
     JSObject* jsthis = (JSObject *)JS_THIS_OBJECT(cx, vp);
     struct jsb_c_proxy_s *proxy = jsb_get_c_proxy_for_jsobject(jsthis);
     cpSpace* arg0 = (cpSpace*) proxy->handle;
-    cpFloat ret_val;
+    cpFloat ret_val = 0;
 
     ret_val = cpSpaceGetCurrentTimeStep((cpSpace*)arg0  );
     args.rval().set(DOUBLE_TO_JSVAL(ret_val));
@@ -2732,7 +2732,7 @@ bool JSB_cpSpace_getDamping(JSContext *cx, uint32_t argc, jsval *vp) {
     JSObject* jsthis = (JSObject *)JS_THIS_OBJECT(cx, vp);
     struct jsb_c_proxy_s *proxy = jsb_get_c_proxy_for_jsobject(jsthis);
     cpSpace* arg0 = (cpSpace*) proxy->handle;
-    cpFloat ret_val;
+    cpFloat ret_val = 0;
 
     ret_val = cpSpaceGetDamping((cpSpace*)arg0  );
     args.rval().set(DOUBLE_TO_JSVAL(ret_val));
@@ -2780,7 +2780,7 @@ bool JSB_cpSpace_getIdleSpeedThreshold(JSContext *cx, uint32_t argc, jsval *vp) 
     JSObject* jsthis = (JSObject *)JS_THIS_OBJECT(cx, vp);
     struct jsb_c_proxy_s *proxy = jsb_get_c_proxy_for_jsobject(jsthis);
     cpSpace* arg0 = (cpSpace*) proxy->handle;
-    cpFloat ret_val;
+    cpFloat ret_val = 0;
 
     ret_val = cpSpaceGetIdleSpeedThreshold((cpSpace*)arg0  );
     args.rval().set(DOUBLE_TO_JSVAL(ret_val));
@@ -2795,7 +2795,7 @@ bool JSB_cpSpace_getIterations(JSContext *cx, uint32_t argc, jsval *vp) {
     JSObject* jsthis = (JSObject *)JS_THIS_OBJECT(cx, vp);
     struct jsb_c_proxy_s *proxy = jsb_get_c_proxy_for_jsobject(jsthis);
     cpSpace* arg0 = (cpSpace*) proxy->handle;
-    int ret_val;
+    int ret_val = 0;
 
     ret_val = cpSpaceGetIterations((cpSpace*)arg0  );
     args.rval().set(INT_TO_JSVAL((int32_t)ret_val));
@@ -2810,7 +2810,7 @@ bool JSB_cpSpace_getSleepTimeThreshold(JSContext *cx, uint32_t argc, jsval *vp) 
     JSObject* jsthis = (JSObject *)JS_THIS_OBJECT(cx, vp);
     struct jsb_c_proxy_s *proxy = jsb_get_c_proxy_for_jsobject(jsthis);
     cpSpace* arg0 = (cpSpace*) proxy->handle;
-    cpFloat ret_val;
+    cpFloat ret_val = 0;
 
     ret_val = cpSpaceGetSleepTimeThreshold((cpSpace*)arg0  );
     args.rval().set(DOUBLE_TO_JSVAL(ret_val));
@@ -2825,7 +2825,7 @@ bool JSB_cpSpace_getStaticBody(JSContext *cx, uint32_t argc, jsval *vp) {
     JSObject* jsthis = (JSObject *)JS_THIS_OBJECT(cx, vp);
     struct jsb_c_proxy_s *proxy = jsb_get_c_proxy_for_jsobject(jsthis);
     cpSpace* arg0 = (cpSpace*) proxy->handle;
-    cpBody* ret_val;
+    cpBody* ret_val = nullptr;
 
     ret_val = cpSpaceGetStaticBody((cpSpace*)arg0  );
 
@@ -2843,7 +2843,7 @@ bool JSB_cpSpace_init(JSContext *cx, uint32_t argc, jsval *vp) {
     JSObject* jsthis = (JSObject *)JS_THIS_OBJECT(cx, vp);
     struct jsb_c_proxy_s *proxy = jsb_get_c_proxy_for_jsobject(jsthis);
     cpSpace* arg0 = (cpSpace*) proxy->handle;
-    cpSpace* ret_val;
+    cpSpace* ret_val = nullptr;
 
     ret_val = cpSpaceInit((cpSpace*)arg0  );
 
@@ -2878,13 +2878,13 @@ bool JSB_cpSpace_pointQueryFirst(JSContext *cx, uint32_t argc, jsval *vp) {
     cpSpace* arg0 = (cpSpace*) proxy->handle;
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpVect arg1; uint32_t arg2; cpGroup arg3;
+    cpVect arg1; uint32_t arg2 = 0; cpGroup arg3 = 0;
 
     ok &= jsval_to_cpVect( cx, args.get(0), (cpVect*) &arg1 );
     ok &= jsval_to_uint32( cx, args.get(1), &arg2 );
     ok &= jsval_to_uint( cx, args.get(2), (unsigned int*) &arg3 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
-    cpShape* ret_val;
+    cpShape* ret_val = nullptr;
 
     ret_val = cpSpacePointQueryFirst((cpSpace*)arg0 , (cpVect)arg1 , (cpLayers)arg2 , (cpGroup)arg3  );
 
@@ -2906,7 +2906,7 @@ bool JSB_cpSpace_reindexShape(JSContext *cx, uint32_t argc, jsval *vp) {
     cpSpace* arg0 = (cpSpace*) proxy->handle;
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpShape* arg1; 
+    cpShape* arg1 = nullptr; 
 
     ok &= jsval_to_c_class( cx, args.get(0), (void**)&arg1, NULL );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
@@ -2926,7 +2926,7 @@ bool JSB_cpSpace_reindexShapesForBody(JSContext *cx, uint32_t argc, jsval *vp) {
     cpSpace* arg0 = (cpSpace*) proxy->handle;
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpBody* arg1; 
+    cpBody* arg1 = nullptr; 
 
     ok &= jsval_to_c_class( cx, args.get(0), (void**)&arg1, NULL );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
@@ -2960,7 +2960,7 @@ bool JSB_cpSpace_setCollisionBias(JSContext *cx, uint32_t argc, jsval *vp) {
     cpSpace* arg0 = (cpSpace*) proxy->handle;
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    double arg1; 
+    double arg1 = 0; 
 
     ok &= JS::ToNumber( cx, args.get(0), &arg1 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
@@ -2980,7 +2980,7 @@ bool JSB_cpSpace_setCollisionPersistence(JSContext *cx, uint32_t argc, jsval *vp
     cpSpace* arg0 = (cpSpace*) proxy->handle;
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    uint32_t arg1; 
+    uint32_t arg1 = 0; 
 
     ok &= jsval_to_uint32( cx, args.get(0), &arg1 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
@@ -3000,7 +3000,7 @@ bool JSB_cpSpace_setCollisionSlop(JSContext *cx, uint32_t argc, jsval *vp) {
     cpSpace* arg0 = (cpSpace*) proxy->handle;
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    double arg1; 
+    double arg1 = 0; 
 
     ok &= JS::ToNumber( cx, args.get(0), &arg1 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
@@ -3020,7 +3020,7 @@ bool JSB_cpSpace_setDamping(JSContext *cx, uint32_t argc, jsval *vp) {
     cpSpace* arg0 = (cpSpace*) proxy->handle;
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    double arg1; 
+    double arg1 = 0; 
 
     ok &= JS::ToNumber( cx, args.get(0), &arg1 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
@@ -3040,7 +3040,7 @@ bool JSB_cpSpace_setEnableContactGraph(JSContext *cx, uint32_t argc, jsval *vp) 
     cpSpace* arg0 = (cpSpace*) proxy->handle;
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    int32_t arg1; 
+    int32_t arg1 = 0; 
 
     ok &= jsval_to_int32( cx, args.get(0), &arg1 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
@@ -3080,7 +3080,7 @@ bool JSB_cpSpace_setIdleSpeedThreshold(JSContext *cx, uint32_t argc, jsval *vp) 
     cpSpace* arg0 = (cpSpace*) proxy->handle;
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    double arg1; 
+    double arg1 = 0; 
 
     ok &= JS::ToNumber( cx, args.get(0), &arg1 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
@@ -3100,7 +3100,7 @@ bool JSB_cpSpace_setIterations(JSContext *cx, uint32_t argc, jsval *vp) {
     cpSpace* arg0 = (cpSpace*) proxy->handle;
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    int32_t arg1; 
+    int32_t arg1 = 0; 
 
     ok &= jsval_to_int32( cx, args.get(0), &arg1 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
@@ -3120,7 +3120,7 @@ bool JSB_cpSpace_setSleepTimeThreshold(JSContext *cx, uint32_t argc, jsval *vp) 
     cpSpace* arg0 = (cpSpace*) proxy->handle;
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    double arg1; 
+    double arg1 = 0; 
 
     ok &= JS::ToNumber( cx, args.get(0), &arg1 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
@@ -3140,7 +3140,7 @@ bool JSB_cpSpace_step(JSContext *cx, uint32_t argc, jsval *vp) {
     cpSpace* arg0 = (cpSpace*) proxy->handle;
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    double arg1; 
+    double arg1 = 0; 
 
     ok &= JS::ToNumber( cx, args.get(0), &arg1 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
@@ -3160,7 +3160,7 @@ bool JSB_cpSpace_useSpatialHash(JSContext *cx, uint32_t argc, jsval *vp) {
     cpSpace* arg0 = (cpSpace*) proxy->handle;
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    double arg1; int32_t arg2; 
+    double arg1 = 0; int32_t arg2 = 0; 
 
     ok &= JS::ToNumber( cx, args.get(0), &arg1 );
     ok &= jsval_to_int32( cx, args.get(1), &arg2 );
@@ -3298,7 +3298,7 @@ bool JSB_cpBody_activateStatic(JSContext *cx, uint32_t argc, jsval *vp) {
     cpBody* arg0 = (cpBody*) proxy->handle;
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpShape* arg1; 
+    cpShape* arg1 = nullptr; 
 
     ok &= jsval_to_c_class( cx, args.get(0), (void**)&arg1, NULL );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
@@ -3372,7 +3372,7 @@ bool JSB_cpBody_getAngVel(JSContext *cx, uint32_t argc, jsval *vp) {
     JSObject* jsthis = (JSObject *)JS_THIS_OBJECT(cx, vp);
     struct jsb_c_proxy_s *proxy = jsb_get_c_proxy_for_jsobject(jsthis);
     cpBody* arg0 = (cpBody*) proxy->handle;
-    cpFloat ret_val;
+    cpFloat ret_val = 0;
 
     ret_val = cpBodyGetAngVel((cpBody*)arg0  );
     args.rval().set(DOUBLE_TO_JSVAL(ret_val));
@@ -3387,7 +3387,7 @@ bool JSB_cpBody_getAngVelLimit(JSContext *cx, uint32_t argc, jsval *vp) {
     JSObject* jsthis = (JSObject *)JS_THIS_OBJECT(cx, vp);
     struct jsb_c_proxy_s *proxy = jsb_get_c_proxy_for_jsobject(jsthis);
     cpBody* arg0 = (cpBody*) proxy->handle;
-    cpFloat ret_val;
+    cpFloat ret_val = 0;
 
     ret_val = cpBodyGetAngVelLimit((cpBody*)arg0  );
     args.rval().set(DOUBLE_TO_JSVAL(ret_val));
@@ -3402,7 +3402,7 @@ bool JSB_cpBody_getAngle(JSContext *cx, uint32_t argc, jsval *vp) {
     JSObject* jsthis = (JSObject *)JS_THIS_OBJECT(cx, vp);
     struct jsb_c_proxy_s *proxy = jsb_get_c_proxy_for_jsobject(jsthis);
     cpBody* arg0 = (cpBody*) proxy->handle;
-    cpFloat ret_val;
+    cpFloat ret_val = 0;
 
     ret_val = cpBodyGetAngle((cpBody*)arg0  );
     args.rval().set(DOUBLE_TO_JSVAL(ret_val));
@@ -3435,7 +3435,7 @@ bool JSB_cpBody_getMass(JSContext *cx, uint32_t argc, jsval *vp) {
     JSObject* jsthis = (JSObject *)JS_THIS_OBJECT(cx, vp);
     struct jsb_c_proxy_s *proxy = jsb_get_c_proxy_for_jsobject(jsthis);
     cpBody* arg0 = (cpBody*) proxy->handle;
-    cpFloat ret_val;
+    cpFloat ret_val = 0;
 
     ret_val = cpBodyGetMass((cpBody*)arg0  );
     args.rval().set(DOUBLE_TO_JSVAL(ret_val));
@@ -3450,7 +3450,7 @@ bool JSB_cpBody_getMoment(JSContext *cx, uint32_t argc, jsval *vp) {
     JSObject* jsthis = (JSObject *)JS_THIS_OBJECT(cx, vp);
     struct jsb_c_proxy_s *proxy = jsb_get_c_proxy_for_jsobject(jsthis);
     cpBody* arg0 = (cpBody*) proxy->handle;
-    cpFloat ret_val;
+    cpFloat ret_val = 0;
 
     ret_val = cpBodyGetMoment((cpBody*)arg0  );
     args.rval().set(DOUBLE_TO_JSVAL(ret_val));
@@ -3501,7 +3501,7 @@ bool JSB_cpBody_getSpace(JSContext *cx, uint32_t argc, jsval *vp) {
     JSObject* jsthis = (JSObject *)JS_THIS_OBJECT(cx, vp);
     struct jsb_c_proxy_s *proxy = jsb_get_c_proxy_for_jsobject(jsthis);
     cpBody* arg0 = (cpBody*) proxy->handle;
-    cpSpace* ret_val;
+    cpSpace* ret_val = nullptr;
 
     ret_val = cpBodyGetSpace((cpBody*)arg0  );
 
@@ -3519,7 +3519,7 @@ bool JSB_cpBody_getTorque(JSContext *cx, uint32_t argc, jsval *vp) {
     JSObject* jsthis = (JSObject *)JS_THIS_OBJECT(cx, vp);
     struct jsb_c_proxy_s *proxy = jsb_get_c_proxy_for_jsobject(jsthis);
     cpBody* arg0 = (cpBody*) proxy->handle;
-    cpFloat ret_val;
+    cpFloat ret_val = 0;
 
     ret_val = cpBodyGetTorque((cpBody*)arg0  );
     args.rval().set(DOUBLE_TO_JSVAL(ret_val));
@@ -3600,7 +3600,7 @@ bool JSB_cpBody_getVelLimit(JSContext *cx, uint32_t argc, jsval *vp) {
     JSObject* jsthis = (JSObject *)JS_THIS_OBJECT(cx, vp);
     struct jsb_c_proxy_s *proxy = jsb_get_c_proxy_for_jsobject(jsthis);
     cpBody* arg0 = (cpBody*) proxy->handle;
-    cpFloat ret_val;
+    cpFloat ret_val = 0;
 
     ret_val = cpBodyGetVelLimit((cpBody*)arg0  );
     args.rval().set(DOUBLE_TO_JSVAL(ret_val));
@@ -3617,12 +3617,12 @@ bool JSB_cpBody_init(JSContext *cx, uint32_t argc, jsval *vp) {
     cpBody* arg0 = (cpBody*) proxy->handle;
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    double arg1; double arg2; 
+    double arg1 = 0; double arg2 = 0; 
 
     ok &= JS::ToNumber( cx, args.get(0), &arg1 );
     ok &= JS::ToNumber( cx, args.get(1), &arg2 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
-    cpBody* ret_val;
+    cpBody* ret_val = nullptr;
 
     ret_val = cpBodyInit((cpBody*)arg0 , (cpFloat)arg1 , (cpFloat)arg2  );
 
@@ -3640,7 +3640,7 @@ bool JSB_cpBody_initStatic(JSContext *cx, uint32_t argc, jsval *vp) {
     JSObject* jsthis = (JSObject *)JS_THIS_OBJECT(cx, vp);
     struct jsb_c_proxy_s *proxy = jsb_get_c_proxy_for_jsobject(jsthis);
     cpBody* arg0 = (cpBody*) proxy->handle;
-    cpBody* ret_val;
+    cpBody* ret_val = nullptr;
 
     ret_val = cpBodyInitStatic((cpBody*)arg0  );
 
@@ -3703,7 +3703,7 @@ bool JSB_cpBody_kineticEnergy(JSContext *cx, uint32_t argc, jsval *vp) {
     JSObject* jsthis = (JSObject *)JS_THIS_OBJECT(cx, vp);
     struct jsb_c_proxy_s *proxy = jsb_get_c_proxy_for_jsobject(jsthis);
     cpBody* arg0 = (cpBody*) proxy->handle;
-    cpFloat ret_val;
+    cpFloat ret_val = 0;
 
     ret_val = cpBodyKineticEnergy((cpBody*)arg0  );
     args.rval().set(DOUBLE_TO_JSVAL(ret_val));
@@ -3758,7 +3758,7 @@ bool JSB_cpBody_setAngVel(JSContext *cx, uint32_t argc, jsval *vp) {
     cpBody* arg0 = (cpBody*) proxy->handle;
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    double arg1; 
+    double arg1 = 0; 
 
     ok &= JS::ToNumber( cx, args.get(0), &arg1 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
@@ -3778,7 +3778,7 @@ bool JSB_cpBody_setAngVelLimit(JSContext *cx, uint32_t argc, jsval *vp) {
     cpBody* arg0 = (cpBody*) proxy->handle;
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    double arg1; 
+    double arg1 = 0; 
 
     ok &= JS::ToNumber( cx, args.get(0), &arg1 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
@@ -3798,7 +3798,7 @@ bool JSB_cpBody_setAngle(JSContext *cx, uint32_t argc, jsval *vp) {
     cpBody* arg0 = (cpBody*) proxy->handle;
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    double arg1; 
+    double arg1 = 0; 
 
     ok &= JS::ToNumber( cx, args.get(0), &arg1 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
@@ -3838,7 +3838,7 @@ bool JSB_cpBody_setMass(JSContext *cx, uint32_t argc, jsval *vp) {
     cpBody* arg0 = (cpBody*) proxy->handle;
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    double arg1; 
+    double arg1 = 0; 
 
     ok &= JS::ToNumber( cx, args.get(0), &arg1 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
@@ -3858,7 +3858,7 @@ bool JSB_cpBody_setMoment(JSContext *cx, uint32_t argc, jsval *vp) {
     cpBody* arg0 = (cpBody*) proxy->handle;
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    double arg1; 
+    double arg1 = 0; 
 
     ok &= JS::ToNumber( cx, args.get(0), &arg1 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
@@ -3898,7 +3898,7 @@ bool JSB_cpBody_setTorque(JSContext *cx, uint32_t argc, jsval *vp) {
     cpBody* arg0 = (cpBody*) proxy->handle;
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    double arg1; 
+    double arg1 = 0; 
 
     ok &= JS::ToNumber( cx, args.get(0), &arg1 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
@@ -3938,7 +3938,7 @@ bool JSB_cpBody_setVelLimit(JSContext *cx, uint32_t argc, jsval *vp) {
     cpBody* arg0 = (cpBody*) proxy->handle;
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    double arg1; 
+    double arg1 = 0; 
 
     ok &= JS::ToNumber( cx, args.get(0), &arg1 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
@@ -3972,7 +3972,7 @@ bool JSB_cpBody_sleepWithGroup(JSContext *cx, uint32_t argc, jsval *vp) {
     cpBody* arg0 = (cpBody*) proxy->handle;
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpBody* arg1; 
+    cpBody* arg1 = nullptr; 
 
     ok &= jsval_to_c_class( cx, args.get(0), (void**)&arg1, NULL );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
@@ -3992,7 +3992,7 @@ bool JSB_cpBody_updatePosition(JSContext *cx, uint32_t argc, jsval *vp) {
     cpBody* arg0 = (cpBody*) proxy->handle;
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    double arg1; 
+    double arg1 = 0; 
 
     ok &= JS::ToNumber( cx, args.get(0), &arg1 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
@@ -4012,7 +4012,7 @@ bool JSB_cpBody_updateVelocity(JSContext *cx, uint32_t argc, jsval *vp) {
     cpBody* arg0 = (cpBody*) proxy->handle;
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpVect arg1; double arg2; double arg3; 
+    cpVect arg1; double arg2 = 0; double arg3 = 0; 
 
     ok &= jsval_to_cpVect( cx, args.get(0), (cpVect*) &arg1 );
     ok &= JS::ToNumber( cx, args.get(1), &arg2 );
@@ -4255,7 +4255,7 @@ bool JSB_cpShape_getBody(JSContext *cx, uint32_t argc, jsval *vp) {
     JSObject* jsthis = (JSObject *)JS_THIS_OBJECT(cx, vp);
     struct jsb_c_proxy_s *proxy = jsb_get_c_proxy_for_jsobject(jsthis);
     cpShape* arg0 = (cpShape*) proxy->handle;
-    cpBody* ret_val;
+    cpBody* ret_val = nullptr;
 
     ret_val = cpShapeGetBody((cpShape*)arg0  );
 
@@ -4273,7 +4273,7 @@ bool JSB_cpShape_getCollisionType(JSContext *cx, uint32_t argc, jsval *vp) {
     JSObject* jsthis = (JSObject *)JS_THIS_OBJECT(cx, vp);
     struct jsb_c_proxy_s *proxy = jsb_get_c_proxy_for_jsobject(jsthis);
     cpShape* arg0 = (cpShape*) proxy->handle;
-    cpCollisionType ret_val;
+    cpCollisionType ret_val = 0;
 
     ret_val = cpShapeGetCollisionType((cpShape*)arg0  );
 
@@ -4291,7 +4291,7 @@ bool JSB_cpShape_getElasticity(JSContext *cx, uint32_t argc, jsval *vp) {
     JSObject* jsthis = (JSObject *)JS_THIS_OBJECT(cx, vp);
     struct jsb_c_proxy_s *proxy = jsb_get_c_proxy_for_jsobject(jsthis);
     cpShape* arg0 = (cpShape*) proxy->handle;
-    cpFloat ret_val;
+    cpFloat ret_val = 0;
 
     ret_val = cpShapeGetElasticity((cpShape*)arg0  );
     args.rval().set(DOUBLE_TO_JSVAL(ret_val));
@@ -4306,7 +4306,7 @@ bool JSB_cpShape_getFriction(JSContext *cx, uint32_t argc, jsval *vp) {
     JSObject* jsthis = (JSObject *)JS_THIS_OBJECT(cx, vp);
     struct jsb_c_proxy_s *proxy = jsb_get_c_proxy_for_jsobject(jsthis);
     cpShape* arg0 = (cpShape*) proxy->handle;
-    cpFloat ret_val;
+    cpFloat ret_val = 0;
 
     ret_val = cpShapeGetFriction((cpShape*)arg0  );
     args.rval().set(DOUBLE_TO_JSVAL(ret_val));
@@ -4321,7 +4321,7 @@ bool JSB_cpShape_getGroup(JSContext *cx, uint32_t argc, jsval *vp) {
     JSObject* jsthis = (JSObject *)JS_THIS_OBJECT(cx, vp);
     struct jsb_c_proxy_s *proxy = jsb_get_c_proxy_for_jsobject(jsthis);
     cpShape* arg0 = (cpShape*) proxy->handle;
-    cpGroup ret_val;
+    cpGroup ret_val = 0;
 
     ret_val = cpShapeGetGroup((cpShape*)arg0  );
 
@@ -4339,7 +4339,7 @@ bool JSB_cpShape_getLayers(JSContext *cx, uint32_t argc, jsval *vp) {
     JSObject* jsthis = (JSObject *)JS_THIS_OBJECT(cx, vp);
     struct jsb_c_proxy_s *proxy = jsb_get_c_proxy_for_jsobject(jsthis);
     cpShape* arg0 = (cpShape*) proxy->handle;
-    cpLayers ret_val;
+    cpLayers ret_val = 0;
 
     ret_val = cpShapeGetLayers((cpShape*)arg0  );
     args.rval().set(UINT_TO_JSVAL((uint32_t)ret_val));
@@ -4369,7 +4369,7 @@ bool JSB_cpShape_getSpace(JSContext *cx, uint32_t argc, jsval *vp) {
     JSObject* jsthis = (JSObject *)JS_THIS_OBJECT(cx, vp);
     struct jsb_c_proxy_s *proxy = jsb_get_c_proxy_for_jsobject(jsthis);
     cpShape* arg0 = (cpShape*) proxy->handle;
-    cpSpace* ret_val;
+    cpSpace* ret_val = nullptr;
 
     ret_val = cpShapeGetSpace((cpShape*)arg0  );
 
@@ -4428,7 +4428,7 @@ bool JSB_cpShape_setBody(JSContext *cx, uint32_t argc, jsval *vp) {
     cpShape* arg0 = (cpShape*) proxy->handle;
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpBody* arg1; 
+    cpBody* arg1 = nullptr; 
 
     ok &= jsval_to_c_class( cx, args.get(0), (void**)&arg1, NULL );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
@@ -4448,7 +4448,7 @@ bool JSB_cpShape_setCollisionType(JSContext *cx, uint32_t argc, jsval *vp) {
     cpShape* arg0 = (cpShape*) proxy->handle;
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpCollisionType arg1; 
+    cpCollisionType arg1 = 0;
 
     ok &= jsval_to_uint( cx, args.get(0), (unsigned int*) &arg1 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
@@ -4468,7 +4468,7 @@ bool JSB_cpShape_setElasticity(JSContext *cx, uint32_t argc, jsval *vp) {
     cpShape* arg0 = (cpShape*) proxy->handle;
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    double arg1; 
+    double arg1 = 0; 
 
     ok &= JS::ToNumber( cx, args.get(0), &arg1 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
@@ -4488,7 +4488,7 @@ bool JSB_cpShape_setFriction(JSContext *cx, uint32_t argc, jsval *vp) {
     cpShape* arg0 = (cpShape*) proxy->handle;
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    double arg1; 
+    double arg1 = 0; 
 
     ok &= JS::ToNumber( cx, args.get(0), &arg1 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
@@ -4508,7 +4508,7 @@ bool JSB_cpShape_setGroup(JSContext *cx, uint32_t argc, jsval *vp) {
     cpShape* arg0 = (cpShape*) proxy->handle;
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpGroup arg1; 
+    cpGroup arg1 = 0; 
 
     ok &= jsval_to_uint( cx, args.get(0), (unsigned int*) &arg1 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
@@ -4528,7 +4528,7 @@ bool JSB_cpShape_setLayers(JSContext *cx, uint32_t argc, jsval *vp) {
     cpShape* arg0 = (cpShape*) proxy->handle;
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    uint32_t arg1; 
+    uint32_t arg1 = 0; 
 
     ok &= jsval_to_uint32( cx, args.get(0), &arg1 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
@@ -4548,7 +4548,7 @@ bool JSB_cpShape_setSensor(JSContext *cx, uint32_t argc, jsval *vp) {
     cpShape* arg0 = (cpShape*) proxy->handle;
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    int32_t arg1; 
+    int32_t arg1 = 0; 
 
     ok &= jsval_to_int32( cx, args.get(0), &arg1 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
@@ -4808,7 +4808,7 @@ bool JSB_cpCircleShape_constructor(JSContext *cx, uint32_t argc, jsval *vp)
     JSObject *jsobj = JS_NewObject(cx, JSB_cpCircleShape_class, JS::RootedObject(cx, JSB_cpCircleShape_object), JS::NullPtr());
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpBody* arg0; double arg1; cpVect arg2; 
+    cpBody* arg0 = nullptr; double arg1 = 0; cpVect arg2; 
 
     ok &= jsval_to_c_class( cx, args.get(0), (void**)&arg0, NULL );
     ok &= JS::ToNumber( cx, args.get(1), &arg1 );
@@ -4865,7 +4865,7 @@ bool JSB_cpCircleShape_getRadius(JSContext *cx, uint32_t argc, jsval *vp) {
     JSObject* jsthis = (JSObject *)JS_THIS_OBJECT(cx, vp);
     struct jsb_c_proxy_s *proxy = jsb_get_c_proxy_for_jsobject(jsthis);
     cpCircleShape* arg0 = (cpCircleShape*) proxy->handle;
-    cpFloat ret_val;
+    cpFloat ret_val = 0;
 
     ret_val = cpCircleShapeGetRadius((cpShape*)arg0  );
     args.rval().set(DOUBLE_TO_JSVAL(ret_val));
@@ -4918,7 +4918,7 @@ bool JSB_cpSegmentShape_constructor(JSContext *cx, uint32_t argc, jsval *vp)
     JSObject *jsobj = JS_NewObject(cx, JSB_cpSegmentShape_class, JS::RootedObject(cx, JSB_cpSegmentShape_object), JS::NullPtr());
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpBody* arg0; cpVect arg1; cpVect arg2; double arg3; 
+    cpBody* arg0 = nullptr; cpVect arg1; cpVect arg2; double arg3 = 0; 
 
     ok &= jsval_to_c_class( cx, args.get(0), (void**)&arg0, NULL );
     ok &= jsval_to_cpVect( cx, args.get(1), (cpVect*) &arg1 );
@@ -5012,7 +5012,7 @@ bool JSB_cpSegmentShape_getRadius(JSContext *cx, uint32_t argc, jsval *vp) {
     JSObject* jsthis = (JSObject *)JS_THIS_OBJECT(cx, vp);
     struct jsb_c_proxy_s *proxy = jsb_get_c_proxy_for_jsobject(jsthis);
     cpSegmentShape* arg0 = (cpSegmentShape*) proxy->handle;
-    cpFloat ret_val;
+    cpFloat ret_val = 0;
 
     ret_val = cpSegmentShapeGetRadius((cpShape*)arg0  );
     args.rval().set(DOUBLE_TO_JSVAL(ret_val));
@@ -5130,7 +5130,7 @@ bool JSB_cpPolyShape_getNumVerts(JSContext *cx, uint32_t argc, jsval *vp) {
     JSObject* jsthis = (JSObject *)JS_THIS_OBJECT(cx, vp);
     struct jsb_c_proxy_s *proxy = jsb_get_c_proxy_for_jsobject(jsthis);
     cpPolyShape* arg0 = (cpPolyShape*) proxy->handle;
-    int ret_val;
+    int ret_val = 0;
 
     ret_val = cpPolyShapeGetNumVerts((cpShape*)arg0  );
     args.rval().set(INT_TO_JSVAL((int32_t)ret_val));
@@ -5147,7 +5147,7 @@ bool JSB_cpPolyShape_getVert(JSContext *cx, uint32_t argc, jsval *vp) {
     cpPolyShape* arg0 = (cpPolyShape*) proxy->handle;
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    int32_t arg1; 
+    int32_t arg1 = 0; 
 
     ok &= jsval_to_int32( cx, args.get(0), &arg1 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
@@ -5403,8 +5403,8 @@ bool js_set_cpSegmentQueryInfo_shape(JSContext *cx, uint32_t argc, jsval *vp)
     struct jsb_c_proxy_s *proxy = jsb_get_c_proxy_for_jsobject(args.thisv().toObjectOrNull());
     cpSegmentQueryInfo* info = (cpSegmentQueryInfo*) proxy->handle;
 
-    cpShape* shape;
-    struct jsb_c_proxy_s *retproxy;
+    cpShape* shape = nullptr;
+    struct jsb_c_proxy_s *retproxy = nullptr;
     jsval_to_c_class( cx, args.get(0), (void**)&shape, &retproxy );
 
     info->shape = shape;
@@ -5509,8 +5509,8 @@ bool js_set_cpNearestPointQueryInfo_shape(JSContext *cx, uint32_t argc, jsval *v
     struct jsb_c_proxy_s *proxy = jsb_get_c_proxy_for_jsobject(args.thisv().toObjectOrNull());
     cpNearestPointQueryInfo* info = (cpNearestPointQueryInfo*) proxy->handle;
 
-    cpShape* shape;
-    struct jsb_c_proxy_s *retproxy;
+    cpShape* shape = nullptr;
+    struct jsb_c_proxy_s *retproxy = nullptr;
     jsval_to_c_class( cx, args.get(0), (void**)&shape, &retproxy );
 
     info->shape = shape;

--- a/cocos/scripting/js-bindings/manual/chipmunk/js_bindings_chipmunk_functions.cpp
+++ b/cocos/scripting/js-bindings/manual/chipmunk/js_bindings_chipmunk_functions.cpp
@@ -19,11 +19,11 @@ bool JSB_cpArbiterGetCount(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 1, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpArbiter* arg0; 
+    cpArbiter* arg0 = nullptr;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
-    int ret_val;
+    int ret_val = 0;
 
     ret_val = cpArbiterGetCount((cpArbiter*)arg0  );
     args.rval().set(INT_TO_JSVAL((int32_t)ret_val));
@@ -36,12 +36,12 @@ bool JSB_cpArbiterGetDepth(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 2, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpArbiter* arg0; int32_t arg1; 
+    cpArbiter* arg0 = nullptr; int32_t arg1 = 0;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     ok &= jsval_to_int32( cx, args.get(1), &arg1 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
-    cpFloat ret_val;
+    cpFloat ret_val = 0;
 
     ret_val = cpArbiterGetDepth((cpArbiter*)arg0 , (int)arg1  );
     args.rval().set(DOUBLE_TO_JSVAL(ret_val));
@@ -54,11 +54,11 @@ bool JSB_cpArbiterGetElasticity(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 1, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpArbiter* arg0; 
+    cpArbiter* arg0 = nullptr;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
-    cpFloat ret_val;
+    cpFloat ret_val = 0;
 
     ret_val = cpArbiterGetElasticity((cpArbiter*)arg0  );
     args.rval().set(DOUBLE_TO_JSVAL(ret_val));
@@ -71,11 +71,11 @@ bool JSB_cpArbiterGetFriction(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 1, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpArbiter* arg0; 
+    cpArbiter* arg0 = nullptr;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
-    cpFloat ret_val;
+    cpFloat ret_val = 0;
 
     ret_val = cpArbiterGetFriction((cpArbiter*)arg0  );
     args.rval().set(DOUBLE_TO_JSVAL(ret_val));
@@ -88,7 +88,7 @@ bool JSB_cpArbiterGetNormal(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 2, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpArbiter* arg0; int32_t arg1; 
+    cpArbiter* arg0 = nullptr; int32_t arg1 = 0;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     ok &= jsval_to_int32( cx, args.get(1), &arg1 );
@@ -109,7 +109,7 @@ bool JSB_cpArbiterGetPoint(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 2, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpArbiter* arg0; int32_t arg1; 
+    cpArbiter* arg0 = nullptr; int32_t arg1 = 0;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     ok &= jsval_to_int32( cx, args.get(1), &arg1 );
@@ -130,7 +130,7 @@ bool JSB_cpArbiterGetSurfaceVelocity(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 1, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpArbiter* arg0; 
+    cpArbiter* arg0 = nullptr;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
@@ -150,7 +150,7 @@ bool JSB_cpArbiterIgnore(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 1, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpArbiter* arg0; 
+    cpArbiter* arg0 = nullptr;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
@@ -166,7 +166,7 @@ bool JSB_cpArbiterIsFirstContact(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 1, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpArbiter* arg0; 
+    cpArbiter* arg0 = nullptr;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
@@ -183,7 +183,7 @@ bool JSB_cpArbiterSetElasticity(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 2, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpArbiter* arg0; double arg1; 
+    cpArbiter* arg0 = nullptr; double arg1 = 0;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     ok &= JS::ToNumber( cx, args.get(1), &arg1 );
@@ -200,7 +200,7 @@ bool JSB_cpArbiterSetFriction(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 2, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpArbiter* arg0; double arg1; 
+    cpArbiter* arg0 = nullptr; double arg1 = 0;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     ok &= JS::ToNumber( cx, args.get(1), &arg1 );
@@ -217,7 +217,7 @@ bool JSB_cpArbiterSetSurfaceVelocity(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 2, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpArbiter* arg0; cpVect arg1; 
+    cpArbiter* arg0 = nullptr; cpVect arg1;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     ok &= jsval_to_cpVect( cx, args.get(1), (cpVect*) &arg1 );
@@ -234,7 +234,7 @@ bool JSB_cpArbiterTotalImpulse(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 1, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpArbiter* arg0; 
+    cpArbiter* arg0 = nullptr;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
@@ -254,7 +254,7 @@ bool JSB_cpArbiterTotalImpulseWithFriction(JSContext *cx, uint32_t argc, jsval *
     JSB_PRECONDITION2( argc == 1, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpArbiter* arg0; 
+    cpArbiter* arg0 = nullptr;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
@@ -274,11 +274,11 @@ bool JSB_cpArbiterTotalKE(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 1, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpArbiter* arg0; 
+    cpArbiter* arg0 = nullptr;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
-    cpFloat ret_val;
+    cpFloat ret_val = 0;
 
     ret_val = cpArbiterTotalKE((cpArbiter*)arg0  );
     args.rval().set(DOUBLE_TO_JSVAL(ret_val));
@@ -291,12 +291,12 @@ bool JSB_cpAreaForCircle(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 2, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    double arg0; double arg1; 
+    double arg0 = 0; double arg1 = 0;
 
     ok &= JS::ToNumber( cx, args.get(0), &arg0 );
     ok &= JS::ToNumber( cx, args.get(1), &arg1 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
-    cpFloat ret_val;
+    cpFloat ret_val = 0;
 
     ret_val = cpAreaForCircle((cpFloat)arg0 , (cpFloat)arg1  );
     args.rval().set(DOUBLE_TO_JSVAL(ret_val));
@@ -309,13 +309,13 @@ bool JSB_cpAreaForSegment(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 3, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpVect arg0; cpVect arg1; double arg2; 
+    cpVect arg0; cpVect arg1; double arg2 = 0;
 
     ok &= jsval_to_cpVect( cx, args.get(0), (cpVect*) &arg0 );
     ok &= jsval_to_cpVect( cx, args.get(1), (cpVect*) &arg1 );
     ok &= JS::ToNumber( cx, args.get(2), &arg2 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
-    cpFloat ret_val;
+    cpFloat ret_val = 0;
 
     ret_val = cpAreaForSegment((cpVect)arg0 , (cpVect)arg1 , (cpFloat)arg2  );
     args.rval().set(DOUBLE_TO_JSVAL(ret_val));
@@ -332,7 +332,7 @@ bool JSB_cpBBArea(JSContext *cx, uint32_t argc, jsval *vp) {
 
     ok &= jsval_to_cpBB( cx, args.get(0), (cpBB*) &arg0 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
-    cpFloat ret_val;
+    cpFloat ret_val = 0;
 
     ret_val = cpBBArea((cpBB)arg0  );
     args.rval().set(DOUBLE_TO_JSVAL(ret_val));
@@ -486,7 +486,7 @@ bool JSB_cpBBMergedArea(JSContext *cx, uint32_t argc, jsval *vp) {
     ok &= jsval_to_cpBB( cx, args.get(0), (cpBB*) &arg0 );
     ok &= jsval_to_cpBB( cx, args.get(1), (cpBB*) &arg1 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
-    cpFloat ret_val;
+    cpFloat ret_val = 0;
 
     ret_val = cpBBMergedArea((cpBB)arg0 , (cpBB)arg1  );
     args.rval().set(DOUBLE_TO_JSVAL(ret_val));
@@ -499,7 +499,7 @@ bool JSB_cpBBNew(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 4, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    double arg0; double arg1; double arg2; double arg3; 
+    double arg0 = 0; double arg1 = 0; double arg2 = 0; double arg3 = 0;
 
     ok &= JS::ToNumber( cx, args.get(0), &arg0 );
     ok &= JS::ToNumber( cx, args.get(1), &arg1 );
@@ -522,7 +522,7 @@ bool JSB_cpBBNewForCircle(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 2, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpVect arg0; double arg1; 
+    cpVect arg0; double arg1 = 0;
 
     ok &= jsval_to_cpVect( cx, args.get(0), (cpVect*) &arg0 );
     ok &= JS::ToNumber( cx, args.get(1), &arg1 );
@@ -549,7 +549,7 @@ bool JSB_cpBBSegmentQuery(JSContext *cx, uint32_t argc, jsval *vp) {
     ok &= jsval_to_cpVect( cx, args.get(1), (cpVect*) &arg1 );
     ok &= jsval_to_cpVect( cx, args.get(2), (cpVect*) &arg2 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
-    cpFloat ret_val;
+    cpFloat ret_val = 0;
 
     ret_val = cpBBSegmentQuery((cpBB)arg0 , (cpVect)arg1 , (cpVect)arg2  );
     args.rval().set(DOUBLE_TO_JSVAL(ret_val));
@@ -583,7 +583,7 @@ bool JSB_cpBodyActivate(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 1, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpBody* arg0; 
+    cpBody* arg0 = nullptr; 
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
@@ -599,7 +599,7 @@ bool JSB_cpBodyActivateStatic(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 2, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpBody* arg0; cpShape* arg1; 
+    cpBody* arg0 = nullptr; cpShape* arg1 = nullptr;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     ok &= jsval_to_opaque( cx, args.get(1), (void**)&arg1 );
@@ -616,7 +616,7 @@ bool JSB_cpBodyApplyForce(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 3, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpBody* arg0; cpVect arg1; cpVect arg2; 
+    cpBody* arg0 = nullptr; cpVect arg1; cpVect arg2;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     ok &= jsval_to_cpVect( cx, args.get(1), (cpVect*) &arg1 );
@@ -634,7 +634,7 @@ bool JSB_cpBodyApplyImpulse(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 3, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpBody* arg0; cpVect arg1; cpVect arg2; 
+    cpBody* arg0 = nullptr; cpVect arg1; cpVect arg2;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     ok &= jsval_to_cpVect( cx, args.get(1), (cpVect*) &arg1 );
@@ -652,7 +652,7 @@ bool JSB_cpBodyDestroy(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 1, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpBody* arg0; 
+    cpBody* arg0 = nullptr;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
@@ -668,7 +668,7 @@ bool JSB_cpBodyFree(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 1, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpBody* arg0; 
+    cpBody* arg0 = nullptr;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
@@ -684,11 +684,11 @@ bool JSB_cpBodyGetAngVel(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 1, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpBody* arg0; 
+    cpBody* arg0 = nullptr;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
-    cpFloat ret_val;
+    cpFloat ret_val = 0;
 
     ret_val = cpBodyGetAngVel((cpBody*)arg0  );
     args.rval().set(DOUBLE_TO_JSVAL(ret_val));
@@ -701,11 +701,11 @@ bool JSB_cpBodyGetAngVelLimit(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 1, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpBody* arg0; 
+    cpBody* arg0 = nullptr;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
-    cpFloat ret_val;
+    cpFloat ret_val = 0;
 
     ret_val = cpBodyGetAngVelLimit((cpBody*)arg0  );
     args.rval().set(DOUBLE_TO_JSVAL(ret_val));
@@ -718,11 +718,11 @@ bool JSB_cpBodyGetAngle(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 1, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpBody* arg0; 
+    cpBody* arg0 = nullptr;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
-    cpFloat ret_val;
+    cpFloat ret_val = 0;
 
     ret_val = cpBodyGetAngle((cpBody*)arg0  );
     args.rval().set(DOUBLE_TO_JSVAL(ret_val));
@@ -735,7 +735,7 @@ bool JSB_cpBodyGetForce(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 1, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpBody* arg0; 
+    cpBody* arg0 = nullptr;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
@@ -755,11 +755,11 @@ bool JSB_cpBodyGetMass(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 1, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpBody* arg0; 
+    cpBody* arg0 = nullptr;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
-    cpFloat ret_val;
+    cpFloat ret_val = 0;
 
     ret_val = cpBodyGetMass((cpBody*)arg0  );
     args.rval().set(DOUBLE_TO_JSVAL(ret_val));
@@ -772,11 +772,11 @@ bool JSB_cpBodyGetMoment(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 1, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpBody* arg0; 
+    cpBody* arg0 = nullptr;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
-    cpFloat ret_val;
+    cpFloat ret_val = 0;
 
     ret_val = cpBodyGetMoment((cpBody*)arg0  );
     args.rval().set(DOUBLE_TO_JSVAL(ret_val));
@@ -789,7 +789,7 @@ bool JSB_cpBodyGetPos(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 1, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpBody* arg0; 
+    cpBody* arg0 = nullptr;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
@@ -809,7 +809,7 @@ bool JSB_cpBodyGetRot(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 1, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpBody* arg0; 
+    cpBody* arg0 = nullptr;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
@@ -829,11 +829,11 @@ bool JSB_cpBodyGetSpace(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 1, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpBody* arg0; 
+    cpBody* arg0 = nullptr;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
-    cpSpace* ret_val;
+    cpSpace* ret_val = nullptr;
 
     ret_val = cpBodyGetSpace((cpBody*)arg0  );
 
@@ -849,11 +849,11 @@ bool JSB_cpBodyGetTorque(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 1, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpBody* arg0; 
+    cpBody* arg0 = nullptr;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
-    cpFloat ret_val;
+    cpFloat ret_val = 0;
 
     ret_val = cpBodyGetTorque((cpBody*)arg0  );
     args.rval().set(DOUBLE_TO_JSVAL(ret_val));
@@ -866,7 +866,7 @@ bool JSB_cpBodyGetVel(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 1, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpBody* arg0; 
+    cpBody* arg0 = nullptr;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
@@ -886,7 +886,7 @@ bool JSB_cpBodyGetVelAtLocalPoint(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 2, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpBody* arg0; cpVect arg1; 
+    cpBody* arg0 = nullptr; cpVect arg1;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     ok &= jsval_to_cpVect( cx, args.get(1), (cpVect*) &arg1 );
@@ -907,7 +907,7 @@ bool JSB_cpBodyGetVelAtWorldPoint(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 2, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpBody* arg0; cpVect arg1; 
+    cpBody* arg0 = nullptr; cpVect arg1;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     ok &= jsval_to_cpVect( cx, args.get(1), (cpVect*) &arg1 );
@@ -928,11 +928,11 @@ bool JSB_cpBodyGetVelLimit(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 1, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpBody* arg0; 
+    cpBody* arg0 = nullptr;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
-    cpFloat ret_val;
+    cpFloat ret_val = 0;
 
     ret_val = cpBodyGetVelLimit((cpBody*)arg0  );
     args.rval().set(DOUBLE_TO_JSVAL(ret_val));
@@ -945,13 +945,13 @@ bool JSB_cpBodyInit(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 3, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpBody* arg0; double arg1; double arg2; 
+    cpBody* arg0 = nullptr; double arg1 = 0; double arg2 = 0;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     ok &= JS::ToNumber( cx, args.get(1), &arg1 );
     ok &= JS::ToNumber( cx, args.get(2), &arg2 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
-    cpBody* ret_val;
+    cpBody* ret_val = nullptr;
 
     ret_val = cpBodyInit((cpBody*)arg0 , (cpFloat)arg1 , (cpFloat)arg2  );
 
@@ -967,11 +967,11 @@ bool JSB_cpBodyInitStatic(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 1, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpBody* arg0; 
+    cpBody* arg0 = nullptr;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
-    cpBody* ret_val;
+    cpBody* ret_val = nullptr;
 
     ret_val = cpBodyInitStatic((cpBody*)arg0  );
 
@@ -987,7 +987,7 @@ bool JSB_cpBodyIsRogue(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 1, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpBody* arg0; 
+    cpBody* arg0 = nullptr;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
@@ -1004,7 +1004,7 @@ bool JSB_cpBodyIsSleeping(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 1, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpBody* arg0; 
+    cpBody* arg0 = nullptr;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
@@ -1021,7 +1021,7 @@ bool JSB_cpBodyIsStatic(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 1, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpBody* arg0; 
+    cpBody* arg0 = nullptr;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
@@ -1038,11 +1038,11 @@ bool JSB_cpBodyKineticEnergy(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 1, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpBody* arg0; 
+    cpBody* arg0 = nullptr;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
-    cpFloat ret_val;
+    cpFloat ret_val = 0;
 
     ret_val = cpBodyKineticEnergy((cpBody*)arg0  );
     args.rval().set(DOUBLE_TO_JSVAL(ret_val));
@@ -1055,7 +1055,7 @@ bool JSB_cpBodyLocal2World(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 2, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpBody* arg0; cpVect arg1; 
+    cpBody* arg0 = nullptr; cpVect arg1;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     ok &= jsval_to_cpVect( cx, args.get(1), (cpVect*) &arg1 );
@@ -1076,12 +1076,12 @@ bool JSB_cpBodyNew(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 2, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    double arg0; double arg1; 
+    double arg0 = 0; double arg1 = 0;
 
     ok &= JS::ToNumber( cx, args.get(0), &arg0 );
     ok &= JS::ToNumber( cx, args.get(1), &arg1 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
-    cpBody* ret_val;
+    cpBody* ret_val = nullptr;
 
     ret_val = cpBodyNew((cpFloat)arg0 , (cpFloat)arg1  );
 
@@ -1096,7 +1096,7 @@ bool JSB_cpBodyNew(JSContext *cx, uint32_t argc, jsval *vp) {
 bool JSB_cpBodyNewStatic(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 0, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
-    cpBody* ret_val;
+    cpBody* ret_val = nullptr;
 
     ret_val = cpBodyNewStatic( );
 
@@ -1112,7 +1112,7 @@ bool JSB_cpBodyResetForces(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 1, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpBody* arg0; 
+    cpBody* arg0 = nullptr;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
@@ -1128,7 +1128,7 @@ bool JSB_cpBodySetAngVel(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 2, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpBody* arg0; double arg1; 
+    cpBody* arg0 = nullptr; double arg1 = 0;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     ok &= JS::ToNumber( cx, args.get(1), &arg1 );
@@ -1145,7 +1145,7 @@ bool JSB_cpBodySetAngVelLimit(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 2, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpBody* arg0; double arg1; 
+    cpBody* arg0 = nullptr; double arg1 = 0;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     ok &= JS::ToNumber( cx, args.get(1), &arg1 );
@@ -1162,7 +1162,7 @@ bool JSB_cpBodySetAngle(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 2, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpBody* arg0; double arg1; 
+    cpBody* arg0 = nullptr; double arg1 = 0;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     ok &= JS::ToNumber( cx, args.get(1), &arg1 );
@@ -1179,7 +1179,7 @@ bool JSB_cpBodySetForce(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 2, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpBody* arg0; cpVect arg1; 
+    cpBody* arg0 = nullptr; cpVect arg1;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     ok &= jsval_to_cpVect( cx, args.get(1), (cpVect*) &arg1 );
@@ -1196,7 +1196,7 @@ bool JSB_cpBodySetMass(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 2, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpBody* arg0; double arg1; 
+    cpBody* arg0 = nullptr; double arg1 = 0;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     ok &= JS::ToNumber( cx, args.get(1), &arg1 );
@@ -1213,7 +1213,7 @@ bool JSB_cpBodySetMoment(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 2, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpBody* arg0; double arg1; 
+    cpBody* arg0 = nullptr; double arg1 = 0;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     ok &= JS::ToNumber( cx, args.get(1), &arg1 );
@@ -1230,7 +1230,7 @@ bool JSB_cpBodySetPos(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 2, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpBody* arg0; cpVect arg1; 
+    cpBody* arg0 = nullptr; cpVect arg1;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     ok &= jsval_to_cpVect( cx, args.get(1), (cpVect*) &arg1 );
@@ -1247,7 +1247,7 @@ bool JSB_cpBodySetTorque(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 2, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpBody* arg0; double arg1; 
+    cpBody* arg0 = nullptr; double arg1 = 0;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     ok &= JS::ToNumber( cx, args.get(1), &arg1 );
@@ -1264,7 +1264,7 @@ bool JSB_cpBodySetVel(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 2, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpBody* arg0; cpVect arg1; 
+    cpBody* arg0 = nullptr; cpVect arg1;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     ok &= jsval_to_cpVect( cx, args.get(1), (cpVect*) &arg1 );
@@ -1281,7 +1281,7 @@ bool JSB_cpBodySetVelLimit(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 2, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpBody* arg0; double arg1; 
+    cpBody* arg0 = nullptr; double arg1 = 0;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     ok &= JS::ToNumber( cx, args.get(1), &arg1 );
@@ -1298,7 +1298,7 @@ bool JSB_cpBodySleep(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 1, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpBody* arg0; 
+    cpBody* arg0 = nullptr;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
@@ -1314,7 +1314,7 @@ bool JSB_cpBodySleepWithGroup(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 2, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpBody* arg0; cpBody* arg1; 
+    cpBody* arg0 = nullptr; cpBody* arg1 = nullptr;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     ok &= jsval_to_opaque( cx, args.get(1), (void**)&arg1 );
@@ -1331,7 +1331,7 @@ bool JSB_cpBodyUpdatePosition(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 2, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpBody* arg0; double arg1; 
+    cpBody* arg0 = nullptr; double arg1 = 0;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     ok &= JS::ToNumber( cx, args.get(1), &arg1 );
@@ -1348,7 +1348,7 @@ bool JSB_cpBodyUpdateVelocity(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 4, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpBody* arg0; cpVect arg1; double arg2; double arg3; 
+    cpBody* arg0 = nullptr; cpVect arg1; double arg2 = 0; double arg3 = 0;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     ok &= jsval_to_cpVect( cx, args.get(1), (cpVect*) &arg1 );
@@ -1367,7 +1367,7 @@ bool JSB_cpBodyWorld2Local(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 2, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpBody* arg0; cpVect arg1; 
+    cpBody* arg0 = nullptr; cpVect arg1;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     ok &= jsval_to_cpVect( cx, args.get(1), (cpVect*) &arg1 );
@@ -1388,13 +1388,13 @@ bool JSB_cpBoxShapeNew(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 3, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpBody* arg0; double arg1; double arg2; 
+    cpBody* arg0 = nullptr; double arg1 = 0; double arg2 = 0;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     ok &= JS::ToNumber( cx, args.get(1), &arg1 );
     ok &= JS::ToNumber( cx, args.get(2), &arg2 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
-    cpShape* ret_val;
+    cpShape* ret_val = nullptr;
 
     ret_val = cpBoxShapeNew((cpBody*)arg0 , (cpFloat)arg1 , (cpFloat)arg2  );
 
@@ -1410,12 +1410,12 @@ bool JSB_cpBoxShapeNew2(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 2, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpBody* arg0; cpBB arg1; 
+    cpBody* arg0 = nullptr; cpBB arg1;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     ok &= jsval_to_cpBB( cx, args.get(1), (cpBB*) &arg1 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
-    cpShape* ret_val;
+    cpShape* ret_val = nullptr;
 
     ret_val = cpBoxShapeNew2((cpBody*)arg0 , (cpBB)arg1  );
 
@@ -1431,7 +1431,7 @@ bool JSB_cpCircleShapeGetOffset(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 1, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpShape* arg0; 
+    cpShape* arg0 = nullptr;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
@@ -1451,11 +1451,11 @@ bool JSB_cpCircleShapeGetRadius(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 1, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpShape* arg0; 
+    cpShape* arg0 = nullptr;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
-    cpFloat ret_val;
+    cpFloat ret_val = 0;
 
     ret_val = cpCircleShapeGetRadius((cpShape*)arg0  );
     args.rval().set(DOUBLE_TO_JSVAL(ret_val));
@@ -1468,13 +1468,13 @@ bool JSB_cpCircleShapeNew(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 3, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpBody* arg0; double arg1; cpVect arg2; 
+    cpBody* arg0 = nullptr; double arg1 = 0; cpVect arg2;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     ok &= JS::ToNumber( cx, args.get(1), &arg1 );
     ok &= jsval_to_cpVect( cx, args.get(2), (cpVect*) &arg2 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
-    cpShape* ret_val;
+    cpShape* ret_val = nullptr;
 
     ret_val = cpCircleShapeNew((cpBody*)arg0 , (cpFloat)arg1 , (cpVect)arg2  );
 
@@ -1490,7 +1490,7 @@ bool JSB_cpConstraintActivateBodies(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 1, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpConstraint* arg0; 
+    cpConstraint* arg0 = nullptr;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
@@ -1506,7 +1506,7 @@ bool JSB_cpConstraintDestroy(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 1, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpConstraint* arg0; 
+    cpConstraint* arg0 = nullptr;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
@@ -1522,7 +1522,7 @@ bool JSB_cpConstraintFree(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 1, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpConstraint* arg0; 
+    cpConstraint* arg0 = nullptr;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
@@ -1538,11 +1538,11 @@ bool JSB_cpConstraintGetA(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 1, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpConstraint* arg0; 
+    cpConstraint* arg0 = nullptr;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
-    cpBody* ret_val;
+    cpBody* ret_val = nullptr;
 
     ret_val = cpConstraintGetA((cpConstraint*)arg0  );
 
@@ -1558,11 +1558,11 @@ bool JSB_cpConstraintGetB(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 1, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpConstraint* arg0; 
+    cpConstraint* arg0 = nullptr;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
-    cpBody* ret_val;
+    cpBody* ret_val = nullptr;
 
     ret_val = cpConstraintGetB((cpConstraint*)arg0  );
 
@@ -1578,11 +1578,11 @@ bool JSB_cpConstraintGetErrorBias(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 1, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpConstraint* arg0; 
+    cpConstraint* arg0 = nullptr;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
-    cpFloat ret_val;
+    cpFloat ret_val = 0;
 
     ret_val = cpConstraintGetErrorBias((cpConstraint*)arg0  );
     args.rval().set(DOUBLE_TO_JSVAL(ret_val));
@@ -1595,11 +1595,11 @@ bool JSB_cpConstraintGetImpulse(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 1, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpConstraint* arg0; 
+    cpConstraint* arg0 = nullptr;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
-    cpFloat ret_val;
+    cpFloat ret_val = 0;
 
     ret_val = cpConstraintGetImpulse((cpConstraint*)arg0  );
     args.rval().set(DOUBLE_TO_JSVAL(ret_val));
@@ -1612,11 +1612,11 @@ bool JSB_cpConstraintGetMaxBias(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 1, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpConstraint* arg0; 
+    cpConstraint* arg0 = nullptr;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
-    cpFloat ret_val;
+    cpFloat ret_val = 0;
 
     ret_val = cpConstraintGetMaxBias((cpConstraint*)arg0  );
     args.rval().set(DOUBLE_TO_JSVAL(ret_val));
@@ -1629,11 +1629,11 @@ bool JSB_cpConstraintGetMaxForce(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 1, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpConstraint* arg0; 
+    cpConstraint* arg0 = nullptr;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
-    cpFloat ret_val;
+    cpFloat ret_val = 0;
 
     ret_val = cpConstraintGetMaxForce((cpConstraint*)arg0  );
     args.rval().set(DOUBLE_TO_JSVAL(ret_val));
@@ -1646,11 +1646,11 @@ bool JSB_cpConstraintGetSpace(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 1, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpConstraint* arg0; 
+    cpConstraint* arg0 = nullptr;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
-    cpSpace* ret_val;
+    cpSpace* ret_val = nullptr;
 
     ret_val = cpConstraintGetSpace((cpConstraint*)arg0  );
 
@@ -1666,7 +1666,7 @@ bool JSB_cpConstraintSetErrorBias(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 2, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpConstraint* arg0; double arg1; 
+    cpConstraint* arg0 = nullptr; double arg1 = 0;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     ok &= JS::ToNumber( cx, args.get(1), &arg1 );
@@ -1683,7 +1683,7 @@ bool JSB_cpConstraintSetMaxBias(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 2, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpConstraint* arg0; double arg1; 
+    cpConstraint* arg0 = nullptr; double arg1 = 0;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     ok &= JS::ToNumber( cx, args.get(1), &arg1 );
@@ -1700,7 +1700,7 @@ bool JSB_cpConstraintSetMaxForce(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 2, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpConstraint* arg0; double arg1; 
+    cpConstraint* arg0 = nullptr; double arg1 = 0;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     ok &= JS::ToNumber( cx, args.get(1), &arg1 );
@@ -1717,11 +1717,11 @@ bool JSB_cpDampedRotarySpringGetDamping(JSContext *cx, uint32_t argc, jsval *vp)
     JSB_PRECONDITION2( argc == 1, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpConstraint* arg0; 
+    cpConstraint* arg0 = nullptr;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
-    cpFloat ret_val;
+    cpFloat ret_val = 0;
 
     ret_val = cpDampedRotarySpringGetDamping((cpConstraint*)arg0  );
     args.rval().set(DOUBLE_TO_JSVAL(ret_val));
@@ -1734,11 +1734,11 @@ bool JSB_cpDampedRotarySpringGetRestAngle(JSContext *cx, uint32_t argc, jsval *v
     JSB_PRECONDITION2( argc == 1, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpConstraint* arg0; 
+    cpConstraint* arg0 = nullptr;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
-    cpFloat ret_val;
+    cpFloat ret_val = 0;
 
     ret_val = cpDampedRotarySpringGetRestAngle((cpConstraint*)arg0  );
     args.rval().set(DOUBLE_TO_JSVAL(ret_val));
@@ -1751,11 +1751,11 @@ bool JSB_cpDampedRotarySpringGetStiffness(JSContext *cx, uint32_t argc, jsval *v
     JSB_PRECONDITION2( argc == 1, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpConstraint* arg0; 
+    cpConstraint* arg0 = nullptr;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
-    cpFloat ret_val;
+    cpFloat ret_val = 0;
 
     ret_val = cpDampedRotarySpringGetStiffness((cpConstraint*)arg0  );
     args.rval().set(DOUBLE_TO_JSVAL(ret_val));
@@ -1768,7 +1768,7 @@ bool JSB_cpDampedRotarySpringNew(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 5, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpBody* arg0; cpBody* arg1; double arg2; double arg3; double arg4; 
+    cpBody* arg0 = nullptr; cpBody* arg1 = nullptr; double arg2 = 0; double arg3 = 0; double arg4 = 0;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     ok &= jsval_to_opaque( cx, args.get(1), (void**)&arg1 );
@@ -1776,7 +1776,7 @@ bool JSB_cpDampedRotarySpringNew(JSContext *cx, uint32_t argc, jsval *vp) {
     ok &= JS::ToNumber( cx, args.get(3), &arg3 );
     ok &= JS::ToNumber( cx, args.get(4), &arg4 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
-    cpConstraint* ret_val;
+    cpConstraint* ret_val = nullptr;
 
     ret_val = cpDampedRotarySpringNew((cpBody*)arg0 , (cpBody*)arg1 , (cpFloat)arg2 , (cpFloat)arg3 , (cpFloat)arg4  );
 
@@ -1792,7 +1792,7 @@ bool JSB_cpDampedRotarySpringSetDamping(JSContext *cx, uint32_t argc, jsval *vp)
     JSB_PRECONDITION2( argc == 2, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpConstraint* arg0; double arg1; 
+    cpConstraint* arg0 = nullptr; double arg1 = 0;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     ok &= JS::ToNumber( cx, args.get(1), &arg1 );
@@ -1809,7 +1809,7 @@ bool JSB_cpDampedRotarySpringSetRestAngle(JSContext *cx, uint32_t argc, jsval *v
     JSB_PRECONDITION2( argc == 2, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpConstraint* arg0; double arg1; 
+    cpConstraint* arg0 = nullptr; double arg1 = 0;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     ok &= JS::ToNumber( cx, args.get(1), &arg1 );
@@ -1826,7 +1826,7 @@ bool JSB_cpDampedRotarySpringSetStiffness(JSContext *cx, uint32_t argc, jsval *v
     JSB_PRECONDITION2( argc == 2, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpConstraint* arg0; double arg1; 
+    cpConstraint* arg0 = nullptr; double arg1 = 0;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     ok &= JS::ToNumber( cx, args.get(1), &arg1 );
@@ -1843,7 +1843,7 @@ bool JSB_cpDampedSpringGetAnchr1(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 1, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpConstraint* arg0; 
+    cpConstraint* arg0 = nullptr; 
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
@@ -1863,7 +1863,7 @@ bool JSB_cpDampedSpringGetAnchr2(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 1, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpConstraint* arg0; 
+    cpConstraint* arg0 = nullptr; 
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
@@ -1883,11 +1883,11 @@ bool JSB_cpDampedSpringGetDamping(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 1, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpConstraint* arg0; 
+    cpConstraint* arg0 = nullptr; 
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
-    cpFloat ret_val;
+    cpFloat ret_val = 0;
 
     ret_val = cpDampedSpringGetDamping((cpConstraint*)arg0  );
     args.rval().set(DOUBLE_TO_JSVAL(ret_val));
@@ -1900,11 +1900,11 @@ bool JSB_cpDampedSpringGetRestLength(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 1, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpConstraint* arg0; 
+    cpConstraint* arg0 = nullptr; 
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
-    cpFloat ret_val;
+    cpFloat ret_val = 0;
 
     ret_val = cpDampedSpringGetRestLength((cpConstraint*)arg0  );
     args.rval().set(DOUBLE_TO_JSVAL(ret_val));
@@ -1917,11 +1917,11 @@ bool JSB_cpDampedSpringGetStiffness(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 1, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpConstraint* arg0; 
+    cpConstraint* arg0 = nullptr; 
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
-    cpFloat ret_val;
+    cpFloat ret_val = 0;
 
     ret_val = cpDampedSpringGetStiffness((cpConstraint*)arg0  );
     args.rval().set(DOUBLE_TO_JSVAL(ret_val));
@@ -1934,7 +1934,7 @@ bool JSB_cpDampedSpringNew(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 7, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpBody* arg0; cpBody* arg1; cpVect arg2; cpVect arg3; double arg4; double arg5; double arg6; 
+    cpBody* arg0 = nullptr; cpBody* arg1 = nullptr; cpVect arg2; cpVect arg3; double arg4 = 0; double arg5 = 0; double arg6 = 0; 
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     ok &= jsval_to_opaque( cx, args.get(1), (void**)&arg1 );
@@ -1944,7 +1944,7 @@ bool JSB_cpDampedSpringNew(JSContext *cx, uint32_t argc, jsval *vp) {
     ok &= JS::ToNumber( cx, args.get(5), &arg5 );
     ok &= JS::ToNumber( cx, args.get(6), &arg6 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
-    cpConstraint* ret_val;
+    cpConstraint* ret_val = nullptr;
 
     ret_val = cpDampedSpringNew((cpBody*)arg0 , (cpBody*)arg1 , (cpVect)arg2 , (cpVect)arg3 , (cpFloat)arg4 , (cpFloat)arg5 , (cpFloat)arg6  );
 
@@ -1960,7 +1960,7 @@ bool JSB_cpDampedSpringSetAnchr1(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 2, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpConstraint* arg0; cpVect arg1; 
+    cpConstraint* arg0 = nullptr; cpVect arg1; 
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     ok &= jsval_to_cpVect( cx, args.get(1), (cpVect*) &arg1 );
@@ -1977,7 +1977,7 @@ bool JSB_cpDampedSpringSetAnchr2(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 2, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpConstraint* arg0; cpVect arg1; 
+    cpConstraint* arg0 = nullptr; cpVect arg1; 
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     ok &= jsval_to_cpVect( cx, args.get(1), (cpVect*) &arg1 );
@@ -1994,7 +1994,7 @@ bool JSB_cpDampedSpringSetDamping(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 2, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpConstraint* arg0; double arg1; 
+    cpConstraint* arg0 = nullptr; double arg1 = 0; 
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     ok &= JS::ToNumber( cx, args.get(1), &arg1 );
@@ -2011,7 +2011,7 @@ bool JSB_cpDampedSpringSetRestLength(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 2, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpConstraint* arg0; double arg1; 
+    cpConstraint* arg0 = nullptr; double arg1 = 0; 
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     ok &= JS::ToNumber( cx, args.get(1), &arg1 );
@@ -2028,7 +2028,7 @@ bool JSB_cpDampedSpringSetStiffness(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 2, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpConstraint* arg0; double arg1; 
+    cpConstraint* arg0 = nullptr; double arg1 = 0; 
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     ok &= JS::ToNumber( cx, args.get(1), &arg1 );
@@ -2045,11 +2045,11 @@ bool JSB_cpGearJointGetPhase(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 1, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpConstraint* arg0; 
+    cpConstraint* arg0 = nullptr; 
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
-    cpFloat ret_val;
+    cpFloat ret_val = 0;
 
     ret_val = cpGearJointGetPhase((cpConstraint*)arg0  );
     args.rval().set(DOUBLE_TO_JSVAL(ret_val));
@@ -2062,11 +2062,11 @@ bool JSB_cpGearJointGetRatio(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 1, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpConstraint* arg0; 
+    cpConstraint* arg0 = nullptr; 
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
-    cpFloat ret_val;
+    cpFloat ret_val = 0;
 
     ret_val = cpGearJointGetRatio((cpConstraint*)arg0  );
     args.rval().set(DOUBLE_TO_JSVAL(ret_val));
@@ -2079,14 +2079,14 @@ bool JSB_cpGearJointNew(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 4, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpBody* arg0; cpBody* arg1; double arg2; double arg3; 
+    cpBody* arg0 = nullptr; cpBody* arg1 = nullptr; double arg2 = 0; double arg3 = 0; 
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     ok &= jsval_to_opaque( cx, args.get(1), (void**)&arg1 );
     ok &= JS::ToNumber( cx, args.get(2), &arg2 );
     ok &= JS::ToNumber( cx, args.get(3), &arg3 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
-    cpConstraint* ret_val;
+    cpConstraint* ret_val = nullptr;
 
     ret_val = cpGearJointNew((cpBody*)arg0 , (cpBody*)arg1 , (cpFloat)arg2 , (cpFloat)arg3  );
 
@@ -2102,7 +2102,7 @@ bool JSB_cpGearJointSetPhase(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 2, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpConstraint* arg0; double arg1; 
+    cpConstraint* arg0 = nullptr; double arg1 = 0; 
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     ok &= JS::ToNumber( cx, args.get(1), &arg1 );
@@ -2119,7 +2119,7 @@ bool JSB_cpGearJointSetRatio(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 2, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpConstraint* arg0; double arg1; 
+    cpConstraint* arg0 = nullptr; double arg1 = 0; 
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     ok &= JS::ToNumber( cx, args.get(1), &arg1 );
@@ -2136,7 +2136,7 @@ bool JSB_cpGrooveJointGetAnchr2(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 1, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpConstraint* arg0; 
+    cpConstraint* arg0 = nullptr; 
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
@@ -2156,7 +2156,7 @@ bool JSB_cpGrooveJointGetGrooveA(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 1, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpConstraint* arg0; 
+    cpConstraint* arg0 = nullptr; 
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
@@ -2176,7 +2176,7 @@ bool JSB_cpGrooveJointGetGrooveB(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 1, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpConstraint* arg0; 
+    cpConstraint* arg0 = nullptr; 
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
@@ -2196,7 +2196,7 @@ bool JSB_cpGrooveJointNew(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 5, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpBody* arg0; cpBody* arg1; cpVect arg2; cpVect arg3; cpVect arg4; 
+    cpBody* arg0 = nullptr; cpBody* arg1 = nullptr; cpVect arg2; cpVect arg3; cpVect arg4; 
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     ok &= jsval_to_opaque( cx, args.get(1), (void**)&arg1 );
@@ -2204,7 +2204,7 @@ bool JSB_cpGrooveJointNew(JSContext *cx, uint32_t argc, jsval *vp) {
     ok &= jsval_to_cpVect( cx, args.get(3), (cpVect*) &arg3 );
     ok &= jsval_to_cpVect( cx, args.get(4), (cpVect*) &arg4 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
-    cpConstraint* ret_val;
+    cpConstraint* ret_val = nullptr;
 
     ret_val = cpGrooveJointNew((cpBody*)arg0 , (cpBody*)arg1 , (cpVect)arg2 , (cpVect)arg3 , (cpVect)arg4  );
 
@@ -2220,7 +2220,7 @@ bool JSB_cpGrooveJointSetAnchr2(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 2, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpConstraint* arg0; cpVect arg1; 
+    cpConstraint* arg0 = nullptr; cpVect arg1; 
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     ok &= jsval_to_cpVect( cx, args.get(1), (cpVect*) &arg1 );
@@ -2237,7 +2237,7 @@ bool JSB_cpGrooveJointSetGrooveA(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 2, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpConstraint* arg0; cpVect arg1; 
+    cpConstraint* arg0 = nullptr; cpVect arg1; 
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     ok &= jsval_to_cpVect( cx, args.get(1), (cpVect*) &arg1 );
@@ -2254,7 +2254,7 @@ bool JSB_cpGrooveJointSetGrooveB(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 2, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpConstraint* arg0; cpVect arg1; 
+    cpConstraint* arg0 = nullptr; cpVect arg1; 
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     ok &= jsval_to_cpVect( cx, args.get(1), (cpVect*) &arg1 );
@@ -2281,13 +2281,13 @@ bool JSB_cpMomentForBox(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 3, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    double arg0; double arg1; double arg2; 
+    double arg0 = 0; double arg1 = 0; double arg2 = 0; 
 
     ok &= JS::ToNumber( cx, args.get(0), &arg0 );
     ok &= JS::ToNumber( cx, args.get(1), &arg1 );
     ok &= JS::ToNumber( cx, args.get(2), &arg2 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
-    cpFloat ret_val;
+    cpFloat ret_val = 0;
 
     ret_val = cpMomentForBox((cpFloat)arg0 , (cpFloat)arg1 , (cpFloat)arg2  );
     args.rval().set(DOUBLE_TO_JSVAL(ret_val));
@@ -2300,12 +2300,12 @@ bool JSB_cpMomentForBox2(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 2, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    double arg0; cpBB arg1; 
+    double arg0 = 0; cpBB arg1; 
 
     ok &= JS::ToNumber( cx, args.get(0), &arg0 );
     ok &= jsval_to_cpBB( cx, args.get(1), (cpBB*) &arg1 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
-    cpFloat ret_val;
+    cpFloat ret_val = 0;
 
     ret_val = cpMomentForBox2((cpFloat)arg0 , (cpBB)arg1  );
     args.rval().set(DOUBLE_TO_JSVAL(ret_val));
@@ -2318,14 +2318,14 @@ bool JSB_cpMomentForCircle(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 4, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    double arg0; double arg1; double arg2; cpVect arg3; 
+    double arg0 = 0; double arg1 = 0; double arg2 = 0; cpVect arg3; 
 
     ok &= JS::ToNumber( cx, args.get(0), &arg0 );
     ok &= JS::ToNumber( cx, args.get(1), &arg1 );
     ok &= JS::ToNumber( cx, args.get(2), &arg2 );
     ok &= jsval_to_cpVect( cx, args.get(3), (cpVect*) &arg3 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
-    cpFloat ret_val;
+    cpFloat ret_val = 0;
 
     ret_val = cpMomentForCircle((cpFloat)arg0 , (cpFloat)arg1 , (cpFloat)arg2 , (cpVect)arg3  );
     args.rval().set(DOUBLE_TO_JSVAL(ret_val));
@@ -2338,13 +2338,13 @@ bool JSB_cpMomentForSegment(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 3, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    double arg0; cpVect arg1; cpVect arg2; 
+    double arg0 = 0; cpVect arg1; cpVect arg2; 
 
     ok &= JS::ToNumber( cx, args.get(0), &arg0 );
     ok &= jsval_to_cpVect( cx, args.get(1), (cpVect*) &arg1 );
     ok &= jsval_to_cpVect( cx, args.get(2), (cpVect*) &arg2 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
-    cpFloat ret_val;
+    cpFloat ret_val = 0;
 
     ret_val = cpMomentForSegment((cpFloat)arg0 , (cpVect)arg1 , (cpVect)arg2  );
     args.rval().set(DOUBLE_TO_JSVAL(ret_val));
@@ -2357,7 +2357,7 @@ bool JSB_cpPinJointGetAnchr1(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 1, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpConstraint* arg0; 
+    cpConstraint* arg0 = nullptr; 
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
@@ -2377,7 +2377,7 @@ bool JSB_cpPinJointGetAnchr2(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 1, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpConstraint* arg0; 
+    cpConstraint* arg0 = nullptr; 
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
@@ -2397,11 +2397,11 @@ bool JSB_cpPinJointGetDist(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 1, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpConstraint* arg0; 
+    cpConstraint* arg0 = nullptr; 
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
-    cpFloat ret_val;
+    cpFloat ret_val = 0;
 
     ret_val = cpPinJointGetDist((cpConstraint*)arg0  );
     args.rval().set(DOUBLE_TO_JSVAL(ret_val));
@@ -2414,14 +2414,14 @@ bool JSB_cpPinJointNew(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 4, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpBody* arg0; cpBody* arg1; cpVect arg2; cpVect arg3; 
+    cpBody* arg0 = nullptr; cpBody* arg1 = nullptr; cpVect arg2; cpVect arg3; 
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     ok &= jsval_to_opaque( cx, args.get(1), (void**)&arg1 );
     ok &= jsval_to_cpVect( cx, args.get(2), (cpVect*) &arg2 );
     ok &= jsval_to_cpVect( cx, args.get(3), (cpVect*) &arg3 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
-    cpConstraint* ret_val;
+    cpConstraint* ret_val = nullptr;
 
     ret_val = cpPinJointNew((cpBody*)arg0 , (cpBody*)arg1 , (cpVect)arg2 , (cpVect)arg3  );
 
@@ -2437,7 +2437,7 @@ bool JSB_cpPinJointSetAnchr1(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 2, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpConstraint* arg0; cpVect arg1; 
+    cpConstraint* arg0 = nullptr; cpVect arg1; 
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     ok &= jsval_to_cpVect( cx, args.get(1), (cpVect*) &arg1 );
@@ -2454,7 +2454,7 @@ bool JSB_cpPinJointSetAnchr2(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 2, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpConstraint* arg0; cpVect arg1; 
+    cpConstraint* arg0 = nullptr; cpVect arg1; 
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     ok &= jsval_to_cpVect( cx, args.get(1), (cpVect*) &arg1 );
@@ -2471,7 +2471,7 @@ bool JSB_cpPinJointSetDist(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 2, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpConstraint* arg0; double arg1; 
+    cpConstraint* arg0 = nullptr; double arg1 = 0; 
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     ok &= JS::ToNumber( cx, args.get(1), &arg1 );
@@ -2488,7 +2488,7 @@ bool JSB_cpPivotJointGetAnchr1(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 1, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpConstraint* arg0; 
+    cpConstraint* arg0 = nullptr; 
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
@@ -2508,7 +2508,7 @@ bool JSB_cpPivotJointGetAnchr2(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 1, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpConstraint* arg0; 
+    cpConstraint* arg0 = nullptr; 
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
@@ -2528,7 +2528,7 @@ bool JSB_cpPivotJointNew(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 3 || argc == 4, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpBody* arg0; cpBody* arg1; cpVect arg2; cpVect arg3;
+    cpBody* arg0 = nullptr; cpBody* arg1 = nullptr; cpVect arg2; cpVect arg3;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     ok &= jsval_to_opaque( cx, args.get(1), (void**)&arg1 );
@@ -2537,7 +2537,7 @@ bool JSB_cpPivotJointNew(JSContext *cx, uint32_t argc, jsval *vp) {
         ok &= jsval_to_cpVect( cx, args.get(3), (cpVect*) &arg3 );
     }
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
-    cpConstraint* ret_val;
+    cpConstraint* ret_val = nullptr;
 
     if(argc == 4) {
         ret_val = cpPivotJointNew2((cpBody*)arg0 , (cpBody*)arg1 , (cpVect)arg2 , (cpVect)arg3  );
@@ -2557,14 +2557,14 @@ bool JSB_cpPivotJointNew2(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 4, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpBody* arg0; cpBody* arg1; cpVect arg2; cpVect arg3; 
+    cpBody* arg0 = nullptr; cpBody* arg1 = nullptr; cpVect arg2; cpVect arg3; 
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     ok &= jsval_to_opaque( cx, args.get(1), (void**)&arg1 );
     ok &= jsval_to_cpVect( cx, args.get(2), (cpVect*) &arg2 );
     ok &= jsval_to_cpVect( cx, args.get(3), (cpVect*) &arg3 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
-    cpConstraint* ret_val;
+    cpConstraint* ret_val = nullptr;
 
     ret_val = cpPivotJointNew2((cpBody*)arg0 , (cpBody*)arg1 , (cpVect)arg2 , (cpVect)arg3  );
 
@@ -2580,7 +2580,7 @@ bool JSB_cpPivotJointSetAnchr1(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 2, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpConstraint* arg0; cpVect arg1; 
+    cpConstraint* arg0 = nullptr; cpVect arg1; 
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     ok &= jsval_to_cpVect( cx, args.get(1), (cpVect*) &arg1 );
@@ -2597,7 +2597,7 @@ bool JSB_cpPivotJointSetAnchr2(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 2, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpConstraint* arg0; cpVect arg1; 
+    cpConstraint* arg0 = nullptr; cpVect arg1; 
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     ok &= jsval_to_cpVect( cx, args.get(1), (cpVect*) &arg1 );
@@ -2614,11 +2614,11 @@ bool JSB_cpPolyShapeGetNumVerts(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 1, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpShape* arg0; 
+    cpShape* arg0 = nullptr; 
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
-    int ret_val;
+    int ret_val = 0;
 
     ret_val = cpPolyShapeGetNumVerts((cpShape*)arg0  );
     args.rval().set(INT_TO_JSVAL((int32_t)ret_val));
@@ -2631,7 +2631,7 @@ bool JSB_cpPolyShapeGetVert(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 2, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpShape* arg0; int32_t arg1; 
+    cpShape* arg0 = nullptr; int32_t arg1 = 0; 
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     ok &= jsval_to_int32( cx, args.get(1), &arg1 );
@@ -2652,11 +2652,11 @@ bool JSB_cpRatchetJointGetAngle(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 1, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpConstraint* arg0; 
+    cpConstraint* arg0 = nullptr; 
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
-    cpFloat ret_val;
+    cpFloat ret_val = 0;
 
     ret_val = cpRatchetJointGetAngle((cpConstraint*)arg0  );
     args.rval().set(DOUBLE_TO_JSVAL(ret_val));
@@ -2669,11 +2669,11 @@ bool JSB_cpRatchetJointGetPhase(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 1, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpConstraint* arg0; 
+    cpConstraint* arg0 = nullptr; 
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
-    cpFloat ret_val;
+    cpFloat ret_val = 0;
 
     ret_val = cpRatchetJointGetPhase((cpConstraint*)arg0  );
     args.rval().set(DOUBLE_TO_JSVAL(ret_val));
@@ -2686,11 +2686,11 @@ bool JSB_cpRatchetJointGetRatchet(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 1, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpConstraint* arg0; 
+    cpConstraint* arg0 = nullptr; 
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
-    cpFloat ret_val;
+    cpFloat ret_val = 0;
 
     ret_val = cpRatchetJointGetRatchet((cpConstraint*)arg0  );
     args.rval().set(DOUBLE_TO_JSVAL(ret_val));
@@ -2703,14 +2703,14 @@ bool JSB_cpRatchetJointNew(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 4, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpBody* arg0; cpBody* arg1; double arg2; double arg3; 
+    cpBody* arg0 = nullptr; cpBody* arg1 = nullptr; double arg2 = 0; double arg3 = 0; 
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     ok &= jsval_to_opaque( cx, args.get(1), (void**)&arg1 );
     ok &= JS::ToNumber( cx, args.get(2), &arg2 );
     ok &= JS::ToNumber( cx, args.get(3), &arg3 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
-    cpConstraint* ret_val;
+    cpConstraint* ret_val = nullptr;
 
     ret_val = cpRatchetJointNew((cpBody*)arg0 , (cpBody*)arg1 , (cpFloat)arg2 , (cpFloat)arg3  );
 
@@ -2726,7 +2726,7 @@ bool JSB_cpRatchetJointSetAngle(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 2, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpConstraint* arg0; double arg1; 
+    cpConstraint* arg0 = nullptr; double arg1 = 0; 
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     ok &= JS::ToNumber( cx, args.get(1), &arg1 );
@@ -2743,7 +2743,7 @@ bool JSB_cpRatchetJointSetPhase(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 2, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpConstraint* arg0; double arg1; 
+    cpConstraint* arg0 = nullptr; double arg1 = 0; 
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     ok &= JS::ToNumber( cx, args.get(1), &arg1 );
@@ -2760,7 +2760,7 @@ bool JSB_cpRatchetJointSetRatchet(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 2, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpConstraint* arg0; double arg1; 
+    cpConstraint* arg0 = nullptr; double arg1 = 0; 
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     ok &= JS::ToNumber( cx, args.get(1), &arg1 );
@@ -2787,11 +2787,11 @@ bool JSB_cpRotaryLimitJointGetMax(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 1, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpConstraint* arg0; 
+    cpConstraint* arg0 = nullptr; 
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
-    cpFloat ret_val;
+    cpFloat ret_val = 0;
 
     ret_val = cpRotaryLimitJointGetMax((cpConstraint*)arg0  );
     args.rval().set(DOUBLE_TO_JSVAL(ret_val));
@@ -2804,11 +2804,11 @@ bool JSB_cpRotaryLimitJointGetMin(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 1, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpConstraint* arg0; 
+    cpConstraint* arg0 = nullptr; 
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
-    cpFloat ret_val;
+    cpFloat ret_val = 0;
 
     ret_val = cpRotaryLimitJointGetMin((cpConstraint*)arg0  );
     args.rval().set(DOUBLE_TO_JSVAL(ret_val));
@@ -2821,14 +2821,14 @@ bool JSB_cpRotaryLimitJointNew(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 4, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpBody* arg0; cpBody* arg1; double arg2; double arg3; 
+    cpBody* arg0 = nullptr; cpBody* arg1 = nullptr; double arg2 = 0; double arg3 = 0; 
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     ok &= jsval_to_opaque( cx, args.get(1), (void**)&arg1 );
     ok &= JS::ToNumber( cx, args.get(2), &arg2 );
     ok &= JS::ToNumber( cx, args.get(3), &arg3 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
-    cpConstraint* ret_val;
+    cpConstraint* ret_val = nullptr;
 
     ret_val = cpRotaryLimitJointNew((cpBody*)arg0 , (cpBody*)arg1 , (cpFloat)arg2 , (cpFloat)arg3  );
 
@@ -2844,7 +2844,7 @@ bool JSB_cpRotaryLimitJointSetMax(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 2, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpConstraint* arg0; double arg1; 
+    cpConstraint* arg0 = nullptr; double arg1 = 0; 
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     ok &= JS::ToNumber( cx, args.get(1), &arg1 );
@@ -2861,7 +2861,7 @@ bool JSB_cpRotaryLimitJointSetMin(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 2, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpConstraint* arg0; double arg1; 
+    cpConstraint* arg0 = nullptr; double arg1 = 0; 
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     ok &= JS::ToNumber( cx, args.get(1), &arg1 );
@@ -2878,7 +2878,7 @@ bool JSB_cpSegmentShapeGetA(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 1, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpShape* arg0; 
+    cpShape* arg0 = nullptr; 
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
@@ -2898,7 +2898,7 @@ bool JSB_cpSegmentShapeGetB(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 1, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpShape* arg0; 
+    cpShape* arg0 = nullptr; 
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
@@ -2918,7 +2918,7 @@ bool JSB_cpSegmentShapeGetNormal(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 1, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpShape* arg0; 
+    cpShape* arg0 = nullptr; 
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
@@ -2938,11 +2938,11 @@ bool JSB_cpSegmentShapeGetRadius(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 1, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpShape* arg0; 
+    cpShape* arg0 = nullptr; 
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
-    cpFloat ret_val;
+    cpFloat ret_val = 0;
 
     ret_val = cpSegmentShapeGetRadius((cpShape*)arg0  );
     args.rval().set(DOUBLE_TO_JSVAL(ret_val));
@@ -2955,14 +2955,14 @@ bool JSB_cpSegmentShapeNew(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 4, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpBody* arg0; cpVect arg1; cpVect arg2; double arg3; 
+    cpBody* arg0 = nullptr; cpVect arg1; cpVect arg2; double arg3 = 0; 
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     ok &= jsval_to_cpVect( cx, args.get(1), (cpVect*) &arg1 );
     ok &= jsval_to_cpVect( cx, args.get(2), (cpVect*) &arg2 );
     ok &= JS::ToNumber( cx, args.get(3), &arg3 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
-    cpShape* ret_val;
+    cpShape* ret_val = nullptr;
 
     ret_val = cpSegmentShapeNew((cpBody*)arg0 , (cpVect)arg1 , (cpVect)arg2 , (cpFloat)arg3  );
 
@@ -2978,7 +2978,7 @@ bool JSB_cpSegmentShapeSetNeighbors(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 3, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpShape* arg0; cpVect arg1; cpVect arg2; 
+    cpShape* arg0 = nullptr; cpVect arg1; cpVect arg2; 
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     ok &= jsval_to_cpVect( cx, args.get(1), (cpVect*) &arg1 );
@@ -2996,7 +2996,7 @@ bool JSB_cpShapeCacheBB(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 1, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpShape* arg0; 
+    cpShape* arg0 = nullptr; 
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
@@ -3016,7 +3016,7 @@ bool JSB_cpShapeDestroy(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 1, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpShape* arg0; 
+    cpShape* arg0 = nullptr; 
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
@@ -3032,7 +3032,7 @@ bool JSB_cpShapeFree(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 1, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpShape* arg0; 
+    cpShape* arg0 = nullptr; 
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
@@ -3048,7 +3048,7 @@ bool JSB_cpShapeGetBB(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 1, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpShape* arg0; 
+    cpShape* arg0 = nullptr; 
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
@@ -3068,11 +3068,11 @@ bool JSB_cpShapeGetBody(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 1, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpShape* arg0; 
+    cpShape* arg0 = nullptr; 
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
-    cpBody* ret_val;
+    cpBody* ret_val = nullptr;
 
     ret_val = cpShapeGetBody((cpShape*)arg0  );
 
@@ -3088,11 +3088,11 @@ bool JSB_cpShapeGetCollisionType(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 1, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpShape* arg0; 
+    cpShape* arg0 = nullptr; 
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
-    cpCollisionType ret_val;
+    cpCollisionType ret_val = 0;
 
     ret_val = cpShapeGetCollisionType((cpShape*)arg0  );
 
@@ -3108,11 +3108,11 @@ bool JSB_cpShapeGetElasticity(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 1, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpShape* arg0; 
+    cpShape* arg0 = nullptr; 
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
-    cpFloat ret_val;
+    cpFloat ret_val = 0;
 
     ret_val = cpShapeGetElasticity((cpShape*)arg0  );
     args.rval().set(DOUBLE_TO_JSVAL(ret_val));
@@ -3125,11 +3125,11 @@ bool JSB_cpShapeGetFriction(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 1, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpShape* arg0; 
+    cpShape* arg0 = nullptr; 
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
-    cpFloat ret_val;
+    cpFloat ret_val = 0;
 
     ret_val = cpShapeGetFriction((cpShape*)arg0  );
     args.rval().set(DOUBLE_TO_JSVAL(ret_val));
@@ -3142,11 +3142,11 @@ bool JSB_cpShapeGetGroup(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 1, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpShape* arg0; 
+    cpShape* arg0 = nullptr; 
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
-    cpGroup ret_val;
+    cpGroup ret_val = 0;
 
     ret_val = cpShapeGetGroup((cpShape*)arg0  );
 
@@ -3162,11 +3162,11 @@ bool JSB_cpShapeGetLayers(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 1, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpShape* arg0; 
+    cpShape* arg0 = nullptr; 
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
-    cpLayers ret_val;
+    cpLayers ret_val = 0;
 
     ret_val = cpShapeGetLayers((cpShape*)arg0  );
     args.rval().set(UINT_TO_JSVAL((uint32_t)ret_val));
@@ -3179,7 +3179,7 @@ bool JSB_cpShapeGetSensor(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 1, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpShape* arg0; 
+    cpShape* arg0 = nullptr; 
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
@@ -3196,11 +3196,11 @@ bool JSB_cpShapeGetSpace(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 1, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpShape* arg0; 
+    cpShape* arg0 = nullptr; 
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
-    cpSpace* ret_val;
+    cpSpace* ret_val = nullptr;
 
     ret_val = cpShapeGetSpace((cpShape*)arg0  );
 
@@ -3216,7 +3216,7 @@ bool JSB_cpShapeGetSurfaceVelocity(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 1, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpShape* arg0; 
+    cpShape* arg0 = nullptr; 
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
@@ -3236,7 +3236,7 @@ bool JSB_cpShapePointQuery(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 2, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpShape* arg0; cpVect arg1; 
+    cpShape* arg0 = nullptr; cpVect arg1; 
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     ok &= jsval_to_cpVect( cx, args.get(1), (cpVect*) &arg1 );
@@ -3254,7 +3254,7 @@ bool JSB_cpShapeSetBody(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 2, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpShape* arg0; cpBody* arg1; 
+    cpShape* arg0 = nullptr; cpBody* arg1 = nullptr; 
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     ok &= jsval_to_opaque( cx, args.get(1), (void**)&arg1 );
@@ -3271,7 +3271,7 @@ bool JSB_cpShapeSetCollisionType(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 2, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpShape* arg0; cpCollisionType arg1; 
+    cpShape* arg0 = nullptr; cpCollisionType arg1 = 0; 
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     ok &= jsval_to_uint( cx, args.get(1), (unsigned int*) &arg1 );
@@ -3288,7 +3288,7 @@ bool JSB_cpShapeSetElasticity(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 2, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpShape* arg0; double arg1; 
+    cpShape* arg0 = nullptr; double arg1 = 0; 
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     ok &= JS::ToNumber( cx, args.get(1), &arg1 );
@@ -3305,7 +3305,7 @@ bool JSB_cpShapeSetFriction(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 2, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpShape* arg0; double arg1; 
+    cpShape* arg0 = nullptr; double arg1 = 0; 
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     ok &= JS::ToNumber( cx, args.get(1), &arg1 );
@@ -3322,7 +3322,7 @@ bool JSB_cpShapeSetGroup(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 2, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpShape* arg0; cpGroup arg1; 
+    cpShape* arg0 = nullptr; cpGroup arg1 = 0; 
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     ok &= jsval_to_uint( cx, args.get(1), (unsigned int*) &arg1 );
@@ -3339,7 +3339,7 @@ bool JSB_cpShapeSetLayers(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 2, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpShape* arg0; uint32_t arg1; 
+    cpShape* arg0 = nullptr; uint32_t arg1 = 0; 
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     ok &= jsval_to_uint32( cx, args.get(1), &arg1 );
@@ -3356,7 +3356,7 @@ bool JSB_cpShapeSetSensor(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 2, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpShape* arg0; int32_t arg1; 
+    cpShape* arg0 = nullptr; int32_t arg1 = 0; 
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     ok &= jsval_to_int32( cx, args.get(1), &arg1 );
@@ -3373,7 +3373,7 @@ bool JSB_cpShapeSetSurfaceVelocity(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 2, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpShape* arg0; cpVect arg1; 
+    cpShape* arg0 = nullptr; cpVect arg1; 
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     ok &= jsval_to_cpVect( cx, args.get(1), (cpVect*) &arg1 );
@@ -3390,7 +3390,7 @@ bool JSB_cpShapeUpdate(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 3, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpShape* arg0; cpVect arg1; cpVect arg2; 
+    cpShape* arg0 = nullptr; cpVect arg1; cpVect arg2;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     ok &= jsval_to_cpVect( cx, args.get(1), (cpVect*) &arg1 );
@@ -3412,11 +3412,11 @@ bool JSB_cpSimpleMotorGetRate(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 1, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpConstraint* arg0; 
+    cpConstraint* arg0 = nullptr;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
-    cpFloat ret_val;
+    cpFloat ret_val = 0;
 
     ret_val = cpSimpleMotorGetRate((cpConstraint*)arg0  );
     args.rval().set(DOUBLE_TO_JSVAL(ret_val));
@@ -3429,13 +3429,13 @@ bool JSB_cpSimpleMotorNew(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 3, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpBody* arg0; cpBody* arg1; double arg2; 
+    cpBody* arg0 = nullptr; cpBody* arg1 = nullptr; double arg2 = 0;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     ok &= jsval_to_opaque( cx, args.get(1), (void**)&arg1 );
     ok &= JS::ToNumber( cx, args.get(2), &arg2 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
-    cpConstraint* ret_val;
+    cpConstraint* ret_val = nullptr;
 
     ret_val = cpSimpleMotorNew((cpBody*)arg0 , (cpBody*)arg1 , (cpFloat)arg2  );
 
@@ -3451,7 +3451,7 @@ bool JSB_cpSimpleMotorSetRate(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 2, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpConstraint* arg0; double arg1; 
+    cpConstraint* arg0 = nullptr; double arg1 = 0;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     ok &= JS::ToNumber( cx, args.get(1), &arg1 );
@@ -3468,7 +3468,7 @@ bool JSB_cpSlideJointGetAnchr1(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 1, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpConstraint* arg0; 
+    cpConstraint* arg0 = nullptr;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
@@ -3488,7 +3488,7 @@ bool JSB_cpSlideJointGetAnchr2(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 1, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpConstraint* arg0; 
+    cpConstraint* arg0 = nullptr;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
@@ -3508,11 +3508,11 @@ bool JSB_cpSlideJointGetMax(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 1, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpConstraint* arg0; 
+    cpConstraint* arg0 = nullptr;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
-    cpFloat ret_val;
+    cpFloat ret_val = 0;
 
     ret_val = cpSlideJointGetMax((cpConstraint*)arg0  );
     args.rval().set(DOUBLE_TO_JSVAL(ret_val));
@@ -3525,11 +3525,11 @@ bool JSB_cpSlideJointGetMin(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 1, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpConstraint* arg0; 
+    cpConstraint* arg0 = nullptr;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
-    cpFloat ret_val;
+    cpFloat ret_val = 0;
 
     ret_val = cpSlideJointGetMin((cpConstraint*)arg0  );
     args.rval().set(DOUBLE_TO_JSVAL(ret_val));
@@ -3542,7 +3542,7 @@ bool JSB_cpSlideJointNew(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 6, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpBody* arg0; cpBody* arg1; cpVect arg2; cpVect arg3; double arg4; double arg5; 
+    cpBody* arg0 = nullptr; cpBody* arg1 = nullptr; cpVect arg2; cpVect arg3; double arg4 = 0; double arg5 = 0;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     ok &= jsval_to_opaque( cx, args.get(1), (void**)&arg1 );
@@ -3551,7 +3551,7 @@ bool JSB_cpSlideJointNew(JSContext *cx, uint32_t argc, jsval *vp) {
     ok &= JS::ToNumber( cx, args.get(4), &arg4 );
     ok &= JS::ToNumber( cx, args.get(5), &arg5 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
-    cpConstraint* ret_val;
+    cpConstraint* ret_val = nullptr;
 
     ret_val = cpSlideJointNew((cpBody*)arg0 , (cpBody*)arg1 , (cpVect)arg2 , (cpVect)arg3 , (cpFloat)arg4 , (cpFloat)arg5  );
 
@@ -3567,7 +3567,7 @@ bool JSB_cpSlideJointSetAnchr1(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 2, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpConstraint* arg0; cpVect arg1; 
+    cpConstraint* arg0 = nullptr; cpVect arg1;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     ok &= jsval_to_cpVect( cx, args.get(1), (cpVect*) &arg1 );
@@ -3584,7 +3584,7 @@ bool JSB_cpSlideJointSetAnchr2(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 2, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpConstraint* arg0; cpVect arg1; 
+    cpConstraint* arg0 = nullptr; cpVect arg1;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     ok &= jsval_to_cpVect( cx, args.get(1), (cpVect*) &arg1 );
@@ -3601,7 +3601,7 @@ bool JSB_cpSlideJointSetMax(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 2, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpConstraint* arg0; double arg1; 
+    cpConstraint* arg0 = nullptr; double arg1 = 0;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     ok &= JS::ToNumber( cx, args.get(1), &arg1 );
@@ -3618,7 +3618,7 @@ bool JSB_cpSlideJointSetMin(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 2, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpConstraint* arg0; double arg1; 
+    cpConstraint* arg0 = nullptr; double arg1 = 0;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     ok &= JS::ToNumber( cx, args.get(1), &arg1 );
@@ -3635,7 +3635,7 @@ bool JSB_cpSpaceActivateShapesTouchingShape(JSContext *cx, uint32_t argc, jsval 
     JSB_PRECONDITION2( argc == 2, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpSpace* arg0; cpShape* arg1; 
+    cpSpace* arg0 = nullptr; cpShape* arg1 = nullptr;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     ok &= jsval_to_opaque( cx, args.get(1), (void**)&arg1 );
@@ -3652,12 +3652,12 @@ bool JSB_cpSpaceAddBody(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 2, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpSpace* arg0; cpBody* arg1; 
+    cpSpace* arg0 = nullptr; cpBody* arg1 = nullptr;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     ok &= jsval_to_opaque( cx, args.get(1), (void**)&arg1 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
-    cpBody* ret_val;
+    cpBody* ret_val = nullptr;
 
     ret_val = cpSpaceAddBody((cpSpace*)arg0 , (cpBody*)arg1  );
 
@@ -3673,12 +3673,12 @@ bool JSB_cpSpaceAddConstraint(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 2, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpSpace* arg0; cpConstraint* arg1; 
+    cpSpace* arg0 = nullptr; cpConstraint* arg1 = nullptr;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     ok &= jsval_to_opaque( cx, args.get(1), (void**)&arg1 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
-    cpConstraint* ret_val;
+    cpConstraint* ret_val = nullptr;
 
     ret_val = cpSpaceAddConstraint((cpSpace*)arg0 , (cpConstraint*)arg1  );
 
@@ -3694,12 +3694,12 @@ bool JSB_cpSpaceAddShape(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 2, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpSpace* arg0; cpShape* arg1; 
+    cpSpace* arg0 = nullptr; cpShape* arg1 = nullptr;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     ok &= jsval_to_opaque( cx, args.get(1), (void**)&arg1 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
-    cpShape* ret_val;
+    cpShape* ret_val = nullptr;
 
     ret_val = cpSpaceAddShape((cpSpace*)arg0 , (cpShape*)arg1  );
 
@@ -3715,12 +3715,12 @@ bool JSB_cpSpaceAddStaticShape(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 2, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpSpace* arg0; cpShape* arg1; 
+    cpSpace* arg0 = nullptr; cpShape* arg1 = nullptr;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     ok &= jsval_to_opaque( cx, args.get(1), (void**)&arg1 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
-    cpShape* ret_val;
+    cpShape* ret_val = nullptr;
 
     ret_val = cpSpaceAddStaticShape((cpSpace*)arg0 , (cpShape*)arg1  );
 
@@ -3736,7 +3736,7 @@ bool JSB_cpSpaceContainsBody(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 2, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpSpace* arg0; cpBody* arg1; 
+    cpSpace* arg0 = nullptr; cpBody* arg1 = nullptr;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     ok &= jsval_to_opaque( cx, args.get(1), (void**)&arg1 );
@@ -3754,7 +3754,7 @@ bool JSB_cpSpaceContainsConstraint(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 2, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpSpace* arg0; cpConstraint* arg1; 
+    cpSpace* arg0 = nullptr; cpConstraint* arg1 = nullptr;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     ok &= jsval_to_opaque( cx, args.get(1), (void**)&arg1 );
@@ -3772,7 +3772,7 @@ bool JSB_cpSpaceContainsShape(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 2, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpSpace* arg0; cpShape* arg1; 
+    cpSpace* arg0 = nullptr; cpShape* arg1 = nullptr;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     ok &= jsval_to_opaque( cx, args.get(1), (void**)&arg1 );
@@ -3790,7 +3790,7 @@ bool JSB_cpSpaceDestroy(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 1, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpSpace* arg0; 
+    cpSpace* arg0 = nullptr;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
@@ -3806,7 +3806,7 @@ bool JSB_cpSpaceFree(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 1, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpSpace* arg0; 
+    cpSpace* arg0 = nullptr;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
@@ -3822,11 +3822,11 @@ bool JSB_cpSpaceGetCollisionBias(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 1, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpSpace* arg0; 
+    cpSpace* arg0 = nullptr;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
-    cpFloat ret_val;
+    cpFloat ret_val = 0;
 
     ret_val = cpSpaceGetCollisionBias((cpSpace*)arg0  );
     args.rval().set(DOUBLE_TO_JSVAL(ret_val));
@@ -3839,11 +3839,11 @@ bool JSB_cpSpaceGetCollisionPersistence(JSContext *cx, uint32_t argc, jsval *vp)
     JSB_PRECONDITION2( argc == 1, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpSpace* arg0; 
+    cpSpace* arg0 = nullptr;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
-    cpTimestamp ret_val;
+    cpTimestamp ret_val = 0;
 
     ret_val = cpSpaceGetCollisionPersistence((cpSpace*)arg0  );
     args.rval().set(UINT_TO_JSVAL((uint32_t)ret_val));
@@ -3856,11 +3856,11 @@ bool JSB_cpSpaceGetCollisionSlop(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 1, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpSpace* arg0; 
+    cpSpace* arg0 = nullptr;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
-    cpFloat ret_val;
+    cpFloat ret_val = 0;
 
     ret_val = cpSpaceGetCollisionSlop((cpSpace*)arg0  );
     args.rval().set(DOUBLE_TO_JSVAL(ret_val));
@@ -3873,11 +3873,11 @@ bool JSB_cpSpaceGetCurrentTimeStep(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 1, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpSpace* arg0; 
+    cpSpace* arg0 = nullptr;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
-    cpFloat ret_val;
+    cpFloat ret_val = 0;
 
     ret_val = cpSpaceGetCurrentTimeStep((cpSpace*)arg0  );
     args.rval().set(DOUBLE_TO_JSVAL(ret_val));
@@ -3890,11 +3890,11 @@ bool JSB_cpSpaceGetDamping(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 1, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpSpace* arg0; 
+    cpSpace* arg0 = nullptr;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
-    cpFloat ret_val;
+    cpFloat ret_val = 0;
 
     ret_val = cpSpaceGetDamping((cpSpace*)arg0  );
     args.rval().set(DOUBLE_TO_JSVAL(ret_val));
@@ -3907,7 +3907,7 @@ bool JSB_cpSpaceGetEnableContactGraph(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 1, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpSpace* arg0; 
+    cpSpace* arg0 = nullptr;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
@@ -3924,7 +3924,7 @@ bool JSB_cpSpaceGetGravity(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 1, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpSpace* arg0; 
+    cpSpace* arg0 = nullptr;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
@@ -3944,11 +3944,11 @@ bool JSB_cpSpaceGetIdleSpeedThreshold(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 1, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpSpace* arg0; 
+    cpSpace* arg0 = nullptr;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
-    cpFloat ret_val;
+    cpFloat ret_val = 0;
 
     ret_val = cpSpaceGetIdleSpeedThreshold((cpSpace*)arg0  );
     args.rval().set(DOUBLE_TO_JSVAL(ret_val));
@@ -3961,11 +3961,11 @@ bool JSB_cpSpaceGetIterations(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 1, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpSpace* arg0; 
+    cpSpace* arg0 = nullptr;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
-    int ret_val;
+    int ret_val = 0;
 
     ret_val = cpSpaceGetIterations((cpSpace*)arg0  );
     args.rval().set(INT_TO_JSVAL((int32_t)ret_val));
@@ -3978,11 +3978,11 @@ bool JSB_cpSpaceGetSleepTimeThreshold(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 1, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpSpace* arg0; 
+    cpSpace* arg0 = nullptr;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
-    cpFloat ret_val;
+    cpFloat ret_val = 0;
 
     ret_val = cpSpaceGetSleepTimeThreshold((cpSpace*)arg0  );
     args.rval().set(DOUBLE_TO_JSVAL(ret_val));
@@ -3995,11 +3995,11 @@ bool JSB_cpSpaceGetStaticBody(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 1, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpSpace* arg0; 
+    cpSpace* arg0 = nullptr;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
-    cpBody* ret_val;
+    cpBody* ret_val = nullptr;
 
     ret_val = cpSpaceGetStaticBody((cpSpace*)arg0  );
 
@@ -4015,11 +4015,11 @@ bool JSB_cpSpaceInit(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 1, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpSpace* arg0; 
+    cpSpace* arg0 = nullptr;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
-    cpSpace* ret_val;
+    cpSpace* ret_val = nullptr;
 
     ret_val = cpSpaceInit((cpSpace*)arg0  );
 
@@ -4035,7 +4035,7 @@ bool JSB_cpSpaceIsLocked(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 1, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpSpace* arg0; 
+    cpSpace* arg0 = nullptr;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
@@ -4051,7 +4051,7 @@ bool JSB_cpSpaceIsLocked(JSContext *cx, uint32_t argc, jsval *vp) {
 bool JSB_cpSpaceNew(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 0, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
-    cpSpace* ret_val;
+    cpSpace* ret_val = nullptr;
 
     ret_val = cpSpaceNew( );
 
@@ -4067,14 +4067,14 @@ bool JSB_cpSpacePointQueryFirst(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 4, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpSpace* arg0; cpVect arg1; uint32_t arg2; cpGroup arg3; 
+    cpSpace* arg0 = nullptr; cpVect arg1; uint32_t arg2 = 0; cpGroup arg3 = 0;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     ok &= jsval_to_cpVect( cx, args.get(1), (cpVect*) &arg1 );
     ok &= jsval_to_uint32( cx, args.get(2), &arg2 );
     ok &= jsval_to_uint( cx, args.get(3), (unsigned int*) &arg3 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
-    cpShape* ret_val;
+    cpShape* ret_val = nullptr;
 
     ret_val = cpSpacePointQueryFirst((cpSpace*)arg0 , (cpVect)arg1 , (cpLayers)arg2 , (cpGroup)arg3  );
     if(ret_val) {
@@ -4093,7 +4093,7 @@ bool JSB_cpSpaceReindexShape(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 2, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpSpace* arg0; cpShape* arg1; 
+    cpSpace* arg0 = nullptr; cpShape* arg1 = nullptr;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     ok &= jsval_to_opaque( cx, args.get(1), (void**)&arg1 );
@@ -4110,7 +4110,7 @@ bool JSB_cpSpaceReindexShapesForBody(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 2, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpSpace* arg0; cpBody* arg1; 
+    cpSpace* arg0 = nullptr; cpBody* arg1 = nullptr;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     ok &= jsval_to_opaque( cx, args.get(1), (void**)&arg1 );
@@ -4127,7 +4127,7 @@ bool JSB_cpSpaceReindexStatic(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 1, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpSpace* arg0; 
+    cpSpace* arg0 = nullptr;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
@@ -4143,7 +4143,7 @@ bool JSB_cpSpaceRemoveBody(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 2, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpSpace* arg0; cpBody* arg1; 
+    cpSpace* arg0 = nullptr; cpBody* arg1 = nullptr;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     ok &= jsval_to_opaque( cx, args.get(1), (void**)&arg1 );
@@ -4160,7 +4160,7 @@ bool JSB_cpSpaceRemoveConstraint(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 2, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpSpace* arg0; cpConstraint* arg1; 
+    cpSpace* arg0 = nullptr; cpConstraint* arg1 = nullptr;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     ok &= jsval_to_opaque( cx, args.get(1), (void**)&arg1 );
@@ -4177,7 +4177,7 @@ bool JSB_cpSpaceRemoveShape(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 2, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpSpace* arg0; cpShape* arg1; 
+    cpSpace* arg0 = nullptr; cpShape* arg1 = nullptr;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     ok &= jsval_to_opaque( cx, args.get(1), (void**)&arg1 );
@@ -4194,7 +4194,7 @@ bool JSB_cpSpaceRemoveStaticShape(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 2, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpSpace* arg0; cpShape* arg1; 
+    cpSpace* arg0 = nullptr; cpShape* arg1 = nullptr;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     ok &= jsval_to_opaque( cx, args.get(1), (void**)&arg1 );
@@ -4211,7 +4211,7 @@ bool JSB_cpSpaceSetCollisionBias(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 2, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpSpace* arg0; double arg1; 
+    cpSpace* arg0 = nullptr; double arg1 = 0;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     ok &= JS::ToNumber( cx, args.get(1), &arg1 );
@@ -4228,7 +4228,7 @@ bool JSB_cpSpaceSetCollisionPersistence(JSContext *cx, uint32_t argc, jsval *vp)
     JSB_PRECONDITION2( argc == 2, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpSpace* arg0; uint32_t arg1; 
+    cpSpace* arg0 = nullptr; uint32_t arg1 = 0;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     ok &= jsval_to_uint32( cx, args.get(1), &arg1 );
@@ -4245,7 +4245,7 @@ bool JSB_cpSpaceSetCollisionSlop(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 2, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpSpace* arg0; double arg1; 
+    cpSpace* arg0 = nullptr; double arg1 = 0;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     ok &= JS::ToNumber( cx, args.get(1), &arg1 );
@@ -4262,7 +4262,7 @@ bool JSB_cpSpaceSetDamping(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 2, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpSpace* arg0; double arg1; 
+    cpSpace* arg0 = nullptr; double arg1 = 0;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     ok &= JS::ToNumber( cx, args.get(1), &arg1 );
@@ -4279,7 +4279,7 @@ bool JSB_cpSpaceSetEnableContactGraph(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 2, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpSpace* arg0; int32_t arg1; 
+    cpSpace* arg0 = nullptr; int32_t arg1 = 0;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     ok &= jsval_to_int32( cx, args.get(1), &arg1 );
@@ -4296,7 +4296,7 @@ bool JSB_cpSpaceSetGravity(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 2, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpSpace* arg0; cpVect arg1; 
+    cpSpace* arg0 = nullptr; cpVect arg1;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     ok &= jsval_to_cpVect( cx, args.get(1), (cpVect*) &arg1 );
@@ -4313,7 +4313,7 @@ bool JSB_cpSpaceSetIdleSpeedThreshold(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 2, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpSpace* arg0; double arg1; 
+    cpSpace* arg0 = nullptr; double arg1 = 0;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     ok &= JS::ToNumber( cx, args.get(1), &arg1 );
@@ -4330,7 +4330,7 @@ bool JSB_cpSpaceSetIterations(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 2, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpSpace* arg0; int32_t arg1; 
+    cpSpace* arg0 = nullptr; int32_t arg1 = 0;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     ok &= jsval_to_int32( cx, args.get(1), &arg1 );
@@ -4347,7 +4347,7 @@ bool JSB_cpSpaceSetSleepTimeThreshold(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 2, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpSpace* arg0; double arg1; 
+    cpSpace* arg0 = nullptr; double arg1 = 0;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     ok &= JS::ToNumber( cx, args.get(1), &arg1 );
@@ -4364,7 +4364,7 @@ bool JSB_cpSpaceStep(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 2, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpSpace* arg0; double arg1; 
+    cpSpace* arg0 = nullptr; double arg1 = 0;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     ok &= JS::ToNumber( cx, args.get(1), &arg1 );
@@ -4381,7 +4381,7 @@ bool JSB_cpSpaceUseSpatialHash(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 3, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpSpace* arg0; double arg1; int32_t arg2; 
+    cpSpace* arg0 = nullptr; double arg1 = 0; int32_t arg2 = 0;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     ok &= JS::ToNumber( cx, args.get(1), &arg1 );
@@ -4399,11 +4399,11 @@ bool JSB_cpfabs(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 1, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    double arg0; 
+    double arg0 = 0;
 
     ok &= JS::ToNumber( cx, args.get(0), &arg0 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
-    cpFloat ret_val;
+    cpFloat ret_val = 0;
 
     ret_val = cpfabs((cpFloat)arg0  );
     args.rval().set(DOUBLE_TO_JSVAL(ret_val));
@@ -4416,13 +4416,13 @@ bool JSB_cpfclamp(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 3, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    double arg0; double arg1; double arg2; 
+    double arg0 = 0; double arg1 = 0; double arg2 = 0;
 
     ok &= JS::ToNumber( cx, args.get(0), &arg0 );
     ok &= JS::ToNumber( cx, args.get(1), &arg1 );
     ok &= JS::ToNumber( cx, args.get(2), &arg2 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
-    cpFloat ret_val;
+    cpFloat ret_val = 0;
 
     ret_val = cpfclamp((cpFloat)arg0 , (cpFloat)arg1 , (cpFloat)arg2  );
     args.rval().set(DOUBLE_TO_JSVAL(ret_val));
@@ -4435,11 +4435,11 @@ bool JSB_cpfclamp01(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 1, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    double arg0; 
+    double arg0 = 0;
 
     ok &= JS::ToNumber( cx, args.get(0), &arg0 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
-    cpFloat ret_val;
+    cpFloat ret_val = 0;
 
     ret_val = cpfclamp01((cpFloat)arg0  );
     args.rval().set(DOUBLE_TO_JSVAL(ret_val));
@@ -4452,13 +4452,13 @@ bool JSB_cpflerp(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 3, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    double arg0; double arg1; double arg2; 
+    double arg0 = 0; double arg1 = 0; double arg2 = 0;
 
     ok &= JS::ToNumber( cx, args.get(0), &arg0 );
     ok &= JS::ToNumber( cx, args.get(1), &arg1 );
     ok &= JS::ToNumber( cx, args.get(2), &arg2 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
-    cpFloat ret_val;
+    cpFloat ret_val = 0;
 
     ret_val = cpflerp((cpFloat)arg0 , (cpFloat)arg1 , (cpFloat)arg2  );
     args.rval().set(DOUBLE_TO_JSVAL(ret_val));
@@ -4471,13 +4471,13 @@ bool JSB_cpflerpconst(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 3, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    double arg0; double arg1; double arg2; 
+    double arg0 = 0; double arg1 = 0; double arg2 = 0;
 
     ok &= JS::ToNumber( cx, args.get(0), &arg0 );
     ok &= JS::ToNumber( cx, args.get(1), &arg1 );
     ok &= JS::ToNumber( cx, args.get(2), &arg2 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
-    cpFloat ret_val;
+    cpFloat ret_val = 0;
 
     ret_val = cpflerpconst((cpFloat)arg0 , (cpFloat)arg1 , (cpFloat)arg2  );
     args.rval().set(DOUBLE_TO_JSVAL(ret_val));
@@ -4490,12 +4490,12 @@ bool JSB_cpfmax(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 2, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    double arg0; double arg1; 
+    double arg0 = 0; double arg1 = 0;
 
     ok &= JS::ToNumber( cx, args.get(0), &arg0 );
     ok &= JS::ToNumber( cx, args.get(1), &arg1 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
-    cpFloat ret_val;
+    cpFloat ret_val = 0;
 
     ret_val = cpfmax((cpFloat)arg0 , (cpFloat)arg1  );
     args.rval().set(DOUBLE_TO_JSVAL(ret_val));
@@ -4508,12 +4508,12 @@ bool JSB_cpfmin(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 2, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    double arg0; double arg1; 
+    double arg0 = 0; double arg1 = 0;
 
     ok &= JS::ToNumber( cx, args.get(0), &arg0 );
     ok &= JS::ToNumber( cx, args.get(1), &arg1 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
-    cpFloat ret_val;
+    cpFloat ret_val = 0;
 
     ret_val = cpfmin((cpFloat)arg0 , (cpFloat)arg1  );
     args.rval().set(DOUBLE_TO_JSVAL(ret_val));
@@ -4547,7 +4547,7 @@ bool JSB_cpvclamp(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 2, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpVect arg0; double arg1; 
+    cpVect arg0; double arg1 = 0;
 
     ok &= jsval_to_cpVect( cx, args.get(0), (cpVect*) &arg0 );
     ok &= JS::ToNumber( cx, args.get(1), &arg1 );
@@ -4573,7 +4573,7 @@ bool JSB_cpvcross(JSContext *cx, uint32_t argc, jsval *vp) {
     ok &= jsval_to_cpVect( cx, args.get(0), (cpVect*) &arg0 );
     ok &= jsval_to_cpVect( cx, args.get(1), (cpVect*) &arg1 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
-    cpFloat ret_val;
+    cpFloat ret_val = 0;
 
     ret_val = cpvcross((cpVect)arg0 , (cpVect)arg1  );
     args.rval().set(DOUBLE_TO_JSVAL(ret_val));
@@ -4591,7 +4591,7 @@ bool JSB_cpvdist(JSContext *cx, uint32_t argc, jsval *vp) {
     ok &= jsval_to_cpVect( cx, args.get(0), (cpVect*) &arg0 );
     ok &= jsval_to_cpVect( cx, args.get(1), (cpVect*) &arg1 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
-    cpFloat ret_val;
+    cpFloat ret_val = 0;
 
     ret_val = cpvdist((cpVect)arg0 , (cpVect)arg1  );
     args.rval().set(DOUBLE_TO_JSVAL(ret_val));
@@ -4609,7 +4609,7 @@ bool JSB_cpvdistsq(JSContext *cx, uint32_t argc, jsval *vp) {
     ok &= jsval_to_cpVect( cx, args.get(0), (cpVect*) &arg0 );
     ok &= jsval_to_cpVect( cx, args.get(1), (cpVect*) &arg1 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
-    cpFloat ret_val;
+    cpFloat ret_val = 0;
 
     ret_val = cpvdistsq((cpVect)arg0 , (cpVect)arg1  );
     args.rval().set(DOUBLE_TO_JSVAL(ret_val));
@@ -4627,7 +4627,7 @@ bool JSB_cpvdot(JSContext *cx, uint32_t argc, jsval *vp) {
     ok &= jsval_to_cpVect( cx, args.get(0), (cpVect*) &arg0 );
     ok &= jsval_to_cpVect( cx, args.get(1), (cpVect*) &arg1 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
-    cpFloat ret_val;
+    cpFloat ret_val = 0;
 
     ret_val = cpvdot((cpVect)arg0 , (cpVect)arg1  );
     args.rval().set(DOUBLE_TO_JSVAL(ret_val));
@@ -4658,7 +4658,7 @@ bool JSB_cpvforangle(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 1, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    double arg0; 
+    double arg0 = 0;
 
     ok &= JS::ToNumber( cx, args.get(0), &arg0 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
@@ -4682,7 +4682,7 @@ bool JSB_cpvlength(JSContext *cx, uint32_t argc, jsval *vp) {
 
     ok &= jsval_to_cpVect( cx, args.get(0), (cpVect*) &arg0 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
-    cpFloat ret_val;
+    cpFloat ret_val = 0;
 
     ret_val = cpvlength((cpVect)arg0  );
     args.rval().set(DOUBLE_TO_JSVAL(ret_val));
@@ -4699,7 +4699,7 @@ bool JSB_cpvlengthsq(JSContext *cx, uint32_t argc, jsval *vp) {
 
     ok &= jsval_to_cpVect( cx, args.get(0), (cpVect*) &arg0 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
-    cpFloat ret_val;
+    cpFloat ret_val = 0;
 
     ret_val = cpvlengthsq((cpVect)arg0  );
     args.rval().set(DOUBLE_TO_JSVAL(ret_val));
@@ -4712,7 +4712,7 @@ bool JSB_cpvlerp(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 3, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpVect arg0; cpVect arg1; double arg2; 
+    cpVect arg0; cpVect arg1; double arg2 = 0;
 
     ok &= jsval_to_cpVect( cx, args.get(0), (cpVect*) &arg0 );
     ok &= jsval_to_cpVect( cx, args.get(1), (cpVect*) &arg1 );
@@ -4734,7 +4734,7 @@ bool JSB_cpvlerpconst(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 3, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpVect arg0; cpVect arg1; double arg2; 
+    cpVect arg0; cpVect arg1; double arg2 = 0;
 
     ok &= jsval_to_cpVect( cx, args.get(0), (cpVect*) &arg0 );
     ok &= jsval_to_cpVect( cx, args.get(1), (cpVect*) &arg1 );
@@ -4756,7 +4756,7 @@ bool JSB_cpvmult(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 2, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpVect arg0; double arg1; 
+    cpVect arg0; double arg1 = 0;
 
     ok &= jsval_to_cpVect( cx, args.get(0), (cpVect*) &arg0 );
     ok &= JS::ToNumber( cx, args.get(1), &arg1 );
@@ -4777,7 +4777,7 @@ bool JSB_cpvnear(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 3, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpVect arg0; cpVect arg1; double arg2; 
+    cpVect arg0; cpVect arg1; double arg2 = 0;
 
     ok &= jsval_to_cpVect( cx, args.get(0), (cpVect*) &arg0 );
     ok &= jsval_to_cpVect( cx, args.get(1), (cpVect*) &arg1 );
@@ -4938,7 +4938,7 @@ bool JSB_cpvslerp(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 3, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpVect arg0; cpVect arg1; double arg2; 
+    cpVect arg0; cpVect arg1; double arg2 = 0;
 
     ok &= jsval_to_cpVect( cx, args.get(0), (cpVect*) &arg0 );
     ok &= jsval_to_cpVect( cx, args.get(1), (cpVect*) &arg1 );
@@ -4960,7 +4960,7 @@ bool JSB_cpvslerpconst(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 3, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpVect arg0; cpVect arg1; double arg2; 
+    cpVect arg0; cpVect arg1; double arg2 = 0;
 
     ok &= jsval_to_cpVect( cx, args.get(0), (cpVect*) &arg0 );
     ok &= jsval_to_cpVect( cx, args.get(1), (cpVect*) &arg1 );
@@ -5007,7 +5007,7 @@ bool JSB_cpvtoangle(JSContext *cx, uint32_t argc, jsval *vp) {
 
     ok &= jsval_to_cpVect( cx, args.get(0), (cpVect*) &arg0 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
-    cpFloat ret_val;
+    cpFloat ret_val = 0;
 
     ret_val = cpvtoangle((cpVect)arg0  );
     args.rval().set(DOUBLE_TO_JSVAL(ret_val));

--- a/cocos/scripting/js-bindings/manual/chipmunk/js_bindings_chipmunk_manual.cpp
+++ b/cocos/scripting/js-bindings/manual/chipmunk/js_bindings_chipmunk_manual.cpp
@@ -98,7 +98,7 @@ bool JSPROXY_CCPhysicsSprite_getCPBody(JSContext *cx, uint32_t argc, jsval *vp) 
     js_proxy_t *proxy = jsb_get_js_proxy(obj);
     PhysicsSprite* real = (PhysicsSprite *)(proxy ? proxy->ptr : NULL);
     TEST_NATIVE_OBJECT(cx, real)
-    cpBody* ret_val;
+    cpBody* ret_val = nullptr;
     
     ret_val = real->getCPBody();
     jsval ret_jsval = c_class_to_jsval( cx, ret_val, JS::RootedObject(cx, JSB_cpBody_object), JSB_cpBody_class, "cpBody" );
@@ -135,7 +135,7 @@ bool JSPROXY_CCPhysicsSprite_setCPBody_(JSContext *cx, uint32_t argc, jsval *vp)
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
     
-    cpBody* arg0;
+    cpBody* arg0 = nullptr;
     
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     if( ! ok ) return false;
@@ -185,7 +185,7 @@ bool JSB_CCPhysicsDebugNode_debugNodeForCPSpace__static(JSContext *cx, uint32_t 
     JSB_PRECONDITION2( argc == 1, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpSpace* arg0; 
+    cpSpace* arg0 = nullptr;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
@@ -228,7 +228,7 @@ bool JSB_CCPhysicsDebugNode_setSpace_(JSContext *cx, uint32_t argc, jsval *vp) {
     JSB_PRECONDITION2( argc == 1, cx, false, "Invalid number of arguments" );
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpSpace* arg0; 
+    cpSpace* arg0 = nullptr;
 
     ok &= jsval_to_opaque( cx, args.get(0), (void**)&arg0 );
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
@@ -343,7 +343,7 @@ bool JSPROXY_CCPhysicsSprite_spriteWithFile_rect__static(JSContext *cx, uint32_t
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
     if (argc == 2) {
-        const char* arg0;
+        const char* arg0 = nullptr;
         std::string arg0_tmp; ok &= jsval_to_std_string(cx, args.get(0), &arg0_tmp); arg0 = arg0_tmp.c_str();
         cocos2d::Rect arg1;
         ok &= jsval_to_ccrect(cx, args.get(1), &arg1);
@@ -374,7 +374,7 @@ bool JSPROXY_CCPhysicsSprite_spriteWithFile_rect__static(JSContext *cx, uint32_t
         return true;
     }
     if (argc == 1) {
-        const char* arg0;
+        const char* arg0 = nullptr;
         std::string arg0_tmp; ok &= jsval_to_std_string(cx, args.get(0), &arg0_tmp); arg0 = arg0_tmp.c_str();
         JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
         
@@ -409,7 +409,7 @@ bool JSPROXY_CCPhysicsSprite_spriteWithFile_rect__static(JSContext *cx, uint32_t
 // Ret value: PhysicsSprite* (o)
 bool JSPROXY_CCPhysicsSprite_spriteWithSpriteFrame__static(JSContext *cx, uint32_t argc, jsval *vp) {
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
-    cocos2d::SpriteFrame* arg0;
+    cocos2d::SpriteFrame* arg0 = nullptr;
     if (argc >= 1) {
         do {
             js_proxy_t *proxy;
@@ -448,7 +448,7 @@ bool JSPROXY_CCPhysicsSprite_spriteWithSpriteFrame__static(JSContext *cx, uint32
 bool JSPROXY_CCPhysicsSprite_spriteWithSpriteFrameName__static(JSContext *cx, uint32_t argc, jsval *vp) {
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    const char* arg0;
+    const char* arg0 = nullptr;
     std::string arg0_tmp;
     if (argc == 1) {
         ok &= jsval_to_std_string(cx, args.get(0), &arg0_tmp); arg0 = arg0_tmp.c_str();
@@ -613,7 +613,7 @@ bool jsval_to_cpBB( JSContext *cx, jsval vp, cpBB *ret )
     ok &= JS_GetProperty(cx, jsobj, "t", &valt);
     JSB_PRECONDITION( ok, "Error obtaining point properties");
     
-    double l, b, r, t;
+    double l = 0, b = 0, r = 0, t = 0;
     ok &= JS::ToNumber(cx, vall, &l);
     ok &= JS::ToNumber(cx, valb, &b);
     ok &= JS::ToNumber(cx, valr, &r);
@@ -656,7 +656,7 @@ bool jsval_to_array_of_cpvect( JSContext *cx, jsval vp, cpVect**verts, int *numV
     
     JSB_PRECONDITION( jsobj && JS_IsArrayObject( cx, jsobj),  "Object must be an array");
 
-    uint32_t len;
+    uint32_t len = 0;
     JS_GetArrayLength(cx, jsobj, &len);
     
     JSB_PRECONDITION( len%2==0, "Array lenght should be even");
@@ -667,7 +667,7 @@ bool jsval_to_array_of_cpvect( JSContext *cx, jsval vp, cpVect**verts, int *numV
         JS::RootedValue valarg(cx);
         JS_GetElement(cx, jsobj, i, &valarg);
 
-        double value;
+        double value = 0;
         ok = JS::ToNumber(cx, valarg, &value);
         JSB_PRECONDITION( ok, "Error converting value to nsobject");
         
@@ -703,7 +703,7 @@ bool jsval_to_cpVect( JSContext *cx, jsval vp, cpVect *ret )
     if( ! ok )
         return false;
 
-    double x, y;
+    double x = 0, y = 0;
     ok &= JS::ToNumber(cx, valx, &x);
     ok &= JS::ToNumber(cx, valy, &y);
 
@@ -717,7 +717,7 @@ bool jsval_to_cpVect( JSContext *cx, jsval vp, cpVect *ret )
 
 #else // #! JSB_COMPATIBLE_WITH_COCOS2D_HTML5_BASIC_TYPES
 
-    JSObject *tmp_arg;
+    JSObject *tmp_arg = nullptr;
     if( ! JS_ValueToObject( cx, vp, &tmp_arg ) )
         return false;
 
@@ -906,7 +906,7 @@ void JSB_cpSpace_finalize(JSFreeOp *fop, JSObject *jsthis)
         
         
         // Remove collision handlers, since the user might have forgotten to manually remove them
-        struct collision_handler *current, *tmp;
+        struct collision_handler *current = nullptr, *tmp = nullptr;
         HASH_ITER(hh, collision_handler_hash, current, tmp) {
             if( current->space == space ) {
 
@@ -945,6 +945,8 @@ static
 bool __jsb_cpSpace_addCollisionHandler(JSContext *cx, jsval *vp, jsval *argvp, cpSpace *space, unsigned int is_oo)
 {
     struct collision_handler *handler = (struct collision_handler*) malloc( sizeof(*handler) );
+    handler->typeA = 0;
+    handler->typeB = 0;
 
     JSB_PRECONDITION(handler, "Error allocating memory");
     
@@ -1021,7 +1023,7 @@ bool JSB_cpSpaceAddCollisionHandler(JSContext *cx, uint32_t argc, jsval *vp)
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
 
     // args
-    cpSpace *space;
+    cpSpace *space = nullptr;
     jsval* argvp = args.array();
     bool ok = jsval_to_opaque( cx, JS::RootedValue(cx, *argvp++), (void**)&space);
     JSB_PRECONDITION(ok, "Error parsing arguments");
@@ -1122,8 +1124,8 @@ bool __jsb_cpSpace_removeCollisionHandler(JSContext *cx, jsval *vp, jsval *argvp
 {
     bool ok = true;
     
-    cpCollisionType typeA;
-    cpCollisionType typeB;
+    cpCollisionType typeA = 0;
+    cpCollisionType typeB = 0;
     ok &= jsval_to_int(cx, JS::RootedValue(cx, *argvp++), (int32_t*) &typeA );
     ok &= jsval_to_int(cx, JS::RootedValue(cx, *argvp++), (int32_t*) &typeB );
 
@@ -1161,7 +1163,7 @@ bool JSB_cpSpaceRemoveCollisionHandler(JSContext *cx, uint32_t argc, jsval *vp)
 
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     
-    cpSpace* space;
+    cpSpace* space = nullptr;
     jsval* argvp = args.array();
     bool ok = jsval_to_opaque( cx, JS::RootedValue(cx, *argvp++), (void**)&space);
     
@@ -1196,7 +1198,7 @@ bool JSB_cpSpace_addBody(JSContext *cx, uint32_t argc, jsval *vp) {
     cpSpace* arg0 = (cpSpace*) proxy->handle;
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpBody* arg1;
+    cpBody* arg1 = nullptr;
     
     jsval retval = args.get(0); struct jsb_c_proxy_s *retproxy;
     ok &= jsval_to_c_class( cx, args.get(0), (void**)&arg1, &retproxy );
@@ -1223,7 +1225,7 @@ bool JSB_cpSpace_addConstraint(JSContext *cx, uint32_t argc, jsval *vp) {
     cpSpace* arg0 = (cpSpace*) proxy->handle;
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpConstraint* arg1;
+    cpConstraint* arg1 = nullptr;
     
     jsval retval = args.get(0); struct jsb_c_proxy_s *retproxy;
     ok &= jsval_to_c_class( cx, args.get(0), (void**)&arg1, &retproxy );
@@ -1250,7 +1252,7 @@ bool JSB_cpSpace_addShape(JSContext *cx, uint32_t argc, jsval *vp) {
     cpSpace* arg0 = (cpSpace*) proxy->handle;
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpShape* arg1;
+    cpShape* arg1 = nullptr;
 
     jsval retval = args.get(0); struct jsb_c_proxy_s *retproxy;
     ok &= jsval_to_c_class( cx, args.get(0), (void**)&arg1, &retproxy );
@@ -1277,7 +1279,7 @@ bool JSB_cpSpace_addStaticShape(JSContext *cx, uint32_t argc, jsval *vp) {
     cpSpace* arg0 = (cpSpace*) proxy->handle;
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpShape* arg1;
+    cpShape* arg1 = nullptr;
     
     jsval retval = args.get(0); struct jsb_c_proxy_s *retproxy;
     ok &= jsval_to_c_class( cx, args.get(0), (void**)&arg1, &retproxy );
@@ -1306,9 +1308,9 @@ bool JSB_cpSpace_removeBody(JSContext *cx, uint32_t argc, jsval *vp) {
     cpSpace* arg0 = (cpSpace*) proxy->handle;
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpBody* arg1;
+    cpBody* arg1 = nullptr;
     
-    struct jsb_c_proxy_s *retproxy;
+    struct jsb_c_proxy_s *retproxy = nullptr;
     ok &= jsval_to_c_class( cx, args.get(0), (void**)&arg1, &retproxy );
     JSB_PRECONDITION(ok, "Error processing arguments");
     
@@ -1329,9 +1331,9 @@ bool JSB_cpSpace_removeConstraint(JSContext *cx, uint32_t argc, jsval *vp) {
     cpSpace* arg0 = (cpSpace*) proxy->handle;
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpConstraint* arg1;
+    cpConstraint* arg1 = nullptr;
     
-    struct jsb_c_proxy_s *retproxy;
+    struct jsb_c_proxy_s *retproxy = nullptr;
     ok &= jsval_to_c_class( cx, args.get(0), (void**)&arg1, &retproxy );
     JSB_PRECONDITION(ok, "Error processing arguments");
     
@@ -1352,9 +1354,9 @@ bool JSB_cpSpace_removeShape(JSContext *cx, uint32_t argc, jsval *vp) {
     cpSpace* arg0 = (cpSpace*) proxy->handle;
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpShape* arg1;
+    cpShape* arg1 = nullptr;
     
-    struct jsb_c_proxy_s *retproxy;
+    struct jsb_c_proxy_s *retproxy = nullptr;
     ok &= jsval_to_c_class( cx, args.get(0), (void**)&arg1, &retproxy );
     JSB_PRECONDITION(ok, "Error processing arguments");
     
@@ -1375,9 +1377,9 @@ bool JSB_cpSpace_removeStaticShape(JSContext *cx, uint32_t argc, jsval *vp) {
     cpSpace* arg0 = (cpSpace*) proxy->handle;
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpShape* arg1;
+    cpShape* arg1 = nullptr;
     
-    struct jsb_c_proxy_s *retproxy;
+    struct jsb_c_proxy_s *retproxy = nullptr;
     ok &= jsval_to_c_class( cx, args.get(0), (void**)&arg1, &retproxy );
     JSB_PRECONDITION(ok, "Error processing arguments");
     
@@ -1398,8 +1400,8 @@ bool JSB_cpSpace_segmentQueryFirst(JSContext *cx, uint32_t argc, jsval *vp){
     
     cpVect start;
     cpVect end;
-    cpLayers layers;
-    cpGroup group;
+    cpLayers layers = 0;
+    cpGroup group = 0;
     bool ok = true;
     ok &= jsval_to_cpVect( cx, args.get(0), &start );
     ok &= jsval_to_cpVect( cx, args.get(1), &end );
@@ -1434,9 +1436,9 @@ bool JSB_cpSpace_nearestPointQueryNearest(JSContext *cx, uint32_t argc, jsval *v
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     
     cpVect point;
-    double maxDistance;
-    cpLayers layers;
-    cpGroup group;
+    double maxDistance = 0;
+    cpLayers layers = 0;
+    cpGroup group = 0;
     bool ok = true;
     ok &= jsval_to_cpVect( cx, args.get(0), &point );
     ok &= JS::ToNumber(cx, args.get(1), &maxDistance);
@@ -1494,8 +1496,8 @@ bool JSB_cpSpace_pointQuery(JSContext *cx, uint32_t argc, jsval *vp)
     cpSpace* space = (cpSpace*) proxy->handle;
 
     cpVect point;
-    cpLayers layers;
-    cpGroup group;
+    cpLayers layers = 0;
+    cpGroup group = 0;
 
     bool ok = jsval_to_cpVect(cx, args.get(0), &point);
     ok &= jsval_to_uint32(cx, args.get(1), &layers);
@@ -1546,9 +1548,9 @@ bool JSB_cpSpace_nearestPointQuery(JSContext *cx, uint32_t argc, jsval *vp)
     cpSpace* space = (cpSpace*) proxy->handle;
 
     cpVect point;
-    double maxDistance;
-    cpLayers layers;
-    cpGroup group;
+    double maxDistance = 0;
+    cpLayers layers = 0;
+    cpGroup group = 0;
 
     bool ok = jsval_to_cpVect(cx, args.get(0), &point);
     ok &= JS::ToNumber(cx, args.get(1), &maxDistance);
@@ -1600,8 +1602,8 @@ bool JSB_cpSpace_segmentQuery(JSContext *cx, uint32_t argc, jsval *vp)
 
     cpVect start;
     cpVect end;
-    cpLayers layers;
-    cpGroup group;
+    cpLayers layers = 0;
+    cpGroup group = 0;
 
     bool ok = jsval_to_cpVect(cx, args.get(0), &start);
     ok = jsval_to_cpVect(cx, args.get(1), &end);
@@ -1636,8 +1638,8 @@ bool JSB_cpSpace_bbQuery(JSContext *cx, uint32_t argc, jsval *vp)
     cpSpace* space = (cpSpace*) proxy->handle;
 
     cpBB bb;
-    cpLayers layers;
-    cpGroup group;
+    cpLayers layers = 0;
+    cpGroup group = 0;
 
     bool ok = jsval_to_cpBB(cx, args.get(0), &bb);
     ok &= jsval_to_uint32(cx, args.get(1), &layers);
@@ -1866,8 +1868,8 @@ bool JSB_cpBody_eachArbiter(JSContext *cx, uint32_t argc, jsval *vp)
 static
 bool __jsb_cpArbiter_getBodies(JSContext *cx, const JS::CallArgs& args, cpArbiter *arbiter, unsigned int is_oo)
 {
-    cpBody *bodyA;
-    cpBody *bodyB;
+    cpBody *bodyA = nullptr;
+    cpBody *bodyB = nullptr;
     cpArbiterGetBodies(arbiter, &bodyA, &bodyB);
     
     JS::RootedValue valA(cx);
@@ -1896,7 +1898,7 @@ bool JSB_cpArbiterGetBodies(JSContext *cx, uint32_t argc, jsval *vp)
     
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     
-    cpArbiter* arbiter;
+    cpArbiter* arbiter = nullptr;
     if( ! jsval_to_opaque( cx, args.get(0), (void**)&arbiter ) )
         return false;
 
@@ -1922,8 +1924,8 @@ bool JSB_cpArbiter_getBodies(JSContext *cx, uint32_t argc, jsval *vp)
 static
 bool __jsb_cpArbiter_getShapes(JSContext *cx, const JS::CallArgs& args, cpArbiter *arbiter, unsigned int is_oo)
 {
-    cpShape *shapeA;
-    cpShape *shapeB;
+    cpShape *shapeA = nullptr;
+    cpShape *shapeB = nullptr;
     cpArbiterGetShapes(arbiter, &shapeA, &shapeB);
 
     JS::RootedValue valA(cx);
@@ -1952,7 +1954,7 @@ bool JSB_cpArbiterGetShapes(JSContext *cx, uint32_t argc, jsval *vp)
     
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     
-    cpArbiter* arbiter;
+    cpArbiter* arbiter = nullptr;
     if( ! jsval_to_opaque( cx, args.get(0), (void**) &arbiter ) )
        return false;
 
@@ -1983,7 +1985,7 @@ bool JSB_cpBody_constructor(JSContext *cx, uint32_t argc, jsval *vp)
     JSObject *jsobj = JS_NewObject(cx, JSB_cpBody_class, JS::RootedObject(cx, JSB_cpBody_object), JS::NullPtr());
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    double m; double i;
+    double m = 0; double i = 0;
     
     ok &= JS::ToNumber( cx, args.get(0), &m );
     ok &= JS::ToNumber( cx, args.get(1), &i );
@@ -2025,7 +2027,7 @@ bool JSB_cpBodyGetUserData(JSContext *cx, uint32_t argc, jsval *vp)
     JSB_PRECONDITION2(argc==1, cx, false, "Invalid number of arguments");
 
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
-    cpBody *body;
+    cpBody *body = nullptr;
     if( ! jsval_to_opaque( cx, args.get(0), (void**) &body ) )
         return false;
 
@@ -2068,7 +2070,7 @@ bool JSB_cpBodySetUserData(JSContext *cx, uint32_t argc, jsval *vp)
     JSB_PRECONDITION2(argc==2, cx, false, "Invalid number of arguments");
 
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
-    cpBody *body;
+    cpBody *body = nullptr;
     jsval* argvp = args.array();
     bool ok = jsval_to_opaque( cx, JS::RootedValue(cx, *argvp++), (void**) &body );
     JSB_PRECONDITION(ok, "Error parsing arguments");
@@ -2096,8 +2098,8 @@ bool JSB_cpAreaForPoly(JSContext *cx, uint32_t argc, jsval *vp)
     JSB_PRECONDITION2(argc==1, cx, false, "Invalid number of arguments");
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpVect *verts;
-    int numVerts;
+    cpVect *verts = nullptr;
+    int numVerts = 0;
     
     ok &= jsval_to_array_of_cpvect( cx, args.get(0), &verts, &numVerts);
     JSB_PRECONDITION2(ok, cx, false, "Error parsing array");
@@ -2116,9 +2118,10 @@ bool JSB_cpMomentForPoly(JSContext *cx, uint32_t argc, jsval *vp)
     JSB_PRECONDITION2(argc==3, cx, false, "Invalid number of arguments");
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpVect *verts; cpVect offset;
-    int numVerts;
-    double m;
+    cpVect *verts = nullptr;
+    cpVect offset;
+    int numVerts = 0;
+    double m = 0;
     
     ok &= JS::ToNumber(cx, args.get(0), &m);
     ok &= jsval_to_array_of_cpvect( cx, args.get(1), &verts, &numVerts);
@@ -2140,8 +2143,8 @@ bool JSB_cpCentroidForPoly(JSContext *cx, uint32_t argc, jsval *vp)
     JSB_PRECONDITION2(argc==1, cx, false, "Invalid number of arguments");
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpVect *verts;
-    int numVerts;
+    cpVect *verts = nullptr;
+    int numVerts = 0;
     
     ok &= jsval_to_array_of_cpvect( cx, args.get(0), &verts, &numVerts);
     JSB_PRECONDITION2(ok, cx, false, "Error parsing args");
@@ -2223,7 +2226,7 @@ bool JSB_cpBase_setHandle(JSContext *cx, uint32_t argc, jsval *vp)
     
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     
-    void *handle;
+    void *handle = nullptr;
     bool ok = jsval_to_opaque(cx, args.get(0), &handle);
     JSB_PRECONDITION( ok, "Invalid parsing arguments");
 
@@ -2274,8 +2277,8 @@ bool JSB_cpPolyShape_constructor(JSContext *cx, uint32_t argc, jsval *vp)
     JSObject *jsobj = JS_NewObject(cx, JSB_cpPolyShape_class, JS::RootedObject(cx, JSB_cpPolyShape_object), JS::NullPtr());
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     bool ok = true;
-    cpBody* body; cpVect *verts; cpVect offset;
-    int numVerts;
+    cpBody* body = nullptr; cpVect *verts = nullptr; cpVect offset;
+    int numVerts = 0;
     
     ok &= jsval_to_c_class( cx, args.get(0), (void**)&body, NULL );
     ok &= jsval_to_array_of_cpvect( cx, args.get(1), &verts, &numVerts);


### PR DESCRIPTION
setCollisionType will create a cpCollisionType(long) type variable to store a JS unsigned int value, as it's not initialized, jsval_to_uint will only modify its low bit values, then the final result will be wrong.

There are many other variables not initialized in JSB codes, I modified all that matters in chipmunk binding codes.
