### PR TITLE
Fix memory leak in DataReaderHelper

### DIFF
--- a/cocos/editor-support/cocostudio/CCDataReaderHelper.cpp
+++ b/cocos/editor-support/cocostudio/CCDataReaderHelper.cpp
@@ -2287,8 +2287,7 @@ void DataReaderHelper::decodeNode(BaseData *node, const rapidjson::Value& json, 
         {
             if (movementBoneData->frameList.size() > 0)
             {
-                FrameData *frameData = new (std::nothrow) FrameData();
-                frameData = movementBoneData->frameList.at(framesizemusone);
+                auto frameData = movementBoneData->frameList.at(framesizemusone);
                 movementBoneData->addFrameData(frameData);
                 frameData->release();
                 frameData->frameID = movementBoneData->duration;


### PR DESCRIPTION
Hello, I found a memory leak in DataReaderHelper. The following code leaks memory:

``` cpp
if (movementBoneData->frameList.size() > 0)
{
    FrameData *frameData = new (std::nothrow) FrameData();       // The first 'frameData' is never used
    frameData = movementBoneData->frameList.at(framesizemusone); // it causes a memory leak right here
    movementBoneData->addFrameData(frameData);
    frameData->release();
    frameData->frameID = movementBoneData->duration;
}
```

This pull request removes unnecessary `new` call and fixes it.
Best wishes!
