### PR TITLE
Make Ref _referenceCounter thread-safe

### DIFF
--- a/cocos/base/CCRef.cpp
+++ b/cocos/base/CCRef.cpp
@@ -40,9 +40,8 @@ static void untrackRef(Ref* ref);
 #endif
 
 Ref::Ref()
+     : _referenceCount(1) // when the Ref is created, the reference count of it is 1
 {
-    _referenceCount.store(1, std::memory_order_relaxed); // when the Ref is created, the reference count of it is 1
-
 #if CC_ENABLE_SCRIPT_BINDING
     static unsigned int uObjectCount = 0;
     _luaID = 0;
@@ -100,9 +99,8 @@ void Ref::retain()
 void Ref::release()
 {
     CCASSERT(_referenceCount.load(std::memory_order_relaxed) > 0, "reference count should be greater than 0");
-    _referenceCount.fetch_sub(1, std::memory_order_relaxed);
 
-    if (_referenceCount.load(std::memory_order_relaxed) == 0)
+    if ((_referenceCount.fetch_sub(1, std::memory_order_relaxed) - 1) == 0)
     {
 #if defined(COCOS2D_DEBUG) && (COCOS2D_DEBUG > 0)
         auto poolManager = PoolManager::getInstance();

--- a/cocos/base/CCRef.h
+++ b/cocos/base/CCRef.h
@@ -147,7 +147,6 @@ public:
         this->_luaID = other._luaID;
         this->_scriptObject = other._scriptObject;
 #endif
-
         return *this;
     }
 

--- a/cocos/base/CCRef.h
+++ b/cocos/base/CCRef.h
@@ -138,18 +138,6 @@ protected:
 
 public:
 
-    Ref& operator=(const Ref& other)
-    {
-        this->_referenceCount.store(other._referenceCount.load(std::memory_order_relaxed), std::memory_order_relaxed);
-        
-#if CC_ENABLE_SCRIPT_BINDING
-        this->_ID = other._ID;
-        this->_luaID = other._luaID;
-        this->_scriptObject = other._scriptObject;
-#endif
-        return *this;
-    }
-
     /**
      * Destructor
      *

--- a/cocos/base/CCRef.h
+++ b/cocos/base/CCRef.h
@@ -28,6 +28,7 @@ THE SOFTWARE.
 
 #include "platform/CCPlatformMacros.h"
 #include "base/ccConfig.h"
+#include <atomic>
 
 #define CC_REF_LEAK_DETECTION 0
 
@@ -133,7 +134,23 @@ protected:
      */
     Ref();
 
+    Ref(const Ref& other);
+
 public:
+
+    Ref& operator=(const Ref& other)
+    {
+        this->_referenceCount.store(other._referenceCount.load(std::memory_order_relaxed), std::memory_order_relaxed);
+        
+#if CC_ENABLE_SCRIPT_BINDING
+        this->_ID = other._ID;
+        this->_luaID = other._luaID;
+        this->_scriptObject = other._scriptObject;
+#endif
+
+        return *this;
+    }
+
     /**
      * Destructor
      *
@@ -144,7 +161,7 @@ public:
 
 protected:
     /// count of references
-    unsigned int _referenceCount;
+    std::atomic<unsigned int> _referenceCount;
 
     friend class AutoreleasePool;
 


### PR DESCRIPTION
This will add a performance overhead, as atomic operations are more expensive then just normal operations
