### PR TITLE
fix: reverse iterator on events + doesn't use additionalTransform

### DIFF
--- a/cocos/2d/CCScene.cpp
+++ b/cocos/2d/CCScene.cpp
@@ -210,8 +210,6 @@ void Scene::render(Renderer* renderer, const Mat4& eyeTransform, const Mat4* eye
         // culling and other stuff.
         if (eyeProjection)
             camera->setAdditionalProjection(*eyeProjection * camera->getProjectionMatrix().getInversed());
-        else
-            camera->setAdditionalTransform(eyeTransform.getInversed());
 
         director->pushMatrix(MATRIX_STACK_TYPE::MATRIX_STACK_PROJECTION);
         director->loadMatrix(MATRIX_STACK_TYPE::MATRIX_STACK_PROJECTION, Camera::_visitingCamera->getViewProjectionMatrix());

--- a/cocos/base/CCEventDispatcher.cpp
+++ b/cocos/base/CCEventDispatcher.cpp
@@ -845,8 +845,10 @@ void EventDispatcher::dispatchTouchEventToListeners(EventListenerVector* listene
             // second, for all camera call all listeners
             // get a copy of cameras, prevent it's been modified in listener callback
             // if camera's depth is greater, process it earlier
-            for (auto& camera: scene->getCameras())
+            auto cameras = scene->getCameras();
+            for (auto rit = cameras.rbegin(); rit != cameras.rend(); ++rit)
             {
+                Camera* camera = *rit;
                 if (camera->isVisible() == false)
                 {
                     continue;


### PR DESCRIPTION
use reverse Camera iterator when traversing events (of course).
but somehow setAdditionalTransform() breaks
setNodeToParentTransform(). And since setAdditionalTransform is not
needed, we just don't use it.

Github issue #15909
