### PR TITLE
three related bug fixes in FontAtlas::prepareLetterDefinitions

### DIFF
--- a/cocos/2d/CCFontAtlas.cpp
+++ b/cocos/2d/CCFontAtlas.cpp
@@ -341,17 +341,12 @@ bool FontAtlas::prepareLetterDefinitions(const std::u16string& utf16Text)
             tempDef.offsetX = tempRect.origin.x + adjustForDistanceMap + adjustForExtend;
             tempDef.offsetY = _fontAscender + tempRect.origin.y - adjustForDistanceMap - adjustForExtend;
 
-            glyphHeight = static_cast<int>(bitmapHeight) + _letterPadding + _letterEdgeExtend;
-            if (glyphHeight > _currLineHeight)
-            {
-                _currLineHeight = glyphHeight;
-            }
             if (_currentPageOrigX + tempDef.width > CacheTextureWidth)
             {
                 _currentPageOrigY += _currLineHeight;
                 _currLineHeight = 0;
                 _currentPageOrigX = 0;
-                if (_currentPageOrigY + _lineHeight >= CacheTextureHeight)
+                if (_currentPageOrigY + _lineHeight + _letterPadding + _letterEdgeExtend >= CacheTextureHeight)
                 {
                     unsigned char *data = nullptr;
                     if (pixelFormat == Texture2D::PixelFormat::AI88)
@@ -384,6 +379,11 @@ bool FontAtlas::prepareLetterDefinitions(const std::u16string& utf16Text)
                     addTexture(tex, _currentPage);
                     tex->release();
                 }
+            }
+            glyphHeight = static_cast<int>(bitmapHeight) + _letterPadding + _letterEdgeExtend;
+            if (glyphHeight > _currLineHeight)
+            {
+                _currLineHeight = glyphHeight;
             }
             _fontFreeType->renderCharAt(_currentPageData, _currentPageOrigX + adjustForExtend, _currentPageOrigY + adjustForExtend, bitmap, bitmapWidth, bitmapHeight);
 
@@ -425,7 +425,7 @@ bool FontAtlas::prepareLetterDefinitions(const std::u16string& utf16Text)
     {
         data = _currentPageData + CacheTextureWidth * (int)startY;
     }
-    _atlasTextures[_currentPage]->updateWithData(data, 0, startY, CacheTextureWidth, _currentPageOrigY - startY + _lineHeight);
+    _atlasTextures[_currentPage]->updateWithData(data, 0, startY, CacheTextureWidth, _currentPageOrigY - startY + _currLineHeight);
 
     return true;
 }


### PR DESCRIPTION
I found four bugs in FontAtlas::prepareLetterDefinitions in version 3.8.1

One of those bugs has already been fixed, in commit bae36b7a98dc27d68ce1aa690d9ef30516671692

This branch contains fixes for the other three bugs:
1) _currLineHeight shouldn't be updated until after we've checked for overflow
2) the check for vertical overflow should include _letterPadding and _letterEdgeExtend, which can make the line higher than _lineHeight
3) _currLineHeight should be used instead of _lineHeight when updating the texture, since it might be greater than _lineHeight

These bugs, and the one already fixed, all lead to previous letter textures being partially overwritten by new letter textures. The bugs are triggered when the letter that causes a horizontal overflow is taller than any letter that follows it before the next horizontal overflow.

Note that the order that letters are rendered in is determined by key iteration over an unordered_map, so it is hard to predict.
