### PR TITLE
Fixes signed/unsigned mismatch warnings.

### DIFF
--- a/cocos/2d/CCFontFNT.cpp
+++ b/cocos/2d/CCFontFNT.cpp
@@ -316,8 +316,8 @@ std::set<unsigned int>* BMFontConfiguration::parseConfigFile(const std::string& 
     
     auto next = strchr(contents, '\n');
     auto base = contents;
-    int lineLength = 0;
-    int parseCount = 0;
+    size_t lineLength = 0;
+    size_t parseCount = 0;
     while (next)
     {
         lineLength = ((int)(next - base));

--- a/cocos/2d/CCLabel.cpp
+++ b/cocos/2d/CCLabel.cpp
@@ -779,9 +779,9 @@ bool Label::alignText()
     do {
         _fontAtlas->prepareLetterDefinitions(_utf16Text);
         auto& textures = _fontAtlas->getTextures();
-        if (textures.size() > _batchNodes.size())
+        if (textures.size() > static_cast<size_t>(_batchNodes.size()))
         {
-            for (auto index = _batchNodes.size(); index < textures.size(); ++index)
+            for (auto index = static_cast<size_t>(_batchNodes.size()); index < textures.size(); ++index)
             {
                 auto batchNode = SpriteBatchNode::createWithTexture(textures.at(index));
                 if (batchNode)

--- a/cocos/scripting/js-bindings/manual/cocos2d_specifics.cpp
+++ b/cocos/scripting/js-bindings/manual/cocos2d_specifics.cpp
@@ -2738,7 +2738,7 @@ bool js_cocos2dx_ActionInterval_easing(JSContext *cx, uint32_t argc, jsval *vp)
     double tag;
     double parameter;
 
-    for (int i = 0; i < argc; i++)
+    for (uint32_t i = 0; i < argc; i++)
     {
         //        jsval vpi = argv[i];
         JS::RootedValue vpi(cx, args.get(i));

--- a/cocos/ui/UIEditBox/UIEditBoxImpl-common.cpp
+++ b/cocos/ui/UIEditBox/UIEditBoxImpl-common.cpp
@@ -110,7 +110,7 @@ void EditBoxImplCommon::setInactiveText(const char* pText)
     if(EditBox::InputFlag::PASSWORD == _editBoxInputFlag)
     {
         std::string passwordString;
-        for(int i = 0; i < strlen(pText); ++i)
+        for(size_t i = 0; i < strlen(pText); ++i)
             passwordString.append(PASSWORD_CHAR);
         _label->setString(passwordString);
     }

--- a/cocos/ui/UIRichText.cpp
+++ b/cocos/ui/UIRichText.cpp
@@ -1570,7 +1570,7 @@ int RichText::findSplitPositionForChar(cocos2d::Label* label, const std::string&
                 leftLength--;
                 break;
             }
-            else if (stringLength <= leftLength) {
+            else if (static_cast<int>(stringLength) <= leftLength) {
                 break;
             }
         }

--- a/cocos/ui/UITextField.cpp
+++ b/cocos/ui/UITextField.cpp
@@ -86,7 +86,7 @@ bool UICCTextField::onTextFieldInsertText(TextFieldTTF *pSender, const char *tex
     setInsertText(true);
     if (_maxLengthEnabled)
     {
-        if (TextFieldTTF::getCharCount() >= _maxLength)
+        if (static_cast<int>(TextFieldTTF::getCharCount()) >= _maxLength)
         {
             return true;
         }

--- a/tests/cpp-tests/Classes/Sprite3DTest/Sprite3DTest.cpp
+++ b/tests/cpp-tests/Classes/Sprite3DTest/Sprite3DTest.cpp
@@ -1966,7 +1966,7 @@ NodeAnimationTest::NodeAnimationTest()
                                               _sprites[_vectorIndex]->setVisible(false);
                                               
                                               int tIndex = _vectorIndex + 1;
-                                              if(tIndex >= _sprites.size())
+                                              if(tIndex >= static_cast<int>(_sprites.size()))
                                                   _vectorIndex = 0;
                                               else
                                                   _vectorIndex++;

--- a/tests/cpp-tests/Classes/TextInputTest/TextInputTest.h
+++ b/tests/cpp-tests/Classes/TextInputTest/TextInputTest.h
@@ -53,7 +53,7 @@ class TextFieldTTFActionTest : public KeyboardNotificationLayer, public cocos2d:
     cocos2d::TextFieldTTF*    _textField;
     cocos2d::Action*          _textFieldAction;
     bool                _action;
-    int                 _charLimit;       // the textfield max char limit
+    size_t              _charLimit;       // the textfield max char limit
 
 public:
     CREATE_FUNC(TextFieldTTFActionTest);


### PR DESCRIPTION
Fixed all `signed/unsigned mismatch` warnings on WinRT build.

```
2d\CCFontFNT.cpp(328): warning C4018: '<' : signed/unsigned mismatch
2d\CCLabel.cpp(782): warning C4018: '>' : signed/unsigned mismatch
2d\CCLabel.cpp(784): warning C4018: '<' : signed/unsigned mismatch
scripting\js-bindings\manual\cocos2d_specifics.cpp(2741): warning C4018: '<' : signed/unsigned mismatch
tests\cpp-tests\Classes\Sprite3DTest\Sprite3DTest.cpp(1969): warning C4018: '>=' : signed/unsigned mismatch
tests\cpp-tests\Classes\TextInputTest\TextInputTest.cpp(264): warning C4018: '>=' : signed/unsigned mismatch
ui\UIEditBox\UIEditBoxImpl-common.cpp(113): warning C4018: '<' : signed/unsigned mismatch
ui\UIRichText.cpp(1573): warning C4018: '<=' : signed/unsigned mismatch
ui\UITextField.cpp(89): warning C4018: '>=' : signed/unsigned mismatch
```
