### PR TITLE
Add Core Video uncompressed pixel format

### DIFF
--- a/cocos/renderer/CCTexture2D.cpp
+++ b/cocos/renderer/CCTexture2D.cpp
@@ -61,6 +61,7 @@ namespace {
     typedef Texture2D::PixelFormatInfoMap::value_type PixelFormatInfoMapValue;
     static const PixelFormatInfoMapValue TexturePixelFormatInfoTablesValue[] =
     {
+        PixelFormatInfoMapValue(Texture2D::PixelFormat::RGBAintBGRAs8888, Texture2D::PixelFormatInfo(GL_RGBA, GL_BGRA, GL_UNSIGNED_BYTE, 32, false, true)),
         PixelFormatInfoMapValue(Texture2D::PixelFormat::BGRA8888, Texture2D::PixelFormatInfo(GL_BGRA, GL_BGRA, GL_UNSIGNED_BYTE, 32, false, true)),
         PixelFormatInfoMapValue(Texture2D::PixelFormat::RGBA8888, Texture2D::PixelFormatInfo(GL_RGBA, GL_RGBA, GL_UNSIGNED_BYTE, 32, false, true)),
         PixelFormatInfoMapValue(Texture2D::PixelFormat::RGBA4444, Texture2D::PixelFormatInfo(GL_RGBA, GL_RGBA, GL_UNSIGNED_SHORT_4_4_4_4, 16, false, true)),

--- a/cocos/renderer/CCTexture2D.h
+++ b/cocos/renderer/CCTexture2D.h
@@ -78,6 +78,8 @@ public:
         BGRA8888,
         //! 32-bit texture: RGBA8888
         RGBA8888,
+        //! 32-bit texture: RGBA8888 internally, BGRA8888 source
+        RGBAintBGRAs8888,
         //! 24-bit texture: RGBA888
         RGB888,
         //! 16-bit texture without Alpha channel


### PR DESCRIPTION
To capture uncompressed preview from the iOS camera, you have to set pixel format to `kCVPixelFormatType_32BGRA`.  See http://stackoverflow.com/questions/15572893/capture-still-uiimage-without-compression-from-cmsamplebufferref.

This PR adds a pixel format that is RGBA8888 internally, sourced from BGRA8888 (i.e. `kCVPixelFormatType_32BGRA`
