### PR TITLE
Clear FontAtlasCache on change content scale factor

### DIFF
--- a/cocos/2d/CCFontAtlasCache.cpp
+++ b/cocos/2d/CCFontAtlasCache.cpp
@@ -44,6 +44,7 @@ void FontAtlasCache::purgeCachedData()
     {
         atlas.second->purgeTexturesAtlas();
     }
+    _atlasMap.clear();
 }
 
 FontAtlas* FontAtlasCache::getFontAtlasTTF(const _ttfConfig* config)

--- a/cocos/base/CCDirector.cpp
+++ b/cocos/base/CCDirector.cpp
@@ -1315,6 +1315,7 @@ void Director::setContentScaleFactor(float scaleFactor)
     {
         _contentScaleFactor = scaleFactor;
         _isStatusLabelUpdated = true;
+        FontAtlasCache::purgeCachedData();
     }
 }
 

--- a/tests/cpp-tests/Classes/LabelTest/LabelTestNew.cpp
+++ b/tests/cpp-tests/Classes/LabelTest/LabelTestNew.cpp
@@ -107,6 +107,7 @@ NewLabelTests::NewLabelTests()
     ADD_TEST_CASE(LabelBold);
 
     ADD_TEST_CASE(LabelLocalizationTest);
+    ADD_TEST_CASE(LabelBMFontScaleFactorTest);
 };
 
 LabelFNTColorAndOpacity::LabelFNTColorAndOpacity()
@@ -3160,4 +3161,66 @@ void LabelLocalizationTest::onChangedRadioButtonSelect(RadioButton* radioButton,
     default:
         break;
     }
+}
+
+std::string LabelBMFontScaleFactorTest::title() const
+{
+    return "LabelBMFont on scaleFactor 2.0";
+}
+
+std::string LabelBMFontScaleFactorTest::subtitle() const
+{
+    return "Should not crash!";
+}
+
+void LabelBMFontScaleFactorTest::onEnter()
+{
+    auto director = Director::getInstance();
+    director->getOpenGLView()->setDesignResolutionSize(_originalDesignSize.width, _originalDesignSize.height, ResolutionPolicy::NO_BORDER);
+    AtlasDemoNew::onEnter();
+}
+
+void LabelBMFontScaleFactorTest::onExit()
+{
+    auto director = Director::getInstance();
+    auto glview = director->getOpenGLView();
+    glview->setDesignResolutionSize(_originalDesignSize.width, _originalDesignSize.height, ResolutionPolicy::SHOW_ALL);
+    director->setContentScaleFactor(_originalScaleFactor);
+    AtlasDemoNew::onExit();
+}
+
+LabelBMFontScaleFactorTest::LabelBMFontScaleFactorTest()
+{
+    auto designSize = Director::getInstance()->getOpenGLView()->getDesignResolutionSize();
+    _originalDesignSize = designSize;
+    _originalScaleFactor = Director::getInstance()->getContentScaleFactor();
+
+    auto menuItem = MenuItemFont::create("restore scaleFactor", [&](cocos2d::Ref* sender) {
+        Director::getInstance()->setContentScaleFactor(_originalScaleFactor);
+        auto center = VisibleRect::center();
+        auto sprite = Sprite::create("Images/grossini.png");
+        sprite->setPosition(center.x * 0.5, center.y);
+        addChild(sprite);
+
+        auto label = Label::createWithBMFont("fonts/bitmapFontTest2.fnt", "Test");
+        label->setPosition(sprite->getPosition());
+        addChild(label);
+    });
+
+    auto center = VisibleRect::center();
+    menuItem->setFontSizeObj(12);
+    auto menu = Menu::createWithItem(menuItem);
+    addChild(menu);
+    auto scale = 0.8f;
+    Director::getInstance()->setContentScaleFactor(_originalScaleFactor / scale);
+    auto winSize = Director::getInstance()->getWinSize();
+    menu->setPosition(winSize.width * 0.9, winSize.height * 0.25f);
+
+    auto sprite = Sprite::create("Images/grossini.png");
+    sprite->setPosition(center.x, center.y);
+    addChild(sprite);
+
+    auto label = Label::createWithBMFont("fonts/bitmapFontTest2.fnt", "Test");
+    label->setPosition(sprite->getPosition());
+    addChild(label);
 }

--- a/tests/cpp-tests/Classes/LabelTest/LabelTestNew.cpp
+++ b/tests/cpp-tests/Classes/LabelTest/LabelTestNew.cpp
@@ -3165,12 +3165,12 @@ void LabelLocalizationTest::onChangedRadioButtonSelect(RadioButton* radioButton,
 
 std::string LabelBMFontScaleFactorTest::title() const
 {
-    return "LabelBMFont on scaleFactor 2.0";
+    return "different scaleFactor LabelBMFont";
 }
 
 std::string LabelBMFontScaleFactorTest::subtitle() const
 {
-    return "Should not crash!";
+    return "Should be valid size";
 }
 
 void LabelBMFontScaleFactorTest::onEnter()

--- a/tests/cpp-tests/Classes/LabelTest/LabelTestNew.h
+++ b/tests/cpp-tests/Classes/LabelTest/LabelTestNew.h
@@ -860,4 +860,21 @@ public:
     cocostudio::ILocalizationManager* _localizationBin;
 };
 
+class LabelBMFontScaleFactorTest : public AtlasDemoNew
+{
+public:
+    CREATE_FUNC(LabelBMFontScaleFactorTest);
+
+    LabelBMFontScaleFactorTest();
+    void onChangedRadioButtonSelect(cocos2d::ui::RadioButton* radioButton, cocos2d::ui::RadioButton::EventType type);
+
+    void onEnter() override;
+    void onExit() override;
+
+    virtual std::string title() const override;
+    virtual std::string subtitle() const override;
+    cocos2d::Size _originalDesignSize;
+    float _originalScaleFactor;
+};
+
 #endif


### PR DESCRIPTION
Hi.
I'v found a bug that LabelBMFont are broken if changed content scale factor.
It becomes FontAtlasCache.
It works fine if I cleared the caches.
Thanks.
