### PR TITLE
Add missing default cases within switch block for JS and Lua JavaBridge

### DIFF
--- a/cocos/scripting/js-bindings/manual/platform/android/CCJavascriptJavaBridge.cpp
+++ b/cocos/scripting/js-bindings/manual/platform/android/CCJavascriptJavaBridge.cpp
@@ -83,11 +83,18 @@ bool JavascriptJavaBridge::CallInfo::execute(void)
             break;
 
         case TypeString:
+        {
             m_retjstring = (jstring)m_env->CallStaticObjectMethod(m_classID, m_methodID);
             std::string strValue = cocos2d::StringUtils::getStringUTFCharsJNI(m_env, m_retjstring);
             
             m_ret.stringValue = new string(strValue);
             break;
+        }
+
+        default:
+            m_error = JSJ_ERR_TYPE_NOT_SUPPORT;
+            LOGD("Return type '%d' is not supported", static_cast<int>(m_returnType));
+            return false;
     }
 
     if (m_env->ExceptionCheck() == JNI_TRUE)
@@ -123,10 +130,17 @@ bool JavascriptJavaBridge::CallInfo::executeWithArgs(jvalue *args)
              break;
 
          case TypeString:
+        {
              m_retjstring = (jstring)m_env->CallStaticObjectMethodA(m_classID, m_methodID, args);
              std::string strValue = cocos2d::StringUtils::getStringUTFCharsJNI(m_env, m_retjstring);
              m_ret.stringValue = new string(strValue);
              break;
+        }
+
+        default:
+            m_error = JSJ_ERR_TYPE_NOT_SUPPORT;
+            LOGD("Return type '%d' is not supported", static_cast<int>(m_returnType));
+            return false;
      }
 
     if (m_env->ExceptionCheck() == JNI_TRUE)
@@ -279,6 +293,8 @@ JS::Value JavascriptJavaBridge::convertReturnValue(JSContext *cx, ReturnValue re
 			return BOOLEAN_TO_JSVAL(retValue.boolValue);
 		case TypeString:
 			return c_string_to_jsval(cx, retValue.stringValue->c_str(),retValue.stringValue->size());
+        default:
+            break;
 	}
 
 	return ret;

--- a/cocos/scripting/lua-bindings/manual/platform/android/CCLuaJavaBridge.cpp
+++ b/cocos/scripting/lua-bindings/manual/platform/android/CCLuaJavaBridge.cpp
@@ -40,10 +40,17 @@ bool LuaJavaBridge::CallInfo::execute(void)
             break;
 
         case TypeString:
+        {
             m_retjs = (jstring)m_env->CallStaticObjectMethod(m_classID, m_methodID);
             std::string strValue = cocos2d::StringUtils::getStringUTFCharsJNI(m_env, m_retjs);
             m_ret.stringValue = new string(strValue);
            break;
+        }
+
+        default:
+            m_error = LUAJ_ERR_TYPE_NOT_SUPPORT;
+            LOGD("Return type '%d' is not supported", static_cast<int>(m_returnType));
+            return false;
     }
 
 	if (m_env->ExceptionCheck() == JNI_TRUE)
@@ -79,10 +86,17 @@ bool LuaJavaBridge::CallInfo::executeWithArgs(jvalue *args)
              break;
 
          case TypeString:
+        {
         	 m_retjs = (jstring)m_env->CallStaticObjectMethodA(m_classID, m_methodID, args);
             std::string strValue = cocos2d::StringUtils::getStringUTFCharsJNI(m_env, m_retjs);
             m_ret.stringValue = new string(strValue);
             break;
+        }
+
+        default:
+            m_error = LUAJ_ERR_TYPE_NOT_SUPPORT;
+            LOGD("Return type '%d' is not supported", static_cast<int>(m_returnType));
+            return false;
      }
 
 	if (m_env->ExceptionCheck() == JNI_TRUE)
@@ -118,6 +132,8 @@ int LuaJavaBridge::CallInfo::pushReturnValue(lua_State *L)
 		case TypeString:
 			lua_pushstring(L, m_ret.stringValue->c_str());
 			return 1;
+        default:
+            break;
 	}
 
 	return 0;


### PR DESCRIPTION
I get the following warnings when trying to compile `libjscocos2d` and `libluacocos2d` with Android NDK r10e/Clang:

```
cocos/scripting/js-bindings/proj.android/../manual/platform/android/CCJavascriptJavaBridge.cpp:67:13: warning: enumeration values 'TypeInvalid', 'TypeVector', and 'TypeFunction' not handled in switch [-Wswitch]
     switch (m_returnType)
             ^
cocos/scripting/js-bindings/proj.android/../manual/platform/android/CCJavascriptJavaBridge.cpp:107:13: warning: enumeration values 'TypeInvalid', 'TypeVector', and 'TypeFunction' not handled in switch [-Wswitch]
     switch (m_returnType)
             ^
cocos/scripting/js-bindings/proj.android/../manual/platform/android/CCJavascriptJavaBridge.cpp:272:10: warning: 4 enumeration values not handled in switch: 'TypeInvalid', 'TypeVoid', 'TypeVector'... [-Wswitch]
  switch (type)
          ^
cocos/scripting/lua-bindings/proj.android/../manual/platform/android/CCLuaJavaBridge.cpp:24:10: warning: enumeration values 'TypeInvalid', 'TypeVector', and 'TypeFunction' not handled in switch [-Wswitch]
 switch (m_returnType)
         ^
cocos/scripting/lua-bindings/proj.android/../manual/platform/android/CCLuaJavaBridge.cpp:63:13: warning: enumeration values 'TypeInvalid', 'TypeVector', and 'TypeFunction' not handled in switch [-Wswitch]
    switch (m_returnType)
            ^
cocos/scripting/lua-bindings/proj.android/../manual/platform/android/CCLuaJavaBridge.cpp:107:10: warning: 4 enumeration values not handled in switch: 'TypeInvalid', 'TypeVoid', 'TypeVector'... [-Wswitch]
 switch (m_returnType)
         ^
```

This PR adds several missing default cases to fix the warnings. Thanks.
