### PR TITLE
Image::initWithRawData() support for more formats

### DIFF
--- a/cocos/platform/CCImage.cpp
+++ b/cocos/platform/CCImage.cpp
@@ -2155,7 +2155,7 @@ bool Image::initWithWebpData(const unsigned char * data, ssize_t dataLen)
 }
 
 
-bool Image::initWithRawData(const unsigned char * data, ssize_t dataLen, int width, int height, int bitsPerComponent, bool preMulti)
+bool Image::initWithRawData(const unsigned char * data, ssize_t dataLen, int width, int height, int bitsPerComponent, bool preMulti, Texture2D::PixelFormat renderFormat)
 {
     bool ret = false;
     do 
@@ -2165,10 +2165,10 @@ bool Image::initWithRawData(const unsigned char * data, ssize_t dataLen, int wid
         _height   = height;
         _width    = width;
         _hasPremultipliedAlpha = preMulti;
-        _renderFormat = Texture2D::PixelFormat::RGBA8888;
+        _renderFormat = renderFormat;
 
-        // only RGBA8888 supported
-        int bytesPerComponent = 4;
+        // only RGBA8888, BGRA8888 and RGB888 supported
+        int bytesPerComponent = (_renderFormat == Texture2D::PixelFormat::RGB888) ? 3 : 4;
         _dataLen = height * width * bytesPerComponent;
         _data = static_cast<unsigned char*>(malloc(_dataLen * sizeof(unsigned char)));
         CC_BREAK_IF(! _data);

--- a/cocos/platform/CCImage.cpp
+++ b/cocos/platform/CCImage.cpp
@@ -2155,6 +2155,11 @@ bool Image::initWithWebpData(const unsigned char * data, ssize_t dataLen)
 }
 
 
+bool Image::initWithRawData(const unsigned char * data, ssize_t dataLen, int width, int height, int bitsPerComponent, bool preMulti)
+{
+  return initWithRawData(data, dataLen, width, height, bitsPerComponent, preMulti, Texture2D::PixelFormat::RGBA8888);
+}
+
 bool Image::initWithRawData(const unsigned char * data, ssize_t dataLen, int width, int height, int bitsPerComponent, bool preMulti, Texture2D::PixelFormat renderFormat)
 {
     bool ret = false;

--- a/cocos/platform/CCImage.h
+++ b/cocos/platform/CCImage.h
@@ -117,8 +117,9 @@ public:
     */
     bool initWithImageData(const unsigned char * data, ssize_t dataLen);
 
-    // @warning kFmtRawData only support RGBA8888
-    bool initWithRawData(const unsigned char * data, ssize_t dataLen, int width, int height, int bitsPerComponent, bool preMulti = false, Texture2D::PixelFormat renderFormat = Texture2D::PixelFormat::RGBA8888);
+    // @warning kFmtRawData only support RGBA8888, BGRA8888 and RGB888
+    bool initWithRawData(const unsigned char * data, ssize_t dataLen, int width, int height, int bitsPerComponent, bool preMulti = false);
+    bool initWithRawData(const unsigned char * data, ssize_t dataLen, int width, int height, int bitsPerComponent, bool preMulti, Texture2D::PixelFormat renderFormat);
 
     // Getters
     inline unsigned char *   getData()               { return _data; }

--- a/cocos/platform/CCImage.h
+++ b/cocos/platform/CCImage.h
@@ -118,7 +118,7 @@ public:
     bool initWithImageData(const unsigned char * data, ssize_t dataLen);
 
     // @warning kFmtRawData only support RGBA8888
-    bool initWithRawData(const unsigned char * data, ssize_t dataLen, int width, int height, int bitsPerComponent, bool preMulti = false);
+    bool initWithRawData(const unsigned char * data, ssize_t dataLen, int width, int height, int bitsPerComponent, bool preMulti = false, Texture2D::PixelFormat renderFormat = Texture2D::PixelFormat::RGBA8888);
 
     // Getters
     inline unsigned char *   getData()               { return _data; }


### PR DESCRIPTION
Supports RGBA8888 (as usual), plus additional support for BGRA8888, and RGB888.
