### PR TITLE
Fix assertion failure when running Sprite Test

### DIFF
--- a/tests/cpp-tests/Classes/SpriteTest/SpriteTest.cpp
+++ b/tests/cpp-tests/Classes/SpriteTest/SpriteTest.cpp
@@ -3685,6 +3685,14 @@ AnimationCacheTest::AnimationCacheTest()
     grossini->runAction(seq);
 }
 
+AnimationCacheTest::~AnimationCacheTest()
+{
+    auto frameCache = SpriteFrameCache::getInstance();
+    frameCache->removeSpriteFramesFromFile("animations/grossini.plist");
+    frameCache->removeSpriteFramesFromFile("animations/grossini_gray.plist");
+    frameCache->removeSpriteFramesFromFile("animations/grossini_blue.plist");
+}
+
 std::string AnimationCacheTest::title() const
 {
     return "AnimationCache";
@@ -3743,6 +3751,14 @@ AnimationCacheFile::AnimationCacheFile()
 
     // run the animation
     grossini->runAction(seq);
+}
+
+AnimationCacheFile::~AnimationCacheFile()
+{
+    auto frameCache = SpriteFrameCache::getInstance();
+    frameCache->removeSpriteFramesFromFile("animations/grossini.plist");
+    frameCache->removeSpriteFramesFromFile("animations/grossini_gray.plist");
+    frameCache->removeSpriteFramesFromFile("animations/grossini_blue.plist");
 }
 
 std::string AnimationCacheFile::title() const

--- a/tests/cpp-tests/Classes/SpriteTest/SpriteTest.h
+++ b/tests/cpp-tests/Classes/SpriteTest/SpriteTest.h
@@ -630,6 +630,7 @@ class AnimationCacheTest : public SpriteTestDemo
 public:
     CREATE_FUNC(AnimationCacheTest);
     AnimationCacheTest();
+    virtual ~AnimationCacheTest();
     virtual std::string title() const override;
     virtual std::string subtitle() const override;
 };
@@ -739,6 +740,7 @@ public:
     CREATE_FUNC(AnimationCacheFile);
 
     AnimationCacheFile();
+    virtual ~AnimationCacheFile();
     virtual std::string title() const override;
     virtual std::string subtitle() const override;
 };


### PR DESCRIPTION
When running `SpriteTests` in `cpp-tests`, I always get an error at the following assert.

```
Sprite* Sprite::createWithSpriteFrameName(const std::string& spriteFrameName)
{
    SpriteFrame *frame = SpriteFrameCache::getInstance()->getSpriteFrameByName(spriteFrameName);

#if COCOS2D_DEBUG > 0
    char msg[256] = {0};
    sprintf(msg, "Invalid spriteFrameName: %s", spriteFrameName.c_str());
    CCASSERT(frame != nullptr, msg);
#endif
```

**Version:**
- Cocos2d-x v3.11.1 (latest version)

**Steps to Reproduce:**

1) Build and run `cpp-tests` in debug mode
2) Open 'Node: Sprite' > '64:AnimationCache - Load file' (`AnimationCacheTest`)

``` cpp
// at case 64, `AnimationCacheTest::AnimationCacheTest()`
auto frameCache = SpriteFrameCache::getInstance();
frameCache->addSpriteFramesWithFile("animations/grossini.plist");
```

3) Switch to the test case '5:Testing SpriteFrame' (`SpriteAnchorPointFromFile`)

``` cpp
// at case 5, `SpriteAnchorPointFromFile::onExit()`
frameCache->removeSpriteFramesFromFile("animations/grossini_anchors.plist");
```

4) Run the next case '6:Testing Sprite' (`SpriteOffsetAnchorRotation`), then crash

``` cpp
// at case 6, `SpriteOffsetAnchorRotation::onEnter()`
frameCache->addSpriteFramesWithFile("animations/grossini.plist");

// assert failed
auto sprite = Sprite::createWithSpriteFrameName("grossini_dance_01.png");
```

**Result:**

```
Assert failed: Invalid spriteFrameName: grossini_dance_01.png
Assertion failed: (frame != nullptr), function createWithSpriteFrameName, file cocos/2d/CCSprite.cpp, line 127.
```

This PR adds missing `SpriteFrameCache::removeSpriteFrameCache()` calls to fix assert failure.
Thank you for considering this. :)
