### PR TITLE
Removed if else check for previous file

### DIFF
--- a/cocos/platform/winrt/CCWinRTUtils.cpp
+++ b/cocos/platform/winrt/CCWinRTUtils.cpp
@@ -365,13 +365,8 @@ bool createMappedCacheFile(const std::string& srcFilePath, std::string& cacheFil
     cacheFilePath = folderPath + computeHashForFile(srcFilePath) + ext;
     std::string prevFile = UserDefault::getInstance()->getStringForKey(srcFilePath.c_str());
 
-    if (prevFile == cacheFilePath) {
-        ret = FileUtils::getInstance()->isFileExist(cacheFilePath);
-    }
-    else {
-        FileUtils::getInstance()->removeFile(prevFile);
-    }
-
+    FileUtils::getInstance()->removeFile(prevFile);
+    
     UserDefault::getInstance()->setStringForKey(srcFilePath.c_str(), cacheFilePath);
     return ret;
 }


### PR DESCRIPTION
This if else is causing issues on Windows Emulator 10.0.10586. An assertion failed on getFileSize() fails the second time an audio file is played in the game.
