### PR TITLE
fix: FPS appears on iOS

### DIFF
--- a/cocos/base/CCDirector.cpp
+++ b/cocos/base/CCDirector.cpp
@@ -256,6 +256,14 @@ void Director::setGLDefaultValues()
     setAlphaBlending(true);
     setDepthTest(false);
     setProjection(_projection);
+
+    // Everything should be drawn within `Scene::render()`.
+    // Otherwise it might not render correctly since the GL state might not be the correct one
+    // so the FPS should be part of Scene. But until we move them there, this little hack is to
+    // set the default glViewPort(), so that when `Scene::render()` exits, the viewport is the correct
+    // one for the FPS
+    auto vp = Camera::getDefaultViewport();
+    glViewport(vp._left, vp._bottom, vp._width, vp._height);
 }
 
 // Draw the Scene


### PR DESCRIPTION
`glViewport()` has a default value so that it has a valid value
after `Scene::render()` exits

Github issue #15934
