### PR TITLE
Fix reloadSpriteFramesWithDictionary function won't support new TexturePacker output format type 3

### DIFF
--- a/cocos/2d/CCSpriteFrameCache.cpp
+++ b/cocos/2d/CCSpriteFrameCache.cpp
@@ -139,163 +139,10 @@ void SpriteFrameCache::initializePolygonInfo(const Size &textureSize,
 
 void SpriteFrameCache::addSpriteFramesWithDictionary(ValueMap& dictionary, Texture2D* texture)
 {
-    /*
-    Supported Zwoptex Formats:
-
-    ZWTCoordinatesFormatOptionXMLLegacy = 0, // Flash Version
-    ZWTCoordinatesFormatOptionXML1_0 = 1, // Desktop Version 0.0 - 0.4b
-    ZWTCoordinatesFormatOptionXML1_1 = 2, // Desktop Version 1.0.0 - 1.0.1
-    ZWTCoordinatesFormatOptionXML1_2 = 3, // Desktop Version 1.0.2+
-
-    Version 3 with TexturePacker 4.0 polygon mesh packing
-    */
-
     if (dictionary["frames"].getType() != cocos2d::Value::Type::MAP)
         return;
 
-    ValueMap& framesDict = dictionary["frames"].asValueMap();
-    int format = 0;
-
-    Size textureSize;
-
-    // get the format
-    if (dictionary.find("metadata") != dictionary.end())
-    {
-        ValueMap& metadataDict = dictionary["metadata"].asValueMap();
-        format = metadataDict["format"].asInt();
-
-        if(metadataDict.find("size") != metadataDict.end())
-        {
-            textureSize = SizeFromString(metadataDict["size"].asString());
-        }
-    }
-
-    // check the format
-    CCASSERT(format >=0 && format <= 3, "format is not supported for SpriteFrameCache addSpriteFramesWithDictionary:textureFilename:");
-
-    auto textureFileName = Director::getInstance()->getTextureCache()->getTextureFilePath(texture);
-    Image* image = nullptr;
-    NinePatchImageParser parser;
-    for (auto iter = framesDict.begin(); iter != framesDict.end(); ++iter)
-    {
-        ValueMap& frameDict = iter->second.asValueMap();
-        std::string spriteFrameName = iter->first;
-        SpriteFrame* spriteFrame = _spriteFrames.at(spriteFrameName);
-        if (spriteFrame)
-        {
-            continue;
-        }
-        
-        if(format == 0) 
-        {
-            float x = frameDict["x"].asFloat();
-            float y = frameDict["y"].asFloat();
-            float w = frameDict["width"].asFloat();
-            float h = frameDict["height"].asFloat();
-            float ox = frameDict["offsetX"].asFloat();
-            float oy = frameDict["offsetY"].asFloat();
-            int ow = frameDict["originalWidth"].asInt();
-            int oh = frameDict["originalHeight"].asInt();
-            // check ow/oh
-            if(!ow || !oh)
-            {
-                CCLOGWARN("cocos2d: WARNING: originalWidth/Height not found on the SpriteFrame. AnchorPoint won't work as expected. Regenerate the .plist");
-            }
-            // abs ow/oh
-            ow = abs(ow);
-            oh = abs(oh);
-            // create frame
-            spriteFrame = SpriteFrame::createWithTexture(texture,
-                                                         Rect(x, y, w, h),
-                                                         false,
-                                                         Vec2(ox, oy),
-                                                         Size((float)ow, (float)oh)
-                                                         );
-        } 
-        else if(format == 1 || format == 2) 
-        {
-            Rect frame = RectFromString(frameDict["frame"].asString());
-            bool rotated = false;
-
-            // rotation
-            if (format == 2)
-            {
-                rotated = frameDict["rotated"].asBool();
-            }
-
-            Vec2 offset = PointFromString(frameDict["offset"].asString());
-            Size sourceSize = SizeFromString(frameDict["sourceSize"].asString());
-
-            // create frame
-            spriteFrame = SpriteFrame::createWithTexture(texture,
-                                                         frame,
-                                                         rotated,
-                                                         offset,
-                                                         sourceSize
-                                                         );
-        } 
-        else if (format == 3)
-        {
-            // get values
-            Size spriteSize = SizeFromString(frameDict["spriteSize"].asString());
-            Vec2 spriteOffset = PointFromString(frameDict["spriteOffset"].asString());
-            Size spriteSourceSize = SizeFromString(frameDict["spriteSourceSize"].asString());
-            Rect textureRect = RectFromString(frameDict["textureRect"].asString());
-            bool textureRotated = frameDict["textureRotated"].asBool();
-
-            // get aliases
-            ValueVector& aliases = frameDict["aliases"].asValueVector();
-
-            for(const auto &value : aliases) {
-                std::string oneAlias = value.asString();
-                if (_spriteFramesAliases.find(oneAlias) != _spriteFramesAliases.end())
-                {
-                    CCLOGWARN("cocos2d: WARNING: an alias with name %s already exists", oneAlias.c_str());
-                }
-
-                _spriteFramesAliases[oneAlias] = Value(spriteFrameName);
-            }
-
-            // create frame
-            spriteFrame = SpriteFrame::createWithTexture(texture,
-                                                         Rect(textureRect.origin.x, textureRect.origin.y, spriteSize.width, spriteSize.height),
-                                                         textureRotated,
-                                                         spriteOffset,
-                                                         spriteSourceSize);
-
-            if(frameDict.find("vertices") != frameDict.end())
-            {
-                std::vector<int> vertices;
-                parseIntegerList(frameDict["vertices"].asString(), vertices);
-                std::vector<int> verticesUV;
-                parseIntegerList(frameDict["verticesUV"].asString(), verticesUV);
-                std::vector<int> indices;
-                parseIntegerList(frameDict["triangles"].asString(), indices);
-
-                PolygonInfo info;
-                initializePolygonInfo(textureSize, spriteSourceSize, vertices, verticesUV, indices, info);
-                spriteFrame->setPolygonInfo(info);
-            }
-            if (frameDict.find("anchor") != frameDict.end())
-            {
-                spriteFrame->setAnchorPoint(PointFromString(frameDict["anchor"].asString()));
-            }
-        }
-
-        bool flag = NinePatchImageParser::isNinePatchImage(spriteFrameName);
-        if(flag)
-        {
-            if (image == nullptr) {
-                image = new (std::nothrow) Image();
-                image->initWithImageFile(textureFileName);
-            }
-            parser.setSpriteFrameInfo(image, spriteFrame->getRectInPixels(), spriteFrame->isRotated());
-            texture->addSpriteFrameCapInset(spriteFrame, parser.parseCapInset());
-        }
-        // add sprite frame
-        _spriteFrames.insert(spriteFrameName, spriteFrame);
-    }
-    CC_SAFE_DELETE(image);
+    loadSpriteFramesWithDictionary(dictionary, texture, false);
 }
 
 void SpriteFrameCache::addSpriteFramesWithFile(const std::string& plist, Texture2D *texture)
@@ -554,31 +401,121 @@ SpriteFrame* SpriteFrameCache::getSpriteFrameByName(const std::string& name)
 
 void SpriteFrameCache::reloadSpriteFramesWithDictionary(ValueMap& dictionary, Texture2D *texture)
 {
-    ValueMap& framesDict = dictionary["frames"].asValueMap();
+    if (dictionary["frames"].getType() != cocos2d::Value::Type::MAP)
+        return;
+
+    loadSpriteFramesWithDictionary(dictionary, texture, true);
+}
+
+bool SpriteFrameCache::reloadTexture(const std::string& plist)
+{
+    CCASSERT(plist.size()>0, "plist filename should not be nullptr");
+
+    auto it = _loadedFileNames->find(plist);
+    if (it != _loadedFileNames->end()) {
+        _loadedFileNames->erase(it);
+    }
+    else
+    {
+        //If one plist has't be loaded, we don't load it here.
+        return false;
+    }
+
+    std::string fullPath = FileUtils::getInstance()->fullPathForFilename(plist);
+    ValueMap dict = FileUtils::getInstance()->getValueMapFromFile(fullPath);
+
+    string texturePath("");
+
+    if (dict.find("metadata") != dict.end())
+    {
+        ValueMap& metadataDict = dict["metadata"].asValueMap();
+        // try to read  texture file name from meta data
+        texturePath = metadataDict["textureFileName"].asString();
+    }
+
+    if (!texturePath.empty())
+    {
+        // build texture path relative to plist file
+        texturePath = FileUtils::getInstance()->fullPathFromRelativeFile(texturePath, plist);
+    }
+    else
+    {
+        // build texture path by replacing file extension
+        texturePath = plist;
+
+        // remove .xxx
+        size_t startPos = texturePath.find_last_of(".");
+        texturePath = texturePath.erase(startPos);
+
+        // append .png
+        texturePath = texturePath.append(".png");
+    }
+
+    Texture2D *texture = nullptr;
+    if (Director::getInstance()->getTextureCache()->reloadTexture(texturePath))
+        texture = Director::getInstance()->getTextureCache()->getTextureForKey(texturePath);
+
+    if (texture)
+    {
+        reloadSpriteFramesWithDictionary(dict, texture);
+        _loadedFileNames->insert(plist);
+    }
+    else
+    {
+        CCLOG("cocos2d: SpriteFrameCache: Couldn't load texture");
+    }
+    return true;
+}
+
+void SpriteFrameCache::loadSpriteFramesWithDictionary(ValueMap& dictionary, Texture2D *texture, bool removeOld)
+{
+    /*
+    Supported Zwoptex Formats:
+
+    ZWTCoordinatesFormatOptionXMLLegacy = 0, // Flash Version
+    ZWTCoordinatesFormatOptionXML1_0 = 1, // Desktop Version 0.0 - 0.4b
+    ZWTCoordinatesFormatOptionXML1_1 = 2, // Desktop Version 1.0.0 - 1.0.1
+    ZWTCoordinatesFormatOptionXML1_2 = 3, // Desktop Version 1.0.2+
+
+    Version 3 with TexturePacker 4.0 polygon mesh packing
+    */
+
     int format = 0;
+    Size textureSize;
+    ValueMap& framesDict = dictionary["frames"].asValueMap();
 
     // get the format
     if (dictionary.find("metadata") != dictionary.end())
     {
         ValueMap& metadataDict = dictionary["metadata"].asValueMap();
         format = metadataDict["format"].asInt();
+
+        if (metadataDict.find("size") != metadataDict.end())
+        {
+            textureSize = SizeFromString(metadataDict["size"].asString());
+        }
     }
 
     // check the format
     CCASSERT(format >= 0 && format <= 3, "format is not supported for SpriteFrameCache addSpriteFramesWithDictionary:textureFilename:");
 
+    auto textureFileName = Director::getInstance()->getTextureCache()->getTextureFilePath(texture);
+    Image* image = nullptr;
+    NinePatchImageParser parser;
     for (auto iter = framesDict.begin(); iter != framesDict.end(); ++iter)
     {
+        SpriteFrame* spriteFrame = nullptr;
+
         ValueMap& frameDict = iter->second.asValueMap();
         std::string spriteFrameName = iter->first;
-
         auto it = _spriteFrames.find(spriteFrameName);
         if (it != _spriteFrames.end())
         {
-            _spriteFrames.erase(it);
+            if (removeOld)
+                _spriteFrames.erase(it);
+            else
+                continue;
         }
-
-        SpriteFrame* spriteFrame = nullptr;
 
         if (format == 0)
         {
@@ -593,7 +530,7 @@ void SpriteFrameCache::reloadSpriteFramesWithDictionary(ValueMap& dictionary, Te
             // check ow/oh
             if (!ow || !oh)
             {
-                CCLOGWARN("cocos2d: WARNING: originalWidth/Height not found on the SpriteFrame. AnchorPoint won't work as expected. Regenrate the .plist");
+                CCLOGWARN("cocos2d: WARNING: originalWidth/Height not found on the SpriteFrame. AnchorPoint won't work as expected. Regenerate the .plist");
             }
             // abs ow/oh
             ow = abs(ow);
@@ -656,71 +593,40 @@ void SpriteFrameCache::reloadSpriteFramesWithDictionary(ValueMap& dictionary, Te
                 textureRotated,
                 spriteOffset,
                 spriteSourceSize);
+
+            if (frameDict.find("vertices") != frameDict.end())
+            {
+                std::vector<int> vertices;
+                parseIntegerList(frameDict["vertices"].asString(), vertices);
+                std::vector<int> verticesUV;
+                parseIntegerList(frameDict["verticesUV"].asString(), verticesUV);
+                std::vector<int> indices;
+                parseIntegerList(frameDict["triangles"].asString(), indices);
+
+                PolygonInfo info;
+                initializePolygonInfo(textureSize, spriteSourceSize, vertices, verticesUV, indices, info);
+                spriteFrame->setPolygonInfo(info);
+            }
+            if (frameDict.find("anchor") != frameDict.end())
+            {
+                spriteFrame->setAnchorPoint(PointFromString(frameDict["anchor"].asString()));
+            }
         }
 
+        bool flag = NinePatchImageParser::isNinePatchImage(spriteFrameName);
+        if (flag)
+        {
+            if (image == nullptr) {
+                image = new (std::nothrow) Image();
+                image->initWithImageFile(textureFileName);
+            }
+            parser.setSpriteFrameInfo(image, spriteFrame->getRectInPixels(), spriteFrame->isRotated());
+            texture->addSpriteFrameCapInset(spriteFrame, parser.parseCapInset());
+        }
         // add sprite frame
         _spriteFrames.insert(spriteFrameName, spriteFrame);
     }
-}
-
-bool SpriteFrameCache::reloadTexture(const std::string& plist)
-{
-    CCASSERT(plist.size()>0, "plist filename should not be nullptr");
-
-    auto it = _loadedFileNames->find(plist);
-    if (it != _loadedFileNames->end()) {
-        _loadedFileNames->erase(it);
-    }
-    else
-    {
-        //If one plist has't be loaded, we don't load it here.
-        return false;
-    }
-
-    std::string fullPath = FileUtils::getInstance()->fullPathForFilename(plist);
-    ValueMap dict = FileUtils::getInstance()->getValueMapFromFile(fullPath);
-
-    string texturePath("");
-
-    if (dict.find("metadata") != dict.end())
-    {
-        ValueMap& metadataDict = dict["metadata"].asValueMap();
-        // try to read  texture file name from meta data
-        texturePath = metadataDict["textureFileName"].asString();
-    }
-
-    if (!texturePath.empty())
-    {
-        // build texture path relative to plist file
-        texturePath = FileUtils::getInstance()->fullPathFromRelativeFile(texturePath, plist);
-    }
-    else
-    {
-        // build texture path by replacing file extension
-        texturePath = plist;
-
-        // remove .xxx
-        size_t startPos = texturePath.find_last_of(".");
-        texturePath = texturePath.erase(startPos);
-
-        // append .png
-        texturePath = texturePath.append(".png");
-    }
-
-    Texture2D *texture = nullptr;
-    if (Director::getInstance()->getTextureCache()->reloadTexture(texturePath))
-        texture = Director::getInstance()->getTextureCache()->getTextureForKey(texturePath);
-
-    if (texture)
-    {
-        reloadSpriteFramesWithDictionary(dict, texture);
-        _loadedFileNames->insert(plist);
-    }
-    else
-    {
-        CCLOG("cocos2d: SpriteFrameCache: Couldn't load texture");
-    }
-    return true;
+    CC_SAFE_DELETE(image);
 }
 
 NS_CC_END

--- a/cocos/2d/CCSpriteFrameCache.h
+++ b/cocos/2d/CCSpriteFrameCache.h
@@ -265,6 +265,8 @@ protected:
 
     void reloadSpriteFramesWithDictionary(ValueMap& dictionary, Texture2D *texture);
 
+    void loadSpriteFramesWithDictionary(ValueMap& dictionary, Texture2D *texture, bool removeOld);
+
     Map<std::string, SpriteFrame*> _spriteFrames;
     ValueMap _spriteFramesAliases;
     std::set<std::string>*  _loadedFileNames;


### PR DESCRIPTION
New TexturePacker output type support only add to addSpriteFramesWithDictionary function, but not add to reloadSpriteFramesWithDictionary function, so when reload texture in editor, the image is broken.
