### PR TITLE
Fix -Wsometimes-uninitialized warning in release build

### DIFF
--- a/cocos/base/allocator/CCAllocatorStrategyGlobalSmallBlock.h
+++ b/cocos/base/allocator/CCAllocatorStrategyGlobalSmallBlock.h
@@ -164,7 +164,7 @@ public:
             } \
             break;
             
-        void* address;
+        void* address = nullptr;
         
         switch (adjusted_size)
         {


### PR DESCRIPTION
This PR fixes the following `-Wsometimes-uninitialized` warning when compiling `libcocos2d` in release mode with Xcode 7.3/Clang. Thanks!

```
cocos/base/allocator/CCAllocatorStrategyGlobalSmallBlock.h:183:9: Variable 'address' is used uninitialized whenever switch default is taken
cocos/base/allocator/CCAllocatorGlobalNewDelete.cpp:27:10: In file included from cocos/base/allocator/CCAllocatorGlobalNewDelete.cpp:27:
cocos/base/allocator/CCAllocatorStrategyGlobalSmallBlock.h:193:16: Uninitialized use occurs here
cocos/base/allocator/CCAllocatorStrategyGlobalSmallBlock.h:167:22: Initialize the variable 'address' to silence this warning
```
