### PR TITLE
v3.11 WINRT add missing _USRJSSTATIC preprocessor define

### DIFF
--- a/cocos/2d/win10_props/cocos2d_win10.props
+++ b/cocos/2d/win10_props/cocos2d_win10.props
@@ -10,7 +10,7 @@
       <AdditionalIncludeDirectories>$(EngineRoot)cocos\editor-support;$(EngineRoot)cocos\platform\winrt;$(EngineRoot)external\$(COCOS2D_PLATFORM)-specific\angle\include;$(EngineRoot)external\freetype2\include\$(COCOS2D_PLATFORM)\freetype2;$(EngineRoot)external\curl\include\$(COCOS2D_PLATFORM);$(EngineRoot)external\websockets\include\$(COCOS2D_PLATFORM);$(EngineRoot)external\chipmunk\include;$(EngineRoot)external\sqlite3\include;$(EngineRoot)cocos;$(EngineRoot)extensions;$(EngineRoot)external;$(EngineRoot)external\edtaa3func;$(EngineRoot)external\unzip;$(EngineRoot)external\tinyxml2;$(EngineRoot);$(EngineRoot)external\ConvertUTF;$(EngineRoot)external\xxhash;$(EngineRoot)external\poly2tri;$(EngineRoot)external\poly2tri\common;$(EngineRoot)external\poly2tri\sweep;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <ClCompile>
-      <PreprocessorDefinitions>WINRT;_VARIADIC_MAX=10;NOMINMAX;GL_GLEXT_PROTOTYPES;_CRT_SECURE_NO_WARNINGS;_SCL_SECURE_NO_WARNINGS;_UNICODE;UNICODE;RAPIDJSON_ENDIAN=RAPIDJSON_LITTLEENDIAN;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WINRT;_VARIADIC_MAX=10;NOMINMAX;GL_GLEXT_PROTOTYPES;_CRT_SECURE_NO_WARNINGS;_SCL_SECURE_NO_WARNINGS;_UNICODE;UNICODE;RAPIDJSON_ENDIAN=RAPIDJSON_LITTLEENDIAN;_USRJSSTATIC;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <CompileAsWinRT>true</CompileAsWinRT>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <MinimalRebuild>false</MinimalRebuild>

--- a/cocos/2d/winrt_8.1_props/cocos2d_winrt_8.1.props
+++ b/cocos/2d/winrt_8.1_props/cocos2d_winrt_8.1.props
@@ -10,7 +10,7 @@
       <AdditionalIncludeDirectories>$(EngineRoot)cocos\editor-support;$(EngineRoot)external\$(COCOS2D_PLATFORM)-specific\angle\include;$(EngineRoot)external\freetype2\include\$(COCOS2D_PLATFORM)\freetype2;$(EngineRoot)external\curl\include\$(COCOS2D_PLATFORM);$(EngineRoot)external\websockets\include\$(COCOS2D_PLATFORM);$(EngineRoot)external\chipmunk\include;$(EngineRoot)external\sqlite3\include;$(EngineRoot)cocos;$(EngineRoot)extensions;$(EngineRoot)external;$(EngineRoot)external\edtaa3func;$(EngineRoot)external\unzip;$(EngineRoot)external\tinyxml2;$(EngineRoot);$(EngineRoot)external\ConvertUTF;$(EngineRoot)external\xxhash;$(EngineRoot)external\poly2tri;$(EngineRoot)external\poly2tri\common;$(EngineRoot)external\poly2tri\sweep;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <ClCompile>
-      <PreprocessorDefinitions>WINRT;_VARIADIC_MAX=10;NOMINMAX;GL_GLEXT_PROTOTYPES;_CRT_SECURE_NO_WARNINGS;_SCL_SECURE_NO_WARNINGS;_UNICODE;UNICODE;RAPIDJSON_ENDIAN=RAPIDJSON_LITTLEENDIAN;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WINRT;_VARIADIC_MAX=10;NOMINMAX;GL_GLEXT_PROTOTYPES;_CRT_SECURE_NO_WARNINGS;_SCL_SECURE_NO_WARNINGS;_UNICODE;UNICODE;RAPIDJSON_ENDIAN=RAPIDJSON_LITTLEENDIAN;_USRJSSTATIC;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <CompileAsWinRT>true</CompileAsWinRT>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <MinimalRebuild>false</MinimalRebuild>


### PR DESCRIPTION
This pull request adds the missing _USRJSSTATIC preprocessor define which fixes several compiler warnings when compiling the JSB code. 
