### PR TITLE
CCSprite::createNode bug fix.

### DIFF
--- a/cocos/3d/CCSprite3D.cpp
+++ b/cocos/3d/CCSprite3D.cpp
@@ -589,6 +589,7 @@ void Sprite3D::createNode(NodeData* nodedata, Node* root, const MaterialDatas& m
                     setScaleY(scale.y);
                     setScaleZ(scale.z);
                     
+                    node = this;
                 }
             }
             else


### PR DESCRIPTION
This bug is to occur in a particular model data.
When you call the "Sprite3D::createNode" to children of node generation, pointer of the parent node is null.

This is test data.
[test_create_child_node_bug.zip](https://github.com/cocos2d/cocos2d-x/files/254450/test_create_child_node_bug.zip)
