### PR TITLE
Fix some typos in comments and strings

### DIFF
--- a/cocos/scripting/js-bindings/script/debugger/actors/script.js
+++ b/cocos/scripting/js-bindings/script/debugger/actors/script.js
@@ -882,7 +882,7 @@ ThreadActor.prototype = {
         generatedLocation));
 
       // Cases when we should pause because we have executed enough to consider
-      // a "step" to have occured:
+      // a "step" to have occurred:
       //
       // 1.1. We change frames.
       // 1.2. We change URLs (can happen without changing frames thanks to

--- a/cocos/scripting/js-bindings/script/debugger/actors/utils/ScriptStore.js
+++ b/cocos/scripting/js-bindings/script/debugger/actors/utils/ScriptStore.js
@@ -94,7 +94,7 @@ ScriptStore.prototype = {
   /**
    * Get all scripts produced from the given source.
    *
-   * @oaram Debugger.Source source
+   * @param Debugger.Source source
    * @returns Array of Debugger.Script
    */
   getScriptsBySource: function(source) {
@@ -113,7 +113,7 @@ ScriptStore.prototype = {
    * Get all scripts produced from the given source whose source code definition
    * spans the given line.
    *
-   * @oaram Debugger.Source source
+   * @param Debugger.Source source
    * @param Number line
    * @returns Array of Debugger.Script
    */

--- a/cocos/scripting/js-bindings/script/debugger/main.js
+++ b/cocos/scripting/js-bindings/script/debugger/main.js
@@ -1305,7 +1305,7 @@ function DebuggerServerConnection(aPrefix, aTransport)
   this._actorPool = new ActorPool(this);
   this._extraPools = [this._actorPool];
 
-  // Responses to a given actor must be returned the the client
+  // Responses to a given actor must be returned the client
   // in the same order as the requests that they're replying to, but
   // Implementations might finish serving requests in a different
   // order.  To keep things in order we generate a promise for each

--- a/cocos/scripting/js-bindings/script/jsb.js
+++ b/cocos/scripting/js-bindings/script/jsb.js
@@ -21,7 +21,7 @@
  */
 
 //
-// Javascript Bindigns helper file
+// JavaScript Bindings helper file
 //
 
 // DO NOT ALTER THE ORDER

--- a/cocos/scripting/js-bindings/script/jsb_create_apis.js
+++ b/cocos/scripting/js-bindings/script/jsb_create_apis.js
@@ -855,7 +855,7 @@ cc.GLProgram.prototype._ctor = function(vShaderFileName, fShaderFileName) {
  * var spriteFrame = cc.spriteFrameCache.getSpriteFrame('grossini_dance_01.png');
  * var sprite = cc.Sprite.create(spriteFrame);
  *
- * 4.Create a sprite with an exsiting texture contained in a CCTexture2D object
+ * 4.Create a sprite with an existing texture contained in a CCTexture2D object
  *      After creation, the rect will be the size of the texture, and the offset will be (0,0).
  * var texture = cc.textureCache.addImage('HelloHTML5World.png');
  * var sprite1 = cc.Sprite.create(texture);

--- a/templates/cpp-template-default/proj.ios_mac/ios/AppController.mm
+++ b/templates/cpp-template-default/proj.ios_mac/ios/AppController.mm
@@ -74,7 +74,7 @@ static AppDelegate s_sharedApplication;
      Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
      Use this method to pause ongoing tasks, disable timers, and throttle down OpenGL ES frame rates. Games should use this method to pause the game.
      */
-     //We don't need to call this method any more. It will interupt user defined game pause&resume logic
+    // We don't need to call this method any more. It will interrupt user defined game pause&resume logic
     /* cocos2d::Director::getInstance()->pause(); */
 }
 
@@ -82,7 +82,7 @@ static AppDelegate s_sharedApplication;
     /*
      Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
      */
-     //We don't need to call this method any more. It will interupt user defined game pause&resume logic
+    // We don't need to call this method any more. It will interrupt user defined game pause&resume logic
     /* cocos2d::Director::getInstance()->resume(); */
 }
 

--- a/templates/js-template-default/frameworks/runtime-src/Classes/AppDelegate.cpp
+++ b/templates/js-template-default/frameworks/runtime-src/Classes/AppDelegate.cpp
@@ -97,7 +97,7 @@ bool AppDelegate::applicationDidFinishLaunching()
     sc->addRegisterCallback(register_all_cocos2dx_builder);
     sc->addRegisterCallback(register_CCBuilderReader);
 
-    // ui can be commented out to reduce the package, attension studio need ui module
+    // ui can be commented out to reduce the package, attention studio need ui module
     sc->addRegisterCallback(register_all_cocos2dx_ui);
     sc->addRegisterCallback(register_all_cocos2dx_ui_manual);
 
@@ -113,7 +113,7 @@ bool AppDelegate::applicationDidFinishLaunching()
     sc->addRegisterCallback(MinXmlHttpRequest::_js_register);
     // websocket can be commented out to reduce the package
     sc->addRegisterCallback(register_jsb_websocket);
-    // sokcet io can be commented out to reduce the package
+    // socket io can be commented out to reduce the package
     sc->addRegisterCallback(register_jsb_socketio);
 
     // 3d can be commented out to reduce the package

--- a/templates/js-template-default/main.js
+++ b/templates/js-template-default/main.js
@@ -25,7 +25,7 @@
     "noCache"       : false,
     // "noCache" set whether your resources will be loaded with a timestamp suffix in the url.
     // In this way, your resources will be force updated even if the browser holds a cache of it.
-    // It's very useful for mobile browser debuging.
+    // It's very useful for mobile browser debugging.
 
     "id"            : "gameCanvas",
     // "gameCanvas" sets the id of your canvas element on the web page, it's useful only on web.

--- a/templates/lua-template-default/frameworks/CMakeLists.txt
+++ b/templates/lua-template-default/frameworks/CMakeLists.txt
@@ -52,7 +52,7 @@ endif(USE_BULLET)
 set(BUILD_CPP_EMPTY_TEST OFF CACHE BOOL "turn off build cpp-empty-test")
 set(BUILD_CPP_TESTS OFF CACHE BOOL "turn off build cpp-tests")
 set(BUILD_LUA_TESTS OFF CACHE BOOL "turn off build lua-tests")
-set(BUILD_JS_LIBS OFF CACHE BOOL "turn off build js releated targets")
+set(BUILD_JS_LIBS OFF CACHE BOOL "turn off build js related targets")
 add_subdirectory(${COCOS2D_ROOT})
 
 

--- a/templates/lua-template-default/frameworks/runtime-src/proj.android-studio/app/src/org/cocos2dx/lua/AppActivity.java
+++ b/templates/lua-template-default/frameworks/runtime-src/proj.android-studio/app/src/org/cocos2dx/lua/AppActivity.java
@@ -72,7 +72,7 @@ public class AppActivity extends Cocos2dxActivity{
             {
                 AlertDialog.Builder builder=new AlertDialog.Builder(this);
                 builder.setTitle("Warning");
-                builder.setMessage("Please open WIFI for debuging...");
+                builder.setMessage("Please open WIFI for debugging...");
                 builder.setPositiveButton("OK",new DialogInterface.OnClickListener() {
                     
                     @Override

--- a/templates/lua-template-default/frameworks/runtime-src/proj.android/src/org/cocos2dx/lua/AppActivity.java
+++ b/templates/lua-template-default/frameworks/runtime-src/proj.android/src/org/cocos2dx/lua/AppActivity.java
@@ -75,7 +75,7 @@ public class AppActivity extends Cocos2dxActivity{
             {
                 AlertDialog.Builder builder=new AlertDialog.Builder(this);
                 builder.setTitle("Warning");
-                builder.setMessage("Please open WIFI for debuging...");
+                builder.setMessage("Please open WIFI for debugging...");
                 builder.setPositiveButton("OK",new DialogInterface.OnClickListener() {
                     
                     @Override

--- a/templates/lua-template-default/frameworks/runtime-src/proj.win32/SimulatorWin.cpp
+++ b/templates/lua-template-default/frameworks/runtime-src/proj.win32/SimulatorWin.cpp
@@ -168,7 +168,7 @@ void SimulatorWin::openNewPlayerWithProjectConfig(const ProjectConfig &config)
     STARTUPINFO si = {0};
     si.cb = sizeof(STARTUPINFO);
 
-#define MAX_COMMAND 1024 // lenth of commandLine is always beyond MAX_PATH
+#define MAX_COMMAND 1024 // length of commandLine is always beyond MAX_PATH
 
     WCHAR command[MAX_COMMAND];
     memset(command, 0, sizeof(command));

--- a/tools/simulator/frameworks/runtime-src/proj.android/src/org/cocos2dx/lua/AppActivity.java
+++ b/tools/simulator/frameworks/runtime-src/proj.android/src/org/cocos2dx/lua/AppActivity.java
@@ -75,7 +75,7 @@ public class AppActivity extends Cocos2dxActivity{
 			{
 				AlertDialog.Builder builder=new AlertDialog.Builder(this);
 				builder.setTitle("Warning");
-				builder.setMessage("Please open WIFI for debuging...");
+				builder.setMessage("Please open WIFI for debugging...");
 				builder.setPositiveButton("OK",new DialogInterface.OnClickListener() {
 					
 					@Override

--- a/tools/simulator/frameworks/runtime-src/proj.win32/SimulatorWin.cpp
+++ b/tools/simulator/frameworks/runtime-src/proj.win32/SimulatorWin.cpp
@@ -189,7 +189,7 @@ void SimulatorWin::openNewPlayerWithProjectConfig(const ProjectConfig &config)
     STARTUPINFO si = {0};
     si.cb = sizeof(STARTUPINFO);
 
-#define MAX_COMMAND 1024 // lenth of commandLine is always beyond MAX_PATH
+#define MAX_COMMAND 1024 // length of commandLine is always beyond MAX_PATH
 
     WCHAR command[MAX_COMMAND];
     memset(command, 0, sizeof(command));

--- a/tools/simulator/libsimulator/lib/platform/mac/openudid/OpenUDIDMac.m
+++ b/tools/simulator/libsimulator/lib/platform/mac/openudid/OpenUDIDMac.m
@@ -322,7 +322,7 @@ static int const kOpenUDIDRedundancySlots = 100;
     // If the UIPasteboard external representation marks this app as opted-out, then to respect privacy, we return the ZERO OpenUDID, a sequence of 40 zeros...
     // This is a *new* case that developers have to deal with. Unlikely, statistically low, but still.
     // To circumvent this and maintain good tracking (conversion ratios, etc.), developers are invited to calculate how many of their users have opted-out from the full set of users.
-    // This ratio will let them extrapolate convertion ratios more accurately.
+    // This ratio will let them extrapolate conversion ratios more accurately.
     //
     if (optedOut) {
         if (error!=nil) *error = [NSError errorWithDomain:kOpenUDIDDomain

--- a/tools/simulator/libsimulator/lib/platform/win32/SimulatorWin.cpp
+++ b/tools/simulator/libsimulator/lib/platform/win32/SimulatorWin.cpp
@@ -160,7 +160,7 @@ void SimulatorWin::openNewPlayerWithProjectConfig(const ProjectConfig &config)
     STARTUPINFO si = {0};
     si.cb = sizeof(STARTUPINFO);
 
-#define MAX_COMMAND 1024 // lenth of commandLine is always beyond MAX_PATH
+#define MAX_COMMAND 1024 // length of commandLine is always beyond MAX_PATH
 
     WCHAR command[MAX_COMMAND];
     memset(command, 0, sizeof(command));

--- a/tools/simulator/libsimulator/lib/runtime/ConsoleCommand.cpp
+++ b/tools/simulator/libsimulator/lib/runtime/ConsoleCommand.cpp
@@ -220,7 +220,7 @@ void ConsoleCommand::onSendCommand(int fd, const std::string &args)
 #endif
             } else if(strcmp(strcmd.c_str(), "getplatform") == 0)
             {
-                string platform="UNKNOW";
+                string platform="UNKNOWN";
 #if (CC_TARGET_PLATFORM == CC_PLATFORM_WIN32)
                 platform = "WIN32";
 #elif (CC_TARGET_PLATFORM == CC_PLATFORM_MAC)


### PR DESCRIPTION
This pull request fixes some spelling errors in comments and strings. Thanks!
