### PR TITLE
Fix compiler warnings caused by Spine 3.4

### DIFF
--- a/cocos/editor-support/spine/extension.h
+++ b/cocos/editor-support/spine/extension.h
@@ -83,8 +83,12 @@
 #define SIN_DEG(A) SIN((A) * DEG_RAD)
 #define COS_DEG(A) COS((A) * DEG_RAD)
 #define CLAMP(x, min, max) ((x) < (min) ? (min) : ((x) > (max) ? (max) : (x)))
+#ifndef MIN
 #define MIN(x, y) ((x) < (y) ? (x) : (y))
+#endif
+#ifndef MAX
 #define MAX(x, y) ((x) > (y) ? (x) : (y))
+#endif
 
 #define UNUSED(x) (void)(x)
 

--- a/cocos/editor-support/spine/spine-cocos2dx.cpp
+++ b/cocos/editor-support/spine/spine-cocos2dx.cpp
@@ -40,6 +40,8 @@ GLuint wrap (spAtlasWrap wrap) {
 
 GLuint filter (spAtlasFilter filter) {
 	switch (filter) {
+	case SP_ATLAS_UNKNOWN_FILTER:
+		break;
 	case SP_ATLAS_NEAREST:
 		return GL_NEAREST;
 	case SP_ATLAS_LINEAR:


### PR DESCRIPTION
When building latest v3 branch (95e60d4124140fe2643418e3e63013ade8087fca) with Xcode 7.3.1 and Clang, I get the following warnings:

```
cocos/editor-support/spine/extension.h:86:9: 'MIN' macro redefined [-Wmacro-redefined]
cocos/editor-support/spine/extension.h:87:9: 'MAX' macro redefined [-Wmacro-redefined]
cocos/editor-support/spine/spine-cocos2dx.cpp:42:10: enumeration value 'SP_ATLAS_UNKNOWN_FILTER' not handled in switch [-Wswitch]
```

This patch fixes those warnings. Also, it has already been merged into upstream on [EsotericSoftware/spine-runtimes](https://github.com/EsotericSoftware/spine-runtimes) repository. Here are the original PRs:
- https://github.com/EsotericSoftware/spine-runtimes/pull/653
- https://github.com/EsotericSoftware/spine-runtimes/pull/654

Thanks!
