### PR TITLE
Android cpu features neon armeabi v7a

### DIFF
--- a/cocos/Android.mk
+++ b/cocos/Android.mk
@@ -280,9 +280,11 @@ LOCAL_WHOLE_STATIC_LIBRARIES += cpufeatures
 # define the macro to compile through support/zip_support/ioapi.c
 LOCAL_CFLAGS   :=  -DUSE_FILE32API
 LOCAL_CFLAGS   +=  -fexceptions
-ifeq ($(TARGET_ARCH_ABI),armeabi-v7a)
-    LOCAL_CFLAGS += -DHAVE_NEON=1
-endif
+
+#ifeq ($(TARGET_ARCH_ABI),armeabi-v7a)
+#    LOCAL_CFLAGS += -DHAVE_NEON=1
+#endif
+
 LOCAL_CPPFLAGS := -Wno-deprecated-declarations
 LOCAL_EXPORT_CFLAGS   := -DUSE_FILE32API
 LOCAL_EXPORT_CPPFLAGS := -Wno-deprecated-declarations

--- a/cocos/Android.mk
+++ b/cocos/Android.mk
@@ -281,6 +281,7 @@ LOCAL_WHOLE_STATIC_LIBRARIES += cpufeatures
 LOCAL_CFLAGS   :=  -DUSE_FILE32API
 LOCAL_CFLAGS   +=  -fexceptions
 
+# Issues #9968
 #ifeq ($(TARGET_ARCH_ABI),armeabi-v7a)
 #    LOCAL_CFLAGS += -DHAVE_NEON=1
 #endif

--- a/cocos/Android.mk
+++ b/cocos/Android.mk
@@ -275,10 +275,14 @@ LOCAL_STATIC_LIBRARIES += recast_static
 LOCAL_STATIC_LIBRARIES += bullet_static
 
 LOCAL_WHOLE_STATIC_LIBRARIES := cocos2dxandroid_static
+LOCAL_WHOLE_STATIC_LIBRARIES += cpufeatures
 
 # define the macro to compile through support/zip_support/ioapi.c
 LOCAL_CFLAGS   :=  -DUSE_FILE32API
 LOCAL_CFLAGS   +=  -fexceptions
+ifeq ($(TARGET_ARCH_ABI),armeabi-v7a)
+    LOCAL_CFLAGS += -DHAVE_NEON=1
+endif
 LOCAL_CPPFLAGS := -Wno-deprecated-declarations
 LOCAL_EXPORT_CFLAGS   := -DUSE_FILE32API
 LOCAL_EXPORT_CPPFLAGS := -Wno-deprecated-declarations
@@ -301,6 +305,7 @@ LOCAL_STATIC_LIBRARIES += audioengine_static
 
 include $(BUILD_STATIC_LIBRARY)
 #==============================================================
+$(call import-module,android/cpufeatures)
 $(call import-module,freetype2/prebuilt/android)
 $(call import-module,platform/android)
 $(call import-module,png/prebuilt/android)

--- a/cocos/Android.mk
+++ b/cocos/Android.mk
@@ -281,10 +281,9 @@ LOCAL_WHOLE_STATIC_LIBRARIES += cpufeatures
 LOCAL_CFLAGS   :=  -DUSE_FILE32API
 LOCAL_CFLAGS   +=  -fexceptions
 
-# Issues #9968
-#ifeq ($(TARGET_ARCH_ABI),armeabi-v7a)
-#    LOCAL_CFLAGS += -DHAVE_NEON=1
-#endif
+ifeq ($(TARGET_ARCH_ABI),armeabi-v7a)
+    LOCAL_CFLAGS += -DHAVE_NEON=1
+endif
 
 LOCAL_CPPFLAGS := -Wno-deprecated-declarations
 LOCAL_EXPORT_CFLAGS   := -DUSE_FILE32API


### PR DESCRIPTION
If armeabi-v7a cpu not always support neon instruction, need check it runtime and change use code.

I see MathUtil.cpp, code:

``` c++
bool MathUtil::isNeon32Enabled()
{
#ifdef USE_NEON32
    return true;
#elif (defined (INCLUDE_NEON32) && (CC_TARGET_PLATFORM == CC_PLATFORM_ANDROID) )
    class AnrdoidNeonChecker
    {
    public:
        AnrdoidNeonChecker()
        {
            if (android_getCpuFamily() == ANDROID_CPU_FAMILY_ARM && (android_getCpuFeatures() & ANDROID_CPU_ARM_FEATURE_NEON) != 0)
                _isNeonEnabled = true;
            else
                _isNeonEnabled = false;
        }
        bool isNeonEnabled() const { return _isNeonEnabled; }
    private:
        bool _isNeonEnabled;
    };
    static AnrdoidNeonChecker checker;
    return checker.isNeonEnabled();
#else
    return false;
#endif
}
```

It now implemented, additionally do not need to do anything.
For arm64-v8a not need define HAVE_NEON

``` c++
#elif (CC_TARGET_PLATFORM == CC_PLATFORM_ANDROID)
    #if defined (__arm64__) || defined (__aarch64__)
    #define USE_NEON64
    #define INCLUDE_NEON64
    #elif defined (__ARM_NEON__)
    #define INCLUDE_NEON32
    #else
    #endif
#else
```

Need add log message, for mobile platform, support neon.

In cpu-features.h check define **ARM_NEON** not HAVE_NEON ?

``` c++
/* define _ARM_HAVE_NEON for ARMv7 architecture if we support the
 * Neon SIMD instruction set extensions. This also implies
 * that VFPv3-D32 is supported.
 */
#if __ARM_ARCH__ >= 7 && defined __ARM_NEON__
#  define __ARM_HAVE_NEON
#endif
```
