### PR TITLE
Add optional alpha parameter to Color4B and Color4F constructors

### DIFF
--- a/cocos/base/ccTypes.cpp
+++ b/cocos/base/ccTypes.cpp
@@ -108,11 +108,11 @@ Color4B::Color4B(GLubyte _r, GLubyte _g, GLubyte _b, GLubyte _a)
 , a(_a)
 {}
 
-Color4B::Color4B(const Color3B& color)
+Color4B::Color4B(const Color3B& color, GLubyte _a)
 : r(color.r)
 , g(color.g)
 , b(color.b)
-, a(255)
+, a(_a)
 {}
 
 Color4B::Color4B(const Color4F& color)
@@ -170,11 +170,11 @@ Color4F::Color4F(float _r, float _g, float _b, float _a)
 , a(_a)
 {}
 
-Color4F::Color4F(const Color3B& color)
+Color4F::Color4F(const Color3B& color, float _a)
 : r(color.r / 255.0f)
 , g(color.g / 255.0f)
 , b(color.b / 255.0f)
-, a(1.0f)
+, a(_a)
 {}
 
 Color4F::Color4F(const Color4B& color)

--- a/cocos/base/ccTypes.h
+++ b/cocos/base/ccTypes.h
@@ -91,7 +91,7 @@ struct CC_DLL Color4B
 {
     Color4B();
     Color4B(GLubyte _r, GLubyte _g, GLubyte _b, GLubyte _a);
-    explicit Color4B(const Color3B& color);
+    explicit Color4B(const Color3B& color, GLubyte _a = 255);
     explicit Color4B(const Color4F& color);
     
     inline void set(GLubyte _r, GLubyte _g, GLubyte _b, GLubyte _a)
@@ -134,7 +134,7 @@ struct CC_DLL Color4F
 {
     Color4F();
     Color4F(float _r, float _g, float _b, float _a);
-    explicit Color4F(const Color3B& color);
+    explicit Color4F(const Color3B& color, float _a = 1.0f);
     explicit Color4F(const Color4B& color);
 
     bool operator==(const Color4F& right) const;


### PR DESCRIPTION
The constructors for `Color4B` and `Color4F` that take a `Color3B` parameter should also take an optional alpha parameter. This is for programmers' convenience. Since the alpha parameter defaults to full opacity, this change is backward compatible.
