### PR TITLE
Add program-generated geometry test case

### DIFF
--- a/tests/cpp-tests/Classes/Sprite3DTest/Sprite3DTest.h
+++ b/tests/cpp-tests/Classes/Sprite3DTest/Sprite3DTest.h
@@ -615,4 +615,31 @@ protected:
     std::string _texFile;
 };
 
+class Sprite3DProgramGeneratedGeometryTest : public Sprite3DTestDemo
+{
+    int perVertexSizeInFloat;
+    int numberOfIterationSteps;
+    
+    cocos2d::Sprite3D* tetrahedron;
+    cocos2d::Action* rotation;
+public:
+    CREATE_FUNC(Sprite3DProgramGeneratedGeometryTest);
+    Sprite3DProgramGeneratedGeometryTest();
+    ~Sprite3DProgramGeneratedGeometryTest();
+
+    bool onTouchBegan(cocos2d::Touch* touch, cocos2d::Event* event);
+    void onTouchEnded(cocos2d::Touch* touch, cocos2d::Event* event);
+
+    virtual std::string title() const override;
+    virtual std::string subtitle() const override;
+    
+private:
+    cocos2d::Sprite3D* generateSprite3d();
+    void AddTetrahedron(std::vector< float > &vertices, cocos2d::MeshData::IndexArray& indices,
+                        float x, float y, float z, float size, int steps);
+    void AddCube(std::vector< float > &vertices, cocos2d::MeshData::IndexArray& indices,
+                        float x, float y, float z, float size);
+
+};
+
 #endif


### PR DESCRIPTION
Add a small test case showing how Sprite3D can support displaying of geometry which has been generated by the program at run-time, instead of loading a predetermined model.
