### PR TITLE
Added the ability to set physics debug color of Shapes & Joints

### DIFF
--- a/cocos/physics/CCPhysicsBody.cpp
+++ b/cocos/physics/CCPhysicsBody.cpp
@@ -855,6 +855,46 @@ int PhysicsBody::getGroup() const
     }
 }
 
+void PhysicsBody::setDebugOutlineColor(const Color4F& outlineColor)
+{ 
+    for (auto& shape : _shapes)
+    {
+        shape->setDebugOutlineColor(outlineColor);
+    }
+}
+
+Color4F PhysicsBody::getDebugOutlineColor() const
+{
+    if (!_shapes.empty())
+    {
+        return _shapes.front()->getDebugOutlineColor();
+    }
+    else
+    {
+        return Color4F(1.0f, 0.0f, 0.0f, 1.0f);
+    }
+}
+
+void PhysicsBody::setDebugFillColor(const Color4F& fillColor)
+{ 
+    for (auto& shape : _shapes)
+    {
+        shape->setDebugFillColor(fillColor);
+    }
+}
+
+Color4F PhysicsBody::getDebugFillColor() const
+{ 
+    if (!_shapes.empty())
+    {
+        return _shapes.front()->getDebugFillColor();
+    }
+    else
+    {
+        return Color4F(1.0f, 0.0f, 0.0f, 0.3f);
+    }
+}
+
 void PhysicsBody::setRotationOffset(float rotation)
 {
     if (std::abs(_rotationOffset - rotation) > 0.5f)

--- a/cocos/physics/CCPhysicsBody.h
+++ b/cocos/physics/CCPhysicsBody.h
@@ -346,6 +346,35 @@ public:
      */
     int getGroup() const;
     
+    /**
+    * Set the debug outlines color.
+    *
+    * @param outlineColor The outline color.
+    */
+    void setDebugOutlineColor(const Color4F& outlineColor);
+
+    /**
+    * Gets the debug outline color.
+    *
+    * @return The outline color.
+    */
+    Color4F getDebugOutlineColor() const;
+
+    /**
+    * Set the debug fill color.
+    *
+    * @param fillColor The fill color.
+    */
+    void setDebugFillColor(const Color4F& fillColor);
+
+    /**
+    * Gets the debug fill color
+    *
+    * @return The fill color.
+    */
+    Color4F getDebugFillColor() const;
+
+
     /** get the body position. */
     Vec2 getPosition() const;
 

--- a/cocos/physics/CCPhysicsJoint.cpp
+++ b/cocos/physics/CCPhysicsJoint.cpp
@@ -43,6 +43,8 @@ PhysicsJoint::PhysicsJoint()
 , _tag(0)
 , _maxForce(PHYSICS_INFINITY)
 , _initDirty(true)
+, _lineColor(0.0f, 0.0f, 1.0f, 1.0f)
+, _jointPointColor(0.0f, 1.0f, 0.0f, 1.0f)
 {
 
 }

--- a/cocos/physics/CCPhysicsJoint.h
+++ b/cocos/physics/CCPhysicsJoint.h
@@ -29,6 +29,7 @@
 #if CC_USE_PHYSICS
 
 #include "base/CCRef.h"
+#include "base/ccTypes.h"
 #include "math/CCGeometry.h"
 
 struct cpConstraint;
@@ -100,6 +101,34 @@ public:
     /** Get the max force setting. */
     float getMaxForce() const { return _maxForce; }
 
+    /**
+    * Set the lines debug color.
+    * The default line color is blue
+    * @param outlineColor The line color.
+    */
+    inline void setDebugLineColor(const Color4F& outlineColor) { _lineColor = outlineColor; }
+
+    /**
+    * Gets the lines debug color.
+    *
+    * @return The line color.
+    */
+    inline const Color4F& getDebugLineColor()  const { return _lineColor; }
+
+    /**
+    * Set the debug point color of this shape.
+    * The default point color is green
+    * @param fillColor The point color of this joint.
+    */
+    inline void setDebugJointPointColor(const Color4F& jointPointColor) { _jointPointColor = jointPointColor; }
+
+    /**
+    * Gets the debug point color of this joint.
+    *
+    * @return The point color.
+    */
+    inline const Color4F& getDebugJointPointColor() const { return _jointPointColor; }
+
 protected:
     bool init(PhysicsBody* a, PhysicsBody* b);
 
@@ -120,6 +149,9 @@ protected:
     float _maxForce;
 
     bool _initDirty;
+
+    Color4F _lineColor;
+    Color4F _jointPointColor;
 
     friend class PhysicsBody;
     friend class PhysicsWorld;

--- a/cocos/physics/CCPhysicsShape.cpp
+++ b/cocos/physics/CCPhysicsShape.cpp
@@ -56,6 +56,8 @@ PhysicsShape::PhysicsShape()
 , _collisionBitmask(UINT_MAX)
 , _contactTestBitmask(0)
 , _group(0)
+, _outlineColor(1.0f, 0.0f, 0.0f, 1.0f)
+, _fillColor(1.0f, 0.0f, 0.0f, 0.3f)
 {
     if (s_sharedBody == nullptr)
     {

--- a/cocos/physics/CCPhysicsShape.h
+++ b/cocos/physics/CCPhysicsShape.h
@@ -29,6 +29,7 @@
 #if CC_USE_PHYSICS
 
 #include "base/CCRef.h"
+#include "base/ccTypes.h"
 #include "math/CCGeometry.h"
 
 struct cpShape;
@@ -328,6 +329,34 @@ public:
      * @return An integer number.
      */
     inline int getGroup() { return _group; }
+
+    /**
+    * Set the debug outline color of this shape.
+    * The default outline color is red
+    * @param outlineColor The outline color.
+    */
+    inline void setDebugOutlineColor(const Color4F& outlineColor) { _outlineColor = outlineColor; }
+
+    /**
+    * Gets the debug outline color of this shape.
+    *
+    * @return The outline color.
+    */
+    inline const Color4F& getDebugOutlineColor()  const { return _outlineColor; }
+
+    /**
+    * Set the debug fill color of this shape.
+    * The default fill color is red with an opacity of 30 percent
+    * @param fillColor The fill color.
+    */
+    inline void setDebugFillColor(const Color4F& fillColor) { _fillColor = fillColor; }
+
+    /**
+    * Gets the debug fill color of this shape.
+    *
+    * @return The fill color.
+    */
+    inline const Color4F& getDebugFillColor() const { return _fillColor; }
     
 protected:
     void setBody(PhysicsBody* body);
@@ -363,6 +392,9 @@ protected:
     int    _contactTestBitmask;
     int    _group;
     
+    Color4F _outlineColor;
+    Color4F _fillColor;
+
     friend class PhysicsWorld;
     friend class PhysicsBody;
     friend class PhysicsJoint;

--- a/cocos/physics/CCPhysicsWorld.cpp
+++ b/cocos/physics/CCPhysicsWorld.cpp
@@ -963,8 +963,8 @@ void PhysicsDebugDraw::end()
 
 void PhysicsDebugDraw::drawShape(PhysicsShape& shape)
 {
-    const Color4F fillColor(1.0f, 0.0f, 0.0f, 0.3f);
-    const Color4F outlineColor(1.0f, 0.0f, 0.0f, 1.0f);
+    const Color4F fillColor(shape.getDebugFillColor());
+    const Color4F outlineColor(shape.getDebugOutlineColor());
     
     for (auto it = shape._cpShapes.begin(); it != shape._cpShapes.end(); ++it)
     {
@@ -974,12 +974,11 @@ void PhysicsDebugDraw::drawShape(PhysicsShape& shape)
         {
             case CP_CIRCLE_SHAPE:
             {
-                
                 float radius = PhysicsHelper::cpfloat2float(cpCircleShapeGetRadius(subShape));
                 Vec2 centre = PhysicsHelper::cpv2point(cpBodyGetPos(cpShapeGetBody(subShape)));
                 Vec2 offset = PhysicsHelper::cpv2point(cpCircleShapeGetOffset(subShape));
                 Vec2 rotation(PhysicsHelper::cpv2point(cpBodyGetRot(cpShapeGetBody(subShape))));
-		              centre += offset.rotate(rotation);
+                centre += offset.rotate(rotation);
                 
                 static const int CIRCLE_SEG_NUM = 12;
                 Vec2 seg[CIRCLE_SEG_NUM] = {};
@@ -1022,13 +1021,12 @@ void PhysicsDebugDraw::drawShape(PhysicsShape& shape)
 
 void PhysicsDebugDraw::drawJoint(PhysicsJoint& joint)
 {
-    const Color4F lineColor(0.0f, 0.0f, 1.0f, 1.0f);
-    const Color4F jointPointColor(0.0f, 1.0f, 0.0f, 1.0f);
+    const Color4F lineColor(joint.getDebugLineColor());
+    const Color4F jointPointColor(joint.getDebugJointPointColor());
     
     for (auto it = joint._cpConstraints.begin(); it != joint._cpConstraints.end(); ++it)
     {
-        cpConstraint *constraint = *it;
-        
+        cpConstraint *constraint = *it;  
         
         cpBody *body_a = constraint->a;
         cpBody *body_b = constraint->b;

--- a/tests/cpp-tests/Classes/PhysicsTest/PhysicsTest.cpp
+++ b/tests/cpp-tests/Classes/PhysicsTest/PhysicsTest.cpp
@@ -171,7 +171,12 @@ Sprite* PhysicsDemo::makeBall(Vec2 point, float radius, PhysicsMaterial material
     
     ball->setScale(0.13f * radius);
     
-    ball->addComponent(PhysicsBody::createCircle(ball->getContentSize().width / 2, material));
+    // create a circle body with a green debug color
+    auto circleBody = PhysicsBody::createCircle(ball->getContentSize().width / 2, material);
+    circleBody->setDebugFillColor(Color4F(0.0f, 1.0f, 0.0f, 0.3f));
+    circleBody->setDebugOutlineColor(Color4F(0.0f, 1.0f, 0.0f, 1.0f));
+
+    ball->addComponent(circleBody);
     ball->setPosition(Vec2(point.x, point.y));
     
     return ball;
@@ -712,6 +717,8 @@ void PhysicsDemoJoints::onEnter()
                     sp2PhysicsBody->setTag(DRAG_BODYS_TAG);
                     
                     PhysicsJointPin* joint = PhysicsJointPin::construct(sp1PhysicsBody, sp2PhysicsBody, offset);
+                    joint->setDebugLineColor(Color4F::GREEN);
+                    joint->setDebugJointPointColor(Color4F::RED);
                     getPhysicsWorld()->addJoint(joint);
                     
                     this->addChild(sp1);

--- a/tests/cpp-tests/Classes/PhysicsTest/PhysicsTest.cpp
+++ b/tests/cpp-tests/Classes/PhysicsTest/PhysicsTest.cpp
@@ -26,6 +26,7 @@ PhysicsTests::PhysicsTests()
     ADD_TEST_CASE(PhysicsDemoBug5482);
     ADD_TEST_CASE(PhysicsFixedUpdate);
     ADD_TEST_CASE(PhysicsTransformTest);
+    ADD_TEST_CASE(PhysicsDebugColorTest);
     ADD_TEST_CASE(PhysicsIssue9959);
 }
 
@@ -173,9 +174,6 @@ Sprite* PhysicsDemo::makeBall(Vec2 point, float radius, PhysicsMaterial material
     
     // create a circle body with a green debug color
     auto circleBody = PhysicsBody::createCircle(ball->getContentSize().width / 2, material);
-    circleBody->setDebugFillColor(Color4F(0.0f, 1.0f, 0.0f, 0.3f));
-    circleBody->setDebugOutlineColor(Color4F(0.0f, 1.0f, 0.0f, 1.0f));
-
     ball->addComponent(circleBody);
     ball->setPosition(Vec2(point.x, point.y));
     
@@ -717,8 +715,6 @@ void PhysicsDemoJoints::onEnter()
                     sp2PhysicsBody->setTag(DRAG_BODYS_TAG);
                     
                     PhysicsJointPin* joint = PhysicsJointPin::construct(sp1PhysicsBody, sp2PhysicsBody, offset);
-                    joint->setDebugLineColor(Color4F::GREEN);
-                    joint->setDebugJointPointColor(Color4F::RED);
                     getPhysicsWorld()->addJoint(joint);
                     
                     this->addChild(sp1);
@@ -1839,6 +1835,51 @@ void PhysicsTransformTest::onEnter()
 std::string PhysicsTransformTest::title() const
 {
     return "Physics transform test";
+}
+
+void PhysicsDebugColorTest::onEnter()
+{
+    PhysicsDemo::onEnter();
+    toggleDebug();
+    _physicsWorld->setGravity(Point::ZERO);
+
+    Vec2 offset(VisibleRect::leftBottom().x + 100, VisibleRect::leftBottom().y + 100);
+
+    auto sp1 = makeBall(offset - Vec2(30, -100), 10);
+    auto sp1PhysicsBody = sp1->getPhysicsBody();
+
+    auto sp2 = makeBall(offset + Vec2(30, 100), 10);
+    auto sp2PhysicsBody = sp2->getPhysicsBody();
+
+    PhysicsJointDistance* joint = PhysicsJointDistance::construct(sp1PhysicsBody, sp2PhysicsBody, Point::ZERO, Point::ZERO);
+    getPhysicsWorld()->addJoint(joint);
+
+    auto sp3 = makeBall(offset - Vec2(30, 0), 10);
+    auto sp3PhysicsBody = sp3->getPhysicsBody();
+
+    auto sp4 = makeBall(offset + Vec2(30, 0), 10);
+    auto sp4PhysicsBody = sp4->getPhysicsBody();
+
+    PhysicsJointDistance* joint2 = PhysicsJointDistance::construct(sp3PhysicsBody, sp4PhysicsBody, Point::ZERO, Point::ZERO);
+    joint2->setDebugLineColor(Color4F::GREEN);
+    joint2->setDebugJointPointColor(Color4F::RED);
+    getPhysicsWorld()->addJoint(joint2);
+
+    auto defaultSprite = addGrossiniAtPosition(VisibleRect::center());
+    auto sprite = addGrossiniAtPosition(VisibleRect::center() + Vec2(defaultSprite->getContentSize().width, 0));
+
+    sprite->getPhysicsBody()->setDebugFillColor(Color4F(0.0f, 0.0f, 1.0f, 0.3f));
+    sprite->getPhysicsBody()->setDebugOutlineColor(Color4F(0.0f, 0.0f, 1.0f, 1.0f));
+
+    this->addChild(sp1);
+    this->addChild(sp2);
+    this->addChild(sp3);
+    this->addChild(sp4);
+}
+
+std::string PhysicsDebugColorTest::title() const
+{
+    return "Custom physics debug draw color";
 }
 
 void PhysicsIssue9959::onEnter()

--- a/tests/cpp-tests/Classes/PhysicsTest/PhysicsTest.h
+++ b/tests/cpp-tests/Classes/PhysicsTest/PhysicsTest.h
@@ -257,6 +257,15 @@ private:
     cocos2d::Layer* _rootLayer;
 };
 
+class PhysicsDebugColorTest : public PhysicsDemo
+{
+public:
+    CREATE_FUNC(PhysicsDebugColorTest);
+
+    void onEnter() override;
+    virtual std::string title() const override;
+};
+
 class PhysicsIssue9959 : public PhysicsDemo
 {
 public:


### PR DESCRIPTION
This pr adds the ability to change the physics debug color of the Shapes fill and outline. 
You can also change this on the PhysicsBody itself to change the color of all its shapes. 
Additionally, you can also set the line and point color of Joints
