### PR TITLE
Fix minor typo: Texure -> Texture

### DIFF
--- a/cocos/renderer/CCGLProgramCache.cpp
+++ b/cocos/renderer/CCGLProgramCache.cpp
@@ -49,7 +49,7 @@ enum {
     kShaderType_PositionTexture_uColor,
     kShaderType_PositionTextureA8Color,
     kShaderType_Position_uColor,
-    kShaderType_PositionLengthTexureColor,
+    kShaderType_PositionLengthTextureColor,
     kShaderType_LabelDistanceFieldNormal,
     kShaderType_LabelDistanceFieldGlow,
     kShaderType_UIGrayScale,
@@ -202,7 +202,7 @@ void GLProgramCache::loadDefaultGLPrograms()
     // Position, Length(TexCoords, Color (used by Draw Node basically )
     //
     p = new (std::nothrow) GLProgram();
-    loadDefaultGLProgram(p, kShaderType_PositionLengthTexureColor);
+    loadDefaultGLProgram(p, kShaderType_PositionLengthTextureColor);
     _programs.insert( std::make_pair(GLProgram::SHADER_NAME_POSITION_LENGTH_TEXTURE_COLOR, p) );
 
     p = new (std::nothrow) GLProgram();
@@ -352,7 +352,7 @@ void GLProgramCache::reloadDefaultGLPrograms()
     //
     p = getGLProgram(GLProgram::SHADER_NAME_POSITION_LENGTH_TEXTURE_COLOR);
     p->reset();
-    loadDefaultGLProgram(p, kShaderType_PositionLengthTexureColor);
+    loadDefaultGLProgram(p, kShaderType_PositionLengthTextureColor);
 
     p = getGLProgram(GLProgram::SHADER_NAME_LABEL_DISTANCEFIELD_NORMAL);
     p->reset();
@@ -487,7 +487,7 @@ void GLProgramCache::loadDefaultGLProgram(GLProgram *p, int type)
             p->initWithByteArrays(ccPosition_uColor_vert, ccPosition_uColor_frag);
             p->bindAttribLocation("aVertex", GLProgram::VERTEX_ATTRIB_POSITION);
             break;
-        case kShaderType_PositionLengthTexureColor:
+        case kShaderType_PositionLengthTextureColor:
             p->initWithByteArrays(ccPositionColorLengthTexture_vert, ccPositionColorLengthTexture_frag);
             break;
         case kShaderType_LabelDistanceFieldNormal:


### PR DESCRIPTION
This PR corrects a minor spelling mistake while reading: `Texure` -> `Texture`
