### PR TITLE
Fixed behavior of "cc.isObject" function for undefined and null values.

### DIFF
--- a/cocos/scripting/js-bindings/script/jsb_prepare.js
+++ b/cocos/scripting/js-bindings/script/jsb_prepare.js
@@ -129,8 +129,7 @@ cc.isUndefined = function(obj) {
  * @returns {boolean}
  */
 cc.isObject = function(obj) {
-    return obj && obj.__nativeObj !== undefined ||
-        ( typeof obj === "object" && Object.prototype.toString.call(obj) === '[object Object]' );
+    return return ( obj !== null && typeof obj === "object" );
 };
 
 /**

--- a/cocos/scripting/js-bindings/script/jsb_prepare.js
+++ b/cocos/scripting/js-bindings/script/jsb_prepare.js
@@ -129,7 +129,7 @@ cc.isUndefined = function(obj) {
  * @returns {boolean}
  */
 cc.isObject = function(obj) {
-    return obj.__nativeObj !== undefined ||
+    return obj && obj.__nativeObj !== undefined ||
         ( typeof obj === "object" && Object.prototype.toString.call(obj) === '[object Object]' );
 };
 

--- a/cocos/scripting/js-bindings/script/jsb_prepare.js
+++ b/cocos/scripting/js-bindings/script/jsb_prepare.js
@@ -129,7 +129,7 @@ cc.isUndefined = function(obj) {
  * @returns {boolean}
  */
 cc.isObject = function(obj) {
-    return return ( obj !== null && typeof obj === "object" );
+    return ( obj !== null && typeof obj === "object" );
 };
 
 /**


### PR DESCRIPTION
On native platforms if obj is undefined or null then attempt to access **obj.__nativeObj** leads to incorrect behavior of function.
