### PR TITLE
Fix deprecated warnings

### DIFF
--- a/cocos/editor-support/cocostudio/CCArmatureDataManager.cpp
+++ b/cocos/editor-support/cocostudio/CCArmatureDataManager.cpp
@@ -250,7 +250,7 @@ const cocos2d::Map<std::string, TextureData*>& ArmatureDataManager::getTextureDa
     return _textureDatas;
 }
 
-void CCArmatureDataManager::addRelativeData(const std::string& configFilePath)
+void ArmatureDataManager::addRelativeData(const std::string& configFilePath)
 {
     if (_relativeDatas.find(configFilePath) == _relativeDatas.end())
     {
@@ -258,7 +258,7 @@ void CCArmatureDataManager::addRelativeData(const std::string& configFilePath)
     }
 }
 
-RelativeData *CCArmatureDataManager::getRelativeData(const std::string&  configFilePath)
+RelativeData *ArmatureDataManager::getRelativeData(const std::string& configFilePath)
 {
     return &_relativeDatas[configFilePath];
 }

--- a/cocos/editor-support/cocostudio/WidgetReader/ArmatureNodeReader/ArmatureNodeReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/ArmatureNodeReader/ArmatureNodeReader.cpp
@@ -165,7 +165,7 @@ void ArmatureNodeReader::setPropsWithFlatBuffers(cocos2d::Node *node,
 
 cocos2d::Node*  ArmatureNodeReader::createNodeWithFlatBuffers(const flatbuffers::Table *nodeOptions)
 {
-	auto node = CCArmature::create();
+	auto node = Armature::create();
 
 	// self
 	auto options = (flatbuffers::CSArmatureNodeOption*)nodeOptions;


### PR DESCRIPTION
This fixes the following warnings when compiling in Xcode 7:

```
CCArmatureDataManager.cpp:253:27: 'CCArmatureDataManager' is deprecated
CCArmatureDataManager.cpp:261:36: 'CCArmatureDataManager' is deprecated
ArmatureNodeReader.cpp:168:24: 'CCArmature' is deprecated
```
