### PR TITLE
Allow to unbind asynchronous texture loading callback with a custom key.

### DIFF
--- a/cocos/renderer/CCTextureCache.h
+++ b/cocos/renderer/CCTextureCache.h
@@ -122,6 +122,8 @@ public:
     */
     virtual void addImageAsync(const std::string &filepath, const std::function<void(Texture2D*)>& callback);
     
+    void addImageAsync(const std::string &path, const std::function<void(Texture2D*)>& callback, const std::string& callbackKey );
+
     /** Unbind a specified bound image asynchronous callback.
      * In the case an object who was bound to an image asynchronous callback was destroyed before the callback is invoked,
      * the object always need to unbind this callback manually.


### PR DESCRIPTION
In order to unbind the callback passed to
`cocos2d::TextureCache::addImageAsync(path, callback)`, one has to
call `cocos2d::TextureCache::unbindImageAsync(path)`. In the cases
where the loading of the same texture is requested from several sources
simultaneously, then none of the source can unbind its own callback
unambiguously.

This commit adds an overload of the `addImageAsync` function taking an extra
argument identifying the callback, thus allowing to unbind it unambiguously
in cases where the loading of path is requested by several sources
simultaneously.
