### PR TITLE
fix Shader-Sprite crash when shader can not compile

### DIFF
--- a/tests/cpp-tests/Classes/ShaderTest/ShaderTest2.cpp
+++ b/tests/cpp-tests/Classes/ShaderTest/ShaderTest2.cpp
@@ -93,9 +93,14 @@ public:
 
                 if(std::get<0>(effect) >=0)
                     break;
-                QuadCommand &q = std::get<2>(effect);
-                q.init(_globalZOrder, _texture->getName(), std::get<1>(effect)->getGLProgramState(), _blendFunc, &_quad, 1, transform, flags);
-                renderer->addCommand(&q);
+                auto glProgramState = std::get<1>(effect)->getGLProgramState();
+                if (glProgramState)
+                {
+                    QuadCommand &q = std::get<2>(effect);
+                    q.init(_globalZOrder, _texture->getName(), glProgramState, _blendFunc, &_quad, 1, transform, flags);
+                    renderer->addCommand(&q);
+                }
+                
                 idx++;
 
             }
@@ -144,8 +149,8 @@ bool Effect::initGLProgramState(const std::string &fragmentFilename)
     _fragSource = fragSource;
 #endif
     
-    _glprogramstate = GLProgramState::getOrCreateWithGLProgram(glprogram);
-    _glprogramstate->retain();
+    _glprogramstate = (glprogram == nullptr ? nullptr : GLProgramState::getOrCreateWithGLProgram(glprogram));
+    CC_SAFE_RETAIN(_glprogramstate);
 
     return _glprogramstate != nullptr;
 }
@@ -194,6 +199,9 @@ protected:
 
 void EffectBlur::setTarget(EffectSprite *sprite)
 {
+    if (_glprogramstate == nullptr)
+        return;
+    
     Size size = sprite->getTexture()->getContentSizeInPixels();
     _glprogramstate->setUniformVec2("resolution", size);
 #if (CC_TARGET_PLATFORM != CC_PLATFORM_WINRT)


### PR DESCRIPTION
Blur shader can not compile on XiaoMi3 because of the for statement in the shader.
And it will crash.
