### PR TITLE
Enumerate getChildren() instead of _children.

### DIFF
--- a/cocos/2d/CCNode.cpp
+++ b/cocos/2d/CCNode.cpp
@@ -903,7 +903,7 @@ bool Node::doEnumerate(std::string name, std::function<bool (Node *)> callback) 
     }
     
     bool ret = false;
-    for (const auto& child : _children)
+    for (const auto& child : getChildren())
     {
         if (std::regex_match(child->_name, std::regex(searchName)))
         {


### PR DESCRIPTION
`CCNode::getChildren()` is virtual. A base class can override getChildren() and return something different than `_children`. Therefore, when the children are enumerated using `doEnumerate()`, `getChildren()` returns the correct list.
