### PR TITLE
Fix gcc warnings and type mismatch issues in AudioEngine for Linux

### DIFF
--- a/cocos/audio/linux/AudioEngine-linux.h
+++ b/cocos/audio/linux/AudioEngine-linux.h
@@ -83,7 +83,7 @@ private:
     FMOD::Channel * getChannel(FMOD::Sound *);
   
     struct ChannelInfo{
-        size_t id; 
+        int id;
         std::string path; 
         FMOD::Sound * sound;
         FMOD::Channel * channel; 


### PR DESCRIPTION
Hello,
When compiling the AudioEngine class with GCC on Linux, I'm getting the following warnings:

```
cocos/audio/linux/AudioEngine-linux.cpp: In member function ‘void cocos2d::experimental::AudioEngineImpl::onSoundFinished(FMOD::Channel*)’:
cocos/audio/linux/AudioEngine-linux.cpp:248:77: warning: format ‘%d’ expects argument of type ‘int’, but argument 2 has type ‘size_t {aka long unsigned int}’ [-Wformat=]
         printf("AudioEngineImpl::onSoundFinished: invalid audioID: %d\n", id);
                                                                             ^
cocos/audio/linux/AudioEngine-linux.cpp: In member function ‘int cocos2d::experimental::AudioEngineImpl::preload(const string&, std::function<void(bool)>)’:
cocos/audio/linux/AudioEngine-linux.cpp:300:43: warning: cast to pointer from integer of different size [-Wint-to-pointer-cast]
     chanelInfo.sound->setUserData((void *)id);
                                           ^
```

I think we have a few minor problems with our implementation:
- int/size_t type mismatch caused by `AudioEngineImpl::ChannelInfo::id`
  - `ChannelInfo::id` is size_t, but `audioID` and `AudioEngineImpl::mapChannelInfo::key_type` are int.
- C-style type casting between void pointer and integer, such as `(void *)id` and `(size_t) data`

So this PR changes the type of `ChannelInfo::id` to `int` to prevent type mismatch issues. The changeset also fixes these compiler warnings.

Thank you for your time and attention.
