### PR TITLE
Fix GroupRadioButton disallow selection won't work bug.

### DIFF
--- a/cocos/ui/UIRadioButton.cpp
+++ b/cocos/ui/UIRadioButton.cpp
@@ -124,7 +124,14 @@ void RadioButton::releaseUpEvent()
 {
     Widget::releaseUpEvent();
     
-    if (!_isSelected)
+    if (_group != nullptr)
+    {
+        if (_group->setSelectedButtonWithoutEvent(this))
+        {
+            dispatchSelectChangedEvent(true);
+        }
+    }
+    else if (!_isSelected)
     {
         setSelected(true);
         dispatchSelectChangedEvent(true);
@@ -262,37 +269,42 @@ int RadioButtonGroup::getSelectedButtonIndex() const
     return (int) _radioButtons.getIndex(_selectedRadioButton);
 }
 
-void RadioButtonGroup::setSelectedButton(int index)
+bool RadioButtonGroup::setSelectedButton(int index)
 {
     CCASSERT(index < _radioButtons.size(), "Out of array index!");
-    setSelectedButton(_radioButtons.at(index));
+    return setSelectedButton(_radioButtons.at(index));
 }
 
-void RadioButtonGroup::setSelectedButton(RadioButton* radioButton)
+bool RadioButtonGroup::setSelectedButton(RadioButton* radioButton)
 {
-    setSelectedButtonWithoutEvent(radioButton);
-    onChangedRadioButtonSelect(_selectedRadioButton);
+    if (setSelectedButtonWithoutEvent(radioButton))
+    {
+        onChangedRadioButtonSelect(_selectedRadioButton);
+        return true;
+    }
+        
+    return false;
 }
 
-void RadioButtonGroup::setSelectedButtonWithoutEvent(int index)
+bool RadioButtonGroup::setSelectedButtonWithoutEvent(int index)
 {
-    setSelectedButtonWithoutEvent(_radioButtons.at(index));
+   return setSelectedButtonWithoutEvent(_radioButtons.at(index));
 }
 
-void RadioButtonGroup::setSelectedButtonWithoutEvent(RadioButton* radioButton)
+bool RadioButtonGroup::setSelectedButtonWithoutEvent(RadioButton* radioButton)
 {
     if(!_allowedNoSelection && radioButton == nullptr)
     {
-        return;
+        return false;
     }
     if(_selectedRadioButton == radioButton)
     {
-        return;
+        return false;
     }
     if(radioButton != nullptr && !_radioButtons.contains(radioButton))
     {
         CCLOGERROR("The radio button does not belong to this group!");
-        return;
+        return false;
     }
     
     deselect();
@@ -301,6 +313,7 @@ void RadioButtonGroup::setSelectedButtonWithoutEvent(RadioButton* radioButton)
     {
         _selectedRadioButton->setSelected(true);
     }
+    return true;
 }
 
 std::string RadioButtonGroup::getDescription() const

--- a/cocos/ui/UIRadioButton.h
+++ b/cocos/ui/UIRadioButton.h
@@ -195,28 +195,28 @@ public:
      *
      * @param index of the radio button
      */
-    virtual void setSelectedButton(int index);
+    virtual bool setSelectedButton(int index);
     
     /**
      * Select a radio button by instance.
      *
      * @param radio button instance
      */
-    virtual void setSelectedButton(RadioButton* radioButton);
+    virtual bool setSelectedButton(RadioButton* radioButton);
     
     /**
      * Select a radio button by index without event dispatch.
      *
      * @param index of the radio button
      */
-    virtual void setSelectedButtonWithoutEvent(int index);
+    virtual bool setSelectedButtonWithoutEvent(int index);
     
     /**
      * Select a radio button by instance without event dispatch.
      *
      * @param radio button instance
      */
-    virtual void setSelectedButtonWithoutEvent(RadioButton* radioButton);
+    virtual bool setSelectedButtonWithoutEvent(RadioButton* radioButton);
     
     /**
      * Add a radio button into this group.


### PR DESCRIPTION
In CocoStudioTest->CocoStudioGUITest->UIRadioBoxTest of lua-test project, use toggle button switch between "No selection is allowed" and "No selection is disallowed", there hasn't any difference between these mode, In "No selection is allowed" mode, still can change selection to other radio button
