### PR TITLE
Fix warnings caused by comparison between RefPtr and C++11's nullptr

### DIFF
--- a/cocos/base/CCRefPtr.h
+++ b/cocos/base/CCRefPtr.h
@@ -29,6 +29,7 @@
 
 #include "base/CCRef.h"
 #include "base/ccMacros.h"
+#include <functional>
 #include <type_traits>
 
 NS_CC_BEGIN
@@ -212,16 +213,12 @@ public:
     
     inline bool operator > (typename std::remove_const<T>::type * other) const { return _ptr > other; }
     
-    inline bool operator > (const std::nullptr_t other) const { return _ptr > other; }
-    
     
     inline bool operator < (const RefPtr<T> & other) const { return _ptr < other._ptr; }
     
     inline bool operator < (const T * other) const { return _ptr < other; }
     
     inline bool operator < (typename std::remove_const<T>::type * other) const { return _ptr < other; }
-    
-    inline bool operator < (const std::nullptr_t other) const { return _ptr < other; }
     
         
     inline bool operator >= (const RefPtr<T> & other) const { return _ptr >= other._ptr; }
@@ -230,16 +227,12 @@ public:
     
     inline bool operator >= (typename std::remove_const<T>::type * other) const { return _ptr >= other; }
     
-    inline bool operator >= (const std::nullptr_t other) const { return _ptr >= other; }
-    
         
     inline bool operator <= (const RefPtr<T> & other) const { return _ptr <= other._ptr; }
     
     inline bool operator <= (const T * other) const { return _ptr <= other; }
     
     inline bool operator <= (typename std::remove_const<T>::type * other) const { return _ptr <= other; }
-    
-    inline bool operator <= (const std::nullptr_t other) const { return _ptr <= other; }
     
         
     inline operator bool() const { return _ptr != nullptr; }
@@ -283,6 +276,54 @@ private:
     Ref * _ptr;
 };
     
+template<class T> inline
+bool operator<(const RefPtr<T>& r, std::nullptr_t)
+{
+    return std::less<T*>()(r.get(), nullptr);
+}
+
+template<class T> inline
+bool operator<(std::nullptr_t, const RefPtr<T>& r)
+{
+    return std::less<T*>()(nullptr, r.get());
+}
+
+template<class T> inline
+bool operator>(const RefPtr<T>& r, std::nullptr_t)
+{
+    return nullptr < r;
+}
+
+template<class T> inline
+bool operator>(std::nullptr_t, const RefPtr<T>& r)
+{
+    return r < nullptr;
+}
+
+template<class T> inline
+bool operator<=(const RefPtr<T>& r, std::nullptr_t)
+{
+    return !(nullptr < r);
+}
+
+template<class T> inline
+bool operator<=(std::nullptr_t, const RefPtr<T>& r)
+{
+    return !(r < nullptr);
+}
+
+template<class T> inline
+bool operator>=(const RefPtr<T>& r, std::nullptr_t)
+{
+    return !(r < nullptr);
+}
+
+template<class T> inline
+bool operator>=(std::nullptr_t, const RefPtr<T>& r)
+{
+    return !(nullptr < r);
+}
+
 /**
  * Cast between RefPtr types statically.
  */

--- a/tests/cpp-tests/Classes/UnitTest/RefPtrTest.cpp
+++ b/tests/cpp-tests/Classes/UnitTest/RefPtrTest.cpp
@@ -264,6 +264,10 @@ void RefPtrTest::onEnter()
         CC_ASSERT(false == (ref1 > nullptr));
         CC_ASSERT(true == (ref1 <= nullptr));
         CC_ASSERT(true == (ref1 >= nullptr));
+        CC_ASSERT(false == (nullptr < ref1));
+        CC_ASSERT(false == (nullptr > ref1));
+        CC_ASSERT(true == (nullptr <= ref1));
+        CC_ASSERT(true == (nullptr >= ref1));
         
         CC_ASSERT(false == (ref1 == __String::create("Hello")));
         CC_ASSERT(true == (ref1 != __String::create("Hello")));
@@ -280,6 +284,17 @@ void RefPtrTest::onEnter()
         CC_ASSERT(true == (ref1 > ref2));
         CC_ASSERT(false == (ref1 <= ref2));
         CC_ASSERT(true == (ref1 >= ref2));
+
+        CC_ASSERT(false == (ref1 == nullptr));
+        CC_ASSERT(true == (ref1 != nullptr));
+        CC_ASSERT(false == (ref1 < nullptr));
+        CC_ASSERT(true == (ref1 > nullptr));
+        CC_ASSERT(false == (ref1 <= nullptr));
+        CC_ASSERT(true == (ref1 >= nullptr));
+        CC_ASSERT(true == (nullptr < ref1));
+        CC_ASSERT(false == (nullptr > ref1));
+        CC_ASSERT(true == (nullptr <= ref1));
+        CC_ASSERT(false == (nullptr >= ref1));
     }
     
     // TEST(moveConstructor)


### PR DESCRIPTION
When using `RefPtr<T>` with GCC 5.2.1 on Ubuntu 15.10, I get the following warning messages:

```
cocos/base/CCRefPtr.h: In member function ‘bool cocos2d::RefPtr<T>::operator>(std::nullptr_t) const’:
cocos/base/CCRefPtr.h:215:79: warning: ordered comparison of pointer with integer zero [-Wextra]
     inline bool operator > (const std::nullptr_t other) const { return _ptr > other; }
                                                                               ^
cocos/base/CCRefPtr.h: In member function ‘bool cocos2d::RefPtr<T>::operator<(std::nullptr_t) const’:
cocos/base/CCRefPtr.h:224:79: warning: ordered comparison of pointer with integer zero [-Wextra]
     inline bool operator < (const std::nullptr_t other) const { return _ptr < other; }
                                                                               ^
cocos/base/CCRefPtr.h: In member function ‘bool cocos2d::RefPtr<T>::operator>=(std::nullptr_t) const’:
cocos/base/CCRefPtr.h:233:81: warning: ordered comparison of pointer with integer zero [-Wextra]
     inline bool operator >= (const std::nullptr_t other) const { return _ptr >= other; }
                                                                                 ^
cocos/base/CCRefPtr.h: In member function ‘bool cocos2d::RefPtr<T>::operator<=(std::nullptr_t) const’:
cocos/base/CCRefPtr.h:242:81: warning: ordered comparison of pointer with integer zero [-Wextra]
     inline bool operator <= (const std::nullptr_t other) const { return _ptr <= other; }
                                                                                 ^
```

This problem seems to be caused by ordered comparison between pointers and null pointer constant. So we can use `std::less()` instead of relational operators such as `<`, `>`, `<=` and `>=`. This pull request fixes them.
