### PR TITLE
Fix size/position calculations for Linux system fonts.

### DIFF
--- a/cocos/platform/linux/CCDevice-linux.cpp
+++ b/cocos/platform/linux/CCDevice-linux.cpp
@@ -71,7 +71,8 @@ struct LineBreakLine {
     void calculateWidth() {
         lineWidth = 0;
         if ( glyphs.empty() == false ) {
-            lineWidth = glyphs.at(glyphs.size() - 1).paintPosition + glyphs.at(glyphs.size() - 1).glyphWidth;
+            LineBreakGlyph& glyph = glyphs.at(glyphs.size() - 1);
+            lineWidth = glyph.paintPosition + max(glyph.glyphWidth, glyph.horizAdvance - glyph.bearingX);
         }
     }
 };
@@ -192,6 +193,7 @@ public:
         LineBreakLine currentLine;
 
         int currentPaintPosition = 0;
+        int firstBreakIndex = -1;
         int lastBreakIndex = -1;
         bool hasKerning = FT_HAS_KERNING( face );
         while ((unicode=utf8((char**)&pText))) {
@@ -202,6 +204,7 @@ public:
                 currentLine.reset();
                 prevGlyphIndex = 0;
                 prevCharacter = 0;
+                firstBreakIndex = -1;
                 lastBreakIndex = -1;
                 currentPaintPosition = 0;
                 continue;
@@ -216,14 +219,6 @@ public:
                 return false;
             }
 
-            if (iswspace(unicode)) {
-                currentPaintPosition += face->glyph->metrics.horiAdvance >> 6;
-                prevGlyphIndex = glyphIndex;
-                prevCharacter = unicode;
-                lastBreakIndex = currentLine.glyphs.size();
-                continue;
-            }
-
             LineBreakGlyph glyph;
             glyph.glyphIndex = glyphIndex;
             glyph.glyphWidth = face->glyph->metrics.width >> 6;
@@ -236,48 +231,66 @@ public:
                 glyph.kerning = delta.x >> 6;
             }
 
-            if (iMaxWidth > 0 && currentPaintPosition + glyph.bearingX + glyph.kerning + glyph.glyphWidth > iMaxWidth) {
-
-                int glyphCount = currentLine.glyphs.size();
-                if ( lastBreakIndex >= 0 && lastBreakIndex < glyphCount && currentPaintPosition + glyph.bearingX + glyph.kerning + glyph.glyphWidth - currentLine.glyphs.at(lastBreakIndex).paintPosition < iMaxWidth ) {
-                    // we insert a line break at our last break opportunity
-                    std::vector<LineBreakGlyph> tempGlyphs;
-                    std::vector<LineBreakGlyph>::iterator it = currentLine.glyphs.begin();
-                    std::advance(it, lastBreakIndex);
-                    tempGlyphs.insert(tempGlyphs.begin(), it, currentLine.glyphs.end());
-                    currentLine.glyphs.erase(it, currentLine.glyphs.end());
-                    currentLine.calculateWidth();
-                    iMaxLineWidth = max(iMaxLineWidth, currentLine.lineWidth);
-                    textLines.push_back(currentLine);
-                    currentLine.reset();
-                    currentPaintPosition = 0;
-                    for ( it = tempGlyphs.begin(); it != tempGlyphs.end(); it++ ) {
-                        if ( currentLine.glyphs.empty() ) {
-                            currentPaintPosition = -(*it).bearingX;
-                            (*it).kerning = 0;
-                        }
-                        (*it).paintPosition = currentPaintPosition + (*it).bearingX + (*it).kerning;
-                        currentLine.glyphs.push_back((*it));
-                        currentPaintPosition += (*it).kerning + (*it).horizAdvance;
-                    }
-                } else {
-                    // the current word is too big to fit into one line, insert line break right here
-                    currentPaintPosition = 0;
-                    glyph.kerning = 0;
-                    currentLine.calculateWidth();
-                    iMaxLineWidth = max(iMaxLineWidth, currentLine.lineWidth);
-                    textLines.push_back(currentLine);
-                    currentLine.reset();
-                }
-
-                prevGlyphIndex = 0;
-                prevCharacter = 0;
-                lastBreakIndex = -1;
-            } else {
+            if (iswspace(unicode)) {
                 prevGlyphIndex = glyphIndex;
                 prevCharacter = unicode;
-            }
+                lastBreakIndex = currentLine.glyphs.size();
 
+                if (firstBreakIndex == -1)
+                    firstBreakIndex = lastBreakIndex;
+            } else {
+                if (iswspace(prevCharacter))
+                    lastBreakIndex = currentLine.glyphs.size();
+
+                if (iMaxWidth > 0 && currentPaintPosition + glyph.bearingX + glyph.kerning + glyph.glyphWidth > iMaxWidth) {
+                    int glyphCount = currentLine.glyphs.size();
+                    if ( lastBreakIndex >= 0 && lastBreakIndex < glyphCount && currentPaintPosition + glyph.bearingX + glyph.kerning + glyph.glyphWidth - currentLine.glyphs.at(lastBreakIndex).paintPosition < iMaxWidth ) {
+                        // we insert a line break at our last break opportunity
+                        std::vector<LineBreakGlyph> tempGlyphs;
+                        std::vector<LineBreakGlyph>::iterator it = currentLine.glyphs.begin();
+                        std::advance(it, lastBreakIndex);
+                        tempGlyphs.insert(tempGlyphs.begin(), it, currentLine.glyphs.end());
+                        if (firstBreakIndex == -1) {
+                            currentLine.glyphs.erase(it, currentLine.glyphs.end());
+                        } else {
+                            it = currentLine.glyphs.begin();
+                            std::advance(it, firstBreakIndex);
+                            currentLine.glyphs.erase(it, currentLine.glyphs.end());
+                        }
+                        currentLine.calculateWidth();
+                        iMaxLineWidth = max(iMaxLineWidth, currentLine.lineWidth);
+                        textLines.push_back(currentLine);
+                        currentLine.reset();
+                        currentPaintPosition = 0;
+                        for ( it = tempGlyphs.begin(); it != tempGlyphs.end(); it++ ) {
+                            if ( currentLine.glyphs.empty() ) {
+                                currentPaintPosition = -(*it).bearingX;
+                                (*it).kerning = 0;
+                            }
+                            (*it).paintPosition = currentPaintPosition + (*it).bearingX + (*it).kerning;
+                            currentLine.glyphs.push_back((*it));
+                            currentPaintPosition += (*it).kerning + (*it).horizAdvance;
+                        }
+                    } else {
+                        // the current word is too big to fit into one line, insert line break right here
+                        currentPaintPosition = 0;
+                        glyph.kerning = 0;
+                        currentLine.calculateWidth();
+                        iMaxLineWidth = max(iMaxLineWidth, currentLine.lineWidth);
+                        textLines.push_back(currentLine);
+                        currentLine.reset();
+                    }
+    
+                    prevGlyphIndex = 0;
+                    prevCharacter = 0;
+                    firstBreakIndex = -1;
+                    lastBreakIndex = -1;
+                } else {
+                    prevGlyphIndex = glyphIndex;
+                    prevCharacter = unicode;
+                }
+            }
+            
             if ( currentLine.glyphs.empty() ) {
                 currentPaintPosition = -glyph.bearingX;
             }
@@ -310,7 +323,7 @@ public:
     }
 
     int computeLineStartY( FT_Face face, Device::TextAlign eAlignMask, int txtHeight, int borderHeight ){
-        int baseLinePos = ceilf(FT_MulFix( face->bbox.yMax, face->size->metrics.y_scale )/64.0f);
+        int baseLinePos = ceilf(face->size->metrics.ascender/64.0f);
         if (eAlignMask == Device::TextAlign::CENTER || eAlignMask == Device::TextAlign::LEFT || eAlignMask == Device::TextAlign::RIGHT) {
             //vertical center
             return (borderHeight - txtHeight) / 2 + baseLinePos;
@@ -404,13 +417,9 @@ public:
         iMaxLineWidth = MAX(iMaxLineWidth, textDefinition._dimensions.width);
 
         //compute the final line height
-        iMaxLineHeight = ceilf(FT_MulFix( face->bbox.yMax - face->bbox.yMin, face->size->metrics.y_scale )/64.0f);
         int lineHeight = face->size->metrics.height>>6;
-        if ( textLines.size() > 0 ) {
-            iMaxLineHeight += (lineHeight * (textLines.size() -1));
-        }
-        int txtHeight = iMaxLineHeight;
-        iMaxLineHeight = MAX(iMaxLineHeight, textDefinition._dimensions.height);
+        int txtHeight = (lineHeight * textLines.size());
+        iMaxLineHeight = MAX(txtHeight, textDefinition._dimensions.height);
 
         _data = (unsigned char*)malloc(sizeof(unsigned char) * (iMaxLineWidth * iMaxLineHeight * 4));
         memset(_data,0, iMaxLineWidth * iMaxLineHeight*4);


### PR DESCRIPTION
Here are screenshots from cpp-tests before and after the change on Linux, and the same screenshots on Windows for comparison.
- RichText XMLSmallBig test before than changes:
  The line height was incorrect (too big) and the horizontal spacing was too small ("normal" was stuck to the dot after "bigger").
  ![xmlsmallbig_before](https://cloud.githubusercontent.com/assets/11037060/17452117/4e4412ce-5b3a-11e6-9b7f-77ac59a98585.png)
- after the changes:
  ![xmlsmallbig_after](https://cloud.githubusercontent.com/assets/11037060/17452137/6bd2be4e-5b3a-11e6-94b9-86bd93c52c1d.png)
- on Windows:
  ![xmlsmallbig_windows](https://cloud.githubusercontent.com/assets/11037060/17452140/7436b446-5b3a-11e6-9c19-22f4e945d868.png)
- XMLFace test before the changes:
  The line height was incorrect (too big).
  ![xmlface_before](https://cloud.githubusercontent.com/assets/11037060/17452142/7e702190-5b3a-11e6-9383-6e263e72f012.png)
- after the changes:
  ![xmlface_after](https://cloud.githubusercontent.com/assets/11037060/17452143/83652984-5b3a-11e6-872c-81b1cae4fcea.png)
- on Windows:
  ![xmlface_windows](https://cloud.githubusercontent.com/assets/11037060/17452145/887eead6-5b3a-11e6-88ea-584198419117.png)
