### PR TITLE
Fix the Anchor Point issue and prepend the methods calls with this->.

### DIFF
--- a/cocos/2d/CCMenu.cpp
+++ b/cocos/2d/CCMenu.cpp
@@ -137,12 +137,11 @@ bool Menu::initWithArray(const Vector<MenuItem*>& arrayOfItems)
         // menu in the center of the screen
         Size s = Director::getInstance()->getWinSize();
 
-        this->setIgnoreAnchorPointForPosition(true);
-        setAnchorPoint(Vec2(0.5f, 0.5f));
+        this->setIgnoreAnchorPointForPosition(false);
+        this->setAnchorPoint(Vec2(0.5f, 0.5f));
         this->setContentSize(s);
 
-        setPosition(s.width/2, s.height/2);
-        
+        this->setPosition(s.width/2, s.height/2);
         int z=0;
         
         for (auto& item : arrayOfItems)


### PR DESCRIPTION
We are setting the anchor point to the center of the Menu
so the call of setIgnoreAnchorPointForPosition must be with
"false" argument.

Also prepend all the methods calls with this to keep the
consistency between the calls.
