### PR TITLE
Add missing reference-return types

### DIFF
--- a/cocos/2d/CCParticleSystem.h
+++ b/cocos/2d/CCParticleSystem.h
@@ -761,7 +761,7 @@ public:
     */
     virtual const BlendFunc &getBlendFunc() const override;
 
-    const std::string getResourceFile() const { return _plistFile; }
+    const std::string& getResourceFile() const { return _plistFile; }
 
     /// @{
     /// @name implement Playable Protocol

--- a/cocos/2d/CCSprite.h
+++ b/cocos/2d/CCSprite.h
@@ -475,7 +475,7 @@ public:
     /// @}
 
     const int getResourceType() const { return _fileType; }
-    const std::string getResourceName() const { return _fileName; }
+    const std::string& getResourceName() const { return _fileName; }
 
 CC_CONSTRUCTOR_ACCESS :
 	/**

--- a/cocos/2d/CCTMXTiledMap.h
+++ b/cocos/2d/CCTMXTiledMap.h
@@ -253,7 +253,7 @@ public:
     virtual std::string getDescription() const override;
 
     int  getLayerNum();
-    const std::string getResourceFile() const { return _tmxFile; }
+    const std::string& getResourceFile() const { return _tmxFile; }
 
 CC_CONSTRUCTOR_ACCESS:
     /**

--- a/cocos/ui/UIScrollView.cpp
+++ b/cocos/ui/UIScrollView.cpp
@@ -230,7 +230,7 @@ void ScrollView::setInnerContainerPosition(const Vec2 &position)
     this->release();
 }
     
-const Vec2 ScrollView::getInnerContainerPosition() const
+const Vec2& ScrollView::getInnerContainerPosition() const
 {
     return _innerContainer->getPosition();
 }

--- a/cocos/ui/UIScrollView.h
+++ b/cocos/ui/UIScrollView.h
@@ -329,7 +329,7 @@ public:
      *
      * @return The inner container position.
      */
-    const Vec2 getInnerContainerPosition() const;
+    const Vec2& getInnerContainerPosition() const;
 
     /**
      * Add callback function which will be called  when scrollview event triggered.

--- a/extensions/Particle3D/PU/CCPUParticleSystem3D.h
+++ b/extensions/Particle3D/PU/CCPUParticleSystem3D.h
@@ -303,7 +303,7 @@ public:
     void setMaxVelocity(float maxVelocity);
 
     void setMaterialName(const std::string &name) { _matName = name; };
-    const std::string getMaterialName() const { return _matName; };
+    const std::string& getMaterialName() const { return _matName; };
 
     /** Forces emission of particles.
      * @remarks The number of requested particles are the exact number that are emitted. No down-scalling is applied.


### PR DESCRIPTION
Hello, this pull request adds several missing reference-return types to avoid copying when returning the members of a class. Thanks.
