### PR TITLE
[BugFixes]Several serious bug fixes related to network/asset_manager

### DIFF
--- a/cocos/network/CCDownloader-apple.mm
+++ b/cocos/network/CCDownloader-apple.mm
@@ -553,9 +553,7 @@ namespace cocos2d { namespace network {
         
         if ('/' == [destPath characterAtIndex:0])
         {
-            // absolute path, need add prefix
-            NSString *prefix = @"file://";
-            destURL = [NSURL URLWithString:[prefix stringByAppendingString: destPath]];
+            destURL = [NSURL fileURLWithPath:destPath];
             break;
         }
         

--- a/cocos/network/HttpAsynConnection-apple.m
+++ b/cocos/network/HttpAsynConnection-apple.m
@@ -187,11 +187,17 @@
         CFDataRef errDataRef = SecTrustCopyExceptions(serverTrust);
         SecTrustSetExceptions(serverTrust, errDataRef);
         SecTrustEvaluate(serverTrust, &trustResult);
-        [(id)errDataRef release];
+        CFRelease(errDataRef);
     }
     [certData release];
-    [(id)certArrayRef release];
-    [(id)certArrayRef release];
+    if (cert)
+    {
+        CFRelease(cert);
+    }
+    if (certArrayRef) 
+    {
+        CFRelease(certArrayRef);
+    }
     //Did our custom trust chain evaluate successfully?
     return trustResult = kSecTrustResultUnspecified || trustResult == kSecTrustResultProceed;    
 }

--- a/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxDownloader.java
+++ b/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxDownloader.java
@@ -99,10 +99,7 @@ class FileTaskHandler extends FileAsyncHttpResponseHandler {
     @Override
     public void onFinish() {
         // onFinish called after onSuccess/onFailure
-        Runnable taskRunnable = _downloader.dequeue();
-        if (taskRunnable != null) {
-            Cocos2dxHelper.getActivity().runOnUiThread(taskRunnable);
-        }
+        _downloader.runNextTaskIfExists();
     }
 
     @Override
@@ -173,6 +170,7 @@ public class Cocos2dxDownloader {
     private int _countOfMaxProcessingTasks;
     private HashMap _taskMap = new HashMap();
     private Queue<Runnable> _taskQueue = new LinkedList<Runnable>();
+    private int _runningTaskCount = 0;
 
     void onProgress(final int id, final long downloadBytes, final long downloadNow, final long downloadTotal) {
         DownloadTask task = (DownloadTask)_taskMap.get(id);
@@ -277,12 +275,7 @@ public class Cocos2dxDownloader {
                 }
             }
         };
-        if (downloader._taskQueue.size() < downloader._countOfMaxProcessingTasks) {
-            Cocos2dxHelper.getActivity().runOnUiThread(taskRunnable);
-            downloader._taskQueue.add(null);
-        } else {
-            downloader._taskQueue.add(taskRunnable);
-        }
+        downloader.enqueueTask(taskRunnable);
     }
 
     public static void cancelAllRequests(final Cocos2dxDownloader downloader) {
@@ -304,14 +297,27 @@ public class Cocos2dxDownloader {
         });
     }
 
-    public Runnable dequeue() {
-        if (!_taskQueue.isEmpty() && _taskQueue.element() == null) {
-            _taskQueue.remove();
+
+    public void enqueueTask(Runnable taskRunnable) {
+        synchronized (_taskQueue) {
+            if (_runningTaskCount < _countOfMaxProcessingTasks) {
+                Cocos2dxHelper.getActivity().runOnUiThread(taskRunnable);
+                _runningTaskCount++;
+            } else {
+                _taskQueue.add(taskRunnable);
+            }
         }
-        if (!_taskQueue.isEmpty()) {
-            return _taskQueue.remove();
+    }
+
+    public void runNextTaskIfExists() {
+        synchronized (_taskQueue) {
+            Runnable taskRunnable = Cocos2dxDownloader.this._taskQueue.poll();
+            if (taskRunnable != null) {
+                Cocos2dxHelper.getActivity().runOnUiThread(taskRunnable);
+            } else {
+                _runningTaskCount--;
+            }
         }
-        return null;
     }
 
     native void nativeOnProgress(int id, int taskId, long dl, long dlnow, long dltotal);

--- a/extensions/assets-manager/AssetsManagerEx.h
+++ b/extensions/assets-manager/AssetsManagerEx.h
@@ -189,6 +189,9 @@ protected:
     
 private:
     void batchDownload();
+
+    // Called when one DownloadUnits finished
+    void onDownloadUnitsFinished();
     
     //! The event of the current AssetsManagerEx in event dispatcher
     std::string _eventName;

--- a/extensions/assets-manager/Manifest.cpp
+++ b/extensions/assets-manager/Manifest.cpp
@@ -160,16 +160,13 @@ bool Manifest::versionEquals(const Manifest *b) const
 std::unordered_map<std::string, Manifest::AssetDiff> Manifest::genDiff(const Manifest *b) const
 {
     std::unordered_map<std::string, AssetDiff> diff_map;
-    std::unordered_map<std::string, Asset> bAssets = b->getAssets();
+    const std::unordered_map<std::string, Asset> &bAssets = b->getAssets();
     
-    std::string key;
-    Asset valueA;
-    Asset valueB;
     std::unordered_map<std::string, Asset>::const_iterator valueIt, it;
     for (it = _assets.begin(); it != _assets.end(); ++it)
     {
-        key = it->first;
-        valueA = it->second;
+        const auto &key = it->first;
+        const auto &valueA = it->second;
         
         // Deleted
         valueIt = bAssets.find(key);
@@ -182,7 +179,7 @@ std::unordered_map<std::string, Manifest::AssetDiff> Manifest::genDiff(const Man
         }
         
         // Modified
-        valueB = valueIt->second;
+        const auto &valueB = valueIt->second;
         if (valueA.md5 != valueB.md5) {
             AssetDiff diff;
             diff.asset = valueB;
@@ -193,8 +190,8 @@ std::unordered_map<std::string, Manifest::AssetDiff> Manifest::genDiff(const Man
     
     for (it = bAssets.begin(); it != bAssets.end(); ++it)
     {
-        key = it->first;
-        valueB = it->second;
+        const auto &key = it->first;
+        const auto &valueB = it->second;
         
         // Added
         valueIt = _assets.find(key);
@@ -318,8 +315,7 @@ void Manifest::setAssetDownloadState(const std::string &key, const Manifest::Dow
                 {
                     for (rapidjson::Value::MemberIterator itr = assets.MemberBegin(); itr != assets.MemberEnd(); ++itr)
                     {
-                        std::string jkey = itr->name.GetString();
-                        if (jkey == key) {
+                        if (key.compare(itr->name.GetString()) == 0) {
                             rapidjson::Value &entry = itr->value;
                             if (entry.HasMember(KEY_DOWNLOAD_STATE) && entry[KEY_DOWNLOAD_STATE].IsInt())
                             {


### PR DESCRIPTION
This PR includes several bug fixes related to network/asset_manager
### Downloader
#### storage path space bug (iOS) https://github.com/cocos2d/cocos2d-x/commit/963efe78fe5d6f1e76a95eb0a20783cbae55faa1

This is merged to v3 in https://github.com/cocos2d/cocos2d-x/pull/14843 but not in v3.11 branch yet.
#### thread safety (Android) https://github.com/cocos2d/cocos2d-x/commit/d848292860421ffd475b6482818060b501380955

This is related to [my previous fix](https://github.com/cocos2d/cocos2d-x/pull/14530) for android downloader that is not thread safe which may crash the app in certain circumstances
### AssetManagerEx
#### If the last task fails, it will stuck at `UPDATING` forever https://github.com/cocos2d/cocos2d-x/commit/58586871619d08a2ef3b8829a6c8529929e82562

See https://github.com/cocos2d/cocos2d-x/issues/15463
#### performance improvement for manifest diff (this is not a bug) https://github.com/cocos2d/cocos2d-x/commit/f3cd1298af0f16d67f93d9be8bfbdd3f22ce2796
### HTTPAsyncConnection
#### Crash when custom SSL certificate is set(iOS) https://github.com/cocos2d/cocos2d-x/commit/200c9fda59f7a5fbece4ba4fa3a3729e38de6998

There is a redundant release of a CFArrayRef causing the object to be deallocated before NSURLConnectionLoader thread tries to release it, making it send a release message to an already deallocated object.
This also fixes a memory leak of SecCertificateRef
See https://github.com/cocos2d/cocos2d-x/issues/15464
