### PR TITLE
PageView::setCurrentPageIndex triggers PageView::EventType::TURNING

### DIFF
--- a/cocos/ui/UIPageView.cpp
+++ b/cocos/ui/UIPageView.cpp
@@ -146,6 +146,8 @@ void PageView::setCurPageIndex( ssize_t index )
 void PageView::setCurrentPageIndex(ssize_t index)
 {
     jumpToItem(index, Vec2::ANCHOR_MIDDLE, Vec2::ANCHOR_MIDDLE);
+    if (getItem(index)) // PageView::EventType::TURNING triggered only if index is valid
+        pageTurningEvent();
 }
 
 void PageView::scrollToPage(ssize_t idx)


### PR DESCRIPTION
When `PageView::setCurrentPageIndex` is called the event `PageView::EventType::TURNING` is triggered
