### PR TITLE
Fix password style text in UTF-16

### DIFF
--- a/cocos/2d/CCTextFieldTTF.cpp
+++ b/cocos/2d/CCTextFieldTTF.cpp
@@ -34,6 +34,7 @@ NS_CC_BEGIN
 
 #define CURSOR_TIME_SHOW_HIDE 0.5f
 #define CURSOR_DEFAULT_CHAR '|'
+#define PASSWORD_STYLE_TEXT_DEFAULT "\xe2\x97\x8f"
 
 static int _calcCharCount(const char * text)
 {
@@ -63,7 +64,7 @@ TextFieldTTF::TextFieldTTF()
 , _placeHolder("")   // prevent Label initWithString assertion
 , _colorText(Color4B::WHITE)
 , _secureTextEntry(false)
-,_passwordStyleText("\u25CF")
+, _passwordStyleText(PASSWORD_STYLE_TEXT_DEFAULT)
 , _cursorEnabled(false)
 , _cursorPosition(0)
 , _cursorChar(CURSOR_DEFAULT_CHAR)

--- a/cocos/2d/CCTextFieldTTF.cpp
+++ b/cocos/2d/CCTextFieldTTF.cpp
@@ -34,8 +34,7 @@ NS_CC_BEGIN
 
 #define CURSOR_TIME_SHOW_HIDE 0.5f
 #define CURSOR_DEFAULT_CHAR '|'
-#define PASSWORD_STYLE_TEXT_DEFAULT "\xe2\x97\x8f"
-
+#define PASSWORD_STYLE_TEXT_DEFAULT "\xe2\x80\xa2"
 static int _calcCharCount(const char * text)
 {
     int n = 0;

--- a/tests/cpp-tests/Classes/TextInputTest/TextInputTest.cpp
+++ b/tests/cpp-tests/Classes/TextInputTest/TextInputTest.cpp
@@ -9,6 +9,7 @@ TextInputTests::TextInputTests()
 {
     ADD_TEST_CASE(TextFieldTTFDefaultTest);
     ADD_TEST_CASE(TextFieldTTFActionTest);
+    ADD_TEST_CASE(TextFieldTTFSecureTextEntryTest);
 }
 
 static Rect getRect(Node * node)
@@ -158,7 +159,7 @@ void TextFieldTTFDefaultTest::onEnter()
 #else
     pTextField->setPosition(Vec2(s.width / 2, s.height / 2));
 #endif
-
+    
     _trackNode = pTextField;
 }
 
@@ -339,4 +340,38 @@ bool TextFieldTTFActionTest::onDraw(TextFieldTTF * sender)
 void TextFieldTTFActionTest::callbackRemoveNodeWhenDidAction(Node * node)
 {
     this->removeChild(node, true);
+}
+
+
+//////////////////////////////////////////////////////////////////////////
+// implement TextFieldTTFSecureTextEntryTest
+//////////////////////////////////////////////////////////////////////////
+
+std::string TextFieldTTFSecureTextEntryTest::subtitle() const
+{
+    return "TextFieldTTF with SecureTextEntry test";
+}
+
+void TextFieldTTFSecureTextEntryTest::onEnter()
+{
+    KeyboardNotificationLayer::onEnter();
+    
+    // add TextFieldTTF
+    auto s = Director::getInstance()->getWinSize();
+    
+    auto pTextField = TextFieldTTF::textFieldWithPlaceHolder("<click here for input>",
+                                                             FONT_NAME,
+                                                             FONT_SIZE);
+    addChild(pTextField);
+    
+#if (CC_TARGET_PLATFORM == CC_PLATFORM_ANDROID)
+    // on android, TextFieldTTF cannot auto adjust its position when soft-keyboard pop up
+    // so we had to set a higher position to make it visable
+    pTextField->setPosition(Vec2(s.width / 2, s.height/2 + 50));
+#else
+    pTextField->setPosition(Vec2(s.width / 2, s.height / 2));
+#endif
+    pTextField->setSecureTextEntry(true);
+    
+    _trackNode = pTextField;
 }

--- a/tests/cpp-tests/Classes/TextInputTest/TextInputTest.h
+++ b/tests/cpp-tests/Classes/TextInputTest/TextInputTest.h
@@ -75,4 +75,17 @@ public:
     virtual bool onDraw(cocos2d::TextFieldTTF*  sender);
 };
 
+//////////////////////////////////////////////////////////////////////////
+// TextFieldTTFSecureTextEntryTest for test TextFieldTTF SecureTextEntry.
+//////////////////////////////////////////////////////////////////////////
+
+class TextFieldTTFSecureTextEntryTest : public TextFieldTTFDefaultTest
+{
+public:
+    CREATE_FUNC(TextFieldTTFSecureTextEntryTest);
+    
+    virtual std::string subtitle() const override;
+    // Layer
+    virtual void onEnter() override;
+};
 #endif    // __TEXT_INPUT_TEST_H__


### PR DESCRIPTION
Label used UTF-16 in internal.
Need string in UTF-8.

Fix incorrect show password char: ? vs ●.
