### PR TITLE
Fix compiler warning: "/* within block comment"

### DIFF
--- a/cocos/network/WebSocket.cpp
+++ b/cocos/network/WebSocket.cpp
@@ -587,7 +587,7 @@ void WebSocket::onSubThreadStarted()
     info.options = 0;
     info.user = this;
 
-    int log_level = LLL_ERR | LLL_WARN | LLL_NOTICE/* | LLL_INFO | LLL_DEBUG/* | LLL_PARSER*/ | LLL_HEADER | LLL_EXT | LLL_CLIENT | LLL_LATENCY;
+    int log_level = LLL_ERR | LLL_WARN | LLL_NOTICE/* | LLL_INFO | LLL_DEBUG | LLL_PARSER*/ | LLL_HEADER | LLL_EXT | LLL_CLIENT | LLL_LATENCY;
     lws_set_log_level(log_level, printWebSocketLog);
 
     _wsContext = lws_create_context(&info);


### PR DESCRIPTION
This fixes the following warning when compiling with gcc (Linux) and clang (Xcode):

```
cocos/network/WebSocket.cpp:590:77: '/*' within block comment
```
