### PR TITLE
Fix deprecation warning in SkeletonRenderer

### DIFF
--- a/cocos/editor-support/spine/SkeletonRenderer.cpp
+++ b/cocos/editor-support/spine/SkeletonRenderer.cpp
@@ -70,7 +70,7 @@ void SkeletonRenderer::initialize () {
 	_blendFunc = BlendFunc::ALPHA_PREMULTIPLIED;
 	setOpacityModifyRGB(true);
 
-	setGLProgram(ShaderCache::getInstance()->getGLProgram(GLProgram::SHADER_NAME_POSITION_TEXTURE_COLOR));
+	setGLProgram(GLProgramCache::getInstance()->getGLProgram(GLProgram::SHADER_NAME_POSITION_TEXTURE_COLOR));
 }
 
 void SkeletonRenderer::setSkeletonData (spSkeletonData *skeletonData, bool ownsSkeletonData) {


### PR DESCRIPTION
This fixes the following warning about deprecated use of `ShaderCache`:

```
cocos2d-x/cocos/editor-support/spine/SkeletonRenderer.cpp:73:26: 'ShaderCache' is deprecated
```
