### PR TITLE
PageView with custom 'scrollToPage' time

### DIFF
--- a/cocos/ui/UIPageView.cpp
+++ b/cocos/ui/UIPageView.cpp
@@ -163,7 +163,7 @@ void PageView::scrollToItem(ssize_t itemIndex)
     ListView::scrollToItem(itemIndex, Vec2::ANCHOR_MIDDLE, Vec2::ANCHOR_MIDDLE);
 }
 
-void PageView::scrollToItem(ssize_t idx, float time)
+void PageView::scrollToItem(ssize_t itemIndex, float time)
 {
     ListView::scrollToItem(itemIndex, Vec2::ANCHOR_MIDDLE, Vec2::ANCHOR_MIDDLE, time >= 0 ? time : _scrollTime);
 }

--- a/cocos/ui/UIPageView.cpp
+++ b/cocos/ui/UIPageView.cpp
@@ -152,10 +152,20 @@ void PageView::scrollToPage(ssize_t idx)
 {
     scrollToItem(idx);
 }
+    
+void PageView::scrollToPage(ssize_t idx, float time)
+{
+    scrollToItem(idx, time);
+}
 
 void PageView::scrollToItem(ssize_t itemIndex)
 {
     ListView::scrollToItem(itemIndex, Vec2::ANCHOR_MIDDLE, Vec2::ANCHOR_MIDDLE);
+}
+
+void PageView::scrollToItem(ssize_t idx, float time)
+{
+    ListView::scrollToItem(itemIndex, Vec2::ANCHOR_MIDDLE, Vec2::ANCHOR_MIDDLE, time >= 0 ? time : _scrollTime);
 }
 
 void PageView::setCustomScrollThreshold(float threshold)

--- a/cocos/ui/UIPageView.h
+++ b/cocos/ui/UIPageView.h
@@ -166,6 +166,14 @@ public:
      * @param idx   A given index in the PageView. Index start from 0 to pageCount -1.
      */
     void scrollToPage(ssize_t idx);
+    
+    /**
+     * Scroll to a page with a given index and with a given scroll time.
+     *
+     * @param idx   A given index in the PageView. Index start from 0 to pageCount -1.
+     * @param time  Scroll time must be >= 0. Otherwise last setted scroll time will be used.
+     */
+    void scrollToPage(ssize_t idx, float time);
 
     /**
      * Scroll to a page with a given index.
@@ -173,6 +181,14 @@ public:
      * @param itemIndex   A given index in the PageView. Index start from 0 to pageCount -1.
      */
     void scrollToItem(ssize_t itemIndex);
+    
+    /**
+     * Scroll to a item with a given index and with a given scroll time.
+     *
+     * @param idx   A given index in the PageView. Index start from 0 to pageCount -1.
+     * @param time  Scroll time must be >= 0. Otherwise last setted scrolltime will be used.
+     */
+    void scrollToItem(ssize_t idx, float time);
 
     /**
      * Gets current displayed page index.


### PR DESCRIPTION
`PageView` has two new public member functions:

```
void scrollToPage(ssize_t idx, float time);
void scrollToItem(ssize_t idx, float time);
```

These can be useful when developer wants scroll to a Page with a custom time (maybe zero), still triggering the `PageView::EventType::TURNING` event.
