### PR TITLE
Additional checks in findChild

### DIFF
--- a/cocos/base/ccUtils.cpp
+++ b/cocos/base/ccUtils.cpp
@@ -370,7 +370,10 @@ Node* findChild(Node* levelRoot, const char* name)
 {
     if (levelRoot == nullptr)
         return nullptr;
-
+        
+    if ( !name || strcmp(name,"") )
+        return nullptr;
+        
     // Find this node
     {
         auto target = levelRoot->getChildByName(name);
@@ -393,6 +396,9 @@ Node* findChild(Node* levelRoot, int tag)
     if (levelRoot == nullptr)
         return nullptr;
 
+	if (tag == Node::INVALID_TAG)
+		return nullptr;
+		
     // Find this node
     {
         auto target = levelRoot->getChildByTag(tag);

--- a/cocos/base/ccUtils.cpp
+++ b/cocos/base/ccUtils.cpp
@@ -371,7 +371,7 @@ Node* findChild(Node* levelRoot, const char* name)
     if (levelRoot == nullptr)
         return nullptr;
         
-    if ( !name || strcmp(name,"") )
+    if ( !name || !strcmp(name,"") )
         return nullptr;
         
     // Find this node
@@ -396,9 +396,9 @@ Node* findChild(Node* levelRoot, int tag)
     if (levelRoot == nullptr)
         return nullptr;
 
-	if (tag == Node::INVALID_TAG)
-		return nullptr;
-		
+    if (tag == Node::INVALID_TAG)
+    return nullptr;
+	
     // Find this node
     {
         auto target = levelRoot->getChildByTag(tag);


### PR DESCRIPTION
Checks must help to avoid nullptr dereference or finding node witch tag or name was not initialized.
