### PR TITLE
Add explicit type casts to suppress -Wformat warnings

### DIFF
--- a/cocos/audio/android/AudioEngine-inl.cpp
+++ b/cocos/audio/android/AudioEngine-inl.cpp
@@ -219,7 +219,7 @@ int AudioEngineImpl::play2d(const std::string &filePath ,bool loop ,float volume
 
                 if (state != IAudioPlayer::State::OVER && state != IAudioPlayer::State::STOPPED)
                 {
-                    ALOGV("Ignore state: %d", state);
+                    ALOGV("Ignore state: %d", static_cast<int>(state));
                     return;
                 }
 

--- a/cocos/audio/android/AudioMixerController.cpp
+++ b/cocos/audio/android/AudioMixerController.cpp
@@ -220,7 +220,7 @@ void AudioMixerController::mixOneFrame()
             }
             else
             {
-                ALOGW("Previous state (%d) isn't PAUSED, couldn't resume!", track->getPrevState());
+                ALOGW("Previous state (%d) isn't PAUSED, couldn't resume!", static_cast<int>(track->getPrevState()));
             }
         }
         else if (state == Track::State::PAUSED)
@@ -231,7 +231,7 @@ void AudioMixerController::mixOneFrame()
             }
             else
             {
-                ALOGW("Previous state (%d) isn't PLAYING, couldn't pause!", track->getPrevState());
+                ALOGW("Previous state (%d) isn't PLAYING, couldn't pause!", static_cast<int>(track->getPrevState()));
             }
         }
         else if (state == Track::State::STOPPED)

--- a/cocos/audio/android/UrlAudioPlayer.cpp
+++ b/cocos/audio/android/UrlAudioPlayer.cpp
@@ -169,7 +169,7 @@ void UrlAudioPlayer::stop()
     }
     else
     {
-        ALOGW("UrlAudioPlayer (%p, state:%d) isn't playing or paused, could not invoke stop!", this, _state);
+        ALOGW("UrlAudioPlayer (%p, state:%d) isn't playing or paused, could not invoke stop!", this, static_cast<int>(_state));
     }
 }
 
@@ -183,7 +183,7 @@ void UrlAudioPlayer::pause()
     }
     else
     {
-        ALOGW("UrlAudioPlayer (%p, state:%d) isn't playing, could not invoke pause!", this, _state);
+        ALOGW("UrlAudioPlayer (%p, state:%d) isn't playing, could not invoke pause!", this, static_cast<int>(_state));
     }
 }
 
@@ -197,7 +197,7 @@ void UrlAudioPlayer::resume()
     }
     else
     {
-        ALOGW("UrlAudioPlayer (%p, state:%d) isn't paused, could not invoke resume!", this, _state);
+        ALOGW("UrlAudioPlayer (%p, state:%d) isn't paused, could not invoke resume!", this, static_cast<int>(_state));
     }
 }
 
@@ -211,7 +211,7 @@ void UrlAudioPlayer::play()
     }
     else
     {
-        ALOGW("UrlAudioPlayer (%p, state:%d) isn't paused or initialized, could not invoke play!", this, _state);
+        ALOGW("UrlAudioPlayer (%p, state:%d) isn't paused or initialized, could not invoke play!", this, static_cast<int>(_state));
     }
 }
 


### PR DESCRIPTION
The new Audio feature generates the following warnings when compiling with Android NDK r10d using GCC 4.9:

```
cocos/audio/android/AudioEngine-inl.cpp:222:118: warning: format '%d' expects argument of type 'int', but argument 4 has type 'cocos2d::experimental::IAudioPlayer::State' [-Wformat=]
cocos/audio/android/AudioMixerController.cpp:223:161: warning: format '%d' expects argument of type 'int', but argument 4 has type 'cocos2d::experimental::Track::State' [-Wformat=]
cocos/audio/android/AudioMixerController.cpp:234:161: warning: format '%d' expects argument of type 'int', but argument 4 has type 'cocos2d::experimental::Track::State' [-Wformat=]
cocos/audio/android/UrlAudioPlayer.cpp:172:165: warning: format '%d' expects argument of type 'int', but argument 5 has type 'cocos2d::experimental::IAudioPlayer::State' [-Wformat=]
cocos/audio/android/UrlAudioPlayer.cpp:186:156: warning: format '%d' expects argument of type 'int', but argument 5 has type 'cocos2d::experimental::IAudioPlayer::State' [-Wformat=]
cocos/audio/android/UrlAudioPlayer.cpp:200:156: warning: format '%d' expects argument of type 'int', but argument 5 has type 'cocos2d::experimental::IAudioPlayer::State' [-Wformat=]
cocos/audio/android/UrlAudioPlayer.cpp:214:169: warning: format '%d' expects argument of type 'int', but argument 5 has type 'cocos2d::experimental::IAudioPlayer::State' [-Wformat=]
```

This patch adds `static_cast<int>` to avoids the warnings. Thanks!
