### PR TITLE
Combine Cocos Studio change to simulator

### DIFF
--- a/tools/simulator/frameworks/runtime-src/Classes/ide-support/RuntimeLuaImpl.cpp
+++ b/tools/simulator/frameworks/runtime-src/Classes/ide-support/RuntimeLuaImpl.cpp
@@ -20,7 +20,7 @@
 #include "runtime/ConfigParser.h"
 #include "runtime/FileServer.h"
 
-extern std::string g_projectPath; // Runtime.cpp
+//extern std::string g_projectPath; // Runtime.cpp
 
 USING_NS_CC;
 using namespace std;

--- a/tools/simulator/frameworks/runtime-src/proj.ios_mac/ios/Info.plist
+++ b/tools/simulator/frameworks/runtime-src/proj.ios_mac/ios/Info.plist
@@ -46,11 +46,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.5rc0</string>
+	<string>3.9</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>20150314</string>
+	<string>20151109</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UILaunchImages</key>

--- a/tools/simulator/frameworks/runtime-src/proj.win32/simulator.vcxproj
+++ b/tools/simulator/frameworks/runtime-src/proj.win32/simulator.vcxproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
@@ -21,7 +21,7 @@
     <CharacterSet>Unicode</CharacterSet>
     <PlatformToolset Condition="'$(VisualStudioVersion)' == '11.0'">v110</PlatformToolset>
     <PlatformToolset Condition="'$(VisualStudioVersion)' == '12.0'">v120</PlatformToolset>
-     <PlatformToolset Condition="'$(VisualStudioVersion)' == '14.0'">v140</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '14.0'">v140</PlatformToolset>
     <PlatformToolset Condition="'$(VisualStudioVersion)' == '14.0' and exists('$(MSBuildProgramFiles32)\Microsoft SDKs\Windows\v7.1A')">v140_xp</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
@@ -30,7 +30,7 @@
     <CharacterSet>Unicode</CharacterSet>
     <PlatformToolset Condition="'$(VisualStudioVersion)' == '11.0'">v110</PlatformToolset>
     <PlatformToolset Condition="'$(VisualStudioVersion)' == '12.0'">v120</PlatformToolset>
-     <PlatformToolset Condition="'$(VisualStudioVersion)' == '14.0'">v140</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '14.0'">v140</PlatformToolset>
     <PlatformToolset Condition="'$(VisualStudioVersion)' == '14.0' and exists('$(MSBuildProgramFiles32)\Microsoft SDKs\Windows\v7.1A')">v140_xp</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
@@ -76,7 +76,7 @@
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WIN32;_WINDOWS;STRICT;_CRT_SECURE_NO_WARNINGS;_SCL_SECURE_NO_WARNINGS_DEBUG;COCOS2D_DEBUG=1;GLFW_EXPOSE_NATIVE_WIN32;GLFW_EXPOSE_NATIVE_WGL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_WINDOWS;STRICT;_CRT_SECURE_NO_WARNINGS;_SCL_SECURE_NO_WARNINGS_DEBUG;COCOS2D_DEBUG=1;GLFW_EXPOSE_NATIVE_WIN32;GLFW_EXPOSE_NATIVE_WGL;_USRLIBSIMSTATIC;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DisableSpecificWarnings>4267;4251;4244;%(DisableSpecificWarnings)</DisableSpecificWarnings>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <ProgramDataBaseFileName>$(IntDir)vc$(PlatformToolsetVersion).pdb</ProgramDataBaseFileName>

--- a/tools/simulator/frameworks/runtime-src/proj.win32/simulator.vcxproj
+++ b/tools/simulator/frameworks/runtime-src/proj.win32/simulator.vcxproj
@@ -141,7 +141,7 @@ xcopy /Y /Q "$(OutDir)lang" "$(ProjectDir)..\..\..\runtime\win32"
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <ExceptionHandling>Sync</ExceptionHandling>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-      <PreprocessorDefinitions>COCOS2D_DEBUG=1;WIN32;_WINDOWS;STRICT;_CRT_SECURE_NO_WARNINGS;_SCL_SECURE_NO_WARNINGSNDEBUG;GLFW_EXPOSE_NATIVE_WIN32;GLFW_EXPOSE_NATIVE_WGL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>COCOS2D_DEBUG=1;WIN32;_WINDOWS;STRICT;_CRT_SECURE_NO_WARNINGS;_SCL_SECURE_NO_WARNINGSNDEBUG;GLFW_EXPOSE_NATIVE_WIN32;GLFW_EXPOSE_NATIVE_WGL;_USRLIBSIMSTATIC;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DisableSpecificWarnings>4267;4251;4244;%(DisableSpecificWarnings)</DisableSpecificWarnings>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <ProgramDataBaseFileName>$(IntDir)vc$(PlatformToolsetVersion).pdb</ProgramDataBaseFileName>

--- a/tools/simulator/libsimulator/lib/AppEvent.h
+++ b/tools/simulator/libsimulator/lib/AppEvent.h
@@ -15,6 +15,7 @@
 #include "json/filestream.h"
 #include "json/stringbuffer.h"
 #include "json/writer.h"
+#include "libSimulatorExport.h"
 
 enum
 {
@@ -25,7 +26,7 @@ enum
 #define kAppEventDropName "APP.EVENT.DROP"
 #define kAppEventName     "APP.EVENT"
 
-class AppEvent : public cocos2d::EventCustom
+class CC_LIBSIM_DLL AppEvent : public cocos2d::EventCustom
 {
 public:
     /** Constructor */

--- a/tools/simulator/libsimulator/lib/AppLang.h
+++ b/tools/simulator/libsimulator/lib/AppLang.h
@@ -11,8 +11,9 @@
 
 #include "json/document.h"
 #include "DeviceEx.h"
+#include "libSimulatorExport.h"
 
-class AppLang
+class CC_LIBSIM_DLL AppLang
 {
 public:
     static AppLang* getInstance();

--- a/tools/simulator/libsimulator/lib/DeviceEx.h
+++ b/tools/simulator/libsimulator/lib/DeviceEx.h
@@ -2,10 +2,11 @@
 
 #include <string>
 #include "PlayerMacros.h"
+#include "libSimulatorExport.h"
 
 PLAYER_NS_BEGIN
 
-class DeviceEx
+class CC_LIBSIM_DLL DeviceEx
 {
 public:
     static DeviceEx *getInstance();

--- a/tools/simulator/libsimulator/lib/PlayerMenuServiceProtocol.h
+++ b/tools/simulator/libsimulator/lib/PlayerMenuServiceProtocol.h
@@ -7,6 +7,7 @@
 #include "cocos2d.h"
 #include "PlayerMacros.h"
 #include "PlayerServiceProtocol.h"
+#include "libSimulatorExport.h"
 
 PLAYER_NS_BEGIN
 
@@ -15,7 +16,7 @@ PLAYER_NS_BEGIN
 #define kPlayerCtrlModifyKey  "ctrl"
 #define kPlayerAltModifyKey   "alt"
 
-class PlayerMenuItem : public cocos2d::Ref
+class CC_LIBSIM_DLL PlayerMenuItem : public cocos2d::Ref
 {
 public:
     virtual ~PlayerMenuItem();

--- a/tools/simulator/libsimulator/lib/PlayerProtocol.h
+++ b/tools/simulator/libsimulator/lib/PlayerProtocol.h
@@ -12,10 +12,11 @@
 #include "PlayerTaskServiceProtocol.h"
 
 #include "ProjectConfig/ProjectConfig.h"
+#include "libSimulatorExport.h"
 
 PLAYER_NS_BEGIN
 
-class PlayerProtocol
+class CC_LIBSIM_DLL PlayerProtocol
 {
 public:
     virtual ~PlayerProtocol();

--- a/tools/simulator/libsimulator/lib/ProjectConfig/ProjectConfig.h
+++ b/tools/simulator/libsimulator/lib/ProjectConfig/ProjectConfig.h
@@ -8,6 +8,7 @@
 using namespace std;
 
 #include "cocos2d.h"
+#include "libSimulatorExport.h"
 
 #define kCCRuntimeDebuggerNone      0
 #define kCCRuntimeDebuggerLDT       1
@@ -37,7 +38,7 @@ using namespace std;
 #define kProjectConfigUploadPort    6020
 #define kProjectConfigDebugPort     5086
 
-class ProjectConfig
+class CC_LIBSIM_DLL ProjectConfig
 {
 public:
     ProjectConfig();

--- a/tools/simulator/libsimulator/lib/ProjectConfig/SimulatorConfig.h
+++ b/tools/simulator/libsimulator/lib/ProjectConfig/SimulatorConfig.h
@@ -8,6 +8,7 @@
 using namespace std;
 
 #include "cocos2d.h"
+#include "libSimulatorExport.h"
 
 #if defined(_WINDOWS)
 #define DIRECTORY_SEPARATOR "\\"
@@ -33,7 +34,7 @@ typedef struct _SimulatorScreenSize {
 typedef vector<SimulatorScreenSize> ScreenSizeArray;
 typedef ScreenSizeArray::iterator ScreenSizeArrayIterator;
 
-class SimulatorConfig
+class CC_LIBSIM_DLL SimulatorConfig
 {
 public:
     static SimulatorConfig *getInstance();

--- a/tools/simulator/libsimulator/lib/libSimulatorExport.h
+++ b/tools/simulator/libsimulator/lib/libSimulatorExport.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#if (defined(WIN32) && defined(_WINDOWS)) || defined(WINRT) || defined(WP8)
+    #ifdef __MINGW32__
+        #include <string.h>
+    #endif
+
+    #if defined(_USRLIBSIMSTATIC)
+        #define CC_LIBSIM_DLL
+    #else
+        #if defined(_USRLIBSIMDLL)
+            #define CC_LIBSIM_DLL     __declspec(dllexport)
+        #else         /* use a DLL library */
+            #define CC_LIBSIM_DLL     __declspec(dllimport)
+        #endif
+    #endif
+
+    /* Define NULL pointer value */
+    #ifndef NULL
+        #ifdef __cplusplus
+            #define NULL    0
+        #else
+            #define NULL    ((void *)0)
+        #endif
+    #endif
+#elif defined(_SHARED_)
+    #define CC_LIBSIM_DLL     __attribute__((visibility("default")))
+#else
+    #define CC_LIBSIM_DLL
+#endif

--- a/tools/simulator/libsimulator/lib/platform/win32/PlayerMenuServiceWin.h
+++ b/tools/simulator/libsimulator/lib/platform/win32/PlayerMenuServiceWin.h
@@ -8,10 +8,11 @@
 #include "cocos2d.h"
 #include "stdafx.h"
 #include "PlayerMenuServiceProtocol.h"
+#include "libSimulatorExport.h"
 
 PLAYER_NS_BEGIN
 
-class PlayerMenuItemWin : public PlayerMenuItem
+class CC_LIBSIM_DLL PlayerMenuItemWin : public PlayerMenuItem
 {
 public:
     static PlayerMenuItemWin *create(const std::string &menuId, const std::string &title);
@@ -34,7 +35,7 @@ protected:
     friend class PlayerMenuServiceWin;
 };
 
-class PlayerMenuServiceWin : public PlayerMenuServiceProtocol
+class CC_LIBSIM_DLL PlayerMenuServiceWin : public PlayerMenuServiceProtocol
 {
 public:
     PlayerMenuServiceWin(HWND hwnd);

--- a/tools/simulator/libsimulator/lib/platform/win32/PlayerWin.h
+++ b/tools/simulator/libsimulator/lib/platform/win32/PlayerWin.h
@@ -9,10 +9,11 @@
 #include "PlayerFileDialogServiceWin.h"
 #include "PlayerEditBoxServiceWin.h"
 #include "PlayerTaskServiceWin.h"
+#include "libSimulatorExport.h"
 
 PLAYER_NS_BEGIN
 
-class PlayerWin : public PlayerProtocol, public cocos2d::Ref
+class CC_LIBSIM_DLL PlayerWin : public PlayerProtocol, public cocos2d::Ref
 {
 public:
     static PlayerWin *createWithHwnd(HWND hWnd);

--- a/tools/simulator/libsimulator/lib/runtime/ConfigParser.h
+++ b/tools/simulator/libsimulator/lib/runtime/ConfigParser.h
@@ -11,9 +11,10 @@ using namespace std;
 USING_NS_CC;
 
 #define CONFIG_FILE "config.json"
+#include "libSimulatorExport.h"
 
 typedef vector<SimulatorScreenSize> ScreenSizeArray;
-class ConfigParser
+class CC_LIBSIM_DLL ConfigParser
 {
 public:
     static ConfigParser *getInstance(void);

--- a/tools/simulator/libsimulator/lib/runtime/ConsoleCommand.cpp
+++ b/tools/simulator/libsimulator/lib/runtime/ConsoleCommand.cpp
@@ -211,8 +211,10 @@ void ConsoleCommand::onSendCommand(int fd, const std::string &args)
             } else if(strcmp(strcmd.c_str(), "shutdownapp") == 0)
             {
 #if (CC_TARGET_PLATFORM == CC_PLATFORM_WIN32)
-                extern void shutDownApp();
-                shutDownApp();
+#include <windows.h>
+                auto glview = dynamic_cast<GLViewImpl*> (Director::getInstance()->getOpenGLView());
+                HWND hWnd = glview->getWin32Window();
+                ::SendMessage(hWnd, WM_CLOSE, NULL, NULL);
 #else
                 exit(0);
 #endif

--- a/tools/simulator/libsimulator/lib/runtime/FileServer.cpp
+++ b/tools/simulator/libsimulator/lib/runtime/FileServer.cpp
@@ -257,7 +257,7 @@ _responseEndThread(false)
     _writePath = FileUtils::getInstance()->getWritablePath();
     
 #if (CC_TARGET_PLATFORM == CC_PLATFORM_MAC)
-    std::string getCurAppName(void);
+#include "Widget_mac.h"
     _writePath += getCurAppName();
     _writePath += "/";
 #endif

--- a/tools/simulator/libsimulator/lib/runtime/FileServer.h
+++ b/tools/simulator/libsimulator/lib/runtime/FileServer.h
@@ -53,7 +53,9 @@ THE SOFTWARE.
 #include <unistd.h>
 #endif
 
-class FileServer
+#include "libSimulatorExport.h"
+
+class CC_LIBSIM_DLL FileServer
 {
     static FileServer *s_sharedFileServer;
 public:

--- a/tools/simulator/libsimulator/lib/runtime/Runtime.cpp
+++ b/tools/simulator/libsimulator/lib/runtime/Runtime.cpp
@@ -190,9 +190,29 @@ void RuntimeEngine::setProjectPath(const std::string &workPath)
 
     if (workPath.empty())
     {
-        extern std::string getCurAppPath();
-        std::string appPath = getCurAppPath();
+        //        extern std::string getCurAppPath();
+        std::string appPath = std::string("");// getCurAppPath();
 #if (CC_TARGET_PLATFORM == CC_PLATFORM_WIN32)
+        TCHAR szAppDir[MAX_PATH] = { 0 };
+        if (GetModuleFileName(NULL, szAppDir, MAX_PATH))
+        {
+            int nEnd = 0;
+            for (int i = 0; szAppDir[i]; i++)
+            {
+                if (szAppDir[i] == '\\')
+                    nEnd = i;
+            }
+            szAppDir[nEnd] = 0;
+            int iLen = 2 * wcslen(szAppDir);
+            char* chRtn = new char[iLen + 1];
+            wcstombs(chRtn, szAppDir, iLen + 1);
+            std::string strPath = chRtn;
+            delete[] chRtn;
+            chRtn = NULL;
+            char fuldir[MAX_PATH] = { 0 };
+            _fullpath(fuldir, strPath.c_str(), MAX_PATH);
+            appPath = fuldir;
+        }
         appPath.append("/../../");
 #elif (CC_TARGET_PLATFORM == CC_PLATFORM_MAC)
         appPath.append("/../../../");

--- a/tools/simulator/libsimulator/lib/runtime/Runtime.h
+++ b/tools/simulator/libsimulator/lib/runtime/Runtime.h
@@ -28,14 +28,17 @@ THE SOFTWARE.
 #include <string>
 #include <functional>
 #include <unordered_map>
+#include "libSimulatorExport.h"
 
 void recvBuf(int fd, char *pbuf, unsigned long bufsize);
 
 void sendBuf(int fd, const char *pbuf, unsigned long bufsize);
 
-std::string& replaceAll(std::string& str, const std::string& old_value, const std::string& new_value);
+CC_LIBSIM_DLL extern std::string g_projectPath;
 
-std::string getIPAddress();
+CC_LIBSIM_DLL extern std::string& replaceAll(std::string& str, const std::string& old_value, const std::string& new_value);
+
+CC_LIBSIM_DLL extern std::string getIPAddress();
 
 const char* getRuntimeVersion();
 
@@ -53,7 +56,7 @@ const char* getRuntimeVersion();
 #define kRuntimeEngineCCS 4
 
 class RuntimeProtocol;
-class RuntimeEngine
+class CC_LIBSIM_DLL RuntimeEngine
 {
 public:
     static RuntimeEngine* getInstance();

--- a/tools/simulator/libsimulator/lib/runtime/RuntimeProtocol.h
+++ b/tools/simulator/libsimulator/lib/runtime/RuntimeProtocol.h
@@ -9,8 +9,9 @@
 
 #include <string>
 #include "json/document.h"
+#include "libSimulatorExport.h"
 
-class RuntimeProtocol
+class CC_LIBSIM_DLL RuntimeProtocol
 {
 public:
     virtual void end();

--- a/tools/simulator/libsimulator/lib/runtime/Widget_mac.h
+++ b/tools/simulator/libsimulator/lib/runtime/Widget_mac.h
@@ -1,0 +1,14 @@
+//
+//  Widget_mac.h
+//  libsimulator_studio
+//
+//  Created by Norman on 11/20/15.
+//  Copyright (c) 2015 cocos. All rights reserved.
+//
+
+#ifndef libsimulator_studio_Widget_mac_h
+#define libsimulator_studio_Widget_mac_h
+
+std::string getCurAppName(void);
+
+#endif

--- a/tools/simulator/libsimulator/lib/runtime/Widget_mac.h
+++ b/tools/simulator/libsimulator/lib/runtime/Widget_mac.h
@@ -1,9 +1,7 @@
 //
 //  Widget_mac.h
-//  libsimulator_studio
+//  Simulator
 //
-//  Created by Norman on 11/20/15.
-//  Copyright (c) 2015 cocos. All rights reserved.
 //
 
 #ifndef libsimulator_studio_Widget_mac_h

--- a/tools/simulator/libsimulator/lib/runtime/Widget_mac.mm
+++ b/tools/simulator/libsimulator/lib/runtime/Widget_mac.mm
@@ -1,0 +1,22 @@
+//
+//  Widget_mac.mm
+//  libsimulator_studio
+//
+//  Created by Norman on 11/20/15.
+//  Copyright (c) 2015 cocos. All rights reserved.
+//
+
+#include <string>
+#include "Widget_mac.h"
+
+using namespace std;
+
+std::string getCurAppName(void)
+{
+    string appName = [[[NSProcessInfo processInfo] processName] UTF8String];
+    size_t found = appName.find(" ");
+    if (found!=std::string::npos)
+        appName = appName.substr(0,found);
+    
+    return appName;
+}

--- a/tools/simulator/libsimulator/lib/runtime/Widget_mac.mm
+++ b/tools/simulator/libsimulator/lib/runtime/Widget_mac.mm
@@ -1,9 +1,7 @@
 //
-//  Widget_mac.mm
-//  libsimulator_studio
+//  Widget_mac.cpp
+//  Simulator
 //
-//  Created by Norman on 11/20/15.
-//  Copyright (c) 2015 cocos. All rights reserved.
 //
 
 #include <string>

--- a/tools/simulator/libsimulator/proj.win32/libsimulator.vcxproj
+++ b/tools/simulator/libsimulator/proj.win32/libsimulator.vcxproj
@@ -84,7 +84,7 @@
       <Optimization>MinSpace</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>COCOS2D_DEBUG=1;WIN32;_WINDOWS;STRICT;_CRT_SECURE_NO_WARNINGS;_SCL_SECURE_NO_WARNINGS_DEBUG;GLFW_EXPOSE_NATIVE_WIN32;GLFW_EXPOSE_NATIVE_WGL;_SILENCE_STDEXT_HASH_DEPRECATION_WARNINGS;%(PreprocessorDefinitions);_SILENCE_STDEXT_HASH_DEPRECATION_WARNINGS</PreprocessorDefinitions>
+      <PreprocessorDefinitions>COCOS2D_DEBUG=1;WIN32;_WINDOWS;STRICT;_CRT_SECURE_NO_WARNINGS;_SCL_SECURE_NO_WARNINGS_DEBUG;GLFW_EXPOSE_NATIVE_WIN32;GLFW_EXPOSE_NATIVE_WGL;_SILENCE_STDEXT_HASH_DEPRECATION_WARNINGS;_USRLIBSIMSTATIC;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>$(ProjectDir);$(ProjectDir)..\lib\protobuf-lite;$(ProjectDir)..\lib;$(EngineRoot)external\win32-specific\zlib\include;$(EngineRoot)cocos\scripting\lua-bindings\auto;$(EngineRoot)cocos\scripting\lua-bindings\manual;$(EngineRoot)cocos\audio\include;$(EngineRoot)external;$(EngineRoot)external\lua\lua;$(EngineRoot)external\lua\tolua;$(EngineRoot)external\chipmunk\include\chipmunk;$(EngineRoot)external\curl\include\win32;$(EngineRoot)extensions;$(EngineRoot);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <CompileAs>CompileAsCpp</CompileAs>

--- a/tools/simulator/libsimulator/proj.win32/libsimulator.vcxproj
+++ b/tools/simulator/libsimulator/proj.win32/libsimulator.vcxproj
@@ -60,7 +60,7 @@
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WIN32;_WINDOWS;STRICT;_CRT_SECURE_NO_WARNINGS;_SCL_SECURE_NO_WARNINGS_DEBUG;COCOS2D_DEBUG=1;GLFW_EXPOSE_NATIVE_WIN32;GLFW_EXPOSE_NATIVE_WGL;%(PreprocessorDefinitions);_SILENCE_STDEXT_HASH_DEPRECATION_WARNINGS</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_WINDOWS;STRICT;_CRT_SECURE_NO_WARNINGS;_SCL_SECURE_NO_WARNINGS_DEBUG;COCOS2D_DEBUG=1;GLFW_EXPOSE_NATIVE_WIN32;GLFW_EXPOSE_NATIVE_WGL;%(PreprocessorDefinitions);_SILENCE_STDEXT_HASH_DEPRECATION_WARNINGS;_USRLIBSIMSTATIC</PreprocessorDefinitions>
       <SDLCheck>
       </SDLCheck>
       <AdditionalIncludeDirectories>$(ProjectDir);$(ProjectDir)..\lib\protobuf-lite;$(ProjectDir)..\lib;$(EngineRoot)external\win32-specific\zlib\include;$(EngineRoot)cocos\scripting\lua-bindings\auto;$(EngineRoot)cocos\scripting\lua-bindings\manual;$(EngineRoot)cocos\audio\include;$(EngineRoot)external;$(EngineRoot)external\lua\lua;$(EngineRoot)external\lua\tolua;$(EngineRoot)external\chipmunk\include\chipmunk;$(EngineRoot)external\curl\include\win32;$(EngineRoot)extensions;$(EngineRoot);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>


### PR DESCRIPTION
Add dllexport to make libsimulator can be compiled as dynamic library.
Fix some irregular implementation, function implement in simulator project, but use in libsimulator project

@ricardoquesada @minggo @pandamicro Please review this pr.
