### PR TITLE
fix build failed using FileUtilsApple on Application code.

### DIFF
--- a/cocos/platform/apple/CCFileUtils-apple.h
+++ b/cocos/platform/apple/CCFileUtils-apple.h
@@ -46,6 +46,7 @@ class CC_DLL FileUtilsApple : public FileUtils
 {
 public:
     FileUtilsApple();
+    virtual ~FileUtilsApple();
     /* override functions */
     virtual std::string getWritablePath() const override;
     virtual std::string getFullPathForDirectoryAndFilename(const std::string& directory, const std::string& filename) const override;

--- a/cocos/platform/apple/CCFileUtils-apple.mm
+++ b/cocos/platform/apple/CCFileUtils-apple.mm
@@ -320,6 +320,8 @@ static void addObjectToNSDict(const std::string& key, const Value& value, NSMuta
 FileUtilsApple::FileUtilsApple() : pimpl_(new IMPL([NSBundle mainBundle])) {
 }
 
+FileUtilsApple::~FileUtilsApple() = default;
+
 #if CC_FILEUTILS_APPLE_ENABLE_OBJC
 void FileUtilsApple::setBundle(NSBundle* bundle) {
     pimpl_->setBundle(bundle);


### PR DESCRIPTION
in current v3 branch.
When coding below code on Application code, invoked build error.

```
#include "platform/apple/CCFileUtils-apple.h"
...
ExtendFileUtilsImpl::init()
{
    bool succeeded = FileUtilsApple::init();
    ...
}
```

```
/path/to/app/Classes/ExtendFileUtils_IOS.mm:10:10: In file included from /path/to/app/Classes/ExtendFileUtils_IOS.mm:10:
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/array:108:10: In file included from /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/array:108:
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/algorithm:628:10: In file included from /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/algorithm:628:
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/memory:2715:13: In instantiation of member function 'std::__1::default_delete<cocos2d::FileUtilsApple::IMPL>::operator()' requested here
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/memory:2683:46: In instantiation of member function 'std::__1::unique_ptr<cocos2d::FileUtilsApple::IMPL, std::__1::default_delete<cocos2d::FileUtilsApple::IMPL> >::reset' requested here
/path/to/app/cocos2d/cocos/platform/apple/CCFileUtils-apple.h:45:14: In instantiation of member function 'std::__1::unique_ptr<cocos2d::FileUtilsApple::IMPL, std::__1::default_delete<cocos2d::FileUtilsApple::IMPL> >::~unique_ptr' requested here
/path/to/app/cocos2d/cocos/platform/apple/CCFileUtils-apple.h:67:12: Forward declaration of 'cocos2d::FileUtilsApple::IMPL’
```

This is the reason for `FileUtilsApple` destructor couldn’t see definition of `FileUtilsApple::IMPL`.  `FileUtilsApple` destructor needs to be able to see the complete definition of `FileUtilsApple::IMPL`.
This PR declared explicitly `FileUtilsApple` destructor on `CCFileUtils-apple.mm` for seeing IMPL definition.

@xpol please review it.
B.R.
