### PR TITLE
Move StringUtils functions from deprecated header file to ccUTF8.h

### DIFF
--- a/cocos/2d/CCAction.cpp
+++ b/cocos/2d/CCAction.cpp
@@ -29,7 +29,7 @@ THE SOFTWARE.
 #include "2d/CCActionInterval.h"
 #include "2d/CCNode.h"
 #include "base/CCDirector.h"
-#include "deprecated/CCString.h"
+#include "base/ccUTF8.h"
 
 NS_CC_BEGIN
 //

--- a/cocos/2d/CCFastTMXLayer.cpp
+++ b/cocos/2d/CCFastTMXLayer.cpp
@@ -44,7 +44,7 @@ THE SOFTWARE.
 #include "renderer/CCRenderer.h"
 #include "renderer/CCVertexIndexBuffer.h"
 #include "base/CCDirector.h"
-#include "deprecated/CCString.h"
+#include "base/ccUTF8.h"
 
 NS_CC_BEGIN
 namespace experimental {

--- a/cocos/2d/CCFastTMXTiledMap.cpp
+++ b/cocos/2d/CCFastTMXTiledMap.cpp
@@ -26,7 +26,7 @@ THE SOFTWARE.
 ****************************************************************************/
 #include "2d/CCFastTMXTiledMap.h"
 #include "2d/CCFastTMXLayer.h"
-#include "deprecated/CCString.h"
+#include "base/ccUTF8.h"
 
 NS_CC_BEGIN
 namespace experimental {

--- a/cocos/2d/CCFontFNT.cpp
+++ b/cocos/2d/CCFontFNT.cpp
@@ -31,9 +31,8 @@
 #include "base/CCConfiguration.h"
 #include "base/CCDirector.h"
 #include "base/CCMap.h"
+#include "base/ccUTF8.h"
 #include "renderer/CCTextureCache.h"
-
-#include "deprecated/CCString.h"
 
 using namespace std;
 NS_CC_BEGIN

--- a/cocos/2d/CCLabelAtlas.cpp
+++ b/cocos/2d/CCLabelAtlas.cpp
@@ -28,9 +28,8 @@ THE SOFTWARE.
 #include "renderer/CCTextureAtlas.h"
 #include "platform/CCFileUtils.h"
 #include "base/CCDirector.h"
+#include "base/ccUTF8.h"
 #include "renderer/CCTextureCache.h"
-
-#include "deprecated/CCString.h"
 
 #if CC_LABELATLAS_DEBUG_DRAW
 #include "renderer/CCRenderer.h"

--- a/cocos/2d/CCLabelBMFont.cpp
+++ b/cocos/2d/CCLabelBMFont.cpp
@@ -32,7 +32,7 @@ http://www.angelcode.com/products/bmfont/ (Free, Windows only)
 
 ****************************************************************************/
 #include "2d/CCLabelBMFont.h"
-#include "deprecated/CCString.h"
+#include "base/ccUTF8.h"
 #include "2d/CCSprite.h"
 
 #if CC_LABELBMFONT_DEBUG_DRAW

--- a/cocos/2d/CCLabelTTF.cpp
+++ b/cocos/2d/CCLabelTTF.cpp
@@ -25,7 +25,7 @@ THE SOFTWARE.
 ****************************************************************************/
 #include "2d/CCLabelTTF.h"
 #include "2d/CCLabel.h"
-#include "deprecated/CCString.h"
+#include "base/ccUTF8.h"
 
 NS_CC_BEGIN
 

--- a/cocos/2d/CCLayer.cpp
+++ b/cocos/2d/CCLayer.cpp
@@ -40,9 +40,7 @@ THE SOFTWARE.
 #include "base/CCEventListenerKeyboard.h"
 #include "base/CCEventAcceleration.h"
 #include "base/CCEventListenerAcceleration.h"
-
-
-#include "deprecated/CCString.h"
+#include "base/ccUTF8.h"
 
 NS_CC_BEGIN
 

--- a/cocos/2d/CCMenu.cpp
+++ b/cocos/2d/CCMenu.cpp
@@ -29,8 +29,8 @@ THE SOFTWARE.
 #include "base/CCTouch.h"
 #include "base/CCEventListenerTouch.h"
 #include "base/CCEventDispatcher.h"
+#include "base/ccUTF8.h"
 #include "platform/CCStdC.h"
-#include "deprecated/CCString.h"
 
 #include <vector>
 

--- a/cocos/2d/CCMenuItem.cpp
+++ b/cocos/2d/CCMenuItem.cpp
@@ -30,7 +30,7 @@ THE SOFTWARE.
 #include "2d/CCSprite.h"
 #include "2d/CCLabelAtlas.h"
 #include "2d/CCLabel.h"
-#include "deprecated/CCString.h"
+#include "base/ccUTF8.h"
 #include <stdarg.h>
 
 NS_CC_BEGIN

--- a/cocos/2d/CCNode.cpp
+++ b/cocos/2d/CCNode.cpp
@@ -35,6 +35,7 @@ THE SOFTWARE.
 #include "base/CCDirector.h"
 #include "base/CCScheduler.h"
 #include "base/CCEventDispatcher.h"
+#include "base/ccUTF8.h"
 #include "2d/CCCamera.h"
 #include "2d/CCActionManager.h"
 #include "2d/CCScene.h"
@@ -43,7 +44,6 @@ THE SOFTWARE.
 #include "renderer/CCGLProgramState.h"
 #include "renderer/CCMaterial.h"
 #include "math/TransformUtils.h"
-#include "deprecated/CCString.h"
 
 
 #if CC_NODE_RENDER_SUBPIXEL

--- a/cocos/2d/CCParticleBatchNode.cpp
+++ b/cocos/2d/CCParticleBatchNode.cpp
@@ -36,7 +36,7 @@
 #include "renderer/CCRenderer.h"
 #include "renderer/CCTextureAtlas.h"
 #include "base/CCProfiling.h"
-#include "deprecated/CCString.h"
+#include "base/ccUTF8.h"
 
 NS_CC_BEGIN
 

--- a/cocos/2d/CCParticleSystem.cpp
+++ b/cocos/2d/CCParticleSystem.cpp
@@ -52,8 +52,8 @@ THE SOFTWARE.
 #include "base/ZipUtils.h"
 #include "base/CCDirector.h"
 #include "base/CCProfiling.h"
+#include "base/ccUTF8.h"
 #include "renderer/CCTextureCache.h"
-#include "deprecated/CCString.h"
 #include "platform/CCFileUtils.h"
 
 using namespace std;

--- a/cocos/2d/CCParticleSystemQuad.cpp
+++ b/cocos/2d/CCParticleSystemQuad.cpp
@@ -41,8 +41,7 @@ THE SOFTWARE.
 #include "base/CCConfiguration.h"
 #include "base/CCEventListenerCustom.h"
 #include "base/CCEventDispatcher.h"
-
-#include "deprecated/CCString.h"
+#include "base/ccUTF8.h"
 
 NS_CC_BEGIN
 

--- a/cocos/2d/CCScene.cpp
+++ b/cocos/2d/CCScene.cpp
@@ -30,9 +30,9 @@ THE SOFTWARE.
 #include "2d/CCCamera.h"
 #include "base/CCEventDispatcher.h"
 #include "base/CCEventListenerCustom.h"
+#include "base/ccUTF8.h"
 #include "renderer/CCRenderer.h"
 #include "renderer/CCFrameBuffer.h"
-#include "deprecated/CCString.h"
 
 #if CC_USE_PHYSICS
 #include "physics/CCPhysicsWorld.h"

--- a/cocos/2d/CCSprite.cpp
+++ b/cocos/2d/CCSprite.cpp
@@ -37,10 +37,8 @@ THE SOFTWARE.
 #include "renderer/CCTexture2D.h"
 #include "renderer/CCRenderer.h"
 #include "base/CCDirector.h"
+#include "base/ccUTF8.h"
 #include "2d/CCCamera.h"
-
-#include "deprecated/CCString.h"
-
 
 NS_CC_BEGIN
 

--- a/cocos/2d/CCSpriteBatchNode.cpp
+++ b/cocos/2d/CCSpriteBatchNode.cpp
@@ -30,12 +30,10 @@ THE SOFTWARE.
 #include "2d/CCSprite.h"
 #include "base/CCDirector.h"
 #include "base/CCProfiling.h"
+#include "base/ccUTF8.h"
 #include "renderer/CCTextureCache.h"
 #include "renderer/CCRenderer.h"
 #include "renderer/CCQuadCommand.h"
-
-#include "deprecated/CCString.h" // For StringUtils::format
-
 
 NS_CC_BEGIN
 

--- a/cocos/2d/CCSpriteFrameCache.cpp
+++ b/cocos/2d/CCSpriteFrameCache.cpp
@@ -37,13 +37,11 @@ THE SOFTWARE.
 #include "platform/CCFileUtils.h"
 #include "base/CCNS.h"
 #include "base/ccMacros.h"
+#include "base/ccUTF8.h"
 #include "base/CCDirector.h"
 #include "renderer/CCTexture2D.h"
 #include "renderer/CCTextureCache.h"
 #include "base/CCNinePatchImageParser.h"
-
-#include "deprecated/CCString.h"
-
 
 using namespace std;
 

--- a/cocos/2d/CCTMXLayer.cpp
+++ b/cocos/2d/CCTMXLayer.cpp
@@ -29,9 +29,9 @@ THE SOFTWARE.
 #include "2d/CCTMXTiledMap.h"
 #include "2d/CCSprite.h"
 #include "base/CCDirector.h"
+#include "base/ccUTF8.h"
 #include "renderer/CCTextureCache.h"
 #include "renderer/CCGLProgram.h"
-#include "deprecated/CCString.h" // For StringUtils::format
 
 NS_CC_BEGIN
 

--- a/cocos/2d/CCTMXTiledMap.cpp
+++ b/cocos/2d/CCTMXTiledMap.cpp
@@ -28,7 +28,7 @@ THE SOFTWARE.
 #include "2d/CCTMXXMLParser.h"
 #include "2d/CCTMXLayer.h"
 #include "2d/CCSprite.h"
-#include "deprecated/CCString.h" // For StringUtils::format
+#include "base/ccUTF8.h"
 
 NS_CC_BEGIN
 

--- a/cocos/2d/CCTileMapAtlas.cpp
+++ b/cocos/2d/CCTileMapAtlas.cpp
@@ -29,8 +29,7 @@ THE SOFTWARE.
 #include "renderer/CCTextureAtlas.h"
 #include "base/TGAlib.h"
 #include "base/CCDirector.h"
-#include "deprecated/CCString.h"
-
+#include "base/ccUTF8.h"
 
 NS_CC_BEGIN
 

--- a/cocos/3d/CCSprite3D.cpp
+++ b/cocos/3d/CCSprite3D.cpp
@@ -32,6 +32,7 @@
 
 #include "base/CCDirector.h"
 #include "base/CCAsyncTaskPool.h"
+#include "base/ccUTF8.h"
 #include "2d/CCLight.h"
 #include "2d/CCCamera.h"
 #include "base/ccMacros.h"
@@ -44,8 +45,6 @@
 #include "renderer/CCMaterial.h"
 #include "renderer/CCTechnique.h"
 #include "renderer/CCPass.h"
-
-#include "deprecated/CCString.h" // For StringUtils::format
 
 NS_CC_BEGIN
 

--- a/cocos/base/CCProperties.cpp
+++ b/cocos/base/CCProperties.cpp
@@ -32,8 +32,6 @@
 #include "math/Mat4.h"
 #include "base/ccUTF8.h"
 #include "base/CCData.h"
-#include "deprecated/CCString.h"
-
 
 USING_NS_CC;
 

--- a/cocos/base/ccUTF8.cpp
+++ b/cocos/base/ccUTF8.cpp
@@ -32,6 +32,27 @@ NS_CC_BEGIN
 
 namespace StringUtils {
 
+std::string format(const char* format, ...)
+{
+#define CC_MAX_STRING_LENGTH (1024*100)
+    
+    std::string ret;
+    
+    va_list ap;
+    va_start(ap, format);
+    
+    char* buf = (char*)malloc(CC_MAX_STRING_LENGTH);
+    if (buf != nullptr)
+    {
+        vsnprintf(buf, CC_MAX_STRING_LENGTH, format, ap);
+        ret = buf;
+        free(buf);
+    }
+    va_end(ap);
+    
+    return ret;
+}
+
 /*
  * @str:    the string to search through.
  * @c:        the character to not look for.

--- a/cocos/base/ccUTF8.h
+++ b/cocos/base/ccUTF8.h
@@ -29,6 +29,7 @@
 #include "platform/CCPlatformMacros.h"
 #include <vector>
 #include <string>
+#include <sstream>
 
 #if (CC_TARGET_PLATFORM == CC_PLATFORM_ANDROID) 
 #include "platform/android/jni/JniHelper.h"
@@ -37,6 +38,16 @@
 NS_CC_BEGIN
 
 namespace StringUtils {
+
+template<typename T>
+std::string toString(T arg)
+{
+    std::stringstream ss;
+    ss << arg;
+    return ss.str();
+}
+
+std::string CC_DLL format(const char* format, ...) CC_FORMAT_PRINTF(1, 2);
 
 /**
  *  @brief Converts from UTF8 string to UTF16 string.

--- a/cocos/deprecated/CCArray.cpp
+++ b/cocos/deprecated/CCArray.cpp
@@ -26,6 +26,7 @@ THE SOFTWARE.
 
 #include "deprecated/CCArray.h"
 #include "deprecated/CCString.h"
+#include "base/ccUTF8.h"
 #include "platform/CCFileUtils.h"
 
 NS_CC_BEGIN

--- a/cocos/deprecated/CCDictionary.cpp
+++ b/cocos/deprecated/CCDictionary.cpp
@@ -25,6 +25,7 @@
 
 #include "deprecated/CCDictionary.h"
 #include <type_traits>
+#include "base/ccUTF8.h"
 #include "platform/CCFileUtils.h"
 #include "deprecated/CCString.h"
 #include "deprecated/CCBool.h"

--- a/cocos/deprecated/CCString.cpp
+++ b/cocos/deprecated/CCString.cpp
@@ -272,30 +272,5 @@ __String* __String::clone() const
 {
     return __String::create(_string);
 }
-
-namespace StringUtils {
-
-std::string format(const char* format, ...)
-{
-#define CC_MAX_STRING_LENGTH (1024*100)
-    
-    std::string ret;
-    
-    va_list ap;
-    va_start(ap, format);
-    
-    char* buf = (char*)malloc(CC_MAX_STRING_LENGTH);
-    if (buf != nullptr)
-    {
-        vsnprintf(buf, CC_MAX_STRING_LENGTH, format, ap);
-        ret = buf;
-        free(buf);
-    }
-    va_end(ap);
-    
-    return ret;
-}
-
-} // namespace StringUtils {
     
 NS_CC_END

--- a/cocos/deprecated/CCString.h
+++ b/cocos/deprecated/CCString.h
@@ -34,9 +34,12 @@ THE SOFTWARE.
 #include <stdarg.h>
 #include <string>
 #include <functional>
-#include <sstream>
 #include "deprecated/CCArray.h"
 #include "base/CCRef.h"
+
+// We need to include `StringUtils::format()` and `StringUtils::toString()`
+// for keeping the backward compatibility
+#include "base/ccUTF8.h"
 
 NS_CC_BEGIN
 
@@ -206,20 +209,6 @@ struct StringCompare : public std::binary_function<__String *, __String *, bool>
 
 #define StringMake(str) String::create(str)
 #define ccs             StringMake
-
-namespace StringUtils {
-
-template<typename T>
-std::string toString(T arg)
-{
-    std::stringstream ss;
-    ss << arg;
-    return ss.str();
-}
-
-std::string CC_DLL format(const char* format, ...) CC_FORMAT_PRINTF(1, 2);
-    
-} // namespace StringUtils {
 
 // end of data_structure group
 /// @}

--- a/cocos/editor-support/cocostudio/ActionTimeline/CSLoader.cpp
+++ b/cocos/editor-support/cocostudio/ActionTimeline/CSLoader.cpp
@@ -26,12 +26,12 @@
 
 #include "base/ObjectFactory.h"
 #include "base/CCDirector.h"
+#include "base/ccUTF8.h"
 #include "ui/CocosGUI.h"
 #include "2d/CCSpriteFrameCache.h"
 #include "2d/CCParticleSystemQuad.h"
 #include "2d/CCTMXTiledMap.h"
 #include "platform/CCFileUtils.h"
-#include "deprecated/CCString.h"
 
 #include "editor-support/cocostudio/ActionTimeline/CCActionTimelineCache.h"
 #include "editor-support/cocostudio/ActionTimeline/CCActionTimeline.h"

--- a/cocos/network/CCDownloader-apple.mm
+++ b/cocos/network/CCDownloader-apple.mm
@@ -25,7 +25,7 @@
 #include "network/CCDownloader-apple.h"
 
 #include "network/CCDownloader.h"
-#include "deprecated/CCString.h"
+#include "base/ccUTF8.h"
 #include <queue>
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cocos/platform/android/jni/Java_org_cocos2dx_lib_Cocos2dxHelper.cpp
+++ b/cocos/platform/android/jni/Java_org_cocos2dx_lib_Cocos2dxHelper.cpp
@@ -29,7 +29,6 @@ THE SOFTWARE.
 #include "platform/android/jni/JniHelper.h"
 #include "platform/android/CCFileUtils-android.h"
 #include "android/asset_manager_jni.h"
-#include "deprecated/CCString.h"
 #include "platform/android/jni/Java_org_cocos2dx_lib_Cocos2dxHelper.h"
 
 #include "base/ccUTF8.h"

--- a/cocos/platform/apple/CCFileUtils-apple.mm
+++ b/cocos/platform/apple/CCFileUtils-apple.mm
@@ -33,7 +33,6 @@ THE SOFTWARE.
 #include <stack>
 
 #include "base/CCDirector.h"
-#include "deprecated/CCString.h"
 #include "deprecated/CCDictionary.h"
 #include "platform/CCFileUtils.h"
 #include "platform/CCSAXParser.h"

--- a/cocos/platform/desktop/CCGLViewImpl-desktop.cpp
+++ b/cocos/platform/desktop/CCGLViewImpl-desktop.cpp
@@ -37,7 +37,6 @@ THE SOFTWARE.
 #include "base/ccUtils.h"
 #include "base/ccUTF8.h"
 #include "2d/CCCamera.h"
-#include "deprecated/CCString.h"
 
 NS_CC_BEGIN
 

--- a/cocos/platform/linux/CCFileUtils-linux.cpp
+++ b/cocos/platform/linux/CCFileUtils-linux.cpp
@@ -30,7 +30,7 @@ THE SOFTWARE.
 #include "platform/linux/CCApplication-linux.h"
 #include "platform/CCCommon.h"
 #include "base/ccMacros.h"
-#include "deprecated/CCString.h"
+#include "base/ccUTF8.h"
 #include <unistd.h>
 #include <sys/stat.h>
 #include <stdio.h>

--- a/cocos/renderer/CCGLProgram.cpp
+++ b/cocos/renderer/CCGLProgram.cpp
@@ -33,11 +33,10 @@ THE SOFTWARE.
 #endif
 
 #include "base/CCDirector.h"
+#include "base/ccUTF8.h"
 #include "base/uthash.h"
 #include "renderer/ccGLStateCache.h"
 #include "platform/CCFileUtils.h"
-
-#include "deprecated/CCString.h"
 
 // helper functions
 

--- a/cocos/renderer/CCGLProgramState.cpp
+++ b/cocos/renderer/CCGLProgramState.cpp
@@ -39,7 +39,6 @@ THE SOFTWARE.
 #include "base/CCDirector.h"
 #include "base/CCEventDispatcher.h"
 #include "2d/CCCamera.h"
-#include "deprecated/CCString.h"
 
 NS_CC_BEGIN
 

--- a/cocos/renderer/CCTexture2D.cpp
+++ b/cocos/renderer/CCTexture2D.cpp
@@ -39,6 +39,7 @@ THE SOFTWARE.
 #include "platform/CCDevice.h"
 #include "base/ccConfig.h"
 #include "base/ccMacros.h"
+#include "base/ccUTF8.h"
 #include "base/CCConfiguration.h"
 #include "platform/CCPlatformMacros.h"
 #include "base/CCDirector.h"
@@ -46,8 +47,6 @@ THE SOFTWARE.
 #include "renderer/ccGLStateCache.h"
 #include "renderer/CCGLProgramCache.h"
 #include "base/CCNinePatchImageParser.h"
-#include "deprecated/CCString.h"
-
 
 #if CC_ENABLE_CACHE_TEXTURE_DATA
     #include "renderer/CCTextureCache.h"

--- a/cocos/renderer/CCTextureAtlas.cpp
+++ b/cocos/renderer/CCTextureAtlas.cpp
@@ -30,6 +30,7 @@ THE SOFTWARE.
 #include <stdlib.h>
 
 #include "base/ccMacros.h"
+#include "base/ccUTF8.h"
 #include "base/CCEventType.h"
 #include "base/CCDirector.h"
 #include "base/CCConfiguration.h"
@@ -41,9 +42,6 @@ THE SOFTWARE.
 #include "renderer/CCRenderer.h"
 #include "renderer/CCTexture2D.h"
 #include "platform/CCGL.h"
-
-
-#include "deprecated/CCString.h"
 
 //According to some tests GL_TRIANGLE_STRIP is slower, MUCH slower. Probably I'm doing something very wrong
 

--- a/cocos/renderer/CCTextureCache.cpp
+++ b/cocos/renderer/CCTextureCache.cpp
@@ -34,12 +34,11 @@ THE SOFTWARE.
 
 #include "renderer/CCTexture2D.h"
 #include "base/ccMacros.h"
+#include "base/ccUTF8.h"
 #include "base/CCDirector.h"
 #include "base/CCScheduler.h"
 #include "platform/CCFileUtils.h"
 #include "base/ccUtils.h"
-
-#include "deprecated/CCString.h"
 #include "base/CCNinePatchImageParser.h"
 
 

--- a/cocos/scripting/js-bindings/manual/network/jsb_websocket.cpp
+++ b/cocos/scripting/js-bindings/manual/network/jsb_websocket.cpp
@@ -23,7 +23,7 @@
 
 #include "scripting/js-bindings/manual/network/jsb_websocket.h"
 
-#include "deprecated/CCString.h"
+#include "base/ccUTF8.h"
 #include "network/WebSocket.h"
 #include "platform/CCPlatformMacros.h"
 #include "scripting/js-bindings/manual/ScriptingCore.h"

--- a/cocos/ui/UIEditBox/UIEditBoxImpl-mac.mm
+++ b/cocos/ui/UIEditBox/UIEditBoxImpl-mac.mm
@@ -28,8 +28,8 @@
 
 #include "ui/UIEditBox/UIEditBoxImpl-mac.h"
 #include "base/CCDirector.h"
+#include "base/ccUTF8.h"
 #include "ui/UIEditBox/UIEditBox.h"
-#include "deprecated/CCString.h"
 #include "ui/UIEditBox/Mac/CCUIEditBoxMac.h"
 
 NS_CC_BEGIN

--- a/extensions/assets-manager/AssetsManagerEx.cpp
+++ b/extensions/assets-manager/AssetsManagerEx.cpp
@@ -23,7 +23,7 @@
  ****************************************************************************/
 #include "AssetsManagerEx.h"
 #include "CCEventListenerAssetsManagerEx.h"
-#include "deprecated/CCString.h"
+#include "base/ccUTF8.h"
 #include "base/CCDirector.h"
 
 #include <stdio.h>

--- a/extensions/assets-manager/CCEventListenerAssetsManagerEx.cpp
+++ b/extensions/assets-manager/CCEventListenerAssetsManagerEx.cpp
@@ -25,7 +25,7 @@
 #include "CCEventListenerAssetsManagerEx.h"
 #include "CCEventAssetsManagerEx.h"
 #include "AssetsManagerEx.h"
-#include "deprecated/CCString.h"
+#include "base/ccUTF8.h"
 
 NS_CC_EXT_BEGIN
 


### PR DESCRIPTION
Hello,

When I use `StringUtils::format()` and `StringUtils::toString()` functions under v3 branch, I need to add `#include "deprecated/CCString.h"` into my code, then the `deprecated` directory makes me confused, because the two functions are not deprecated.

Also according to the [cocos2d.h](https://github.com/cocos2d/cocos2d-x/blob/103bdb3d378554260e8324ac633b5c1fa1d30357/cocos/cocos2d.h#L314-L315):

```
It is recommanded that you just inlcude what is needed.
eg. #include "deprecated/CCString.h" if you only need cocos2d::__String.
```

So I suggest that we should move these function declarations outside of the deprecated header, in the same way as v4-develop changes (commit: https://github.com/cocos2d/cocos2d-x/commit/497db86977921deeb159527dd91809fe75a36329).

This PR does the following:
- Move `StringUtils::format()` and `StringUtils::toString()` from `deprecated/CCString.h` to `base/ccUTF8.h`
- Add `#include "base/ccUTF8.h"` into `CCString.h` to keep the backward compatibility
- Replace inclusion of deprecated header with `base/ccUTF8.h`

Thank you for considering!
