### PR TITLE
Add 3d touch support to iOS 9.0 or higher version on iPhone6s or later device

### DIFF
--- a/cocos/base/CCTouch.cpp
+++ b/cocos/base/CCTouch.cpp
@@ -70,4 +70,16 @@ Vec2 Touch::getDelta() const
     return getLocation() - getPreviousLocation();
 }
 
+// Returns the current touch force for 3d touch.
+float Touch::getCurrentForce() const
+{
+    return _curForce;
+}
+
+// Returns the maxium touch force for 3d touch.
+float Touch::getMaxForce() const
+{
+    return _maxForce;
+}
+
 NS_CC_END

--- a/cocos/base/CCTouch.cpp
+++ b/cocos/base/CCTouch.cpp
@@ -76,7 +76,7 @@ float Touch::getCurrentForce() const
     return _curForce;
 }
 
-// Returns the maxium touch force for 3d touch.
+// Returns the maximum touch force for 3d touch.
 float Touch::getMaxForce() const
 {
     return _maxForce;

--- a/cocos/base/CCTouch.h
+++ b/cocos/base/CCTouch.h
@@ -57,7 +57,9 @@ public:
      */
     Touch() 
         : _id(0),
-        _startPointCaptured(false)
+        _startPointCaptured(false),
+        _curForce(0.f),
+        _maxForce(0.f)
     {}
 
     /** Returns the current touch location in OpenGL coordinates.
@@ -101,13 +103,17 @@ public:
      * @param id A given id
      * @param x A given x coordinate.
      * @param y A given y coordinate.
+     * @param force Current force for 3d touch.
+     * @param maxForce Maxium possible force for 3d touch.
      */
-    void setTouchInfo(int id, float x, float y)
+    void setTouchInfo(int id, float x, float y, float force = 0.0f, float maxForce = 0.0f)
     {
         _id = id;
         _prevPoint = _point;
         _point.x   = x;
         _point.y   = y;
+        _curForce = force;
+        _maxForce = maxForce;
         if (!_startPointCaptured)
         {
             _startPoint = _point;
@@ -125,6 +131,16 @@ public:
     {
         return _id;
     }
+    /** Returns the current touch force for 3d touch.
+     *
+     * @return The current touch force for 3d touch.
+     */
+    float getCurrentForce() const;
+    /** Returns the maxium touch force for 3d touch.
+     *
+     * @return The maxium touch force for 3d touch.
+     */
+    float getMaxForce() const;
 
 private:
     int _id;
@@ -132,6 +148,8 @@ private:
     Vec2 _startPoint;
     Vec2 _point;
     Vec2 _prevPoint;
+    float _curForce;
+    float _maxForce;
 };
 
 // end of base group

--- a/cocos/base/CCTouch.h
+++ b/cocos/base/CCTouch.h
@@ -103,10 +103,32 @@ public:
      * @param id A given id
      * @param x A given x coordinate.
      * @param y A given y coordinate.
-     * @param force Current force for 3d touch.
-     * @param maxForce Maxium possible force for 3d touch.
      */
-    void setTouchInfo(int id, float x, float y, float force = 0.0f, float maxForce = 0.0f)
+    void setTouchInfo(int id, float x, float y)
+    {
+        _id = id;
+        _prevPoint = _point;
+        _point.x   = x;
+        _point.y   = y;
+        _curForce = 0.0f;
+        _maxForce = 0.0f;
+        if (!_startPointCaptured)
+        {
+            _startPoint = _point;
+            _startPointCaptured = true;
+            _prevPoint = _point;
+        }
+    }
+
+    /** Set the touch information. It always used to monitor touch event.
+     *
+     * @param id A given id
+     * @param x A given x coordinate.
+     * @param y A given y coordinate.
+     * @param force Current force for 3d touch.
+     * @param maxForce maximum possible force for 3d touch.
+     */
+    void setTouchInfo(int id, float x, float y, float force, float maxForce)
     {
         _id = id;
         _prevPoint = _point;
@@ -136,9 +158,9 @@ public:
      * @return The current touch force for 3d touch.
      */
     float getCurrentForce() const;
-    /** Returns the maxium touch force for 3d touch.
+    /** Returns the maximum touch force for 3d touch.
      *
-     * @return The maxium touch force for 3d touch.
+     * @return The maximum touch force for 3d touch.
      */
     float getMaxForce() const;
 

--- a/cocos/platform/CCGLView.cpp
+++ b/cocos/platform/CCGLView.cpp
@@ -317,11 +317,13 @@ void GLView::handleTouchesBegin(int num, intptr_t ids[], float xs[], float ys[])
     dispatcher->dispatchEvent(&touchEvent);
 }
 
-void GLView::handleTouchesMove(int num, intptr_t ids[], float xs[], float ys[])
+void GLView::handleTouchesMove(int num, intptr_t ids[], float xs[], float ys[], float fs[], float ms[])
 {
     intptr_t id = 0;
     float x = 0.0f;
     float y = 0.0f;
+    float force = 0.0f;
+    float maxForce = 0.0f;
     EventTouch touchEvent;
     
     for (int i = 0; i < num; ++i)
@@ -329,6 +331,8 @@ void GLView::handleTouchesMove(int num, intptr_t ids[], float xs[], float ys[])
         id = ids[i];
         x = xs[i];
         y = ys[i];
+        force = fs ? fs[i] : 0.0f;
+        maxForce = ms ? ms[i] : 0.0f;
 
         auto iter = g_touchIdReorderMap.find(id);
         if (iter == g_touchIdReorderMap.end())
@@ -337,12 +341,12 @@ void GLView::handleTouchesMove(int num, intptr_t ids[], float xs[], float ys[])
             continue;
         }
 
-        CCLOGINFO("Moving touches with id: %d, x=%f, y=%f", id, x, y);
+        CCLOGINFO("Moving touches with id: %d, x=%f, y=%f, force=%f, maxFource=%f", id, x, y, force, maxForce);
         Touch* touch = g_touches[iter->second];
         if (touch)
         {
             touch->setTouchInfo(iter->second, (x - _viewPortRect.origin.x) / _scaleX,
-                                (y - _viewPortRect.origin.y) / _scaleY);
+                                (y - _viewPortRect.origin.y) / _scaleY, force, maxForce);
             
             touchEvent._touches.push_back(touch);
         }

--- a/cocos/platform/CCGLView.cpp
+++ b/cocos/platform/CCGLView.cpp
@@ -317,6 +317,11 @@ void GLView::handleTouchesBegin(int num, intptr_t ids[], float xs[], float ys[])
     dispatcher->dispatchEvent(&touchEvent);
 }
 
+void GLView::handleTouchesMove(int num, intptr_t ids[], float xs[], float ys[])
+{
+    handleTouchesMove(num, ids, xs, ys, nullptr, nullptr);
+}
+
 void GLView::handleTouchesMove(int num, intptr_t ids[], float xs[], float ys[], float fs[], float ms[])
 {
     intptr_t id = 0;

--- a/cocos/platform/CCGLView.h
+++ b/cocos/platform/CCGLView.h
@@ -311,8 +311,10 @@ public:
      * @param ids The identity of the touch.
      * @param xs The points of x.
      * @param ys The points of y.
+     * @param fs The force of 3d touches.
+     # @param ms The maxium force of 3d touches
      */
-    virtual void handleTouchesMove(int num, intptr_t ids[], float xs[], float ys[]);
+    virtual void handleTouchesMove(int num, intptr_t ids[], float xs[], float ys[], float fs[] = nullptr, float ms[] = nullptr);
     
     /** Touch events are handled by default; if you want to customize your handlers, please override this function.
      *

--- a/cocos/platform/CCGLView.h
+++ b/cocos/platform/CCGLView.h
@@ -311,10 +311,19 @@ public:
      * @param ids The identity of the touch.
      * @param xs The points of x.
      * @param ys The points of y.
-     * @param fs The force of 3d touches.
-     # @param ms The maxium force of 3d touches
      */
-    virtual void handleTouchesMove(int num, intptr_t ids[], float xs[], float ys[], float fs[] = nullptr, float ms[] = nullptr);
+    virtual void handleTouchesMove(int num, intptr_t ids[], float xs[], float ys[]);
+
+    /** Touch events are handled by default; if you want to customize your handlers, please override this function.
+     *
+     * @param num The number of touch.
+     * @param ids The identity of the touch.
+     * @param xs The points of x.
+     * @param ys The points of y.
+     * @param fs The force of 3d touches.
+     # @param ms The maximum force of 3d touches
+     */
+    virtual void handleTouchesMove(int num, intptr_t ids[], float xs[], float ys[], float fs[], float ms[]);
     
     /** Touch events are handled by default; if you want to customize your handlers, please override this function.
      *

--- a/cocos/platform/ios/CCEAGLView-ios.mm
+++ b/cocos/platform/ios/CCEAGLView-ios.mm
@@ -420,17 +420,27 @@ Copyright (C) 2008 Apple Inc. All Rights Reserved.
     UITouch* ids[IOS_MAX_TOUCHES_COUNT] = {0};
     float xs[IOS_MAX_TOUCHES_COUNT] = {0.0f};
     float ys[IOS_MAX_TOUCHES_COUNT] = {0.0f};
+    float fs[IOS_MAX_TOUCHES_COUNT] = {0.0f};
+    float ms[IOS_MAX_TOUCHES_COUNT] = {0.0f};
     
     int i = 0;
     for (UITouch *touch in touches) {
         ids[i] = touch;
         xs[i] = [touch locationInView: [touch view]].x * self.contentScaleFactor;;
         ys[i] = [touch locationInView: [touch view]].y * self.contentScaleFactor;;
+
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_9_0 // User 9.0 or higher SDK compiled
+        // running on iOS 9.0 or higher version
+        if ([[[UIDevice currentDevice] systemVersion] floatValue] >= 9.0f) {
+            fs[i] = touch.force;
+            ms[i] = touch.maximumPossibleForce;
+        }
+#endif
         ++i;
     }
 
     auto glview = cocos2d::Director::getInstance()->getOpenGLView();
-    glview->handleTouchesMove(i, (intptr_t*)ids, xs, ys);
+    glview->handleTouchesMove(i, (intptr_t*)ids, xs, ys, fs, ms);
 }
 
 - (void)touchesEnded:(NSSet *)touches withEvent:(UIEvent *)event

--- a/cocos/platform/ios/CCEAGLView-ios.mm
+++ b/cocos/platform/ios/CCEAGLView-ios.mm
@@ -429,7 +429,7 @@ Copyright (C) 2008 Apple Inc. All Rights Reserved.
         xs[i] = [touch locationInView: [touch view]].x * self.contentScaleFactor;;
         ys[i] = [touch locationInView: [touch view]].y * self.contentScaleFactor;;
 
-#if __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_9_0 // User 9.0 or higher SDK compiled
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_9_0 // Use 9.0 or higher SDK to compile
         // running on iOS 9.0 or higher version
         if ([[[UIDevice currentDevice] systemVersion] floatValue] >= 9.0f) {
             fs[i] = touch.force;

--- a/tests/cpp-tests/Classes/TouchesTest/TouchesTest.cpp
+++ b/tests/cpp-tests/Classes/TouchesTest/TouchesTest.cpp
@@ -22,6 +22,9 @@ enum
 TouchesTests::TouchesTests()
 {
     ADD_TEST_CASE(PongScene);
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_9_0 // User 9.0 or higher SDK compiled
+    ADD_TEST_CASE(ForceTouchTest);
+#endif
 }
 //------------------------------------------------------------------
 //
@@ -111,3 +114,60 @@ void PongLayer::doStep(float delta)
     else if (_ball->getPosition().y < VisibleRect::bottom().y-_ball->radius())
         resetAndScoreBallForPlayer( kHighPlayer );
 }
+
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_9_0 // User 9.0 or higher SDK compiled
+
+const char * _Info_Formatter = "Current force value : %0.02f, Maxium possible force : %0.02f";
+char formatBuffer[256] = {0, };
+
+ForceTouchTest::ForceTouchTest()
+{
+    auto s = Director::getInstance()->getWinSize();
+
+    _infoLabel = Label::createWithTTF(TTFConfig("fonts/arial.ttf"), "Current force value : 0.00, Maxium possible force : 0.00");
+    _infoLabel->setPosition(s.width / 2, s.height / 2);
+    addChild(_infoLabel);
+
+    auto listener = EventListenerTouchAllAtOnce::create();
+    listener->onTouchesBegan = CC_CALLBACK_2(ForceTouchTest::onTouchesBegan, this);
+    listener->onTouchesMoved = CC_CALLBACK_2(ForceTouchTest::onTouchesMoved, this);
+    listener->onTouchesEnded = CC_CALLBACK_2(ForceTouchTest::onTouchesEnded, this);
+    _eventDispatcher->addEventListenerWithSceneGraphPriority(listener, this);
+}
+
+ForceTouchTest::~ForceTouchTest()
+{
+}
+
+std::string ForceTouchTest::title() const
+{
+    return std::string("3D Touch Test");
+}
+
+std::string ForceTouchTest::subtitle() const
+{
+    return std::string("Touch with force to see info label changes");
+}
+    
+void ForceTouchTest::onTouchesBegan(const std::vector<cocos2d::Touch*>& touches, cocos2d::Event* event)
+{
+}
+
+void ForceTouchTest::onTouchesMoved(const std::vector<cocos2d::Touch*>& touches, cocos2d::Event* event)
+{
+    for(auto& t : touches)
+    {
+        float currentForce = t->getCurrentForce();
+        float maxForce = t->getMaxForce();
+        sprintf(formatBuffer, _Info_Formatter, currentForce, maxForce);
+        _infoLabel->setString(std::string(formatBuffer));
+    }
+}
+
+void ForceTouchTest::onTouchesEnded(const std::vector<cocos2d::Touch*>& touches, cocos2d::Event* event)
+{
+    sprintf(formatBuffer, _Info_Formatter, 0.0f, 0.0f);
+    _infoLabel->setString(std::string(formatBuffer));
+}
+
+#endif

--- a/tests/cpp-tests/Classes/TouchesTest/TouchesTest.cpp
+++ b/tests/cpp-tests/Classes/TouchesTest/TouchesTest.cpp
@@ -22,7 +22,7 @@ enum
 TouchesTests::TouchesTests()
 {
     ADD_TEST_CASE(PongScene);
-#if __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_9_0 // User 9.0 or higher SDK compiled
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_9_0 // Use 9.0 or higher SDK to compile
     ADD_TEST_CASE(ForceTouchTest);
 #endif
 }
@@ -115,16 +115,16 @@ void PongLayer::doStep(float delta)
         resetAndScoreBallForPlayer( kHighPlayer );
 }
 
-#if __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_9_0 // User 9.0 or higher SDK compiled
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_9_0 // Use 9.0 or higher SDK to compile
 
-const char * _Info_Formatter = "Current force value : %0.02f, Maxium possible force : %0.02f";
+const char * _Info_Formatter = "Current force value : %0.02f, maximum possible force : %0.02f";
 char formatBuffer[256] = {0, };
 
 ForceTouchTest::ForceTouchTest()
 {
     auto s = Director::getInstance()->getWinSize();
 
-    _infoLabel = Label::createWithTTF(TTFConfig("fonts/arial.ttf"), "Current force value : 0.00, Maxium possible force : 0.00");
+    _infoLabel = Label::createWithTTF(TTFConfig("fonts/arial.ttf"), "Current force value : 0.00, maximum possible force : 0.00");
     _infoLabel->setPosition(s.width / 2, s.height / 2);
     addChild(_infoLabel);
 

--- a/tests/cpp-tests/Classes/TouchesTest/TouchesTest.h
+++ b/tests/cpp-tests/Classes/TouchesTest/TouchesTest.h
@@ -31,7 +31,7 @@ public:
     void doStep(float delta);
 };
 
-#if __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_9_0 // User 9.0 or higher SDK compiled
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_9_0 // Use 9.0 or higher SDK to compile
 class ForceTouchTest : public TestCase
 {
 public:

--- a/tests/cpp-tests/Classes/TouchesTest/TouchesTest.h
+++ b/tests/cpp-tests/Classes/TouchesTest/TouchesTest.h
@@ -31,4 +31,25 @@ public:
     void doStep(float delta);
 };
 
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_9_0 // User 9.0 or higher SDK compiled
+class ForceTouchTest : public TestCase
+{
+public:
+    CREATE_FUNC(ForceTouchTest);
+    
+    virtual std::string title() const override;
+    virtual std::string subtitle() const override;
+
+    void onTouchesBegan(const std::vector<cocos2d::Touch*>& touches, cocos2d::Event* event);
+    void onTouchesMoved(const std::vector<cocos2d::Touch*>& touches, cocos2d::Event* event);
+    void onTouchesEnded(const std::vector<cocos2d::Touch*>& touches, cocos2d::Event* event);
+    
+protected:
+    ForceTouchTest();
+    virtual ~ForceTouchTest();
+
+    cocos2d::Label * _infoLabel;
+};
+#endif
+
 #endif

--- a/tests/js-tests/src/EventTest/EventTest.js
+++ b/tests/js-tests/src/EventTest/EventTest.js
@@ -253,7 +253,9 @@ var TouchAllAtOnce = EventTest.extend({
             var touch = touches[i];
             var pos = touch.getLocation();
             var id = touch.getID();
-            cc.log("Touch #" + i + ". onTouchesMoved at: " + pos.x + " " + pos.y + " Id:" + id);
+            var force = touch.getCurrentForce();
+            var maxForce = touch.getMaxForce();
+            cc.log("Touch #" + i + ". onTouchesMoved at: " + pos.x + " " + pos.y + " Id:" + id + " current force:" + force + " Maxium postible force:" + maxForce);
             target.update_id(id, pos);
         }
     },

--- a/tests/js-tests/src/EventTest/EventTest.js
+++ b/tests/js-tests/src/EventTest/EventTest.js
@@ -255,7 +255,7 @@ var TouchAllAtOnce = EventTest.extend({
             var id = touch.getID();
             var force = touch.getCurrentForce();
             var maxForce = touch.getMaxForce();
-            cc.log("Touch #" + i + ". onTouchesMoved at: " + pos.x + " " + pos.y + " Id:" + id + " current force:" + force + " Maxium postible force:" + maxForce);
+            cc.log("Touch #" + i + ". onTouchesMoved at: " + pos.x + " " + pos.y + " Id:" + id + " current force:" + force + " maximum postible force:" + maxForce);
             target.update_id(id, pos);
         }
     },

--- a/tests/lua-tests/src/NewEventDispatcherTest/NewEventDispatcherTest.lua
+++ b/tests/lua-tests/src/NewEventDispatcherTest/NewEventDispatcherTest.lua
@@ -818,7 +818,16 @@ function RemoveAndRetainNodeTest:onEnter()
         local target = event:getCurrentTarget()
         local posX,posY = target:getPosition()
         local delta = touch:getDelta()
-        target:setPosition(cc.p(posX + delta.x, posY + delta.y))
+        local force = touch:getCurrentForce()
+        local maxForce = touch:getMaxForce()
+        if force > 0.0 and (force / maxForce) > 0.8 then
+            local origin = cc.Director:getInstance():getVisibleOrigin()
+            local size = cc.Director:getInstance():getVisibleSize()
+            target:setPosition(cc.p(origin.x + size.width/2, origin.y + size.height/2))
+            print(string.format("3D touch detected, reset to default position. force = %f, max force = %f", force, maxForce))
+        else
+            target:setPosition(cc.p(posX + delta.x, posY + delta.y))
+        end
     end
 
     local function onTouchEnded(touch,event)


### PR DESCRIPTION
Test case:
cpp - 64:Touches->2:3D Touch Test : see information lable
js  - Event Test -> Touch all at once : see log in console
lua - NewEventDispatcherTest -> RemoveAndRetainNodeTest : When presser more than 80% of max, will reset sprite position and log info.

@ricardoquesada @pandamicro Please review this PR.
