### PR TITLE
CCFontFreeType : Changed the type of parameter 'outline' from int to float.

### DIFF
--- a/cocos/2d/CCFontFreeType.cpp
+++ b/cocos/2d/CCFontFreeType.cpp
@@ -49,7 +49,7 @@ typedef struct _DataRef
 
 static std::unordered_map<std::string, DataRef> s_cacheFontData;
 
-FontFreeType * FontFreeType::create(const std::string &fontName, float fontSize, GlyphCollection glyphs, const char *customGlyphs,bool distanceFieldEnabled /* = false */,int outline /* = 0 */)
+FontFreeType * FontFreeType::create(const std::string &fontName, float fontSize, GlyphCollection glyphs, const char *customGlyphs,bool distanceFieldEnabled /* = false */, float outline /* = 0 */)
 {
     FontFreeType *tempFont =  new FontFreeType(distanceFieldEnabled,outline);
 
@@ -96,7 +96,7 @@ FT_Library FontFreeType::getFTLibrary()
     return _FTlibrary;
 }
 
-FontFreeType::FontFreeType(bool distanceFieldEnabled /* = false */,int outline /* = 0 */)
+FontFreeType::FontFreeType(bool distanceFieldEnabled /* = false */, float outline /* = 0 */)
 : _fontRef(nullptr)
 , _stroker(nullptr)
 , _distanceFieldEnabled(distanceFieldEnabled)

--- a/cocos/2d/CCFontFreeType.h
+++ b/cocos/2d/CCFontFreeType.h
@@ -54,7 +54,7 @@ public:
     static const int DistanceMapSpread;
 
     static FontFreeType* create(const std::string &fontName, float fontSize, GlyphCollection glyphs,
-        const char *customGlyphs,bool distanceFieldEnabled = false,int outline = 0);
+        const char *customGlyphs,bool distanceFieldEnabled = false, float outline = 0);
 
     static void shutdownFreeType();
 
@@ -84,7 +84,7 @@ private:
     static FT_Library _FTlibrary;
     static bool _FTInitialized;
 
-    FontFreeType(bool distanceFieldEnabled = false, int outline = 0);
+    FontFreeType(bool distanceFieldEnabled = false, float outline = 0);
     virtual ~FontFreeType();
 
     bool createFontObject(const std::string &fontName, float fontSize);

--- a/cocos/2d/CCLabel.cpp
+++ b/cocos/2d/CCLabel.cpp
@@ -1032,7 +1032,7 @@ void Label::enableGlow(const Color4B& glowColor)
     }
 }
 
-void Label::enableOutline(const Color4B& outlineColor,int outlineSize /* = -1 */)
+void Label::enableOutline(const Color4B& outlineColor, float outlineSize /* = -1 */)
 {
     CCASSERT(_currentLabelType == LabelType::STRING_TEXTURE || _currentLabelType == LabelType::TTF, "Only supported system font and TTF!");
 

--- a/cocos/2d/CCLabel.h
+++ b/cocos/2d/CCLabel.h
@@ -53,7 +53,7 @@ typedef struct _ttfConfig
     const char *customGlyphs;
 
     bool distanceFieldEnabled;
-    int outlineSize;
+    float outlineSize;
 
     bool italics;
     bool bold;
@@ -61,7 +61,7 @@ typedef struct _ttfConfig
     bool strikethrough;
 
     _ttfConfig(const std::string& filePath = "",float size = 12, const GlyphCollection& glyphCollection = GlyphCollection::DYNAMIC,
-        const char *customGlyphCollection = nullptr, bool useDistanceField = false, int outline = 0,
+        const char *customGlyphCollection = nullptr, bool useDistanceField = false, float outline = 0.f,
                bool useItalics = false, bool useBold = false, bool useUnderline = false, bool useStrikethrough = false)
         : fontFilePath(filePath)
         , fontSize(size)
@@ -345,7 +345,7 @@ public:
      * Enable outline effect to Label.
      * @warning Limiting use to only when the Label created with true type font or system font.
      */
-    virtual void enableOutline(const Color4B& outlineColor,int outlineSize = -1);
+    virtual void enableOutline(const Color4B& outlineColor, float outlineSize = -1);
 
     /**
     * Enable glow effect to Label.


### PR DESCRIPTION
I found that 'outline' parameter is `int` type in CCFontFreeType.
The private value for 'outline' is `float`, so I think that there is no reason to limit the type as `int`.
Is there any reason to keep the parameter type as `int`?

p.s.) I didn't modify `int` 'outline' for codes related to ui::Widgets as I worried a side-effect.
