### PR TITLE
Fix typo in function name: Keybard -> Keyboard

### DIFF
--- a/cocos/scripting/js-bindings/manual/ScriptingCore.cpp
+++ b/cocos/scripting/js-bindings/manual/ScriptingCore.cpp
@@ -1525,7 +1525,7 @@ bool ScriptingCore::executeFunctionWithOwner(jsval owner, const char *name, cons
     return bRet;
 }
 
-bool ScriptingCore::handleKeybardEvent(void* nativeObj, cocos2d::EventKeyboard::KeyCode keyCode, bool isPressed, cocos2d::Event* event)
+bool ScriptingCore::handleKeyboardEvent(void* nativeObj, cocos2d::EventKeyboard::KeyCode keyCode, bool isPressed, cocos2d::Event* event)
 {
     JSAutoCompartment ac(_cx, _global.ref());
 

--- a/cocos/scripting/js-bindings/manual/ScriptingCore.h
+++ b/cocos/scripting/js-bindings/manual/ScriptingCore.h
@@ -548,7 +548,7 @@ public:
     bool handleMouseEvent(void* nativeObj, cocos2d::EventMouse::MouseEventType eventType, cocos2d::Event* event);
     bool handleMouseEvent(void* nativeObj, cocos2d::EventMouse::MouseEventType eventType, cocos2d::Event* event, JS::MutableHandleValue jsvalRet);
 
-    bool handleKeybardEvent(void* nativeObj, cocos2d::EventKeyboard::KeyCode keyCode, bool isPressed, cocos2d::Event* event);
+    bool handleKeyboardEvent(void* nativeObj, cocos2d::EventKeyboard::KeyCode keyCode, bool isPressed, cocos2d::Event* event);
     bool handleFocusEvent(void* nativeObj, cocos2d::ui::Widget* widgetLoseFocus, cocos2d::ui::Widget* widgetGetFocus);
 
     void restartVM();

--- a/cocos/scripting/js-bindings/manual/jsb_event_dispatcher_manual.cpp
+++ b/cocos/scripting/js-bindings/manual/jsb_event_dispatcher_manual.cpp
@@ -138,11 +138,11 @@ bool js_EventListenerKeyboard_create(JSContext *cx, uint32_t argc, jsval *vp)
         auto ret = EventListenerKeyboard::create();
 
         ret->onKeyPressed = [ret](EventKeyboard::KeyCode keyCode, Event* event) {
-            ScriptingCore::getInstance()->handleKeybardEvent(ret, keyCode, true, event);
+            ScriptingCore::getInstance()->handleKeyboardEvent(ret, keyCode, true, event);
         };
 
         ret->onKeyReleased = [ret](EventKeyboard::KeyCode keyCode, Event* event) {
-            ScriptingCore::getInstance()->handleKeybardEvent(ret, keyCode, false, event);
+            ScriptingCore::getInstance()->handleKeyboardEvent(ret, keyCode, false, event);
         };
 
         jsval jsret = OBJECT_TO_JSVAL(js_get_or_create_jsobject<EventListenerKeyboard>(cx, ret));


### PR DESCRIPTION
This fixes misspelling of the word `Keyboard`.
