### PR TITLE
Enable WebView's local storage on Android

### DIFF
--- a/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxWebView.java
+++ b/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxWebView.java
@@ -54,6 +54,7 @@ public class Cocos2dxWebView extends WebView {
 
         this.getSettings().setSupportZoom(false);
 
+        this.getSettings().setDomStorageEnabled(true);
         this.getSettings().setJavaScriptEnabled(true);
 
         // `searchBoxJavaBridge_` has big security risk. http://jvn.jp/en/jp/JVN53768697


### PR DESCRIPTION
Problem:
cocos2d::experimental::ui::WebView' local storage wasn't working on
Android. On iOS worked fine.

Solution:
Enable local storage of android.webkit.WebView in Android.

References:
https://developer.android.com/reference/android/webkit/WebSettings.html
http://stackoverflow.com/questions/5899087/android-webview-localstorage
