### PR TITLE
fix unneeded define that breaks some libraries to build on windows

### DIFF
--- a/cocos/platform/win32/CCStdC-win32.h
+++ b/cocos/platform/win32/CCStdC-win32.h
@@ -45,8 +45,10 @@ typedef SSIZE_T ssize_t;
     #define _USE_MATH_DEFINES       // make M_PI can be use
 #endif
 
+#if _MSC_VER < 1800
 #if !defined(isnan)
     #define isnan   _isnan
+#endif
 #endif
 
 #if _MSC_VER < 1900


### PR DESCRIPTION
fix unneeded define that breaks some libraries to build on windows
