### PR TITLE
extend the RichText

### DIFF
--- a/cocos/ui/UIRichText.cpp
+++ b/cocos/ui/UIRichText.cpp
@@ -24,6 +24,7 @@
 
 #include "ui/UIRichText.h"
 
+#include <sstream>
 #include <vector>
 
 #include "tinyxml2/tinyxml2.h"
@@ -37,54 +38,68 @@
 #include "base/ccUTF8.h"
 #include "ui/UIHelper.h"
 
-NS_CC_BEGIN
+USING_NS_CC;
+using namespace cocos2d::ui;
 
-namespace ui {
-    class ListenerComponent : public Component
+class ListenerComponent : public Component
+{
+public:
+    static const std::string COMPONENT_NAME;    /*!< component name */
+
+    static ListenerComponent* create(Node* parent, const std::string& url, const RichText::OpenUrlHandler handleOpenUrl = nullptr)
     {
-    public:
-        static ListenerComponent* create(Label* parent, const std::string& url)
-        {
-            auto component = new (std::nothrow) ListenerComponent(parent, url);
-            component->autorelease();
-            return component;
-        }
+        auto component = new (std::nothrow) ListenerComponent(parent, url, handleOpenUrl);
+        component->autorelease();
+        return component;
+    }
 
-        explicit ListenerComponent(Label* parent, const std::string& url)
-        : _parent(parent)
-        , _url(url)
-        {
-            _touchListener = cocos2d::EventListenerTouchAllAtOnce::create();
-            _touchListener->onTouchesEnded = CC_CALLBACK_2(ListenerComponent::onTouchesEnded, this);
+    explicit ListenerComponent(Node* parent, const std::string& url, const RichText::OpenUrlHandler handleOpenUrl)
+    : _parent(parent)
+    , _url(url)
+    , _handleOpenUrl(handleOpenUrl)
+    {
+        setName(ListenerComponent::COMPONENT_NAME);
+        
+        _touchListener = cocos2d::EventListenerTouchAllAtOnce::create();
+        _touchListener->onTouchesEnded = CC_CALLBACK_2(ListenerComponent::onTouchesEnded, this);
 
-            Director::getInstance()->getEventDispatcher()->addEventListenerWithSceneGraphPriority(_touchListener, _parent);
-            _touchListener->retain();
-        }
+        Director::getInstance()->getEventDispatcher()->addEventListenerWithSceneGraphPriority(_touchListener, _parent);
+        _touchListener->retain();
+    }
 
-        virtual ~ListenerComponent()
-        {
-            Director::getInstance()->getEventDispatcher()->removeEventListener(_touchListener);
-            _touchListener->release();
-        }
+    virtual ~ListenerComponent()
+    {
+        Director::getInstance()->getEventDispatcher()->removeEventListener(_touchListener);
+        _touchListener->release();
+    }
 
-        void onTouchesEnded(const std::vector<Touch*>& touches, Event *event)
+    void onTouchesEnded(const std::vector<Touch*>& touches, Event *event)
+    {
+        for (const auto& touch: touches)
         {
-            for (const auto& touch: touches)
-            {
-                // FIXME: Node::getBoundBox() doesn't return it in local coordinates... so create one manually.
-                Rect localRect = Rect(Vec2::ZERO, _parent->getContentSize());
-                if (localRect.containsPoint(_parent->convertTouchToNodeSpace(touch)))
-                    Application::getInstance()->openURL(_url);
+            // FIXME: Node::getBoundBox() doesn't return it in local coordinates... so create one manually.
+            Rect localRect = Rect(Vec2::ZERO, _parent->getContentSize());
+            if (localRect.containsPoint(_parent->convertTouchToNodeSpace(touch))) {
+                if (_handleOpenUrl) {
+                    _handleOpenUrl(_url);
+                }
             }
         }
+    }
+    
+    void setOpenUrlHandler(const RichText::OpenUrlHandler& handleOpenUrl)
+    {
+        _handleOpenUrl = handleOpenUrl;
+    }
 
-    private:
-        Label* _parent;      // weak ref.
-        std::string _url;
-        EventDispatcher* _eventDispatcher;  // weak ref.
-        EventListenerTouchAllAtOnce* _touchListener;    // strong ref.
-    };
-
+private:
+    Node* _parent;      // weak ref.
+    std::string _url;
+    RichText::OpenUrlHandler _handleOpenUrl;
+    EventDispatcher* _eventDispatcher;  // weak ref.
+    EventListenerTouchAllAtOnce* _touchListener;    // strong ref.
+};
+const std::string ListenerComponent::COMPONENT_NAME("cocos2d_ui_UIRichText_ListenerComponent");
 
 bool RichElement::init(int tag, const Color3B &color, GLubyte opacity)
 {
@@ -93,12 +108,26 @@ bool RichElement::init(int tag, const Color3B &color, GLubyte opacity)
     _opacity = opacity;
     return true;
 }
-    
-    
-RichElementText* RichElementText::create(int tag, const Color3B &color, GLubyte opacity, const std::string& text, const std::string& fontName, float fontSize, uint32_t flags, const std::string& url)
+
+bool RichElement::equalType(Type type)
+{
+    return (_type == type);
+}
+
+void RichElement::setColor(const Color3B& color)
+{
+    _color = color;
+}
+
+RichElementText* RichElementText::create(int tag, const Color3B &color, GLubyte opacity, const std::string& text,
+                                         const std::string& fontName, float fontSize, uint32_t flags, const std::string& url,
+                                         const Color3B& outlineColor, int outlineSize ,
+                                         const Color3B& shadowColor, const cocos2d::Size& shadowOffset, int shadowBlurRadius,
+                                         const Color3B& glowColor)
 {
     RichElementText* element = new (std::nothrow) RichElementText();
-    if (element && element->init(tag, color, opacity, text, fontName, fontSize, flags, url))
+    if (element && element->init(tag, color, opacity, text, fontName, fontSize, flags, url,
+                                 outlineColor, outlineSize, shadowColor, shadowOffset, shadowBlurRadius, glowColor))
     {
         element->autorelease();
         return element;
@@ -107,7 +136,11 @@ RichElementText* RichElementText::create(int tag, const Color3B &color, GLubyte 
     return nullptr;
 }
     
-bool RichElementText::init(int tag, const Color3B &color, GLubyte opacity, const std::string& text, const std::string& fontName, float fontSize, uint32_t flags, const std::string& url)
+bool RichElementText::init(int tag, const Color3B &color, GLubyte opacity, const std::string& text,
+                           const std::string& fontName, float fontSize, uint32_t flags, const std::string& url,
+                           const Color3B& outlineColor, int outlineSize ,
+                           const Color3B& shadowColor, const cocos2d::Size& shadowOffset, int shadowBlurRadius,
+                           const Color3B& glowColor)
 {
     if (RichElement::init(tag, color, opacity))
     {
@@ -116,15 +149,21 @@ bool RichElementText::init(int tag, const Color3B &color, GLubyte opacity, const
         _fontSize = fontSize;
         _flags = flags;
         _url = url;
+        _outlineColor = outlineColor;
+        _outlineSize = outlineSize;
+        _shadowColor = shadowColor;
+        _shadowOffset = shadowOffset;
+        _shadowBlurRadius = shadowBlurRadius;
+        _glowColor = glowColor;
         return true;
     }
     return false;
 }
 
-RichElementImage* RichElementImage::create(int tag, const Color3B &color, GLubyte opacity, const std::string& filePath)
+RichElementImage* RichElementImage::create(int tag, const Color3B &color, GLubyte opacity, const std::string& filePath, const std::string& url)
 {
     RichElementImage* element = new (std::nothrow) RichElementImage();
-    if (element && element->init(tag, color, opacity, filePath))
+    if (element && element->init(tag, color, opacity, filePath, url))
     {
         element->autorelease();
         return element;
@@ -133,17 +172,19 @@ RichElementImage* RichElementImage::create(int tag, const Color3B &color, GLubyt
     return nullptr;
 }
     
-bool RichElementImage::init(int tag, const Color3B &color, GLubyte opacity, const std::string& filePath)
+bool RichElementImage::init(int tag, const Color3B &color, GLubyte opacity, const std::string& filePath, const std::string& url)
 {
     if (RichElement::init(tag, color, opacity))
     {
         _filePath = filePath;
         _width = -1;
         _height = -1;
+        _url = url;
         return true;
     }
     return false;
 }
+
 void RichElementImage::setWidth(int width)
 {
     _width = width;
@@ -152,6 +193,11 @@ void RichElementImage::setWidth(int width)
 void RichElementImage::setHeight(int height)
 {
     _height = height;
+}
+
+void RichElementImage::setUrl(const std::string& url)
+{
+    _url = url;
 }
 
 RichElementCustomNode* RichElementCustomNode::create(int tag, const Color3B &color, GLubyte opacity, cocos2d::Node *customNode)
@@ -188,13 +234,659 @@ RichElementNewLine* RichElementNewLine::create(int tag, const Color3B& color, GL
     CC_SAFE_DELETE(element);
     return nullptr;
 }
+
+/** @brief parse a XML. */
+class MyXMLVisitor: public tinyxml2::XMLVisitor
+{
+public:
+    /** @brief underline or strikethrough */
+    enum class StyleLine {
+        NONE,
+        UNDERLINE,          /*!< underline */
+        STRIKETHROUGH       /*!< a typographical presentation of words with a horizontal line through their center */
+    };
     
+    /** @brief outline, shadow or glow */
+    enum class StyleEffect {
+        NONE,
+        OUTLINE,            /*!< outline effect enabled */
+        SHADOW,             /*!< shadow effect enabled */
+        GLOW                /*!< glow effect enabled @discussion Limiting use to only when the Label created with true type font. */
+    };
+    
+    /** @brief the attributes of text tag */
+    struct Attributes
+    {
+        std::string face;                       /*!< font name */
+        std::string url;                        /*!< url is a attribute of a anchor tag */
+        float fontSize;                         /*!< font size */
+        Color3B color;                          /*!< font color */
+        bool hasColor;                          /*!< or color is specified? */
+        bool bold;                              /*!< bold text */
+        bool italics;                           /*!< italic text */
+        StyleLine line;                         /*!< underline or strikethrough */
+        StyleEffect effect;                     /*!< outline, shadow or glow */
+        Color3B outlineColor;                   /*!< the color of the outline */
+        int outlineSize;                        /*!< the outline effect size value */
+        Color3B shadowColor;                    /*!< the shadow effect color value */
+        cocos2d::Size shadowOffset;             /*!< shadow effect offset value */
+        int shadowBlurRadius;                   /*!< the shadow effect blur radius */
+        Color3B glowColor;                      /*!< the glow effect color value */
+        
+        void setColor(const Color3B& acolor)
+        {
+            color = acolor;
+            hasColor = true;
+        }
+        Attributes()
+        : bold(false)
+        , italics(false)
+        , line(StyleLine::NONE)
+        , hasColor(false)
+        , fontSize(-1)
+        , effect(StyleEffect::NONE)
+        {
+        }
+    };
+    
+private:
+    std::vector<Attributes> _fontElements;
+    
+    RichText* _richText;
+    
+    struct TagBehavior {
+        bool                isFontElement;
+        RichText::VisitEnterHandler   handleVisitEnter;
+    };
+    typedef std::unordered_map<std::string, TagBehavior> TagTables;
+    
+    static TagTables        _tagTables;
+    
+public:
+    explicit MyXMLVisitor(RichText* richText);
+    virtual ~MyXMLVisitor();
+    
+    Color3B getColor() const;
+    
+    float getFontSize() const;
+    
+    std::string getFace() const;
+    
+    std::string getURL() const;
+    
+    bool getBold() const;
+    
+    bool getItalics() const;
+    
+    bool getUnderline() const;
+    
+    bool getStrikethrough() const;
+    
+    std::tuple<bool, Color3B, int> getOutline() const;
+    
+    std::tuple<bool, Color3B, cocos2d::Size, int> getShadow() const;
+    
+    std::tuple<bool, Color3B> getGlow() const;
+    
+    /// Visit an element.
+    virtual bool VisitEnter( const tinyxml2::XMLElement& element, const tinyxml2::XMLAttribute* firstAttribute );
+    
+    /// Visit an element.
+    virtual bool VisitExit( const tinyxml2::XMLElement& element );
+    
+    /// Visit a text node.
+    virtual bool Visit(const tinyxml2::XMLText& text);
+    
+    void pushBackFontElement(const Attributes& attribs);
+    
+    void popBackFontElement();
+    
+    void pushBackElement(RichElement* element);
+    
+    static void setTagDescription(const std::string& tag, bool isFontElement, RichText::VisitEnterHandler handleVisitEnter);
+    
+    static void removeTagDescription(const std::string& tag);
+    
+private:
+    ValueMap tagAttrMapWithXMLElement(const tinyxml2::XMLElement& element);
+};
+
+MyXMLVisitor::TagTables MyXMLVisitor::_tagTables;
+
+MyXMLVisitor::MyXMLVisitor(RichText* richText)
+: _richText(richText)
+, _fontElements(20)
+{
+    MyXMLVisitor::setTagDescription("font", true, [](const ValueMap& tagAttrValueMap) {
+        // supported attributes:
+        // size, color, align, face
+        ValueMap attrValueMap;
+        
+        if (tagAttrValueMap.find("size") != tagAttrValueMap.end()) {
+            attrValueMap[RichText::KEY_FONT_SIZE] = tagAttrValueMap.at("size").asString();
+        }
+        if (tagAttrValueMap.find("color") != tagAttrValueMap.end()) {
+            attrValueMap[RichText::KEY_FONT_COLOR_STRING] = tagAttrValueMap.at("color").asString();
+        }
+        if (tagAttrValueMap.find("face") != tagAttrValueMap.end()) {
+            attrValueMap[RichText::KEY_FONT_FACE] = tagAttrValueMap.at("face").asString();
+        }
+        
+        return make_pair(attrValueMap, nullptr);
+    });
+    
+    MyXMLVisitor::setTagDescription("b", true, [](const ValueMap& tagAttrValueMap) {
+        // no supported attributes
+        ValueMap attrValueMap;
+        attrValueMap[RichText::KEY_TEXT_BOLD] = true;
+        return make_pair(attrValueMap, nullptr);
+    });
+    
+    MyXMLVisitor::setTagDescription("i", true, [](const ValueMap& tagAttrValueMap) {
+        // no supported attributes
+        ValueMap attrValueMap;
+        attrValueMap[RichText::KEY_TEXT_ITALIC] = true;
+        return make_pair(attrValueMap, nullptr);
+    });
+    
+    MyXMLVisitor::setTagDescription("del", true, [](const ValueMap& tagAttrValueMap) {
+        // no supported attributes
+        ValueMap attrValueMap;
+        attrValueMap[RichText::KEY_TEXT_LINE] = RichText::VALUE_TEXT_LINE_DEL;
+        return make_pair(attrValueMap, nullptr);
+    });
+    
+    MyXMLVisitor::setTagDescription("u", true, [](const ValueMap& tagAttrValueMap) {
+        // no supported attributes
+        ValueMap attrValueMap;
+        attrValueMap[RichText::KEY_TEXT_LINE] = RichText::VALUE_TEXT_LINE_UNDER;
+        return make_pair(attrValueMap, nullptr);
+    });
+    
+    MyXMLVisitor::setTagDescription("small", true, [](const ValueMap& tagAttrValueMap) {
+        ValueMap attrValueMap;
+        attrValueMap[RichText::KEY_FONT_SMALL] = true;
+        return make_pair(attrValueMap, nullptr);
+    });
+    
+    MyXMLVisitor::setTagDescription("big", true, [](const ValueMap& tagAttrValueMap) {
+        ValueMap attrValueMap;
+        attrValueMap[RichText::KEY_FONT_BIG] = true;
+        return make_pair(attrValueMap, nullptr);
+    });
+    
+    MyXMLVisitor::setTagDescription("img", false, [](const ValueMap& tagAttrValueMap) {
+        // supported attributes:
+        // src, height, width
+        std::string src;
+        int height = -1;
+        int width = -1;
+        
+        if (tagAttrValueMap.find("src") != tagAttrValueMap.end()) {
+            src = tagAttrValueMap.at("src").asString();
+        }
+        if (tagAttrValueMap.find("height") != tagAttrValueMap.end()) {
+            height = tagAttrValueMap.at("height").asInt();
+        }
+        if (tagAttrValueMap.find("width") != tagAttrValueMap.end()) {
+            width = tagAttrValueMap.at("width").asInt();
+        }
+        
+        RichElementImage* elementImg = nullptr;
+        if (src.length()) {
+            elementImg = RichElementImage::create(0, Color3B::WHITE, 255, src);
+            if (0 <= height) elementImg->setHeight(height);
+            if (0 <= width)  elementImg->setWidth(width);
+        }
+        return make_pair(ValueMap(), elementImg);
+    });
+    
+    MyXMLVisitor::setTagDescription("a", true, [](const ValueMap& tagAttrValueMap) {
+        // supported attributes:
+        ValueMap attrValueMap;
+        
+        if (tagAttrValueMap.find("href") != tagAttrValueMap.end()) {
+            attrValueMap[RichText::KEY_URL] = tagAttrValueMap.at("href").asString();
+        }
+        return make_pair(attrValueMap, nullptr);
+    });
+    
+    MyXMLVisitor::setTagDescription("br", false, [](const ValueMap& tagAttrValueMap)  {
+        RichElementNewLine* richElement = RichElementNewLine::create(0, Color3B::WHITE, 255);
+        return make_pair(ValueMap(), richElement);
+    });
+    
+    MyXMLVisitor::setTagDescription("outline", true, [](const ValueMap& tagAttrValueMap) {
+        // supported attributes:
+        // color, cize
+        ValueMap attrValueMap;
+        
+        attrValueMap[RichText::KEY_TEXT_STYLE] = RichText::VALUE_TEXT_STYLE_OUTLINE;
+        if (tagAttrValueMap.find("color") != tagAttrValueMap.end()) {
+            attrValueMap[RichText::KEY_TEXT_OUTLINE_COLOR] = tagAttrValueMap.at("color").asString();
+        }
+        if (tagAttrValueMap.find("size") != tagAttrValueMap.end()) {
+            attrValueMap[RichText::KEY_TEXT_OUTLINE_SIZE] = tagAttrValueMap.at("size").asString();
+        }
+        return make_pair(attrValueMap, nullptr);
+    });
+    
+    MyXMLVisitor::setTagDescription("shadow", true, [](const ValueMap& tagAttrValueMap) {
+        // supported attributes:
+        // color, offsetWidth, offsetHeight, blurRadius
+        ValueMap attrValueMap;
+        
+        attrValueMap[RichText::KEY_TEXT_STYLE] = RichText::VALUE_TEXT_STYLE_SHADOW;
+        if (tagAttrValueMap.find("color") != tagAttrValueMap.end()) {
+            attrValueMap[RichText::KEY_TEXT_SHADOW_COLOR] = tagAttrValueMap.at("color").asString();
+        }
+        if (tagAttrValueMap.find("offsetWidth") != tagAttrValueMap.end()) {
+            attrValueMap[RichText::KEY_TEXT_SHADOW_OFFSET_WIDTH] = tagAttrValueMap.at("offsetWidth").asString();
+        }
+        if (tagAttrValueMap.find("offsetHeight") != tagAttrValueMap.end()) {
+            attrValueMap[RichText::KEY_TEXT_SHADOW_OFFSET_HEIGHT] = tagAttrValueMap.at("offsetHeight").asString();
+        }
+        if (tagAttrValueMap.find("blurRadius") != tagAttrValueMap.end()) {
+            attrValueMap[RichText::KEY_TEXT_SHADOW_BLUR_RADIUS] = tagAttrValueMap.at("blurRadius").asString();
+        }
+        return make_pair(attrValueMap, nullptr);
+    });
+    
+    MyXMLVisitor::setTagDescription("glow", true, [](const ValueMap& tagAttrValueMap) {
+        // supported attributes:
+        // color
+        ValueMap attrValueMap;
+        
+        attrValueMap[RichText::KEY_TEXT_STYLE] = RichText::VALUE_TEXT_STYLE_GLOW;
+        if (tagAttrValueMap.find("color") != tagAttrValueMap.end()) {
+            attrValueMap[RichText::KEY_TEXT_GLOW_COLOR] = tagAttrValueMap.at("color").asString();
+        }
+        return make_pair(attrValueMap, nullptr);
+    });
+}
+
+MyXMLVisitor::~MyXMLVisitor()
+{
+}
+
+Color3B MyXMLVisitor::getColor() const
+{
+    for (auto i = _fontElements.rbegin(); i != _fontElements.rend(); ++i)
+    {
+        if (i->hasColor)
+            return i->color;
+    }
+    return Color3B::WHITE;
+}
+
+float MyXMLVisitor::getFontSize() const
+{
+    for (auto i = _fontElements.rbegin(); i != _fontElements.rend(); ++i)
+    {
+        if (i->fontSize != -1)
+            return i->fontSize;
+    }
+    return 12;
+}
+
+std::string MyXMLVisitor::getFace() const
+{
+    for (auto i = _fontElements.rbegin(); i != _fontElements.rend(); ++i)
+    {
+        if (i->face.size() != 0)
+            return i->face;
+    }
+    return "fonts/Marker Felt.ttf";
+}
+
+std::string MyXMLVisitor::getURL() const
+{
+    for (auto i = _fontElements.rbegin(); i != _fontElements.rend(); ++i)
+    {
+        if (i->url.size() != 0)
+            return i->url;
+    }
+    return "";
+}
+
+bool MyXMLVisitor::getBold() const
+{
+    for (auto i = _fontElements.rbegin(); i != _fontElements.rend(); ++i)
+    {
+        if (i->bold)
+            return true;
+    }
+    return false;
+}
+
+bool MyXMLVisitor::getItalics() const
+{
+    for (auto i = _fontElements.rbegin(); i != _fontElements.rend(); ++i)
+    {
+        if (i->italics)
+            return true;
+    }
+    return false;
+}
+
+bool MyXMLVisitor::getUnderline() const
+{
+    for (auto i = _fontElements.rbegin(); i != _fontElements.rend(); ++i)
+    {
+        if (i->line == StyleLine::UNDERLINE)
+            return true;
+    }
+    return false;
+}
+
+bool MyXMLVisitor::getStrikethrough() const
+{
+    for (auto i = _fontElements.rbegin(); i != _fontElements.rend(); ++i)
+    {
+        if (i->line == StyleLine::STRIKETHROUGH)
+            return true;
+    }
+    return false;
+}
+
+std::tuple<bool, Color3B, int> MyXMLVisitor::getOutline() const
+{
+    for (auto i = _fontElements.rbegin(); i != _fontElements.rend(); ++i)
+    {
+        if (i->effect == StyleEffect::OUTLINE)
+            return std::make_tuple(true, i->outlineColor, i->outlineSize);
+    }
+    return std::make_tuple(false, Color3B::WHITE, -1);
+}
+
+std::tuple<bool, Color3B, cocos2d::Size, int> MyXMLVisitor::getShadow() const
+{
+    for (auto i = _fontElements.rbegin(); i != _fontElements.rend(); ++i)
+    {
+        if (i->effect == StyleEffect::SHADOW)
+            return std::make_tuple(true, i->shadowColor, i->shadowOffset, i->shadowBlurRadius);
+    }
+    return std::make_tuple(false, Color3B::BLACK, Size(2.0, -2.0), 0);
+}
+
+std::tuple<bool, Color3B> MyXMLVisitor::getGlow() const
+{
+    for (auto i = _fontElements.rbegin(); i != _fontElements.rend(); ++i)
+    {
+        if (i->effect == StyleEffect::GLOW)
+            return std::make_tuple(true, i->glowColor);
+    }
+    return std::make_tuple(false, Color3B::WHITE);
+}
+
+bool MyXMLVisitor::VisitEnter( const tinyxml2::XMLElement& element, const tinyxml2::XMLAttribute* firstAttribute )
+{
+    auto elementName = element.Value();
+    auto it = _tagTables.find(elementName);
+    if (it != _tagTables.end()) {
+        auto tagBehavior = it->second;
+        if (tagBehavior.handleVisitEnter != nullptr) {
+            ValueMap&& tagAttrValueMap = tagAttrMapWithXMLElement(element);
+            auto result = tagBehavior.handleVisitEnter(tagAttrValueMap);
+            ValueMap& attrValueMap = result.first;
+            RichElement* richElement = result.second;
+            if (!attrValueMap.empty()) {
+                Attributes attributes;
+                
+                if (attrValueMap.find(RichText::KEY_FONT_SIZE) != attrValueMap.end()) {
+                    attributes.fontSize = attrValueMap.at(RichText::KEY_FONT_SIZE).asFloat();
+                }
+                if (attrValueMap.find(RichText::KEY_FONT_SMALL) != attrValueMap.end()) {
+                    attributes.fontSize = getFontSize() * 0.8;
+                }
+                if (attrValueMap.find(RichText::KEY_FONT_BIG) != attrValueMap.end()) {
+                    attributes.fontSize = getFontSize() * 1.25;
+                }
+                if (attrValueMap.find(RichText::KEY_FONT_COLOR_STRING) != attrValueMap.end()) {
+                    attributes.setColor(_richText->color3BWithString(attrValueMap.at(RichText::KEY_FONT_COLOR_STRING).asString()));
+                }
+                if (attrValueMap.find(RichText::KEY_FONT_FACE) != attrValueMap.end()) {
+                    attributes.face = attrValueMap.at(RichText::KEY_FONT_FACE).asString();
+                }
+                if (attrValueMap.find(RichText::KEY_TEXT_BOLD) != attrValueMap.end()) {
+                    attributes.bold = true;
+                }
+                if (attrValueMap.find(RichText::KEY_TEXT_ITALIC) != attrValueMap.end()) {
+                    attributes.italics = true;
+                }
+                if (attrValueMap.find(RichText::KEY_TEXT_LINE) != attrValueMap.end()) {
+                    auto keyTextLine = attrValueMap.at(RichText::KEY_TEXT_LINE).asString();
+                    if (keyTextLine == RichText::VALUE_TEXT_LINE_DEL) {
+                        attributes.line = StyleLine::STRIKETHROUGH;
+                    }
+                    else if (keyTextLine == RichText::VALUE_TEXT_LINE_UNDER) {
+                        attributes.line = StyleLine::UNDERLINE;
+                    }
+                }
+                if (attrValueMap.find(RichText::KEY_URL) != attrValueMap.end()) {
+                    attributes.url = attrValueMap.at(RichText::KEY_URL).asString();
+                    attributes.setColor(_richText->getAnchorFontColor3B());
+                    if (_richText->isAnchorTextBoldEnabled()) {
+                        attributes.bold = true;
+                    }
+                    if (_richText->isAnchorTextItalicEnabled()) {
+                        attributes.italics = true;
+                    }
+                    if (_richText->isAnchorTextUnderlineEnabled()) {
+                        attributes.line = StyleLine::UNDERLINE;
+                    }
+                    if (_richText->isAnchorTextDelEnabled()) {
+                        attributes.line = StyleLine::STRIKETHROUGH;
+                    }
+                    if (_richText->isAnchorTextOutlineEnabled()) {
+                        attributes.effect = StyleEffect::OUTLINE;
+                        attributes.outlineColor = _richText->getAnchorTextOutlineColor3B();
+                        attributes.outlineSize = _richText->getAnchorTextOutlineSize();
+                    }
+                    if (_richText->isAnchorTextShadowEnabled()) {
+                        attributes.effect = StyleEffect::SHADOW;
+                        attributes.shadowColor = _richText->getAnchorTextShadowColor3B();
+                        attributes.shadowOffset = _richText->getAnchorTextShadowOffset();
+                        attributes.shadowBlurRadius = _richText->getAnchorTextShadowBlurRadius();
+                    }
+                    if (_richText->isAnchorTextGlowEnabled()) {
+                        attributes.effect = StyleEffect::GLOW;
+                        attributes.glowColor = _richText->getAnchorTextGlowColor3B();
+                    }
+                }
+                if (attrValueMap.find(RichText::KEY_TEXT_STYLE) != attrValueMap.end()) {
+                    auto keyTextStyle = attrValueMap.at(RichText::KEY_TEXT_STYLE).asString();
+                    if (keyTextStyle == RichText::VALUE_TEXT_STYLE_OUTLINE) {
+                        attributes.effect = StyleEffect::OUTLINE;
+                        if (attrValueMap.find(RichText::KEY_TEXT_OUTLINE_COLOR) != attrValueMap.end()) {
+                            attributes.outlineColor = _richText->color3BWithString(attrValueMap.at(RichText::KEY_TEXT_OUTLINE_COLOR).asString());
+                        }
+                        if (attrValueMap.find(RichText::KEY_TEXT_OUTLINE_SIZE) != attrValueMap.end()) {
+                            attributes.outlineSize = attrValueMap.at(RichText::KEY_TEXT_OUTLINE_SIZE).asInt();
+                        }
+                    }
+                    else if (keyTextStyle == RichText::VALUE_TEXT_STYLE_SHADOW) {
+                        attributes.effect = StyleEffect::SHADOW;
+                        if (attrValueMap.find(RichText::KEY_TEXT_SHADOW_COLOR) != attrValueMap.end()) {
+                            attributes.shadowColor = _richText->color3BWithString(attrValueMap.at(RichText::KEY_TEXT_SHADOW_COLOR).asString());
+                        }
+                        if ((attrValueMap.find(RichText::KEY_TEXT_SHADOW_OFFSET_WIDTH) != attrValueMap.end())
+                                && (attrValueMap.find(RichText::KEY_TEXT_SHADOW_OFFSET_HEIGHT) != attrValueMap.end())) {
+                            attributes.shadowOffset = Size(attrValueMap.at(RichText::KEY_TEXT_SHADOW_OFFSET_WIDTH).asFloat(),
+                                                           attrValueMap.at(RichText::KEY_TEXT_SHADOW_OFFSET_HEIGHT).asFloat());
+                        }
+                        if (attrValueMap.find(RichText::KEY_TEXT_SHADOW_BLUR_RADIUS) != attrValueMap.end()) {
+                            attributes.shadowBlurRadius = attrValueMap.at(RichText::KEY_TEXT_SHADOW_BLUR_RADIUS).asInt();
+                        }
+                    }
+                    else if (keyTextStyle == RichText::VALUE_TEXT_STYLE_GLOW) {
+                        attributes.effect = StyleEffect::GLOW;
+                        if (attrValueMap.find(RichText::KEY_TEXT_GLOW_COLOR) != attrValueMap.end()) {
+                            attributes.glowColor = _richText->color3BWithString(attrValueMap.at(RichText::KEY_TEXT_GLOW_COLOR).asString());
+                        }
+                    }
+                }
+                
+                pushBackFontElement(attributes);
+            }
+            if (richElement) {
+                if (richElement->equalType(RichElement::Type::IMAGE)) {
+                    richElement->setColor(getColor());
+                    auto* richElementImage = static_cast<RichElementImage*>(richElement);
+                    richElementImage->setUrl(getURL());
+                }
+                else if (richElement->equalType(RichElement::Type::NEWLINE)) {
+                    richElement->setColor(getColor());
+                }
+                pushBackElement(richElement);
+            }
+        }
+    }
+    return true;
+}
+
+bool MyXMLVisitor::VisitExit( const tinyxml2::XMLElement& element )
+{
+    auto elementName = element.Value();
+    auto it = _tagTables.find(elementName);
+    if (it != _tagTables.end()) {
+        auto tagBehavior = it->second;
+        if (tagBehavior.isFontElement) {
+            popBackFontElement();
+        }
+    }
+    return true;
+}
+
+bool MyXMLVisitor::Visit(const tinyxml2::XMLText& text)
+{
+    auto color = getColor();
+    auto face = getFace();
+    auto fontSize = getFontSize();
+    auto italics = getItalics();
+    auto underline = getUnderline();
+    auto strikethrough = getStrikethrough();
+    auto bold = getBold();
+    auto url = getURL();
+    auto outline = getOutline();
+    auto shadow = getShadow();
+    auto glow = getGlow();
+    
+    uint32_t flags = 0;
+    if (italics)
+        flags |= RichElementText::ITALICS_FLAG;
+    if (bold)
+        flags |= RichElementText::BOLD_FLAG;
+    if (underline)
+        flags |= RichElementText::UNDERLINE_FLAG;
+    if (strikethrough)
+        flags |= RichElementText::STRIKETHROUGH_FLAG;
+    if (url.size() > 0)
+        flags |= RichElementText::URL_FLAG;
+    if (std::get<0>(outline))
+        flags |= RichElementText::OUTLINE_FLAG;
+    if (std::get<0>(shadow))
+        flags |= RichElementText::SHADOW_FLAG;
+    if (std::get<0>(glow))
+        flags |= RichElementText::GLOW_FLAG;
+    
+    auto element = RichElementText::create(0, color, 255, text.Value(), face, fontSize, flags, url,
+                                           std::get<1>(outline), std::get<2>(outline),
+                                           std::get<1>(shadow), std::get<2>(shadow), std::get<3>(shadow),
+                                           std::get<1>(glow));
+    _richText->pushBackElement(element);
+    return true;
+}
+
+void MyXMLVisitor::pushBackFontElement(const MyXMLVisitor::Attributes& attribs)
+{
+    _fontElements.push_back(attribs);
+}
+
+void MyXMLVisitor::popBackFontElement()
+{
+    _fontElements.pop_back();
+}
+
+void MyXMLVisitor::pushBackElement(RichElement* element)
+{
+    _richText->pushBackElement(element);
+}
+
+void MyXMLVisitor::setTagDescription(const std::string& tag, bool isFontElement, RichText::VisitEnterHandler handleVisitEnter)
+{
+    MyXMLVisitor::_tagTables[tag] = {isFontElement, handleVisitEnter};
+}
+
+void MyXMLVisitor::removeTagDescription(const std::string& tag)
+{
+    MyXMLVisitor::_tagTables.erase(tag);
+}
+
+ValueMap MyXMLVisitor::tagAttrMapWithXMLElement(const tinyxml2::XMLElement& element)
+{
+    ValueMap tagAttrValueMap;
+    for (const tinyxml2::XMLAttribute* attr = element.FirstAttribute(); attr != nullptr; attr = attr->Next()) {
+        if (attr->Name() && attr->Value()) {
+            tagAttrValueMap[std::string(attr->Name())] = std::string(attr->Value());
+        }
+    }
+    return tagAttrValueMap;
+}
+
+const std::string RichText::KEY_VERTICAL_SPACE("KEY_VERTICAL_SPACE");
+const std::string RichText::KEY_WRAP_MODE("KEY_WRAP_MODE");
+const std::string RichText::KEY_FONT_COLOR_STRING("KEY_FONT_COLOR_STRING");
+const std::string RichText::KEY_FONT_SIZE("KEY_FONT_SIZE");
+const std::string RichText::KEY_FONT_SMALL("KEY_FONT_SMALL");
+const std::string RichText::KEY_FONT_BIG("KEY_FONT_BIG");
+const std::string RichText::KEY_FONT_FACE("KEY_FONT_FACE");
+const std::string RichText::KEY_TEXT_BOLD("KEY_TEXT_BOLD");
+const std::string RichText::KEY_TEXT_ITALIC("KEY_TEXT_ITALIC");
+const std::string RichText::KEY_TEXT_LINE("KEY_TEXT_LINE");
+const std::string RichText::VALUE_TEXT_LINE_NONE("VALUE_TEXT_LINE_NONE");
+const std::string RichText::VALUE_TEXT_LINE_DEL("VALUE_TEXT_LINE_DEL");
+const std::string RichText::VALUE_TEXT_LINE_UNDER("VALUE_TEXT_LINE_UNDER");
+const std::string RichText::KEY_TEXT_STYLE("KEY_TEXT_STYLE");
+const std::string RichText::VALUE_TEXT_STYLE_NONE("VALUE_TEXT_STYLE_NONE");
+const std::string RichText::VALUE_TEXT_STYLE_OUTLINE("VALUE_TEXT_STYLE_OUTLINE");
+const std::string RichText::VALUE_TEXT_STYLE_SHADOW("VALUE_TEXT_STYLE_SHADOW");
+const std::string RichText::VALUE_TEXT_STYLE_GLOW("VALUE_TEXT_STYLE_GLOW");
+const std::string RichText::KEY_TEXT_OUTLINE_COLOR("KEY_TEXT_OUTLINE_COLOR");
+const std::string RichText::KEY_TEXT_OUTLINE_SIZE("KEY_TEXT_OUTLINE_SIZE");
+const std::string RichText::KEY_TEXT_SHADOW_COLOR("KEY_TEXT_SHADOW_COLOR");
+const std::string RichText::KEY_TEXT_SHADOW_OFFSET_WIDTH("KEY_TEXT_SHADOW_OFFSET_WIDTH");
+const std::string RichText::KEY_TEXT_SHADOW_OFFSET_HEIGHT("KEY_TEXT_SHADOW_OFFSET_HEIGHT");
+const std::string RichText::KEY_TEXT_SHADOW_BLUR_RADIUS("KEY_TEXT_SHADOW_BLUR_RADIUS");
+const std::string RichText::KEY_TEXT_GLOW_COLOR("KEY_TEXT_GLOW_COLOR");
+const std::string RichText::KEY_URL("KEY_URL");
+const std::string RichText::KEY_ANCHOR_FONT_COLOR_STRING("KEY_ANCHOR_FONT_COLOR_STRING");
+const std::string RichText::KEY_ANCHOR_TEXT_BOLD("KEY_ANCHOR_TEXT_BOLD");
+const std::string RichText::KEY_ANCHOR_TEXT_ITALIC("KEY_ANCHOR_TEXT_ITALIC");
+const std::string RichText::KEY_ANCHOR_TEXT_LINE("KEY_ANCHOR_TEXT_LINE");
+const std::string RichText::KEY_ANCHOR_TEXT_STYLE("KEY_ANCHOR_TEXT_STYLE");
+const std::string RichText::KEY_ANCHOR_TEXT_OUTLINE_COLOR("KEY_ANCHOR_TEXT_OUTLINE_COLOR");
+const std::string RichText::KEY_ANCHOR_TEXT_OUTLINE_SIZE("KEY_ANCHOR_TEXT_OUTLINE_SIZE");
+const std::string RichText::KEY_ANCHOR_TEXT_SHADOW_COLOR("KEY_ANCHOR_TEXT_SHADOW_COLOR");
+const std::string RichText::KEY_ANCHOR_TEXT_SHADOW_OFFSET_WIDTH("KEY_ANCHOR_TEXT_SHADOW_OFFSET_WIDTH");
+const std::string RichText::KEY_ANCHOR_TEXT_SHADOW_OFFSET_HEIGHT("KEY_ANCHOR_TEXT_SHADOW_OFFSET_HEIGHT");
+const std::string RichText::KEY_ANCHOR_TEXT_SHADOW_BLUR_RADIUS("KEY_ANCHOR_TEXT_SHADOW_BLUR_RADIUS");
+const std::string RichText::KEY_ANCHOR_TEXT_GLOW_COLOR("KEY_ANCHOR_TEXT_GLOW_COLOR");
+
 RichText::RichText()
     : _formatTextDirty(true)
     , _leftSpaceWidth(0.0f)
-    , _verticalSpace(0.0f)
-    , _wrapMode(WRAP_PER_WORD)
 {
+    _defaults[KEY_VERTICAL_SPACE] = 0.0f;
+    _defaults[KEY_WRAP_MODE] = static_cast<int>(WrapMode::WRAP_PER_WORD);
+    _defaults[KEY_FONT_COLOR_STRING] = "#ffffff";
+    _defaults[KEY_FONT_SIZE] = 12.0f;
+    _defaults[KEY_FONT_FACE] = "Verdana";
+    _defaults[KEY_ANCHOR_FONT_COLOR_STRING] = "#0000FF";
+    _defaults[KEY_ANCHOR_TEXT_BOLD] = false;
+    _defaults[KEY_ANCHOR_TEXT_ITALIC] = false;
+    _defaults[KEY_ANCHOR_TEXT_LINE] = VALUE_TEXT_LINE_NONE;
+    _defaults[KEY_ANCHOR_TEXT_STYLE] = VALUE_TEXT_STYLE_NONE;
 }
     
 RichText::~RichText()
@@ -214,10 +906,10 @@ RichText* RichText::create()
     return nullptr;
 }
 
-RichText* RichText::createWithXML(const std::string& xml)
+RichText* RichText::createWithXML(const std::string& xml, const ValueMap& defaults, const OpenUrlHandler& handleOpenUrl)
 {
     RichText* widget = new (std::nothrow) RichText();
-    if (widget && widget->initWithXML(xml))
+    if (widget && widget->initWithXML(xml, defaults, handleOpenUrl))
     {
         widget->autorelease();
         return widget;
@@ -225,7 +917,7 @@ RichText* RichText::createWithXML(const std::string& xml)
     CC_SAFE_DELETE(widget);
     return nullptr;
 }
-    
+
 bool RichText::init()
 {
     if (Widget::init())
@@ -235,296 +927,29 @@ bool RichText::init()
     return false;
 }
 
-class MyXMLVisitor: public tinyxml2::XMLVisitor
+bool RichText::initWithXML(const std::string& origxml, const ValueMap& defaults, const OpenUrlHandler& handleOpenUrl)
 {
-    struct Attributes
-    {
-        std::string face;
-        std::string url;
-        float fontSize;
-        Color3B color;
-        bool hasColor;
-        bool bold;
-        bool italics;
-        bool underline;
-        bool strikethrough;
-
-        void setColor(const Color3B& acolor)
-        {
-            color = acolor;
-            hasColor = true;
-        }
-        Attributes()
-        : bold(false)
-        , italics(false)
-        , underline(false)
-        , strikethrough(false)
-        , hasColor(false)
-        , fontSize(-1)
-        {
-        }
+    static std::function<std::string(RichText*)> startTagFont = [](RichText* richText) {
+        std::string fontFace = richText->getFontFace();
+        std::stringstream ss;
+        ss << richText->getFontSize();
+        std::string fontSize = ss.str();
+        std::string fontColor = richText->getFontColor();
+        return "<font face=\"" + fontFace + "\" size=\"" + fontSize + "\" color=\"" + fontColor + "\">";
     };
-
-    std::vector<Attributes> _fontElements;
-
-    RichText* _richText;
-
-    Color3B getColor() const
-    {
-        for (auto i = _fontElements.rbegin(); i != _fontElements.rend(); ++i)
-        {
-            if (i->hasColor)
-                return i->color;
-        }
-        return Color3B::WHITE;
-    }
-
-    float getFontSize() const
-    {
-        for (auto i = _fontElements.rbegin(); i != _fontElements.rend(); ++i)
-        {
-            if (i->fontSize != -1)
-                return i->fontSize;
-        }
-        return 12;
-    }
-
-    std::string getFace() const
-    {
-        for (auto i = _fontElements.rbegin(); i != _fontElements.rend(); ++i)
-        {
-            if (i->face.size() != 0)
-                return i->face;
-        }
-        return "fonts/Marker Felt.ttf";
-    }
-
-    std::string getURL() const
-    {
-        for (auto i = _fontElements.rbegin(); i != _fontElements.rend(); ++i)
-        {
-            if (i->url.size() != 0)
-                return i->url;
-        }
-        return "";
-    }
-
-    bool getBold() const
-    {
-        for (auto i = _fontElements.rbegin(); i != _fontElements.rend(); ++i)
-        {
-            if (i->bold)
-                return true;
-        }
-        return false;
-    }
-
-    bool getItalics() const
-    {
-        for (auto i = _fontElements.rbegin(); i != _fontElements.rend(); ++i)
-        {
-            if (i->italics)
-                return true;
-        }
-        return false;
-    }
-
-    bool getUnderline() const
-    {
-        for (auto i = _fontElements.rbegin(); i != _fontElements.rend(); ++i)
-        {
-            if (i->underline)
-                return true;
-        }
-        return false;
-    }
-
-    bool getStrikethrough() const
-    {
-        for (auto i = _fontElements.rbegin(); i != _fontElements.rend(); ++i)
-        {
-            if (i->strikethrough)
-                return true;
-        }
-        return false;
-    }
-
-public:
-    explicit MyXMLVisitor(RichText* richText)
-    : _richText(richText)
-    , _fontElements(20)
-    {}
-    virtual ~MyXMLVisitor() {}
-
-    /// Visit an element.
-    virtual bool VisitEnter( const tinyxml2::XMLElement& element, const tinyxml2::XMLAttribute* firstAttribute )
-    {
-        auto elementName = element.Value();
-
-        if (strcmp(elementName, "font") == 0)
-        {
-            // supported attributes:
-            // size, color, align, face
-            auto size = element.Attribute("size");
-            auto color = element.Attribute("color");
-            auto face = element.Attribute("face");
-
-            Attributes attribs;
-            if (size)
-                attribs.fontSize = atof(size);
-            if (color)
-            {
-                if (strlen(color) == 7)
-                {
-                    int r,g,b;
-                    sscanf(color, "%*c%2x%2x%2x", &r, &g, &b);
-                    attribs.setColor(Color3B(r,g,b));
-                }
-                else
-                    attribs.setColor(Color3B::WHITE);
-            }
-            if (face)
-                attribs.face = face;
-
-            _fontElements.push_back(attribs);
-        }
-        else if (strcmp(elementName, "b") == 0)
-        {
-            // no supported attributes
-            Attributes attribs;
-            attribs.bold = 1;
-            _fontElements.push_back(attribs);
-        }
-        else if (strcmp(elementName, "i") == 0)
-        {
-            // no supported attributes
-            Attributes attribs;
-            attribs.italics = 1;
-            _fontElements.push_back(attribs);
-        }
-        else if (strcmp(elementName, "del") == 0)
-        {
-            // no supported attributes
-            Attributes attribs;
-            attribs.strikethrough = true;
-            _fontElements.push_back(attribs);
-        }
-        else if (strcmp(elementName, "u") == 0)
-        {
-            // no supported attributes
-            Attributes attribs;
-            attribs.underline = true;
-            _fontElements.push_back(attribs);
-        }
-        else if (strcmp(elementName, "small") == 0)
-        {
-            Attributes attribs;
-            attribs.fontSize = getFontSize() * 0.8;
-            _fontElements.push_back(attribs);
-        }
-
-        else if (strcmp(elementName, "big") == 0)
-        {
-            Attributes attribs;
-            attribs.fontSize = getFontSize() * 1.25;
-            _fontElements.push_back(attribs);
-        }
-
-        else if (strcmp(elementName, "img") == 0)
-        {
-            // supported attributes:
-            // src, height, width
-            auto src = element.Attribute("src");
-            auto height = element.Attribute("height");
-            auto width = element.Attribute("width");
-
-            if (src) {
-                auto elementNL = RichElementImage::create(0, getColor(), 255, src);
-
-                if (height)
-                    elementNL->setHeight(atoi(height));
-                if (width)
-                    elementNL->setWidth(atoi(width));
-                
-                _richText->pushBackElement(elementNL);
-            }
-        }
-        else if (strcmp(elementName, "a") ==  0)
-        {
-            // supported attributes:
-            Attributes attribs;
-            auto href = element.Attribute("href");
-            attribs.setColor(Color3B::BLUE);
-            attribs.underline = true;
-            attribs.url = href;
-            _fontElements.push_back(attribs);
-        }
-        else if (strcmp(elementName, "br") == 0)
-        {
-            auto color = getColor();
-            auto elementNL = RichElementNewLine::create(0, color, 255);
-            _richText->pushBackElement(elementNL);
-        }
-        return true;
-    }
-    /// Visit an element.
-    virtual bool VisitExit( const tinyxml2::XMLElement& element )
-    {
-        auto elementName = element.Value();
-        if ((strcmp(elementName, "font") == 0) ||
-            (strcmp(elementName, "i") == 0) ||
-            (strcmp(elementName, "b") == 0) ||
-            (strcmp(elementName, "del") == 0) ||
-            (strcmp(elementName, "u") == 0) ||
-            (strcmp(elementName, "small") == 0) ||
-            (strcmp(elementName, "big") == 0) ||
-            (strcmp(elementName, "a") == 0))
-        {
-            _fontElements.pop_back();
-        }
-        return true;
-    }
-
-    /// Visit a text node.
-    virtual bool Visit(const tinyxml2::XMLText& text)
-    {
-        auto color = getColor();
-        auto face = getFace();
-        auto fontSize = getFontSize();
-        auto italics = getItalics();
-        auto underline = getUnderline();
-        auto strikethrough = getStrikethrough();
-        auto bold = getBold();
-        auto url = getURL();
-
-        uint32_t flags = 0;
-        if (italics)
-            flags |= RichElementText::ITALICS_FLAG;
-        if (bold)
-            flags |= RichElementText::BOLD_FLAG;
-        if (underline)
-            flags |= RichElementText::UNDERLINE_FLAG;
-        if (strikethrough)
-            flags |= RichElementText::STRIKETHROUGH_FLAG;
-        if (url.size() > 0)
-            flags |= RichElementText::URL_FLAG;
-
-        auto element = RichElementText::create(0, color, 255, text.Value(), face, fontSize, flags, url);
-        _richText->pushBackElement(element);
-        return true;
-    }
-};
-
-bool RichText::initWithXML(const std::string& origxml)
-{
     if (Widget::init())
     {
+        setDefaults(defaults);
+        setOpenUrlHandler(handleOpenUrl);
+        
         tinyxml2::XMLDocument document;
 
         // solves to issues:
         //  - creates defaults values
         //  - makes sure that the xml well formed and starts with an element
-        auto xml = "<font face=\"Verdana\" size=\"12\" color=\"#ffffff\">" + origxml + "</font>";
+        std::string xml = startTagFont(this);
+        xml += origxml;
+        xml += "</font>";
 
         auto error = document.Parse(xml.c_str(), xml.length());
         if (error == tinyxml2::XML_SUCCESS)
@@ -568,16 +993,341 @@ void RichText::removeElement(RichElement *element)
 
 RichText::WrapMode RichText::getWrapMode() const
 {
-    return _wrapMode;
+    return static_cast<RichText::WrapMode>(_defaults.at(KEY_WRAP_MODE).asInt());
 }
 
 void RichText::setWrapMode(RichText::WrapMode wrapMode)
 {
-    if (_wrapMode != wrapMode)
+    if (static_cast<RichText::WrapMode>(_defaults.at(KEY_WRAP_MODE).asInt()) != wrapMode)
     {
-        _wrapMode = wrapMode;
+        _defaults[KEY_WRAP_MODE] = static_cast<int>(wrapMode);
         _formatTextDirty = true;
     }
+}
+
+void RichText::setFontColor(const std::string& color)
+{
+    _defaults[KEY_FONT_COLOR_STRING] = color;
+}
+
+std::string RichText::getFontColor()
+{
+    return _defaults.at(KEY_FONT_COLOR_STRING).asString();
+}
+
+cocos2d::Color3B RichText::getFontColor3B()
+{
+    return color3BWithString(getFontColor());
+}
+
+void RichText::setFontSize(float size)
+{
+    _defaults[KEY_FONT_SIZE] = size;
+}
+
+float RichText::getFontSize()
+{
+    return _defaults.at(KEY_FONT_SIZE).asFloat();
+}
+
+void RichText::setFontFace(const std::string& face)
+{
+    _defaults[KEY_FONT_FACE] = face;
+}
+
+std::string RichText::getFontFace()
+{
+    return _defaults.at(KEY_FONT_FACE).asString();
+}
+
+void RichText::setAnchorFontColor(const std::string& color)
+{
+    _defaults[KEY_ANCHOR_FONT_COLOR_STRING] = color;
+}
+
+std::string RichText::getAnchorFontColor()
+{
+    return _defaults.at(KEY_ANCHOR_FONT_COLOR_STRING).asString();
+}
+
+cocos2d::Color3B RichText::getAnchorFontColor3B()
+{
+    return color3BWithString(getAnchorFontColor());
+}
+
+void RichText::setAnchorTextBold(bool enable)
+{
+    _defaults[KEY_ANCHOR_TEXT_BOLD] = enable;
+}
+
+bool RichText::isAnchorTextBoldEnabled()
+{
+    return _defaults[KEY_ANCHOR_TEXT_BOLD].asBool();
+}
+
+void RichText::setAnchorTextItalic(bool enable)
+{
+    _defaults[KEY_ANCHOR_TEXT_ITALIC] = enable;
+}
+
+bool RichText::isAnchorTextItalicEnabled()
+{
+    return _defaults[KEY_ANCHOR_TEXT_ITALIC].asBool();
+}
+
+void RichText::setAnchorTextDel(bool enable)
+{
+    if (enable)
+        _defaults[KEY_ANCHOR_TEXT_LINE] = VALUE_TEXT_LINE_DEL;
+    else if (_defaults[KEY_ANCHOR_TEXT_LINE].asString() == VALUE_TEXT_LINE_DEL)
+        _defaults[KEY_ANCHOR_TEXT_LINE] = VALUE_TEXT_LINE_NONE;
+}
+
+bool RichText::isAnchorTextDelEnabled()
+{
+    return (_defaults[KEY_ANCHOR_TEXT_LINE].asString() == VALUE_TEXT_LINE_DEL);
+}
+
+void RichText::setAnchorTextUnderline(bool enable)
+{
+    if (enable)
+        _defaults[KEY_ANCHOR_TEXT_LINE] = VALUE_TEXT_LINE_UNDER;
+    else if (_defaults[KEY_ANCHOR_TEXT_LINE].asString() == VALUE_TEXT_LINE_UNDER)
+        _defaults[KEY_ANCHOR_TEXT_LINE] = VALUE_TEXT_LINE_NONE;
+}
+
+bool RichText::isAnchorTextUnderlineEnabled()
+{
+    return (_defaults[KEY_ANCHOR_TEXT_LINE].asString() == VALUE_TEXT_LINE_UNDER);
+}
+
+void RichText::setAnchorTextOutline(bool enable, const Color3B& outlineColor, int outlineSize)
+{
+    if (enable)
+        _defaults[KEY_ANCHOR_TEXT_STYLE] = VALUE_TEXT_STYLE_OUTLINE;
+    else if (_defaults[KEY_ANCHOR_TEXT_STYLE].asString() == VALUE_TEXT_STYLE_OUTLINE)
+        _defaults[KEY_ANCHOR_TEXT_STYLE] = VALUE_TEXT_STYLE_NONE;
+    _defaults[KEY_ANCHOR_TEXT_OUTLINE_COLOR] = stringWithColor3B(outlineColor);
+    _defaults[KEY_ANCHOR_TEXT_OUTLINE_SIZE] = outlineSize;
+}
+
+bool RichText::isAnchorTextOutlineEnabled()
+{
+    return (_defaults[KEY_ANCHOR_TEXT_STYLE].asString() == VALUE_TEXT_STYLE_OUTLINE);
+}
+
+Color3B RichText::getAnchorTextOutlineColor3B()
+{
+    if (_defaults.find(KEY_ANCHOR_TEXT_OUTLINE_COLOR) != _defaults.end()) {
+        return color3BWithString(_defaults.at(KEY_ANCHOR_TEXT_OUTLINE_COLOR).asString());
+    }
+    return Color3B();
+}
+
+int RichText::getAnchorTextOutlineSize()
+{
+    if (_defaults.find(KEY_ANCHOR_TEXT_OUTLINE_SIZE) != _defaults.end()) {
+        return _defaults.at(KEY_ANCHOR_TEXT_OUTLINE_SIZE).asInt();
+    }
+    return -1;
+}
+
+void RichText::setAnchorTextShadow(bool enable, const Color3B& shadowColor, const Size& offset, int blurRadius)
+{
+    if (enable)
+        _defaults[KEY_ANCHOR_TEXT_STYLE] = VALUE_TEXT_STYLE_SHADOW;
+    else if (_defaults[KEY_ANCHOR_TEXT_STYLE].asString() == VALUE_TEXT_STYLE_SHADOW)
+        _defaults[KEY_ANCHOR_TEXT_STYLE] = VALUE_TEXT_STYLE_NONE;
+    _defaults[KEY_ANCHOR_TEXT_SHADOW_COLOR] = stringWithColor3B(shadowColor);
+    _defaults[KEY_ANCHOR_TEXT_SHADOW_OFFSET_WIDTH] = offset.width;
+    _defaults[KEY_ANCHOR_TEXT_SHADOW_OFFSET_HEIGHT] = offset.height;
+    _defaults[KEY_ANCHOR_TEXT_SHADOW_BLUR_RADIUS] = blurRadius;
+}
+
+bool RichText::isAnchorTextShadowEnabled()
+{
+    return (_defaults[KEY_ANCHOR_TEXT_STYLE].asString() == VALUE_TEXT_STYLE_SHADOW);
+}
+
+Color3B RichText::getAnchorTextShadowColor3B()
+{
+    if (_defaults.find(KEY_ANCHOR_TEXT_SHADOW_COLOR) != _defaults.end()) {
+        return color3BWithString(_defaults.at(KEY_ANCHOR_TEXT_SHADOW_COLOR).asString());
+    }
+    return Color3B();
+}
+
+Size RichText::getAnchorTextShadowOffset()
+{
+    float width = 2.0f;
+    float height = -2.0f;
+    if (_defaults.find(KEY_ANCHOR_TEXT_SHADOW_OFFSET_WIDTH) != _defaults.end()) {
+        width = _defaults.at(KEY_ANCHOR_TEXT_SHADOW_OFFSET_WIDTH).asFloat();
+    }
+    if (_defaults.find(KEY_ANCHOR_TEXT_SHADOW_OFFSET_HEIGHT) != _defaults.end()) {
+        height = _defaults.at(KEY_ANCHOR_TEXT_SHADOW_OFFSET_HEIGHT).asFloat();
+    }
+    return Size(width, height);
+}
+
+int RichText::getAnchorTextShadowBlurRadius()
+{
+    if (_defaults.find(KEY_ANCHOR_TEXT_SHADOW_BLUR_RADIUS) != _defaults.end()) {
+        return _defaults.at(KEY_ANCHOR_TEXT_SHADOW_BLUR_RADIUS).asInt();
+    }
+    return 0;
+}
+
+void RichText::setAnchorTextGlow(bool enable, const Color3B& glowColor)
+{
+    if (enable)
+        _defaults[KEY_ANCHOR_TEXT_STYLE] = VALUE_TEXT_STYLE_GLOW;
+    else if (_defaults[KEY_ANCHOR_TEXT_STYLE].asString() == VALUE_TEXT_STYLE_GLOW)
+        _defaults[KEY_ANCHOR_TEXT_STYLE] = VALUE_TEXT_STYLE_NONE;
+    _defaults[KEY_ANCHOR_TEXT_GLOW_COLOR] = stringWithColor3B(glowColor);
+}
+
+bool RichText::isAnchorTextGlowEnabled()
+{
+    return (_defaults[KEY_ANCHOR_TEXT_STYLE].asString() == VALUE_TEXT_STYLE_GLOW);
+}
+
+Color3B RichText::getAnchorTextGlowColor3B()
+{
+    if (_defaults.find(KEY_ANCHOR_TEXT_GLOW_COLOR) != _defaults.end()) {
+        return color3BWithString(_defaults.at(KEY_ANCHOR_TEXT_GLOW_COLOR).asString());
+    }
+    return Color3B();
+}
+
+void RichText::setDefaults(const ValueMap& defaults)
+{
+    if (defaults.find(KEY_VERTICAL_SPACE) != defaults.end()) {
+        _defaults[KEY_VERTICAL_SPACE] = defaults.at(KEY_VERTICAL_SPACE).asFloat();
+    }
+    if (defaults.find(KEY_WRAP_MODE) != defaults.end()) {
+        _defaults[KEY_WRAP_MODE] = defaults.at(KEY_WRAP_MODE).asInt();
+    }
+    if (defaults.find(KEY_FONT_COLOR_STRING) != defaults.end()) {
+        _defaults[KEY_FONT_COLOR_STRING] = defaults.at(KEY_FONT_COLOR_STRING).asString();
+    }
+    if (defaults.find(KEY_FONT_SIZE) != defaults.end()) {
+        _defaults[KEY_FONT_SIZE] = defaults.at(KEY_FONT_SIZE).asFloat();
+    }
+    if (defaults.find(KEY_FONT_FACE) != defaults.end()) {
+        _defaults[KEY_FONT_FACE] = defaults.at(KEY_FONT_FACE).asString();
+    }
+    if (defaults.find(KEY_ANCHOR_FONT_COLOR_STRING) != defaults.end()) {
+        _defaults[KEY_ANCHOR_FONT_COLOR_STRING] = defaults.at(KEY_ANCHOR_FONT_COLOR_STRING).asString();
+    }
+    if (defaults.find(KEY_ANCHOR_TEXT_BOLD) != defaults.end()) {
+        _defaults[KEY_ANCHOR_TEXT_BOLD] = defaults.at(KEY_ANCHOR_TEXT_BOLD).asBool();
+    }
+    if (defaults.find(KEY_ANCHOR_TEXT_ITALIC) != defaults.end()) {
+        _defaults[KEY_ANCHOR_TEXT_ITALIC] = defaults.at(KEY_ANCHOR_TEXT_ITALIC).asBool();
+    }
+    if (defaults.find(KEY_ANCHOR_TEXT_LINE) != defaults.end()) {
+        _defaults[KEY_ANCHOR_TEXT_LINE] = defaults.at(KEY_ANCHOR_TEXT_LINE).asString();
+    }
+    if (defaults.find(KEY_ANCHOR_TEXT_STYLE) != defaults.end()) {
+        _defaults[KEY_ANCHOR_TEXT_STYLE] = defaults.at(KEY_ANCHOR_TEXT_STYLE).asString();
+    }
+    if (defaults.find(KEY_ANCHOR_TEXT_OUTLINE_COLOR) != defaults.end()) {
+        _defaults[KEY_ANCHOR_TEXT_OUTLINE_COLOR] = defaults.at(KEY_ANCHOR_TEXT_OUTLINE_COLOR).asString();
+    }
+    if (defaults.find(KEY_ANCHOR_TEXT_OUTLINE_SIZE) != defaults.end()) {
+        _defaults[KEY_ANCHOR_TEXT_OUTLINE_SIZE] = defaults.at(KEY_ANCHOR_TEXT_OUTLINE_SIZE).asInt();
+    }
+    if (defaults.find(KEY_ANCHOR_TEXT_SHADOW_COLOR) != defaults.end()) {
+        _defaults[KEY_ANCHOR_TEXT_SHADOW_COLOR] = defaults.at(KEY_ANCHOR_TEXT_SHADOW_COLOR).asString();
+    }
+    if (defaults.find(KEY_ANCHOR_TEXT_SHADOW_OFFSET_WIDTH) != defaults.end()) {
+        _defaults[KEY_ANCHOR_TEXT_SHADOW_OFFSET_WIDTH] = defaults.at(KEY_ANCHOR_TEXT_SHADOW_OFFSET_WIDTH).asFloat();
+    }
+    if (defaults.find(KEY_ANCHOR_TEXT_SHADOW_OFFSET_HEIGHT) != defaults.end()) {
+        _defaults[KEY_ANCHOR_TEXT_SHADOW_OFFSET_HEIGHT] = defaults.at(KEY_ANCHOR_TEXT_SHADOW_OFFSET_HEIGHT).asFloat();
+    }
+    if (defaults.find(KEY_ANCHOR_TEXT_SHADOW_BLUR_RADIUS) != defaults.end()) {
+        _defaults[KEY_ANCHOR_TEXT_SHADOW_BLUR_RADIUS] = defaults.at(KEY_ANCHOR_TEXT_SHADOW_BLUR_RADIUS).asInt();
+    }
+    if (defaults.find(KEY_ANCHOR_TEXT_GLOW_COLOR) != defaults.end()) {
+        _defaults[KEY_ANCHOR_TEXT_GLOW_COLOR] = defaults.at(KEY_ANCHOR_TEXT_GLOW_COLOR).asString();
+    }
+}
+
+ValueMap RichText::getDefaults() const
+{
+    ValueMap defaults;
+    return defaults;
+}
+
+cocos2d::Color3B RichText::color3BWithString(const std::string& color)
+{
+    if (color.length() == 4) {
+        int r, g, b;
+        sscanf(color.c_str(), "%*c%1x%1x%1x", &r, &g, &b);
+        r += r * 16;
+        g += g * 16;
+        b += b * 16;
+        return Color3B(r, g, b);
+    }
+    else if (color.length() == 7) {
+        int r, g, b;
+        sscanf(color.c_str(), "%*c%2x%2x%2x", &r, &g, &b);
+        return Color3B(r, g, b);
+    }
+    else if (color.length() == 9) {
+        int r, g, b, a;
+        sscanf(color.c_str(), "%*c%2x%2x%2x%2x", &r, &g, &b, &a);
+        return Color3B(r, g, b);
+    }
+    return Color3B::WHITE;
+}
+
+std::string RichText::stringWithColor3B(const cocos2d::Color3B& color3b)
+{
+    int r = color3b.r;
+    int g = color3b.g;
+    int b = color3b.b;
+    char buf[8];
+    snprintf(buf, sizeof(buf), "#%02x%02x%02x", r, g, b);
+    return std::string(buf, 7);
+}
+
+std::string RichText::stringWithColor4B(const cocos2d::Color4B& color4b)
+{
+    int r = color4b.r;
+    int g = color4b.g;
+    int b = color4b.b;
+    int a = color4b.a;
+    char buf[10];
+    snprintf(buf, sizeof(buf), "#%02x%02x%02x%02x", r, g, b, a);
+    return std::string(buf, 9);
+}
+
+void RichText::setTagDescription(const std::string& tag, bool isFontElement, VisitEnterHandler handleVisitEnter)
+{
+    MyXMLVisitor::setTagDescription(tag, isFontElement, handleVisitEnter);
+}
+
+void RichText::removeTagDescription(const std::string& tag)
+{
+    MyXMLVisitor::removeTagDescription(tag);
+}
+
+void RichText::openUrl(const std::string& url)
+{
+    if (_handleOpenUrl) {
+        _handleOpenUrl(url);
+    }
+    else {
+        Application::getInstance()->openURL(url);
+    }
+}
+
+void RichText::setOpenUrlHandler(const OpenUrlHandler& handleOpenUrl)
+{
+    _handleOpenUrl = handleOpenUrl;
 }
 
 void RichText::formatText()
@@ -616,7 +1366,19 @@ void RichText::formatText()
                         if (elmtText->_flags & RichElementText::STRIKETHROUGH_FLAG)
                             label->enableStrikethrough();
                         if (elmtText->_flags & RichElementText::URL_FLAG)
-                            label->addComponent(ListenerComponent::create(label, elmtText->_url));
+                            label->addComponent(ListenerComponent::create(label, elmtText->_url,
+                                                                          std::bind(&RichText::openUrl, this, std::placeholders::_1)));
+                        if (elmtText->_flags & RichElementText::OUTLINE_FLAG) {
+                            label->enableOutline(Color4B(elmtText->_outlineColor), elmtText->_outlineSize);
+                        }
+                        if (elmtText->_flags & RichElementText::SHADOW_FLAG) {
+                            label->enableShadow(Color4B(elmtText->_shadowColor),
+                                                elmtText->_shadowOffset,
+                                                elmtText->_shadowBlurRadius);
+                        }
+                        if (elmtText->_flags & RichElementText::GLOW_FLAG) {
+                            label->enableGlow(Color4B(elmtText->_glowColor));
+                        }
                         elementRenderer = label;
                         break;
                     }
@@ -633,6 +1395,9 @@ void RichText::formatText()
                                 elementRenderer->setScaleY(elmtImage->_height / currentSize.height);
                             elementRenderer->setContentSize(Size(currentSize.width * elementRenderer->getScaleX(),
                                                                  currentSize.height * elementRenderer->getScaleY()));
+                            elementRenderer->addComponent(ListenerComponent::create(elementRenderer,
+                                                                                    elmtImage->_url,
+                                                                                    std::bind(&RichText::openUrl, this, std::placeholders::_1)));
                         }
                         break;
                     }
@@ -670,13 +1435,17 @@ void RichText::formatText()
                     case RichElement::Type::TEXT:
                     {
                         RichElementText* elmtText = static_cast<RichElementText*>(element);
-                        handleTextRenderer(elmtText->_text, elmtText->_fontName, elmtText->_fontSize, elmtText->_color, elmtText->_opacity, elmtText->_flags, elmtText->_url);
+                        handleTextRenderer(elmtText->_text, elmtText->_fontName, elmtText->_fontSize, elmtText->_color,
+                                           elmtText->_opacity, elmtText->_flags, elmtText->_url,
+                                           elmtText->_outlineColor, elmtText->_outlineSize,
+                                           elmtText->_shadowColor, elmtText->_shadowOffset, elmtText->_shadowBlurRadius,
+                                           elmtText->_glowColor);
                         break;
                     }
                     case RichElement::Type::IMAGE:
                     {
                         RichElementImage* elmtImage = static_cast<RichElementImage*>(element);
-                        handleImageRenderer(elmtImage->_filePath, elmtImage->_color, elmtImage->_opacity, elmtImage->_width, elmtImage->_height);
+                        handleImageRenderer(elmtImage->_filePath, elmtImage->_color, elmtImage->_opacity, elmtImage->_width, elmtImage->_height, elmtImage->_url);
                         break;
                     }
                     case RichElement::Type::CUSTOM:
@@ -811,7 +1580,11 @@ int RichText::findSplitPositionForChar(cocos2d::Label* label, const std::string&
     return leftLength;
 }
 
-void RichText::handleTextRenderer(const std::string& text, const std::string& fontName, float fontSize, const Color3B &color, GLubyte opacity, uint32_t flags, const std::string& url)
+void RichText::handleTextRenderer(const std::string& text, const std::string& fontName, float fontSize, const Color3B &color,
+                                  GLubyte opacity, uint32_t flags, const std::string& url,
+                                  const Color3B& outlineColor, int outlineSize ,
+                                  const Color3B& shadowColor, const cocos2d::Size& shadowOffset, int shadowBlurRadius,
+                                  const Color3B& glowColor)
 {
     auto fileExist = FileUtils::getInstance()->isFileExist(fontName);
     Label* textRenderer = nullptr;
@@ -832,14 +1605,25 @@ void RichText::handleTextRenderer(const std::string& text, const std::string& fo
     if (flags & RichElementText::STRIKETHROUGH_FLAG)
         textRenderer->enableStrikethrough();
     if (flags & RichElementText::URL_FLAG)
-        textRenderer->addComponent(ListenerComponent::create(textRenderer, url));
+        textRenderer->addComponent(ListenerComponent::create(textRenderer,
+                                                             url,
+                                                             std::bind(&RichText::openUrl, this, std::placeholders::_1)));
+    if (flags & RichElementText::OUTLINE_FLAG) {
+        textRenderer->enableOutline(Color4B(outlineColor), outlineSize);
+    }
+    if (flags & RichElementText::SHADOW_FLAG) {
+        textRenderer->enableShadow(Color4B(shadowColor), shadowOffset, shadowBlurRadius);
+    }
+    if (flags & RichElementText::GLOW_FLAG) {
+        textRenderer->enableGlow(Color4B(glowColor));
+    }
 
     float textRendererWidth = textRenderer->getContentSize().width;
     _leftSpaceWidth -= textRendererWidth;
     if (_leftSpaceWidth < 0.0f)
     {
         int leftLength = 0;
-        if (_wrapMode == WRAP_PER_WORD)
+        if (static_cast<RichText::WrapMode>(_defaults.at(KEY_WRAP_MODE).asInt()) == WRAP_PER_WORD)
             leftLength = findSplitPositionForWord(textRenderer, text);
         else
             leftLength = findSplitPositionForChar(textRenderer, text);
@@ -877,13 +1661,26 @@ void RichText::handleTextRenderer(const std::string& text, const std::string& fo
                 if (flags & RichElementText::STRIKETHROUGH_FLAG)
                     leftRenderer->enableStrikethrough();
                 if (flags & RichElementText::URL_FLAG)
-                    leftRenderer->addComponent(ListenerComponent::create(leftRenderer, url));
-
+                    leftRenderer->addComponent(ListenerComponent::create(leftRenderer,
+                                                                         url,
+                                                                         std::bind(&RichText::openUrl, this, std::placeholders::_1)));
+                if (flags & RichElementText::OUTLINE_FLAG) {
+                    leftRenderer->enableOutline(Color4B(outlineColor), outlineSize);
+                }
+                if (flags & RichElementText::SHADOW_FLAG) {
+                    leftRenderer->enableShadow(Color4B(shadowColor), shadowOffset, shadowBlurRadius);
+                }
+                if (flags & RichElementText::GLOW_FLAG) {
+                    leftRenderer->enableGlow(Color4B(glowColor));
+                }
             }
         }
 
         addNewLine();
-        handleTextRenderer(cutWords, fontName, fontSize, color, opacity, flags, url);
+        handleTextRenderer(cutWords, fontName, fontSize, color, opacity, flags, url,
+                           outlineColor, outlineSize,
+                           shadowColor, shadowOffset, shadowBlurRadius,
+                           glowColor);
     }
     else
     {
@@ -893,7 +1690,7 @@ void RichText::handleTextRenderer(const std::string& text, const std::string& fo
     }
 }
     
-void RichText::handleImageRenderer(const std::string& filePath, const Color3B &color, GLubyte opacity, int width, int height)
+void RichText::handleImageRenderer(const std::string& filePath, const Color3B &color, GLubyte opacity, int width, int height, const std::string url)
 {
     Sprite* imageRenderer = Sprite::create(filePath);
     if (imageRenderer)
@@ -907,6 +1704,9 @@ void RichText::handleImageRenderer(const std::string& filePath, const Color3B &c
                                              currentSize.height * imageRenderer->getScaleY()));
 
         handleCustomRenderer(imageRenderer);
+        imageRenderer->addComponent(ListenerComponent::create(imageRenderer,
+                                                              url,
+                                                              std::bind(&RichText::openUrl, this, std::placeholders::_1)));
     }
 }
 
@@ -981,7 +1781,7 @@ void RichText::formarRenderers()
         {
             Vector<Node*>* row = (_elementRenders[i]);
             float nextPosX = 0.0f;
-            nextPosY -= (maxHeights[i] + _verticalSpace);
+            nextPosY -= (maxHeights[i] + _defaults.at(KEY_VERTICAL_SPACE).asFloat());
             
             for (ssize_t j=0; j<row->size(); j++)
             {
@@ -1032,7 +1832,7 @@ void RichText::pushToContainer(cocos2d::Node *renderer)
     
 void RichText::setVerticalSpace(float space)
 {
-    _verticalSpace = space;
+    _defaults[KEY_VERTICAL_SPACE] = space;
 }
 
 void RichText::ignoreContentAdaptWithSize(bool ignore)
@@ -1048,7 +1848,3 @@ std::string RichText::getDescription() const
 {
     return "RichText";
 }
-
-}
-
-NS_CC_END

--- a/cocos/ui/UIRichText.h
+++ b/cocos/ui/UIRichText.h
@@ -27,6 +27,7 @@
 
 #include "ui/UIWidget.h"
 #include "ui/GUIExport.h"
+#include "base/CCValue.h"
 
 NS_CC_BEGIN
 /**
@@ -37,7 +38,7 @@ NS_CC_BEGIN
 class Label;
 
 namespace ui {
-    
+
 /**
  *@brief Rich text element base class.
  * It defines the basic common properties for all rich text element.
@@ -50,10 +51,10 @@ public:
      */
     enum class Type
     {
-        TEXT,
-        IMAGE,
-        CUSTOM,
-        NEWLINE
+        TEXT,   /*!< RichElementText */
+        IMAGE,  /*!< RichElementImage */
+        CUSTOM, /*!< RichElementCustomNode */
+        NEWLINE /*!< RichElementNewLine */
     };
     
     /**
@@ -80,11 +81,14 @@ public:
      * @return True if initialize success, false otherwise.
      */
     bool init(int tag, const Color3B& color, GLubyte opacity);
+    
+    bool equalType(Type type);
+    void setColor(const Color3B& color);
 protected:
-    Type _type;
-    int _tag;
-    Color3B _color;
-    GLubyte _opacity;
+    Type _type;             /*!< Rich element type. */
+    int _tag;               /*!< A integer tag value. */
+    Color3B _color;         /*!< A color in `Color3B`. */
+    GLubyte _opacity;       /*!< A opacity value in `GLubyte`. */
     friend class RichText;
 };
     
@@ -104,11 +108,14 @@ public:
     {_type = Type::TEXT;};
 
     enum {
-        ITALICS_FLAG = 1 << 0,
-        BOLD_FLAG = 1 << 1,
-        UNDERLINE_FLAG = 1 << 2,
-        STRIKETHROUGH_FLAG = 1 << 3,
-        URL_FLAG = 1 << 4
+        ITALICS_FLAG = 1 << 0,          /*!< italic text */
+        BOLD_FLAG = 1 << 1,             /*!< bold text */
+        UNDERLINE_FLAG = 1 << 2,        /*!< underline */
+        STRIKETHROUGH_FLAG = 1 << 3,    /*!< strikethrough */
+        URL_FLAG = 1 << 4,              /*!< url of anchor */
+        OUTLINE_FLAG = 1 << 5,          /*!< outline effect */
+        SHADOW_FLAG = 1 << 6,           /*!< shadow effect */
+        GLOW_FLAG = 1 << 7              /*!< glow effect */
     };
     
     /**
@@ -127,11 +134,21 @@ public:
      * @param text Content string.
      * @param fontName Content font name.
      * @param fontSize Content font size.
-     * @param flags: italics, bold, underline or strikethrough
+     * @param flags: italics, bold, underline, strikethrough, url, outline, shadow or glow
+     * @param url uniform resource locator
+     * @param outlineColor the color of the outline
+     * @param outlineSize the outline effect size value
+     * @param shadowColor the shadow effect color value
+     * @param shadowOffset shadow effect offset value
+     * @param shadowBlurRadius the shadow effect blur radius
+     * @param glowColor glow color
      * @return True if initialize success, false otherwise.
      */
-    bool init(int tag, const Color3B& color, GLubyte opacity, const std::string& text, const std::string& fontName, float fontSize, uint32_t flags, const std::string& url);
-
+    bool init(int tag, const Color3B& color, GLubyte opacity, const std::string& text,
+              const std::string& fontName, float fontSize, uint32_t flags, const std::string& url,
+              const Color3B& outlineColor = Color3B::WHITE, int outlineSize = -1,
+              const Color3B& shadowColor = Color3B::BLACK, const cocos2d::Size& shadowOffset = Size(2.0, -2.0), int shadowBlurRadius = 0,
+              const Color3B& glowColor = Color3B::WHITE);
     
     /**
      * @brief Create a RichElementText with various arguments.
@@ -142,19 +159,34 @@ public:
      * @param text Content string.
      * @param fontName Content font name.
      * @param fontSize Content font size.
-     * @param flags: italics, bold, underline or strikethrough
+     * @param flags: italics, bold, underline, strikethrough, url, outline, shadow or glow
+     * @param url uniform resource locator
+     * @param outlineColor the color of the outline
+     * @param outlineSize the outline effect size value
+     * @param shadowColor the shadow effect color value
+     * @param shadowOffset shadow effect offset value
+     * @param shadowBlurRadius the shadow effect blur radius
+     * @param glowColor glow color
      * @return RichElementText instance.
      */
     static RichElementText* create(int tag, const Color3B& color, GLubyte opacity, const std::string& text,
-                                   const std::string& fontName, float fontSize, uint32_t flags=0, const std::string& url="");
+                                   const std::string& fontName, float fontSize, uint32_t flags=0, const std::string& url="",
+                                   const Color3B& outlineColor = Color3B::WHITE, int outlineSize = -1,
+                                   const Color3B& shadowColor = Color3B::BLACK, const cocos2d::Size& shadowOffset = Size(2.0, -2.0), int shadowBlurRadius = 0,
+                                   const Color3B& glowColor = Color3B::WHITE);
 protected:
     std::string _text;
     std::string _fontName;
     float _fontSize;
     uint32_t _flags;
     std::string _url;
+    Color3B _outlineColor;                  /*!< the color of the outline */
+    int _outlineSize;                       /*!< the outline effect size value */
+    Color3B _shadowColor;                   /*!< the shadow effect color value */
+    cocos2d::Size _shadowOffset;            /*!< shadow effect offset value */
+    int _shadowBlurRadius;                  /*!< the shadow effect blur radius */
+    Color3B _glowColor;                     /*!< attributes of glow tag */
     friend class RichText;
-    
 };
     
 /**
@@ -188,9 +220,10 @@ public:
      * @param color A color in Color3B.
      * @param opacity A opacity in GLubyte.
      * @param filePath A image file name.
+     * @param url uniform resource locator
      * @return True if initialize success, false otherwise.
      */
-    bool init(int tag, const Color3B& color, GLubyte opacity, const std::string& filePath);
+    bool init(int tag, const Color3B& color, GLubyte opacity, const std::string& filePath, const std::string& url = "");
 
     
     /**
@@ -200,12 +233,14 @@ public:
      * @param color A color in Color3B.
      * @param opacity A opacity in GLubyte.
      * @param filePath A image file name.
+     * @param url uniform resource locator
      * @return A RichElementImage instance.
      */
-    static RichElementImage* create(int tag, const Color3B& color, GLubyte opacity, const std::string& filePath);
+    static RichElementImage* create(int tag, const Color3B& color, GLubyte opacity, const std::string& filePath, const std::string& url = "");
 
     void setWidth(int width);
     void setHeight(int height);
+    void setUrl(const std::string& url);
 protected:
     std::string _filePath;
     Rect _textureRect;
@@ -213,6 +248,7 @@ protected:
     friend class RichText;
     int _width;
     int _height;
+    std::string _url;   /*!< attributes of anchor tag */
 };
     
 /**
@@ -298,7 +334,7 @@ public:
 protected:
     friend class RichText;
 };
-    
+
 /**
  *@brief A container for displaying various RichElements.
  * We could use it to display texts with images easily.
@@ -311,6 +347,58 @@ public:
         WRAP_PER_WORD,
         WRAP_PER_CHAR
     };
+    
+    /**
+     * @brief call to open a resource specified by a URL
+     * @param url a URL
+     */
+    typedef std::function<void(const std::string& url)> OpenUrlHandler;
+    
+    /**
+     * @brief called on the specified tag
+     * @param tagAttrValueMap the attributes of a tag
+     * @result text attributes and RichElement
+     */
+    typedef std::function<std::pair<ValueMap, RichElement*>(const ValueMap& tagAttrValueMap)> VisitEnterHandler;
+    
+    static const std::string KEY_VERTICAL_SPACE;                    /*!< key of vertical space */
+    static const std::string KEY_WRAP_MODE;                         /*!< key of per word, or per char */
+    static const std::string KEY_FONT_COLOR_STRING;                 /*!< key of font color */
+    static const std::string KEY_FONT_SIZE;                         /*!< key of font size */
+    static const std::string KEY_FONT_SMALL;                        /*!< key of font size small */
+    static const std::string KEY_FONT_BIG;                          /*!< key of font size big */
+    static const std::string KEY_FONT_FACE;                         /*!< key of font name */
+    static const std::string KEY_TEXT_BOLD;                         /*!< key of text bold */
+    static const std::string KEY_TEXT_ITALIC;                       /*!< key of text italic */
+    static const std::string KEY_TEXT_LINE;                         /*!< key of line style */
+    static const std::string VALUE_TEXT_LINE_NONE;                  /*!< value of none */
+    static const std::string VALUE_TEXT_LINE_DEL;                   /*!< value of strikethrough line */
+    static const std::string VALUE_TEXT_LINE_UNDER;                 /*!< value of underline */
+    static const std::string KEY_TEXT_STYLE;                        /*!< key of effect style */
+    static const std::string VALUE_TEXT_STYLE_NONE;                 /*!< value of none */
+    static const std::string VALUE_TEXT_STYLE_OUTLINE;              /*!< value of outline */
+    static const std::string VALUE_TEXT_STYLE_SHADOW;               /*!< value of shadow */
+    static const std::string VALUE_TEXT_STYLE_GLOW;                 /*!< value of glow */
+    static const std::string KEY_TEXT_OUTLINE_COLOR;                /*!< key of outline color */
+    static const std::string KEY_TEXT_OUTLINE_SIZE;                 /*!< key of outline size */
+    static const std::string KEY_TEXT_SHADOW_COLOR;                 /*!< key of shadow color */
+    static const std::string KEY_TEXT_SHADOW_OFFSET_WIDTH;          /*!< key of shadow offset (width) */
+    static const std::string KEY_TEXT_SHADOW_OFFSET_HEIGHT;         /*!< key of shadow offset (height) */
+    static const std::string KEY_TEXT_SHADOW_BLUR_RADIUS;           /*!< key of shadow blur radius */
+    static const std::string KEY_TEXT_GLOW_COLOR;                   /*!< key of glow color */
+    static const std::string KEY_URL;                               /*!< key of url */
+    static const std::string KEY_ANCHOR_FONT_COLOR_STRING;          /*!< key of font color of anchor tag */
+    static const std::string KEY_ANCHOR_TEXT_BOLD;                  /*!< key of text bold of anchor tag */
+    static const std::string KEY_ANCHOR_TEXT_ITALIC;                /*!< key of text italic of anchor tag */
+    static const std::string KEY_ANCHOR_TEXT_LINE;                  /*!< key of line style of anchor tag */
+    static const std::string KEY_ANCHOR_TEXT_STYLE;                 /*!< key of effect style of anchor tag */
+    static const std::string KEY_ANCHOR_TEXT_OUTLINE_COLOR;         /*!< key of outline color of anchor tag */
+    static const std::string KEY_ANCHOR_TEXT_OUTLINE_SIZE;          /*!< key of outline size of anchor tag */
+    static const std::string KEY_ANCHOR_TEXT_SHADOW_COLOR;          /*!< key of shadow color of anchor tag */
+    static const std::string KEY_ANCHOR_TEXT_SHADOW_OFFSET_WIDTH;   /*!< key of shadow offset (width) of anchor tag */
+    static const std::string KEY_ANCHOR_TEXT_SHADOW_OFFSET_HEIGHT;  /*!< key of shadow offset (height) of anchor tag */
+    static const std::string KEY_ANCHOR_TEXT_SHADOW_BLUR_RADIUS;    /*!< key of shadow blur radius of anchor tag */
+    static const std::string KEY_ANCHOR_TEXT_GLOW_COLOR;            /*!< key of glow color of anchor tag */
     
     /**
      * @brief Default constructor.
@@ -338,7 +426,7 @@ public:
      *
      * @return RichText instance.
      */
-    static RichText* createWithXML(const std::string& xml);
+    static RichText* createWithXML(const std::string& xml, const ValueMap& defaults = ValueMap(), const OpenUrlHandler& handleOpenUrl = nullptr);
 
     /**
      * @brief Insert a RichElement at a given index.
@@ -386,25 +474,86 @@ public:
     virtual void ignoreContentAdaptWithSize(bool ignore) override;
     virtual std::string getDescription() const override;
 
-    /** @brief sets the wrapping mode: WRAP_PER_CHAR or WRAP_PER_WORD
-     */
-    void setWrapMode(WrapMode wrapMode);
+    void setWrapMode(WrapMode wrapMode);                /*!< sets the wrapping mode: WRAP_PER_CHAR or WRAP_PER_WORD */
+    WrapMode getWrapMode() const;                       /*!< returns the current wrapping mode */
+    void setFontColor(const std::string& color);        /*!< Set the font color. @param color the #RRGGBB hexadecimal notation. */
+    std::string getFontColor();                         /*!< return the current font color */
+    Color3B getFontColor3B();                           /*!< return the current font color */
+    void setFontSize(float size);                       /*!< Set the font size. @param size the font size. */
+    float getFontSize();                                /*!< return the current font size */
+    void setFontFace(const std::string& face);          /*!< Set the font face. @param face the font face. */
+    std::string getFontFace();                          /*!< return the current font face */
+    void setAnchorFontColor(const std::string& color);  /*!< Set the font color of a-tag. @param face the font color. */
+    std::string getAnchorFontColor();                   /*!< return the current font color of a-tag */
+    cocos2d::Color3B getAnchorFontColor3B();            /*!< return the current font color of a-tag */
+    void setAnchorTextBold(bool enable);                /*!< enable bold text of a-tag */
+    bool isAnchorTextBoldEnabled();                     /*!< valid style is bold text of a-tag? */
+    void setAnchorTextItalic(bool enable);              /*!< enable italic text of a-tag */
+    bool isAnchorTextItalicEnabled();                   /*!< valid style is italic text of a-tag? */
+    void setAnchorTextDel(bool enable);                 /*!< enable the strikethrough of a-tag */
+    bool isAnchorTextDelEnabled();                      /*!< valid strikethrough of a-tag? */
+    void setAnchorTextUnderline(bool enable);           /*!< enable the underline of a-tag */
+    bool isAnchorTextUnderlineEnabled();                /*!< valid underline of a-tag? */
+    /** @breif enable the outline of a-tag */
+    void setAnchorTextOutline(bool enable, const Color3B& outlineColor = Color3B::WHITE, int outlineSize = -1);
+    bool isAnchorTextOutlineEnabled();                  /*!< valid outline of a-tag? */
+    Color3B getAnchorTextOutlineColor3B();              /*!< return the current text outline color of a-tag */
+    int getAnchorTextOutlineSize();                     /*!< return the current text outline size of a-tag */
+    /** @breif enable the shadow of a-tag */
+    void setAnchorTextShadow(bool enable, const Color3B& shadowColor = Color3B::BLACK, const Size& offset = Size(2.0, -2.0), int blurRadius = 0);
+    bool isAnchorTextShadowEnabled();                   /*!< valid shadow of a-tag? */
+    Color3B getAnchorTextShadowColor3B();               /*!< return the current text shadow color of a-tag */
+    Size getAnchorTextShadowOffset();                   /*!< return the current text shadow offset of a-tag */
+    int getAnchorTextShadowBlurRadius();                /*!< return the current text shadow blur radius of a-tag */
+    void setAnchorTextGlow(bool enable, const Color3B& glowColor = Color3B::WHITE); /*!< enable the glow of a-tag */
+    bool isAnchorTextGlowEnabled();                     /*!< valid glow of a-tag? */
+    Color3B getAnchorTextGlowColor3B();                 /*!< return the current text glow color of a-tag */
+    void setDefaults(const ValueMap& defaults);         /*!< set the default values */
+    ValueMap getDefaults() const;                       /*!< returns the default values */
 
-    /** @brief returns the current wrapping mode */
-    WrapMode getWrapMode() const;
+    cocos2d::Color3B color3BWithString(const std::string& color);   /*!< convert a color string into a Color3B. */
+    std::string stringWithColor3B(const cocos2d::Color3B& color3b); /*!< convert a Color3B into a color string. */
+    std::string stringWithColor4B(const cocos2d::Color4B& color4b); /*!< convert a Color4B into a color string. */
+
+    /**
+     * @brief add a callback to own tag.
+     * @param tag tag's name
+     * @param isFontElement use attributes of text tag
+     * @param handleVisitEnter callback
+     */
+    static void setTagDescription(const std::string& tag, bool isFontElement, VisitEnterHandler handleVisitEnter);
+
+    /**
+     * @brief remove a callback to own tag.
+     * @param tag tag's name
+     */
+    static void removeTagDescription(const std::string& tag);
     
+    void openUrl(const std::string& url);
+
+    /**
+     * @brief Asks the callback to open a resource specified by a URL.
+     * @discussion If you set up your own URL in the anchor tag, it is used to intercept the URL open.
+     * @param handleOpenUrl the callback
+     */
+    void setOpenUrlHandler(const OpenUrlHandler& handleOpenUrl);
+
 CC_CONSTRUCTOR_ACCESS:
     virtual bool init() override;
 
-    bool initWithXML(const std::string& xml);
+    bool initWithXML(const std::string& xml, const ValueMap& defaults = ValueMap(), const OpenUrlHandler& handleOpenUrl = nullptr);
 
 protected:
     virtual void adaptRenderers() override;
 
     virtual void initRenderer() override;
     void pushToContainer(Node* renderer);
-    void handleTextRenderer(const std::string& text, const std::string& fontName, float fontSize, const Color3B& color, GLubyte opacity, uint32_t flags, const std::string& url="");
-    void handleImageRenderer(const std::string& fileParh, const Color3B& color, GLubyte opacity, int width, int height);
+    void handleTextRenderer(const std::string& text, const std::string& fontName, float fontSize, const Color3B& color,
+                            GLubyte opacity, uint32_t flags, const std::string& url="",
+                            const Color3B& outlineColor = Color3B::WHITE, int outlineSize = -1,
+                            const Color3B& shadowColor = Color3B::BLACK, const cocos2d::Size& shadowOffset = Size(2.0, -2.0), int shadowBlurRadius = 0,
+                            const Color3B& glowColor = Color3B::WHITE);
+    void handleImageRenderer(const std::string& fileParh, const Color3B& color, GLubyte opacity, int width, int height, const std::string url);
     void handleCustomRenderer(Node* renderer);
     void formarRenderers();
     void addNewLine();
@@ -415,10 +564,9 @@ protected:
     Vector<RichElement*> _richElements;
     std::vector<Vector<Node*>*> _elementRenders;
     float _leftSpaceWidth;
-    float _verticalSpace;
 
-    // per word, or per char
-    WrapMode _wrapMode;
+    ValueMap _defaults;             /*!< default values */
+    OpenUrlHandler _handleOpenUrl;  /*!< the callback for open URL */
 };
     
 }

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIRichTextTest/UIRichTextTest.cpp
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIRichTextTest/UIRichTextTest.cpp
@@ -16,9 +16,14 @@ UIRichTextTests::UIRichTextTests()
     ADD_TEST_CASE(UIRichTextXMLSUIB3);
     ADD_TEST_CASE(UIRichTextXMLImg);
     ADD_TEST_CASE(UIRichTextXMLUrl);
+    ADD_TEST_CASE(UIRichTextXMLUrlImg);
     ADD_TEST_CASE(UIRichTextXMLFace);
     ADD_TEST_CASE(UIRichTextXMLBR);
     ADD_TEST_CASE(UIRichTextXMLInvalid);
+    ADD_TEST_CASE(UIRichTextXMLOutline);
+    ADD_TEST_CASE(UIRichTextXMLShadow);
+    ADD_TEST_CASE(UIRichTextXMLGlow);
+    ADD_TEST_CASE(UIRichTextXMLExtend);
 }
 
 
@@ -827,6 +832,91 @@ void UIRichTextXMLUrl::switchWrapMode(Ref *pSender, Widget::TouchEventType type)
 }
 
 //
+// UIRichTextXMLUrlImg
+//
+bool UIRichTextXMLUrlImg::init()
+{
+    if (UIScene::init())
+    {
+        Size widgetSize = _widget->getContentSize();
+        
+        // Add the alert
+        Text *alert = Text::create("RichText", "fonts/Marker Felt.ttf", 30);
+        alert->setColor(Color3B(159, 168, 176));
+        alert->setPosition(Vec2(widgetSize.width / 2.0f, widgetSize.height / 2.0f - alert->getContentSize().height * 3.125));
+        _widget->addChild(alert);
+        
+        
+        Button* button = Button::create("cocosui/animationbuttonnormal.png", "cocosui/animationbuttonpressed.png");
+        button->setTouchEnabled(true);
+        button->setTitleText("switch");
+        button->setPosition(Vec2(widgetSize.width * 1 / 3, widgetSize.height / 2.0f + button->getContentSize().height * 2.5));
+        button->addTouchEventListener(CC_CALLBACK_2(UIRichTextXMLUrlImg::touchEvent, this));
+        button->setLocalZOrder(10);
+        _widget->addChild(button);
+        
+        Button* button2 = Button::create("cocosui/animationbuttonnormal.png", "cocosui/animationbuttonpressed.png");
+        button2->setTouchEnabled(true);
+        button2->setTitleText("wrap mode");
+        button2->setPosition(Vec2(widgetSize.width * 2 / 3, widgetSize.height / 2.0f + button2->getContentSize().height * 2.5));
+        button2->addTouchEventListener(CC_CALLBACK_2(UIRichTextXMLUrlImg::switchWrapMode, this));
+        button2->setLocalZOrder(10);
+        _widget->addChild(button2);
+        
+        
+        // RichText
+        _richText = RichText::createWithXML("And this link will redirect you to google: <a href='http://www.google.com'><img src=\"cocosui/ccicon.png\" height=\"48\" width=\"48\" /></a>");
+        _richText->ignoreContentAdaptWithSize(false);
+        _richText->setContentSize(Size(100, 100));
+        
+        _richText->setPosition(Vec2(widgetSize.width / 2, widgetSize.height / 2));
+        _richText->setLocalZOrder(10);
+        
+        
+        _widget->addChild(_richText);
+        
+        // test remove all children, this call won't effect the test
+        _richText->removeAllChildren();
+        
+        return true;
+    }
+    return false;
+}
+
+void UIRichTextXMLUrlImg::touchEvent(Ref *pSender, Widget::TouchEventType type)
+{
+    switch (type)
+    {
+        case Widget::TouchEventType::ENDED:
+        {
+            if (_richText->isIgnoreContentAdaptWithSize())
+            {
+                _richText->ignoreContentAdaptWithSize(false);
+                _richText->setContentSize(Size(100, 100));
+            }
+            else
+            {
+                _richText->ignoreContentAdaptWithSize(true);
+            }
+        }
+            break;
+            
+        default:
+            break;
+    }
+}
+
+void UIRichTextXMLUrlImg::switchWrapMode(Ref *pSender, Widget::TouchEventType type)
+{
+    if (type == Widget::TouchEventType::ENDED)
+    {
+        auto wrapMode = _richText->getWrapMode();
+        wrapMode = (wrapMode == RichText::WRAP_PER_WORD) ? RichText::WRAP_PER_CHAR : RichText::WRAP_PER_WORD;
+        _richText->setWrapMode(wrapMode);
+    }
+}
+
+//
 // UIRichTextXMLFace
 //
 bool UIRichTextXMLFace::init()
@@ -1033,3 +1123,378 @@ bool UIRichTextXMLInvalid::init()
     return false;
 }
 
+//
+// UIRichTextXMLOutline
+//
+bool UIRichTextXMLOutline::init()
+{
+    if (UIScene::init())
+    {
+        Size widgetSize = _widget->getContentSize();
+        
+        // Add the alert
+        Text *alert = Text::create("Outline", "fonts/Marker Felt.ttf", 30);
+        alert->setColor(Color3B(159, 168, 176));
+        alert->setPosition(Vec2(widgetSize.width / 2.0f, widgetSize.height / 2.0f - alert->getContentSize().height * 3.125));
+        _widget->addChild(alert);
+        
+        
+        Button* button = Button::create("cocosui/animationbuttonnormal.png", "cocosui/animationbuttonpressed.png");
+        button->setTouchEnabled(true);
+        button->setTitleText("switch");
+        button->setPosition(Vec2(widgetSize.width * 1 / 3, widgetSize.height / 2.0f + button->getContentSize().height * 2.5));
+        button->addTouchEventListener(CC_CALLBACK_2(UIRichTextXMLOutline::touchEvent, this));
+        button->setLocalZOrder(10);
+        _widget->addChild(button);
+        
+        Button* button2 = Button::create("cocosui/animationbuttonnormal.png", "cocosui/animationbuttonpressed.png");
+        button2->setTouchEnabled(true);
+        button2->setTitleText("wrap mode");
+        button2->setPosition(Vec2(widgetSize.width * 2 / 3, widgetSize.height / 2.0f + button2->getContentSize().height * 2.5));
+        button2->addTouchEventListener(CC_CALLBACK_2(UIRichTextXMLOutline::switchWrapMode, this));
+        button2->setLocalZOrder(10);
+        _widget->addChild(button2);
+        
+        
+        // RichText
+        _richText = RichText::createWithXML("<font face='fonts/Marker Felt.ttf' size=\"24\"><outline color=\"#D2B48C\" size=\"2\">OUTLINE</outline></font>");
+        _richText->ignoreContentAdaptWithSize(false);
+        _richText->setContentSize(Size(100, 100));
+        
+        _richText->setPosition(Vec2(widgetSize.width / 2, widgetSize.height / 2));
+        _richText->setLocalZOrder(10);
+        
+        
+        _widget->addChild(_richText);
+        
+        // test remove all children, this call won't effect the test
+        _richText->removeAllChildren();
+        
+        return true;
+    }
+    return false;
+}
+
+void UIRichTextXMLOutline::touchEvent(Ref *pSender, Widget::TouchEventType type)
+{
+    switch (type)
+    {
+        case Widget::TouchEventType::ENDED:
+        {
+            if (_richText->isIgnoreContentAdaptWithSize())
+            {
+                _richText->ignoreContentAdaptWithSize(false);
+                _richText->setContentSize(Size(100, 100));
+            }
+            else
+            {
+                _richText->ignoreContentAdaptWithSize(true);
+            }
+        }
+            break;
+            
+        default:
+            break;
+    }
+}
+
+void UIRichTextXMLOutline::switchWrapMode(Ref *pSender, Widget::TouchEventType type)
+{
+    if (type == Widget::TouchEventType::ENDED)
+    {
+        auto wrapMode = _richText->getWrapMode();
+        wrapMode = (wrapMode == RichText::WRAP_PER_WORD) ? RichText::WRAP_PER_CHAR : RichText::WRAP_PER_WORD;
+        _richText->setWrapMode(wrapMode);
+    }
+}
+
+//
+// UIRichTextXMLShadow
+//
+bool UIRichTextXMLShadow::init()
+{
+    if (UIScene::init())
+    {
+        Size widgetSize = _widget->getContentSize();
+        
+        // Add the alert
+        Text *alert = Text::create("Shadow", "fonts/Marker Felt.ttf", 30);
+        alert->setColor(Color3B(159, 168, 176));
+        alert->setPosition(Vec2(widgetSize.width / 2.0f, widgetSize.height / 2.0f - alert->getContentSize().height * 3.125));
+        _widget->addChild(alert);
+        
+        
+        Button* button = Button::create("cocosui/animationbuttonnormal.png", "cocosui/animationbuttonpressed.png");
+        button->setTouchEnabled(true);
+        button->setTitleText("switch");
+        button->setPosition(Vec2(widgetSize.width * 1 / 3, widgetSize.height / 2.0f + button->getContentSize().height * 2.5));
+        button->addTouchEventListener(CC_CALLBACK_2(UIRichTextXMLShadow::touchEvent, this));
+        button->setLocalZOrder(10);
+        _widget->addChild(button);
+        
+        Button* button2 = Button::create("cocosui/animationbuttonnormal.png", "cocosui/animationbuttonpressed.png");
+        button2->setTouchEnabled(true);
+        button2->setTitleText("wrap mode");
+        button2->setPosition(Vec2(widgetSize.width * 2 / 3, widgetSize.height / 2.0f + button2->getContentSize().height * 2.5));
+        button2->addTouchEventListener(CC_CALLBACK_2(UIRichTextXMLShadow::switchWrapMode, this));
+        button2->setLocalZOrder(10);
+        _widget->addChild(button2);
+        
+        
+        // RichText
+        _richText = RichText::createWithXML("<font size=\"24\"><shadow color=\"#4169E1\" offsetWidth=\"8\" offsetHeight=\"-8\" blurRadius=\"2\">SHADOW</shadow></font>");
+        _richText->ignoreContentAdaptWithSize(false);
+        _richText->setContentSize(Size(100, 100));
+        
+        _richText->setPosition(Vec2(widgetSize.width / 2, widgetSize.height / 2));
+        _richText->setLocalZOrder(10);
+        
+        
+        _widget->addChild(_richText);
+        
+        // test remove all children, this call won't effect the test
+        _richText->removeAllChildren();
+        
+        return true;
+    }
+    return false;
+}
+
+void UIRichTextXMLShadow::touchEvent(Ref *pSender, Widget::TouchEventType type)
+{
+    switch (type)
+    {
+        case Widget::TouchEventType::ENDED:
+        {
+            if (_richText->isIgnoreContentAdaptWithSize())
+            {
+                _richText->ignoreContentAdaptWithSize(false);
+                _richText->setContentSize(Size(100, 100));
+            }
+            else
+            {
+                _richText->ignoreContentAdaptWithSize(true);
+            }
+        }
+            break;
+            
+        default:
+            break;
+    }
+}
+
+void UIRichTextXMLShadow::switchWrapMode(Ref *pSender, Widget::TouchEventType type)
+{
+    if (type == Widget::TouchEventType::ENDED)
+    {
+        auto wrapMode = _richText->getWrapMode();
+        wrapMode = (wrapMode == RichText::WRAP_PER_WORD) ? RichText::WRAP_PER_CHAR : RichText::WRAP_PER_WORD;
+        _richText->setWrapMode(wrapMode);
+    }
+}
+
+//
+// UIRichTextXMLGlow
+//
+bool UIRichTextXMLGlow::init()
+{
+    if (UIScene::init())
+    {
+        Size widgetSize = _widget->getContentSize();
+        
+        // Add the alert
+        Text *alert = Text::create("Glow", "fonts/Marker Felt.ttf", 30);
+        alert->setColor(Color3B(159, 168, 176));
+        alert->setPosition(Vec2(widgetSize.width / 2.0f, widgetSize.height / 2.0f - alert->getContentSize().height * 3.125));
+        _widget->addChild(alert);
+        
+        
+        Button* button = Button::create("cocosui/animationbuttonnormal.png", "cocosui/animationbuttonpressed.png");
+        button->setTouchEnabled(true);
+        button->setTitleText("switch");
+        button->setPosition(Vec2(widgetSize.width * 1 / 3, widgetSize.height / 2.0f + button->getContentSize().height * 2.5));
+        button->addTouchEventListener(CC_CALLBACK_2(UIRichTextXMLGlow::touchEvent, this));
+        button->setLocalZOrder(10);
+        _widget->addChild(button);
+        
+        Button* button2 = Button::create("cocosui/animationbuttonnormal.png", "cocosui/animationbuttonpressed.png");
+        button2->setTouchEnabled(true);
+        button2->setTitleText("wrap mode");
+        button2->setPosition(Vec2(widgetSize.width * 2 / 3, widgetSize.height / 2.0f + button2->getContentSize().height * 2.5));
+        button2->addTouchEventListener(CC_CALLBACK_2(UIRichTextXMLGlow::switchWrapMode, this));
+        button2->setLocalZOrder(10);
+        _widget->addChild(button2);
+        
+        
+        // RichText
+        _richText = RichText::createWithXML("<font face=\"fonts/Marker Felt.ttf\" size=\"24\"><glow color=\"#AFEEEE\">GLOW</glow></font>");
+        _richText->ignoreContentAdaptWithSize(false);
+        _richText->setContentSize(Size(100, 100));
+        
+        _richText->setPosition(Vec2(widgetSize.width / 2, widgetSize.height / 2));
+        _richText->setLocalZOrder(10);
+        
+        
+        _widget->addChild(_richText);
+        
+        // test remove all children, this call won't effect the test
+        _richText->removeAllChildren();
+        
+        return true;
+    }
+    return false;
+}
+
+void UIRichTextXMLGlow::touchEvent(Ref *pSender, Widget::TouchEventType type)
+{
+    switch (type)
+    {
+        case Widget::TouchEventType::ENDED:
+        {
+            if (_richText->isIgnoreContentAdaptWithSize())
+            {
+                _richText->ignoreContentAdaptWithSize(false);
+                _richText->setContentSize(Size(100, 100));
+            }
+            else
+            {
+                _richText->ignoreContentAdaptWithSize(true);
+            }
+        }
+            break;
+            
+        default:
+            break;
+    }
+}
+
+void UIRichTextXMLGlow::switchWrapMode(Ref *pSender, Widget::TouchEventType type)
+{
+    if (type == Widget::TouchEventType::ENDED)
+    {
+        auto wrapMode = _richText->getWrapMode();
+        wrapMode = (wrapMode == RichText::WRAP_PER_WORD) ? RichText::WRAP_PER_CHAR : RichText::WRAP_PER_WORD;
+        _richText->setWrapMode(wrapMode);
+    }
+}
+
+//
+// UIRichTextXMLExtend
+//
+bool UIRichTextXMLExtend::init()
+{
+    if (UIScene::init())
+    {
+        Size widgetSize = _widget->getContentSize();
+        
+        // Add the alert
+        Text *alert = Text::create("Extend", "fonts/Marker Felt.ttf", 30);
+        alert->setColor(Color3B(159, 168, 176));
+        alert->setPosition(Vec2(widgetSize.width / 2.0f, widgetSize.height / 2.0f - alert->getContentSize().height * 3.125));
+        _widget->addChild(alert);
+        
+        
+        Button* button = Button::create("cocosui/animationbuttonnormal.png", "cocosui/animationbuttonpressed.png");
+        button->setTouchEnabled(true);
+        button->setTitleText("switch");
+        button->setPosition(Vec2(widgetSize.width * 1 / 3, widgetSize.height / 2.0f + button->getContentSize().height * 2.5));
+        button->addTouchEventListener(CC_CALLBACK_2(UIRichTextXMLExtend::touchEvent, this));
+        button->setLocalZOrder(10);
+        _widget->addChild(button);
+        
+        Button* button2 = Button::create("cocosui/animationbuttonnormal.png", "cocosui/animationbuttonpressed.png");
+        button2->setTouchEnabled(true);
+        button2->setTitleText("wrap mode");
+        button2->setPosition(Vec2(widgetSize.width * 2 / 3, widgetSize.height / 2.0f + button2->getContentSize().height * 2.5));
+        button2->addTouchEventListener(CC_CALLBACK_2(UIRichTextXMLExtend::switchWrapMode, this));
+        button2->setLocalZOrder(10);
+        _widget->addChild(button2);
+        
+        /* Tag extension */
+        RichText::setTagDescription("CloseNormal", false, [](const ValueMap& tagAttrValueMap) {
+            RichElementImage* richElement = RichElementImage::create(0, Color3B::WHITE, 255, "cocosui/CloseNormal.png");
+            return make_pair(ValueMap(), richElement);
+        });
+        RichText::setTagDescription("CloseSelected", false, [](const ValueMap& tagAttrValueMap) {
+            RichElementImage* richElement = RichElementImage::create(0, Color3B::WHITE, 255, "cocosui/CloseSelected.png");
+            return make_pair(ValueMap(), richElement);
+        });
+        
+        /* Defaults */
+        ValueMap defaults;
+        defaults[RichText::KEY_FONT_COLOR_STRING] = "#FFF";
+        defaults[RichText::KEY_FONT_SIZE] = 12.0f;
+        defaults[RichText::KEY_FONT_FACE] = "fonts/Marker Felt.ttf";
+        defaults[RichText::KEY_ANCHOR_FONT_COLOR_STRING] = "#f0f8ff";
+        defaults[RichText::KEY_ANCHOR_TEXT_BOLD] = false;
+        defaults[RichText::KEY_ANCHOR_TEXT_ITALIC] = false;
+        //defaults[RichText::KEY_ANCHOR_TEXT_LINE] = RichText::VALUE_TEXT_LINE_NONE;
+        //defaults[RichText::KEY_ANCHOR_TEXT_LINE] = RichText::VALUE_TEXT_LINE_DEL;
+        defaults[RichText::KEY_ANCHOR_TEXT_LINE] = RichText::VALUE_TEXT_LINE_UNDER;
+        //defaults[RichText::KEY_ANCHOR_TEXT_STYLE] = RichText::VALUE_TEXT_STYLE_NONE;
+        //defaults[RichText::KEY_ANCHOR_TEXT_STYLE] = RichText::VALUE_TEXT_STYLE_OUTLINE;
+        //defaults[RichText::KEY_ANCHOR_TEXT_STYLE] = RichText::VALUE_TEXT_STYLE_SHADOW;
+        //defaults[RichText::KEY_ANCHOR_TEXT_STYLE] = RichText::VALUE_TEXT_STYLE_GLOW;
+        defaults[RichText::KEY_ANCHOR_TEXT_OUTLINE_COLOR] = "#D2B48C";
+        defaults[RichText::KEY_ANCHOR_TEXT_OUTLINE_SIZE] = 4;
+        defaults[RichText::KEY_ANCHOR_TEXT_SHADOW_COLOR] = "#4169E1";
+        defaults[RichText::KEY_ANCHOR_TEXT_SHADOW_OFFSET_WIDTH] = 4.0f;
+        defaults[RichText::KEY_ANCHOR_TEXT_SHADOW_OFFSET_HEIGHT] = -4.0f;
+        defaults[RichText::KEY_ANCHOR_TEXT_SHADOW_BLUR_RADIUS] = 0;
+        defaults[RichText::KEY_ANCHOR_TEXT_GLOW_COLOR] = "#AFEEEE";
+        
+        // RichText
+        _richText = RichText::createWithXML("<span>CloseNormal-tag:<br /><CloseNormal /><br /><br />CloseSelected-tag:<br /><CloseSelected></CloseSelected></span>",
+                                            defaults,
+                                            [](const std::string& url) {
+            Application::getInstance()->openURL(url);
+        });
+        _richText->ignoreContentAdaptWithSize(false);
+        _richText->setContentSize(Size(100, 100));
+        
+        _richText->setPosition(Vec2(widgetSize.width / 2, widgetSize.height / 2));
+        _richText->setLocalZOrder(10);
+        
+        
+        _widget->addChild(_richText);
+        
+        // test remove all children, this call won't effect the test
+        _richText->removeAllChildren();
+        
+        return true;
+    }
+    return false;
+}
+
+void UIRichTextXMLExtend::touchEvent(Ref *pSender, Widget::TouchEventType type)
+{
+    switch (type)
+    {
+        case Widget::TouchEventType::ENDED:
+        {
+            if (_richText->isIgnoreContentAdaptWithSize())
+            {
+                _richText->ignoreContentAdaptWithSize(false);
+                _richText->setContentSize(Size(100, 100));
+            }
+            else
+            {
+                _richText->ignoreContentAdaptWithSize(true);
+            }
+        }
+            break;
+            
+        default:
+            break;
+    }
+}
+
+void UIRichTextXMLExtend::switchWrapMode(Ref *pSender, Widget::TouchEventType type)
+{
+    if (type == Widget::TouchEventType::ENDED)
+    {
+        auto wrapMode = _richText->getWrapMode();
+        wrapMode = (wrapMode == RichText::WRAP_PER_WORD) ? RichText::WRAP_PER_CHAR : RichText::WRAP_PER_WORD;
+        _richText->setWrapMode(wrapMode);
+    }
+}

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIRichTextTest/UIRichTextTest.h
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIRichTextTest/UIRichTextTest.h
@@ -124,6 +124,19 @@ protected:
     cocos2d::ui::RichText* _richText;
 };
 
+class UIRichTextXMLUrlImg : public UIScene
+{
+public:
+    CREATE_FUNC(UIRichTextXMLUrlImg);
+    
+    bool init() override;
+    void touchEvent(cocos2d::Ref* sender, cocos2d::ui::Widget::TouchEventType type);
+    void switchWrapMode(cocos2d::Ref* sender, cocos2d::ui::Widget::TouchEventType type);
+    
+protected:
+    cocos2d::ui::RichText* _richText;
+};
+
 class UIRichTextXMLFace : public UIScene
 {
 public:
@@ -161,6 +174,56 @@ protected:
     cocos2d::ui::RichText* _richText;
 };
 
+class UIRichTextXMLOutline : public UIScene
+{
+public:
+    CREATE_FUNC(UIRichTextXMLOutline);
+    
+    bool init() override;
+    void touchEvent(cocos2d::Ref* sender, cocos2d::ui::Widget::TouchEventType type);
+    void switchWrapMode(cocos2d::Ref* sender, cocos2d::ui::Widget::TouchEventType type);
+    
+protected:
+    cocos2d::ui::RichText* _richText;
+};
 
+class UIRichTextXMLShadow : public UIScene
+{
+public:
+    CREATE_FUNC(UIRichTextXMLShadow);
+    
+    bool init() override;
+    void touchEvent(cocos2d::Ref* sender, cocos2d::ui::Widget::TouchEventType type);
+    void switchWrapMode(cocos2d::Ref* sender, cocos2d::ui::Widget::TouchEventType type);
+    
+protected:
+    cocos2d::ui::RichText* _richText;
+};
+
+class UIRichTextXMLGlow : public UIScene
+{
+public:
+    CREATE_FUNC(UIRichTextXMLGlow);
+    
+    bool init() override;
+    void touchEvent(cocos2d::Ref* sender, cocos2d::ui::Widget::TouchEventType type);
+    void switchWrapMode(cocos2d::Ref* sender, cocos2d::ui::Widget::TouchEventType type);
+    
+protected:
+    cocos2d::ui::RichText* _richText;
+};
+
+class UIRichTextXMLExtend : public UIScene
+{
+public:
+    CREATE_FUNC(UIRichTextXMLExtend);
+    
+    bool init() override;
+    void touchEvent(cocos2d::Ref* sender, cocos2d::ui::Widget::TouchEventType type);
+    void switchWrapMode(cocos2d::Ref* sender, cocos2d::ui::Widget::TouchEventType type);
+    
+protected:
+    cocos2d::ui::RichText* _richText;
+};
 
 #endif /* defined(__TestCpp__UIRichTextTest__) */

--- a/tools/tojs/cocos2dx_ui.ini
+++ b/tools/tojs/cocos2dx_ui.ini
@@ -30,9 +30,9 @@ headers = %(cocosdir)s/cocos/ui/CocosGUI.h %(cocosdir)s/cocos/ui/UIScrollViewBar
 
 # what classes to produce code for. You can use regular expressions here. When testing the regular
 # expression, it will be enclosed in "^$", like this: "^Menu*$".
-classes = Helper Layout Widget Button CheckBox ImageView Text TextAtlas TextBMFont RichText RichElement RichElementText RichElementImage RichElementCustomNode LoadingBar Slider TextField UICCTextField ScrollView ScrollViewBar PageView ListView LayoutParameter LinearLayoutParameter RelativeLayoutParameter VideoPlayer HBox VBox RelativeBox Scale9Sprite EditBox$ LayoutComponent RadioButtonGroup RadioButton AbstractCheckButton TabControl TabHeader
+classes = Helper Layout Widget Button CheckBox ImageView Text TextAtlas TextBMFont RichText RichElement RichElementText RichElementImage RichElementCustomNode RichElementNewLine LoadingBar Slider TextField UICCTextField ScrollView ScrollViewBar PageView ListView LayoutParameter LinearLayoutParameter RelativeLayoutParameter VideoPlayer HBox VBox RelativeBox Scale9Sprite EditBox$ LayoutComponent RadioButtonGroup RadioButton AbstractCheckButton TabControl TabHeader
 
-classes_need_extend = Layout Widget Button CheckBox ImageView Text TextAtlas TextBMFont RichText RichElement RichElementText RichElementImage RichElementCustomNode LoadingBar Slider TextField ScrollView ScrollViewBar PageView ListView VideoPlayer HBox VBox RelativeBox Scale9Sprite EditBox$ LayoutComponent RadioButtonGroup RadioButton AbstractCheckButton TabControl TabHeader
+classes_need_extend = Layout Widget Button CheckBox ImageView Text TextAtlas TextBMFont RichText RichElement RichElementText RichElementImage RichElementCustomNode RichElementNewLine LoadingBar Slider TextField ScrollView ScrollViewBar PageView ListView VideoPlayer HBox VBox RelativeBox Scale9Sprite EditBox$ LayoutComponent RadioButtonGroup RadioButton AbstractCheckButton TabControl TabHeader
 
 # what should we skip? in the format ClassName::[function function]
 # ClassName is a regular expression, but will be used like this: "^ClassName$" functions are also
@@ -46,7 +46,7 @@ skip = *::[^visit$ copyWith.* onEnter.* onExit.* ^description$ getObjectType .*H
         Layer::[getInputManager],
         LayoutParameter::[(s|g)etMargin],
         ImageView::[doubleClickEvent checkDoubleClick],
-        RichText::[getVirtualRendererSize],
+        RichText::[getVirtualRendererSize setTagDescription removeTagDescription setOpenUrlHandler],
         EditBox::[(g|s)etDelegate ^keyboard.* touchDownAction getScriptEditBoxHandler registerScriptEditBoxHandler unregisterScriptEditBoxHandler]
 
 rename_functions = Widget::[init=_init],

--- a/tools/tolua/cocos2dx_ui.ini
+++ b/tools/tolua/cocos2dx_ui.ini
@@ -41,7 +41,8 @@ classes = Helper Widget Layout Button CheckBox ImageView Text TextAtlas TextBMFo
 
 skip = *::[^visit$ copyWith.* onEnter.* onExit.* ^description$ getObjectType .*HSV onTouch.* onAcc.* onKey.* onRegisterTouchListener ccTouch.* (g|s)etDelegate],
         Widget::[addTouchEventListener addClickEventListener addCCSEventListener],
-        LayoutParameter::[(s|g)etMargin]
+        LayoutParameter::[(s|g)etMargin],
+        RichText::[setTagDescription removeTagDescription setOpenUrlHandler]
 
 rename_functions = 
 


### PR DESCRIPTION
This is a PR to extend the RichText.
- Set of default values.
- Append to ability to extend the tags.
- Add the effect of outline, shadow and glow.
- Catch a event of open url.
- Anchor of the image tag.

I have consulted the arguments for the initialization function of RichElementText.
By this time of expansion, the number of arguments of the init() and create() has increased (8 -> 11). The increase was the argument made to have a default value, you have to maintain compatibility, but you will not be able to be only part of the growing argument.
For example, I think that the argument is ValueMap or the structure, but when it will change, it will affect compatibility.
If there is good correspondence way, will not you tell me?
