### PR TITLE
Fix crash (integer overflow) in Device::getTextureDataForText (ios)

### DIFF
--- a/cocos/platform/ios/CCDevice-ios.mm
+++ b/cocos/platform/ios/CCDevice-ios.mm
@@ -485,8 +485,8 @@ Data Device::getTextureDataForText(const char * text, const FontDefinition& text
         {
             break;
         }
-        height = (short)info.height;
-        width = (short)info.width;
+        height = info.height;
+        width = info.width;
         ret.fastSet(info.data,width * height * 4);
         hasPremultipliedAlpha = true;
     } while (0);


### PR DESCRIPTION
## Explanation

There was the problem when _height_ and _width_ were typecast to **short**
integer. So for values bigger than **sizeof(short)** we had integer overflow. Values may became negative.
## Steps to reproduce:

Create simple application with **cocos2d::ui::EditBox**. Start it. Add 1000 (just
example) characters at a time to the edit box. Method
**Device::getTextureDataForText** will be called and there will be integer
overflow for _height_ and/or _width_:

![screen shot 2015-09-22 at 16 00 34](https://cloud.githubusercontent.com/assets/2412624/10018995/5a5575ea-6143-11e5-8235-793aefeb3fa6.png)
As a result application will crash later.
## Notes

This fix is related to platform (IOS) dependent code! So it is in _CCDevice-ios.mm_.
