### PR TITLE
V3: fixed msbuild by removing incorrect AppxBundle properties from project

### DIFF
--- a/tests/cpp-empty-test/proj.win10/cpp-empty-test.vcxproj
+++ b/tests/cpp-empty-test/proj.win10/cpp-empty-test.vcxproj
@@ -125,8 +125,6 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
     <PackageCertificateKeyFile>cpp-empty-test_TemporaryKey.pfx</PackageCertificateKeyFile>
-    <AppxAutoIncrementPackageRevision>False</AppxAutoIncrementPackageRevision>
-    <AppxBundlePlatforms>x86</AppxBundlePlatforms>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <LinkIncremental>false</LinkIncremental>

--- a/tests/cpp-tests/proj.win10/cpp-tests.vcxproj
+++ b/tests/cpp-tests/proj.win10/cpp-tests.vcxproj
@@ -125,9 +125,6 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
     <PackageCertificateKeyFile>cpp-tests_TemporaryKey.pfx</PackageCertificateKeyFile>
-    <AppxAutoIncrementPackageRevision>False</AppxAutoIncrementPackageRevision>
-    <AppxBundlePlatforms>arm</AppxBundlePlatforms>
-    <AppxBundle>Always</AppxBundle>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <LinkIncremental>false</LinkIncremental>


### PR DESCRIPTION
This pull requests fixes building the Windows 10 UWP apps from the command line using MSBuild. There was some incorrect AppxBundlePlatforms properties in the vcxproj for ccp-test and empty-test.
