### PR TITLE
Bitmap font sizes are not loaded from binary .fnt files.

### DIFF
--- a/cocos/2d/CCFontFNT.cpp
+++ b/cocos/2d/CCFontFNT.cpp
@@ -397,6 +397,7 @@ std::set<unsigned int>* BMFontConfiguration::parseBinaryConfigFile(unsigned char
              fontName       n+1 string   14 null terminated string with length n
              */
 
+            memcpy(&_fontSize, pData, 2);
             _padding.top = (unsigned char)pData[7];
             _padding.right = (unsigned char)pData[8];
             _padding.bottom = (unsigned char)pData[9];


### PR DESCRIPTION
This problem causes bitmap fonts based on .fnt files to not appear at all, and no error is thrown.
Fixes #15042.
