### PR TITLE
Fix a bug, in lua can't get the "backClicked" but a nil

### DIFF
--- a/cocos/scripting/lua-bindings/manual/CCLuaEngine.cpp
+++ b/cocos/scripting/lua-bindings/manual/CCLuaEngine.cpp
@@ -395,7 +395,7 @@ int LuaEngine::handleKeypadEvent(void* data)
 
     switch(action)
     {
-        case EventKeyboard::KeyCode::KEY_BACKSPACE:
+        case EventKeyboard::KeyCode::KEY_ESCAPE:
 			_stack->pushString("backClicked");
 			break;
 		case EventKeyboard::KeyCode::KEY_MENU:


### PR DESCRIPTION
in lua, I registerScriptKeypadHandler,when debug on Andriod, after clicking back button, I didn't get "backClicked",but a nil 
I see that in CHANGELOG:
cocos2d-x-3.1  May.24 2014
    [FIX]           EventKeyboard::KeyCode: key code for back button changed from KEY_BACKSPACE to KEY_ESCAPE
so,I fix it , and get the right "backClicked"
