### PR TITLE
Refactored Cocos2dxDownloader

### DIFF
--- a/cocos/network/CCDownloader-android.cpp
+++ b/cocos/network/CCDownloader-android.cpp
@@ -67,13 +67,13 @@ namespace cocos2d { namespace network {
         {
             DLLOG("Construct DownloaderAndroid: %p", this);
             JniMethodInfo methodInfo;
-            if (JniHelper::getStaticMethodInfo(methodInfo,
-                                               JCLS_DOWNLOADER,
-                                               "createDownloader",
-                                               "(II" JARG_STR "I)" JARG_DOWNLOADER))
+            if (JniHelper::getMethodInfo(methodInfo,
+                                         JCLS_DOWNLOADER,
+                                         "<init>",
+                                         "(II" JARG_STR "I)V"))
             {
                 jobject jStr = methodInfo.env->NewStringUTF(hints.tempFileNameSuffix.c_str());
-                jobject jObj = methodInfo.env->CallStaticObjectMethod(
+                jobject jObj = methodInfo.env->NewObject(
                         methodInfo.classID,
                         methodInfo.methodID,
                         _id,
@@ -95,15 +95,14 @@ namespace cocos2d { namespace network {
             if(_impl != nullptr)
             {
                 JniMethodInfo methodInfo;
-                if (JniHelper::getStaticMethodInfo(methodInfo,
-                                                   JCLS_DOWNLOADER,
-                                                   "cancelAllRequests",
-                                                   "(" JARG_DOWNLOADER ")V"))
+                if (JniHelper::getMethodInfo(methodInfo,
+                                             JCLS_DOWNLOADER,
+                                             "cancelAllRequests",
+                                             "(V)V"))
                 {
-                    methodInfo.env->CallStaticVoidMethod(
-                            methodInfo.classID,
-                            methodInfo.methodID,
-                            _impl
+                    methodInfo.env->CallVoidMethod(
+                            _impl,
+                            methodInfo.methodID
                     );
                     methodInfo.env->DeleteLocalRef(methodInfo.classID);
                 }
@@ -119,14 +118,14 @@ namespace cocos2d { namespace network {
             coTask->task = task;
 
             JniMethodInfo methodInfo;
-            if (JniHelper::getStaticMethodInfo(methodInfo,
-                                               JCLS_DOWNLOADER,
-                                               "createTask",
-                                               "(" JARG_DOWNLOADER "I" JARG_STR JARG_STR")V"))
+            if (JniHelper::getMethodInfo(methodInfo,
+                                         JCLS_DOWNLOADER,
+                                         "createTask",
+                                         "(I" JARG_STR JARG_STR")V"))
             {
                 jstring jstrURL = methodInfo.env->NewStringUTF(task->requestURL.c_str());
                 jstring jstrPath= methodInfo.env->NewStringUTF(task->storagePath.c_str());
-                methodInfo.env->CallStaticVoidMethod(methodInfo.classID, methodInfo.methodID, _impl, coTask->id, jstrURL, jstrPath);
+                methodInfo.env->CallVoidMethod( _impl, methodInfo.methodID, coTask->id, jstrURL, jstrPath);
                 methodInfo.env->DeleteLocalRef(jstrURL);
                 methodInfo.env->DeleteLocalRef(jstrPath);
                 methodInfo.env->DeleteLocalRef(methodInfo.classID);

--- a/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxDownloader.java
+++ b/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxDownloader.java
@@ -1,317 +1,300 @@
 package org.cocos2dx.lib;
 
+import java.io.File;
+import java.util.LinkedList;
+import java.util.Queue;
+
+import org.apache.http.Header;
+import org.apache.http.message.BasicHeader;
+
 import com.loopj.android.http.AsyncHttpClient;
-import com.loopj.android.http.AsyncHttpResponseHandler;
 import com.loopj.android.http.BinaryHttpResponseHandler;
 import com.loopj.android.http.FileAsyncHttpResponseHandler;
 import com.loopj.android.http.RequestHandle;
 
 import android.util.SparseArray;
 
-import org.apache.http.Header;
-import org.apache.http.message.BasicHeader;
-
-import java.io.File;
-import java.util.*;
-
-class DataTaskHandler extends BinaryHttpResponseHandler {
-    int _id;
-    private Cocos2dxDownloader _downloader;
-    private long _lastBytesWritten;
-
-    void LogD(String msg) {
-        android.util.Log.d("Cocos2dxDownloader", msg);
-    }
-
-    public DataTaskHandler(Cocos2dxDownloader downloader, int id) {
-        super(new String[]{".*"});
-        _downloader = downloader;
-        _id = id;
-        _lastBytesWritten = 0;
-    }
-
-    @Override
-    public void onProgress(long bytesWritten, long totalSize) {
-        //LogD("onProgress(bytesWritten:" + bytesWritten + " totalSize:" + totalSize);
-        long dlBytes = bytesWritten - _lastBytesWritten;
-        long dlNow = bytesWritten;
-        long dlTotal = totalSize;
-        _downloader.onProgress(_id, dlBytes, dlNow, dlTotal);
-        _lastBytesWritten = bytesWritten;
-    }
-
-    @Override
-    public void onStart() {
-        _downloader.onStart(_id);
-    }
-
-    @Override
-    public void onFailure(int i, Header[] headers, byte[] errorResponse, Throwable throwable) {
-        LogD("onFailure(i:" + i + " headers:" + headers + " throwable:" + throwable);
-        String errStr = "";
-        if (null != throwable) {
-            errStr = throwable.toString();
-        }
-        _downloader.onFinish(_id, i, errStr, null);
-    }
-
-    @Override
-    public void onSuccess(int i, Header[] headers, byte[] binaryData) {
-        LogD("onSuccess(i:" + i + " headers:" + headers);
-        _downloader.onFinish(_id, 0, null, binaryData);
-    }
-}
-
-class FileTaskHandler extends FileAsyncHttpResponseHandler {
-    int _id;
-    File _finalFile;
-
-    private long _initFileLen;
-    private long _lastBytesWritten;
-    private Cocos2dxDownloader _downloader;
-
-    void LogD(String msg) {
-        android.util.Log.d("Cocos2dxDownloader", msg);
-    }
-
-    public FileTaskHandler(Cocos2dxDownloader downloader, int id, File temp, File finalFile) {
-        super(temp, true);
-        _finalFile = finalFile;
-        _downloader = downloader;
-        _id = id;
-        _initFileLen = getTargetFile().length();
-        _lastBytesWritten = 0;
-    }
-
-    @Override
-    public void onProgress(long bytesWritten, long totalSize) {
-        //LogD("onProgress(bytesWritten:" + bytesWritten + " totalSize:" + totalSize);
-        long dlBytes = bytesWritten - _lastBytesWritten;
-        long dlNow = bytesWritten + _initFileLen;
-        long dlTotal = totalSize + _initFileLen;
-        _downloader.onProgress(_id, dlBytes, dlNow, dlTotal);
-        _lastBytesWritten = bytesWritten;
-    }
-
-    @Override
-    public void onStart() {
-        _downloader.onStart(_id);
-    }
-
-    @Override
-    public void onFinish() {
-        // onFinish called after onSuccess/onFailure
-        Runnable taskRunnable = _downloader.dequeue();
-        if (taskRunnable != null) {
-            Cocos2dxHelper.getActivity().runOnUiThread(taskRunnable);
-        }
-    }
-
-    @Override
-    public void onFailure(int i, Header[] headers, Throwable throwable, File file) {
-        LogD("onFailure(i:" + i + " headers:" + headers + " throwable:" + throwable + " file:" + file);
-        String errStr = "";
-        if (null != throwable) {
-            errStr = throwable.toString();
-        }
-        _downloader.onFinish(_id, i, errStr, null);
-    }
-
-    @Override
-    public void onSuccess(int i, Header[] headers, File file) {
-        LogD("onSuccess(i:" + i + " headers:" + headers + " file:" + file);
-        String errStr = null;
-        do {
-            // rename temp file to final file
-            // if final file exist, remove it
-            if (_finalFile.exists()) {
-                if (_finalFile.isDirectory()) {
-                    errStr = "Dest file is directory:" + _finalFile.getAbsolutePath();
-                    break;
-                }
-                if (false == _finalFile.delete()) {
-                    errStr = "Can't remove old file:" + _finalFile.getAbsolutePath();
-                    break;
-                }
-            }
-
-            File tempFile = getTargetFile();
-            tempFile.renameTo(_finalFile);
-        } while (false);
-        _downloader.onFinish(_id, 0, errStr, null);
-    }
-}
-
-class DownloadTask {
-
-    DownloadTask() {
-        handle = null;
-        handler = null;
-        resetStatus();
-    }
-
-    void resetStatus() {
-        bytesReceived = 0;
-        totalBytesReceived = 0;
-        totalBytesExpected = 0;
-        data = null;
-    }
-
-    RequestHandle handle;
-    AsyncHttpResponseHandler handler;
-
-    // progress
-    long bytesReceived;
-    long totalBytesReceived;
-    long totalBytesExpected;
-    byte[] data;
-
-}
-
 public class Cocos2dxDownloader {
     private int _id;
-    private AsyncHttpClient _httpClient = new AsyncHttpClient();
+    private AsyncHttpClient _httpClient;
     private String _tempFileNameSufix;
     private int _countOfMaxProcessingTasks;
-    private SparseArray<DownloadTask> _taskMap = new SparseArray<DownloadTask>();
-    private Queue<Runnable> _taskQueue = new LinkedList<Runnable>();
+    private Queue<Runnable> _taskQueue;
 
-    void onProgress(final int id, final long downloadBytes, final long downloadNow, final long downloadTotal) {
-        DownloadTask task = _taskMap.get(id);
-        if (null != task) {
-            task.bytesReceived = downloadBytes;
-            task.totalBytesReceived = downloadNow;
-            task.totalBytesExpected = downloadTotal;
-        }
-        Cocos2dxHelper.runOnGLThread(new Runnable() {
-            @Override
-            public void run() {
-                nativeOnProgress(_id, id, downloadBytes, downloadNow, downloadTotal);
-            }
-        });
+    private SparseArray<RequestHandle> taskHandles;
+
+    static {
+	AsyncHttpClient.allowRetryExceptionClass(javax.net.ssl.SSLException.class);
+    }
+
+    @Deprecated
+    public Cocos2dxDownloader() {
+    }
+    public Cocos2dxDownloader(int id, int timeoutInSeconds, String tempFileNameSufix, int countOfMaxProcessingTasks) {
+	_id = id;
+
+	_httpClient = new AsyncHttpClient();
+	_httpClient.setEnableRedirects(true);
+	if (timeoutInSeconds > 0) {
+	    _httpClient.setTimeout(timeoutInSeconds * 1000);
+	}
+
+	_tempFileNameSufix = tempFileNameSufix;
+	_countOfMaxProcessingTasks = countOfMaxProcessingTasks;
+
+	_taskQueue = new LinkedList<Runnable>();
+
+	taskHandles = new SparseArray<RequestHandle>();
     }
 
     public void onStart(int id) {
-        DownloadTask task = _taskMap.get(id);
-        if (null != task) {
-            task.resetStatus();
-        }
     }
 
-    public void onFinish(final int id, final int errCode, final String errStr, final byte[] data) {
-        DownloadTask task = _taskMap.get(id);
-        if (null == task) return;
-        _taskMap.remove(id);
-        Cocos2dxHelper.runOnGLThread(new Runnable() {
-            @Override
-            public void run() {
-                nativeOnFinish(_id, id, errCode, errStr, data);
-            }
-        });
+    void onProgress(final int taskID, final long downloadBytes, final long downloadNow, final long downloadTotal) {
+	Cocos2dxHelper.runOnGLThread(new Runnable() {
+	    @Override
+	    public void run() {
+		nativeOnProgress(_id, taskID, downloadBytes, downloadNow, downloadTotal);
+	    }
+	});
     }
 
+    public void onFinish(final int taskID, final int errCode, final String errStr, final byte[] data) {
+	RequestHandle handle = taskHandles.get(taskID);
+	if (handle != null) {
+	    taskHandles.remove(taskID);
+	}
+	Cocos2dxHelper.runOnGLThread(new Runnable() {
+	    @Override
+	    public void run() {
+		nativeOnFinish(_id, taskID, errCode, errStr, data);
+	    }
+	});
+    }
+
+    @Deprecated
     public static Cocos2dxDownloader createDownloader(int id, int timeoutInSeconds, String tempFileNameSufix, int countOfMaxProcessingTasks) {
-        Cocos2dxDownloader downloader = new Cocos2dxDownloader();
-        downloader._id = id;
-
-        downloader._httpClient.setEnableRedirects(true);
-        if (timeoutInSeconds > 0) {
-            downloader._httpClient.setTimeout(timeoutInSeconds * 1000);
-        }
-        // downloader._httpClient.setMaxRetriesAndTimeout(3, timeoutInSeconds * 1000);
-        AsyncHttpClient.allowRetryExceptionClass(javax.net.ssl.SSLException.class);
-
-        downloader._tempFileNameSufix = tempFileNameSufix;
-        downloader._countOfMaxProcessingTasks = countOfMaxProcessingTasks;
-        return downloader;
+	return new Cocos2dxDownloader(id, timeoutInSeconds, tempFileNameSufix, countOfMaxProcessingTasks);
     }
 
-    public static void createTask(final Cocos2dxDownloader downloader, int id_, String url_, String path_) {
-        final int id = id_;
-        final String url = url_;
-        final String path = path_;
+    public void createTask(final int taskID, final String url, final String path) {
+	Runnable taskRunnable = new Runnable() {
+	    @Override
+	    public void run() {
+		RequestHandle handle;
 
-        Runnable taskRunnable = new Runnable() {
-            @Override
-            public void run() {
-                DownloadTask task = new DownloadTask();
-                if (0 == path.length()) {
-                    // data task
-                    task.handler = new DataTaskHandler(downloader, id);
-                    task.handle = downloader._httpClient.get(Cocos2dxHelper.getActivity(), url, task.handler);
-                }
+		if (0 == path.length()) {
+		    // data task
+		    DataTaskHandler handler = new DataTaskHandler(taskID);
+		    handle = _httpClient.get(Cocos2dxHelper.getActivity(), url, handler);
+		} else {
+		    // file task
+		    File tempFile = new File(path + _tempFileNameSufix);
+		    if (tempFile.isDirectory()) {
+			final String errStr = "Can't create DownloadTask for " + url + ". Unable to create temp file: " + tempFile;
+			Cocos2dxHelper.runOnGLThread(new Runnable() {
+			    @Override
+			    public void run() {
+				nativeOnFinish(_id, taskID, 0, errStr, null);
+			    }
+			});
+			return;
+		    }
 
-                do {
-                    if (0 == path.length()) break;
-                    // file task
-                    File tempFile = new File(path + downloader._tempFileNameSufix);
-                    if (tempFile.isDirectory()) break;
+		    File parent = tempFile.getParentFile();
+		    if (!parent.isDirectory() && !parent.mkdirs()) {
+			final String errStr = "Can't create DownloadTask for " + url + ". Unable to create temp file directory: " + parent;
+			Cocos2dxHelper.runOnGLThread(new Runnable() {
+			    @Override
+			    public void run() {
+				nativeOnFinish(_id, taskID, 0, errStr, null);
+			    }
+			});
+			return;
+		    }
 
-                    File parent = tempFile.getParentFile();
-                    if (!parent.isDirectory() && !parent.mkdirs()) break;
+		    File finalFile = new File(path);
+		    if (finalFile.isDirectory()) {
+			final String errStr = "Can't create DownloadTask for " + url + ". Unable to create file: " + finalFile;
+			Cocos2dxHelper.runOnGLThread(new Runnable() {
+			    @Override
+			    public void run() {
+				nativeOnFinish(_id, taskID, 0, errStr, null);
+			    }
+			});
+			return;
+		    }
 
-                    File finalFile = new File(path);
-                    if (tempFile.isDirectory()) break;
+		    FileTaskHandler handler = new FileTaskHandler(taskID, tempFile, finalFile);
+		    Header[] headers = null;
+		    long fileLen = tempFile.length();
+		    if (fileLen > 0) {
+			// continue download
+			headers = new Header[1];
+			headers[0] = new BasicHeader("Range", "bytes=" + fileLen + "-");
+		    }
+		    handle = _httpClient.get(Cocos2dxHelper.getActivity(), url, headers, null, handler);
+		    //task.handle = downloader._httpClient.get(url, task.handler);
+		}
 
-                    task.handler = new FileTaskHandler(downloader, id, tempFile, finalFile);
-                    Header[] headers = null;
-                    long fileLen = tempFile.length();
-                    if (fileLen > 0) {
-                        // continue download
-                        List<Header> list = new ArrayList<Header>();
-                        list.add(new BasicHeader("Range", "bytes=" + fileLen + "-"));
-                        headers = list.toArray(new Header[list.size()]);
-                    }
-                    task.handle = downloader._httpClient.get(Cocos2dxHelper.getActivity(), url, headers, null, task.handler);
-                    //task.handle = downloader._httpClient.get(url, task.handler);
-                } while (false);
-
-                if (null == task.handle) {
-                    final String errStr = "Can't create DownloadTask for " + url;
-                    Cocos2dxHelper.runOnGLThread(new Runnable() {
-                        @Override
-                        public void run() {
-                            downloader.nativeOnFinish(downloader._id, id, 0, errStr, null);
-                        }
-                    });
-                } else {
-                    downloader._taskMap.put(id, task);
-                }
-            }
-        };
-        if (downloader._taskQueue.size() < downloader._countOfMaxProcessingTasks) {
-            Cocos2dxHelper.getActivity().runOnUiThread(taskRunnable);
-            downloader._taskQueue.add(null);
-        } else {
-            downloader._taskQueue.add(taskRunnable);
-        }
+		taskHandles.put(taskID, handle);
+	    }
+	};
+	if (_taskQueue.size() < _countOfMaxProcessingTasks) {
+	    Cocos2dxHelper.getActivity().runOnUiThread(taskRunnable);
+	} else {
+	    _taskQueue.add(taskRunnable);
+	}
+    }
+    @Deprecated
+    public static void createTask(final Cocos2dxDownloader downloader, final int taskID, final String url, final String path) {
+	downloader.createTask(taskID, url, path);
     }
 
+    public void cancelAllRequests() {
+	Cocos2dxHelper.getActivity().runOnUiThread(new Runnable() {
+	    @Override
+	    public void run() {
+		int s = taskHandles.size();
+		for (int i = 0; i < s; i++) {
+		    RequestHandle handle = taskHandles.valueAt(i);
+		    if (handle != null) {
+			handle.cancel(true);
+		    }
+		}
+	    }
+	});
+    }
+    @Deprecated
     public static void cancelAllRequests(final Cocos2dxDownloader downloader) {
-        Cocos2dxHelper.getActivity().runOnUiThread(new Runnable() {
-            @Override
-            public void run() {
-                int s = downloader._taskMap.size();
-                for (int i = 0; i < s; i++) {
-                    DownloadTask task = downloader._taskMap.valueAt(i);
-                    if (task.handle != null) {
-                	task.handle.cancel(true);
-                    }
-                }
-            }
-        });
-    }
-
-    public Runnable dequeue() {
-        if (!_taskQueue.isEmpty() && _taskQueue.element() == null) {
-            _taskQueue.remove();
-        }
-        if (!_taskQueue.isEmpty()) {
-            return _taskQueue.remove();
-        }
-        return null;
+	downloader.cancelAllRequests();
     }
 
     native void nativeOnProgress(int id, int taskId, long dl, long dlnow, long dltotal);
     native void nativeOnFinish(int id, int taskId, int errCode, String errStr, final byte[] data);
+
+    private class DataTaskHandler extends BinaryHttpResponseHandler {
+	int _id;
+	private long _lastBytesWritten;
+
+	void LogD(String msg) {
+	    android.util.Log.d("Cocos2dxDownloader", msg);
+	}
+
+	public DataTaskHandler(int id) {
+	    super(new String[]{".*"});
+	    _id = id;
+	    _lastBytesWritten = 0;
+	}
+
+	@Override
+	public void onProgress(long bytesWritten, long totalSize) {
+	    //LogD("onProgress(bytesWritten:" + bytesWritten + " totalSize:" + totalSize);
+	    long dlBytes = bytesWritten - _lastBytesWritten;
+	    long dlNow = bytesWritten;
+	    long dlTotal = totalSize;
+	    Cocos2dxDownloader.this.onProgress(_id, dlBytes, dlNow, dlTotal);
+	    _lastBytesWritten = bytesWritten;
+	}
+
+	@Override
+	public void onStart() {
+	    Cocos2dxDownloader.this.onStart(_id);
+	}
+
+	@Override
+	public void onFailure(int i, Header[] headers, byte[] errorResponse, Throwable throwable) {
+	    LogD("onFailure(i:" + i + " headers:" + headers + " throwable:" + throwable);
+	    String errStr = null;
+	    if (null != throwable) {
+		errStr = throwable.toString();
+	    }
+	    Cocos2dxDownloader.this.onFinish(_id, i, errStr, null);
+	}
+
+	@Override
+	public void onSuccess(int i, Header[] headers, byte[] binaryData) {
+	    LogD("onSuccess(i:" + i + " headers:" + headers);
+	    Cocos2dxDownloader.this.onFinish(_id, 0, null, binaryData);
+	}
+    }
+
+    private class FileTaskHandler extends FileAsyncHttpResponseHandler {
+	int _id;
+	File _finalFile;
+
+	private long _initFileLen;
+	private long _lastBytesWritten;
+
+	void LogD(String msg) {
+	    android.util.Log.d("Cocos2dxDownloader", msg);
+	}
+
+	public FileTaskHandler(int id, File temp, File finalFile) {
+	    super(temp, true);
+	    _finalFile = finalFile;
+	    _id = id;
+	    _initFileLen = getTargetFile().length();
+	    _lastBytesWritten = 0;
+	}
+
+	@Override
+	public void onProgress(long bytesWritten, long totalSize) {
+	    //LogD("onProgress(bytesWritten:" + bytesWritten + " totalSize:" + totalSize);
+	    long dlBytes = bytesWritten - _lastBytesWritten;
+	    long dlNow = bytesWritten + _initFileLen;
+	    long dlTotal = totalSize + _initFileLen;
+	    Cocos2dxDownloader.this.onProgress(_id, dlBytes, dlNow, dlTotal);
+	    _lastBytesWritten = bytesWritten;
+	}
+
+	@Override
+	public void onStart() {
+	    Cocos2dxDownloader.this.onStart(_id);
+	}
+
+	@Override
+	public void onFinish() {
+	    // onFinish called after onSuccess/onFailure
+	    Runnable taskRunnable = Cocos2dxDownloader.this._taskQueue.poll();
+	    if (taskRunnable != null) {
+		Cocos2dxHelper.getActivity().runOnUiThread(taskRunnable);
+	    }
+	}
+
+	@Override
+	public void onFailure(int i, Header[] headers, Throwable throwable, File file) {
+	    LogD("onFailure(i:" + i + " headers:" + headers + " throwable:" + throwable + " file:" + file);
+	    String errStr = "";
+	    if (null != throwable) {
+		errStr = throwable.toString();
+	    }
+	    Cocos2dxDownloader.this.onFinish(_id, i, errStr, null);
+	}
+
+	@Override
+	public void onSuccess(int i, Header[] headers, File file) {
+	    LogD("onSuccess(i:" + i + " headers:" + headers + " file:" + file);
+	    String errStr = null;
+
+	    // rename temp file to final file
+	    // if final file exist, remove it
+	    if (_finalFile.exists()) {
+		if (_finalFile.isDirectory()) {
+		    errStr = "Dest file is directory:" + _finalFile.getAbsolutePath();
+		    Cocos2dxDownloader.this.onFinish(_id, 0, errStr, null);
+		    return;
+		}
+		if (false == _finalFile.delete()) {
+		    errStr = "Can't remove old file:" + _finalFile.getAbsolutePath();
+		    Cocos2dxDownloader.this.onFinish(_id, 0, errStr, null);
+		    return;
+		}
+	    }
+
+	    File tempFile = getTargetFile();
+	    tempFile.renameTo(_finalFile);
+	    Cocos2dxDownloader.this.onFinish(_id, 0, errStr, null);
+	}
+    }
 }


### PR DESCRIPTION
- Turned DataTaskHandler and FileTaskHandler into inner classes of Cocos2dxDownloader. These classes are only supposed to be used by Cococ2dxDownloader instances and this way they do not need to be passed a reference to said instances explicitly.
- Removed DownloadTask as it seems to be unnecessary.
- Deprecated the use of static methods to create instances and doing work on instances.
- Using SparseArray instead of HashMap for tracking tasks because they provide the same functionality, without the need to use auto-boxing for the integer keys.
