### PR TITLE
Revert "fix: uses correct constant for Eye in Director"

### DIFF
--- a/cocos/base/CCDirector.cpp
+++ b/cocos/base/CCDirector.cpp
@@ -660,7 +660,7 @@ void Director::purgeCachedData(void)
 
 float Director::getZEye(void) const
 {
-    return (_winSizeInPoints.height / (2 * tanf(M_PI/6)));
+    return (_winSizeInPoints.height / 1.1566f);
 }
 
 void Director::setAlphaBlending(bool on)


### PR DESCRIPTION
Reverts cocos2d/cocos2d-x#16369
