### PR TITLE
Animations with only one frame are allowed now.

### DIFF
--- a/cocos/editor-support/cocostudio/CCActionNode.cpp
+++ b/cocos/editor-support/cocostudio/CCActionNode.cpp
@@ -22,12 +22,12 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 ****************************************************************************/
 
-#include "cocostudio/CCActionNode.h"
-#include "cocostudio/CCActionFrameEasing.h"
+#include "editor-support/cocostudio/CCActionNode.h"
+#include "editor-support/cocostudio/CCActionFrameEasing.h"
 #include "ui/UIWidget.h"
 #include "ui/UIHelper.h"
 #include "ui/UILayout.h"
-#include "cocostudio/CocoLoader.h"
+#include "editor-support/cocostudio/CocoLoader.h"
 #include "base/ccUtils.h"
 
 using namespace cocos2d;

--- a/cocos/editor-support/cocostudio/CCActionNode.cpp
+++ b/cocos/editor-support/cocostudio/CCActionNode.cpp
@@ -22,12 +22,12 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 ****************************************************************************/
 
-#include "editor-support/cocostudio/CCActionNode.h"
-#include "editor-support/cocostudio/CCActionFrameEasing.h"
+#include "cocostudio/CCActionNode.h"
+#include "cocostudio/CCActionFrameEasing.h"
 #include "ui/UIWidget.h"
 #include "ui/UIHelper.h"
 #include "ui/UILayout.h"
-#include "editor-support/cocostudio/CocoLoader.h"
+#include "cocostudio/CocoLoader.h"
 #include "base/ccUtils.h"
 
 using namespace cocos2d;
@@ -454,26 +454,37 @@ Spawn * ActionNode::refreshActionProperty()
 
         Vector<FiniteTimeAction*> cSequenceArray;
         auto frameCount = cArray->size();
-        for (int i = 0; i < frameCount; i++)
-        {
-            auto frame = cArray->at(i);
-            if (i == 0)
-            {
-            }
-            else
-            {
-                auto srcFrame = cArray->at(i-1);
-                float duration = (frame->getFrameIndex() - srcFrame->getFrameIndex()) * getUnitTime();
-                Action* cAction = frame->getAction(duration);
-                if(cAction != nullptr)
-                cSequenceArray.pushBack(static_cast<FiniteTimeAction*>(cAction));
-            }
-        }
-        Sequence* cSequence = Sequence::create(cSequenceArray);
-        if (cSequence != nullptr)
-        {
-            cSpawnArray.pushBack(cSequence);
-        }
+		if(frameCount > 1)
+		{ 
+			for (int i = 0; i < frameCount; i++)
+			{
+				auto frame = cArray->at(i);
+				if (i == 0)
+				{
+				}
+				else
+				{
+					auto srcFrame = cArray->at(i-1);
+					float duration = (frame->getFrameIndex() - srcFrame->getFrameIndex()) * getUnitTime();
+					Action* cAction = frame->getAction(duration);
+					if(cAction != nullptr)
+					cSequenceArray.pushBack(static_cast<FiniteTimeAction*>(cAction));
+				}
+			}
+		}
+		else if (frameCount == 1)
+		{
+			auto frame = cArray->at(0);
+			float duration = 0.0f;
+			Action* cAction = frame->getAction(duration);
+			if (cAction != nullptr)
+				cSequenceArray.pushBack(static_cast<FiniteTimeAction*>(cAction));
+		}
+		Sequence* cSequence = Sequence::create(cSequenceArray);
+		if (cSequence != nullptr)
+		{
+			cSpawnArray.pushBack(cSequence);
+		}
     }
 
     if (_action == nullptr)


### PR DESCRIPTION
If an animation with only a frame is created on Cocos Studio UI 1.6, it is loaded in html5 [correctly](https://github.com/cocos2d/cocos2d-html5/pull/2884), but not in native now. Example:

![Cocos Studio 16 One Frame Animation](https://cloud.githubusercontent.com/assets/3737721/7534707/535903b0-f57d-11e4-93dc-7dffbf0a7379.png)

The behaviour is the same now.
