### PR TITLE
exported api for Cocos Studio.

### DIFF
--- a/cocos/scripting/js-bindings/manual/ScriptingCore.h
+++ b/cocos/scripting/js-bindings/manual/ScriptingCore.h
@@ -657,7 +657,7 @@ JSObject* jsb_ref_autoreleased_get_or_create_jsobject(JSContext *cx, cocos2d::Re
  * The reference created from JSObject to native object is weak because it won't retain it.
  * The behavior is exactly the same with 'jsb_ref_get_or_create_jsobject' when CC_ENABLE_GC_FOR_NATIVE_OBJECTS desactivated.
  */
-JSObject* jsb_get_or_create_weak_jsobject(JSContext *cx, void *native, js_type_class_t *typeClass, const char* debug);
+CC_JS_DLL JSObject* jsb_get_or_create_weak_jsobject(JSContext *cx, void *native, js_type_class_t *typeClass, const char* debug);
 
 /**
  * Register finalize hook and its owner as an entry in _js_hook_owner_map,

--- a/cocos/scripting/js-bindings/manual/cocos2d_specifics.cpp
+++ b/cocos/scripting/js-bindings/manual/cocos2d_specifics.cpp
@@ -544,6 +544,11 @@ JSObject* getObjectFromNamespace(JSContext* cx, JS::HandleObject ns, const char 
     return NULL;
 }
 
+js_type_class_t *js_get_type_from_node(cocos2d::Node* native_obj)
+{
+    return js_get_type_from_native<cocos2d::Node>(native_obj);
+}
+
 void js_add_FinalizeHook(JSContext *cx, JS::HandleObject target)
 {
     JS::RootedObject proto(cx, jsb_FinalizeHook_prototype);

--- a/cocos/scripting/js-bindings/manual/cocos2d_specifics.hpp
+++ b/cocos/scripting/js-bindings/manual/cocos2d_specifics.hpp
@@ -84,6 +84,11 @@ inline js_type_class_t *js_get_type_from_native(T* native_obj) {
 }
 
 /**
+* get type from a cocos2d::Node, call function(js_get_type_from_native) above.
+*/
+CC_JS_DLL js_type_class_t *js_get_type_from_node(cocos2d::Node* native_obj);
+
+/**
  * Gets or creates a JSObject based on native_obj.
  * If native_obj is subclass of Ref, it will use the jsb_ref functions.
  * Otherwise it will Root the newly created JSObject

--- a/cocos/scripting/js-bindings/manual/js_manual_conversions.h
+++ b/cocos/scripting/js-bindings/manual/js_manual_conversions.h
@@ -263,7 +263,7 @@ jsval ushort_to_jsval( JSContext *cx, unsigned short number );
 jsval long_to_jsval( JSContext *cx, long number );
 jsval ulong_to_jsval(JSContext* cx, unsigned long v);
 jsval long_long_to_jsval(JSContext* cx, long long v);
-jsval std_string_to_jsval(JSContext* cx, const std::string& v);
+CC_JS_DLL jsval std_string_to_jsval(JSContext* cx, const std::string& v);
 jsval c_string_to_jsval(JSContext* cx, const char* v, size_t length = -1);
 jsval ccpoint_to_jsval(JSContext* cx, const cocos2d::Point& v);
 jsval ccrect_to_jsval(JSContext* cx, const cocos2d::Rect& v);


### PR DESCRIPTION
1) exported 'jsb_get_or_create_weak_jsobject' in ScriptingCore.h.
2) exported 'std_string_to_jsval' in js_manual_conversions.h.
3) exported 'js_get_type_from_native' as 'js_get_type_from_node' in cocos2d_specifics.hpp.
