### PR TITLE
Uniformize image support macro usage.

### DIFF
--- a/cocos/platform/CCImage.cpp
+++ b/cocos/platform/CCImage.cpp
@@ -802,7 +802,7 @@ namespace
 #endif // CC_USE_JPEG
 }
 
-#ifdef CC_USE_WIC
+#if CC_USE_WIC
 bool Image::decodeWithWIC(const unsigned char *data, ssize_t dataLen)
 {
     bool bRet = false;

--- a/cocos/platform/CCImage.h
+++ b/cocos/platform/CCImage.h
@@ -30,7 +30,7 @@ THE SOFTWARE.
 #include "base/CCRef.h"
 #include "renderer/CCTexture2D.h"
 
-#if defined(CC_USE_WIC)
+#if CC_USE_WIC
 #include "platform/winrt/WICImageLoader-winrt.h"
 #endif
 
@@ -155,7 +155,7 @@ public:
     static void setPVRImagesHavePremultipliedAlpha(bool haveAlphaPremultiplied);
 
 protected:
-#if defined(CC_USE_WIC)
+#if CC_USE_WIC
     bool encodeWithWIC(const std::string& filePath, bool isToRGB, GUID containerFormat);
     bool decodeWithWIC(const unsigned char *data, ssize_t dataLen);
 #endif

--- a/cocos/platform/winrt/WICImageLoader-winrt.cpp
+++ b/cocos/platform/winrt/WICImageLoader-winrt.cpp
@@ -29,7 +29,7 @@ obtained from https://directxtk.codeplex.com
 
 NS_CC_BEGIN
 
-#if defined(CC_USE_WIC)
+#if CC_USE_WIC
 
 	IWICImagingFactory* WICImageLoader::_wicFactory = NULL;
 

--- a/cocos/platform/winrt/WICImageLoader-winrt.h
+++ b/cocos/platform/winrt/WICImageLoader-winrt.h
@@ -31,7 +31,7 @@ obtained from https://directxtk.codeplex.com
 #include "base/ccConfig.h"
 
 
-#if defined(CC_USE_WIC)
+#if CC_USE_WIC
 
 #include <memory>
 #include <string>


### PR DESCRIPTION
All images format implementation but WIC test the value of a CC_USE_<FORMAT>
preprocessor macro to verify if the implementation must be available or not.
WIC support is checked against the definition of the macro only,
independently of its value, thus making the implementation available even
if CC_USE_WIC = 0.

This commit makes the tests of the CC_USE_WIC macro identical to the tests
of the other similar image format macros.
