### PR TITLE
Fix socketio to work with servers v1.0+

### DIFF
--- a/cocos/network/SocketIO.cpp
+++ b/cocos/network/SocketIO.cpp
@@ -84,7 +84,7 @@ protected:
     std::string _name;//event name
     std::vector<std::string> _args;//we will be using a vector of strings to store multiple data
     std::string _endpoint;//
-    std::string _endpointseperator;//socket.io 1.x requires a ',' between endpoint and payload
+    std::string _endpointseparator;//socket.io 1.x requires a ',' between endpoint and payload
     std::string _type;//message type
     std::string _separator;//for stringify the object
     std::vector<std::string> _types;//types of messages
@@ -101,7 +101,7 @@ private:
     std::vector<std::string> _typesMessage;
 };
 
-SocketIOPacket::SocketIOPacket() :_separator(":")
+SocketIOPacket::SocketIOPacket() :_separator(":"), _endpointseparator("")
 {
     _types.push_back("disconnect");
     _types.push_back("connect");
@@ -149,7 +149,7 @@ std::string SocketIOPacket::toString()const
 
     // Add the endpoint for the namespace to be used if not the default namespace "" or "/", and as long as it is not an ACK, heartbeat, or disconnect packet
     if (_endpoint != "/" && _endpoint != "" && _type != "ack" && _type != "heartbeat" && _type != "disconnect") {
-        encoded << _endpoint << _endpointseperator;
+        encoded << _endpoint << _endpointseparator;
     }
     encoded << this->_separator;
 
@@ -231,7 +231,7 @@ std::string SocketIOPacket::stringify()const
 SocketIOPacketV10x::SocketIOPacketV10x()
 {
     _separator = "";
-    _endpointseperator = ",";
+    _endpointseparator = ",";
     _types.push_back("disconnected");
     _types.push_back("connected");
     _types.push_back("heartbeat");

--- a/cocos/network/SocketIO.cpp
+++ b/cocos/network/SocketIO.cpp
@@ -230,7 +230,7 @@ std::string SocketIOPacket::stringify()const
 
 SocketIOPacketV10x::SocketIOPacketV10x()
 {
-    _separator = ":";
+    _separator = "";
     _endpointseperator = ",";
     _types.push_back("disconnected");
     _types.push_back("connected");

--- a/tests/cpp-tests/Classes/ExtensionsTest/NetworkTest/SocketIOTest.cpp
+++ b/tests/cpp-tests/Classes/ExtensionsTest/NetworkTest/SocketIOTest.cpp
@@ -195,7 +195,7 @@ void SocketIOTest::closedSocketAction(network::SIOClient* client)
 void SocketIOTest::onMenuSIOClientClicked(cocos2d::Ref *sender)
 {
 	//create a client by using this static method, url does not need to contain the protocol
-	_sioClient = SocketIO::connect("ws://dev.channon.us:3010", *this);
+	_sioClient = SocketIO::connect("ws://localhost:3010", *this);
 	//you may set a tag for the client for reference in callbacks
 	_sioClient->setTag("Test Client");
 
@@ -212,7 +212,7 @@ void SocketIOTest::onMenuSIOClientClicked(cocos2d::Ref *sender)
 void SocketIOTest::onMenuSIOEndpointClicked(cocos2d::Ref *sender)
 {
 	//repeat the same connection steps for the namespace "testpoint"
-	_sioEndpoint = SocketIO::connect("ws://dev.channon.us:3010/testpoint", *this);
+	_sioEndpoint = SocketIO::connect("ws://localhost:3010/testpoint", *this);
 	//a tag to differentiate in shared callbacks
 	_sioEndpoint->setTag("Test Endpoint");
 


### PR DESCRIPTION
Fixes incorrect packet format by updating the separator between data fields for socketio v1.x packets

fixes #13929 
