### PR TITLE
Fixed Renderer::checkVisibility() to support all cameras

### DIFF
--- a/cocos/2d/CCCamera.cpp
+++ b/cocos/2d/CCCamera.cpp
@@ -332,6 +332,16 @@ bool Camera::isVisibleInFrustum(const AABB* aabb) const
     return !_frustum.isOutOfFrustum(*aabb);
 }
 
+bool Camera::isVisibleInFrustum(const Rect& rect) const
+{
+    if (_frustumDirty)
+    {
+        _frustum.initFrustum(this);
+        _frustumDirty = false;
+    }
+    return !_frustum.isOutOfFrustum(rect);
+}
+
 float Camera::getDepthInView(const Mat4& transform) const
 {
     Mat4 camWorldMat = getNodeToWorldTransform();

--- a/cocos/2d/CCCamera.h
+++ b/cocos/2d/CCCamera.h
@@ -194,6 +194,11 @@ public:
     bool isVisibleInFrustum(const AABB* aabb) const;
     
     /**
+     * Is this rect visible in frustum
+     */
+    bool isVisibleInFrustum(const Rect& rect) const;
+    
+    /**
      * Get object depth towards camera
      */
     float getDepthInView(const Mat4& transform) const;

--- a/cocos/3d/CCFrustum.cpp
+++ b/cocos/3d/CCFrustum.cpp
@@ -54,6 +54,30 @@ bool Frustum::isOutOfFrustum(const AABB& aabb) const
     return false;
 }
 
+bool Frustum::isOutOfFrustum(const Rect& rect)
+{
+    if (_initialized)
+    {
+        Vec3 point;
+        
+        int plane = _clipZ ? 6 : 4;
+        float minX = rect.getMinX();
+        float maxX = rect.getMaxX();
+        float minY = rect.getMinY();
+        float maxY = rect.getMaxY();
+        for (int i = 0; i < plane; i++)
+        {
+            const Vec3& normal = _plane[i].getNormal();
+            point.x = normal.x < 0 ? maxX : minX;
+            point.y = normal.y < 0 ? maxY : minY;
+            
+            if (_plane[i].getSide(point) == PointSide::FRONT_PLANE )
+                return true;
+        }
+    }
+    return false;
+}
+
 bool Frustum::isOutOfFrustum(const OBB& obb) const
 {
     if (_initialized)

--- a/cocos/3d/CCFrustum.h
+++ b/cocos/3d/CCFrustum.h
@@ -30,6 +30,7 @@
 #include "3d/CCAABB.h"
 #include "3d/CCOBB.h"
 #include "3d/CCPlane.h"
+#include "math/CCGeometry.h"
 
 NS_CC_BEGIN
 
@@ -64,6 +65,10 @@ public:
      * is obb out of frustum
      */
     bool isOutOfFrustum(const OBB& obb) const;
+    /**
+     * is rect out of frustum
+     */
+    bool isOutOfFrustum(const Rect& rect);
 
     /**
      * get & set z clip. if bclipZ == true use near and far plane

--- a/cocos/renderer/CCRenderer.cpp
+++ b/cocos/renderer/CCRenderer.cpp
@@ -872,34 +872,15 @@ void Renderer::flushTriangles()
 // helpers
 bool Renderer::checkVisibility(const Mat4 &transform, const Size &size)
 {
-    auto scene = Director::getInstance()->getRunningScene();
-    
-    //If draw to Rendertexture, return true directly.
-    // only cull the default camera. The culling algorithm is valid for default camera.
-    if (!scene || (scene && scene->_defaultCamera != Camera::getVisitingCamera()))
-        return true;
-
     auto director = Director::getInstance();
-    Rect visiableRect(director->getVisibleOrigin(), director->getVisibleSize());
+    Rect visibleRect( director->getVisibleOrigin(), director->getVisibleSize());
     
-    // transform center point to screen space
-    float hSizeX = size.width/2;
-    float hSizeY = size.height/2;
-    Vec3 v3p(hSizeX, hSizeY, 0);
-    transform.transformPoint(&v3p);
-    Vec2 v2p = Camera::getVisitingCamera()->projectGL(v3p);
-
-    // convert content size to world coordinates
-    float wshw = std::max(fabsf(hSizeX * transform.m[0] + hSizeY * transform.m[4]), fabsf(hSizeX * transform.m[0] - hSizeY * transform.m[4]));
-    float wshh = std::max(fabsf(hSizeX * transform.m[1] + hSizeY * transform.m[5]), fabsf(hSizeX * transform.m[1] - hSizeY * transform.m[5]));
+    auto camera = Camera::getVisitingCamera();
     
-    // enlarge visible rect half size in screen coord
-    visiableRect.origin.x -= wshw;
-    visiableRect.origin.y -= wshh;
-    visiableRect.size.width += wshw * 2;
-    visiableRect.size.height += wshh * 2;
-    bool ret = visiableRect.containsPoint(v2p);
-    return ret;
+    Rect rect(Vec2::ZERO, size);
+    rect = RectApplyTransform(rect, transform);
+    
+    return camera->isVisibleInFrustum(rect);
 }
 
 


### PR DESCRIPTION
Converted design resolution 2D content to 3D AABB for frustum check to better support non default cameras.
