### PR TITLE
[ci skip] Bug fix

### DIFF
--- a/tests/cpp-tests/Resources/Images/blocks9ss.plist
+++ b/tests/cpp-tests/Resources/Images/blocks9ss.plist
@@ -56,7 +56,7 @@
 			<key>sourceSize</key>
 			<string>{96, 96}</string>
 		</dict>
-		<key>grossini_dance_01.png</key>
+		<key>grossini_dance01.png</key>
 		<dict>
 			<key>frame</key>
 			<string>{{67,2},{51,109}}</string>
@@ -69,7 +69,7 @@
 			<key>sourceSize</key>
 			<string>{85,121}</string>
 		</dict>
-		<key>grossini_dance_02.png</key>
+		<key>grossini_dance02.png</key>
 		<dict>
 			<key>frame</key>
 			<string>{{2,113},{63,109}}</string>
@@ -82,7 +82,7 @@
 			<key>sourceSize</key>
 			<string>{85,121}</string>
 		</dict>
-		<key>grossini_dance_03.png</key>
+		<key>grossini_dance03.png</key>
 		<dict>
 			<key>frame</key>
 			<string>{{2,2},{63,109}}</string>


### PR DESCRIPTION
Both Image/blocks9ss.plist and animations/grossini.plist have image frames grossini_dance__.png, and in Image/blocks9ss.plist the frames is smaller than frames in animations/grossini.plist, so if load Image/blocks9ss.plist first, the samples use frames named grossini_dance__.png in animations/grossini.plist will crash. After check in source file, we found these frames in Image/blocks9ss.plist hasn't been used, so we changed frames name in Image/blocks9ss.plist to avoid crash.

@zilongshanren @pandamicro Please review this PR
