### PR TITLE
check for correct GL extension

### DIFF
--- a/cocos/base/CCConfiguration.cpp
+++ b/cocos/base/CCConfiguration.cpp
@@ -144,7 +144,7 @@ void Configuration::gatherGPUInfo()
     _supportsNPOT = true;
 	_valueDict["gl.supports_NPOT"] = Value(_supportsNPOT);
 	
-    _supportsBGRA8888 = checkForGLExtension("GL_IMG_texture_format_BGRA888");
+    _supportsBGRA8888 = checkForGLExtension("GL_IMG_texture_format_BGRA8888");
 	_valueDict["gl.supports_BGRA8888"] = Value(_supportsBGRA8888);
 
     _supportsDiscardFramebuffer = checkForGLExtension("GL_EXT_discard_framebuffer");


### PR DESCRIPTION
uses `GL_IMG_texture_format_BGRA8888` instead of `GL_IMG_texture_format_BGRA888`

fixes issue #16336
