### PR TITLE
fix label text formatter right alignment

### DIFF
--- a/cocos/2d/CCLabelTextFormatter.cpp
+++ b/cocos/2d/CCLabelTextFormatter.cpp
@@ -218,7 +218,7 @@ bool Label::multilineTextWrap(std::function<int(const std::u16string&, int, int)
                     nextLetterX += _horizontalKernings[letterIndex + 1];
                 nextLetterX += letterDef.xAdvance * _bmfontScale + _additionalKerning;
 
-                tokenRight = letterPosition.x + letterDef.width * _bmfontScale;
+                tokenRight = nextLetterX / contentScaleFactor;
             }
             nextChangeSize = true;
 


### PR DESCRIPTION
Current text formatter for label looks weird when label's alignment is set to right.

``` cpp
  auto label = Label::createWithBMFont(fontFilePath, "");
  label->setAlignment(cocos2d::TextHAlignment::RIGHT);
  label->setColor(cocos2d::Color3B::WHITE);
  label->setString("0000000000\n1111111111\n0101010101");
  addChild(label);
```

This PR changes to use the beginning of the next letter when determining the width of a line, so that right alignment does not look weird anymore.

Before:
![img_0831](https://cloud.githubusercontent.com/assets/2549967/16981434/912294e0-4ea5-11e6-9c49-fb2f6a925141.PNG)

After:
![img_0830](https://cloud.githubusercontent.com/assets/2549967/16981432/8e07b36c-4ea5-11e6-8a1f-44e035a12d49.PNG)
