### PR TITLE
Add missing class declaration and remove duplicate declaration

### DIFF
--- a/cocos/base/CCProperties.cpp
+++ b/cocos/base/CCProperties.cpp
@@ -30,6 +30,7 @@
 #include "math/Vec3.h"
 #include "math/Vec4.h"
 #include "math/Mat4.h"
+#include "math/Quaternion.h"
 #include "base/ccUTF8.h"
 #include "base/CCData.h"
 

--- a/cocos/base/CCProperties.h
+++ b/cocos/base/CCProperties.h
@@ -41,7 +41,7 @@ class Vec2;
 class Vec3;
 class Vec4;
 class Mat4;
-class Data;
+class Quaternion;
 class Data;
 
 


### PR DESCRIPTION
This PR adds a missing type declaration and header include for class `Quaternion`, it also removes a duplicate declaration of `Data` in `CCProperties.h`. Thanks!
