### PR TITLE
Optimize scale9sprite

### DIFF
--- a/cocos/2d/CCAutoPolygon.cpp
+++ b/cocos/2d/CCAutoPolygon.cpp
@@ -87,6 +87,12 @@ void PolygonInfo::setQuad(V3F_C4B_T2F_Quad *quad)
     triangles.verts = (V3F_C4B_T2F*)quad;
 }
 
+void PolygonInfo::reset()
+{
+    this->releaseVertsAndIndices();
+    isVertsOwner = false;
+}
+
 void PolygonInfo::releaseVertsAndIndices()
 {
     if(isVertsOwner)

--- a/cocos/2d/CCAutoPolygon.h
+++ b/cocos/2d/CCAutoPolygon.h
@@ -111,6 +111,8 @@ public:
     std::string filename;
     TrianglesCommand::Triangles triangles;
     
+    void reset();
+    
 protected:
     bool isVertsOwner;
     

--- a/cocos/2d/CCSprite.cpp
+++ b/cocos/2d/CCSprite.cpp
@@ -643,11 +643,7 @@ void Sprite::updateTransform(void)
         // MARMALADE CHANGE: ADDED CHECK FOR nullptr, TO PERMIT SPRITES WITH NO BATCH NODE / TEXTURE ATLAS
         if (_textureAtlas)
         {
-            if (_type == Type::Simple) {
-                _textureAtlas->updateQuad(&_quad, _atlasIndex);
-            }else if(_type == Type::Sliced){
-                CCLOG("update sliced quad");
-            }
+            _textureAtlas->updateQuad(&_quad, _atlasIndex);
         }
 
         _recursiveDirty = false;

--- a/cocos/2d/CCSprite.cpp
+++ b/cocos/2d/CCSprite.cpp
@@ -664,7 +664,6 @@ void Sprite::updateTransform(void)
 void Sprite::caculateSlicedVertices()
 {
     if (_type == Type::Sliced) {
-        CCLOG("draw sliced sprite");
         Texture2D *tex = _batchNode ? _textureAtlas->getTexture() : _texture;
 
         if (tex == nullptr || _isDefaultTexture)
@@ -928,7 +927,7 @@ void Sprite::draw(Renderer *renderer, const Mat4 &transform, uint32_t flags)
         _trianglesCommand.init(_globalZOrder, _texture->getName(), getGLProgramState(), _blendFunc, _polyInfo.triangles, transform, flags);
         renderer->addCommand(&_trianglesCommand);
 
-#if  0//CC_SPRITE_DEBUG_DRAW
+#if  CC_SPRITE_DEBUG_DRAW
         _debugDrawNode->clear();
         auto count = _polyInfo.triangles.indexCount/3;
         auto indices = _polyInfo.triangles.indices;
@@ -938,15 +937,15 @@ void Sprite::draw(Renderer *renderer, const Mat4 &transform, uint32_t flags)
             //draw 3 lines
             Vec3 from =verts[indices[i*3]].vertices;
             Vec3 to = verts[indices[i*3+1]].vertices;
-            _debugDrawNode->drawLine(Vec2(from.x, from.y), Vec2(to.x,to.y), Color4F::RED);
+            _debugDrawNode->drawLine(Vec2(from.x, from.y), Vec2(to.x,to.y), Color4F::WHITE);
 
             from =verts[indices[i*3+1]].vertices;
             to = verts[indices[i*3+2]].vertices;
-            _debugDrawNode->drawLine(Vec2(from.x, from.y), Vec2(to.x,to.y), Color4F::RED);
+            _debugDrawNode->drawLine(Vec2(from.x, from.y), Vec2(to.x,to.y), Color4F::WHITE);
 
             from =verts[indices[i*3+2]].vertices;
             to = verts[indices[i*3]].vertices;
-            _debugDrawNode->drawLine(Vec2(from.x, from.y), Vec2(to.x,to.y), Color4F::RED);
+            _debugDrawNode->drawLine(Vec2(from.x, from.y), Vec2(to.x,to.y), Color4F::WHITE);
         }
 #endif //CC_SPRITE_DEBUG_DRAW
     }
@@ -1177,8 +1176,6 @@ void Sprite::setContentSize(const cocos2d::Size &size)
     if (!_preferredSize.equals(size))
     {
         _preferredSize = size;
-        //TODO: content size change should only update vetices, the texture uv are not changed.
-       
         this->caculateSlicedVertices();
         
     }
@@ -1480,7 +1477,6 @@ void Sprite::setType(Type type)
     }
     else
     {
-        //TODO: optimize the operation
         this->setContentSize(_preferredSize);
     }
 }

--- a/cocos/2d/CCSprite.cpp
+++ b/cocos/2d/CCSprite.cpp
@@ -1173,12 +1173,8 @@ void Sprite::setContentSize(const cocos2d::Size &size)
 {
     Node::setContentSize(size);
     
-    if (!_preferredSize.equals(size))
-    {
-        _preferredSize = size;
-        this->caculateSlicedVertices();
-        
-    }
+    _preferredSize = size;
+    this->caculateSlicedVertices();
    
 }
 

--- a/cocos/2d/CCSprite.cpp
+++ b/cocos/2d/CCSprite.cpp
@@ -41,7 +41,6 @@ THE SOFTWARE.
 
 #include "deprecated/CCString.h"
 
-
 NS_CC_BEGIN
 
 // MARK: create, init, dealloc
@@ -120,13 +119,13 @@ Sprite* Sprite::createWithSpriteFrame(SpriteFrame *spriteFrame)
 Sprite* Sprite::createWithSpriteFrameName(const std::string& spriteFrameName)
 {
     SpriteFrame *frame = SpriteFrameCache::getInstance()->getSpriteFrameByName(spriteFrameName);
-    
+
 #if COCOS2D_DEBUG > 0
     char msg[256] = {0};
     sprintf(msg, "Invalid spriteFrameName: %s", spriteFrameName.c_str());
     CCASSERT(frame != nullptr, msg);
 #endif
-    
+
     return createWithSpriteFrame(frame);
 }
 
@@ -165,7 +164,7 @@ bool Sprite::initWithTexture(Texture2D *texture, const Rect& rect)
 bool Sprite::initWithFile(const std::string& filename)
 {
     CCASSERT(filename.size()>0, "Invalid filename for sprite");
-
+    
     Texture2D *texture = Director::getInstance()->getTextureCache()->addImage(filename);
     if (texture)
     {
@@ -173,23 +172,26 @@ bool Sprite::initWithFile(const std::string& filename)
         rect.size = texture->getContentSize();
         return initWithTexture(texture, rect);
     }
-
+    
     // don't release here.
     // when load texture failed, it's better to get a "transparent" sprite then a crashed program
     // this->release();
     return false;
 }
 
+
 bool Sprite::initWithFile(const std::string &filename, const Rect& rect)
 {
     CCASSERT(filename.size()>0, "Invalid filename");
-
+    
     Texture2D *texture = Director::getInstance()->getTextureCache()->addImage(filename);
     if (texture)
     {
-        return initWithTexture(texture, rect);
+        
+        bool ret = initWithTexture(texture, rect);
+        return ret;
     }
-
+    
     // don't release here.
     // when load texture failed, it's better to get a "transparent" sprite then a crashed program
     // this->release();
@@ -199,19 +201,22 @@ bool Sprite::initWithFile(const std::string &filename, const Rect& rect)
 bool Sprite::initWithSpriteFrameName(const std::string& spriteFrameName)
 {
     CCASSERT(spriteFrameName.size() > 0, "Invalid spriteFrameName");
-
+    
     SpriteFrame *frame = SpriteFrameCache::getInstance()->getSpriteFrameByName(spriteFrameName);
     return initWithSpriteFrame(frame);
 }
 
+
+
 bool Sprite::initWithSpriteFrame(SpriteFrame *spriteFrame)
 {
     CCASSERT(spriteFrame != nullptr, "spriteFrame can't be nullptr!");
-
+    
     bool bRet = initWithTexture(spriteFrame->getTexture(), spriteFrame->getRect());
     setSpriteFrame(spriteFrame);
-
+    
     return bRet;
+
 }
 
 bool Sprite::initWithPolygon(const cocos2d::PolygonInfo &info)
@@ -234,38 +239,38 @@ bool Sprite::initWithTexture(Texture2D *texture, const Rect& rect, bool rotated)
     if (Node::init())
     {
         _batchNode = nullptr;
-        
+
         _recursiveDirty = false;
         setDirty(false);
-        
+
         _opacityModifyRGB = true;
-        
+
         _blendFunc = BlendFunc::ALPHA_PREMULTIPLIED;
-        
+
         _flippedX = _flippedY = false;
-        
+
         // default transform anchor: center
         setAnchorPoint(Vec2(0.5f, 0.5f));
-        
+
         // zwoptex default values
         _offsetPosition.setZero();
 
         // clean the Quad
         memset(&_quad, 0, sizeof(_quad));
-        
+
         // Atlas: Color
         _quad.bl.colors = Color4B::WHITE;
         _quad.br.colors = Color4B::WHITE;
         _quad.tl.colors = Color4B::WHITE;
         _quad.tr.colors = Color4B::WHITE;
-        
+
         // shader state
         setGLProgramState(GLProgramState::getOrCreateWithGLProgramName(GLProgram::SHADER_NAME_POSITION_TEXTURE_COLOR_NO_MVP));
 
         // update texture (calls updateBlendFunc)
         setTexture(texture);
         setTextureRect(rect, rotated, rect.size);
-        
+
         // by default use "Self Render".
         // if the sprite is added to a batchnode, then it will automatically switch to "batchnode Render"
         setBatchNode(nullptr);
@@ -281,12 +286,23 @@ bool Sprite::initWithTexture(Texture2D *texture, const Rect& rect, bool rotated)
 }
 
 Sprite::Sprite(void)
-: _batchNode(nullptr)
+: _type(Type::Simple)
+, _brightState(State::NORMAL)
+, _capInsetsDirty(false)
+, _isPatch9(false)
+, _insetLeft(0.0f)
+, _insetRight(0.0f)
+, _insetTop(0.0f)
+, _insetBottom(0.0f)
+, _batchNode(nullptr)
 , _textureAtlas(nullptr)
 , _shouldBeHidden(false)
 , _texture(nullptr)
 , _spriteFrame(nullptr)
 , _insideBounds(true)
+, _sliceVertices(nullptr)
+, _sliceIndices(nullptr)
+, _isDefaultTexture(false)
 {
 #if CC_SPRITE_DEBUG_DRAW
     _debugDrawNode = DrawNode::create();
@@ -298,6 +314,8 @@ Sprite::~Sprite(void)
 {
     CC_SAFE_RELEASE(_spriteFrame);
     CC_SAFE_RELEASE(_texture);
+    CC_SAFE_DELETE_ARRAY(_sliceIndices);
+    CC_SAFE_DELETE_ARRAY(_sliceVertices);
 }
 
 /*
@@ -342,7 +360,7 @@ void Sprite::setTexture(Texture2D *texture)
     CCASSERT(! _batchNode || (texture &&  texture->getName() == _batchNode->getTexture()->getName()), "CCSprite: Batched sprites should use the same texture as the batchnode");
     // accept texture==nil as argument
     CCASSERT( !texture || dynamic_cast<Texture2D*>(texture), "setTexture expects a Texture2D. Invalid argument");
-
+    _isDefaultTexture = false;
     if (texture == nullptr)
     {
         // Gets the texture by key firstly.
@@ -358,6 +376,20 @@ void Sprite::setTexture(Texture2D *texture)
 
             texture = Director::getInstance()->getTextureCache()->addImage(image, CC_2x2_WHITE_IMAGE_KEY);
             CC_SAFE_RELEASE(image);
+        }
+    }
+    //the originalSize is valid when sprite is not in atlas
+    _originalSize = texture->getContentSize();
+    
+    auto  defaultTexture = Director::getInstance()->getTextureCache()->getTextureForKey(CC_2x2_WHITE_IMAGE_KEY);
+    
+    // If texture wasn't in cache, create it from RAW data.
+    if (defaultTexture != nullptr)
+    {
+        GLuint defaultTextureName =  defaultTexture->getName();
+        if (defaultTextureName == texture->getName())
+        {
+            _isDefaultTexture = true;
         }
     }
 
@@ -413,7 +445,7 @@ void Sprite::setTextureRect(const Rect& rect, bool rotated, const Size& untrimme
     else
     {
         // self rendering
-        
+
         // Atlas: Vertex
         float x1 = 0.0f + _offsetPosition.x;
         float y1 = 0.0f + _offsetPosition.y;
@@ -426,7 +458,17 @@ void Sprite::setTextureRect(const Rect& rect, bool rotated, const Size& untrimme
         _quad.tl.vertices.set(x1, y2, 0.0f);
         _quad.tr.vertices.set(x2, y2, 0.0f);
     }
-    
+
+   if (_texture->isContain9PatchInfo())
+   {
+       auto& parsedCapInset = _texture->getSpriteFrameCapInset(this->getSpriteFrame());
+       if(!parsedCapInset.equals(Rect::ZERO))
+       {
+           this->_isPatch9 = true;
+           _capInsetsInternal = parsedCapInset;
+       }
+   }
+
     _polyInfo.setQuad(&_quad);
 }
 
@@ -564,7 +606,7 @@ void Sprite::updateTransform(void)
 
             float x2 = x1 + size.width;
             float y2 = y1 + size.height;
-            
+
             if (_flippedX)
             {
                 std::swap(x1, x2);
@@ -573,7 +615,7 @@ void Sprite::updateTransform(void)
             {
                 std::swap(y1, y2);
             }
-            
+
             float x = _transformToBatch.m[12];
             float y = _transformToBatch.m[13];
 
@@ -613,11 +655,250 @@ void Sprite::updateTransform(void)
     // recursively iterate over children
 /*    if( _hasChildren )
     {
-        // MARMALADE: CHANGED TO USE Node*
-        // NOTE THAT WE HAVE ALSO DEFINED virtual Node::updateTransform()
+         MARMALADE: CHANGED TO USE Node*
+         NOTE THAT WE HAVE ALSO DEFINED virtual Node::updateTransform()
         arrayMakeObjectsPerformSelector(_children, updateTransform, Sprite*);
     }*/
     Node::updateTransform();
+}
+
+void Sprite::caculateSlicedVertices()
+{
+    if (_type == Type::Sliced) {
+        CCLOG("draw sliced sprite");
+        if (_texture == nullptr || _isDefaultTexture)
+        {
+            return;
+        }
+        auto textureSize = _texture->getContentSize();
+        
+        this->updateBlendFunc();
+        //caculate texture coordinate
+        float leftWidth = 0, centerWidth = 0, rightWidth = 0;
+        float topHeight = 0, centerHeight = 0, bottomHeight = 0;
+        auto capInsets = _capInsetsInternal;
+        auto textureRect = _rect;
+        auto spriteRectSize = _originalSize;
+        if(capInsets.equals(Rect::ZERO))
+        {
+            capInsets = Rect(_originalSize.width/3, _originalSize.height/3,
+                             _originalSize.width/3, _originalSize.height/3);
+        }
+        
+        //handle .9.png
+        if (_isPatch9)
+        {
+            float offset = 1;
+            if (_rectRotated) {
+                textureRect = Rect(textureRect.origin.x,
+                                 textureRect.origin.y + 2,
+                                 textureRect.size.width,
+                                 textureRect.size.height - 2);
+            }else{
+                textureRect = Rect(textureRect.origin.x +  offset,
+                                 textureRect.origin.y +  offset,
+                                 textureRect.size.width,
+                                 textureRect.size.height);
+            }
+            spriteRectSize = Size(spriteRectSize.width - 2, spriteRectSize.height-2);
+        }
+
+        if (_rectRotated)
+        {
+            rightWidth = capInsets.origin.y;
+            centerWidth = capInsets.size.height;
+            leftWidth = spriteRectSize.height - centerWidth - rightWidth;
+
+            topHeight = capInsets.origin.x;
+            centerHeight = capInsets.size.width;
+            bottomHeight = spriteRectSize.width - (topHeight + centerHeight);
+        }
+        else
+        {
+            leftWidth = capInsets.origin.x;
+            centerWidth = capInsets.size.width;
+            rightWidth = spriteRectSize.width - (leftWidth + centerWidth);
+
+            topHeight = capInsets.origin.y;
+            centerHeight = capInsets.size.height;
+            bottomHeight =spriteRectSize.height - (topHeight + centerHeight);
+        }
+
+        // (0,0)  O = capInsets.origin
+        // v0----------------------
+        // |        |      |      |
+        // |        |      |      |
+        // v1-------O------+------|
+        // |        |      |      |
+        // |        |      |      |
+        // v2-------+------+------|
+        // |        |      |      |
+        // |        |      |      |
+        // v3-------------------- (1,1)  (texture coordinate is flipped)
+        // u0       u1     u2     u3
+
+        //uv computation should take spritesheet into account.
+        float u0, u1, u2, u3;
+        float v0, v1, v2, v3;
+
+
+        if (_rectRotated)
+        {
+            u0 = textureRect.origin.x / textureSize.width;
+            u1 = (leftWidth + textureRect.origin.x) / textureSize.width;
+            u2 = (leftWidth + centerWidth + textureRect.origin.x) / textureSize.width;
+            u3 = (textureRect.origin.x + textureRect.size.height) / textureSize.width;
+
+            v3 = textureRect.origin.y / textureSize.height;
+            v2 = (topHeight + textureRect.origin.y) / textureSize.height;
+            v1 = (topHeight + centerHeight + textureRect.origin.y) / textureSize.height;
+            v0 = (textureRect.origin.y + textureRect.size.width) / textureSize.height;
+        }
+        else
+        {
+            u0 = textureRect.origin.x / textureSize.width;
+            u1 = (leftWidth + textureRect.origin.x) / textureSize.width;
+            u2 = (leftWidth + centerWidth + textureRect.origin.x) / textureSize.width;
+            u3 = (textureRect.origin.x + textureRect.size.width) / textureSize.width;
+
+            v0 = textureRect.origin.y / textureSize.height;
+            v1 = (topHeight + textureRect.origin.y) / textureSize.height;
+            v2 = (topHeight + centerHeight + textureRect.origin.y) / textureSize.height;
+            v3 = (textureRect.origin.y + textureRect.size.height) / textureSize.height;
+        }
+
+        std::vector<float> uvRow = {u0, u1, u2, u3};
+        std::vector<float> uvColumn = {v3, v2, v1, v0};
+
+        // Recalculate the sizable info
+        if(_rectRotated)
+        {
+            leftWidth = capInsets.origin.x;
+            centerWidth = capInsets.size.width;
+            rightWidth = spriteRectSize.width - (leftWidth + centerWidth);
+
+            topHeight = capInsets.origin.y;
+            centerHeight = capInsets.size.height;
+            bottomHeight =spriteRectSize.height - (topHeight + centerHeight);
+        }
+
+        float sizableWidth = _preferredSize.width - leftWidth - rightWidth;
+        float sizableHeight = _preferredSize.height - topHeight - bottomHeight;
+        float x0,x1,x2,x3;
+        float y0,y1,y2,y3;
+        if(sizableWidth >= 0)
+        {
+            x0 = 0;
+            x1 = leftWidth;
+            x2 = leftWidth + sizableWidth;
+            x3 = _preferredSize.width;
+        }
+        else
+        {
+            float xScale = _preferredSize.width / (leftWidth + rightWidth);
+            x0 = 0;
+            x1 = x2 = leftWidth * xScale;
+            x3 = (leftWidth + rightWidth) * xScale;
+        }
+
+        if(sizableHeight >= 0)
+        {
+            y0 = 0;
+            y1 = bottomHeight;
+            y2 = bottomHeight + sizableHeight;
+            y3 = _preferredSize.height;
+        }
+        else
+        {
+            float yScale = _preferredSize.height / (topHeight + bottomHeight);
+            y0 = 0;
+            y1 = y2= bottomHeight * yScale;
+            y3 = (bottomHeight + topHeight) * yScale;
+        }
+
+
+        //
+        // y3----------------------(preferedSize.width, preferedSize.height)
+        // |        |      |      |
+        // |        |      |      |
+        // y2-------O------+------|
+        // |        |      |      |
+        // |        |      |      |
+        // y1-------+------+------|
+        // |        |      |      |
+        // |        |      |      |
+        //x0,y0--------------------
+        //         x1     x2     x3
+
+        float row[4] = { x0, x1, x2, x3};
+        float colum[4] = {y0, y1, y2, y3};
+
+
+        const unsigned short slicedTotalVertexCount = 16;
+        const unsigned short slicedTotalVertices = 54;
+        CC_SAFE_DELETE_ARRAY(_sliceVertices);
+        CC_SAFE_DELETE_ARRAY(_sliceIndices);
+        
+        _sliceVertices = new V3F_C4B_T2F[slicedTotalVertexCount];
+        _sliceIndices = new unsigned short[slicedTotalVertices];
+
+        unsigned short indicesStart = 0;
+        const unsigned short indicesOffset = 6;
+        const unsigned short quadIndices[]={4,0,5, 1,5,0};
+
+        Color4B color4( _displayedColor.r, _displayedColor.g, _displayedColor.b, _displayedOpacity );
+
+        // special opacity for premultiplied textures
+        if (_opacityModifyRGB)
+        {
+            color4.r *= _displayedOpacity/255.0f;
+            color4.g *= _displayedOpacity/255.0f;
+            color4.b *= _displayedOpacity/255.0f;
+        }
+
+        for (int j = 0; j <= 3; ++j)
+        {
+            for (int i = 0; i <= 3; ++i)
+            {
+                V3F_C4B_T2F vertextData;
+                vertextData.vertices.x = row[i];
+                vertextData.vertices.y = colum[j];
+
+                if (_rectRotated)
+                {
+                    vertextData.texCoords.u = uvRow[j];
+                    vertextData.texCoords.v = uvColumn[i];
+                }
+                else
+                {
+                    vertextData.texCoords.u = uvRow[i];
+                    vertextData.texCoords.v = uvColumn[j];
+                }
+
+                vertextData.colors = color4;
+
+                if (i < 3 && j < 3)
+                {
+                    memcpy(_sliceIndices + indicesStart, quadIndices, indicesOffset * sizeof(unsigned short));
+
+                    for (int k = 0; k  < indicesOffset; ++k)
+                    {
+                        unsigned short actualIndex = (i  + j * 3) * indicesOffset;
+                        _sliceIndices[k + actualIndex] = _sliceIndices[k + actualIndex] + j * 4 + i;
+                    }
+                    indicesStart = indicesStart + indicesOffset;
+                }
+
+                memcpy(_sliceVertices + i + j * 4, &vertextData, sizeof(V3F_C4B_T2F));
+            }
+        }
+
+        this->_polyInfo.reset();
+        this->_polyInfo.triangles.vertCount = slicedTotalVertexCount;
+        this->_polyInfo.triangles.indexCount = slicedTotalVertices;
+        this->_polyInfo.triangles.verts = _sliceVertices;
+        this->_polyInfo.triangles.indices = _sliceIndices;
+    }
 }
 
 // draw
@@ -639,10 +920,14 @@ void Sprite::draw(Renderer *renderer, const Mat4 &transform, uint32_t flags)
     if(_insideBounds)
 #endif
     {
+        if (_capInsetsDirty) {
+            this->caculateSlicedVertices();
+            _capInsetsDirty = false;
+        }
         _trianglesCommand.init(_globalZOrder, _texture->getName(), getGLProgramState(), _blendFunc, _polyInfo.triangles, transform, flags);
         renderer->addCommand(&_trianglesCommand);
-        
-#if CC_SPRITE_DEBUG_DRAW
+
+#if  0//CC_SPRITE_DEBUG_DRAW
         _debugDrawNode->clear();
         auto count = _polyInfo.triangles.indexCount/3;
         auto indices = _polyInfo.triangles.indices;
@@ -652,15 +937,15 @@ void Sprite::draw(Renderer *renderer, const Mat4 &transform, uint32_t flags)
             //draw 3 lines
             Vec3 from =verts[indices[i*3]].vertices;
             Vec3 to = verts[indices[i*3+1]].vertices;
-            _debugDrawNode->drawLine(Vec2(from.x, from.y), Vec2(to.x,to.y), Color4F::WHITE);
-            
+            _debugDrawNode->drawLine(Vec2(from.x, from.y), Vec2(to.x,to.y), Color4F::RED);
+
             from =verts[indices[i*3+1]].vertices;
             to = verts[indices[i*3+2]].vertices;
-            _debugDrawNode->drawLine(Vec2(from.x, from.y), Vec2(to.x,to.y), Color4F::WHITE);
-            
+            _debugDrawNode->drawLine(Vec2(from.x, from.y), Vec2(to.x,to.y), Color4F::RED);
+
             from =verts[indices[i*3+2]].vertices;
             to = verts[indices[i*3]].vertices;
-            _debugDrawNode->drawLine(Vec2(from.x, from.y), Vec2(to.x,to.y), Color4F::WHITE);
+            _debugDrawNode->drawLine(Vec2(from.x, from.y), Vec2(to.x,to.y), Color4F::RED);
         }
 #endif //CC_SPRITE_DEBUG_DRAW
     }
@@ -692,7 +977,7 @@ void Sprite::addChild(Node *child, int zOrder, int tag)
 void Sprite::addChild(Node *child, int zOrder, const std::string &name)
 {
     CCASSERT(child != nullptr, "Argument must be non-nullptr");
-    
+
     if (_batchNode)
     {
         Sprite* childSprite = dynamic_cast<Sprite*>(child);
@@ -701,7 +986,7 @@ void Sprite::addChild(Node *child, int zOrder, const std::string &name)
                  "childSprite's texture name should be equal to _textureAtlas's texture name.");
         //put it in descendants array of batch node
         _batchNode->appendChild(childSprite);
-        
+
         if (!_reorderChildDirty)
         {
             setReorderChildDirtyRecursively();
@@ -826,7 +1111,7 @@ void Sprite::setPosition(float x, float y)
 void Sprite::setRotation(float rotation)
 {
     Node::setRotation(rotation);
-    
+
     SET_DIRTY_RECURSIVELY();
 }
 
@@ -884,6 +1169,28 @@ void Sprite::setPositionZ(float fVertexZ)
     SET_DIRTY_RECURSIVELY();
 }
 
+void Sprite::setContentSize(const cocos2d::Size &size)
+{
+    Node::setContentSize(size);
+    
+    if (!_preferredSize.equals(size))
+    {
+        _preferredSize = size;
+        //TODO: content size change should only update vetices, the texture uv are not changed.
+        _capInsetsDirty = true;
+    }
+   
+}
+
+const Size& Sprite::getContentSize()const
+{
+    if(_type == Type::Sliced)
+    {
+        return _preferredSize;
+    }
+    return _contentSize;
+}
+
 void Sprite::setAnchorPoint(const Vec2& anchor)
 {
     Node::setAnchorPoint(anchor);
@@ -907,12 +1214,19 @@ void Sprite::setFlippedX(bool flippedX)
     if (_flippedX != flippedX)
     {
         _flippedX = flippedX;
-        for (ssize_t i = 0; i < _polyInfo.triangles.vertCount; i++) {
-            auto& v = _polyInfo.triangles.verts[i].vertices;
-            v.x = _contentSize.width -v.x;
+        if(_type == Type::Simple)
+        {
+            for (ssize_t i = 0; i < _polyInfo.triangles.vertCount; i++) {
+                auto& v = _polyInfo.triangles.verts[i].vertices;
+                v.x = _contentSize.width -v.x;
+            }
+            if (_textureAtlas) {
+                setDirty(true);
+            }
         }
-        if (_textureAtlas) {
-            setDirty(true);
+        else if(_type == Type::Sliced)
+        {
+            this->setScaleX(flippedX ? -1 : 1);
         }
     }
 }
@@ -927,12 +1241,19 @@ void Sprite::setFlippedY(bool flippedY)
     if (_flippedY != flippedY)
     {
         _flippedY = flippedY;
-        for (ssize_t i = 0; i < _polyInfo.triangles.vertCount; i++) {
-            auto& v = _polyInfo.triangles.verts[i].vertices;
-            v.y = _contentSize.height -v.y;
+        if(_type == Type::Simple)
+        {
+            for (ssize_t i = 0; i < _polyInfo.triangles.vertCount; i++) {
+                auto& v = _polyInfo.triangles.verts[i].vertices;
+                v.y = _contentSize.height -v.y;
+            }
+            if (_textureAtlas) {
+                setDirty(true);
+            }
         }
-        if (_textureAtlas) {
-            setDirty(true);
+        else if(_type == Type::Sliced)
+        {
+            this->setScaleY(flippedY ? -1 : 1);
         }
     }
 }
@@ -949,7 +1270,7 @@ bool Sprite::isFlippedY(void) const
 void Sprite::updateColor(void)
 {
     Color4B color4( _displayedColor.r, _displayedColor.g, _displayedColor.b, _displayedOpacity );
-    
+
     // special opacity for premultiplied textures
     if (_opacityModifyRGB)
     {
@@ -1028,8 +1349,10 @@ void Sprite::setSpriteFrame(SpriteFrame *spriteFrame)
 
     // update rect
     _rectRotated = spriteFrame->isRotated();
+    _originalSize = spriteFrame->getOriginalSize();
     setTextureRect(spriteFrame->getRect(), _rectRotated, spriteFrame->getOriginalSize());
 }
+
 
 void Sprite::setDisplayFrameWithAnimationName(const std::string& animationName, ssize_t frameIndex)
 {
@@ -1138,6 +1461,134 @@ PolygonInfo Sprite::getPolygonInfo() const
 void Sprite::setPolygonInfo(const PolygonInfo& info)
 {
     _polyInfo = info;
+}
+
+void Sprite::setType(Type type)
+{
+    if (_type == type) {
+        return;
+    }
+    
+    this->_type = type;
+    if (type == Type::Simple)
+    {
+        _polyInfo.setQuad(&this->_quad);
+        Node::setContentSize(_originalSize);
+    }
+    else
+    {
+        //TODO: optimize the operation
+        this->setContentSize(_preferredSize);
+        _capInsetsDirty = true;
+    }
+}
+
+Sprite::Type Sprite::getType()const
+{
+    return this->_type;
+}
+
+
+void Sprite::setCapInsets(const cocos2d::Rect &rect)
+{
+    this->_insetLeft = rect.origin.x;
+    this->_insetTop = rect.origin.y;
+    this->_insetRight = _originalSize.width - this->_insetLeft - rect.size.width;
+    this->_insetBottom = _originalSize.height - this->_insetTop - rect.size.height;
+    _capInsetsInternal = rect;
+
+    _capInsetsDirty = true;
+}
+
+Rect Sprite::getCapInsets()const
+{
+    return _capInsetsInternal;
+}
+
+Sprite::State Sprite::getState()const
+{
+    return this->_brightState;
+}
+
+void Sprite::setState(Sprite::State state)
+{
+    GLProgramState *glState = nullptr;
+    switch (state)
+    {
+    case State::NORMAL:
+    {
+        glState = GLProgramState::getOrCreateWithGLProgramName(GLProgram::SHADER_NAME_POSITION_TEXTURE_COLOR_NO_MVP);
+    }
+    break;
+    case State::GRAY:
+    {
+        glState = GLProgramState::getOrCreateWithGLProgramName(GLProgram::SHADER_NAME_POSITION_GRAYSCALE);
+    }
+    default:
+        break;
+    }
+        
+    this->setGLProgramState(glState);
+    _brightState = state;
+}
+
+Size Sprite::getOriginalSize() const
+{
+    return this->_originalSize;
+}
+
+float Sprite::getInsetLeft()const
+{
+    return this->_insetLeft;
+}
+
+float Sprite::getInsetTop()const
+{
+    return this->_insetTop;
+}
+
+float Sprite::getInsetRight()const
+{
+    return this->_insetRight;
+}
+
+float Sprite::getInsetBottom()const
+{
+    return this->_insetBottom;
+}
+
+
+void Sprite::setInsetLeft(float insetLeft)
+{
+    this->_insetLeft = insetLeft;
+    this->updateCapInset();
+}
+
+void Sprite::setInsetTop(float insetTop)
+{
+    this->_insetTop = insetTop;
+    this->updateCapInset();
+}
+
+void Sprite::setInsetRight(float insetRight)
+{
+    this->_insetRight = insetRight;
+    this->updateCapInset();
+}
+
+void Sprite::setInsetBottom(float insetBottom)
+{
+    this->_insetBottom = insetBottom;
+    this->updateCapInset();
+}
+
+void Sprite::updateCapInset()
+{
+    Rect insets = Rect(_insetLeft,
+                      _insetTop,
+                      _originalSize.width-_insetLeft-_insetRight,
+                      _originalSize.height-_insetTop-_insetBottom);
+    this->setCapInsets(insets);
 }
 
 NS_CC_END

--- a/cocos/2d/CCSprite.h
+++ b/cocos/2d/CCSprite.h
@@ -71,6 +71,7 @@ struct transformValues_;
  *  - Put all your sprites in the same spritesheet (http://www.codeandweb.com/what-is-a-sprite-sheet).
  *  - Use the same blending function for all your sprites.
  *  - ...and the Renderer will automatically "batch" your sprites (will draw all of them in one OpenGL call).
+ *  // TODO:  Introduce the new sliced rendering type.
  *
  *  To gain an additional 5% ~ 10% more in the rendering, you can parent your sprites into a `SpriteBatchNode`.
  *  But doing so carries the following limitations:
@@ -85,6 +86,23 @@ struct transformValues_;
 class CC_DLL Sprite : public Node, public TextureProtocol
 {
 public:
+    /**
+     * Simple: The classical cocos2d sprite type, you can't change content size to stretch, use scale instead.
+     * Sliced: Sliced aka 9-slice scaling which allows you to specify how scaling is applied
+     *         to specific areas of a sprite. With 9-slice scaling (3x3 grid),
+     *         you can ensure that the sprite does not become distorted when scaled.
+     */
+    enum class Type
+    {
+        Simple,
+        Sliced
+    };
+    
+    enum class State
+    {
+        NORMAL,
+        GRAY
+    };
      /** Sprite invalid index on the SpriteBatchNode. */
     static const int INDEX_NOT_INITIALIZED = -1;
 
@@ -98,6 +116,7 @@ public:
      * @return An autoreleased sprite object.
      */
     static Sprite* create();
+
 
     /**
      * Creates a sprite with an image filename.
@@ -251,6 +270,7 @@ public:
      * Sets a new SpriteFrame to the Sprite.
      */
     virtual void setSpriteFrame(const std::string &spriteFrameName);
+    
     virtual void setSpriteFrame(SpriteFrame* newFrame);
     /** @} */
 
@@ -433,6 +453,16 @@ public:
     virtual void setScaleX(float scaleX) override;
     virtual void setScaleY(float scaleY) override;
     virtual void setScale(float scaleX, float scaleY) override;
+    virtual void setContentSize(const Size & size) override;
+    /**
+     * Returns the untransformed size of the node when type is Simple.
+     *
+     * @see `setContentSize(const Size&)`
+     *
+     * @return The untransformed size of the node. When type is sliced, the content size is the 
+     *         prefered size.
+     */
+    virtual const Size& getContentSize() const override;
     /**
     * @js  NA
     * @lua NA
@@ -526,6 +556,7 @@ CC_CONSTRUCTOR_ACCESS:
      */
     virtual bool initWithSpriteFrame(SpriteFrame *spriteFrame);
 
+
     /**
      * Initializes a sprite with an sprite frame name.
      *
@@ -537,6 +568,7 @@ CC_CONSTRUCTOR_ACCESS:
      */
     virtual bool initWithSpriteFrameName(const std::string& spriteFrameName);
 
+   
     /**
      * Initializes a sprite with an image filename.
      *
@@ -563,7 +595,7 @@ CC_CONSTRUCTOR_ACCESS:
      * @lua     init
      */
     virtual bool initWithFile(const std::string& filename, const Rect& rect);
-    
+
     /**
      * returns a copy of the polygon information associated with this sprite
      * because this is a copy process it is slower than getting the reference, so use wisely
@@ -578,16 +610,126 @@ CC_CONSTRUCTOR_ACCESS:
      * @param PolygonInfo the polygon information object
      */
     void setPolygonInfo(const PolygonInfo& info);
-protected:
 
+    void setType(Type type);
+    Type getType()const;
+    
+    /**
+     * @brief Change the cap inset size.
+     *
+     * @param rect A delimitation zone.
+     */
+    void setCapInsets(const Rect& rect);
+    
+    /**
+     * @brief Query the Scale9Sprite's prefered size.
+     *
+     * @return Scale9Sprite's cap inset.
+     */
+    Rect getCapInsets()const;
+    /**
+     * Change the state of 9-slice sprite.
+     * @see `State`
+     * @param state A enum value in State.
+     * @since v3.9
+     */
+    void setState(State state);
+
+    /**
+     * Query the current bright state.
+     * @return @see `State`
+     * @since v3.9
+     */
+    State getState()const;
+
+    /**
+     * @brief Query the sprite's original size.
+     *
+     * @return Sprite size.
+     */
+    Size getOriginalSize() const;
+    /**
+     * @brief Change the left sprite's cap inset.
+     *
+     * @param leftInset The values to use for the cap inset.
+     */
+    void setInsetLeft(float leftInset);
+
+    /**
+     * @brief Query the left sprite's cap inset.
+     *
+     * @return The left sprite's cap inset.
+     */
+    float getInsetLeft()const;
+
+    /**
+     * @brief Change the top sprite's cap inset.
+     *
+     * @param topInset The values to use for the cap inset.
+     */
+    void setInsetTop(float topInset);
+
+    /**
+     * @brief Query the top sprite's cap inset.
+     *
+     * @return The top sprite's cap inset.
+     */
+    float getInsetTop()const;
+
+    /**
+     * @brief Change the right sprite's cap inset.
+     *
+     * @param rightInset The values to use for the cap inset.
+     */
+    void setInsetRight(float rightInset);
+
+    /**
+     * @brief Query the right sprite's cap inset.
+     *
+     * @return The right sprite's cap inset.
+     */
+    float getInsetRight()const;
+
+    /**
+     * @brief Change the bottom sprite's cap inset.
+     *
+     * @param bottomInset The values to use for the cap inset.
+
+     */
+    void setInsetBottom(float bottomInset);
+
+    /**
+     * @brief Query the bottom sprite's cap inset.
+     *
+     * @return The bottom sprite's cap inset.
+     */
+    float getInsetBottom()const;
+
+    
+protected:
+    void caculateSlicedVertices();
+    void updateCapInset();
     void updateColor() override;
     virtual void setTextureCoords(Rect rect);
     virtual void updateBlendFunc();
     virtual void setReorderChildDirtyRecursively();
     virtual void setDirtyRecursively(bool value);
 
-
-    
+    // TODO: add a Scale9Info structure and make it a pointer.
+    Type _type;
+    float _insetLeft;
+    float _insetRight;
+    float _insetBottom;
+    float _insetTop;
+    Rect _capInsetsInternal;
+    Size _originalSize;
+    State _brightState;
+    bool _capInsetsDirty;
+    bool _isPatch9;
+    V3F_C4B_T2F* _sliceVertices;
+    unsigned short* _sliceIndices;
+    bool _isDefaultTexture;
+    Size _preferredSize;
     //
     // Data used when the sprite is rendered using a SpriteSheet
     //

--- a/cocos/2d/CCSprite.h
+++ b/cocos/2d/CCSprite.h
@@ -491,9 +491,21 @@ public:
     virtual bool isOpacityModifyRGB() const override;
     /// @}
     
-    //methods for sliced sprite
+    /**
+     *@brief Change the rendering type of sprite
+     *@param type  @see Sprite::Type
+     */
     void setType(Type type);
+    
+    /**
+     * Return the rendering type of sprite
+     *@return The actual rendering type of sprite.
+     */
     Type getType()const;
+    
+    /**
+     * Whether is the sprite is using the default 2x2 white texture.
+     */
     bool isUsingDefaultTexture()const;
     /**
      * @brief Change the cap inset size.
@@ -707,8 +719,6 @@ CC_CONSTRUCTOR_ACCESS:
     void setPolygonInfo(const PolygonInfo& info);
 
     
-
-    
 protected:
     void caculateSlicedVertices();
     void updateCapInset();
@@ -718,7 +728,6 @@ protected:
     virtual void setReorderChildDirtyRecursively();
     virtual void setDirtyRecursively(bool value);
 
-    // TODO: add a Scale9Info structure and make it a pointer.
     Type _type;
     float _insetLeft;
     float _insetRight;

--- a/cocos/2d/CCSprite.h
+++ b/cocos/2d/CCSprite.h
@@ -490,6 +490,101 @@ public:
     virtual void setOpacityModifyRGB(bool modify) override;
     virtual bool isOpacityModifyRGB() const override;
     /// @}
+    
+    //methods for sliced sprite
+    void setType(Type type);
+    Type getType()const;
+    bool isUsingDefaultTexture()const;
+    /**
+     * @brief Change the cap inset size.
+     *
+     * @param rect A delimitation zone.
+     */
+    void setCapInsets(const Rect& rect);
+    
+    /**
+     * @brief Query the Scale9Sprite's prefered size.
+     *
+     * @return Scale9Sprite's cap inset.
+     */
+    Rect getCapInsets()const;
+    /**
+     * Change the state of 9-slice sprite.
+     * @see `State`
+     * @param state A enum value in State.
+     * @since v3.9
+     */
+    void setState(State state);
+    
+    /**
+     * Query the current bright state.
+     * @return @see `State`
+     * @since v3.9
+     */
+    State getState()const;
+    
+    /**
+     * @brief Query the sprite's original size.
+     *
+     * @return Sprite size.
+     */
+    Size getOriginalSize() const;
+    /**
+     * @brief Change the left sprite's cap inset.
+     *
+     * @param leftInset The values to use for the cap inset.
+     */
+    void setInsetLeft(float leftInset);
+    
+    /**
+     * @brief Query the left sprite's cap inset.
+     *
+     * @return The left sprite's cap inset.
+     */
+    float getInsetLeft()const;
+    
+    /**
+     * @brief Change the top sprite's cap inset.
+     *
+     * @param topInset The values to use for the cap inset.
+     */
+    void setInsetTop(float topInset);
+    
+    /**
+     * @brief Query the top sprite's cap inset.
+     *
+     * @return The top sprite's cap inset.
+     */
+    float getInsetTop()const;
+    
+    /**
+     * @brief Change the right sprite's cap inset.
+     *
+     * @param rightInset The values to use for the cap inset.
+     */
+    void setInsetRight(float rightInset);
+    
+    /**
+     * @brief Query the right sprite's cap inset.
+     *
+     * @return The right sprite's cap inset.
+     */
+    float getInsetRight()const;
+    
+    /**
+     * @brief Change the bottom sprite's cap inset.
+     *
+     * @param bottomInset The values to use for the cap inset.
+     
+     */
+    void setInsetBottom(float bottomInset);
+    
+    /**
+     * @brief Query the bottom sprite's cap inset.
+     *
+     * @return The bottom sprite's cap inset.
+     */
+    float getInsetBottom()const;
 
 CC_CONSTRUCTOR_ACCESS:
 	/**
@@ -611,99 +706,7 @@ CC_CONSTRUCTOR_ACCESS:
      */
     void setPolygonInfo(const PolygonInfo& info);
 
-    void setType(Type type);
-    Type getType()const;
     
-    /**
-     * @brief Change the cap inset size.
-     *
-     * @param rect A delimitation zone.
-     */
-    void setCapInsets(const Rect& rect);
-    
-    /**
-     * @brief Query the Scale9Sprite's prefered size.
-     *
-     * @return Scale9Sprite's cap inset.
-     */
-    Rect getCapInsets()const;
-    /**
-     * Change the state of 9-slice sprite.
-     * @see `State`
-     * @param state A enum value in State.
-     * @since v3.9
-     */
-    void setState(State state);
-
-    /**
-     * Query the current bright state.
-     * @return @see `State`
-     * @since v3.9
-     */
-    State getState()const;
-
-    /**
-     * @brief Query the sprite's original size.
-     *
-     * @return Sprite size.
-     */
-    Size getOriginalSize() const;
-    /**
-     * @brief Change the left sprite's cap inset.
-     *
-     * @param leftInset The values to use for the cap inset.
-     */
-    void setInsetLeft(float leftInset);
-
-    /**
-     * @brief Query the left sprite's cap inset.
-     *
-     * @return The left sprite's cap inset.
-     */
-    float getInsetLeft()const;
-
-    /**
-     * @brief Change the top sprite's cap inset.
-     *
-     * @param topInset The values to use for the cap inset.
-     */
-    void setInsetTop(float topInset);
-
-    /**
-     * @brief Query the top sprite's cap inset.
-     *
-     * @return The top sprite's cap inset.
-     */
-    float getInsetTop()const;
-
-    /**
-     * @brief Change the right sprite's cap inset.
-     *
-     * @param rightInset The values to use for the cap inset.
-     */
-    void setInsetRight(float rightInset);
-
-    /**
-     * @brief Query the right sprite's cap inset.
-     *
-     * @return The right sprite's cap inset.
-     */
-    float getInsetRight()const;
-
-    /**
-     * @brief Change the bottom sprite's cap inset.
-     *
-     * @param bottomInset The values to use for the cap inset.
-
-     */
-    void setInsetBottom(float bottomInset);
-
-    /**
-     * @brief Query the bottom sprite's cap inset.
-     *
-     * @return The bottom sprite's cap inset.
-     */
-    float getInsetBottom()const;
 
     
 protected:

--- a/cocos/2d/CCSprite.h
+++ b/cocos/2d/CCSprite.h
@@ -66,12 +66,15 @@ struct transformValues_;
  * Sprite is a 2d image ( http://en.wikipedia.org/wiki/Sprite_(computer_graphics) ).
  *
  * Sprite can be created with an image, or with a sub-rectangle of an image.
+ * Sprite comes with two rendering mode.
+ *  - Simple: The original Cocos2D style.
+ *  - Sliced: A new way to draw 9-sliced sprite.
  *
  * To optimize the Sprite rendering, please follow the following best practices:
  *  - Put all your sprites in the same spritesheet (http://www.codeandweb.com/what-is-a-sprite-sheet).
  *  - Use the same blending function for all your sprites.
  *  - ...and the Renderer will automatically "batch" your sprites (will draw all of them in one OpenGL call).
- *  // TODO:  Introduce the new sliced rendering type.
+ *
  *
  *  To gain an additional 5% ~ 10% more in the rendering, you can parent your sprites into a `SpriteBatchNode`.
  *  But doing so carries the following limitations:
@@ -80,6 +83,7 @@ struct transformValues_;
  *  - The Blending function property belongs to `SpriteBatchNode`, so you can't individually set the blending function property.
  *  - `ParallaxNode` is not supported, but can be simulated with a "proxy" sprite.
  *  - Sprites can only have other Sprites (or subclasses of Sprite) as children.
+ *  - Type::Sliced Sprite can't be added as children of SpriteBatchNode
  *
  * The default anchorPoint in Sprite is (0.5, 0.5).
  */

--- a/cocos/renderer/CCTexture2D.h
+++ b/cocos/renderer/CCTexture2D.h
@@ -41,11 +41,7 @@ class Image;
 class NinePatchInfo;
 class SpriteFrame;
 typedef struct _MipmapInfo MipmapInfo;
-
-namespace ui
-{
-    class Scale9Sprite;
-}
+class Sprite;
 
 /**
  * @addtogroup _2d
@@ -539,7 +535,7 @@ protected:
     NinePatchInfo* _ninePatchInfo;
     friend class SpriteFrameCache;
     friend class TextureCache;
-    friend class ui::Scale9Sprite;
+    friend class Sprite;
 };
 
 

--- a/cocos/ui/UIAbstractCheckButton.cpp
+++ b/cocos/ui/UIAbstractCheckButton.cpp
@@ -154,7 +154,7 @@ void AbstractCheckButton::setupBackgroundTexture()
     
     this->updateChildrenDisplayedRGBA();
     
-    updateContentSizeWithTextureSize(_backGroundBoxRenderer->getContentSize());
+    updateContentSizeWithTextureSize(_backGroundBoxRenderer->getOriginalSize());
     _backGroundBoxRendererAdaptDirty = true;
 }
 
@@ -437,7 +437,7 @@ void AbstractCheckButton::adaptRenderers()
 
 Size AbstractCheckButton::getVirtualRendererSize() const
 {
-    return _backGroundBoxRenderer->getContentSize();
+    return _backGroundBoxRenderer->getOriginalSize();
 }
 
 Node* AbstractCheckButton::getVirtualRenderer()
@@ -454,7 +454,7 @@ void AbstractCheckButton::backGroundTextureScaleChangedWithSize()
     }
     else
     {
-        Size textureSize = _backGroundBoxRenderer->getContentSize();
+        Size textureSize = _backGroundBoxRenderer->getOriginalSize();
         if (textureSize.width <= 0.0f || textureSize.height <= 0.0f)
         {
             _backGroundBoxRenderer->setScale(1.0f);
@@ -479,7 +479,7 @@ void AbstractCheckButton::backGroundSelectedTextureScaleChangedWithSize()
     }
     else
     {
-        Size textureSize = _backGroundSelectedBoxRenderer->getContentSize();
+        Size textureSize = _backGroundSelectedBoxRenderer->getOriginalSize();
         if (textureSize.width <= 0.0f || textureSize.height <= 0.0f)
         {
             _backGroundSelectedBoxRenderer->setScale(1.0f);
@@ -501,7 +501,7 @@ void AbstractCheckButton::frontCrossTextureScaleChangedWithSize()
     }
     else
     {
-        Size textureSize = _frontCrossRenderer->getContentSize();
+        Size textureSize = _frontCrossRenderer->getOriginalSize();
         if (textureSize.width <= 0.0f || textureSize.height <= 0.0f)
         {
             _frontCrossRenderer->setScale(1.0f);
@@ -523,7 +523,7 @@ void AbstractCheckButton::backGroundDisabledTextureScaleChangedWithSize()
     }
     else
     {
-        Size textureSize = _backGroundBoxDisabledRenderer->getContentSize();
+        Size textureSize = _backGroundBoxDisabledRenderer->getOriginalSize();
         if (textureSize.width <= 0.0f || textureSize.height <= 0.0f)
         {
             _backGroundBoxDisabledRenderer->setScale(1.0f);
@@ -545,7 +545,7 @@ void AbstractCheckButton::frontCrossDisabledTextureScaleChangedWithSize()
     }
     else
     {
-        Size textureSize = _frontCrossDisabledRenderer->getContentSize();
+        Size textureSize = _frontCrossDisabledRenderer->getOriginalSize();
         if (textureSize.width <= 0.0f || textureSize.height <= 0.0f)
         {
             _frontCrossDisabledRenderer->setScale(1.0f);

--- a/cocos/ui/UIButton.cpp
+++ b/cocos/ui/UIButton.cpp
@@ -28,8 +28,6 @@ THE SOFTWARE.
 #include "2d/CCSprite.h"
 #include "2d/CCActionInterval.h"
 #include "platform/CCFileUtils.h"
-#include "base/CCDirector.h"
-#include "renderer/CCTextureCache.h"
 #include "ui/UIHelper.h"
 #include <algorithm>
 
@@ -926,27 +924,20 @@ void Button::copySpecialProperties(Widget *widget)
     {
         _prevIgnoreSize = button->_prevIgnoreSize;
         setScale9Enabled(button->_scale9Enabled);
-        //FIXME: encapsulate a functino to determin whether a sprite is using the default texture?
-        auto  defaultTexture = Director::getInstance()->getTextureCache()->getTextureForKey("/cc_2x2_white_image");
-        GLuint defaultTextureName =  defaultTexture->getName();
         
-        auto normalSprite = button->_buttonNormalRenderer->getSprite();
-        auto textureName = normalSprite->getTexture()->getName();
-        if (textureName != defaultTextureName)
+        if (!button->_buttonNormalRenderer->isUsingDefaultTexture())
         {
-            loadTextureNormal(normalSprite->getSpriteFrame());
+            loadTextureNormal(button->_buttonNormalRenderer->getSpriteFrame());
         }
-        auto clickedSprite = button->_buttonClickedRenderer->getSprite();
-        textureName = clickedSprite->getTexture()->getName();
-        if (textureName != defaultTextureName)
+        
+        if (!button->_buttonClickedRenderer->isUsingDefaultTexture())
         {
-            loadTexturePressed(clickedSprite->getSpriteFrame());
+            loadTexturePressed(button->_buttonClickedRenderer->getSpriteFrame());
         }
-        auto disabledSprite = button->_buttonDisabledRenderer->getSprite();
-        textureName = disabledSprite->getTexture()->getName();
-        if (textureName != defaultTextureName)
+        
+        if (!button->_buttonDisabledRenderer->isUsingDefaultTexture())
         {
-            loadTextureDisabled(disabledSprite->getSpriteFrame());
+            loadTextureDisabled(button->_buttonDisabledRenderer->getSpriteFrame());
         }
         setCapInsetsNormalRenderer(button->_capInsetsNormal);
         setCapInsetsPressedRenderer(button->_capInsetsPressed);

--- a/cocos/ui/UIImageView.cpp
+++ b/cocos/ui/UIImageView.cpp
@@ -302,10 +302,9 @@ void ImageView::copySpecialProperties(Widget *widget)
     {
         _prevIgnoreSize = imageView->_prevIgnoreSize;
         setScale9Enabled(imageView->_scale9Enabled);
-        auto imageSprite = imageView->_imageRenderer->getSprite();
-        if(nullptr != imageSprite)
+        if(!imageView->_imageRenderer->isUsingDefaultTexture())
         {
-            loadTexture(imageSprite->getSpriteFrame());
+            loadTexture(imageView->_imageRenderer->getSpriteFrame());
         }
         setCapInsets(imageView->_capInsets);
     }

--- a/cocos/ui/UIImageView.cpp
+++ b/cocos/ui/UIImageView.cpp
@@ -145,7 +145,7 @@ void ImageView::loadTexture(SpriteFrame* spriteframe)
 
 void ImageView::setupTexture()
 {
-    _imageTextureSize = _imageRenderer->getContentSize();
+    _imageTextureSize = _imageRenderer->getOriginalSize();
 
     this->updateChildrenDisplayedRGBA();
 

--- a/cocos/ui/UILoadingBar.cpp
+++ b/cocos/ui/UILoadingBar.cpp
@@ -104,34 +104,21 @@ void LoadingBar::setDirection(cocos2d::ui::LoadingBar::Direction direction)
     }
     _direction = direction;
     
+    this->updateRendererAnchorPoint();
+    this->updateRendererPosition();
+}
+    
+void LoadingBar::updateRendererPosition()
+{
     switch (_direction)
     {
         case Direction::LEFT:
-            _barRenderer->setAnchorPoint(Vec2(0.0f,0.5f));
             _barRenderer->setPosition(Vec2(0,_contentSize.height*0.5f));
-            if (!_scale9Enabled)
-            {
-                auto innerSprite = _barRenderer->getSprite();
-                if (nullptr != innerSprite)
-                {
-                    innerSprite->setFlippedX(false);
-                }
-            }
             break;
         case Direction::RIGHT:
-            _barRenderer->setAnchorPoint(Vec2(1.0f,0.5f));
             _barRenderer->setPosition(Vec2(_totalLength,_contentSize.height*0.5f));
-            if (!_scale9Enabled)
-            {
-                auto innerSprite = _barRenderer->getSprite();
-                if (nullptr != innerSprite)
-                {
-                    innerSprite->setFlippedX(true);
-                }
-            }
             break;
     }
-
 }
 
 LoadingBar::Direction LoadingBar::getDirection()const
@@ -166,36 +153,26 @@ void LoadingBar::loadTexture(SpriteFrame* spriteframe)
     this->_barRenderer->initWithSpriteFrame(spriteframe);
     this->setupTexture();
 }
-
-void LoadingBar::setupTexture()
+    
+void LoadingBar::updateRendererAnchorPoint()
 {
-    _barRendererTextureSize = _barRenderer->getContentSize();
-
     switch (_direction)
     {
         case Direction::LEFT:
             _barRenderer->setAnchorPoint(Vec2(0.0f,0.5f));
-            if (!_scale9Enabled)
-            {
-                auto innerSprite = _barRenderer->getSprite();
-                if (nullptr != innerSprite)
-                {
-                    innerSprite->setFlippedX(false);
-                }
-            }
             break;
         case Direction::RIGHT:
             _barRenderer->setAnchorPoint(Vec2(1.0f,0.5f));
-            if (!_scale9Enabled)
-            {
-                auto innerSprite = _barRenderer->getSprite();
-                if (nullptr != innerSprite)
-                {
-                    innerSprite->setFlippedX(true);
-                }
-            }
             break;
     }
+}
+
+void LoadingBar::setupTexture()
+{
+    _barRendererTextureSize = _barRenderer->getOriginalSize();
+
+    this->updateRendererAnchorPoint();
+    
     _barRenderer->setCapInsets(_capInsets);
     this->updateChildrenDisplayedRGBA();
 
@@ -371,17 +348,8 @@ void LoadingBar::barRendererScaleChangedWithSize()
             _barRenderer->setScaleY(scaleY);
         }
     }
-    switch (_direction)
-    {
-        case Direction::LEFT:
-            _barRenderer->setPosition(Vec2(0.0f,_contentSize.height*0.5f));
-            break;
-        case Direction::RIGHT:
-            _barRenderer->setPosition(Vec2(_totalLength,_contentSize.height*0.5f));
-            break;
-        default:
-            break;
-    }
+   
+    this->updateRendererPosition();
 }
 
 void LoadingBar::setScale9Scale()

--- a/cocos/ui/UILoadingBar.cpp
+++ b/cocos/ui/UILoadingBar.cpp
@@ -134,6 +134,7 @@ void LoadingBar::loadTexture(const std::string& texture,TextureResType texType)
         return;
     }
     _renderBarTexType = texType;
+    _textureFile = texture;
     switch (_renderBarTexType)
     {
         case TextureResType::LOCAL:
@@ -145,12 +146,6 @@ void LoadingBar::loadTexture(const std::string& texture,TextureResType texType)
         default:
             break;
     }
-    this->setupTexture();
-}
-
-void LoadingBar::loadTexture(SpriteFrame* spriteframe)
-{
-    this->_barRenderer->initWithSpriteFrame(spriteframe);
     this->setupTexture();
 }
     
@@ -375,10 +370,9 @@ void LoadingBar::copySpecialProperties(Widget *widget)
     {
         _prevIgnoreSize = loadingBar->_prevIgnoreSize;
         setScale9Enabled(loadingBar->_scale9Enabled);
-        auto barSprite = loadingBar->_barRenderer->getSprite();
-        if(nullptr != barSprite)
+        if(!loadingBar->_barRenderer->isUsingDefaultTexture())
         {
-            loadTexture(barSprite->getSpriteFrame());
+            loadTexture(loadingBar->_textureFile,loadingBar->_renderBarTexType);
         }
         setCapInsets(loadingBar->_capInsets);
         setPercent(loadingBar->_percent);

--- a/cocos/ui/UILoadingBar.h
+++ b/cocos/ui/UILoadingBar.h
@@ -180,7 +180,6 @@ protected:
     void barRendererScaleChangedWithSize();
 
     void setupTexture();
-    void loadTexture(SpriteFrame* spriteframe);
     
     virtual void adaptRenderers() override;
     
@@ -199,6 +198,7 @@ protected:
     bool _prevIgnoreSize;
     Rect _capInsets;
     bool _barRendererAdaptDirty;
+    std::string _textureFile;
 };
 
 }

--- a/cocos/ui/UILoadingBar.h
+++ b/cocos/ui/UILoadingBar.h
@@ -35,8 +35,8 @@ NS_CC_BEGIN
  */
 
 namespace ui {
-    class Scale9Sprite;
 
+class Scale9Sprite;
 /**
  *@brief Visual indicator of progress in some operation.
  * Displays a bar to the user representing how far the operation has progressed.
@@ -187,6 +187,8 @@ protected:
     virtual Widget* createCloneInstance() override;
     virtual void copySpecialProperties(Widget* model) override;
 protected:
+    void updateRendererAnchorPoint();
+    void updateRendererPosition();
     Direction _direction;
     float _percent;
     float _totalLength;

--- a/cocos/ui/UIScale9Sprite.cpp
+++ b/cocos/ui/UIScale9Sprite.cpp
@@ -250,7 +250,6 @@ namespace ui {
                                   const Size &originalSize,
                                   const Rect& capInsets)
     {
-        // updateBlendFunc(sprite?sprite->getTexture():nullptr);
         
         this->setSpriteFrame(sprite->getSpriteFrame());
         _offsetPosition = offset;

--- a/cocos/ui/UIScale9Sprite.cpp
+++ b/cocos/ui/UIScale9Sprite.cpp
@@ -57,6 +57,19 @@ namespace ui {
         return nullptr;
     }
     
+    Scale9Sprite* Scale9Sprite::create(const Rect& capInsets, const std::string& file)
+    {
+        Scale9Sprite *sprite = new (std::nothrow) Scale9Sprite();
+        if (sprite && sprite->initWithFile(file))
+        {
+            sprite->setCapInsets(capInsets);
+            sprite->autorelease();
+            return sprite;
+        }
+        CC_SAFE_DELETE(sprite);
+        return nullptr;
+    }
+    
     Scale9Sprite* Scale9Sprite::create(const std::string& filename)
     {
         Scale9Sprite *sprite = new (std::nothrow) Scale9Sprite();

--- a/cocos/ui/UIScale9Sprite.cpp
+++ b/cocos/ui/UIScale9Sprite.cpp
@@ -1,5 +1,6 @@
 /****************************************************************************
- Copyright (c) 2013-2014 Chukong Technologies Inc.
+ Copyright (c) 2013-2015 Chukong Technologies Inc.
+ Copyright (c) 2013-2015 zilongshanren
 
  http://www.cocos2d-x.org
 
@@ -23,288 +24,77 @@
 ****************************************************************************/
 
 #include "UIScale9Sprite.h"
-#include "2d/CCSprite.h"
 #include "2d/CCSpriteFrameCache.h"
-#include "base/CCVector.h"
 #include "base/CCDirector.h"
-#include "renderer/CCGLProgram.h"
-#include "renderer/ccShaders.h"
-#include "platform/CCImage.h"
-#include "base/CCNinePatchImageParser.h"
+#include "renderer/CCTextureCache.h"
 
 
 NS_CC_BEGIN
 namespace ui {
-
-    Scale9Sprite::Scale9Sprite()
-        : _spritesGenerated(false)
-        , _spriteFrameRotated(false)
-        , _positionsAreDirty(true)
-        , _scale9Image(nullptr)
-        , _topLeftSprite(nullptr)
-        , _topSprite(nullptr)
-        , _topRightSprite(nullptr)
-        , _leftSprite(nullptr)
-        , _centerSprite(nullptr)
-        , _rightSprite(nullptr)
-        , _bottomLeftSprite(nullptr)
-        , _bottomSprite(nullptr)
-        , _bottomRightSprite(nullptr)
-        , _scale9Enabled(true)
-        , _insetLeft(0)
-        , _insetTop(0)
-        , _insetRight(0)
-        , _insetBottom(0)
-        ,_flippedX(false)
-        ,_flippedY(false)
-        ,_isPatch9(false)
-        ,_brightState(State::NORMAL)
-
-    {
-        this->setAnchorPoint(Vec2(0.5,0.5));
-    }
-
-    Scale9Sprite::~Scale9Sprite()
-    {
-        this->cleanupSlicedSprites();
-        CC_SAFE_RELEASE(_scale9Image);
-    }
-
-    bool Scale9Sprite::initWithFile(const Rect& capInsets, const std::string& file)
-    {
-        bool pReturn = this->initWithFile(file, Rect::ZERO, capInsets);
-        return pReturn;
-    }
-
-    bool Scale9Sprite::initWithFile(const std::string& file)
-    {
-        bool pReturn = this->initWithFile(file, Rect::ZERO);
-        return pReturn;
-    }
-    bool Scale9Sprite::initWithSpriteFrame(SpriteFrame* spriteFrame,
-                                           const Rect& capInsets)
-    {
-        Texture2D* texture = spriteFrame->getTexture();
-        CCASSERT(texture != NULL, "CCTexture must be not nil");
-        Sprite *sprite = Sprite::createWithSpriteFrame(spriteFrame);
-        CCASSERT(sprite != NULL, "sprite must be not nil");
-        bool pReturn = this->init(sprite,
-                                  spriteFrame->getRect(),
-                                  spriteFrame->isRotated(),
-                                  spriteFrame->getOffset(),
-                                  spriteFrame->getOriginalSize(),
-                                  capInsets);
-        return pReturn;
-    }
-    bool Scale9Sprite::initWithSpriteFrame(SpriteFrame* spriteFrame)
-    {
-        CCASSERT(spriteFrame != NULL, "Invalid spriteFrame for sprite");
-        bool pReturn = this->initWithSpriteFrame(spriteFrame, Rect::ZERO);
-        return pReturn;
-    }
-    bool Scale9Sprite::initWithSpriteFrameName(const std::string& spriteFrameName,
-                                               const Rect& capInsets)
-    {
-        CCASSERT((SpriteFrameCache::getInstance()) != NULL,
-                 "SpriteFrameCache::getInstance() must be non-NULL");
-
-        SpriteFrame *frame = SpriteFrameCache::getInstance()->getSpriteFrameByName(spriteFrameName);
-        CCASSERT(frame != NULL, "CCSpriteFrame must be non-NULL");
-
-        if (NULL == frame) return false;
-        bool pReturn = this->initWithSpriteFrame(frame, capInsets);
-        return pReturn;
-    }
-    bool Scale9Sprite::initWithSpriteFrameName(const std::string& spriteFrameName)
-    {
-        bool pReturn = this->initWithSpriteFrameName(spriteFrameName, Rect::ZERO);
-        return pReturn;
-    }
-
-    bool Scale9Sprite::init()
-    {
-        return this->init(NULL, Rect::ZERO, Rect::ZERO);
-    }
-
-    bool Scale9Sprite::init(Sprite* sprite, const Rect& rect, const Rect& capInsets)
-    {
-        return this->init(sprite, rect, false, capInsets);
-    }
-
-    bool Scale9Sprite::init(Sprite* sprite,
-                            const Rect& rect,
-                            bool rotated,
-                            const Rect& capInsets)
-    {
-        return init(sprite, rect, rotated, Vec2::ZERO, rect.size, capInsets);
-    }
-
-    bool Scale9Sprite::init(Sprite* sprite,
-                            const Rect& rect,
-                            bool rotated,
-                            const Vec2 &offset,
-                            const Size &originalSize,
-                            const Rect& capInsets)
-    {
-        if(sprite)
-        {
-            auto texture = sprite->getTexture();
-            auto spriteFrame = sprite->getSpriteFrame();
-            Rect actualCapInsets = capInsets;
-
-            if (texture->isContain9PatchInfo())
-            {
-                auto& parsedCapInset = texture->getSpriteFrameCapInset(spriteFrame);
-                if(!parsedCapInset.equals(Rect::ZERO))
-                {
-                    this->_isPatch9 = true;
-                    if(capInsets.equals(Rect::ZERO))
-                    {
-                        actualCapInsets = parsedCapInset;
-                    }
-
-                }
-            }
-           
-            this->updateWithSprite(sprite,
-                                   rect,
-                                   rotated,
-                                   offset,
-                                   originalSize,
-                                   actualCapInsets);
-        }
-
-        return true;
-    }
-
-    bool Scale9Sprite::initWithBatchNode(cocos2d::SpriteBatchNode *batchnode,
-                                         const cocos2d::Rect &rect,
-                                         bool rotated,
-                                         const cocos2d::Rect &capInsets)
-    {
-        Sprite *sprite = Sprite::createWithTexture(batchnode->getTexture());
-        return init(sprite, rect, rotated, capInsets);
-    }
-
-    bool Scale9Sprite::initWithBatchNode(cocos2d::SpriteBatchNode *batchnode,
-                                         const cocos2d::Rect &rect,
-                                         const cocos2d::Rect &capInsets)
-    {
-        auto sprite = Sprite::createWithTexture(batchnode->getTexture());
-        return init(sprite, rect, false, capInsets);
-    }
-    bool Scale9Sprite::initWithFile(const std::string& file,
-                                    const Rect& rect,
-                                    const Rect& capInsets)
-    {
-        Sprite *sprite = nullptr;
-        sprite = Sprite::create(file);
-        bool pReturn = this->init(sprite, rect, capInsets);
-        return pReturn;
-    }
-
-    bool Scale9Sprite::initWithFile(const std::string& file, const Rect& rect)
-    {
-        bool pReturn = this->initWithFile(file, rect, Rect::ZERO);
-        return pReturn;
-    }
-
     Scale9Sprite* Scale9Sprite::create()
     {
-        Scale9Sprite *pReturn = new (std::nothrow) Scale9Sprite();
-        if (pReturn && pReturn->init())
+        Scale9Sprite *sprite = new (std::nothrow) Scale9Sprite();
+        if (sprite && sprite->init())
         {
-            pReturn->autorelease();
-            return pReturn;
+            sprite->autorelease();
+            return sprite;
         }
-        CC_SAFE_DELETE(pReturn);
-        return NULL;
+        CC_SAFE_DELETE(sprite);
+        return nullptr;
     }
-
-    Scale9Sprite* Scale9Sprite::create(const std::string& file,
-                                       const Rect& rect,
-                                       const Rect& capInsets)
+    
+    
+    Scale9Sprite* Scale9Sprite::create(const std::string& filename, const Rect& rect)
     {
-        Scale9Sprite* pReturn = new (std::nothrow) Scale9Sprite();
-        if ( pReturn && pReturn->initWithFile(file, rect, capInsets) )
+        Scale9Sprite *sprite = new (std::nothrow) Scale9Sprite();
+        if (sprite && sprite->initWithFile(filename, rect))
         {
-            pReturn->autorelease();
-            return pReturn;
+            sprite->autorelease();
+            return sprite;
         }
-        CC_SAFE_DELETE(pReturn);
-        return NULL;
+        CC_SAFE_DELETE(sprite);
+        return nullptr;
     }
-
-
-    Scale9Sprite* Scale9Sprite::create(const std::string& file, const Rect& rect)
+    
+    Scale9Sprite* Scale9Sprite::create(const std::string& filename)
     {
-        Scale9Sprite* pReturn = new (std::nothrow) Scale9Sprite();
-        if ( pReturn && pReturn->initWithFile(file, rect) )
+        Scale9Sprite *sprite = new (std::nothrow) Scale9Sprite();
+        if (sprite && sprite->initWithFile(filename))
         {
-            pReturn->autorelease();
-            return pReturn;
+            sprite->autorelease();
+            return sprite;
         }
-        CC_SAFE_DELETE(pReturn);
-        return NULL;
+        CC_SAFE_DELETE(sprite);
+        return nullptr;
     }
-
-
-
-    Scale9Sprite* Scale9Sprite::create(const Rect& capInsets,
-                                       const std::string& file)
+    
+    Scale9Sprite* Scale9Sprite::createWithSpriteFrame(SpriteFrame *spriteFrame)
     {
-        Scale9Sprite* pReturn = new (std::nothrow) Scale9Sprite();
-        if ( pReturn && pReturn->initWithFile(capInsets, file) )
+        Scale9Sprite *sprite = new (std::nothrow) Scale9Sprite();
+        if (sprite && spriteFrame && sprite->initWithSpriteFrame(spriteFrame))
         {
-            pReturn->autorelease();
-            return pReturn;
+            sprite->autorelease();
+            return sprite;
         }
-        CC_SAFE_DELETE(pReturn);
-        return NULL;
+        CC_SAFE_DELETE(sprite);
+        return nullptr;
     }
-
-
-    Scale9Sprite* Scale9Sprite::create(const std::string& file)
+    
+    Scale9Sprite* Scale9Sprite::createWithSpriteFrameName(const std::string& spriteFrameName)
     {
-        Scale9Sprite* pReturn = new (std::nothrow) Scale9Sprite();
-        if ( pReturn && pReturn->initWithFile(file) )
-        {
-            pReturn->autorelease();
-            return pReturn;
-        }
-        CC_SAFE_DELETE(pReturn);
-        return NULL;
+        SpriteFrame *frame = SpriteFrameCache::getInstance()->getSpriteFrameByName(spriteFrameName);
+        
+#if COCOS2D_DEBUG > 0
+        char msg[256] = {0};
+        sprintf(msg, "Invalid spriteFrameName: %s", spriteFrameName.c_str());
+        CCASSERT(frame != nullptr, msg);
+#endif
+        
+        return createWithSpriteFrame(frame);
     }
-
-
-    Scale9Sprite* Scale9Sprite::createWithSpriteFrame(SpriteFrame* spriteFrame,
-                                                      const Rect& capInsets)
-    {
-        Scale9Sprite* pReturn = new (std::nothrow) Scale9Sprite();
-        if ( pReturn && pReturn->initWithSpriteFrame(spriteFrame, capInsets) )
-        {
-            pReturn->autorelease();
-            return pReturn;
-        }
-        CC_SAFE_DELETE(pReturn);
-        return NULL;
-    }
-
-    Scale9Sprite* Scale9Sprite::createWithSpriteFrame(SpriteFrame* spriteFrame)
-    {
-        Scale9Sprite* pReturn = new (std::nothrow) Scale9Sprite();
-        if ( pReturn && pReturn->initWithSpriteFrame(spriteFrame) )
-        {
-            pReturn->autorelease();
-            return pReturn;
-        }
-        CC_SAFE_DELETE(pReturn);
-        return NULL;
-    }
-
-
+    
     Scale9Sprite* Scale9Sprite::createWithSpriteFrameName(const std::string& spriteFrameName,
-                                                          const Rect& capInsets)
+                                              const Rect& capInsets)
     {
         Scale9Sprite* pReturn = new (std::nothrow) Scale9Sprite();
         if ( pReturn && pReturn->initWithSpriteFrameName(spriteFrameName, capInsets) )
@@ -315,736 +105,12 @@ namespace ui {
         CC_SAFE_DELETE(pReturn);
         return NULL;
     }
-
-    Scale9Sprite* Scale9Sprite::createWithSpriteFrameName(const std::string& spriteFrameName)
+    
+    Scale9Sprite* Scale9Sprite::createWithSpriteFrame(SpriteFrame* spriteFrame,
+                                          const Rect& capInsets)
     {
         Scale9Sprite* pReturn = new (std::nothrow) Scale9Sprite();
-        if ( pReturn && pReturn->initWithSpriteFrameName(spriteFrameName) )
-        {
-            pReturn->autorelease();
-            return pReturn;
-        }
-        CC_SAFE_DELETE(pReturn);
-
-        log("Could not allocate Scale9Sprite()");
-        return NULL;
-
-    }
-
-    void Scale9Sprite::cleanupSlicedSprites()
-    {
-        if (_topLeftSprite && _topLeftSprite->isRunning())
-        {
-            _topLeftSprite->onExit();
-        }
-        if (_topSprite && _topSprite->isRunning())
-        {
-            _topSprite->onExit();
-        }
-        if (_topRightSprite && _topRightSprite->isRunning())
-        {
-            _topRightSprite->onExit();
-        }
-
-        if (_leftSprite && _leftSprite->isRunning())
-        {
-            _leftSprite->onExit();
-        }
-
-        if (_centerSprite && _centerSprite->isRunning())
-        {
-            _centerSprite->onExit();
-        }
-
-        if (_rightSprite && _rightSprite->isRunning())
-        {
-            _rightSprite->onExit();
-        }
-
-        if (_bottomLeftSprite && _bottomLeftSprite->isRunning())
-        {
-            _bottomLeftSprite->onExit();
-        }
-
-        if (_bottomRightSprite && _bottomRightSprite->isRunning())
-        {
-            _bottomRightSprite->onExit();
-        }
-
-        if (_bottomSprite && _bottomSprite->isRunning())
-        {
-            _bottomSprite->onExit();
-        }
-
-        CC_SAFE_RELEASE_NULL(_topLeftSprite);
-        CC_SAFE_RELEASE_NULL(_topSprite);
-        CC_SAFE_RELEASE_NULL(_topRightSprite);
-        CC_SAFE_RELEASE_NULL(_leftSprite);
-        CC_SAFE_RELEASE_NULL(_centerSprite);
-        CC_SAFE_RELEASE_NULL(_rightSprite);
-        CC_SAFE_RELEASE_NULL(_bottomLeftSprite);
-        CC_SAFE_RELEASE_NULL(_bottomSprite);
-        CC_SAFE_RELEASE_NULL(_bottomRightSprite);
-    }
-
-
-    void Scale9Sprite::setBlendFunc(const BlendFunc &blendFunc)
-    {
-        _blendFunc = blendFunc;
-        applyBlendFunc();
-    }
-    const BlendFunc &Scale9Sprite::getBlendFunc() const
-    {
-        return _blendFunc;
-    }
-
-    void Scale9Sprite::updateBlendFunc(Texture2D *texture)
-    {
-
-        // it is possible to have an untextured sprite
-        if (! texture || ! texture->hasPremultipliedAlpha())
-        {
-            _blendFunc = BlendFunc::ALPHA_NON_PREMULTIPLIED;
-            setOpacityModifyRGB(false);
-        }
-        else
-        {
-            _blendFunc = BlendFunc::ALPHA_PREMULTIPLIED;
-            setOpacityModifyRGB(true);
-        }
-    }
-
-    void Scale9Sprite::applyBlendFunc()
-    {
-        if(_scale9Image)
-            _scale9Image->setBlendFunc(_blendFunc);
-        if(_topLeftSprite)
-            _topLeftSprite->setBlendFunc(_blendFunc);
-        if(_topSprite)
-            _topSprite->setBlendFunc(_blendFunc);
-        if(_topRightSprite)
-            _topRightSprite->setBlendFunc(_blendFunc);
-        if(_leftSprite)
-            _leftSprite->setBlendFunc(_blendFunc);
-        if(_centerSprite)
-            _centerSprite->setBlendFunc(_blendFunc);
-        if(_rightSprite)
-            _rightSprite->setBlendFunc(_blendFunc);
-        if(_bottomLeftSprite)
-            _bottomLeftSprite->setBlendFunc(_blendFunc);
-        if(_bottomSprite)
-            _bottomSprite->setBlendFunc(_blendFunc);
-        if(_bottomRightSprite)
-            _bottomRightSprite->setBlendFunc(_blendFunc);
-    }
-
-    bool Scale9Sprite::updateWithBatchNode(cocos2d::SpriteBatchNode *batchnode,
-                                           const cocos2d::Rect &originalRect,
-                                           bool rotated,
-                                           const cocos2d::Rect &capInsets)
-    {
-        Sprite *sprite = Sprite::createWithTexture(batchnode->getTexture());
-        return this->updateWithSprite(sprite,
-                                      originalRect,
-                                      rotated,
-                                      Vec2::ZERO,
-                                      originalRect.size,
-                                      capInsets);
-    }
-
-    bool Scale9Sprite::updateWithSprite(Sprite* sprite,
-                                        const Rect& rect,
-                                        bool rotated,
-                                        const Rect& capInsets)
-    {
-        return updateWithSprite(sprite, rect, rotated, Vec2::ZERO, rect.size, capInsets);
-    }
-
-    static Rect intersectRect(const Rect &first, const Rect &second)
-    {
-        Rect ret;
-        ret.origin.x = std::max(first.origin.x,second.origin.x);
-        ret.origin.y = std::max(first.origin.y,second.origin.y);
-
-        float rightRealPoint = std::min(first.origin.x + first.size.width,
-                                        second.origin.x + second.size.width);
-        float bottomRealPoint = std::min(first.origin.y + first.size.height,
-                                         second.origin.y + second.size.height);
-
-        ret.size.width = std::max(rightRealPoint - ret.origin.x, 0.0f);
-        ret.size.height = std::max(bottomRealPoint - ret.origin.y, 0.0f);
-        return ret;
-    }
-
-    bool Scale9Sprite::updateWithSprite(Sprite* sprite,
-                                        const Rect& textureRect,
-                                        bool rotated,
-                                        const Vec2 &offset,
-                                        const Size &originalSize,
-                                        const Rect& capInsets)
-    {
-        GLubyte opacity = getOpacity();
-        Color3B color = getColor();
-
-        // Release old sprites
-        this->cleanupSlicedSprites();
-        _protectedChildren.clear();
-
-        updateBlendFunc(sprite?sprite->getTexture():nullptr);
-
-        if(nullptr != sprite)
-        {
-            if (nullptr == sprite->getSpriteFrame())
-            {
-                return false;
-            }
-
-            if (nullptr == _scale9Image)
-            {
-                _scale9Image = sprite;
-                _scale9Image->retain();
-            }
-            else
-            {
-                _scale9Image->setSpriteFrame(sprite->getSpriteFrame());
-            }
-        }
-
-        if (!_scale9Image)
-        {
-            return false;
-        }
-
-        SpriteFrame *spriteFrame = _scale9Image->getSpriteFrame();
-
-        if (!spriteFrame)
-        {
-            return false;
-        }
-
-        Rect rect(textureRect);
-        Size size(originalSize);
-        
-        _capInsets = capInsets;
-
-        // If there is no given rect
-        if ( rect.equals(Rect::ZERO) )
-        {
-            // Get the texture size as original
-            Size textureSize = _scale9Image->getTexture()->getContentSize();
-
-            rect = Rect(0, 0, textureSize.width, textureSize.height);
-        }
-
-        if( size.equals(Size::ZERO) )
-        {
-            size = rect.size;
-        }
-
-        // Set the given rect's size as original size
-        _spriteRect = rect;
-        _offset = offset;
-        _spriteFrameRotated = rotated;
-        _originalSize = size;
-        _preferredSize = size;
-
-        _capInsetsInternal = capInsets;
-
-        if (_scale9Enabled)
-        {
-            this->createSlicedSprites();
-        }
-
-        applyBlendFunc();
-        this->setState(_brightState);
-        if(this->_isPatch9)
-        {
-            size.width = size.width - 2;
-            size.height = size.height - 2;
-        }
-        this->setContentSize(size);
-
-        if (_spritesGenerated)
-        {
-            // Restore color and opacity
-            this->setOpacity(opacity);
-            this->setColor(color);
-        }
-        _spritesGenerated = true;
-
-        return true;
-    }
-
-    void Scale9Sprite::createSlicedSprites()
-    {
-        float width = _originalSize.width;
-        float height = _originalSize.height;
-
-        Vec2 offsetPosition(floor(_offset.x + (_originalSize.width - _spriteRect.size.width) / 2),
-                            floor(_offset.y + (_originalSize.height - _spriteRect.size.height) / 2));
-
-        // If there is no specified center region
-        if ( _capInsetsInternal.equals(Rect::ZERO) )
-        {
-            // log("... cap insets not specified : using default cap insets ...");
-            _capInsetsInternal = Rect(width /3, height /3, width /3, height /3);
-        }
-
-        Rect originalRect=_spriteRect;
-        if(_spriteFrameRotated)
-            originalRect = Rect(_spriteRect.origin.x - offsetPosition.y,
-                                _spriteRect.origin.y - offsetPosition.x,
-                                _originalSize.width, _originalSize.height);
-        else
-            originalRect = Rect(_spriteRect.origin.x - offsetPosition.x,
-                                _spriteRect.origin.y - offsetPosition.y,
-                                _originalSize.width, _originalSize.height);
-
-        float leftWidth = _capInsetsInternal.origin.x;
-        float centerWidth = _capInsetsInternal.size.width;
-        float rightWidth = originalRect.size.width - (leftWidth + centerWidth);
-
-        float topHeight = _capInsetsInternal.origin.y;
-        float centerHeight = _capInsetsInternal.size.height;
-        float bottomHeight = originalRect.size.height - (topHeight + centerHeight);
-
-        // calculate rects
-
-        // ... top row
-        float x = 0.0;
-        float y = 0.0;
-        //why do we need pixelRect?
-        Rect pixelRect = Rect(offsetPosition.x, offsetPosition.y,
-                              _spriteRect.size.width, _spriteRect.size.height);
-
-        // top left
-        Rect leftTopBoundsOriginal = Rect(x, y, leftWidth, topHeight);
-        Rect leftTopBounds = leftTopBoundsOriginal;
-
-        // top center
-        x += leftWidth;
-        Rect centerTopBounds = Rect(x, y, centerWidth, topHeight);
-
-        // top right
-        x += centerWidth;
-        Rect rightTopBounds = Rect(x, y, rightWidth, topHeight);
-
-        // ... center row
-        x = 0.0;
-        y = 0.0;
-        y += topHeight;
-
-        // center left
-        Rect leftCenterBounds = Rect(x, y, leftWidth, centerHeight);
-
-        // center center
-        x += leftWidth;
-        Rect centerBoundsOriginal = Rect(x, y, centerWidth, centerHeight);
-        Rect centerBounds = centerBoundsOriginal;
-
-        // center right
-        x += centerWidth;
-        Rect rightCenterBounds = Rect(x, y, rightWidth, centerHeight);
-
-        // ... bottom row
-        x = 0.0;
-        y = 0.0;
-        y += topHeight;
-        y += centerHeight;
-
-        // bottom left
-        Rect leftBottomBounds = Rect(x, y, leftWidth, bottomHeight);
-
-        // bottom center
-        x += leftWidth;
-        Rect centerBottomBounds = Rect(x, y, centerWidth, bottomHeight);
-
-        // bottom right
-        x += centerWidth;
-        Rect rightBottomBoundsOriginal = Rect(x, y, rightWidth, bottomHeight);
-        Rect rightBottomBounds = rightBottomBoundsOriginal;
-
-        if((_capInsetsInternal.origin.x + _capInsetsInternal.size.width) <= _originalSize.width
-           || (_capInsetsInternal.origin.y + _capInsetsInternal.size.height) <= _originalSize.height)
-            //in general case it is error but for legacy support we will check it
-        {
-            leftTopBounds = intersectRect(leftTopBounds, pixelRect);
-            centerTopBounds = intersectRect(centerTopBounds, pixelRect);
-            rightTopBounds = intersectRect(rightTopBounds, pixelRect);
-            leftCenterBounds = intersectRect(leftCenterBounds, pixelRect);
-            centerBounds = intersectRect(centerBounds, pixelRect);
-            rightCenterBounds = intersectRect(rightCenterBounds, pixelRect);
-            leftBottomBounds = intersectRect(leftBottomBounds, pixelRect);
-            centerBottomBounds = intersectRect(centerBottomBounds, pixelRect);
-            rightBottomBounds = intersectRect(rightBottomBounds, pixelRect);
-        }
-        else
-            //it is error but for legacy turn off clip system
-            CCLOG("Scale9Sprite capInsetsInternal > originalSize");
-
-        Rect rotatedLeftTopBoundsOriginal = leftTopBoundsOriginal;
-        Rect rotatedCenterBoundsOriginal = centerBoundsOriginal;
-        Rect rotatedRightBottomBoundsOriginal = rightBottomBoundsOriginal;
-
-        Rect rotatedCenterBounds = centerBounds;
-        Rect rotatedRightBottomBounds = rightBottomBounds;
-        Rect rotatedLeftBottomBounds = leftBottomBounds;
-        Rect rotatedRightTopBounds = rightTopBounds;
-        Rect rotatedLeftTopBounds = leftTopBounds;
-        Rect rotatedRightCenterBounds = rightCenterBounds;
-        Rect rotatedLeftCenterBounds = leftCenterBounds;
-        Rect rotatedCenterBottomBounds = centerBottomBounds;
-        Rect rotatedCenterTopBounds = centerTopBounds;
-
-        if (!_spriteFrameRotated)
-        {
-
-            AffineTransform t = AffineTransform::IDENTITY;
-            t = AffineTransformTranslate(t, originalRect.origin.x, originalRect.origin.y);
-
-            rotatedLeftTopBoundsOriginal = RectApplyAffineTransform(rotatedLeftTopBoundsOriginal, t);
-            rotatedCenterBoundsOriginal = RectApplyAffineTransform(rotatedCenterBoundsOriginal, t);
-            rotatedRightBottomBoundsOriginal = RectApplyAffineTransform(rotatedRightBottomBoundsOriginal, t);
-
-            rotatedCenterBounds = RectApplyAffineTransform(rotatedCenterBounds, t);
-            rotatedRightBottomBounds = RectApplyAffineTransform(rotatedRightBottomBounds, t);
-            rotatedLeftBottomBounds = RectApplyAffineTransform(rotatedLeftBottomBounds, t);
-            rotatedRightTopBounds = RectApplyAffineTransform(rotatedRightTopBounds, t);
-            rotatedLeftTopBounds = RectApplyAffineTransform(rotatedLeftTopBounds, t);
-            rotatedRightCenterBounds = RectApplyAffineTransform(rotatedRightCenterBounds, t);
-            rotatedLeftCenterBounds = RectApplyAffineTransform(rotatedLeftCenterBounds, t);
-            rotatedCenterBottomBounds = RectApplyAffineTransform(rotatedCenterBottomBounds, t);
-            rotatedCenterTopBounds = RectApplyAffineTransform(rotatedCenterTopBounds, t);
-
-
-        }
-        else
-        {
-            // set up transformation of coordinates
-            // to handle the case where the sprite is stored rotated
-            // in the spritesheet
-            // log("rotated");
-
-            AffineTransform t = AffineTransform::IDENTITY;
-
-            t = AffineTransformTranslate(t, originalRect.size.height+originalRect.origin.x, originalRect.origin.y);
-            t = AffineTransformRotate(t, 1.57079633f);
-
-            leftTopBoundsOriginal = RectApplyAffineTransform(leftTopBoundsOriginal, t);
-            centerBoundsOriginal = RectApplyAffineTransform(centerBoundsOriginal, t);
-            rightBottomBoundsOriginal = RectApplyAffineTransform(rightBottomBoundsOriginal, t);
-
-            centerBounds = RectApplyAffineTransform(centerBounds, t);
-            rightBottomBounds = RectApplyAffineTransform(rightBottomBounds, t);
-            leftBottomBounds = RectApplyAffineTransform(leftBottomBounds, t);
-            rightTopBounds = RectApplyAffineTransform(rightTopBounds, t);
-            leftTopBounds = RectApplyAffineTransform(leftTopBounds, t);
-            rightCenterBounds = RectApplyAffineTransform(rightCenterBounds, t);
-            leftCenterBounds = RectApplyAffineTransform(leftCenterBounds, t);
-            centerBottomBounds = RectApplyAffineTransform(centerBottomBounds, t);
-            centerTopBounds = RectApplyAffineTransform(centerTopBounds, t);
-
-            rotatedLeftTopBoundsOriginal.origin = leftTopBoundsOriginal.origin;
-            rotatedCenterBoundsOriginal.origin = centerBoundsOriginal.origin;
-            rotatedRightBottomBoundsOriginal.origin = rightBottomBoundsOriginal.origin;
-
-            rotatedCenterBounds.origin = centerBounds.origin;
-            rotatedRightBottomBounds.origin = rightBottomBounds.origin;
-            rotatedLeftBottomBounds.origin = leftBottomBounds.origin;
-            rotatedRightTopBounds.origin = rightTopBounds.origin;
-            rotatedLeftTopBounds.origin = leftTopBounds.origin;
-            rotatedRightCenterBounds.origin = rightCenterBounds.origin;
-            rotatedLeftCenterBounds.origin = leftCenterBounds.origin;
-            rotatedCenterBottomBounds.origin = centerBottomBounds.origin;
-            rotatedCenterTopBounds.origin = centerTopBounds.origin;
-
-
-        }
-
-        _topLeftSize = rotatedLeftTopBoundsOriginal.size;
-        _centerSize = rotatedCenterBoundsOriginal.size;
-        _bottomRightSize = rotatedRightBottomBoundsOriginal.size;
-        if(_isPatch9)
-        {
-            _topLeftSize.width = _topLeftSize.width - 1;
-            _topLeftSize.height = _topLeftSize.height - 1;
-            _bottomRightSize.width = _bottomRightSize.width - 1;
-            _bottomRightSize.height = _bottomRightSize.height - 1;
-        }
-
-        if(_spriteFrameRotated)
-        {
-            float offsetX = (rotatedCenterBounds.origin.x + rotatedCenterBounds.size.height/2)
-                - (rotatedCenterBoundsOriginal.origin.x + rotatedCenterBoundsOriginal.size.height/2);
-            float offsetY = (rotatedCenterBoundsOriginal.origin.y + rotatedCenterBoundsOriginal.size.width/2)
-                - (rotatedCenterBounds.origin.y + rotatedCenterBounds.size.width/2);
-            _centerOffset.x = -offsetY;
-            _centerOffset.y = offsetX;
-        }
-        else
-        {
-            float offsetX = (rotatedCenterBounds.origin.x + rotatedCenterBounds.size.width/2)
-                - (rotatedCenterBoundsOriginal.origin.x + rotatedCenterBoundsOriginal.size.width/2);
-            float offsetY = (rotatedCenterBoundsOriginal.origin.y + rotatedCenterBoundsOriginal.size.height/2)
-                - (rotatedCenterBounds.origin.y + rotatedCenterBounds.size.height/2);
-            _centerOffset.x = offsetX;
-            _centerOffset.y = offsetY;
-        }
-
-        //shrink the image size when it is 9-patch
-        if(_isPatch9)
-        {
-            float offset = 1.0f;
-            //Top left
-            if(!_spriteFrameRotated)
-            {
-                rotatedLeftTopBounds.origin.x+=offset;
-                rotatedLeftTopBounds.origin.y+=offset;
-                rotatedLeftTopBounds.size.width-=offset;
-                rotatedLeftTopBounds.size.height-=offset;
-                //Center left
-                rotatedLeftCenterBounds.origin.x+=offset;
-                rotatedLeftCenterBounds.size.width-=offset;
-                //Bottom left
-                rotatedLeftBottomBounds.origin.x+=offset;
-                rotatedLeftBottomBounds.size.width-=offset;
-                rotatedLeftBottomBounds.size.height-=offset;
-                //Top center
-                rotatedCenterTopBounds.size.height-=offset;
-                rotatedCenterTopBounds.origin.y+=offset;
-                //Bottom center
-                rotatedCenterBottomBounds.size.height-=offset;
-                //Top right
-                rotatedRightTopBounds.size.width-=offset;
-                rotatedRightTopBounds.size.height-=offset;
-                rotatedRightTopBounds.origin.y+=offset;
-                //Center right
-                rotatedRightCenterBounds.size.width-=offset;
-                //Bottom right
-                rotatedRightBottomBounds.size.width-=offset;
-                rotatedRightBottomBounds.size.height-=offset;
-            }
-            else
-            {
-                //Top left
-                rotatedLeftTopBounds.size.width-=offset;
-                rotatedLeftTopBounds.size.height-=offset;
-                rotatedLeftTopBounds.origin.y+=offset;
-                //Center left
-                rotatedLeftCenterBounds.origin.y+=offset;
-                rotatedLeftCenterBounds.size.width-=offset;
-                //Bottom left
-                rotatedLeftBottomBounds.origin.x+=offset;
-                rotatedLeftBottomBounds.origin.y+=offset;
-                rotatedLeftBottomBounds.size.width-=offset;
-                rotatedLeftBottomBounds.size.height-=offset;
-                //Top center
-                rotatedCenterTopBounds.size.height-=offset;
-                //Bottom center
-                rotatedCenterBottomBounds.size.height-=offset;
-                rotatedCenterBottomBounds.origin.x+=offset;
-                //Top right
-                rotatedRightTopBounds.size.width-=offset;
-                rotatedRightTopBounds.size.height-=offset;
-                //Center right
-                rotatedRightCenterBounds.size.width-=offset;
-                //Bottom right
-                rotatedRightBottomBounds.size.width-=offset;
-                rotatedRightBottomBounds.size.height-=offset;
-                rotatedRightBottomBounds.origin.x+=offset;
-            }
-        }
-
-        // Centre
-        if(rotatedCenterBounds.size.width > 0 && rotatedCenterBounds.size.height > 0 )
-        {
-            _centerSprite = Sprite::createWithTexture(_scale9Image->getTexture(),
-                                                      rotatedCenterBounds,
-                                                      _spriteFrameRotated);
-            _centerSprite->retain();
-            this->addProtectedChild(_centerSprite);
-        }
-
-        // Top
-        if(rotatedCenterTopBounds.size.width > 0 && rotatedCenterTopBounds.size.height > 0 )
-        {
-            _topSprite = Sprite::createWithTexture(_scale9Image->getTexture(),
-                                                   rotatedCenterTopBounds,
-                                                   _spriteFrameRotated);
-            _topSprite->retain();
-            this->addProtectedChild(_topSprite);
-        }
-
-        // Bottom
-        if(rotatedCenterBottomBounds.size.width > 0 && rotatedCenterBottomBounds.size.height > 0 )
-        {
-            _bottomSprite = Sprite::createWithTexture(_scale9Image->getTexture(),
-                                                      rotatedCenterBottomBounds,
-                                                      _spriteFrameRotated);
-            _bottomSprite->retain();
-            this->addProtectedChild(_bottomSprite);
-        }
-
-        // Left
-        if(rotatedLeftCenterBounds.size.width > 0 && rotatedLeftCenterBounds.size.height > 0 )
-        {
-            _leftSprite = Sprite::createWithTexture(_scale9Image->getTexture(),
-                                                    rotatedLeftCenterBounds,
-                                                    _spriteFrameRotated);
-            _leftSprite->retain();
-            this->addProtectedChild(_leftSprite);
-        }
-
-        // Right
-        if(rotatedRightCenterBounds.size.width > 0 && rotatedRightCenterBounds.size.height > 0 )
-        {
-            _rightSprite = Sprite::createWithTexture(_scale9Image->getTexture(),
-                                                     rotatedRightCenterBounds,
-                                                     _spriteFrameRotated);
-            _rightSprite->retain();
-            this->addProtectedChild(_rightSprite);
-        }
-
-        // Top left
-        if(rotatedLeftTopBounds.size.width > 0 && rotatedLeftTopBounds.size.height > 0 )
-        {
-            _topLeftSprite = Sprite::createWithTexture(_scale9Image->getTexture(),
-                                                       rotatedLeftTopBounds,
-                                                       _spriteFrameRotated);
-            _topLeftSprite->retain();
-            this->addProtectedChild(_topLeftSprite);
-        }
-
-        // Top right
-        if(rotatedRightTopBounds.size.width > 0 && rotatedRightTopBounds.size.height > 0 )
-        {
-            _topRightSprite = Sprite::createWithTexture(_scale9Image->getTexture(),
-                                                        rotatedRightTopBounds,
-                                                        _spriteFrameRotated);
-            _topRightSprite->retain();
-            this->addProtectedChild(_topRightSprite);
-        }
-
-        // Bottom left
-        if(rotatedLeftBottomBounds.size.width > 0 && rotatedLeftBottomBounds.size.height > 0 )
-        {
-            _bottomLeftSprite = Sprite::createWithTexture(_scale9Image->getTexture(),
-                                                          rotatedLeftBottomBounds,
-                                                          _spriteFrameRotated);
-            _bottomLeftSprite->retain();
-            this->addProtectedChild(_bottomLeftSprite);
-        }
-
-        // Bottom right
-        if(rotatedRightBottomBounds.size.width > 0 && rotatedRightBottomBounds.size.height > 0 )
-        {
-            _bottomRightSprite = Sprite::createWithTexture(_scale9Image->getTexture(),
-                                                           rotatedRightBottomBounds,
-                                                           _spriteFrameRotated);
-            _bottomRightSprite->retain();
-            this->addProtectedChild(_bottomRightSprite);
-        }
-    }
-
-    void Scale9Sprite::setContentSize(const Size &size)
-    {
-        Node::setContentSize(size);
-        this->_positionsAreDirty = true;
-    }
-
-    void Scale9Sprite::updatePositions()
-    {
-        Size size = this->_contentSize;
-
-        float sizableWidth = size.width - _topLeftSize.width - _bottomRightSize.width;
-        float sizableHeight = size.height - _topLeftSize.height - _bottomRightSize.height;
-
-        float horizontalScale = sizableWidth/_centerSize.width;
-        float verticalScale = sizableHeight/_centerSize.height;
-
-        if(_centerSprite)
-        {
-            _centerSprite->setScaleX(horizontalScale);
-            _centerSprite->setScaleY(verticalScale);
-        }
-
-        float rescaledWidth = _centerSize.width * horizontalScale;
-        float rescaledHeight = _centerSize.height * verticalScale;
-
-        float leftWidth = _topLeftSize.width;
-        float bottomHeight = _bottomRightSize.height;
-
-        Vec2 centerOffset(_centerOffset.x * horizontalScale, _centerOffset.y * verticalScale);
-
-        // Position corners
-        if(_bottomLeftSprite)
-        {
-            _bottomLeftSprite->setAnchorPoint(Vec2(1,1));
-            _bottomLeftSprite->setPosition(leftWidth,bottomHeight);
-        }
-        if(_bottomRightSprite)
-        {
-            _bottomRightSprite->setAnchorPoint(Vec2(0,1));
-            _bottomRightSprite->setPosition(leftWidth+rescaledWidth,bottomHeight);
-        }
-        if(_topLeftSprite)
-        {
-            _topLeftSprite->setAnchorPoint(Vec2(1,0));
-            _topLeftSprite->setPosition(leftWidth, bottomHeight+rescaledHeight);
-        }
-        if(_topRightSprite)
-        {
-            _topRightSprite->setAnchorPoint(Vec2(0,0));
-            _topRightSprite->setPosition(leftWidth+rescaledWidth, bottomHeight+rescaledHeight);
-        }
-
-        // Scale and position borders
-        if(_leftSprite)
-        {
-            _leftSprite->setAnchorPoint(Vec2(1,0.5));
-            _leftSprite->setPosition(leftWidth, bottomHeight+rescaledHeight/2 + centerOffset.y);
-            _leftSprite->setScaleY(verticalScale);
-        }
-        if(_rightSprite)
-        {
-            _rightSprite->setAnchorPoint(Vec2(0,0.5));
-            _rightSprite->setPosition(leftWidth+rescaledWidth,bottomHeight+rescaledHeight/2 + centerOffset.y);
-            _rightSprite->setScaleY(verticalScale);
-        }
-        if(_topSprite)
-        {
-            _topSprite->setAnchorPoint(Vec2(0.5,0));
-            _topSprite->setPosition(leftWidth+rescaledWidth/2 + centerOffset.x,bottomHeight+rescaledHeight);
-            _topSprite->setScaleX(horizontalScale);
-        }
-        if(_bottomSprite)
-        {
-            _bottomSprite->setAnchorPoint(Vec2(0.5,1));
-            _bottomSprite->setPosition(leftWidth+rescaledWidth/2 + centerOffset.x,bottomHeight);
-            _bottomSprite->setScaleX(horizontalScale);
-        }
-        // Position centre
-        if(_centerSprite)
-        {
-            _centerSprite->setAnchorPoint(Vec2(0.5,0.5));
-            _centerSprite->setPosition(leftWidth+rescaledWidth/2 + centerOffset.x,
-                                       bottomHeight+rescaledHeight/2 + centerOffset.y);
-            _centerSprite->setScaleX(horizontalScale);
-            _centerSprite->setScaleY(verticalScale);
-        }
-    }
-
-
-
-    Scale9Sprite* Scale9Sprite::resizableSpriteWithCapInsets(const Rect& capInsets) const
-    {
-        Scale9Sprite* pReturn = new (std::nothrow) Scale9Sprite();
-        if ( pReturn && pReturn->init(_scale9Image,
-                                      _spriteRect,
-                                      _spriteFrameRotated,
-                                      _offset,
-                                      _originalSize,
-                                      _capInsets) )
+        if ( pReturn && pReturn->initWithSpriteFrame(spriteFrame, capInsets) )
         {
             pReturn->autorelease();
             return pReturn;
@@ -1053,526 +119,180 @@ namespace ui {
         return NULL;
     }
     
-    Scale9Sprite::State Scale9Sprite::getState()const
+    Scale9Sprite* Scale9Sprite::create(const std::string& file,
+                           const Rect& rect,
+                           const Rect& capInsets)
     {
-        return _brightState;
+        Scale9Sprite* pReturn = new (std::nothrow) Scale9Sprite();
+        if ( pReturn && pReturn->initWithFile(file, rect, capInsets) )
+        {
+            pReturn->autorelease();
+            return pReturn;
+        }
+        CC_SAFE_DELETE(pReturn);
+        return NULL;
     }
-
-    void Scale9Sprite::setState(cocos2d::ui::Scale9Sprite::State state)
+    
+    bool Scale9Sprite::initWithSpriteFrameName(const std::string& spriteFrameName,
+                                         const Rect& capInsets)
     {
-        GLProgramState *glState = nullptr;
-        switch (state)
+        CCASSERT(spriteFrameName.size() > 0, "Invalid spriteFrameName");
+        
+        SpriteFrame *frame = SpriteFrameCache::getInstance()->getSpriteFrameByName(spriteFrameName);
+        return initWithSpriteFrame(frame, capInsets);
+    }
+    
+    bool Scale9Sprite::initWithSpriteFrame(SpriteFrame* spriteFrame,
+                                     const Rect& capInsets)
+    {
+        CCASSERT(spriteFrame != nullptr, "spriteFrame can't be nullptr!");
+        
+        bool bRet = initWithTexture(spriteFrame->getTexture(), spriteFrame->getRect());
+        setSpriteFrame(spriteFrame);
+        setCapInsets(capInsets);
+        
+        return bRet;
+    }
+    
+    bool Scale9Sprite::initWithFile(const Rect& capInsets, const std::string& file)
+    {
+        bool pReturn = this->initWithFile(file, Rect::ZERO, capInsets);
+        return pReturn;
+    }
+    
+    
+    bool Scale9Sprite::initWithFile(const std::string& filename, const Rect& rect,  const Rect& capInsets)
+    {
+        CCASSERT(filename.size()>0, "Invalid filename");
+        
+        Texture2D *texture = Director::getInstance()->getTextureCache()->addImage(filename);
+        if (texture)
         {
-        case State::NORMAL:
-        {
-            glState = GLProgramState::getOrCreateWithGLProgramName(GLProgram::SHADER_NAME_POSITION_TEXTURE_COLOR_NO_MVP);
-        }
-        break;
-        case State::GRAY:
-        {
-            glState = GLProgramState::getOrCreateWithGLProgramName(GLProgram::SHADER_NAME_POSITION_GRAYSCALE);
-        }
-        default:
-            break;
+            
+            bool ret = initWithTexture(texture, rect);
+            this->setCapInsets(capInsets);
+            return ret;
         }
         
-        if (nullptr != _scale9Image)
-        {
-            _scale9Image->setGLProgramState(glState);
-        }
-
-        if (_scale9Enabled)
-        {
-            for (auto& sp : _protectedChildren)
-            {
-                sp->setGLProgramState(glState);
-            }
-        }
-        _brightState = state;
+        // don't release here.
+        // when load texture failed, it's better to get a "transparent" sprite then a crashed program
+        // this->release();
+        return false;
     }
-
-/** sets the opacity.
-    @warning If the the texture has premultiplied alpha then, the R, G and B channels will be modifed.
-    Values goes from 0 to 255, where 255 means fully opaque.
-*/
-
-
-
-    void Scale9Sprite::updateCapInset()
+    
+    Scale9Sprite::Scale9Sprite()
     {
-        Rect insets;
-        if (this->_insetLeft == 0 && this->_insetTop == 0 && this->_insetRight == 0 && this->_insetBottom == 0)
-        {
-            insets = Rect::ZERO;
-        }
-        else
-        {
-            insets = Rect(_insetLeft,
-                          _insetTop,
-                          _originalSize.width-_insetLeft-_insetRight,
-                          _originalSize.height-_insetTop-_insetBottom);
-        }
-        this->setCapInsets(insets);
+        this->setType(Type::Sliced);
     }
-
-
-    void Scale9Sprite::setSpriteFrame(SpriteFrame * spriteFrame, const Rect& capInsets)
+    
+    Scale9Sprite::~Scale9Sprite()
     {
-        Sprite * sprite = Sprite::createWithTexture(spriteFrame->getTexture());
-        this->updateWithSprite(sprite,
-                               spriteFrame->getRect(),
-                               spriteFrame->isRotated(),
-                               spriteFrame->getOffset(),
-                               spriteFrame->getOriginalSize(),
-                               capInsets);
-
-        // Reset insets
-        this->_insetLeft = capInsets.origin.x;
-        this->_insetTop = capInsets.origin.y;
-        this->_insetRight = _originalSize.width - _insetLeft - capInsets.size.width;
-        this->_insetBottom = _originalSize.height - _insetTop - capInsets.size.height;
+        
     }
-
-    void Scale9Sprite::setPreferredSize(const Size& preferredSize)
-    {
-        this->setContentSize(preferredSize);
-        this->_preferredSize = preferredSize;
-    }
-
-
-    void Scale9Sprite::setCapInsets(const Rect& capInsets)
-    {
-        Size contentSize = this->_contentSize;
-        this->updateWithSprite(this->_scale9Image,
-                               _spriteRect,
-                               _spriteFrameRotated,
-                               _offset,
-                               _originalSize,
-                               capInsets);
-        this->_insetLeft = capInsets.origin.x;
-        this->_insetTop = capInsets.origin.y;
-        this->_insetRight = _originalSize.width - _insetLeft - capInsets.size.width;
-        this->_insetBottom = _originalSize.height - _insetTop - capInsets.size.height;
-        this->setContentSize(contentSize);
-    }
-
-
-    void Scale9Sprite::setInsetLeft(float insetLeft)
-    {
-        this->_insetLeft = insetLeft;
-        this->updateCapInset();
-    }
-
-    void Scale9Sprite::setInsetTop(float insetTop)
-    {
-        this->_insetTop = insetTop;
-        this->updateCapInset();
-    }
-
-    void Scale9Sprite::setInsetRight(float insetRight)
-    {
-        this->_insetRight = insetRight;
-        this->updateCapInset();
-    }
-
-    void Scale9Sprite::setInsetBottom(float insetBottom)
-    {
-        this->_insetBottom = insetBottom;
-        this->updateCapInset();
-    }
-
-    void Scale9Sprite::visit(Renderer *renderer, const Mat4 &parentTransform, uint32_t parentFlags)
-    {
-
-        // quick return if not visible. children won't be drawn.
-        if (!_visible)
-        {
-            return;
-        }
-
-        uint32_t flags = processParentFlags(parentTransform, parentFlags);
-
-        // IMPORTANT:
-        // To ease the migration to v3.0, we still support the Mat4 stack,
-        // but it is deprecated and your code should not rely on it
-        Director* director = Director::getInstance();
-        CCASSERT(nullptr != director, "Director is null when setting matrix stack");
-        director->pushMatrix(MATRIX_STACK_TYPE::MATRIX_STACK_MODELVIEW);
-        director->loadMatrix(MATRIX_STACK_TYPE::MATRIX_STACK_MODELVIEW, _modelViewTransform);
-
-        int i = 0;      // used by _children
-        int j = 0;      // used by _protectedChildren
-
-        sortAllChildren();
-        sortAllProtectedChildren();
-
-        //
-        // draw children and protectedChildren zOrder < 0
-        //
-        for( ; i < _children.size(); i++ )
-        {
-            auto node = _children.at(i);
-
-            if ( node && node->getLocalZOrder() < 0 )
-                node->visit(renderer, _modelViewTransform, flags);
-            else
-                break;
-        }
-
-        if (_scale9Enabled)
-        {
-            for( ; j < _protectedChildren.size(); j++ )
-            {
-                auto node = _protectedChildren.at(j);
-
-                if ( node && node->getLocalZOrder() < 0 )
-                    node->visit(renderer, _modelViewTransform, flags);
-                else
-                    break;
-            }
-        }
-        else
-        {
-            if (_scale9Image && _scale9Image->getLocalZOrder() < 0 )
-            {
-                _scale9Image->visit(renderer, _modelViewTransform, flags);
-            }
-        }
-
-        //
-        // draw self
-        //
-        if (isVisitableByVisitingCamera())
-            this->draw(renderer, _modelViewTransform, flags);
-
-        //
-        // draw children and protectedChildren zOrder >= 0
-        //
-        if (_scale9Enabled)
-        {
-            for(auto it=_protectedChildren.cbegin()+j; it != _protectedChildren.cend(); ++it)
-                (*it)->visit(renderer, _modelViewTransform, flags);
-        }
-        else
-        {
-            if (_scale9Image && _scale9Image->getLocalZOrder() >= 0 )
-            {
-                _scale9Image->visit(renderer, _modelViewTransform, flags);
-            }
-        }
-
-
-        for(auto it=_children.cbegin()+i; it != _children.cend(); ++it)
-            (*it)->visit(renderer, _modelViewTransform, flags);
-
-        // FIX ME: Why need to set _orderOfArrival to 0??
-        // Please refer to https://github.com/cocos2d/cocos2d-x/pull/6920
-        // setOrderOfArrival(0);
-
-        director->popMatrix(MATRIX_STACK_TYPE::MATRIX_STACK_MODELVIEW);
-
-    }
-
-    Size Scale9Sprite::getOriginalSize()const
-    {
-        return _originalSize;
-    }
-
-
-    Size Scale9Sprite::getPreferredSize() const
-    {
-        return _preferredSize;
-    }
-
-    Rect Scale9Sprite::getCapInsets()const
-    {
-        return _capInsets;
-    }
-
-
-    float Scale9Sprite::getInsetLeft()const
-    {
-        return this->_insetLeft;
-    }
-
-    float Scale9Sprite::getInsetTop()const
-    {
-        return this->_insetTop;
-    }
-
-    float Scale9Sprite::getInsetRight()const
-    {
-        return this->_insetRight;
-    }
-
-    float Scale9Sprite::getInsetBottom()const
-    {
-        return this->_insetBottom;
-    }
-
+    
     void Scale9Sprite::setScale9Enabled(bool enabled)
     {
-        if (_scale9Enabled == enabled)
+        if(enabled)
         {
-            return;
+            this->setType(Type::Sliced);
         }
-        _scale9Enabled = enabled;
-
-        this->cleanupSlicedSprites();
-        _protectedChildren.clear();
-
-        //we must invalide the transform when toggling scale9enabled
-        _transformUpdated = _transformDirty = _inverseDirty = true;
-
-        if (_scale9Enabled)
+        else
         {
-            if (_scale9Image)
-            {
-                this->updateWithSprite(this->_scale9Image,
-                                       _spriteRect,
-                                       _spriteFrameRotated,
-                                       _offset,
-                                       _originalSize,
-                                       _capInsets);
-            }
-        }
-        _positionsAreDirty = true;
-    }
-
-    bool Scale9Sprite::isScale9Enabled() const
-    {
-        return _scale9Enabled;
-    }
-
-    void Scale9Sprite::addProtectedChild(cocos2d::Node *child)
-    {
-        _reorderProtectedChildDirty = true;
-        _protectedChildren.pushBack(child);
-    }
-
-    void Scale9Sprite::sortAllProtectedChildren()
-    {
-        if(this->_positionsAreDirty)
-        {
-            this->updatePositions();
-            this->adjustScale9ImagePosition();
-            this->_positionsAreDirty = false;
-        }
-        if( _reorderProtectedChildDirty )
-        {
-            std::sort( std::begin(_protectedChildren),
-                       std::end(_protectedChildren),
-                       nodeComparisonLess );
-            _reorderProtectedChildDirty = false;
+            this->setType(Type::Simple);
         }
     }
-
-    void Scale9Sprite::adjustScale9ImagePosition()
+    
+    bool Scale9Sprite::isScale9Enabled()const
     {
-        if (_scale9Image)
-        {
-            _scale9Image->setPosition(_contentSize.width * _scale9Image->getAnchorPoint().x,
-                                      _contentSize.height * _scale9Image->getAnchorPoint().y);
-        }
+        return _type == Type::Sliced;
     }
-
-    void Scale9Sprite::setAnchorPoint(const cocos2d::Vec2 &position)
+    
+    Scale9Sprite* Scale9Sprite::getSprite()
     {
-        Node::setAnchorPoint(position);
-        if (!_scale9Enabled)
-        {
-            if (_scale9Image)
-            {
-                _scale9Image->setAnchorPoint(position);
-                _positionsAreDirty = true;
-            }
-        }
+        return this;
     }
-
-    void Scale9Sprite::cleanup()
+    
+    Size Scale9Sprite::getPreferredSize()const
     {
-#if CC_ENABLE_SCRIPT_BINDING
-        if (_scriptType == kScriptTypeJavascript)
+        return this->_preferredSize;
+    }
+    
+    void Scale9Sprite::setPreferredSize(const cocos2d::Size &size)
+    {
+        Sprite::setContentSize(size);
+    }
+    
+    Scale9Sprite* Scale9Sprite::resizableSpriteWithCapInsets(const Rect& capInsets) const
+    {
+        Scale9Sprite* pReturn = new (std::nothrow) Scale9Sprite();
+        if ( pReturn && pReturn->initWithTexture(_texture))
         {
-            if (ScriptEngineManager::sendNodeEventToJSExtended(this, kNodeOnCleanup))
-                return;
+            pReturn->setCapInsets(capInsets);
+            pReturn->autorelease();
+            return pReturn;
         }
-#endif // #if CC_ENABLE_SCRIPT_BINDING
+        CC_SAFE_DELETE(pReturn);
+        return NULL;
+    }
+    
+    bool Scale9Sprite::updateWithSprite(Sprite* sprite,
+                                  const Rect& rect,
+                                  bool rotated,
+                                  const Rect& capInsets)
+    {
+        return updateWithSprite(sprite, rect, rotated, Vec2::ZERO, rect.size, capInsets);
+    }
+    
+    bool Scale9Sprite::updateWithSprite(Sprite* sprite,
+                                  const Rect& textureRect,
+                                  bool rotated,
+                                  const Vec2 &offset,
+                                  const Size &originalSize,
+                                  const Rect& capInsets)
+    {
+        // updateBlendFunc(sprite?sprite->getTexture():nullptr);
         
-        Node::cleanup();
-        // timers
-        for( const auto &child: _protectedChildren)
-            child->cleanup();
-    }
-
-    void Scale9Sprite::onEnter()
-    {
-#if CC_ENABLE_SCRIPT_BINDING
-        if (_scriptType == kScriptTypeJavascript)
-        {
-            if (ScriptEngineManager::sendNodeEventToJSExtended(this, kNodeOnEnter))
-                return;
-        }
-#endif
-        Node::onEnter();
-        for( const auto &child: _protectedChildren)
-            child->onEnter();
-    }
-
-    void Scale9Sprite::onExit()
-    {
-#if CC_ENABLE_SCRIPT_BINDING
-        if (_scriptType == kScriptTypeJavascript)
-        {
-            if (ScriptEngineManager::sendNodeEventToJSExtended(this, kNodeOnExit))
-                return;
-        }
-#endif
+        this->setSpriteFrame(sprite->getSpriteFrame());
+        _offsetPosition = offset;
+        this->setTextureRect(textureRect, rotated, originalSize);
+        this->setCapInsets(capInsets);
         
-        Node::onExit();
-        for( const auto &child: _protectedChildren)
-            child->onExit();
+        //change texture should reset program state.
+        this->setState(_brightState);
+        return true;
     }
-
-    void Scale9Sprite::onEnterTransitionDidFinish()
+    
+    void Scale9Sprite::setSpriteFrame(SpriteFrame * spriteFrame, const Rect& capInsets)
     {
-#if CC_ENABLE_SCRIPT_BINDING
-        if (_scriptType == kScriptTypeJavascript)
-        {
-            if (ScriptEngineManager::sendNodeEventToJSExtended(this, kNodeOnEnterTransitionDidFinish))
-                return;
-        }
-#endif
-        
-        Node::onEnterTransitionDidFinish();
-        for( const auto &child: _protectedChildren)
-            child->onEnterTransitionDidFinish();
+        this->setSpriteFrame(spriteFrame);
+        this->setCapInsets(capInsets);
     }
-
-    void Scale9Sprite::onExitTransitionDidStart()
-    {
-#if CC_ENABLE_SCRIPT_BINDING
-        if (_scriptType == kScriptTypeJavascript)
-        {
-            if (ScriptEngineManager::sendNodeEventToJSExtended(this, kNodeOnExitTransitionDidStart))
-                return;
-        }
-#endif
-        
-        Node::onExitTransitionDidStart();
-        for( const auto &child: _protectedChildren)
-            child->onExitTransitionDidStart();
-    }
-
-    void Scale9Sprite::updateDisplayedColor(const cocos2d::Color3B &parentColor)
-    {
-        _displayedColor.r = _realColor.r * parentColor.r/255.0;
-        _displayedColor.g = _realColor.g * parentColor.g/255.0;
-        _displayedColor.b = _realColor.b * parentColor.b/255.0;
-        updateColor();
-
-        if (_scale9Image)
-        {
-            _scale9Image->updateDisplayedColor(_displayedColor);
-        }
-
-        for(const auto &child : _protectedChildren)
-        {
-            child->updateDisplayedColor(_displayedColor);
-        }
-
-        if (_cascadeColorEnabled)
-        {
-            for(const auto &child : _children)
-            {
-                child->updateDisplayedColor(_displayedColor);
-            }
-        }
-    }
-
-    void Scale9Sprite::updateDisplayedOpacity(GLubyte parentOpacity)
-    {
-        _displayedOpacity = _realOpacity * parentOpacity/255.0;
-        updateColor();
-
-        if (_scale9Image)
-        {
-            _scale9Image->updateDisplayedOpacity(_displayedOpacity);
-        }
-
-        for(auto child : _protectedChildren)
-        {
-            child->updateDisplayedOpacity(_displayedOpacity);
-        }
-
-        if (_cascadeOpacityEnabled)
-        {
-            for(auto child : _children)
-            {
-                child->updateDisplayedOpacity(_displayedOpacity);
-            }
-        }
-    }
-
-    void Scale9Sprite::disableCascadeColor()
-    {
-        for(auto child : _children)
-        {
-            child->updateDisplayedColor(Color3B::WHITE);
-        }
-        for(auto child : _protectedChildren)
-        {
-            child->updateDisplayedColor(Color3B::WHITE);
-        }
-        if (_scale9Image)
-        {
-            _scale9Image->updateDisplayedColor(Color3B::WHITE);
-        }
-    }
-
-    void Scale9Sprite::disableCascadeOpacity()
-    {
-        _displayedOpacity = _realOpacity;
-
-        for(auto child : _children){
-            child->updateDisplayedOpacity(255);
-        }
-
-        for(auto child : _protectedChildren){
-            child->updateDisplayedOpacity(255);
-        }
-    }
-
-    Sprite* Scale9Sprite::getSprite()const
-    {
-        return _scale9Image;
-    }
-
+    
     void Scale9Sprite::setFlippedX(bool flippedX)
     {
-
+        
         float realScale = this->getScaleX();
         _flippedX = flippedX;
         this->setScaleX(realScale);
     }
-
+    
     void Scale9Sprite::setFlippedY(bool flippedY)
     {
         float realScale = this->getScaleY();
         _flippedY = flippedY;
         this->setScaleY(realScale);
     }
-
+    
     bool Scale9Sprite::isFlippedX()const
     {
         return _flippedX;
     }
-
+    
     bool Scale9Sprite::isFlippedY()const
     {
         return _flippedY;
     }
-
+    
     void Scale9Sprite::setScaleX(float scaleX)
     {
         if (_flippedX) {
@@ -1580,7 +300,7 @@ namespace ui {
         }
         Node::setScaleX(scaleX);
     }
-
+    
     void Scale9Sprite::setScaleY(float scaleY)
     {
         if (_flippedY) {
@@ -1588,20 +308,20 @@ namespace ui {
         }
         Node::setScaleY(scaleY);
     }
-
+    
     void Scale9Sprite::setScale(float scale)
     {
         this->setScaleX(scale);
         this->setScaleY(scale);
         this->setScaleZ(scale);
     }
-
+    
     void Scale9Sprite::setScale(float scaleX, float scaleY)
     {
         this->setScaleX(scaleX);
         this->setScaleY(scaleY);
     }
-
+    
     float Scale9Sprite::getScaleX()const
     {
         float originalScale = Node::getScaleX();
@@ -1611,7 +331,7 @@ namespace ui {
         }
         return originalScale;
     }
-
+    
     float Scale9Sprite::getScaleY()const
     {
         float originalScale = Node::getScaleY();
@@ -1621,7 +341,7 @@ namespace ui {
         }
         return originalScale;
     }
-
+    
     float Scale9Sprite::getScale()const
     {
         CCASSERT(this->getScaleX() == this->getScaleY(),
@@ -1629,17 +349,6 @@ namespace ui {
         return this->getScaleX();
     }
 
-    void Scale9Sprite::setCameraMask(unsigned short mask, bool applyChildren)
-    {
-        Node::setCameraMask(mask, applyChildren);
+}
 
-        if(_scale9Image)
-            _scale9Image->setCameraMask(mask,applyChildren);
-
-        for(auto& iter: _protectedChildren)
-        {
-            iter->setCameraMask(mask);
-        }
-    }
-
-}}
+NS_CC_END

--- a/cocos/ui/UIScale9Sprite.cpp
+++ b/cocos/ui/UIScale9Sprite.cpp
@@ -27,6 +27,7 @@
 #include "2d/CCSpriteFrameCache.h"
 #include "base/CCDirector.h"
 #include "renderer/CCTextureCache.h"
+#include "2d/CCSpriteBatchNode.h"
 
 
 NS_CC_BEGIN
@@ -152,6 +153,37 @@ namespace ui {
         setCapInsets(capInsets);
         
         return bRet;
+    }
+    
+    bool Scale9Sprite::initWithBatchNode(cocos2d::SpriteBatchNode *batchnode,
+                                         const cocos2d::Rect &rect,
+                                         bool rotated,
+                                         const cocos2d::Rect &capInsets)
+    {
+        Sprite *sprite = Sprite::createWithTexture(batchnode->getTexture());
+        return updateWithSprite(sprite, rect, false, capInsets);
+    }
+    
+    bool Scale9Sprite::initWithBatchNode(cocos2d::SpriteBatchNode *batchnode,
+                                         const cocos2d::Rect &rect,
+                                         const cocos2d::Rect &capInsets)
+    {
+        auto sprite = Sprite::createWithTexture(batchnode->getTexture());
+        return updateWithSprite(sprite, rect, false, capInsets);
+    }
+    
+    bool Scale9Sprite::updateWithBatchNode(cocos2d::SpriteBatchNode *batchnode,
+                                           const cocos2d::Rect &originalRect,
+                                           bool rotated,
+                                           const cocos2d::Rect &capInsets)
+    {
+        Sprite *sprite = Sprite::createWithTexture(batchnode->getTexture());
+        return this->updateWithSprite(sprite,
+                                      originalRect,
+                                      rotated,
+                                      Vec2::ZERO,
+                                      originalRect.size,
+                                      capInsets);
     }
     
     bool Scale9Sprite::initWithFile(const Rect& capInsets, const std::string& file)

--- a/cocos/ui/UIScale9Sprite.h
+++ b/cocos/ui/UIScale9Sprite.h
@@ -217,6 +217,21 @@ namespace ui {
                                       const Vec2 &offset,
                                       const Size &originalSize,
                                       const Rect& capInsets);
+        
+        /**
+         * @brief Update Scale9Sprite with a specified sprite.
+         *
+         * @deprecated Use @see `updateWithSprite` instead.
+         * @param sprite A sprite pointer.
+         * @param originalRect A delimitation zone.
+         * @param rotated Whether the sprite is rotated or not.
+         * @param capInsets The Values to use for the cap insets.
+         * @return True if update success, false otherwise.
+         */
+        CC_DEPRECATED(v3) bool updateWithBatchNode(SpriteBatchNode* batchnode,
+                                                   const Rect& originalRect,
+                                                   bool rotated,
+                                                   const Rect& capInsets);
         /**
          * Creates and returns a new sprite object with the specified cap insets.
          * You use this method to add cap insets to a sprite or to change the existing
@@ -227,6 +242,37 @@ namespace ui {
          * @return A Scale9Sprite instance.
          */
         Scale9Sprite* resizableSpriteWithCapInsets(const Rect& capInsets) const;
+        
+        /**
+         * @brief Initializes a 9-slice sprite with a sprite batchnode.
+         * Once the sprite is created, you can then call its "setContentSize:" method
+         * to resize the sprite will all it's 9-slice goodness intract.
+         * It respects the anchorPoint too.
+         *
+         * @deprecated Use @see `init` instead.
+         * @param batchnode A batch node pointer.
+         * @param rect A delimitation zone.
+         * @param rotated Whether the sprite in batch node is rotated or not.
+         * @param capInsets The values to use for the cap insets.
+         * @return True if initializes success, false otherwise.
+         */
+        CC_DEPRECATED(v3) virtual bool initWithBatchNode(SpriteBatchNode* batchnode,
+                                                         const Rect& rect,
+                                                         bool rotated,
+                                                         const Rect& capInsets);
+        /**
+         * @brief Initializes a 9-slice sprite with a sprite batch node.
+         * Once the sprite is created, you can then call its "setContentSize:" method
+         * to resize the sprite will all it's 9-slice goodness intract.
+         * It respects the anchorPoint too.
+         *
+         * @deprecated Use @see `init` instead.
+         * @param batchnode A batch node pointer.
+         * @param rect A delimitation zone.
+         * @param capInsets The values to use for the cap insets.
+         * @return True if initializes success, false otherwise.
+         */
+        CC_DEPRECATED(v3) virtual bool initWithBatchNode(SpriteBatchNode* batchnode, const Rect& rect, const Rect& capInsets);
         
         /**
          * Initializes a 9-slice sprite with an sprite frame and with the specified

--- a/cocos/ui/UIScale9Sprite.h
+++ b/cocos/ui/UIScale9Sprite.h
@@ -1,18 +1,19 @@
 /****************************************************************************
- Copyright (c) 2013-2014 Chukong Technologies Inc.
- 
+ Copyright (c) 2013-2015 Chukong Technologies Inc.
+ Copyright (c) 2013-2015 zilongshanren
+
  http://www.cocos2d-x.org
- 
+
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal
  in the Software without restriction, including without limitation the rights
  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  copies of the Software, and to permit persons to whom the Software is
  furnished to do so, subject to the following conditions:
- 
+
  The above copyright notice and this permission notice shall be included in
  all copies or substantial portions of the Software.
- 
+
  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -25,58 +26,16 @@
 #ifndef __cocos2d_libs__UIScale9Sprite__
 #define __cocos2d_libs__UIScale9Sprite__
 
-#include "2d/CCNode.h"
-#include "2d/CCSpriteFrame.h"
-#include "2d/CCSpriteBatchNode.h"
-#include "platform/CCPlatformMacros.h"
-#include "ui/GUIExport.h"
+#include "2d/CCSprite.h"
 
-/**
- * @addtogroup ui
- * @{
- */
 NS_CC_BEGIN
 namespace ui {
-    
     /**
-     *@brief A 9-slice sprite for cocos2d-x.
-     *
-     * 9-slice scaling allows you to specify how scaling is applied
-     * to specific areas of a sprite. With 9-slice scaling (3x3 grid),
-     * you can ensure that the sprite does not become distorted when
-     * scaled.
-     * Note: When you set _scale9Enabled to false,
-     * then you could call `scale9Sprite->getSprite()` to return the inner Sprite pointer.
-     * Then you could call any methods of Sprite class with the return pointers.
-     *
+     * Scale9Sprite is exists for back compatiability reasons.
+     * If you want to use slice sprite, please stick to Sprite class with type equals Type::Sliced.
      */
-    class CC_GUI_DLL Scale9Sprite : public Node , public cocos2d::BlendProtocol
+    class Scale9Sprite : public cocos2d::Sprite
     {
-    public:
-        /**
-         * Default constructor.
-         * @js ctor
-         * @lua new
-         */
-        Scale9Sprite();
-
-        /**
-         * Default destructor.
-         * @js NA
-         * @lua NA
-         */
-        virtual ~Scale9Sprite();
-        
-        /**
-         * Builtin shader state.
-         * Currenly support Normal and Gray state.
-         */
-        enum class State
-        {
-            NORMAL,
-            GRAY
-        };
-        
     public:
         
         /**
@@ -180,221 +139,50 @@ namespace ui {
          */
         static Scale9Sprite* createWithSpriteFrameName(const std::string& spriteFrameName, const Rect& capInsets);
         
+        
         /**
-         * Initializes a 9-slice sprite with a texture file, a delimitation zone and
-         * with the specified cap insets.
-         * Once the sprite is created, you can then call its "setContentSize:" method
-         * to resize the sprite will all it's 9-slice goodness intract.
-         * It respects the anchorPoint too.
+         * @brief Change inner sprite's sprite frame.
          *
-         * @param file The name of the texture file.
-         * @param rect The rectangle that describes the sub-part of the texture that
-         * is the whole image. If the shape is the whole texture, set this to the
-         * texture's full rect.
+         * @param spriteFrame A sprite frame pointer.
          * @param capInsets The values to use for the cap insets.
-         * @return True if initialize success, false otherwise.
          */
-        virtual bool initWithFile(const std::string& file, const Rect& rect,  const Rect& capInsets);
-        
+        virtual void setSpriteFrame(SpriteFrame * spriteFrame, const Rect& capInsets);
+        using Sprite::setSpriteFrame;
         /**
-         * Initializes a 9-slice sprite with a texture file and a delimitation zone. The
-         * texture will be broken down into a 3×3 grid of equal blocks.
-         * Once the sprite is created, you can then call its "setContentSize:" method
-         * to resize the sprite will all it's 9-slice goodness intract.
-         * It respects the anchorPoint too.
-         *
-         * @param file The name of the texture file.
-         * @param rect The rectangle that describes the sub-part of the texture that
-         * is the whole image. If the shape is the whole texture, set this to the
-         * texture's full rect.
-         * @return True if initializes success, false otherwise.
-         */
-        virtual bool initWithFile(const std::string& file, const Rect& rect);
-        
-        /**
-         * Initializes a 9-slice sprite with a texture file and with the specified cap
-         * insets.
-         * Once the sprite is created, you can then call its "setContentSize:" method
-         * to resize the sprite will all it's 9-slice goodness intract.
-         * It respects the anchorPoint too.
-         *
-         * @param file The name of the texture file.
-         * @param capInsets The values to use for the cap insets.
-         * @return True if initializes success, false otherwise.
-         */
-        virtual bool initWithFile(const Rect& capInsets, const std::string& file);
-        
-        /**
-         * Initializes a 9-slice sprite with a texture file. The whole texture will be
-         * broken down into a 3×3 grid of equal blocks.
-         * Once the sprite is created, you can then call its "setContentSize:" method
-         * to resize the sprite will all it's 9-slice goodness intract.
-         * It respects the anchorPoint too.
-         *
-         * @param file The name of the texture file.
-         * @return True if initializes success, false otherwise.
-         */
-        virtual bool initWithFile(const std::string& file);
-        
-        /**
-         * Initializes a 9-slice sprite with an sprite frame and with the specified
-         * cap insets.
-         * Once the sprite is created, you can then call its "setContentSize:" method
-         * to resize the sprite will all it's 9-slice goodness intract.
-         * It respects the anchorPoint too.
-         *
-         * @param spriteFrame The sprite frame object.
-         * @param capInsets The values to use for the cap insets.
-         * @return True if initializes success, false otherwise.
-         */
-        virtual bool initWithSpriteFrame(SpriteFrame* spriteFrame, const Rect& capInsets);
-        
-        /**
-         * Initializes a 9-slice sprite with an sprite frame.
-         * Once the sprite is created, you can then call its "setContentSize:" method
-         * to resize the sprite will all it's 9-slice goodness intract.
-         * It respects the anchorPoint too.
-         *
-         * @param spriteFrame The sprite frame object.
-         * @return True if initializes success, false otherwise.
-         */
-        virtual bool initWithSpriteFrame(SpriteFrame* spriteFrame);
-        
-        /**
-         * Initializes a 9-slice sprite with an sprite frame name and with the specified
-         * cap insets.
-         * Once the sprite is created, you can then call its "setContentSize:" method
-         * to resize the sprite will all it's 9-slice goodness intract.
-         * It respects the anchorPoint too.
-         *
-         * @param spriteFrameName The sprite frame name.
-         * @param capInsets The values to use for the cap insets.
-         * @return True if initializes success, false otherwise.
-         */
-        virtual bool initWithSpriteFrameName(const std::string& spriteFrameName, const Rect& capInsets);
-        
-        /**
-         * Initializes a 9-slice sprite with an sprite frame name.
-         * Once the sprite is created, you can then call its "setContentSize:" method
-         * to resize the sprite will all it's 9-slice goodness intract.
-         * It respects the anchorPoint too.
-         *
-         * @param spriteFrameName The sprite frame name.
-         * @return True if initializes success, false otherwise.
-         */
-        virtual bool initWithSpriteFrameName(const std::string& spriteFrameName);
-        
-        //override function
-        virtual bool init() override;
-
-        /**
-         * @brief Initializes a 9-slice sprite with an sprite instance.
-         * Once the sprite is created, you can then call its "setContentSize:" method
-         * to resize the sprite will all it's 9-slice goodness intract.
-         * It respects the anchorPoint too.
-         *
-         * @param sprite The sprite instance.
-         * @param rect A delimitation zone.
-         * @param rotated Whether the sprite is rotated or not.
-         * @param capInsets The values to use for the cap insets.
-         * @return True if initializes success, false otherwise.
-         */
-        virtual bool init(Sprite* sprite, const Rect& rect, bool rotated, const Rect& capInsets);
-
-        /**
-         * @brief Initializes a 9-slice sprite with an sprite instance.
-         * Once the sprite is created, you can then call its "setContentSize:" method
-         * to resize the sprite will all it's 9-slice goodness intract.
-         * It respects the anchorPoint too.
-         *
-         * @param sprite The sprite instance.
-         * @param rect A delimitation zone.
-         * @param capInsets The values to use for the cap insets.
-         * @return True if initializes success, false otherwise.
-         */
-        virtual bool init(Sprite* sprite, const Rect& rect, const Rect& capInsets);
-
-        /**
-         * @brief Initializes a 9-slice sprite with an sprite instance.
-         * Once the sprite is created, you can then call its "setContentSize:" method
-         * to resize the sprite will all it's 9-slice goodness intract.
-         * It respects the anchorPoint too.
-         *
-         * @param sprite The sprite instance.
-         * @param rect A delimitation zone.
-         * @param rotated Whether the sprite is rotated or not.
-         * @param offset The offset when slice the sprite.
-         * @param originalSize The original size of sprite.
-         * @param capInsets The values to use for the cap insets.
-         * @return True if initializes success, false otherwise.
-         */
-        virtual bool init(Sprite* sprite,
-                          const Rect& rect,
-                          bool rotated,
-                          const Vec2 &offset,
-                          const Size &originalSize,
-                          const Rect& capInsets);
-        
-        /**
-         * @brief Initializes a 9-slice sprite with a sprite batchnode.
-         * Once the sprite is created, you can then call its "setContentSize:" method
-         * to resize the sprite will all it's 9-slice goodness intract.
-         * It respects the anchorPoint too.
-         *
-         * @deprecated Use @see `init` instead.
-         * @param batchnode A batch node pointer.
-         * @param rect A delimitation zone.
-         * @param rotated Whether the sprite in batch node is rotated or not.
-         * @param capInsets The values to use for the cap insets.
-         * @return True if initializes success, false otherwise.
-         */
-         CC_DEPRECATED(v3) virtual bool initWithBatchNode(SpriteBatchNode* batchnode,
-                                                          const Rect& rect,
-                                                          bool rotated,
-                                                          const Rect& capInsets);
-        /**
-         * @brief Initializes a 9-slice sprite with a sprite batch node.
-         * Once the sprite is created, you can then call its "setContentSize:" method
-         * to resize the sprite will all it's 9-slice goodness intract.
-         * It respects the anchorPoint too.
-         *
-         * @deprecated Use @see `init` instead.
-         * @param batchnode A batch node pointer.
-         * @param rect A delimitation zone.
-         * @param capInsets The values to use for the cap insets.
-         * @return True if initializes success, false otherwise.
-         */
-        CC_DEPRECATED(v3) virtual bool initWithBatchNode(SpriteBatchNode* batchnode, const Rect& rect, const Rect& capInsets);
-        
-        /**
-         * Sets the source blending function.
-         *
-         * @param blendFunc A structure with source and destination factor to specify pixel arithmetic. e.g. {GL_ONE, GL_ONE}, {GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA}.
+         * @brief Toggle 9-slice feature.
+         * If Scale9Sprite is 9-slice disabled, the Scale9Sprite will rendered as a normal sprite.
+         * @param enabled True to enable 9-slice, false otherwise.
          * @js NA
-         * @lua NA
          */
-        virtual void setBlendFunc(const BlendFunc &blendFunc) override;
+        void setScale9Enabled(bool enabled);
         
         /**
-         * Returns the blending function that is currently being used.
+         * @brief Query whether the Scale9Sprite is enable 9-slice or not.
          *
-         * @return A BlendFunc structure with source and destination factor which specified pixel arithmetic.
+         * @return True if 9-slice is enabled, false otherwise.
          * @js NA
-         * @lua NA
          */
-        virtual const BlendFunc &getBlendFunc() const override;
-
+        bool isScale9Enabled()const;
         /**
-         * Creates and returns a new sprite object with the specified cap insets.
-         * You use this method to add cap insets to a sprite or to change the existing
-         * cap insets of a sprite. In both cases, you get back a new image and the
-         * original sprite remains untouched.
+         * @brief Get the original no 9-sliced sprite
          *
-         * @param capInsets The values to use for the cap insets.
-         * @return A Scale9Sprite instance.
+         * @return A sprite instance.
          */
-        Scale9Sprite* resizableSpriteWithCapInsets(const Rect& capInsets) const;
+        Scale9Sprite* getSprite();
         
+        /**
+         * @brief Change the prefered size of Scale9Sprite.
+         *
+         * @param size A delimitation zone.
+         */
+        void setPreferredSize(const Size& size);
+        
+        /**
+         * @brief Query the  Scale9Sprite's prefered size.
+         *
+         * @return Scale9Sprite's prefered size.
+         */
+        Size getPreferredSize() const;
         
         /**
          * @brief Update Scale9Sprite with a specified sprite.
@@ -410,7 +198,7 @@ namespace ui {
                                       const Rect& rect,
                                       bool rotated,
                                       const Rect& capInsets);
-
+        
         /**
          * @brief Update Scale9Sprite with a specified sprite.
          *
@@ -429,206 +217,77 @@ namespace ui {
                                       const Vec2 &offset,
                                       const Size &originalSize,
                                       const Rect& capInsets);
-
         /**
-         * @brief Update Scale9Sprite with a specified sprite.
+         * Creates and returns a new sprite object with the specified cap insets.
+         * You use this method to add cap insets to a sprite or to change the existing
+         * cap insets of a sprite. In both cases, you get back a new image and the
+         * original sprite remains untouched.
          *
-         * @deprecated Use @see `updateWithSprite` instead.
-         * @param sprite A sprite pointer.
-         * @param originalRect A delimitation zone.
-         * @param rotated Whether the sprite is rotated or not.
-         * @param capInsets The Values to use for the cap insets.
-         * @return True if update success, false otherwise.
-         */
-        CC_DEPRECATED(v3) bool updateWithBatchNode(SpriteBatchNode* batchnode,
-                                                   const Rect& originalRect,
-                                                   bool rotated,
-                                                   const Rect& capInsets);
-
-        
-        /**
-         * @brief Change inner sprite's sprite frame.
-         *
-         * @param spriteFrame A sprite frame pointer.
          * @param capInsets The values to use for the cap insets.
+         * @return A Scale9Sprite instance.
          */
-        virtual void setSpriteFrame(SpriteFrame * spriteFrame, const Rect& capInsets = Rect::ZERO);
-        
-        // overrides
-        virtual void setContentSize(const Size & size) override;
-        virtual void setAnchorPoint(const Vec2& anchorPoint) override;
+        Scale9Sprite* resizableSpriteWithCapInsets(const Rect& capInsets) const;
         
         /**
-         * Change the state of 9-slice sprite.
-         * @see `State`
-         * @param state A enum value in State.
-         * @since v3.4
-         */
-        void setState(State state);
-        
-        /**
-         * Query the current bright state.
-         * @return @see `State`
-         * @since v3.7
-         */
-        State getState()const;
-        
-        /**
-         * @brief Query the sprite's original size.
+         * Initializes a 9-slice sprite with an sprite frame and with the specified
+         * cap insets.
+         * Once the sprite is created, you can then call its "setContentSize:" method
+         * to resize the sprite will all it's 9-slice goodness intract.
+         * It respects the anchorPoint too.
          *
-         * @return Sprite size.
+         * @param spriteFrame The sprite frame object.
+         * @param capInsets The values to use for the cap insets.
+         * @return True if initializes success, false otherwise.
          */
-        Size getOriginalSize() const;
+        virtual bool initWithSpriteFrame(SpriteFrame* spriteFrame, const Rect& capInsets);
+        using Sprite::initWithSpriteFrame;
         
         /**
-         * @brief Change the preferred size of Scale9Sprite.
+         * Initializes a 9-slice sprite with an sprite frame name and with the specified
+         * cap insets.
+         * Once the sprite is created, you can then call its "setContentSize:" method
+         * to resize the sprite will all it's 9-slice goodness intract.
+         * It respects the anchorPoint too.
          *
-         * @param size A delimitation zone.
+         * @param spriteFrameName The sprite frame name.
+         * @param capInsets The values to use for the cap insets.
+         * @return True if initializes success, false otherwise.
          */
-        void setPreferredSize(const Size& size);
+        virtual bool initWithSpriteFrameName(const std::string& spriteFrameName, const Rect& capInsets);
+        using Sprite::initWithSpriteFrameName;
         
         /**
-         * @brief Query the Scale9Sprite's preferred size.
+         * Initializes a 9-slice sprite with a texture file and with the specified cap
+         * insets.
+         * Once the sprite is created, you can then call its "setContentSize:" method
+         * to resize the sprite will all it's 9-slice goodness intract.
+         * It respects the anchorPoint too.
          *
-         * @return Scale9Sprite's preferred size.
+         * @param file The name of the texture file.
+         * @param capInsets The values to use for the cap insets.
+         * @return True if initializes success, false otherwise.
          */
-        Size getPreferredSize() const;
+        virtual bool initWithFile(const Rect& capInsets, const std::string& file);
+        using Sprite::initWithFile;
         
         /**
-         * @brief Change the cap inset size.
+         * Initializes a 9-slice sprite with a texture file, a delimitation zone and
+         * with the specified cap insets.
+         * Once the sprite is created, you can then call its "setContentSize:" method
+         * to resize the sprite will all it's 9-slice goodness intract.
+         * It respects the anchorPoint too.
          *
-         * @param rect A delimitation zone.
+         * @param file The name of the texture file.
+         * @param rect The rectangle that describes the sub-part of the texture that
+         * is the whole image. If the shape is the whole texture, set this to the
+         * texture's full rect.
+         * @param capInsets The values to use for the cap insets.
+         * @return True if initialize success, false otherwise.
          */
-        void setCapInsets(const Rect& rect);
+        virtual bool initWithFile(const std::string& file, const Rect& rect,  const Rect& capInsets);
         
-        /**
-         * @brief Query the Scale9Sprite's preferred size.
-         *
-         * @return Scale9Sprite's cap inset.
-         */
-        Rect getCapInsets()const;
-        
-        /**
-         * @brief Change the left sprite's cap inset.
-         *
-         * @param leftInset The values to use for the cap inset.
-         */
-        void setInsetLeft(float leftInset);
-        
-        /**
-         * @brief Query the left sprite's cap inset.
-         *
-         * @return The left sprite's cap inset.
-         */
-        float getInsetLeft()const;
-        
-        /**
-         * @brief Change the top sprite's cap inset.
-         *
-         * @param topInset The values to use for the cap inset.
-         */
-        void setInsetTop(float topInset);
-        
-        /**
-         * @brief Query the top sprite's cap inset.
-         *
-         * @return The top sprite's cap inset.
-         */
-        float getInsetTop()const;
-        
-        /**
-         * @brief Change the right sprite's cap inset.
-         *
-         * @param rightInset The values to use for the cap inset.
-         */
-        void setInsetRight(float rightInset);
-        
-        /**
-         * @brief Query the right sprite's cap inset.
-         *
-         * @return The right sprite's cap inset.
-         */
-        float getInsetRight()const;
-        
-        /**
-         * @brief Change the bottom sprite's cap inset.
-         *
-         * @param bottomInset The values to use for the cap inset.
-         
-         */
-        void setInsetBottom(float bottomInset);
-        
-        /**
-         * @brief Query the bottom sprite's cap inset.
-         *
-         * @return The bottom sprite's cap inset.
-         */
-        float getInsetBottom()const;
-        
-        /**
-         * @brief Toggle 9-slice feature.
-         * If Scale9Sprite is 9-slice disabled, the Scale9Sprite will rendered as a normal sprite.
-         * @param enabled True to enable 9-slice, false otherwise.
-         * @js NA
-         */
-        void setScale9Enabled(bool enabled);
-        
-        /**
-         * @brief Query whether the Scale9Sprite is enable 9-slice or not.
-         *
-         * @return True if 9-slice is enabled, false otherwise.
-         * @js NA
-         */
-        bool isScale9Enabled()const;
-        
-        /// @} end of Children and Parent
-        
-        virtual void visit(Renderer *renderer, const Mat4 &parentTransform, uint32_t parentFlags) override;
-        virtual void cleanup() override;
-        
-        /**
-         * @lua NA
-         */
-        virtual void onEnter() override;
-        
-        /** Event callback that is invoked when the Node enters in the 'stage'.
-         * If the Node enters the 'stage' with a transition, this event is called when the transition finishes.
-         * If you override onEnterTransitionDidFinish, you shall call its parent's one, e.g. Node::onEnterTransitionDidFinish()
-         * @js NA
-         * @lua NA
-         */
-        virtual void onEnterTransitionDidFinish() override;
-        
-        /**
-         * Event callback that is invoked every time the Node leaves the 'stage'.
-         * If the Node leaves the 'stage' with a transition, this event is called when the transition finishes.
-         * During onExit you can't access a sibling node.
-         * If you override onExit, you shall call its parent's one, e.g., Node::onExit().
-         * @js NA
-         * @lua NA
-         */
-        virtual void onExit() override;
-        
-        /**
-         * Event callback that is called every time the Node leaves the 'stage'.
-         * If the Node leaves the 'stage' with a transition, this callback is called when the transition starts.
-         * @js NA
-         * @lua NA
-         */
-        virtual void onExitTransitionDidStart() override;
-        
-        virtual void updateDisplayedOpacity(GLubyte parentOpacity) override;
-        virtual void updateDisplayedColor(const Color3B& parentColor) override;
-        virtual void disableCascadeColor() override;
-        virtual void disableCascadeOpacity() override;
-        
-        
-        /**
-         * @brief Get the original no 9-sliced sprite
-         *
-         * @return A sprite instance.
-         */
-        Sprite* getSprite()const;
+        Scale9Sprite();
+        virtual ~Scale9Sprite();
         
         /**
          * Sets whether the widget should be flipped horizontally or not.
@@ -654,8 +313,8 @@ namespace ui {
          *
          * @param flippedY true if the widget should be flipped vertically, false otherwise.
          */
-        virtual void setFlippedY(bool flippedY);
-
+        virtual void setFlippedY(bool flippedY) ;
+        
         /**
          * Return the flag which indicates whether the widget is flipped vertically or not.
          *
@@ -678,83 +337,12 @@ namespace ui {
         virtual float getScaleY() const override;
         virtual float getScale() const override;
         using Node::getScaleZ;
-        virtual void setCameraMask(unsigned short mask, bool applyChildren = true) override;
-    protected:
-        void updateCapInset();
-        void updatePositions();
-        void createSlicedSprites();
-        void cleanupSlicedSprites();
-        void adjustScale9ImagePosition();
-        void applyBlendFunc();
-        void updateBlendFunc(Texture2D *texture);
-        /**
-         * Sorts the children array once before drawing, instead of every time when a child is added or reordered.
-         * This approach can improves the performance massively.
-         * @note Don't call this manually unless a child added needs to be removed in the same frame
-         */
-        virtual void sortAllProtectedChildren();
-        
-        bool _spritesGenerated;
-        Rect _spriteRect;
-        bool   _spriteFrameRotated;
-        Rect _capInsetsInternal;
-        bool _positionsAreDirty;
-        
-        Sprite* _scale9Image; //the original sprite
-        Sprite* _topLeftSprite;
-        Sprite* _topSprite;
-        Sprite* _topRightSprite;
-        Sprite* _leftSprite;
-        Sprite* _centerSprite;
-        Sprite* _rightSprite;
-        Sprite* _bottomLeftSprite;
-        Sprite* _bottomSprite;
-        Sprite* _bottomRightSprite;
-        
-        bool _scale9Enabled;
-        BlendFunc _blendFunc;
-        
-        Size _topLeftSize;
-        Size _centerSize;
-        Size _bottomRightSize;
-        Vec2 _centerOffset;
-        
-        /** Original sprite's size. */
-        Size _originalSize;
-        Vec2 _offset;
-        /** Preferred sprite's size. By default the preferred size is the original size. */
-        
-        //if the preferredSize component is given as -1, it is ignored
-        Size _preferredSize;
-        /**
-         * The end-cap insets.
-         * On a non-resizeable sprite, this property is set to CGRect::ZERO; the sprite
-         * does not use end caps and the entire sprite is subject to stretching.
-         */
-        Rect _capInsets;
-        /** Sets the left side inset */
-        float _insetLeft;
-        /** Sets the top side inset */
-        float _insetTop;
-        /** Sets the right side inset */
-        float _insetRight;
-        /** Sets the bottom side inset */
-        float _insetBottom;
-        
-        /// helper that reorder a child
-        void addProtectedChild(Node* child);
-        
-        Vector<Node*> _protectedChildren;        ///holds the 9 sprites
-        bool _reorderProtectedChildDirty;
-        
-        bool _flippedX;
-        bool _flippedY;
-        bool _isPatch9;
-        State _brightState;
+    private:
+        CC_DISALLOW_COPY_AND_ASSIGN(Scale9Sprite);
     };
-    
-}}  //end of namespace
-// end of ui group
-/// @}
+}
+
+NS_CC_END
+
 
 #endif /* defined(__cocos2d_libs__UIScale9Sprite__) */

--- a/cocos/ui/UISlider.cpp
+++ b/cocos/ui/UISlider.cpp
@@ -699,15 +699,13 @@ void Slider::copySpecialProperties(Widget *widget)
     {
         _prevIgnoreSize = slider->_prevIgnoreSize;
         setScale9Enabled(slider->_scale9Enabled);
-        auto barSprite = slider->_barRenderer->getSprite();
-        if (nullptr != barSprite)
+        if (!slider->_barRenderer->isUsingDefaultTexture())
         {
-            loadBarTexture(barSprite->getSpriteFrame());
+            loadBarTexture(slider->_barRenderer->getSpriteFrame());
         }
-        auto progressSprite = slider->_progressBarRenderer->getSprite();
-        if (nullptr != progressSprite)
+        if (!slider->_progressBarRenderer->isUsingDefaultTexture())
         {
-            loadProgressBarTexture(progressSprite->getSpriteFrame());
+            loadProgressBarTexture(slider->_progressBarRenderer->getSpriteFrame());
         }
         loadSlidBallTextureNormal(slider->_slidBallNormalRenderer->getSpriteFrame());
         loadSlidBallTexturePressed(slider->_slidBallPressedRenderer->getSpriteFrame());

--- a/cocos/ui/UISlider.cpp
+++ b/cocos/ui/UISlider.cpp
@@ -176,8 +176,8 @@ void Slider::setupBarTexture()
     this->updateChildrenDisplayedRGBA();
     _barRendererAdaptDirty = true;
     _progressBarRendererDirty = true;
-    updateContentSizeWithTextureSize(_barRenderer->getContentSize());
-    _barTextureSize = _barRenderer->getContentSize();
+    updateContentSizeWithTextureSize(_barRenderer->getOriginalSize());
+    _barTextureSize = _barRenderer->getOriginalSize();
 }
 
 void Slider::loadProgressBarTexture(const std::string& fileName, TextureResType texType)
@@ -211,7 +211,7 @@ void Slider::setupProgressBarTexture()
 {
     this->updateChildrenDisplayedRGBA();
     _progressBarRenderer->setAnchorPoint(Vec2(0.0f, 0.5f));
-    _progressBarTextureSize = _progressBarRenderer->getContentSize();
+    _progressBarTextureSize = _progressBarRenderer->getOriginalSize();
     _progressBarRendererDirty = true;
 }
 
@@ -429,11 +429,11 @@ void Slider::setPercent(int percent)
 bool Slider::hitTest(const cocos2d::Vec2 &pt, const Camera *camera, Vec3 *p) const
 {
     Rect rect;
-    rect.size = _slidBallNormalRenderer->getContentSize();
+    rect.size = _slidBallNormalRenderer->getOriginalSize();
     auto w2l = _slidBallNormalRenderer->getWorldToNodeTransform();
 
     Rect sliderBarRect;
-    sliderBarRect.size = this->_barRenderer->getContentSize();
+    sliderBarRect.size = this->_barRenderer->getOriginalSize();
     auto barW2l = this->_barRenderer->getWorldToNodeTransform();
     return isScreenPointInRect(pt, camera, w2l, rect, nullptr) || isScreenPointInRect(pt, camera, barW2l, sliderBarRect, nullptr);
 }
@@ -533,7 +533,7 @@ void Slider::adaptRenderers()
 
 Size Slider::getVirtualRendererSize() const
 {
-    return _barRenderer->getContentSize();
+    return _barRenderer->getOriginalSize();
 }
 
 Node* Slider::getVirtualRenderer()


### PR DESCRIPTION
1. Add Sliced sprite support for Sprite class and rewrite the original scale9sprite. The new Scale9Sprite inherit from Sprite with type default to `Sliced`.
2. Now the Slice sprite uses 16 vertices and 54 indices instead of the old 9 sprite way.
   The memory consumption is lower than previous implementation. And the computation is also more efficient.
3. Fix a bug when scale9sprite shrink smaller than the center stretch area. 
4. A few minor change to use the new slice sprite in UI widgets. No behavior changed!  If you notice one, please report.

Note: **SpriteBatchNode**  can't support the new sliced sprite at the moment. In the past, it also the same. The original Scale9Sprite is a node, so it can't be added into the `SpriteBtachNode`.
But now the Sliced sprite is a Sprite which means it should be OK when adding it to the `SpriteBatchNode`.  

I suggest we mention this restrict in the release note and fix it in the future release. Thoughts?

@dabingnn  @ricardoquesada  @super626  Please help me to review this PR.

Any testing or suggestions will be welcome.

Thanks.
