### PR TITLE
Prevent variable shadowing warnings

### DIFF
--- a/cocos/base/ccUtils.cpp
+++ b/cocos/base/ccUtils.cpp
@@ -338,9 +338,11 @@ Node* findChild(Node* levelRoot, const char* name)
         return nullptr;
 
     // Find this node
-    auto target = levelRoot->getChildByName(name);
-    if (target != nullptr)
-        return target;
+    {
+        auto target = levelRoot->getChildByName(name);
+        if (target != nullptr)
+            return target;
+    }
 
     // Find recursively
     for (auto& child : levelRoot->getChildren())
@@ -358,9 +360,11 @@ Node* findChild(Node* levelRoot, int tag)
         return nullptr;
 
     // Find this node
-    auto target = levelRoot->getChildByTag(tag);
-    if (target != nullptr)
-        return target;
+    {
+        auto target = levelRoot->getChildByTag(tag);
+        if (target != nullptr)
+            return target;
+    }
 
     // Find recursively
     for (auto& child : levelRoot->getChildren())


### PR DESCRIPTION
This commit prevents two warnings caused by variable shadowing on Xcode 7.3 since commit 9ff61f915ca1e9342114918a898b78655d6369a2 :

```
cocos/base/ccUtils.cpp:348:14: Declaration shadows a local variable
cocos/base/ccUtils.cpp:370:14: Declaration shadows a local variable
```
