### PR TITLE
AudioEngine-linux fix: add map contains IDs of preloaded files

### DIFF
--- a/cocos/audio/linux/AudioEngine-linux.cpp
+++ b/cocos/audio/linux/AudioEngine-linux.cpp
@@ -261,6 +261,8 @@ void AudioEngineImpl::uncache(const std::string& path)
         }
         mapSound.erase(it);
     }
+    if (mapId.find(path) != mapId.end())
+        mapId.erase(path);
 }
 
 void AudioEngineImpl::uncacheAll()
@@ -272,6 +274,7 @@ void AudioEngineImpl::uncacheAll()
         }
     }
     mapSound.clear();
+    mapId.clear();
 }
 
 int AudioEngineImpl::preload(const std::string& filePath, std::function<void(bool isSuccess)> callback)
@@ -291,6 +294,11 @@ int AudioEngineImpl::preload(const std::string& filePath, std::function<void(boo
     }
 
     int id = static_cast<int>(mapChannelInfo.size()) + 1;
+    if (mapId.find(filePath) == mapId.end())
+        mapId.insert({filePath, id});
+    else
+        id = mapId.at(filePath);
+
     auto& chanelInfo = mapChannelInfo[id];
     chanelInfo.sound = sound;
     chanelInfo.id = id;

--- a/cocos/audio/linux/AudioEngine-linux.h
+++ b/cocos/audio/linux/AudioEngine-linux.h
@@ -93,6 +93,8 @@ private:
     };
     
     std::map<int, ChannelInfo> mapChannelInfo;
+
+    std::map<std::string, int> mapId;
     
     std::map<std::string, FMOD::Sound *> mapSound;  
     


### PR DESCRIPTION
Fix for `Fail to play <something> cause by limited max instance of AudioEngine` when playing same audio file multiple times. Platform Linux.

Forum topic of issue http://discuss.cocos2d-x.org/t/fail-to-play-cause-by-limited-max-instance-of-audioengine/26800
