### PR TITLE
Prevent memory leak: force drain on autoreleased `data`.

### DIFF
--- a/cocos/platform/ios/CCImage-ios.mm
+++ b/cocos/platform/ios/CCImage-ios.mm
@@ -99,22 +99,20 @@ bool cocos2d::Image::saveToFile(const std::string& filename, bool isToRGB)
     CGImageRelease(iref);    
     CGColorSpaceRelease(colorSpaceRef);
     CGDataProviderRelease(provider);
-    
-    NSData *data;
-                
-    if (saveToPNG)
-    {
-        data = UIImagePNGRepresentation(image);
+
+    // NOTE: Prevent memory leak. Requires ARC enabled.
+    @autoreleasepool {
+        NSData *data;
+        if (saveToPNG) {
+            data = UIImagePNGRepresentation(image);
+        } else {
+            data = UIImageJPEGRepresentation(image, 1.0f);
+        }
+        [data writeToFile:[NSString stringWithUTF8String:filename.c_str()] atomically:YES];
     }
-    else
-    {
-        data = UIImageJPEGRepresentation(image, 1.0f);
-    }
-    
-    [data writeToFile:[NSString stringWithUTF8String:filename.c_str()] atomically:YES];
-        
+
     [image release];
-        
+
     if (needToCopyPixels)
     {
         delete [] pixels;


### PR DESCRIPTION
Based on discussion: http://discuss.cocos2d-x.org/t/capturescreen-memory-leak/29108/
`@autoreleasepool block` supposedly requires ARC, but seems to work with or without ARC on OS X 10.7+ and iOS 5.0+.
It is currently being used already in HttpClient-apple.mm.
