### PR TITLE
Remove unnecessary 'extern' to prevent compiler warnings

### DIFF
--- a/cocos/renderer/ccShader_ETC1AS_PositionTextureColor.frag
+++ b/cocos/renderer/ccShader_ETC1AS_PositionTextureColor.frag
@@ -23,7 +23,7 @@
  * THE SOFTWARE.
  */
 
-extern const char* ccETC1ASPositionTextureColor_frag = STRINGIFY(
+const char* ccETC1ASPositionTextureColor_frag = STRINGIFY(
 \n#ifdef GL_ES\n
     precision mediump float;
 \n#endif\n

--- a/cocos/renderer/ccShader_ETC1AS_PositionTextureGray.frag
+++ b/cocos/renderer/ccShader_ETC1AS_PositionTextureGray.frag
@@ -23,7 +23,7 @@
  * THE SOFTWARE.
  */
 
-extern const char* ccETC1ASPositionTextureGray_frag = STRINGIFY(
+const char* ccETC1ASPositionTextureGray_frag = STRINGIFY(
 \n#ifdef GL_ES\n
     precision mediump float;
 \n#endif\n


### PR DESCRIPTION
I get the following two warnings when compiling the latest v3 branch on Xcode 7.3.1 and Android NDK r11c (Clang):

```
cocos/renderer/ccShader_ETC1AS_PositionTextureColor.frag:26:20: 'extern' variable has an initializer [-Wextern-initializer]
cocos/renderer/ccShader_ETC1AS_PositionTextureGray.frag:26:20: 'extern' variable has an initializer [-Wextern-initializer]
```

and I have the same warnings when compiling with GCC on Linux:

```
cocos/renderer/ccShader_ETC1AS_PositionTextureColor.frag:26:20: warning: ‘ccETC1ASPositionTextureColor_frag’ initialized and declared ‘extern’
cocos/renderer/ccShader_ETC1AS_PositionTextureGray.frag:26:20: warning: ‘ccETC1ASPositionTextureGray_frag’ initialized and declared ‘extern’
```

This patch removes unnecessary `extern` keywords to prevent the warnings.
Thanks.
