### PR TITLE
v3.13.1 updated winrt libcocos2d dll version to 3.13.1

### DIFF
--- a/cocos/2d/libcocos2d_8_1/libcocos2d_8_1/libcocos2d_8_1.Windows/libcocos2d_8_1.Windows.vcxproj
+++ b/cocos/2d/libcocos2d_8_1/libcocos2d_8_1/libcocos2d_8_1.Windows/libcocos2d_8_1.Windows.vcxproj
@@ -119,40 +119,40 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <GenerateManifest>false</GenerateManifest>
     <IgnoreImportLibrary>false</IgnoreImportLibrary>
-    <TargetName>libcocos2d_v3.13_Windows_8.1</TargetName>
+    <TargetName>libcocos2d_v3.13.1_Windows_8.1</TargetName>
     <LinkIncremental>
     </LinkIncremental>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <GenerateManifest>false</GenerateManifest>
     <IgnoreImportLibrary>false</IgnoreImportLibrary>
-    <TargetName>libcocos2d_v3.13_Windows_8.1</TargetName>
+    <TargetName>libcocos2d_v3.13.1_Windows_8.1</TargetName>
     <LinkIncremental>
     </LinkIncremental>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
     <GenerateManifest>false</GenerateManifest>
     <IgnoreImportLibrary>false</IgnoreImportLibrary>
-    <TargetName>libcocos2d_v3.13_Windows_8.1</TargetName>
+    <TargetName>libcocos2d_v3.13.1_Windows_8.1</TargetName>
     <LinkIncremental>false</LinkIncremental>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
     <GenerateManifest>false</GenerateManifest>
     <IgnoreImportLibrary>false</IgnoreImportLibrary>
-    <TargetName>libcocos2d_v3.13_Windows_8.1</TargetName>
+    <TargetName>libcocos2d_v3.13.1_Windows_8.1</TargetName>
     <LinkIncremental>false</LinkIncremental>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <GenerateManifest>false</GenerateManifest>
     <IgnoreImportLibrary>false</IgnoreImportLibrary>
-    <TargetName>libcocos2d_v3.13_Windows_8.1</TargetName>
+    <TargetName>libcocos2d_v3.13.1_Windows_8.1</TargetName>
     <LinkIncremental>
     </LinkIncremental>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <GenerateManifest>false</GenerateManifest>
     <IgnoreImportLibrary>false</IgnoreImportLibrary>
-    <TargetName>libcocos2d_v3.13_Windows_8.1</TargetName>
+    <TargetName>libcocos2d_v3.13.1_Windows_8.1</TargetName>
     <LinkIncremental>
     </LinkIncremental>
   </PropertyGroup>

--- a/cocos/2d/libcocos2d_8_1/libcocos2d_8_1/libcocos2d_8_1.WindowsPhone/libcocos2d_8_1.WindowsPhone.vcxproj
+++ b/cocos/2d/libcocos2d_8_1/libcocos2d_8_1/libcocos2d_8_1.WindowsPhone/libcocos2d_8_1.WindowsPhone.vcxproj
@@ -91,23 +91,23 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <GenerateManifest>false</GenerateManifest>
     <IgnoreImportLibrary>false</IgnoreImportLibrary>
-    <TargetName>libcocos2d_v3.13_WindowsPhone_8.1</TargetName>
+    <TargetName>libcocos2d_v3.13.1_WindowsPhone_8.1</TargetName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <GenerateManifest>false</GenerateManifest>
     <IgnoreImportLibrary>false</IgnoreImportLibrary>
-    <TargetName>libcocos2d_v3.13_WindowsPhone_8.1</TargetName>
+    <TargetName>libcocos2d_v3.13.1_WindowsPhone_8.1</TargetName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
     <GenerateManifest>false</GenerateManifest>
     <IgnoreImportLibrary>false</IgnoreImportLibrary>
-    <TargetName>libcocos2d_v3.13_WindowsPhone_8.1</TargetName>
+    <TargetName>libcocos2d_v3.13.1_WindowsPhone_8.1</TargetName>
     <LinkIncremental>false</LinkIncremental>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
     <GenerateManifest>false</GenerateManifest>
     <IgnoreImportLibrary>false</IgnoreImportLibrary>
-    <TargetName>libcocos2d_v3.13_WindowsPhone_8.1</TargetName>
+    <TargetName>libcocos2d_v3.13.1_WindowsPhone_8.1</TargetName>
     <LinkIncremental>false</LinkIncremental>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">

--- a/cocos/2d/libcocos2d_win10/libcocos2d.vcxproj
+++ b/cocos/2d/libcocos2d_win10/libcocos2d.vcxproj
@@ -1542,34 +1542,34 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <GenerateManifest>false</GenerateManifest>
     <IgnoreImportLibrary>false</IgnoreImportLibrary>
-    <TargetName>libcocos2d_v3.13_Windows_10.0</TargetName>
+    <TargetName>libcocos2d_v3.13.1_Windows_10.0</TargetName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <GenerateManifest>false</GenerateManifest>
     <IgnoreImportLibrary>false</IgnoreImportLibrary>
-    <TargetName>libcocos2d_v3.13_Windows_10.0</TargetName>
+    <TargetName>libcocos2d_v3.13.1_Windows_10.0</TargetName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
     <GenerateManifest>false</GenerateManifest>
     <IgnoreImportLibrary>false</IgnoreImportLibrary>
     <LinkIncremental>false</LinkIncremental>
-    <TargetName>libcocos2d_v3.13_Windows_10.0</TargetName>
+    <TargetName>libcocos2d_v3.13.1_Windows_10.0</TargetName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
     <GenerateManifest>false</GenerateManifest>
     <IgnoreImportLibrary>false</IgnoreImportLibrary>
     <LinkIncremental>false</LinkIncremental>
-    <TargetName>libcocos2d_v3.13_Windows_10.0</TargetName>
+    <TargetName>libcocos2d_v3.13.1_Windows_10.0</TargetName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <GenerateManifest>false</GenerateManifest>
     <IgnoreImportLibrary>false</IgnoreImportLibrary>
-    <TargetName>libcocos2d_v3.13_Windows_10.0</TargetName>
+    <TargetName>libcocos2d_v3.13.1_Windows_10.0</TargetName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <GenerateManifest>false</GenerateManifest>
     <IgnoreImportLibrary>false</IgnoreImportLibrary>
-    <TargetName>libcocos2d_v3.13_Windows_10.0</TargetName>
+    <TargetName>libcocos2d_v3.13.1_Windows_10.0</TargetName>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>


### PR DESCRIPTION
This pull request updates the dll version of the Windows 10 UWP and Windows 8.1 libcocos2d dlls to v3.13.1 as required by the Windows Store version tracking.
