### PR TITLE
Allow plist and other ValueMap files be (easy) decrypted.

### DIFF
--- a/cocos/platform/apple/CCFileUtils-apple.mm
+++ b/cocos/platform/apple/CCFileUtils-apple.mm
@@ -403,7 +403,7 @@ static int unlink_cb(const char *fpath, const struct stat *sb, int typeflag, str
     {
         log("Fail to remove: %s ",fpath);
     }
-    
+
     return ret;
 }
 
@@ -445,21 +445,8 @@ std::string FileUtilsApple::getFullPathForDirectoryAndFilename(const std::string
 
 ValueMap FileUtilsApple::getValueMapFromFile(const std::string& filename)
 {
-    std::string fullPath = fullPathForFilename(filename);
-    NSString* path = [NSString stringWithUTF8String:fullPath.c_str()];
-    NSDictionary* dict = [NSDictionary dictionaryWithContentsOfFile:path];
-
-    ValueMap ret;
-
-    if (dict != nil)
-    {
-        for (id key in [dict allKeys])
-        {
-            id value = [dict objectForKey:key];
-            addValueToDict(key, value, ret);
-        }
-    }
-    return ret;
+    auto d(FileUtils::getInstance()->getDataFromFile(filename));
+    return getValueMapFromData(reinterpret_cast<char*>(d.getBytes()), static_cast<int>(d.getSize()));
 }
 
 ValueMap FileUtilsApple::getValueMapFromData(const char* filedata, int filesize)
@@ -489,19 +476,19 @@ bool FileUtilsApple::writeToFile(const ValueMap& dict, const std::string &fullPa
 
 bool FileUtils::writeValueMapToFile(const ValueMap& dict, const std::string& fullPath)
 {
-    
+
     //CCLOG("iOS||Mac Dictionary %d write to file %s", dict->_ID, fullPath.c_str());
     NSMutableDictionary *nsDict = [NSMutableDictionary dictionary];
-    
+
     for (auto iter = dict.begin(); iter != dict.end(); ++iter)
     {
         addObjectToNSDict(iter->first, iter->second, nsDict);
     }
-    
+
     NSString *file = [NSString stringWithUTF8String:fullPath.c_str()];
     // do it atomically
     [nsDict writeToFile:file atomically:YES];
-    
+
     return true;
 }
 
@@ -509,14 +496,14 @@ bool FileUtils::writeValueVectorToFile(const ValueVector& vecData, const std::st
 {
     NSString* path = [NSString stringWithUTF8String:fullPath.c_str()];
     NSMutableArray* array = [NSMutableArray array];
-    
+
     for (const auto &e : vecData)
     {
         addObjectToNSArray(e, array);
     }
-    
+
     [array writeToFile:path atomically:YES];
-    
+
     return true;
 }
 ValueVector FileUtilsApple::getValueVectorFromFile(const std::string& filename)


### PR DESCRIPTION
The origin implementation of `FileUtilsApple::getValueMapFromFile()` reads the contents of file and parse it by calling one Apple API.
This make it harder to decrypt user encrypted plist files.

This PR use the `FileUtils::getDataFromFile()` to read file data and then use `getValueMapFromData()`
to parse it into a ValueMap. Where `FileUtils::getDataFromFile()` can be overwrite by user's decoding file utils (say `DecodingFileUtils`).

I know that user's `DecodingFileUtils` can also overwrite `getValueMapFromFile`, but this pr make the author of `DecodingFileUtils` less suffering.
