### PR TITLE
Use const references whenever possible

### DIFF
--- a/cocos/2d/CCActionCatmullRom.cpp
+++ b/cocos/2d/CCActionCatmullRom.cpp
@@ -112,7 +112,7 @@ void PointArray::setControlPoints(vector<Vec2*> *controlPoints)
     _controlPoints = controlPoints;
 }
 
-void PointArray::addControlPoint(Vec2 controlPoint)
+void PointArray::addControlPoint(const Vec2& controlPoint)
 {    
     _controlPoints->push_back(new Vec2(controlPoint.x, controlPoint.y));
 }

--- a/cocos/2d/CCActionCatmullRom.h
+++ b/cocos/2d/CCActionCatmullRom.h
@@ -88,7 +88,7 @@ public:
      * @js NA
      * @param controlPoint A control point.
      */
-    void addControlPoint(Vec2 controlPoint);
+    void addControlPoint(const Vec2& controlPoint);
 
     /** Inserts a controlPoint at index.
      *

--- a/cocos/2d/CCActionGrid3D.cpp
+++ b/cocos/2d/CCActionGrid3D.cpp
@@ -653,7 +653,7 @@ void Waves::update(float time)
 
 // implementation of Twirl
 
-Twirl* Twirl::create(float duration, const Size& gridSize, Vec2 position, unsigned int twirls, float amplitude)
+Twirl* Twirl::create(float duration, const Size& gridSize, const Vec2& position, unsigned int twirls, float amplitude)
 {
     Twirl *action = new (std::nothrow) Twirl();
 
@@ -672,7 +672,7 @@ Twirl* Twirl::create(float duration, const Size& gridSize, Vec2 position, unsign
     return action;
 }
 
-bool Twirl::initWithDuration(float duration, const Size& gridSize, Vec2 position, unsigned int twirls, float amplitude)
+bool Twirl::initWithDuration(float duration, const Size& gridSize, const Vec2& position, unsigned int twirls, float amplitude)
 {
     if (Grid3DAction::initWithDuration(duration, gridSize))
     {

--- a/cocos/2d/CCActionGrid3D.h
+++ b/cocos/2d/CCActionGrid3D.h
@@ -545,7 +545,7 @@ public:
     @param amplitude Specify the amplitude of the Twirl action.
     @return If the creation success, return a pointer of Twirl action; otherwise, return nil.
     */
-    static Twirl* create(float duration, const Size& gridSize, Vec2 position, unsigned int twirls, float amplitude);
+    static Twirl* create(float duration, const Size& gridSize, const Vec2& position, unsigned int twirls, float amplitude);
 
     /**
     @brief Get the center position of twirl action.
@@ -598,7 +598,7 @@ CC_CONSTRUCTOR_ACCESS:
     @param amplitude Specify the amplitude of the Twirl action.
     @return If the initialization success, return true; otherwise, return false.
     */
-    bool initWithDuration(float duration, const Size& gridSize, Vec2 position, unsigned int twirls, float amplitude);
+    bool initWithDuration(float duration, const Size& gridSize, const Vec2& position, unsigned int twirls, float amplitude);
 
 protected:
     /* twirl center */

--- a/cocos/2d/CCAutoPolygon.cpp
+++ b/cocos/2d/CCAutoPolygon.cpp
@@ -421,7 +421,7 @@ float AutoPolygon::perpendicularDistance(const cocos2d::Vec2& i, const cocos2d::
     }
     return res;
 }
-std::vector<cocos2d::Vec2> AutoPolygon::rdp(std::vector<cocos2d::Vec2> v, const float& optimization)
+std::vector<cocos2d::Vec2> AutoPolygon::rdp(const std::vector<cocos2d::Vec2>& v, float optimization)
 {
     if(v.size() < 3)
         return v;

--- a/cocos/2d/CCAutoPolygon.h
+++ b/cocos/2d/CCAutoPolygon.h
@@ -260,7 +260,7 @@ protected:
     int getIndexFromPos(const unsigned int& x, const unsigned int& y){return y*_width+x;};
     cocos2d::Vec2 getPosFromIndex(const unsigned int& i){return cocos2d::Vec2(i%_width, i/_width);};
 
-    std::vector<cocos2d::Vec2> rdp(std::vector<cocos2d::Vec2> v, const float& optimization);
+    std::vector<cocos2d::Vec2> rdp(const std::vector<cocos2d::Vec2>& v, float optimization);
     float perpendicularDistance(const cocos2d::Vec2& i, const cocos2d::Vec2& start, const cocos2d::Vec2& end);
 
     //real rect is the size that is in scale with the texture file

--- a/cocos/2d/CCFastTMXLayer.cpp
+++ b/cocos/2d/CCFastTMXLayer.cpp
@@ -828,7 +828,7 @@ void TMXLayer::setTileGID(int gid, const Vec2& tileCoordinate, TMXTileFlags flag
     }
 }
 
-void TMXLayer::setupTileSprite(Sprite* sprite, Vec2 pos, int gid)
+void TMXLayer::setupTileSprite(Sprite* sprite, const Vec2& pos, int gid)
 {
     sprite->setPosition(getPositionAt(pos));
     sprite->setPositionZ((float)getVertexZForPos(pos));

--- a/cocos/2d/CCFastTMXLayer.h
+++ b/cocos/2d/CCFastTMXLayer.h
@@ -261,7 +261,7 @@ public:
      * @param pos The tile coordinate.
      * @param gid The tile gid.
      */
-    void setupTileSprite(Sprite* sprite, Vec2 pos, int gid);
+    void setupTileSprite(Sprite* sprite, const Vec2& pos, int gid);
 
     //
     // Override

--- a/cocos/2d/CCTMXLayer.cpp
+++ b/cocos/2d/CCTMXLayer.cpp
@@ -224,7 +224,7 @@ void TMXLayer::parseInternalProperties()
     }
 }
 
-void TMXLayer::setupTileSprite(Sprite* sprite, Vec2 pos, int gid)
+void TMXLayer::setupTileSprite(Sprite* sprite, const Vec2& pos, int gid)
 {
     sprite->setPosition(getPositionAt(pos));
     sprite->setPositionZ((float)getVertexZForPos(pos));
@@ -281,7 +281,7 @@ void TMXLayer::setupTileSprite(Sprite* sprite, Vec2 pos, int gid)
     }
 }
 
-Sprite* TMXLayer::reusedTileWithRect(Rect rect)
+Sprite* TMXLayer::reusedTileWithRect(const Rect& rect)
 {
     if (! _reusedTile) 
     {

--- a/cocos/2d/CCTMXLayer.h
+++ b/cocos/2d/CCTMXLayer.h
@@ -307,8 +307,8 @@ protected:
 
     /* The layer recognizes some special properties, like cc_vertexz */
     void parseInternalProperties();
-    void setupTileSprite(Sprite* sprite, Vec2 pos, int gid);
-    Sprite* reusedTileWithRect(Rect rect);
+    void setupTileSprite(Sprite* sprite, const Vec2& pos, int gid);
+    Sprite* reusedTileWithRect(const Rect& rect);
     int getVertexZForPos(const Vec2& pos);
 
     // index

--- a/cocos/3d/CCTerrain.cpp
+++ b/cocos/3d/CCTerrain.cpp
@@ -294,7 +294,7 @@ Terrain::Terrain()
 #endif
 }
 
-void Terrain::setChunksLOD(Vec3 cameraPos)
+void Terrain::setChunksLOD(const Vec3& cameraPos)
 {
     int chunk_amount_y = _imageHeight/_chunkSize.height;
     int chunk_amount_x = _imageWidth/_chunkSize.width;
@@ -369,9 +369,9 @@ float Terrain::getHeight(float x, float z, Vec3 * normal) const
     }
 }
 
-float Terrain::getHeight(Vec2 pos, Vec3*Normal) const
+float Terrain::getHeight(const Vec2& pos, Vec3* normal) const
 {
-    return getHeight(pos.x,pos.y,Normal);
+    return getHeight(pos.x, pos.y, normal);
 }
 
 float Terrain::getImageHeight(int pixel_x,int pixel_y) const
@@ -606,7 +606,7 @@ void Terrain::setMaxDetailMapAmount(int max_value)
     _maxDetailMapValue = max_value;
 }
 
-cocos2d::Vec2 Terrain::convertToTerrainSpace(Vec2 worldSpaceXZ) const
+cocos2d::Vec2 Terrain::convertToTerrainSpace(const Vec2& worldSpaceXZ) const
 {
     Vec2 pos(worldSpaceXZ.x,worldSpaceXZ.y);
 
@@ -1638,14 +1638,14 @@ Terrain::DetailMap::DetailMap()
     _detailMapSize = 35;
 }
 
-Terrain::Triangle::Triangle(Vec3 p1, Vec3 p2, Vec3 p3)
+Terrain::Triangle::Triangle(const Vec3& p1, const Vec3& p2, const Vec3& p3)
 {
     _p1 = p1;
     _p2 = p2;
     _p3 = p3;
 }
 
-void Terrain::Triangle::transform(cocos2d::Mat4 matrix)
+void Terrain::Triangle::transform(const cocos2d::Mat4& matrix)
 {
     matrix.transformPoint(&_p1);
     matrix.transformPoint(&_p2);

--- a/cocos/3d/CCTerrain.h
+++ b/cocos/3d/CCTerrain.h
@@ -114,9 +114,9 @@ public:
      */
     struct Triangle
     {
-        Triangle(Vec3 p1, Vec3 p2, Vec3 p3);
+        Triangle(const Vec3& p1, const Vec3& p2, const Vec3& p3);
         bool getInsterctPoint(const Ray &ray, Vec3& interScetPoint) const;
-        void transform(Mat4 matrix);
+        void transform(const Mat4& matrix);
         Vec3 _p1, _p2, _p3;
     };
 
@@ -181,7 +181,7 @@ private:
     {
         /*constructor*/
         TerrainVertexData(){};
-        TerrainVertexData(Vec3 v1, Tex2F v2)
+        TerrainVertexData(const Vec3& v1, const Tex2F& v2)
         {
             _position = v1;
             _texcoord = v2;
@@ -334,7 +334,7 @@ public:
      * @param normal the specified position's normal vector in terrain . if this argument is NULL or nullptr,Normal calculation shall be skip.
      * @return the height value of the specified position of the terrain, if the (X,Z) position is out of the terrain bounds,it shall return 0;
      **/
-    float getHeight(Vec2 pos, Vec3*Normal = nullptr) const;
+    float getHeight(const Vec2& pos, Vec3* normal = nullptr) const;
 
     /**get the normal of the specified position in terrain
      * @return the normal vector of the specified position of the terrain.
@@ -387,7 +387,7 @@ public:
     /**
      * Convert a world Space position (X,Z) to terrain space position (X,Z)
      */
-    Vec2 convertToTerrainSpace(Vec2 worldSpace) const;
+    Vec2 convertToTerrainSpace(const Vec2& worldSpace) const;
 
     /**
      * reset the heightmap data.
@@ -442,7 +442,7 @@ protected:
      * recursively set each chunk's LOD
      * @param cameraPos the camera position in world space
      **/
-    void setChunksLOD(Vec3 cameraPos);
+    void setChunksLOD(const Vec3& cameraPos);
 
     /**
      * load Vertices from height filed for the whole terrain.

--- a/cocos/base/CCConsole.cpp
+++ b/cocos/base/CCConsole.cpp
@@ -247,7 +247,7 @@ std::vector<std::string> Console::Utility::split(const std::string& s, char deli
 }
 
 //isFloat taken from http://stackoverflow.com/questions/447206/c-isfloat-function
-bool Console::Utility::isFloat(std::string myString) {
+bool Console::Utility::isFloat(const std::string& myString) {
     std::istringstream iss(myString);
     float f;
     iss >> std::noskipws >> f; // noskipws considers leading whitespace invalid

--- a/cocos/base/CCConsole.h
+++ b/cocos/base/CCConsole.h
@@ -88,7 +88,7 @@ public:
         static std::vector<std::string> split(const std::string& s, char delim);
         
         /** Checks myString is a floating-point type. */
-        static bool isFloat(std::string myString);
+        static bool isFloat(const std::string& myString);
         
         /** send a message to console */
         static ssize_t sendToConsole(int fd, const void* buffer, size_t length, int flags = 0);

--- a/cocos/base/ccUTF8.cpp
+++ b/cocos/base/ccUTF8.cpp
@@ -228,7 +228,7 @@ std::string getStringUTFCharsJNI(JNIEnv* env, jstring srcjStr, bool* ret)
     return utf8Str;
 }
 
-jstring newStringUTFJNI(JNIEnv* env, std::string utf8Str, bool* ret)
+jstring newStringUTFJNI(JNIEnv* env, const std::string& utf8Str, bool* ret)
 {
     std::u16string utf16Str;
     bool flag = cocos2d::StringUtils::UTF8ToUTF16(utf8Str, utf16Str);

--- a/cocos/base/ccUTF8.h
+++ b/cocos/base/ccUTF8.h
@@ -118,7 +118,7 @@ CC_DLL std::string getStringUTFCharsJNI(JNIEnv* env, jstring srcjStr, bool* ret 
 *  @param ret     True if the conversion succeeds and the ret pointer isn't null
 *  @returns the result of jstring,the jstring need to DeleteLocalRef(jstring);
 */
-CC_DLL jstring newStringUTFJNI(JNIEnv* env, std::string utf8Str, bool* ret = nullptr);
+CC_DLL jstring newStringUTFJNI(JNIEnv* env, const std::string& utf8Str, bool* ret = nullptr);
 #endif
 
 /**

--- a/cocos/network/HttpClient-android.cpp
+++ b/cocos/network/HttpClient-android.cpp
@@ -399,7 +399,7 @@ public:
     }
     
 private:
-    void createHttpURLConnection(std::string url)
+    void createHttpURLConnection(const std::string& url)
     {
         JniMethodInfo methodInfo;
         if (JniHelper::getStaticMethodInfo(methodInfo,

--- a/cocos/network/HttpConnection-winrt.cpp
+++ b/cocos/network/HttpConnection-winrt.cpp
@@ -53,7 +53,7 @@ namespace network {
     }
 
     // Get user authentication token (Platform specific approach)
-    static bool getAuthenticationToken(std::string verb, std::string url, std::string headersXST, std::string bodyXST, std::string& token, std::string& signature)
+    static bool getAuthenticationToken(const std::string& verb, const std::string& url, const std::string& headersXST, const std::string& bodyXST, std::string& token, std::string& signature)
     {
 #if defined(_XBOX_ONE)
         using namespace Windows::Xbox::System;
@@ -565,22 +565,22 @@ namespace network {
         return _isInitialized = SUCCEEDED(hr);
     }
 
-    bool HttpConnection::open(std::string verb)
+    bool HttpConnection::open(const std::string& verb)
     {
         return open(verb, false, "");
     }
 
-    bool HttpConnection::open(std::string verb, bool userAuthentication)
+    bool HttpConnection::open(const std::string& verb, bool userAuthentication)
     {
         return open(verb, userAuthentication, "");
     }
 
-    bool HttpConnection::open(std::string verb, std::string cookieFile)
+    bool HttpConnection::open(const std::string& verb, const std::string& cookieFile)
     {
         return open(verb, false, cookieFile);
     }
 
-    bool HttpConnection::open(std::string verb, bool userAuthentication, std::string cookieFile)
+    bool HttpConnection::open(const std::string& verb, bool userAuthentication, const std::string& cookieFile)
     {
         if (!_isInitialized) {
             return false;
@@ -629,7 +629,7 @@ namespace network {
         return SUCCEEDED(hr);
     }
 
-    HRESULT HttpConnection::authenticateUser(std::string& verb, std::string& url, std::string& headers)
+    HRESULT HttpConnection::authenticateUser(const std::string& verb, const std::string& url, const std::string& headers)
     {
         HRESULT hr = S_OK;
         std::string authToken;
@@ -654,7 +654,7 @@ namespace network {
         return hr;
     }
 
-    HRESULT HttpConnection::processCookieFile(std::string& url, std::string& cookieFile)
+    HRESULT HttpConnection::processCookieFile(const std::string& url, const std::string& cookieFile)
     {
         HRESULT hr = S_OK;
 

--- a/cocos/network/HttpConnection-winrt.h
+++ b/cocos/network/HttpConnection-winrt.h
@@ -132,10 +132,10 @@ namespace network {
         ~HttpConnection();
 
         bool init(HttpRequest *pRequest, DWORD timeOutInMs = 0);
-        bool open(std::string verb);
-        bool open(std::string verb, bool userAuthentication);
-        bool open(std::string verb, std::string cookieFile);
-        bool open(std::string verb, bool userAuthentication, std::string cookieFile);
+        bool open(const std::string& verb);
+        bool open(const std::string& verb, bool userAuthentication);
+        bool open(const std::string& verb, const std::string& cookieFile);
+        bool open(const std::string& verb, bool userAuthentication, const std::string& cookieFile);
         bool send();
         DWORD getStatusCode();
         std::string getErrorMessage();
@@ -144,8 +144,8 @@ namespace network {
 
     protected:
         void cancelRequest(HRESULT hrError);
-        HRESULT authenticateUser(std::string& verb, std::string& url, std::string& headers);
-        HRESULT processCookieFile(std::string& url, std::string& cookieFile);
+        HRESULT authenticateUser(const std::string& verb, const std::string& url, const std::string& headers);
+        HRESULT processCookieFile(const std::string& url, const std::string& cookieFile);
 
     private:
         bool _isInitialized;

--- a/cocos/network/HttpRequest.h
+++ b/cocos/network/HttpRequest.h
@@ -318,7 +318,7 @@ public:
      *
      * @param pHeaders the string vector of custom-defined headers.
      */
-    inline void setHeaders(std::vector<std::string> pHeaders)
+    inline void setHeaders(const std::vector<std::string>& pHeaders)
     {
         _headers = pHeaders;
     }

--- a/cocos/network/SocketIO.cpp
+++ b/cocos/network/SocketIO.cpp
@@ -76,7 +76,7 @@ public:
     std::vector<std::string> getData()const{ return _args; };
     virtual std::string stringify()const;
 
-    static SocketIOPacket * createPacketWithType(std::string type, SocketIOVersion version);
+    static SocketIOPacket * createPacketWithType(const std::string& type, SocketIOVersion version);
     static SocketIOPacket * createPacketWithTypeIndex(int type, SocketIOVersion version);
 protected:
     std::string _pId;//id message
@@ -302,7 +302,7 @@ SocketIOPacketV10x::~SocketIOPacketV10x()
     _endpoint = "";
 }
 
-SocketIOPacket * SocketIOPacket::createPacketWithType(std::string type, SocketIOPacket::SocketIOVersion version)
+SocketIOPacket * SocketIOPacket::createPacketWithType(const std::string& type, SocketIOPacket::SocketIOVersion version)
 {
     SocketIOPacket *ret;
     switch (version)

--- a/cocos/platform/ios/CCGLViewImpl-ios.h
+++ b/cocos/platform/ios/CCGLViewImpl-ios.h
@@ -48,7 +48,7 @@ public:
     static GLViewImpl* create(const std::string& viewName);
 
     /** creates a GLViewImpl with a title name, a rect and the zoom factor */
-    static GLViewImpl* createWithRect(const std::string& viewName, Rect rect, float frameZoomFactor = 1.0f);
+    static GLViewImpl* createWithRect(const std::string& viewName, const Rect& rect, float frameZoomFactor = 1.0f);
 
     /** creates a GLViewImpl with a name in fullscreen mode */
     static GLViewImpl* createWithFullScreen(const std::string& viewName);
@@ -80,7 +80,7 @@ protected:
     virtual ~GLViewImpl();
 
     bool initWithEAGLView(void* eaGLView);
-    bool initWithRect(const std::string& viewName, Rect rect, float frameZoomFactor);
+    bool initWithRect(const std::string& viewName, const Rect& rect, float frameZoomFactor);
     bool initWithFullScreen(const std::string& viewName);
 
     // the objective-c CCEAGLView instance

--- a/cocos/platform/ios/CCGLViewImpl-ios.mm
+++ b/cocos/platform/ios/CCGLViewImpl-ios.mm
@@ -61,7 +61,7 @@ GLViewImpl* GLViewImpl::create(const std::string& viewName)
     return nullptr;
 }
 
-GLViewImpl* GLViewImpl::createWithRect(const std::string& viewName, Rect rect, float frameZoomFactor)
+GLViewImpl* GLViewImpl::createWithRect(const std::string& viewName, const Rect& rect, float frameZoomFactor)
 {
     auto ret = new (std::nothrow) GLViewImpl;
     if(ret && ret->initWithRect(viewName, rect, frameZoomFactor)) {
@@ -130,7 +130,7 @@ bool GLViewImpl::initWithEAGLView(void *eaglview)
     return true;
 }
 
-bool GLViewImpl::initWithRect(const std::string& viewName, Rect rect, float frameZoomFactor)
+bool GLViewImpl::initWithRect(const std::string& viewName, const Rect& rect, float frameZoomFactor)
 {
     CGRect r = CGRectMake(rect.origin.x, rect.origin.y, rect.size.width, rect.size.height);
     convertAttrs();


### PR DESCRIPTION
Hello,

When we call a function with its non-[fundamental](https://msdn.microsoft.com/en-us/library/cc953fe1.aspx) parameter, we should pass [by reference](https://msdn.microsoft.com/en-us/library/f0a5bh3e.aspx) instead of by value if available.
This PR changes some parameters to use const reference instead, and avoids needless copying. Also it keeps backward compatibility with the original version.

Thank you for your time.
