### PR TITLE
Fixed a bug that audio resources

### DIFF
--- a/tests/js-tests/src/CocosDenshionTest/CocosDenshionTest.js
+++ b/tests/js-tests/src/CocosDenshionTest/CocosDenshionTest.js
@@ -232,7 +232,7 @@ var soundId = null;
 var playMusic = function () {
     cc.log("play background music");
     var musicFile = MUSIC_FILE;
-    if (cc.sys.os == cc.sys.OS_ANDROID) {
+    if (cc.sys.isNative && cc.sys.os == cc.sys.OS_ANDROID) {
         musicFile = "res/"+musicFile;
     }
     audioEngine.playMusic(musicFile, false);


### PR DESCRIPTION
@pandamicro 
Why does JSB need to add 'res'?
