### PR TITLE
Fix typos and other mistakes in docs

### DIFF
--- a/cocos/2d/CCAction.h
+++ b/cocos/2d/CCAction.h
@@ -156,7 +156,7 @@ public:
     inline unsigned int getFlags() const { return _flags; }
     /** Changes the flag field that is used to group the actions easily.
      *
-     * @param tag Used to identify the action easily.
+     * @param flags Used to group the actions easily.
      */
     inline void setFlags(unsigned int flags) { _flags = flags; }
 

--- a/cocos/2d/CCDrawingPrimitives.h
+++ b/cocos/2d/CCDrawingPrimitives.h
@@ -101,7 +101,7 @@ namespace DrawPrimitives
 
     /** Draws an array of points.
      *
-     * @param point A point coordinates.
+     * @param points A point coordinates.
      * @param numberOfPoints The number of points.
      * @since v0.7.2
      */

--- a/cocos/2d/CCNode.cpp
+++ b/cocos/2d/CCNode.cpp
@@ -1750,7 +1750,7 @@ const Mat4& Node::getNodeToParentTransform() const
         // at some point setNodeToParentTransform() is called.
         // and later setAdditionalTransform() is called every time. And since _transform
         // is being overwritten everyframe, _additionalTransform[1] is used to have a copy
-        // of the last "_trasform without _additionalTransform"
+        // of the last "_transform without _additionalTransform"
         if (_transformDirty)
             _additionalTransform[1] = _transform;
 

--- a/cocos/3d/CCAnimate3D.h
+++ b/cocos/3d/CCAnimate3D.h
@@ -64,7 +64,7 @@ public:
     /**
      * create Animate3D
      * @param animation used to generate animate3D
-     * @param formTime 
+     * @param fromTime
      * @param duration Time the Animate3D lasts
      * @return Animate3D created using animate
      */

--- a/cocos/3d/CCBundleReader.h
+++ b/cocos/3d/CCBundleReader.h
@@ -59,7 +59,7 @@ public:
     
     /**
      * initialise
-     * @param lpbuffer The data buffer pointer
+     * @param buffer The data buffer pointer
      * @param length The data buffer size
      */
     void init(char* buffer, ssize_t length);

--- a/cocos/3d/CCTerrain.h
+++ b/cocos/3d/CCTerrain.h
@@ -323,7 +323,7 @@ public:
     static Terrain * create(TerrainData &parameter, CrackFixedType fixedType = CrackFixedType::INCREASE_LOWER);
     /**get specified position's height mapping to the terrain,use bi-linear interpolation method
      * @param x the X position
-     * @param y the Z position
+     * @param z the Z position
      * @param normal the specified position's normal vector in terrain . if this argument is NULL or nullptr,Normal calculation shall be skip.
      * @return the height value of the specified position of the terrain, if the (X,Z) position is out of the terrain bounds,it shall return 0;
      **/

--- a/cocos/audio/mac/CocosDenshion.m
+++ b/cocos/audio/mac/CocosDenshion.m
@@ -809,7 +809,7 @@ static BOOL _mixerRateSet = NO;
 /**
  * Play a sound.
  * @param soundId the id of the sound to play (buffer id).
- * @param SourceGroupId the source group that will be used to play the sound.
+ * @param sourceGroupId the source group that will be used to play the sound.
  * @param pitch pitch multiplier. e.g 1.0 is unaltered, 0.5 is 1 octave lower. 
  * @param pan stereo position. -1 is fully left, 0 is centre and 1 is fully right.
  * @param gain gain multiplier. e.g. 1.0 is unaltered, 0.5 is half the gain

--- a/cocos/base/CCUserDefault.h
+++ b/cocos/base/CCUserDefault.h
@@ -227,7 +227,7 @@ public:
     * If you don't want to system default implementation after setting delegate, you can just pass nullptr
     * to this function.
     *
-    * @warm It will delete previous delegate
+    * @warning It will delete previous delegate
     */
     static void setDelegate(UserDefault *delegate);
 

--- a/cocos/base/ZipUtils.h
+++ b/cocos/base/ZipUtils.h
@@ -85,7 +85,7 @@ typedef struct unz_file_info_s unz_file_info;
         /** 
         * Inflates either zlib or gzip deflated memory. The inflated memory is expected to be freed by the caller.
         *
-        * @param outLenghtHint It is assumed to be the needed room to allocate the inflated buffer.
+        * @param outLengthHint It is assumed to be the needed room to allocate the inflated buffer.
         *
         * @return The length of the deflated buffer.
         * @since v1.0.0
@@ -269,7 +269,7 @@ typedef struct unz_file_info_s unz_file_info;
         /**
         * Get resource file data from a zip file.
         * @param fileName File name
-        * @param[out] pSize If the file read operation succeeds, it will be the data size, otherwise 0.
+        * @param[out] size If the file read operation succeeds, it will be the data size, otherwise 0.
         * @return Upon success, a pointer to the data is returned, otherwise nullptr.
         * @warning Recall: you are responsible for calling free() on any Non-nullptr pointer returned.
         *

--- a/cocos/network/HttpRequest.h
+++ b/cocos/network/HttpRequest.h
@@ -322,7 +322,7 @@ public:
     /**
      * Set custom-defined headers.
      *
-     * @param pHeaders the string vector of custom-defined headers.
+     * @param headers The string vector of custom-defined headers.
      */
     inline void setHeaders(const std::vector<std::string>& headers)
        {

--- a/cocos/physics3d/CCPhysics3DObject.h
+++ b/cocos/physics3d/CCPhysics3DObject.h
@@ -438,7 +438,7 @@ public:
     float getRestitution() const;
 
     /** Set friction. 
-     *  @param rest The friction.
+     *  @param frict The friction.
     */
     void setFriction(float frict);
 

--- a/cocos/platform/CCFileUtils.h
+++ b/cocos/platform/CCFileUtils.h
@@ -350,7 +350,7 @@ public:
     /**
      *  Sets the filenameLookup dictionary.
      *
-     *  @param pFilenameLookupDict The dictionary for replacing filename.
+     *  @param filenameLookupDict The dictionary for replacing filename.
      *  @since v2.1
      */
     virtual void setFilenameLookupDictionary(const ValueMap& filenameLookupDict);
@@ -358,7 +358,7 @@ public:
     /**
      *  Gets full path from a file name and the path of the relative file.
      *  @param filename The file name.
-     *  @param pszRelativeFile The path of the relative file.
+     *  @param relativeFile The path of the relative file.
      *  @return The full path.
      *          e.g. filename: hello.png, pszRelativeFile: /User/path1/path2/hello.plist
      *               Return: /User/path1/path2/hello.pvr (If there a a key(hello.png)-value(hello.pvr) in FilenameLookup dictionary. )
@@ -521,7 +521,7 @@ public:
     * Windows fopen can't support UTF-8 filename
     * Need convert all parameters fopen and other 3rd-party libs
     *
-    * @param filename std::string name file for conversion from utf-8
+    * @param filenameUtf8 std::string name file for conversion from utf-8
     * @return std::string ansi filename in current locale
     */
     virtual std::string getSuitableFOpen(const std::string& filenameUtf8) const;

--- a/cocos/renderer/CCGLProgramState.h
+++ b/cocos/renderer/CCGLProgramState.h
@@ -367,7 +367,7 @@ public:
      * to an enumeration value. If it matches to one of the predefined strings, it will create a
      * callback to get the correct value at runtime.
      *
-     * @param name The name of the material parameter to store an auto-binding for.
+     * @param uniformName The name of the material parameter to store an auto-binding for.
      * @param autoBinding A string matching one of the built-in AutoBinding enum constants.
      */
     void setParameterAutoBinding(const std::string& uniformName, const std::string& autoBinding);

--- a/cocos/renderer/CCTexture2D.h
+++ b/cocos/renderer/CCTexture2D.h
@@ -289,7 +289,7 @@ public:
      @param hAlignment The font horizontal text alignment type.
      @param vAlignment The font vertical text alignment type.
      @param enableWrap Whether enable text wrap or not.
-     @param shrinkFontSize Whether shrink font size when content larger than the dimensions.
+     @param overflow Whether shrink font size when content larger than the dimensions.
      */
     bool initWithString(const char *text,  const std::string &fontName, float fontSize, const Size& dimensions = Size(0, 0), TextHAlignment hAlignment = TextHAlignment::CENTER, TextVAlignment vAlignment = TextVAlignment::TOP, bool enableWrap = true, int overflow = 0);
 

--- a/cocos/scripting/js-bindings/manual/ScriptingCore.cpp
+++ b/cocos/scripting/js-bindings/manual/ScriptingCore.cpp
@@ -701,7 +701,7 @@ JS::PersistentRootedScript* ScriptingCore::compileScript(const char *path, JS::H
     // a) check jsc file first
     std::string byteCodePath = RemoveFileExt(std::string(path)) + BYTE_CODE_FILE_EXT;
 
-    // Check whether '.jsc' files exist to avoid outputing log which says 'couldn't find .jsc file'.
+    // Check whether '.jsc' files exist to avoid outputting log which says 'couldn't find .jsc file'.
     if (futil->isFileExist(byteCodePath))
     {
         Data data = futil->getDataFromFile(byteCodePath);

--- a/cocos/scripting/js-bindings/manual/ScriptingCore.h
+++ b/cocos/scripting/js-bindings/manual/ScriptingCore.h
@@ -406,7 +406,7 @@ public:
     /**@~english
      * Simulate a multi touch event and dispatch it to a js object.
      * @param eventType @~english The touch event type
-     * @param touches @~english Touchs list for multitouch
+     * @param touches @~english Touches list for multitouch
      * @param obj @~english The js object
      * @return @~english Return 1 if succeed, otherwise return 0.
      */
@@ -634,7 +634,7 @@ JSObject* jsb_ref_autoreleased_create_jsobject(JSContext *cx, cocos2d::Ref *ref,
 /**
  * It will try to get the associated JSObjct for the native object.
  * The reference created from JSObject to native object is weak because it won't retain it.
- * The behavior is exactly the same with 'jsb_ref_create_jsobject' when CC_ENABLE_GC_FOR_NATIVE_OBJECTS desactivated.
+ * The behavior is exactly the same with 'jsb_ref_create_jsobject' when CC_ENABLE_GC_FOR_NATIVE_OBJECTS deactivated.
  */
 JSObject* jsb_create_weak_jsobject(JSContext *cx, void *native, js_type_class_t *typeClass, const char* debug);
 
@@ -656,7 +656,7 @@ JSObject* jsb_ref_autoreleased_get_or_create_jsobject(JSContext *cx, cocos2d::Re
  * It will try to get the associated JSObjct for the native object.
  * If it can't find it, it will create a new one associating it to the native object.
  * The reference created from JSObject to native object is weak because it won't retain it.
- * The behavior is exactly the same with 'jsb_ref_get_or_create_jsobject' when CC_ENABLE_GC_FOR_NATIVE_OBJECTS desactivated.
+ * The behavior is exactly the same with 'jsb_ref_get_or_create_jsobject' when CC_ENABLE_GC_FOR_NATIVE_OBJECTS deactivated.
  */
 CC_JS_DLL JSObject* jsb_get_or_create_weak_jsobject(JSContext *cx, void *native, js_type_class_t *typeClass, const char* debug);
 

--- a/cocos/ui/UILayout.h
+++ b/cocos/ui/UILayout.h
@@ -504,7 +504,7 @@ protected:
     /**
      * When the layout get focused, it the layout pass the focus to its child, it will use this method to determine which child 
      * will get the focus.  The current algorithm to determine which child will get focus is nearest-distance-priority algorithm
-     *@param dir next focused widget direction
+     *@param direction The next focused widget direction
      *@return The index of child widget in the container
      */
      int findNearestChildWidgetIndex(FocusDirection direction, Widget* baseWidget);
@@ -512,7 +512,7 @@ protected:
     /**
      * When the layout get focused, it the layout pass the focus to its child, it will use this method to determine which child
      * will get the focus.  The current algorithm to determine which child will get focus is farthest-distance-priority algorithm
-     *@param dir next focused widget direction
+     *@param direction The next focused widget direction
      *@return The index of child widget in the container
      */
     int findFarthestChildWidgetIndex(FocusDirection direction, Widget* baseWidget);
@@ -559,7 +559,7 @@ protected:
     
     /**
      * this method is called internally by nextFocusedWidget. When the dir is Right/Down, then this method will be called
-     *@param dir  the direction.
+     *@param direction  the direction.
      *@param current  the current focused widget
      *@return the next focused widget
      */
@@ -567,7 +567,7 @@ protected:
     
     /**
      * this method is called internally by nextFocusedWidget. When the dir is Left/Up, then this method will be called
-     *@param dir  the direction.
+     *@param direction  the direction.
      *@param current  the current focused widget
      *@return the next focused widget
      */

--- a/cocos/ui/UIListView.h
+++ b/cocos/ui/UIListView.h
@@ -360,9 +360,9 @@ public:
     ssize_t getCurSelectedIndex() const;
     
     /**
-     +     * @brief Set current selected widget's index and call TouchEventType::ENDED event.
-     +     * @param A index of a selected item.
-     +     */
+     * @brief Set current selected widget's index and call TouchEventType::ENDED event.
+     * @param itemIndex A index of a selected item.
+     */
      void setCurSelectedIndex(int itemIndex);
     
     /**

--- a/cocos/ui/UIPageView.h
+++ b/cocos/ui/UIPageView.h
@@ -170,7 +170,7 @@ public:
     /**
      * Scroll to a page with a given index.
      *
-     * @param idx   A given index in the PageView. Index start from 0 to pageCount -1.
+     * @param itemIndex   A given index in the PageView. Index start from 0 to pageCount -1.
      */
     void scrollToItem(ssize_t itemIndex);
 

--- a/cocos/ui/UIScale9Sprite.h
+++ b/cocos/ui/UIScale9Sprite.h
@@ -443,7 +443,7 @@ namespace ui {
          * @brief Update Scale9Sprite with a specified sprite.
          *
          * @deprecated Use @see `updateWithSprite` instead.
-         * @param sprite A sprite pointer.
+         * @param batchnode A sprite batch pointer.
          * @param originalRect A delimitation zone.
          * @param rotated Whether the sprite is rotated or not.
          * @param capInsets The Values to use for the cap insets.

--- a/extensions/Particle3D/PU/CCPUEmitter.h
+++ b/extensions/Particle3D/PU/CCPUEmitter.h
@@ -238,7 +238,7 @@ public:
     /** Sets the direction of the particle that the emitter is emitting.
     @remarks
         Don't confuse this with the emitters own direction.
-    @param dir The base direction of emitted particles.
+    @param direction The base direction of emitted particles.
     */
     void setParticleDirection(const Vec3& direction);
 

--- a/extensions/Particle3D/PU/CCPULineEmitterTranslator.cpp
+++ b/extensions/Particle3D/PU/CCPULineEmitterTranslator.cpp
@@ -81,7 +81,7 @@ bool PULineEmitterTranslator::translateChildProperty( PUScriptCompiler* compiler
     }
     else if (prop->name == token[TOKEN_LINE_EMIT_MAX_INCREMENT])
     {
-        // Property: line_em_max_increment (de[recated and replaced by 'max_increment')
+        // Property: line_em_max_increment (deprecated and replaced by 'max_increment')
         if (passValidateProperty(compiler, prop, token[TOKEN_LINE_EMIT_MAX_INCREMENT], VAL_REAL))
         {
             float val = 0.0f;

--- a/extensions/Particle3D/PU/CCPUParticleSystem3D.h
+++ b/extensions/Particle3D/PU/CCPUParticleSystem3D.h
@@ -306,7 +306,7 @@ public:
     const std::string& getMaterialName() const { return _matName; };
 
     /** Forces emission of particles.
-     * @remarks The number of requested particles are the exact number that are emitted. No down-scalling is applied.
+     * @remarks The number of requested particles are the exact number that are emitted. No down-scaling is applied.
      */
     void forceEmission(PUEmitter* emitter, unsigned requested);
 

--- a/extensions/assets-manager/AssetsManager.h
+++ b/extensions/assets-manager/AssetsManager.h
@@ -139,7 +139,7 @@ public:
     /* @brief Sets storage path.
      *
      * @param storagePath The path to store downloaded resources.
-     * @warm The path should be a valid path.
+     * @warning The path should be a valid path.
      */
     void setStoragePath(const char* storagePath);
     


### PR DESCRIPTION
This pull request fixes various spelling mistakes, typos, merge conflicts, and parameter name mismatch between `@param` comments and C++ function declarations. Thanks.
