### PR TITLE
Fix Sprite3D::setMaterial when multiple meshes exist

### DIFF
--- a/cocos/3d/CCSprite3D.cpp
+++ b/cocos/3d/CCSprite3D.cpp
@@ -457,9 +457,9 @@ void Sprite3D::setMaterial(Material *material, int meshIndex)
 
     if (meshIndex == -1)
     {
-        for (auto mesh: _meshes)
+        for (size_t i = 0; i < _meshes.size(); i++)
         {
-            mesh->setMaterial(material);
+            _meshes.at(i)->setMaterial(i == 0 ? material : material->clone());
         }
     }
     else


### PR DESCRIPTION
Each mesh should have its own material.
