### PR TITLE
fix: Text::create() does not crash on mac/ios

### DIFF
--- a/cocos/platform/ios/CCDevice-ios.mm
+++ b/cocos/platform/ios/CCDevice-ios.mm
@@ -387,6 +387,8 @@ static bool _initWithString(const char * text, cocos2d::Device::TextAlign align,
         CC_BREAK_IF(! font);
         
         NSString * str          = [NSString stringWithUTF8String:text];
+        CC_BREAK_IF(!str);
+
         CGSize dimensions;
         dimensions.width     = info->width;
         dimensions.height    = info->height;

--- a/cocos/platform/mac/CCDevice-mac.mm
+++ b/cocos/platform/mac/CCDevice-mac.mm
@@ -232,6 +232,7 @@ static bool _initWithString(const char * text, Device::TextAlign align, const ch
     
     do {
         NSString * string  = [NSString stringWithUTF8String:text];
+        CC_BREAK_IF(!string);
         
         id font = _createSystemFont(fontName, size);
         CC_BREAK_IF(!font);

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UITextTest/UITextTest.cpp
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UITextTest/UITextTest.cpp
@@ -12,6 +12,7 @@ UITextTests::UITextTests()
     ADD_TEST_CASE(UITextTest_TTF);
     ADD_TEST_CASE(UITextTest_IgnoreConentSize);
     ADD_TEST_CASE(UITextTest_Clone);
+    ADD_TEST_CASE(Issue16073Test);
 }
 
 // UITextTest
@@ -288,6 +289,25 @@ bool UITextTest_Clone::init()
         cloneText->setPosition(Vec2(widgetSize.width / 2.0f + 80,
             widgetSize.height / 2.0f));
         _uiLayer->addChild(cloneText);
+
+        return true;
+    }
+    return false;
+}
+
+// Issue16073Test
+
+bool Issue16073Test::init()
+{
+    if (UIScene::init())
+    {
+        Size widgetSize = _widget->getContentSize();
+
+        Text* singleText = Text::create("mwhahaha\360", "Verdana", 40);
+
+        singleText->setPosition(Vec2(widgetSize.width / 2.0f - 80,
+                                     widgetSize.height / 2.0f));
+        _uiLayer->addChild(singleText);
 
         return true;
     }

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UITextTest/UITextTest.h
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UITextTest/UITextTest.h
@@ -79,4 +79,12 @@ public:
     virtual bool init() override;
 };
 
+class Issue16073Test : public UIScene
+{
+public:
+    CREATE_FUNC(Issue16073Test);
+
+    virtual bool init() override;
+};
+
 #endif /* defined(__TestCpp__UITextTest__) */


### PR DESCRIPTION
...on invalid unicode.

fixes issue #16073
