### PR TITLE
fix: compile cpp-tests in release mode

### DIFF
--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIListViewTest/UIListViewTest.cpp
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIListViewTest/UIListViewTest.cpp
@@ -243,14 +243,14 @@ void UIListViewTest_Vertical::selectedItemEvent(Ref *pSender, ListView::EventTyp
         {
             ListView* listView = static_cast<ListView*>(pSender);
             auto item = listView->getItem(listView->getCurSelectedIndex());
-            CCLOG("select child start index = %d", item->getTag());
+            log("select child start index = %d", item->getTag());
             break;
         }
         case cocos2d::ui::ListView::EventType::ON_SELECTED_ITEM_END:
         {
             ListView* listView = static_cast<ListView*>(pSender);
             auto item = listView->getItem(listView->getCurSelectedIndex());
-            CCLOG("select child end index = %d", item->getTag());
+            log("select child end index = %d", item->getTag());
             break;
         }
         default:
@@ -458,14 +458,14 @@ void UIListViewTest_Horizontal::selectedItemEvent(Ref *pSender, ListView::EventT
         {
             ListView* listView = static_cast<ListView*>(pSender);
             auto item = listView->getItem(listView->getCurSelectedIndex());
-            CCLOG("select child start index = %d", item->getTag());
+            log("select child start index = %d", item->getTag());
             break;
         }
         case cocos2d::ui::ListView::EventType::ON_SELECTED_ITEM_END:
         {
             ListView* listView = static_cast<ListView*>(pSender);
             auto item = listView->getItem(listView->getCurSelectedIndex());
-            CCLOG("select child end index = %d", item->getTag());
+            log("select child end index = %d", item->getTag());
             break;
         }
         default:

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIScrollViewTest/UIScrollViewTest.cpp
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIScrollViewTest/UIScrollViewTest.cpp
@@ -667,9 +667,9 @@ bool UIScrollViewInnerSize::init()
         scrollView->setScrollBarPositionFromCorner(Vec2(2, 2));
         scrollView->setScrollBarColor(Color3B::WHITE);
         scrollView->setBackGroundColorType(Layout::BackGroundColorType::SOLID);
-        scrollView->setBackGroundColor(ccc3(150, 150, 100));
+        scrollView->setBackGroundColor(Color3B(150, 150, 100));
         scrollView->getInnerContainer()->setBackGroundColorType(Layout::BackGroundColorType::SOLID);
-        scrollView->getInnerContainer()->setBackGroundColor(ccc3(50, 100, 50));
+        scrollView->getInnerContainer()->setBackGroundColor(Color3B(50, 100, 50));
         scrollView->getInnerContainer()->setBackGroundColorOpacity(100);
         scrollView->setClippingEnabled(false);
         _uiLayer->addChild(scrollView);


### PR DESCRIPTION
replace some deprecated functions
use `log` instead of `CCLOG` in order to avoid Warnings when not using
some variables
