### PR TITLE
Fix deprecation warning in FontFNT

### DIFF
--- a/cocos/2d/CCFontFNT.cpp
+++ b/cocos/2d/CCFontFNT.cpp
@@ -821,7 +821,7 @@ void FontFNT::reloadBMFontResource(const std::string& fntFilePath)
     if (ret)
     {
         s_configurations->insert(fntFilePath, ret);
-        TextureCache::getInstance()->reloadTexture(ret->getAtlasName());
+        Director::getInstance()->getTextureCache()->reloadTexture(ret->getAtlasName());
 
     }
 }


### PR DESCRIPTION
This fixes the following warning when compiling in Xcode 7:

```
cocos/2d/CCFontFNT.cpp:824:23: 'getInstance' is deprecated
cocos/renderer/CCTextureCache.h:68:51: 'getInstance' has been explicitly marked deprecated here
```
