### PR TITLE
Add missing override keywords

### DIFF
--- a/cocos/platform/linux/CCApplication-linux.h
+++ b/cocos/platform/linux/CCApplication-linux.h
@@ -53,7 +53,7 @@ public:
      @brief Callback by Director for limit FPS.
      @param interval    The time, which expressed in second in second, between current frame and next.
      */
-    void setAnimationInterval(float interval);
+    void setAnimationInterval(float interval) override;
 
     /**
      @brief Run the message loop.
@@ -70,25 +70,25 @@ public:
     CC_DEPRECATED_ATTRIBUTE static Application* sharedApplication();
     
     /* override functions */
-    virtual LanguageType getCurrentLanguage();
+    virtual LanguageType getCurrentLanguage() override;
 
     /**
     @brief Get current language iso 639-1 code
     @return Current language iso 639-1 code
     */
-    virtual const char * getCurrentLanguageCode();
+    virtual const char * getCurrentLanguageCode() override;
     
     /**
     @brief Get application version
     */
     virtual std::string getVersion() override;
 
-  /**
-   @brief Open url in default browser
-   @param String with url to open.
-   @return true if the resource located by the URL was successfully opened; otherwise false.
-   */
-  virtual bool openURL(const std::string &url);
+    /**
+     @brief Open url in default browser
+     @param String with url to open.
+     @return true if the resource located by the URL was successfully opened; otherwise false.
+     */
+    virtual bool openURL(const std::string &url) override;
 
 
     /**
@@ -106,7 +106,7 @@ public:
     /**
      @brief Get target platform
      */
-    virtual Platform getTargetPlatform();
+    virtual Platform getTargetPlatform() override;
 protected:
     long       _animationInterval;  //micro second
     std::string _resourceRootPath;

--- a/cocos/platform/linux/CCFileUtils-linux.h
+++ b/cocos/platform/linux/CCFileUtils-linux.h
@@ -51,8 +51,8 @@ private:
     std::string _writablePath;
 public:
     /* override functions */
-    bool init();
-    virtual std::string getWritablePath() const;
+    bool init() override;
+    virtual std::string getWritablePath() const override;
 private:
     virtual bool isFileExistInternal(const std::string& strFilePath) const override;
 };

--- a/cocos/ui/UIEditBox/UIEditBoxImpl-linux.h
+++ b/cocos/ui/UIEditBox/UIEditBoxImpl-linux.h
@@ -70,7 +70,7 @@ public:
     virtual const char* getNativeDefaultFontName() override {};
     virtual void nativeOpenKeyboard() override;
     virtual void nativeCloseKeyboard() override {};
-    virtual void setNativeMaxLength(int maxLength) {};
+    virtual void setNativeMaxLength(int maxLength) override {};
 
     
 private:


### PR DESCRIPTION
Hello, when I tried to compile with Clang 3.8 on Linux, I get the following warning message:

```
cocos/platform/linux/CCApplication-linux.h:56:10: warning: 'setAnimationInterval' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
    void setAnimationInterval(float interval);
         ^
cocos/platform/linux/CCApplication-linux.h:73:26: warning: 'getCurrentLanguage' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
    virtual LanguageType getCurrentLanguage();
                         ^
cocos/platform/linux/CCApplication-linux.h:79:26: warning: 'getCurrentLanguageCode' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
    virtual const char * getCurrentLanguageCode();
                         ^
cocos/platform/linux/CCApplication-linux.h:91:16: warning: 'openURL' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
  virtual bool openURL(const std::string &url);
               ^
cocos/platform/linux/CCApplication-linux.h:109:22: warning: 'getTargetPlatform' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
    virtual Platform getTargetPlatform();
                     ^
cocos/platform/linux/CCFileUtils-linux.h:54:10: warning: 'init' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
    bool init();
         ^
cocos/platform/linux/CCFileUtils-linux.h:55:25: warning: 'getWritablePath' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
    virtual std::string getWritablePath() const;
                        ^
cocos/ui/UIEditBox/UIEditBoxImpl-linux.h:73:18: warning: 'setNativeMaxLength' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
    virtual void setNativeMaxLength(int maxLength) {};
                 ^
```

This PR adds the missing override keywords and fix indentation (2 spaces to 4 spaces).
