### PR TITLE
Fix variable shadowing warnings caused by Spine 3.4

### DIFF
--- a/cocos/editor-support/spine/SkeletonJson.c
+++ b/cocos/editor-support/spine/SkeletonJson.c
@@ -832,7 +832,6 @@ spSkeletonData* spSkeletonJson_readSkeletonData (spSkeletonJson* self, const cha
 					const char* attachmentName = Json_getString(attachmentMap, "name", skinAttachmentName);
 					const char* path = Json_getString(attachmentMap, "path", attachmentName);
 					const char* color;
-					int i;
 					Json* entry;
 
 					const char* typeString = Json_getString(attachmentMap, "type", "region");
@@ -911,14 +910,14 @@ spSkeletonData* spSkeletonJson_readSkeletonData (spSkeletonJson* self, const cha
 							entry = Json_getItem(attachmentMap, "triangles");
 							mesh->trianglesCount = entry->size;
 							mesh->triangles = MALLOC(unsigned short, entry->size);
-							for (entry = entry->child, i = 0; entry; entry = entry->next, ++i)
-								mesh->triangles[i] = (unsigned short)entry->valueInt;
+							for (entry = entry->child, ii = 0; entry; entry = entry->next, ++ii)
+								mesh->triangles[ii] = (unsigned short)entry->valueInt;
 
 							entry = Json_getItem(attachmentMap, "uvs");
 							verticesLength = entry->size;
 							mesh->regionUVs = MALLOC(float, verticesLength);
-							for (entry = entry->child, i = 0; entry; entry = entry->next, ++i)
-								mesh->regionUVs[i] = entry->valueFloat;
+							for (entry = entry->child, ii = 0; entry; entry = entry->next, ++ii)
+								mesh->regionUVs[ii] = entry->valueFloat;
 
 							_readVertices(self, attachmentMap, SUPER(mesh), verticesLength);
 
@@ -930,8 +929,8 @@ spSkeletonData* spSkeletonJson_readSkeletonData (spSkeletonJson* self, const cha
 							if (entry) {
 								mesh->edgesCount = entry->size;
 								mesh->edges = MALLOC(int, entry->size);
-								for (entry = entry->child, i = 0; entry; entry = entry->next, ++i)
-									mesh->edges[i] = entry->valueInt;
+								for (entry = entry->child, ii = 0; entry; entry = entry->next, ++ii)
+									mesh->edges[ii] = entry->valueInt;
 							}
 
 							spAttachmentLoader_configureAttachment(self->attachmentLoader, attachment);
@@ -960,8 +959,8 @@ spSkeletonData* spSkeletonJson_readSkeletonData (spSkeletonJson* self, const cha
 						path->lengths = MALLOC(float, path->lengthsLength);
 
 						curves = Json_getItem(attachmentMap, "lengths");
-						for (curves = curves->child, i = 0; curves; curves = curves->next, ++i) {
-							path->lengths[i] = curves->valueFloat * self->scale;
+						for (curves = curves->child, ii = 0; curves; curves = curves->next, ++ii) {
+							path->lengths[ii] = curves->valueFloat * self->scale;
 						}
 						break;
 					}

--- a/cocos/editor-support/spine/VertexAttachment.c
+++ b/cocos/editor-support/spine/VertexAttachment.c
@@ -71,7 +71,7 @@ void spVertexAttachment_computeWorldVertices1 (spVertexAttachment* self, int sta
 			worldVertices[w + 1] = vx * bone->c + vy * bone->d + y;
 		}
 	} else {
-		int v = 0, skip = 0, i, w, b, n;
+		int v = 0, skip = 0, i;
 		spBone** skeletonBones;
 		for (i = 0; i < start; i += 2) {
 			int n = bones[v];
@@ -80,9 +80,10 @@ void spVertexAttachment_computeWorldVertices1 (spVertexAttachment* self, int sta
 		}
 		skeletonBones = skeleton->bones;
 		if (deformLength == 0) {
+			int w, b;
 			for (w = offset, b = skip * 3; w < count; w += 2) {
 				float wx = x, wy = y;
-				n = bones[v++];
+				int n = bones[v++];
 				n += v;
 				for (; v < n; v++, b += 3) {
 					spBone* bone = skeletonBones[bones[v]];
@@ -94,10 +95,10 @@ void spVertexAttachment_computeWorldVertices1 (spVertexAttachment* self, int sta
 				worldVertices[w + 1] = wy;
 			}
 		} else {
-			int w, b, f, n;
+			int w, b, f;
 			for (w = offset, b = skip * 3, f = skip << 1; w < count; w += 2) {
 				float wx = x, wy = y;
-				n = bones[v++];
+				int n = bones[v++];
 				n += v;
 				for (; v < n; v++, b += 3, f += 2) {
 					spBone* bone = skeletonBones[bones[v]];


### PR DESCRIPTION
This PR fixes the following compiler warnings caused by spine-c runtime 3.4 with Xcode 7.3.1:

```
cocos/editor-support/spine/VertexAttachment.c:77:8: declaration shadows a local variable [-Wshadow]
cocos/editor-support/spine/VertexAttachment.c:97:8: declaration shadows a local variable [-Wshadow]
cocos/editor-support/spine/VertexAttachment.c:97:11: declaration shadows a local variable [-Wshadow]
cocos/editor-support/spine/VertexAttachment.c:97:17: declaration shadows a local variable [-Wshadow]
cocos/editor-support/spine/SkeletonJson.c:835:10: declaration shadows a local variable [-Wshadow]
```

Also, this patch has already been submitted and merged in upstream on [EsotericSoftware/spine-runtimes](https://github.com/EsotericSoftware/spine-runtimes) repo:
- https://github.com/EsotericSoftware/spine-runtimes/pull/656
- https://github.com/EsotericSoftware/spine-runtimes/pull/684

Thanks!
