### PR TITLE
V3 Win10 UWP fixes

### DIFF
--- a/cocos/2d/libcocos2d_win10/libcocos2d.vcxproj
+++ b/cocos/2d/libcocos2d_win10/libcocos2d.vcxproj
@@ -565,7 +565,6 @@
     <ClCompile Include="..\..\physics3d\CCPhysics3DShape.cpp" />
     <ClCompile Include="..\..\physics3d\CCPhysics3DWorld.cpp" />
     <ClCompile Include="..\..\physics3d\CCPhysicsSprite3D.cpp" />
-    <ClCompile Include="..\..\physics\CCComponentPhysics2d.cpp" />
     <ClCompile Include="..\..\physics\CCPhysicsBody.cpp" />
     <ClCompile Include="..\..\physics\CCPhysicsContact.cpp" />
     <ClCompile Include="..\..\physics\CCPhysicsJoint.cpp" />
@@ -1181,7 +1180,6 @@
     <ClInclude Include="..\..\physics3d\CCPhysics3DShape.h" />
     <ClInclude Include="..\..\physics3d\CCPhysics3DWorld.h" />
     <ClInclude Include="..\..\physics3d\CCPhysicsSprite3D.h" />
-    <ClInclude Include="..\..\physics\CCComponentPhysics2d.h" />
     <ClInclude Include="..\..\physics\CCPhysicsBody.h" />
     <ClInclude Include="..\..\physics\CCPhysicsContact.h" />
     <ClInclude Include="..\..\physics\CCPhysicsHelper.h" />

--- a/cocos/2d/libcocos2d_win10/libcocos2d.vcxproj.filters
+++ b/cocos/2d/libcocos2d_win10/libcocos2d.vcxproj.filters
@@ -1578,9 +1578,6 @@
     <ClCompile Include="..\..\network\WebSocket.cpp">
       <Filter>network</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\physics\CCComponentPhysics2d.cpp">
-      <Filter>physics</Filter>
-    </ClCompile>
     <ClCompile Include="..\..\physics\CCPhysicsBody.cpp">
       <Filter>physics</Filter>
     </ClCompile>
@@ -3394,9 +3391,6 @@
     </ClInclude>
     <ClInclude Include="..\..\network\WebSocket.h">
       <Filter>network</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\physics\CCComponentPhysics2d.h">
-      <Filter>physics</Filter>
     </ClInclude>
     <ClInclude Include="..\..\physics\CCPhysicsBody.h">
       <Filter>physics</Filter>

--- a/cocos/platform/winrt/CCWinRTUtils.cpp
+++ b/cocos/platform/winrt/CCWinRTUtils.cpp
@@ -59,6 +59,7 @@ bool isWindowsPhone()
 #else
     return false;
 #endif
+    return false;
 }
 
 CC_DEPRECATED_ATTRIBUTE std::wstring CC_DLL CCUtf8ToUnicode(const char * pszUtf8Str, unsigned len /*= -1*/)


### PR DESCRIPTION
This pull request fixes the broken v3 Win10 UWP build by removing CCComponentPhysics2d files from the libcocos2d project.
