### PR TITLE
lua binding : Rename end() to endToLua().

### DIFF
--- a/cocos/2d/CCRenderTexture.h
+++ b/cocos/2d/CCRenderTexture.h
@@ -113,12 +113,9 @@ public:
      */
     virtual void beginWithClear(float r, float g, float b, float a, float depthValue, int stencilValue);
 
-    /** End is key word of lua, use other name to export to lua.
-     * @js NA
+    /** Ends grabbing.
+     * @lua endToLua
      */
-    inline void endToLua(){ end();};
-
-    /** Ends grabbing. */
     virtual void end();
 
     /** Clears the texture with a color. 

--- a/cocos/audio/include/AudioEngine.h
+++ b/cocos/audio/include/AudioEngine.h
@@ -110,6 +110,7 @@ public:
      * Release objects relating to AudioEngine.
      *
      * @warning It must be called before the application exit.
+     * @lua endToLua
      */
     static void end();
     

--- a/cocos/editor-support/cocostudio/CCComAudio.h
+++ b/cocos/editor-support/cocostudio/CCComAudio.h
@@ -75,6 +75,9 @@ public:
 
     virtual bool serialize(void* r) override;
 public:
+    /**
+    * @lua endToLua
+    */
     void end();
     void preloadBackgroundMusic(const char* pszFilePath);
     void playBackgroundMusic(const char* pszFilePath, bool bLoop);

--- a/cocos/platform/CCGLView.h
+++ b/cocos/platform/CCGLView.h
@@ -106,7 +106,10 @@ public:
      */
     virtual ~GLView();
 
-    /** Force destroying EGL view, subclass must implement this method. */
+    /** Force destroying EGL view, subclass must implement this method. 
+     *
+     * @lua endToLua
+     */
     virtual void end() = 0;
 
     /** Get whether opengl render system is ready, subclass must implement this method. */

--- a/tools/tolua/cocos2dx.ini
+++ b/tools/tolua/cocos2dx.ini
@@ -154,7 +154,9 @@ rename_functions = SpriteFrameCache::[addSpriteFramesWithFile=addSpriteFrames ge
     LabelAtlas::[create=_create],
     Touch::[getID=getId],
     FileUtils::[loadFilenameLookupDictionaryFromFile=loadFilenameLookup],
-    Director::[end=endToLua]
+    Director::[end=endToLua],
+    GLView::[end=endToLua],
+    RenderTexture::[end=endToLua]
 
 rename_classes = ParticleSystemQuad::ParticleSystem
 

--- a/tools/tolua/cocos2dx_audioengine.ini
+++ b/tools/tolua/cocos2dx_audioengine.ini
@@ -40,7 +40,7 @@ classes = AudioEngine AudioProfile
 
 skip = AudioEngine::[setFinishCallback]
 
-rename_functions = 
+rename_functions = AudioEngine::[end=endToLua]
 
 rename_classes =
 

--- a/tools/tolua/cocos2dx_studio.ini
+++ b/tools/tolua/cocos2dx_studio.ini
@@ -56,8 +56,8 @@ skip =  *::[^visit$ copyWith.* onEnter.* onExit.* ^description$ getObjectType .*
         ActionTimeline::[setFrameEventCallFunc]
 
 rename_functions =  ActionManagerEx::[shareManager=getInstance purgeActionManager=destroyInstance],
-                    SceneReader::[purgeSceneReader=destroyInstance]
-
+                    SceneReader::[purgeSceneReader=destroyInstance],
+					ComAudio::[end=endToLua]
 
 rename_classes =
 


### PR DESCRIPTION
There're still some end() functions need to rename to endToLua(), such as AudioEngine::end() and GLView::end(). And the way RenderTexture used to rename end() is out-of-date, so I changed it too.Please review this patch. Thanks.
