### PR TITLE
Add ability to get the font family

### DIFF
--- a/cocos/2d/CCFontFreeType.cpp
+++ b/cocos/2d/CCFontFreeType.cpp
@@ -647,7 +647,7 @@ void FontFreeType::releaseFont(const std::string &fontName)
     auto item = s_cacheFontData.begin();
     while (s_cacheFontData.end() != item)
     {
-        if (item->first.find(fontName) >= 0)
+        if (item->first.find(fontName) != std::string::npos)
             item = s_cacheFontData.erase(item);
         else
             item++;

--- a/cocos/2d/CCFontFreeType.cpp
+++ b/cocos/2d/CCFontFreeType.cpp
@@ -274,6 +274,14 @@ int FontFreeType::getFontAscender() const
     return (static_cast<int>(_fontRef->size->metrics.ascender >> 6));
 }
 
+const char* FontFreeType::getFontFamily() const
+{
+    if (!_fontRef)
+        return nullptr;
+
+    return _fontRef->family_name;
+}
+
 unsigned char* FontFreeType::getGlyphBitmap(unsigned short theChar, long &outWidth, long &outHeight, Rect &outRect,int &xAdvance)
 {
     bool invalidChar = true;

--- a/cocos/2d/CCFontFreeType.h
+++ b/cocos/2d/CCFontFreeType.h
@@ -71,6 +71,7 @@ public:
     unsigned char* getGlyphBitmap(unsigned short theChar, long &outWidth, long &outHeight, Rect &outRect,int &xAdvance);
     
     int getFontAscender() const;
+    const char* getFontFamily() const;
 
     virtual FontAtlas* createFontAtlas() override;
     virtual int getFontMaxHeight() const override { return _lineHeight; }


### PR DESCRIPTION
The ability to know the font family is helpful for implementing custom rendering.

Additional fix for compiler warning where the return value from calling `first->find(fontName)` is unsigned and thus always >= 0. The proper comparison is whether `find()` returns `std::string::npos`.
