### PR TITLE
Remove duplicate allocation to fix memory leak

### DIFF
--- a/cocos/editor-support/cocostudio/ActionTimeline/CCActionTimelineCache.cpp
+++ b/cocos/editor-support/cocostudio/ActionTimeline/CCActionTimelineCache.cpp
@@ -951,8 +951,6 @@ ActionTimeline* ActionTimelineCache::createActionWithFlatBuffersForSimulator(con
     auto csparsebinary = GetCSParseBinary(builder->GetBufferPointer());
     auto nodeAction = csparsebinary->action();
     
-    action = ActionTimeline::create();
-    
     int duration = nodeAction->duration();
     action->setDuration(duration);
     


### PR DESCRIPTION
The `action` is created at line 954 of `CCActionTimelineCache.cpp` but `ActionTimeline::create()` has already been called at line 949.

``` cpp
949: ActionTimeline* action = ActionTimeline::create();
950: 
      ...
953:
954: action = ActionTimeline::create(); // memory leak
```

There is a memory leak here, and this patch fixes it, thanks.
