### PR TITLE
fix iOS downloader crash when storage path contains spaces

### DIFF
--- a/cocos/network/CCDownloader-apple.mm
+++ b/cocos/network/CCDownloader-apple.mm
@@ -553,9 +553,7 @@ namespace cocos2d { namespace network {
         
         if ('/' == [destPath characterAtIndex:0])
         {
-            // absolute path, need add prefix
-            NSString *prefix = @"file://";
-            destURL = [NSURL URLWithString:[prefix stringByAppendingString: destPath]];
+            destURL = [NSURL fileURLWithPath:destPath];
             break;
         }
         


### PR DESCRIPTION
This PR fixes https://github.com/cocos2d/cocos2d-x/issues/14842
which causes iOS downloader to crash when storagePath contains spaces (e.g. the app's Application Support directory)

This problem can either be fixed by changing

```
[NSURL URLWithString:[prefix stringByAppendingString: destPath]];
```

to 

```
[NSURL URLWithString:[[prefix stringByAppendingString: destPath] stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding]];
```

or

```
destURL = [NSURL fileURLWithPath:destPath];
```

which is more concise.
