### PR TITLE
Fix typos in variable names

### DIFF
--- a/cocos/3d/CCBillBoard.cpp
+++ b/cocos/3d/CCBillBoard.cpp
@@ -44,54 +44,54 @@ BillBoard::~BillBoard()
 
 BillBoard* BillBoard::createWithTexture(Texture2D *texture, Mode mode)
 {
-    BillBoard *billborad = new (std::nothrow) BillBoard();
-    if (billborad && billborad->initWithTexture(texture))
+    BillBoard *billboard = new (std::nothrow) BillBoard();
+    if (billboard && billboard->initWithTexture(texture))
     {
-        billborad->_mode = mode;
-        billborad->autorelease();
-        return billborad;
+        billboard->_mode = mode;
+        billboard->autorelease();
+        return billboard;
     }
-    CC_SAFE_DELETE(billborad);
+    CC_SAFE_DELETE(billboard);
     return nullptr;
 }
 
 
 BillBoard* BillBoard::create(const std::string& filename, Mode mode)
 {
-    BillBoard *billborad = new (std::nothrow) BillBoard();
-    if (billborad && billborad->initWithFile(filename))
+    BillBoard *billboard = new (std::nothrow) BillBoard();
+    if (billboard && billboard->initWithFile(filename))
     {
-        billborad->_mode = mode;
-        billborad->autorelease();
-        return billborad;
+        billboard->_mode = mode;
+        billboard->autorelease();
+        return billboard;
     }
-    CC_SAFE_DELETE(billborad);
+    CC_SAFE_DELETE(billboard);
     return nullptr;
 }
 
 BillBoard* BillBoard::create(const std::string& filename, const Rect& rect, Mode mode)
 {
-    BillBoard *billborad = new (std::nothrow) BillBoard();
-    if (billborad && billborad->initWithFile(filename, rect))
+    BillBoard *billboard = new (std::nothrow) BillBoard();
+    if (billboard && billboard->initWithFile(filename, rect))
     {
-        billborad->_mode = mode;
-        billborad->autorelease();
-        return billborad;
+        billboard->_mode = mode;
+        billboard->autorelease();
+        return billboard;
     }
-    CC_SAFE_DELETE(billborad);
+    CC_SAFE_DELETE(billboard);
     return nullptr;
 }
 
 BillBoard* BillBoard::create(Mode mode)
 {
-    BillBoard *billborad = new (std::nothrow) BillBoard();
-    if (billborad && billborad->init())
+    BillBoard *billboard = new (std::nothrow) BillBoard();
+    if (billboard && billboard->init())
     {
-        billborad->_mode = mode;
-        billborad->autorelease();
-        return billborad;
+        billboard->_mode = mode;
+        billboard->autorelease();
+        return billboard;
     }
-    CC_SAFE_DELETE(billborad);
+    CC_SAFE_DELETE(billboard);
     return nullptr;
 }
 

--- a/cocos/3d/CCBundle3D.cpp
+++ b/cocos/3d/CCBundle3D.cpp
@@ -98,10 +98,10 @@ void getChildMap(std::map<int, std::vector<int> >& map, SkinData* skinData, cons
 
     // get transform matrix
     Mat4 transform;
-    const rapidjson::Value& parent_tranform = val[OLDTRANSFORM];
-    for (rapidjson::SizeType j = 0; j < parent_tranform.Size(); j++)
+    const rapidjson::Value& parent_transform = val[OLDTRANSFORM];
+    for (rapidjson::SizeType j = 0; j < parent_transform.Size(); j++)
     {
-        transform.m[j] = parent_tranform[j].GetDouble();
+        transform.m[j] = parent_transform[j].GetDouble();
     }
 
     // set origin matrices

--- a/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxHandler.java
+++ b/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxHandler.java
@@ -73,7 +73,7 @@ public class Cocos2dxHandler extends Handler {
         Cocos2dxActivity theActivity = this.mActivity.get();
         DialogMessage dialogMessage = (DialogMessage)msg.obj;
         new AlertDialog.Builder(theActivity)
-        .setTitle(dialogMessage.titile)
+        .setTitle(dialogMessage.title)
         .setMessage(dialogMessage.message)
         .setPositiveButton("Ok", 
                 new DialogInterface.OnClickListener() {
@@ -92,11 +92,11 @@ public class Cocos2dxHandler extends Handler {
     // ===========================================================
     
     public static class DialogMessage {
-        public String titile;
+        public String title;
         public String message;
         
         public DialogMessage(String title, String message) {
-            this.titile = title;
+            this.title = title;
             this.message = message;
         }
     }

--- a/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxHttpURLConnection.java
+++ b/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxHttpURLConnection.java
@@ -389,15 +389,15 @@ public class Cocos2dxHttpURLConnection
 
     private static String str2Seconds(String strTime) {
         Calendar c = Calendar.getInstance();
-        long millisSecond = 0;
+        long milliseconds = 0;
 
         try {
             c.setTime(new SimpleDateFormat("EEE, dd-MMM-yy hh:mm:ss zzz", Locale.US).parse(strTime));
-            millisSecond = c.getTimeInMillis()/1000;
+            milliseconds = c.getTimeInMillis() / 1000;
         } catch (ParseException e) {
             Log.e("URLConnection exception", e.toString());
         }
 
-        return Long.toString(millisSecond);
+        return Long.toString(milliseconds);
     }
 }

--- a/cocos/platform/tizen/CCDevice-tizen.cpp
+++ b/cocos/platform/tizen/CCDevice-tizen.cpp
@@ -82,9 +82,9 @@ static void accelerometer_sensor_cb(sensor_h _sensor, sensor_event_s *sensor_dat
 
     double tmp = _acceleration->x;
     Application *app = Application::getInstance();
-    int oritentation = elm_win_rotation_get(app->_win);
+    int orientation = elm_win_rotation_get(app->_win);
 
-   switch (oritentation)
+    switch (orientation)
     {
     case 0:
         _acceleration->x = _acceleration->y;

--- a/cocos/ui/UIListView.cpp
+++ b/cocos/ui/UIListView.cpp
@@ -295,7 +295,7 @@ void ListView::addChild(Node* child, int zOrder, const std::string &name)
     }
 }
     
-void ListView::removeChild(cocos2d::Node *child, bool cleaup)
+void ListView::removeChild(cocos2d::Node *child, bool cleanup)
 {
     Widget* widget = dynamic_cast<Widget*>(child);
     if (nullptr != widget)
@@ -316,7 +316,7 @@ void ListView::removeChild(cocos2d::Node *child, bool cleaup)
         onItemListChanged();
     }
    
-    ScrollView::removeChild(child, cleaup);
+    ScrollView::removeChild(child, cleanup);
 }
     
 void ListView::removeAllChildren()

--- a/cocos/ui/UIListView.h
+++ b/cocos/ui/UIListView.h
@@ -268,7 +268,7 @@ public:
     virtual void addChild(Node* child, int zOrder, const std::string &name) override;
     virtual void removeAllChildren() override;
     virtual void removeAllChildrenWithCleanup(bool cleanup) override;
-    virtual void removeChild(Node* child, bool cleaup = true) override;
+    virtual void removeChild(Node* child, bool cleanup = true) override;
 
     /**
      * @brief Query the closest item to a specific position in inner container.

--- a/cocos/ui/UIScrollView.h
+++ b/cocos/ui/UIScrollView.h
@@ -352,7 +352,7 @@ public:
     virtual void addChild(Node* child, int localZOrder, const std::string &name) override;
     virtual void removeAllChildren() override;
     virtual void removeAllChildrenWithCleanup(bool cleanup) override;
-    virtual void removeChild(Node* child, bool cleaup = true) override;
+    virtual void removeChild(Node* child, bool cleanup = true) override;
     virtual Vector<Node*>& getChildren() override;
     virtual const Vector<Node*>& getChildren() const override;
     virtual ssize_t getChildrenCount() const override;

--- a/cocos/ui/UIWebViewImpl-ios.mm
+++ b/cocos/ui/UIWebViewImpl-ios.mm
@@ -359,13 +359,13 @@ void WebViewImpl::setScalesPageToFit(const bool scalesPageToFit) {
 void WebViewImpl::draw(cocos2d::Renderer *renderer, cocos2d::Mat4 const &transform, uint32_t flags) {
     if (flags & cocos2d::Node::FLAGS_TRANSFORM_DIRTY) {
         
-        auto direcrot = cocos2d::Director::getInstance();
-        auto glView = direcrot->getOpenGLView();
+        auto director = cocos2d::Director::getInstance();
+        auto glView = director->getOpenGLView();
         auto frameSize = glView->getFrameSize();
         
         auto scaleFactor = [static_cast<CCEAGLView *>(glView->getEAGLView()) contentScaleFactor];
 
-        auto winSize = direcrot->getWinSize();
+        auto winSize = director->getWinSize();
 
         auto leftBottom = this->_webView->convertToWorldSpace(cocos2d::Vec2::ZERO);
         auto rightTop = this->_webView->convertToWorldSpace(cocos2d::Vec2(this->_webView->getContentSize().width, this->_webView->getContentSize().height));

--- a/extensions/GUI/CCScrollView/CCScrollView.h
+++ b/extensions/GUI/CCScrollView/CCScrollView.h
@@ -259,7 +259,7 @@ public:
 
     virtual void removeAllChildren() override;
     virtual void removeAllChildrenWithCleanup(bool cleanup) override;
-    virtual void removeChild(Node* child, bool cleaup = true) override;
+    virtual void removeChild(Node* child, bool cleanup = true) override;
     /**
      * CCActionTweenDelegate
      */


### PR DESCRIPTION
This pull request fixes several spelling errors in variable names. It also doesn't break backwards compatibility. Thanks!
