### PR TITLE
fix crash in EaseExponentialOut::clone()

### DIFF
--- a/cocos/2d/CCActionEase.cpp
+++ b/cocos/2d/CCActionEase.cpp
@@ -293,7 +293,7 @@ EaseExponentialOut* EaseExponentialOut::clone() const
 {
     // no copy constructor
     if (_inner)
-        EaseExponentialOut::create(_inner->clone());
+        return EaseExponentialOut::create(_inner->clone());
     
     return nullptr;
 }


### PR DESCRIPTION
This is just an obvious bug fix. It always returns nullptr.
