### PR TITLE
V3: fixed another missing image asset in Win10 UWP manifest

### DIFF
--- a/cocos/platform/winrt/CCStdC.h
+++ b/cocos/platform/winrt/CCStdC.h
@@ -49,8 +49,10 @@ typedef SSIZE_T ssize_t;
     #define isnan   _isnan
 #endif
 
+#if _MSC_VER < 1900
 #ifndef snprintf
 #define snprintf _snprintf
+#endif
 #endif
 
 #include <math.h>

--- a/tests/cpp-tests/proj.win10/Package.appxmanifest
+++ b/tests/cpp-tests/proj.win10/Package.appxmanifest
@@ -15,10 +15,9 @@
   </Resources>
   <Applications>
     <Application Id="App" Executable="$targetnametoken$.exe" EntryPoint="cpp_tests.App">
-      <uap:VisualElements DisplayName="cpp-tests" Square150x150Logo="Assets\Square150x150Logo.png" Square44x44Logo="Assets\SmallLogo.png" Description="cpp-tests" BackgroundColor="#464646">
+      <uap:VisualElements DisplayName="cpp-tests" Square150x150Logo="Assets\Square150x150Logo.png" Square44x44Logo="Assets\Square44x44Logo.png" Description="cpp-tests" BackgroundColor="#464646">
         <uap:DefaultTile Wide310x150Logo="Assets\Wide310x150Logo.png">
           <uap:ShowNameOnTiles>
-            <uap:ShowOn Tile="square150x150Logo" />
             <uap:ShowOn Tile="wide310x150Logo" />
           </uap:ShowNameOnTiles>
         </uap:DefaultTile>


### PR DESCRIPTION
This PR fixes another missing image asset in Win10 UWP manifest for cpp-tests Win10 project.
