### PR TITLE
Fix unused variable warning when building with Xcode

### DIFF
--- a/cocos/base/CCStencilStateManager.cpp
+++ b/cocos/base/CCStencilStateManager.cpp
@@ -38,7 +38,6 @@
 NS_CC_BEGIN
 
 GLint StencilStateManager::s_layer = -1;
-static GLint g_sStencilBits = -1;
 
 StencilStateManager::StencilStateManager()
 : _alphaThreshold(1.0f)


### PR DESCRIPTION
This gets rid of the unused variable warning that was generated by commit 926a4c8d4a85f3b1b20721c9e66ee572ecedb987 with Xcode 7.3:

```
cocos/base/CCStencilStateManager.cpp:41:14: Unused variable 'g_sStencilBits'
```
