### PR TITLE
Combine Studio change for get program file full path.

### DIFF
--- a/cocos/platform/win32/CCFileUtils-win32.cpp
+++ b/cocos/platform/win32/CCFileUtils-win32.cpp
@@ -136,14 +136,9 @@ static void _checkPath()
 {
     if (s_resourcePath.empty())
     {
-        WCHAR *pUtf16ExePath = nullptr;
-#ifdef CC_STUDIO_ENABLED_VIEW
         WCHAR utf16Path[CC_MAX_PATH] = { 0 };
         GetModuleFileNameW(NULL, utf16Path, CC_MAX_PATH - 1);
-        pUtf16ExePath = &(utf16Path[0]);
-#else
-        _get_wpgmptr(&pUtf16ExePath); // CocoStudio Notice : This function won't work under studio, will cause a assert in system library
-#endif
+        WCHAR *pUtf16ExePath = &(utf16Path[0]);
 
         // We need only directory part without exe
         WCHAR *pUtf16DirEnd = wcsrchr(pUtf16ExePath, L'\\');

--- a/cocos/platform/win32/CCFileUtils-win32.cpp
+++ b/cocos/platform/win32/CCFileUtils-win32.cpp
@@ -137,7 +137,13 @@ static void _checkPath()
     if (s_resourcePath.empty())
     {
         WCHAR *pUtf16ExePath = nullptr;
-        _get_wpgmptr(&pUtf16ExePath);
+#ifdef CC_STUDIO_ENABLED_VIEW
+        WCHAR utf16Path[CC_MAX_PATH] = { 0 };
+        GetModuleFileNameW(NULL, utf16Path, CC_MAX_PATH - 1);
+        pUtf16ExePath = &(utf16Path[0]);
+#else
+        _get_wpgmptr(&pUtf16ExePath); // CocoStudio Notice : This function won't work under studio, will cause a assert in system library
+#endif
 
         // We need only directory part without exe
         WCHAR *pUtf16DirEnd = wcsrchr(pUtf16ExePath, L'\\');


### PR DESCRIPTION
_get_wpgmptr function will cause ASSERT in system library when program is start by C#, so it can not use in Cocos Studio.

@pandamicro @minggo Please reivew this PR.
