### PR TITLE
PMA Handling issue

### DIFF
--- a/cocos/renderer/CCTexture2D.cpp
+++ b/cocos/renderer/CCTexture2D.cpp
@@ -756,6 +756,9 @@ bool Texture2D::initWithImage(Image *image, PixelFormat format)
 
         initWithMipmaps(image->getMipmaps(), image->getNumberOfMipmaps(), image->getRenderFormat(), imageWidth, imageHeight);
         
+        // set the premultiplied tag
+        _hasPremultipliedAlpha = image->hasPremultipliedAlpha();
+        
         return true;
     }
     else if (image->isCompressed())
@@ -766,6 +769,10 @@ bool Texture2D::initWithImage(Image *image, PixelFormat format)
         }
 
         initWithData(tempData, tempDataLen, image->getRenderFormat(), imageWidth, imageHeight, imageSize);
+        
+        // set the premultiplied tag
+        _hasPremultipliedAlpha = image->hasPremultipliedAlpha();
+        
         return true;
     }
     else


### PR DESCRIPTION
Hi,

I compared to cocos2D-x v2.x and it seems that there is an issue with the _hasPremultipliedAlpha flag not beeing set correctly for mipmaps and compressed textures.
I guess it's a mistake due to the reorganization of the code between the old CCTexture2D and the new one.
In our tests, this fixes the issue.

Best,

Sebastien
