### PR TITLE
Add TextureCache::addTexture

### DIFF
--- a/cocos/renderer/CCTextureCache.cpp
+++ b/cocos/renderer/CCTextureCache.cpp
@@ -422,6 +422,21 @@ Texture2D* TextureCache::addImage(Image *image, const std::string &key)
     return texture;
 }
 
+void TextureCache::addTexture(Texture2D *tex, const std::string &key)
+{
+    CCASSERT(tex != nullptr, "TextureCache: Texture MUST not be nil");
+
+    auto it = _textures.find(key);
+    if( it != _textures.end() ) {
+        CCLOG("TextureCache: failed to add texture to TextureCache, the key (%s) already exist", key.c_str());
+        return;
+    }
+
+    _textures.insert( std::make_pair(key, tex) );
+    tex->retain();
+    tex->autorelease();
+}
+
 bool TextureCache::reloadTexture(const std::string& fileName)
 {
     Texture2D * texture = nullptr;

--- a/cocos/renderer/CCTextureCache.h
+++ b/cocos/renderer/CCTextureCache.h
@@ -144,6 +144,13 @@ public:
     Texture2D* addImage(Image *image, const std::string &key);
     CC_DEPRECATED_ATTRIBUTE Texture2D* addUIImage(Image *image, const std::string& key) { return addImage(image,key); }
 
+    /**
+    * Add a new texture object to the texture cache with the given key.
+    * @param tex The texture object to be added.
+    * @param key Used as the key for the texture.
+    */
+    void addTexture(Texture2D *tex, const std::string &key);
+
     /** Returns an already created texture. Returns nil if the texture doesn't exist.
     @param key It's the related/absolute path of the file image.
     @since v0.99.5


### PR DESCRIPTION
Related web engine PR: https://github.com/cocos2d/cocos2d-html5/pull/3214

@ricardoquesada Adding texture directly with a key into TextureCache have been frequently requested, I also think it's very useful, so took some time to create a patch. What do you think ?
