### PR TITLE
Change PageView to derive from ListView

### DIFF
--- a/build/cocos2d_libs.xcodeproj/project.pbxproj
+++ b/build/cocos2d_libs.xcodeproj/project.pbxproj
@@ -2068,6 +2068,10 @@
 		B5668D7E1B3838E4003CBD5E /* UIScrollViewBar.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B5668D7B1B3838E4003CBD5E /* UIScrollViewBar.cpp */; };
 		B5668D7F1B3838E4003CBD5E /* UIScrollViewBar.h in Headers */ = {isa = PBXBuildFile; fileRef = B5668D7C1B3838E4003CBD5E /* UIScrollViewBar.h */; };
 		B5668D801B3838E4003CBD5E /* UIScrollViewBar.h in Headers */ = {isa = PBXBuildFile; fileRef = B5668D7C1B3838E4003CBD5E /* UIScrollViewBar.h */; };
+		B5A738961BB0051F00BAAEF8 /* UIPageViewIndicator.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B5A738941BB0051F00BAAEF8 /* UIPageViewIndicator.cpp */; settings = {ASSET_TAGS = (); }; };
+		B5A738971BB0051F00BAAEF8 /* UIPageViewIndicator.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B5A738941BB0051F00BAAEF8 /* UIPageViewIndicator.cpp */; settings = {ASSET_TAGS = (); }; };
+		B5A738981BB0051F00BAAEF8 /* UIPageViewIndicator.h in Headers */ = {isa = PBXBuildFile; fileRef = B5A738951BB0051F00BAAEF8 /* UIPageViewIndicator.h */; settings = {ASSET_TAGS = (); }; };
+		B5A738991BB0051F00BAAEF8 /* UIPageViewIndicator.h in Headers */ = {isa = PBXBuildFile; fileRef = B5A738951BB0051F00BAAEF8 /* UIPageViewIndicator.h */; settings = {ASSET_TAGS = (); }; };
 		B5CE6DBE1B3BF2B1002B0419 /* UIAbstractCheckButton.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B5CE6DBC1B3BF2B1002B0419 /* UIAbstractCheckButton.cpp */; };
 		B5CE6DBF1B3BF2B1002B0419 /* UIAbstractCheckButton.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B5CE6DBC1B3BF2B1002B0419 /* UIAbstractCheckButton.cpp */; };
 		B5CE6DC01B3BF2B1002B0419 /* UIAbstractCheckButton.h in Headers */ = {isa = PBXBuildFile; fileRef = B5CE6DBD1B3BF2B1002B0419 /* UIAbstractCheckButton.h */; };
@@ -4799,6 +4803,8 @@
 		B3AF019F1842FBA400A98B85 /* b2MotorJoint.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = b2MotorJoint.h; sourceTree = "<group>"; };
 		B5668D7B1B3838E4003CBD5E /* UIScrollViewBar.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = UIScrollViewBar.cpp; sourceTree = "<group>"; };
 		B5668D7C1B3838E4003CBD5E /* UIScrollViewBar.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = UIScrollViewBar.h; sourceTree = "<group>"; };
+		B5A738941BB0051F00BAAEF8 /* UIPageViewIndicator.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = UIPageViewIndicator.cpp; sourceTree = "<group>"; };
+		B5A738951BB0051F00BAAEF8 /* UIPageViewIndicator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = UIPageViewIndicator.h; sourceTree = "<group>"; };
 		B5CE6DBC1B3BF2B1002B0419 /* UIAbstractCheckButton.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = UIAbstractCheckButton.cpp; sourceTree = "<group>"; };
 		B5CE6DBD1B3BF2B1002B0419 /* UIAbstractCheckButton.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = UIAbstractCheckButton.h; sourceTree = "<group>"; };
 		B5CE6DC61B3C05BA002B0419 /* UIRadioButton.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = UIRadioButton.cpp; sourceTree = "<group>"; };
@@ -6956,6 +6962,8 @@
 				2905FA0118CF08D000240AA3 /* UILoadingBar.h */,
 				2905FA0218CF08D000240AA3 /* UIPageView.cpp */,
 				2905FA0318CF08D000240AA3 /* UIPageView.h */,
+				B5A738941BB0051F00BAAEF8 /* UIPageViewIndicator.cpp */,
+				B5A738951BB0051F00BAAEF8 /* UIPageViewIndicator.h */,
 				2905FA0418CF08D000240AA3 /* UIRichText.cpp */,
 				2905FA0518CF08D000240AA3 /* UIRichText.h */,
 				2905FA0718CF08D000240AA3 /* UIScrollView.cpp */,
@@ -9464,6 +9472,7 @@
 				B665E3F41AA80A6600DDB1C5 /* CCPUSlaveEmitter.h in Headers */,
 				15AE1B6919AADA9900C27E9E /* UIDeprecated.h in Headers */,
 				1A570223180BCC1A0088DEC7 /* CCParticleBatchNode.h in Headers */,
+				B5A738981BB0051F00BAAEF8 /* UIPageViewIndicator.h in Headers */,
 				B6CAB53F1AF9AA1A00B9B856 /* cl_platform.h in Headers */,
 				15AE1A8319AAD40300C27E9E /* b2GearJoint.h in Headers */,
 				15AE1BD519AAE01E00C27E9E /* CCControlSaturationBrightnessPicker.h in Headers */,
@@ -10966,6 +10975,7 @@
 				B665E2951AA80A6500DDB1C5 /* CCPUEmitter.h in Headers */,
 				B6CAB3BE1AF9AA1A00B9B856 /* btGeneric6DofSpringConstraint.h in Headers */,
 				B6CAB3521AF9AA1A00B9B856 /* gim_geometry.h in Headers */,
+				B5A738991BB0051F00BAAEF8 /* UIPageViewIndicator.h in Headers */,
 				15AE1BED19AAE01E00C27E9E /* CCControlColourPicker.h in Headers */,
 				15AE195019AAD35100C27E9E /* CCDatas.h in Headers */,
 				15AE18B319AAD33D00C27E9E /* CCBReader.h in Headers */,
@@ -11151,6 +11161,7 @@
 				ED9C6A9418599AD8000A5232 /* CCNodeGrid.cpp in Sources */,
 				15AE1A2C19AAD3D500C27E9E /* b2DynamicTree.cpp in Sources */,
 				B665E36A1AA80A6500DDB1C5 /* CCPUOnVelocityObserver.cpp in Sources */,
+				B5A738961BB0051F00BAAEF8 /* UIPageViewIndicator.cpp in Sources */,
 				B665E3961AA80A6500DDB1C5 /* CCPUPointEmitter.cpp in Sources */,
 				15AE184019AAD2F700C27E9E /* CCSprite3D.cpp in Sources */,
 				B6CAB2E51AF9AA1A00B9B856 /* btSphereShape.cpp in Sources */,
@@ -12625,6 +12636,7 @@
 				B665E1FB1AA80A6500DDB1C5 /* CCPUAffectorTranslator.cpp in Sources */,
 				B665E3931AA80A6500DDB1C5 /* CCPUPlaneColliderTranslator.cpp in Sources */,
 				382383F71A258FA7002C4610 /* idl_gen_fbs.cpp in Sources */,
+				B5A738971BB0051F00BAAEF8 /* UIPageViewIndicator.cpp in Sources */,
 				B665E24B1AA80A6500DDB1C5 /* CCPUColorAffector.cpp in Sources */,
 				B665E20F1AA80A6500DDB1C5 /* CCPUBaseForceAffector.cpp in Sources */,
 				15AE1B7419AADA9A00C27E9E /* UILoadingBar.cpp in Sources */,

--- a/cocos/2d/libcocos2d.vcxproj
+++ b/cocos/2d/libcocos2d.vcxproj
@@ -652,6 +652,7 @@ xcopy /Y /Q "$(ProjectDir)..\..\external\chipmunk\prebuilt\win32\release-lib\*.*
     <ClCompile Include="..\ui\UIListView.cpp" />
     <ClCompile Include="..\ui\UILoadingBar.cpp" />
     <ClCompile Include="..\ui\UIPageView.cpp" />
+    <ClCompile Include="..\ui\UIPageViewIndicator.cpp" />
     <ClCompile Include="..\ui\UIRelativeBox.cpp" />
     <ClCompile Include="..\ui\UIRichText.cpp" />
     <ClCompile Include="..\ui\UIScale9Sprite.cpp" />

--- a/cocos/2d/libcocos2d.vcxproj.filters
+++ b/cocos/2d/libcocos2d.vcxproj.filters
@@ -934,6 +934,9 @@
     <ClCompile Include="..\ui\UIPageView.cpp">
       <Filter>ui\UIWidgets\ScrollWidget</Filter>
     </ClCompile>
+    <ClCompile Include="..\ui\UIPageViewIndicator.cpp">
+      <Filter>ui\UIWidgets\ScrollWidget</Filter>
+    </ClCompile>
     <ClCompile Include="..\ui\UIScrollView.cpp">
       <Filter>ui\UIWidgets\ScrollWidget</Filter>
     </ClCompile>

--- a/cocos/2d/libcocos2d_8_1/libcocos2d_8_1/libcocos2d_8_1.Shared/libcocos2d_8_1.Shared.vcxitems
+++ b/cocos/2d/libcocos2d_8_1/libcocos2d_8_1/libcocos2d_8_1.Shared/libcocos2d_8_1.Shared.vcxitems
@@ -1151,6 +1151,7 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\..\..\ui\UIListView.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\..\..\ui\UILoadingBar.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\..\..\ui\UIPageView.cpp" />
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\..\..\ui\UIPageViewIndicator.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\..\..\ui\UIRelativeBox.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\..\..\ui\UIRichText.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\..\..\ui\UIScale9Sprite.cpp" />

--- a/cocos/2d/libcocos2d_8_1/libcocos2d_8_1/libcocos2d_8_1.Shared/libcocos2d_8_1.Shared.vcxitems.filters
+++ b/cocos/2d/libcocos2d_8_1/libcocos2d_8_1/libcocos2d_8_1.Shared/libcocos2d_8_1.Shared.vcxitems.filters
@@ -2322,6 +2322,9 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\..\..\ui\UIPageView.cpp">
       <Filter>ui\UIWidgets\ScrollWidget</Filter>
     </ClCompile>
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\..\..\ui\UIPageViewIndicator.cpp">
+      <Filter>ui\UIWidgets\ScrollWidget</Filter>
+    </ClCompile>
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\..\..\ui\UIScrollView.cpp">
       <Filter>ui\UIWidgets\ScrollWidget</Filter>
     </ClCompile>

--- a/cocos/2d/libcocos2d_win10/libcocos2d.vcxproj
+++ b/cocos/2d/libcocos2d_win10/libcocos2d.vcxproj
@@ -652,6 +652,7 @@
     <ClCompile Include="..\..\ui\UIListView.cpp" />
     <ClCompile Include="..\..\ui\UILoadingBar.cpp" />
     <ClCompile Include="..\..\ui\UIPageView.cpp" />
+    <ClCompile Include="..\..\ui\UIPageViewIndicator.cpp" />
     <ClCompile Include="..\..\ui\UIRelativeBox.cpp" />
     <ClCompile Include="..\..\ui\UIRichText.cpp" />
     <ClCompile Include="..\..\ui\UIScale9Sprite.cpp" />

--- a/cocos/2d/libcocos2d_win10/libcocos2d.vcxproj.filters
+++ b/cocos/2d/libcocos2d_win10/libcocos2d.vcxproj.filters
@@ -1686,6 +1686,9 @@
     <ClCompile Include="..\..\ui\UIPageView.cpp">
       <Filter>ui\UIWidgets\ScrollWidget</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\ui\UIPageViewIndicator.cpp">
+      <Filter>ui\UIWidgets\ScrollWidget</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\ui\UIScrollView.cpp">
       <Filter>ui\UIWidgets\ScrollWidget</Filter>
     </ClCompile>

--- a/cocos/base/ccUtils.cpp
+++ b/cocos/base/ccUtils.cpp
@@ -30,10 +30,12 @@ THE SOFTWARE.
 #include "base/CCDirector.h"
 #include "base/CCAsyncTaskPool.h"
 #include "base/CCEventDispatcher.h"
+#include "base/base64.h"
 #include "renderer/CCCustomCommand.h"
 #include "renderer/CCRenderer.h"
 #include "platform/CCImage.h"
 #include "platform/CCFileUtils.h"
+#include "2d/CCSprite.h"
 
 NS_CC_BEGIN
 
@@ -263,7 +265,28 @@ Rect getCascadeBoundingBox(Node *node)
     
     return cbb;
 }
+
+Sprite* createSpriteFromBase64(const char* base64String)
+{
+    unsigned char* decoded;
+    int length = base64Decode((const unsigned char*) base64String, (unsigned int) strlen(base64String), &decoded);
+
+    Image *image = new Image();
+    bool imageResult = image->initWithImageData(decoded, length);
+    CCASSERT(imageResult, "Failed to create image from base64!");
+    free(decoded);
+
+    Texture2D *texture = new Texture2D();
+    texture->initWithImage(image);
+    texture->setAliasTexParameters();
+    image->release();
+
+    Sprite* sprite = Sprite::createWithTexture(texture);
+    texture->release();
     
+    return sprite;
+}
+
 }
 
 NS_CC_END

--- a/cocos/base/ccUtils.h
+++ b/cocos/base/ccUtils.h
@@ -52,6 +52,8 @@ Examples:
 
 int ccNextPOT(int value);
 
+class Sprite;
+
 namespace utils
 {
     /** Capture the entire screen.
@@ -100,6 +102,14 @@ namespace utils
      * @return Returns unionof bounding box of a node and its children.
      */
     Rect CC_DLL getCascadeBoundingBox(Node *node);
+
+    /**
+     * Create a sprite instance from base64 encoded image.
+
+     * @return Returns an instance of sprite
+     */
+    Sprite* CC_DLL createSpriteFromBase64(const char* base64String);
+
 }
 
 NS_CC_END

--- a/cocos/base/ccUtils.h
+++ b/cocos/base/ccUtils.h
@@ -108,7 +108,7 @@ namespace utils
 
      * @return Returns an instance of sprite
      */
-    Sprite* CC_DLL createSpriteFromBase64(const char* base64String);
+    Sprite* createSpriteFromBase64(const char* base64String);
 
 }
 

--- a/cocos/ui/Android.mk
+++ b/cocos/ui/Android.mk
@@ -18,6 +18,7 @@ CocosGUI.cpp \
 UIHelper.cpp \
 UIListView.cpp \
 UIPageView.cpp \
+UIPageViewIndicator.cpp \
 UIScrollView.cpp \
 UIScrollViewBar.cpp \
 UIButton.cpp \

--- a/cocos/ui/CMakeLists.txt
+++ b/cocos/ui/CMakeLists.txt
@@ -38,6 +38,7 @@ set(COCOS_UI_SRC
   ui/UIListView.cpp
   ui/UILoadingBar.cpp
   ui/UIPageView.cpp
+  ui/UIPageViewIndicator.cpp
   ui/UIRelativeBox.cpp
   ui/UIRichText.cpp
   ui/UIScale9Sprite.cpp

--- a/cocos/ui/UIListView.cpp
+++ b/cocos/ui/UIListView.cpp
@@ -758,11 +758,13 @@ void ListView::jumpToItem(ssize_t itemIndex, const Vec2& positionRatioInView, co
     doLayout();
 
     Vec2 destination = calculateItemDestination(getContentSize(), item, positionRatioInView, itemAnchorPoint);
-    destination = flattenVectorByDirection(destination);
-    Vec2 delta = destination - getInnerContainerPosition();
-    Vec2 outOfBoundary = getHowMuchOutOfBoundary(delta);
-    destination += outOfBoundary;
-    moveChildrenToPosition(destination);
+    if(!_bounceEnabled)
+    {
+        Vec2 delta = destination - getInnerContainerPosition();
+        Vec2 outOfBoundary = getHowMuchOutOfBoundary(delta);
+        destination += outOfBoundary;
+    }
+    jumpToDestination(destination);
 }
 
 void ListView::scrollToItem(ssize_t itemIndex, const Vec2& positionRatioInView, const Vec2& itemAnchorPoint)

--- a/cocos/ui/UIListView.cpp
+++ b/cocos/ui/UIListView.cpp
@@ -743,8 +743,9 @@ void ListView::jumpToPercentBothDirection(const Vec2& percent)
     ScrollView::jumpToPercentBothDirection(percent);
 }
 
-static Vec2 calculateItemDestination(const Size& contentSize, Widget* item, const Vec2& positionRatioInView, const Vec2& itemAnchorPoint)
+Vec2 ListView::calculateItemDestination(const Vec2& positionRatioInView, Widget* item, const Vec2& itemAnchorPoint)
 {
+    const Size& contentSize = getContentSize();
     Vec2 positionInView;
     positionInView.x += contentSize.width * positionRatioInView.x;
     positionInView.y += contentSize.height * positionRatioInView.y;
@@ -762,7 +763,7 @@ void ListView::jumpToItem(ssize_t itemIndex, const Vec2& positionRatioInView, co
     }
     doLayout();
 
-    Vec2 destination = calculateItemDestination(getContentSize(), item, positionRatioInView, itemAnchorPoint);
+    Vec2 destination = calculateItemDestination(positionRatioInView, item, itemAnchorPoint);
     if(!_bounceEnabled)
     {
         Vec2 delta = destination - getInnerContainerPosition();
@@ -784,7 +785,7 @@ void ListView::scrollToItem(ssize_t itemIndex, const Vec2& positionRatioInView, 
     {
         return;
     }
-    Vec2 destination = calculateItemDestination(getContentSize(), item, positionRatioInView, itemAnchorPoint);
+    Vec2 destination = calculateItemDestination(positionRatioInView, item, itemAnchorPoint);
     startAutoScrollToDestination(destination, timeInSec, true);
 }
 

--- a/cocos/ui/UIListView.cpp
+++ b/cocos/ui/UIListView.cpp
@@ -72,7 +72,7 @@ bool ListView::init()
 {
     if (ScrollView::init())
     {
-        setLayoutType(Type::VERTICAL);
+        setDirection(Direction::VERTICAL);
         return true;
     }
     return false;
@@ -365,7 +365,7 @@ void ListView::removeAllItems()
     removeAllChildren();
 }
 
-Widget* ListView::getItem(ssize_t index)const
+Widget* ListView::getItem(ssize_t index) const
 {
     if (index < 0 || index >= _items.size())
     {
@@ -748,7 +748,7 @@ static Vec2 calculateItemDestination(const Size& contentSize, Widget* item, cons
     return -(itemPosition - positionInView);
 }
 
-void ListView::jumpToItem(int itemIndex, const Vec2& positionRatioInView, const Vec2& itemAnchorPoint)
+void ListView::jumpToItem(ssize_t itemIndex, const Vec2& positionRatioInView, const Vec2& itemAnchorPoint)
 {
     Widget* item = getItem(itemIndex);
     if (item == nullptr)
@@ -765,12 +765,12 @@ void ListView::jumpToItem(int itemIndex, const Vec2& positionRatioInView, const 
     moveChildrenToPosition(destination);
 }
 
-void ListView::scrollToItem(int itemIndex, const Vec2& positionRatioInView, const Vec2& itemAnchorPoint)
+void ListView::scrollToItem(ssize_t itemIndex, const Vec2& positionRatioInView, const Vec2& itemAnchorPoint)
 {
     scrollToItem(itemIndex, positionRatioInView, itemAnchorPoint, DEFAULT_TIME_IN_SEC_FOR_SCROLL_TO_ITEM);
 }
 
-void ListView::scrollToItem(int itemIndex, const Vec2& positionRatioInView, const Vec2& itemAnchorPoint, float timeInSec)
+void ListView::scrollToItem(ssize_t itemIndex, const Vec2& positionRatioInView, const Vec2& itemAnchorPoint, float timeInSec)
 {
     Widget* item = getItem(itemIndex);
     if (item == nullptr)
@@ -847,7 +847,7 @@ Vec2 ListView::getHowMuchOutOfBoundary(const Vec2& addition)
     float topBoundary = _topBoundary;
     float bottomBoundary = _bottomBoundary;
     {
-        int lastItemIndex = _items.size() - 1;
+        ssize_t lastItemIndex = _items.size() - 1;
         Size contentSize = getContentSize();
         Vec2 firstItemAdjustment, lastItemAdjustment;
         if(_magneticType == MagneticType::CENTER)

--- a/cocos/ui/UIListView.cpp
+++ b/cocos/ui/UIListView.cpp
@@ -100,6 +100,11 @@ void ListView::handleReleaseLogic(Touch *touch)
     }
 }
 
+void ListView::onItemListChanged()
+{
+    _outOfBoundaryAmountDirty = true;
+}
+
 void ListView::updateInnerContainerSize()
 {
     switch (_direction)
@@ -263,7 +268,7 @@ void ListView::addChild(cocos2d::Node *child, int zOrder, int tag)
     if (nullptr != widget)
     {
         _items.pushBack(widget);
-        _outOfBoundaryAmountDirty = true;
+        onItemListChanged();
     }
 }
     
@@ -285,7 +290,7 @@ void ListView::addChild(Node* child, int zOrder, const std::string &name)
     if (nullptr != widget)
     {
         _items.pushBack(widget);
-        _outOfBoundaryAmountDirty = true;
+        onItemListChanged();
     }
 }
     
@@ -307,7 +312,7 @@ void ListView::removeChild(cocos2d::Node *child, bool cleaup)
             }
         }
         _items.eraseObject(widget);
-        _outOfBoundaryAmountDirty = true;
+        onItemListChanged();
     }
    
     ScrollView::removeChild(child, cleaup);
@@ -321,9 +326,9 @@ void ListView::removeAllChildren()
 void ListView::removeAllChildrenWithCleanup(bool cleanup)
 {
     ScrollView::removeAllChildrenWithCleanup(cleanup);
-    _items.clear();
     _curSelectedIndex = -1;
-    _outOfBoundaryAmountDirty = true;
+    _items.clear();
+    onItemListChanged();
 }
 
 void ListView::insertCustomItem(Widget* item, ssize_t index)
@@ -336,8 +341,8 @@ void ListView::insertCustomItem(Widget* item, ssize_t index)
         }
     }
     _items.insert(index, item);
-    _outOfBoundaryAmountDirty = true;
-    
+    onItemListChanged();
+
     ScrollView::addChild(item);
 
     remedyLayoutParameter(item);

--- a/cocos/ui/UIListView.cpp
+++ b/cocos/ui/UIListView.cpp
@@ -484,8 +484,8 @@ void ListView::doLayout()
         item->setLocalZOrder(i);
         remedyLayoutParameter(item);
     }
-    _innerContainer->forceDoLayout();
     updateInnerContainerSize();
+    _innerContainer->forceDoLayout();
     _innerContainerDoLayoutDirty = false;
 }
     

--- a/cocos/ui/UIListView.h
+++ b/cocos/ui/UIListView.h
@@ -255,25 +255,25 @@ public:
     virtual void removeAllChildrenWithCleanup(bool cleanup) override;
     virtual void removeChild(Node* child, bool cleaup = true) override;
 
-	/**
-	 * @brief Query the closest item to a specific position in inner container.
-	 *
-	 * @param targetPosition Specifies the target position in inner container's coordinates.
-	 * @param itemAnchorPoint Specifies an anchor point of each item for position to calculate distance.
-	 * @return A item instance if list view is not empty. Otherwise, returns null.
-	 */
-	Widget* getClosestItemToPosition(const Vec2& targetPosition, const Vec2& itemAnchorPoint) const;
-	
-	/**
-	 * @brief Query the closest item to a specific position in current view.
+    /**
+     * @brief Query the closest item to a specific position in inner container.
+     *
+     * @param targetPosition Specifies the target position in inner container's coordinates.
+     * @param itemAnchorPoint Specifies an anchor point of each item for position to calculate distance.
+     * @return A item instance if list view is not empty. Otherwise, returns null.
+     */
+    Widget* getClosestItemToPosition(const Vec2& targetPosition, const Vec2& itemAnchorPoint) const;
+    
+    /**
+     * @brief Query the closest item to a specific position in current view.
      * For instance, to find the item in the center of view, call 'getClosestItemToPositionInCurrentView(Vec2::ANCHOR_MIDDLE, Vec2::ANCHOR_MIDDLE)'.
-	 *
-	 * @param positionRatioInView Specifies the target position with ratio in list view's content size.
-	 * @param itemAnchorPoint Specifies an anchor point of each item for position to calculate distance.
-	 * @return A item instance if list view is not empty. Otherwise, returns null.
-	 */
-	Widget* getClosestItemToPositionInCurrentView(const Vec2& positionRatioInView, const Vec2& itemAnchorPoint) const;
-	
+     *
+     * @param positionRatioInView Specifies the target position with ratio in list view's content size.
+     * @param itemAnchorPoint Specifies an anchor point of each item for position to calculate distance.
+     * @return A item instance if list view is not empty. Otherwise, returns null.
+     */
+    Widget* getClosestItemToPositionInCurrentView(const Vec2& positionRatioInView, const Vec2& itemAnchorPoint) const;
+    
     /**
      * @brief Query the center item
      * @return A item instance.
@@ -327,15 +327,15 @@ public:
      */
     void jumpToItem(ssize_t itemIndex, const Vec2& positionRatioInView, const Vec2& itemAnchorPoint);
     
-	/**
-	 * @brief Scroll to specific item
-	 * @param positionRatioInView Specifies the position with ratio in list view's content size.
-	 * @param itemAnchorPoint Specifies an anchor point of each item for position to calculate distance.
-	 * @param timeInSec Scroll time
-	 */
+    /**
+     * @brief Scroll to specific item
+     * @param positionRatioInView Specifies the position with ratio in list view's content size.
+     * @param itemAnchorPoint Specifies an anchor point of each item for position to calculate distance.
+     * @param timeInSec Scroll time
+     */
     void scrollToItem(ssize_t itemIndex, const Vec2& positionRatioInView, const Vec2& itemAnchorPoint);
-	void scrollToItem(ssize_t itemIndex, const Vec2& positionRatioInView, const Vec2& itemAnchorPoint, float timeInSec);
-	
+    void scrollToItem(ssize_t itemIndex, const Vec2& positionRatioInView, const Vec2& itemAnchorPoint, float timeInSec);
+    
     /**
      * @brief Query current selected widget's idnex.
      *

--- a/cocos/ui/UIListView.h
+++ b/cocos/ui/UIListView.h
@@ -407,6 +407,7 @@ protected:
     virtual void startAttenuatingAutoScroll(const Vec2& deltaMove, const Vec2& initialVelocity) override;
     
     void startMagneticScroll();
+    Vec2 calculateItemDestination(const Vec2& positionRatioInView, Widget* item, const Vec2& itemAnchorPoint);
     
 protected:
     Widget* _model;

--- a/cocos/ui/UIListView.h
+++ b/cocos/ui/UIListView.h
@@ -172,8 +172,7 @@ public:
      * @param index A given index in ssize_t.
      */
     void removeItem(ssize_t index);
-    
-    
+
     /**
      * @brief Remove all items in current ListView.
      *
@@ -326,7 +325,7 @@ public:
      * @param positionRatioInView Specifies the position with ratio in list view's content size.
      * @param itemAnchorPoint Specifies an anchor point of each item for position to calculate distance.
      */
-    void jumpToItem(int itemIndex, const Vec2& positionRatioInView, const Vec2& itemAnchorPoint);
+    void jumpToItem(ssize_t itemIndex, const Vec2& positionRatioInView, const Vec2& itemAnchorPoint);
     
 	/**
 	 * @brief Scroll to specific item
@@ -334,8 +333,8 @@ public:
 	 * @param itemAnchorPoint Specifies an anchor point of each item for position to calculate distance.
 	 * @param timeInSec Scroll time
 	 */
-    void scrollToItem(int itemIndex, const Vec2& positionRatioInView, const Vec2& itemAnchorPoint);
-	void scrollToItem(int itemIndex, const Vec2& positionRatioInView, const Vec2& itemAnchorPoint, float timeInSec);
+    void scrollToItem(ssize_t itemIndex, const Vec2& positionRatioInView, const Vec2& itemAnchorPoint);
+	void scrollToItem(ssize_t itemIndex, const Vec2& positionRatioInView, const Vec2& itemAnchorPoint, float timeInSec);
 	
     /**
      * @brief Query current selected widget's idnex.

--- a/cocos/ui/UIListView.h
+++ b/cocos/ui/UIListView.h
@@ -387,7 +387,9 @@ CC_CONSTRUCTOR_ACCESS:
     
 protected:
     virtual void handleReleaseLogic(Touch *touch) override;
-    
+
+    virtual void onItemListChanged();
+
     void updateInnerContainerSize();
     void remedyLayoutParameter(Widget* item);
     void remedyVerticalLayoutParameter(LinearLayoutParameter* layoutParameter, ssize_t itemIndex);

--- a/cocos/ui/UIPageView.cpp
+++ b/cocos/ui/UIPageView.cpp
@@ -34,7 +34,7 @@ IMPLEMENT_CLASS_GUI_INFO(PageView)
 PageView::PageView():
 _indicatorEnabled(false),
 _indicator(nullptr),
-_indicatorPositionAsAnchorPoint(Vec2::ANCHOR_MIDDLE),
+_indicatorPositionAsAnchorPoint(Vec2(0.5f, 0.1f)),
 _currentPageIndex(-1),
 _customScrollThreshold(0.0),
 _usingCustomScrollThreshold(false),
@@ -65,11 +65,11 @@ PageView* PageView::create()
     
 bool PageView::init()
 {
+    _indicator = PageViewIndicator::create();
+    addProtectedChild(_indicator, 10000);
+
     if (ListView::init())
     {
-        _indicator = PageViewIndicator::create();
-        addProtectedChild(_indicator, 10000);
-        
         setDirection(Direction::HORIZONTAL);
         setMagneticType(MagneticType::CENTER);
 		setScrollBarEnabled(false);
@@ -200,9 +200,8 @@ void PageView::handleReleaseLogic(Touch *touch)
 
     Vec2 touchMoveVelocity = flattenVectorByDirection(calculateTouchMoveVelocity());
 
-    static const float THRESHOLD = 500;
-    CCLOG("handleReleaseLogic() touchMoveVelocity.length()=%.2f", touchMoveVelocity.length());
-    if(touchMoveVelocity.length() < THRESHOLD)
+    static const float DEFAULT_THRESHOLD = 500;
+    if(touchMoveVelocity.length() < DEFAULT_THRESHOLD)
     {
         startMagneticScroll();
     }

--- a/cocos/ui/UIPageView.cpp
+++ b/cocos/ui/UIPageView.cpp
@@ -96,17 +96,17 @@ void PageView::addWidgetToPage(Widget *widget, ssize_t pageIdx, bool forceCreate
     insertCustomItem(widget, pageIdx);
 }
 
-void PageView::addPage(Layout* page)
+void PageView::addPage(Widget* page)
 {
     pushBackCustomItem(page);
 }
 
-void PageView::insertPage(Layout* page, int idx)
+void PageView::insertPage(Widget* page, int idx)
 {
     insertCustomItem(page, idx);
 }
 
-void PageView::removePage(Layout* page)
+void PageView::removePage(Widget* page)
 {
     removeItem(getIndex(page));
 }

--- a/cocos/ui/UIPageView.cpp
+++ b/cocos/ui/UIPageView.cpp
@@ -137,6 +137,13 @@ bool PageView::isUsingCustomScrollThreshold()const
     return _usingCustomScrollThreshold;
 }
 
+void PageView::onItemListChanged()
+{
+    ListView::onItemListChanged();
+    ssize_t index = getIndex(getCenterItemInCurrentView());
+    _indicator->reset(_items.size(), index);
+}
+
 void PageView::onSizeChanged()
 {
     ListView::onSizeChanged();

--- a/cocos/ui/UIPageView.cpp
+++ b/cocos/ui/UIPageView.cpp
@@ -72,6 +72,22 @@ bool PageView::init()
     return false;
 }
 
+void PageView::doLayout()
+{
+    if(!_innerContainerDoLayoutDirty)
+    {
+        return;
+    }
+
+    ListView::doLayout();
+    if(_indicator != nullptr)
+    {
+        ssize_t index = getIndex(getCenterItemInCurrentView());
+        _indicator->indicate(index);
+    }
+    _innerContainerDoLayoutDirty = false;
+}
+
 void PageView::setDirection(PageView::Direction direction)
 {
     ListView::setDirection(direction);
@@ -174,10 +190,9 @@ void PageView::moveInnerContainer(const Vec2& deltaMove, bool canStartBounceBack
 void PageView::onItemListChanged()
 {
     ListView::onItemListChanged();
-    ssize_t index = getIndex(getCenterItemInCurrentView());
     if(_indicator != nullptr)
     {
-        _indicator->reset(_items.size(), index);
+        _indicator->reset(_items.size());
     }
 }
 

--- a/cocos/ui/UIPageView.cpp
+++ b/cocos/ui/UIPageView.cpp
@@ -33,6 +33,7 @@ IMPLEMENT_CLASS_GUI_INFO(PageView)
 
 PageView::PageView():
 _indicator(nullptr),
+_indicatorPositionAsAnchorPoint(Vec2::ANCHOR_MIDDLE),
 _currentPageIndex(-1),
 _customScrollThreshold(0.0),
 _usingCustomScrollThreshold(false),
@@ -69,6 +70,8 @@ bool PageView::init()
         addProtectedChild(_indicator, 10000);
         
         setDirection(ListView::Direction::HORIZONTAL);
+        _indicatorPositionAsAnchorPoint = Vec2(0.5f, 0.1f);
+
         setMagneticType(MagneticType::CENTER);
 		setScrollBarEnabled(false);
         return true;
@@ -160,7 +163,15 @@ void PageView::onItemListChanged()
 void PageView::onSizeChanged()
 {
     ListView::onSizeChanged();
-    _indicator->setPosition(Vec2(getContentSize() / 2) + Vec2(0, -50));
+    refreshIndicatorPosition();
+}
+
+void PageView::refreshIndicatorPosition()
+{
+    const Size& contentSize = getContentSize();
+    float posX = contentSize.width * _indicatorPositionAsAnchorPoint.x;
+    float posY = contentSize.height * _indicatorPositionAsAnchorPoint.y;
+    _indicator->setPosition(Vec2(posX, posY));
 }
 
 void PageView::handleReleaseLogic(Touch *touch)
@@ -299,6 +310,30 @@ void PageView::copySpecialProperties(Widget *widget)
         _usingCustomScrollThreshold = pageView->_usingCustomScrollThreshold;
         _customScrollThreshold = pageView->_customScrollThreshold;
     }
+}
+
+void PageView::setIndicatorPositionAsAnchorPoint(const Vec2& positionAsAnchorPoint)
+{
+    _indicatorPositionAsAnchorPoint = positionAsAnchorPoint;
+    refreshIndicatorPosition();
+}
+
+const Vec2& PageView::getIndicatorPositionAsAnchorPoint() const
+{
+    return _indicatorPositionAsAnchorPoint;
+}
+
+void PageView::setIndicatorPosition(const Vec2& position)
+{
+    const Size& contentSize = getContentSize();
+    _indicatorPositionAsAnchorPoint.x = position.x / contentSize.width;
+    _indicatorPositionAsAnchorPoint.y = position.y / contentSize.height;
+    _indicator->setPosition(position);
+}
+
+const Vec2& PageView::getIndicatorPosition() const
+{
+    return _indicator->getPosition();
 }
 
 }

--- a/cocos/ui/UIPageView.cpp
+++ b/cocos/ui/UIPageView.cpp
@@ -134,7 +134,31 @@ bool PageView::isUsingCustomScrollThreshold()const
 
 void PageView::handleReleaseLogic(Touch *touch)
 {
-    ListView::handleReleaseLogic(touch);
+    // Use `ScrollView` method instead of `ListView` to
+    ScrollView::handleReleaseLogic(touch);
+
+    static const float THRESHOLD = 5000;
+    Vec2 touchMoveVelocity = flattenVectorByDirection(calculateTouchMoveVelocity());
+    CCLOG("handleReleaseLogic() touchMoveVelocity.length()=%.2f", touchMoveVelocity.length());
+    if(touchMoveVelocity.length() < THRESHOLD)
+    {
+        startMagneticScroll();
+    }
+    else
+    {
+        ssize_t currentIndex = getIndex(getCenterItemInCurrentView());
+        if(touchMoveVelocity.x < 0 || touchMoveVelocity.y > 0)
+        {
+            ++currentIndex;
+        }
+        else
+        {
+            --currentIndex;
+        }
+        currentIndex = MIN(currentIndex, _items.size());
+        currentIndex = MAX(currentIndex, 0);
+        scrollToItem(currentIndex, Vec2::ANCHOR_MIDDLE, Vec2::ANCHOR_MIDDLE);
+    }
 }
 
 void PageView::pageTurningEvent()

--- a/cocos/ui/UIPageView.cpp
+++ b/cocos/ui/UIPageView.cpp
@@ -355,6 +355,26 @@ const Vec2& PageView::getIndicatorPosition() const
     return _indicator->getPosition();
 }
 
+void PageView::setIndicatorSpaceBetweenIndexNodes(float spaceBetweenIndexNodes)
+{
+    _indicator->setSpaceBetweenIndexNodes(spaceBetweenIndexNodes);
+}
+float PageView::getIndicatorSpaceBetweenIndexNodes() const
+{
+    return _indicator->getSpaceBetweenIndexNodes();
+}
+
+void PageView::setIndicatorSelectedIndexColor(const Color3B& color)
+{
+    _indicator->setSelectedIndexColor(color);
+}
+
+const Color3B& PageView::getIndicatorSelectedIndexColor() const
+{
+    return _indicator->getSelectedIndexColor();
+}
+
+
 }
 
 NS_CC_END

--- a/cocos/ui/UIPageView.cpp
+++ b/cocos/ui/UIPageView.cpp
@@ -32,6 +32,7 @@ namespace ui {
 IMPLEMENT_CLASS_GUI_INFO(PageView)
 
 PageView::PageView():
+_indicatorEnabled(false),
 _indicator(nullptr),
 _indicatorPositionAsAnchorPoint(Vec2::ANCHOR_MIDDLE),
 _currentPageIndex(-1),
@@ -69,14 +70,27 @@ bool PageView::init()
         _indicator = PageViewIndicator::create();
         addProtectedChild(_indicator, 10000);
         
-        setDirection(ListView::Direction::HORIZONTAL);
-        _indicatorPositionAsAnchorPoint = Vec2(0.5f, 0.1f);
-
+        setDirection(Direction::HORIZONTAL);
         setMagneticType(MagneticType::CENTER);
 		setScrollBarEnabled(false);
         return true;
     }
     return false;
+}
+
+void PageView::setDirection(PageView::Direction direction)
+{
+    ListView::setDirection(direction);
+    if(direction == Direction::HORIZONTAL)
+    {
+        _indicatorPositionAsAnchorPoint = Vec2(0.5f, 0.1f);
+    }
+    else if(direction == Direction::VERTICAL)
+    {
+        _indicatorPositionAsAnchorPoint = Vec2(0.1f, 0.5f);
+    }
+	_indicator->setDirection(direction);
+    refreshIndicatorPosition();
 }
 
 void PageView::addWidgetToPage(Widget *widget, ssize_t pageIdx, bool forceCreate)
@@ -310,6 +324,12 @@ void PageView::copySpecialProperties(Widget *widget)
         _usingCustomScrollThreshold = pageView->_usingCustomScrollThreshold;
         _customScrollThreshold = pageView->_customScrollThreshold;
     }
+}
+
+void PageView::setIndicatorEnabled(bool enabled)
+{
+    _indicatorEnabled = enabled;
+    _indicator->setVisible(_indicatorEnabled);
 }
 
 void PageView::setIndicatorPositionAsAnchorPoint(const Vec2& positionAsAnchorPoint)

--- a/cocos/ui/UIPageView.cpp
+++ b/cocos/ui/UIPageView.cpp
@@ -210,19 +210,21 @@ void PageView::handleReleaseLogic(Touch *touch)
 
     Vec2 touchMoveVelocity = flattenVectorByDirection(calculateTouchMoveVelocity());
 
-    static const float DEFAULT_THRESHOLD = 500;
-    if(touchMoveVelocity.length() < DEFAULT_THRESHOLD)
+    static const float INERTIA_THRESHOLD = 500;
+    if(touchMoveVelocity.length() < INERTIA_THRESHOLD)
     {
         startMagneticScroll();
     }
     else
     {
+        // Handle paging by inertia force.
         Widget* currentPage = getItem(_currentPageIndex);
         Vec2 destination = calculateItemDestination(Vec2::ANCHOR_MIDDLE, currentPage, Vec2::ANCHOR_MIDDLE);
-        Vec2 deltaToCurrentpage;
-        deltaToCurrentpage = destination - getInnerContainerPosition();
+        Vec2 deltaToCurrentpage = destination - getInnerContainerPosition();
         deltaToCurrentpage = flattenVectorByDirection(deltaToCurrentpage);
 
+        // If the direction of displacement to current page and the direction of touch are same, just start magnetic scroll to the current page.
+        // Otherwise, move to the next page of touch direction.
         if(touchMoveVelocity.x * deltaToCurrentpage.x > 0 || touchMoveVelocity.y * deltaToCurrentpage.y > 0)
         {
             startMagneticScroll();

--- a/cocos/ui/UIPageView.cpp
+++ b/cocos/ui/UIPageView.cpp
@@ -135,7 +135,12 @@ void PageView::setCurrentPageIndex(ssize_t index)
 
 void PageView::scrollToPage(ssize_t idx)
 {
-	scrollToItem(idx, Vec2::ANCHOR_MIDDLE, Vec2::ANCHOR_MIDDLE);
+    scrollToItem(idx);
+}
+
+void PageView::scrollToItem(ssize_t itemIndex)
+{
+    ListView::scrollToItem(itemIndex, Vec2::ANCHOR_MIDDLE, Vec2::ANCHOR_MIDDLE);
 }
 
 void PageView::setCustomScrollThreshold(float threshold)
@@ -238,7 +243,7 @@ void PageView::handleReleaseLogic(Touch *touch)
             }
             _currentPageIndex = MIN(_currentPageIndex, _items.size());
             _currentPageIndex = MAX(_currentPageIndex, 0);
-            scrollToItem(_currentPageIndex, Vec2::ANCHOR_MIDDLE, Vec2::ANCHOR_MIDDLE);
+            scrollToItem(_currentPageIndex);
         }
     }
 }

--- a/cocos/ui/UIPageView.cpp
+++ b/cocos/ui/UIPageView.cpp
@@ -348,6 +348,7 @@ void PageView::setIndicatorEnabled(bool enabled)
     else
     {
         _indicator = PageViewIndicator::create();
+        _indicator->setDirection(getDirection());
         addProtectedChild(_indicator, 10000);
         setIndicatorSelectedIndexColor(Color3B(100, 100, 255));
         refreshIndicatorPosition();

--- a/cocos/ui/UIPageView.cpp
+++ b/cocos/ui/UIPageView.cpp
@@ -35,8 +35,6 @@ PageView::PageView():
 _indicator(nullptr),
 _indicatorPositionAsAnchorPoint(Vec2(0.5f, 0.1f)),
 _currentPageIndex(-1),
-_customScrollThreshold(0.0),
-_usingCustomScrollThreshold(false),
 _childFocusCancelOffset(5.0f),
 _pageViewEventListener(nullptr),
 _pageViewEventSelector(nullptr),
@@ -145,24 +143,22 @@ void PageView::scrollToItem(ssize_t itemIndex)
 
 void PageView::setCustomScrollThreshold(float threshold)
 {
-    CCASSERT(threshold > 0, "Invalid threshold!");
-    _customScrollThreshold = threshold;
-    this->setUsingCustomScrollThreshold(true);
+    CCLOG("PageView::setCustomScrollThreshold() has no effect!");
 }
 
 float PageView::getCustomScrollThreshold()const
 {
-    return _customScrollThreshold;
+    return 0;
 }
     
 void PageView::setUsingCustomScrollThreshold(bool flag)
 {
-    _usingCustomScrollThreshold = flag;
+    CCLOG("PageView::setUsingCustomScrollThreshold() has no effect!");
 }
     
 bool PageView::isUsingCustomScrollThreshold()const
 {
-    return _usingCustomScrollThreshold;
+    return false;
 }
 
 void PageView::moveInnerContainer(const Vec2& deltaMove, bool canStartBounceBack)
@@ -334,8 +330,6 @@ void PageView::copySpecialProperties(Widget *widget)
         _ccEventCallback = pageView->_ccEventCallback;
         _pageViewEventListener = pageView->_pageViewEventListener;
         _pageViewEventSelector = pageView->_pageViewEventSelector;
-        _usingCustomScrollThreshold = pageView->_usingCustomScrollThreshold;
-        _customScrollThreshold = pageView->_customScrollThreshold;
     }
 }
 

--- a/cocos/ui/UIPageView.cpp
+++ b/cocos/ui/UIPageView.cpp
@@ -68,7 +68,7 @@ bool PageView::init()
     {
         setDirection(Direction::HORIZONTAL);
         setMagneticType(MagneticType::CENTER);
-		setScrollBarEnabled(false);
+        setScrollBarEnabled(false);
         return true;
     }
     return false;
@@ -95,32 +95,32 @@ void PageView::setDirection(PageView::Direction direction)
 
 void PageView::addWidgetToPage(Widget *widget, ssize_t pageIdx, bool forceCreate)
 {
-	insertCustomItem(widget, pageIdx);
+    insertCustomItem(widget, pageIdx);
 }
 
 void PageView::addPage(Layout* page)
 {
-	pushBackCustomItem(page);
+    pushBackCustomItem(page);
 }
 
 void PageView::insertPage(Layout* page, int idx)
 {
-	insertCustomItem(page, idx);
+    insertCustomItem(page, idx);
 }
 
 void PageView::removePage(Layout* page)
 {
-	removeItem(getIndex(page));
+    removeItem(getIndex(page));
 }
 
 void PageView::removePageAtIndex(ssize_t index)
 {
-	removeItem(index);
+    removeItem(index);
 }
     
 void PageView::removeAllPages()
 {
-	removeAllItems();
+    removeAllItems();
 }
 
 void PageView::setCurPageIndex( ssize_t index )
@@ -279,22 +279,22 @@ void PageView::addEventListener(const ccPageViewCallback& callback)
 
 ssize_t PageView::getCurPageIndex() const
 {
-	Widget* widget = ListView::getCenterItemInCurrentView();
-	return getIndex(widget);
+    Widget* widget = ListView::getCenterItemInCurrentView();
+    return getIndex(widget);
 }
 
 Vector<Layout*>& PageView::getPages()
 {
-	CCASSERT(false, "This method is obsolete!");
+    CCASSERT(false, "This method is obsolete!");
 
     // Temporary code to keep backward compatibility.
     static Vector<Layout*> pages;
-	pages.clear();
-	for(Widget* widget : getItems())
-	{
-		pages.pushBack(dynamic_cast<Layout*>(widget));
-	}
-	return pages;
+    pages.clear();
+    for(Widget* widget : getItems())
+    {
+        pages.pushBack(dynamic_cast<Layout*>(widget));
+    }
+    return pages;
 }
 
 Layout* PageView::getPage(ssize_t index)
@@ -306,11 +306,11 @@ Layout* PageView::getPage(ssize_t index)
 
     // Temporary code to keep backward compatibility.
     static Vector<Layout*> pages;
-	pages.clear();
-	for(Widget* widget : getItems())
-	{
-		pages.pushBack(dynamic_cast<Layout*>(widget));
-	}
+    pages.clear();
+    for(Widget* widget : getItems())
+    {
+        pages.pushBack(dynamic_cast<Layout*>(widget));
+    }
     return pages.at(index);
 }
 

--- a/cocos/ui/UIPageView.cpp
+++ b/cocos/ui/UIPageView.cpp
@@ -23,6 +23,7 @@ THE SOFTWARE.
 ****************************************************************************/
 
 #include "ui/UIPageView.h"
+#include "ui/UIPageViewIndicator.h"
 
 NS_CC_BEGIN
 
@@ -31,6 +32,7 @@ namespace ui {
 IMPLEMENT_CLASS_GUI_INFO(PageView)
 
 PageView::PageView():
+_indicator(nullptr),
 _customScrollThreshold(0.0),
 _usingCustomScrollThreshold(false),
 _childFocusCancelOffset(5.0f),
@@ -62,6 +64,9 @@ bool PageView::init()
 {
     if (ListView::init())
     {
+        _indicator = PageViewIndicator::create();
+        addProtectedChild(_indicator);
+        
         setDirection(ListView::Direction::HORIZONTAL);
         setMagneticType(MagneticType::CENTER);
 		setScrollBarEnabled(false);
@@ -130,6 +135,12 @@ void PageView::setUsingCustomScrollThreshold(bool flag)
 bool PageView::isUsingCustomScrollThreshold()const
 {
     return _usingCustomScrollThreshold;
+}
+
+void PageView::onSizeChanged()
+{
+    ListView::onSizeChanged();
+    _indicator->setPosition(getContentSize() / 2);
 }
 
 void PageView::handleReleaseLogic(Touch *touch)

--- a/cocos/ui/UIPageView.cpp
+++ b/cocos/ui/UIPageView.cpp
@@ -35,7 +35,6 @@ _isAutoScrolling(false),
 _autoScrollDistance(0.0f),
 _autoScrollSpeed(0.0f),
 _autoScrollDirection(AutoScrollDirection::LEFT),
-_direction(Direction::HORIZONTAL),
 _curPageIdx(-1),
 _touchMoveDirection(TouchDirection::LEFT),
 _leftBoundaryChild(nullptr),
@@ -50,6 +49,7 @@ _pageViewEventSelector(nullptr),
 _eventCallback(nullptr)
 {
     this->setTouchEnabled(true);
+    setDirection(ScrollView::Direction::HORIZONTAL);
 }
 
 PageView::~PageView()
@@ -80,15 +80,17 @@ void PageView::onEnter()
     }
 #endif
     
-    Layout::onEnter();
+    ListView::onEnter();
     scheduleUpdate();
 }
 
 bool PageView::init()
 {
-    if (Layout::init())
+    if (ListView::init())
     {
-        setClippingEnabled(true);
+        setDirection(ListView::Direction::HORIZONTAL);
+        setMagneticType(MagneticType::CENTER);
+		setScrollBarEnabled(false);
         return true;
     }
     return false;
@@ -239,7 +241,7 @@ float PageView::getPositionYByIndex(ssize_t idx)const
 
 void PageView::onSizeChanged()
 {
-    Layout::onSizeChanged();
+    ListView::onSizeChanged();
     if (_direction == Direction::HORIZONTAL)
     {
         _rightBoundary = getContentSize().width;
@@ -343,16 +345,6 @@ void PageView::scrollToPage(ssize_t idx)
     _autoScrollSpeed = fabs(_autoScrollDistance)/0.2f;
     _isAutoScrolling = true;
 }
-    
-void PageView::setDirection(cocos2d::ui::PageView::Direction direction)
-{
-    this->_direction = direction;
-}
-    
-PageView::Direction PageView::getDirection()const
-{
-    return this->_direction;
-}
 
 void PageView::update(float dt)
 {
@@ -421,13 +413,13 @@ void PageView::autoScroll(float dt)
 
 bool PageView::onTouchBegan(Touch *touch, Event *unusedEvent)
 {
-    bool pass = Layout::onTouchBegan(touch, unusedEvent);
+    bool pass = ListView::onTouchBegan(touch, unusedEvent);
     return pass;
 }
 
 void PageView::onTouchMoved(Touch *touch, Event *unusedEvent)
 {
-    Layout::onTouchMoved(touch, unusedEvent);
+    ListView::onTouchMoved(touch, unusedEvent);
     if (!_isInterceptTouch)
     {
         handleMoveLogic(touch);
@@ -436,7 +428,7 @@ void PageView::onTouchMoved(Touch *touch, Event *unusedEvent)
 
 void PageView::onTouchEnded(Touch *touch, Event *unusedEvent)
 {
-    Layout::onTouchEnded(touch, unusedEvent);
+    ListView::onTouchEnded(touch, unusedEvent);
     if (!_isInterceptTouch)
     {
         handleReleaseLogic(touch);
@@ -446,7 +438,7 @@ void PageView::onTouchEnded(Touch *touch, Event *unusedEvent)
     
 void PageView::onTouchCancelled(Touch *touch, Event *unusedEvent)
 {
-    Layout::onTouchCancelled(touch, unusedEvent);
+    ListView::onTouchCancelled(touch, unusedEvent);
     if (!_isInterceptTouch)
     {
         handleReleaseLogic(touch);
@@ -701,7 +693,7 @@ void PageView::interceptTouchEvent(TouchEventType event, Widget *sender, Touch *
 {
     if (!_touchEnabled)
     {
-        Layout::interceptTouchEvent(event, sender, touch);
+        ListView::interceptTouchEvent(event, sender, touch);
         return;
     }
     Vec2 touchPoint = touch->getLocation();
@@ -819,14 +811,13 @@ void PageView::copySpecialProperties(Widget *widget)
     PageView* pageView = dynamic_cast<PageView*>(widget);
     if (pageView)
     {
-        Layout::copySpecialProperties(widget);
+        ListView::copySpecialProperties(widget);
         _eventCallback = pageView->_eventCallback;
         _ccEventCallback = pageView->_ccEventCallback;
         _pageViewEventListener = pageView->_pageViewEventListener;
         _pageViewEventSelector = pageView->_pageViewEventSelector;
         _usingCustomScrollThreshold = pageView->_usingCustomScrollThreshold;
         _customScrollThreshold = pageView->_customScrollThreshold;
-        _direction = pageView->_direction;
     }
 }
 

--- a/cocos/ui/UIPageView.cpp
+++ b/cocos/ui/UIPageView.cpp
@@ -65,7 +65,7 @@ bool PageView::init()
     if (ListView::init())
     {
         _indicator = PageViewIndicator::create();
-        addProtectedChild(_indicator);
+        addProtectedChild(_indicator, 10000);
         
         setDirection(ListView::Direction::HORIZONTAL);
         setMagneticType(MagneticType::CENTER);
@@ -147,7 +147,7 @@ void PageView::onItemListChanged()
 void PageView::onSizeChanged()
 {
     ListView::onSizeChanged();
-    _indicator->setPosition(getContentSize() / 2);
+    _indicator->setPosition(Vec2(getContentSize() / 2) + Vec2(0, -50));
 }
 
 void PageView::handleReleaseLogic(Touch *touch)

--- a/cocos/ui/UIPageView.cpp
+++ b/cocos/ui/UIPageView.cpp
@@ -32,7 +32,6 @@ namespace ui {
 IMPLEMENT_CLASS_GUI_INFO(PageView)
 
 PageView::PageView():
-_indicatorEnabled(false),
 _indicator(nullptr),
 _indicatorPositionAsAnchorPoint(Vec2(0.5f, 0.1f)),
 _currentPageIndex(-1),
@@ -65,9 +64,6 @@ PageView* PageView::create()
     
 bool PageView::init()
 {
-    _indicator = PageViewIndicator::create();
-    addProtectedChild(_indicator, 10000);
-
     if (ListView::init())
     {
         setDirection(Direction::HORIZONTAL);
@@ -89,8 +85,12 @@ void PageView::setDirection(PageView::Direction direction)
     {
         _indicatorPositionAsAnchorPoint = Vec2(0.1f, 0.5f);
     }
-	_indicator->setDirection(direction);
-    refreshIndicatorPosition();
+
+    if(_indicator != nullptr)
+    {
+        _indicator->setDirection(direction);
+        refreshIndicatorPosition();
+    }
 }
 
 void PageView::addWidgetToPage(Widget *widget, ssize_t pageIdx, bool forceCreate)
@@ -164,14 +164,20 @@ void PageView::moveInnerContainer(const Vec2& deltaMove, bool canStartBounceBack
 {
     ListView::moveInnerContainer(deltaMove, canStartBounceBack);
     _currentPageIndex = getIndex(getCenterItemInCurrentView());
-    _indicator->indicate(_currentPageIndex);
+    if(_indicator != nullptr)
+    {
+        _indicator->indicate(_currentPageIndex);
+    }
 }
 
 void PageView::onItemListChanged()
 {
     ListView::onItemListChanged();
     ssize_t index = getIndex(getCenterItemInCurrentView());
-    _indicator->reset(_items.size(), index);
+    if(_indicator != nullptr)
+    {
+        _indicator->reset(_items.size(), index);
+    }
 }
 
 void PageView::onSizeChanged()
@@ -182,10 +188,13 @@ void PageView::onSizeChanged()
 
 void PageView::refreshIndicatorPosition()
 {
-    const Size& contentSize = getContentSize();
-    float posX = contentSize.width * _indicatorPositionAsAnchorPoint.x;
-    float posY = contentSize.height * _indicatorPositionAsAnchorPoint.y;
-    _indicator->setPosition(Vec2(posX, posY));
+    if(_indicator != nullptr)
+    {
+        const Size& contentSize = getContentSize();
+        float posX = contentSize.width * _indicatorPositionAsAnchorPoint.x;
+        float posY = contentSize.height * _indicatorPositionAsAnchorPoint.y;
+        _indicator->setPosition(Vec2(posX, posY));
+    }
 }
 
 void PageView::handleReleaseLogic(Touch *touch)
@@ -327,8 +336,23 @@ void PageView::copySpecialProperties(Widget *widget)
 
 void PageView::setIndicatorEnabled(bool enabled)
 {
-    _indicatorEnabled = enabled;
-    _indicator->setVisible(_indicatorEnabled);
+    if(enabled == (_indicator != nullptr))
+    {
+        return;
+    }
+
+    if(!enabled)
+    {
+        removeProtectedChild(_indicator);
+        _indicator = nullptr;
+    }
+    else
+    {
+        _indicator = PageViewIndicator::create();
+        addProtectedChild(_indicator, 10000);
+        setIndicatorSelectedIndexColor(Color3B(100, 100, 255));
+        refreshIndicatorPosition();
+    }
 }
 
 void PageView::setIndicatorPositionAsAnchorPoint(const Vec2& positionAsAnchorPoint)
@@ -344,33 +368,45 @@ const Vec2& PageView::getIndicatorPositionAsAnchorPoint() const
 
 void PageView::setIndicatorPosition(const Vec2& position)
 {
-    const Size& contentSize = getContentSize();
-    _indicatorPositionAsAnchorPoint.x = position.x / contentSize.width;
-    _indicatorPositionAsAnchorPoint.y = position.y / contentSize.height;
-    _indicator->setPosition(position);
+    if(_indicator != nullptr)
+    {
+        const Size& contentSize = getContentSize();
+        _indicatorPositionAsAnchorPoint.x = position.x / contentSize.width;
+        _indicatorPositionAsAnchorPoint.y = position.y / contentSize.height;
+        _indicator->setPosition(position);
+    }
 }
 
 const Vec2& PageView::getIndicatorPosition() const
 {
+    CCASSERT(_indicator != nullptr, "");
     return _indicator->getPosition();
 }
 
 void PageView::setIndicatorSpaceBetweenIndexNodes(float spaceBetweenIndexNodes)
 {
-    _indicator->setSpaceBetweenIndexNodes(spaceBetweenIndexNodes);
+    if(_indicator != nullptr)
+    {
+        _indicator->setSpaceBetweenIndexNodes(spaceBetweenIndexNodes);
+    }
 }
 float PageView::getIndicatorSpaceBetweenIndexNodes() const
 {
+    CCASSERT(_indicator != nullptr, "");
     return _indicator->getSpaceBetweenIndexNodes();
 }
 
 void PageView::setIndicatorSelectedIndexColor(const Color3B& color)
 {
-    _indicator->setSelectedIndexColor(color);
+    if(_indicator != nullptr)
+    {
+        _indicator->setSelectedIndexColor(color);
+    }
 }
 
 const Color3B& PageView::getIndicatorSelectedIndexColor() const
 {
+    CCASSERT(_indicator != nullptr, "");
     return _indicator->getSelectedIndexColor();
 }
 

--- a/cocos/ui/UIPageView.h
+++ b/cocos/ui/UIPageView.h
@@ -328,27 +328,31 @@ public:
     /**
      *@brief If you don't specify the value, the pageView will turn page when scrolling at the half width of a page.
      *@param threshold  A threshold in float.
+     *@deprecated Since v3.9, this method has no effect.
      */
-    void setCustomScrollThreshold(float threshold);
+    CC_DEPRECATED_ATTRIBUTE void setCustomScrollThreshold(float threshold);
 
     /**
      *@brief Query the custom scroll threshold of the PageView.
      *@return Custom scroll threshold in float.
+     *@deprecated Since v3.9, this method always returns 0.
      */
-    float getCustomScrollThreshold()const;
+    CC_DEPRECATED_ATTRIBUTE float getCustomScrollThreshold()const;
 
     /**
      *@brief Set using user defined scroll page threshold or not.
      * If you set it to false, then the default scroll threshold is pageView.width / 2
      *@param flag True if using custom scroll threshold, false otherwise.
+     *@deprecated Since v3.9, this method has no effect.
      */
-    void setUsingCustomScrollThreshold(bool flag);
+    CC_DEPRECATED_ATTRIBUTE void setUsingCustomScrollThreshold(bool flag);
 
     /**
      *@brief Query whether use user defined scroll page threshold or not.
      *@return True if using custom scroll threshold, false otherwise.
+     *@deprecated Since v3.9, this method always returns false.
      */
-    bool isUsingCustomScrollThreshold()const;
+    CC_DEPRECATED_ATTRIBUTE bool isUsingCustomScrollThreshold()const;
 
 CC_CONSTRUCTOR_ACCESS:
     virtual bool init() override;
@@ -371,9 +375,6 @@ protected:
     Vec2 _indicatorPositionAsAnchorPoint;
 
     ssize_t _currentPageIndex;
-
-    float _customScrollThreshold;
-    bool _usingCustomScrollThreshold;
 
     float _childFocusCancelOffset;
 

--- a/cocos/ui/UIPageView.h
+++ b/cocos/ui/UIPageView.h
@@ -121,8 +121,8 @@ public:
      * @param widget    Widget to be added to pageview.
      * @param pageIdx   A given index.
      * @param forceCreate   If `forceCreate` is true and `widget` isn't exists, pageview would create a default page and add it.
-	 *
-	 * Since v3.9, this is deprecated. Use `ListView::insertCustomItem(Widget* item, ssize_t index)` instead.
+     *
+     * Since v3.9, this is deprecated. Use `ListView::insertCustomItem(Widget* item, ssize_t index)` instead.
      */
     CC_DEPRECATED_ATTRIBUTE void addWidgetToPage(Widget* widget, ssize_t pageIdx, bool forceCreate);
     
@@ -130,8 +130,8 @@ public:
      * Insert a page into the end of PageView.
      *
      * @param page Page to be inserted.
-	 *
-	 * Since v3.9, this is deprecated. Use `ListView::pushBackCustomItem(Widget* item)` instead.
+     *
+     * Since v3.9, this is deprecated. Use `ListView::pushBackCustomItem(Widget* item)` instead.
      */
     CC_DEPRECATED_ATTRIBUTE void addPage(Layout* page);
     
@@ -140,8 +140,8 @@ public:
      *
      * @param page  Page to be inserted.
      * @param idx   A given index.
-	 *
-	 * Since v3.9, this is deprecated. Use `ListView::insertCustomItem(Widget* item, ssize_t index)` instead.
+     *
+     * Since v3.9, this is deprecated. Use `ListView::insertCustomItem(Widget* item, ssize_t index)` instead.
      */
     CC_DEPRECATED_ATTRIBUTE void insertPage(Layout* page, int idx);
     
@@ -149,35 +149,35 @@ public:
      * Remove a page of PageView.
      *
      * @param page  Page to be removed.
-	 *
-	 * Since v3.9, this is deprecated. Use `ListView::removeItem(getIndex(item))` instead.
-	 */
-	CC_DEPRECATED_ATTRIBUTE void removePage(Layout* page);
+     *
+     * Since v3.9, this is deprecated. Use `ListView::removeItem(getIndex(item))` instead.
+     */
+    CC_DEPRECATED_ATTRIBUTE void removePage(Layout* page);
 
     /**
      * Remove a page at a given index of PageView.
      *
      * @param index  A given index.
-	 *
-	 * Since v3.9, this is deprecated. Use `ListView::removeItem(ssize_t index)` instead.
-	 */
-	CC_DEPRECATED_ATTRIBUTE void removePageAtIndex(ssize_t index);
+     *
+     * Since v3.9, this is deprecated. Use `ListView::removeItem(ssize_t index)` instead.
+     */
+    CC_DEPRECATED_ATTRIBUTE void removePageAtIndex(ssize_t index);
 
     /**
      * @brief Remove all pages of the PageView.
-	 *
-	 * Since v3.9, this is deprecated. Use `ListView::removeAllItems()` instead.
-	 */
-	CC_DEPRECATED_ATTRIBUTE void removeAllPages();
+     *
+     * Since v3.9, this is deprecated. Use `ListView::removeAllItems()` instead.
+     */
+    CC_DEPRECATED_ATTRIBUTE void removeAllPages();
     
     /**
      * Scroll to a page with a given index.
      *
      * @param idx   A given index in the PageView. Index start from 0 to pageCount -1.
-	 *
-	 * Since v3.9, this is deprecated. Use `ListView::scrollToItem(ssize_t itemIndex, Vec2::ANCHOR_MIDDLE, Vec2::ANCHOR_MIDDLE)` instead.
-	 */
-	CC_DEPRECATED_ATTRIBUTE void scrollToPage(ssize_t idx);
+     *
+     * Since v3.9, this is deprecated. Use `ListView::scrollToItem(ssize_t itemIndex, Vec2::ANCHOR_MIDDLE, Vec2::ANCHOR_MIDDLE)` instead.
+     */
+    CC_DEPRECATED_ATTRIBUTE void scrollToPage(ssize_t idx);
 
     /**
      * Scroll to a page with a given index.
@@ -205,9 +205,9 @@ public:
      * This is the different between scrollToPage.
      *
      * @param index A given index in PageView. Index start from 0 to pageCount -1.
-	 *
-	 * Since v3.9, this is deprecated. Use `setCurrentPageIndex()` instead.
-	 */
+     *
+     * Since v3.9, this is deprecated. Use `setCurrentPageIndex()` instead.
+     */
     CC_DEPRECATED_ATTRIBUTE void setCurPageIndex(ssize_t index);
 
     /**
@@ -221,20 +221,20 @@ public:
     /**
      * @brief Get all the pages in the PageView.
      * @return A vector of Layout pointers.
-	 *
-	 * Since v3.9, this is obsolete. Use `Vector<Widget*>& ListView::getItems()` instead.
-	 */
-	CC_DEPRECATED_ATTRIBUTE Vector<Layout*>& getPages();
+     *
+     * Since v3.9, this is obsolete. Use `Vector<Widget*>& ListView::getItems()` instead.
+     */
+    CC_DEPRECATED_ATTRIBUTE Vector<Layout*>& getPages();
 
     /**
      * @brief Get a page at a given index
      *
      * @param index A given index.
      * @return A layout pointer in PageView container.
-	 *
-	 * Since v3.9, this is obsolete. Use `Widget* ListView::getItem(index)` instead.
-	 */
-	CC_DEPRECATED_ATTRIBUTE Layout* getPage(ssize_t index);
+     *
+     * Since v3.9, this is obsolete. Use `Widget* ListView::getItem(index)` instead.
+     */
+    CC_DEPRECATED_ATTRIBUTE Layout* getPage(ssize_t index);
     
     /**
      * Add a page turn callback to PageView, then when one page is turning, the callback will be called.

--- a/cocos/ui/UIPageView.h
+++ b/cocos/ui/UIPageView.h
@@ -258,8 +258,13 @@ public:
     void setIndicatorPosition(const Vec2& position);
     const Vec2& getIndicatorPosition() const;
 
+    void setIndicatorSpaceBetweenIndexNodes(float spaceBetweenIndexNodes);
+    float getIndicatorSpaceBetweenIndexNodes() const;
 
-    /**   
+    void setIndicatorSelectedIndexColor(const Color3B& color);
+    const Color3B& getIndicatorSelectedIndexColor() const;
+
+    /**
      *@brief If you don't specify the value, the pageView will turn page when scrolling at the half width of a page.
      *@param threshold  A threshold in float.
      */

--- a/cocos/ui/UIPageView.h
+++ b/cocos/ui/UIPageView.h
@@ -344,6 +344,9 @@ public:
 CC_CONSTRUCTOR_ACCESS:
     virtual bool init() override;
 
+    //override methods
+    virtual void doLayout() override;
+
 protected:
     void pageTurningEvent();
 

--- a/cocos/ui/UIPageView.h
+++ b/cocos/ui/UIPageView.h
@@ -122,7 +122,7 @@ public:
      * @param pageIdx   A given index.
      * @param forceCreate   If `forceCreate` is true and `widget` isn't exists, pageview would create a default page and add it.
      *
-     * Since v3.9, this is deprecated. Use `ListView::insertCustomItem(Widget* item, ssize_t index)` instead.
+     * Since v3.9, this is deprecated. Use `insertPage(Widget* page, int idx)` instead.
      */
     CC_DEPRECATED_ATTRIBUTE void addWidgetToPage(Widget* widget, ssize_t pageIdx, bool forceCreate);
     
@@ -130,54 +130,42 @@ public:
      * Insert a page into the end of PageView.
      *
      * @param page Page to be inserted.
-     *
-     * Since v3.9, this is deprecated. Use `ListView::pushBackCustomItem(Widget* item)` instead.
      */
-    CC_DEPRECATED_ATTRIBUTE void addPage(Layout* page);
-    
+    void addPage(Widget* page);
+
     /**
      * Insert a page into PageView at a given index.
      *
      * @param page  Page to be inserted.
      * @param idx   A given index.
-     *
-     * Since v3.9, this is deprecated. Use `ListView::insertCustomItem(Widget* item, ssize_t index)` instead.
      */
-    CC_DEPRECATED_ATTRIBUTE void insertPage(Layout* page, int idx);
-    
+    void insertPage(Widget* page, int idx);
+
     /**
      * Remove a page of PageView.
      *
      * @param page  Page to be removed.
-     *
-     * Since v3.9, this is deprecated. Use `ListView::removeItem(getIndex(item))` instead.
      */
-    CC_DEPRECATED_ATTRIBUTE void removePage(Layout* page);
+    void removePage(Widget* page);
 
     /**
      * Remove a page at a given index of PageView.
      *
      * @param index  A given index.
-     *
-     * Since v3.9, this is deprecated. Use `ListView::removeItem(ssize_t index)` instead.
      */
-    CC_DEPRECATED_ATTRIBUTE void removePageAtIndex(ssize_t index);
+    void removePageAtIndex(ssize_t index);
 
     /**
      * @brief Remove all pages of the PageView.
-     *
-     * Since v3.9, this is deprecated. Use `ListView::removeAllItems()` instead.
      */
-    CC_DEPRECATED_ATTRIBUTE void removeAllPages();
+    void removeAllPages();
     
     /**
      * Scroll to a page with a given index.
      *
      * @param idx   A given index in the PageView. Index start from 0 to pageCount -1.
-     *
-     * Since v3.9, this is deprecated. Use `ListView::scrollToItem(ssize_t itemIndex, Vec2::ANCHOR_MIDDLE, Vec2::ANCHOR_MIDDLE)` instead.
      */
-    CC_DEPRECATED_ATTRIBUTE void scrollToPage(ssize_t idx);
+    void scrollToPage(ssize_t idx);
 
     /**
      * Scroll to a page with a given index.
@@ -244,7 +232,6 @@ public:
      */
     CC_DEPRECATED_ATTRIBUTE void addEventListenerPageView(Ref *target, SEL_PageViewEvent selector);
 
-    
     /**
      * @brief Add a page turn callback to PageView, then when one page is turning, the callback will be called.
      *

--- a/cocos/ui/UIPageView.h
+++ b/cocos/ui/UIPageView.h
@@ -256,6 +256,7 @@ CC_CONSTRUCTOR_ACCESS:
 protected:
     void pageTurningEvent();
 
+    virtual void onItemListChanged() override;
     virtual void onSizeChanged() override;
     virtual void handleReleaseLogic(Touch *touch) override;
 

--- a/cocos/ui/UIPageView.h
+++ b/cocos/ui/UIPageView.h
@@ -241,6 +241,14 @@ public:
     //override methods
     virtual std::string getDescription() const override;
 
+
+    void setIndicatorPositionAsAnchorPoint(const Vec2& positionAsAnchorPoint);
+    const Vec2& getIndicatorPositionAsAnchorPoint() const;
+
+    void setIndicatorPosition(const Vec2& position);
+    const Vec2& getIndicatorPosition() const;
+
+
     /**   
      *@brief If you don't specify the value, the pageView will turn page when scrolling at the half width of a page.
      *@param threshold  A threshold in float.
@@ -280,8 +288,11 @@ protected:
     virtual Widget* createCloneInstance() override;
     virtual void copySpecialProperties(Widget* model) override;
 
+    void refreshIndicatorPosition();
+
 protected:
     PageViewIndicator* _indicator;
+    Vec2 _indicatorPositionAsAnchorPoint;
 
     ssize_t _currentPageIndex;
 

--- a/cocos/ui/UIPageView.h
+++ b/cocos/ui/UIPageView.h
@@ -260,7 +260,7 @@ public:
      *
      * @return True if page indicator is enabled, false otherwise.
      */
-    bool getIndicatorEnabled() const { return _indicatorEnabled; }
+    bool getIndicatorEnabled() const { return _indicator != nullptr; }
 
     /**
      * @brief Set the page indicator's position using anchor point.
@@ -360,7 +360,6 @@ protected:
     void refreshIndicatorPosition();
 
 protected:
-    bool _indicatorEnabled;
     PageViewIndicator* _indicator;
     Vec2 _indicatorPositionAsAnchorPoint;
 

--- a/cocos/ui/UIPageView.h
+++ b/cocos/ui/UIPageView.h
@@ -180,6 +180,13 @@ public:
 	CC_DEPRECATED_ATTRIBUTE void scrollToPage(ssize_t idx);
 
     /**
+     * Scroll to a page with a given index.
+     *
+     * @param idx   A given index in the PageView. Index start from 0 to pageCount -1.
+     */
+    void scrollToItem(ssize_t itemIndex);
+
+    /**
      * Gets current displayed page index.
      * @return current page index.
      *

--- a/cocos/ui/UIPageView.h
+++ b/cocos/ui/UIPageView.h
@@ -25,7 +25,7 @@ THE SOFTWARE.
 #ifndef __UIPAGEVIEW_H__
 #define __UIPAGEVIEW_H__
 
-#include "ui/UILayout.h"
+#include "ui/UIListView.h"
 #include "ui/GUIExport.h"
 
 /**
@@ -56,7 +56,7 @@ typedef void (Ref::*SEL_PageViewEvent)(Ref*, PageViewEventType);
  *@brief Layout manager that allows the user to flip left & right and up & down through pages of data.
  *
  */
-class CC_GUI_DLL PageView : public Layout
+class CC_GUI_DLL PageView : public ListView
 {
     
     DECLARE_CLASS_GUI_INFO
@@ -80,15 +80,9 @@ public:
         UP,
         DOWN
     };
-    
-    enum class Direction
-    {
-        HORIZONTAL,
-        VERTICAL
-    };
-    
+
     /**
-     *PageView page turn event callback.
+     * PageView page turn event callback.
      */
     typedef std::function<void(Ref*,EventType)> ccPageViewCallback;
 
@@ -150,24 +144,6 @@ public:
      */
     void removePageAtIndex(ssize_t index);
 
-    /**
-     * Changes scroll direction of PageView
-     *
-     * @see `Direction`
-     * @param direction Scroll direction enum.
-     * @since v3.8
-     */
-    void setDirection(Direction direction);
-
-    /**
-     * Query scroll direction of PageView.
-     *
-     * @see `Direction`
-     * @since v3.8
-     * @return PageView scroll direction.
-     */
-    Direction getDirection()const;
-    
     /**
      * @brief Remove all pages of the PageView.
      */
@@ -307,8 +283,7 @@ protected:
     float _autoScrollDistance;
     float _autoScrollSpeed;
     AutoScrollDirection _autoScrollDirection;
-    Direction _direction;
-    
+
     ssize_t _curPageIdx;
     Vector<Layout*> _pages;
 

--- a/cocos/ui/UIPageView.h
+++ b/cocos/ui/UIPageView.h
@@ -84,7 +84,7 @@ public:
     /**
      * PageView page turn event callback.
      */
-    typedef std::function<void(Ref*,EventType)> ccPageViewCallback;
+    typedef std::function<void(Ref*, EventType)> ccPageViewCallback;
 
     /**
      * Default constructor
@@ -112,50 +112,63 @@ public:
      * @param widget    Widget to be added to pageview.
      * @param pageIdx   A given index.
      * @param forceCreate   If `forceCreate` is true and `widget` isn't exists, pageview would create a default page and add it.
+	 *
+	 * Since v3.9, this is deprecated. Use `ListView::insertCustomItem(Widget* item, ssize_t index)` instead.
      */
-    void addWidgetToPage(Widget* widget, ssize_t pageIdx, bool forceCreate);
+    CC_DEPRECATED_ATTRIBUTE void addWidgetToPage(Widget* widget, ssize_t pageIdx, bool forceCreate);
     
     /**
      * Insert a page into the end of PageView.
      *
      * @param page Page to be inserted.
+	 *
+	 * Since v3.9, this is deprecated. Use `ListView::pushBackCustomItem(Widget* item)` instead.
      */
-    void addPage(Layout* page);
+    CC_DEPRECATED_ATTRIBUTE void addPage(Layout* page);
     
     /**
      * Insert a page into PageView at a given index.
      *
      * @param page  Page to be inserted.
      * @param idx   A given index.
+	 *
+	 * Since v3.9, this is deprecated. Use `ListView::insertCustomItem(Widget* item, ssize_t index)` instead.
      */
-    void insertPage(Layout* page, int idx);
+    CC_DEPRECATED_ATTRIBUTE void insertPage(Layout* page, int idx);
     
     /**
      * Remove a page of PageView.
      *
      * @param page  Page to be removed.
-     */
-    void removePage(Layout* page);
+	 *
+	 * Since v3.9, this is deprecated. Use `ListView::removeItem(getIndex(item))` instead.
+	 */
+	CC_DEPRECATED_ATTRIBUTE void removePage(Layout* page);
 
     /**
      * Remove a page at a given index of PageView.
      *
      * @param index  A given index.
-     */
-    void removePageAtIndex(ssize_t index);
+	 *
+	 * Since v3.9, this is deprecated. Use `ListView::removeItem(ssize_t index)` instead.
+	 */
+	CC_DEPRECATED_ATTRIBUTE void removePageAtIndex(ssize_t index);
 
     /**
      * @brief Remove all pages of the PageView.
-     */
-    void removeAllPages();
+	 *
+	 * Since v3.9, this is deprecated. Use `ListView::removeAllItems()` instead.
+	 */
+	CC_DEPRECATED_ATTRIBUTE void removeAllPages();
     
     /**
      * Scroll to a page with a given index.
      *
      * @param idx   A given index in the PageView. Index start from 0 to pageCount -1.
-     */
-    void scrollToPage(ssize_t idx);
-
+	 *
+	 * Since v3.9, this is deprecated. Use `ListView::scrollToItem(ssize_t itemIndex, Vec2::ANCHOR_MIDDLE, Vec2::ANCHOR_MIDDLE)` instead.
+	 */
+	CC_DEPRECATED_ATTRIBUTE void scrollToPage(ssize_t idx);
 
     /**
      * Gets current displayed page index.
@@ -168,23 +181,28 @@ public:
      * This is the different between scrollToPage.
      *
      * @param index A given index in PageView. Index start from 0 to pageCount -1.
-     */
-    void setCurPageIndex(ssize_t index);
-     
+	 *
+	 * Since v3.9, this is deprecated. Use `ListView::jumpToItem(ssize_t itemIndex, Vec2::ANCHOR_MIDDLE, Vec2::ANCHOR_MIDDLE)` instead.
+	 */
+	CC_DEPRECATED_ATTRIBUTE void setCurPageIndex(ssize_t index);
+
     /**
      * @brief Get all the pages in the PageView.
      * @return A vector of Layout pointers.
-     */
-    Vector<Layout*>& getPages();
-    
-    
+	 *
+	 * Since v3.9, this is obsolete. Use `Vector<Widget*>& ListView::getItems()` instead.
+	 */
+	CC_DEPRECATED_ATTRIBUTE Vector<Layout*>& getPages();
+
     /**
      * @brief Get a page at a given index
      *
      * @param index A given index.
      * @return A layout pointer in PageView container.
-     */
-    Layout* getPage(ssize_t index);
+	 *
+	 * Since v3.9, this is obsolete. Use `Widget* ListView::getItem(index)` instead.
+	 */
+	CC_DEPRECATED_ATTRIBUTE Layout* getPage(ssize_t index);
     
     /**
      * Add a page turn callback to PageView, then when one page is turning, the callback will be called.
@@ -203,18 +221,7 @@ public:
     void addEventListener(const ccPageViewCallback& callback);
     
     //override methods
-    virtual bool onTouchBegan(Touch *touch, Event *unusedEvent) override;
-    virtual void onTouchMoved(Touch *touch, Event *unusedEvent) override;
-    virtual void onTouchEnded(Touch *touch, Event *unusedEvent) override;
-    virtual void onTouchCancelled(Touch *touch, Event *unusedEvent) override;
-    virtual void update(float dt) override;
-    virtual void setLayoutType(Type type) override{};
-    virtual Type getLayoutType() const override{return Type::ABSOLUTE;};
     virtual std::string getDescription() const override;
-    /**
-     * @lua NA
-     */
-    virtual void onEnter() override;
 
     /**   
      *@brief If you don't specify the value, the pageView will turn page when scrolling at the half width of a page.
@@ -245,55 +252,14 @@ CC_CONSTRUCTOR_ACCESS:
     virtual bool init() override;
 
 protected:
-
-    Layout* createPage();
-    float getPositionXByIndex(ssize_t idx)const;
-    float getPositionYByIndex(ssize_t idx)const;
-    ssize_t getPageCount()const;
-
-    void updateBoundaryPages();
-    virtual bool scrollPages(Vec2 touchOffset);
-    void movePages(Vec2 offset);
     void pageTurningEvent();
-    void updateAllPagesSize();
-    void updateAllPagesPosition();
-    void autoScroll(float dt);
 
-    virtual void handleMoveLogic(Touch *touch) ;
-    virtual void handleReleaseLogic(Touch *touch) ;
-    virtual void interceptTouchEvent(TouchEventType event, Widget* sender,Touch *touch) override;
-    
-    
-    virtual void onSizeChanged() override;
+    virtual void handleReleaseLogic(Touch *touch) override;
+
     virtual Widget* createCloneInstance() override;
     virtual void copySpecialProperties(Widget* model) override;
-    virtual void copyClonedWidgetChildren(Widget* model) override;
-
-    virtual void doLayout() override;
 
 protected:
-    enum class AutoScrollDirection
-    {
-        LEFT,
-        RIGHT,
-        UP,
-        DOWN
-    };
-    bool _isAutoScrolling;
-    float _autoScrollDistance;
-    float _autoScrollSpeed;
-    AutoScrollDirection _autoScrollDirection;
-
-    ssize_t _curPageIdx;
-    Vector<Layout*> _pages;
-
-    TouchDirection _touchMoveDirection;
-   
-    Widget* _leftBoundaryChild;
-    Widget* _rightBoundaryChild;
-    
-    float _leftBoundary;
-    float _rightBoundary;
     float _customScrollThreshold;
     bool _usingCustomScrollThreshold;
 

--- a/cocos/ui/UIPageView.h
+++ b/cocos/ui/UIPageView.h
@@ -248,20 +248,74 @@ public:
     //override methods
     virtual std::string getDescription() const override;
 
+    /**
+     * @brief Toggle page indicator enabled.
+     *
+     * @param enabled True if enable page indicator, false otherwise.
+     */
     void setIndicatorEnabled(bool enabled);
 
+    /**
+     * @brief Query page indicator state.
+     *
+     * @return True if page indicator is enabled, false otherwise.
+     */
     bool getIndicatorEnabled() const { return _indicatorEnabled; }
 
+    /**
+     * @brief Set the page indicator's position using anchor point.
+     *
+     * @param positionAsAnchorPoint The position as anchor point.
+     */
     void setIndicatorPositionAsAnchorPoint(const Vec2& positionAsAnchorPoint);
+
+    /**
+     * @brief Get the page indicator's position as anchor point.
+     *
+     * @return positionAsAnchorPoint
+     */
     const Vec2& getIndicatorPositionAsAnchorPoint() const;
 
+    /**
+     * @brief Set the page indicator's position in page view.
+     *
+     * @param position The position in page view
+     */
     void setIndicatorPosition(const Vec2& position);
+    
+    /**
+     * @brief Get the page indicator's position.
+     *
+     * @return positionAsAnchorPoint
+     */
     const Vec2& getIndicatorPosition() const;
 
+    /**
+     * @brief Set space between page indicator's index nodes.
+     *
+     * @param spaceBetweenIndexNodes Space between nodes in pixel.
+     */
     void setIndicatorSpaceBetweenIndexNodes(float spaceBetweenIndexNodes);
+
+    /**
+     * @brief Get the space between page indicator's index nodes.
+     *
+     * @return spaceBetweenIndexNodes
+     */
     float getIndicatorSpaceBetweenIndexNodes() const;
 
+    /**
+     * @brief Set color of page indicator's selected index.
+     *
+     * @param spaceBetweenIndexNodes Space between nodes in pixel.
+     */
     void setIndicatorSelectedIndexColor(const Color3B& color);
+
+    /**
+     * @brief Get the color of page indicator's selected index.
+     *
+     * @return color
+     */
     const Color3B& getIndicatorSelectedIndexColor() const;
 
     /**

--- a/cocos/ui/UIPageView.h
+++ b/cocos/ui/UIPageView.h
@@ -107,7 +107,14 @@ public:
      *@return A PageView instance.
      */
     static PageView* create();
-    
+
+    /**
+     * Changes direction
+     *  Direction Direction::VERTICAL means vertical scroll, Direction::HORIZONTAL means horizontal scroll.
+     * @param direction Set the page view's scroll direction.
+     */
+    virtual void setDirection(Direction direction) override;
+
     /**
      * Add a widget as a page of PageView in a given index.
      *
@@ -241,6 +248,9 @@ public:
     //override methods
     virtual std::string getDescription() const override;
 
+    void setIndicatorEnabled(bool enabled);
+
+    bool getIndicatorEnabled() const { return _indicatorEnabled; }
 
     void setIndicatorPositionAsAnchorPoint(const Vec2& positionAsAnchorPoint);
     const Vec2& getIndicatorPositionAsAnchorPoint() const;
@@ -291,6 +301,7 @@ protected:
     void refreshIndicatorPosition();
 
 protected:
+    bool _indicatorEnabled;
     PageViewIndicator* _indicator;
     Vec2 _indicatorPositionAsAnchorPoint;
 

--- a/cocos/ui/UIPageView.h
+++ b/cocos/ui/UIPageView.h
@@ -175,8 +175,16 @@ public:
     /**
      * Gets current displayed page index.
      * @return current page index.
+     *
+     * Since v3.9, this is deprecated. Use `getCurrentPageIndex()` instead.
      */
-    ssize_t getCurPageIndex() const;
+    CC_DEPRECATED_ATTRIBUTE ssize_t getCurPageIndex() const;
+
+    /**
+     * Gets current displayed page index.
+     * @return current page index.
+     */
+    ssize_t getCurrentPageIndex() const { return _currentPageIndex; }
 
     /**
      * Jump to a page with a given index without scrolling.
@@ -184,9 +192,17 @@ public:
      *
      * @param index A given index in PageView. Index start from 0 to pageCount -1.
 	 *
-	 * Since v3.9, this is deprecated. Use `ListView::jumpToItem(ssize_t itemIndex, Vec2::ANCHOR_MIDDLE, Vec2::ANCHOR_MIDDLE)` instead.
+	 * Since v3.9, this is deprecated. Use `setCurrentPageIndex()` instead.
 	 */
-	CC_DEPRECATED_ATTRIBUTE void setCurPageIndex(ssize_t index);
+    CC_DEPRECATED_ATTRIBUTE void setCurPageIndex(ssize_t index);
+
+    /**
+     * Jump to a page with a given index without scrolling.
+     * This is the different between scrollToPage.
+     *
+     * @param index A given index in PageView. Index start from 0 to pageCount -1.
+     */
+    void setCurrentPageIndex(ssize_t index);
 
     /**
      * @brief Get all the pages in the PageView.
@@ -256,6 +272,7 @@ CC_CONSTRUCTOR_ACCESS:
 protected:
     void pageTurningEvent();
 
+    virtual void moveInnerContainer(const Vec2& deltaMove, bool canStartBounceBack) override;
     virtual void onItemListChanged() override;
     virtual void onSizeChanged() override;
     virtual void handleReleaseLogic(Touch *touch) override;
@@ -265,6 +282,8 @@ protected:
 
 protected:
     PageViewIndicator* _indicator;
+
+    ssize_t _currentPageIndex;
 
     float _customScrollThreshold;
     bool _usingCustomScrollThreshold;

--- a/cocos/ui/UIPageView.h
+++ b/cocos/ui/UIPageView.h
@@ -36,6 +36,8 @@ NS_CC_BEGIN
 
 namespace ui {
 
+class PageViewIndicator;
+
 /**
  *PageView page turn event type.
  *@deprecated Use `PageView::EventType` instead.
@@ -254,12 +256,15 @@ CC_CONSTRUCTOR_ACCESS:
 protected:
     void pageTurningEvent();
 
+    virtual void onSizeChanged() override;
     virtual void handleReleaseLogic(Touch *touch) override;
 
     virtual Widget* createCloneInstance() override;
     virtual void copySpecialProperties(Widget* model) override;
 
 protected:
+    PageViewIndicator* _indicator;
+
     float _customScrollThreshold;
     bool _usingCustomScrollThreshold;
 

--- a/cocos/ui/UIPageViewIndicator.cpp
+++ b/cocos/ui/UIPageViewIndicator.cpp
@@ -26,7 +26,7 @@ THE SOFTWARE.
 #include "2d/CCSprite.h"
 #include "base/ccUtils.h"
 
-static const char* CIRCLE_IMAGE = "iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAMAAAAoLQ9TAAAATlBMVEX///////////////////////////////////////////////////////////////////////////////////////////////////////+QPFRFAAAAGXRSTlMAFBYXUFVWf4GEhYjNz9DR0u/x8vP09fj+spJk/AAAAGFJREFUeNptzkkOgCAMQNGCgoAToEz3v6iVNNoY364/aQF+CbOltEwCyBhaF0aaayO1FxHbI95bpjEOw8qDx1B4KN9wYti/K5aHGYNkzx4SkHo/pqDTJ13UQAbrc/ZugD8XjW0OTSlBlOwAAAAASUVORK5CYII=";
+static const char* CIRCLE_IMAGE = "iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAQAAADZc7J/AAAA8ElEQVRIx62VyRGCQBBF+6gWRCEmYDIQkhiBCgHhSclC8YqWzOV5oVzKAYZp3r1/9fpbxAIBMTsKrjx5cqVgR0wgLhCRUWOjJiPqD56xoaGPhpRZV/iSEy6crHmw5oIrF9b/lVeMofrJgjlnxlIy/wik+JB+mme8BExbBhm+5CJC2LE2LtSEQoyGWDioBA5CoRIohJtK4CYDxzNEM4GAugR1E9VjVC+SZpXvhCJCrjomESLvc17pDGX7bWmlh6UtpjPVCWy9zaJ0TD7qfm3pwERMz2trRVZk3K3BD/L34AY+dEDCniMVBkPFkT2J/b2/AIV+dRpFLOYoAAAAAElFTkSuQmCC";
 
 NS_CC_BEGIN
 
@@ -61,7 +61,7 @@ bool PageViewIndicator::init()
 {
     _currentIndexNode = (Node*) utils::createSpriteFromBase64(CIRCLE_IMAGE);
     _currentIndexNode->setVisible(false);
-    addProtectedChild(_currentIndexNode);
+    addProtectedChild(_currentIndexNode, 1);
     return true;
 }
 
@@ -141,7 +141,7 @@ void PageViewIndicator::setSpaceBetweenIndexNodes(float spaceBetweenIndexNodes)
 void PageViewIndicator::increaseNumberOfPages()
 {
     Sprite* indexNode = utils::createSpriteFromBase64(CIRCLE_IMAGE);
-    indexNode->setOpacity(255 * 0.3f);
+//    indexNode->setOpacity(255 * 0.3f);
     addProtectedChild(indexNode);
     _indexNodes.pushBack(indexNode);
 }

--- a/cocos/ui/UIPageViewIndicator.cpp
+++ b/cocos/ui/UIPageViewIndicator.cpp
@@ -47,7 +47,8 @@ PageViewIndicator* PageViewIndicator::create()
 }
 
 PageViewIndicator::PageViewIndicator()
-: _currentIndexNode(nullptr)
+: _direction(PageView::Direction::HORIZONTAL)
+, _currentIndexNode(nullptr)
 , _spaceBetweenIndexNodes(SPACE_BETWEEN_INDEX_NODES_DEFAULT)
 {
 }
@@ -62,6 +63,12 @@ bool PageViewIndicator::init()
     _currentIndexNode->setVisible(false);
     addProtectedChild(_currentIndexNode);
     return true;
+}
+
+void PageViewIndicator::setDirection(PageView::Direction direction)
+{
+    _direction = direction;
+    rearrange();
 }
 
 void PageViewIndicator::reset(ssize_t numberOfTotalPages, ssize_t currentIndex)
@@ -95,8 +102,7 @@ void PageViewIndicator::rearrange()
         return;
     }
 
-//    bool bHorizon = m_eContainerDirection == CONTAINER_HORIZONTAL;
-    bool horizontal = true;
+    bool horizontal = (_direction == PageView::Direction::HORIZONTAL);
 
     // Calculate total size
     Size indexNodeSize = _indexNodes.at(0)->getContentSize();

--- a/cocos/ui/UIPageViewIndicator.cpp
+++ b/cocos/ui/UIPageViewIndicator.cpp
@@ -71,7 +71,7 @@ void PageViewIndicator::setDirection(PageView::Direction direction)
     rearrange();
 }
 
-void PageViewIndicator::reset(ssize_t numberOfTotalPages, ssize_t currentIndex)
+void PageViewIndicator::reset(ssize_t numberOfTotalPages)
 {
     while(_indexNodes.size() < numberOfTotalPages)
     {
@@ -82,7 +82,6 @@ void PageViewIndicator::reset(ssize_t numberOfTotalPages, ssize_t currentIndex)
         decreaseNumberOfPages();
     }
     rearrange();
-    indicate(currentIndex);
     _currentIndexNode->setVisible(!_indexNodes.empty());
 }
 

--- a/cocos/ui/UIPageViewIndicator.cpp
+++ b/cocos/ui/UIPageViewIndicator.cpp
@@ -120,7 +120,7 @@ void PageViewIndicator::rearrange()
         }
         else
         {
-            position = Vec2(indexNodeSize.width / 2.0f, posValue);
+            position = Vec2(indexNodeSize.width / 2.0f, -posValue);
         }
         indexNode->setPosition(position);
         posValue += sizeValue + _spaceBetweenIndexNodes;

--- a/cocos/ui/UIPageViewIndicator.cpp
+++ b/cocos/ui/UIPageViewIndicator.cpp
@@ -1,0 +1,43 @@
+/****************************************************************************
+Copyright (c) 2015 Neo Kim (neo.kim@neofect.com)
+
+http://www.cocos2d-x.org
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+****************************************************************************/
+
+#include "UIPageViewIndicator.h"
+
+NS_CC_BEGIN
+
+namespace ui {
+
+UIPageViewIndicator::UIPageViewIndicator()
+{
+
+}
+
+UIPageViewIndicator::~UIPageViewIndicator()
+{
+
+}
+
+}
+
+NS_CC_END

--- a/cocos/ui/UIPageViewIndicator.cpp
+++ b/cocos/ui/UIPageViewIndicator.cpp
@@ -23,19 +23,128 @@ THE SOFTWARE.
 ****************************************************************************/
 
 #include "UIPageViewIndicator.h"
+#include "2d/CCSprite.h"
+#include "base/ccUtils.h"
+
+static const char* CIRCLE_IMAGE = "iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAMAAAAoLQ9TAAAATlBMVEX///////////////////////////////////////////////////////////////////////////////////////////////////////+QPFRFAAAAGXRSTlMAFBYXUFVWf4GEhYjNz9DR0u/x8vP09fj+spJk/AAAAGFJREFUeNptzkkOgCAMQNGCgoAToEz3v6iVNNoY364/aQF+CbOltEwCyBhaF0aaayO1FxHbI95bpjEOw8qDx1B4KN9wYti/K5aHGYNkzx4SkHo/pqDTJ13UQAbrc/ZugD8XjW0OTSlBlOwAAAAASUVORK5CYII=";
 
 NS_CC_BEGIN
 
+static const float SPACE_BETWEEN_INDEX_NODES_DEFAULT = 23;
+
 namespace ui {
 
-UIPageViewIndicator::UIPageViewIndicator()
+PageViewIndicator* PageViewIndicator::create()
 {
+    PageViewIndicator* node = new (std::nothrow) PageViewIndicator();
+    if (node && node->init())
+    {
+        node->autorelease();
+        return node;
+    }
+    CC_SAFE_DELETE(node);
+    return nullptr;
+}
+
+PageViewIndicator::PageViewIndicator()
+: _currentIndexNode(nullptr)
+, _spaceBetweenIndexNodes(SPACE_BETWEEN_INDEX_NODES_DEFAULT)
+{
+}
+
+PageViewIndicator::~PageViewIndicator()
+{
+}
+
+bool PageViewIndicator::init()
+{
+    _currentIndexNode = (Node*) utils::createSpriteFromBase64(CIRCLE_IMAGE);
+    _currentIndexNode->setVisible(false);
+    addProtectedChild(_currentIndexNode);
+    return true;
+}
+
+void PageViewIndicator::indicate(int index)
+{
+    CCASSERT(index >= 0 && index < _indexNodes.size(), "");
+    _currentIndexNode->setPosition(_indexNodes.at(index)->getPosition());
+}
+
+void PageViewIndicator::rearrange()
+{
+    if(_indexNodes.empty())
+    {
+        return;
+    }
+
+//    bool bHorizon = m_eContainerDirection == CONTAINER_HORIZONTAL;
+    bool horizontal = true;
+
+    // Positions
+    Size indexNodeSize = _indexNodes.at(0)->getContentSize();
+    float sizeValue = (horizontal ? indexNodeSize.width : indexNodeSize.height);
+
+    float posValue = -sizeValue / 2;
+    for(auto indexNode : _indexNodes) {
+        posValue += sizeValue + _spaceBetweenIndexNodes;
+        Vec2 position;
+        if(horizontal)
+        {
+            position = Vec2(posValue, indexNodeSize.height / 2.0f);
+        }
+        else
+        {
+            position = Vec2(indexNodeSize.width / 2.0f, posValue);
+        }
+        indexNode->setPosition(position);
+    }
 
 }
 
-UIPageViewIndicator::~UIPageViewIndicator()
+void PageViewIndicator::setSpaceBetweenIndexNodes(float spaceBetweenIndexNodes)
 {
+    if(_spaceBetweenIndexNodes == spaceBetweenIndexNodes)
+    {
+        return;
+    }
+    _spaceBetweenIndexNodes = spaceBetweenIndexNodes;
+    rearrange();
+}
 
+void PageViewIndicator::increaseNumberOfPages()
+{
+    Sprite* indexNode = utils::createSpriteFromBase64(CIRCLE_IMAGE);
+    indexNode->setOpacity(255 * 0.3f);
+    addProtectedChild(indexNode);
+    _indexNodes.pushBack(indexNode);
+    rearrange();
+
+    if(_indexNodes.size() == 1) {
+        _currentIndexNode->setVisible(true);
+        indicate(0);
+    }
+}
+
+void PageViewIndicator::decreaseNumberOfPages()
+{
+    (*(_indexNodes.end() - 1))->removeFromParent();
+    _indexNodes.erase(_indexNodes.end() - 1);
+    rearrange();
+
+    if(_indexNodes.empty())
+    {
+        _currentIndexNode->setVisible(false);
+    }
+}
+
+void PageViewIndicator::clear()
+{
+    for(auto indexNode : _indexNodes)
+    {
+        removeProtectedChild(indexNode);
+    }
+    _indexNodes.clear();
+    _currentIndexNode->setVisible(false);
 }
 
 }

--- a/cocos/ui/UIPageViewIndicator.h
+++ b/cocos/ui/UIPageViewIndicator.h
@@ -25,7 +25,7 @@ THE SOFTWARE.
 #ifndef __UIPAGEVIEWINDICATOR_H__
 #define __UIPAGEVIEWINDICATOR_H__
 
-#include "2d/CCProtectedNode.h"
+#include "UIPageView.h"
 
 NS_CC_BEGIN
 /**
@@ -48,6 +48,7 @@ public:
     PageViewIndicator();
     virtual ~PageViewIndicator();
 
+    void setDirection(PageView::Direction direction);
     void reset(ssize_t numberOfTotalPages, ssize_t currentIndex);
     void indicate(ssize_t index);
     void clear();
@@ -59,6 +60,7 @@ protected:
     void decreaseNumberOfPages();
     void rearrange();
 
+    PageView::Direction _direction;
     Vector<Node*> _indexNodes;
     Node* _currentIndexNode;
     float _spaceBetweenIndexNodes;

--- a/cocos/ui/UIPageViewIndicator.h
+++ b/cocos/ui/UIPageViewIndicator.h
@@ -48,14 +48,15 @@ public:
     PageViewIndicator();
     virtual ~PageViewIndicator();
 
-    void indicate(int index);
-    void increaseNumberOfPages();
-    void decreaseNumberOfPages();
+    void reset(ssize_t numberOfTotalPages, ssize_t currentIndex);
+    void indicate(ssize_t index);
     void clear();
     void setSpaceBetweenIndexNodes(float fSpaceBetweenIndexNodes);
 
 protected:
     bool init() override;
+    void increaseNumberOfPages();
+    void decreaseNumberOfPages();
     void rearrange();
 
     Vector<Node*> _indexNodes;

--- a/cocos/ui/UIPageViewIndicator.h
+++ b/cocos/ui/UIPageViewIndicator.h
@@ -49,7 +49,7 @@ public:
     virtual ~PageViewIndicator();
 
     void setDirection(PageView::Direction direction);
-    void reset(ssize_t numberOfTotalPages, ssize_t currentIndex);
+    void reset(ssize_t numberOfTotalPages);
     void indicate(ssize_t index);
     void clear();
     void setSpaceBetweenIndexNodes(float spaceBetweenIndexNodes);

--- a/cocos/ui/UIPageViewIndicator.h
+++ b/cocos/ui/UIPageViewIndicator.h
@@ -25,6 +25,8 @@ THE SOFTWARE.
 #ifndef __UIPAGEVIEWINDICATOR_H__
 #define __UIPAGEVIEWINDICATOR_H__
 
+#include "2d/CCProtectedNode.h"
+
 NS_CC_BEGIN
 /**
  * @addtogroup ui
@@ -33,12 +35,32 @@ NS_CC_BEGIN
 
 namespace ui {
 
-class UIPageViewIndicator
+class PageViewIndicator : public ProtectedNode
 {
 
 public:
-    UIPageViewIndicator();
-    virtual ~UIPageViewIndicator();
+    /**
+     * Create a page view indicator with its parent page view.
+     * @return A page view indicator instance.
+     */
+    static PageViewIndicator* create();
+
+    PageViewIndicator();
+    virtual ~PageViewIndicator();
+
+    void indicate(int index);
+    void increaseNumberOfPages();
+    void decreaseNumberOfPages();
+    void clear();
+    void setSpaceBetweenIndexNodes(float fSpaceBetweenIndexNodes);
+
+protected:
+    bool init() override;
+    void rearrange();
+
+    Vector<Node*> _indexNodes;
+    Node* _currentIndexNode;
+    float _spaceBetweenIndexNodes;
 
 };
 

--- a/cocos/ui/UIPageViewIndicator.h
+++ b/cocos/ui/UIPageViewIndicator.h
@@ -1,0 +1,50 @@
+/****************************************************************************
+Copyright (c) 2015 Neo Kim (neo.kim@neofect.com)
+
+http://www.cocos2d-x.org
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+****************************************************************************/
+
+#ifndef __UIPAGEVIEWINDICATOR_H__
+#define __UIPAGEVIEWINDICATOR_H__
+
+NS_CC_BEGIN
+/**
+ * @addtogroup ui
+ * @{
+ */
+
+namespace ui {
+
+class UIPageViewIndicator
+{
+
+public:
+    UIPageViewIndicator();
+    virtual ~UIPageViewIndicator();
+
+};
+
+}
+// end of ui group
+/// @}
+NS_CC_END
+
+#endif /* defined(__UIPAGEVIEWINDICATOR_H__) */

--- a/cocos/ui/UIPageViewIndicator.h
+++ b/cocos/ui/UIPageViewIndicator.h
@@ -52,7 +52,10 @@ public:
     void reset(ssize_t numberOfTotalPages, ssize_t currentIndex);
     void indicate(ssize_t index);
     void clear();
-    void setSpaceBetweenIndexNodes(float fSpaceBetweenIndexNodes);
+    void setSpaceBetweenIndexNodes(float spaceBetweenIndexNodes);
+    float getSpaceBetweenIndexNodes() const { return _spaceBetweenIndexNodes; }
+    void setSelectedIndexColor(const Color3B& color) { _currentIndexNode->setColor(color); }
+    const Color3B& getSelectedIndexColor() const { return _currentIndexNode->getColor(); }
 
 protected:
     bool init() override;

--- a/cocos/ui/UIScrollView.cpp
+++ b/cocos/ui/UIScrollView.cpp
@@ -570,7 +570,7 @@ void ScrollView::jumpToDestination(const Vec2 &des)
     moveInnerContainer(des - getInnerContainerPosition(), true);
 }
 
-bool ScrollView::scrollChildren(float touchOffsetX, float touchOffsetY)
+void ScrollView::scrollChildren(float touchOffsetX, float touchOffsetY)
 {
     touchOffsetX = (_direction == Direction::VERTICAL ? 0 : touchOffsetX);
     touchOffsetY = (_direction == Direction::HORIZONTAL ? 0 : touchOffsetY);
@@ -659,10 +659,6 @@ bool ScrollView::scrollChildren(float touchOffsetX, float touchOffsetY)
     {
         processScrollEvent(MoveDirection::RIGHT, false);
     }
-    
-    bool scrollEnabledUpDown = (!scrolledToBottom && !scrolledToTop);
-    bool scrollEnabledLeftRight = (!scrolledToLeft && !scrolledToRight);
-    return scrollEnabledUpDown || scrollEnabledLeftRight;
 }
 
 void ScrollView::scrollToBottom(float timeInSec, bool attenuated)

--- a/cocos/ui/UIScrollView.cpp
+++ b/cocos/ui/UIScrollView.cpp
@@ -1116,11 +1116,11 @@ bool ScrollView::isInertiaScrollEnabled() const
 
 void ScrollView::setScrollBarEnabled(bool enabled)
 {
-	if(_scrollBarEnabled == enabled)
-	{
-		return;
-	}
-	
+    if(_scrollBarEnabled == enabled)
+    {
+        return;
+    }
+    
     if(_scrollBarEnabled)
     {
         removeScrollBar();

--- a/cocos/ui/UIScrollView.cpp
+++ b/cocos/ui/UIScrollView.cpp
@@ -566,17 +566,8 @@ void ScrollView::processAutoScrolling(float deltaTime)
 
 void ScrollView::jumpToDestination(const Vec2 &des)
 {
-    float finalOffsetX = des.x;
-    float finalOffsetY = des.y;
-    if (des.y <= 0 && _direction != Direction::HORIZONTAL)
-    {
-        finalOffsetY = MAX(des.y, _contentSize.height - _innerContainer->getContentSize().height);
-    }
-    if (des.x <= 0 && _direction != Direction::VERTICAL)
-    {
-        finalOffsetX = MAX(des.x, _contentSize.width - _innerContainer->getContentSize().width);
-    }
-    moveInnerContainer(Vec2(finalOffsetX, finalOffsetY) - getInnerContainerPosition(), true);
+    _autoScrolling = false;
+    moveInnerContainer(des - getInnerContainerPosition(), true);
 }
 
 bool ScrollView::scrollChildren(float touchOffsetX, float touchOffsetY)

--- a/cocos/ui/UIScrollView.cpp
+++ b/cocos/ui/UIScrollView.cpp
@@ -176,23 +176,6 @@ void ScrollView::setInnerContainerSize(const Size &size)
     }
     _innerContainer->setContentSize(Size(innerSizeWidth, innerSizeHeight));
 
-    // move children appropriately
-    {
-        Size newInnerSize = _innerContainer->getContentSize();
-        float offsetY = originalInnerSize.height - newInnerSize.height;
-        float offsetX = 0;
-        if (_innerContainer->getRightBoundary() <= _contentSize.width)
-        {
-            offsetX = originalInnerSize.width - newInnerSize.width;
-        }
-        if(offsetX != 0 || offsetY != 0)
-        {
-            Vec2 position = _innerContainer->getPosition() + Vec2(offsetX, offsetY);
-            setInnerContainerPosition(position);
-        }
-    }
-
-    
     // Calculate and set the position of the inner container.
     Vec2 pos = _innerContainer->getPosition();
     if (_innerContainer->getLeftBoundary() > 0.0f)

--- a/cocos/ui/UIScrollView.cpp
+++ b/cocos/ui/UIScrollView.cpp
@@ -553,76 +553,63 @@ void ScrollView::jumpToDestination(const Vec2 &des)
     moveInnerContainer(des - getInnerContainerPosition(), true);
 }
 
-void ScrollView::scrollChildren(float touchOffsetX, float touchOffsetY)
+void ScrollView::scrollChildren(const Vec2& deltaMove)
 {
-    touchOffsetX = (_direction == Direction::VERTICAL ? 0 : touchOffsetX);
-    touchOffsetY = (_direction == Direction::HORIZONTAL ? 0 : touchOffsetY);
+    Vec2 realMove = deltaMove;
     if(_bounceEnabled)
     {
         // If the position of the inner container is out of the boundary, the offsets should be divided by two.
         Vec2 outOfBoundary = getHowMuchOutOfBoundary();
-        touchOffsetX *= (outOfBoundary.x == 0 ? 1 : 0.5f);
-        touchOffsetY *= (outOfBoundary.y == 0 ? 1 : 0.5f);
+        realMove.x *= (outOfBoundary.x == 0 ? 1 : 0.5f);
+        realMove.y *= (outOfBoundary.y == 0 ? 1 : 0.5f);
     }
     
-    float realOffsetX = touchOffsetX;
-    float realOffsetY = touchOffsetY;
-
     if(!_bounceEnabled)
     {
-        Vec2 outOfBoundary = getHowMuchOutOfBoundary(Vec2(realOffsetX, realOffsetY));
-        realOffsetX += outOfBoundary.x;
-        realOffsetY += outOfBoundary.y;
+        Vec2 outOfBoundary = getHowMuchOutOfBoundary(realMove);
+        realMove += outOfBoundary;
     }
     
     bool scrolledToLeft = false;
     bool scrolledToRight = false;
     bool scrolledToTop = false;
     bool scrolledToBottom = false;
-    if (realOffsetY > 0.0f) // up
+    if (realMove.y > 0.0f) // up
     {
         float icBottomPos = _innerContainer->getBottomBoundary();
-        if (icBottomPos + realOffsetY >= _bottomBoundary)
+        if (icBottomPos + realMove.y >= _bottomBoundary)
         {
             scrolledToBottom = true;
         }
     }
-    else if (realOffsetY < 0.0f) // down
+    else if (realMove.y < 0.0f) // down
     {
         float icTopPos = _innerContainer->getTopBoundary();
-        if (icTopPos + realOffsetY <= _topBoundary)
+        if (icTopPos + realMove.y <= _topBoundary)
         {
             scrolledToTop = true;
         }
     }
     
-    if (realOffsetX < 0.0f) // left
+    if (realMove.x < 0.0f) // left
     {
         float icRightPos = _innerContainer->getRightBoundary();
-        if (icRightPos + realOffsetX <= _rightBoundary)
+        if (icRightPos + realMove.x <= _rightBoundary)
         {
-            if(!_bounceEnabled)
-            {
-                realOffsetX = _rightBoundary - icRightPos;
-            }
             scrolledToRight = true;
         }
     }
-    else if (realOffsetX > 0.0f) // right
+    else if (realMove.x > 0.0f) // right
     {
         float icLeftPos = _innerContainer->getLeftBoundary();
-        if (icLeftPos + realOffsetX >= _leftBoundary)
+        if (icLeftPos + realMove.x >= _leftBoundary)
         {
-            if(!_bounceEnabled)
-            {
-                realOffsetX = _leftBoundary - icLeftPos;
-            }
             scrolledToLeft = true;
         }
     }
-    moveInnerContainer(Vec2(realOffsetX, realOffsetY), false);
+    moveInnerContainer(realMove, false);
     
-    if(realOffsetX != 0 || realOffsetY != 0)
+    if(realMove.x != 0 || realMove.y != 0)
     {
         processScrollingEvent();
     }
@@ -875,7 +862,7 @@ void ScrollView::handleMoveLogic(Touch *touch)
     }
     Vec3 delta3 = currPt - prevPt;
     Vec2 delta(delta3.x, delta3.y);
-    scrollChildren(delta.x, delta.y);
+    scrollChildren(delta);
     
     // Gather touch move information for speed calculation
     gatherTouchMove(delta);

--- a/cocos/ui/UIScrollView.h
+++ b/cocos/ui/UIScrollView.h
@@ -571,7 +571,7 @@ protected:
     bool isOutOfBoundary();
 
     void moveInnerContainer(const Vec2& deltaMove, bool canStartBounceBack);
-	
+
 	bool calculateCurrAndPrevTouchPoints(Touch* touch, Vec3* currPt, Vec3* prevPt);
 	void gatherTouchMove(const Vec2& delta);
     Vec2 calculateTouchMoveVelocity() const;

--- a/cocos/ui/UIScrollView.h
+++ b/cocos/ui/UIScrollView.h
@@ -588,7 +588,7 @@ protected:
 
     void jumpToDestination(const Vec2& des);
 
-    virtual bool scrollChildren(float touchOffsetX, float touchOffsetY);
+    virtual void scrollChildren(float touchOffsetX, float touchOffsetY);
 
     virtual void handlePressLogic(Touch *touch);
     virtual void handleMoveLogic(Touch *touch);

--- a/cocos/ui/UIScrollView.h
+++ b/cocos/ui/UIScrollView.h
@@ -569,9 +569,8 @@ protected:
     virtual Vec2 getHowMuchOutOfBoundary(const Vec2& addition = Vec2::ZERO);
     bool isOutOfBoundary(MoveDirection dir);
     bool isOutOfBoundary();
-    
-    void moveChildren(float offsetX, float offsetY);
-    void moveChildrenToPosition(const Vec2& position);
+
+    void moveInnerContainer(const Vec2& deltaMove, bool canStartBounceBack);
 	
 	bool calculateCurrAndPrevTouchPoints(Touch* touch, Vec3* currPt, Vec3* prevPt);
 	void gatherTouchMove(const Vec2& delta);

--- a/cocos/ui/UIScrollView.h
+++ b/cocos/ui/UIScrollView.h
@@ -572,8 +572,8 @@ protected:
 
     virtual void moveInnerContainer(const Vec2& deltaMove, bool canStartBounceBack);
 
-	bool calculateCurrAndPrevTouchPoints(Touch* touch, Vec3* currPt, Vec3* prevPt);
-	void gatherTouchMove(const Vec2& delta);
+    bool calculateCurrAndPrevTouchPoints(Touch* touch, Vec3* currPt, Vec3* prevPt);
+    void gatherTouchMove(const Vec2& delta);
     Vec2 calculateTouchMoveVelocity() const;
     
     virtual void startAttenuatingAutoScroll(const Vec2& deltaMove, const Vec2& initialVelocity);

--- a/cocos/ui/UIScrollView.h
+++ b/cocos/ui/UIScrollView.h
@@ -570,7 +570,7 @@ protected:
     bool isOutOfBoundary(MoveDirection dir);
     bool isOutOfBoundary();
 
-    void moveInnerContainer(const Vec2& deltaMove, bool canStartBounceBack);
+    virtual void moveInnerContainer(const Vec2& deltaMove, bool canStartBounceBack);
 
 	bool calculateCurrAndPrevTouchPoints(Touch* touch, Vec3* currPt, Vec3* prevPt);
 	void gatherTouchMove(const Vec2& delta);

--- a/cocos/ui/UIScrollView.h
+++ b/cocos/ui/UIScrollView.h
@@ -588,7 +588,7 @@ protected:
 
     void jumpToDestination(const Vec2& des);
 
-    virtual void scrollChildren(float touchOffsetX, float touchOffsetY);
+    virtual void scrollChildren(const Vec2& deltaMove);
 
     virtual void handlePressLogic(Touch *touch);
     virtual void handleMoveLogic(Touch *touch);

--- a/cocos/ui/UIScrollViewBar.cpp
+++ b/cocos/ui/UIScrollViewBar.cpp
@@ -25,7 +25,7 @@ THE SOFTWARE.
 #include "UIScrollViewBar.h"
 #include "CCImage.h"
 #include "2d/CCSprite.h"
-#include "base/base64.h"
+#include "base/ccUtils.h"
 
 NS_CC_BEGIN
 
@@ -38,27 +38,6 @@ static const Color3B DEFAULT_COLOR(52, 65, 87);
 static const float DEFAULT_MARGIN = 20;
 static const float DEFAULT_AUTO_HIDE_TIME = 0.2f;
 static const float DEFAULT_SCROLLBAR_OPACITY = 0.4f;
-
-static Sprite* createSpriteFromBase64(const char* base64String)
-{
-    unsigned char* decoded;
-    int length = base64Decode((const unsigned char*) base64String, (unsigned int) strlen(base64String), &decoded);
-    
-    Image *image = new Image();
-    bool imageResult = image->initWithImageData(decoded, length);
-    CCASSERT(imageResult, "Failed to create image from base64!");
-    free(decoded);
-    
-    Texture2D *texture = new Texture2D();
-    texture->initWithImage(image);
-    texture->setAliasTexParameters();
-    image->release();
-    
-    Sprite* sprite = Sprite::createWithTexture(texture);
-    texture->release();
-    
-    return sprite;
-}
 
 ScrollViewBar::ScrollViewBar(ScrollView* parent, ScrollView::Direction direction):
 _parent(parent),
@@ -103,7 +82,7 @@ bool ScrollViewBar::init()
         return false;
     }
     
-    _upperHalfCircle = createSpriteFromBase64(HALF_CIRCLE_IMAGE);
+    _upperHalfCircle = utils::createSpriteFromBase64(HALF_CIRCLE_IMAGE);
     _upperHalfCircle->setAnchorPoint(Vec2::ANCHOR_MIDDLE_BOTTOM);
     addProtectedChild(_upperHalfCircle);
     
@@ -112,7 +91,7 @@ bool ScrollViewBar::init()
     _lowerHalfCircle->setAnchorPoint(Vec2::ANCHOR_MIDDLE_BOTTOM);
     addProtectedChild(_lowerHalfCircle);
     
-    _body = createSpriteFromBase64(BODY_IMAGE_1_PIXEL_HEIGHT);
+    _body = utils::createSpriteFromBase64(BODY_IMAGE_1_PIXEL_HEIGHT);
     _body->setAnchorPoint(Vec2::ANCHOR_MIDDLE_BOTTOM);
     addProtectedChild(_body);
     

--- a/cocos/ui/UIScrollViewBar.h
+++ b/cocos/ui/UIScrollViewBar.h
@@ -157,13 +157,13 @@ private:
     
     ScrollView* _parent;
     ScrollView::Direction _direction;
-	
+    
     Sprite* _upperHalfCircle;
     Sprite* _lowerHalfCircle;
     Sprite* _body;
     
     GLubyte _opacity;
-	
+    
     float _marginFromBoundary;
     float _marginForLength;
 

--- a/cocos/ui/UIScrollViewBar.h
+++ b/cocos/ui/UIScrollViewBar.h
@@ -59,8 +59,8 @@ public:
     virtual ~ScrollViewBar();
     
     /**
-     * Create a ScrollView with its parent ScrollView and direction.
-     * @return A ScrollViewBar instance.
+     * Create a scroll bar with its parent scroll view and direction.
+     * @return A scroll bar instance.
      */
     static ScrollViewBar* create(ScrollView* parent, ScrollView::Direction direction);
     

--- a/cocos/ui/proj.win32/libui.vcxproj
+++ b/cocos/ui/proj.win32/libui.vcxproj
@@ -62,6 +62,7 @@
     <ClCompile Include="..\UIListView.cpp" />
     <ClCompile Include="..\UILoadingBar.cpp" />
     <ClCompile Include="..\UIPageView.cpp" />
+    <ClCompile Include="..\UIPageViewIndicator.cpp" />
     <ClCompile Include="..\UIRelativeBox.cpp" />
     <ClCompile Include="..\UIRichText.cpp" />
     <ClCompile Include="..\UIScale9Sprite.cpp" />

--- a/cocos/ui/proj.win32/libui.vcxproj.filters
+++ b/cocos/ui/proj.win32/libui.vcxproj.filters
@@ -131,6 +131,9 @@
     <ClCompile Include="..\UIPageView.cpp">
       <Filter>UIWidgets\ScrollWidget</Filter>
     </ClCompile>
+    <ClCompile Include="..\UIPageViewIndicator.cpp">
+      <Filter>UIWidgets\ScrollWidget</Filter>
+    </ClCompile>
     <ClCompile Include="..\UIButton.cpp">
       <Filter>UIWidgets</Filter>
     </ClCompile>

--- a/templates/cocos2dx_files.json
+++ b/templates/cocos2dx_files.json
@@ -1255,6 +1255,8 @@
         "cocos/ui/UILoadingBar.h", 
         "cocos/ui/UIPageView.cpp", 
         "cocos/ui/UIPageView.h", 
+        "cocos/ui/UIPageViewIndicator.cpp", 
+        "cocos/ui/UIPageViewIndicator.h", 
         "cocos/ui/UIRadioButton.cpp", 
         "cocos/ui/UIRadioButton.h", 
         "cocos/ui/UIRelativeBox.cpp", 

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIPageViewTest/UIPageViewTest.cpp
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIPageViewTest/UIPageViewTest.cpp
@@ -6,9 +6,6 @@ using namespace cocos2d::ui;
 
 UIPageViewTests::UIPageViewTests()
 {
-    ADD_TEST_CASE(UIPageViewByListViewTest);
-
-
     ADD_TEST_CASE(UIPageViewTest);
     ADD_TEST_CASE(UIPageViewButtonTest);
     ADD_TEST_CASE(UIPageViewCustomScrollThreshold);
@@ -55,9 +52,10 @@ bool UIPageViewTest::init()
         Layout* background = dynamic_cast<Layout*>(root->getChildByName("background_Panel"));
         
         // Create the page view
+        Size size(240, 130);
         PageView* pageView = PageView::create();
         pageView->setDirection(PageView::Direction::HORIZONTAL);
-        pageView->setContentSize(Size(240.0f, 130.0f));
+        pageView->setContentSize(size);
         Size backgroundSize = background->getContentSize();
         pageView->setPosition((widgetSize - pageView->getContentSize()) / 2.0f);
         pageView->removeAllItems();
@@ -66,11 +64,11 @@ bool UIPageViewTest::init()
         for (int i = 0; i < pageCount; ++i)
         {
             Layout* layout = Layout::create();
-            layout->setContentSize(Size(240.0f, 130.0f));
+            layout->setContentSize(size);
             
             ImageView* imageView = ImageView::create("cocosui/scrollviewbg.png");
             imageView->setScale9Enabled(true);
-            imageView->setContentSize(Size(240, 130));
+            imageView->setContentSize(size);
             imageView->setPosition(Vec2(layout->getContentSize().width / 2.0f, layout->getContentSize().height / 2.0f));
             layout->addChild(imageView);
             
@@ -109,73 +107,6 @@ void UIPageViewTest::pageViewEvent(Ref *pSender, PageView::EventType type)
         default:
             break;
     }
-}
-
-
-// UIPageViewByListViewTest
-bool UIPageViewByListViewTest::init()
-{
-    if (!UIScene::init())
-    {
-        return false;
-    }
-
-    Size widgetSize = _widget->getContentSize();
-
-    // Add a label in which the dragpanel events will be displayed
-    auto label = Text::create("Move by horizontal direction", "fonts/Marker Felt.ttf", 32);
-    label->setAnchorPoint(Vec2(0.5f, -1.0f));
-    label->setPosition(Vec2(widgetSize / 2) + Vec2(0, label->getContentSize().height * 1.5));
-    _uiLayer->addChild(label);
-
-    Layout* root = static_cast<Layout*>(_uiLayer->getChildByTag(81));
-    Layout* background = dynamic_cast<Layout*>(root->getChildByName("background_Panel"));
-
-    // Create the page view
-    Size size(240.0f, 130.0f);
-//    auto pageView = ListView::create();
-    auto pageView = PageView::create();
-    {
-        pageView->setDirection(ScrollView::Direction::HORIZONTAL);
-        pageView->setContentSize(size);
-        Size backgroundSize = background->getContentSize();
-        pageView->setPosition((widgetSize - pageView->getContentSize()) / 2);
-        _uiLayer->addChild(pageView);
-    }
-
-    int pageCount = 20;
-    for (int i = 0; i < pageCount; ++i)
-    {
-        Color3B color;
-        if(i % 3 == 0)
-        {
-            color = Color3B::WHITE;
-        }
-        else if(i % 3 == 1)
-        {
-            color = Color3B::YELLOW;
-        }
-        else if(i % 3 == 2)
-        {
-            color = Color3B::ORANGE;
-        }
-
-        Layout* pLayout = Layout::create();
-        pLayout->setContentSize(size);
-        pLayout->setBackGroundColorType(Layout::BackGroundColorType::SOLID);
-        pLayout->setBackGroundColor(color);
-
-        Button *btn = Button::create("cocosui/animationbuttonnormal.png",
-                                     "cocosui/animationbuttonpressed.png");
-        btn->setName(StringUtils::format("button %d", i));
-        btn->setScale9Enabled(true);
-        btn->setContentSize(size);
-        btn->setPosition(size / 2);
-        pLayout->addChild(btn);
-
-        pageView->pushBackCustomItem(pLayout);
-    }
-    return true;
 }
 
 

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIPageViewTest/UIPageViewTest.cpp
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIPageViewTest/UIPageViewTest.cpp
@@ -59,6 +59,7 @@ bool UIPageViewTest::init()
         Size backgroundSize = background->getContentSize();
         pageView->setPosition((widgetSize - pageView->getContentSize()) / 2.0f);
         pageView->removeAllItems();
+        pageView->setIndicatorEnabled(true);
         
         int pageCount = 4;
         for (int i = 0; i < pageCount; ++i)
@@ -81,8 +82,7 @@ bool UIPageViewTest::init()
         }
         
         pageView->removeItem(0);
-        pageView->scrollToItem(pageCount - 2, Vec2::ANCHOR_MIDDLE, Vec2::ANCHOR_MIDDLE);
-        
+        pageView->scrollToItem(pageCount - 2);
         pageView->addEventListener(CC_CALLBACK_2(UIPageViewTest::pageViewEvent, this));
         
         _uiLayer->addChild(pageView);
@@ -100,7 +100,7 @@ void UIPageViewTest::pageViewEvent(Ref *pSender, PageView::EventType type)
         {
             PageView* pageView = dynamic_cast<PageView*>(pSender);
             
-            _displayValueLabel->setString(StringUtils::format("page = %ld", pageView->getCurPageIndex() + 1));
+            _displayValueLabel->setString(StringUtils::format("page = %ld", pageView->getCurrentPageIndex() + 1));
         }
             break;
             
@@ -154,7 +154,7 @@ bool UIPageViewButtonTest::init()
                                    (widgetSize.height - backgroundSize.height) / 2.0f +
                                    (backgroundSize.height - pageView->getContentSize().height) / 2.0f));
         
-        pageView->removeAllPages();
+        pageView->removeAllItems();
         
         int pageCount = 4;
         for (int i = 0; i < pageCount; ++i)
@@ -182,10 +182,10 @@ bool UIPageViewButtonTest::init()
 
             }
             
-            pageView->insertPage(outerBox,i);
+            pageView->insertCustomItem(outerBox, i);
         }
         
-        pageView->removePageAtIndex(0);
+        pageView->removeItem(0);
         
         pageView->addEventListener(CC_CALLBACK_2(UIPageViewButtonTest::pageViewEvent, this));
         
@@ -210,7 +210,7 @@ void UIPageViewButtonTest::pageViewEvent(Ref *pSender, PageView::EventType type)
         {
             PageView* pageView = dynamic_cast<PageView*>(pSender);
             
-            _displayValueLabel->setString(StringUtils::format("page = %ld", pageView->getCurPageIndex() + 1));
+            _displayValueLabel->setString(StringUtils::format("page = %ld", pageView->getCurrentPageIndex() + 1));
         }
             break;
             
@@ -281,7 +281,7 @@ bool UIPageViewCustomScrollThreshold::init()
             label->setPosition(Vec2(layout->getContentSize().width / 2.0f, layout->getContentSize().height / 2.0f));
             layout->addChild(label);
             
-            pageView->insertPage(layout,i);
+            pageView->insertCustomItem(layout, i);
         }
         
         _uiLayer->addChild(pageView);
@@ -389,7 +389,7 @@ bool UIPageViewTouchPropagationTest::init()
                 
             }
             
-            pageView->insertPage(outerBox,i);
+            pageView->insertCustomItem(outerBox, i);
         }
         
         pageView->addEventListener(CC_CALLBACK_2(UIPageViewTouchPropagationTest::pageViewEvent, this));
@@ -506,7 +506,7 @@ void UIPageViewTouchPropagationTest::pageViewEvent(Ref *pSender, PageView::Event
         {
             PageView* pageView = dynamic_cast<PageView*>(pSender);
             
-            _displayValueLabel->setString(StringUtils::format("page = %ld", pageView->getCurPageIndex() + 1));
+            _displayValueLabel->setString(StringUtils::format("page = %ld", pageView->getCurrentPageIndex() + 1));
         }
             break;
             
@@ -586,7 +586,7 @@ bool UIPageViewDynamicAddAndRemoveTest::init()
                 
             }
             
-            pageView->insertPage(outerBox,i);
+            pageView->insertCustomItem(outerBox, i);
         }
         
         pageView->addEventListener(CC_CALLBACK_2(UIPageViewDynamicAddAndRemoveTest::pageViewEvent, this));
@@ -622,9 +622,9 @@ bool UIPageViewDynamicAddAndRemoveTest::init()
                 outerBox->addChild(innerBox);
             }
             
-            pageView->addPage(outerBox);
-            _displayValueLabel->setString(StringUtils::format("page count = %ld", pageView->getPages().size()));
-            CCLOG("current page index = %zd", pageView->getCurPageIndex());
+            pageView->pushBackCustomItem(outerBox);
+            _displayValueLabel->setString(StringUtils::format("page count = %ld", pageView->getItems().size()));
+            CCLOG("current page index = %zd", pageView->getCurrentPageIndex());
         });
         _uiLayer->addChild(button);
         
@@ -636,16 +636,16 @@ bool UIPageViewDynamicAddAndRemoveTest::init()
         button2->setTitleColor(Color3B::RED);
         button2->addClickEventListener([=](Ref* sender)
         {
-            if (pageView->getPages().size() > 0)
+            if (pageView->getItems().size() > 0)
             {
-                pageView->removePageAtIndex(pageView->getPages().size()-1);
+                pageView->removeItem(pageView->getItems().size()-1);
             }
             else
             {
                 CCLOG("There is no page to remove!");
             }
-            _displayValueLabel->setString(StringUtils::format("page count = %ld", pageView->getPages().size()));
-            CCLOG("current page index = %zd", pageView->getCurPageIndex());
+            _displayValueLabel->setString(StringUtils::format("page count = %ld", pageView->getItems().size()));
+            CCLOG("current page index = %zd", pageView->getCurrentPageIndex());
 
         });
         _uiLayer->addChild(button2);
@@ -658,9 +658,9 @@ bool UIPageViewDynamicAddAndRemoveTest::init()
         button3->setTitleColor(Color3B::RED);
         button3->addClickEventListener([=](Ref* sender)
         {
-            pageView->removeAllPages();
-            _displayValueLabel->setString(StringUtils::format("page count = %ld", pageView->getPages().size()));
-            CCLOG("current page index = %zd", pageView->getCurPageIndex());
+            pageView->removeAllItems();
+            _displayValueLabel->setString(StringUtils::format("page count = %ld", pageView->getItems().size()));
+            CCLOG("current page index = %zd", pageView->getCurrentPageIndex());
 
         });
         _uiLayer->addChild(button3);
@@ -669,8 +669,8 @@ bool UIPageViewDynamicAddAndRemoveTest::init()
         button4->setTitleText("Scroll to Page4");
         button4->setNormalizedPosition(Vec2(0.85,0.5));
         button4->addClickEventListener([=](Ref* sender){
-            pageView->scrollToPage(3);
-            CCLOG("current page index = %zd", pageView->getCurPageIndex());
+            pageView->scrollToItem(3);
+            CCLOG("current page index = %zd", pageView->getCurrentPageIndex());
         });
         _uiLayer->addChild(button4);
         
@@ -688,7 +688,7 @@ void UIPageViewDynamicAddAndRemoveTest::pageViewEvent(Ref *pSender, PageView::Ev
         {
             PageView* pageView = dynamic_cast<PageView*>(pSender);
             
-            _displayValueLabel->setString(StringUtils::format("page = %ld", pageView->getCurPageIndex() + 1));
+            _displayValueLabel->setString(StringUtils::format("page = %ld", pageView->getCurrentPageIndex() + 1));
         }
             break;
             
@@ -716,7 +716,7 @@ bool UIPageViewJumpToPageTest::init()
         Size widgetSize = _widget->getContentSize();
 
         // Add a label in which the dragpanel events will be displayed
-        _displayValueLabel = Text::create("setCurPageIndex API Test", "fonts/Marker Felt.ttf", 32);
+        _displayValueLabel = Text::create("setCurrentPageIndex API Test", "fonts/Marker Felt.ttf", 32);
         _displayValueLabel->setAnchorPoint(Vec2(0.5f, -1.0f));
         _displayValueLabel->setPosition(Vec2(widgetSize.width / 2.0f,
                                               widgetSize.height / 2.0f +
@@ -742,7 +742,7 @@ bool UIPageViewJumpToPageTest::init()
                                   (widgetSize.height - backgroundSize.height) / 2.0f +
                                   (backgroundSize.height - pageView->getContentSize().height) / 2.0f));
 
-        pageView->removeAllPages();
+        pageView->removeAllItems();
 
         int pageCount = 4;
         for (int i = 0; i < pageCount; ++i)
@@ -761,10 +761,10 @@ bool UIPageViewJumpToPageTest::init()
             label->setPosition(Vec2(layout->getContentSize().width / 2.0f, layout->getContentSize().height / 2.0f));
             layout->addChild(label);
 
-            pageView->insertPage(layout,i);
+            pageView->insertCustomItem(layout, i);
         }
 
-        pageView->setCurPageIndex(1);
+        pageView->setCurrentPageIndex(1);
 
         //add buttons to jump to specific page
         auto button1 = ui::Button::create();
@@ -773,7 +773,7 @@ bool UIPageViewJumpToPageTest::init()
         CCLOG("button1 content Size = %f, %f", button1->getContentSize().width,
               button1->getContentSize().height);
         button1->addClickEventListener([=](Ref*){
-            pageView->setCurPageIndex(0);
+            pageView->setCurrentPageIndex(0);
         });
         _uiLayer->addChild(button1);
 
@@ -783,7 +783,7 @@ bool UIPageViewJumpToPageTest::init()
         CCLOG("button2 content Size = %f, %f", button2->getContentSize().width,
               button2->getContentSize().height);
         button2->addClickEventListener([=](Ref*){
-            pageView->setCurPageIndex(1);
+            pageView->setCurrentPageIndex(1);
         });
         _uiLayer->addChild(button2);
 
@@ -791,7 +791,7 @@ bool UIPageViewJumpToPageTest::init()
         button3->setTitleText("Jump to Page3");
         button3->setNormalizedPosition(Vec2(0.9, 0.75));
         button3->addClickEventListener([=](Ref*){
-            pageView->setCurPageIndex(2);
+            pageView->setCurrentPageIndex(2);
         });
         _uiLayer->addChild(button3);
 
@@ -799,7 +799,7 @@ bool UIPageViewJumpToPageTest::init()
         button4->setTitleText("Jump to Page4");
         button4->setNormalizedPosition(Vec2(0.9, 0.65));
         button4->addClickEventListener([=](Ref*){
-            pageView->setCurPageIndex(3);
+            pageView->setCurrentPageIndex(3);
         });
         _uiLayer->addChild(button4);
         _uiLayer->addChild(pageView);
@@ -854,7 +854,7 @@ bool UIPageViewVerticalTest::init()
                                    (widgetSize.height - backgroundSize.height) / 2.0f +
                                    (backgroundSize.height - pageView->getContentSize().height) / 2.0f));
         
-        pageView->removeAllPages();
+        pageView->removeAllItems();
         
         int pageCount = 4;
         for (int i = 0; i < pageCount; ++i)
@@ -873,7 +873,7 @@ bool UIPageViewVerticalTest::init()
             label->setPosition(Vec2(layout->getContentSize().width / 2.0f, layout->getContentSize().height / 2.0f));
             layout->addChild(label);
             
-            pageView->insertPage(layout,i);
+            pageView->insertCustomItem(layout, i);
         }
         
         pageView->addEventListener(CC_CALLBACK_2(UIPageViewVerticalTest::pageViewEvent, this));
@@ -893,7 +893,7 @@ void UIPageViewVerticalTest::pageViewEvent(Ref *pSender, PageView::EventType typ
         {
             PageView* pageView = dynamic_cast<PageView*>(pSender);
             
-            _displayValueLabel->setString(StringUtils::format("page = %ld", pageView->getCurPageIndex() + 1));
+            _displayValueLabel->setString(StringUtils::format("page = %ld", pageView->getCurrentPageIndex() + 1));
         }
             break;
             
@@ -947,7 +947,7 @@ bool UIPageViewDisableTouchTest::init()
                                    (backgroundSize.height - pageView->getContentSize().height) / 2.0f));
         pageView->setDirection(ui::PageView::Direction::VERTICAL);
         pageView->setTouchEnabled(false);
-        pageView->removeAllPages();
+        pageView->removeAllItems();
         
         int pageCount = 4;
         for (int i = 0; i < pageCount; ++i)
@@ -966,7 +966,7 @@ bool UIPageViewDisableTouchTest::init()
             label->setPosition(Vec2(layout->getContentSize().width / 2.0f, layout->getContentSize().height / 2.0f));
             layout->addChild(label);
             
-            pageView->insertPage(layout,i);
+            pageView->insertCustomItem(layout, i);
         }
         
         _uiLayer->addChild(pageView);

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIPageViewTest/UIPageViewTest.cpp
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIPageViewTest/UIPageViewTest.cpp
@@ -259,11 +259,8 @@ bool UIPageViewCustomScrollThreshold::init()
         PageView* pageView = PageView::create();
         pageView->setContentSize(Size(240.0f, 100.0f));
         Size backgroundSize = background->getContentSize();
-        pageView->setPosition(Vec2((widgetSize.width - backgroundSize.width) / 2.0f +
-                                   (backgroundSize.width - pageView->getContentSize().width) / 2.0f,
-                                   (widgetSize.height - backgroundSize.height) / 2.0f +
-                                   (backgroundSize.height - pageView->getContentSize().height) / 2.0f + 20));
-        
+		pageView->setPosition(Vec2(widgetSize - pageView->getContentSize()) / 2.0f + Vec2(0, 20));
+
         int pageCount = 4;
         for (int i = 0; i < pageCount; ++i)
         {
@@ -273,12 +270,12 @@ bool UIPageViewCustomScrollThreshold::init()
             ImageView* imageView = ImageView::create("cocosui/scrollviewbg.png");
             imageView->setScale9Enabled(true);
             imageView->setContentSize(Size(240, 130));
-            imageView->setPosition(Vec2(layout->getContentSize().width / 2.0f, layout->getContentSize().height / 2.0f));
+            imageView->setPosition(layout->getContentSize() / 2.0f);
             layout->addChild(imageView);
             
             Text* label = Text::create(StringUtils::format("page %d",(i+1)), "fonts/Marker Felt.ttf", 30);
             label->setColor(Color3B(192, 192, 192));
-            label->setPosition(Vec2(layout->getContentSize().width / 2.0f, layout->getContentSize().height / 2.0f));
+            label->setPosition(layout->getContentSize() / 2.0f);
             layout->addChild(label);
             
             pageView->insertCustomItem(layout, i);
@@ -558,6 +555,7 @@ bool UIPageViewDynamicAddAndRemoveTest::init()
         pageView->setPosition(Vec2(widgetSize.width / 2.0f ,widgetSize.height / 2.0f));
         pageView->setBackGroundColor(Color3B::GREEN);
         pageView->setBackGroundColorType(Layout::BackGroundColorType::SOLID);
+        pageView->setIndicatorEnabled(true);
         
         int pageCount = 4;
         for (int i = 0; i < pageCount; ++i)
@@ -741,7 +739,7 @@ bool UIPageViewJumpToPageTest::init()
                                   (backgroundSize.width - pageView->getContentSize().width) / 2.0f,
                                   (widgetSize.height - backgroundSize.height) / 2.0f +
                                   (backgroundSize.height - pageView->getContentSize().height) / 2.0f));
-
+        pageView->setIndicatorEnabled(true);
         pageView->removeAllItems();
 
         int pageCount = 4;
@@ -846,6 +844,7 @@ bool UIPageViewVerticalTest::init()
         
         // Create the page view
         PageView* pageView = PageView::create();
+        pageView->setIndicatorEnabled(true);
         pageView->setDirection(ui::PageView::Direction::VERTICAL);
         pageView->setContentSize(Size(240.0f, 130.0f));
         Size backgroundSize = background->getContentSize();
@@ -853,7 +852,6 @@ bool UIPageViewVerticalTest::init()
                                    (backgroundSize.width - pageView->getContentSize().width) / 2.0f,
                                    (widgetSize.height - backgroundSize.height) / 2.0f +
                                    (backgroundSize.height - pageView->getContentSize().height) / 2.0f));
-        
         pageView->removeAllItems();
         
         int pageCount = 4;

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIPageViewTest/UIPageViewTest.cpp
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIPageViewTest/UIPageViewTest.cpp
@@ -55,11 +55,7 @@ bool UIPageViewTest::init()
         PageView* pageView = PageView::create();
         pageView->setContentSize(Size(240.0f, 130.0f));
         Size backgroundSize = background->getContentSize();
-        pageView->setPosition(Vec2((widgetSize.width - backgroundSize.width) / 2.0f +
-                                  (backgroundSize.width - pageView->getContentSize().width) / 2.0f,
-                                  (widgetSize.height - backgroundSize.height) / 2.0f +
-                                  (backgroundSize.height - pageView->getContentSize().height) / 2.0f));
-        
+        pageView->setPosition((widgetSize - pageView->getContentSize()) / 2.0f);
         pageView->removeAllPages();
         
         int pageCount = 4;

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIPageViewTest/UIPageViewTest.cpp
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIPageViewTest/UIPageViewTest.cpp
@@ -53,6 +53,7 @@ bool UIPageViewTest::init()
         
         // Create the page view
         PageView* pageView = PageView::create();
+        pageView->setDirection(PageView::Direction::HORIZONTAL);
         pageView->setContentSize(Size(240.0f, 130.0f));
         Size backgroundSize = background->getContentSize();
         pageView->setPosition((widgetSize - pageView->getContentSize()) / 2.0f);

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIPageViewTest/UIPageViewTest.cpp
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIPageViewTest/UIPageViewTest.cpp
@@ -452,6 +452,7 @@ bool UIPageViewDynamicAddAndRemoveTest::init()
         
         // Create the page view
         PageView* pageView = PageView::create();
+        pageView->setDirection(ui::PageView::Direction::VERTICAL);
         pageView->setContentSize(Size(240.0f, 130.0f));
         pageView->setAnchorPoint(Vec2(0.5,0.5));
         Size backgroundSize = background->getContentSize();
@@ -459,7 +460,8 @@ bool UIPageViewDynamicAddAndRemoveTest::init()
         pageView->setBackGroundColor(Color3B::GREEN);
         pageView->setBackGroundColorType(Layout::BackGroundColorType::SOLID);
         pageView->setIndicatorEnabled(true);
-        
+        pageView->setIndicatorSpaceBetweenIndexNodes(10);
+
         int pageCount = 4;
         for (int i = 0; i < pageCount; ++i)
         {
@@ -751,10 +753,7 @@ bool UIPageViewVerticalTest::init()
         pageView->setDirection(ui::PageView::Direction::VERTICAL);
         pageView->setContentSize(Size(240.0f, 130.0f));
         Size backgroundSize = background->getContentSize();
-        pageView->setPosition(Vec2((widgetSize.width - backgroundSize.width) / 2.0f +
-                                   (backgroundSize.width - pageView->getContentSize().width) / 2.0f,
-                                   (widgetSize.height - backgroundSize.height) / 2.0f +
-                                   (backgroundSize.height - pageView->getContentSize().height) / 2.0f));
+        pageView->setPosition((widgetSize - pageView->getContentSize()) / 2.0f);
         pageView->removeAllItems();
         
         int pageCount = 4;

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIPageViewTest/UIPageViewTest.cpp
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIPageViewTest/UIPageViewTest.cpp
@@ -6,6 +6,9 @@ using namespace cocos2d::ui;
 
 UIPageViewTests::UIPageViewTests()
 {
+    ADD_TEST_CASE(UIPageViewByListViewTest);
+
+
     ADD_TEST_CASE(UIPageViewTest);
     ADD_TEST_CASE(UIPageViewButtonTest);
     ADD_TEST_CASE(UIPageViewCustomScrollThreshold);
@@ -57,7 +60,7 @@ bool UIPageViewTest::init()
         pageView->setContentSize(Size(240.0f, 130.0f));
         Size backgroundSize = background->getContentSize();
         pageView->setPosition((widgetSize - pageView->getContentSize()) / 2.0f);
-        pageView->removeAllPages();
+        pageView->removeAllItems();
         
         int pageCount = 4;
         for (int i = 0; i < pageCount; ++i)
@@ -76,11 +79,11 @@ bool UIPageViewTest::init()
             label->setPosition(Vec2(layout->getContentSize().width / 2.0f, layout->getContentSize().height / 2.0f));
             layout->addChild(label);
             
-            pageView->insertPage(layout,i);
+            pageView->insertCustomItem(layout, i);
         }
         
-        pageView->removePageAtIndex(0);
-        pageView->scrollToPage(pageCount-2);
+        pageView->removeItem(0);
+        pageView->scrollToItem(pageCount - 2, Vec2::ANCHOR_MIDDLE, Vec2::ANCHOR_MIDDLE);
         
         pageView->addEventListener(CC_CALLBACK_2(UIPageViewTest::pageViewEvent, this));
         
@@ -109,6 +112,73 @@ void UIPageViewTest::pageViewEvent(Ref *pSender, PageView::EventType type)
 }
 
 
+// UIPageViewByListViewTest
+bool UIPageViewByListViewTest::init()
+{
+    if (!UIScene::init())
+    {
+        return false;
+    }
+
+    Size widgetSize = _widget->getContentSize();
+
+    // Add a label in which the dragpanel events will be displayed
+    auto label = Text::create("Move by horizontal direction", "fonts/Marker Felt.ttf", 32);
+    label->setAnchorPoint(Vec2(0.5f, -1.0f));
+    label->setPosition(Vec2(widgetSize / 2) + Vec2(0, label->getContentSize().height * 1.5));
+    _uiLayer->addChild(label);
+
+    Layout* root = static_cast<Layout*>(_uiLayer->getChildByTag(81));
+    Layout* background = dynamic_cast<Layout*>(root->getChildByName("background_Panel"));
+
+    // Create the page view
+    Size size(240.0f, 130.0f);
+//    auto pageView = ListView::create();
+    auto pageView = PageView::create();
+    {
+        pageView->setDirection(ScrollView::Direction::HORIZONTAL);
+        pageView->setContentSize(size);
+        Size backgroundSize = background->getContentSize();
+        pageView->setPosition((widgetSize - pageView->getContentSize()) / 2);
+        _uiLayer->addChild(pageView);
+    }
+
+    int pageCount = 20;
+    for (int i = 0; i < pageCount; ++i)
+    {
+        Color3B color;
+        if(i % 3 == 0)
+        {
+            color = Color3B::WHITE;
+        }
+        else if(i % 3 == 1)
+        {
+            color = Color3B::YELLOW;
+        }
+        else if(i % 3 == 2)
+        {
+            color = Color3B::ORANGE;
+        }
+
+        Layout* pLayout = Layout::create();
+        pLayout->setContentSize(size);
+        pLayout->setBackGroundColorType(Layout::BackGroundColorType::SOLID);
+        pLayout->setBackGroundColor(color);
+
+        Button *btn = Button::create("cocosui/animationbuttonnormal.png",
+                                     "cocosui/animationbuttonpressed.png");
+        btn->setName(StringUtils::format("button %d", i));
+        btn->setScale9Enabled(true);
+        btn->setContentSize(size);
+        btn->setPosition(size / 2);
+        pLayout->addChild(btn);
+
+        pageView->pushBackCustomItem(pLayout);
+    }
+    return true;
+}
+
+
 // UIPageViewButtonTest
 UIPageViewButtonTest::UIPageViewButtonTest()
 : _displayValueLabel(nullptr)
@@ -126,7 +196,7 @@ bool UIPageViewButtonTest::init()
     {
         Size widgetSize = _widget->getContentSize();
         
-        // Add a label in which the dragpanel events will be displayed
+        // Add a label in which the drag panel events will be displayed
         _displayValueLabel = Text::create("Move by horizontal direction", "fonts/Marker Felt.ttf", 32);
         _displayValueLabel->setAnchorPoint(Vec2(0.5f, -1.0f));
         _displayValueLabel->setPosition(Vec2(widgetSize.width / 2.0f,

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIPageViewTest/UIPageViewTest.cpp
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIPageViewTest/UIPageViewTest.cpp
@@ -8,7 +8,6 @@ UIPageViewTests::UIPageViewTests()
 {
     ADD_TEST_CASE(UIPageViewTest);
     ADD_TEST_CASE(UIPageViewButtonTest);
-    ADD_TEST_CASE(UIPageViewCustomScrollThreshold);
     ADD_TEST_CASE(UIPageViewTouchPropagationTest);
     ADD_TEST_CASE(UIPageViewDynamicAddAndRemoveTest);
     ADD_TEST_CASE(UIPageViewJumpToPageTest);
@@ -219,102 +218,6 @@ void UIPageViewButtonTest::pageViewEvent(Ref *pSender, PageView::EventType type)
     }
 }
 
-
-// UIPageViewCustomScrollThreshold
-UIPageViewCustomScrollThreshold::UIPageViewCustomScrollThreshold()
-: _displayValueLabel(nullptr)
-{
-    
-}
-
-UIPageViewCustomScrollThreshold::~UIPageViewCustomScrollThreshold()
-{
-}
-
-bool UIPageViewCustomScrollThreshold::init()
-{
-    if (UIScene::init())
-    {
-        Size widgetSize = _widget->getContentSize();
-        
-        // Add a label in which the dragpanel events will be displayed
-        _displayValueLabel = Text::create("Scroll Threshold", "fonts/Marker Felt.ttf", 32);
-        _displayValueLabel->setAnchorPoint(Vec2(0.5f, -1.0f));
-        _displayValueLabel->setPosition(Vec2(widgetSize.width / 2.0f,
-                                             widgetSize.height / 2.0f +
-                                             _displayValueLabel->getContentSize().height * 1.5));
-        _uiLayer->addChild(_displayValueLabel);
-        
-        // Add the black background
-        Text* alert = Text::create("PageView", "fonts/Marker Felt.ttf", 30);
-        alert->setColor(Color3B(159, 168, 176));
-        alert->setPosition(Vec2(widgetSize.width / 2.0f, widgetSize.height / 2.0f - alert->getContentSize().height * 3.075f));
-        _uiLayer->addChild(alert);
-        
-        Layout* root = static_cast<Layout*>(_uiLayer->getChildByTag(81));
-        
-        Layout* background = dynamic_cast<Layout*>(root->getChildByName("background_Panel"));
-        
-        // Create the page view
-        PageView* pageView = PageView::create();
-        pageView->setContentSize(Size(240.0f, 100.0f));
-        Size backgroundSize = background->getContentSize();
-		pageView->setPosition(Vec2(widgetSize - pageView->getContentSize()) / 2.0f + Vec2(0, 20));
-
-        int pageCount = 4;
-        for (int i = 0; i < pageCount; ++i)
-        {
-            Layout* layout = Layout::create();
-            layout->setContentSize(Size(240.0f, 130.0f));
-            
-            ImageView* imageView = ImageView::create("cocosui/scrollviewbg.png");
-            imageView->setScale9Enabled(true);
-            imageView->setContentSize(Size(240, 130));
-            imageView->setPosition(layout->getContentSize() / 2.0f);
-            layout->addChild(imageView);
-            
-            Text* label = Text::create(StringUtils::format("page %d",(i+1)), "fonts/Marker Felt.ttf", 30);
-            label->setColor(Color3B(192, 192, 192));
-            label->setPosition(layout->getContentSize() / 2.0f);
-            layout->addChild(label);
-            
-            pageView->insertCustomItem(layout, i);
-        }
-        
-        _uiLayer->addChild(pageView);
-        pageView->setName("pageView");
-        
-        Slider* slider = Slider::create();
-        slider->loadBarTexture("cocosui/sliderTrack.png");
-        slider->loadSlidBallTextures("cocosui/sliderThumb.png", "cocosui/sliderThumb.png", "");
-        slider->loadProgressBarTexture("cocosui/sliderProgress.png");
-        slider->setPosition(Vec2(widgetSize.width / 2.0f , widgetSize.height / 2.0f - 40));
-        slider->addEventListener(CC_CALLBACK_2(UIPageViewCustomScrollThreshold::sliderEvent, this));
-        slider->setPercent(50);
-        _uiLayer->addChild(slider);
-
-        
-        return true;
-    }
-    return false;
-}
-
-
-void UIPageViewCustomScrollThreshold::sliderEvent(Ref *pSender, Slider::EventType type)
-{
-    if (type == Slider::EventType::ON_PERCENTAGE_CHANGED)
-    {
-        Slider* slider = dynamic_cast<Slider*>(pSender);
-        int percent = slider->getPercent();
-        PageView* pageView = (PageView*)_uiLayer->getChildByName("pageView");
-        if (percent == 0) {
-            percent = 1;
-        }
-        pageView->setCustomScrollThreshold(percent * 0.01 * pageView->getContentSize().width);
-        
-        _displayValueLabel->setString(StringUtils::format("Scroll Threshold: %f", pageView->getCustomScrollThreshold()));
-    }
-}
 
 // UIPageViewTouchPropagationTest
 UIPageViewTouchPropagationTest::UIPageViewTouchPropagationTest()

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIPageViewTest/UIPageViewTest.h
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIPageViewTest/UIPageViewTest.h
@@ -45,13 +45,6 @@ protected:
     cocos2d::ui::Text* _displayValueLabel;
 };
 
-class UIPageViewByListViewTest : public UIScene
-{
-public:
-    CREATE_FUNC(UIPageViewByListViewTest);
-    virtual bool init() override;
-};
-
 class UIPageViewButtonTest : public UIScene
 {
 public:

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIPageViewTest/UIPageViewTest.h
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIPageViewTest/UIPageViewTest.h
@@ -37,12 +37,19 @@ public:
     UIPageViewTest();
     ~UIPageViewTest();
     virtual bool init() override;
-    
+
     void pageViewEvent(cocos2d::Ref* sender, cocos2d::ui::PageView::EventType type);
-    
+
 protected:
-    
+
     cocos2d::ui::Text* _displayValueLabel;
+};
+
+class UIPageViewByListViewTest : public UIScene
+{
+public:
+    CREATE_FUNC(UIPageViewByListViewTest);
+    virtual bool init() override;
 };
 
 class UIPageViewButtonTest : public UIScene

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIPageViewTest/UIPageViewTest.h
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIPageViewTest/UIPageViewTest.h
@@ -61,23 +61,6 @@ protected:
     cocos2d::ui::Text* _displayValueLabel;
 };
 
-class UIPageViewCustomScrollThreshold : public UIScene
-{
-public:
-    CREATE_FUNC(UIPageViewCustomScrollThreshold);
-
-    UIPageViewCustomScrollThreshold();
-    ~UIPageViewCustomScrollThreshold();
-    virtual bool init() override;
-    
-    void sliderEvent(cocos2d::Ref* sender, cocos2d::ui::Slider::EventType type);
-
-    void pageViewEvent(cocos2d::Ref* sender, cocos2d::ui::PageView::EventType type);
-protected:
-    
-    cocos2d::ui::Text* _displayValueLabel;
-};
-
 class UIPageViewTouchPropagationTest : public UIScene
 {
 public:


### PR DESCRIPTION
`PageView` was derived from `Layout` and it implemented the features of scrolling and item arrangement from scratch. But the features are already there in `ListView`. So remove those duplicated implementations from `PageView` and make it subclass from `ListView`.

By this, `PageView` becomes more simplified and maintainable because it considers only paging implementation. And the user experiences regarding scrolling are processed in one place - `ScrollView`.

One more, page view now has a page indicator which is represented as a list of small circles.
