### PR TITLE
Fix typos in comments and documentation

### DIFF
--- a/cocos/editor-support/cocostudio/CCActionFrame.h
+++ b/cocos/editor-support/cocostudio/CCActionFrame.h
@@ -167,7 +167,7 @@ public:
     /**
     * Gets the ActionInterval of ActionFrame.
     *
-    * @parame duration   the duration time of ActionFrame
+    * @param duration   the duration time of ActionFrame
     *
     * @return ActionInterval
     */
@@ -175,9 +175,9 @@ public:
     /**
     * Gets the ActionInterval of ActionFrame.
     *
-    * @parame duration   the duration time of ActionFrame
+    * @param duration   the duration time of ActionFrame
     *
-    * @parame duration   the source ActionFrame
+    * @param duration   the source ActionFrame
     *
     * @return ActionInterval
     */
@@ -186,7 +186,7 @@ public:
     /**
     *Set the ActionInterval easing parameter.
     *
-    *@parame parameter   the parameter for frame ease
+    *@param parameter   the parameter for frame ease
     *
     */
     virtual void setEasingParameter(std::vector<float>& parameter);
@@ -194,7 +194,7 @@ protected:
     /**
     * Gets the Easing Action of ActionFrame.
     *
-    * @parame action   the duration time of ActionFrame
+    * @param action   the duration time of ActionFrame
     *
     * @return ActionInterval
     */
@@ -242,7 +242,7 @@ public:
     /**
     * Gets the ActionInterval of ActionFrame.
     *
-    * @parame duration   the duration time of ActionFrame
+    * @param duration   the duration time of ActionFrame
     *
     * @return ActionInterval
     */
@@ -300,7 +300,7 @@ public:
     /**
     * Gets the ActionInterval of ActionFrame.
     *
-    * @parame duration   the duration time of ActionFrame
+    * @param duration   the duration time of ActionFrame
     *
     * @return ActionInterval
     */
@@ -344,7 +344,7 @@ public:
     /**
     * Gets the ActionInterval of ActionFrame.
     *
-    * @parame duration   the duration time of ActionFrame
+    * @param duration   the duration time of ActionFrame
     *
     * @return ActionInterval
     */
@@ -352,9 +352,9 @@ public:
     /**
     * Gets the ActionInterval of ActionFrame.
     *
-    * @parame duration   the duration time of ActionFrame
+    * @param duration   the duration time of ActionFrame
     *
-    * @parame duration   the source ActionFrame
+    * @param duration   the source ActionFrame
     *
     * @return ActionInterval
     */
@@ -397,7 +397,7 @@ public:
     /**
     * Gets the ActionInterval of ActionFrame.
     *
-    * @parame duration   the duration time of ActionFrame
+    * @param duration   the duration time of ActionFrame
     *
     * @return ActionInterval
     */
@@ -441,7 +441,7 @@ public:
     /**
     * Gets the ActionInterval of ActionFrame.
     *
-    * @parame duration   the duration time of ActionFrame
+    * @param duration   the duration time of ActionFrame
     *
     * @return ActionInterval
     */

--- a/cocos/editor-support/cocostudio/CCActionManagerEx.h
+++ b/cocos/editor-support/cocostudio/CCActionManagerEx.h
@@ -109,7 +109,7 @@ public:
     */
     ActionObject* stopActionByName(const char* jsonName,const char* actionName);
 
-    /*init properties with json dictionay*/
+    /*init properties with json dictionary*/
     void initWithDictionary(const char* jsonName,const rapidjson::Value &dic, Ref* root);
     void initWithBinary(const char* file, Ref* root,  CocoLoader* cocoLoader, stExpCocoNode*    pCocoNode);
 

--- a/cocos/editor-support/cocostudio/CCArmatureAnimation.h
+++ b/cocos/editor-support/cocostudio/CCArmatureAnimation.h
@@ -279,7 +279,7 @@ protected:
 
     Armature *_armature;                        //! A weak reference of armature
 
-    std::string _movementID;                //! Current movment's name
+    std::string _movementID;                //! Current movement's name
 
     int _toIndex;                                //! The frame index in MovementData->m_pMovFrameDataArr, it's different from m_iFrameIndex.
 

--- a/cocos/editor-support/cocostudio/CCArmatureDataManager.h
+++ b/cocos/editor-support/cocostudio/CCArmatureDataManager.h
@@ -48,7 +48,7 @@ public:
     /** @deprecated Use getInstance() instead */
     CC_DEPRECATED_ATTRIBUTE static ArmatureDataManager *sharedArmatureDataManager() { return ArmatureDataManager::getInstance(); }
 
-    /** @deprecated Use destoryInstance() instead */
+    /** @deprecated Use destroyInstance() instead */
     CC_DEPRECATED_ATTRIBUTE static void purge() { ArmatureDataManager::destroyInstance(); };
     
     static ArmatureDataManager *getInstance();

--- a/cocos/editor-support/cocostudio/CCBone.h
+++ b/cocos/editor-support/cocostudio/CCBone.h
@@ -107,7 +107,7 @@ public:
 
     /**
      * Set parent bone.
-     * If parent is NUll, then also remove this bone from armature.
+     * If parent is null, then also remove this bone from armature.
      * It will not set the Armature, if you want to add the bone to a Armature, you should use Armature::addBone(Bone *bone, const char* parentName).
      *
      * @param parent  the parent bone.

--- a/cocos/editor-support/cocostudio/CCDatas.h
+++ b/cocos/editor-support/cocostudio/CCDatas.h
@@ -108,7 +108,7 @@ public:
     /**
     * x y skewX skewY scaleX scaleY used to calculate transform matrix
     * skewX, skewY can have rotation effect
-    * To get more matrix information, you can have a look at this pape : http://www.senocular.com/flash/tutorials/transformmatrix/
+    * To get more matrix information, you can have a look at this paper : http://www.senocular.com/flash/tutorials/transformmatrix/
     */
     float skewX;
     float skewY;
@@ -441,7 +441,7 @@ public:
     cocos2d::tweenfunc::TweenType tweenEasing;
 
     /**
-    * @brief    save movment bone data
+    * @brief    save movement bone data
     * @key    const std::string& 
     * @value    MovementBoneData *
     */

--- a/cocos/editor-support/cocostudio/CCDisplayManager.h
+++ b/cocos/editor-support/cocostudio/CCDisplayManager.h
@@ -51,7 +51,7 @@ public:
 
     /**
      * Use BoneData to init the display list.
-     * If display is a sprite, and it have texture info in the TexutreData, then use TexutreData to init the display's anchor point
+     * If display is a sprite, and it have texture info in the TextureData, then use TextureData to init the display's anchor point
      * If the display is a Armature, then create a new Armature
      */
     virtual void initDisplayList(BoneData *boneData);

--- a/cocos/editor-support/cocostudio/CCTween.h
+++ b/cocos/editor-support/cocostudio/CCTween.h
@@ -134,7 +134,7 @@ protected:
 
     Bone *_bone;                    //! A weak reference to the Bone
 
-    TweenType _frameTweenEasing;  //! Dedermine which tween effect current frame use
+    TweenType _frameTweenEasing;  //! Determine which tween effect current frame use
 
     int _betweenDuration;           //! Current key frame will last _betweenDuration frames
     int _totalDuration;

--- a/cocos/editor-support/cocostudio/FlatBuffersSerialize.cpp
+++ b/cocos/editor-support/cocostudio/FlatBuffersSerialize.cpp
@@ -560,7 +560,7 @@ Offset<NodeAction> FlatBuffersSerialize::createNodeAction(const tinyxml2::XMLEle
     // ActionTimeline
     const tinyxml2::XMLAttribute* attribute = objectData->FirstAttribute();
     
-    // attibutes
+    // attributes
     while (attribute)
     {
         std::string name = attribute->Name();
@@ -634,7 +634,7 @@ Offset<TimeLine> FlatBuffersSerialize::createTimeLine(const tinyxml2::XMLElement
     int actionTag = 0;
     std::string property = "";
     
-    // TimelineData attrsibutes
+    // TimelineData attributes
     const tinyxml2::XMLAttribute* attribute = objectData->FirstAttribute();
     while (attribute)
     {


### PR DESCRIPTION
This commit fixes some typos and doxygen annotations (`@parame` => `@param`).
