### PR TITLE
Fix unused parameter warning when compiling CCArray

### DIFF
--- a/cocos/deprecated/CCArray.cpp
+++ b/cocos/deprecated/CCArray.cpp
@@ -695,7 +695,7 @@ void __Array::exchangeObjectAtIndex(ssize_t index1, ssize_t index2)
 void __Array::replaceObjectAtIndex(ssize_t index, Ref* object, bool releaseObject/* = true*/)
 {
     ccArrayInsertObjectAtIndex(data, object, index);
-    ccArrayRemoveObjectAtIndex(data, index + 1);
+    ccArrayRemoveObjectAtIndex(data, index + 1, releaseObject);
 }
 
 void __Array::reverseObjects()


### PR DESCRIPTION
This patch fixes the following warning when compiling `__Array` class with GCC 5.2.1 on Ubuntu 15.10:

```
cocos/deprecated/CCArray.cpp:695:69: warning: unused parameter ‘releaseObject’ [-Wunused-parameter]
 void __Array::replaceObjectAtIndex(ssize_t index, Ref* object, bool releaseObject/* = true*/)
                                                                     ^
```

Thanks!
