### PR TITLE
Combine Studio change for particle 3d

### DIFF
--- a/extensions/ExtensionExport.h
+++ b/extensions/ExtensionExport.h
@@ -24,6 +24,8 @@
             #define NULL    ((void *)0)
         #endif
     #endif
+#elif defined(_SHARED_)
+    #define CC_EX_DLL     __attribute__((visibility("default")))
 #else
     #define CC_EX_DLL
 #endif

--- a/extensions/Particle3D/PU/CCPUMaterialManager.h
+++ b/extensions/Particle3D/PU/CCPUMaterialManager.h
@@ -31,7 +31,7 @@
 
 NS_CC_BEGIN
 
-class PUMaterial : public Ref
+class CC_DLL PUMaterial : public Ref
 {
 public:
 
@@ -54,7 +54,7 @@ public:
     GLuint wrapMode;
 };
 
-class PUMaterialCache
+class CC_DLL PUMaterialCache
 {
 public:
 

--- a/extensions/Particle3D/PU/CCPUParticleSystem3D.h
+++ b/extensions/Particle3D/PU/CCPUParticleSystem3D.h
@@ -353,6 +353,8 @@ public:
     virtual PUParticleSystem3D* clone();
     virtual void copyAttributesTo(PUParticleSystem3D* system);
 
+    bool initSystem(const std::string &filePath);
+
 CC_CONSTRUCTOR_ACCESS:
     PUParticleSystem3D();
     virtual ~PUParticleSystem3D();
@@ -379,7 +381,6 @@ protected:
     
     inline bool isExpired(PUParticle3D* particle, float timeElapsed);
 
-    bool initSystem(const std::string &filePath);
     static void convertToUnixStylePath(std::string &path);
 
 protected:

--- a/extensions/Particle3D/PU/CCPUScriptCompiler.h
+++ b/extensions/Particle3D/PU/CCPUScriptCompiler.h
@@ -41,10 +41,10 @@ enum PUAbstractNodeType
     ANT_VARIABLE_SET,
     ANT_VARIABLE_ACCESS
 };
-class PUAbstractNode;
+class CC_DLL PUAbstractNode;
 typedef std::list<PUAbstractNode*> PUAbstractNodeList;
 
-class PUAbstractNode
+class CC_DLL PUAbstractNode
 {
 public:
     std::string file;
@@ -97,7 +97,7 @@ public:
 };
 
 /** This abstract node represents a script property */
-class  PUPropertyAbstractNode : public PUAbstractNode
+class CC_DLL PUPropertyAbstractNode : public PUAbstractNode
 {
 public:
     std::string name;
@@ -111,7 +111,7 @@ public:
 };
 
 /** This is an abstract node which cannot be broken down further */
-class PUAtomAbstractNode : public PUAbstractNode
+class CC_DLL PUAtomAbstractNode : public PUAbstractNode
 {
 public:
     std::string value;
@@ -124,8 +124,8 @@ private:
     void parseNumber() const;
 };
 
-class PUParticleSystem3D;
-class PUScriptCompiler
+class CC_DLL PUParticleSystem3D;
+class CC_DLL PUScriptCompiler
 {
 
 private:


### PR DESCRIPTION
Add dll_export statement to particle 3d related class to make it can be use when cocos2d-x compiled as dynamic library.
Move initSystem function in PUParticleSystem3D class to public, so editor can change particle resource of a particle 3d object.

@pandamicro @minggo Please review this PR.
