### PR TITLE
Remove deprecated attribute on Node::_setLocalZOrder() function to avoid deprecation warnings

### DIFF
--- a/cocos/2d/CCNode.h
+++ b/cocos/2d/CCNode.h
@@ -165,7 +165,7 @@ public:
      Helper function used by `setLocalZOrder`. Don't use it unless you know what you are doing.
      @js NA
      */
-    CC_DEPRECATED_ATTRIBUTE virtual void _setLocalZOrder(int z);
+    virtual void _setLocalZOrder(int z);
 
     /** !!! ONLY FOR INTERNAL USE
     * Sets the arrival order when this node has a same ZOrder with other children.


### PR DESCRIPTION
Hi, I'm getting this warning message with the recent build and Xcode 7.3.1 since v3.13.

```
cocos/2d/CCNode.cpp:259:5: '_setLocalZOrder' is deprecated
cocos/2d/CCNode.cpp:1136:12: '_setLocalZOrder' is deprecated
cocos/2d/CCNode.cpp:1144:12: '_setLocalZOrder' is deprecated
```

`_setLocalZOrder()` has been deprecated two years ago (since commit https://github.com/cocos2d/cocos2d-x/commit/31c508ef6de537a55ae73cffc52077f5436dc584), so we should not use it in a core feature of the engine such as `cocos2d::Node`.

This pull request does the following to prevent the warnings:
- Add a new private member function `setLocalZOrderHelper()` instead of `_setLocalZOrder()`
- Replace `_setLocalZOrder()` with `setLocalZOrderHelper()`
- Improve & cleanup documentation comments

Thank you for your time!
