### PR TITLE
Combine Studio change for compatible with 32 bit Mac System

### DIFF
--- a/cocos/network/HttpAsynConnection-apple.h
+++ b/cocos/network/HttpAsynConnection-apple.h
@@ -34,6 +34,18 @@
 /// @cond
 @interface HttpAsynConnection : NSObject <NSURLConnectionDelegate, NSURLConnectionDataDelegate>
 {
+    NSString *srcURL;
+    NSString *sslFile;
+    NSDictionary *responseHeader;
+    NSMutableData *responseData;
+    NSInteger getDataTime;
+    NSInteger responseCode;
+    NSString *statusString;
+    NSError *responseError;
+    NSError *connError;
+    NSURLConnection *conn;
+    bool finish;
+    NSRunLoop *runLoop;
 }
 
 // The original URL to download.  Due to redirects the actual content may come from another URL

--- a/cocos/network/HttpAsynConnection-apple.m
+++ b/cocos/network/HttpAsynConnection-apple.m
@@ -35,18 +35,18 @@
 
 @implementation HttpAsynConnection
 
-@synthesize srcURL;
-@synthesize sslFile;
-@synthesize responseHeader;
-@synthesize responseData;
-@synthesize getDataTime;
-@synthesize responseCode;
-@synthesize statusString;
-@synthesize responseError;
-@synthesize connError;
-@synthesize conn;
-@synthesize finish;
-@synthesize runLoop;
+@synthesize srcURL = srcURL;
+@synthesize sslFile = sslFile;
+@synthesize responseHeader = responseHeader;
+@synthesize responseData = responseData;
+@synthesize getDataTime = getDataTime;
+@synthesize responseCode = responseCode;
+@synthesize statusString = statusString;
+@synthesize responseError = responseError;
+@synthesize connError = connError;
+@synthesize conn = conn;
+@synthesize finish = finish;
+@synthesize runLoop = runLoop;
 
 - (void)dealloc
 {

--- a/cocos/ui/UIEditBox/UIEditBoxImpl-mac.mm
+++ b/cocos/ui/UIEditBox/UIEditBoxImpl-mac.mm
@@ -41,12 +41,16 @@
 /** TODO: Missing doc - What does "CustomTextFieldFormatter" do?
  */
 @interface CustomTextFieldFormatter : NSFormatter
+{
+    int _maximumLength;
+}
 
 @property (nonatomic, assign) int maximumLength;
 
 @end
 
 @implementation CustomTextFieldFormatter
+@synthesize maximumLength = _maximumLength;
 
 - (instancetype)init
 {
@@ -88,6 +92,16 @@
 #pragma mark - UIEditBox mac implementation
 
 @interface UIEditBoxImplMac : NSObject <NSTextFieldDelegate>
+{
+    NSTextField* _textField;
+    NSSecureTextField* _secureTextField;
+    NSMutableDictionary* _placeholderAttributes;
+    NSWindow* _window;
+
+    BOOL _editState;
+    BOOL _secure;
+    void* _editBox;
+}
 
 @property (nonatomic, retain) NSTextField* textField;
 @property (nonatomic, retain) NSSecureTextField *secureTextField;
@@ -110,6 +124,13 @@
 
 
 @implementation UIEditBoxImplMac
+@synthesize textField = _textField;
+@synthesize secureTextField = _secureTextField;
+@synthesize placeholderAttributes = _placeholderAttributes;
+@synthesize window = _window;
+@synthesize editState = _editState;
+@synthesize secure = _secure;
+@synthesize editBox = _editBox;
 
 - (instancetype)initWithFrame:(NSRect)frameRect editBox:(void *)editBox
 {


### PR DESCRIPTION
Cocos studio is compile as 32 bit executable file, so the code must be compatible with 32 bit compiler.
@pandamicro @minggo Please review this pr
