### PR TITLE
Added Application::getVersion() to get the app version.

### DIFF
--- a/cocos/platform/CCApplicationProtocol.h
+++ b/cocos/platform/CCApplicationProtocol.h
@@ -137,6 +137,13 @@ public:
     virtual Platform getTargetPlatform() = 0;
     
     /**
+     @brief Get application version.
+     * @js NA
+     * @lua NA
+     */
+    virtual std::string getVersion() = 0;
+    
+    /**
      @brief Open url in default browser.
      @param String with url to open.
      @return True if the resource located by the URL was successfully opened; otherwise false.

--- a/cocos/platform/android/CCApplication-android.cpp
+++ b/cocos/platform/android/CCApplication-android.cpp
@@ -200,6 +200,11 @@ Application::Platform Application::getTargetPlatform()
     return Platform::OS_ANDROID;
 }
 
+std::string Application::getVersion()
+{
+    return getVersionJNI();
+}
+
 bool Application::openURL(const std::string &url)
 {
     return openURLJNI(url.c_str());

--- a/cocos/platform/android/CCApplication-android.h
+++ b/cocos/platform/android/CCApplication-android.h
@@ -85,6 +85,11 @@ public:
     virtual Platform getTargetPlatform();
     
     /**
+     @brief Get application version.
+     */
+    virtual std::string getVersion();
+
+    /**
      @brief Open url in default browser
      @param String with url to open.
      @return true if the resource located by the URL was successfully opened; otherwise false.

--- a/cocos/platform/android/CCApplication-android.h
+++ b/cocos/platform/android/CCApplication-android.h
@@ -87,7 +87,7 @@ public:
     /**
      @brief Get application version.
      */
-    virtual std::string getVersion();
+    virtual std::string getVersion() override;
 
     /**
      @brief Open url in default browser

--- a/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxHelper.java
+++ b/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxHelper.java
@@ -212,6 +212,15 @@ public class Cocos2dxHelper {
         sVibrateService.vibrate((long)(duration * 1000));
     }
 
+ 	public static String getVersion() {
+ 		try {
+ 			String version = Cocos2dxActivity.getContext().getPackageManager().getPackageInfo(Cocos2dxActivity.getContext().getPackageName(), 0).versionName;
+ 			return version;
+ 		} catch(Exception e) {
+ 			return "-";
+ 		}
+ 	}
+
     public static boolean openURL(String url) { 
         boolean ret = false;
         try {

--- a/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxHelper.java
+++ b/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxHelper.java
@@ -217,7 +217,7 @@ public class Cocos2dxHelper {
  			String version = Cocos2dxActivity.getContext().getPackageManager().getPackageInfo(Cocos2dxActivity.getContext().getPackageName(), 0).versionName;
  			return version;
  		} catch(Exception e) {
- 			return "-";
+ 			return "";
  		}
  	}
 

--- a/cocos/platform/android/jni/Java_org_cocos2dx_lib_Cocos2dxHelper.cpp
+++ b/cocos/platform/android/jni/Java_org_cocos2dx_lib_Cocos2dxHelper.cpp
@@ -205,6 +205,19 @@ void vibrateJni(float duration) {
     }
 }
 
+std::string getVersionJNI() {
+    JniMethodInfo t;
+    std::string ret("");
+
+    if (JniHelper::getStaticMethodInfo(t, CLASS_NAME, "getVersion", "()Ljava/lang/String;")) {
+        jstring str = (jstring)t.env->CallStaticObjectMethod(t.classID, t.methodID);
+        t.env->DeleteLocalRef(t.classID);
+        ret = JniHelper::jstring2string(str);
+        t.env->DeleteLocalRef(str);
+    }
+    return ret;
+}
+
 extern bool openURLJNI(const char* url) {
     JniMethodInfo t;
     

--- a/cocos/platform/android/jni/Java_org_cocos2dx_lib_Cocos2dxHelper.h
+++ b/cocos/platform/android/jni/Java_org_cocos2dx_lib_Cocos2dxHelper.h
@@ -40,6 +40,7 @@ extern void disableAccelerometerJni();
 extern void setAccelerometerIntervalJni(float interval);
 extern void setKeepScreenOnJni(bool value);
 extern void vibrateJni(float duration);
+extern std::string getVersionJNI();
 extern bool openURLJNI(const char* url);
 // functions for UserDefault
 extern bool getBoolForKeyJNI(const char* key, bool defaultValue);

--- a/cocos/platform/ios/CCApplication-ios.h
+++ b/cocos/platform/ios/CCApplication-ios.h
@@ -67,24 +67,24 @@ public:
      @brief    Callback by Director for limit FPS.
      @param interval    The time, expressed in seconds, between current frame and next.
      */
-    virtual void setAnimationInterval(float interval);
+    virtual void setAnimationInterval(float interval) override;
 
     /**
     @brief Get current language config
     @return Current language config
     */
-    virtual LanguageType getCurrentLanguage();
+    virtual LanguageType getCurrentLanguage() override;
     
     /**
      @brief Get current language iso 639-1 code
      @return Current language iso 639-1 code
      */
-    virtual const char * getCurrentLanguageCode();
+    virtual const char * getCurrentLanguageCode() override;
     
     /**
      @brief Get target platform
      */
-    virtual Platform getTargetPlatform();
+    virtual Platform getTargetPlatform() override;
     
     /**
      @brief Get application version.
@@ -96,7 +96,7 @@ public:
      @param String with url to open.
      @return true if the resource located by the URL was successfully opened; otherwise false.
      */
-    virtual bool openURL(const std::string &url);
+    virtual bool openURL(const std::string &url) override;
 
     /**
     @brief  This function will be called when the application screen size is changed.

--- a/cocos/platform/ios/CCApplication-ios.h
+++ b/cocos/platform/ios/CCApplication-ios.h
@@ -89,7 +89,7 @@ public:
     /**
      @brief Get application version.
      */
-    virtual std::string getVersion();
+    virtual std::string getVersion() override;
     
     /**
      @brief Open url in default browser

--- a/cocos/platform/ios/CCApplication-ios.h
+++ b/cocos/platform/ios/CCApplication-ios.h
@@ -87,6 +87,11 @@ public:
     virtual Platform getTargetPlatform();
     
     /**
+     @brief Get application version.
+     */
+    virtual std::string getVersion();
+    
+    /**
      @brief Open url in default browser
      @param String with url to open.
      @return true if the resource located by the URL was successfully opened; otherwise false.

--- a/cocos/platform/ios/CCApplication-ios.mm
+++ b/cocos/platform/ios/CCApplication-ios.mm
@@ -139,6 +139,14 @@ Application::Platform Application::getTargetPlatform()
     }
 }
 
+std::string Application::getVersion() {
+    NSString* version = [[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleShortVersionString"];
+    if (version) {
+        return [version UTF8String];
+    }
+    return "";
+}
+
 bool Application::openURL(const std::string &url)
 {
     NSString* msg = [NSString stringWithCString:url.c_str() encoding:NSUTF8StringEncoding];

--- a/cocos/platform/linux/CCApplication-linux.cpp
+++ b/cocos/platform/linux/CCApplication-linux.cpp
@@ -136,6 +136,11 @@ Application::Platform Application::getTargetPlatform()
     return Platform::OS_LINUX;
 }
 
+std::string Application::getVersion()
+{
+    return "";
+}
+
 bool Application::openURL(const std::string &url)
 {
     std::string op = std::string("open ").append(url);

--- a/cocos/platform/linux/CCApplication-linux.h
+++ b/cocos/platform/linux/CCApplication-linux.h
@@ -81,7 +81,7 @@ public:
     /**
     @brief Get application version
     */
-    virtual std::string getVersion();
+    virtual std::string getVersion() override;
 
   /**
    @brief Open url in default browser

--- a/cocos/platform/linux/CCApplication-linux.h
+++ b/cocos/platform/linux/CCApplication-linux.h
@@ -78,6 +78,11 @@ public:
     */
     virtual const char * getCurrentLanguageCode();
     
+    /**
+    @brief Get application version
+    */
+    virtual std::string getVersion();
+
   /**
    @brief Open url in default browser
    @param String with url to open.

--- a/cocos/platform/mac/CCApplication-mac.h
+++ b/cocos/platform/mac/CCApplication-mac.h
@@ -52,7 +52,7 @@ public:
     @brief  Callback by Director for limit FPS.
     @param interval The time, which expressed in second in second, between current frame and next.
     */
-    virtual void setAnimationInterval(float interval);
+    virtual void setAnimationInterval(float interval) override;
     
     /**
     @brief  Get status bar rectangle in GLView window.
@@ -78,18 +78,18 @@ public:
     @brief Get current language config
     @return Current language config
     */
-    virtual LanguageType getCurrentLanguage();
+    virtual LanguageType getCurrentLanguage() override;
     
     /**
     @brief Get current language iso 639-1 code
     @return Current language iso 639-1 code
     */
-    virtual const char * getCurrentLanguageCode();
+    virtual const char * getCurrentLanguageCode() override;
     
     /**
      @brief Get target platform
      */
-    virtual Platform getTargetPlatform();
+    virtual Platform getTargetPlatform() override;
     
     /**
      @brief Get application version.
@@ -101,7 +101,7 @@ public:
      @param String with url to open.
      @return true if the resource located by the URL was successfully opened; otherwise false.
      */
-    virtual bool openURL(const std::string &url);
+    virtual bool openURL(const std::string &url) override;
 
     /**
      *  Sets the Resource root path.

--- a/cocos/platform/mac/CCApplication-mac.h
+++ b/cocos/platform/mac/CCApplication-mac.h
@@ -94,7 +94,7 @@ public:
     /**
      @brief Get application version.
      */
-    virtual std::string getVersion();
+    virtual std::string getVersion() override;
 
     /**
      @brief Open url in default browser

--- a/cocos/platform/mac/CCApplication-mac.h
+++ b/cocos/platform/mac/CCApplication-mac.h
@@ -92,6 +92,11 @@ public:
     virtual Platform getTargetPlatform();
     
     /**
+     @brief Get application version.
+     */
+    virtual std::string getVersion();
+
+    /**
      @brief Open url in default browser
      @param String with url to open.
      @return true if the resource located by the URL was successfully opened; otherwise false.

--- a/cocos/platform/mac/CCApplication-mac.mm
+++ b/cocos/platform/mac/CCApplication-mac.mm
@@ -118,6 +118,14 @@ Application::Platform Application::getTargetPlatform()
     return Platform::OS_MAC;
 }
 
+std::string Application::getVersion() {
+    NSString* version = [[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleShortVersionString"];
+    if (version) {
+        return [version UTF8String];
+    }
+    return "";
+}
+
 /////////////////////////////////////////////////////////////////////////////////////////////////
 // static member function
 //////////////////////////////////////////////////////////////////////////////////////////////////

--- a/cocos/platform/win32/CCApplication-win32.cpp
+++ b/cocos/platform/win32/CCApplication-win32.cpp
@@ -217,6 +217,11 @@ Application::Platform Application::getTargetPlatform()
     return Platform::OS_WINDOWS;
 }
 
+std::string Application::getVersion()
+{
+    return "";
+}
+
 bool Application::openURL(const std::string &url)
 {
     WCHAR *temp = new WCHAR[url.size() + 1];

--- a/cocos/platform/win32/CCApplication-win32.h
+++ b/cocos/platform/win32/CCApplication-win32.h
@@ -78,7 +78,7 @@ public:
     /**
     @brief Get application version
     */
-    virtual std::string getVersion();
+    virtual std::string getVersion() override;
 
     /**
      @brief Open url in default browser

--- a/cocos/platform/win32/CCApplication-win32.h
+++ b/cocos/platform/win32/CCApplication-win32.h
@@ -76,6 +76,11 @@ public:
     virtual Platform getTargetPlatform();
     
     /**
+    @brief Get application version
+    */
+    virtual std::string getVersion();
+
+    /**
      @brief Open url in default browser
      @param String with url to open.
      @return true if the resource located by the URL was successfully opened; otherwise false.

--- a/cocos/platform/winrt/CCApplication.cpp
+++ b/cocos/platform/winrt/CCApplication.cpp
@@ -36,6 +36,7 @@ using namespace Windows::Foundation;
 #include "platform/CCFileUtils.h"
 #include "CCWinRTUtils.h"
 #include "platform/CCApplication.h"
+#include "tinyxml2/tinyxml2.h"
 
 /**
 @brief    This function change the PVRFrame show/hide setting in register.
@@ -223,6 +224,25 @@ Application::Platform  Application::getTargetPlatform()
     {
         return Platform::OS_WINRT;
     }
+}
+
+std::string  Application::getVersion()
+{
+    std::string r("");
+    std::string s = FileUtils::getInstance()->getStringFromFile("WMAppManifest.xml");
+    if (!s.empty()) {
+        tinyxml2::XMLDocument doc;
+        if (!doc.Parse(s.c_str())) {
+            tinyxml2::XMLElement *app = doc.RootElement()->FirstChildElement("App");
+            if (app) {
+                const char* version = app->Attribute("Version");
+                if (version) {
+                    r = version;
+                }
+            }
+        }
+    }
+    return r;
 }
 
 bool Application::openURL(const std::string &url)

--- a/cocos/platform/winrt/CCApplication.h
+++ b/cocos/platform/winrt/CCApplication.h
@@ -63,6 +63,11 @@ public:
      @brief Get target platform
      */
     virtual Platform getTargetPlatform() override;
+
+    /**
+     @brief Get application version
+     */
+    virtual std::string getVersion() override;
     
     /**
      @brief Open url in default browser


### PR DESCRIPTION
Added a method to the Application class to get the version of the app on iOS/Mac/Android/Win8, on the remaining platforms that don't have app versions it should return an empty string.

The feature has been requested in this discussion thread: http://discuss.cocos2d-x.org/t/check-app-version/6294/5
