### PR TITLE
Scale9Sprite: allow to set custom shaders (fix #12753)

### DIFF
--- a/cocos/ui/UIScale9Sprite.cpp
+++ b/cocos/ui/UIScale9Sprite.cpp
@@ -483,7 +483,11 @@ namespace ui {
         }
 
         applyBlendFunc();
-        this->setState(_brightState);
+        if (getGLProgramState()) {
+            _scale9Image->setGLProgramState(getGLProgramState());
+        } else {
+            this->setState(_brightState);
+        }
         if(this->_isPatch9)
         {
             size.width = size.width - 2;
@@ -604,11 +608,7 @@ namespace ui {
             break;
         }
         
-        if (nullptr != _scale9Image)
-        {
-            _scale9Image->setGLProgramState(glState);
-        }
-
+        setGLProgramState(glState);
         _brightState = state;
     }
 
@@ -977,6 +977,20 @@ namespace ui {
 
         for(auto child : _children){
             child->updateDisplayedOpacity(255);
+        }
+    }
+    
+    void Scale9Sprite::setGLProgram(GLProgram *glprogram) {
+        Node::setGLProgram(glprogram);
+        if (_scale9Image) {
+            _scale9Image->setGLProgram(glprogram);
+        }
+    }
+    
+    void Scale9Sprite::setGLProgramState(GLProgramState *glProgramState) {
+        Node::setGLProgramState(glProgramState);
+        if (_scale9Image) {
+            _scale9Image->setGLProgramState(glProgramState);
         }
     }
 

--- a/cocos/ui/UIScale9Sprite.h
+++ b/cocos/ui/UIScale9Sprite.h
@@ -601,7 +601,8 @@ namespace ui {
         virtual void updateDisplayedColor(const Color3B& parentColor) override;
         virtual void disableCascadeColor() override;
         virtual void disableCascadeOpacity() override;
-        
+        virtual void setGLProgram(GLProgram *glprogram) override;
+        virtual void setGLProgramState(GLProgramState *glProgramState) override;
         
         /**
          * @brief Get the original no 9-sliced sprite


### PR DESCRIPTION
As **State** also sets shaders, may be it would be better to add third state like _CUSTOM_ or _NONE_ that will be set when used custom shaders.
