### PR TITLE
Fix SocketIO crash on reconnect

### DIFF
--- a/cocos/network/SocketIO.cpp
+++ b/cocos/network/SocketIO.cpp
@@ -986,6 +986,10 @@ void SIOClientImpl::onClose(WebSocket* ws)
         {
             iter->second->socketClosed();
         }
+        // discard this client
+        _connected = false;
+        Director::getInstance()->getScheduler()->unscheduleAllForTarget(this);
+        SocketIO::getInstance()->removeSocket(_uri);
     }
 
     this->release();


### PR DESCRIPTION
Cleans up SIOClientImpl instance when websocket is unexpectedly closed. Fixes #14287
