### PR TITLE
Fix OpenGL macro redefinition warning in JS bindings/Mac

### DIFF
--- a/cocos/scripting/js-bindings/manual/jsb_opengl_functions.cpp
+++ b/cocos/scripting/js-bindings/manual/jsb_opengl_functions.cpp
@@ -13,6 +13,7 @@
 #include "js_bindings_core.h"
 #include "js_manual_conversions.h"
 #include "jsb_opengl_functions.h"
+#include "platform/CCGL.h"
 
 // Arguments: GLenum
 // Ret value: void

--- a/cocos/scripting/js-bindings/manual/jsb_opengl_manual.cpp
+++ b/cocos/scripting/js-bindings/manual/jsb_opengl_manual.cpp
@@ -28,6 +28,7 @@
 #include "js_manual_conversions.h"
 #include "js_bindings_core.h"
 #include "jsb_opengl_functions.h"
+#include "platform/CCGL.h"
 
 
 // Helper functions that link "glGenXXXs" (OpenGL ES 2.0 spec), with "gl.createXXX" (WebGL spec)

--- a/cocos/scripting/js-bindings/manual/jsb_opengl_manual.h
+++ b/cocos/scripting/js-bindings/manual/jsb_opengl_manual.h
@@ -28,21 +28,8 @@
 #include "js_bindings_config.h"
 #ifdef JSB_INCLUDE_OPENGL
 
-//#include <Availability.h>
 #include "jsapi.h"
 #include "jsfriendapi.h"
-
-#ifdef __IPHONE_OS_VERSION_MAX_ALLOWED
-#elif defined(__MAC_OS_X_VERSION_MAX_ALLOWED)
-
-// compatible with iOS
-#define glClearDepthf glClearDepth
-#define glDepthRangef glDepthRange
-#ifndef glReleaseShaderCompiler
-    #define glReleaseShaderCompiler()
-#endif
-
-#endif // __MAC_OS_X_VERSION_MAX_ALLOWED
 
 // forward declaration of new functions
 bool JSB_glGetSupportedExtensions(JSContext *cx, uint32_t argc, jsval *vp);


### PR DESCRIPTION
When I build `libjscocos2d Mac` on Xcode 7, I get the following warning:

```
cocos/platform/mac/CCGL-mac.h:44:9: 'glReleaseShaderCompiler' macro redefined
cocos/scripting/js-bindings/manual/jsb_opengl_manual.h:42:13: Previous definition is here
```

I think JS bindings can use `#include "platform/CCGL.h"` instead of the macro redefinition in `jsb_opengl_manual.h`. This PR improves and fixes the warning, thanks.
