### PR TITLE
fix opengl log function.

### DIFF
--- a/cocos/renderer/CCGLProgram.cpp
+++ b/cocos/renderer/CCGLProgram.cpp
@@ -571,17 +571,15 @@ void GLProgram::use()
 
 static std::string logForOpenGLShader(GLuint shader)
 {
-    std::string ret;
-    GLint logLength = 0, charsWritten = 0;
+    GLint logLength = 0;
 
     glGetShaderiv(shader, GL_INFO_LOG_LENGTH, &logLength);
     if (logLength < 1)
         return "";
 
-    char *logBytes = (char*)malloc(logLength + 1);
-    glGetShaderInfoLog(shader, logLength, &charsWritten, logBytes);
-    logBytes[logLength] = '\0';
-    ret = logBytes;
+    char *logBytes = (char*)malloc(sizeof(char) * logLength);
+    glGetShaderInfoLog(shader, logLength, nullptr, logBytes);
+    std::string ret(logBytes);
 
     free(logBytes);
     return ret;
@@ -589,17 +587,15 @@ static std::string logForOpenGLShader(GLuint shader)
 
 static std::string logForOpenGLProgram(GLuint program)
 {
-    std::string ret;
-    GLint logLength = 0, charsWritten = 0;
+    GLint logLength = 0;
 
     glGetProgramiv(program, GL_INFO_LOG_LENGTH, &logLength);
     if (logLength < 1)
         return "";
 
-    char *logBytes = (char*)malloc(logLength + 1);
-    glGetProgramInfoLog(program, logLength, &charsWritten, logBytes);
-    logBytes[logLength] = '\0';
-    ret = logBytes;
+    char *logBytes = (char*)malloc(sizeof(char) * logLength);
+    glGetProgramInfoLog(program, logLength, nullptr, logBytes);
+    std::string ret(logBytes);
 
     free(logBytes);
     return ret;


### PR DESCRIPTION
This PR is for [Issue 15210](https://github.com/cocos2d/cocos2d-x/issues/15210). 

---

Issue 15210:

I've been using cocos2d-x v2.2.3 for a long time. Recently, My cocos program crashed on Windows because of the call of logForOpenGLObject() function when I have some errors in my shaders. Then I checked v3 branch, and I found that the problem have been fixed already. However, I've found that these two functions : `logForOpenGLShader()` and `logForOpenGLProgram()` have some flaws:

``` c++
static std::string logForOpenGLShader(GLuint shader)
{
    std::string ret;
    GLint logLength = 0, charsWritten = 0;

    glGetShaderiv(shader, GL_INFO_LOG_LENGTH, &logLength);
    if (logLength < 1)
        return "";

    char *logBytes = (char*)malloc(logLength + 1);
    glGetShaderInfoLog(shader, logLength, &charsWritten, logBytes);
    logBytes[logLength] = '\0';
    ret = logBytes;

    free(logBytes);
    return ret;
}
```
1. I think maybe we should define `std::string ret` in where we really need it. According to my test on android platform the function returns at `return "";`, which makes the `ret` unnecessary.
2. `charsWritten` is not used, it's better to use it or delete it. Because the codes don't check the bytes written, I think we can just delete it.
3.  (logLength+1) space for `logBytes` is too much, because `logBytes`  returned by calling `glGetShaderInfoLog(shader, logLength, nullptr, logBytes)` takes `logLength` bytes at most, including the ending null character,  i.e. `(strlen(logBytes) + 1 ==  logLength)` always yield true. According to the offical opengles sdk docs: https://www.khronos.org/opengles/sdk/docs/man/xhtml/glGetShaderInfoLog.xml.
   and
   https://www.khronos.org/opengles/sdk/docs/man/xhtml/glGetShaderiv.xml
4. `logBytes[logLength] = '\0' is unnecessary, because`logBytes` returned is already null-terminated.

`logForOpenGLProgram()` has the same flaws as `logForOpenGLShader`.

I've created a [pull request](https://github.com/cocos2d/cocos2d-x/pull/14965) for this issue, following are the codes modified:

``` c++
static std::string logForOpenGLShader(GLuint shader)
{
    GLint logLength = 0;

    glGetShaderiv(shader, GL_INFO_LOG_LENGTH, &logLength);
    if (logLength < 1)
        return "";

    char *logBytes = (char*)malloc(sizeof(char) * logLength);
    glGetShaderInfoLog(shader, logLength, nullptr, logBytes);
    std::string ret(logBytes);

    free(logBytes);
    return ret;
}

static std::string logForOpenGLProgram(GLuint program)
{
    GLint logLength = 0;

    glGetProgramiv(program, GL_INFO_LOG_LENGTH, &logLength);
    if (logLength < 1)
        return "";

    char *logBytes = (char*)malloc(sizeof(char) * logLength);
    glGetProgramInfoLog(program, logLength, nullptr, logBytes);
    std::string ret(logBytes);

    free(logBytes);
    return ret;
}
```

By doing this, we save 1 byte and one GLint: `charsWritten' and shorter codes.

Maybe you think this is a trivial fix, but it's good for the better future of cocos. Please consider merge this pull request, Every little helps.
