### PR TITLE
Fix return value of VertexAttribBinding::init()

### DIFF
--- a/cocos/renderer/CCVertexAttribBinding.cpp
+++ b/cocos/renderer/CCVertexAttribBinding.cpp
@@ -111,7 +111,7 @@ bool VertexAttribBinding::init(MeshIndexData* meshIndexData, GLProgramState* glP
         if (__maxVertexAttribs <= 0)
         {
             CCLOGERROR("The maximum number of vertex attributes supported by OpenGL on the current device is 0 or less.");
-            return NULL;
+            return false;
         }
     }
 


### PR DESCRIPTION
According to the declaration, `VertexAttribBinding::init()` function must return a bool type value, not null pointer constant. So this pull request replaces `NULL` with `false`, to avoid implicit conversion of null to bool.
