### PR TITLE
[android] Include stdint.h for uint32_t in UIWebViewImpl-android.h

### DIFF
--- a/cocos/ui/UIWebViewImpl-android.h
+++ b/cocos/ui/UIWebViewImpl-android.h
@@ -29,6 +29,7 @@
 #ifdef __ANDROID__
 
 #include <iosfwd>
+#include <stdint.h> // for uint32_t
 
 namespace cocos2d {
     class Data;


### PR DESCRIPTION
This fixes compilation error when building cocos2d-x demo by CrystaX NDK.

According to [POSIX](http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/stdint.h.html), `uint32_t` is defined in "stdint.h", so if you use it in code, you should include "stdint.h".

In Google's Android NDK it works because their "iosfwd" include "stdint.h" implicitly; however, it's not a requirement and you shouldn't rely on that.

With this fix, cocos2d-x demo getting built no matter which NDK is used - CrystaX or Google's one.
