### PR TITLE
fix: underline will have the same solor as text in TTF

### DIFF
--- a/cocos/2d/CCLabel.cpp
+++ b/cocos/2d/CCLabel.cpp
@@ -1876,16 +1876,22 @@ void Label::updateDisplayedColor(const Color3B& parentColor)
 {
     Node::updateDisplayedColor(parentColor);
 
+    if (_currentLabelType == LabelType::TTF || _currentLabelType == LabelType::STRING_TEXTURE)
+        setTextColor(Color4B(_displayedColor));
+
     if (_textSprite)
     {
         _textSprite->updateDisplayedColor(_displayedColor);
-        if (_shadowNode)
-        {
-            _shadowNode->updateDisplayedColor(_displayedColor);
-        }
+    }
 
-        if (_underlineNode)
-            _contentDirty = true;
+    if (_shadowNode)
+    {
+        _shadowNode->updateDisplayedColor(_displayedColor);
+    }
+
+    if (_underlineNode)
+    {
+        _contentDirty = true;
     }
 
     for (auto&& it : _letters)

--- a/tests/cpp-tests/Classes/LabelTest/LabelTestNew.cpp
+++ b/tests/cpp-tests/Classes/LabelTest/LabelTestNew.cpp
@@ -106,6 +106,8 @@ NewLabelTests::NewLabelTests()
     ADD_TEST_CASE(LabelBold);
 
     ADD_TEST_CASE(LabelLocalizationTest);
+
+    ADD_TEST_CASE(LabelIssue15214);
 };
 
 LabelFNTColorAndOpacity::LabelFNTColorAndOpacity()
@@ -3148,4 +3150,30 @@ void LabelLocalizationTest::onChangedRadioButtonSelect(RadioButton* radioButton,
     default:
         break;
     }
+}
+
+// LabelBMFontBinaryFormat
+LabelIssue15214::LabelIssue15214()
+{
+    auto size = Director::getInstance()->getVisibleSize();
+    Label* label = Label::createWithTTF("CHECK!", "fonts/arial.ttf", 48.0f);
+    label->enableUnderline();
+    label->setColor(cocos2d::Color3B::BLUE);
+    label->setPosition(size.width/2, size.height/3*2);
+    this->addChild(label);
+    label = Label::createWithSystemFont("CHECK!", "Verdana", 48.0f);
+    label->enableUnderline();
+    label->setColor(cocos2d::Color3B::BLUE);
+    label->setPosition(size.width/2, size.height/3*1);
+    this->addChild(label);
+}
+
+std::string LabelIssue15214::title() const
+{
+    return "Githug Issue 15214";
+}
+
+std::string LabelIssue15214::subtitle() const
+{
+    return "Font and underline should be of the same color";
 }

--- a/tests/cpp-tests/Classes/LabelTest/LabelTestNew.h
+++ b/tests/cpp-tests/Classes/LabelTest/LabelTestNew.h
@@ -850,4 +850,14 @@ public:
     cocostudio::ILocalizationManager* _localizationBin;
 };
 
+class LabelIssue15214 : public AtlasDemoNew
+{
+public:
+    CREATE_FUNC(LabelIssue15214);
+
+    LabelIssue15214();
+
+    virtual std::string title() const override;
+    virtual std::string subtitle() const override;
+};
 #endif


### PR DESCRIPTION
underline will have the same solor as text in TTF when calling
`setColor`. There is another method called `setTextColor` which is
confusing. What does each function?

github issue #15214
