### PR TITLE
Fix typos in documentation and comments

### DIFF
--- a/cocos/2d/CCFontFNT.cpp
+++ b/cocos/2d/CCFontFNT.cpp
@@ -381,7 +381,7 @@ std::set<unsigned int>* BMFontConfiguration::parseBinaryConfigFile(unsigned char
         {
             /*
              fontSize       2   int      0
-             bitField       1   bits     2  bit 0: smooth, bit 1: unicode, bit 2: italic, bit 3: bold, bit 4: fixedHeigth, bits 5-7: reserved
+             bitField       1   bits     2  bit 0: smooth, bit 1: unicode, bit 2: italic, bit 3: bold, bit 4: fixedHeight, bits 5-7: reserved
              charSet        1   uint     3
              stretchH       2   uint     4
              aa             1   uint     6

--- a/cocos/audio/android/AudioDecoder.cpp
+++ b/cocos/audio/android/AudioDecoder.cpp
@@ -44,7 +44,7 @@ namespace cocos2d { namespace experimental {
  *  */
 #define PCM_METADATA_VALUE_SIZE 32
 
-/* used to detect errors likely to have occured when the OpenSL ES framework fails to open
+/* used to detect errors likely to have occurred when the OpenSL ES framework fails to open
  * a resource, for instance because a file URI is invalid, or an HTTP server doesn't respond.
  */
 #define PREFETCHEVENT_ERROR_CANDIDATE (SL_PREFETCHEVENT_STATUSCHANGE | SL_PREFETCHEVENT_FILLLEVELCHANGE)

--- a/cocos/audio/android/AudioResampler.cpp
+++ b/cocos/audio/android/AudioResampler.cpp
@@ -548,7 +548,7 @@ resampleMono16_exit:
 *       vl, vr : left and right gain
 *       phaseFraction : pointer on current phase fraction
 *       phaseIncrement
-*   Ouput:
+*   Output:
 *       outputIndex :
 *       out : updated buffer
 *       inputIndex : index of next to use
@@ -669,7 +669,7 @@ void AudioResamplerOrder1::AsmMono16Loop(int16_t *in, int32_t* maxOutPt, int32_t
 *       vl, vr : left and right gain
 *       phaseFraction : pointer on current phase fraction
 *       phaseIncrement
-*   Ouput:
+*   Output:
 *       outputIndex :
 *       out : updated buffer
 *       inputIndex : index of next to use

--- a/cocos/audio/android/CCThreadPool.h
+++ b/cocos/audio/android/CCThreadPool.h
@@ -82,7 +82,7 @@ public:
     static ThreadPool *newFixedThreadPool(int threadNum);
 
     /*
-     * Creates a thread pool with only one thread in the pool, it could be used to exeute multipy tasks serially in just one thread.
+     * Creates a thread pool with only one thread in the pool, it could be used to execute multiply tasks serially in just one thread.
      * @note The return value has to be delete while it doesn't needed
      */
     static ThreadPool *newSingleThreadPool();
@@ -123,7 +123,7 @@ public:
 
     /* 
      * Trys to shrink pool
-     * @note This method is only avaiable for cached thread pool
+     * @note This method is only available for cached thread pool
      */
     bool tryShrinkPool();
 

--- a/cocos/audio/android/UrlAudioPlayer.cpp
+++ b/cocos/audio/android/UrlAudioPlayer.cpp
@@ -287,7 +287,7 @@ bool UrlAudioPlayer::prepare(const std::string &url, SLuint32 locatorType, std::
     // Although locFd & locUri are only used inside if/else block, its lifecycle
     // will be destroyed right after '}' block. And since we pass a pointer to
     // 'audioSrc.pLocator=&locFd/&locUri', pLocator will point to an invalid address
-    // while invoking Engine::createAudioPlayer interface. So be care of change the postion
+    // while invoking Engine::createAudioPlayer interface. So be care of change the position
     // of these two variables.
     SLDataLocator_AndroidFD locFd;
     SLDataLocator_URI locUri;

--- a/cocos/audio/android/audio.h
+++ b/cocos/audio/android/audio.h
@@ -121,7 +121,7 @@ typedef enum {
  * indicates options and parameters for each format. The sub format is mainly
  * used for record to indicate for instance the requested bitrate or profile.
  * It can also be used for certain formats to give informations not present in
- * the encoded audio stream (e.g. octet alignement for AMR).
+ * the encoded audio stream (e.g. octet alignment for AMR).
  */
 typedef enum {
     AUDIO_FORMAT_INVALID             = 0xFFFFFFFFUL,

--- a/cocos/cocos2d.h
+++ b/cocos/cocos2d.h
@@ -307,7 +307,7 @@ THE SOFTWARE.
 
 // Deprecated
 // All deprecated features are include inside deprecated/CCDeprecated.h.
-// It is recommanded that you just inlcude what is needed.
+// It is recommended that you just include what is needed.
 // eg. #include "deprecated/CCString.h" if you only need cocos2d::__String.
 #include "deprecated/CCDeprecated.h"
 

--- a/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxEditBoxHelper.java
+++ b/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxEditBoxHelper.java
@@ -258,7 +258,7 @@ public class Cocos2dxEditBoxHelper {
                     }else{
                         tf = Typeface.DEFAULT;
                     }
-                    //TODO: The font size is not the same across all the anroid devices...
+                    // TODO: The font size is not the same across all the android devices...
                     if (fontSize >= 0){
                         float density =  mCocos2dxActivity.getResources().getDisplayMetrics().density;
 //                        Log.e("XXX", "density is " + density);

--- a/cocos/renderer/CCGLProgram.h
+++ b/cocos/renderer/CCGLProgram.h
@@ -507,7 +507,7 @@ protected:
     Update the uniform data in location.
     @param location The location of the uniform.
     @param data Updated data.
-    @oaram bytes Data length in bytes to update.
+    @param bytes Data length in bytes to update.
     */
     bool updateUniformLocation(GLint location, const GLvoid* data, unsigned int bytes);
     /**Get a general description of the shader.*/

--- a/cocos/scripting/lua-bindings/manual/lua_module_register.cpp
+++ b/cocos/scripting/lua-bindings/manual/lua_module_register.cpp
@@ -15,7 +15,7 @@
 
 int lua_module_register(lua_State* L)
 {
-    //Dont' change the module register order unless you know what your are doing
+    // Don't change the module register order unless you know what your are doing
     register_cocosdenshion_module(L);
     register_network_module(L);
     register_cocosbuilder_module(L);


### PR DESCRIPTION
This pull request fixes several minor typos/mistakes in documentation and comments. 
