### PR TITLE
Avoid overhead of casting float to double

### DIFF
--- a/cocos/math/CCGeometry.cpp
+++ b/cocos/math/CCGeometry.cpp
@@ -26,6 +26,7 @@ THE SOFTWARE.
 #include "math/CCGeometry.h"
 
 #include <algorithm>
+#include <cmath>
 #include "base/ccMacros.h"
 
 // implementation of Vec2
@@ -90,8 +91,8 @@ void Size::setSize(float w, float h)
 
 bool Size::equals(const Size& target) const
 {
-    return (fabs(this->width  - target.width)  < FLT_EPSILON)
-        && (fabs(this->height - target.height) < FLT_EPSILON);
+    return (std::abs(this->width  - target.width)  < FLT_EPSILON)
+        && (std::abs(this->height - target.height) < FLT_EPSILON);
 }
 
 const Size Size::ZERO = Size(0, 0);
@@ -200,16 +201,16 @@ bool Rect::intersectsCircle(const Vec2& center, float radius) const
     float w = size.width / 2;
     float h = size.height / 2;
     
-    float dx = fabs(center.x - rectangleCenter.x);
-    float dy = fabs(center.y - rectangleCenter.y);
+    float dx = std::abs(center.x - rectangleCenter.x);
+    float dy = std::abs(center.y - rectangleCenter.y);
     
     if (dx > (radius + w) || dy > (radius + h))
     {
         return false;
     }
     
-    Vec2 circleDistance(fabs(center.x - origin.x - w),
-                        fabs(center.y - origin.y - h));
+    Vec2 circleDistance(std::abs(center.x - origin.x - w),
+                        std::abs(center.y - origin.y - h));
     
     if (circleDistance.x <= (w))
     {

--- a/cocos/math/CCGeometry.h
+++ b/cocos/math/CCGeometry.h
@@ -26,8 +26,6 @@ THE SOFTWARE.
 #ifndef __MATH_CCGEOMETRY_H__
 #define __MATH_CCGEOMETRY_H__
 
-#include <math.h>
-
 #include "platform/CCPlatformMacros.h"
 #include "base/ccMacros.h"
 #include "math/CCMath.h"

--- a/cocos/math/Vec2.cpp
+++ b/cocos/math/Vec2.cpp
@@ -123,7 +123,7 @@ float Vec2::distance(const Vec2& v) const
     float dx = v.x - x;
     float dy = v.y - y;
 
-    return sqrt(dx * dx + dy * dy);
+    return std::sqrt(dx * dx + dy * dy);
 }
 
 float Vec2::dot(const Vec2& v1, const Vec2& v2)
@@ -133,7 +133,7 @@ float Vec2::dot(const Vec2& v1, const Vec2& v2)
 
 float Vec2::length() const
 {
-    return sqrt(x * x + y * y);
+    return std::sqrt(x * x + y * y);
 }
 
 void Vec2::normalize()
@@ -143,7 +143,7 @@ void Vec2::normalize()
     if (n == 1.0f)
         return;
     
-    n = sqrt(n);
+    n = std::sqrt(n);
     // Too close to zero.
     if (n < MATH_TOLERANCE)
         return;
@@ -162,8 +162,8 @@ Vec2 Vec2::getNormalized() const
 
 void Vec2::rotate(const Vec2& point, float angle)
 {
-    double sinAngle = sin(angle);
-    double cosAngle = cos(angle);
+    float sinAngle = std::sin(angle);
+    float cosAngle = std::cos(angle);
 
     if (point.isZero())
     {
@@ -199,8 +199,8 @@ void Vec2::subtract(const Vec2& v1, const Vec2& v2, Vec2* dst)
 
 bool Vec2::equals(const Vec2& target) const
 {
-    return (fabs(this->x - target.x) < FLT_EPSILON)
-        && (fabs(this->y - target.y) < FLT_EPSILON);
+    return (std::abs(this->x - target.x) < FLT_EPSILON)
+        && (std::abs(this->y - target.y) < FLT_EPSILON);
 }
 
 bool Vec2::fuzzyEquals(const Vec2& b, float var) const
@@ -216,7 +216,7 @@ float Vec2::getAngle(const Vec2& other) const
     Vec2 a2 = getNormalized();
     Vec2 b2 = other.getNormalized();
     float angle = atan2f(a2.cross(b2), a2.dot(b2));
-    if( fabs(angle) < FLT_EPSILON ) return 0.f;
+    if (std::abs(angle) < FLT_EPSILON) return 0.f;
     return angle;
 }
 

--- a/cocos/math/Vec2.h
+++ b/cocos/math/Vec2.h
@@ -24,7 +24,7 @@
 
 #include <algorithm>
 #include <functional>
-#include <math.h>
+#include <cmath>
 #include "math/CCMathBase.h"
 
 /**

--- a/cocos/math/Vec3.cpp
+++ b/cocos/math/Vec3.cpp
@@ -74,7 +74,7 @@ float Vec3::angle(const Vec3& v1, const Vec3& v2)
     float dy = v1.z * v2.x - v1.x * v2.z;
     float dz = v1.x * v2.y - v1.y * v2.x;
 
-    return atan2f(sqrt(dx * dx + dy * dy + dz * dz) + MATH_FLOAT_SMALL, dot(v1, v2));
+    return std::atan2(std::sqrt(dx * dx + dy * dy + dz * dz) + MATH_FLOAT_SMALL, dot(v1, v2));
 }
 
 void Vec3::add(const Vec3& v1, const Vec3& v2, Vec3* dst)
@@ -157,7 +157,7 @@ float Vec3::distance(const Vec3& v) const
     float dy = v.y - y;
     float dz = v.z - z;
 
-    return sqrt(dx * dx + dy * dy + dz * dz);
+    return std::sqrt(dx * dx + dy * dy + dz * dz);
 }
 
 float Vec3::distanceSquared(const Vec3& v) const
@@ -186,7 +186,7 @@ void Vec3::normalize()
     if (n == 1.0f)
         return;
     
-    n = sqrt(n);
+    n = std::sqrt(n);
     // Too close to zero.
     if (n < MATH_TOLERANCE)
         return;

--- a/cocos/math/Vec3.h
+++ b/cocos/math/Vec3.h
@@ -22,6 +22,7 @@
 #ifndef MATH_VEC3_H
 #define MATH_VEC3_H
 
+#include <cmath>
 #include "math/CCMathBase.h"
 
 /**

--- a/cocos/math/Vec3.inl
+++ b/cocos/math/Vec3.inl
@@ -50,7 +50,7 @@ inline void Vec3::add(float xx, float yy, float zz)
 
 inline float Vec3::length() const
 {
-    return sqrt(x * x + y * y + z * z);
+    return std::sqrt(x * x + y * y + z * z);
 }
 
 inline float Vec3::lengthSquared() const


### PR DESCRIPTION
When I try to compile libcocos2d on Clang/Xcode 7.3.1 at the highest warning level (`-Weverything`), I get a bunch of warnings related to converting between `float` and `double`:

```
cocos/math/CCGeometry.cpp:93:31: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
cocos/math/CCGeometry.cpp:93:50: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
cocos/math/CCGeometry.cpp:94:31: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
cocos/math/CCGeometry.cpp:94:50: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
cocos/math/CCGeometry.cpp:203:30: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
cocos/math/CCGeometry.cpp:204:30: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
cocos/math/CCGeometry.cpp:211:50: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
cocos/math/CCGeometry.cpp:212:50: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
cocos/math/Vec2.cpp:126:25: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
cocos/math/Vec2.cpp:136:23: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
cocos/math/Vec2.cpp:146:14: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
cocos/math/Vec2.cpp:165:27: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
cocos/math/Vec2.cpp:166:27: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
cocos/math/Vec2.cpp:170:23: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
cocos/math/Vec2.cpp:170:38: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
cocos/math/Vec2.cpp:171:13: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
cocos/math/Vec2.cpp:171:28: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
cocos/math/Vec2.cpp:179:13: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
cocos/math/Vec2.cpp:179:32: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
cocos/math/Vec2.cpp:179:57: warning: implicit conversion increases floating-point precision: 'const float' to 'double' [-Wdouble-promotion]
cocos/math/Vec2.cpp:180:13: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
cocos/math/Vec2.cpp:180:32: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
cocos/math/Vec2.cpp:180:57: warning: implicit conversion increases floating-point precision: 'const float' to 'double' [-Wdouble-promotion]
cocos/math/Vec2.cpp:202:26: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
cocos/math/Vec2.cpp:202:40: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
cocos/math/Vec2.cpp:203:26: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
cocos/math/Vec2.cpp:203:40: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
cocos/math/Vec2.cpp:219:14: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
cocos/math/Vec2.cpp:219:23: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
cocos/math/Vec3.cpp:77:42: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
cocos/math/Vec3.cpp:77:55: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
cocos/math/Vec3.cpp:160:35: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
cocos/math/Vec3.cpp:189:14: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
cocos/math/Vec3.inl:53:31: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
```

These warnings are caused by using math functions that take `double` argument and return `double` as the result such as `::fabs(double)`, `::sqrt(double)`, `::sin(double)` and `::cos(double)`. To suppress the warnings, we can use `std::abs(float)` or `::fabsf(float)` etc. instead them.

Also, this issue affects the performance because it causes unnecessary implicit casting between `float` and `double` such as `cvtss2sd` or `fcvtds`. Actually, I try to reproduce the implicit conversion with the small test case below on my local machine. (Btw, you can try to compile it online [at this site](http://gcc.godbolt.org/).)

**Code:**

``` cpp
#include <math.h>

float length(float x, float y)
{
    return sqrt(x * x + y * y);
}
```

**Assembly code snippets:**

``` assembly
# x86, Clang 3.8
cvtss2sd        %xmm0, %xmm0    # casting double to float
callq   sqrt                    # ::sqrt(double)
cvtsd2ss        %xmm0, %xmm0    # casting float to double
```

``` assembly
# ARM, GCC 4.8.2
fcvtds  d7, s15                 # casting double to float
fcpyd   d0, d7
bl      sqrt                    # ::sqrt(double)
fcpyd   d7, d0
fcvtsd  s15, d7                 # casting float to double
```

**Code:**

``` cpp
#include <cmath>

float length(float x, float y)
{
    return std::sqrt(x * x + y * y);
}
```

**Assembly code snippets:**

``` assembly
# x86, Clang 3.8
callq   std::sqrt(float)
```

``` assembly
# ARM, GCC 4.8.2
fcpys   s0, s15
bl      std::sqrt(float)
fcpys   s15, s0
```

So this pull request fixes the warnings and avoids overhead of casting `float` to `double` for performance and portability. Thank you for reading.
