### PR TITLE
Make PageView page turning event time tweak configurable.

### DIFF
--- a/cocos/ui/UIPageView.cpp
+++ b/cocos/ui/UIPageView.cpp
@@ -38,7 +38,8 @@ _currentPageIndex(-1),
 _childFocusCancelOffset(5.0f),
 _pageViewEventListener(nullptr),
 _pageViewEventSelector(nullptr),
-_eventCallback(nullptr)
+_eventCallback(nullptr),
+_autoScrollStopEpsilon(0.001f)
 {
 }
 
@@ -177,6 +178,11 @@ bool PageView::isUsingCustomScrollThreshold()const
     return false;
 }
 
+void PageView::setAutoScrollStopEpsilon(float epsilon)
+{
+    _autoScrollStopEpsilon = epsilon;
+}
+
 void PageView::moveInnerContainer(const Vec2& deltaMove, bool canStartBounceBack)
 {
     ListView::moveInnerContainer(deltaMove, canStartBounceBack);
@@ -263,7 +269,7 @@ void PageView::handleReleaseLogic(Touch *touch)
     
 float PageView::getAutoScrollStopEpsilon() const
 {
-    return 0.001;
+    return _autoScrollStopEpsilon;
 }
 
 void PageView::pageTurningEvent()

--- a/cocos/ui/UIPageView.h
+++ b/cocos/ui/UIPageView.h
@@ -341,6 +341,8 @@ public:
      */
     CC_DEPRECATED_ATTRIBUTE bool isUsingCustomScrollThreshold()const;
 
+    void setAutoScrollStopEpsilon(float epsilon);
+
 CC_CONSTRUCTOR_ACCESS:
     virtual bool init() override;
 
@@ -384,6 +386,7 @@ protected:
 #pragma warning (pop)
 #endif
     ccPageViewCallback _eventCallback;
+    float _autoScrollStopEpsilon;
 };
 
 }

--- a/cocos/ui/UIScrollView.cpp
+++ b/cocos/ui/UIScrollView.cpp
@@ -545,6 +545,11 @@ void ScrollView::processAutoScrolling(float deltaTime)
     Vec2 newPosition = _autoScrollStartPosition + (_autoScrollTargetDelta * percentage);
     bool reachedEnd = fabs(percentage - 1) <= this->getAutoScrollStopEpsilon();
     
+    if (reachedEnd)
+    {
+        newPosition = _autoScrollStartPosition + _autoScrollTargetDelta;
+    }
+
     if(_bounceEnabled)
     {
         // The new position is adjusted if out of boundary


### PR DESCRIPTION
This change allows user to tweak when the page turning event is raised.
Even with the existing tweak, it seemed to me that the event was raised a bit late. So instead of changing the hard-coded value, I added a way to set a different value for the tweak.
