### PR TITLE
Fix minor grammar and typo in documentation

### DIFF
--- a/cocos/2d/CCAnimation.h
+++ b/cocos/2d/CCAnimation.h
@@ -183,7 +183,7 @@ public:
     /* Creates an animation with an array of AnimationFrame, the delay per units in seconds and and how many times it should be executed.
      * @since v2.0
      * @param arrayOfAnimationFrameNames An animation with an array of AnimationFrame.
-     * @param delayPerUnit The delay per units in seconds and and how many times it should be executed.
+     * @param delayPerUnit The delay per units in seconds and how many times it should be executed.
      * @param loops The times the animation is going to loop.
      */
     static Animation* create(const Vector<AnimationFrame*>& arrayOfAnimationFrameNames, float delayPerUnit, unsigned int loops = 1);

--- a/cocos/2d/CCDrawNode.h
+++ b/cocos/2d/CCDrawNode.h
@@ -143,7 +143,7 @@ public:
      * @param origin The origin of the bezier path.
      * @param control The control of the bezier path.
      * @param destination The destination of the bezier path.
-     * @param segments The The number of segments.
+     * @param segments The number of segments.
      * @param color Set the quad bezier color.
      */
     void drawQuadBezier(const Vec2 &origin, const Vec2 &control, const Vec2 &destination, unsigned int segments, const Color4F &color);
@@ -154,7 +154,7 @@ public:
      * @param control1 The first control of the bezier path.
      * @param control2 The second control of the bezier path.
      * @param destination The destination of the bezier path.
-     * @param segments The The number of segments.
+     * @param segments The number of segments.
      * @param color Set the cubic bezier color.
      */
     void drawCubicBezier(const Vec2 &origin, const Vec2 &control1, const Vec2 &control2, const Vec2 &destination, unsigned int segments, const Color4F &color);
@@ -163,7 +163,7 @@ public:
      *
      * @param config A array point.
      * @param tension The tension of the spline.
-     * @param segments The The number of segments.
+     * @param segments The number of segments.
      * @param color Set the Spline color.
      */
     void drawCardinalSpline(PointArray *config, float tension,  unsigned int segments, const Color4F &color);
@@ -171,7 +171,7 @@ public:
     /** Draws a Catmull Rom path.
      *
      * @param points A point array  of control point.
-     * @param segments The The number of segments.
+     * @param segments The number of segments.
      * @param color The Catmull Rom color.
      */
     void drawCatmullRom(PointArray *points, unsigned int segments, const Color4F &color);
@@ -274,7 +274,7 @@ public:
      * @param from The origin of the bezier path.
      * @param control The control of the bezier path.
      * @param to The destination of the bezier path.
-     * @param segments The The number of segments.
+     * @param segments The number of segments.
      * @param color The quadratic bezier color.
      * @js NA
      */

--- a/cocos/2d/CCFontFNT.cpp
+++ b/cocos/2d/CCFontFNT.cpp
@@ -98,7 +98,7 @@ typedef struct _KerningHashElement
     UT_hash_handle	hh;
 } tKerningHashElement;
 
-/** @brief BMFontConfiguration has parsed configuration of the the .fnt file
+/** @brief BMFontConfiguration has parsed configuration of the .fnt file
 @since v0.8
 */
 class CC_DLL BMFontConfiguration : public Ref

--- a/cocos/2d/CCParallaxNode.h
+++ b/cocos/2d/CCParallaxNode.h
@@ -42,7 +42,7 @@ struct _ccArray;
 /** @class ParallaxNode
  * @brief ParallaxNode: A node that simulates a parallax scroller
 
-The children will be moved faster / slower than the parent according the the parallax ratio.
+The children will be moved faster / slower than the parent according the parallax ratio.
 
 */
 class CC_DLL ParallaxNode : public Node

--- a/cocos/2d/CCTMXLayer.h
+++ b/cocos/2d/CCTMXLayer.h
@@ -115,7 +115,7 @@ public:
     CC_DEPRECATED_ATTRIBUTE Sprite* tileAt(const Vec2& tileCoordinate) { return getTileAt(tileCoordinate); };
     
     /** Returns the tile gid at a given tile coordinate. It also returns the tile flags.
-     * This method requires the the tile map has not been previously released (eg. don't call [layer releaseMap]).
+     * This method requires the tile map has not been previously released (eg. don't call [layer releaseMap]).
      * 
      * @param tileCoordinate The tile coordinate.
      * @param flags Tile flags.

--- a/cocos/base/CCData.h
+++ b/cocos/base/CCData.h
@@ -116,7 +116,7 @@ public:
     /** 
      * Check whether the data is null.
      *
-     * @return True if the the Data is null, false if not.
+     * @return True if the Data is null, false if not.
      */
     bool isNull() const;
     

--- a/cocos/base/ccConfig.h
+++ b/cocos/base/ccConfig.h
@@ -48,7 +48,7 @@ THE SOFTWARE.
 
 /** @def CC_ENABLE_GL_STATE_CACHE
  * If enabled, cocos2d will maintain an OpenGL state cache internally to avoid unnecessary switches.
- * In order to use them, you have to use the following functions, instead of the the GL ones:
+ * In order to use them, you have to use the following functions, instead of the GL ones:
  *  - ccGLUseProgram() instead of glUseProgram().
  *  - GL::deleteProgram() instead of glDeleteProgram().
  *  - GL::blendFunc() instead of glBlendFunc().

--- a/cocos/editor-support/cocostudio/CCActionFrame.h
+++ b/cocos/editor-support/cocostudio/CCActionFrame.h
@@ -293,7 +293,7 @@ public:
     /**
     * Gets the scale action scaleY.
     *
-    * @return the the scale action scaleY.
+    * @return the scale action scaleY.
     */
     float getScaleY();
 

--- a/cocos/math/Mat4.h
+++ b/cocos/math/Mat4.h
@@ -483,7 +483,7 @@ public:
     /**
      * Inverts this matrix.
      *
-     * @return true if the the matrix can be inverted, false otherwise.
+     * @return true if the matrix can be inverted, false otherwise.
      */
     bool inverse();
 

--- a/cocos/platform/ios/CCEAGLView-ios.mm
+++ b/cocos/platform/ios/CCEAGLView-ios.mm
@@ -274,7 +274,7 @@ Copyright (C) 2008 Apple Inc. All Rights Reserved.
     // IMPORTANT:
     // - preconditions
     //    -> context_ MUST be the OpenGL context
-    //    -> renderbuffer_ must be the the RENDER BUFFER
+    //    -> renderbuffer_ must be the RENDER BUFFER
 
 #ifdef __IPHONE_4_0
     

--- a/cocos/platform/win8.1-universal/OpenGLESPage.xaml.cpp
+++ b/cocos/platform/win8.1-universal/OpenGLESPage.xaml.cpp
@@ -155,7 +155,7 @@ void OpenGLESPage::CreateRenderSurface()
 {
     if (mOpenGLES && mRenderSurface == EGL_NO_SURFACE)
     {
-        // The app can configure the the SwapChainPanel which may boost performance.
+        // The app can configure the SwapChainPanel which may boost performance.
         // By default, this template uses the default configuration.
         mRenderSurface = mOpenGLES->CreateSurface(swapChainPanel, nullptr, nullptr);
 

--- a/cocos/scripting/js-bindings/manual/js_bindings_config.h
+++ b/cocos/scripting/js-bindings/manual/js_bindings_config.h
@@ -78,7 +78,7 @@
 /** @def JSB_REPRESENT_LONGLONG_AS_STR
  When JSB_REPRESENT_LONGLONG_AS_STR is defined, the long long will be represented as JS strings.
  Otherwise they will be represented as an array of two integers.
- It is needed to to use an special representation since there are no 64-bit integers in JS.
+ It is needed to use an special representation since there are no 64-bit integers in JS.
  Representing the long long as string could be a bit slower, but it is easier to debug from JS.
  Enabled by default.
  */

--- a/cocos/scripting/lua-bindings/manual/CCLuaStack.h
+++ b/cocos/scripting/lua-bindings/manual/CCLuaStack.h
@@ -222,7 +222,7 @@ public:
     /**
      * Pushes a lua table onto the stack.
      * The key of table is the key of LuaValueDict which is std::map.
-     * The value of table is according to the the type of LuaValue of LuaValueDict by calling pushLuaValue,@see pushLuaValue.
+     * The value of table is according to the type of LuaValue of LuaValueDict by calling pushLuaValue,@see pushLuaValue.
      *
      * @param dict a LuaValueDict object.
      */
@@ -231,7 +231,7 @@ public:
     /**
      * Pushes a lua array table onto the stack.
      * The index of array table is begin at 1.
-     * The value of array table is according to the the type of LuaValue of LuaValueDict by calling pushLuaValue,@see pushLuaValue.
+     * The value of array table is according to the type of LuaValue of LuaValueDict by calling pushLuaValue,@see pushLuaValue.
      */
     virtual void pushLuaValueArray(const LuaValueArray& array);
     

--- a/cocos/scripting/lua-bindings/manual/LuaBasicConversions.h
+++ b/cocos/scripting/lua-bindings/manual/LuaBasicConversions.h
@@ -179,7 +179,7 @@ extern bool luaval_to_long_long(lua_State* L,int lo,long long* outValue, const c
  * @param lo the given accpetable index of stack.
  * @param outValue the pointer to store std::string value converted from the Lua value.
  * @param funcName the name of calling function, it is used for error output in the debug model.
- * @return Return true if the value at the given accpetable index of stack is is a string or a number convertible to a string, otherwise return false.
+ * @return Return true if the value at the given acceptable index of stack is a string or a number convertible to a string, otherwise return false.
  */
 extern bool luaval_to_std_string(lua_State* L, int lo, std::string* outValue, const char* funcName = "");
 
@@ -837,7 +837,7 @@ extern bool luaval_to_std_map_string_string(lua_State* L, int lo, std::map<std::
 
 /**
  * @name native_to_luaval
- * The following function are all used to convert native c++ values to the the corresponding Lua values,then push it into the Lua stack.
+ * The following function are all used to convert native c++ values to the corresponding Lua values, then push it into the Lua stack.
  *
  * @{
  **/

--- a/cocos/ui/UIListView.h
+++ b/cocos/ui/UIListView.h
@@ -136,7 +136,7 @@ public:
     void setItemModel(Widget* model);
     
     /**
-     * Insert a  a default item(create by a cloned model) at the end of the listview.
+     * Insert a default item(create by a cloned model) at the end of the listview.
      */
     void pushBackDefaultItem();
     

--- a/cocos/ui/UIScale9Sprite.cpp
+++ b/cocos/ui/UIScale9Sprite.cpp
@@ -1092,7 +1092,7 @@ namespace ui {
     }
 
 /** sets the opacity.
-    @warning If the the texture has premultiplied alpha then, the R, G and B channels will be modifed.
+    @warning If the texture has premultiplied alpha then, the R, G and B channels will be modifed.
     Values goes from 0 to 255, where 255 means fully opaque.
 */
 

--- a/cocos/ui/UITextField.h
+++ b/cocos/ui/UITextField.h
@@ -572,7 +572,7 @@ public:
     virtual std::string getDescription() const override;
     
     /**
-     * @brief Get the the renderer size in auto mode.
+     * @brief Get the renderer size in auto mode.
      *
      * @return A delimitation zone.
      */


### PR DESCRIPTION
Just some minor grammar/typo fixes while reading the docs. Thanks.
