### PR TITLE
Fixed ClippingNode not cleaning up _stencil correctly

### DIFF
--- a/cocos/2d/CCClippingNode.cpp
+++ b/cocos/2d/CCClippingNode.cpp
@@ -303,9 +303,16 @@ void ClippingNode::setStencil(Node *stencil)
             sEngine->retainScriptObject(this, stencil);
     }
 #endif // CC_ENABLE_GC_FOR_NATIVE_OBJECTS
-    CC_SAFE_RETAIN(stencil);
+
+    if(_stencil != nullptr && _stencil->isRunning())
+    {
+        _stencil->onExitTransitionDidStart();
+        _stencil->onExit();
+    }
+    
     CC_SAFE_RELEASE(_stencil);
     _stencil = stencil;
+    CC_SAFE_RETAIN(_stencil);
 }
 
 bool ClippingNode::hasContent() const

--- a/cocos/2d/CCClippingNode.cpp
+++ b/cocos/2d/CCClippingNode.cpp
@@ -290,6 +290,7 @@ Node* ClippingNode::getStencil() const
 
 void ClippingNode::setStencil(Node *stencil)
 {
+    //early out if the stencil is already set
     if (_stencil == stencil)
         return;
     
@@ -303,16 +304,26 @@ void ClippingNode::setStencil(Node *stencil)
             sEngine->retainScriptObject(this, stencil);
     }
 #endif // CC_ENABLE_GC_FOR_NATIVE_OBJECTS
-
+    
+    //cleanup current stencil
     if(_stencil != nullptr && _stencil->isRunning())
     {
         _stencil->onExitTransitionDidStart();
         _stencil->onExit();
     }
+    CC_SAFE_RELEASE_NULL(_stencil);
     
-    CC_SAFE_RELEASE(_stencil);
+    //initialise new stencil
     _stencil = stencil;
     CC_SAFE_RETAIN(_stencil);
+    if(_stencil != nullptr && this->isRunning())
+    {
+        _stencil->onEnter();
+        if(this->_isTransitionFinished)
+        {
+            _stencil->onEnterTransitionDidFinish();
+        }
+    }
 }
 
 bool ClippingNode::hasContent() const


### PR DESCRIPTION
_stencil may be running due to onEnter() called by ClippingNode. If onExit() is not called then Node::~Node() will assert when _stencil is released.
