### PR TITLE
fix setflip for batch sprite

### DIFF
--- a/cocos/2d/CCSprite.cpp
+++ b/cocos/2d/CCSprite.cpp
@@ -578,15 +578,6 @@ void Sprite::updateTransform(void)
             float x2 = x1 + size.width;
             float y2 = y1 + size.height;
             
-            if (_flippedX)
-            {
-                std::swap(x1, x2);
-            }
-            if (_flippedY)
-            {
-                std::swap(y1, y2);
-            }
-            
             float x = _transformToBatch.m[12];
             float y = _transformToBatch.m[13];
 
@@ -610,6 +601,7 @@ void Sprite::updateTransform(void)
             _quad.br.vertices.set(SPRITE_RENDER_IN_SUBPIXEL(bx), SPRITE_RENDER_IN_SUBPIXEL(by), _positionZ);
             _quad.tl.vertices.set(SPRITE_RENDER_IN_SUBPIXEL(dx), SPRITE_RENDER_IN_SUBPIXEL(dy), _positionZ);
             _quad.tr.vertices.set(SPRITE_RENDER_IN_SUBPIXEL(cx), SPRITE_RENDER_IN_SUBPIXEL(cy), _positionZ);
+            setTextureCoords(_rect);
         }
 
         // MARMALADE CHANGE: ADDED CHECK FOR nullptr, TO PERMIT SPRITES WITH NO BATCH NODE / TEXTURE ATLAS


### PR DESCRIPTION
Since we use _quad.bl, _quad.br, _quad.tl, _quad.tr, we should modify the texture coordinates of it according to flip flag.
