### PR TITLE
Fixes #14589 allocation issue with remote images

### DIFF
--- a/cocos/scripting/js-bindings/manual/extension/jsb_cocos2dx_extension_manual.cpp
+++ b/cocos/scripting/js-bindings/manual/extension/jsb_cocos2dx_extension_manual.cpp
@@ -872,16 +872,19 @@ void __JSDownloaderDelegator::startDownload()
         _downloader->onDataTaskSuccess = [this](const cocos2d::network::DownloadTask& task,
                                                 std::vector<unsigned char>& data)
         {
-            Image img;
+            Image* img = new (std::nothrow) Image();
             Texture2D *tex = nullptr;
             do
             {
-                if (false == img.initWithImageData(data.data(), data.size()))
+                if (false == img->initWithImageData(data.data(), data.size()))
                 {
                     break;
                 }
-                tex = Director::getInstance()->getTextureCache()->addImage(&img, _url);
+                tex = Director::getInstance()->getTextureCache()->addImage(img, _url);
             } while (0);
+            
+            CC_SAFE_RELEASE(img);
+            
             if (tex)
             {
                 this->onSuccess(tex);


### PR DESCRIPTION
Fix for #14589 - this change allocates a remotely downloaded image on the heap before adding to the texture cache.

Without this change, I see a crash (on Android) after removing the downloaded image from the texture cache. I do not have a test case that reproduces the crash, its hard to isolate from everything thats going on in my game, but it may be during cleanup of a widget that is using the offending texture. This is the crash dump:

`Stack frame #00  pc 01282b20  /data/app-lib/co.superlive.battlestars-88/libcocos2djs.so (cocos2d::ui::Widget::~Widget()+344): Routine cocos2d::ui::Widget::~Widget() at /Users/pan/Superlive/Workspace/battlestars-x/frameworks/runtime-src/proj.android-studio/../../cocos2d-x/cocos/ui/UIWidget.cpp:177
Stack frame #01  pc 0000dd57  /system/lib/libc.so (free+10)`

In any case I believe the change I am proposing here is more consistent with the rest of the codebase for how images are allocated and added to the texture cache, e.g. 
https://github.com/cocos2d/cocos2d-x/blob/v3/cocos/renderer/CCTextureCache.cpp#L793
