### PR TITLE
Remove unused debug function in RenderCommand

### DIFF
--- a/cocos/renderer/CCRenderCommand.cpp
+++ b/cocos/renderer/CCRenderCommand.cpp
@@ -60,24 +60,6 @@ void RenderCommand::init(float globalZOrder, const cocos2d::Mat4 &transform, uin
     }
 }
 
-void printBits(ssize_t const size, void const * const ptr)
-{
-    unsigned char *b = (unsigned char*) ptr;
-    unsigned char byte;
-    ssize_t i, j;
-
-    for (i=size-1;i>=0;i--)
-    {
-        for (j=7;j>=0;j--)
-        {
-            byte = b[i] & (1<<j);
-            byte >>= j;
-            printf("%u", byte);
-        }
-    }
-    puts("");
-}
-
 void RenderCommand::printID()
 {
     printf("Command Depth: %f\n", _globalOrder);


### PR DESCRIPTION
This pull request removes `printBits` function that is not used anywhere in the RenderCommand (since commit: https://github.com/cocos2d/cocos2d-x/commit/8931d968c0ea639e055440acd194d9397afc8e60) to speed up compile time. Thanks.
