### PR TITLE
Improve unicode support

### DIFF
--- a/cocos/2d/CCFont.h
+++ b/cocos/2d/CCFont.h
@@ -30,6 +30,7 @@
 
 #include <string>
 #include "base/ccTypes.h"
+#include "base/ccUTF8.h"
 
 NS_CC_BEGIN
 
@@ -40,8 +41,13 @@ class CC_DLL Font : public Ref
 public:
     virtual FontAtlas* createFontAtlas() = 0;
 
-    virtual int* getHorizontalKerningForTextUTF16(const std::u16string& text, int &outNumLetters) const = 0;
-    
+    virtual int* getHorizontalKerningForTextUTF32(const std::u32string& text, int &outNumLetters) const = 0;
+    CC_DEPRECATED_ATTRIBUTE inline int* getHorizontalKerningForTextUTF16(const std::u16string& text, int &outNumLetters) const
+    {
+        std::u32string utf32;
+        StringUtils::UTF16ToUTF32(text, utf32);
+        return getHorizontalKerningForTextUTF32(utf32, outNumLetters);
+    }
     virtual int getFontMaxHeight() const { return 0; }
 };
 

--- a/cocos/2d/CCFontAtlas.h
+++ b/cocos/2d/CCFontAtlas.h
@@ -33,6 +33,7 @@
 
 #include "platform/CCPlatformMacros.h"
 #include "base/CCRef.h"
+#include "base/ccUTF8.h"
 #include "platform/CCStdC.h" // ssize_t on windows
 
 NS_CC_BEGIN
@@ -76,7 +77,13 @@ public:
     void addLetterDefinition(char16_t utf16Char, const FontLetterDefinition &letterDefinition);
     bool getLetterDefinitionForChar(char16_t utf16Char, FontLetterDefinition &letterDefinition);
     
-    bool prepareLetterDefinitions(const std::u16string& utf16String);
+    bool prepareLetterDefinitions(const std::u32string& utf32String);
+    CC_DEPRECATED_ATTRIBUTE inline bool prepareLetterDefinitions(const std::u16string& utf16String)
+    {
+        std::u32string utf32;
+        StringUtils::UTF16ToUTF32(utf16String, utf32);
+        return prepareLetterDefinitions(utf32);
+    }
 
     inline const std::unordered_map<ssize_t, Texture2D*>& getTextures() const{ return _atlasTextures;}
     void  addTexture(Texture2D *texture, int slot);
@@ -111,12 +118,12 @@ public:
 protected:
     void relaseTextures();
 
-    void findNewCharacters(const std::u16string& u16Text, std::unordered_map<unsigned short, unsigned short>& charCodeMap);
+    void findNewCharacters(const std::u32string& u32Text, std::unordered_map<char32_t, char32_t>& charCodeMap);
 
-    void conversionU16TOGB2312(const std::u16string& u16Text, std::unordered_map<unsigned short, unsigned short>& charCodeMap);
+    void conversionU32TOGB2312(const std::u32string& u32Text, std::unordered_map<char32_t, char32_t>& charCodeMap);
 
     std::unordered_map<ssize_t, Texture2D*> _atlasTextures;
-    std::unordered_map<char16_t, FontLetterDefinition> _letterDefinitions;
+    std::unordered_map<char32_t, FontLetterDefinition> _letterDefinitions;
     float _lineHeight;
     Font* _font;
     FontFreeType* _fontFreeType;

--- a/cocos/2d/CCFontCharMap.cpp
+++ b/cocos/2d/CCFontCharMap.cpp
@@ -98,7 +98,7 @@ FontCharMap::~FontCharMap()
 
 }
 
-int* FontCharMap::getHorizontalKerningForTextUTF16(const std::u16string& text, int &outNumLetters) const
+int* FontCharMap::getHorizontalKerningForTextUTF32(const std::u32string& text, int &outNumLetters) const
 {
     return nullptr;
 }

--- a/cocos/2d/CCFontCharMap.h
+++ b/cocos/2d/CCFontCharMap.h
@@ -40,7 +40,7 @@ public:
     static FontCharMap * create(Texture2D* texture, int itemWidth, int itemHeight, int startCharMap);
     static FontCharMap * create(const std::string& plistFile);
     
-    virtual int* getHorizontalKerningForTextUTF16(const std::u16string& text, int &outNumLetters) const override;
+    virtual int* getHorizontalKerningForTextUTF32(const std::u32string& text, int &outNumLetters) const override;
     virtual FontAtlas *createFontAtlas() override;
     
 protected:    

--- a/cocos/2d/CCFontFNT.h
+++ b/cocos/2d/CCFontFNT.h
@@ -44,7 +44,7 @@ public:
     Removes from memory the cached configurations and the atlas name dictionary.
     */
     static void purgeCachedData();
-    virtual int* getHorizontalKerningForTextUTF16(const std::u16string& text, int &outNumLetters) const override;
+    virtual int* getHorizontalKerningForTextUTF32(const std::u32string& text, int &outNumLetters) const override;
     virtual FontAtlas *createFontAtlas() override;
     
 protected:
@@ -58,7 +58,7 @@ protected:
     
 private:
     
-    int  getHorizontalKerningForChars(unsigned short firstChar, unsigned short secondChar) const;
+    int  getHorizontalKerningForChars(char32_t firstChar, char32_t secondChar) const;
     
     BMFontConfiguration * _configuration;
     Vec2                   _imageOffset;

--- a/cocos/2d/CCFontFreeType.cpp
+++ b/cocos/2d/CCFontFreeType.cpp
@@ -208,10 +208,10 @@ FontAtlas * FontFreeType::createFontAtlas()
         _fontAtlas = new (std::nothrow) FontAtlas(*this);
         if (_fontAtlas && _usedGlyphs != GlyphCollection::DYNAMIC)
         {
-            std::u16string utf16;
-            if (StringUtils::UTF8ToUTF16(getGlyphCollection(), utf16))
+            std::u32string utf32;
+            if (StringUtils::UTF8ToUTF32(getGlyphCollection(), utf32))
             {
-                _fontAtlas->prepareLetterDefinitions(utf16);
+                _fontAtlas->prepareLetterDefinitions(utf32);
             }
         }
         this->release();
@@ -220,7 +220,7 @@ FontAtlas * FontFreeType::createFontAtlas()
     return _fontAtlas;
 }
 
-int * FontFreeType::getHorizontalKerningForTextUTF16(const std::u16string& text, int &outNumLetters) const
+int* FontFreeType::getHorizontalKerningForTextUTF32(const std::u32string& text, int &outNumLetters) const
 {
     if (!_fontRef)
         return nullptr;
@@ -247,7 +247,7 @@ int * FontFreeType::getHorizontalKerningForTextUTF16(const std::u16string& text,
     return sizes;
 }
 
-int  FontFreeType::getHorizontalKerningForChars(unsigned short firstChar, unsigned short secondChar) const
+int  FontFreeType::getHorizontalKerningForChars(char32_t firstChar, char32_t secondChar) const
 {
     // get the ID to the char we need
     int glyphIndex1 = FT_Get_Char_Index(_fontRef, firstChar);
@@ -274,7 +274,7 @@ int FontFreeType::getFontAscender() const
     return (static_cast<int>(_fontRef->size->metrics.ascender >> 6));
 }
 
-unsigned char* FontFreeType::getGlyphBitmap(unsigned short theChar, long &outWidth, long &outHeight, Rect &outRect,int &xAdvance)
+unsigned char* FontFreeType::getGlyphBitmap(char32_t theChar, long &outWidth, long &outHeight, Rect &outRect,int &xAdvance)
 {
     bool invalidChar = true;
     unsigned char* ret = nullptr;
@@ -396,7 +396,7 @@ unsigned char* FontFreeType::getGlyphBitmap(unsigned short theChar, long &outWid
     }
 }
 
-unsigned char * FontFreeType::getGlyphBitmapWithOutline(unsigned short theChar, FT_BBox &bbox)
+unsigned char* FontFreeType::getGlyphBitmapWithOutline(char32_t theChar, FT_BBox &bbox)
 {   
     unsigned char* ret = nullptr;
     if (FT_Load_Char(_fontRef, theChar, FT_LOAD_NO_BITMAP) == 0)

--- a/cocos/2d/CCFontFreeType.h
+++ b/cocos/2d/CCFontFreeType.h
@@ -66,9 +66,13 @@ public:
 
     FT_Encoding getEncoding() const { return _encoding; }
 
-    int* getHorizontalKerningForTextUTF16(const std::u16string& text, int &outNumLetters) const override;
+    int* getHorizontalKerningForTextUTF32(const std::u32string& text, int &outNumLetters) const override;
     
-    unsigned char* getGlyphBitmap(unsigned short theChar, long &outWidth, long &outHeight, Rect &outRect,int &xAdvance);
+    unsigned char* getGlyphBitmap(char32_t theChar, long &outWidth, long &outHeight, Rect &outRect,int &xAdvance);
+    CC_DEPRECATED_ATTRIBUTE inline unsigned char* getGlyphBitmap(unsigned short theChar, long &outWidth, long &outHeight, Rect &outRect,int &xAdvance)
+    {
+        return getGlyphBitmap(static_cast<char32_t>(theChar), outWidth, outHeight, outRect, xAdvance);
+    }
     
     int getFontAscender() const;
 
@@ -88,8 +92,8 @@ private:
     bool initFreeType();
     FT_Library getFTLibrary();
     
-    int getHorizontalKerningForChars(unsigned short firstChar, unsigned short secondChar) const;
-    unsigned char* getGlyphBitmapWithOutline(unsigned short code, FT_BBox &bbox);
+    int getHorizontalKerningForChars(char32_t firstChar, char32_t secondChar) const;
+    unsigned char* getGlyphBitmapWithOutline(char32_t code, FT_BBox &bbox);
 
     void setGlyphCollection(GlyphCollection glyphs, const char* customGlyphs = nullptr);
     const char* getGlyphCollection() const;

--- a/cocos/2d/CCLabel.h
+++ b/cocos/2d/CCLabel.h
@@ -483,7 +483,7 @@ CC_CONSTRUCTOR_ACCESS:
 protected:
     struct LetterInfo
     {
-        char16_t utf16Char;
+        char32_t utf16Char;
         bool valid;
         float positionX;
         float positionY;
@@ -512,7 +512,7 @@ protected:
     void updateLabelLetters();
     virtual void alignText();
     void computeAlignmentOffset();
-    bool computeHorizontalKernings(const std::u16string& stringToRender);
+    bool computeHorizontalKernings(const std::u32string& stringToRender);
 
     void recordLetterInfo(const cocos2d::Vec2& point, char16_t utf16Char, int letterIndex, int lineIndex);
     void recordPlaceholderInfo(int letterIndex, char16_t utf16Char);
@@ -532,7 +532,7 @@ protected:
 
     LabelType _currentLabelType;
     bool _contentDirty;
-    std::u16string _utf16Text;
+    std::u32string _utf32Text;
     std::string _utf8Text;
     int _numberOfLines;
 

--- a/cocos/2d/CCLabelTextFormatter.cpp
+++ b/cocos/2d/CCLabelTextFormatter.cpp
@@ -71,9 +71,9 @@ void Label::computeAlignmentOffset()
     }
 }
 
-static int getFirstWordLen(const std::u16string& utf16Text, int startIndex, int textLen)
+static int getFirstWordLen(const std::u32string& utf32Text, int startIndex, int textLen)
 {
-    auto character = utf16Text[startIndex];
+    auto character = utf32Text[startIndex];
     if (StringUtils::isCJKUnicode(character) || StringUtils::isUnicodeSpace(character) || character == '\n')
     {
         return 1;
@@ -82,7 +82,7 @@ static int getFirstWordLen(const std::u16string& utf16Text, int startIndex, int 
     int len = 1;
     for (int index = startIndex + 1; index < textLen; ++index)
     {
-        character = utf16Text[index];
+        character = utf32Text[index];
         if (character == '\n' || StringUtils::isUnicodeSpace(character) || StringUtils::isCJKUnicode(character))
         {
             break;
@@ -111,7 +111,7 @@ bool Label::multilineTextWrapByWord()
     
     for (int index = 0; index < textLen; )
     {
-        auto character = _utf16Text[index];
+        auto character = _utf32Text[index];
         if (character == '\n')
         {
             _linesWidth.push_back(letterRight);
@@ -124,7 +124,7 @@ bool Label::multilineTextWrapByWord()
             continue;
         }
 
-        auto wordLen = getFirstWordLen(_utf16Text, index, textLen);
+        auto wordLen = getFirstWordLen(_utf32Text, index, textLen);
         float wordHighestY = highestY;;
         float wordLowestY = lowestY;
         float wordRight = letterRight;
@@ -133,7 +133,7 @@ bool Label::multilineTextWrapByWord()
         for (int tmp = 0; tmp < wordLen;++tmp)
         {
             int letterIndex = index + tmp;
-            character = _utf16Text[letterIndex];
+            character = _utf32Text[letterIndex];
             if (character == '\r')
             {
                 recordPlaceholderInfo(letterIndex, character);
@@ -234,7 +234,7 @@ bool Label::multilineTextWrapByChar()
 
     for (int index = 0; index < textLen; index++)
     {
-        auto character = _utf16Text[index];
+        auto character = _utf32Text[index];
         if (character == '\r')
         {
             recordPlaceholderInfo(index, character);

--- a/cocos/base/ccUTF8.cpp
+++ b/cocos/base/ccUTF8.cpp
@@ -73,14 +73,19 @@ static void trimUTF16VectorFromIndex(std::vector<char16_t>& str, int index)
  *
  * Return value: weather the character is a whitespace character.
  * */
-bool isUnicodeSpace(char16_t ch)
+bool isUnicodeSpace(char32_t ch)
 {
     return  (ch >= 0x0009 && ch <= 0x000D) || ch == 0x0020 || ch == 0x0085 || ch == 0x00A0 || ch == 0x1680
     || (ch >= 0x2000 && ch <= 0x200A) || ch == 0x2028 || ch == 0x2029 || ch == 0x202F
     ||  ch == 0x205F || ch == 0x3000;
 }
 
-bool isCJKUnicode(char16_t ch)
+bool isUnicodeSpace(char16_t ch)
+{
+    isUnicodeSpace(static_cast<char32_t>(ch));
+}
+
+bool isCJKUnicode(char32_t ch)
 {
     return (ch >= 0x4E00 && ch <= 0x9FBF)   // CJK Unified Ideographs
         || (ch >= 0x2E80 && ch <= 0x2FDF)   // CJK Radicals Supplement & Kangxi Radicals
@@ -90,6 +95,11 @@ bool isCJKUnicode(char16_t ch)
         || (ch >= 0xF900 && ch <= 0xFAFF)   // CJK Compatibility Ideographs
         || (ch >= 0xFE30 && ch <= 0xFE4F)   // CJK Compatibility Forms
         || (ch >= 0x31C0 && ch <= 0x4DFF);  // Other exiensions
+}
+
+bool isCJKUnicode(char16_t ch)
+{
+    isCJKUnicode(static_cast<char32_t>(ch));
 }
 
 void trimUTF16Vector(std::vector<char16_t>& str)
@@ -280,13 +290,13 @@ void cc_utf8_trim_ws(std::vector<unsigned short>* str)
 
 bool isspace_unicode(unsigned short ch)
 {
-    return StringUtils::isUnicodeSpace(ch);
+    return StringUtils::isUnicodeSpace(static_cast<char32_t>(ch));
 }
 
 
 bool iscjk_unicode(unsigned short ch)
 {
-    return StringUtils::isCJKUnicode(ch);
+    return StringUtils::isCJKUnicode(static_cast<char32_t>(ch));
 }
 
 

--- a/cocos/base/ccUTF8.h
+++ b/cocos/base/ccUTF8.h
@@ -135,6 +135,7 @@ CC_DLL void trimUTF16Vector(std::vector<char16_t>& str);
  *
  */
 CC_DLL bool isUnicodeSpace(char16_t ch);
+CC_DLL bool isUnicodeSpace(char32_t ch);
 
 /**
  *  @brief Whether the character is a Chinese/Japanese/Korean character.
@@ -146,6 +147,7 @@ CC_DLL bool isUnicodeSpace(char16_t ch);
  *
  */
 CC_DLL bool isCJKUnicode(char16_t ch);
+CC_DLL bool isCJKUnicode(char32_t ch);
 
 /**
  *  @brief Returns the length of the string in characters.


### PR DESCRIPTION
Try to fixes #14444
1. refactor and add full set UTF convert functions to StringUtils.
2. replace all usage to UTF16 with UTF32 in Font/Label system.
3. add deprecated inline implement to old public APIs.
