### PR TITLE
Mark equals() functions as const

### DIFF
--- a/cocos/base/CCVector.h
+++ b/cocos/base/CCVector.h
@@ -300,7 +300,7 @@ public:
      * @param other The vector to be compared.
      * @return True if two vectors are equal, false if not.
      */
-    bool equals(const Vector<T> &other)
+    bool equals(const Vector<T> &other) const
     {
         ssize_t s = this->size();
         if (s != other.size())

--- a/cocos/base/ccTypes.h
+++ b/cocos/base/ccTypes.h
@@ -63,7 +63,7 @@ struct CC_DLL Color3B
     bool operator!=(const Color4B& right) const;
     bool operator!=(const Color4F& right) const;
 
-    bool equals(const Color3B& other)
+    bool equals(const Color3B& other) const
     {
         return (*this == other);
     }
@@ -144,7 +144,7 @@ struct CC_DLL Color4F
     bool operator!=(const Color3B& right) const;
     bool operator!=(const Color4B& right) const;
 
-    bool equals(const Color4F &other)
+    bool equals(const Color4F &other) const
     {
         return (*this == other);
     }


### PR DESCRIPTION
I think several `equals()` functions are effectively const methods, but they aren’t marked `const`.
This PR adds `const` keyword to them.
