### PR TITLE
Add missing dllexport to avoid warning C4275

### DIFF
--- a/cocos/editor-support/cocostudio/LocalizationManager.h
+++ b/cocos/editor-support/cocostudio/LocalizationManager.h
@@ -10,7 +10,7 @@ namespace cocostudio {
     /**
     *@brief Localization string manager interface template.
     */
-    class ILocalizationManager
+    class CC_STUDIO_DLL ILocalizationManager
     {
     public:
         virtual ~ILocalizationManager() = default;


### PR DESCRIPTION
Hello, I get the following warnings [C4275](https://msdn.microsoft.com/en-us/library/3tdb471s.aspx) when building `cocos2d-win32.sln` and `cocos2d-win8.1-universal.sln` with Visual Studio 2015:

```
cocos\editor-support/cocostudio/LocalizationManager.h(28): warning C4275: non dll-interface class 'cocostudio::ILocalizationManager' used as base for dll-interface class 'cocostudio::JsonLocalizationManager'
cocos\editor-support/cocostudio/LocalizationManager.h(56): warning C4275: non dll-interface class 'cocostudio::ILocalizationManager' used as base for dll-interface class 'cocostudio::BinLocalizationManager'
```

This pull request adds `CC_STUDIO_DLL` macro as a prefix to `ILocalizationManager` and fixes that.
