### PR TITLE
Fix implicit conversion issues with Xcode 7.3

### DIFF
--- a/cocos/base/CCMap.h
+++ b/cocos/base/CCMap.h
@@ -346,7 +346,7 @@ public:
     {
         if (!_data.empty())
         {
-            ssize_t randIdx = RandomHelper::random_int<int>(0, _data.size()-1);
+            ssize_t randIdx = RandomHelper::random_int<int>(0, static_cast<int>(_data.size()) - 1);
             const_iterator randIter = _data.begin();
             std::advance(randIter , randIdx);
             return randIter->second;

--- a/cocos/base/CCVector.h
+++ b/cocos/base/CCVector.h
@@ -288,7 +288,7 @@ public:
     {
         if (!_data.empty())
         {
-            ssize_t randIdx = RandomHelper::random_int<int>(0,_data.size()-1);
+            ssize_t randIdx = RandomHelper::random_int<int>(0, static_cast<int>(_data.size()) - 1);
             return *(_data.begin() + randIdx);
         }
         return nullptr;


### PR DESCRIPTION
Hi, I get the following errors when building `cpp-tests Mac` target on Xcode 7.3 (since commit https://github.com/cocos2d/cocos2d-x/commit/107cef06672279d6332b226ad2f4b24e132ea48e):

```
cocos/base/CCVector.h:291:75: Implicit conversion loses integer precision: 'unsigned long' to 'int'
cocos/base/CCMap.h:349:76: Implicit conversion loses integer precision: 'unsigned long' to 'int'
```

This pull request fixes the implicit conversion issues.
