### PR TITLE
Fix loading pluginx lib when compile Android with --compile-script flag

### DIFF
--- a/cocos/scripting/js-bindings/script/jsb.js
+++ b/cocos/scripting/js-bindings/script/jsb.js
@@ -79,7 +79,7 @@ if (cc.BuilderAnimationManager) {
     require('script/jsb_cocosbuilder.js');
 }
 
-if (jsb.fileUtils.isFileExist('jsb_pluginx.js')) {
+if (jsb.fileUtils.isFileExist('jsb_pluginx.js') || jsb.fileUtils.isFileExist('jsb_pluginx.jsc')) {
     if (cc.sys.os == cc.sys.OS_IOS || cc.sys.os == cc.sys.OS_ANDROID) {
         require('jsb_pluginx.js');
     }


### PR DESCRIPTION
Fix bug if compile Android build with `--compile-script` flag then it cannot load file `jsb_pluginx.js` because it renamed to `jsb_pluginx.jsc`
