### PR TITLE
FileUtils: Add std::move for retun value.

### DIFF
--- a/cocos/platform/CCFileUtils.cpp
+++ b/cocos/platform/CCFileUtils.cpp
@@ -618,14 +618,14 @@ std::string FileUtils::getStringFromFile(const std::string& filename)
     // truncated
     s.resize(strlen(s.data()));
 
-    return s;
+    return std::move(s);
 }
 
 Data FileUtils::getDataFromFile(const std::string& filename)
 {
     Data d;
     getContents(filename, &d);
-    return d;
+    return std::move(d);
 }
 
 


### PR DESCRIPTION
Explicit avoid unnecessary memory alloc & copy.
