### PR TITLE
fix pageview turning event

### DIFF
--- a/cocos/ui/UIPageView.cpp
+++ b/cocos/ui/UIPageView.cpp
@@ -39,7 +39,8 @@ _childFocusCancelOffset(5.0f),
 _pageViewEventListener(nullptr),
 _pageViewEventSelector(nullptr),
 _eventCallback(nullptr),
-_autoScrollStopEpsilon(0.001f)
+_autoScrollStopEpsilon(0.001f),
+_previousPageIndex(-1)
 {
 }
 
@@ -218,6 +219,12 @@ void PageView::refreshIndicatorPosition()
         _indicator->setPosition(Vec2(posX, posY));
     }
 }
+    
+void PageView::handlePressLogic(Touch *touch)
+{
+    ListView::handlePressLogic(touch);
+    _previousPageIndex = _currentPageIndex;
+}
 
 void PageView::handleReleaseLogic(Touch *touch)
 {
@@ -228,7 +235,6 @@ void PageView::handleReleaseLogic(Touch *touch)
     {
         return;
     }
-
     Vec2 touchMoveVelocity = flattenVectorByDirection(calculateTouchMoveVelocity());
 
     static const float INERTIA_THRESHOLD = 500;
@@ -272,6 +278,19 @@ float PageView::getAutoScrollStopEpsilon() const
     return _autoScrollStopEpsilon;
 }
 
+void PageView::addEventListenerPageView(Ref *target, SEL_PageViewEvent selector)
+{
+    _pageViewEventListener = target;
+    _pageViewEventSelector = selector;
+    
+    ccScrollViewCallback scrollViewCallback = [=](Ref* ref, ScrollView::EventType type) -> void{
+        if (type == ScrollView::EventType::AUTOSCROLL_ENDED && _previousPageIndex != _currentPageIndex) {
+            pageTurningEvent();
+        }
+    };
+    this->addEventListener(scrollViewCallback);
+}
+    
 void PageView::pageTurningEvent()
 {
     this->retain();
@@ -289,19 +308,13 @@ void PageView::pageTurningEvent()
     }
     this->release();
 }
-
-void PageView::addEventListenerPageView(Ref *target, SEL_PageViewEvent selector)
-{
-    _pageViewEventListener = target;
-    _pageViewEventSelector = selector;
-}
     
 void PageView::addEventListener(const ccPageViewCallback& callback)
 {
     _eventCallback = callback;
     ccScrollViewCallback scrollViewCallback = [=](Ref* ref, ScrollView::EventType type) -> void{
-        if (type == ScrollView::EventType::AUTOSCROLL_ENDED) {
-            callback(ref, PageView::EventType::TURNING);
+        if (type == ScrollView::EventType::AUTOSCROLL_ENDED && _previousPageIndex != _currentPageIndex) {
+            pageTurningEvent();
         }
     };
     this->addEventListener(scrollViewCallback);
@@ -364,6 +377,11 @@ void PageView::copySpecialProperties(Widget *widget)
         _ccEventCallback = pageView->_ccEventCallback;
         _pageViewEventListener = pageView->_pageViewEventListener;
         _pageViewEventSelector = pageView->_pageViewEventSelector;
+        _currentPageIndex = pageView->_currentPageIndex;
+        _previousPageIndex = pageView->_previousPageIndex;
+        _childFocusCancelOffset = pageView->_childFocusCancelOffset;
+        _autoScrollStopEpsilon = pageView->_autoScrollStopEpsilon;
+        _indicatorPositionAsAnchorPoint = pageView->_indicatorPositionAsAnchorPoint;
     }
 }
 

--- a/cocos/ui/UIPageView.h
+++ b/cocos/ui/UIPageView.h
@@ -394,6 +394,7 @@ protected:
     virtual void onItemListChanged() override;
     virtual void onSizeChanged() override;
     virtual void handleReleaseLogic(Touch *touch) override;
+    virtual void handlePressLogic(Touch *touch) override;
 
     virtual Widget* createCloneInstance() override;
     virtual void copySpecialProperties(Widget* model) override;
@@ -423,6 +424,7 @@ protected:
 #endif
     ccPageViewCallback _eventCallback;
     float _autoScrollStopEpsilon;
+    ssize_t _previousPageIndex;
 };
 
 }

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIPageViewTest/UIPageViewTest.cpp
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIPageViewTest/UIPageViewTest.cpp
@@ -84,7 +84,8 @@ bool UIPageViewTest::init()
         
         pageView->removeItem(0);
         pageView->scrollToItem(pageCount - 2);
-        pageView->addEventListener((PageView::ccPageViewCallback)CC_CALLBACK_2(UIPageViewTest::pageViewEvent, this));
+        //This method is deprecated, we used here only testing purpose
+        pageView->addEventListenerPageView(this, pagevieweventselector(UIPageViewTest::pageViewEvent));
         
         _uiLayer->addChild(pageView);
         
@@ -93,11 +94,11 @@ bool UIPageViewTest::init()
     return false;
 }
 
-void UIPageViewTest::pageViewEvent(Ref *pSender, PageView::EventType type)
+void UIPageViewTest::pageViewEvent(Ref *pSender, PageViewEventType type)
 {
     switch (type)
     {
-        case PageView::EventType::TURNING:
+        case PAGEVIEW_EVENT_TURNING:
         {
             PageView* pageView = dynamic_cast<PageView*>(pSender);
             
@@ -199,7 +200,9 @@ bool UIPageViewButtonTest::init()
 
 void UIPageViewButtonTest::onButtonClicked(Ref* sender, Widget::TouchEventType type)
 {
-    log("button %s clicked", static_cast<Button*>(sender)->getName().c_str());
+    if(type == Widget::TouchEventType::ENDED) {
+        log("button %s clicked", static_cast<Button*>(sender)->getName().c_str());
+    }
 }
 
 

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIPageViewTest/UIPageViewTest.h
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIPageViewTest/UIPageViewTest.h
@@ -38,7 +38,7 @@ public:
     ~UIPageViewTest();
     virtual bool init() override;
 
-    void pageViewEvent(cocos2d::Ref* sender, cocos2d::ui::PageView::EventType type);
+    void pageViewEvent(cocos2d::Ref* sender, cocos2d::ui::PageViewEventType type);
 
 protected:
 


### PR DESCRIPTION
1. Fix PageView turning event timing, only issue turning event when PageView is indeed turn pages
2. Fix deprecated addEventListenerPageView can't receive turning event issue.
3. Fix PageView clone missing cloning some member instances.
