### PR TITLE
Fix warning: extra tokens at end of #ifdef directive

### DIFF
--- a/cocos/platform/ios/CCEAGLView-ios.mm
+++ b/cocos/platform/ios/CCEAGLView-ios.mm
@@ -427,7 +427,7 @@ Copyright (C) 2008 Apple Inc. All Rights Reserved.
         ids[i] = touch;
         xs[i] = [touch locationInView: [touch view]].x * self.contentScaleFactor;;
         ys[i] = [touch locationInView: [touch view]].y * self.contentScaleFactor;;
-#ifdef __IPHONE_9_0 && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_9_0
+#if defined(__IPHONE_9_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_9_0)
         // running on iOS 9.0 or higher version
         if ([[[UIDevice currentDevice] systemVersion] floatValue] >= 9.0f) {
             fs[i] = touch.force;


### PR DESCRIPTION
I get the following warning when building libcocos2d-iOS (and tvOS) on Xcode 7.2:

```
cocos/platform/ios/CCEAGLView-ios.mm:430:21: Extra tokens at end of #ifdef directive
```

This patch fixes it, thanks!
