### PR TITLE
individual kerning is wrong

### DIFF
--- a/cocos/2d/CCLabelTextFormatter.cpp
+++ b/cocos/2d/CCLabelTextFormatter.cpp
@@ -164,7 +164,7 @@ bool Label::multilineTextWrapByWord()
             recordLetterInfo(letterPosition, character, letterIndex, lineIndex);
 
             if (_horizontalKernings && letterIndex < textLen - 1)
-                nextLetterX += _horizontalKernings[letterIndex + 1];
+                nextLetterX += _horizontalKernings[letterIndex];
             nextLetterX += letterDef.xAdvance + _additionalKerning;
 
             wordRight = letterPosition.x + letterDef.width;
@@ -272,7 +272,7 @@ bool Label::multilineTextWrapByChar()
         recordLetterInfo(letterPosition, character, index, lineIndex);
 
         if (_horizontalKernings && index < textLen - 1)
-            nextLetterX += _horizontalKernings[index + 1];
+            nextLetterX += _horizontalKernings[index];
         nextLetterX += letterDef.xAdvance + _additionalKerning;
 
         letterRight = letterPosition.x + letterDef.width;


### PR DESCRIPTION
`_horizontalKernings[index]` contains the amount of kerning between the letter at index and the next letter, so adding 1 to index is wrong
