### PR TITLE
Fixes wrong usage of std::vector's constructor in EventDispatcher::removeAllEventListener.

### DIFF
--- a/cocos/base/CCEventDispatcher.cpp
+++ b/cocos/base/CCEventDispatcher.cpp
@@ -1484,7 +1484,8 @@ void EventDispatcher::removeCustomEventListeners(const std::string& customEventN
 void EventDispatcher::removeAllEventListeners()
 {
     bool cleanMap = true;
-    std::vector<EventListener::ListenerID> types(_listenerMap.size());
+    std::vector<EventListener::ListenerID> types;
+    types.reserve(_listenerMap.size());
     
     for (const auto& e : _listenerMap)
     {


### PR DESCRIPTION
Please refer to http://www.cplusplus.com/reference/vector/vector/vector

std::vector<>(n), n means `resize` the vector to n size rather than `reserve`.
