### PR TITLE
cocosstudio can manage TexturePacker Image.

### DIFF
--- a/cocos/editor-support/cocostudio/WidgetReader/ImageViewReader/ImageViewReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/ImageViewReader/ImageViewReader.cpp
@@ -312,6 +312,11 @@ namespace cocostudio
                 {
                     fileExist = true;
                 }
+                else if(SpriteFrameCache::getInstance()->getSpriteFrameByName(imageFileName))
+                {
+                    fileExist = true;
+                    imageFileNameType = 1;
+                }
                 else
                 {
                     errorFilePath = imageFileName;


### PR DESCRIPTION
Hi.

I want to use TexturePacker and cocosstudio because it is less memory.
But now it cannot.
I fixed it.

Thanks.
