### PR TITLE
Use nullptr instead of 0 or NULL whenever possible

### DIFF
--- a/cocos/2d/CCFontFNT.cpp
+++ b/cocos/2d/CCFontFNT.cpp
@@ -685,11 +685,11 @@ int * FontFNT::getHorizontalKerningForTextUTF16(const std::u16string& text, int 
     outNumLetters = static_cast<int>(text.length());
     
     if (!outNumLetters)
-        return 0;
+        return nullptr;
     
     int *sizes = new (std::nothrow) int[outNumLetters];
     if (!sizes)
-        return 0;
+        return nullptr;
     
     for (int c = 0; c < outNumLetters; ++c)
     {

--- a/cocos/3d/CCBundleReader.cpp
+++ b/cocos/3d/CCBundleReader.cpp
@@ -87,7 +87,7 @@ ssize_t BundleReader::read(void* ptr, ssize_t size, ssize_t count)
 char* BundleReader::readLine(int num,char* line)
 {
     if (!_buffer)
-        return 0;
+        return nullptr;
 
     char* buffer = (char*)_buffer+_position;
     char* p = line;

--- a/cocos/audio/android/cddSimpleAudioEngine.cpp
+++ b/cocos/audio/android/cddSimpleAudioEngine.cpp
@@ -29,7 +29,7 @@ THE SOFTWARE.
 
 namespace CocosDenshion {
 
-    static SimpleAudioEngine *s_pEngine = 0;
+    static SimpleAudioEngine *s_pEngine = nullptr;
 
     SimpleAudioEngine* SimpleAudioEngine::getInstance() {
         if (! s_pEngine) {
@@ -42,7 +42,7 @@ namespace CocosDenshion {
     void SimpleAudioEngine::end() {
         if (s_pEngine) {
             delete s_pEngine;
-            s_pEngine = NULL;
+            s_pEngine = nullptr;
         }
     }
 

--- a/cocos/audio/apple/AudioCache.mm
+++ b/cocos/audio/apple/AudioCache.mm
@@ -39,10 +39,10 @@
 typedef ALvoid	AL_APIENTRY	(*alBufferDataStaticProcPtr) (const ALint bid, ALenum format, ALvoid* data, ALsizei size, ALsizei freq);
 static ALvoid  alBufferDataStaticProc(const ALint bid, ALenum format, ALvoid* data, ALsizei size, ALsizei freq)
 {
-	static	alBufferDataStaticProcPtr	proc = NULL;
+    static alBufferDataStaticProcPtr proc = nullptr;
     
-    if (proc == NULL){
-        proc = (alBufferDataStaticProcPtr) alcGetProcAddress(NULL, (const ALCchar*) "alBufferDataStatic");
+    if (proc == nullptr) {
+        proc = (alBufferDataStaticProcPtr) alcGetProcAddress(nullptr, (const ALCchar*) "alBufferDataStatic");
     }
     
     if (proc){

--- a/cocos/audio/ios/SimpleAudioEngine.mm
+++ b/cocos/audio/ios/SimpleAudioEngine.mm
@@ -169,7 +169,7 @@ void SimpleAudioEngine::end()
     if (s_pEngine)
     {
         delete s_pEngine;
-        s_pEngine = NULL;
+        s_pEngine = nullptr;
     }
     
     static_end();

--- a/cocos/audio/mac/SimpleAudioEngine.mm
+++ b/cocos/audio/mac/SimpleAudioEngine.mm
@@ -170,7 +170,7 @@ void SimpleAudioEngine::end()
     if (s_pEngine)
     {
         delete s_pEngine;
-        s_pEngine = NULL;
+        s_pEngine = nullptr;
     }
     
     static_end();

--- a/cocos/audio/win32/SimpleAudioEngine.cpp
+++ b/cocos/audio/win32/SimpleAudioEngine.cpp
@@ -82,7 +82,7 @@ void SimpleAudioEngine::end()
     while (p != sharedList().end())
     {
         delete p->second;
-        p->second = NULL;
+        p->second = nullptr;
         p++;
     }   
     sharedList().clear();
@@ -251,7 +251,7 @@ void SimpleAudioEngine::unloadEffect(const char* pszFilePath)
     if (p != sharedList().end())
     {
         delete p->second;
-        p->second = NULL;
+        p->second = nullptr;
         sharedList().erase(nID);
     }    
 }

--- a/cocos/audio/winrt/AudioSourceReader.cpp
+++ b/cocos/audio/winrt/AudioSourceReader.cpp
@@ -404,7 +404,7 @@ HRESULT MP3Reader::readAudioData(IMFSourceReader* pReader)
 
             _audioSize += cbSize;
             hr = pBuffer->Unlock();
-            pAudioData = NULL;
+            pAudioData = nullptr;
         }
 
         if (FAILED(hr)) {

--- a/cocos/audio/winrt/SimpleAudioEngine.cpp
+++ b/cocos/audio/winrt/SimpleAudioEngine.cpp
@@ -28,7 +28,7 @@ USING_NS_CC;
 
 namespace CocosDenshion {
 
-Audio* s_audioController = NULL;
+Audio* s_audioController = nullptr;
 bool s_initialized = false;
 
 SimpleAudioEngine* SimpleAudioEngine::getInstance()
@@ -42,7 +42,7 @@ static Audio* sharedAudioController()
 {
     if (! s_audioController || !s_initialized)
     {
-        if(s_audioController == NULL)
+        if (s_audioController == nullptr)
         {
             s_audioController = new Audio;
         }

--- a/cocos/base/CCProperties.cpp
+++ b/cocos/base/CCProperties.cpp
@@ -88,7 +88,7 @@ Properties* Properties::createNonRefCounted(const std::string& url)
     if (url.size() == 0)
     {
         CCLOGERROR("Attempting to create a Properties object from an empty URL!");
-        return NULL;
+        return nullptr;
     }
 
     // Calculate the file and full namespace path from the specified url.
@@ -111,7 +111,7 @@ Properties* Properties::createNonRefCounted(const std::string& url)
     {
         CCLOGWARN("Failed to load properties from url '%s'.", url.c_str());
         CC_SAFE_DELETE(properties);
-        return NULL;
+        return nullptr;
     }
 
     // If the loaded properties object is not the root namespace,
@@ -650,7 +650,7 @@ Properties* Properties::getNextNamespace()
         return ns;
     }
 
-    return NULL;
+    return nullptr;
 }
 
 void Properties::rewind()
@@ -678,7 +678,7 @@ Properties* Properties::getNamespace(const char* id, bool searchNames, bool recu
         }
     }
 
-    return NULL;
+    return nullptr;
 }
 
 const char* Properties::getNamespace() const
@@ -1150,7 +1150,7 @@ Properties* getPropertiesFromNamespacePath(Properties* properties, const std::ve
                 if (iter == NULL)
                 {
                     CCLOGWARN("Failed to load properties object from url.");
-                    return NULL;
+                    return nullptr;
                 }
 
                 if (strcmp(iter->getId(), namespacePath[i].c_str()) == 0)

--- a/cocos/base/CCUserDefault-winrt.cpp
+++ b/cocos/base/CCUserDefault-winrt.cpp
@@ -246,7 +246,7 @@ void UserDefault::setDataForKey(const char* pKey, const Data& value) {
         return;
     }
 
-    char *encodedData = 0;
+    char *encodedData = nullptr;
     base64Encode(value.getBytes(), static_cast<unsigned int>(value.getSize()), &encodedData);
 
     setPlatformKeyValue(pKey, dynamic_cast<PropertyValue^>(PropertyValue::CreateString(PlatformStringFromString(encodedData))));

--- a/cocos/base/ccUtils.cpp
+++ b/cocos/base/ccUtils.cpp
@@ -136,7 +136,7 @@ void onCaptureScreen(const std::function<void(bool, const std::string&)>& afterC
                 startedCapture = false;
             };
 
-            AsyncTaskPool::getInstance()->enqueue(AsyncTaskPool::TaskType::TASK_IO, mainThread, (void*)NULL, [image, outputFile]()
+            AsyncTaskPool::getInstance()->enqueue(AsyncTaskPool::TaskType::TASK_IO, mainThread, nullptr, [image, outputFile]()
             {
                 succeedSaveToFile = image->saveToFile(outputFile);
                 delete image;

--- a/cocos/navmesh/CCNavMeshUtils.cpp
+++ b/cocos/navmesh/CCNavMeshUtils.cpp
@@ -52,9 +52,9 @@ void LinearAllocator::free(void* /*ptr*/)
 void* LinearAllocator::alloc(const int size)
 {
     if (!buffer)
-        return 0;
+        return nullptr;
     if (top + size > capacity)
-        return 0;
+        return nullptr;
     unsigned char* mem = &buffer[top];
     top += size;
     return mem;

--- a/cocos/platform/android/CCApplication-android.cpp
+++ b/cocos/platform/android/CCApplication-android.cpp
@@ -49,7 +49,7 @@ static const std::string helperClassName = "org/cocos2dx/lib/Cocos2dxHelper";
 NS_CC_BEGIN
 
 // sharedApplication pointer
-Application * Application::sm_pSharedApplication = 0;
+Application * Application::sm_pSharedApplication = nullptr;
 
 Application::Application()
 {
@@ -60,7 +60,7 @@ Application::Application()
 Application::~Application()
 {
     CCAssert(this == sm_pSharedApplication, "");
-    sm_pSharedApplication = NULL;
+    sm_pSharedApplication = nullptr;
 }
 
 int Application::run()

--- a/cocos/platform/ios/CCApplication-ios.mm
+++ b/cocos/platform/ios/CCApplication-ios.mm
@@ -34,7 +34,7 @@
 
 NS_CC_BEGIN
 
-Application* Application::sm_pSharedApplication = 0;
+Application* Application::sm_pSharedApplication = nullptr;
 
 Application::Application()
 {

--- a/cocos/platform/linux/CCApplication-linux.cpp
+++ b/cocos/platform/linux/CCApplication-linux.cpp
@@ -37,7 +37,7 @@ NS_CC_BEGIN
 
 
 // sharedApplication pointer
-Application * Application::sm_pSharedApplication = 0;
+Application * Application::sm_pSharedApplication = nullptr;
 
 static long getCurrentMillSecond() {
     long lLastTime;
@@ -58,7 +58,7 @@ Application::Application()
 Application::~Application()
 {
     CC_ASSERT(this == sm_pSharedApplication);
-    sm_pSharedApplication = NULL;
+    sm_pSharedApplication = nullptr;
 }
 
 int Application::run()

--- a/cocos/platform/linux/CCFileUtils-linux.cpp
+++ b/cocos/platform/linux/CCFileUtils-linux.cpp
@@ -46,13 +46,13 @@ NS_CC_BEGIN
 
 FileUtils* FileUtils::getInstance()
 {
-    if (s_sharedFileUtils == NULL)
+    if (s_sharedFileUtils == nullptr)
     {
         s_sharedFileUtils = new FileUtilsLinux();
         if(!s_sharedFileUtils->init())
         {
           delete s_sharedFileUtils;
-          s_sharedFileUtils = NULL;
+          s_sharedFileUtils = nullptr;
           CCLOG("ERROR: Could not init CCFileUtilsLinux");
         }
     }

--- a/cocos/platform/mac/CCApplication-mac.mm
+++ b/cocos/platform/mac/CCApplication-mac.mm
@@ -46,7 +46,7 @@ static long getCurrentMillSecond()
     return lLastTime;
 }
 
-Application* Application::sm_pSharedApplication = 0;
+Application* Application::sm_pSharedApplication = nullptr;
 
 Application::Application()
 : _animationInterval(1.0f/60.0f*1000.0f)

--- a/cocos/platform/win32/CCApplication-win32.cpp
+++ b/cocos/platform/win32/CCApplication-win32.cpp
@@ -41,7 +41,7 @@ static void PVRFrameEnableControlWindow(bool bEnable);
 NS_CC_BEGIN
 
 // sharedApplication pointer
-Application * Application::sm_pSharedApplication = 0;
+Application * Application::sm_pSharedApplication = nullptr;
 
 Application::Application()
 : _instance(nullptr)

--- a/cocos/platform/win32/CCDevice-win32.cpp
+++ b/cocos/platform/win32/CCDevice-win32.cpp
@@ -243,7 +243,7 @@ public:
     int drawText(const char * pszText, SIZE& tSize, Device::TextAlign eAlign)
     {
         int nRet = 0;
-        wchar_t * pwszBuffer = 0;
+        wchar_t * pwszBuffer = nullptr;
         wchar_t* fixedText = nullptr;
         do
         {

--- a/cocos/platform/winrt/CCApplication.cpp
+++ b/cocos/platform/winrt/CCApplication.cpp
@@ -46,7 +46,7 @@ using namespace Windows::Foundation;
 NS_CC_BEGIN
 
 // sharedApplication pointer
-Application * Application::sm_pSharedApplication = 0;
+Application * Application::sm_pSharedApplication = nullptr;
 
 
 
@@ -57,7 +57,7 @@ Application * Application::sm_pSharedApplication = 0;
 ////////////////////////////////////////////////////////////////////////////////
 
 // sharedApplication pointer
-Application * s_pSharedApplication = 0;
+Application * s_pSharedApplication = nullptr;
 
 Application::Application() :
 m_openURLDelegate(nullptr)
@@ -70,7 +70,7 @@ m_openURLDelegate(nullptr)
 Application::~Application()
 {
     CC_ASSERT(this == sm_pSharedApplication);
-    sm_pSharedApplication = NULL;
+    sm_pSharedApplication = nullptr;
 }
 
 int Application::run()

--- a/cocos/platform/winrt/CCFileUtilsWinRT.cpp
+++ b/cocos/platform/winrt/CCFileUtilsWinRT.cpp
@@ -84,13 +84,13 @@ static void _checkPath()
 
 FileUtils* FileUtils::getInstance()
 {
-    if (s_sharedFileUtils == NULL)
+    if (s_sharedFileUtils == nullptr)
     {
         s_sharedFileUtils = new CCFileUtilsWinRT();
         if(!s_sharedFileUtils->init())
         {
           delete s_sharedFileUtils;
-          s_sharedFileUtils = NULL;
+          s_sharedFileUtils = nullptr;
           CCLOG("ERROR: Could not init CCFileUtilsWinRT");
         }
     }
@@ -184,7 +184,7 @@ FileUtils::Status CCFileUtilsWinRT::getContents(const std::string& filename, Res
 bool CCFileUtilsWinRT::isFileExistInternal(const std::string& strFilePath) const
 {
     bool ret = false;
-    FILE * pf = 0;
+    FILE * pf = nullptr;
 
     std::string strPath = strFilePath;
     if (!isAbsolutePath(strPath))

--- a/cocos/platform/winrt/CCGLViewImpl-winrt.cpp
+++ b/cocos/platform/winrt/CCGLViewImpl-winrt.cpp
@@ -60,7 +60,7 @@ using namespace Microsoft::WRL;
 
 NS_CC_BEGIN
 
-static GLViewImpl* s_pEglView = NULL;
+static GLViewImpl* s_pEglView = nullptr;
 
 GLViewImpl* GLViewImpl::create(const std::string& viewName)
 {
@@ -103,7 +103,7 @@ GLViewImpl::GLViewImpl()
 GLViewImpl::~GLViewImpl()
 {
 	CC_ASSERT(this == s_pEglView);
-    s_pEglView = NULL;
+    s_pEglView = nullptr;
 
 	// TODO: cleanup 
 }

--- a/cocos/platform/winrt/CCGLViewImpl.cpp
+++ b/cocos/platform/winrt/CCGLViewImpl.cpp
@@ -54,7 +54,7 @@ using namespace Windows::UI::ViewManagement;
 
 NS_CC_BEGIN
 
-static GLViewImpl* s_pEglView = NULL;
+static GLViewImpl* s_pEglView = nullptr;
 
 //////////////////////////////////////////////////////////////////////////
 // implement GLView
@@ -408,7 +408,7 @@ GLViewImpl::GLViewImpl()
 GLViewImpl::~GLViewImpl()
 {
 	CC_ASSERT(this == s_pEglView);
-    s_pEglView = NULL;
+    s_pEglView = nullptr;
 
 	// TODO: cleanup 
 }

--- a/cocos/platform/winrt/CCPrecompiledShaders.cpp
+++ b/cocos/platform/winrt/CCPrecompiledShaders.cpp
@@ -38,7 +38,7 @@ using namespace concurrency;
 NS_CC_BEGIN
 
 // singleton stuff
-static CCPrecompiledShaders *s_pPrecompiledShaders = NULL;
+static CCPrecompiledShaders *s_pPrecompiledShaders = nullptr;
 
 #define SHADER_NAME_PREFIX "s_"
 

--- a/cocos/scripting/js-bindings/manual/ScriptingCore.cpp
+++ b/cocos/scripting/js-bindings/manual/ScriptingCore.cpp
@@ -663,7 +663,7 @@ JSScript* ScriptingCore::getScript(const char *path)
     if (filename_script.find(fullPath) != filename_script.end())
         return filename_script[fullPath];
 
-    return NULL;
+    return nullptr;
 }
 
 void ScriptingCore::compileScript(const char *path, JS::HandleObject global, JSContext* cx)

--- a/cocos/scripting/lua-bindings/manual/cocos2d/LuaOpengl.cpp
+++ b/cocos/scripting/lua-bindings/manual/cocos2d/LuaOpengl.cpp
@@ -4344,7 +4344,7 @@ static int tolua_Cocos2d_glVertexAttribPointer00(lua_State* tolua_S)
         bool arg3 = tolua_toboolean(tolua_S, 4, 0);
         int arg4 = (int)tolua_tonumber(tolua_S, 5, 0);
         //int arg5 = (int)tolua_tonumber(tolua_S, 7, 0);
-        glVertexAttribPointer((GLuint)arg0 , (GLint)arg1 , (GLenum)arg2 , (GLboolean)arg3 , (GLsizei)arg4 , (GLvoid*)NULL);
+        glVertexAttribPointer((GLuint)arg0, (GLint)arg1, (GLenum)arg2, (GLboolean)arg3, (GLsizei)arg4, nullptr);
     }
     return 0;
 #ifndef TOLUA_RELEASE

--- a/cocos/ui/UIEditBox/UIEditBoxImpl-stub.cpp
+++ b/cocos/ui/UIEditBox/UIEditBoxImpl-stub.cpp
@@ -8,7 +8,7 @@ namespace ui {
 
 EditBoxImpl* __createSystemEditBox(EditBox* pEditBox)
 {
-    return NULL;
+    return nullptr;
 }
 
 }

--- a/extensions/Particle3D/PU/CCPUObserver.cpp
+++ b/extensions/Particle3D/PU/CCPUObserver.cpp
@@ -170,7 +170,7 @@ PUEventHandler* PUObserver::getEventHandler (size_t index) const
 PUEventHandler* PUObserver::getEventHandler (const std::string& eventHandlerName) const
 {
     if (eventHandlerName.empty())
-        return 0;
+        return nullptr;
 
     ParticleEventHandlerConstIterator it;
     ParticleEventHandlerConstIterator itEnd = _eventHandlers.end();
@@ -182,7 +182,7 @@ PUEventHandler* PUObserver::getEventHandler (const std::string& eventHandlerName
         }
     }
 
-    return 0;
+    return nullptr;
 }
 //-----------------------------------------------------------------------
 size_t PUObserver::getNumEventHandlers (void) const


### PR DESCRIPTION
This pull request changes some null pointer constants to nullptr for the following reasons:
- When compiling with the latest GCC, they will cause `-Wzero-as-null-pointer-constant` warnings.
- If possible, we should follow [our adopted coding style](https://github.com/cocos2d/cocos2d-x/wiki/Cpp--Coding-Style#0-and-nullptrnull) for better maintenance and readability.

Thanks!
