### PR TITLE
iOS: ARC support #12518

### DIFF
--- a/templates/cpp-template-default/proj.ios_mac/ios/AppController.mm
+++ b/templates/cpp-template-default/proj.ios_mac/ios/AppController.mm
@@ -49,7 +49,7 @@ static AppDelegate s_sharedApplication;
 
     // Init the CCEAGLView
     CCEAGLView *eaglView = [CCEAGLView viewWithFrame: [window bounds]
-                                         pixelFormat: (NSString*)cocos2d::GLViewImpl::_pixelFormat
+                                         pixelFormat: (__bridge NSString *)cocos2d::GLViewImpl::_pixelFormat
                                          depthFormat: cocos2d::GLViewImpl::_depthFormat
                                   preserveBackbuffer: NO
                                           sharegroup: nil
@@ -81,7 +81,7 @@ static AppDelegate s_sharedApplication;
     [[UIApplication sharedApplication] setStatusBarHidden:true];
 
     // IMPORTANT: Setting the GLView should be done after creating the RootViewController
-    cocos2d::GLView *glview = cocos2d::GLViewImpl::createWithEAGLView(eaglView);
+    cocos2d::GLView *glview = cocos2d::GLViewImpl::createWithEAGLView((__bridge void *)eaglView);
     cocos2d::Director::getInstance()->setOpenGLView(glview);
 
     app->run();
@@ -140,10 +140,13 @@ static AppDelegate s_sharedApplication;
 }
 
 
+#if __has_feature(objc_arc)
+#else
 - (void)dealloc {
     [window release];
     [super dealloc];
 }
+#endif
 
 
 @end

--- a/templates/cpp-template-default/proj.ios_mac/ios/AppController.mm
+++ b/templates/cpp-template-default/proj.ios_mac/ios/AppController.mm
@@ -144,6 +144,7 @@ static AppDelegate s_sharedApplication;
 #else
 - (void)dealloc {
     [window release];
+    [_viewController release];
     [super dealloc];
 }
 #endif

--- a/templates/cpp-template-default/proj.ios_mac/ios/RootViewController.mm
+++ b/templates/cpp-template-default/proj.ios_mac/ios/RootViewController.mm
@@ -76,7 +76,7 @@
 
     if (glview)
     {
-        CCEAGLView *eaglview = (CCEAGLView*) glview->getEAGLView();
+        CCEAGLView *eaglview = (__bridge CCEAGLView *)glview->getEAGLView();
 
         if (eaglview)
         {
@@ -104,11 +104,5 @@
     // Release any retained subviews of the main view.
     // e.g. self.myOutlet = nil;
 }
-
-
-- (void)dealloc {
-    [super dealloc];
-}
-
 
 @end

--- a/templates/cpp-template-default/proj.ios_mac/ios/main.m
+++ b/templates/cpp-template-default/proj.ios_mac/ios/main.m
@@ -1,9 +1,15 @@
 #import <UIKit/UIKit.h>
 
 int main(int argc, char *argv[]) {
-    
+    NSString *appControllerClassName = @"AppController";
+#if __has_feature(objc_arc)
+    @autoreleasepool {
+        return UIApplicationMain(argc, argv, nil, appControllerClassName);
+    }
+#else
     NSAutoreleasePool * pool = [[NSAutoreleasePool alloc] init];
-    int retVal = UIApplicationMain(argc, argv, nil, @"AppController");
+    const int retVal = UIApplicationMain(argc, argv, nil, appControllerClassName);
     [pool release];
     return retVal;
+#endif
 }

--- a/templates/cpp-template-default/proj.ios_mac/ios/main.m
+++ b/templates/cpp-template-default/proj.ios_mac/ios/main.m
@@ -1,15 +1,7 @@
 #import <UIKit/UIKit.h>
 
 int main(int argc, char *argv[]) {
-    NSString *appControllerClassName = @"AppController";
-#if __has_feature(objc_arc)
     @autoreleasepool {
-        return UIApplicationMain(argc, argv, nil, appControllerClassName);
+        return UIApplicationMain(argc, argv, nil, @"AppController");
     }
-#else
-    NSAutoreleasePool * pool = [[NSAutoreleasePool alloc] init];
-    const int retVal = UIApplicationMain(argc, argv, nil, appControllerClassName);
-    [pool release];
-    return retVal;
-#endif
 }


### PR DESCRIPTION
Ability to easily turn on/off ARC support in 'Build Settings' for template project (and only for it). Cocos2d-x engine itself is not affected.

It's safe to have outer project with arc support and libraries/frameworks/depended projects with or without arc support.
