### PR TITLE
Cleanup and refactor RootViewController

### DIFF
--- a/templates/cpp-template-default/proj.ios_mac/ios/AppController.mm
+++ b/templates/cpp-template-default/proj.ios_mac/ios/AppController.mm
@@ -38,8 +38,6 @@
 static AppDelegate s_sharedApplication;
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {    
-
-    
     // Override point for customization after application launch.
 
     // Add the view controller's view to the window and display.

--- a/templates/cpp-template-default/proj.ios_mac/ios/RootViewController.mm
+++ b/templates/cpp-template-default/proj.ios_mac/ios/RootViewController.mm
@@ -27,15 +27,7 @@
 #import "cocos2d.h"
 #import "platform/ios/CCEAGLView-ios.h"
 
-@interface RootViewController()
 
-
-@property(strong,nonatomic) CCEAGLView *eaglView;
-
-//dismisses the game scene and moves to native iOS screen
-
-//-(void)closeGameScene;
-@end
 @implementation RootViewController
 
 /*
@@ -48,26 +40,17 @@
 }
 */
 
-/*
 // Implement loadView to create a view hierarchy programmatically, without using a nib.
 - (void)loadView {
-}
-*/
-
-
-// Implement viewDidLoad to do additional setup after loading the view, typically from a nib.
-- (void)viewDidLoad {
-    [super viewDidLoad];
-    
     cocos2d::Application *app = cocos2d::Application::getInstance();
     
-    //initialize the GLView attributes
+    // Initialize the GLView attributes
     app->initGLContextAttrs();
     cocos2d::GLViewImpl::convertAttrs();
     
-    //initialize the CCEAGLView
-    self.eaglView = [CCEAGLView viewWithFrame: [UIScreen mainScreen].bounds
-                                         pixelFormat: (NSString*)cocos2d::GLViewImpl::_pixelFormat
+    // Initialize the CCEAGLView
+    CCEAGLView *eaglView = [CCEAGLView viewWithFrame: [UIScreen mainScreen].bounds
+                                         pixelFormat: (__bridge NSString *)cocos2d::GLViewImpl::_pixelFormat
                                          depthFormat: cocos2d::GLViewImpl::_depthFormat
                                   preserveBackbuffer: NO
                                           sharegroup: nil
@@ -75,54 +58,40 @@
                                      numberOfSamples: 0 ];
     
     // Enable or disable multiple touches
-    [self.eaglView setMultipleTouchEnabled:NO];
-
-    /*Use the RootViewController to manage the CCEAGLView*/
+    [eaglView setMultipleTouchEnabled:NO];
     
-    //insert EAGLView as subview of RootViewController
-    [self.view insertSubview:self.eaglView atIndex:0];
+    // Set EAGLView as view of RootViewController
+    self.view = eaglView;
     
-    //Create a custom event listener to listen to the custom event triggered by HelloWorldScene.cpp and add the event listener to the Director to close the game scene and move to native iOS screen(if present) without quitting the application 
-    /*
-    cocos2d::EventListenerCustom *_listener = cocos2d::EventListenerCustom::create("game_scene_close_event", [=](cocos2d::EventCustom *gameCustomEvent){
-        
-        printf("game_scene_close_event\n");
-        
-        [self closeGameScene];
-        
-        
-    });
-    
-    cocos2d::Director::getInstance()->getEventDispatcher()->addEventListenerWithFixedPriority(_listener, 1);
-     
-     */
-    
-    // IMPORTANT: Setting the GLView should be done after creating the RootViewController
-    
-    cocos2d::GLView *glview = cocos2d::GLViewImpl::createWithEAGLView(self.eaglView);
+    cocos2d::GLView *glview = cocos2d::GLViewImpl::createWithEAGLView((__bridge void *)self.view);
     
     //set the GLView as OpenGLView of the Director
     cocos2d::Director::getInstance()->setOpenGLView(glview);
     
     //run the cocos2d-x game scene
     app->run();
-    
-    
 }
 
-
-// Override to allow orientations other than the default portrait orientation.
-// This method is deprecated on ios6
-- (BOOL)shouldAutorotateToInterfaceOrientation:(UIInterfaceOrientation)interfaceOrientation {
-    return UIInterfaceOrientationIsLandscape( interfaceOrientation );
+// Implement viewDidLoad to do additional setup after loading the view, typically from a nib.
+- (void)viewDidLoad {
+    [super viewDidLoad];
 }
+
+- (void)viewWillAppear:(BOOL)animated {
+    [super viewWillAppear:animated];
+}
+
+- (void)viewDidDisappear:(BOOL)animated {
+    [super viewDidDisappear:animated];
+}
+
 
 // For ios6, use supportedInterfaceOrientations & shouldAutorotate instead
-- (NSUInteger) supportedInterfaceOrientations{
 #ifdef __IPHONE_6_0
+- (NSUInteger) supportedInterfaceOrientations{
     return UIInterfaceOrientationMaskAllButUpsideDown;
-#endif
 }
+#endif
 
 - (BOOL) shouldAutorotate {
     return YES;
@@ -146,8 +115,7 @@
 }
 
 //fix not hide status on ios7
-- (BOOL)prefersStatusBarHidden
-{
+- (BOOL)prefersStatusBarHidden {
     return YES;
 }
 
@@ -158,25 +126,5 @@
     // Release any cached data, images, etc that aren't in use.
 }
 
-//dismisses the game scene without quitting the application and navigates to native iOS screen 
-
-/*
--(void)closeGameScene{
-    
-    cocos2d::Director::getInstance()->end();
-    
-    [self dismissViewControllerAnimated:YES completion:nil];
-}
-*/
-- (void)viewDidDisappear:(BOOL)animated{
-    
-    //manually release the CCEAGLView when closing the RootViewController
-    self.eaglView = nil;
-}
-- (void)viewDidUnload {
-    [super viewDidUnload];
-    // Release any retained subviews of the main view.
-    // e.g. self.myOutlet = nil;
-}
 
 @end


### PR DESCRIPTION
- removed some redundant code & comments;
- make EAGLView a root view of RootViewController instead of subview;
- added missed `bridge` casts;

Also, few proposals:
- do some actions in `viewDidDisappear` & `viewWillAppear` (when new ViewController is pushed). E.g. pause/resume the game, so open GL view is not used while it's not visible;
- rename `RootViewController` to `CocosViewController`;
- extract multi touch setting into cocos side;
