### PR TITLE
Fix memory leak when loading Cocos Studio file

### DIFF
--- a/tools/simulator/libsimulator/lib/runtime/RuntimeCCSImpl.cpp
+++ b/tools/simulator/libsimulator/lib/runtime/RuntimeCCSImpl.cpp
@@ -86,8 +86,9 @@ void RuntimeCCSImpl::loadCSDProject(const std::string& file)
                     attribute = attribute->Next();
                 }
             }
-
         }
+
+        delete document;
 
         if (Director::getInstance()->getRunningScene())
         {


### PR DESCRIPTION
Another leak found by cppcheck.

In [line 64](https://github.com/cocos2d/cocos2d-x/blob/v3/tools/simulator/libsimulator/lib/runtime/RuntimeCCSImpl.cpp#L64) of RuntimeCCSImpl.cpp a new tinyxml2::XMLDocument is allocated when loading a Cocos Studio file, but the allocated memory is never deleted.
