### PR TITLE
fix compile error in visual studio 2015

### DIFF
--- a/templates/js-template-default/frameworks/runtime-src/proj.win32/game.rc
+++ b/templates/js-template-default/frameworks/runtime-src/proj.win32/game.rc
@@ -7,7 +7,7 @@
 //
 // Generated from the TEXTINCLUDE 2 resource.
 //
-#include "afxres.h"
+#include "winresrc.h"
 
 /////////////////////////////////////////////////////////////////////////////
 #undef APSTUDIO_READONLY_SYMBOLS
@@ -27,7 +27,7 @@ LANGUAGE LANG_CHINESE, SUBLANG_CHINESE_SIMPLIFIED
 
 2 TEXTINCLUDE 
 BEGIN
-    "#include ""afxres.h""\r\n"
+    "#include ""winresrc.h""\r\n"
     "\0"
 END
 

--- a/templates/js-template-runtime/frameworks/runtime-src/proj.win32/game.rc
+++ b/templates/js-template-runtime/frameworks/runtime-src/proj.win32/game.rc
@@ -7,7 +7,7 @@
 //
 // Generated from the TEXTINCLUDE 2 resource.
 //
-#include "afxres.h"
+#include "winresrc.h"
 
 /////////////////////////////////////////////////////////////////////////////
 #undef APSTUDIO_READONLY_SYMBOLS
@@ -27,7 +27,7 @@ LANGUAGE LANG_CHINESE, SUBLANG_CHINESE_SIMPLIFIED
 
 2 TEXTINCLUDE 
 BEGIN
-    "#include ""afxres.h""\r\n"
+    "#include ""winresrc.h""\r\n"
     "\0"
 END
 


### PR DESCRIPTION
There's no include file "afxres.h" in visual studio 2015 Enterprise version, so that change it to "winresrc.h" 
