### PR TITLE
std::shared_ptr<bool> -> std::shared_ptr<std::atomic<bool>>

### DIFF
--- a/cocos/network/WebSocket.cpp
+++ b/cocos/network/WebSocket.cpp
@@ -313,7 +313,7 @@ WebSocket::WebSocket()
 , _wsHelper(nullptr)
 , _wsInstance(nullptr)
 , _wsContext(nullptr)
-, _isDestroyed(std::make_shared<bool>(false))
+, _isDestroyed(std::make_shared<std::atomic<bool>>(false))
 , _delegate(nullptr)
 , _SSLConnection(0)
 , _wsProtocols(nullptr)
@@ -327,7 +327,7 @@ WebSocket::WebSocket()
 
     __websocketInstances->push_back(this);
     
-    std::shared_ptr<bool> isDestroyed = _isDestroyed;
+    std::shared_ptr<std::atomic<bool>> isDestroyed = _isDestroyed;
     _resetDirectorListener = Director::getInstance()->getEventDispatcher()->addCustomEventListener(Director::EVENT_RESET, [this, isDestroyed](EventCustom*){
         if (*isDestroyed)
             return;
@@ -815,7 +815,7 @@ void WebSocket::onClientReceivedData(void* in, ssize_t len)
             frameData->push_back('\0');
         }
 
-        std::shared_ptr<bool> isDestroyed = _isDestroyed;
+        std::shared_ptr<std::atomic<bool>> isDestroyed = _isDestroyed;
         _wsHelper->sendMessageToCocosThread([this, frameData, frameSize, isBinary, isDestroyed](){
             // In UI thread
             LOGD("Notify data len %d to Cocos thread.\n", (int)frameSize);
@@ -851,7 +851,7 @@ void WebSocket::onConnectionOpened()
     _readyState = State::OPEN;
     _readStateMutex.unlock();
 
-    std::shared_ptr<bool> isDestroyed = _isDestroyed;
+    std::shared_ptr<std::atomic<bool>> isDestroyed = _isDestroyed;
     _wsHelper->sendMessageToCocosThread([this, isDestroyed](){
         if (*isDestroyed)
         {
@@ -872,7 +872,7 @@ void WebSocket::onConnectionError()
     _readyState = State::CLOSING;
     _readStateMutex.unlock();
 
-    std::shared_ptr<bool> isDestroyed = _isDestroyed;
+    std::shared_ptr<std::atomic<bool>> isDestroyed = _isDestroyed;
     _wsHelper->sendMessageToCocosThread([this, isDestroyed](){
         if (*isDestroyed)
         {
@@ -900,7 +900,7 @@ void WebSocket::onConnectionClosed()
     _readStateMutex.unlock();
 
     _wsHelper->quitWebSocketThread();
-    std::shared_ptr<bool> isDestroyed = _isDestroyed;
+    std::shared_ptr<std::atomic<bool>> isDestroyed = _isDestroyed;
     _wsHelper->sendMessageToCocosThread([this, isDestroyed](){
         if (*isDestroyed)
         {

--- a/cocos/network/WebSocket.h
+++ b/cocos/network/WebSocket.h
@@ -34,6 +34,7 @@
 #include <vector>
 #include <mutex>
 #include <memory>  // for std::shared_ptr
+#include <atomic>
 
 #include "platform/CCPlatformMacros.h"
 #include "platform/CCStdC.h"
@@ -238,7 +239,7 @@ private:
 
     struct lws*         _wsInstance;
     struct lws_context* _wsContext;
-    std::shared_ptr<bool> _isDestroyed;
+    std::shared_ptr<std::atomic<bool>> _isDestroyed;
     Delegate* _delegate;
     int _SSLConnection;
     struct lws_protocols* _wsProtocols;


### PR DESCRIPTION
The reference count field in shared_ptr is thread safe but the value field is not. So we need to wrap a std::atomic for preventing potential thread racing.

Refer to http://en.cppreference.com/w/cpp/memory/shared_ptr/atomic

If multiple threads of execution access the same std::shared_ptr object without synchronization and any of those accesses uses a non-const member function of shared_ptr then a data race will occur unless all such access is performed through these functions, which are overloads of the corresponding atomic access functions (std::atomic_load, std::atomic_store, etc.)
Note that the control block of a shared_ptr is thread-safe: different std::shared_ptr objects can be accessed using mutable operations, such as operator= or reset, simultaneously by multiple threads, even when these instances are copies, and share the same control block internally.
