### PR TITLE
fix buffer over-read in CCGLProgram.cpp in memcmp call (Address Sanitizer...

### DIFF
--- a/cocos/renderer/CCGLProgram.cpp
+++ b/cocos/renderer/CCGLProgram.cpp
@@ -640,17 +640,17 @@ bool GLProgram::updateUniformLocation(GLint location, const GLvoid* data, unsign
     }
     else
     {
-        if (memcmp(element->second.first, data, bytes) == 0)
+        if (element->second.second < bytes)
         {
-            updated = false;
+            GLvoid* value = realloc(element->second.first, bytes);
+            memcpy(value, data, bytes);
+            _hashForUniforms[location] = std::make_pair(value, bytes);
         }
         else
         {
-            if (element->second.second < bytes)
+            if (memcmp(element->second.first, data, bytes) == 0)
             {
-                GLvoid* value = realloc(element->second.first, bytes);
-                memcpy(value, data, bytes );
-                _hashForUniforms[location] = std::make_pair(value, bytes);
+                updated = false;
             }
             else
                 memcpy(element->second.first, data, bytes);


### PR DESCRIPTION
… spots it easily)
- previously the flow went `memcmp`, if that `!= 0`, do a bounds check, etc
- now do a bounds check, if `destSize >= srcSize`, do `memcmp`, etc

This bug manifests when you use any of the `setUniform*v` methods, with a buffer of size `x`, then on a subsequent frame, data of a larger size, `y`.

The fix was swapping the locations of two if clauses, nothing else was changed.
