### PR TITLE
Suppress warning C4800 on MSVC

### DIFF
--- a/cocos/physics/CCPhysicsBody.cpp
+++ b/cocos/physics/CCPhysicsBody.cpp
@@ -755,7 +755,7 @@ void PhysicsBody::setEnabled(bool enable)
 
 bool PhysicsBody::isResting() const
 {
-    return cpBodyIsSleeping(_cpBody);
+    return cpBodyIsSleeping(_cpBody) != cpFalse;
 }
 
 void PhysicsBody::setResting(bool rest) const


### PR DESCRIPTION
This patch fixes MSVC warning [C4800](https://msdn.microsoft.com/en-us/library/b6801kcy.aspx) about forcing integer value to bool with Visual Studio 2015:

```
cocos\physics\CCPhysicsBody.cpp(758): warning C4800: 'cpBool' : forcing value to bool 'true' or 'false' (performance warning)
```
