### PR TITLE
Improve RefPtr to avoid casting when possible

### DIFF
--- a/cocos/base/CCRefPtr.h
+++ b/cocos/base/CCRefPtr.h
@@ -87,8 +87,7 @@ template <typename T> class RefPtr
 public:
     
     inline RefPtr()
-    :
-        _ptr(nullptr)
+        : _ptr(nullptr)
     {
         
     }
@@ -100,22 +99,19 @@ public:
     }
 
     inline RefPtr(T * ptr)
-    :
-        _ptr(const_cast<typename std::remove_const<T>::type*>(ptr))     // Const cast allows RefPtr<T> to reference objects marked const too.
+        : _ptr(ptr)
     {
         CC_REF_PTR_SAFE_RETAIN(_ptr);
     }
     
     inline RefPtr(std::nullptr_t ptr)
-    :
-        _ptr(nullptr)
+        : _ptr(nullptr)
     {
         
     }
     
     inline RefPtr(const RefPtr<T> & other)
-    :
-        _ptr(other._ptr)
+        : _ptr(other._ptr)
     {
         CC_REF_PTR_SAFE_RETAIN(_ptr);
     }
@@ -155,7 +151,7 @@ public:
         {
             CC_REF_PTR_SAFE_RETAIN(other);
             CC_REF_PTR_SAFE_RELEASE(_ptr);
-            _ptr = const_cast<typename std::remove_const<T>::type*>(other);     // Const cast allows RefPtr<T> to reference objects marked const too.
+            _ptr = other;
         }
         
         return *this;
@@ -167,26 +163,21 @@ public:
         return *this;
     }
     
-    // Note: using reinterpret_cast<> instead of static_cast<> here because it doesn't require type info.
-    // Since we verify the correct type cast at compile time on construction/assign we don't need to know the type info
-    // here. Not needing the type info here enables us to use these operations in inline functions in header files when
-    // the type pointed to by this class is only forward referenced.
-    
-    inline operator T * () const { return reinterpret_cast<T*>(_ptr); }
+    inline operator T * () const { return _ptr; }
     
     inline T & operator * () const
     {
         CCASSERT(_ptr, "Attempt to dereference a null pointer!");
-        return reinterpret_cast<T&>(*_ptr);
+        return *_ptr;
     }
     
     inline T * operator->() const
     {
         CCASSERT(_ptr, "Attempt to dereference a null pointer!");
-        return reinterpret_cast<T*>(_ptr);
+        return _ptr;
     }
     
-    inline T * get() const { return reinterpret_cast<T*>(_ptr); }
+    inline T * get() const { return _ptr; }
     
     
     inline bool operator == (const RefPtr<T> & other) const { return _ptr == other._ptr; }
@@ -246,7 +237,7 @@ public:
     {
         if (&other != this)
         {
-            Ref * tmp = _ptr;
+            T * tmp = _ptr;
             _ptr = other._ptr;
             other._ptr = tmp;
         }
@@ -273,7 +264,10 @@ public:
     }
     
 private:
-    Ref * _ptr;
+    T * _ptr;
+
+    // NOTE: We can ensure T is derived from cocos2d::Ref at compile time here.
+    static_assert(std::is_base_of<Ref, typename std::remove_const<T>::type>::value, "T must be derived from Ref");
 };
     
 template<class T> inline

--- a/tests/cpp-tests/Classes/UnitTest/RefPtrTest.cpp
+++ b/tests/cpp-tests/Classes/UnitTest/RefPtrTest.cpp
@@ -117,6 +117,13 @@ void RefPtrTest::onEnter()
         
         ref1.reset();
         CC_ASSERT((__String*) nullptr == ref1.get());
+
+        RefPtr<__String const> ref2 = __String::create("Hello");
+        CC_ASSERT(strcmp("Hello", ref2.get()->getCString()) == 0);
+        
+        ref2.reset();
+        CC_ASSERT(nullptr == ref2.get());
+        static_assert(std::is_same<const __String*, decltype(ref2.get())>::value, "");
     }
     
     // TEST(reset)


### PR DESCRIPTION
This pull request improves the `RefPtr` implementation. It does the following:
- Replace the type of `RefPtr::_ptr` with `T*` instead of `Ref*` to avoid casting when possible
- Remove unneeded `reinterpret_cast` and `const_cast`
- Add `static_assert` to ensure `T` is derived from `cocos2d::Ref` at compile-time
- Add test case for `RefPtr<T const>`
- Minor code formatting

This change has no overhead at runtime. It also provides more compile-time safety.
Thanks!
