### PR TITLE
Fix naming typos

### DIFF
--- a/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxEditBox.java
+++ b/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxEditBox.java
@@ -106,7 +106,7 @@ public class Cocos2dxEditBox extends EditText {
     private final int kKeyboardReturnTypeGo = 4;
 
     private int mInputFlagConstraints;
-    private int mInputModeContraints;
+    private int mInputModeConstraints;
     private  int mMaxLength;
 
     //OpenGL view scaleX
@@ -146,7 +146,7 @@ public class Cocos2dxEditBox extends EditText {
     }
 
     public void setMultilineEnabled(boolean flag){
-        this.mInputModeContraints |= InputType.TYPE_TEXT_FLAG_MULTI_LINE;
+        this.mInputModeConstraints |= InputType.TYPE_TEXT_FLAG_MULTI_LINE;
     }
 
     public void setReturnType(int returnType) {
@@ -176,32 +176,32 @@ public class Cocos2dxEditBox extends EditText {
 
         switch (inputMode) {
             case kEditBoxInputModeAny:
-                this.mInputModeContraints = InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_FLAG_MULTI_LINE;
+                this.mInputModeConstraints = InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_FLAG_MULTI_LINE;
                 break;
             case kEditBoxInputModeEmailAddr:
-                this.mInputModeContraints = InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_VARIATION_EMAIL_ADDRESS;
+                this.mInputModeConstraints = InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_VARIATION_EMAIL_ADDRESS;
                 break;
             case kEditBoxInputModeNumeric:
-                this.mInputModeContraints = InputType.TYPE_CLASS_NUMBER | InputType.TYPE_NUMBER_FLAG_SIGNED;
+                this.mInputModeConstraints = InputType.TYPE_CLASS_NUMBER | InputType.TYPE_NUMBER_FLAG_SIGNED;
                 break;
             case kEditBoxInputModePhoneNumber:
-                this.mInputModeContraints = InputType.TYPE_CLASS_PHONE;
+                this.mInputModeConstraints = InputType.TYPE_CLASS_PHONE;
                 break;
             case kEditBoxInputModeUrl:
-                this.mInputModeContraints = InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_VARIATION_URI;
+                this.mInputModeConstraints = InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_VARIATION_URI;
                 break;
             case kEditBoxInputModeDecimal:
-                this.mInputModeContraints = InputType.TYPE_CLASS_NUMBER | InputType.TYPE_NUMBER_FLAG_DECIMAL | InputType.TYPE_NUMBER_FLAG_SIGNED;
+                this.mInputModeConstraints = InputType.TYPE_CLASS_NUMBER | InputType.TYPE_NUMBER_FLAG_DECIMAL | InputType.TYPE_NUMBER_FLAG_SIGNED;
                 break;
             case kEditBoxInputModeSingleLine:
-                this.mInputModeContraints = InputType.TYPE_CLASS_TEXT;
+                this.mInputModeConstraints = InputType.TYPE_CLASS_TEXT;
                 break;
             default:
 
                 break;
         }
 
-        this.setInputType(this.mInputModeContraints | this.mInputFlagConstraints);
+        this.setInputType(this.mInputModeConstraints | this.mInputFlagConstraints);
 
     }
 
@@ -247,6 +247,6 @@ public class Cocos2dxEditBox extends EditText {
                 break;
         }
 
-        this.setInputType(this.mInputFlagConstraints | this.mInputModeContraints);
+        this.setInputType(this.mInputFlagConstraints | this.mInputModeConstraints);
     }
 }

--- a/cocos/platform/ios/CCDevice-ios.mm
+++ b/cocos/platform/ios/CCDevice-ios.mm
@@ -49,7 +49,7 @@
     CMMotionManager *_motionManager;
 }
 
-+ (id) sharedAccelerometerDispather;
++ (id) sharedAccelerometerDispatcher;
 - (id) init;
 - (void) setAccelerometerEnabled: (bool) isEnabled;
 - (void) setAccelerometerInterval:(float) interval;
@@ -60,7 +60,7 @@
 
 static CCAccelerometerDispatcher* s_pAccelerometerDispatcher;
 
-+ (id) sharedAccelerometerDispather
++ (id) sharedAccelerometerDispatcher
 {
     if (s_pAccelerometerDispatcher == nil) {
         s_pAccelerometerDispatcher = [[self alloc] init];
@@ -177,12 +177,12 @@ int Device::getDPI()
 
 void Device::setAccelerometerEnabled(bool isEnabled)
 {
-    [[CCAccelerometerDispatcher sharedAccelerometerDispather] setAccelerometerEnabled:isEnabled];
+    [[CCAccelerometerDispatcher sharedAccelerometerDispatcher] setAccelerometerEnabled:isEnabled];
 }
 
 void Device::setAccelerometerInterval(float interval)
 {
-    [[CCAccelerometerDispatcher sharedAccelerometerDispather] setAccelerometerInterval:interval];
+    [[CCAccelerometerDispatcher sharedAccelerometerDispatcher] setAccelerometerInterval:interval];
 }
 
 typedef struct

--- a/cocos/platform/win8.1-universal/Cocos2dRenderer.h
+++ b/cocos/platform/win8.1-universal/Cocos2dRenderer.h
@@ -29,7 +29,7 @@ class Cocos2dRenderer
 public:
     Cocos2dRenderer(int width, int height, float dpi, 
         Windows::Graphics::Display::DisplayOrientations orientation, 
-        Windows::UI::Core::CoreDispatcher^ dispathcer, Windows::UI::Xaml::Controls::Panel^ panel);
+        Windows::UI::Core::CoreDispatcher^ dispatcher, Windows::UI::Xaml::Controls::Panel^ panel);
     ~Cocos2dRenderer();
     void Draw(GLsizei width, GLsizei height, float dpi, Windows::Graphics::Display::DisplayOrientations orientation);
 	void QueuePointerEvent(cocos2d::PointerEventType type, Windows::UI::Core::PointerEventArgs^ args);


### PR DESCRIPTION
This fixes minor typos in `cocos/platform`.
