### PR TITLE
fixed #16169: new android project crash in android 5.0.2 device (Nexus 7) when use 3.12

### DIFF
--- a/cocos/2d/CCFontAtlas.cpp
+++ b/cocos/2d/CCFontAtlas.cpp
@@ -265,7 +265,7 @@ void FontAtlas::findNewCharacters(const std::u16string& u16Text, std::unordered_
     //find new characters
     if (_letterDefinitions.empty())
     {
-        newChars = u16Text;
+        newChars.append(u16Text);
     }
     else
     {

--- a/cocos/2d/CCFontAtlas.cpp
+++ b/cocos/2d/CCFontAtlas.cpp
@@ -265,6 +265,19 @@ void FontAtlas::findNewCharacters(const std::u16string& u16Text, std::unordered_
     //find new characters
     if (_letterDefinitions.empty())
     {
+        // fixed #16169: new android project crash in android 5.0.2 device (Nexus 7) when use 3.12.
+        // While using clang compiler with gnustl_static on android, the copy assignment operator of `std::u16string`
+        // will affect the memory validity, it means after `newChars` is destroyed, the memory of `u16Text` holds
+        // will be a dead region. `u16text` represents the variable in `Label::_utf16Text`, when somewhere
+        // allocates memory by `malloc, realloc, new, new[]`, the generated memory address may be the same
+        // as `Label::_utf16Text` holds. If doing a `memset` or other memory operations, the orignal `Label::_utf16Text`
+        // will be in an unknown state. Meanwhile, a bunch lots of logic which depends on `Label::_utf16Text`
+        // will be broken.
+        
+        // newChars = u16Text;
+        
+        // Using `append` method is a workaround for this issue. So please be carefuly while using the assignment operator
+        // of `std::u16string`.
         newChars.append(u16Text);
     }
     else


### PR DESCRIPTION
While using clang compiler with gnustl_static on android, the copy assignment operator of `std::u16string` will affect the memory validity, it means after `newChars` is destroyed, the memory of `u16Text` holds will be a dead region. `u16text` represents the variable in `Label::_utf16Text`, when somewhere allocates memory by `malloc, realloc, new, new[]`, the generated memory address may be the same as `Label::_utf16Text` holds. If doing a `memset` or other memory operations, the orignal `Label::_utf16Text` will be in an unknown state. Meanwhile, a bunch lots of logic which depends on `Label::_utf16Text` will be broken.
