### PR TITLE
Fix misspelled APIs in v3.10

### DIFF
--- a/cocos/editor-support/cocostudio/CocosStudioExtension.h
+++ b/cocos/editor-support/cocostudio/CocosStudioExtension.h
@@ -6,20 +6,20 @@
 
 NS_CC_BEGIN
 
-struct CC_DLL ResouceData
+struct CC_DLL ResourceData
 {
     int         type;
     std::string file;
     std::string plist;
 
-    ResouceData()
+    ResourceData()
     {
         type = 0;
         file = "";
         plist = "";
     }
 
-    ResouceData(int iType, std::string sFile, std::string sPlist)
+    ResourceData(int iType, std::string sFile, std::string sPlist)
     {
         type = iType;
         file = sFile;

--- a/cocos/scripting/js-bindings/manual/js_manual_conversions.cpp
+++ b/cocos/scripting/js-bindings/manual/js_manual_conversions.cpp
@@ -2855,7 +2855,7 @@ jsval std_map_string_string_to_jsval(JSContext* cx, const std::map<std::string, 
     return OBJECT_TO_JSVAL(jsRet);
 }
 
-bool jsval_to_resoucedata(JSContext *cx, JS::HandleValue v, ResouceData* ret) {
+bool jsval_to_resoucedata(JSContext *cx, JS::HandleValue v, ResourceData* ret) {
     JS::RootedObject tmp(cx);
     JS::RootedValue jstype(cx);
     JS::RootedValue jsfile(cx);
@@ -2880,7 +2880,7 @@ bool jsval_to_resoucedata(JSContext *cx, JS::HandleValue v, ResouceData* ret) {
     return true;
 }
 
-jsval resoucedata_to_jsval(JSContext* cx, const ResouceData& v)
+jsval resoucedata_to_jsval(JSContext* cx, const ResourceData& v)
 {
     JS::RootedObject proto(cx);
     JS::RootedObject parent(cx);

--- a/cocos/scripting/js-bindings/manual/js_manual_conversions.cpp
+++ b/cocos/scripting/js-bindings/manual/js_manual_conversions.cpp
@@ -2855,7 +2855,7 @@ jsval std_map_string_string_to_jsval(JSContext* cx, const std::map<std::string, 
     return OBJECT_TO_JSVAL(jsRet);
 }
 
-bool jsval_to_resoucedata(JSContext *cx, JS::HandleValue v, ResourceData* ret) {
+bool jsval_to_resourcedata(JSContext *cx, JS::HandleValue v, ResourceData* ret) {
     JS::RootedObject tmp(cx);
     JS::RootedValue jstype(cx);
     JS::RootedValue jsfile(cx);
@@ -2880,7 +2880,7 @@ bool jsval_to_resoucedata(JSContext *cx, JS::HandleValue v, ResourceData* ret) {
     return true;
 }
 
-jsval resoucedata_to_jsval(JSContext* cx, const ResourceData& v)
+jsval resourcedata_to_jsval(JSContext* cx, const ResourceData& v)
 {
     JS::RootedObject proto(cx);
     JS::RootedObject parent(cx);

--- a/cocos/scripting/js-bindings/manual/js_manual_conversions.h
+++ b/cocos/scripting/js-bindings/manual/js_manual_conversions.h
@@ -37,7 +37,7 @@
 #define JSB_COMPATIBLE_WITH_COCOS2D_HTML5_BASIC_TYPES
 
 NS_CC_BEGIN
-struct CC_DLL ResouceData;
+struct CC_DLL ResourceData;
 NS_CC_END
 
 // just a simple utility to avoid mem leaking when using JSString
@@ -116,7 +116,7 @@ bool jsvals_variadic_to_ccarray( JSContext *cx, jsval *vp, int argc, cocos2d::__
 bool jsval_to_quaternion(JSContext *cx, JS::HandleValue vp, cocos2d::Quaternion* ret);
 bool jsval_to_obb(JSContext *cx, JS::HandleValue vp, cocos2d::OBB* ret);
 bool jsval_to_ray(JSContext *cx, JS::HandleValue vp, cocos2d::Ray* ret);
-bool jsval_to_resoucedata(JSContext *cx, JS::HandleValue v, cocos2d::ResouceData* ret);
+bool jsval_to_resoucedata(JSContext *cx, JS::HandleValue v, cocos2d::ResourceData* ret);
 
 // forward declaration
 CC_JS_DLL js_proxy_t* jsb_get_js_proxy(JS::HandleObject jsObj);
@@ -278,7 +278,7 @@ jsval FontDefinition_to_jsval(JSContext* cx, const cocos2d::FontDefinition& t);
 jsval quaternion_to_jsval(JSContext* cx, const cocos2d::Quaternion& q);
 jsval meshVertexAttrib_to_jsval(JSContext* cx, const cocos2d::MeshVertexAttrib& q);
 jsval uniform_to_jsval(JSContext* cx, const cocos2d::Uniform* uniform);
-jsval resoucedata_to_jsval(JSContext* cx, const cocos2d::ResouceData& v);
+jsval resoucedata_to_jsval(JSContext* cx, const cocos2d::ResourceData& v);
 
 template<class T>
 js_proxy_t *js_get_or_create_proxy(JSContext *cx, T *native_obj);

--- a/cocos/scripting/js-bindings/manual/js_manual_conversions.h
+++ b/cocos/scripting/js-bindings/manual/js_manual_conversions.h
@@ -116,7 +116,7 @@ bool jsvals_variadic_to_ccarray( JSContext *cx, jsval *vp, int argc, cocos2d::__
 bool jsval_to_quaternion(JSContext *cx, JS::HandleValue vp, cocos2d::Quaternion* ret);
 bool jsval_to_obb(JSContext *cx, JS::HandleValue vp, cocos2d::OBB* ret);
 bool jsval_to_ray(JSContext *cx, JS::HandleValue vp, cocos2d::Ray* ret);
-bool jsval_to_resoucedata(JSContext *cx, JS::HandleValue v, cocos2d::ResourceData* ret);
+bool jsval_to_resourcedata(JSContext *cx, JS::HandleValue v, cocos2d::ResourceData* ret);
 
 // forward declaration
 CC_JS_DLL js_proxy_t* jsb_get_js_proxy(JS::HandleObject jsObj);
@@ -278,7 +278,7 @@ jsval FontDefinition_to_jsval(JSContext* cx, const cocos2d::FontDefinition& t);
 jsval quaternion_to_jsval(JSContext* cx, const cocos2d::Quaternion& q);
 jsval meshVertexAttrib_to_jsval(JSContext* cx, const cocos2d::MeshVertexAttrib& q);
 jsval uniform_to_jsval(JSContext* cx, const cocos2d::Uniform* uniform);
-jsval resoucedata_to_jsval(JSContext* cx, const cocos2d::ResourceData& v);
+jsval resourcedata_to_jsval(JSContext* cx, const cocos2d::ResourceData& v);
 
 template<class T>
 js_proxy_t *js_get_or_create_proxy(JSContext *cx, T *native_obj);

--- a/cocos/ui/UIAbstractCheckButton.cpp
+++ b/cocos/ui/UIAbstractCheckButton.cpp
@@ -607,7 +607,7 @@ ResouceData AbstractCheckButton::getCrossNormalFile()
     return rData;
 }
 
-ResouceData AbstractCheckButton::getCrossDisabeldFile()
+ResouceData AbstractCheckButton::getCrossDisabledFile()
 {
     ResouceData rData;
     rData.type = (int)_frontCrossDisabledTexType;

--- a/cocos/ui/UIAbstractCheckButton.cpp
+++ b/cocos/ui/UIAbstractCheckButton.cpp
@@ -575,41 +575,41 @@ void AbstractCheckButton::copySpecialProperties(Widget *widget)
 }
 
 
-ResouceData AbstractCheckButton::getBackNormalFile()
+ResourceData AbstractCheckButton::getBackNormalFile()
 {
-    ResouceData rData;
+    ResourceData rData;
     rData.type = (int)_backGroundTexType;
     rData.file = _backGroundFileName;
     return rData;
 }
 
-ResouceData AbstractCheckButton::getBackPressedFile()
+ResourceData AbstractCheckButton::getBackPressedFile()
 {
-    ResouceData rData;
+    ResourceData rData;
     rData.type = (int)_backGroundSelectedTexType;
     rData.file = _backGroundSelectedFileName;
     return rData;
 }
 
-ResouceData AbstractCheckButton::getBackDisabledFile()
+ResourceData AbstractCheckButton::getBackDisabledFile()
 {
-    ResouceData rData;
+    ResourceData rData;
     rData.type = (int)_backGroundDisabledTexType;
     rData.file = _backGroundDisabledFileName;
     return rData;
 }
 
-ResouceData AbstractCheckButton::getCrossNormalFile()
+ResourceData AbstractCheckButton::getCrossNormalFile()
 {
-    ResouceData rData;
+    ResourceData rData;
     rData.type = (int)_frontCrossTexType;
     rData.file = _frontCrossFileName;
     return rData;
 }
 
-ResouceData AbstractCheckButton::getCrossDisabledFile()
+ResourceData AbstractCheckButton::getCrossDisabledFile()
 {
-    ResouceData rData;
+    ResourceData rData;
     rData.type = (int)_frontCrossDisabledTexType;
     rData.file = _frontCrossDisabledFileName;
     return rData;

--- a/cocos/ui/UIAbstractCheckButton.h
+++ b/cocos/ui/UIAbstractCheckButton.h
@@ -166,7 +166,7 @@ public:
     ResouceData getBackPressedFile();
     ResouceData getBackDisabledFile();
     ResouceData getCrossNormalFile();
-    ResouceData getCrossDisabeldFile();
+    ResouceData getCrossDisabledFile();
 
 CC_CONSTRUCTOR_ACCESS:
     virtual bool init() override;

--- a/cocos/ui/UIAbstractCheckButton.h
+++ b/cocos/ui/UIAbstractCheckButton.h
@@ -34,7 +34,7 @@ THE SOFTWARE.
  */
 NS_CC_BEGIN
 class Sprite;
-struct CC_DLL ResouceData;
+struct CC_DLL ResourceData;
 
 namespace ui {
     
@@ -162,11 +162,11 @@ public:
      */
     Sprite* getRendererFrontCrossDisabled() const { return _frontCrossDisabledRenderer; }
 
-    ResouceData getBackNormalFile();
-    ResouceData getBackPressedFile();
-    ResouceData getBackDisabledFile();
-    ResouceData getCrossNormalFile();
-    ResouceData getCrossDisabledFile();
+    ResourceData getBackNormalFile();
+    ResourceData getBackPressedFile();
+    ResourceData getBackDisabledFile();
+    ResourceData getCrossNormalFile();
+    ResourceData getCrossDisabledFile();
 
 CC_CONSTRUCTOR_ACCESS:
     virtual bool init() override;

--- a/cocos/ui/UIButton.cpp
+++ b/cocos/ui/UIButton.cpp
@@ -1041,23 +1041,23 @@ void Button::resetDisabledRender()
     _buttonDisabledRenderer->resetRender();
 }
 
-ResouceData Button::getNormalFile()
+ResourceData Button::getNormalFile()
 {
-    ResouceData rData;
+    ResourceData rData;
     rData.type = (int)_normalTexType;
     rData.file = _normalFileName;
     return rData;
 }
-ResouceData Button::getPressedFile()
+ResourceData Button::getPressedFile()
 {
-    ResouceData rData;
+    ResourceData rData;
     rData.type = (int)_pressedTexType;
     rData.file = _clickedFileName;
     return rData;
 }
-ResouceData Button::getDisabledFile()
+ResourceData Button::getDisabledFile()
 {
-    ResouceData rData;
+    ResourceData rData;
     rData.type = (int)_disabledTexType;
     rData.file = _disabledFileName;
     return rData;

--- a/cocos/ui/UIButton.h
+++ b/cocos/ui/UIButton.h
@@ -36,7 +36,7 @@ NS_CC_BEGIN
 
 class Label;
 class SpriteFrame;
-struct CC_DLL ResouceData;
+struct CC_DLL ResourceData;
 
 namespace ui{
 
@@ -301,9 +301,9 @@ public:
     void resetPressedRender();
     void resetDisabledRender();
 
-    ResouceData getNormalFile();
-    ResouceData getPressedFile();
-    ResouceData getDisabledFile();
+    ResourceData getNormalFile();
+    ResourceData getPressedFile();
+    ResourceData getDisabledFile();
 
 CC_CONSTRUCTOR_ACCESS:
     virtual bool init() override;

--- a/cocos/ui/UIImageView.cpp
+++ b/cocos/ui/UIImageView.cpp
@@ -314,9 +314,9 @@ void ImageView::copySpecialProperties(Widget *widget)
     }
 }
 
-ResouceData ImageView::getRenderFile()
+ResourceData ImageView::getRenderFile()
 {
-    ResouceData rData;
+    ResourceData rData;
     rData.type = (int)_imageTexType;
     rData.file = _textureFile;
     return rData;

--- a/cocos/ui/UIImageView.h
+++ b/cocos/ui/UIImageView.h
@@ -34,7 +34,7 @@ THE SOFTWARE.
  */
 NS_CC_BEGIN
 
-struct CC_DLL ResouceData;
+struct CC_DLL ResourceData;
 
 namespace ui {
     class Scale9Sprite;
@@ -124,7 +124,7 @@ public:
     virtual Size getVirtualRendererSize() const override;
     virtual Node* getVirtualRenderer() override;
 
-    ResouceData getRenderFile();
+    ResourceData getRenderFile();
 
 CC_CONSTRUCTOR_ACCESS:
     //initializes state of widget.

--- a/cocos/ui/UILayout.cpp
+++ b/cocos/ui/UILayout.cpp
@@ -1880,9 +1880,9 @@ void Layout::setCameraMask(unsigned short mask, bool applyChildren)
     }
 }
     
-ResouceData Layout::getRenderFile()
+ResourceData Layout::getRenderFile()
 {
-    ResouceData rData;
+    ResourceData rData;
     rData.type = (int)_bgImageTexType;
     rData.file = _backGroundImageFileName;
     return rData;

--- a/cocos/ui/UILayout.h
+++ b/cocos/ui/UILayout.h
@@ -40,7 +40,7 @@ class DrawNode;
 class LayerColor;
 class LayerGradient;
 class StencilStateManager;
-struct CC_DLL ResouceData;
+struct CC_DLL ResourceData;
 
 namespace ui {
     
@@ -459,7 +459,7 @@ public:
      */
     virtual void setCameraMask(unsigned short mask, bool applyChildren = true) override;
 
-    ResouceData getRenderFile();
+    ResourceData getRenderFile();
 
 CC_CONSTRUCTOR_ACCESS:
     //override "init" method of widget.

--- a/cocos/ui/UILoadingBar.cpp
+++ b/cocos/ui/UILoadingBar.cpp
@@ -421,9 +421,9 @@ void LoadingBar::copySpecialProperties(Widget *widget)
     }
 }
 
-ResouceData LoadingBar::getRenderFile()
+ResourceData LoadingBar::getRenderFile()
 {
-    ResouceData rData;
+    ResourceData rData;
     rData.type = (int)_renderBarTexType;
     rData.file = _textureFile;
     return rData;

--- a/cocos/ui/UILoadingBar.h
+++ b/cocos/ui/UILoadingBar.h
@@ -34,7 +34,7 @@ NS_CC_BEGIN
  * @{
  */
 
-struct CC_DLL ResouceData;
+struct CC_DLL ResourceData;
 
 namespace ui {
     class Scale9Sprite;
@@ -174,7 +174,7 @@ public:
     virtual Node* getVirtualRenderer() override;
     virtual std::string getDescription() const override;
 
-    ResouceData getRenderFile(); 
+    ResourceData getRenderFile(); 
 
 protected:
     virtual void initRenderer() override;

--- a/cocos/ui/UISlider.cpp
+++ b/cocos/ui/UISlider.cpp
@@ -777,7 +777,7 @@ ResouceData Slider::getBallPressedFile()
     rData.file = _slidBallPressedTextureFile;
     return rData;
 }
-ResouceData Slider::getBallDisabeldFile()
+ResouceData Slider::getBallDisabledFile()
 {
     ResouceData rData;
     rData.type = (int)_ballDTexType;

--- a/cocos/ui/UISlider.cpp
+++ b/cocos/ui/UISlider.cpp
@@ -749,37 +749,37 @@ void Slider::copySpecialProperties(Widget *widget)
     }
 }
 
-ResouceData Slider::getBackFile()
+ResourceData Slider::getBackFile()
 {
-    ResouceData rData;
+    ResourceData rData;
     rData.type = (int)_barTexType;
     rData.file = _textureFile;
     return rData;
 }
-ResouceData Slider::getProgressBarFile()
+ResourceData Slider::getProgressBarFile()
 {
-    ResouceData rData;
+    ResourceData rData;
     rData.type = (int)_progressBarTexType;
     rData.file = _progressBarTextureFile;
     return rData;
 }
-ResouceData Slider::getBallNormalFile()
+ResourceData Slider::getBallNormalFile()
 {
-    ResouceData rData;
+    ResourceData rData;
     rData.type = (int)_ballNTexType;
     rData.file = _slidBallNormalTextureFile;
     return rData;
 }
-ResouceData Slider::getBallPressedFile()
+ResourceData Slider::getBallPressedFile()
 {
-    ResouceData rData;
+    ResourceData rData;
     rData.type = (int)_ballPTexType;
     rData.file = _slidBallPressedTextureFile;
     return rData;
 }
-ResouceData Slider::getBallDisabledFile()
+ResourceData Slider::getBallDisabledFile()
 {
-    ResouceData rData;
+    ResourceData rData;
     rData.type = (int)_ballDTexType;
     rData.file = _slidBallDisabledTextureFile;
     return rData;

--- a/cocos/ui/UISlider.h
+++ b/cocos/ui/UISlider.h
@@ -269,7 +269,7 @@ public:
     ResouceData getProgressBarFile();
     ResouceData getBallNormalFile();
     ResouceData getBallPressedFile();
-    ResouceData getBallDisabeldFile();
+    ResouceData getBallDisabledFile();
 
 CC_CONSTRUCTOR_ACCESS:
     virtual bool init() override;

--- a/cocos/ui/UISlider.h
+++ b/cocos/ui/UISlider.h
@@ -36,7 +36,7 @@ NS_CC_BEGIN
  */
 
 class Sprite;
-struct CC_DLL ResouceData;
+struct CC_DLL ResourceData;
 
 namespace ui {
     class Scale9Sprite;
@@ -265,11 +265,11 @@ public:
      */
     float getZoomScale()const;
 
-    ResouceData getBackFile();
-    ResouceData getProgressBarFile();
-    ResouceData getBallNormalFile();
-    ResouceData getBallPressedFile();
-    ResouceData getBallDisabledFile();
+    ResourceData getBackFile();
+    ResourceData getProgressBarFile();
+    ResourceData getBallNormalFile();
+    ResourceData getBallPressedFile();
+    ResourceData getBallDisabledFile();
 
 CC_CONSTRUCTOR_ACCESS:
     virtual bool init() override;

--- a/cocos/ui/UITextAtlas.cpp
+++ b/cocos/ui/UITextAtlas.cpp
@@ -191,9 +191,9 @@ void TextAtlas::copySpecialProperties(Widget *widget)
     }
 }
     
-ResouceData TextAtlas::getRenderFile()
+ResourceData TextAtlas::getRenderFile()
 {
-    ResouceData rData;
+    ResourceData rData;
     rData.type = 0;
     rData.file = _charMapFileName;
     return rData;

--- a/cocos/ui/UITextAtlas.h
+++ b/cocos/ui/UITextAtlas.h
@@ -36,7 +36,7 @@ NS_CC_BEGIN
  */
 
 class Label;
-struct CC_DLL ResouceData;
+struct CC_DLL ResourceData;
 
 namespace ui {
     
@@ -140,7 +140,7 @@ public:
      */
     virtual void adaptRenderers() override;
 
-    ResouceData getRenderFile();
+    ResourceData getRenderFile();
 
 protected:
     virtual void initRenderer() override;

--- a/cocos/ui/UITextBMFont.cpp
+++ b/cocos/ui/UITextBMFont.cpp
@@ -187,9 +187,9 @@ void TextBMFont::copySpecialProperties(Widget *widget)
     }
 }
 
-ResouceData TextBMFont::getRenderFile()
+ResourceData TextBMFont::getRenderFile()
 {
-    ResouceData rData;
+    ResourceData rData;
     rData.type = 0;
     rData.file = _fntFileName;
     return rData;

--- a/cocos/ui/UITextBMFont.h
+++ b/cocos/ui/UITextBMFont.h
@@ -35,7 +35,7 @@ THE SOFTWARE.
 NS_CC_BEGIN
 
 class Label;
-struct CC_DLL ResouceData;
+struct CC_DLL ResourceData;
 
 namespace ui {
     
@@ -96,7 +96,7 @@ public:
      */
     virtual std::string getDescription() const override;
 
-    ResouceData getRenderFile();
+    ResourceData getRenderFile();
 
 protected:
     virtual void initRenderer() override;


### PR DESCRIPTION
Hello.
There are several spelling mistakes I found in the new APIs that will be added to v3.10.
This pull request provides the following proposed fixes:
- Replace `ResouceData` class with `ResourceData`
- Rename function in JSB (except `auto`) 
  - `jsval_to_resoucedata` => `jsval_to_resourcedata`
  - `resoucedata_to_jsval` => `resourcedata_to_jsval`
- Fix typo in UI
  - `getCrossDisabeldFile` => `getCrossDisabledFile`
  - `getBallDisabeldFile` => `getBallDisabledFile`

Thanks.
