### PR TITLE
fix some minor typos in the comments

### DIFF
--- a/cocos/ui/UIListView.h
+++ b/cocos/ui/UIListView.h
@@ -128,7 +128,7 @@ public:
     static ListView* create();
     
     /**
-     * Set a item model for listview.
+     * Set an item model for listview.
      *
      * When calling `pushBackDefaultItem`, the model will be used as a blueprint and new model copy will be inserted into ListView.
      * @param model  Model in `Widget*`.
@@ -142,13 +142,13 @@ public:
     
     /**
      * Insert a default item(create by cloning model) into listview at a give index.
-     *@param index  A index in ssize_t.
+     *@param index  An index in ssize_t.
      */
     void insertDefaultItem(ssize_t index);
     
     /**
      * Insert a  custom item into the end of ListView.
-     *@param item A item in `Widget*`.
+     *@param item An item in `Widget*`.
      */
     void pushBackCustomItem(Widget* item);
     
@@ -167,7 +167,7 @@ public:
     void removeLastItem();
     
     /**
-     * Remove a item at given index.
+     * Remove an item at given index.
      *
      * @param index A given index in ssize_t.
      */
@@ -181,7 +181,7 @@ public:
     void removeAllItems();
     
     /**
-     * Return a item at a given index.
+     * Return an item at a given index.
      *
      * @param index A given index in ssize_t.
      * @return A widget instance.
@@ -260,7 +260,7 @@ public:
      *
      * @param targetPosition Specifies the target position in inner container's coordinates.
      * @param itemAnchorPoint Specifies an anchor point of each item for position to calculate distance.
-     * @return A item instance if list view is not empty. Otherwise, returns null.
+     * @return An item instance if list view is not empty. Otherwise, returns null.
      */
     Widget* getClosestItemToPosition(const Vec2& targetPosition, const Vec2& itemAnchorPoint) const;
     
@@ -270,37 +270,37 @@ public:
      *
      * @param positionRatioInView Specifies the target position with ratio in list view's content size.
      * @param itemAnchorPoint Specifies an anchor point of each item for position to calculate distance.
-     * @return A item instance if list view is not empty. Otherwise, returns null.
+     * @return An item instance if list view is not empty. Otherwise, returns null.
      */
     Widget* getClosestItemToPositionInCurrentView(const Vec2& positionRatioInView, const Vec2& itemAnchorPoint) const;
     
     /**
      * @brief Query the center item
-     * @return A item instance.
+     * @return An item instance.
      */
     Widget* getCenterItemInCurrentView() const;
     
     /**
      * @brief Query the leftmost item in horizontal list
-     * @return A item instance.
+     * @return An item instance.
      */
     Widget* getLeftmostItemInCurrentView() const;
     
     /**
      * @brief Query the rightmost item in horizontal list
-     * @return A item instance.
+     * @return An item instance.
      */
     Widget* getRightmostItemInCurrentView() const;
     
     /**
      * @brief Query the topmost item in horizontal list
-     * @return A item instance.
+     * @return An item instance.
      */
     Widget* getTopmostItemInCurrentView() const;
     
     /**
      * @brief Query the bottommost item in horizontal list
-     * @return A item instance.
+     * @return An item instance.
      */
     Widget* getBottommostItemInCurrentView() const;
 
@@ -340,12 +340,12 @@ public:
      * @brief Query current selected widget's index.
      *
      
-     * @return A index of a selected item.
+     * @return An index of a selected item.
      */
     ssize_t getCurSelectedIndex() const;
     
     /**
-     * Add a event click callback to ListView, then one item of Listview is clicked, the callback will be called.
+     * Add an event click callback to ListView, then one item of Listview is clicked, the callback will be called.
      *@deprecated Use  `addEventListener` instead.
      *@param target A pointer of `Ref*` type.
      *@param selector A member function pointer with type of `SEL_ListViewEvent`.
@@ -353,7 +353,7 @@ public:
     CC_DEPRECATED_ATTRIBUTE void addEventListenerListView(Ref* target, SEL_ListViewEvent selector);
 
     /**
-     * Add a event click callback to ListView, then one item of Listview is clicked, the callback will be called.
+     * Add an event click callback to ListView, then one item of Listview is clicked, the callback will be called.
      *@param callback A callback function with type of `ccListViewCallback`.
      */
     void addEventListener(const ccListViewCallback& callback);


### PR DESCRIPTION
change spelling from 
- _a item_ to _an item_
- _a event_ to _an event_
- _a index_ to _an index_

in `cocos/ui/UIListView.h`
