### PR TITLE
Remove unnecessary const from return types

### DIFF
--- a/cocos/2d/CCAutoPolygon.cpp
+++ b/cocos/2d/CCAutoPolygon.cpp
@@ -114,22 +114,22 @@ void PolygonInfo::releaseVertsAndIndices()
     }
 }
 
-const unsigned int PolygonInfo::getVertCount() const
+unsigned int PolygonInfo::getVertCount() const
 {
     return (unsigned int)triangles.vertCount;
 }
 
-const unsigned int PolygonInfo::getTrianglesCount() const
+unsigned int PolygonInfo::getTrianglesCount() const
 {
     return (unsigned int)triangles.indexCount/3;
 }
 
-const unsigned int PolygonInfo::getTriaglesCount() const
+unsigned int PolygonInfo::getTriaglesCount() const
 {
     return getTrianglesCount();
 }
 
-const float PolygonInfo::getArea() const
+float PolygonInfo::getArea() const
 {
     float area = 0;
     V3F_C4B_T2F *verts = triangles.verts;

--- a/cocos/2d/CCAutoPolygon.h
+++ b/cocos/2d/CCAutoPolygon.h
@@ -101,22 +101,22 @@ public:
      * get vertex count
      * @return number of vertices
      */
-    const unsigned int getVertCount() const;
+    unsigned int getVertCount() const;
     
     /**
      * get triangles count
      * @return number of triangles
      */
-    const unsigned int getTrianglesCount() const;
+    unsigned int getTrianglesCount() const;
 
     /** @deprecated Use method getTrianglesCount() instead */
-    CC_DEPRECATED_ATTRIBUTE const unsigned int getTriaglesCount() const;
+    CC_DEPRECATED_ATTRIBUTE unsigned int getTriaglesCount() const;
     
     /**
      * get sum of all triangle area size
      * @return sum of all triangle area size
      */
-    const float getArea() const;
+    float getArea() const;
     
     Rect rect;
     std::string filename;

--- a/cocos/2d/CCClippingRectangleNode.h
+++ b/cocos/2d/CCClippingRectangleNode.h
@@ -77,7 +77,7 @@ public:
     @brief Get whether the clipping is enabled or not.
     @return Whether the clipping is enabled or not. Default is true.
     */
-    const bool isClippingEnabled() const {
+    bool isClippingEnabled() const {
         return _clippingEnabled;
     }
 

--- a/cocos/2d/CCSprite.h
+++ b/cocos/2d/CCSprite.h
@@ -474,7 +474,7 @@ public:
     virtual bool isOpacityModifyRGB() const override;
     /// @}
 
-    const int getResourceType() const { return _fileType; }
+    int getResourceType() const { return _fileType; }
     const std::string& getResourceName() const { return _fileName; }
 
 CC_CONSTRUCTOR_ACCESS :

--- a/cocos/base/CCProperties.cpp
+++ b/cocos/base/CCProperties.cpp
@@ -707,7 +707,7 @@ bool Properties::exists(const char* name) const
     return false;
 }
 
-static const bool isStringNumeric(const char* str)
+static bool isStringNumeric(const char* str)
 {
     CCASSERT(str, "invalid str");
 

--- a/cocos/base/allocator/CCAllocatorStrategyFixedBlock.h
+++ b/cocos/base/allocator/CCAllocatorStrategyFixedBlock.h
@@ -222,7 +222,7 @@ protected:
 protected:
         
     // @brief Returns the size of a page in bytes + overhead.
-    const size_t pageSize() const
+    size_t pageSize() const
     {
         return AllocatorBase::kDefaultAlignment + AllocatorBase::nextPow2BlockSize(block_size) * _pageSize;
     }

--- a/cocos/editor-support/cocostudio/CCComExtensionData.cpp
+++ b/cocos/editor-support/cocostudio/CCComExtensionData.cpp
@@ -88,7 +88,7 @@ namespace cocostudio
         _timelineData->setActionTag(actionTag);
     }
     
-    const int ComExtensionData::getActionTag() const
+    int ComExtensionData::getActionTag() const
     {
         return _timelineData->getActionTag();
     }

--- a/cocos/editor-support/cocostudio/CCComExtensionData.h
+++ b/cocos/editor-support/cocostudio/CCComExtensionData.h
@@ -73,7 +73,7 @@ namespace cocostudio
         virtual std::string getCustomProperty() const { return _customProperty; };
         
         virtual void setActionTag(int actionTag);
-        virtual const int getActionTag() const;
+        virtual int getActionTag() const;
         
     public:
         ComExtensionData();

--- a/cocos/editor-support/cocostudio/CCDatas.cpp
+++ b/cocos/editor-support/cocostudio/CCDatas.cpp
@@ -142,7 +142,7 @@ Color4B BaseData::getColor()
     return Color4B(r, g, b, a);
 }
 
-const std::string DisplayData::changeDisplayToTexture(const std::string& displayName)
+std::string DisplayData::changeDisplayToTexture(const std::string& displayName)
 {
     // remove .xxx
     std::string textureName = displayName;

--- a/cocos/editor-support/cocostudio/CCDatas.h
+++ b/cocos/editor-support/cocostudio/CCDatas.h
@@ -143,7 +143,7 @@ class CC_STUDIO_DLL DisplayData : public cocos2d::Ref
 public:
     CC_CREATE_NO_PARAM_NO_INIT(DisplayData)
 
-    static const std::string changeDisplayToTexture(const std::string& displayName);
+    static std::string changeDisplayToTexture(const std::string& displayName);
 public:
     /**
      * @js ctor

--- a/cocos/editor-support/cocostudio/CCSGUIReader.cpp
+++ b/cocos/editor-support/cocostudio/CCSGUIReader.cpp
@@ -145,7 +145,7 @@ void GUIReader::storeFileDesignSize(const char *fileName, const cocos2d::Size &s
     _fileDesignSizes[keyHeight] = cocos2d::Value(size.height);
 }
 
-const cocos2d::Size GUIReader::getFileDesignSize(const char* fileName) const
+cocos2d::Size GUIReader::getFileDesignSize(const char* fileName) const
 {
     std::string keyWidth = fileName;
     keyWidth.append("width");

--- a/cocos/editor-support/cocostudio/CCSGUIReader.h
+++ b/cocos/editor-support/cocostudio/CCSGUIReader.h
@@ -73,7 +73,7 @@ public:
     /**
      *  @js NA
      */
-    const cocos2d::Size getFileDesignSize(const char* fileName) const;
+    cocos2d::Size getFileDesignSize(const char* fileName) const;
     
     void setFilePath(const std::string& strFilePath) { m_strFilePath = strFilePath; }
     const std::string& getFilePath() const { return m_strFilePath; }

--- a/cocos/platform/CCImage.cpp
+++ b/cocos/platform/CCImage.cpp
@@ -1838,7 +1838,7 @@ bool Image::initWithTGAData(tImageTGA* tgaData)
 
 namespace
 {
-    static const uint32_t makeFourCC(char ch0, char ch1, char ch2, char ch3)
+    static uint32_t makeFourCC(char ch0, char ch1, char ch2, char ch3)
     {
         const uint32_t fourCC = ((uint32_t)(char)(ch0) | ((uint32_t)(char)(ch1) << 8) | ((uint32_t)(char)(ch2) << 16) | ((uint32_t)(char)(ch3) << 24 ));
         return fourCC;

--- a/cocos/renderer/CCGLProgram.h
+++ b/cocos/renderer/CCGLProgram.h
@@ -489,7 +489,7 @@ public:
     */
     void reset();
     /** returns the OpenGL Program object */
-    inline const GLuint getProgram() const { return _program; }
+    inline GLuint getProgram() const { return _program; }
 
     /** returns the Uniform flags */
     inline const UniformFlags& getUniformFlags() const { return _flags; }

--- a/cocos/renderer/CCTextureCache.cpp
+++ b/cocos/renderer/CCTextureCache.cpp
@@ -542,7 +542,7 @@ void TextureCache::reloadAllTextures()
 // #endif
 }
 
-const std::string TextureCache::getTextureFilePath( cocos2d::Texture2D *texture )const
+std::string TextureCache::getTextureFilePath(cocos2d::Texture2D* texture) const
 {
     for(auto& item : _textures)
     {

--- a/cocos/renderer/CCTextureCache.h
+++ b/cocos/renderer/CCTextureCache.h
@@ -202,7 +202,7 @@ public:
      *
      * @return The full path of the file.
      */
-    const std::string getTextureFilePath(Texture2D* texture)const;
+    std::string getTextureFilePath(Texture2D* texture) const;
 
     /** Reload texture from a new file.
     * This function is mainly for editor, won't suggest use it in game for performance reason.

--- a/cocos/ui/UIButton.cpp
+++ b/cocos/ui/UIButton.cpp
@@ -714,7 +714,7 @@ void Button::setTitleText(const std::string& text)
     updateTitleLocation();
 }
 
-const std::string Button::getTitleText() const
+std::string Button::getTitleText() const
 {
     if(nullptr == _titleRenderer)
     {
@@ -824,7 +824,7 @@ Label* Button::getTitleRenderer()const
     return _titleRenderer;
 }
 
-const std::string Button::getTitleFontName() const
+std::string Button::getTitleFontName() const
 {
     if (nullptr != _titleRenderer)
     {

--- a/cocos/ui/UIButton.h
+++ b/cocos/ui/UIButton.h
@@ -210,7 +210,7 @@ public:
      * Query the button title content.
      *@return Get the button's title content.
      */
-    const std::string getTitleText() const;
+    std::string getTitleText() const;
 
     /**
      * Change the color of button's title.
@@ -246,7 +246,7 @@ public:
      * Query the font name of button's title
      *@return font name in std::string
      */
-    const std::string getTitleFontName() const;
+    std::string getTitleFontName() const;
 
     /**
      * Sets the title's text horizontal alignment.


### PR DESCRIPTION
When compiling libcocos2d with GCC on Linux, it will always show warning messages below:

```
cocos/2d/CCAutoPolygon.h:104:39: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
cocos/2d/CCAutoPolygon.h:110:44: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
cocos/2d/CCAutoPolygon.h:113:67: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
cocos/2d/CCAutoPolygon.h:119:27: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
cocos/2d/CCSprite.h:477:33: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
cocos/renderer/CCGLProgram.h:492:38: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
...
```

In C/C++, const qualifiers on function return types are indeed superfluous. It will also trigger the warning when compiling with option `[-Wignored-qualifiers]`.
So this pull request removes unnecessary `const` from return types and fixes them.

Thank you for your time and attention.
