### PR TITLE
Textfiled support cursor v1.1

### DIFF
--- a/cocos/2d/CCLabel.cpp
+++ b/cocos/2d/CCLabel.cpp
@@ -1497,7 +1497,7 @@ void Label::computeStringNumLines()
     size_t stringLen = _utf16Text.length();
     for (size_t i = 0; i < stringLen - 1; ++i)
     {
-        if (_utf16Text[i] == '\n')
+        if (_utf16Text[i] == (char16_t)TextFormatter::NewLine)
         {
             quantityOfLines++;
         }

--- a/cocos/2d/CCLabel.h
+++ b/cocos/2d/CCLabel.h
@@ -71,6 +71,13 @@ typedef struct _ttfConfig
     }
 }TTFConfig;
 
+enum class TextFormatter : char
+{
+    NewLine = '\n',
+    CarriageReturn = '\r',
+    NextCharNoChangeX = '\b'
+};
+
 class Sprite;
 class SpriteBatchNode;
 class DrawNode;

--- a/cocos/2d/CCLabelTextFormatter.cpp
+++ b/cocos/2d/CCLabelTextFormatter.cpp
@@ -74,7 +74,7 @@ void Label::computeAlignmentOffset()
 static int getFirstWordLen(const std::u16string& utf16Text, int startIndex, int textLen)
 {
     auto character = utf16Text[startIndex];
-    if (StringUtils::isCJKUnicode(character) || StringUtils::isUnicodeSpace(character) || character == '\n')
+    if (StringUtils::isCJKUnicode(character) || StringUtils::isUnicodeSpace(character) || character == (char16_t)TextFormatter::NewLine)
     {
         return 1;
     }
@@ -83,7 +83,7 @@ static int getFirstWordLen(const std::u16string& utf16Text, int startIndex, int 
     for (int index = startIndex + 1; index < textLen; ++index)
     {
         character = utf16Text[index];
-        if (character == '\n' || StringUtils::isUnicodeSpace(character) || StringUtils::isCJKUnicode(character))
+        if (character == (char16_t)TextFormatter::NewLine || StringUtils::isUnicodeSpace(character) || StringUtils::isCJKUnicode(character))
         {
             break;
         }
@@ -107,11 +107,12 @@ bool Label::multilineTextWrapByWord()
     float lowestY = 0.f;
     FontLetterDefinition letterDef;
     Vec2 letterPosition;
+    bool nextChangeSize = true;
     
     for (int index = 0; index < textLen; )
     {
         auto character = _utf16Text[index];
-        if (character == '\n')
+        if (character == (char16_t)TextFormatter::NewLine)
         {
             _linesWidth.push_back(letterRight);
             letterRight = 0.f;
@@ -133,8 +134,15 @@ bool Label::multilineTextWrapByWord()
         {
             int letterIndex = index + tmp;
             character = _utf16Text[letterIndex];
-            if (character == '\r')
+            if (character == (char16_t)TextFormatter::CarriageReturn)
             {
+                recordPlaceholderInfo(letterIndex, character);
+                continue;
+            }
+            // \b - Next char not change x position
+            if (character == (char16_t)TextFormatter::NextCharNoChangeX)
+            {
+                nextChangeSize = false;
                 recordPlaceholderInfo(letterIndex, character);
                 continue;
             }
@@ -146,7 +154,7 @@ bool Label::multilineTextWrapByWord()
             }
 
             auto letterX = (nextLetterX + letterDef.offsetX) / contentScaleFactor;
-            if (_maxLineWidth > 0.f && nextWordX > 0.f && letterX + letterDef.width > _maxLineWidth)
+            if (_maxLineWidth > 0.f && nextWordX > 0.f && letterX + letterDef.width > _maxLineWidth && nextChangeSize)
             {
                 _linesWidth.push_back(letterRight);
                 letterRight = 0.f;
@@ -163,11 +171,15 @@ bool Label::multilineTextWrapByWord()
             letterPosition.y = (nextWordY - letterDef.offsetY) / contentScaleFactor;
             recordLetterInfo(letterPosition, character, letterIndex, lineIndex);
 
-            if (_horizontalKernings && letterIndex < textLen - 1)
-                nextLetterX += _horizontalKernings[letterIndex + 1];
-            nextLetterX += letterDef.xAdvance + _additionalKerning;
+            if (nextChangeSize)
+            {
+                if (_horizontalKernings && letterIndex < textLen - 1)
+                    nextLetterX += _horizontalKernings[letterIndex + 1];
+                nextLetterX += letterDef.xAdvance + _additionalKerning;
 
-            wordRight = letterPosition.x + letterDef.width;
+                wordRight = letterPosition.x + letterDef.width;
+            }
+            nextChangeSize = true;
 
             if (wordHighestY < letterPosition.y)
                 wordHighestY = letterPosition.y;
@@ -227,22 +239,30 @@ bool Label::multilineTextWrapByChar()
     float lowestY = 0.f;
     FontLetterDefinition letterDef;
     Vec2 letterPosition;
+    bool nextChangeSize = true;
 
     for (int index = 0; index < textLen; index++)
     {
         auto character = _utf16Text[index];
-        if (character == '\r')
+        if (character == (char16_t)TextFormatter::CarriageReturn)
         {
             recordPlaceholderInfo(index, character);
             continue;
         }
-        if (character == '\n')
+        if (character == (char16_t)TextFormatter::NewLine)
         {
             _linesWidth.push_back(letterRight);
             letterRight = 0.f;
             lineIndex++;
             nextLetterX = 0.f;
             nextLetterY -= _lineHeight;
+            recordPlaceholderInfo(index, character);
+            continue;
+        }
+        // \b - Next char not change x position
+        if (character == (char16_t)TextFormatter::NextCharNoChangeX)
+        {
+            nextChangeSize = false;
             recordPlaceholderInfo(index, character);
             continue;
         }
@@ -255,7 +275,7 @@ bool Label::multilineTextWrapByChar()
         }
 
         auto letterX = (nextLetterX + letterDef.offsetX) / contentScaleFactor;
-        if (_maxLineWidth > 0.f && nextLetterX > 0.f && letterX + letterDef.width > _maxLineWidth)
+        if (_maxLineWidth > 0.f && nextLetterX > 0.f && letterX + letterDef.width > _maxLineWidth && nextChangeSize)
         {
             _linesWidth.push_back(letterRight);
             letterRight = 0.f;
@@ -271,11 +291,15 @@ bool Label::multilineTextWrapByChar()
         letterPosition.y = (nextLetterY - letterDef.offsetY) / contentScaleFactor;
         recordLetterInfo(letterPosition, character, index, lineIndex);
 
-        if (_horizontalKernings && index < textLen - 1)
-            nextLetterX += _horizontalKernings[index + 1];
-        nextLetterX += letterDef.xAdvance + _additionalKerning;
+        if (nextChangeSize)
+        {
+            if (_horizontalKernings && index < textLen - 1)
+                nextLetterX += _horizontalKernings[index + 1];
+            nextLetterX += letterDef.xAdvance + _additionalKerning;
 
-        letterRight = letterPosition.x + letterDef.width;
+            letterRight = letterPosition.x + letterDef.width;
+        }
+        nextChangeSize = true;
 
         if (highestY < letterPosition.y)
             highestY = letterPosition.y;

--- a/cocos/2d/CCTextFieldTTF.cpp
+++ b/cocos/2d/CCTextFieldTTF.cpp
@@ -26,6 +26,7 @@ THE SOFTWARE.
 #include "2d/CCTextFieldTTF.h"
 
 #include "base/CCDirector.h"
+#include "platform/CCFileUtils.h"
 
 NS_CC_BEGIN
 
@@ -108,21 +109,33 @@ TextFieldTTF * TextFieldTTF::textFieldWithPlaceHolder(const std::string& placeho
 
 bool TextFieldTTF::initWithPlaceHolder(const std::string& placeholder, const Size& dimensions, TextHAlignment alignment, const std::string& fontName, float fontSize)
 {
-    _placeHolder = placeholder;
-    setDimensions(dimensions.width,dimensions.height);
-    setSystemFontName(fontName);
-    setSystemFontSize(fontSize);
-    setAlignment(alignment,TextVAlignment::CENTER);
-    Label::setTextColor(_colorSpaceHolder);
-    Label::setString(_placeHolder);
+    setDimensions(dimensions.width, dimensions.height);
+    setAlignment(alignment, TextVAlignment::CENTER);
 
-    return true;
+    return initWithPlaceHolder(placeholder, fontName, fontSize);
 }
 bool TextFieldTTF::initWithPlaceHolder(const std::string& placeholder, const std::string& fontName, float fontSize)
 {
-    _placeHolder = std::string(placeholder);
-    setSystemFontName(fontName);
-    setSystemFontSize(fontSize);
+    _placeHolder = placeholder;
+
+    do 
+    {
+        // If fontName is ttf file and it corrected, use TTFConfig
+        if (FileUtils::getInstance()->isFileExist(fontName))
+        {
+            TTFConfig ttfConfig(fontName.c_str(), fontSize, GlyphCollection::DYNAMIC);
+            if (setTTFConfig(ttfConfig))
+            {
+                break;
+            }
+        }
+
+        setSystemFontName(fontName);
+        setSystemFontSize(fontSize);
+
+    } while (false);
+
+
     Label::setTextColor(_colorSpaceHolder);
     Label::setString(_placeHolder);
 

--- a/cocos/2d/CCTextFieldTTF.cpp
+++ b/cocos/2d/CCTextFieldTTF.cpp
@@ -27,8 +27,13 @@ THE SOFTWARE.
 
 #include "base/CCDirector.h"
 #include "platform/CCFileUtils.h"
+#include "base/ccUTF8.h"
+#include "2d/CCSprite.h"
 
 NS_CC_BEGIN
+
+#define CURSOR_TIME_SHOW_HIDE 0.5f
+#define CURSOR_DEFAULT_CHAR '|'
 
 static int _calcCharCount(const char * text)
 {
@@ -58,6 +63,11 @@ TextFieldTTF::TextFieldTTF()
 , _placeHolder("")   // prevent Label initWithString assertion
 , _colorText(Color4B::WHITE)
 , _secureTextEntry(false)
+, _cursorUse(false)
+, _cursorPosition(0)
+, _cursorChar(CURSOR_DEFAULT_CHAR)
+, _cursorShowingTime(0.0f)
+, _isAttachWithIME(false)
 {
     _colorSpaceHolder.r = _colorSpaceHolder.g = _colorSpaceHolder.b = 127;
     _colorSpaceHolder.a = 255;
@@ -139,6 +149,14 @@ bool TextFieldTTF::initWithPlaceHolder(const std::string& placeholder, const std
     Label::setTextColor(_colorSpaceHolder);
     Label::setString(_placeHolder);
 
+#if (CC_TARGET_PLATFORM == CC_PLATFORM_MAC || CC_TARGET_PLATFORM == CC_PLATFORM_WIN32 || CC_TARGET_PLATFORM == CC_PLATFORM_LINUX)
+    // On desktop default enable cursor
+    if (_currentLabelType == LabelType::TTF)
+    {
+        setCursorUse(true);
+    }
+#endif
+
     return true;
 }
 
@@ -176,6 +194,16 @@ bool TextFieldTTF::detachWithIME()
     return ret;
 }
 
+void TextFieldTTF::didAttachWithIME()
+{
+    setAttachWithIME(true);
+}
+
+void TextFieldTTF::didDetachWithIME()
+{
+    setAttachWithIME(false);
+}
+
 bool TextFieldTTF::canAttachWithIME()
 {
     return (_delegate) ? (! _delegate->onTextFieldAttachWithIME(this)) : true;
@@ -191,7 +219,7 @@ void TextFieldTTF::insertText(const char * text, size_t len)
     std::string insert(text, len);
 
     // insert \n means input end
-    int pos = static_cast<int>(insert.find('\n'));
+    int pos = static_cast<int>(insert.find((char)TextFormatter::NewLine));
     if ((int)insert.npos != pos)
     {
         len = pos;
@@ -206,10 +234,26 @@ void TextFieldTTF::insertText(const char * text, size_t len)
             return;
         }
 
-        _charCount += _calcCharCount(insert.c_str());
-        std::string sText(_inputText);
-        sText.append(insert);
-        setString(sText);
+        int countInsertChar = _calcCharCount(insert.c_str());
+        _charCount += countInsertChar;
+
+        if (_cursorUse)
+        {
+            StringUtils::StringUTF8 stringUTF8;
+
+            stringUTF8.set(_inputText);
+            stringUTF8.insert(_cursorPosition, insert);
+
+            setCursorPosition(_cursorPosition + countInsertChar);            
+
+            setString(stringUTF8.getAsCharSequence());
+        }
+        else
+        {
+            std::string sText(_inputText);
+            sText.append(insert);
+            setString(sText);
+        }
     }
 
     if ((int)insert.npos == pos) {
@@ -254,14 +298,32 @@ void TextFieldTTF::deleteBackward()
     {
         _inputText = "";
         _charCount = 0;
-        Label::setTextColor(_colorSpaceHolder);
-        Label::setString(_placeHolder);
+        setCursorPosition(0);
+        setString(_inputText);
         return;
     }
 
     // set new input text
-    std::string text(_inputText.c_str(), len - deleteLen);
-    setString(text);
+    if (_cursorUse)
+    {
+        if (_cursorPosition)
+        {
+            setCursorPosition(_cursorPosition - 1);
+
+            StringUtils::StringUTF8 stringUTF8;
+
+            stringUTF8.set(_inputText);
+            stringUTF8.deleteChar(_cursorPosition);
+
+            _charCount = stringUTF8.length();
+            setString(stringUTF8.getAsCharSequence());
+        }
+    }
+    else
+    {
+        std::string text(_inputText.c_str(), len - deleteLen);
+        setString(text);
+    }
 }
 
 const std::string& TextFieldTTF::getContentText()
@@ -269,10 +331,73 @@ const std::string& TextFieldTTF::getContentText()
     return _inputText;
 }
 
+void TextFieldTTF::setCursorPosition(std::size_t cursorPosition)
+{
+    if (_cursorUse && cursorPosition <= (std::size_t)_charCount)
+    {
+        _cursorPosition = cursorPosition;
+        _cursorShowingTime = CURSOR_TIME_SHOW_HIDE*2.0;
+    }
+}
+
+void TextFieldTTF::setCursorFromPoint(const Vec2 &point, const Camera* camera)
+{
+    if (_cursorUse)
+    {
+        // Reset Label, no cursor
+        bool oldIsAttachWithIME = _isAttachWithIME;
+        _isAttachWithIME = false;
+        updateCursorDisplayText();
+
+        Rect rect;
+        rect.size = getContentSize();
+        if (isScreenPointInRect(point, camera, getWorldToNodeTransform(), rect, nullptr))
+        {
+            int latterPosition = 0;
+            for (; latterPosition < _lengthOfString; ++latterPosition)
+            {
+                if (_lettersInfo[latterPosition].valid)
+                {
+                    auto sprite = getLetter(latterPosition);
+                    rect.size = sprite->getContentSize();
+                    if (isScreenPointInRect(point, camera, sprite->getWorldToNodeTransform(), rect, nullptr))
+                    {
+                        setCursorPosition(latterPosition);
+                        break;
+                    }
+                }
+            }
+            if (latterPosition == _lengthOfString)
+            {
+                setCursorPosition(latterPosition);
+            }
+        }
+
+        // Set cursor
+        _isAttachWithIME = oldIsAttachWithIME;
+        updateCursorDisplayText();
+    }
+}
+
+void TextFieldTTF::setAttachWithIME(bool isAttachWithIME)
+{
+    if (isAttachWithIME != _isAttachWithIME)
+    {
+        _isAttachWithIME = isAttachWithIME;
+
+        if (_isAttachWithIME)
+        {
+            setCursorPosition(_charCount);
+        }
+        updateCursorDisplayText();
+    }
+}
+
 void TextFieldTTF::setTextColor(const Color4B &color)
 {
     _colorText = color;
-    if (!_inputText.empty()) {
+    if (!_inputText.empty()) 
+    {
         Label::setTextColor(_colorText);
     }
 }
@@ -284,6 +409,33 @@ void TextFieldTTF::visit(Renderer *renderer, const Mat4 &parentTransform, uint32
         return;
     }
     Label::visit(renderer,parentTransform,parentFlags);
+}
+
+void TextFieldTTF::update(float delta)
+{
+    if (_cursorUse && _isAttachWithIME)
+    {
+        _cursorShowingTime -= delta;
+        if (_cursorShowingTime < -CURSOR_TIME_SHOW_HIDE)
+        {
+            _cursorShowingTime = CURSOR_TIME_SHOW_HIDE;
+        }
+        // before cursor inserted '\b', need next letter
+        auto sprite = getLetter(_cursorPosition + 1);
+
+        if (sprite)
+        {
+            if (_cursorShowingTime >= 0.0f)
+            {
+                sprite->setOpacity(255);
+            }
+            else
+            {
+                sprite->setOpacity(0);
+            }
+            sprite->setDirty(true);
+        }
+    }
 }
 
 const Color4B& TextFieldTTF::getColorSpaceHolder()
@@ -306,7 +458,8 @@ void TextFieldTTF::setColorSpaceHolder(const Color3B& color)
 void TextFieldTTF::setColorSpaceHolder(const Color4B& color)
 {
     _colorSpaceHolder = color;
-    if (_inputText.empty()) {
+    if (_inputText.empty())
+    {
         Label::setTextColor(_colorSpaceHolder);
     }
 }
@@ -320,16 +473,17 @@ void TextFieldTTF::setString(const std::string &text)
 {
     static char bulletString[] = {(char)0xe2, (char)0x80, (char)0xa2, (char)0x00};
     std::string displayText;
-    size_t length;
 
+    int charCount = 0;
     if (!text.empty())
     {
         _inputText = text;
         displayText = _inputText;
+        charCount = _calcCharCount(_inputText.c_str());
         if (_secureTextEntry)
         {
             displayText = "";
-            length = _inputText.length();
+            size_t length = charCount;
             while (length)
             {
                 displayText.append(bulletString);
@@ -342,18 +496,133 @@ void TextFieldTTF::setString(const std::string &text)
         _inputText = "";
     }
 
+    if (_cursorUse && charCount != _charCount)
+    {
+        _cursorPosition = charCount;
+    }
+
+    if (_cursorUse)
+    {
+        // Need for recreate all letters in Label
+        Label::removeAllChildrenWithCleanup(false);
+    }
+
     // if there is no input text, display placeholder instead
-    if (_inputText.empty())
+    if (_inputText.empty() && (!_cursorUse || !_isAttachWithIME))
     {
         Label::setTextColor(_colorSpaceHolder);
         Label::setString(_placeHolder);
     }
     else
     {
+        makeStringSupportCursor(displayText);
+
         Label::setTextColor(_colorText);
         Label::setString(displayText);
     }
-    _charCount = _calcCharCount(_inputText.c_str());
+    _charCount = charCount;
+}
+
+void TextFieldTTF::appendString(const std::string& text)
+{
+    insertText(text.c_str(), text.length());
+}
+
+void TextFieldTTF::makeStringSupportCursor(std::string& displayText)
+{
+    if (_cursorUse && _isAttachWithIME)
+    {
+        if (displayText.empty())
+        {
+            // \b - Next char not change x position
+            displayText.push_back((char)TextFormatter::NextCharNoChangeX);
+            displayText.push_back(_cursorChar);
+        }
+        else
+        {
+            StringUtils::StringUTF8 stringUTF8;
+
+            stringUTF8.set(displayText);
+
+            if (_cursorPosition > stringUTF8.length())
+            {
+                _cursorPosition = stringUTF8.length();
+            }
+            std::string cursorChar;
+            // \b - Next char not change x position
+            cursorChar.push_back((char)TextFormatter::NextCharNoChangeX);
+            cursorChar.push_back(_cursorChar);
+            stringUTF8.insert(_cursorPosition, cursorChar);
+
+            displayText = stringUTF8.getAsCharSequence();
+        }
+    }
+}
+
+void TextFieldTTF::updateCursorDisplayText()
+{
+    // Update Label content
+    setString(_inputText);
+}
+
+void TextFieldTTF::setCursorChar(char cursor)
+{
+    if (_cursorChar != cursor)
+    {
+        _cursorChar = cursor;
+        updateCursorDisplayText();
+    }
+}
+
+void TextFieldTTF::controlKey(EventKeyboard::KeyCode keyCode)
+{
+    if (_cursorUse)
+    {
+        switch (keyCode)
+        {
+        case EventKeyboard::KeyCode::KEY_HOME:
+        case EventKeyboard::KeyCode::KEY_KP_HOME:
+            setCursorPosition(0);
+            updateCursorDisplayText();
+            break;
+        case EventKeyboard::KeyCode::KEY_END:
+            setCursorPosition(_charCount);
+            updateCursorDisplayText();
+            break;
+        case EventKeyboard::KeyCode::KEY_DELETE:
+        case EventKeyboard::KeyCode::KEY_KP_DELETE:
+            if (_cursorPosition < (std::size_t)_charCount)
+            {
+                StringUtils::StringUTF8 stringUTF8;
+
+                stringUTF8.set(_inputText);
+                stringUTF8.deleteChar(_cursorPosition);
+                setCursorPosition(_cursorPosition);
+                _charCount = stringUTF8.length();
+                setString(stringUTF8.getAsCharSequence());
+            }
+            break;
+        case EventKeyboard::KeyCode::KEY_LEFT_ARROW:
+            if (_cursorPosition)
+            {
+                setCursorPosition(_cursorPosition - 1);
+                updateCursorDisplayText();
+            }
+            break;
+        case EventKeyboard::KeyCode::KEY_RIGHT_ARROW:
+            if (_cursorPosition < (std::size_t)_charCount)
+            {
+                setCursorPosition(_cursorPosition + 1);
+                updateCursorDisplayText();
+            }
+            break;
+        case EventKeyboard::KeyCode::KEY_ESCAPE:
+            detachWithIME();
+            break;
+        default:
+            break;
+        }
+    }
 }
 
 const std::string& TextFieldTTF::getString() const
@@ -375,6 +644,33 @@ void TextFieldTTF::setPlaceHolder(const std::string& text)
 const std::string& TextFieldTTF::getPlaceHolder() const
 {
     return _placeHolder;
+}
+
+void TextFieldTTF::setCursorUse(bool value)
+{
+    if (_currentLabelType == LabelType::TTF)
+    {
+        if (_cursorUse != value)
+        {
+            _cursorUse = value;
+            if (_cursorUse)
+            {
+                _cursorPosition = _charCount;
+
+                scheduleUpdate();
+            }
+            else
+            {
+                _cursorPosition = 0;
+
+                unscheduleUpdate();
+            }
+        }
+    }
+    else
+    {
+        CCLOG("TextFieldTTF cursor worked only LabelType::TTF");
+    }
 }
 
 // secureTextEntry

--- a/cocos/2d/CCTextFieldTTF.h
+++ b/cocos/2d/CCTextFieldTTF.h
@@ -195,6 +195,12 @@ public:
     virtual void setString(const std::string& text) override;
 
     /**
+    * Append to input text of TextField.
+    *@param text The append text of TextField.
+    */
+    virtual void appendString(const std::string& text);
+
+    /**
      * Query the input text of TextField.
      *@return Get the input text of TextField.
      */
@@ -230,6 +236,32 @@ public:
 
     virtual void visit(Renderer *renderer, const Mat4 &parentTransform, uint32_t parentFlags) override;
 
+    virtual void update(float delta) override;
+
+    /**
+    * Set enable cursor use.
+    * @js NA
+    */
+    void setCursorUse(bool value);
+
+    /**
+    * Set char showing cursor.
+    * @js NA
+    */
+    void setCursorChar(char cursor);
+
+    /**
+    * Set cursor position, if enabled
+    * @js NA
+    */
+    void setCursorPosition(std::size_t cursorPosition);
+
+    /**
+    * Set cursor position to hit letter, if enabled
+    * @js NA
+    */
+    void setCursorFromPoint(const Vec2 &point, const Camera* camera);
+
 protected:
     //////////////////////////////////////////////////////////////////////////
     // IMEDelegate interface
@@ -237,9 +269,12 @@ protected:
 
     virtual bool canAttachWithIME() override;
     virtual bool canDetachWithIME() override;
+    virtual void didAttachWithIME() override;
+    virtual void didDetachWithIME() override;
     virtual void insertText(const char * text, size_t len) override;
     virtual void deleteBackward() override;
     virtual const std::string& getContentText() override;
+    virtual void controlKey(EventKeyboard::KeyCode keyCode) override;
 
     TextFieldDelegate * _delegate;
     int _charCount;
@@ -251,6 +286,21 @@ protected:
     Color4B _colorText;
 
     bool _secureTextEntry;
+
+    // Need use cursor
+    bool _cursorUse;
+    // Current position cursor
+    std::size_t _cursorPosition;
+    // Char showing cursor
+    char _cursorChar;
+    // >0 - show, <0 - hide
+    float _cursorShowingTime;
+
+    bool _isAttachWithIME;
+
+    void makeStringSupportCursor(std::string& displayText);
+    void updateCursorDisplayText();
+    void setAttachWithIME(bool isAttachWithIME);
 
 private:
     class LengthStack;

--- a/cocos/base/CCIMEDelegate.h
+++ b/cocos/base/CCIMEDelegate.h
@@ -28,6 +28,7 @@ THE SOFTWARE.
 
 #include <string>
 #include "math/CCGeometry.h"
+#include "base/CCEventKeyboard.h"
 
 /**
  * @addtogroup base
@@ -123,6 +124,13 @@ protected:
     * @lua NA
     */
     virtual void deleteBackward() {}
+
+    /**
+    @brief    Called by IMEDispatcher after the user press control key.
+    * @js NA
+    * @lua NA
+    */
+    virtual void controlKey(EventKeyboard::KeyCode keyCode) {}
 
     /**
     @brief    Called by IMEDispatcher for text stored in delegate.

--- a/cocos/base/CCIMEDispatcher.cpp
+++ b/cocos/base/CCIMEDispatcher.cpp
@@ -144,19 +144,22 @@ bool IMEDispatcher::attachDelegateWithIME(IMEDelegate * delegate)
 
         if (_impl->_delegateWithIme)
         {
-            // if old delegate canDetachWithIME return false 
-            // or pDelegate canAttachWithIME return false,
-            // do nothing.
-            CC_BREAK_IF(! _impl->_delegateWithIme->canDetachWithIME()
-                || ! delegate->canAttachWithIME());
+            if (_impl->_delegateWithIme != delegate)
+            {
+                // if old delegate canDetachWithIME return false 
+                // or pDelegate canAttachWithIME return false,
+                // do nothing.
+                CC_BREAK_IF(!_impl->_delegateWithIme->canDetachWithIME()
+                    || !delegate->canAttachWithIME());
 
-            // detach first
-            IMEDelegate * oldDelegate = _impl->_delegateWithIme;
-            _impl->_delegateWithIme = 0;
-            oldDelegate->didDetachWithIME();
+                // detach first
+                IMEDelegate * oldDelegate = _impl->_delegateWithIme;
+                _impl->_delegateWithIme = 0;
+                oldDelegate->didDetachWithIME();
 
-            _impl->_delegateWithIme = *iter;
-            delegate->didAttachWithIME();
+                _impl->_delegateWithIme = *iter;
+                delegate->didAttachWithIME();
+            }
             ret = true;
             break;
         }
@@ -237,6 +240,19 @@ void IMEDispatcher::dispatchDeleteBackward()
         CC_BREAK_IF(! _impl->_delegateWithIme);
 
         _impl->_delegateWithIme->deleteBackward();
+    } while (0);
+}
+
+void IMEDispatcher::dispatchControlKey(EventKeyboard::KeyCode keyCode)
+{
+    do
+    {
+        CC_BREAK_IF(!_impl);
+
+        // there is no delegate attached to IME
+        CC_BREAK_IF(!_impl->_delegateWithIme);
+
+        _impl->_delegateWithIme->controlKey(keyCode);
     } while (0);
 }
 

--- a/cocos/base/CCIMEDispatcher.h
+++ b/cocos/base/CCIMEDispatcher.h
@@ -67,6 +67,12 @@ public:
     void dispatchDeleteBackward();
 
     /**
+    * @brief Dispatches the press control key operation.
+    * @lua NA
+    */
+    void dispatchControlKey(EventKeyboard::KeyCode keyCode);
+
+    /**
      * @brief Get the content text from IMEDelegate, retrieved previously from IME.
      * @lua NA
      */

--- a/cocos/base/ccUTF8.cpp
+++ b/cocos/base/ccUTF8.cpp
@@ -213,6 +213,106 @@ long getCharacterCountInUTF8String(const std::string& utf8)
     return getUTF8StringLength((const UTF8*)utf8.c_str());
 }
 
+
+StringUTF8::StringUTF8()
+{
+
+}
+
+StringUTF8::StringUTF8(const std::string& newStr)
+{
+    set(newStr);
+}
+
+StringUTF8::StringUTF8(const StringUTF8& copyStrUtf8)
+{
+    _str = copyStrUtf8._str;
+}
+
+StringUTF8::~StringUTF8()
+{
+
+}
+
+std::size_t StringUTF8::length() const
+{
+    return _str.size();
+}
+
+void StringUTF8::set(const std::string& newStr)
+{
+    _str.clear();
+    if (!newStr.empty())
+    {
+        UTF8* sequenceUtf8 = (UTF8*)newStr.c_str();
+
+        int lengthString = getUTF8StringLength(sequenceUtf8);
+
+        if (lengthString == 0)
+        {
+            CCLOG("Bad utf-8 set string: %s", newStr.c_str());
+            return;
+        }
+
+        while (*sequenceUtf8)
+        {
+            std::size_t lengthChar = getNumBytesForUTF8(*sequenceUtf8);
+
+            CharUTF8 charUTF8;
+            charUTF8._char.append((char*)sequenceUtf8, lengthChar);
+            sequenceUtf8 += lengthChar;
+
+            _str.push_back(charUTF8);
+        }
+    }
+}
+
+std::string StringUTF8::getAsCharSequence() const
+{
+    std::string charSequence;
+
+    for (auto& charUtf8 : _str)
+    {
+        charSequence.append(charUtf8._char);
+    }
+
+    return charSequence;
+}
+
+bool StringUTF8::deleteChar(std::size_t pos)
+{
+    if (pos < _str.size())
+    {
+        _str.erase(_str.begin() + pos);
+        return true;
+    }
+    else
+    {
+        return false;
+    }
+}
+
+bool StringUTF8::insert(std::size_t pos, const std::string& insertStr)
+{
+    StringUTF8 utf8(insertStr);
+
+    return insert(pos, utf8);
+}
+
+bool StringUTF8::insert(std::size_t pos, const StringUTF8& insertStr)
+{
+    if (pos <= _str.size())
+    {
+        _str.insert(_str.begin() + pos, insertStr._str.begin(), insertStr._str.end());
+
+        return true;
+    }
+    else
+    {
+        return false;
+    }
+}
+
 } //namespace StringUtils {
 
 

--- a/cocos/base/ccUTF8.h
+++ b/cocos/base/ccUTF8.h
@@ -142,6 +142,43 @@ CC_DLL unsigned int getIndexOfLastNotChar16(const std::vector<char16_t>& str, ch
  */
 CC_DLL std::vector<char16_t> getChar16VectorFromUTF16String(const std::u16string& utf16);
 
+
+
+/**
+* Utf8 sequence
+* Store all utf8 chars as std::string
+* Build from std::string
+*/
+class CC_DLL StringUTF8
+{
+public:
+    struct CharUTF8
+    {
+        std::string _char;
+        bool isAnsi() { return _char.size() == 1; }
+    };
+    typedef std::vector<CharUTF8> CharUTF8Store;
+
+    StringUTF8();
+    StringUTF8(const std::string& newStr);
+    explicit StringUTF8(const StringUTF8& copyStrUtf8);
+    ~StringUTF8();
+
+    std::size_t length() const;
+    void set(const std::string& newStr);
+
+    std::string getAsCharSequence() const;
+
+    bool deleteChar(std::size_t pos);
+    bool insert(std::size_t pos, const std::string& insertStr);
+    bool insert(std::size_t pos, const StringUTF8& insertStr);
+
+    CharUTF8Store& getString() { return _str; }
+
+private:
+    CharUTF8Store _str;
+};
+
 } // namespace StringUtils {
 
 /**

--- a/cocos/platform/desktop/CCGLViewImpl-desktop.cpp
+++ b/cocos/platform/desktop/CCGLViewImpl-desktop.cpp
@@ -712,9 +712,26 @@ void GLViewImpl::onGLFWKeyCallback(GLFWwindow *window, int key, int scancode, in
         dispatcher->dispatchEvent(&event);
     }
     
-    if (GLFW_RELEASE != action && g_keyCodeMap[key] == EventKeyboard::KeyCode::KEY_BACKSPACE)
+    if (GLFW_RELEASE != action)
     {
-        IMEDispatcher::sharedDispatcher()->dispatchDeleteBackward();
+        switch (g_keyCodeMap[key])
+        {
+        case EventKeyboard::KeyCode::KEY_BACKSPACE:
+            IMEDispatcher::sharedDispatcher()->dispatchDeleteBackward();
+            break;
+        case EventKeyboard::KeyCode::KEY_HOME:
+        case EventKeyboard::KeyCode::KEY_KP_HOME:
+        case EventKeyboard::KeyCode::KEY_DELETE:
+        case EventKeyboard::KeyCode::KEY_KP_DELETE:
+        case EventKeyboard::KeyCode::KEY_END:
+        case EventKeyboard::KeyCode::KEY_LEFT_ARROW:
+        case EventKeyboard::KeyCode::KEY_RIGHT_ARROW:
+        case EventKeyboard::KeyCode::KEY_ESCAPE:
+            IMEDispatcher::sharedDispatcher()->dispatchControlKey(g_keyCodeMap[key]);
+            break;
+        default:
+            break;
+        }
     }
 }
 

--- a/cocos/platform/desktop/CCGLViewImpl-desktop.cpp
+++ b/cocos/platform/desktop/CCGLViewImpl-desktop.cpp
@@ -741,8 +741,24 @@ void GLViewImpl::onGLFWCharCallback(GLFWwindow *window, unsigned int character)
     std::string utf8String;
 
     StringUtils::UTF16ToUTF8( wcharString, utf8String );
-    IMEDispatcher::sharedDispatcher()->dispatchInsertText( utf8String.c_str(), utf8String.size() );
-}
+    
+    static std::set<std::string> controlUnicode = {
+        "\xEF\x9C\x80", // up
+        "\xEF\x9C\x81", // down
+        "\xEF\x9C\x82", // left
+        "\xEF\x9C\x83", // right
+        "\xEF\x9C\xA8", // delete
+        "\xEF\x9C\xA9", // home
+        "\xEF\x9C\xAB", // end
+        "\xEF\x9C\xAC", // pageup
+        "\xEF\x9C\xAD", // pagedown
+        "\xEF\x9C\xB9"  // clear
+    };
+    // Check for send control key
+    if (controlUnicode.find(utf8String) == controlUnicode.end())
+    {
+        IMEDispatcher::sharedDispatcher()->dispatchInsertText( utf8String.c_str(), utf8String.size() );
+    }}
 
 void GLViewImpl::onGLFWWindowPosCallback(GLFWwindow *windows, int x, int y)
 {

--- a/cocos/platform/win8.1-universal/OpenGLESPage.xaml.cpp
+++ b/cocos/platform/win8.1-universal/OpenGLESPage.xaml.cpp
@@ -172,14 +172,11 @@ void OpenGLESPage::OnPointerReleased(Object^ sender, PointerEventArgs^ e)
 
 void OpenGLESPage::OnKeyPressed(CoreWindow^ sender, KeyEventArgs^ e)
 {
-	if (!e->KeyStatus.WasKeyDown)
-	{
-		//log("OpenGLESPage::OnKeyPressed %d", e->VirtualKey);
-		if (mRenderer)
-		{
-			mRenderer->QueueKeyboardEvent(WinRTKeyboardEventType::KeyPressed, e);
-		}
-	}
+    //log("OpenGLESPage::OnKeyPressed %d", e->VirtualKey);
+    if (mRenderer)
+    {
+        mRenderer->QueueKeyboardEvent(WinRTKeyboardEventType::KeyPressed, e);
+    }
 }
 
 void OpenGLESPage::OnCharacterReceived(CoreWindow^ sender, CharacterReceivedEventArgs^ e)

--- a/templates/cpp-template-default/proj.win10/App/Cocos2dEngine/OpenGLESPage.xaml.cpp
+++ b/templates/cpp-template-default/proj.win10/App/Cocos2dEngine/OpenGLESPage.xaml.cpp
@@ -172,14 +172,11 @@ void OpenGLESPage::OnPointerReleased(Object^ sender, PointerEventArgs^ e)
 
 void OpenGLESPage::OnKeyPressed(CoreWindow^ sender, KeyEventArgs^ e)
 {
-	if (!e->KeyStatus.WasKeyDown)
-	{
-		//log("OpenGLESPage::OnKeyPressed %d", e->VirtualKey);
-		if (mRenderer)
-		{
-			mRenderer->QueueKeyboardEvent(WinRTKeyboardEventType::KeyPressed, e);
-		}
-	}
+    //log("OpenGLESPage::OnKeyPressed %d", e->VirtualKey);
+    if (mRenderer)
+    {
+        mRenderer->QueueKeyboardEvent(WinRTKeyboardEventType::KeyPressed, e);
+    }
 }
 
 void OpenGLESPage::OnCharacterReceived(CoreWindow^ sender, CharacterReceivedEventArgs^ e)

--- a/templates/cpp-template-default/proj.win8.1-universal/App.Shared/OpenGLESPage.xaml.cpp
+++ b/templates/cpp-template-default/proj.win8.1-universal/App.Shared/OpenGLESPage.xaml.cpp
@@ -172,14 +172,11 @@ void OpenGLESPage::OnPointerReleased(Object^ sender, PointerEventArgs^ e)
 
 void OpenGLESPage::OnKeyPressed(CoreWindow^ sender, KeyEventArgs^ e)
 {
-	if (!e->KeyStatus.WasKeyDown)
-	{
-		//log("OpenGLESPage::OnKeyPressed %d", e->VirtualKey);
-		if (mRenderer)
-		{
-			mRenderer->QueueKeyboardEvent(WinRTKeyboardEventType::KeyPressed, e);
-		}
-	}
+    //log("OpenGLESPage::OnKeyPressed %d", e->VirtualKey);
+    if (mRenderer)
+    {
+        mRenderer->QueueKeyboardEvent(WinRTKeyboardEventType::KeyPressed, e);
+    }
 }
 
 void OpenGLESPage::OnCharacterReceived(CoreWindow^ sender, CharacterReceivedEventArgs^ e)

--- a/templates/js-template-default/frameworks/runtime-src/proj.win8.1-universal/App.Shared/OpenGLESPage.xaml.cpp
+++ b/templates/js-template-default/frameworks/runtime-src/proj.win8.1-universal/App.Shared/OpenGLESPage.xaml.cpp
@@ -172,14 +172,11 @@ void OpenGLESPage::OnPointerReleased(Object^ sender, PointerEventArgs^ e)
 
 void OpenGLESPage::OnKeyPressed(CoreWindow^ sender, KeyEventArgs^ e)
 {
-	if (!e->KeyStatus.WasKeyDown)
-	{
-		//log("OpenGLESPage::OnKeyPressed %d", e->VirtualKey);
-		if (mRenderer)
-		{
-			mRenderer->QueueKeyboardEvent(WinRTKeyboardEventType::KeyPressed, e);
-		}
-	}
+    //log("OpenGLESPage::OnKeyPressed %d", e->VirtualKey);
+    if (mRenderer)
+    {
+        mRenderer->QueueKeyboardEvent(WinRTKeyboardEventType::KeyPressed, e);
+    }
 }
 
 void OpenGLESPage::OnCharacterReceived(CoreWindow^ sender, CharacterReceivedEventArgs^ e)


### PR DESCRIPTION
Add StringUtils::StringUTF8 for easy manipulate utf8 string.
If TextField active(focused input text) show text cursor( default '|',
change TextFieldTTF::setCursorChar ).
Show/Hide interval CURSOR_TIME_SHOW_HIDE
Change position text cursor control key: KEY_HOME, KEY_END,
KEY_LEFT_ARROW, KEY_RIGHT_ARROW
CC_PLATFORM_MAC, CC_PLATFORM_WIN32, CC_PLATFORM_LINUX default use
cursor( For change state TextFieldTTF::setCursorUse )
Desktop implement dispatchControlKey
WinRT support key repeat and implement dispatchControlKey
Text cursor worked only on LabelType::TTF

new version it: #13600 , for easy merge
