### PR TITLE
Avoid shadow warning when building with Xcode 7.3

### DIFF
--- a/extensions/assets-manager/AssetsManagerEx.cpp
+++ b/extensions/assets-manager/AssetsManagerEx.cpp
@@ -664,8 +664,8 @@ void AssetsManagerEx::updateSucceed()
     _compressedFiles.clear();
 
     std::function<void(void*)> mainThread = [this](void* param) {
-        AsyncData* asyncData = (AsyncData*)param;
-        if (asyncData->errorCompressedFile.empty())
+        auto asyncDataInner = reinterpret_cast<AsyncData*>(param);
+        if (asyncDataInner->errorCompressedFile.empty())
         {
             // 5. Set update state
             _updateState = State::UP_TO_DATE;
@@ -675,10 +675,10 @@ void AssetsManagerEx::updateSucceed()
         else
         {
             _updateState = State::FAIL_TO_UPDATE;
-            dispatchUpdateEvent(EventAssetsManagerEx::EventCode::ERROR_DECOMPRESS, "", "Unable to decompress file " + asyncData->errorCompressedFile);
+            dispatchUpdateEvent(EventAssetsManagerEx::EventCode::ERROR_DECOMPRESS, "", "Unable to decompress file " + asyncDataInner->errorCompressedFile);
         }
 
-        delete asyncData;
+        delete asyncDataInner;
     };
     AsyncTaskPool::getInstance()->enqueue(AsyncTaskPool::TaskType::TASK_OTHER, mainThread, (void*)asyncData, [this, asyncData]() {
         // Decompress all compressed files


### PR DESCRIPTION
Hello, this PR avoids the following `-Wshadow` warning when compiling AssetsManagerEx with Xcode 7.3:

```
extensions/assets-manager/AssetsManagerEx.cpp:667:20: declaration shadows a local variable [-Wshadow]

        AsyncData* asyncData = (AsyncData*)param;
                      ^
```

So far this is the last patch for fixing minor compiler warnings in `libcocos2d Mac` (except those caused by third party libraries or bindings). :tada:

Thanks for the great work on cocos2d-x!
