### PR TITLE
Allow Sprite3D::setTexture to specify texture usage

### DIFF
--- a/cocos/3d/CCSprite3D.cpp
+++ b/cocos/3d/CCSprite3D.cpp
@@ -664,6 +664,20 @@ void Sprite3D::setTexture(Texture2D* texture)
         mesh->setTexture(texture);
     }
 }
+
+void Sprite3D::setTexture(const std::string& texFile, NTextureData::Usage usage)
+{
+    auto tex = Director::getInstance()->getTextureCache()->addImage(texFile);
+    setTexture(tex, usage);
+}
+
+void Sprite3D::setTexture(Texture2D* texture, NTextureData::Usage usage)
+{
+    for (auto mesh: _meshes) {
+        mesh->setTexture(texture, usage);
+    }
+}
+
 AttachNode* Sprite3D::getAttachNode(const std::string& boneName)
 {
     auto it = _attachments.find(boneName);

--- a/cocos/3d/CCSprite3D.h
+++ b/cocos/3d/CCSprite3D.h
@@ -83,6 +83,10 @@ public:
     /**set diffuse texture, set the first if multiple textures exist*/
     void setTexture(const std::string& texFile);
     void setTexture(Texture2D* texture);
+
+    /**set texture with usage specified. set the first if multiple textures exist */
+    void setTexture(const std::string& texFile, NTextureData::Usage usage);
+    void setTexture(Texture2D* texture, NTextureData::Usage usage);
     
     /**get Mesh by index*/
     Mesh* getMeshByIndex(int index) const;


### PR DESCRIPTION
Allow a texture usage to be specified for Sprite3D::setTexture (as it can for Mesh::setTexture)
