### PR TITLE
Fix format string warning when compiling with Android NDK

### DIFF
--- a/cocos/ui/UIHelper.cpp
+++ b/cocos/ui/UIHelper.cpp
@@ -122,7 +122,7 @@ std::string Helper::getSubStringOfUTF8String(const std::string& str, std::string
         return "";
     }
     if (utf32.size() < start) {
-        CCLOGERROR("'start' is out of range: %lu, %s", start, str.c_str());
+        CCLOGERROR("'start' is out of range: %zu, %s", static_cast<size_t>(start), str.c_str());
         return "";
     }
     std::string result;


### PR DESCRIPTION
This patch fixes the following warning when compiling with Clang for Android NDK r10e:

```
cocos/ui/UIHelper.cpp:125:58: warning: format specifies type 'unsigned long' but the argument has type 'std::string::size_type' (aka 'unsigned int') [-Wformat]
        cocos2d::log("'start' is out of range: %lu, %s", start, str.c_str());
                                               ~~~       ^~~~~
                                               %u
```

Thanks.
