### PR TITLE
v3 added missing getFileSize() method for winrt

### DIFF
--- a/cocos/platform/winrt/CCFileUtilsWinRT.cpp
+++ b/cocos/platform/winrt/CCFileUtilsWinRT.cpp
@@ -129,6 +129,19 @@ std::string CCFileUtilsWinRT::getSuitableFOpen(const std::string& filenameUtf8) 
     return UTF8StringToMultiByte(filenameUtf8);
 }
 
+long CCFileUtilsWinRT::getFileSize(const std::string &filepath)
+{
+    WIN32_FILE_ATTRIBUTE_DATA fad;
+    if (!GetFileAttributesEx(StringUtf8ToWideChar(filepath).c_str(), GetFileExInfoStandard, &fad))
+    {
+        return 0; // error condition, could call GetLastError to find out more
+    }
+    LARGE_INTEGER size;
+    size.HighPart = fad.nFileSizeHigh;
+    size.LowPart = fad.nFileSizeLow;
+    return (long)size.QuadPart;
+}
+
 bool CCFileUtilsWinRT::isFileExistInternal(const std::string& strFilePath) const
 {
     bool ret = false;

--- a/cocos/platform/winrt/CCFileUtilsWinRT.h
+++ b/cocos/platform/winrt/CCFileUtilsWinRT.h
@@ -53,6 +53,7 @@ public:
     virtual std::string getFullPathForDirectoryAndFilename(const std::string& strDirectory, const std::string& strFilename) const override;
 	virtual std::string getStringFromFile(const std::string& filename) override;
     virtual std::string getSuitableFOpen(const std::string& filenameUtf8) const override;
+    virtual long getFileSize(const std::string &filepath);
 	static std::string getAppPath();
 
 private:


### PR DESCRIPTION
This pull request adds the missing getFileSize() method to winrt file implementation. This fixes issue #14737.
