### PR TITLE
UIEditBox attachWithIME, detachWithIME make working

### DIFF
--- a/cocos/base/CCIMEDelegate.h
+++ b/cocos/base/CCIMEDelegate.h
@@ -79,6 +79,13 @@ public:
      */
     virtual bool detachWithIME();
 
+    /**
+     * Check whether the IME is attached or not.
+     * @js NA
+     * @lua NA
+     */
+    virtual bool isAttachedWithIME();
+
 protected:
     friend class IMEDispatcher;
 

--- a/cocos/base/CCIMEDispatcher.cpp
+++ b/cocos/base/CCIMEDispatcher.cpp
@@ -53,6 +53,11 @@ bool IMEDelegate::detachWithIME()
     return IMEDispatcher::sharedDispatcher()->detachDelegateWithIME(this);
 }
 
+bool IMEDelegate::isAttachedWithIME()
+{
+    return IMEDispatcher::sharedDispatcher()->isAttachedWithIME(this);
+}
+
 //////////////////////////////////////////////////////////////////////////
 
 typedef std::list< IMEDelegate * > DelegateList;
@@ -211,6 +216,21 @@ void IMEDispatcher::removeDelegate(IMEDelegate* delegate)
         }
         _impl->_delegateList.erase(iter);
     } while (0);
+}
+
+bool IMEDispatcher::isAttachedWithIME(IMEDelegate * delegate)
+{
+    bool ret = false;
+    do
+    {
+        CC_BREAK_IF(! delegate || ! _impl);
+		
+        // if pDelegate is not the current delegate attached to IME, return
+        CC_BREAK_IF(_impl->_delegateWithIme != delegate);
+		
+        ret = true;
+    } while (0);
+    return ret;
 }
 
 //////////////////////////////////////////////////////////////////////////

--- a/cocos/base/CCIMEDispatcher.h
+++ b/cocos/base/CCIMEDispatcher.h
@@ -129,6 +129,13 @@ protected:
      */
     void removeDelegate(IMEDelegate * delegate);
 
+    /**
+     *@brief Check the Delegate is attached to the IME or not.
+     *@param delegate A instance implements IMEDelegate delegate.
+     *@return If the delegate is attached to the IME return true, otherwise false.
+     */
+    bool isAttachedWithIME(IMEDelegate * delegate);
+	
 private:
     IMEDispatcher();
     

--- a/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxEditBoxHelper.java
+++ b/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxEditBoxHelper.java
@@ -312,14 +312,28 @@ public class Cocos2dxEditBoxHelper {
                         editBox.requestFocus();
                         Cocos2dxEditBoxHelper.openKeyboard(index);
                     }else{
-                        mCocos2dxActivity.getGLSurfaceView().requestFocus();
-                        Cocos2dxEditBoxHelper.closeKeyboard(index);
+                        if (editBox == mCocos2dxActivity.getCurrentFocus()) {
+                            mCocos2dxActivity.getGLSurfaceView().requestFocus();
+                            Cocos2dxEditBoxHelper.closeKeyboard(index);
+                        }
                     }
                 }
             }
         });
     }
 
+    public static void clearFocus(final int index) {
+        mCocos2dxActivity.runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                Cocos2dxEditBox editBox = mEditBoxArray.get(index);
+                if (editBox != null && editBox == mCocos2dxActivity.getCurrentFocus()) {
+                    mCocos2dxActivity.getGLSurfaceView().requestFocus();
+                    Cocos2dxEditBoxHelper.closeKeyboard(index);
+                }
+            }
+        });
+    }
 
     public static void setText(final int index, final String text){
         mCocos2dxActivity.runOnUiThread(new Runnable() {

--- a/cocos/ui/UIEditBox/UIEditBox.cpp
+++ b/cocos/ui/UIEditBox/UIEditBox.cpp
@@ -63,7 +63,7 @@ EditBox::~EditBox(void)
 void EditBox::touchDownAction(Ref *sender, TouchEventType controlEvent)
 {
     if (controlEvent == Widget::TouchEventType::ENDED) {
-        _editBoxImpl->openKeyboard();
+        attachWithIME();
     }
 }
 
@@ -455,7 +455,7 @@ void EditBox::onExit(void)
     if (_editBoxImpl != nullptr)
     {
         // remove system edit control
-        _editBoxImpl->closeKeyboard();
+        detachWithIME();
     }
 }
 
@@ -525,6 +525,16 @@ void EditBox::unregisterScriptEditBoxHandler(void)
     }
 }
 #endif
+
+void EditBox::didAttachWithIME()
+{
+    _editBoxImpl->openKeyboard();
+}
+
+void EditBox::didDetachWithIME()
+{
+    _editBoxImpl->closeKeyboard();
+}
 
 }
 

--- a/cocos/ui/UIEditBox/UIEditBox.h
+++ b/cocos/ui/UIEditBox/UIEditBox.h
@@ -461,6 +461,11 @@ namespace ui {
          */
         void touchDownAction(Ref *sender, TouchEventType controlEvent);
             
+        virtual bool canAttachWithIME() override { return true; }
+        virtual bool canDetachWithIME() override { return true; }
+        virtual void didAttachWithIME() override;
+        virtual void didDetachWithIME() override;
+
     protected:
         virtual void adaptRenderers() override;
 

--- a/cocos/ui/UIEditBox/UIEditBoxImpl-android.cpp
+++ b/cocos/ui/UIEditBox/UIEditBoxImpl-android.cpp
@@ -194,7 +194,7 @@ void EditBoxImplAndroid::nativeOpenKeyboard()
 
 void EditBoxImplAndroid::nativeCloseKeyboard()
 {
-    JniHelper::callStaticVoidMethod(editBoxClassName, "closeKeyboard", _editBoxIndex);
+    JniHelper::callStaticVoidMethod(editBoxClassName, "clearFocus", _editBoxIndex);
 }
 
 void editBoxEditingDidBegin(int index)


### PR DESCRIPTION
it's not available editbox's attaching and detaching by programmatically.
i made it possible.

uieditbox already had imedelegate as a parent, and i overrode methods aboud ime attaching, detaching.

now it is available editbox's attaching and detaching by programmatically.
(android, iOS tested)
