### PR TITLE
WICImageLoader incorrect use S_FALSE constant

### DIFF
--- a/cocos/platform/winrt/WICImageLoader-winrt.cpp
+++ b/cocos/platform/winrt/WICImageLoader-winrt.cpp
@@ -95,7 +95,7 @@ WICImageLoader::~WICImageLoader()
 bool WICImageLoader::decodeImageData(ImageBlob blob, size_t size)
 {
     bool bRet = false;
-    HRESULT hr = E_FAIL; // S_FALSE is succeeded
+    HRESULT hr = E_FAIL;
 
 	IWICStream* pWicStream = NULL;
 	IWICImagingFactory* pWicFactory = getWICFactory();
@@ -127,7 +127,7 @@ bool WICImageLoader::decodeImageData(ImageBlob blob, size_t size)
 
 bool WICImageLoader::processImage(IWICBitmapDecoder* pDecoder)
 {
-    HRESULT hr = E_FAIL; // S_FALSE is succeeded
+    HRESULT hr = E_FAIL;
 	IWICBitmapFrameDecode* pFrame = NULL;
 
 	if(NULL != pDecoder)
@@ -240,7 +240,7 @@ HRESULT WICImageLoader::convertFormatIfRequired(IWICBitmapFrameDecode* pFrame, I
 
 size_t WICImageLoader::getBitsPerPixel(WICPixelFormatGUID format)
 {
-    HRESULT hr = E_FAIL; // S_FALSE is succeeded
+    HRESULT hr = E_FAIL;
 
 	IWICImagingFactory* pfactory = getWICFactory();
 

--- a/cocos/platform/winrt/WICImageLoader-winrt.cpp
+++ b/cocos/platform/winrt/WICImageLoader-winrt.cpp
@@ -94,8 +94,8 @@ WICImageLoader::~WICImageLoader()
 
 bool WICImageLoader::decodeImageData(ImageBlob blob, size_t size)
 {
-	bool bRet = false;
-	HRESULT hr = S_FALSE;
+    bool bRet = false;
+    HRESULT hr = E_FAIL; // S_FALSE is succeeded
 
 	IWICStream* pWicStream = NULL;
 	IWICImagingFactory* pWicFactory = getWICFactory();
@@ -127,7 +127,7 @@ bool WICImageLoader::decodeImageData(ImageBlob blob, size_t size)
 
 bool WICImageLoader::processImage(IWICBitmapDecoder* pDecoder)
 {
-	HRESULT hr = S_FALSE;
+    HRESULT hr = E_FAIL; // S_FALSE is succeeded
 	IWICBitmapFrameDecode* pFrame = NULL;
 
 	if(NULL != pDecoder)
@@ -240,7 +240,7 @@ HRESULT WICImageLoader::convertFormatIfRequired(IWICBitmapFrameDecode* pFrame, I
 
 size_t WICImageLoader::getBitsPerPixel(WICPixelFormatGUID format)
 {
-	HRESULT hr = S_FALSE;
+    HRESULT hr = E_FAIL; // S_FALSE is succeeded
 
 	IWICImagingFactory* pfactory = getWICFactory();
 


### PR DESCRIPTION
HRESULT default set S_FALSE, but SUCCEEDED(S_FALSE) is true
Now HRESULT default set E_FAIL - SUCCEEDED(E_FAIL ) is false
