### PR TITLE
Renamed ignoreAnchorPointForPosition()

### DIFF
--- a/cocos/2d/CCMenu.cpp
+++ b/cocos/2d/CCMenu.cpp
@@ -137,7 +137,7 @@ bool Menu::initWithArray(const Vector<MenuItem*>& arrayOfItems)
         // menu in the center of the screen
         Size s = Director::getInstance()->getWinSize();
 
-        this->ignoreAnchorPointForPosition(true);
+        this->setIgnoreAnchorPointForPosition(true);
         setAnchorPoint(Vec2(0.5f, 0.5f));
         this->setContentSize(s);
 

--- a/cocos/2d/CCMotionStreak.cpp
+++ b/cocos/2d/CCMotionStreak.cpp
@@ -102,7 +102,7 @@ bool MotionStreak::initWithFade(float fade, float minSeg, float stroke, const Co
 {
     Node::setPosition(Vec2::ZERO);
     setAnchorPoint(Vec2::ZERO);
-    ignoreAnchorPointForPosition(true);
+    setIgnoreAnchorPointForPosition(true);
     _startingPositionInitialized = false;
 
     _positionR.setZero();

--- a/cocos/2d/CCNode.cpp
+++ b/cocos/2d/CCNode.cpp
@@ -653,8 +653,9 @@ bool Node::isIgnoreAnchorPointForPosition() const
 {
     return _ignoreAnchorPointForPosition;
 }
+
 /// isRelativeAnchorPoint setter
-void Node::ignoreAnchorPointForPosition(bool newValue)
+void Node::setIgnoreAnchorPointForPosition(bool newValue)
 {
     if (newValue != _ignoreAnchorPointForPosition) 
     {

--- a/cocos/2d/CCNode.cpp
+++ b/cocos/2d/CCNode.cpp
@@ -1,5 +1,3 @@
-
-
 /****************************************************************************
 Copyright (c) 2008-2010 Ricardo Quesada
 Copyright (c) 2009      Valentin Milea

--- a/cocos/2d/CCNode.h
+++ b/cocos/2d/CCNode.h
@@ -705,13 +705,14 @@ public:
      * The default value is false, while in Layer and Scene are true.
      *
      * @param ignore    true if anchor point will be (0,0) when you position this node.
-     * @todo This method should be renamed as setIgnoreAnchorPointForPosition(bool) or something with "set".
      */
-    virtual void ignoreAnchorPointForPosition(bool ignore);
+    virtual void setIgnoreAnchorPointForPosition(bool ignore);
+    CC_DEPRECATED_ATTRIBUTE virtual void ignoreAnchorPointForPosition(bool ignore) { setIgnoreAnchorPointForPosition(ignore); }
+    
     /**
      * Gets whether the anchor point will be (0,0) when you position this node.
      *
-     * @see `ignoreAnchorPointForPosition(bool)`
+     * @see `setIgnoreAnchorPointForPosition(bool)`
      *
      * @return true if the anchor point will be (0,0) when you position this node.
      */
@@ -1264,7 +1265,6 @@ public:
      * Composable actions are counted as 1 action. Example:
      *    If you are running 1 Sequence of 7 actions, it will return 1.
      *    If you are running 7 Sequences of 2 actions, it will return 7.
-     * @todo Rename to getNumberOfRunningActions()
      *
      * @return The number of actions that are running plus the ones that are schedule to run.
      */

--- a/cocos/2d/CCSprite.cpp
+++ b/cocos/2d/CCSprite.cpp
@@ -924,10 +924,10 @@ void Sprite::setAnchorPoint(const Vec2& anchor)
     SET_DIRTY_RECURSIVELY();
 }
 
-void Sprite::ignoreAnchorPointForPosition(bool value)
+void Sprite::setIgnoreAnchorPointForPosition(bool value)
 {
-    CCASSERT(! _batchNode, "ignoreAnchorPointForPosition is invalid in Sprite");
-    Node::ignoreAnchorPointForPosition(value);
+    CCASSERT(! _batchNode, "setIgnoreAnchorPointForPosition is invalid in Sprite");
+    Node::setIgnoreAnchorPointForPosition(value);
 }
 
 void Sprite::setVisible(bool bVisible)

--- a/cocos/2d/CCSprite.h
+++ b/cocos/2d/CCSprite.h
@@ -467,7 +467,12 @@ public:
     virtual void setScale(float scale) override;
     virtual void setPositionZ(float positionZ) override;
     virtual void setAnchorPoint(const Vec2& anchor) override;
-    virtual void ignoreAnchorPointForPosition(bool value) override;
+    
+    virtual void setIgnoreAnchorPointForPosition(bool value) override;
+    
+    // @deprecated Use setIgnoreAnchorPointForPosition() instead.
+    CC_DEPRECATED_ATTRIBUTE virtual void ignoreAnchorPointForPosition(bool value) override { setIgnoreAnchorPointForPosition(value); }
+    
     virtual void setVisible(bool bVisible) override;
     virtual void draw(Renderer *renderer, const Mat4 &transform, uint32_t flags) override;
     virtual void setOpacityModifyRGB(bool modify) override;

--- a/cocos/3d/CCMotionStreak3D.cpp
+++ b/cocos/3d/CCMotionStreak3D.cpp
@@ -104,7 +104,7 @@ bool MotionStreak3D::initWithFade(float fade, float minSeg, float stroke, const 
 {
     Node::setPosition(Vec2::ZERO);
     setAnchorPoint(Vec2::ZERO);
-    ignoreAnchorPointForPosition(true);
+    setIgnoreAnchorPointForPosition(true);
     _startingPositionInitialized = false;
 
     _positionR.setZero();

--- a/cocos/editor-support/cocosbuilder/CCBReader.cpp
+++ b/cocos/editor-support/cocosbuilder/CCBReader.cpp
@@ -604,7 +604,7 @@ Node * CCBReader::readNodeGraph(Node * pParent)
         embeddedNode->setScaleY(ccbFileNode->getScaleY());
         embeddedNode->setTag(ccbFileNode->getTag());
         embeddedNode->setVisible(true);
-        //embeddedNode->ignoreAnchorPointForPosition(ccbFileNode->isIgnoreAnchorPointForPosition());
+        //embeddedNode->setIgnoreAnchorPointForPosition(ccbFileNode->isIgnoreAnchorPointForPosition());
         
         _animationManager->moveAnimationsFromNode(ccbFileNode, embeddedNode);
 

--- a/cocos/editor-support/cocosbuilder/CCNodeLoader.cpp
+++ b/cocos/editor-support/cocosbuilder/CCNodeLoader.cpp
@@ -1097,7 +1097,7 @@ void NodeLoader::onHandlePropTypeCheck(Node * pNode, Node * pParent, const char*
     if(strcmp(pPropertyName, PROPERTY_VISIBLE) == 0) {
         pNode->setVisible(pCheck);
     } else if(strcmp(pPropertyName, PROPERTY_IGNOREANCHORPOINTFORPOSITION) == 0) {
-        pNode->ignoreAnchorPointForPosition(pCheck);
+        pNode->setIgnoreAnchorPointForPosition(pCheck);
     } else {
         //ASSERT_FAIL_UNEXPECTED_PROPERTY(pPropertyName);
         // It may be a custom property, add it to custom property dictionary.

--- a/extensions/GUI/CCControlExtension/CCControlButton.cpp
+++ b/extensions/GUI/CCControlExtension/CCControlButton.cpp
@@ -87,7 +87,7 @@ bool ControlButton::initWithLabelAndBackgroundSprite(Node* node, ui::Scale9Sprit
         _scaleRatio = 1.1f;
         
         // Set the default anchor point
-        ignoreAnchorPointForPosition(false);
+        setIgnoreAnchorPointForPosition(false);
         setAnchorPoint(Vec2::ANCHOR_MIDDLE);
         
         // Set the nodes

--- a/extensions/GUI/CCControlExtension/CCControlSlider.cpp
+++ b/extensions/GUI/CCControlExtension/CCControlSlider.cpp
@@ -122,7 +122,7 @@ bool ControlSlider::initWithSprites(Sprite * backgroundSprite, Sprite* progressS
         CCASSERT(thumbSprite,           "Thumb sprite must be not nil");
         CCASSERT(selectedThumbSprite,   "Thumb sprite must be not nil");
 
-        ignoreAnchorPointForPosition(false);
+        setIgnoreAnchorPointForPosition(false);
 
         this->setBackgroundSprite(backgroundSprite);
         this->setProgressSprite(progressSprite);

--- a/extensions/GUI/CCControlExtension/CCControlStepper.cpp
+++ b/extensions/GUI/CCControlExtension/CCControlStepper.cpp
@@ -82,7 +82,7 @@ bool ControlStepper::initWithMinusSpriteAndPlusSprite(Sprite *minusSprite, Sprit
         _value                              = 0;
         _stepValue                          = 1;
         _wraps                              = false;
-        this->ignoreAnchorPointForPosition( false );
+        this->setIgnoreAnchorPointForPosition( false );
     
         // Add the minus components
         this->setMinusSprite(minusSprite);

--- a/extensions/GUI/CCControlExtension/CCControlSwitch.cpp
+++ b/extensions/GUI/CCControlExtension/CCControlSwitch.cpp
@@ -329,7 +329,7 @@ bool ControlSwitch::initWithMaskSprite(Sprite *maskSprite, Sprite * onSprite, Sp
         _switchSprite->setPosition(_switchSprite->getContentSize().width / 2, _switchSprite->getContentSize().height / 2);
         addChild(_switchSprite);
         
-        ignoreAnchorPointForPosition(false);
+        setIgnoreAnchorPointForPosition(false);
         setAnchorPoint(Vec2(0.5f, 0.5f));
         setContentSize(_switchSprite->getContentSize());
         return true;

--- a/extensions/GUI/CCScrollView/CCScrollView.cpp
+++ b/extensions/GUI/CCScrollView/CCScrollView.cpp
@@ -112,7 +112,7 @@ bool ScrollView::initWithViewSize(Size size, Node *container/* = nullptr*/)
         if (!this->_container)
         {
             _container = Layer::create();
-            _container->ignoreAnchorPointForPosition(false);
+            _container->setIgnoreAnchorPointForPosition(false);
             _container->setAnchorPoint(Vec2(0.0f, 0.0f));
         }
 
@@ -346,7 +346,7 @@ void ScrollView::setContainer(Node * pContainer)
     this->removeAllChildrenWithCleanup(true);
     this->_container = pContainer;
 
-    this->_container->ignoreAnchorPointForPosition(false);
+    this->_container->setIgnoreAnchorPointForPosition(false);
     this->_container->setAnchorPoint(Vec2(0.0f, 0.0f));
 
     this->addChild(this->_container);

--- a/tests/cpp-tests/Classes/ActionsTest/ActionsTest.cpp
+++ b/tests/cpp-tests/Classes/ActionsTest/ActionsTest.cpp
@@ -333,7 +333,7 @@ void ActionRotationalSkewVSStandardSkew::onEnter()
     auto box = LayerColor::create(Color4B(255,255,0,255));
     box->setAnchorPoint(Vec2(0.5,0.5));
     box->setContentSize( boxSize );
-    box->ignoreAnchorPointForPosition(false);
+    box->setIgnoreAnchorPointForPosition(false);
     box->setPosition(s.width/2, s.height - 100 - box->getContentSize().height/2);
     this->addChild(box);
 
@@ -349,7 +349,7 @@ void ActionRotationalSkewVSStandardSkew::onEnter()
     box = LayerColor::create(Color4B(255,255,0,255));
     box->setAnchorPoint(Vec2(0.5,0.5));
     box->setContentSize(boxSize);
-    box->ignoreAnchorPointForPosition(false);
+    box->setIgnoreAnchorPointForPosition(false);
     box->setPosition(s.width/2, s.height - 250 - box->getContentSize().height/2);
     this->addChild(box);
 

--- a/tests/cpp-tests/Classes/BugsTest/Bug-1159.cpp
+++ b/tests/cpp-tests/Classes/BugsTest/Bug-1159.cpp
@@ -22,7 +22,7 @@ bool Bug1159Layer::init()
 
         auto sprite_a = LayerColor::create(Color4B(255, 0, 0, 255), 700, 700);
         sprite_a->setAnchorPoint(Vec2(0.5f, 0.5f));
-        sprite_a->ignoreAnchorPointForPosition(false);
+        sprite_a->setIgnoreAnchorPointForPosition(false);
         sprite_a->setPosition(0.0f, s.height/2);
         addChild(sprite_a);
 
@@ -33,7 +33,7 @@ bool Bug1159Layer::init()
 
         auto sprite_b = LayerColor::create(Color4B(0, 0, 255, 255), 400, 400);
         sprite_b->setAnchorPoint(Vec2(0.5f, 0.5f));
-        sprite_b->ignoreAnchorPointForPosition(false);
+        sprite_b->setIgnoreAnchorPointForPosition(false);
         sprite_b->setPosition(s.width/2, s.height/2);
         addChild(sprite_b);
 

--- a/tests/cpp-tests/Classes/BugsTest/Bug-914.cpp
+++ b/tests/cpp-tests/Classes/BugsTest/Bug-914.cpp
@@ -32,7 +32,7 @@ bool Bug914Layer::init()
             layer->setContentSize(Size(i*100, i*100));
             layer->setPosition(size.width/2, size.height/2);
             layer->setAnchorPoint(Vec2(0.5f, 0.5f));
-            layer->ignoreAnchorPointForPosition(false);
+            layer->setIgnoreAnchorPointForPosition(false);
             addChild(layer, -1-i);
         }
 

--- a/tests/cpp-tests/Classes/FontTest/FontTest.cpp
+++ b/tests/cpp-tests/Classes/FontTest/FontTest.cpp
@@ -79,9 +79,9 @@ void FontTest::showFont(const std::string& fontFile)
     auto centerColor = LayerColor::create(Color4B(200, 100, 100, 255), blockSize.width, blockSize.height);
     auto rightColor = LayerColor::create(Color4B(100, 100, 200, 255), blockSize.width, blockSize.height);
 
-    leftColor->ignoreAnchorPointForPosition(false);
-    centerColor->ignoreAnchorPointForPosition(false);
-    rightColor->ignoreAnchorPointForPosition(false);
+    leftColor->setIgnoreAnchorPointForPosition(false);
+    centerColor->setIgnoreAnchorPointForPosition(false);
+    rightColor->setIgnoreAnchorPointForPosition(false);
 
 
     top->setAnchorPoint(Vec2(0.5, 1));

--- a/tests/cpp-tests/Classes/LayerTest/LayerTest.cpp
+++ b/tests/cpp-tests/Classes/LayerTest/LayerTest.cpp
@@ -372,7 +372,7 @@ void LayerTest1::onEnter()
     auto s = Director::getInstance()->getWinSize();
     auto layer = LayerColor::create( Color4B(0xFF, 0x00, 0x00, 0x80), 200, 200); 
     
-    layer->ignoreAnchorPointForPosition(false);
+    layer->setIgnoreAnchorPointForPosition(false);
     layer->setPosition( Vec2(s.width/2, s.height/2) );
     addChild(layer, 1, kTagLayer);
 }
@@ -422,12 +422,12 @@ void LayerTest2::onEnter()
     auto s = Director::getInstance()->getWinSize();
     auto layer1 = LayerColor::create( Color4B(255, 255, 0, 80), 100, 300);
     layer1->setPosition(Vec2(s.width/3, s.height/2));
-    layer1->ignoreAnchorPointForPosition(false);
+    layer1->setIgnoreAnchorPointForPosition(false);
     addChild(layer1, 1);
     
     auto layer2 = LayerColor::create( Color4B(0, 0, 255, 255), 100, 300);
     layer2->setPosition(Vec2((s.width/3)*2, s.height/2));
-    layer2->ignoreAnchorPointForPosition(false);
+    layer2->setIgnoreAnchorPointForPosition(false);
     addChild(layer2, 1);
     
     auto actionTint = TintBy::create(2, -255, -127, 0);
@@ -613,7 +613,7 @@ void LayerIgnoreAnchorPointPos::onToggle(Ref* pObject)
 {
     auto layer = this->getChildByTag(kLayerIgnoreAnchorPoint);
     bool ignore = layer->isIgnoreAnchorPointForPosition();
-    layer->ignoreAnchorPointForPosition(! ignore);
+    layer->setIgnoreAnchorPointForPosition(! ignore);
 }
 
 std::string LayerIgnoreAnchorPointPos::title() const
@@ -661,7 +661,7 @@ void LayerIgnoreAnchorPointRot::onToggle(Ref* pObject)
 {
     auto layer = this->getChildByTag(kLayerIgnoreAnchorPoint);
     bool ignore = layer->isIgnoreAnchorPointForPosition();
-    layer->ignoreAnchorPointForPosition(! ignore);
+    layer->setIgnoreAnchorPointForPosition(! ignore);
 }
 
 std::string LayerIgnoreAnchorPointRot::title() const
@@ -712,7 +712,7 @@ void LayerIgnoreAnchorPointScale::onToggle(Ref* pObject)
 {
     auto layer = this->getChildByTag(kLayerIgnoreAnchorPoint);
     bool ignore = layer->isIgnoreAnchorPointForPosition();
-    layer->ignoreAnchorPointForPosition(! ignore);
+    layer->setIgnoreAnchorPointForPosition(! ignore);
 }
 
 std::string LayerIgnoreAnchorPointScale::title() const

--- a/tests/cpp-tests/Classes/RotateWorldTest/RotateWorldTest.cpp
+++ b/tests/cpp-tests/Classes/RotateWorldTest/RotateWorldTest.cpp
@@ -115,7 +115,7 @@ void RotateWorldMainLayer::onEnter()
 
     white->setScale(0.5f);
     white->setPosition(Vec2(x/4,y/4));
-    white->ignoreAnchorPointForPosition(false);
+    white->setIgnoreAnchorPointForPosition(false);
     white->setPosition(Vec2(x/4*3,y/4*3));
 
     addChild(blue, -1);

--- a/tests/cpp-tests/Classes/SpriteTest/SpriteTest.cpp
+++ b/tests/cpp-tests/Classes/SpriteTest/SpriteTest.cpp
@@ -1189,7 +1189,7 @@ Sprite6::Sprite6()
     // Don't use capacity=1 in your real game. It is expensive to resize the capacity
     auto batch = SpriteBatchNode::create("Images/grossini_dance_atlas.png", 1);
     addChild(batch, 0, kTagSpriteBatchNode);
-    batch->ignoreAnchorPointForPosition( true );
+    batch->setIgnoreAnchorPointForPosition( true );
 
     auto s = Director::getInstance()->getWinSize();
 

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIRadioButtonTest/UIRadioButtonTest.cpp
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIRadioButtonTest/UIRadioButtonTest.cpp
@@ -302,7 +302,7 @@ bool UIRadioButtonTabTest::init()
         
         // Background for buttons
         LayerColor* colorLayer = LayerColor::create(Color4B::WHITE);
-        colorLayer->ignoreAnchorPointForPosition(false);
+        colorLayer->setIgnoreAnchorPointForPosition(false);
         colorLayer->setAnchorPoint(Vec2::ANCHOR_MIDDLE);
         colorLayer->setContentSize(Size(buttonWidth * 3, 170 / Director::getInstance()->getContentScaleFactor()));
         colorLayer->setPosition(widgetSize / 2.0f);


### PR DESCRIPTION
- I added `ignoreAnchorPointForPositon()` deprecated funcs (CCNode.h, CCSprite.h)
  And add new implementation `setIgnoreAnchorPointForPosition()`
- Codes that invoked `ignoreAnchorPointForPosition()` use new functions
- Removed completed todo comments.
