### PR TITLE
remove port info to avoid enametoolong error

### DIFF
--- a/cocos/network/WebSocket.cpp
+++ b/cocos/network/WebSocket.cpp
@@ -623,7 +623,7 @@ void WebSocket::onSubThreadStarted()
 
         char portStr[10];
         sprintf(portStr, "%d", _port);
-        std::string ads_port = _host + ":" + portStr;
+        std::string ads_port = _host; // + ":" + portStr;
 
         _wsInstance = lws_client_connect(_wsContext, _host.c_str(), _port, _SSLConnection,
                                              _path.c_str(), ads_port.c_str(), ads_port.c_str(),


### PR DESCRIPTION
while testing on iOS simulator and devices, the connect function in libwebsockets, returns errno 36, which is enametoolong. 
I have no idea what this means, but remove the port did fix the problem.

more details could be found here:

http://forum.cocos.com/t/libwebsockets-ipv6-no-route-to-host/37089/2
