### PR TITLE
Fix spelling for `getPolygonCenter` function

### DIFF
--- a/cocos/physics/CCPhysicsShape.cpp
+++ b/cocos/physics/CCPhysicsShape.cpp
@@ -286,13 +286,18 @@ void PhysicsShape::recenterPoints(Vec2* points, int count, const Vec2& center)
     }
 }
 
-Vec2 PhysicsShape::getPolyonCenter(const Vec2* points, int count)
+Vec2 PhysicsShape::getPolygonCenter(const Vec2* points, int count)
 {
     cpVect* cpvs = new (std::nothrow) cpVect[count];
     cpVect center = cpCentroidForPoly(count, PhysicsHelper::points2cpvs(points, cpvs, count));
     delete[] cpvs;
     
     return PhysicsHelper::cpv2point(center);
+}
+
+Vec2 PhysicsShape::getPolyonCenter(const Vec2* points, int count)
+{
+    return getPolygonCenter(points, count);
 }
 
 void PhysicsShape::setBody(PhysicsBody *body)

--- a/cocos/physics/CCPhysicsShape.h
+++ b/cocos/physics/CCPhysicsShape.h
@@ -260,13 +260,16 @@ public:
     static void recenterPoints(Vec2* points, int count, const Vec2& center = Vec2::ZERO);
 
     /**
-     * Get center of the polyon points.
+     * Get center of the polygon points.
      *
      * @param points A Vec2 object pointer.
      * @param count An integer number.
      * @return A Vec2 object.
      */
-    static Vec2 getPolyonCenter(const Vec2* points, int count);
+    static Vec2 getPolygonCenter(const Vec2* points, int count);
+
+    /** @deprecated use getPolygonCenter() instead */
+    CC_DEPRECATED_ATTRIBUTE static Vec2 getPolyonCenter(const Vec2* points, int count);
     
     /**
      * Set a mask that defines which categories this physics body belongs to.

--- a/cocos/scripting/lua-bindings/manual/cocos2d/lua_cocos2dx_physics_manual.cpp
+++ b/cocos/scripting/lua-bindings/manual/cocos2d/lua_cocos2dx_physics_manual.cpp
@@ -738,7 +738,7 @@ tolua_lerror:
     return 0;
 }
 
-int lua_cocos2dx_physics_PhysicsShape_getPolyonCenter(lua_State* tolua_S)
+int lua_cocos2dx_physics_PhysicsShape_getPolygonCenter(lua_State* tolua_S)
 {
     int argc = 0;
     bool ok  = true;
@@ -758,7 +758,7 @@ int lua_cocos2dx_physics_PhysicsShape_getPolyonCenter(lua_State* tolua_S)
         cocos2d::Vec2* arg0;
         int arg1 = 0;
         do {
-            ok = luaval_to_array_of_vec2(tolua_S, 2, &arg0, &arg1, "cc.PhysicsShape:getPolyonCenter");
+            ok = luaval_to_array_of_vec2(tolua_S, 2, &arg0, &arg1, "cc.PhysicsShape:getPolygonCenter");
             if (nullptr == arg0){
                 LUA_PRECONDITION( arg0, "Invalid Native Object");
             }} while (0);
@@ -767,16 +767,16 @@ int lua_cocos2dx_physics_PhysicsShape_getPolyonCenter(lua_State* tolua_S)
             CC_SAFE_DELETE_ARRAY(arg0);
             return 0;
         }
-        cocos2d::Vec2 ret = cocos2d::PhysicsShape::getPolyonCenter(arg0, arg1);
+        cocos2d::Vec2 ret = cocos2d::PhysicsShape::getPolygonCenter(arg0, arg1);
         CC_SAFE_DELETE_ARRAY(arg0);
         vec2_to_luaval(tolua_S, ret);
         return 1;
     }
-    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d\n ", "getPolyonCenter",argc, 2);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d\n ", "getPolygonCenter",argc, 2);
     return 0;
 #if COCOS2D_DEBUG >= 1
 tolua_lerror:
-    tolua_error(tolua_S,"#ferror in function 'lua_cocos2dx_physics_PhysicsShape_getPolyonCenter'.",&tolua_err);
+    tolua_error(tolua_S,"#ferror in function 'lua_cocos2dx_physics_PhysicsShape_getPolygonCenter'.",&tolua_err);
 #endif
     return 0;
 }
@@ -1502,8 +1502,11 @@ int register_all_cocos2dx_physics_manual(lua_State* tolua_S)
         lua_pushstring(tolua_S,"recenterPoints");
         lua_pushcfunction(tolua_S,lua_cocos2dx_physics_PhysicsShape_recenterPoints );
         lua_rawset(tolua_S,-3);
+        lua_pushstring(tolua_S,"getPolygonCenter");
+        lua_pushcfunction(tolua_S,lua_cocos2dx_physics_PhysicsShape_getPolygonCenter );
+        lua_rawset(tolua_S,-3);
         lua_pushstring(tolua_S,"getPolyonCenter");
-        lua_pushcfunction(tolua_S,lua_cocos2dx_physics_PhysicsShape_getPolyonCenter );
+        lua_pushcfunction(tolua_S,lua_cocos2dx_physics_PhysicsShape_getPolygonCenter );
         lua_rawset(tolua_S,-3);
     }
     lua_pop(tolua_S, 1);

--- a/tests/cpp-tests/Classes/PhysicsTest/PhysicsTest.cpp
+++ b/tests/cpp-tests/Classes/PhysicsTest/PhysicsTest.cpp
@@ -962,7 +962,7 @@ void PhysicsDemoPump::onEnter()
     
     // pump
     auto pump = Node::create();
-    auto center = PhysicsShape::getPolyonCenter(vec, 4);
+    auto center = PhysicsShape::getPolygonCenter(vec, 4);
     pump->setPosition(center);
     auto pumpBody = PhysicsBody::createPolygon(vec, 4, PHYSICSBODY_MATERIAL_DEFAULT, -center);
     pump->addComponent(pumpBody);
@@ -1199,7 +1199,7 @@ void PhysicsDemoSlice::clipPoly(PhysicsShapePolygon* shape, Vec2 normal, float d
         }
     }
     
-    Vec2 center = PhysicsShape::getPolyonCenter(points, pointsCount);
+    Vec2 center = PhysicsShape::getPolygonCenter(points, pointsCount);
     Node* node = Node::create();
     PhysicsBody* polyon = PhysicsBody::createPolygon(points, pointsCount, PHYSICSBODY_MATERIAL_DEFAULT, -center);
     node->setPosition(center);

--- a/tests/lua-tests/src/PhysicsTest/PhysicsTest.lua
+++ b/tests/lua-tests/src/PhysicsTest/PhysicsTest.lua
@@ -957,7 +957,7 @@ local function PhysicsDemoPump()
     
     -- pump
     local pump = cc.Node:create()
-    local center = cc.PhysicsShape:getPolyonCenter(vec)
+    local center = cc.PhysicsShape:getPolygonCenter(vec)
     pump:setPosition(center)
     local pumpB = cc.PhysicsBody:createPolygon(vec, 
                                                cc.PHYSICSBODY_MATERIAL_DEFAULT, 
@@ -1034,7 +1034,7 @@ local function PhysicsDemoSlice()
           j = i
         end
     
-        local center = cc.PhysicsShape:getPolyonCenter(points)
+        local center = cc.PhysicsShape:getPolygonCenter(points)
         local node = cc.Node:create()
         local polyon = cc.PhysicsBody:createPolygon(points, 
                                                     cc.PHYSICSBODY_MATERIAL_DEFAULT, 

--- a/tools/tolua/cocos2dx_physics.ini
+++ b/tools/tolua/cocos2dx_physics.ini
@@ -39,7 +39,7 @@ classes = Event(.*(Physics).*) Physics.*
 # functions from all classes.
 
 skip = PhysicsBody::[getJoints createPolygon createEdgeChain createEdgePolygon],
-       PhysicsShape::[recenterPoints getPolyonCenter],
+       PhysicsShape::[recenterPoints getPolygonCenter getPolyonCenter],
        PhysicsShapeBox::[^getPoints$],
        PhysicsShapeEdgeBox::[^getPoints$],
        PhysicsShapePolygon::[create calculateArea calculateMoment ^getPoints$],


### PR DESCRIPTION
This PR deprecates the misspelled `getPolyonCenter` function in favour of correctly spelled `getPolygonCenter` in PhysicsShape class. It does the following:
- Replaces the `getPolyonCenter` declaration and definition with `getPolygonCenter`
- Adds deprecated `getPolyonCenter` function to keep backward compatibility
- Lua binding is also the same as C++ code

Thanks.
