### PR TITLE
Add support for Unsigned with CCValue

### DIFF
--- a/cocos/base/CCValue.cpp
+++ b/cocos/base/CCValue.cpp
@@ -53,7 +53,7 @@ Value::Value(int v)
     _field.intVal = v;
 }
 
-Value::Value(unsigned v)
+Value::Value(unsigned int v)
 : _type(Type::UNSIGNED)
 {
     _field.unsignedVal = v;
@@ -275,7 +275,7 @@ Value& Value::operator= (int v)
     return *this;
 }
 
-Value& Value::operator= (unsigned v)
+Value& Value::operator= (unsigned int v)
 {
     reset(Type::UNSIGNED);
     _field.unsignedVal = v;
@@ -534,18 +534,18 @@ unsigned int Value::asUnsignedInt() const
     if (_type == Type::INTEGER)
     {
         CCASSERT(_field.intVal >= 0, "Only values >= 0 can be converted to unsigned");
-        return static_cast<unsigned>(_field.intVal);
+        return static_cast<unsigned int>(_field.intVal);
     }
 
     if (_type == Type::BYTE)
     {
-        return static_cast<unsigned>(_field.byteVal);
+        return static_cast<unsigned int>(_field.byteVal);
     }
 
     if (_type == Type::STRING)
     {
         // NOTE: strtoul is required (need to augment on unsupported platforms)
-        return static_cast<unsigned int>(strtoul(_field.strVal->c_str(), NULL, 10));
+        return static_cast<unsigned int>(strtoul(_field.strVal->c_str(), nullptr, 10));
     }
 
     if (_type == Type::FLOAT)

--- a/cocos/base/CCValue.cpp
+++ b/cocos/base/CCValue.cpp
@@ -53,6 +53,12 @@ Value::Value(int v)
     _field.intVal = v;
 }
 
+Value::Value(unsigned v)
+: _type(Type::UNSIGNED)
+{
+    _field.unsignedVal = v;
+}
+
 Value::Value(float v)
 : _type(Type::FLOAT)
 {
@@ -159,6 +165,9 @@ Value& Value::operator= (const Value& other)
             case Type::INTEGER:
                 _field.intVal = other._field.intVal;
                 break;
+            case Type::UNSIGNED:
+                _field.unsignedVal = other._field.unsignedVal;
+                break;
             case Type::FLOAT:
                 _field.floatVal = other._field.floatVal;
                 break;
@@ -216,6 +225,9 @@ Value& Value::operator= (Value&& other)
             case Type::INTEGER:
                 _field.intVal = other._field.intVal;
                 break;
+            case Type::UNSIGNED:
+                _field.unsignedVal = other._field.unsignedVal;
+                break;
             case Type::FLOAT:
                 _field.floatVal = other._field.floatVal;
                 break;
@@ -260,6 +272,13 @@ Value& Value::operator= (int v)
 {
     reset(Type::INTEGER);
     _field.intVal = v;
+    return *this;
+}
+
+Value& Value::operator= (unsigned v)
+{
+    reset(Type::UNSIGNED);
+    _field.unsignedVal = v;
     return *this;
 }
 
@@ -361,57 +380,58 @@ bool Value::operator== (const Value& v) const
     if (this->isNull()) return true;
     switch (_type)
     {
-    case Type::BYTE:    return v._field.byteVal   == this->_field.byteVal;
-    case Type::INTEGER: return v._field.intVal    == this->_field.intVal;
-    case Type::BOOLEAN: return v._field.boolVal   == this->_field.boolVal;
-    case Type::STRING:  return *v._field.strVal   == *this->_field.strVal;
-    case Type::FLOAT:   return fabs(v._field.floatVal  - this->_field.floatVal)  <= FLT_EPSILON;
-    case Type::DOUBLE:  return fabs(v._field.doubleVal - this->_field.doubleVal) <= FLT_EPSILON;
-    case Type::VECTOR:
-    {
-        const auto &v1 = *(this->_field.vectorVal);
-        const auto &v2 = *(v._field.vectorVal);
-        const auto size = v1.size();
-        if (size == v2.size())
+        case Type::BYTE:    return v._field.byteVal     == this->_field.byteVal;
+        case Type::INTEGER: return v._field.intVal      == this->_field.intVal;
+        case Type::UNSIGNED:return v._field.unsignedVal == this->_field.unsignedVal;
+        case Type::BOOLEAN: return v._field.boolVal     == this->_field.boolVal;
+        case Type::STRING:  return *v._field.strVal     == *this->_field.strVal;
+        case Type::FLOAT:   return fabs(v._field.floatVal  - this->_field.floatVal)  <= FLT_EPSILON;
+        case Type::DOUBLE:  return fabs(v._field.doubleVal - this->_field.doubleVal) <= FLT_EPSILON;
+        case Type::VECTOR:
         {
-            for (size_t i = 0; i < size; i++)
+            const auto &v1 = *(this->_field.vectorVal);
+            const auto &v2 = *(v._field.vectorVal);
+            const auto size = v1.size();
+            if (size == v2.size())
             {
-                if (v1[i] != v2[i]) return false;
+                for (size_t i = 0; i < size; i++)
+                {
+                    if (v1[i] != v2[i]) return false;
+                }
+                return true;
+            }
+            return false;
+        }
+        case Type::MAP:
+        {
+            const auto &map1 = *(this->_field.mapVal);
+            const auto &map2 = *(v._field.mapVal);
+            for (const auto &kvp : map1)
+            {
+                auto it = map2.find(kvp.first);
+                if (it == map2.end() || it->second != kvp.second)
+                {
+                    return false;
+                }
             }
             return true;
         }
-        return false;
-    }
-    case Type::MAP:
-    {
-        const auto &map1 = *(this->_field.mapVal);
-        const auto &map2 = *(v._field.mapVal);
-        for (const auto &kvp : map1)
+        case Type::INT_KEY_MAP:
         {
-            auto it = map2.find(kvp.first);
-            if (it == map2.end() || it->second != kvp.second)
+            const auto &map1 = *(this->_field.intKeyMapVal);
+            const auto &map2 = *(v._field.intKeyMapVal);
+            for (const auto &kvp : map1)
             {
-                return false;
+                auto it = map2.find(kvp.first);
+                if (it == map2.end() || it->second != kvp.second)
+                {
+                    return false;
+                }
             }
+            return true;
         }
-        return true;
-    }
-    case Type::INT_KEY_MAP:
-    {
-        const auto &map1 = *(this->_field.intKeyMapVal);
-        const auto &map2 = *(v._field.intKeyMapVal);
-        for (const auto &kvp : map1)
-        {
-            auto it = map2.find(kvp.first);
-            if (it == map2.end() || it->second != kvp.second)
-            {
-                return false;
-            }
-        }
-        return true;
-    }
-    default:
-        break;
+        default:
+            break;
     };
 
     return false;
@@ -430,6 +450,11 @@ unsigned char Value::asByte() const
     if (_type == Type::INTEGER)
     {
         return static_cast<unsigned char>(_field.intVal);
+    }
+
+    if (_type == Type::UNSIGNED)
+    {
+        return static_cast<unsigned char>(_field.unsignedVal);
     }
 
     if (_type == Type::STRING)
@@ -463,6 +488,12 @@ int Value::asInt() const
         return _field.intVal;
     }
 
+    if (_type == Type::UNSIGNED)
+    {
+        CCASSERT(_field.unsignedVal < INT_MAX, "Can only convert values < INT_MAX");
+        return (int)_field.unsignedVal;
+    }
+
     if (_type == Type::BYTE)
     {
         return _field.byteVal;
@@ -491,6 +522,50 @@ int Value::asInt() const
     return 0;
 }
 
+
+unsigned int Value::asUnsignedInt() const
+{
+    CCASSERT(_type != Type::VECTOR && _type != Type::MAP && _type != Type::INT_KEY_MAP, "Only base type (bool, string, float, double, int) could be converted");
+    if (_type == Type::UNSIGNED)
+    {
+        return _field.unsignedVal;
+    }
+
+    if (_type == Type::INTEGER)
+    {
+        CCASSERT(_field.intVal >= 0, "Only values >= 0 can be converted to unsigned");
+        return static_cast<unsigned>(_field.intVal);
+    }
+
+    if (_type == Type::BYTE)
+    {
+        return static_cast<unsigned>(_field.byteVal);
+    }
+
+    if (_type == Type::STRING)
+    {
+        // NOTE: strtoul is required (need to augment on unsupported platforms)
+        return static_cast<unsigned int>(strtoul(_field.strVal->c_str(), NULL, 10));
+    }
+
+    if (_type == Type::FLOAT)
+    {
+        return static_cast<unsigned int>(_field.floatVal);
+    }
+
+    if (_type == Type::DOUBLE)
+    {
+        return static_cast<unsigned int>(_field.doubleVal);
+    }
+
+    if (_type == Type::BOOLEAN)
+    {
+        return _field.boolVal ? 1u : 0u;
+    }
+
+    return 0u;
+}
+
 float Value::asFloat() const
 {
     CCASSERT(_type != Type::VECTOR && _type != Type::MAP && _type != Type::INT_KEY_MAP, "Only base type (bool, string, float, double, int) could be converted");
@@ -512,6 +587,11 @@ float Value::asFloat() const
     if (_type == Type::INTEGER)
     {
         return static_cast<float>(_field.intVal);
+    }
+
+    if (_type == Type::UNSIGNED)
+    {
+        return static_cast<float>(_field.unsignedVal);
     }
 
     if (_type == Type::DOUBLE)
@@ -550,6 +630,11 @@ double Value::asDouble() const
         return static_cast<double>(_field.intVal);
     }
 
+    if (_type == Type::UNSIGNED)
+    {
+        return static_cast<double>(_field.unsignedVal);
+    }
+
     if (_type == Type::FLOAT)
     {
         return static_cast<double>(_field.floatVal);
@@ -586,6 +671,11 @@ bool Value::asBool() const
         return _field.intVal == 0 ? false : true;
     }
 
+    if (_type == Type::UNSIGNED)
+    {
+        return _field.unsignedVal == 0 ? false : true;
+    }
+
     if (_type == Type::FLOAT)
     {
         return _field.floatVal == 0.0f ? false : true;
@@ -617,6 +707,9 @@ std::string Value::asString() const
             break;
         case Type::INTEGER:
             ret << _field.intVal;
+            break;
+        case Type::UNSIGNED:
+            ret << _field.unsignedVal;
             break;
         case Type::FLOAT:
             ret << std::fixed << std::setprecision( 7 )<< _field.floatVal;
@@ -734,6 +827,7 @@ static std::string visit(const Value& v, int depth)
         case Value::Type::NONE:
         case Value::Type::BYTE:
         case Value::Type::INTEGER:
+        case Value::Type::UNSIGNED:
         case Value::Type::FLOAT:
         case Value::Type::DOUBLE:
         case Value::Type::BOOLEAN:
@@ -775,6 +869,9 @@ void Value::clear()
         case Type::INTEGER:
             _field.intVal = 0;
             break;
+        case Type::UNSIGNED:
+            _field.unsignedVal = 0u;
+            break;
         case Type::FLOAT:
             _field.floatVal = 0.0f;
             break;
@@ -799,7 +896,7 @@ void Value::clear()
         default:
             break;
     }
-    
+
     _type = Type::NONE;
 }
 

--- a/cocos/base/CCValue.h
+++ b/cocos/base/CCValue.h
@@ -67,7 +67,7 @@ public:
     explicit Value(int v);
 
     /** Create a Value by an unsigned value. */
-    explicit Value(unsigned v);
+    explicit Value(unsigned int v);
 
     /** Create a Value by a float value. */
     explicit Value(float v);
@@ -117,7 +117,7 @@ public:
     /** Assignment operator, assign from integer to Value. */
     Value& operator= (int v);
     /** Assignment operator, assign from integer to Value. */
-    Value& operator= (unsigned v);
+    Value& operator= (unsigned int v);
     /** Assignment operator, assign from float to Value. */
     Value& operator= (float v);
     /** Assignment operator, assign from double to Value. */
@@ -158,7 +158,7 @@ public:
     /** Gets as an integer value. Will convert to integer if possible, or will trigger assert error. */
     int asInt() const;
     /** Gets as an unsigned value. Will convert to unsigned if possible, or will trigger assert error. */
-    unsigned asUnsignedInt() const;
+    unsigned int asUnsignedInt() const;
     /** Gets as a float value. Will convert to float if possible, or will trigger assert error. */
     float asFloat() const;
     /** Gets as a double value. Will convert to double if possible, or will trigger assert error. */
@@ -230,7 +230,7 @@ private:
     {
         unsigned char byteVal;
         int intVal;
-        unsigned unsignedVal;
+        unsigned int unsignedVal;
         float floatVal;
         double doubleVal;
         bool boolVal;

--- a/cocos/base/CCValue.h
+++ b/cocos/base/CCValue.h
@@ -65,7 +65,10 @@ public:
     
     /** Create a Value by an integer value. */
     explicit Value(int v);
-    
+
+    /** Create a Value by an unsigned value. */
+    explicit Value(unsigned v);
+
     /** Create a Value by a float value. */
     explicit Value(float v);
     
@@ -113,6 +116,8 @@ public:
     Value& operator= (unsigned char v);
     /** Assignment operator, assign from integer to Value. */
     Value& operator= (int v);
+    /** Assignment operator, assign from integer to Value. */
+    Value& operator= (unsigned v);
     /** Assignment operator, assign from float to Value. */
     Value& operator= (float v);
     /** Assignment operator, assign from double to Value. */
@@ -152,6 +157,8 @@ public:
     unsigned char asByte() const;
     /** Gets as an integer value. Will convert to integer if possible, or will trigger assert error. */
     int asInt() const;
+    /** Gets as an unsigned value. Will convert to unsigned if possible, or will trigger assert error. */
+    unsigned asUnsignedInt() const;
     /** Gets as a float value. Will convert to float if possible, or will trigger assert error. */
     float asFloat() const;
     /** Gets as a double value. Will convert to double if possible, or will trigger assert error. */
@@ -191,6 +198,8 @@ public:
         BYTE,
         /// wrap integer
         INTEGER,
+        /// wrap unsigned
+        UNSIGNED,
         /// wrap float
         FLOAT,
         /// wrap double
@@ -221,6 +230,7 @@ private:
     {
         unsigned char byteVal;
         int intVal;
+        unsigned unsignedVal;
         float floatVal;
         double doubleVal;
         bool boolVal;


### PR DESCRIPTION
This is meant to support getting and storing unsigned values into the Value class. The instigator of adding this is to fix a bug in TMX Tiled parser where flipped/rotated GIDs are not parsed correctly as they're larger than MAX_INT.
