### PR TITLE
Refactoring Scale9 ui widgets to use the latest RenderingType feature.

### DIFF
--- a/cocos/ui/UIButton.cpp
+++ b/cocos/ui/UIButton.cpp
@@ -66,10 +66,6 @@ _capInsetsDisabled(Rect::ZERO),
 _normalTextureSize(_contentSize),
 _pressedTextureSize(_contentSize),
 _disabledTextureSize(_contentSize),
-_normalTextureScaleXInSize(1.0f),
-_normalTextureScaleYInSize(1.0f),
-_pressedTextureScaleXInSize(1.0f),
-_pressedTextureScaleYInSize(1.0f),
 _normalTextureLoaded(false),
 _pressedTextureLoaded(false),
 _disabledTextureLoaded(false),
@@ -146,9 +142,9 @@ void Button::initRenderer()
     _buttonNormalRenderer = Scale9Sprite::create();
     _buttonClickedRenderer = Scale9Sprite::create();
     _buttonDisabledRenderer = Scale9Sprite::create();
-    _buttonClickedRenderer->setScale9Enabled(false);
-    _buttonNormalRenderer->setScale9Enabled(false);
-    _buttonDisabledRenderer->setScale9Enabled(false);
+    _buttonClickedRenderer->setRenderingType(Scale9Sprite::RenderingType::SIMPLE);
+    _buttonNormalRenderer->setRenderingType(Scale9Sprite::RenderingType::SIMPLE);
+    _buttonDisabledRenderer->setRenderingType(Scale9Sprite::RenderingType::SIMPLE);
 
     addProtectedChild(_buttonNormalRenderer, NORMAL_RENDERER_Z, -1);
     addProtectedChild(_buttonClickedRenderer, PRESSED_RENDERER_Z, -1);
@@ -171,9 +167,16 @@ void Button::setScale9Enabled(bool able)
 
     _scale9Enabled = able;
 
-    _buttonNormalRenderer->setScale9Enabled(_scale9Enabled);
-    _buttonClickedRenderer->setScale9Enabled(_scale9Enabled);
-    _buttonDisabledRenderer->setScale9Enabled(_scale9Enabled);
+    if (_scale9Enabled) {
+        _buttonNormalRenderer->setRenderingType(Scale9Sprite::RenderingType::SLICE);
+        _buttonClickedRenderer->setRenderingType(Scale9Sprite::RenderingType::SLICE);
+        _buttonDisabledRenderer->setRenderingType(Scale9Sprite::RenderingType::SLICE);
+    }else{
+        _buttonNormalRenderer->setRenderingType(Scale9Sprite::RenderingType::SIMPLE);
+        _buttonClickedRenderer->setRenderingType(Scale9Sprite::RenderingType::SIMPLE);
+        _buttonDisabledRenderer->setRenderingType(Scale9Sprite::RenderingType::SIMPLE);
+    }
+    
 
     if (_scale9Enabled)
     {
@@ -251,6 +254,10 @@ void Button::loadTextureNormal(const std::string& normal,TextureResType texType)
         default:
             break;
         }
+    }
+    //FIXME: https://github.com/cocos2d/cocos2d-x/issues/12249
+    if (!_ignoreSize) {
+        _customSize = _buttonNormalRenderer->getContentSize();
     }
     this->setupNormalTexture(textureLoaded);
 }
@@ -443,8 +450,8 @@ void Button::onPressStateChangedToNormal()
 
 //            Action *zoomAction = ScaleTo::create(ZOOM_ACTION_TIME_STEP, _normalTextureScaleXInSize, _normalTextureScaleYInSize);
             //fixme: the zoomAction will run in the next frame which will cause the _buttonNormalRenderer to a wrong scale
-            _buttonNormalRenderer->setScale(_normalTextureScaleXInSize, _normalTextureScaleYInSize);
-            _buttonClickedRenderer->setScale(_pressedTextureScaleXInSize, _pressedTextureScaleYInSize);
+            _buttonNormalRenderer->setScale(1.0);
+            _buttonClickedRenderer->setScale(1.0);
 
             if(nullptr != _titleRenderer)
             {
@@ -465,7 +472,7 @@ void Button::onPressStateChangedToNormal()
     else
     {
         _buttonNormalRenderer->stopAllActions();
-        _buttonNormalRenderer->setScale(_normalTextureScaleXInSize, _normalTextureScaleYInSize);
+        _buttonNormalRenderer->setScale(1.0);
 
         if(nullptr != _titleRenderer)
         {
@@ -493,12 +500,12 @@ void Button::onPressStateChangedToPressed()
             _buttonClickedRenderer->stopAllActions();
 
             Action *zoomAction = ScaleTo::create(ZOOM_ACTION_TIME_STEP,
-                                                 _pressedTextureScaleXInSize + _zoomScale,
-                                                 _pressedTextureScaleYInSize + _zoomScale);
+                                                 1.0 + _zoomScale,
+                                                 1.0 + _zoomScale);
             _buttonClickedRenderer->runAction(zoomAction);
 
-            _buttonNormalRenderer->setScale(_pressedTextureScaleXInSize + _zoomScale,
-                                            _pressedTextureScaleYInSize + _zoomScale);
+            _buttonNormalRenderer->setScale(1.0 + _zoomScale,
+                                            1.0 + _zoomScale);
 
             if(nullptr != _titleRenderer)
             {
@@ -516,7 +523,7 @@ void Button::onPressStateChangedToPressed()
         _buttonDisabledRenderer->setVisible(false);
 
         _buttonNormalRenderer->stopAllActions();
-        _buttonNormalRenderer->setScale(_normalTextureScaleXInSize +_zoomScale, _normalTextureScaleYInSize + _zoomScale);
+        _buttonNormalRenderer->setScale(1.0 +_zoomScale, 1.0 + _zoomScale);
 
         if(nullptr != _titleRenderer)
         {
@@ -544,8 +551,8 @@ void Button::onPressStateChangedToDisabled()
     }
 
     _buttonClickedRenderer->setVisible(false);
-    _buttonNormalRenderer->setScale(_normalTextureScaleXInSize, _normalTextureScaleYInSize);
-    _buttonClickedRenderer->setScale(_pressedTextureScaleXInSize, _pressedTextureScaleYInSize);
+    _buttonNormalRenderer->setScale(1.0);
+    _buttonClickedRenderer->setScale(1.0);
 }
 
 void Button::updateTitleLocation()
@@ -649,112 +656,22 @@ Node* Button::getVirtualRenderer()
 
 void Button::normalTextureScaleChangedWithSize()
 {
-
-    if (_ignoreSize && !_unifySize)
-    {
-        if (!_scale9Enabled)
-        {
-            _buttonNormalRenderer->setScale(1.0f);
-            _normalTextureScaleXInSize = _normalTextureScaleYInSize = 1.0f;
-        }
-    }
-    else
-    {
-        if (_scale9Enabled)
-        {
-            _buttonNormalRenderer->setPreferredSize(_contentSize);
-            _normalTextureScaleXInSize = _normalTextureScaleYInSize = 1.0f;
-            _buttonNormalRenderer->setScale(_normalTextureScaleXInSize,_normalTextureScaleYInSize);
-        }
-        else
-        {
-            Size textureSize = _normalTextureSize;
-            if (textureSize.width <= 0.0f || textureSize.height <= 0.0f)
-            {
-                _buttonNormalRenderer->setScale(1.0f);
-                return;
-            }
-            float scaleX = _contentSize.width / textureSize.width;
-            float scaleY = _contentSize.height / textureSize.height;
-            _buttonNormalRenderer->setScaleX(scaleX);
-            _buttonNormalRenderer->setScaleY(scaleY);
-            _normalTextureScaleXInSize = scaleX;
-            _normalTextureScaleYInSize = scaleY;
-        }
-    }
+    _buttonNormalRenderer->setPreferredSize(_contentSize);
 
     _buttonNormalRenderer->setPosition(_contentSize.width / 2.0f, _contentSize.height / 2.0f);
 }
 
 void Button::pressedTextureScaleChangedWithSize()
 {
+    _buttonClickedRenderer->setPreferredSize(_contentSize);
 
-    if (_ignoreSize && !_unifySize)
-    {
-        if (!_scale9Enabled)
-        {
-            _buttonClickedRenderer->setScale(1.0f);
-            _pressedTextureScaleXInSize = _pressedTextureScaleYInSize = 1.0f;
-        }
-    }
-    else
-    {
-        if (_scale9Enabled)
-        {
-            _buttonClickedRenderer->setPreferredSize(_contentSize);
-            _pressedTextureScaleXInSize = _pressedTextureScaleYInSize = 1.0f;
-            _buttonClickedRenderer->setScale(_pressedTextureScaleXInSize,_pressedTextureScaleYInSize);
-        }
-        else
-        {
-            Size textureSize = _pressedTextureSize;
-            if (textureSize.width <= 0.0f || textureSize.height <= 0.0f)
-            {
-                _buttonClickedRenderer->setScale(1.0f);
-                return;
-            }
-            float scaleX = _contentSize.width / _pressedTextureSize.width;
-            float scaleY = _contentSize.height / _pressedTextureSize.height;
-            _buttonClickedRenderer->setScaleX(scaleX);
-            _buttonClickedRenderer->setScaleY(scaleY);
-            _pressedTextureScaleXInSize = scaleX;
-            _pressedTextureScaleYInSize = scaleY;
-        }
-    }
     _buttonClickedRenderer->setPosition(_contentSize.width / 2.0f, _contentSize.height / 2.0f);
 }
 
 void Button::disabledTextureScaleChangedWithSize()
 {
-
-    if (_ignoreSize && !_unifySize)
-    {
-        if (!_scale9Enabled)
-        {
-            _buttonDisabledRenderer->setScale(1.0f);
-        }
-    }
-    else
-    {
-        if (_scale9Enabled)
-        {
-            _buttonDisabledRenderer->setScale(1.0);
-            _buttonDisabledRenderer->setPreferredSize(_contentSize);
-        }
-        else
-        {
-            Size textureSize = _disabledTextureSize;
-            if (textureSize.width <= 0.0f || textureSize.height <= 0.0f)
-            {
-                _buttonDisabledRenderer->setScale(1.0f);
-                return;
-            }
-            float scaleX = _contentSize.width / _disabledTextureSize.width;
-            float scaleY = _contentSize.height / _disabledTextureSize.height;
-            _buttonDisabledRenderer->setScaleX(scaleX);
-            _buttonDisabledRenderer->setScaleY(scaleY);
-        }
-    }
+    _buttonDisabledRenderer->setPreferredSize(_contentSize);
+    
     _buttonDisabledRenderer->setPosition(_contentSize.width / 2.0f, _contentSize.height / 2.0f);
 }
 

--- a/cocos/ui/UIButton.h
+++ b/cocos/ui/UIButton.h
@@ -360,11 +360,6 @@ protected:
     Size _pressedTextureSize;
     Size _disabledTextureSize;
 
-    float _normalTextureScaleXInSize;
-    float _normalTextureScaleYInSize;
-    float _pressedTextureScaleXInSize;
-    float _pressedTextureScaleYInSize;
-
     bool _normalTextureLoaded;
     bool _pressedTextureLoaded;
     bool _disabledTextureLoaded;

--- a/cocos/ui/UIImageView.cpp
+++ b/cocos/ui/UIImageView.cpp
@@ -112,7 +112,7 @@ bool ImageView::init(const std::string &imageFileName, TextureResType texType)
 void ImageView::initRenderer()
 {
     _imageRenderer = Scale9Sprite::create();
-    _imageRenderer->setScale9Enabled(false);
+    _imageRenderer->setRenderingType(Scale9Sprite::RenderingType::SIMPLE);
     
     addProtectedChild(_imageRenderer, IMAGE_RENDERER_Z, -1);
 }
@@ -185,7 +185,11 @@ void ImageView::setScale9Enabled(bool able)
     
     
     _scale9Enabled = able;
-    _imageRenderer->setScale9Enabled(_scale9Enabled);
+    if (_scale9Enabled) {
+        _imageRenderer->setRenderingType(Scale9Sprite::RenderingType::SLICE);
+    }else{
+        _imageRenderer->setRenderingType(Scale9Sprite::RenderingType::SIMPLE);
+    }
     
     if (_scale9Enabled)
     {
@@ -257,34 +261,8 @@ Node* ImageView::getVirtualRenderer()
 
 void ImageView::imageTextureScaleChangedWithSize()
 {
-    if (_ignoreSize)
-    {
-        if (!_scale9Enabled)
-        {
-            _imageRenderer->setScale(1.0f);
-        }
-    }
-    else
-    {
-        if (_scale9Enabled)
-        {
-            _imageRenderer->setPreferredSize(_contentSize);
-            _imageRenderer->setScale(1.0f);
-        }
-        else
-        {
-            Size textureSize = _imageTextureSize;
-            if (textureSize.width <= 0.0f || textureSize.height <= 0.0f)
-            {
-                _imageRenderer->setScale(1.0f);
-                return;
-            }
-            float scaleX = _contentSize.width / textureSize.width;
-            float scaleY = _contentSize.height / textureSize.height;
-            _imageRenderer->setScaleX(scaleX);
-            _imageRenderer->setScaleY(scaleY);
-        }
-    }
+    _imageRenderer->setPreferredSize(_contentSize);
+    
     _imageRenderer->setPosition(_contentSize.width / 2.0f, _contentSize.height / 2.0f);
 }
 

--- a/cocos/ui/UIImageView.cpp
+++ b/cocos/ui/UIImageView.cpp
@@ -136,7 +136,10 @@ void ImageView::loadTexture(const std::string& fileName, TextureResType texType)
         default:
             break;
     }
-
+    //FIXME: https://github.com/cocos2d/cocos2d-x/issues/12249
+    if (!_ignoreSize) {
+        _customSize = _imageRenderer->getContentSize();
+    }
     this->setupTexture();
 }
 

--- a/cocos/ui/UILayout.cpp
+++ b/cocos/ui/UILayout.cpp
@@ -557,8 +557,12 @@ void Layout::setBackGroundImageScale9Enabled(bool able)
         addBackGroundImage();
         setBackGroundImage(_backGroundImageFileName,_bgImageTexType);
     }
-    _backGroundImage->setScale9Enabled(_backGroundScale9Enabled);
-    
+    if(_backGroundScale9Enabled){
+        _backGroundImage->setRenderingType(Scale9Sprite::RenderingType::SLICE);
+    }else{
+        _backGroundImage->setRenderingType(Scale9Sprite::RenderingType::SIMPLE);
+    }
+
     if (able) {
         _backGroundImage->setPreferredSize(_contentSize);
     }
@@ -580,7 +584,11 @@ void Layout::setBackGroundImage(const std::string& fileName,TextureResType texTy
     if (_backGroundImage == nullptr)
     {
         addBackGroundImage();
-        _backGroundImage->setScale9Enabled(_backGroundScale9Enabled);
+        if(_backGroundScale9Enabled){
+            _backGroundImage->setRenderingType(Scale9Sprite::RenderingType::SLICE);
+        }else{
+            _backGroundImage->setRenderingType(Scale9Sprite::RenderingType::SIMPLE);
+        }
     }
     _backGroundImageFileName = fileName;
     _bgImageTexType = texType;
@@ -656,7 +664,7 @@ void Layout::supplyTheLayoutParameterLackToChild(Widget *child)
 void Layout::addBackGroundImage()
 {
     _backGroundImage = Scale9Sprite::create();
-    _backGroundImage->setScale9Enabled(false);
+    _backGroundImage->setRenderingType(Scale9Sprite::RenderingType::SIMPLE);
     
     addProtectedChild(_backGroundImage, BACKGROUNDIMAGE_Z, -1);
    

--- a/cocos/ui/UILoadingBar.cpp
+++ b/cocos/ui/UILoadingBar.cpp
@@ -161,6 +161,11 @@ void LoadingBar::loadTexture(const std::string& texture,TextureResType texType)
         default:
             break;
     }
+    
+    //FIXME: https://github.com/cocos2d/cocos2d-x/issues/12249
+    if (!_ignoreSize) {
+        _customSize = _barRenderer->getContentSize();
+    }
     this->setupTexture();
 }
 
@@ -203,6 +208,7 @@ void LoadingBar::setupTexture()
     this->updateChildrenDisplayedRGBA();
 
     barRendererScaleChangedWithSize();
+
     updateContentSizeWithTextureSize(_barRendererTextureSize);
 
     this->updateProgressBar();

--- a/cocos/ui/UILoadingBar.cpp
+++ b/cocos/ui/UILoadingBar.cpp
@@ -92,7 +92,7 @@ LoadingBar* LoadingBar::create(const std::string &textureName,
 void LoadingBar::initRenderer()
 {
     _barRenderer = Scale9Sprite::create();
-    _barRenderer->setScale9Enabled(false);
+    _barRenderer->setRenderingType(Scale9Sprite::RenderingType::SIMPLE);
     addProtectedChild(_barRenderer, BAR_RENDERER_Z, -1);
     _barRenderer->setAnchorPoint(Vec2(0.0,0.5));
 }
@@ -216,7 +216,11 @@ void LoadingBar::setScale9Enabled(bool enabled)
         return;
     }
     _scale9Enabled = enabled;
-    _barRenderer->setScale9Enabled(_scale9Enabled);
+    if (_scale9Enabled) {
+        _barRenderer->setRenderingType(Scale9Sprite::RenderingType::SLICE);
+    }else{
+        _barRenderer->setRenderingType(Scale9Sprite::RenderingType::SIMPLE);
+    }
     
     if (_scale9Enabled)
     {
@@ -279,21 +283,8 @@ void LoadingBar::setPercent(float percent)
     
 void LoadingBar::updateProgressBar()
 {
-    if (_scale9Enabled)
-    {
-        setScale9Scale();
-    }
-    else
-    {
-        Sprite* innerSprite = _barRenderer->getSprite();
-        if (nullptr != innerSprite)
-        {
-            float res = _percent / 100.0f;
-            Rect rect = innerSprite->getTextureRect();
-            rect.size.width = _barRendererTextureSize.width * res;
-            innerSprite->setTextureRect(rect, innerSprite->isTextureRectRotated(), rect.size);
-        }
-    }
+    float width = (float)(_percent) / 100.0f * _totalLength;
+    _barRenderer->setPreferredSize(Size(width, _contentSize.height));
 }
 
 float LoadingBar::getPercent() const
@@ -354,25 +345,7 @@ void LoadingBar::barRendererScaleChangedWithSize()
     else
     {
         _totalLength = _contentSize.width;
-        if (_scale9Enabled)
-        {
-            this->setScale9Scale();
-            _barRenderer->setScale(1.0f);
-        }
-        else
-        {
-            
-            Size textureSize = _barRendererTextureSize;
-            if (textureSize.width <= 0.0f || textureSize.height <= 0.0f)
-            {
-                _barRenderer->setScale(1.0f);
-                return;
-            }
-            float scaleX = _contentSize.width / textureSize.width;
-            float scaleY = _contentSize.height / textureSize.height;
-            _barRenderer->setScaleX(scaleX);
-            _barRenderer->setScaleY(scaleY);
-        }
+        this->updateProgressBar();
     }
     switch (_direction)
     {
@@ -385,12 +358,6 @@ void LoadingBar::barRendererScaleChangedWithSize()
         default:
             break;
     }
-}
-
-void LoadingBar::setScale9Scale()
-{
-    float width = (float)(_percent) / 100.0f * _totalLength;
-    _barRenderer->setPreferredSize(Size(width, _contentSize.height));
 }
 
 std::string LoadingBar::getDescription() const

--- a/cocos/ui/UILoadingBar.h
+++ b/cocos/ui/UILoadingBar.h
@@ -180,7 +180,6 @@ protected:
     virtual void initRenderer() override;
     virtual void onSizeChanged() override;
    
-    void setScale9Scale();
     void updateProgressBar();
     void barRendererScaleChangedWithSize();
 

--- a/cocos/ui/UIScale9Sprite.cpp
+++ b/cocos/ui/UIScale9Sprite.cpp
@@ -39,8 +39,7 @@ NS_CC_BEGIN
 namespace ui {
 
     Scale9Sprite::Scale9Sprite()
-        : _spritesGenerated(false)
-        , _spriteFrameRotated(false)
+        : _spriteFrameRotated(false)
         , _scale9Image(nullptr)
         , _scale9Enabled(true)
         , _insetLeft(0)
@@ -401,10 +400,6 @@ namespace ui {
                                         const Size &originalSize,
                                         const Rect& capInsets)
     {
-        
-        GLubyte opacity = getOpacity();
-        Color3B color = getColor();
-
         // Release old sprites
         this->cleanupSlicedSprites();
 
@@ -477,15 +472,7 @@ namespace ui {
             size.height = size.height - 2;
         }
         this->setContentSize(size);
-
-        if (_spritesGenerated)
-        {
-            // Restore color and opacity
-            this->setOpacity(opacity);
-            this->setColor(color);
-        }
-        _spritesGenerated = true;
-
+        
         return true;
     }
     

--- a/cocos/ui/UIScale9Sprite.h
+++ b/cocos/ui/UIScale9Sprite.h
@@ -687,7 +687,6 @@ namespace ui {
         TrianglesCommand::Triangles calculateTriangles(const std::vector<Vec2>& uv,
                                                       const std::vector<Vec2>& vertices);
         
-        bool _spritesGenerated;
         Rect _spriteRect;
         bool   _spriteFrameRotated;
         Rect _capInsetsInternal;

--- a/cocos/ui/UISlider.cpp
+++ b/cocos/ui/UISlider.cpp
@@ -282,7 +282,10 @@ void Slider::setCapInsets(const Rect &capInsets)
 void Slider::setCapInsetsBarRenderer(const Rect &capInsets)
 {
     _capInsetsBarRenderer = ui::Helper::restrictCapInsetRect(capInsets, _barRenderer->getContentSize());
-   
+    if (!_scale9Enabled)
+    {
+        return;
+    }
     _barRenderer->setCapInsets(_capInsetsBarRenderer);
 }
     
@@ -294,7 +297,10 @@ const Rect& Slider::getCapInsetsBarRenderer()const
 void Slider::setCapInsetProgressBarRebderer(const Rect &capInsets)
 {
     _capInsetsProgressBarRenderer = ui::Helper::restrictCapInsetRect(capInsets, _progressBarRenderer->getContentSize());
-    
+    if (!_scale9Enabled)
+    {
+        return;
+    }
     _progressBarRenderer->setCapInsets(_capInsetsProgressBarRenderer);
 }
     

--- a/cocos/ui/UISlider.cpp
+++ b/cocos/ui/UISlider.cpp
@@ -171,6 +171,10 @@ void Slider::loadBarTexture(const std::string& fileName, TextureResType texType)
             break;
         }
     }
+    //FIXME: https://github.com/cocos2d/cocos2d-x/issues/12249
+    if (!_ignoreSize) {
+        _customSize = _barRenderer->getContentSize();
+    }
     this->setupBarTexture();
 }
 void Slider::loadBarTexture(SpriteFrame* spriteframe)

--- a/cocos/ui/UISlider.cpp
+++ b/cocos/ui/UISlider.cpp
@@ -54,8 +54,6 @@ _maxPercent(100),
 _scale9Enabled(false),
 _prevIgnoreSize(true),
 _zoomScale(0.1f),
-_sliderBallNormalTextureScaleX(1.0),
-_sliderBallNormalTextureScaleY(1.0),
 _isSliderBallPressedTextureLoaded(false),
 _isSliderBallDisabledTexturedLoaded(false),
 _capInsetsBarRenderer(Rect::ZERO),
@@ -126,8 +124,8 @@ void Slider::initRenderer()
 {
     _barRenderer = Scale9Sprite::create();
     _progressBarRenderer = Scale9Sprite::create();
-    _barRenderer->setScale9Enabled(false);
-    _progressBarRenderer->setScale9Enabled(false);
+    _barRenderer->setRenderingType(Scale9Sprite::RenderingType::SIMPLE);
+    _progressBarRenderer->setRenderingType(Scale9Sprite::RenderingType::SIMPLE);
     
     _progressBarRenderer->setAnchorPoint(Vec2(0.0f, 0.5f));
     
@@ -237,8 +235,13 @@ void Slider::setScale9Enabled(bool able)
     }
     
     _scale9Enabled = able;
-    _barRenderer->setScale9Enabled(_scale9Enabled);
-    _progressBarRenderer->setScale9Enabled(_scale9Enabled);
+    if (_scale9Enabled) {
+        _barRenderer->setRenderingType(Scale9Sprite::RenderingType::SLICE);
+        _progressBarRenderer->setRenderingType(Scale9Sprite::RenderingType::SLICE);
+    }else{
+        _barRenderer->setRenderingType(Scale9Sprite::RenderingType::SIMPLE);
+        _progressBarRenderer->setRenderingType(Scale9Sprite::RenderingType::SIMPLE);
+    }
     
     if (_scale9Enabled)
     {
@@ -279,10 +282,7 @@ void Slider::setCapInsets(const Rect &capInsets)
 void Slider::setCapInsetsBarRenderer(const Rect &capInsets)
 {
     _capInsetsBarRenderer = ui::Helper::restrictCapInsetRect(capInsets, _barRenderer->getContentSize());
-    if (!_scale9Enabled)
-    {
-        return;
-    }
+   
     _barRenderer->setCapInsets(_capInsetsBarRenderer);
 }
     
@@ -295,10 +295,6 @@ void Slider::setCapInsetProgressBarRebderer(const Rect &capInsets)
 {
     _capInsetsProgressBarRenderer = ui::Helper::restrictCapInsetRect(capInsets, _progressBarRenderer->getContentSize());
     
-    if (!_scale9Enabled)
-    {
-        return;
-    }
     _progressBarRenderer->setCapInsets(_capInsetsProgressBarRenderer);
 }
     
@@ -436,20 +432,8 @@ void Slider::setPercent(int percent)
     float res = 1.0 * percent / _maxPercent;
     float dis = _barLength * res;
     _slidBallRenderer->setPosition(dis, _contentSize.height / 2.0f);
-    if (_scale9Enabled)
-    {
-        _progressBarRenderer->setPreferredSize(Size(dis,_contentSize.height));
-    }
-    else
-    {
-        Sprite* spriteRenderer = _progressBarRenderer->getSprite();
-        
-        if (nullptr != spriteRenderer) {
-            Rect rect = spriteRenderer->getTextureRect();
-            rect.size.width = _progressBarTextureSize.width * res;
-            spriteRenderer->setTextureRect(rect, spriteRenderer->isTextureRectRotated(), rect.size);
-        }
-    }
+   
+    _progressBarRenderer->setPreferredSize(Size(dis,_contentSize.height));
 }
     
 bool Slider::hitTest(const cocos2d::Vec2 &pt, const Camera *camera, Vec3 *p) const
@@ -569,83 +553,17 @@ Node* Slider::getVirtualRenderer()
 
 void Slider::barRendererScaleChangedWithSize()
 {
-    if (_unifySize)
-    {
-        _barLength = _contentSize.width;
-        _barRenderer->setPreferredSize(_contentSize);
-    }
-    else if (_ignoreSize)
-    {
-        
-        _barRenderer->setScale(1.0f);
-        _barLength = _contentSize.width;
-    }
-    else
-    {
-        _barLength = _contentSize.width;
-        if (_scale9Enabled)
-        {
-            _barRenderer->setPreferredSize(_contentSize);
-            _barRenderer->setScale(1.0f);
-        }
-        else
-        {
-            Size btextureSize = _barTextureSize;
-            if (btextureSize.width <= 0.0f || btextureSize.height <= 0.0f)
-            {
-                _barRenderer->setScale(1.0f);
-            }
-            else
-            {
-                float bscaleX = _contentSize.width / btextureSize.width;
-                float bscaleY = _contentSize.height / btextureSize.height;
-                _barRenderer->setScaleX(bscaleX);
-                _barRenderer->setScaleY(bscaleY);
-            }
-        }
-    }
+    _barLength = _contentSize.width;
+    _barRenderer->setPreferredSize(_contentSize);
+    
     _barRenderer->setPosition(_contentSize.width / 2.0f, _contentSize.height / 2.0f);
     setPercent(_percent);
 }
 
 void Slider::progressBarRendererScaleChangedWithSize()
 {
-    if (_unifySize)
-    {
-        _progressBarRenderer->setPreferredSize(_contentSize);
-    }
-    else if (_ignoreSize)
-    {
-        if (!_scale9Enabled)
-        {
-            Size ptextureSize = _progressBarTextureSize;
-            float pscaleX = _contentSize.width / ptextureSize.width;
-            float pscaleY = _contentSize.height / ptextureSize.height;
-            _progressBarRenderer->setScaleX(pscaleX);
-            _progressBarRenderer->setScaleY(pscaleY);
-        }
-    }
-    else
-    {
-        if (_scale9Enabled)
-        {
-            _progressBarRenderer->setPreferredSize(_contentSize);
-            _progressBarRenderer->setScale(1.0);
-        }
-        else
-        {
-            Size ptextureSize = _progressBarTextureSize;
-            if (ptextureSize.width <= 0.0f || ptextureSize.height <= 0.0f)
-            {
-                _progressBarRenderer->setScale(1.0f);
-                return;
-            }
-            float pscaleX = _contentSize.width / ptextureSize.width;
-            float pscaleY = _contentSize.height / ptextureSize.height;
-            _progressBarRenderer->setScaleX(pscaleX);
-            _progressBarRenderer->setScaleY(pscaleY);
-        }
-    }
+    _progressBarRenderer->setPreferredSize(_contentSize);
+
     _progressBarRenderer->setPosition(0.0f, _contentSize.height / 2.0f);
     setPercent(_percent);
 }
@@ -656,8 +574,8 @@ void Slider::onPressStateChangedToNormal()
     _slidBallPressedRenderer->setVisible(false);
     _slidBallDisabledRenderer->setVisible(false);
     
+    _slidBallNormalRenderer->setScale(1.0);
     _slidBallNormalRenderer->setGLProgramState(this->getNormalGLProgramState());
-    _slidBallNormalRenderer->setScale(_sliderBallNormalTextureScaleX, _sliderBallNormalTextureScaleY);
 }
 
 void Slider::onPressStateChangedToPressed()
@@ -667,8 +585,7 @@ void Slider::onPressStateChangedToPressed()
     
     if (!_isSliderBallPressedTextureLoaded)
     {
-        _slidBallNormalRenderer->setScale(_sliderBallNormalTextureScaleX + _zoomScale,
-                                          _sliderBallNormalTextureScaleY + _zoomScale);
+        _slidBallNormalRenderer->setScale(1.0 + _zoomScale, 1.0 + _zoomScale);
     }
     else
     {
@@ -690,9 +607,7 @@ void Slider::onPressStateChangedToDisabled()
         _slidBallNormalRenderer->setVisible(false);
         _slidBallDisabledRenderer->setVisible(true);
     }
-    
-    _slidBallNormalRenderer->setScale(_sliderBallNormalTextureScaleX, _sliderBallNormalTextureScaleY);
-    
+    _slidBallNormalRenderer->setScale(1.0);
     _slidBallPressedRenderer->setVisible(false);
 }
     

--- a/cocos/ui/UISlider.h
+++ b/cocos/ui/UISlider.h
@@ -315,8 +315,6 @@ protected:
     bool _prevIgnoreSize;
     
     float _zoomScale;
-    float _sliderBallNormalTextureScaleX;
-    float _sliderBallNormalTextureScaleY;
 
     bool _isSliderBallPressedTextureLoaded;
     bool _isSliderBallDisabledTexturedLoaded;

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIButtonTest/UIButtonTest.cpp
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIButtonTest/UIButtonTest.cpp
@@ -1089,7 +1089,23 @@ bool UIButtonCloneTest::init()
         buttonCopy->setPosition(Vec2(widgetSize.width / 2.0f + 80,
                                      widgetSize.height / 2.0f + 40));
         this->addChild(buttonCopy);
-
+        
+        
+        
+        auto buttonScale9Copy = (Button*)button->clone();
+        buttonScale9Copy->setPosition(button->getPosition() + Vec2(0, -60));
+        buttonScale9Copy->setScale9Enabled(true);
+        buttonScale9Copy->setContentSize(button->getContentSize() * 1.5);
+        this->addChild(buttonScale9Copy);
+        
+        
+        auto buttonScale9Copy2 = (Button*)buttonScale9Copy->clone();
+        buttonScale9Copy2->setPosition(buttonCopy->getPosition() + Vec2(0, -60));
+        buttonScale9Copy2->setScale9Enabled(true);
+        buttonScale9Copy2->setContentSize(buttonCopy->getContentSize() * 1.5);
+        this->addChild(buttonScale9Copy2);
+        
+        
         CCASSERT(button->getTitleRenderer() == nullptr,
                  "Original Button title render must be nullptr ");
 

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIImageViewTest/UIImageViewTest.cpp
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIImageViewTest/UIImageViewTest.cpp
@@ -10,6 +10,7 @@ UIImageViewTests::UIImageViewTests()
     ADD_TEST_CASE(UIImageViewTest_Scale9_State_Change);
     ADD_TEST_CASE(UIImageViewTest_ContentSize);
     ADD_TEST_CASE(UIImageViewFlipTest);
+    ADD_TEST_CASE(UIImageViewIssue12249Test);
 }
 
 // UIImageViewTest
@@ -239,3 +240,49 @@ bool UIImageViewFlipTest::init()
     }
     return false;
 }
+
+
+// UIImageViewIssue12249Test
+
+bool UIImageViewIssue12249Test::init()
+{
+    if (UIScene::init())
+    {
+        SpriteFrameCache::getInstance()->addSpriteFramesWithFile("Images/blocks9ss.plist");
+        Size widgetSize = _widget->getContentSize();
+        
+        Text* alert = Text::create("UIImageViewIssue12249Test", "fonts/Marker Felt.ttf", 26);
+        alert->setColor(Color3B(159, 168, 176));
+        alert->setPosition(Vec2(widgetSize.width / 2.0f,
+                                widgetSize.height / 2.0f - alert->getContentSize().height * 2.125f));
+        
+        _uiLayer->addChild(alert);
+        
+        // Create the imageview
+        ImageView* imageView = ImageView::create("blocks9r.png", Widget::TextureResType::PLIST);
+        imageView->setScale9Enabled(true);
+        imageView->setContentSize(Size(250, imageView->getContentSize().height * 2));
+        imageView->setFlippedX(true);
+        imageView->setScale(0.5);
+        imageView->setPosition(Vec2(widgetSize.width / 2.0f - 80,
+                                    widgetSize.height / 2.0f));
+        
+        _uiLayer->addChild(imageView);
+        
+        ImageView* imageView2 = ImageView::create();
+        imageView2->setScale9Enabled(true);
+        imageView2->loadTexture("blocks9r.png", Widget::TextureResType::PLIST);
+        imageView2->setContentSize(Size(250, imageView2->getContentSize().height * 2));
+        imageView2->setFlippedX(true);
+        imageView2->setScale(0.5);
+        imageView2->setPosition(Vec2(widgetSize.width / 2.0f + 80,
+                                    widgetSize.height / 2.0f));
+        
+        _uiLayer->addChild(imageView2);
+        
+        
+        return true;
+    }
+    return false;
+}
+

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIImageViewTest/UIImageViewTest.h
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIImageViewTest/UIImageViewTest.h
@@ -69,4 +69,12 @@ public:
     virtual bool init() override;
 };
 
+class UIImageViewIssue12249Test : public UIScene
+{
+public:
+    CREATE_FUNC(UIImageViewIssue12249Test);
+    
+    virtual bool init() override;
+};
+
 #endif /* defined(__TestCpp__UIImageViewTest__) */

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UILoadingBarTest/UILoadingBarTest.cpp
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UILoadingBarTest/UILoadingBarTest.cpp
@@ -11,6 +11,7 @@ UILoadingBarTests::UILoadingBarTests()
     ADD_TEST_CASE(UILoadingBarTest_Right_Scale9);
     ADD_TEST_CASE(UILoadingBarTest_Scale9_State_Change);
     ADD_TEST_CASE(UILoadingBarReloadTexture);
+    ADD_TEST_CASE(UILoadingBarIssue12249);
 }
 
 // UILoadingBarTest_Left
@@ -402,4 +403,94 @@ void UILoadingBarReloadTexture::update(float delta)
     }
     LoadingBar* loadingBar = static_cast<LoadingBar*>(_uiLayer->getChildByTag(0));
     loadingBar->setPercent(_count);
+}
+
+
+// UILoadingBarIssue12249
+
+UILoadingBarIssue12249::UILoadingBarIssue12249()
+: _count(0)
+{
+    
+}
+
+UILoadingBarIssue12249::~UILoadingBarIssue12249()
+{
+    unscheduleUpdate();
+}
+
+bool UILoadingBarIssue12249::init()
+{
+    if (UIScene::init())
+    {
+        scheduleUpdate();
+        
+        Size widgetSize = _widget->getContentSize();
+        
+        // Add the alert
+        Text* alert = Text::create("Test LoadingBar Change Direction",
+                                   "fonts/Marker Felt.ttf", 30);
+        alert->setColor(Color3B(159, 168, 176));
+        alert->setPosition(Vec2(widgetSize.width / 2.0f,
+                                widgetSize.height / 2.0f - alert->getContentSize().height * 1.75f));
+        _uiLayer->addChild(alert);
+        
+        // Create the loading bar
+        LoadingBar* loadingBar = LoadingBar::create("cocosui/sliderProgress.png");
+        loadingBar->setScale9Enabled(true);
+        loadingBar->setContentSize(Size(200, loadingBar->getContentSize().height * 1.5));
+        loadingBar->setTag(0);
+        loadingBar->setPosition(Vec2(widgetSize.width / 2.0f,
+                                     widgetSize.height / 2.0f + loadingBar->getContentSize().height / 4.0f));
+        
+        LoadingBar* loadingBarCopy = LoadingBar::create();
+        loadingBarCopy->setScale9Enabled(true);
+        loadingBarCopy->loadTexture("cocosui/sliderProgress.png");
+        loadingBarCopy->setContentSize(Size(200, loadingBarCopy->getContentSize().height * 1.5));
+        loadingBarCopy->setTag(1);
+        loadingBarCopy->setPosition(loadingBar->getPosition()
+                                    + Vec2(0, -40));
+        loadingBarCopy->setDirection(LoadingBar::Direction::RIGHT);
+        
+        Button* button = Button::create("cocosui/animationbuttonnormal.png",
+                                        "cocosui/animationbuttonpressed.png");
+        button->setPosition(Vec2(widgetSize.width / 2.0f, widgetSize.height / 2.0f + 50));
+        button->setTitleText("Click to change direction!");
+        
+        button->addTouchEventListener([=](Ref*, Widget::TouchEventType type)
+                                      {
+                                          if (type == Widget::TouchEventType::ENDED)
+                                          {
+                                              if (loadingBar->getDirection() == LoadingBar::Direction::LEFT)
+                                              {
+                                                  loadingBar->setDirection(LoadingBar::Direction::RIGHT);
+                                                  loadingBarCopy->setDirection(LoadingBar::Direction::LEFT);
+                                              }
+                                              else
+                                              {
+                                                  loadingBar->setDirection(LoadingBar::Direction::LEFT);
+                                                  loadingBarCopy->setDirection(LoadingBar::Direction::RIGHT);
+                                              }
+                                          }
+                                      });
+        _uiLayer->addChild(loadingBar,1);
+        _uiLayer->addChild(loadingBarCopy,2);
+        _uiLayer->addChild(button);
+        
+        return true;
+    }
+    return false;
+}
+
+void UILoadingBarIssue12249::update(float delta)
+{
+    _count++;
+    if (_count > 100)
+    {
+        _count = 0;
+    }
+    LoadingBar* loadingBar = static_cast<LoadingBar*>(_uiLayer->getChildByTag(0));
+    LoadingBar* loadingBarCopy = static_cast<LoadingBar*>(_uiLayer->getChildByTag(1));
+    loadingBar->setPercent(_count);
+    loadingBarCopy->setPercent(_count);
 }

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UILoadingBarTest/UILoadingBarTest.h
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UILoadingBarTest/UILoadingBarTest.h
@@ -113,4 +113,18 @@ protected:
     
 };
 
+class UILoadingBarIssue12249 : public UIScene
+{
+public:
+    CREATE_FUNC(UILoadingBarIssue12249);
+    
+    UILoadingBarIssue12249();
+    ~UILoadingBarIssue12249();
+    virtual bool init() override;
+    void update(float delta)override;
+    
+protected:
+    int _count;
+};
+
 #endif /* defined(__TestCpp__UILoadingBarTest__) */

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UISliderTest/UISliderTest.cpp
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UISliderTest/UISliderTest.cpp
@@ -11,6 +11,7 @@ UISliderTests::UISliderTests()
     ADD_TEST_CASE(UISliderNormalDefaultTest);
     ADD_TEST_CASE(UISliderDisabledDefaultTest);
     ADD_TEST_CASE(UISliderNewEventCallbackTest);
+    ADD_TEST_CASE(UISliderIssue12249Test);
 }
 
 // UISliderTest
@@ -369,4 +370,58 @@ bool UISliderNewEventCallbackTest::init()
         return true;
     }
     return false;
+}
+
+
+// UISliderIssue12249Test
+
+UISliderIssue12249Test::UISliderIssue12249Test()
+: _displayValueLabel(nullptr)
+{
+    
+}
+
+UISliderIssue12249Test::~UISliderIssue12249Test()
+{
+}
+
+bool UISliderIssue12249Test::init()
+{
+    if (UIScene::init())
+    {
+        Size widgetSize = _widget->getContentSize();
+        
+        // Add a label in which the slider alert will be displayed
+        _displayValueLabel = TextBMFont::create("Move the slider thumb", "ccb/markerfelt24shadow.fnt");
+        _displayValueLabel->setAnchorPoint(Vec2(0.5f, -1));
+        _displayValueLabel->setPosition(Vec2(widgetSize.width / 2.0f, widgetSize.height / 2.0f));
+        _uiLayer->addChild(_displayValueLabel);
+        
+        // Create the slider
+        Slider* slider = Slider::create();
+        slider->setScale9Enabled(true);
+        slider->loadBarTexture("cocosui/sliderTrack.png");
+        slider->loadSlidBallTextures("cocosui/sliderThumb.png", "cocosui/sliderThumb.png", "");
+        slider->loadProgressBarTexture("cocosui/sliderProgress.png");
+        slider->setContentSize(Size(300, slider->getContentSize().height * 1.5));
+        slider->setMaxPercent(10000);
+        slider->setPosition(Vec2(widgetSize.width / 2.0f, widgetSize.height / 2.0f/* + slider->getSize().height * 2.0f*/));
+        slider->addEventListener(CC_CALLBACK_2(UISliderIssue12249Test::sliderEvent, this));
+        _uiLayer->addChild(slider);
+        
+        
+        return true;
+    }
+    return false;
+}
+
+void UISliderIssue12249Test::sliderEvent(Ref *pSender, Slider::EventType type)
+{
+    if (type == Slider::EventType::ON_PERCENTAGE_CHANGED)
+    {
+        Slider* slider = dynamic_cast<Slider*>(pSender);
+        int percent = slider->getPercent();
+        int maxPercent = slider->getMaxPercent();
+        _displayValueLabel->setString(StringUtils::format("Percent %f", 10000.0 * percent / maxPercent));
+    }
 }

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UISliderTest/UISliderTest.h
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UISliderTest/UISliderTest.h
@@ -110,4 +110,18 @@ public:
 protected:
     cocos2d::ui::Text* _displayValueLabel;
 };
+
+class UISliderIssue12249Test : public UIScene
+{
+public:
+    CREATE_FUNC(UISliderIssue12249Test);
+    
+    UISliderIssue12249Test();
+    ~UISliderIssue12249Test();
+    virtual bool init() override;
+    void sliderEvent(cocos2d::Ref* sender, cocos2d::ui::Slider::EventType type);
+    
+protected:
+    cocos2d::ui::TextBMFont* _displayValueLabel;
+};
 #endif /* defined(__TestCpp__UISliderTest__) */


### PR DESCRIPTION
1.  It simplify the logic to calculate the size for the original "non scale9" enabled widget.
   We don't need to scale the sprite, instead we could switch the scale9sprite to SIMPLE rendering mode.
2. Fix scale9 enabled button clone size issue.
3. Fix #12249 Note: All the scale9 enabled widget has similar issue with 12249
