### PR TITLE
Fix some minor typos in local variable names

### DIFF
--- a/cocos/3d/CCBundle3D.cpp
+++ b/cocos/3d/CCBundle3D.cpp
@@ -924,9 +924,9 @@ bool Bundle3D::loadMaterialsBinary(MaterialDatas& materialdatas)
         float  data[14];
         _binaryReader.read(&data,sizeof(float), 14);
         
-        unsigned int textruenum = 1;
-        _binaryReader.read(&textruenum, 4, 1);
-        for(unsigned int j = 0; j < textruenum ; j++ )
+        unsigned int textureNum = 1;
+        _binaryReader.read(&textureNum, 4, 1);
+        for (unsigned int j = 0; j < textureNum; j++)
         {
             NTextureData  textureData;
             textureData.id = _binaryReader.readString();

--- a/cocos/base/CCDirector.cpp
+++ b/cocos/base/CCDirector.cpp
@@ -908,8 +908,8 @@ void Director::popToSceneStackLevel(int level)
     if (level >= c)
         return;
 
-    auto fisrtOnStackScene = _scenesStack.back();
-    if (fisrtOnStackScene == _runningScene)
+    auto firstOnStackScene = _scenesStack.back();
+    if (firstOnStackScene == _runningScene)
     {
 #if CC_ENABLE_GC_FOR_NATIVE_OBJECTS
         auto sEngine = ScriptEngineManager::getInstance()->getScriptEngine();

--- a/cocos/base/CCProfiling.cpp
+++ b/cocos/base/CCProfiling.cpp
@@ -118,10 +118,10 @@ ProfilingTimer::~ProfilingTimer(void)
 
 std::string ProfilingTimer::getDescription() const
 {
-    static char s_desciption[512] = {0};
+    static char s_description[512] = {0};
 
-    sprintf(s_desciption, "%s ::\tavg1: %ldµ,\tavg2: %ldµ,\tmin: %ldµ,\tmax: %ldµ,\ttotal: %.2fs,\tnr calls: %ld", _nameStr.c_str(), _averageTime1, _averageTime2, minTime, maxTime, totalTime/1000000., numberOfCalls);
-    return s_desciption;
+    sprintf(s_description, "%s ::\tavg1: %ldµ,\tavg2: %ldµ,\tmin: %ldµ,\tmax: %ldµ,\ttotal: %.2fs,\tnr calls: %ld", _nameStr.c_str(), _averageTime1, _averageTime2, minTime, maxTime, totalTime/1000000., numberOfCalls);
+    return s_description;
 }
 
 void ProfilingTimer::reset()

--- a/cocos/editor-support/cocostudio/WidgetReader/Node3DReader/Node3DReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/Node3DReader/Node3DReader.cpp
@@ -359,13 +359,13 @@ namespace cocostudio
             child = child->NextSiblingElement();
         }
         
-        Vector3 postion3D(position.x, position.y, position.z);
+        Vector3 position3D(position.x, position.y, position.z);
         Vector3 rotation3D(rotation.x, rotation.y, rotation.z);
         Vector3 scale3D(scale.x, scale.y, scale.z);
 
         auto options = CreateNode3DOption(*builder,
                                            nodeOptions,
-                                           &postion3D,
+                                           &position3D,
                                            &rotation3D,
                                            &scale3D,
                                            cameraMask

--- a/cocos/physics3d/CCPhysics3DConstraint.cpp
+++ b/cocos/physics3d/CCPhysics3DConstraint.cpp
@@ -74,9 +74,9 @@ int	Physics3DConstraint::getOverrideNumSolverIterations() const
 
 ///override the number of constraint solver iterations used to solve this constraint
 ///-1 will use the default number of iterations, as specified in SolverInfo.m_numIterations
-void Physics3DConstraint::setOverrideNumSolverIterations(int overideNumIterations)
+void Physics3DConstraint::setOverrideNumSolverIterations(int overrideNumIterations)
 {
-    _constraint->setOverrideNumSolverIterations(overideNumIterations);
+    _constraint->setOverrideNumSolverIterations(overrideNumIterations);
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/cocos/physics3d/CCPhysics3DConstraint.h
+++ b/cocos/physics3d/CCPhysics3DConstraint.h
@@ -110,7 +110,7 @@ public:
     /**
      * override the number of constraint solver iterations used to solve this constraint, -1 will use the default number of iterations, as specified in SolverInfo.m_numIterations
      */
-    void setOverrideNumSolverIterations(int overideNumIterations);
+    void setOverrideNumSolverIterations(int overrideNumIterations);
     
 #if (CC_ENABLE_BULLET_INTEGRATION)
     btTypedConstraint* getbtContraint() { return _constraint; }

--- a/cocos/scripting/js-bindings/manual/platform/android/CCJavascriptJavaBridge.cpp
+++ b/cocos/scripting/js-bindings/manual/platform/android/CCJavascriptJavaBridge.cpp
@@ -383,9 +383,9 @@ JS_BINDED_FUNC_IMPL(JavascriptJavaBridge, callStaticMethod)
                 switch (call.argumentTypeAtIndex(i))
                 {
                     case TypeInteger:
-                        double interger;
-                        JS::ToNumber(cx, argv.get(index), &interger);
-                        args[i].i = (int)interger;
+                        double integer;
+                        JS::ToNumber(cx, argv.get(index), &integer);
+                        args[i].i = (int)integer;
                         break;
 
                     case TypeFloat:

--- a/cocos/ui/UITextField.cpp
+++ b/cocos/ui/UITextField.cpp
@@ -727,10 +727,10 @@ void TextField::deleteBackwardEvent()
     this->release();
 }
 
-void TextField::addEventListenerTextField(Ref *target, SEL_TextFieldEvent selecor)
+void TextField::addEventListenerTextField(Ref *target, SEL_TextFieldEvent selector)
 {
     _textFieldEventListener = target;
-    _textFieldEventSelector = selecor;
+    _textFieldEventSelector = selector;
 }
     
 void TextField::addEventListener(const ccTextFieldCallback& callback)

--- a/cocos/ui/UITextField.h
+++ b/cocos/ui/UITextField.h
@@ -555,9 +555,9 @@ public:
      * Add a event listener to TextField, when some predefined event happens, the callback will be called.
      *@deprecated Use @see `addEventListener` instead.
      *@param target A pointer of `Ref*` type.
-     *@param selecor A member function pointer with type of `SEL_TextFieldEvent`.
+     *@param selector A member function pointer with type of `SEL_TextFieldEvent`.
      */
-    CC_DEPRECATED_ATTRIBUTE void addEventListenerTextField(Ref* target, SEL_TextFieldEvent selecor);
+    CC_DEPRECATED_ATTRIBUTE void addEventListenerTextField(Ref* target, SEL_TextFieldEvent selector);
     /**
      * Add a event listener to TextField, when some predefined event happens, the callback will be called.
      *@param callback A callback function with type of `ccTextFieldCallback`.

--- a/tests/cpp-tests/Classes/ShaderTest/ShaderTest.cpp
+++ b/tests/cpp-tests/Classes/ShaderTest/ShaderTest.cpp
@@ -754,9 +754,9 @@ void ShaderMultiTexture::changeTexture(Ref*)
         "Images/grossinis_sister1.png",
         "Images/grossinis_sister2.png"
     };
-    auto textrue = Director::getInstance()->getTextureCache()->addImage(textureFiles[_changedTextureId++ % textureFilesCount]);
+    auto texture = Director::getInstance()->getTextureCache()->addImage(textureFiles[_changedTextureId++ % textureFilesCount]);
     Sprite* right = dynamic_cast<Sprite*>(getChildByTag(rightSpriteTag));
-    right->setTexture(textrue);
+    right->setTexture(texture);
     auto programState = _sprite->getGLProgramState();
     programState->setUniformTexture("u_texture1", right->getTexture());
 }

--- a/tests/cpp-tests/Classes/ShaderTest/ShaderTest2.cpp
+++ b/tests/cpp-tests/Classes/ShaderTest/ShaderTest2.cpp
@@ -415,8 +415,8 @@ bool EffectNormalMapped::init()
 }
 bool EffectNormalMapped::initNormalMap(const std::string& normalMapFileName)
 {
-    auto normalMapTextrue = Director::getInstance()->getTextureCache()->addImage(normalMapFileName);
-    getGLProgramState()->setUniformTexture("u_normalMap", normalMapTextrue);
+    auto normalMapTexture = Director::getInstance()->getTextureCache()->addImage(normalMapFileName);
+    getGLProgramState()->setUniformTexture("u_normalMap", normalMapTexture);
     return true;
 }
 void EffectNormalMapped::setTarget(EffectSprite* sprite)


### PR DESCRIPTION
This PR fixes some minor typos in local variable names, and doesn't break backward compatibility.
Thanks!
