### PR TITLE
CPPCheck fixes, correct deallocation, array size.

### DIFF
--- a/cocos/platform/winrt/CCApplication.cpp
+++ b/cocos/platform/winrt/CCApplication.cpp
@@ -122,7 +122,7 @@ const char * Application::getCurrentLanguageCode()
 
         if (pwszLanguagesBuffer)
         {
-            delete pwszLanguagesBuffer;
+            delete [] pwszLanguagesBuffer;
         }
     }
 

--- a/extensions/Particle3D/PU/CCPUScriptCompiler.cpp
+++ b/extensions/Particle3D/PU/CCPUScriptCompiler.cpp
@@ -302,8 +302,8 @@ void PUScriptCompiler::visit(PUConcreteNode *node)
             temp2 = *iter;
         
         
-        //brance inner//
-        if(temp1->type == CNT_RBRACE && temp2->type == CNT_LBRACE)
+        //brance inner
+        if(temp1 && temp1->type == CNT_RBRACE && temp2 && temp2->type == CNT_LBRACE)
         {
            
             if(node->children.size() < 2)

--- a/templates/lua-template-default/frameworks/runtime-src/proj.win32/SimulatorWin.cpp
+++ b/templates/lua-template-default/frameworks/runtime-src/proj.win32/SimulatorWin.cpp
@@ -668,7 +668,7 @@ std::string SimulatorWin::getUserDocumentPath()
     char* tempstring = new char[length + 1];
     wcstombs(tempstring, filePath, length + 1);
     string userDocumentPath(tempstring);
-    free(tempstring);
+    delete [] tempstring;
 
     userDocumentPath = convertPathFormatToUnixStyle(userDocumentPath);
     userDocumentPath.append("/");

--- a/tools/simulator/frameworks/runtime-src/proj.win32/SimulatorWin.cpp
+++ b/tools/simulator/frameworks/runtime-src/proj.win32/SimulatorWin.cpp
@@ -797,7 +797,7 @@ std::string SimulatorWin::getUserDocumentPath()
     char* tempstring = new char[length + 1];
     wcstombs(tempstring, filePath, length + 1);
     string userDocumentPath(tempstring);
-    free(tempstring);
+    delete [] tempstring;
 
     userDocumentPath = convertPathFormatToUnixStyle(userDocumentPath);
     userDocumentPath.append("/");

--- a/tools/simulator/libsimulator/lib/platform/win32/DeviceEx-win32.cpp
+++ b/tools/simulator/libsimulator/lib/platform/win32/DeviceEx-win32.cpp
@@ -65,7 +65,7 @@ void DeviceEx::makeUILangName()
             WideCharToMultiByte(CP_UTF8, 0, pwszLanguagesBuffer, -1, dest, size, NULL, NULL);
             _uiLangName = dest;
         }
-        delete pwszLanguagesBuffer;
+        delete [] pwszLanguagesBuffer;
     }
 }
 

--- a/tools/simulator/libsimulator/lib/platform/win32/SimulatorWin.cpp
+++ b/tools/simulator/libsimulator/lib/platform/win32/SimulatorWin.cpp
@@ -650,7 +650,7 @@ std::string SimulatorWin::getUserDocumentPath()
     char* tempstring = new char[length + 1];
     wcstombs(tempstring, filePath, length + 1);
     string userDocumentPath(tempstring);
-    free(tempstring);
+    delete [] tempstring;
 
     userDocumentPath = convertPathFormatToUnixStyle(userDocumentPath);
     userDocumentPath.append("/");

--- a/tools/simulator/libsimulator/lib/runtime/FileServer.cpp
+++ b/tools/simulator/libsimulator/lib/runtime/FileServer.cpp
@@ -508,7 +508,7 @@ void FileServer::loopResponse()
         char dataBuf[1024] = {0};
         struct ResponseHeaderStruct
         {
-            char startFlag[12];
+            char startFlag[13]; // needs to store PROTO_START, which is 12+NULL long
             unsigned short protoNum;
             unsigned short protoBufLen;
         };


### PR DESCRIPTION
General Fixes:
- changed some delete operations to be deletions of arrays where applicable
- changed some "free" operations to "delete" where memory was allocated with "new"

CCPUScriptCompiler.cpp:
- added checks to see if temp1 and temp2 are non-null before dereferencing them

FileServer.cpp:
- changed the size of startFlag to be 13, seeing as the strcpy into it copies a string, "RuntimeSend:",
  is already 12 characters long, but strcpy() attempts to copy the NULL terminator too.
