### PR TITLE
Add size config in manifest for AssetsManagerEx

### DIFF
--- a/cocos/editor-support/cocostudio/ActionTimeline/CSLoader.cpp
+++ b/cocos/editor-support/cocostudio/ActionTimeline/CSLoader.cpp
@@ -162,11 +162,6 @@ static const char* TEXTURES_PNG = "texturesPng";
 
 static const char* MONO_COCOS2D_VERSION     = "cocos2dVersion";
 
-// hide the logs of CSLoader --add by vincent
-#define CCLOG(...)       do {} while (0)
-#define CCLOGINFO(...)   do {} while (0)
-#define CCLOGERROR(...)  do {} while (0)
-#define CCLOGWARN(...)   do {} while (0)
 
 // CSLoader
 static CSLoader* _sharedCSLoader = nullptr;

--- a/cocos/editor-support/cocostudio/ActionTimeline/CSLoader.cpp
+++ b/cocos/editor-support/cocostudio/ActionTimeline/CSLoader.cpp
@@ -162,6 +162,11 @@ static const char* TEXTURES_PNG = "texturesPng";
 
 static const char* MONO_COCOS2D_VERSION     = "cocos2dVersion";
 
+// hide the logs of CSLoader --add by vincent
+#define CCLOG(...)       do {} while (0)
+#define CCLOGINFO(...)   do {} while (0)
+#define CCLOGERROR(...)  do {} while (0)
+#define CCLOGWARN(...)   do {} while (0)
 
 // CSLoader
 static CSLoader* _sharedCSLoader = nullptr;

--- a/extensions/assets-manager/AssetsManagerEx.h
+++ b/extensions/assets-manager/AssetsManagerEx.h
@@ -88,6 +88,10 @@ public:
      */
     void update();
     
+    /** @brief Start to download.
+     */
+    void batchDownload();
+    
     /** @brief Reupdate all failed assets under the current AssetsManagerEx context
      */
     void downloadFailedAssets();
@@ -107,6 +111,13 @@ public:
     /** @brief Function for retrieve the remote manifest object
      */
     const Manifest* getRemoteManifest() const;
+    
+    /** @brief Function for get total file size need to be downloaded
+     */
+    inline double getTotalSize() const
+    {
+        return _totalSize;
+    };
     
 CC_CONSTRUCTOR_ACCESS:
     
@@ -188,7 +199,6 @@ protected:
     virtual void onSuccess(const std::string &srcUrl, const std::string &storagePath, const std::string &customId);
     
 private:
-    void batchDownload();
     
     //! The event of the current AssetsManagerEx in event dispatcher
     std::string _eventName;

--- a/extensions/assets-manager/Manifest.cpp
+++ b/extensions/assets-manager/Manifest.cpp
@@ -41,6 +41,7 @@
 
 #define KEY_PATH                "path"
 #define KEY_MD5                 "md5"
+#define KEY_SIZE                "size"
 #define KEY_GROUP               "group"
 #define KEY_COMPRESSED          "compressed"
 #define KEY_COMPRESSED_FILE     "compressedFile"
@@ -221,6 +222,7 @@ void Manifest::genResumeAssetsList(DownloadUnits *units) const
             unit.customId = it->first;
             unit.srcUrl = _packageUrl + asset.path;
             unit.storagePath = _manifestRoot + asset.path;
+            unit.size = asset.size;
             units->emplace(unit.customId, unit);
         }
     }
@@ -370,6 +372,12 @@ Manifest::Asset Manifest::parseAsset(const std::string &path, const rapidjson::V
         asset.md5 = json[KEY_MD5].GetString();
     }
     else asset.md5 = "";
+    
+    if ( json.HasMember(KEY_SIZE) && json[KEY_SIZE].IsNumber() )
+    {
+        asset.size = json[KEY_SIZE].GetDouble();
+    }
+    else asset.size = 0;
     
     if ( json.HasMember(KEY_PATH) && json[KEY_PATH].IsString() )
     {

--- a/extensions/assets-manager/Manifest.h
+++ b/extensions/assets-manager/Manifest.h
@@ -43,6 +43,7 @@ struct DownloadUnit
     std::string srcUrl;
     std::string storagePath;
     std::string customId;
+    double size;
 };
 
 typedef std::unordered_map<std::string, DownloadUnit> DownloadUnits;
@@ -70,6 +71,7 @@ public:
     struct Asset {
         std::string md5;
         std::string path;
+        double size;
         bool compressed;
         DownloadState downloadState;
     };


### PR DESCRIPTION
We know AssetsManagerEx cannot get the total size before update and cannot get the percent(not percent by file) timely.
In most cases,we should get the total size and let users to commit download especially in 3G network.
I add a member “size” in Manifest file,and cal the total size after get diff assets map.If you config the size in manifest file,you can get the total size and it will not continue download unless you call batchDownload().
I think I have considered the compatibility
Thank you for reviewing my code! Wish you have a nice day!
