### PR TITLE
Remove redundant includes

### DIFF
--- a/cocos/audio/android/CCThreadPool.h
+++ b/cocos/audio/android/CCThreadPool.h
@@ -36,7 +36,6 @@
 #include <condition_variable>
 #include <vector>
 #include <atomic>
-#include <mutex>
 
 namespace cocos2d { namespace experimental {
 

--- a/cocos/platform/apple/CCFileUtils-apple.mm
+++ b/cocos/platform/apple/CCFileUtils-apple.mm
@@ -33,7 +33,6 @@ THE SOFTWARE.
 #include <stack>
 
 #include "base/CCDirector.h"
-#include "deprecated/CCDictionary.h"
 #include "platform/CCFileUtils.h"
 #include "platform/CCSAXParser.h"
 

--- a/cocos/platform/ios/CCEAGLView-ios.mm
+++ b/cocos/platform/ios/CCEAGLView-ios.mm
@@ -69,7 +69,6 @@ Copyright (C) 2008 Apple Inc. All Rights Reserved.
 #import <QuartzCore/QuartzCore.h>
 
 #import "base/CCDirector.h"
-#import "deprecated/CCSet.h"
 #import "base/CCTouch.h"
 #import "base/CCIMEDispatcher.h"
 #import "platform/ios/CCGLViewImpl-ios.h"

--- a/cocos/platform/ios/CCGLViewImpl-ios.mm
+++ b/cocos/platform/ios/CCGLViewImpl-ios.mm
@@ -31,7 +31,6 @@
 #include "platform/ios/CCEAGLView-ios.h"
 #include "platform/ios/CCDirectorCaller-ios.h"
 #include "platform/ios/CCGLViewImpl-ios.h"
-#include "deprecated/CCSet.h"
 #include "base/CCTouch.h"
 
 NS_CC_BEGIN

--- a/cocos/renderer/CCPrimitiveCommand.cpp
+++ b/cocos/renderer/CCPrimitiveCommand.cpp
@@ -31,8 +31,6 @@
 
 #include "base/CCDirector.h"
 
-#include "xxhash.h"
-
 NS_CC_BEGIN
 
 PrimitiveCommand::PrimitiveCommand()

--- a/cocos/renderer/CCQuadCommand.cpp
+++ b/cocos/renderer/CCQuadCommand.cpp
@@ -32,7 +32,6 @@
 #include "renderer/CCRenderer.h"
 #include "renderer/CCPass.h"
 #include "renderer/CCTexture2D.h"
-#include "xxhash.h"
 
 NS_CC_BEGIN
 


### PR DESCRIPTION
This PR removes unnecessary or duplicate `#include` directives to improve compilation time.
Thanks!
