### PR TITLE
fixes compile error for win32

### DIFF
--- a/tests/cpp-tests/Classes/UnitTest/UnitTest.cpp
+++ b/tests/cpp-tests/Classes/UnitTest/UnitTest.cpp
@@ -839,13 +839,13 @@ void UIHelperSubStringTest::onEnter()
         CC_ASSERT(Helper::getSubStringOfUTF8String(source, 7, 0) == "");
         CC_ASSERT(Helper::getSubStringOfUTF8String(source, 8, 0) == "");
         CC_ASSERT(Helper::getSubStringOfUTF8String(source, 8, 1) == "");
-        CC_ASSERT(Helper::getSubStringOfUTF8String(source, 0, 1) == "这");
-        CC_ASSERT(Helper::getSubStringOfUTF8String(source, 0, 4) == "这里是中");
-        CC_ASSERT(Helper::getSubStringOfUTF8String(source, 0, 8) == "这里是中文测试例");
-        CC_ASSERT(Helper::getSubStringOfUTF8String(source, 0, 100) == "这里是中文测试例");
-        CC_ASSERT(Helper::getSubStringOfUTF8String(source, 2, 5) == "是中文测试");
-        CC_ASSERT(Helper::getSubStringOfUTF8String(source, 6, 2) == "试例");
-        CC_ASSERT(Helper::getSubStringOfUTF8String(source, 6, 100) == "试例");
+        CC_ASSERT(Helper::getSubStringOfUTF8String(source, 0, 1) == "\xe8\xbf\x99");
+        CC_ASSERT(Helper::getSubStringOfUTF8String(source, 0, 4) == "\xe8\xbf\x99\xe9\x87\x8c\xe6\x98\xaf\xe4\xb8\xad");
+        CC_ASSERT(Helper::getSubStringOfUTF8String(source, 0, 8) == "\xe8\xbf\x99\xe9\x87\x8c\xe6\x98\xaf\xe4\xb8\xad\xe6\x96\x87\xe6\xb5\x8b\xe8\xaf\x95\xe4\xbe\x8b");
+        CC_ASSERT(Helper::getSubStringOfUTF8String(source, 0, 100) == "\xe8\xbf\x99\xe9\x87\x8c\xe6\x98\xaf\xe4\xb8\xad\xe6\x96\x87\xe6\xb5\x8b\xe8\xaf\x95\xe4\xbe\x8b");
+        CC_ASSERT(Helper::getSubStringOfUTF8String(source, 2, 5) == "\xe6\x98\xaf\xe4\xb8\xad\xe6\x96\x87\xe6\xb5\x8b\xe8\xaf\x95");
+        CC_ASSERT(Helper::getSubStringOfUTF8String(source, 6, 2) == "\xe8\xaf\x95\xe4\xbe\x8b");
+        CC_ASSERT(Helper::getSubStringOfUTF8String(source, 6, 100) == "\xe8\xaf\x95\xe4\xbe\x8b");
 
         // Error: These cases cause "out of range" error
         CC_ASSERT(Helper::getSubStringOfUTF8String(source, 9, 0) == "");


### PR DESCRIPTION
Visual Studio doesn't like Chinese string in source code.
We should use binary format of Chinese string instead.

UnitTest have been updated some days ago and all Pull Requests passed Jenkins CI, therefore, I have no idea about why `Building UnitTest.cpp` failed on Win32.

Probably, it's because Jenkins CI uses command line to build the project while I used `Visual Studio 2013/2015` editor.
