### PR TITLE
getSlidBallRenderer methods to allow more customization of UISlider

### DIFF
--- a/cocos/ui/UISlider.cpp
+++ b/cocos/ui/UISlider.cpp
@@ -753,19 +753,19 @@ void Slider::copySpecialProperties(Widget *widget)
     }
 }
 
-Sprite* Slider::getSlidBallNormalRenderer() {
+Sprite* Slider::getSlidBallNormalRenderer() const {
     return _slidBallNormalRenderer;
 }
 
-Sprite* Slider::getSlidBallPressedRenderer() {
+Sprite* Slider::getSlidBallPressedRenderer() const {
     return _slidBallPressedRenderer;
 }
 
-Sprite* Slider::getSlidBallDisabledRenderer() {
+Sprite* Slider::getSlidBallDisabledRenderer() const {
     return _slidBallDisabledRenderer;
 }
 
-Node* Slider::getSlidBallRenderer() {
+Node* Slider::getSlidBallRenderer() const {
     return _slidBallRenderer;
 }
 

--- a/cocos/ui/UISlider.cpp
+++ b/cocos/ui/UISlider.cpp
@@ -753,6 +753,22 @@ void Slider::copySpecialProperties(Widget *widget)
     }
 }
 
+Sprite* Slider::getSlidBallNormalRenderer() {
+    return _slidBallNormalRenderer;
+}
+
+Sprite* Slider::getSlidBallPressedRenderer() {
+    return _slidBallPressedRenderer;
+}
+
+Sprite* Slider::getSlidBallDisabledRenderer() {
+    return _slidBallDisabledRenderer;
+}
+
+Node* Slider::getSlidBallRenderer() {
+    return _slidBallRenderer;
+}
+
 ResourceData Slider::getBackFile()
 {
     ResourceData rData;

--- a/cocos/ui/UISlider.h
+++ b/cocos/ui/UISlider.h
@@ -265,6 +265,11 @@ public:
      */
     float getZoomScale()const;
 
+    Sprite* getSlidBallNormalRenderer();
+    Sprite* getSlidBallPressedRenderer();
+    Sprite* getSlidBallDisabledRenderer();
+    Node* getSlidBallRenderer();
+
     ResourceData getBackFile();
     ResourceData getProgressBarFile();
     ResourceData getBallNormalFile();

--- a/cocos/ui/UISlider.h
+++ b/cocos/ui/UISlider.h
@@ -265,10 +265,10 @@ public:
      */
     float getZoomScale()const;
 
-    Sprite* getSlidBallNormalRenderer();
-    Sprite* getSlidBallPressedRenderer();
-    Sprite* getSlidBallDisabledRenderer();
-    Node* getSlidBallRenderer();
+    Sprite* getSlidBallNormalRenderer() const;
+    Sprite* getSlidBallPressedRenderer() const;
+    Sprite* getSlidBallDisabledRenderer() const;
+    Node* getSlidBallRenderer() const;
 
     ResourceData getBackFile();
     ResourceData getProgressBarFile();


### PR DESCRIPTION
getSlidBallRenderer methods to allow more customization of UISlider look and feel.

```
Sprite* getSlidBallNormalRenderer();
Sprite* getSlidBallPressedRenderer();
Sprite* getSlidBallDisabledRenderer();
Node* getSlidBallRenderer();
```

We also need jsb bindings for these but I think those are to be generated automatically by scripts, so I am not including them in the pull request. I can add them if needed.
