### PR TITLE
Add missing 'override' keywords

### DIFF
--- a/cocos/platform/android/CCFileUtils-android.h
+++ b/cocos/platform/android/CCFileUtils-android.h
@@ -59,7 +59,7 @@ public:
     static AAssetManager* getAssetManager() { return assetmanager; }
 
     /* override functions */
-    bool init();
+    bool init() override;
 
     virtual std::string getNewFilename(const std::string &filename) const override;
 
@@ -77,8 +77,8 @@ public:
      */
     virtual Data getDataFromFile(const std::string& filename) override;
 
-    virtual std::string getWritablePath() const;
-    virtual bool isAbsolutePath(const std::string& strPath) const;
+    virtual std::string getWritablePath() const override;
+    virtual bool isAbsolutePath(const std::string& strPath) const override;
     
 private:
     virtual bool isFileExistInternal(const std::string& strFilePath) const override;


### PR DESCRIPTION
Hello, when I tried to build with clang 3.6 for Android NDK, I get the following warnings:

```
platform/android/CCFileUtils-android.h:62:10: warning:
      'init' overrides a member function but is not marked 'override'
      [-Winconsistent-missing-override]
    bool init();
         ^

platform/android/CCFileUtils-android.h:80:25: warning:
      'getWritablePath' overrides a member function but is not marked 'override'
      [-Winconsistent-missing-override]
    virtual std::string getWritablePath() const;
                        ^

platform/android/CCFileUtils-android.h:81:18: warning:
      'isAbsolutePath' overrides a member function but is not marked 'override'
      [-Winconsistent-missing-override]
    virtual bool isAbsolutePath(const std::string& strPath) const;
                 ^
```

This pull request adds several missing `override` keywords and fixes them. Thanks.
