### PR TITLE
Fix app-project generates .lib file in Win32

### DIFF
--- a/cocos/deprecated/CCArray.h
+++ b/cocos/deprecated/CCArray.h
@@ -502,7 +502,7 @@ public:
      * @js NA
      * @lua NA
      */
-    virtual __Array* clone() const;
+    virtual __Array* clone() const override;
 
     // ------------------------------------------
     // Iterators

--- a/cocos/deprecated/CCBool.h
+++ b/cocos/deprecated/CCBool.h
@@ -46,7 +46,7 @@ public:
 
     static __Bool* create(bool v)
     {
-        __Bool* pRet = new __Bool(v);
+        __Bool* pRet = new (std::nothrow) __Bool(v);
         if (pRet)
         {
             pRet->autorelease();
@@ -57,7 +57,7 @@ public:
     /* override functions */
     virtual void acceptVisitor(DataVisitor &visitor) { visitor.visit(this); }
 
-    __Bool* clone() const
+    virtual __Bool* clone() const override
     {
         return __Bool::create(_value);
     }

--- a/cocos/deprecated/CCDictionary.h
+++ b/cocos/deprecated/CCDictionary.h
@@ -420,7 +420,7 @@ public:
      *  @js NA
      *  @lua NA
      */
-    virtual __Dictionary* clone() const;
+    virtual __Dictionary* clone() const override;
     
 private:
     /** 

--- a/cocos/deprecated/CCDouble.h
+++ b/cocos/deprecated/CCDouble.h
@@ -45,7 +45,7 @@ public:
 
     static __Double* create(double v)
     {
-        __Double* pRet = new __Double(v);
+        __Double* pRet = new (std::nothrow) __Double(v);
         if (pRet)
         {
             pRet->autorelease();
@@ -56,7 +56,7 @@ public:
     /* override functions */
     virtual void acceptVisitor(DataVisitor &visitor) { visitor.visit(this); }
     
-    __Double* clone() const
+    virtual __Double* clone() const override
     {
         return __Double::create(_value);
     }

--- a/cocos/deprecated/CCFloat.h
+++ b/cocos/deprecated/CCFloat.h
@@ -45,7 +45,7 @@ public:
 
     static __Float* create(float v)
     {
-        __Float* pRet = new __Float(v);
+        __Float* pRet = new (std::nothrow) __Float(v);
         if (pRet)
         {
             pRet->autorelease();
@@ -56,7 +56,7 @@ public:
     /* override functions */
     virtual void acceptVisitor(DataVisitor &visitor) { visitor.visit(this); }
     
-    __Float* clone() const
+    virtual __Float* clone() const override
     {
         return __Float::create(_value);
     }

--- a/cocos/deprecated/CCInteger.h
+++ b/cocos/deprecated/CCInteger.h
@@ -43,7 +43,7 @@ class CC_DLL __Integer : public Ref, public Clonable
 public:
     static __Integer* create(int v)
     {
-        __Integer* pRet = new __Integer(v);
+        __Integer* pRet = new (std::nothrow) __Integer(v);
         pRet->autorelease();
         return pRet;
     }

--- a/cocos/deprecated/CCSet.cpp
+++ b/cocos/deprecated/CCSet.cpp
@@ -31,12 +31,12 @@ NS_CC_BEGIN
 
 __Set::__Set(void)
 {
-    _set = new set<Ref *>;
+    _set = new (std::nothrow) set<Ref *>;
 }
 
 __Set::__Set(const __Set &other)
 {
-    _set = new set<Ref *>(*other._set);
+    _set = new (std::nothrow) set<Ref *>(*other._set);
 
     // call retain of members
     __SetIterator iter;
@@ -64,7 +64,7 @@ void __Set::acceptVisitor(DataVisitor &visitor)
 
 __Set * __Set::create()
 {
-    __Set * pRet = new __Set();
+    __Set * pRet = new (std::nothrow) __Set();
     
     if (pRet != nullptr)
     {
@@ -76,7 +76,7 @@ __Set * __Set::create()
 
 __Set* __Set::copy(void)
 {
-    __Set *p__Set = new __Set(*this);
+    __Set *p__Set = new (std::nothrow) __Set(*this);
 
     return p__Set;
 }

--- a/cocos/deprecated/CCString.cpp
+++ b/cocos/deprecated/CCString.cpp
@@ -220,7 +220,7 @@ bool __String::isEqual(const Ref* pObject)
 
 __String* __String::create(const std::string& str)
 {
-    __String* ret = new __String(str);
+    __String* ret = new (std::nothrow) __String(str);
     ret->autorelease();
     return ret;
 }

--- a/cocos/deprecated/CCString.h
+++ b/cocos/deprecated/CCString.h
@@ -186,7 +186,7 @@ public:
      * @js NA
      * @lua NA
      */
-    virtual __String* clone() const;
+    virtual __String* clone() const override;
     
 private:
 


### PR DESCRIPTION
I'm sorry I'm not good at express in English well.

When I link my game with cocos2d-x v3.x in Visual C++, they also generate AppName.lib file.
So I analyzed the lib and obj files, it contains the following 4 lines..

/EXPORT:?clone@__Bool@cocos2d@@QBEPAVClonable@2@XZ
/EXPORT:?clone@__Float@cocos2d@@QBEPAVClonable@2@XZ
/EXPORT:?clone@__Double@cocos2d@@QBEPAVClonable@2@XZ
/EXPORT:?clone@__Integer@cocos2d@@QBEPAVClonable@2@XZ

the Demangled name is.. "cocos2d::Clonable\* cocos2d::__Bool::clone() const "
Then I looked the __Bool source code..

"cocos2d::Clonable\* cocos2d::Clonable::clone() const" is pure virtual function..
But the Clonable-derived __Bool class only defined "cocos2d::__Bool\* cocos2d::__Bool::clone() const" doesn't override the Clonable::clone() because return-value is different and virtual" keyword is not specified.
So I just added "virtual" keyword to them, the problems are solved. and then now I added "override" keywords for the coding convention.
