### PR TITLE
fix: not crash if CC_SPRITE_DEBUG_DRAW is enabled in SpriteBatchNode

### DIFF
--- a/cocos/2d/CCSpriteBatchNode.cpp
+++ b/cocos/2d/CCSpriteBatchNode.cpp
@@ -544,6 +544,18 @@ void SpriteBatchNode::appendChild(Sprite* sprite)
     // add children recursively
     auto& children = sprite->getChildren();
     for(const auto &child: children) {
+#if CC_SPRITE_DEBUG_DRAW
+        // when using CC_SPRITE_DEBUG_DRAW, a DrawNode is appended to sprites. remove it since only Sprites can be used
+        // as children in SpriteBatchNode
+        // Github issue #14730
+        if (dynamic_cast<DrawNode*>(child)) {
+            // to avoid calling Sprite::removeChild()
+            sprite->Node::removeChild(child, true);
+        }
+        else
+#else
+        CCASSERT(dynamic_cast<Sprite*>(child) != nullptr, "You can only add Sprites (or subclass of Sprite) to SpriteBatchNode");
+#endif
         appendChild(static_cast<Sprite*>(child));
     }
 }


### PR DESCRIPTION
`SpriteBatchNode` was trying to render `DrawNode` when
`CC_SPRITE_DEBUG_DRAW` was enabled.

Github issue #14730
