### PR TITLE
Avoid implicit conversion from size_t to int

### DIFF
--- a/cocos/scripting/js-bindings/manual/jsb_opengl_manual.cpp
+++ b/cocos/scripting/js-bindings/manual/jsb_opengl_manual.cpp
@@ -380,7 +380,7 @@ bool JSB_glGetSupportedExtensions(JSContext *cx, uint32_t argc, jsval *vp)
     GLubyte* copy = new (std::nothrow) GLubyte[len+1];
     strncpy((char*)copy, (const char*)extensions, len );
 
-    int start_extension=0;
+    size_t start_extension = 0;
     int element=0;
     for( size_t i=0; i<len+1; i++) {
         if( copy[i]==' ' || copy[i]==',' || i==len ) {


### PR DESCRIPTION
This patch fixes a implicit conversion warning below when compiling libjscocos2d with Xcode 7.3.1:

```
cocos/scripting/js-bindings/manual/jsb_opengl_manual.cpp:392:32: Implicit conversion loses integer precision: 'unsigned long' to 'int'
```
