### PR TITLE
deprecates CCProgressTimer::setReverseProgress()

### DIFF
--- a/cocos/2d/CCProgressTimer.cpp
+++ b/cocos/2d/CCProgressTimer.cpp
@@ -142,7 +142,7 @@ void ProgressTimer::setType(Type type)
     }
 }
 
-void ProgressTimer::setReverseProgress(bool reverse)
+void ProgressTimer::setReverseDirection(bool reverse)
 {
     if( _reverseDirection != reverse ) {
         _reverseDirection = reverse;

--- a/cocos/2d/CCProgressTimer.h
+++ b/cocos/2d/CCProgressTimer.h
@@ -99,14 +99,7 @@ public:
      */
     void setType(Type type);
     
-    /** Set the Reverse direction.
-     * @js setReverseDirection
-     * @lua setReverseDirection
-     * @param reverse If reverse is false it will clockwise,if is true it will Anti-clockwise.
-     */
-    void setReverseProgress(bool reverse);
-    
-    /** Return the Reverse direction. 
+    /** Return the Reverse direction.
      *
      * @return If the direction is Anti-clockwise,it will return true.
      */
@@ -116,7 +109,15 @@ public:
      *
      * @param value If value is false it will clockwise,if is true it will Anti-clockwise.
      */
-    inline void setReverseDirection(bool value) { _reverseDirection = value; };
+    void setReverseDirection(bool value);
+
+    /** Set the Reverse direction.
+     * @js setReverseDirection
+     * @lua setReverseDirection
+     * @param reverse If reverse is false it will clockwise,if is true it will Anti-clockwise.
+     */
+    CC_DEPRECATED_ATTRIBUTE void setReverseProgress(bool reverse) { setReverseDirection(reverse); }
+
 
     /**
      *    Midpoint is used to modify the progress start position.


### PR DESCRIPTION
use CCProgressTimer::setReverseDirection() instead.

fixes github issue #14678
