### PR TITLE
Fixed to fail FileUtils::writeValueMapToFile on iOS.

### DIFF
--- a/cocos/platform/CCFileUtils.cpp
+++ b/cocos/platform/CCFileUtils.cpp
@@ -1268,4 +1268,12 @@ std::string FileUtils::getFileExtension(const std::string& filePath) const
     return fileExtension;
 }
 
+void FileUtils::valueMapCompact(ValueMap& valueMap)
+{
+}
+
+void FileUtils::valueVectorCompact(ValueVector& valueVector)
+{
+}
+
 NS_CC_END

--- a/cocos/platform/CCFileUtils.h
+++ b/cocos/platform/CCFileUtils.h
@@ -728,6 +728,11 @@ protected:
      */
     static FileUtils* s_sharedFileUtils;
 
+    /**
+     *  Remove null value key (for iOS)
+     */
+    virtual void valueMapCompact(ValueMap& valueMap);
+    virtual void valueVectorCompact(ValueVector& valueVector);
 };
 
 // end of support group

--- a/cocos/platform/apple/CCFileUtils-apple.h
+++ b/cocos/platform/apple/CCFileUtils-apple.h
@@ -64,6 +64,8 @@ public:
 private:
     virtual bool isFileExistInternal(const std::string& filePath) const override;
     virtual bool removeDirectory(const std::string& dirPath) override;
+    virtual void valueMapCompact(ValueMap& valueMap) override;
+    virtual void valueVectorCompact(ValueVector& valueVector) override;
 
     struct IMPL;
     std::unique_ptr<IMPL> pimpl_;

--- a/cocos/platform/apple/CCFileUtils-apple.mm
+++ b/cocos/platform/apple/CCFileUtils-apple.mm
@@ -367,7 +367,7 @@ bool FileUtilsApple::writeToFile(const ValueMap& dict, const std::string &fullPa
 
 bool FileUtils::writeValueMapToFile(const ValueMap& dict, const std::string& fullPath)
 {
-
+    valueMapCompact(const_cast<ValueMap&>(dict));
     //CCLOG("iOS||Mac Dictionary %d write to file %s", dict->_ID, fullPath.c_str());
     NSMutableDictionary *nsDict = [NSMutableDictionary dictionary];
 
@@ -378,9 +378,59 @@ bool FileUtils::writeValueMapToFile(const ValueMap& dict, const std::string& ful
 
     NSString *file = [NSString stringWithUTF8String:fullPath.c_str()];
     // do it atomically
-    [nsDict writeToFile:file atomically:YES];
+    return [nsDict writeToFile:file atomically:YES];
+}
 
-    return true;
+void FileUtilsApple::valueMapCompact(ValueMap& valueMap)
+{
+    auto itr = valueMap.begin();
+    while(itr != valueMap.end()){
+        auto vtype = itr->second.getType();
+        switch(vtype){
+            case Value::Type::NONE:{
+                itr = valueMap.erase(itr);
+                continue;
+            }
+                break;
+            case Value::Type::MAP:{
+                valueMapCompact(itr->second.asValueMap());
+            }
+                break;
+            case Value::Type::VECTOR:{
+                valueVectorCompact(itr->second.asValueVector());
+            }
+                break;
+            default:
+                break;
+        }
+        itr++;
+    }
+}
+
+void FileUtilsApple::valueVectorCompact(ValueVector& valueVector)
+{
+    auto itr = valueVector.begin();
+    while(itr != valueVector.end()){
+        auto vtype = (*itr).getType();
+        switch(vtype){
+            case Value::Type::NONE:{
+                itr = valueVector.erase(itr);
+                continue;
+            }
+                break;
+            case Value::Type::MAP:{
+                valueMapCompact((*itr).asValueMap());
+            }
+                break;
+            case Value::Type::VECTOR:{
+                valueVectorCompact((*itr).asValueVector());
+            }
+                break;
+            default:
+                break;
+        }
+        itr++;
+    }
 }
 
 bool FileUtils::writeValueVectorToFile(const ValueVector& vecData, const std::string& fullPath)

--- a/tests/cpp-tests/Classes/FileUtilsTest/FileUtilsTest.cpp
+++ b/tests/cpp-tests/Classes/FileUtilsTest/FileUtilsTest.cpp
@@ -795,6 +795,8 @@ void TestWriteValueMap::onEnter()
     ValueMap mapInValueMap;
     mapInValueMap["string1"] = "string in dictInMap key 0";
     mapInValueMap["string2"] = "string in dictInMap key 1";
+    mapInValueMap["none"].getType();
+    
     valueMap["data0"] = Value(mapInValueMap);
 
     valueMap["data1"] = Value("string in array");


### PR DESCRIPTION
Hi.
I found a bug that FileUtils::writeValueMapToFile fail on iOS, because NSDict writeToFile cannot accept null.
So this patch remove null data key from the ValueMap.
