### PR TITLE
Remove AppDelegate memory leak in Android projects

### DIFF
--- a/templates/cpp-template-default/proj.android-studio/app/jni/hellocpp/main.cpp
+++ b/templates/cpp-template-default/proj.android-studio/app/jni/hellocpp/main.cpp
@@ -1,3 +1,5 @@
+#include <memory>
+
 #include <android/log.h>
 #include <jni.h>
 
@@ -6,7 +8,11 @@
 #define  LOG_TAG    "main"
 #define  LOGD(...)  __android_log_print(ANDROID_LOG_DEBUG,LOG_TAG,__VA_ARGS__)
 
+namespace {
+std::unique_ptr<AppDelegate> appDelegate;
+}
+
 void cocos_android_app_init(JNIEnv* env) {
     LOGD("cocos_android_app_init");
-    AppDelegate *pAppDelegate = new AppDelegate();
+    appDelegate.reset(new AppDelegate());
 }

--- a/templates/cpp-template-default/proj.android-studio/app/jni/hellocpp/main.cpp
+++ b/templates/cpp-template-default/proj.android-studio/app/jni/hellocpp/main.cpp
@@ -1,15 +1,12 @@
-#include "AppDelegate.h"
-#include "cocos2d.h"
-#include "platform/android/jni/JniHelper.h"
-#include <jni.h>
 #include <android/log.h>
+#include <jni.h>
+
+#include "AppDelegate.h"
 
 #define  LOG_TAG    "main"
 #define  LOGD(...)  __android_log_print(ANDROID_LOG_DEBUG,LOG_TAG,__VA_ARGS__)
 
-using namespace cocos2d;
-
-void cocos_android_app_init (JNIEnv* env) {
+void cocos_android_app_init(JNIEnv* env) {
     LOGD("cocos_android_app_init");
     AppDelegate *pAppDelegate = new AppDelegate();
 }

--- a/templates/cpp-template-default/proj.android/jni/hellocpp/main.cpp
+++ b/templates/cpp-template-default/proj.android/jni/hellocpp/main.cpp
@@ -1,3 +1,5 @@
+#include <memory>
+
 #include <android/log.h>
 #include <jni.h>
 
@@ -6,7 +8,11 @@
 #define  LOG_TAG    "main"
 #define  LOGD(...)  __android_log_print(ANDROID_LOG_DEBUG,LOG_TAG,__VA_ARGS__)
 
+namespace {
+std::unique_ptr<AppDelegate> appDelegate;
+}
+
 void cocos_android_app_init(JNIEnv* env) {
     LOGD("cocos_android_app_init");
-    AppDelegate *pAppDelegate = new AppDelegate();
+    appDelegate.reset(new AppDelegate());
 }

--- a/templates/cpp-template-default/proj.android/jni/hellocpp/main.cpp
+++ b/templates/cpp-template-default/proj.android/jni/hellocpp/main.cpp
@@ -1,15 +1,12 @@
-#include "AppDelegate.h"
-#include "cocos2d.h"
-#include "platform/android/jni/JniHelper.h"
-#include <jni.h>
 #include <android/log.h>
+#include <jni.h>
+
+#include "AppDelegate.h"
 
 #define  LOG_TAG    "main"
 #define  LOGD(...)  __android_log_print(ANDROID_LOG_DEBUG,LOG_TAG,__VA_ARGS__)
 
-using namespace cocos2d;
-
-void cocos_android_app_init (JNIEnv* env) {
+void cocos_android_app_init(JNIEnv* env) {
     LOGD("cocos_android_app_init");
     AppDelegate *pAppDelegate = new AppDelegate();
 }

--- a/templates/js-template-default/frameworks/runtime-src/proj.android-studio/app/jni/hellojavascript/main.cpp
+++ b/templates/js-template-default/frameworks/runtime-src/proj.android-studio/app/jni/hellojavascript/main.cpp
@@ -1,3 +1,5 @@
+#include <memory>
+
 #include <android/log.h>
 #include <jni.h>
 
@@ -6,7 +8,11 @@
 #define  LOG_TAG    "main"
 #define  LOGD(...)  __android_log_print(ANDROID_LOG_DEBUG,LOG_TAG,__VA_ARGS__)
 
+namespace {
+std::unique_ptr<AppDelegate> appDelegate;
+}
+
 void cocos_android_app_init(JNIEnv* env) {
     LOGD("cocos_android_app_init");
-    AppDelegate *pAppDelegate = new AppDelegate();
+    appDelegate.reset(new AppDelegate());
 }

--- a/templates/js-template-default/frameworks/runtime-src/proj.android-studio/app/jni/hellojavascript/main.cpp
+++ b/templates/js-template-default/frameworks/runtime-src/proj.android-studio/app/jni/hellojavascript/main.cpp
@@ -1,15 +1,12 @@
-#include "AppDelegate.h"
-#include "cocos2d.h"
-#include "platform/android/jni/JniHelper.h"
-#include <jni.h>
 #include <android/log.h>
+#include <jni.h>
+
+#include "AppDelegate.h"
 
 #define  LOG_TAG    "main"
 #define  LOGD(...)  __android_log_print(ANDROID_LOG_DEBUG,LOG_TAG,__VA_ARGS__)
 
-using namespace cocos2d;
-
-void cocos_android_app_init (JNIEnv* env) {
+void cocos_android_app_init(JNIEnv* env) {
     LOGD("cocos_android_app_init");
     AppDelegate *pAppDelegate = new AppDelegate();
 }

--- a/templates/js-template-default/frameworks/runtime-src/proj.android/jni/hellojavascript/main.cpp
+++ b/templates/js-template-default/frameworks/runtime-src/proj.android/jni/hellojavascript/main.cpp
@@ -1,3 +1,5 @@
+#include <memory>
+
 #include <android/log.h>
 #include <jni.h>
 
@@ -6,7 +8,11 @@
 #define  LOG_TAG    "main"
 #define  LOGD(...)  __android_log_print(ANDROID_LOG_DEBUG,LOG_TAG,__VA_ARGS__)
 
+namespace {
+std::unique_ptr<AppDelegate> appDelegate;
+}
+
 void cocos_android_app_init(JNIEnv* env) {
     LOGD("cocos_android_app_init");
-    AppDelegate *pAppDelegate = new AppDelegate();
+    appDelegate.reset(new AppDelegate());
 }

--- a/templates/js-template-default/frameworks/runtime-src/proj.android/jni/hellojavascript/main.cpp
+++ b/templates/js-template-default/frameworks/runtime-src/proj.android/jni/hellojavascript/main.cpp
@@ -1,15 +1,12 @@
-#include "AppDelegate.h"
-#include "cocos2d.h"
-#include "platform/android/jni/JniHelper.h"
-#include <jni.h>
 #include <android/log.h>
+#include <jni.h>
+
+#include "AppDelegate.h"
 
 #define  LOG_TAG    "main"
 #define  LOGD(...)  __android_log_print(ANDROID_LOG_DEBUG,LOG_TAG,__VA_ARGS__)
 
-using namespace cocos2d;
-
-void cocos_android_app_init (JNIEnv* env) {
+void cocos_android_app_init(JNIEnv* env) {
     LOGD("cocos_android_app_init");
     AppDelegate *pAppDelegate = new AppDelegate();
 }

--- a/templates/lua-template-default/frameworks/runtime-src/proj.android-studio/app/jni/hellolua/main.cpp
+++ b/templates/lua-template-default/frameworks/runtime-src/proj.android-studio/app/jni/hellolua/main.cpp
@@ -1,3 +1,5 @@
+#include <memory>
+
 #include <android/log.h>
 #include <jni.h>
 
@@ -6,7 +8,11 @@
 #define  LOG_TAG    "main"
 #define  LOGD(...)  __android_log_print(ANDROID_LOG_DEBUG,LOG_TAG,__VA_ARGS__)
 
+namespace {
+std::unique_ptr<AppDelegate> appDelegate;
+}
+
 void cocos_android_app_init(JNIEnv* env) {
     LOGD("cocos_android_app_init");
-    AppDelegate *pAppDelegate = new AppDelegate();
+    appDelegate.reset(new AppDelegate());
 }

--- a/templates/lua-template-default/frameworks/runtime-src/proj.android-studio/app/jni/hellolua/main.cpp
+++ b/templates/lua-template-default/frameworks/runtime-src/proj.android-studio/app/jni/hellolua/main.cpp
@@ -1,13 +1,12 @@
-#include "AppDelegate.h"
-#include "cocos2d.h"
 #include <android/log.h>
+#include <jni.h>
+
+#include "AppDelegate.h"
 
 #define  LOG_TAG    "main"
 #define  LOGD(...)  __android_log_print(ANDROID_LOG_DEBUG,LOG_TAG,__VA_ARGS__)
 
-using namespace cocos2d;
-
-void cocos_android_app_init (JNIEnv* env) {
+void cocos_android_app_init(JNIEnv* env) {
     LOGD("cocos_android_app_init");
     AppDelegate *pAppDelegate = new AppDelegate();
 }

--- a/templates/lua-template-default/frameworks/runtime-src/proj.android/jni/hellolua/main.cpp
+++ b/templates/lua-template-default/frameworks/runtime-src/proj.android/jni/hellolua/main.cpp
@@ -1,3 +1,5 @@
+#include <memory>
+
 #include <android/log.h>
 #include <jni.h>
 
@@ -6,7 +8,11 @@
 #define  LOG_TAG    "main"
 #define  LOGD(...)  __android_log_print(ANDROID_LOG_DEBUG,LOG_TAG,__VA_ARGS__)
 
+namespace {
+std::unique_ptr<AppDelegate> appDelegate;
+}
+
 void cocos_android_app_init(JNIEnv* env) {
     LOGD("cocos_android_app_init");
-    AppDelegate *pAppDelegate = new AppDelegate();
+    appDelegate.reset(new AppDelegate());
 }

--- a/templates/lua-template-default/frameworks/runtime-src/proj.android/jni/hellolua/main.cpp
+++ b/templates/lua-template-default/frameworks/runtime-src/proj.android/jni/hellolua/main.cpp
@@ -1,13 +1,12 @@
-#include "AppDelegate.h"
-#include "cocos2d.h"
 #include <android/log.h>
+#include <jni.h>
+
+#include "AppDelegate.h"
 
 #define  LOG_TAG    "main"
 #define  LOGD(...)  __android_log_print(ANDROID_LOG_DEBUG,LOG_TAG,__VA_ARGS__)
 
-using namespace cocos2d;
-
-void cocos_android_app_init (JNIEnv* env) {
+void cocos_android_app_init(JNIEnv* env) {
     LOGD("cocos_android_app_init");
     AppDelegate *pAppDelegate = new AppDelegate();
 }

--- a/tests/cpp-empty-test/proj.android-studio/app/jni/main.cpp
+++ b/tests/cpp-empty-test/proj.android-studio/app/jni/main.cpp
@@ -1,3 +1,5 @@
+#include <memory>
+
 #include <android/log.h>
 #include <jni.h>
 
@@ -6,7 +8,11 @@
 #define  LOG_TAG    "main"
 #define  LOGD(...)  __android_log_print(ANDROID_LOG_DEBUG,LOG_TAG,__VA_ARGS__)
 
+namespace {
+std::unique_ptr<AppDelegate> appDelegate;
+}
+
 void cocos_android_app_init(JNIEnv* env) {
     LOGD("cocos_android_app_init");
-    AppDelegate *pAppDelegate = new AppDelegate();
+    appDelegate.reset(new AppDelegate());
 }

--- a/tests/cpp-empty-test/proj.android-studio/app/jni/main.cpp
+++ b/tests/cpp-empty-test/proj.android-studio/app/jni/main.cpp
@@ -1,16 +1,12 @@
-#include "AppDelegate.h"
-#include "platform/android/jni/JniHelper.h"
-#include <jni.h>
 #include <android/log.h>
+#include <jni.h>
 
-#include "cocos2d.h"
+#include "AppDelegate.h"
 
 #define  LOG_TAG    "main"
 #define  LOGD(...)  __android_log_print(ANDROID_LOG_DEBUG,LOG_TAG,__VA_ARGS__)
 
-using namespace cocos2d;
-
-void cocos_android_app_init (JNIEnv* env) {
+void cocos_android_app_init(JNIEnv* env) {
     LOGD("cocos_android_app_init");
     AppDelegate *pAppDelegate = new AppDelegate();
 }

--- a/tests/cpp-empty-test/proj.android/jni/main.cpp
+++ b/tests/cpp-empty-test/proj.android/jni/main.cpp
@@ -1,3 +1,5 @@
+#include <memory>
+
 #include <android/log.h>
 #include <jni.h>
 
@@ -6,7 +8,11 @@
 #define  LOG_TAG    "main"
 #define  LOGD(...)  __android_log_print(ANDROID_LOG_DEBUG,LOG_TAG,__VA_ARGS__)
 
+namespace {
+std::unique_ptr<AppDelegate> appDelegate;
+}
+
 void cocos_android_app_init(JNIEnv* env) {
     LOGD("cocos_android_app_init");
-    AppDelegate *pAppDelegate = new AppDelegate();
+    appDelegate.reset(new AppDelegate());
 }

--- a/tests/cpp-empty-test/proj.android/jni/main.cpp
+++ b/tests/cpp-empty-test/proj.android/jni/main.cpp
@@ -1,16 +1,12 @@
-#include "AppDelegate.h"
-#include "platform/android/jni/JniHelper.h"
-#include <jni.h>
 #include <android/log.h>
+#include <jni.h>
 
-#include "cocos2d.h"
+#include "AppDelegate.h"
 
 #define  LOG_TAG    "main"
 #define  LOGD(...)  __android_log_print(ANDROID_LOG_DEBUG,LOG_TAG,__VA_ARGS__)
 
-using namespace cocos2d;
-
-void cocos_android_app_init (JNIEnv* env) {
+void cocos_android_app_init(JNIEnv* env) {
     LOGD("cocos_android_app_init");
     AppDelegate *pAppDelegate = new AppDelegate();
 }

--- a/tests/cpp-tests/proj.android-studio/app/jni/main.cpp
+++ b/tests/cpp-tests/proj.android-studio/app/jni/main.cpp
@@ -1,3 +1,5 @@
+#include <memory>
+
 #include <android/log.h>
 #include <jni.h>
 
@@ -6,7 +8,11 @@
 #define  LOG_TAG    "main"
 #define  LOGD(...)  __android_log_print(ANDROID_LOG_DEBUG,LOG_TAG,__VA_ARGS__)
 
+namespace {
+std::unique_ptr<AppDelegate> appDelegate;
+}
+
 void cocos_android_app_init(JNIEnv* env) {
     LOGD("cocos_android_app_init");
-    AppDelegate *pAppDelegate = new AppDelegate();
+    appDelegate.reset(new AppDelegate());
 }

--- a/tests/cpp-tests/proj.android-studio/app/jni/main.cpp
+++ b/tests/cpp-tests/proj.android-studio/app/jni/main.cpp
@@ -1,15 +1,12 @@
-#include "AppDelegate.h"
-#include "cocos2d.h"
-#include "platform/android/jni/JniHelper.h"
-#include <jni.h>
 #include <android/log.h>
+#include <jni.h>
+
+#include "AppDelegate.h"
 
 #define  LOG_TAG    "main"
 #define  LOGD(...)  __android_log_print(ANDROID_LOG_DEBUG,LOG_TAG,__VA_ARGS__)
 
-using namespace cocos2d;
-
-void cocos_android_app_init (JNIEnv* env) {
+void cocos_android_app_init(JNIEnv* env) {
     LOGD("cocos_android_app_init");
     AppDelegate *pAppDelegate = new AppDelegate();
 }

--- a/tests/cpp-tests/proj.android/jni/main.cpp
+++ b/tests/cpp-tests/proj.android/jni/main.cpp
@@ -1,3 +1,5 @@
+#include <memory>
+
 #include <android/log.h>
 #include <jni.h>
 
@@ -6,7 +8,11 @@
 #define  LOG_TAG    "main"
 #define  LOGD(...)  __android_log_print(ANDROID_LOG_DEBUG,LOG_TAG,__VA_ARGS__)
 
+namespace {
+std::unique_ptr<AppDelegate> appDelegate;
+}
+
 void cocos_android_app_init(JNIEnv* env) {
     LOGD("cocos_android_app_init");
-    AppDelegate *pAppDelegate = new AppDelegate();
+    appDelegate.reset(new AppDelegate());
 }

--- a/tests/cpp-tests/proj.android/jni/main.cpp
+++ b/tests/cpp-tests/proj.android/jni/main.cpp
@@ -1,15 +1,12 @@
-#include "AppDelegate.h"
-#include "cocos2d.h"
-#include "platform/android/jni/JniHelper.h"
-#include <jni.h>
 #include <android/log.h>
+#include <jni.h>
+
+#include "AppDelegate.h"
 
 #define  LOG_TAG    "main"
 #define  LOGD(...)  __android_log_print(ANDROID_LOG_DEBUG,LOG_TAG,__VA_ARGS__)
 
-using namespace cocos2d;
-
-void cocos_android_app_init (JNIEnv* env) {
+void cocos_android_app_init(JNIEnv* env) {
     LOGD("cocos_android_app_init");
     AppDelegate *pAppDelegate = new AppDelegate();
 }

--- a/tests/game-controller-test/proj.android-studio/app/jni/main.cpp
+++ b/tests/game-controller-test/proj.android-studio/app/jni/main.cpp
@@ -1,3 +1,5 @@
+#include <memory>
+
 #include <android/log.h>
 #include <jni.h>
 
@@ -6,7 +8,11 @@
 #define  LOG_TAG    "main"
 #define  LOGD(...)  __android_log_print(ANDROID_LOG_DEBUG,LOG_TAG,__VA_ARGS__)
 
+namespace {
+std::unique_ptr<AppDelegate> appDelegate;
+}
+
 void cocos_android_app_init(JNIEnv* env) {
     LOGD("cocos_android_app_init");
-    AppDelegate *pAppDelegate = new AppDelegate();
+    appDelegate.reset(new AppDelegate());
 }

--- a/tests/game-controller-test/proj.android-studio/app/jni/main.cpp
+++ b/tests/game-controller-test/proj.android-studio/app/jni/main.cpp
@@ -1,16 +1,12 @@
-#include "AppDelegate.h"
-#include "platform/android/jni/JniHelper.h"
-#include <jni.h>
 #include <android/log.h>
+#include <jni.h>
 
-#include "cocos2d.h"
+#include "AppDelegate.h"
 
 #define  LOG_TAG    "main"
 #define  LOGD(...)  __android_log_print(ANDROID_LOG_DEBUG,LOG_TAG,__VA_ARGS__)
 
-using namespace cocos2d;
-
-void cocos_android_app_init (JNIEnv* env) {
+void cocos_android_app_init(JNIEnv* env) {
     LOGD("cocos_android_app_init");
     AppDelegate *pAppDelegate = new AppDelegate();
 }

--- a/tests/game-controller-test/proj.android/jni/main.cpp
+++ b/tests/game-controller-test/proj.android/jni/main.cpp
@@ -1,3 +1,5 @@
+#include <memory>
+
 #include <android/log.h>
 #include <jni.h>
 
@@ -6,7 +8,11 @@
 #define  LOG_TAG    "main"
 #define  LOGD(...)  __android_log_print(ANDROID_LOG_DEBUG,LOG_TAG,__VA_ARGS__)
 
+namespace {
+std::unique_ptr<AppDelegate> appDelegate;
+}
+
 void cocos_android_app_init(JNIEnv* env) {
     LOGD("cocos_android_app_init");
-    AppDelegate *pAppDelegate = new AppDelegate();
+    appDelegate.reset(new AppDelegate());
 }

--- a/tests/game-controller-test/proj.android/jni/main.cpp
+++ b/tests/game-controller-test/proj.android/jni/main.cpp
@@ -1,16 +1,12 @@
-#include "AppDelegate.h"
-#include "platform/android/jni/JniHelper.h"
-#include <jni.h>
 #include <android/log.h>
+#include <jni.h>
 
-#include "cocos2d.h"
+#include "AppDelegate.h"
 
 #define  LOG_TAG    "main"
 #define  LOGD(...)  __android_log_print(ANDROID_LOG_DEBUG,LOG_TAG,__VA_ARGS__)
 
-using namespace cocos2d;
-
-void cocos_android_app_init (JNIEnv* env) {
+void cocos_android_app_init(JNIEnv* env) {
     LOGD("cocos_android_app_init");
     AppDelegate *pAppDelegate = new AppDelegate();
 }

--- a/tests/js-memory-gc-tests/project/proj.android-studio/app/jni/main.cpp
+++ b/tests/js-memory-gc-tests/project/proj.android-studio/app/jni/main.cpp
@@ -1,3 +1,5 @@
+#include <memory>
+
 #include <android/log.h>
 #include <jni.h>
 
@@ -6,7 +8,11 @@
 #define  LOG_TAG    "main"
 #define  LOGD(...)  __android_log_print(ANDROID_LOG_DEBUG,LOG_TAG,__VA_ARGS__)
 
+namespace {
+std::unique_ptr<AppDelegate> appDelegate;
+}
+
 void cocos_android_app_init(JNIEnv* env) {
     LOGD("cocos_android_app_init");
-    AppDelegate *pAppDelegate = new AppDelegate();
+    appDelegate.reset(new AppDelegate());
 }

--- a/tests/js-memory-gc-tests/project/proj.android-studio/app/jni/main.cpp
+++ b/tests/js-memory-gc-tests/project/proj.android-studio/app/jni/main.cpp
@@ -1,17 +1,12 @@
-#include "AppDelegate.h"
-#include "cocos2d.h"
-#include "platform/android/jni/JniHelper.h"
-#include <jni.h>
 #include <android/log.h>
+#include <jni.h>
+
+#include "AppDelegate.h"
 
 #define  LOG_TAG    "main"
 #define  LOGD(...)  __android_log_print(ANDROID_LOG_DEBUG,LOG_TAG,__VA_ARGS__)
 
-using namespace cocos2d;
-
-void cocos_android_app_init (JNIEnv* env) {
+void cocos_android_app_init(JNIEnv* env) {
     LOGD("cocos_android_app_init");
     AppDelegate *pAppDelegate = new AppDelegate();
-    JavaVM* vm;
-    env->GetJavaVM(&vm);
 }

--- a/tests/js-memory-gc-tests/project/proj.android/jni/main.cpp
+++ b/tests/js-memory-gc-tests/project/proj.android/jni/main.cpp
@@ -1,3 +1,5 @@
+#include <memory>
+
 #include <android/log.h>
 #include <jni.h>
 
@@ -6,7 +8,11 @@
 #define  LOG_TAG    "main"
 #define  LOGD(...)  __android_log_print(ANDROID_LOG_DEBUG,LOG_TAG,__VA_ARGS__)
 
+namespace {
+std::unique_ptr<AppDelegate> appDelegate;
+}
+
 void cocos_android_app_init(JNIEnv* env) {
     LOGD("cocos_android_app_init");
-    AppDelegate *pAppDelegate = new AppDelegate();
+    appDelegate.reset(new AppDelegate());
 }

--- a/tests/js-memory-gc-tests/project/proj.android/jni/main.cpp
+++ b/tests/js-memory-gc-tests/project/proj.android/jni/main.cpp
@@ -1,17 +1,12 @@
-#include "AppDelegate.h"
-#include "cocos2d.h"
-#include "platform/android/jni/JniHelper.h"
-#include <jni.h>
 #include <android/log.h>
+#include <jni.h>
+
+#include "AppDelegate.h"
 
 #define  LOG_TAG    "main"
 #define  LOGD(...)  __android_log_print(ANDROID_LOG_DEBUG,LOG_TAG,__VA_ARGS__)
 
-using namespace cocos2d;
-
-void cocos_android_app_init (JNIEnv* env) {
+void cocos_android_app_init(JNIEnv* env) {
     LOGD("cocos_android_app_init");
     AppDelegate *pAppDelegate = new AppDelegate();
-    JavaVM* vm;
-    env->GetJavaVM(&vm);
 }

--- a/tests/js-tests/project/proj.android-studio/app/jni/main.cpp
+++ b/tests/js-tests/project/proj.android-studio/app/jni/main.cpp
@@ -1,3 +1,5 @@
+#include <memory>
+
 #include <android/log.h>
 #include <jni.h>
 
@@ -6,7 +8,11 @@
 #define  LOG_TAG    "main"
 #define  LOGD(...)  __android_log_print(ANDROID_LOG_DEBUG,LOG_TAG,__VA_ARGS__)
 
+namespace {
+std::unique_ptr<AppDelegate> appDelegate;
+}
+
 void cocos_android_app_init(JNIEnv* env) {
     LOGD("cocos_android_app_init");
-    AppDelegate *pAppDelegate = new AppDelegate();
+    appDelegate.reset(new AppDelegate());
 }

--- a/tests/js-tests/project/proj.android-studio/app/jni/main.cpp
+++ b/tests/js-tests/project/proj.android-studio/app/jni/main.cpp
@@ -1,17 +1,12 @@
-#include "AppDelegate.h"
-#include "cocos2d.h"
-#include "platform/android/jni/JniHelper.h"
-#include <jni.h>
 #include <android/log.h>
+#include <jni.h>
+
+#include "AppDelegate.h"
 
 #define  LOG_TAG    "main"
 #define  LOGD(...)  __android_log_print(ANDROID_LOG_DEBUG,LOG_TAG,__VA_ARGS__)
 
-using namespace cocos2d;
-
-void cocos_android_app_init (JNIEnv* env) {
+void cocos_android_app_init(JNIEnv* env) {
     LOGD("cocos_android_app_init");
     AppDelegate *pAppDelegate = new AppDelegate();
-    JavaVM* vm;
-    env->GetJavaVM(&vm);
 }

--- a/tests/js-tests/project/proj.android/jni/main.cpp
+++ b/tests/js-tests/project/proj.android/jni/main.cpp
@@ -1,3 +1,5 @@
+#include <memory>
+
 #include <android/log.h>
 #include <jni.h>
 
@@ -6,7 +8,11 @@
 #define  LOG_TAG    "main"
 #define  LOGD(...)  __android_log_print(ANDROID_LOG_DEBUG,LOG_TAG,__VA_ARGS__)
 
+namespace {
+std::unique_ptr<AppDelegate> appDelegate;
+}
+
 void cocos_android_app_init(JNIEnv* env) {
     LOGD("cocos_android_app_init");
-    AppDelegate *pAppDelegate = new AppDelegate();
+    appDelegate.reset(new AppDelegate());
 }

--- a/tests/js-tests/project/proj.android/jni/main.cpp
+++ b/tests/js-tests/project/proj.android/jni/main.cpp
@@ -1,17 +1,12 @@
-#include "AppDelegate.h"
-#include "cocos2d.h"
-#include "platform/android/jni/JniHelper.h"
-#include <jni.h>
 #include <android/log.h>
+#include <jni.h>
+
+#include "AppDelegate.h"
 
 #define  LOG_TAG    "main"
 #define  LOGD(...)  __android_log_print(ANDROID_LOG_DEBUG,LOG_TAG,__VA_ARGS__)
 
-using namespace cocos2d;
-
-void cocos_android_app_init (JNIEnv* env) {
+void cocos_android_app_init(JNIEnv* env) {
     LOGD("cocos_android_app_init");
     AppDelegate *pAppDelegate = new AppDelegate();
-    JavaVM* vm;
-    env->GetJavaVM(&vm);
 }

--- a/tests/lua-empty-test/project/proj.android-studio/app/jni/main.cpp
+++ b/tests/lua-empty-test/project/proj.android-studio/app/jni/main.cpp
@@ -1,3 +1,5 @@
+#include <memory>
+
 #include <android/log.h>
 #include <jni.h>
 
@@ -6,7 +8,11 @@
 #define  LOG_TAG    "main"
 #define  LOGD(...)  __android_log_print(ANDROID_LOG_DEBUG,LOG_TAG,__VA_ARGS__)
 
+namespace {
+std::unique_ptr<AppDelegate> appDelegate;
+}
+
 void cocos_android_app_init(JNIEnv* env) {
     LOGD("cocos_android_app_init");
-    AppDelegate *pAppDelegate = new AppDelegate();
+    appDelegate.reset(new AppDelegate());
 }

--- a/tests/lua-empty-test/project/proj.android-studio/app/jni/main.cpp
+++ b/tests/lua-empty-test/project/proj.android-studio/app/jni/main.cpp
@@ -1,15 +1,12 @@
-#include "AppDelegate.h"
-#include "cocos2d.h"
-#include "platform/android/jni/JniHelper.h"
-#include <jni.h>
 #include <android/log.h>
+#include <jni.h>
+
+#include "AppDelegate.h"
 
 #define  LOG_TAG    "main"
 #define  LOGD(...)  __android_log_print(ANDROID_LOG_DEBUG,LOG_TAG,__VA_ARGS__)
 
-using namespace cocos2d;
-
-void cocos_android_app_init (JNIEnv* env) {
+void cocos_android_app_init(JNIEnv* env) {
     LOGD("cocos_android_app_init");
     AppDelegate *pAppDelegate = new AppDelegate();
 }

--- a/tests/lua-empty-test/project/proj.android/jni/main.cpp
+++ b/tests/lua-empty-test/project/proj.android/jni/main.cpp
@@ -1,3 +1,5 @@
+#include <memory>
+
 #include <android/log.h>
 #include <jni.h>
 
@@ -6,7 +8,11 @@
 #define  LOG_TAG    "main"
 #define  LOGD(...)  __android_log_print(ANDROID_LOG_DEBUG,LOG_TAG,__VA_ARGS__)
 
+namespace {
+std::unique_ptr<AppDelegate> appDelegate;
+}
+
 void cocos_android_app_init(JNIEnv* env) {
     LOGD("cocos_android_app_init");
-    AppDelegate *pAppDelegate = new AppDelegate();
+    appDelegate.reset(new AppDelegate());
 }

--- a/tests/lua-empty-test/project/proj.android/jni/main.cpp
+++ b/tests/lua-empty-test/project/proj.android/jni/main.cpp
@@ -1,15 +1,12 @@
-#include "AppDelegate.h"
-#include "cocos2d.h"
-#include "platform/android/jni/JniHelper.h"
-#include <jni.h>
 #include <android/log.h>
+#include <jni.h>
+
+#include "AppDelegate.h"
 
 #define  LOG_TAG    "main"
 #define  LOGD(...)  __android_log_print(ANDROID_LOG_DEBUG,LOG_TAG,__VA_ARGS__)
 
-using namespace cocos2d;
-
-void cocos_android_app_init (JNIEnv* env) {
+void cocos_android_app_init(JNIEnv* env) {
     LOGD("cocos_android_app_init");
     AppDelegate *pAppDelegate = new AppDelegate();
 }

--- a/tests/lua-game-controller-test/project/proj.android-studio/app/jni/main.cpp
+++ b/tests/lua-game-controller-test/project/proj.android-studio/app/jni/main.cpp
@@ -1,3 +1,5 @@
+#include <memory>
+
 #include <android/log.h>
 #include <jni.h>
 
@@ -6,7 +8,11 @@
 #define  LOG_TAG    "main"
 #define  LOGD(...)  __android_log_print(ANDROID_LOG_DEBUG,LOG_TAG,__VA_ARGS__)
 
+namespace {
+std::unique_ptr<AppDelegate> appDelegate;
+}
+
 void cocos_android_app_init(JNIEnv* env) {
     LOGD("cocos_android_app_init");
-    AppDelegate *pAppDelegate = new AppDelegate();
+    appDelegate.reset(new AppDelegate());
 }

--- a/tests/lua-game-controller-test/project/proj.android-studio/app/jni/main.cpp
+++ b/tests/lua-game-controller-test/project/proj.android-studio/app/jni/main.cpp
@@ -1,15 +1,12 @@
-#include "AppDelegate.h"
-#include "cocos2d.h"
-#include "platform/android/jni/JniHelper.h"
-#include <jni.h>
 #include <android/log.h>
+#include <jni.h>
+
+#include "AppDelegate.h"
 
 #define  LOG_TAG    "main"
 #define  LOGD(...)  __android_log_print(ANDROID_LOG_DEBUG,LOG_TAG,__VA_ARGS__)
 
-using namespace cocos2d;
-
-void cocos_android_app_init (JNIEnv* env) {
+void cocos_android_app_init(JNIEnv* env) {
     LOGD("cocos_android_app_init");
-    AppDelegate *pAppDelegate = new (std::nothrow) AppDelegate();
+    AppDelegate *pAppDelegate = new AppDelegate();
 }

--- a/tests/lua-game-controller-test/project/proj.android/jni/main.cpp
+++ b/tests/lua-game-controller-test/project/proj.android/jni/main.cpp
@@ -1,3 +1,5 @@
+#include <memory>
+
 #include <android/log.h>
 #include <jni.h>
 
@@ -6,7 +8,11 @@
 #define  LOG_TAG    "main"
 #define  LOGD(...)  __android_log_print(ANDROID_LOG_DEBUG,LOG_TAG,__VA_ARGS__)
 
+namespace {
+std::unique_ptr<AppDelegate> appDelegate;
+}
+
 void cocos_android_app_init(JNIEnv* env) {
     LOGD("cocos_android_app_init");
-    AppDelegate *pAppDelegate = new AppDelegate();
+    appDelegate.reset(new AppDelegate());
 }

--- a/tests/lua-game-controller-test/project/proj.android/jni/main.cpp
+++ b/tests/lua-game-controller-test/project/proj.android/jni/main.cpp
@@ -1,15 +1,12 @@
-#include "AppDelegate.h"
-#include "cocos2d.h"
-#include "platform/android/jni/JniHelper.h"
-#include <jni.h>
 #include <android/log.h>
+#include <jni.h>
+
+#include "AppDelegate.h"
 
 #define  LOG_TAG    "main"
 #define  LOGD(...)  __android_log_print(ANDROID_LOG_DEBUG,LOG_TAG,__VA_ARGS__)
 
-using namespace cocos2d;
-
-void cocos_android_app_init (JNIEnv* env) {
+void cocos_android_app_init(JNIEnv* env) {
     LOGD("cocos_android_app_init");
-    AppDelegate *pAppDelegate = new (std::nothrow) AppDelegate();
+    AppDelegate *pAppDelegate = new AppDelegate();
 }

--- a/tests/lua-tests/project/proj.android-studio/app/jni/main.cpp
+++ b/tests/lua-tests/project/proj.android-studio/app/jni/main.cpp
@@ -1,3 +1,5 @@
+#include <memory>
+
 #include <android/log.h>
 #include <jni.h>
 
@@ -6,7 +8,11 @@
 #define  LOG_TAG    "main"
 #define  LOGD(...)  __android_log_print(ANDROID_LOG_DEBUG,LOG_TAG,__VA_ARGS__)
 
+namespace {
+std::unique_ptr<AppDelegate> appDelegate;
+}
+
 void cocos_android_app_init(JNIEnv* env) {
     LOGD("cocos_android_app_init");
-    AppDelegate *pAppDelegate = new AppDelegate();
+    appDelegate.reset(new AppDelegate());
 }

--- a/tests/lua-tests/project/proj.android-studio/app/jni/main.cpp
+++ b/tests/lua-tests/project/proj.android-studio/app/jni/main.cpp
@@ -1,15 +1,12 @@
-#include "AppDelegate.h"
-#include "cocos2d.h"
-#include "platform/android/jni/JniHelper.h"
-#include <jni.h>
 #include <android/log.h>
+#include <jni.h>
+
+#include "AppDelegate.h"
 
 #define  LOG_TAG    "main"
 #define  LOGD(...)  __android_log_print(ANDROID_LOG_DEBUG,LOG_TAG,__VA_ARGS__)
 
-using namespace cocos2d;
-
-void cocos_android_app_init (JNIEnv* env) {
+void cocos_android_app_init(JNIEnv* env) {
     LOGD("cocos_android_app_init");
     AppDelegate *pAppDelegate = new AppDelegate();
 }

--- a/tests/lua-tests/project/proj.android/jni/main.cpp
+++ b/tests/lua-tests/project/proj.android/jni/main.cpp
@@ -1,3 +1,5 @@
+#include <memory>
+
 #include <android/log.h>
 #include <jni.h>
 
@@ -6,7 +8,11 @@
 #define  LOG_TAG    "main"
 #define  LOGD(...)  __android_log_print(ANDROID_LOG_DEBUG,LOG_TAG,__VA_ARGS__)
 
+namespace {
+std::unique_ptr<AppDelegate> appDelegate;
+}
+
 void cocos_android_app_init(JNIEnv* env) {
     LOGD("cocos_android_app_init");
-    AppDelegate *pAppDelegate = new AppDelegate();
+    appDelegate.reset(new AppDelegate());
 }

--- a/tests/lua-tests/project/proj.android/jni/main.cpp
+++ b/tests/lua-tests/project/proj.android/jni/main.cpp
@@ -1,15 +1,12 @@
-#include "AppDelegate.h"
-#include "cocos2d.h"
-#include "platform/android/jni/JniHelper.h"
-#include <jni.h>
 #include <android/log.h>
+#include <jni.h>
+
+#include "AppDelegate.h"
 
 #define  LOG_TAG    "main"
 #define  LOGD(...)  __android_log_print(ANDROID_LOG_DEBUG,LOG_TAG,__VA_ARGS__)
 
-using namespace cocos2d;
-
-void cocos_android_app_init (JNIEnv* env) {
+void cocos_android_app_init(JNIEnv* env) {
     LOGD("cocos_android_app_init");
     AppDelegate *pAppDelegate = new AppDelegate();
 }

--- a/tests/performance-tests/proj.android-studio/app/jni/hellocpp/main.cpp
+++ b/tests/performance-tests/proj.android-studio/app/jni/hellocpp/main.cpp
@@ -1,3 +1,5 @@
+#include <memory>
+
 #include <android/log.h>
 #include <jni.h>
 
@@ -6,7 +8,11 @@
 #define  LOG_TAG    "main"
 #define  LOGD(...)  __android_log_print(ANDROID_LOG_DEBUG,LOG_TAG,__VA_ARGS__)
 
+namespace {
+std::unique_ptr<AppDelegate> appDelegate;
+}
+
 void cocos_android_app_init(JNIEnv* env) {
     LOGD("cocos_android_app_init");
-    AppDelegate *pAppDelegate = new AppDelegate();
+    appDelegate.reset(new AppDelegate());
 }

--- a/tests/performance-tests/proj.android-studio/app/jni/hellocpp/main.cpp
+++ b/tests/performance-tests/proj.android-studio/app/jni/hellocpp/main.cpp
@@ -1,15 +1,12 @@
-#include "AppDelegate.h"
-#include "cocos2d.h"
-#include "platform/android/jni/JniHelper.h"
-#include <jni.h>
 #include <android/log.h>
+#include <jni.h>
+
+#include "AppDelegate.h"
 
 #define  LOG_TAG    "main"
 #define  LOGD(...)  __android_log_print(ANDROID_LOG_DEBUG,LOG_TAG,__VA_ARGS__)
 
-using namespace cocos2d;
-
-void cocos_android_app_init (JNIEnv* env) {
+void cocos_android_app_init(JNIEnv* env) {
     LOGD("cocos_android_app_init");
     AppDelegate *pAppDelegate = new AppDelegate();
 }

--- a/tests/performance-tests/proj.android/jni/hellocpp/main.cpp
+++ b/tests/performance-tests/proj.android/jni/hellocpp/main.cpp
@@ -1,3 +1,5 @@
+#include <memory>
+
 #include <android/log.h>
 #include <jni.h>
 
@@ -6,7 +8,11 @@
 #define  LOG_TAG    "main"
 #define  LOGD(...)  __android_log_print(ANDROID_LOG_DEBUG,LOG_TAG,__VA_ARGS__)
 
+namespace {
+std::unique_ptr<AppDelegate> appDelegate;
+}
+
 void cocos_android_app_init(JNIEnv* env) {
     LOGD("cocos_android_app_init");
-    AppDelegate *pAppDelegate = new AppDelegate();
+    appDelegate.reset(new AppDelegate());
 }

--- a/tests/performance-tests/proj.android/jni/hellocpp/main.cpp
+++ b/tests/performance-tests/proj.android/jni/hellocpp/main.cpp
@@ -1,15 +1,12 @@
-#include "AppDelegate.h"
-#include "cocos2d.h"
-#include "platform/android/jni/JniHelper.h"
-#include <jni.h>
 #include <android/log.h>
+#include <jni.h>
+
+#include "AppDelegate.h"
 
 #define  LOG_TAG    "main"
 #define  LOGD(...)  __android_log_print(ANDROID_LOG_DEBUG,LOG_TAG,__VA_ARGS__)
 
-using namespace cocos2d;
-
-void cocos_android_app_init (JNIEnv* env) {
+void cocos_android_app_init(JNIEnv* env) {
     LOGD("cocos_android_app_init");
     AppDelegate *pAppDelegate = new AppDelegate();
 }

--- a/tools/simulator/frameworks/runtime-src/proj.android/jni/hellolua/main.cpp
+++ b/tools/simulator/frameworks/runtime-src/proj.android/jni/hellolua/main.cpp
@@ -1,3 +1,5 @@
+#include <memory>
+
 #include <android/log.h>
 #include <jni.h>
 
@@ -6,7 +8,11 @@
 #define  LOG_TAG    "main"
 #define  LOGD(...)  __android_log_print(ANDROID_LOG_DEBUG,LOG_TAG,__VA_ARGS__)
 
+namespace {
+std::unique_ptr<AppDelegate> appDelegate;
+}
+
 void cocos_android_app_init(JNIEnv* env) {
     LOGD("cocos_android_app_init");
-    AppDelegate *pAppDelegate = new AppDelegate();
+    appDelegate.reset(new AppDelegate());
 }

--- a/tools/simulator/frameworks/runtime-src/proj.android/jni/hellolua/main.cpp
+++ b/tools/simulator/frameworks/runtime-src/proj.android/jni/hellolua/main.cpp
@@ -1,13 +1,12 @@
+#include <android/log.h>
+#include <jni.h>
+
 #include "AppDelegate.h"
-#include "cocos2d.h"
 
 #define  LOG_TAG    "main"
 #define  LOGD(...)  __android_log_print(ANDROID_LOG_DEBUG,LOG_TAG,__VA_ARGS__)
 
-using namespace cocos2d;
-
-void cocos_android_app_init (JNIEnv* env, jobject thiz) {
+void cocos_android_app_init(JNIEnv* env) {
     LOGD("cocos_android_app_init");
     AppDelegate *pAppDelegate = new AppDelegate();
 }
-


### PR DESCRIPTION
AppDelegate object and all its members are never released.
As a solution, I proposed to use static `unique_ptr` that could destroy it at the end of the application.

Before applying the aforementioned fix I corrected also code style and correctness of `main.cpp` files in Android projects:
- removed unused includes (reducing dependencies and compilation time)
- removed unused code
- corrected code style (whitespaces, headers' order, etc).
