### PR TITLE
Add missing override keyword

### DIFF
--- a/cocos/2d/CCLabel.cpp
+++ b/cocos/2d/CCLabel.cpp
@@ -122,7 +122,7 @@ public:
         Node::updateTransform();
     }
 
-    virtual void updateColor()
+    virtual void updateColor() override
     {
         if (_textureAtlas == nullptr)
         {
@@ -146,7 +146,7 @@ public:
     }
 
     //LabelLetter doesn't need to draw directly.
-    void draw(Renderer *renderer, const Mat4 &transform, uint32_t flags)
+    void draw(Renderer *renderer, const Mat4 &transform, uint32_t flags) override
     {
     }
 };

--- a/cocos/ui/UIEditBox/UIEditBoxImpl-common.h
+++ b/cocos/ui/UIEditBox/UIEditBoxImpl-common.h
@@ -50,30 +50,30 @@ public:
      */
     virtual ~EditBoxImplCommon();
     
-    virtual bool initWithSize(const Size& size);
+    virtual bool initWithSize(const Size& size) override;
     
-    virtual void setFont(const char* pFontName, int fontSize);
-    virtual void setFontColor(const Color4B& color);
-    virtual void setPlaceholderFont(const char* pFontName, int fontSize);
-    virtual void setPlaceholderFontColor(const Color4B& color);
-    virtual void setInputMode(EditBox::InputMode inputMode);
-    virtual void setInputFlag(EditBox::InputFlag inputFlag);
-    virtual void setReturnType(EditBox::KeyboardReturnType returnType);
-    virtual void setText(const char* pText);
-    virtual void setPlaceHolder(const char* pText);
-    virtual void setVisible(bool visible);
+    virtual void setFont(const char* pFontName, int fontSize) override;
+    virtual void setFontColor(const Color4B& color) override;
+    virtual void setPlaceholderFont(const char* pFontName, int fontSize) override;
+    virtual void setPlaceholderFontColor(const Color4B& color) override;
+    virtual void setInputMode(EditBox::InputMode inputMode) override;
+    virtual void setInputFlag(EditBox::InputFlag inputFlag) override;
+    virtual void setReturnType(EditBox::KeyboardReturnType returnType) override;
+    virtual void setText(const char* pText) override;
+    virtual void setPlaceHolder(const char* pText) override;
+    virtual void setVisible(bool visible) override;
 
 
-    virtual void setMaxLength(int maxLength);
-    virtual int  getMaxLength();
+    virtual void setMaxLength(int maxLength) override;
+    virtual int  getMaxLength() override;
     
-    virtual const char* getText(void);
+    virtual const char* getText(void) override;
     virtual void refreshInactiveText();
     
-    virtual void setContentSize(const Size& size);
+    virtual void setContentSize(const Size& size) override;
     
-    virtual void setAnchorPoint(const Vec2& anchorPoint){}
-    virtual void setPosition(const Vec2& pos) {}
+    virtual void setAnchorPoint(const Vec2& anchorPoint) override {}
+    virtual void setPosition(const Vec2& pos) override {}
     
     /**
      * @js NA
@@ -84,9 +84,9 @@ public:
      * @js NA
      * @lua NA
      */
-    virtual void onEnter(void);
-    virtual void openKeyboard();
-    virtual void closeKeyboard();
+    virtual void onEnter(void) override;
+    virtual void openKeyboard() override;
+    virtual void closeKeyboard() override;
 
     virtual void onEndEditing(const std::string& text);
     
@@ -94,7 +94,7 @@ public:
     void editBoxEditingChanged(const std::string& text);
     void editBoxEditingDidEnd(const std::string& text);
     
-    virtual bool isEditing() = 0;
+    virtual bool isEditing() override = 0;
     virtual void createNativeControl(const Rect& frame) = 0;
     virtual void setNativeFont(const char* pFontName, int fontSize) = 0;
     virtual void setNativeFontColor(const Color4B& color) = 0;

--- a/cocos/ui/UIEditBox/UIEditBoxImpl-ios.h
+++ b/cocos/ui/UIEditBox/UIEditBoxImpl-ios.h
@@ -78,7 +78,7 @@ public:
     //need to remove siri text
     virtual const char* getText(void)override;
 
-    virtual void doAnimationWhenKeyboardMove(float duration, float distance);
+    virtual void doAnimationWhenKeyboardMove(float duration, float distance) override;
 private:
     UIFont*         constructFont(const char* fontName, int fontSize);
     void			adjustTextFieldPosition();

--- a/cocos/ui/UIEditBox/UIEditBoxImpl-mac.h
+++ b/cocos/ui/UIEditBox/UIEditBoxImpl-mac.h
@@ -53,39 +53,39 @@ public:
      */
     virtual ~EditBoxImplMac();
     
-    virtual bool initWithSize(const Size& size);
-    virtual void setFont(const char* pFontName, int fontSize);
-    virtual void setFontColor(const Color4B& color);
-    virtual void setPlaceholderFont(const char* pFontName, int fontSize);
-    virtual void setPlaceholderFontColor(const Color4B& color);
-    virtual void setInputMode(EditBox::InputMode inputMode);
-    virtual void setInputFlag(EditBox::InputFlag inputFlag);
-    virtual void setMaxLength(int maxLength);
-    virtual int  getMaxLength();
-    virtual void setReturnType(EditBox::KeyboardReturnType returnType);
-    virtual bool isEditing();
+    virtual bool initWithSize(const Size& size) override;
+    virtual void setFont(const char* pFontName, int fontSize) override;
+    virtual void setFontColor(const Color4B& color) override;
+    virtual void setPlaceholderFont(const char* pFontName, int fontSize) override;
+    virtual void setPlaceholderFontColor(const Color4B& color) override;
+    virtual void setInputMode(EditBox::InputMode inputMode) override;
+    virtual void setInputFlag(EditBox::InputFlag inputFlag) override;
+    virtual void setMaxLength(int maxLength) override;
+    virtual int  getMaxLength() override;
+    virtual void setReturnType(EditBox::KeyboardReturnType returnType) override;
+    virtual bool isEditing() override;
     
-    virtual void setText(const char* pText);
-    virtual const char* getText(void);
-    virtual void setPlaceHolder(const char* pText);
-    virtual void setPosition(const Vec2& pos);
-    virtual void setVisible(bool visible);
-    virtual void setContentSize(const Size& size);
-    virtual void setAnchorPoint(const Vec2& anchorPoint);
+    virtual void setText(const char* pText) override;
+    virtual const char* getText(void) override;
+    virtual void setPlaceHolder(const char* pText) override;
+    virtual void setPosition(const Vec2& pos) override;
+    virtual void setVisible(bool visible) override;
+    virtual void setContentSize(const Size& size) override;
+    virtual void setAnchorPoint(const Vec2& anchorPoint) override;
     /**
      * @js NA
      * @lua NA
      */
     virtual void draw(Renderer *renderer, const Mat4 &transform, uint32_t flags)override;
-    virtual void doAnimationWhenKeyboardMove(float duration, float distance);
-    virtual void openKeyboard();
-    virtual void closeKeyboard();
+    virtual void doAnimationWhenKeyboardMove(float duration, float distance) override;
+    virtual void openKeyboard() override;
+    virtual void closeKeyboard() override;
     virtual void updatePosition(float dt) override;
     /**
      * @js NA
      * @lua NA
      */
-    virtual void onEnter(void);
+    virtual void onEnter(void) override;
 private:
     NSPoint    convertDesignCoordToScreenCoord(const Vec2& designCoord, bool bInRetinaMode);
     void       adjustTextFieldPosition();


### PR DESCRIPTION
This fixes the following clang warnings when building using Xcode 7.

```
UIEditBoxImpl-common.h:53:18: 'initWithSize' overrides a member function but is not marked 'override'
UIEditBoxImpl-common.h:55:18: 'setFont' overrides a member function but is not marked 'override'
...
```
