### PR TITLE
Add missing float suffix to avoid warning C4305

### DIFF
--- a/cocos/2d/CCLabel.cpp
+++ b/cocos/2d/CCLabel.cpp
@@ -1128,7 +1128,7 @@ void Label::enableBold()
     if (!_boldEnabled)
     {
         // bold is implemented with outline
-        enableShadow(Color4B::WHITE, Size(0.9,0), 0);
+        enableShadow(Color4B::WHITE, Size(0.9f, 0), 0);
         // add one to kerning
         setAdditionalKerning(_additionalKerning+1);
         _boldEnabled = true;

--- a/templates/cpp-template-default/Classes/AppDelegate.cpp
+++ b/templates/cpp-template-default/Classes/AppDelegate.cpp
@@ -51,7 +51,7 @@ bool AppDelegate::applicationDidFinishLaunching() {
     director->setDisplayStats(true);
 
     // set FPS. the default value is 1.0/60 if you don't call this
-    director->setAnimationInterval(1.0 / 60);
+    director->setAnimationInterval(1.0f / 60);
 
     // Set the design resolution
     glview->setDesignResolutionSize(designResolutionSize.width, designResolutionSize.height, ResolutionPolicy::NO_BORDER);

--- a/templates/js-template-default/frameworks/runtime-src/Classes/AppDelegate.cpp
+++ b/templates/js-template-default/frameworks/runtime-src/Classes/AppDelegate.cpp
@@ -77,7 +77,7 @@ bool AppDelegate::applicationDidFinishLaunching()
 }
 
     // set FPS. the default value is 1.0/60 if you don't call this
-    director->setAnimationInterval(1.0 / 60);
+    director->setAnimationInterval(1.0f / 60);
 
     ScriptingCore* sc = ScriptingCore::getInstance();
     sc->addRegisterCallback(register_all_cocos2dx);

--- a/templates/js-template-runtime/frameworks/runtime-src/Classes/AppDelegate.cpp
+++ b/templates/js-template-runtime/frameworks/runtime-src/Classes/AppDelegate.cpp
@@ -47,7 +47,7 @@ bool AppDelegate::applicationDidFinishLaunching()
     auto director = Director::getInstance();
 
     // set FPS. the default value is 1.0/60 if you don't call this
-    director->setAnimationInterval(1.0 / 60);
+    director->setAnimationInterval(1.0f / 60);
 
 #if (COCOS2D_DEBUG > 0) && (CC_CODE_IDE_DEBUG_SUPPORT > 0)
 

--- a/tests/cpp-empty-test/Classes/AppDelegate.cpp
+++ b/tests/cpp-empty-test/Classes/AppDelegate.cpp
@@ -95,7 +95,7 @@ bool AppDelegate::applicationDidFinishLaunching() {
     director->setDisplayStats(true);
 
     // set FPS. the default value is 1.0/60 if you don't call this
-    director->setAnimationInterval(1.0 / 60);
+    director->setAnimationInterval(1.0f / 60);
 
     // create a scene. it's an autorelease object
     auto scene = HelloWorld::scene();

--- a/tests/cpp-tests/Classes/AppDelegate.cpp
+++ b/tests/cpp-tests/Classes/AppDelegate.cpp
@@ -70,7 +70,7 @@ bool AppDelegate::applicationDidFinishLaunching()
     }
 
     director->setDisplayStats(true);
-    director->setAnimationInterval(1.0 / 60);
+    director->setAnimationInterval(1.0f / 60);
 
     auto screenSize = glview->getFrameSize();
     auto designSize = Size(480, 320);

--- a/tests/cpp-tests/Classes/Camera3DTest/Camera3DTest.cpp
+++ b/tests/cpp-tests/Classes/Camera3DTest/Camera3DTest.cpp
@@ -1452,7 +1452,7 @@ void CameraFrameBufferTest::onEnter()
     fbo->attachRenderTarget(rt);
     fbo->attachDepthStencilTarget(rtDS);
     auto sprite = Sprite::createWithTexture(fbo->getRenderTarget()->getTexture());
-    sprite->setScale(0.3);
+    sprite->setScale(0.3f);
     sprite->runAction(RepeatForever::create(RotateBy::create(1, 90)));
     sprite->setPosition(size.width/2, size.height/2);
     addChild(sprite);

--- a/tests/cpp-tests/Classes/ExtensionsTest/CocoStudioActionTimelineTest/ActionTimelineTestScene.cpp
+++ b/tests/cpp-tests/Classes/ExtensionsTest/CocoStudioActionTimelineTest/ActionTimelineTestScene.cpp
@@ -732,7 +732,7 @@ void TestActionTimelinePlayableFrame::onEnter()
     timeline_p->addFrame(frame_p2);
     action->addTimeline(timeline_p);
 
-    action->setTimeSpeed(0.2);
+    action->setTimeSpeed(0.2f);
     action->setDuration(65);
     node->runAction(action);
     action->gotoFrameAndPlay(0);

--- a/tests/cpp-tests/Classes/Scene3DTest/Scene3DTest.cpp
+++ b/tests/cpp-tests/Classes/Scene3DTest/Scene3DTest.cpp
@@ -249,7 +249,7 @@ bool Scene3DTestScene::init()
         ca = _gameCameras[CAMERA_WORLD_3D_SCENE] =
             Camera::createPerspective(60,
                                       visibleSize.width/visibleSize.height,
-                                      0.1,
+                                      0.1f,
                                       200);
         ca->setDepth(CAMERA_WORLD_3D_SCENE);
         ca->setName(s_CameraNames[CAMERA_WORLD_3D_SCENE]);
@@ -401,7 +401,7 @@ void Scene3DTestScene::createWorld3D()
     _player = Player::create("Sprite3DTest/girl.c3b",
                              _gameCameras[CAMERA_WORLD_3D_SCENE],
                              _terrain);
-    _player->setScale(0.08);
+    _player->setScale(0.08f);
     _player->setPositionY(_terrain->getHeight(_player->getPositionX(),
                                               _player->getPositionZ()));
     
@@ -494,7 +494,7 @@ void Scene3DTestScene::createUI()
         cb->setSelected(true);
         if (text) cb->setName(text);
         cb->setAnchorPoint(Vec2(0, 0.5));
-        cb->setScale(0.8);
+        cb->setScale(0.8f);
         cb->addClickEventListener([this](Ref* sender)
             {
                 auto index = static_cast<Node *>(sender)->getTag();

--- a/tests/cpp-tests/Classes/Sprite3DTest/Sprite3DTest.cpp
+++ b/tests/cpp-tests/Classes/Sprite3DTest/Sprite3DTest.cpp
@@ -2553,12 +2553,12 @@ Sprite3DNormalMappingTest::Sprite3DNormalMappingTest()
         static bool reverseDir = false;
         node->setPosition3D(Vec3(radius * cos(angle), 0.0f, radius * sin(angle)));
         if (reverseDir){
-            angle -= 0.01;
+            angle -= 0.01f;
             if (angle < 0.0)
                 reverseDir = false;
         }
         else{
-            angle += 0.01;
+            angle += 0.01f;
             if (3.14159 < angle)
                 reverseDir = true;
         }

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIListViewTest/UIListViewTest.cpp
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIListViewTest/UIListViewTest.cpp
@@ -25,7 +25,7 @@ _spawnCount(5), //swpanCount should > listview.width / tempalteWidth + 2
 _totalCount(50),
 _bufferZone(45), //bufferZone should be larger than List item width
 _updateTimer(0),
-_updateInterval(1.0 / 24), // you could tweak this value to adjust ListView data update rate
+_updateInterval(1.0f / 24), // you could tweak this value to adjust ListView data update rate
 _lastContentPosY(0), //use this value to detect if we are scrolling left or right
 _itemTemplateHeight(0)
 {
@@ -281,7 +281,7 @@ _spawnCount(4), //swpanCount should > listview.width / tempalteWidth + 2
 _totalCount(50),
 _bufferZone(140), //bufferZone should be larger than List item width
 _updateTimer(0),
-_updateInterval(1.0 / 24), // you could tweak this value to adjust ListView data update rate
+_updateInterval(1.0f / 24), // you could tweak this value to adjust ListView data update rate
 _lastContentPosX(0), //use this value to detect if we are scrolling left or right
 _itemTemplateWidth(0)
 {

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIPageViewTest/UIPageViewTest.cpp
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIPageViewTest/UIPageViewTest.cpp
@@ -571,7 +571,7 @@ bool UIPageViewDynamicAddAndRemoveTest::init()
 
         auto button4 = (ui::Button*)button3->clone();
         button4->setTitleText("Scroll to Page4");
-        button4->setNormalizedPosition(Vec2(0.85,0.5));
+        button4->setNormalizedPosition(Vec2(0.85f, 0.5f));
         button4->addClickEventListener([=](Ref* sender){
             pageView->scrollToItem(3);
             CCLOG("current page index = %zd", pageView->getCurrentPageIndex());
@@ -672,7 +672,7 @@ bool UIPageViewJumpToPageTest::init()
 
         //add buttons to jump to specific page
         auto button1 = ui::Button::create();
-        button1->setNormalizedPosition(Vec2(0.1, 0.75));
+        button1->setNormalizedPosition(Vec2(0.1f, 0.75f));
         button1->setTitleText("Jump to Page1");
         CCLOG("button1 content Size = %f, %f", button1->getContentSize().width,
               button1->getContentSize().height);
@@ -683,7 +683,7 @@ bool UIPageViewJumpToPageTest::init()
 
         auto button2 = static_cast<ui::Button*>(button1->clone());
         button2->setTitleText("Jump to Page2");
-        button2->setNormalizedPosition(Vec2(0.1, 0.65));
+        button2->setNormalizedPosition(Vec2(0.1f, 0.65f));
         CCLOG("button2 content Size = %f, %f", button2->getContentSize().width,
               button2->getContentSize().height);
         button2->addClickEventListener([=](Ref*){
@@ -693,7 +693,7 @@ bool UIPageViewJumpToPageTest::init()
 
         auto button3 = static_cast<ui::Button*>(button2->clone());
         button3->setTitleText("Jump to Page3");
-        button3->setNormalizedPosition(Vec2(0.9, 0.75));
+        button3->setNormalizedPosition(Vec2(0.9f, 0.75f));
         button3->addClickEventListener([=](Ref*){
             pageView->setCurrentPageIndex(2);
         });
@@ -701,7 +701,7 @@ bool UIPageViewJumpToPageTest::init()
 
         auto button4 = static_cast<ui::Button*>(button2->clone());
         button4->setTitleText("Jump to Page4");
-        button4->setNormalizedPosition(Vec2(0.9, 0.65));
+        button4->setNormalizedPosition(Vec2(0.9f, 0.65f));
         button4->addClickEventListener([=](Ref*){
             pageView->setCurrentPageIndex(3);
         });

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIPageViewTest/UIPageViewTest_Editor.cpp
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIPageViewTest/UIPageViewTest_Editor.cpp
@@ -39,7 +39,7 @@ bool UIPageViewTest_Editor::init()
 
         auto button1 = Button::create();
         button1->setTitleText("scrollToPage 3");
-        button1->setNormalizedPosition(Vec2(0.8,0.2));
+        button1->setNormalizedPosition(Vec2(0.8f, 0.2f));
         button1->addClickEventListener([=](Ref*){
             pageView->scrollToPage(2);
         });

--- a/tests/js-memory-gc-tests/project/Classes/AppDelegate.cpp
+++ b/tests/js-memory-gc-tests/project/Classes/AppDelegate.cpp
@@ -87,7 +87,7 @@ bool AppDelegate::applicationDidFinishLaunching()
     }
 
     // set FPS. the default value is 1.0/60 if you don't call this
-    director->setAnimationInterval(1.0 / 60);
+    director->setAnimationInterval(1.0f / 60);
 
     ScriptingCore* sc = ScriptingCore::getInstance();
     sc->addRegisterCallback(register_all_cocos2dx);

--- a/tests/js-tests/project/Classes/AppDelegate.cpp
+++ b/tests/js-tests/project/Classes/AppDelegate.cpp
@@ -88,7 +88,7 @@ bool AppDelegate::applicationDidFinishLaunching()
     }
 
     // set FPS. the default value is 1.0/60 if you don't call this
-    director->setAnimationInterval(1.0 / 60);
+    director->setAnimationInterval(1.0f / 60);
 
     ScriptingCore* sc = ScriptingCore::getInstance();
     sc->addRegisterCallback(register_all_cocos2dx);

--- a/tests/performance-tests/Classes/AppDelegate.cpp
+++ b/tests/performance-tests/Classes/AppDelegate.cpp
@@ -51,7 +51,7 @@ bool AppDelegate::applicationDidFinishLaunching() {
     director->setDisplayStats(true);
 
     // set FPS. the default value is 1.0/60 if you don't call this
-    director->setAnimationInterval(1.0 / 60);
+    director->setAnimationInterval(1.0f / 60);
 
     // Set the design resolution
     glview->setDesignResolutionSize(designResolutionSize.width, designResolutionSize.height, ResolutionPolicy::NO_BORDER);


### PR DESCRIPTION
This pull request fixes [C4305 warning](https://msdn.microsoft.com/en-us/library/0as1ke3f.aspx) about truncation 'double' to 'float' during compilation on Visual Studio 2015.

```
5>..\CCLabel.cpp(1131): warning C4305: 'argument': truncation from 'double' to 'float'
6>..\Classes\AppDelegate.cpp(98): warning C4305: 'argument': truncation from 'double' to 'float'
7>..\Classes\AppDelegate.cpp(73): warning C4305: 'argument': truncation from 'double' to 'float'
7>..\Classes\Camera3DTest\Camera3DTest.cpp(1455): warning C4305: 'argument': truncation from 'double' to 'float'
7>..\Classes\ExtensionsTest\CocoStudioActionTimelineTest\ActionTimelineTestScene.cpp(735): warning C4305: 'argument': truncation from 'double' to 'float'
7>..\Classes\Scene3DTest\Scene3DTest.cpp(253): warning C4305: 'argument': truncation from 'double' to 'float'
7>..\Classes\Scene3DTest\Scene3DTest.cpp(404): warning C4305: 'argument': truncation from 'double' to 'float'
7>..\Classes\Scene3DTest\Scene3DTest.cpp(497): warning C4305: 'argument': truncation from 'double' to 'float'
7>..\Classes\Sprite3DTest\Sprite3DTest.cpp(2556): warning C4305: '-=': truncation from 'double' to 'float'
7>..\Classes\Sprite3DTest\Sprite3DTest.cpp(2561): warning C4305: '+=': truncation from 'double' to 'float'
7>..\Classes\UITest\CocoStudioGUITest\UIListViewTest\UIListViewTest.cpp(31): warning C4305: 'initializing': truncation from 'double' to 'float'
7>..\Classes\UITest\CocoStudioGUITest\UIListViewTest\UIListViewTest.cpp(31): warning C4305: 'initializing': truncation from 'double' to 'float'
7>..\Classes\UITest\CocoStudioGUITest\UIPageViewTest\UIPageViewTest.cpp(574): warning C4305: 'argument': truncation from 'double' to 'float'
7>..\Classes\UITest\CocoStudioGUITest\UIPageViewTest\UIPageViewTest.cpp(675): warning C4305: 'argument': truncation from 'double' to 'float'
7>..\Classes\UITest\CocoStudioGUITest\UIPageViewTest\UIPageViewTest.cpp(686): warning C4305: 'argument': truncation from 'double' to 'float'
7>..\Classes\UITest\CocoStudioGUITest\UIPageViewTest\UIPageViewTest.cpp(696): warning C4305: 'argument': truncation from 'double' to 'float'
7>..\Classes\UITest\CocoStudioGUITest\UIPageViewTest\UIPageViewTest.cpp(704): warning C4305: 'argument': truncation from 'double' to 'float'
7>..\Classes\UITest\CocoStudioGUITest\UIPageViewTest\UIPageViewTest_Editor.cpp(42): warning C4305: 'argument': truncation from 'double' to 'float'
8>..\Classes\AppDelegate.cpp(91): warning C4305: 'argument' : truncation from 'double' to 'float'
```
