### PR TITLE
Allow inherit form FileUtilsLinux, FileUtilsWin32 and FileUtilsWinRT.

### DIFF
--- a/cocos/platform/apple/CCFileUtils-apple.h
+++ b/cocos/platform/apple/CCFileUtils-apple.h
@@ -54,13 +54,9 @@ public:
     virtual bool writeToFile(ValueMap& dict, const std::string& fullPath) override;
 
     virtual ValueVector getValueVectorFromFile(const std::string& filename) override;
-    void setBundle(NSBundle* bundle);
 private:
     virtual bool isFileExistInternal(const std::string& filePath) const override;
     virtual bool removeDirectory(const std::string& dirPath) override;
-    
-    NSBundle* getBundle() const;
-    NSBundle* _bundle;
 };
 
 // end of platform group

--- a/cocos/platform/apple/CCFileUtils-apple.mm
+++ b/cocos/platform/apple/CCFileUtils-apple.mm
@@ -304,16 +304,11 @@ static void addObjectToNSDict(const std::string& key, const Value& value, NSMuta
 }
 
 FileUtilsApple::FileUtilsApple() {
-    _bundle = [NSBundle mainBundle];
+
 }
 
-
-void FileUtilsApple::setBundle(NSBundle* bundle) {
-    _bundle = bundle;
-}
-
-NSBundle* FileUtilsApple::getBundle() const {
-    return _bundle;
+static NSBundle* getBundle() {
+    return [NSBundle mainBundle];
 }
 
 

--- a/cocos/platform/linux/CCFileUtils-linux.h
+++ b/cocos/platform/linux/CCFileUtils-linux.h
@@ -45,7 +45,9 @@ NS_CC_BEGIN
 class CC_DLL FileUtilsLinux : public FileUtils
 {
     friend class FileUtils;
+protected:
     FileUtilsLinux();
+private:
     std::string _writablePath;
 public:
     /* override functions */

--- a/cocos/platform/win32/CCFileUtils-win32.h
+++ b/cocos/platform/win32/CCFileUtils-win32.h
@@ -45,6 +45,7 @@ NS_CC_BEGIN
 class CC_DLL FileUtilsWin32 : public FileUtils
 {
     friend class FileUtils;
+protected:
     FileUtilsWin32();
 public:
     /* override functions */

--- a/cocos/platform/winrt/CCFileUtilsWinRT.h
+++ b/cocos/platform/winrt/CCFileUtilsWinRT.h
@@ -43,6 +43,7 @@ NS_CC_BEGIN
 class CC_DLL CCFileUtilsWinRT : public FileUtils
 {
     friend class FileUtils;
+protected:
     CCFileUtilsWinRT();
 public:
     /* override functions */


### PR DESCRIPTION
The doc for FileUtils::setDelegate() says:

```
 * You can inherit from platform dependent implementation of FileUtils, such as FileUtilsAndroid,
 * and use this function to set delegate, then FileUtils will invoke delegate's implementation.
 * For example, your resources are encrypted, so you need to decrypt it after reading data from
 * resources, then you can implement all getXXX functions, and engine will invoke your own getXX
 * functions when reading data of resources.
```

But the constructor of  FileUtilsLinux, FileUtilsWin32 and FileUtilsWinRT are private.

So make these constructors protected which allows inherit from them.

---

BTW:

Why inheritance?
Why not something like `FileUtils::setCrypt(const Crypt& crypt)`.
After set, `Crypt::encrypt()` are called before save data/string to file.
and `Crypt::decrypt()` are called after read data/string from file.
If not set a Crypt to file utils, just do normal reading and writing.
