### PR TITLE
Fix bugs with music not resuming when iOS app is reactivated

### DIFF
--- a/cocos/audio/ios/CDAudioManager.m
+++ b/cocos/audio/ios/CDAudioManager.m
@@ -644,7 +644,7 @@ static BOOL configured = FALSE;
         case kAMRBStopPlay:
             
             for( CDLongAudioSource *audioSource in audioSourceChannels) {
-                if (!audioSystem->systemPaused) {
+                if (!audioSource->systemPaused) {
                     if (audioSource.isPlaying) {
                         audioSource->systemPaused = YES;
                         audioSource->systemPauseLocation = audioSource.audioSourcePlayer.currentTime;

--- a/cocos/audio/ios/CDAudioManager.m
+++ b/cocos/audio/ios/CDAudioManager.m
@@ -647,7 +647,7 @@ static BOOL configured = FALSE;
                 if (audioSource.isPlaying) {
                     audioSource->systemPaused = YES;
                     audioSource->systemPauseLocation = audioSource.audioSourcePlayer.currentTime;
-                    [audioSource stop];
+                    [audioSource pause];
                 } else {
                     //Music is either paused or stopped, if it is paused it will be restarted
                     //by OS so we will stop it.

--- a/cocos/audio/ios/CDAudioManager.m
+++ b/cocos/audio/ios/CDAudioManager.m
@@ -644,15 +644,17 @@ static BOOL configured = FALSE;
         case kAMRBStopPlay:
             
             for( CDLongAudioSource *audioSource in audioSourceChannels) {
-                if (audioSource.isPlaying) {
-                    audioSource->systemPaused = YES;
-                    audioSource->systemPauseLocation = audioSource.audioSourcePlayer.currentTime;
-                    [audioSource pause];
-                } else {
-                    //Music is either paused or stopped, if it is paused it will be restarted
-                    //by OS so we will stop it.
-                    audioSource->systemPaused = NO;
-                    [audioSource stop];
+                if (!audioSystem->systemPaused) {
+                    if (audioSource.isPlaying) {
+                        audioSource->systemPaused = YES;
+                        audioSource->systemPauseLocation = audioSource.audioSourcePlayer.currentTime;
+                        [audioSource pause];
+                    } else {
+                        //Music is either paused or stopped, if it is paused it will be restarted
+                        //by OS so we will stop it.
+                        audioSource->systemPaused = NO;
+                        [audioSource stop];
+                    }
                 }
             }
             break;


### PR DESCRIPTION
The audio manager's automatic resign/active behaviour aims to pause the music when the app goes to the background, and resume it again when it comes back to the foreground.

This used to work in older versions of cocos, but appears to have been broken by https://github.com/cocos2d/cocos2d-x/commit/26a04b38f2bd879d5705b38f55470f9fd9423df6

This change pauses instead of stops the music on resign.

The [audioSource stop] causes the music to be stopped, and therefore it fails to resume later on a call to [audioSource resume], due to the addition of the if (!stopped) check in resume added in https://github.com/cocos2d/cocos2d-x/commit/26a04b38f2bd879d5705b38f55470f9fd9423df6
