### PR TITLE
Textfiled support cursor v1.2

### DIFF
--- a/cocos/2d/CCLabel.cpp
+++ b/cocos/2d/CCLabel.cpp
@@ -1824,7 +1824,7 @@ void Label::computeStringNumLines()
     size_t stringLen = _utf16Text.length();
     for (size_t i = 0; i < stringLen - 1; ++i)
     {
-        if (_utf16Text[i] == '\n')
+        if (_utf16Text[i] == (char16_t)TextFormatter::NewLine)
         {
             quantityOfLines++;
         }

--- a/cocos/2d/CCLabel.h
+++ b/cocos/2d/CCLabel.h
@@ -81,6 +81,13 @@ typedef struct _ttfConfig
     }
 } TTFConfig;
 
+enum class TextFormatter : char
+{
+    NewLine = '\n',
+    CarriageReturn = '\r',
+    NextCharNoChangeX = '\b'
+};
+
 class Sprite;
 class SpriteBatchNode;
 class DrawNode;

--- a/cocos/2d/CCLabelTextFormatter.cpp
+++ b/cocos/2d/CCLabelTextFormatter.cpp
@@ -80,7 +80,7 @@ static int getFirstCharLen(const std::u16string& utf16Text, int startIndex, int 
 static int getFirstWordLen(const std::u16string& utf16Text, int startIndex, int textLen)
 {
     auto character = utf16Text[startIndex];
-    if (StringUtils::isCJKUnicode(character) || StringUtils::isUnicodeSpace(character) || character == '\n')
+    if (StringUtils::isCJKUnicode(character) || StringUtils::isUnicodeSpace(character) || character == (char16_t)TextFormatter::NewLine)
     {
         return 1;
     }
@@ -89,7 +89,7 @@ static int getFirstWordLen(const std::u16string& utf16Text, int startIndex, int 
     for (int index = startIndex + 1; index < textLen; ++index)
     {
         character = utf16Text[index];
-        if (character == '\n' || StringUtils::isUnicodeSpace(character) || StringUtils::isCJKUnicode(character))
+        if (character == (char16_t)TextFormatter::NewLine || StringUtils::isUnicodeSpace(character) || StringUtils::isCJKUnicode(character))
         {
             break;
         }
@@ -126,13 +126,14 @@ bool Label::multilineTextWrap(std::function<int(const std::u16string&, int, int)
     float lowestY = 0.f;
     FontLetterDefinition letterDef;
     Vec2 letterPosition;
+    bool nextChangeSize = true;
     
     this->updateBMFontScale();
     
     for (int index = 0; index < textLen; )
     {
         auto character = _utf16Text[index];
-        if (character == '\n')
+        if (character == (char16_t)TextFormatter::NewLine)
         {
             _linesWidth.push_back(letterRight);
             letterRight = 0.f;
@@ -154,8 +155,15 @@ bool Label::multilineTextWrap(std::function<int(const std::u16string&, int, int)
         {
             int letterIndex = index + tmp;
             character = _utf16Text[letterIndex];
-            if (character == '\r')
+            if (character == (char16_t)TextFormatter::CarriageReturn)
             {
+                recordPlaceholderInfo(letterIndex, character);
+                continue;
+            }
+            // \b - Next char not change x position
+            if (character == (char16_t)TextFormatter::NextCharNoChangeX)
+            {
+                nextChangeSize = false;
                 recordPlaceholderInfo(letterIndex, character);
                 continue;
             }
@@ -168,7 +176,7 @@ bool Label::multilineTextWrap(std::function<int(const std::u16string&, int, int)
             
             auto letterX = (nextLetterX + letterDef.offsetX * _bmfontScale) / contentScaleFactor;
             if (_enableWrap && _maxLineWidth > 0.f && nextTokenX > 0.f && letterX + letterDef.width * _bmfontScale > _maxLineWidth
-                && !StringUtils::isUnicodeSpace(character))
+                && !StringUtils::isUnicodeSpace(character) && nextChangeSize)
             {
                 _linesWidth.push_back(letterRight);
                 letterRight = 0.f;
@@ -185,11 +193,15 @@ bool Label::multilineTextWrap(std::function<int(const std::u16string&, int, int)
             letterPosition.y = (nextTokenY - letterDef.offsetY * _bmfontScale) / contentScaleFactor;
             recordLetterInfo(letterPosition, character, letterIndex, lineIndex);
             
-            if (_horizontalKernings && letterIndex < textLen - 1)
-                nextLetterX += _horizontalKernings[letterIndex + 1];
-            nextLetterX += letterDef.xAdvance * _bmfontScale + _additionalKerning;
+            if (nextChangeSize)
+            {
+                if (_horizontalKernings && letterIndex < textLen - 1)
+                    nextLetterX += _horizontalKernings[letterIndex + 1];
+                nextLetterX += letterDef.xAdvance * _bmfontScale + _additionalKerning;
             
-            tokenRight = letterPosition.x + letterDef.width * _bmfontScale;
+                tokenRight = letterPosition.x + letterDef.width * _bmfontScale;
+            }
+            nextChangeSize = true;
             
             if (tokenHighestY < letterPosition.y)
                 tokenHighestY = letterPosition.y;

--- a/cocos/2d/CCTextFieldTTF.cpp
+++ b/cocos/2d/CCTextFieldTTF.cpp
@@ -63,7 +63,7 @@ TextFieldTTF::TextFieldTTF()
 , _placeHolder("")   // prevent Label initWithString assertion
 , _colorText(Color4B::WHITE)
 , _secureTextEntry(false)
-, _cursorUse(false)
+, _cursorEnabled(false)
 , _cursorPosition(0)
 , _cursorChar(CURSOR_DEFAULT_CHAR)
 , _cursorShowingTime(0.0f)
@@ -153,7 +153,7 @@ bool TextFieldTTF::initWithPlaceHolder(const std::string& placeholder, const std
     // On desktop default enable cursor
     if (_currentLabelType == LabelType::TTF)
     {
-        setCursorUse(true);
+        setCursorEnabled(true);
     }
 #endif
 
@@ -237,11 +237,11 @@ void TextFieldTTF::insertText(const char * text, size_t len)
         int countInsertChar = _calcCharCount(insert.c_str());
         _charCount += countInsertChar;
 
-        if (_cursorUse)
+        if (_cursorEnabled)
         {
             StringUtils::StringUTF8 stringUTF8;
 
-            stringUTF8.set(_inputText);
+            stringUTF8.replace(_inputText);
             stringUTF8.insert(_cursorPosition, insert);
 
             setCursorPosition(_cursorPosition + countInsertChar);            
@@ -304,7 +304,7 @@ void TextFieldTTF::deleteBackward()
     }
 
     // set new input text
-    if (_cursorUse)
+    if (_cursorEnabled)
     {
         if (_cursorPosition)
         {
@@ -312,7 +312,7 @@ void TextFieldTTF::deleteBackward()
 
             StringUtils::StringUTF8 stringUTF8;
 
-            stringUTF8.set(_inputText);
+            stringUTF8.replace(_inputText);
             stringUTF8.deleteChar(_cursorPosition);
 
             _charCount = stringUTF8.length();
@@ -333,7 +333,7 @@ const std::string& TextFieldTTF::getContentText()
 
 void TextFieldTTF::setCursorPosition(std::size_t cursorPosition)
 {
-    if (_cursorUse && cursorPosition <= (std::size_t)_charCount)
+    if (_cursorEnabled && cursorPosition <= (std::size_t)_charCount)
     {
         _cursorPosition = cursorPosition;
         _cursorShowingTime = CURSOR_TIME_SHOW_HIDE*2.0;
@@ -342,7 +342,7 @@ void TextFieldTTF::setCursorPosition(std::size_t cursorPosition)
 
 void TextFieldTTF::setCursorFromPoint(const Vec2 &point, const Camera* camera)
 {
-    if (_cursorUse)
+    if (_cursorEnabled)
     {
         // Reset Label, no cursor
         bool oldIsAttachWithIME = _isAttachWithIME;
@@ -413,7 +413,7 @@ void TextFieldTTF::visit(Renderer *renderer, const Mat4 &parentTransform, uint32
 
 void TextFieldTTF::update(float delta)
 {
-    if (_cursorUse && _isAttachWithIME)
+    if (_cursorEnabled && _isAttachWithIME)
     {
         _cursorShowingTime -= delta;
         if (_cursorShowingTime < -CURSOR_TIME_SHOW_HIDE)
@@ -496,19 +496,19 @@ void TextFieldTTF::setString(const std::string &text)
         _inputText = "";
     }
 
-    if (_cursorUse && charCount != _charCount)
+    if (_cursorEnabled && charCount != _charCount)
     {
         _cursorPosition = charCount;
     }
 
-    if (_cursorUse)
+    if (_cursorEnabled)
     {
         // Need for recreate all letters in Label
         Label::removeAllChildrenWithCleanup(false);
     }
 
     // if there is no input text, display placeholder instead
-    if (_inputText.empty() && (!_cursorUse || !_isAttachWithIME))
+    if (_inputText.empty() && (!_cursorEnabled || !_isAttachWithIME))
     {
         Label::setTextColor(_colorSpaceHolder);
         Label::setString(_placeHolder);
@@ -530,7 +530,7 @@ void TextFieldTTF::appendString(const std::string& text)
 
 void TextFieldTTF::makeStringSupportCursor(std::string& displayText)
 {
-    if (_cursorUse && _isAttachWithIME)
+    if (_cursorEnabled && _isAttachWithIME)
     {
         if (displayText.empty())
         {
@@ -542,7 +542,7 @@ void TextFieldTTF::makeStringSupportCursor(std::string& displayText)
         {
             StringUtils::StringUTF8 stringUTF8;
 
-            stringUTF8.set(displayText);
+            stringUTF8.replace(displayText);
 
             if (_cursorPosition > stringUTF8.length())
             {
@@ -576,7 +576,7 @@ void TextFieldTTF::setCursorChar(char cursor)
 
 void TextFieldTTF::controlKey(EventKeyboard::KeyCode keyCode)
 {
-    if (_cursorUse)
+    if (_cursorEnabled)
     {
         switch (keyCode)
         {
@@ -595,7 +595,7 @@ void TextFieldTTF::controlKey(EventKeyboard::KeyCode keyCode)
             {
                 StringUtils::StringUTF8 stringUTF8;
 
-                stringUTF8.set(_inputText);
+                stringUTF8.replace(_inputText);
                 stringUTF8.deleteChar(_cursorPosition);
                 setCursorPosition(_cursorPosition);
                 _charCount = stringUTF8.length();
@@ -646,14 +646,14 @@ const std::string& TextFieldTTF::getPlaceHolder() const
     return _placeHolder;
 }
 
-void TextFieldTTF::setCursorUse(bool value)
+void TextFieldTTF::setCursorEnabled(bool enabled)
 {
     if (_currentLabelType == LabelType::TTF)
     {
-        if (_cursorUse != value)
+        if (_cursorEnabled != enabled)
         {
-            _cursorUse = value;
-            if (_cursorUse)
+            _cursorEnabled = enabled;
+            if (_cursorEnabled)
             {
                 _cursorPosition = _charCount;
 

--- a/cocos/2d/CCTextFieldTTF.h
+++ b/cocos/2d/CCTextFieldTTF.h
@@ -242,7 +242,7 @@ public:
     * Set enable cursor use.
     * @js NA
     */
-    void setCursorUse(bool value);
+    void setCursorEnabled(bool enabled);
 
     /**
     * Set char showing cursor.
@@ -288,7 +288,7 @@ protected:
     bool _secureTextEntry;
 
     // Need use cursor
-    bool _cursorUse;
+    bool _cursorEnabled;
     // Current position cursor
     std::size_t _cursorPosition;
     // Char showing cursor

--- a/cocos/2d/CCTextFieldTTF.h
+++ b/cocos/2d/CCTextFieldTTF.h
@@ -195,6 +195,12 @@ public:
     virtual void setString(const std::string& text) override;
 
     /**
+    * Append to input text of TextField.
+    *@param text The append text of TextField.
+    */
+    virtual void appendString(const std::string& text);
+
+    /**
      * Query the input text of TextField.
      *@return Get the input text of TextField.
      */
@@ -230,6 +236,32 @@ public:
 
     virtual void visit(Renderer *renderer, const Mat4 &parentTransform, uint32_t parentFlags) override;
 
+    virtual void update(float delta) override;
+
+    /**
+    * Set enable cursor use.
+    * @js NA
+    */
+    void setCursorUse(bool value);
+
+    /**
+    * Set char showing cursor.
+    * @js NA
+    */
+    void setCursorChar(char cursor);
+
+    /**
+    * Set cursor position, if enabled
+    * @js NA
+    */
+    void setCursorPosition(std::size_t cursorPosition);
+
+    /**
+    * Set cursor position to hit letter, if enabled
+    * @js NA
+    */
+    void setCursorFromPoint(const Vec2 &point, const Camera* camera);
+
 protected:
     //////////////////////////////////////////////////////////////////////////
     // IMEDelegate interface
@@ -237,9 +269,12 @@ protected:
 
     virtual bool canAttachWithIME() override;
     virtual bool canDetachWithIME() override;
+    virtual void didAttachWithIME() override;
+    virtual void didDetachWithIME() override;
     virtual void insertText(const char * text, size_t len) override;
     virtual void deleteBackward() override;
     virtual const std::string& getContentText() override;
+    virtual void controlKey(EventKeyboard::KeyCode keyCode) override;
 
     TextFieldDelegate * _delegate;
     int _charCount;
@@ -251,6 +286,21 @@ protected:
     Color4B _colorText;
 
     bool _secureTextEntry;
+
+    // Need use cursor
+    bool _cursorUse;
+    // Current position cursor
+    std::size_t _cursorPosition;
+    // Char showing cursor
+    char _cursorChar;
+    // >0 - show, <0 - hide
+    float _cursorShowingTime;
+
+    bool _isAttachWithIME;
+
+    void makeStringSupportCursor(std::string& displayText);
+    void updateCursorDisplayText();
+    void setAttachWithIME(bool isAttachWithIME);
 
 private:
     class LengthStack;

--- a/cocos/base/CCIMEDelegate.h
+++ b/cocos/base/CCIMEDelegate.h
@@ -28,6 +28,7 @@ THE SOFTWARE.
 
 #include <string>
 #include "math/CCGeometry.h"
+#include "base/CCEventKeyboard.h"
 
 /**
  * @addtogroup base
@@ -123,6 +124,13 @@ protected:
     * @lua NA
     */
     virtual void deleteBackward() {}
+
+    /**
+    @brief    Called by IMEDispatcher after the user press control key.
+    * @js NA
+    * @lua NA
+    */
+    virtual void controlKey(EventKeyboard::KeyCode keyCode) {}
 
     /**
     @brief    Called by IMEDispatcher for text stored in delegate.

--- a/cocos/base/CCIMEDispatcher.cpp
+++ b/cocos/base/CCIMEDispatcher.cpp
@@ -144,19 +144,22 @@ bool IMEDispatcher::attachDelegateWithIME(IMEDelegate * delegate)
 
         if (_impl->_delegateWithIme)
         {
-            // if old delegate canDetachWithIME return false 
-            // or pDelegate canAttachWithIME return false,
-            // do nothing.
-            CC_BREAK_IF(! _impl->_delegateWithIme->canDetachWithIME()
-                || ! delegate->canAttachWithIME());
+            if (_impl->_delegateWithIme != delegate)
+            {
+                // if old delegate canDetachWithIME return false 
+                // or pDelegate canAttachWithIME return false,
+                // do nothing.
+                CC_BREAK_IF(!_impl->_delegateWithIme->canDetachWithIME()
+                    || !delegate->canAttachWithIME());
 
-            // detach first
-            IMEDelegate * oldDelegate = _impl->_delegateWithIme;
-            _impl->_delegateWithIme = 0;
-            oldDelegate->didDetachWithIME();
+                // detach first
+                IMEDelegate * oldDelegate = _impl->_delegateWithIme;
+                _impl->_delegateWithIme = 0;
+                oldDelegate->didDetachWithIME();
 
-            _impl->_delegateWithIme = *iter;
-            delegate->didAttachWithIME();
+                _impl->_delegateWithIme = *iter;
+                delegate->didAttachWithIME();
+            }
             ret = true;
             break;
         }
@@ -237,6 +240,19 @@ void IMEDispatcher::dispatchDeleteBackward()
         CC_BREAK_IF(! _impl->_delegateWithIme);
 
         _impl->_delegateWithIme->deleteBackward();
+    } while (0);
+}
+
+void IMEDispatcher::dispatchControlKey(EventKeyboard::KeyCode keyCode)
+{
+    do
+    {
+        CC_BREAK_IF(!_impl);
+
+        // there is no delegate attached to IME
+        CC_BREAK_IF(!_impl->_delegateWithIme);
+
+        _impl->_delegateWithIme->controlKey(keyCode);
     } while (0);
 }
 

--- a/cocos/base/CCIMEDispatcher.h
+++ b/cocos/base/CCIMEDispatcher.h
@@ -67,6 +67,12 @@ public:
     void dispatchDeleteBackward();
 
     /**
+    * @brief Dispatches the press control key operation.
+    * @lua NA
+    */
+    void dispatchControlKey(EventKeyboard::KeyCode keyCode);
+
+    /**
      * @brief Get the content text from IMEDelegate, retrieved previously from IME.
      * @lua NA
      */

--- a/cocos/base/ccUTF8.cpp
+++ b/cocos/base/ccUTF8.cpp
@@ -221,12 +221,7 @@ StringUTF8::StringUTF8()
 
 StringUTF8::StringUTF8(const std::string& newStr)
 {
-    set(newStr);
-}
-
-StringUTF8::StringUTF8(const StringUTF8& copyStrUtf8)
-{
-    _str = copyStrUtf8._str;
+    replace(newStr);
 }
 
 StringUTF8::~StringUTF8()
@@ -239,7 +234,7 @@ std::size_t StringUTF8::length() const
     return _str.size();
 }
 
-void StringUTF8::set(const std::string& newStr)
+void StringUTF8::replace(const std::string& newStr)
 {
     _str.clear();
     if (!newStr.empty())

--- a/cocos/base/ccUTF8.cpp
+++ b/cocos/base/ccUTF8.cpp
@@ -213,6 +213,106 @@ long getCharacterCountInUTF8String(const std::string& utf8)
     return getUTF8StringLength((const UTF8*)utf8.c_str());
 }
 
+
+StringUTF8::StringUTF8()
+{
+
+}
+
+StringUTF8::StringUTF8(const std::string& newStr)
+{
+    set(newStr);
+}
+
+StringUTF8::StringUTF8(const StringUTF8& copyStrUtf8)
+{
+    _str = copyStrUtf8._str;
+}
+
+StringUTF8::~StringUTF8()
+{
+
+}
+
+std::size_t StringUTF8::length() const
+{
+    return _str.size();
+}
+
+void StringUTF8::set(const std::string& newStr)
+{
+    _str.clear();
+    if (!newStr.empty())
+    {
+        UTF8* sequenceUtf8 = (UTF8*)newStr.c_str();
+
+        int lengthString = getUTF8StringLength(sequenceUtf8);
+
+        if (lengthString == 0)
+        {
+            CCLOG("Bad utf-8 set string: %s", newStr.c_str());
+            return;
+        }
+
+        while (*sequenceUtf8)
+        {
+            std::size_t lengthChar = getNumBytesForUTF8(*sequenceUtf8);
+
+            CharUTF8 charUTF8;
+            charUTF8._char.append((char*)sequenceUtf8, lengthChar);
+            sequenceUtf8 += lengthChar;
+
+            _str.push_back(charUTF8);
+        }
+    }
+}
+
+std::string StringUTF8::getAsCharSequence() const
+{
+    std::string charSequence;
+
+    for (auto& charUtf8 : _str)
+    {
+        charSequence.append(charUtf8._char);
+    }
+
+    return charSequence;
+}
+
+bool StringUTF8::deleteChar(std::size_t pos)
+{
+    if (pos < _str.size())
+    {
+        _str.erase(_str.begin() + pos);
+        return true;
+    }
+    else
+    {
+        return false;
+    }
+}
+
+bool StringUTF8::insert(std::size_t pos, const std::string& insertStr)
+{
+    StringUTF8 utf8(insertStr);
+
+    return insert(pos, utf8);
+}
+
+bool StringUTF8::insert(std::size_t pos, const StringUTF8& insertStr)
+{
+    if (pos <= _str.size())
+    {
+        _str.insert(_str.begin() + pos, insertStr._str.begin(), insertStr._str.end());
+
+        return true;
+    }
+    else
+    {
+        return false;
+    }
+}
+
 } //namespace StringUtils {
 
 

--- a/cocos/base/ccUTF8.h
+++ b/cocos/base/ccUTF8.h
@@ -142,6 +142,43 @@ CC_DLL unsigned int getIndexOfLastNotChar16(const std::vector<char16_t>& str, ch
  */
 CC_DLL std::vector<char16_t> getChar16VectorFromUTF16String(const std::u16string& utf16);
 
+
+
+/**
+* Utf8 sequence
+* Store all utf8 chars as std::string
+* Build from std::string
+*/
+class CC_DLL StringUTF8
+{
+public:
+    struct CharUTF8
+    {
+        std::string _char;
+        bool isAnsi() { return _char.size() == 1; }
+    };
+    typedef std::vector<CharUTF8> CharUTF8Store;
+
+    StringUTF8();
+    StringUTF8(const std::string& newStr);
+    explicit StringUTF8(const StringUTF8& copyStrUtf8);
+    ~StringUTF8();
+
+    std::size_t length() const;
+    void set(const std::string& newStr);
+
+    std::string getAsCharSequence() const;
+
+    bool deleteChar(std::size_t pos);
+    bool insert(std::size_t pos, const std::string& insertStr);
+    bool insert(std::size_t pos, const StringUTF8& insertStr);
+
+    CharUTF8Store& getString() { return _str; }
+
+private:
+    CharUTF8Store _str;
+};
+
 } // namespace StringUtils {
 
 /**

--- a/cocos/base/ccUTF8.h
+++ b/cocos/base/ccUTF8.h
@@ -161,11 +161,10 @@ public:
 
     StringUTF8();
     StringUTF8(const std::string& newStr);
-    explicit StringUTF8(const StringUTF8& copyStrUtf8);
     ~StringUTF8();
 
     std::size_t length() const;
-    void set(const std::string& newStr);
+    void replace(const std::string& newStr);
 
     std::string getAsCharSequence() const;
 

--- a/cocos/platform/win8.1-universal/OpenGLESPage.xaml.cpp
+++ b/cocos/platform/win8.1-universal/OpenGLESPage.xaml.cpp
@@ -385,13 +385,10 @@ void OpenGLESPage::OnPointerWheelChanged(Object^ sender, PointerEventArgs^ e)
 
 void OpenGLESPage::OnKeyPressed(CoreWindow^ sender, KeyEventArgs^ e)
 {
-    if (!e->KeyStatus.WasKeyDown)
+    //log("OpenGLESPage::OnKeyPressed %d", e->VirtualKey);
+    if (mRenderer)
     {
-        //log("OpenGLESPage::OnKeyPressed %d", e->VirtualKey);
-        if (mRenderer)
-        {
-            mRenderer->QueueKeyboardEvent(WinRTKeyboardEventType::KeyPressed, e);
-        }
+        mRenderer->QueueKeyboardEvent(WinRTKeyboardEventType::KeyPressed, e);
     }
 }
 

--- a/cocos/platform/winrt/Keyboard-winrt.cpp
+++ b/cocos/platform/winrt/Keyboard-winrt.cpp
@@ -270,33 +270,47 @@ void KeyBoardWinRT::OnWinRTKeyboardEvent(WinRTKeyboardEventType type, KeyEventAr
 {
     bool pressed = (type == WinRTKeyboardEventType::KeyPressed);
 
-    // don't allow key repeats
-    if (pressed && args->KeyStatus.WasKeyDown)
-    {
-        return;
-    }
+    // Is key repeats
+    bool repeat = pressed && args->KeyStatus.WasKeyDown;
 
     int key = static_cast<int>(args->VirtualKey);
     auto it = g_keyCodeMap.find(key);
     if (it != g_keyCodeMap.end())
     {
-        switch (it->second)
+
+        EventKeyboard::KeyCode keyCode = it->second;
+
+        EventKeyboard event(keyCode, pressed);
+        if (!repeat)
         {
-        case EventKeyboard::KeyCode::KEY_BACKSPACE:
-            if (pressed)
-            {
-                IMEDispatcher::sharedDispatcher()->dispatchDeleteBackward();
-            }
-            break;
-        default:
-            EventKeyboard event(it->second, pressed);
             auto dispatcher = Director::getInstance()->getEventDispatcher();
             dispatcher->dispatchEvent(&event);
-            if (it->second == EventKeyboard::KeyCode::KEY_ENTER)
+            if (keyCode == EventKeyboard::KeyCode::KEY_ENTER)
             {
                 IMEDispatcher::sharedDispatcher()->dispatchInsertText("\n", 1);
-                }
-            break;
+            }
+        }
+
+        if (pressed && !event.isStopped())
+        {
+            switch (keyCode)
+            {
+            case EventKeyboard::KeyCode::KEY_BACKSPACE:
+                IMEDispatcher::sharedDispatcher()->dispatchDeleteBackward();
+                break;
+            case EventKeyboard::KeyCode::KEY_HOME:
+            case EventKeyboard::KeyCode::KEY_KP_HOME:
+            case EventKeyboard::KeyCode::KEY_DELETE:
+            case EventKeyboard::KeyCode::KEY_KP_DELETE:
+            case EventKeyboard::KeyCode::KEY_END:
+            case EventKeyboard::KeyCode::KEY_LEFT_ARROW:
+            case EventKeyboard::KeyCode::KEY_RIGHT_ARROW:
+            case EventKeyboard::KeyCode::KEY_ESCAPE:
+                IMEDispatcher::sharedDispatcher()->dispatchControlKey(keyCode);
+                break;
+            default:
+                break;
+            }
         }
     }
     else

--- a/templates/cpp-template-default/proj.win10/App/Cocos2dEngine/OpenGLESPage.xaml.cpp
+++ b/templates/cpp-template-default/proj.win10/App/Cocos2dEngine/OpenGLESPage.xaml.cpp
@@ -385,13 +385,10 @@ void OpenGLESPage::OnPointerWheelChanged(Object^ sender, PointerEventArgs^ e)
 
 void OpenGLESPage::OnKeyPressed(CoreWindow^ sender, KeyEventArgs^ e)
 {
-    if (!e->KeyStatus.WasKeyDown)
+    //log("OpenGLESPage::OnKeyPressed %d", e->VirtualKey);
+    if (mRenderer)
     {
-        //log("OpenGLESPage::OnKeyPressed %d", e->VirtualKey);
-        if (mRenderer)
-        {
-            mRenderer->QueueKeyboardEvent(WinRTKeyboardEventType::KeyPressed, e);
-        }
+        mRenderer->QueueKeyboardEvent(WinRTKeyboardEventType::KeyPressed, e);
     }
 }
 

--- a/templates/cpp-template-default/proj.win8.1-universal/App.Shared/OpenGLESPage.xaml.cpp
+++ b/templates/cpp-template-default/proj.win8.1-universal/App.Shared/OpenGLESPage.xaml.cpp
@@ -385,13 +385,10 @@ void OpenGLESPage::OnPointerWheelChanged(Object^ sender, PointerEventArgs^ e)
 
 void OpenGLESPage::OnKeyPressed(CoreWindow^ sender, KeyEventArgs^ e)
 {
-    if (!e->KeyStatus.WasKeyDown)
+    //log("OpenGLESPage::OnKeyPressed %d", e->VirtualKey);
+    if (mRenderer)
     {
-        //log("OpenGLESPage::OnKeyPressed %d", e->VirtualKey);
-        if (mRenderer)
-        {
-            mRenderer->QueueKeyboardEvent(WinRTKeyboardEventType::KeyPressed, e);
-        }
+        mRenderer->QueueKeyboardEvent(WinRTKeyboardEventType::KeyPressed, e);
     }
 }
 

--- a/templates/js-template-default/frameworks/runtime-src/proj.win8.1-universal/App.Shared/OpenGLESPage.xaml.cpp
+++ b/templates/js-template-default/frameworks/runtime-src/proj.win8.1-universal/App.Shared/OpenGLESPage.xaml.cpp
@@ -385,13 +385,10 @@ void OpenGLESPage::OnPointerWheelChanged(Object^ sender, PointerEventArgs^ e)
 
 void OpenGLESPage::OnKeyPressed(CoreWindow^ sender, KeyEventArgs^ e)
 {
-    if (!e->KeyStatus.WasKeyDown)
+    //log("OpenGLESPage::OnKeyPressed %d", e->VirtualKey);
+    if (mRenderer)
     {
-        //log("OpenGLESPage::OnKeyPressed %d", e->VirtualKey);
-        if (mRenderer)
-        {
-            mRenderer->QueueKeyboardEvent(WinRTKeyboardEventType::KeyPressed, e);
-        }
+        mRenderer->QueueKeyboardEvent(WinRTKeyboardEventType::KeyPressed, e);
     }
 }
 


### PR DESCRIPTION
Add StringUtils::StringUTF8 for easy manipulate utf8 string.
If TextField active(focused input text) show text cursor( default '|',
change TextFieldTTF::setCursorChar ).
Show/Hide interval CURSOR_TIME_SHOW_HIDE
Change position text cursor control key: KEY_HOME, KEY_END,
KEY_LEFT_ARROW, KEY_RIGHT_ARROW
CC_PLATFORM_MAC, CC_PLATFORM_WIN32, CC_PLATFORM_LINUX default use
cursor( For change state TextFieldTTF::setCursorUse )
Desktop implement dispatchControlKey
WinRT support key repeat and implement dispatchControlKey
Text cursor worked only on LabelType::TTF

new version it: #13903 , for easy merge

Example use: http://youtu.be/g6jpmaip1fY
