### PR TITLE
Fix warning and a bug in FontAtlasCache::unloadFontAtlasTTF()

### DIFF
--- a/cocos/2d/CCFontAtlasCache.cpp
+++ b/cocos/2d/CCFontAtlasCache.cpp
@@ -266,7 +266,7 @@ void FontAtlasCache::unloadFontAtlasTTF(const std::string& fontFileName)
     auto item = _atlasMap.begin();
     while (item != _atlasMap.end())
     {
-        if (item->first.find(fontFileName) >= 0)
+        if (item->first.find(fontFileName) != std::string::npos)
         {
             CC_SAFE_RELEASE_NULL(item->second);
             item = _atlasMap.erase(item);


### PR DESCRIPTION
I get the following warning when compiling on Xcode 7:

```
CCFontAtlasCache.cpp:269:44: Comparison of unsigned expression >= 0 is always true
```

The warning is caused by the line `CCFontAtlasCache.cpp:269`, and there is a bug.

``` cpp
if (item->first.find(fontFileName) >= 0) // Here is a bug
```

So I think the following code is better:

``` cpp
if (item->first.find(fontFileName) != std::string::npos)
```

This patch fixes it.
