### PR TITLE
Bug fix & make test case more clear.

### DIFF
--- a/cocos/2d/CCCameraBackgroundBrush.cpp
+++ b/cocos/2d/CCCameraBackgroundBrush.cpp
@@ -232,8 +232,8 @@ CameraBackgroundSkyBoxBrush::CameraBackgroundSkyBoxBrush()
 , _vertexBuffer(0)
 , _indexBuffer(0)
 , _texture(nullptr)
-, _actived(false)
-, _textureValid(false)
+, _actived(true)
+, _textureValid(true)
 {
 #if (CC_TARGET_PLATFORM == CC_PLATFORM_ANDROID || CC_TARGET_PLATFORM == CC_PLATFORM_WINRT)
     _backToForegroundListener = EventListenerCustom::create(EVENT_RENDERER_RECREATED,

--- a/cocos/ui/UIButton.cpp
+++ b/cocos/ui/UIButton.cpp
@@ -235,7 +235,7 @@ void Button::loadTextureNormal(const std::string& normal,TextureResType texType)
     bool textureLoaded = true;
     if (normal.empty())
     {
-        _buttonNormalRenderer->init();
+        _buttonNormalRenderer->resetRender();
         textureLoaded = false;
     }
     else
@@ -292,7 +292,7 @@ void Button::loadTexturePressed(const std::string& selected,TextureResType texTy
     bool textureLoade = true;
     if (selected.empty())
     {
-        _buttonClickedRenderer->init();
+        _buttonClickedRenderer->resetRender();
         textureLoade = false;
     }
     else
@@ -335,7 +335,7 @@ void Button::loadTextureDisabled(const std::string& disabled,TextureResType texT
     bool textureLoaded = true;
     if (disabled.empty())
     {
-        _buttonDisabledRenderer->init();
+        _buttonDisabledRenderer->resetRender();
         textureLoaded = false;
     }
     else

--- a/cocos/ui/UISlider.cpp
+++ b/cocos/ui/UISlider.cpp
@@ -157,7 +157,7 @@ void Slider::loadBarTexture(const std::string& fileName, TextureResType texType)
     _barTexType = texType;
     if (fileName.empty())
     {
-        _barRenderer->init();
+        _barRenderer->resetRender();
     }
     else
     {
@@ -196,7 +196,7 @@ void Slider::loadProgressBarTexture(const std::string& fileName, TextureResType 
     _progressBarTexType = texType;
     if (fileName.empty())
     {
-        _progressBarRenderer->init();
+        _progressBarRenderer->resetRender();
     }
     else
     {

--- a/tests/cpp-tests/Classes/LabelTest/LabelTestNew.cpp
+++ b/tests/cpp-tests/Classes/LabelTest/LabelTestNew.cpp
@@ -2084,6 +2084,7 @@ void LabelLayoutBaseTest::initWrapOption(const cocos2d::Size& size)
     checkBox->setScale(0.5);
     checkBox->setSelected(true);
     checkBox->setName("toggleWrap");
+    checkBox->setEnabled(false);
 
     checkBox->addEventListener([=](Ref* ref, CheckBox::EventType event){
         if (event == CheckBox::EventType::SELECTED) {


### PR DESCRIPTION
1. In CameraBackgroundSkyBoxBrush _actived and _textureValid should set true as default, otherwise will cause user get wrong display status.
2. "Enable Wrap" check box in "31:Node: Label - New API -> 55:Resize content Test" is not used, so set it to disabled, won't let user to change it.
3. When set blank texture to UISlider or UISlider button, use resetRender function to clear texture, use init with blank file name will cause error.

@zilongshanren Please review this PR.
