### PR TITLE
Suppress MSVC warning C4800

### DIFF
--- a/cocos/editor-support/cocostudio/WidgetReader/Light3DReader/Light3DReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/Light3DReader/Light3DReader.cpp
@@ -161,7 +161,7 @@ namespace cocostudio
         float intensity = options->intensity();
         float range = options->range();
         float outerAngle = options->outerAngle()*0.5f;
-        bool enabled = options->enabled();
+        bool enabled = (options->enabled() != 0);
         switch (type)
         {
         case cocos2d::LightType::DIRECTIONAL:

--- a/cocos/editor-support/cocostudio/WidgetReader/TabControlReader/TabControlReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/TabControlReader/TabControlReader.cpp
@@ -180,7 +180,7 @@ void TabControlReader::setPropsWithFlatBuffers(cocos2d::Node* node, const flatbu
     auto options = (flatbuffers::TabControlOption*)nodeOption;
     
     int headerPlace = options->headerPlace();
-    tabControl->ignoreHeadersTextureSize((bool)options->ignoreHeaderTextureSize());
+    tabControl->ignoreHeadersTextureSize(options->ignoreHeaderTextureSize() != 0);
     tabControl->setHeaderDockPlace((cocos2d::ui::TabControl::Dock)headerPlace);
     tabControl->setHeaderWidth(options->headerWidth());
     tabControl->setHeaderHeight(options->headerHeight());

--- a/cocos/network/WebSocket.cpp
+++ b/cocos/network/WebSocket.cpp
@@ -811,7 +811,7 @@ void WebSocket::onClientReceivedData(void* in, ssize_t len)
 
         ssize_t frameSize = frameData->size();
 
-        bool isBinary = lws_frame_is_binary(_wsInstance);
+        bool isBinary = (lws_frame_is_binary(_wsInstance) != 0);
 
         if (!isBinary)
         {

--- a/cocos/platform/CCImage.cpp
+++ b/cocos/platform/CCImage.cpp
@@ -2126,7 +2126,7 @@ bool Image::initWithWebpData(const unsigned char * data, ssize_t dataLen)
         _height   = config.input.height;
         
         //we ask webp to give data with premultiplied alpha
-        _hasPremultipliedAlpha = config.input.has_alpha;
+        _hasPremultipliedAlpha = (config.input.has_alpha != 0);
         
         _dataLen = _width * _height * (config.input.has_alpha?4:3);
         _data = static_cast<unsigned char*>(malloc(_dataLen * sizeof(unsigned char)));


### PR DESCRIPTION
Hello. This pull request suppresses the [C4800](https://msdn.microsoft.com/en-us/library/b6801kcy.aspx) warnings in Visual Studio 2015, as shown below:

```
3>..\editor-support\cocostudio\WidgetReader\Light3DReader\Light3DReader.cpp(164): warning C4800: 'uint8_t' : forcing value to bool 'true' or 'false' (performance warning)
3>..\editor-support\cocostudio\WidgetReader\TabControlReader\TabControlReader.cpp(183): warning C4800: 'uint8_t' : forcing value to bool 'true' or 'false' (performance warning) 
3>..\network\WebSocket.cpp(814): warning C4800: 'int' : forcing value to bool 'true' or 'false' (performance warning)
3>..\platform\CCImage.cpp(2129): warning C4800: 'int' : forcing value to bool 'true' or 'false' (performance warning)
```

And thank you for releasing v3.11. :smiley:
