### PR TITLE
Avoid overhead of casting between float and double

### DIFF
--- a/cocos/base/ccUtils.cpp
+++ b/cocos/base/ccUtils.cpp
@@ -25,6 +25,7 @@ THE SOFTWARE.
 
 #include "base/ccUtils.h"
 
+#include <cmath>
 #include <stdlib.h>
 
 #include "base/CCDirector.h"
@@ -198,7 +199,7 @@ Image* captureNode(Node* startNode, float scale)
     rtx->end();
     startNode->setPosition(savedPos);
 
-    if (std::abs(scale - 1.0f) < 1e-6/* no scale */)
+    if (std::abs(scale - 1.0f) < 1e-6f/* no scale */)
         finalRtx = rtx;
     else {
         /* scale */

--- a/cocos/math/Mat4.cpp
+++ b/cocos/math/Mat4.cpp
@@ -19,6 +19,8 @@
  */
 
 #include "math/Mat4.h"
+
+#include <cmath>
 #include "math/Quaternion.h"
 #include "math/MathUtil.h"
 #include "base/ccMacros.h"
@@ -108,12 +110,12 @@ void Mat4::createPerspective(float fieldOfView, float aspectRatio,
 
     float f_n = 1.0f / (zFarPlane - zNearPlane);
     float theta = MATH_DEG_TO_RAD(fieldOfView) * 0.5f;
-    if (fabs(fmod(theta, MATH_PIOVER2)) < MATH_EPSILON)
+    if (std::abs(std::fmod(theta, MATH_PIOVER2)) < MATH_EPSILON)
     {
         CCLOGERROR("Invalid field of view value (%f) causes attempted calculation tan(%f), which is undefined.", fieldOfView, theta);
         return;
     }
-    float divisor = tan(theta);
+    float divisor = std::tan(theta);
     GP_ASSERT(divisor);
     float factor = 1.0f / divisor;
 
@@ -293,7 +295,7 @@ void Mat4::createRotation(const Vec3& axis, float angle, Mat4* dst)
     if (n != 1.0f)
     {
         // Not normalized.
-        n = sqrt(n);
+        n = std::sqrt(n);
         // Prevent divide too close to zero.
         if (n > 0.000001f)
         {
@@ -304,8 +306,8 @@ void Mat4::createRotation(const Vec3& axis, float angle, Mat4* dst)
         }
     }
 
-    float c = cos(angle);
-    float s = sin(angle);
+    float c = std::cos(angle);
+    float s = std::sin(angle);
 
     float t = 1.0f - c;
     float tx = t * x;
@@ -345,8 +347,8 @@ void Mat4::createRotationX(float angle, Mat4* dst)
 
     memcpy(dst, &IDENTITY, MATRIX_SIZE);
 
-    float c = cos(angle);
-    float s = sin(angle);
+    float c = std::cos(angle);
+    float s = std::sin(angle);
 
     dst->m[5]  = c;
     dst->m[6]  = s;
@@ -360,8 +362,8 @@ void Mat4::createRotationY(float angle, Mat4* dst)
 
     memcpy(dst, &IDENTITY, MATRIX_SIZE);
 
-    float c = cos(angle);
-    float s = sin(angle);
+    float c = std::cos(angle);
+    float s = std::sin(angle);
 
     dst->m[0]  = c;
     dst->m[2]  = -s;
@@ -375,8 +377,8 @@ void Mat4::createRotationZ(float angle, Mat4* dst)
 
     memcpy(dst, &IDENTITY, MATRIX_SIZE);
 
-    float c = cos(angle);
-    float s = sin(angle);
+    float c = std::cos(angle);
+    float s = std::sin(angle);
 
     dst->m[0] = c;
     dst->m[1] = s;
@@ -479,7 +481,7 @@ bool Mat4::decompose(Vec3* scale, Quaternion* rotation, Vec3* translation) const
         return true;
 
     // Scale too close to zero, can't decompose rotation.
-    if (scaleX < MATH_TOLERANCE || scaleY < MATH_TOLERANCE || fabs(scaleZ) < MATH_TOLERANCE)
+    if (scaleX < MATH_TOLERANCE || scaleY < MATH_TOLERANCE || std::abs(scaleZ) < MATH_TOLERANCE)
         return false;
 
     float rn;
@@ -505,7 +507,7 @@ bool Mat4::decompose(Vec3* scale, Quaternion* rotation, Vec3* translation) const
 
     if (trace > MATH_EPSILON)
     {
-        float s = 0.5f / sqrt(trace);
+        float s = 0.5f / std::sqrt(trace);
         rotation->w = 0.25f / s;
         rotation->x = (yaxis.z - zaxis.y) * s;
         rotation->y = (zaxis.x - xaxis.z) * s;
@@ -517,7 +519,7 @@ bool Mat4::decompose(Vec3* scale, Quaternion* rotation, Vec3* translation) const
         // we will never divide by zero in the code below.
         if (xaxis.x > yaxis.y && xaxis.x > zaxis.z)
         {
-            float s = 0.5f / sqrt(1.0f + xaxis.x - yaxis.y - zaxis.z);
+            float s = 0.5f / std::sqrt(1.0f + xaxis.x - yaxis.y - zaxis.z);
             rotation->w = (yaxis.z - zaxis.y) * s;
             rotation->x = 0.25f / s;
             rotation->y = (yaxis.x + xaxis.y) * s;
@@ -525,7 +527,7 @@ bool Mat4::decompose(Vec3* scale, Quaternion* rotation, Vec3* translation) const
         }
         else if (yaxis.y > zaxis.z)
         {
-            float s = 0.5f / sqrt(1.0f + yaxis.y - xaxis.x - zaxis.z);
+            float s = 0.5f / std::sqrt(1.0f + yaxis.y - xaxis.x - zaxis.z);
             rotation->w = (zaxis.x - xaxis.z) * s;
             rotation->x = (yaxis.x + xaxis.y) * s;
             rotation->y = 0.25f / s;
@@ -533,7 +535,7 @@ bool Mat4::decompose(Vec3* scale, Quaternion* rotation, Vec3* translation) const
         }
         else
         {
-            float s = 0.5f / sqrt(1.0f + zaxis.z - xaxis.x - yaxis.y );
+            float s = 0.5f / std::sqrt(1.0f + zaxis.z - xaxis.x - yaxis.y);
             rotation->w = (xaxis.y - yaxis.x ) * s;
             rotation->x = (zaxis.x + xaxis.z ) * s;
             rotation->y = (zaxis.y + yaxis.z ) * s;
@@ -658,7 +660,7 @@ bool Mat4::inverse()
     float det = a0 * b5 - a1 * b4 + a2 * b3 + a3 * b2 - a4 * b1 + a5 * b0;
 
     // Close to zero, can't invert.
-    if (fabs(det) <= MATH_TOLERANCE)
+    if (std::abs(det) <= MATH_TOLERANCE)
         return false;
 
     // Support the case where m == dst.

--- a/cocos/math/Quaternion.cpp
+++ b/cocos/math/Quaternion.cpp
@@ -19,6 +19,8 @@
  */
 
 #include "math/Quaternion.h"
+
+#include <cmath>
 #include "base/ccMacros.h"
 
 NS_CC_MATH_BEGIN
@@ -177,7 +179,7 @@ void Quaternion::normalize()
     if (n == 1.0f)
         return;
     
-    n = sqrt(n);
+    n = std::sqrt(n);
     // Too close to zero.
     if (n < 0.000001f)
         return;
@@ -251,7 +253,7 @@ float Quaternion::toAxisAngle(Vec3* axis) const
     axis->z = q.z;
     axis->normalize();
 
-    return (2.0f * acos(q.w));
+    return (2.0f * std::acos(q.w));
 }
 
 void Quaternion::lerp(const Quaternion& q1, const Quaternion& q2, float t, Quaternion* dst)
@@ -405,7 +407,7 @@ void Quaternion::slerpForSquad(const Quaternion& q1, const Quaternion& q2, float
     // This is a straight-forward implementation of the formula of slerp. It does not do any sign switching.
     float c = q1.x * q2.x + q1.y * q2.y + q1.z * q2.z + q1.w * q2.w;
 
-    if (fabs(c) >= 1.0f)
+    if (std::abs(c) >= 1.0f)
     {
         dst->x = q1.x;
         dst->y = q1.y;
@@ -414,9 +416,9 @@ void Quaternion::slerpForSquad(const Quaternion& q1, const Quaternion& q2, float
         return;
     }
 
-    float omega = acos(c);
-    float s = sqrt(1.0f - c * c);
-    if (fabs(s) <= 0.00001f)
+    float omega = std::acos(c);
+    float s = std::sqrt(1.0f - c * c);
+    if (std::abs(s) <= 0.00001f)
     {
         dst->x = q1.x;
         dst->y = q1.y;
@@ -425,8 +427,8 @@ void Quaternion::slerpForSquad(const Quaternion& q1, const Quaternion& q2, float
         return;
     }
 
-    float r1 = sin((1 - t) * omega) / s;
-    float r2 = sin(t * omega) / s;
+    float r1 = std::sin((1 - t) * omega) / s;
+    float r2 = std::sin(t * omega) / s;
     dst->x = (q1.x * r1 + q2.x * r2);
     dst->y = (q1.y * r1 + q2.y * r2);
     dst->z = (q1.z * r1 + q2.z * r2);

--- a/cocos/math/Vec4.cpp
+++ b/cocos/math/Vec4.cpp
@@ -19,6 +19,8 @@
  */
 
 #include "math/Vec4.h"
+
+#include <cmath>
 #include "math/MathUtil.h"
 #include "base/ccMacros.h"
 
@@ -84,7 +86,7 @@ float Vec4::angle(const Vec4& v1, const Vec4& v2)
     float dy = v1.w * v2.y - v1.y * v2.w - v1.z * v2.x + v1.x * v2.z;
     float dz = v1.w * v2.z - v1.z * v2.w - v1.x * v2.y + v1.y * v2.x;
 
-    return atan2f(sqrt(dx * dx + dy * dy + dz * dz) + MATH_FLOAT_SMALL, dot(v1, v2));
+    return std::atan2(std::sqrt(dx * dx + dy * dy + dz * dz) + MATH_FLOAT_SMALL, dot(v1, v2));
 }
 
 void Vec4::add(const Vec4& v)
@@ -175,7 +177,7 @@ float Vec4::distance(const Vec4& v) const
     float dz = v.z - z;
     float dw = v.w - w;
 
-    return sqrt(dx * dx + dy * dy + dz * dz + dw * dw);
+    return std::sqrt(dx * dx + dy * dy + dz * dz + dw * dw);
 }
 
 float Vec4::distanceSquared(const Vec4& v) const
@@ -200,7 +202,7 @@ float Vec4::dot(const Vec4& v1, const Vec4& v2)
 
 float Vec4::length() const
 {
-    return sqrt(x * x + y * y + z * z + w * w);
+    return std::sqrt(x * x + y * y + z * z + w * w);
 }
 
 
@@ -224,7 +226,7 @@ void Vec4::normalize()
     if (n == 1.0f)
         return;
     
-    n = sqrt(n);
+    n = std::sqrt(n);
     // Too close to zero.
     if (n < MATH_TOLERANCE)
         return;

--- a/cocos/vr/CCVRGenericHeadTracker.cpp
+++ b/cocos/vr/CCVRGenericHeadTracker.cpp
@@ -28,6 +28,8 @@
 // To change this behvior, use the File Inspector from Xcode
 
 #include "vr/CCVRGenericHeadTracker.h"
+
+#include <cmath>
 #include "platform/CCPlatformMacros.h"
 #include "platform/CCDevice.h"
 
@@ -127,15 +129,15 @@ Vec3 lowPass(const Vec3& input, const Vec3& prev)
 
 static Mat4 getRotateEulerMatrix(float x, float y, float z)
 {
-    x *= (float)(M_PI / 180.0f);
-    y *= (float)(M_PI / 180.0f);
-    z *= (float)(M_PI / 180.0f);
-    float cx = (float) cos(x);
-    float sx = (float) sin(x);
-    float cy = (float) cos(y);
-    float sy = (float) sin(y);
-    float cz = (float) cos(z);
-    float sz = (float) sin(z);
+    x *= static_cast<float>(M_PI) / 180.0f;
+    y *= static_cast<float>(M_PI) / 180.0f;
+    z *= static_cast<float>(M_PI) / 180.0f;
+    float cx = std::cos(x);
+    float sx = std::sin(x);
+    float cy = std::cos(y);
+    float sy = std::sin(y);
+    float cz = std::cos(z);
+    float sz = std::sin(z);
     float cxsy = cx * sy;
     float sxsy = sx * sy;
     Mat4 matrix;


### PR DESCRIPTION
Hello.

This pull request fixes some `-Wdouble-promotion` warnings to improve the performance and make compiler happy for the same reason as https://github.com/cocos2d/cocos2d-x/pull/16055. It addresses the following warnings when compiling on Xcode 7.3.1 with `-Wdouble-promotion` (or `-Weverything`) option.

```
cocos/base/ccUtils.cpp:201:9: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
cocos/math/Mat4.cpp:111:19: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
cocos/math/Mat4.cpp:111:26: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
cocos/math/Mat4.cpp:111:43: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
cocos/math/Mat4.cpp:116:25: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
cocos/math/Mat4.cpp:296:18: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
cocos/math/Mat4.cpp:307:19: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
cocos/math/Mat4.cpp:308:19: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
cocos/math/Mat4.cpp:348:19: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
cocos/math/Mat4.cpp:349:19: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
cocos/math/Mat4.cpp:363:19: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
cocos/math/Mat4.cpp:364:19: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
cocos/math/Mat4.cpp:378:19: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
cocos/math/Mat4.cpp:379:19: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
cocos/math/Mat4.cpp:482:68: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
cocos/math/Mat4.cpp:482:78: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
cocos/math/Mat4.cpp:508:19: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
cocos/math/Mat4.cpp:508:31: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
cocos/math/Mat4.cpp:520:23: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
cocos/math/Mat4.cpp:520:60: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
cocos/math/Mat4.cpp:528:23: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
cocos/math/Mat4.cpp:528:60: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
cocos/math/Mat4.cpp:536:23: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
cocos/math/Mat4.cpp:536:60: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
cocos/math/Mat4.cpp:661:14: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
cocos/math/Mat4.cpp:661:22: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
cocos/math/Quaternion.cpp:180:14: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
cocos/math/Quaternion.cpp:254:13: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
cocos/math/Quaternion.cpp:254:27: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
cocos/math/Quaternion.cpp:408:14: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
cocos/math/Quaternion.cpp:408:20: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
cocos/math/Quaternion.cpp:417:24: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
cocos/math/Quaternion.cpp:418:25: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
cocos/math/Quaternion.cpp:419:14: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
cocos/math/Quaternion.cpp:419:20: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
cocos/math/Quaternion.cpp:428:28: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
cocos/math/Quaternion.cpp:428:39: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
cocos/math/Quaternion.cpp:429:22: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
cocos/math/Vec4.cpp:87:42: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
cocos/math/Vec4.cpp:87:55: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
cocos/math/Vec4.cpp:178:45: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
cocos/math/Vec4.cpp:203:39: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
cocos/math/Vec4.cpp:227:14: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
cocos/vr/CCVRGenericHeadTracker.cpp:130:25: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
cocos/vr/CCVRGenericHeadTracker.cpp:131:25: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
cocos/vr/CCVRGenericHeadTracker.cpp:132:25: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
cocos/vr/CCVRGenericHeadTracker.cpp:132:25: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
cocos/vr/CCVRGenericHeadTracker.cpp:134:28: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
cocos/vr/CCVRGenericHeadTracker.cpp:135:28: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
cocos/vr/CCVRGenericHeadTracker.cpp:136:28: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
cocos/vr/CCVRGenericHeadTracker.cpp:137:28: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
cocos/vr/CCVRGenericHeadTracker.cpp:138:28: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
```

Thank you for your time and consideration.
