### PR TITLE
Set music volume control as default

### DIFF
--- a/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxActivity.java
+++ b/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxActivity.java
@@ -29,6 +29,7 @@ import android.content.Intent;
 import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageManager;
 import android.graphics.PixelFormat;
+import android.media.AudioManager;
 import android.opengl.GLSurfaceView;
 import android.os.Build;
 import android.os.Bundle;
@@ -281,6 +282,8 @@ public abstract class Cocos2dxActivity extends Activity implements Cocos2dxHelpe
 
         Window window = this.getWindow();
         window.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_PAN);
+
+        this.setVolumeControlStream(AudioManager.STREAM_MUSIC);
     }
 
     //native method,call GLViewImpl::getGLContextAttrs() to get the OpenGL ES context attributions


### PR DESCRIPTION
Cocos2d-x uses STREAM_MUSIC for audio and video playback, however this stream is not set as a volume control stream. If any audio is playing, pressing volume keys will affect audio level, however, if app is silent at the moment, volume keys will change alarm level.

So the user will have to use volume keys exactly when something is playing to change the sound level which is a bad experience. This commit fixes the issue.

Based on http://developer.android.com/training/managing-audio/volume-playback.html
