### PR TITLE
Add enum value for no key

### DIFF
--- a/cocos/base/CCController.h
+++ b/cocos/base/CCController.h
@@ -56,6 +56,8 @@ public:
      */
     enum Key
     {
+        KEY_NONE = 0,
+        
         JOYSTICK_LEFT_X = 1000,
         JOYSTICK_LEFT_Y,
         JOYSTICK_RIGHT_X,


### PR DESCRIPTION
Add enum value for "none" key just like KEY_NONE in EventKeyboard::KeyCode enum so that you don't have to cast 0 to Controller::Key.
