### PR TITLE
Adding a setBounce for webview

### DIFF
--- a/cocos/ui/UIWebView-inl.h
+++ b/cocos/ui/UIWebView-inl.h
@@ -140,6 +140,11 @@ namespace experimental{
             _impl->setVisible(visible);
         }
         
+        void WebView::setBounces(bool bounces)
+        {
+          _impl->setBounces(bounces);
+        }
+        
         cocos2d::ui::Widget* WebView::createCloneInstance()
         {
             return WebView::create();

--- a/cocos/ui/UIWebView.h
+++ b/cocos/ui/UIWebView.h
@@ -197,6 +197,11 @@ public:
      */
     ccWebViewCallback getOnJSCallback()const;
 
+    /**
+     * Set whether the webview bounces at end of scroll of WebView.
+     */
+    void setBounces(bool bounce);
+
     virtual void draw(cocos2d::Renderer *renderer, cocos2d::Mat4 const &transform, uint32_t flags) override;
 
     /**

--- a/cocos/ui/UIWebViewImpl-ios.h
+++ b/cocos/ui/UIWebViewImpl-ios.h
@@ -80,6 +80,8 @@ public:
 
     virtual void setVisible(bool visible);
 
+    void setBounces(bool bounces);
+
 private:
     UIWebViewWrapper *_uiWebViewWrapper;
     WebView *_webView;

--- a/cocos/ui/UIWebViewImpl-ios.mm
+++ b/cocos/ui/UIWebViewImpl-ios.mm
@@ -72,6 +72,8 @@ static std::string getFixedBaseUrl(const std::string& baseUrl)
 
 - (void)setVisible:(bool)visible;
 
+- (void)setBounces:(bool)bounces;
+
 - (void)setFrameWithX:(float)x y:(float)y width:(float)width height:(float)height;
 
 - (void)setJavascriptInterfaceScheme:(const std::string &)scheme;
@@ -144,6 +146,10 @@ static std::string getFixedBaseUrl(const std::string& baseUrl)
 
 - (void)setVisible:(bool)visible {
     self.uiWebView.hidden = !visible;
+}
+
+- (void)setBounces:(bool)bounces {
+  self.uiWebView.scrollView.bounces = bounces;
 }
 
 - (void)setFrameWithX:(float)x y:(float)y width:(float)width height:(float)height {
@@ -340,6 +346,10 @@ void WebViewImpl::goForward() {
 
 void WebViewImpl::evaluateJS(const std::string &js) {
     [_uiWebViewWrapper evaluateJS:js];
+}
+
+void WebViewImpl::setBounces(bool bounces) {
+    [_uiWebViewWrapper setBounces:bounces];
 }
 
 void WebViewImpl::setScalesPageToFit(const bool scalesPageToFit) {


### PR DESCRIPTION
This makes the .bounces setting of the scrollview element publically accessible

When set to true it stops the grey over-scroll indicator on webviews
