### PR TITLE
correct assign to equal in cert trust expression

### DIFF
--- a/cocos/network/HttpAsynConnection-apple.m
+++ b/cocos/network/HttpAsynConnection-apple.m
@@ -199,7 +199,7 @@
         CFRelease(certArrayRef);
     }
     //Did our custom trust chain evaluate successfully?
-    return trustResult = kSecTrustResultUnspecified || trustResult == kSecTrustResultProceed;    
+    return trustResult == kSecTrustResultUnspecified || trustResult == kSecTrustResultProceed;    
 }
 
 - (void) connection:(NSURLConnection *)connection willSendRequestForAuthenticationChallenge:(NSURLAuthenticationChallenge *)challenge


### PR DESCRIPTION
This PR simply fixes an obvious bug which uses assign(=) in a boolean expression
