### PR TITLE
Refactor FileUtils::getFileData() and CCFreeTypeFont::loadFont().

### DIFF
--- a/cocos/base/CCData.cpp
+++ b/cocos/base/CCData.cpp
@@ -1,7 +1,7 @@
 /****************************************************************************
  Copyright (c) 2010-2012 cocos2d-x.org
  Copyright (c) 2013-2014 Chukong Technologies Inc.
- 
+
  http://www.cocos2d-x.org
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -77,7 +77,7 @@ void Data::move(Data& other)
 {
     _bytes = other._bytes;
     _size = other._size;
-    
+
     other._bytes = nullptr;
     other._size = 0;
 }
@@ -100,7 +100,7 @@ ssize_t Data::getSize() const
 void Data::copy(const unsigned char* bytes, const ssize_t size)
 {
     clear();
-    
+
     if (size > 0)
     {
         _size = size;
@@ -120,6 +120,15 @@ void Data::clear()
     free(_bytes);
     _bytes = nullptr;
     _size = 0;
+}
+
+unsigned char* Data::takeBuffer(ssize_t* size)
+{
+    auto buffer = getBytes();
+    if (size)
+        *size = getSize();
+    fastSet(nullptr, 0);
+    return buffer;
 }
 
 NS_CC_END

--- a/cocos/base/CCData.h
+++ b/cocos/base/CCData.h
@@ -1,7 +1,7 @@
 /****************************************************************************
  Copyright (c) 2010-2012 cocos2d-x.org
  Copyright (c) 2013-2014 Chukong Technologies Inc.
- 
+
  http://www.cocos2d-x.org
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -41,64 +41,64 @@ NS_CC_BEGIN
 class CC_DLL Data
 {
     friend class Properties;
-    
+
 public:
     /**
      * This parameter is defined for convenient reference if a null Data object is needed.
      */
     static const Data Null;
-    
+
     /**
      * Constructor of Data.
      */
     Data();
-    
+
     /**
      * Copy constructor of Data.
      */
     Data(const Data& other);
-    
+
     /**
      * Copy constructor of Data.
      */
     Data(Data&& other);
-    
+
     /**
      * Destructor of Data.
      */
     ~Data();
-    
+
     /**
      * Overloads of operator=.
      */
     Data& operator= (const Data& other);
-    
+
     /**
      * Overloads of operator=.
      */
     Data& operator= (Data&& other);
-    
+
     /**
      * Gets internal bytes of Data. It will return the pointer directly used in Data, so don't delete it.
      *
      * @return Pointer of bytes used internal in Data.
      */
     unsigned char* getBytes() const;
-    
+
     /**
      * Gets the size of the bytes.
      *
      * @return The size of bytes of Data.
      */
     ssize_t getSize() const;
-    
+
     /** Copies the buffer pointer and its size.
      *  @note This method will copy the whole buffer.
      *        Developer should free the pointer after invoking this method.
      *  @see Data::fastSet
      */
     void copy(const unsigned char* bytes, const ssize_t size);
-    
+
     /** Fast set the buffer pointer and its size. Please use it carefully.
      *  @param bytes The buffer pointer, note that it have to be allocated by 'malloc' or 'calloc',
      *         since in the destructor of Data, the buffer will be deleted by 'free'.
@@ -107,22 +107,45 @@ public:
      *  @see Data::copy
      */
     void fastSet(unsigned char* bytes, const ssize_t size);
-    
-    /** 
+
+    /**
      * Clears data, free buffer and reset data size.
      */
     void clear();
-    
-    /** 
+
+    /**
      * Check whether the data is null.
      *
      * @return True if the Data is null, false if not.
      */
     bool isNull() const;
-    
+
+    /**
+     * Get the internal buffer of data and set data to empty state.
+     *
+     * The ownership of the buffer removed from the data object.
+     * That is the user have to free the returned buffer.
+     * The data object is set to empty state, that is internal buffer is set to nullptr
+     * and size is set to zero.
+     * Usage:
+     *  <pre>
+     *  {@code
+     *  Data d;
+     *  // ...
+     *  ssize_t size;
+     *  unsigned char* buffer = d.takeBuffer(&size);
+     *  // use buffer and size
+     *  free(buffer);
+     *  }
+     * </pre
+     *
+     * @param size Will fill with the data buffer size in bytes, if you do not care buffer size, pass nullptr.
+     * @return the internal data buffer, free it after use.
+     */
+    unsigned char* takeBuffer(ssize_t* size);
 private:
     void move(Data& other);
-    
+
 private:
     unsigned char* _bytes;
     ssize_t _size;

--- a/cocos/platform/CCFileUtils.cpp
+++ b/cocos/platform/CCFileUtils.cpp
@@ -665,19 +665,13 @@ unsigned char* FileUtils::getFileData(const std::string& filename, const char* m
     CCASSERT(!filename.empty() && size != nullptr && mode != nullptr, "Invalid parameters.");
     (void)(mode); // mode is unused, as we do not support text mode any more...
 
-    *size = 0;
-    std::string s;
-    if (getContents(filename, &s) != Status::OK)
+    Data d;
+    if (getContents(filename, &d) != Status::OK) {
+        *size = 0;
         return nullptr;
+    }
 
-    unsigned char * buffer = (unsigned char*)malloc(s.size());
-    if (!buffer)
-        return nullptr;
-
-    memcpy(buffer, s.data(), s.size());
-    *size = s.size();
-
-    return buffer;
+    return d.takeBuffer(size);
 }
 
 unsigned char* FileUtils::getFileDataFromZip(const std::string& zipFilePath, const std::string& filename, ssize_t *size)

--- a/cocos/platform/winrt/CCFreeTypeFont.cpp
+++ b/cocos/platform/winrt/CCFreeTypeFont.cpp
@@ -576,16 +576,6 @@ void  CCFreeTypeFont::compute_bbox(std::vector<TGlyph>& glyphs, FT_BBox  *abbox)
     *abbox = bbox;
 }
 
-namespace {
-    inline unsigned char* takeBuffer(Data& data, ssize_t* size) {
-        auto buffer = data.getBytes();
-        if (size)
-            *size = data.getSize();
-        data.fastSet(nullptr, 0);
-        return buffer;
-    }
-}
-
 unsigned char* CCFreeTypeFont::loadFont(const char *pFontName, ssize_t *size)
 {
 
@@ -623,7 +613,7 @@ unsigned char* CCFreeTypeFont::loadFont(const char *pFontName, ssize_t *size)
 
     Data d;
     FileUtils::getInstance()->getContents(fullpath, &d);
-    return takeBuffer(d, size);
+    return d.takeBuffer(size);
 }
 
 unsigned char* CCFreeTypeFont::loadSystemFont(const char *pFontName, ssize_t *size)


### PR DESCRIPTION
- Remove unnecessary memory copy in `FileUtils::getFileData()`
- Add `Data::takeBuffer()` to simplify `FileUtils::getFileData()` and `CCFreeTypeFont::loadFont()`.
