### PR TITLE
Fix typo of function name in AsyncTaskPool

### DIFF
--- a/cocos/base/CCAsyncTaskPool.cpp
+++ b/cocos/base/CCAsyncTaskPool.cpp
@@ -38,7 +38,7 @@ AsyncTaskPool* AsyncTaskPool::getInstance()
     return s_asyncTaskPool;
 }
 
-void AsyncTaskPool::destoryInstance()
+void AsyncTaskPool::destroyInstance()
 {
     delete s_asyncTaskPool;
     s_asyncTaskPool = nullptr;

--- a/cocos/base/CCAsyncTaskPool.h
+++ b/cocos/base/CCAsyncTaskPool.h
@@ -71,7 +71,10 @@ public:
     /**
      * Destroys the async task pool.
      */
-    static void destoryInstance();
+    static void destroyInstance();
+    
+    /** @deprecated Use method destroyInstance() instead. */
+    CC_DEPRECATED_ATTRIBUTE static void destoryInstance() { return destroyInstance(); }
     
     /**
      * Stop tasks.

--- a/cocos/base/CCDirector.cpp
+++ b/cocos/base/CCDirector.cpp
@@ -1037,7 +1037,7 @@ void Director::reset()
     GLProgramCache::destroyInstance();
     GLProgramStateCache::destroyInstance();
     FileUtils::destroyInstance();
-    AsyncTaskPool::destoryInstance();
+    AsyncTaskPool::destroyInstance();
     
     // cocos2d-x specific data structures
     UserDefault::destroyInstance();


### PR DESCRIPTION
I fixed a small spelling mistake: `destoryInstance` -> `destroyInstance`.

Also, this pull request marks the old API as deprecated for backwards compatibility reasons.
Thanks!
