### PR TITLE
Add missing virtual destructor in ILocalizationManager

### DIFF
--- a/cocos/editor-support/cocostudio/LocalizationManager.h
+++ b/cocos/editor-support/cocostudio/LocalizationManager.h
@@ -13,6 +13,7 @@ namespace cocostudio {
     class ILocalizationManager
     {
     public:
+        virtual ~ILocalizationManager() = default;
         virtual bool initLanguageData(std::string file) = 0;
         virtual std::string getLocalizationString(std::string key) = 0;
     };


### PR DESCRIPTION
Hello, I get the following warning when I compile with Xcode 7.3:

```
cocos/editor-support/cocostudio/LocalizationManager.h:13:11: 'cocostudio::ILocalizationManager' has virtual functions but non-virtual destructor
```

This pull request adds missing virtual destructor in ILocalizationManager, and fixes it. Thanks!
