### PR TITLE
Fix method name spelling in AutoPolygon

### DIFF
--- a/cocos/2d/CCAutoPolygon.cpp
+++ b/cocos/2d/CCAutoPolygon.cpp
@@ -119,9 +119,14 @@ const unsigned int PolygonInfo::getVertCount() const
     return (unsigned int)triangles.vertCount;
 }
 
-const unsigned int PolygonInfo::getTriaglesCount() const
+const unsigned int PolygonInfo::getTrianglesCount() const
 {
     return (unsigned int)triangles.indexCount/3;
+}
+
+const unsigned int PolygonInfo::getTriaglesCount() const
+{
+    return getTrianglesCount();
 }
 
 const float PolygonInfo::getArea() const

--- a/cocos/2d/CCAutoPolygon.h
+++ b/cocos/2d/CCAutoPolygon.h
@@ -107,7 +107,10 @@ public:
      * get triangles count
      * @return number of triangles
      */
-    const unsigned int getTriaglesCount() const;
+    const unsigned int getTrianglesCount() const;
+
+    /** @deprecated Use method getTrianglesCount() instead */
+    CC_DEPRECATED_ATTRIBUTE const unsigned int getTriaglesCount() const;
     
     /**
      * get sum of all triangle area size

--- a/cocos/scripting/js-bindings/manual/cocos2d_specifics.cpp
+++ b/cocos/scripting/js-bindings/manual/cocos2d_specifics.cpp
@@ -5418,7 +5418,7 @@ bool js_cocos2dx_PolygonInfo_getTriaglesCount(JSContext *cx, uint32_t argc, jsva
     JSB_PRECONDITION2( cobj, cx, false, "js_cocos2dx_PolygonInfo_getTriaglesCount : Invalid Native Object");
     if (argc == 0)
     {
-        const unsigned int ret = cobj->getTriaglesCount();
+        const unsigned int ret = cobj->getTrianglesCount();
         jsval jsret = JSVAL_NULL;
         jsret = uint32_to_jsval(cx, ret);
         args.rval().set(jsret);

--- a/tests/cpp-tests/Classes/SpritePolygonTest/SpritePolygonTest.cpp
+++ b/tests/cpp-tests/Classes/SpritePolygonTest/SpritePolygonTest.cpp
@@ -593,7 +593,7 @@ void SpritePolygonPerformanceTestDynamic::initIncrementStats()
 {
     _pinfo = AutoPolygon::generatePolygon(s_pathGrossini);
     _incVert = _pinfo.getVertCount();
-    _incTri = _pinfo.getTriaglesCount();
+    _incTri = _pinfo.getTrianglesCount();
     _incPix = _pinfo.getArea();
 }
 


### PR DESCRIPTION
I found a small mistake in the `AutoPolygon` class and renamed one:
- `getTriaglesCount` => `getTrianglesCount`

Also I've marked the old functions as deprecated, so there's no breaking changes in the API.
