### PR TITLE
Fix for the continuous repeat suddenly stopping.

### DIFF
--- a/cocos/2d/CCActionInterval.cpp
+++ b/cocos/2d/CCActionInterval.cpp
@@ -496,7 +496,7 @@ void Repeat::update(float dt)
 {
     if (dt >= _nextDt)
     {
-        while (dt >= _nextDt && _total < _times)
+        while (dt > _nextDt && _total < _times)
         {
             if (!(sendUpdateEventToScript(1.0f, _innerAction)))
                 _innerAction->update(1.0f);
@@ -508,7 +508,7 @@ void Repeat::update(float dt)
         }
 
         // fix for issue #1288, incorrect end value of repeat
-        if(fabs(dt - 1.0f) < FLT_EPSILON && _total < _times)
+        if(dt - 1.0f >= FLT_EPSILON && _total < _times)
         {
             if (!(sendUpdateEventToScript(1.0f, _innerAction)))
                 _innerAction->update(1.0f);


### PR DESCRIPTION
With Repeat class, the continuous repeat animation stops suddenly during about 30 minutes.
It may be a rare timing-bug.
I've tested this fix and verified with Android and iOS app.

Regards, Kaoru
