### PR TITLE
[Android] Notify waitup only while preloadEffect(info, cb) is invoked in play2d.

### DIFF
--- a/cocos/audio/android/AudioDecoder.cpp
+++ b/cocos/audio/android/AudioDecoder.cpp
@@ -133,9 +133,24 @@ bool AudioDecoder::start()
     bool ret;
     do
     {
-        ret = decodeToPcm(); if (!ret) break;
-        ret = resample(); if (!ret) break;
-        ret = interleave(); if (!ret) break;
+        ret = decodeToPcm();
+        if (!ret) 
+        {
+            ALOGE("decodeToPcm (%s) failed!", _url.c_str());
+            break;
+        }
+        ret = resample();
+        if (!ret) 
+        {
+            ALOGE("resample (%s) failed!", _url.c_str());
+            break;
+        }
+        ret = interleave();
+        if (!ret) 
+        {
+            ALOGE("interleave (%s) failed!", _url.c_str());
+            break;
+        }
 
         auto nowTime = clockNow();
 
@@ -143,6 +158,8 @@ bool AudioDecoder::start()
               intervalInMS(oldTime, nowTime));
 
     } while(false);
+
+    ALOGV_IF(!ret, "%s returns false, decode (%s)", __FUNCTION__, _url.c_str());
     return ret;
 }
 

--- a/cocos/audio/android/AudioPlayerProvider.h
+++ b/cocos/audio/android/AudioPlayerProvider.h
@@ -88,7 +88,7 @@ private:
 
     UrlAudioPlayer *createUrlAudioPlayer(const AudioFileInfo &info);
 
-    void preloadEffect(const AudioFileInfo &info, const PreloadCallback& cb);
+    void preloadEffect(const AudioFileInfo &info, const PreloadCallback& cb, bool isPreloadInPlay2d);
 
     AudioFileInfo getFileInfo(const std::string &audioFilePath);
 


### PR DESCRIPTION
Currently, if a audio isn't preloaded, then play2d will wait the preload operation to finish.
