### PR TITLE
spine should support normal blend mode

### DIFF
--- a/cocos/editor-support/spine/SkeletonRenderer.cpp
+++ b/cocos/editor-support/spine/SkeletonRenderer.cpp
@@ -219,6 +219,9 @@ void SkeletonRenderer::drawSkeleton (const Mat4 &transform, uint32_t transformFl
 				_batch->flush();
 				blendMode = slot->data->blendMode;
 				switch (slot->data->blendMode) {
+				case SP_BLEND_MODE_NORMAL:
+					GL::blendFunc(_premultipliedAlpha ? GL_ONE : GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+					break;
 				case SP_BLEND_MODE_ADDITIVE:
 					GL::blendFunc(_premultipliedAlpha ? GL_ONE : GL_SRC_ALPHA, GL_ONE);
 					break;


### PR DESCRIPTION
设置混合模式时，应该支持 normal，否则使用 _blendFunc 里面的混合模式，渲染有可能发生错误

测试动画：
[aitiwen.zip](https://github.com/cocos2d/cocos2d-x/files/189123/aitiwen.zip)

原先表现：（右边多了一个光点，没有隐藏起来）
![image](https://cloud.githubusercontent.com/assets/1503156/14039193/d0cb4474-f294-11e5-9fde-c97268dcd49f.png)

正确表现：（光点使用 src_alpha 混合后，就会变透明）
![image](https://cloud.githubusercontent.com/assets/1503156/14039182/b5da1dac-f294-11e5-9849-1c965a2d62e8.png)
