### PR TITLE
fix system font creation on Android platform

### DIFF
--- a/cocos/platform/android/CCDevice-android.cpp
+++ b/cocos/platform/android/CCDevice-android.cpp
@@ -114,7 +114,7 @@ public:
            int count = strlen(text);
            jbyteArray strArray = methodInfo.env->NewByteArray(count);
            methodInfo.env->SetByteArrayRegion(strArray, 0, count, reinterpret_cast<const jbyte*>(text));
-           jstring jstrFont = methodInfo.env->NewStringUTF(fullPathOrFontName.c_str());
+           jstring jstrFont = methodInfo.env->NewStringUTF(fullPathOrFontName.empty() ? textDefinition._fontName.c_str() : fullPathOrFontName.c_str());
 
            if(!methodInfo.env->CallStaticBooleanMethod(methodInfo.classID, methodInfo.methodID, strArray,
                jstrFont, textDefinition._fontSize, textDefinition._fontFillColor.r, textDefinition._fontFillColor.g, 

--- a/tests/js-tests/src/FontTest/FontTest.js
+++ b/tests/js-tests/src/FontTest/FontTest.js
@@ -33,6 +33,8 @@ var fontIdx = 0;
 var fontList = [
 
     // System Fonts
+    "sans-serif",
+    "sans-serif-light",
     "Verdana",
     "Lucida Sans Unicode",
     "Bookman Old Style",


### PR DESCRIPTION
Since this PR https://github.com/cocos2d/cocos2d-x/pull/9915/files changed the default behavior of `fullPathForFilename`, when pass system font name isn't a valid file path, it will return empty string.
