### PR TITLE
Homogenous shadows and strokes for system fonts.

### DIFF
--- a/build/cocos2d_libs.xcodeproj/project.pbxproj
+++ b/build/cocos2d_libs.xcodeproj/project.pbxproj
@@ -7,6 +7,12 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0AE22ECF1C4AE8D80099B83F /* CCStroke.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0AE22ECD1C4AE8D80099B83F /* CCStroke.cpp */; };
+		0AE22ED01C4AE8D80099B83F /* CCStroke.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0AE22ECD1C4AE8D80099B83F /* CCStroke.cpp */; };
+		0AE22ED11C4AE8D80099B83F /* CCStroke.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0AE22ECD1C4AE8D80099B83F /* CCStroke.cpp */; };
+		0AE22ED21C4AE8D80099B83F /* CCStroke.h in Headers */ = {isa = PBXBuildFile; fileRef = 0AE22ECE1C4AE8D80099B83F /* CCStroke.h */; };
+		0AE22ED31C4AE8D80099B83F /* CCStroke.h in Headers */ = {isa = PBXBuildFile; fileRef = 0AE22ECE1C4AE8D80099B83F /* CCStroke.h */; };
+		0AE22ED41C4AE8D80099B83F /* CCStroke.h in Headers */ = {isa = PBXBuildFile; fileRef = 0AE22ECE1C4AE8D80099B83F /* CCStroke.h */; };
 		0C261F281BE7528900707478 /* Light3DReader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0C261F261BE7528900707478 /* Light3DReader.cpp */; };
 		0C261F291BE7528900707478 /* Light3DReader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0C261F261BE7528900707478 /* Light3DReader.cpp */; };
 		0C261F2A1BE7528900707478 /* Light3DReader.h in Headers */ = {isa = PBXBuildFile; fileRef = 0C261F271BE7528900707478 /* Light3DReader.h */; };
@@ -5773,6 +5779,8 @@
 		06CAAABF186AD63B0012A414 /* TriggerMng.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TriggerMng.h; sourceTree = "<group>"; };
 		06CAAAC0186AD63B0012A414 /* TriggerObj.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TriggerObj.cpp; sourceTree = "<group>"; };
 		06CAAAC1186AD63B0012A414 /* TriggerObj.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TriggerObj.h; sourceTree = "<group>"; };
+		0AE22ECD1C4AE8D80099B83F /* CCStroke.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CCStroke.cpp; sourceTree = "<group>"; };
+		0AE22ECE1C4AE8D80099B83F /* CCStroke.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CCStroke.h; sourceTree = "<group>"; };
 		0C261F261BE7528900707478 /* Light3DReader.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Light3DReader.cpp; sourceTree = "<group>"; };
 		0C261F271BE7528900707478 /* Light3DReader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Light3DReader.h; sourceTree = "<group>"; };
 		1551A33F158F2AB200E66CFE /* libcocos2d Mac.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libcocos2d Mac.a"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -9994,6 +10002,8 @@
 				50ABBF281926664700A911A9 /* CCImage.h */,
 				50ABBF291926664700A911A9 /* CCSAXParser.cpp */,
 				50ABBF2A1926664700A911A9 /* CCSAXParser.h */,
+				0AE22ECD1C4AE8D80099B83F /* CCStroke.cpp */,
+				0AE22ECE1C4AE8D80099B83F /* CCStroke.h */,
 				50ABBF2B1926664700A911A9 /* CCThread.cpp */,
 				50ABBF2C1926664700A911A9 /* CCThread.h */,
 			);
@@ -12427,6 +12437,7 @@
 				B6DD2FEB1B04825B00E47F5F /* DetourProximityGrid.h in Headers */,
 				5020A1EF1D49912500E80C72 /* SkeletonBounds.h in Headers */,
 				B6DD2FC51B04825B00E47F5F /* DetourNavMesh.h in Headers */,
+				0AE22ED21C4AE8D80099B83F /* CCStroke.h in Headers */,
 				50ABC0171926664800A911A9 /* CCImage.h in Headers */,
 				B6DD2FCD1B04825B00E47F5F /* DetourNavMeshQuery.h in Headers */,
 				50ABBDA91925AB4100A911A9 /* CCRenderCommand.h in Headers */,
@@ -12845,6 +12856,7 @@
 				507B3E8B1C31BDD30067B53E /* UIEditBoxImpl-android.h in Headers */,
 				507B3E8C1C31BDD30067B53E /* PlatformDefinitions.h in Headers */,
 				507B3E8D1C31BDD30067B53E /* CCPUJetAffectorTranslator.h in Headers */,
+				0AE22ED41C4AE8D80099B83F /* CCStroke.h in Headers */,
 				507B3E8E1C31BDD30067B53E /* GUIDefine.h in Headers */,
 				507B3E8F1C31BDD30067B53E /* CCDownloader.h in Headers */,
 				5020A1CD1D49912500E80C72 /* PathConstraint.h in Headers */,
@@ -13904,6 +13916,7 @@
 				5020A2021D49912500E80C72 /* SkeletonRenderer.h in Headers */,
 				B6CAB49E1AF9AA1A00B9B856 /* PlatformDefinitions.h in Headers */,
 				B665E2DD1AA80A6500DDB1C5 /* CCPUJetAffectorTranslator.h in Headers */,
+				0AE22ED31C4AE8D80099B83F /* CCStroke.h in Headers */,
 				15AE1B9419AADA9A00C27E9E /* GUIDefine.h in Headers */,
 				50693C611B6BF2AE005C5820 /* CCDownloader.h in Headers */,
 				B6CAB3E41AF9AA1A00B9B856 /* btUniversalConstraint.h in Headers */,
@@ -15409,6 +15422,7 @@
 				B6CAB4BF1AF9AA1A00B9B856 /* SpuLibspe2Support.cpp in Sources */,
 				B665E21E1AA80A6500DDB1C5 /* CCPUBehaviourManager.cpp in Sources */,
 				15AE18E319AAD35000C27E9E /* TriggerObj.cpp in Sources */,
+				0AE22ECF1C4AE8D80099B83F /* CCStroke.cpp in Sources */,
 				15AE1BA119AADFDF00C27E9E /* UILayoutParameter.cpp in Sources */,
 				50ABC0211926664800A911A9 /* CCGLViewImpl-desktop.cpp in Sources */,
 				5033419C1D9DC7B400770EC7 /* SkeletonBinary.c in Sources */,
@@ -15567,6 +15581,7 @@
 				507B39F51C31BDD30067B53E /* b2WorldCallbacks.cpp in Sources */,
 				507B39F61C31BDD30067B53E /* btQuantizedBvh.cpp in Sources */,
 				507B39F71C31BDD30067B53E /* btSimpleDynamicsWorld.cpp in Sources */,
+				0AE22ED11C4AE8D80099B83F /* CCStroke.cpp in Sources */,
 				507B39F81C31BDD30067B53E /* CCMenuItemImageLoader.cpp in Sources */,
 				507B39F91C31BDD30067B53E /* fastlz.c in Sources */,
 				507B39FA1C31BDD30067B53E /* CCSAXParser.cpp in Sources */,
@@ -16422,6 +16437,7 @@
 				15AE1AAC19AAD40300C27E9E /* b2WorldCallbacks.cpp in Sources */,
 				B6CAB20C1AF9AA1A00B9B856 /* btQuantizedBvh.cpp in Sources */,
 				B6CAB3F21AF9AA1A00B9B856 /* btSimpleDynamicsWorld.cpp in Sources */,
+				0AE22ED01C4AE8D80099B83F /* CCStroke.cpp in Sources */,
 				15AE18C719AAD33D00C27E9E /* CCMenuItemImageLoader.cpp in Sources */,
 				B6DD2FF61B04825B00E47F5F /* fastlz.c in Sources */,
 				50ABC01A1926664800A911A9 /* CCSAXParser.cpp in Sources */,

--- a/cocos/2d/CCLabel.h
+++ b/cocos/2d/CCLabel.h
@@ -1,6 +1,7 @@
 /****************************************************************************
  Copyright (c) 2013      Zynga Inc.
  Copyright (c) 2013-2016 Chukong Technologies Inc.
+ Copyright (c) 2015 	 IsCool Entertainment
 
  http://www.cocos2d-x.org
 
@@ -667,6 +668,9 @@ protected:
 
     void createSpriteForSystemFont(const FontDefinition& fontDef);
     void createShadowSpriteForSystemFont(const FontDefinition& fontDef);
+
+    Texture2D* getOrCreateTextTexture( const FontDefinition& font ) const;
+    void adjustSize();
 
     virtual void updateShaderProgram();
     void updateBMFontScale();

--- a/cocos/Android.mk
+++ b/cocos/Android.mk
@@ -93,6 +93,8 @@ platform/CCFileUtils.cpp \
 platform/CCGLView.cpp \
 platform/CCImage.cpp \
 platform/CCSAXParser.cpp \
+platform/CCStroke.cpp \
+platform/CCStrokeScan.cpp \
 platform/CCThread.cpp \
 $(MATHNEONFILE) \
 math/CCAffineTransform.cpp \

--- a/cocos/platform/CCStroke.cpp
+++ b/cocos/platform/CCStroke.cpp
@@ -1,0 +1,133 @@
+#include "platform/CCStroke.h"
+
+#include "platform/CCStrokeScan.h"
+
+#include "base/ccTypes.h"
+
+#include <cstdint>
+#include <cassert>
+#include <algorithm>
+
+namespace cocos2d
+{
+    namespace detail
+    {
+        static void transparentStroke
+        ( unsigned char*& src, int& width, int& height,
+          const FontStroke& stroke );
+
+        static void convolutionFull
+        ( unsigned char*& src, int& width, int& height,
+          const FontStroke& stroke );
+
+        static int getStrokeSize( const FontStroke& stroke );
+        
+        static std::unique_ptr< std::uint8_t[] > buildMatrix
+        ( std::size_t matrixWidth );
+    }
+}
+
+void cocos2d::drawStroke
+( unsigned char*& src, int& width, int& height, const FontStroke& stroke )
+{
+    if ( stroke._strokeAlpha == 0 )
+        detail::transparentStroke( src, width, height, stroke );
+    else
+        detail::convolutionFull( src, width, height, stroke );
+}
+
+static void cocos2d::detail::transparentStroke
+( unsigned char*& src, int& width, int& height, const FontStroke& stroke )
+{
+    const int strokeSize( getStrokeSize( stroke ) );
+
+    if ( ( strokeSize <= 0 ) || !stroke._strokeEnabled )
+        return;
+
+    const int destWidth( width + strokeSize * 2 );
+    const int destHeight( height + strokeSize * 2 );
+    static constexpr int bpp( 4 );
+    const int lineLength( destWidth * bpp );
+    const std::size_t destSize
+        ( sizeof( unsigned char ) * lineLength * destHeight );
+    unsigned char* dest( static_cast< unsigned char* >( malloc( destSize ) ) );
+
+    std::fill( dest, dest + strokeSize * lineLength, 0 );
+    std::fill
+        ( dest + ( destHeight - strokeSize ) * lineLength, dest + destSize, 0 );
+    
+    for ( int y( strokeSize ); y != destHeight - strokeSize; ++y )
+    {
+        unsigned char* const lineBegin( dest + y * lineLength );
+        std::fill( lineBegin, lineBegin + strokeSize * bpp, 0 );
+
+        unsigned char* const lineEnd( lineBegin + lineLength );
+        std::fill( lineEnd - strokeSize * bpp, lineEnd, 0 );
+        
+        for ( int x( strokeSize ); x != destWidth - strokeSize; ++x )
+        {
+            const std::size_t i( ( y - strokeSize ) * width + x - strokeSize );
+            const std::uint32_t srcColor
+                ( reinterpret_cast< std::uint32_t*>( src )[ i ] );
+
+            const std::size_t j( y * destWidth + x );
+            std::uint32_t&  destColor
+                ( *reinterpret_cast< std::uint32_t* >( &dest[ j * bpp ] ) );
+            
+            destColor = srcColor;
+        }
+    }
+
+    std::swap( dest, src );
+    free( dest );
+
+    width = destWidth;
+    height = destHeight;
+}
+
+static void cocos2d::detail::convolutionFull
+( unsigned char*& src, int& width, int& height, const FontStroke& stroke )
+{
+    const int strokeSize( getStrokeSize( stroke ) );
+    
+    if ( ( strokeSize <= 0 ) || !stroke._strokeEnabled )
+        return;
+
+    const std::size_t matrixWidth( 2 * strokeSize + 1 );
+
+    const std::unique_ptr< std::uint8_t[] > matrix
+        ( buildMatrix( matrixWidth ) );
+
+    detail::StrokeScan scanner
+        ( matrix.get(), matrixWidth, src, width, height, stroke, strokeSize );
+    scanner.run();
+}
+
+static int cocos2d::detail::getStrokeSize( const FontStroke& stroke )
+{
+    return std::ceil( stroke._strokeSize );
+}
+
+static std::unique_ptr< std::uint8_t[] >
+cocos2d::detail::buildMatrix( std::size_t matrixWidth )
+{
+    const int matrixHalfWidth( matrixWidth / 2 );
+    const std::size_t matrixSize( matrixWidth * matrixWidth );
+    std::unique_ptr< std::uint8_t[] > result( new std::uint8_t[ matrixSize ] );
+
+    for ( std::size_t i( 0 ); i != matrixSize; ++i )
+    {
+        const int x( i % matrixWidth );
+        const int y( i / matrixWidth );
+
+        const int dx( x - matrixHalfWidth );
+        const int dy( y - matrixHalfWidth );
+
+        if ( std::sqrt( dx * dx + dy * dy ) <= matrixHalfWidth )
+            result[ i ] = 1;
+        else
+            result[ i ] = 0;
+    }
+
+    return result;
+}

--- a/cocos/platform/CCStroke.h
+++ b/cocos/platform/CCStroke.h
@@ -1,0 +1,12 @@
+#ifndef COCOS2D_STROKE_H
+#define COCOS2D_STROKE_H
+
+namespace cocos2d
+{
+    struct FontStroke;
+    
+    void drawStroke
+    ( unsigned char*& src, int& width, int& height, const FontStroke& stroke );
+}
+
+#endif

--- a/cocos/platform/CCStrokeScan.cpp
+++ b/cocos/platform/CCStrokeScan.cpp
@@ -1,0 +1,463 @@
+#include "platform/CCStrokeScan.h"
+
+#include "base/ccTypes.h"
+
+#include <cassert>
+#include <algorithm>
+
+namespace cocos2d
+{
+    namespace detail
+    {
+        class LineBounds
+        {
+        public:
+            LineBounds( std::size_t matrixWidth, int destWidth );
+
+            void queueStart( int x );
+            void queueEnd( int x );
+
+            int getStart();
+            int getEnd();
+
+            void roll();
+
+        private:
+            std::vector< int > starts;
+            std::vector< int > ends;
+        };
+        
+        class MatrixResult
+        {
+        public:
+            MatrixResult();
+            
+            unsigned int nonZeroCount;
+            unsigned int weightedAlpha;
+        };
+
+        static std::uint32_t blend
+        ( std::uint32_t c0, std::uint32_t c1, std::uint32_t a1 );
+
+        static std::uint32_t colorA( std::uint32_t c );
+        static std::uint32_t colorB( std::uint32_t c );
+        static std::uint32_t colorG( std::uint32_t c );
+        static std::uint32_t colorR( std::uint32_t c );
+
+        static std::uint32_t toColor
+        ( std::uint32_t r, std::uint32_t g, std::uint32_t b, std::uint32_t a );
+
+        static std::uint32_t getColorAt
+        ( unsigned char* src, int width, int height, int x, int y );
+
+        static MatrixResult applyMatrix
+        ( const std::uint8_t* matrix, std::size_t matrixWidth,
+          unsigned char* src, int srcx, int srcy, int width, int height );
+
+        static constexpr std::uint32_t fullAlphaSquared = 65025;
+    }
+}
+
+enum class cocos2d::detail::StrokeScan::Progress
+{
+    jump,
+    forward,
+    rewind
+};
+    
+cocos2d::detail::StrokeScan::StrokeScan
+( std::uint8_t* matrix, std::size_t matrixWidth, unsigned char*& src,
+  int& width, int& height, const FontStroke& stroke, int strokeSize )
+    : _matrix( matrix ),
+      _matrixWidth( matrixWidth ),
+      _src( src ),
+      _width( width ),
+      _height( height ),
+      _stroke( stroke ),
+      _strokeSize( strokeSize ),
+      _destWidth( width + strokeSize * 2 ),
+      _destHeight( height + strokeSize * 2 ),
+      _dest
+      ( static_cast< unsigned char* >
+        ( malloc( sizeof( unsigned char ) * _destWidth * _destHeight * 4 ) ) ),
+      _strokeColor
+      ( toColor
+        ( stroke._strokeColor.r * stroke._strokeAlpha / 255,
+          stroke._strokeColor.g * stroke._strokeAlpha / 255,
+          stroke._strokeColor.b * stroke._strokeAlpha / 255,
+          stroke._strokeAlpha ) )
+
+{    
+    assert( _strokeSize > 0 );
+}
+
+void cocos2d::detail::StrokeScan::run()
+{
+    scan();
+    
+    std::swap( _dest, _src );
+    free( _dest );
+
+    _width = _destWidth;
+    _height = _destHeight;
+}
+
+void cocos2d::detail::StrokeScan::scan()
+{
+    LineBounds bounds( _matrixWidth, _destWidth );
+    std::size_t destIndex( 0 );
+    
+    for ( int desty( 0 ); desty != _destHeight; ++desty )
+    {
+        assert( destIndex == std::size_t( desty * _destWidth ) * 4 );
+            
+        queueBounds( bounds, desty + _strokeSize );
+
+        destIndex =
+            boundedScan( destIndex, bounds.getStart(), bounds.getEnd(), desty );
+        
+        bounds.roll();
+    }
+}
+
+void cocos2d::detail::StrokeScan::queueBounds
+( LineBounds& bounds, int bottomLine ) const
+{
+    const int lineStart( findFirstNonTransparent( bottomLine ) );
+    assert( lineStart >= _strokeSize );
+
+    bounds.queueStart( lineStart );
+
+    if ( lineStart == _destWidth )
+        bounds.queueEnd( 0 );
+    else
+        bounds.queueEnd( findLastNonTransparent( bottomLine ) + 1 );
+}
+
+std::size_t cocos2d::detail::StrokeScan::boundedScan
+( std::size_t destIndex, int startx, int endx, int desty ) const
+{
+    bool doScan( false );
+        
+    if ( startx < endx )
+    {
+        doScan = true;
+        startx -= _strokeSize;
+        endx += _strokeSize;
+    }
+
+    destIndex += startx * 4;
+    fillTransparent( destIndex, -1, startx );
+
+    if ( doScan )
+    {
+        assert( endx <= _destWidth );
+        assert
+            ( destIndex == std::size_t( startx + desty * _destWidth ) * 4 );
+
+        destIndex = scanDestinationLine( destIndex, startx, endx, desty );
+
+        assert( destIndex == std::size_t( endx + desty * _destWidth ) * 4 );
+
+        destIndex += ( _destWidth - endx ) * 4;
+        fillTransparent( destIndex, endx - 1, _destWidth );
+    }
+
+    return destIndex;
+}
+
+int cocos2d::detail::StrokeScan::scanDestinationLine
+( int destIndex, int startx, int endx, int desty ) const
+{
+    assert( endx > startx );
+    
+    int lastJump( startx );
+        
+    for ( int destx( startx ); destx != endx; )
+    {
+        std::uint32_t& destColor
+            ( *reinterpret_cast< std::uint32_t* >
+              ( &_dest[ destIndex ] ) );
+            
+        const Progress progress( apply( destx, desty, destColor ) );
+        unsigned int stepSize;
+            
+        if ( progress == Progress::jump )
+        {
+            fillTransparent( destIndex, lastJump, destx );
+            stepSize = std::min< unsigned int >( endx - destx, _matrixWidth );
+        }
+        else
+        {
+            applyInRange( destIndex, lastJump, destx, desty );
+            stepSize = 1;
+        }
+            
+        lastJump = destx;
+        destx += stepSize;
+        destIndex += 4 * stepSize;
+    }
+        
+    fillTransparent( destIndex, lastJump, endx );
+
+    return destIndex;
+}
+
+cocos2d::detail::StrokeScan::Progress
+cocos2d::detail::StrokeScan::apply
+( int destx, int desty, std::uint32_t& destColor ) const
+{
+    const int srcx( destx - _strokeSize );
+    const int srcy( desty - _strokeSize );
+
+    const std::uint32_t srcColor
+        ( getColorAt( _src, _width, _height, srcx, srcy ) );
+    const std::uint32_t srcAlpha( colorA( srcColor ) );
+
+    if ( srcAlpha == 255 )
+    {
+        destColor = srcColor;
+        return Progress::forward;
+    }
+
+    const MatrixResult matrixResult
+        ( applyMatrix
+          ( _matrix, _matrixWidth, _src, srcx, srcy, _width, _height ) );
+    const unsigned int weightedAlpha
+        ( std::min< unsigned int >( 255, matrixResult.weightedAlpha ) );
+    
+    const std::uint32_t strokeAlpha
+        ( weightedAlpha * _stroke._strokeAlpha / 255 );
+
+    assert( strokeAlpha <= 255 );
+
+    if ( srcAlpha == 0 )
+    {
+        destColor =
+            toColor
+            ( colorR( _strokeColor ) * strokeAlpha / 255,
+              colorG( _strokeColor ) * strokeAlpha / 255,
+              colorB( _strokeColor ) * strokeAlpha / 255,
+              strokeAlpha );
+
+        if ( matrixResult.nonZeroCount == 0 )
+            return Progress::jump;
+
+        return Progress::rewind;
+    }
+
+    const std::uint32_t complementarySrcAlpha( 255 - srcAlpha );
+    const std::uint32_t a
+        ( srcAlpha
+          + strokeAlpha * complementarySrcAlpha / 255 );
+    const std::uint32_t multipliedAlpha
+        ( strokeAlpha * complementarySrcAlpha );
+            
+    const std::uint32_t r
+        ( blend
+          ( colorR( srcColor ), colorR( _strokeColor ),
+            multipliedAlpha ) );
+
+    const std::uint32_t g
+        ( blend
+          ( colorG( srcColor ), colorG( _strokeColor ),
+            multipliedAlpha ) );
+
+    const std::uint32_t b
+        ( blend
+          ( colorB( srcColor ), colorB( _strokeColor ),
+            multipliedAlpha ) );
+
+    destColor = toColor( r, g, b, a );
+
+    return Progress::rewind;
+}
+
+int cocos2d::detail::StrokeScan::findFirstNonTransparent( int desty ) const
+{
+    const int srcy( desty - _strokeSize );
+
+    if ( ( srcy < 0 ) || ( srcy >= _height ) )
+        return _destWidth;
+    
+    int cursor( ( srcy * _width ) * 4 + 3 );
+    
+    for ( int srcx( 0 ); srcx != _width; ++srcx, cursor += 4 )
+        if ( _src[ cursor ] != 0 )
+            return srcx + _strokeSize;
+
+    return _destWidth;
+}
+
+int cocos2d::detail::StrokeScan::findLastNonTransparent( int desty ) const
+{
+    const int srcy( desty - _strokeSize );
+
+    if ( ( srcy < 0 ) || ( srcy >= _height ) )
+        return -1;
+    
+    int cursor( ( ( srcy + 1 ) * _width - 1 ) * 4 + 3 );
+    
+    for ( int srcx( 0 ); srcx != _width; ++srcx, cursor -= 4 )
+        if ( _src[ cursor ] != 0 )
+            return _width - srcx - 1 + _strokeSize;
+
+    return -1;
+}
+
+void cocos2d::detail::StrokeScan::fillTransparent
+( std::size_t upperIndex, int lowerx, int upperx ) const
+{
+    assert( upperIndex <= std::size_t( _destWidth * _destHeight * 4 ) );
+    
+    if ( upperx == lowerx )
+        return;
+
+    unsigned char* const end( _dest + upperIndex );
+    std::fill( end - ( upperx - lowerx - 1 ) * 4, end, 0 );
+}
+
+void cocos2d::detail::StrokeScan::applyInRange
+( std::size_t upperIndex, int lowerx, int upperx, int desty ) const
+{
+    std::size_t i( upperIndex );
+    
+    for ( int x( upperx - 1 ); x > lowerx; --x )
+    {
+        i -= 4;
+        std::uint32_t& destColor
+            ( *reinterpret_cast< std::uint32_t* >( &_dest[ i ] ) );
+        apply( x, desty, destColor );
+    }
+}
+
+cocos2d::detail::LineBounds::LineBounds
+( std::size_t matrixWidth, int destWidth )
+    : starts( matrixWidth, destWidth ),
+      ends( matrixWidth, 0 )
+{
+    
+}
+
+void cocos2d::detail::LineBounds::queueStart( int x )
+{
+    starts.back() = x;
+}
+
+void cocos2d::detail::LineBounds::queueEnd( int x )
+{
+    ends.back() = x;
+}
+
+int cocos2d::detail::LineBounds::getStart()
+{
+    return  *std::min_element( starts.begin(), starts.end() );
+}
+    
+int cocos2d::detail::LineBounds::getEnd()
+{
+    return *std::max_element( ends.begin(), ends.end() );
+}
+
+void cocos2d::detail::LineBounds::roll()
+{
+    const std::size_t count( starts.size() );
+            
+    for ( std::size_t i( 1 ); i != count; ++i )
+    {
+        starts[ i - 1 ] = starts[ i ];
+        ends[ i - 1 ] = ends[ i ];
+    }
+}
+
+cocos2d::detail::MatrixResult::MatrixResult()
+    : nonZeroCount( 0 ),
+      weightedAlpha( 0 )
+{
+
+}
+
+static std::uint32_t cocos2d::detail::blend
+( std::uint32_t c0, std::uint32_t c1, std::uint32_t a1 )
+{
+    const std::uint32_t result( c0 + c1 * a1 / fullAlphaSquared );
+    assert( result <= 255 );
+    return result;
+}
+
+static std::uint32_t cocos2d::detail::colorA( std::uint32_t c )
+{
+    return ( c & 0xff000000 ) >> 24;
+}
+
+static std::uint32_t cocos2d::detail::colorB( std::uint32_t c )
+{
+    return ( c & 0xff0000 ) >> 16;
+}
+
+static std::uint32_t cocos2d::detail::colorG( std::uint32_t c )
+{
+    return ( c & 0xff00 ) >> 8;
+}
+
+static std::uint32_t cocos2d::detail::colorR( std::uint32_t c )
+{
+    return c & 0xff;
+}
+
+static std::uint32_t cocos2d::detail::toColor
+( std::uint32_t r, std::uint32_t g, std::uint32_t b, std::uint32_t a )
+{
+    assert( r <= 255 );
+    assert( g <= 255 );
+    assert( b <= 255 );
+    assert( a <= 255 );
+    
+    return ( a << 24 ) | ( b << 16 ) | ( g << 8 ) | r;
+}
+
+static std::uint32_t cocos2d::detail::getColorAt
+( unsigned char* src, int width, int height, int x, int y )
+{
+    if ( ( x < 0 ) || ( x >= width ) || ( y < 0 ) || ( y >= height ) )
+        return 0;
+    else
+        return
+            *reinterpret_cast< std::uint32_t* >
+            ( &src[ ( y * width + x ) * 4 ] );
+}
+
+static cocos2d::detail::MatrixResult cocos2d::detail::applyMatrix
+( const std::uint8_t* matrix, std::size_t matrixWidth,
+  unsigned char* src, int srcx, int srcy, int width, int height )
+{
+    const int matrixHalfWidth( matrixWidth / 2 );
+    MatrixResult result;
+
+    std::size_t i( 0 );
+    
+    for ( std::size_t y( 0 ); y != matrixWidth; ++y )
+        for ( std::size_t x( 0 ); x != matrixWidth; ++x )
+        {
+            const std::uint8_t coeff( matrix[ i ] );
+            ++i;
+
+            const int refx( srcx - matrixHalfWidth + x );
+            const int refy( srcy - matrixHalfWidth + y );
+
+            if ( ( refx >= 0 ) && ( refx < width )
+                 && ( refy >= 0 ) && ( refy < height ) )
+            {
+                const unsigned int value
+                    ( static_cast< unsigned int >
+                      ( src[ ( refy * width + refx ) * 4 + 3 ] ) );
+
+                if ( coeff != 0 )
+                    result.weightedAlpha += value;
+                
+                result.nonZeroCount += ( value != 0 );
+            }
+        }
+
+    return result;
+}

--- a/cocos/platform/CCStrokeScan.h
+++ b/cocos/platform/CCStrokeScan.h
@@ -1,0 +1,65 @@
+#ifndef COCOS2D_STROKE_SCAN_H
+#define COCOS2D_STROKE_SCAN_H
+
+#include <cstdint>
+#include <cstdlib>
+
+namespace cocos2d
+{
+    struct FontStroke;
+        
+    namespace detail
+    {
+        class LineBounds;
+        
+        class StrokeScan
+        {
+        public:
+            StrokeScan
+            ( std::uint8_t* matrix, std::size_t matrixWidth,
+              unsigned char*& src, int& width, int& height,
+              const FontStroke& stroke, int strokeSize );
+
+            void run();
+
+        private:
+            enum class Progress;
+
+        private:
+            void scan();
+            void queueBounds( LineBounds& bounds, int bottomLine ) const;
+            
+            std::size_t boundedScan
+            ( std::size_t destIndex, int startx, int endx, int desty ) const;
+            
+            int scanDestinationLine
+            ( int destIndex, int startx, int endx, int desty ) const;
+
+            Progress apply
+            ( int destx, int desty, std::uint32_t& destColor ) const;
+
+            int findFirstNonTransparent( int desty ) const;
+            int findLastNonTransparent( int desty ) const;
+            void fillTransparent
+            ( std::size_t upperIndex, int lowerx, int upperx ) const;
+            void applyInRange
+            ( std::size_t upperIndex, int lowerx, int upperx, int desty ) const;
+
+        private:
+            std::uint8_t* const _matrix;
+            const std::size_t _matrixWidth;
+            unsigned char*& _src;
+            int& _width;
+            int& _height;
+            const FontStroke& _stroke;
+
+            const int _strokeSize;
+            const int _destWidth;
+            const int _destHeight;
+            unsigned char* _dest;
+            const std::uint32_t _strokeColor;
+        };
+    }
+}
+
+#endif

--- a/cocos/platform/CMakeLists.txt
+++ b/cocos/platform/CMakeLists.txt
@@ -111,6 +111,8 @@ include_directories(
 set(COCOS_PLATFORM_SRC
 
   platform/CCSAXParser.cpp
+  platform/CCStroke.cpp
+  platform/CCStrokeScan.cpp
   platform/CCThread.cpp
   platform/CCGLView.cpp
   platform/CCFileUtils.cpp

--- a/cocos/platform/android/CCDevice-android.cpp
+++ b/cocos/platform/android/CCDevice-android.cpp
@@ -1,6 +1,7 @@
 /****************************************************************************
 Copyright (c) 2010-2012 cocos2d-x.org
 Copyright (c) 2013-2016 Chukong Technologies Inc.
+Copyright (c) 2015 	IsCool Entertainment
 
 http://www.cocos2d-x.org
 
@@ -33,6 +34,7 @@ THE SOFTWARE.
 #include "base/ccTypes.h"
 #include "platform/android/jni/JniHelper.h"
 #include "platform/CCFileUtils.h"
+#include "platform/CCStroke.h"
 
 static const std::string helperClassName = "org/cocos2dx/lib/Cocos2dxHelper";
 
@@ -157,13 +159,17 @@ Data Device::getTextureDataForText(const char * text, const FontDefinition& text
     {
         BitmapDC &dc = sharedBitmapDC();
 
+        FontDefinition systemFontDefinition( textDefinition );
+        systemFontDefinition._stroke._strokeEnabled = false;
+    
         if(! dc.getBitmapFromJavaShadowStroke(text, 
             (int)textDefinition._dimensions.width, 
             (int)textDefinition._dimensions.height, 
-            align, textDefinition )) { break;};
+            align, systemFontDefinition )) { break;};
 
         width = dc._width;
         height = dc._height;
+        drawStroke( dc._data, width, height, textDefinition._stroke );
         ret.fastSet(dc._data,width * height * 4);
         hasPremultipliedAlpha = true;
     } while (0);

--- a/cocos/platform/ios/CCDevice-ios.mm
+++ b/cocos/platform/ios/CCDevice-ios.mm
@@ -1,6 +1,7 @@
 /****************************************************************************
  Copyright (c) 2010-2012 cocos2d-x.org
  Copyright (c) 2013-2016 Chukong Technologies Inc.
+ Copyright (c) 2015 	 IsCool Entertainment
 
  http://www.cocos2d-x.org
 
@@ -33,6 +34,7 @@
 #include "base/CCEventDispatcher.h"
 #include "base/CCEventAcceleration.h"
 #include "base/CCDirector.h"
+#include "platform/CCStroke.h"
 #import <UIKit/UIKit.h>
 
 // Accelerometer
@@ -555,17 +557,8 @@ Data Device::getTextureDataForText(const char * text, const FontDefinition& text
         tImageInfo info = {0};
         info.width                  = textDefinition._dimensions.width;
         info.height                 = textDefinition._dimensions.height;
-        info.hasShadow              = textDefinition._shadow._shadowEnabled;
-        info.shadowOffset.width     = textDefinition._shadow._shadowOffset.width;
-        info.shadowOffset.height    = textDefinition._shadow._shadowOffset.height;
-        info.shadowBlur             = textDefinition._shadow._shadowBlur;
-        info.shadowOpacity          = textDefinition._shadow._shadowOpacity;
-        info.hasStroke              = textDefinition._stroke._strokeEnabled;
-        info.strokeColorR           = textDefinition._stroke._strokeColor.r / 255.0f;
-        info.strokeColorG           = textDefinition._stroke._strokeColor.g / 255.0f;
-        info.strokeColorB           = textDefinition._stroke._strokeColor.b / 255.0f;
-        info.strokeColorA           = textDefinition._stroke._strokeAlpha / 255.0f;
-        info.strokeSize             = textDefinition._stroke._strokeSize;
+        info.hasShadow              = false;
+        info.hasStroke              = false;
         info.tintColorR             = textDefinition._fontFillColor.r / 255.0f;
         info.tintColorG             = textDefinition._fontFillColor.g / 255.0f;
         info.tintColorB             = textDefinition._fontFillColor.b / 255.0f;
@@ -575,10 +568,13 @@ Data Device::getTextureDataForText(const char * text, const FontDefinition& text
         {
             break;
         }
+
         height = info.height;
         width = info.width;
+        drawStroke( info.data, width, height, textDefinition._stroke );
+
         ret.fastSet(info.data,width * height * 4);
-        hasPremultipliedAlpha = true;
+        hasPremultipliedAlpha = info.isPremultipliedAlpha;
     } while (0);
 
     return ret;

--- a/cocos/platform/mac/CCDevice-mac.mm
+++ b/cocos/platform/mac/CCDevice-mac.mm
@@ -1,6 +1,7 @@
 /****************************************************************************
 Copyright (c) 2010-2012 cocos2d-x.org
 Copyright (c) 2013-2016 Chukong Technologies Inc.
+Copyright (c) 2015 	IsCool Entertainment
 
 http://www.cocos2d-x.org
 
@@ -31,6 +32,7 @@ THE SOFTWARE.
 #include <Cocoa/Cocoa.h>
 #include <string>
 #include "base/ccTypes.h"
+#include "platform/CCStroke.h"
 #include "platform/apple/CCDevice-apple.h"
 
 NS_CC_BEGIN
@@ -352,6 +354,7 @@ Data Device::getTextureDataForText(const char * text, const FontDefinition& text
         }
         height = (short)info.height;
         width = (short)info.width;
+        drawStroke( info.data, width, height, textDefinition._stroke );
         ret.fastSet(info.data,width * height * 4);
         hasPremultipliedAlpha = true;
     } while (0);

--- a/cocos/renderer/CCTexture2D.cpp
+++ b/cocos/renderer/CCTexture2D.cpp
@@ -2,6 +2,7 @@
 Copyright (c) 2008      Apple Inc. All Rights Reserved.
 Copyright (c) 2010-2012 cocos2d-x.org
 Copyright (c) 2013-2016 Chukong Technologies Inc.
+Copyright (c) 2015 	IsCool Entertainment
 
 http://www.cocos2d-x.org
 
@@ -1128,7 +1129,7 @@ bool Texture2D::initWithString(const char *text, const FontDefinition& textDefin
         return false;
     }
     
-#if (CC_TARGET_PLATFORM != CC_PLATFORM_ANDROID) && (CC_TARGET_PLATFORM != CC_PLATFORM_IOS)
+#if (CC_TARGET_PLATFORM != CC_PLATFORM_ANDROID) && (CC_TARGET_PLATFORM != CC_PLATFORM_IOS) && (CC_TARGET_PLATFORM != CC_PLATFORM_LINUX) && (CC_TARGET_PLATFORM != CC_PLATFORM_MAC)
     CCASSERT(textDefinition._stroke._strokeEnabled == false, "Currently stroke only supported on iOS and Android!");
 #endif
 

--- a/cocos/renderer/CCTextureCache.cpp
+++ b/cocos/renderer/CCTextureCache.cpp
@@ -3,6 +3,7 @@ Copyright (c) 2008-2010 Ricardo Quesada
 Copyright (c) 2010-2012 cocos2d-x.org
 Copyright (c) 2011      Zynga Inc.
 Copyright (c) 2013-2016 Chukong Technologies Inc.
+Copyright (c) 2015 	IsCool Entertainment
 
 http://www.cocos2d-x.org
 
@@ -373,12 +374,7 @@ Texture2D * TextureCache::addImage(const std::string &path)
 
             if (texture && texture->initWithImage(image))
             {
-#if CC_ENABLE_CACHE_TEXTURE_DATA
-                // cache the texture file name
-                VolatileTextureMgr::addImageTexture(texture, fullpath);
-#endif
-                // texture already retained, no need to re-retain it
-                _textures.emplace(fullpath, texture);
+                addTexture(texture, fullpath);
 
                 //-- ANDROID ETC1 ALPHA SUPPORTS.
                 std::string alphaFullPath = path + s_etc1AlphaFileSuffix;
@@ -394,7 +390,7 @@ Texture2D * TextureCache::addImage(const std::string &path)
                         CC_SAFE_RELEASE(pAlphaTexture);
                     }
                 }
-
+                
                 //parse 9-patch info
                 this->parseNinePatchImage(image, texture, path);
             }
@@ -412,7 +408,21 @@ Texture2D * TextureCache::addImage(const std::string &path)
     return texture;
 }
 
-void TextureCache::parseNinePatchImage(cocos2d::Image *image, cocos2d::Texture2D *texture, const std::string& path)
+void TextureCache::addTexture(Texture2D* texture, const std::string& key)
+{
+    CCASSERT(getTextureForKey( key ) == nullptr,
+             "TextureCache: key must not exist" );
+    CCASSERT(texture != nullptr, "TextureCache: texture MUST not be nil");
+
+#if CC_ENABLE_CACHE_TEXTURE_DATA
+    // cache the texture file name
+    VolatileTextureMgr::addImageTexture(texture, key);
+#endif
+    // texture already retained, no need to re-retain it
+    _textures.emplace(key, texture);
+}
+
+void TextureCache::parseNinePatchImage(cocos2d::Image *image, cocos2d::Texture2D *texture,const std::string& path)
 {
     if (NinePatchImageParser::isNinePatchImage(path))
     {

--- a/cocos/renderer/CCTextureCache.h
+++ b/cocos/renderer/CCTextureCache.h
@@ -3,6 +3,7 @@ Copyright (c) 2008-2010 Ricardo Quesada
 Copyright (c) 2010-2012 cocos2d-x.org
 Copyright (c) 2011      Zynga Inc.
 Copyright (c) 2013-2016 Chukong Technologies Inc.
+Copyright (c) 2015 	IsCool Entertainment
 
 http://www.cocos2d-x.org
 
@@ -145,6 +146,11 @@ public:
     Texture2D* addImage(Image *image, const std::string &key);
     CC_DEPRECATED_ATTRIBUTE Texture2D* addUIImage(Image *image, const std::string& key) { return addImage(image,key); }
 
+    /** Adds a Texture2D and associates it with the given key.
+    * @param key The "key" parameter will be used as the "key" for the cache.
+    */
+    void addTexture(Texture2D* texture, const std::string& key);
+    
     /** Returns an already created texture. Returns nil if the texture doesn't exist.
     @param key It's the related/absolute path of the file image.
     @since v0.99.5

--- a/cocos/renderer/ccShader_Label_shadow.frag
+++ b/cocos/renderer/ccShader_Label_shadow.frag
@@ -1,0 +1,38 @@
+/*
+ * cocos2d for iPhone: http://www.cocos2d-iphone.org
+ *
+ * Copyright (c) 2015 IsCool Entertainment
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+const char* ccLabelShadow_frag = STRINGIFY(
+\n#ifdef GL_ES\n
+precision lowp float;
+\n#endif\n
+
+varying vec4 v_fragmentColor;
+varying vec2 v_texCoord;
+
+void main()
+{
+    float a = texture2D(CC_Texture0, v_texCoord).a;
+    gl_FragColor = vec4( v_fragmentColor.rgba * vec4( a, a, a, a ) );
+}
+);

--- a/cocos/renderer/ccShaders.cpp
+++ b/cocos/renderer/ccShaders.cpp
@@ -2,6 +2,7 @@
 Copyright (c) 2011      Zynga Inc.
 Copyright (c) 2012 		cocos2d-x.org
 Copyright (c) 2013-2016 Chukong Technologies Inc.
+Copyright (c) 2015 	IsCool Entertainment
 
 http://www.cocos2d-x.org
 
@@ -75,6 +76,7 @@ NS_CC_BEGIN
 #include "renderer/ccShader_Label_df_glow.frag"
 #include "renderer/ccShader_Label_normal.frag"
 #include "renderer/ccShader_Label_outline.frag"
+#include "renderer/ccShader_Label_shadow.frag"
 
 //
 #include "renderer/ccShader_3D_PositionTex.vert"

--- a/cocos/renderer/ccShaders.h
+++ b/cocos/renderer/ccShaders.h
@@ -2,6 +2,7 @@
 Copyright (c) 2011      Zynga Inc.
 Copyright (c) 2012 		cocos2d-x.org
 Copyright (c) 2013-2016 Chukong Technologies Inc.
+Copyright (c) 2015 	IsCool Entertainment
 
 http://www.cocos2d-x.org
 
@@ -74,6 +75,7 @@ extern CC_DLL const GLchar * ccLabelNormal_frag;
 extern CC_DLL const GLchar * ccLabelOutline_frag;
 
 extern CC_DLL const GLchar * ccLabel_vert;
+extern CC_DLL const GLchar * ccLabelShadow_frag;
 
 extern CC_DLL const GLchar * cc3D_PositionTex_vert;
 extern CC_DLL const GLchar * cc3D_SkinPositionTex_vert;

--- a/tests/cpp-tests/Classes/LabelTest/LabelTestNew.cpp
+++ b/tests/cpp-tests/Classes/LabelTest/LabelTestNew.cpp
@@ -70,6 +70,7 @@ NewLabelTests::NewLabelTests()
     ADD_TEST_CASE(LabelCharMapColorTest);
 
     ADD_TEST_CASE(LabelSystemFontColor);
+    ADD_TEST_CASE(LabelSystemFontShadowAndOutline);
     ADD_TEST_CASE(LabelTTFOldNew);
     ADD_TEST_CASE(LabelFontNameTest);
 
@@ -1823,6 +1824,73 @@ std::string LabelSystemFontColor::title() const
 std::string LabelSystemFontColor::subtitle() const
 {
     return "Testing text color of system font";
+}
+
+LabelSystemFontShadowAndOutline::LabelSystemFontShadowAndOutline()
+{
+    auto size = Director::getInstance()->getWinSize();
+
+    {
+      auto label =
+        Label::createWithSystemFont("Outline", "fonts/arial.ttf", 20);
+      label->setPosition(Vec2(size.width / 2, size.height * 0.3f));
+      label->setTextColor(Color4B::RED);
+      label->enableOutline(Color4B::BLUE, 1);
+      addChild(label);
+    }
+
+    {
+      auto label =
+        Label::createWithSystemFont("Blue Shadow", "fonts/arial.ttf", 20);
+      label->setPosition(Vec2(size.width / 2, size.height * 0.4f));
+      label->setTextColor(Color4B::GREEN);
+      label->enableShadow(Color4B::BLUE, Size(5, -3));
+      addChild(label);
+    }
+
+    {
+      auto label =
+        Label::createWithSystemFont
+        ("Outline and Shadow", "fonts/arial.ttf", 20);
+      label->setPosition(Vec2(size.width / 2, size.height * 0.5f));
+      label->setTextColor(Color4B::BLUE);
+      label->enableOutline(Color4B::YELLOW, 5);
+      label->enableShadow(Color4B::GREEN, Size(-3, 10));
+      addChild(label);
+    }
+
+    {
+      auto label =
+        Label::createWithSystemFont
+        ("Transparent stroke and shadow", "fonts/arial.ttf", 20);
+      label->setPosition(Vec2(size.width / 2, size.height * 0.6f));
+      label->setTextColor(Color4B::YELLOW);
+      label->enableOutline(Color4B( 255, 128, 0, 128 ), 3);
+      label->enableShadow(Color4B( 120, 60, 10, 80 ), Size(3, -5));
+      addChild(label);
+    }
+
+    {
+      auto label =
+        Label::createWithSystemFont
+        ("With emojis too \xF0\x9F\x98\x83, yep \xF0\x9F\x99\x8C",
+         "fonts/arial.ttf", 20);
+      label->setPosition(Vec2(size.width / 2, size.height * 0.7f));
+      label->setTextColor(Color4B::YELLOW);
+      label->enableOutline(Color4B( 0, 128, 255, 255 ), 1);
+      label->enableShadow(Color4B( 10, 90, 180, 255 ), Size(3, -5));
+      addChild(label);
+    }
+}
+
+std::string LabelSystemFontShadowAndOutline::title() const
+{
+    return "New Label + system font + outline and shadow";
+}
+
+std::string LabelSystemFontShadowAndOutline::subtitle() const
+{
+    return "Testing text outline and shadow of system font";
 }
 
 LabelIssue10773Test::LabelIssue10773Test()

--- a/tests/cpp-tests/Classes/LabelTest/LabelTestNew.h
+++ b/tests/cpp-tests/Classes/LabelTest/LabelTestNew.h
@@ -520,6 +520,17 @@ public:
     virtual std::string subtitle() const override;
 };
 
+class LabelSystemFontShadowAndOutline : public AtlasDemoNew
+{
+public:
+    CREATE_FUNC(LabelSystemFontShadowAndOutline);
+
+    LabelSystemFontShadowAndOutline();
+
+    virtual std::string title() const override;
+    virtual std::string subtitle() const override;
+};
+
 class LabelIssue10773Test : public AtlasDemoNew
 {
 public:


### PR DESCRIPTION
_Note: this branch has been previously submitted for the pull request #14046. Due to a renaming of the original branch for clarity, the previous request has been closed. This commit includes the merge fixes requested in the previous pull request. Sorry for the inconvenience_

Please review and merge this commit which provides the following features.

The stroke and the shadow of a cocos2d::Label rendered using the system fonts
are now handled on cocos' side.

For Linux and Mac targets this commit enables the stroke and shadow features.

For Linux targets this commits fixes the color used to render system fonts.

For Mac targets this commit also fixes the font creation. Previously only the
font family was searched. Now we try to get the font with the provided name.

For iOS and Android targets this commit enables the stroke and the shadow on
the emojis.

Textures created with system fonts are now cached and reused if a new label
is requested with the same text and same font definition.
