### PR TITLE
fix part of the android restart game crash in Layer::Color to glDrawArrays

### DIFF
--- a/cocos/renderer/ccGLStateCache.cpp
+++ b/cocos/renderer/ccGLStateCache.cpp
@@ -64,7 +64,6 @@ void invalidateStateCache( void )
 {
     Director::getInstance()->resetMatrixStack();
     s_currentProjectionMatrix = -1;
-    s_attributeFlags = 0;
 
 #if CC_ENABLE_GL_STATE_CACHE
     s_currentShaderProgram = -1;


### PR DESCRIPTION
restart game -> call invalidateStateCache to s_attributeFlags  = 0;
-> reset  glEnableVertexAttribArray type, Cause glDrawArrays crash.

part of the android (test mi3, huawei)
