### PR TITLE
Optimize the OpenGL Log Functions in CCGLProgram.cpp

### DIFF
--- a/cocos/renderer/CCGLProgram.cpp
+++ b/cocos/renderer/CCGLProgram.cpp
@@ -571,17 +571,15 @@ void GLProgram::use()
 
 static std::string logForOpenGLShader(GLuint shader)
 {
-    std::string ret;
-    GLint logLength = 0, charsWritten = 0;
+    GLint logLength = 0;
 
     glGetShaderiv(shader, GL_INFO_LOG_LENGTH, &logLength);
     if (logLength < 1)
         return "";
 
-    char *logBytes = (char*)malloc(logLength + 1);
-    glGetShaderInfoLog(shader, logLength, &charsWritten, logBytes);
-    logBytes[logLength] = '\0';
-    ret = logBytes;
+    char *logBytes = (char*)malloc(logLength);
+    glGetShaderInfoLog(shader, logLength, nullptr, logBytes);
+    std::string ret(logBytes);
 
     free(logBytes);
     return ret;
@@ -589,17 +587,15 @@ static std::string logForOpenGLShader(GLuint shader)
 
 static std::string logForOpenGLProgram(GLuint program)
 {
-    std::string ret;
-    GLint logLength = 0, charsWritten = 0;
+    GLint logLength = 0;
 
     glGetProgramiv(program, GL_INFO_LOG_LENGTH, &logLength);
     if (logLength < 1)
         return "";
 
-    char *logBytes = (char*)malloc(logLength + 1);
-    glGetProgramInfoLog(program, logLength, &charsWritten, logBytes);
-    logBytes[logLength] = '\0';
-    ret = logBytes;
+    char *logBytes = (char*)malloc(logLength);
+    glGetProgramInfoLog(program, logLength, nullptr, logBytes);
+    std::string ret(logBytes);
 
     free(logBytes);
     return ret;

--- a/cocos/renderer/CCGLProgram.cpp
+++ b/cocos/renderer/CCGLProgram.cpp
@@ -577,7 +577,7 @@ static std::string logForOpenGLShader(GLuint shader)
     if (logLength < 1)
         return "";
 
-    char *logBytes = (char*)malloc(logLength);
+    char *logBytes = (char*)malloc(sizeof(char) * logLength);
     glGetShaderInfoLog(shader, logLength, nullptr, logBytes);
     std::string ret(logBytes);
 
@@ -593,7 +593,7 @@ static std::string logForOpenGLProgram(GLuint program)
     if (logLength < 1)
         return "";
 
-    char *logBytes = (char*)malloc(logLength);
+    char *logBytes = (char*)malloc(sizeof(char) * logLength);
     glGetProgramInfoLog(program, logLength, nullptr, logBytes);
     std::string ret(logBytes);
 


### PR DESCRIPTION
Following codes are the original OpenGL log function in CCGLProgram.cpp.

``` c++
static std::string logForOpenGLShader(GLuint shader)
{
    std::string ret;
    GLint logLength = 0, charsWritten = 0;

    glGetShaderiv(shader, GL_INFO_LOG_LENGTH, &logLength);
    if (logLength < 1)
        return "";

    char *logBytes = (char*)malloc(logLength + 1);
    glGetShaderInfoLog(shader, logLength, &charsWritten, logBytes);
    logBytes[logLength] = '\0';
    ret = logBytes;

    free(logBytes);
    return ret;
}
```
1. We should define `std::string ret` in where we really need it. According to my test on android platform the function returns at `return "";`, which makes the `ret` unnecessary.
2. `charsWritten` is not used, we should either delete it or use it. Because we don't check the bytes written, I think we can just delete it.
3.  We don't need (logLength+1) space for `logBytes`, because `logBytes`  returned by calling glGetShaderInfoLog(shader, logLength, nullptr, logBytes) takes `logLength` bytes at most, including the ending null character,  i.e. `(strlen(logBytes) + 1 ==  logLength)` always yield true. According to the offical opengles sdk docs: https://www.khronos.org/opengles/sdk/docs/man/xhtml/glGetShaderInfoLog.xml.
   and
   https://www.khronos.org/opengles/sdk/docs/man/xhtml/glGetShaderiv.xml
4. We don't need `logBytes[logLength] = '\0';`, because `logBytes` returned is already null-terminated.

so, maybe we can change the codes to:

``` c++
static std::string logForOpenGLShader(GLuint shader)
{
    GLint logLength = 0;

    glGetShaderiv(shader, GL_INFO_LOG_LENGTH, &logLength);
    if (logLength < 1)
        return "";

    char *logBytes = (char*)malloc(logLength);
    glGetShaderInfoLog(shader, logLength, nullptr, logBytes);
    std::string ret(logBytes);

    free(logBytes);
    return ret;
}

```

just like the codes in the "Gold Book", "OpenGL ES 2.0 Programming Guide" : 

``` c++
if(!compiled)
{
    GLint infoLen = 0;

    glGetShaderiv(shader, GL_INFO_LOG_LENGTH, &infoLen);

    if(infoLen > 1)
    {
        char* infoLog = malloc(sizeof(char) * infoLen);
        glGetShaderInfoLog(shader, infoLen, NULL, infoLog);
        esLogMessage("Error compiling shader:\n%s\n", infoLog);

        free(infoLog);
    }

    glDeleteShader(shader);
    return 0;
}
```

the same things happen with logForOpenGLProgram().

``` c++
static std::string logForOpenGLProgram(GLuint program)
{
    GLint logLength = 0;

    glGetProgramiv(program, GL_INFO_LOG_LENGTH, &logLength);
    if (logLength < 1)
        return "";

    char *logBytes = (char*)malloc(sizeof(char) * logLength);
    glGetProgramInfoLog(program, logLength, nullptr, logBytes);
    std::string ret(logBytes);

    free(logBytes);
    return ret;
}
```
