### PR TITLE
possible memory leak when font size is 0

### DIFF
--- a/cocos/2d/CCFontFreeType.cpp
+++ b/cocos/2d/CCFontFreeType.cpp
@@ -316,7 +316,7 @@ unsigned char* FontFreeType::getGlyphBitmap(unsigned short theChar, long &outWid
         outHeight = _fontRef->glyph->bitmap.rows;
         ret = _fontRef->glyph->bitmap.buffer;
 
-        if (_outlineSize > 0)
+        if (_outlineSize > 0 && outWidth > 0 && outHeight > 0)
         {
             auto copyBitmap = new (std::nothrow) unsigned char[outWidth * outHeight];
             memcpy(copyBitmap,ret,outWidth * outHeight * sizeof(unsigned char));


### PR DESCRIPTION
When outWidth or outHeight is 0, new bitmap is allocated with 0 size.
And this bitmap will never be deallocated because FontAtlas::prepareLetterDefinitions just skip character which has 0 size.
