### PR TITLE
Replaced uthash...

### DIFF
--- a/build/cocos2d_tests.xcodeproj/xcshareddata/xcschemes/js-tests Mac.xcscheme
+++ b/build/cocos2d_tests.xcodeproj/xcshareddata/xcschemes/js-tests Mac.xcscheme
@@ -49,7 +49,6 @@
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
-      enableAddressSanitizer = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
       <BuildableProductRunnable

--- a/build/cocos2d_tests.xcodeproj/xcshareddata/xcschemes/js-tests Mac.xcscheme
+++ b/build/cocos2d_tests.xcodeproj/xcshareddata/xcschemes/js-tests Mac.xcscheme
@@ -49,6 +49,7 @@
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
+      enableAddressSanitizer = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
       <BuildableProductRunnable

--- a/cocos/base/CCRef.cpp
+++ b/cocos/base/CCRef.cpp
@@ -36,7 +36,7 @@ NS_CC_BEGIN
 
 // EXPERIMENTAL: Enable this in order to get rid of retain/release
 // when using the Garbage Collector
-#define CC_ENABLE_GC_FOR_NATIVE_OBJECTS 1
+#define CC_ENABLE_GC_FOR_NATIVE_OBJECTS 0
 
 #if CC_REF_LEAK_DETECTION
 static void trackRef(Ref* ref);

--- a/cocos/base/CCRef.cpp
+++ b/cocos/base/CCRef.cpp
@@ -36,7 +36,7 @@ NS_CC_BEGIN
 
 // EXPERIMENTAL: Enable this in order to get rid of retain/release
 // when using the Garbage Collector
-#define CC_ENABLE_GC_FOR_NATIVE_OBJECTS 0
+#define CC_ENABLE_GC_FOR_NATIVE_OBJECTS 1
 
 #if CC_REF_LEAK_DETECTION
 static void trackRef(Ref* ref);

--- a/cocos/scripting/js-bindings/manual/ScriptingCore.cpp
+++ b/cocos/scripting/js-bindings/manual/ScriptingCore.cpp
@@ -78,7 +78,7 @@
 
 // EXPERIMENTAL: Enable this in order to get rid of retain/release
 // when using the Garbage Collector
-#define CC_ENABLE_GC_FOR_NATIVE_OBJECTS 0
+#define CC_ENABLE_GC_FOR_NATIVE_OBJECTS 1
 
 using namespace cocos2d;
 
@@ -93,9 +93,12 @@ static uint32_t s_nestedLoopLevel = 0;
 // server entry point for the bg thread
 static void serverEntryPoint(unsigned int port);
 
-js_proxy_t *_native_js_global_ht = NULL;
-js_proxy_t *_js_native_global_ht = NULL;
+//js_proxy_t *_native_js_global_ht = NULL;
+//js_proxy_t *_js_native_global_ht = NULL;
 std::unordered_map<std::string, js_type_class_t*> _js_global_type_map;
+static std::unordered_map<void*, js_proxy_t*> _native_js_global_map;
+static std::unordered_map<JSObject*, js_proxy_t*> _js_native_global_map;
+
 
 static char *_js_log_buf = NULL;
 
@@ -214,25 +217,19 @@ static std::string getMouseFuncName(EventMouse::MouseEventType eventType)
 
 static void removeJSObject(JSContext* cx, cocos2d::Ref* nativeObj)
 {
-    js_proxy_t* nproxy;
-    js_proxy_t* jsproxy;
-
-    nproxy = jsb_get_native_proxy(nativeObj);
-    if (nproxy)
+    auto proxy = jsb_get_native_proxy(nativeObj);
+    if (proxy)
     {
-        jsproxy = jsb_get_js_proxy(nproxy->obj);
-        JS::RemoveObjectRoot(cx, &jsproxy->obj);
-
 #if CC_ENABLE_GC_FOR_NATIVE_OBJECTS
         nativeObj->_rooted = false;
-
         // FIXME BUG TODO: remove this line... but if I do so
         // another misterious bug appears
-        jsb_remove_proxy(nproxy, jsproxy);
+//        jsb_remove_proxy(proxy);
 #else
         // only remove when not using GC,
         // otherwise finalize won't be able to find the proxy
-        jsb_remove_proxy(nproxy, jsproxy);
+        JS::RemoveObjectRoot(cx, &proxy->obj);
+        jsb_remove_proxy(proxy);
 #endif
     }
     else CCLOG("removeJSObject: BUG: cannot find native object = %p", nativeObj);
@@ -539,19 +536,20 @@ void ScriptingCore::addRegisterCallback(sc_register_sth callback) {
     registrationList.push_back(callback);
 }
 
-void ScriptingCore::removeAllRoots(JSContext *cx) {
-    js_proxy_t *current, *tmp;
-    HASH_ITER(hh, _js_native_global_ht, current, tmp) {
-        RemoveObjectRoot(cx, &current->obj);
-        HASH_DEL(_js_native_global_ht, current);
-        free(current);
+void ScriptingCore::removeAllRoots(JSContext *cx)
+{
+    // Native -> JS. No need to free "second"
+    _native_js_global_map.clear();
+
+    // JS -> Native: free "second" and "unroot" it.
+    auto it_js = _js_native_global_map.begin();
+    while (it_js != _js_native_global_map.end())
+    {
+        JS::RemoveObjectRoot(cx, &it_js->second->obj);
+        free(it_js->second);
+        it_js = _js_native_global_map.erase(it_js);
     }
-    HASH_ITER(hh, _native_js_global_ht, current, tmp) {
-        HASH_DEL(_native_js_global_ht, current);
-        free(current);
-    }
-    HASH_CLEAR(hh, _js_native_global_ht);
-    HASH_CLEAR(hh, _native_js_global_ht);
+    _js_native_global_map.clear();
 }
 
 // Just a wrapper around JSPrincipals that allows static construction.
@@ -878,22 +876,15 @@ bool ScriptingCore::log(JSContext* cx, uint32_t argc, jsval *vp)
 }
 
 
-void ScriptingCore::removeScriptObjectByObject(Ref* pObj)
+void ScriptingCore::removeScriptObjectByObject(cocos2d::Ref* nativeObj)
 {
-    js_proxy_t* nproxy;
-    js_proxy_t* jsproxy;
-    void *ptr = (void*)pObj;
-    nproxy = jsb_get_native_proxy(ptr);
-    if (nproxy)
+    auto proxy = jsb_get_native_proxy(nativeObj);
+    if (proxy)
     {
         JSContext *cx = getGlobalContext();
-        jsproxy = jsb_get_js_proxy(nproxy->obj);
-        if (jsproxy)
-        {
-            RemoveObjectRoot(cx, &jsproxy->obj);
-            jsb_remove_proxy(nproxy, jsproxy);
-        }
-//        else CCLOG("removeScriptObjectByObject. BUG: jsproxy not found = %p", nproxy);
+        // copy it before removing it
+        JS::RemoveObjectRoot(cx, &proxy->obj);
+        jsb_remove_proxy(proxy);
     }
 //    else CCLOG("removeScriptObjectByObject. BUG: nproxy not found = %p", nproxy);
 }
@@ -978,7 +969,7 @@ bool ScriptingCore::removeRootJS(JSContext *cx, uint32_t argc, jsval *vp)
         JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
         JS::Heap<JSObject*> o(args.get(0).toObjectOrNull());
         if (o != nullptr) {
-            RemoveObjectRoot(cx, &o);
+            JS::RemoveObjectRoot(cx, &o);
         }
         return true;
     }
@@ -1154,7 +1145,7 @@ int ScriptingCore::handleComponentEvent(void* data)
     JS::RootedValue retval(_cx);
     jsval dataVal = INT_TO_JSVAL(1);
     
-    JS::RootedValue nodeValue(_cx, OBJECT_TO_JSVAL(p->obj.get()));
+    JS::RootedValue nodeValue(_cx, OBJECT_TO_JSVAL(p->obj));
     
     if (action == kComponentOnAdd)
     {
@@ -1284,13 +1275,13 @@ bool ScriptingCore::handleMouseEvent(void* nativeObj, cocos2d::EventMouse::Mouse
     js_proxy_t * p = jsb_get_native_proxy(nativeObj);
     if (p)
     {
-        jsval dataVal[1];
         js_type_class_t *typeClass = js_get_type_from_native<cocos2d::Event>(event);
-        dataVal[0] = OBJECT_TO_JSVAL(jsb_ref_get_or_create_jsobject(_cx, event, typeClass, "cocos2d::Event"));
-        ret = executeFunctionWithOwner(OBJECT_TO_JSVAL(p->obj), funcName.c_str(), 1, dataVal, jsvalRet);
-    }
+        jsval dataVal = OBJECT_TO_JSVAL(jsb_ref_get_or_create_jsobject(_cx, event, typeClass, "cocos2d::Event"));
+        ret = executeFunctionWithOwner(OBJECT_TO_JSVAL(p->obj), funcName.c_str(), 1, &dataVal, jsvalRet);
 
-    removeJSObject(_cx, event);
+        removeJSObject(_cx, event);
+    }
+    else CCLOG("ScriptingCore::handleMouseEvent native proxy NOT found");
     
     return ret;
 }
@@ -1572,14 +1563,10 @@ bool ScriptingCore::isObjectValid(JSContext *cx, uint32_t argc, jsval *vp)
 
 void ScriptingCore::rootObject(Ref* ref)
 {
-    js_proxy_t* nproxy;
-    js_proxy_t* jsproxy;
-    void *ptr = (void*)ref;
-    nproxy = jsb_get_native_proxy(ptr);
-    if (nproxy) {
+    auto proxy = jsb_get_native_proxy(ref);
+    if (proxy) {
         JSContext *cx = getGlobalContext();
-        jsproxy = jsb_get_js_proxy(nproxy->obj);
-        JS::AddNamedObjectRoot(cx, &jsproxy->obj, typeid(*ref).name());
+        JS::AddNamedObjectRoot(cx, &proxy->obj, typeid(*ref).name());
         ref->_rooted = true;
     }
     else CCLOG("rootObject: BUG. native not found: %p",  ref);
@@ -1587,15 +1574,10 @@ void ScriptingCore::rootObject(Ref* ref)
 
 void ScriptingCore::unrootObject(Ref* ref)
 {
-    js_proxy_t* nproxy;
-    js_proxy_t* jsproxy;
-    void *ptr = (void*)ref;
-
-    nproxy = jsb_get_native_proxy(ptr);
-    if (nproxy) {
+    auto proxy = jsb_get_native_proxy(ref);
+    if (proxy) {
         JSContext *cx = getGlobalContext();
-        jsproxy = jsb_get_js_proxy(nproxy->obj);
-        JS::RemoveObjectRoot(cx, &jsproxy->obj);
+        JS::RemoveObjectRoot(cx, &proxy->obj);
         ref->_rooted = false;
     }
     else CCLOG("unrootObject: BUG. native not found: %p",  ref);
@@ -1924,63 +1906,88 @@ bool jsb_get_reserved_slot(JSObject *obj, uint32_t idx, jsval& ret)
     return true;
 }
 
-js_proxy_t* jsb_new_proxy(void* nativeObj, JS::HandleObject jsObj)
+js_proxy_t* jsb_new_proxy(void* nativeObj, JS::HandleObject jsHandle)
 {
-    js_proxy_t* p = nullptr;
-    JSObject* ptr = jsObj.get();
+    js_proxy_t* proxy = nullptr;
+    JSObject* jsObj = jsHandle.get();
 
-    // native to JS index
-    p = (js_proxy_t *)malloc(sizeof(js_proxy_t));
-    assert(p);
-    js_proxy_t* nativeObjJsObjtmp = NULL;
-    HASH_FIND_PTR(_native_js_global_ht, &nativeObj, nativeObjJsObjtmp);
-    assert(!nativeObjJsObjtmp);
-    p->ptr = nativeObj;
-    p->obj = ptr;
-    HASH_ADD_PTR(_native_js_global_ht, ptr, p);
+    if (nativeObj && jsObj)
+    {
+        // native to JS index
+        proxy = (js_proxy_t *)malloc(sizeof(js_proxy_t));
+        CC_ASSERT(proxy && "not enough memory");
+        CC_ASSERT(_native_js_global_map.find(nativeObj) == _native_js_global_map.end() && "Native Key should not be present");
+        CC_ASSERT(_js_native_global_map.find(jsObj) == _js_native_global_map.end() && "JS Key should not be present");
 
-    // JS to native Index
-    p = (js_proxy_t *)malloc(sizeof(js_proxy_t));
-    assert(p);
-    nativeObjJsObjtmp = NULL;
-    HASH_FIND_PTR(_js_native_global_ht, &ptr, nativeObjJsObjtmp);
-    assert(!nativeObjJsObjtmp);
-    p->ptr = nativeObj;
-    p->obj = ptr;
-    HASH_ADD_PTR(_js_native_global_ht, obj, p);
+        proxy->ptr = nativeObj;
+        proxy->obj = jsObj;
+        proxy->_jsobj = jsObj;
 
-    return p;
+        // One Proxy in two entries
+        _native_js_global_map[nativeObj] = proxy;
+        _js_native_global_map[jsObj] = proxy;
+
+        CCLOG("jsb_new_proxy: %p,%p = %p", nativeObj, jsObj, proxy);
+    }
+    else CCLOG("jsb_new_proxy: Invalid keys");
+
+    return proxy;
 }
 
 js_proxy_t* jsb_get_native_proxy(void* nativeObj)
 {
-    js_proxy_t* p = nullptr;
-    HASH_FIND_PTR(_native_js_global_ht, &nativeObj, p);
-    return p;
+    auto search = _native_js_global_map.find(nativeObj);
+    if(search != _native_js_global_map.end())
+        return search->second;
+    return nullptr;
 }
 
 js_proxy_t* jsb_get_js_proxy(JSObject* jsObj)
 {
-    js_proxy_t* p = nullptr;
-    HASH_FIND_PTR(_js_native_global_ht, &jsObj, p);
-    return p;
+    auto search = _js_native_global_map.find(jsObj);
+    if(search != _js_native_global_map.end())
+        return search->second;
+    return nullptr;
 }
 
 void jsb_remove_proxy(js_proxy_t* nativeProxy, js_proxy_t* jsProxy)
 {
-    if (nativeProxy)
-    {
-        HASH_DEL(_native_js_global_ht, nativeProxy);
-        free(nativeProxy);
-    }
-    else CCLOG("jsb_remove_proxy: BUG: nativeProxy is null");
+    js_proxy_t* proxy = nativeProxy ? nativeProxy : jsProxy;
+    jsb_remove_proxy(proxy);
+}
 
-    if (jsProxy)
+void jsb_remove_proxy(js_proxy_t* proxy)
+{
+    void* nativeKey = proxy->ptr;
+    JSObject* jsKey = proxy->_jsobj;
+
+    CC_ASSERT(nativeKey && "Invalid nativeKey");
+    CC_ASSERT(jsKey && "Invalid JSKey");
+
+    CCLOG("jsb_remove_proxy: %p,%p", nativeKey, jsKey);
+
+    auto it_nat = _native_js_global_map.find(nativeKey);
+    auto it_js = _js_native_global_map.find(jsKey);
+
+    // XXX FIXME: sanity check. Remove me once it is tested that it works Ok
+    if (it_nat != _native_js_global_map.end() && it_js != _js_native_global_map.end())
     {
-        HASH_DEL(_js_native_global_ht, jsProxy);
-        free(jsProxy);
+        CC_ASSERT(it_nat->second == it_js->second && "BUG. Different enties");
     }
-    else CCLOG("jsb_remove_proxy: BUG: jsProxy is null");
+
+    if (it_nat != _native_js_global_map.end())
+    {
+        _native_js_global_map.erase(it_nat);
+    }
+    else CCLOG("jsb_remove_proxy: failed. Native key not found");
+
+    if (it_js != _js_native_global_map.end())
+    {
+        // Free it once, since we only have one proxy alloced entry
+        free(it_js->second);
+        _js_native_global_map.erase(it_js);
+    }
+    else CCLOG("jsb_remove_proxy: failed. JS key not found");
 }
 
 //
@@ -2012,8 +2019,13 @@ JSObject* jsb_ref_autoreleased_create_jsobject(JSContext *cx, cocos2d::Ref *ref,
 JSObject* jsb_ref_get_or_create_jsobject(JSContext *cx, cocos2d::Ref *ref, js_type_class_t *typeClass, const char* debug)
 {
     auto proxy = jsb_get_native_proxy(ref);
-    if (proxy)
+    if (proxy) {
+#if CC_ENABLE_GC_FOR_NATIVE_OBJECTS
+        // needed, since removeObject() might "unown it"
+        ref->_scriptOwned = true;
+#endif //
         return proxy->obj;
+    }
 
     // don't auto-release, don't retain.
     JS::RootedObject proto(cx, typeClass->proto.ref());
@@ -2081,22 +2093,14 @@ void jsb_ref_autoreleased_init(JSContext* cx, JS::Heap<JSObject*> *obj, Ref* ref
 void jsb_ref_finalize(JSFreeOp* fop, JSObject* obj)
 {
 #if CC_ENABLE_GC_FOR_NATIVE_OBJECTS
-    js_proxy_t* nproxy;
-    js_proxy_t* jsproxy;
-
-    jsproxy = jsb_get_js_proxy(obj);
-    if (jsproxy)
+    auto proxy = jsb_get_js_proxy(obj);
+    if (proxy)
     {
-        auto ref = static_cast<cocos2d::Ref*>(jsproxy->ptr);
-        nproxy = jsb_get_native_proxy(jsproxy->ptr);
-
+        auto ref = static_cast<cocos2d::Ref*>(proxy->ptr);
+        CCLOG("jsb_ref_finalize: %s", typeid(*ref).name());
+        jsb_remove_proxy(proxy);
         if (ref)
-        {
-            jsb_remove_proxy(nproxy, jsproxy);
             ref->release();
-        }
-        else
-            jsb_remove_proxy(nullptr, jsproxy);
     }
     else CCLOG("jsb_ref_finalize: BUG: proxy not found for %p", obj);
 #else
@@ -2105,12 +2109,12 @@ void jsb_ref_finalize(JSFreeOp* fop, JSObject* obj)
 }
 
 // rebind
-void jsb_ref_rebind(JSContext* cx, JS::HandleObject jsobj, js_proxy_t *js2native_proxy, cocos2d::Ref* oldRef, cocos2d::Ref* newRef, const char* debug)
+void jsb_ref_rebind(JSContext* cx, JS::HandleObject jsobj, js_proxy_t *proxy, cocos2d::Ref* oldRef, cocos2d::Ref* newRef, const char* debug)
 {
 #if not CC_ENABLE_GC_FOR_NATIVE_OBJECTS
-    JS::RemoveObjectRoot(cx, &js2native_proxy->obj);
+    JS::RemoveObjectRoot(cx, &proxy->obj);
 #endif
-    jsb_remove_proxy(jsb_get_native_proxy(oldRef), js2native_proxy);
+    jsb_remove_proxy(proxy);
 
     // Rebind js obj with new action
     js_proxy_t* newProxy = jsb_new_proxy(newRef, jsobj);

--- a/cocos/scripting/js-bindings/manual/ScriptingCore.h
+++ b/cocos/scripting/js-bindings/manual/ScriptingCore.h
@@ -562,10 +562,17 @@ js_type_class_t *jsb_register_class(JSContext *cx, JSClass *jsClass, JS::HandleO
     return p;
 }
 
+/** creates two new proxies: one associaged with the nativeObj,
+ and another one associated with the JsObj */
 js_proxy_t* jsb_new_proxy(void* nativeObj, JS::HandleObject jsObj);
+/** returns the proxy associated with the Native* */
 js_proxy_t* jsb_get_native_proxy(void* nativeObj);
+/** returns the proxy associated with the JSObject* */
 js_proxy_t* jsb_get_js_proxy(JSObject* jsObj);
+/** deprecated: use jsb_remove_proxy(js_proxy_t* proxy) instead */
 void jsb_remove_proxy(js_proxy_t* nativeProxy, js_proxy_t* jsProxy);
+/** removes both the native and js proxies */
+void jsb_remove_proxy(js_proxy_t* proxy);
 
 /**
  * Generic initialization function for subclasses of Ref

--- a/cocos/scripting/js-bindings/manual/cocos2d_specifics.cpp
+++ b/cocos/scripting/js-bindings/manual/cocos2d_specifics.cpp
@@ -5549,20 +5549,15 @@ bool js_cocos2dx_PolygonInfo_constructor(JSContext *cx, uint32_t argc, jsval *vp
 
 void js_cocos2d_PolygonInfo_finalize(JSFreeOp *fop, JSObject *obj) {
     CCLOGINFO("jsbindings: finalizing JS object %p (PolygonInfo)", obj);
-    js_proxy_t* nproxy;
-    js_proxy_t* jsproxy;
     JSContext *cx = ScriptingCore::getInstance()->getGlobalContext();
     JS::RootedObject jsobj(cx, obj);
-    jsproxy = jsb_get_js_proxy(jsobj);
-    if (jsproxy)
+    auto proxy = jsb_get_js_proxy(jsobj);
+    if (proxy)
     {
-        nproxy = jsb_get_native_proxy(jsproxy->ptr);
-        
-        cocos2d::PolygonInfo *nobj = static_cast<cocos2d::PolygonInfo *>(nproxy->ptr);
+        cocos2d::PolygonInfo *nobj = static_cast<cocos2d::PolygonInfo *>(proxy->ptr);
         if (nobj)
             delete nobj;
-        
-        jsb_remove_proxy(nproxy, jsproxy);
+        jsb_remove_proxy(proxy);
     }
 }
 
@@ -5712,19 +5707,14 @@ bool js_cocos2dx_AutoPolygon_constructor(JSContext *cx, uint32_t argc, jsval *vp
 
 void js_cocos2d_AutoPolygon_finalize(JSFreeOp *fop, JSObject *obj) {
     CCLOGINFO("jsbindings: finalizing JS object %p (AutoPolygon)", obj);
-    js_proxy_t* nproxy;
-    js_proxy_t* jsproxy;
     JSContext *cx = ScriptingCore::getInstance()->getGlobalContext();
     JS::RootedObject jsobj(cx, obj);
-    jsproxy = jsb_get_js_proxy(jsobj);
-    if (jsproxy) {
-        nproxy = jsb_get_native_proxy(jsproxy->ptr);
-        
-        cocos2d::AutoPolygon *nobj = static_cast<cocos2d::AutoPolygon *>(nproxy->ptr);
+    auto proxy = jsb_get_js_proxy(jsobj);
+    if (proxy) {
+        cocos2d::AutoPolygon *nobj = static_cast<cocos2d::AutoPolygon *>(proxy->ptr);
         if (nobj)
             delete nobj;
-        
-        jsb_remove_proxy(nproxy, jsproxy);
+        jsb_remove_proxy(proxy);
     }
 }
 

--- a/cocos/scripting/js-bindings/manual/component/CCComponentJS.cpp
+++ b/cocos/scripting/js-bindings/manual/component/CCComponentJS.cpp
@@ -88,12 +88,9 @@ ComponentJS::~ComponentJS()
     if (jsObj && !jsObj->empty())
     {
         // Remove proxy
-        js_proxy_t* jsproxy = jsb_get_js_proxy(jsObj->ref());
-        if (jsproxy)
-        {
-            js_proxy_t* nproxy = jsb_get_native_proxy(jsproxy->ptr);
-            jsb_remove_proxy(nproxy, jsproxy);
-        }
+        js_proxy_t* proxy = jsb_get_js_proxy(jsObj->ref());
+        if (proxy)
+            jsb_remove_proxy(proxy);
     }
     // Delete rooted object
     if (jsObj != nullptr)

--- a/cocos/scripting/js-bindings/manual/network/jsb_websocket.cpp
+++ b/cocos/scripting/js-bindings/manual/network/jsb_websocket.cpp
@@ -139,10 +139,9 @@ public:
         jsval args = OBJECT_TO_JSVAL(jsobj);
         ScriptingCore::getInstance()->executeFunctionWithOwner(OBJECT_TO_JSVAL(_JSDelegate.ref()), "onclose", 1, &args);
 
-        JS::RootedObject wsobj(cx, p->obj);
-        js_proxy_t* jsproxy = jsb_get_js_proxy(wsobj);
-        JS::RemoveObjectRoot(cx, &jsproxy->obj);
-        jsb_remove_proxy(p, jsproxy);
+        auto copy = &p->obj;
+        jsb_remove_proxy(p);
+        JS::RemoveObjectRoot(cx, copy);
         CC_SAFE_DELETE(ws);
     }
     

--- a/cocos/scripting/js-bindings/manual/spidermonkey_specifics.h
+++ b/cocos/scripting/js-bindings/manual/spidermonkey_specifics.h
@@ -25,14 +25,22 @@
 
 #include "jsapi.h"
 #include "jsfriendapi.h"
-#include "uthash.h"
 #include "mozilla/Maybe.h"
 #include <unordered_map>
 
+// No need to keep this struct
+// since we are using unordered_map now
+// but can't remove it since easily since lot's of code depends on it
 typedef struct js_proxy {
+    /** the native object. usually a pointer to cocos2d::Ref, but could be a pointer to another object */
     void *ptr;
+    /** the JS object, as a heap object. Required by GC best practices */
     JS::Heap<JSObject*> obj;
-    UT_hash_handle hh;
+    /** This is the raw pointer. The same as the "obj", but 'raw'. This is needed
+     because under certain circumstances JS::RemoveRootObject will be called on "obj"
+     and "obj" will became NULL. Which is not Ok if we need to use "obj" later for other stuff
+     */
+    JSObject* _jsobj;
 } js_proxy_t;
 
 typedef struct js_type_class {

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIButtonTest/UIButtonTest.cpp
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIButtonTest/UIButtonTest.cpp
@@ -75,7 +75,15 @@ bool UIButtonTest::init()
 
         _uiLayer->addChild(imageView);
 
+        _button = button;
 
+        TTFConfig ttfConfig("fonts/arial.ttf", 15);
+        auto label1 = Label::createWithTTF(ttfConfig, "Print Resources");
+        auto item1 = MenuItemLabel::create(label1, CC_CALLBACK_1(UIButtonTest::printWidgetResources, this));
+        item1->setPosition(Vec2(VisibleRect::left().x + 60, VisibleRect::bottom().y + item1->getContentSize().height * 3));
+        auto pMenu1 = Menu::create(item1, nullptr);
+        pMenu1->setPosition(Vec2(0, 0));
+        this->addChild(pMenu1, 10);
 
         return true;
     }
@@ -115,6 +123,16 @@ void UIButtonTest::touchEvent(Ref *pSender, Widget::TouchEventType type)
         default:
             break;
     }
+}
+
+void UIButtonTest::printWidgetResources(cocos2d::Ref* sender)
+{
+    cocos2d::ResourceData normalFileName = _button->getNormalFile();
+    CCLOG("normalFileName  Name : %s, Type: %d", normalFileName.file.c_str(), normalFileName.type);
+    cocos2d::ResourceData clickedFileName = _button->getPressedFile();
+    CCLOG("clickedFileName  Name : %s, Type: %d", clickedFileName.file.c_str(), clickedFileName.type);
+    cocos2d::ResourceData disabledFileName = _button->getDisabledFile();
+    CCLOG("disabledFileName  Name : %s, Type: %d", disabledFileName.file.c_str(), disabledFileName.type);
 }
 
 

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIButtonTest/UIButtonTest.h
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIButtonTest/UIButtonTest.h
@@ -40,8 +40,10 @@ public:
     virtual bool init() override;
     void touchEvent(cocos2d::Ref* sender, cocos2d::ui::Widget::TouchEventType type);
 
+    void printWidgetResources(cocos2d::Ref* sender);
 protected:
     cocos2d::ui::Text* _displayValueLabel;
+    cocos2d::ui::Button* _button;
 };
 
 class UIButtonTest_Scale9 : public UIScene

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UICheckBoxTest/UICheckBoxTest.cpp
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UICheckBoxTest/UICheckBoxTest.cpp
@@ -40,15 +40,23 @@ bool UICheckBoxTest::init()
         _uiLayer->addChild(alert);        
         
         // Create the checkbox
-        CheckBox* checkBox = CheckBox::create("cocosui/check_box_normal.png",
+        _checkBox = CheckBox::create("cocosui/check_box_normal.png",
                                               "cocosui/check_box_normal_press.png",
                                               "cocosui/check_box_active.png",
                                               "cocosui/check_box_normal_disable.png",
                                               "cocosui/check_box_active_disable.png");
-        checkBox->setPosition(Vec2(widgetSize.width / 2.0f, widgetSize.height / 2.0f));
+        _checkBox->setPosition(Vec2(widgetSize.width / 2.0f, widgetSize.height / 2.0f));
         
-        checkBox->addEventListener(CC_CALLBACK_2(UICheckBoxTest::selectedEvent, this));
-        _uiLayer->addChild(checkBox);
+        _checkBox->addEventListener(CC_CALLBACK_2(UICheckBoxTest::selectedEvent, this));
+        _uiLayer->addChild(_checkBox);
+
+        TTFConfig ttfConfig("fonts/arial.ttf", 15);
+        auto label1 = Label::createWithTTF(ttfConfig, "Print Resources");
+        auto item1 = MenuItemLabel::create(label1, CC_CALLBACK_1(UICheckBoxTest::printWidgetResources, this));
+        item1->setPosition(Vec2(VisibleRect::left().x + 60, VisibleRect::bottom().y + item1->getContentSize().height * 3));
+        auto pMenu1 = Menu::create(item1, nullptr);
+        pMenu1->setPosition(Vec2(0, 0));
+        this->addChild(pMenu1, 10);
         
         return true;
     }
@@ -71,6 +79,20 @@ void UICheckBoxTest::selectedEvent(Ref* pSender,CheckBox::EventType type)
             break;
     }
     
+}
+
+void UICheckBoxTest::printWidgetResources(cocos2d::Ref* sender)
+{
+    cocos2d::ResourceData backGroundFileName = _checkBox->getBackNormalFile();
+    CCLOG("backGroundFile  Name : %s, Type: %d", backGroundFileName.file.c_str(),backGroundFileName.type);
+    cocos2d::ResourceData backGroundSelectedFileName = _checkBox->getBackPressedFile();
+    CCLOG("backGroundSelectedFile  Name : %s, Type: %d", backGroundSelectedFileName.file.c_str(), backGroundSelectedFileName.type);
+    cocos2d::ResourceData backGroundDisabledFileName = _checkBox->getBackDisabledFile();
+    CCLOG("backGroundDisabledFile  Name : %s, Type: %d", backGroundDisabledFileName.file.c_str(), backGroundDisabledFileName.type);
+    cocos2d::ResourceData frontCrossFileName = _checkBox->getCrossNormalFile();
+    CCLOG("frontCrossFile  Name : %s, Type: %d", frontCrossFileName.file.c_str(), frontCrossFileName.type);
+    cocos2d::ResourceData frontCrossDisabledFileName = _checkBox->getCrossDisabledFile();
+    CCLOG("frontCrossDisabledFile  Name : %s, Type: %d", frontCrossDisabledFileName.file.c_str(), frontCrossDisabledFileName.type);
 }
 
 

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UICheckBoxTest/UICheckBoxTest.h
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UICheckBoxTest/UICheckBoxTest.h
@@ -40,8 +40,10 @@ public:
     virtual bool init() override;
     void selectedEvent(cocos2d::Ref* sender,cocos2d::ui::CheckBox::EventType type);
     
+    void printWidgetResources(cocos2d::Ref* sender);
 protected:
     cocos2d::ui::Text* _displayValueLabel;
+    cocos2d::ui::CheckBox* _checkBox;
 };
 
 class UICheckBoxDefaultBehaviorTest : public UIScene

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIImageViewTest/UIImageViewTest.cpp
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIImageViewTest/UIImageViewTest.cpp
@@ -35,13 +35,26 @@ bool UIImageViewTest::init()
         
         _uiLayer->addChild(imageView);
         
-      
+        _image = imageView;
+
+        TTFConfig ttfConfig("fonts/arial.ttf", 15);
+        auto label1 = Label::createWithTTF(ttfConfig, "Print Resources");
+        auto item1 = MenuItemLabel::create(label1, CC_CALLBACK_1(UIImageViewTest::printWidgetResources, this));
+        item1->setPosition(Vec2(VisibleRect::left().x + 60, VisibleRect::bottom().y + item1->getContentSize().height * 3));
+        auto pMenu1 = Menu::create(item1, nullptr);
+        pMenu1->setPosition(Vec2(0, 0));
+        this->addChild(pMenu1, 10);
         
         return true;
     }
     return false;
 }
 
+void UIImageViewTest::printWidgetResources(cocos2d::Ref* sender)
+{
+    cocos2d::ResourceData textureFile = _image->getRenderFile();
+    CCLOG("textureFile  Name : %s, Type: %d", textureFile.file.c_str(), textureFile.type);
+}
 
 // UIImageViewTest_Scale9
 

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIImageViewTest/UIImageViewTest.h
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIImageViewTest/UIImageViewTest.h
@@ -35,6 +35,10 @@ public:
     CREATE_FUNC(UIImageViewTest);
 
     virtual bool init() override;
+
+    void printWidgetResources(cocos2d::Ref* sender);
+protected:
+    cocos2d::ui::ImageView* _image;
 };
 
 class UIImageViewTest_Scale9 : public UIScene

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UILayoutTest/UILayoutTest.cpp
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UILayoutTest/UILayoutTest.cpp
@@ -264,10 +264,26 @@ bool UILayoutTest_BackGroundImage::init()
                                          button_scale9->getContentSize().height / 2.0f));
         
         layout->addChild(button_scale9);        
+
+        _layout = layout;
+
+        TTFConfig ttfConfig("fonts/arial.ttf", 15);
+        auto label1 = Label::createWithTTF(ttfConfig, "Print Resources");
+        auto item1 = MenuItemLabel::create(label1, CC_CALLBACK_1(UILayoutTest_BackGroundImage::printWidgetResources, this));
+        item1->setPosition(Vec2(VisibleRect::left().x + 60, VisibleRect::bottom().y + item1->getContentSize().height * 3));
+        auto pMenu1 = Menu::create(item1, nullptr);
+        pMenu1->setPosition(Vec2(0, 0));
+        this->addChild(pMenu1, 10);
         
         return true;
     }
     return false;
+}
+
+void UILayoutTest_BackGroundImage::printWidgetResources(cocos2d::Ref* sender)
+{
+    cocos2d::ResourceData textureFile = _layout->getRenderFile();
+    CCLOG("textureFile  Name : %s, Type: %d", textureFile.file.c_str(), textureFile.type);
 }
 
 // UILayoutTest_BackGroundImage_Scale9

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UILayoutTest/UILayoutTest.h
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UILayoutTest/UILayoutTest.h
@@ -67,6 +67,10 @@ public:
     virtual bool init() override;
     
     CREATE_FUNC(UILayoutTest_BackGroundImage);
+
+    void printWidgetResources(cocos2d::Ref* sender);
+protected:
+    cocos2d::ui::Layout* _layout;
 };
 
 class UILayoutTest_BackGroundImage_Scale9 : public UIScene

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UILoadingBarTest/UILoadingBarTest.cpp
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UILoadingBarTest/UILoadingBarTest.cpp
@@ -79,6 +79,16 @@ bool UILoadingBarTest_Left::init()
          _uiLayer->addChild(loadingBar,1);
         _uiLayer->addChild(loadingBarCopy,2);
         _uiLayer->addChild(button);
+
+        _loadingBar = loadingBar;
+
+        TTFConfig ttfConfig("fonts/arial.ttf", 15);
+        auto label1 = Label::createWithTTF(ttfConfig, "Print Resources");
+        auto item1 = MenuItemLabel::create(label1, CC_CALLBACK_1(UILoadingBarTest_Left::printWidgetResources, this));
+        item1->setPosition(Vec2(VisibleRect::left().x + 60, VisibleRect::bottom().y + item1->getContentSize().height * 3));
+        auto pMenu1 = Menu::create(item1, nullptr);
+        pMenu1->setPosition(Vec2(0, 0));
+        this->addChild(pMenu1, 10);
         
         return true;
     }
@@ -96,6 +106,12 @@ void UILoadingBarTest_Left::update(float delta)
     LoadingBar* loadingBarCopy = static_cast<LoadingBar*>(_uiLayer->getChildByTag(1));
     loadingBar->setPercent(_count);
     loadingBarCopy->setPercent(_count);
+}
+
+void UILoadingBarTest_Left::printWidgetResources(cocos2d::Ref* sender)
+{
+    cocos2d::ResourceData textureFile = _loadingBar->getRenderFile();
+    CCLOG("textureFile  Name : %s, Type: %d", textureFile.file.c_str(), textureFile.type);
 }
 
 // UILoadingBarTest_Right

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UILoadingBarTest/UILoadingBarTest.h
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UILoadingBarTest/UILoadingBarTest.h
@@ -38,9 +38,11 @@ public:
     ~UILoadingBarTest_Left();
     virtual bool init() override;
     void update(float delta)override;
+    void printWidgetResources(cocos2d::Ref* sender);
     
 protected:
     int _count;
+    cocos2d::ui::LoadingBar* _loadingBar;
 };
 
 class UILoadingBarTest_Right : public UIScene

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UISliderTest/UISliderTest.cpp
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UISliderTest/UISliderTest.cpp
@@ -54,6 +54,15 @@ bool UISliderTest::init()
         slider->addEventListener(CC_CALLBACK_2(UISliderTest::sliderEvent, this));
         _uiLayer->addChild(slider);
 
+        _slider = slider;
+
+        TTFConfig ttfConfig("fonts/arial.ttf", 15);
+        auto label1 = Label::createWithTTF(ttfConfig, "Print Resources");
+        auto item1 = MenuItemLabel::create(label1, CC_CALLBACK_1(UISliderTest::printWidgetResources, this));
+        item1->setPosition(Vec2(VisibleRect::left().x + 60, VisibleRect::bottom().y + item1->getContentSize().height * 3));
+        auto pMenu1 = Menu::create(item1, nullptr);
+        pMenu1->setPosition(Vec2(0, 0));
+        this->addChild(pMenu1, 10);
         
         return true;
     }
@@ -69,6 +78,19 @@ void UISliderTest::sliderEvent(Ref *pSender, Slider::EventType type)
         int maxPercent = slider->getMaxPercent();
         _displayValueLabel->setString(StringUtils::format("Percent %f", 10000.0 * percent / maxPercent));
     }
+}
+void UISliderTest::printWidgetResources(cocos2d::Ref* sender)
+{
+    cocos2d::ResourceData textureFile = _slider->getBackFile();
+    CCLOG("textureFile  Name : %s, Type: %d", textureFile.file.c_str(), textureFile.type);
+    cocos2d::ResourceData progressBarTextureFile = _slider->getProgressBarFile();
+    CCLOG("progressBarTextureFile  Name : %s, Type: %d", progressBarTextureFile.file.c_str(), progressBarTextureFile.type);
+    cocos2d::ResourceData slidBallNormalTextureFile = _slider->getBallNormalFile();
+    CCLOG("slidBallNormalTextureFile  Name : %s, Type: %d", slidBallNormalTextureFile.file.c_str(), slidBallNormalTextureFile.type);
+    cocos2d::ResourceData slidBallPressedTextureFile = _slider->getBallPressedFile();
+    CCLOG("slidBallPressedTextureFile  Name : %s, Type: %d", slidBallPressedTextureFile.file.c_str(), slidBallPressedTextureFile.type);
+    cocos2d::ResourceData slidBallDisabledTextureFile = _slider->getBallDisabledFile();
+    CCLOG("slidBallDisabledTextureFile  Name : %s, Type: %d", slidBallDisabledTextureFile.file.c_str(), slidBallDisabledTextureFile.type);
 }
 
 // UISliderTest_Scale9

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UISliderTest/UISliderTest.h
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UISliderTest/UISliderTest.h
@@ -38,9 +38,11 @@ public:
     ~UISliderTest();
     virtual bool init() override;
     void sliderEvent(cocos2d::Ref* sender, cocos2d::ui::Slider::EventType type);
+    void printWidgetResources(cocos2d::Ref* sender);
     
 protected:
     cocos2d::ui::TextBMFont* _displayValueLabel;
+    cocos2d::ui::Slider* _slider;
 };
 
 class UISliderTest_Scale9 : public UIScene

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UITextAtlasTest/UITextAtlasTest.cpp
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UITextAtlasTest/UITextAtlasTest.cpp
@@ -34,7 +34,21 @@ bool UITextAtlasTest::init()
         textAtlas->setPosition(Vec2((widgetSize.width) / 2, widgetSize.height / 2.0f));
         _uiLayer->addChild(textAtlas);                
         
+        _textAtlas = textAtlas;
+
+        TTFConfig ttfConfig("fonts/arial.ttf", 15);
+        auto label1 = Label::createWithTTF(ttfConfig, "Print Resources");
+        auto item1 = MenuItemLabel::create(label1, CC_CALLBACK_1(UITextAtlasTest::printWidgetResources, this));
+        item1->setPosition(Vec2(VisibleRect::left().x + 60, VisibleRect::bottom().y + item1->getContentSize().height * 3));
+        auto pMenu1 = Menu::create(item1, nullptr);
+        pMenu1->setPosition(Vec2(0, 0));
+        this->addChild(pMenu1, 10);
         return true;
     }
     return false;
+}
+void UITextAtlasTest::printWidgetResources(cocos2d::Ref* sender)
+{
+    cocos2d::ResourceData textureFile = _textAtlas->getRenderFile();
+    CCLOG("textureFile  Name : %s, Type: %d", textureFile.file.c_str(), textureFile.type);
 }

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UITextAtlasTest/UITextAtlasTest.h
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UITextAtlasTest/UITextAtlasTest.h
@@ -13,6 +13,9 @@ public:
     CREATE_FUNC(UITextAtlasTest);
 
     virtual bool init() override;
+    void printWidgetResources(cocos2d::Ref* sender);
+protected:
+    cocos2d::ui::TextAtlas* _textAtlas;
 };
 
 #endif /* defined(__TestCpp__UITextAtlasTest__) */

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UITextBMFontTest/UITextBMFontTest.cpp
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UITextBMFontTest/UITextBMFontTest.cpp
@@ -25,7 +25,22 @@ bool UITextBMFontTest::init()
         textBMFont->setPosition(Vec2(widgetSize.width / 2, widgetSize.height / 2.0f + textBMFont->getContentSize().height / 8.0f));
         _uiLayer->addChild(textBMFont);
         
+        _textBMFont = textBMFont;
+
+        TTFConfig ttfConfig("fonts/arial.ttf", 15);
+        auto label1 = Label::createWithTTF(ttfConfig, "Print Resources");
+        auto item1 = MenuItemLabel::create(label1, CC_CALLBACK_1(UITextBMFontTest::printWidgetResources, this));
+        item1->setPosition(Vec2(VisibleRect::left().x + 60, VisibleRect::bottom().y + item1->getContentSize().height * 3));
+        auto pMenu1 = Menu::create(item1, nullptr);
+        pMenu1->setPosition(Vec2(0, 0));
+        this->addChild(pMenu1, 10);
+
         return true;
     }
     return false;
+}
+void UITextBMFontTest::printWidgetResources(cocos2d::Ref* sender)
+{
+    cocos2d::ResourceData textureFile = _textBMFont->getRenderFile();
+    CCLOG("textureFile  Name : %s, Type: %d", textureFile.file.c_str(), textureFile.type);
 }

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UITextBMFontTest/UITextBMFontTest.h
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UITextBMFontTest/UITextBMFontTest.h
@@ -35,6 +35,9 @@ public:
     CREATE_FUNC(UITextBMFontTest)
 
     virtual bool init() override;
+    void printWidgetResources(cocos2d::Ref* sender);
+protected:
+    cocos2d::ui::TextBMFont* _textBMFont;
 };
 
 #endif /* defined(__TestCpp__UITextBMFontTest__) */


### PR DESCRIPTION
Instead of using two uthash entires, it uses two `unordered_map` entries.
Benefits are:
- easier to debug. I can inspect the contents of the `unorderd_map` with the debugger
- less memory. I don't need to allocate two proxies. I only allocate one proxy and I added it into both maps

If also fixes an important bug when unrooting objects. Unroot was cleaning the heap object. So now proxy adds a _jsobj, which is a raw pointer. Needed under certain cases.
