### PR TITLE
Fix typo in constant name

### DIFF
--- a/cocos/renderer/CCRenderer.cpp
+++ b/cocos/renderer/CCRenderer.cpp
@@ -215,7 +215,7 @@ Renderer::Renderer()
     
     RenderQueue defaultRenderQueue;
     _renderGroups.push_back(defaultRenderQueue);
-    _queuedTriangleCommands.reserve(BATCH_TRIAGCOMMAND_RESEVER_SIZE);
+    _queuedTriangleCommands.reserve(BATCH_TRIAGCOMMAND_RESERVED_SIZE);
 
     // default clear color
     _clearColor = Color4F::BLACK;

--- a/cocos/renderer/CCRenderer.h
+++ b/cocos/renderer/CCRenderer.h
@@ -144,8 +144,8 @@ public:
     static const int VBO_SIZE = 65536;
     /**The max number of indices in a index buffer.*/
     static const int INDEX_VBO_SIZE = VBO_SIZE * 6 / 4;
-    /**The rendercommands which can be batched will be saved into a list, this is the reversed size of this list.*/
-    static const int BATCH_TRIAGCOMMAND_RESEVER_SIZE = 64;
+    /**The rendercommands which can be batched will be saved into a list, this is the reserved size of this list.*/
+    static const int BATCH_TRIAGCOMMAND_RESERVED_SIZE = 64;
     /**Reserved for material id, which means that the command could not be batched.*/
     static const int MATERIAL_ID_DO_NOT_BATCH = 0;
     /**Constructor.*/


### PR DESCRIPTION
Hi, this PR fixes spelling mistakes I found while reading. I guess `BATCH_TRIAGCOMMAND_RESEVER_SIZE` should be `BATCH_TRIAGCOMMAND_RESERVED_SIZE` (or `BATCH_TRIAGCOMMAND_RESERVE_SIZE`).

Thanks!
