### PR TITLE
fix: web view crash in ios 6.x

### DIFF
--- a/cocos/ui/UIWebViewImpl-ios.mm
+++ b/cocos/ui/UIWebViewImpl-ios.mm
@@ -133,6 +133,10 @@ static std::string getFixedBaseUrl(const std::string& baseUrl)
     if (!self.uiWebView) {
         self.uiWebView = [[[UIWebView alloc] init] autorelease];
         self.uiWebView.delegate = self;
+
+        auto view = cocos2d::Director::getInstance()->getOpenGLView();
+        auto frame = view->getFrameSize();
+        [self setFrameWithX:0 y:0 width:frame.width height:frame.height];
     }
     if (!self.uiWebView.superview) {
         auto view = cocos2d::Director::getInstance()->getOpenGLView();


### PR DESCRIPTION
Web view crashes on iOS 6.x devices because frame is zero.
