### PR TITLE
Fix memory leak caused by packetOut in SocketIO.cpp

### DIFF
--- a/cocos/network/SocketIO.cpp
+++ b/cocos/network/SocketIO.cpp
@@ -880,7 +880,6 @@ void SIOClientImpl::onMessage(WebSocket* ws, const WebSocket::Data& data)
                 int control2 = payload.at(0) - '0';
                 CCLOGINFO("Message code: [%i]", control2);
 
-                SocketIOPacket *packetOut = SocketIOPacket::createPacketWithType("event", _version);
                 std::string endpoint = "";
 
                 std::string::size_type a = payload.find("/");
@@ -901,8 +900,6 @@ void SIOClientImpl::onMessage(WebSocket* ws, const WebSocket::Data& data)
 
                 // we didn't find and endpoint and we are in the default namespace
                 if (endpoint == "") endpoint = "/";
-
-                packetOut->setEndpoint(endpoint);
 
                 c = getClient(endpoint);
 


### PR DESCRIPTION
Static code analyzer cppcheck showed the following error on SocketIO.cpp:

```
Checking SocketIO.cpp...
[SocketIO.cpp:964]: (error) Memory leak: packetOut
```

I manually inspected the code and as far as I can tell it is, indeed, a memory leak.
