### PR TITLE
return null if read failed in js_cocos2dx_CCFileUtils_getDataFromFile

### DIFF
--- a/cocos/scripting/js-bindings/manual/cocos2d_specifics.cpp
+++ b/cocos/scripting/js-bindings/manual/cocos2d_specifics.cpp
@@ -4441,6 +4441,10 @@ bool js_cocos2dx_CCFileUtils_getDataFromFile(JSContext *cx, uint32_t argc, jsval
                 args.rval().set(OBJECT_TO_JSVAL(array));
                 return true;
             }
+
+            // return null if read failed.
+            args.rval().set(JSVAL_NULL);
+            return true;
         } while(false);
         
         JS_ReportError(cx, "get file(%s) data fails", arg0.c_str());


### PR DESCRIPTION
calling getDataFromFile() from js should return null if file not exists, as c++ code does.
