### PR TITLE
Use std::abs to avoid overhead of casting float to double

### DIFF
--- a/cocos/2d/CCActionInterval.cpp
+++ b/cocos/2d/CCActionInterval.cpp
@@ -508,7 +508,7 @@ void Repeat::update(float dt)
         }
 
         // fix for issue #1288, incorrect end value of repeat
-        if(fabs(dt - 1.0f) < FLT_EPSILON && _total < _times)
+        if (std::abs(dt - 1.0f) < FLT_EPSILON && _total < _times)
         {
             if (!(sendUpdateEventToScript(1.0f, _innerAction)))
                 _innerAction->update(1.0f);

--- a/cocos/2d/CCFontFNT.cpp
+++ b/cocos/2d/CCFontFNT.cpp
@@ -24,6 +24,7 @@
  ****************************************************************************/
 
 #include "2d/CCFontFNT.h"
+#include <cmath>
 #include <set>
 #include "base/uthash.h"
 #include "2d/CCFontAtlas.h"
@@ -750,7 +751,7 @@ FontAtlas * FontFNT::createFontAtlas()
     int originalFontSize = _configuration->_fontSize;
     float originalLineHeight = _configuration->_commonHeight;
     float factor = 0.0f;
-    if (fabs(_fontSize - originalFontSize) < FLT_EPSILON) {
+    if (std::abs(_fontSize - originalFontSize) < FLT_EPSILON) {
         factor = 1.0f;
     }else {
         factor = _fontSize / originalFontSize;

--- a/cocos/2d/CCLabel.cpp
+++ b/cocos/2d/CCLabel.cpp
@@ -620,7 +620,7 @@ bool Label::setBMFontFilePath(const std::string& bmfontFilePath, const Vec2& ima
     }
 
     //assign the default fontSize
-    if (fabs(fontSize) < FLT_EPSILON) {
+    if (std::abs(fontSize) < FLT_EPSILON) {
         FontFNT *bmFont = (FontFNT*)newAtlas->getFont();
         if (bmFont) {
             float originalFontSize = bmFont->getOriginalFontSize();
@@ -1002,7 +1002,7 @@ void Label::scaleFontSizeDown(float fontSize)
         ttfConfig.fontSize = fontSize;
         this->setTTFConfigInternal(ttfConfig);
     }else if(_currentLabelType == LabelType::BMFONT){
-        if (fabs(fontSize) < FLT_EPSILON) {
+        if (std::abs(fontSize) < FLT_EPSILON) {
             fontSize = 0.1f;
             shouldUpdateContent = false;
         }
@@ -2162,7 +2162,7 @@ void Label::updateLetterSpriteScale(Sprite* sprite)
     }
     else
     {
-        if(fabs(_bmFontSize)<FLT_EPSILON)
+        if (std::abs(_bmFontSize) < FLT_EPSILON)
         {
             sprite->setScale(0);
         }

--- a/cocos/3d/CCAnimationCurve.h
+++ b/cocos/3d/CCAnimationCurve.h
@@ -24,6 +24,7 @@
 #ifndef __CCANIMATIONCURVE_H__
 #define __CCANIMATIONCURVE_H__
 
+#include <cmath>
 #include <functional>
 
 #include "platform/CCPlatformMacros.h"

--- a/cocos/3d/CCAnimationCurve.inl
+++ b/cocos/3d/CCAnimationCurve.inl
@@ -33,7 +33,7 @@ void AnimationCurve<componentSize>::evaluate(float time, float* dst, EvaluateTyp
         break;
         case EvaluateType::INT_NEAR:
         {
-            float* src = fabs(t) > 0.5f ? toValue : fromValue;
+            float* src = std::abs(t) > 0.5f ? toValue : fromValue;
             memcpy(dst, src, _componentSizeByte);
         }
         break;

--- a/cocos/base/CCValue.cpp
+++ b/cocos/base/CCValue.cpp
@@ -23,6 +23,7 @@
 ****************************************************************************/
 
 #include "base/CCValue.h"
+#include <cmath>
 #include <sstream>
 #include <iomanip>
 #include "base/ccUtils.h"
@@ -385,8 +386,8 @@ bool Value::operator== (const Value& v) const
         case Type::UNSIGNED:return v._field.unsignedVal == this->_field.unsignedVal;
         case Type::BOOLEAN: return v._field.boolVal     == this->_field.boolVal;
         case Type::STRING:  return *v._field.strVal     == *this->_field.strVal;
-        case Type::FLOAT:   return fabs(v._field.floatVal  - this->_field.floatVal)  <= FLT_EPSILON;
-        case Type::DOUBLE:  return fabs(v._field.doubleVal - this->_field.doubleVal) <= FLT_EPSILON;
+        case Type::FLOAT:   return std::abs(v._field.floatVal  - this->_field.floatVal)  <= FLT_EPSILON;
+        case Type::DOUBLE:  return std::abs(v._field.doubleVal - this->_field.doubleVal) <= DBL_EPSILON;
         case Type::VECTOR:
         {
             const auto &v1 = *(this->_field.vectorVal);

--- a/cocos/navmesh/CCNavMeshAgent.cpp
+++ b/cocos/navmesh/CCNavMeshAgent.cpp
@@ -349,7 +349,7 @@ void NavMeshAgent::syncToNode()
         _owner->setPosition3D(pos);
         _state = agent->state;
         if (_needAutoOrientation){
-            if ( fabs(agent->vel[0]) > 0.3f || fabs(agent->vel[1]) > 0.3f || fabs(agent->vel[2]) > 0.3f)
+            if (std::abs(agent->vel[0]) > 0.3f || std::abs(agent->vel[1]) > 0.3f || std::abs(agent->vel[2]) > 0.3f)
             {
                 Vec3 axes(_rotRefAxes);
                 axes.normalize();

--- a/cocos/physics/CCPhysicsShape.cpp
+++ b/cocos/physics/CCPhysicsShape.cpp
@@ -26,6 +26,7 @@
 #if CC_USE_PHYSICS
 
 #include <climits>
+#include <cmath>
 #include <unordered_map>
 
 #include "chipmunk/chipmunk.h"
@@ -111,7 +112,7 @@ void PhysicsShape::setMaterial(const PhysicsMaterial& material)
 
 void PhysicsShape::setScale(float scaleX, float scaleY)
 {
-    if (fabs(_scaleX - scaleX) > FLT_EPSILON || fabs(_scaleY - scaleY) > FLT_EPSILON)
+    if (std::abs(_scaleX - scaleX) > FLT_EPSILON || std::abs(_scaleY - scaleY) > FLT_EPSILON)
     {
         if (_type == Type::CIRCLE && scaleX != scaleY)
         {

--- a/cocos/platform/desktop/CCGLViewImpl-desktop.cpp
+++ b/cocos/platform/desktop/CCGLViewImpl-desktop.cpp
@@ -25,6 +25,7 @@ THE SOFTWARE.
 
 #include "platform/desktop/CCGLViewImpl-desktop.h"
 
+#include <cmath>
 #include <unordered_map>
 
 #include "platform/CCApplication.h"
@@ -533,7 +534,7 @@ void GLViewImpl::setFrameZoomFactor(float zoomFactor)
 {
     CCASSERT(zoomFactor > 0.0f, "zoomFactor must be larger than 0");
 
-    if (fabs(_frameZoomFactor - zoomFactor) < FLT_EPSILON)
+    if (std::abs(_frameZoomFactor - zoomFactor) < FLT_EPSILON)
     {
         return;
     }
@@ -800,7 +801,7 @@ void GLViewImpl::onGLFWframebuffersize(GLFWwindow* window, int w, int h)
     float factorX = frameSizeW / w * _retinaFactor * _frameZoomFactor;
     float factorY = frameSizeH / h * _retinaFactor * _frameZoomFactor;
 
-    if (fabs(factorX - 0.5f) < FLT_EPSILON && fabs(factorY - 0.5f) < FLT_EPSILON )
+    if (std::abs(factorX - 0.5f) < FLT_EPSILON && std::abs(factorY - 0.5f) < FLT_EPSILON)
     {
         _isInRetinaMonitor = true;
         if (_isRetinaEnabled)
@@ -814,7 +815,7 @@ void GLViewImpl::onGLFWframebuffersize(GLFWwindow* window, int w, int h)
 
         glfwSetWindowSize(window, static_cast<int>(frameSizeW * 0.5f * _retinaFactor * _frameZoomFactor) , static_cast<int>(frameSizeH * 0.5f * _retinaFactor * _frameZoomFactor));
     }
-    else if(fabs(factorX - 2.0f) < FLT_EPSILON && fabs(factorY - 2.0f) < FLT_EPSILON)
+    else if (std::abs(factorX - 2.0f) < FLT_EPSILON && std::abs(factorY - 2.0f) < FLT_EPSILON)
     {
         _isInRetinaMonitor = false;
         _retinaFactor = 1;

--- a/cocos/ui/UIScrollView.cpp
+++ b/cocos/ui/UIScrollView.cpp
@@ -543,7 +543,7 @@ void ScrollView::processAutoScrolling(float deltaTime)
     
     // Calculate the new position
     Vec2 newPosition = _autoScrollStartPosition + (_autoScrollTargetDelta * percentage);
-    bool reachedEnd = fabs(percentage - 1) <= this->getAutoScrollStopEpsilon();
+    bool reachedEnd = std::abs(percentage - 1) <= this->getAutoScrollStopEpsilon();
     
     if (reachedEnd)
     {
@@ -1010,10 +1010,10 @@ void ScrollView::interceptTouchEvent(Widget::TouchEventType event, Widget *sende
             switch (_direction)
             {
                 case Direction::HORIZONTAL:
-                    offsetInInch = convertDistanceFromPointToInch(Vec2(fabs(sender->getTouchBeganPosition().x - touchPoint.x), 0));
+                    offsetInInch = convertDistanceFromPointToInch(Vec2(std::abs(sender->getTouchBeganPosition().x - touchPoint.x), 0));
                     break;
                 case Direction::VERTICAL:
-                    offsetInInch = convertDistanceFromPointToInch(Vec2(0, fabs(sender->getTouchBeganPosition().y - touchPoint.y)));
+                    offsetInInch = convertDistanceFromPointToInch(Vec2(0, std::abs(sender->getTouchBeganPosition().y - touchPoint.y)));
                     break;
                 case Direction::BOTH:
                     offsetInInch = convertDistanceFromPointToInch(sender->getTouchBeganPosition() - touchPoint);

--- a/cocos/ui/UIScrollViewBar.cpp
+++ b/cocos/ui/UIScrollViewBar.cpp
@@ -285,7 +285,7 @@ Vec2 ScrollViewBar::calculatePosition(float innerContainerMeasure, float scrollV
     float denominatorValue = innerContainerMeasure - scrollViewMeasure;
     if(outOfBoundaryValue != 0)
     {
-        denominatorValue += fabs(outOfBoundaryValue);
+        denominatorValue += std::abs(outOfBoundaryValue);
     }
     
     float positionRatio = 0;


### PR DESCRIPTION
Hello, I'm getting the following warnings when trying to compile libcocos2d with `-Wdouble-promotion` and Xcode 7.3.1/Clang:

```
cocos/2d/CCActionInterval.cpp:511:20: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
cocos/2d/CCActionInterval.cpp:511:30: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
cocos/2d/CCLabel.cpp:623:14: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
cocos/2d/CCLabel.cpp:623:26: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
cocos/2d/CCLabel.cpp:1005:18: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
cocos/2d/CCLabel.cpp:1005:30: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
cocos/2d/CCLabel.cpp:2165:17: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
cocos/2d/CCLabel.cpp:2165:30: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
cocos/3d/CCAnimationCurve.inl:36:31: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
cocos/3d/CCAnimationCurve.inl:36:36: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
cocos/base/CCValue.cpp:388:60: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
cocos/base/CCValue.cpp:388:89: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
cocos/navmesh/CCNavMeshAgent.cpp:352:23: warning: implicit conversion increases floating-point precision: 'const float' to 'double' [-Wdouble-promotion]
cocos/navmesh/CCNavMeshAgent.cpp:352:40: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
cocos/navmesh/CCNavMeshAgent.cpp:352:40: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
cocos/navmesh/CCNavMeshAgent.cpp:352:70: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
cocos/navmesh/CCNavMeshAgent.cpp:352:83: warning: implicit conversion increases floating-point precision: 'const float' to 'double' [-Wdouble-promotion]
cocos/navmesh/CCNavMeshAgent.cpp:352:100: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
cocos/physics/CCPhysicsShape.cpp:114:22: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
cocos/physics/CCPhysicsShape.cpp:114:34: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
cocos/physics/CCPhysicsShape.cpp:114:62: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
cocos/physics/CCPhysicsShape.cpp:114:74: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
cocos/platform/desktop/CCGLViewImpl-desktop.cpp:536:31: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
cocos/platform/desktop/CCGLViewImpl-desktop.cpp:536:47: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
cocos/platform/desktop/CCGLViewImpl-desktop.cpp:803:22: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
cocos/platform/desktop/CCGLViewImpl-desktop.cpp:803:32: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
cocos/platform/desktop/CCGLViewImpl-desktop.cpp:817:26: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
cocos/platform/desktop/CCGLViewImpl-desktop.cpp:817:36: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
cocos/ui/UIScrollView.cpp:546:39: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
cocos/ui/UIScrollView.cpp:546:47: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
cocos/ui/UIScrollView.cpp:1013:111: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
cocos/ui/UIScrollView.cpp:1016:114: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
cocos/ui/UIScrollViewBar.cpp:288:34: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
```

This pull request fixes them to avoid unnecessary overhead of casting float to double, for the same reason as #16055. Thanks.
