### PR TITLE
Combine Studio change for openGL related operation

### DIFF
--- a/cocos/3d/CCMeshVertexIndexData.h
+++ b/cocos/3d/CCMeshVertexIndexData.h
@@ -54,7 +54,7 @@ class MeshVertexData;
  * @js NA
  * @lua NA
  */
-class MeshIndexData : public Ref
+class CC_DLL MeshIndexData : public Ref
 {
 public:
     /** create  */

--- a/cocos/3d/CCMeshVertexIndexData.h
+++ b/cocos/3d/CCMeshVertexIndexData.h
@@ -99,7 +99,7 @@ protected:
  * the MeshVertexData class.
  * @brief the MeshIndexData contain all of the vertices data which mesh need.
  */
-class MeshVertexData : public Ref
+class CC_DLL MeshVertexData : public Ref
 {
     friend class Sprite3D;
     friend class Mesh;

--- a/cocos/platform/desktop/CCGLViewImpl-desktop.cpp
+++ b/cocos/platform/desktop/CCGLViewImpl-desktop.cpp
@@ -264,7 +264,7 @@ static keyCodeItem g_keyCodeStructArray[] = {
 //////////////////////////////////////////////////////////////////////////
 
 
-GLViewImpl::GLViewImpl()
+GLViewImpl::GLViewImpl(bool initglfw)
 : _captured(false)
 , _supportTouch(false)
 , _isInRetinaMonitor(false)
@@ -284,9 +284,11 @@ GLViewImpl::GLViewImpl()
     }
 
     GLFWEventHandler::setGLViewImpl(this);
-
-    glfwSetErrorCallback(GLFWEventHandler::onGLFWError);
-    glfwInit();
+    if (initglfw)
+    {
+        glfwSetErrorCallback(GLFWEventHandler::onGLFWError);
+        glfwInit();
+    }
 }
 
 GLViewImpl::~GLViewImpl()

--- a/cocos/platform/desktop/CCGLViewImpl-desktop.h
+++ b/cocos/platform/desktop/CCGLViewImpl-desktop.h
@@ -112,7 +112,7 @@ public:
 #endif // #if (CC_TARGET_PLATFORM == CC_PLATFORM_MAC)
 
 protected:
-    GLViewImpl();
+    GLViewImpl(bool initglfw = true);
     virtual ~GLViewImpl();
 
     bool initWithRect(const std::string& viewName, Rect rect, float frameZoomFactor);

--- a/cocos/renderer/CCGLProgram.cpp
+++ b/cocos/renderer/CCGLProgram.cpp
@@ -181,7 +181,6 @@ GLProgram::GLProgram()
 , _vertShader(0)
 , _fragShader(0)
 , _flags()
-, _isShaderClearable(true)
 {
     _director = Director::getInstance();
     CCASSERT(nullptr != _director, "Director is null when init a GLProgram");
@@ -221,11 +220,7 @@ bool GLProgram::initWithByteArrays(const GLchar* vShaderByteArray, const GLchar*
     std::string replacedDefines = "";
     replaceDefines(compileTimeDefines, replacedDefines);
 
-    if (_isShaderClearable)
-        // When _isShaderClearable = true, vertShader & _fragShader has been already released, won't need release again.
-        _vertShader = _fragShader = 0;
-    else
-        clearShader();
+    _vertShader = _fragShader = 0;
 
     if (vShaderByteArray)
     {
@@ -548,12 +543,7 @@ bool GLProgram::link()
     parseVertexAttribs();
     parseUniforms();
 
-    // Keep _vertShader & _fragShader for editor by set _isShaderClearable to false,
-    //  because them are needed for 3d object click detection in 3d scene editing.
-    if (_isShaderClearable)
-    {
-        clearShader();
-    }
+    clearShader();
 
 #if DEBUG || (CC_TARGET_PLATFORM == CC_PLATFORM_WINRT)
     glGetProgramiv(_program, GL_LINK_STATUS, &status);

--- a/cocos/renderer/CCGLProgram.cpp
+++ b/cocos/renderer/CCGLProgram.cpp
@@ -220,7 +220,11 @@ bool GLProgram::initWithByteArrays(const GLchar* vShaderByteArray, const GLchar*
     std::string replacedDefines = "";
     replaceDefines(compileTimeDefines, replacedDefines);
 
+#if CC_TARGET_PLATFORM != CC_PLATFORM_MAC && CC_TARGET_PLATFORM != CC_PLATFORM_WIN32
+    _vertShader = _fragShader = 0;
+#else
     clearShader();
+#endif
 
     if (vShaderByteArray)
     {
@@ -542,6 +546,12 @@ bool GLProgram::link()
 
     parseVertexAttribs();
     parseUniforms();
+
+#if CC_TARGET_PLATFORM != CC_PLATFORM_MAC && CC_TARGET_PLATFORM != CC_PLATFORM_WIN32
+    // Keep _vertShader & _fragShader on PC for cocos studio, because them 
+    //  are needed for 3d object click detection in 3d scene editing.
+    clearShader();
+#endif
 
 #if DEBUG || (CC_TARGET_PLATFORM == CC_PLATFORM_WINRT)
     glGetProgramiv(_program, GL_LINK_STATUS, &status);
@@ -913,7 +923,7 @@ void GLProgram::reset()
     _hashForUniforms.clear();
 }
 
-void GLProgram::clearShader()
+inline void GLProgram::clearShader()
 {
     if (_vertShader)
     {

--- a/cocos/renderer/CCGLProgram.cpp
+++ b/cocos/renderer/CCGLProgram.cpp
@@ -191,17 +191,7 @@ GLProgram::~GLProgram()
 {
     CCLOGINFO("%s %d deallocing GLProgram: %p", __FUNCTION__, __LINE__, this);
 
-    if (_vertShader)
-    {
-        glDeleteShader(_vertShader);
-    }
-
-    if (_fragShader)
-    {
-        glDeleteShader(_fragShader);
-    }
-
-    _vertShader = _fragShader = 0;
+    clearShader();
 
     if (_program)
     {
@@ -230,7 +220,7 @@ bool GLProgram::initWithByteArrays(const GLchar* vShaderByteArray, const GLchar*
     std::string replacedDefines = "";
     replaceDefines(compileTimeDefines, replacedDefines);
 
-    _vertShader = _fragShader = 0;
+    clearShader();
 
     if (vShaderByteArray)
     {
@@ -552,18 +542,6 @@ bool GLProgram::link()
 
     parseVertexAttribs();
     parseUniforms();
-
-    if (_vertShader)
-    {
-        glDeleteShader(_vertShader);
-    }
-
-    if (_fragShader)
-    {
-        glDeleteShader(_fragShader);
-    }
-
-    _vertShader = _fragShader = 0;
 
 #if DEBUG || (CC_TARGET_PLATFORM == CC_PLATFORM_WINRT)
     glGetProgramiv(_program, GL_LINK_STATUS, &status);
@@ -933,6 +911,21 @@ void GLProgram::reset()
     }
 
     _hashForUniforms.clear();
+}
+
+void GLProgram::clearShader()
+{
+    if (_vertShader)
+    {
+        glDeleteShader(_vertShader);
+    }
+
+    if (_fragShader)
+    {
+        glDeleteShader(_fragShader);
+    }
+
+    _vertShader = _fragShader = 0;
 }
 
 NS_CC_END

--- a/cocos/renderer/CCGLProgram.h
+++ b/cocos/renderer/CCGLProgram.h
@@ -462,6 +462,9 @@ public:
     /*Get the built in openGL handle of the program.*/
     inline const GLuint getProgram() const { return _program; }
 
+    GLuint getVertShader() const { return _vertShader; }
+    GLuint getFragShader() const { return _fragShader; }
+
     //DEPRECATED
     CC_DEPRECATED_ATTRIBUTE bool initWithVertexShaderByteArray(const GLchar* vertexByteArray, const GLchar* fragByteArray)
     { return initWithByteArrays(vertexByteArray, fragByteArray); }
@@ -501,6 +504,8 @@ protected:
     GLint             _builtInUniforms[UNIFORM_MAX];
     /**Indicate whether it has a offline shader compiler or not.*/
     bool              _hasShaderCompiler;
+
+    void clearShader();
 
     struct flag_struct {
         unsigned int usesTime:1;

--- a/cocos/renderer/CCGLProgram.h
+++ b/cocos/renderer/CCGLProgram.h
@@ -505,7 +505,7 @@ protected:
     /**Indicate whether it has a offline shader compiler or not.*/
     bool              _hasShaderCompiler;
 
-    void clearShader();
+    inline void clearShader();
 
     struct flag_struct {
         unsigned int usesTime:1;

--- a/cocos/renderer/CCGLProgram.h
+++ b/cocos/renderer/CCGLProgram.h
@@ -462,6 +462,9 @@ public:
     /*Get the built in openGL handle of the program.*/
     inline const GLuint getProgram() const { return _program; }
 
+    /** Set if shader can be cleared after link. In editor mode, shader need to be kept to make click test working well. */
+    void setShaderClearable(bool isClearable) { _isShaderClearable = isClearable; }
+
     GLuint getVertShader() const { return _vertShader; }
     GLuint getFragShader() const { return _fragShader; }
 
@@ -504,6 +507,8 @@ protected:
     GLint             _builtInUniforms[UNIFORM_MAX];
     /**Indicate whether it has a offline shader compiler or not.*/
     bool              _hasShaderCompiler;
+
+    bool              _isShaderClearable;
 
     inline void clearShader();
 

--- a/cocos/renderer/CCGLProgram.h
+++ b/cocos/renderer/CCGLProgram.h
@@ -462,12 +462,6 @@ public:
     /*Get the built in openGL handle of the program.*/
     inline const GLuint getProgram() const { return _program; }
 
-    /** Set if shader can be cleared after link. In editor mode, shader need to be kept to make click test working well. */
-    void setShaderClearable(bool isClearable) { _isShaderClearable = isClearable; }
-
-    GLuint getVertShader() const { return _vertShader; }
-    GLuint getFragShader() const { return _fragShader; }
-
     //DEPRECATED
     CC_DEPRECATED_ATTRIBUTE bool initWithVertexShaderByteArray(const GLchar* vertexByteArray, const GLchar* fragByteArray)
     { return initWithByteArrays(vertexByteArray, fragByteArray); }
@@ -507,8 +501,6 @@ protected:
     GLint             _builtInUniforms[UNIFORM_MAX];
     /**Indicate whether it has a offline shader compiler or not.*/
     bool              _hasShaderCompiler;
-
-    bool              _isShaderClearable;
 
     inline void clearShader();
 

--- a/cocos/renderer/CCVertexAttribBinding.h
+++ b/cocos/renderer/CCVertexAttribBinding.h
@@ -51,7 +51,7 @@ class VertexAttribValue;
  * arrays, since it is slower than the server-side VAOs used by OpenGL
  * (when creating a VertexAttribBinding between a Mesh and Effect).
  */
-class VertexAttribBinding : public Ref
+class CC_DLL VertexAttribBinding : public Ref
 {
 public:
 

--- a/extensions/Particle3D/PU/CCPUScriptCompiler.h
+++ b/extensions/Particle3D/PU/CCPUScriptCompiler.h
@@ -71,7 +71,7 @@ public:
 
 
 /** This specific abstract node represents a script object */
-class PUObjectAbstractNode : public PUAbstractNode
+class CC_DLL PUObjectAbstractNode : public PUAbstractNode
 {
 private:
     std::map<std::string,std::string> _env;


### PR DESCRIPTION
Cocos Studio will init openGL itself, so we add a param to CCGLViewImpl-desktop constructor to let user choose whether cocos2dx will init openGL or not.

In 3d scene, cocos studio will use _vertShader & _fragShader in CCGLProgram to detect click on 3d item, but after glLinkProgram called it have been deleted and cleaned, we changed code to save them, and clean them when reload shader or destruct class.

@pandamicro @minggo Please review this PR.
