### PR TITLE
Fix typo in FileUtils::Status enum

### DIFF
--- a/cocos/platform/CCFileUtils.cpp
+++ b/cocos/platform/CCFileUtils.cpp
@@ -650,7 +650,7 @@ FileUtils::Status FileUtils::getContents(const std::string& filename, ResizableB
 
     if (readsize < size) {
         buffer->resize(readsize);
-        return Status::ReadFaild;
+        return Status::ReadFailed;
     }
 
     return Status::OK;

--- a/cocos/platform/CCFileUtils.h
+++ b/cocos/platform/CCFileUtils.h
@@ -166,7 +166,7 @@ public:
         OK = 0,
         NotExists = 1, // File not exists
         OpenFailed = 2, // Open file failed.
-        ReadFaild = 3, // Read failed
+        ReadFailed = 3, // Read failed
         NotInitialized = 4, // FileUtils is not initializes
         TooLarge = 5, // The file is too large (great than 2^32-1)
         ObtainSizeFailed = 6 // Failed to obtain the file size.
@@ -226,7 +226,7 @@ public:
      *      - Status::OK when there is no error, the buffer is filled with the contents of file.
      *      - Status::NotExists when file not exists, the buffer will not changed.
      *      - Status::OpenFailed when cannot open file, the buffer will not changed.
-     *      - Status::ReadFaild when read end up before read whole, the buffer will fill with already read bytes.
+     *      - Status::ReadFailed when read end up before read whole, the buffer will fill with already read bytes.
      *      - Status::NotInitialized when FileUtils is not initializes, the buffer will not changed.
      *      - Status::TooLarge when there file to be read is too large (> 2^32-1), the buffer will not changed.
      *      - Status::ObtainSizeFailed when failed to obtain the file size, the buffer will not changed.

--- a/cocos/platform/android/CCFileUtils-android.cpp
+++ b/cocos/platform/android/CCFileUtils-android.cpp
@@ -295,7 +295,7 @@ FileUtils::Status FileUtilsAndroid::getContents(const std::string& filename, Res
     if (readsize < size) {
         if (readsize >= 0)
             buffer->resize(readsize);
-        return FileUtils::Status::ReadFaild;
+        return FileUtils::Status::ReadFailed;
     }
 
     return FileUtils::Status::OK;

--- a/cocos/platform/win32/CCFileUtils-win32.cpp
+++ b/cocos/platform/win32/CCFileUtils-win32.cpp
@@ -264,7 +264,7 @@ FileUtils::Status FileUtilsWin32::getContents(const std::string& filename, Resiz
     if (!successed) {
 		CCLOG("Get data from file(%s) failed, error code is %s", filename.data(), std::to_string(::GetLastError()).data());
 		buffer->resize(sizeRead);
-		return FileUtils::Status::ReadFaild;
+		return FileUtils::Status::ReadFailed;
     }
     return FileUtils::Status::OK;
 }

--- a/cocos/platform/winrt/CCFileUtilsWinRT.cpp
+++ b/cocos/platform/winrt/CCFileUtilsWinRT.cpp
@@ -176,7 +176,7 @@ FileUtils::Status CCFileUtilsWinRT::getContents(const std::string& filename, Res
     {
         buffer->resize(sizeRead);
         CCLOG("Get data from file(%s) failed, error code is %s", filename.data(), std::to_string(::GetLastError()).data());
-        return FileUtils::Status::ReadFaild;
+        return FileUtils::Status::ReadFailed;
     }
     return FileUtils::Status::OK;
 }

--- a/tests/cpp-tests/Classes/FileUtilsTest/FileUtilsTest.cpp
+++ b/tests/cpp-tests/Classes/FileUtilsTest/FileUtilsTest.cpp
@@ -622,7 +622,7 @@ static const std::string FileErrors[] = {
     "OK",
     "NotExists",
     "OpenFailed",
-    "ReadFaild",
+    "ReadFailed",
     "NotInitialized",
     "TooLarge",
     "ObtainSizeFailed",


### PR DESCRIPTION
This patch corrects a minor typo I found while reading v3.12 features: `ReadFaild` -> `ReadFailed`
