### PR TITLE
Fixed AudioPlayer crash in Win32

### DIFF
--- a/cocos/audio/win32/AudioPlayer.cpp
+++ b/cocos/audio/win32/AudioPlayer.cpp
@@ -56,6 +56,7 @@ AudioPlayer::AudioPlayer(const AudioPlayer& player)
     _finishCallbak = player._finishCallbak;
     _ready = player._ready;
     _audioCache = player._audioCache;
+    _readForRemove = player._readForRemove;
 }
 
 AudioPlayer::~AudioPlayer()


### PR DESCRIPTION
Environment: Win32

Because cocos2d::experimental::AudioPlayer copy constructor doesn't initialize _readForRemove property, _readForRemove value is not false. So AudioEngineImpl::update() erases this AudioPlayer immediate during the audio is playing. So that makes crash at the AudioPlayer::rotateBufferThread().

※ AudioPlayer is inserted into AudioEngineImpl::_audioPlayers by the copy constructor at AudioEngineImple::play2d().
