### PR TITLE
Combine Studio change for UI components

### DIFF
--- a/cocos/2d/CocosStudioExtension.h
+++ b/cocos/2d/CocosStudioExtension.h
@@ -1,0 +1,44 @@
+
+#ifndef __COCOSSTUDIOEXTENSION_H__
+#define __COCOSSTUDIOEXTENSION_H__
+
+#include "math/CCAffineTransform.h"
+
+NS_CC_BEGIN
+
+struct CC_DLL ResouceData
+{
+    int         type;
+    std::string file;
+    std::string plist;
+
+    ResouceData()
+    {
+        type = 0;
+        file = "";
+        plist = "";
+    }
+
+    ResouceData(int iType, std::string sFile, std::string sPlist)
+    {
+        type = iType;
+        file = sFile;
+        plist = sPlist;
+    }
+};
+
+class CC_DLL NodeExtension
+{
+public:
+    NodeExtension();
+    ~NodeExtension();
+
+private:
+
+};
+
+
+NS_CC_END
+
+
+#endif

--- a/cocos/2d/libcocos2d.vcxproj
+++ b/cocos/2d/libcocos2d.vcxproj
@@ -1254,6 +1254,7 @@ xcopy /Y /Q "$(ProjectDir)..\..\external\chipmunk\prebuilt\win32\release-lib\*.*
     <ClInclude Include="..\storage\local-storage\LocalStorage.h" />
     <ClInclude Include="..\ui\CocosGUI.h" />
     <ClInclude Include="..\ui\GUIExport.h" />
+    <ClInclude Include="..\ui\UIAbstractCheckButton.h" />
     <ClInclude Include="..\ui\UIButton.h" />
     <ClInclude Include="..\ui\UICheckBox.h" />
     <ClInclude Include="..\ui\UIDeprecated.h" />

--- a/cocos/2d/libcocos2d.vcxproj.filters
+++ b/cocos/2d/libcocos2d.vcxproj.filters
@@ -3776,6 +3776,9 @@
       <Filter>network\Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\editor-support\cocostudio\WidgetReader\Light3DReader\Light3DReader.h" />
+    <ClInclude Include="..\ui\UIAbstractCheckButton.h">
+      <Filter>ui</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <None Include="..\math\Mat4.inl">

--- a/cocos/cocos2d.h
+++ b/cocos/cocos2d.h
@@ -30,7 +30,7 @@ THE SOFTWARE.
 
 // 0x00 HI ME LO
 // 00   03 08 00
-#define COCOS2D_VERSION 0x00030900
+#define COCOS2D_VERSION 0x00030800
 
 //
 // all cocos2d include files

--- a/cocos/cocos2d.h
+++ b/cocos/cocos2d.h
@@ -30,7 +30,7 @@ THE SOFTWARE.
 
 // 0x00 HI ME LO
 // 00   03 08 00
-#define COCOS2D_VERSION 0x00030800
+#define COCOS2D_VERSION 0x00030900
 
 //
 // all cocos2d include files

--- a/cocos/scripting/js-bindings/manual/js_manual_conversions.h
+++ b/cocos/scripting/js-bindings/manual/js_manual_conversions.h
@@ -34,6 +34,10 @@
 
 #define JSB_COMPATIBLE_WITH_COCOS2D_HTML5_BASIC_TYPES
 
+NS_CC_BEGIN
+struct CC_DLL ResouceData;
+NS_CC_END
+
 // just a simple utility to avoid mem leaking when using JSString
 class JSStringWrapper
 {
@@ -110,6 +114,7 @@ bool jsvals_variadic_to_ccarray( JSContext *cx, jsval *vp, int argc, cocos2d::__
 bool jsval_to_quaternion(JSContext *cx, JS::HandleValue vp, cocos2d::Quaternion* ret);
 bool jsval_to_obb(JSContext *cx, JS::HandleValue vp, cocos2d::OBB* ret);
 bool jsval_to_ray(JSContext *cx, JS::HandleValue vp, cocos2d::Ray* ret);
+bool jsval_to_resoucedata(JSContext *cx, JS::HandleValue v, ResouceData* ret);
 
 // forward declaration
 js_proxy_t* jsb_get_js_proxy(JSObject* jsObj);
@@ -272,6 +277,7 @@ jsval FontDefinition_to_jsval(JSContext* cx, const cocos2d::FontDefinition& t);
 jsval quaternion_to_jsval(JSContext* cx, const cocos2d::Quaternion& q);
 jsval meshVertexAttrib_to_jsval(JSContext* cx, const cocos2d::MeshVertexAttrib& q);
 jsval uniform_to_jsval(JSContext* cx, const cocos2d::Uniform* uniform);
+jsval resoucedata_to_jsval(JSContext* cx, const ResouceData& v);
 
 template<class T>
 js_proxy_t *js_get_or_create_proxy(JSContext *cx, T *native_obj);

--- a/cocos/scripting/js-bindings/manual/js_manual_conversions.h
+++ b/cocos/scripting/js-bindings/manual/js_manual_conversions.h
@@ -114,7 +114,7 @@ bool jsvals_variadic_to_ccarray( JSContext *cx, jsval *vp, int argc, cocos2d::__
 bool jsval_to_quaternion(JSContext *cx, JS::HandleValue vp, cocos2d::Quaternion* ret);
 bool jsval_to_obb(JSContext *cx, JS::HandleValue vp, cocos2d::OBB* ret);
 bool jsval_to_ray(JSContext *cx, JS::HandleValue vp, cocos2d::Ray* ret);
-bool jsval_to_resoucedata(JSContext *cx, JS::HandleValue v, ResouceData* ret);
+bool jsval_to_resoucedata(JSContext *cx, JS::HandleValue v, cocos2d::ResouceData* ret);
 
 // forward declaration
 js_proxy_t* jsb_get_js_proxy(JSObject* jsObj);
@@ -277,7 +277,7 @@ jsval FontDefinition_to_jsval(JSContext* cx, const cocos2d::FontDefinition& t);
 jsval quaternion_to_jsval(JSContext* cx, const cocos2d::Quaternion& q);
 jsval meshVertexAttrib_to_jsval(JSContext* cx, const cocos2d::MeshVertexAttrib& q);
 jsval uniform_to_jsval(JSContext* cx, const cocos2d::Uniform* uniform);
-jsval resoucedata_to_jsval(JSContext* cx, const ResouceData& v);
+jsval resoucedata_to_jsval(JSContext* cx, const cocos2d::ResouceData& v);
 
 template<class T>
 js_proxy_t *js_get_or_create_proxy(JSContext *cx, T *native_obj);

--- a/cocos/ui/CocosGUI.h
+++ b/cocos/ui/CocosGUI.h
@@ -57,6 +57,7 @@ THE SOFTWARE.
 #include "ui/UIScale9Sprite.h"
 #include "ui/UIEditBox/UIEditBox.h"
 #include "ui/UILayoutComponent.h"
+#include "2d/CocosStudioExtension.h"
 
 /**
  * @addtogroup ui

--- a/cocos/ui/GUIExport.h
+++ b/cocos/ui/GUIExport.h
@@ -24,6 +24,8 @@
             #define NULL    ((void *)0)
         #endif
     #endif
+#elif defined(_SHARED_)
+    #define CC_GUI_DLL     __attribute__((visibility("default")))
 #else
     #define CC_GUI_DLL
 #endif

--- a/cocos/ui/UIAbstractCheckButton.cpp
+++ b/cocos/ui/UIAbstractCheckButton.cpp
@@ -136,12 +136,6 @@ void AbstractCheckButton::loadTextures(const std::string& backGround,
 void AbstractCheckButton::loadTextureBackGround(const std::string& backGround,TextureResType texType)
 {
     _backGroundFileName = backGround;
-#ifndef CC_STUDIO_ENABLED_VIEW   // for cocostudio only
-    if (backGround.empty())
-    {
-        return;
-    }
-#endif
 
     _backGroundTexType = texType;
     switch (_backGroundTexType)
@@ -178,12 +172,6 @@ void AbstractCheckButton::loadTextureBackGroundSelected(const std::string& backG
 {
     _backGroundSelectedFileName = backGroundSelected;
     _isBackgroundSelectedTextureLoaded = !backGroundSelected.empty();
-#ifndef CC_STUDIO_ENABLED_VIEW   // for cocostudio only
-    if (backGroundSelected.empty())
-    {
-        return;
-    }
-#endif
 
     _backGroundSelectedTexType = texType;
     switch (_backGroundSelectedTexType)
@@ -215,12 +203,6 @@ void AbstractCheckButton::setupBackgroundSelectedTexture()
 void AbstractCheckButton::loadTextureFrontCross(const std::string& cross,TextureResType texType)
 {
     _frontCrossFileName = cross;
-#ifndef CC_STUDIO_ENABLED_VIEW   // for cocostudio only
-    if (cross.empty())
-    {
-        return;
-    }
-#endif
 
     _frontCrossTexType = texType;
     switch (_frontCrossTexType)
@@ -253,12 +235,6 @@ void AbstractCheckButton::loadTextureBackGroundDisabled(const std::string& backG
 {
     _backGroundDisabledFileName = backGroundDisabled;
     _isBackgroundDisabledTextureLoaded = !backGroundDisabled.empty();
-#ifndef CC_STUDIO_ENABLED_VIEW   // for cocostudio only
-    if (backGroundDisabled.empty())
-    {
-        return;
-    }
-#endif
 
     _backGroundDisabledTexType = texType;
     switch (_backGroundDisabledTexType)
@@ -292,12 +268,6 @@ void AbstractCheckButton::loadTextureFrontCrossDisabled(const std::string& front
 {
     _frontCrossDisabledFileName = frontCrossDisabled;
     _isFrontCrossDisabledTextureLoaded = !frontCrossDisabled.empty();
-#ifndef CC_STUDIO_ENABLED_VIEW   // for cocostudio only
-    if (frontCrossDisabled.empty())
-    {
-        return;
-    }
-#endif
 
     _frontCrossDisabledTexType = texType;
     switch (_frontCrossDisabledTexType)

--- a/cocos/ui/UIAbstractCheckButton.cpp
+++ b/cocos/ui/UIAbstractCheckButton.cpp
@@ -24,6 +24,7 @@ THE SOFTWARE.
 
 #include "ui/UIAbstractCheckButton.h"
 #include "2d/CCSprite.h"
+#include "2d/CocosStudioExtension.h"
 
 NS_CC_BEGIN
 
@@ -53,6 +54,11 @@ _frontCrossDisabledTexType(TextureResType::LOCAL),
 _zoomScale(0.1f),
 _backgroundTextureScaleX(1.0),
 _backgroundTextureScaleY(1.0),
+_backGroundFileName(""),
+_backGroundSelectedFileName(""),
+_frontCrossFileName(""),
+_backGroundDisabledFileName(""),
+_frontCrossDisabledFileName(""),
 _backGroundBoxRendererAdaptDirty(true),
 _backGroundSelectedBoxRendererAdaptDirty(true),
 _frontCrossRendererAdaptDirty(true),
@@ -129,10 +135,14 @@ void AbstractCheckButton::loadTextures(const std::string& backGround,
 
 void AbstractCheckButton::loadTextureBackGround(const std::string& backGround,TextureResType texType)
 {
+    _backGroundFileName = backGround;
+#ifndef CC_STUDIO_ENABLED_VIEW   // for cocostudio only
     if (backGround.empty())
     {
         return;
     }
+#endif
+
     _backGroundTexType = texType;
     switch (_backGroundTexType)
     {
@@ -166,13 +176,16 @@ void AbstractCheckButton::loadTextureBackGround(SpriteFrame* spriteFrame)
 
 void AbstractCheckButton::loadTextureBackGroundSelected(const std::string& backGroundSelected,TextureResType texType)
 {
+    _backGroundSelectedFileName = backGroundSelected;
+    _isBackgroundSelectedTextureLoaded = !backGroundSelected.empty();
+#ifndef CC_STUDIO_ENABLED_VIEW   // for cocostudio only
     if (backGroundSelected.empty())
     {
         return;
     }
-    
+#endif
+
     _backGroundSelectedTexType = texType;
-    _isBackgroundSelectedTextureLoaded = true;
     switch (_backGroundSelectedTexType)
     {
         case TextureResType::LOCAL:
@@ -201,10 +214,14 @@ void AbstractCheckButton::setupBackgroundSelectedTexture()
 
 void AbstractCheckButton::loadTextureFrontCross(const std::string& cross,TextureResType texType)
 {
+    _frontCrossFileName = cross;
+#ifndef CC_STUDIO_ENABLED_VIEW   // for cocostudio only
     if (cross.empty())
     {
         return;
     }
+#endif
+
     _frontCrossTexType = texType;
     switch (_frontCrossTexType)
     {
@@ -234,12 +251,16 @@ void AbstractCheckButton::setupFrontCrossTexture()
 
 void AbstractCheckButton::loadTextureBackGroundDisabled(const std::string& backGroundDisabled,TextureResType texType)
 {
+    _backGroundDisabledFileName = backGroundDisabled;
+    _isBackgroundDisabledTextureLoaded = !backGroundDisabled.empty();
+#ifndef CC_STUDIO_ENABLED_VIEW   // for cocostudio only
     if (backGroundDisabled.empty())
     {
         return;
     }
+#endif
+
     _backGroundDisabledTexType = texType;
-    _isBackgroundDisabledTextureLoaded = true;
     switch (_backGroundDisabledTexType)
     {
         case TextureResType::LOCAL:
@@ -269,12 +290,16 @@ void AbstractCheckButton::setupBackgroundDisable()
 
 void AbstractCheckButton::loadTextureFrontCrossDisabled(const std::string& frontCrossDisabled,TextureResType texType)
 {
+    _frontCrossDisabledFileName = frontCrossDisabled;
+    _isFrontCrossDisabledTextureLoaded = !frontCrossDisabled.empty();
+#ifndef CC_STUDIO_ENABLED_VIEW   // for cocostudio only
     if (frontCrossDisabled.empty())
     {
         return;
     }
+#endif
+
     _frontCrossDisabledTexType = texType;
-    _isFrontCrossDisabledTextureLoaded = true;
     switch (_frontCrossDisabledTexType)
     {
         case TextureResType::LOCAL:
@@ -577,6 +602,47 @@ void AbstractCheckButton::copySpecialProperties(Widget *widget)
         _isBackgroundDisabledTextureLoaded = abstractCheckButton->_isBackgroundDisabledTextureLoaded;
         _isFrontCrossDisabledTextureLoaded = abstractCheckButton->_isFrontCrossDisabledTextureLoaded;
     }
+}
+
+
+ResouceData AbstractCheckButton::getBackNormalFile()
+{
+    ResouceData rData;
+    rData.type = (int)_backGroundTexType;
+    rData.file = _backGroundFileName;
+    return rData;
+}
+
+ResouceData AbstractCheckButton::getBackPressedFile()
+{
+    ResouceData rData;
+    rData.type = (int)_backGroundSelectedTexType;
+    rData.file = _backGroundSelectedFileName;
+    return rData;
+}
+
+ResouceData AbstractCheckButton::getBackDisabledFile()
+{
+    ResouceData rData;
+    rData.type = (int)_backGroundDisabledTexType;
+    rData.file = _backGroundDisabledFileName;
+    return rData;
+}
+
+ResouceData AbstractCheckButton::getCrossNormalFile()
+{
+    ResouceData rData;
+    rData.type = (int)_frontCrossTexType;
+    rData.file = _frontCrossFileName;
+    return rData;
+}
+
+ResouceData AbstractCheckButton::getCrossDisabeldFile()
+{
+    ResouceData rData;
+    rData.type = (int)_frontCrossDisabledTexType;
+    rData.file = _frontCrossDisabledFileName;
+    return rData;
 }
 
 }

--- a/cocos/ui/UIAbstractCheckButton.h
+++ b/cocos/ui/UIAbstractCheckButton.h
@@ -34,6 +34,7 @@ THE SOFTWARE.
  */
 NS_CC_BEGIN
 class Sprite;
+struct CC_DLL ResouceData;
 
 namespace ui {
     
@@ -160,7 +161,13 @@ public:
      * @return the sprite instance of front cross when disabled
      */
     Sprite* getRendererFrontCrossDisabled() const { return _frontCrossDisabledRenderer; }
-    
+
+    ResouceData getBackNormalFile();
+    ResouceData getBackPressedFile();
+    ResouceData getBackDisabledFile();
+    ResouceData getCrossNormalFile();
+    ResouceData getCrossDisabeldFile();
+
 CC_CONSTRUCTOR_ACCESS:
     virtual bool init() override;
     virtual bool init(const std::string& backGround,
@@ -237,6 +244,12 @@ protected:
     bool _frontCrossRendererAdaptDirty;
     bool _backGroundBoxDisabledRendererAdaptDirty;
     bool _frontCrossDisabledRendererAdaptDirty;
+
+    std::string _backGroundFileName;
+    std::string _backGroundSelectedFileName;
+    std::string _frontCrossFileName;
+    std::string _backGroundDisabledFileName;
+    std::string _frontCrossDisabledFileName;
 };
     
 }

--- a/cocos/ui/UIButton.cpp
+++ b/cocos/ui/UIButton.cpp
@@ -30,6 +30,7 @@ THE SOFTWARE.
 #include "platform/CCFileUtils.h"
 #include "ui/UIHelper.h"
 #include <algorithm>
+#include "2d/CocosStudioExtension.h"
 
 NS_CC_BEGIN
 
@@ -49,6 +50,13 @@ _buttonClickedRenderer(nullptr),
 _buttonDisabledRenderer(nullptr),
 _titleRenderer(nullptr),
 _zoomScale(0.1f),
+_normalFileName(""),
+_clickedFileName(""),
+_disabledFileName(""),
+_normalTexType(TextureResType::LOCAL),
+_pressedTexType(TextureResType::LOCAL),
+_disabledTexType(TextureResType::LOCAL),
+_fontName(""),
 _prevIgnoreSize(true),
 _scale9Enabled(false),
 _pressedActionEnabled(false),
@@ -222,10 +230,16 @@ void Button::loadTextures(const std::string& normal,
 
 void Button::loadTextureNormal(const std::string& normal,TextureResType texType)
 {
-    if(normal.empty())
+    _normalFileName = normal;
+    _normalTexType = texType;
+
+#ifndef CC_STUDIO_ENABLED_VIEW   // for cocostudio only
+    if (normal.empty())
     {
         return;
     }
+#endif
+
     switch (texType)
     {
         case TextureResType::LOCAL:
@@ -273,10 +287,15 @@ void Button::loadTextureNormal(SpriteFrame* normalSpriteFrame)
 
 void Button::loadTexturePressed(const std::string& selected,TextureResType texType)
 {
+    _clickedFileName = selected;
+    _pressedTexType = texType;
+
+#ifndef CC_STUDIO_ENABLED_VIEW   // for cocostudio only
     if (selected.empty())
     {
         return;
     }
+#endif
 
     switch (texType)
     {
@@ -311,10 +330,15 @@ void Button::loadTexturePressed(SpriteFrame* pressedSpriteFrame)
 
 void Button::loadTextureDisabled(const std::string& disabled,TextureResType texType)
 {
+    _disabledFileName = disabled;
+    _disabledTexType = texType;
+
+#ifndef CC_STUDIO_ENABLED_VIEW   // for cocostudio only
     if (disabled.empty())
     {
         return;
     }
+#endif
 
     switch (texType)
     {
@@ -876,6 +900,7 @@ void Button::setTitleFontName(const std::string& fontName)
         _titleRenderer->setSystemFontSize(_fontSize);
         _type = FontType::SYSTEM;
     }
+    _fontName = fontName;
     this->updateContentSize();
 }
 
@@ -903,7 +928,7 @@ const std::string Button::getTitleFontName() const
     }
     else
     {
-        return "";
+        return _fontName;
     }
 }
 
@@ -976,6 +1001,67 @@ Size Button::getNormalTextureSize() const
 {
     return _normalTextureSize;
 }
+
+void Button::resetNormalRender()
+{
+    _normalFileName = "";
+    _normalTexType = TextureResType::LOCAL;
+
+    _normalTextureSize = Size(0, 0);
+
+    _normalTextureLoaded = false;
+    _normalTextureAdaptDirty = false;
+
+    _buttonNormalRenderer->resetRender();
+}
+void Button::resetPressedRender()
+{
+    _clickedFileName = "";
+    _pressedTexType = TextureResType::LOCAL;
+
+    _pressedTextureSize = Size(0, 0);
+
+    _pressedTextureLoaded = false;
+    _pressedTextureAdaptDirty = false;
+
+    _buttonClickedRenderer->resetRender();
+}
+
+void Button::resetDisabledRender()
+{
+    _disabledFileName = "";
+    _disabledTexType = TextureResType::LOCAL;
+
+    _disabledTextureSize = Size(0, 0);
+
+    _disabledTextureLoaded = false;
+    _disabledTextureAdaptDirty = false;
+
+    _buttonDisabledRenderer->resetRender();
+}
+
+ResouceData Button::getNormalFile()
+{
+    ResouceData rData;
+    rData.type = (int)_normalTexType;
+    rData.file = _normalFileName;
+    return rData;
+}
+ResouceData Button::getPressedFile()
+{
+    ResouceData rData;
+    rData.type = (int)_pressedTexType;
+    rData.file = _clickedFileName;
+    return rData;
+}
+ResouceData Button::getDisabledFile()
+{
+    ResouceData rData;
+    rData.type = (int)_disabledTexType;
+    rData.file = _disabledFileName;
+    return rData;
+}
+
 }
 
 NS_CC_END

--- a/cocos/ui/UIButton.cpp
+++ b/cocos/ui/UIButton.cpp
@@ -233,13 +233,6 @@ void Button::loadTextureNormal(const std::string& normal,TextureResType texType)
     _normalFileName = normal;
     _normalTexType = texType;
 
-#ifndef CC_STUDIO_ENABLED_VIEW   // for cocostudio only
-    if (normal.empty())
-    {
-        return;
-    }
-#endif
-
     switch (texType)
     {
         case TextureResType::LOCAL:
@@ -290,13 +283,6 @@ void Button::loadTexturePressed(const std::string& selected,TextureResType texTy
     _clickedFileName = selected;
     _pressedTexType = texType;
 
-#ifndef CC_STUDIO_ENABLED_VIEW   // for cocostudio only
-    if (selected.empty())
-    {
-        return;
-    }
-#endif
-
     switch (texType)
     {
         case TextureResType::LOCAL:
@@ -332,13 +318,6 @@ void Button::loadTextureDisabled(const std::string& disabled,TextureResType texT
 {
     _disabledFileName = disabled;
     _disabledTexType = texType;
-
-#ifndef CC_STUDIO_ENABLED_VIEW   // for cocostudio only
-    if (disabled.empty())
-    {
-        return;
-    }
-#endif
 
     switch (texType)
     {

--- a/cocos/ui/UIButton.h
+++ b/cocos/ui/UIButton.h
@@ -36,6 +36,7 @@ NS_CC_BEGIN
 
 class Label;
 class SpriteFrame;
+struct CC_DLL ResouceData;
 
 namespace ui{
 
@@ -296,6 +297,14 @@ public:
      */
     Scale9Sprite* getRendererDisabled() const { return _buttonDisabledRenderer; }
 
+    void resetNormalRender();
+    void resetPressedRender();
+    void resetDisabledRender();
+
+    ResouceData getNormalFile();
+    ResouceData getPressedFile();
+    ResouceData getDisabledFile();
+
 CC_CONSTRUCTOR_ACCESS:
     virtual bool init() override;
     virtual bool init(const std::string& normalImage,
@@ -363,6 +372,13 @@ protected:
     bool _pressedTextureAdaptDirty;
     bool _disabledTextureAdaptDirty;
 
+    std::string _normalFileName;
+    std::string _clickedFileName;
+    std::string _disabledFileName;
+    TextureResType _normalTexType;
+    TextureResType _pressedTexType;
+    TextureResType _disabledTexType;
+
 private:
     enum class FontType
     {
@@ -373,6 +389,7 @@ private:
 
     int _fontSize;
     FontType _type;
+    std::string _fontName;
 };
 
 }

--- a/cocos/ui/UIImageView.cpp
+++ b/cocos/ui/UIImageView.cpp
@@ -26,6 +26,7 @@ THE SOFTWARE.
 #include "ui/UIScale9Sprite.h"
 #include "ui/UIHelper.h"
 #include "2d/CCSprite.h"
+#include "2d/CocosStudioExtension.h"
 
 NS_CC_BEGIN
 
@@ -39,6 +40,7 @@ ImageView::ImageView():
 _scale9Enabled(false),
 _prevIgnoreSize(true),
 _capInsets(Rect::ZERO),
+_textureFile(""),
 _imageRenderer(nullptr),
 _imageTexType(TextureResType::LOCAL),
 _imageTextureSize(_contentSize),
@@ -121,6 +123,7 @@ void ImageView::loadTexture(const std::string& fileName, TextureResType texType)
     {
         return;
     }
+    _textureFile = fileName;
     _imageTexType = texType;
     switch (_imageTexType)
     {
@@ -309,6 +312,14 @@ void ImageView::copySpecialProperties(Widget *widget)
         }
         setCapInsets(imageView->_capInsets);
     }
+}
+
+ResouceData ImageView::getRenderFile()
+{
+    ResouceData rData;
+    rData.type = (int)_imageTexType;
+    rData.file = _textureFile;
+    return rData;
 }
 
 }

--- a/cocos/ui/UIImageView.h
+++ b/cocos/ui/UIImageView.h
@@ -38,7 +38,7 @@ struct CC_DLL ResouceData;
 
 namespace ui {
     class Scale9Sprite;
-    /**
+/**
  * @brief A widget to display images.
  */
 class CC_GUI_DLL ImageView : public Widget

--- a/cocos/ui/UIImageView.h
+++ b/cocos/ui/UIImageView.h
@@ -34,9 +34,11 @@ THE SOFTWARE.
  */
 NS_CC_BEGIN
 
+struct CC_DLL ResouceData;
+
 namespace ui {
     class Scale9Sprite;
-/**
+    /**
  * @brief A widget to display images.
  */
 class CC_GUI_DLL ImageView : public Widget
@@ -121,7 +123,9 @@ public:
     virtual std::string getDescription() const override;
     virtual Size getVirtualRendererSize() const override;
     virtual Node* getVirtualRenderer() override;
-    
+
+    ResouceData getRenderFile();
+
 CC_CONSTRUCTOR_ACCESS:
     //initializes state of widget.
     virtual bool init() override;
@@ -146,6 +150,7 @@ protected:
     TextureResType _imageTexType;
     Size _imageTextureSize;
     bool _imageRendererAdaptDirty;
+    std::string _textureFile;
 };
 
 }

--- a/cocos/ui/UILayout.cpp
+++ b/cocos/ui/UILayout.cpp
@@ -37,6 +37,7 @@ THE SOFTWARE.
 #include "2d/CCLayer.h"
 #include "2d/CCSprite.h"
 #include "base/CCEventFocus.h"
+#include "2d/CocosStudioExtension.h"
 
 
 NS_CC_BEGIN
@@ -2032,5 +2033,13 @@ void Layout::setCameraMask(unsigned short mask, bool applyChildren)
     }
 }
     
+ResouceData Layout::getRenderFile()
+{
+    ResouceData rData;
+    rData.type = (int)_bgImageTexType;
+    rData.file = _backGroundImageFileName;
+    return rData;
+}
+
 }
 NS_CC_END

--- a/cocos/ui/UILayout.h
+++ b/cocos/ui/UILayout.h
@@ -39,6 +39,7 @@ NS_CC_BEGIN
 class DrawNode;
 class LayerColor;
 class LayerGradient;
+struct CC_DLL ResouceData;
 
 
 namespace ui {
@@ -457,6 +458,8 @@ public:
      * @param applyChildren If true call this function recursively from this node to its children.
      */
     virtual void setCameraMask(unsigned short mask, bool applyChildren = true) override;
+
+    ResouceData getRenderFile();
 
 CC_CONSTRUCTOR_ACCESS:
     //override "init" method of widget.

--- a/cocos/ui/UILayoutComponent.cpp
+++ b/cocos/ui/UILayoutComponent.cpp
@@ -184,7 +184,7 @@ namespace ui {
             else
             {
                 _positionPercentX = 0;
-                if (_usingPositionPercentX)
+                if (_usingPositionPercentX || _horizontalEdge == HorizontalEdge::Center)
                     ownerPoint.x = 0;
             }
 
@@ -193,7 +193,7 @@ namespace ui {
             else
             {
                 _positionPercentY = 0;
-                if (_usingPositionPercentY)
+                if (_usingPositionPercentY || _verticalEdge == VerticalEdge::Center)
                     ownerPoint.y = 0;
             }
 
@@ -227,11 +227,14 @@ namespace ui {
     {
         _positionPercentX = percentMargin;
 
-        Node* parent = this->getOwnerParent();
-        if (parent != nullptr)
+        if (_usingPositionPercentX || _horizontalEdge == HorizontalEdge::Center)
         {
-            _owner->setPositionX(parent->getContentSize().width * _positionPercentX);
-            this->refreshHorizontalMargin();
+            Node* parent = this->getOwnerParent();
+            if (parent != nullptr)
+            {
+                _owner->setPositionX(parent->getContentSize().width * _positionPercentX);
+                this->refreshHorizontalMargin();
+            }
         }
     }
 
@@ -256,11 +259,14 @@ namespace ui {
     {
         _positionPercentY = percentMargin;
 
-        Node* parent = this->getOwnerParent();
-        if (parent != nullptr)
+        if (_usingPositionPercentY || _verticalEdge == VerticalEdge::Center)
         {
-            _owner->setPositionY(parent->getContentSize().height * _positionPercentY);
-            this->refreshVerticalMargin();
+            Node* parent = this->getOwnerParent();
+            if (parent != nullptr)
+            {
+                _owner->setPositionY(parent->getContentSize().height * _positionPercentY);
+                this->refreshVerticalMargin();
+            }
         }
     }
 
@@ -275,24 +281,6 @@ namespace ui {
         {
             _usingPositionPercentX = false;
         }
-
-        Node* parent = this->getOwnerParent();
-        if (parent != nullptr)
-        {
-            Point ownerPoint = _owner->getPosition();
-            const Size& parentSize = parent->getContentSize();
-            if (parentSize.width != 0)
-                _positionPercentX = ownerPoint.x / parentSize.width;
-            else
-            {
-                _positionPercentX = 0;
-                ownerPoint.x = 0;
-                if (_usingPositionPercentX)
-                    _owner->setPosition(ownerPoint);
-            }
-
-            this->refreshHorizontalMargin();
-        }
     }
 
     LayoutComponent::VerticalEdge LayoutComponent::getVerticalEdge()const
@@ -305,24 +293,6 @@ namespace ui {
         if (_verticalEdge != VerticalEdge::None)
         {
             _usingPositionPercentY = false;
-        }
-
-        Node* parent = this->getOwnerParent();
-        if (parent != nullptr)
-        {
-            Point ownerPoint = _owner->getPosition();
-            const Size& parentSize = parent->getContentSize();
-            if (parentSize.height != 0)
-                _positionPercentY = ownerPoint.y / parentSize.height;
-            else
-            {
-                _positionPercentY = 0;
-                ownerPoint.y = 0;
-                if (_usingPositionPercentY)
-                    _owner->setPosition(ownerPoint);
-            }
-
-            this->refreshVerticalMargin();
         }
     }
 
@@ -380,7 +350,7 @@ namespace ui {
             else
             {
                 _percentWidth = 0;
-                if (_usingPercentWidth)
+                if (_usingPercentWidth || (this->_horizontalEdge != HorizontalEdge::Center && this->_usingStretchWidth))
                     ownerSize.width = 0;
             }
 
@@ -389,7 +359,7 @@ namespace ui {
             else
             {
                 _percentHeight = 0;
-                if (_usingPercentHeight)
+                if (_usingPercentHeight || (this->_verticalEdge != VerticalEdge::Center && this->_usingStretchHeight))
                     ownerSize.height = 0;
             }
 
@@ -451,14 +421,17 @@ namespace ui {
     {
         _percentWidth = percentWidth;
 
-        Node* parent = this->getOwnerParent();
-        if (parent != nullptr)
+        if (_usingPercentWidth)
         {
-            Size ownerSize = _owner->getContentSize();
-            ownerSize.width = parent->getContentSize().width * _percentWidth;
-            _owner->setContentSize(ownerSize);
+            Node* parent = this->getOwnerParent();
+            if (parent != nullptr)
+            {
+                Size ownerSize = _owner->getContentSize();
+                ownerSize.width = parent->getContentSize().width * _percentWidth;
+                _owner->setContentSize(ownerSize);
 
-            this->refreshHorizontalMargin();
+                this->refreshHorizontalMargin();
+            }
         }
     }
 
@@ -511,14 +484,17 @@ namespace ui {
     {
         _percentHeight = percentHeight;
 
-        Node* parent = this->getOwnerParent();
-        if (parent != nullptr)
+        if (_usingPercentHeight)
         {
-            Size ownerSize = _owner->getContentSize();
-            ownerSize.height = parent->getContentSize().height * _percentHeight;
-            _owner->setContentSize(ownerSize);
+            Node* parent = this->getOwnerParent();
+            if (parent != nullptr)
+            {
+                Size ownerSize = _owner->getContentSize();
+                ownerSize.height = parent->getContentSize().height * _percentHeight;
+                _owner->setContentSize(ownerSize);
 
-            this->refreshVerticalMargin();
+                this->refreshVerticalMargin();
+            }
         }
     }
 

--- a/cocos/ui/UILoadingBar.cpp
+++ b/cocos/ui/UILoadingBar.cpp
@@ -26,6 +26,7 @@ THE SOFTWARE.
 #include "ui/UIHelper.h"
 #include "ui/UIScale9Sprite.h"
 #include "2d/CCSprite.h"
+#include "2d/CocosStudioExtension.h"
 
 NS_CC_BEGIN
 
@@ -39,6 +40,7 @@ LoadingBar::LoadingBar():
 _direction(Direction::LEFT),
 _percent(100.0),
 _totalLength(0),
+_textureFile(""),
 _barRenderer(nullptr),
 _renderBarTexType(TextureResType::LOCAL),
 _barRendererTextureSize(Size::ZERO),
@@ -146,6 +148,7 @@ void LoadingBar::loadTexture(const std::string& texture,TextureResType texType)
     {
         return;
     }
+    _textureFile = texture;
     _renderBarTexType = texType;
     switch (_renderBarTexType)
     {
@@ -416,6 +419,14 @@ void LoadingBar::copySpecialProperties(Widget *widget)
         setPercent(loadingBar->_percent);
         setDirection(loadingBar->_direction);
     }
+}
+
+ResouceData LoadingBar::getRenderFile()
+{
+    ResouceData rData;
+    rData.type = (int)_renderBarTexType;
+    rData.file = _textureFile;
+    return rData;
 }
 
 }

--- a/cocos/ui/UILoadingBar.h
+++ b/cocos/ui/UILoadingBar.h
@@ -34,6 +34,8 @@ NS_CC_BEGIN
  * @{
  */
 
+struct CC_DLL ResouceData;
+
 namespace ui {
     class Scale9Sprite;
 
@@ -171,6 +173,9 @@ public:
     virtual Size getVirtualRendererSize() const override;
     virtual Node* getVirtualRenderer() override;
     virtual std::string getDescription() const override;
+
+    ResouceData getRenderFile(); 
+
 protected:
     virtual void initRenderer() override;
     virtual void onSizeChanged() override;
@@ -197,6 +202,7 @@ protected:
     bool _prevIgnoreSize;
     Rect _capInsets;
     bool _barRendererAdaptDirty;
+    std::string _textureFile;
 };
 
 }

--- a/cocos/ui/UIScale9Sprite.cpp
+++ b/cocos/ui/UIScale9Sprite.cpp
@@ -420,6 +420,10 @@ namespace ui {
                 _scale9Image->setSpriteFrame(sprite->getSpriteFrame());
             }
         }
+        else
+        {
+            CC_SAFE_RELEASE_NULL(_scale9Image);
+        }
 
         if (!_scale9Image)
         {
@@ -1284,6 +1288,14 @@ namespace ui {
     Scale9Sprite::RenderingType Scale9Sprite::getRenderingType()const
     {
         return _renderingType;
+    }
+
+    void Scale9Sprite::resetRender()
+    {
+        // Release old sprites
+        this->cleanupSlicedSprites();
+
+        CC_SAFE_RELEASE_NULL(this->_scale9Image);
     }
 
 }}

--- a/cocos/ui/UIScale9Sprite.h
+++ b/cocos/ui/UIScale9Sprite.h
@@ -667,6 +667,9 @@ namespace ui {
          * Return the slice sprite rendering type.
          */
         RenderingType getRenderingType()const;
+
+        void resetRender();
+
     protected:
         void updateCapInset();
         void createSlicedSprites();

--- a/cocos/ui/UISlider.cpp
+++ b/cocos/ui/UISlider.cpp
@@ -27,6 +27,7 @@ THE SOFTWARE.
 #include "ui/UIHelper.h"
 #include "2d/CCSprite.h"
 #include "2d/CCCamera.h"
+#include "2d/CocosStudioExtension.h"
 
 NS_CC_BEGIN
 
@@ -68,7 +69,12 @@ _ballNTexType(TextureResType::LOCAL),
 _ballPTexType(TextureResType::LOCAL),
 _ballDTexType(TextureResType::LOCAL),
 _barRendererAdaptDirty(true),
-_progressBarRendererDirty(true)
+_progressBarRendererDirty(true),
+_textureFile(""),
+_progressBarTextureFile(""),
+_slidBallNormalTextureFile(""),
+_slidBallPressedTextureFile(""),
+_slidBallDisabledTextureFile("")
 {
     setTouchEnabled(true);
 }
@@ -147,10 +153,13 @@ void Slider::initRenderer()
 
 void Slider::loadBarTexture(const std::string& fileName, TextureResType texType)
 {
+    _textureFile = fileName;
+#ifndef CC_STUDIO_ENABLED_VIEW   // for cocostudio only
     if (fileName.empty())
     {
         return;
     }
+#endif
     _barTexType = texType;
     switch (_barTexType)
     {
@@ -182,10 +191,13 @@ void Slider::setupBarTexture()
 
 void Slider::loadProgressBarTexture(const std::string& fileName, TextureResType texType)
 {
+    _progressBarTextureFile = fileName;
+#ifndef CC_STUDIO_ENABLED_VIEW   // for cocostudio only
     if (fileName.empty())
     {
         return;
     }
+#endif
     _progressBarTexType = texType;
     switch (_progressBarTexType)
     {
@@ -305,10 +317,13 @@ void Slider::loadSlidBallTextures(const std::string& normal,
 
 void Slider::loadSlidBallTextureNormal(const std::string& normal,TextureResType texType)
 {
+    _slidBallNormalTextureFile = normal;
+#ifndef CC_STUDIO_ENABLED_VIEW   // for cocostudio only
     if (normal.empty())
     {
         return;
     }
+#endif
     _ballNTexType = texType;
     switch (_ballNTexType)
     {
@@ -331,12 +346,15 @@ void Slider::loadSlidBallTextureNormal(SpriteFrame* spriteframe)
 
 void Slider::loadSlidBallTexturePressed(const std::string& pressed,TextureResType texType)
 {
+    _slidBallPressedTextureFile = pressed;
+    _isSliderBallPressedTextureLoaded = !pressed.empty();
+#ifndef CC_STUDIO_ENABLED_VIEW   // for cocostudio only
     if (pressed.empty())
     {
         return;
     }
+#endif
     _ballPTexType = texType;
-    _isSliderBallPressedTextureLoaded = true;
     switch (_ballPTexType)
     {
         case TextureResType::LOCAL:
@@ -360,11 +378,14 @@ void Slider::loadSlidBallTexturePressed(SpriteFrame* spriteframe)
 
 void Slider::loadSlidBallTextureDisabled(const std::string& disabled,TextureResType texType)
 {
+    _slidBallDisabledTextureFile = disabled;
+    _isSliderBallDisabledTexturedLoaded = !disabled.empty();
+#ifndef CC_STUDIO_ENABLED_VIEW   // for cocostudio only
     if (disabled.empty())
     {
         return;
     }
-    _isSliderBallDisabledTexturedLoaded = true;
+#endif
     _ballDTexType = texType;
     switch (_ballDTexType)
     {
@@ -721,6 +742,42 @@ void Slider::copySpecialProperties(Widget *widget)
         _eventCallback = slider->_eventCallback;
         _ccEventCallback = slider->_ccEventCallback;
     }
+}
+
+ResouceData Slider::getBackFile()
+{
+    ResouceData rData;
+    rData.type = (int)_barTexType;
+    rData.file = _textureFile;
+    return rData;
+}
+ResouceData Slider::getProgressBarFile()
+{
+    ResouceData rData;
+    rData.type = (int)_progressBarTexType;
+    rData.file = _progressBarTextureFile;
+    return rData;
+}
+ResouceData Slider::getBallNormalFile()
+{
+    ResouceData rData;
+    rData.type = (int)_ballNTexType;
+    rData.file = _slidBallNormalTextureFile;
+    return rData;
+}
+ResouceData Slider::getBallPressedFile()
+{
+    ResouceData rData;
+    rData.type = (int)_ballPTexType;
+    rData.file = _slidBallPressedTextureFile;
+    return rData;
+}
+ResouceData Slider::getBallDisabeldFile()
+{
+    ResouceData rData;
+    rData.type = (int)_ballDTexType;
+    rData.file = _slidBallDisabledTextureFile;
+    return rData;
 }
 
 }

--- a/cocos/ui/UISlider.cpp
+++ b/cocos/ui/UISlider.cpp
@@ -154,12 +154,6 @@ void Slider::initRenderer()
 void Slider::loadBarTexture(const std::string& fileName, TextureResType texType)
 {
     _textureFile = fileName;
-#ifndef CC_STUDIO_ENABLED_VIEW   // for cocostudio only
-    if (fileName.empty())
-    {
-        return;
-    }
-#endif
     _barTexType = texType;
     switch (_barTexType)
     {
@@ -192,12 +186,6 @@ void Slider::setupBarTexture()
 void Slider::loadProgressBarTexture(const std::string& fileName, TextureResType texType)
 {
     _progressBarTextureFile = fileName;
-#ifndef CC_STUDIO_ENABLED_VIEW   // for cocostudio only
-    if (fileName.empty())
-    {
-        return;
-    }
-#endif
     _progressBarTexType = texType;
     switch (_progressBarTexType)
     {
@@ -318,12 +306,6 @@ void Slider::loadSlidBallTextures(const std::string& normal,
 void Slider::loadSlidBallTextureNormal(const std::string& normal,TextureResType texType)
 {
     _slidBallNormalTextureFile = normal;
-#ifndef CC_STUDIO_ENABLED_VIEW   // for cocostudio only
-    if (normal.empty())
-    {
-        return;
-    }
-#endif
     _ballNTexType = texType;
     switch (_ballNTexType)
     {
@@ -348,12 +330,6 @@ void Slider::loadSlidBallTexturePressed(const std::string& pressed,TextureResTyp
 {
     _slidBallPressedTextureFile = pressed;
     _isSliderBallPressedTextureLoaded = !pressed.empty();
-#ifndef CC_STUDIO_ENABLED_VIEW   // for cocostudio only
-    if (pressed.empty())
-    {
-        return;
-    }
-#endif
     _ballPTexType = texType;
     switch (_ballPTexType)
     {
@@ -380,12 +356,6 @@ void Slider::loadSlidBallTextureDisabled(const std::string& disabled,TextureResT
 {
     _slidBallDisabledTextureFile = disabled;
     _isSliderBallDisabledTexturedLoaded = !disabled.empty();
-#ifndef CC_STUDIO_ENABLED_VIEW   // for cocostudio only
-    if (disabled.empty())
-    {
-        return;
-    }
-#endif
     _ballDTexType = texType;
     switch (_ballDTexType)
     {

--- a/cocos/ui/UISlider.h
+++ b/cocos/ui/UISlider.h
@@ -36,6 +36,7 @@ NS_CC_BEGIN
  */
 
 class Sprite;
+struct CC_DLL ResouceData;
 
 namespace ui {
     class Scale9Sprite;
@@ -264,7 +265,12 @@ public:
      */
     float getZoomScale()const;
 
-    
+    ResouceData getBackFile();
+    ResouceData getProgressBarFile();
+    ResouceData getBallNormalFile();
+    ResouceData getBallPressedFile();
+    ResouceData getBallDisabeldFile();
+
 CC_CONSTRUCTOR_ACCESS:
     virtual bool init() override;
 
@@ -341,6 +347,12 @@ protected:
     TextureResType _ballDTexType;
     bool _barRendererAdaptDirty;
     bool _progressBarRendererDirty;
+
+    std::string _textureFile;
+    std::string _progressBarTextureFile;
+    std::string _slidBallNormalTextureFile;
+    std::string _slidBallPressedTextureFile;
+    std::string _slidBallDisabledTextureFile;
 };
 
 }

--- a/cocos/ui/UITextAtlas.cpp
+++ b/cocos/ui/UITextAtlas.cpp
@@ -24,6 +24,7 @@ THE SOFTWARE.
 
 #include "ui/UITextAtlas.h"
 #include "2d/CCLabel.h"
+#include "2d/CocosStudioExtension.h"
 
 NS_CC_BEGIN
 
@@ -190,5 +191,13 @@ void TextAtlas::copySpecialProperties(Widget *widget)
     }
 }
     
+ResouceData TextAtlas::getRenderFile()
+{
+    ResouceData rData;
+    rData.type = 0;
+    rData.file = _charMapFileName;
+    return rData;
+}
+
 }
 NS_CC_END

--- a/cocos/ui/UITextAtlas.h
+++ b/cocos/ui/UITextAtlas.h
@@ -36,6 +36,7 @@ NS_CC_BEGIN
  */
 
 class Label;
+struct CC_DLL ResouceData;
 
 namespace ui {
     
@@ -138,6 +139,9 @@ public:
      * @js NA
      */
     virtual void adaptRenderers() override;
+
+    ResouceData getRenderFile();
+
 protected:
     virtual void initRenderer() override;
     virtual void onSizeChanged() override;

--- a/cocos/ui/UITextBMFont.cpp
+++ b/cocos/ui/UITextBMFont.cpp
@@ -24,6 +24,7 @@ THE SOFTWARE.
 
 #include "ui/UITextBMFont.h"
 #include "2d/CCLabel.h"
+#include "2d/CocosStudioExtension.h"
 
 NS_CC_BEGIN
 
@@ -184,6 +185,14 @@ void TextBMFont::copySpecialProperties(Widget *widget)
         setFntFile(labelBMFont->_fntFileName);
         setString(labelBMFont->_stringValue);
     }
+}
+
+ResouceData TextBMFont::getRenderFile()
+{
+    ResouceData rData;
+    rData.type = 0;
+    rData.file = _fntFileName;
+    return rData;
 }
 
 }

--- a/cocos/ui/UITextBMFont.h
+++ b/cocos/ui/UITextBMFont.h
@@ -35,6 +35,7 @@ THE SOFTWARE.
 NS_CC_BEGIN
 
 class Label;
+struct CC_DLL ResouceData;
 
 namespace ui {
     
@@ -94,6 +95,9 @@ public:
      * Returns the "class name" of widget.
      */
     virtual std::string getDescription() const override;
+
+    ResouceData getRenderFile();
+
 protected:
     virtual void initRenderer() override;
     virtual void onSizeChanged() override;

--- a/cocos/ui/UIWidget.cpp
+++ b/cocos/ui/UIWidget.cpp
@@ -303,7 +303,7 @@ void Widget::setContentSize(const cocos2d::Size &contentSize)
     }
     else if (_ignoreSize)
     {
-        _contentSize = getVirtualRendererSize();
+        ProtectedNode::setContentSize(getVirtualRendererSize());
     }
     if (!_usingLayoutComponent && _running)
     {
@@ -609,6 +609,11 @@ bool Widget::isHighlighted() const
 
 void Widget::setHighlighted(bool highlight)
 {
+    if (highlight == _highlight)
+    {
+        return;
+    }
+
     _highlight = highlight;
     if (_bright)
     {


### PR DESCRIPTION
This PR can not pass auto build, because it need 2d/CocosStudioExtension.h file in 2d component combine pr.

This is a big PR. But most modify is to save resource file name, and add function that can return these resource file name back. And some other function modify is to clean / replace resource already loaded. Because in editor, resource may change often, not like in game, after resource loaded, it never change.

UILayoutComponent.cpp is changed for make sub component do the right layout operation by Liam.
