### PR TITLE
Update CSLoader.cpp

### DIFF
--- a/cocos/editor-support/cocostudio/ActionTimeline/CSLoader.cpp
+++ b/cocos/editor-support/cocostudio/ActionTimeline/CSLoader.cpp
@@ -1016,6 +1016,7 @@ Node* CSLoader::nodeWithFlatBuffers(const flatbuffers::NodeTree *nodetree, const
             {
                 Data buf = FileUtils::getInstance()->getDataFromFile(filePath);
                 node = createNode(buf, callback);
+				            timeline::ActionTimelineCache::getInstance()->removeAction(filePath);
                 action = timeline::ActionTimelineCache::getInstance()->loadAnimationWithDataBuffer(buf, filePath);
             }
             else


### PR DESCRIPTION
CSLoader 在加载 csb 嵌套动画时候的 bug. bug 描述如下:
1. 存在一个动画节点 A.
2. 新建一个节点B, B 里面放入 2 个 节点A. 2 个 节点A 在不同帧上开始播放动画. 
3. 此时 2 个 节点A 实例应该有各自的 ActionTimeline 对象. 而这里在加载的时候 2 个 节点A 实例使用了同一个缓存的 ActionTimeline 对象. 这样只有最后一个应用到 ActionTimeline 上的 节点 是正常工作的. 其余 节点 都无法正常工作.
