### PR TITLE
Bump simulator version number to 3.12

### DIFF
--- a/tools/simulator/frameworks/runtime-src/proj.ios_mac/mac/Info.plist
+++ b/tools/simulator/frameworks/runtime-src/proj.ios_mac/mac/Info.plist
@@ -41,7 +41,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.11</string>
+	<string>3.12</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/tools/simulator/frameworks/runtime-src/proj.win32/game.rc
+++ b/tools/simulator/frameworks/runtime-src/proj.win32/game.rc
@@ -64,7 +64,7 @@ STYLE DS_SETFONT | DS_MODALFRAME | DS_FIXEDSYS | WS_POPUP | WS_CAPTION | WS_SYSM
 CAPTION "About Simulator"
 FONT 8, "MS Shell Dlg", 400, 0, 0x1
 BEGIN
-    CTEXT           "Version 3.11 (20160330)",IDC_ABOUT_VERSION,35,70,173,17
+    CTEXT           "Version 3.12 (20160706)",IDC_ABOUT_VERSION,35,70,173,17
     CTEXT           "Cocos Simulator",IDC_ABOUT_TITLE,35,49,173,17
     CTEXT           "Copyright (C) 2015. All rights reserved.",IDC_STATIC,35,94,173,17
     ICON            "GLFW_ICON",IDC_STATIC,111,15,20,20


### PR DESCRIPTION
Simulator version number does not seem to be updated in v3.12. This patch bumps the current version to 3.12 (July 6, 2016). Thanks.
