### PR TITLE
TextureCache::addImageAsync : Set pixel format correctly.

### DIFF
--- a/cocos/renderer/CCTextureCache.cpp
+++ b/cocos/renderer/CCTextureCache.cpp
@@ -93,11 +93,12 @@ std::string TextureCache::getDescription() const
 struct TextureCache::AsyncStruct
 {
 public:
-    AsyncStruct(const std::string& fn, std::function<void(Texture2D*)> f) : filename(fn), callback(f), loadSuccess(false) {}
+    AsyncStruct(const std::string& fn, std::function<void(Texture2D*)> f) : filename(fn), callback(f), pixelFormat(Texture2D::getDefaultAlphaPixelFormat()), loadSuccess(false) {}
     
     std::string filename;
     std::function<void(Texture2D*)> callback;
     Image image;
+    Texture2D::PixelFormat pixelFormat;
     bool loadSuccess;
 };
 
@@ -280,7 +281,7 @@ void TextureCache::addImageAsyncCallBack(float dt)
                 // generate texture in render thread
                 texture = new (std::nothrow) Texture2D();
                 
-                texture->initWithImage(image);
+                texture->initWithImage(image, asyncStruct->pixelFormat);
                 //parse 9-patch info
                 this->parseNinePatchImage(image, texture, asyncStruct->filename);
 #if CC_ENABLE_CACHE_TEXTURE_DATA


### PR DESCRIPTION
Above all, please consider the code given below:

> Texture2D::setDefaultAlphaPixelFormat(Texture2D::PixelFormat::RGBA4444);
> Director::getInstance()->getTextureCache()->addImageAsync("HelloWorld.png", [this](Texture2D * texture) {
>     Sprite *sprite = Sprite::createWithTexture(texture);
>     this->addChild(sprite);
> });
> Texture2D::setDefaultAlphaPixelFormat(Texture2D::PixelFormat::RGBA8888);

Obviously, I wanna to create a texture which pixel format is set to RGBA4444, but unfortunately, the code did not work correctly, because in most of the time when the image finish loading, the default pixel format is back to RGBA8888.

An easy and of course non-side-effect way to solve the problem is to store the defaultAlphaPixelFormat in AsyncStruct and use the stored value to create the texture. I do this job in this pull request. Please review and accept it. Thank.
