### PR TITLE
Add missing fclose() to fix a possible bug caused by PR #16114

### DIFF
--- a/cocos/platform/CCFileUtils.cpp
+++ b/cocos/platform/CCFileUtils.cpp
@@ -647,6 +647,7 @@ FileUtils::Status FileUtils::getContents(const std::string& filename, ResizableB
 #endif
     struct stat statBuf;
     if (fstat(descriptor, &statBuf) == -1) {
+        fclose(fp);
         return Status::ReadFailed;
     }
     size_t size = statBuf.st_size;


### PR DESCRIPTION
This patch adds a missing `fclose()` to fix a possible bug that caused by PR #16114 .
I'm sorry, it's my mistake. :sweat: Thanks. 
