### PR TITLE
Added a mechanism of delayed autorelease for objects created in background threads

### DIFF
--- a/cocos/base/CCAsyncTaskPool.h
+++ b/cocos/base/CCAsyncTaskPool.h
@@ -91,7 +91,21 @@ public:
      */
     template<class F>
     inline void enqueue(TaskType type, const TaskCallBack& callback, void* callbackParam, F&& f);
-    
+
+    /**
+    * Adds an object that will be managed later.
+    *
+    * The object will be added in an array specific to a thread id. The AutoreleasePool will call this method instead of managing the
+    * object directly when called from a thread other than the main one.
+    * Once the task is over and its callback called, it will be put in the autorelease pool in the cocos thread and then autoreleased.
+    *
+    * @param object Object pointer to be added in the managed object list.
+    * @param threadId Thread creating the object, when the current task is over in this thread the objects are autoreleased.
+    * @js  NA
+    * @lua NA
+    */
+    inline void addObject(Ref* object, std::thread::id threadId);
+
 CC_CONSTRUCTOR_ACCESS:
     AsyncTaskPool();
     ~AsyncTaskPool();
@@ -106,48 +120,9 @@ protected:
             void*                 callbackParam;
         };
     public:
-        ThreadTasks()
-        : _stop(false)
-        {
-            _thread = std::thread(
-                                  [this]
-                                  {
-                                      for(;;)
-                                      {
-                                          std::function<void()> task;
-                                          AsyncTaskCallBack callback;
-                                          {
-                                              std::unique_lock<std::mutex> lock(this->_queueMutex);
-                                              this->_condition.wait(lock,
-                                                                    [this]{ return this->_stop || !this->_tasks.empty(); });
-                                              if(this->_stop && this->_tasks.empty())
-                                                  return;
-                                              task = std::move(this->_tasks.front());
-                                              callback = std::move(this->_taskCallBacks.front());
-                                              this->_tasks.pop();
-                                              this->_taskCallBacks.pop();
-                                          }
-                                          
-                                          task();
-                                          Director::getInstance()->getScheduler()->performFunctionInCocosThread([&, callback]{ callback.callback(callback.callbackParam); });
-                                      }
-                                  }
-                                  );
-        }
-        ~ThreadTasks()
-        {
-            {
-                std::unique_lock<std::mutex> lock(_queueMutex);
-                _stop = true;
-                
-                while(_tasks.size())
-                    _tasks.pop();
-                while (_taskCallBacks.size())
-                    _taskCallBacks.pop();
-            }
-            _condition.notify_all();
-            _thread.join();
-        }
+        ThreadTasks();
+        ~ThreadTasks();
+
         void clear()
         {
             std::unique_lock<std::mutex> lock(_queueMutex);
@@ -156,6 +131,7 @@ protected:
             while (_taskCallBacks.size())
                 _taskCallBacks.pop();
         }
+
         template<class F>
         void enqueue(const TaskCallBack& callback, void* callbackParam, F&& f)
         {
@@ -179,8 +155,9 @@ protected:
             }
             _condition.notify_one();
         }
+
     private:
-        
+       
         // need to keep track of thread so we can join them
         std::thread _thread;
         // the task queue
@@ -196,6 +173,11 @@ protected:
     //tasks
     ThreadTasks _threadTasks[int(TaskType::TASK_MAX_TYPE)];
     
+    // The asynchronous release mechanism.
+    std::vector<Ref*> popThreadManagedObjects(std::thread::id threadId);
+    void mergeThreadManagedObjects(const std::vector<Ref*>& objets);
+    std::map<std::thread::id, std::vector<Ref*>> _managedAsyncObjectArrays;
+
     static AsyncTaskPool* s_asyncTaskPool;
 };
 
@@ -213,6 +195,10 @@ inline void AsyncTaskPool::enqueue(AsyncTaskPool::TaskType type, const TaskCallB
     threadTask.enqueue(callback, callbackParam, f);
 }
 
+inline void AsyncTaskPool::addObject(Ref* object, std::thread::id threadId)
+{
+    _managedAsyncObjectArrays[threadId].push_back(object);
+}
 
 NS_CC_END
 // end group

--- a/cocos/base/CCAsyncTaskPool.h
+++ b/cocos/base/CCAsyncTaskPool.h
@@ -92,20 +92,6 @@ public:
     template<class F>
     inline void enqueue(TaskType type, const TaskCallBack& callback, void* callbackParam, F&& f);
 
-    /**
-    * Adds an object that will be managed later.
-    *
-    * The object will be added in an array specific to a thread id. The AutoreleasePool will call this method instead of managing the
-    * object directly when called from a thread other than the main one.
-    * Once the task is over and its callback called, it will be put in the autorelease pool in the cocos thread and then autoreleased.
-    *
-    * @param object Object pointer to be added in the managed object list.
-    * @param threadId Thread creating the object, when the current task is over in this thread the objects are autoreleased.
-    * @js  NA
-    * @lua NA
-    */
-    inline void addObject(Ref* object, std::thread::id threadId);
-
 CC_CONSTRUCTOR_ACCESS:
     AsyncTaskPool();
     ~AsyncTaskPool();
@@ -170,6 +156,21 @@ protected:
         bool _stop;
     };
     
+    /**
+     * Adds an object that will be managed later, to be called by AutoreleasePool.
+     *
+     * The object will be added in an array specific to a thread id. The AutoreleasePool will call this method instead of managing the
+     * object directly when called from a thread other than the main one.
+     * Once the task is over and its callback called, it will be put in the autorelease pool in the cocos thread and then autoreleased.
+     *
+     * @param object Object pointer to be added in the managed object list.
+     * @param threadId Thread creating the object, when the current task is over in this thread the objects are autoreleased.
+     * @js  NA
+     * @lua NA
+     */
+    inline void addObject(Ref* object, std::thread::id threadId);
+    friend class AutoreleasePool;
+
     //tasks
     ThreadTasks _threadTasks[int(TaskType::TASK_MAX_TYPE)];
     

--- a/cocos/base/CCAutoreleasePool.cpp
+++ b/cocos/base/CCAutoreleasePool.cpp
@@ -24,6 +24,8 @@ THE SOFTWARE.
 ****************************************************************************/
 #include "base/CCAutoreleasePool.h"
 #include "base/ccMacros.h"
+#include "base/CCDirector.h"
+#include "base/CCAsyncTaskPool.h"
 
 NS_CC_BEGIN
 
@@ -57,7 +59,17 @@ AutoreleasePool::~AutoreleasePool()
 
 void AutoreleasePool::addObject(Ref* object)
 {
-    _managedObjectArray.push_back(object);
+    auto threadId = std::this_thread::get_id();
+
+    if (Director::getInstance()->getCocos2dThreadId() != threadId)
+    {
+        // Delay the autorelease of this object. It will be autoreleased after the task that added it is done.
+        AsyncTaskPool::getInstance()->addObject(object, threadId);
+    }
+    else
+    {
+        _managedObjectArray.push_back(object);
+    }
 }
 
 void AutoreleasePool::clear()

--- a/cocos/base/CCAutoreleasePool.h
+++ b/cocos/base/CCAutoreleasePool.h
@@ -35,7 +35,6 @@ THE SOFTWARE.
  */
 NS_CC_BEGIN
 
-
 /**
  * A pool for managing autorlease objects.
  * @js NA
@@ -134,7 +133,7 @@ private:
      */
     std::vector<Ref*> _managedObjectArray;
     std::string _name;
-    
+
 #if defined(COCOS2D_DEBUG) && (COCOS2D_DEBUG > 0)
     /**
      *  The flag for checking whether the pool is doing `clear` operation.

--- a/cocos/base/CCDirector.cpp
+++ b/cocos/base/CCDirector.cpp
@@ -113,6 +113,8 @@ bool Director::init(void)
 {
     setDefaultValues();
 
+    _cocos2d_thread_id = std::this_thread::get_id();
+
     // scenes
     _runningScene = nullptr;
     _nextScene = nullptr;
@@ -1316,8 +1318,6 @@ void DisplayLinkDirector::startAnimation()
     }
 
     _invalid = false;
-
-    _cocos2d_thread_id = std::this_thread::get_id();
 
     Application::getInstance()->setAnimationInterval(_animationInterval);
 


### PR DESCRIPTION
With this change, it is now possible to create autorelease objects from the background threads created by the async task pool.
Before this change, they could be released by the autorelease pool (in the main thread) before they could be retained or their reference count incremented (in the background thread).

The change has no impact on objects created from the main thread, it works as before. The only addition is the current thread id check which is performed in negligible time (30 nanoseconds on Windows, 150 nanoseconds on Android - based on 100k checks).

The change was tested on Windows (with Visual Studio and MinGW) and Android.
We don't have access to the other cocos2d-x supported platforms, but nothing in the changeset is platform dependent.
