### PR TITLE
Fix: not cransh on android when mapBuffer() is not present

### DIFF
--- a/cocos/base/CCConfiguration.cpp
+++ b/cocos/base/CCConfiguration.cpp
@@ -51,6 +51,7 @@ Configuration::Configuration()
 , _supportsShareableVAO(false)
 , _supportsOESDepth24(false)
 , _supportsOESPackedDepthStencil(false)
+, _supportsOESMapBuffer(false)
 , _maxSamplesAllowed(0)
 , _maxTextureUnits(0)
 , _glExtensions(nullptr)
@@ -150,8 +151,11 @@ void Configuration::gatherGPUInfo()
 	_valueDict["gl.supports_discard_framebuffer"] = Value(_supportsDiscardFramebuffer);
 
     _supportsShareableVAO = checkForGLExtension("vertex_array_object");
-	_valueDict["gl.supports_vertex_array_object"] = Value(_supportsShareableVAO);
-    
+    _valueDict["gl.supports_vertex_array_object"] = Value(_supportsShareableVAO);
+
+    _supportsOESMapBuffer = checkForGLExtension("GL_OES_mapbuffer");
+    _valueDict["gl.supports_OES_map_buffer"] = Value(_supportsOESMapBuffer);
+
     _supportsOESDepth24 = checkForGLExtension("GL_OES_depth24");
     _valueDict["gl.supports_OES_depth24"] = Value(_supportsOESDepth24);
 
@@ -269,6 +273,22 @@ bool Configuration::supportsShareableVAO() const
 #endif
 }
 
+bool Configuration::supportsMapBuffer() const
+{
+    // Fixes Github issue #16123
+    //
+    // XXX: Fixme. Should check GL ES and not iOS or Android
+    // For example, linux could be compiled with GL ES. Or perhaps in the future Android will
+    // support OpenGL. This is because glMapBufferOES() is an extension of OpenGL ES. And glMapBuffer()
+    // is always implemented in OpenGL.
+
+    // XXX: Warning. On iOS this is always `true`. Avoiding the comparison.
+#if (CC_TARGET_PLATFORM == CC_PLATFORM_ANDROID)
+    return _supportsOESMapBuffer;
+#else
+    return true;
+#endif
+}
 
 bool Configuration::supportsOESDepth24() const
 {

--- a/cocos/base/CCConfiguration.h
+++ b/cocos/base/CCConfiguration.h
@@ -160,7 +160,16 @@ public:
      */
     bool supportsOESPackedDepthStencil() const;
 
-    
+    /** Whether or not glMapBuffer() is supported.
+     *
+     * On Desktop it returns `true`.
+     * On Mobile it checks for the extension `GL_OES_mapbuffer`
+     *
+     * @return Whether or not `glMapBuffer()` is supported.
+     * @since v3.13
+     */
+    bool supportsMapBuffer() const;
+
     
     /** Max support directional light in shader, for Sprite3D.
      *
@@ -248,6 +257,7 @@ protected:
     bool            _supportsBGRA8888;
     bool            _supportsDiscardFramebuffer;
     bool            _supportsShareableVAO;
+    bool            _supportsOESMapBuffer;
     bool            _supportsOESDepth24;
     bool            _supportsOESPackedDepthStencil;
     

--- a/cocos/renderer/CCRenderer.cpp
+++ b/cocos/renderer/CCRenderer.cpp
@@ -784,7 +784,8 @@ void Renderer::drawBatchedTriangles()
     batchesTotal++;
 
     /************** 2: Copy vertices/indices to GL objects *************/
-    if (Configuration::getInstance()->supportsShareableVAO())
+    auto conf = Configuration::getInstance();
+    if (conf->supportsShareableVAO() && conf->supportsMapBuffer())
     {
         //Bind VAO
         GL::bindVAO(_buffersVAO);

--- a/cocos/renderer/CCTextureAtlas.cpp
+++ b/cocos/renderer/CCTextureAtlas.cpp
@@ -606,7 +606,8 @@ void TextureAtlas::drawNumberOfQuads(ssize_t numberOfQuads, ssize_t start)
     
     GL::bindTexture2D(_texture->getName());
 
-    if (Configuration::getInstance()->supportsShareableVAO())
+    auto conf = Configuration::getInstance();
+    if (conf->supportsShareableVAO() && conf->supportsMapBuffer())
     {
         //
         // Using VBO and VAO


### PR DESCRIPTION
more info:
https://www.khronos.org/registry/gles/extensions/OES/OES_mapbuffer.txt

Issue #15805 
