### PR TITLE
Remove unnecessary c_str() calls

### DIFF
--- a/cocos/editor-support/cocosbuilder/CCNodeLoader.cpp
+++ b/cocos/editor-support/cocosbuilder/CCNodeLoader.cpp
@@ -580,7 +580,7 @@ SpriteFrame * NodeLoader::parsePropTypeSpriteFrame(Node * pNode, Node * pParent,
         if (spriteSheet.empty())
         {
             spriteFile = ccbReader->getCCBRootPath() + spriteFile;
-            Texture2D * texture = Director::getInstance()->getTextureCache()->addImage(spriteFile.c_str());
+            Texture2D * texture = Director::getInstance()->getTextureCache()->addImage(spriteFile);
             if(texture != nullptr) {
                 Rect bounds = Rect(0, 0, texture->getContentSize().width, texture->getContentSize().height);
                 spriteFrame = SpriteFrame::createWithTexture(texture, bounds);
@@ -593,11 +593,11 @@ SpriteFrame * NodeLoader::parsePropTypeSpriteFrame(Node * pNode, Node * pParent,
             // Load the sprite sheet only if it is not loaded
             if (ccbReader->getLoadedSpriteSheet().find(spriteSheet) == ccbReader->getLoadedSpriteSheet().end())
             {
-                frameCache->addSpriteFramesWithFile(spriteSheet.c_str());
+                frameCache->addSpriteFramesWithFile(spriteSheet);
                 ccbReader->getLoadedSpriteSheet().insert(spriteSheet);
             }
             
-            spriteFrame = frameCache->getSpriteFrameByName(spriteFile.c_str());
+            spriteFrame = frameCache->getSpriteFrameByName(spriteFile);
         }
         
         if (ccbReader->getAnimatedProperties()->find(pPropertyName) != ccbReader->getAnimatedProperties()->end())
@@ -626,9 +626,9 @@ Animation * NodeLoader::parsePropTypeAnimation(Node * pNode, Node * pParent, CCB
     if (!animation.empty()) 
     {
         AnimationCache * animationCache = AnimationCache::getInstance();
-        animationCache->addAnimationsWithFile(animationFile.c_str());
+        animationCache->addAnimationsWithFile(animationFile);
         
-        ccAnimation = animationCache->getAnimation(animation.c_str());
+        ccAnimation = animationCache->getAnimation(animation);
     }
     return ccAnimation;
 }
@@ -638,7 +638,7 @@ Texture2D * NodeLoader::parsePropTypeTexture(Node * pNode, Node * pParent, CCBRe
     
     if (!spriteFile.empty())
     {
-        return Director::getInstance()->getTextureCache()->addImage(spriteFile.c_str());
+        return Director::getInstance()->getTextureCache()->addImage(spriteFile);
     }
     else 
     {
@@ -925,7 +925,7 @@ Node * NodeLoader::parsePropTypeCCBFile(Node * pNode, Node * pParent, CCBReader 
     ccbFileName = ccbFileWithoutPathExtension + ".ccbi";
     
     // Load sub file
-    std::string path = FileUtils::getInstance()->fullPathForFilename(ccbFileName.c_str());
+    std::string path = FileUtils::getInstance()->fullPathForFilename(ccbFileName);
 
     auto dataPtr = std::make_shared<Data>(FileUtils::getInstance()->getDataFromFile(path));
     

--- a/cocos/editor-support/cocostudio/CCSGUIReader.cpp
+++ b/cocos/editor-support/cocostudio/CCSGUIReader.cpp
@@ -492,7 +492,7 @@ Widget* WidgetPropertiesReader0250::createWidget(const rapidjson::Value& data, c
         const char* file = DICTOOL->getStringValueFromArray_json(data, "textures", i);
         std::string tp = fullPath;
         tp.append(file);
-        SpriteFrameCache::getInstance()->addSpriteFramesWithFile(tp.c_str());
+        SpriteFrameCache::getInstance()->addSpriteFramesWithFile(tp);
     }
     float fileDesignWidth = DICTOOL->getFloatValue_json(data, "designWidth");
     float fileDesignHeight = DICTOOL->getFloatValue_json(data, "designHeight");
@@ -1214,7 +1214,7 @@ Widget* WidgetPropertiesReader0300::createWidget(const rapidjson::Value& data, c
         const char* file = DICTOOL->getStringValueFromArray_json(data, "textures", i);
         std::string tp = fullPath;
         tp.append(file);
-        SpriteFrameCache::getInstance()->addSpriteFramesWithFile(tp.c_str());
+        SpriteFrameCache::getInstance()->addSpriteFramesWithFile(tp);
     }
     float fileDesignWidth = DICTOOL->getFloatValue_json(data, "designWidth");
     float fileDesignHeight = DICTOOL->getFloatValue_json(data, "designHeight");

--- a/cocos/editor-support/spine/spine-cocos2dx.cpp
+++ b/cocos/editor-support/spine/spine-cocos2dx.cpp
@@ -48,7 +48,7 @@ void _spAtlasPage_disposeTexture (spAtlasPage* self) {
 
 char* _spUtil_readFile (const char* path, int* length) {
 	Data data = FileUtils::getInstance()->getDataFromFile(
-			FileUtils::getInstance()->fullPathForFilename(path).c_str());
+			FileUtils::getInstance()->fullPathForFilename(path));
 	*length = data.getSize();
 	char* bytes = MALLOC(char, *length);
 	memcpy(bytes, data.getBytes(), *length);

--- a/cocos/network/SocketIO.cpp
+++ b/cocos/network/SocketIO.cpp
@@ -417,7 +417,7 @@ void SIOClientImpl::handshake()
     pre << "http://" << _uri << "/socket.io/1/?EIO=2&transport=polling&b64=true";
 
     HttpRequest* request = new (std::nothrow) HttpRequest();
-    request->setUrl(pre.str().c_str());
+    request->setUrl(pre.str());
     request->setRequestType(HttpRequest::Type::GET);
 
     request->setResponseCallback(CC_CALLBACK_2(SIOClientImpl::handshakeResponse, this));
@@ -865,7 +865,7 @@ void SIOClientImpl::onMessage(WebSocket* ws, const WebSocket::Data& data)
             case 2:
                 CCLOGINFO("Ping received, send pong");
                 payload = "3" + payload;
-                _ws->send(payload.c_str());
+                _ws->send(payload);
                 break;
             case 3:
                 CCLOGINFO("Pong received");

--- a/cocos/scripting/lua-bindings/manual/network/lua_xml_http_request.cpp
+++ b/cocos/scripting/lua-bindings/manual/network/lua_xml_http_request.cpp
@@ -789,7 +789,7 @@ static int lua_cocos2dx_XMLHttpRequest_open(lua_State* L)
                 self->getHttpRequest()->setRequestType(network::HttpRequest::Type::UNKNOWN);
             }
             
-            self->getHttpRequest()->setUrl(url.c_str());
+            self->getHttpRequest()->setUrl(url);
             
         }
         


### PR DESCRIPTION
This commit removes some unnecessary `c_str()` calls to avoid creating temporary string objects.
