### PR TITLE
Fix format string warnings

### DIFF
--- a/cocos/audio/android/AudioEngine-inl.cpp
+++ b/cocos/audio/android/AudioEngine-inl.cpp
@@ -321,7 +321,7 @@ void AudioEngineImpl::setVolume(int audioID,float volume)
     }
     auto result = (*player._fdPlayerVolume)->SetVolumeLevel(player._fdPlayerVolume, dbVolume);
     if(SL_RESULT_SUCCESS != result){
-        log("%s error:%u",__func__, result);
+        log("%s error:%lu", __func__, result);
     }
 }
 
@@ -341,7 +341,7 @@ void AudioEngineImpl::pause(int audioID)
     auto& player = _audioPlayers[audioID];
     auto result = (*player._fdPlayerPlay)->SetPlayState(player._fdPlayerPlay, SL_PLAYSTATE_PAUSED);
     if(SL_RESULT_SUCCESS != result){
-        log("%s error:%u",__func__, result);
+        log("%s error:%lu", __func__, result);
     }
 }
 
@@ -350,7 +350,7 @@ void AudioEngineImpl::resume(int audioID)
     auto& player = _audioPlayers[audioID];
     auto result = (*player._fdPlayerPlay)->SetPlayState(player._fdPlayerPlay, SL_PLAYSTATE_PLAYING);
     if(SL_RESULT_SUCCESS != result){
-        log("%s error:%u",__func__, result);
+        log("%s error:%lu", __func__, result);
     }
 }
 
@@ -359,7 +359,7 @@ void AudioEngineImpl::stop(int audioID)
     auto& player = _audioPlayers[audioID];
     auto result = (*player._fdPlayerPlay)->SetPlayState(player._fdPlayerPlay, SL_PLAYSTATE_STOPPED);
     if(SL_RESULT_SUCCESS != result){
-        log("%s error:%u",__func__, result);
+        log("%s error:%lu", __func__, result);
     }
 
     /*If destroy openSL object immediately,it may cause dead lock.


### PR DESCRIPTION
When compiling with GCC 4.9 for Android NDK, it shows the warnings below:

```
cocos/audio/android/AudioEngine-inl.cpp:324:54: warning: format '%u' expects argument of type 'unsigned int', but argument 3 has type 'long unsigned int' [-Wformat=]
cocos/audio/android/AudioEngine-inl.cpp:344:54: warning: format '%u' expects argument of type 'unsigned int', but argument 3 has type 'long unsigned int' [-Wformat=]
cocos/audio/android/AudioEngine-inl.cpp:353:54: warning: format '%u' expects argument of type 'unsigned int', but argument 3 has type 'long unsigned int' [-Wformat=]
cocos/audio/android/AudioEngine-inl.cpp:362:54: warning: format '%u' expects argument of type 'unsigned int', but argument 3 has type 'long unsigned int' [-Wformat=]
```

This patch replaces `%u` (unsigned int) with `%lu` (long unsigned int) and fixes them.
