### PR TITLE
Fix -Wformat-security warning on Xcode

### DIFF
--- a/cocos/platform/desktop/CCGLViewImpl-desktop.cpp
+++ b/cocos/platform/desktop/CCGLViewImpl-desktop.cpp
@@ -615,7 +615,7 @@ Rect GLViewImpl::getScissorRect() const
 void GLViewImpl::onGLFWError(int errorID, const char* errorDesc)
 {
     _glfwError = StringUtils::format("GLFWError #%d Happen, %s", errorID, errorDesc);
-    CCLOGERROR(_glfwError.c_str());
+    CCLOGERROR("%s", _glfwError.c_str());
 }
 
 void GLViewImpl::onGLFWMouseCallBack(GLFWwindow* window, int button, int action, int modify)


### PR DESCRIPTION
This fixes `-Wformat-security` warning like:

```
CCGLViewImpl-desktop.cpp:618:16: Format string is not a string literal (potentially insecure)
```
