### PR TITLE
fix leak in Data on move assignment

### DIFF
--- a/cocos/base/CCData.cpp
+++ b/cocos/base/CCData.cpp
@@ -75,6 +75,8 @@ Data& Data::operator= (Data&& other)
 
 void Data::move(Data& other)
 {
+    clear();
+    
     _bytes = other._bytes;
     _size = other._size;
     


### PR DESCRIPTION
add a call to `clear()` in `void Data::move(Data& other)`

`Data& Data::operator= (Data&& other)` calls `move` internally without calling `clear()`. This results in memory leaks in code such as the following:

``` cpp
Data d = getSomeData();
// do work
d = getSomeMoreData();
```

The call to `clear()` could have been made in the move assignment operator, but it felt better to put the call inside of `move` for consistency with `copy`.
