### PR TITLE
added methods to set individual components of velocity of a PhysicsBody

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1369,8 +1369,11 @@ Retired Core Developers:
 
     thuydx55
         Fixed a bug of loading pluginx lib when compile Android with --compile-script flag.
-
+    greekman99 
+        Refined PhysicsBody methods + corrected documentation issues
+       
     
+
 
 Cocos2d-x can not grow so fast without the active community.
 Thanks to all developers who report & trace bugs, discuss the engine usage in forum & QQ groups!

--- a/cocos/physics/CCPhysicsBody.cpp
+++ b/cocos/physics/CCPhysicsBody.cpp
@@ -608,12 +608,12 @@ Vec2 PhysicsBody::getVelocity()
     return PhysicsHelper::cpv2point(cpBodyGetVel(_cpBody));
 }
 
-float PhysicsBody::getVelocityX()
+float PhysicsBody::getVelocityX() const
 {
     return PhysicsHelper::cpv2point(cpBodyGetVel(_cpBody)).x;
 }
 
-float PhysicsBody::getVelocityY()
+float PhysicsBody::getVelocityY() const
 {
     return PhysicsHelper::cpv2point(cpBodyGetVel(_cpBody)).y;
 }

--- a/cocos/physics/CCPhysicsBody.cpp
+++ b/cocos/physics/CCPhysicsBody.cpp
@@ -581,9 +581,41 @@ void PhysicsBody::setVelocity(const Vec2& velocity)
     cpBodySetVel(_cpBody, PhysicsHelper::point2cpv(velocity));
 }
 
+void PhysicsBody::setVelocityX(float velocity)
+{
+    if (!_dynamic)
+    {
+        CCLOG("physics warning: your can't set velocity for a static body.");
+        return;
+    }
+    
+    cpBodySetVel(_cpBody, PhysicsHelper::point2cpv(Vec2(velocity, getVelocityY())));
+}
+
+void PhysicsBody::setVelocityY(float velocity)
+{
+    if (!_dynamic)
+    {
+        CCLOG("physics warning: your can't set velocity for a static body.");
+        return;
+    }
+    
+    cpBodySetVel(_cpBody, PhysicsHelper::point2cpv(Vec2(getVelocityX(), velocity)));
+}
+
 Vec2 PhysicsBody::getVelocity()
 {
     return PhysicsHelper::cpv2point(cpBodyGetVel(_cpBody));
+}
+
+float PhysicsBody::getVelocityX()
+{
+    return PhysicsHelper::cpv2point(cpBodyGetVel(_cpBody)).x;
+}
+
+float PhysicsBody::getVelocityY()
+{
+    return PhysicsHelper::cpv2point(cpBodyGetVel(_cpBody)).y;
 }
 
 Vec2 PhysicsBody::getVelocityAtLocalPoint(const Vec2& point)

--- a/cocos/physics/CCPhysicsBody.h
+++ b/cocos/physics/CCPhysicsBody.h
@@ -261,10 +261,10 @@ public:
     virtual Vec2 getVelocity();
 
     /** Get the x-component of velocity of a body. */
-    float getVelocityX();
+    float getVelocityX() const;
 
      /** Get the x-component of velocity of a body. */
-    float getVelocityY();   
+    float getVelocityY() const;   
     
     /** 
      * Set the angular velocity of a body.

--- a/cocos/physics/CCPhysicsBody.h
+++ b/cocos/physics/CCPhysicsBody.h
@@ -242,9 +242,29 @@ public:
      * @param velocity The velocity is set to this body.
      */
     virtual void setVelocity(const Vec2& velocity);
-    
+
+    /**
+    * Set the x-component of velocity of a body. The y-component remains unchanged.
+    *
+    * @param velocity The x component of velocity set to this body
+    */
+    virtual void setVelocityX(float velocity);
+
+     /**
+    * Set the y-component of velocity of a body. The x-component remains unchanged.
+    *
+    * @param velocity The y component of velocity set to this body
+    */
+    virtual void setVelocityY(float velocity);   
+
     /** Get the velocity of a body. */
     virtual Vec2 getVelocity();
+
+    /** Get the x-component of velocity of a body. */
+    float getVelocityX();
+
+     /** Get the x-component of velocity of a body. */
+    float getVelocityY();   
     
     /** 
      * Set the angular velocity of a body.


### PR DESCRIPTION
Sometimes I find it annoying having to set the individual components of velocity of a body. It would usually involve something that looks like this in the case where I just want to set the x-component of velocity, but leave the y-component unchanged:

x = 100;
body->setVelocity(x, body->getVelocity().y);

I propose an alternative, more nicer solution, by introducing the methods:
setVelocityX();
setVelocityY();
which allow the individual components to be set, whilst leaving the other unchanged.

For completedness I have also included the methods:
getVelocityX();
getVelocityY()
