### PR TITLE
Allow inherit form platform fileutils

### DIFF
--- a/cocos/base/ccConfig.h
+++ b/cocos/base/ccConfig.h
@@ -393,4 +393,8 @@ THE SOFTWARE.
 # define CC_ALLOCATOR_GLOBAL_NEW_DELETE cocos2d::allocator::AllocatorStrategyGlobalSmallBlock
 #endif
 
+#ifndef CC_FILEUTILS_APPLE_ENABLE_OBJC
+#define CC_FILEUTILS_APPLE_ENABLE_OBJC  1
+#endif
+
 #endif // __CCCONFIG_H__

--- a/cocos/platform/apple/CCFileUtils-apple.h
+++ b/cocos/platform/apple/CCFileUtils-apple.h
@@ -56,7 +56,7 @@ public:
 
     virtual ValueVector getValueVectorFromFile(const std::string& filename) override;
 #if CC_FILEUTILS_APPLE_ENABLE_OBJC
-    CC_DEPRECATED_ATTRIBUTE void setBundle(NSBundle* bundle);
+    void setBundle(NSBundle* bundle);
 #endif
 private:
     virtual bool isFileExistInternal(const std::string& filePath) const override;

--- a/cocos/platform/apple/CCFileUtils-apple.h
+++ b/cocos/platform/apple/CCFileUtils-apple.h
@@ -54,13 +54,15 @@ public:
     virtual bool writeToFile(const ValueMap& dict, const std::string& fullPath) override;
 
     virtual ValueVector getValueVectorFromFile(const std::string& filename) override;
-    void setBundle(NSBundle* bundle);
+#ifdef FILEUTILS_APPLE_ENABLE_OBJC
+    CC_DEPRECATED_ATTRIBUTE void setBundle(NSBundle* bundle);
+#endif
 private:
     virtual bool isFileExistInternal(const std::string& filePath) const override;
     virtual bool removeDirectory(const std::string& dirPath) override;
 
-    NSBundle* getBundle() const;
-    NSBundle* _bundle;
+    struct IMPL;
+    IMPL* pimpl_;
 };
 
 // end of platform group

--- a/cocos/platform/apple/CCFileUtils-apple.h
+++ b/cocos/platform/apple/CCFileUtils-apple.h
@@ -26,6 +26,7 @@
 #ifndef __CC_FILEUTILS_APPLE_H__
 #define __CC_FILEUTILS_APPLE_H__
 
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -62,7 +63,7 @@ private:
     virtual bool removeDirectory(const std::string& dirPath) override;
 
     struct IMPL;
-    IMPL* pimpl_;
+    std::unique_ptr<IMPL> pimpl_;
 };
 
 // end of platform group

--- a/cocos/platform/apple/CCFileUtils-apple.h
+++ b/cocos/platform/apple/CCFileUtils-apple.h
@@ -55,7 +55,7 @@ public:
     virtual bool writeToFile(const ValueMap& dict, const std::string& fullPath) override;
 
     virtual ValueVector getValueVectorFromFile(const std::string& filename) override;
-#ifdef FILEUTILS_APPLE_ENABLE_OBJC
+#if CC_FILEUTILS_APPLE_ENABLE_OBJC
     CC_DEPRECATED_ATTRIBUTE void setBundle(NSBundle* bundle);
 #endif
 private:

--- a/cocos/platform/apple/CCFileUtils-apple.mm
+++ b/cocos/platform/apple/CCFileUtils-apple.mm
@@ -320,7 +320,7 @@ static void addObjectToNSDict(const std::string& key, const Value& value, NSMuta
 FileUtilsApple::FileUtilsApple() : pimpl_(new IMPL([NSBundle mainBundle])) {
 }
 
-#ifdef FILEUTILS_APPLE_ENABLE_OBJC
+#if CC_FILEUTILS_APPLE_ENABLE_OBJC
 void FileUtilsApple::setBundle(NSBundle* bundle) {
     pimpl_->setBundle(bundle);
 }

--- a/cocos/platform/apple/CCFileUtils-apple.mm
+++ b/cocos/platform/apple/CCFileUtils-apple.mm
@@ -317,8 +317,7 @@ static void addObjectToNSDict(const std::string& key, const Value& value, NSMuta
     }
 }
 
-FileUtilsApple::FileUtilsApple() {
-    pimpl_ = new IMPL([NSBundle mainBundle]);
+FileUtilsApple::FileUtilsApple() : pimpl_(new IMPL([NSBundle mainBundle])) {
 }
 
 #ifdef FILEUTILS_APPLE_ENABLE_OBJC

--- a/cocos/platform/linux/CCFileUtils-linux.h
+++ b/cocos/platform/linux/CCFileUtils-linux.h
@@ -45,7 +45,9 @@ NS_CC_BEGIN
 class CC_DLL FileUtilsLinux : public FileUtils
 {
     friend class FileUtils;
+protected:
     FileUtilsLinux();
+private:
     std::string _writablePath;
 public:
     /* override functions */

--- a/cocos/platform/win32/CCFileUtils-win32.h
+++ b/cocos/platform/win32/CCFileUtils-win32.h
@@ -45,6 +45,7 @@ NS_CC_BEGIN
 class CC_DLL FileUtilsWin32 : public FileUtils
 {
     friend class FileUtils;
+protected:
     FileUtilsWin32();
 public:
     /* override functions */

--- a/cocos/platform/winrt/CCFileUtilsWinRT.h
+++ b/cocos/platform/winrt/CCFileUtilsWinRT.h
@@ -43,6 +43,7 @@ NS_CC_BEGIN
 class CC_DLL CCFileUtilsWinRT : public FileUtils
 {
     friend class FileUtils;
+protected:
     CCFileUtilsWinRT();
 public:
     /* override functions */


### PR DESCRIPTION
The doc for FileUtils::setDelegate() says:

```
 * You can inherit from platform dependent implementation of FileUtils, such as FileUtilsAndroid,
 * and use this function to set delegate, then FileUtils will invoke delegate's implementation.
 * For example, your resources are encrypted, so you need to decrypt it after reading data from
 * resources, then you can implement all getXXX functions, and engine will invoke your own getXX
 * functions when reading data of resources.
```

But the constructor of  FileUtilsLinux, FileUtilsWin32 and FileUtilsWinRT are private.

So make these constructors protected which allows inherit from them.
