### PR TITLE
add etc2 CPU and GPU decode. (PVR fileformat only)

### DIFF
--- a/build/cocos2d_libs.xcodeproj/project.pbxproj
+++ b/build/cocos2d_libs.xcodeproj/project.pbxproj
@@ -3714,6 +3714,16 @@
 		5E9F612B1A3FFE3D0038DE01 /* CCPlane.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5E9F61241A3FFE3D0038DE01 /* CCPlane.cpp */; };
 		5E9F612C1A3FFE3D0038DE01 /* CCPlane.h in Headers */ = {isa = PBXBuildFile; fileRef = 5E9F61251A3FFE3D0038DE01 /* CCPlane.h */; };
 		5E9F612D1A3FFE3D0038DE01 /* CCPlane.h in Headers */ = {isa = PBXBuildFile; fileRef = 5E9F61251A3FFE3D0038DE01 /* CCPlane.h */; };
+		7D1EC4771C58CA7200BB8CE9 /* etcdec.cxx in Sources */ = {isa = PBXBuildFile; fileRef = 7D1EC4761C58CA7200BB8CE9 /* etcdec.cxx */; };
+		7D1EC4781C58CA7200BB8CE9 /* etcdec.cxx in Sources */ = {isa = PBXBuildFile; fileRef = 7D1EC4761C58CA7200BB8CE9 /* etcdec.cxx */; };
+		7D4DADE41C2423FF0024FDD9 /* etc2.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7D4DADDF1C2423FF0024FDD9 /* etc2.cpp */; };
+		7D4DADE51C2423FF0024FDD9 /* etc2.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7D4DADDF1C2423FF0024FDD9 /* etc2.cpp */; };
+		7D4DADE61C2423FF0024FDD9 /* etc2.h in Headers */ = {isa = PBXBuildFile; fileRef = 7D4DADE01C2423FF0024FDD9 /* etc2.h */; };
+		7D4DADE71C2423FF0024FDD9 /* etc2.h in Headers */ = {isa = PBXBuildFile; fileRef = 7D4DADE01C2423FF0024FDD9 /* etc2.h */; };
+		7D4DADEA1C2423FF0024FDD9 /* etc2types.h in Headers */ = {isa = PBXBuildFile; fileRef = 7D4DADE21C2423FF0024FDD9 /* etc2types.h */; };
+		7D4DADEB1C2423FF0024FDD9 /* etc2types.h in Headers */ = {isa = PBXBuildFile; fileRef = 7D4DADE21C2423FF0024FDD9 /* etc2types.h */; };
+		7D4DADEC1C2423FF0024FDD9 /* etc2unpack.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7D4DADE31C2423FF0024FDD9 /* etc2unpack.cpp */; };
+		7D4DADED1C2423FF0024FDD9 /* etc2unpack.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7D4DADE31C2423FF0024FDD9 /* etc2unpack.cpp */; };
 		826294331AAF001C00CB7CF7 /* HttpAsynConnection-apple.m in Sources */ = {isa = PBXBuildFile; fileRef = 52B47A2A1A5349A3004E4C60 /* HttpAsynConnection-apple.m */; };
 		826294341AAF003E00CB7CF7 /* HttpClient-apple.mm in Sources */ = {isa = PBXBuildFile; fileRef = 52B47A2B1A5349A3004E4C60 /* HttpClient-apple.mm */; };
 		826294351AAF004C00CB7CF7 /* HttpCookie.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 52B47A2C1A5349A3004E4C60 /* HttpCookie.cpp */; };
@@ -6550,6 +6560,11 @@
 		5E9F61231A3FFE3D0038DE01 /* CCFrustum.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CCFrustum.h; sourceTree = "<group>"; };
 		5E9F61241A3FFE3D0038DE01 /* CCPlane.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CCPlane.cpp; sourceTree = "<group>"; };
 		5E9F61251A3FFE3D0038DE01 /* CCPlane.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CCPlane.h; sourceTree = "<group>"; };
+		7D1EC4761C58CA7200BB8CE9 /* etcdec.cxx */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = etcdec.cxx; path = ../base/etcdec.cxx; sourceTree = "<group>"; };
+		7D4DADDF1C2423FF0024FDD9 /* etc2.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = etc2.cpp; path = ../base/etc2.cpp; sourceTree = "<group>"; };
+		7D4DADE01C2423FF0024FDD9 /* etc2.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = etc2.h; path = ../base/etc2.h; sourceTree = "<group>"; };
+		7D4DADE21C2423FF0024FDD9 /* etc2types.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = etc2types.h; path = ../base/etc2types.h; sourceTree = "<group>"; };
+		7D4DADE31C2423FF0024FDD9 /* etc2unpack.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = etc2unpack.cpp; path = ../base/etc2unpack.cpp; sourceTree = "<group>"; };
 		8525E3A11B291E42008EE815 /* clipper.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = clipper.hpp; sourceTree = "<group>"; };
 		85B374381B204B9400C488D6 /* clipper.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = clipper.cpp; sourceTree = "<group>"; };
 		A045F6D41BA81577005076C7 /* CCTextureCube.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CCTextureCube.cpp; sourceTree = "<group>"; };
@@ -7901,6 +7916,11 @@
 				50ABBE131925AB6F00A911A9 /* CCVector.h */,
 				50ABBE141925AB6F00A911A9 /* etc1.cpp */,
 				50ABBE151925AB6F00A911A9 /* etc1.h */,
+				7D4DADDF1C2423FF0024FDD9 /* etc2.cpp */,
+				7D4DADE01C2423FF0024FDD9 /* etc2.h */,
+				7D4DADE21C2423FF0024FDD9 /* etc2types.h */,
+				7D4DADE31C2423FF0024FDD9 /* etc2unpack.cpp */,
+				7D1EC4761C58CA7200BB8CE9 /* etcdec.cxx */,
 				50ABBE161925AB6F00A911A9 /* firePngData.h */,
 				50ABBE171925AB6F00A911A9 /* s3tc.cpp */,
 				50ABBE181925AB6F00A911A9 /* s3tc.h */,
@@ -11417,6 +11437,7 @@
 				B6CAB2CF1AF9AA1A00B9B856 /* btMultimaterialTriangleMeshShape.h in Headers */,
 				15AE18F119AAD35000C27E9E /* CCArmatureAnimation.h in Headers */,
 				1A57022F180BCC1A0088DEC7 /* CCParticleSystemQuad.h in Headers */,
+				7D4DADEA1C2423FF0024FDD9 /* etc2types.h in Headers */,
 				B6CAB4EB1AF9AA1A00B9B856 /* TrbStateVec.h in Headers */,
 				B6CAB2831AF9AA1A00B9B856 /* btBoxShape.h in Headers */,
 				B665E37C1AA80A6500DDB1C5 /* CCPUParticleSystem3D.h in Headers */,
@@ -11910,6 +11931,7 @@
 				50ABBECD1925AB6F00A911A9 /* s3tc.h in Headers */,
 				B6CAB3651AF9AA1A00B9B856 /* btContinuousConvexCollision.h in Headers */,
 				15AE1BD119AAE01E00C27E9E /* CCControlHuePicker.h in Headers */,
+				7D4DADE61C2423FF0024FDD9 /* etc2.h in Headers */,
 				B5CE6DC01B3BF2B1002B0419 /* UIAbstractCheckButton.h in Headers */,
 				D0FD03571A3B51AA00825BB5 /* CCAllocatorMutex.h in Headers */,
 				B6CAB36D1AF9AA1A00B9B856 /* btDiscreteCollisionDetectorInterface.h in Headers */,
@@ -12950,6 +12972,7 @@
 				46A170FF1807CECB005B8026 /* CCPhysicsContact.h in Headers */,
 				B6CAB37E1AF9AA1A00B9B856 /* btGjkPairDetector.h in Headers */,
 				B6CAB3101AF9AA1A00B9B856 /* btTriangleShape.h in Headers */,
+				7D4DADE71C2423FF0024FDD9 /* etc2.h in Headers */,
 				B6CAB5141AF9AA1A00B9B856 /* btMatrixX.h in Headers */,
 				3EACC9A319F5014D00EB3C5E /* CCCamera.h in Headers */,
 				B29A7E1A19EE1B7700872B35 /* Event.h in Headers */,
@@ -13216,6 +13239,7 @@
 				B665E32D1AA80A6500DDB1C5 /* CCPUOnCountObserver.h in Headers */,
 				503DD8E61926736A00CD74DD /* CCEAGLView-ios.h in Headers */,
 				50ABBE4C1925AB6F00A911A9 /* CCEventAcceleration.h in Headers */,
+				7D4DADEB1C2423FF0024FDD9 /* etc2types.h in Headers */,
 				B665E2F91AA80A6500DDB1C5 /* CCPUListener.h in Headers */,
 				B6CAB4F41AF9AA1A00B9B856 /* btAabbUtil2.h in Headers */,
 				50ABBD571925AB0000A911A9 /* TransformUtils.h in Headers */,
@@ -14103,6 +14127,7 @@
 				50ABBD501925AB0000A911A9 /* Quaternion.cpp in Sources */,
 				B6CAB2751AF9AA1A00B9B856 /* btUnionFind.cpp in Sources */,
 				B665E36E1AA80A6500DDB1C5 /* CCPUOnVelocityObserverTranslator.cpp in Sources */,
+				7D4DADEC1C2423FF0024FDD9 /* etc2unpack.cpp in Sources */,
 				15AE190119AAD35000C27E9E /* CCComController.cpp in Sources */,
 				B6CAB4071AF9AA1A00B9B856 /* btMultiBodyJointLimitConstraint.cpp in Sources */,
 				B6CAB38F1AF9AA1A00B9B856 /* btRaycastCallback.cpp in Sources */,
@@ -14415,6 +14440,7 @@
 				B6CAB4FF1AF9AA1A00B9B856 /* btConvexHullComputer.cpp in Sources */,
 				1A570208180BCBDF0088DEC7 /* CCMotionStreak.cpp in Sources */,
 				15FB20971AE7C57D00C31518 /* sweep.cc in Sources */,
+				7D1EC4771C58CA7200BB8CE9 /* etcdec.cxx in Sources */,
 				1A570210180BCBF40088DEC7 /* CCProgressTimer.cpp in Sources */,
 				501216941AC47393009A4BEA /* CCPass.cpp in Sources */,
 				292DB15F19B461CA00A80320 /* ExtensionDeprecated.cpp in Sources */,
@@ -14800,6 +14826,7 @@
 				B6CAB4D31AF9AA1A00B9B856 /* SpuGatheringCollisionTask.cpp in Sources */,
 				15AE1B6519AADA9900C27E9E /* UIImageView.cpp in Sources */,
 				B29A7E1519EE1B7700872B35 /* BoundingBoxAttachment.c in Sources */,
+				7D4DADE41C2423FF0024FDD9 /* etc2.cpp in Sources */,
 				B6CAB4E31AF9AA1A00B9B856 /* SpuSampleTaskProcess.cpp in Sources */,
 				15AE1A2519AAD3D500C27E9E /* b2CollideCircle.cpp in Sources */,
 				B665E3321AA80A6500DDB1C5 /* CCPUOnEmissionObserver.cpp in Sources */,
@@ -16186,6 +16213,7 @@
 				B665E3671AA80A6500DDB1C5 /* CCPUOnTimeObserverTranslator.cpp in Sources */,
 				B665E27B1AA80A6500DDB1C5 /* CCPUDoScaleEventHandler.cpp in Sources */,
 				15AE18CE19AAD33D00C27E9E /* CCNodeLoader.cpp in Sources */,
+				7D4DADE51C2423FF0024FDD9 /* etc2.cpp in Sources */,
 				B665E42F1AA80A6600DDB1C5 /* CCPUVelocityMatchingAffectorTranslator.cpp in Sources */,
 				38ACD1FD1A27111900C3093D /* WidgetCallBackHandlerProtocol.cpp in Sources */,
 				29394CF719B01DBA00D2DE1A /* UIWebViewImpl-ios.mm in Sources */,
@@ -16209,6 +16237,7 @@
 				B6CAB3DE1AF9AA1A00B9B856 /* btTypedConstraint.cpp in Sources */,
 				B665E3231AA80A6500DDB1C5 /* CCPUOnCollisionObserver.cpp in Sources */,
 				B665E3271AA80A6500DDB1C5 /* CCPUOnCollisionObserverTranslator.cpp in Sources */,
+				7D1EC4781C58CA7200BB8CE9 /* etcdec.cxx in Sources */,
 				15AE18B519AAD33D00C27E9E /* CCBSequence.cpp in Sources */,
 				B665E3C31AA80A6600DDB1C5 /* CCPUScaleAffectorTranslator.cpp in Sources */,
 				B665E2631AA80A6500DDB1C5 /* CCPUDoExpireEventHandler.cpp in Sources */,
@@ -16217,6 +16246,7 @@
 				1A570283180BCC900088DEC7 /* CCSpriteBatchNode.cpp in Sources */,
 				B6CAB23A1AF9AA1A00B9B856 /* btCompoundCompoundCollisionAlgorithm.cpp in Sources */,
 				B665E2F71AA80A6500DDB1C5 /* CCPUListener.cpp in Sources */,
+				7D4DADED1C2423FF0024FDD9 /* etc2unpack.cpp in Sources */,
 				1A570287180BCC900088DEC7 /* CCSpriteFrame.cpp in Sources */,
 				507003221B69735300E83DDD /* HttpConnection-winrt.cpp in Sources */,
 				B6CAB3AA1AF9AA1A00B9B856 /* btContactConstraint.cpp in Sources */,

--- a/cocos/2d/libcocos2d.vcxproj
+++ b/cocos/2d/libcocos2d.vcxproj
@@ -448,6 +448,9 @@ xcopy /Y /Q "$(ProjectDir)..\..\external\chipmunk\prebuilt\win32\release-lib\*.*
     <ClCompile Include="..\base\ccUtils.cpp" />
     <ClCompile Include="..\base\CCValue.cpp" />
     <ClCompile Include="..\base\etc1.cpp" />
+    <ClCompile Include="..\base\etc2.cpp" />
+    <ClCompile Include="..\base\etc2unpack.cpp" />
+    <ClCompile Include="..\base\etcdec.cxx" />
     <ClCompile Include="..\base\pvr.cpp" />
     <ClCompile Include="..\base\ObjectFactory.cpp" />
     <ClCompile Include="..\base\s3tc.cpp" />
@@ -1034,6 +1037,8 @@ xcopy /Y /Q "$(ProjectDir)..\..\external\chipmunk\prebuilt\win32\release-lib\*.*
     <ClInclude Include="..\base\CCValue.h" />
     <ClInclude Include="..\base\CCVector.h" />
     <ClInclude Include="..\base\etc1.h" />
+    <ClInclude Include="..\base\etc2.h" />
+    <ClInclude Include="..\base\etc2types.h" />
     <ClInclude Include="..\base\firePngData.h" />
     <ClInclude Include="..\base\ObjectFactory.h" />
     <ClInclude Include="..\base\pvr.h" />

--- a/cocos/2d/libcocos2d.vcxproj.filters
+++ b/cocos/2d/libcocos2d.vcxproj.filters
@@ -1941,6 +1941,15 @@
       <Filter>network</Filter>
     </ClCompile>
     <ClCompile Include="..\editor-support\cocostudio\WidgetReader\Light3DReader\Light3DReader.cpp" />
+    <ClCompile Include="..\base\etc2.cpp">
+      <Filter>base</Filter>
+    </ClCompile>
+    <ClCompile Include="..\base\etc2unpack.cpp">
+      <Filter>base</Filter>
+    </ClCompile>
+    <ClCompile Include="..\base\etcdec.cxx">
+      <Filter>base</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\physics\CCPhysicsBody.h">
@@ -3787,6 +3796,12 @@
     <ClInclude Include="..\editor-support\cocostudio\WidgetReader\Light3DReader\Light3DReader.h" />
     <ClInclude Include="..\ui\UIAbstractCheckButton.h">
       <Filter>ui</Filter>
+    </ClInclude>
+    <ClInclude Include="..\base\etc2.h">
+      <Filter>base</Filter>
+    </ClInclude>
+    <ClInclude Include="..\base\etc2types.h">
+      <Filter>base</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/cocos/2d/libcocos2d_8_1/libcocos2d_8_1/libcocos2d_8_1.Shared/libcocos2d_8_1.Shared.vcxitems
+++ b/cocos/2d/libcocos2d_8_1/libcocos2d_8_1/libcocos2d_8_1.Shared/libcocos2d_8_1.Shared.vcxitems
@@ -304,6 +304,8 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\..\..\base\CCValue.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\..\..\base\CCVector.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\..\..\base\etc1.h" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\..\..\base\etc2.h" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\..\..\base\etc2types.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\..\..\base\firePngData.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\..\..\base\ObjectFactory.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\..\..\base\pvr.h" />
@@ -933,6 +935,9 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\..\..\base\ccUtils.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\..\..\base\CCValue.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\..\..\base\etc1.cpp" />
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\..\..\base\etc2.cpp" />
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\..\..\base\etc2unpack.cpp" />
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\..\..\base\etcdec.cxx" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\..\..\base\ObjectFactory.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\..\..\base\pvr.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\..\..\base\s3tc.cpp" />

--- a/cocos/2d/libcocos2d_8_1/libcocos2d_8_1/libcocos2d_8_1.Shared/libcocos2d_8_1.Shared.vcxitems.filters
+++ b/cocos/2d/libcocos2d_8_1/libcocos2d_8_1/libcocos2d_8_1.Shared/libcocos2d_8_1.Shared.vcxitems.filters
@@ -1877,6 +1877,12 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\..\..\editor-support\cocostudio\WidgetReader\Light3DReader\Light3DReader.h">
       <Filter>cocostudio\reader\WidgetReader\Light3DReader</Filter>
     </ClInclude>
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\..\..\base\etc2.h">
+      <Filter>base</Filter>
+    </ClInclude>
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\..\..\base\etc2types.h">
+      <Filter>base</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\..\..\cocos2d.cpp">
@@ -3588,6 +3594,15 @@
     </ClCompile>
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\..\..\editor-support\cocostudio\WidgetReader\Light3DReader\Light3DReader.cpp">
       <Filter>cocostudio\reader\WidgetReader\Light3DReader</Filter>
+    </ClCompile>
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\..\..\base\etc2.cpp">
+      <Filter>base</Filter>
+    </ClCompile>
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\..\..\base\etc2unpack.cpp">
+      <Filter>base</Filter>
+    </ClCompile>
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\..\..\base\etcdec.cxx">
+      <Filter>base</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/cocos/Android.mk
+++ b/cocos/Android.mk
@@ -162,6 +162,9 @@ base/ccUtils.cpp \
 base/etc1.cpp \
 base/pvr.cpp \
 base/s3tc.cpp \
+base/etc2.cpp \
+base/etc2unpack.cpp \
+base/etcdec.cxx \
 renderer/CCBatchCommand.cpp \
 renderer/CCCustomCommand.cpp \
 renderer/CCGLProgram.cpp \

--- a/cocos/base/CCConfiguration.cpp
+++ b/cocos/base/CCConfiguration.cpp
@@ -43,6 +43,7 @@ Configuration::Configuration()
 , _maxModelviewStackDepth(0)
 , _supportsPVRTC(false)
 , _supportsETC1(false)
+, _supportsETC2(false)
 , _supportsS3TC(false)
 , _supportsATITC(false)
 , _supportsNPOT(false)
@@ -130,6 +131,16 @@ void Configuration::gatherGPUInfo()
     
     _supportsETC1 = checkForGLExtension("GL_OES_compressed_ETC1_RGB8_texture");
     _valueDict["gl.supports_ETC1"] = Value(_supportsETC1);
+
+    GLint majorVersion = 0;
+#if (CC_TARGET_OPENGLES == CC_OPENGLES_3)
+    glGetIntegerv(GL_MAJOR_VERSION, &majorVersion);
+#endif
+    if (majorVersion >= 3)
+    {
+        _supportsETC2 = true;
+    }
+    _valueDict["gl.supports_ETC2"] = Value(_supportsETC2);
     
     _supportsS3TC = checkForGLExtension("GL_EXT_texture_compression_s3tc");
     _valueDict["gl.supports_S3TC"] = Value(_supportsS3TC);
@@ -234,6 +245,11 @@ bool Configuration::supportsETC() const
 #else
     return false;
 #endif
+}
+
+bool Configuration::supportsETC2() const
+{
+    return _supportsETC2;
 }
 
 bool Configuration::supportsS3TC() const

--- a/cocos/base/CCConfiguration.h
+++ b/cocos/base/CCConfiguration.h
@@ -113,6 +113,13 @@ public:
      * @return Is true if supports ETC Texture Compressed.
      */
     bool supportsETC() const;
+
+    /** Whether or not ETC Texture Compressed is supported.
+     * 
+     *
+     * @return Is true if supports ETC Texture Compressed.
+     */
+    bool supportsETC2() const;
     
     /** Whether or not S3TC Texture Compressed is supported.
      *
@@ -242,6 +249,7 @@ protected:
     GLint           _maxModelviewStackDepth;
     bool            _supportsPVRTC;
     bool            _supportsETC1;
+    bool            _supportsETC2;
     bool            _supportsS3TC;
     bool            _supportsATITC;
     bool            _supportsNPOT;

--- a/cocos/base/CCDirector.cpp
+++ b/cocos/base/CCDirector.cpp
@@ -1306,6 +1306,11 @@ void Director::setEventDispatcher(EventDispatcher* dispatcher)
     }
 }
 
+int Director::getTargetOpenGLESVersion()
+{
+    return CC_TARGET_OPENGLES;
+}
+
 /***************************************************
 * implementation of DisplayLinkDirector
 **************************************************/

--- a/cocos/base/CCDirector.h
+++ b/cocos/base/CCDirector.h
@@ -497,6 +497,11 @@ public:
      */
     const std::thread::id& getCocos2dThreadId() const { return _cocos2d_thread_id; }
 
+    /**
+     * return target OpenGLES version.
+     */
+    int getTargetOpenGLESVersion();
+
 protected:
     void reset();
     

--- a/cocos/base/CMakeLists.txt
+++ b/cocos/base/CMakeLists.txt
@@ -62,6 +62,9 @@ set(COCOS_BASE_SRC
   base/etc1.cpp
   base/pvr.cpp
   base/s3tc.cpp
+  base/etc2.cpp
+  base/etc2unpack.cpp
+  base/etcdec.cxx
   ${COCOS_BASE_SPECIFIC_SRC}
 
 )

--- a/cocos/base/etc2.cpp
+++ b/cocos/base/etc2.cpp
@@ -1,0 +1,30 @@
+/**
+    @file   etc2.cpp
+    @note   etc2 cpu decode
+*/
+
+#include "platform/CCGL.h"
+#include "etc2.h"
+#include "etc2types.h"
+
+extern ETC2_error_code
+_unpackETC(const GLubyte* __restrict srcETC, const GLenum srcFormat,
+            etc2_uint32_t activeWidth, etc2_uint32_t activeHeight,
+            GLubyte** __restrict dstImage,
+            GLenum* __restrict format, GLenum* __restrict internalFormat, GLenum* __restrict type,
+            GLint R16Formats, GLboolean supportsSRGB);
+
+int etc2_decode_image(const unsigned char* pIn, const GLenum srcFormat, unsigned int width, unsigned int height, unsigned char** pOut)
+{
+    GLenum format;
+    GLenum internalFormat;
+    GLenum type;
+    ETC2_error_code ret = _unpackETC(
+            pIn, srcFormat,
+            width, height,
+            pOut,
+            &format, &internalFormat, &type,
+            ETC2_NO_R16_FORMATS, false);
+    return (ret == ETC2_SUCCESS) ? 0 : -1;
+}
+

--- a/cocos/base/etc2.h
+++ b/cocos/base/etc2.h
@@ -1,0 +1,19 @@
+/**
+    @file   etc2.h
+    @note   etc2 cpu decode
+*/
+
+#ifndef __etc2_h__
+#define __etc2_h__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int etc2_decode_image(const unsigned char* pIn, const GLenum srcFormat, unsigned int width, unsigned int height, unsigned char** pOut);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/cocos/base/etc2types.h
+++ b/cocos/base/etc2types.h
@@ -1,0 +1,226 @@
+/**
+    @file   etc2types.h
+    @note   etc2 typedefs and defines.
+*/
+
+/*
+Copyright (c) 2010 The Khronos Group Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and/or associated documentation files (the
+"Materials"), to deal in the Materials without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Materials, and to
+permit persons to whom the Materials are furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be included
+unaltered in all copies or substantial portions of the Materials.
+Any additions, deletions, or changes to the original source files
+must be clearly indicated in accompanying documentation.
+
+If only executable code is distributed, then the accompanying
+documentation must state that "this software is based in part on the
+work of the Khronos Group."
+
+THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+*/
+
+#ifndef _ETC2_TYPES_H_
+#define _ETC2_TYPES_H_
+
+#include "platform/CCGL.h"
+
+/*
+   typedefs
+*/
+typedef unsigned int    etc2_uint32_t;
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Error codes returned by library functions.
+ */
+typedef enum ETC2_error_code_t {
+	ETC2_SUCCESS = 0,		 /*!< Operation was successful. */
+	ETC2_FILE_OPEN_FAILED,	 /*!< The target file could not be opened. */
+	ETC2_FILE_WRITE_ERROR,    /*!< An error occurred while writing to the file. */
+	ETC2_GL_ERROR,            /*!< GL operations resulted in an error. */
+	ETC2_INVALID_OPERATION,   /*!< The operation is not allowed in the current state. */
+	ETC2_INVALID_VALUE,	     /*!< A parameter value was not valid */
+	ETC2_NOT_FOUND,			 /*!< Requested key was not found */
+	ETC2_OUT_OF_MEMORY,       /*!< Not enough memory to complete the operation. */
+	ETC2_UNEXPECTED_END_OF_FILE, /*!< The file did not contain enough data */
+	ETC2_UNKNOWN_FILE_FORMAT, /*!< The file not a ETC2 file */
+	ETC2_UNSUPPORTED_TEXTURE_TYPE, /*!< The ETC2 file specifies an unsupported texture type. */
+} ETC2_error_code;
+
+
+/**
+ * @internal
+ * @brief used to pass GL context capabilites to subroutines.
+ */
+#define ETC2_NO_R16_FORMATS     0x0
+#define ETC2_R16_FORMATS_NORM	0x1
+#define ETC2_R16_FORMATS_SNORM	0x2
+#define ETC2_ALL_R16_FORMATS (ETC2_R16_FORMATS_NORM | ETC2_R16_FORMATS_SNORM)
+
+
+/*
+ * These defines are needed to compile the KTX library. When
+ * these things are not available in the GL header in use at
+ * compile time, the library provides its own support, handles
+ * the expected run-time errors or just needs the token value.
+ */
+#ifndef GL_LUMINANCE
+#define GL_ALPHA						0x1906
+#define GL_LUMINANCE					0x1909
+#define GL_LUMINANCE_ALPHA				0x190A
+#endif
+#ifndef GL_INTENSITY
+#define GL_INTENSITY					0x8049
+#endif
+#ifndef GL_TEXTURE_1D
+#define GL_TEXTURE_1D                   0x0DE0
+#endif
+#ifndef GL_TEXTURE_3D
+#define GL_TEXTURE_3D                   0x806F
+#endif
+#ifndef GL_TEXTURE_CUBE_MAP
+#define GL_TEXTURE_CUBE_MAP             0x8513
+#define GL_TEXTURE_CUBE_MAP_POSITIVE_X  0x8515
+#endif
+/* from GL_EXT_texture_array */
+#ifndef GL_TEXTURE_1D_ARRAY_EXT
+#define GL_TEXTURE_1D_ARRAY_EXT         0x8C18
+#define GL_TEXTURE_2D_ARRAY_EXT         0x8C1A
+#endif
+#ifndef GL_GENERATE_MIPMAP
+#define GL_GENERATE_MIPMAP              0x8191
+#endif
+
+/* For writer.c */
+#if !defined(GL_BGR)
+#define GL_BGR							0x80E0
+#define GL_BGRA							0x80E1
+#endif
+#if !defined(GL_RED_INTEGER)
+#define GL_RED_INTEGER					0x8D94
+#define GL_RGB_INTEGER					0x8D98
+#define GL_RGBA_INTEGER					0x8D99
+#endif
+#if !defined(GL_GREEN_INTEGER)
+#define GL_GREEN_INTEGER				0x8D95
+#define GL_BLUE_INTEGER					0x8D96
+#define GL_ALPHA_INTEGER				0x8D97
+#endif
+#if !defined (GL_BGR_INTEGER)
+#define GL_BGR_INTEGER					0x8D9A
+#define GL_BGRA_INTEGER					0x8D9B
+#endif
+#if !defined(GL_INT)
+#define GL_INT 0x1404
+#define GL_UNSIGNED_INT 0x1405
+#endif
+#if !defined(GL_HALF_FLOAT)
+typedef unsigned short GLhalf;
+#define GL_HALF_FLOAT					0x140B
+#endif
+#if !defined(GL_UNSIGNED_BYTE_3_3_2)
+#define GL_UNSIGNED_BYTE_3_3_2			0x8032
+#define GL_UNSIGNED_INT_8_8_8_8			0x8035
+#define GL_UNSIGNED_INT_10_10_10_2		0x8036
+#endif
+#if !defined(GL_UNSIGNED_BYTE_2_3_3_REV)
+#define GL_UNSIGNED_BYTE_2_3_3_REV		0x8362
+#define GL_UNSIGNED_SHORT_5_6_5			0x8363
+#define GL_UNSIGNED_SHORT_5_6_5_REV		0x8364
+#define GL_UNSIGNED_SHORT_4_4_4_4_REV	0x8365
+#define GL_UNSIGNED_SHORT_1_5_5_5_REV	0x8366
+#define GL_UNSIGNED_INT_8_8_8_8_REV		0x8367
+#define GL_UNSIGNED_INT_2_10_10_10_REV	0x8368
+#endif
+#if !defined(GL_UNSIGNED_INT_24_8)
+#define GL_DEPTH_STENCIL				0x84F9
+#define GL_UNSIGNED_INT_24_8			0x84FA
+#endif
+#if !defined(GL_UNSIGNED_INT_5_9_9_9_REV)
+#define GL_UNSIGNED_INT_5_9_9_9_REV		0x8C3E
+#endif
+#if !defined(GL_UNSIGNED_INT_10F_11F_11F_REV)
+#define GL_UNSIGNED_INT_10F_11F_11F_REV 0x8C3B
+#endif
+#if !defined (GL_FLOAT_32_UNSIGNED_INT_24_8_REV)
+#define GL_FLOAT_32_UNSIGNED_INT_24_8_REV	0x8DAD
+#endif
+
+#ifndef GL_ETC1_RGB8_OES
+#define GL_ETC1_RGB8_OES				0x8D64
+#endif
+
+#ifndef GL_COMPRESSED_R11_EAC
+#define GL_COMPRESSED_R11_EAC                            0x9270
+#define GL_COMPRESSED_SIGNED_R11_EAC                     0x9271
+#define GL_COMPRESSED_RG11_EAC                           0x9272
+#define GL_COMPRESSED_SIGNED_RG11_EAC                    0x9273
+#define GL_COMPRESSED_RGB8_ETC2                          0x9274
+#define GL_COMPRESSED_SRGB8_ETC2                         0x9275
+#define GL_COMPRESSED_RGB8_PUNCHTHROUGH_ALPHA1_ETC2      0x9276
+#define GL_COMPRESSED_SRGB8_PUNCHTHROUGH_ALPHA1_ETC2     0x9277
+#define GL_COMPRESSED_RGBA8_ETC2_EAC                     0x9278
+#define GL_COMPRESSED_SRGB8_ALPHA8_ETC2_EAC				 0x9279
+#endif
+#ifndef GL_R16_SNORM
+#define GL_R16_SNORM					0x8F98
+#define GL_RG16_SNORM					0x8F99
+#endif
+#ifndef GL_RED
+#define GL_RED							0x1903
+#define GL_GREEN						0x1904
+#define GL_BLUE							0x1905
+#define GL_RG							0x8227
+#define GL_RG_INTEGER					0x8228
+#endif
+#ifndef GL_R16
+#define GL_R16							0x822A
+#define GL_RG16							0x822C
+#endif
+#ifndef GL_RGB8
+#define GL_RGB8                         0x8051
+#define GL_RGBA8                        0x8058
+#endif
+#ifndef GL_SRGB8
+#define GL_SRGB8						0x8C41
+#define GL_SRGB8_ALPHA8					0x8C43
+#endif
+
+#ifndef GL_MAJOR_VERSION
+#define GL_MAJOR_VERSION                0x821B
+#define GL_MINOR_VERSION                0x821C
+#endif
+
+#ifndef GL_CONTEXT_PROFILE_MASK
+#define GL_CONTEXT_PROFILE_MASK				 0x9126
+#define GL_CONTEXT_CORE_PROFILE_BIT			 0x00000001
+#define GL_CONTEXT_COMPATIBILITY_PROFILE_BIT 0x00000002
+#endif
+
+#ifndef MAX
+#define MAX(x, y) (((x) > (y)) ? (x) : (y))
+#endif
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // _ETC2_TYPES_H_

--- a/cocos/base/etc2unpack.cpp
+++ b/cocos/base/etc2unpack.cpp
@@ -1,0 +1,426 @@
+/* -*- tab-width: 4; -*- */
+/* vi: set sw=2 ts=4: */
+
+/* $Id: d555f6fdc46c28e4db334b44fdb8ac5b4bcef91a $ */
+
+/* @internal
+ * @~English
+ * @file
+ *
+ * Unpack a texture compressed with ETC1
+ *
+ * @author Mark Callow, HI Corporation.
+ */
+
+/*
+Copyright (c) 2010 The Khronos Group Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and/or associated documentation files (the
+"Materials"), to deal in the Materials without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Materials, and to
+permit persons to whom the Materials are furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be included
+unaltered in all copies or substantial portions of the Materials.
+Any additions, deletions, or changes to the original source files
+must be clearly indicated in accompanying documentation.
+
+If only executable code is distributed, then the accompanying
+documentation must state that "this software is based in part on the
+work of the Khronos Group."
+
+THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+*/
+
+#include <assert.h>
+#include <stdlib.h>
+#include "etc2types.h"
+
+#define CC_ETC2_DECODE_USE_THREAD   (1)     // 1 : CPU decode by thread
+#if CC_ETC2_DECODE_USE_THREAD
+#include <vector>
+#include <future>
+#endif
+
+typedef unsigned int uint;
+typedef unsigned char uint8;
+
+extern void decompressBlockETC2c(uint block_part1, uint block_part2, uint8* img,
+								 int width, int height, int startx, int starty, int channels);
+extern void decompressBlockETC21BitAlphaC(uint block_part1, uint block_part2, uint8* img, uint8* alphaimg,
+										  int width, int height, int startx, int starty, int channels);
+extern void decompressBlockAlphaC(uint8* data, uint8* img, int width, int height, int ix, int iy, int channels);
+extern void decompressBlockAlpha16bitC(uint8* data, uint8* img, int width, int height, int ix, int iy, int channels);
+
+extern void setupAlphaTable();
+
+extern ETC2_error_code
+_unpackETC(const GLubyte* __restrict srcETC, const GLenum srcFormat,
+			  etc2_uint32_t activeWidth, etc2_uint32_t activeHeight,
+			  GLubyte** __restrict dstImage,
+			  GLenum* __restrict format, GLenum* __restrict internalFormat, GLenum* __restrict type,
+			  GLint R16Formats, GLboolean supportsSRGB);
+
+// This global variable affects the behaviour of decompressBlockAlpha16bitC.
+extern int formatSigned;
+
+static void
+readBigEndian4byteWord(uint32_t* __restrict pBlock, const GLubyte* __restrict s)
+{
+	*pBlock = (s[0] << 24) | (s[1] << 16) | (s[2] << 8) | s[3];
+}
+
+
+/* Unpack an ETC1_RGB8_OES format compressed texture */
+ETC2_error_code
+_unpackETC(const GLubyte* __restrict srcETC, const GLenum srcFormat,
+			  etc2_uint32_t activeWidth, etc2_uint32_t activeHeight,
+			  GLubyte** __restrict dstImage,
+			  GLenum* __restrict format, GLenum* __restrict internalFormat, GLenum* __restrict type,
+			  GLint R16Formats, GLboolean supportsSRGB)
+{
+	unsigned int width, height;
+#if !CC_ETC2_DECODE_USE_THREAD
+	unsigned int block_part1, block_part2;
+#endif
+	unsigned int x, y;
+	/*const*/ GLubyte* src = (GLubyte*)srcETC;
+	// AF_11BIT is used to compress R11 & RG11 though its not alpha data.
+	enum {AF_NONE, AF_1BIT, AF_8BIT, AF_11BIT} alphaFormat = AF_NONE;
+	int dstChannels, dstChannelBytes;
+
+	switch (srcFormat) {
+	  case GL_COMPRESSED_SIGNED_R11_EAC:
+		if (R16Formats & ETC2_R16_FORMATS_SNORM) {
+			dstChannelBytes = sizeof(GLshort);
+			dstChannels = 1;
+			formatSigned = GL_TRUE;
+			*internalFormat = GL_R16_SNORM;
+			*format = GL_RED;
+			*type = GL_SHORT;
+			alphaFormat = AF_11BIT;
+		} else
+			return ETC2_UNSUPPORTED_TEXTURE_TYPE; 
+		break;
+
+	  case GL_COMPRESSED_R11_EAC:
+		if (R16Formats & ETC2_R16_FORMATS_NORM) {
+			dstChannelBytes = sizeof(GLshort);
+			dstChannels = 1;
+			formatSigned = GL_FALSE;
+			*internalFormat = GL_R16;
+			*format = GL_RED;
+			*type = GL_UNSIGNED_SHORT;
+			alphaFormat = AF_11BIT;
+		} else
+			return ETC2_UNSUPPORTED_TEXTURE_TYPE; 
+        break;
+
+	  case GL_COMPRESSED_SIGNED_RG11_EAC:
+		if (R16Formats & ETC2_R16_FORMATS_SNORM) {
+			dstChannelBytes = sizeof(GLshort);
+			dstChannels = 2;
+			formatSigned = GL_TRUE;
+			*internalFormat = GL_RG16_SNORM;
+			*format = GL_RG;
+			*type = GL_SHORT;
+			alphaFormat = AF_11BIT;
+		} else
+			return ETC2_UNSUPPORTED_TEXTURE_TYPE; 
+        break;
+
+	  case GL_COMPRESSED_RG11_EAC:
+		if (R16Formats & ETC2_R16_FORMATS_NORM) {
+			dstChannelBytes = sizeof(GLshort);
+			dstChannels = 2;
+			formatSigned = GL_FALSE;
+			*internalFormat = GL_RG16;
+			*format = GL_RG;
+			*type = GL_UNSIGNED_SHORT;
+			alphaFormat = AF_11BIT;
+		} else
+			return ETC2_UNSUPPORTED_TEXTURE_TYPE; 
+        break;
+
+	  case GL_ETC1_RGB8_OES:
+	  case GL_COMPRESSED_RGB8_ETC2:
+	    dstChannelBytes = sizeof(GLubyte);
+		dstChannels = 3;
+		*internalFormat = GL_RGB8;
+		*format = GL_RGB;
+		*type = GL_UNSIGNED_BYTE;
+        break;
+
+	  case GL_COMPRESSED_RGBA8_ETC2_EAC:
+	    dstChannelBytes = sizeof(GLubyte);
+		dstChannels = 4;
+		*internalFormat = GL_RGBA8;
+		*format = GL_RGBA;
+		*type = GL_UNSIGNED_BYTE;
+	    alphaFormat = AF_8BIT;
+		break;
+
+	  case GL_COMPRESSED_RGB8_PUNCHTHROUGH_ALPHA1_ETC2:
+	    dstChannelBytes = sizeof(GLubyte);
+		dstChannels = 4;
+		*internalFormat = GL_RGBA8;
+		*format = GL_RGBA;
+		*type = GL_UNSIGNED_BYTE;
+		alphaFormat = AF_1BIT;
+        break;
+
+	  case GL_COMPRESSED_SRGB8_ETC2:
+		if (supportsSRGB) {
+			dstChannelBytes = sizeof(GLubyte);
+			dstChannels = 3;
+			*internalFormat = GL_SRGB8;
+			*format = GL_RGB;
+			*type = GL_UNSIGNED_BYTE;
+		} else
+			return ETC2_UNSUPPORTED_TEXTURE_TYPE; 
+        break;
+
+	  case GL_COMPRESSED_SRGB8_ALPHA8_ETC2_EAC:
+		if (supportsSRGB) {
+			dstChannelBytes = sizeof(GLubyte);
+			dstChannels = 4;
+			*internalFormat = GL_SRGB8_ALPHA8;
+ 			*format = GL_RGBA;
+			*type = GL_UNSIGNED_BYTE;
+			alphaFormat = AF_8BIT;
+		} else
+			return ETC2_UNSUPPORTED_TEXTURE_TYPE; 
+		break;
+
+	  case GL_COMPRESSED_SRGB8_PUNCHTHROUGH_ALPHA1_ETC2:
+		if (supportsSRGB) {
+			dstChannelBytes = sizeof(GLubyte);
+			dstChannels = 4;
+			*internalFormat = GL_SRGB8_ALPHA8;
+ 			*format = GL_RGBA;
+			*type = GL_UNSIGNED_BYTE;
+			alphaFormat = AF_1BIT;
+		} else
+			return ETC2_UNSUPPORTED_TEXTURE_TYPE; 
+        break;
+
+	  default:
+	    assert(0); // Upper levels should be passing only one of the above srcFormats.
+	}
+
+    /* active_{width,height} show how many pixels contain active data,
+	 * (the rest are just for making sure we have a 2*a x 4*b size).
+	 */
+
+	/* Compute the full width & height. */
+	width = ((activeWidth+3)/4)*4;
+	height = ((activeHeight+3)/4)*4;
+
+	/* printf("Width = %d, Height = %d\n", width, height); */
+	/* printf("active pixel area: top left %d x %d area.\n", activeWidth, activeHeight); */
+
+    *dstImage = new GLubyte[dstChannels*dstChannelBytes*width*height];
+    if (!*dstImage) {
+        return ETC2_OUT_OF_MEMORY;
+    }
+    
+    if (alphaFormat != AF_NONE)
+        setupAlphaTable();
+
+    // NOTE: none of the decompress functions actually use the <height> parameter
+    switch (alphaFormat)
+    {
+        case AF_11BIT:
+        {
+            // One or two 11-bit alpha channels for R or RG.
+            for (y=0; y < height/4; y++) {
+                for (x=0; x < width/4; x++) {
+                    decompressBlockAlpha16bitC(src, *dstImage, width, height, 4*x, 4*y, dstChannels);
+                    src += 8;
+                    if (srcFormat == GL_COMPRESSED_RG11_EAC || srcFormat == GL_COMPRESSED_SIGNED_RG11_EAC) {
+                        decompressBlockAlpha16bitC(src, *dstImage + dstChannelBytes, width, height, 4*x, 4*y, dstChannels);
+                        src += 8;
+                    }
+                }
+            }
+        }
+        break;
+        case AF_8BIT:
+        {
+#if !CC_ETC2_DECODE_USE_THREAD
+            for (y=0; y < height/4; y++) {
+                for (x=0; x < width/4; x++) {
+                    // Decode alpha channel for RGBA
+                    decompressBlockAlphaC(src, *dstImage + 3, width, height, 4*x, 4*y, dstChannels);
+                    src += 8;
+                    // Decode color dstChannels
+                    readBigEndian4byteWord(&block_part1, src);
+                    src += 4;
+                    readBigEndian4byteWord(&block_part2, src);
+                    src += 4;
+                    decompressBlockETC2c(block_part1, block_part2, *dstImage, width, height, 4*x, 4*y, dstChannels);
+                }
+            }
+#else
+            std::vector<std::thread> threads;
+            std::function<void(unsigned int, unsigned int)> decodeFunction = [src, dstImage, width, height, dstChannels](unsigned int start_y, unsigned int end_y)
+            {
+                auto srcth = src + start_y * (16*width/4);
+                for (unsigned int ty=start_y; ty < end_y; ty++)
+                {
+                    unsigned int th_block_part1, th_block_part2;
+                    for (unsigned int tx=0; tx < width/4; tx++) {
+                        // Decode alpha channel for RGBA
+                        decompressBlockAlphaC(srcth, *dstImage + 3, width, height, 4*tx, 4*ty, dstChannels);
+                        srcth += 8;
+                        // Decode color dstChannels
+                        readBigEndian4byteWord(&th_block_part1, srcth);
+                        srcth += 4;
+                        readBigEndian4byteWord(&th_block_part2, srcth);
+                        srcth += 4;
+                        decompressBlockETC2c(th_block_part1, th_block_part2, *dstImage, width, height, 4*tx, 4*ty, dstChannels);
+                    }
+                }
+            };
+            threads.push_back(std::thread(decodeFunction, 0, height/16));
+            threads.push_back(std::thread(decodeFunction, height/16, height/12));
+            threads.push_back(std::thread(decodeFunction, height/12, height/8));
+            threads.push_back(std::thread(decodeFunction, height/8, height/4));
+            for (std::thread &th : threads)
+            {
+                th.join();
+            }
+#endif
+        }
+        break;
+        case AF_1BIT:
+        {
+#if !CC_ETC2_DECODE_USE_THREAD
+            for (y=0; y < height/4; y++) {
+                for (x=0; x < width/4; x++) {
+                    // Decode color dstChannels
+                    readBigEndian4byteWord(&block_part1, src);
+                    src += 4;
+                    readBigEndian4byteWord(&block_part2, src);
+                    src += 4;
+                    decompressBlockETC21BitAlphaC(block_part1, block_part2, *dstImage, 0, width, height, 4*x, 4*y, dstChannels);
+                }
+            }
+#else
+            std::vector<std::thread> threads;
+            std::function<void(unsigned int, unsigned int)> decodeFunction = [src, dstImage, width, height, dstChannels](unsigned int start_y, unsigned int end_y)
+            {
+                auto srcth = src + start_y * (8*width/4);
+                for (unsigned int ty=start_y; ty < end_y; ty++)
+                {
+                    unsigned int th_block_part1, th_block_part2;
+                    for (unsigned int tx=0; tx < width/4; tx++)
+                    {
+                        // Decode color dstChannels
+                        readBigEndian4byteWord(&th_block_part1, srcth);
+                        srcth += 4;
+                        readBigEndian4byteWord(&th_block_part2, srcth);
+                        srcth += 4;
+                        decompressBlockETC21BitAlphaC(th_block_part1, th_block_part2, *dstImage, 0, width, height, 4*tx, 4*ty, dstChannels);
+                    }
+                }
+            };
+            threads.push_back(std::thread(decodeFunction, 0, height/16));
+            threads.push_back(std::thread(decodeFunction, height/16, height/12));
+            threads.push_back(std::thread(decodeFunction, height/12, height/8));
+            threads.push_back(std::thread(decodeFunction, height/8, height/4));
+            for (std::thread &th : threads)
+            {
+                th.join();
+            }
+#endif
+        }
+        break;
+        default:
+        {
+#if !CC_ETC2_DECODE_USE_THREAD
+            for (y=0; y < height/4; y++) {
+                for (x=0; x < width/4; x++) {
+                    // Decode color dstChannels
+                    readBigEndian4byteWord(&block_part1, src);
+                    src += 4;
+                    readBigEndian4byteWord(&block_part2, src);
+                    src += 4;
+                    decompressBlockETC2c(block_part1, block_part2, *dstImage, width, height, 4*x, 4*y, dstChannels);
+                }
+            }
+#else
+            std::vector<std::thread> threads;
+            std::function<void(unsigned int, unsigned int)> decodeFunction = [src, dstImage, width, height, dstChannels](unsigned int start_y, unsigned int end_y)
+            {
+                auto srcth = src + start_y * (8*width/4);
+                for (unsigned int ty=start_y; ty < end_y; ty++)
+                {
+                    unsigned int th_block_part1, th_block_part2;
+                    for (unsigned int tx=0; tx < width/4; tx++)
+                    {
+                        // Decode color dstChannels
+                        readBigEndian4byteWord(&th_block_part1, srcth);
+                        srcth += 4;
+                        readBigEndian4byteWord(&th_block_part2, srcth);
+                        srcth += 4;
+                        decompressBlockETC2c(th_block_part1, th_block_part2, *dstImage, width, height, 4*tx, 4*ty, dstChannels);
+                    }
+                }
+            };
+            threads.push_back(std::thread(decodeFunction, 0, height/16));
+            threads.push_back(std::thread(decodeFunction, height/16, height/12));
+            threads.push_back(std::thread(decodeFunction, height/12, height/8));
+            threads.push_back(std::thread(decodeFunction, height/8, height/4));
+            for (std::thread &th : threads)
+            {
+                th.join();
+            }
+#endif
+        }
+        break;
+    }
+
+	/* Ok, now write out the active pixels to the destination image.
+	 * (But only if the active pixels differ from the total pixels)
+	 */
+
+	if( !(height == activeHeight && width == activeWidth) ) {
+		int dstPixelBytes = dstChannels * dstChannelBytes;
+		int dstRowBytes = dstPixelBytes * width;
+		int activeRowBytes = activeWidth * dstPixelBytes;
+		GLubyte *newimg = (GLubyte*)malloc(dstPixelBytes * activeWidth * activeHeight);
+		unsigned int xx, yy;
+		int zz;
+
+		if (!newimg) {
+			free(*dstImage);
+			return ETC2_OUT_OF_MEMORY;
+		}
+		
+		/* Convert from total area to active area: */
+
+		for (yy = 0; yy < activeHeight; yy++) {
+			for (xx = 0; xx < activeWidth; xx++) {
+				for (zz = 0; zz < dstPixelBytes; zz++) {
+					newimg[ yy*activeRowBytes + xx*dstPixelBytes + zz ] = (*dstImage)[ yy*dstRowBytes + xx*dstPixelBytes + zz];
+				}
+			}
+		}
+
+		free(*dstImage);
+		*dstImage = newimg;
+	}
+
+	return ETC2_SUCCESS;
+}
+

--- a/cocos/base/etcdec.cxx
+++ b/cocos/base/etcdec.cxx
@@ -1,0 +1,1842 @@
+/**
+ 
+@~English
+@page licensing Licensing
+ 
+@section etcdec etcdec.cxx License
+ 
+etcdec.cxx is made available under the terms and conditions of the following
+License Agreement.
+
+Software License Agreement
+
+PLEASE REVIEW THE FOLLOWING TERMS AND CONDITIONS PRIOR TO USING THE
+ERICSSON TEXTURE COMPRESSION CODEC SOFTWARE (THE "SOFTWARE"). THE USE
+OF THE SOFTWARE IS SUBJECT TO THE TERMS AND CONDITIONS OF THE
+FOLLOWING SOFTWARE LICENSE AGREEMENT (THE "SLA"). IF YOU DO NOT ACCEPT
+SUCH TERMS AND CONDITIONS YOU MAY NOT USE THE SOFTWARE.
+
+Subject to the terms and conditions of the SLA, the licensee of the
+Software (the "Licensee") hereby, receives a non-exclusive,
+non-transferable, limited, free-of-charge, perpetual and worldwide
+license, to copy, use, distribute and modify the Software, but only
+for the purpose of developing, manufacturing, selling, using and
+distributing products including the Software in binary form, which
+products are used for compression and/or decompression according to
+the Khronos standard specifications OpenGL, OpenGL ES and
+WebGL. Notwithstanding anything of the above, Licensee may distribute
+[etcdec.cxx] in source code form provided (i) it is in unmodified
+form; and (ii) it is included in software owned by Licensee.
+
+If Licensee institutes, or threatens to institute, patent litigation
+against Ericsson or Ericsson's affiliates for using the Software for
+developing, having developed, manufacturing, having manufactured,
+selling, offer for sale, importing, using, leasing, operating,
+repairing and/or distributing products (i) within the scope of the
+Khronos framework; or (ii) using software or other intellectual
+property rights owned by Ericsson or its affiliates and provided under
+the Khronos framework, Ericsson shall have the right to terminate this
+SLA with immediate effect. Moreover, if Licensee institutes, or
+threatens to institute, patent litigation against any other licensee
+of the Software for using the Software in products within the scope of
+the Khronos framework, Ericsson shall have the right to terminate this
+SLA with immediate effect. However, should Licensee institute, or
+threaten to institute, patent litigation against any other licensee of
+the Software based on such other licensee's use of any other software
+together with the Software, then Ericsson shall have no right to
+terminate this SLA.
+
+This SLA does not transfer to Licensee any ownership to any Ericsson
+or third party intellectual property rights. All rights not expressly
+granted by Ericsson under this SLA are hereby expressly
+reserved. Furthermore, nothing in this SLA shall be construed as a
+right to use or sell products in a manner which conveys or purports to
+convey whether explicitly, by principles of implied license, or
+otherwise, any rights to any third party, under any patent of Ericsson
+or of Ericsson's affiliates covering or relating to any combination of
+the Software with any other software or product (not licensed
+hereunder) where the right applies specifically to the combination and
+not to the software or product itself.
+
+THE SOFTWARE IS PROVIDED "AS IS". ERICSSON MAKES NO REPRESENTATIONS OF
+ANY KIND, EXTENDS NO WARRANTIES OR CONDITIONS OF ANY KIND, EITHER
+EXPRESS, IMPLIED OR STATUTORY; INCLUDING, BUT NOT LIMITED TO, EXPRESS,
+IMPLIED OR STATUTORY WARRANTIES OR CONDITIONS OF TITLE,
+MERCHANTABILITY, SATISFACTORY QUALITY, SUITABILITY, AND FITNESS FOR A
+PARTICULAR PURPOSE. THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE
+OF THE SOFTWARE IS WITH THE LICENSEE. SHOULD THE SOFTWARE PROVE
+DEFECTIVE, THE LICENSEE ASSUMES THE COST OF ALL NECESSARY SERVICING,
+REPAIR OR CORRECTION. ERICSSON MAKES NO WARRANTY THAT THE MANUFACTURE,
+SALE, OFFERING FOR SALE, DISTRIBUTION, LEASE, USE OR IMPORTATION UNDER
+THE SLA WILL BE FREE FROM INFRINGEMENT OF PATENTS, COPYRIGHTS OR OTHER
+INTELLECTUAL PROPERTY RIGHTS OF OTHERS, AND THE VALIDITY OF THE
+LICENSE AND THE SLA ARE SUBJECT TO LICENSEE'S SOLE RESPONSIBILITY TO
+MAKE SUCH DETERMINATION AND ACQUIRE SUCH LICENSES AS MAY BE NECESSARY
+WITH RESPECT TO PATENTS, COPYRIGHT AND OTHER INTELLECTUAL PROPERTY OF
+THIRD PARTIES.
+
+THE LICENSEE ACKNOWLEDGES AND ACCEPTS THAT THE SOFTWARE (I) IS NOT
+LICENSED FOR; (II) IS NOT DESIGNED FOR OR INTENDED FOR; AND (III) MAY
+NOT BE USED FOR; ANY MISSION CRITICAL APPLICATIONS SUCH AS, BUT NOT
+LIMITED TO OPERATION OF NUCLEAR OR HEALTHCARE COMPUTER SYSTEMS AND/OR
+NETWORKS, AIRCRAFT OR TRAIN CONTROL AND/OR COMMUNICATION SYSTEMS OR
+ANY OTHER COMPUTER SYSTEMS AND/OR NETWORKS OR CONTROL AND/OR
+COMMUNICATION SYSTEMS ALL IN WHICH CASE THE FAILURE OF THE SOFTWARE
+COULD LEAD TO DEATH, PERSONAL INJURY, OR SEVERE PHYSICAL, MATERIAL OR
+ENVIRONMENTAL DAMAGE. LICENSEE'S RIGHTS UNDER THIS LICENSE WILL
+TERMINATE AUTOMATICALLY AND IMMEDIATELY WITHOUT NOTICE IF LICENSEE
+FAILS TO COMPLY WITH THIS PARAGRAPH.
+
+IN NO EVENT SHALL ERICSSON BE LIABLE FOR ANY DAMAGES WHATSOEVER,
+INCLUDING BUT NOT LIMITED TO PERSONAL INJURY, ANY GENERAL, SPECIAL,
+INDIRECT, INCIDENTAL OR CONSEQUENTIAL DAMAGES, ARISING OUT OF OR IN
+CONNECTION WITH THE USE OR INABILITY TO USE THE SOFTWARE (INCLUDING
+BUT NOT LIMITED TO LOSS OF PROFITS, BUSINESS INTERUPTIONS, OR ANY
+OTHER COMMERCIAL DAMAGES OR LOSSES, LOSS OF DATA OR DATA BEING
+RENDERED INACCURATE OR LOSSES SUSTAINED BY THE LICENSEE OR THIRD
+PARTIES OR A FAILURE OF THE SOFTWARE TO OPERATE WITH ANY OTHER
+SOFTWARE) REGARDLESS OF THE THEORY OF LIABILITY (CONTRACT, TORT, OR
+OTHERWISE), EVEN IF THE LICENSEE OR ANY OTHER PARTY HAS BEEN ADVISED
+OF THE POSSIBILITY OF SUCH DAMAGES.
+
+Licensee acknowledges that "ERICSSON ///" is the corporate trademark
+of Telefonaktiebolaget LM Ericsson and that both "Ericsson" and the
+figure "///" are important features of the trade names of
+Telefonaktiebolaget LM Ericsson. Nothing contained in these terms and
+conditions shall be deemed to grant Licensee any right, title or
+interest in the word "Ericsson" or the figure "///". No delay or
+omission by Ericsson to exercise any right or power shall impair any
+such right or power to be construed to be a waiver thereof. Consent by
+Ericsson to, or waiver of, a breach by the Licensee shall not
+constitute consent to, waiver of, or excuse for any other different or
+subsequent breach.
+
+This SLA shall be governed by the substantive law of Sweden. Any
+dispute, controversy or claim arising out of or in connection with
+this SLA, or the breach, termination or invalidity thereof, shall be
+submitted to the exclusive jurisdiction of the Swedish Courts.
+
+*/
+
+//// etcpack v2.74
+//// 
+//// NO WARRANTY 
+//// 
+//// BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE THE PROGRAM IS PROVIDED
+//// "AS IS". ERICSSON MAKES NO REPRESENTATIONS OF ANY KIND, EXTENDS NO
+//// WARRANTIES OR CONDITIONS OF ANY KIND; EITHER EXPRESS, IMPLIED OR
+//// STATUTORY; INCLUDING, BUT NOT LIMITED TO, EXPRESS, IMPLIED OR
+//// STATUTORY WARRANTIES OR CONDITIONS OF TITLE, MERCHANTABILITY,
+//// SATISFACTORY QUALITY, SUITABILITY AND FITNESS FOR A PARTICULAR
+//// PURPOSE. THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE
+//// PROGRAM IS WITH YOU. SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME
+//// THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION. ERICSSON
+//// MAKES NO WARRANTY THAT THE MANUFACTURE, SALE, OFFERING FOR SALE,
+//// DISTRIBUTION, LEASE, USE OR IMPORTATION UNDER THE LICENSE WILL BE FREE
+//// FROM INFRINGEMENT OF PATENTS, COPYRIGHTS OR OTHER INTELLECTUAL
+//// PROPERTY RIGHTS OF OTHERS, AND THE VALIDITY OF THE LICENSE IS SUBJECT
+//// TO YOUR SOLE RESPONSIBILITY TO MAKE SUCH DETERMINATION AND ACQUIRE
+//// SUCH LICENSES AS MAY BE NECESSARY WITH RESPECT TO PATENTS, COPYRIGHT
+//// AND OTHER INTELLECTUAL PROPERTY OF THIRD PARTIES.
+//// 
+//// FOR THE AVOIDANCE OF DOUBT THE PROGRAM (I) IS NOT LICENSED FOR; (II)
+//// IS NOT DESIGNED FOR OR INTENDED FOR; AND (III) MAY NOT BE USED FOR;
+//// ANY MISSION CRITICAL APPLICATIONS SUCH AS, BUT NOT LIMITED TO
+//// OPERATION OF NUCLEAR OR HEALTHCARE COMPUTER SYSTEMS AND/OR NETWORKS,
+//// AIRCRAFT OR TRAIN CONTROL AND/OR COMMUNICATION SYSTEMS OR ANY OTHER
+//// COMPUTER SYSTEMS AND/OR NETWORKS OR CONTROL AND/OR COMMUNICATION
+//// SYSTEMS ALL IN WHICH CASE THE FAILURE OF THE PROGRAM COULD LEAD TO
+//// DEATH, PERSONAL INJURY, OR SEVERE PHYSICAL, MATERIAL OR ENVIRONMENTAL
+//// DAMAGE. YOUR RIGHTS UNDER THIS LICENSE WILL TERMINATE AUTOMATICALLY
+//// AND IMMEDIATELY WITHOUT NOTICE IF YOU FAIL TO COMPLY WITH THIS
+//// PARAGRAPH.
+//// 
+//// IN NO EVENT WILL ERICSSON, BE LIABLE FOR ANY DAMAGES WHATSOEVER,
+//// INCLUDING BUT NOT LIMITED TO PERSONAL INJURY, ANY GENERAL, SPECIAL,
+//// INDIRECT, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF OR IN
+//// CONNECTION WITH THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT
+//// NOT LIMITED TO LOSS OF PROFITS, BUSINESS INTERUPTIONS, OR ANY OTHER
+//// COMMERCIAL DAMAGES OR LOSSES, LOSS OF DATA OR DATA BEING RENDERED
+//// INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A FAILURE OF
+//// THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS) REGARDLESS OF THE
+//// THEORY OF LIABILITY (CONTRACT, TORT OR OTHERWISE), EVEN IF SUCH HOLDER
+//// OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+//// 
+//// (C) Ericsson AB 2013. All Rights Reserved.
+//// 
+
+#include <stdio.h>
+#include <stdlib.h>
+
+// Typedefs
+typedef unsigned char uint8;
+typedef unsigned short uint16;
+typedef short int16;
+
+// Macros to help with bit extraction/insertion
+#define SHIFT(size,startpos) ((startpos)-(size)+1)
+#define MASK(size, startpos) (((2<<(size-1))-1) << SHIFT(size,startpos))
+#define PUTBITS( dest, data, size, startpos) dest = ((dest & ~MASK(size, startpos)) | ((data << SHIFT(size, startpos)) & MASK(size,startpos)))
+#define SHIFTHIGH(size, startpos) (((startpos)-32)-(size)+1)
+#define MASKHIGH(size, startpos) (((1<<(size))-1) << SHIFTHIGH(size,startpos))
+#define PUTBITSHIGH(dest, data, size, startpos) dest = ((dest & ~MASKHIGH(size, startpos)) | ((data << SHIFTHIGH(size, startpos)) & MASKHIGH(size,startpos)))
+#define GETBITS(source, size, startpos)  (( (source) >> ((startpos)-(size)+1) ) & ((1<<(size)) -1))
+#define GETBITSHIGH(source, size, startpos)  (( (source) >> (((startpos)-32)-(size)+1) ) & ((1<<(size)) -1))
+#ifndef PGMOUT
+#define PGMOUT 0
+#endif
+// Thumb macros and definitions
+#define	R_BITS59T 4
+#define G_BITS59T 4
+#define	B_BITS59T 4
+#define	R_BITS58H 4
+#define G_BITS58H 4
+#define	B_BITS58H 4
+#define	MAXIMUM_ERROR (255*255*16*1000)
+#define R 0
+#define G 1
+#define B 2
+#define BLOCKHEIGHT 4
+#define BLOCKWIDTH 4
+#define BINPOW(power) (1<<(power))
+#define	TABLE_BITS_59T 3
+#define	TABLE_BITS_58H 3
+
+// Helper Macros
+#define CLAMP(ll,x,ul) (((x)<(ll)) ? (ll) : (((x)>(ul)) ? (ul) : (x)))
+#define JAS_ROUND(x) (((x) < 0.0 ) ? ((int)((x)-0.5)) : ((int)((x)+0.5)))
+
+#define RED_CHANNEL(img,width,x,y,channels)   img[channels*(y*width+x)+0]
+#define GREEN_CHANNEL(img,width,x,y,channels) img[channels*(y*width+x)+1]
+#define BLUE_CHANNEL(img,width,x,y,channels)  img[channels*(y*width+x)+2]
+#define ALPHA_CHANNEL(img,width,x,y,channels)  img[channels*(y*width+x)+3]
+
+
+// Global tables
+static uint8 table59T[8] = {3,6,11,16,23,32,41,64};  // 3-bit table for the 59 bit T-mode
+static uint8 table58H[8] = {3,6,11,16,23,32,41,64};  // 3-bit table for the 58 bit H-mode
+static int compressParams[16][4] = {{-8, -2,  2, 8}, {-8, -2,  2, 8}, {-17, -5, 5, 17}, {-17, -5, 5, 17}, {-29, -9, 9, 29}, {-29, -9, 9, 29}, {-42, -13, 13, 42}, {-42, -13, 13, 42}, {-60, -18, 18, 60}, {-60, -18, 18, 60}, {-80, -24, 24, 80}, {-80, -24, 24, 80}, {-106, -33, 33, 106}, {-106, -33, 33, 106}, {-183, -47, 47, 183}, {-183, -47, 47, 183}};
+static int unscramble[4] = {2, 3, 1, 0};
+int alphaTableInitialized = 0;
+int alphaTable[256][8];
+int alphaBase[16][4] = {	
+              {-15,-9,-6,-3},
+							{-13,-10,-7,-3},
+							{-13,-8,-5,-2},
+							{-13,-6,-4,-2},
+							{-12,-8,-6,-3},
+							{-11,-9,-7,-3},
+							{-11,-8,-7,-4},
+							{-11,-8,-5,-3},
+							{ -10,-8,-6,-2},
+							{ -10,-8,-5,-2},
+							{ -10,-8,-4,-2},
+							{ -10,-7,-5,-2},
+							{ -10,-7,-4,-3},
+							{ -10,-3,-2, -1},
+							{ -9,-8,-6,-4},
+							{ -9,-7,-5,-3}
+											};
+
+// Global variables
+int formatSigned = 0;
+
+// Enums
+ enum{PATTERN_H = 0, 
+      PATTERN_T = 1};
+
+
+// Code used to create the valtab
+// NO WARRANTY --- SEE STATEMENT IN TOP OF FILE (C) Ericsson AB 2013. All Rights Reserved.
+void setupAlphaTable() 
+{
+  if(alphaTableInitialized)
+    return;
+  alphaTableInitialized = 1;
+
+	//read table used for alpha compression
+	int buf;
+	for(int i = 16; i<32; i++) 
+	{
+		for(int j=0; j<8; j++) 
+		{
+			buf=alphaBase[i-16][3-j%4];
+			if(j<4)
+				alphaTable[i][j]=buf;
+			else
+				alphaTable[i][j]=(-buf-1);
+		}
+	}
+	
+	//beyond the first 16 values, the rest of the table is implicit.. so calculate that!
+	for(int i=0; i<256; i++) 
+	{
+		//fill remaining slots in table with multiples of the first ones.
+		int mul = i/16;
+		int old = 16+i%16;
+		for(int j = 0; j<8; j++) 
+		{
+			alphaTable[i][j]=alphaTable[old][j]*mul;
+			//note: we don't do clamping here, though we could, because we'll be clamped afterwards anyway.
+		}
+	}
+}
+
+// Read a word in big endian style
+// NO WARRANTY --- SEE STATEMENT IN TOP OF FILE (C) Ericsson AB 2013. All Rights Reserved.
+void read_big_endian_2byte_word(unsigned short *blockadr, FILE *f)
+{
+	uint8 bytes[2];
+	unsigned short block;
+
+	(void) fread(&bytes[0], 1, 1, f);
+	(void) fread(&bytes[1], 1, 1, f);
+
+	block = 0;
+	block |= bytes[0];
+	block = block << 8;
+	block |= bytes[1];
+
+	blockadr[0] = block;
+}
+
+// Read a word in big endian style
+// NO WARRANTY --- SEE STATEMENT IN TOP OF FILE (C) Ericsson AB 2013. All Rights Reserved.
+void read_big_endian_4byte_word(unsigned int *blockadr, FILE *f)
+{
+	uint8 bytes[4];
+	unsigned int block;
+
+	(void) fread(&bytes[0], 1, 1, f);
+	(void) fread(&bytes[1], 1, 1, f);
+	(void) fread(&bytes[2], 1, 1, f);
+	(void) fread(&bytes[3], 1, 1, f);
+
+	block = 0;
+	block |= bytes[0];
+	block = block << 8;
+	block |= bytes[1];
+	block = block << 8;
+	block |= bytes[2];
+	block = block << 8;
+	block |= bytes[3];
+
+	blockadr[0] = block;
+}
+
+// The format stores the bits for the three extra modes in a roundabout way to be able to
+// fit them without increasing the bit rate. This function converts them into something
+// that is easier to work with. 
+// NO WARRANTY --- SEE STATEMENT IN TOP OF FILE (C) Ericsson AB 2013. All Rights Reserved.
+void unstuff57bits(unsigned int planar_word1, unsigned int planar_word2, unsigned int &planar57_word1, unsigned int &planar57_word2)
+{
+	// Get bits from twotimer configuration for 57 bits
+	// 
+	// Go to this bit layout:
+	//
+	//      63 62 61 60 59 58 57 56 55 54 53 52 51 50 49 48 47 46 45 44 43 42 41 40 39 38 37 36 35 34 33 32 
+	//      -----------------------------------------------------------------------------------------------
+	//     |R0               |G01G02              |B01B02  ;B03     |RH1           |RH2|GH                 |
+	//      -----------------------------------------------------------------------------------------------
+	//
+	//      31 30 29 28 27 26 25 24 23 22 21 20 19 18 17 16 15 14 13 12 11 10  9  8  7  6  5  4  3  2  1  0
+	//      -----------------------------------------------------------------------------------------------
+	//     |BH               |RV               |GV                  |BV                | not used          |   
+	//      -----------------------------------------------------------------------------------------------
+	//
+	//  From this:
+	// 
+	//      63 62 61 60 59 58 57 56 55 54 53 52 51 50 49 48 47 46 45 44 43 42 41 40 39 38 37 36 35 34 33 32 
+	//      ------------------------------------------------------------------------------------------------
+	//     |//|R0               |G01|/|G02              |B01|/ // //|B02  |//|B03     |RH1           |df|RH2|
+	//      ------------------------------------------------------------------------------------------------
+	//
+	//      31 30 29 28 27 26 25 24 23 22 21 20 19 18 17 16 15 14 13 12 11 10  9  8  7  6  5  4  3  2  1  0
+	//      -----------------------------------------------------------------------------------------------
+	//     |GH                  |BH               |RV               |GV                   |BV              |
+	//      -----------------------------------------------------------------------------------------------
+	//
+	//      63 62 61 60 59 58 57 56 55 54 53 52 51 50 49 48 47 46 45 44 43 42 41 40 39 38 37 36 35 34  33  32 
+	//      ---------------------------------------------------------------------------------------------------
+	//     | base col1    | dcol 2 | base col1    | dcol 2 | base col 1   | dcol 2 | table  | table  |diff|flip|
+	//     | R1' (5 bits) | dR2    | G1' (5 bits) | dG2    | B1' (5 bits) | dB2    | cw 1   | cw 2   |bit |bit |
+	//      ---------------------------------------------------------------------------------------------------
+
+	uint8 RO, GO1, GO2, BO1, BO2, BO3, RH1, RH2, GH, BH, RV, GV, BV;
+
+	RO  = GETBITSHIGH( planar_word1, 6, 62);
+	GO1 = GETBITSHIGH( planar_word1, 1, 56);
+	GO2 = GETBITSHIGH( planar_word1, 6, 54);
+	BO1 = GETBITSHIGH( planar_word1, 1, 48);
+	BO2 = GETBITSHIGH( planar_word1, 2, 44);
+	BO3 = GETBITSHIGH( planar_word1, 3, 41);
+	RH1 = GETBITSHIGH( planar_word1, 5, 38);
+	RH2 = GETBITSHIGH( planar_word1, 1, 32);
+	GH  = GETBITS(     planar_word2, 7, 31);
+	BH  = GETBITS(     planar_word2, 6, 24);
+	RV  = GETBITS(     planar_word2, 6, 18);
+	GV  = GETBITS(     planar_word2, 7, 12);
+	BV  = GETBITS(     planar_word2, 6,  5);
+
+	planar57_word1 = 0; planar57_word2 = 0;
+	PUTBITSHIGH( planar57_word1, RO,  6, 63);
+	PUTBITSHIGH( planar57_word1, GO1, 1, 57);
+	PUTBITSHIGH( planar57_word1, GO2, 6, 56);
+	PUTBITSHIGH( planar57_word1, BO1, 1, 50);
+	PUTBITSHIGH( planar57_word1, BO2, 2, 49);
+	PUTBITSHIGH( planar57_word1, BO3, 3, 47);
+	PUTBITSHIGH( planar57_word1, RH1, 5, 44);
+	PUTBITSHIGH( planar57_word1, RH2, 1, 39);
+	PUTBITSHIGH( planar57_word1, GH, 7, 38);
+	PUTBITS(     planar57_word2, BH, 6, 31);
+	PUTBITS(     planar57_word2, RV, 6, 25);
+	PUTBITS(     planar57_word2, GV, 7, 19);
+	PUTBITS(     planar57_word2, BV, 6, 12);
+}
+
+// The format stores the bits for the three extra modes in a roundabout way to be able to
+// fit them without increasing the bit rate. This function converts them into something
+// that is easier to work with. 
+// NO WARRANTY --- SEE STATEMENT IN TOP OF FILE (C) Ericsson AB 2013. All Rights Reserved.
+void unstuff58bits(unsigned int thumbH_word1, unsigned int thumbH_word2, unsigned int &thumbH58_word1, unsigned int &thumbH58_word2)
+{
+	// Go to this layout:
+	//
+	//     |63 62 61 60 59 58|57 56 55 54 53 52 51|50 49|48 47 46 45 44 43 42 41 40 39 38 37 36 35 34 33|32   |
+	//     |-------empty-----|part0---------------|part1|part2------------------------------------------|part3|
+	//
+	//  from this:
+	// 
+	//      63 62 61 60 59 58 57 56 55 54 53 52 51 50 49 48 47 46 45 44 43 42 41 40 39 38 37 36 35 34 33 32 
+	//      --------------------------------------------------------------------------------------------------|
+	//     |//|part0               |// // //|part1|//|part2                                          |df|part3|
+	//      --------------------------------------------------------------------------------------------------|
+
+	unsigned int part0, part1, part2, part3;
+
+	// move parts
+	part0 = GETBITSHIGH( thumbH_word1, 7, 62);
+	part1 = GETBITSHIGH( thumbH_word1, 2, 52);
+	part2 = GETBITSHIGH( thumbH_word1,16, 49);
+	part3 = GETBITSHIGH( thumbH_word1, 1, 32);
+	thumbH58_word1 = 0;
+	PUTBITSHIGH( thumbH58_word1, part0,  7, 57);
+	PUTBITSHIGH( thumbH58_word1, part1,  2, 50);
+	PUTBITSHIGH( thumbH58_word1, part2, 16, 48);
+	PUTBITSHIGH( thumbH58_word1, part3,  1, 32);
+
+	thumbH58_word2 = thumbH_word2;
+}
+
+// The format stores the bits for the three extra modes in a roundabout way to be able to
+// fit them without increasing the bit rate. This function converts them into something
+// that is easier to work with. 
+// NO WARRANTY --- SEE STATEMENT IN TOP OF FILE (C) Ericsson AB 2013. All Rights Reserved.
+void unstuff59bits(unsigned int thumbT_word1, unsigned int thumbT_word2, unsigned int &thumbT59_word1, unsigned int &thumbT59_word2)
+{
+	// Get bits from twotimer configuration 59 bits. 
+	// 
+	// Go to this bit layout:
+	//
+	//     |63 62 61 60 59|58 57 56 55|54 53 52 51|50 49 48 47|46 45 44 43|42 41 40 39|38 37 36 35|34 33 32|
+	//     |----empty-----|---red 0---|--green 0--|--blue 0---|---red 1---|--green 1--|--blue 1---|--dist--|
+	//
+	//     |31 30 29 28 27 26 25 24 23 22 21 20 19 18 17 16 15 14 13 12 11 10 09 08 07 06 05 04 03 02 01 00|
+	//     |----------------------------------------index bits---------------------------------------------|
+	//
+	//
+	//  From this:
+	// 
+	//      63 62 61 60 59 58 57 56 55 54 53 52 51 50 49 48 47 46 45 44 43 42 41 40 39 38 37 36 35 34 33 32 
+	//      -----------------------------------------------------------------------------------------------
+	//     |// // //|R0a  |//|R0b  |G0         |B0         |R1         |G1         |B1          |da  |df|db|
+	//      -----------------------------------------------------------------------------------------------
+	//
+	//     |31 30 29 28 27 26 25 24 23 22 21 20 19 18 17 16 15 14 13 12 11 10 09 08 07 06 05 04 03 02 01 00|
+	//     |----------------------------------------index bits---------------------------------------------|
+	//
+	//      63 62 61 60 59 58 57 56 55 54 53 52 51 50 49 48 47 46 45 44 43 42 41 40 39 38 37 36 35 34 33 32 
+	//      -----------------------------------------------------------------------------------------------
+	//     | base col1    | dcol 2 | base col1    | dcol 2 | base col 1   | dcol 2 | table  | table  |df|fp|
+	//     | R1' (5 bits) | dR2    | G1' (5 bits) | dG2    | B1' (5 bits) | dB2    | cw 1   | cw 2   |bt|bt|
+	//      ------------------------------------------------------------------------------------------------
+
+	uint8 R0a;
+
+	// Fix middle part
+	thumbT59_word1 = thumbT_word1 >> 1;
+	// Fix db (lowest bit of d)
+	PUTBITSHIGH( thumbT59_word1, thumbT_word1,  1, 32);
+	// Fix R0a (top two bits of R0)
+	R0a = GETBITSHIGH( thumbT_word1, 2, 60);
+	PUTBITSHIGH( thumbT59_word1, R0a,  2, 58);
+
+	// Zero top part (not needed)
+	PUTBITSHIGH( thumbT59_word1, 0,  5, 63);
+
+	thumbT59_word2 = thumbT_word2;
+}
+
+// The color bits are expanded to the full color
+// NO WARRANTY --- SEE STATEMENT IN TOP OF FILE (C) Ericsson AB 2013. All Rights Reserved.
+void decompressColor(int R_B, int G_B, int B_B, uint8 (colors_RGB444)[2][3], uint8 (colors)[2][3]) 
+{
+	// The color should be retrieved as:
+	//
+	// c = round(255/(r_bits^2-1))*comp_color
+	//
+	// This is similar to bit replication
+	// 
+	// Note -- this code only work for bit replication from 4 bits and up --- 3 bits needs
+	// two copy operations.
+
+ 	colors[0][R] = (colors_RGB444[0][R] << (8 - R_B)) | (colors_RGB444[0][R] >> (R_B - (8-R_B)) );
+ 	colors[0][G] = (colors_RGB444[0][G] << (8 - G_B)) | (colors_RGB444[0][G] >> (G_B - (8-G_B)) );
+ 	colors[0][B] = (colors_RGB444[0][B] << (8 - B_B)) | (colors_RGB444[0][B] >> (B_B - (8-B_B)) );
+ 	colors[1][R] = (colors_RGB444[1][R] << (8 - R_B)) | (colors_RGB444[1][R] >> (R_B - (8-R_B)) );
+ 	colors[1][G] = (colors_RGB444[1][G] << (8 - G_B)) | (colors_RGB444[1][G] >> (G_B - (8-G_B)) );
+ 	colors[1][B] = (colors_RGB444[1][B] << (8 - B_B)) | (colors_RGB444[1][B] >> (B_B - (8-B_B)) );
+}
+
+void calculatePaintColors59T(uint8 d, uint8 p, uint8 (colors)[2][3], uint8 (possible_colors)[4][3]) 
+{
+	//////////////////////////////////////////////
+	//
+	//		C3      C1		C4----C1---C2
+	//		|		|			  |
+	//		|		|			  |
+	//		|-------|			  |
+	//		|		|			  |
+	//		|		|			  |
+	//		C4      C2			  C3
+	//
+	//////////////////////////////////////////////
+
+	// C4
+	possible_colors[3][R] = CLAMP(0,colors[1][R] - table59T[d],255);
+	possible_colors[3][G] = CLAMP(0,colors[1][G] - table59T[d],255);
+	possible_colors[3][B] = CLAMP(0,colors[1][B] - table59T[d],255);
+	
+	if (p == PATTERN_T) 
+	{
+		// C3
+		possible_colors[0][R] = colors[0][R];
+		possible_colors[0][G] = colors[0][G];
+		possible_colors[0][B] = colors[0][B];
+		// C2
+		possible_colors[1][R] = CLAMP(0,colors[1][R] + table59T[d],255);
+		possible_colors[1][G] = CLAMP(0,colors[1][G] + table59T[d],255);
+		possible_colors[1][B] = CLAMP(0,colors[1][B] + table59T[d],255);
+		// C1
+		possible_colors[2][R] = colors[1][R];
+		possible_colors[2][G] = colors[1][G];
+		possible_colors[2][B] = colors[1][B];
+
+	} 
+	else 
+	{
+		printf("Invalid pattern. Terminating");
+		exit(1);
+	}
+}
+// Decompress a T-mode block (simple packing)
+// Simple 59T packing:
+//|63 62 61 60 59|58 57 56 55|54 53 52 51|50 49 48 47|46 45 44 43|42 41 40 39|38 37 36 35|34 33 32|
+//|----empty-----|---red 0---|--green 0--|--blue 0---|---red 1---|--green 1--|--blue 1---|--dist--|
+//
+//|31 30 29 28 27 26 25 24 23 22 21 20 19 18 17 16 15 14 13 12 11 10 09 08 07 06 05 04 03 02 01 00|
+//|----------------------------------------index bits---------------------------------------------|
+// NO WARRANTY --- SEE STATEMENT IN TOP OF FILE (C) Ericsson AB 2013. All Rights Reserved.
+void decompressBlockTHUMB59Tc(unsigned int block_part1, unsigned int block_part2, uint8 *img,int width,int height,int startx,int starty, int channels)
+{
+	uint8 colorsRGB444[2][3];
+	uint8 colors[2][3];
+	uint8 paint_colors[4][3];
+	uint8 distance;
+	uint8 block_mask[4][4];
+
+	// First decode left part of block.
+	colorsRGB444[0][R]= GETBITSHIGH(block_part1, 4, 58);
+	colorsRGB444[0][G]= GETBITSHIGH(block_part1, 4, 54);
+	colorsRGB444[0][B]= GETBITSHIGH(block_part1, 4, 50);
+
+	colorsRGB444[1][R]= GETBITSHIGH(block_part1, 4, 46);
+	colorsRGB444[1][G]= GETBITSHIGH(block_part1, 4, 42);
+	colorsRGB444[1][B]= GETBITSHIGH(block_part1, 4, 38);
+
+	distance   = GETBITSHIGH(block_part1, TABLE_BITS_59T, 34);
+
+	// Extend the two colors to RGB888	
+	decompressColor(R_BITS59T, G_BITS59T, B_BITS59T, colorsRGB444, colors);	
+	calculatePaintColors59T(distance, PATTERN_T, colors, paint_colors);
+	
+	// Choose one of the four paint colors for each texel
+	for (uint8 x = 0; x < BLOCKWIDTH; ++x) 
+	{
+		for (uint8 y = 0; y < BLOCKHEIGHT; ++y) 
+		{
+			//block_mask[x][y] = GETBITS(block_part2,2,31-(y*4+x)*2);
+			block_mask[x][y] = GETBITS(block_part2,1,(y+x*4)+16)<<1;
+			block_mask[x][y] |= GETBITS(block_part2,1,(y+x*4));
+			img[channels*((starty+y)*width+startx+x)+R] =
+				CLAMP(0,paint_colors[block_mask[x][y]][R],255); // RED
+			img[channels*((starty+y)*width+startx+x)+G] =
+				CLAMP(0,paint_colors[block_mask[x][y]][G],255); // GREEN
+			img[channels*((starty+y)*width+startx+x)+B] =
+				CLAMP(0,paint_colors[block_mask[x][y]][B],255); // BLUE
+		}
+	}
+}
+
+void decompressBlockTHUMB59T(unsigned int block_part1, unsigned int block_part2, uint8 *img, int width, int height, int startx, int starty)
+{
+  decompressBlockTHUMB59Tc(block_part1, block_part2, img, width, height, startx, starty, 3);
+}
+
+// Calculate the paint colors from the block colors 
+// using a distance d and one of the H- or T-patterns.
+// NO WARRANTY --- SEE STATEMENT IN TOP OF FILE (C) Ericsson AB 2013. All Rights Reserved.
+void calculatePaintColors58H(uint8 d, uint8 p, uint8 (colors)[2][3], uint8 (possible_colors)[4][3]) 
+{
+	
+	//////////////////////////////////////////////
+	//
+	//		C3      C1		C4----C1---C2
+	//		|		|			  |
+	//		|		|			  |
+	//		|-------|			  |
+	//		|		|			  |
+	//		|		|			  |
+	//		C4      C2			  C3
+	//
+	//////////////////////////////////////////////
+
+	// C4
+	possible_colors[3][R] = CLAMP(0,colors[1][R] - table58H[d],255);
+	possible_colors[3][G] = CLAMP(0,colors[1][G] - table58H[d],255);
+	possible_colors[3][B] = CLAMP(0,colors[1][B] - table58H[d],255);
+	
+	if (p == PATTERN_H) 
+	{ 
+		// C1
+		possible_colors[0][R] = CLAMP(0,colors[0][R] + table58H[d],255);
+		possible_colors[0][G] = CLAMP(0,colors[0][G] + table58H[d],255);
+		possible_colors[0][B] = CLAMP(0,colors[0][B] + table58H[d],255);
+		// C2
+		possible_colors[1][R] = CLAMP(0,colors[0][R] - table58H[d],255);
+		possible_colors[1][G] = CLAMP(0,colors[0][G] - table58H[d],255);
+		possible_colors[1][B] = CLAMP(0,colors[0][B] - table58H[d],255);
+		// C3
+		possible_colors[2][R] = CLAMP(0,colors[1][R] + table58H[d],255);
+		possible_colors[2][G] = CLAMP(0,colors[1][G] + table58H[d],255);
+		possible_colors[2][B] = CLAMP(0,colors[1][B] + table58H[d],255);
+	} 
+	else 
+	{
+		printf("Invalid pattern. Terminating");
+		exit(1);
+	}
+}
+
+// Decompress an H-mode block 
+// NO WARRANTY --- SEE STATEMENT IN TOP OF FILE (C) Ericsson AB 2013. All Rights Reserved.
+void decompressBlockTHUMB58Hc(unsigned int block_part1, unsigned int block_part2, uint8 *img, int width, int height, int startx, int starty, int channels)
+{
+	unsigned int col0, col1;
+	uint8 colors[2][3];
+	uint8 colorsRGB444[2][3];
+	uint8 paint_colors[4][3];
+	uint8 distance;
+	uint8 block_mask[4][4];
+	
+	// First decode left part of block.
+	colorsRGB444[0][R]= GETBITSHIGH(block_part1, 4, 57);
+	colorsRGB444[0][G]= GETBITSHIGH(block_part1, 4, 53);
+	colorsRGB444[0][B]= GETBITSHIGH(block_part1, 4, 49);
+
+	colorsRGB444[1][R]= GETBITSHIGH(block_part1, 4, 45);
+	colorsRGB444[1][G]= GETBITSHIGH(block_part1, 4, 41);
+	colorsRGB444[1][B]= GETBITSHIGH(block_part1, 4, 37);
+
+	distance = 0;
+	distance = (GETBITSHIGH(block_part1, 2, 33)) << 1;
+
+	col0 = GETBITSHIGH(block_part1, 12, 57);
+	col1 = GETBITSHIGH(block_part1, 12, 45);
+
+	if(col0 >= col1)
+	{
+		distance |= 1;
+	}
+
+	// Extend the two colors to RGB888	
+	decompressColor(R_BITS58H, G_BITS58H, B_BITS58H, colorsRGB444, colors);	
+	
+	calculatePaintColors58H(distance, PATTERN_H, colors, paint_colors);
+	
+	// Choose one of the four paint colors for each texel
+	for (uint8 x = 0; x < BLOCKWIDTH; ++x) 
+	{
+		for (uint8 y = 0; y < BLOCKHEIGHT; ++y) 
+		{
+			//block_mask[x][y] = GETBITS(block_part2,2,31-(y*4+x)*2);
+			block_mask[x][y] = GETBITS(block_part2,1,(y+x*4)+16)<<1;
+			block_mask[x][y] |= GETBITS(block_part2,1,(y+x*4));
+			img[channels*((starty+y)*width+startx+x)+R] =
+				CLAMP(0,paint_colors[block_mask[x][y]][R],255); // RED
+			img[channels*((starty+y)*width+startx+x)+G] =
+				CLAMP(0,paint_colors[block_mask[x][y]][G],255); // GREEN
+			img[channels*((starty+y)*width+startx+x)+B] =
+				CLAMP(0,paint_colors[block_mask[x][y]][B],255); // BLUE
+		}
+	}
+}
+void decompressBlockTHUMB58H(unsigned int block_part1, unsigned int block_part2, uint8 *img, int width, int height, int startx, int starty)
+{
+  decompressBlockTHUMB58Hc(block_part1, block_part2, img, width, height, startx, starty, 3);
+}
+
+// Decompress the planar mode.
+// NO WARRANTY --- SEE STATEMENT IN TOP OF FILE (C) Ericsson AB 2013. All Rights Reserved.
+void decompressBlockPlanar57c(unsigned int compressed57_1, unsigned int compressed57_2, uint8 *img, int width, int height, int startx, int starty, int channels)
+{
+	uint8 colorO[3], colorH[3], colorV[3];
+
+	colorO[0] = GETBITSHIGH( compressed57_1, 6, 63);
+	colorO[1] = GETBITSHIGH( compressed57_1, 7, 57);
+	colorO[2] = GETBITSHIGH( compressed57_1, 6, 50);
+	colorH[0] = GETBITSHIGH( compressed57_1, 6, 44);
+	colorH[1] = GETBITSHIGH( compressed57_1, 7, 38);
+	colorH[2] = GETBITS(     compressed57_2, 6, 31);
+	colorV[0] = GETBITS(     compressed57_2, 6, 25);
+	colorV[1] = GETBITS(     compressed57_2, 7, 19);
+	colorV[2] = GETBITS(     compressed57_2, 6, 12);
+
+	colorO[0] = (colorO[0] << 2) | (colorO[0] >> 4);
+	colorO[1] = (colorO[1] << 1) | (colorO[1] >> 6);
+	colorO[2] = (colorO[2] << 2) | (colorO[2] >> 4);
+
+	colorH[0] = (colorH[0] << 2) | (colorH[0] >> 4);
+	colorH[1] = (colorH[1] << 1) | (colorH[1] >> 6);
+	colorH[2] = (colorH[2] << 2) | (colorH[2] >> 4);
+
+	colorV[0] = (colorV[0] << 2) | (colorV[0] >> 4);
+	colorV[1] = (colorV[1] << 1) | (colorV[1] >> 6);
+	colorV[2] = (colorV[2] << 2) | (colorV[2] >> 4);
+
+	int xx, yy;
+
+	for( xx=0; xx<4; xx++)
+	{
+		for( yy=0; yy<4; yy++)
+		{
+			img[channels*width*(starty+yy) + channels*(startx+xx) + 0] = CLAMP(0, ((xx*(colorH[0]-colorO[0]) + yy*(colorV[0]-colorO[0]) + 4*colorO[0] + 2) >> 2),255);
+			img[channels*width*(starty+yy) + channels*(startx+xx) + 1] = CLAMP(0, ((xx*(colorH[1]-colorO[1]) + yy*(colorV[1]-colorO[1]) + 4*colorO[1] + 2) >> 2),255);
+			img[channels*width*(starty+yy) + channels*(startx+xx) + 2] = CLAMP(0, ((xx*(colorH[2]-colorO[2]) + yy*(colorV[2]-colorO[2]) + 4*colorO[2] + 2) >> 2),255);
+
+			//Equivalent method
+			/*img[channels*width*(starty+yy) + channels*(startx+xx) + 0] = (int)CLAMP(0, JAS_ROUND((xx*(colorH[0]-colorO[0])/4.0 + yy*(colorV[0]-colorO[0])/4.0 + colorO[0])), 255);
+			img[channels*width*(starty+yy) + channels*(startx+xx) + 1] = (int)CLAMP(0, JAS_ROUND((xx*(colorH[1]-colorO[1])/4.0 + yy*(colorV[1]-colorO[1])/4.0 + colorO[1])), 255);
+			img[channels*width*(starty+yy) + channels*(startx+xx) + 2] = (int)CLAMP(0, JAS_ROUND((xx*(colorH[2]-colorO[2])/4.0 + yy*(colorV[2]-colorO[2])/4.0 + colorO[2])), 255);*/
+			
+		}
+	}
+}
+void decompressBlockPlanar57(unsigned int compressed57_1, unsigned int compressed57_2, uint8 *img, int width, int height, int startx, int starty)
+{
+  decompressBlockPlanar57c(compressed57_1, compressed57_2, img, width, height, startx, starty, 3);
+}
+// Decompress an ETC1 block (or ETC2 using individual or differential mode).
+// NO WARRANTY --- SEE STATEMENT IN TOP OF FILE (C) Ericsson AB 2013. All Rights Reserved.
+void decompressBlockDiffFlipC(unsigned int block_part1, unsigned int block_part2, uint8 *img, int width, int height, int startx, int starty, int channels)
+{
+	uint8 avg_color[3], enc_color1[3], enc_color2[3];
+	signed char diff[3];
+	int table;
+	int index,shift;
+	int r,g,b;
+	int diffbit;
+	int flipbit;
+
+	diffbit = (GETBITSHIGH(block_part1, 1, 33));
+	flipbit = (GETBITSHIGH(block_part1, 1, 32));
+
+	if( !diffbit )
+	{
+		// We have diffbit = 0.
+
+		// First decode left part of block.
+		avg_color[0]= GETBITSHIGH(block_part1, 4, 63);
+		avg_color[1]= GETBITSHIGH(block_part1, 4, 55);
+		avg_color[2]= GETBITSHIGH(block_part1, 4, 47);
+
+		// Here, we should really multiply by 17 instead of 16. This can
+		// be done by just copying the four lower bits to the upper ones
+		// while keeping the lower bits.
+		avg_color[0] |= (avg_color[0] <<4);
+		avg_color[1] |= (avg_color[1] <<4);
+		avg_color[2] |= (avg_color[2] <<4);
+
+		table = GETBITSHIGH(block_part1, 3, 39) << 1;
+
+		unsigned int pixel_indices_MSB, pixel_indices_LSB;
+			
+		pixel_indices_MSB = GETBITS(block_part2, 16, 31);
+		pixel_indices_LSB = GETBITS(block_part2, 16, 15);
+
+		if( (flipbit) == 0 )
+		{
+			// We should not flip
+			shift = 0;
+			for(int x=startx; x<startx+2; x++)
+			{
+				for(int y=starty; y<starty+4; y++)
+				{
+					index  = ((pixel_indices_MSB >> shift) & 1) << 1;
+					index |= ((pixel_indices_LSB >> shift) & 1);
+					shift++;
+					index=unscramble[index];
+
+ 					r=RED_CHANNEL(img,width,x,y,channels)  =CLAMP(0,avg_color[0]+compressParams[table][index],255);
+ 					g=GREEN_CHANNEL(img,width,x,y,channels)=CLAMP(0,avg_color[1]+compressParams[table][index],255);
+ 					b=BLUE_CHANNEL(img,width,x,y,channels) =CLAMP(0,avg_color[2]+compressParams[table][index],255);
+				}
+			}
+		}
+		else
+		{
+			// We should flip
+			shift = 0;
+			for(int x=startx; x<startx+4; x++)
+			{
+				for(int y=starty; y<starty+2; y++)
+				{
+					index  = ((pixel_indices_MSB >> shift) & 1) << 1;
+					index |= ((pixel_indices_LSB >> shift) & 1);
+					shift++;
+					index=unscramble[index];
+
+ 					r=RED_CHANNEL(img,width,x,y,channels)  =CLAMP(0,avg_color[0]+compressParams[table][index],255);
+ 					g=GREEN_CHANNEL(img,width,x,y,channels)=CLAMP(0,avg_color[1]+compressParams[table][index],255);
+ 					b=BLUE_CHANNEL(img,width,x,y,channels) =CLAMP(0,avg_color[2]+compressParams[table][index],255);
+				}
+				shift+=2;
+			}
+		}
+
+		// Now decode other part of block. 
+		avg_color[0]= GETBITSHIGH(block_part1, 4, 59);
+		avg_color[1]= GETBITSHIGH(block_part1, 4, 51);
+		avg_color[2]= GETBITSHIGH(block_part1, 4, 43);
+
+		// Here, we should really multiply by 17 instead of 16. This can
+		// be done by just copying the four lower bits to the upper ones
+		// while keeping the lower bits.
+		avg_color[0] |= (avg_color[0] <<4);
+		avg_color[1] |= (avg_color[1] <<4);
+		avg_color[2] |= (avg_color[2] <<4);
+
+		table = GETBITSHIGH(block_part1, 3, 36) << 1;
+		pixel_indices_MSB = GETBITS(block_part2, 16, 31);
+		pixel_indices_LSB = GETBITS(block_part2, 16, 15);
+
+		if( (flipbit) == 0 )
+		{
+			// We should not flip
+			shift=8;
+			for(int x=startx+2; x<startx+4; x++)
+			{
+				for(int y=starty; y<starty+4; y++)
+				{
+					index  = ((pixel_indices_MSB >> shift) & 1) << 1;
+					index |= ((pixel_indices_LSB >> shift) & 1);
+					shift++;
+					index=unscramble[index];
+
+ 					r=RED_CHANNEL(img,width,x,y,channels)  =CLAMP(0,avg_color[0]+compressParams[table][index],255);
+ 					g=GREEN_CHANNEL(img,width,x,y,channels)=CLAMP(0,avg_color[1]+compressParams[table][index],255);
+ 					b=BLUE_CHANNEL(img,width,x,y,channels) =CLAMP(0,avg_color[2]+compressParams[table][index],255);
+				}
+			}
+		}
+		else
+		{
+			// We should flip
+			shift=2;
+			for(int x=startx; x<startx+4; x++)
+			{
+				for(int y=starty+2; y<starty+4; y++)
+				{
+					index  = ((pixel_indices_MSB >> shift) & 1) << 1;
+					index |= ((pixel_indices_LSB >> shift) & 1);
+					shift++;
+					index=unscramble[index];
+
+ 					r=RED_CHANNEL(img,width,x,y,channels)  =CLAMP(0,avg_color[0]+compressParams[table][index],255);
+ 					g=GREEN_CHANNEL(img,width,x,y,channels)=CLAMP(0,avg_color[1]+compressParams[table][index],255);
+ 					b=BLUE_CHANNEL(img,width,x,y,channels) =CLAMP(0,avg_color[2]+compressParams[table][index],255);
+				}
+				shift += 2;
+			}
+		}
+	}
+	else
+	{
+		// We have diffbit = 1. 
+
+//      63 62 61 60 59 58 57 56 55 54 53 52 51 50 49 48 47 46 45 44 43 42 41 40 39 38 37 36 35 34  33  32 
+//      ---------------------------------------------------------------------------------------------------
+//     | base col1    | dcol 2 | base col1    | dcol 2 | base col 1   | dcol 2 | table  | table  |diff|flip|
+//     | R1' (5 bits) | dR2    | G1' (5 bits) | dG2    | B1' (5 bits) | dB2    | cw 1   | cw 2   |bit |bit |
+//      ---------------------------------------------------------------------------------------------------
+// 
+// 
+//     c) bit layout in bits 31 through 0 (in both cases)
+// 
+//      31 30 29 28 27 26 25 24 23 22 21 20 19 18 17 16 15 14 13 12 11 10  9  8  7  6  5  4  3   2   1  0
+//      --------------------------------------------------------------------------------------------------
+//     |       most significant pixel index bits       |         least significant pixel index bits       |  
+//     | p| o| n| m| l| k| j| i| h| g| f| e| d| c| b| a| p| o| n| m| l| k| j| i| h| g| f| e| d| c | b | a |
+//      --------------------------------------------------------------------------------------------------      
+
+		// First decode left part of block.
+		enc_color1[0]= GETBITSHIGH(block_part1, 5, 63);
+		enc_color1[1]= GETBITSHIGH(block_part1, 5, 55);
+		enc_color1[2]= GETBITSHIGH(block_part1, 5, 47);
+
+		// Expand from 5 to 8 bits
+		avg_color[0] = (enc_color1[0] <<3) | (enc_color1[0] >> 2);
+		avg_color[1] = (enc_color1[1] <<3) | (enc_color1[1] >> 2);
+		avg_color[2] = (enc_color1[2] <<3) | (enc_color1[2] >> 2);
+
+		table = GETBITSHIGH(block_part1, 3, 39) << 1;
+
+		unsigned int pixel_indices_MSB, pixel_indices_LSB;
+			
+		pixel_indices_MSB = GETBITS(block_part2, 16, 31);
+		pixel_indices_LSB = GETBITS(block_part2, 16, 15);
+
+		if( (flipbit) == 0 )
+		{
+			// We should not flip
+			shift = 0;
+			for(int x=startx; x<startx+2; x++)
+			{
+				for(int y=starty; y<starty+4; y++)
+				{
+					index  = ((pixel_indices_MSB >> shift) & 1) << 1;
+					index |= ((pixel_indices_LSB >> shift) & 1);
+					shift++;
+					index=unscramble[index];
+
+ 					r=RED_CHANNEL(img,width,x,y,channels)  =CLAMP(0,avg_color[0]+compressParams[table][index],255);
+ 					g=GREEN_CHANNEL(img,width,x,y,channels)=CLAMP(0,avg_color[1]+compressParams[table][index],255);
+ 					b=BLUE_CHANNEL(img,width,x,y,channels) =CLAMP(0,avg_color[2]+compressParams[table][index],255);
+				}
+			}
+		}
+		else
+		{
+			// We should flip
+			shift = 0;
+			for(int x=startx; x<startx+4; x++)
+			{
+				for(int y=starty; y<starty+2; y++)
+				{
+					index  = ((pixel_indices_MSB >> shift) & 1) << 1;
+					index |= ((pixel_indices_LSB >> shift) & 1);
+					shift++;
+					index=unscramble[index];
+
+ 					r=RED_CHANNEL(img,width,x,y,channels)  =CLAMP(0,avg_color[0]+compressParams[table][index],255);
+ 					g=GREEN_CHANNEL(img,width,x,y,channels)=CLAMP(0,avg_color[1]+compressParams[table][index],255);
+ 					b=BLUE_CHANNEL(img,width,x,y,channels) =CLAMP(0,avg_color[2]+compressParams[table][index],255);
+				}
+				shift+=2;
+			}
+		}
+
+		// Now decode right part of block. 
+		diff[0]= GETBITSHIGH(block_part1, 3, 58);
+		diff[1]= GETBITSHIGH(block_part1, 3, 50);
+		diff[2]= GETBITSHIGH(block_part1, 3, 42);
+
+		// Extend sign bit to entire byte. 
+		diff[0] = (diff[0] << 5);
+		diff[1] = (diff[1] << 5);
+		diff[2] = (diff[2] << 5);
+		diff[0] = diff[0] >> 5;
+		diff[1] = diff[1] >> 5;
+		diff[2] = diff[2] >> 5;
+
+		//  Calculale second color
+		enc_color2[0]= enc_color1[0] + diff[0];
+		enc_color2[1]= enc_color1[1] + diff[1];
+		enc_color2[2]= enc_color1[2] + diff[2];
+
+		// Expand from 5 to 8 bits
+		avg_color[0] = (enc_color2[0] <<3) | (enc_color2[0] >> 2);
+		avg_color[1] = (enc_color2[1] <<3) | (enc_color2[1] >> 2);
+		avg_color[2] = (enc_color2[2] <<3) | (enc_color2[2] >> 2);
+
+		table = GETBITSHIGH(block_part1, 3, 36) << 1;
+		pixel_indices_MSB = GETBITS(block_part2, 16, 31);
+		pixel_indices_LSB = GETBITS(block_part2, 16, 15);
+
+		if( (flipbit) == 0 )
+		{
+			// We should not flip
+			shift=8;
+			for(int x=startx+2; x<startx+4; x++)
+			{
+				for(int y=starty; y<starty+4; y++)
+				{
+					index  = ((pixel_indices_MSB >> shift) & 1) << 1;
+					index |= ((pixel_indices_LSB >> shift) & 1);
+					shift++;
+					index=unscramble[index];
+
+ 					r=RED_CHANNEL(img,width,x,y,channels)  =CLAMP(0,avg_color[0]+compressParams[table][index],255);
+ 					g=GREEN_CHANNEL(img,width,x,y,channels)=CLAMP(0,avg_color[1]+compressParams[table][index],255);
+ 					b=BLUE_CHANNEL(img,width,x,y,channels) =CLAMP(0,avg_color[2]+compressParams[table][index],255);
+				}
+			}
+		}
+		else
+		{
+			// We should flip
+			shift=2;
+			for(int x=startx; x<startx+4; x++)
+			{
+				for(int y=starty+2; y<starty+4; y++)
+				{
+					index  = ((pixel_indices_MSB >> shift) & 1) << 1;
+					index |= ((pixel_indices_LSB >> shift) & 1);
+					shift++;
+					index=unscramble[index];
+
+ 					r=RED_CHANNEL(img,width,x,y,channels)  =CLAMP(0,avg_color[0]+compressParams[table][index],255);
+ 					g=GREEN_CHANNEL(img,width,x,y,channels)=CLAMP(0,avg_color[1]+compressParams[table][index],255);
+ 					b=BLUE_CHANNEL(img,width,x,y,channels) =CLAMP(0,avg_color[2]+compressParams[table][index],255);
+				}
+				shift += 2;
+			}
+		}
+	}
+}
+void decompressBlockDiffFlip(unsigned int block_part1, unsigned int block_part2, uint8 *img, int width, int height, int startx, int starty)
+{
+  decompressBlockDiffFlipC(block_part1, block_part2, img, width, height, startx, starty, 3);
+}
+
+// Decompress an ETC2 RGB block
+// NO WARRANTY --- SEE STATEMENT IN TOP OF FILE (C) Ericsson AB 2013. All Rights Reserved.
+void decompressBlockETC2c(unsigned int block_part1, unsigned int block_part2, uint8 *img, int width, int height, int startx, int starty, int channels)
+{
+	int diffbit;
+	signed char color1[3];
+	signed char diff[3];
+	signed char red, green, blue;
+
+	diffbit = (GETBITSHIGH(block_part1, 1, 33));
+
+	if( diffbit )
+	{
+		// We have diffbit = 1;
+
+		// Base color
+		color1[0]= GETBITSHIGH(block_part1, 5, 63);
+		color1[1]= GETBITSHIGH(block_part1, 5, 55);
+		color1[2]= GETBITSHIGH(block_part1, 5, 47);
+
+		// Diff color
+		diff[0]= GETBITSHIGH(block_part1, 3, 58);
+		diff[1]= GETBITSHIGH(block_part1, 3, 50);
+		diff[2]= GETBITSHIGH(block_part1, 3, 42);
+
+		// Extend sign bit to entire byte. 
+		diff[0] = (diff[0] << 5);
+		diff[1] = (diff[1] << 5);
+		diff[2] = (diff[2] << 5);
+		diff[0] = diff[0] >> 5;
+		diff[1] = diff[1] >> 5;
+		diff[2] = diff[2] >> 5;
+
+		red   = color1[0] + diff[0];
+		green = color1[1] + diff[1];
+		blue  = color1[2] + diff[2];
+
+		if(red < 0 || red > 31)
+		{
+			unsigned int block59_part1, block59_part2;
+			unstuff59bits(block_part1, block_part2, block59_part1, block59_part2);
+			decompressBlockTHUMB59Tc(block59_part1, block59_part2, img, width, height, startx, starty, channels);
+		}
+		else if (green < 0 || green > 31)
+		{
+			unsigned int block58_part1, block58_part2;
+			unstuff58bits(block_part1, block_part2, block58_part1, block58_part2);
+			decompressBlockTHUMB58Hc(block58_part1, block58_part2, img, width, height, startx, starty, channels);
+		}
+		else if(blue < 0 || blue > 31)
+		{
+			unsigned int block57_part1, block57_part2;
+
+			unstuff57bits(block_part1, block_part2, block57_part1, block57_part2);
+			decompressBlockPlanar57c(block57_part1, block57_part2, img, width, height, startx, starty, channels);
+		}
+		else
+		{
+ 			decompressBlockDiffFlipC(block_part1, block_part2, img, width, height, startx, starty, channels);
+		}
+	}
+	else
+	{
+		// We have diffbit = 0;
+		decompressBlockDiffFlipC(block_part1, block_part2, img, width, height, startx, starty, channels);
+	}
+}
+void decompressBlockETC2(unsigned int block_part1, unsigned int block_part2, uint8 *img, int width, int height, int startx, int starty)
+{
+  decompressBlockETC2c(block_part1, block_part2, img, width, height, startx, starty, 3);
+}
+// Decompress an ETC2 block with punchthrough alpha
+// NO WARRANTY --- SEE STATEMENT IN TOP OF FILE (C) Ericsson AB 2013. All Rights Reserved.
+void decompressBlockDifferentialWithAlphaC(unsigned int block_part1, unsigned int block_part2, uint8* img, uint8* alpha, int width, int height, int startx, int starty, int channelsRGB)
+{
+	
+	uint8 avg_color[3], enc_color1[3], enc_color2[3];
+	signed char diff[3];
+	int table;
+	int index,shift;
+	int r,g,b;
+	int diffbit;
+	int flipbit;
+  int channelsA;
+
+  if(channelsRGB == 3)
+  {
+    // We will decode the alpha data to a separate memory area. 
+    channelsA = 1;
+  }
+  else
+  {
+    // We will decode the RGB data and the alpha data to the same memory area, 
+    // interleaved as RGBA. 
+    channelsA = 4;
+    alpha = &img[0+3];
+  }
+
+	//the diffbit now encodes whether or not the entire alpha channel is 255.
+	diffbit = (GETBITSHIGH(block_part1, 1, 33));
+ 	flipbit = (GETBITSHIGH(block_part1, 1, 32));
+
+	// First decode left part of block.
+	enc_color1[0]= GETBITSHIGH(block_part1, 5, 63);
+	enc_color1[1]= GETBITSHIGH(block_part1, 5, 55);
+	enc_color1[2]= GETBITSHIGH(block_part1, 5, 47);
+
+	// Expand from 5 to 8 bits
+	avg_color[0] = (enc_color1[0] <<3) | (enc_color1[0] >> 2);
+	avg_color[1] = (enc_color1[1] <<3) | (enc_color1[1] >> 2);
+	avg_color[2] = (enc_color1[2] <<3) | (enc_color1[2] >> 2);
+
+	table = GETBITSHIGH(block_part1, 3, 39) << 1;
+
+	unsigned int pixel_indices_MSB, pixel_indices_LSB;
+		
+	pixel_indices_MSB = GETBITS(block_part2, 16, 31);
+	pixel_indices_LSB = GETBITS(block_part2, 16, 15);
+
+	if( (flipbit) == 0 )
+	{
+		// We should not flip
+		shift = 0;
+		for(int x=startx; x<startx+2; x++)
+		{
+			for(int y=starty; y<starty+4; y++)
+			{
+				index  = ((pixel_indices_MSB >> shift) & 1) << 1;
+				index |= ((pixel_indices_LSB >> shift) & 1);
+				shift++;
+				index=unscramble[index];
+
+				int mod = compressParams[table][index];
+				if(diffbit==0&&(index==1||index==2)) 
+				{
+					mod=0;
+				}
+				
+				r=RED_CHANNEL(img,width,x,y,channelsRGB)  =CLAMP(0,avg_color[0]+mod,255);
+				g=GREEN_CHANNEL(img,width,x,y,channelsRGB)=CLAMP(0,avg_color[1]+mod,255);
+				b=BLUE_CHANNEL(img,width,x,y,channelsRGB) =CLAMP(0,avg_color[2]+mod,255);
+				if(diffbit==0&&index==1) 
+				{
+					alpha[(y*width+x)*channelsA]=0;
+					r=RED_CHANNEL(img,width,x,y,channelsRGB)=0;
+					g=GREEN_CHANNEL(img,width,x,y,channelsRGB)=0;
+					b=BLUE_CHANNEL(img,width,x,y,channelsRGB)=0;
+				}
+				else 
+				{
+					alpha[(y*width+x)*channelsA]=255;
+				}
+
+			}
+		}
+	}
+	else
+	{
+		// We should flip
+		shift = 0;
+		for(int x=startx; x<startx+4; x++)
+		{
+			for(int y=starty; y<starty+2; y++)
+			{
+				index  = ((pixel_indices_MSB >> shift) & 1) << 1;
+				index |= ((pixel_indices_LSB >> shift) & 1);
+				shift++;
+				index=unscramble[index];
+				int mod = compressParams[table][index];
+				if(diffbit==0&&(index==1||index==2)) 
+				{
+					mod=0;
+				}
+				r=RED_CHANNEL(img,width,x,y,channelsRGB)  =CLAMP(0,avg_color[0]+mod,255);
+				g=GREEN_CHANNEL(img,width,x,y,channelsRGB)=CLAMP(0,avg_color[1]+mod,255);
+				b=BLUE_CHANNEL(img,width,x,y,channelsRGB) =CLAMP(0,avg_color[2]+mod,255);
+				if(diffbit==0&&index==1) 
+				{
+					alpha[(y*width+x)*channelsA]=0;
+					r=RED_CHANNEL(img,width,x,y,channelsRGB)=0;
+					g=GREEN_CHANNEL(img,width,x,y,channelsRGB)=0;
+					b=BLUE_CHANNEL(img,width,x,y,channelsRGB)=0;
+				}
+				else 
+				{
+					alpha[(y*width+x)*channelsA]=255;
+				}
+			}
+			shift+=2;
+		}
+	}
+	// Now decode right part of block. 
+	diff[0]= GETBITSHIGH(block_part1, 3, 58);
+	diff[1]= GETBITSHIGH(block_part1, 3, 50);
+	diff[2]= GETBITSHIGH(block_part1, 3, 42);
+
+	// Extend sign bit to entire byte. 
+	diff[0] = (diff[0] << 5);
+	diff[1] = (diff[1] << 5);
+	diff[2] = (diff[2] << 5);
+	diff[0] = diff[0] >> 5;
+	diff[1] = diff[1] >> 5;
+	diff[2] = diff[2] >> 5;
+
+	//  Calculate second color
+	enc_color2[0]= enc_color1[0] + diff[0];
+	enc_color2[1]= enc_color1[1] + diff[1];
+	enc_color2[2]= enc_color1[2] + diff[2];
+
+	// Expand from 5 to 8 bits
+	avg_color[0] = (enc_color2[0] <<3) | (enc_color2[0] >> 2);
+	avg_color[1] = (enc_color2[1] <<3) | (enc_color2[1] >> 2);
+	avg_color[2] = (enc_color2[2] <<3) | (enc_color2[2] >> 2);
+
+	table = GETBITSHIGH(block_part1, 3, 36) << 1;
+	pixel_indices_MSB = GETBITS(block_part2, 16, 31);
+	pixel_indices_LSB = GETBITS(block_part2, 16, 15);
+
+	if( (flipbit) == 0 )
+	{
+		// We should not flip
+		shift=8;
+		for(int x=startx+2; x<startx+4; x++)
+		{
+			for(int y=starty; y<starty+4; y++)
+			{
+				index  = ((pixel_indices_MSB >> shift) & 1) << 1;
+				index |= ((pixel_indices_LSB >> shift) & 1);
+				shift++;
+				index=unscramble[index];
+				int mod = compressParams[table][index];
+				if(diffbit==0&&(index==1||index==2)) 
+				{
+					mod=0;
+				}
+				
+				r=RED_CHANNEL(img,width,x,y,channelsRGB)  =CLAMP(0,avg_color[0]+mod,255);
+				g=GREEN_CHANNEL(img,width,x,y,channelsRGB)=CLAMP(0,avg_color[1]+mod,255);
+				b=BLUE_CHANNEL(img,width,x,y,channelsRGB) =CLAMP(0,avg_color[2]+mod,255);
+				if(diffbit==0&&index==1) 
+				{
+					alpha[(y*width+x)*channelsA]=0;
+					r=RED_CHANNEL(img,width,x,y,channelsRGB)=0;
+					g=GREEN_CHANNEL(img,width,x,y,channelsRGB)=0;
+					b=BLUE_CHANNEL(img,width,x,y,channelsRGB)=0;
+				}
+				else 
+				{
+					alpha[(y*width+x)*channelsA]=255;
+				}
+			}
+		}
+	}
+	else
+	{
+		// We should flip
+		shift=2;
+		for(int x=startx; x<startx+4; x++)
+		{
+			for(int y=starty+2; y<starty+4; y++)
+			{
+				index  = ((pixel_indices_MSB >> shift) & 1) << 1;
+				index |= ((pixel_indices_LSB >> shift) & 1);
+				shift++;
+				index=unscramble[index];
+				int mod = compressParams[table][index];
+				if(diffbit==0&&(index==1||index==2)) 
+				{
+					mod=0;
+				}
+				
+				r=RED_CHANNEL(img,width,x,y,channelsRGB)  =CLAMP(0,avg_color[0]+mod,255);
+				g=GREEN_CHANNEL(img,width,x,y,channelsRGB)=CLAMP(0,avg_color[1]+mod,255);
+				b=BLUE_CHANNEL(img,width,x,y,channelsRGB) =CLAMP(0,avg_color[2]+mod,255);
+				if(diffbit==0&&index==1) 
+				{
+					alpha[(y*width+x)*channelsA]=0;
+					r=RED_CHANNEL(img,width,x,y,channelsRGB)=0;
+					g=GREEN_CHANNEL(img,width,x,y,channelsRGB)=0;
+					b=BLUE_CHANNEL(img,width,x,y,channelsRGB)=0;
+				}
+				else 
+				{
+					alpha[(y*width+x)*channelsA]=255;
+				}
+			}
+			shift += 2;
+		}
+	}
+}
+void decompressBlockDifferentialWithAlpha(unsigned int block_part1, unsigned int block_part2, uint8* img, uint8* alpha, int width, int height, int startx, int starty)
+{
+  decompressBlockDifferentialWithAlphaC(block_part1, block_part2, img, alpha, width, height, startx, starty, 3);
+}
+
+
+// similar to regular decompression, but alpha channel is set to 0 if pixel index is 2, otherwise 255.
+// NO WARRANTY --- SEE STATEMENT IN TOP OF FILE (C) Ericsson AB 2013. All Rights Reserved.
+void decompressBlockTHUMB59TAlphaC(unsigned int block_part1, unsigned int block_part2, uint8 *img, uint8* alpha, int width, int height, int startx, int starty, int channelsRGB)
+{
+
+	uint8 colorsRGB444[2][3];
+	uint8 colors[2][3];
+	uint8 paint_colors[4][3];
+	uint8 distance;
+	uint8 block_mask[4][4];
+  int channelsA;
+
+  if(channelsRGB == 3)
+  {
+    // We will decode the alpha data to a separate memory area. 
+    channelsA = 1;
+  }
+  else
+  {
+    // We will decode the RGB data and the alpha data to the same memory area, 
+    // interleaved as RGBA. 
+    channelsA = 4;
+    alpha = &img[0+3];
+  }
+
+	// First decode left part of block.
+	colorsRGB444[0][R]= GETBITSHIGH(block_part1, 4, 58);
+	colorsRGB444[0][G]= GETBITSHIGH(block_part1, 4, 54);
+	colorsRGB444[0][B]= GETBITSHIGH(block_part1, 4, 50);
+
+	colorsRGB444[1][R]= GETBITSHIGH(block_part1, 4, 46);
+	colorsRGB444[1][G]= GETBITSHIGH(block_part1, 4, 42);
+	colorsRGB444[1][B]= GETBITSHIGH(block_part1, 4, 38);
+
+	distance   = GETBITSHIGH(block_part1, TABLE_BITS_59T, 34);
+
+	// Extend the two colors to RGB888	
+	decompressColor(R_BITS59T, G_BITS59T, B_BITS59T, colorsRGB444, colors);	
+	calculatePaintColors59T(distance, PATTERN_T, colors, paint_colors);
+	
+	// Choose one of the four paint colors for each texel
+	for (uint8 x = 0; x < BLOCKWIDTH; ++x) 
+	{
+		for (uint8 y = 0; y < BLOCKHEIGHT; ++y) 
+		{
+			//block_mask[x][y] = GETBITS(block_part2,2,31-(y*4+x)*2);
+			block_mask[x][y] = GETBITS(block_part2,1,(y+x*4)+16)<<1;
+			block_mask[x][y] |= GETBITS(block_part2,1,(y+x*4));
+			img[channelsRGB*((starty+y)*width+startx+x)+R] = 
+				CLAMP(0,paint_colors[block_mask[x][y]][R],255); // RED
+			img[channelsRGB*((starty+y)*width+startx+x)+G] =
+				CLAMP(0,paint_colors[block_mask[x][y]][G],255); // GREEN
+			img[channelsRGB*((starty+y)*width+startx+x)+B] =
+				CLAMP(0,paint_colors[block_mask[x][y]][B],255); // BLUE
+			if(block_mask[x][y]==2)  
+			{
+				alpha[channelsA*(x+startx+(y+starty)*width)]=0;
+				img[channelsRGB*((starty+y)*width+startx+x)+R] =0;
+				img[channelsRGB*((starty+y)*width+startx+x)+G] =0;
+				img[channelsRGB*((starty+y)*width+startx+x)+B] =0;
+			}
+			else
+				alpha[channelsA*(x+startx+(y+starty)*width)]=255;
+		}
+	}
+}
+void decompressBlockTHUMB59TAlpha(unsigned int block_part1, unsigned int block_part2, uint8 *img, uint8* alpha, int width, int height, int startx, int starty)
+{
+  decompressBlockTHUMB59TAlphaC(block_part1, block_part2, img, alpha, width, height, startx, starty, 3);
+}
+
+
+// Decompress an H-mode block with alpha
+// NO WARRANTY --- SEE STATEMENT IN TOP OF FILE (C) Ericsson AB 2013. All Rights Reserved.
+void decompressBlockTHUMB58HAlphaC(unsigned int block_part1, unsigned int block_part2, uint8 *img, uint8* alpha, int width, int height, int startx, int starty, int channelsRGB)
+{
+	unsigned int col0, col1;
+	uint8 colors[2][3];
+	uint8 colorsRGB444[2][3];
+	uint8 paint_colors[4][3];
+	uint8 distance;
+	uint8 block_mask[4][4];
+  int channelsA;	
+
+  if(channelsRGB == 3)
+  {
+    // We will decode the alpha data to a separate memory area. 
+    channelsA = 1;
+  }
+  else
+  {
+    // We will decode the RGB data and the alpha data to the same memory area, 
+    // interleaved as RGBA. 
+    channelsA = 4;
+    alpha = &img[0+3];
+  }
+
+	// First decode left part of block.
+	colorsRGB444[0][R]= GETBITSHIGH(block_part1, 4, 57);
+	colorsRGB444[0][G]= GETBITSHIGH(block_part1, 4, 53);
+	colorsRGB444[0][B]= GETBITSHIGH(block_part1, 4, 49);
+
+	colorsRGB444[1][R]= GETBITSHIGH(block_part1, 4, 45);
+	colorsRGB444[1][G]= GETBITSHIGH(block_part1, 4, 41);
+	colorsRGB444[1][B]= GETBITSHIGH(block_part1, 4, 37);
+
+  distance = 0;
+	distance = (GETBITSHIGH(block_part1, 2, 33)) << 1;
+
+	col0 = GETBITSHIGH(block_part1, 12, 57);
+	col1 = GETBITSHIGH(block_part1, 12, 45);
+
+	if(col0 >= col1)
+	{
+		distance |= 1;
+	}
+
+	// Extend the two colors to RGB888	
+	decompressColor(R_BITS58H, G_BITS58H, B_BITS58H, colorsRGB444, colors);	
+	
+	calculatePaintColors58H(distance, PATTERN_H, colors, paint_colors);
+	
+	// Choose one of the four paint colors for each texel
+	for (uint8 x = 0; x < BLOCKWIDTH; ++x) 
+	{
+		for (uint8 y = 0; y < BLOCKHEIGHT; ++y) 
+		{
+			//block_mask[x][y] = GETBITS(block_part2,2,31-(y*4+x)*2);
+			block_mask[x][y] = GETBITS(block_part2,1,(y+x*4)+16)<<1;
+			block_mask[x][y] |= GETBITS(block_part2,1,(y+x*4));
+			img[channelsRGB*((starty+y)*width+startx+x)+R] =
+				CLAMP(0,paint_colors[block_mask[x][y]][R],255); // RED
+			img[channelsRGB*((starty+y)*width+startx+x)+G] =
+				CLAMP(0,paint_colors[block_mask[x][y]][G],255); // GREEN
+			img[channelsRGB*((starty+y)*width+startx+x)+B] =
+				CLAMP(0,paint_colors[block_mask[x][y]][B],255); // BLUE
+			
+			if(block_mask[x][y]==2)  
+			{
+				alpha[channelsA*(x+startx+(y+starty)*width)]=0;
+				img[channelsRGB*((starty+y)*width+startx+x)+R] =0;
+				img[channelsRGB*((starty+y)*width+startx+x)+G] =0;
+				img[channelsRGB*((starty+y)*width+startx+x)+B] =0;
+			}
+			else
+				alpha[channelsA*(x+startx+(y+starty)*width)]=255;
+		}
+	}
+}
+void decompressBlockTHUMB58HAlpha(unsigned int block_part1, unsigned int block_part2, uint8 *img, uint8* alpha, int width, int height, int startx, int starty)
+{
+  decompressBlockTHUMB58HAlphaC(block_part1, block_part2, img, alpha, width, height, startx, starty, 3);
+}
+// Decompression function for ETC2_RGBA1 format.
+// NO WARRANTY --- SEE STATEMENT IN TOP OF FILE (C) Ericsson AB 2013. All Rights Reserved.
+void decompressBlockETC21BitAlphaC(unsigned int block_part1, unsigned int block_part2, uint8 *img, uint8* alphaimg, int width, int height, int startx, int starty, int channelsRGB)
+{
+	int diffbit;
+	signed char color1[3];
+	signed char diff[3];
+	signed char red, green, blue;
+  int channelsA;	
+
+  if(channelsRGB == 3)
+  {
+    // We will decode the alpha data to a separate memory area. 
+    channelsA = 1;
+  }
+  else
+  {
+    // We will decode the RGB data and the alpha data to the same memory area, 
+    // interleaved as RGBA. 
+    channelsA = 4;
+    alphaimg = &img[0+3];
+  }
+
+	diffbit = (GETBITSHIGH(block_part1, 1, 33));
+
+	if( diffbit )
+	{
+		// We have diffbit = 1, meaning no transparent pixels. regular decompression.
+
+		// Base color
+		color1[0]= GETBITSHIGH(block_part1, 5, 63);
+		color1[1]= GETBITSHIGH(block_part1, 5, 55);
+		color1[2]= GETBITSHIGH(block_part1, 5, 47);
+
+		// Diff color
+		diff[0]= GETBITSHIGH(block_part1, 3, 58);
+		diff[1]= GETBITSHIGH(block_part1, 3, 50);
+		diff[2]= GETBITSHIGH(block_part1, 3, 42);
+
+		// Extend sign bit to entire byte. 
+		diff[0] = (diff[0] << 5);
+		diff[1] = (diff[1] << 5);
+		diff[2] = (diff[2] << 5);
+		diff[0] = diff[0] >> 5;
+		diff[1] = diff[1] >> 5;
+		diff[2] = diff[2] >> 5;
+
+		red   = color1[0] + diff[0];
+		green = color1[1] + diff[1];
+		blue  = color1[2] + diff[2];
+
+		if(red < 0 || red > 31)
+		{
+			unsigned int block59_part1, block59_part2;
+			unstuff59bits(block_part1, block_part2, block59_part1, block59_part2);
+			decompressBlockTHUMB59Tc(block59_part1, block59_part2, img, width, height, startx, starty, channelsRGB);
+		}
+		else if (green < 0 || green > 31)
+		{
+			unsigned int block58_part1, block58_part2;
+			unstuff58bits(block_part1, block_part2, block58_part1, block58_part2);
+			decompressBlockTHUMB58Hc(block58_part1, block58_part2, img, width, height, startx, starty, channelsRGB);
+		}
+		else if(blue < 0 || blue > 31)
+		{
+			unsigned int block57_part1, block57_part2;
+
+			unstuff57bits(block_part1, block_part2, block57_part1, block57_part2);
+			decompressBlockPlanar57c(block57_part1, block57_part2, img, width, height, startx, starty, channelsRGB);
+		}
+		else
+		{
+ 			decompressBlockDifferentialWithAlphaC(block_part1, block_part2, img, alphaimg, width, height, startx, starty, channelsRGB);
+		}
+		for(int x=startx; x<startx+4; x++) 
+		{
+			for(int y=starty; y<starty+4; y++) 
+			{
+				alphaimg[channelsA*(x+y*width)]=255;
+			}
+		}
+	}
+	else
+	{
+		// We have diffbit = 0, transparent pixels. Only T-, H- or regular diff-mode possible.
+		
+		// Base color
+		color1[0]= GETBITSHIGH(block_part1, 5, 63);
+		color1[1]= GETBITSHIGH(block_part1, 5, 55);
+		color1[2]= GETBITSHIGH(block_part1, 5, 47);
+
+		// Diff color
+		diff[0]= GETBITSHIGH(block_part1, 3, 58);
+		diff[1]= GETBITSHIGH(block_part1, 3, 50);
+		diff[2]= GETBITSHIGH(block_part1, 3, 42);
+
+		// Extend sign bit to entire byte. 
+		diff[0] = (diff[0] << 5);
+		diff[1] = (diff[1] << 5);
+		diff[2] = (diff[2] << 5);
+		diff[0] = diff[0] >> 5;
+		diff[1] = diff[1] >> 5;
+		diff[2] = diff[2] >> 5;
+
+		red   = color1[0] + diff[0];
+		green = color1[1] + diff[1];
+		blue  = color1[2] + diff[2];
+		if(red < 0 || red > 31)
+		{
+			unsigned int block59_part1, block59_part2;
+			unstuff59bits(block_part1, block_part2, block59_part1, block59_part2);
+			decompressBlockTHUMB59TAlphaC(block59_part1, block59_part2, img, alphaimg, width, height, startx, starty, channelsRGB);
+		}
+		else if(green < 0 || green > 31) 
+		{
+			unsigned int block58_part1, block58_part2;
+			unstuff58bits(block_part1, block_part2, block58_part1, block58_part2);
+			decompressBlockTHUMB58HAlphaC(block58_part1, block58_part2, img, alphaimg, width, height, startx, starty, channelsRGB);
+		}
+		else if(blue < 0 || blue > 31)
+		{
+			unsigned int block57_part1, block57_part2;
+
+			unstuff57bits(block_part1, block_part2, block57_part1, block57_part2);
+			decompressBlockPlanar57c(block57_part1, block57_part2, img, width, height, startx, starty, channelsRGB);
+			for(int x=startx; x<startx+4; x++) 
+			{
+				for(int y=starty; y<starty+4; y++) 
+				{
+					alphaimg[channelsA*(x+y*width)]=255;
+				}
+			}
+		}
+		else
+			decompressBlockDifferentialWithAlphaC(block_part1, block_part2, img,alphaimg, width, height, startx, starty, channelsRGB);
+	}
+}
+void decompressBlockETC21BitAlpha(unsigned int block_part1, unsigned int block_part2, uint8 *img, uint8* alphaimg, int width, int height, int startx, int starty)
+{
+  decompressBlockETC21BitAlphaC(block_part1, block_part2, img, alphaimg, width, height, startx, starty, 3);
+}
+//
+//	Utility functions used for alpha compression
+//
+
+// bit number frompos is extracted from input, and moved to bit number topos in the return value.
+// NO WARRANTY --- SEE STATEMENT IN TOP OF FILE (C) Ericsson AB 2013. All Rights Reserved.
+uint8 getbit(uint8 input, int frompos, int topos) 
+{
+	uint8 output=0;
+	if(frompos>topos)
+		return ((1<<frompos)&input)>>(frompos-topos);
+	return ((1<<frompos)&input)<<(topos-frompos);
+}
+
+// takes as input a value, returns the value clamped to the interval [0,255].
+// NO WARRANTY --- SEE STATEMENT IN TOP OF FILE (C) Ericsson AB 2013. All Rights Reserved.
+int clamp(int val) 
+{
+	if(val<0)
+		val=0;
+	if(val>255)
+		val=255;
+	return val;
+}
+
+// Decodes tha alpha component in a block coded with GL_COMPRESSED_RGBA8_ETC2_EAC.
+// Note that this decoding is slightly different from that of GL_COMPRESSED_R11_EAC.
+// However, a hardware decoder can share gates between the two formats as explained
+// in the specification under GL_COMPRESSED_R11_EAC.
+// NO WARRANTY --- SEE STATEMENT IN TOP OF FILE (C) Ericsson AB 2013. All Rights Reserved.
+void decompressBlockAlphaC(uint8* data, uint8* img, int width, int height, int ix, int iy, int channels) 
+{
+	int alpha = data[0];
+	int table = data[1];
+	
+	int bit=0;
+	int byte=2;
+	//extract an alpha value for each pixel.
+	for(int x=0; x<4; x++) 
+	{
+		for(int y=0; y<4; y++) 
+		{
+			//Extract table index
+			int index=0;
+			for(int bitpos=0; bitpos<3; bitpos++) 
+			{
+				index|=getbit(data[byte],7-bit,2-bitpos);
+				bit++;
+				if(bit>7) 
+				{
+					bit=0;
+					byte++;
+				}
+			}
+			img[(ix+x+(iy+y)*width)*channels]=clamp(alpha +alphaTable[table][index]);
+		}
+	}
+}
+void decompressBlockAlpha(uint8* data, uint8* img, int width, int height, int ix, int iy) 
+{
+  decompressBlockAlphaC(data, img, width, height, ix, iy, 1);
+}
+
+// Does decompression and then immediately converts from 11 bit signed to a 16-bit format.
+// 
+// NO WARRANTY --- SEE STATEMENT IN TOP OF FILE (C) Ericsson AB 2013. All Rights Reserved.
+int16 get16bits11signed(int base, int table, int mul, int index) 
+{
+	int elevenbase = base-128;
+	if(elevenbase==-128)
+		elevenbase=-127;
+	elevenbase*=8;
+	//i want the positive value here
+	int tabVal = -alphaBase[table][3-index%4]-1;
+	//and the sign, please
+	int sign = 1-(index/4);
+	
+	if(sign)
+		tabVal=tabVal+1;
+	int elevenTabVal = tabVal*8;
+
+	if(mul!=0)
+		elevenTabVal*=mul;
+	else
+		elevenTabVal/=8;
+
+	if(sign)
+		elevenTabVal=-elevenTabVal;
+
+	//calculate sum
+	int elevenbits = elevenbase+elevenTabVal;
+
+	//clamp..
+	if(elevenbits>=1024)
+		elevenbits=1023;
+	else if(elevenbits<-1023)
+		elevenbits=-1023;
+	//this is the value we would actually output.. 
+	//but there aren't any good 11-bit file or uncompressed GL formats
+	//so we extend to 15 bits signed.
+	sign = elevenbits<0;
+	elevenbits=abs(elevenbits);
+	int16 fifteenbits = (elevenbits<<5)+(elevenbits>>5);
+	int16 sixteenbits=fifteenbits;
+
+	if(sign)
+		sixteenbits=-sixteenbits;
+	
+	return sixteenbits;
+}
+
+// Does decompression and then immediately converts from 11 bit signed to a 16-bit format 
+// Calculates the 11 bit value represented by base, table, mul and index, and extends it to 16 bits.
+// NO WARRANTY --- SEE STATEMENT IN TOP OF FILE (C) Ericsson AB 2013. All Rights Reserved.
+uint16 get16bits11bits(int base, int table, int mul, int index) 
+{
+	int elevenbase = base*8+4;
+
+	//i want the positive value here
+	int tabVal = -alphaBase[table][3-index%4]-1;
+	//and the sign, please
+	int sign = 1-(index/4);
+	
+	if(sign)
+		tabVal=tabVal+1;
+	int elevenTabVal = tabVal*8;
+
+	if(mul!=0)
+		elevenTabVal*=mul;
+	else
+		elevenTabVal/=8;
+
+	if(sign)
+		elevenTabVal=-elevenTabVal;
+
+	//calculate sum
+	int elevenbits = elevenbase+elevenTabVal;
+
+	//clamp..
+	if(elevenbits>=256*8)
+		elevenbits=256*8-1;
+	else if(elevenbits<0)
+		elevenbits=0;
+	//elevenbits now contains the 11 bit alpha value as defined in the spec.
+
+	//extend to 16 bits before returning, since we don't have any good 11-bit file formats.
+	uint16 sixteenbits = (elevenbits<<5)+(elevenbits>>6);
+
+	return sixteenbits;
+}
+
+// Decompresses a block using one of the GL_COMPRESSED_R11_EAC or GL_COMPRESSED_SIGNED_R11_EAC-formats
+// NO WARRANTY --- SEE STATEMENT IN TOP OF FILE (C) Ericsson AB 2013. All Rights Reserved.
+void decompressBlockAlpha16bitC(uint8* data, uint8* img, int width, int height, int ix, int iy, int channels) 
+{
+	int alpha = data[0];
+	int table = data[1];
+
+	if(formatSigned) 
+	{
+		//if we have a signed format, the base value is given as a signed byte. We convert it to (0-255) here,
+		//so more code can be shared with the unsigned mode.
+		alpha = *((signed char*)(&data[0]));
+		alpha = alpha+128;
+	}
+
+	int bit=0;
+	int byte=2;
+	//extract an alpha value for each pixel.
+	for(int x=0; x<4; x++) 
+	{
+		for(int y=0; y<4; y++) 
+		{
+			//Extract table index
+			int index=0;
+			for(int bitpos=0; bitpos<3; bitpos++) 
+			{
+				index|=getbit(data[byte],7-bit,2-bitpos);
+				bit++;
+				if(bit>7) 
+				{
+					bit=0;
+					byte++;
+				}
+			}
+			int windex = channels*(2*(ix+x+(iy+y)*width));
+#if !PGMOUT
+			if(formatSigned)
+			{
+				*(int16 *)&img[windex] = get16bits11signed(alpha,(table%16),(table/16),index);
+			}
+			else
+			{
+				*(uint16 *)&img[windex] = get16bits11bits(alpha,(table%16),(table/16),index);
+			}
+#else
+			//make data compatible with the .pgm format. See the comment in compressBlockAlpha16() for details.
+			uint16 uSixteen;
+			if (formatSigned)
+			{
+				//the pgm-format only allows unsigned images,
+				//so we add 2^15 to get a 16-bit value.
+				uSixteen = get16bits11signed(alpha,(table%16),(table/16),index) + 256*128;
+			}
+			else
+			{
+				uSixteen = get16bits11bits(alpha,(table%16),(table/16),index);
+			}
+			//byte swap for pgm
+			img[windex] = uSixteen/256;
+			img[windex+1] = uSixteen%256;
+#endif
+
+		}
+	}			
+}
+
+void decompressBlockAlpha16bit(uint8* data, uint8* img, int width, int height, int ix, int iy)
+{
+  decompressBlockAlpha16bitC(data, img, width, height, ix, iy, 1);
+}

--- a/cocos/platform/CCGL_compatible.h
+++ b/cocos/platform/CCGL_compatible.h
@@ -1,0 +1,174 @@
+/**
+    @date   2015/12/04
+    @note   When you build in Opengles2, thereby compatible OpenGLES3
+*/
+
+
+#ifndef __PLATFORM_CCGL_COMPATIBLE_H__
+#define __PLATFORM_CCGL_COMPATIBLE_H__
+
+#ifndef GL_LUMINANCE
+#define GL_ALPHA						0x1906
+#define GL_LUMINANCE					0x1909
+#define GL_LUMINANCE_ALPHA				0x190A
+#endif
+#ifndef GL_INTENSITY
+#define GL_INTENSITY					0x8049
+#endif
+#if SUPPORT_LEGACY_FORMAT_CONVERSION
+/* For loading legacy KTX files. */
+#ifndef GL_LUMINANCE4
+#define GL_ALPHA4						0x803B
+#define GL_ALPHA8						0x803C
+#define GL_ALPHA12						0x803D
+#define GL_ALPHA16						0x803E
+#define GL_LUMINANCE4					0x803F
+#define GL_LUMINANCE8					0x8040
+#define GL_LUMINANCE12					0x8041
+#define GL_LUMINANCE16					0x8042
+#define GL_LUMINANCE4_ALPHA4			0x8043
+#define GL_LUMINANCE6_ALPHA2			0x8044
+#define GL_LUMINANCE8_ALPHA8			0x8045
+#define GL_LUMINANCE12_ALPHA4			0x8046
+#define GL_LUMINANCE12_ALPHA12			0x8047
+#define GL_LUMINANCE16_ALPHA16			0x8048
+#endif
+#ifndef GL_INTENSITY4
+#define GL_INTENSITY4					0x804A
+#define GL_INTENSITY8					0x804B
+#define GL_INTENSITY12					0x804C
+#define GL_INTENSITY16					0x804D
+#endif
+#ifndef GL_SLUMINANCE
+#define GL_SLUMINANCE_ALPHA				0x8C44
+#define GL_SLUMINANCE8_ALPHA8			0x8C45
+#define GL_SLUMINANCE					0x8C46
+#define GL_SLUMINANCE8					0x8C47
+#endif
+#endif /* SUPPORT_LEGACY_FORMAT_CONVERSION */
+#ifndef GL_TEXTURE_1D
+#define GL_TEXTURE_1D                   0x0DE0
+#endif
+#ifndef GL_TEXTURE_3D
+#define GL_TEXTURE_3D                   0x806F
+#endif
+#ifndef GL_TEXTURE_CUBE_MAP
+#define GL_TEXTURE_CUBE_MAP             0x8513
+#define GL_TEXTURE_CUBE_MAP_POSITIVE_X  0x8515
+#endif
+/* from GL_EXT_texture_array */
+#ifndef GL_TEXTURE_1D_ARRAY_EXT
+#define GL_TEXTURE_1D_ARRAY_EXT         0x8C18
+#define GL_TEXTURE_2D_ARRAY_EXT         0x8C1A
+#endif
+#ifndef GL_GENERATE_MIPMAP
+#define GL_GENERATE_MIPMAP              0x8191
+#endif
+
+/* For writer.c */
+#if !defined(GL_BGR)
+#define GL_BGR							0x80E0
+#define GL_BGRA							0x80E1
+#endif
+#if !defined(GL_RED_INTEGER)
+#define GL_RED_INTEGER					0x8D94
+#define GL_RGB_INTEGER					0x8D98
+#define GL_RGBA_INTEGER					0x8D99
+#endif
+#if !defined(GL_GREEN_INTEGER)
+#define GL_GREEN_INTEGER				0x8D95
+#define GL_BLUE_INTEGER					0x8D96
+#define GL_ALPHA_INTEGER				0x8D97
+#endif
+#if !defined (GL_BGR_INTEGER)
+#define GL_BGR_INTEGER					0x8D9A
+#define GL_BGRA_INTEGER					0x8D9B
+#endif
+#if !defined(GL_INT)
+#define GL_INT 0x1404
+#define GL_UNSIGNED_INT 0x1405
+#endif
+#if !defined(GL_HALF_FLOAT)
+typedef unsigned short GLhalf;
+#define GL_HALF_FLOAT					0x140B
+#endif
+#if !defined(GL_UNSIGNED_BYTE_3_3_2)
+#define GL_UNSIGNED_BYTE_3_3_2			0x8032
+#define GL_UNSIGNED_INT_8_8_8_8			0x8035
+#define GL_UNSIGNED_INT_10_10_10_2		0x8036
+#endif
+#if !defined(GL_UNSIGNED_BYTE_2_3_3_REV)
+#define GL_UNSIGNED_BYTE_2_3_3_REV		0x8362
+#define GL_UNSIGNED_SHORT_5_6_5			0x8363
+#define GL_UNSIGNED_SHORT_5_6_5_REV		0x8364
+#define GL_UNSIGNED_SHORT_4_4_4_4_REV	0x8365
+#define GL_UNSIGNED_SHORT_1_5_5_5_REV	0x8366
+#define GL_UNSIGNED_INT_8_8_8_8_REV		0x8367
+#define GL_UNSIGNED_INT_2_10_10_10_REV	0x8368
+#endif
+#if !defined(GL_UNSIGNED_INT_24_8)
+#define GL_DEPTH_STENCIL				0x84F9
+#define GL_UNSIGNED_INT_24_8			0x84FA
+#endif
+#if !defined(GL_UNSIGNED_INT_5_9_9_9_REV)
+#define GL_UNSIGNED_INT_5_9_9_9_REV		0x8C3E
+#endif
+#if !defined(GL_UNSIGNED_INT_10F_11F_11F_REV)
+#define GL_UNSIGNED_INT_10F_11F_11F_REV 0x8C3B
+#endif
+#if !defined (GL_FLOAT_32_UNSIGNED_INT_24_8_REV)
+#define GL_FLOAT_32_UNSIGNED_INT_24_8_REV	0x8DAD
+#endif
+
+#ifndef GL_ETC1_RGB8_OES
+#define GL_ETC1_RGB8_OES				0x8D64
+#endif
+
+#ifndef GL_COMPRESSED_R11_EAC
+#define GL_COMPRESSED_R11_EAC                            0x9270
+#define GL_COMPRESSED_SIGNED_R11_EAC                     0x9271
+#define GL_COMPRESSED_RG11_EAC                           0x9272
+#define GL_COMPRESSED_SIGNED_RG11_EAC                    0x9273
+#define GL_COMPRESSED_RGB8_ETC2                          0x9274
+#define GL_COMPRESSED_SRGB8_ETC2                         0x9275
+#define GL_COMPRESSED_RGB8_PUNCHTHROUGH_ALPHA1_ETC2      0x9276
+#define GL_COMPRESSED_SRGB8_PUNCHTHROUGH_ALPHA1_ETC2     0x9277
+#define GL_COMPRESSED_RGBA8_ETC2_EAC                     0x9278
+#define GL_COMPRESSED_SRGB8_ALPHA8_ETC2_EAC				 0x9279
+#endif
+#ifndef GL_R16_SNORM
+#define GL_R16_SNORM					0x8F98
+#define GL_RG16_SNORM					0x8F99
+#endif
+#ifndef GL_RED
+#define GL_RED							0x1903
+#define GL_GREEN						0x1904
+#define GL_BLUE							0x1905
+#define GL_RG							0x8227
+#define GL_RG_INTEGER					0x8228
+#endif
+#ifndef GL_R16
+#define GL_R16							0x822A
+#define GL_RG16							0x822C
+#endif
+#ifndef GL_RGB8
+#define GL_RGB8                         0x8051
+#define GL_RGBA8                        0x8058
+#endif
+#ifndef GL_SRGB8
+#define GL_SRGB8						0x8C41
+#define GL_SRGB8_ALPHA8					0x8C43
+#endif
+
+#ifndef GL_MAJOR_VERSION
+#define GL_MAJOR_VERSION                0x821B
+#define GL_MINOR_VERSION                0x821C
+#endif
+
+#ifndef GL_CONTEXT_PROFILE_MASK
+#define GL_CONTEXT_PROFILE_MASK				 0x9126
+#define GL_CONTEXT_CORE_PROFILE_BIT			 0x00000001
+#define GL_CONTEXT_COMPATIBILITY_PROFILE_BIT 0x00000002
+#endif
+
+#endif // __PLATFORM_CCGL_COMPATIBLE_H__

--- a/cocos/platform/CCImage.cpp
+++ b/cocos/platform/CCImage.cpp
@@ -68,6 +68,7 @@ extern "C"
 #if CC_USE_JPEG
 #include "jpeglib.h"
 #endif // CC_USE_JPEG
+#include "base/etc2.h"
 }
 #include "base/s3tc.h"
 #include "base/atitc.h"
@@ -232,6 +233,9 @@ namespace
         _pixel3_formathash::value_type(PVR3TexturePixelFormat::PVRTC4BPP_RGBA,      Texture2D::PixelFormat::PVRTC4A),
 
         _pixel3_formathash::value_type(PVR3TexturePixelFormat::ETC1,        Texture2D::PixelFormat::ETC),
+        _pixel3_formathash::value_type(PVR3TexturePixelFormat::ETC2_RGB,    Texture2D::PixelFormat::ETC2),
+        _pixel3_formathash::value_type(PVR3TexturePixelFormat::ETC2_RGBA1,  Texture2D::PixelFormat::ETC2A1),
+        _pixel3_formathash::value_type(PVR3TexturePixelFormat::ETC2_RGBA,   Texture2D::PixelFormat::ETC2A),
     };
         
     static const int PVR3_MAX_TABLE_ELEMENTS = sizeof(v3_pixel_formathash_value) / sizeof(v3_pixel_formathash_value[0]);
@@ -447,6 +451,17 @@ Texture2D::PixelFormat getDevicePixelFormat(Texture2D::PixelFormat format)
                 return format;
             else
                 return Texture2D::PixelFormat::RGB888;
+        case Texture2D::PixelFormat::ETC2:
+            if(Configuration::getInstance()->supportsETC2())
+                return format;
+            else
+                return Texture2D::PixelFormat::RGB888;
+        case Texture2D::PixelFormat::ETC2A1:
+        case Texture2D::PixelFormat::ETC2A:
+            if(Configuration::getInstance()->supportsETC2())
+                return format;
+            else
+                return Texture2D::PixelFormat::RGBA8888;
         default:
             return format;
     }
@@ -1364,6 +1379,9 @@ namespace
             case PVR3TexturePixelFormat::A8:
             case PVR3TexturePixelFormat::L8:
             case PVR3TexturePixelFormat::LA88:
+            case PVR3TexturePixelFormat::ETC2_RGB:
+            case PVR3TexturePixelFormat::ETC2_RGBA1:
+            case PVR3TexturePixelFormat::ETC2_RGBA:
                 return true;
                 
             default:
@@ -1650,6 +1668,37 @@ bool Image::initWithPVRv3Data(const unsigned char * data, ssize_t dataLen)
                     }
                 }
                 blockSize = 4 * 4; // Pixel by pixel block size for 4bpp
+                widthBlocks = width / 4;
+                heightBlocks = height / 4;
+                break;
+            case PVR3TexturePixelFormat::ETC2_RGB:
+            case PVR3TexturePixelFormat::ETC2_RGBA1:
+            case PVR3TexturePixelFormat::ETC2_RGBA:
+                if (!Configuration::getInstance()->supportsETC2())
+                {
+                    CCLOG("cocos2d: Hardware ETC2 decoder not present. Using software decoder");
+                    int bytePerPixel;
+                    if (pixelFormat == PVR3TexturePixelFormat::ETC2_RGB)
+                    {
+                        bytePerPixel = 3;
+                    }
+                    else
+                    {
+                        bytePerPixel = 4;
+                    }
+                    _unpack = true;
+                    _mipmaps[i].len = width*height*bytePerPixel;
+                    auto formatmap = Texture2D::getPixelFormatInfoMap().find(v3_pixel_formathash.at(pixelFormat));
+                    if (formatmap == Texture2D::getPixelFormatInfoMap().end())
+                    {
+                        return false;
+                    }
+                    if (etc2_decode_image(static_cast<const unsigned char*>(_data+dataOffset), formatmap->second.internalFormat, width, height, static_cast<unsigned char**>(&_mipmaps[i].address)) != 0)
+                    {
+                        return false;
+                    }
+                }
+                blockSize = 4 * 4;
                 widthBlocks = width / 4;
                 heightBlocks = height / 4;
                 break;

--- a/cocos/platform/CCPlatformConfig.h
+++ b/cocos/platform/CCPlatformConfig.h
@@ -140,6 +140,32 @@ THE SOFTWARE.
     #define CC_TARGET_PLATFORM          CC_PLATFORM_WINRT
 #endif
 
+
+// define supported OpenGLES version
+#define CC_OPENGLES_UNKNOWN            0
+#define CC_OPENGLES_2                  2
+#define CC_OPENGLES_3                  3
+
+// version of OpenGLES to use
+#ifndef CC_USE_OPENGLES
+#define CC_USE_OPENGLES     CC_OPENGLES_2
+#endif
+
+#define CC_TARGET_OPENGLES  CC_OPENGLES_UNKNOWN
+
+// iphone
+#if defined(CC_TARGET_OS_IPHONE)
+    #undef  CC_TARGET_OPENGLES
+    #define CC_TARGET_OPENGLES  CC_USE_OPENGLES
+#endif
+
+// android
+#if defined(ANDROID)
+    #undef  CC_TARGET_OPENGLES
+    #define CC_TARGET_OPENGLES  CC_USE_OPENGLES
+#endif
+
+
 //////////////////////////////////////////////////////////////////////////
 // post configure
 //////////////////////////////////////////////////////////////////////////

--- a/cocos/platform/android/CCApplication-android.cpp
+++ b/cocos/platform/android/CCApplication-android.cpp
@@ -208,5 +208,17 @@ void Application::applicationScreenSizeChanged(int newWidth, int newHeight) {
 
 NS_CC_END
 
+// this method is called by Cocos2dxGLSurfaceView
+extern "C"
+{
+    /**
+    * this method is called by java code to init target opengles version.
+    */
+    JNIEXPORT int JNICALL Java_org_cocos2dx_lib_Cocos2dxGLSurfaceView_getTargetOpenGLESVersion()
+    {
+        return cocos2d::Director::getInstance()->getTargetOpenGLESVersion();
+    }
+};
+
 #endif // CC_TARGET_PLATFORM == CC_PLATFORM_ANDROID
 

--- a/cocos/platform/android/CCGL-android.h
+++ b/cocos/platform/android/CCGL-android.h
@@ -33,22 +33,36 @@ THE SOFTWARE.
 #define glDeleteVertexArrays        glDeleteVertexArraysOES
 #define glGenVertexArrays           glGenVertexArraysOES
 #define glBindVertexArray           glBindVertexArrayOES
+#if (CC_TARGET_OPENGLES != CC_OPENGLES_3)
 #define glMapBuffer                 glMapBufferOES
 #define glUnmapBuffer               glUnmapBufferOES
+#endif
 
+#if (CC_TARGET_OPENGLES != CC_OPENGLES_3)
 #define GL_DEPTH24_STENCIL8         GL_DEPTH24_STENCIL8_OES
 #define GL_WRITE_ONLY               GL_WRITE_ONLY_OES
+#endif
 
 // GL_GLEXT_PROTOTYPES isn't defined in glplatform.h on android ndk r7 
 // we manually define it here
+#if (CC_TARGET_OPENGLES == CC_OPENGLES_3)
+#include <GLES3/gl3platform.h>
+#else
 #include <GLES2/gl2platform.h>
+#endif
 #ifndef GL_GLEXT_PROTOTYPES
 #define GL_GLEXT_PROTOTYPES 1
 #endif
 
+#if (CC_TARGET_OPENGLES == CC_OPENGLES_3)
+#include <GLES3/gl3.h>
+#include <GLES3/gl3ext.h>
+#else
 // normal process
 #include <GLES2/gl2.h>
 #include <GLES2/gl2ext.h>
+#include "platform/CCGL_compatible.h"
+#endif
 // gl2.h doesn't define GLchar on Android
 typedef char GLchar;
 // android defines GL_BGRA_EXT but not GL_BRGA
@@ -56,6 +70,7 @@ typedef char GLchar;
 #define GL_BGRA  0x80E1
 #endif
 
+#if (CC_TARGET_OPENGLES != CC_OPENGLES_3)
 //declare here while define in EGLView_android.cpp
 extern PFNGLGENVERTEXARRAYSOESPROC glGenVertexArraysOESEXT;
 extern PFNGLBINDVERTEXARRAYOESPROC glBindVertexArrayOESEXT;
@@ -64,6 +79,7 @@ extern PFNGLDELETEVERTEXARRAYSOESPROC glDeleteVertexArraysOESEXT;
 #define glGenVertexArraysOES glGenVertexArraysOESEXT
 #define glBindVertexArrayOES glBindVertexArrayOESEXT
 #define glDeleteVertexArraysOES glDeleteVertexArraysOESEXT
+#endif
 
 
 #endif // CC_TARGET_PLATFORM == CC_PLATFORM_ANDROID

--- a/cocos/platform/android/CCGLViewImpl-android.cpp
+++ b/cocos/platform/android/CCGLViewImpl-android.cpp
@@ -37,14 +37,19 @@ THE SOFTWARE.
 
 // <EGL/egl.h> exists since android 2.3
 #include <EGL/egl.h>
+
+#if (CC_TARGET_OPENGLES != CC_OPENGLES_3)
 PFNGLGENVERTEXARRAYSOESPROC glGenVertexArraysOESEXT = 0;
 PFNGLBINDVERTEXARRAYOESPROC glBindVertexArrayOESEXT = 0;
 PFNGLDELETEVERTEXARRAYSOESPROC glDeleteVertexArraysOESEXT = 0;
+#endif
 
 void initExtensions() {
+#if (CC_TARGET_OPENGLES != CC_OPENGLES_3)
      glGenVertexArraysOESEXT = (PFNGLGENVERTEXARRAYSOESPROC)eglGetProcAddress("glGenVertexArraysOES");
      glBindVertexArrayOESEXT = (PFNGLBINDVERTEXARRAYOESPROC)eglGetProcAddress("glBindVertexArrayOES");
      glDeleteVertexArraysOESEXT = (PFNGLDELETEVERTEXARRAYSOESPROC)eglGetProcAddress("glDeleteVertexArraysOES");
+#endif
 }
 
 NS_CC_BEGIN

--- a/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxGLSurfaceView.java
+++ b/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxGLSurfaceView.java
@@ -34,6 +34,7 @@ import android.view.KeyEvent;
 import android.view.MotionEvent;
 import android.view.View;
 import android.view.inputmethod.InputMethodManager;
+import android.os.Build;
 
 public class Cocos2dxGLSurfaceView extends GLSurfaceView {
     // ===========================================================
@@ -68,6 +69,8 @@ public class Cocos2dxGLSurfaceView extends GLSurfaceView {
 
     private boolean mSoftKeyboardShown = false;
 
+    private static native int getTargetOpenGLESVersion();
+
 
     // ===========================================================
     // Constructors
@@ -86,7 +89,14 @@ public class Cocos2dxGLSurfaceView extends GLSurfaceView {
     }
 
     protected void initView() {
-        this.setEGLContextClientVersion(2);
+        if ((getTargetOpenGLESVersion() > 2) && (Build.VERSION.SDK_INT >= 18))
+        {
+            this.setEGLContextClientVersion(3);
+        }
+        else
+        {
+            this.setEGLContextClientVersion(2);
+        }
         this.setFocusableInTouchMode(true);
 
         Cocos2dxGLSurfaceView.mCocos2dxGLSurfaceView = this;

--- a/cocos/platform/ios/CCEAGLView-ios.h
+++ b/cocos/platform/ios/CCEAGLView-ios.h
@@ -67,8 +67,13 @@ Copyright (C) 2008 Apple Inc. All Rights Reserved.
 #import <UIKit/UIKit.h>
 #import <OpenGLES/EAGL.h>
 #import <OpenGLES/EAGLDrawable.h>
+#if (CC_TARGET_OPENGLES == CC_OPENGLES_3)
+#import <OpenGLES/ES3/gl.h>
+#import <OpenGLES/ES3/glext.h>
+#else
 #import <OpenGLES/ES2/gl.h>
 #import <OpenGLES/ES2/glext.h>
+#endif
 #import <CoreFoundation/CoreFoundation.h>
 
 #import "CCESRenderer-ios.h"

--- a/cocos/platform/ios/CCES2Renderer-ios.h
+++ b/cocos/platform/ios/CCES2Renderer-ios.h
@@ -33,8 +33,13 @@
 
 #import "CCESRenderer-ios.h"
 
+#if (CC_TARGET_OPENGLES == CC_OPENGLES_3)
+#import <OpenGLES/ES3/gl.h>
+#import <OpenGLES/ES3/glext.h>
+#else
 #import <OpenGLES/ES2/gl.h>
 #import <OpenGLES/ES2/glext.h>
+#endif
 
 #import "CCPlatformMacros.h"
 

--- a/cocos/platform/ios/CCES2Renderer-ios.m
+++ b/cocos/platform/ios/CCES2Renderer-ios.m
@@ -55,9 +55,29 @@
     if (self)
     {
         if( ! sharegroup )
+#if (CC_TARGET_OPENGLES == CC_OPENGLES_3)
+        {
+            context_ = [[EAGLContext alloc] initWithAPI:kEAGLRenderingAPIOpenGLES3];
+            if (context_ == nil)
+            {
+                context_ = [[EAGLContext alloc] initWithAPI:kEAGLRenderingAPIOpenGLES2];
+            }
+        }
+#else
             context_ = [[EAGLContext alloc] initWithAPI:kEAGLRenderingAPIOpenGLES2];
+#endif
         else
+#if (CC_TARGET_OPENGLES == CC_OPENGLES_3)
+        {
+            context_ = [[EAGLContext alloc] initWithAPI:kEAGLRenderingAPIOpenGLES3 sharegroup:sharegroup];
+            if (context_ == nil)
+            {
+                context_ = [[EAGLContext alloc] initWithAPI:kEAGLRenderingAPIOpenGLES2 sharegroup:sharegroup];
+            }
+        }
+#else
             context_ = [[EAGLContext alloc] initWithAPI:kEAGLRenderingAPIOpenGLES2 sharegroup:sharegroup];
+#endif
 
         if (!context_ || ![EAGLContext setCurrentContext:context_] )
         {

--- a/cocos/platform/ios/CCGL-ios.h
+++ b/cocos/platform/ios/CCGL-ios.h
@@ -39,8 +39,14 @@ THE SOFTWARE.
 #define GL_DEPTH24_STENCIL8         GL_DEPTH24_STENCIL8_OES
 #define GL_WRITE_ONLY               GL_WRITE_ONLY_OES
 
+#if (CC_TARGET_OPENGLES == CC_OPENGLES_3)
+#import <OpenGLES/ES3/gl.h>
+#import <OpenGLES/ES3/glext.h>
+#else
 #include <OpenGLES/ES2/gl.h>
 #include <OpenGLES/ES2/glext.h>
+#include "platform/CCGL_compatible.h"
+#endif
 
 #endif // CC_PLATFORM_IOS
 

--- a/cocos/platform/linux/CCGL-linux.h
+++ b/cocos/platform/linux/CCGL-linux.h
@@ -29,6 +29,7 @@ THE SOFTWARE.
 #if CC_TARGET_PLATFORM == CC_PLATFORM_LINUX
 
 #include "GL/glew.h"
+#include "platform/CCGL_compatible.h"
 
 #define CC_GL_DEPTH24_STENCIL8      GL_DEPTH24_STENCIL8
 

--- a/cocos/platform/mac/CCGL-mac.h
+++ b/cocos/platform/mac/CCGL-mac.h
@@ -32,6 +32,7 @@ THE SOFTWARE.
 #import <OpenGL/gl.h>
 #import <OpenGL/glu.h>
 #import <OpenGL/glext.h>
+#include "platform/CCGL_compatible.h"
 
 #define CC_GL_DEPTH24_STENCIL8      -1
 

--- a/cocos/platform/win32/CCGL-win32.h
+++ b/cocos/platform/win32/CCGL-win32.h
@@ -30,6 +30,7 @@ THE SOFTWARE.
 #if CC_TARGET_PLATFORM == CC_PLATFORM_WIN32
 
 #include "GL/glew.h"
+#include "platform/CCGL_compatible.h"
 
 #define CC_GL_DEPTH24_STENCIL8      GL_DEPTH24_STENCIL8
 

--- a/cocos/renderer/CCRenderer.cpp
+++ b/cocos/renderer/CCRenderer.cpp
@@ -830,6 +830,11 @@ void Renderer::drawBatchedTriangles()
         //Set VBO data
         glBindBuffer(GL_ARRAY_BUFFER, _buffersVBO[0]);
 
+#if (CC_TARGET_OPENGLES == CC_OPENGLES_3)
+        void* buf = glMapBufferRange(GL_ARRAY_BUFFER, 0, sizeof(_verts[0]) * _filledVertex, GL_MAP_WRITE_BIT);
+        memcpy(buf, _verts, sizeof(_verts[0])* _filledVertex);
+        glUnmapBuffer(GL_ARRAY_BUFFER);
+#else
         // option 1: subdata
 //        glBufferSubData(GL_ARRAY_BUFFER, sizeof(_quads[0])*start, sizeof(_quads[0]) * n , &_quads[start] );
 
@@ -841,6 +846,7 @@ void Renderer::drawBatchedTriangles()
         void *buf = glMapBuffer(GL_ARRAY_BUFFER, GL_WRITE_ONLY);
         memcpy(buf, _verts, sizeof(_verts[0])* _filledVertex);
         glUnmapBuffer(GL_ARRAY_BUFFER);
+#endif
 
         glBindBuffer(GL_ARRAY_BUFFER, 0);
         
@@ -938,6 +944,11 @@ void Renderer::drawBatchedQuads()
         //Set VBO data
         glBindBuffer(GL_ARRAY_BUFFER, _quadbuffersVBO[0]);
         
+#if (CC_TARGET_OPENGLES == CC_OPENGLES_3)
+        void* buf = glMapBufferRange(GL_ARRAY_BUFFER, 0, sizeof(_quadVerts[0]) * _numberQuads, GL_MAP_WRITE_BIT);
+        memcpy(buf, _quadVerts, sizeof(_quadVerts[0])* _numberQuads * 4);
+        glUnmapBuffer(GL_ARRAY_BUFFER);
+#else
         // option 1: subdata
         //  glBufferSubData(GL_ARRAY_BUFFER, sizeof(_quads[0])*start, sizeof(_quads[0]) * n , &_quads[start] );
         
@@ -949,6 +960,7 @@ void Renderer::drawBatchedQuads()
         void *buf = glMapBuffer(GL_ARRAY_BUFFER, GL_WRITE_ONLY);
         memcpy(buf, _quadVerts, sizeof(_quadVerts[0])* _numberQuads * 4);
         glUnmapBuffer(GL_ARRAY_BUFFER);
+#endif
         
         glBindBuffer(GL_ARRAY_BUFFER, 0);
         

--- a/cocos/renderer/CCTexture2D.cpp
+++ b/cocos/renderer/CCTexture2D.cpp
@@ -81,6 +81,11 @@ namespace {
 #ifdef GL_ETC1_RGB8_OES
         PixelFormatInfoMapValue(Texture2D::PixelFormat::ETC, Texture2D::PixelFormatInfo(GL_ETC1_RGB8_OES, 0xFFFFFFFF, 0xFFFFFFFF, 4, true, false)),
 #endif
+#ifdef GL_COMPRESSED_RGBA8_ETC2_EAC
+        PixelFormatInfoMapValue(Texture2D::PixelFormat::ETC2, Texture2D::PixelFormatInfo(GL_COMPRESSED_RGB8_ETC2, 0xFFFFFFFF, 0xFFFFFFFF, 4, true, false)),
+        PixelFormatInfoMapValue(Texture2D::PixelFormat::ETC2A1, Texture2D::PixelFormatInfo(GL_COMPRESSED_RGB8_PUNCHTHROUGH_ALPHA1_ETC2, 0xFFFFFFFF, 0xFFFFFFFF, 4, true, true)),
+        PixelFormatInfoMapValue(Texture2D::PixelFormat::ETC2A, Texture2D::PixelFormatInfo(GL_COMPRESSED_RGBA8_ETC2_EAC, 0xFFFFFFFF, 0xFFFFFFFF, 8, true, true)),
+#endif
         
 #ifdef GL_COMPRESSED_RGBA_S3TC_DXT1_EXT
         PixelFormatInfoMapValue(Texture2D::PixelFormat::S3TC_DXT1, Texture2D::PixelFormatInfo(GL_COMPRESSED_RGBA_S3TC_DXT1_EXT, 0xFFFFFFFF, 0xFFFFFFFF, 4, true, false)),
@@ -574,6 +579,7 @@ bool Texture2D::initWithMipmaps(MipmapInfo* mipmaps, int mipmapsNum, PixelFormat
 
     if (info.compressed && !Configuration::getInstance()->supportsPVRTC()
                         && !Configuration::getInstance()->supportsETC()
+                        && !Configuration::getInstance()->supportsETC2()
                         && !Configuration::getInstance()->supportsS3TC()
                         && !Configuration::getInstance()->supportsATITC())
     {

--- a/cocos/renderer/CCTexture2D.h
+++ b/cocos/renderer/CCTexture2D.h
@@ -102,6 +102,12 @@ public:
         PVRTC2A,
         //! ETC-compressed texture: ETC
         ETC,
+        //! 4-bit ETC2-compressed texture: ETC2 RGB
+        ETC2,
+        //! 4-bit ETC2-compressed texture: ETC2 RGB8 1bit Alpha channel
+        ETC2A1,
+        //! 8-bit ETC2-compressed texture: ETC2 RGBA8 (has alpha channel)
+        ETC2A,
         //! S3TC-compressed texture: S3TC_Dxt1
         S3TC_DXT1,
         //! S3TC-compressed texture: S3TC_Dxt3

--- a/cocos/renderer/CCTextureAtlas.cpp
+++ b/cocos/renderer/CCTextureAtlas.cpp
@@ -624,11 +624,17 @@ void TextureAtlas::drawNumberOfQuads(ssize_t numberOfQuads, ssize_t start)
             // option 2: data
 //            glBufferData(GL_ARRAY_BUFFER, sizeof(quads_[0]) * (n-start), &quads_[start], GL_DYNAMIC_DRAW);
 
+#if (CC_TARGET_OPENGLES == CC_OPENGLES_3)
+            void* buf = glMapBufferRange(GL_ARRAY_BUFFER, 0, sizeof(_quads[0]) * _capacity, GL_MAP_WRITE_BIT);
+            memcpy(buf, _quads, sizeof(_quads[0])* _totalQuads);
+            glUnmapBuffer(GL_ARRAY_BUFFER);
+#else
             // option 3: orphaning + glMapBuffer
             glBufferData(GL_ARRAY_BUFFER, sizeof(_quads[0]) * _capacity, nullptr, GL_DYNAMIC_DRAW);
             void *buf = glMapBuffer(GL_ARRAY_BUFFER, GL_WRITE_ONLY);
             memcpy(buf, _quads, sizeof(_quads[0])* _totalQuads);
             glUnmapBuffer(GL_ARRAY_BUFFER);
+#endif
             
             glBindBuffer(GL_ARRAY_BUFFER, 0);
 

--- a/licenses/LICENSE_ktx.txt
+++ b/licenses/LICENSE_ktx.txt
@@ -1,0 +1,7 @@
+Licensing
+---
+The library and tools are open source software. Most of the code is licensed
+under a modified BSD license. The code for unpacking ETC1, ETC2 and EAC
+compressed textures has a separate license that restricts it to uses
+associated with Khronos Group APIs. See [Licensing](http://www.khronos.org/opengles/sdk/tools/KTX/doc/libktx/licensing.html)
+for more details.


### PR DESCRIPTION
add etc2 CPU and GPU decode. (PVR fileformat only)
original source code is KTX(Khronos).
optimize for KTX cpu decode.
etc2 GPU decode setting is add "-DCC_USE_OPENGLES=3" for compile option.
## ETC2 GPU decode

GPU decode of ETC2 requires OpenGLES3.

for example.

Xcode
Preprocessor Macros
“CC_USE_OPENGLES=3”

Android
Application.mk
“APP_CPPFLAGS := -DCC_USE_OPENGLES=3”
