### PR TITLE
fix: not crash after removing a physics body right after...

### DIFF
--- a/cocos/physics/CCPhysicsBody.cpp
+++ b/cocos/physics/CCPhysicsBody.cpp
@@ -953,7 +953,11 @@ void PhysicsBody::onAdd()
 
 void PhysicsBody::onRemove()
 {
+    CCASSERT(_owner != nullptr, "_owner can't be nullptr");
+
     removeFromPhysicsWorld();
+
+    _owner->_physicsBody = nullptr;
 }
 
 void PhysicsBody::addToPhysicsWorld()
@@ -968,10 +972,11 @@ void PhysicsBody::addToPhysicsWorld()
 
 void PhysicsBody::removeFromPhysicsWorld()
 {
-    if (_world)
+    if (_owner)
     {
-        _world->removeBody(this);
-        _world = nullptr;
+        auto scene = _owner->getScene();
+        if (scene)
+            scene->getPhysicsWorld()->removeBody(this);
     }
 }
 

--- a/tests/cpp-tests/Classes/PhysicsTest/PhysicsTest.cpp
+++ b/tests/cpp-tests/Classes/PhysicsTest/PhysicsTest.cpp
@@ -27,6 +27,7 @@ PhysicsTests::PhysicsTests()
     ADD_TEST_CASE(PhysicsFixedUpdate);
     ADD_TEST_CASE(PhysicsTransformTest);
     ADD_TEST_CASE(PhysicsIssue9959);
+    ADD_TEST_CASE(PhysicsIssue15932);
 }
 
 namespace
@@ -1864,6 +1865,26 @@ std::string PhysicsIssue9959::title() const
 std::string PhysicsIssue9959::subtitle() const
 {
     return "Test Scale9Sprite run scale/move/rotation action in physics scene";
+}
+
+//
+void PhysicsIssue15932::onEnter()
+{
+    PhysicsDemo::onEnter();
+
+    PhysicsBody *pb=PhysicsBody::createBox(Size(15,5),PhysicsMaterial(0.1f,0.0f,1.0f));
+    this->addComponent(pb);
+    this->removeComponent(pb);
+}
+
+std::string PhysicsIssue15932::title() const
+{
+    return "Github issue #15932";
+}
+
+std::string PhysicsIssue15932::subtitle() const
+{
+    return "addComponent()/removeComponent() should not crash";
 }
 
 #endif

--- a/tests/cpp-tests/Classes/PhysicsTest/PhysicsTest.h
+++ b/tests/cpp-tests/Classes/PhysicsTest/PhysicsTest.h
@@ -267,4 +267,14 @@ public:
     virtual std::string subtitle() const override;
 };
 
+class PhysicsIssue15932 : public PhysicsDemo
+{
+public:
+    CREATE_FUNC(PhysicsIssue15932);
+
+    void onEnter() override;
+    virtual std::string title() const override;
+    virtual std::string subtitle() const override;
+};
+
 #endif // #if CC_USE_PHYSICS


### PR DESCRIPTION
adding it.

Github issue #15932 
