### PR TITLE
Fix deprecation warning caused by PageView::getPages()

### DIFF
--- a/cocos/ui/UIPageView.cpp
+++ b/cocos/ui/UIPageView.cpp
@@ -329,7 +329,7 @@ Vector<Layout*>& PageView::getPages()
 
 Layout* PageView::getPage(ssize_t index)
 {
-    if (index < 0 || index >= this->getPages().size())
+    if (index < 0 || index >= this->getItems().size())
     {
         return nullptr;
     }


### PR DESCRIPTION
Hello, I'm getting this warning while compiling libcocos2d with GCC on Linux:

```
cocos/ui/UIPageView.cpp:332:46: warning: ‘cocos2d::Vector<cocos2d::ui::Layout*>& cocos2d::ui::PageView::getPages()’ is deprecated (declared at cocos/ui/UIPageView.cpp:316) [-Wdeprecated-declarations]
     if (index < 0 || index >= this->getPages().size())
                                              ^
```

Also getting the same warning when building on Windows:

```
3>..\ui\UIPageView.cpp(332): warning C4996: 'cocos2d::ui::PageView::getPages': was declared deprecated [cocos\2d\libcocos2d.vcxproj]
```

This pull request suppresses that deprecation warning and keeps backward compatibility with the v3.
Thanks!
