### PR TITLE
Fix unused variable warnings when compiling release mode

### DIFF
--- a/cocos/2d/CCAutoPolygon.cpp
+++ b/cocos/2d/CCAutoPolygon.cpp
@@ -253,7 +253,6 @@ std::vector<cocos2d::Vec2> AutoPolygon::marchSquare(const Rect& rect, const Vec2
     int curx = startx;
     int cury = starty;
     unsigned int count = 0;
-    unsigned int totalPixel = _width*_height;
     bool problem = false;
     std::vector<int> case9s;
     std::vector<int> case6s;
@@ -408,7 +407,11 @@ std::vector<cocos2d::Vec2> AutoPolygon::marchSquare(const Rect& rect, const Vec2
         prevx = stepx;
         prevy = stepy;
         problem = false;
+
+#if defined(COCOS2D_DEBUG) && (COCOS2D_DEBUG > 0)
+        const auto totalPixel = _width * _height;
         CCASSERT(count <= totalPixel, "oh no, marching square cannot find starting position");
+#endif
     } while(curx != startx || cury != starty);
     return _points;
 }

--- a/cocos/base/ccUtils.cpp
+++ b/cocos/base/ccUtils.cpp
@@ -326,6 +326,11 @@ Sprite* createSpriteFromBase64Cached(const char* base64String, const char* key)
         CCASSERT(imageResult, "Failed to create image from base64!");
         free(decoded);
 
+        if (!imageResult) {
+            CC_SAFE_RELEASE_NULL(image);
+            return nullptr;
+        }
+
         texture = Director::getInstance()->getTextureCache()->addImage(image, key);
         image->release();
     }
@@ -344,6 +349,11 @@ Sprite* createSpriteFromBase64(const char* base64String)
     bool imageResult = image->initWithImageData(decoded, length);
     CCASSERT(imageResult, "Failed to create image from base64!");
     free(decoded);
+
+    if (!imageResult) {
+        CC_SAFE_RELEASE_NULL(image);
+        return nullptr;
+    }
 
     Texture2D *texture = new (std::nothrow) Texture2D();
     texture->initWithImage(image);


### PR DESCRIPTION
This PR fixes the `-Wunused-variable` warnings (pasted below) when compiling in release mode under Xcode 7.3. Thanks!

```
cocos/2d/CCAutoPolygon.cpp:256:18: Unused variable 'totalPixel'
cocos/base/ccUtils.cpp:325:14: Unused variable 'imageResult'
cocos/base/ccUtils.cpp:344:10: Unused variable 'imageResult'
```
