### PR TITLE
Add ability to stop auto scrolling in ui::ScrollView and extension::ScrollView

### DIFF
--- a/cocos/ui/UIScrollView.cpp
+++ b/cocos/ui/UIScrollView.cpp
@@ -472,7 +472,7 @@ void ScrollView::stopAutoScroll()
 {
     _autoScrolling = false;
     _autoScrollAttenuate = true;
-    _autoScrollDuration = 0;
+    _autoScrollTotalTime = 0;
     _autoScrollAccumulatedTime = 0;
 }
 

--- a/cocos/ui/UIScrollView.cpp
+++ b/cocos/ui/UIScrollView.cpp
@@ -468,6 +468,14 @@ void ScrollView::startAutoScroll(const Vec2& deltaMove, float timeInSec, bool at
     }
 }
 
+void ScrollView::stopAutoScroll()
+{
+    _autoScrolling = false;
+    _autoScrollAttenuate = true;
+    _autoScrollDuration = 0;
+    _autoScrollAccumulatedTime = 0;
+}
+
 bool ScrollView::isNecessaryAutoScrollBrake()
 {
     if(_autoScrollBraking)

--- a/cocos/ui/UIScrollView.h
+++ b/cocos/ui/UIScrollView.h
@@ -157,63 +157,63 @@ public:
     /**
      * Immediately stops inner container scroll initiated by any of the "scrollTo*" member functions
      */
-    void stopAutoScroll();
+    virtual void stopAutoScroll();
 
     /**
      * Scroll inner container to bottom boundary of scrollview.
      * @param timeInSec Time in seconds.
      * @param attenuated Whether scroll speed attenuate or not.
      */
-    void scrollToBottom(float timeInSec, bool attenuated);
+    virtual void scrollToBottom(float timeInSec, bool attenuated);
 
     /**
      * Scroll inner container to top boundary of scrollview.
      * @param timeInSec Time in seconds.
      * @param attenuated Whether scroll speed attenuate or not.
      */
-    void scrollToTop(float timeInSec, bool attenuated);
+    virtual void scrollToTop(float timeInSec, bool attenuated);
 
     /**
      * Scroll inner container to left boundary of scrollview.
      * @param timeInSec Time in seconds.
      * @param attenuated Whether scroll speed attenuate or not.
      */
-    void scrollToLeft(float timeInSec, bool attenuated);
+    virtual void scrollToLeft(float timeInSec, bool attenuated);
 
     /**
      * Scroll inner container to right boundary of scrollview.
      * @param timeInSec Time in seconds.
      * @param attenuated Whether scroll speed attenuate or not.
      */
-    void scrollToRight(float timeInSec, bool attenuated);
+    virtual void scrollToRight(float timeInSec, bool attenuated);
 
     /**
      * Scroll inner container to top and left boundary of scrollview.
      * @param timeInSec Time in seconds.
      * @param attenuated Whether scroll speed attenuate or not.
      */
-    void scrollToTopLeft(float timeInSec, bool attenuated);
+    virtual void scrollToTopLeft(float timeInSec, bool attenuated);
 
     /**
      * Scroll inner container to top and right boundary of scrollview.
      * @param timeInSec Time in seconds.
      * @param attenuated Whether scroll speed attenuate or not.
      */
-    void scrollToTopRight(float timeInSec, bool attenuated);
+    virtual void scrollToTopRight(float timeInSec, bool attenuated);
 
     /**
      * Scroll inner container to bottom and left boundary of scrollview.
      * @param timeInSec Time in seconds.
      * @param attenuated Whether scroll speed attenuate or not.
      */
-    void scrollToBottomLeft(float timeInSec, bool attenuated);
+    virtual void scrollToBottomLeft(float timeInSec, bool attenuated);
 
     /**
      * Scroll inner container to bottom and right boundary of scrollview.
      * @param timeInSec Time in seconds
      * @param attenuated Whether scroll speed attenuate or not.
      */
-    void scrollToBottomRight(float timeInSec, bool attenuated);
+    virtual void scrollToBottomRight(float timeInSec, bool attenuated);
 
     /**
      * Scroll inner container to vertical percent position of scrollview.
@@ -221,7 +221,7 @@ public:
      * @param timeInSec Time in seconds.
      * @param attenuated Whether scroll speed attenuate or not.
      */
-    void scrollToPercentVertical(float percent, float timeInSec, bool attenuated);
+    virtual void scrollToPercentVertical(float percent, float timeInSec, bool attenuated);
 
     /**
      * Scroll inner container to horizontal percent position of scrollview.
@@ -229,7 +229,7 @@ public:
      * @param timeInSec Time in seconds.
      * @param attenuated Whether scroll speed attenuate or not.
      */
-    void scrollToPercentHorizontal(float percent, float timeInSec, bool attenuated);
+    virtual void scrollToPercentHorizontal(float percent, float timeInSec, bool attenuated);
 
     /**
      * Scroll inner container to both direction percent position of scrollview.
@@ -237,7 +237,7 @@ public:
      * @param timeInSec Time in seconds.
      * @param attenuated Whether scroll speed attenuate or not.
      */
-    void scrollToPercentBothDirection(const Vec2& percent, float timeInSec, bool attenuated);
+    virtual void scrollToPercentBothDirection(const Vec2& percent, float timeInSec, bool attenuated);
 
     /**
      * Move inner container to bottom boundary of scrollview.

--- a/cocos/ui/UIScrollView.h
+++ b/cocos/ui/UIScrollView.h
@@ -155,6 +155,11 @@ public:
     Layout* getInnerContainer()const;
 
     /**
+     * Immediately stops inner container scroll initiated by any of the "scrollTo*" member functions
+     */
+    void stopAutoScroll();
+
+    /**
      * Scroll inner container to bottom boundary of scrollview.
      * @param timeInSec Time in seconds.
      * @param attenuated Whether scroll speed attenuate or not.

--- a/extensions/GUI/CCScrollView/CCScrollView.cpp
+++ b/extensions/GUI/CCScrollView/CCScrollView.cpp
@@ -64,6 +64,7 @@ ScrollView::ScrollView()
 , _maxScale(0.0f)
 , _scissorRestored(false)
 , _touchListener(nullptr)
+, _animatedScrollAction(nullptr)
 {
 
 }
@@ -234,10 +235,19 @@ void ScrollView::setContentOffsetInDuration(Vec2 offset, float dt)
 {
     FiniteTimeAction *scroll, *expire;
     
+    if (_animatedScrollAction) {
+        stopAnimatedContentOffset();
+    }
     scroll = MoveTo::create(dt, offset);
     expire = CallFuncN::create(CC_CALLBACK_1(ScrollView::stoppedAnimatedScroll,this));
-    _container->runAction(Sequence::create(scroll, expire, nullptr));
+    _animatedScrollAction = _container->runAction(Sequence::create(scroll, expire, nullptr));
     this->schedule(CC_SCHEDULE_SELECTOR(ScrollView::performedAnimatedScroll));
+}
+
+void ScrollView::stopAnimatedContentOffset() {
+    stopAction(_animatedScrollAction);
+    _animatedScrollAction = nullptr;
+    stoppedAnimatedScroll(this);
 }
 
 Vec2 ScrollView::getContentOffset()

--- a/extensions/GUI/CCScrollView/CCScrollView.h
+++ b/extensions/GUI/CCScrollView/CCScrollView.h
@@ -128,6 +128,10 @@ public:
      * @param dt        The animation duration.
      */
     void setContentOffsetInDuration(Vec2 offset, float dt); 
+    /**
+     * Halts the movement animation of the inner content started with setContentOffset() or setContentOffsetInDuration()
+     */
+    void stopAnimatedContentOffset();
 
     void setZoomScale(float s);
     /**
@@ -378,6 +382,11 @@ protected:
     
     CustomCommand _beforeDrawCommand;
     CustomCommand _afterDrawCommand;
+
+    /**
+     * Action created with setContentOffsetInDuration(), saved so it can be halted
+     */
+    Action* _animatedScrollAction;
 };
 
 


### PR DESCRIPTION
The new methods are:

``` c++
ui::ScrollView::stopAutoScroll();
extension::ScrollView::stopAnimatedContentOffset();
```

These methods effectively do the same thing, but are named in correlation to the methods that initiated the auto scroll.

Also made all the `ui::ScrollView::scrollTo*` methods `virtual`, which mirrors the functionality already present in the `jumpTo*` methods.

@neokim @steerlink @joshbodily 
