### PR TITLE
V3.13 remove the /ZW option from all .c files in Win10 libSpline

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,4 +37,4 @@ before_install:
 # whitelist
 branches:
   only:
-    - v3
+    - v3.13

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,57 @@
+cocos2d-x-3.13 Aug 22 2016
+
+[HIGHLIGHT]     add VR plugin
+[HIGHLIGHT]     support ETC1 alpha channel
+[HIGHLIGHT]     fix AudioEngine performance for Android 4.2+
+[HIGHLIGHT]     add Andorid arm-64 support
+[HIGHLIGHT]     switch to use gcc 4.9
+[HIGHLIGHT]     upgrade CURL to 7.50.0
+[HIGHLIGHT]     upgrade Spine to 3.4
+[HIGHLIGHT]     update glfw to 3.2
+
+[NEW]           add `Configuration::supportsMapBuffer()`
+[NEW]           support hexagonal tile maps
+[NEW]           add `ListView::setScrollDuration()`
+[NEW]           implement `SimpleAudioEngine::willPlayBackgroundMusic()` on Android
+[NEW]           implement `AudioEngine::preload()` on Android
+[NEW]           add `cc.Node['.classname']` to get class name for tolua C++ class in lua
+
+[REFINE]        optimize Node sorting speed for 64-bit
+[REFINE]        using `chrono::steady_clock()` instread of gettimeofday for FPS calculation
+[REFINE]        use `fstat` instead of `fseek` and `ftell` for performance to read file content
+[REFINE]        use std::string reference instead of char* for `utils::findChild()`
+[REFINE]        make `MotionStreak` _maxPoints framerate independent
+[REFINE]        support utf-8 bom lua script
+[REFINE]        can show utf-8 characters in MessageBox and lua log on win32
+
+[FIX]           the color of underline is different from the text color
+[FIX]           memory leak in `MenuItemToggle::create()`
+[FIX]           crash after removing a physics body right after adding it
+[FIX]           SpriteBatchNode crash if CC_SPRITE_DEBUG_DRAW is enabled
+[FIX]           `FileUtils::removeDirectory()` can not work on all platforms except iOS and Mac
+[FIX]           memory leak in `Data::move()`
+[FIX]           crash in `EaseExpoentialOut::clone()`
+[FIX]           buffer over-read in `GLProgram::updateUniformLocation()`
+[FIX]           `dirty` variable incorrectly reset with a multiple camera setup causing drawing issues on Sprite
+[FIX]           fix label text formatter right alignment
+[FIX]           `bsd_signal` link error on Android
+[FIX]           crash while decoding small MP3 file on Android
+[FIX]           `AppDelegate::applicationWillEnterForeground()` is invoked at launch on Android
+[FIX]           fix `relocation overflow in R_ARM_THM_CALL` on Android
+[FIX]           navigation bar doesn't hide if show and dismiss keyboard on Android
+[FIX]           `utils::getTimeInMilliseconds()` may return wrong value on Android
+[FIX]           compiling error with Android 6.0(API 23)
+[FIX]           music is not resumed when app is reactived on iOS
+[FIX]           random crash in `alGenBuffers` at startup on iOS
+[FIX]           can not play audio if uncache and play audio many times on iOS
+[FIX]           `Text::create()` crash if it contains invalid string on iOS
+[FIX]           new js project link error on linux
+[FIX]           design resolution broken after minimize on desk platforms
+[FIX]           can not get the `backClicked` in lua
+[FIX]           `cc.convertColor` issue in lua
+[FIX]           browser version detection
+[FIX]           compiling error with `cocos gen-libs`
+
 cocos2d-x-3.12 Jul 06 2016
 
 [HIGHLIGHT]     add VR support

--- a/README.md
+++ b/README.md
@@ -170,11 +170,11 @@ Main features
 Build Requirements
 ------------------
 
-* Mac OS X 10.7+, Xcode 5.1+
+* Mac OS X 10.7+, Xcode 7+
 * or Ubuntu 12.10+, CMake 2.6+
 * or Windows 7+, VS 2013+
 * Python 2.7.5
-* NDK r11+ is required to build Android games
+* NDK r11+ and API level 19 is required to build Android games
 * Windows Phone/Store 8.1 VS 2013 Update 4+ or VS 2015
 * Windows Phone/Store 10.0 VS 2015
 * JRE or JDK 1.6+ is required for web publishing

--- a/cocos/2d/CCMotionStreak.cpp
+++ b/cocos/2d/CCMotionStreak.cpp
@@ -386,7 +386,7 @@ void MotionStreak::onDraw(const Mat4 &transform, uint32_t flags)
     GL::enableVertexAttribs(GL::VERTEX_ATTRIB_FLAG_POS_COLOR_TEX );
     GL::blendFunc( _blendFunc.src, _blendFunc.dst );
 
-    GL::bindTexture2D( _texture->getName() );
+    GL::bindTexture2D( _texture );
 
     glVertexAttribPointer(GLProgram::VERTEX_ATTRIB_POSITION, 2, GL_FLOAT, GL_FALSE, 0, _vertices);
     glVertexAttribPointer(GLProgram::VERTEX_ATTRIB_TEX_COORD, 2, GL_FLOAT, GL_FALSE, 0, _texCoords);

--- a/cocos/2d/CCNode.cpp
+++ b/cocos/2d/CCNode.cpp
@@ -953,7 +953,6 @@ void Node::addChildHelper(Node* child, int localZOrder, int tag, const std::stri
         child->setName(name);
     
     child->setParent(this);
-    child->setCameraMask(getCameraMask());
 
     child->updateOrderOfArrival();
 

--- a/cocos/2d/CCProgressTimer.cpp
+++ b/cocos/2d/CCProgressTimer.cpp
@@ -78,7 +78,7 @@ bool ProgressTimer::initWithSprite(Sprite* sp)
     setSprite(sp);
 
     // shader state
-    setGLProgramState(sp->getGLProgramState()/*GLProgramState::getOrCreateWithGLProgramName(GLProgram::SHADER_NAME_POSITION_TEXTURE_COLOR)*/);
+    setGLProgramState(GLProgramState::getOrCreateWithGLProgramName(GLProgram::SHADER_NAME_POSITION_TEXTURE_COLOR));
     return true;
 }
 

--- a/cocos/2d/CCProgressTimer.cpp
+++ b/cocos/2d/CCProgressTimer.cpp
@@ -78,7 +78,7 @@ bool ProgressTimer::initWithSprite(Sprite* sp)
     setSprite(sp);
 
     // shader state
-    setGLProgramState(GLProgramState::getOrCreateWithGLProgramName(GLProgram::SHADER_NAME_POSITION_TEXTURE_COLOR));
+    setGLProgramState(GLProgramState::getOrCreateWithGLProgramName(GLProgram::SHADER_NAME_POSITION_TEXTURE_COLOR, sp->getTexture()));
     return true;
 }
 
@@ -512,7 +512,7 @@ void ProgressTimer::onDraw(const Mat4 &transform, uint32_t flags)
 
     GL::enableVertexAttribs(GL::VERTEX_ATTRIB_FLAG_POS_COLOR_TEX );
 
-    GL::bindTexture2D( _sprite->getTexture()->getName() );
+    GL::bindTexture2D( _sprite->getTexture() );
 
     glVertexAttribPointer( GLProgram::VERTEX_ATTRIB_POSITION, 2, GL_FLOAT, GL_FALSE, sizeof(_vertexData[0]) , &_vertexData[0].vertices);
     glVertexAttribPointer( GLProgram::VERTEX_ATTRIB_TEX_COORD, 2, GL_FLOAT, GL_FALSE, sizeof(_vertexData[0]), &_vertexData[0].texCoords);

--- a/cocos/audio/android/AudioDecoder.cpp
+++ b/cocos/audio/android/AudioDecoder.cpp
@@ -133,9 +133,24 @@ bool AudioDecoder::start()
     bool ret;
     do
     {
-        ret = decodeToPcm(); if (!ret) break;
-        ret = resample(); if (!ret) break;
-        ret = interleave(); if (!ret) break;
+        ret = decodeToPcm();
+        if (!ret) 
+        {
+            ALOGE("decodeToPcm (%s) failed!", _url.c_str());
+            break;
+        }
+        ret = resample();
+        if (!ret) 
+        {
+            ALOGE("resample (%s) failed!", _url.c_str());
+            break;
+        }
+        ret = interleave();
+        if (!ret) 
+        {
+            ALOGE("interleave (%s) failed!", _url.c_str());
+            break;
+        }
 
         auto nowTime = clockNow();
 
@@ -143,6 +158,8 @@ bool AudioDecoder::start()
               intervalInMS(oldTime, nowTime));
 
     } while(false);
+
+    ALOGV_IF(!ret, "%s returns false, decode (%s)", __FUNCTION__, _url.c_str());
     return ret;
 }
 

--- a/cocos/audio/android/AudioPlayerProvider.h
+++ b/cocos/audio/android/AudioPlayerProvider.h
@@ -88,7 +88,7 @@ private:
 
     UrlAudioPlayer *createUrlAudioPlayer(const AudioFileInfo &info);
 
-    void preloadEffect(const AudioFileInfo &info, const PreloadCallback& cb);
+    void preloadEffect(const AudioFileInfo &info, const PreloadCallback& cb, bool isPreloadInPlay2d);
 
     AudioFileInfo getFileInfo(const std::string &audioFilePath);
 

--- a/cocos/audio/win32/AudioCache.h
+++ b/cocos/audio/win32/AudioCache.h
@@ -41,6 +41,38 @@
 #define QUEUEBUFFER_NUM 5
 #define QUEUEBUFFER_TIME_STEP 0.1f
 
+// log, CCLOG aren't threadsafe, since we uses sub threads for parsing pcm data, threadsafe log output
+// is needed. Define the following macros (ALOGV, ALOGD, ALOGI, ALOGW, ALOGE) for threadsafe log output.
+
+//FIXME:Move the definition of the following macros to a separated file.
+
+void audioLog(const char * format, ...);
+
+#define QUOTEME_(x) #x
+#define QUOTEME(x) QUOTEME_(x)
+
+#if defined(COCOS2D_DEBUG) && COCOS2D_DEBUG > 0
+#define ALOGV(fmt, ...) audioLog("V/" LOG_TAG " (" QUOTEME(__LINE__) "): " fmt "", ##__VA_ARGS__)
+#else
+#define ALOGV(fmt, ...) do {} while(false)
+#endif
+#define ALOGD(fmt, ...) audioLog("D/" LOG_TAG " (" QUOTEME(__LINE__) "): " fmt "", ##__VA_ARGS__)
+#define ALOGI(fmt, ...) audioLog("I/" LOG_TAG " (" QUOTEME(__LINE__) "): " fmt "", ##__VA_ARGS__)
+#define ALOGW(fmt, ...) audioLog("W/" LOG_TAG " (" QUOTEME(__LINE__) "): " fmt "", ##__VA_ARGS__)
+#define ALOGE(fmt, ...) audioLog("E/" LOG_TAG " (" QUOTEME(__LINE__) "): " fmt "", ##__VA_ARGS__)
+
+#if defined(COCOS2D_DEBUG) && COCOS2D_DEBUG > 0
+#define CHECK_AL_ERROR_DEBUG() \
+do { \
+    GLenum __error = alGetError(); \
+    if (__error) { \
+        ALOGE("OpenAL error 0x%04X in %s %s %d\n", __error, __FILE__, __FUNCTION__, __LINE__); \
+    } \
+} while (false)
+#else
+#define CHECK_AL_ERROR_DEBUG() 
+#endif
+
 NS_CC_BEGIN
 namespace experimental{
 

--- a/cocos/audio/win32/AudioEngine-win32.cpp
+++ b/cocos/audio/win32/AudioEngine-win32.cpp
@@ -21,6 +21,8 @@
  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  THE SOFTWARE.
  ****************************************************************************/
+#define LOG_TAG "AudioEngine-Win32"
+
 #include "platform/CCPlatformConfig.h"
 
 #if CC_TARGET_PLATFORM == CC_PLATFORM_WIN32
@@ -88,7 +90,7 @@ bool AudioEngineImpl::init()
             alGenSources(MAX_AUDIOINSTANCES, _alSources);
             alError = alGetError();
             if(alError != AL_NO_ERROR){
-                log("%s:generating sources fail! error = %x\n", __FUNCTION__, alError);
+                ALOGE("%s:generating sources fail! error = %x\n", __FUNCTION__, alError);
                 break;
             }
             
@@ -140,14 +142,14 @@ AudioCache* AudioEngineImpl::preload(const std::string& filePath, std::function<
                 }
                 else
                 {
-                    log("Basic setup goes wrong: %s", mpg123_plain_strerror(error));
+                    ALOGE("Basic setup goes wrong: %s", mpg123_plain_strerror(error));
                     break;
                 }
             }
         }
         else
         {
-            log("Unsupported media type file: %s\n", filePath.c_str());
+            ALOGE("Unsupported media type file: %s\n", filePath.c_str());
             break;
         }
 
@@ -245,7 +247,7 @@ void AudioEngineImpl::setVolume(int audioID,float volume)
         
         auto error = alGetError();
         if (error != AL_NO_ERROR) {
-            log("%s: audio id = %d, error = %x\n", __FUNCTION__,audioID,error);
+            ALOGE("%s: audio id = %d, error = %x\n", __FUNCTION__,audioID,error);
         }
     }
 }
@@ -266,7 +268,7 @@ void AudioEngineImpl::setLoop(int audioID, bool loop)
             
             auto error = alGetError();
             if (error != AL_NO_ERROR) {
-                log("%s: audio id = %d, error = %x\n", __FUNCTION__,audioID,error);
+                ALOGE("%s: audio id = %d, error = %x\n", __FUNCTION__,audioID,error);
             }
         }
     }
@@ -283,7 +285,7 @@ bool AudioEngineImpl::pause(int audioID)
     auto error = alGetError();
     if (error != AL_NO_ERROR) {
         ret = false;
-        log("%s: audio id = %d, error = %x\n", __FUNCTION__,audioID,error);
+        ALOGE("%s: audio id = %d, error = %x\n", __FUNCTION__,audioID,error);
     }
     
     return ret;
@@ -297,7 +299,7 @@ bool AudioEngineImpl::resume(int audioID)
     auto error = alGetError();
     if (error != AL_NO_ERROR) {
         ret = false;
-        log("%s: audio id = %d, error = %x\n", __FUNCTION__,audioID,error);
+        ALOGE("%s: audio id = %d, error = %x\n", __FUNCTION__,audioID,error);
     }
     
     return ret;
@@ -313,7 +315,7 @@ bool AudioEngineImpl::stop(int audioID)
         auto error = alGetError();
         if (error != AL_NO_ERROR) {
             ret = false;
-            log("%s: audio id = %d, error = %x\n", __FUNCTION__,audioID,error);
+            ALOGE("%s: audio id = %d, error = %x\n", __FUNCTION__,audioID,error);
         }
     }
     
@@ -380,7 +382,7 @@ float AudioEngineImpl::getCurrentTime(int audioID)
             
             auto error = alGetError();
             if (error != AL_NO_ERROR) {
-                log("%s, audio id:%d,error code:%x", __FUNCTION__,audioID,error);
+                ALOGE("%s, audio id:%d,error code:%x", __FUNCTION__,audioID,error);
             }
         }
     }
@@ -407,7 +409,7 @@ bool AudioEngineImpl::setCurrentTime(int audioID, float time)
             
             auto error = alGetError();
             if (error != AL_NO_ERROR) {
-                log("%s: audio id = %d, error = %x\n", __FUNCTION__,audioID,error);
+                ALOGE("%s: audio id = %d, error = %x\n", __FUNCTION__,audioID,error);
             }
             ret = true;
         }

--- a/cocos/audio/win32/AudioPlayer.h
+++ b/cocos/audio/win32/AudioPlayer.h
@@ -61,7 +61,8 @@ public:
 protected:
     void rotateBufferThread(int offsetFrame);
     bool play2d(AudioCache* cache);
-    
+	int readPcmData(char* buffer, int bufferSize, const std::function<int/*readBytes*/(char* /*buf*/, int /*bytesToRead*/)>& fileReader);
+
     AudioCache* _audioCache;
     
     float _volume;

--- a/cocos/audio/win32/MciPlayer.cpp
+++ b/cocos/audio/win32/MciPlayer.cpp
@@ -88,13 +88,13 @@ void MciPlayer::Open(const char* pFileName, UINT uId)
         MCI_OPEN_PARMS mciOpen = {0};
         MCIERROR mciError;
         mciOpen.lpstrDeviceType = (LPCTSTR)MCI_ALL_DEVICE_ID;
-		WCHAR* fileNameWideChar = new WCHAR[nLen + 1];
-		BREAK_IF(! fileNameWideChar);
-		MultiByteToWideChar(CP_ACP, 0, pFileName, nLen + 1, fileNameWideChar, nLen + 1);
+        WCHAR* fileNameWideChar = new WCHAR[nLen + 1];
+        BREAK_IF(! fileNameWideChar);
+        MultiByteToWideChar(CP_ACP, 0, pFileName, nLen + 1, fileNameWideChar, nLen + 1);
         mciOpen.lpstrElementName = fileNameWideChar;
 
         mciError = mciSendCommand(0,MCI_OPEN, MCI_OPEN_ELEMENT, reinterpret_cast<DWORD_PTR>(&mciOpen));
-		CC_SAFE_DELETE_ARRAY(mciOpen.lpstrElementName);
+        CC_SAFE_DELETE_ARRAY(mciOpen.lpstrElementName);
         BREAK_IF(mciError);
 
         _dev = mciOpen.wDeviceID;

--- a/cocos/editor-support/spine/proj.win10/libSpine.vcxproj
+++ b/cocos/editor-support/spine/proj.win10/libSpine.vcxproj
@@ -30,132 +30,256 @@
     <ClCompile Include="..\Animation.c">
       <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">false</CompileAsWinRT>
       <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">false</CompileAsWinRT>
+      <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">false</CompileAsWinRT>
+      <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">false</CompileAsWinRT>
+      <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</CompileAsWinRT>
+      <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</CompileAsWinRT>
     </ClCompile>
     <ClCompile Include="..\AnimationState.c">
       <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">false</CompileAsWinRT>
       <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">false</CompileAsWinRT>
+      <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">false</CompileAsWinRT>
+      <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">false</CompileAsWinRT>
+      <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</CompileAsWinRT>
+      <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</CompileAsWinRT>
     </ClCompile>
     <ClCompile Include="..\AnimationStateData.c">
       <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">false</CompileAsWinRT>
       <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">false</CompileAsWinRT>
+      <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">false</CompileAsWinRT>
+      <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">false</CompileAsWinRT>
+      <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</CompileAsWinRT>
+      <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</CompileAsWinRT>
     </ClCompile>
     <ClCompile Include="..\Atlas.c">
       <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">false</CompileAsWinRT>
       <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">false</CompileAsWinRT>
+      <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">false</CompileAsWinRT>
+      <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">false</CompileAsWinRT>
+      <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</CompileAsWinRT>
+      <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</CompileAsWinRT>
     </ClCompile>
     <ClCompile Include="..\AtlasAttachmentLoader.c">
       <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">false</CompileAsWinRT>
       <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">false</CompileAsWinRT>
+      <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">false</CompileAsWinRT>
+      <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">false</CompileAsWinRT>
+      <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</CompileAsWinRT>
+      <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</CompileAsWinRT>
     </ClCompile>
     <ClCompile Include="..\Attachment.c">
       <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">false</CompileAsWinRT>
       <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">false</CompileAsWinRT>
+      <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">false</CompileAsWinRT>
+      <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">false</CompileAsWinRT>
+      <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</CompileAsWinRT>
+      <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</CompileAsWinRT>
     </ClCompile>
     <ClCompile Include="..\AttachmentLoader.c">
       <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">false</CompileAsWinRT>
       <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">false</CompileAsWinRT>
+      <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">false</CompileAsWinRT>
+      <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">false</CompileAsWinRT>
+      <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</CompileAsWinRT>
+      <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</CompileAsWinRT>
     </ClCompile>
     <ClCompile Include="..\AttachmentVertices.cpp" />
     <ClCompile Include="..\Bone.c">
       <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">false</CompileAsWinRT>
       <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">false</CompileAsWinRT>
+      <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">false</CompileAsWinRT>
+      <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">false</CompileAsWinRT>
+      <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</CompileAsWinRT>
+      <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</CompileAsWinRT>
     </ClCompile>
     <ClCompile Include="..\BoneData.c">
       <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">false</CompileAsWinRT>
       <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">false</CompileAsWinRT>
+      <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">false</CompileAsWinRT>
+      <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">false</CompileAsWinRT>
+      <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</CompileAsWinRT>
+      <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</CompileAsWinRT>
     </ClCompile>
     <ClCompile Include="..\BoundingBoxAttachment.c">
       <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">false</CompileAsWinRT>
       <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">false</CompileAsWinRT>
+      <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">false</CompileAsWinRT>
+      <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">false</CompileAsWinRT>
+      <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</CompileAsWinRT>
+      <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</CompileAsWinRT>
     </ClCompile>
     <ClCompile Include="..\Cocos2dAttachmentLoader.cpp" />
     <ClCompile Include="..\Event.c">
       <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">false</CompileAsWinRT>
       <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">false</CompileAsWinRT>
+      <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">false</CompileAsWinRT>
+      <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">false</CompileAsWinRT>
+      <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</CompileAsWinRT>
+      <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</CompileAsWinRT>
     </ClCompile>
     <ClCompile Include="..\EventData.c">
       <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">false</CompileAsWinRT>
       <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">false</CompileAsWinRT>
+      <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">false</CompileAsWinRT>
+      <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">false</CompileAsWinRT>
+      <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</CompileAsWinRT>
+      <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</CompileAsWinRT>
     </ClCompile>
     <ClCompile Include="..\extension.c">
       <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">false</CompileAsWinRT>
       <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">false</CompileAsWinRT>
+      <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">false</CompileAsWinRT>
+      <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">false</CompileAsWinRT>
+      <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</CompileAsWinRT>
+      <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</CompileAsWinRT>
     </ClCompile>
     <ClCompile Include="..\IkConstraint.c">
       <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">false</CompileAsWinRT>
       <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">false</CompileAsWinRT>
+      <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">false</CompileAsWinRT>
+      <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">false</CompileAsWinRT>
+      <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</CompileAsWinRT>
+      <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</CompileAsWinRT>
     </ClCompile>
     <ClCompile Include="..\IkConstraintData.c">
       <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">false</CompileAsWinRT>
       <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">false</CompileAsWinRT>
+      <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">false</CompileAsWinRT>
+      <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">false</CompileAsWinRT>
+      <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</CompileAsWinRT>
+      <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</CompileAsWinRT>
     </ClCompile>
     <ClCompile Include="..\Json.c">
       <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">false</CompileAsWinRT>
       <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">false</CompileAsWinRT>
+      <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">false</CompileAsWinRT>
+      <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">false</CompileAsWinRT>
+      <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</CompileAsWinRT>
+      <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</CompileAsWinRT>
     </ClCompile>
     <ClCompile Include="..\MeshAttachment.c">
       <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">false</CompileAsWinRT>
       <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">false</CompileAsWinRT>
+      <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">false</CompileAsWinRT>
+      <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">false</CompileAsWinRT>
+      <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</CompileAsWinRT>
+      <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</CompileAsWinRT>
     </ClCompile>
     <ClCompile Include="..\PathAttachment.c">
       <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">false</CompileAsWinRT>
       <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">false</CompileAsWinRT>
+      <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">false</CompileAsWinRT>
+      <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">false</CompileAsWinRT>
+      <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</CompileAsWinRT>
+      <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</CompileAsWinRT>
     </ClCompile>
     <ClCompile Include="..\PathConstraint.c">
       <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">false</CompileAsWinRT>
       <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">false</CompileAsWinRT>
+      <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">false</CompileAsWinRT>
+      <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">false</CompileAsWinRT>
+      <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</CompileAsWinRT>
+      <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</CompileAsWinRT>
     </ClCompile>
     <ClCompile Include="..\PathConstraintData.c">
       <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">false</CompileAsWinRT>
       <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">false</CompileAsWinRT>
+      <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">false</CompileAsWinRT>
+      <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">false</CompileAsWinRT>
+      <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</CompileAsWinRT>
+      <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</CompileAsWinRT>
     </ClCompile>
     <ClCompile Include="..\RegionAttachment.c">
       <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">false</CompileAsWinRT>
       <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">false</CompileAsWinRT>
+      <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">false</CompileAsWinRT>
+      <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">false</CompileAsWinRT>
+      <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</CompileAsWinRT>
+      <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</CompileAsWinRT>
     </ClCompile>
     <ClCompile Include="..\Skeleton.c">
       <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">false</CompileAsWinRT>
       <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">false</CompileAsWinRT>
+      <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">false</CompileAsWinRT>
+      <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">false</CompileAsWinRT>
+      <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</CompileAsWinRT>
+      <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</CompileAsWinRT>
     </ClCompile>
     <ClCompile Include="..\SkeletonAnimation.cpp" />
     <ClCompile Include="..\SkeletonBatch.cpp" />
     <ClCompile Include="..\SkeletonBounds.c">
       <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">false</CompileAsWinRT>
       <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">false</CompileAsWinRT>
+      <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">false</CompileAsWinRT>
+      <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">false</CompileAsWinRT>
+      <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</CompileAsWinRT>
+      <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</CompileAsWinRT>
     </ClCompile>
     <ClCompile Include="..\SkeletonData.c">
       <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">false</CompileAsWinRT>
       <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">false</CompileAsWinRT>
+      <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">false</CompileAsWinRT>
+      <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">false</CompileAsWinRT>
+      <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</CompileAsWinRT>
+      <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</CompileAsWinRT>
     </ClCompile>
     <ClCompile Include="..\SkeletonJson.c">
       <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">false</CompileAsWinRT>
       <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">false</CompileAsWinRT>
+      <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">false</CompileAsWinRT>
+      <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">false</CompileAsWinRT>
+      <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</CompileAsWinRT>
+      <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</CompileAsWinRT>
     </ClCompile>
     <ClCompile Include="..\SkeletonRenderer.cpp" />
     <ClCompile Include="..\Skin.c">
       <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">false</CompileAsWinRT>
       <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">false</CompileAsWinRT>
+      <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">false</CompileAsWinRT>
+      <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">false</CompileAsWinRT>
+      <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</CompileAsWinRT>
+      <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</CompileAsWinRT>
     </ClCompile>
     <ClCompile Include="..\Slot.c">
       <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">false</CompileAsWinRT>
       <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">false</CompileAsWinRT>
+      <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">false</CompileAsWinRT>
+      <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">false</CompileAsWinRT>
+      <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</CompileAsWinRT>
+      <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</CompileAsWinRT>
     </ClCompile>
     <ClCompile Include="..\SlotData.c">
       <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">false</CompileAsWinRT>
       <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">false</CompileAsWinRT>
+      <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">false</CompileAsWinRT>
+      <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">false</CompileAsWinRT>
+      <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</CompileAsWinRT>
+      <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</CompileAsWinRT>
     </ClCompile>
     <ClCompile Include="..\spine-cocos2dx.cpp" />
     <ClCompile Include="..\TransformConstraint.c">
       <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">false</CompileAsWinRT>
       <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">false</CompileAsWinRT>
+      <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">false</CompileAsWinRT>
+      <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">false</CompileAsWinRT>
+      <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</CompileAsWinRT>
+      <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</CompileAsWinRT>
     </ClCompile>
     <ClCompile Include="..\TransformConstraintData.c">
       <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">false</CompileAsWinRT>
       <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">false</CompileAsWinRT>
+      <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">false</CompileAsWinRT>
+      <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">false</CompileAsWinRT>
+      <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</CompileAsWinRT>
+      <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</CompileAsWinRT>
     </ClCompile>
     <ClCompile Include="..\VertexAttachment.c">
       <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">false</CompileAsWinRT>
       <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">false</CompileAsWinRT>
+      <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">false</CompileAsWinRT>
+      <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">false</CompileAsWinRT>
+      <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</CompileAsWinRT>
+      <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</CompileAsWinRT>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/cocos/platform/android/java/project.properties
+++ b/cocos/platform/android/java/project.properties
@@ -12,4 +12,4 @@
 
 android.library=true
 # Project target.
-target=android-21
+target=android-19

--- a/cocos/platform/android/javaactivity-android.cpp
+++ b/cocos/platform/android/javaactivity-android.cpp
@@ -38,6 +38,7 @@ THE SOFTWARE.
 #include "platform/android/jni/JniHelper.h"
 #include "network/CCDownloader-android.h"
 #include <android/log.h>
+#include <android/api-level.h>
 #include <jni.h>
 
 #define  LOG_TAG    "main"
@@ -49,6 +50,28 @@ using namespace cocos2d;
 
 extern "C"
 {
+
+// ndk break compatibility, refer to https://github.com/cocos2d/cocos2d-x/issues/16267 for detail information
+// should remove it when using NDK r13 since NDK r13 will add back bsd_signal()
+#if __ANDROID_API__ > 19
+#include <signal.h>
+#include <dlfcn.h>
+  typedef __sighandler_t (*bsd_signal_func_t)(int, __sighandler_t);
+  bsd_signal_func_t bsd_signal_func = NULL;
+
+  __sighandler_t bsd_signal(int s, __sighandler_t f) {
+    if (bsd_signal_func == NULL) {
+      // For now (up to Android 7.0) this is always available 
+      bsd_signal_func = (bsd_signal_func_t) dlsym(RTLD_DEFAULT, "bsd_signal");
+
+      if (bsd_signal_func == NULL) {
+        __android_log_assert("", "bsd_signal_wrapper", "bsd_signal symbol not found!");
+      }
+    }
+
+    return bsd_signal_func(s, f);
+  }
+#endif // __ANDROID_API__ > 19
 
 JNIEXPORT jint JNI_OnLoad(JavaVM *vm, void *reserved)
 {

--- a/cocos/renderer/ccGLStateCache.cpp
+++ b/cocos/renderer/ccGLStateCache.cpp
@@ -152,6 +152,15 @@ void bindTexture2D(GLuint textureId)
     GL::bindTexture2DN(0, textureId);
 }
 
+void bindTexture2D(Texture2D* texture)
+{
+    GL::bindTexture2DN(0, texture->getName());
+    auto alphaTexID = texture->getAlphaTextureName();
+    if (alphaTexID > 0) {
+        GL::bindTexture2DN(1, alphaTexID);
+    }
+}
+
 void bindTexture2DN(GLuint textureUnit, GLuint textureId)
 {
 #if CC_ENABLE_GL_STATE_CACHE

--- a/cocos/renderer/ccGLStateCache.h
+++ b/cocos/renderer/ccGLStateCache.h
@@ -41,7 +41,7 @@ NS_CC_BEGIN
  */
 
 class GLProgram;
-
+class Texture2D;
 namespace GL {
 
 /** Vertex attrib flags. */
@@ -125,6 +125,16 @@ void CC_DLL enableVertexAttribs(uint32_t flags);
  * @since v2.0.0
  */
 void CC_DLL bindTexture2D(GLuint textureId);
+
+/**
+* If the texture is not already bound to texture unit 0, it binds it.
+*
+* If CC_ENABLE_GL_STATE_CACHE is disabled, it will call glBindTexture() directly.
+*
+* @remark: It will bind alpha texture to support ETC1 alpha channel.
+* @since v3.13
+*/
+void CC_DLL bindTexture2D(Texture2D* texture);
 
 /** 
  * If the texture is not already bound to a given unit, it binds it.

--- a/cocos/ui/UIPageView.cpp
+++ b/cocos/ui/UIPageView.cpp
@@ -28,7 +28,7 @@ THE SOFTWARE.
 NS_CC_BEGIN
 
 namespace ui {
-    
+
 IMPLEMENT_CLASS_GUI_INFO(PageView)
 
 PageView::PageView():
@@ -62,7 +62,7 @@ PageView* PageView::create()
     CC_SAFE_DELETE(widget);
     return nullptr;
 }
-    
+
 bool PageView::init()
 {
     if (ListView::init())
@@ -134,7 +134,7 @@ void PageView::removePageAtIndex(ssize_t index)
 {
     removeItem(index);
 }
-    
+
 void PageView::removeAllPages()
 {
     removeAllItems();
@@ -169,12 +169,12 @@ float PageView::getCustomScrollThreshold()const
 {
     return 0;
 }
-    
+
 void PageView::setUsingCustomScrollThreshold(bool flag)
 {
     CCLOG("PageView::setUsingCustomScrollThreshold() has no effect!");
 }
-    
+
 bool PageView::isUsingCustomScrollThreshold()const
 {
     return false;
@@ -220,11 +220,12 @@ void PageView::refreshIndicatorPosition()
         _indicator->setPosition(Vec2(posX, posY));
     }
 }
-    
+
 void PageView::handlePressLogic(Touch *touch)
 {
     ListView::handlePressLogic(touch);
     if (!_isTouchBegin) {
+        _currentPageIndex = getIndex(getCenterItemInCurrentView());
         _previousPageIndex = _currentPageIndex;
         _isTouchBegin = true;
     }
@@ -276,7 +277,7 @@ void PageView::handleReleaseLogic(Touch *touch)
         }
     }
 }
-    
+
 float PageView::getAutoScrollStopEpsilon() const
 {
     return _autoScrollStopEpsilon;
@@ -286,7 +287,7 @@ void PageView::addEventListenerPageView(Ref *target, SEL_PageViewEvent selector)
 {
     _pageViewEventListener = target;
     _pageViewEventSelector = selector;
-    
+
     ccScrollViewCallback scrollViewCallback = [=](Ref* ref, ScrollView::EventType type) -> void{
         if (type == ScrollView::EventType::AUTOSCROLL_ENDED && _previousPageIndex != _currentPageIndex) {
             pageTurningEvent();
@@ -294,7 +295,7 @@ void PageView::addEventListenerPageView(Ref *target, SEL_PageViewEvent selector)
     };
     this->addEventListener(scrollViewCallback);
 }
-    
+
 void PageView::pageTurningEvent()
 {
     this->retain();
@@ -313,7 +314,7 @@ void PageView::pageTurningEvent()
     _isTouchBegin = false;
     this->release();
 }
-    
+
 void PageView::addEventListener(const ccPageViewCallback& callback)
 {
     _eventCallback = callback;
@@ -475,13 +476,13 @@ void PageView::setIndicatorIndexNodesColor(const Color3B& color)
         _indicator->setIndexNodesColor(color);
     }
 }
-    
+
 const Color3B& PageView::getIndicatorIndexNodesColor() const
 {
     CCASSERT(_indicator != nullptr, "");
     return _indicator->getIndexNodesColor();
 }
-    
+
 void PageView::setIndicatorIndexNodesScale(float indexNodesScale)
 {
     if(_indicator != nullptr)
@@ -490,13 +491,13 @@ void PageView::setIndicatorIndexNodesScale(float indexNodesScale)
         _indicator->indicate(_currentPageIndex);
     }
 }
-    
+
 float PageView::getIndicatorIndexNodesScale() const
 {
     CCASSERT(_indicator != nullptr, "");
     return _indicator->getIndexNodesScale();
 }
-  
+
 void PageView::setIndicatorIndexNodesTexture(const std::string& texName,Widget::TextureResType texType)
 {
     if(_indicator != nullptr)
@@ -505,7 +506,7 @@ void PageView::setIndicatorIndexNodesTexture(const std::string& texName,Widget::
         _indicator->indicate(_currentPageIndex);
     }
 }
-    
+
 void PageView::remedyLayoutParameter(Widget *item)
 {
     item->setContentSize(this->getContentSize());

--- a/cocos/ui/UIPageView.cpp
+++ b/cocos/ui/UIPageView.cpp
@@ -39,7 +39,8 @@ _childFocusCancelOffset(5.0f),
 _pageViewEventListener(nullptr),
 _pageViewEventSelector(nullptr),
 _eventCallback(nullptr),
-_autoScrollStopEpsilon(0.001f)
+_autoScrollStopEpsilon(0.001f),
+_previousPageIndex(-1)
 {
 }
 
@@ -218,6 +219,12 @@ void PageView::refreshIndicatorPosition()
         _indicator->setPosition(Vec2(posX, posY));
     }
 }
+    
+void PageView::handlePressLogic(Touch *touch)
+{
+    ListView::handlePressLogic(touch);
+    _previousPageIndex = _currentPageIndex;
+}
 
 void PageView::handleReleaseLogic(Touch *touch)
 {
@@ -228,7 +235,6 @@ void PageView::handleReleaseLogic(Touch *touch)
     {
         return;
     }
-
     Vec2 touchMoveVelocity = flattenVectorByDirection(calculateTouchMoveVelocity());
 
     static const float INERTIA_THRESHOLD = 500;
@@ -272,6 +278,19 @@ float PageView::getAutoScrollStopEpsilon() const
     return _autoScrollStopEpsilon;
 }
 
+void PageView::addEventListenerPageView(Ref *target, SEL_PageViewEvent selector)
+{
+    _pageViewEventListener = target;
+    _pageViewEventSelector = selector;
+    
+    ccScrollViewCallback scrollViewCallback = [=](Ref* ref, ScrollView::EventType type) -> void{
+        if (type == ScrollView::EventType::AUTOSCROLL_ENDED && _previousPageIndex != _currentPageIndex) {
+            pageTurningEvent();
+        }
+    };
+    this->addEventListener(scrollViewCallback);
+}
+    
 void PageView::pageTurningEvent()
 {
     this->retain();
@@ -289,19 +308,13 @@ void PageView::pageTurningEvent()
     }
     this->release();
 }
-
-void PageView::addEventListenerPageView(Ref *target, SEL_PageViewEvent selector)
-{
-    _pageViewEventListener = target;
-    _pageViewEventSelector = selector;
-}
     
 void PageView::addEventListener(const ccPageViewCallback& callback)
 {
     _eventCallback = callback;
     ccScrollViewCallback scrollViewCallback = [=](Ref* ref, ScrollView::EventType type) -> void{
-        if (type == ScrollView::EventType::AUTOSCROLL_ENDED) {
-            callback(ref, PageView::EventType::TURNING);
+        if (type == ScrollView::EventType::AUTOSCROLL_ENDED && _previousPageIndex != _currentPageIndex) {
+            pageTurningEvent();
         }
     };
     this->addEventListener(scrollViewCallback);
@@ -364,6 +377,11 @@ void PageView::copySpecialProperties(Widget *widget)
         _ccEventCallback = pageView->_ccEventCallback;
         _pageViewEventListener = pageView->_pageViewEventListener;
         _pageViewEventSelector = pageView->_pageViewEventSelector;
+        _currentPageIndex = pageView->_currentPageIndex;
+        _previousPageIndex = pageView->_previousPageIndex;
+        _childFocusCancelOffset = pageView->_childFocusCancelOffset;
+        _autoScrollStopEpsilon = pageView->_autoScrollStopEpsilon;
+        _indicatorPositionAsAnchorPoint = pageView->_indicatorPositionAsAnchorPoint;
     }
 }
 

--- a/cocos/ui/UIPageView.cpp
+++ b/cocos/ui/UIPageView.cpp
@@ -40,7 +40,8 @@ _pageViewEventListener(nullptr),
 _pageViewEventSelector(nullptr),
 _eventCallback(nullptr),
 _autoScrollStopEpsilon(0.001f),
-_previousPageIndex(-1)
+_previousPageIndex(-1),
+_isTouchBegin(false)
 {
 }
 
@@ -223,7 +224,10 @@ void PageView::refreshIndicatorPosition()
 void PageView::handlePressLogic(Touch *touch)
 {
     ListView::handlePressLogic(touch);
-    _previousPageIndex = _currentPageIndex;
+    if (!_isTouchBegin) {
+        _previousPageIndex = _currentPageIndex;
+        _isTouchBegin = true;
+    }
 }
 
 void PageView::handleReleaseLogic(Touch *touch)
@@ -306,6 +310,7 @@ void PageView::pageTurningEvent()
     {
         _ccEventCallback(this, static_cast<int>(EventType::TURNING));
     }
+    _isTouchBegin = false;
     this->release();
 }
     
@@ -382,6 +387,7 @@ void PageView::copySpecialProperties(Widget *widget)
         _childFocusCancelOffset = pageView->_childFocusCancelOffset;
         _autoScrollStopEpsilon = pageView->_autoScrollStopEpsilon;
         _indicatorPositionAsAnchorPoint = pageView->_indicatorPositionAsAnchorPoint;
+        _isTouchBegin = pageView->_isTouchBegin;
     }
 }
 

--- a/cocos/ui/UIPageView.h
+++ b/cocos/ui/UIPageView.h
@@ -425,6 +425,7 @@ protected:
     ccPageViewCallback _eventCallback;
     float _autoScrollStopEpsilon;
     ssize_t _previousPageIndex;
+    bool _isTouchBegin;
 };
 
 }

--- a/cocos/ui/UIPageView.h
+++ b/cocos/ui/UIPageView.h
@@ -394,6 +394,7 @@ protected:
     virtual void onItemListChanged() override;
     virtual void onSizeChanged() override;
     virtual void handleReleaseLogic(Touch *touch) override;
+    virtual void handlePressLogic(Touch *touch) override;
 
     virtual Widget* createCloneInstance() override;
     virtual void copySpecialProperties(Widget* model) override;
@@ -423,6 +424,7 @@ protected:
 #endif
     ccPageViewCallback _eventCallback;
     float _autoScrollStopEpsilon;
+    ssize_t _previousPageIndex;
 };
 
 }

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -26,7 +26,7 @@
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
-# Cocos2d-x 3.12 Release Notes #
+# Cocos2d-x 3.13 Release Notes #
 
 # Misc Information
 
@@ -47,9 +47,9 @@
 
 ## Compiler Requirements
 
-* Xcode 5.1 or newer for iOS or Mac
-* gcc 4.9 or newer for Linux
-* ndk-r11+ for Android
+* Xcode 7+ for iOS or Mac
+* gcc 4.9+ for Linux
+* ndk-r11+ and API level 19 for Android
 * Visual Studio 2013 or newer for Windows (win32)
 * Visual Studio 2013 update4 or newer for Windows 8.1 universal Apps
 * Visual Studio 2015 or newer and Windows 10.0 (build 10074 or higher) for Windows 10.0 UWP Apps
@@ -150,45 +150,54 @@ Use the __cocos__ console app to create a new game:
 cocos new -l cpp|js|lua MyNewGame
 ```
 
-# v3.12
+# v3.13
 
 ## Highlights
 
-* add VR support in experimental
-* add Tizen support
-* improve Android performance issue
-* improve web engine performance in WebGL mode
-* support Android obb extension
-* use clang instead of gcc on Android, use NDK r11+
+* add VR plugin
+* support ETC1 alpha channel
+* fix AudioEngine performance for Android 4.2+
+* add Andorid arm-64 support
+* switch to use gcc 4.9
+* upgrade CURL to 7.50.0
+* upgrade Spine to 3.4
+* update glfw to 3.2
 
-## The main features in detail of Cocos2d-x v3.12
+## The main features in detail of Cocos2d-x v3.13
 
-### VR support
-VR Support is now available! Currently there is support for __Google Cardboard__, __Oculus Rift__, __Samsung Gear__ and __Deepoon E2__. Also provided is a *generic* __VR__ renderer to help with testing. It should not be used to trust deploying a production __VR__ game. In usual Cocos2d-x fashion it is very easy to get started with an easy to understand API. Read our chapter in the [Programmers Guide](http://cocos2d-x.org/docs/programmers-guide/vr/index.html) for more information.
+### Add VR plugin
 
-### Tizen support
-You can now develop for the __Tizen__ mobile platform. The latest __2.4__ SDK is supported. Tizen development uses it's own uniqie IDE as well as a simulator for testing applications. For setup instructions please read our [documentation](http://cocos2d-x.org/docs/installation/Tizen/).
+TBD: add link of PG
 
-### Improve Android performance
+### Support ETC1 alpha channel
 
-Thank you to our users for helping diagnose performance issues on some Android devices. It is because Cocos2d-x creates a big map buffer by default and fills the map buffer with actual data, which is less than the map buffer size. On some Android devices, it will transfer as much data as the map buffer size which causes performance issue.
+Thanks [halx99](https://github.com/halx99)'s contribution, now cocos2d-x supports ETC1 alpha channel by default.
 
-More detail information and discussion can refer to [the issue](https://github.com/cocos2d/cocos2d-x/issues/15652).
+If want to use ETC1 alpha chaneel, you should put `xxx.pkm` and `xxx.pkm@alpha` in the same folder, and use it like this:
 
-### Improve web engine performance in WebGL mode
+```c++
+auto sprite = Sprite::create("xxx.pkm");
+```
 
-The web engine is receiving a big performance upgrade. The WebGL renderer have been completely refactored from the ground up. This means improved rendering and a reduced memory footprint.
+`xxx.pkm@alpha` is the resource for alpha channel. `@alpha` subfix is required by engine to load alpha texture automatically.
 
-![rendering performance](https://raw.githubusercontent.com/minggo/Pictures/master/web-performance-improve/adverage-time-per-frame.png)
+More detail usage can refer to the implementation of `Sprite1ETC1Alpha` in `tests/cpp-tests/Classes/SpriteTest/SpriteTest.cpp`.
 
-![cpu-usage](https://raw.githubusercontent.com/minggo/Pictures/master/web-performance-improve/cpu-usage.png)
+### AudioEngine performance for Android 4.2+
 
-![memory-usage](https://raw.githubusercontent.com/minggo/Pictures/master/web-performance-improve/memory-usage.png)
+AudioEngine uses [OpenSL ES](https://developer.android.com/ndk/guides/audio/opensl-for-android.html) on Android, and it supports decoding audio source file to PCM data in codes since Android 4.2. Now AudioEngine uses this feature to fix the performance issue. The performane is the same as before if running on Android 4.1 or lower version.
 
-### Use clang on Android
-[Google deprecated gcc starting in NDK r11](https://developer.android.com/ndk/downloads/revision_history.html), Cocos2d-x now uses clang. We suggest using the NDK r11c.
+### Android arm-64 support
 
-We found an issue that, if using NDKr 10c + clang, then `Node::enumerateChildren()` will crash on Android.
+Now we provide arm-64 bit 3rd party libraries, which means can build 64-bit apps on Android. You can use the command to build 64-bit apps:
+```
+cocos run -p android --app-abi arm64-v8a
+```
 
-## Other changes
-View our [full changelog](https://github.com/cocos2d/cocos2d-x/blob/v3/CHANGELOG).
+### Switch to use gcc 4.9
+
+cocos2d-x switch to use clang in `v3.12`, but developers reported [some crash issue](https://github.com/cocos2d/cocos2d-x/issues/16244) that caused by using `clang+gnustl_static`, so we switch to use gcc 4.9. We will change to use `clang+c++_static` when `c++_static` is stable.
+
+### Upgrade CURL to 7.50.0
+
+Because CURL has [a bug about connect to IPV4 numerical IP address in NAT64 environment](https://github.com/curl/curl/issues/863), and it is fixed in v7.50.0, so we upgrade to this version when v7.50.0 is released.

--- a/templates/lua-template-default/frameworks/runtime-src/proj.android-studio/app/jni/Android.mk
+++ b/templates/lua-template-default/frameworks/runtime-src/proj.android-studio/app/jni/Android.mk
@@ -8,9 +8,6 @@ LOCAL_MODULE_FILENAME := libcocos2dlua
 
 LOCAL_SRC_FILES := \
 ../../../Classes/AppDelegate.cpp \
-../../../Classes/ide-support/SimpleConfigParser.cpp \
-../../../Classes/ide-support/RuntimeLuaImpl.cpp \
-../../../Classes/ide-support/lua_debugger.c \
 hellolua/main.cpp
 
 LOCAL_C_INCLUDES := $(LOCAL_PATH)/../../../Classes
@@ -19,7 +16,6 @@ LOCAL_C_INCLUDES := $(LOCAL_PATH)/../../../Classes
 # _COCOS_HEADER_ANDROID_END
 
 LOCAL_STATIC_LIBRARIES := cocos2d_lua_static
-LOCAL_STATIC_LIBRARIES += cocos2d_simulator_static
 
 # _COCOS_LIB_ANDROID_BEGIN
 # _COCOS_LIB_ANDROID_END
@@ -27,7 +23,6 @@ LOCAL_STATIC_LIBRARIES += cocos2d_simulator_static
 include $(BUILD_SHARED_LIBRARY)
 
 $(call import-module,scripting/lua-bindings/proj.android)
-$(call import-module,tools/simulator/libsimulator/proj.android)
 
 # _COCOS_LIB_IMPORT_ANDROID_BEGIN
 # _COCOS_LIB_IMPORT_ANDROID_END

--- a/templates/lua-template-default/frameworks/runtime-src/proj.android/jni/Android.mk
+++ b/templates/lua-template-default/frameworks/runtime-src/proj.android/jni/Android.mk
@@ -23,7 +23,6 @@ LOCAL_STATIC_LIBRARIES := cocos2d_lua_static
 include $(BUILD_SHARED_LIBRARY)
 
 $(call import-module,scripting/lua-bindings/proj.android)
-$(call import-module,tools/simulator/libsimulator/proj.android)
 
 # _COCOS_LIB_IMPORT_ANDROID_BEGIN
 # _COCOS_LIB_IMPORT_ANDROID_END

--- a/tests/cpp-tests/Classes/BugsTest/Bug-15776.cpp
+++ b/tests/cpp-tests/Classes/BugsTest/Bug-15776.cpp
@@ -11,6 +11,13 @@
 
 USING_NS_CC;
 
+
+//
+// IMPORTANT:
+// THIS TEST WILL CRASH ON TextureCache::addImage()
+// THIS IS NOT A BUG
+// It is expected to crash there
+//
 bool Bug15776Layer::init()
 {
     if (BugsTestBase::init())
@@ -23,4 +30,14 @@ bool Bug15776Layer::init()
     }
 
     return false;
+}
+
+std::string Bug15776Layer::title() const
+{
+    return "Testing Issue #15776";
+}
+
+std::string Bug15776Layer::subtitle() const
+{
+    return "It should crash on TextureCache::addImage()";
 }

--- a/tests/cpp-tests/Classes/BugsTest/Bug-15776.h
+++ b/tests/cpp-tests/Classes/BugsTest/Bug-15776.h
@@ -17,6 +17,9 @@ public:
     CREATE_FUNC(Bug15776Layer);
 
     virtual bool init() override;
+
+    virtual std::string title() const override;
+    virtual std::string subtitle() const override;
 };
 
 

--- a/tests/cpp-tests/Classes/MaterialSystemTest/MaterialSystemTest.cpp
+++ b/tests/cpp-tests/Classes/MaterialSystemTest/MaterialSystemTest.cpp
@@ -533,7 +533,7 @@ void Material_renderState::onEnter()
     sprite->runAction(repeat);
 
     // SPINE
-    auto skeletonNode = spine::SkeletonAnimation::createWithFile("spine/goblins-ffd.json", "spine/goblins-ffd.atlas", 1.5f);
+    auto skeletonNode = spine::SkeletonAnimation::createWithFile("spine/goblins.json", "spine/goblins.atlas", 1.5f);
     skeletonNode->setAnimation(0, "walk", true);
     skeletonNode->setSkin("goblin");
 

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIPageViewTest/UIPageViewTest.cpp
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIPageViewTest/UIPageViewTest.cpp
@@ -84,7 +84,8 @@ bool UIPageViewTest::init()
         
         pageView->removeItem(0);
         pageView->scrollToItem(pageCount - 2);
-        pageView->addEventListener((PageView::ccPageViewCallback)CC_CALLBACK_2(UIPageViewTest::pageViewEvent, this));
+        //This method is deprecated, we used here only testing purpose
+        pageView->addEventListenerPageView(this, pagevieweventselector(UIPageViewTest::pageViewEvent));
         
         _uiLayer->addChild(pageView);
         
@@ -93,11 +94,11 @@ bool UIPageViewTest::init()
     return false;
 }
 
-void UIPageViewTest::pageViewEvent(Ref *pSender, PageView::EventType type)
+void UIPageViewTest::pageViewEvent(Ref *pSender, PageViewEventType type)
 {
     switch (type)
     {
-        case PageView::EventType::TURNING:
+        case PAGEVIEW_EVENT_TURNING:
         {
             PageView* pageView = dynamic_cast<PageView*>(pSender);
             
@@ -199,7 +200,9 @@ bool UIPageViewButtonTest::init()
 
 void UIPageViewButtonTest::onButtonClicked(Ref* sender, Widget::TouchEventType type)
 {
-    log("button %s clicked", static_cast<Button*>(sender)->getName().c_str());
+    if(type == Widget::TouchEventType::ENDED) {
+        log("button %s clicked", static_cast<Button*>(sender)->getName().c_str());
+    }
 }
 
 

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIPageViewTest/UIPageViewTest.h
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIPageViewTest/UIPageViewTest.h
@@ -38,7 +38,7 @@ public:
     ~UIPageViewTest();
     virtual bool init() override;
 
-    void pageViewEvent(cocos2d::Ref* sender, cocos2d::ui::PageView::EventType type);
+    void pageViewEvent(cocos2d::Ref* sender, cocos2d::ui::PageViewEventType type);
 
 protected:
 


### PR DESCRIPTION
This PR removes the /ZW option from all .c files in Win10 libSpline project for all build configurations. Recent updates to spline broke the Win10 build.
