### PR TITLE
Fix -Wreturn-type warnings when compiling JSB with Clang

### DIFF
--- a/cocos/scripting/js-bindings/manual/experimental/jsb_cocos2dx_experimental_video_manual.cpp
+++ b/cocos/scripting/js-bindings/manual/experimental/jsb_cocos2dx_experimental_video_manual.cpp
@@ -34,6 +34,9 @@ static bool jsb_cocos2dx_experimental_ui_VideoPlayer_addEventListener(JSContext 
         });
         return true;
     }
+
+    JS_ReportError(cx, "jsb_cocos2dx_experimental_ui_VideoPlayer_addEventListener : wrong number of arguments: %d, was expecting %d", argc, 1);
+    return false;
 }
 
 extern JSObject* jsb_cocos2d_experimental_ui_VideoPlayer_prototype;

--- a/cocos/scripting/js-bindings/manual/experimental/jsb_cocos2dx_experimental_webView_manual.cpp
+++ b/cocos/scripting/js-bindings/manual/experimental/jsb_cocos2dx_experimental_webView_manual.cpp
@@ -35,6 +35,9 @@ static bool jsb_cocos2dx_experimental_webView_setOnShouldStartLoading(JSContext 
         });
         return true;
     }
+
+    JS_ReportError(cx, "jsb_cocos2dx_experimental_webView_setOnShouldStartLoading : wrong number of arguments: %d, was expecting %d", argc, 1);
+    return false;
 }
 
 static bool jsb_cocos2dx_experimental_webView_setOnDidFinishLoading(JSContext *cx, uint32_t argc, jsval *vp)
@@ -62,6 +65,9 @@ static bool jsb_cocos2dx_experimental_webView_setOnDidFinishLoading(JSContext *c
         });
         return true;
     }
+
+    JS_ReportError(cx, "jsb_cocos2dx_experimental_webView_setOnDidFinishLoading : wrong number of arguments: %d, was expecting %d", argc, 1);
+    return false;
 }
 
 static bool jsb_cocos2dx_experimental_webView_setOnDidFailLoading(JSContext *cx, uint32_t argc, jsval *vp)
@@ -89,6 +95,9 @@ static bool jsb_cocos2dx_experimental_webView_setOnDidFailLoading(JSContext *cx,
         });
         return true;
     }
+
+    JS_ReportError(cx, "jsb_cocos2dx_experimental_webView_setOnDidFailLoading : wrong number of arguments: %d, was expecting %d", argc, 1);
+    return false;
 }
 
 static bool jsb_cocos2dx_experimental_webView_setOnJSCallback(JSContext *cx, uint32_t argc, jsval *vp)
@@ -116,6 +125,9 @@ static bool jsb_cocos2dx_experimental_webView_setOnJSCallback(JSContext *cx, uin
         });
         return true;
     }
+
+    JS_ReportError(cx, "jsb_cocos2dx_experimental_webView_setOnJSCallback : wrong number of arguments: %d, was expecting %d", argc, 1);
+    return false;
 }
 extern JSObject* jsb_cocos2d_experimental_ui_WebView_prototype;
 


### PR DESCRIPTION
When compiling libjscocos2d iOS/Android under Xcode 7.3 or Android NDK r10e with Clang, I get the following `-Wreturn-type` warnings:

```
cocos/scripting/js-bindings/manual/experimental/jsb_cocos2dx_experimental_video_manual.cpp:37:1: warning: control may reach end of non-void function [-Wreturn-type]
cocos/scripting/js-bindings/manual/experimental/jsb_cocos2dx_experimental_webView_manual.cpp:38:1: warning: control may reach end of non-void function [-Wreturn-type]
cocos/scripting/js-bindings/manual/experimental/jsb_cocos2dx_experimental_webView_manual.cpp:65:1: warning: control may reach end of non-void function [-Wreturn-type]
cocos/scripting/js-bindings/manual/experimental/jsb_cocos2dx_experimental_webView_manual.cpp:92:1: warning: control may reach end of non-void function [-Wreturn-type]
cocos/scripting/js-bindings/manual/experimental/jsb_cocos2dx_experimental_webView_manual.cpp:119:1: warning: control may reach end of non-void function [-Wreturn-type]
```

This pull request adds missing `return` statements and `JS_ReportError()` calls to fix them.
Thank you as always for the great work. :smiley:
