### PR TITLE
Add a config option to enable or disable the premultiplied alpha code.

### DIFF
--- a/cocos/base/ccConfig.h
+++ b/cocos/base/ccConfig.h
@@ -397,4 +397,12 @@ THE SOFTWARE.
 #define CC_FILEUTILS_APPLE_ENABLE_OBJC  1
 #endif
 
+/** @def CC_ENABLE_PREMULTIPLIED_ALPHA
+ * If enabled, all textures will be preprocessed to multiply its rgb components
+ * by its alpha component.
+ */
+#ifndef CC_ENABLE_PREMULTIPLIED_ALPHA
+# define CC_ENABLE_PREMULTIPLIED_ALPHA 1
+#endif
+
 #endif // __CCCONFIG_H__

--- a/cocos/platform/CCImage.cpp
+++ b/cocos/platform/CCImage.cpp
@@ -2451,6 +2451,10 @@ bool Image::saveImageToJPG(const std::string& filePath)
 
 void Image::premultipliedAlpha()
 {
+#if CC_ENABLE_PREMULTIPLIED_ALPHA == 0
+        _hasPremultipliedAlpha = false;
+        return;
+#else
     CCASSERT(_renderFormat == Texture2D::PixelFormat::RGBA8888, "The pixel format should be RGBA8888!");
     
     unsigned int* fourBytes = (unsigned int*)_data;
@@ -2461,6 +2465,7 @@ void Image::premultipliedAlpha()
     }
     
     _hasPremultipliedAlpha = true;
+#endif
 }
 
 


### PR DESCRIPTION
Computing premultiplied alpha when loading an image is expensive and can be ignored in some situations. This commit adds a config option to enable or disable the premultiplied alpha code (default is to enable) so the developer can choose the option most suitable for him.
