### PR TITLE
Add FileUtils::getContents().

### DIFF
--- a/cocos/editor-support/cocostudio/CCDataReaderHelper.cpp
+++ b/cocos/editor-support/cocostudio/CCDataReaderHelper.cpp
@@ -143,11 +143,12 @@ static const char *CONTENT_SCALE = "content_scale";
 
 static std::string readFileContent(const std::string& filename, bool binary) {
     auto fs = FileUtils::getInstance();
-    if (binary) {
-        Data data(fs->getDataFromFile(filename));
-        return std::string((const char*)data.getBytes(), data.getSize());
-    }
-    return fs->getStringFromFile(filename);
+    std::string s;
+    if (binary)
+        fs->getContents(filename, &s);
+    else
+        s = std::move(fs->getStringFromFile(filename));
+    return s;
 };
 
 namespace cocostudio {

--- a/cocos/platform/CCFileUtils.cpp
+++ b/cocos/platform/CCFileUtils.cpp
@@ -610,6 +610,9 @@ void FileUtils::purgeCachedEntries()
     _fullPathCache.clear();
 }
 
+
+#if CC_TARGET_PLATFORM == CC_PLATFORM_WINRT
+// TODO: only winrt support text mode. it is possibly a bug. if true, remove the follow code for text mode.
 namespace
 {
     // TODO: move this function to StringUtils.
@@ -634,15 +637,14 @@ namespace
         retval.append( current, next );
         return retval;
     }
-    
+
     static inline void textFormCRLF(std::string& s) {
         static const std::string CRLF("\r\n");
         static const std::string LF("\n");
-#if CC_TARGET_PLATFORM == CC_PLATFORM_WIN32 // this is what getStringFromFile() does before...
         s = std::move(replaceAll(s, CRLF, LF));
-#endif
     }
 }
+#endif
 
 
 std::string FileUtils::getStringFromFile(const std::string& filename)
@@ -702,9 +704,12 @@ unsigned char* FileUtils::getFileData(const std::string& filename, const char* m
     std::string s;
     getContents(filename, &s);
 
+#if CC_TARGET_PLATFORM == CC_PLATFORM_WINRT
+    // TODO: only winrt support text mode. it is possibly a bug. if true, remove the follow code for text mode.
     bool textmode = strchr(mode, 't') != NULL;
     if (textmode)
         textFormCRLF(s);
+#endif
 
     unsigned char * buffer = (unsigned char*)malloc(s.size());
     memcpy(buffer, s.data(), s.size());

--- a/cocos/platform/CCFileUtils.cpp
+++ b/cocos/platform/CCFileUtils.cpp
@@ -610,43 +610,6 @@ void FileUtils::purgeCachedEntries()
     _fullPathCache.clear();
 }
 
-
-#if CC_TARGET_PLATFORM == CC_PLATFORM_WINRT
-// TODO: only winrt support text mode. it is possibly a bug. if true, remove the follow code for text mode.
-namespace
-{
-    // TODO: move this function to StringUtils.
-    // http://stackoverflow.com/a/7724536/87021
-    static inline std::string replaceAll(
-                                         std::string const& original,
-                                         std::string const& before,
-                                         std::string const& after
-                                         )
-    {
-        std::string retval;
-        retval.reserve(original.size());
-        auto end = original.end();
-        auto current = original.begin();
-        auto next = std::search( current, end, before.begin(), before.end() );
-        while ( next != end ) {
-            retval.append( current, next );
-            retval.append( after );
-            current = next + before.size();
-            next = std::search( current, end, before.begin(), before.end() );
-        }
-        retval.append( current, next );
-        return retval;
-    }
-
-    inline void textFormCRLF(std::string& s) {
-        static const std::string CRLF("\r\n");
-        static const std::string LF("\n");
-        s = std::move(replaceAll(s, CRLF, LF));
-    }
-}
-#endif
-
-
 std::string FileUtils::getStringFromFile(const std::string& filename)
 {
     std::string s;
@@ -700,18 +663,12 @@ FileUtils::Status FileUtils::getContents(const std::string& filename, ResizableB
 unsigned char* FileUtils::getFileData(const std::string& filename, const char* mode, ssize_t *size)
 {
     CCASSERT(!filename.empty() && size != nullptr && mode != nullptr, "Invalid parameters.");
+    (void)(mode); // mode is unused, as we do not support text mode any more...
 
     *size = 0;
     std::string s;
     if (getContents(filename, &s) != Status::OK)
         return nullptr;
-
-#if CC_TARGET_PLATFORM == CC_PLATFORM_WINRT
-    // TODO: only winrt support text mode. it is possibly a bug. if true, remove the follow code for text mode.
-    bool textmode = strchr(mode, 't') != NULL;
-    if (textmode)
-        textFormCRLF(s);
-#endif
 
     unsigned char * buffer = (unsigned char*)malloc(s.size());
     if (!buffer)

--- a/cocos/platform/CCFileUtils.cpp
+++ b/cocos/platform/CCFileUtils.cpp
@@ -686,20 +686,20 @@ Data FileUtils::getDataFromFile(const std::string& filename)
 }
 
 
-FileError FileUtils::getContents(const std::string& filename, ResizableBuffer* buffer)
+FileUtils::Error FileUtils::getContents(const std::string& filename, ResizableBuffer* buffer)
 {
     if (filename.empty())
-        return FileError::NotExists;
+        return Error::NotExists;
 
     auto fs = FileUtils::getInstance();
 
     std::string fullPath = fs->fullPathForFilename(filename);
     if (fullPath.empty())
-        return FileError::NotExists;
+        return Error::NotExists;
 
     FILE *fp = fopen(fs->getSuitableFOpen(fullPath).c_str(), "rb");
     if (!fp)
-        return FileError::OpenFailed;
+        return Error::OpenFailed;
 
     fseek(fp, 0, SEEK_END);
     size_t size = ftell(fp);
@@ -711,10 +711,10 @@ FileError FileUtils::getContents(const std::string& filename, ResizableBuffer* b
 
     if (readsize < size) {
         buffer->resize(readsize);
-        return FileError::ReadFaild;
+        return Error::ReadFaild;
     }
 
-    return FileError::OK;
+    return Error::OK;
 }
 
 unsigned char* FileUtils::getFileData(const std::string& filename, const char* mode, ssize_t *size)

--- a/cocos/platform/CCFileUtils.cpp
+++ b/cocos/platform/CCFileUtils.cpp
@@ -666,20 +666,20 @@ Data FileUtils::getDataFromFile(const std::string& filename)
 }
 
 
-FileUtils::Error FileUtils::getContents(const std::string& filename, ResizableBuffer* buffer)
+FileUtils::Status FileUtils::getContents(const std::string& filename, ResizableBuffer* buffer)
 {
     if (filename.empty())
-        return Error::NotExists;
+        return Status::NotExists;
 
     auto fs = FileUtils::getInstance();
 
     std::string fullPath = fs->fullPathForFilename(filename);
     if (fullPath.empty())
-        return Error::NotExists;
+        return Status::NotExists;
 
     FILE *fp = fopen(fs->getSuitableFOpen(fullPath).c_str(), "rb");
     if (!fp)
-        return Error::OpenFailed;
+        return Status::OpenFailed;
 
     fseek(fp, 0, SEEK_END);
     size_t size = ftell(fp);
@@ -691,10 +691,10 @@ FileUtils::Error FileUtils::getContents(const std::string& filename, ResizableBu
 
     if (readsize < size) {
         buffer->resize(readsize);
-        return Error::ReadFaild;
+        return Status::ReadFaild;
     }
 
-    return Error::OK;
+    return Status::OK;
 }
 
 unsigned char* FileUtils::getFileData(const std::string& filename, const char* mode, ssize_t *size)
@@ -703,7 +703,7 @@ unsigned char* FileUtils::getFileData(const std::string& filename, const char* m
 
     *size = 0;
     std::string s;
-    if (getContents(filename, &s) != Error::OK)
+    if (getContents(filename, &s) != Status::OK)
         return nullptr;
 
 #if CC_TARGET_PLATFORM == CC_PLATFORM_WINRT

--- a/cocos/platform/CCFileUtils.cpp
+++ b/cocos/platform/CCFileUtils.cpp
@@ -653,9 +653,6 @@ std::string FileUtils::getStringFromFile(const std::string& filename)
     // truncated
     s.resize(strlen(s.data()));
 
-    // simulate text mode, CRLF -> LF
-    textFormCRLF(s);
-
     return s;
 }
 

--- a/cocos/platform/CCFileUtils.cpp
+++ b/cocos/platform/CCFileUtils.cpp
@@ -634,8 +634,8 @@ namespace
         retval.append( current, next );
         return retval;
     }
-    
-    static inline void textFormCRLF(std::string& s) {
+
+    inline void textFormCRLF(std::string& s) {
         static const std::string CRLF("\r\n");
         static const std::string LF("\n");
 #if CC_TARGET_PLATFORM == CC_PLATFORM_WIN32 // this is what getStringFromFile() does before...

--- a/cocos/platform/CCFileUtils.cpp
+++ b/cocos/platform/CCFileUtils.cpp
@@ -709,6 +709,7 @@ unsigned char* FileUtils::getFileData(const std::string& filename, const char* m
 
     unsigned char * buffer = (unsigned char*)malloc(s.size());
     memcpy(buffer, s.data(), s.size());
+    *size = s.size();
 
     return buffer;
 }

--- a/cocos/platform/CCFileUtils.cpp
+++ b/cocos/platform/CCFileUtils.cpp
@@ -701,8 +701,10 @@ unsigned char* FileUtils::getFileData(const std::string& filename, const char* m
 {
     CCASSERT(!filename.empty() && size != nullptr && mode != nullptr, "Invalid parameters.");
 
+    *size = 0;
     std::string s;
-    getContents(filename, &s);
+    if (getContents(filename, &s) != Error::OK)
+        return nullptr;
 
 #if CC_TARGET_PLATFORM == CC_PLATFORM_WINRT
     // TODO: only winrt support text mode. it is possibly a bug. if true, remove the follow code for text mode.
@@ -712,6 +714,9 @@ unsigned char* FileUtils::getFileData(const std::string& filename, const char* m
 #endif
 
     unsigned char * buffer = (unsigned char*)malloc(s.size());
+    if (!buffer)
+        return nullptr;
+
     memcpy(buffer, s.data(), s.size());
     *size = s.size();
 

--- a/cocos/platform/CCFileUtils.cpp
+++ b/cocos/platform/CCFileUtils.cpp
@@ -638,7 +638,7 @@ static inline void textFormCRLF(std::string& s) {
     static const std::string CRLF("\r\n");
     static const std::string LF("\n");
 #if CC_TARGET_PLATFORM == CC_PLATFORM_WIN32 // this is what getStringFromFile() does before...
-    s = replaceAll(s, CRLF, LF, result);
+    s = std::move(replaceAll(s, CRLF, LF));
 #endif
 }
 

--- a/cocos/platform/CCFileUtils.cpp
+++ b/cocos/platform/CCFileUtils.cpp
@@ -610,36 +610,38 @@ void FileUtils::purgeCachedEntries()
     _fullPathCache.clear();
 }
 
-
-// TODO: move this function to StringUtils.
-// http://stackoverflow.com/a/7724536/87021
-static inline std::string replaceAll(
-    std::string const& original,
-    std::string const& before,
-    std::string const& after
-)
+namespace
 {
-    std::string retval;
-    retval.reserve(original.size());
-    auto end = original.end();
-    auto current = original.begin();
-    auto next = std::search( current, end, before.begin(), before.end() );
-    while ( next != end ) {
+    // TODO: move this function to StringUtils.
+    // http://stackoverflow.com/a/7724536/87021
+    static inline std::string replaceAll(
+                                         std::string const& original,
+                                         std::string const& before,
+                                         std::string const& after
+                                         )
+    {
+        std::string retval;
+        retval.reserve(original.size());
+        auto end = original.end();
+        auto current = original.begin();
+        auto next = std::search( current, end, before.begin(), before.end() );
+        while ( next != end ) {
+            retval.append( current, next );
+            retval.append( after );
+            current = next + before.size();
+            next = std::search( current, end, before.begin(), before.end() );
+        }
         retval.append( current, next );
-        retval.append( after );
-        current = next + before.size();
-        next = std::search( current, end, before.begin(), before.end() );
+        return retval;
     }
-    retval.append( current, next );
-    return retval;
-}
-
-static inline void textFormCRLF(std::string& s) {
-    static const std::string CRLF("\r\n");
-    static const std::string LF("\n");
+    
+    static inline void textFormCRLF(std::string& s) {
+        static const std::string CRLF("\r\n");
+        static const std::string LF("\n");
 #if CC_TARGET_PLATFORM == CC_PLATFORM_WIN32 // this is what getStringFromFile() does before...
-    s = std::move(replaceAll(s, CRLF, LF));
+        s = std::move(replaceAll(s, CRLF, LF));
 #endif
+    }
 }
 
 

--- a/cocos/platform/CCFileUtils.h
+++ b/cocos/platform/CCFileUtils.h
@@ -197,7 +197,7 @@ public:
      *  you may get 0 ~ sizeof(T)-1 bytes padding.
      *
      *  - To write a new buffer class works with getContents, just extend ResizableBuffer.
-     *  - To write a adapter for existing class, write a for ResizableBufferAdapter, see follow code.
+     *  - To write a adapter for existing class, write a specialized ResizableBufferAdapter for that class, see follow code.
      *
      *  <pre>
      *  {@code

--- a/cocos/platform/CCFileUtils.h
+++ b/cocos/platform/CCFileUtils.h
@@ -102,16 +102,6 @@ public:
     }
 };
 
-enum class FileError
-{
-    OK = 0,
-    NotExists = 0x01, /** File not exists */
-    OpenFailed = 0x02, /** Open file failed. */
-    ReadFaild = 0x03, /** Read failed */
-    NotInitialized = 0x04, /** FileUtils is not initializes */
-};
-
-
 /** Helper class to handle file operations. */
 class CC_DLL FileUtils
 {
@@ -170,6 +160,16 @@ public:
      */
     virtual Data getDataFromFile(const std::string& filename);
 
+
+    enum class Error
+    {
+        OK = 0,
+        NotExists = 0x01, /** File not exists */
+        OpenFailed = 0x02, /** Open file failed. */
+        ReadFaild = 0x03, /** Read failed */
+        NotInitialized = 0x04, /** FileUtils is not initializes */
+    };
+
     /**
      *  Gets whole file contents as string from a file.
      *
@@ -219,11 +219,11 @@ public:
      *  @param[in]  filename The resource file name which contains the path.
      *  @param[out] buffer The buffer where the file contents are store to.
      *  @return Returns:
-     *      - FileError::OK when there is no error, the buffer is filled with the contents of file.
-     *      - FileError::NotExists when file not exists, the buffer will not changed.
-     *      - FileError::OpenFailed when cannot open file, the buffer will not changed.
-     *      - FileError::ReadFaild when read end up before read whole, the buffer will fill with already read bytes.
-     *      - FileError::NotInitialized when FileUtils is not initializes, the buffer will not changed.
+     *      - Error::OK when there is no error, the buffer is filled with the contents of file.
+     *      - Error::NotExists when file not exists, the buffer will not changed.
+     *      - Error::OpenFailed when cannot open file, the buffer will not changed.
+     *      - Error::ReadFaild when read end up before read whole, the buffer will fill with already read bytes.
+     *      - Error::NotInitialized when FileUtils is not initializes, the buffer will not changed.
      */
     template <
         typename T,
@@ -231,11 +231,11 @@ public:
             std::is_base_of< ResizableBuffer, ResizableBufferAdapter<T> >::value
         >::type
     >
-    FileError getContents(const std::string& filename, T* buffer) {
+    Error getContents(const std::string& filename, T* buffer) {
         ResizableBufferAdapter<T> buf(buffer);
         return getContents(filename, &buf);
     }
-    virtual FileError getContents(const std::string& filename, ResizableBuffer* buffer);
+    virtual Error getContents(const std::string& filename, ResizableBuffer* buffer);
 
     /**
      *  Gets resource file data

--- a/cocos/platform/CCFileUtils.h
+++ b/cocos/platform/CCFileUtils.h
@@ -161,7 +161,7 @@ public:
     virtual Data getDataFromFile(const std::string& filename);
 
 
-    enum class Error
+    enum class Status
     {
         OK = 0,
         NotExists = 0x01, /** File not exists */
@@ -222,11 +222,12 @@ public:
      *  @param[in]  filename The resource file name which contains the path.
      *  @param[out] buffer The buffer where the file contents are store to.
      *  @return Returns:
-     *      - Error::OK when there is no error, the buffer is filled with the contents of file.
-     *      - Error::NotExists when file not exists, the buffer will not changed.
-     *      - Error::OpenFailed when cannot open file, the buffer will not changed.
-     *      - Error::ReadFaild when read end up before read whole, the buffer will fill with already read bytes.
-     *      - Error::NotInitialized when FileUtils is not initializes, the buffer will not changed.
+     *      - Status::OK when there is no error, the buffer is filled with the contents of file.
+     *      - Status::NotExists when file not exists, the buffer will not changed.
+     *      - Status::OpenFailed when cannot open file, the buffer will not changed.
+     *      - Status::ReadFaild when read end up before read whole, the buffer will fill with already read bytes.
+     *      - Status::NotInitialized when FileUtils is not initializes, the buffer will not changed.
+     *      - Status::TooLarge when there file to be read is too large (> 2^32-1), the buffer will not changed.
      */
     template <
         typename T,
@@ -234,11 +235,11 @@ public:
             std::is_base_of< ResizableBuffer, ResizableBufferAdapter<T> >::value
         >::type
     >
-    Error getContents(const std::string& filename, T* buffer) {
+    Status getContents(const std::string& filename, T* buffer) {
         ResizableBufferAdapter<T> buf(buffer);
         return getContents(filename, &buf);
     }
-    virtual Error getContents(const std::string& filename, ResizableBuffer* buffer);
+    virtual Status getContents(const std::string& filename, ResizableBuffer* buffer);
 
     /**
      *  Gets resource file data

--- a/cocos/platform/CCFileUtils.h
+++ b/cocos/platform/CCFileUtils.h
@@ -173,8 +173,9 @@ public:
     /**
      *  Gets whole file contents as string from a file.
      *
-     *  Unlike getStringFromFile, these methods does not truncate the string when '\0' is found.
-     *  That is thie returned string of getContents may have '\0' in it.
+     *  Unlike getStringFromFile, these getContents methods:
+     *      - read file in binary mode (does not convert CRLF to LF).
+     *      - does not truncate the string when '\0' is found (returned string of getContents may have '\0' in the middle.).
      *
      *  The template version of can accept cocos2d::Data, std::basic_string and std::vector.
      *  For other type of buffer, please write an adapter for it, and use the non-template version.
@@ -189,6 +190,29 @@ public:
      *
      *  Data dbuf;
      *  FileUtils::getInstance()->getContents("path/to/file", &dbuf);
+     *  }
+     * </pre
+     *
+     *  - To write a new buffer class works with getContents, just extend ResizableBuffer.
+     *  - To write a adapter for existing class, write a for ResizableBufferAdapter, see follow code.
+     *
+     *  <pre>
+     *  {@code
+     *  NS_CC_BEGIN // ResizableBufferAdapter needed in cocos2d namespace.
+     *  template<>
+     *  class ResizableBufferAdapter<AlreadyExistsBuffer> : public ResizableBuffer {
+     *  public:
+     *      ResizableBufferAdapter(AlreadyExistsBuffer* buffer)  {
+     *          // your code here
+     *      }
+     *      virtual void resize(size_t size) override  {
+     *          // your code here
+     *      }
+     *      virtual void* buffer() const override {
+     *          // your code here
+     *      }
+     *  };
+     *  NS_CC_END
      *  }
      * </pre
      *

--- a/cocos/platform/CCFileUtils.h
+++ b/cocos/platform/CCFileUtils.h
@@ -168,7 +168,8 @@ public:
         OpenFailed = 0x02, /** Open file failed. */
         ReadFaild = 0x03, /** Read failed */
         NotInitialized = 0x04, /** FileUtils is not initializes */
-		TooLarge = 0x05, // The file is too large (greate than 2^32-1)
+        TooLarge = 0x05, // The file is too large (greate than 2^32-1)
+        ObtainSizeFailed = 0x06, // Failed to obtain the file size.
     };
 
     /**
@@ -228,6 +229,7 @@ public:
      *      - Status::ReadFaild when read end up before read whole, the buffer will fill with already read bytes.
      *      - Status::NotInitialized when FileUtils is not initializes, the buffer will not changed.
      *      - Status::TooLarge when there file to be read is too large (> 2^32-1), the buffer will not changed.
+     *      - Status::ObtainSizeFailed when failed to obtain the file size, the buffer will not changed.
      */
     template <
         typename T,

--- a/cocos/platform/CCFileUtils.h
+++ b/cocos/platform/CCFileUtils.h
@@ -59,7 +59,7 @@ class ResizableBufferAdapter< std::basic_string<C, T, A> > : public ResizableBuf
     typedef std::basic_string<C, T, A> BufferType;
     BufferType* _buffer;
 public:
-    ResizableBufferAdapter(BufferType* buffer) : _buffer(buffer) {}
+    explicit ResizableBufferAdapter(BufferType* buffer) : _buffer(buffer) {}
     virtual void resize(size_t size) override {
         _buffer->resize((size + sizeof(C)) / sizeof(C));
     }
@@ -73,7 +73,7 @@ class ResizableBufferAdapter< std::vector<T, A> > : public ResizableBuffer {
     typedef std::vector<T, A> BufferType;
     BufferType* _buffer;
 public:
-    ResizableBufferAdapter(BufferType* buffer) : _buffer(buffer) {}
+    explicit ResizableBufferAdapter(BufferType* buffer) : _buffer(buffer) {}
     virtual void resize(size_t size) override {
         _buffer->resize((size + sizeof(T)) / sizeof(T));
     }
@@ -88,7 +88,7 @@ class ResizableBufferAdapter<Data> : public ResizableBuffer {
     typedef Data BufferType;
     BufferType* _buffer;
 public:
-    ResizableBufferAdapter(BufferType* buffer) : _buffer(buffer) {}
+    explicit ResizableBufferAdapter(BufferType* buffer) : _buffer(buffer) {}
     virtual void resize(size_t size) override {
         if (_buffer->getSize() < size) {
             auto old = _buffer->getBytes();

--- a/cocos/platform/CCFileUtils.h
+++ b/cocos/platform/CCFileUtils.h
@@ -168,6 +168,7 @@ public:
         OpenFailed = 0x02, /** Open file failed. */
         ReadFaild = 0x03, /** Read failed */
         NotInitialized = 0x04, /** FileUtils is not initializes */
+		TooLarge = 0x05, // The file is too large (greate than 2^32-1)
     };
 
     /**

--- a/cocos/platform/CCFileUtils.h
+++ b/cocos/platform/CCFileUtils.h
@@ -193,6 +193,9 @@ public:
      *  }
      * </pre
      *
+     *  Note: if you read to std::vector<T> and std::basic_string<T> where T is not 8 bit type,
+     *  you may get 0 ~ sizeof(T)-1 bytes padding.
+     *
      *  - To write a new buffer class works with getContents, just extend ResizableBuffer.
      *  - To write a adapter for existing class, write a for ResizableBufferAdapter, see follow code.
      *

--- a/cocos/platform/CCFileUtils.h
+++ b/cocos/platform/CCFileUtils.h
@@ -54,23 +54,23 @@ template<typename T>
 class ResizableBufferAdapter { };
 
 
-template<typename C, typename T, typename A>
-class ResizableBufferAdapter< std::basic_string<C, T, A> > : public ResizableBuffer {
-    typedef std::basic_string<C, T, A> BufferType;
+template<typename CharT, typename Traits, typename Allocator>
+class ResizableBufferAdapter< std::basic_string<CharT, Traits, Allocator> > : public ResizableBuffer {
+    typedef std::basic_string<CharT, Traits, Allocator> BufferType;
     BufferType* _buffer;
 public:
     explicit ResizableBufferAdapter(BufferType* buffer) : _buffer(buffer) {}
     virtual void resize(size_t size) override {
-        _buffer->resize((size + sizeof(C) - 1) / sizeof(C));
+        _buffer->resize((size + sizeof(CharT) - 1) / sizeof(CharT));
     }
     virtual void* buffer() const override {
         return &_buffer->front();
     }
 };
 
-template<typename T, typename A>
-class ResizableBufferAdapter< std::vector<T, A> > : public ResizableBuffer {
-    typedef std::vector<T, A> BufferType;
+template<typename T, typename Allocator>
+class ResizableBufferAdapter< std::vector<T, Allocator> > : public ResizableBuffer {
+    typedef std::vector<T, Allocator> BufferType;
     BufferType* _buffer;
 public:
     explicit ResizableBufferAdapter(BufferType* buffer) : _buffer(buffer) {}
@@ -230,7 +230,7 @@ public:
      */
     template <
         typename T,
-        typename X = typename std::enable_if<
+        typename Enable = typename std::enable_if<
             std::is_base_of< ResizableBuffer, ResizableBufferAdapter<T> >::value
         >::type
     >

--- a/cocos/platform/CCFileUtils.h
+++ b/cocos/platform/CCFileUtils.h
@@ -61,7 +61,7 @@ class ResizableBufferAdapter< std::basic_string<C, T, A> > : public ResizableBuf
 public:
     explicit ResizableBufferAdapter(BufferType* buffer) : _buffer(buffer) {}
     virtual void resize(size_t size) override {
-        _buffer->resize((size + sizeof(C)) / sizeof(C));
+        _buffer->resize((size + sizeof(C) - 1) / sizeof(C));
     }
     virtual void* buffer() const override {
         return &_buffer->front();
@@ -75,7 +75,7 @@ class ResizableBufferAdapter< std::vector<T, A> > : public ResizableBuffer {
 public:
     explicit ResizableBufferAdapter(BufferType* buffer) : _buffer(buffer) {}
     virtual void resize(size_t size) override {
-        _buffer->resize((size + sizeof(T)) / sizeof(T));
+        _buffer->resize((size + sizeof(T) - 1) / sizeof(T));
     }
     virtual void* buffer() const override {
         return &_buffer->front();

--- a/cocos/platform/CCFileUtils.h
+++ b/cocos/platform/CCFileUtils.h
@@ -57,28 +57,28 @@ class ResizableBufferAdapter { };
 template<typename C, typename T, typename A>
 class ResizableBufferAdapter< std::basic_string<C, T, A> > : public ResizableBuffer {
     typedef std::basic_string<C, T, A> BufferType;
-    BufferType* buffer_;
+    BufferType* _buffer;
 public:
-    ResizableBufferAdapter(BufferType* buffer) : buffer_(buffer) {}
+    ResizableBufferAdapter(BufferType* buffer) : _buffer(buffer) {}
     virtual void resize(size_t size) override {
-        buffer_->resize((size + sizeof(C)) / sizeof(C));
+        _buffer->resize((size + sizeof(C)) / sizeof(C));
     }
     virtual void* buffer() const override {
-        return &buffer_->front();
+        return &_buffer->front();
     }
 };
 
 template<typename T, typename A>
 class ResizableBufferAdapter< std::vector<T, A> > : public ResizableBuffer {
     typedef std::vector<T, A> BufferType;
-    BufferType* buffer_;
+    BufferType* _buffer;
 public:
-    ResizableBufferAdapter(BufferType* buffer) : buffer_(buffer) {}
+    ResizableBufferAdapter(BufferType* buffer) : _buffer(buffer) {}
     virtual void resize(size_t size) override {
-        buffer_->resize((size + sizeof(T)) / sizeof(T));
+        _buffer->resize((size + sizeof(T)) / sizeof(T));
     }
     virtual void* buffer() const override {
-        return &buffer_->front();
+        return &_buffer->front();
     }
 };
 
@@ -86,19 +86,19 @@ public:
 template<>
 class ResizableBufferAdapter<Data> : public ResizableBuffer {
     typedef Data BufferType;
-    BufferType* buffer_;
+    BufferType* _buffer;
 public:
-    ResizableBufferAdapter(BufferType* buffer) : buffer_(buffer) {}
+    ResizableBufferAdapter(BufferType* buffer) : _buffer(buffer) {}
     virtual void resize(size_t size) override {
-        if (buffer_->getSize() < size) {
-            auto old = buffer_->getBytes();
+        if (_buffer->getSize() < size) {
+            auto old = _buffer->getBytes();
             void* buffer = realloc(old, size);
             if (buffer)
-                buffer_->fastSet((unsigned char*)buffer, size);
+                _buffer->fastSet((unsigned char*)buffer, size);
         }
     }
     virtual void* buffer() const override {
-        return buffer_->getBytes();
+        return _buffer->getBytes();
     }
 };
 
@@ -203,9 +203,9 @@ public:
      */
     template <
         typename T,
-        typename std::enable_if<
+        typename X = typename std::enable_if<
             std::is_base_of< ResizableBuffer, ResizableBufferAdapter<T> >::value
-        >::type* = nullptr
+        >::type
     >
     FileError getContents(const std::string& filename, T* buffer) {
         ResizableBufferAdapter<T> buf(buffer);

--- a/cocos/platform/CCFileUtils.h
+++ b/cocos/platform/CCFileUtils.h
@@ -164,12 +164,12 @@ public:
     enum class Status
     {
         OK = 0,
-        NotExists = 0x01, /** File not exists */
-        OpenFailed = 0x02, /** Open file failed. */
-        ReadFaild = 0x03, /** Read failed */
-        NotInitialized = 0x04, /** FileUtils is not initializes */
-        TooLarge = 0x05, // The file is too large (greate than 2^32-1)
-        ObtainSizeFailed = 0x06, // Failed to obtain the file size.
+        NotExists = 1, // File not exists
+        OpenFailed = 2, // Open file failed.
+        ReadFaild = 3, // Read failed
+        NotInitialized = 4, // FileUtils is not initializes
+        TooLarge = 5, // The file is too large (great than 2^32-1)
+        ObtainSizeFailed = 6 // Failed to obtain the file size.
     };
 
     /**

--- a/cocos/platform/CCFileUtils.h
+++ b/cocos/platform/CCFileUtils.h
@@ -178,7 +178,6 @@ public:
      *      - does not truncate the string when '\0' is found (returned string of getContents may have '\0' in the middle.).
      *
      *  The template version of can accept cocos2d::Data, std::basic_string and std::vector.
-     *  For other type of buffer, please write an adapter for it, and use the non-template version.
      *
      *  <pre>
      *  {@code

--- a/cocos/platform/CCFileUtils.h
+++ b/cocos/platform/CCFileUtils.h
@@ -90,7 +90,7 @@ class ResizableBufferAdapter<Data> : public ResizableBuffer {
 public:
     explicit ResizableBufferAdapter(BufferType* buffer) : _buffer(buffer) {}
     virtual void resize(size_t size) override {
-        if (_buffer->getSize() < size) {
+        if (static_cast<size_t>(_buffer->getSize()) < size) {
             auto old = _buffer->getBytes();
             void* buffer = realloc(old, size);
             if (buffer)

--- a/cocos/platform/android/CCFileUtils-android.cpp
+++ b/cocos/platform/android/CCFileUtils-android.cpp
@@ -230,11 +230,11 @@ bool FileUtilsAndroid::isAbsolutePath(const std::string& strPath) const
     return false;
 }
 
-FileUtils::Error FileUtilsAndroid::getContents(const std::string& filename, ResizableBuffer* buffer)
+FileUtils::Status FileUtilsAndroid::getContents(const std::string& filename, ResizableBuffer* buffer)
 {
     static const std::string apkprefix("assets/");
     if (filename.empty())
-        return FileUtils::Error::NotExists;
+        return FileUtils::Status::NotExists;
 
     string fullPath = fullPathForFilename(filename);
 
@@ -252,13 +252,13 @@ FileUtils::Error FileUtilsAndroid::getContents(const std::string& filename, Resi
 
     if (nullptr == assetmanager) {
         LOGD("... FileUtilsAndroid::assetmanager is nullptr");
-        return FileUtils::Error::NotInitialized;
+        return FileUtils::Status::NotInitialized;
     }
 
     AAsset* asset = AAssetManager_open(assetmanager, relativePath.data(), AASSET_MODE_UNKNOWN);
     if (nullptr == asset) {
         LOGD("asset is nullptr");
-        return FileUtils::Error::OpenFailed;
+        return FileUtils::Status::OpenFailed;
     }
 
     auto size = AAsset_getLength(asset);
@@ -270,10 +270,10 @@ FileUtils::Error FileUtilsAndroid::getContents(const std::string& filename, Resi
     if (readsize < size) {
         if (readsize >= 0)
             buffer->resize(readsize);
-        return FileUtils::Error::ReadFaild;
+        return FileUtils::Status::ReadFaild;
     }
 
-    return FileUtils::Error::OK;
+    return FileUtils::Status::OK;
 }
 
 string FileUtilsAndroid::getWritablePath() const

--- a/cocos/platform/android/CCFileUtils-android.cpp
+++ b/cocos/platform/android/CCFileUtils-android.cpp
@@ -230,113 +230,6 @@ bool FileUtilsAndroid::isAbsolutePath(const std::string& strPath) const
     return false;
 }
 
-Data FileUtilsAndroid::getData(const std::string& filename, bool forString)
-{
-    if (filename.empty())
-    {
-        return Data::Null;
-    }
-
-    unsigned char* data = nullptr;
-    ssize_t size = 0;
-    string fullPath = fullPathForFilename(filename);
-
-    if (fullPath[0] != '/')
-    {
-        string relativePath = string();
-
-        size_t position = fullPath.find("assets/");
-        if (0 == position) {
-            // "assets/" is at the beginning of the path and we don't want it
-            relativePath += fullPath.substr(strlen("assets/"));
-        } else {
-            relativePath += fullPath;
-        }
-        CCLOGINFO("relative path = %s", relativePath.c_str());
-
-        if (nullptr == FileUtilsAndroid::assetmanager) {
-            LOGD("... FileUtilsAndroid::assetmanager is nullptr");
-            return Data::Null;
-        }
-
-        // read asset data
-        AAsset* asset =
-            AAssetManager_open(FileUtilsAndroid::assetmanager,
-                               relativePath.c_str(),
-                               AASSET_MODE_UNKNOWN);
-        if (nullptr == asset) {
-            LOGD("asset is nullptr");
-            return Data::Null;
-        }
-
-        off_t fileSize = AAsset_getLength(asset);
-
-        if (forString)
-        {
-            data = (unsigned char*) malloc(fileSize + 1);
-            data[fileSize] = '\0';
-        }
-        else
-        {
-            data = (unsigned char*) malloc(fileSize);
-        }
-
-        int bytesread = AAsset_read(asset, (void*)data, fileSize);
-        size = bytesread;
-
-        AAsset_close(asset);
-    }
-    else
-    {
-        do
-        {
-            // read rrom other path than user set it
-            //CCLOG("GETTING FILE ABSOLUTE DATA: %s", filename);
-            const char* mode = nullptr;
-            if (forString)
-                mode = "rt";
-            else
-                mode = "rb";
-
-            FILE *fp = fopen(fullPath.c_str(), mode);
-            CC_BREAK_IF(!fp);
-
-            long fileSize;
-            fseek(fp,0,SEEK_END);
-            fileSize = ftell(fp);
-            fseek(fp,0,SEEK_SET);
-            if (forString)
-            {
-                data = (unsigned char*) malloc(fileSize + 1);
-                data[fileSize] = '\0';
-            }
-            else
-            {
-                data = (unsigned char*) malloc(fileSize);
-            }
-            fileSize = fread(data,sizeof(unsigned char), fileSize,fp);
-            fclose(fp);
-
-            size = fileSize;
-        } while (0);
-    }
-
-    Data ret;
-    if (data == nullptr || size == 0)
-    {
-        std::string msg = "Get data from file(";
-        msg.append(filename).append(") failed!");
-        CCLOG("%s", msg.c_str());
-    }
-    else
-    {
-        ret.fastSet(data, size);
-    }
-
-    return ret;
-}
-
-
 FileUtils::Error FileUtilsAndroid::getContents(const std::string& filename, ResizableBuffer* buffer)
 {
     static const std::string apkprefix("assets/");
@@ -385,102 +278,17 @@ FileUtils::Error FileUtilsAndroid::getContents(const std::string& filename, Resi
 
 std::string FileUtilsAndroid::getStringFromFile(const std::string& filename)
 {
-    Data data = getData(filename, true);
-    if (data.isNull())
-        return "";
-
-    std::string ret((const char*)data.getBytes());
-    return ret;
+    return FileUtils::getStringFromFile();
 }
 
 Data FileUtilsAndroid::getDataFromFile(const std::string& filename)
 {
-    return getData(filename, false);
+    return FileUtils::getDataFromFile(filename);
 }
 
 unsigned char* FileUtilsAndroid::getFileData(const std::string& filename, const char* mode, ssize_t * size)
 {
-    unsigned char * data = 0;
-
-    if ( filename.empty() || (! mode) )
-    {
-        return 0;
-    }
-
-    string fullPath = fullPathForFilename(filename);
-
-    if (fullPath[0] != '/')
-    {
-        string relativePath = string();
-
-        size_t position = fullPath.find("assets/");
-        if (0 == position) {
-            // "assets/" is at the beginning of the path and we don't want it
-            relativePath += fullPath.substr(strlen("assets/"));
-        } else {
-            relativePath += fullPath;
-        }
-        LOGD("relative path = %s", relativePath.c_str());
-
-        if (nullptr == FileUtilsAndroid::assetmanager) {
-            LOGD("... FileUtilsAndroid::assetmanager is nullptr");
-            return nullptr;
-        }
-
-        // read asset data
-        AAsset* asset =
-            AAssetManager_open(FileUtilsAndroid::assetmanager,
-                               relativePath.c_str(),
-                               AASSET_MODE_UNKNOWN);
-        if (nullptr == asset) {
-            LOGD("asset is nullptr");
-            return nullptr;
-        }
-
-        off_t fileSize = AAsset_getLength(asset);
-
-        data = (unsigned char*) malloc(fileSize);
-
-        int bytesread = AAsset_read(asset, (void*)data, fileSize);
-        if (size)
-        {
-            *size = bytesread;
-        }
-
-        AAsset_close(asset);
-    }
-    else
-    {
-        do
-        {
-            // read rrom other path than user set it
-            //CCLOG("GETTING FILE ABSOLUTE DATA: %s", filename);
-            FILE *fp = fopen(fullPath.c_str(), mode);
-            CC_BREAK_IF(!fp);
-
-            long fileSize;
-            fseek(fp,0,SEEK_END);
-            fileSize = ftell(fp);
-            fseek(fp,0,SEEK_SET);
-            data = (unsigned char*) malloc(fileSize);
-            fileSize = fread(data,sizeof(unsigned char), fileSize,fp);
-            fclose(fp);
-
-            if (size)
-            {
-                *size = fileSize;
-            }
-        } while (0);
-    }
-
-    if (! data)
-    {
-        std::string msg = "Get data from file(";
-        msg.append(filename).append(") failed!");
-        CCLOG("%s", msg.c_str());
-    }
-
-    return data;
+    return FileUtils::getFileData(filename, mode, size);
 }
 
 string FileUtilsAndroid::getWritablePath() const

--- a/cocos/platform/android/CCFileUtils-android.cpp
+++ b/cocos/platform/android/CCFileUtils-android.cpp
@@ -337,11 +337,11 @@ Data FileUtilsAndroid::getData(const std::string& filename, bool forString)
 }
 
 
-FileError FileUtilsAndroid::getContents(const std::string& filename, ResizableBuffer* buffer)
+FileUtils::Error FileUtilsAndroid::getContents(const std::string& filename, ResizableBuffer* buffer)
 {
     static const std::string apkprefix("assets/");
     if (filename.empty())
-        return FileError::NotExists;
+        return FileUtils::Error::NotExists;
 
     string fullPath = fullPathForFilename(filename);
 
@@ -359,13 +359,13 @@ FileError FileUtilsAndroid::getContents(const std::string& filename, ResizableBu
 
     if (nullptr == assetmanager) {
         LOGD("... FileUtilsAndroid::assetmanager is nullptr");
-        return FileError::NotInitialized;
+        return FileUtils::Error::NotInitialized;
     }
 
     AAsset* asset = AAssetManager_open(assetmanager, relativePath.data(), AASSET_MODE_UNKNOWN);
     if (nullptr == asset) {
         LOGD("asset is nullptr");
-        return FileError::OpenFailed;
+        return FileUtils::Error::OpenFailed;
     }
 
     auto size = AAsset_getLength(asset);
@@ -377,10 +377,10 @@ FileError FileUtilsAndroid::getContents(const std::string& filename, ResizableBu
     if (readsize < size) {
         if (readsize >= 0)
             buffer->resize(readsize);
-        return FileError::ReadFaild;
+        return FileUtils::Error::ReadFaild;
     }
 
-    return FileError::OK;
+    return FileUtils::Error::OK;
 }
 
 std::string FileUtilsAndroid::getStringFromFile(const std::string& filename)

--- a/cocos/platform/android/CCFileUtils-android.cpp
+++ b/cocos/platform/android/CCFileUtils-android.cpp
@@ -276,21 +276,6 @@ FileUtils::Error FileUtilsAndroid::getContents(const std::string& filename, Resi
     return FileUtils::Error::OK;
 }
 
-std::string FileUtilsAndroid::getStringFromFile(const std::string& filename)
-{
-    return FileUtils::getStringFromFile(filename);
-}
-
-Data FileUtilsAndroid::getDataFromFile(const std::string& filename)
-{
-    return FileUtils::getDataFromFile(filename);
-}
-
-unsigned char* FileUtilsAndroid::getFileData(const std::string& filename, const char* mode, ssize_t * size)
-{
-    return FileUtils::getFileData(filename, mode, size);
-}
-
 string FileUtilsAndroid::getWritablePath() const
 {
     // Fix for Nexus 10 (Android 4.2 multi-user environment)

--- a/cocos/platform/android/CCFileUtils-android.cpp
+++ b/cocos/platform/android/CCFileUtils-android.cpp
@@ -278,7 +278,7 @@ FileUtils::Error FileUtilsAndroid::getContents(const std::string& filename, Resi
 
 std::string FileUtilsAndroid::getStringFromFile(const std::string& filename)
 {
-    return FileUtils::getStringFromFile();
+    return FileUtils::getStringFromFile(filename);
 }
 
 Data FileUtilsAndroid::getDataFromFile(const std::string& filename)

--- a/cocos/platform/android/CCFileUtils-android.h
+++ b/cocos/platform/android/CCFileUtils-android.h
@@ -77,7 +77,7 @@ public:
      */
     virtual Data getDataFromFile(const std::string& filename) override;
 
-    virtual FileError getContents(const std::string& filename, ResizableBuffer* buffer) override;
+    virtual FileUtils::Error getContents(const std::string& filename, ResizableBuffer* buffer) override;
 
     virtual std::string getWritablePath() const override;
     virtual bool isAbsolutePath(const std::string& strPath) const override;

--- a/cocos/platform/android/CCFileUtils-android.h
+++ b/cocos/platform/android/CCFileUtils-android.h
@@ -85,7 +85,6 @@ public:
 private:
     virtual bool isFileExistInternal(const std::string& strFilePath) const override;
     virtual bool isDirectoryExistInternal(const std::string& dirPath) const override;
-    Data getData(const std::string& filename, bool forString);
 
     static AAssetManager* assetmanager;
 };

--- a/cocos/platform/android/CCFileUtils-android.h
+++ b/cocos/platform/android/CCFileUtils-android.h
@@ -63,7 +63,7 @@ public:
 
     virtual std::string getNewFilename(const std::string &filename) const override;
 
-    virtual FileUtils::Error getContents(const std::string& filename, ResizableBuffer* buffer) override;
+    virtual FileUtils::Status getContents(const std::string& filename, ResizableBuffer* buffer) override;
 
     virtual std::string getWritablePath() const override;
     virtual bool isAbsolutePath(const std::string& strPath) const override;

--- a/cocos/platform/android/CCFileUtils-android.h
+++ b/cocos/platform/android/CCFileUtils-android.h
@@ -63,20 +63,6 @@ public:
 
     virtual std::string getNewFilename(const std::string &filename) const override;
 
-    /** @deprecated Please use FileUtils::getDataFromFile or FileUtils::getStringFromFile instead. */
-    CC_DEPRECATED_ATTRIBUTE virtual unsigned char* getFileData(const std::string& filename, const char* mode, ssize_t * size) override;
-
-    /**
-     *  Gets string from a file.
-     */
-    virtual std::string getStringFromFile(const std::string& filename) override;
-
-    /**
-     *  Creates binary data from a file.
-     *  @return A data object.
-     */
-    virtual Data getDataFromFile(const std::string& filename) override;
-
     virtual FileUtils::Error getContents(const std::string& filename, ResizableBuffer* buffer) override;
 
     virtual std::string getWritablePath() const override;

--- a/cocos/platform/android/CCFileUtils-android.h
+++ b/cocos/platform/android/CCFileUtils-android.h
@@ -1,19 +1,19 @@
 /****************************************************************************
 Copyright (c) 2010-2012 cocos2d-x.org
 Copyright (c) 2013-2014 Chukong Technologies Inc.
- 
+
  http://www.cocos2d-x.org
- 
+
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal
  in the Software without restriction, including without limitation the rights
  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  copies of the Software, and to permit persons to whom the Software is
  furnished to do so, subject to the following conditions:
- 
+
  The above copyright notice and this permission notice shall be included in
  all copies or substantial portions of the Software.
- 
+
  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -70,16 +70,18 @@ public:
      *  Gets string from a file.
      */
     virtual std::string getStringFromFile(const std::string& filename) override;
-    
+
     /**
      *  Creates binary data from a file.
      *  @return A data object.
      */
     virtual Data getDataFromFile(const std::string& filename) override;
 
+    virtual FileError getContents(const std::string& filename, ResizableBuffer* buffer) override;
+
     virtual std::string getWritablePath() const override;
     virtual bool isAbsolutePath(const std::string& strPath) const override;
-    
+
 private:
     virtual bool isFileExistInternal(const std::string& strFilePath) const override;
     virtual bool isDirectoryExistInternal(const std::string& dirPath) const override;

--- a/cocos/platform/linux/CCDevice-linux.cpp
+++ b/cocos/platform/linux/CCDevice-linux.cpp
@@ -27,6 +27,8 @@ THE SOFTWARE.
 #if CC_TARGET_PLATFORM == CC_PLATFORM_LINUX
 
 #include "platform/CCDevice.h"
+#include "platform/CCFileUtils.h"
+
 #include <X11/Xlib.h>
 #include <stdio.h>
 
@@ -36,7 +38,6 @@ THE SOFTWARE.
 #include <string>
 #include <sstream>
 #include <fontconfig/fontconfig.h>
-#include "platform/CCFileUtils.h"
 
 #include "ft2build.h"
 #include FT_FREETYPE_H

--- a/cocos/platform/win32/CCFileUtils-win32.cpp
+++ b/cocos/platform/win32/CCFileUtils-win32.cpp
@@ -237,24 +237,24 @@ bool FileUtilsWin32::isAbsolutePath(const std::string& strPath) const
 }
 
 
-FileUtils::Error FileUtilsWin32::getContents(const std::string& filename, ResizableBuffer* buffer)
+FileUtils::Status FileUtilsWin32::getContents(const std::string& filename, ResizableBuffer* buffer)
 {
     if (filename.empty())
-        return FileUtils::Error::NotExists;
+        return FileUtils::Status::NotExists;
 
     // read the file from hardware
     std::string fullPath = FileUtils::getInstance()->fullPathForFilename(filename);
 
     HANDLE fileHandle = ::CreateFile(StringUtf8ToWideChar(fullPath).c_str(), GENERIC_READ, FILE_SHARE_READ | FILE_SHARE_WRITE, NULL, OPEN_EXISTING, NULL, nullptr);
     if (fileHandle == INVALID_HANDLE_VALUE)
-        return FileUtils::Error::OpenFailed;
+        return FileUtils::Status::OpenFailed;
 
 	DWORD hi;
     auto size = ::GetFileSize(fileHandle, &hi);
 	if (hi > 0)
 	{
 		::CloseHandle(fileHandle);
-		return FileUtils::Error::TooLarge;
+		return FileUtils::Status::TooLarge;
 	}
     buffer->resize(size);
     DWORD sizeRead = 0;
@@ -264,9 +264,9 @@ FileUtils::Error FileUtilsWin32::getContents(const std::string& filename, Resiza
     if (!successed) {
 		CCLOG("Get data from file(%s) failed, error code is %s", filename.data(), std::to_string(::GetLastError()).data());
 		buffer->resize(sizeRead);
-		return FileUtils::Error::ReadFaild;
+		return FileUtils::Status::ReadFaild;
     }
-    return FileUtils::Error::OK;
+    return FileUtils::Status::OK;
 }
 
 std::string FileUtilsWin32::getPathForFilename(const std::string& filename, const std::string& resolutionDirectory, const std::string& searchPath) const

--- a/cocos/platform/win32/CCFileUtils-win32.h
+++ b/cocos/platform/win32/CCFileUtils-win32.h
@@ -107,9 +107,9 @@ protected:
     *  @return True if the directory have been removed successfully, false if not.
     */
     virtual bool removeDirectory(const std::string& dirPath) override;
-    
 
-	virtual FileUtils::Error getContents(const std::string& filename, ResizableBuffer* buffer) override;
+
+	virtual FileUtils::Status getContents(const std::string& filename, ResizableBuffer* buffer) override;
 
     /**
      *  Gets full path for filename, resolution directory and search path.
@@ -142,4 +142,3 @@ NS_CC_END
 #endif // CC_TARGET_PLATFORM == CC_PLATFORM_WIN32
 
 #endif    // __CC_FILEUTILS_WIN32_H__
-

--- a/cocos/platform/win32/CCFileUtils-win32.h
+++ b/cocos/platform/win32/CCFileUtils-win32.h
@@ -108,27 +108,8 @@ protected:
     */
     virtual bool removeDirectory(const std::string& dirPath) override;
     
-    /**
-     *  Gets resource file data
-     *
-     *  @param[in]  filename    The resource file name which contains the path.
-     *  @param[in]  mode        The read mode of the file.
-     *  @param[out] size        If the file read operation succeeds, it will be the data size, otherwise 0.
-     *  @return Upon success, a pointer to the data is returned, otherwise NULL.
-     *  @warning Recall: you are responsible for calling delete[] on any Non-NULL pointer returned.
-     */
-    CC_DEPRECATED_ATTRIBUTE virtual unsigned char* getFileData(const std::string& filename, const char* mode, ssize_t * size) override;
 
-    /**
-     *  Gets string from a file.
-     */
-    virtual std::string getStringFromFile(const std::string& filename) override;
-    
-    /**
-     *  Creates binary data from a file.
-     *  @return A data object.
-     */
-    virtual Data getDataFromFile(const std::string& filename) override;
+	virtual FileUtils::Error getContents(const std::string& filename, ResizableBuffer* buffer) override;
 
     /**
      *  Gets full path for filename, resolution directory and search path.

--- a/cocos/platform/winrt/CCFileUtilsWinRT.cpp
+++ b/cocos/platform/winrt/CCFileUtilsWinRT.cpp
@@ -331,16 +331,6 @@ bool CCFileUtilsWinRT::renameFile(const std::string &path, const std::string &ol
     return renameFile(oldPath, newPath);
 }
 
-std::string CCFileUtilsWinRT::getStringFromFile(const std::string& filename)
-{
-    Data data = getDataFromFile(filename);
-    if (data.isNull())
-    {
-        return "";
-    }
-    std::string ret((const char*)data.getBytes(), data.getSize());
-    return ret;
-}
 
 string CCFileUtilsWinRT::getWritablePath() const
 {

--- a/cocos/platform/winrt/CCFileUtilsWinRT.cpp
+++ b/cocos/platform/winrt/CCFileUtilsWinRT.cpp
@@ -142,23 +142,23 @@ long CCFileUtilsWinRT::getFileSize(const std::string &filepath)
     return (long)size.QuadPart;
 }
 
-FileUtils::Error CCFileUtilsWinRT::getContents(const std::string& filename, ResizableBuffer* buffer)
+FileUtils::Status CCFileUtilsWinRT::getContents(const std::string& filename, ResizableBuffer* buffer)
 {
     if (filename.empty())
-        return FileUtils::Error::NotExists;
+        return FileUtils::Status::NotExists;
 	
     // read the file from hardware
     std::string fullPath = FileUtils::getInstance()->fullPathForFilename(filename);
 
     HANDLE fileHandle = ::CreateFile2(StringUtf8ToWideChar(fullPath).c_str(), GENERIC_READ, FILE_SHARE_READ | FILE_SHARE_WRITE, OPEN_EXISTING, nullptr);
     if (fileHandle == INVALID_HANDLE_VALUE)
-        return FileUtils::Error::OpenFailed;
+        return FileUtils::Status::OpenFailed;
 
 	LARGE_INTEGER lisize;
     ::GetFileSizeEx(fileHandle, &lisize);
 	if (lisize.HighPart > 0) {
 		::CloseHandle(fileHandle);
-		return FileUtils::Error::TooLarge;
+		return FileUtils::Status::TooLarge;
 	}
 
     buffer->resize(lisize.LowPart);
@@ -169,9 +169,9 @@ FileUtils::Error CCFileUtilsWinRT::getContents(const std::string& filename, Resi
     if (!successed) {
         buffer->resize(sizeRead);
 		CCLOG("Get data from file(%s) failed, error code is %s", filename.data(), std::to_string(::GetLastError()).data());
-		return FileUtils::Error::ReadFaild;
+		return FileUtils::Status::ReadFaild;
     }
-    return FileUtils::Error::OK;
+    return FileUtils::Status::OK;
 }
 
 bool CCFileUtilsWinRT::isFileExistInternal(const std::string& strFilePath) const

--- a/cocos/platform/winrt/CCFileUtilsWinRT.cpp
+++ b/cocos/platform/winrt/CCFileUtilsWinRT.cpp
@@ -157,7 +157,7 @@ FileUtils::Status CCFileUtilsWinRT::getContents(const std::string& filename, Res
     FILE_STANDARD_INFO info = {0};
     if (::GetFileInformationByHandleEx(fileHandle, FileStandardInfo, &info, sizeof(info)) == 0)
     {
-        ::CloseHandle(hFile);
+        ::CloseHandle(fileHandle);
         return FileUtils::Status::OpenFailed;
     }
 

--- a/cocos/platform/winrt/CCFileUtilsWinRT.h
+++ b/cocos/platform/winrt/CCFileUtilsWinRT.h
@@ -53,7 +53,8 @@ public:
     virtual std::string getPathForFilename(const std::string& filename, const std::string& resolutionDirectory, const std::string& searchPath) const override;
     virtual std::string getFullPathForDirectoryAndFilename(const std::string& strDirectory, const std::string& strFilename) const override;
     virtual std::string getSuitableFOpen(const std::string& filenameUtf8) const override;
-    virtual long getFileSize(const std::string &filepath);
+    virtual long getFileSize(const std::string &filepath) override;
+	virtual FileUtils::Error getContents(const std::string& filename, ResizableBuffer* buffer) override;
 	static std::string getAppPath();
 
 private:

--- a/cocos/platform/winrt/CCFileUtilsWinRT.h
+++ b/cocos/platform/winrt/CCFileUtilsWinRT.h
@@ -54,7 +54,7 @@ public:
     virtual std::string getFullPathForDirectoryAndFilename(const std::string& strDirectory, const std::string& strFilename) const override;
     virtual std::string getSuitableFOpen(const std::string& filenameUtf8) const override;
     virtual long getFileSize(const std::string &filepath) override;
-	virtual FileUtils::Error getContents(const std::string& filename, ResizableBuffer* buffer) override;
+	virtual FileUtils::Status getContents(const std::string& filename, ResizableBuffer* buffer) override;
 	static std::string getAppPath();
 
 private:

--- a/cocos/platform/winrt/CCFileUtilsWinRT.h
+++ b/cocos/platform/winrt/CCFileUtilsWinRT.h
@@ -52,7 +52,6 @@ public:
     virtual bool isAbsolutePath(const std::string& strPath) const;
     virtual std::string getPathForFilename(const std::string& filename, const std::string& resolutionDirectory, const std::string& searchPath) const override;
     virtual std::string getFullPathForDirectoryAndFilename(const std::string& strDirectory, const std::string& strFilename) const override;
-	virtual std::string getStringFromFile(const std::string& filename) override;
     virtual std::string getSuitableFOpen(const std::string& filenameUtf8) const override;
     virtual long getFileSize(const std::string &filepath);
 	static std::string getAppPath();

--- a/tests/cpp-tests/Classes/FileUtilsTest/FileUtilsTest.cpp
+++ b/tests/cpp-tests/Classes/FileUtilsTest/FileUtilsTest.cpp
@@ -653,7 +653,7 @@ void TestReadAll::onEnter()
 
     std::string sbuf;
     auto serr = FileUtils::getInstance()->getContents(fullPath, &sbuf);
-    if (serr != FileError::OK)
+    if (serr != FileUtils::Error::OK)
     {
         readResult->setString("getContents() failed: error: " + errors[(int)serr]);
         return;
@@ -661,7 +661,7 @@ void TestReadAll::onEnter()
 
     std::vector<int> vbuf;
     auto verr = FileUtils::getInstance()->getContents(fullPath, &vbuf);
-    if (verr != FileError::OK)
+    if (verr != FileUtils::Error::OK)
     {
         readResult->setString("getContents() failed: error: " + errors[(int)verr]);
         return;
@@ -669,7 +669,7 @@ void TestReadAll::onEnter()
 
     Data dbuf;
     auto derr = FileUtils::getInstance()->getContents(fullPath, &dbuf);
-    if (derr != FileError::OK)
+    if (derr != FileUtils::Error::OK)
     {
         readResult->setString("getContents() failed: error: " + errors[(int)derr]);
         return;

--- a/tests/cpp-tests/Classes/FileUtilsTest/FileUtilsTest.cpp
+++ b/tests/cpp-tests/Classes/FileUtilsTest/FileUtilsTest.cpp
@@ -624,7 +624,8 @@ static const std::string FileErrors[] = {
     "OpenFailed",
     "ReadFaild",
     "NotInitialized",
-    "TooLarge"
+    "TooLarge",
+    "ObtainSizeFailed",
 };
 
 

--- a/tests/cpp-tests/Classes/FileUtilsTest/FileUtilsTest.cpp
+++ b/tests/cpp-tests/Classes/FileUtilsTest/FileUtilsTest.cpp
@@ -593,6 +593,23 @@ std::string TestWriteString::subtitle() const
     return "";
 }
 
+class CustomBuffer : public ResizableBuffer {};
+
+struct AlreadyExistsBuffer {};
+
+NS_CC_BEGIN
+template<>
+class ResizableBufferAdapter<AlreadyExistsBuffer> : public ResizableBuffer {
+public:
+    explicit ResizableBufferAdapter(AlreadyExistsBuffer* buffer) {}
+    virtual void resize(size_t size) override {
+
+    }
+    virtual void* buffer() const override {
+
+    }
+};
+NS_CC_END
 
 void TestReadAll::onEnter()
 {
@@ -658,6 +675,11 @@ void TestReadAll::onEnter()
         return;
     }
 
+    auto test_if_compiles = [fullPath]() {
+        FileUtils::getInstance()->getContents(fullPath, (CustomBuffer*)(nullptr));
+        AlreadyExistsBuffer buf;
+        FileUtils::getInstance()->getContents(fullPath, &buf);
+    };
 
     if (memcmp(&sbuf.front(), &vbuf.front(), sbuf.size()) != 0)
     {

--- a/tests/cpp-tests/Classes/FileUtilsTest/FileUtilsTest.cpp
+++ b/tests/cpp-tests/Classes/FileUtilsTest/FileUtilsTest.cpp
@@ -654,7 +654,7 @@ void TestGetContents::onEnter()
     std::string otext;
     fs->getContents(generated, &otext);
     if (text != otext) {
-        readResult->setString("getContents() failed");
+        readResult->setString("FileUtils::getContents() failed: CRLF or zero handling error");
         return;
     }
     
@@ -678,7 +678,7 @@ void TestGetContents::onEnter()
         auto serr = fs->getContents(file, &sbuf);
         if (serr != FileUtils::Error::OK)
         {
-            readResult->setString("getContents() failed: error: " + errors[(int)serr]);
+            readResult->setString("FileUtils::getContents() failed: error: " + errors[(int)serr]);
             return;
         }
         
@@ -686,7 +686,7 @@ void TestGetContents::onEnter()
         auto verr = fs->getContents(file, &vbuf);
         if (verr != FileUtils::Error::OK)
         {
-            readResult->setString("getContents() failed: error: " + errors[(int)verr]);
+            readResult->setString("FileUtils::getContents() failed: error: " + errors[(int)verr]);
             return;
         }
         
@@ -694,13 +694,13 @@ void TestGetContents::onEnter()
         auto derr = fs->getContents(file, &dbuf);
         if (derr != FileUtils::Error::OK)
         {
-            readResult->setString("getContents() failed: error: " + errors[(int)derr]);
+            readResult->setString("FileUtils::getContents() failed: error: " + errors[(int)derr]);
             return;
         }
 
         if (memcmp(&sbuf.front(), &vbuf.front(), sbuf.size()) != 0)
         {
-            readResult->setString("getContents() failed: error: sbuf != vbuf");
+            readResult->setString("FileUtils::getContents() failed: error: sbuf != vbuf");
             return;
         }
         
@@ -708,7 +708,7 @@ void TestGetContents::onEnter()
         {
             auto s1 = sbuf.size();
             auto s2 = dbuf.getSize();
-            auto s = StringUtils::format("getContents() failed: error: sbuf.size() != dbuf.getSize() (%d vs %d)",
+            auto s = StringUtils::format("FileUtils::getContents() failed: error: sbuf.size() != dbuf.getSize() (%d vs %d)",
                                 (int)s1, (int)s2);
             readResult->setString(s);
             return;
@@ -716,7 +716,7 @@ void TestGetContents::onEnter()
         
         if (memcmp(&sbuf.front(), dbuf.getBytes(), sbuf.size()) != 0)
         {
-            readResult->setString("getContents() failed: error: sbuf != dbuf");
+            readResult->setString("FileUtils::getContents() failed: error: sbuf != dbuf");
             return;
         }
         

--- a/tests/cpp-tests/Classes/FileUtilsTest/FileUtilsTest.cpp
+++ b/tests/cpp-tests/Classes/FileUtilsTest/FileUtilsTest.cpp
@@ -645,11 +645,19 @@ void TestGetContents::onEnter()
     specialchars.push_back('\r');
     specialchars.push_back('\n');
     
-    std::string text(text.begin(), text.end());
+    std::string text(specialchars.begin(), specialchars.end());
     
     std::string generated(fs->getWritablePath() + "file-with-zeros-and-crlf");
 
     fs->writeStringToFile(text, generated);
+    
+    std::string otext;
+    fs->getContents(generated, &otext);
+    if (text != otext) {
+        readResult->setString("getContents() failed");
+        return;
+    }
+    
     
     std::string files[] = {"background.wav", "fileLookup.plist", generated};
 

--- a/tests/cpp-tests/Classes/FileUtilsTest/FileUtilsTest.cpp
+++ b/tests/cpp-tests/Classes/FileUtilsTest/FileUtilsTest.cpp
@@ -670,17 +670,17 @@ void TestGetContents::onEnter()
             std::string sbuf;
 
             auto serr = fs->getContents(file, &sbuf);
-            if (serr != FileUtils::Error::OK)
+            if (serr != FileUtils::Status::OK)
                 return std::string("failed: error: " + FileErrors[(int)serr]);
 
             std::vector<int> vbuf;
             auto verr = fs->getContents(file, &vbuf);
-            if (verr != FileUtils::Error::OK)
+            if (verr != FileUtils::Status::OK)
                 return std::string("failed: error: " + FileErrors[(int)verr]);
 
             Data dbuf;
             auto derr = fs->getContents(file, &dbuf);
-            if (derr != FileUtils::Error::OK)
+            if (derr != FileUtils::Status::OK)
                 return std::string("failed: error: " + FileErrors[(int)derr]);
 
             if (memcmp(&sbuf.front(), &vbuf.front(), sbuf.size()) != 0)

--- a/tests/cpp-tests/Classes/FileUtilsTest/FileUtilsTest.cpp
+++ b/tests/cpp-tests/Classes/FileUtilsTest/FileUtilsTest.cpp
@@ -623,7 +623,8 @@ static const std::string FileErrors[] = {
     "NotExists",
     "OpenFailed",
     "ReadFaild",
-    "NotInitialized"
+    "NotInitialized",
+    "TooLarge"
 };
 
 

--- a/tests/cpp-tests/Classes/FileUtilsTest/FileUtilsTest.cpp
+++ b/tests/cpp-tests/Classes/FileUtilsTest/FileUtilsTest.cpp
@@ -656,17 +656,12 @@ void TestGetContents::onEnter()
         std::string bs;
         fs->getContents(generated_file, &bs);
         if ( bs.size() != binary.size() || !std::equal( bs.begin(), bs.end(), binary.begin() ) )
-            return std::string("failed: read CRLFs and zeros in binary mode");
+            return std::string("failed: read as binary string");
 
         // Text read string in text mode
         std::string ts = fs->getStringFromFile(generated_file);
-#if CC_TARGET_PLATFORM == CC_PLATFORM_WIN32
-        if (ts != "\n\n")
-            return std::string("failed: read CRLFs and zeros in text mode");
-#else
         if (ts != "\r\n\r\n")
-            return std::string("failed: read CRLFs and zeros in text mode");
-#endif
+            return std::string("failed: read as zero terminated string");
 
 
         std::string files[] = {generated_file, "background.wav", "fileLookup.plist"};

--- a/tests/cpp-tests/Classes/FileUtilsTest/FileUtilsTest.cpp
+++ b/tests/cpp-tests/Classes/FileUtilsTest/FileUtilsTest.cpp
@@ -632,13 +632,13 @@ void TestGetContents::onEnter()
     FileUtilsDemo::onEnter();
     auto fs = FileUtils::getInstance();
 
-    auto test_if_compiles = [fs]() {
+    auto testIfCompiles = [fs]() {
         fs->getContents("", (CustomBuffer*)(nullptr));
         AlreadyExistsBuffer buf;
         fs->getContents("", &buf);
     };
 
-    (void)(test_if_compiles);
+    (void)(testIfCompiles);
 
     auto winSize = Director::getInstance()->getWinSize();
 
@@ -647,19 +647,19 @@ void TestGetContents::onEnter()
     readResult->setPosition(winSize.width / 2, winSize.height / 2);
 
     std::vector<char> binary = {'\r','\n','\r','\n','\0','\0','\r','\n'};
-    generated_file = fs->getWritablePath() + "file-with-zeros-and-crlf";
-    saveAsBinaryText(generated_file, binary);
-    
+    _generatedFile = fs->getWritablePath() + "file-with-zeros-and-crlf";
+    saveAsBinaryText(_generatedFile, binary);
+
 
     auto runTests = [&]() {
         // Test read string in binary mode
         std::string bs;
-        fs->getContents(generated_file, &bs);
+        fs->getContents(_generatedFile, &bs);
         if ( bs.size() != binary.size() || !std::equal( bs.begin(), bs.end(), binary.begin() ) )
             return std::string("failed: read CRLFs and zeros in binary mode");
 
         // Text read string in text mode
-        std::string ts = fs->getStringFromFile(generated_file);
+        std::string ts = fs->getStringFromFile(_generatedFile);
 #if CC_TARGET_PLATFORM == CC_PLATFORM_WIN32
         if (ts != "\n\n")
             return std::string("failed: read CRLFs and zeros in text mode");
@@ -669,7 +669,7 @@ void TestGetContents::onEnter()
 #endif
 
 
-        std::string files[] = {generated_file, "background.wav", "fileLookup.plist"};
+        std::string files[] = {_generatedFile, "background.wav", "fileLookup.plist"};
         for (auto& file : files) {
             std::string sbuf;
 
@@ -703,8 +703,8 @@ void TestGetContents::onEnter()
 
 void TestGetContents::onExit()
 {
-    if (!generated_file.empty())
-        FileUtils::getInstance()->removeFile(generated_file);
+    if (!_generatedFile.empty())
+        FileUtils::getInstance()->removeFile(_generatedFile);
 
     FileUtilsDemo::onExit();
 }

--- a/tests/cpp-tests/Classes/FileUtilsTest/FileUtilsTest.h
+++ b/tests/cpp-tests/Classes/FileUtilsTest/FileUtilsTest.h
@@ -113,10 +113,10 @@ public:
     virtual std::string subtitle() const override;
 };
 
-class TestReadAll : public FileUtilsDemo
+class TestGetContents : public FileUtilsDemo
 {
 public:
-    CREATE_FUNC(TestReadAll);
+    CREATE_FUNC(TestGetContents);
     
     virtual void onEnter() override;
     virtual void onExit() override;

--- a/tests/cpp-tests/Classes/FileUtilsTest/FileUtilsTest.h
+++ b/tests/cpp-tests/Classes/FileUtilsTest/FileUtilsTest.h
@@ -113,6 +113,17 @@ public:
     virtual std::string subtitle() const override;
 };
 
+class TestReadAll : public FileUtilsDemo
+{
+public:
+    CREATE_FUNC(TestReadAll);
+    
+    virtual void onEnter() override;
+    virtual void onExit() override;
+    virtual std::string title() const override;
+    virtual std::string subtitle() const override;
+};
+
 class TestWriteData : public FileUtilsDemo
 {
 public:

--- a/tests/cpp-tests/Classes/FileUtilsTest/FileUtilsTest.h
+++ b/tests/cpp-tests/Classes/FileUtilsTest/FileUtilsTest.h
@@ -64,7 +64,7 @@ class TestIsDirectoryExist : public FileUtilsDemo
 {
 public:
     CREATE_FUNC(TestIsDirectoryExist);
-    
+
     virtual void onEnter() override;
     virtual void onExit() override;
     virtual std::string title() const override;
@@ -117,11 +117,13 @@ class TestGetContents : public FileUtilsDemo
 {
 public:
     CREATE_FUNC(TestGetContents);
-    
+
     virtual void onEnter() override;
     virtual void onExit() override;
     virtual std::string title() const override;
     virtual std::string subtitle() const override;
+private:
+    std::string generated_file;
 };
 
 class TestWriteData : public FileUtilsDemo
@@ -161,7 +163,7 @@ class TestUnicodePath : public FileUtilsDemo
 {
 public:
     CREATE_FUNC(TestUnicodePath);
-    
+
     virtual void onEnter() override;
     virtual void onExit() override;
     virtual std::string title() const override;

--- a/tests/cpp-tests/Classes/FileUtilsTest/FileUtilsTest.h
+++ b/tests/cpp-tests/Classes/FileUtilsTest/FileUtilsTest.h
@@ -123,7 +123,7 @@ public:
     virtual std::string title() const override;
     virtual std::string subtitle() const override;
 private:
-    std::string generated_file;
+    std::string _generatedFile;
 };
 
 class TestWriteData : public FileUtilsDemo

--- a/tools/tojs/cocos2dx.ini
+++ b/tools/tojs/cocos2dx.ini
@@ -106,7 +106,7 @@ skip = Node::[^setPosition$ setGLServerState description getUserObject .*UserDat
         Scheduler::[pause resume ^unschedule$ unscheduleUpdate unscheduleAllForTarget schedule isTargetPaused isScheduled],
         TextureCache::[addPVRTCImage],
         *::[copyWith.* ^cleanup$ onEnter.* onExit.* ^description$ getObjectType onTouch.* onAcc.* onKey.* onRegisterTouchListener operator.+],
-        FileUtils::[getFileData getDataFromFile writeDataToFile setFilenameLookupDictionary destroyInstance getFullPathCache],
+        FileUtils::[getFileData getDataFromFile writeDataToFile setFilenameLookupDictionary destroyInstance getFullPathCache getContents],
         Application::[^application.* ^run$ getCurrentLanguageCode setAnimationInterval],
         Camera::[getEyeXYZ getCenterXYZ getUpXYZ],
         ccFontDefinition::[*],

--- a/tools/tolua/cocos2dx.ini
+++ b/tools/tolua/cocos2dx.ini
@@ -100,7 +100,7 @@ skip = Node::[setGLServerState description getUserObject .*UserData getGLServerS
         TextureCache::[addPVRTCImage addImageAsync],
         Timer::[getSelector createWithScriptHandler],
         *::[copyWith.* onEnter.* onExit.* ^description$ getObjectType (g|s)etDelegate onTouch.* onAcc.* onKey.* onRegisterTouchListener],
-        FileUtils::[getFileData getDataFromFile writeDataToFile getFullPathCache],
+        FileUtils::[getFileData getDataFromFile writeDataToFile getFullPathCache getContents],
         Application::[^application.* ^run$],
         Camera::[getEyeXYZ getCenterXYZ getUpXYZ],
         ccFontDefinition::[*],
@@ -173,4 +173,3 @@ abstract_classes = Action FiniteTimeAction ActionInterval ActionEase EaseRateAct
 
 # Determining whether to use script object(js object) to control the lifecycle of native(cpp) object or the other way around. Supported values are 'yes' or 'no'.
 script_control_cpp = no
-


### PR DESCRIPTION
Why another file read API?

Current APIs has some problem:
1. `FileUtils::getDataFormFile()` can't return string, convert from Data to string will make extra copy.
2. `FileUtils::getStringFormFile()` can't read binary file, and it truncate contents.
3. `FileUtils::getDataFormFile()` and `FileUtils::getStringFormFile()` does not tell different from empty file and io errors.

Advantage of `FileUtils::getContents()`
1. Support read into `cocos2d::Data` `std::basic_string` and `std::vector`
2. It has abstract of the output buffer, custom type of buffer object can be adapted by writing subclass `ResizableBuffer`.
3. It returns error code, so that we can know the different form empty file and io error.
