### PR TITLE
Avoid const_cast when calling Node::setAdditionalTransform

### DIFF
--- a/cocos/2d/CCNode.cpp
+++ b/cocos/2d/CCNode.cpp
@@ -1800,7 +1800,7 @@ void Node::setAdditionalTransform(const AffineTransform& additionalTransform)
     setAdditionalTransform(&tmp);
 }
 
-void Node::setAdditionalTransform(Mat4* additionalTransform)
+void Node::setAdditionalTransform(const Mat4* additionalTransform)
 {
     if (additionalTransform == nullptr)
     {
@@ -1823,8 +1823,7 @@ void Node::setAdditionalTransform(Mat4* additionalTransform)
 
 void Node::setAdditionalTransform(const Mat4& additionalTransform)
 {
-    Mat4* mat4= const_cast<Mat4*>(&additionalTransform);
-    setAdditionalTransform(mat4);
+    setAdditionalTransform(&additionalTransform);
 }
 
 AffineTransform Node::getParentToNodeAffineTransform() const

--- a/cocos/2d/CCNode.h
+++ b/cocos/2d/CCNode.h
@@ -1643,7 +1643,7 @@ public:
      *
      * @param additionalTransform An additional transform matrix.
      */
-    void setAdditionalTransform(Mat4* additionalTransform);
+    void setAdditionalTransform(const Mat4* additionalTransform);
     void setAdditionalTransform(const Mat4& additionalTransform);
     void setAdditionalTransform(const AffineTransform& additionalTransform);
 


### PR DESCRIPTION
This PR adds a const qualifier to `Node::setAdditionalTransform(Mat4*)` parameter and removes unnecessary `const_cast` for the reasons below:
- The definition of `Node::setAdditionalTransform(Mat4*)` doesn't seem to require non-const parameter which should be const. It can also use `const Mat4*` instead.
- We should avoid using `const_cast` whenever possible for better maintenance and performance.

The function is not virtual, so this change doesn't break backward compatibility.
Thanks.
