### PR TITLE
dlfree fix for HttpClient, the instances of Ref or its sub classes should be released by CC_SAFE_RELEASE rather than CC_SAFE_DELETE.

### DIFF
--- a/cocos/network/HttpClient-android.cpp
+++ b/cocos/network/HttpClient-android.cpp
@@ -892,7 +892,7 @@ HttpClient::HttpClient()
 HttpClient::~HttpClient()
 {
     CCLOG("In the destructor of HttpClient!");
-    CC_SAFE_DELETE(_requestSentinel);
+    CC_SAFE_RELEASE(_requestSentinel);
 }
 
 //Lazy create semaphore & mutex & thread

--- a/cocos/network/HttpClient-apple.mm
+++ b/cocos/network/HttpClient-apple.mm
@@ -381,7 +381,7 @@ HttpClient::HttpClient()
 
 HttpClient::~HttpClient()
 {
-    CC_SAFE_DELETE(_requestSentinel);
+    CC_SAFE_RELEASE(_requestSentinel);
     if (!_cookieFilename.empty() && nullptr != _cookie)
     {
         _cookie->writeFile();

--- a/cocos/network/HttpClient.cpp
+++ b/cocos/network/HttpClient.cpp
@@ -411,7 +411,7 @@ HttpClient::HttpClient()
 
 HttpClient::~HttpClient()
 {
-	CC_SAFE_DELETE(_requestSentinel);
+	CC_SAFE_RELEASE(_requestSentinel);
 	CCLOG("HttpClient destructor");
 }
 


### PR DESCRIPTION
This patch fix crash while exiting game. The crash information is:

```
A/libc(16401): heap corruption detected by dlfree
```
