### PR TITLE
Fix Downloader bug iOS & Android

### DIFF
--- a/cocos/network/CCDownloader-android.cpp
+++ b/cocos/network/CCDownloader-android.cpp
@@ -70,7 +70,7 @@ namespace cocos2d { namespace network {
             if (JniHelper::getStaticMethodInfo(methodInfo,
                                                JCLS_DOWNLOADER,
                                                "createDownloader",
-                                               "(II" JARG_STR ")" JARG_DOWNLOADER))
+                                               "(II" JARG_STR "I)" JARG_DOWNLOADER))
             {
                 jobject jStr = methodInfo.env->NewStringUTF(hints.tempFileNameSuffix.c_str());
                 jobject jObj = methodInfo.env->CallStaticObjectMethod(
@@ -78,7 +78,8 @@ namespace cocos2d { namespace network {
                         methodInfo.methodID,
                         _id,
                         hints.timeoutInSeconds,
-                        jStr
+                        jStr,
+                        hints.countOfMaxProcessingTasks
                 );
                 _impl = methodInfo.env->NewGlobalRef(jObj);
                 DLLOG("android downloader: jObj: %p, _impl: %p", jObj, _impl);


### PR DESCRIPTION
## Problem

After upgrading my employer's game from Cocos2d-x 3.8.1 to 3.9, the AssetManagerEx failed to work properly. After some investigation I fixed 2 bugs that lies in the new iOS & Android native Downloaders. 

The game involved has 3000+ asset files managed by the AssetManagerEx.
### iOS https://github.com/cezheng/cocos2d-x/commit/ecf94a3dc4fbfd3e9764021657713ec21a527e4d

Upon calling NSURLSessionDownloadTask's resume, the task's timeout
countdown starts. When the AssetManagerEx starts downloading, it creates
all the tasks all at once and just `resume` upon creation. When the
number of asset files is very large, later tasks tend to end up in
'request timed out -1001' error before they can even start downloading.
This commit adds a buffer queue to prevent all the NSURLSessionTasks to
start all at once.

> Without this fix, our game was able to download 1200 of the 3000+ files(which means in the default timeout setting, we were able to download 1200 files while the other 2000 files timedout without even starting)
### Android https://github.com/cezheng/cocos2d-x/commit/d174a98afa20abf1e6c949d1571c966af977d4d8

When the AssetManagerEx start downloading, it used to create all the
download tasks all at once. When the app has a large number of asset
files, it is likely to crash due to out of memory when creating threads
for each of the download tasks. This commit adds a buffer queue to the
downloader to use the `countOfMaxProcessingTasks` property from hints,
preventing all the tasks from starting all at once.

> Without this fix, the downloader seems to be creating a lot of threads all at once causing out of memory error.
