### PR TITLE
fix cpp-tests proj.android-stdio build failed

### DIFF
--- a/tests/cpp-tests/proj.android-studio/app/jni/Android.mk
+++ b/tests/cpp-tests/proj.android-studio/app/jni/Android.mk
@@ -187,6 +187,7 @@ LOCAL_SRC_FILES := main.cpp \
 ../../../Classes/UITest/CocoStudioGUITest/UIWebViewTest/UIWebViewTest.cpp \
 ../../../Classes/UITest/CocoStudioGUITest/UIWidgetAddNodeTest/UIWidgetAddNodeTest.cpp \
 ../../../Classes/UITest/CocoStudioGUITest/UIWidgetAddNodeTest/UIWidgetAddNodeTest_Editor.cpp \
+../../../Classes/UITest/CocoStudioGUITest/UITabControlTest/UITabControlTest.cpp \
 ../../../Classes/UITest/UITest.cpp \
 ../../../Classes/UnitTest/RefPtrTest.cpp \
 ../../../Classes/UnitTest/UnitTest.cpp \


### PR DESCRIPTION
UITabControlTest/UITabControlTest.cpp is forgotten to add to Android.mk. :)
