### PR TITLE
Update utils::getTimeInMilliseconds()

### DIFF
--- a/cocos/base/ccUtils.cpp
+++ b/cocos/base/ccUtils.cpp
@@ -265,7 +265,7 @@ long long getTimeInMilliseconds()
 {
     struct timeval tv;
     gettimeofday (&tv, nullptr);
-    return tv.tv_sec * 1000 + tv.tv_usec / 1000;
+    return (long long)tv.tv_sec * 1000 + tv.tv_usec / 1000;
 }
 
 Rect getCascadeBoundingBox(Node *node)


### PR DESCRIPTION
My device android samsung s4 bad result, The iPhone is a good result.

'return tv.tv_sec \* 1000 + tv.tv_usec / 1000;'
The result comes across as negative.
So I added the (long long).
