### PR TITLE
Analyzing directory exists function for mac & ios

### DIFF
--- a/cocos/platform/apple/CCFileUtils-apple.h
+++ b/cocos/platform/apple/CCFileUtils-apple.h
@@ -57,6 +57,7 @@ public:
     void setBundle(NSBundle* bundle);
 private:
     virtual bool isFileExistInternal(const std::string& filePath) const override;
+    virtual bool isDirectoryExistInternal(const std::string& dirPath) const override;
     virtual bool removeDirectory(const std::string& dirPath) override;
     
     NSBundle* getBundle() const;

--- a/cocos/platform/apple/CCFileUtils-apple.mm
+++ b/cocos/platform/apple/CCFileUtils-apple.mm
@@ -394,6 +394,35 @@ bool FileUtilsApple::isFileExistInternal(const std::string& filePath) const
     return ret;
 }
 
+bool FileUtilsApple::isDirectoryExistInternal(const std::string& dirPath) const
+{
+    if (dirPath.empty())
+    {
+        return false;
+    }
+    
+    bool ret = false;
+    
+    if (dirPath[0] != '/')
+    {
+        BOOL isDir = false;
+        NSString *path = [NSString stringWithFormat:@"%s/%s",[getBundle() resourcePath].UTF8String, dirPath.c_str()];
+        if ([s_fileManager fileExistsAtPath:path isDirectory:&isDir]) {
+            ret = isDir;
+        }
+    }
+    else
+    {
+        // Search path is an absolute path.
+        BOOL isDir = false;
+        if ([s_fileManager fileExistsAtPath:[NSString stringWithUTF8String:dirPath.c_str()] isDirectory:&isDir]) {
+            ret = isDir;
+        }
+    }
+
+    return ret;
+}
+
 static int unlink_cb(const char *fpath, const struct stat *sb, int typeflag, struct FTW *ftwbuf)
 {
     auto ret = remove(fpath);


### PR DESCRIPTION
The 'isDirectoryExist(const std::string& dirPath)' function has some problems that can not return the correct result in iOS and mac when analyzing the bundle directory.
Also,it may not work in win32 and android for the same reason.
I fixed it for iOS and mac, continue seeking solution for android and win32.
