### PR TITLE
Fix edit box native size and a typo on placeholder font

### DIFF
--- a/cocos/ui/UIEditBox/UIEditBox.cpp
+++ b/cocos/ui/UIEditBox/UIEditBox.cpp
@@ -268,7 +268,7 @@ void EditBox::setPlaceholderFontName(const char* pFontName)
     _placeholderFontName = pFontName;
     if (_editBoxImpl != nullptr)
     {
-        _editBoxImpl->setPlaceholderFont(pFontName, _fontSize);
+        _editBoxImpl->setPlaceholderFont(pFontName, _placeholderFontSize);
     }
 }
 

--- a/cocos/ui/UIEditBox/UIEditBoxImpl-common.cpp
+++ b/cocos/ui/UIEditBox/UIEditBoxImpl-common.cpp
@@ -124,7 +124,7 @@ void EditBoxImplCommon::setInactiveText(const char* pText)
     
 void EditBoxImplCommon::setFont(const char* pFontName, int fontSize)
 {
-    this->setNativeFont(pFontName, fontSize);
+    this->setNativeFont(pFontName, fontSize * _label->nodeToWorldTransform().a);
 
     if(strlen(pFontName) > 0)
     {
@@ -145,7 +145,7 @@ void EditBoxImplCommon::setFontColor(const Color4B& color)
 
 void EditBoxImplCommon::setPlaceholderFont(const char* pFontName, int fontSize)
 {
-    this->setNativePlaceholderFont(pFontName, fontSize);
+    this->setNativePlaceholderFont(pFontName, fontSize * _labelPlaceHolder->nodeToWorldTransform().a);
     
     if( strlen(pFontName) > 0)
     {
@@ -249,7 +249,7 @@ void EditBoxImplCommon::setContentSize(const Size& size)
     
     auto director = cocos2d::Director::getInstance();
     auto glview = director->getOpenGLView();
-    Size  controlSize = Size(size.width * glview->getScaleX(),size.height * glview->getScaleY());
+    Size  controlSize = Size(size.width * glview->getScaleX() * _label->nodeToWorldTransform().a,size.height * glview->getScaleY() * _label->nodeToWorldTransform().a);
        
     this->setNativeContentSize(controlSize);
 

--- a/cocos/ui/UIEditBox/UIEditBoxImpl-common.cpp
+++ b/cocos/ui/UIEditBox/UIEditBoxImpl-common.cpp
@@ -124,7 +124,7 @@ void EditBoxImplCommon::setInactiveText(const char* pText)
     
 void EditBoxImplCommon::setFont(const char* pFontName, int fontSize)
 {
-    this->setNativeFont(pFontName, fontSize * _label->nodeToWorldTransform().a);
+    this->setNativeFont(pFontName, fontSize * _label->getNodeToWorldTransform().a);
 
     if(strlen(pFontName) > 0)
     {
@@ -145,7 +145,7 @@ void EditBoxImplCommon::setFontColor(const Color4B& color)
 
 void EditBoxImplCommon::setPlaceholderFont(const char* pFontName, int fontSize)
 {
-    this->setNativePlaceholderFont(pFontName, fontSize * _labelPlaceHolder->nodeToWorldTransform().a);
+    this->setNativePlaceholderFont(pFontName, fontSize * _labelPlaceHolder->getNodeToWorldTransform().a);
     
     if( strlen(pFontName) > 0)
     {
@@ -249,7 +249,7 @@ void EditBoxImplCommon::setContentSize(const Size& size)
     
     auto director = cocos2d::Director::getInstance();
     auto glview = director->getOpenGLView();
-    Size  controlSize = Size(size.width * glview->getScaleX() * _label->nodeToWorldTransform().a,size.height * glview->getScaleY() * _label->nodeToWorldTransform().a);
+    Size  controlSize = Size(size.width * glview->getScaleX() * _label->getNodeToWorldTransform().a,size.height * glview->getScaleY() * _label->getNodeToWorldTransform().a);
        
     this->setNativeContentSize(controlSize);
 

--- a/cocos/ui/UIEditBox/UIEditBoxImpl-common.cpp
+++ b/cocos/ui/UIEditBox/UIEditBoxImpl-common.cpp
@@ -124,7 +124,7 @@ void EditBoxImplCommon::setInactiveText(const char* pText)
     
 void EditBoxImplCommon::setFont(const char* pFontName, int fontSize)
 {
-    this->setNativeFont(pFontName, fontSize * _label->getNodeToWorldTransform().a);
+    this->setNativeFont(pFontName, fontSize * _label->getNodeToWorldAffineTransform().a);
 
     if(strlen(pFontName) > 0)
     {
@@ -145,7 +145,7 @@ void EditBoxImplCommon::setFontColor(const Color4B& color)
 
 void EditBoxImplCommon::setPlaceholderFont(const char* pFontName, int fontSize)
 {
-    this->setNativePlaceholderFont(pFontName, fontSize * _labelPlaceHolder->getNodeToWorldTransform().a);
+    this->setNativePlaceholderFont(pFontName, fontSize * _labelPlaceHolder->getNodeToWorldAffineTransform().a);
     
     if( strlen(pFontName) > 0)
     {
@@ -249,7 +249,7 @@ void EditBoxImplCommon::setContentSize(const Size& size)
     
     auto director = cocos2d::Director::getInstance();
     auto glview = director->getOpenGLView();
-    Size  controlSize = Size(size.width * glview->getScaleX() * _label->getNodeToWorldTransform().a,size.height * glview->getScaleY() * _label->getNodeToWorldTransform().a);
+    Size  controlSize = Size(size.width * glview->getScaleX() * _label->getNodeToWorldAffineTransform().a,size.height * glview->getScaleY() * _label->getNodeToWorldAffineTransform().a);
        
     this->setNativeContentSize(controlSize);
 

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIEditBoxTest.cpp
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIEditBoxTest.cpp
@@ -100,11 +100,11 @@ bool UIEditBoxTest::init()
         addChild(buttonPassword);
         
         // bottom
-				// Add an intermediate Node to test scaling and content size relative to world
-				_editEmailParent = Node::create();
-				_editEmailParent->setScale(0.5);
+        // Add an intermediate Node to test scaling and content size relative to world
+        _editEmailParent = Node::create();
+        _editEmailParent->setScale(0.5);
         _editEmailParent->setPosition(Vec2(visibleOrigin.x+visibleSize.width/2-50, visibleOrigin.y+visibleSize.height/4));
-				addChild(_editEmailParent);
+        addChild(_editEmailParent);
 					
         auto bottomButtonSize = Size(editBoxSize.width, editBoxSize.height + 10);
         _editEmail = ui::EditBox::create(bottomButtonSize, "extensions/yellow_edit.png");
@@ -112,9 +112,9 @@ bool UIEditBoxTest::init()
         _editEmail->setInputMode(ui::EditBox::InputMode::EMAIL_ADDRESS);
         _editEmail->setDelegate(this);
         _editEmailParent->addChild(_editEmail);
-				//It is required to use setFontSize and setContentSize after adding it to the hierarchy, so that native EditBox get the right size
-				_editEmail->setFontSize(30);
-				_editEmail->setContentSize(bottomButtonSize);
+        //It is required to use setFontSize and setContentSize after adding it to the hierarchy, so that native EditBox get the right size
+        _editEmail->setFontSize(30);
+        _editEmail->setContentSize(bottomButtonSize);
         
         auto buttonEmail = (ui::Button*)button->clone();
         buttonEmail->setTitleText("Multiline");

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIEditBoxTest.cpp
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIEditBoxTest.cpp
@@ -100,17 +100,25 @@ bool UIEditBoxTest::init()
         addChild(buttonPassword);
         
         // bottom
+				// Add an intermediate Node to test scaling and content size relative to world
+				_editEmailParent = Node::create();
+				_editEmailParent->setScale(0.5);
+        _editEmailParent->setPosition(Vec2(visibleOrigin.x+visibleSize.width/2-50, visibleOrigin.y+visibleSize.height/4));
+				addChild(_editEmailParent);
+					
         auto bottomButtonSize = Size(editBoxSize.width, editBoxSize.height + 10);
         _editEmail = ui::EditBox::create(bottomButtonSize, "extensions/yellow_edit.png");
-        _editEmail->setPosition(Vec2(visibleOrigin.x+visibleSize.width/2-50, visibleOrigin.y+visibleSize.height/4));
         _editEmail->setPlaceHolder("Email:");
         _editEmail->setInputMode(ui::EditBox::InputMode::EMAIL_ADDRESS);
         _editEmail->setDelegate(this);
-        addChild(_editEmail);
+        _editEmailParent->addChild(_editEmail);
+				//It is required to use setFontSize and setContentSize after adding it to the hierarchy, so that native EditBox get the right size
+				_editEmail->setFontSize(30);
+				_editEmail->setContentSize(bottomButtonSize);
         
         auto buttonEmail = (ui::Button*)button->clone();
         buttonEmail->setTitleText("Multiline");
-        buttonEmail->setPosition(_editEmail->getPosition() + Vec2(editBoxSize.width/2 + buttonSize.width/2, 0 ));
+        buttonEmail->setPosition(_editEmailParent->getPosition() + Vec2(editBoxSize.width/2 + buttonSize.width/2, 0 ));
         buttonEmail->addClickEventListener([=](Ref* ref){
             _editEmail->setInputMode(ui::EditBox::InputMode::ANY);
         });

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIEditBoxTest.h
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIEditBoxTest.h
@@ -47,6 +47,7 @@ protected:
     cocos2d::ui::EditBox* _editName;
     cocos2d::ui::EditBox* _editPassword;
     cocos2d::ui::EditBox* _editEmail;
+		cocos2d::Node* _editEmailParent;
 };
 
 #endif /* defined(__cocos2d_tests__UIEditBoxTest__) */


### PR DESCRIPTION
The EditBox native parts need to be set after nodeToWorldTransform, for when parents have scale != 1. Tested on various iOS simulators, I don't have easy access to other platforms.

There was also a typo in setPlaceholderFontName which would result in placeholder incorrectly using normal label font size.
