### PR TITLE
Add missing references to avoid unnecessary copies

### DIFF
--- a/cocos/network/HttpClient-android.cpp
+++ b/cocos/network/HttpClient-android.cpp
@@ -383,7 +383,7 @@ public:
         return header;
     }
     
-    const std::string getCookieFileName()
+    const std::string& getCookieFileName() const
     {
         return _cookieFileName;
     }
@@ -608,7 +608,7 @@ private:
         return len;
     }
 
-    const std::string getCookieString()
+    const std::string& getCookieString() const
     {
         return _responseCookies;
     }

--- a/cocos/network/HttpCookie.cpp
+++ b/cocos/network/HttpCookie.cpp
@@ -152,7 +152,7 @@ void HttpCookie::writeFile()
     fclose(out);
 }
 
-void HttpCookie::setCookieFileName(std::string filename)
+void HttpCookie::setCookieFileName(const std::string& filename)
 {
     _cookieFileName = filename;
 }

--- a/cocos/network/HttpCookie.h
+++ b/cocos/network/HttpCookie.h
@@ -46,7 +46,7 @@ public:
     void readFile();
     
     void writeFile();
-    void setCookieFileName(const std::string fileName);
+    void setCookieFileName(const std::string& fileName);
     
     const std::vector<CookiesInfo>* getCookies()const;
     const CookiesInfo* getMatchCookie(const std::string& url) const;

--- a/cocos/renderer/CCTextureCache.cpp
+++ b/cocos/renderer/CCTextureCache.cpp
@@ -600,7 +600,7 @@ std::string TextureCache::getCachedTextureInfo() const
     return buffer;
 }
 
-void TextureCache::renameTextureWithKey(const std::string srcName, const std::string dstName)
+void TextureCache::renameTextureWithKey(const std::string& srcName, const std::string& dstName)
 {
     std::string key = srcName;
     auto it = _textures.find(key);

--- a/cocos/renderer/CCTextureCache.h
+++ b/cocos/renderer/CCTextureCache.h
@@ -212,7 +212,7 @@ public:
     *
     * @since v3.10
     */
-    void renameTextureWithKey(const std::string srcName, const std::string dstName);
+    void renameTextureWithKey(const std::string& srcName, const std::string& dstName);
 
 
 private:

--- a/cocos/ui/UIRichText.cpp
+++ b/cocos/ui/UIRichText.cpp
@@ -1691,7 +1691,7 @@ void RichText::handleTextRenderer(const std::string& text, const std::string& fo
     }
 }
     
-void RichText::handleImageRenderer(const std::string& filePath, const Color3B &color, GLubyte opacity, int width, int height, const std::string url)
+void RichText::handleImageRenderer(const std::string& filePath, const Color3B &color, GLubyte opacity, int width, int height, const std::string& url)
 {
     Sprite* imageRenderer = Sprite::create(filePath);
     if (imageRenderer)

--- a/cocos/ui/UIRichText.h
+++ b/cocos/ui/UIRichText.h
@@ -553,7 +553,7 @@ protected:
                             const Color3B& outlineColor = Color3B::WHITE, int outlineSize = -1,
                             const Color3B& shadowColor = Color3B::BLACK, const cocos2d::Size& shadowOffset = Size(2.0, -2.0), int shadowBlurRadius = 0,
                             const Color3B& glowColor = Color3B::WHITE);
-    void handleImageRenderer(const std::string& fileParh, const Color3B& color, GLubyte opacity, int width, int height, const std::string url);
+    void handleImageRenderer(const std::string& fileParh, const Color3B& color, GLubyte opacity, int width, int height, const std::string& url);
     void handleCustomRenderer(Node* renderer);
     void formarRenderers();
     void addNewLine();


### PR DESCRIPTION
This PR adds several missing reference types (such as `const &`) to the function declarations for better performance.
