### PR TITLE
Fix typo in method name: 'destory' -> 'destroy'

### DIFF
--- a/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxLocalStorage.java
+++ b/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxLocalStorage.java
@@ -56,7 +56,7 @@ public class Cocos2dxLocalStorage {
         return false;
     }
     
-    public static void destory() {
+    public static void destroy() {
         if (mDatabase != null) {
             mDatabase.close();
         }

--- a/cocos/storage/local-storage/LocalStorage-android.cpp
+++ b/cocos/storage/local-storage/LocalStorage-android.cpp
@@ -72,7 +72,7 @@ void localStorageInit( const std::string& fullpath)
 void localStorageFree()
 {
     if (_initialized) {
-        JniHelper::callStaticVoidMethod(className, "destory");
+        JniHelper::callStaticVoidMethod(className, "destroy");
         _initialized = 0;
     }
 }


### PR DESCRIPTION
There is a typo in method name, `destory` should be `destroy` in LocalStorage for Android. And so this patch fixes it.

Thanks.
