### PR TITLE
fixed #16490: [android, audio] AudioEngine::stop() triggers 'finished…

### DIFF
--- a/cocos/audio/android/AudioEngine-inl.cpp
+++ b/cocos/audio/android/AudioEngine-inl.cpp
@@ -225,11 +225,15 @@ int AudioEngineImpl::play2d(const std::string &filePath ,bool loop ,float volume
 
                 int id = player->getId();
 
-                ALOGV("Removing player id=%d", id);
+                ALOGV("Removing player id=%d, state:%d", id, (int)state);
+
                 auto iter = _callbackMap.find(id);
                 if (iter != _callbackMap.end())
                 {
-                    iter->second(id, *AudioEngine::_audioIDInfoMap[id].filePath);
+                    if (state == IAudioPlayer::State::OVER)
+                    {
+                        iter->second(id, *AudioEngine::_audioIDInfoMap[id].filePath);
+                    }
                     _callbackMap.erase(iter);
                 }
                 AudioEngine::remove(id);

--- a/tests/cpp-tests/Classes/NewAudioEngineTest/NewAudioEngineTest.cpp
+++ b/tests/cpp-tests/Classes/NewAudioEngineTest/NewAudioEngineTest.cpp
@@ -40,9 +40,12 @@ AudioEngineTests::AudioEngineTests()
     ADD_TEST_CASE(InvalidAudioFileTest);
     ADD_TEST_CASE(LargeAudioFileTest);
     ADD_TEST_CASE(AudioPerformanceTest);
-    ADD_TEST_CASE(AudioSwitchStateTest);
     ADD_TEST_CASE(AudioSmallFileTest);
     ADD_TEST_CASE(AudioPauseResumeAfterPlay);
+    ADD_TEST_CASE(AudioPlayFileInWritablePath);
+    
+    //FIXME: Please keep AudioSwitchStateTest to the last position since this test case doesn't work well on each platforms.
+    ADD_TEST_CASE(AudioSwitchStateTest);
 }
 
 namespace {
@@ -208,18 +211,35 @@ bool AudioControlTest::init()
     _duration = AudioEngine::TIME_UNKNOWN;
     _timeRatio = 0.0f;
     _updateTimeSlider = true;
+    _isStopped = false;
     
     std::string fontFilePath = "fonts/arial.ttf";
     
     auto& layerSize = this->getContentSize();
+    
+    _playOverLabel = Label::createWithSystemFont("Play Over", "", 30);
+    _playOverLabel->setPosition(Vec2(layerSize/2) + Vec2(0, 30));
+    _playOverLabel->setVisible(false);
+    addChild(_playOverLabel, 99999);
     
     auto playItem = TextButton::create("play", [&](TextButton* button){
         if (_audioID == AudioEngine::INVALID_AUDIO_ID) {
             _audioID = AudioEngine::play2d("background.mp3", _loopEnabled, _volume);
             
             if(_audioID != AudioEngine::INVALID_AUDIO_ID) {
+                _isStopped = false;
+                
                 button->setEnabled(false);
                 AudioEngine::setFinishCallback(_audioID, [&](int id, const std::string& filePath){
+                    log("_audioID(%d), _isStopped:(%d), played over!!!", _audioID, _isStopped);
+                    
+                    _playOverLabel->setVisible(true);
+                    
+                    scheduleOnce([&](float dt){
+                        _playOverLabel->setVisible(false);
+                    }, 2.0f, "hide_play_over_label");
+                    
+                    assert(!_isStopped); // Stop audio should not trigger finshed callback
                     _audioID = AudioEngine::INVALID_AUDIO_ID;
                     ((TextButton*)_playItem)->setEnabled(true);
                     
@@ -235,6 +255,7 @@ bool AudioControlTest::init()
     
     auto stopItem = TextButton::create("stop", [&](TextButton* button){
         if (_audioID != AudioEngine::INVALID_AUDIO_ID ) {
+            _isStopped = true;
             AudioEngine::stop(_audioID);
             
             _audioID = AudioEngine::INVALID_AUDIO_ID;
@@ -827,4 +848,47 @@ std::string AudioPauseResumeAfterPlay::title() const
 std::string AudioPauseResumeAfterPlay::subtitle() const
 {
     return "Should not crash";
+}
+
+void AudioPlayFileInWritablePath::onEnter()
+{
+    AudioEngineTestDemo::onEnter();
+    
+    auto fileUtils = FileUtils::getInstance();
+    std::string writablePath = fileUtils->getWritablePath();
+    std::string musicFile = "background.mp3";
+    std::string saveFilePath = writablePath + "background_in_writable_dir.mp3";
+    
+    _oldSearchPaths = fileUtils->getSearchPaths();
+    fileUtils->addSearchPath(writablePath, true);
+
+    if (!fileUtils->isFileExist(saveFilePath))
+    {
+        Data data = fileUtils->getDataFromFile(musicFile);
+        FILE* fp = fopen(saveFilePath.c_str(), "wb");
+        if (fp != nullptr)
+        {
+            fwrite(data.getBytes(), data.getSize(), 1, fp);
+            fclose(fp);
+        }
+    }
+    
+    AudioEngine::play2d(saveFilePath);
+}
+
+void AudioPlayFileInWritablePath::onExit()
+{
+    AudioEngineTestDemo::onExit();
+    
+    FileUtils::getInstance()->setSearchPaths(_oldSearchPaths);
+}
+
+std::string AudioPlayFileInWritablePath::title() const
+{
+    return "Play audio in writable path";
+}
+
+std::string AudioPlayFileInWritablePath::subtitle() const
+{
+    return "Could play audio";
 }

--- a/tests/cpp-tests/Classes/NewAudioEngineTest/NewAudioEngineTest.h
+++ b/tests/cpp-tests/Classes/NewAudioEngineTest/NewAudioEngineTest.h
@@ -68,6 +68,8 @@ private:
     void* _playItem;
     void* _timeSlider;
     bool _updateTimeSlider;
+    bool _isStopped;
+    cocos2d::Label* _playOverLabel;
 };
 
 class PlaySimultaneouslyTest : public AudioEngineTestDemo
@@ -208,6 +210,21 @@ public:
     
     virtual std::string title() const override;
     virtual std::string subtitle() const override;
+};
+
+class AudioPlayFileInWritablePath : public AudioEngineTestDemo
+{
+public:
+    CREATE_FUNC(AudioPlayFileInWritablePath);
+    
+    virtual void onEnter() override;
+    virtual void onExit() override;
+    
+    virtual std::string title() const override;
+    virtual std::string subtitle() const override;
+    
+private:
+    std::vector<std::string> _oldSearchPaths;
 };
 
 #endif /* defined(__NEWAUDIOENGINE_TEST_H_) */


### PR DESCRIPTION
…' callback (#16491)
