### PR TITLE
Add missing header

### DIFF
--- a/cocos/base/allocator/CCAllocatorStrategyDefault.h
+++ b/cocos/base/allocator/CCAllocatorStrategyDefault.h
@@ -27,6 +27,7 @@
 #define CC_ALLOCATOR_STRATEGY_DEFAULT_H
 /// @cond DO_NOT_SHOW
 
+#include <stdlib.h>
 #include "base/allocator/CCAllocatorMacros.h"
 #include "base/allocator/CCAllocatorBase.h"
 


### PR DESCRIPTION
This commit fixes the following compile error on Linux clang 3.7

```
In file included from /home/user/local/cocos2d-x/cocos/base/allocator/CCAllocatorGlobal.h:31:
/home/user/local/cocos2d-x/cocos/base/allocator/CCAllocatorStrategyDefault.h:45:16: error: use of undeuserred identifier 'malloc'
        return malloc(size);
               ^
/home/user/local/cocos2d-x/cocos/base/allocator/CCAllocatorStrategyDefault.h:51:13: error: use of undeuserred identifier 'free'
            free(address);
            ^
```
