### PR TITLE
New PR based on @Jaxz PR - Rewrote all action ease classes using templates

### DIFF
--- a/cocos/2d/CCActionEase.cpp
+++ b/cocos/2d/CCActionEase.cpp
@@ -103,6 +103,7 @@ ActionInterval* ActionEase::getInnerAction()
 // EaseRateAction
 //
 
+/*
 EaseRateAction* EaseRateAction::create(ActionInterval* action, float rate)
 {
     EaseRateAction *easeRateAction = new (std::nothrow) EaseRateAction();
@@ -115,6 +116,7 @@ EaseRateAction* EaseRateAction::create(ActionInterval* action, float rate)
     delete easeRateAction;
     return nullptr;
 }
+*/
 
 bool EaseRateAction::initWithAction(ActionInterval *action, float rate)
 {
@@ -132,324 +134,58 @@ EaseRateAction::~EaseRateAction()
 }
 
 //
-// EeseIn
+// EaseTemplate
 //
 
-EaseIn* EaseIn::create(ActionInterval *action, float rate)
+template<float(*F)(float), float(*I)(float)>
+EaseTemplate<F,I>* EaseTemplate<F,I>::create(cocos2d::ActionInterval *action)
 {
-    EaseIn *easeIn = new (std::nothrow) EaseIn();
-    if (easeIn && easeIn->initWithAction(action, rate))
-    {
-        easeIn->autorelease();
-        return easeIn;
-    }
-
-    delete easeIn;
-    return nullptr;
+  EaseTemplate<F,I> *ease = new (std::nothrow) EaseTemplate<F,I>();
+  if (ease)
+  {
+    if (ease->initWithAction(action))
+      ease->autorelease();
+    else
+      CC_SAFE_RELEASE_NULL(ease);
+  }
+  return ease;
 }
 
-EaseIn* EaseIn::clone() const
+template<float(*F)(float), float(*I)(float)>
+ActionEase* EaseTemplate<F,I>::clone() const
 {
-    // no copy constructor
-    if (_inner)
-        return EaseIn::create(_inner->clone(), _rate);
-    
-    return nullptr;
-}
-
-void EaseIn::update(float time)
-{
-    _inner->update(tweenfunc::easeIn(time, _rate));
-}
-
-EaseIn* EaseIn::reverse() const
-{
-    return EaseIn::create(_inner->reverse(), 1 / _rate);
+  auto a = new (std::nothrow) EaseTemplate<F,I>();
+  a->initWithAction(_inner->clone());
+  a->autorelease();
+  return a;
 }
 
 //
-// EaseOut
-//
-EaseOut* EaseOut::create(ActionInterval *action, float rate)
-{
-    EaseOut *easeOut = new (std::nothrow) EaseOut();
-    if (easeOut && easeOut->initWithAction(action, rate))
-    {
-        easeOut->autorelease();
-        return easeOut;
-    }
-
-    delete easeOut;
-    return nullptr;
-}
-
-EaseOut* EaseOut::clone() const
-{
-    // no copy constructor
-    if (_inner)
-        return EaseOut::create(_inner->clone(), _rate);
-    
-    return nullptr;
-}
-
-void EaseOut::update(float time)
-{
-    _inner->update(tweenfunc::easeOut(time, _rate));
-}
-
-EaseOut* EaseOut::reverse() const
-{
-    return EaseOut::create(_inner->reverse(), 1 / _rate);
-}
-
-//
-// EaseInOut
-//
-EaseInOut* EaseInOut::create(ActionInterval *action, float rate)
-{
-    EaseInOut *easeInOut = new (std::nothrow) EaseInOut();
-    if (easeInOut && easeInOut->initWithAction(action, rate))
-    {
-        easeInOut->autorelease();
-        return easeInOut;
-    }
-
-    delete easeInOut;
-    return nullptr;
-}
-
-EaseInOut* EaseInOut::clone() const
-{
-    // no copy constructor
-    if (_inner)
-        return EaseInOut::create(_inner->clone(), _rate);
-    
-    return nullptr;
-}
-
-void EaseInOut::update(float time)
-{
-    _inner->update(tweenfunc::easeInOut(time, _rate));
-}
-
-// InOut and OutIn are symmetrical
-EaseInOut* EaseInOut::reverse() const
-{
-    return EaseInOut::create(_inner->reverse(), _rate);
-}
-
-//
-// EaseExponentialIn
-//
-EaseExponentialIn* EaseExponentialIn::create(ActionInterval* action)
-{
-    EaseExponentialIn *ret = new (std::nothrow) EaseExponentialIn();
-    if (ret && ret->initWithAction(action))
-    {
-        ret->autorelease();
-        return ret;
-    }
-
-    delete ret;
-    return nullptr;
-}
-
-EaseExponentialIn* EaseExponentialIn::clone() const
-{
-    // no copy constructor
-    if (_inner)
-        return EaseExponentialIn::create(_inner->clone());
-    
-    return nullptr;
-}
-
-void EaseExponentialIn::update(float time)
-{
-    _inner->update(tweenfunc::expoEaseIn(time));
-}
-
-ActionEase * EaseExponentialIn::reverse() const
-{
-    return EaseExponentialOut::create(_inner->reverse());
-}
-
-//
-// EaseExponentialOut
-//
-EaseExponentialOut* EaseExponentialOut::create(ActionInterval* action)
-{
-    EaseExponentialOut *ret = new (std::nothrow) EaseExponentialOut();
-    if (ret && ret->initWithAction(action))
-    {
-        ret->autorelease();
-        return ret;
-    }
-
-    delete ret;
-    return nullptr;
-}
-
-EaseExponentialOut* EaseExponentialOut::clone() const
-{
-    // no copy constructor
-    if (_inner)
-        return EaseExponentialOut::create(_inner->clone());
-    
-    return nullptr;
-}
-
-void EaseExponentialOut::update(float time)
-{
-    _inner->update(tweenfunc::expoEaseOut(time));
-}
-
-ActionEase* EaseExponentialOut::reverse() const
-{
-    return EaseExponentialIn::create(_inner->reverse());
-}
-
-//
-// EaseExponentialInOut
+// EaseRateTemplate<F,I>
 //
 
-EaseExponentialInOut* EaseExponentialInOut::create(ActionInterval *action)
+template<float(*F)(float,float), float(*I)(float,float)>
+EaseRateTemplate<F,I>* EaseRateTemplate<F,I>::create(ActionInterval* action, float rate)
 {
-    EaseExponentialInOut *ret = new (std::nothrow) EaseExponentialInOut();
-    if (ret && ret->initWithAction(action))
-    {
-        ret->autorelease();
-        return ret;
-    }
+  EaseRateTemplate<F,I> *ease = new (std::nothrow) EaseRateTemplate<F,I>();
+  if (action)
+  {
+    if (ease->initWithAction(action, rate))
+      ease->autorelease();
+    else
+      CC_SAFE_RELEASE_NULL(ease);
+  }
 
-    delete ret;
-    return nullptr;
+  return ease;
 }
 
-EaseExponentialInOut* EaseExponentialInOut::clone() const
+template<float(*F)(float,float), float(*I)(float,float)>
+EaseRateAction* EaseRateTemplate<F,I>::clone() const
 {
-    // no copy constructor
-    if (_inner)
-        return EaseExponentialInOut::create(_inner->clone());
-    
-    return nullptr;
-}
-
-void EaseExponentialInOut::update(float time)
-{
-    _inner->update(tweenfunc::expoEaseInOut(time));
-}
-
-EaseExponentialInOut* EaseExponentialInOut::reverse() const
-{
-    return EaseExponentialInOut::create(_inner->reverse());
-}
-
-//
-// EaseSineIn
-//
-
-EaseSineIn* EaseSineIn::create(ActionInterval* action)
-{
-    EaseSineIn *ret = new (std::nothrow) EaseSineIn();
-    if (ret && ret->initWithAction(action))
-    {
-        ret->autorelease();
-        return ret;
-    }
-
-    delete ret;
-    return nullptr;
-}
-
-EaseSineIn* EaseSineIn::clone() const
-{
-    // no copy constructor
-    if (_inner)
-        return EaseSineIn::create(_inner->clone());
-    
-    return nullptr;
-}
-
-void EaseSineIn::update(float time)
-{
-    _inner->update(tweenfunc::sineEaseIn(time));
-}
-
-ActionEase* EaseSineIn::reverse() const
-{
-    return EaseSineOut::create(_inner->reverse());
-}
-
-//
-// EaseSineOut
-//
-
-EaseSineOut* EaseSineOut::create(ActionInterval* action)
-{
-    EaseSineOut *ret = new (std::nothrow) EaseSineOut();
-    if (ret && ret->initWithAction(action))
-    {
-        ret->autorelease();
-        return ret;
-    }
-
-    delete ret;
-    return nullptr;
-}
-
-EaseSineOut* EaseSineOut::clone() const
-{
-    // no copy constructor
-    if (_inner)
-        return EaseSineOut::create(_inner->clone());
-    
-    return nullptr;
-}
-
-void EaseSineOut::update(float time)
-{
-    _inner->update(tweenfunc::sineEaseOut(time));
-}
-
-ActionEase* EaseSineOut::reverse(void) const
-{
-    return EaseSineIn::create(_inner->reverse());
-}
-
-//
-// EaseSineInOut
-//
-
-EaseSineInOut* EaseSineInOut::create(ActionInterval* action)
-{
-    EaseSineInOut *ret = new (std::nothrow) EaseSineInOut();
-    if (ret && ret->initWithAction(action))
-    {
-        ret->autorelease();
-        return ret;
-    }
-
-    delete ret;
-    return nullptr;
-}
-
-EaseSineInOut* EaseSineInOut::clone() const
-{
-    // no copy constructor
-    if (_inner)
-        return EaseSineInOut::create(_inner->clone());
-    
-    return nullptr;
-}
-
-void EaseSineInOut::update(float time)
-{
-    _inner->update(tweenfunc::sineEaseInOut(time));
-}
-
-EaseSineInOut* EaseSineInOut::reverse() const
-{
-    return EaseSineInOut::create(_inner->reverse());
+  auto a = new EaseRateTemplate<F,I>();
+  a->initWithAction(_inner->clone(), _rate);
+  a->autorelease();
+  return a;
 }
 
 //
@@ -468,935 +204,79 @@ bool EaseElastic::initWithAction(ActionInterval *action, float period/* = 0.3f*/
 }
 
 //
-// EaseElasticIn
+// EaseElastic Template
 //
 
-EaseElasticIn* EaseElasticIn::create(ActionInterval *action)
+template<float(*F)(float,float), float(*I)(float,float)>
+EaseElasticTemplate<F,I>* EaseElasticTemplate<F,I>::create(ActionInterval* action, float period)
 {
-    return EaseElasticIn::create(action, 0.3f);
+  EaseElasticTemplate<F,I> *ease = new (std::nothrow) EaseElasticTemplate<F,I>();
+  if (action)
+  {
+    if (ease->initWithAction(action, period))
+      ease->autorelease();
+    else
+      CC_SAFE_RELEASE_NULL(ease);
+  }
+
+  return ease;
 }
 
-EaseElasticIn* EaseElasticIn::create(ActionInterval *action, float period/* = 0.3f*/)
+template<float(*F)(float,float), float(*I)(float,float)>
+EaseElastic* EaseElasticTemplate<F,I>::clone() const
 {
-    EaseElasticIn *ret = new (std::nothrow) EaseElasticIn();
-    if (ret && ret->initWithAction(action, period))
-    {
-        ret->autorelease();
-        return ret;
-    }
-
-    delete ret;
-    return nullptr;
-}
-
-EaseElasticIn* EaseElasticIn::clone() const
-{
-    // no copy constructor
-    if (_inner)
-        return EaseElasticIn::create(_inner->clone(), _period);
-    
-    return nullptr;
-}
-
-void EaseElasticIn::update(float time)
-{
-    _inner->update(tweenfunc::elasticEaseIn(time, _period));
-}
-
-EaseElastic* EaseElasticIn::reverse() const
-{
-    return EaseElasticOut::create(_inner->reverse(), _period);
-}
-
-//
-// EaseElasticOut
-//
-
-EaseElasticOut* EaseElasticOut::create(ActionInterval *action)
-{
-    return EaseElasticOut::create(action, 0.3f);
-}
-
-EaseElasticOut* EaseElasticOut::create(ActionInterval *action, float period/* = 0.3f*/)
-{
-    EaseElasticOut *ret = new (std::nothrow) EaseElasticOut();
-    if (ret && ret->initWithAction(action, period))
-    {
-        ret->autorelease();
-        return ret;
-    }
-
-    delete ret;
-    return nullptr;
-}
-
-EaseElasticOut* EaseElasticOut::clone() const
-{
-    // no copy constructor
-    if (_inner)
-        return EaseElasticOut::create(_inner->clone(), _period);
-    
-    return nullptr;
-}
-
-void EaseElasticOut::update(float time)
-{
-    _inner->update(tweenfunc::elasticEaseOut(time, _period));
-}
-
-EaseElastic* EaseElasticOut::reverse() const
-{
-    return EaseElasticIn::create(_inner->reverse(), _period);
-}
-
-//
-// EaseElasticInOut
-//
-
-EaseElasticInOut* EaseElasticInOut::create(ActionInterval *action)
-{
-    return EaseElasticInOut::create(action, 0.3f);
-}
-
-EaseElasticInOut* EaseElasticInOut::create(ActionInterval *action, float period/* = 0.3f*/)
-{
-    EaseElasticInOut *ret = new (std::nothrow) EaseElasticInOut();
-    if (ret && ret->initWithAction(action, period))
-    {
-        ret->autorelease();
-        return ret;
-    }
-    
-    delete ret;
-    return nullptr;
-}
-
-EaseElasticInOut* EaseElasticInOut::clone() const
-{
-    // no copy constructor
-    if (_inner)
-        return EaseElasticInOut::create(_inner->clone(), _period);
-    
-    return nullptr;
-}
-
-void EaseElasticInOut::update(float time)
-{
-    _inner->update(tweenfunc::elasticEaseInOut(time, _period));
-}
-
-EaseElasticInOut* EaseElasticInOut::reverse() const
-{
-    return EaseElasticInOut::create(_inner->reverse(), _period);
-}
-
-//
-// EaseBounce
-//
-
-//
-// EaseBounceIn
-//
-
-EaseBounceIn* EaseBounceIn::create(ActionInterval* action)
-{
-    EaseBounceIn *ret = new (std::nothrow) EaseBounceIn();
-    if (ret && ret->initWithAction(action))
-    {
-        ret->autorelease();
-        return ret;
-    }
-
-    delete ret;
-    return nullptr;
-}
-
-EaseBounceIn* EaseBounceIn::clone() const
-{
-    // no copy constructor
-    if (_inner)
-        return EaseBounceIn::create(_inner->clone());
-    
-    return nullptr;
-}
-
-void EaseBounceIn::update(float time)
-{
-    _inner->update(tweenfunc::bounceEaseIn(time));
-}
-
-EaseBounce* EaseBounceIn::reverse() const
-{
-    return EaseBounceOut::create(_inner->reverse());
-}
-
-//
-// EaseBounceOut
-//
-
-EaseBounceOut* EaseBounceOut::create(ActionInterval* action)
-{
-    EaseBounceOut *ret = new (std::nothrow) EaseBounceOut();
-    if (ret && ret->initWithAction(action))
-    {
-        ret->autorelease();
-        return ret;
-    }
-
-    delete ret;
-    return nullptr;
-}
-
-EaseBounceOut* EaseBounceOut::clone() const
-{
-    // no copy constructor
-    if (_inner)
-        return EaseBounceOut::create(_inner->clone());
-    
-    return nullptr;
-}
-
-void EaseBounceOut::update(float time)
-{
-    _inner->update(tweenfunc::bounceEaseOut(time));
-}
-
-EaseBounce* EaseBounceOut::reverse() const
-{
-    return EaseBounceIn::create(_inner->reverse());
-}
-
-//
-// EaseBounceInOut
-//
-
-EaseBounceInOut* EaseBounceInOut::create(ActionInterval* action)
-{
-    EaseBounceInOut *ret = new (std::nothrow) EaseBounceInOut();
-    if (ret && ret->initWithAction(action))
-    {
-        ret->autorelease();
-        return ret;
-    }
-
-    delete ret;
-    return nullptr;
-}
-
-EaseBounceInOut* EaseBounceInOut::clone() const
-{
-    // no copy constructor
-    if (_inner)
-        return EaseBounceInOut::create(_inner->clone());
-    
-    return nullptr;
-}
-
-void EaseBounceInOut::update(float time)
-{
-    _inner->update(tweenfunc::bounceEaseInOut(time));
-}
-
-EaseBounceInOut* EaseBounceInOut::reverse() const
-{
-    return EaseBounceInOut::create(_inner->reverse());
-}
-
-//
-// EaseBackIn
-//
-
-EaseBackIn* EaseBackIn::create(ActionInterval *action)
-{
-    EaseBackIn *ret = new (std::nothrow) EaseBackIn();
-    if (ret && ret->initWithAction(action))
-    {
-        ret->autorelease();
-        return ret;
-    }
-
-    delete ret;
-    return nullptr;
-}
-
-EaseBackIn* EaseBackIn::clone() const
-{
-    if (_inner)
-        return EaseBackIn::create(_inner->clone());
-
-    return nullptr;
-}
-
-void EaseBackIn::update(float time)
-{
-    _inner->update(tweenfunc::backEaseIn(time));
-}
-
-ActionEase* EaseBackIn::reverse() const
-{
-    return EaseBackOut::create(_inner->reverse());
-}
-
-//
-// EaseBackOut
-//
-
-EaseBackOut* EaseBackOut::create(ActionInterval* action)
-{
-    EaseBackOut *ret = new (std::nothrow) EaseBackOut();
-    if (ret && ret->initWithAction(action))
-    {
-        ret->autorelease();
-        return ret;
-    }
-
-    delete ret;
-    return nullptr;
-}
-
-EaseBackOut* EaseBackOut::clone() const
-{
-    if (_inner)
-        return EaseBackOut::create(_inner->clone());
-
-    return nullptr;
-}
-
-void EaseBackOut::update(float time)
-{
-    _inner->update(tweenfunc::backEaseOut(time));
-}
-
-ActionEase* EaseBackOut::reverse() const
-{
-    return EaseBackIn::create(_inner->reverse());
-}
-
-//
-// EaseBackInOut
-//
-
-EaseBackInOut* EaseBackInOut::create(ActionInterval* action)
-{
-    EaseBackInOut *ret = new (std::nothrow) EaseBackInOut();
-    if (ret && ret->initWithAction(action))
-    {
-        ret->autorelease();
-        return ret;
-    }
-
-    delete ret;
-    return nullptr;
-}
-
-EaseBackInOut* EaseBackInOut::clone() const
-{
-    if (_inner)
-        return EaseBackInOut::create(_inner->clone());
-
-    return nullptr;
-}
-
-void EaseBackInOut::update(float time)
-{
-    _inner->update(tweenfunc::backEaseInOut(time));
-}
-
-EaseBackInOut* EaseBackInOut::reverse() const
-{
-    return EaseBackInOut::create(_inner->reverse());
+  auto a = new EaseElasticTemplate<F,I>();
+  a->initWithAction(_inner->clone(), _period);
+  a->autorelease();
+  return a;
 }
 
 EaseBezierAction* EaseBezierAction::create(cocos2d::ActionInterval* action)
 {
-    EaseBezierAction *ret = new (std::nothrow) EaseBezierAction();
-    if (ret && ret->initWithAction(action))
-    {
-        ret->autorelease();
-        return ret;
-    }
-    
-    delete ret;
-    return nullptr;
+	EaseBezierAction *ret = new EaseBezierAction();
+	if (ret)
+	{
+		if (ret->initWithAction(action))
+		{
+			ret->autorelease();
+		}
+		else
+		{
+			CC_SAFE_RELEASE_NULL(ret);
+		}
+	}
+
+	return ret; 
 }
 
 void EaseBezierAction::setBezierParamer( float p0, float p1, float p2, float p3)
 {
-    _p0 = p0;
-    _p1 = p1;
-    _p2 = p2;
-    _p3 = p3;
+	_p0 = p0;
+	_p1 = p1;
+	_p2 = p2;
+	_p3 = p3;
 }
 
 EaseBezierAction* EaseBezierAction::clone() const
 {
-    // no copy constructor
-    if (_inner)
-    {
-        auto ret = EaseBezierAction::create(_inner->clone());
-        if (ret)
-        {
-            ret->setBezierParamer(_p0,_p1,_p2,_p3);
-        }
-        return ret;
-    }
-    
-    return nullptr;
+	// no copy constructor
+	auto a = new EaseBezierAction();
+	a->initWithAction(_inner->clone());
+	a->setBezierParamer(_p0,_p1,_p2,_p3);
+	a->autorelease();
+	return a;
 }
 
 void EaseBezierAction::update(float time)
 {
-    _inner->update(tweenfunc::bezieratFunction(_p0,_p1,_p2,_p3,time));
+	_inner->update(tweenfunc::bezieratFunction(_p0,_p1,_p2,_p3,time));
 }
 
 EaseBezierAction* EaseBezierAction::reverse() const
 {
-    EaseBezierAction* reverseAction = EaseBezierAction::create(_inner->reverse());
-    reverseAction->setBezierParamer(_p3,_p2,_p1,_p0);
-    return reverseAction;
-}
-
-//
-// EaseQuadraticActionIn
-//
-
-EaseQuadraticActionIn* EaseQuadraticActionIn::create(ActionInterval* action)
-{
-    EaseQuadraticActionIn *ret = new (std::nothrow) EaseQuadraticActionIn();
-    if (ret && ret->initWithAction(action))
-    {
-        ret->autorelease();
-        return ret;
-    }
-
-    delete ret;
-    return nullptr;
-}
-
-EaseQuadraticActionIn* EaseQuadraticActionIn::clone() const
-{
-    // no copy constructor
-    if (_inner)
-        return EaseQuadraticActionIn::create(_inner->clone());
-    
-    return nullptr;
-}
-
-void EaseQuadraticActionIn::update(float time)
-{
-    _inner->update(tweenfunc::quadraticIn(time));
-}
-
-EaseQuadraticActionIn* EaseQuadraticActionIn::reverse() const
-{
-    return EaseQuadraticActionIn::create(_inner->reverse());
-}
-
-//
-// EaseQuadraticActionOut
-//
-
-EaseQuadraticActionOut* EaseQuadraticActionOut::create(ActionInterval* action)
-{
-    EaseQuadraticActionOut *ret = new (std::nothrow) EaseQuadraticActionOut();
-    if (ret && ret->initWithAction(action))
-    {
-        ret->autorelease();
-        return ret;
-    }
-
-    delete ret;
-    return nullptr;
-}
-
-EaseQuadraticActionOut* EaseQuadraticActionOut::clone() const
-{
-    // no copy constructor
-    if (_inner)
-        return EaseQuadraticActionOut::create(_inner->clone());
-    
-    return nullptr;
-}
-
-void EaseQuadraticActionOut::update(float time)
-{
-    _inner->update(tweenfunc::quadraticOut(time));
-}
-
-EaseQuadraticActionOut* EaseQuadraticActionOut::reverse() const
-{
-    return EaseQuadraticActionOut::create(_inner->reverse());
-}
-
-//
-// EaseQuadraticActionInOut
-//
-
-EaseQuadraticActionInOut* EaseQuadraticActionInOut::create(ActionInterval* action)
-{
-    EaseQuadraticActionInOut *ret = new (std::nothrow) EaseQuadraticActionInOut();
-    if (ret && ret->initWithAction(action))
-    {
-        ret->autorelease();
-        return ret;
-    }
-
-    delete ret;
-    return nullptr;
-}
-
-EaseQuadraticActionInOut* EaseQuadraticActionInOut::clone() const
-{
-    // no copy constructor
-    if (_inner)
-        return EaseQuadraticActionInOut::create(_inner->clone());
-    
-    return nullptr;
-}
-
-void EaseQuadraticActionInOut::update(float time)
-{
-    _inner->update(tweenfunc::quadraticInOut(time));
-}
-
-EaseQuadraticActionInOut* EaseQuadraticActionInOut::reverse() const
-{
-    return EaseQuadraticActionInOut::create(_inner->reverse());
-}
-
-//
-// EaseQuarticActionIn
-//
-
-EaseQuarticActionIn* EaseQuarticActionIn::create(ActionInterval* action)
-{
-    EaseQuarticActionIn *ret = new (std::nothrow) EaseQuarticActionIn();
-    if (ret && ret->initWithAction(action))
-    {
-        ret->autorelease();
-        return ret;
-    }
-
-    delete ret;
-    return nullptr;
-}
-
-EaseQuarticActionIn* EaseQuarticActionIn::clone() const
-{
-    // no copy constructor
-    if (_inner)
-        return EaseQuarticActionIn::create(_inner->clone());
-    
-    return nullptr;
-}
-
-void EaseQuarticActionIn::update(float time)
-{
-    _inner->update(tweenfunc::quartEaseIn(time));
-}
-
-EaseQuarticActionIn* EaseQuarticActionIn::reverse() const
-{
-    return EaseQuarticActionIn::create(_inner->reverse());
-}
-
-//
-// EaseQuarticActionOut
-//
-
-EaseQuarticActionOut* EaseQuarticActionOut::create(ActionInterval* action)
-{
-    EaseQuarticActionOut *ret = new (std::nothrow) EaseQuarticActionOut();
-    if (ret && ret->initWithAction(action))
-    {
-        ret->autorelease();
-        return ret;
-    }
-
-    delete ret;
-    return nullptr;
-}
-
-EaseQuarticActionOut* EaseQuarticActionOut::clone() const
-{
-    // no copy constructor
-    if (_inner)
-        return EaseQuarticActionOut::create(_inner->clone());
-    
-    return nullptr;
-}
-
-void EaseQuarticActionOut::update(float time)
-{
-    _inner->update(tweenfunc::quartEaseOut(time));
-}
-
-EaseQuarticActionOut* EaseQuarticActionOut::reverse() const
-{
-    return EaseQuarticActionOut::create(_inner->reverse());
-}
-
-//
-// EaseQuarticActionInOut
-//
-
-EaseQuarticActionInOut* EaseQuarticActionInOut::create(ActionInterval* action)
-{
-    EaseQuarticActionInOut *ret = new (std::nothrow) EaseQuarticActionInOut();
-    if (ret && ret->initWithAction(action))
-    {
-        ret->autorelease();
-        return ret;
-    }
-
-    delete ret;
-    return nullptr;
-}
-
-EaseQuarticActionInOut* EaseQuarticActionInOut::clone() const
-{
-    // no copy constructor
-    if (_inner)
-        return EaseQuarticActionInOut::create(_inner->clone());
-    
-    return nullptr;
-}
-
-void EaseQuarticActionInOut::update(float time)
-{
-    _inner->update(tweenfunc::quartEaseInOut(time));
-}
-
-EaseQuarticActionInOut* EaseQuarticActionInOut::reverse() const
-{
-    return EaseQuarticActionInOut::create(_inner->reverse());
-}
-
-//
-// EaseQuinticActionIn
-//
-
-EaseQuinticActionIn* EaseQuinticActionIn::create(ActionInterval* action)
-{
-    EaseQuinticActionIn *ret = new (std::nothrow) EaseQuinticActionIn();
-    if (ret && ret->initWithAction(action))
-    {
-        ret->autorelease();
-        return ret;
-    }
-
-    delete ret;
-    return nullptr;
-}
-
-EaseQuinticActionIn* EaseQuinticActionIn::clone() const
-{
-    // no copy constructor
-    if (_inner)
-        return EaseQuinticActionIn::create(_inner->clone());
-    
-    return nullptr;
-}
-
-void EaseQuinticActionIn::update(float time)
-{
-    _inner->update(tweenfunc::quintEaseIn(time));
-}
-
-EaseQuinticActionIn* EaseQuinticActionIn::reverse() const
-{
-    return EaseQuinticActionIn::create(_inner->reverse());
-}
-
-//
-// EaseQuinticActionOut
-//
-
-EaseQuinticActionOut* EaseQuinticActionOut::create(ActionInterval* action)
-{
-    EaseQuinticActionOut *ret = new (std::nothrow) EaseQuinticActionOut();
-    if (ret && ret->initWithAction(action))
-    {
-        ret->autorelease();
-        return ret;
-    }
-
-    delete ret;
-    return nullptr;
-}
-
-EaseQuinticActionOut* EaseQuinticActionOut::clone() const
-{
-    // no copy constructor
-    if (_inner)
-        return EaseQuinticActionOut::create(_inner->clone());
-    
-    return nullptr;
-}
-
-void EaseQuinticActionOut::update(float time)
-{
-    _inner->update(tweenfunc::quintEaseOut(time));
-}
-
-EaseQuinticActionOut* EaseQuinticActionOut::reverse() const
-{
-    return EaseQuinticActionOut::create(_inner->reverse());
-}
-
-//
-// EaseQuinticActionInOut
-//
-
-EaseQuinticActionInOut* EaseQuinticActionInOut::create(ActionInterval* action)
-{
-    EaseQuinticActionInOut *ret = new (std::nothrow) EaseQuinticActionInOut();
-    if (ret && ret->initWithAction(action))
-    {
-        ret->autorelease();
-        return ret;
-    }
-
-    delete ret;
-    return nullptr;
-}
-
-EaseQuinticActionInOut* EaseQuinticActionInOut::clone() const
-{
-    // no copy constructor
-    if (_inner)
-        return EaseQuinticActionInOut::create(_inner->clone());
-    
-    return nullptr;
-}
-
-void EaseQuinticActionInOut::update(float time)
-{
-    _inner->update(tweenfunc::quintEaseInOut(time));
-}
-
-EaseQuinticActionInOut* EaseQuinticActionInOut::reverse() const
-{
-    return EaseQuinticActionInOut::create(_inner->reverse());
-}
-
-//
-// EaseCircleActionIn
-//
-
-EaseCircleActionIn* EaseCircleActionIn::create(ActionInterval* action)
-{
-    EaseCircleActionIn *ret = new (std::nothrow) EaseCircleActionIn();
-    if (ret && ret->initWithAction(action))
-    {
-        ret->autorelease();
-        return ret;
-    }
-
-    delete ret;
-    return nullptr;
-}
-
-EaseCircleActionIn* EaseCircleActionIn::clone() const
-{
-    // no copy constructor
-    if (_inner)
-        return EaseCircleActionIn::create(_inner->clone());
-    
-    return nullptr;
-}
-
-void EaseCircleActionIn::update(float time)
-{
-    _inner->update(tweenfunc::circEaseIn(time));
-}
-
-EaseCircleActionIn* EaseCircleActionIn::reverse() const
-{
-    return EaseCircleActionIn::create(_inner->reverse());
-}
-
-//
-// EaseCircleActionOut
-//
-
-EaseCircleActionOut* EaseCircleActionOut::create(ActionInterval* action)
-{
-    EaseCircleActionOut *ret = new (std::nothrow) EaseCircleActionOut();
-    if (ret && ret->initWithAction(action))
-    {
-        ret->autorelease();
-        return ret;
-    }
-
-    delete ret;
-    return nullptr;
-}
-
-EaseCircleActionOut* EaseCircleActionOut::clone() const
-{
-    // no copy constructor
-    if (_inner)
-        return EaseCircleActionOut::create(_inner->clone());
-    
-    return nullptr;
-}
-
-void EaseCircleActionOut::update(float time)
-{
-    _inner->update(tweenfunc::circEaseOut(time));
-}
-
-EaseCircleActionOut* EaseCircleActionOut::reverse() const
-{
-    return EaseCircleActionOut::create(_inner->reverse());
-}
-
-//
-// EaseCircleActionInOut
-//
-
-EaseCircleActionInOut* EaseCircleActionInOut::create(ActionInterval* action)
-{
-    EaseCircleActionInOut *ret = new (std::nothrow) EaseCircleActionInOut();
-    if (ret && ret->initWithAction(action))
-    {
-        ret->autorelease();
-        return ret;
-    }
-    
-    delete ret;
-    return nullptr;
-}
-
-EaseCircleActionInOut* EaseCircleActionInOut::clone() const
-{
-    // no copy constructor
-    if (_inner)
-        return EaseCircleActionInOut::create(_inner->clone());
-    
-    return nullptr;
-}
-
-void EaseCircleActionInOut::update(float time)
-{
-    _inner->update(tweenfunc::circEaseInOut(time));
-}
-
-EaseCircleActionInOut* EaseCircleActionInOut::reverse() const
-{
-    return EaseCircleActionInOut::create(_inner->reverse());
-}
-
-//
-// EaseCubicActionIn
-//
-
-EaseCubicActionIn* EaseCubicActionIn::create(ActionInterval* action)
-{
-    EaseCubicActionIn *ret = new (std::nothrow) EaseCubicActionIn();
-    if (ret && ret->initWithAction(action))
-    {
-        ret->autorelease();
-        return ret;
-    }
-
-    delete ret;
-    return nullptr;
-}
-
-EaseCubicActionIn* EaseCubicActionIn::clone() const
-{
-    // no copy constructor
-    if (_inner)
-        return EaseCubicActionIn::create(_inner->clone());
-    
-    return nullptr;
-}
-
-void EaseCubicActionIn::update(float time)
-{
-    _inner->update(tweenfunc::cubicEaseIn(time));
-}
-
-EaseCubicActionIn* EaseCubicActionIn::reverse() const
-{
-    return EaseCubicActionIn::create(_inner->reverse());
-}
-
-//
-// EaseCubicActionOut
-//
-
-EaseCubicActionOut* EaseCubicActionOut::create(ActionInterval* action)
-{
-    EaseCubicActionOut *ret = new (std::nothrow) EaseCubicActionOut();
-    if (ret && ret->initWithAction(action))
-    {
-        ret->autorelease();
-        return ret;
-    }
-
-    delete ret;
-    return nullptr;
-}
-
-EaseCubicActionOut* EaseCubicActionOut::clone() const
-{
-    // no copy constructor
-    if (_inner)
-        return EaseCubicActionOut::create(_inner->clone());
-    
-    return nullptr;
-}
-
-void EaseCubicActionOut::update(float time)
-{
-    _inner->update(tweenfunc::cubicEaseOut(time));
-}
-
-EaseCubicActionOut* EaseCubicActionOut::reverse() const
-{
-    return EaseCubicActionOut::create(_inner->reverse());
-}
-
-//
-// EaseCubicActionInOut
-//
-
-EaseCubicActionInOut* EaseCubicActionInOut::create(ActionInterval* action)
-{
-    EaseCubicActionInOut *ret = new (std::nothrow) EaseCubicActionInOut();
-    if (ret && ret->initWithAction(action))
-    {
-        ret->autorelease();
-        return ret;
-    }
-
-    delete ret;
-    return nullptr;
-}
-
-EaseCubicActionInOut* EaseCubicActionInOut::clone() const
-{
-    // no copy constructor
-    if (_inner)
-        return EaseCubicActionInOut::create(_inner->clone());
-    
-    return nullptr;
-}
-
-void EaseCubicActionInOut::update(float time)
-{
-    _inner->update(tweenfunc::cubicEaseInOut(time));
-}
-
-EaseCubicActionInOut* EaseCubicActionInOut::reverse() const
-{
-    if (_inner)
-        return EaseCubicActionInOut::create(_inner->reverse());
-    
-    return nullptr;
+	EaseBezierAction* reverseAction = EaseBezierAction::create(_inner->reverse());
+	reverseAction->setBezierParamer(_p3,_p2,_p1,_p0);
+	return reverseAction;
 }
 
 NS_CC_END

--- a/cocos/2d/CCActionEase.h
+++ b/cocos/2d/CCActionEase.h
@@ -28,6 +28,9 @@ THE SOFTWARE.
 #define __ACTION_CCEASE_ACTION_H__
 
 #include "2d/CCActionInterval.h"
+#include "CCTweenFunction.h"
+
+#define EASE_MACRO_COMMA ,
 
 NS_CC_BEGIN
 
@@ -36,38 +39,27 @@ NS_CC_BEGIN
  * @{
  */
 
-/** 
+/**
  @class ActionEase
  @brief Base class for Easing actions.
  @details Ease actions are created from other interval actions.
-         The ease action will change the timeline of the inner action.
+ The ease action will change the timeline of the inner action.
  @ingroup Actions
  */
 class CC_DLL ActionEase : public ActionInterval
 {
 public:
-
     /**
-    @brief Get the pointer of the inner action.
-    @return The pointer of the inner action.
+     @brief Get the pointer of the inner action.
+     @return The pointer of the inner action.
     */
     virtual ActionInterval* getInnerAction();
 
     //
     // Overrides
     //
-    virtual ActionEase* clone() const override
-    {
-        CC_ASSERT(0);
-        return nullptr;
-    }
-    
-    virtual ActionEase* reverse() const override
-    {
-        CC_ASSERT(0);
-        return nullptr;
-    }
-
+    virtual ActionEase* clone() const override = 0;
+    virtual ActionEase* reverse() const override = 0;
     virtual void startWithTarget(Node *target) override;
     virtual void stop() override;
     virtual void update(float time) override;
@@ -78,7 +70,7 @@ CC_CONSTRUCTOR_ACCESS:
     {}
     
     virtual ~ActionEase();
-    /** 
+    /**
      @brief Initializes the action.
      @return Return true when the initialization success, otherwise return false.
     */
@@ -93,7 +85,7 @@ private:
 
 /** 
  @class EaseRateAction
- @brief Base class for Easing actions with rate parameters.
+ @brief Base class for Easing actions with rate parameters
  @details Ease the inner action with specified rate.
  @ingroup Actions
  */
@@ -101,47 +93,31 @@ class CC_DLL EaseRateAction : public ActionEase
 {
 public:
     /**
-     @brief Creates the action with the inner action and the rate parameter.
-     @param action A given ActionInterval
-     @param rate A given rate
-     @return An autoreleased EaseRateAction object.
-    **/
-    static EaseRateAction* create(ActionInterval* action, float rate);
-    
-    /**
-     @brief Set the rate value for the ease rate action.
-     @param rate The value will be set.
-     */
+    @brief Set the rate value for the ease rate action.
+    @param rate The value will be set.
+    */
     inline void setRate(float rate) { _rate = rate; }
     /**
-     @brief Get the rate value of the ease rate action.
-     @return Return the rate value of the ease rate action.
-     */
+    @brief Get the rate value of the ease rate action.
+    @return Return the rate value of the ease rate action.
+    */
     inline float getRate() const { return _rate; }
 
     //
     // Overrides
     //
-    virtual EaseRateAction* clone() const override
-    {
-        CC_ASSERT(0);
-        return nullptr;
-    }
-    virtual EaseRateAction* reverse() const override
-    {
-        CC_ASSERT(0);
-        return nullptr;
-    }
+    virtual EaseRateAction* clone() const override = 0;
+    virtual EaseRateAction* reverse() const override = 0;
 
 CC_CONSTRUCTOR_ACCESS:
     EaseRateAction() {}
     virtual ~EaseRateAction();
-    /** 
+    /**
      @brief Initializes the action with the inner action and the rate parameter.
      @param pAction The pointer of the inner action.
      @param fRate The value of the rate parameter.
      @return Return true when the initialization success, otherwise return false.
-     */
+    */
     bool initWithAction(ActionInterval *pAction, float fRate);
 
 protected:
@@ -151,284 +127,329 @@ private:
     CC_DISALLOW_COPY_AND_ASSIGN(EaseRateAction);
 };
 
-/** 
- @class EaseIn
- @brief EaseIn action with a rate.
- @details The timeline of inner action will be changed by:
-         \f${ time }^{ rate }\f$.
- @ingroup Actions
- */
-class CC_DLL EaseIn : public EaseRateAction
+template<float (*F)(float), float (*I)(float) = F>
+class CC_DLL EaseTemplate : public ActionEase
 {
-public:
-    /** 
-     @brief Create the action with the inner action and the rate parameter.
-     @param action The pointer of the inner action.
-     @param rate The value of the rate parameter.
-     @return A pointer of EaseIn action. If creation failed, return nil.
-    */
-    static EaseIn* create(ActionInterval* action, float rate);
-
-    // Overrides
-    virtual void update(float time) override;
-    virtual EaseIn* clone() const override;
-    virtual EaseIn* reverse() const override;
-
 CC_CONSTRUCTOR_ACCESS:
-    EaseIn() {}
-    virtual ~EaseIn() {}
+    virtual ~EaseTemplate() { }
+    EaseTemplate<F>() { }
+
+public:
+    static EaseTemplate<F,I>* create(ActionInterval* action);
+
+    void update(float time) override { _inner->update(F(time)); }
+    ActionEase* reverse() const override { return EaseTemplate<I,F>::create(_inner->reverse()); }
+    ActionEase* clone() const override;
 
 private:
-    CC_DISALLOW_COPY_AND_ASSIGN(EaseIn);
+    CC_DISALLOW_COPY_AND_ASSIGN(EaseTemplate<F EASE_MACRO_COMMA I>);
 };
 
-/** 
- @class EaseOut
- @brief EaseOut action with a rate.
- @details The timeline of inner action will be changed by:
-         \f${ time }^ { (1/rate) }\f$.
+/**
+ @class EaseBounce
+ @brief EaseBounce type alias.
+ @since v0.8.2
  @ingroup Actions
  */
-class CC_DLL EaseOut : public EaseRateAction
-{
-public:
-    /** 
-     @brief Create the action with the inner action and the rate parameter.
-     @param action The pointer of the inner action.
-     @param rate The value of the rate parameter.
-     @return A pointer of EaseOut action. If creation failed, return nil.
-    */
-    static EaseOut* create(ActionInterval* action, float rate);
+using EaseBounce = ActionEase;
 
-    // Overrides
-    virtual void update(float time) override;
-    virtual EaseOut* clone() const  override;
-    virtual EaseOut* reverse() const  override;
+template class EaseTemplate<tweenfunc::expoEaseIn, tweenfunc::expoEaseOut>;
+template class EaseTemplate<tweenfunc::expoEaseOut, tweenfunc::expoEaseIn>;
+template class EaseTemplate<tweenfunc::expoEaseInOut>;
 
-CC_CONSTRUCTOR_ACCESS:
-    EaseOut() {}
-    virtual ~EaseOut() {}
+template class EaseTemplate<tweenfunc::sineEaseIn, tweenfunc::sineEaseOut>;
+template class EaseTemplate<tweenfunc::sineEaseOut, tweenfunc::sineEaseIn>;
+template class EaseTemplate<tweenfunc::sineEaseInOut>;
 
-private:
-    CC_DISALLOW_COPY_AND_ASSIGN(EaseOut);
-};
+template class EaseTemplate<tweenfunc::bounceEaseIn, tweenfunc::bounceEaseOut>;
+template class EaseTemplate<tweenfunc::bounceEaseOut, tweenfunc::bounceEaseIn>;
+template class EaseTemplate<tweenfunc::bounceEaseInOut>;
 
-/** 
- @class EaseInOut
- @brief EaseInOut action with a rate
- @details If time * 2 < 1, the timeline of inner action will be changed by:
-         \f$0.5*{ time }^{ rate }\f$.
-         Else, the timeline of inner action will be changed by:
-         \f$1.0-0.5*{ 2-time }^{ rate }\f$.
- @ingroup Actions
- */
-class CC_DLL EaseInOut : public EaseRateAction
-{
-public:
-    /** 
-     @brief Create the action with the inner action and the rate parameter.
-     @param action The pointer of the inner action.
-     @param rate The value of the rate parameter.
-     @return A pointer of EaseInOut action. If creation failed, return nil.
-    */
-    static EaseInOut* create(ActionInterval* action, float rate);
+template class EaseTemplate<tweenfunc::backEaseIn, tweenfunc::backEaseOut>;
+template class EaseTemplate<tweenfunc::backEaseOut, tweenfunc::backEaseIn>;
+template class EaseTemplate<tweenfunc::backEaseInOut>;
 
-    // Overrides
-    virtual void update(float time) override;
-    virtual EaseInOut* clone() const  override;
-    virtual EaseInOut* reverse() const  override;
+template class EaseTemplate<tweenfunc::quadraticIn>;
+template class EaseTemplate<tweenfunc::quadraticOut>;
+template class EaseTemplate<tweenfunc::quadraticInOut>;
 
-CC_CONSTRUCTOR_ACCESS:
-    EaseInOut() {}
-    virtual ~EaseInOut() {}
+template class EaseTemplate<tweenfunc::quartEaseIn>;
+template class EaseTemplate<tweenfunc::quartEaseOut>;
+template class EaseTemplate<tweenfunc::quartEaseInOut>;
 
-private:
-    CC_DISALLOW_COPY_AND_ASSIGN(EaseInOut);
-};
+template class EaseTemplate<tweenfunc::quintEaseIn>;
+template class EaseTemplate<tweenfunc::quintEaseOut>;
+template class EaseTemplate<tweenfunc::quintEaseInOut>;
 
-/** 
+template class EaseTemplate<tweenfunc::circEaseIn>;
+template class EaseTemplate<tweenfunc::circEaseOut>;
+template class EaseTemplate<tweenfunc::circEaseInOut>;
+
+template class EaseTemplate<tweenfunc::cubicEaseIn>;
+template class EaseTemplate<tweenfunc::cubicEaseOut>;
+template class EaseTemplate<tweenfunc::cubicEaseInOut>;
+
+/**
  @class EaseExponentialIn
  @brief Ease Exponential In action.
  @details The timeline of inner action will be changed by:
-         \f${ 2 }^{ 10*(time-1) }-1*0.001\f$.
+ \f${ 2 }^{ 10*(time-1) }-1*0.001\f$.
  @ingroup Actions
  */
-class CC_DLL EaseExponentialIn : public ActionEase
-{
-public:
-    /** 
-     @brief Create the action with the inner action.
-     @param action The pointer of the inner action.
-     @return A pointer of EaseExponentialIn action. If creation failed, return nil.
-    */
-    static EaseExponentialIn* create(ActionInterval* action);
-
-    // Overrides
-    virtual void update(float time) override;
-    virtual EaseExponentialIn* clone() const override;
-    virtual ActionEase* reverse() const override;
-
-CC_CONSTRUCTOR_ACCESS:
-    EaseExponentialIn() {}
-    virtual ~EaseExponentialIn() {}
-
-private:
-    CC_DISALLOW_COPY_AND_ASSIGN(EaseExponentialIn);
-};
-
-/** 
+using EaseExponentialIn = EaseTemplate<tweenfunc::expoEaseIn, tweenfunc::expoEaseOut>;
+/**
  @class EaseExponentialOut
  @brief Ease Exponential Out
  @details The timeline of inner action will be changed by:
-         \f$1-{ 2 }^{ -10*(time-1) }\f$.
+ \f$1-{ 2 }^{ -10*(time-1) }\f$.
  @ingroup Actions
  */
-class CC_DLL EaseExponentialOut : public ActionEase
-{
-public:
-    /** 
-     @brief Create the action with the inner action.
-     @param action The pointer of the inner action.
-     @return A pointer of EaseExponentialOut action. If creation failed, return nil.
-    */
-    static EaseExponentialOut* create(ActionInterval* action);
-
-    // Overrides
-    virtual void update(float time) override;
-    virtual EaseExponentialOut* clone() const override;
-    virtual ActionEase* reverse() const override;
-
-CC_CONSTRUCTOR_ACCESS:
-    EaseExponentialOut() {}
-    virtual ~EaseExponentialOut() {}
-
-private:
-    CC_DISALLOW_COPY_AND_ASSIGN(EaseExponentialOut);
-};
-
-/** 
+using EaseExponentialOut = EaseTemplate<tweenfunc::expoEaseOut, tweenfunc::expoEaseIn>;
+/**
  @class EaseExponentialInOut
  @brief Ease Exponential InOut
  @details If time * 2 < 1, the timeline of inner action will be changed by:
-         \f$0.5*{ 2 }^{ 10*(time-1) }\f$.
-         else, the timeline of inner action will be changed by:
-         \f$0.5*(2-{ 2 }^{ -10*(time-1) })\f$.
+ \f$0.5*{ 2 }^{ 10*(time-1) }\f$.
+ else, the timeline of inner action will be changed by:
+ \f$0.5*(2-{ 2 }^{ -10*(time-1) })\f$.
  @ingroup Actions
  */
-class CC_DLL EaseExponentialInOut : public ActionEase
-{
-public:
-    /** 
-     @brief Create the action with the inner action.
-     @param action The pointer of the inner action.
-     @return A pointer of EaseExponentialInOut action. If creation failed, return nil.
-    */
-    static EaseExponentialInOut* create(ActionInterval* action);
+using EaseExponentialInOut = EaseTemplate<tweenfunc::expoEaseInOut>;
 
-    // Overrides
-    virtual void update(float time) override;
-    virtual EaseExponentialInOut* clone() const override;
-    virtual EaseExponentialInOut* reverse() const override;
-
-CC_CONSTRUCTOR_ACCESS:
-    EaseExponentialInOut() {}
-    virtual ~EaseExponentialInOut() {}
-
-private:
-    CC_DISALLOW_COPY_AND_ASSIGN(EaseExponentialInOut);
-};
-
-/** 
+/**
  @class EaseSineIn
  @brief Ease Sine In
  @details The timeline of inner action will be changed by:
-         \f$1-cos(time*\frac { \pi  }{ 2 } )\f$.
+ \f$1-cos(time*\frac { \pi  }{ 2 } )\f$.
  @ingroup Actions
  */
-class CC_DLL EaseSineIn : public ActionEase
-{
-public:
-    /** 
-     @brief Create the action with the inner action.
-     @param action The pointer of the inner action.
-     @return A pointer of EaseSineIn action. If creation failed, return nil.
-    */
-    static EaseSineIn* create(ActionInterval* action);
+using EaseSineIn = EaseTemplate<tweenfunc::sineEaseIn, tweenfunc::sineEaseOut>;
 
-    // Overrides
-    virtual void update(float time) override;
-    virtual EaseSineIn* clone() const override;
-    virtual ActionEase* reverse() const override;
-
-CC_CONSTRUCTOR_ACCESS:
-    EaseSineIn() {}
-    virtual ~EaseSineIn() {}
-
-private:
-    CC_DISALLOW_COPY_AND_ASSIGN(EaseSineIn);
-};
-
-/** 
+/**
  @class EaseSineOut
  @brief Ease Sine Out
  @details The timeline of inner action will be changed by:
-         \f$sin(time*\frac { \pi  }{ 2 } )\f$.
+ \f$sin(time*\frac { \pi  }{ 2 } )\f$.
  @ingroup Actions
  */
-class CC_DLL EaseSineOut : public ActionEase
-{
-public:
-    /** 
-     @brief Create the action with the inner action.
-     @param action The pointer of the inner action.
-     @return A pointer of EaseSineOut action. If creation failed, return nil.
-    */
-    static EaseSineOut* create(ActionInterval* action);
-
-    // Overrides
-    virtual void update(float time) override;
-    virtual EaseSineOut* clone() const override;
-    virtual ActionEase* reverse() const override;
-
-CC_CONSTRUCTOR_ACCESS:
-    EaseSineOut() {}
-    virtual ~EaseSineOut() {}
-
-private:
-    CC_DISALLOW_COPY_AND_ASSIGN(EaseSineOut);
-};
-
-/** 
+using EaseSineOut = EaseTemplate<tweenfunc::sineEaseOut, tweenfunc::sineEaseIn>;
+/**
  @class EaseSineInOut
  @brief Ease Sine InOut
  @details The timeline of inner action will be changed by:
-         \f$-0.5*(cos(\pi *time)-1)\f$.
+ \f$-0.5*(cos(\pi *time)-1)\f$.
  @ingroup Actions
  */
-class CC_DLL EaseSineInOut : public ActionEase
+using EaseSineInOut = EaseTemplate<tweenfunc::sineEaseInOut>;
+
+/**
+ @class EaseBounceIn
+ @brief EaseBounceIn action.
+ @warning This action doesn't use a bijective function.
+ Actions like Sequence might have an unexpected result when used with this action.
+ @since v0.8.2
+ @ingroup Actions
+ */
+using EaseBounceIn = EaseTemplate<tweenfunc::bounceEaseIn, tweenfunc::bounceEaseOut>;
+/**
+ @class EaseBounceOut
+ @brief EaseBounceOut action.
+ @warning This action doesn't use a bijective function.
+ Actions like Sequence might have an unexpected result when used with this action.
+ @since v0.8.2
+ @ingroup Actions
+ */
+using EaseBounceOut = EaseTemplate<tweenfunc::bounceEaseOut, tweenfunc::bounceEaseIn>;
+/**
+ @class EaseBounceInOut
+ @brief EaseBounceInOut action.
+ @warning This action doesn't use a bijective function.
+ Actions like Sequence might have an unexpected result when used with this action.
+ @since v0.8.2
+ @ingroup Actions
+ */
+using EaseBounceInOut = EaseTemplate<tweenfunc::bounceEaseInOut>;
+
+/**
+ @class EaseBackIn
+ @brief EaseBackIn action.
+ @warning This action doesn't use a bijective function.
+ Actions like Sequence might have an unexpected result when used with this action.
+ @since v0.8.2
+ @ingroup Actions
+ */
+using EaseBackIn = EaseTemplate<tweenfunc::backEaseIn, tweenfunc::backEaseOut>;
+/**
+ @class EaseBackOut
+ @brief EaseBackOut action.
+ @warning This action doesn't use a bijective function.
+ Actions like Sequence might have an unexpected result when used with this action.
+ @since v0.8.2
+ @ingroup Actions
+ */
+using EaseBackOut = EaseTemplate<tweenfunc::backEaseOut, tweenfunc::backEaseIn>;
+/**
+ @class EaseBackInOut
+ @brief EaseBackInOut action.
+ @warning This action doesn't use a bijective function.
+ Actions like Sequence might have an unexpected result when used with this action.
+ @since v0.8.2
+ @ingroup Actions
+ */
+using EaseBackInOut = EaseTemplate<tweenfunc::backEaseInOut>;
+
+/**
+ @class EaseQuadraticActionIn
+ @brief Ease Quadratic In
+ @ingroup Actions
+ */
+using EaseQuadraticActionIn = EaseTemplate<tweenfunc::quadraticIn>;
+/**
+ @class EaseQuadraticActionOut
+ @brief Ease Quadratic Out
+ @ingroup Actions
+ */
+using EaseQuadraticActionOut = EaseTemplate<tweenfunc::quadraticOut>;
+/**
+ @class EaseQuadraticActionInOut
+ @brief Ease Quadratic InOut
+ @ingroup Actions
+ */
+using EaseQuadraticActionInOut = EaseTemplate<tweenfunc::quadraticInOut>;
+
+/**
+ @class EaseQuarticActionIn
+ @brief Ease Quartic In
+ @ingroup Actions
+ */
+using EaseQuarticActionIn = EaseTemplate<tweenfunc::quartEaseIn>;
+/**
+ @class EaseQuarticActionOut
+ @brief Ease Quartic Out
+ @ingroup Actions
+ */
+using EaseQuarticActionOut = EaseTemplate<tweenfunc::quartEaseOut>;
+/**
+ @class EaseQuarticActionInOut
+ @brief Ease Quartic InOut
+ @ingroup Actions
+ */
+using EaseQuarticActionInOut = EaseTemplate<tweenfunc::quartEaseInOut>;
+
+/**
+ @class EaseQuinticActionIn
+ @brief Ease Quintic In
+ @ingroup Actions
+ */
+using EaseQuinticActionIn = EaseTemplate<tweenfunc::quintEaseIn>;
+/**
+ @class EaseQuinticActionOut
+ @brief Ease Quintic Out
+ @ingroup Actions
+ */
+using EaseQuinticActionOut = EaseTemplate<tweenfunc::quintEaseOut>;
+/**
+ @class EaseQuinticActionInOut
+ @brief Ease Quintic InOut
+ @ingroup Actions
+ */
+using EaseQuinticActionInOut = EaseTemplate<tweenfunc::quintEaseInOut>;
+
+/**
+ @class EaseCircleActionIn
+ @brief Ease Circle In
+ @ingroup Actions
+ */
+using EaseCircleActionIn = EaseTemplate<tweenfunc::circEaseIn>;
+/**
+ @class EaseCircleActionOut
+ @brief Ease Circle Out
+ @ingroup Actions
+ */
+using EaseCircleActionOut = EaseTemplate<tweenfunc::circEaseOut>;
+/**
+ @class EaseCircleActionInOut
+ @brief Ease Circle InOut
+ @ingroup Actions
+ */
+using EaseCircleActionInOut = EaseTemplate<tweenfunc::circEaseInOut>;
+
+/**
+ @class EaseCubicActionIn
+ @brief Ease Cubic In
+ @ingroup Actions
+ */
+using EaseCubicActionIn = EaseTemplate<tweenfunc::cubicEaseIn>;
+/**
+ @class EaseCubicActionOut
+ @brief Ease Cubic Out
+ @ingroup Actions
+ */
+using EaseCubicActionOut = EaseTemplate<tweenfunc::cubicEaseOut>;
+/**
+ @class EaseCubicActionInOut
+ @brief Ease Cubic InOut
+ @ingroup Actions
+ */
+using EaseCubicActionInOut = EaseTemplate<tweenfunc::cubicEaseInOut>;
+
+template<float (*F)(float,float), float(*I)(float,float) = F>
+class CC_DLL EaseRateTemplate : public EaseRateAction
 {
-public:
-    /** 
-     @brief Create the action with the inner action.
-     @param action The pointer of the inner action.
-     @return A pointer of EaseSineInOut action. If creation failed, return nil.
-    */
-    static EaseSineInOut* create(ActionInterval* action);
-
-    // Overrides
-    virtual void update(float time) override;
-    virtual EaseSineInOut* clone() const override;
-    virtual EaseSineInOut* reverse() const override;
-
 CC_CONSTRUCTOR_ACCESS:
-    EaseSineInOut() {}
-    virtual ~EaseSineInOut() {}
+    virtual ~EaseRateTemplate() { }
+    EaseRateTemplate<F,I>() { }
+
+public:
+    /**
+     @brief Creates the action with the inner action and the rate parameter.
+     @param action A given ActionInterval
+     @param rate A given rate
+     @return An autoreleased EaseRateAction object.
+    **/
+    static EaseRateTemplate<F,I>* create(ActionInterval* action, float rate);
+
+    void update(float time) override { _inner->update(F(time, _rate)); }
+    EaseRateAction* reverse() const override { return EaseRateTemplate<I,F>::create(_inner->reverse(), 1 / _rate); }
+    EaseRateAction* clone() const override;
 
 private:
-    CC_DISALLOW_COPY_AND_ASSIGN(EaseSineInOut);
+    CC_DISALLOW_COPY_AND_ASSIGN(EaseRateTemplate<F EASE_MACRO_COMMA I>);
 };
 
-/** 
+template class EaseRateTemplate<tweenfunc::easeIn>;
+template class EaseRateTemplate<tweenfunc::easeOut>;
+template class EaseRateTemplate<tweenfunc::easeInOut>;
+
+/**
+ @class EaseIn
+ @brief EaseIn action with a rate.
+ @details The timeline of inner action will be changed by:
+ \f${ time }^{ rate }\f$.
+ @ingroup Actions
+ */
+using EaseIn = EaseRateTemplate<tweenfunc::easeIn>;
+/**
+ @class EaseOut
+ @brief EaseOut action with a rate.
+ @details The timeline of inner action will be changed by:
+ \f${ time }^ { (1/rate) }\f$.
+ @ingroup Actions
+ */
+using EaseOut = EaseRateTemplate<tweenfunc::easeOut>;
+/**
+ @class EaseInOut
+ @brief EaseInOut action with a rate
+ @details If time * 2 < 1, the timeline of inner action will be changed by:
+ \f$0.5*{ time }^{ rate }\f$.
+ Else, the timeline of inner action will be changed by:
+ \f$1.0-0.5*{ 2-time }^{ rate }\f$.
+ @ingroup Actions
+ */
+using EaseInOut = EaseRateTemplate<tweenfunc::easeInOut>;
+
+
+/**
  @class EaseElastic
  @brief Ease Elastic abstract class
  @since v0.8.2
@@ -438,7 +459,7 @@ class CC_DLL EaseElastic : public ActionEase
 {
 public:
 
-    /** 
+    /**
      @brief Get period of the wave in radians. Default value is 0.3.
      @return Return the period of the wave in radians.
     */
@@ -452,22 +473,13 @@ public:
     //
     // Overrides
     //
-    virtual EaseElastic* clone() const override
-    {
-        CC_ASSERT(0);
-        return nullptr;
-    }
-    
-    virtual EaseElastic* reverse() const override
-    {
-        CC_ASSERT(0);
-        return nullptr;
-    }
+	  virtual EaseElastic* clone() const override = 0;
+	  virtual EaseElastic* reverse() const override = 0;
 
 CC_CONSTRUCTOR_ACCESS:
     EaseElastic() {}
     virtual ~EaseElastic() {}
-    /** 
+    /**
      @brief Initializes the action with the inner action and the period in radians.
      @param action The pointer of the inner action.
      @param period Period of the wave in radians. Default is 0.3.
@@ -480,372 +492,88 @@ protected:
 
 private:
     CC_DISALLOW_COPY_AND_ASSIGN(EaseElastic);
-
 };
 
-/** 
+template<float (*F)(float,float), float(*I)(float,float) = F>
+class CC_DLL EaseElasticTemplate : public EaseElastic
+{
+
+CC_CONSTRUCTOR_ACCESS:
+    virtual ~EaseElasticTemplate() { }
+    EaseElasticTemplate<F,I>() { }
+
+public:
+    static EaseElasticTemplate<F,I>* create(ActionInterval* action, float rate = 0.3f);
+
+    void update(float time) override { _inner->update(F(time, _period)); }
+    EaseElastic* reverse() const override { return EaseElasticTemplate<I,F>::create(_inner->reverse(), _period); }
+    EaseElastic* clone() const override;
+
+private:
+    CC_DISALLOW_COPY_AND_ASSIGN(EaseElasticTemplate<F EASE_MACRO_COMMA I>);
+};
+
+template class EaseElasticTemplate<tweenfunc::elasticEaseIn>;
+template class EaseElasticTemplate<tweenfunc::elasticEaseOut>;
+template class EaseElasticTemplate<tweenfunc::elasticEaseInOut>;
+
+/**
  @class EaseElasticIn
  @brief Ease Elastic In action.
  @details If time == 0 or time == 1, the timeline of inner action will not be changed.
-         Else, the timeline of inner action will be changed by:
-         \f$-{ 2 }^{ 10*(time-1) }*sin((time-1-\frac { period }{ 4 } )*\pi *2/period)\f$.
+ Else, the timeline of inner action will be changed by:
+ \f$-{ 2 }^{ 10*(time-1) }*sin((time-1-\frac { period }{ 4 } )*\pi *2/period)\f$.
 
  @warning This action doesn't use a bijective function.
-          Actions like Sequence might have an unexpected result when used with this action.
+ Actions like Sequence might have an unexpected result when used with this action.
  @since v0.8.2
  @ingroup Actions
  */
-class CC_DLL EaseElasticIn : public EaseElastic
-{
-public:
-    /** 
-     @brief Create the EaseElasticIn action with the inner action and the period in radians.
-     @param action The pointer of the inner action.
-     @param period Period of the wave in radians.
-     @return A pointer of EaseElasticIn action. If creation failed, return nil.
-    */
-    static EaseElasticIn* create(ActionInterval *action, float period);
-
-    /** 
-     @brief Create the EaseElasticIn action with the inner action and period value is 0.3.
-     @param action The pointer of the inner action.
-     @return A pointer of EaseElasticIn action. If creation failed, return nil.
-    */
-    static EaseElasticIn* create(ActionInterval *action);
-
-    // Overrides
-    virtual void update(float time) override;
-    virtual EaseElasticIn* clone() const override;
-    virtual EaseElastic* reverse() const override;
-
-CC_CONSTRUCTOR_ACCESS:
-    EaseElasticIn() {}
-    virtual ~EaseElasticIn() {}
-
-private:
-    CC_DISALLOW_COPY_AND_ASSIGN(EaseElasticIn);
-};
-
-/** 
+using EaseElasticIn = EaseElasticTemplate<tweenfunc::elasticEaseIn>;
+/**
  @class EaseElasticOut
  @brief Ease Elastic Out action.
  @details If time == 0 or time == 1, the timeline of inner action will not be changed.
-         Else, the timeline of inner action will be changed by:
-         \f${ 2 }^{ -10*time }*sin((time-\frac { period }{ 4 } )*\pi *2/period)+1\f$.
+ Else, the timeline of inner action will be changed by:
+ \f${ 2 }^{ -10*time }*sin((time-\frac { period }{ 4 } )*\pi *2/period)+1\f$.
  @warning This action doesn't use a bijective function.
-          Actions like Sequence might have an unexpected result when used with this action.
+ Actions like Sequence might have an unexpected result when used with this action.
  @since v0.8.2
  @ingroup Actions
  */
-class CC_DLL EaseElasticOut : public EaseElastic
-{
-public:
-    /** 
-     @brief Create the EaseElasticOut action with the inner action and the period in radians.
-     @param action The pointer of the inner action.
-     @param period Period of the wave in radians.
-     @return A pointer of EaseElasticOut action. If creation failed, return nil.
-    */
-    static EaseElasticOut* create(ActionInterval *action, float period);
-
-    /** 
-     @brief Create the EaseElasticOut action with the inner action and period value is 0.3.
-     @param action The pointer of the inner action.
-     @return A pointer of EaseElasticOut action. If creation failed, return nil.
-    */
-    static EaseElasticOut* create(ActionInterval *action);
-
-    // Overrides
-    virtual void update(float time) override;
-    virtual EaseElasticOut* clone() const override;
-    virtual EaseElastic* reverse() const override;
-
-CC_CONSTRUCTOR_ACCESS:
-    EaseElasticOut() {}
-    virtual ~EaseElasticOut() {}
-
-private:
-    CC_DISALLOW_COPY_AND_ASSIGN(EaseElasticOut);
-};
-
-/** 
+using EaseElasticOut = EaseElasticTemplate<tweenfunc::elasticEaseOut>;
+/**
  @class EaseElasticInOut
  @brief Ease Elastic InOut action.
  @warning This action doesn't use a bijective function.
-          Actions like Sequence might have an unexpected result when used with this action.
+ Actions like Sequence might have an unexpected result when used with this action.
  @since v0.8.2
  @ingroup Actions
  */
-class CC_DLL EaseElasticInOut : public EaseElastic
-{
-public:
-    /** 
-     @brief Create the EaseElasticInOut action with the inner action and the period in radians.
-     @param action The pointer of the inner action.
-     @param period Period of the wave in radians.
-     @return A pointer of EaseElasticInOut action. If creation failed, return nil.
-    */
-    static EaseElasticInOut* create(ActionInterval *action, float period);
+using EaseElasticInOut = EaseElasticTemplate<tweenfunc::elasticEaseInOut>;
 
-    /** 
-     @brief Create the EaseElasticInOut action with the inner action and period value is 0.3.
-     @param action The pointer of the inner action.
-     @return A pointer of EaseElasticInOut action. If creation failed, return nil.
-    */
-    static EaseElasticInOut* create(ActionInterval *action);
 
-    // Overrides
-    virtual void update(float time) override;
-    virtual EaseElasticInOut* clone() const override;
-    virtual EaseElasticInOut* reverse() const override;
-
-CC_CONSTRUCTOR_ACCESS:
-    EaseElasticInOut() {}
-    virtual ~EaseElasticInOut() {}
-
-private:
-    CC_DISALLOW_COPY_AND_ASSIGN(EaseElasticInOut);
-};
-
-/** 
- @class EaseBounce
- @brief EaseBounce abstract class.
- @since v0.8.2
- @ingroup Actions
-*/
-class CC_DLL EaseBounce : public ActionEase
-{
-public:
-
-    // Overrides
-    virtual EaseBounce* clone() const override
-    {
-        CC_ASSERT(0);
-        return nullptr;
-    }
-
-    virtual EaseBounce* reverse() const override
-    {
-        CC_ASSERT(0);
-        return nullptr;
-    }
-
-CC_CONSTRUCTOR_ACCESS:
-    EaseBounce() {}
-    virtual ~EaseBounce() {}
-
-private:
-    CC_DISALLOW_COPY_AND_ASSIGN(EaseBounce);
-};
-
-/** 
- @class EaseBounceIn
- @brief EaseBounceIn action.
- @warning This action doesn't use a bijective function.
-          Actions like Sequence might have an unexpected result when used with this action.
- @since v0.8.2
- @ingroup Actions
-*/
-class CC_DLL EaseBounceIn : public EaseBounce
-{
-public:
-    /** 
-     @brief Create the action with the inner action.
-     @param action The pointer of the inner action.
-     @return A pointer of EaseBounceIn action. If creation failed, return nil.
-    */
-    static EaseBounceIn* create(ActionInterval* action);
-
-    // Overrides
-    virtual void update(float time) override;
-    virtual EaseBounceIn* clone() const override;
-    virtual EaseBounce* reverse() const override;
-
-CC_CONSTRUCTOR_ACCESS:
-    EaseBounceIn() {}
-    virtual ~EaseBounceIn() {}
-
-private:
-    CC_DISALLOW_COPY_AND_ASSIGN(EaseBounceIn);
-};
-
-/** 
- @class EaseBounceOut
- @brief EaseBounceOut action.
- @warning This action doesn't use a bijective function.
-          Actions like Sequence might have an unexpected result when used with this action.
- @since v0.8.2
+/**
+ @class EaseBezierAction
+ @brief Ease Bezier
  @ingroup Actions
  */
-class CC_DLL EaseBounceOut : public EaseBounce
+class EaseBezierAction : public cocos2d::ActionEase
 {
 public:
-    /** 
-     @brief Create the action with the inner action.
-     @param action The pointer of the inner action.
-     @return A pointer of EaseBounceOut action. If creation failed, return nil.
-    */
-    static EaseBounceOut* create(ActionInterval* action);
-
-    // Overrides
-    virtual void update(float time) override;
-    virtual EaseBounceOut* clone() const override;
-    virtual EaseBounce* reverse() const override;
-
-CC_CONSTRUCTOR_ACCESS:
-    EaseBounceOut() {}
-    virtual ~EaseBounceOut() {}
-
-private:
-    CC_DISALLOW_COPY_AND_ASSIGN(EaseBounceOut);
-};
-
-/** 
- @class EaseBounceInOut
- @brief EaseBounceInOut action.
- @warning This action doesn't use a bijective function.
-          Actions like Sequence might have an unexpected result when used with this action.
- @since v0.8.2
- @ingroup Actions
- */
-class CC_DLL EaseBounceInOut : public EaseBounce
-{
-public:
-    /** 
-     @brief Create the action with the inner action.
-     @param action The pointer of the inner action.
-     @return A pointer of EaseBounceInOut action. If creation failed, return nil.
-    */
-    static EaseBounceInOut* create(ActionInterval* action);
-
-    // Overrides
-    virtual void update(float time) override;
-    virtual EaseBounceInOut* clone() const override;
-    virtual EaseBounceInOut* reverse() const override;
-
-CC_CONSTRUCTOR_ACCESS:
-    EaseBounceInOut() {}
-    virtual ~EaseBounceInOut() {}
-
-private:
-    CC_DISALLOW_COPY_AND_ASSIGN(EaseBounceInOut);
-};
-
-/** 
- @class EaseBackIn
- @brief EaseBackIn action.
- @warning This action doesn't use a bijective function.
-          Actions like Sequence might have an unexpected result when used with this action.
- @since v0.8.2
- @ingroup Actions
- */
-class CC_DLL EaseBackIn : public ActionEase
-{
-public:
-    /** 
-     @brief Create the action with the inner action.
-     @param action The pointer of the inner action.
-     @return A pointer of EaseBackIn action. If creation failed, return nil.
-    */
-    static EaseBackIn* create(ActionInterval* action);
-
-    // Overrides
-    virtual void update(float time) override;
-    virtual EaseBackIn* clone() const override;
-    virtual ActionEase* reverse() const override;
-
-CC_CONSTRUCTOR_ACCESS:
-    EaseBackIn() {}
-    virtual ~EaseBackIn() {}
-
-private:
-    CC_DISALLOW_COPY_AND_ASSIGN(EaseBackIn);
-};
-
-/** 
- @class EaseBackOut
- @brief EaseBackOut action.
- @warning This action doesn't use a bijective function.
-          Actions like Sequence might have an unexpected result when used with this action.
- @since v0.8.2
- @ingroup Actions
- */
-class CC_DLL EaseBackOut : public ActionEase
-{
-public:
-    /** 
-     @brief Create the action with the inner action.
-     @param action The pointer of the inner action.
-     @return A pointer of EaseBackOut action. If creation failed, return nil.
-    */
-    static EaseBackOut* create(ActionInterval* action);
-
-    // Overrides
-    virtual void update(float time) override;
-    virtual EaseBackOut* clone() const override;
-    virtual ActionEase* reverse() const override;
-
-CC_CONSTRUCTOR_ACCESS:
-    EaseBackOut() {}
-    virtual ~EaseBackOut() {}
-
-private:
-    CC_DISALLOW_COPY_AND_ASSIGN(EaseBackOut);
-};
-
-/** 
- @class EaseBackInOut
- @brief EaseBackInOut action.
- @warning This action doesn't use a bijective function.
-          Actions like Sequence might have an unexpected result when used with this action.
- @since v0.8.2
- @ingroup Actions
- */
-class CC_DLL EaseBackInOut : public ActionEase
-{
-public:
-    /** 
-     @brief Create the action with the inner action.
-     @param action The pointer of the inner action.
-     @return A pointer of EaseBackInOut action. If creation failed, return nil.
-    */
-    static EaseBackInOut* create(ActionInterval* action);
-
-    // Overrides
-    virtual void update(float time) override;
-    virtual EaseBackInOut* clone() const override;
-    virtual EaseBackInOut* reverse() const override;
-
-CC_CONSTRUCTOR_ACCESS:
-    EaseBackInOut() {}
-    virtual ~EaseBackInOut() {}
-
-private:
-    CC_DISALLOW_COPY_AND_ASSIGN(EaseBackInOut);
-};
-
-
-/** 
-@class EaseBezierAction
-@brief Ease Bezier
-@ingroup Actions
-*/
-class CC_DLL EaseBezierAction : public ActionEase
-{
-public:
-    /** 
+    /**
      @brief Create the action with the inner action.
      @param action The pointer of the inner action.
      @return A pointer of EaseBezierAction action. If creation failed, return nil.
     */
-    static EaseBezierAction* create(ActionInterval* action);
-    
+    static EaseBezierAction* create(cocos2d::ActionInterval* action);
+
     virtual void update(float time) override;
     virtual EaseBezierAction* clone() const override;
     virtual EaseBezierAction* reverse() const override;
 
     /**
-    @brief Set the bezier parameters.
+     @brief Set the bezier parameters.
     */
     virtual void setBezierParamer( float p0, float p1, float p2, float p3);
 
@@ -861,414 +589,6 @@ protected:
 
 private:
     CC_DISALLOW_COPY_AND_ASSIGN(EaseBezierAction);
-};
-
-/** 
-@class EaseQuadraticActionIn
-@brief Ease Quadratic In
-@ingroup Actions
-*/
-class CC_DLL EaseQuadraticActionIn : public ActionEase
-{
-public:
-    /** 
-     @brief Create the action with the inner action.
-     @param action The pointer of the inner action.
-     @return A pointer of EaseQuadraticActionIn action. If creation failed, return nil.
-    */
-    static EaseQuadraticActionIn* create(ActionInterval* action);
-    
-    virtual void update(float time) override;
-    virtual EaseQuadraticActionIn* clone() const override;
-    virtual EaseQuadraticActionIn* reverse() const override;
-
-CC_CONSTRUCTOR_ACCESS:
-    EaseQuadraticActionIn() {}
-    virtual ~EaseQuadraticActionIn() {}
-
-private:
-    CC_DISALLOW_COPY_AND_ASSIGN(EaseQuadraticActionIn);
-
-};
-
-/** 
-@class EaseQuadraticActionOut
-@brief Ease Quadratic Out
-@ingroup Actions
-*/
-class CC_DLL EaseQuadraticActionOut : public ActionEase
-{
-public:
-    /** 
-     @brief Create the action with the inner action.
-     @param action The pointer of the inner action.
-     @return A pointer of EaseQuadraticActionOut action. If creation failed, return nil.
-    */
-    static EaseQuadraticActionOut* create(ActionInterval* action);
-    
-    virtual void update(float time) override;
-    virtual EaseQuadraticActionOut* clone() const override;
-    virtual EaseQuadraticActionOut* reverse() const override;
-
-CC_CONSTRUCTOR_ACCESS:
-    EaseQuadraticActionOut() {}
-    virtual ~EaseQuadraticActionOut() {}
-
-private:
-    CC_DISALLOW_COPY_AND_ASSIGN(EaseQuadraticActionOut);
-
-};
-
-/** 
-@class EaseQuadraticActionInOut
-@brief Ease Quadratic InOut
-@ingroup Actions
-*/
-class CC_DLL EaseQuadraticActionInOut : public ActionEase
-{
-public:
-    /** 
-     @brief Create the action with the inner action.
-     @param action The pointer of the inner action.
-     @return A pointer of EaseQuadraticActionInOut action. If creation failed, return nil.
-    */
-    static EaseQuadraticActionInOut* create(ActionInterval* action);
-    
-    virtual void update(float time) override;
-    virtual EaseQuadraticActionInOut* clone() const override;
-    virtual EaseQuadraticActionInOut* reverse() const override;
-
-CC_CONSTRUCTOR_ACCESS:
-    EaseQuadraticActionInOut() {}
-    virtual ~EaseQuadraticActionInOut() {}
-
-private:
-    CC_DISALLOW_COPY_AND_ASSIGN(EaseQuadraticActionInOut);
-};
-
-/** 
-@class EaseQuarticActionIn
-@brief Ease Quartic In
-@ingroup Actions
-*/
-class CC_DLL EaseQuarticActionIn : public ActionEase
-{
-public:
-    /** 
-     @brief Create the action with the inner action.
-     @param action The pointer of the inner action.
-     @return A pointer of EaseQuarticActionIn action. If creation failed, return nil.
-    */
-    static EaseQuarticActionIn* create(ActionInterval* action);
-    
-    virtual void update(float time) override;
-    virtual EaseQuarticActionIn* clone() const override;
-    virtual EaseQuarticActionIn* reverse() const override;
-
-CC_CONSTRUCTOR_ACCESS:
-    EaseQuarticActionIn() {}
-    virtual ~EaseQuarticActionIn() {}
-
-private:
-    CC_DISALLOW_COPY_AND_ASSIGN(EaseQuarticActionIn);
-};
-
-/** 
-@class EaseQuarticActionOut
-@brief Ease Quartic Out
-@ingroup Actions
-*/
-class CC_DLL EaseQuarticActionOut : public ActionEase
-{
-public:
-    /** 
-     @brief Create the action with the inner action.
-     @param action The pointer of the inner action.
-     @return A pointer of EaseQuarticActionOut action. If creation failed, return nil.
-    */
-    static EaseQuarticActionOut* create(ActionInterval* action);
-    
-    virtual void update(float time) override;
-    virtual EaseQuarticActionOut* clone() const override;
-    virtual EaseQuarticActionOut* reverse() const override;
-
-CC_CONSTRUCTOR_ACCESS:
-    EaseQuarticActionOut() {}
-    virtual ~EaseQuarticActionOut() {}
-
-private:
-    CC_DISALLOW_COPY_AND_ASSIGN(EaseQuarticActionOut);
-};
-
-/** 
-@class EaseQuarticActionInOut
-@brief Ease Quartic InOut
-@ingroup Actions
-*/
-class CC_DLL EaseQuarticActionInOut : public ActionEase
-{
-public:
-    /** 
-     @brief Create the action with the inner action.
-     @param action The pointer of the inner action.
-     @return A pointer of EaseQuarticActionInOut action. If creation failed, return nil.
-    */
-    static EaseQuarticActionInOut* create(ActionInterval* action);
-    
-    virtual void update(float time) override;
-    virtual EaseQuarticActionInOut* clone() const override;
-    virtual EaseQuarticActionInOut* reverse() const override;
-
-CC_CONSTRUCTOR_ACCESS:
-    EaseQuarticActionInOut() {}
-    virtual ~EaseQuarticActionInOut() {}
-
-private:
-    CC_DISALLOW_COPY_AND_ASSIGN(EaseQuarticActionInOut);
-};
-
-
-/** 
-@class EaseQuinticActionIn
-@brief Ease Quintic In
-@ingroup Actions
-*/
-class CC_DLL EaseQuinticActionIn : public ActionEase
-{
-public:
-    /** 
-     @brief Create the action with the inner action.
-     @param action The pointer of the inner action.
-     @return A pointer of EaseQuinticActionIn action. If creation failed, return nil.
-    */
-    static EaseQuinticActionIn* create(ActionInterval* action);
-    
-    virtual void update(float time) override;
-    virtual EaseQuinticActionIn* clone() const override;
-    virtual EaseQuinticActionIn* reverse() const override;
-
-CC_CONSTRUCTOR_ACCESS:
-    EaseQuinticActionIn() {}
-    virtual ~EaseQuinticActionIn() {}
-
-private:
-    CC_DISALLOW_COPY_AND_ASSIGN(EaseQuinticActionIn);
-};
-
-/** 
-@class EaseQuinticActionOut
-@brief Ease Quintic Out
-@ingroup Actions
-*/
-class CC_DLL EaseQuinticActionOut : public ActionEase
-{
-public:
-    /** 
-     @brief Create the action with the inner action.
-     @param action The pointer of the inner action.
-     @return A pointer of EaseQuinticActionOut action. If creation failed, return nil.
-    */
-    static EaseQuinticActionOut* create(ActionInterval* action);
-    
-    virtual void update(float time) override;
-    virtual EaseQuinticActionOut* clone() const override;
-    virtual EaseQuinticActionOut* reverse() const override;
-
-CC_CONSTRUCTOR_ACCESS:
-    EaseQuinticActionOut() {}
-    virtual ~EaseQuinticActionOut() {}
-
-private:
-    CC_DISALLOW_COPY_AND_ASSIGN(EaseQuinticActionOut);
-};
-
-/** 
-@class EaseQuinticActionInOut
-@brief Ease Quintic InOut
-@ingroup Actions
-*/
-class CC_DLL EaseQuinticActionInOut : public ActionEase
-{
-public:
-    /** 
-     @brief Create the action with the inner action.
-     @param action The pointer of the inner action.
-     @return A pointer of EaseQuinticActionInOut action. If creation failed, return nil.
-    */
-    static EaseQuinticActionInOut* create(ActionInterval* action);
-    
-    virtual void update(float time) override;
-    virtual EaseQuinticActionInOut* clone() const override;
-    virtual EaseQuinticActionInOut* reverse() const override;
-
-CC_CONSTRUCTOR_ACCESS:
-    EaseQuinticActionInOut() {}
-    virtual ~EaseQuinticActionInOut() {}
-
-private:
-    CC_DISALLOW_COPY_AND_ASSIGN(EaseQuinticActionInOut);
-};
-
-/** 
-@class EaseCircleActionIn
-@brief Ease Circle In
-@ingroup Actions
-*/
-class CC_DLL EaseCircleActionIn : public ActionEase
-{
-public:
-    /** 
-     @brief Create the action with the inner action.
-     @param action The pointer of the inner action.
-     @return A pointer of EaseCircleActionIn action. If creation failed, return nil.
-    */
-    static EaseCircleActionIn* create(ActionInterval* action);
-    
-    virtual void update(float time) override;
-    virtual EaseCircleActionIn* clone() const override;
-    virtual EaseCircleActionIn* reverse() const override;
-
-CC_CONSTRUCTOR_ACCESS:
-    EaseCircleActionIn() {}
-    virtual ~EaseCircleActionIn() {}
-
-private:
-    CC_DISALLOW_COPY_AND_ASSIGN(EaseCircleActionIn);
-};
-
-/** 
-@class EaseCircleActionOut
-@brief Ease Circle Out
-@ingroup Actions
-*/
-class CC_DLL EaseCircleActionOut : public ActionEase
-{
-public:
-    /** 
-     @brief Create the action with the inner action.
-     @param action The pointer of the inner action.
-     @return A pointer of EaseCircleActionOut action. If creation failed, return nil.
-    */
-    static EaseCircleActionOut* create(ActionInterval* action);
-    
-    virtual void update(float time) override;
-    virtual EaseCircleActionOut* clone() const override;
-    virtual EaseCircleActionOut* reverse() const override;
-
-CC_CONSTRUCTOR_ACCESS:
-    EaseCircleActionOut() {}
-    virtual ~EaseCircleActionOut() {}
-
-private:
-    CC_DISALLOW_COPY_AND_ASSIGN(EaseCircleActionOut);
-};
-
-/** 
-@class EaseCircleActionInOut
-@brief Ease Circle InOut
-@ingroup Actions
-*/
-class CC_DLL EaseCircleActionInOut:public ActionEase
-{
-public:
-    /** 
-     @brief Create the action with the inner action.
-     @param action The pointer of the inner action.
-     @return A pointer of EaseCircleActionInOut action. If creation failed, return nil.
-    */
-    static EaseCircleActionInOut* create(ActionInterval* action);
-    
-    virtual void update(float time) override;
-    virtual EaseCircleActionInOut* clone() const override;
-    virtual EaseCircleActionInOut* reverse() const override;
-
-CC_CONSTRUCTOR_ACCESS:
-    EaseCircleActionInOut() {}
-    virtual ~EaseCircleActionInOut() {}
-
-private:
-    CC_DISALLOW_COPY_AND_ASSIGN(EaseCircleActionInOut);
-};
-
-/** 
-@class EaseCubicActionIn
-@brief Ease Cubic In
-@ingroup Actions
-*/
-class CC_DLL EaseCubicActionIn:public ActionEase
-{
-public:
-    /** 
-     @brief Create the action with the inner action.
-     @param action The pointer of the inner action.
-     @return A pointer of EaseCubicActionIn action. If creation failed, return nil.
-    */
-    static EaseCubicActionIn* create(ActionInterval* action);
-    
-    virtual void update(float time) override;
-    virtual EaseCubicActionIn* clone() const override;
-    virtual EaseCubicActionIn* reverse() const override;
-
-CC_CONSTRUCTOR_ACCESS:
-    EaseCubicActionIn() {}
-    virtual ~EaseCubicActionIn() {}
-
-private:
-    CC_DISALLOW_COPY_AND_ASSIGN(EaseCubicActionIn);
-};
-
-/** 
-@class EaseCubicActionOut
-@brief Ease Cubic Out
-@ingroup Actions
-*/
-class CC_DLL EaseCubicActionOut : public ActionEase
-{
-public:
-    /** 
-     @brief Create the action with the inner action.
-     @param action The pointer of the inner action.
-     @return A pointer of EaseCubicActionOut action. If creation failed, return nil.
-    */
-    static EaseCubicActionOut* create(ActionInterval* action);
-    
-    virtual void update(float time) override;
-    virtual EaseCubicActionOut* clone() const override;
-    virtual EaseCubicActionOut* reverse() const override;
-
-CC_CONSTRUCTOR_ACCESS:
-    EaseCubicActionOut() {}
-    virtual ~EaseCubicActionOut() {}
-
-private:
-    CC_DISALLOW_COPY_AND_ASSIGN(EaseCubicActionOut);
-};
-
-/** 
-@class EaseCubicActionInOut
-@brief Ease Cubic InOut
-@ingroup Actions
-*/
-class CC_DLL EaseCubicActionInOut : public ActionEase
-{
-public:
-    /** 
-     @brief Create the action with the inner action.
-     @param action The pointer of the inner action.
-     @return A pointer of EaseCubicActionInOut action. If creation failed, return nil.
-    */
-    static EaseCubicActionInOut* create(ActionInterval* action);
-    
-    virtual void update(float time) override;
-    virtual EaseCubicActionInOut* clone() const override;
-    virtual EaseCubicActionInOut* reverse() const override;
-
-CC_CONSTRUCTOR_ACCESS:
-    EaseCubicActionInOut() {}
-    virtual ~EaseCubicActionInOut() {}
-
-private:
-    CC_DISALLOW_COPY_AND_ASSIGN(EaseCubicActionInOut);
 };
 
 // end of actions group

--- a/cocos/2d/CCActionEase.h
+++ b/cocos/2d/CCActionEase.h
@@ -28,7 +28,7 @@ THE SOFTWARE.
 #define __ACTION_CCEASE_ACTION_H__
 
 #include "2d/CCActionInterval.h"
-#include "CCTweenFunction.h"
+#include "2d/CCTweenFunction.h"
 
 #define EASE_MACRO_COMMA ,
 


### PR DESCRIPTION
Duplicated Jakz PR to maybe get into 3.13 since it appears to be inactive since April.

I'm also thinking that maybe there could be a more generic data driven Action refactor where there's only one or a couple actual functions instead of the many functions that currently exist. This may not be as performant, however, so will have to test out an idea or two and I'll post discussion on forum first if I implement something.

Original PR Desc:

> Rewrote all action ease classes using templates to remove the redundancy of having a single class definition for every possible ease function. This has been done through some template classes which accept functions as arguments.
> 
> This makes both header and source file much shorter and much more maintanable. Readability shouldn't be a concern since now there is almost no code to read.
> 
> Performance should identical since everything is bound at compile time. The following patch should be compatible with all recent (C++11) compilers but I have no way to test it, I tested it on LLVM3.4 on a OS X machine.
> 
> This patch also gives the possiblity to have ready to go custom ease function without the need to sublass ActionEase at all (as long as the prototype of the function is supported).
