### PR TITLE
Can set scroll to item duration in ListView and derived classes

### DIFF
--- a/cocos/ui/UIListView.cpp
+++ b/cocos/ui/UIListView.cpp
@@ -39,6 +39,7 @@ _gravity(Gravity::CENTER_VERTICAL),
 _magneticType(MagneticType::NONE),
 _magneticAllowedOutOfBoundary(true),
 _itemsMargin(0.0f),
+_scrollTime(DEFAULT_TIME_IN_SEC_FOR_SCROLL_TO_ITEM),
 _curSelectedIndex(-1),
 _innerContainerDoLayoutDirty(true),
 _listViewEventListener(nullptr),
@@ -440,6 +441,17 @@ float ListView::getItemsMargin()const
     return _itemsMargin;
 }
 
+void ListView::setScrollDuration(const float time) 
+{
+    if (time >= 0)
+        _scrollTime = time;
+}
+
+float ListView::getScrollDuration() const 
+{
+    return _scrollTime;
+}
+
 void ListView::setDirection(Direction dir)
 {
     switch (dir)
@@ -775,7 +787,7 @@ void ListView::jumpToItem(ssize_t itemIndex, const Vec2& positionRatioInView, co
 
 void ListView::scrollToItem(ssize_t itemIndex, const Vec2& positionRatioInView, const Vec2& itemAnchorPoint)
 {
-    scrollToItem(itemIndex, positionRatioInView, itemAnchorPoint, DEFAULT_TIME_IN_SEC_FOR_SCROLL_TO_ITEM);
+    scrollToItem(itemIndex, positionRatioInView, itemAnchorPoint, _scrollTime);
 }
 
 void ListView::scrollToItem(ssize_t itemIndex, const Vec2& positionRatioInView, const Vec2& itemAnchorPoint, float timeInSec)

--- a/cocos/ui/UIListView.cpp
+++ b/cocos/ui/UIListView.cpp
@@ -441,7 +441,7 @@ float ListView::getItemsMargin()const
     return _itemsMargin;
 }
 
-void ListView::setScrollDuration(const float time) 
+void ListView::setScrollDuration(float time)
 {
     if (time >= 0)
         _scrollTime = time;

--- a/cocos/ui/UIListView.h
+++ b/cocos/ui/UIListView.h
@@ -245,14 +245,17 @@ public:
     float getItemsMargin()const;
     
     /**
-     * Set time to scroll between items (see scrollToItem)
-     * @param time
+     * Set the time in seconds to scroll between items.
+     * Subsequent calls of function 'scrollToItem', will take 'time' seconds for scrolling.
+     * @param time The seconds needed to scroll between two items. 'time' must be >= 0
+     * @see scrollToItem(ssize_t, const Vec2&, const Vec2&)
      */
-    void  setScrollDuration(const float time);
+    void  setScrollDuration(float time);
     
      /**
-     * Get time to scroll between items
-     * @param time
+     * Get the time in seconds to scroll between items.
+     * @return The time in seconds to scroll between items
+     * @see setScrollDuration(float)
      */
     float getScrollDuration() const;
     

--- a/cocos/ui/UIListView.h
+++ b/cocos/ui/UIListView.h
@@ -244,6 +244,18 @@ public:
      */
     float getItemsMargin()const;
     
+    /**
+     * Set time to scroll between items (see scrollToItem)
+     * @param time
+     */
+    void  setScrollDuration(const float time);
+    
+     /**
+     * Get time to scroll between items
+     * @param time
+     */
+    float getScrollDuration() const;
+    
     //override methods
     virtual void doLayout() override;
     virtual void requestDoLayout() override;
@@ -426,6 +438,8 @@ protected:
     bool _magneticAllowedOutOfBoundary;
     
     float _itemsMargin;
+    
+    float _scrollTime;
     
     ssize_t _curSelectedIndex;
 


### PR DESCRIPTION
This patch add the possibility to set the scroll duration between items.
I found this particularly useful in PageView (derived from ListView).
