### PR TITLE
fix compiling and linking error with ndk r12b

### DIFF
--- a/cocos/3d/Android.mk
+++ b/cocos/3d/Android.mk
@@ -2,6 +2,7 @@ LOCAL_PATH := $(call my-dir)
 include $(CLEAR_VARS)
 
 LOCAL_MODULE := cocos3d_static
+LOCAL_ARM_MODE := arm
 
 LOCAL_MODULE_FILENAME := libcocos3d
 

--- a/cocos/Android.mk
+++ b/cocos/Android.mk
@@ -6,9 +6,7 @@ LOCAL_MODULE := cocos2dx_internal_static
 
 LOCAL_MODULE_FILENAME := libcocos2dxinternal
 
-ifeq ($(USE_ARM_MODE),1)
 LOCAL_ARM_MODE := arm
-endif
 
 ifeq ($(TARGET_ARCH_ABI),armeabi-v7a)
 MATHNEONFILE := math/MathUtil.cpp.neon

--- a/cocos/editor-support/cocosbuilder/Android.mk
+++ b/cocos/editor-support/cocosbuilder/Android.mk
@@ -5,9 +5,7 @@ LOCAL_MODULE := cocosbuilder_static
 
 LOCAL_MODULE_FILENAME := libcocosbuilder
 
-ifeq ($(USE_ARM_MODE),1)
 LOCAL_ARM_MODE := arm
-endif
 
 LOCAL_SRC_FILES := CCBAnimationManager.cpp \
 CCBFileLoader.cpp \

--- a/cocos/editor-support/cocostudio/Android.mk
+++ b/cocos/editor-support/cocostudio/Android.mk
@@ -5,9 +5,7 @@ LOCAL_MODULE := cocostudio_static
 
 LOCAL_MODULE_FILENAME := libcocostudio
 
-ifeq ($(USE_ARM_MODE),1)
 LOCAL_ARM_MODE := arm
-endif
 
 LOCAL_SRC_FILES := CCActionFrame.cpp \
 CCActionFrameEasing.cpp \

--- a/cocos/editor-support/spine/Android.mk
+++ b/cocos/editor-support/spine/Android.mk
@@ -5,9 +5,7 @@ LOCAL_MODULE := spine_static
 
 LOCAL_MODULE_FILENAME := libspine
 
-ifeq ($(USE_ARM_MODE),1)
 LOCAL_ARM_MODE := arm
-endif
 
 LOCAL_SRC_FILES := Animation.c \
 AnimationState.c \

--- a/cocos/network/Android.mk
+++ b/cocos/network/Android.mk
@@ -5,6 +5,8 @@ LOCAL_MODULE := cocos_network_static
 
 LOCAL_MODULE_FILENAME := libnetwork
 
+LOCAL_ARM_MODE := arm
+
 LOCAL_SRC_FILES := HttpClient-android.cpp \
 SocketIO.cpp \
 WebSocket.cpp \

--- a/cocos/scripting/js-bindings/proj.android/Android.mk
+++ b/cocos/scripting/js-bindings/proj.android/Android.mk
@@ -6,9 +6,7 @@ LOCAL_MODULE := cocos2d_js_android_static
 
 LOCAL_MODULE_FILENAME := libjscocos2dandroid
 
-ifeq ($(COCOS_SIMULATOR_BUILD),1)
 LOCAL_ARM_MODE := arm
-endif
 
 LOCAL_SRC_FILES := ../manual/platform/android/CCJavascriptJavaBridge.cpp
 
@@ -34,6 +32,8 @@ include $(CLEAR_VARS)
 LOCAL_MODULE := cocos2d_js_static
 
 LOCAL_MODULE_FILENAME := libjscocos2d
+
+LOCAL_ARM_MODE := arm
 
 LOCAL_SRC_FILES := ../auto/jsb_cocos2dx_3d_auto.cpp \
                    ../auto/jsb_cocos2dx_extension_auto.cpp \

--- a/cocos/scripting/lua-bindings/proj.android/Android.mk
+++ b/cocos/scripting/lua-bindings/proj.android/Android.mk
@@ -6,6 +6,8 @@ LOCAL_MODULE := cocos2d_lua_android_static
 
 LOCAL_MODULE_FILENAME := libluacocos2dandroid
 
+LOCAL_ARM_MODE := arm
+
 LOCAL_SRC_FILES := ../manual/platform/android/CCLuaJavaBridge.cpp \
                    ../manual/platform/android/jni/Java_org_cocos2dx_lib_Cocos2dxLuaJavaBridge.cpp
 
@@ -31,9 +33,7 @@ LOCAL_MODULE    := cocos2d_lua_static
 
 LOCAL_MODULE_FILENAME := libluacocos2d
 
-ifeq ($(COCOS_SIMULATOR_BUILD),1)
 LOCAL_ARM_MODE := arm
-endif
 
 LOCAL_SRC_FILES := ../manual/CCLuaBridge.cpp \
           ../manual/CCLuaEngine.cpp \

--- a/cocos/storage/local-storage/Android.mk
+++ b/cocos/storage/local-storage/Android.mk
@@ -5,6 +5,8 @@ LOCAL_MODULE := cocos_localstorage_static
 
 LOCAL_MODULE_FILENAME := liblocalstorage
 
+LOCAL_ARM_MODE := arm
+
 LOCAL_SRC_FILES := LocalStorage.cpp \
 LocalStorage-android.cpp 
 

--- a/cocos/ui/Android.mk
+++ b/cocos/ui/Android.mk
@@ -5,9 +5,7 @@ LOCAL_MODULE := cocos_ui_static
 
 LOCAL_MODULE_FILENAME := libui
 
-ifeq ($(USE_ARM_MODE),1)
 LOCAL_ARM_MODE := arm
-endif
 
 LOCAL_SRC_FILES := \
 UIWidget.cpp \

--- a/extensions/Android.mk
+++ b/extensions/Android.mk
@@ -5,9 +5,7 @@ LOCAL_MODULE    := cocos_extension_static
 
 LOCAL_MODULE_FILENAME := libextension
 
-ifeq ($(USE_ARM_MODE),1)
 LOCAL_ARM_MODE := arm
-endif
 
 LOCAL_SRC_FILES := \
 assets-manager/AssetsManager.cpp \

--- a/external/config.json
+++ b/external/config.json
@@ -1,5 +1,5 @@
 {
-    "version":"v3-deps-100",
+    "version":"v3-deps-101",
     "zip_file_size":"128440074",
     "repo_name":"cocos2d-x-3rd-party-libs-bin",
     "repo_parent":"https://github.com/cocos2d/",

--- a/tests/cpp-empty-test/proj.android-studio/app/jni/Android.mk
+++ b/tests/cpp-empty-test/proj.android-studio/app/jni/Android.mk
@@ -6,6 +6,8 @@ LOCAL_MODULE := cpp_empty_test_shared
 
 LOCAL_MODULE_FILENAME := libcpp_empty_test
 
+LOCAL_ARM_MODE := arm
+
 LOCAL_SRC_FILES := main.cpp \
                    ../../../Classes/AppDelegate.cpp \
                    ../../../Classes/HelloWorldScene.cpp

--- a/tests/cpp-empty-test/proj.android-studio/app/jni/Application.mk
+++ b/tests/cpp-empty-test/proj.android-studio/app/jni/Application.mk
@@ -2,7 +2,7 @@ APP_STL := gnustl_static
 
 APP_CPPFLAGS := -frtti -DCC_ENABLE_CHIPMUNK_INTEGRATION=1 -std=c++11 -fsigned-char
 APP_LDFLAGS := -latomic
-
+APP_ABI := armeabi
 
 ifeq ($(NDK_DEBUG),1)
   APP_CPPFLAGS += -DCOCOS2D_DEBUG=1

--- a/tests/cpp-empty-test/proj.android/jni/Android.mk
+++ b/tests/cpp-empty-test/proj.android/jni/Android.mk
@@ -6,6 +6,8 @@ LOCAL_MODULE := cpp_empty_test_shared
 
 LOCAL_MODULE_FILENAME := libcpp_empty_test
 
+LOCAL_ARM_MODE := arm
+
 LOCAL_SRC_FILES := main.cpp \
                    ../../Classes/AppDelegate.cpp \
                    ../../Classes/HelloWorldScene.cpp

--- a/tests/cpp-empty-test/proj.android/jni/Application.mk
+++ b/tests/cpp-empty-test/proj.android/jni/Application.mk
@@ -2,6 +2,7 @@ APP_STL := gnustl_static
 
 APP_CPPFLAGS := -frtti -DCC_ENABLE_CHIPMUNK_INTEGRATION=1 -std=c++11 -fsigned-char
 APP_LDFLAGS := -latomic
+APP_ABI := armeabi
 
 
 ifeq ($(NDK_DEBUG),1)

--- a/tests/cpp-tests/proj.android-studio/app/jni/Android.mk
+++ b/tests/cpp-tests/proj.android-studio/app/jni/Android.mk
@@ -6,6 +6,8 @@ LOCAL_MODULE := cpp_tests_shared
 
 LOCAL_MODULE_FILENAME := libcpp_tests
 
+LOCAL_ARM_MODE := arm
+
 LOCAL_SRC_FILES := main.cpp \
 ../../../Classes/ActionManagerTest/ActionManagerTest.cpp \
 ../../../Classes/ActionsEaseTest/ActionsEaseTest.cpp \

--- a/tests/cpp-tests/proj.android-studio/app/jni/Application.mk
+++ b/tests/cpp-tests/proj.android-studio/app/jni/Application.mk
@@ -3,6 +3,8 @@ APP_STL := gnustl_static
 APP_CPPFLAGS := -frtti -DCC_ENABLE_CHIPMUNK_INTEGRATION=1 -std=c++11 -fsigned-char
 APP_LDFLAGS := -latomic
 
+APP_ABI := armeabi
+
 ifeq ($(NDK_DEBUG),1)
   APP_CPPFLAGS += -DCOCOS2D_DEBUG=1
   APP_OPTIM := debug

--- a/tests/cpp-tests/proj.android/jni/Android.mk
+++ b/tests/cpp-tests/proj.android/jni/Android.mk
@@ -6,6 +6,8 @@ LOCAL_MODULE := cpp_tests_shared
 
 LOCAL_MODULE_FILENAME := libcpp_tests
 
+LOCAL_ARM_MODE := arm
+
 LOCAL_SRC_FILES := main.cpp \
 ../../Classes/ActionManagerTest/ActionManagerTest.cpp \
 ../../Classes/ActionsEaseTest/ActionsEaseTest.cpp \

--- a/tests/cpp-tests/proj.android/jni/Application.mk
+++ b/tests/cpp-tests/proj.android/jni/Application.mk
@@ -3,6 +3,8 @@ APP_STL := gnustl_static
 APP_CPPFLAGS := -frtti -DCC_ENABLE_CHIPMUNK_INTEGRATION=1 -std=c++11 -fsigned-char
 APP_LDFLAGS := -latomic
 
+APP_ABI := armeabi
+
 ifeq ($(NDK_DEBUG),1)
   APP_CPPFLAGS += -DCOCOS2D_DEBUG=1
   APP_OPTIM := debug

--- a/tests/game-controller-test/proj.android-studio/app/jni/Android.mk
+++ b/tests/game-controller-test/proj.android-studio/app/jni/Android.mk
@@ -6,6 +6,8 @@ LOCAL_MODULE := game_controller_test_shared
 
 LOCAL_MODULE_FILENAME := libgame_controller_test
 
+LOCAL_ARM_MODE := arm
+
 LOCAL_SRC_FILES := main.cpp \
                    ../../../Classes/AppDelegate.cpp \
                    ../../../Classes/GameControllerTest.cpp

--- a/tests/game-controller-test/proj.android-studio/app/jni/Application.mk
+++ b/tests/game-controller-test/proj.android-studio/app/jni/Application.mk
@@ -2,7 +2,7 @@ APP_STL := gnustl_static
 
 APP_CPPFLAGS := -frtti -DCC_ENABLE_CHIPMUNK_INTEGRATION=1 -std=c++11 -fsigned-char
 APP_LDFLAGS := -latomic
-
+APP_ABI := armeabi
 
 ifeq ($(NDK_DEBUG),1)
   APP_CPPFLAGS += -DCOCOS2D_DEBUG=1

--- a/tests/game-controller-test/proj.android/jni/Android.mk
+++ b/tests/game-controller-test/proj.android/jni/Android.mk
@@ -6,6 +6,8 @@ LOCAL_MODULE := game_controller_test_shared
 
 LOCAL_MODULE_FILENAME := libgame_controller_test
 
+LOCAL_ARM_MODE := arm
+
 LOCAL_SRC_FILES := main.cpp \
                    ../../Classes/AppDelegate.cpp \
                    ../../Classes/GameControllerTest.cpp

--- a/tests/game-controller-test/proj.android/jni/Application.mk
+++ b/tests/game-controller-test/proj.android/jni/Application.mk
@@ -2,7 +2,7 @@ APP_STL := gnustl_static
 
 APP_CPPFLAGS := -frtti -DCC_ENABLE_CHIPMUNK_INTEGRATION=1 -std=c++11 -fsigned-char
 APP_LDFLAGS := -latomic
-
+APP_ABI := armeabi
 
 ifeq ($(NDK_DEBUG),1)
   APP_CPPFLAGS += -DCOCOS2D_DEBUG=1

--- a/tests/js-memory-gc-tests/project/proj.android-studio/app/jni/Android.mk
+++ b/tests/js-memory-gc-tests/project/proj.android-studio/app/jni/Android.mk
@@ -6,6 +6,8 @@ LOCAL_MODULE := js_tests_shared
 
 LOCAL_MODULE_FILENAME := libjs_tests
 
+LOCAL_ARM_MODE := arm
+
 LOCAL_SRC_FILES := main.cpp \
                    ../../../Classes/AppDelegate.cpp \
                    ../../../Classes/js_DrawNode3D_bindings.cpp \

--- a/tests/js-memory-gc-tests/project/proj.android-studio/app/jni/Application.mk
+++ b/tests/js-memory-gc-tests/project/proj.android-studio/app/jni/Application.mk
@@ -5,8 +5,7 @@ APP_STL := gnustl_static
 
 APP_CPPFLAGS := -frtti -DCC_ENABLE_CHIPMUNK_INTEGRATION=1 -std=c++11 -fsigned-char
 APP_LDFLAGS := -latomic
-
-USE_ARM_MODE := 1
+APP_ABI := armeabi
 
 ifeq ($(NDK_DEBUG),1)
   APP_CPPFLAGS += -DCOCOS2D_DEBUG=1

--- a/tests/js-memory-gc-tests/project/proj.android/jni/Android.mk
+++ b/tests/js-memory-gc-tests/project/proj.android/jni/Android.mk
@@ -6,6 +6,8 @@ LOCAL_MODULE := js_tests_shared
 
 LOCAL_MODULE_FILENAME := libjs_tests
 
+LOCAL_ARM_MODE := arm
+
 LOCAL_SRC_FILES := main.cpp \
                    ../../Classes/AppDelegate.cpp \
                    ../../Classes/js_DrawNode3D_bindings.cpp \

--- a/tests/js-memory-gc-tests/project/proj.android/jni/Application.mk
+++ b/tests/js-memory-gc-tests/project/proj.android/jni/Application.mk
@@ -5,8 +5,7 @@ APP_STL := gnustl_static
 
 APP_CPPFLAGS := -frtti -DCC_ENABLE_CHIPMUNK_INTEGRATION=1 -std=c++11 -fsigned-char
 APP_LDFLAGS := -latomic
-
-USE_ARM_MODE := 1
+APP_ABI := armeabi
 
 ifeq ($(NDK_DEBUG),1)
   APP_CPPFLAGS += -DCOCOS2D_DEBUG=1

--- a/tests/js-tests/project/proj.android-studio/app/jni/Android.mk
+++ b/tests/js-tests/project/proj.android-studio/app/jni/Android.mk
@@ -6,6 +6,8 @@ LOCAL_MODULE := js_tests_shared
 
 LOCAL_MODULE_FILENAME := libjs_tests
 
+LOCAL_ARM_MODE := arm
+
 LOCAL_SRC_FILES := main.cpp \
                    ../../../Classes/AppDelegate.cpp \
                    ../../../Classes/js_DrawNode3D_bindings.cpp \

--- a/tests/js-tests/project/proj.android-studio/app/jni/Application.mk
+++ b/tests/js-tests/project/proj.android-studio/app/jni/Application.mk
@@ -5,8 +5,7 @@ APP_STL := gnustl_static
 
 APP_CPPFLAGS := -frtti -DCC_ENABLE_CHIPMUNK_INTEGRATION=1 -std=c++11 -fsigned-char
 APP_LDFLAGS := -latomic
-
-USE_ARM_MODE := 1
+APP_ABI := armeabi
 
 ifeq ($(NDK_DEBUG),1)
   APP_CPPFLAGS += -DCOCOS2D_DEBUG=1

--- a/tests/js-tests/project/proj.android/jni/Android.mk
+++ b/tests/js-tests/project/proj.android/jni/Android.mk
@@ -6,6 +6,8 @@ LOCAL_MODULE := js_tests_shared
 
 LOCAL_MODULE_FILENAME := libjs_tests
 
+LOCAL_ARM_MODE := arm
+
 LOCAL_SRC_FILES := main.cpp \
                    ../../Classes/AppDelegate.cpp \
                    ../../Classes/js_DrawNode3D_bindings.cpp \

--- a/tests/js-tests/project/proj.android/jni/Application.mk
+++ b/tests/js-tests/project/proj.android/jni/Application.mk
@@ -5,8 +5,7 @@ APP_STL := gnustl_static
 
 APP_CPPFLAGS := -frtti -DCC_ENABLE_CHIPMUNK_INTEGRATION=1 -std=c++11 -fsigned-char
 APP_LDFLAGS := -latomic
-
-USE_ARM_MODE := 1
+APP_ABI := armeabi
 
 ifeq ($(NDK_DEBUG),1)
   APP_CPPFLAGS += -DCOCOS2D_DEBUG=1

--- a/tests/lua-empty-test/project/proj.android-studio/app/jni/Android.mk
+++ b/tests/lua-empty-test/project/proj.android-studio/app/jni/Android.mk
@@ -6,6 +6,8 @@ LOCAL_MODULE := lua_empty_test_shared
 
 LOCAL_MODULE_FILENAME := liblua_empty_test
 
+LOCAL_ARM_MODE := arm
+
 LOCAL_SRC_FILES := main.cpp \
                    ../../../Classes/AppDelegate.cpp
 

--- a/tests/lua-empty-test/project/proj.android-studio/app/jni/Application.mk
+++ b/tests/lua-empty-test/project/proj.android-studio/app/jni/Application.mk
@@ -2,6 +2,7 @@ APP_STL := gnustl_static
 
 APP_CPPFLAGS := -frtti -DCC_ENABLE_CHIPMUNK_INTEGRATION=1 -std=c++11 -fsigned-char
 APP_LDFLAGS := -latomic
+APP_ABI := armeabi
 
 
 ifeq ($(NDK_DEBUG),1)

--- a/tests/lua-empty-test/project/proj.android/jni/Android.mk
+++ b/tests/lua-empty-test/project/proj.android/jni/Android.mk
@@ -6,6 +6,8 @@ LOCAL_MODULE := lua_empty_test_shared
 
 LOCAL_MODULE_FILENAME := liblua_empty_test
 
+LOCAL_ARM_MODE := arm
+
 LOCAL_SRC_FILES := main.cpp \
                    ../../Classes/AppDelegate.cpp
 

--- a/tests/lua-empty-test/project/proj.android/jni/Application.mk
+++ b/tests/lua-empty-test/project/proj.android/jni/Application.mk
@@ -2,6 +2,7 @@ APP_STL := gnustl_static
 
 APP_CPPFLAGS := -frtti -DCC_ENABLE_CHIPMUNK_INTEGRATION=1 -std=c++11 -fsigned-char
 APP_LDFLAGS := -latomic
+APP_ABI := armeabi
 
 
 ifeq ($(NDK_DEBUG),1)

--- a/tests/lua-game-controller-test/project/proj.android-studio/app/jni/Android.mk
+++ b/tests/lua-game-controller-test/project/proj.android-studio/app/jni/Android.mk
@@ -6,6 +6,8 @@ LOCAL_MODULE := lua_game_controller_test_shared
 
 LOCAL_MODULE_FILENAME := liblua_game_controller
 
+LOCAL_ARM_MODE := arm
+
 LOCAL_SRC_FILES := main.cpp \
                    ../../../Classes/AppDelegate.cpp \
                    ../../../../../../cocos/scripting/lua-bindings/auto/lua_cocos2dx_controller_auto.cpp \

--- a/tests/lua-game-controller-test/project/proj.android-studio/app/jni/Application.mk
+++ b/tests/lua-game-controller-test/project/proj.android-studio/app/jni/Application.mk
@@ -2,6 +2,7 @@ APP_STL := gnustl_static
 
 APP_CPPFLAGS := -frtti -DCC_ENABLE_CHIPMUNK_INTEGRATION=1 -std=c++11 -fsigned-char
 APP_LDFLAGS := -latomic
+APP_ABI := armeabi
 
 
 ifeq ($(NDK_DEBUG),1)

--- a/tests/lua-game-controller-test/project/proj.android/jni/Android.mk
+++ b/tests/lua-game-controller-test/project/proj.android/jni/Android.mk
@@ -6,6 +6,8 @@ LOCAL_MODULE := lua_game_controller_test_shared
 
 LOCAL_MODULE_FILENAME := liblua_game_controller
 
+LOCAL_ARM_MODE := arm
+
 LOCAL_SRC_FILES := main.cpp \
                    ../../Classes/AppDelegate.cpp \
                    ../../../../../cocos/scripting/lua-bindings/auto/lua_cocos2dx_controller_auto.cpp \

--- a/tests/lua-game-controller-test/project/proj.android/jni/Application.mk
+++ b/tests/lua-game-controller-test/project/proj.android/jni/Application.mk
@@ -2,7 +2,7 @@ APP_STL := gnustl_static
 
 APP_CPPFLAGS := -frtti -DCC_ENABLE_CHIPMUNK_INTEGRATION=1 -std=c++11 -fsigned-char
 APP_LDFLAGS := -latomic
-
+APP_ABI := armeabi
 
 ifeq ($(NDK_DEBUG),1)
   APP_CPPFLAGS += -DCOCOS2D_DEBUG=1

--- a/tests/lua-tests/project/proj.android-studio/app/jni/Android.mk
+++ b/tests/lua-tests/project/proj.android-studio/app/jni/Android.mk
@@ -6,6 +6,8 @@ LOCAL_MODULE := lua_tests_shared
 
 LOCAL_MODULE_FILENAME := liblua_tests
 
+LOCAL_ARM_MODE := arm
+
 LOCAL_SRC_FILES += main.cpp \
                    ../../../Classes/AppDelegate.cpp \
                    ../../../Classes/lua_assetsmanager_test_sample.cpp \

--- a/tests/lua-tests/project/proj.android-studio/app/jni/Application.mk
+++ b/tests/lua-tests/project/proj.android-studio/app/jni/Application.mk
@@ -2,7 +2,7 @@ APP_STL := gnustl_static
 
 APP_CPPFLAGS := -frtti -DCC_ENABLE_CHIPMUNK_INTEGRATION=1 -std=c++11 -fsigned-char
 APP_LDFLAGS := -latomic
-
+APP_ABI := armeabi
 
 ifeq ($(NDK_DEBUG),1)
   APP_CPPFLAGS += -DCOCOS2D_DEBUG=1

--- a/tests/lua-tests/project/proj.android/jni/Android.mk
+++ b/tests/lua-tests/project/proj.android/jni/Android.mk
@@ -6,6 +6,8 @@ LOCAL_MODULE := lua_tests_shared
 
 LOCAL_MODULE_FILENAME := liblua_tests
 
+LOCAL_ARM_MODE := arm
+
 LOCAL_SRC_FILES += main.cpp \
                    ../../Classes/AppDelegate.cpp \
                    ../../Classes/lua_assetsmanager_test_sample.cpp \

--- a/tests/lua-tests/project/proj.android/jni/Application.mk
+++ b/tests/lua-tests/project/proj.android/jni/Application.mk
@@ -2,7 +2,7 @@ APP_STL := gnustl_static
 
 APP_CPPFLAGS := -frtti -DCC_ENABLE_CHIPMUNK_INTEGRATION=1 -std=c++11 -fsigned-char
 APP_LDFLAGS := -latomic
-
+APP_ABI := armeabi
 
 ifeq ($(NDK_DEBUG),1)
   APP_CPPFLAGS += -DCOCOS2D_DEBUG=1

--- a/tests/performance-tests/proj.android-studio/app/jni/Android.mk
+++ b/tests/performance-tests/proj.android-studio/app/jni/Android.mk
@@ -6,6 +6,8 @@ LOCAL_MODULE := cocos2dcpp_shared
 
 LOCAL_MODULE_FILENAME := libcocos2dcpp
 
+LOCAL_ARM_MODE := arm
+
 LOCAL_SRC_FILES := hellocpp/main.cpp \
                    ../../../Classes/AppDelegate.cpp \
                    ../../../Classes/Profile.cpp \

--- a/tests/performance-tests/proj.android-studio/app/jni/Application.mk
+++ b/tests/performance-tests/proj.android-studio/app/jni/Application.mk
@@ -2,7 +2,7 @@ APP_STL := gnustl_static
 
 APP_CPPFLAGS := -frtti -DCC_ENABLE_CHIPMUNK_INTEGRATION=1 -std=c++11 -fsigned-char
 APP_LDFLAGS := -latomic
-
+APP_ABI := armeabi
 
 ifeq ($(NDK_DEBUG),1)
   APP_CPPFLAGS += -DCOCOS2D_DEBUG=1

--- a/tests/performance-tests/proj.android/jni/Android.mk
+++ b/tests/performance-tests/proj.android/jni/Android.mk
@@ -6,6 +6,8 @@ LOCAL_MODULE := cocos2dcpp_shared
 
 LOCAL_MODULE_FILENAME := libcocos2dcpp
 
+LOCAL_ARM_MODE := arm
+
 LOCAL_SRC_FILES := hellocpp/main.cpp \
                    ../../Classes/AppDelegate.cpp \
                    ../../Classes/Profile.cpp \

--- a/tests/performance-tests/proj.android/jni/Application.mk
+++ b/tests/performance-tests/proj.android/jni/Application.mk
@@ -2,7 +2,7 @@ APP_STL := gnustl_static
 
 APP_CPPFLAGS := -frtti -DCC_ENABLE_CHIPMUNK_INTEGRATION=1 -std=c++11 -fsigned-char
 APP_LDFLAGS := -latomic
-
+APP_ABI := armeabi
 
 ifeq ($(NDK_DEBUG),1)
   APP_CPPFLAGS += -DCOCOS2D_DEBUG=1

--- a/tools/simulator/frameworks/runtime-src/proj.android/jni/Android.mk
+++ b/tools/simulator/frameworks/runtime-src/proj.android/jni/Android.mk
@@ -6,9 +6,7 @@ LOCAL_MODULE := cocos2dlua_shared
 
 LOCAL_MODULE_FILENAME := libcocos2dlua
 
-ifeq ($(COCOS_SIMULATOR_BUILD),1)
 LOCAL_ARM_MODE := arm
-endif
 
 FILE_LIST := hellolua/main.cpp
 FILE_LIST += $(wildcard $(LOCAL_PATH)/../../Classes/*.cpp)

--- a/tools/simulator/libsimulator/proj.android/Android.mk
+++ b/tools/simulator/libsimulator/proj.android/Android.mk
@@ -5,6 +5,8 @@ LOCAL_MODULE := cocos2d_simulator_static
 
 LOCAL_MODULE_FILENAME := libsimulator
 
+LOCAL_ARM_MODE := arm
+
 LOCAL_SRC_FILES := \
 ../lib/protobuf-lite/google/protobuf/io/coded_stream.cc \
 ../lib/protobuf-lite/google/protobuf/stubs/common.cc \


### PR DESCRIPTION
- add `APP_ABI : armeabi` in Application.mk, because the default is `armeavi-v8a` in ndk r12b, and cocos2d-x doesn't support `armeabi-v8a`
- add `LOCAL_ARM_MODE := arm` in Android.mk to fix linking error `error: relocation overflow in R_ARM_THM_CALL`
- update 3d party library because `LOCAL_ARM_MODE := arm` is added in Android.mk that using source codes
