### PR TITLE
setPhysicsBody can be called multiple times again

### DIFF
--- a/cocos/2d/CCNode.h
+++ b/cocos/2d/CCNode.h
@@ -38,6 +38,10 @@
 #include "2d/CCComponentContainer.h"
 #include "2d/CCComponent.h"
 
+#if CC_USE_PHYSICS
+#include "physics/CCPhysicsBody.h"
+#endif
+
 NS_CC_BEGIN
 
 class GridBase;
@@ -1940,9 +1944,9 @@ protected:
     ComponentContainer *_componentContainer;        ///< Dictionary of components
     
     // opacity controls
-    GLubyte         _displayedOpacity;
+    GLubyte     _displayedOpacity;
     GLubyte     _realOpacity;
-    Color3B         _displayedColor;
+    Color3B     _displayedColor;
     Color3B     _realColor;
     bool        _cascadeColorEnabled;
     bool        _cascadeOpacityEnabled;
@@ -1961,8 +1965,13 @@ protected:
 #if CC_USE_PHYSICS
     PhysicsBody* _physicsBody;
 public:
-    void setPhysicsBody(Component* physicsBody) 
-    { 
+    void setPhysicsBody(PhysicsBody* physicsBody)
+    {
+        if (_physicsBody != nullptr)
+        {
+            removeComponent(_physicsBody);
+        }
+
         addComponent(physicsBody);
     }
     PhysicsBody* getPhysicsBody() const { return _physicsBody; }


### PR DESCRIPTION
Before the addition of Physics component, one was able to call `setPhysicsBody` multiple times. The current `setPhysicsBody` method for backwards compability doesn't allow that anymore, because same components can't be added multiple times. This pr fixes that.

This is a updated version of my previous pr https://github.com/cocos2d/cocos2d-x/pull/14371
