### PR TITLE
Fix memory leak when initWithImage() failed

### DIFF
--- a/cocos/renderer/CCTextureCache.cpp
+++ b/cocos/renderer/CCTextureCache.cpp
@@ -360,6 +360,8 @@ Texture2D * TextureCache::addImage(const std::string &path)
             else
             {
                 CCLOG("cocos2d: Couldn't create texture for file:%s in TextureCache", path.c_str());
+                CC_SAFE_RELEASE(texture);
+                texture = nullptr;
             }
         } while (0);
     }


### PR DESCRIPTION
There is a memory leak in `TextureCache::addImage()` when `texture->initWithImage(image)` failed.
