### PR TITLE
Fix MenuItemSprite::unselected() on disabled items

### DIFF
--- a/cocos/2d/CCMenuItem.cpp
+++ b/cocos/2d/CCMenuItem.cpp
@@ -609,20 +609,7 @@ void MenuItemSprite::selected()
 void MenuItemSprite::unselected()
 {
     MenuItem::unselected();
-    if (_normalImage)
-    {
-        _normalImage->setVisible(true);
-
-        if (_selectedImage)
-        {
-            _selectedImage->setVisible(false);
-        }
-
-        if (_disabledImage)
-        {
-            _disabledImage->setVisible(false);
-        }
-    }
+    this->updateImagesVisibility();
 }
 
 void MenuItemSprite::setEnabled(bool bEnabled)


### PR DESCRIPTION
Calling MenuItemSprite::unselected() on a disabled item makes it show _normalImage instead of _disabledImage.
