### PR TITLE
fix bug

### DIFF
--- a/cocos/editor-support/spine/Atlas.c
+++ b/cocos/editor-support/spine/Atlas.c
@@ -223,7 +223,7 @@ spAtlas* spAtlas_create (const char* begin, int length, const char* dir, void* r
 			if (!readValue(end, &str)) return abortAtlas(self);
 			if (!equals(&str, "none")) {
 				page->uWrap = *str.begin == 'x' ? SP_ATLAS_REPEAT : (*str.begin == 'y' ? SP_ATLAS_CLAMPTOEDGE : SP_ATLAS_REPEAT);
-				page->vWrap = *str.begin == 'x' ? SP_ATLAS_CLAMPTOEDGE : (*str.begin == 'y' ? SP_ATLAS_REPEAT : SP_ATLAS_REPEAT);
+				page->vWrap = *str.begin == 'y' ? SP_ATLAS_CLAMPTOEDGE : (*str.begin == 'x' ? SP_ATLAS_REPEAT : SP_ATLAS_REPEAT);
 			}
 
 			_spAtlasPage_createTexture(page, path);

--- a/cocos/scripting/lua-bindings/manual/cocostudio/lua_cocos2dx_coco_studio_manual.cpp
+++ b/cocos/scripting/lua-bindings/manual/cocostudio/lua_cocos2dx_coco_studio_manual.cpp
@@ -52,7 +52,7 @@ LuaArmatureWrapper::LuaArmatureWrapper()
 
 LuaArmatureWrapper::~LuaArmatureWrapper()
 {
-    
+    ScriptHandlerMgr::getInstance()->removeObjectAllHandlers((void*)this);
 }
 
 void LuaArmatureWrapper::addArmatureFileInfoAsyncCallback(float percent)

--- a/cocos/scripting/lua-bindings/manual/spine/lua_cocos2dx_spine_manual.cpp
+++ b/cocos/scripting/lua-bindings/manual/spine/lua_cocos2dx_spine_manual.cpp
@@ -294,15 +294,19 @@ int tolua_Cocos2d_CCSkeletonAnimation_unregisterSpineEventHandler00(lua_State* t
             ScriptHandlerMgr::HandlerType handlerType = ScriptHandlerMgr::HandlerType::EVENT_SPINE_ANIMATION_START;
             switch (eventType) {
                 case spEventType::SP_ANIMATION_START:
+                    self->setStartListener(nullptr);
                     handlerType = ScriptHandlerMgr::HandlerType::EVENT_SPINE_ANIMATION_START;
                     break;
                 case spEventType::SP_ANIMATION_END:
+                    self->setEndListener(nullptr);
                     handlerType = ScriptHandlerMgr::HandlerType::EVENT_SPINE_ANIMATION_END;
                     break;
                 case spEventType::SP_ANIMATION_COMPLETE:
+                    self->setCompleteListener(nullptr);
                     handlerType = ScriptHandlerMgr::HandlerType::EVENT_SPINE_ANIMATION_COMPLETE;
                     break;
                 case spEventType::SP_ANIMATION_EVENT:
+                    self->setEventListener(nullptr);
                     handlerType = ScriptHandlerMgr::HandlerType::EVENT_SPINE_ANIMATION_EVENT;
                     break;
                     


### PR DESCRIPTION
Correction of mipmap parameter setting error in spine
When LuaArmatureWrapper delete delete registered all scripts on Obj
Set the unregisterSpineEventHandler callback function for nullptr
