### PR TITLE
improve scale9sprite

### DIFF
--- a/cocos/2d/CCAutoPolygon.cpp
+++ b/cocos/2d/CCAutoPolygon.cpp
@@ -87,6 +87,17 @@ void PolygonInfo::setQuad(V3F_C4B_T2F_Quad *quad)
     triangles.verts = (V3F_C4B_T2F*)quad;
 }
 
+void PolygonInfo::setTriangles(TrianglesCommand::Triangles other)
+{
+    this->releaseVertsAndIndices();
+    isVertsOwner = false;
+    
+    this->triangles.vertCount = other.vertCount;
+    this->triangles.indexCount = other.indexCount;
+    this->triangles.verts = other.verts;
+    this->triangles.indices = other.indices;
+}
+
 void PolygonInfo::releaseVertsAndIndices()
 {
     if(isVertsOwner)

--- a/cocos/2d/CCAutoPolygon.h
+++ b/cocos/2d/CCAutoPolygon.h
@@ -90,6 +90,14 @@ public:
     void setQuad(V3F_C4B_T2F_Quad *quad);
 
     /**
+     * set the data to be a pointer to a triangles
+     * the member verts will not be released when this PolygonInfo destructs
+     * as the verts memory are managed by other objects
+     * @param triangles  a pointer to the TrianglesCommand::Triangles object
+     */
+    void setTriangles(TrianglesCommand::Triangles triangles);
+
+    /**
      * get vertex count
      * @return number of vertices
      */
@@ -110,7 +118,6 @@ public:
     Rect rect;
     std::string filename;
     TrianglesCommand::Triangles triangles;
-    
 protected:
     bool isVertsOwner;
     

--- a/cocos/2d/CCSprite.cpp
+++ b/cocos/2d/CCSprite.cpp
@@ -1135,7 +1135,7 @@ std::string Sprite::getDescription() const
     return StringUtils::format("<Sprite | Tag = %d, TextureID = %d>", _tag, texture_id );
 }
 
-PolygonInfo Sprite::getPolygonInfo() const
+PolygonInfo& Sprite::getPolygonInfo()
 {
     return _polyInfo;
 }

--- a/cocos/2d/CCSprite.h
+++ b/cocos/2d/CCSprite.h
@@ -403,6 +403,19 @@ public:
      */
     CC_DEPRECATED_ATTRIBUTE void setFlipY(bool flippedY) { setFlippedY(flippedY); };
 
+    /**
+     * returns a reference of the polygon information associated with this sprite
+     *
+     * @return a copy of PolygonInfo
+     */
+    PolygonInfo& getPolygonInfo();
+
+    /**
+     * set the sprite to use this new PolygonInfo
+     *
+     * @param PolygonInfo the polygon information object
+     */
+    void setPolygonInfo(const PolygonInfo& info);
     //
     // Overrides
     //
@@ -564,20 +577,6 @@ CC_CONSTRUCTOR_ACCESS:
      */
     virtual bool initWithFile(const std::string& filename, const Rect& rect);
     
-    /**
-     * returns a copy of the polygon information associated with this sprite
-     * because this is a copy process it is slower than getting the reference, so use wisely
-     *
-     * @return a copy of PolygonInfo
-     */
-    PolygonInfo getPolygonInfo() const;
-    
-    /**
-     * set the sprite to use this new PolygonInfo
-     *
-     * @param PolygonInfo the polygon information object
-     */
-    void setPolygonInfo(const PolygonInfo& info);
 protected:
 
     void updateColor() override;

--- a/cocos/ui/UIScale9Sprite.cpp
+++ b/cocos/ui/UIScale9Sprite.cpp
@@ -477,6 +477,14 @@ namespace ui {
 
         return true;
     }
+    
+    void Scale9Sprite::configureSimpleModeRendering()
+    {
+        this->setInsetTop(0);
+        this->setInsetBottom(0);
+        this->setInsetLeft(0);
+        this->setInsetRight(0);
+    }
 
     void Scale9Sprite::createSlicedSprites()
     {
@@ -488,6 +496,11 @@ namespace ui {
             if (tex == nullptr)
             {
                 return;
+            }
+            
+            if (_renderingType == RenderingType::SIMPLE)
+            {
+                this->configureSimpleModeRendering();
             }
 
             auto capInsets = CC_RECT_POINTS_TO_PIXELS(_capInsetsInternal);
@@ -1261,13 +1274,6 @@ namespace ui {
     void Scale9Sprite::setRenderingType(cocos2d::ui::Scale9Sprite::RenderingType type)
     {
         _renderingType = type;
-        if (_renderingType == RenderingType::SIMPLE)
-        {
-            this->setInsetTop(0);
-            this->setInsetBottom(0);
-            this->setInsetLeft(0);
-            this->setInsetRight(0);
-        }
     }
     
     Scale9Sprite::RenderingType Scale9Sprite::getRenderingType()const

--- a/cocos/ui/UIScale9Sprite.cpp
+++ b/cocos/ui/UIScale9Sprite.cpp
@@ -1273,7 +1273,12 @@ namespace ui {
     
     void Scale9Sprite::setRenderingType(cocos2d::ui::Scale9Sprite::RenderingType type)
     {
+        if (_renderingType == type)
+        {
+            return;
+        }
         _renderingType = type;
+        _sliceSpriteDirty = true;
     }
     
     Scale9Sprite::RenderingType Scale9Sprite::getRenderingType()const

--- a/cocos/ui/UIScale9Sprite.cpp
+++ b/cocos/ui/UIScale9Sprite.cpp
@@ -52,6 +52,7 @@ namespace ui {
         ,_nonSliceSpriteAnchor(Vec2::ANCHOR_MIDDLE)
         ,_sliceVertices(nullptr)
         ,_sliceIndices(nullptr)
+        ,_sliceSpriteDirty(false)
     {
         this->setAnchorPoint(Vec2(0.5,0.5));
     }
@@ -453,7 +454,7 @@ namespace ui {
         {
             _scale9Image->setAnchorPoint(Vec2::ZERO);
             _scale9Image->setPosition(Vec2::ZERO);
-            this->createSlicedSprites();
+            _sliceSpriteDirty = true;
         }
 
         applyBlendFunc();
@@ -521,8 +522,8 @@ namespace ui {
         }
         Node::setContentSize(size);
         _preferredSize = size;
-        this->createSlicedSprites();
-        this->adjustScale9ImagePosition();
+        _sliceSpriteDirty = true;
+        this->adjustNoneScale9ImagePosition();
     }
 
     Scale9Sprite* Scale9Sprite::resizableSpriteWithCapInsets(const Rect& capInsets) const
@@ -533,7 +534,7 @@ namespace ui {
                                       _spriteFrameRotated,
                                       Vec2::ZERO,
                                       _originalSize,
-                                      _capInsetsInternal) )
+                                      capInsets) )
         {
             pReturn->autorelease();
             return pReturn;
@@ -662,6 +663,10 @@ namespace ui {
         if (!_visible)
         {
             return;
+        }
+        if (_scale9Enabled && _sliceSpriteDirty) {
+            this->createSlicedSprites();
+            _sliceSpriteDirty = false;
         }
 
         uint32_t flags = processParentFlags(parentTransform, parentFlags);
@@ -796,7 +801,7 @@ namespace ui {
             }
           
         }
-        this->adjustScale9ImagePosition();
+        this->adjustNoneScale9ImagePosition();
     }
 
     bool Scale9Sprite::isScale9Enabled() const
@@ -813,12 +818,12 @@ namespace ui {
             {
                 _nonSliceSpriteAnchor = position;
                 _scale9Image->setAnchorPoint(position);
-                this->adjustScale9ImagePosition();
+                this->adjustNoneScale9ImagePosition();
             }
         }
     }
 
-    void Scale9Sprite::adjustScale9ImagePosition()
+    void Scale9Sprite::adjustNoneScale9ImagePosition()
     {
         if (_scale9Image)
         {

--- a/cocos/ui/UIScale9Sprite.cpp
+++ b/cocos/ui/UIScale9Sprite.cpp
@@ -49,9 +49,9 @@ namespace ui {
         ,_flippedY(false)
         ,_isPatch9(false)
         ,_brightState(State::NORMAL)
+        ,_nonSliceSpriteAnchor(Vec2::ANCHOR_MIDDLE)
         ,_sliceVertices(nullptr)
         ,_sliceIndices(nullptr)
-        ,_nonSliceSpriteAnchor(Vec2::ANCHOR_MIDDLE)
     {
         this->setAnchorPoint(Vec2(0.5,0.5));
     }
@@ -138,6 +138,7 @@ namespace ui {
                             const Size &originalSize,
                             const Rect& capInsets)
     {
+        bool ret = true;
         if(sprite)
         {
             auto texture = sprite->getTexture();
@@ -157,16 +158,16 @@ namespace ui {
 
                 }
             }
-           
-            this->updateWithSprite(sprite,
-                                   rect,
-                                   rotated,
-                                   offset,
-                                   originalSize,
-                                   actualCapInsets);
+
+            ret = this->updateWithSprite(sprite,
+                                         rect,
+                                         rotated,
+                                         offset,
+                                         originalSize,
+                                         actualCapInsets);
         }
 
-        return true;
+        return ret;
     }
 
     bool Scale9Sprite::initWithBatchNode(cocos2d::SpriteBatchNode *batchnode,
@@ -391,6 +392,7 @@ namespace ui {
                                         const Size &originalSize,
                                         const Rect& capInsets)
     {
+        
         GLubyte opacity = getOpacity();
         Color3B color = getColor();
 
@@ -418,15 +420,6 @@ namespace ui {
         }
 
         if (!_scale9Image)
-        {
-            return false;
-        }
-        _scale9Image->setAnchorPoint(Vec2::ZERO);
-        _scale9Image->setPosition(Vec2::ZERO);
-        
-        SpriteFrame *spriteFrame = _scale9Image->getSpriteFrame();
-
-        if (!spriteFrame)
         {
             return false;
         }
@@ -458,6 +451,8 @@ namespace ui {
 
         if (_scale9Enabled)
         {
+            _scale9Image->setAnchorPoint(Vec2::ZERO);
+            _scale9Image->setPosition(Vec2::ZERO);
             this->createSlicedSprites();
         }
 
@@ -487,33 +482,33 @@ namespace ui {
         if (_scale9Enabled)
         {
             Texture2D *tex = _scale9Image ? _scale9Image->getTexture() : nullptr;
-            
+
             if (tex == nullptr)
             {
                 return;
             }
-            
+
             auto capInsets = CC_RECT_POINTS_TO_PIXELS(_capInsetsInternal);
             auto textureRect = CC_RECT_POINTS_TO_PIXELS(_spriteRect);
             auto spriteRectSize = CC_SIZE_POINTS_TO_PIXELS(_originalSize);
-            
+
             //handle .9.png
             if (_isPatch9)
             {
                 spriteRectSize = Size(spriteRectSize.width - 2, spriteRectSize.height-2);
             }
-            
-            
+
+
             if(capInsets.equals(Rect::ZERO))
             {
                 capInsets = Rect(spriteRectSize.width/3, spriteRectSize.height/3,
                                  spriteRectSize.width/3, spriteRectSize.height/3);
             }
-            
+
             auto uv = this->calculateUV(tex, capInsets, spriteRectSize);
             auto vertices = this->calculateVertices(capInsets, spriteRectSize);
             auto triangles = this->calculateTriangles(uv, vertices);
-            
+
             _scale9Image->getPolygonInfo().setTriangles(triangles);
         }
     }

--- a/cocos/ui/UIScale9Sprite.cpp
+++ b/cocos/ui/UIScale9Sprite.cpp
@@ -39,17 +39,7 @@ namespace ui {
     Scale9Sprite::Scale9Sprite()
         : _spritesGenerated(false)
         , _spriteFrameRotated(false)
-        , _positionsAreDirty(true)
         , _scale9Image(nullptr)
-        , _topLeftSprite(nullptr)
-        , _topSprite(nullptr)
-        , _topRightSprite(nullptr)
-        , _leftSprite(nullptr)
-        , _centerSprite(nullptr)
-        , _rightSprite(nullptr)
-        , _bottomLeftSprite(nullptr)
-        , _bottomSprite(nullptr)
-        , _bottomRightSprite(nullptr)
         , _scale9Enabled(true)
         , _insetLeft(0)
         , _insetTop(0)
@@ -59,7 +49,9 @@ namespace ui {
         ,_flippedY(false)
         ,_isPatch9(false)
         ,_brightState(State::NORMAL)
-
+        ,_sliceVertices(nullptr)
+        ,_sliceIndices(nullptr)
+        ,_nonSliceSpriteAnchor(Vec2::ANCHOR_MIDDLE)
     {
         this->setAnchorPoint(Vec2(0.5,0.5));
     }
@@ -333,58 +325,8 @@ namespace ui {
 
     void Scale9Sprite::cleanupSlicedSprites()
     {
-        if (_topLeftSprite && _topLeftSprite->isRunning())
-        {
-            _topLeftSprite->onExit();
-        }
-        if (_topSprite && _topSprite->isRunning())
-        {
-            _topSprite->onExit();
-        }
-        if (_topRightSprite && _topRightSprite->isRunning())
-        {
-            _topRightSprite->onExit();
-        }
-
-        if (_leftSprite && _leftSprite->isRunning())
-        {
-            _leftSprite->onExit();
-        }
-
-        if (_centerSprite && _centerSprite->isRunning())
-        {
-            _centerSprite->onExit();
-        }
-
-        if (_rightSprite && _rightSprite->isRunning())
-        {
-            _rightSprite->onExit();
-        }
-
-        if (_bottomLeftSprite && _bottomLeftSprite->isRunning())
-        {
-            _bottomLeftSprite->onExit();
-        }
-
-        if (_bottomRightSprite && _bottomRightSprite->isRunning())
-        {
-            _bottomRightSprite->onExit();
-        }
-
-        if (_bottomSprite && _bottomSprite->isRunning())
-        {
-            _bottomSprite->onExit();
-        }
-
-        CC_SAFE_RELEASE_NULL(_topLeftSprite);
-        CC_SAFE_RELEASE_NULL(_topSprite);
-        CC_SAFE_RELEASE_NULL(_topRightSprite);
-        CC_SAFE_RELEASE_NULL(_leftSprite);
-        CC_SAFE_RELEASE_NULL(_centerSprite);
-        CC_SAFE_RELEASE_NULL(_rightSprite);
-        CC_SAFE_RELEASE_NULL(_bottomLeftSprite);
-        CC_SAFE_RELEASE_NULL(_bottomSprite);
-        CC_SAFE_RELEASE_NULL(_bottomRightSprite);
+        CC_SAFE_DELETE_ARRAY(_sliceIndices);
+        CC_SAFE_DELETE_ARRAY(_sliceVertices);
     }
 
 
@@ -418,24 +360,6 @@ namespace ui {
     {
         if(_scale9Image)
             _scale9Image->setBlendFunc(_blendFunc);
-        if(_topLeftSprite)
-            _topLeftSprite->setBlendFunc(_blendFunc);
-        if(_topSprite)
-            _topSprite->setBlendFunc(_blendFunc);
-        if(_topRightSprite)
-            _topRightSprite->setBlendFunc(_blendFunc);
-        if(_leftSprite)
-            _leftSprite->setBlendFunc(_blendFunc);
-        if(_centerSprite)
-            _centerSprite->setBlendFunc(_blendFunc);
-        if(_rightSprite)
-            _rightSprite->setBlendFunc(_blendFunc);
-        if(_bottomLeftSprite)
-            _bottomLeftSprite->setBlendFunc(_blendFunc);
-        if(_bottomSprite)
-            _bottomSprite->setBlendFunc(_blendFunc);
-        if(_bottomRightSprite)
-            _bottomRightSprite->setBlendFunc(_blendFunc);
     }
 
     bool Scale9Sprite::updateWithBatchNode(cocos2d::SpriteBatchNode *batchnode,
@@ -460,22 +384,6 @@ namespace ui {
         return updateWithSprite(sprite, rect, rotated, Vec2::ZERO, rect.size, capInsets);
     }
 
-    static Rect intersectRect(const Rect &first, const Rect &second)
-    {
-        Rect ret;
-        ret.origin.x = std::max(first.origin.x,second.origin.x);
-        ret.origin.y = std::max(first.origin.y,second.origin.y);
-
-        float rightRealPoint = std::min(first.origin.x + first.size.width,
-                                        second.origin.x + second.size.width);
-        float bottomRealPoint = std::min(first.origin.y + first.size.height,
-                                         second.origin.y + second.size.height);
-
-        ret.size.width = std::max(rightRealPoint - ret.origin.x, 0.0f);
-        ret.size.height = std::max(bottomRealPoint - ret.origin.y, 0.0f);
-        return ret;
-    }
-
     bool Scale9Sprite::updateWithSprite(Sprite* sprite,
                                         const Rect& textureRect,
                                         bool rotated,
@@ -488,7 +396,6 @@ namespace ui {
 
         // Release old sprites
         this->cleanupSlicedSprites();
-        _protectedChildren.clear();
 
         updateBlendFunc(sprite?sprite->getTexture():nullptr);
 
@@ -514,7 +421,9 @@ namespace ui {
         {
             return false;
         }
-
+        _scale9Image->setAnchorPoint(Vec2::ZERO);
+        _scale9Image->setPosition(Vec2::ZERO);
+        
         SpriteFrame *spriteFrame = _scale9Image->getSpriteFrame();
 
         if (!spriteFrame)
@@ -525,8 +434,6 @@ namespace ui {
         Rect rect(textureRect);
         Size size(originalSize);
         
-        _capInsets = capInsets;
-
         // If there is no given rect
         if ( rect.equals(Rect::ZERO) )
         {
@@ -543,7 +450,6 @@ namespace ui {
 
         // Set the given rect's size as original size
         _spriteRect = rect;
-        _offset = offset;
         _spriteFrameRotated = rotated;
         _originalSize = size;
         _preferredSize = size;
@@ -577,464 +483,52 @@ namespace ui {
 
     void Scale9Sprite::createSlicedSprites()
     {
-        float width = _originalSize.width;
-        float height = _originalSize.height;
-
-        Vec2 offsetPosition(floor(_offset.x + (_originalSize.width - _spriteRect.size.width) / 2),
-                            floor(_offset.y + (_originalSize.height - _spriteRect.size.height) / 2));
-
-        // If there is no specified center region
-        if ( _capInsetsInternal.equals(Rect::ZERO) )
+        //todo create sliced sprite
+        if (_scale9Enabled)
         {
-            // log("... cap insets not specified : using default cap insets ...");
-            _capInsetsInternal = Rect(width /3, height /3, width /3, height /3);
-        }
-
-        Rect originalRect=_spriteRect;
-        if(_spriteFrameRotated)
-            originalRect = Rect(_spriteRect.origin.x - offsetPosition.y,
-                                _spriteRect.origin.y - offsetPosition.x,
-                                _originalSize.width, _originalSize.height);
-        else
-            originalRect = Rect(_spriteRect.origin.x - offsetPosition.x,
-                                _spriteRect.origin.y - offsetPosition.y,
-                                _originalSize.width, _originalSize.height);
-
-        float leftWidth = _capInsetsInternal.origin.x;
-        float centerWidth = _capInsetsInternal.size.width;
-        float rightWidth = originalRect.size.width - (leftWidth + centerWidth);
-
-        float topHeight = _capInsetsInternal.origin.y;
-        float centerHeight = _capInsetsInternal.size.height;
-        float bottomHeight = originalRect.size.height - (topHeight + centerHeight);
-
-        // calculate rects
-
-        // ... top row
-        float x = 0.0;
-        float y = 0.0;
-        //why do we need pixelRect?
-        Rect pixelRect = Rect(offsetPosition.x, offsetPosition.y,
-                              _spriteRect.size.width, _spriteRect.size.height);
-
-        // top left
-        Rect leftTopBoundsOriginal = Rect(x, y, leftWidth, topHeight);
-        Rect leftTopBounds = leftTopBoundsOriginal;
-
-        // top center
-        x += leftWidth;
-        Rect centerTopBounds = Rect(x, y, centerWidth, topHeight);
-
-        // top right
-        x += centerWidth;
-        Rect rightTopBounds = Rect(x, y, rightWidth, topHeight);
-
-        // ... center row
-        x = 0.0;
-        y = 0.0;
-        y += topHeight;
-
-        // center left
-        Rect leftCenterBounds = Rect(x, y, leftWidth, centerHeight);
-
-        // center center
-        x += leftWidth;
-        Rect centerBoundsOriginal = Rect(x, y, centerWidth, centerHeight);
-        Rect centerBounds = centerBoundsOriginal;
-
-        // center right
-        x += centerWidth;
-        Rect rightCenterBounds = Rect(x, y, rightWidth, centerHeight);
-
-        // ... bottom row
-        x = 0.0;
-        y = 0.0;
-        y += topHeight;
-        y += centerHeight;
-
-        // bottom left
-        Rect leftBottomBounds = Rect(x, y, leftWidth, bottomHeight);
-
-        // bottom center
-        x += leftWidth;
-        Rect centerBottomBounds = Rect(x, y, centerWidth, bottomHeight);
-
-        // bottom right
-        x += centerWidth;
-        Rect rightBottomBoundsOriginal = Rect(x, y, rightWidth, bottomHeight);
-        Rect rightBottomBounds = rightBottomBoundsOriginal;
-
-        if((_capInsetsInternal.origin.x + _capInsetsInternal.size.width) <= _originalSize.width
-           || (_capInsetsInternal.origin.y + _capInsetsInternal.size.height) <= _originalSize.height)
-            //in general case it is error but for legacy support we will check it
-        {
-            leftTopBounds = intersectRect(leftTopBounds, pixelRect);
-            centerTopBounds = intersectRect(centerTopBounds, pixelRect);
-            rightTopBounds = intersectRect(rightTopBounds, pixelRect);
-            leftCenterBounds = intersectRect(leftCenterBounds, pixelRect);
-            centerBounds = intersectRect(centerBounds, pixelRect);
-            rightCenterBounds = intersectRect(rightCenterBounds, pixelRect);
-            leftBottomBounds = intersectRect(leftBottomBounds, pixelRect);
-            centerBottomBounds = intersectRect(centerBottomBounds, pixelRect);
-            rightBottomBounds = intersectRect(rightBottomBounds, pixelRect);
-        }
-        else
-            //it is error but for legacy turn off clip system
-            CCLOG("Scale9Sprite capInsetsInternal > originalSize");
-
-        Rect rotatedLeftTopBoundsOriginal = leftTopBoundsOriginal;
-        Rect rotatedCenterBoundsOriginal = centerBoundsOriginal;
-        Rect rotatedRightBottomBoundsOriginal = rightBottomBoundsOriginal;
-
-        Rect rotatedCenterBounds = centerBounds;
-        Rect rotatedRightBottomBounds = rightBottomBounds;
-        Rect rotatedLeftBottomBounds = leftBottomBounds;
-        Rect rotatedRightTopBounds = rightTopBounds;
-        Rect rotatedLeftTopBounds = leftTopBounds;
-        Rect rotatedRightCenterBounds = rightCenterBounds;
-        Rect rotatedLeftCenterBounds = leftCenterBounds;
-        Rect rotatedCenterBottomBounds = centerBottomBounds;
-        Rect rotatedCenterTopBounds = centerTopBounds;
-
-        if (!_spriteFrameRotated)
-        {
-
-            AffineTransform t = AffineTransform::IDENTITY;
-            t = AffineTransformTranslate(t, originalRect.origin.x, originalRect.origin.y);
-
-            rotatedLeftTopBoundsOriginal = RectApplyAffineTransform(rotatedLeftTopBoundsOriginal, t);
-            rotatedCenterBoundsOriginal = RectApplyAffineTransform(rotatedCenterBoundsOriginal, t);
-            rotatedRightBottomBoundsOriginal = RectApplyAffineTransform(rotatedRightBottomBoundsOriginal, t);
-
-            rotatedCenterBounds = RectApplyAffineTransform(rotatedCenterBounds, t);
-            rotatedRightBottomBounds = RectApplyAffineTransform(rotatedRightBottomBounds, t);
-            rotatedLeftBottomBounds = RectApplyAffineTransform(rotatedLeftBottomBounds, t);
-            rotatedRightTopBounds = RectApplyAffineTransform(rotatedRightTopBounds, t);
-            rotatedLeftTopBounds = RectApplyAffineTransform(rotatedLeftTopBounds, t);
-            rotatedRightCenterBounds = RectApplyAffineTransform(rotatedRightCenterBounds, t);
-            rotatedLeftCenterBounds = RectApplyAffineTransform(rotatedLeftCenterBounds, t);
-            rotatedCenterBottomBounds = RectApplyAffineTransform(rotatedCenterBottomBounds, t);
-            rotatedCenterTopBounds = RectApplyAffineTransform(rotatedCenterTopBounds, t);
-
-
-        }
-        else
-        {
-            // set up transformation of coordinates
-            // to handle the case where the sprite is stored rotated
-            // in the spritesheet
-            // log("rotated");
-
-            AffineTransform t = AffineTransform::IDENTITY;
-
-            t = AffineTransformTranslate(t, originalRect.size.height+originalRect.origin.x, originalRect.origin.y);
-            t = AffineTransformRotate(t, 1.57079633f);
-
-            leftTopBoundsOriginal = RectApplyAffineTransform(leftTopBoundsOriginal, t);
-            centerBoundsOriginal = RectApplyAffineTransform(centerBoundsOriginal, t);
-            rightBottomBoundsOriginal = RectApplyAffineTransform(rightBottomBoundsOriginal, t);
-
-            centerBounds = RectApplyAffineTransform(centerBounds, t);
-            rightBottomBounds = RectApplyAffineTransform(rightBottomBounds, t);
-            leftBottomBounds = RectApplyAffineTransform(leftBottomBounds, t);
-            rightTopBounds = RectApplyAffineTransform(rightTopBounds, t);
-            leftTopBounds = RectApplyAffineTransform(leftTopBounds, t);
-            rightCenterBounds = RectApplyAffineTransform(rightCenterBounds, t);
-            leftCenterBounds = RectApplyAffineTransform(leftCenterBounds, t);
-            centerBottomBounds = RectApplyAffineTransform(centerBottomBounds, t);
-            centerTopBounds = RectApplyAffineTransform(centerTopBounds, t);
-
-            rotatedLeftTopBoundsOriginal.origin = leftTopBoundsOriginal.origin;
-            rotatedCenterBoundsOriginal.origin = centerBoundsOriginal.origin;
-            rotatedRightBottomBoundsOriginal.origin = rightBottomBoundsOriginal.origin;
-
-            rotatedCenterBounds.origin = centerBounds.origin;
-            rotatedRightBottomBounds.origin = rightBottomBounds.origin;
-            rotatedLeftBottomBounds.origin = leftBottomBounds.origin;
-            rotatedRightTopBounds.origin = rightTopBounds.origin;
-            rotatedLeftTopBounds.origin = leftTopBounds.origin;
-            rotatedRightCenterBounds.origin = rightCenterBounds.origin;
-            rotatedLeftCenterBounds.origin = leftCenterBounds.origin;
-            rotatedCenterBottomBounds.origin = centerBottomBounds.origin;
-            rotatedCenterTopBounds.origin = centerTopBounds.origin;
-
-
-        }
-
-        _topLeftSize = rotatedLeftTopBoundsOriginal.size;
-        _centerSize = rotatedCenterBoundsOriginal.size;
-        _bottomRightSize = rotatedRightBottomBoundsOriginal.size;
-        if(_isPatch9)
-        {
-            _topLeftSize.width = _topLeftSize.width - 1;
-            _topLeftSize.height = _topLeftSize.height - 1;
-            _bottomRightSize.width = _bottomRightSize.width - 1;
-            _bottomRightSize.height = _bottomRightSize.height - 1;
-        }
-
-        if(_spriteFrameRotated)
-        {
-            float offsetX = (rotatedCenterBounds.origin.x + rotatedCenterBounds.size.height/2)
-                - (rotatedCenterBoundsOriginal.origin.x + rotatedCenterBoundsOriginal.size.height/2);
-            float offsetY = (rotatedCenterBoundsOriginal.origin.y + rotatedCenterBoundsOriginal.size.width/2)
-                - (rotatedCenterBounds.origin.y + rotatedCenterBounds.size.width/2);
-            _centerOffset.x = -offsetY;
-            _centerOffset.y = offsetX;
-        }
-        else
-        {
-            float offsetX = (rotatedCenterBounds.origin.x + rotatedCenterBounds.size.width/2)
-                - (rotatedCenterBoundsOriginal.origin.x + rotatedCenterBoundsOriginal.size.width/2);
-            float offsetY = (rotatedCenterBoundsOriginal.origin.y + rotatedCenterBoundsOriginal.size.height/2)
-                - (rotatedCenterBounds.origin.y + rotatedCenterBounds.size.height/2);
-            _centerOffset.x = offsetX;
-            _centerOffset.y = offsetY;
-        }
-
-        //shrink the image size when it is 9-patch
-        if(_isPatch9)
-        {
-            float offset = 1.0f;
-            //Top left
-            if(!_spriteFrameRotated)
+            Texture2D *tex = _scale9Image ? _scale9Image->getTexture() : nullptr;
+            
+            if (tex == nullptr)
             {
-                rotatedLeftTopBounds.origin.x+=offset;
-                rotatedLeftTopBounds.origin.y+=offset;
-                rotatedLeftTopBounds.size.width-=offset;
-                rotatedLeftTopBounds.size.height-=offset;
-                //Center left
-                rotatedLeftCenterBounds.origin.x+=offset;
-                rotatedLeftCenterBounds.size.width-=offset;
-                //Bottom left
-                rotatedLeftBottomBounds.origin.x+=offset;
-                rotatedLeftBottomBounds.size.width-=offset;
-                rotatedLeftBottomBounds.size.height-=offset;
-                //Top center
-                rotatedCenterTopBounds.size.height-=offset;
-                rotatedCenterTopBounds.origin.y+=offset;
-                //Bottom center
-                rotatedCenterBottomBounds.size.height-=offset;
-                //Top right
-                rotatedRightTopBounds.size.width-=offset;
-                rotatedRightTopBounds.size.height-=offset;
-                rotatedRightTopBounds.origin.y+=offset;
-                //Center right
-                rotatedRightCenterBounds.size.width-=offset;
-                //Bottom right
-                rotatedRightBottomBounds.size.width-=offset;
-                rotatedRightBottomBounds.size.height-=offset;
+                return;
             }
-            else
+            
+            auto capInsets = CC_RECT_POINTS_TO_PIXELS(_capInsetsInternal);
+            auto textureRect = CC_RECT_POINTS_TO_PIXELS(_spriteRect);
+            auto spriteRectSize = CC_SIZE_POINTS_TO_PIXELS(_originalSize);
+            
+            //handle .9.png
+            if (_isPatch9)
             {
-                //Top left
-                rotatedLeftTopBounds.size.width-=offset;
-                rotatedLeftTopBounds.size.height-=offset;
-                rotatedLeftTopBounds.origin.y+=offset;
-                //Center left
-                rotatedLeftCenterBounds.origin.y+=offset;
-                rotatedLeftCenterBounds.size.width-=offset;
-                //Bottom left
-                rotatedLeftBottomBounds.origin.x+=offset;
-                rotatedLeftBottomBounds.origin.y+=offset;
-                rotatedLeftBottomBounds.size.width-=offset;
-                rotatedLeftBottomBounds.size.height-=offset;
-                //Top center
-                rotatedCenterTopBounds.size.height-=offset;
-                //Bottom center
-                rotatedCenterBottomBounds.size.height-=offset;
-                rotatedCenterBottomBounds.origin.x+=offset;
-                //Top right
-                rotatedRightTopBounds.size.width-=offset;
-                rotatedRightTopBounds.size.height-=offset;
-                //Center right
-                rotatedRightCenterBounds.size.width-=offset;
-                //Bottom right
-                rotatedRightBottomBounds.size.width-=offset;
-                rotatedRightBottomBounds.size.height-=offset;
-                rotatedRightBottomBounds.origin.x+=offset;
+                spriteRectSize = Size(spriteRectSize.width - 2, spriteRectSize.height-2);
             }
-        }
-
-        // Centre
-        if(rotatedCenterBounds.size.width > 0 && rotatedCenterBounds.size.height > 0 )
-        {
-            _centerSprite = Sprite::createWithTexture(_scale9Image->getTexture(),
-                                                      rotatedCenterBounds,
-                                                      _spriteFrameRotated);
-            _centerSprite->retain();
-            this->addProtectedChild(_centerSprite);
-        }
-
-        // Top
-        if(rotatedCenterTopBounds.size.width > 0 && rotatedCenterTopBounds.size.height > 0 )
-        {
-            _topSprite = Sprite::createWithTexture(_scale9Image->getTexture(),
-                                                   rotatedCenterTopBounds,
-                                                   _spriteFrameRotated);
-            _topSprite->retain();
-            this->addProtectedChild(_topSprite);
-        }
-
-        // Bottom
-        if(rotatedCenterBottomBounds.size.width > 0 && rotatedCenterBottomBounds.size.height > 0 )
-        {
-            _bottomSprite = Sprite::createWithTexture(_scale9Image->getTexture(),
-                                                      rotatedCenterBottomBounds,
-                                                      _spriteFrameRotated);
-            _bottomSprite->retain();
-            this->addProtectedChild(_bottomSprite);
-        }
-
-        // Left
-        if(rotatedLeftCenterBounds.size.width > 0 && rotatedLeftCenterBounds.size.height > 0 )
-        {
-            _leftSprite = Sprite::createWithTexture(_scale9Image->getTexture(),
-                                                    rotatedLeftCenterBounds,
-                                                    _spriteFrameRotated);
-            _leftSprite->retain();
-            this->addProtectedChild(_leftSprite);
-        }
-
-        // Right
-        if(rotatedRightCenterBounds.size.width > 0 && rotatedRightCenterBounds.size.height > 0 )
-        {
-            _rightSprite = Sprite::createWithTexture(_scale9Image->getTexture(),
-                                                     rotatedRightCenterBounds,
-                                                     _spriteFrameRotated);
-            _rightSprite->retain();
-            this->addProtectedChild(_rightSprite);
-        }
-
-        // Top left
-        if(rotatedLeftTopBounds.size.width > 0 && rotatedLeftTopBounds.size.height > 0 )
-        {
-            _topLeftSprite = Sprite::createWithTexture(_scale9Image->getTexture(),
-                                                       rotatedLeftTopBounds,
-                                                       _spriteFrameRotated);
-            _topLeftSprite->retain();
-            this->addProtectedChild(_topLeftSprite);
-        }
-
-        // Top right
-        if(rotatedRightTopBounds.size.width > 0 && rotatedRightTopBounds.size.height > 0 )
-        {
-            _topRightSprite = Sprite::createWithTexture(_scale9Image->getTexture(),
-                                                        rotatedRightTopBounds,
-                                                        _spriteFrameRotated);
-            _topRightSprite->retain();
-            this->addProtectedChild(_topRightSprite);
-        }
-
-        // Bottom left
-        if(rotatedLeftBottomBounds.size.width > 0 && rotatedLeftBottomBounds.size.height > 0 )
-        {
-            _bottomLeftSprite = Sprite::createWithTexture(_scale9Image->getTexture(),
-                                                          rotatedLeftBottomBounds,
-                                                          _spriteFrameRotated);
-            _bottomLeftSprite->retain();
-            this->addProtectedChild(_bottomLeftSprite);
-        }
-
-        // Bottom right
-        if(rotatedRightBottomBounds.size.width > 0 && rotatedRightBottomBounds.size.height > 0 )
-        {
-            _bottomRightSprite = Sprite::createWithTexture(_scale9Image->getTexture(),
-                                                           rotatedRightBottomBounds,
-                                                           _spriteFrameRotated);
-            _bottomRightSprite->retain();
-            this->addProtectedChild(_bottomRightSprite);
+            
+            
+            if(capInsets.equals(Rect::ZERO))
+            {
+                capInsets = Rect(spriteRectSize.width/3, spriteRectSize.height/3,
+                                 spriteRectSize.width/3, spriteRectSize.height/3);
+            }
+            
+            auto uv = this->calculateUV(tex, capInsets, spriteRectSize);
+            auto vertices = this->calculateVertices(capInsets, spriteRectSize);
+            auto triangles = this->calculateTriangles(uv, vertices);
+            
+            _scale9Image->getPolygonInfo().setTriangles(triangles);
         }
     }
 
     void Scale9Sprite::setContentSize(const Size &size)
     {
+        if (_contentSize.equals(size))
+        {
+            return;
+        }
         Node::setContentSize(size);
-        this->_positionsAreDirty = true;
+        _preferredSize = size;
+        this->createSlicedSprites();
+        this->adjustScale9ImagePosition();
     }
-
-    void Scale9Sprite::updatePositions()
-    {
-        Size size = this->_contentSize;
-
-        float sizableWidth = size.width - _topLeftSize.width - _bottomRightSize.width;
-        float sizableHeight = size.height - _topLeftSize.height - _bottomRightSize.height;
-
-        float horizontalScale = sizableWidth/_centerSize.width;
-        float verticalScale = sizableHeight/_centerSize.height;
-
-        if(_centerSprite)
-        {
-            _centerSprite->setScaleX(horizontalScale);
-            _centerSprite->setScaleY(verticalScale);
-        }
-
-        float rescaledWidth = _centerSize.width * horizontalScale;
-        float rescaledHeight = _centerSize.height * verticalScale;
-
-        float leftWidth = _topLeftSize.width;
-        float bottomHeight = _bottomRightSize.height;
-
-        Vec2 centerOffset(_centerOffset.x * horizontalScale, _centerOffset.y * verticalScale);
-
-        // Position corners
-        if(_bottomLeftSprite)
-        {
-            _bottomLeftSprite->setAnchorPoint(Vec2(1,1));
-            _bottomLeftSprite->setPosition(leftWidth,bottomHeight);
-        }
-        if(_bottomRightSprite)
-        {
-            _bottomRightSprite->setAnchorPoint(Vec2(0,1));
-            _bottomRightSprite->setPosition(leftWidth+rescaledWidth,bottomHeight);
-        }
-        if(_topLeftSprite)
-        {
-            _topLeftSprite->setAnchorPoint(Vec2(1,0));
-            _topLeftSprite->setPosition(leftWidth, bottomHeight+rescaledHeight);
-        }
-        if(_topRightSprite)
-        {
-            _topRightSprite->setAnchorPoint(Vec2(0,0));
-            _topRightSprite->setPosition(leftWidth+rescaledWidth, bottomHeight+rescaledHeight);
-        }
-
-        // Scale and position borders
-        if(_leftSprite)
-        {
-            _leftSprite->setAnchorPoint(Vec2(1,0.5));
-            _leftSprite->setPosition(leftWidth, bottomHeight+rescaledHeight/2 + centerOffset.y);
-            _leftSprite->setScaleY(verticalScale);
-        }
-        if(_rightSprite)
-        {
-            _rightSprite->setAnchorPoint(Vec2(0,0.5));
-            _rightSprite->setPosition(leftWidth+rescaledWidth,bottomHeight+rescaledHeight/2 + centerOffset.y);
-            _rightSprite->setScaleY(verticalScale);
-        }
-        if(_topSprite)
-        {
-            _topSprite->setAnchorPoint(Vec2(0.5,0));
-            _topSprite->setPosition(leftWidth+rescaledWidth/2 + centerOffset.x,bottomHeight+rescaledHeight);
-            _topSprite->setScaleX(horizontalScale);
-        }
-        if(_bottomSprite)
-        {
-            _bottomSprite->setAnchorPoint(Vec2(0.5,1));
-            _bottomSprite->setPosition(leftWidth+rescaledWidth/2 + centerOffset.x,bottomHeight);
-            _bottomSprite->setScaleX(horizontalScale);
-        }
-        // Position centre
-        if(_centerSprite)
-        {
-            _centerSprite->setAnchorPoint(Vec2(0.5,0.5));
-            _centerSprite->setPosition(leftWidth+rescaledWidth/2 + centerOffset.x,
-                                       bottomHeight+rescaledHeight/2 + centerOffset.y);
-            _centerSprite->setScaleX(horizontalScale);
-            _centerSprite->setScaleY(verticalScale);
-        }
-    }
-
-
 
     Scale9Sprite* Scale9Sprite::resizableSpriteWithCapInsets(const Rect& capInsets) const
     {
@@ -1042,9 +536,9 @@ namespace ui {
         if ( pReturn && pReturn->init(_scale9Image,
                                       _spriteRect,
                                       _spriteFrameRotated,
-                                      _offset,
+                                      Vec2::ZERO,
                                       _originalSize,
-                                      _capInsets) )
+                                      _capInsetsInternal) )
         {
             pReturn->autorelease();
             return pReturn;
@@ -1081,13 +575,6 @@ namespace ui {
             _scale9Image->setGLProgramState(glState);
         }
 
-        if (_scale9Enabled)
-        {
-            for (auto& sp : _protectedChildren)
-            {
-                sp->setGLProgramState(glState);
-            }
-        }
         _brightState = state;
     }
 
@@ -1101,17 +588,10 @@ namespace ui {
     void Scale9Sprite::updateCapInset()
     {
         Rect insets;
-        if (this->_insetLeft == 0 && this->_insetTop == 0 && this->_insetRight == 0 && this->_insetBottom == 0)
-        {
-            insets = Rect::ZERO;
-        }
-        else
-        {
-            insets = Rect(_insetLeft,
-                          _insetTop,
-                          _originalSize.width-_insetLeft-_insetRight,
-                          _originalSize.height-_insetTop-_insetBottom);
-        }
+        insets = Rect(_insetLeft,
+                      _insetTop,
+                      _originalSize.width-_insetLeft-_insetRight,
+                      _originalSize.height-_insetTop-_insetBottom);
         this->setCapInsets(insets);
     }
 
@@ -1136,7 +616,6 @@ namespace ui {
     void Scale9Sprite::setPreferredSize(const Size& preferredSize)
     {
         this->setContentSize(preferredSize);
-        this->_preferredSize = preferredSize;
     }
 
 
@@ -1146,7 +625,7 @@ namespace ui {
         this->updateWithSprite(this->_scale9Image,
                                _spriteRect,
                                _spriteFrameRotated,
-                               _offset,
+                               Vec2::ZERO,
                                _originalSize,
                                capInsets);
         this->_insetLeft = capInsets.origin.x;
@@ -1201,10 +680,8 @@ namespace ui {
         director->loadMatrix(MATRIX_STACK_TYPE::MATRIX_STACK_MODELVIEW, _modelViewTransform);
 
         int i = 0;      // used by _children
-        int j = 0;      // used by _protectedChildren
 
         sortAllChildren();
-        sortAllProtectedChildren();
 
         //
         // draw children and protectedChildren zOrder < 0
@@ -1219,25 +696,11 @@ namespace ui {
                 break;
         }
 
-        if (_scale9Enabled)
+        if (_scale9Image && _scale9Image->getLocalZOrder() < 0 )
         {
-            for( ; j < _protectedChildren.size(); j++ )
-            {
-                auto node = _protectedChildren.at(j);
-
-                if ( node && node->getLocalZOrder() < 0 )
-                    node->visit(renderer, _modelViewTransform, flags);
-                else
-                    break;
-            }
+            _scale9Image->visit(renderer, _modelViewTransform, flags);
         }
-        else
-        {
-            if (_scale9Image && _scale9Image->getLocalZOrder() < 0 )
-            {
-                _scale9Image->visit(renderer, _modelViewTransform, flags);
-            }
-        }
+        
 
         //
         // draw self
@@ -1248,17 +711,9 @@ namespace ui {
         //
         // draw children and protectedChildren zOrder >= 0
         //
-        if (_scale9Enabled)
+        if (_scale9Image && _scale9Image->getLocalZOrder() >= 0 )
         {
-            for(auto it=_protectedChildren.cbegin()+j; it != _protectedChildren.cend(); ++it)
-                (*it)->visit(renderer, _modelViewTransform, flags);
-        }
-        else
-        {
-            if (_scale9Image && _scale9Image->getLocalZOrder() >= 0 )
-            {
-                _scale9Image->visit(renderer, _modelViewTransform, flags);
-            }
+            _scale9Image->visit(renderer, _modelViewTransform, flags);
         }
 
 
@@ -1286,7 +741,7 @@ namespace ui {
 
     Rect Scale9Sprite::getCapInsets()const
     {
-        return _capInsets;
+        return _capInsetsInternal;
     }
 
 
@@ -1319,7 +774,6 @@ namespace ui {
         _scale9Enabled = enabled;
 
         this->cleanupSlicedSprites();
-        _protectedChildren.clear();
 
         //we must invalide the transform when toggling scale9enabled
         _transformUpdated = _transformDirty = _inverseDirty = true;
@@ -1331,51 +785,30 @@ namespace ui {
                 this->updateWithSprite(this->_scale9Image,
                                        _spriteRect,
                                        _spriteFrameRotated,
-                                       _offset,
+                                       Vec2::ZERO,
                                        _originalSize,
-                                       _capInsets);
+                                       _capInsetsInternal);
             }
         }
-        _positionsAreDirty = true;
+        else
+        {
+            if (_scale9Image)
+            {
+                auto quad = _scale9Image->getQuad();
+                PolygonInfo polyInfo;
+                polyInfo.setQuad(&quad);
+                _scale9Image->setPolygonInfo(polyInfo);
+            }
+          
+        }
+        this->adjustScale9ImagePosition();
     }
 
     bool Scale9Sprite::isScale9Enabled() const
     {
         return _scale9Enabled;
     }
-
-    void Scale9Sprite::addProtectedChild(cocos2d::Node *child)
-    {
-        _reorderProtectedChildDirty = true;
-        _protectedChildren.pushBack(child);
-    }
-
-    void Scale9Sprite::sortAllProtectedChildren()
-    {
-        if(this->_positionsAreDirty)
-        {
-            this->updatePositions();
-            this->adjustScale9ImagePosition();
-            this->_positionsAreDirty = false;
-        }
-        if( _reorderProtectedChildDirty )
-        {
-            std::sort( std::begin(_protectedChildren),
-                       std::end(_protectedChildren),
-                       nodeComparisonLess );
-            _reorderProtectedChildDirty = false;
-        }
-    }
-
-    void Scale9Sprite::adjustScale9ImagePosition()
-    {
-        if (_scale9Image)
-        {
-            _scale9Image->setPosition(_contentSize.width * _scale9Image->getAnchorPoint().x,
-                                      _contentSize.height * _scale9Image->getAnchorPoint().y);
-        }
-    }
-
+    
     void Scale9Sprite::setAnchorPoint(const cocos2d::Vec2 &position)
     {
         Node::setAnchorPoint(position);
@@ -1383,85 +816,24 @@ namespace ui {
         {
             if (_scale9Image)
             {
+                _nonSliceSpriteAnchor = position;
                 _scale9Image->setAnchorPoint(position);
-                _positionsAreDirty = true;
+                this->adjustScale9ImagePosition();
             }
         }
     }
 
-    void Scale9Sprite::cleanup()
+    void Scale9Sprite::adjustScale9ImagePosition()
     {
-#if CC_ENABLE_SCRIPT_BINDING
-        if (_scriptType == kScriptTypeJavascript)
+        if (_scale9Image)
         {
-            if (ScriptEngineManager::sendNodeEventToJSExtended(this, kNodeOnCleanup))
-                return;
-        }
-#endif // #if CC_ENABLE_SCRIPT_BINDING
-        
-        Node::cleanup();
-        // timers
-        for( const auto &child: _protectedChildren)
-            child->cleanup();
-    }
+            if (!_scale9Enabled) {
+                _scale9Image->setAnchorPoint(_nonSliceSpriteAnchor);
+                _scale9Image->setPosition(_contentSize.width * _scale9Image->getAnchorPoint().x,
+                                          _contentSize.height * _scale9Image->getAnchorPoint().y);
 
-    void Scale9Sprite::onEnter()
-    {
-#if CC_ENABLE_SCRIPT_BINDING
-        if (_scriptType == kScriptTypeJavascript)
-        {
-            if (ScriptEngineManager::sendNodeEventToJSExtended(this, kNodeOnEnter))
-                return;
+            }
         }
-#endif
-        Node::onEnter();
-        for( const auto &child: _protectedChildren)
-            child->onEnter();
-    }
-
-    void Scale9Sprite::onExit()
-    {
-#if CC_ENABLE_SCRIPT_BINDING
-        if (_scriptType == kScriptTypeJavascript)
-        {
-            if (ScriptEngineManager::sendNodeEventToJSExtended(this, kNodeOnExit))
-                return;
-        }
-#endif
-        
-        Node::onExit();
-        for( const auto &child: _protectedChildren)
-            child->onExit();
-    }
-
-    void Scale9Sprite::onEnterTransitionDidFinish()
-    {
-#if CC_ENABLE_SCRIPT_BINDING
-        if (_scriptType == kScriptTypeJavascript)
-        {
-            if (ScriptEngineManager::sendNodeEventToJSExtended(this, kNodeOnEnterTransitionDidFinish))
-                return;
-        }
-#endif
-        
-        Node::onEnterTransitionDidFinish();
-        for( const auto &child: _protectedChildren)
-            child->onEnterTransitionDidFinish();
-    }
-
-    void Scale9Sprite::onExitTransitionDidStart()
-    {
-#if CC_ENABLE_SCRIPT_BINDING
-        if (_scriptType == kScriptTypeJavascript)
-        {
-            if (ScriptEngineManager::sendNodeEventToJSExtended(this, kNodeOnExitTransitionDidStart))
-                return;
-        }
-#endif
-        
-        Node::onExitTransitionDidStart();
-        for( const auto &child: _protectedChildren)
-            child->onExitTransitionDidStart();
     }
 
     void Scale9Sprite::updateDisplayedColor(const cocos2d::Color3B &parentColor)
@@ -1475,12 +847,7 @@ namespace ui {
         {
             _scale9Image->updateDisplayedColor(_displayedColor);
         }
-
-        for(const auto &child : _protectedChildren)
-        {
-            child->updateDisplayedColor(_displayedColor);
-        }
-
+        
         if (_cascadeColorEnabled)
         {
             for(const auto &child : _children)
@@ -1500,11 +867,6 @@ namespace ui {
             _scale9Image->updateDisplayedOpacity(_displayedOpacity);
         }
 
-        for(auto child : _protectedChildren)
-        {
-            child->updateDisplayedOpacity(_displayedOpacity);
-        }
-
         if (_cascadeOpacityEnabled)
         {
             for(auto child : _children)
@@ -1520,10 +882,7 @@ namespace ui {
         {
             child->updateDisplayedColor(Color3B::WHITE);
         }
-        for(auto child : _protectedChildren)
-        {
-            child->updateDisplayedColor(Color3B::WHITE);
-        }
+
         if (_scale9Image)
         {
             _scale9Image->updateDisplayedColor(Color3B::WHITE);
@@ -1535,10 +894,6 @@ namespace ui {
         _displayedOpacity = _realOpacity;
 
         for(auto child : _children){
-            child->updateDisplayedOpacity(255);
-        }
-
-        for(auto child : _protectedChildren){
             child->updateDisplayedOpacity(255);
         }
     }
@@ -1635,11 +990,227 @@ namespace ui {
 
         if(_scale9Image)
             _scale9Image->setCameraMask(mask,applyChildren);
+    }
+    
+    // (0,0)  O = capInsets.origin
+    // v0----------------------
+    // |        |      |      |
+    // |        |      |      |
+    // v1-------O------+------|
+    // |        |      |      |
+    // |        |      |      |
+    // v2-------+------+------|
+    // |        |      |      |
+    // |        |      |      |
+    // v3-------------------- (1,1)  (texture coordinate is flipped)
+    // u0       u1     u2     u3
+    std::vector<Vec2> Scale9Sprite::calculateUV(Texture2D *tex,
+                                               const Rect& capInsets,
+                                               const Size& spriteRectSize)
+    {
+        auto atlasWidth = tex->getPixelsWide();
+        auto atlasHeight = tex->getPixelsHigh();
 
-        for(auto& iter: _protectedChildren)
+        //caculate texture coordinate
+        float leftWidth = 0, centerWidth = 0, rightWidth = 0;
+        float topHeight = 0, centerHeight = 0, bottomHeight = 0;
+
+        if (_spriteFrameRotated)
         {
-            iter->setCameraMask(mask);
+            rightWidth = capInsets.origin.y;
+            centerWidth = capInsets.size.height;
+            leftWidth = spriteRectSize.height - centerWidth - rightWidth;
+
+            topHeight = capInsets.origin.x;
+            centerHeight = capInsets.size.width;
+            bottomHeight = spriteRectSize.width - (topHeight + centerHeight);
         }
+        else
+        {
+            leftWidth = capInsets.origin.x;
+            centerWidth = capInsets.size.width;
+            rightWidth = spriteRectSize.width - (leftWidth + centerWidth);
+
+            topHeight = capInsets.origin.y;
+            centerHeight = capInsets.size.height;
+            bottomHeight =spriteRectSize.height - (topHeight + centerHeight);
+        }
+
+        auto textureRect = CC_RECT_POINTS_TO_PIXELS(_spriteRect);
+        //handle .9.png
+        if (_isPatch9)
+        {
+            //This magic number is used to avoiding artifact with .9.png format.
+            float offset = 1.3f;
+            textureRect = Rect(textureRect.origin.x +  offset,
+                               textureRect.origin.y +  offset,
+                               textureRect.size.width - 2,
+                               textureRect.size.height - 2);
+        }
+
+        //uv computation should take spritesheet into account.
+        float u0, u1, u2, u3;
+        float v0, v1, v2, v3;
+        if (_spriteFrameRotated)
+        {
+            u0 = textureRect.origin.x / atlasWidth;
+            u1 = (leftWidth + textureRect.origin.x) / atlasWidth;
+            u2 = (leftWidth + centerWidth + textureRect.origin.x) / atlasWidth;
+            u3 = (textureRect.origin.x + textureRect.size.height) / atlasWidth;
+
+            v3 = textureRect.origin.y / atlasHeight;
+            v2 = (topHeight + textureRect.origin.y) / atlasHeight;
+            v1 = (topHeight + centerHeight + textureRect.origin.y) / atlasHeight;
+            v0 = (textureRect.origin.y + textureRect.size.width) / atlasHeight;
+        }
+        else
+        {
+            u0 = textureRect.origin.x / atlasWidth;
+            u1 = (leftWidth + textureRect.origin.x) / atlasWidth;
+            u2 = (leftWidth + centerWidth + textureRect.origin.x) / atlasWidth;
+            u3 = (textureRect.origin.x + textureRect.size.width) / atlasWidth;
+
+            v0 = textureRect.origin.y / atlasHeight;
+            v1 = (topHeight + textureRect.origin.y) / atlasHeight;
+            v2 = (topHeight + centerHeight + textureRect.origin.y) / atlasHeight;
+            v3 = (textureRect.origin.y + textureRect.size.height) / atlasHeight;
+        }
+
+        std::vector<Vec2> uvCoordinates = {Vec2(u0,v3), Vec2(u1,v2), Vec2(u2,v1), Vec2(u3,v0)};
+
+        return uvCoordinates;
+    }
+
+    //
+    // y3----------------------(preferedSize.width, preferedSize.height)
+    // |        |      |      |
+    // |        |      |      |
+    // y2-------O------+------|
+    // |        |      |      |
+    // |        |      |      |
+    // y1-------+------+------|
+    // |        |      |      |
+    // |        |      |      |
+    //x0,y0--------------------
+    //         x1     x2     x3
+    std::vector<Vec2> Scale9Sprite::calculateVertices(const Rect& capInsets,
+                                                     const Size& spriteRectSize)
+    {
+        float leftWidth = 0, centerWidth = 0, rightWidth = 0;
+        float topHeight = 0, centerHeight = 0, bottomHeight = 0;
+
+        leftWidth = capInsets.origin.x;
+        centerWidth = capInsets.size.width;
+        rightWidth = spriteRectSize.width - (leftWidth + centerWidth);
+
+        topHeight = capInsets.origin.y;
+        centerHeight = capInsets.size.height;
+        bottomHeight = spriteRectSize.height - (topHeight + centerHeight);
+
+
+        leftWidth = leftWidth / CC_CONTENT_SCALE_FACTOR();
+        rightWidth = rightWidth / CC_CONTENT_SCALE_FACTOR();
+        topHeight = topHeight / CC_CONTENT_SCALE_FACTOR();
+        bottomHeight = bottomHeight / CC_CONTENT_SCALE_FACTOR();
+        float sizableWidth = _preferredSize.width - leftWidth - rightWidth;
+        float sizableHeight = _preferredSize.height - topHeight - bottomHeight;
+        float x0,x1,x2,x3;
+        float y0,y1,y2,y3;
+        if(sizableWidth >= 0)
+        {
+            x0 = 0;
+            x1 = leftWidth;
+            x2 = leftWidth + sizableWidth;
+            x3 = _preferredSize.width;
+        }
+        else
+        {
+            float xScale = _preferredSize.width / (leftWidth + rightWidth);
+            x0 = 0;
+            x1 = x2 = leftWidth * xScale;
+            x3 = (leftWidth + rightWidth) * xScale;
+        }
+
+        if(sizableHeight >= 0)
+        {
+            y0 = 0;
+            y1 = bottomHeight;
+            y2 = bottomHeight + sizableHeight;
+            y3 = _preferredSize.height;
+        }
+        else
+        {
+            float yScale = _preferredSize.height / (topHeight + bottomHeight);
+            y0 = 0;
+            y1 = y2= bottomHeight * yScale;
+            y3 = (bottomHeight + topHeight) * yScale;
+        }
+
+        std::vector<Vec2> vertices = {Vec2(x0,y0), Vec2(x1,y1), Vec2(x2,y2), Vec2(x3,y3)};
+        return vertices;
+    }
+
+    TrianglesCommand::Triangles Scale9Sprite::calculateTriangles(const std::vector<Vec2>& uv,
+                                                                const std::vector<Vec2>& vertices)
+    {
+        const unsigned short slicedTotalVertexCount = 16;
+        const unsigned short slicedTotalIndices = 54;
+        CC_SAFE_DELETE_ARRAY(_sliceVertices);
+        CC_SAFE_DELETE_ARRAY(_sliceIndices);
+
+        _sliceVertices = new V3F_C4B_T2F[slicedTotalVertexCount];
+        _sliceIndices = new unsigned short[slicedTotalIndices];
+
+        unsigned short indicesStart = 0;
+        const unsigned short indicesOffset = 6;
+        const unsigned short quadIndices[]={4,0,5, 1,5,0};
+
+        Color4B color4 = Color4B(_scale9Image->getDisplayedColor());
+
+        for (int j = 0; j <= 3; ++j)
+        {
+            for (int i = 0; i <= 3; ++i)
+            {
+                V3F_C4B_T2F vertextData;
+                vertextData.vertices.x = vertices[i].x;
+                vertextData.vertices.y = vertices[j].y;
+
+                if (_spriteFrameRotated)
+                {
+                    vertextData.texCoords.u = uv[j].x;
+                    vertextData.texCoords.v = uv[i].y;
+                }
+                else
+                {
+                    vertextData.texCoords.u = uv[i].x;
+                    vertextData.texCoords.v = uv[j].y;
+                }
+
+                vertextData.colors = color4;
+
+                if (i < 3 && j < 3)
+                {
+                    memcpy(_sliceIndices + indicesStart, quadIndices, indicesOffset * sizeof(unsigned short));
+
+                    for (int k = 0; k  < indicesOffset; ++k)
+                    {
+                        unsigned short actualIndex = (i  + j * 3) * indicesOffset;
+                        _sliceIndices[k + actualIndex] = _sliceIndices[k + actualIndex] + j * 4 + i;
+                    }
+                    indicesStart = indicesStart + indicesOffset;
+                }
+
+                memcpy(_sliceVertices + i + j * 4, &vertextData, sizeof(V3F_C4B_T2F));
+            }
+        }
+
+        TrianglesCommand::Triangles triangles;
+        triangles.vertCount = slicedTotalVertexCount;
+        triangles.indexCount = slicedTotalIndices;
+        triangles.verts = _sliceVertices;
+        triangles.indices = _sliceIndices;
+
+        return triangles;
     }
 
 }}

--- a/cocos/ui/UIScale9Sprite.h
+++ b/cocos/ui/UIScale9Sprite.h
@@ -672,6 +672,7 @@ namespace ui {
         void createSlicedSprites();
         void cleanupSlicedSprites();
         void adjustNoneScale9ImagePosition();
+        void configureSimpleModeRendering();
         void applyBlendFunc();
         void updateBlendFunc(Texture2D *texture);
         std::vector<Vec2> calculateUV(Texture2D *tex, const Rect& capInsets,

--- a/cocos/ui/UIScale9Sprite.h
+++ b/cocos/ui/UIScale9Sprite.h
@@ -78,6 +78,12 @@ namespace ui {
             GRAY
         };
         
+        enum class RenderingType
+        {
+            SIMPLE,
+            SLICE
+        };
+        
     public:
         
         /**
@@ -648,6 +654,19 @@ namespace ui {
         virtual float getScale() const override;
         using Node::getScaleZ;
         virtual void setCameraMask(unsigned short mask, bool applyChildren = true) override;
+        
+        /**
+         * Set the slice sprite rendering type.
+         * When setting to SIMPLE, only 4 vertexes is used to rendering.
+         * otherwise 16 vertexes will be used to rendering.
+         * @see RenderingType
+         */
+        void setRenderingType(RenderingType type);
+        
+        /**
+         * Return the slice sprite rendering type.
+         */
+        RenderingType getRenderingType()const;
     protected:
         void updateCapInset();
         void createSlicedSprites();
@@ -696,6 +715,7 @@ namespace ui {
         V3F_C4B_T2F* _sliceVertices;
         unsigned short* _sliceIndices;
         bool _sliceSpriteDirty;
+        RenderingType _renderingType;
     };
     
 }}  //end of namespace

--- a/cocos/ui/UIScale9Sprite.h
+++ b/cocos/ui/UIScale9Sprite.h
@@ -652,7 +652,7 @@ namespace ui {
         void updateCapInset();
         void createSlicedSprites();
         void cleanupSlicedSprites();
-        void adjustScale9ImagePosition();
+        void adjustNoneScale9ImagePosition();
         void applyBlendFunc();
         void updateBlendFunc(Texture2D *texture);
         std::vector<Vec2> calculateUV(Texture2D *tex, const Rect& capInsets,
@@ -695,6 +695,7 @@ namespace ui {
         
         V3F_C4B_T2F* _sliceVertices;
         unsigned short* _sliceIndices;
+        bool _sliceSpriteDirty;
     };
     
 }}  //end of namespace

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIScale9SpriteTest.cpp
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIScale9SpriteTest.cpp
@@ -53,6 +53,7 @@ UIScale9SpriteTests::UIScale9SpriteTests()
     ADD_TEST_CASE(UIS9Flip);
     ADD_TEST_CASE(UIS9ChangeAnchorPoint);
     ADD_TEST_CASE(UIS9NinePatchTest);
+    ADD_TEST_CASE(UIS9BatchTest);
 }
 
 // UIScale9SpriteTest
@@ -347,7 +348,7 @@ bool UIS9FrameNameSpriteSheetCropped::init()
         auto blocks = ui::Scale9Sprite::createWithSpriteFrameName("blocks9c.png");
         blocks->setRenderingType(Scale9Sprite::RenderingType::SIMPLE);
         blocks->setPosition(Vec2(x, y));
-        
+        blocks->setCapInsets(Rect(5,5,5,5));
         this->addChild(blocks);
         
         return true;
@@ -368,7 +369,7 @@ bool UIS9FrameNameSpriteSheetCroppedRotated::init()
         auto blocks = ui::Scale9Sprite::createWithSpriteFrameName("blocks9cr.png");
         blocks->setRenderingType(Scale9Sprite::RenderingType::SIMPLE);
         blocks->setPosition(Vec2(x, y));
-        
+        blocks->setInsetBottom(10);
         this->addChild(blocks);
         
         return true;
@@ -904,3 +905,53 @@ bool UIS9NinePatchTest::init()
     }
     return false;
 }
+
+bool UIS9BatchTest::init()
+{
+    if (UIScene::init()) {
+        SpriteFrameCache::getInstance()->addSpriteFramesWithFile("Images/blocks9ss.plist");
+        
+        auto winSize = Director::getInstance()->getVisibleSize();
+        
+        auto label = Label::createWithSystemFont("Click Button to Add Sprite and Slice Sprite\nThe draw call should always be 19 after adding sprites", "Arial", 15);
+        label->setPosition(Vec2(winSize.width/2, winSize.height - 60));
+        this->addChild(label);
+        
+        auto preferedSize = Size(150,99);
+        std::vector<std::string>  spriteFrameNameArray = {"blocks9.png", "blocks9r.png"};
+        auto addSpriteButton = ui::Button::create("cocosui/animationbuttonnormal.png", "cocosui/animationbuttonpressed.png");
+        addSpriteButton->setPosition(Vec2(winSize.width/2 - 50,winSize.height - 100));
+        addSpriteButton->setTitleText("Add Normal Sprite");
+        srand((unsigned)time(nullptr));
+        addSpriteButton->addClickEventListener([=](Ref*){
+            auto spriteFrameName = spriteFrameNameArray[rand()%2];
+            auto sprite = Sprite::createWithSpriteFrameName(spriteFrameName);
+            sprite->setPosition(Vec2(rand() % (int)winSize.width + 50, winSize.height/2));
+            this->addChild(sprite);
+        });
+        this->addChild(addSpriteButton);
+        
+        auto addSliceSpriteButton = ui::Button::create("cocosui/animationbuttonnormal.png", "cocosui/animationbuttonpressed.png");
+        addSliceSpriteButton->setPosition(Vec2(winSize.width/2 + 50,winSize.height - 100));
+        addSliceSpriteButton->setTitleText("Add Slice Sprite");
+        addSliceSpriteButton->addClickEventListener([=](Ref*){
+            int random = rand()%2;
+            auto spriteFrameName = spriteFrameNameArray[random];
+            auto sprite = ui::Scale9Sprite::createWithSpriteFrameName(spriteFrameName);
+            sprite->setPosition(Vec2(rand() % (int)winSize.width + 50, winSize.height/3));
+            if (random == 0) {
+                sprite->setRenderingType(Scale9Sprite::RenderingType::SIMPLE);
+            }else{
+                sprite->setRenderingType(Scale9Sprite::RenderingType::SLICE);
+            }
+            sprite->setPreferredSize(preferedSize);
+            this->addChild(sprite);
+        });
+        this->addChild(addSliceSpriteButton);
+        
+        
+        return true;
+    }
+    return false;
+}
+

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIScale9SpriteTest.cpp
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIScale9SpriteTest.cpp
@@ -54,6 +54,7 @@ UIScale9SpriteTests::UIScale9SpriteTests()
     ADD_TEST_CASE(UIS9ChangeAnchorPoint);
     ADD_TEST_CASE(UIS9NinePatchTest);
     ADD_TEST_CASE(UIS9BatchTest);
+    ADD_TEST_CASE(UIS9ToggleRenderingTypeTest);
 }
 
 // UIScale9SpriteTest
@@ -949,6 +950,44 @@ bool UIS9BatchTest::init()
         });
         this->addChild(addSliceSpriteButton);
         
+        
+        return true;
+    }
+    return false;
+}
+
+bool UIS9ToggleRenderingTypeTest::init()
+{
+    if (UIScene::init()) {
+        
+        auto winSize = Director::getInstance()->getWinSize();
+        float x = winSize.width / 2;
+        float y = 0 + (winSize.height / 2 - 20);
+        
+        auto label = Label::createWithSystemFont("Click Button to toggle rendering type", "Arial", 15);
+        label->setPosition(Vec2(winSize.width/2, winSize.height - 60));
+        this->addChild(label);
+        
+        auto blocks = ui::Scale9Sprite::create("Images/blocks9.png");
+      
+        blocks->setPosition(Vec2(x, y));
+        blocks->setPreferredSize(Size(96*2, 96));
+        this->addChild(blocks);
+        
+        auto addSliceSpriteButton = ui::Button::create("cocosui/animationbuttonnormal.png", "cocosui/animationbuttonpressed.png");
+        addSliceSpriteButton->setPosition(Vec2(winSize.width/2,winSize.height - 100));
+        addSliceSpriteButton->setTitleText("Slice Rendering");
+        addSliceSpriteButton->addClickEventListener([=](Ref*){
+            if (blocks->getRenderingType() == Scale9Sprite::RenderingType::SLICE) {
+                blocks->setRenderingType(Scale9Sprite::RenderingType::SIMPLE);
+                addSliceSpriteButton->setTitleText("Simple Rendering");
+            }else{
+                blocks->setRenderingType(Scale9Sprite::RenderingType::SLICE);
+                addSliceSpriteButton->setTitleText("Slice Rendering");
+                blocks->setCapInsets(Rect(96/3,96/3,96/3,96/3));
+            }
+        });
+        this->addChild(addSliceSpriteButton);
         
         return true;
     }

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIScale9SpriteTest.cpp
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIScale9SpriteTest.cpp
@@ -345,7 +345,7 @@ bool UIS9FrameNameSpriteSheetCropped::init()
         SpriteFrameCache::getInstance()->addSpriteFramesWithFile(s_s9s_blocks9_plist);
         
         auto blocks = ui::Scale9Sprite::createWithSpriteFrameName("blocks9c.png");
-        
+        blocks->setRenderingType(Scale9Sprite::RenderingType::SIMPLE);
         blocks->setPosition(Vec2(x, y));
         
         this->addChild(blocks);
@@ -366,7 +366,7 @@ bool UIS9FrameNameSpriteSheetCroppedRotated::init()
         SpriteFrameCache::getInstance()->addSpriteFramesWithFile(s_s9s_blocks9_plist);
         
         auto blocks = ui::Scale9Sprite::createWithSpriteFrameName("blocks9cr.png");
-        
+        blocks->setRenderingType(Scale9Sprite::RenderingType::SIMPLE);
         blocks->setPosition(Vec2(x, y));
         
         this->addChild(blocks);

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIScale9SpriteTest.h
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIScale9SpriteTest.h
@@ -258,4 +258,12 @@ public:
     virtual bool init() override;
 };
 
+class UIS9BatchTest: public UIScene
+{
+public:
+    CREATE_FUNC(UIS9BatchTest);
+    
+    virtual bool init() override;
+};
+
 #endif /* defined(__cocos2d_tests__UIScale9SpriteTest__) */

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIScale9SpriteTest.h
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIScale9SpriteTest.h
@@ -266,4 +266,12 @@ public:
     virtual bool init() override;
 };
 
+class UIS9ToggleRenderingTypeTest: public UIScene
+{
+public:
+    CREATE_FUNC(UIS9ToggleRenderingTypeTest);
+    
+    virtual bool init() override;
+};
+
 #endif /* defined(__cocos2d_tests__UIScale9SpriteTest__) */


### PR DESCRIPTION
1. Completely rewrite the slice-9 feature of ui::Scale9Sprite. 
2. Now the Slice sprite uses 16 vertices and 54 indices instead of the old 9 sprite way.
   The memory consumption is much lower than the previous implementation. And it is also more time efficient.
3. Fix a bug when scale9sprite shrink smaller than the center stretch area. 
4. Add RenderingType to slice sprite. When Scale9Enable is true, then we have two rendering type here. 
   
   In Simple mode, the 4 borders are all 0 and the whole sprite will scale horizontally and vertically. In this mode only 1 quad is used to rendering.
   
   In Slice mode, it will use 18 triangles to rendering the slice 9 sprite. If the 4 borders are 0,  there still be 18 triangles computed. So choose your RenderingType wisely.
