### PR TITLE
Replace CCAssert macros with CCASSERT

### DIFF
--- a/cocos/platform/CCImage.cpp
+++ b/cocos/platform/CCImage.cpp
@@ -844,7 +844,7 @@ bool Image::decodeWithWIC(const unsigned char *data, ssize_t dataLen)
 
         _dataLen = img.getImageDataSize();
 
-        CCAssert(_dataLen > 0, "Image: Decompressed data length is invalid");
+        CCASSERT(_dataLen > 0, "Image: Decompressed data length is invalid");
 
         _data = new (std::nothrow) unsigned char[_dataLen];
         bRet = (img.getImageData(_data, _dataLen) > 0);
@@ -1599,7 +1599,7 @@ bool Image::initWithPVRv3Data(const unsigned char * data, ssize_t dataLen)
     memcpy(_data, static_cast<const unsigned char*>(data) + sizeof(PVRv3TexHeader) + header->metadataLength, _dataLen);
     
     _numberOfMipmaps = header->numberOfMipmaps;
-    CCAssert(_numberOfMipmaps < MIPMAP_MAX, "Image: Maximum number of mimpaps reached. Increase the CC_MIPMAP_MAX value");
+    CCASSERT(_numberOfMipmaps < MIPMAP_MAX, "Image: Maximum number of mimpaps reached. Increase the CC_MIPMAP_MAX value");
     
     for (int i = 0; i < _numberOfMipmaps; i++)
     {
@@ -1687,7 +1687,7 @@ bool Image::initWithPVRv3Data(const unsigned char * data, ssize_t dataLen)
         }
         
         dataOffset += packetLength;
-        CCAssert(dataOffset <= _dataLen, "CCTexurePVR: Invalid length");
+        CCASSERT(dataOffset <= _dataLen, "Image: Invalid length");
         
         
         width = MAX(width >> 1, 1);

--- a/cocos/ui/UIEditBox/UIEditBoxImpl-win32.cpp
+++ b/cocos/ui/UIEditBox/UIEditBoxImpl-win32.cpp
@@ -307,7 +307,7 @@ INT_PTR CWin32InputBox::InputBoxEx(WIN32INPUTBOX_PARAM *param,
 			dlgTemplate->y = param->yPos;
 	}
 
-	CCAssert(s_win32InputBox == nullptr, "Only one instance of Win32InputBox allowed");
+	CCASSERT(s_win32InputBox == nullptr, "Only one instance of Win32InputBox allowed");
 
 	s_win32InputBox = new (std::nothrow) CWin32InputBox(param);
 	s_win32InputBox->_returnType = eReturnType;
@@ -492,7 +492,7 @@ void CWin32InputBox::InitDialog()
 		break;
 	}
 
-	CCAssert(_getMsgHook == NULL, "Windows Message hook already set");
+	CCASSERT(_getMsgHook == nullptr, "Windows Message hook already set");
 
 	// To make the enter key work, here need a Windows Message hook.
 	// Please refer to https://support.microsoft.com/en-us/kb/187988

--- a/extensions/Particle3D/PU/CCPURibbonTrail.cpp
+++ b/extensions/Particle3D/PU/CCPURibbonTrail.cpp
@@ -58,7 +58,7 @@ void PURibbonTrail::addNode(Node* n)
 {
     if (_nodeList.size() == _chainCount)
     {
-        CCAssert(false, " cannot monitor any more nodes, chain count exceeded");
+        CCASSERT(false, " cannot monitor any more nodes, chain count exceeded");
     }
 
     //if (n->getListener())
@@ -87,7 +87,7 @@ size_t PURibbonTrail::getChainIndexForNode(const Node* n)
     NodeToChainSegmentMap::const_iterator i = _nodeToSegMap.find(n);
     if (i == _nodeToSegMap.end())
     {
-        CCAssert(false, "This node is not being tracked");
+        CCASSERT(false, "This node is not being tracked");
     }
     return i->second;
 }
@@ -130,7 +130,7 @@ void PURibbonTrail::setMaxChainElements(size_t maxElements)
 //-----------------------------------------------------------------------
 void PURibbonTrail::setNumberOfChains(size_t numChains)
 {
-    CCAssert(numChains >= _nodeList.size(), "Can't shrink the number of chains less than number of tracking nodes");
+    CCASSERT(numChains >= _nodeList.size(), "Can't shrink the number of chains less than number of tracking nodes");
 
     size_t oldChains = getNumberOfChains();
 
@@ -181,7 +181,7 @@ void PURibbonTrail::setInitialColour(size_t chainIndex, const Vec4& col)
 //-----------------------------------------------------------------------
 void PURibbonTrail::setInitialColour(size_t chainIndex, float r, float g, float b, float a)
 {
-    CCAssert(chainIndex < _chainCount, "chainIndex out of bounds");
+    CCASSERT(chainIndex < _chainCount, "chainIndex out of bounds");
     _initialColor[chainIndex].x = r;
     _initialColor[chainIndex].y = g;
     _initialColor[chainIndex].z = b;
@@ -190,19 +190,19 @@ void PURibbonTrail::setInitialColour(size_t chainIndex, float r, float g, float 
 //-----------------------------------------------------------------------
 const Vec4& PURibbonTrail::getInitialColour(size_t chainIndex) const
 {
-    CCAssert(chainIndex < _chainCount, "chainIndex out of bounds");
+    CCASSERT(chainIndex < _chainCount, "chainIndex out of bounds");
     return _initialColor[chainIndex];
 }
 //-----------------------------------------------------------------------
 void PURibbonTrail::setInitialWidth(size_t chainIndex, float width)
 {
-    CCAssert(chainIndex < _chainCount, "chainIndex out of bounds");
+    CCASSERT(chainIndex < _chainCount, "chainIndex out of bounds");
     _initialWidth[chainIndex] = width;
 }
 //-----------------------------------------------------------------------
 float PURibbonTrail::getInitialWidth(size_t chainIndex) const
 {
-    CCAssert(chainIndex < _chainCount, "chainIndex out of bounds");
+    CCASSERT(chainIndex < _chainCount, "chainIndex out of bounds");
     return _initialWidth[chainIndex];
 }
 //-----------------------------------------------------------------------
@@ -214,7 +214,7 @@ void PURibbonTrail::setColourChange(size_t chainIndex, const Vec4& valuePerSecon
 //-----------------------------------------------------------------------
 void PURibbonTrail::setColourChange(size_t chainIndex, float r, float g, float b, float a)
 {
-    CCAssert(chainIndex < _chainCount, "chainIndex out of bounds");
+    CCASSERT(chainIndex < _chainCount, "chainIndex out of bounds");
     _deltaColor[chainIndex].x = r;
     _deltaColor[chainIndex].y = g;
     _deltaColor[chainIndex].z = b;
@@ -226,20 +226,20 @@ void PURibbonTrail::setColourChange(size_t chainIndex, float r, float g, float b
 //-----------------------------------------------------------------------
 const Vec4& PURibbonTrail::getColourChange(size_t chainIndex) const
 {
-    CCAssert(chainIndex < _chainCount, "chainIndex out of bounds");
+    CCASSERT(chainIndex < _chainCount, "chainIndex out of bounds");
     return _deltaColor[chainIndex];
 }
 //-----------------------------------------------------------------------
 void PURibbonTrail::setWidthChange(size_t chainIndex, float widthDeltaPerSecond)
 {
-    CCAssert(chainIndex < _chainCount, "chainIndex out of bounds");
+    CCASSERT(chainIndex < _chainCount, "chainIndex out of bounds");
     _deltaWidth[chainIndex] = widthDeltaPerSecond;
     manageController();
 }
 //-----------------------------------------------------------------------
 float PURibbonTrail::getWidthChange(size_t chainIndex) const
 {
-    CCAssert(chainIndex < _chainCount, "chainIndex out of bounds");
+    CCASSERT(chainIndex < _chainCount, "chainIndex out of bounds");
     return _deltaWidth[chainIndex];
 
 }


### PR DESCRIPTION
The `CCAssert` macro is deprecated since commit 89d210bdb38a6f8845ced65ab63c34100627e6fd. This pull request replaces `CCAssert` macros with `CCASSERT`.
