### PR TITLE
Wrong log message if use tga image

### DIFF
--- a/cocos/platform/CCImage.cpp
+++ b/cocos/platform/CCImage.cpp
@@ -724,7 +724,6 @@ Image::Format Image::detectFormat(const unsigned char * data, ssize_t dataLen)
     }
     else
     {
-        CCLOG("cocos2d: can't detect image format");
         return Format::UNKNOWN;
     }
 }


### PR DESCRIPTION
detectFormat don't need log message.
initWithImageData call detectFormat, and if Format::UNKNOWN check tga format.
Before check tga, CCLOG("cocos2d: unsupported image format!");
