### PR TITLE
Fix some typos in docs

### DIFF
--- a/cocos/2d/CCLabel.h
+++ b/cocos/2d/CCLabel.h
@@ -380,7 +380,7 @@ public:
     LabelEffect getLabelEffectType() const { return _currLabelEffect; }
 
     /**
-    * Return current effect color vlaue.
+    * Return current effect color value.
     */
     Color4F getEffectColor() const { return _effectColorF; }
 

--- a/cocos/network/HttpAsynConnection-apple.m
+++ b/cocos/network/HttpAsynConnection-apple.m
@@ -141,7 +141,7 @@
 }
 
 /**
- * This delegate methodis called if the connection cannot be established to the server.  
+ * This delegate method is called if the connection cannot be established to the server.  
  * The error object will have a description of the error
  **/
 - (void)connection:(NSURLConnection *)connection 

--- a/cocos/network/HttpClient.h
+++ b/cocos/network/HttpClient.h
@@ -46,7 +46,7 @@ namespace network {
     
 
 
-/** Singleton that handles asynchrounous http requests.
+/** Singleton that handles asynchronous http requests.
  *
  * Once the request completed, a callback will issued in main thread when it provided during make request.
  *
@@ -94,7 +94,7 @@ public:
     void setSSLVerification(const std::string& caFile);
     
     /**
-     * Get ths ssl CA filename
+     * Get the ssl CA filename
      * 
      * @return the ssl CA filename
      */

--- a/cocos/network/HttpResponse.h
+++ b/cocos/network/HttpResponse.h
@@ -101,8 +101,8 @@ public:
     }
         
     /** 
-     * To see if the http reqeust is returned successfully.
-     * Althrough users can judge if (http response code = 200), we want an easier way.
+     * To see if the http request is returned successfully.
+     * Although users can judge if (http response code = 200), we want an easier way.
      * If this getter returns false, you can call getResponseCode and getErrorBuffer to find more details.
      * @return bool the flag that represent whether the http request return successfully or not.
      */
@@ -228,7 +228,7 @@ protected:
     
     // properties
     HttpRequest*        _pHttpRequest;  /// the corresponding HttpRequest pointer who leads to this response 
-    bool                _succeed;       /// to indecate if the http request is successful simply
+    bool                _succeed;       /// to indicate if the http request is successful simply
     std::vector<char>   _responseData;  /// the returned raw data. You can also dump it as a string
     std::vector<char>   _responseHeader;  /// the returned raw header data. You can also dump it as a string
     long                _responseCode;    /// the status code returned from libcurl, e.g. 200, 404

--- a/cocos/network/SocketIO.h
+++ b/cocos/network/SocketIO.h
@@ -213,7 +213,7 @@ private:
 
 public:
     /**
-     * Construtor of SIOClient class.
+     * Constructor of SIOClient class.
      *
      * @param host the string that represent the host address.
      * @param port the int value represent the port number.
@@ -223,7 +223,7 @@ public:
      */
     SIOClient(const std::string& host, int port, const std::string& path, SIOClientImpl* impl, SocketIO::SIODelegate& delegate);
     /**
-     * Destructior of SIOClient class.
+     * Destructor of SIOClient class.
      */
     virtual ~SIOClient(void);
 

--- a/cocos/network/WebSocket.h
+++ b/cocos/network/WebSocket.h
@@ -59,7 +59,7 @@ class CC_DLL WebSocket
 {
 public:
     /**
-     * Construtor of WebSocket.
+     * Constructor of WebSocket.
      *
      * @js ctor
      */

--- a/cocos/platform/ios/CCEAGLView-ios.h
+++ b/cocos/platform/ios/CCEAGLView-ios.h
@@ -119,7 +119,7 @@ Copyright (C) 2008 Apple Inc. All Rights Reserved.
 + (id) viewWithFrame:(CGRect)frame pixelFormat:(NSString*)format;
 /** creates an initializes an CCEAGLView with a frame, a color buffer format, and a depth buffer format */
 + (id) viewWithFrame:(CGRect)frame pixelFormat:(NSString*)format depthFormat:(GLuint)depth;
-/** creates an initializes an CCEAGLView with a frame, a color buffer format, a depth buffer format, a sharegroup, and multisamping */
+/** creates an initializes an CCEAGLView with a frame, a color buffer format, a depth buffer format, a sharegroup, and multisampling */
 + (id) viewWithFrame:(CGRect)frame pixelFormat:(NSString*)format depthFormat:(GLuint)depth preserveBackbuffer:(BOOL)retained sharegroup:(EAGLSharegroup*)sharegroup multiSampling:(BOOL)multisampling numberOfSamples:(unsigned int)samples;
 
 /** Initializes an CCEAGLView with a frame and 0-bit depth buffer, and a RGB565 color buffer */

--- a/cocos/scripting/js-bindings/manual/ScriptingCore.h
+++ b/cocos/scripting/js-bindings/manual/ScriptingCore.h
@@ -260,7 +260,7 @@ public:
     
     /**@~english
      * Compile the specified js file
-     * @param path    @~english The path of the script to to compiled
+     * @param path    @~english The path of the script to be compiled
      * @param global    @~english The js global object
      * @param cx        @~english The js context
      */
@@ -405,7 +405,7 @@ public:
     static bool log(JSContext *cx, uint32_t argc, jsval *vp);
     
     /**@~english
-     * Sets a js value to the targeted js obejct's reserved slot, which is not exposed to script environment.
+     * Sets a js value to the targeted js object's reserved slot, which is not exposed to script environment.
      * @param i @~english The slot index
      * @param obj @~english The targeted object
      * @param value @~english The js value to set to the slot
@@ -567,7 +567,7 @@ js_type_class_t *jsb_register_class(JSContext *cx, JSClass *jsClass, JS::HandleO
     return p;
 }
 
-/** creates two new proxies: one associaged with the nativeObj,
+/** creates two new proxies: one associated with the nativeObj,
  and another one associated with the JsObj */
 js_proxy_t* jsb_new_proxy(void* nativeObj, JS::HandleObject jsObj);
 /** returns the proxy associated with the Native* */

--- a/cocos/scripting/lua-bindings/manual/LuaBasicConversions.h
+++ b/cocos/scripting/lua-bindings/manual/LuaBasicConversions.h
@@ -1238,7 +1238,7 @@ void ccvector_std_string_to_luaval(lua_State* L, const std::vector<std::string>&
  * The format of table as follows: {numberValue1, numberValue2, ..., numberVectorSize}
  *
  * @param L the current lua_State.
- * @param inValue a std::vector<int> vaule.
+ * @param inValue a std::vector<int> value.
  */
 void ccvector_int_to_luaval(lua_State* L, const std::vector<int>& inValue);
 
@@ -1247,7 +1247,7 @@ void ccvector_int_to_luaval(lua_State* L, const std::vector<int>& inValue);
  * The format of table as follows: {numberValue1, numberValue2, ..., numberVectorSize}
  *
  * @param L the current lua_State.
- * @param inValue a std::vector<float> vaule.
+ * @param inValue a std::vector<float> value.
  */
 void ccvector_float_to_luaval(lua_State* L, const std::vector<float>& inValue);
 
@@ -1256,7 +1256,7 @@ void ccvector_float_to_luaval(lua_State* L, const std::vector<float>& inValue);
  * The format of table as follows: {numberValue1, numberValue2, ..., numberVectorSize}
  *
  * @param L the current lua_State.
- * @param inValue a std::vector<float> vaule.
+ * @param inValue a std::vector<float> value.
  */
 void ccvector_ushort_to_luaval(lua_State* L, const std::vector<unsigned short>& inValue);
 
@@ -1283,7 +1283,7 @@ void texParams_to_luaval(lua_State* L, const cocos2d::Texture2D::TexParams& inVa
  * The format of table as follows: {vec3Value1, vec3Value2, ..., vec3ValueSize}
  *
  * @param L the current lua_State.
- * @param inValue a std::vector<cocos2d::Vec3> vaule.
+ * @param inValue a std::vector<cocos2d::Vec3> value.
  */
 void std_vector_vec3_to_luaval(lua_State* L, const std::vector<cocos2d::Vec3>& inValue);
 
@@ -1291,7 +1291,7 @@ void std_vector_vec3_to_luaval(lua_State* L, const std::vector<cocos2d::Vec3>& i
  * Push a Lua dict table converted from a std::map<std::string, std::string> into the Lua stack.
  *
  * @param L the current lua_State.
- * @param inValue a std::map<std::string, std::string> vaule.
+ * @param inValue a std::map<std::string, std::string> value.
  */
 void std_map_string_string_to_luaval(lua_State* L, const std::map<std::string, std::string>& inValue);
 

--- a/cocos/ui/UIText.h
+++ b/cocos/ui/UIText.h
@@ -319,7 +319,7 @@ public:
     */
     LabelEffect getLabelEffectType() const;
     /**
-    * Return current effect color vlaue.
+    * Return current effect color value.
     */
     Color4B getEffectColor() const;
 


### PR DESCRIPTION
This fixes some typos and spelling mistakes in the documentation.
