### PR TITLE
V3: removed incorrect AppBundle info for Win10 cpp-test project

### DIFF
--- a/tests/cpp-tests/proj.win10/cpp-tests.vcxproj
+++ b/tests/cpp-tests/proj.win10/cpp-tests.vcxproj
@@ -126,9 +126,6 @@
   <PropertyGroup>
     <PackageCertificateKeyFile>cpp-tests_TemporaryKey.pfx</PackageCertificateKeyFile>
     <PackageCertificateThumbprint>F3187E657336E152D7AC4C352643738EE7C7C055</PackageCertificateThumbprint>
-    <AppxAutoIncrementPackageRevision>False</AppxAutoIncrementPackageRevision>
-    <AppxBundle>Always</AppxBundle>
-    <AppxBundlePlatforms>x86</AppxBundlePlatforms>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <LinkIncremental>false</LinkIncremental>


### PR DESCRIPTION
This PR removes removes the incorrect AppBundle info from the Win10 cpp-tests project that was breaking arm builds.
