### PR TITLE
Fix drawing in incorrect app states on iOS

### DIFF
--- a/cocos/platform/ios/CCDirectorCaller-ios.h
+++ b/cocos/platform/ios/CCDirectorCaller-ios.h
@@ -31,6 +31,7 @@
 @interface CCDirectorCaller : NSObject {
         id displayLink;
         int interval;
+        BOOL isAppActive;
 }
 @property (readwrite) int interval;
 -(void) startMainLoop;

--- a/cocos/platform/ios/CCDirectorCaller-ios.mm
+++ b/cocos/platform/ios/CCDirectorCaller-ios.mm
@@ -69,10 +69,34 @@ static id s_sharedDirectorCaller;
         interval = 1;
 }
 
+- (instancetype)init
+{
+    self = [super init];
+    if (self)
+    {
+        isAppActive = [UIApplication sharedApplication].applicationState == UIApplicationStateActive;
+        NSNotificationCenter *nc = [NSNotificationCenter defaultCenter];
+        [nc addObserver:self selector:@selector(appDidBecomeActive) name:UIApplicationDidBecomeActiveNotification object:nil];
+        [nc addObserver:self selector:@selector(appDidBecomeInactive) name:UIApplicationWillResignActiveNotification object:nil];
+    }
+    return self;
+}
+
 -(void) dealloc
 {
+    [[NSNotificationCenter defaultCenter] removeObserver:self];
     [displayLink release];
     [super dealloc];
+}
+
+- (void)appDidBecomeActive
+{
+    isAppActive = YES;
+}
+
+- (void)appDidBecomeInactive
+{
+    isAppActive = NO;
 }
 
 -(void) startMainLoop
@@ -105,9 +129,11 @@ static id s_sharedDirectorCaller;
                       
 -(void) doCaller: (id) sender
 {
-    cocos2d::Director* director = cocos2d::Director::getInstance();
-    [EAGLContext setCurrentContext: [(CCEAGLView*)director->getOpenGLView()->getEAGLView() context]];
-    director->mainLoop();
+    if (isAppActive) {
+        cocos2d::Director* director = cocos2d::Director::getInstance();
+        [EAGLContext setCurrentContext: [(CCEAGLView*)director->getOpenGLView()->getEAGLView() context]];
+        director->mainLoop();
+    }
 }
 
 @end

--- a/cocos/platform/ios/CCEAGLView-ios.mm
+++ b/cocos/platform/ios/CCEAGLView-ios.mm
@@ -266,7 +266,10 @@ Copyright (C) 2008 Apple Inc. All Rights Reserved.
 
     // Avoid flicker. Issue #350
     //[director performSelectorOnMainThread:@selector(drawScene) withObject:nil waitUntilDone:YES];
-    cocos2d::Director::getInstance()->drawScene();
+    if ([NSThread isMainThread])
+    {
+        cocos2d::Director::getInstance()->drawScene();
+    }
 }
 
 - (void) swapBuffers


### PR DESCRIPTION
1. Sometimes _layoutSubviews_ called from WebThread. Possibly it occurs due to some issues with banners.
2. Sometimes drawScene called too early, while app still is not Active (_applicationDidFinishLaunching_ was called, but _applicationDidBecomeActive_ wasn't).

P.S. Haven't find any reports when app crashed due to using opengl in inactive state after it successfully started. So it may be better to fix this issue only for _start_ flow, and remove _if_ condition inside _doCaller_.
