### PR TITLE
fix CCImage premultipliedAlpha for ETC format

### DIFF
--- a/cocos/platform/CCImage.cpp
+++ b/cocos/platform/CCImage.cpp
@@ -466,7 +466,7 @@ Image::Image()
 , _fileType(Format::UNKNOWN)
 , _renderFormat(Texture2D::PixelFormat::NONE)
 , _numberOfMipmaps(0)
-, _hasPremultipliedAlpha(true)
+, _hasPremultipliedAlpha(false)
 {
 
 }
@@ -813,7 +813,6 @@ bool Image::decodeWithWIC(const unsigned char *data, ssize_t dataLen)
     {
         _width = img.getWidth();
         _height = img.getHeight();
-        _hasPremultipliedAlpha = false;
 
         WICPixelFormatGUID format = img.getPixelFormat();
 
@@ -963,7 +962,6 @@ bool Image::initWithJpgData(const unsigned char * data, ssize_t dataLen)
         /* init image info */
         _width  = cinfo.output_width;
         _height = cinfo.output_height;
-        _hasPremultipliedAlpha = false;
 
         _dataLen = cinfo.output_width*cinfo.output_height*cinfo.output_components;
         _data = static_cast<unsigned char*>(malloc(_dataLen * sizeof(unsigned char)));
@@ -1128,10 +1126,6 @@ bool Image::initWithPngData(const unsigned char * data, ssize_t dataLen)
         if (PNG_PREMULTIPLIED_ALPHA_ENABLED && color_type == PNG_COLOR_TYPE_RGB_ALPHA)
         {
             premultipliedAlpha();
-        }
-        else
-        {
-            _hasPremultipliedAlpha = false;
         }
 
         if (row_pointers != nullptr)
@@ -1583,8 +1577,6 @@ bool Image::initWithPVRv3Data(const unsigned char * data, ssize_t dataLen)
     {
         _hasPremultipliedAlpha = true;
     }
-    else
-        _hasPremultipliedAlpha = false;
     
     // sizing
     int width = CC_SWAP_INT32_LITTLE_TO_HOST(header->width);
@@ -1810,9 +1802,7 @@ bool Image::initWithTGAData(tImageTGA* tgaData)
         _data = tgaData->imageData;
         _dataLen = _width * _height * tgaData->pixelDepth / 8;
         _fileType = Format::TGA;
-        
-        _hasPremultipliedAlpha = false;
-        
+
         ret = true;
         
     }while(false);
@@ -1847,7 +1837,6 @@ namespace
 
 bool Image::initWithS3TCData(const unsigned char * data, ssize_t dataLen)
 {
-    _hasPremultipliedAlpha = false;
     const uint32_t FOURCC_DXT1 = makeFourCC('D', 'X', 'T', '1');
     const uint32_t FOURCC_DXT3 = makeFourCC('D', 'X', 'T', '3');
     const uint32_t FOURCC_DXT5 = makeFourCC('D', 'X', 'T', '5');


### PR DESCRIPTION
translucent part of ETC format textures are rendered too bright due to
the fact that v3.12 sets PremultipliedAlpha to true by default. This
commit sets default value of _hasPremultipliedAlpha = false, deletes
unnecessary `_hasPremultipliedAlpha = false` code in multiple places,
making ETC format's _hasPremultipliedAlpha false while keeping other
formats unchanged.
