### PR TITLE
Fix crash due to reallocation of shared indices memory

### DIFF
--- a/cocos/renderer/CCQuadCommand.cpp
+++ b/cocos/renderer/CCQuadCommand.cpp
@@ -39,13 +39,18 @@ NS_CC_BEGIN
 int QuadCommand::__indexCapacity = -1;
 GLushort* QuadCommand::__indices = nullptr;
 
-QuadCommand::QuadCommand()
-: _indexSize(-1)
+QuadCommand::QuadCommand():
+_indexSize(-1),
+_ownedIndices()
 {
 }
 
 QuadCommand::~QuadCommand()
 {
+    for (auto& indices : _ownedIndices)
+    {
+        CC_SAFE_DELETE_ARRAY(indices);
+    }
 }
 
 void QuadCommand::init(float globalOrder, GLuint textureID, GLProgramState* glProgramState, const BlendFunc& blendType, V3F_C4B_T2F_Quad* quads, ssize_t quadCount,
@@ -70,7 +75,8 @@ void QuadCommand::reIndex(int indicesCount)
     if (indicesCount > __indexCapacity)
     {
         CCLOG("cocos2d: QuadCommand: resizing index size from [%d] to [%d]", __indexCapacity, indicesCount);
-        __indices = (GLushort*) realloc(__indices, indicesCount * sizeof(__indices[0]));
+        _ownedIndices.push_back(__indices);
+        __indices = new (std::nothrow) GLushort[indicesCount];
         __indexCapacity = indicesCount;
     }
 

--- a/cocos/renderer/CCQuadCommand.h
+++ b/cocos/renderer/CCQuadCommand.h
@@ -25,6 +25,8 @@
 #ifndef _CC_QUADCOMMAND_H_
 #define _CC_QUADCOMMAND_H_
 
+#include <vector>
+
 #include "renderer/CCTrianglesCommand.h"
 #include "renderer/CCGLProgramState.h"
 
@@ -69,6 +71,7 @@ protected:
     void reIndex(int indices);
 
     int _indexSize;
+    std::vector<GLushort*> _ownedIndices;
 
     // shared across all instances
     static int __indexCapacity;


### PR DESCRIPTION
This PR provides a fix for issue #15439.

As detailed in the issue, the crash is caused by multiple references to the static `__indices[]` array and the invalidation of these references when this cache is expanded with `realloc()`.

Rather than simply expanding, new memory is allocated to `__indicies[]` and references to any previous `__indicies` are captured by the `QuadCommand` for the duration of its lifetime. The triangle indices used by the `Renderer` are now guaranteed to be valid at the point copying the GL buffer.

The proposed fix will result in a slightly higher amount of memory usage whenever the shared indices buffer grows but will eventually stabilise (assuming no references to the `QuadCommand` are kept from deallocating).

Maybe a larger refactor for dealing with the shared memory should be considered but this is a fairly low impact fix which should at least stop the crashes!
