### PR TITLE
Fixed typo in UILayout using clipping rect x instead of y coordinate.

### DIFF
--- a/cocos/ui/UILayout.cpp
+++ b/cocos/ui/UILayout.cpp
@@ -494,7 +494,7 @@ const Rect& Layout::getClippingRect()
             float bottomOffset = worldPos.y - parentClippingRect.origin.y;
             if (bottomOffset < 0.0f)
             {
-                finalY = parentClippingRect.origin.x;
+                finalY = parentClippingRect.origin.y;
                 finalHeight += bottomOffset;
             }
             if (finalWidth < 0.0f)


### PR DESCRIPTION
The getClippingRect() calculation returns an incorrect origin based on a parent clipping rect, due to calculating finalY using the parent's X origin. This appears to be a simple typo, and replacing this with the Y coordinate returns the correct clipping rect.
