### PR TITLE
Remove unnecessary const from return types in PU and Lua

### DIFF
--- a/cocos/scripting/lua-bindings/manual/CCLuaValue.h
+++ b/cocos/scripting/lua-bindings/manual/CCLuaValue.h
@@ -201,7 +201,7 @@ public:
      * 
      * @return the type of LuaValue object.
      */
-    const LuaValueType getType(void) const {
+    LuaValueType getType() const {
         return _type;
     }
     

--- a/extensions/Particle3D/PU/CCPUBaseCollider.cpp
+++ b/extensions/Particle3D/PU/CCPUBaseCollider.cpp
@@ -48,7 +48,7 @@ PUBaseCollider::~PUBaseCollider()
 {
 }
 
-const PUBaseCollider::IntersectionType PUBaseCollider::getIntersectionType() const
+PUBaseCollider::IntersectionType PUBaseCollider::getIntersectionType() const
 {
     return _intersectionType;
 }
@@ -58,7 +58,7 @@ void PUBaseCollider::setIntersectionType( const IntersectionType& intersectionTy
     _intersectionType = intersectionType;
 }
 
-const PUBaseCollider::CollisionType PUBaseCollider::getCollisionType() const
+PUBaseCollider::CollisionType PUBaseCollider::getCollisionType() const
 {
     return _collisionType;
 }
@@ -68,7 +68,7 @@ void PUBaseCollider::setCollisionType( const CollisionType& collisionType )
     _collisionType = collisionType;
 }
 
-const float PUBaseCollider::getFriction() const
+float PUBaseCollider::getFriction() const
 {
     return _friction;
 }
@@ -78,7 +78,7 @@ void PUBaseCollider::setFriction( const float friction )
     _friction = friction;
 }
 
-const float PUBaseCollider::getBouncyness() const
+float PUBaseCollider::getBouncyness() const
 {
     return _bouncyness;
 }

--- a/extensions/Particle3D/PU/CCPUBaseCollider.h
+++ b/extensions/Particle3D/PU/CCPUBaseCollider.h
@@ -72,7 +72,7 @@ public:
 
         /** Returns the type of intersection.
     */
-    const IntersectionType getIntersectionType() const;
+    IntersectionType getIntersectionType() const;
 
     /** Sets the type of intersection.
     */
@@ -80,7 +80,7 @@ public:
 
     /** Returns the type of collision.
     */
-    const CollisionType getCollisionType() const;
+    CollisionType getCollisionType() const;
 
     /** Sets the type of collision.
     */
@@ -88,7 +88,7 @@ public:
 
     /** Returns the friction value.
     */
-    const float getFriction() const;
+    float getFriction() const;
 
     /** Sets the friction value.
     */
@@ -96,7 +96,7 @@ public:
 
     /** Returns the bouncyness value.
     */
-    const float getBouncyness() const;
+    float getBouncyness() const;
 
     /** Sets the bouncyness value.
     */

--- a/extensions/Particle3D/PU/CCPUBoxCollider.cpp
+++ b/extensions/Particle3D/PU/CCPUBoxCollider.cpp
@@ -54,7 +54,7 @@ PUBoxCollider::~PUBoxCollider()
 {
 }
 //-----------------------------------------------------------------------
-const float PUBoxCollider::getWidth() const
+float PUBoxCollider::getWidth() const
 {
     return _width;
 }
@@ -64,7 +64,7 @@ void PUBoxCollider::setWidth(const float width)
     _width = width;
 }
 //-----------------------------------------------------------------------
-const float PUBoxCollider::getHeight() const
+float PUBoxCollider::getHeight() const
 {
     return _height;
 }
@@ -74,7 +74,7 @@ void PUBoxCollider::setHeight(const float height)
     _height = height;
 }
 //-----------------------------------------------------------------------
-const float PUBoxCollider::getDepth() const
+float PUBoxCollider::getDepth() const
 {
     return _depth;
 }

--- a/extensions/Particle3D/PU/CCPUBoxCollider.h
+++ b/extensions/Particle3D/PU/CCPUBoxCollider.h
@@ -45,7 +45,7 @@ public:
 
     /** Returns the width of the box
     */
-    const float getWidth() const;
+    float getWidth() const;
 
     /** Sets the width of the box
     */
@@ -53,7 +53,7 @@ public:
 
     /** Returns the height of the box
     */
-    const float getHeight() const;
+    float getHeight() const;
 
     /** Sets the height of the box
     */
@@ -61,7 +61,7 @@ public:
 
     /** Returns the depth of the box
     */
-    const float getDepth() const;
+    float getDepth() const;
 
     /** Sets the depth of the box
     */

--- a/extensions/Particle3D/PU/CCPUBoxEmitter.cpp
+++ b/extensions/Particle3D/PU/CCPUBoxEmitter.cpp
@@ -45,7 +45,7 @@ CCPUBoxEmitter::CCPUBoxEmitter(void) :
 {
 }
 //-----------------------------------------------------------------------
-const float CCPUBoxEmitter::getHeight(void) const
+float CCPUBoxEmitter::getHeight() const
 {
     return _height;
 }
@@ -56,7 +56,7 @@ void CCPUBoxEmitter::setHeight(const float height)
     _yRange = 0.5f * height;
 }
 //-----------------------------------------------------------------------
-const float CCPUBoxEmitter::getWidth(void) const
+float CCPUBoxEmitter::getWidth() const
 {
     return _width;
 }
@@ -67,7 +67,7 @@ void CCPUBoxEmitter::setWidth(const float width)
     _xRange = 0.5f * width;
 }
 //-----------------------------------------------------------------------
-const float CCPUBoxEmitter::getDepth(void) const
+float CCPUBoxEmitter::getDepth() const
 {
     return _depth;
 }

--- a/extensions/Particle3D/PU/CCPUBoxEmitter.h
+++ b/extensions/Particle3D/PU/CCPUBoxEmitter.h
@@ -43,17 +43,17 @@ public:
 
     /** 
     */
-    const float getHeight(void) const;
+    float getHeight() const;
     void setHeight(const float height);
 
     /** 
     */
-    const float getWidth(void) const;
+    float getWidth() const;
     void setWidth(const float width);
 
     /** 
     */
-    const float getDepth(void) const;
+    float getDepth() const;
     void setDepth(const float depth);
 
     virtual CCPUBoxEmitter* clone() override;

--- a/extensions/Particle3D/PU/CCPUCircleEmitter.cpp
+++ b/extensions/Particle3D/PU/CCPUCircleEmitter.cpp
@@ -52,7 +52,7 @@ PUCircleEmitter::PUCircleEmitter(void) :
 {
 }
 //-----------------------------------------------------------------------
-const float PUCircleEmitter::getRadius(void) const
+float PUCircleEmitter::getRadius() const
 {
     return _radius;
 }
@@ -62,7 +62,7 @@ void PUCircleEmitter::setRadius(const float radius)
     _radius = radius;
 }
 //-----------------------------------------------------------------------
-const float PUCircleEmitter::getCircleAngle(void) const
+float PUCircleEmitter::getCircleAngle() const
 {
     return _originalCircleAngle;
 }
@@ -73,7 +73,7 @@ void PUCircleEmitter::setCircleAngle(const float circleAngle)
     _circleAngle = circleAngle;
 }
 //-----------------------------------------------------------------------
-const float PUCircleEmitter::getStep(void) const
+float PUCircleEmitter::getStep() const
 {
     return _step;
 }
@@ -83,7 +83,7 @@ void PUCircleEmitter::setStep(const float step)
     _step = step;
 }
 //-----------------------------------------------------------------------
-const bool PUCircleEmitter::isRandom(void) const
+bool PUCircleEmitter::isRandom() const
 {
     return _random;
 }

--- a/extensions/Particle3D/PU/CCPUCircleEmitter.h
+++ b/extensions/Particle3D/PU/CCPUCircleEmitter.h
@@ -45,22 +45,22 @@ public:
 
     /** 
     */
-    const float getRadius(void) const;
+    float getRadius() const;
     void setRadius(const float radius);
 
     /** 
     */
-    const float getCircleAngle(void) const;
+    float getCircleAngle() const;
     void setCircleAngle(const float circleAngle);
 
     /** 
     */
-    const float getStep(void) const;
+    float getStep() const;
     void setStep(const float step);
 
     /** 
     */
-    const bool isRandom(void) const;
+    bool isRandom() const;
     void setRandom(const bool random);
 
     /* 

--- a/extensions/Particle3D/PU/CCPUDoAffectorEventHandler.h
+++ b/extensions/Particle3D/PU/CCPUDoAffectorEventHandler.h
@@ -48,7 +48,7 @@ public:
 
     /** Get the indication whether pre- and postprocessing must be done.
     */
-    const bool getPrePost(void) const {return _prePost;};
+    bool getPrePost() const {return _prePost;};
 
     /** Set the indication whether pre- and postprocessing must be done.
     */

--- a/extensions/Particle3D/PU/CCPUDoScaleEventHandler.cpp
+++ b/extensions/Particle3D/PU/CCPUDoScaleEventHandler.cpp
@@ -50,7 +50,7 @@ void PUDoScaleEventHandler::setScaleType(const PUDoScaleEventHandler::ScaleType&
     _scaleType = scaleType;
 }
 //-----------------------------------------------------------------------
-const float PUDoScaleEventHandler::getScaleFraction(void) const
+float PUDoScaleEventHandler::getScaleFraction() const
 {
     return _scaleFraction;
 }

--- a/extensions/Particle3D/PU/CCPUDoScaleEventHandler.h
+++ b/extensions/Particle3D/PU/CCPUDoScaleEventHandler.h
@@ -62,7 +62,7 @@ public:
 
     /** Returns the scale fraction
     */
-    const float getScaleFraction(void) const;
+    float getScaleFraction() const;
 
     /** Set the scale fraction. This scale fraction value is used to scale different attributes if the 
         event handler is called.

--- a/extensions/Particle3D/PU/CCPUForceField.cpp
+++ b/extensions/Particle3D/PU/CCPUForceField.cpp
@@ -259,7 +259,7 @@ PUForceFieldCalculationFactory* PUForceField::createForceFieldCalculationFactory
     }
 }
 //-----------------------------------------------------------------------
-const PUForceField::ForceFieldType PUForceField::getForceFieldType(void) const
+PUForceField::ForceFieldType PUForceField::getForceFieldType() const
 {
     return _forceFieldType;
 }

--- a/extensions/Particle3D/PU/CCPUForceField.h
+++ b/extensions/Particle3D/PU/CCPUForceField.h
@@ -186,7 +186,7 @@ class PUForceField
             
         /** Get/Set the Forcefield type
         */
-        const ForceFieldType getForceFieldType(void) const;
+        ForceFieldType getForceFieldType() const;
         void setForceFieldType(const ForceFieldType forceFieldType);
 
     protected:

--- a/extensions/Particle3D/PU/CCPUForceFieldAffector.cpp
+++ b/extensions/Particle3D/PU/CCPUForceFieldAffector.cpp
@@ -68,7 +68,7 @@ PUForceFieldAffector::~PUForceFieldAffector()
 {
 };
 //-----------------------------------------------------------------------
-const PUForceField::ForceFieldType PUForceFieldAffector::getForceFieldType(void) const
+PUForceField::ForceFieldType PUForceFieldAffector::getForceFieldType() const
 {
     return _forceFieldType;
 }

--- a/extensions/Particle3D/PU/CCPUForceFieldAffector.h
+++ b/extensions/Particle3D/PU/CCPUForceFieldAffector.h
@@ -57,7 +57,7 @@ public:
 
     /** Get/Set Forcefield type
     */
-    const PUForceField::ForceFieldType getForceFieldType(void) const;
+    PUForceField::ForceFieldType getForceFieldType() const;
     void setForceFieldType(const PUForceField::ForceFieldType forceFieldType);
 
     /** Get/Set Delta

--- a/extensions/Particle3D/PU/CCPUMeshSurfaceEmitter.cpp
+++ b/extensions/Particle3D/PU/CCPUMeshSurfaceEmitter.cpp
@@ -216,7 +216,7 @@ const PUTriangle& MeshInfo::getTriangle (size_t triangleIndex)
 }
 
 //-----------------------------------------------------------------------
-const size_t MeshInfo::getRandomTriangleIndex (void)
+size_t MeshInfo::getRandomTriangleIndex()
 {
     size_t index;
     if (mDistribution == MSD_HOMOGENEOUS || mDistribution == MSD_HETEROGENEOUS_1)
@@ -538,7 +538,7 @@ void PUMeshSurfaceEmitter::setMeshName(const std::string& meshName, bool doBuild
     }
 }
 //-----------------------------------------------------------------------
-const MeshInfo::MeshSurfaceDistribution PUMeshSurfaceEmitter::getDistribution (void) const
+MeshInfo::MeshSurfaceDistribution PUMeshSurfaceEmitter::getDistribution() const
 {
     return _distribution;
 }

--- a/extensions/Particle3D/PU/CCPUMeshSurfaceEmitter.h
+++ b/extensions/Particle3D/PU/CCPUMeshSurfaceEmitter.h
@@ -147,7 +147,7 @@ public:
     const PUTriangle& getTriangle (size_t triangleIndex);
 
     /** Get a random triangle (index) from the mesh. */
-    const size_t getRandomTriangleIndex (void);
+    size_t getRandomTriangleIndex();
     
     /** Get triangle number */
     size_t getTriangleCount() const { return _triangles.size(); }
@@ -198,7 +198,7 @@ public:
         There are several ways to emit particles on the surface of a mesh. This attribute indicates
         the type of distribution on the surface.
     */
-    const MeshInfo::MeshSurfaceDistribution getDistribution (void) const;
+    MeshInfo::MeshSurfaceDistribution getDistribution() const;
 
     /** Set the type of particle distribution on the surface of a mesh.
     */

--- a/extensions/Particle3D/PU/CCPUOnCountObserver.h
+++ b/extensions/Particle3D/PU/CCPUOnCountObserver.h
@@ -66,7 +66,7 @@ public:
 
     /** 
     */
-    const PUComparisionOperator getCompare(void) const {return _compare;};
+    PUComparisionOperator getCompare() const {return _compare;};
     void setCompare(PUComparisionOperator op){_compare = op;};
 
     virtual void copyAttributesTo (PUObserver* observer) override;

--- a/extensions/Particle3D/PU/CCPUOnPositionObserver.h
+++ b/extensions/Particle3D/PU/CCPUOnPositionObserver.h
@@ -80,9 +80,9 @@ public:
 
     /** 
         */
-    const PUComparisionOperator getComparePositionX(void) const {return _comparePositionX;};
-    const PUComparisionOperator getComparePositionY(void) const {return _comparePositionY;};
-    const PUComparisionOperator getComparePositionZ(void) const {return _comparePositionZ;};
+    PUComparisionOperator getComparePositionX() const {return _comparePositionX;};
+    PUComparisionOperator getComparePositionY() const {return _comparePositionY;};
+    PUComparisionOperator getComparePositionZ() const {return _comparePositionZ;};
 
     virtual void copyAttributesTo (PUObserver* observer) override;
 

--- a/extensions/Particle3D/PU/CCPUOnTimeObserver.h
+++ b/extensions/Particle3D/PU/CCPUOnTimeObserver.h
@@ -61,7 +61,7 @@ public:
 
     /** 
     */
-    const PUComparisionOperator getCompare(void) const {return _compare;};
+    PUComparisionOperator getCompare() const {return _compare;};
     void setCompare(PUComparisionOperator op){_compare = op;};
 
     /** 

--- a/extensions/Particle3D/PU/CCPUOnVelocityObserver.h
+++ b/extensions/Particle3D/PU/CCPUOnVelocityObserver.h
@@ -55,7 +55,7 @@ public:
 
     /** 
     */
-    const PUComparisionOperator getCompare(void) const {return _compare;};
+    PUComparisionOperator getCompare() const {return _compare;};
     void setCompare(PUComparisionOperator op){_compare = op;};
 
     virtual void copyAttributesTo (PUObserver* observer) override;

--- a/extensions/Particle3D/PU/CCPUParticleSystem3D.cpp
+++ b/extensions/Particle3D/PU/CCPUParticleSystem3D.cpp
@@ -731,7 +731,7 @@ void PUParticleSystem3D::emitParticles( float elapsedTime )
 
 }
 
-const float PUParticleSystem3D::getDefaultWidth( void ) const
+float PUParticleSystem3D::getDefaultWidth() const
 {
     return _defaultWidth;
 }
@@ -741,7 +741,7 @@ void PUParticleSystem3D::setDefaultWidth( const float width )
     _defaultWidth = width;
 }
 
-const float PUParticleSystem3D::getDefaultHeight( void ) const
+float PUParticleSystem3D::getDefaultHeight() const
 {
     return _defaultHeight;
 }
@@ -751,7 +751,7 @@ void PUParticleSystem3D::setDefaultHeight( const float height )
     _defaultHeight = height;
 }
 
-const float PUParticleSystem3D::getDefaultDepth( void ) const
+float PUParticleSystem3D::getDefaultDepth() const
 {
     return _defaultDepth;
 }

--- a/extensions/Particle3D/PU/CCPUParticleSystem3D.h
+++ b/extensions/Particle3D/PU/CCPUParticleSystem3D.h
@@ -273,19 +273,19 @@ public:
     /**
      * default particle width
      */
-    const float getDefaultWidth(void) const;
+    float getDefaultWidth() const;
     void setDefaultWidth(const float width);
 
     /** 
      * default particle height
      */
-    const float getDefaultHeight(void) const;
+    float getDefaultHeight() const;
     void setDefaultHeight(const float height);
 
     /** 
      * default particle depth
      */
-    const float getDefaultDepth(void) const;
+    float getDefaultDepth() const;
     void setDefaultDepth(const float depth);
 
     Vec3 getDerivedPosition();

--- a/extensions/Particle3D/PU/CCPUSineForceAffector.cpp
+++ b/extensions/Particle3D/PU/CCPUSineForceAffector.cpp
@@ -63,7 +63,7 @@ void PUSineForceAffector::preUpdateAffector(float deltaTime)
     }
 }
 //-----------------------------------------------------------------------
-const float PUSineForceAffector::getFrequencyMin(void) const
+float PUSineForceAffector::getFrequencyMin() const
 {
     return _frequencyMin;
 }
@@ -77,7 +77,7 @@ void PUSineForceAffector::setFrequencyMin(const float frequencyMin)
     }
 }
 //-----------------------------------------------------------------------
-const float PUSineForceAffector::getFrequencyMax(void) const
+float PUSineForceAffector::getFrequencyMax() const
 {
     return _frequencyMax;
 }

--- a/extensions/Particle3D/PU/CCPUSineForceAffector.h
+++ b/extensions/Particle3D/PU/CCPUSineForceAffector.h
@@ -46,12 +46,12 @@ public:
 
     /** 
     */
-    const float getFrequencyMin(void) const;
+    float getFrequencyMin() const;
     void setFrequencyMin(const float frequencyMin);
 
     /** 
     */
-    const float getFrequencyMax(void) const;
+    float getFrequencyMax() const;
     void setFrequencyMax(const float frequencyMax);
 
     virtual void copyAttributesTo (PUAffector* affector) override;

--- a/extensions/Particle3D/PU/CCPUSphereCollider.cpp
+++ b/extensions/Particle3D/PU/CCPUSphereCollider.cpp
@@ -44,7 +44,7 @@ PUSphereCollider::~PUSphereCollider( void )
 }
 
 //-----------------------------------------------------------------------
-const float PUSphereCollider::getRadius(void) const
+float PUSphereCollider::getRadius() const
 {
     return _radius;
 }

--- a/extensions/Particle3D/PU/CCPUSphereCollider.h
+++ b/extensions/Particle3D/PU/CCPUSphereCollider.h
@@ -46,7 +46,7 @@ public:
 
     /** Returns the radius of the sphere
     */
-    const float getRadius(void) const;
+    float getRadius() const;
 
     /** Sets the radius of the sphere
     */

--- a/extensions/Particle3D/PU/CCPUSphereSurfaceEmitter.cpp
+++ b/extensions/Particle3D/PU/CCPUSphereSurfaceEmitter.cpp
@@ -38,7 +38,7 @@ PUSphereSurfaceEmitter::PUSphereSurfaceEmitter(void) :
 {
 }
 //-----------------------------------------------------------------------
-const float PUSphereSurfaceEmitter::getRadius(void) const
+float PUSphereSurfaceEmitter::getRadius() const
 {
     return _radius;
 }

--- a/extensions/Particle3D/PU/CCPUSphereSurfaceEmitter.h
+++ b/extensions/Particle3D/PU/CCPUSphereSurfaceEmitter.h
@@ -40,7 +40,7 @@ public:
     static PUSphereSurfaceEmitter* create();
     /** 
     */
-    const float getRadius(void) const;
+    float getRadius() const;
     void setRadius(const float radius);
 
     /** 


### PR DESCRIPTION
Hello, this fixes the following compiler warnings when building on Linux with GCC, for similar reasons #15132:

```
cocos/scripting/lua-bindings/manual/CCLuaValue.h:204:38: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
extensions/Particle3D/PU/CCPUBaseCollider.h:75:50: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
extensions/Particle3D/PU/CCPUBaseCollider.h:83:44: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
extensions/Particle3D/PU/CCPUBaseCollider.h:91:31: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
extensions/Particle3D/PU/CCPUBaseCollider.h:99:33: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
extensions/Particle3D/PU/CCPUBoxCollider.h:48:28: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
extensions/Particle3D/PU/CCPUBoxCollider.h:56:29: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
extensions/Particle3D/PU/CCPUBoxCollider.h:64:28: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
extensions/Particle3D/PU/CCPUBoxEmitter.h:46:33: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
...
```

Btw, probably this patch will remove 1170 warning messages generated by the Jenkins build such as [console log](http://45.56.80.45:8080/job/daily-build-v3/node=linux/407/consoleFull). Thanks!
