### PR TITLE
Fix C4267 and C4309 warnings when compiling for Windows 10 UWP

### DIFF
--- a/cocos/network/CCDownloader-curl.cpp
+++ b/cocos/network/CCDownloader-curl.cpp
@@ -108,7 +108,7 @@ namespace cocos2d { namespace network {
             do
             {
                 string dir;
-                unsigned long found = _tempFileName.find_last_of("/\\");
+                size_t found = _tempFileName.find_last_of("/\\");
                 if (found == string::npos)
                 {
                     _errCode = DownloadTask::ERROR_INVALID_PARAMS;

--- a/cocos/platform/winrt/CCFileUtilsWinRT.cpp
+++ b/cocos/platform/winrt/CCFileUtilsWinRT.cpp
@@ -36,8 +36,8 @@ static std::string s_pszResourcePath;
 static inline std::string convertPathFormatToUnixStyle(const std::string& path)
 {
     std::string ret = path;
-    int len = ret.length();
-    for (int i = 0; i < len; ++i)
+    size_t len = ret.length();
+    for (size_t i = 0; i < len; ++i)
     {
         if (ret[i] == '\\')
         {

--- a/cocos/platform/winrt/CCWinRTUtils.cpp
+++ b/cocos/platform/winrt/CCWinRTUtils.cpp
@@ -321,8 +321,7 @@ Concurrency::task<Platform::Array<byte>^> ReadDataAsync(Platform::String^ path)
 std::string computeHashForFile(const std::string& filePath)
 {
     std::string ret = filePath;
-    int pos = std::string::npos;
-    pos = ret.find_last_of('/');
+    size_t pos = ret.find_last_of('/');
 
     if (pos != std::string::npos) {
         ret = ret.substr(pos);


### PR DESCRIPTION
I get the following warnings when building `build/cocos2d-win10.sln` with Visual Studio 2015 and Windows 10 64-bit:

```
5>..\..\network\CCDownloader-curl.cpp(111): warning C4267: 'initializing': conversion from 'size_t' to 'unsigned long', possible loss of data
5>..\..\platform\winrt\CCFileUtilsWinRT.cpp(39): warning C4267: 'initializing': conversion from 'size_t' to 'int', possible loss of data
5>..\..\platform\winrt\CCWinRTUtils.cpp(324): warning C4309: 'initializing': truncation of constant value
5>..\..\platform\winrt\CCWinRTUtils.cpp(325): warning C4267: '=': conversion from 'size_t' to 'int', possible loss of data
5>..\..\platform\winrt\CCWinRTUtils.cpp(331): warning C4267: '=': conversion from 'size_t' to 'int', possible loss of data
```

This pull request makes the integer types more consistent with default values to suppress these warnings.
