### PR TITLE
[3.9] Fix bug if Node::setPhysicsBody is called multiple times

### DIFF
--- a/cocos/2d/CCNode.h
+++ b/cocos/2d/CCNode.h
@@ -38,6 +38,10 @@
 #include "2d/CCComponentContainer.h"
 #include "2d/CCComponent.h"
 
+#if CC_USE_PHYSICS
+#include "physics/CCPhysicsBody.h"
+#endif
+
 NS_CC_BEGIN
 
 class GridBase;
@@ -1629,7 +1633,7 @@ public:
      */
     Vec2 convertTouchToNodeSpaceAR(Touch * touch) const;
 
-	/**
+    /**
      *  Sets an additional transform matrix to the node.
      *
      *  In order to remove it, call it again with the argument `nullptr`.
@@ -1841,11 +1845,11 @@ protected:
     ComponentContainer *_componentContainer;        ///< Dictionary of components
     
     // opacity controls
-    GLubyte		_displayedOpacity;
+    GLubyte     _displayedOpacity;
     GLubyte     _realOpacity;
-    Color3B	    _displayedColor;
+    Color3B     _displayedColor;
     Color3B     _realColor;
-    bool		_cascadeColorEnabled;
+    bool        _cascadeColorEnabled;
     bool        _cascadeOpacityEnabled;
 
     static int s_globalOrderOfArrival;
@@ -1862,8 +1866,13 @@ protected:
 #if CC_USE_PHYSICS
     PhysicsBody* _physicsBody;
 public:
-    void setPhysicsBody(Component* physicsBody) 
-    { 
+    void setPhysicsBody(PhysicsBody* physicsBody)
+    {
+        if (_physicsBody != nullptr)
+        {
+            removeComponent(_physicsBody);
+        }
+
         addComponent(physicsBody);
     }
     PhysicsBody* getPhysicsBody() const { return _physicsBody; }

--- a/cocos/physics/CCPhysicsBody.cpp
+++ b/cocos/physics/CCPhysicsBody.cpp
@@ -76,6 +76,7 @@ PhysicsBody::PhysicsBody()
 , _recordScaleX(1.f)
 , _recordScaleY(1.f)
 {
+    _name = COMPONENT_NAME;
 }
 
 PhysicsBody::~PhysicsBody()


### PR DESCRIPTION
Firstly, this fixed some inconsistency with the other components, as the compontents should have `COMPONENT_NAME` as their default name so they can be easily added/removed. This also fixes a problem if you call `Node::setPhysicsBody` multiple times, before 3.9 this set the new physics body, but before this pr it would do nothing on the second call as there is already the same component in the container(not the same behaviour as previous version).

@pandamicro @WenhaiLin this should be in 3.9 final as it is an important bug fix for backward compatibility
