### PR TITLE
Fixes jsval_to_std_string could not convert number to string. (#16504)

### DIFF
--- a/cocos/scripting/js-bindings/manual/js_manual_conversions.cpp
+++ b/cocos/scripting/js-bindings/manual/js_manual_conversions.cpp
@@ -602,7 +602,7 @@ bool jsval_to_long_long(JSContext *cx, JS::HandleValue vp, long long* r)
 }
 
 bool jsval_to_std_string(JSContext *cx, JS::HandleValue v, std::string* ret) {
-    if(v.isString() || v.isBoolean())
+    if (v.isString() || v.isBoolean() || v.isNumber())
     {
         JSString *tmp = JS::ToString(cx, v);
         JSB_PRECONDITION3(tmp, cx, false, "Error processing arguments");

--- a/tests/cpp-tests/Classes/ActionsProgressTest/ActionsProgressTest.cpp
+++ b/tests/cpp-tests/Classes/ActionsProgressTest/ActionsProgressTest.cpp
@@ -88,7 +88,7 @@ void SpriteProgressToRadial::onEnter()
     auto right = ProgressTimer::create(Sprite::create(s_pathBlock));
     right->setType(ProgressTimer::Type::RADIAL);
     // Makes the ridial CCW
-    right->setReverseProgress(true);
+    right->setReverseDirection(true);
     addChild(right);
     right->setPosition(s.width-100, s.height/2);
     right->runAction( RepeatForever::create(to2));


### PR DESCRIPTION
Don't use deprecated method in ActionsProgressTest.
