### PR TITLE
Added Particle Emitter Pause option, and tests

### DIFF
--- a/cocos/2d/CCParticleSystem.cpp
+++ b/cocos/2d/CCParticleSystem.cpp
@@ -588,6 +588,8 @@ ParticleSystem::~ParticleSystem()
 
 void ParticleSystem::addParticles(int count)
 {
+    if (paused)
+        return;
     uint32_t RANDSEED = rand();
 
     int start = _particleCount;
@@ -1348,4 +1350,22 @@ void ParticleSystem::stop()
 {
     stopSystem();
 }
+
+bool ParticleSystem::isPaused()
+{
+    return paused;
+}
+
+void ParticleSystem::pauseEmissions()
+{
+    paused = true;
+}
+
+void ParticleSystem::unPauseEmissions()
+{
+    paused = false;
+}
+
+
+
 NS_CC_END

--- a/cocos/2d/CCParticleSystem.cpp
+++ b/cocos/2d/CCParticleSystem.cpp
@@ -588,7 +588,7 @@ ParticleSystem::~ParticleSystem()
 
 void ParticleSystem::addParticles(int count)
 {
-    if (paused)
+    if (_paused)
         return;
     uint32_t RANDSEED = rand();
 
@@ -1351,19 +1351,19 @@ void ParticleSystem::stop()
     stopSystem();
 }
 
-bool ParticleSystem::isPaused()
+bool ParticleSystem::isPaused() const
 {
-    return paused;
+    return _paused;
 }
 
 void ParticleSystem::pauseEmissions()
 {
-    paused = true;
+    _paused = true;
 }
 
-void ParticleSystem::unPauseEmissions()
+void ParticleSystem::resumeEmissions()
 {
-    paused = false;
+    _paused = false;
 }
 
 

--- a/cocos/2d/CCParticleSystem.h
+++ b/cocos/2d/CCParticleSystem.h
@@ -801,6 +801,17 @@ CC_CONSTRUCTOR_ACCESS:
     
     //! Initializes a system with a fixed number of particles
     virtual bool initWithTotalParticles(int numberOfParticles);
+    
+    /** Are the emissions paused
+     @return True if the emissions are paused, else false
+     */
+    virtual bool isPaused();
+    
+    /* Pause the emissions*/
+    virtual void pauseEmissions();
+    
+    /* UnPause the emissions*/
+    virtual void unPauseEmissions();
 
 protected:
     virtual void updateBlendFunc();
@@ -956,6 +967,9 @@ protected:
      @since v0.8
      */
     PositionType _positionType;
+    
+    /** is the emitter paused */
+    bool paused;
 
 private:
     CC_DISALLOW_COPY_AND_ASSIGN(ParticleSystem);

--- a/cocos/2d/CCParticleSystem.h
+++ b/cocos/2d/CCParticleSystem.h
@@ -805,13 +805,13 @@ CC_CONSTRUCTOR_ACCESS:
     /** Are the emissions paused
      @return True if the emissions are paused, else false
      */
-    virtual bool isPaused();
+    virtual bool isPaused() const;
     
     /* Pause the emissions*/
     virtual void pauseEmissions();
     
     /* UnPause the emissions*/
-    virtual void unPauseEmissions();
+    virtual void resumeEmissions();
 
 protected:
     virtual void updateBlendFunc();
@@ -969,7 +969,7 @@ protected:
     PositionType _positionType;
     
     /** is the emitter paused */
-    bool paused;
+    bool _paused;
 
 private:
     CC_DISALLOW_COPY_AND_ASSIGN(ParticleSystem);

--- a/cocos/2d/CCParticleSystemQuad.cpp
+++ b/cocos/2d/CCParticleSystemQuad.cpp
@@ -707,4 +707,10 @@ std::string ParticleSystemQuad::getDescription() const
     return StringUtils::format("<ParticleSystemQuad | Tag = %d, Total Particles = %d>", _tag, _totalParticles);
 }
 
+
+
+
+
+
+
 NS_CC_END

--- a/cocos/2d/CCParticleSystemQuad.cpp
+++ b/cocos/2d/CCParticleSystemQuad.cpp
@@ -706,11 +706,4 @@ std::string ParticleSystemQuad::getDescription() const
 {
     return StringUtils::format("<ParticleSystemQuad | Tag = %d, Total Particles = %d>", _tag, _totalParticles);
 }
-
-
-
-
-
-
-
 NS_CC_END

--- a/cocos/2d/CCParticleSystemQuad.h
+++ b/cocos/2d/CCParticleSystemQuad.h
@@ -144,8 +144,6 @@ public:
 
     virtual std::string getDescription() const override;
     
-
-    
 CC_CONSTRUCTOR_ACCESS:
     /**
      * @js ctor

--- a/cocos/2d/CCParticleSystemQuad.h
+++ b/cocos/2d/CCParticleSystemQuad.h
@@ -144,6 +144,8 @@ public:
 
     virtual std::string getDescription() const override;
     
+
+    
 CC_CONSTRUCTOR_ACCESS:
     /**
      * @js ctor
@@ -161,6 +163,8 @@ CC_CONSTRUCTOR_ACCESS:
      * @lua NA
      */
     virtual bool initWithTotalParticles(int numberOfParticles) override;
+    
+
 
 protected:
     /** initializes the indices for the vertices*/
@@ -182,6 +186,8 @@ protected:
     GLuint              _buffersVBO[2]; //0: vertex  1: indices
 
     QuadCommand _quadCommand;           // quad command
+    
+
 
 private:
     CC_DISALLOW_COPY_AND_ASSIGN(ParticleSystemQuad);

--- a/tests/cpp-tests/Classes/ParticleTest/ParticleTest.cpp
+++ b/tests/cpp-tests/Classes/ParticleTest/ParticleTest.cpp
@@ -82,6 +82,43 @@ std::string DemoSun::subtitle() const
 
 //------------------------------------------------------------------
 //
+// DemoPause
+//
+//------------------------------------------------------------------
+void DemoPause::onEnter()
+{
+    ParticleDemo::onEnter();
+    
+    _emitter = ParticleSmoke::create();
+    _emitter->retain();
+    _background->addChild(_emitter, 10);
+    
+    _emitter->setTexture( Director::getInstance()->getTextureCache()->addImage(s_fire) );
+    
+    setEmitterPosition();
+    schedule(CC_SCHEDULE_SELECTOR(DemoPause::pauseEmitter), 2.0f);
+
+
+}
+void DemoPause::pauseEmitter(float time)
+{
+    if (_emitter->isPaused())
+    {
+        _emitter->unPauseEmissions();
+    }
+    else
+    {
+        _emitter->pauseEmissions();
+    }
+}
+
+std::string DemoPause::subtitle() const
+{
+    return "Pause Particle";
+}
+
+//------------------------------------------------------------------
+//
 // DemoGalaxy
 //
 //------------------------------------------------------------------
@@ -976,6 +1013,7 @@ ParticleTests::ParticleTests()
     ADD_TEST_CASE(DemoModernArt);
     ADD_TEST_CASE(DemoRing);
     ADD_TEST_CASE(ParallaxParticle);
+    ADD_TEST_CASE(DemoPause);
     addTestCase("BoilingFoam", [](){return DemoParticleFromFile::create("BoilingFoam");});
     addTestCase("BurstPipe", [](){return DemoParticleFromFile::create("BurstPipe"); });
     addTestCase("Comet", [](){return DemoParticleFromFile::create("Comet"); });

--- a/tests/cpp-tests/Classes/ParticleTest/ParticleTest.cpp
+++ b/tests/cpp-tests/Classes/ParticleTest/ParticleTest.cpp
@@ -104,7 +104,7 @@ void DemoPause::pauseEmitter(float time)
 {
     if (_emitter->isPaused())
     {
-        _emitter->unPauseEmissions();
+        _emitter->resumeEmissions();
     }
     else
     {

--- a/tests/cpp-tests/Classes/ParticleTest/ParticleTest.h
+++ b/tests/cpp-tests/Classes/ParticleTest/ParticleTest.h
@@ -380,4 +380,13 @@ public:
     virtual std::string subtitle() const override;
 };
 
+class DemoPause : public ParticleDemo
+{
+public:
+    CREATE_FUNC(DemoPause);
+    virtual void onEnter() override;
+    virtual std::string subtitle() const override;
+    void pauseEmitter(float time);
+};
+
 #endif

--- a/tests/js-tests/src/ParticleTest/ParticleTest.js
+++ b/tests/js-tests/src/ParticleTest/ParticleTest.js
@@ -135,6 +135,9 @@ var particleSceneArr = [
     },
     function() {
         return new ParticleResizeTest();
+    },
+    function() {
+        return new DemoPause();
     }
 ];
 
@@ -431,6 +434,23 @@ var DemoSun = ParticleDemo.extend({
         return "ParticleSun";
     }
 });
+
+var DemoPause = ParticleDemo.extend({
+    onEnter:function () {
+    this._super();
+
+    this._emitter = new cc.ParticleSmoke();
+    this._background.addChild(this._emitter, 10);
+    this._emitter.texture = cc.textureCache.addImage(s_fire);
+    if (this._emitter.setShapeType)
+    this._emitter.setShapeType(cc.ParticleSystem.BALL_SHAPE);
+
+    this.setEmitterPosition();
+    },
+    title:function () {
+    return "Pause Particle";
+    }
+    });
 
 var DemoGalaxy = ParticleDemo.extend({
     onEnter:function () {

--- a/tests/lua-tests/src/ParticleTest/ParticleTest.lua
+++ b/tests/lua-tests/src/ParticleTest/ParticleTest.lua
@@ -472,6 +472,24 @@ local function DemoSun()
 end
 
 ---------------------------------
+--  DemoPause
+---------------------------------
+local function DemoPause()
+local layer = getBaseLayer()
+
+emitter = cc.ParticleSmoke:create()
+-- emitter:retain()
+background:addChild(emitter, 10)
+
+emitter:setTexture(cc.Director:getInstance():getTextureCache():addImage(s_fire))
+
+setEmitterPosition()
+
+titleLabel:setString("Pasue Particle")
+return layer
+end
+
+---------------------------------
 --  DemoMeteor
 ---------------------------------
 local function DemoMeteor()
@@ -1489,6 +1507,8 @@ function CreateParticleLayer()
 	elseif SceneIdx == 40 then return ReorderParticleSystems()
 	elseif SceneIdx == 41 then return PremultipliedAlphaTest()
 	elseif SceneIdx == 42 then return PremultipliedAlphaTest2()
+    elseif SceneIdx == 43  then return DemoPause()
+
 	end
 end
 


### PR DESCRIPTION
Added methods to Pause and UnPause emissions.
When paused, existing particles continue but new particles are not created.
UnPause continues to emit new particles.
Also adds IsPaused boolean.

Included Test/Demo of the effect in the tests.

I accidentally included changes to CCParticleSystemQuad (I made changes but then undid them - and did not intend to include them in the pull.
