### PR TITLE
Fix deprecation warnings in tests

### DIFF
--- a/tests/cpp-tests/Classes/ExtensionsTest/CocoStudioActionTimelineTest/ActionTimelineTestScene.cpp
+++ b/tests/cpp-tests/Classes/ExtensionsTest/CocoStudioActionTimelineTest/ActionTimelineTestScene.cpp
@@ -746,7 +746,7 @@ std::string TestActionTimelinePlayableFrame::title() const
 
 void TestActionTimelineIssueWith2SameActionInOneNode::onEnter()
 {
-    CCFileUtils::getInstance()->addSearchPath("ActionTimeline");
+    FileUtils::getInstance()->addSearchPath("ActionTimeline");
     ActionTimelineBaseTest::onEnter();
 
     Node* node = CSLoader::createNode("ani2.csb");

--- a/tests/cpp-tests/Classes/ShaderTest/ShaderTest.cpp
+++ b/tests/cpp-tests/Classes/ShaderTest/ShaderTest.cpp
@@ -402,15 +402,14 @@ bool SpriteBlur::initWithTexture(Texture2D* texture, const Rect& rect)
 
 void SpriteBlur::initGLProgram()
 {
-    GLchar * fragSource = nullptr;
 #if (CC_TARGET_PLATFORM != CC_PLATFORM_WINRT)
-    fragSource = (GLchar*) String::createWithContentsOfFile(
-                                FileUtils::getInstance()->fullPathForFilename("Shaders/example_Blur.fsh").c_str())->getCString();  
+    std::string fragSource = FileUtils::getInstance()->getStringFromFile(
+        FileUtils::getInstance()->fullPathForFilename("Shaders/example_Blur.fsh"));
 #else
-    fragSource = (GLchar*)String::createWithContentsOfFile(
-								FileUtils::getInstance()->fullPathForFilename("Shaders/example_Blur_winrt.fsh").c_str())->getCString();
+    std::string fragSource = FileUtils::getInstance()->getStringFromFile(
+        FileUtils::getInstance()->fullPathForFilename("Shaders/example_Blur_winrt.fsh"));
 #endif
-    auto program = GLProgram::createWithByteArrays(ccPositionTextureColor_noMVP_vert, fragSource);
+    auto program = GLProgram::createWithByteArrays(ccPositionTextureColor_noMVP_vert, fragSource.data());
 
     auto glProgramState = GLProgramState::getOrCreateWithGLProgram(program);
     setGLProgramState(glProgramState);

--- a/tests/cpp-tests/Classes/ShaderTest/ShaderTest2.cpp
+++ b/tests/cpp-tests/Classes/ShaderTest/ShaderTest2.cpp
@@ -540,7 +540,7 @@ bool EffectSpriteLamp::init()
         this->addChild(_lightSprite);
         _lightSprite->setPosition(Vec2(pos.x, s.height- pos.y));
         Mat4 mat = _sprite->getNodeToWorldTransform();
-        Point lightPosInLocalSpace=PointApplyAffineTransform(Vec2(pos.x, pos.y),_sprite->worldToNodeTransform());
+        Point lightPosInLocalSpace = PointApplyAffineTransform(Vec2(pos.x, pos.y), _sprite->getWorldToNodeAffineTransform());
         lampEffect->setLightColor(Color4F(1,1,1,1));
         lampEffect->setLightPos(Vec3(lightPosInLocalSpace.x, lightPosInLocalSpace.y, 50));
         lampEffect->setKBump(2);
@@ -567,7 +567,7 @@ void EffectSpriteLamp::onTouchesBegan(const std::vector<Touch*>& touches, Event 
         _lightSprite->setPosition(Vec2( loc_winSpace.x,  s.height - loc_winSpace.y));
         Vec3 pos(loc_winSpace.x,loc_winSpace.y, 50);
         Mat4 mat = _sprite->getNodeToWorldTransform();
-        Point lightPosInLocalSpace=PointApplyAffineTransform(Vec2(pos.x, pos.y),_sprite->worldToNodeTransform());
+        Point lightPosInLocalSpace = PointApplyAffineTransform(Vec2(pos.x, pos.y), _sprite->getWorldToNodeAffineTransform());
         ((EffectNormalMapped*)_effect)->setLightPos(Vec3(lightPosInLocalSpace.x, lightPosInLocalSpace.y, 50));
     }
 }
@@ -582,7 +582,7 @@ void EffectSpriteLamp::onTouchesMoved(const std::vector<Touch*>& touches, Event 
         _lightSprite->setPosition(Vec2( loc_winSpace.x, s.height - loc_winSpace.y));
         Vec3 pos(loc_winSpace.x,loc_winSpace.y, 50);
         Mat4 mat = _sprite->getNodeToWorldTransform();
-        Point lightPosInLocalSpace=PointApplyAffineTransform(Vec2(pos.x, pos.y),_sprite->worldToNodeTransform());
+        Point lightPosInLocalSpace = PointApplyAffineTransform(Vec2(pos.x, pos.y), _sprite->getWorldToNodeAffineTransform());
         ((EffectNormalMapped*)_effect)->setLightPos(Vec3(lightPosInLocalSpace.x, lightPosInLocalSpace.y, 50));
     }
 }
@@ -597,7 +597,7 @@ void EffectSpriteLamp::onTouchesEnded(const std::vector<Touch*>& touches, Event 
         _lightSprite->setPosition(Vec2( loc_winSpace.x, s.height - loc_winSpace.y));
         Vec3 pos(loc_winSpace.x,loc_winSpace.y, 50);
         Mat4 mat = _sprite->getNodeToWorldTransform();
-        Point lightPosInLocalSpace=PointApplyAffineTransform(Vec2(pos.x, pos.y),_sprite->worldToNodeTransform());
+        Point lightPosInLocalSpace = PointApplyAffineTransform(Vec2(pos.x, pos.y), _sprite->getWorldToNodeAffineTransform());
         ((EffectNormalMapped*)_effect)->setLightPos(Vec3(lightPosInLocalSpace.x, lightPosInLocalSpace.y, 50));
     }
 }

--- a/tests/cpp-tests/Classes/UnitTest/RefPtrTest.cpp
+++ b/tests/cpp-tests/Classes/UnitTest/RefPtrTest.cpp
@@ -14,7 +14,7 @@ void RefPtrTest::onEnter()
         CC_ASSERT(nullptr == ref1.get());
 
         // Parameter constructor
-        RefPtr<__String> ref2(cocos2d::String::create("Hello"));
+        RefPtr<__String> ref2(__String::create("Hello"));
         CC_ASSERT(strcmp("Hello", ref2->getCString()) == 0);
         CC_ASSERT(2 == ref2->getReferenceCount());
 
@@ -201,7 +201,7 @@ void RefPtrTest::onEnter()
     
     // TEST(dynamicPointerCast)
     {
-        RefPtr<__String> ref1 = cocos2d::String::create("Hello");
+        RefPtr<__String> ref1 = __String::create("Hello");
         CC_ASSERT(2 == ref1->getReferenceCount());
         
         RefPtr<Ref> ref2 = dynamic_pointer_cast<Ref>(ref1);


### PR DESCRIPTION
This pull request cleans up several deprecation warnings when building cpp-tests with Clang:

```
cpp-tests/Classes/ExtensionsTest/CocoStudioActionTimelineTest/ActionTimelineTestScene.cpp:749:16: 'CCFileUtils' is deprecated
cpp-tests/Classes/ShaderTest/ShaderTest.cpp:407:34: 'String' is deprecated
cpp-tests/Classes/ShaderTest/ShaderTest2.cpp:543:90: 'worldToNodeTransform' is deprecated
cpp-tests/Classes/ShaderTest/ShaderTest2.cpp:570:90: 'worldToNodeTransform' is deprecated
cpp-tests/Classes/ShaderTest/ShaderTest2.cpp:585:90: 'worldToNodeTransform' is deprecated
cpp-tests/Classes/ShaderTest/ShaderTest2.cpp:600:90: 'worldToNodeTransform' is deprecated
cpp-tests/Classes/UnitTest/RefPtrTest.cpp:17:46: 'String' is deprecated
cpp-tests/Classes/UnitTest/RefPtrTest.cpp:204:48: 'String' is deprecated
```
