### PR TITLE
Use GL_GENERATE_MIPMAP for OpenGL version less 3.0 v1.1

### DIFF
--- a/cocos/3d/CCTerrain.cpp
+++ b/cocos/3d/CCTerrain.cpp
@@ -862,8 +862,8 @@ bool Terrain::initTextures()
         auto textImage = new (std::nothrow)Image();
         textImage->initWithImageFile(_terrainData._detailMaps[0]._detailMapSrc);
         auto texture = new (std::nothrow)Texture2D();
+        texture->setAutoGenerateMipmap(true);
         texture->initWithImage(textImage);
-        texture->generateMipmap();
         _detailMapTextures[0] = texture;
         texParam.minFilter = GL_LINEAR_MIPMAP_LINEAR;
         texParam.magFilter = GL_LINEAR;
@@ -888,9 +888,9 @@ bool Terrain::initTextures()
             auto textImage = new (std::nothrow)Image();
             textImage->initWithImageFile(_terrainData._detailMaps[i]._detailMapSrc);
             auto texture = new (std::nothrow)Texture2D();
+            texture->setAutoGenerateMipmap(true);
             texture->initWithImage(textImage);
             delete textImage;
-            texture->generateMipmap();
             _detailMapTextures[i] = texture;
 
             texParam.wrapS = GL_REPEAT;

--- a/cocos/base/CCConfiguration.cpp
+++ b/cocos/base/CCConfiguration.cpp
@@ -51,6 +51,7 @@ Configuration::Configuration()
 , _supportsShareableVAO(false)
 , _supportsOESDepth24(false)
 , _supportsOESPackedDepthStencil(false)
+, _supportsGenerateMipmap(false)
 , _maxSamplesAllowed(0)
 , _maxTextureUnits(0)
 , _glExtensions(nullptr)
@@ -159,6 +160,20 @@ void Configuration::gatherGPUInfo()
     _supportsOESPackedDepthStencil = checkForGLExtension("GL_OES_packed_depth_stencil");
     _valueDict["gl.supports_OES_packed_depth_stencil"] = Value(_supportsOESPackedDepthStencil);
 
+    _supportsGenerateMipmap = true;
+
+#ifndef GL_ES_VERSION_2_0
+    // glGenerateMipmap supports:
+    // OpenGL ES 2.0 or greater https://www.khronos.org/opengles/sdk/docs/man3/html/glGenerateMipmap.xhtml
+    // OpenGL 3.0 or greater https://www.opengl.org/sdk/docs/man/html/glGenerateMipmap.xhtml
+
+    float glVersion = _valueDict["gl.version"].asFloat();
+    if (glVersion < 3.0)
+    {
+        _supportsGenerateMipmap = false;
+    }
+#endif
+    _valueDict["gl.supports_generate_mipmap"] = Value(_supportsGenerateMipmap);
 
     CHECK_GL_ERROR_DEBUG();
 }
@@ -275,12 +290,16 @@ bool Configuration::supportsOESDepth24() const
     return _supportsOESDepth24;
     
 }
+
 bool Configuration::supportsOESPackedDepthStencil() const
 {
     return _supportsOESPackedDepthStencil;
 }
 
-
+bool Configuration::supportsGenerateMipmap() const
+{
+    return _supportsGenerateMipmap;
+}
 
 int Configuration::getMaxSupportDirLightInShader() const
 {

--- a/cocos/base/CCConfiguration.h
+++ b/cocos/base/CCConfiguration.h
@@ -159,8 +159,14 @@ public:
      * @since v2.0.0
      */
     bool supportsOESPackedDepthStencil() const;
-
     
+
+    /** Whether or not glGenerateMipmap are supported.
+    *
+    * @return Is true if glGenerateMipmap.
+    * @since v3.8.0
+    */
+    bool supportsGenerateMipmap() const;
     
     /** Max support directional light in shader, for Sprite3D.
      *
@@ -250,6 +256,7 @@ protected:
     bool            _supportsShareableVAO;
     bool            _supportsOESDepth24;
     bool            _supportsOESPackedDepthStencil;
+    bool            _supportsGenerateMipmap;
     
     GLint           _maxSamplesAllowed;
     GLint           _maxTextureUnits;

--- a/cocos/renderer/CCMaterial.cpp
+++ b/cocos/renderer/CCMaterial.cpp
@@ -217,7 +217,15 @@ bool Material::parseSampler(GLProgramState* glProgramState, Properties* samplerP
     // required
     auto filename = samplerProperties->getString("path");
 
-    auto texture = Director::getInstance()->getTextureCache()->addImage(filename);
+    // mipmap
+    bool generateMipMap = false;
+    const char* mipmap = getOptionalString(samplerProperties, "mipmap", "false");
+    if (mipmap && strcasecmp(mipmap, "true") == 0) 
+    {
+        generateMipMap = true;
+    }
+
+    auto texture = Director::getInstance()->getTextureCache()->addImage(filename, generateMipMap);
     if (!texture) {
         CCLOG("Invalid filepath");
         return false;
@@ -227,14 +235,6 @@ bool Material::parseSampler(GLProgramState* glProgramState, Properties* samplerP
 
     {
         Texture2D::TexParams texParams;
-
-        // mipmap
-        bool usemipmap = false;
-        const char* mipmap = getOptionalString(samplerProperties, "mipmap", "false");
-        if (mipmap && strcasecmp(mipmap, "true")==0) {
-            texture->generateMipmap();
-            usemipmap = true;
-        }
 
         // valid options: REPEAT, CLAMP
         const char* wrapS = getOptionalString(samplerProperties, "wrapS", "CLAMP_TO_EDGE");
@@ -257,7 +257,7 @@ bool Material::parseSampler(GLProgramState* glProgramState, Properties* samplerP
 
 
         // valid options: NEAREST, LINEAR, NEAREST_MIPMAP_NEAREST, LINEAR_MIPMAP_NEAREST, NEAREST_MIPMAP_LINEAR, LINEAR_MIPMAP_LINEAR
-        const char* minFilter = getOptionalString(samplerProperties, "minFilter", usemipmap ? "LINEAR_MIPMAP_NEAREST" : "LINEAR");
+        const char* minFilter = getOptionalString(samplerProperties, "minFilter", generateMipMap ? "LINEAR_MIPMAP_NEAREST" : "LINEAR");
         if (strcasecmp(minFilter, "NEAREST")==0)
             texParams.minFilter = GL_NEAREST;
         else if(strcasecmp(minFilter, "LINEAR")==0)

--- a/cocos/renderer/CCTexture2D.cpp
+++ b/cocos/renderer/CCTexture2D.cpp
@@ -433,6 +433,7 @@ Texture2D::Texture2D()
 , _maxT(0.0)
 , _hasPremultipliedAlpha(false)
 , _hasMipmaps(false)
+, _generateMipmaps(false)
 , _shaderProgram(nullptr)
 , _antialiasEnabled(true)
 , _ninePatchInfo(nullptr)
@@ -551,8 +552,6 @@ bool Texture2D::initWithData(const void *data, ssize_t dataLen, Texture2D::Pixel
 
 bool Texture2D::initWithMipmaps(MipmapInfo* mipmaps, int mipmapsNum, PixelFormat pixelFormat, int pixelsWide, int pixelsHigh)
 {
-
-
     //the pixelFormat must be a certain value 
     CCASSERT(pixelFormat != PixelFormat::NONE && pixelFormat != PixelFormat::AUTO, "the \"pixelFormat\" param must be a certain value!");
     CCASSERT(pixelsWide>0 && pixelsHigh>0, "Invalid size");
@@ -628,6 +627,15 @@ bool Texture2D::initWithMipmaps(MipmapInfo* mipmaps, int mipmapsNum, PixelFormat
     glTexParameteri( GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE );
     glTexParameteri( GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE );
 
+#ifndef GL_ES_VERSION_2_0
+    if (mipmapsNum == 1 && _generateMipmaps && !Configuration::getInstance()->supportsGenerateMipmap())
+    {
+        // glGenerateMipmap supports: OpenGL ES 2.0 or greater and OpenGL 3.0 or greater
+        // https://www.opengl.org/wiki/Common_Mistakes#Automatic_mipmap_generation
+        glTexParameteri(GL_TEXTURE_2D, GL_GENERATE_MIPMAP, GL_TRUE); 
+    }
+#endif
+
 #if CC_ENABLE_CACHE_TEXTURE_DATA
     if (_antialiasEnabled)
     {
@@ -690,7 +698,12 @@ bool Texture2D::initWithMipmaps(MipmapInfo* mipmaps, int mipmapsNum, PixelFormat
     _maxT = 1;
 
     _hasPremultipliedAlpha = false;
-    _hasMipmaps = mipmapsNum > 1;
+    _hasMipmaps = mipmapsNum > 1 || _generateMipmaps;
+
+    if (mipmapsNum == 1 && _generateMipmaps && Configuration::getInstance()->supportsGenerateMipmap())
+    {
+        generateMipmapInternal();
+    }
 
     // shader
     setGLProgram(GLProgramCache::getInstance()->getGLProgram(GLProgram::SHADER_NAME_POSITION_TEXTURE));
@@ -1213,15 +1226,22 @@ void Texture2D::PVRImagesHavePremultipliedAlpha(bool haveAlphaPremultiplied)
 //
 // implementation Texture2D (GLFilter)
 
-void Texture2D::generateMipmap()
+void Texture2D::generateMipmapInternal()
 {
-    CCASSERT(_pixelsWide == ccNextPOT(_pixelsWide) && _pixelsHigh == ccNextPOT(_pixelsHigh), "Mipmap texture only works in POT textures");
-    GL::bindTexture2D( _name );
-    glGenerateMipmap(GL_TEXTURE_2D);
-    _hasMipmaps = true;
+    if (Configuration::getInstance()->supportsGenerateMipmap())
+    {
+        CCASSERT(_pixelsWide == ccNextPOT(_pixelsWide) && _pixelsHigh == ccNextPOT(_pixelsHigh), "Mipmap texture only works in POT textures");
+        GL::bindTexture2D( _name );
+        glGenerateMipmap(GL_TEXTURE_2D);
+        _hasMipmaps = true;
 #if CC_ENABLE_CACHE_TEXTURE_DATA
-    VolatileTextureMgr::setHasMipmaps(this, _hasMipmaps);
+        VolatileTextureMgr::setHasMipmaps(this, _hasMipmaps);
 #endif
+    }
+    else
+    {
+        CCLOG("glGenerateMipmap required OpenGL 3.0 or OpenGL ES 2.0 or greater");
+    }
 }
 
 bool Texture2D::hasMipmaps() const
@@ -1442,6 +1462,11 @@ void Texture2D::removeSpriteFrameCapInset(SpriteFrame* spriteFrame)
             capInsetMap.erase(spriteFrame);
         }
     }
+}
+
+void Texture2D::setAutoGenerateMipmap(bool generateMipmaps)
+{
+    _generateMipmaps = generateMipmaps;
 }
 
 NS_CC_END

--- a/cocos/renderer/CCTexture2D.h
+++ b/cocos/renderer/CCTexture2D.h
@@ -349,7 +349,7 @@ public:
     /** Need generate mipmap images for the texture.
     Call before init
     It only works if the texture size is POT (power of 2).
-    @since v3.8.0
+    @since v3.11
     */
     void setAutoGenerateMipmap(bool generateMipmaps);
 
@@ -441,7 +441,7 @@ private:
 
     /** Generates mipmap images for the texture.
     It only works if the texture size is POT (power of 2).
-    @since v0.99.0
+    @since v3.11
     */
     void generateMipmapInternal();
 

--- a/cocos/renderer/CCTexture2D.h
+++ b/cocos/renderer/CCTexture2D.h
@@ -339,11 +339,19 @@ public:
     void setAliasTexParameters();
 
 
-    /** Generates mipmap images for the texture.
+    /** DEPRECATED, use setAutoGenerateMipmap(before call init)
+    Generates mipmap images for the texture.
     It only works if the texture size is POT (power of 2).
     @since v0.99.0
     */
-    void generateMipmap();
+    CC_DEPRECATED_ATTRIBUTE void generateMipmap(){ generateMipmapInternal(); }
+
+    /** Need generate mipmap images for the texture.
+    Call before init
+    It only works if the texture size is POT (power of 2).
+    @since v3.8.0
+    */
+    void setAutoGenerateMipmap(bool generateMipmaps);
 
     /** Returns the pixel format.
      @since v2.0
@@ -430,6 +438,12 @@ private:
      * @return True is Texture contains a 9-patch info, false otherwise.
      */
     bool isContain9PatchInfo()const;
+
+    /** Generates mipmap images for the texture.
+    It only works if the texture size is POT (power of 2).
+    @since v0.99.0
+    */
+    void generateMipmapInternal();
 
     /**
      * Get spriteFrame capInset, If spriteFrame can't be found in 9-patch info map,
@@ -530,6 +544,9 @@ protected:
     
     /** whether or not the texture has mip maps*/
     bool _hasMipmaps;
+
+    /** whether or not generate the texture mip maps*/
+    bool _generateMipmaps;
 
     /** shader program used by drawAtPoint and drawInRect */
     GLProgram* _shaderProgram;

--- a/cocos/renderer/CCTextureCache.cpp
+++ b/cocos/renderer/CCTextureCache.cpp
@@ -533,12 +533,12 @@ void TextureCache::removeTextureForKey(const std::string &textureKeyName)
     }
 }
 
-Texture2D* TextureCache::getTextureForKey(const std::string &textureKeyName, bool checkFullPath) const
+Texture2D* TextureCache::getTextureForKey(const std::string &textureKeyName) const
 {
     std::string key = textureKeyName;
     auto it = _textures.find(key);
 
-    if (checkFullPath && it == _textures.end()) {
+    if (it == _textures.end()) {
         key = FileUtils::getInstance()->fullPathForFilename(textureKeyName);
         it = _textures.find(key);
     }

--- a/cocos/renderer/CCTextureCache.cpp
+++ b/cocos/renderer/CCTextureCache.cpp
@@ -128,6 +128,11 @@ public:
  Does process all response in addImageAsyncCallback consume more time?
  - Convert image to texture faster than load image from disk, so this isn't a problem.
  */
+void TextureCache::addImageAsync(const std::string &path, const std::function<void(Texture2D*)>& callback)
+{
+    addImageAsync(path, callback, false);
+}
+
 void TextureCache::addImageAsync(const std::string &path, const std::function<void(Texture2D*)>& callback, bool generateMipMap)
 {
     Texture2D *texture = nullptr;
@@ -321,6 +326,11 @@ void TextureCache::addImageAsyncCallBack(float dt)
     {
         Director::getInstance()->getScheduler()->unschedule(CC_SCHEDULE_SELECTOR(TextureCache::addImageAsyncCallBack), this);
     }
+}
+
+Texture2D * TextureCache::addImage(const std::string &path)
+{
+    return addImage(path, false);
 }
 
 Texture2D * TextureCache::addImage(const std::string &path, bool generateMipMap)

--- a/cocos/renderer/CCTextureCache.cpp
+++ b/cocos/renderer/CCTextureCache.cpp
@@ -93,10 +93,11 @@ std::string TextureCache::getDescription() const
 struct TextureCache::AsyncStruct
 {
 public:
-    AsyncStruct(const std::string& fn, std::function<void(Texture2D*)> f) : filename(fn), callback(f), loadSuccess(false) {}
+    AsyncStruct(const std::string& fn, std::function<void(Texture2D*)> f, bool mipMap) : filename(fn), callback(f), generateMipMap(mipMap), loadSuccess(false) {}
     
     std::string filename;
     std::function<void(Texture2D*)> callback;
+    bool generateMipMap;
     Image image;
     bool loadSuccess;
 };
@@ -127,7 +128,7 @@ public:
  Does process all response in addImageAsyncCallback consume more time?
  - Convert image to texture faster than load image from disk, so this isn't a problem.
  */
-void TextureCache::addImageAsync(const std::string &path, const std::function<void(Texture2D*)>& callback)
+void TextureCache::addImageAsync(const std::string &path, const std::function<void(Texture2D*)>& callback, bool generateMipMap)
 {
     Texture2D *texture = nullptr;
 
@@ -165,7 +166,7 @@ void TextureCache::addImageAsync(const std::string &path, const std::function<vo
     ++_asyncRefCount;
 
     // generate async struct
-    AsyncStruct *data = new (std::nothrow) AsyncStruct(fullpath, callback);
+    AsyncStruct *data = new (std::nothrow) AsyncStruct(fullpath, callback, generateMipMap);
     
     // add async struct into queue
     _asyncStructQueue.push_back(data);
@@ -250,7 +251,8 @@ void TextureCache::addImageAsyncCallBack(float dt)
         if(_responseQueue.empty())
         {
             asyncStruct = nullptr;
-        }else
+        }
+        else
         {
             asyncStruct = _responseQueue.front();
             _responseQueue.pop_front();
@@ -261,7 +263,8 @@ void TextureCache::addImageAsyncCallBack(float dt)
         }
         _responseMutex.unlock();
         
-        if (nullptr == asyncStruct) {
+        if (nullptr == asyncStruct) 
+        {
             break;
         }
         
@@ -279,20 +282,25 @@ void TextureCache::addImageAsyncCallBack(float dt)
                 Image* image = &(asyncStruct->image);
                 // generate texture in render thread
                 texture = new (std::nothrow) Texture2D();
+                if (texture)
+                {             
+                    texture->setAutoGenerateMipmap(asyncStruct->generateMipMap);
+                    texture->initWithImage(image);
+                    //parse 9-patch info
+                    this->parseNinePatchImage(image, texture, asyncStruct->filename);
+    #if CC_ENABLE_CACHE_TEXTURE_DATA
+                    // cache the texture file name
+                    VolatileTextureMgr::addImageTexture(texture, asyncStruct->filename);
+    #endif
+                    // cache the texture. retain it, since it is added in the map
+                    _textures.insert( std::make_pair(asyncStruct->filename, texture) );
+                    texture->retain();
                 
-                texture->initWithImage(image);
-                //parse 9-patch info
-                this->parseNinePatchImage(image, texture, asyncStruct->filename);
-#if CC_ENABLE_CACHE_TEXTURE_DATA
-                // cache the texture file name
-                VolatileTextureMgr::addImageTexture(texture, asyncStruct->filename);
-#endif
-                // cache the texture. retain it, since it is added in the map
-                _textures.insert( std::make_pair(asyncStruct->filename, texture) );
-                texture->retain();
-                
-                texture->autorelease();
-            } else {
+                    texture->autorelease();
+                }
+            } 
+            else 
+            {
                 texture = nullptr;
                 CCLOG("cocos2d: failed to call TextureCache::addImageAsync(%s)", asyncStruct->filename.c_str());
             }
@@ -315,7 +323,7 @@ void TextureCache::addImageAsyncCallBack(float dt)
     }
 }
 
-Texture2D * TextureCache::addImage(const std::string &path)
+Texture2D * TextureCache::addImage(const std::string &path, bool generateMipMap)
 {
     Texture2D * texture = nullptr;
     Image* image = nullptr;
@@ -344,6 +352,11 @@ Texture2D * TextureCache::addImage(const std::string &path)
             CC_BREAK_IF(!bRet);
 
             texture = new (std::nothrow) Texture2D();
+
+            if (texture)
+            {
+                texture->setAutoGenerateMipmap(generateMipMap);
+            }
 
             if( texture && texture->initWithImage(image) )
             {
@@ -382,7 +395,7 @@ void TextureCache::parseNinePatchImage(cocos2d::Image *image, cocos2d::Texture2D
 
 }
 
-Texture2D* TextureCache::addImage(Image *image, const std::string &key)
+Texture2D* TextureCache::addImage(Image *image, const std::string &key, bool generateMipMap)
 {
     CCASSERT(image != nullptr, "TextureCache: image MUST not be nil");
 
@@ -398,10 +411,11 @@ Texture2D* TextureCache::addImage(Image *image, const std::string &key)
 
         // prevents overloading the autorelease pool
         texture = new (std::nothrow) Texture2D();
-        texture->initWithImage(image);
 
         if(texture)
         {
+            texture->setAutoGenerateMipmap(generateMipMap);
+            texture->initWithImage(image);
             _textures.insert( std::make_pair(key, texture) );
             texture->retain();
 
@@ -495,7 +509,7 @@ void TextureCache::removeTexture(Texture2D* texture)
 
     for( auto it=_textures.cbegin(); it!=_textures.cend(); /* nothing */ ) {
         if( it->second == texture ) {
-            it->second->release();
+            texture->release();
             _textures.erase(it++);
             break;
         } else
@@ -519,12 +533,12 @@ void TextureCache::removeTextureForKey(const std::string &textureKeyName)
     }
 }
 
-Texture2D* TextureCache::getTextureForKey(const std::string &textureKeyName) const
+Texture2D* TextureCache::getTextureForKey(const std::string &textureKeyName, bool checkFullPath) const
 {
     std::string key = textureKeyName;
     auto it = _textures.find(key);
 
-    if( it == _textures.end() ) {
+    if (checkFullPath && it == _textures.end()) {
         key = FileUtils::getInstance()->fullPathForFilename(textureKeyName);
         it = _textures.find(key);
     }
@@ -542,7 +556,7 @@ void TextureCache::reloadAllTextures()
 // #endif
 }
 
-std::string TextureCache::getTextureFilePath(cocos2d::Texture2D* texture) const
+std::string TextureCache::getTextureFilePath( cocos2d::Texture2D *texture )const
 {
     for(auto& item : _textures)
     {
@@ -782,6 +796,7 @@ void VolatileTextureMgr::reloadAllTextures()
     {
         VolatileTexture *vt = *iter++;
 
+        vt->_texture->setAutoGenerateMipmap(vt->_hasMipmaps);
         switch (vt->_cashedImageType)
         {
         case VolatileTexture::kImageFile:
@@ -823,9 +838,6 @@ void VolatileTextureMgr::reloadAllTextures()
             break;
         default:
             break;
-        }
-        if (vt->_hasMipmaps) {
-            vt->_texture->generateMipmap();
         }
         vt->_texture->setTexParameters(vt->_texParams);
     }

--- a/cocos/renderer/CCTextureCache.h
+++ b/cocos/renderer/CCTextureCache.h
@@ -107,9 +107,10 @@ public:
     * Object and it will return it. It will use the filename as a key.
     * Otherwise it will return a reference of a previously loaded image.
     * Supported image extensions: .png, .bmp, .tiff, .jpeg, .pvr.
-     @param filepath A null terminated string.
+    * @param filepath A null terminated string.
+    * @param generateMipMap need generate mipmap levels(if image does not contain).
     */
-    Texture2D* addImage(const std::string &filepath);
+    Texture2D* addImage(const std::string &filepath, bool generateMipMap = false);
 
     /** Returns a Texture2D object given a file image.
     * If the file image was not previously loaded, it will create a new Texture2D object and it will return it.
@@ -118,9 +119,10 @@ public:
     * Supported image extensions: .png, .jpg
      @param filepath A null terminated string.
      @param callback A callback function would be invoked after the image is loaded.
+     @param generateMipMap need generate mipmap levels(if image does not contain).
      @since v0.8
     */
-    virtual void addImageAsync(const std::string &filepath, const std::function<void(Texture2D*)>& callback);
+    virtual void addImageAsync(const std::string &filepath, const std::function<void(Texture2D*)>& callback, bool generateMipMap = false);
     
     /** Unbind a specified bound image asynchronous callback.
      * In the case an object who was bound to an image asynchronous callback was destroyed before the callback is invoked,
@@ -139,16 +141,18 @@ public:
     * If the image was not previously loaded, it will create a new Texture2D object and it will return it.
     * Otherwise it will return a reference of a previously loaded image.
     * @param key The "key" parameter will be used as the "key" for the cache.
+    * @param generateMipMap need generate mipmap levels(if image does not contain).
     * If "key" is nil, then a new texture will be created each time.
     */
-    Texture2D* addImage(Image *image, const std::string &key);
+    Texture2D* addImage(Image *image, const std::string &key, bool generateMipMap = false);
     CC_DEPRECATED_ATTRIBUTE Texture2D* addUIImage(Image *image, const std::string& key) { return addImage(image,key); }
 
     /** Returns an already created texture. Returns nil if the texture doesn't exist.
     @param key It's the related/absolute path of the file image.
+    @param checkFullPath If key not found, check key = fullPathForFilename(key). Default true
     @since v0.99.5
     */
-    Texture2D* getTextureForKey(const std::string& key) const;
+    Texture2D* getTextureForKey(const std::string& key, bool checkFullPath = true) const;
     CC_DEPRECATED_ATTRIBUTE Texture2D* textureForKey(const std::string& key) const { return getTextureForKey(key); }
 
     /** Reload texture from the image file.

--- a/cocos/renderer/CCTextureCache.h
+++ b/cocos/renderer/CCTextureCache.h
@@ -107,22 +107,45 @@ public:
     * Object and it will return it. It will use the filename as a key.
     * Otherwise it will return a reference of a previously loaded image.
     * Supported image extensions: .png, .bmp, .tiff, .jpeg, .pvr.
+    * Not generate mipmap
+    * @param filepath A null terminated string.
+    */
+    Texture2D* addImage(const std::string &filepath);
+
+    /** Returns a Texture2D object given an filename.
+    * If the filename was not previously loaded, it will create a new Texture2D.
+    * Object and it will return it. It will use the filename as a key.
+    * Otherwise it will return a reference of a previously loaded image.
+    * Supported image extensions: .png, .bmp, .tiff, .jpeg, .pvr.
     * @param filepath A null terminated string.
     * @param generateMipMap need generate mipmap levels(if image does not contain).
+      @since v3.11
     */
-    Texture2D* addImage(const std::string &filepath, bool generateMipMap = false);
+    Texture2D* addImage(const std::string &filepath, bool generateMipMap);
 
     /** Returns a Texture2D object given a file image.
     * If the file image was not previously loaded, it will create a new Texture2D object and it will return it.
     * Otherwise it will load a texture in a new thread, and when the image is loaded, the callback will be called with the Texture2D as a parameter.
     * The callback will be called from the main thread, so it is safe to create any cocos2d object from the callback.
     * Supported image extensions: .png, .jpg
+    * Not generate mipmap
      @param filepath A null terminated string.
      @param callback A callback function would be invoked after the image is loaded.
-     @param generateMipMap need generate mipmap levels(if image does not contain).
      @since v0.8
     */
-    virtual void addImageAsync(const std::string &filepath, const std::function<void(Texture2D*)>& callback, bool generateMipMap = false);
+    virtual void addImageAsync(const std::string &filepath, const std::function<void(Texture2D*)>& callback);
+
+    /** Returns a Texture2D object given a file image.
+    * If the file image was not previously loaded, it will create a new Texture2D object and it will return it.
+    * Otherwise it will load a texture in a new thread, and when the image is loaded, the callback will be called with the Texture2D as a parameter.
+    * The callback will be called from the main thread, so it is safe to create any cocos2d object from the callback.
+    * Supported image extensions: .png, .jpg
+    @param filepath A null terminated string.
+    @param callback A callback function would be invoked after the image is loaded.
+    @param generateMipMap need generate mipmap levels(if image does not contain).
+    @since v3.11
+    */
+    virtual void addImageAsync(const std::string &filepath, const std::function<void(Texture2D*)>& callback, bool generateMipMap);
     
     /** Unbind a specified bound image asynchronous callback.
      * In the case an object who was bound to an image asynchronous callback was destroyed before the callback is invoked,

--- a/cocos/renderer/CCTextureCache.h
+++ b/cocos/renderer/CCTextureCache.h
@@ -149,10 +149,9 @@ public:
 
     /** Returns an already created texture. Returns nil if the texture doesn't exist.
     @param key It's the related/absolute path of the file image.
-    @param checkFullPath If key not found, check key = fullPathForFilename(key). Default true
     @since v0.99.5
     */
-    Texture2D* getTextureForKey(const std::string& key, bool checkFullPath = true) const;
+    Texture2D* getTextureForKey(const std::string& key) const;
     CC_DEPRECATED_ATTRIBUTE Texture2D* textureForKey(const std::string& key) const { return getTextureForKey(key); }
 
     /** Reload texture from the image file.


### PR DESCRIPTION
glGenerateMipmap supports:
OpenGL ES 2.0 or greater
https://www.khronos.org/opengles/sdk/docs/man3/html/glGenerateMipmap.xhtml
OpenGL 3.0 or greater
https://www.opengl.org/sdk/docs/man/html/glGenerateMipmap.xhtml

Add Configuration::supportsGenerateMipmap() for check it
Add Texture2D::setAutoGenerateMipmap for use old GL_GENERATE_MIPMAP (
need set before glTexImage2D ), and use it any initWithImage

GL_GENERATE_MIPMAP -
https://www.opengl.org/wiki/Common_Mistakes#Automatic_mipmap_generation

new version it: #13233 , for easy merge
