### PR TITLE
Fix ActionManagerEx some times crash when reload action frames.

### DIFF
--- a/cocos/editor-support/cocostudio/CCActionObject.cpp
+++ b/cocos/editor-support/cocostudio/CCActionObject.cpp
@@ -51,6 +51,8 @@ ActionObject::ActionObject()
 
 ActionObject::~ActionObject()
 {
+    _loop = false;
+    _pScheduler->unscheduleAllForTarget(this);
     _actionNodeList.clear();
     CC_SAFE_RELEASE(_pScheduler);
     CC_SAFE_RELEASE(_CallBack);


### PR DESCRIPTION
@pandamicro This pr fix the ActionManagerEx crash when switch between scenes, please review it.
