### PR TITLE
getCachePath() implementation for most platforms

### DIFF
--- a/cocos/platform/CCFileUtils.h
+++ b/cocos/platform/CCFileUtils.h
@@ -299,6 +299,12 @@ public:
     virtual std::string getWritablePath() const = 0;
 
     /**
+     *  Gets the cache path.
+     *  @return  The path that can be write/read a file in
+     */
+    virtual std::string getCachePath() const = 0;
+
+    /**
      *  Sets writable path.
      */
     virtual void setWritablePath(const std::string& writablePath);
@@ -578,6 +584,11 @@ protected:
      * Writable path.
      */
     std::string _writablePath;
+    
+    /**
+     * Cache path.
+     */
+    std::string _cachePath;
 
     /**
      *  The singleton pointer of FileUtils.

--- a/cocos/platform/android/CCFileUtils-android.cpp
+++ b/cocos/platform/android/CCFileUtils-android.cpp
@@ -485,6 +485,25 @@ string FileUtilsAndroid::getWritablePath() const
     }
 }
 
+string FileUtilsAndroid::getCachePath() const
+{
+    // Fix for Nexus 10 (Android 4.2 multi-user environment)
+    // the path is retrieved through Java Context.getCacheDir() method
+    string dir("");
+    string tmp = getCacheDirectoryJNI();
+
+    if (tmp.length() > 0)
+    {
+        dir.append(tmp).append("/");
+
+        return dir;
+    }
+    else
+    {
+        return "";
+    }
+}
+
 NS_CC_END
 
 #endif // CC_TARGET_PLATFORM == CC_PLATFORM_ANDROID

--- a/cocos/platform/android/CCFileUtils-android.h
+++ b/cocos/platform/android/CCFileUtils-android.h
@@ -80,6 +80,8 @@ public:
     virtual std::string getWritablePath() const;
     virtual bool isAbsolutePath(const std::string& strPath) const;
     
+    virtual std::string getCachePath() const;
+    
 private:
     virtual bool isFileExistInternal(const std::string& strFilePath) const override;
     virtual bool isDirectoryExistInternal(const std::string& dirPath) const override;

--- a/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxHelper.java
+++ b/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxHelper.java
@@ -69,6 +69,7 @@ public class Cocos2dxHelper {
     private static boolean sActivityVisible;
     private static String sPackageName;
     private static String sFileDirectory;
+    private static String sCacheDirectory;
     private static Activity sActivity = null;
     private static Cocos2dxHelperListener sCocos2dxHelperListener;
     private static Set<OnActivityResultListener> onActivityResultListeners = new LinkedHashSet<OnActivityResultListener>();
@@ -96,9 +97,11 @@ public class Cocos2dxHelper {
             Cocos2dxHelper.sPackageName = applicationInfo.packageName;
             if (CocosPlayClient.isEnabled() && !CocosPlayClient.isDemo()) {
                 Cocos2dxHelper.sFileDirectory = CocosPlayClient.getGameRoot();
+                Cocos2dxHelper.sCacheDirectory = CocosPlayClient.getGameRoot();
             }
             else {
                 Cocos2dxHelper.sFileDirectory = activity.getFilesDir().getAbsolutePath();
+                Cocos2dxHelper.sCacheDirectory = activity.getCacheDir().getAbsolutePath();
             }
             
             Cocos2dxHelper.nativeSetApkPath(applicationInfo.sourceDir);
@@ -175,6 +178,10 @@ public class Cocos2dxHelper {
     }
     public static String getCocos2dxWritablePath() {
         return Cocos2dxHelper.sFileDirectory;
+    }
+    
+    public static String getCocos2dxCachePath() {
+        return Cocos2dxHelper.sCacheDirectory;
     }
 
     public static String getCurrentLanguage() {

--- a/cocos/platform/android/jni/Java_org_cocos2dx_lib_Cocos2dxHelper.cpp
+++ b/cocos/platform/android/jni/Java_org_cocos2dx_lib_Cocos2dxHelper.cpp
@@ -144,6 +144,20 @@ std::string getFileDirectoryJNI() {
     return ret;
 }
 
+std::string getCacheDirectoryJNI() {
+    JniMethodInfo t;
+    std::string ret("");
+
+    if (JniHelper::getStaticMethodInfo(t, CLASS_NAME, "getCocos2dxCachePath", "()Ljava/lang/String;")) {
+        jstring str = (jstring)t.env->CallStaticObjectMethod(t.classID, t.methodID);
+        t.env->DeleteLocalRef(t.classID);
+        ret = JniHelper::jstring2string(str);
+        t.env->DeleteLocalRef(str);
+    }
+    
+    return ret;
+}
+
 std::string getCurrentLanguageJNI() {
     JniMethodInfo t;
     std::string ret("");

--- a/cocos/platform/android/jni/Java_org_cocos2dx_lib_Cocos2dxHelper.h
+++ b/cocos/platform/android/jni/Java_org_cocos2dx_lib_Cocos2dxHelper.h
@@ -35,6 +35,7 @@ extern void terminateProcessJNI();
 extern std::string getCurrentLanguageJNI();
 extern std::string getPackageNameJNI();
 extern std::string getFileDirectoryJNI();
+extern std::string getCacheDirectoryJNI();
 extern void enableAccelerometerJni();
 extern void disableAccelerometerJni();
 extern void setAccelerometerIntervalJni(float interval);

--- a/cocos/platform/apple/CCFileUtils-apple.h
+++ b/cocos/platform/apple/CCFileUtils-apple.h
@@ -48,6 +48,7 @@ public:
     /* override functions */
     virtual std::string getWritablePath() const override;
     virtual std::string getFullPathForDirectoryAndFilename(const std::string& directory, const std::string& filename) const override;
+    virtual std::string getCachePath() const override;
 
     virtual ValueMap getValueMapFromFile(const std::string& filename) override;
     virtual ValueMap getValueMapFromData(const char* filedata, int filesize)override;

--- a/cocos/platform/apple/CCFileUtils-apple.mm
+++ b/cocos/platform/apple/CCFileUtils-apple.mm
@@ -343,11 +343,51 @@ std::string FileUtilsApple::getWritablePath() const
     {
         return _writablePath;
     }
-
+    
+#if (CC_TARGET_PLATFORM == CC_PLATFORM_MAC)
+    NSArray *paths = NSSearchPathForDirectoriesInDomains(NSLibraryDirectory, NSUserDomainMask, YES);
+    NSString *bundleName = [[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleName"];
+    NSString *documentsDirectory = [[paths objectAtIndex:0] stringByAppendingPathComponent:bundleName];
+    BOOL isDir = NO;
+    NSError *error = nil;
+    if (! [[NSFileManager defaultManager] fileExistsAtPath:documentsDirectory isDirectory:&isDir] && isDir == NO) {
+        [[NSFileManager defaultManager] createDirectoryAtPath:documentsDirectory withIntermediateDirectories:NO attributes:nil error:&error];
+    }
+#else
     // save to document folder
     NSArray *paths = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES);
     NSString *documentsDirectory = [paths objectAtIndex:0];
+#endif
+    
     std::string strRet = [documentsDirectory UTF8String];
+    strRet.append("/");
+    return strRet;
+}
+
+std::string FileUtilsApple::getCachePath() const
+{
+    if (_writablePath.length())
+    {
+        return _writablePath;
+    }
+    
+    // save to document folder
+    NSArray *paths = NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES);
+    
+#if (CC_TARGET_PLATFORM == CC_PLATFORM_MAC)
+    NSString *bundleName =
+    [[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleIdentifier"];
+    NSString *cacheDirectory = [[paths objectAtIndex:0] stringByAppendingPathComponent:bundleName];
+    BOOL isDir = NO;
+    NSError *error = nil;
+    if (! [[NSFileManager defaultManager] fileExistsAtPath:cacheDirectory isDirectory:&isDir] && isDir == NO) {
+        [[NSFileManager defaultManager] createDirectoryAtPath:cacheDirectory withIntermediateDirectories:NO attributes:nil error:&error];
+    }
+#else
+    NSString *cacheDirectory = [paths objectAtIndex:0];
+#endif
+    
+    std::string strRet = [cacheDirectory UTF8String];
     strRet.append("/");
     return strRet;
 }

--- a/cocos/platform/linux/CCFileUtils-linux.cpp
+++ b/cocos/platform/linux/CCFileUtils-linux.cpp
@@ -105,6 +105,17 @@ string FileUtilsLinux::getWritablePath() const
     return _writablePath;
 }
 
+string FileUtilsLinux::getCachePath() const
+{
+    struct stat st;
+    stat(_writablePath.c_str(), &st);
+    if (!S_ISDIR(st.st_mode)) {
+        mkdir(_writablePath.c_str(), 0744);
+    }
+
+    return _writablePath;
+}
+
 bool FileUtilsLinux::isFileExistInternal(const std::string& strFilePath) const
 {
     if (strFilePath.empty())

--- a/cocos/platform/linux/CCFileUtils-linux.h
+++ b/cocos/platform/linux/CCFileUtils-linux.h
@@ -51,6 +51,7 @@ public:
     /* override functions */
     bool init();
     virtual std::string getWritablePath() const;
+    virtual std::string getCachePath() const;
 private:
     virtual bool isFileExistInternal(const std::string& strFilePath) const override;
 };

--- a/cocos/platform/win32/CCFileUtils-win32.cpp
+++ b/cocos/platform/win32/CCFileUtils-win32.cpp
@@ -633,6 +633,62 @@ bool FileUtilsWin32::removeDirectory(const std::string& dirPath)
     return false;
 }
 
+string FileUtilsWin32::getCachePath() const
+{
+    if (_cachePath.length())
+    {
+        return _cachePath;
+    }
+
+    // Get full path of executable, e.g. c:\Program Files (x86)\My Game Folder\MyGame.exe
+    WCHAR full_path[CC_MAX_PATH + 1] = { 0 };
+    ::GetModuleFileName(nullptr, full_path, CC_MAX_PATH + 1);
+
+    // Debug app uses executable directory; Non-debug app uses local app data directory
+//#ifndef _DEBUG
+    // Get filename of executable only, e.g. MyGame.exe
+    WCHAR *base_name = wcsrchr(full_path, '\\');
+    wstring retPath;
+    if(base_name)
+    {
+        WCHAR app_data_path[CC_MAX_PATH + 1];
+
+        // Get local app data directory, e.g. C:\Documents and Settings\username\Local Settings\Application Data
+        if (SUCCEEDED(SHGetFolderPath(nullptr, CSIDL_LOCAL_APPDATA, nullptr, SHGFP_TYPE_CURRENT, app_data_path)))
+        {
+            wstring ret(app_data_path);
+
+            // Adding Temp folder, e.g. C:\Documents and Settings\username\Local Settings\Application Data\Temp
+            ret += L"\\Temp";
+
+            // Adding executable filename, e.g. C:\Documents and Settings\username\Local Settings\Application Data\Temp\MyGame.exe
+            ret += base_name;
+
+            // Remove ".exe" extension, e.g. C:\Documents and Settings\username\Local Settings\Application Data\Temp\MyGame
+            ret = ret.substr(0, ret.rfind(L"."));
+
+            ret += L"\\";
+
+            // Create directory
+            if (SUCCEEDED(SHCreateDirectoryEx(nullptr, ret.c_str(), nullptr)))
+            {
+                retPath = ret;
+            }
+        }
+    }
+    if (retPath.empty())
+//#endif // not defined _DEBUG
+    {
+        // If fetching of local app data directory fails, use the executable one
+        retPath = full_path;
+
+        // remove xxx.exe
+        retPath = retPath.substr(0, retPath.rfind(L"\\") + 1);
+    }
+
+    return convertPathFormatToUnixStyle(StringWideCharToUtf8(retPath));
+}
+
 NS_CC_END
 
 #endif // CC_TARGET_PLATFORM == CC_PLATFORM_WIN32

--- a/cocos/platform/win32/CCFileUtils-win32.h
+++ b/cocos/platform/win32/CCFileUtils-win32.h
@@ -50,6 +50,7 @@ public:
     /* override functions */
     bool init();
     virtual std::string getWritablePath() const override;
+    virtual std::string getCachePath() const override;
     virtual bool isAbsolutePath(const std::string& strPath) const override;
     virtual std::string getSuitableFOpen(const std::string& filenameUtf8) const override;
     virtual long getFileSize(const std::string &filepath);

--- a/cocos/platform/winrt/CCFileUtilsWinRT.cpp
+++ b/cocos/platform/winrt/CCFileUtilsWinRT.cpp
@@ -335,6 +335,12 @@ string CCFileUtilsWinRT::getWritablePath() const
     return convertPathFormatToUnixStyle(std::string(PlatformStringToString(localFolderPath)) + '\\');
 }
 
+string CCFileUtilsWinRT::getCachePath() const
+{
+	auto tempFolderPath = Windows::Storage::ApplicationData::Current->TemporaryFolder->Path;
+	return convertPathFormatToUnixStyle(std::string(PlatformStringToString(tempFolderPath)) + '\\');
+}
+
 string CCFileUtilsWinRT::getAppPath()
 {
     Windows::ApplicationModel::Package^ package = Windows::ApplicationModel::Package::Current;

--- a/cocos/platform/winrt/CCFileUtilsWinRT.h
+++ b/cocos/platform/winrt/CCFileUtilsWinRT.h
@@ -48,6 +48,7 @@ public:
     /* override functions */
     bool init();
     virtual std::string getWritablePath() const;
+    virtual std::string getCachePath() const;
     virtual bool isAbsolutePath(const std::string& strPath) const;
     virtual std::string getPathForFilename(const std::string& filename, const std::string& resolutionDirectory, const std::string& searchPath) const override;
     virtual std::string getFullPathForDirectoryAndFilename(const std::string& strDirectory, const std::string& strFilename) const override;


### PR DESCRIPTION
getCachePath() for most platform except linux(i just don't now what does it mean on linux it return writable path)
for example if you download something from internet to documents dir(writable path) you app can be rejected and also changed writable path for mac for more suitable(its bad practice to write something in root of user documents folder)
