### PR TITLE
Add pageSize param to PageView

### DIFF
--- a/cocos/ui/UIPageView.h
+++ b/cocos/ui/UIPageView.h
@@ -264,6 +264,12 @@ public:
      *@return True if using custom scroll threshold, false otherwise.
      */
     bool isUsingCustomScrollThreshold()const;
+  
+    /**
+     *@brief Set size of the page - allows to have for ex. 2 pages visible (when page size is set to half of a pageView size). 
+     * Applies to width when HORIZONTAL and height when VERTICAL.
+     */
+    void setPageSize(float pageSize);
 
 CC_CONSTRUCTOR_ACCESS:
     virtual bool init() override;
@@ -316,7 +322,8 @@ protected:
    
     Widget* _leftBoundaryChild;
     Widget* _rightBoundaryChild;
-    
+  
+    float _pageSize;
     float _leftBoundary;
     float _rightBoundary;
     float _customScrollThreshold;


### PR DESCRIPTION
Previously size of the pages inside pageView were set to fill all pageView, which didn't allow to have ex. more than one page visible on the screen.

Now you can do:

```
pageView->setContentSize(Size(1200,500));
pageView->setPageSize(600);
```

to have 2 pages visible, or `pageView->setPageSize(300)` to have `4`. It works for both HORIZONTAL and VERTICAL.

**If you don't specify pageSize it works as before**.
