### PR TITLE
Prevent too many C4996 warnings caused by ignoreAnchorPointForPosition()

### DIFF
--- a/cocos/2d/CCSprite.h
+++ b/cocos/2d/CCSprite.h
@@ -470,9 +470,6 @@ public:
     
     virtual void setIgnoreAnchorPointForPosition(bool value) override;
     
-    // @deprecated Use setIgnoreAnchorPointForPosition() instead.
-    CC_DEPRECATED_ATTRIBUTE virtual void ignoreAnchorPointForPosition(bool value) override { setIgnoreAnchorPointForPosition(value); }
-    
     virtual void setVisible(bool bVisible) override;
     virtual void draw(Renderer *renderer, const Mat4 &transform, uint32_t flags) override;
     virtual void setOpacityModifyRGB(bool modify) override;


### PR DESCRIPTION
Hello,

When I use the latest cocos2d-x (since commit 86df9b535a5d51479ee6eaa93b85d991b4c3c974) in my project with Visual Studio 2015, I got a lot of warning messages about `Node::ignoreAnchorPointForPosition()` was declared deprecated.

Then I tried to build libcocos2d and cpp-tests, it can reproduce the same warning as following:

```
5>cocos\2d/CCSprite.h(474): warning C4996: 'cocos2d::Node::ignoreAnchorPointForPosition': was declared deprecated (compiling source file ..\ui\UIButton.cpp)
5>cocos\2d/CCSprite.h(474): warning C4996: 'cocos2d::Node::ignoreAnchorPointForPosition': was declared deprecated (compiling source file ..\ui\UIRichText.cpp)
...
6>cocos\2d/CCSprite.h(474): warning C4996: 'cocos2d::Node::ignoreAnchorPointForPosition': was declared deprecated (compiling source file ..\Classes\BillBoardTest\BillBoardTest.cpp)
6>cocos\2d/CCSprite.h(474): warning C4996: 'cocos2d::Node::ignoreAnchorPointForPosition': was declared deprecated (compiling source file ..\Classes\ActionsTest\ActionsTest.cpp)
...
```

![cocos2d-x-pull-15692](https://cloud.githubusercontent.com/assets/4461792/15451537/17c90b5e-2003-11e6-9d0b-1782272c9d5a.png)

The warning C4996 seem to be caused by the `Sprite::ignoreAnchorPointForPosition()` function which override the deprecated `Node::ignoreAnchorPointForPosition()` function in the `CCSprite.h` file. I know we need to fully support the `ignoreAnchorPointForPosition()` for backwards compatibility, but those warning messages are too many for me (and CI such as Jenkins).

So this PR removes the function definition of the `Sprite::ignoreAnchorPointForPosition()` to prevent the warning, for these reasons:
- `Sprite::ignoreAnchorPointForPosition()` and `Sprite::setIgnoreAnchorPointForPosition()` are both overridding virtual functions of the `Node` class.
- `Node::ignoreAnchorPointForPosition()` calls `setIgnoreAnchorPointForPosition()` internally. 
- `Sprite::setIgnoreAnchorPointForPosition()` is executed when the `Node::ignoreAnchorPointForPosition()` is invoked instead of `Sprite::ignoreAnchorPointForPosition()`.
- This change will not affect C++ APIs and the documentation generated by doxygen.

In other words, I think it's unnecessary to explicitly keep the definition of the `Sprite::ignoreAnchorPointForPosition()`.

I've also tried to verify if this change keeps backwards compatibility with the following test case:

```
auto sprite = Sprite::create("HelloWorld.png");

// `Sprite::setIgnoreAnchorPointForPosition()` function can be invoked in 3 different ways:
sprite->ignoreAnchorPointForPosition(true);
sprite->Sprite::ignoreAnchorPointForPosition(true);
static_cast<Node*>(sprite)->ignoreAnchorPointForPosition(true);

addChild(sprite);
```

The same issue has been reported here:
http://discuss.cocos2d-x.org/t/gen-libs-error-c4996/29404

Thank you for taking your time to read this. :smiley:
