### PR TITLE
Add captureNode for cocos2d::utils

### DIFF
--- a/cocos/base/ccUtils.cpp
+++ b/cocos/base/ccUtils.cpp
@@ -33,9 +33,11 @@ THE SOFTWARE.
 #include "base/base64.h"
 #include "renderer/CCCustomCommand.h"
 #include "renderer/CCRenderer.h"
+
 #include "platform/CCImage.h"
 #include "platform/CCFileUtils.h"
 #include "2d/CCSprite.h"
+#include "2d/CCRenderTexture.h"
 
 NS_CC_BEGIN
 
@@ -172,6 +174,49 @@ void captureScreen(const std::function<void(bool, const std::string&)>& afterCap
         director->getRenderer()->addCommand(&s_captureScreenCommand);
         director->getRenderer()->render();
     });
+}
+
+Image* captureNode(Node* startNode, float scale)
+{ // The best snapshot API, support Scene and any Node
+    auto& size = startNode->getContentSize();
+
+    Director::getInstance()->setNextDeltaTimeZero(true);
+
+    RenderTexture* finalRtx = nullptr;
+
+    auto rtx = RenderTexture::create(size.width, size.height, Texture2D::PixelFormat::RGBA8888, GL_DEPTH24_STENCIL8);
+    // rtx->setKeepMatrix(true);
+    Point savedPos = startNode->getPosition();
+    Point anchor;
+    if (!startNode->isIgnoreAnchorPointForPosition()) {
+        anchor = startNode->getAnchorPoint();
+    }
+    startNode->setPosition(Point(size.width * anchor.x, size.height * anchor.y));
+    rtx->begin(); 
+    startNode->visit();
+    rtx->end();
+    startNode->setPosition(savedPos);
+
+    if (std::abs(scale - 1.0f) < 1e-6/* no scale */)
+        finalRtx = rtx;
+    else {
+        /* scale */
+        auto finalRect = Rect(0, 0, size.width, size.height);
+        Sprite *sprite = Sprite::createWithTexture(rtx->getSprite()->getTexture(), finalRect);
+        sprite->setAnchorPoint(Point(0, 0));
+        sprite->setFlippedY(true);
+
+        finalRtx = RenderTexture::create(size.width * scale, size.height * scale, Texture2D::PixelFormat::RGBA8888, GL_DEPTH24_STENCIL8);
+
+        sprite->setScale(scale); // or use finalRtx->setKeepMatrix(true);
+        finalRtx->begin(); 
+        sprite->visit();
+        finalRtx->end();
+    }
+
+    Director::getInstance()->getRenderer()->render();
+
+    return finalRtx->newImage();
 }
 
 std::vector<Node*> findChildren(const Node &node, const std::string &name)

--- a/cocos/base/ccUtils.h
+++ b/cocos/base/ccUtils.h
@@ -53,6 +53,7 @@ Examples:
 int ccNextPOT(int value);
 
 class Sprite;
+class Image;
 
 namespace utils
 {
@@ -64,7 +65,16 @@ namespace utils
      * base filename ("hello.png" etc.), don't use a relative path containing directory names.("mydir/hello.png" etc.).
      * @since v3.2
      */
-    void CC_DLL captureScreen(const std::function<void(bool, const std::string&)>& afterCaptured, const std::string& filename);
+    CC_DLL void  captureScreen(const std::function<void(bool, const std::string&)>& afterCaptured, const std::string& filename);
+
+    /** Capture a specific Node.
+    * @param startNode: specify the snapshot Node. It chould be cocos2d::Scene
+    * @param scale
+    * @returns: return a Image, then can call saveToFile to save the image as "xxx.png or xxx.jpg".
+    * @since v3.11
+    * !!! remark: Caller is responsible for releasing it by calling delete.
+    */
+    CC_DLL Image* captureNode(Node* startNode, float scale = 1.0f);
     
     /** Find children by name, it will return all child that has the same name.
      * It supports c++ 11 regular expression. It is  a helper function of `Node::enumerateChildren()`.
@@ -75,7 +85,7 @@ namespace utils
      * @return Array of Nodes that matches the name
      * @since v3.2
      */
-    std::vector<Node*> CC_DLL findChildren(const Node &node, const std::string &name);
+    CC_DLL std::vector<Node*>  findChildren(const Node &node, const std::string &name);
     
     /** Same to ::atof, but strip the string, remain 7 numbers after '.' before call atof.
      * Why we need this? Because in android c++_static, atof ( and std::atof ) is unsupported for numbers have long decimal part and contain
@@ -83,46 +93,46 @@ namespace utils
      * @param str The string be to converted to double.
      * @return Returns converted value of a string.
      */
-    double CC_DLL atof(const char* str);
+    CC_DLL double  atof(const char* str);
 
     /** Get current exact time, accurate to nanoseconds.
      * @return Returns the time in seconds since the Epoch.
      */
-    double CC_DLL gettime();
+    CC_DLL double  gettime();
 
     /**
      * Get current time in milliseconds, accurate to nanoseconds
      *
      * @return  Returns the time in milliseconds since the Epoch.
      */
-    long long CC_DLL getTimeInMilliseconds();
+    CC_DLL long long  getTimeInMilliseconds();
 
     /**
      * Calculate unionof bounding box of a node and its children.
      * @return Returns unionof bounding box of a node and its children.
      */
-    Rect CC_DLL getCascadeBoundingBox(Node *node);
+    CC_DLL Rect getCascadeBoundingBox(Node *node);
 
     /**
      * Create a sprite instance from base64 encoded image.
 
      * @return Returns an instance of sprite
      */
-    Sprite* createSpriteFromBase64(const char* base64String);
+    CC_DLL Sprite* createSpriteFromBase64(const char* base64String);
     
     /**
      * Find a child by name recursively
 
      * @return  Returns found node or nullptr
      */
-    Node*  findChild(Node* levelRoot, const char* name);
+    CC_DLL Node*  findChild(Node* levelRoot, const char* name);
 
     /**
      * Find a child by tag recursively
 
      * @return Returns found node or nullptr
      */
-    Node*  findChild(Node* levelRoot, int tag);
+   CC_DLL Node*  findChild(Node* levelRoot, int tag);
 
     /**
      * Find a child by name recursively

--- a/tests/cpp-tests/Classes/NewRendererTest/NewRendererTest.cpp
+++ b/tests/cpp-tests/Classes/NewRendererTest/NewRendererTest.cpp
@@ -35,6 +35,7 @@ NewRendererTests::NewRendererTests()
     ADD_TEST_CASE(NewCullingTest);
     ADD_TEST_CASE(VBOFullTest);
     ADD_TEST_CASE(CaptureScreenTest);
+    ADD_TEST_CASE(CaptureNodeTest);
     ADD_TEST_CASE(BugAutoCulling);
     ADD_TEST_CASE(RendererBatchQuadTri);
 };
@@ -476,6 +477,72 @@ void CaptureScreenTest::afterCaptured(bool succeed, const std::string& outputFil
     {
         log("Capture screen failed.");
     }
+}
+
+CaptureNodeTest::CaptureNodeTest()
+{
+    Size s = Director::getInstance()->getWinSize();
+    Vec2 left(s.width / 4, s.height / 2);
+    Vec2 right(s.width / 4 * 3, s.height / 2);
+
+    auto sp1 = Sprite::create("Images/grossini.png");
+    sp1->setPosition(left);
+    auto move1 = MoveBy::create(1, Vec2(s.width / 2, 0));
+    auto seq1 = RepeatForever::create(Sequence::create(move1, move1->reverse(), nullptr));
+    addChild(sp1);
+    sp1->runAction(seq1);
+    auto sp2 = Sprite::create("Images/grossinis_sister1.png");
+    sp2->setPosition(right);
+    auto move2 = MoveBy::create(1, Vec2(-s.width / 2, 0));
+    auto seq2 = RepeatForever::create(Sequence::create(move2, move2->reverse(), nullptr));
+    addChild(sp2);
+    sp2->runAction(seq2);
+
+    auto label1 = Label::createWithTTF(TTFConfig("fonts/arial.ttf"), "capture this scene");
+    auto mi1 = MenuItemLabel::create(label1, CC_CALLBACK_1(CaptureNodeTest::onCaptured, this));
+    auto menu = Menu::create(mi1, nullptr);
+    addChild(menu);
+    menu->setPosition(s.width / 2, s.height / 4);
+
+    _filename = "";
+}
+
+CaptureNodeTest::~CaptureNodeTest()
+{
+    Director::getInstance()->getTextureCache()->removeTextureForKey(_filename);
+}
+
+std::string CaptureNodeTest::title() const
+{
+    return "New Renderer";
+}
+
+std::string CaptureNodeTest::subtitle() const
+{
+    return "Capture node test, press the menu items to capture this scene with scale 0.5";
+}
+
+void CaptureNodeTest::onCaptured(Ref*)
+{
+    Director::getInstance()->getTextureCache()->removeTextureForKey(_filename);
+    removeChildByTag(childTag);
+    
+    _filename = FileUtils::getInstance()->getWritablePath() + "/CaptureNodeTest.png";
+
+    // capture this
+    auto image = utils::captureNode(this, 0.5);
+
+    // create a sprite with the captured image directly
+    auto sp = Sprite::createWithTexture(TextureCache::getInstance()->addImage(image, _filename));
+    addChild(sp, 0, childTag);
+    Size s = Director::getInstance()->getWinSize();
+    sp->setPosition(s.width / 2, s.height / 2);
+
+    // store to disk
+    image->saveToFile(_filename, false);
+
+    // release the captured image
+    image->release();
 }
 
 BugAutoCulling::BugAutoCulling()

--- a/tests/cpp-tests/Classes/NewRendererTest/NewRendererTest.cpp
+++ b/tests/cpp-tests/Classes/NewRendererTest/NewRendererTest.cpp
@@ -533,13 +533,13 @@ void CaptureNodeTest::onCaptured(Ref*)
     auto image = utils::captureNode(this, 0.5);
 
     // create a sprite with the captured image directly
-    auto sp = Sprite::createWithTexture(TextureCache::getInstance()->addImage(image, _filename));
+    auto sp = Sprite::createWithTexture(Director::getInstance()->getTextureCache()->addImage(image, _filename));
     addChild(sp, 0, childTag);
     Size s = Director::getInstance()->getWinSize();
     sp->setPosition(s.width / 2, s.height / 2);
 
     // store to disk
-    image->saveToFile(_filename, false);
+    image->saveToFile(_filename);
 
     // release the captured image
     image->release();

--- a/tests/cpp-tests/Classes/NewRendererTest/NewRendererTest.cpp
+++ b/tests/cpp-tests/Classes/NewRendererTest/NewRendererTest.cpp
@@ -523,7 +523,7 @@ std::string CaptureNodeTest::subtitle() const
 }
 
 void CaptureNodeTest::onCaptured(Ref*)
-{
+{ 
     Director::getInstance()->getTextureCache()->removeTextureForKey(_filename);
     removeChildByTag(childTag);
     

--- a/tests/cpp-tests/Classes/NewRendererTest/NewRendererTest.h
+++ b/tests/cpp-tests/Classes/NewRendererTest/NewRendererTest.h
@@ -129,6 +129,23 @@ protected:
     std::string _filename;
 };
 
+class CaptureNodeTest : public MultiSceneTest
+{
+    static const int childTag = 120;
+public:
+    CREATE_FUNC(CaptureNodeTest);
+    virtual std::string title() const override;
+    virtual std::string subtitle() const override;
+
+protected:
+    CaptureNodeTest();
+    ~CaptureNodeTest();
+
+    void onCaptured(cocos2d::Ref*);
+
+    std::string _filename;
+};
+
 class BugAutoCulling : public MultiSceneTest
 {
 public:


### PR DESCRIPTION
Add captureNode for cocos2d::utils and fix CC_DLL syntax.

Bring all CC_DLL to front of function decl, The follow is the reason:
For MSVC: 
int __declspec(dllexport) compile_ok();
int\* __declspec(dllexport) compile_error(); // compile will failed with syntax error, when the return type is pointer
int  __declspec(dllexport) \* compile_ok2(); // compile ok, but not styled.
__declspec(dllexport) int\* compile_fine(); // so this a good syntax for DLL export.
