### PR TITLE
Fix format string warning when compiling for iOS armv7

### DIFF
--- a/cocos/audio/apple/AudioEngine-inl.mm
+++ b/cocos/audio/apple/AudioEngine-inl.mm
@@ -67,7 +67,7 @@ void AudioEngineInterruptionListenerCallback(void* user_data, UInt32 interruptio
     else if (kAudioSessionEndInterruption == interruption_state)
     {
       OSStatus result = AudioSessionSetActive(true);
-      if (result) NSLog(@"Error setting audio session active! %d\n", result);
+      if (result) NSLog(@"Error setting audio session active! %d\n", static_cast<int>(result));
 
       alcMakeContextCurrent(s_ALContext);
     }


### PR DESCRIPTION
This pull request fixes the following warning when compiling libcocos2d for iOS armv7 (32-bit) on Xcode 7.3.1:

```
cocos/audio/apple/AudioEngine-inl.mm:70:70: values of type 'OSStatus' should not be used as format arguments; add an explicit cast to 'int' instead [-Wformat]
```
