### PR TITLE
Export WICImageLoader form DLL

### DIFF
--- a/cocos/platform/winrt/WICImageLoader-winrt.h
+++ b/cocos/platform/winrt/WICImageLoader-winrt.h
@@ -49,7 +49,7 @@ struct WICConvert
 	WICPixelFormatGUID target;
 };
 
-class WICImageLoader
+class CC_DLL WICImageLoader
 {
 public:
 


### PR DESCRIPTION
We have a remote image loader that base64 encodes WICPixelFormat buffers and sends them to our backend.  We found it useful to DLL export WICImageLoader so that we didn't have to use a different library and/or roll our own.

@stammen
