### PR TITLE
Use nullptr instead of 0 or NULL

### DIFF
--- a/cocos/2d/CCActionInterval.cpp
+++ b/cocos/2d/CCActionInterval.cpp
@@ -1958,7 +1958,7 @@ bool Blink::initWithDuration(float duration, int blinks)
 
 void Blink::stop()
 {
-    if(NULL != _target)
+    if (nullptr != _target)
         _target->setVisible(_originalState);
     ActionInterval::stop();
 }

--- a/cocos/base/CCDirector.cpp
+++ b/cocos/base/CCDirector.cpp
@@ -1088,7 +1088,7 @@ void Director::restartDirector()
     
     // Real restart in script level
 #if CC_ENABLE_SCRIPT_BINDING
-    ScriptEvent scriptEvent(kRestartGame, NULL);
+    ScriptEvent scriptEvent(kRestartGame, nullptr);
     ScriptEngineManager::getInstance()->getScriptEngine()->sendEvent(&scriptEvent);
 #endif
 }

--- a/cocos/base/CCIMEDispatcher.cpp
+++ b/cocos/base/CCIMEDispatcher.cpp
@@ -273,7 +273,7 @@ void IMEDispatcher::dispatchKeyboardWillShow(IMEKeyboardNotificationInfo& info)
 {
     if (_impl)
     {
-        IMEDelegate * delegate = 0;
+        IMEDelegate * delegate = nullptr;
         DelegateIter last = _impl->_delegateList.end();
         for (DelegateIter first = _impl->_delegateList.begin(); first != last; ++first)
         {
@@ -290,7 +290,7 @@ void IMEDispatcher::dispatchKeyboardDidShow(IMEKeyboardNotificationInfo& info)
 {
     if (_impl)
     {
-        IMEDelegate * delegate = 0;
+        IMEDelegate * delegate = nullptr;
         DelegateIter last = _impl->_delegateList.end();
         for (DelegateIter first = _impl->_delegateList.begin(); first != last; ++first)
         {
@@ -307,7 +307,7 @@ void IMEDispatcher::dispatchKeyboardWillHide(IMEKeyboardNotificationInfo& info)
 {
     if (_impl)
     {
-        IMEDelegate * delegate = 0;
+        IMEDelegate * delegate = nullptr;
         DelegateIter last = _impl->_delegateList.end();
         for (DelegateIter first = _impl->_delegateList.begin(); first != last; ++first)
         {
@@ -324,7 +324,7 @@ void IMEDispatcher::dispatchKeyboardDidHide(IMEKeyboardNotificationInfo& info)
 {
     if (_impl)
     {
-        IMEDelegate * delegate = 0;
+        IMEDelegate * delegate = nullptr;
         DelegateIter last = _impl->_delegateList.end();
         for (DelegateIter first = _impl->_delegateList.begin(); first != last; ++first)
         {

--- a/cocos/base/CCUserDefault.cpp
+++ b/cocos/base/CCUserDefault.cpp
@@ -394,7 +394,7 @@ void UserDefault::setDataForKey(const char* pKey, const Data& value) {
         return;
     }
 
-    char *encodedData = 0;
+    char *encodedData = nullptr;
     
     base64Encode(value.getBytes(), static_cast<unsigned int>(value.getSize()), &encodedData);
         

--- a/cocos/navmesh/CCNavMesh.cpp
+++ b/cocos/navmesh/CCNavMesh.cpp
@@ -229,7 +229,7 @@ bool NavMesh::loadNavMeshFile()
 
 bool NavMesh::loadGeomFile()
 {
-    unsigned char* buf = 0;
+    unsigned char* buf = nullptr;
     auto data = FileUtils::getInstance()->getDataFromFile(_geomFilePath);
     if (data.isNull()) return false;
     buf = data.getBytes();

--- a/cocos/navmesh/CCNavMeshUtils.cpp
+++ b/cocos/navmesh/CCNavMeshUtils.cpp
@@ -193,8 +193,8 @@ int fixupShortcuts(dtPolyRef* path, int npath, dtNavMeshQuery* navQuery)
     dtPolyRef neis[maxNeis];
     int nneis = 0;
 
-    const dtMeshTile* tile = 0;
-    const dtPoly* poly = 0;
+    const dtMeshTile* tile = nullptr;
+    const dtPoly* poly = nullptr;
     if (dtStatusFailed(navQuery->getAttachedNavMesh()->getTileAndPolyByRef(path[0], &tile, &poly)))
         return npath;
 

--- a/cocos/navmesh/CCNavMeshUtils.h
+++ b/cocos/navmesh/CCNavMeshUtils.h
@@ -125,7 +125,7 @@ bool getSteerTarget(dtNavMeshQuery* navQuery, const float* startPos, const float
     const float minTargetDist,
     const dtPolyRef* path, const int pathSize,
     float* steerPos, unsigned char& steerPosFlag, dtPolyRef& steerPosRef,
-    float* outPoints = 0, int* outPointCount = 0);
+    float* outPoints = nullptr, int* outPointCount = nullptr);
 /** @} */
 
 NS_CC_END

--- a/cocos/physics3d/CCPhysics3DObject.cpp
+++ b/cocos/physics3d/CCPhysics3DObject.cpp
@@ -379,7 +379,7 @@ public:
     ~btCollider(){};
 
     ///this method is mainly for expert/internal use only.
-    virtual void	addOverlappingObjectInternal(btBroadphaseProxy* otherProxy, btBroadphaseProxy* thisProxy = 0) override
+    virtual void addOverlappingObjectInternal(btBroadphaseProxy* otherProxy, btBroadphaseProxy* thisProxy = nullptr) override
     {
         btCollisionObject* otherObject = (btCollisionObject*)otherProxy->m_clientObject;
         btAssert(otherObject);
@@ -395,7 +395,7 @@ public:
     }
 
     ///this method is mainly for expert/internal use only.
-    virtual void	removeOverlappingObjectInternal(btBroadphaseProxy* otherProxy, btDispatcher* dispatcher, btBroadphaseProxy* thisProxy = 0) override
+    virtual void removeOverlappingObjectInternal(btBroadphaseProxy* otherProxy, btDispatcher* dispatcher, btBroadphaseProxy* thisProxy = nullptr) override
     {
         btCollisionObject* otherObject = (btCollisionObject*)otherProxy->m_clientObject;
         btAssert(otherObject);

--- a/cocos/renderer/CCGLProgram.cpp
+++ b/cocos/renderer/CCGLProgram.cpp
@@ -349,7 +349,7 @@ void GLProgram::parseVertexAttribs()
     else
     {
         GLchar ErrorLog[1024];
-        glGetProgramInfoLog(_program, sizeof(ErrorLog), NULL, ErrorLog);
+        glGetProgramInfoLog(_program, sizeof(ErrorLog), nullptr, ErrorLog);
         CCLOG("Error linking shader program: '%s'\n", ErrorLog);
     }
 }
@@ -407,7 +407,7 @@ void GLProgram::parseUniforms()
     else
     {
         GLchar ErrorLog[1024];
-        glGetProgramInfoLog(_program, sizeof(ErrorLog), NULL, ErrorLog);
+        glGetProgramInfoLog(_program, sizeof(ErrorLog), nullptr, ErrorLog);
         CCLOG("Error linking shader program: '%s'\n", ErrorLog);
 
     }

--- a/cocos/renderer/CCGLProgramCache.cpp
+++ b/cocos/renderer/CCGLProgramCache.cpp
@@ -71,7 +71,7 @@ enum {
     kShaderType_MAX,
 };
 
-static GLProgramCache *_sharedGLProgramCache = 0;
+static GLProgramCache *_sharedGLProgramCache = nullptr;
 
 GLProgramCache* GLProgramCache::getInstance()
 {

--- a/cocos/renderer/CCRenderState.cpp
+++ b/cocos/renderer/CCRenderState.cpp
@@ -55,7 +55,7 @@ RenderState::~RenderState()
 
 void RenderState::initialize()
 {
-    if (StateBlock::_defaultState == NULL)
+    if (StateBlock::_defaultState == nullptr)
     {
         StateBlock::_defaultState = StateBlock::create();
         CC_SAFE_RETAIN(StateBlock::_defaultState);
@@ -121,7 +121,7 @@ void RenderState::bind(Pass* pass)
     StateBlock::restore(stateOverrideBits);
 
     // Apply renderer state for the entire hierarchy, top-down.
-    rs = NULL;
+    rs = nullptr;
     while ((rs = getTopmost(rs)))
     {
         if (rs->_state)
@@ -137,12 +137,12 @@ RenderState* RenderState::getTopmost(RenderState* below)
     if (rs == below)
     {
         // Nothing below ourself.
-        return NULL;
+        return nullptr;
     }
 
     while (rs)
     {
-        if (rs->_parent == below || rs->_parent == NULL)
+        if (rs->_parent == below || rs->_parent == nullptr)
         {
             // Stop traversing up here.
             return rs;
@@ -150,7 +150,7 @@ RenderState* RenderState::getTopmost(RenderState* below)
         rs = rs->_parent;
     }
 
-    return NULL;
+    return nullptr;
 }
 
 RenderState::StateBlock* RenderState::getStateBlock() const

--- a/cocos/renderer/CCTextureCache.cpp
+++ b/cocos/renderer/CCTextureCache.cpp
@@ -679,7 +679,7 @@ void VolatileTextureMgr::addImage(Texture2D *tt, Image *image)
 
 VolatileTexture* VolatileTextureMgr::findVolotileTexture(Texture2D *tt)
 {
-    VolatileTexture *vt = 0;
+    VolatileTexture *vt = nullptr;
     auto i = _textures.begin();
     while (i != _textures.end())
     {

--- a/cocos/ui/UIScale9Sprite.cpp
+++ b/cocos/ui/UIScale9Sprite.cpp
@@ -87,11 +87,11 @@ namespace ui {
         bool ret = false;
         do {
             Texture2D* texture = spriteFrame->getTexture();
-            CCASSERT(texture != NULL, "CCTexture must be not nil");
+            CCASSERT(texture != nullptr, "Texture2D must be not null");
             if(texture == nullptr) break;
             
             Sprite *sprite = Sprite::createWithSpriteFrame(spriteFrame);
-            CCASSERT(sprite != NULL, "sprite must be not nil");
+            CCASSERT(sprite != nullptr, "Sprite must be not null");
             if(sprite == nullptr) break;
             
             ret = this->init(sprite,
@@ -106,7 +106,7 @@ namespace ui {
     }
     bool Scale9Sprite::initWithSpriteFrame(SpriteFrame* spriteFrame)
     {
-        CCASSERT(spriteFrame != NULL, "Invalid spriteFrame for sprite");
+        CCASSERT(spriteFrame != nullptr, "Invalid spriteFrame for sprite");
         bool pReturn = this->initWithSpriteFrame(spriteFrame, Rect::ZERO);
         return pReturn;
     }
@@ -137,7 +137,7 @@ namespace ui {
 
     bool Scale9Sprite::init()
     {
-        return this->init(NULL, Rect::ZERO, Rect::ZERO);
+        return this->init(nullptr, Rect::ZERO, Rect::ZERO);
     }
 
     bool Scale9Sprite::init(Sprite* sprite, const Rect& rect, const Rect& capInsets)
@@ -236,7 +236,7 @@ namespace ui {
             return pReturn;
         }
         CC_SAFE_DELETE(pReturn);
-        return NULL;
+        return nullptr;
     }
 
     Scale9Sprite* Scale9Sprite::create(const std::string& file,
@@ -250,7 +250,7 @@ namespace ui {
             return pReturn;
         }
         CC_SAFE_DELETE(pReturn);
-        return NULL;
+        return nullptr;
     }
 
 
@@ -263,7 +263,7 @@ namespace ui {
             return pReturn;
         }
         CC_SAFE_DELETE(pReturn);
-        return NULL;
+        return nullptr;
     }
 
 
@@ -278,7 +278,7 @@ namespace ui {
             return pReturn;
         }
         CC_SAFE_DELETE(pReturn);
-        return NULL;
+        return nullptr;
     }
 
 
@@ -291,7 +291,7 @@ namespace ui {
             return pReturn;
         }
         CC_SAFE_DELETE(pReturn);
-        return NULL;
+        return nullptr;
     }
 
 
@@ -305,7 +305,7 @@ namespace ui {
             return pReturn;
         }
         CC_SAFE_DELETE(pReturn);
-        return NULL;
+        return nullptr;
     }
 
     Scale9Sprite* Scale9Sprite::createWithSpriteFrame(SpriteFrame* spriteFrame)
@@ -317,7 +317,7 @@ namespace ui {
             return pReturn;
         }
         CC_SAFE_DELETE(pReturn);
-        return NULL;
+        return nullptr;
     }
 
 
@@ -331,7 +331,7 @@ namespace ui {
             return pReturn;
         }
         CC_SAFE_DELETE(pReturn);
-        return NULL;
+        return nullptr;
     }
 
     Scale9Sprite* Scale9Sprite::createWithSpriteFrameName(const std::string& spriteFrameName)
@@ -345,8 +345,7 @@ namespace ui {
         CC_SAFE_DELETE(pReturn);
 
         log("Could not allocate Scale9Sprite()");
-        return NULL;
-
+        return nullptr;
     }
 
     void Scale9Sprite::cleanupSlicedSprites()
@@ -582,7 +581,7 @@ namespace ui {
             return pReturn;
         }
         CC_SAFE_DELETE(pReturn);
-        return NULL;
+        return nullptr;
     }
     
     Scale9Sprite::State Scale9Sprite::getState()const


### PR DESCRIPTION
In C++11 and later, we should use `nullptr` instead of `0` or `NULL` if possible.  So this PR changes some null pointer constants to `nullptr` and makes them consistent with the [coding style](https://github.com/cocos2d/cocos2d-x/wiki/Cpp--Coding-Style#0-and-nullptrnull).
