### PR TITLE
Fixed AssetsManagerEx bugs

### DIFF
--- a/cocos/network/CCDownloader-curl.cpp
+++ b/cocos/network/CCDownloader-curl.cpp
@@ -132,15 +132,6 @@ namespace cocos2d { namespace network {
                     }
                 }
 
-                // open file
-                _fp = fopen(util->getSuitableFOpen(_tempFileName).c_str(), "ab");
-                if (nullptr == _fp)
-                {
-                    _errCode = DownloadTask::ERROR_FILE_OP_FAILED;
-                    _errCodeInternal = 0;
-                    _errDescription = "Can't open file:";
-                    _errDescription.append(_tempFileName);
-                }
                 ret = true;
             } while (0);
 
@@ -165,6 +156,19 @@ namespace cocos2d { namespace network {
         {
             lock_guard<mutex> lock(_mutex);
             size_t ret = 0;
+
+            if (!_fp && _tempFileName.length())
+            {
+                auto util = FileUtils::getInstance();
+                // open file
+                _fp = fopen(util->getSuitableFOpen(_tempFileName).c_str(), "ab");
+                if (!_fp)
+                {
+                    // This will cause CURLE_WRITE_ERROR
+                    return 0;
+                }
+            }
+
             if (_fp)
             {
                 ret = fwrite(buffer, size, count, _fp);
@@ -851,5 +855,5 @@ namespace cocos2d { namespace network {
             DLLOG("    DownloaderCURL: finish Task: Id(%d)", coTask.serialId);
         }
     }
-    
+
 }}  //  namespace cocos2d::network

--- a/extensions/assets-manager/AssetsManagerEx.cpp
+++ b/extensions/assets-manager/AssetsManagerEx.cpp
@@ -857,6 +857,11 @@ void AssetsManagerEx::onError(const network::DownloadTask& task,
 
         if (_totalWaitToDownload <= _failedUnits.size())
         {
+            // Save current download manifest information for resuming
+            _tempManifest->saveToFile(_tempManifestPath);
+
+            decompressDownloadedZip();
+
             _updateState = State::FAIL_TO_UPDATE;
             dispatchUpdateEvent(EventAssetsManagerEx::EventCode::UPDATE_FAILED);
         }

--- a/extensions/assets-manager/AssetsManagerEx.cpp
+++ b/extensions/assets-manager/AssetsManagerEx.cpp
@@ -854,6 +854,12 @@ void AssetsManagerEx::onError(const network::DownloadTask& task,
             _failedUnits.emplace(unit.customId, unit);
         }
         dispatchUpdateEvent(EventAssetsManagerEx::EventCode::ERROR_UPDATING, task.identifier, errorStr, errorCode, errorCodeInternal);
+
+        if (_totalWaitToDownload <= _failedUnits.size())
+        {
+            _updateState = State::FAIL_TO_UPDATE;
+            dispatchUpdateEvent(EventAssetsManagerEx::EventCode::UPDATE_FAILED);
+        }
     }
 }
 
@@ -957,7 +963,7 @@ void AssetsManagerEx::onSuccess(const std::string &srcUrl, const std::string &st
             _failedUnits.erase(unitIt);
         }
         
-        if (_totalWaitToDownload <= 0)
+        if (_totalWaitToDownload <= _failedUnits.size())
         {
             // Finished with error check
             if (_failedUnits.size() > 0)


### PR DESCRIPTION
I've tested this code with cpp-tests's AssetsManagerExTest.cpp code.

BUGS 1. After download error occurs, AssetsManagerEx never calls extension::EventAssetsManagerEx::EventCode::UPDATE_FAILED nor extension::EventAssetsManagerEx::EventCode::UPDATE_FINISHED because AssetsManagerEx::_totalWaitToDownload can't be 0.
( Download-retrying code is only at the UPDATE_FAILED event trigger code in the example.. )

BUGS 2. AssetsManagerEx::batchDownload() creates CCDownloader-curl task, but it opens temporary files at the time, not in the task thread. :( so.. if I pass assets lists above 512 files, that will makes open file limit error. (Windows's fopen() default file-open-limit is 512)
