### PR TITLE
Suppress '-Wundefined-bool-conversion' warnings on Android NDK with Clang

### DIFF
--- a/cocos/deprecated/CCArray.cpp
+++ b/cocos/deprecated/CCArray.cpp
@@ -732,10 +732,16 @@ __Array* __Array::clone() const
     ret->autorelease();
     ret->initWithCapacity(this->data->num > 0 ? this->data->num : 1);
 
+    if (data->num <= 0) {
+        return ret;
+    }
+
     Ref* obj = nullptr;
     Ref* tmpObj = nullptr;
     Clonable* clonable = nullptr;
-    CCARRAY_FOREACH(this, obj)
+    CC_ASSERT(data->num > 0);
+    for (Ref** arr = data->arr, **end = data->arr + data->num - 1;
+        arr <= end && ((obj = *arr) != nullptr); arr++)
     {
         clonable = dynamic_cast<Clonable*>(obj);
         if (clonable)

--- a/cocos/deprecated/CCDictionary.cpp
+++ b/cocos/deprecated/CCDictionary.cpp
@@ -570,7 +570,8 @@ __Dictionary* __Dictionary::clone() const
     Clonable* obj = nullptr;
     if (_dictType == kDictInt)
     {
-        CCDICT_FOREACH(this, element)
+        DictElement* tmp = nullptr;
+        HASH_ITER(hh, _elements, element, tmp)
         {
             obj = dynamic_cast<Clonable*>(element->getObject());
             if (obj)
@@ -589,7 +590,8 @@ __Dictionary* __Dictionary::clone() const
     }
     else if (_dictType == kDictStr)
     {
-        CCDICT_FOREACH(this, element)
+        DictElement* tmp = nullptr;
+        HASH_ITER(hh, _elements, element, tmp)
         {
             obj = dynamic_cast<Clonable*>(element->getObject());
             if (obj)


### PR DESCRIPTION
This patch suppresses compiler warnings due to the use of old `FOREACH` macros with `this` pointer when compiling with Android NDK r10e/Clang. Thanks.

```
cocos/deprecated/CCArray.cpp:738:10: warning: 'this' pointer cannot be null in well-defined C++ code; pointer may be assumed to always convert to true [-Wundefined-bool-conversion]
    if ((this) && (this)->data->num > 0) for(Ref** __arr__ = (this)->data->arr, **__end__ = (this)->data->arr + (this)->data->num-1; __arr__ <= __end__ && (((obj) = *__arr__) != __null ); __arr__++)
         ^~~~  ~~
cocos/deprecated/CCDictionary.cpp:573:53: warning: 'this' pointer cannot be null in well-defined C++ code; pointer may be assumed to always convert to true [-Wundefined-bool-conversion]
        DictElement* pTmpthiselement = nullptr; if (this) for((element)=((this)->_elements),(pTmpthiselement)=(__typeof(element))(((this)->_elements)?((this)->_elements)->hh.next:__null); element; (element)=(pTmpthiselement),(pTmpthiselement)=(__typeof(element))((pTmpthiselement)?(pTmpthiselement)->hh.next:__null))
                                                ~~  ^~~~
cocos/deprecated/CCDictionary.cpp:592:53: warning: 'this' pointer cannot be null in well-defined C++ code; pointer may be assumed to always convert to true [-Wundefined-bool-conversion]
        DictElement* pTmpthiselement = nullptr; if (this) for((element)=((this)->_elements),(pTmpthiselement)=(__typeof(element))(((this)->_elements)?((this)->_elements)->hh.next:__null); element; (element)=(pTmpthiselement),(pTmpthiselement)=(__typeof(element))((pTmpthiselement)?(pTmpthiselement)->hh.next:__null))
                                                ~~  ^~~~
```
