### PR TITLE
Copy the resources to a separate folder on the Win32 output directory

### DIFF
--- a/templates/cpp-template-default/proj.win32/HelloCpp.vcxproj
+++ b/templates/cpp-template-default/proj.win32/HelloCpp.vcxproj
@@ -101,8 +101,8 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup>
     <CustomBuildStep>
-      <Command>if not exist "$(OutDir)" mkdir "$(OutDir)"
-xcopy "$(ProjectDir)..\Resources" "$(OutDir)" /D /E /I /F /Y
+      <Command>if not exist "$(OutDir)\Resources" mkdir "$(OutDir)\Resources"
+xcopy "$(ProjectDir)..\Resources" "$(OutDir)\Resources" /D /E /I /F /Y
       </Command>
       <Outputs>$(TargetName).cab</Outputs>
       <Inputs>$(TargetFileName)</Inputs>


### PR DESCRIPTION
Currently, Resources contents are copied to `$(OutDir)`. And that makes that folder overly crowded and hard to find the resource folders. This commit creates a `$(OutDir)\Resources` and copies the contents to that place.
