### PR TITLE
fix: validates director before layout in iOS

### DIFF
--- a/cocos/base/CCDirector.cpp
+++ b/cocos/base/CCDirector.cpp
@@ -81,7 +81,7 @@ NS_CC_BEGIN
 // FIXME: it should be a Director ivar. Move it there once support for multiple directors is added
 
 // singleton stuff
-static DisplayLinkDirector *s_SharedDirector = nullptr;
+static Director *s_SharedDirector = nullptr;
 
 #define kDefaultFPS        60  // 60 frames per second
 extern const char* cocos2dVersion(void);
@@ -97,7 +97,7 @@ Director* Director::getInstance()
 {
     if (!s_SharedDirector)
     {
-        s_SharedDirector = new (std::nothrow) DisplayLinkDirector();
+        s_SharedDirector = new (std::nothrow) Director;
         CCASSERT(s_SharedDirector, "FATAL: Not enough memory");
         s_SharedDirector->init();
     }
@@ -107,6 +107,7 @@ Director* Director::getInstance()
 
 Director::Director()
 : _isStatusLabelUpdated(true)
+, _invalid(true)
 {
 }
 
@@ -1365,14 +1366,7 @@ void Director::setEventDispatcher(EventDispatcher* dispatcher)
     }
 }
 
-/***************************************************
-* implementation of DisplayLinkDirector
-**************************************************/
-
-// should we implement 4 types of director ??
-// I think DisplayLinkDirector is enough
-// so we now only support DisplayLinkDirector
-void DisplayLinkDirector::startAnimation()
+void Director::startAnimation()
 {
     _lastUpdate = std::chrono::steady_clock::now();
 
@@ -1386,7 +1380,7 @@ void DisplayLinkDirector::startAnimation()
     setNextDeltaTimeZero(true);
 }
 
-void DisplayLinkDirector::mainLoop()
+void Director::mainLoop()
 {
     if (_purgeDirectorInNextLoop)
     {
@@ -1407,12 +1401,12 @@ void DisplayLinkDirector::mainLoop()
     }
 }
 
-void DisplayLinkDirector::stopAnimation()
+void Director::stopAnimation()
 {
     _invalid = true;
 }
 
-void DisplayLinkDirector::setAnimationInterval(float interval)
+void Director::setAnimationInterval(float interval)
 {
     _animationInterval = interval;
     if (! _invalid)

--- a/cocos/base/CCDirector.h
+++ b/cocos/base/CCDirector.h
@@ -149,8 +149,8 @@ public:
      * @js NA
      * @lua NA
      */
-    virtual ~Director();
-    virtual bool init();
+    ~Director();
+    bool init();
 
     // attribute
 
@@ -160,7 +160,7 @@ public:
     /** Gets the FPS value. */
     inline float getAnimationInterval() { return _animationInterval; }
     /** Sets the FPS value. FPS = 1/interval. */
-    virtual void setAnimationInterval(float interval) = 0;
+    void setAnimationInterval(float interval);
 
     /** Whether or not displaying the FPS on the bottom-left corner of the screen. */
     inline bool isDisplayStats() { return _displayStats; }
@@ -344,13 +344,13 @@ public:
     /** Stops the animation. Nothing will be drawn. The main loop won't be triggered anymore.
      * If you don't want to pause your animation call [pause] instead.
      */
-    virtual void stopAnimation() = 0;
+    void stopAnimation();
 
     /** The main loop is triggered again.
      * Call this function only if [stopAnimation] was called earlier.
      * @warning Don't call this function to start the main loop. To run the main loop call runWithScene.
      */
-    virtual void startAnimation() = 0;
+    void startAnimation();
 
     /** Draw the scene.
      * This method is called every frame. Don't call it manually.
@@ -388,7 +388,7 @@ public:
     /** Enables/disables OpenGL depth test. */
     void setDepthTest(bool on);
 
-    virtual void mainLoop() = 0;
+    void mainLoop();
 
     /** The size in pixels of the surface. It could be different than the screen size.
      * High-res devices might have a higher surface size than the screen size.
@@ -499,6 +499,11 @@ public:
      Useful to know if certain code is already running on the cocos2d thread
      */
     const std::thread::id& getCocos2dThreadId() const { return _cocos2d_thread_id; }
+
+    /**
+     * returns whether or not the Director is in a valid state
+     */
+    inline bool isValid() const { return !_invalid; }
 
 protected:
     void reset();
@@ -621,41 +626,21 @@ protected:
     /* cocos2d thread id */
     std::thread::id _cocos2d_thread_id;
 
+    /* whether or not the director is in a valid state */
+    bool _invalid;
+
     // GLView will recreate stats labels to fit visible rect
     friend class GLView;
 };
 
+// FIXME: Added for backward compatibility in case
+// someone is subclassing it.
+// Should be removed in v4.0
+class DisplayLinkDirector : public Director
+{};
+
 // end of base group
 /** @} */
-
-/** 
- @brief DisplayLinkDirector is a Director that synchronizes timers with the refresh rate of the display.
- 
- Features and Limitations:
-  - Scheduled timers & drawing are synchronizes with the refresh rate of the display
-  - Only supports animation intervals of 1/60 1/30 & 1/15
- 
- @since v0.8.2
- */
-class DisplayLinkDirector : public Director
-{
-public:
-    DisplayLinkDirector() 
-        : _invalid(false)
-    {}
-    virtual ~DisplayLinkDirector(){}
-
-    //
-    // Overrides
-    //
-    virtual void mainLoop() override;
-    virtual void setAnimationInterval(float value) override;
-    virtual void startAnimation() override;
-    virtual void stopAnimation() override;
-
-protected:
-    bool _invalid;
-};
 
 NS_CC_END
 

--- a/cocos/platform/ios/CCEAGLView-ios.mm
+++ b/cocos/platform/ios/CCEAGLView-ios.mm
@@ -252,6 +252,11 @@ Copyright (C) 2008 Apple Inc. All Rights Reserved.
 
 - (void) layoutSubviews
 {
+    if (!cocos2d::Director::getInstance()->isValid())
+    {
+        return;
+    }
+    
     [renderer_ resizeFromLayer:(CAEAGLLayer*)self.layer];
     size_ = [renderer_ backingSize];
 


### PR DESCRIPTION
Adds Director::isValid()
removes DisplayLinkDirector()
removes virtual functions from Director()
Director is no longer an abstract class

github issue #14276
