### PR TITLE
fix AudioEngine bug for iOS, UTF8 filePath

### DIFF
--- a/cocos/audio/apple/AudioCache.mm
+++ b/cocos/audio/apple/AudioCache.mm
@@ -102,7 +102,7 @@ void AudioCache::readDataTask()
     AudioBufferList theDataBuffer;
     ExtAudioFileRef extRef = nullptr;
     
-    NSString *fileFullPath = [[NSString alloc] initWithCString:_fileFullPath.c_str() encoding:[NSString defaultCStringEncoding]];
+    NSString *fileFullPath = [[NSString alloc] initWithCString:_fileFullPath.c_str() encoding:NSUTF8StringEncoding];
     auto fileURL = (CFURLRef)[[NSURL alloc] initFileURLWithPath:fileFullPath];
     [fileFullPath release];
 

--- a/cocos/audio/apple/AudioPlayer.mm
+++ b/cocos/audio/apple/AudioPlayer.mm
@@ -145,7 +145,7 @@ void AudioPlayer::rotateBufferThread(int offsetFrame)
     ALint bufferProcessed = 0;
     ExtAudioFileRef extRef = nullptr;
     
-    NSString *fileFullPath = [[NSString alloc] initWithCString:_audioCache->_fileFullPath.c_str() encoding:[NSString defaultCStringEncoding]];
+    NSString *fileFullPath = [[NSString alloc] initWithCString:_audioCache->_fileFullPath.c_str() encoding:NSUTF8StringEncoding];
     auto fileURL = (CFURLRef)[[NSURL alloc] initFileURLWithPath:fileFullPath];
     [fileFullPath release];
     char* tmpBuffer = (char*)malloc(_audioCache->_queBufferBytes);


### PR DESCRIPTION
Fix bug for apple platform, open audio file failed with chinese App Name.
