### PR TITLE
Fix deprecation warnings in PU

### DIFF
--- a/extensions/Particle3D/PU/CCPUBillboardChain.cpp
+++ b/extensions/Particle3D/PU/CCPUBillboardChain.cpp
@@ -734,9 +734,9 @@ void PUBillboardChain::setBlendFunc(const BlendFunc& blendFunc)
 
 GLuint PUBillboardChain::getTextureName()
 {
-    if (TextureCache::getInstance()->isDirty())
+    if (Director::getInstance()->getTextureCache()->isDirty())
     {
-        if (TextureCache::getInstance()->getTextureForKey(_texFile) == nullptr)
+        if (Director::getInstance()->getTextureCache()->getTextureForKey(_texFile) == nullptr)
         {
             _texture = nullptr;
             this->init("");

--- a/extensions/Particle3D/PU/CCPURender.cpp
+++ b/extensions/Particle3D/PU/CCPURender.cpp
@@ -589,9 +589,9 @@ bool PUParticle3DEntityRender::initRender( const std::string &texFile )
 
 GLuint PUParticle3DEntityRender::getTextureName()
 {
-    if (TextureCache::getInstance()->isDirty())
+    if (Director::getInstance()->getTextureCache()->isDirty())
     {
-        if (TextureCache::getInstance()->getTextureForKey(_texFile) == nullptr)
+        if (Director::getInstance()->getTextureCache()->getTextureForKey(_texFile) == nullptr)
         {
             _texture = nullptr;
             this->initRender("");


### PR DESCRIPTION
This patch fixes the following warnings when compiling with Xcode 7:

```
extensions/Particle3D/PU/CCPUBillboardChain.cpp:737:23: 'getInstance' is deprecated
extensions/Particle3D/PU/CCPUBillboardChain.cpp:739:27: 'getInstance' is deprecated
extensions/Particle3D/PU/CCPURender.cpp:592:23: 'getInstance' is deprecated
extensions/Particle3D/PU/CCPURender.cpp:594:27: 'getInstance' is deprecated
```
