### PR TITLE
Reduce unnecessary c_str() calls

### DIFF
--- a/cocos/2d/CCTextFieldTTF.cpp
+++ b/cocos/2d/CCTextFieldTTF.cpp
@@ -134,7 +134,7 @@ bool TextFieldTTF::initWithPlaceHolder(const std::string& placeholder, const std
         // If fontName is ttf file and it corrected, use TTFConfig
         if (FileUtils::getInstance()->isFileExist(fontName))
         {
-            TTFConfig ttfConfig(fontName.c_str(), fontSize, GlyphCollection::DYNAMIC);
+            TTFConfig ttfConfig(fontName, fontSize, GlyphCollection::DYNAMIC);
             if (setTTFConfig(ttfConfig))
             {
                 break;

--- a/cocos/editor-support/cocostudio/CCComAttribute.cpp
+++ b/cocos/editor-support/cocostudio/CCComAttribute.cpp
@@ -196,7 +196,7 @@ bool ComAttribute::serialize(void* r)
 		{
 			filePath.assign(cocos2d::FileUtils::getInstance()->fullPathForFilename(file));
 		}
-		if (parse(filePath.c_str()))
+		if (parse(filePath))
 		{
             ret = true;
 		}

--- a/cocos/editor-support/cocostudio/FlatBuffersSerialize.cpp
+++ b/cocos/editor-support/cocostudio/FlatBuffersSerialize.cpp
@@ -1280,7 +1280,7 @@ flatbuffers::Offset<flatbuffers::EasingData> FlatBuffersSerialize::createEasingD
 /* create flat buffers with XML */
 FlatBufferBuilder* FlatBuffersSerialize::createFlatBuffersWithXMLFileForSimulator(const std::string &xmlFileName)
 {    
-    std::string inFullpath = FileUtils::getInstance()->fullPathForFilename(xmlFileName).c_str();
+    std::string inFullpath = FileUtils::getInstance()->fullPathForFilename(xmlFileName);
     
     // xml read
     if (!FileUtils::getInstance()->isFileExist(inFullpath))

--- a/cocos/ui/UIEditBox/UIEditBoxImpl-win32.cpp
+++ b/cocos/ui/UIEditBox/UIEditBoxImpl-win32.cpp
@@ -389,7 +389,7 @@ void CWin32InputBox::InitDialog()
 		_hwndEditCtrl = hwndEdit1;
 
 	std::u16string utf16Result;
-	cocos2d::StringUtils::UTF8ToUTF16(_param->pstrResult->c_str(), utf16Result);
+	cocos2d::StringUtils::UTF8ToUTF16(*_param->pstrResult, utf16Result);
 	::SetWindowTextW(_hwndEditCtrl, (LPCWSTR) utf16Result.c_str());
 
 	RECT rectDlg, rectEdit1, rectEdit2;

--- a/cocos/ui/UITextField.cpp
+++ b/cocos/ui/UITextField.cpp
@@ -402,16 +402,15 @@ void TextField::setString(const std::string& text)
         }
     }
     
-    const char* content = strText.c_str();
     if (isPasswordEnabled())
     {
-        _textFieldRenderer->setPasswordText(content);
+        _textFieldRenderer->setPasswordText(strText);
         _textFieldRenderer->setString("");
-        _textFieldRenderer->insertText(content, strlen(content));
+        _textFieldRenderer->insertText(strText.c_str(), strText.size());
     }
     else
     {
-        _textFieldRenderer->setString(content);
+        _textFieldRenderer->setString(strText);
     }
     _textFieldRendererAdaptDirty = true;
     updateContentSizeWithTextureSize(_textFieldRenderer->getContentSize());

--- a/cocos/ui/UIWebViewImpl-ios.mm
+++ b/cocos/ui/UIWebViewImpl-ios.mm
@@ -38,7 +38,7 @@
 static std::string getFixedBaseUrl(const std::string& baseUrl)
 {
     std::string fixedBaseUrl;
-    if (baseUrl.empty() || baseUrl.c_str()[0] != '/') {
+    if (baseUrl.empty() || baseUrl.at(0) != '/') {
         fixedBaseUrl = [[[NSBundle mainBundle] resourcePath] UTF8String];
         fixedBaseUrl += "/";
         fixedBaseUrl += baseUrl;
@@ -52,7 +52,7 @@ static std::string getFixedBaseUrl(const std::string& baseUrl)
         fixedBaseUrl.replace(pos, 1, "%20");
     }
     
-    if (fixedBaseUrl.c_str()[fixedBaseUrl.length() - 1] != '/') {
+    if (fixedBaseUrl.at(fixedBaseUrl.length() - 1) != '/') {
         fixedBaseUrl += "/";
     }
     


### PR DESCRIPTION
This pull request removes several `c_str()` calls to improve readability and avoid the copying overhead of conversion to `std::string`.
