### PR TITLE
Fix getSubStringOfUTF8String bug

### DIFF
--- a/cocos/ui/UIHelper.cpp
+++ b/cocos/ui/UIHelper.cpp
@@ -26,6 +26,7 @@ THE SOFTWARE.
 #include "ui/UIWidget.h"
 #include "ui/UILayoutComponent.h"
 #include "base/CCDirector.h"
+#include "base/ccUTF8.h"
 
 NS_CC_BEGIN
 
@@ -115,39 +116,21 @@ Widget* Helper::seekActionWidgetByActionTag(Widget* root, int tag)
     
 std::string Helper::getSubStringOfUTF8String(const std::string& str, std::string::size_type start, std::string::size_type length)
 {
-    if (length==0)
-    {
+    std::u32string utf32;
+    if (!StringUtils::UTF8ToUTF32(str, utf32)) {
+        CCLOGERROR("Can't convert string to UTF-32: %s", str.c_str());
         return "";
     }
-    std::string::size_type c, i, ix, q, min=std::string::npos, max=std::string::npos;
-    for (q=0, i=0, ix=str.length(); i < ix; i++, q++)
-    {
-        if (q==start)
-        {
-            min = i;
-        }
-        if (q <= start+length || length==std::string::npos)
-        {
-            max = i;
-        }
-        
-        c = (unsigned char) str[i];
-        
-        if      (c<=127) i+=0;
-        else if ((c & 0xE0) == 0xC0) i+=1;
-        else if ((c & 0xF0) == 0xE0) i+=2;
-        else if ((c & 0xF8) == 0xF0) i+=3;
-        else return "";//invalid utf8
-    }
-    if (q <= start+length || length == std::string::npos)
-    {
-        max = i;
-    }
-    if (min==std::string::npos || max==std::string::npos)
-    {
+    if (utf32.size() < start) {
+        CCLOGERROR("'start' is out of range: %lu, %s", start, str.c_str());
         return "";
     }
-    return str.substr(min,max);
+    std::string result;
+    if (!StringUtils::UTF32ToUTF8(utf32.substr(start, length), result)) {
+        CCLOGERROR("Can't convert internal UTF-32 string to UTF-8: %s", str.c_str());
+        return "";
+    }
+    return result;
 }
 
 void Helper::changeLayoutSystemActiveState(bool bActive)

--- a/tests/cpp-tests/Classes/UnitTest/UnitTest.cpp
+++ b/tests/cpp-tests/Classes/UnitTest/UnitTest.cpp
@@ -1,5 +1,6 @@
 #include "UnitTest.h"
 #include "RefPtrTest.h"
+#include "ui/UIHelper.h"
 
 USING_NS_CC;
 
@@ -43,6 +44,7 @@ UnitTests::UnitTests()
     ADD_TEST_CASE(ValueTest);
     ADD_TEST_CASE(RefPtrTest);
     ADD_TEST_CASE(UTFConversionTest);
+    ADD_TEST_CASE(UIHelperSubStringTest);
 #ifdef UNIT_TEST_FOR_OPTIMIZED_MATH_UTIL
     ADD_TEST_CASE(MathUtilTest);
 #endif
@@ -779,6 +781,116 @@ std::string UTFConversionTest::subtitle() const
     return "UTF8 <-> UTF16 Conversion Test, no crash";
 }
 
+// UIHelperSubStringTest
+
+void UIHelperSubStringTest::onEnter()
+{
+    UnitTestDemo::onEnter();
+
+    using cocos2d::ui::Helper;
+    {
+        // Trivial case
+        std::string source = "abcdefghij";
+        CC_ASSERT(Helper::getSubStringOfUTF8String(source, 0, 2) == "ab");
+        CC_ASSERT(Helper::getSubStringOfUTF8String(source, 2, 2) == "cd");
+        CC_ASSERT(Helper::getSubStringOfUTF8String(source, 4, 2) == "ef");
+    }
+    {
+        // Empty string
+        std::string source = "";
+
+        // OK
+        CC_ASSERT(Helper::getSubStringOfUTF8String(source, 0, 0) == "");
+        CC_ASSERT(Helper::getSubStringOfUTF8String(source, 0, 1) == "");
+
+        // Error: These cases cause "out of range" error
+        CC_ASSERT(Helper::getSubStringOfUTF8String(source, 1, 0) == "");
+        CC_ASSERT(Helper::getSubStringOfUTF8String(source, 1, 1) == "");
+    }
+    {
+        // Ascii
+        std::string source = "abc";
+
+        // OK
+        CC_ASSERT(Helper::getSubStringOfUTF8String(source, 0, 0) == "");
+        CC_ASSERT(Helper::getSubStringOfUTF8String(source, 1, 0) == "");
+        CC_ASSERT(Helper::getSubStringOfUTF8String(source, 2, 0) == "");
+        CC_ASSERT(Helper::getSubStringOfUTF8String(source, 3, 0) == "");
+        CC_ASSERT(Helper::getSubStringOfUTF8String(source, 0, 3) == "abc");
+        CC_ASSERT(Helper::getSubStringOfUTF8String(source, 0, 4) == "abc");
+        CC_ASSERT(Helper::getSubStringOfUTF8String(source, 1, 2) == "bc");
+        CC_ASSERT(Helper::getSubStringOfUTF8String(source, 1, 3) == "bc");
+        CC_ASSERT(Helper::getSubStringOfUTF8String(source, 2, 1) == "c");
+        CC_ASSERT(Helper::getSubStringOfUTF8String(source, 2, 2) == "c");
+        CC_ASSERT(Helper::getSubStringOfUTF8String(source, 3, 1) == "");
+        CC_ASSERT(Helper::getSubStringOfUTF8String(source, 3, 2) == "");
+
+        // Error: These cases cause "out of range" error
+        CC_ASSERT(Helper::getSubStringOfUTF8String(source, 4, 0) == "");
+        CC_ASSERT(Helper::getSubStringOfUTF8String(source, 4, 1) == "");
+    }
+    {
+        // CJK characters
+        std::string source = "这里是中文测试例";
+
+        // OK
+        CC_ASSERT(Helper::getSubStringOfUTF8String(source, 0, 0) == "");
+        CC_ASSERT(Helper::getSubStringOfUTF8String(source, 1, 0) == "");
+        CC_ASSERT(Helper::getSubStringOfUTF8String(source, 7, 0) == "");
+        CC_ASSERT(Helper::getSubStringOfUTF8String(source, 8, 0) == "");
+        CC_ASSERT(Helper::getSubStringOfUTF8String(source, 8, 1) == "");
+        CC_ASSERT(Helper::getSubStringOfUTF8String(source, 0, 1) == "这");
+        CC_ASSERT(Helper::getSubStringOfUTF8String(source, 0, 4) == "这里是中");
+        CC_ASSERT(Helper::getSubStringOfUTF8String(source, 0, 8) == "这里是中文测试例");
+        CC_ASSERT(Helper::getSubStringOfUTF8String(source, 0, 100) == "这里是中文测试例");
+        CC_ASSERT(Helper::getSubStringOfUTF8String(source, 2, 5) == "是中文测试");
+        CC_ASSERT(Helper::getSubStringOfUTF8String(source, 6, 2) == "试例");
+        CC_ASSERT(Helper::getSubStringOfUTF8String(source, 6, 100) == "试例");
+
+        // Error: These cases cause "out of range" error
+        CC_ASSERT(Helper::getSubStringOfUTF8String(source, 9, 0) == "");
+        CC_ASSERT(Helper::getSubStringOfUTF8String(source, 9, 1) == "");
+    }
+    {
+        // Redundant UTF-8 sequence for Directory traversal attack (1)
+        std::string source = "\xC0\xAF";
+
+        // Error: Can't convert string to correct encoding such as UTF-32
+        CC_ASSERT(Helper::getSubStringOfUTF8String(source, 0, 0) == "");
+        CC_ASSERT(Helper::getSubStringOfUTF8String(source, 0, 1) == "");
+        CC_ASSERT(Helper::getSubStringOfUTF8String(source, 1, 0) == "");
+        CC_ASSERT(Helper::getSubStringOfUTF8String(source, 1, 1) == "");
+        CC_ASSERT(Helper::getSubStringOfUTF8String(source, 0, 2) == "");
+    }
+    {
+        // Redundant UTF-8 sequence for Directory traversal attack (2)
+        std::string source = "\xE0\x80\xAF";
+
+        // Error: Can't convert string to correct encoding such as UTF-32
+        CC_ASSERT(Helper::getSubStringOfUTF8String(source, 0, 0) == "");
+        CC_ASSERT(Helper::getSubStringOfUTF8String(source, 0, 1) == "");
+        CC_ASSERT(Helper::getSubStringOfUTF8String(source, 1, 0) == "");
+        CC_ASSERT(Helper::getSubStringOfUTF8String(source, 1, 1) == "");
+        CC_ASSERT(Helper::getSubStringOfUTF8String(source, 0, 3) == "");
+    }
+    {
+        // Redundant UTF-8 sequence for Directory traversal attack (3)
+        std::string source = "\xF0\x80\x80\xAF";
+
+        // Error: Can't convert string to correct encoding such as UTF-32
+        CC_ASSERT(Helper::getSubStringOfUTF8String(source, 0, 0) == "");
+        CC_ASSERT(Helper::getSubStringOfUTF8String(source, 0, 1) == "");
+        CC_ASSERT(Helper::getSubStringOfUTF8String(source, 1, 0) == "");
+        CC_ASSERT(Helper::getSubStringOfUTF8String(source, 1, 1) == "");
+        CC_ASSERT(Helper::getSubStringOfUTF8String(source, 0, 4) == "");
+    }
+}
+
+std::string UIHelperSubStringTest::subtitle() const
+{
+    return "ui::Helper::getSubStringOfUTF8String Test";
+}
+
 // MathUtilTest
 
 namespace UnitTest {
@@ -1061,4 +1173,3 @@ std::string MathUtilTest::subtitle() const
 {
     return "MathUtilTest";
 }
-

--- a/tests/cpp-tests/Classes/UnitTest/UnitTest.h
+++ b/tests/cpp-tests/Classes/UnitTest/UnitTest.h
@@ -48,6 +48,14 @@ public:
     virtual std::string subtitle() const override;
 };
 
+class UIHelperSubStringTest : public UnitTestDemo
+{
+public:
+    CREATE_FUNC(UIHelperSubStringTest);
+    virtual void onEnter() override;
+    virtual std::string subtitle() const override;
+};
+
 class MathUtilTest : public UnitTestDemo
 {
 public:


### PR DESCRIPTION
Hello, this pull request addresses the `ui::Helper::getSubStringOfUTF8String` issue raised here:
http://discuss.cocos2d-x.org/t/problem-with-utf-strings/30461

I think we should not handle a raw utf-8 string without unicode-specific third-party library/implementation (such as LLVM's `ConvertUTF` and UTF8-CPP etc.) for maintenance or security reasons. So this changeset simply replaces with a code using `StringUtils::UTF8ToUTF32`, and adds a new test case.

Thank you for your time and consideration.
