### PR TITLE
Fixed Camera::_viewProjectionUpdated state

### DIFF
--- a/cocos/2d/CCCamera.cpp
+++ b/cocos/2d/CCCamera.cpp
@@ -111,6 +111,7 @@ Camera::Camera()
 , _viewProjectionDirty(true)
 , _cameraFlag(1)
 , _frustumDirty(true)
+, _viewProjectionUpdated(false)
 , _depth(-1)
 , _fbo(nullptr)
 {
@@ -441,6 +442,7 @@ void Camera::setFrameBufferObject(experimental::FrameBuffer *fbo)
 
 void Camera::apply()
 {
+    _viewProjectionUpdated = _transformUpdated;
     applyFrameBufferObject();
     applyViewport();
 }


### PR DESCRIPTION
Camera::_viewProjectionUpdated is not initialised in constructor. Should be initialised to false.
This can lead to redundant visibility checks if _viewProjectionUpdated happens to resolve true.

As Camera::visit() is never called, _viewProjectionUpdated is never actually updated, resulting in no visibility tests when the camera transform changes.

Fixes #16404
