### PR TITLE
Android import cpufeatures in cocos.

### DIFF
--- a/cocos/Android.mk
+++ b/cocos/Android.mk
@@ -280,9 +280,11 @@ LOCAL_WHOLE_STATIC_LIBRARIES += cpufeatures
 # define the macro to compile through support/zip_support/ioapi.c
 LOCAL_CFLAGS   :=  -DUSE_FILE32API
 LOCAL_CFLAGS   +=  -fexceptions
-ifeq ($(TARGET_ARCH_ABI),armeabi-v7a)
-    LOCAL_CFLAGS += -DHAVE_NEON=1
-endif
+
+#ifeq ($(TARGET_ARCH_ABI),armeabi-v7a)
+#    LOCAL_CFLAGS += -DHAVE_NEON=1
+#endif
+
 LOCAL_CPPFLAGS := -Wno-deprecated-declarations
 LOCAL_EXPORT_CFLAGS   := -DUSE_FILE32API
 LOCAL_EXPORT_CPPFLAGS := -Wno-deprecated-declarations

--- a/cocos/Android.mk
+++ b/cocos/Android.mk
@@ -281,6 +281,7 @@ LOCAL_WHOLE_STATIC_LIBRARIES += cpufeatures
 LOCAL_CFLAGS   :=  -DUSE_FILE32API
 LOCAL_CFLAGS   +=  -fexceptions
 
+# Issues #9968
 #ifeq ($(TARGET_ARCH_ABI),armeabi-v7a)
 #    LOCAL_CFLAGS += -DHAVE_NEON=1
 #endif

--- a/cocos/Android.mk
+++ b/cocos/Android.mk
@@ -275,10 +275,14 @@ LOCAL_STATIC_LIBRARIES += recast_static
 LOCAL_STATIC_LIBRARIES += bullet_static
 
 LOCAL_WHOLE_STATIC_LIBRARIES := cocos2dxandroid_static
+LOCAL_WHOLE_STATIC_LIBRARIES += cpufeatures
 
 # define the macro to compile through support/zip_support/ioapi.c
 LOCAL_CFLAGS   :=  -DUSE_FILE32API
 LOCAL_CFLAGS   +=  -fexceptions
+ifeq ($(TARGET_ARCH_ABI),armeabi-v7a)
+    LOCAL_CFLAGS += -DHAVE_NEON=1
+endif
 LOCAL_CPPFLAGS := -Wno-deprecated-declarations
 LOCAL_EXPORT_CFLAGS   := -DUSE_FILE32API
 LOCAL_EXPORT_CPPFLAGS := -Wno-deprecated-declarations
@@ -301,6 +305,7 @@ LOCAL_STATIC_LIBRARIES += audioengine_static
 
 include $(BUILD_STATIC_LIBRARY)
 #==============================================================
+$(call import-module,android/cpufeatures)
 $(call import-module,freetype2/prebuilt/android)
 $(call import-module,platform/android)
 $(call import-module,png/prebuilt/android)


### PR DESCRIPTION
Add import cpufeatures internal.
Now cpufeatures imported in 3rd party libs webp.
If not use webp, android not build.
