### PR TITLE
Fix keyboard type for cocos2d::ui::EditBox::InputMode::NUMERIC.

### DIFF
--- a/cocos/ui/UIEditBox/iOS/CCUIEditBoxIOS.mm
+++ b/cocos/ui/UIEditBox/iOS/CCUIEditBoxIOS.mm
@@ -155,7 +155,7 @@
             self.keyboardType = UIKeyboardTypeEmailAddress;
             break;
         case cocos2d::ui::EditBox::InputMode::NUMERIC:
-            self.keyboardType = UIKeyboardTypeDecimalPad;
+            self.keyboardType = UIKeyboardTypeNumberPad;
             break;
         case cocos2d::ui::EditBox::InputMode::PHONE_NUMBER:
             self.keyboardType = UIKeyboardTypePhonePad;


### PR DESCRIPTION
Should be UIKeyboardTypeNumberPad.
