### PR TITLE
Fix scheduler callback target lost issue

### DIFF
--- a/cocos/scripting/js-bindings/manual/cocos2d_specifics.hpp
+++ b/cocos/scripting/js-bindings/manual/cocos2d_specifics.hpp
@@ -148,8 +148,6 @@ public:
     const jsval getJSCallbackFunc() const;
     const jsval getJSCallbackThis() const;
     const jsval getJSExtraData() const;
-    
-    void reset();
 protected:
     JS::Heap<JS::Value> _owner;
     JS::Heap<JS::Value> _jsCallback;


### PR DESCRIPTION
https://github.com/cocos2d/cocos2d-x/pull/15769 wasn't the effective fix, problem is finally solved in this commit.

The core reason is JSScheduleWrapper is released right after unschedule call, then its callback reference is lost. The problem occurs when a frame took longer than schedule interval, then the scheduleFunc will be triggered multiply times, but if it's unscheduled during the first time, the following invocation will crash the game.
