### PR TITLE
Fix misspelled enum: POLYGEN -> POLYGON

### DIFF
--- a/cocos/physics/CCPhysicsShape.cpp
+++ b/cocos/physics/CCPhysicsShape.cpp
@@ -551,7 +551,7 @@ bool PhysicsShapePolygon::init(const Vec2* points, int count, const PhysicsMater
 {
     do
     {
-        _type = Type::POLYGEN;
+        _type = Type::POLYGON;
         
         auto vecs = new (std::nothrow) cpVect[count];
         PhysicsHelper::points2cpvs(points, vecs, count);        //count = cpConvexHull((int)count, vecs, nullptr, nullptr, 0);
@@ -763,7 +763,7 @@ bool PhysicsShapeEdgePolygon::init(const Vec2* points, int count, const PhysicsM
     cpVect* vec = nullptr;
     do
     {
-        _type = Type::EDGEPOLYGEN;
+        _type = Type::EDGEPOLYGON;
         
         vec = new (std::nothrow) cpVect[count];
         PhysicsHelper::points2cpvs(points, vec, count);

--- a/cocos/physics/CCPhysicsShape.h
+++ b/cocos/physics/CCPhysicsShape.h
@@ -77,11 +77,17 @@ public:
         UNKNOWN,
         CIRCLE,
         BOX,
-        POLYGEN,
+        POLYGON,
         EDGESEGMENT,
         EDGEBOX,
-        EDGEPOLYGEN,
+        EDGEPOLYGON,
         EDGECHAIN,
+
+        /** @deprecated Use Type::POLYGON instead. */
+        POLYGEN = POLYGON,
+
+        /** @deprecated Use Type::EDGEPOLYGON instead. */
+        EDGEPOLYGEN = EDGEPOLYGON,
     };
     
 public:


### PR DESCRIPTION
I noticed that there are minor misspellings in the `PhysicsShape::Type` enum. `POLYGEN` should be `POLYGON`, `EDGEPOLYGEN` should be `EDGEPOLYGON`.

This pull request fixes them and also keeps backward compatibility of API.
Thanks.
