### PR TITLE
Fix unused parameter warning

### DIFF
--- a/cocos/2d/CCActionCatmullRom.cpp
+++ b/cocos/2d/CCActionCatmullRom.cpp
@@ -57,6 +57,9 @@ PointArray* PointArray::create(ssize_t capacity)
 bool PointArray::initWithCapacity(ssize_t capacity)
 {
     _controlPoints = new (std::nothrow) vector<Vec2*>();
+    if (capacity > 0) {
+        _controlPoints->reserve(capacity);
+    }
     
     return true;
 }


### PR DESCRIPTION
This pull request fixes the following `-Wunused-parameter` warning when compiling with GCC 5.2.1 on Ubuntu 15.10.

```
cocos/2d/CCActionCatmullRom.cpp:57:43: warning: unused parameter ‘capacity’ [-Wunused-parameter]
 bool PointArray::initWithCapacity(ssize_t capacity)
                                           ^
```
