### PR TITLE
Improving CCRef LEAK_DETECTION tool by making them thread safe. It i…

### DIFF
--- a/cocos/base/CCRef.cpp
+++ b/cocos/base/CCRef.cpp
@@ -30,6 +30,9 @@ THE SOFTWARE.
 
 #if CC_REF_LEAK_DETECTION
 #include <algorithm>    // std::find
+#include <thread>
+#include <mutex>
+#include <vector>
 #endif
 
 NS_CC_BEGIN
@@ -154,10 +157,12 @@ unsigned int Ref::getReferenceCount() const
 
 #if CC_REF_LEAK_DETECTION
 
-static std::list<Ref*> __refAllocationList;
+static std::vector<Ref*> __refAllocationList;
+static std::mutex __refMutex;
 
 void Ref::printLeaks()
 {
+    std::lock_guard<std::mutex> refLockGuard(__refMutex);
     // Dump Ref object memory leaks
     if (__refAllocationList.empty())
     {
@@ -178,6 +183,7 @@ void Ref::printLeaks()
 
 static void trackRef(Ref* ref)
 {
+    std::lock_guard<std::mutex> refLockGuard(__refMutex);
     CCASSERT(ref, "Invalid parameter, ref should not be null!");
 
     // Create memory allocation record.
@@ -186,6 +192,7 @@ static void trackRef(Ref* ref)
 
 static void untrackRef(Ref* ref)
 {
+    std::lock_guard<std::mutex> refLockGuard(__refMutex);
     auto iter = std::find(__refAllocationList.begin(), __refAllocationList.end(), ref);
     if (iter == __refAllocationList.end())
     {


### PR DESCRIPTION
…s possible that ref's can be created and mutated off thread, and with leak detection on. This can cause ungaurded writes from two or more threads to a non-protected structure. Fixing a crash on iOS when using std::list instead of std::vector.
