### PR TITLE
Remove unnecessary sinf, cosf, tanf and sqrtf macros

### DIFF
--- a/cocos/platform/linux/CCStdC-linux.h
+++ b/cocos/platform/linux/CCStdC-linux.h
@@ -50,12 +50,6 @@ THE SOFTWARE.
 #define MAX(x,y) (((x) < (y)) ? (y) : (x))
 #endif  // MAX
 
-// some function linux do not have
-#define tanf tan
-#define sqrtf sqrt
-#define cosf cos
-#define sinf sin
-
 #endif // CC_TARGET_PLATFORM == CC_PLATFORM_LINUX
 
 #endif  // __CC_STD_C_H__

--- a/cocos/platform/tizen/CCStdC-tizen.h
+++ b/cocos/platform/tizen/CCStdC-tizen.h
@@ -49,12 +49,6 @@
 #define MAX(x,y) (((x) < (y)) ? (y) : (x))
 #endif  // MAX
 
-// some function linux do not have
-#define tanf tan
-#define sqrtf sqrt
-#define cosf cos
-#define sinf sin
-
 #endif // CC_TARGET_PLATFORM == CC_PLATFORM_TIZEN
 
 #endif  // __CC_STD_C_H__


### PR DESCRIPTION
This pull request removes the user-defined C99 mathematical macros below from `CCStdC.h`:

```
#define tanf tan
#define sqrtf sqrt
#define cosf cos
#define sinf sin
```

The problem is that when I use `::sinf(float)` with my project on Linux, our `sinf` macro replaces it with `::sin(double)`. These macros are unnecessary, because they are [defined in C99](http://en.cppreference.com/w/c/numeric/math/sin), and the latest cocos2d-x [requires a C99 compiler](https://github.com/cocos2d/cocos2d-x/search?utf8=%E2%9C%93&q=c99&type=Code).
