### PR TITLE
Bug Fix & h5 engine ref update

### DIFF
--- a/cocos/scripting/js-bindings/script/studio/parsers/action-1.x.js
+++ b/cocos/scripting/js-bindings/script/studio/parsers/action-1.x.js
@@ -233,6 +233,7 @@
         });
     });
 
+    load.registerParser("action", "0.*", parser);
     load.registerParser("action", "1.*", parser);
 
 })(ccs._load, ccs._parser);

--- a/cocos/scripting/js-bindings/script/studio/parsers/timelineParser-1.x.js
+++ b/cocos/scripting/js-bindings/script/studio/parsers/timelineParser-1.x.js
@@ -287,6 +287,7 @@
         });
     });
 
+    load.registerParser("timeline", "0.*", parser);
     load.registerParser("timeline", "1.*", parser);
 
 })(ccs._load, ccs._parser);

--- a/tests/lua-tests/src/CocoStudioTest/CocoStudioGUITest/CocoStudioGUITest.lua
+++ b/tests/lua-tests/src/CocoStudioTest/CocoStudioGUITest/CocoStudioGUITest.lua
@@ -1722,13 +1722,11 @@ add_new_testcase(function()
             local pageView = ccui.PageView:create()
             pageView:setTouchEnabled(true)
             pageView:setContentSize(cc.size(240, 130))
-            pageView:setDirection(ccui.PageViewDirection.HORIZONTAL)
             local backgroundSize = background:getContentSize()
             pageView:setPosition(cc.p((widgetSize.width - backgroundSize.width) / 2 +
                                          (backgroundSize.width - pageView:getContentSize().width) / 2,
                                      (widgetSize.height - backgroundSize.height) / 2 +
                                          (backgroundSize.height - pageView:getContentSize().height) / 2))
-
             for i = 1 , 3 do
                 local layout = ccui.Layout:create()
                 layout:setContentSize(cc.size(240, 130))
@@ -1788,7 +1786,7 @@ add_new_testcase(function()
 
             local pageView = ccui.PageView:create()
             pageView:setTouchEnabled(true)
-            pageView:setDirection(ccui.PageViewDirection.VERTICAL)
+            pageView:setDirection(ccui.ScrollViewDir.vertical)
             pageView:setContentSize(cc.size(240, 130))
             local backgroundSize = background:getContentSize()
             pageView:setPosition(cc.p((widgetSize.width - backgroundSize.width) / 2 +


### PR DESCRIPTION
Fix pageViewTest Horizontal scroll won't work in Lua-test
PageView default direction is horizontal, we won't set it again after create it. And after refact, now ccui.PageViewDirection won't exist any more, all scroll direction should use ccui.ScrollViewDir define.

synchronize h5 engine parser match modifications and update h5 engine ref

@pandamicro Please review this PR
