### PR TITLE
fix: FPS appears again

### DIFF
--- a/cocos/base/CCDirector.cpp
+++ b/cocos/base/CCDirector.cpp
@@ -253,14 +253,6 @@ void Director::setGLDefaultValues()
     setAlphaBlending(true);
     setDepthTest(false);
     setProjection(_projection);
-
-    // Everything should be drawn within `Scene::render()`.
-    // Otherwise it might not render correctly since the GL state might not be the correct one
-    // so the FPS should be part of Scene. But until we move them there, this little hack is to
-    // set the default glViewPort(), so that when `Scene::render()` exits, the viewport is the correct
-    // one for the FPS
-    auto vp = Camera::getDefaultViewport();
-    glViewport(vp._left, vp._bottom, vp._width, vp._height);
 }
 
 // Draw the Scene

--- a/cocos/platform/CCGLView.cpp
+++ b/cocos/platform/CCGLView.cpp
@@ -158,12 +158,19 @@ void GLView::updateDesignResolutionSize()
         float viewPortH = _designResolutionSize.height * _scaleY;
         
         _viewPortRect.setRect((_screenSize.width - viewPortW) / 2, (_screenSize.height - viewPortH) / 2, viewPortW, viewPortH);
-        
+
+
         // reset director's member variables to fit visible rect
         auto director = Director::getInstance();
         director->_winSizeInPoints = getDesignResolutionSize();
         director->_isStatusLabelUpdated = true;
         director->setProjection(director->getProjection());
+
+        // Github issue #16139
+        // A default viewport is needed in order to display the FPS,
+        // since the FPS are rendered in the Director, and there is no viewport there.
+        // Everything, including the FPS should renderer in the Scene.
+        glViewport(0, 0, _screenSize.width, _screenSize.height);
     }
 }
 

--- a/cocos/platform/desktop/CCGLViewImpl-desktop.cpp
+++ b/cocos/platform/desktop/CCGLViewImpl-desktop.cpp
@@ -432,9 +432,9 @@ bool GLViewImpl::initWithRect(const std::string& viewName, Rect rect, float fram
     // Enable point size by default.
     glEnable(GL_VERTEX_PROGRAM_POINT_SIZE);
 
-    // GLFW v3.2 no longer emits "onGLFWWindowSizeFunCallback" at creation time. Force default viewport:
-    setViewPortInPoints(0, 0, neededWidth, neededHeight);
-
+//    // GLFW v3.2 no longer emits "onGLFWWindowSizeFunCallback" at creation time. Force default viewport:
+//    setViewPortInPoints(0, 0, neededWidth, neededHeight);
+//
     return true;
 }
 


### PR DESCRIPTION
Sets default glviewport() when the GLView::updateDesignResolutionSize()
is called

github issue #16139
