### PR TITLE
fix some bugs in FileUtils

### DIFF
--- a/cocos/platform/CCFileUtils.h
+++ b/cocos/platform/CCFileUtils.h
@@ -64,7 +64,12 @@ public:
         _buffer->resize((size + sizeof(CharT) - 1) / sizeof(CharT));
     }
     virtual void* buffer() const override {
-        return &_buffer->front();
+        // can not invoke string::front() if it is empty
+
+        if (_buffer.empty())
+            return nullptr;
+        else
+            return &_buffer->front();
     }
 };
 
@@ -78,7 +83,12 @@ public:
         _buffer->resize((size + sizeof(T) - 1) / sizeof(T));
     }
     virtual void* buffer() const override {
-        return &_buffer->front();
+        // can not invoke vector::front() if it is empty
+
+        if (_buffer.empty())
+            return nullptr;
+        else
+            return &_buffer->front();
     }
 };
 

--- a/cocos/platform/CCFileUtils.h
+++ b/cocos/platform/CCFileUtils.h
@@ -66,7 +66,7 @@ public:
     virtual void* buffer() const override {
         // can not invoke string::front() if it is empty
 
-        if (_buffer.empty())
+        if (_buffer->empty())
             return nullptr;
         else
             return &_buffer->front();
@@ -85,7 +85,7 @@ public:
     virtual void* buffer() const override {
         // can not invoke vector::front() if it is empty
 
-        if (_buffer.empty())
+        if (_buffer->empty())
             return nullptr;
         else
             return &_buffer->front();

--- a/cocos/platform/win32/CCFileUtils-win32.cpp
+++ b/cocos/platform/win32/CCFileUtils-win32.cpp
@@ -256,6 +256,13 @@ FileUtils::Status FileUtilsWin32::getContents(const std::string& filename, Resiz
 		::CloseHandle(fileHandle);
 		return FileUtils::Status::TooLarge;
 	}
+    // don't read file content if it is empty
+    if (size == 0)
+    {
+        ::CloseHandle(fileHandle);
+        return FileUtils::Status::OK;
+    }
+
     buffer->resize(size);
     DWORD sizeRead = 0;
     BOOL successed = ::ReadFile(fileHandle, buffer->buffer(), size, &sizeRead, nullptr);


### PR DESCRIPTION
1. should not invoke container's `front()` function if the container is empty, or the result is undefined, met assert error on windows7 VS2013
2. don't read file content if it is empty
