### PR TITLE
Add a feature of jumping to a specific item in list tview

### DIFF
--- a/cocos/ui/UILayout.h
+++ b/cocos/ui/UILayout.h
@@ -401,7 +401,7 @@ public:
     /**
      * request to refresh widget layout
      */
-    void requestDoLayout();
+    virtual void requestDoLayout();
     
     /**
      * @lua NA

--- a/cocos/ui/UIListView.cpp
+++ b/cocos/ui/UIListView.cpp
@@ -40,6 +40,7 @@ _magneticType(MagneticType::NONE),
 _magneticAllowedOutOfBoundary(true),
 _itemsMargin(0.0f),
 _curSelectedIndex(-1),
+_innerContainerDoLayoutDirty(true),
 _listViewEventListener(nullptr),
 _listViewEventSelector(nullptr),
 _eventCallback(nullptr)
@@ -459,9 +460,14 @@ void ListView::refreshView()
     forceDoLayout();
 }
 
+void ListView::requestDoLayout()
+{
+    _innerContainerDoLayoutDirty = true;
+}
+
 void ListView::doLayout()
 {
-    if(!_doLayoutDirty)
+    if(!_innerContainerDoLayoutDirty)
     {
         return;
     }
@@ -475,7 +481,7 @@ void ListView::doLayout()
     }
     _innerContainer->forceDoLayout();
     updateInnerContainerSize();
-    _doLayoutDirty = false;
+    _innerContainerDoLayoutDirty = false;
 }
     
 void ListView::addEventListenerListView(Ref *target, SEL_ListViewEvent selector)

--- a/cocos/ui/UIListView.cpp
+++ b/cocos/ui/UIListView.cpp
@@ -40,7 +40,6 @@ _magneticType(MagneticType::NONE),
 _magneticAllowedOutOfBoundary(true),
 _itemsMargin(0.0f),
 _curSelectedIndex(-1),
-_refreshViewDirty(true),
 _listViewEventListener(nullptr),
 _listViewEventSelector(nullptr),
 _eventCallback(nullptr)
@@ -235,7 +234,7 @@ void ListView::pushBackDefaultItem()
     Widget* newItem = _model->clone();
     remedyLayoutParameter(newItem);
     addChild(newItem);
-    _refreshViewDirty = true;
+    requestDoLayout();
 }
 
 void ListView::insertDefaultItem(ssize_t index)
@@ -252,7 +251,7 @@ void ListView::pushBackCustomItem(Widget* item)
 {
     remedyLayoutParameter(item);
     addChild(item);
-    _refreshViewDirty = true;
+    requestDoLayout();
 }
     
 void ListView::addChild(cocos2d::Node *child, int zOrder, int tag)
@@ -341,7 +340,7 @@ void ListView::insertCustomItem(Widget* item, ssize_t index)
     ScrollView::addChild(item);
 
     remedyLayoutParameter(item);
-    _refreshViewDirty = true;
+    requestDoLayout();
 }
 
 void ListView::removeItem(ssize_t index)
@@ -352,7 +351,7 @@ void ListView::removeItem(ssize_t index)
         return;
     }
     removeChild(item, true);
-    _refreshViewDirty = true;
+    requestDoLayout();
 }
 
 void ListView::removeLastItem()
@@ -395,7 +394,7 @@ void ListView::setGravity(Gravity gravity)
         return;
     }
     _gravity = gravity;
-    _refreshViewDirty = true;
+    requestDoLayout();
 }
 
 void ListView::setMagneticType(MagneticType magneticType)
@@ -427,7 +426,7 @@ void ListView::setItemsMargin(float margin)
         return;
     }
     _itemsMargin = margin;
-    _refreshViewDirty = true;
+    requestDoLayout();
 }
     
 float ListView::getItemsMargin()const
@@ -455,15 +454,20 @@ void ListView::setDirection(Direction dir)
     ScrollView::setDirection(dir);
 }
     
-void ListView::requestRefreshView()
-{
-    _refreshViewDirty = true;
-}
-
 void ListView::refreshView()
 {
+    forceDoLayout();
+}
+
+void ListView::doLayout()
+{
+    if(!_doLayoutDirty)
+    {
+        return;
+    }
+
     ssize_t length = _items.size();
-    for (int i=0; i<length; i++)
+    for (int i = 0; i < length; ++i)
     {
         Widget* item = _items.at(i);
         item->setLocalZOrder(i);
@@ -471,27 +475,7 @@ void ListView::refreshView()
     }
     _innerContainer->forceDoLayout();
     updateInnerContainerSize();
-    _refreshViewDirty = false;
-}
-
-void ListView::refreshViewIfNecessary()
-{
-    if (_refreshViewDirty)
-    {
-        refreshView();
-    }
-}
-    
-void ListView::forceDoLayout()
-{
-    refreshViewIfNecessary();
-    this->_innerContainer->forceDoLayout();
-}
-
-void ListView::doLayout()
-{
-    Layout::doLayout();
-    refreshViewIfNecessary();
+    _doLayoutDirty = false;
 }
     
 void ListView::addEventListenerListView(Ref *target, SEL_ListViewEvent selector)
@@ -684,67 +668,67 @@ Widget* ListView::getBottommostItemInCurrentView() const
 
 void ListView::jumpToBottom()
 {
-    refreshViewIfNecessary();
+    doLayout();
     ScrollView::jumpToBottom();
 }
 
 void ListView::jumpToTop()
 {
-    refreshViewIfNecessary();
+    doLayout();
     ScrollView::jumpToTop();
 }
 
 void ListView::jumpToLeft()
 {
-    refreshViewIfNecessary();
+    doLayout();
     ScrollView::jumpToLeft();
 }
 
 void ListView::jumpToRight()
 {
-    refreshViewIfNecessary();
+    doLayout();
     ScrollView::jumpToRight();
 }
 
 void ListView::jumpToTopLeft()
 {
-    refreshViewIfNecessary();
+    doLayout();
     ScrollView::jumpToTopLeft();
 }
 
 void ListView::jumpToTopRight()
 {
-    refreshViewIfNecessary();
+    doLayout();
     ScrollView::jumpToTopRight();
 }
 
 void ListView::jumpToBottomLeft()
 {
-    refreshViewIfNecessary();
+    doLayout();
     ScrollView::jumpToBottomLeft();
 }
 
 void ListView::jumpToBottomRight()
 {
-    refreshViewIfNecessary();
+    doLayout();
     ScrollView::jumpToBottomRight();
 }
 
 void ListView::jumpToPercentVertical(float percent)
 {
-    refreshViewIfNecessary();
+    doLayout();
     ScrollView::jumpToPercentVertical(percent);
 }
 
 void ListView::jumpToPercentHorizontal(float percent)
 {
-    refreshViewIfNecessary();
+    doLayout();
     ScrollView::jumpToPercentHorizontal(percent);
 }
 
 void ListView::jumpToPercentBothDirection(const Vec2& percent)
 {
-    refreshViewIfNecessary();
+    doLayout();
     ScrollView::jumpToPercentBothDirection(percent);
 }
 
@@ -765,7 +749,7 @@ void ListView::jumpToItem(int itemIndex, const Vec2& positionRatioInView, const 
     {
         return;
     }
-    refreshViewIfNecessary();
+    doLayout();
 
     Vec2 destination = calculateItemDestination(getContentSize(), item, positionRatioInView, itemAnchorPoint);
     destination = flattenVectorByDirection(destination);
@@ -799,7 +783,7 @@ ssize_t ListView::getCurSelectedIndex() const
 void ListView::onSizeChanged()
 {
     ScrollView::onSizeChanged();
-    _refreshViewDirty = true;
+    requestDoLayout();
 }
 
 std::string ListView::getDescription() const

--- a/cocos/ui/UIListView.h
+++ b/cocos/ui/UIListView.h
@@ -247,6 +247,7 @@ public:
     
     //override methods
     virtual void doLayout() override;
+    virtual void requestDoLayout() override;
     virtual void addChild(Node* child)override;
     virtual void addChild(Node * child, int localZOrder)override;
     virtual void addChild(Node* child, int zOrder, int tag) override;
@@ -254,7 +255,7 @@ public:
     virtual void removeAllChildren() override;
     virtual void removeAllChildrenWithCleanup(bool cleanup) override;
     virtual void removeChild(Node* child, bool cleaup = true) override;
-    
+
 	/**
 	 * @brief Query the closest item to a specific position in inner container.
 	 *
@@ -418,6 +419,8 @@ protected:
     float _itemsMargin;
     
     ssize_t _curSelectedIndex;
+
+    bool _innerContainerDoLayoutDirty;
     
     Ref*       _listViewEventListener;
 #if defined(__GNUC__) && ((__GNUC__ >= 4) || ((__GNUC__ == 3) && (__GNUC_MINOR__ >= 1)))

--- a/cocos/ui/UIListView.h
+++ b/cocos/ui/UIListView.h
@@ -246,7 +246,6 @@ public:
     float getItemsMargin()const;
     
     //override methods
-    virtual void forceDoLayout()override;
     virtual void doLayout() override;
     virtual void addChild(Node* child)override;
     virtual void addChild(Node * child, int localZOrder)override;
@@ -371,16 +370,16 @@ public:
     
     /**
      * @brief Refresh view and layout of ListView manually.
-     * This method will mark ListView content as dirty and the content view will be refershed in the next frame.
+     * This method will mark ListView content as dirty and the content view will be refreshed in the next frame.
+     * @deprecated Use method requestDoLayout() instead
      */
-    void requestRefreshView();
+    CC_DEPRECATED_ATTRIBUTE void requestRefreshView();
 
-    
     /**
      * @brief Refresh content view of ListView.
+     * @deprecated Use method forceDoLayout() instead
      */
-    void refreshView();
-    void refreshViewIfNecessary();
+    CC_DEPRECATED_ATTRIBUTE void refreshView();
 
 CC_CONSTRUCTOR_ACCESS:
     virtual bool init() override;
@@ -419,7 +418,6 @@ protected:
     float _itemsMargin;
     
     ssize_t _curSelectedIndex;
-    bool _refreshViewDirty;
     
     Ref*       _listViewEventListener;
 #if defined(__GNUC__) && ((__GNUC__ >= 4) || ((__GNUC__ == 3) && (__GNUC_MINOR__ >= 1)))

--- a/cocos/ui/UIListView.h
+++ b/cocos/ui/UIListView.h
@@ -320,6 +320,13 @@ public:
     virtual void jumpToPercentHorizontal(float percent) override;
     virtual void jumpToPercentBothDirection(const Vec2& percent) override;
 
+    /**
+     * @brief Jump to specific item
+     * @param positionRatioInView Specifies the position with ratio in list view's content size.
+     * @param itemAnchorPoint Specifies an anchor point of each item for position to calculate distance.
+     */
+    void jumpToItem(int itemIndex, const Vec2& positionRatioInView, const Vec2& itemAnchorPoint);
+    
 	/**
 	 * @brief Scroll to specific item
 	 * @param positionRatioInView Specifies the position with ratio in list view's content size.

--- a/cocos/ui/UIListView.h
+++ b/cocos/ui/UIListView.h
@@ -322,6 +322,7 @@ public:
 
     /**
      * @brief Jump to specific item
+     * @param itemIndex Specifies the item's index
      * @param positionRatioInView Specifies the position with ratio in list view's content size.
      * @param itemAnchorPoint Specifies an anchor point of each item for position to calculate distance.
      */


### PR DESCRIPTION
- Add `jumpToItem()` to list view.
- Refactor the layout related methods of list view to comply with `Layout`'s practice like `Layout::doLayout()`.
  - `requestDoLayout()` and `doLayout()` are overridden and have to use another dirty flag for list view layout other than `Layout::_doLayoutDirty` because `Layout::onEnter()` forces `_doLayoutDirty` to be true always. But, list view should have a way not to do layout in `onEnter()`.
