### PR TITLE
Copy polygonInfo when cloning SpriteFrame

### DIFF
--- a/cocos/2d/CCSpriteFrame.cpp
+++ b/cocos/2d/CCSpriteFrame.cpp
@@ -137,6 +137,7 @@ SpriteFrame* SpriteFrame::clone() const
     SpriteFrame *copy = new (std::nothrow) SpriteFrame();
     copy->initWithTextureFilename(_textureFilename, _rectInPixels, _rotated, _offsetInPixels, _originalSizeInPixels);
     copy->setTexture(_texture);
+    copy->setPolygonInfo(_polygonInfo);
     copy->autorelease();
     return copy;
 }


### PR DESCRIPTION
Copy the `_polygonInfo` over in SpriteFrame's `clone()` function. Otherwise, for example, calling `reverse()` on an Animate action will incorrectly draw the the node that it is applied to.
