### PR TITLE
Fix a 'heap use after free' crash in ActionManager::update.

### DIFF
--- a/cocos/2d/CCActionManager.cpp
+++ b/cocos/2d/CCActionManager.cpp
@@ -448,7 +448,16 @@ void ActionManager::update(float dt)
         // only delete currentTarget if no actions were scheduled during the cycle (issue #481)
         if (_currentTargetSalvaged && _currentTarget->actions->num == 0)
         {
-            deleteHashElement(_currentTarget);
+            // N.B - CRASH FIX! Close a small window of opportunity here where the next hash element could
+            // potentially be destroyed before we move onto it. Calling 'deleteHashElement' could potentially
+            // trigger a series of cleanup/deallocation calls which might result in the hash element pointed
+            // to by 'elt' being destroyed before the next loop iteration. Combat this by setting '_currentTarget'
+            // here early, before the next loop iteration. This will safeguard the next hash element from being
+            // destroyed before we move onto it:
+            tHashElement* hashElementToDelete = _currentTarget;
+            _currentTarget = elt;
+            _currentTargetSalvaged = false;
+            deleteHashElement(hashElementToDelete);
         }
     }
 

--- a/tests/cpp-tests/Classes/ActionManagerTest/ActionManagerTest.h
+++ b/tests/cpp-tests/Classes/ActionManagerTest/ActionManagerTest.h
@@ -30,6 +30,17 @@ public:
     void removeThis();
 };
 
+class CrashTest2 : public ActionManagerTest
+{
+public:
+    CREATE_FUNC(CrashTest2);
+    
+    virtual std::string subtitle() const override;
+    virtual void onEnter() override;
+    virtual void onExit() override;
+    virtual void update(float dt) override;
+};
+
 class LogicTest : public ActionManagerTest
 {
 public:


### PR DESCRIPTION
In some circumstances it was possible to get the ActionManager to access a hash element that had been destroyed due to certain cleanup patterns in user code. This may result in random crashes depending on the environment and how strictly it treats invalid memory access. This change fixes the crash and adds a test case to reproduce the original crash without the fix applied. Note: on iOS you should enable the Xcode 'address sanitizer' feature in the Xcode Scheme in order to reproduce this crash more easily; it may be difficult to reproduce otherwise, especially for debug builds.
