### PR TITLE
remove gcc comipling flag

### DIFF
--- a/cocos/storage/local-storage/Android.mk
+++ b/cocos/storage/local-storage/Android.mk
@@ -14,9 +14,6 @@ LOCAL_EXPORT_C_INCLUDES := $(LOCAL_PATH)/..
 
 LOCAL_C_INCLUDES := $(LOCAL_PATH)/../..
 
-LOCAL_CFLAGS += -Wno-psabi
-LOCAL_EXPORT_CFLAGS += -Wno-psabi
-
 LOCAL_STATIC_LIBRARIES := cocos2dx_internal_static
 
 include $(BUILD_STATIC_LIBRARY)


### PR DESCRIPTION
Now we change to use clang, and these flags are for gcc.
