### PR TITLE
fix the layer touch recover,  using the Scene:

### DIFF
--- a/extensions/CocoStudio/GUI/System/UITouchGroup.cpp
+++ b/extensions/CocoStudio/GUI/System/UITouchGroup.cpp
@@ -30,7 +30,8 @@ NS_CC_BEGIN
 namespace ui {
 
 TouchGroup::TouchGroup():
-m_pRootWidget(NULL)
+m_pRootWidget(NULL),
+m_bTouchEnabledExit(true)
 {
 }
 
@@ -50,6 +51,7 @@ bool TouchGroup::init()
         m_pRootWidget = Widget::create();
         m_pRootWidget->retain();
         addChild(m_pRootWidget);
+        setTouchEnabled(true);
         return true;
     }
     return false;
@@ -73,14 +75,23 @@ TouchGroup* TouchGroup::create(void)
 void TouchGroup::onEnter()
 {
     setTouchMode(kCCTouchesOneByOne);
-    setTouchEnabled(true);
+    bool isTouchGroupTouch = this->m_bTouchEnabledExit;
+    setTouchEnabled(isTouchGroupTouch);
     CCLayer::onEnter();
 }
 
 void TouchGroup::onExit()
 {
+    bool isTouchGroupTouch = isTouchEnabled();
     setTouchEnabled(false);
+    this->m_bTouchEnabledExit = isTouchGroupTouch;
     CCLayer::onExit();
+}
+
+void TouchGroup::setTouchEnabled(bool enabled)
+{
+    this->m_bTouchEnabledExit = enabled;
+    CCLayer::setTouchEnabled(enabled);
 }
 
 void TouchGroup::onEnterTransitionDidFinish()

--- a/extensions/CocoStudio/GUI/System/UITouchGroup.h
+++ b/extensions/CocoStudio/GUI/System/UITouchGroup.h
@@ -114,6 +114,7 @@ public:
 protected:
     bool checkEventWidget(CCTouch* touch, CCEvent *pEvent);
     bool checkTouchEvent(Widget* root, CCTouch* touch, CCEvent* pEvent);
+	void setTouchEnabled(bool enabled);
 protected:
     Widget* m_pRootWidget;
     CCPoint touchBeganedPoint;
@@ -121,6 +122,7 @@ protected:
     CCPoint touchEndedPoint;
     CCPoint touchCanceledPoint;
     CCArray* m_pSelectedWidgets;
+	bool m_bTouchEnabledExit;
 };
     
 }


### PR DESCRIPTION
add layer XX into the scene. and setTouchEnabled false, then, remove XX from the scene,but not release. at last , add XX into scene again, it will setTouchEnable true. So, this is a bug, the layer add into scene again, the touch state need to same with  it onExit
