### PR TITLE
fix: not resize textureatlas multiple times on Label::create()

### DIFF
--- a/cocos/2d/CCLabel.cpp
+++ b/cocos/2d/CCLabel.cpp
@@ -822,6 +822,12 @@ bool Label::alignText()
         {
             return true;
         }
+        // optimize for one-texture-only sceneario
+        // if multiple textures, then we should count how many chars
+        // are per texture
+        if (_batchNodes.size()==1)
+            _batchNodes.at(0)->reserveCapacity(_utf16Text.size());
+
         _reusedLetter->setBatchNode(_batchNodes.at(0));
         
         _lengthOfString = 0;

--- a/cocos/2d/CCSpriteBatchNode.cpp
+++ b/cocos/2d/CCSpriteBatchNode.cpp
@@ -404,6 +404,19 @@ void SpriteBatchNode::increaseAtlasCapacity()
     }
 }
 
+void SpriteBatchNode::reserveCapacity(ssize_t newCapacity)
+{
+    if (newCapacity <= _textureAtlas->getCapacity())
+        return;
+
+    if (! _textureAtlas->resizeCapacity(newCapacity))
+    {
+        // serious problems
+        CCLOGWARN("cocos2d: WARNING: Not enough memory to resize the atlas");
+        CCASSERT(false, "Not enough memory to resize the atlas");
+    }
+}
+
 ssize_t SpriteBatchNode::rebuildIndexInOrder(Sprite *parent, ssize_t index)
 {
     CCASSERT(index>=0 && index < _children.size(), "Invalid index");

--- a/cocos/2d/CCSpriteBatchNode.h
+++ b/cocos/2d/CCSpriteBatchNode.h
@@ -221,7 +221,11 @@ public:
      * It add the sprite to the children and descendants array, but it doesn't update add it to the texture atlas
      */
     SpriteBatchNode * addSpriteWithoutQuad(Sprite *child, int z, int aTag);
-    
+
+    /** reserves capacity for the batch node.
+     If the current capacity is bigger, nothing happens.
+     otherwise, a new capacity is allocated */
+    void reserveCapacity(ssize_t newCapacity);
 CC_CONSTRUCTOR_ACCESS:
     /**
      * @js ctor

--- a/tests/cpp-tests/Classes/LabelTest/LabelTestNew.cpp
+++ b/tests/cpp-tests/Classes/LabelTest/LabelTestNew.cpp
@@ -108,6 +108,7 @@ NewLabelTests::NewLabelTests()
     ADD_TEST_CASE(LabelLocalizationTest);
 
     ADD_TEST_CASE(LabelIssue15214);
+    ADD_TEST_CASE(LabelIssue16293);
 };
 
 LabelFNTColorAndOpacity::LabelFNTColorAndOpacity()
@@ -3176,4 +3177,23 @@ std::string LabelIssue15214::title() const
 std::string LabelIssue15214::subtitle() const
 {
     return "Font and underline should be of the same color";
+}
+
+// LabelBMFontBinaryFormat
+LabelIssue16293::LabelIssue16293()
+{
+    auto size = Director::getInstance()->getVisibleSize();
+    Label* label = Label::createWithTTF("012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789", "fonts/arial.ttf", 12);
+    label->setPosition(size.width/2, size.height/2);
+    this->addChild(label);
+}
+
+std::string LabelIssue16293::title() const
+{
+    return "Githug Issue 16293";
+}
+
+std::string LabelIssue16293::subtitle() const
+{
+    return "No TextureAtlas resizes";
 }

--- a/tests/cpp-tests/Classes/LabelTest/LabelTestNew.h
+++ b/tests/cpp-tests/Classes/LabelTest/LabelTestNew.h
@@ -860,4 +860,16 @@ public:
     virtual std::string title() const override;
     virtual std::string subtitle() const override;
 };
+
+class LabelIssue16293 : public AtlasDemoNew
+{
+public:
+    CREATE_FUNC(LabelIssue16293);
+
+    LabelIssue16293();
+
+    virtual std::string title() const override;
+    virtual std::string subtitle() const override;
+};
+
 #endif


### PR DESCRIPTION
since we know the size before allocating it, just reserve
the needed capacity once.

fixes github issue #16293
