### PR TITLE
Add missing float suffix to avoid -Wdouble-promotion

### DIFF
--- a/cocos/2d/CCActionPageTurn3D.cpp
+++ b/cocos/2d/CCActionPageTurn3D.cpp
@@ -71,7 +71,7 @@ void PageTurn3D::update(float time)
     float ay = -100 - deltaAy;
     
     float deltaTheta = sqrtf(time);
-    float theta = deltaTheta>0.5?(float)M_PI_2*deltaTheta:(float)M_PI_2*(1-deltaTheta);
+    float theta = deltaTheta > 0.5f ? (float)M_PI_2*deltaTheta : (float)M_PI_2*(1-deltaTheta);
     
     float rotateByYAxis = (2-time)* M_PI;
     

--- a/cocos/2d/CCAutoPolygon.cpp
+++ b/cocos/2d/CCAutoPolygon.cpp
@@ -494,7 +494,7 @@ std::vector<Vec2> AutoPolygon::reduce(const std::vector<Vec2>& points, const Rec
     std::vector<Vec2> result = rdp(points, ep);
     
     auto last = result.back();
-    if(last.y > result.front().y && last.getDistance(result.front()) < ep*0.5)
+    if (last.y > result.front().y && last.getDistance(result.front()) < ep * 0.5f)
     {
         result.front().y = last.y;
         result.pop_back();

--- a/cocos/2d/CCDrawNode.cpp
+++ b/cocos/2d/CCDrawNode.cpp
@@ -771,7 +771,7 @@ void DrawNode::drawPolygon(const Vec2 *verts, int count, const Color4F &fillColo
 {
     CCASSERT(count >= 0, "invalid count value");
     
-    bool outline = (borderColor.a > 0.0 && borderWidth > 0.0);
+    bool outline = (borderColor.a > 0.0f && borderWidth > 0.0f);
     
     auto  triangle_count = outline ? (3*count - 2) : (count - 2);
     auto vertex_count = 3*triangle_count;
@@ -806,7 +806,7 @@ void DrawNode::drawPolygon(const Vec2 *verts, int count, const Color4F &fillColo
             Vec2 n1 = v2fnormalize(v2fperp(v2fsub(v1, v0)));
             Vec2 n2 = v2fnormalize(v2fperp(v2fsub(v2, v1)));
             
-            Vec2 offset = v2fmult(v2fadd(n1, n2), 1.0/(v2fdot(n1, n2) + 1.0));
+            Vec2 offset = v2fmult(v2fadd(n1, n2), 1.0f / (v2fdot(n1, n2) + 1.0f));
             struct ExtrudeVerts tmp = {offset, n2};
             extrude[i] = tmp;
         }

--- a/cocos/2d/CCFastTMXLayer.cpp
+++ b/cocos/2d/CCFastTMXLayer.cpp
@@ -151,8 +151,8 @@ void TMXLayer::draw(Renderer *renderer, const Mat4& transform, uint32_t flags)
     if( flags != 0 || _dirty || _quadsDirty || isViewProjectionUpdated)
     {
         Size s = Director::getInstance()->getVisibleSize();
-        auto rect = Rect(Camera::getVisitingCamera()->getPositionX() - s.width * 0.5,
-                     Camera::getVisitingCamera()->getPositionY() - s.height * 0.5,
+        auto rect = Rect(Camera::getVisitingCamera()->getPositionX() - s.width * 0.5f,
+                     Camera::getVisitingCamera()->getPositionY() - s.height * 0.5f,
                      s.width,
                      s.height);
         

--- a/cocos/2d/CCTextFieldTTF.cpp
+++ b/cocos/2d/CCTextFieldTTF.cpp
@@ -337,7 +337,7 @@ void TextFieldTTF::setCursorPosition(std::size_t cursorPosition)
     if (_cursorEnabled && cursorPosition <= (std::size_t)_charCount)
     {
         _cursorPosition = cursorPosition;
-        _cursorShowingTime = CURSOR_TIME_SHOW_HIDE*2.0;
+        _cursorShowingTime = CURSOR_TIME_SHOW_HIDE * 2.0f;
     }
 }
 

--- a/cocos/2d/CCTweenFunction.cpp
+++ b/cocos/2d/CCTweenFunction.cpp
@@ -436,16 +436,16 @@ float backEaseInOut(float time)
 // Bounce Ease
 float bounceTime(float time)
 {
-    if (time < 1 / 2.75)
+    if (time < 1 / 2.75f)
     {
         return 7.5625f * time * time;
     }
-    else if (time < 2 / 2.75)
+    else if (time < 2 / 2.75f)
     {
         time -= 1.5f / 2.75f;
         return 7.5625f * time * time + 0.75f;
     }
-    else if(time < 2.5 / 2.75)
+    else if(time < 2.5f / 2.75f)
     {
         time -= 2.25f / 2.75f;
         return 7.5625f * time * time + 0.9375f;

--- a/cocos/3d/CCAnimate3D.cpp
+++ b/cocos/3d/CCAnimate3D.cpp
@@ -337,7 +337,7 @@ void Animate3D::update(float t)
                 float* trans = nullptr, *rot = nullptr, *scale = nullptr;
                 if (_playReverse){
                     t = 1 - t;
-                    lastTime = 1.0 - lastTime;
+                    lastTime = 1.0f - lastTime;
                 }
                 
                 t = _start + t * _last;

--- a/cocos/3d/CCObjLoader.cpp
+++ b/cocos/3d/CCObjLoader.cpp
@@ -572,7 +572,7 @@ namespace tinyobj {
             if (token[0] == 'T' && token[1] == 'r' && isSpace(token[2])) {
                 token += 2;
                 // Invert value of Tr(assume Tr is in range [0, 1])
-                material.dissolve = 1.0 - parseFloat(token);
+                material.dissolve = 1.0f - parseFloat(token);
                 continue;
             }
             

--- a/cocos/3d/CCTerrain.cpp
+++ b/cocos/3d/CCTerrain.cpp
@@ -1357,7 +1357,7 @@ void Terrain::Chunk::updateVerticesForLOD()
     int gridY = _size.height;
     int gridX = _size.width;
 
-    if(_currentLod>=2 && std::abs(_slope)>1.2)
+    if (_currentLod >= 2 && std::abs(_slope) > 1.2f)
     {
         int step = 1<<_currentLod;
         for(int i =step;i<gridY-step;i+=step)

--- a/cocos/audio/mac/CocosDenshion.m
+++ b/cocos/audio/mac/CocosDenshion.m
@@ -1411,7 +1411,7 @@ static BOOL _mixerRateSet = NO;
                 
             case kIT_SCurve:
                 //Cubic s curve t^2 * (3 - 2t)
-                return ((float)(t * t * (3.0 - (2.0 * t))) * (end - start)) + start;
+                return ((t * t * (3.0f - (2.0f * t))) * (end - start)) + start;
                 
             case kIT_Exponential:    
                 //Formulas taken from EaseAction
@@ -1486,7 +1486,7 @@ static BOOL _mixerRateSet = NO;
 }    
 
 -(void) modify:(float) t {
-    if (t < 1.0) {
+    if (t < 1.0f) {
         [self _setTargetProperty:[interpolator interpolate:t]];
     } else {
         //At the end

--- a/cocos/base/CCDirector.cpp
+++ b/cocos/base/CCDirector.cpp
@@ -730,7 +730,7 @@ Vec2 Director::convertToGL(const Vec2& uiPoint)
     Vec4 glCoord;
     //transformInv.transformPoint(clipCoord, &glCoord);
     transformInv.transformVector(clipCoord, &glCoord);
-    float factor = 1.0/glCoord.w;
+    float factor = 1.0f / glCoord.w;
     return Vec2(glCoord.x * factor, glCoord.y * factor);
 }
 
@@ -757,8 +757,8 @@ Vec2 Director::convertToUI(const Vec2& glPoint)
 	clipCoord.z = clipCoord.z / clipCoord.w;
 
     Size glSize = _openGLView->getDesignResolutionSize();
-    float factor = 1.0/glCoord.w;
-    return Vec2(glSize.width*(clipCoord.x*0.5 + 0.5) * factor, glSize.height*(-clipCoord.y*0.5 + 0.5) * factor);
+    float factor = 1.0f / glCoord.w;
+    return Vec2(glSize.width * (clipCoord.x * 0.5f + 0.5f) * factor, glSize.height * (-clipCoord.y * 0.5f + 0.5f) * factor);
 }
 
 const Size& Director::getWinSize(void) const

--- a/cocos/physics/CCPhysicsBody.cpp
+++ b/cocos/physics/CCPhysicsBody.cpp
@@ -941,8 +941,8 @@ void PhysicsBody::onAdd()
 {
     _owner->_physicsBody = this;
     auto contentSize = _owner->getContentSize();
-    _ownerCenterOffset.x = 0.5 * contentSize.width;
-    _ownerCenterOffset.y = 0.5 * contentSize.height;
+    _ownerCenterOffset.x = 0.5f * contentSize.width;
+    _ownerCenterOffset.y = 0.5f * contentSize.height;
 
     setRotationOffset(_owner->getRotation());
 

--- a/cocos/renderer/CCGLProgram.cpp
+++ b/cocos/renderer/CCGLProgram.cpp
@@ -905,9 +905,9 @@ void GLProgram::setUniformsForBuiltins(const Mat4 &matrixMV)
         // Getting Mach time per frame per shader using time could be extremely expensive.
         float time = _director->getTotalFrames() * _director->getAnimationInterval();
 
-        setUniformLocationWith4f(_builtInUniforms[GLProgram::UNIFORM_TIME], time/10.0, time, time*2, time*4);
-        setUniformLocationWith4f(_builtInUniforms[GLProgram::UNIFORM_SIN_TIME], time/8.0, time/4.0, time/2.0, sinf(time));
-        setUniformLocationWith4f(_builtInUniforms[GLProgram::UNIFORM_COS_TIME], time/8.0, time/4.0, time/2.0, cosf(time));
+        setUniformLocationWith4f(_builtInUniforms[GLProgram::UNIFORM_TIME], time/10.0f, time, time*2, time*4);
+        setUniformLocationWith4f(_builtInUniforms[GLProgram::UNIFORM_SIN_TIME], time/8.0f, time/4.0f, time/2.0f, sinf(time));
+        setUniformLocationWith4f(_builtInUniforms[GLProgram::UNIFORM_COS_TIME], time/8.0f, time/4.0f, time/2.0f, cosf(time));
     }
 
     if (_flags.usesRandom)

--- a/cocos/ui/UIButton.cpp
+++ b/cocos/ui/UIButton.cpp
@@ -500,12 +500,12 @@ void Button::onPressStateChangedToPressed()
             _buttonClickedRenderer->stopAllActions();
 
             Action *zoomAction = ScaleTo::create(ZOOM_ACTION_TIME_STEP,
-                                                 1.0 + _zoomScale,
-                                                 1.0 + _zoomScale);
+                                                 1.0f + _zoomScale,
+                                                 1.0f + _zoomScale);
             _buttonClickedRenderer->runAction(zoomAction);
 
-            _buttonNormalRenderer->setScale(1.0 + _zoomScale,
-                                            1.0 + _zoomScale);
+            _buttonNormalRenderer->setScale(1.0f + _zoomScale,
+                                            1.0f + _zoomScale);
 
             if(nullptr != _titleRenderer)
             {
@@ -523,7 +523,7 @@ void Button::onPressStateChangedToPressed()
         _buttonDisabledRenderer->setVisible(false);
 
         _buttonNormalRenderer->stopAllActions();
-        _buttonNormalRenderer->setScale(1.0 +_zoomScale, 1.0 + _zoomScale);
+        _buttonNormalRenderer->setScale(1.0f +_zoomScale, 1.0f + _zoomScale);
 
         if(nullptr != _titleRenderer)
         {

--- a/cocos/ui/UIRichText.cpp
+++ b/cocos/ui/UIRichText.cpp
@@ -638,10 +638,10 @@ bool MyXMLVisitor::VisitEnter( const tinyxml2::XMLElement& element, const tinyxm
                     attributes.fontSize = attrValueMap.at(RichText::KEY_FONT_SIZE).asFloat();
                 }
                 if (attrValueMap.find(RichText::KEY_FONT_SMALL) != attrValueMap.end()) {
-                    attributes.fontSize = getFontSize() * 0.8;
+                    attributes.fontSize = getFontSize() * 0.8f;
                 }
                 if (attrValueMap.find(RichText::KEY_FONT_BIG) != attrValueMap.end()) {
-                    attributes.fontSize = getFontSize() * 1.25;
+                    attributes.fontSize = getFontSize() * 1.25f;
                 }
                 if (attrValueMap.find(RichText::KEY_FONT_COLOR_STRING) != attrValueMap.end()) {
                     attributes.setColor(_richText->color3BWithString(attrValueMap.at(RichText::KEY_FONT_COLOR_STRING).asString()));

--- a/cocos/ui/UIScale9Sprite.cpp
+++ b/cocos/ui/UIScale9Sprite.cpp
@@ -1059,7 +1059,7 @@ namespace ui {
         float originalScale = Node::getScaleX();
         if (_flippedX)
         {
-            originalScale = originalScale * -1.0;
+            originalScale = originalScale * -1.0f;
         }
         return originalScale;
     }
@@ -1069,7 +1069,7 @@ namespace ui {
         float originalScale = Node::getScaleY();
         if (_flippedY)
         {
-            originalScale = originalScale * -1.0;
+            originalScale = originalScale * -1.0f;
         }
         return originalScale;
     }

--- a/cocos/ui/UIWidget.cpp
+++ b/cocos/ui/UIWidget.cpp
@@ -1312,7 +1312,7 @@ void Widget::copyProperties(Widget *widget)
         float originalScale = Node::getScaleX();
         if (_flippedX)
         {
-            originalScale = originalScale * -1.0;
+            originalScale = originalScale * -1.0f;
         }
         return originalScale;
     }
@@ -1322,7 +1322,7 @@ void Widget::copyProperties(Widget *widget)
         float originalScale = Node::getScaleY();
         if (_flippedY)
         {
-            originalScale = originalScale * -1.0;
+            originalScale = originalScale * -1.0f;
         }
         return originalScale;
     }

--- a/extensions/Particle3D/PU/CCPUBaseCollider.cpp
+++ b/extensions/Particle3D/PU/CCPUBaseCollider.cpp
@@ -106,7 +106,7 @@ void PUBaseCollider::calculateRotationSpeedAfterCollision( PUParticle3D* particl
     if (particle->particleType != PUParticle3D::PT_VISUAL)
         return;
 
-    float signedFriction = CCRANDOM_0_1() > 0.5 ? -(_friction - 1) : (_friction - 1);
+    float signedFriction = CCRANDOM_0_1() > 0.5f ? -(_friction - 1) : (_friction - 1);
 
     particle->rotationSpeed *= signedFriction;
     particle->zRotationSpeed *= signedFriction;

--- a/extensions/Particle3D/PU/CCPULineAffector.cpp
+++ b/extensions/Particle3D/PU/CCPULineAffector.cpp
@@ -123,7 +123,7 @@ void PULineAffector::updatePUAffector( PUParticle3D *particle, float deltaTime )
     {
         //PUParticle3D *particle = iter;
         (static_cast<PUParticleSystem3D *>(_particleSystem))->rotationOffset(particle->originalPosition); // Always update
-        if (_update && CCRANDOM_0_1() > 0.5 && !_first)
+        if (_update && CCRANDOM_0_1() > 0.5f && !_first)
         {
             // Generate a random vector perpendicular on the line
             Vec3 perpendicular;


### PR DESCRIPTION
When trying to compile libcocos2d with Xcode 7.3.1/Clang in my project at the highest warning level, I get the following warnings with `-Wdouble-promotion` option:

```
cocos/2d/CCActionPageTurn3D.cpp:74:19: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
    float theta = deltaTheta>0.5?(float)M_PI_2*deltaTheta:(float)M_PI_2*(1-deltaTheta);
                  ^~~~~~~~~~~
cocos/2d/CCAutoPolygon.cpp:497:37: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
    if(last.y > result.front().y && last.getDistance(result.front()) < ep*0.5)
                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ~
cocos/2d/CCAutoPolygon.cpp:497:72: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
    if(last.y > result.front().y && last.getDistance(result.front()) < ep*0.5)
                                                                       ^~~
cocos/2d/CCDrawNode.cpp:774:33: warning: implicit conversion increases floating-point precision: 'const GLfloat' (aka 'const float') to 'double' [-Wdouble-promotion]
    bool outline = (borderColor.a > 0.0 && borderWidth > 0.0);
                    ~~~~~~~~~~~~^ ~
cocos/2d/CCDrawNode.cpp:774:44: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
    bool outline = (borderColor.a > 0.0 && borderWidth > 0.0);
                                           ^~~~~~~~~~~ ~
cocos/2d/CCDrawNode.cpp:809:56: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
            Vec2 offset = v2fmult(v2fadd(n1, n2), 1.0/(v2fdot(n1, n2) + 1.0));
                                                       ^~~~~~~~~~~~~~ ~
cocos/2d/CCFastTMXLayer.cpp:154:26: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
        auto rect = Rect(Camera::getVisitingCamera()->getPositionX() - s.width * 0.5,
                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ~
cocos/2d/CCFastTMXLayer.cpp:154:74: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
        auto rect = Rect(Camera::getVisitingCamera()->getPositionX() - s.width * 0.5,
                                                                       ~~^~~~~ ~
cocos/2d/CCFastTMXLayer.cpp:155:22: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
                     Camera::getVisitingCamera()->getPositionY() - s.height * 0.5,
                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ~
...
```

In this case, it seems that the warning could be easily solved by simply adding the `f` suffix for floating point constant. So this pull request adds missing float suffix to avoid those warnings and casting float to double.

Thank you for considering this!
