### PR TITLE
Refactor the AudioEngine-Linux to make more maintainable

### DIFF
--- a/cocos/audio/linux/AudioEngine-linux.cpp
+++ b/cocos/audio/linux/AudioEngine-linux.cpp
@@ -33,7 +33,7 @@ FMOD_RESULT F_CALLBACK channelCallback(FMOD_CHANNELCONTROL *channelcontrol,
                                        void *commandData1, void *commandData2)
 {
   
-  if(controltype == FMOD_CHANNELCONTROL_CHANNEL && callbacktype == FMOD_CHANNELCONTROL_CALLBACK_END){
+    if(controltype == FMOD_CHANNELCONTROL_CHANNEL && callbacktype == FMOD_CHANNELCONTROL_CALLBACK_END){
         g_AudioEngineImpl->onSoundFinished((FMOD::Channel *)channelcontrol);
     }else{
     }
@@ -45,262 +45,262 @@ AudioEngineImpl::AudioEngineImpl(){
 }
 
 AudioEngineImpl::~AudioEngineImpl(){
-  FMOD_RESULT result;
-  result = pSystem->close();
-  ERRCHECKWITHEXIT(result);
-  result = pSystem->release();
-  ERRCHECKWITHEXIT(result);
+    FMOD_RESULT result;
+    result = pSystem->close();
+    ERRCHECKWITHEXIT(result);
+    result = pSystem->release();
+    ERRCHECKWITHEXIT(result);
 }
 
     
 bool AudioEngineImpl::init(){
-  FMOD_RESULT result;
-  /*
-  Create a System object and initialize.
-  */
-  result = FMOD::System_Create(&pSystem);
-  ERRCHECKWITHEXIT(result);
+    FMOD_RESULT result;
+    /*
+    Create a System object and initialize.
+    */
+    result = FMOD::System_Create(&pSystem);
+    ERRCHECKWITHEXIT(result);
   
-  result = pSystem->setOutput(FMOD_OUTPUTTYPE_PULSEAUDIO);
-  ERRCHECKWITHEXIT(result);
+    result = pSystem->setOutput(FMOD_OUTPUTTYPE_PULSEAUDIO);
+    ERRCHECKWITHEXIT(result);
 
-  result = pSystem->init(32, FMOD_INIT_NORMAL, 0);
-  ERRCHECKWITHEXIT(result);
+    result = pSystem->init(32, FMOD_INIT_NORMAL, 0);
+    ERRCHECKWITHEXIT(result);
 
-  mapChannelInfo.clear();
-  mapSound.clear();
+    mapChannelInfo.clear();
+    mapSound.clear();
   
-  auto scheduler = cocos2d::Director::getInstance()->getScheduler();
-  scheduler->schedule(schedule_selector(AudioEngineImpl::update), this, 0.05f, false);
+    auto scheduler = cocos2d::Director::getInstance()->getScheduler();
+    scheduler->schedule(schedule_selector(AudioEngineImpl::update), this, 0.05f, false);
   
-  g_AudioEngineImpl = this; 
+    g_AudioEngineImpl = this;
   
-  return true;
+    return true;
 }
 
 int AudioEngineImpl::play2d(const std::string &fileFullPath ,bool loop ,float volume){
-  int id = preload(fileFullPath, nullptr); 
-  if(id >= 0){
-    mapChannelInfo[id].loop=loop;  
-    mapChannelInfo[id].channel->setPaused(true); 
-    mapChannelInfo[id].volume = volume;
-    AudioEngine::_audioIDInfoMap[id].state = AudioEngine::AudioState::PAUSED;
-    resume(id); 
-  }
-  return id; 
+    int id = preload(fileFullPath, nullptr);
+    if(id >= 0){
+        mapChannelInfo[id].loop=loop;
+        mapChannelInfo[id].channel->setPaused(true);
+        mapChannelInfo[id].volume = volume;
+        AudioEngine::_audioIDInfoMap[id].state = AudioEngine::AudioState::PAUSED;
+        resume(id);
+    }
+    return id;
 }
 
 void AudioEngineImpl::setVolume(int audioID,float volume){
-  try{
-    mapChannelInfo[audioID].channel->setVolume(volume);
-  }catch(const std::out_of_range& oor){
-      printf("AudioEngineImpl::setVolume: invalid audioID: %d\n", audioID);
-  }
+    try{
+        mapChannelInfo[audioID].channel->setVolume(volume);
+    }catch(const std::out_of_range& oor){
+        printf("AudioEngineImpl::setVolume: invalid audioID: %d\n", audioID);
+    }
 }
 
 void AudioEngineImpl::setLoop(int audioID, bool loop){
-  try{
-    mapChannelInfo[audioID].channel->setLoopCount(loop?-1:0); 
-  }catch(const std::out_of_range& oor){
-      printf("AudioEngineImpl::setLoop: invalid audioID: %d\n", audioID);
-  }
+    try{
+        mapChannelInfo[audioID].channel->setLoopCount(loop?-1:0);
+    }catch(const std::out_of_range& oor){
+        printf("AudioEngineImpl::setLoop: invalid audioID: %d\n", audioID);
+    }
 }
 
 bool AudioEngineImpl::pause(int audioID){
-  try{
-    mapChannelInfo[audioID].channel->setPaused(true); 
-    AudioEngine::_audioIDInfoMap[audioID].state = AudioEngine::AudioState::PAUSED;
-    return true; 
-  }catch(const std::out_of_range& oor){
-      printf("AudioEngineImpl::pause: invalid audioID: %d\n", audioID);
-      return false;
-  }
+    try{
+        mapChannelInfo[audioID].channel->setPaused(true);
+        AudioEngine::_audioIDInfoMap[audioID].state = AudioEngine::AudioState::PAUSED;
+        return true;
+    }catch(const std::out_of_range& oor){
+        printf("AudioEngineImpl::pause: invalid audioID: %d\n", audioID);
+        return false;
+    }
 }
 
 bool AudioEngineImpl::resume(int audioID){
-try{
+    try{
 
-    if(!mapChannelInfo[audioID].channel){
-      FMOD::Channel *channel = nullptr;
-      FMOD::ChannelGroup *channelgroup = nullptr;
-      //starts the sound in pause mode, use the channel to unpause
-      FMOD_RESULT result = pSystem->playSound(mapChannelInfo[audioID].sound, channelgroup, true, &channel);
-      if(ERRCHECK(result)){
-        return false; 
-      }
-      channel->setMode(mapChannelInfo[audioID].loop?FMOD_LOOP_NORMAL:FMOD_LOOP_OFF);  
-      channel->setLoopCount(mapChannelInfo[audioID].loop?-1:0); 
-      channel->setVolume(mapChannelInfo[audioID].volume);
-      channel->setUserData((void *)mapChannelInfo[audioID].id);
-      mapChannelInfo[audioID].channel = channel; 
+        if(!mapChannelInfo[audioID].channel){
+            FMOD::Channel *channel = nullptr;
+            FMOD::ChannelGroup *channelgroup = nullptr;
+            //starts the sound in pause mode, use the channel to unpause
+            FMOD_RESULT result = pSystem->playSound(mapChannelInfo[audioID].sound, channelgroup, true, &channel);
+            if(ERRCHECK(result)){
+                return false;
+            }
+            channel->setMode(mapChannelInfo[audioID].loop?FMOD_LOOP_NORMAL:FMOD_LOOP_OFF);
+            channel->setLoopCount(mapChannelInfo[audioID].loop?-1:0);
+            channel->setVolume(mapChannelInfo[audioID].volume);
+            channel->setUserData((void *)mapChannelInfo[audioID].id);
+            mapChannelInfo[audioID].channel = channel;
+        }
+    
+        mapChannelInfo[audioID].channel->setPaused(false);
+        AudioEngine::_audioIDInfoMap[audioID].state = AudioEngine::AudioState::PLAYING;
+    
+        return true;
+    }catch(const std::out_of_range& oor){
+        printf("AudioEngineImpl::resume: invalid audioID: %d\n", audioID);
+        return false;
     }
-    
-    mapChannelInfo[audioID].channel->setPaused(false); 
-    AudioEngine::_audioIDInfoMap[audioID].state = AudioEngine::AudioState::PLAYING;
-    
-    return true; 
-  }catch(const std::out_of_range& oor){
-      printf("AudioEngineImpl::resume: invalid audioID: %d\n", audioID);
-      return false;
-  }
 }
 
 bool AudioEngineImpl::stop(int audioID){
-  try{
-    mapChannelInfo[audioID].channel->stop(); 
-    mapChannelInfo[audioID].channel = nullptr; 
-    return true; 
-  }catch(const std::out_of_range& oor){
-      printf("AudioEngineImpl::stop: invalid audioID: %d\n", audioID);
-      return false;
-  }
+    try{
+        mapChannelInfo[audioID].channel->stop();
+        mapChannelInfo[audioID].channel = nullptr;
+        return true;
+    }catch(const std::out_of_range& oor){
+        printf("AudioEngineImpl::stop: invalid audioID: %d\n", audioID);
+        return false;
+    }
 }
 
 void AudioEngineImpl::stopAll(){
-  for (auto it = mapChannelInfo.begin(); it != mapChannelInfo.end(); ++it) {
-    ChannelInfo & audioRef = it->second;
-    audioRef.channel->stop();
-    audioRef.channel = nullptr;
-  }
+    for (auto it = mapChannelInfo.begin(); it != mapChannelInfo.end(); ++it) {
+        ChannelInfo & audioRef = it->second;
+        audioRef.channel->stop();
+        audioRef.channel = nullptr;
+    }
 }
 
 float AudioEngineImpl::getDuration(int audioID){
-  try{
-    FMOD::Sound * sound = mapChannelInfo[audioID].sound; 
-    unsigned int length; 
-    FMOD_RESULT result = sound->getLength(&length, FMOD_TIMEUNIT_MS);
-    ERRCHECK(result);
-    float duration = (float)length / 1000.0f; 
-    return duration;
+    try{
+        FMOD::Sound * sound = mapChannelInfo[audioID].sound;
+        unsigned int length;
+        FMOD_RESULT result = sound->getLength(&length, FMOD_TIMEUNIT_MS);
+        ERRCHECK(result);
+        float duration = (float)length / 1000.0f;
+        return duration;
     }catch(const std::out_of_range& oor){
-      printf("AudioEngineImpl::getDuration: invalid audioID: %d\n", audioID);
-    return AudioEngine::TIME_UNKNOWN;
-  }
+        printf("AudioEngineImpl::getDuration: invalid audioID: %d\n", audioID);
+        return AudioEngine::TIME_UNKNOWN;
+    }
 }
 
 float AudioEngineImpl::getCurrentTime(int audioID){
- try{
-    unsigned int position; 
-    FMOD_RESULT result = mapChannelInfo[audioID].channel->getPosition(&position, FMOD_TIMEUNIT_MS);
-    ERRCHECK(result);
-    float currenttime = position /1000.0f;
-    return currenttime; 
+    try{
+        unsigned int position;
+        FMOD_RESULT result = mapChannelInfo[audioID].channel->getPosition(&position, FMOD_TIMEUNIT_MS);
+        ERRCHECK(result);
+        float currenttime = position /1000.0f;
+        return currenttime;
     }catch(const std::out_of_range& oor){
-      printf("AudioEngineImpl::getCurrentTime: invalid audioID: %d\n", audioID);
-    return AudioEngine::TIME_UNKNOWN;
-  }
+        printf("AudioEngineImpl::getCurrentTime: invalid audioID: %d\n", audioID);
+        return AudioEngine::TIME_UNKNOWN;
+    }
 }
 
 bool AudioEngineImpl::setCurrentTime(int audioID, float time){
- try{
-    unsigned int position = (unsigned int)(time * 1000.0f); 
-    FMOD_RESULT result = mapChannelInfo[audioID].channel->setPosition(position, FMOD_TIMEUNIT_MS);
-    ERRCHECK(result);
+    try{
+        unsigned int position = (unsigned int)(time * 1000.0f);
+        FMOD_RESULT result = mapChannelInfo[audioID].channel->setPosition(position, FMOD_TIMEUNIT_MS);
+        ERRCHECK(result);
     }catch(const std::out_of_range& oor){
-      printf("AudioEngineImpl::setCurrentTime: invalid audioID: %d\n", audioID);
-  }
+        printf("AudioEngineImpl::setCurrentTime: invalid audioID: %d\n", audioID);
+    }
 }
 
 void AudioEngineImpl::setFinishCallback(int audioID, const std::function<void (int, const std::string &)> &callback){
- try{
-    FMOD::Channel * channel = mapChannelInfo[audioID].channel;
-    mapChannelInfo[audioID].callback = callback; 
-    FMOD_RESULT result = channel->setCallback(channelCallback);
-    ERRCHECK(result);
+    try{
+        FMOD::Channel * channel = mapChannelInfo[audioID].channel;
+        mapChannelInfo[audioID].callback = callback;
+        FMOD_RESULT result = channel->setCallback(channelCallback);
+        ERRCHECK(result);
     }catch(const std::out_of_range& oor){
-      printf("AudioEngineImpl::setFinishCallback: invalid audioID: %d\n", audioID);
-  }
+        printf("AudioEngineImpl::setFinishCallback: invalid audioID: %d\n", audioID);
+    }
 }
 
 
 void AudioEngineImpl::onSoundFinished(FMOD::Channel * channel){
-    size_t id; 
+    size_t id;
     try{
-    void * data;
-    channel->getUserData(&data);
-    id = (size_t) data; 
-    if(mapChannelInfo[id].callback){
-     mapChannelInfo[id].callback(id, mapChannelInfo[id].path);
-    }
-    mapChannelInfo[id].channel = nullptr; 
+        void * data;
+        channel->getUserData(&data);
+        id = (size_t) data;
+        if(mapChannelInfo[id].callback){
+            mapChannelInfo[id].callback(id, mapChannelInfo[id].path);
+        }
+        mapChannelInfo[id].channel = nullptr;
     }catch(const std::out_of_range& oor){
-      printf("AudioEngineImpl::onSoundFinished: invalid audioID: %d\n", id);
-  }
+        printf("AudioEngineImpl::onSoundFinished: invalid audioID: %d\n", id);
+    }
 }
     
 
 void AudioEngineImpl::uncache(const std::string& path){
-  std::string fullPath = FileUtils::getInstance()->fullPathForFilename(path);  
-  std::map<std::string, FMOD::Sound *>::const_iterator it = mapSound.find(fullPath);
-  if(it!=mapSound.end()){
-    FMOD::Sound * sound = it->second; 
-    if(sound){
-      sound->release();
-    }
+    std::string fullPath = FileUtils::getInstance()->fullPathForFilename(path);
+    std::map<std::string, FMOD::Sound *>::const_iterator it = mapSound.find(fullPath);
+    if(it!=mapSound.end()){
+        FMOD::Sound * sound = it->second;
+        if(sound){
+            sound->release();
+        }
     mapSound.erase(it);
   }
 }
 
 
 void AudioEngineImpl::uncacheAll(){
-for (auto it = mapSound.cbegin(); it != mapSound.cend(); ++it) {
-    auto sound = it->second;
-    if(sound){
-      sound->release();
-    }
+    for (auto it = mapSound.cbegin(); it != mapSound.cend(); ++it) {
+        auto sound = it->second;
+        if(sound){
+            sound->release();
+        }
   }
   mapSound.clear();
 }
 
     
 int AudioEngineImpl::preload(const std::string& filePath, std::function<void(bool isSuccess)> callback){
-  FMOD::Sound * sound = findSound(filePath); 
-  if(!sound){
-    std::string fullPath = FileUtils::getInstance()->fullPathForFilename(filePath);
-    FMOD_RESULT result = pSystem->createSound(fullPath.c_str(), FMOD_LOOP_OFF, 0, &sound);
-    if (ERRCHECK(result)){
-      printf("sound effect in %s could not be preload\n", filePath.c_str());
-      if(callback){
-       callback(false);
-      }
-      return -1;
+    FMOD::Sound * sound = findSound(filePath);
+    if(!sound){
+        std::string fullPath = FileUtils::getInstance()->fullPathForFilename(filePath);
+        FMOD_RESULT result = pSystem->createSound(fullPath.c_str(), FMOD_LOOP_OFF, 0, &sound);
+        if (ERRCHECK(result)){
+            printf("sound effect in %s could not be preload\n", filePath.c_str());
+            if(callback){
+                callback(false);
+            }
+            return -1;
+        }
+        mapSound[fullPath] = sound;
     }
-    mapSound[fullPath] = sound; 
-  }
   
-  int id = mapChannelInfo.size() + 1;
-  auto& chanelInfo = mapChannelInfo[id];
-  chanelInfo.sound = sound; 
-  chanelInfo.id = (size_t) id; 
-  chanelInfo.channel = nullptr; 
-  chanelInfo.callback = nullptr; 
-  chanelInfo.path = filePath;
-  //we are going to use UserData to store pointer to Channel when playing
-  chanelInfo.sound->setUserData((void *)id);
+    int id = mapChannelInfo.size() + 1;
+    auto& chanelInfo = mapChannelInfo[id];
+    chanelInfo.sound = sound;
+    chanelInfo.id = (size_t) id;
+    chanelInfo.channel = nullptr;
+    chanelInfo.callback = nullptr;
+    chanelInfo.path = filePath;
+    //we are going to use UserData to store pointer to Channel when playing
+    chanelInfo.sound->setUserData((void *)id);
   
-  if(callback){
-   callback(true); 
-  }
-  return id; 
+    if(callback){
+        callback(true);
+    }
+    return id;
 }
 
 
 void AudioEngineImpl::update(float dt){
-  pSystem->update();
+    pSystem->update();
 }
 
 
 FMOD::Sound * AudioEngineImpl::findSound(const std::string &path){
-  std::string fullPath = FileUtils::getInstance()->fullPathForFilename(path);  
-  std::map<std::string, FMOD::Sound *>::const_iterator it = mapSound.find(fullPath);
-  return (it!=mapSound.end())?(it->second):nullptr; 
+    std::string fullPath = FileUtils::getInstance()->fullPathForFilename(path);
+    std::map<std::string, FMOD::Sound *>::const_iterator it = mapSound.find(fullPath);
+    return (it!=mapSound.end())?(it->second):nullptr;
 }
 
 
 FMOD::Channel * AudioEngineImpl::getChannel(FMOD::Sound *sound){
-  size_t id; 
-  void * data;
-  sound->getUserData(&data);
-  id = (size_t) data; 
-  return mapChannelInfo[id].channel; 
+    size_t id;
+    void * data;
+    sound->getUserData(&data);
+    id = (size_t) data;
+    return mapChannelInfo[id].channel;
 }

--- a/cocos/audio/linux/AudioEngine-linux.cpp
+++ b/cocos/audio/linux/AudioEngine-linux.cpp
@@ -13,13 +13,15 @@ using namespace cocos2d::experimental;
 
 AudioEngineImpl * g_AudioEngineImpl = nullptr;
 
-void ERRCHECKWITHEXIT(FMOD_RESULT result) {
+void ERRCHECKWITHEXIT(FMOD_RESULT result)
+{
     if (result != FMOD_OK) {
         printf("FMOD error! (%d) %s\n", result, FMOD_ErrorString(result));
     }
 }
 
-bool ERRCHECK(FMOD_RESULT result) {
+bool ERRCHECK(FMOD_RESULT result)
+{
     if (result != FMOD_OK) {
         printf("FMOD error! (%d) %s\n", result, FMOD_ErrorString(result));
         return true;
@@ -32,17 +34,18 @@ FMOD_RESULT F_CALLBACK channelCallback(FMOD_CHANNELCONTROL *channelcontrol,
                                        FMOD_CHANNELCONTROL_CALLBACK_TYPE callbacktype,
                                        void *commandData1, void *commandData2)
 {
-    if(controltype == FMOD_CHANNELCONTROL_CHANNEL && callbacktype == FMOD_CHANNELCONTROL_CALLBACK_END){
+    if (controltype == FMOD_CHANNELCONTROL_CHANNEL && callbacktype == FMOD_CHANNELCONTROL_CALLBACK_END) {
         g_AudioEngineImpl->onSoundFinished((FMOD::Channel *)channelcontrol);
-    }else{
     }
     return FMOD_OK;
 }
 
-AudioEngineImpl::AudioEngineImpl(){
+AudioEngineImpl::AudioEngineImpl()
+{
 }
 
-AudioEngineImpl::~AudioEngineImpl(){
+AudioEngineImpl::~AudioEngineImpl()
+{
     FMOD_RESULT result;
     result = pSystem->close();
     ERRCHECKWITHEXIT(result);
@@ -50,7 +53,8 @@ AudioEngineImpl::~AudioEngineImpl(){
     ERRCHECKWITHEXIT(result);
 }
 
-bool AudioEngineImpl::init(){
+bool AudioEngineImpl::init()
+{
     FMOD_RESULT result;
     /*
     Create a System object and initialize.
@@ -75,9 +79,10 @@ bool AudioEngineImpl::init(){
     return true;
 }
 
-int AudioEngineImpl::play2d(const std::string &fileFullPath ,bool loop ,float volume){
+int AudioEngineImpl::play2d(const std::string &fileFullPath, bool loop, float volume)
+{
     int id = preload(fileFullPath, nullptr);
-    if(id >= 0){
+    if (id >= 0) {
         mapChannelInfo[id].loop=loop;
         mapChannelInfo[id].channel->setPaused(true);
         mapChannelInfo[id].volume = volume;
@@ -87,45 +92,52 @@ int AudioEngineImpl::play2d(const std::string &fileFullPath ,bool loop ,float vo
     return id;
 }
 
-void AudioEngineImpl::setVolume(int audioID,float volume){
-    try{
+void AudioEngineImpl::setVolume(int audioID, float volume)
+{
+    try {
         mapChannelInfo[audioID].channel->setVolume(volume);
-    }catch(const std::out_of_range& oor){
+    }
+    catch (const std::out_of_range& oor) {
         printf("AudioEngineImpl::setVolume: invalid audioID: %d\n", audioID);
     }
 }
 
-void AudioEngineImpl::setLoop(int audioID, bool loop){
-    try{
-        mapChannelInfo[audioID].channel->setLoopCount(loop?-1:0);
-    }catch(const std::out_of_range& oor){
+void AudioEngineImpl::setLoop(int audioID, bool loop)
+{
+    try {
+        mapChannelInfo[audioID].channel->setLoopCount(loop ? -1 : 0);
+    }
+    catch (const std::out_of_range& oor) {
         printf("AudioEngineImpl::setLoop: invalid audioID: %d\n", audioID);
     }
 }
 
-bool AudioEngineImpl::pause(int audioID){
-    try{
+bool AudioEngineImpl::pause(int audioID)
+{
+    try {
         mapChannelInfo[audioID].channel->setPaused(true);
         AudioEngine::_audioIDInfoMap[audioID].state = AudioEngine::AudioState::PAUSED;
         return true;
-    }catch(const std::out_of_range& oor){
+    }
+    catch (const std::out_of_range& oor) {
         printf("AudioEngineImpl::pause: invalid audioID: %d\n", audioID);
         return false;
     }
 }
 
-bool AudioEngineImpl::resume(int audioID){
-    try{
-        if(!mapChannelInfo[audioID].channel){
+bool AudioEngineImpl::resume(int audioID)
+{
+    try {
+        if (!mapChannelInfo[audioID].channel) {
             FMOD::Channel *channel = nullptr;
             FMOD::ChannelGroup *channelgroup = nullptr;
             //starts the sound in pause mode, use the channel to unpause
             FMOD_RESULT result = pSystem->playSound(mapChannelInfo[audioID].sound, channelgroup, true, &channel);
-            if(ERRCHECK(result)){
+            if (ERRCHECK(result)) {
                 return false;
             }
-            channel->setMode(mapChannelInfo[audioID].loop?FMOD_LOOP_NORMAL:FMOD_LOOP_OFF);
-            channel->setLoopCount(mapChannelInfo[audioID].loop?-1:0);
+            channel->setMode(mapChannelInfo[audioID].loop ? FMOD_LOOP_NORMAL : FMOD_LOOP_OFF);
+            channel->setLoopCount(mapChannelInfo[audioID].loop ? -1 : 0);
             channel->setVolume(mapChannelInfo[audioID].volume);
             channel->setUserData((void *)mapChannelInfo[audioID].id);
             mapChannelInfo[audioID].channel = channel;
@@ -135,24 +147,28 @@ bool AudioEngineImpl::resume(int audioID){
         AudioEngine::_audioIDInfoMap[audioID].state = AudioEngine::AudioState::PLAYING;
 
         return true;
-    }catch(const std::out_of_range& oor){
+    }
+    catch (const std::out_of_range& oor) {
         printf("AudioEngineImpl::resume: invalid audioID: %d\n", audioID);
         return false;
     }
 }
 
-bool AudioEngineImpl::stop(int audioID){
-    try{
+bool AudioEngineImpl::stop(int audioID)
+{
+    try {
         mapChannelInfo[audioID].channel->stop();
         mapChannelInfo[audioID].channel = nullptr;
         return true;
-    }catch(const std::out_of_range& oor){
+    }
+    catch (const std::out_of_range& oor) {
         printf("AudioEngineImpl::stop: invalid audioID: %d\n", audioID);
         return false;
     }
 }
 
-void AudioEngineImpl::stopAll(){
+void AudioEngineImpl::stopAll()
+{
     for (auto it = mapChannelInfo.begin(); it != mapChannelInfo.end(); ++it) {
         ChannelInfo & audioRef = it->second;
         audioRef.channel->stop();
@@ -160,99 +176,112 @@ void AudioEngineImpl::stopAll(){
     }
 }
 
-float AudioEngineImpl::getDuration(int audioID){
-    try{
+float AudioEngineImpl::getDuration(int audioID)
+{
+    try {
         FMOD::Sound * sound = mapChannelInfo[audioID].sound;
         unsigned int length;
         FMOD_RESULT result = sound->getLength(&length, FMOD_TIMEUNIT_MS);
         ERRCHECK(result);
         float duration = (float)length / 1000.0f;
         return duration;
-    }catch(const std::out_of_range& oor){
+    }
+    catch (const std::out_of_range& oor) {
         printf("AudioEngineImpl::getDuration: invalid audioID: %d\n", audioID);
         return AudioEngine::TIME_UNKNOWN;
     }
 }
 
-float AudioEngineImpl::getCurrentTime(int audioID){
-    try{
+float AudioEngineImpl::getCurrentTime(int audioID)
+{
+    try {
         unsigned int position;
         FMOD_RESULT result = mapChannelInfo[audioID].channel->getPosition(&position, FMOD_TIMEUNIT_MS);
         ERRCHECK(result);
         float currenttime = position /1000.0f;
         return currenttime;
-    }catch(const std::out_of_range& oor){
+    }
+    catch (const std::out_of_range& oor) {
         printf("AudioEngineImpl::getCurrentTime: invalid audioID: %d\n", audioID);
         return AudioEngine::TIME_UNKNOWN;
     }
 }
 
-bool AudioEngineImpl::setCurrentTime(int audioID, float time){
-    try{
+bool AudioEngineImpl::setCurrentTime(int audioID, float time)
+{
+    try {
         unsigned int position = (unsigned int)(time * 1000.0f);
         FMOD_RESULT result = mapChannelInfo[audioID].channel->setPosition(position, FMOD_TIMEUNIT_MS);
         ERRCHECK(result);
-    }catch(const std::out_of_range& oor){
+    }
+    catch (const std::out_of_range& oor) {
         printf("AudioEngineImpl::setCurrentTime: invalid audioID: %d\n", audioID);
     }
 }
 
-void AudioEngineImpl::setFinishCallback(int audioID, const std::function<void (int, const std::string &)> &callback){
-    try{
+void AudioEngineImpl::setFinishCallback(int audioID, const std::function<void (int, const std::string &)> &callback)
+{
+    try {
         FMOD::Channel * channel = mapChannelInfo[audioID].channel;
         mapChannelInfo[audioID].callback = callback;
         FMOD_RESULT result = channel->setCallback(channelCallback);
         ERRCHECK(result);
-    }catch(const std::out_of_range& oor){
+    }
+    catch (const std::out_of_range& oor) {
         printf("AudioEngineImpl::setFinishCallback: invalid audioID: %d\n", audioID);
     }
 }
 
-void AudioEngineImpl::onSoundFinished(FMOD::Channel * channel){
+void AudioEngineImpl::onSoundFinished(FMOD::Channel * channel)
+{
     size_t id;
-    try{
+    try {
         void * data;
         channel->getUserData(&data);
         id = (size_t) data;
-        if(mapChannelInfo[id].callback){
+        if (mapChannelInfo[id].callback) {
             mapChannelInfo[id].callback(id, mapChannelInfo[id].path);
         }
         mapChannelInfo[id].channel = nullptr;
-    }catch(const std::out_of_range& oor){
+    }
+    catch (const std::out_of_range& oor) {
         printf("AudioEngineImpl::onSoundFinished: invalid audioID: %d\n", id);
     }
 }
 
-void AudioEngineImpl::uncache(const std::string& path){
+void AudioEngineImpl::uncache(const std::string& path)
+{
     std::string fullPath = FileUtils::getInstance()->fullPathForFilename(path);
     std::map<std::string, FMOD::Sound *>::const_iterator it = mapSound.find(fullPath);
-    if(it!=mapSound.end()){
+    if (it!=mapSound.end()) {
         FMOD::Sound * sound = it->second;
-        if(sound){
+        if (sound) {
             sound->release();
         }
         mapSound.erase(it);
     }
 }
 
-void AudioEngineImpl::uncacheAll(){
+void AudioEngineImpl::uncacheAll()
+{
     for (auto it = mapSound.cbegin(); it != mapSound.cend(); ++it) {
         auto sound = it->second;
-        if(sound){
+        if (sound) {
             sound->release();
         }
     }
     mapSound.clear();
 }
 
-int AudioEngineImpl::preload(const std::string& filePath, std::function<void(bool isSuccess)> callback){
+int AudioEngineImpl::preload(const std::string& filePath, std::function<void(bool isSuccess)> callback)
+{
     FMOD::Sound * sound = findSound(filePath);
-    if(!sound){
+    if (!sound) {
         std::string fullPath = FileUtils::getInstance()->fullPathForFilename(filePath);
         FMOD_RESULT result = pSystem->createSound(fullPath.c_str(), FMOD_LOOP_OFF, 0, &sound);
-        if (ERRCHECK(result)){
+        if (ERRCHECK(result)) {
             printf("sound effect in %s could not be preload\n", filePath.c_str());
-            if(callback){
+            if (callback) {
                 callback(false);
             }
             return -1;
@@ -270,23 +299,26 @@ int AudioEngineImpl::preload(const std::string& filePath, std::function<void(boo
     //we are going to use UserData to store pointer to Channel when playing
     chanelInfo.sound->setUserData((void *)id);
 
-    if(callback){
+    if (callback) {
         callback(true);
     }
     return id;
 }
 
-void AudioEngineImpl::update(float dt){
+void AudioEngineImpl::update(float dt)
+{
     pSystem->update();
 }
 
-FMOD::Sound * AudioEngineImpl::findSound(const std::string &path){
+FMOD::Sound * AudioEngineImpl::findSound(const std::string &path)
+{
     std::string fullPath = FileUtils::getInstance()->fullPathForFilename(path);
     std::map<std::string, FMOD::Sound *>::const_iterator it = mapSound.find(fullPath);
-    return (it!=mapSound.end())?(it->second):nullptr;
+    return (it != mapSound.end()) ? (it->second) : nullptr;
 }
 
-FMOD::Channel * AudioEngineImpl::getChannel(FMOD::Sound *sound){
+FMOD::Channel * AudioEngineImpl::getChannel(FMOD::Sound *sound)
+{
     size_t id;
     void * data;
     sound->getUserData(&data);

--- a/cocos/audio/linux/AudioEngine-linux.cpp
+++ b/cocos/audio/linux/AudioEngine-linux.cpp
@@ -1,6 +1,6 @@
 /**
  * @author cesarpachon
- */ 
+ */
 #include <cstring>
 #include "audio/linux/AudioEngine-linux.h"
 
@@ -27,19 +27,17 @@ bool ERRCHECK(FMOD_RESULT result) {
     return false;
 }
 
-FMOD_RESULT F_CALLBACK channelCallback(FMOD_CHANNELCONTROL *channelcontrol, 
-                                       FMOD_CHANNELCONTROL_TYPE controltype, 
-                                       FMOD_CHANNELCONTROL_CALLBACK_TYPE callbacktype, 
+FMOD_RESULT F_CALLBACK channelCallback(FMOD_CHANNELCONTROL *channelcontrol,
+                                       FMOD_CHANNELCONTROL_TYPE controltype,
+                                       FMOD_CHANNELCONTROL_CALLBACK_TYPE callbacktype,
                                        void *commandData1, void *commandData2)
 {
-  
     if(controltype == FMOD_CHANNELCONTROL_CHANNEL && callbacktype == FMOD_CHANNELCONTROL_CALLBACK_END){
         g_AudioEngineImpl->onSoundFinished((FMOD::Channel *)channelcontrol);
     }else{
     }
     return FMOD_OK;
 }
-
 
 AudioEngineImpl::AudioEngineImpl(){
 }
@@ -52,7 +50,6 @@ AudioEngineImpl::~AudioEngineImpl(){
     ERRCHECKWITHEXIT(result);
 }
 
-    
 bool AudioEngineImpl::init(){
     FMOD_RESULT result;
     /*
@@ -60,7 +57,7 @@ bool AudioEngineImpl::init(){
     */
     result = FMOD::System_Create(&pSystem);
     ERRCHECKWITHEXIT(result);
-  
+
     result = pSystem->setOutput(FMOD_OUTPUTTYPE_PULSEAUDIO);
     ERRCHECKWITHEXIT(result);
 
@@ -69,12 +66,12 @@ bool AudioEngineImpl::init(){
 
     mapChannelInfo.clear();
     mapSound.clear();
-  
+
     auto scheduler = cocos2d::Director::getInstance()->getScheduler();
     scheduler->schedule(schedule_selector(AudioEngineImpl::update), this, 0.05f, false);
-  
+
     g_AudioEngineImpl = this;
-  
+
     return true;
 }
 
@@ -119,7 +116,6 @@ bool AudioEngineImpl::pause(int audioID){
 
 bool AudioEngineImpl::resume(int audioID){
     try{
-
         if(!mapChannelInfo[audioID].channel){
             FMOD::Channel *channel = nullptr;
             FMOD::ChannelGroup *channelgroup = nullptr;
@@ -134,10 +130,10 @@ bool AudioEngineImpl::resume(int audioID){
             channel->setUserData((void *)mapChannelInfo[audioID].id);
             mapChannelInfo[audioID].channel = channel;
         }
-    
+
         mapChannelInfo[audioID].channel->setPaused(false);
         AudioEngine::_audioIDInfoMap[audioID].state = AudioEngine::AudioState::PLAYING;
-    
+
         return true;
     }catch(const std::out_of_range& oor){
         printf("AudioEngineImpl::resume: invalid audioID: %d\n", audioID);
@@ -212,7 +208,6 @@ void AudioEngineImpl::setFinishCallback(int audioID, const std::function<void (i
     }
 }
 
-
 void AudioEngineImpl::onSoundFinished(FMOD::Channel * channel){
     size_t id;
     try{
@@ -227,7 +222,6 @@ void AudioEngineImpl::onSoundFinished(FMOD::Channel * channel){
         printf("AudioEngineImpl::onSoundFinished: invalid audioID: %d\n", id);
     }
 }
-    
 
 void AudioEngineImpl::uncache(const std::string& path){
     std::string fullPath = FileUtils::getInstance()->fullPathForFilename(path);
@@ -237,10 +231,9 @@ void AudioEngineImpl::uncache(const std::string& path){
         if(sound){
             sound->release();
         }
-    mapSound.erase(it);
-  }
+        mapSound.erase(it);
+    }
 }
-
 
 void AudioEngineImpl::uncacheAll(){
     for (auto it = mapSound.cbegin(); it != mapSound.cend(); ++it) {
@@ -248,11 +241,10 @@ void AudioEngineImpl::uncacheAll(){
         if(sound){
             sound->release();
         }
-  }
-  mapSound.clear();
+    }
+    mapSound.clear();
 }
 
-    
 int AudioEngineImpl::preload(const std::string& filePath, std::function<void(bool isSuccess)> callback){
     FMOD::Sound * sound = findSound(filePath);
     if(!sound){
@@ -267,7 +259,7 @@ int AudioEngineImpl::preload(const std::string& filePath, std::function<void(boo
         }
         mapSound[fullPath] = sound;
     }
-  
+
     int id = mapChannelInfo.size() + 1;
     auto& chanelInfo = mapChannelInfo[id];
     chanelInfo.sound = sound;
@@ -277,25 +269,22 @@ int AudioEngineImpl::preload(const std::string& filePath, std::function<void(boo
     chanelInfo.path = filePath;
     //we are going to use UserData to store pointer to Channel when playing
     chanelInfo.sound->setUserData((void *)id);
-  
+
     if(callback){
         callback(true);
     }
     return id;
 }
 
-
 void AudioEngineImpl::update(float dt){
     pSystem->update();
 }
-
 
 FMOD::Sound * AudioEngineImpl::findSound(const std::string &path){
     std::string fullPath = FileUtils::getInstance()->fullPathForFilename(path);
     std::map<std::string, FMOD::Sound *>::const_iterator it = mapSound.find(fullPath);
     return (it!=mapSound.end())?(it->second):nullptr;
 }
-
 
 FMOD::Channel * AudioEngineImpl::getChannel(FMOD::Sound *sound){
     size_t id;

--- a/cocos/audio/linux/AudioEngine-linux.cpp
+++ b/cocos/audio/linux/AudioEngine-linux.cpp
@@ -42,7 +42,7 @@ FMOD_RESULT F_CALLBACK channelCallback(FMOD_CHANNELCONTROL *channelcontrol,
 
 
 AudioEngineImpl::AudioEngineImpl(){
-};
+}
 
 AudioEngineImpl::~AudioEngineImpl(){
   FMOD_RESULT result;
@@ -50,7 +50,7 @@ AudioEngineImpl::~AudioEngineImpl(){
   ERRCHECKWITHEXIT(result);
   result = pSystem->release();
   ERRCHECKWITHEXIT(result);
-};
+}
 
     
 bool AudioEngineImpl::init(){
@@ -76,7 +76,7 @@ bool AudioEngineImpl::init(){
   g_AudioEngineImpl = this; 
   
   return true;
-};
+}
 
 int AudioEngineImpl::play2d(const std::string &fileFullPath ,bool loop ,float volume){
   int id = preload(fileFullPath, nullptr); 
@@ -88,7 +88,7 @@ int AudioEngineImpl::play2d(const std::string &fileFullPath ,bool loop ,float vo
     resume(id); 
   }
   return id; 
-};
+}
 
 void AudioEngineImpl::setVolume(int audioID,float volume){
   try{
@@ -96,7 +96,7 @@ void AudioEngineImpl::setVolume(int audioID,float volume){
   }catch(const std::out_of_range& oor){
       printf("AudioEngineImpl::setVolume: invalid audioID: %d\n", audioID);
   }
-};
+}
 
 void AudioEngineImpl::setLoop(int audioID, bool loop){
   try{
@@ -104,7 +104,7 @@ void AudioEngineImpl::setLoop(int audioID, bool loop){
   }catch(const std::out_of_range& oor){
       printf("AudioEngineImpl::setLoop: invalid audioID: %d\n", audioID);
   }
-};
+}
 
 bool AudioEngineImpl::pause(int audioID){
   try{
@@ -115,7 +115,7 @@ bool AudioEngineImpl::pause(int audioID){
       printf("AudioEngineImpl::pause: invalid audioID: %d\n", audioID);
       return false;
   }
-};
+}
 
 bool AudioEngineImpl::resume(int audioID){
 try{
@@ -143,7 +143,7 @@ try{
       printf("AudioEngineImpl::resume: invalid audioID: %d\n", audioID);
       return false;
   }
-};
+}
 
 bool AudioEngineImpl::stop(int audioID){
   try{
@@ -154,7 +154,7 @@ bool AudioEngineImpl::stop(int audioID){
       printf("AudioEngineImpl::stop: invalid audioID: %d\n", audioID);
       return false;
   }
-};
+}
 
 void AudioEngineImpl::stopAll(){
   for (auto it = mapChannelInfo.begin(); it != mapChannelInfo.end(); ++it) {
@@ -162,7 +162,7 @@ void AudioEngineImpl::stopAll(){
     audioRef.channel->stop();
     audioRef.channel = nullptr;
   }
-};
+}
 
 float AudioEngineImpl::getDuration(int audioID){
   try{
@@ -176,7 +176,7 @@ float AudioEngineImpl::getDuration(int audioID){
       printf("AudioEngineImpl::getDuration: invalid audioID: %d\n", audioID);
     return AudioEngine::TIME_UNKNOWN;
   }
-};
+}
 
 float AudioEngineImpl::getCurrentTime(int audioID){
  try{
@@ -189,7 +189,7 @@ float AudioEngineImpl::getCurrentTime(int audioID){
       printf("AudioEngineImpl::getCurrentTime: invalid audioID: %d\n", audioID);
     return AudioEngine::TIME_UNKNOWN;
   }
-};
+}
 
 bool AudioEngineImpl::setCurrentTime(int audioID, float time){
  try{
@@ -199,7 +199,7 @@ bool AudioEngineImpl::setCurrentTime(int audioID, float time){
     }catch(const std::out_of_range& oor){
       printf("AudioEngineImpl::setCurrentTime: invalid audioID: %d\n", audioID);
   }
-};
+}
 
 void AudioEngineImpl::setFinishCallback(int audioID, const std::function<void (int, const std::string &)> &callback){
  try{
@@ -210,7 +210,7 @@ void AudioEngineImpl::setFinishCallback(int audioID, const std::function<void (i
     }catch(const std::out_of_range& oor){
       printf("AudioEngineImpl::setFinishCallback: invalid audioID: %d\n", audioID);
   }
-};
+}
 
 
 void AudioEngineImpl::onSoundFinished(FMOD::Channel * channel){
@@ -226,7 +226,7 @@ void AudioEngineImpl::onSoundFinished(FMOD::Channel * channel){
     }catch(const std::out_of_range& oor){
       printf("AudioEngineImpl::onSoundFinished: invalid audioID: %d\n", id);
   }
-}; 
+}
     
 
 void AudioEngineImpl::uncache(const std::string& path){
@@ -239,7 +239,7 @@ void AudioEngineImpl::uncache(const std::string& path){
     }
     mapSound.erase(it);
   }
-};
+}
 
 
 void AudioEngineImpl::uncacheAll(){
@@ -250,7 +250,7 @@ for (auto it = mapSound.cbegin(); it != mapSound.cend(); ++it) {
     }
   }
   mapSound.clear();
-};
+}
 
     
 int AudioEngineImpl::preload(const std::string& filePath, std::function<void(bool isSuccess)> callback){
@@ -282,12 +282,12 @@ int AudioEngineImpl::preload(const std::string& filePath, std::function<void(boo
    callback(true); 
   }
   return id; 
-};
+}
 
 
 void AudioEngineImpl::update(float dt){
   pSystem->update();
-};
+}
 
 
 FMOD::Sound * AudioEngineImpl::findSound(const std::string &path){
@@ -303,4 +303,4 @@ FMOD::Channel * AudioEngineImpl::getChannel(FMOD::Sound *sound){
   sound->getUserData(&data);
   id = (size_t) data; 
   return mapChannelInfo[id].channel; 
-};
+}

--- a/cocos/audio/linux/SimpleAudioEngine.cpp
+++ b/cocos/audio/linux/SimpleAudioEngine.cpp
@@ -9,50 +9,50 @@ using namespace cocos2d::experimental;
 
 
 struct SimpleAudioEngineLinux{
-  SimpleAudioEngine * engine = nullptr; 
-  int musicid; 
-  float effectsvolume;
-  std::string musicpath; 
+    SimpleAudioEngine * engine = nullptr;
+    int musicid;
+    float effectsvolume;
+    std::string musicpath;
 };
 
-SimpleAudioEngineLinux * g_SimpleAudioEngineLinux = nullptr; 
+SimpleAudioEngineLinux * g_SimpleAudioEngineLinux = nullptr;
 
 
 SimpleAudioEngine* SimpleAudioEngine::getInstance(){
-  if(!g_SimpleAudioEngineLinux){
-    g_SimpleAudioEngineLinux = new SimpleAudioEngineLinux();
-    g_SimpleAudioEngineLinux->engine = new SimpleAudioEngine(); 
-  }
-  return g_SimpleAudioEngineLinux->engine; 
+    if(!g_SimpleAudioEngineLinux){
+        g_SimpleAudioEngineLinux = new SimpleAudioEngineLinux();
+        g_SimpleAudioEngineLinux->engine = new SimpleAudioEngine();
+    }
+    return g_SimpleAudioEngineLinux->engine;
 }
 
-  void SimpleAudioEngine::end(){
+void SimpleAudioEngine::end(){
     if(g_SimpleAudioEngineLinux){
-      delete g_SimpleAudioEngineLinux->engine; 
-      delete g_SimpleAudioEngineLinux;       
+        delete g_SimpleAudioEngineLinux->engine;
+        delete g_SimpleAudioEngineLinux;
     }
-    g_SimpleAudioEngineLinux = nullptr; 
-  }
+    g_SimpleAudioEngineLinux = nullptr;
+}
   
   
-    SimpleAudioEngine::SimpleAudioEngine(){
-      g_SimpleAudioEngineLinux->musicid = -1;
-      g_SimpleAudioEngineLinux->effectsvolume = 1.0f; 
-    }
+SimpleAudioEngine::SimpleAudioEngine(){
+    g_SimpleAudioEngineLinux->musicid = -1;
+    g_SimpleAudioEngineLinux->effectsvolume = 1.0f;
+}
 
-    SimpleAudioEngine::~SimpleAudioEngine(){
+SimpleAudioEngine::~SimpleAudioEngine(){
       
-    }
+}
 
-    void SimpleAudioEngine::preloadBackgroundMusic(const char* filePath){
-      g_SimpleAudioEngineLinux->musicpath = filePath; 
-      AudioEngine::preload(filePath); 
-    }
+void SimpleAudioEngine::preloadBackgroundMusic(const char* filePath){
+    g_SimpleAudioEngineLinux->musicpath = filePath;
+    AudioEngine::preload(filePath);
+}
     
-    void SimpleAudioEngine::playBackgroundMusic(const char* filePath, bool loop){
-      g_SimpleAudioEngineLinux->musicpath = filePath; 
-      g_SimpleAudioEngineLinux->musicid = AudioEngine::play2d(filePath, loop); 
-    }
+void SimpleAudioEngine::playBackgroundMusic(const char* filePath, bool loop){
+    g_SimpleAudioEngineLinux->musicpath = filePath;
+    g_SimpleAudioEngineLinux->musicid = AudioEngine::play2d(filePath, loop);
+}
 
     void SimpleAudioEngine::stopBackgroundMusic(bool releaseData){
       AudioEngine::stop(g_SimpleAudioEngineLinux->musicid);
@@ -61,38 +61,38 @@ SimpleAudioEngine* SimpleAudioEngine::getInstance(){
       }
     }
 
-    void SimpleAudioEngine::pauseBackgroundMusic(){
-      AudioEngine::pause(g_SimpleAudioEngineLinux->musicid); 
-    }
+void SimpleAudioEngine::pauseBackgroundMusic(){
+    AudioEngine::pause(g_SimpleAudioEngineLinux->musicid);
+}
 
-    void SimpleAudioEngine::resumeBackgroundMusic(){
-      AudioEngine::resume(g_SimpleAudioEngineLinux->musicid);
-    }
+void SimpleAudioEngine::resumeBackgroundMusic(){
+    AudioEngine::resume(g_SimpleAudioEngineLinux->musicid);
+}
 
     void SimpleAudioEngine::rewindBackgroundMusic(){
       AudioEngine::setCurrentTime(g_SimpleAudioEngineLinux->musicid, 0);
     }
 
-    bool SimpleAudioEngine::willPlayBackgroundMusic(){
-      return g_SimpleAudioEngineLinux->musicid != -1; 
-    }
+bool SimpleAudioEngine::willPlayBackgroundMusic(){
+    return g_SimpleAudioEngineLinux->musicid != -1;
+}
 
     bool SimpleAudioEngine::isBackgroundMusicPlaying(){
         return AudioEngine::getState(g_SimpleAudioEngineLinux->musicid) == AudioEngine::AudioState::PLAYING; 
     }
 
-    // 
-    // properties
-    //
+//
+// properties
+//
 
-    /**
-     * The volume of the background music within the range of 0.0 as the minimum and 1.0 as the maximum.
-     * @js getMusicVolume
-     * @lua getMusicVolume
-     */
-    float SimpleAudioEngine::getBackgroundMusicVolume(){
-      return AudioEngine::getVolume(g_SimpleAudioEngineLinux->musicid);
-    }
+/**
+ * The volume of the background music within the range of 0.0 as the minimum and 1.0 as the maximum.
+ * @js getMusicVolume
+ * @lua getMusicVolume
+ */
+float SimpleAudioEngine::getBackgroundMusicVolume(){
+    return AudioEngine::getVolume(g_SimpleAudioEngineLinux->musicid);
+}
 
     /**
      * Set the volume of background music.
@@ -105,12 +105,12 @@ SimpleAudioEngine* SimpleAudioEngine::getInstance(){
       AudioEngine::setVolume(g_SimpleAudioEngineLinux->musicid, volume); 
     }
 
-    /**
-     * The volume of the effects within the range of 0.0 as the minimum and 1.0 as the maximum.
-     */
-    float SimpleAudioEngine::getEffectsVolume(){
-      return g_SimpleAudioEngineLinux->effectsvolume;
-    }
+/**
+ * The volume of the effects within the range of 0.0 as the minimum and 1.0 as the maximum.
+ */
+float SimpleAudioEngine::getEffectsVolume(){
+    return g_SimpleAudioEngineLinux->effectsvolume;
+}
 
     /**
      * Set the volume of sound effects.
@@ -121,23 +121,23 @@ SimpleAudioEngine* SimpleAudioEngine::getInstance(){
       g_SimpleAudioEngineLinux->effectsvolume = volume; 
     }
 
-    /**
-     * Play sound effect with a file path, pitch, pan and gain.
-     *
-     * @param filePath The path of the effect file.
-     * @param loop Determines whether to loop the effect playing or not. The default value is false.
-     * @param pitch Frequency, normal value is 1.0. Will also change effect play time.
-     * @param pan   Stereo effect, in the range of [-1..1] where -1 enables only left channel.
-     * @param gain  Volume, in the range of [0..1]. The normal value is 1.
-     * @return The sound id.
-     * 
-     * @note Full support is under development, now there are limitations:
-     *     - no pitch effect on Samsung Galaxy S2 with OpenSL backend enabled;
-     *     - no pitch/pan/gain on win32.
-     */
-    unsigned int SimpleAudioEngine::playEffect(const char* filePath, bool loop, float pitch, float pan, float gain){
-        return AudioEngine::play2d(filePath, loop, gain);
-    }
+/**
+ * Play sound effect with a file path, pitch, pan and gain.
+ *
+ * @param filePath The path of the effect file.
+ * @param loop Determines whether to loop the effect playing or not. The default value is false.
+ * @param pitch Frequency, normal value is 1.0. Will also change effect play time.
+ * @param pan   Stereo effect, in the range of [-1..1] where -1 enables only left channel.
+ * @param gain  Volume, in the range of [0..1]. The normal value is 1.
+ * @return The sound id.
+ * 
+ * @note Full support is under development, now there are limitations:
+ *     - no pitch effect on Samsung Galaxy S2 with OpenSL backend enabled;
+ *     - no pitch/pan/gain on win32.
+ */
+unsigned int SimpleAudioEngine::playEffect(const char* filePath, bool loop, float pitch, float pan, float gain){
+    return AudioEngine::play2d(filePath, loop, gain);
+}
 
     /**
      * Pause playing sound effect.
@@ -148,12 +148,12 @@ SimpleAudioEngine* SimpleAudioEngine::getInstance(){
       AudioEngine::pause(soundId);
     }
 
-    /**
-     * Pause all playing sound effect.
-     */
-    void SimpleAudioEngine::pauseAllEffects(){
-      AudioEngine::pauseAll();
-    }
+/**
+ * Pause all playing sound effect.
+ */
+void SimpleAudioEngine::pauseAllEffects(){
+    AudioEngine::pauseAll();
+}
 
     /**
      * Resume playing sound effect.
@@ -164,12 +164,12 @@ SimpleAudioEngine* SimpleAudioEngine::getInstance(){
       AudioEngine::resume(soundId);
     }
 
-    /**
-     * Resume all playing sound effect.
-     */
-    void SimpleAudioEngine::resumeAllEffects(){
-      AudioEngine::resumeAll();
-    }
+/**
+ * Resume all playing sound effect.
+ */
+void SimpleAudioEngine::resumeAllEffects(){
+    AudioEngine::resumeAll();
+}
 
     /**
      * Stop playing sound effect.
@@ -180,12 +180,12 @@ SimpleAudioEngine* SimpleAudioEngine::getInstance(){
       AudioEngine::stop(soundId);
     }
 
-    /**
-     * Stop all playing sound effects.
-     */
-    void SimpleAudioEngine::stopAllEffects(){
-      AudioEngine::stopAll();
-    }
+/**
+ * Stop all playing sound effects.
+ */
+void SimpleAudioEngine::stopAllEffects(){
+    AudioEngine::stopAll();
+}
 
     /**
      * Preload a compressed audio file.
@@ -199,13 +199,13 @@ SimpleAudioEngine* SimpleAudioEngine::getInstance(){
       AudioEngine::preload(filePath);
     }
 
-    /**
-     * Unload the preloaded effect from internal buffer.
-     *
-     * @param filePath The path of the effect file.
-     */
-    void SimpleAudioEngine::unloadEffect(const char* filePath){
-      AudioEngine::uncache(filePath);
-    }
+/**
+ * Unload the preloaded effect from internal buffer.
+ *
+ * @param filePath The path of the effect file.
+ */
+void SimpleAudioEngine::unloadEffect(const char* filePath){
+    AudioEngine::uncache(filePath);
+}
 
     

--- a/cocos/audio/linux/SimpleAudioEngine.cpp
+++ b/cocos/audio/linux/SimpleAudioEngine.cpp
@@ -7,7 +7,6 @@ using namespace CocosDenshion;
 using namespace cocos2d;
 using namespace cocos2d::experimental;
 
-
 struct SimpleAudioEngineLinux{
     SimpleAudioEngine * engine = nullptr;
     int musicid;
@@ -16,7 +15,6 @@ struct SimpleAudioEngineLinux{
 };
 
 SimpleAudioEngineLinux * g_SimpleAudioEngineLinux = nullptr;
-
 
 SimpleAudioEngine* SimpleAudioEngine::getInstance(){
     if(!g_SimpleAudioEngineLinux){
@@ -33,33 +31,32 @@ void SimpleAudioEngine::end(){
     }
     g_SimpleAudioEngineLinux = nullptr;
 }
-  
-  
+
 SimpleAudioEngine::SimpleAudioEngine(){
     g_SimpleAudioEngineLinux->musicid = -1;
     g_SimpleAudioEngineLinux->effectsvolume = 1.0f;
 }
 
 SimpleAudioEngine::~SimpleAudioEngine(){
-      
+
 }
 
 void SimpleAudioEngine::preloadBackgroundMusic(const char* filePath){
     g_SimpleAudioEngineLinux->musicpath = filePath;
     AudioEngine::preload(filePath);
 }
-    
+
 void SimpleAudioEngine::playBackgroundMusic(const char* filePath, bool loop){
     g_SimpleAudioEngineLinux->musicpath = filePath;
     g_SimpleAudioEngineLinux->musicid = AudioEngine::play2d(filePath, loop);
 }
 
-    void SimpleAudioEngine::stopBackgroundMusic(bool releaseData){
-      AudioEngine::stop(g_SimpleAudioEngineLinux->musicid);
-      if(releaseData){
-        AudioEngine::uncache(g_SimpleAudioEngineLinux->musicpath.c_str()); 
-      }
+void SimpleAudioEngine::stopBackgroundMusic(bool releaseData){
+    AudioEngine::stop(g_SimpleAudioEngineLinux->musicid);
+    if(releaseData){
+        AudioEngine::uncache(g_SimpleAudioEngineLinux->musicpath.c_str());
     }
+}
 
 void SimpleAudioEngine::pauseBackgroundMusic(){
     AudioEngine::pause(g_SimpleAudioEngineLinux->musicid);
@@ -69,17 +66,17 @@ void SimpleAudioEngine::resumeBackgroundMusic(){
     AudioEngine::resume(g_SimpleAudioEngineLinux->musicid);
 }
 
-    void SimpleAudioEngine::rewindBackgroundMusic(){
-      AudioEngine::setCurrentTime(g_SimpleAudioEngineLinux->musicid, 0);
-    }
+void SimpleAudioEngine::rewindBackgroundMusic(){
+    AudioEngine::setCurrentTime(g_SimpleAudioEngineLinux->musicid, 0);
+}
 
 bool SimpleAudioEngine::willPlayBackgroundMusic(){
     return g_SimpleAudioEngineLinux->musicid != -1;
 }
 
-    bool SimpleAudioEngine::isBackgroundMusicPlaying(){
-        return AudioEngine::getState(g_SimpleAudioEngineLinux->musicid) == AudioEngine::AudioState::PLAYING; 
-    }
+bool SimpleAudioEngine::isBackgroundMusicPlaying(){
+    return AudioEngine::getState(g_SimpleAudioEngineLinux->musicid) == AudioEngine::AudioState::PLAYING;
+}
 
 //
 // properties
@@ -94,16 +91,16 @@ float SimpleAudioEngine::getBackgroundMusicVolume(){
     return AudioEngine::getVolume(g_SimpleAudioEngineLinux->musicid);
 }
 
-    /**
-     * Set the volume of background music.
-     *
-     * @param volume must be within the range of 0.0 as the minimum and 1.0 as the maximum.
-     * @js setMusicVolume
-     * @lua setMusicVolume
-     */
-    void SimpleAudioEngine::setBackgroundMusicVolume(float volume){
-      AudioEngine::setVolume(g_SimpleAudioEngineLinux->musicid, volume); 
-    }
+/**
+ * Set the volume of background music.
+ *
+ * @param volume must be within the range of 0.0 as the minimum and 1.0 as the maximum.
+ * @js setMusicVolume
+ * @lua setMusicVolume
+ */
+void SimpleAudioEngine::setBackgroundMusicVolume(float volume){
+    AudioEngine::setVolume(g_SimpleAudioEngineLinux->musicid, volume);
+}
 
 /**
  * The volume of the effects within the range of 0.0 as the minimum and 1.0 as the maximum.
@@ -112,14 +109,14 @@ float SimpleAudioEngine::getEffectsVolume(){
     return g_SimpleAudioEngineLinux->effectsvolume;
 }
 
-    /**
-     * Set the volume of sound effects.
-     *
-     * @param volume must be within the range of 0.0 as the minimum and 1.0 as the maximum.
-     */
-    void SimpleAudioEngine::setEffectsVolume(float volume){
-      g_SimpleAudioEngineLinux->effectsvolume = volume; 
-    }
+/**
+ * Set the volume of sound effects.
+ *
+ * @param volume must be within the range of 0.0 as the minimum and 1.0 as the maximum.
+ */
+void SimpleAudioEngine::setEffectsVolume(float volume){
+    g_SimpleAudioEngineLinux->effectsvolume = volume;
+}
 
 /**
  * Play sound effect with a file path, pitch, pan and gain.
@@ -130,7 +127,7 @@ float SimpleAudioEngine::getEffectsVolume(){
  * @param pan   Stereo effect, in the range of [-1..1] where -1 enables only left channel.
  * @param gain  Volume, in the range of [0..1]. The normal value is 1.
  * @return The sound id.
- * 
+ *
  * @note Full support is under development, now there are limitations:
  *     - no pitch effect on Samsung Galaxy S2 with OpenSL backend enabled;
  *     - no pitch/pan/gain on win32.
@@ -139,14 +136,14 @@ unsigned int SimpleAudioEngine::playEffect(const char* filePath, bool loop, floa
     return AudioEngine::play2d(filePath, loop, gain);
 }
 
-    /**
-     * Pause playing sound effect.
-     *
-     * @param soundId The return value of function playEffect.
-     */
-    void SimpleAudioEngine::pauseEffect(unsigned int soundId){
-      AudioEngine::pause(soundId);
-    }
+/**
+ * Pause playing sound effect.
+ *
+ * @param soundId The return value of function playEffect.
+ */
+void SimpleAudioEngine::pauseEffect(unsigned int soundId){
+    AudioEngine::pause(soundId);
+}
 
 /**
  * Pause all playing sound effect.
@@ -155,14 +152,14 @@ void SimpleAudioEngine::pauseAllEffects(){
     AudioEngine::pauseAll();
 }
 
-    /**
-     * Resume playing sound effect.
-     *
-     * @param soundId The return value of function playEffect.
-     */
-    void SimpleAudioEngine::resumeEffect(unsigned int soundId){
-      AudioEngine::resume(soundId);
-    }
+/**
+ * Resume playing sound effect.
+ *
+ * @param soundId The return value of function playEffect.
+ */
+void SimpleAudioEngine::resumeEffect(unsigned int soundId){
+    AudioEngine::resume(soundId);
+}
 
 /**
  * Resume all playing sound effect.
@@ -171,14 +168,14 @@ void SimpleAudioEngine::resumeAllEffects(){
     AudioEngine::resumeAll();
 }
 
-    /**
-     * Stop playing sound effect.
-     *
-     * @param soundId The return value of function playEffect.
-     */
-    void SimpleAudioEngine::stopEffect(unsigned int soundId){
-      AudioEngine::stop(soundId);
-    }
+/**
+ * Stop playing sound effect.
+ *
+ * @param soundId The return value of function playEffect.
+ */
+void SimpleAudioEngine::stopEffect(unsigned int soundId){
+    AudioEngine::stop(soundId);
+}
 
 /**
  * Stop all playing sound effects.
@@ -187,17 +184,17 @@ void SimpleAudioEngine::stopAllEffects(){
     AudioEngine::stopAll();
 }
 
-    /**
-     * Preload a compressed audio file.
-     *
-     * The compressed audio will be decoded to wave, then written into an internal buffer in SimpleAudioEngine.
-     *
-     * @param filePath The path of the effect file.
-     * @js NA
-     */
-    void SimpleAudioEngine::preloadEffect(const char* filePath){
-      AudioEngine::preload(filePath);
-    }
+/**
+ * Preload a compressed audio file.
+ *
+ * The compressed audio will be decoded to wave, then written into an internal buffer in SimpleAudioEngine.
+ *
+ * @param filePath The path of the effect file.
+ * @js NA
+ */
+void SimpleAudioEngine::preloadEffect(const char* filePath){
+    AudioEngine::preload(filePath);
+}
 
 /**
  * Unload the preloaded effect from internal buffer.
@@ -207,5 +204,3 @@ void SimpleAudioEngine::stopAllEffects(){
 void SimpleAudioEngine::unloadEffect(const char* filePath){
     AudioEngine::uncache(filePath);
 }
-
-    

--- a/cocos/audio/linux/SimpleAudioEngine.cpp
+++ b/cocos/audio/linux/SimpleAudioEngine.cpp
@@ -7,7 +7,7 @@ using namespace CocosDenshion;
 using namespace cocos2d;
 using namespace cocos2d::experimental;
 
-struct SimpleAudioEngineLinux{
+struct SimpleAudioEngineLinux {
     SimpleAudioEngine * engine = nullptr;
     int musicid;
     float effectsvolume;
@@ -16,65 +16,76 @@ struct SimpleAudioEngineLinux{
 
 SimpleAudioEngineLinux * g_SimpleAudioEngineLinux = nullptr;
 
-SimpleAudioEngine* SimpleAudioEngine::getInstance(){
-    if(!g_SimpleAudioEngineLinux){
+SimpleAudioEngine* SimpleAudioEngine::getInstance()
+{
+    if (!g_SimpleAudioEngineLinux) {
         g_SimpleAudioEngineLinux = new SimpleAudioEngineLinux();
         g_SimpleAudioEngineLinux->engine = new SimpleAudioEngine();
     }
     return g_SimpleAudioEngineLinux->engine;
 }
 
-void SimpleAudioEngine::end(){
-    if(g_SimpleAudioEngineLinux){
+void SimpleAudioEngine::end()
+{
+    if (g_SimpleAudioEngineLinux) {
         delete g_SimpleAudioEngineLinux->engine;
         delete g_SimpleAudioEngineLinux;
     }
     g_SimpleAudioEngineLinux = nullptr;
 }
 
-SimpleAudioEngine::SimpleAudioEngine(){
+SimpleAudioEngine::SimpleAudioEngine()
+{
     g_SimpleAudioEngineLinux->musicid = -1;
     g_SimpleAudioEngineLinux->effectsvolume = 1.0f;
 }
 
-SimpleAudioEngine::~SimpleAudioEngine(){
-
+SimpleAudioEngine::~SimpleAudioEngine()
+{
 }
 
-void SimpleAudioEngine::preloadBackgroundMusic(const char* filePath){
+void SimpleAudioEngine::preloadBackgroundMusic(const char* filePath)
+{
     g_SimpleAudioEngineLinux->musicpath = filePath;
     AudioEngine::preload(filePath);
 }
 
-void SimpleAudioEngine::playBackgroundMusic(const char* filePath, bool loop){
+void SimpleAudioEngine::playBackgroundMusic(const char* filePath, bool loop)
+{
     g_SimpleAudioEngineLinux->musicpath = filePath;
     g_SimpleAudioEngineLinux->musicid = AudioEngine::play2d(filePath, loop);
 }
 
-void SimpleAudioEngine::stopBackgroundMusic(bool releaseData){
+void SimpleAudioEngine::stopBackgroundMusic(bool releaseData)
+{
     AudioEngine::stop(g_SimpleAudioEngineLinux->musicid);
-    if(releaseData){
+    if (releaseData) {
         AudioEngine::uncache(g_SimpleAudioEngineLinux->musicpath.c_str());
     }
 }
 
-void SimpleAudioEngine::pauseBackgroundMusic(){
+void SimpleAudioEngine::pauseBackgroundMusic()
+{
     AudioEngine::pause(g_SimpleAudioEngineLinux->musicid);
 }
 
-void SimpleAudioEngine::resumeBackgroundMusic(){
+void SimpleAudioEngine::resumeBackgroundMusic()
+{
     AudioEngine::resume(g_SimpleAudioEngineLinux->musicid);
 }
 
-void SimpleAudioEngine::rewindBackgroundMusic(){
+void SimpleAudioEngine::rewindBackgroundMusic()
+{
     AudioEngine::setCurrentTime(g_SimpleAudioEngineLinux->musicid, 0);
 }
 
-bool SimpleAudioEngine::willPlayBackgroundMusic(){
+bool SimpleAudioEngine::willPlayBackgroundMusic()
+{
     return g_SimpleAudioEngineLinux->musicid != -1;
 }
 
-bool SimpleAudioEngine::isBackgroundMusicPlaying(){
+bool SimpleAudioEngine::isBackgroundMusicPlaying()
+{
     return AudioEngine::getState(g_SimpleAudioEngineLinux->musicid) == AudioEngine::AudioState::PLAYING;
 }
 
@@ -87,7 +98,8 @@ bool SimpleAudioEngine::isBackgroundMusicPlaying(){
  * @js getMusicVolume
  * @lua getMusicVolume
  */
-float SimpleAudioEngine::getBackgroundMusicVolume(){
+float SimpleAudioEngine::getBackgroundMusicVolume()
+{
     return AudioEngine::getVolume(g_SimpleAudioEngineLinux->musicid);
 }
 
@@ -98,14 +110,16 @@ float SimpleAudioEngine::getBackgroundMusicVolume(){
  * @js setMusicVolume
  * @lua setMusicVolume
  */
-void SimpleAudioEngine::setBackgroundMusicVolume(float volume){
+void SimpleAudioEngine::setBackgroundMusicVolume(float volume)
+{
     AudioEngine::setVolume(g_SimpleAudioEngineLinux->musicid, volume);
 }
 
 /**
  * The volume of the effects within the range of 0.0 as the minimum and 1.0 as the maximum.
  */
-float SimpleAudioEngine::getEffectsVolume(){
+float SimpleAudioEngine::getEffectsVolume()
+{
     return g_SimpleAudioEngineLinux->effectsvolume;
 }
 
@@ -114,7 +128,8 @@ float SimpleAudioEngine::getEffectsVolume(){
  *
  * @param volume must be within the range of 0.0 as the minimum and 1.0 as the maximum.
  */
-void SimpleAudioEngine::setEffectsVolume(float volume){
+void SimpleAudioEngine::setEffectsVolume(float volume)
+{
     g_SimpleAudioEngineLinux->effectsvolume = volume;
 }
 
@@ -132,7 +147,8 @@ void SimpleAudioEngine::setEffectsVolume(float volume){
  *     - no pitch effect on Samsung Galaxy S2 with OpenSL backend enabled;
  *     - no pitch/pan/gain on win32.
  */
-unsigned int SimpleAudioEngine::playEffect(const char* filePath, bool loop, float pitch, float pan, float gain){
+unsigned int SimpleAudioEngine::playEffect(const char* filePath, bool loop, float pitch, float pan, float gain)
+{
     return AudioEngine::play2d(filePath, loop, gain);
 }
 
@@ -141,14 +157,16 @@ unsigned int SimpleAudioEngine::playEffect(const char* filePath, bool loop, floa
  *
  * @param soundId The return value of function playEffect.
  */
-void SimpleAudioEngine::pauseEffect(unsigned int soundId){
+void SimpleAudioEngine::pauseEffect(unsigned int soundId)
+{
     AudioEngine::pause(soundId);
 }
 
 /**
  * Pause all playing sound effect.
  */
-void SimpleAudioEngine::pauseAllEffects(){
+void SimpleAudioEngine::pauseAllEffects()
+{
     AudioEngine::pauseAll();
 }
 
@@ -157,14 +175,16 @@ void SimpleAudioEngine::pauseAllEffects(){
  *
  * @param soundId The return value of function playEffect.
  */
-void SimpleAudioEngine::resumeEffect(unsigned int soundId){
+void SimpleAudioEngine::resumeEffect(unsigned int soundId)
+{
     AudioEngine::resume(soundId);
 }
 
 /**
  * Resume all playing sound effect.
  */
-void SimpleAudioEngine::resumeAllEffects(){
+void SimpleAudioEngine::resumeAllEffects()
+{
     AudioEngine::resumeAll();
 }
 
@@ -173,14 +193,16 @@ void SimpleAudioEngine::resumeAllEffects(){
  *
  * @param soundId The return value of function playEffect.
  */
-void SimpleAudioEngine::stopEffect(unsigned int soundId){
+void SimpleAudioEngine::stopEffect(unsigned int soundId)
+{
     AudioEngine::stop(soundId);
 }
 
 /**
  * Stop all playing sound effects.
  */
-void SimpleAudioEngine::stopAllEffects(){
+void SimpleAudioEngine::stopAllEffects()
+{
     AudioEngine::stopAll();
 }
 
@@ -192,7 +214,8 @@ void SimpleAudioEngine::stopAllEffects(){
  * @param filePath The path of the effect file.
  * @js NA
  */
-void SimpleAudioEngine::preloadEffect(const char* filePath){
+void SimpleAudioEngine::preloadEffect(const char* filePath)
+{
     AudioEngine::preload(filePath);
 }
 
@@ -201,6 +224,7 @@ void SimpleAudioEngine::preloadEffect(const char* filePath){
  *
  * @param filePath The path of the effect file.
  */
-void SimpleAudioEngine::unloadEffect(const char* filePath){
+void SimpleAudioEngine::unloadEffect(const char* filePath)
+{
     AudioEngine::uncache(filePath);
 }

--- a/cocos/audio/linux/SimpleAudioEngine.cpp
+++ b/cocos/audio/linux/SimpleAudioEngine.cpp
@@ -24,7 +24,7 @@ SimpleAudioEngine* SimpleAudioEngine::getInstance(){
     g_SimpleAudioEngineLinux->engine = new SimpleAudioEngine(); 
   }
   return g_SimpleAudioEngineLinux->engine; 
-};
+}
 
   void SimpleAudioEngine::end(){
     if(g_SimpleAudioEngineLinux){
@@ -32,54 +32,54 @@ SimpleAudioEngine* SimpleAudioEngine::getInstance(){
       delete g_SimpleAudioEngineLinux;       
     }
     g_SimpleAudioEngineLinux = nullptr; 
-  };
+  }
   
   
     SimpleAudioEngine::SimpleAudioEngine(){
       g_SimpleAudioEngineLinux->musicid = -1;
       g_SimpleAudioEngineLinux->effectsvolume = 1.0f; 
-    };
+    }
 
     SimpleAudioEngine::~SimpleAudioEngine(){
       
-    };
+    }
 
     void SimpleAudioEngine::preloadBackgroundMusic(const char* filePath){
       g_SimpleAudioEngineLinux->musicpath = filePath; 
       AudioEngine::preload(filePath); 
-    };
+    }
     
     void SimpleAudioEngine::playBackgroundMusic(const char* filePath, bool loop){
       g_SimpleAudioEngineLinux->musicpath = filePath; 
       g_SimpleAudioEngineLinux->musicid = AudioEngine::play2d(filePath, loop); 
-    };
+    }
 
     void SimpleAudioEngine::stopBackgroundMusic(bool releaseData){
       AudioEngine::stop(g_SimpleAudioEngineLinux->musicid);
       if(releaseData){
         AudioEngine::uncache(g_SimpleAudioEngineLinux->musicpath.c_str()); 
       }
-    };
+    }
 
     void SimpleAudioEngine::pauseBackgroundMusic(){
       AudioEngine::pause(g_SimpleAudioEngineLinux->musicid); 
-    };
+    }
 
     void SimpleAudioEngine::resumeBackgroundMusic(){
       AudioEngine::resume(g_SimpleAudioEngineLinux->musicid);
-    };
+    }
 
     void SimpleAudioEngine::rewindBackgroundMusic(){
       AudioEngine::setCurrentTime(g_SimpleAudioEngineLinux->musicid, 0);
-    };
+    }
 
     bool SimpleAudioEngine::willPlayBackgroundMusic(){
       return g_SimpleAudioEngineLinux->musicid != -1; 
-    };
+    }
 
     bool SimpleAudioEngine::isBackgroundMusicPlaying(){
         return AudioEngine::getState(g_SimpleAudioEngineLinux->musicid) == AudioEngine::AudioState::PLAYING; 
-    };
+    }
 
     // 
     // properties
@@ -92,7 +92,7 @@ SimpleAudioEngine* SimpleAudioEngine::getInstance(){
      */
     float SimpleAudioEngine::getBackgroundMusicVolume(){
       return AudioEngine::getVolume(g_SimpleAudioEngineLinux->musicid);
-    };
+    }
 
     /**
      * Set the volume of background music.
@@ -103,14 +103,14 @@ SimpleAudioEngine* SimpleAudioEngine::getInstance(){
      */
     void SimpleAudioEngine::setBackgroundMusicVolume(float volume){
       AudioEngine::setVolume(g_SimpleAudioEngineLinux->musicid, volume); 
-    };
+    }
 
     /**
      * The volume of the effects within the range of 0.0 as the minimum and 1.0 as the maximum.
      */
     float SimpleAudioEngine::getEffectsVolume(){
       return g_SimpleAudioEngineLinux->effectsvolume;
-    };
+    }
 
     /**
      * Set the volume of sound effects.
@@ -119,7 +119,7 @@ SimpleAudioEngine* SimpleAudioEngine::getInstance(){
      */
     void SimpleAudioEngine::setEffectsVolume(float volume){
       g_SimpleAudioEngineLinux->effectsvolume = volume; 
-    };
+    }
 
     /**
      * Play sound effect with a file path, pitch, pan and gain.
@@ -137,7 +137,7 @@ SimpleAudioEngine* SimpleAudioEngine::getInstance(){
      */
     unsigned int SimpleAudioEngine::playEffect(const char* filePath, bool loop, float pitch, float pan, float gain){
         return AudioEngine::play2d(filePath, loop, gain);
-    };
+    }
 
     /**
      * Pause playing sound effect.
@@ -146,14 +146,14 @@ SimpleAudioEngine* SimpleAudioEngine::getInstance(){
      */
     void SimpleAudioEngine::pauseEffect(unsigned int soundId){
       AudioEngine::pause(soundId);
-    };
+    }
 
     /**
      * Pause all playing sound effect.
      */
     void SimpleAudioEngine::pauseAllEffects(){
       AudioEngine::pauseAll();
-    };
+    }
 
     /**
      * Resume playing sound effect.
@@ -162,14 +162,14 @@ SimpleAudioEngine* SimpleAudioEngine::getInstance(){
      */
     void SimpleAudioEngine::resumeEffect(unsigned int soundId){
       AudioEngine::resume(soundId);
-    };
+    }
 
     /**
      * Resume all playing sound effect.
      */
     void SimpleAudioEngine::resumeAllEffects(){
       AudioEngine::resumeAll();
-    };
+    }
 
     /**
      * Stop playing sound effect.
@@ -178,14 +178,14 @@ SimpleAudioEngine* SimpleAudioEngine::getInstance(){
      */
     void SimpleAudioEngine::stopEffect(unsigned int soundId){
       AudioEngine::stop(soundId);
-    };
+    }
 
     /**
      * Stop all playing sound effects.
      */
     void SimpleAudioEngine::stopAllEffects(){
       AudioEngine::stopAll();
-    };
+    }
 
     /**
      * Preload a compressed audio file.
@@ -197,7 +197,7 @@ SimpleAudioEngine* SimpleAudioEngine::getInstance(){
      */
     void SimpleAudioEngine::preloadEffect(const char* filePath){
       AudioEngine::preload(filePath);
-    };
+    }
 
     /**
      * Unload the preloaded effect from internal buffer.
@@ -206,6 +206,6 @@ SimpleAudioEngine* SimpleAudioEngine::getInstance(){
      */
     void SimpleAudioEngine::unloadEffect(const char* filePath){
       AudioEngine::uncache(filePath);
-    };
+    }
 
     


### PR DESCRIPTION
This pull request fixes a few minor formatting issues in AudioEngine-Linux. It does the following:
- Fix indentation
- Change 2 spaces to 4 spaces indentation
- Remove trailing whitespaces
- Remove unnecessary trailing semicolons
- Remove empty if-else statement at line AudioEngine-linux.cpp:38
- Prevent gcc warning: "no newline at end of file"
- Code formatting to follow the [cocos2d-x code style](https://github.com/cocos2d/cocos2d-x/wiki/Cpp--Coding-Style)
