### PR TITLE
Add missing definition of PhysicsBody::getFirstShape (Revert part of #13923)

### DIFF
--- a/cocos/physics/CCPhysicsBody.h
+++ b/cocos/physics/CCPhysicsBody.h
@@ -200,6 +200,13 @@ public:
      */
     inline const Vector<PhysicsShape*>& getShapes() const { return _shapes; }
 
+    /**
+     * Get the first shape of the body shapes.
+     *
+     * @return The first shape in this body.
+     */
+    inline PhysicsShape* getFirstShape() const { return _shapes.size() >= 1 ? _shapes.at(0) : nullptr; }
+
     /** 
      * get the shape of the body.
      *


### PR DESCRIPTION
Here is a link to the forum post: http://discuss.cocos2d-x.org/t/bug-in-physicsbody-cocos2dx-api/28609

`PhysicsBody::getFirstShape` function can not be found, but the function exists in the currently `v3-doc` branch and API docs here:
- https://github.com/cocos2d/cocos2d-x/blob/v3-doc/cocos/physics/CCPhysicsBody.h#L296-L305
- http://www.cocos2d-x.org/docs/api-ref/cplusplus/v3x/d7/d7b/classcocos2d_1_1_physics_body.html#aa84c257ea4703d4f9f924b3e18e1b0f4

It seems to be deleted on `v3` branch in commit https://github.com/cocos2d/cocos2d-x/commit/a17a702cd1389bfed376dffbd74ec95780a2ca74 (PR: https://github.com/cocos2d/cocos2d-x/pull/13923, since v3.9), so it looks like it was a mistake.

This PR reverts the part of the commit https://github.com/cocos2d/cocos2d-x/commit/a17a702cd1389bfed376dffbd74ec95780a2ca74#diff-48ac453e3782f31d7148e35abdab40e6L210. If `PhysicsBody::getFirstShape` will be removed in a future version, we should mark it as deprecated and remove after some time.

Thanks!
