### PR TITLE
Inprove SpriteFrameCache::addSpriteFramesWithDictionary

### DIFF
--- a/cocos/2d/CCSpriteFrameCache.cpp
+++ b/cocos/2d/CCSpriteFrameCache.cpp
@@ -105,8 +105,7 @@ void SpriteFrameCache::addSpriteFramesWithDictionary(ValueMap& dictionary, Textu
     CCASSERT(format >=0 && format <= 3, "format is not supported for SpriteFrameCache addSpriteFramesWithDictionary:textureFilename:");
 
     auto textureFileName = Director::getInstance()->getTextureCache()->getTextureFilePath(texture);
-    auto image = new Image();
-    image->initWithImageFile(textureFileName);
+    Image* image = nullptr;
     NinePatchImageParser parser;
     for (auto iter = framesDict.begin(); iter != framesDict.end(); ++iter)
     {
@@ -199,6 +198,10 @@ void SpriteFrameCache::addSpriteFramesWithDictionary(ValueMap& dictionary, Textu
         bool flag = NinePatchImageParser::isNinePatchImage(spriteFrameName);
         if(flag)
         {
+            if (image == nullptr) {
+                image = new Image();
+                image->initWithImageFile(textureFileName);
+            }
             parser.setSpriteFrameInfo(image, spriteFrame->getRectInPixels(), spriteFrame->isRotated());
             texture->addSpriteFrameCapInset(spriteFrame, parser.parseCapInset());
         }


### PR DESCRIPTION
- Moved initialization of image to an appropriate location, because it always called twice in SpriteFrameCache::addSpriteFramesWithFile()
