### PR TITLE
Fix crash when using cocos2d::Controller on iOS6

### DIFF
--- a/cocos/base/CCController-iOS.mm
+++ b/cocos/base/CCController-iOS.mm
@@ -81,7 +81,7 @@ static GCControllerConnectionEventHandler* __instance = nil;
 
 -(void)dealloc {
     [[NSNotificationCenter defaultCenter] removeObserver:self];
-	[super dealloc];
+    [super dealloc];
 }
 
 -(void) onControllerConnected :(NSNotification *)connectedNotification {
@@ -114,7 +114,8 @@ public:
     GCController* _gcController;
 };
 
-void Controller::startDiscoveryController() {
+void Controller::startDiscoveryController()
+{
     if (NSClassFromString(@"GCController") == nil) {
         return;
     }
@@ -148,7 +149,8 @@ void Controller::startDiscoveryController() {
     }];
 }
 
-void Controller::stopDiscoveryController() {
+void Controller::stopDiscoveryController()
+{
     if (NSClassFromString(@"GCController") == nil) {
         return;
     }

--- a/cocos/base/CCController-iOS.mm
+++ b/cocos/base/CCController-iOS.mm
@@ -114,8 +114,10 @@ public:
     GCController* _gcController;
 };
 
-void Controller::startDiscoveryController()
-{
+void Controller::startDiscoveryController() {
+    if (NSClassFromString(@"GCController") == nil) {
+        return;
+    }
     [GCController startWirelessControllerDiscoveryWithCompletionHandler: nil];
     
     [[GCControllerConnectionEventHandler getInstance] observerConnection: ^(GCController* gcController) {
@@ -146,8 +148,10 @@ void Controller::startDiscoveryController()
     }];
 }
 
-void Controller::stopDiscoveryController()
-{
+void Controller::stopDiscoveryController() {
+    if (NSClassFromString(@"GCController") == nil) {
+        return;
+    }
     [GCController stopWirelessControllerDiscovery];
 }
 


### PR DESCRIPTION
Using Controller on iOS6 crashes the app because GameController.framework was only added on iOS7. 

This PR fixes that crash by doing nothing in Controller::startDiscoveryController if the class GCController is not available.
