### PR TITLE
updated version and filesize to get latest winrt websockets builds

### DIFF
--- a/external/config.json
+++ b/external/config.json
@@ -1,6 +1,6 @@
 {
-    "version":"v3-deps-88",
-    "zip_file_size":"128300879",
+    "version":"v3-deps-89",
+    "zip_file_size":"128440074",
     "repo_name":"cocos2d-x-3rd-party-libs-bin",
     "repo_parent":"https://github.com/cocos2d/",
     "move_dirs":{


### PR DESCRIPTION
Updated config.json version and filesize to get latest winrt websockets builds

PR requested by @minggo https://github.com/cocos2d/cocos2d-x-3rd-party-libs-bin/pull/211
