### PR TITLE
Fixed APP_NAME for cpp, cpp-empty, js, and lua tests.

### DIFF
--- a/tests/cpp-empty-test/CMakeLists.txt
+++ b/tests/cpp-empty-test/CMakeLists.txt
@@ -22,7 +22,7 @@
 # THE SOFTWARE.
 # ****************************************************************************/
 
-set(APP_NAME cpp_empty_test)
+set(APP_NAME cpp-empty-test)
 
 if(ANDROID)
   set(PLATFORM_SRC proj.android/jni/main.cpp)

--- a/tests/cpp-tests/CMakeLists.txt
+++ b/tests/cpp-tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(APP_NAME cpp_tests)
+set(APP_NAME cpp-tests)
 
 # Use same method as in cocos library
 cocos_find_package(CURL CURL REQUIRED)

--- a/tests/js-tests/project/CMakeLists.txt
+++ b/tests/js-tests/project/CMakeLists.txt
@@ -22,7 +22,7 @@
 # THE SOFTWARE.
 # ****************************************************************************/
 
-set(APP_NAME js_tests)
+set(APP_NAME js-tests)
 
 if(WIN32)
 

--- a/tests/lua-tests/project/CMakeLists.txt
+++ b/tests/lua-tests/project/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(APP_NAME lua_tests)
+set(APP_NAME lua-tests)
 
 set(SAMPLE_SRC
     Classes/AppDelegate.cpp


### PR DESCRIPTION
Compiling and running the cpp, cpp-empty, js, and lua tests for Linux results in a "No such file or directory" error without this fix.
