### PR TITLE
V3: fixed Windows 10 UWP app manifest by correcting image asset paths

### DIFF
--- a/cocos/2d/libcocos2d_8_1/libcocos2d_8_1/libcocos2d_8_1.Shared/libcocos2d_8_1.Shared.vcxitems.filters
+++ b/cocos/2d/libcocos2d_8_1/libcocos2d_8_1/libcocos2d_8_1.Shared/libcocos2d_8_1.Shared.vcxitems.filters
@@ -40,7 +40,7 @@
       <Filter>3d</Filter>
     </ClInclude>
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\..\..\3d\CCMotionStreak3D.h">
-        <Filter>3d</Filter>
+      <Filter>3d</Filter>
     </ClInclude>
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\..\..\3d\CCOBB.h">
       <Filter>3d</Filter>
@@ -1861,9 +1861,6 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\..\..\network\CCDownloader-curl.h">
       <Filter>network\Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\..\..\network\CCIDownloaderImpl.h">
-      <Filter>network\Header Files</Filter>
-    </ClInclude>
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\..\..\editor-support\cocostudio\WidgetReader\GameNode3DReader\GameNode3DReader.h">
       <Filter>cocostudio\reader\WidgetReader\GameNodeDReader</Filter>
     </ClInclude>
@@ -1873,6 +1870,7 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\..\..\renderer\CCTextureCube.h">
       <Filter>renderer</Filter>
     </ClInclude>
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\..\..\network\CCDownloaderImpl.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\..\..\cocos2d.cpp">
@@ -1908,7 +1906,7 @@
       <Filter>3d</Filter>
     </ClCompile>
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\..\..\3d\CCMotionStreak3D.cpp">
-        <Filter>3d</Filter>
+      <Filter>3d</Filter>
     </ClCompile>
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\..\..\3d\CCOBB.cpp">
       <Filter>3d</Filter>

--- a/cocos/audio/winrt/AudioEngine-winrt.cpp
+++ b/cocos/audio/winrt/AudioEngine-winrt.cpp
@@ -16,11 +16,15 @@
 * See the License for the specific language governing permissions and limitations under the License.
 */
 
+#include "base/ccMacros.h"
 #include "platform/CCPlatformConfig.h"
 
 #if CC_TARGET_PLATFORM == CC_PLATFORM_WINRT
 
 #include "AudioEngine-winrt.h"
+#include "platform/CCFileUtils.h"
+#include "base/CCDirector.h"
+#include "base/CCScheduler.h"
 
 using namespace cocos2d;
 using namespace cocos2d::experimental;

--- a/cocos/audio/winrt/AudioSourceReader.cpp
+++ b/cocos/audio/winrt/AudioSourceReader.cpp
@@ -16,7 +16,10 @@
 * See the License for the specific language governing permissions and limitations under the License.
 */
 
+#include "base/ccMacros.h"
 #include "platform/CCPlatformConfig.h"
+#include "platform/CCFileUtils.h"
+
 
 #if CC_TARGET_PLATFORM == CC_PLATFORM_WINRT
 

--- a/cocos/audio/winrt/AudioSourceReader.h
+++ b/cocos/audio/winrt/AudioSourceReader.h
@@ -16,6 +16,7 @@
 * See the License for the specific language governing permissions and limitations under the License.
 */
 
+#include "base/ccMacros.h"
 #include "platform/CCPlatformConfig.h"
 
 #if CC_TARGET_PLATFORM == CC_PLATFORM_WINRT

--- a/cocos/base/CCUserDefault-winrt.cpp
+++ b/cocos/base/CCUserDefault-winrt.cpp
@@ -26,6 +26,7 @@ THE SOFTWARE.
 #include "platform/CCCommon.h"
 #include "base/base64.h"
 #include "base/ccUtils.h"
+#include "platform/CCFileUtils.h"
 
 #if (CC_TARGET_PLATFORM == CC_PLATFORM_WINRT)
 #include "CCWinRTUtils.h"

--- a/cocos/editor-support/cocosbuilder/CCBReader.h
+++ b/cocos/editor-support/cocosbuilder/CCBReader.h
@@ -11,6 +11,12 @@
 #include "extensions/GUI/CCControlExtension/CCControl.h"
 #include "cocosbuilder/CCBAnimationManager.h"
 
+#if (CC_TARGET_PLATFORM == CC_PLATFORM_WINRT)
+#ifdef ABSOLUTE
+#undef ABSOLUTE
+#endif
+#endif
+
 #define CCB_STATIC_NEW_AUTORELEASE_OBJECT_METHOD(T, METHOD) static T * METHOD() { \
     T * ptr = new (std::nothrow) T(); \
     if(ptr != NULL) { \

--- a/cocos/network/HttpCookie.h
+++ b/cocos/network/HttpCookie.h
@@ -26,6 +26,9 @@
 #define HTTP_COOKIE_H
 /// @cond DO_NOT_SHOW
 
+#include <string>
+#include <vector>
+
 struct CookiesInfo
 {
     std::string domain;

--- a/cocos/platform/winrt/CCApplication.cpp
+++ b/cocos/platform/winrt/CCApplication.cpp
@@ -35,6 +35,7 @@ using namespace Windows::Foundation;
 #include <algorithm>
 #include "platform/CCFileUtils.h"
 #include "CCWinRTUtils.h"
+#include "platform/CCApplication.h"
 
 /**
 @brief    This function change the PVRFrame show/hide setting in register.

--- a/cocos/platform/winrt/CCCommon.cpp
+++ b/cocos/platform/winrt/CCCommon.cpp
@@ -24,6 +24,7 @@ THE SOFTWARE.
 ****************************************************************************/
 #include "platform/CCCommon.h"
 #include "platform/CCStdC.h"
+#include "platform/winrt/CCGLViewImpl-winrt.h"
 #include "CCWinRTUtils.h"
 
 #if defined(VLD_DEBUG_MEMORY)

--- a/cocos/platform/winrt/CCDevice.cpp
+++ b/cocos/platform/winrt/CCDevice.cpp
@@ -26,12 +26,12 @@ THE SOFTWARE.
 #include "platform/CCPlatformConfig.h"
 #if (CC_TARGET_PLATFORM == CC_PLATFORM_WINRT)
 
-#include "cocos2d.h"
 #include "platform/CCDevice.h"
 #include "platform/CCFileUtils.h"
 #include "platform/winrt/CCFreeTypeFont.h"
 #include "platform/winrt/CCWinRTUtils.h"
 #include "platform/CCStdC.h"
+#include "platform/winrt/CCGLViewImpl-winrt.h"
 
 using namespace Windows::Graphics::Display;
 using namespace Windows::Devices::Sensors;

--- a/cocos/platform/winrt/CCGLViewImpl-winrt.cpp
+++ b/cocos/platform/winrt/CCGLViewImpl-winrt.cpp
@@ -28,9 +28,15 @@ THE SOFTWARE.
 #include "base/CCDirector.h"
 #include "base/CCTouch.h"
 #include "base/CCIMEDispatcher.h"
+#include "base/CCEventListenerKeyboard.h"
 #include "CCApplication.h"
 #include "CCWinRTUtils.h"
 #include "deprecated/CCNotificationCenter.h"
+#include "base/CCDirector.h"
+#include "base/CCEventDispatcher.h"
+#include "base/CCIMEDispatcher.h"
+#include "base/CCEventMouse.h"
+
 #include <map>
 
 using namespace Platform;

--- a/cocos/platform/winrt/CCGLViewImpl-winrt.h
+++ b/cocos/platform/winrt/CCGLViewImpl-winrt.h
@@ -28,16 +28,15 @@ THE SOFTWARE.
 
 #include "CCStdC.h"
 #include "platform/CCCommon.h"
+#include "Keyboard-winrt.h"
 #include "platform/CCGLView.h"
-#include "InputEvent.h"
-
+#include "base/CCEventKeyboard.h"
 
 #include <agile.h>
 #include <concurrent_queue.h>
 #include <string>
 #include <memory>
 #include <wrl/client.h>
-#include <Keyboard-winrt.h>
 
 NS_CC_BEGIN
 

--- a/cocos/platform/winrt/CCPThreadWinRT.h
+++ b/cocos/platform/winrt/CCPThreadWinRT.h
@@ -30,9 +30,12 @@ THE SOFTWARE.
 #include "platform/CCPlatformConfig.h"
 #if (CC_TARGET_PLATFORM == CC_PLATFORM_WINRT)
 
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include <Windows.h>
 #include "platform/CCPlatformMacros.h"
 
-#include <Windows.h>
 
 NS_CC_BEGIN
 

--- a/cocos/platform/winrt/CCWinRTUtils.cpp
+++ b/cocos/platform/winrt/CCWinRTUtils.cpp
@@ -23,15 +23,15 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 ****************************************************************************/
 #include "CCWinRTUtils.h"
-#ifndef WIN32_LEAN_AND_MEAN
-#define WIN32_LEAN_AND_MEAN 1
-#endif
-#include <Windows.h>
 #include <wrl/client.h>
 #include <wrl/wrappers/corewrappers.h>
 #include <ppl.h>
 #include <ppltasks.h>
 #include <sstream>
+#include "base/ccMacros.h"
+#include "platform/CCPlatformMacros.h"
+#include "platform/CCFileUtils.h"
+#include "base/CCUserDefault.h"
 
 using namespace Windows::UI::Xaml;
 using namespace Windows::UI::Xaml::Controls;

--- a/cocos/platform/winrt/CCWinRTUtils.h
+++ b/cocos/platform/winrt/CCWinRTUtils.h
@@ -27,9 +27,6 @@ THE SOFTWARE.
 #define __CCWINRT_UTILS_H__
 
 #include "platform/CCPlatformMacros.h"
-
-#include <wrl/client.h>
-#include <ppl.h>
 #include <ppltasks.h>
 
 #include <string>

--- a/cocos/platform/winrt/InputEvent.cpp
+++ b/cocos/platform/winrt/InputEvent.cpp
@@ -27,6 +27,9 @@ THE SOFTWARE.
 #include "CCWinRTUtils.h"
 #include "CCGLViewImpl-winrt.h"
 #include "base/CCEventAcceleration.h"
+#include "base/CCDirector.h"
+#include "base/CCEventDispatcher.h"
+#include "base/CCIMEDispatcher.h"
 
 NS_CC_BEGIN
 

--- a/cocos/platform/winrt/InputEvent.h
+++ b/cocos/platform/winrt/InputEvent.h
@@ -23,14 +23,16 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 ****************************************************************************/
 
-#ifndef __INPUT_EVENT__
-#define __INPUT_EVENT__
+#ifndef __WINRT_INPUT_EVENT__
+#define __WINRT_INPUT_EVENT__
 
-#include "cocos2d.h"
+#include "CCPlatformMacros.h"
 #include "InputEventTypes.h"
+#include "base/ccTypes.h"
 #include <agile.h>
 
 NS_CC_BEGIN
+
 
 enum PointerEventType
 {
@@ -143,5 +145,5 @@ private:
 
 NS_CC_END
 
-#endif // #ifndef __INPUT_EVENT__
+#endif // #ifndef __WINRT_INPUT_EVENT__
 

--- a/cocos/platform/winrt/Keyboard-winrt.cpp
+++ b/cocos/platform/winrt/Keyboard-winrt.cpp
@@ -26,10 +26,14 @@ THE SOFTWARE.
 ****************************************************************************/
 
 #include "Keyboard-winrt.h"
+#include "base/CCEventKeyboard.h"
+#include "CCGLViewImpl-winrt.h"
+#include "base/CCIMEDispatcher.h"
+#include "base/CCDirector.h"
+#include "base/CCEventDispatcher.h"
 
 using namespace cocos2d;
 using namespace Platform;
-using namespace Concurrency;
 using namespace Windows::System;
 using namespace Windows::System::Threading;
 using namespace Windows::UI::Core;

--- a/cocos/platform/winrt/Keyboard-winrt.h
+++ b/cocos/platform/winrt/Keyboard-winrt.h
@@ -28,6 +28,7 @@ THE SOFTWARE.
 #pragma once
 
 #include <agile.h>
+#include "InputEvent.h"
 
 NS_CC_BEGIN
 

--- a/cocos/platform/winrt/WICImageLoader-winrt.h
+++ b/cocos/platform/winrt/WICImageLoader-winrt.h
@@ -28,6 +28,9 @@ obtained from https://directxtk.codeplex.com
 #ifndef __WIC_IMAGE_LOADER_H__
 #define __WIC_IMAGE_LOADER_H__
 
+#include "base/ccConfig.h"
+
+
 #if defined(CC_USE_WIC)
 
 #include <memory>

--- a/cocos/scripting/js-bindings/proj.win8.1-universal/libjscocos2d/libjscocos2d.Shared/libjscocos2d.Shared.vcxitems.filters
+++ b/cocos/scripting/js-bindings/proj.win8.1-universal/libjscocos2d/libjscocos2d.Shared/libjscocos2d.Shared.vcxitems.filters
@@ -95,9 +95,6 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\..\manual\cocostudio\jsb_cocos2dx_studio_manual.h">
       <Filter>manual\cocostudio</Filter>
     </ClInclude>
-    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\..\manual\component\CCComponentJS.h">
-      <Filter>manual\component</Filter>
-    </ClInclude>
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\..\manual\extension\jsb_cocos2dx_extension_manual.h">
       <Filter>manual\extension</Filter>
     </ClInclude>
@@ -143,6 +140,7 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\..\auto\jsb_cocos2dx_navmesh_auto.hpp">
       <Filter>auto</Filter>
     </ClInclude>
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\..\manual\component\CCComponentJS.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\..\auto\jsb_cocos2dx_3d_auto.cpp">
@@ -220,9 +218,6 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\..\manual\cocostudio\jsb_cocos2dx_studio_manual.cpp">
       <Filter>manual\cocostudio</Filter>
     </ClCompile>
-    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\..\manual\component\CCComponentJS.cpp">
-      <Filter>manual\component</Filter>
-    </ClCompile>
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\..\manual\extension\jsb_cocos2dx_extension_manual.cpp">
       <Filter>manual\extension</Filter>
     </ClCompile>
@@ -265,6 +260,7 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\..\auto\jsb_cocos2dx_navmesh_auto.cpp">
       <Filter>auto</Filter>
     </ClCompile>
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\..\manual\component\CCComponentJS.cpp" />
   </ItemGroup>
   <ItemGroup>
     <Filter Include="auto">

--- a/cocos/ui/UIEditBox/UIEditBoxImpl-winrt.h
+++ b/cocos/ui/UIEditBox/UIEditBoxImpl-winrt.h
@@ -27,6 +27,9 @@ THE SOFTWARE.
 #include "platform/CCPlatformConfig.h"
 #if (CC_TARGET_PLATFORM == CC_PLATFORM_WINRT)
 
+#include <agile.h>
+#include <concrt.h>
+
 #include "UIEditBoxImpl.h"
 
 NS_CC_BEGIN

--- a/tests/cpp-tests/proj.win10/Package.appxmanifest
+++ b/tests/cpp-tests/proj.win10/Package.appxmanifest
@@ -15,7 +15,13 @@
   </Resources>
   <Applications>
     <Application Id="App" Executable="$targetnametoken$.exe" EntryPoint="cpp_tests.App">
-      <uap:VisualElements DisplayName="cpp-tests" Square150x150Logo="Assets\Logo.png" Square44x44Logo="Assets\SmallLogo.png" Description="cpp-tests" BackgroundColor="#464646">
+      <uap:VisualElements DisplayName="cpp-tests" Square150x150Logo="Assets\Square150x150Logo.png" Square44x44Logo="Assets\SmallLogo.png" Description="cpp-tests" BackgroundColor="#464646">
+        <uap:DefaultTile Wide310x150Logo="Assets\Wide310x150Logo.png">
+          <uap:ShowNameOnTiles>
+            <uap:ShowOn Tile="square150x150Logo" />
+            <uap:ShowOn Tile="wide310x150Logo" />
+          </uap:ShowNameOnTiles>
+        </uap:DefaultTile>
         <uap:SplashScreen Image="Assets\SplashScreen.png" />
         <uap:InitialRotationPreference>
           <uap:Rotation Preference="landscape" />


### PR DESCRIPTION
V3: fixed Windows 10 UWP app manifest by correcting image asset paths. The latest update to Visual Studio 2015 identified that there were incorrect paths to the app image files.

Cleaned up include paths for all WINRT platforms
