### PR TITLE
fix bug: ReEntry a same frameindex after scaled action's speed.

### DIFF
--- a/cocos/editor-support/cocostudio/ActionTimeline/CCActionTimeline.cpp
+++ b/cocos/editor-support/cocostudio/ActionTimeline/CCActionTimeline.cpp
@@ -197,10 +197,12 @@ void ActionTimeline::step(float delta)
     {
         return;
     }
-
     _time += delta * _timeSpeed;
-    const float endtoffset = _time - _endFrame * _frameInternal;
+    float deltaCurrFrameTime = abs(_time - _currentFrame * _frameInternal);
+    if (deltaCurrFrameTime < _frameInternal)
+        return;
 
+    const float endtoffset = _time - _endFrame * _frameInternal;
     if (endtoffset < _frameInternal)
     {
         _currentFrame = (int)(_time / _frameInternal);


### PR DESCRIPTION
fix bug:  fix ReEntry a same frameindex when scale action's speed.
