### PR TITLE
Remove obsolete Win32 references.

### DIFF
--- a/cocos/ui/proj.win32/libui.vcxproj
+++ b/cocos/ui/proj.win32/libui.vcxproj
@@ -40,9 +40,7 @@
     <ClInclude Include="..\UIVBox.h" />
     <ClInclude Include="..\UIWebView-inl.h" />
     <ClInclude Include="..\UIWebView.h" />
-    <ClInclude Include="..\UIWebViewImpl-win32.h" />
     <ClInclude Include="..\UIWidget.h" />
-    <ClInclude Include="Win32InputBox.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\CocosGUI.cpp" />
@@ -75,14 +73,9 @@
     <ClCompile Include="..\UITextField.cpp" />
     <ClCompile Include="..\UIVBox.cpp" />
     <ClCompile Include="..\UIWebView.cpp" />
-    <ClCompile Include="..\UIWebViewImpl-win32.cpp" />
     <ClCompile Include="..\UIWidget.cpp" />
-    <ClCompile Include="Win32InputBox.cpp" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\..\extensions\proj.win32\libextension.vcxproj">
-      <Project>{21b2c324-891f-48ea-ad1a-5ae13de12e28}</Project>
-    </ProjectReference>
     <ProjectReference Include="..\..\2d\libcocos2d.vcxproj">
       <Project>{98a51ba8-fc3a-415b-ac8f-8c7bd464e93e}</Project>
     </ProjectReference>

--- a/cocos/ui/proj.win32/libui.vcxproj.filters
+++ b/cocos/ui/proj.win32/libui.vcxproj.filters
@@ -105,16 +105,10 @@
     <ClInclude Include="..\UIEditBox\UIEditBoxImplWin.h">
       <Filter>UIWidgets\UIEditBox</Filter>
     </ClInclude>
-    <ClInclude Include="Win32InputBox.h">
-      <Filter>UIWidgets\UIEditBox</Filter>
-    </ClInclude>
     <ClInclude Include="..\UIWebView-inl.h">
       <Filter>UIWidgets</Filter>
     </ClInclude>
     <ClInclude Include="..\UIWebView.h">
-      <Filter>UIWidgets</Filter>
-    </ClInclude>
-    <ClInclude Include="..\UIWebViewImpl-win32.h">
       <Filter>UIWidgets</Filter>
     </ClInclude>
   </ItemGroup>
@@ -209,13 +203,7 @@
     <ClCompile Include="..\UIEditBox\UIEditBoxImplWin.cpp">
       <Filter>UIWidgets\UIEditBox</Filter>
     </ClCompile>
-    <ClCompile Include="Win32InputBox.cpp">
-      <Filter>UIWidgets\UIEditBox</Filter>
-    </ClCompile>
     <ClCompile Include="..\UIWebView.cpp">
-      <Filter>UIWidgets</Filter>
-    </ClCompile>
-    <ClCompile Include="..\UIWebViewImpl-win32.cpp">
       <Filter>UIWidgets</Filter>
     </ClCompile>
   </ItemGroup>


### PR DESCRIPTION
Remove references to files that no longer exist. Win32 cpp-tests was built to verify changes.
