### PR TITLE
Bug fix for js-test and cpp-test

### DIFF
--- a/cocos/2d/CCParticleSystem.cpp
+++ b/cocos/2d/CCParticleSystem.cpp
@@ -839,6 +839,8 @@ void ParticleSystem::update(float dt)
         if (_particleCount < _totalParticles)
         {
             _emitCounter += dt;
+            if (_emitCounter < 0.f)
+                _emitCounter = 0.f;
         }
         
         int emitCount = MIN(_totalParticles - _particleCount, _emitCounter / rate);
@@ -846,6 +848,8 @@ void ParticleSystem::update(float dt)
         _emitCounter -= rate * emitCount;
         
         _elapsed += dt;
+        if (_elapsed < 0.f)
+            _elapsed = 0.f;
         if (_duration != DURATION_INFINITY && _duration < _elapsed)
         {
             this->stopSystem();

--- a/cocos/base/CCEventDispatcher.cpp
+++ b/cocos/base/CCEventDispatcher.cpp
@@ -844,7 +844,7 @@ void EventDispatcher::dispatchTouchEventToListeners(EventListenerVector* listene
                 auto cameraFlag = (unsigned short)camera->getCameraFlag();
                 for (auto& l : sceneListeners)
                 {
-                    if (0 == (l->getAssociatedNode()->getCameraMask() & cameraFlag))
+                    if (nullptr == l->getAssociatedNode() || 0 == (l->getAssociatedNode()->getCameraMask() & cameraFlag))
                     {
                         continue;
                     }

--- a/cocos/ui/UISlider.cpp
+++ b/cocos/ui/UISlider.cpp
@@ -459,6 +459,7 @@ void Slider::onTouchMoved(Touch *touch, Event *unusedEvent)
 void Slider::onTouchEnded(Touch *touch, Event *unusedEvent)
 {
     Widget::onTouchEnded(touch, unusedEvent);
+    percentChangedEvent(EventType::ON_PERCENTAGE_CHANGED);
     percentChangedEvent(EventType::ON_SLIDEBALL_UP);
 }
 


### PR DESCRIPTION
Fix when click "remove ui" in "native test-JSBExtendTest" under project js-test will crash the program.
Fix "Node:ui -> GUI Dynamic Create Test -> Slider Test" under project cpp-test when click slider bar the slider button moved but won't refresh percentage value.
Fix in "Scheduler->Scheduler ttimeScale Test" when drag slider to left then click the middle of slider bar and drag slider button to right may raise crash.
