### PR TITLE
[BugFix]apply contentScale calculating label letter width

### DIFF
--- a/cocos/2d/CCLabelTextFormatter.cpp
+++ b/cocos/2d/CCLabelTextFormatter.cpp
@@ -218,7 +218,7 @@ bool Label::multilineTextWrap(std::function<int(const std::u16string&, int, int)
                     nextLetterX += _horizontalKernings[letterIndex + 1];
                 nextLetterX += letterDef.xAdvance * _bmfontScale + _additionalKerning;
 
-                tokenRight = letterPosition.x + letterDef.width * _bmfontScale;
+                tokenRight = letterPosition.x + letterDef.width * _bmfontScale / contentScaleFactor;
             }
             nextChangeSize = true;
 


### PR DESCRIPTION
Currently the label text formater has a bug when calculating letter width of bitmap fonts, which causes the multi-line text wrapping to look weird.

Say if we have a label created by the following code:

``` cpp
  auto label = Label::createWithBMFont(bitmapFontFile, "");
  label->setAlignment(cocos2d::TextHAlignment::RIGHT);
  label->setColor(cocos2d::Color3B::WHITE);
  label->setString("000000\n111111\n010101");
  addChild(label);
```

The actually label looks like this
![screen shot 2016-07-19 at 11 09 52 pm](https://cloud.githubusercontent.com/assets/2549967/16953336/9ad0933c-4e07-11e6-941e-4cd5201a060a.png)

After applying this fix, it looks like this
![screen shot 2016-07-19 at 11 08 58 pm](https://cloud.githubusercontent.com/assets/2549967/16953356/ab3f92a4-4e07-11e6-9a31-c43aa631ac92.png)

If we take a look at how `letterPosition.x` is calculated, we will see that it is devided by `contentScaleFactor`, but the line involved does not apply `contentScaleFactor` to `letterDef.width` causing `tokenRight` to be miscalculated.
