### PR TITLE
Remove screen direction check in simulator to avoid render error

### DIFF
--- a/tools/simulator/config.json
+++ b/tools/simulator/config.json
@@ -1,6 +1,5 @@
 {
     "init_cfg":{
-       "isLandscape": true,
        "isWindowTop": false,
        "name": "simulator",
        "width": 960,

--- a/tools/simulator/frameworks/runtime-src/proj.win32/SimulatorWin.cpp
+++ b/tools/simulator/frameworks/runtime-src/proj.win32/SimulatorWin.cpp
@@ -758,14 +758,14 @@ void SimulatorWin::parseCocosProjectConfig(ProjectConfig &config)
     config.setConsolePort(parser->getConsolePort());
     config.setFileUploadPort(parser->getUploadPort());
     config.setFrameSize(parser->getInitViewSize());
-    if (parser->isLanscape())
-    {
-        config.changeFrameOrientationToLandscape();
-    }
-    else
-    {
-        config.changeFrameOrientationToPortait();
-    }
+    //if (parser->isLanscape())
+    //{
+    //    config.changeFrameOrientationToLandscape();
+    //}
+    //else
+    //{
+    //    config.changeFrameOrientationToPortait();
+    //}
     config.setScriptFile(parser->getEntryFile());
 }
 

--- a/tools/simulator/libsimulator/lib/runtime/ConfigParser.cpp
+++ b/tools/simulator/libsimulator/lib/runtime/ConfigParser.cpp
@@ -76,10 +76,10 @@ void ConfigParser::readConfig(const string &filepath)
             {
                 _viewName = objectInitView["name"].GetString();
             }
-            if (objectInitView.HasMember("isLandscape") && objectInitView["isLandscape"].IsBool())
-            {
-                _isLandscape = objectInitView["isLandscape"].GetBool();
-            }
+            //if (objectInitView.HasMember("isLandscape") && objectInitView["isLandscape"].IsBool())
+            //{
+            //    _isLandscape = objectInitView["isLandscape"].GetBool();
+            //}
             if (objectInitView.HasMember("entry") && objectInitView["entry"].IsString())
             {
                 setEntryFile(objectInitView["entry"].GetString());
@@ -120,7 +120,7 @@ void ConfigParser::readConfig(const string &filepath)
 }
 
 ConfigParser::ConfigParser(void) :
-_isLandscape(true),
+//_isLandscape(false),
 _isWindowTop(false),
 _consolePort(kProjectConfigConsolePort),
 _uploadPort(kProjectConfigUploadPort),
@@ -152,10 +152,10 @@ Size ConfigParser::getInitViewSize()
     return _initViewSize;
 }
 
-bool ConfigParser::isLanscape()
-{
-    return _isLandscape;
-}
+//bool ConfigParser::isLanscape()
+//{
+//    return _isLandscape;
+//}
 
 bool ConfigParser::isWindowTop()
 {

--- a/tools/simulator/libsimulator/lib/runtime/ConfigParser.h
+++ b/tools/simulator/libsimulator/lib/runtime/ConfigParser.h
@@ -33,7 +33,7 @@ public:
     int getConsolePort();
     int getUploadPort();
     int getDebugPort();
-    bool isLanscape();
+    //bool isLanscape();
     bool isWindowTop();
     
     void setEntryFile(const std::string &file);
@@ -49,7 +49,7 @@ private:
     cocos2d::Size _initViewSize;
     string _viewName;
     string _entryfile;
-    bool _isLandscape;
+    //bool _isLandscape;
     bool _isWindowTop;
     int _consolePort;
     int _uploadPort;

--- a/tools/simulator/libsimulator/lib/runtime/ConnectWaitLayer.cpp
+++ b/tools/simulator/libsimulator/lib/runtime/ConnectWaitLayer.cpp
@@ -37,15 +37,15 @@ ConnectWaitLayer::ConnectWaitLayer()
     int designHeight = 800;
     _imagebg = new Image();
     
-    if (ConfigParser::getInstance()->isLanscape())
-    {
-        _imagebg->initWithImageData(__landscapePngData, sizeof(__landscapePngData));
-        Director::getInstance()->getOpenGLView()->setDesignResolutionSize(designWidth, designHeight, ResolutionPolicy::EXACT_FIT);
-    } else
-    {
-        _imagebg->initWithImageData(__portraitPngData, sizeof(__portraitPngData));
-        Director::getInstance()->getOpenGLView()->setDesignResolutionSize(designHeight, designWidth, ResolutionPolicy::FIXED_HEIGHT);
-    }
+    //if (ConfigParser::getInstance()->isLanscape())
+    //{
+    //    _imagebg->initWithImageData(__landscapePngData, sizeof(__landscapePngData));
+    //    Director::getInstance()->getOpenGLView()->setDesignResolutionSize(designWidth, designHeight, ResolutionPolicy::EXACT_FIT);
+    //} else
+    //{
+    //    _imagebg->initWithImageData(__portraitPngData, sizeof(__portraitPngData));
+    //    Director::getInstance()->getOpenGLView()->setDesignResolutionSize(designHeight, designWidth, ResolutionPolicy::FIXED_HEIGHT);
+    //}
     Texture2D* texturebg = Director::getInstance()->getTextureCache()->addImage(_imagebg, "play_background");
     auto background = Sprite::createWithTexture(texturebg);
     background->setAnchorPoint(Vec2(0.5, 0.5));
@@ -113,16 +113,16 @@ ConnectWaitLayer::ConnectWaitLayer()
     _labelUploadFile->setAlignment(TextHAlignment::LEFT);
     addChild(_labelUploadFile, 9003);
 
-    if (ConfigParser::getInstance()->isLanscape())
-    {
-        playSprite->setPosition(lanscaptX, lanscaptY);
-        shineSprite->setPosition(lanscaptX, lanscaptY);
-    }
-    else
-    {
-        playSprite->setPosition(portraitX, portraitY);
-        shineSprite->setPosition(portraitX, portraitY);
-    }
+    //if (ConfigParser::getInstance()->isLanscape())
+    //{
+    //    playSprite->setPosition(lanscaptX, lanscaptY);
+    //    shineSprite->setPosition(lanscaptX, lanscaptY);
+    //}
+    //else
+    //{
+    //    playSprite->setPosition(portraitX, portraitY);
+    //    shineSprite->setPosition(portraitX, portraitY);
+    //}
 
     auto listener = EventListenerTouchOneByOne::create();
     listener->onTouchBegan = [](Touch* touch, Event  *event)->bool{

--- a/tools/simulator/libsimulator/lib/runtime/Runtime.cpp
+++ b/tools/simulator/libsimulator/lib/runtime/Runtime.cpp
@@ -94,10 +94,10 @@ const char* getRuntimeVersion()
 void resetDesignResolution()
 {
     cocos2d::Size size = ConfigParser::getInstance()->getInitViewSize();
-    if (!ConfigParser::getInstance()->isLanscape())
-    {
-        std::swap(size.width, size.height);
-    }
+    //if (!ConfigParser::getInstance()->isLanscape())
+    //{
+    //    std::swap(size.width, size.height);
+    //}
     Director::getInstance()->getOpenGLView()->setDesignResolutionSize(size.width, size.height, ResolutionPolicy::EXACT_FIT);
 }
 


### PR DESCRIPTION
Simulator set to landscape screen direction in default, when create a portrait scene in CocoStudio, the simulator try to set default scene size as landscape, it will make scene display in stretch mode can not fill the window.
