### PR TITLE
Fix typos in documentation comments

### DIFF
--- a/cocos/2d/CCMotionStreak.h
+++ b/cocos/2d/CCMotionStreak.h
@@ -51,10 +51,10 @@ public:
      * @param minSeg The minimum segments.
      * @param strokeWidth The width of stroke.
      * @param strokeColor The color of stroke.
-     * @param iamgePath The texture file name of stoke.
+     * @param imagePath The texture file name of stoke.
      * @return An autoreleased MotionStreak object.
      */
-    static MotionStreak* create(float timeToFade, float minSeg, float strokeWidth, const Color3B& strokeColor, const std::string& iamgePath);
+    static MotionStreak* create(float timeToFade, float minSeg, float strokeWidth, const Color3B& strokeColor, const std::string& imagePath);
     /** Creates and initializes a motion streak with fade in seconds, minimum segments, stroke's width, color, texture.
      * 
      * @param timeToFade The fade time, in seconds.

--- a/cocos/2d/CCNode.h
+++ b/cocos/2d/CCNode.h
@@ -150,8 +150,8 @@ public:
      If two nodes have the same LocalZOrder, then the node that was added first to the children's array will be in front of the other node in the array.
      
      Also, the Scene Graph is traversed using the "In-Order" tree traversal algorithm ( http://en.wikipedia.org/wiki/Tree_traversal#In-order )
-     And Nodes that have LocalZOder values < 0 are the "left" subtree
-     While Nodes with LocalZOder >=0 are the "right" subtree.
+     And Nodes that have LocalZOrder values < 0 are the "left" subtree
+     While Nodes with LocalZOrder >=0 are the "right" subtree.
      
      @see `setGlobalZOrder`
      @see `setVertexZ`
@@ -179,10 +179,10 @@ public:
     CC_DEPRECATED_ATTRIBUTE virtual int getZOrder() const { return getLocalZOrder(); }
 
     /**
-     Defines the oder in which the nodes are renderer.
+     Defines the order in which the nodes are renderer.
      Nodes that have a Global Z Order lower, are renderer first.
      
-     In case two or more nodes have the same Global Z Order, the oder is not guaranteed.
+     In case two or more nodes have the same Global Z Order, the order is not guaranteed.
      The only exception if the Nodes have a Global Z Order == 0. In that case, the Scene Graph order is used.
      
      By default, all nodes have a Global Z Order = 0. That means that by default, the Scene Graph order is used to render the nodes.

--- a/cocos/physics/CCPhysicsContact.h
+++ b/cocos/physics/CCPhysicsContact.h
@@ -206,7 +206,7 @@ public:
     
     /** Check the listener is available.
 
-     *@return Ture if there's one available callback function at least, false if there's no one.
+     * @return True if there's one available callback function at least, false if there's no one.
      */
     virtual bool checkAvailable() override;
     

--- a/cocos/ui/UIRichText.h
+++ b/cocos/ui/UIRichText.h
@@ -494,12 +494,12 @@ public:
     bool isAnchorTextDelEnabled();                      /*!< valid strikethrough of a-tag? */
     void setAnchorTextUnderline(bool enable);           /*!< enable the underline of a-tag */
     bool isAnchorTextUnderlineEnabled();                /*!< valid underline of a-tag? */
-    /** @breif enable the outline of a-tag */
+    /** @brief enable the outline of a-tag */
     void setAnchorTextOutline(bool enable, const Color3B& outlineColor = Color3B::WHITE, int outlineSize = -1);
     bool isAnchorTextOutlineEnabled();                  /*!< valid outline of a-tag? */
     Color3B getAnchorTextOutlineColor3B();              /*!< return the current text outline color of a-tag */
     int getAnchorTextOutlineSize();                     /*!< return the current text outline size of a-tag */
-    /** @breif enable the shadow of a-tag */
+    /** @brief enable the shadow of a-tag */
     void setAnchorTextShadow(bool enable, const Color3B& shadowColor = Color3B::BLACK, const Size& offset = Size(2.0, -2.0), int blurRadius = 0);
     bool isAnchorTextShadowEnabled();                   /*!< valid shadow of a-tag? */
     Color3B getAnchorTextShadowColor3B();               /*!< return the current text shadow color of a-tag */


### PR DESCRIPTION
This pull request fixes several minor typos I found while reading the documentation.
