### PR TITLE
Support for compiling more OpenGL ES shaders on desktop platforms also.

### DIFF
--- a/cocos/renderer/CCGLProgram.cpp
+++ b/cocos/renderer/CCGLProgram.cpp
@@ -461,6 +461,8 @@ bool GLProgram::compileShader(GLuint* shader, GLenum type, const GLchar* source,
         (type == GL_VERTEX_SHADER ? "precision mediump float;\n precision mediump int;\n" : "precision mediump float;\n precision mediump int;\n"),
 #elif (CC_TARGET_PLATFORM != CC_PLATFORM_WIN32 && CC_TARGET_PLATFORM != CC_PLATFORM_LINUX && CC_TARGET_PLATFORM != CC_PLATFORM_MAC)
         (type == GL_VERTEX_SHADER ? "precision highp float;\n precision highp int;\n" : "precision mediump float;\n precision mediump int;\n"),
+#else
+        (type == GL_VERTEX_SHADER ? "\n" : "#define lowp\n #define mediump\n #define highp\n"),
 #endif
         COCOS2D_SHADER_UNIFORMS,
         convertedDefines.c_str(),


### PR DESCRIPTION
Support compiling OpenGL ES shaders that use lowp, mediump or highp on desktop platforms also. These symbols are not defined on desktop platforms so the code defines these symbols.
