### PR TITLE
Fix spelling of function name

### DIFF
--- a/cocos/2d/CCFontAtlas.cpp
+++ b/cocos/2d/CCFontAtlas.cpp
@@ -110,7 +110,7 @@ FontAtlas::~FontAtlas()
 #endif
 
     _font->release();
-    relaseTextures();
+    releaseTextures();
 
     delete []_currentPageData;
 
@@ -123,7 +123,7 @@ FontAtlas::~FontAtlas()
 #endif
 }
 
-void FontAtlas::relaseTextures()
+void FontAtlas::releaseTextures()
 {
     for( auto &item: _atlasTextures)
     {

--- a/cocos/2d/CCFontAtlas.cpp
+++ b/cocos/2d/CCFontAtlas.cpp
@@ -132,6 +132,11 @@ void FontAtlas::releaseTextures()
     _atlasTextures.clear();
 }
 
+void FontAtlas::relaseTextures()
+{
+    releaseTextures();
+}
+
 void FontAtlas::purgeTexturesAtlas()
 {
     if (_fontFreeType && _atlasTextures.size() > 1)

--- a/cocos/2d/CCFontAtlas.h
+++ b/cocos/2d/CCFontAtlas.h
@@ -109,7 +109,7 @@ public:
      void setAliasTexParameters();
 
 protected:
-    void relaseTextures();
+    void releaseTextures();
 
     void findNewCharacters(const std::u16string& u16Text, std::unordered_map<unsigned short, unsigned short>& charCodeMap);
 

--- a/cocos/2d/CCFontAtlas.h
+++ b/cocos/2d/CCFontAtlas.h
@@ -111,6 +111,9 @@ public:
 protected:
     void releaseTextures();
 
+    /** @deprecated Use method releaseTextures() instead */
+    CC_DEPRECATED_ATTRIBUTE void relaseTextures();
+
     void findNewCharacters(const std::u16string& u16Text, std::unordered_map<unsigned short, unsigned short>& charCodeMap);
 
     void conversionU16TOGB2312(const std::u16string& u16Text, std::unordered_map<unsigned short, unsigned short>& charCodeMap);

--- a/cocos/ui/UILayoutManager.cpp
+++ b/cocos/ui/UILayoutManager.cpp
@@ -522,6 +522,16 @@ void RelativeLayoutManager::calculateFinalPositionWithRelativeAlign()
     }
 }
 
+bool RelativeLayoutManager::caculateFinalPositionWithRelativeWidget(LayoutProtocol *layout)
+{
+    return calculateFinalPositionWithRelativeWidget(layout);
+}
+
+void RelativeLayoutManager::caculateFinalPositionWithRelativeAlign()
+{
+    calculateFinalPositionWithRelativeAlign();
+}
+
 void RelativeLayoutManager::doLayout(LayoutProtocol *layout)
 {
     

--- a/cocos/ui/UILayoutManager.cpp
+++ b/cocos/ui/UILayoutManager.cpp
@@ -203,7 +203,7 @@ Widget* RelativeLayoutManager::getRelativeWidget(Widget* widget)
     return relativeWidget;
 }
     
-bool RelativeLayoutManager::caculateFinalPositionWithRelativeWidget(LayoutProtocol *layout)
+bool RelativeLayoutManager::calculateFinalPositionWithRelativeWidget(LayoutProtocol *layout)
 {
     Vec2 ap = _widget->getAnchorPoint();
     Size cs = _widget->getContentSize();
@@ -426,7 +426,7 @@ bool RelativeLayoutManager::caculateFinalPositionWithRelativeWidget(LayoutProtoc
     return true;
 }
     
-void RelativeLayoutManager::caculateFinalPositionWithRelativeAlign()
+void RelativeLayoutManager::calculateFinalPositionWithRelativeAlign()
 {
     RelativeLayoutParameter* layoutParameter = dynamic_cast<RelativeLayoutParameter*>(_widget->getLayoutParameter());
     
@@ -543,12 +543,12 @@ void RelativeLayoutManager::doLayout(LayoutProtocol *layout)
                 }
                 
                
-                bool ret = this->caculateFinalPositionWithRelativeWidget(layout);
+                bool ret = this->calculateFinalPositionWithRelativeWidget(layout);
                 if (!ret) {
                     continue;
                 }
                 
-                this->caculateFinalPositionWithRelativeAlign();
+                this->calculateFinalPositionWithRelativeAlign();
             
             
                 _widget->setPosition(Vec2(_finalPositionX, _finalPositionY));

--- a/cocos/ui/UILayoutManager.h
+++ b/cocos/ui/UILayoutManager.h
@@ -115,8 +115,8 @@ private:
     
     Vector<Widget*> getAllWidgets(LayoutProtocol *layout);
     Widget* getRelativeWidget(Widget* widget);
-    bool caculateFinalPositionWithRelativeWidget(LayoutProtocol *layout);
-    void caculateFinalPositionWithRelativeAlign();
+    bool calculateFinalPositionWithRelativeWidget(LayoutProtocol *layout);
+    void calculateFinalPositionWithRelativeAlign();
     
     ssize_t _unlayoutChildCount;
     Vector<Widget*> _widgetChildren;

--- a/cocos/ui/UILayoutManager.h
+++ b/cocos/ui/UILayoutManager.h
@@ -118,6 +118,12 @@ private:
     bool calculateFinalPositionWithRelativeWidget(LayoutProtocol *layout);
     void calculateFinalPositionWithRelativeAlign();
     
+    /** @deprecated Use method calculateFinalPositionWithRelativeWidget() instead */
+    CC_DEPRECATED_ATTRIBUTE bool caculateFinalPositionWithRelativeWidget(LayoutProtocol *layout);
+
+    /** @deprecated Use method calculateFinalPositionWithRelativeAlign() instead */
+    CC_DEPRECATED_ATTRIBUTE void caculateFinalPositionWithRelativeAlign();
+
     ssize_t _unlayoutChildCount;
     Vector<Widget*> _widgetChildren;
     Widget* _widget;


### PR DESCRIPTION
This commit fixes three small spelling mistakes:
- `relaseTextures()` -> `releaseTextures()`
- `caculateFinalPositionWithRelativeWidget()` -> `calculateFinalPositionWithRelativeWidget()`
- `caculateFinalPositionWithRelativeAlign()` -> `calculateFinalPositionWithRelativeAlign()`

Thanks for your work on this engine. :relaxed:
