### PR TITLE
Update the test case of hex map with axis is x.

### DIFF
--- a/tests/cpp-tests/Resources/TileMaps/hexa-axis-x.tmx
+++ b/tests/cpp-tests/Resources/TileMaps/hexa-axis-x.tmx
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.0" orientation="hexagonal" renderorder="right-down" width="3" height="3" tilewidth="80" tileheight="80" hexsidelength="40" staggeraxis="x" staggerindex="even" nextobjectid="1">
- <tileset firstgid="1" name="hexa-axis-x" tilewidth="80" tileheight="80" tilecount="2" columns="2">
+<map version="1.0" orientation="hexagonal" renderorder="right-down" width="13" height="4" tilewidth="80" tileheight="80" hexsidelength="40" staggeraxis="x" staggerindex="odd" nextobjectid="1">
+ <tileset firstgid="1" name="tiles-ground" tilewidth="80" tileheight="80" tilecount="2" columns="2">
   <image source="hexa-axis-x.png" width="160" height="80"/>
   <tile id="0">
    <properties>
@@ -15,11 +15,9 @@
    </properties>
   </tile>
  </tileset>
- <layer name="ground" width="3" height="3" opacity="0.2">
-  <data encoding="csv">
-1,2,1,
-2,2,1,
-1,1,2
-</data>
+ <layer name="ground" width="13" height="4" opacity="0.2">
+  <data encoding="base64" compression="zlib">
+   eJxjZGBgYIRiJjQaH2ZCU4+OCenHZRax6nHJAQAcSABB
+  </data>
  </layer>
 </map>


### PR DESCRIPTION
Related issue : https://github.com/cocos2d/cocos2d-x/pull/16105

@ricardoquesada 
Once there are more tiles in the hex map with axis is x. The effect is error again. 
Could you please check it once more? Thanks.

BTW, I think the existing test cases `32:TMX Hex Odd X` & `33:TMX Hex Even X` are not the common usage of hex map. Because the `png` file used by the `tmx` file is for **Axis is Y**:
![hexmini.png](https://github.com/cocos2d/cocos2d-x/blob/v3/tests/cpp-tests/Resources/TileMaps/hexmini.png?raw=true) 
