### PR TITLE
Fix mismatched memory deallocator

### DIFF
--- a/cocos/2d/CCTMXLayer.cpp
+++ b/cocos/2d/CCTMXLayer.cpp
@@ -145,7 +145,7 @@ TMXLayer::~TMXLayer()
         _atlasIndexArray = nullptr;
     }
 
-    CC_SAFE_DELETE_ARRAY(_tiles);
+    CC_SAFE_FREE(_tiles);
 }
 
 void TMXLayer::releaseMap()


### PR DESCRIPTION
When the allocated data for a Tiled map gets deallocated, valgrind reports the following error:

```
==23578== Mismatched free() / delete / delete []
==23578==    at 0x4C2B696: operator delete[](void*) (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==23578==    by 0xB4CCC8: cocos2d::TMXLayer::~TMXLayer() (CCTMXLayer.cpp:148)
...
```

Upon further inspection, the allocated memory which `_tiles` points to gets allocated on [CCTMXXMLParser.cpp:457](https://github.com/cocos2d/cocos2d-x/blob/v3/cocos/2d/CCTMXXMLParser.cpp#L457) using `malloc`, therefore a `free` must be used instead of `delete []`. Otherwise we might get undefined behavior on some devices.
