### PR TITLE
fix restart game crash in FT_Get_Char_Index

### DIFF
--- a/cocos/base/CCDirector.cpp
+++ b/cocos/base/CCDirector.cpp
@@ -1008,6 +1008,7 @@ void Director::reset()
     
     // purge bitmap cache
     FontFNT::purgeCachedData();
+    FontAtlasCache::purgeCachedData();
     
     FontFreeType::shutdownFreeType();
     


### PR DESCRIPTION
fix restart game crash in FT_Get_Char_Index    why not call cache     FontAtlasCache::purgeCachedData() or Director::purgeCachedData() ?
