### PR TITLE
Fixed android controller events propagation

### DIFF
--- a/cocos/base/CCController.cpp
+++ b/cocos/base/CCController.cpp
@@ -77,12 +77,14 @@ const Controller::KeyStatus& Controller::getKeyStatus(int keyCode)
 
 void Controller::onConnected()
 {
+    _connectEvent->resetPropagation();
     _connectEvent->setConnectStatus(true);
     _eventDispatcher->dispatchEvent(_connectEvent);
 }
 
 void Controller::onDisconnected()
 {
+    _connectEvent->resetPropagation();
     _connectEvent->setConnectStatus(false);
     _eventDispatcher->dispatchEvent(_connectEvent);
 
@@ -96,6 +98,7 @@ void Controller::onButtonEvent(int keyCode, bool isPressed, float value, bool is
     _allKeyStatus[keyCode].value = value;
     _allKeyStatus[keyCode].isAnalog = isAnalog;
 
+    _keyEvent->resetPropagation();
     _keyEvent->setKeyCode(keyCode);
     _eventDispatcher->dispatchEvent(_keyEvent);
 }
@@ -106,6 +109,7 @@ void Controller::onAxisEvent(int axisCode, float value, bool isAnalog)
     _allKeyStatus[axisCode].value = value;
     _allKeyStatus[axisCode].isAnalog = isAnalog;
 
+    _axisEvent->resetPropagation();
     _axisEvent->setKeyCode(axisCode);
     _eventDispatcher->dispatchEvent(_axisEvent);
 }

--- a/cocos/base/CCEvent.h
+++ b/cocos/base/CCEvent.h
@@ -74,6 +74,10 @@ public:
      */
     inline void stopPropagation() { _isStopped = true; };
     
+    /** Resets propagation for current event.
+     */
+    inline void resetPropagation() { _isStopped = false; };
+
     /** Checks whether the event has been stopped.
      *
      * @return True if the event has been stopped.


### PR DESCRIPTION
To test it, simply use the propagation mechanism on a controller event (call stopPropagation on it), and all future events of the same type, will be dispatched with their propagation already stopped.

Another solution would have been to create new Event objects instead of re-using Event objects created once, but maybe there is a specific reason for how it's done here, so I chose to simply add a resetPropagation method which is called before dispatching the event.
