### PR TITLE
【bugfix】Update CCFontFreeType.cpp

### DIFF
--- a/cocos/2d/CCFontFreeType.cpp
+++ b/cocos/2d/CCFontFreeType.cpp
@@ -338,7 +338,7 @@ unsigned char* FontFreeType::getGlyphBitmap(unsigned short theChar, long &outWid
             auto blendWidth = MAX(outlineMaxX, glyphMaxX) - blendImageMinX;
             auto blendHeight = blendImageMaxY - MIN(outlineMinY, glyphMinY);
 
-            outRect.origin.x = blendImageMinX;
+            outRect.origin.x = blendImageMinX + _outlineSize;
             outRect.origin.y = -blendImageMaxY + _outlineSize;
 
             long index, index2;


### PR DESCRIPTION
加描边时，文字和label的外框有偏移。
![image](https://cloud.githubusercontent.com/assets/4133961/11359816/8d1663f6-92ba-11e5-86b0-bf41cc06b5ea.png)
