### PR TITLE
Fix compiler warning C4804 under Visual Studio

### DIFF
--- a/cocos/3d/CCSprite3D.cpp
+++ b/cocos/3d/CCSprite3D.cpp
@@ -774,7 +774,7 @@ void Sprite3D::draw(Renderer *renderer, const Mat4 &transform, uint32_t flags)
         const auto lights = scene->getLights();
         bool usingLight = false;
         for (const auto light : lights) {
-            usingLight = (light->isEnabled() && (unsigned int)light->getLightFlag() & _lightMask) > 0;
+            usingLight = light->isEnabled() && ((static_cast<unsigned int>(light->getLightFlag()) & _lightMask) > 0);
             if (usingLight)
                 break;
         }


### PR DESCRIPTION
This pull request fixes the warning C4804 that was created by commit a4d67867d78bb8f95a8eb5182249850fe2014d5b with Visual Studio 2015:

```
..\3d\CCSprite3D.cpp(777): warning C4804: '>' : unsafe use of type 'bool' in operation [cocos\2d\libcocos2d.vcxproj]
```
