### PR TITLE
Let ScrollView swallow touch events by default.

### DIFF
--- a/extensions/GUI/CCScrollView/CCScrollView.cpp
+++ b/extensions/GUI/CCScrollView/CCScrollView.cpp
@@ -190,6 +190,7 @@ void ScrollView::setTouchEnabled(bool enabled)
     if (enabled)
     {
         _touchListener = EventListenerTouchOneByOne::create();
+        _touchListener->setSwallowTouches(true);
         _touchListener->onTouchBegan = CC_CALLBACK_2(ScrollView::onTouchBegan, this);
         _touchListener->onTouchMoved = CC_CALLBACK_2(ScrollView::onTouchMoved, this);
         _touchListener->onTouchEnded = CC_CALLBACK_2(ScrollView::onTouchEnded, this);


### PR DESCRIPTION
  This is more intuitive. It's used by `UIWidget` too.
