### PR TITLE
Fix doxygen format mistakes in enum class Platform

### DIFF
--- a/cocos/platform/CCApplicationProtocol.h
+++ b/cocos/platform/CCApplicationProtocol.h
@@ -46,18 +46,18 @@ public:
      */
     enum class Platform
     {
-        OS_WINDOWS,/** Windows */
-        OS_LINUX,/** Linux */
-        OS_MAC,/** Mac*/
-        OS_ANDROID,/** Android */
-        OS_IPHONE,/** Iphone */
-        OS_IPAD,/** Ipad */
-        OS_BLACKBERRY,/** BLACKBERRY */
-        OS_NACL,/** Nacl */
-        OS_EMSCRIPTEN,/** Emscripten */
-        OS_TIZEN,/** Tizen */
-        OS_WINRT,/** Windows Store Applications */
-        OS_WP8/** Windows Phone Applications */
+        OS_WINDOWS,     /**< Windows */
+        OS_LINUX,       /**< Linux */
+        OS_MAC,         /**< Mac OS X*/
+        OS_ANDROID,     /**< Android */
+        OS_IPHONE,      /**< iPhone */
+        OS_IPAD,        /**< iPad */
+        OS_BLACKBERRY,  /**< BlackBerry */
+        OS_NACL,        /**< Native Client in Chrome */
+        OS_EMSCRIPTEN,  /**< Emscripten */
+        OS_TIZEN,       /**< Tizen */
+        OS_WINRT,       /**< Windows Runtime Applications */
+        OS_WP8          /**< Windows Phone 8 Applications */
     };
 
     /**


### PR DESCRIPTION
An user reported this error in the forum http://forum.cocos.com/t/api-document/36199/2
I noticed that our doxygen was written in wrong format.
