### PR TITLE
Some Important Fixes for File Reading, may cause stack overflow

### DIFF
--- a/cocos/2d/CCFontFNT.cpp
+++ b/cocos/2d/CCFontFNT.cpp
@@ -279,21 +279,37 @@ std::set<unsigned int>* BMFontConfiguration::parseConfigFile(const std::string& 
     CCASSERT((!data.isNull()), "BMFontConfiguration::parseConfigFile | Open file error.");
 
     if (memcmp("BMF", data.getBytes(), 3) == 0) {
+        // Handle fnt file of binary format
         std::set<unsigned int>* ret = parseBinaryConfigFile(data.getBytes(), data.getSize(), controlFile);
         return ret;
     }
 
-    auto contents = (const char*)data.getBytes();
-    if (contents[0] == 0)
+    if (data.getBytes()[0] == 0)
     {
         CCLOG("cocos2d: Error parsing FNTfile %s", controlFile.c_str());
         return nullptr;
     }
-
+    
+    // Handle fnt file of string format, allocate one extra byte '\0' at the end since c string needs it.
+    // 'strchr' finds a char until it gets a '\0', if 'contents' self doesn't end with '\0',
+    // 'strchr' will search '\n' out of 'contents' 's buffer size, it will trigger potential and random crashes since
+    // lineLength may bigger than 512 and 'memcpy(line, contents + parseCount, lineLength);' will cause stack buffer overflow.
+    // Please note that 'contents' needs to be freed before this function returns.
+    char* contents = (char*)malloc(data.getSize() + 1);
+    if (contents == nullptr)
+    {
+        CCLOGERROR("BMFontConfiguration::parseConfigFile, out of memory!");
+        return nullptr;
+    }
+    
+    memcpy(contents, data.getBytes(), data.getSize());
+    // Ensure the last byte is '\0'
+    contents[data.getSize()] = '\0';
+    
     std::set<unsigned int> *validCharsString = new (std::nothrow) std::set<unsigned int>();
     
-    auto contentsLen = data.getSize();
-    char line[512];
+    auto contentsLen = strlen(contents);
+    char line[512] = {0};
     
     auto next = strchr(contents, '\n');
     auto base = contents;
@@ -356,6 +372,8 @@ std::set<unsigned int>* BMFontConfiguration::parseConfigFile(const std::string& 
             this->parseKerningEntry(line);
         }
     }
+    
+    CC_SAFE_FREE(contents);
     
     return validCharsString;
 }

--- a/cocos/3d/CCBundle3D.cpp
+++ b/cocos/3d/CCBundle3D.cpp
@@ -162,12 +162,12 @@ void Bundle3D::clear()
 {
     if (_isBinary)
     {
-        CC_SAFE_DELETE(_binaryBuffer);
+        _binaryBuffer.clear();
         CC_SAFE_DELETE_ARRAY(_references);
     }
     else
     {
-        CC_SAFE_DELETE_ARRAY(_jsonBuffer);
+        _jsonBuffer.clear();
     }
 }
 
@@ -1038,14 +1038,9 @@ bool Bundle3D::loadJson(const std::string& path)
 {
     clear();
 
-    Data data = FileUtils::getInstance()->getDataFromFile(path);
-    ssize_t size = data.getSize();
+    _jsonBuffer = FileUtils::getInstance()->getStringFromFile(path);
 
-    // json need null-terminated string.
-    _jsonBuffer = new char[size + 1];
-    memcpy(_jsonBuffer, data.getBytes(), size);
-    _jsonBuffer[size] = '\0';
-    if (_jsonReader.ParseInsitu<0>(_jsonBuffer).HasParseError())
+    if (_jsonReader.ParseInsitu<0>((char*)_jsonBuffer.c_str()).HasParseError())
     {
         clear();
         CCLOG("Parse json failed in Bundle3D::loadJson function");
@@ -1067,10 +1062,9 @@ bool Bundle3D::loadBinary(const std::string& path)
     clear();
     
     // get file data
-    CC_SAFE_DELETE(_binaryBuffer);
-    _binaryBuffer = new (std::nothrow) Data();
-    *_binaryBuffer = FileUtils::getInstance()->getDataFromFile(path);
-    if (_binaryBuffer->isNull())
+    _binaryBuffer.clear();
+    _binaryBuffer = FileUtils::getInstance()->getDataFromFile(path);
+    if (_binaryBuffer.isNull())
     {
         clear();
         CCLOG("warning: Failed to read file: %s", path.c_str());
@@ -1078,7 +1072,7 @@ bool Bundle3D::loadBinary(const std::string& path)
     }
     
     // Initialise bundle reader
-    _binaryReader.init( (char*)_binaryBuffer->getBytes(),  _binaryBuffer->getSize() );
+    _binaryReader.init( (char*)_binaryBuffer.getBytes(),  _binaryBuffer.getSize() );
     
     // Read identifier info
     char identifier[] = { 'C', '3', 'B', '\0'};
@@ -2199,8 +2193,6 @@ Bundle3D::Bundle3D()
 : _modelPath(""),
 _path(""),
 _version(""),
-_jsonBuffer(nullptr),
-_binaryBuffer(nullptr),
 _referenceCount(0),
 _references(nullptr),
 _isBinary(false)

--- a/cocos/3d/CCBundle3D.h
+++ b/cocos/3d/CCBundle3D.h
@@ -25,6 +25,7 @@
 #ifndef __CCBUNDLE3D_H__
 #define __CCBUNDLE3D_H__
 
+#include "base/CCData.h"
 #include "3d/CCBundle3DData.h"
 #include "3d/CCBundleReader.h"
 #include "json/document.h"
@@ -37,7 +38,6 @@ NS_CC_BEGIN
  */
 
 class Animation3D;
-class Data;
 
 /**
  * @brief Defines a bundle file that contains a collection of assets. Mesh, Material, MeshSkin, Animation
@@ -177,11 +177,11 @@ protected:
     std::string _version;// the c3b or c3t version
     
     // for json reading
-    char* _jsonBuffer;
+    std::string _jsonBuffer;
     rapidjson::Document _jsonReader;
 
     // for binary reading
-    Data* _binaryBuffer;
+    Data _binaryBuffer;
     BundleReader _binaryReader;
     unsigned int _referenceCount;
     Reference* _references;

--- a/cocos/editor-support/cocostudio/ActionTimeline/CCActionTimelineCache.cpp
+++ b/cocos/editor-support/cocostudio/ActionTimeline/CCActionTimelineCache.cpp
@@ -434,7 +434,7 @@ ActionTimeline* ActionTimelineCache::loadAnimationActionWithFlatBuffersFile(cons
     return action;
 }
 
-ActionTimeline* ActionTimelineCache::loadAnimationWithDataBuffer(const cocos2d::Data data, const std::string fileName)
+ActionTimeline* ActionTimelineCache::loadAnimationWithDataBuffer(const cocos2d::Data& data, const std::string& fileName)
 {
     // if already exists an action with filename, then return this action
     ActionTimeline* action = _animationActions.at(fileName);
@@ -453,7 +453,7 @@ ActionTimeline* ActionTimelineCache::loadAnimationWithDataBuffer(const cocos2d::
     return action;
 }
 
-inline ActionTimeline* ActionTimelineCache::createActionWithDataBuffer(const cocos2d::Data data)
+ActionTimeline* ActionTimelineCache::createActionWithDataBuffer(const cocos2d::Data& data)
 {
     auto csparsebinary = GetCSParseBinary(data.getBytes());
 

--- a/cocos/editor-support/cocostudio/ActionTimeline/CCActionTimelineCache.h
+++ b/cocos/editor-support/cocostudio/ActionTimeline/CCActionTimelineCache.h
@@ -84,7 +84,7 @@ public:
     
     ActionTimeline* createActionWithFlatBuffersFile(const std::string& fileName);
     ActionTimeline* loadAnimationActionWithFlatBuffersFile(const std::string& fileName);
-    ActionTimeline* loadAnimationWithDataBuffer(const cocos2d::Data data, const std::string fileName);
+    ActionTimeline* loadAnimationWithDataBuffer(const cocos2d::Data& data, const std::string& fileName);
     
     ActionTimeline* createActionWithFlatBuffersForSimulator(const std::string& fileName);
     
@@ -122,7 +122,7 @@ protected:
     Frame* loadBlendFrameWithFlatBuffers        (const flatbuffers::BlendFrame* flatbuffers);
     void loadEasingDataWithFlatBuffers(Frame* frame, const flatbuffers::EasingData* flatbuffers);
 
-    inline ActionTimeline* createActionWithDataBuffer(const cocos2d::Data data);
+    inline ActionTimeline* createActionWithDataBuffer(const cocos2d::Data& data);
 protected:
 
     typedef std::function<Frame*(const rapidjson::Value& json)> FrameCreateFunc;

--- a/cocos/editor-support/cocostudio/ActionTimeline/CSLoader.cpp
+++ b/cocos/editor-support/cocostudio/ActionTimeline/CSLoader.cpp
@@ -348,7 +348,7 @@ ActionTimeline* CSLoader::createTimeline(const std::string &filename)
     return nullptr;
 }
 
-ActionTimeline* CSLoader::createTimeline(const Data data, const std::string& filename)
+ActionTimeline* CSLoader::createTimeline(const Data& data, const std::string& filename)
 {
     std::string suffix = getExtentionName(filename);
 
@@ -853,12 +853,12 @@ Component* CSLoader::loadComAudio(const rapidjson::Value &json)
     return audio;
 }
 
-cocos2d::Node* CSLoader::createNode(const Data data)
+cocos2d::Node* CSLoader::createNode(const Data& data)
 {
     return createNode(data, nullptr);
 }
 
-Node * CSLoader::createNode(const Data data, const ccNodeLoadCallback &callback)
+Node * CSLoader::createNode(const Data& data, const ccNodeLoadCallback &callback)
 {
     CSLoader * loader = CSLoader::getInstance();
     Node * node = nullptr;

--- a/cocos/editor-support/cocostudio/ActionTimeline/CSLoader.h
+++ b/cocos/editor-support/cocostudio/ActionTimeline/CSLoader.h
@@ -79,13 +79,13 @@ public:
     
     static cocos2d::Node* createNode(const std::string& filename);
     static cocos2d::Node* createNode(const std::string& filename, const ccNodeLoadCallback& callback);
-    static cocos2d::Node* createNode(const Data data);
-    static cocos2d::Node* createNode(const Data data, const ccNodeLoadCallback &callback);
+    static cocos2d::Node* createNode(const Data& data);
+    static cocos2d::Node* createNode(const Data& data, const ccNodeLoadCallback &callback);
     static cocos2d::Node* createNodeWithVisibleSize(const std::string& filename);
     static cocos2d::Node* createNodeWithVisibleSize(const std::string& filename, const ccNodeLoadCallback& callback);
 
     static cocostudio::timeline::ActionTimeline* createTimeline(const std::string& filename);
-    static cocostudio::timeline::ActionTimeline* createTimeline(const Data data, const std::string& filename);
+    static cocostudio::timeline::ActionTimeline* createTimeline(const Data& data, const std::string& filename);
 
     /*
     static cocostudio::timeline::ActionTimelineNode* createActionTimelineNode(const std::string& filename);

--- a/cocos/renderer/CCMaterial.cpp
+++ b/cocos/renderer/CCMaterial.cpp
@@ -105,10 +105,6 @@ bool Material::initWithGLProgramState(cocos2d::GLProgramState *state)
 
 bool Material::initWithFile(const std::string& validfilename)
 {
-    Data data = FileUtils::getInstance()->getDataFromFile(validfilename);
-    char* bytes = (char*)data.getBytes();
-    bytes[data.getSize()-1]='\0';
-
     // Warning: properties is not a "Ref" object, must be manually deleted
     Properties* properties = Properties::createNonRefCounted(validfilename);
 

--- a/tests/cpp-tests/Classes/SpriteTest/SpriteTest.cpp
+++ b/tests/cpp-tests/Classes/SpriteTest/SpriteTest.cpp
@@ -1868,27 +1868,16 @@ void SpriteFramesFromFileContent::onEnter()
 	SpriteTestDemo::onEnter();
 	auto s = Director::getInstance()->getWinSize();
 
-	std::string plist_content;
-	{
-		std::string fullPath = FileUtils::getInstance()->fullPathForFilename(sheetName() + ".plist");
-		Data data = FileUtils::getInstance()->getDataFromFile(fullPath);
-		if (!data.isNull())
-			plist_content.assign((const char*)data.getBytes(), data.getSize());
-	}
+	std::string plist_content = FileUtils::getInstance()->getStringFromFile(sheetName() + ".plist");
+	Data image_content = FileUtils::getInstance()->getDataFromFile(sheetName() + ".png");
 
-	std::string image_content;
-	{
-		std::string fullPath = FileUtils::getInstance()->fullPathForFilename(sheetName() + ".png");
-		Data data = FileUtils::getInstance()->getDataFromFile(fullPath);
-		if (!data.isNull())
-			image_content.assign((const char*)data.getBytes(), data.getSize());
-	}
-
-	Image image;
-	image.initWithImageData((const uint8_t*)image_content.c_str(), image_content.size());
+    Image* image = new (std::nothrow) Image();
+	image->initWithImageData((const uint8_t*)image_content.getBytes(), image_content.getSize());
 	Texture2D* texture = new (std::nothrow) Texture2D();
-	texture->initWithImage(&image);
+	texture->initWithImage(image);
 	texture->autorelease();
+    
+    CC_SAFE_RELEASE(image);
 
 	auto cache = SpriteFrameCache::getInstance();
 	cache->addSpriteFramesWithFileContent(plist_content, texture);
@@ -1918,13 +1907,7 @@ void SpriteFramesFromFileContent::onExit()
 {
 	SpriteTestDemo::onExit();
 
-	std::string plist_content;
-	{
-		std::string fullPath = FileUtils::getInstance()->fullPathForFilename("animations/grossini.plist");
-		Data data = FileUtils::getInstance()->getDataFromFile(fullPath);
-		if (!data.isNull())
-			plist_content.assign((const char*)data.getBytes(), data.getSize());
-	}
+	std::string plist_content = FileUtils::getInstance()->getStringFromFile("animations/grossini.plist");
 
 	SpriteFrameCache::getInstance()->removeSpriteFramesFromFileContent(plist_content);
 }


### PR DESCRIPTION
- The fix for BMFontConfiguration::parseConfigFile reads string file.
  
  'strchr' finds a char until it gets a '\0' or the char to find, if 'contents' self doesn't end with '\0',
  'strchr' will search '\n' out of 'contents' 's buffer size, it will trigger **potential and random crashes** since lineLength may bigger than 512 and 'memcpy(line, contents + parseCount, lineLength);' will cause stack buffer overflow.
- const Data -> const Data& for function argument, performance improvement.
- Removes unused code in Material::initWithFile.
- Refactor CCBundle3D, remove wrong use of getDataFromFile. _jsonBuffer is std::string, _binaryBuffer is Data instance now.
- SpriteTest fix
  - Image is Ref class, please new & release it. Don't allocate it on stack.
  - Fixes complicated logic of getting string from file.
