### PR TITLE
Small refactor FileUtils.

### DIFF
--- a/cocos/platform/CCFileUtils.cpp
+++ b/cocos/platform/CCFileUtils.cpp
@@ -570,7 +570,8 @@ bool FileUtils::writeStringToFile(const std::string& dataStr, const std::string&
     bool rv = writeDataToFile(data, fullPath);
 
     data.fastSet(nullptr, 0);
-    return rv;}
+    return rv;
+}
 
 bool FileUtils::writeDataToFile(const Data& data, const std::string& fullPath)
 {

--- a/cocos/platform/CCFileUtils.cpp
+++ b/cocos/platform/CCFileUtils.cpp
@@ -565,10 +565,12 @@ FileUtils::~FileUtils()
 bool FileUtils::writeStringToFile(const std::string& dataStr, const std::string& fullPath)
 {
     Data data;
-    data.copy((unsigned char*)dataStr.c_str(), dataStr.size());
+    data.fastSet((unsigned char*)dataStr.c_str(), dataStr.size());
 
-    return writeDataToFile(data, fullPath);
-}
+    bool rv = writeDataToFile(data, fullPath);
+
+    data.fastSet(nullptr, 0);
+    return rv;}
 
 bool FileUtils::writeDataToFile(const Data& data, const std::string& fullPath)
 {

--- a/cocos/platform/CCFileUtils.cpp
+++ b/cocos/platform/CCFileUtils.cpp
@@ -356,12 +356,12 @@ static tinyxml2::XMLElement* generateElementForDict(const ValueMap& dict, tinyxm
 /*
  * Use tinyxml2 to write plist files
  */
-bool FileUtils::writeToFile(ValueMap& dict, const std::string &fullPath)
+bool FileUtils::writeToFile(const ValueMap& dict, const std::string &fullPath)
 {
     return writeValueMapToFile(dict, fullPath);
 }
 
-bool FileUtils::writeValueMapToFile(ValueMap& dict, const std::string& fullPath)
+bool FileUtils::writeValueMapToFile(const ValueMap& dict, const std::string& fullPath)
 {
     tinyxml2::XMLDocument *doc = new (std::nothrow)tinyxml2::XMLDocument();
     if (nullptr == doc)
@@ -401,7 +401,7 @@ bool FileUtils::writeValueMapToFile(ValueMap& dict, const std::string& fullPath)
     return ret;
 }
 
-bool FileUtils::writeValueVectorToFile(ValueVector vecData, const std::string& fullPath)
+bool FileUtils::writeValueVectorToFile(const ValueVector& vecData, const std::string& fullPath)
 {
     tinyxml2::XMLDocument *doc = new (std::nothrow)tinyxml2::XMLDocument();
     if (nullptr == doc)
@@ -533,7 +533,7 @@ static tinyxml2::XMLElement* generateElementForArray(const ValueVector& array, t
 ValueMap FileUtils::getValueMapFromFile(const std::string& filename) {return ValueMap();}
 ValueMap FileUtils::getValueMapFromData(const char* filedata, int filesize) {return ValueMap();}
 ValueVector FileUtils::getValueVectorFromFile(const std::string& filename) {return ValueVector();}
-bool FileUtils::writeToFile(ValueMap& dict, const std::string &fullPath) {return false;}
+bool FileUtils::writeToFile(const ValueMap& dict, const std::string &fullPath) {return false;}
 
 #endif /* (CC_TARGET_PLATFORM != CC_PLATFORM_IOS) && (CC_TARGET_PLATFORM != CC_PLATFORM_MAC) */
 
@@ -562,7 +562,7 @@ FileUtils::~FileUtils()
 {
 }
 
-bool FileUtils::writeStringToFile(std::string dataStr, const std::string& fullPath)
+bool FileUtils::writeStringToFile(const std::string& dataStr, const std::string& fullPath)
 {
     Data retData;
     retData.copy((unsigned char*)dataStr.c_str(), dataStr.size());
@@ -570,7 +570,7 @@ bool FileUtils::writeStringToFile(std::string dataStr, const std::string& fullPa
     return writeDataToFile(retData, fullPath);
 }
 
-bool FileUtils::writeDataToFile(Data retData, const std::string& fullPath)
+bool FileUtils::writeDataToFile(const Data& retData, const std::string& fullPath)
 {
     size_t size = 0;
     const char* mode = "wb";
@@ -1308,4 +1308,3 @@ std::string FileUtils::getFileExtension(const std::string& filePath) const
 }
 
 NS_CC_END
-

--- a/cocos/platform/CCFileUtils.cpp
+++ b/cocos/platform/CCFileUtils.cpp
@@ -564,18 +564,18 @@ FileUtils::~FileUtils()
 
 bool FileUtils::writeStringToFile(const std::string& dataStr, const std::string& fullPath)
 {
-    Data retData;
-    retData.copy((unsigned char*)dataStr.c_str(), dataStr.size());
+    Data data;
+    data.copy((unsigned char*)dataStr.c_str(), dataStr.size());
 
-    return writeDataToFile(retData, fullPath);
+    return writeDataToFile(data, fullPath);
 }
 
-bool FileUtils::writeDataToFile(const Data& retData, const std::string& fullPath)
+bool FileUtils::writeDataToFile(const Data& data, const std::string& fullPath)
 {
     size_t size = 0;
     const char* mode = "wb";
 
-    CCASSERT(!fullPath.empty() && retData.getSize() != 0, "Invalid parameters.");
+    CCASSERT(!fullPath.empty() && data.getSize() != 0, "Invalid parameters.");
 
     auto fileutils = FileUtils::getInstance();
     do
@@ -583,9 +583,9 @@ bool FileUtils::writeDataToFile(const Data& retData, const std::string& fullPath
         // Read the file from hardware
         FILE *fp = fopen(fileutils->getSuitableFOpen(fullPath).c_str(), mode);
         CC_BREAK_IF(!fp);
-        size = retData.getSize();
+        size = data.getSize();
 
-        fwrite(retData.getBytes(), size, 1, fp);
+        fwrite(data.getBytes(), size, 1, fp);
 
         fclose(fp);
 

--- a/cocos/platform/CCFileUtils.h
+++ b/cocos/platform/CCFileUtils.h
@@ -334,7 +334,7 @@ public:
     *@param fullPath The full path to the file you want to save a string
     *@return bool
     */
-    virtual bool writeToFile(ValueMap& dict, const std::string& fullPath);
+    virtual bool writeToFile(const ValueMap& dict, const std::string& fullPath);
 
     /**
      *  write a string into a file
@@ -343,7 +343,7 @@ public:
      * @param fullPath The full path to the file you want to save a string
      * @return bool True if write success
      */
-    virtual bool writeStringToFile(std::string dataStr, const std::string& fullPath);
+    virtual bool writeStringToFile(const std::string& dataStr, const std::string& fullPath);
 
 
     /**
@@ -353,7 +353,7 @@ public:
      *@param fullPath The full path to the file you want to save a string
      *@return bool
      */
-    virtual bool writeDataToFile(Data retData, const std::string& fullPath);
+    virtual bool writeDataToFile(const Data& retData, const std::string& fullPath);
 
     /**
     * write ValueMap into a plist file
@@ -362,7 +362,7 @@ public:
     *@param fullPath The full path to the file you want to save a string
     *@return bool
     */
-    virtual bool writeValueMapToFile(ValueMap& dict, const std::string& fullPath);
+    virtual bool writeValueMapToFile(const ValueMap& dict, const std::string& fullPath);
 
     /**
     * write ValueVector into a plist file
@@ -371,7 +371,7 @@ public:
     *@param fullPath The full path to the file you want to save a string
     *@return bool
     */
-    virtual bool writeValueVectorToFile(ValueVector vecData, const std::string& fullPath);
+    virtual bool writeValueVectorToFile(const ValueVector& vecData, const std::string& fullPath);
 
     /**
     * Windows fopen can't support UTF-8 filename

--- a/cocos/platform/CCFileUtils.h
+++ b/cocos/platform/CCFileUtils.h
@@ -349,11 +349,11 @@ public:
     /**
      * write Data into a file
      *
-     *@param retData the data want to save
+     *@param data the data want to save
      *@param fullPath The full path to the file you want to save a string
      *@return bool
      */
-    virtual bool writeDataToFile(const Data& retData, const std::string& fullPath);
+    virtual bool writeDataToFile(const Data& data, const std::string& fullPath);
 
     /**
     * write ValueMap into a plist file

--- a/cocos/platform/apple/CCFileUtils-apple.h
+++ b/cocos/platform/apple/CCFileUtils-apple.h
@@ -51,14 +51,14 @@ public:
 
     virtual ValueMap getValueMapFromFile(const std::string& filename) override;
     virtual ValueMap getValueMapFromData(const char* filedata, int filesize)override;
-    virtual bool writeToFile(ValueMap& dict, const std::string& fullPath) override;
+    virtual bool writeToFile(const ValueMap& dict, const std::string& fullPath) override;
 
     virtual ValueVector getValueVectorFromFile(const std::string& filename) override;
     void setBundle(NSBundle* bundle);
 private:
     virtual bool isFileExistInternal(const std::string& filePath) const override;
     virtual bool removeDirectory(const std::string& dirPath) override;
-    
+
     NSBundle* getBundle() const;
     NSBundle* _bundle;
 };
@@ -69,4 +69,3 @@ private:
 NS_CC_END
 
 #endif    // __CC_FILEUTILS_APPLE_H__
-

--- a/cocos/platform/apple/CCFileUtils-apple.mm
+++ b/cocos/platform/apple/CCFileUtils-apple.mm
@@ -480,12 +480,12 @@ ValueMap FileUtilsApple::getValueMapFromData(const char* filedata, int filesize)
     return ret;
 }
 
-bool FileUtilsApple::writeToFile(ValueMap& dict, const std::string &fullPath)
+bool FileUtilsApple::writeToFile(const ValueMap& dict, const std::string &fullPath)
 {
     return writeValueMapToFile(dict, fullPath);
 }
 
-bool FileUtils::writeValueMapToFile(ValueMap& dict, const std::string& fullPath)
+bool FileUtils::writeValueMapToFile(const ValueMap& dict, const std::string& fullPath)
 {
     
     //CCLOG("iOS||Mac Dictionary %d write to file %s", dict->_ID, fullPath.c_str());
@@ -503,7 +503,7 @@ bool FileUtils::writeValueMapToFile(ValueMap& dict, const std::string& fullPath)
     return true;
 }
 
-bool FileUtils::writeValueVectorToFile(ValueVector vecData, const std::string& fullPath)
+bool FileUtils::writeValueVectorToFile(const ValueVector& vecData, const std::string& fullPath)
 {
     NSString* path = [NSString stringWithUTF8String:fullPath.c_str()];
     NSMutableArray* array = [NSMutableArray array];
@@ -539,4 +539,3 @@ ValueVector FileUtilsApple::getValueVectorFromFile(const std::string& filename)
 }
 
 NS_CC_END
-


### PR DESCRIPTION
- Should be const reference for data/string args to be written in FileUtils methods.
-  Better name for data to be saved.
- Remove unnecessary memory copy when saving string to file.
