### PR TITLE
use manifestUrl from remote version

### DIFF
--- a/extensions/assets-manager/AssetsManagerEx.cpp
+++ b/extensions/assets-manager/AssetsManagerEx.cpp
@@ -494,7 +494,13 @@ void AssetsManagerEx::downloadManifest()
     if (_updateState != State::PREDOWNLOAD_MANIFEST)
         return;
 
-    std::string manifestUrl = _localManifest->getManifestFileUrl();
+    std::string manifestUrl;
+    if (_remoteManifest->isVersionLoaded()) {
+        manifestUrl = _remoteManifest->getManifestFileUrl();
+    } else {
+        manifestUrl = _localManifest->getManifestFileUrl();
+    }
+
     if (manifestUrl.size() > 0)
     {
         _updateState = State::DOWNLOADING_MANIFEST;


### PR DESCRIPTION
In case if local version file is very old, and remote version has changed the manifest url ever since, this fix will make sure that AssetsManagerEx will download the correct manifest file.

This PR is moved from https://github.com/cocos2d/cocos2d-x/pull/15689#issuecomment-220927212
