### PR TITLE
Some lua bindings fixes:

### DIFF
--- a/cocos/base/CCScriptSupport.h
+++ b/cocos/base/CCScriptSupport.h
@@ -557,11 +557,18 @@ struct CommonScriptData
     : handler(inHandler),
       eventSource(inSource)
     {
-        strncpy(eventName, inName, 64);
+        if (nullptr == inName)
+        {
+            memset(eventName, 0, sizeof(eventName));
+        }
+        else
+        {
+            strncpy(eventName, inName, sizeof(eventName));
+        }
         
         if (nullptr == inClassName)
         {
-            memset(eventSourceClassName, 0, 64*sizeof(char));
+            memset(eventSourceClassName, 0, sizeof(eventSourceClassName));
         }
         else
         {

--- a/cocos/scripting/lua-bindings/manual/CCLuaEngine.cpp
+++ b/cocos/scripting/lua-bindings/manual/CCLuaEngine.cpp
@@ -438,14 +438,14 @@ int LuaEngine::handleCommonEvent(void* data)
     if (NULL == data)
         return 0;
    
-    CommonScriptData* commonInfo = static_cast<CommonScriptData*>(data);
-    if ('\0' == commonInfo->eventName[0] || 0 == commonInfo->handler)
+    CommonScriptData* commonInfo = static_cast<CommonScriptData*>(data); 
+    if (0 == commonInfo->handler)
         return 0;
     
     _stack->pushString(commonInfo->eventName);
     if (NULL != commonInfo->eventSource)
     {
-        if ('\0' != commonInfo->eventSourceClassName[0])
+        if (strlen(commonInfo->eventSourceClassName) > 0)
         {
             _stack->pushObject(commonInfo->eventSource, commonInfo->eventSourceClassName);
         }

--- a/cocos/scripting/lua-bindings/manual/network/Lua_web_socket.cpp
+++ b/cocos/scripting/lua-bindings/manual/network/Lua_web_socket.cpp
@@ -133,7 +133,7 @@ void LuaWebSocket::onError(WebSocket* ws, const WebSocket::ErrorCode& error)
 {
     LuaWebSocket* luaWs = dynamic_cast<LuaWebSocket*>(ws);
     if (NULL != luaWs) {
-        int nHandler = 0;//luaWs->getScriptHandler(LuaWebSocket::kWebSocketScriptHandlerError);
+        int nHandler = ScriptHandlerMgr::getInstance()->getObjectHandler((void*)this,ScriptHandlerMgr::HandlerType::WEBSOCKET_ERROR);
         if (0 != nHandler)
         {
             CommonScriptData data(nHandler,"");


### PR DESCRIPTION
1) Reverts changes in  #15443, the behavor of LuaEngine::handleCommonEvent should not be changed. empty eventName should be supported, otherwise it will break compatiblity.
2) Null pointer check in CommonScriptData initialization
3) No error callback in lua (fixed #15904)
