### PR TITLE
issues #14050 ActionManager memory leak

### DIFF
--- a/cocos/2d/CCActionManager.cpp
+++ b/cocos/2d/CCActionManager.cpp
@@ -450,6 +450,11 @@ void ActionManager::update(float dt)
         {
             deleteHashElement(_currentTarget);
         }
+        //if some node refrence 'target', it's refrence count >= 2 (issues #14050)
+        else if (_currentTarget->target->getReferenceCount() == 1)
+        {
+            deleteHashElement(_currentTarget);
+        }
     }
 
     // issue #635


### PR DESCRIPTION
fixed ActionManager memory leak
when I create a node with an action, and not add to any other node, such as:

```
var sp = cc.Sprite.create("text.png");
sp.runAction(cc.fadeOut(10));
//has not parent
```

This will lead to memory leak, in correctly, 'sp' will be released in next frame, but when it run an action, 'sp' will not be released forever.
