### PR TITLE
Issue 16471

### DIFF
--- a/cocos/2d/CCLabel.cpp
+++ b/cocos/2d/CCLabel.cpp
@@ -1945,6 +1945,9 @@ void Label::updateDisplayedOpacity(GLubyte parentOpacity)
     }
 }
 
+// FIXME: it is not clear what is the difference between setTextColor() and setColor()
+// if setTextColor() only changes the text and nothing but the text (no glow, no outline, not underline)
+// that's fine but it should be documented
 void Label::setTextColor(const Color4B &color)
 {
     CCASSERT(_currentLabelType == LabelType::TTF || _currentLabelType == LabelType::STRING_TEXTURE, "Only supported system font and ttf!");

--- a/cocos/2d/CCLabel.cpp
+++ b/cocos/2d/CCLabel.cpp
@@ -1409,6 +1409,7 @@ void Label::updateContent()
 
         if (_numberOfLines)
         {
+            // This is the logic for TTF fonts
             const float charheight = (_textDesiredHeight / _numberOfLines);
             _underlineNode->setLineWidth(charheight/6);
 
@@ -1420,12 +1421,15 @@ void Label::updateContent()
                     offsety += charheight / 2;
                 // FIXME: Might not work with different vertical alignments
                 float y = (_numberOfLines - i - 1) * charheight + offsety;
-                _underlineNode->drawLine(Vec2(_linesOffsetX[i],y), Vec2(_linesWidth[i] + _linesOffsetX[i],y), _textColorF);
+
+                // Github issue #15214. Uses _displayedColor instead of _textColor for the underline.
+                // This is to have the same behavior of SystemFonts.
+                _underlineNode->drawLine(Vec2(_linesOffsetX[i],y), Vec2(_linesWidth[i] + _linesOffsetX[i],y), Color4F(_displayedColor));
             }
         }
         else if (_textSprite)
         {
-            // system font
+            // ...and is the logic for System fonts
             float y = 0;
             const auto spriteSize = _textSprite->getContentSize();
             _underlineNode->setLineWidth(spriteSize.height/6);
@@ -1896,9 +1900,6 @@ void Label::updateDisplayedColor(const Color3B& parentColor)
 {
     Node::updateDisplayedColor(parentColor);
 
-    if (_currentLabelType == LabelType::TTF || _currentLabelType == LabelType::STRING_TEXTURE)
-        setTextColor(Color4B(_displayedColor));
-
     if (_textSprite)
     {
         _textSprite->updateDisplayedColor(_displayedColor);
@@ -1911,6 +1912,11 @@ void Label::updateDisplayedColor(const Color3B& parentColor)
 
     if (_underlineNode)
     {
+        // FIXME: _underlineNode is not a sprite/label. It is a DrawNode
+        // and updating its color doesn't work. it must be re-drawn,
+        // which makes it super expensive to change update it frequently
+        // Correct solution is to update the DrawNode directly since we know it is
+        // a line. Returning a pointer to the line is an option
         _contentDirty = true;
     }
 

--- a/tests/cpp-tests/Classes/LabelTest/LabelTestNew.cpp
+++ b/tests/cpp-tests/Classes/LabelTest/LabelTestNew.cpp
@@ -109,6 +109,7 @@ NewLabelTests::NewLabelTests()
 
     ADD_TEST_CASE(LabelIssue15214);
     ADD_TEST_CASE(LabelIssue16293);
+    ADD_TEST_CASE(LabelIssue16471);
 };
 
 LabelFNTColorAndOpacity::LabelFNTColorAndOpacity()
@@ -3153,25 +3154,45 @@ void LabelLocalizationTest::onChangedRadioButtonSelect(RadioButton* radioButton,
     }
 }
 
-// LabelBMFontBinaryFormat
+//
+// LabelIssue15214
+//
 LabelIssue15214::LabelIssue15214()
 {
     auto size = Director::getInstance()->getVisibleSize();
-    Label* label = Label::createWithTTF("CHECK!", "fonts/arial.ttf", 48.0f);
+
+    // 1
+    Label* label = Label::createWithTTF("TTF with setColor()", "fonts/arial.ttf", 24.0f);
     label->enableUnderline();
     label->setColor(cocos2d::Color3B::BLUE);
-    label->setPosition(size.width/2, size.height/3*2);
+    label->setPosition(size.width/2, size.height/5*4);
     this->addChild(label);
-    label = Label::createWithSystemFont("CHECK!", "Verdana", 48.0f);
-    label->enableUnderline();
-    label->setColor(cocos2d::Color3B::BLUE);
-    label->setPosition(size.width/2, size.height/3*1);
-    this->addChild(label);
+
+    // 2
+    Label* label2 = Label::createWithSystemFont("System with setColor()", "Verdana", 24.0f);
+    label2->enableUnderline();
+    label2->setColor(cocos2d::Color3B::BLUE);
+    label2->setPosition(size.width/2, size.height/5*3);
+    this->addChild(label2);
+
+    // 3
+    Label* label3 = Label::createWithTTF("TTF with setTextColor()", "fonts/arial.ttf", 24.0f);
+    label3->enableUnderline();
+    label3->setTextColor(Color4B::BLUE);
+    label3->setPosition(size.width/2, size.height/5*2);
+    this->addChild(label3);
+
+    // 4
+    Label* label4 = Label::createWithSystemFont("System with setTextColor()", "Verdana", 24.0f);
+    label4->enableUnderline();
+    label4->setTextColor(Color4B::BLUE);
+    label4->setPosition(size.width/2, size.height/5*1);
+    this->addChild(label4);
 }
 
 std::string LabelIssue15214::title() const
 {
-    return "Githug Issue 15214";
+    return "Github Issue 15214";
 }
 
 std::string LabelIssue15214::subtitle() const
@@ -3179,7 +3200,9 @@ std::string LabelIssue15214::subtitle() const
     return "Font and underline should be of the same color";
 }
 
-// LabelBMFontBinaryFormat
+//
+// LabelIssue16293
+//
 LabelIssue16293::LabelIssue16293()
 {
     auto size = Director::getInstance()->getVisibleSize();
@@ -3190,10 +3213,45 @@ LabelIssue16293::LabelIssue16293()
 
 std::string LabelIssue16293::title() const
 {
-    return "Githug Issue 16293";
+    return "Github Issue 16293";
 }
 
 std::string LabelIssue16293::subtitle() const
 {
     return "No TextureAtlas resizes";
 }
+
+//
+// LabelIssue16471
+//
+LabelIssue16471::LabelIssue16471()
+{
+    auto size = Director::getInstance()->getVisibleSize();
+
+    auto node = Node::create();
+    addChild(node, 100);
+    node->setPosition(size.width/2, size.height/2);
+
+    // Used Google Translate to translate from Chinese:
+    //    Here is set to false then textLabel: TextColor valid
+    //    set to true testLabel: setTextColor invalid
+    // Original:
+    //    此处设置为false则testLabel:setTextColor有效
+    //    设置为true则testLabel:setTextColor无效
+    // if set false then  testLabel:setTextColor is useful
+    node->setCascadeColorEnabled(true);
+    Label* label = Label::createWithTTF("Should be Yellow", "fonts/arial.ttf", 12);
+    label->setTextColor(Color4B::YELLOW);
+    node->addChild(label);
+}
+
+std::string LabelIssue16471::title() const
+{
+    return "Github Issue 16471";
+}
+
+std::string LabelIssue16471::subtitle() const
+{
+    return "Label should be yellow";
+}
+

--- a/tests/cpp-tests/Classes/LabelTest/LabelTestNew.cpp
+++ b/tests/cpp-tests/Classes/LabelTest/LabelTestNew.cpp
@@ -3197,7 +3197,7 @@ std::string LabelIssue15214::title() const
 
 std::string LabelIssue15214::subtitle() const
 {
-    return "Font and underline should be of the same color";
+    return "Font + underline: same color with setColor()";
 }
 
 //

--- a/tests/cpp-tests/Classes/LabelTest/LabelTestNew.h
+++ b/tests/cpp-tests/Classes/LabelTest/LabelTestNew.h
@@ -872,4 +872,15 @@ public:
     virtual std::string subtitle() const override;
 };
 
+class LabelIssue16471 : public AtlasDemoNew
+{
+public:
+    CREATE_FUNC(LabelIssue16471);
+
+    LabelIssue16471();
+
+    virtual std::string title() const override;
+    virtual std::string subtitle() const override;
+};
+
 #endif


### PR DESCRIPTION
fix: Label updateColor() and underline color work as expected
fixes Github issue #15214 correctly. underline uses _displayColor
and not _textColorF. _textColorF is only for the text.
This also emulates the SystemFont underline behavior

fixes Github issue #16471
