### PR TITLE
导出：CCArmatureDataManager::[.*AnimationData .*ArmatureData]接口到js

### DIFF
--- a/extensions/CocoStudio/Armature/utils/CCDataReaderHelper.cpp
+++ b/extensions/CocoStudio/Armature/utils/CCDataReaderHelper.cpp
@@ -153,7 +153,7 @@ NS_CC_EXT_BEGIN
 
 float s_PositionReadScale = 1;
 
-std::vector<LoadCfgNode> CCDataReaderHelper::s_arrConfigFileList;
+std::vector<FileInfo> CCDataReaderHelper::s_arrConfigFileList;
 CCDataReaderHelper *CCDataReaderHelper::s_DataReaderHelper = NULL;
 
 enum ConfigType
@@ -191,11 +191,11 @@ typedef struct _DataInfo
     float cocoStudioVersion;
 } DataInfo;
 
-typedef struct _LoadCfgNode
+typedef struct _FileInfo
 {
 	std::string filename; 
 	bool loaded;
-} LoadCfgNode;
+} FileInfo;
 
 
 static pthread_t s_loadingThread;
@@ -383,10 +383,10 @@ void CCDataReaderHelper::addDataFromFile(const char *filePath)
     }
 
 	std::string basefilePath = filePath;
-	LoadCfgNode node;
-	node.filename = basefilePath;
-	node.loaded = true;
-	s_arrConfigFileList.push_back(node);
+	FileInfo loadFileInfo;
+	loadFileInfo.filename = basefilePath;
+	loadFileInfo.loaded = true;
+	s_arrConfigFileList.push_back(loadFileInfo);
 
     //! find the base file path
     size_t pos = basefilePath.find_last_of("/");
@@ -470,10 +470,10 @@ void CCDataReaderHelper::addDataFromFileAsync(const char *imagePath, const char 
     }
 
 	std::string basefilePath = filePath;
-	LoadCfgNode node;
-	node.filename = basefilePath;
-	node.loaded = false;
-	s_arrConfigFileList.push_back(node);
+	FileInfo loadFileInfo;
+	loadFileInfo.filename = basefilePath;
+	loadFileInfo.loaded = false;
+	s_arrConfigFileList.push_back(loadFileInfo);
 
     //! find the base file path
     size_t pos = basefilePath.find_last_of("/");
@@ -633,8 +633,8 @@ void CCDataReaderHelper::addDataAsyncCallBack(float dt)
 
 void CCDataReaderHelper::removeConfigFile(const char *configFile)
 {
-    std::vector<LoadCfgNode>::iterator it = s_arrConfigFileList.end();
-	for (std::vector<LoadCfgNode>::iterator i = s_arrConfigFileList.begin(); i != s_arrConfigFileList.end(); i++)
+    std::vector<FileInfo>::iterator it = s_arrConfigFileList.end();
+	for (std::vector<FileInfo>::iterator i = s_arrConfigFileList.begin(); i != s_arrConfigFileList.end(); i++)
     {
         if (i->filename.compare(configFile) == 0)
         {

--- a/extensions/CocoStudio/Armature/utils/CCDataReaderHelper.h
+++ b/extensions/CocoStudio/Armature/utils/CCDataReaderHelper.h
@@ -41,6 +41,8 @@ namespace tinyxml2
 NS_CC_EXT_BEGIN
 
 typedef struct _DataInfo DataInfo;
+typedef struct _LoadCfgNode  LoadCfgNode;
+
 /**
 *   @js NA
 *   @lua NA
@@ -143,7 +145,7 @@ public:
     static void decodeNode(CCBaseData *node, CocoLoader *pCocoLoader, stExpCocoNode *pCocoNode, DataInfo *dataInfo);
 
 private:
-    static std::vector<std::string> s_arrConfigFileList;
+	static std::vector<LoadCfgNode> s_arrConfigFileList;
 
     static CCDataReaderHelper *s_DataReaderHelper;
 };

--- a/extensions/CocoStudio/Armature/utils/CCDataReaderHelper.h
+++ b/extensions/CocoStudio/Armature/utils/CCDataReaderHelper.h
@@ -41,7 +41,7 @@ namespace tinyxml2
 NS_CC_EXT_BEGIN
 
 typedef struct _DataInfo DataInfo;
-typedef struct _LoadCfgNode  LoadCfgNode;
+typedef struct _FileInfo FileInfo;
 
 /**
 *   @js NA
@@ -145,7 +145,7 @@ public:
     static void decodeNode(CCBaseData *node, CocoLoader *pCocoLoader, stExpCocoNode *pCocoNode, DataInfo *dataInfo);
 
 private:
-	static std::vector<LoadCfgNode> s_arrConfigFileList;
+	static std::vector<FileInfo> s_arrConfigFileList;
 
     static CCDataReaderHelper *s_DataReaderHelper;
 };


### PR DESCRIPTION
修复: android异步文件读取引发崩溃的问题.
