### PR TITLE
Remove unnecessary inline keywords

### DIFF
--- a/cocos/2d/CCAction.h
+++ b/cocos/2d/CCAction.h
@@ -119,17 +119,17 @@ public:
      *
      * @return A certain target.
      */
-    inline Node* getTarget() const { return _target; }
+    Node* getTarget() const { return _target; }
     /** The action will modify the target properties. 
      *
      * @param target A certain target.
      */
-    inline void setTarget(Node *target) { _target = target; }
+    void setTarget(Node *target) { _target = target; }
     /** Return a original Target. 
      *
      * @return A original Target.
      */
-    inline Node* getOriginalTarget() const { return _originalTarget; }
+    Node* getOriginalTarget() const { return _originalTarget; }
     /** 
      * Set the original target, since target can be nil.
      * Is the target that were used to run the action. Unless you are doing something complex, like ActionManager, you should NOT call this method.
@@ -138,27 +138,27 @@ public:
      *
      * @param originalTarget Is 'assigned', it is not 'retained'.
      */
-    inline void setOriginalTarget(Node *originalTarget) { _originalTarget = originalTarget; }
+    void setOriginalTarget(Node *originalTarget) { _originalTarget = originalTarget; }
     /** Returns a tag that is used to identify the action easily. 
      *
      * @return A tag.
      */
-    inline int getTag() const { return _tag; }
+    int getTag() const { return _tag; }
     /** Changes the tag that is used to identify the action easily. 
      *
      * @param tag Used to identify the action easily.
      */
-    inline void setTag(int tag) { _tag = tag; }
+    void setTag(int tag) { _tag = tag; }
     /** Returns a flag field that is used to group the actions easily.
      *
      * @return A tag.
      */
-    inline unsigned int getFlags() const { return _flags; }
+    unsigned int getFlags() const { return _flags; }
     /** Changes the flag field that is used to group the actions easily.
      *
      * @param flags Used to group the actions easily.
      */
-    inline void setFlags(unsigned int flags) { _flags = flags; }
+    void setFlags(unsigned int flags) { _flags = flags; }
 
 CC_CONSTRUCTOR_ACCESS:
     Action();
@@ -200,12 +200,12 @@ public:
      *
      * @return The duration in seconds of the action.
      */
-    inline float getDuration() const { return _duration; }
+    float getDuration() const { return _duration; }
     /** Set duration in seconds of the action. 
      *
      * @param duration In seconds of the action.
      */
-    inline void setDuration(float duration) { _duration = duration; }
+    void setDuration(float duration) { _duration = duration; }
 
     //
     // Overrides
@@ -256,12 +256,12 @@ public:
      *
      * @return The action speed.
      */
-    inline float getSpeed(void) const { return _speed; }
+    float getSpeed() const { return _speed; }
     /** Alter the speed of the inner function in runtime. 
      *
      * @param speed Alter the speed of the inner function in runtime.
      */
-    inline void setSpeed(float speed) { _speed = speed; }
+    void setSpeed(float speed) { _speed = speed; }
 
     /** Replace the interior action.
      *
@@ -272,7 +272,7 @@ public:
      *
      * @return The interior action.
      */
-    inline ActionInterval* getInnerAction() const { return _innerAction; }
+    ActionInterval* getInnerAction() const { return _innerAction; }
 
     //
     // Override
@@ -348,18 +348,18 @@ public:
      *
      * @return Return boundarySet.
      */
-    inline bool isBoundarySet() const { return _boundarySet; }
+    bool isBoundarySet() const { return _boundarySet; }
     /** Alter behavior - turn on/off boundary. 
      *
      * @param value Turn on/off boundary.
      */
-    inline void setBoundarySet(bool value) { _boundarySet = value; }
+    void setBoundarySet(bool value) { _boundarySet = value; }
     
     /** @deprecated Alter behavior - turn on/off boundary. 
      *
      * @param value Turn on/off boundary.
      */
-    CC_DEPRECATED_ATTRIBUTE inline void setBoudarySet(bool value) { setBoundarySet(value); }
+    CC_DEPRECATED_ATTRIBUTE void setBoudarySet(bool value) { setBoundarySet(value); }
 
     //
     // Override

--- a/cocos/2d/CCActionCatmullRom.h
+++ b/cocos/2d/CCActionCatmullRom.h
@@ -205,12 +205,12 @@ public:
      *
      * @return A PointArray.
      */
-    inline PointArray* getPoints() { return _points; }
+    PointArray* getPoints() { return _points; }
     /**
      * @js NA
      * @lua NA
      */
-    inline void setPoints(PointArray* points)
+    void setPoints(PointArray* points)
     {
         CC_SAFE_RETAIN(points);
         CC_SAFE_RELEASE(_points);

--- a/cocos/2d/CCActionEase.h
+++ b/cocos/2d/CCActionEase.h
@@ -93,12 +93,12 @@ public:
     @brief Set the rate value for the ease rate action.
     @param rate The value will be set.
     */
-    inline void setRate(float rate) { _rate = rate; }
+    void setRate(float rate) { _rate = rate; }
     /**
     @brief Get the rate value of the ease rate action.
     @return Return the rate value of the ease rate action.
     */
-    inline float getRate() const { return _rate; }
+    float getRate() const { return _rate; }
 
 CC_CONSTRUCTOR_ACCESS:
     EaseRateAction() {}
@@ -429,12 +429,12 @@ public:
      @brief Get period of the wave in radians. Default value is 0.3.
      @return Return the period of the wave in radians.
     */
-    inline float getPeriod() const { return _period; }
+    float getPeriod() const { return _period; }
     /**
      @brief Set period of the wave in radians.
      @param fPeriod The value will be set.
     */
-    inline void setPeriod(float fPeriod) { _period = fPeriod; }
+    void setPeriod(float fPeriod) { _period = fPeriod; }
 
 CC_CONSTRUCTOR_ACCESS:
     EaseElastic() {}

--- a/cocos/2d/CCActionGrid.h
+++ b/cocos/2d/CCActionGrid.h
@@ -108,7 +108,7 @@ public:
      * @js NA
      * @lua NA
      */
-    CC_DEPRECATED_ATTRIBUTE inline Vec3 vertex(const Vec2& position) { return getVertex(position); }
+    CC_DEPRECATED_ATTRIBUTE Vec3 vertex(const Vec2& position) { return getVertex(position); }
 
     /** 
      * @brief Get the non-transformed vertex that belongs to certain position in the grid.
@@ -123,7 +123,7 @@ public:
      * @js NA
      * @lua NA
      */
-    CC_DEPRECATED_ATTRIBUTE inline Vec3 originalVertex(const Vec2& position) { return getOriginalVertex(position); }
+    CC_DEPRECATED_ATTRIBUTE Vec3 originalVertex(const Vec2& position) { return getOriginalVertex(position); }
 
     /** 
      * @brief Set a new vertex to a certain position of the grid.
@@ -231,12 +231,12 @@ public:
     @brief Get the value of amplitude rate.
     @return the value of amplitude rate.
     */
-    inline float getRate(void) const { return _rate; }
+    float getRate() const { return _rate; }
     /**
     @brief Set the value of amplitude rate.
     @param rate Specify the value of amplitude rate.
     */
-    inline void setRate(float rate) { _rate = rate; }
+    void setRate(float rate) { _rate = rate; }
 
     // Overrides
     virtual void startWithTarget(Node *target) override;
@@ -283,12 +283,12 @@ public:
     @brief Get the value of amplitude rate.
     @return The value of amplitude rate.
     */
-    inline float getRate() const { return _rate; }
+    float getRate() const { return _rate; }
     /**
     @brief Set the value of amplitude rate.
     @param rate Specify the value of amplitude rate.
     */
-    inline void setRate(float rate) { _rate = rate; }
+    void setRate(float rate) { _rate = rate; }
 
     // Overrides
     virtual void startWithTarget(Node *target) override;
@@ -329,12 +329,12 @@ public:
     @brief Get the value of amplitude rate.
     @return The value of amplitude rate.
     */
-    inline float getRate() const { return _rate; }
+    float getRate() const { return _rate; }
     /**
     @brief Set the value of amplitude rate.
     @param rate Specify the value.
     */
-    inline void setRate(float rate) { _rate = rate; }
+    void setRate(float rate) { _rate = rate; }
 
     // overrides
     virtual void startWithTarget(Node *target) override;

--- a/cocos/2d/CCActionGrid3D.h
+++ b/cocos/2d/CCActionGrid3D.h
@@ -58,23 +58,23 @@ public:
     @brief Get the amplitude of the effect.
     @return Return the amplitude of the effect.
     */
-    inline float getAmplitude() const { return _amplitude; }
+    float getAmplitude() const { return _amplitude; }
     /**
     @brief Set the amplitude to the effect.
     @param amplitude The value of amplitude will be set.
     */
-    inline void setAmplitude(float amplitude) { _amplitude = amplitude; }
+    void setAmplitude(float amplitude) { _amplitude = amplitude; }
 
     /**
     @brief Get the amplitude rate of the effect.
     @return Return the amplitude rate of the effect.
     */
-    inline float getAmplitudeRate() const { return _amplitudeRate; }
+    float getAmplitudeRate() const { return _amplitudeRate; }
     /**
     @brief Set the amplitude rate of the effect.
     @param amplitudeRate The value of amplitude rate will be set.
     */
-    inline void setAmplitudeRate(float amplitudeRate) { _amplitudeRate = amplitudeRate; }
+    void setAmplitudeRate(float amplitudeRate) { _amplitudeRate = amplitudeRate; }
 
     // Overrides
     virtual Waves3D* clone() const override;
@@ -193,25 +193,25 @@ public:
     @brief Get the value of lens effect. Default value is 0.7.
     @return The value of lens effect.
     */
-    inline float getLensEffect() const { return _lensEffect; }
+    float getLensEffect() const { return _lensEffect; }
 
     /**
     @brief Set the value of lens effect.
     @param lensEffect The value of lens effect will be set.
     */
-    inline void setLensEffect(float lensEffect) { _lensEffect = lensEffect; }
+    void setLensEffect(float lensEffect) { _lensEffect = lensEffect; }
 
     /**
     @brief Set whether lens is concave.
     @param concave Whether lens is concave.
     */
-    inline void setConcave(bool concave) { _concave = concave; }
+    void setConcave(bool concave) { _concave = concave; }
 
     /**
     @brief Get the center position of lens effect.
     @return The center position of lens effect.
     */
-    inline const Vec2& getPosition() const { return _position; }
+    const Vec2& getPosition() const { return _position; }
 
     /**
     @brief Set the center position of lens effect.
@@ -278,7 +278,7 @@ public:
     @brief Get the center position of ripple effect.
     @return The center position of ripple effect.
     */
-    inline const Vec2& getPosition() const { return _position; }
+    const Vec2& getPosition() const { return _position; }
     /**
     @brief Set the center position of ripple effect.
     @param position The center position of ripple effect will be set.
@@ -289,23 +289,23 @@ public:
     @brief Get the amplitude of ripple effect.
     @return The amplitude of ripple effect.
     */
-    inline float getAmplitude() const { return _amplitude; }
+    float getAmplitude() const { return _amplitude; }
     /**
     @brief Set the amplitude of ripple effect.
     @param fAmplitude The amplitude of ripple effect.
     */
-    inline void setAmplitude(float fAmplitude) { _amplitude = fAmplitude; }
+    void setAmplitude(float fAmplitude) { _amplitude = fAmplitude; }
 
     /**
     @brief Get the amplitude rate of ripple effect.
     @return The amplitude rate of ripple effect.
     */
-    inline float getAmplitudeRate() const { return _amplitudeRate; }
+    float getAmplitudeRate() const { return _amplitudeRate; }
     /**
     @brief Set the amplitude rate of ripple effect.
     @param fAmplitudeRate The amplitude rate of ripple effect.
     */
-    inline void setAmplitudeRate(float fAmplitudeRate) { _amplitudeRate = fAmplitudeRate; }
+    void setAmplitudeRate(float fAmplitudeRate) { _amplitudeRate = fAmplitudeRate; }
 
     // Override
     virtual Ripple3D* clone() const override;
@@ -407,23 +407,23 @@ public:
     @brief Get the amplitude of the effect.
     @return Return the amplitude of the effect.
     */
-    inline float getAmplitude() const { return _amplitude; }
+    float getAmplitude() const { return _amplitude; }
     /**
     @brief Set the amplitude to the effect.
     @param amplitude The value of amplitude will be set.
     */
-    inline void setAmplitude(float amplitude) { _amplitude = amplitude; }
+    void setAmplitude(float amplitude) { _amplitude = amplitude; }
 
     /**
     @brief Get the amplitude rate of the effect.
     @return Return the amplitude rate of the effect.
     */
-    inline float getAmplitudeRate() const { return _amplitudeRate; }
+    float getAmplitudeRate() const { return _amplitudeRate; }
     /**
     @brief Set the amplitude rate of the effect.
     @param amplitudeRate The value of amplitude rate will be set.
     */
-    inline void setAmplitudeRate(float amplitudeRate) { _amplitudeRate = amplitudeRate; }
+    void setAmplitudeRate(float amplitudeRate) { _amplitudeRate = amplitudeRate; }
 
     // Overrides
     virtual Liquid* clone() const override;
@@ -478,23 +478,23 @@ public:
     @brief Get the amplitude of the effect.
     @return Return the amplitude of the effect.
     */
-    inline float getAmplitude() const { return _amplitude; }
+    float getAmplitude() const { return _amplitude; }
     /**
     @brief Set the amplitude to the effect.
     @param amplitude The value of amplitude will be set.
     */
-    inline void setAmplitude(float amplitude) { _amplitude = amplitude; }
+    void setAmplitude(float amplitude) { _amplitude = amplitude; }
 
     /**
     @brief Get the amplitude rate of the effect.
     @return Return the amplitude rate of the effect.
     */
-    inline float getAmplitudeRate() const { return _amplitudeRate; }
+    float getAmplitudeRate() const { return _amplitudeRate; }
     /**
     @brief Set the amplitude rate of the effect.
     @param amplitudeRate The value of amplitude rate will be set.
     */
-    inline void setAmplitudeRate(float amplitudeRate) { _amplitudeRate = amplitudeRate; }
+    void setAmplitudeRate(float amplitudeRate) { _amplitudeRate = amplitudeRate; }
 
     // Overrides
     virtual Waves* clone() const override;
@@ -551,7 +551,7 @@ public:
     @brief Get the center position of twirl action.
     @return The center position of twirl action.
     */
-    inline const Vec2& getPosition() const { return _position; }
+    const Vec2& getPosition() const { return _position; }
     /**
     @brief Set the center position of twirl action.
     @param position The center position of twirl action will be set.
@@ -562,23 +562,23 @@ public:
     @brief Get the amplitude of the effect.
     @return Return the amplitude of the effect.
     */
-    inline float getAmplitude() const { return _amplitude; }
+    float getAmplitude() const { return _amplitude; }
     /**
     @brief Set the amplitude to the effect.
     @param amplitude The value of amplitude will be set.
     */
-    inline void setAmplitude(float amplitude) { _amplitude = amplitude; }
+    void setAmplitude(float amplitude) { _amplitude = amplitude; }
 
     /**
     @brief Get the amplitude rate of the effect.
     @return Return the amplitude rate of the effect.
     */
-    inline float getAmplitudeRate() const { return _amplitudeRate; }
+    float getAmplitudeRate() const { return _amplitudeRate; }
     /**
     @brief Set the amplitude rate of the effect.
     @param amplitudeRate The value of amplitude rate will be set.
     */
-    inline void setAmplitudeRate(float amplitudeRate) { _amplitudeRate = amplitudeRate; }
+    void setAmplitudeRate(float amplitudeRate) { _amplitudeRate = amplitudeRate; }
 
 
     // Overrides

--- a/cocos/2d/CCActionInstant.h
+++ b/cocos/2d/CCActionInstant.h
@@ -347,7 +347,7 @@ public:
      *
      * @return The selector target.
      */
-    inline Ref* getTargetCallback()
+    Ref* getTargetCallback()
     {
         return _selectorTarget;
     }
@@ -356,7 +356,7 @@ public:
      *
      * @param sel The selector target.
      */
-    inline void setTargetCallback(Ref* sel)
+    void setTargetCallback(Ref* sel)
     {
         if (sel != _selectorTarget)
         {

--- a/cocos/2d/CCActionInterval.h
+++ b/cocos/2d/CCActionInterval.h
@@ -73,7 +73,7 @@ public:
      *
      * @return The seconds had elapsed since the actions started to run.
      */
-    inline float getElapsed(void) { return _elapsed; }
+    float getElapsed() { return _elapsed; }
 
     /** Sets the amplitude rate, extension in GridAction
      *
@@ -225,7 +225,7 @@ public:
      *
      * @param action The inner action.
      */
-    inline void setInnerAction(FiniteTimeAction *action)
+    void setInnerAction(FiniteTimeAction *action)
     {
         if (_innerAction != action)
         {
@@ -239,7 +239,7 @@ public:
      *
      * @return The inner action.
      */
-    inline FiniteTimeAction* getInnerAction()
+    FiniteTimeAction* getInnerAction()
     {
         return _innerAction;
     }
@@ -295,7 +295,7 @@ public:
      *
      * @param action The inner action.
      */
-    inline void setInnerAction(ActionInterval *action)
+    void setInnerAction(ActionInterval *action)
     {
         if (_innerAction != action)
         {
@@ -309,7 +309,7 @@ public:
      *
      * @return The inner action.
      */
-    inline ActionInterval* getInnerAction()
+    ActionInterval* getInnerAction()
     {
         return _innerAction;
     }

--- a/cocos/2d/CCActionManager.h
+++ b/cocos/2d/CCActionManager.h
@@ -143,7 +143,7 @@ public:
 
     /** @deprecated Use getNumberOfRunningActionsInTarget() instead.
      */
-    CC_DEPRECATED_ATTRIBUTE inline ssize_t numberOfRunningActionsInTarget(Node *target) const { return getNumberOfRunningActionsInTarget(target); }
+    CC_DEPRECATED_ATTRIBUTE ssize_t numberOfRunningActionsInTarget(Node *target) const { return getNumberOfRunningActionsInTarget(target); }
 
     /** Pauses the target: all running actions and newly added actions will be paused.
      *

--- a/cocos/2d/CCActionTiledGrid.h
+++ b/cocos/2d/CCActionTiledGrid.h
@@ -404,23 +404,23 @@ public:
     @brief Get the amplitude of the effect.
     @return Return the amplitude of the effect.
     */
-    inline float getAmplitude() const { return _amplitude; }
+    float getAmplitude() const { return _amplitude; }
     /**
     @brief Set the amplitude to the effect.
     @param amplitude The value of amplitude will be set.
     */
-    inline void setAmplitude(float amplitude) { _amplitude = amplitude; }
+    void setAmplitude(float amplitude) { _amplitude = amplitude; }
 
     /**
     @brief Get the amplitude rate of the effect.
     @return Return the amplitude rate of the effect.
     */
-    inline float getAmplitudeRate() const { return _amplitudeRate; }
+    float getAmplitudeRate() const { return _amplitudeRate; }
     /**
     @brief Set the amplitude rate of the effect.
     @param amplitudeRate The value of amplitude rate will be set.
     */
-    inline void setAmplitudeRate(float amplitudeRate) { _amplitudeRate = amplitudeRate; }
+    void setAmplitudeRate(float amplitudeRate) { _amplitudeRate = amplitudeRate; }
 
     // Override
     virtual WavesTiles3D* clone() const override;
@@ -470,23 +470,23 @@ public:
     @brief Get the amplitude of the effect.
     @return Return the amplitude of the effect.
     */
-    inline float getAmplitude() const { return _amplitude; }
+    float getAmplitude() const { return _amplitude; }
     /**
     @brief Set the amplitude to the effect.
     @param amplitude The value of amplitude will be set.
     */
-    inline void setAmplitude(float amplitude) { _amplitude = amplitude; }
+    void setAmplitude(float amplitude) { _amplitude = amplitude; }
 
     /**
     @brief Get the amplitude rate of the effect.
     @return Return the amplitude rate of the effect.
     */
-    inline float getAmplitudeRate() const { return _amplitudeRate; }
+    float getAmplitudeRate() const { return _amplitudeRate; }
     /**
     @brief Set the amplitude rate of the effect.
     @param amplitudeRate The value of amplitude rate will be set.
     */
-    inline void setAmplitudeRate(float amplitudeRate) { _amplitudeRate = amplitudeRate; }
+    void setAmplitudeRate(float amplitudeRate) { _amplitudeRate = amplitudeRate; }
 
     // Override
     virtual JumpTiles3D* clone() const override;

--- a/cocos/2d/CCFastTMXLayer.h
+++ b/cocos/2d/CCFastTMXLayer.h
@@ -151,37 +151,37 @@ public:
      *
      * @return The tile layer name.
      */
-    inline const std::string& getLayerName(){ return _layerName; }
+    const std::string& getLayerName() { return _layerName; }
     
     /** Set the tile layer name.
      *
      * @param layerName The new layer name.
      */
-    inline void setLayerName(const std::string& layerName){ _layerName = layerName; }
+    void setLayerName(const std::string& layerName) { _layerName = layerName; }
 
     /** Size of the layer in tiles.
      *
      * @return Size of the layer in tiles.
      */
-    inline const Size& getLayerSize() const { return _layerSize; };
+    const Size& getLayerSize() const { return _layerSize; }
     
     /** Set the size of the layer in tiles. 
      *
      * @param size The new size of the layer in tiles.
      */
-    inline void setLayerSize(const Size& size) { _layerSize = size; };
+    void setLayerSize(const Size& size) { _layerSize = size; }
     
     /** Size of the map's tile (could be different from the tile's size).
      *
      * @return Size of the map's tile (could be different from the tile's size).
      */
-    inline const Size& getMapTileSize() const { return _mapTileSize; };
+    const Size& getMapTileSize() const { return _mapTileSize; }
     
     /** Set the size of the map's tile. 
      *
      * @param size The new size of the map's tile.
      */
-    inline void setMapTileSize(const Size& size) { _mapTileSize = size; };
+    void setMapTileSize(const Size& size) { _mapTileSize = size; }
     
     /** Pointer to the map of tiles.
      * @js NA
@@ -200,13 +200,13 @@ public:
      *
      * @return Tileset information for the layer.
      */
-    inline TMXTilesetInfo* getTileSet() const { return _tileSet; };
+    TMXTilesetInfo* getTileSet() const { return _tileSet; }
     
     /** Set the tileset information for the layer. 
      *
      * @param info The new tileset information for the layer.
      */
-    inline void setTileSet(TMXTilesetInfo* info) {
+    void setTileSet(TMXTilesetInfo* info) {
         CC_SAFE_RETAIN(info);
         CC_SAFE_RELEASE(_tileSet);
         _tileSet = info;
@@ -216,31 +216,31 @@ public:
      *
      * @return Layer orientation, which is the same as the map orientation.
      */
-    inline int getLayerOrientation() const { return _layerOrientation; };
+    int getLayerOrientation() const { return _layerOrientation; }
     
     /** Set Layer orientation, which is the same as the map orientation. 
      *
      * @param orientation Layer orientation, which is the same as the map orientation.
      */
-    inline void setLayerOrientation(int orientation) { _layerOrientation = orientation; };
+    void setLayerOrientation(int orientation) { _layerOrientation = orientation; }
     
     /** Properties from the layer. They can be added using Tiled. 
      *
      * @return Properties from the layer. They can be added using Tiled.
      */
-    inline const ValueMap& getProperties() const { return _properties; };
+    const ValueMap& getProperties() const { return _properties; }
     
     /** Properties from the layer. They can be added using Tiled.
      *
      * @return Properties from the layer. They can be added using Tiled.
      */
-    inline ValueMap& getProperties() { return _properties; };
+    ValueMap& getProperties() { return _properties; }
     
     /** Set the properties to the layer.
      *
      * @param properties The properties to the layer.
      */
-    inline void setProperties(const ValueMap& properties)
+    void setProperties(const ValueMap& properties)
     {
         _properties = properties;
     };
@@ -291,7 +291,7 @@ protected:
     void updateTotalQuads();
     
     void onDraw(Primitive* primitive);
-    inline int getTileIndexByPos(int x, int y) const { return x + y * (int) _layerSize.width; }
+    int getTileIndexByPos(int x, int y) const { return x + y * (int) _layerSize.width; }
     
     void updateVertexBuffer();
     void updateIndexBuffer();

--- a/cocos/2d/CCFastTMXTiledMap.h
+++ b/cocos/2d/CCFastTMXTiledMap.h
@@ -141,50 +141,50 @@ public:
      *
      * @return The map's size property measured in tiles.
      */
-    inline const Size& getMapSize() const { return _mapSize; };
+    const Size& getMapSize() const { return _mapSize; }
     
     /** Set the map's size property measured in tiles.
      *
      * @param mapSize The map's size property measured in tiles.
      */
-    inline void setMapSize(const Size& mapSize) { _mapSize = mapSize; };
+    void setMapSize(const Size& mapSize) { _mapSize = mapSize; }
 
     /** The tiles's size property measured in pixels.
      *
      * @return The tiles's size property measured in pixels.
      */
-    inline const Size& getTileSize() const { return _tileSize; };
+    const Size& getTileSize() const { return _tileSize; }
     
     /** Set the tiles's size property measured in pixels. 
      *
      * @param tileSize The tiles's size property measured in pixels.
      */
-    inline void setTileSize(const Size& tileSize) { _tileSize = tileSize; };
+    void setTileSize(const Size& tileSize) { _tileSize = tileSize; }
 
     /** Get map orientation. 
      *
      * @return The map orientation.
      */
-    inline int getMapOrientation() const { return _mapOrientation; };
+    int getMapOrientation() const { return _mapOrientation; }
     
     /** Set map orientation. 
      *
      * @param mapOrientation The map orientation.
      */
-    inline void setMapOrientation(int mapOrientation) { _mapOrientation = mapOrientation; };
+    void setMapOrientation(int mapOrientation) { _mapOrientation = mapOrientation; }
 
     /** Get object groups. 
      *
      * @return Object groups.
      */
-    inline const Vector<TMXObjectGroup*>& getObjectGroups() const { return _objectGroups; };
-    inline Vector<TMXObjectGroup*>& getObjectGroups() { return _objectGroups; };
+    const Vector<TMXObjectGroup*>& getObjectGroups() const { return _objectGroups; }
+    Vector<TMXObjectGroup*>& getObjectGroups() { return _objectGroups; }
     
     /** Set object groups. 
      *
      * @param groups An object groups.
      */
-    inline void setObjectGroups(const Vector<TMXObjectGroup*>& groups) {
+    void setObjectGroups(const Vector<TMXObjectGroup*>& groups) {
         _objectGroups = groups;
     };
     
@@ -192,13 +192,13 @@ public:
      *
      * @return Properties.
      */
-    inline const ValueMap& getProperties() const { return _properties; };
+    const ValueMap& getProperties() const { return _properties; }
     
     /** Set properties. 
      *
      * @param properties An ValueMap Properties.
      */
-    inline void setProperties(const ValueMap& properties) {
+    void setProperties(const ValueMap& properties) {
         _properties = properties;
     };
 

--- a/cocos/2d/CCFontAtlas.h
+++ b/cocos/2d/CCFontAtlas.h
@@ -78,7 +78,7 @@ public:
     
     bool prepareLetterDefinitions(const std::u16string& utf16String);
 
-    inline const std::unordered_map<ssize_t, Texture2D*>& getTextures() const{ return _atlasTextures;}
+    const std::unordered_map<ssize_t, Texture2D*>& getTextures() const { return _atlasTextures; }
     void  addTexture(Texture2D *texture, int slot);
     float getLineHeight() const { return _lineHeight; }
     void  setLineHeight(float newHeight);

--- a/cocos/2d/CCFontFNT.cpp
+++ b/cocos/2d/CCFontFNT.cpp
@@ -143,8 +143,8 @@ public:
     /** initializes a BitmapFontConfiguration with a FNT file */
     bool initWithFNTfile(const std::string& FNTfile);
     
-    inline const std::string& getAtlasName(){ return _atlasName; }
-    inline void setAtlasName(const std::string& atlasName) { _atlasName = atlasName; }
+    const std::string& getAtlasName() { return _atlasName; }
+    void setAtlasName(const std::string& atlasName) { _atlasName = atlasName; }
     
     std::set<unsigned int>* getCharacterSet() const;
 private:

--- a/cocos/2d/CCGrid.h
+++ b/cocos/2d/CCGrid.h
@@ -74,27 +74,27 @@ public:
     /** @{
     Getter and setter of the active state of the grid.
     */
-    inline bool isActive(void) const { return _active; }
+    bool isActive() const { return _active; }
     void setActive(bool active);
     /**@}*/
 
     /** Get number of times that the grid will be reused. */
-    inline int getReuseGrid(void) const { return _reuseGrid; }
+    int getReuseGrid() const { return _reuseGrid; }
     /** Set number of times that the grid will be reused. */
-    inline void setReuseGrid(int reuseGrid) { _reuseGrid = reuseGrid; }
+    void setReuseGrid(int reuseGrid) { _reuseGrid = reuseGrid; }
 
     /** Size of the grid. */
-    inline const Size& getGridSize(void) const { return _gridSize; }
+    const Size& getGridSize() const { return _gridSize; }
     /**Set the size of the grid.*/
-    inline void setGridSize(const Size& gridSize) { _gridSize = gridSize; }
+    void setGridSize(const Size& gridSize) { _gridSize = gridSize; }
 
     /** Pixels between the grids. */
-    inline const Vec2& getStep(void) const { return _step; }
+    const Vec2& getStep() const { return _step; }
     /**Get the pixels between the grids.*/
-    inline void setStep(const Vec2& step) { _step = step; }
+    void setStep(const Vec2& step) { _step = step; }
 
     /** is texture flipped. */
-    inline bool isTextureFlipped(void) const { return _isTextureFlipped; }
+    bool isTextureFlipped() const { return _isTextureFlipped; }
     /**Set the texture flipped or not.*/
     void setTextureFlipped(bool flipped);
     
@@ -132,7 +132,7 @@ public:
      * @brief Get the effect grid rect.
      * @return Return the effect grid rect.
      */
-    inline const Rect& getGridRect() const {return _gridRect;}
+    const Rect& getGridRect() const { return _gridRect; }
 
 protected:
     bool _active;

--- a/cocos/2d/CCMenuItem.h
+++ b/cocos/2d/CCMenuItem.h
@@ -159,13 +159,13 @@ public:
     std::string getString() const;
 
     /** Gets the color that will be used when the item is disabled. */
-    inline const Color3B& getDisabledColor() const { return _disabledColor; };
+    const Color3B& getDisabledColor() const { return _disabledColor; }
 
     /** Sets the color that will be used when the item is disabled. */
-    inline void setDisabledColor(const Color3B& color) { _disabledColor = color; };
+    void setDisabledColor(const Color3B& color) { _disabledColor = color; }
     
     /** Gets the label that is rendered. */
-    inline Node* getLabel() const { return _label; };
+    Node* getLabel() const { return _label; }
     
     /** Sets the label that is rendered. */
     void setLabel(Node* node);
@@ -353,19 +353,19 @@ public:
     static MenuItemSprite * create(Node* normalSprite, Node* selectedSprite, Node* disabledSprite, const ccMenuCallback& callback);
 
     /** Gets the image used when the item is not selected. */
-    inline Node* getNormalImage() const { return _normalImage; };
+    Node* getNormalImage() const { return _normalImage; }
     
     /** Sets the image used when the item is not selected. */
     void setNormalImage(Node* image);
     
     /** Gets the image used when the item is selected. */
-    inline Node* getSelectedImage() const { return _selectedImage; };
+    Node* getSelectedImage() const { return _selectedImage; }
     
     /** Sets the image used when the item is selected. */
     void setSelectedImage(Node* image);
     
     /** Gets the image used when the item is disabled. */
-    inline Node* getDisabledImage() const { return _disabledImage; };
+    Node* getDisabledImage() const { return _disabledImage; }
     
     /** Sets the image used when the item is disabled. */
     void setDisabledImage(Node* image);
@@ -528,7 +528,7 @@ public:
     CC_DEPRECATED_ATTRIBUTE MenuItem* selectedItem() { return getSelectedItem(); }
 
     /** Gets the index of the selected item. */
-    inline unsigned int getSelectedIndex() const { return _selectedIndex; };
+    unsigned int getSelectedIndex() const { return _selectedIndex; }
     
     /** Sets the index of the selected item. */
     void setSelectedIndex(unsigned int index);
@@ -539,11 +539,11 @@ public:
      * @js NA
      * @lua NA
      */
-    inline const Vector<MenuItem*>& getSubItems() const { return _subItems; };
-    inline Vector<MenuItem*>& getSubItems() { return _subItems; };
+    const Vector<MenuItem*>& getSubItems() const { return _subItems; }
+    Vector<MenuItem*>& getSubItems() { return _subItems; }
 
     /** Sets the array that contains the subitems. */
-    inline void setSubItems(const Vector<MenuItem*>& items) {
+    void setSubItems(const Vector<MenuItem*>& items) {
         _subItems = items;
     }
     

--- a/cocos/2d/CCMotionStreak.h
+++ b/cocos/2d/CCMotionStreak.h
@@ -80,33 +80,33 @@ public:
      * 
      * @return True if fast mode is enabled.
      */
-    inline bool isFastMode() const { return _fastMode; }
+    bool isFastMode() const { return _fastMode; }
     /** Sets fast mode or not.
      *
      * @param bFastMode True if enabled fast mode.
      */
-    inline void setFastMode(bool bFastMode) { _fastMode = bFastMode; }
+    void setFastMode(bool bFastMode) { _fastMode = bFastMode; }
     /** Get stroke.
      *
      * @return float stroke.
      */
-    inline float getStroke() const { return _stroke; }
+    float getStroke() const { return _stroke; }
     /** Set stroke.
      *
      * @param stroke The width of stroke.
      */
-    inline void setStroke(float stroke) { _stroke = stroke; }
+    void setStroke(float stroke) { _stroke = stroke; }
 
     /** Is the starting position initialized or not.
      *
      * @return True if the starting position is initialized.
      */
-    inline bool isStartingPositionInitialized() const { return _startingPositionInitialized; }
+    bool isStartingPositionInitialized() const { return _startingPositionInitialized; }
     /** Sets the starting position initialized or not.
      *
      * @param bStartingPositionInitialized True if initialized the starting position.
      */
-    inline void setStartingPositionInitialized(bool bStartingPositionInitialized)
+    void setStartingPositionInitialized(bool bStartingPositionInitialized)
     {
         _startingPositionInitialized = bStartingPositionInitialized; 
     }

--- a/cocos/2d/CCNode.h
+++ b/cocos/2d/CCNode.h
@@ -775,7 +775,7 @@ public:
      * @return a Node with the given tag that can be cast to Type T.
     */
     template <typename T>
-    inline T getChildByTag(int tag) const { return static_cast<T>(getChildByTag(tag)); }
+    T getChildByTag(int tag) const { return static_cast<T>(getChildByTag(tag)); }
     
     /**
      * Gets a child from the container with its name.
@@ -795,7 +795,7 @@ public:
      * @return a Node with the given name that can be cast to Type T.
     */
     template <typename T>
-    inline T getChildByName(const std::string& name) const { return static_cast<T>(getChildByName(name)); }
+    T getChildByName(const std::string& name) const { return static_cast<T>(getChildByName(name)); }
     /** Search the children of the receiving node to perform processing for nodes which share a name.
      *
      * @param name The name to search for, supports c++11 regular expression.
@@ -1186,7 +1186,7 @@ public:
     virtual Rect getBoundingBox() const;
 
     /** @deprecated Use getBoundingBox instead */
-    CC_DEPRECATED_ATTRIBUTE inline virtual Rect boundingBox() const { return getBoundingBox(); }
+    CC_DEPRECATED_ATTRIBUTE virtual Rect boundingBox() const { return getBoundingBox(); }
 
     /** Set event dispatcher for scene.
      *
@@ -1552,7 +1552,7 @@ public:
     virtual void setNodeToParentTransform(const Mat4& transform);
 
     /** @deprecated use getNodeToParentTransform() instead */
-    CC_DEPRECATED_ATTRIBUTE inline virtual AffineTransform nodeToParentTransform() const { return getNodeToParentAffineTransform(); }
+    CC_DEPRECATED_ATTRIBUTE virtual AffineTransform nodeToParentTransform() const { return getNodeToParentAffineTransform(); }
 
     /**
      * Returns the matrix that transform parent's space coordinates to the node's (local) space coordinates.
@@ -1564,7 +1564,7 @@ public:
     virtual AffineTransform getParentToNodeAffineTransform() const;
 
     /** @deprecated Use getParentToNodeTransform() instead */
-    CC_DEPRECATED_ATTRIBUTE inline virtual AffineTransform parentToNodeTransform() const { return getParentToNodeAffineTransform(); }
+    CC_DEPRECATED_ATTRIBUTE virtual AffineTransform parentToNodeTransform() const { return getParentToNodeAffineTransform(); }
 
     /**
      * Returns the world affine transform matrix. The matrix is in Pixels.
@@ -1575,7 +1575,7 @@ public:
     virtual AffineTransform getNodeToWorldAffineTransform() const;
 
     /** @deprecated Use getNodeToWorldTransform() instead */
-    CC_DEPRECATED_ATTRIBUTE inline virtual AffineTransform nodeToWorldTransform() const { return getNodeToWorldAffineTransform(); }
+    CC_DEPRECATED_ATTRIBUTE virtual AffineTransform nodeToWorldTransform() const { return getNodeToWorldAffineTransform(); }
 
     /**
      * Returns the inverse world affine transform matrix. The matrix is in Pixels.
@@ -1586,7 +1586,7 @@ public:
     virtual AffineTransform getWorldToNodeAffineTransform() const;
 
     /** @deprecated Use getWorldToNodeTransform() instead */
-    CC_DEPRECATED_ATTRIBUTE inline virtual AffineTransform worldToNodeTransform() const { return getWorldToNodeAffineTransform(); }
+    CC_DEPRECATED_ATTRIBUTE virtual AffineTransform worldToNodeTransform() const { return getWorldToNodeAffineTransform(); }
 
     /// @} end of Transformations
 

--- a/cocos/2d/CCNodeGrid.h
+++ b/cocos/2d/CCNodeGrid.h
@@ -79,12 +79,12 @@ public:
      * @brief Set the effect grid rect.
      * @param gridRect The effect grid rect.
      */
-    inline void setGridRect(const Rect& gridRect){_gridRect = gridRect;}
+    void setGridRect(const Rect& gridRect) { _gridRect = gridRect; }
     /**
      * @brief Get the effect grid rect.
      * @return Return the effect grid rect.
      */
-    inline const Rect& getGridRect() const { return _gridRect;}
+    const Rect& getGridRect() const { return _gridRect; }
 
     // overrides
     virtual void visit(Renderer *renderer, const Mat4 &parentTransform, uint32_t parentFlags) override;

--- a/cocos/2d/CCParallaxNode.cpp
+++ b/cocos/2d/CCParallaxNode.cpp
@@ -48,14 +48,14 @@ public:
         return true;
     }
     
-    inline const Vec2& getRatio() const { return _ratio; };
-    inline void setRatio(const Vec2& ratio) { _ratio = ratio; };
+    const Vec2& getRatio() const { return _ratio; }
+    void setRatio(const Vec2& ratio) { _ratio = ratio; }
 
-    inline const Vec2& getOffset() const { return _offset; };
-    inline void setOffset(const Vec2& offset) { _offset = offset; };
+    const Vec2& getOffset() const { return _offset; }
+    void setOffset(const Vec2& offset) { _offset = offset; }
     
-    inline Node* getChild() const { return _child; };
-    inline void setChild(Node* child) { _child = child; };
+    Node* getChild() const { return _child; }
+    void setChild(Node* child) { _child = child; }
     
 private:
     Vec2 _ratio;

--- a/cocos/2d/CCParticleBatchNode.h
+++ b/cocos/2d/CCParticleBatchNode.h
@@ -112,13 +112,13 @@ public:
      *
      * @return The texture atlas used for drawing the quads.
      */
-    inline TextureAtlas* getTextureAtlas() const { return _textureAtlas; };
+    TextureAtlas* getTextureAtlas() const { return _textureAtlas; }
     
     /** Sets the texture atlas used for drawing the quads.
      *
      * @param atlas The texture atlas used for drawing the quads.
      */
-    inline void setTextureAtlas(TextureAtlas* atlas) { _textureAtlas = atlas; };
+    void setTextureAtlas(TextureAtlas* atlas) { _textureAtlas = atlas; }
     
     // Overrides
     virtual void visit(Renderer *renderer, const Mat4 &parentTransform, uint32_t parentFlags) override;

--- a/cocos/2d/CCParticleSystem.h
+++ b/cocos/2d/CCParticleSystem.h
@@ -95,9 +95,9 @@ public:
     ParticleData();
     bool init(int count);
     void release();
-    inline unsigned int getMaxCount(){ return maxCount;}
+    unsigned int getMaxCount() { return maxCount; }
     
-    inline void copyParticle(int p1,int p2)
+    void copyParticle(int p1, int p2)
     {
         posx[p1] = posx[p2];
         posy[p1] = posy[p2];
@@ -466,95 +466,95 @@ public:
      *
      * @return The index of system in batch node array.
      */
-    inline int getAtlasIndex() const { return _atlasIndex; };
+    int getAtlasIndex() const { return _atlasIndex; }
     /** Sets the index of system in batch node array.
      *
      * @param index The index of system in batch node array.
      */
-    inline void setAtlasIndex(int index) { _atlasIndex = index; };
+    void setAtlasIndex(int index) { _atlasIndex = index; }
 
     /** Gets the Quantity of particles that are being simulated at the moment.
      *
      * @return The Quantity of particles that are being simulated at the moment.
      */
-    inline unsigned int getParticleCount() const { return _particleCount; };
+    unsigned int getParticleCount() const { return _particleCount; }
     
     /** Gets how many seconds the emitter will run. -1 means 'forever'.
      *
      * @return The seconds that the emitter will run. -1 means 'forever'.
      */
-    inline float getDuration() const { return _duration; };
+    float getDuration() const { return _duration; }
     /** Sets how many seconds the emitter will run. -1 means 'forever'.
      *
      * @param duration The seconds that the emitter will run. -1 means 'forever'.
      */
-    inline void setDuration(float duration) { _duration = duration; };
+    void setDuration(float duration) { _duration = duration; }
     
     /** Gets the source position of the emitter.
      *
      * @return The source position of the emitter.
      */
-    inline const Vec2& getSourcePosition() const { return _sourcePosition; };
+    const Vec2& getSourcePosition() const { return _sourcePosition; }
     /** Sets the source position of the emitter.
      *
      * @param pos The source position of the emitter.
      */
-    inline void setSourcePosition(const Vec2& pos) { _sourcePosition = pos; };
+    void setSourcePosition(const Vec2& pos) { _sourcePosition = pos; }
     
     /** Gets the position variance of the emitter.
      *
      * @return The position variance of the emitter.
      */
-    inline const Vec2& getPosVar() const { return _posVar; };
+    const Vec2& getPosVar() const { return _posVar; }
     /** Sets the position variance of the emitter.
      *
      * @param pos The position variance of the emitter.
      */
-    inline void setPosVar(const Vec2& pos) { _posVar = pos; };
+    void setPosVar(const Vec2& pos) { _posVar = pos; }
 
     /** Gets the life of each particle.
      *
      * @return The life of each particle.
      */
-    inline float getLife() const { return _life; };
+    float getLife() const { return _life; }
     /** Sets the life of each particle.
      *
      * @param life The life of each particle.
      */
-    inline void setLife(float life) { _life = life; };
+    void setLife(float life) { _life = life; }
 
     /** Gets the life variance of each particle.
      *
      * @return The life variance of each particle.
      */
-    inline float getLifeVar() const { return _lifeVar; };
+    float getLifeVar() const { return _lifeVar; }
     /** Sets the life variance of each particle.
      *
      * @param lifeVar The life variance of each particle.
      */
-    inline void setLifeVar(float lifeVar) { _lifeVar = lifeVar; };
+    void setLifeVar(float lifeVar) { _lifeVar = lifeVar; }
 
     /** Gets the angle of each particle. 
      *
      * @return The angle of each particle.
      */
-    inline float getAngle() const { return _angle; };
+    float getAngle() const { return _angle; }
     /** Sets the angle of each particle.
      *
      * @param angle The angle of each particle.
      */
-    inline void setAngle(float angle) { _angle = angle; };
+    void setAngle(float angle) { _angle = angle; }
 
     /** Gets the angle variance of each particle.
      *
      * @return The angle variance of each particle.
      */
-    inline float getAngleVar() const { return _angleVar; };
+    float getAngleVar() const { return _angleVar; }
     /** Sets the angle variance of each particle.
      *
      * @param angleVar The angle variance of each particle.
      */
-    inline void setAngleVar(float angleVar) { _angleVar = angleVar; };
+    void setAngleVar(float angleVar) { _angleVar = angleVar; }
     
     /** Switch between different kind of emitter modes:
      - kParticleModeGravity: uses gravity, speed, radial and tangential acceleration.
@@ -562,155 +562,155 @@ public:
      *
      * @return The mode of the emitter.
      */
-    inline Mode getEmitterMode() const { return _emitterMode; };
+    Mode getEmitterMode() const { return _emitterMode; }
     /** Sets the mode of the emitter.
      *
      * @param mode The mode of the emitter.
      */
-    inline void setEmitterMode(Mode mode) { _emitterMode = mode; };
+    void setEmitterMode(Mode mode) { _emitterMode = mode; }
     
     /** Gets the start size in pixels of each particle.
      *
      * @return The start size in pixels of each particle.
      */
-    inline float getStartSize() const { return _startSize; };
+    float getStartSize() const { return _startSize; }
     /** Sets the start size in pixels of each particle.
      *
      * @param startSize The start size in pixels of each particle.
      */
-    inline void setStartSize(float startSize) { _startSize = startSize; };
+    void setStartSize(float startSize) { _startSize = startSize; }
 
     /** Gets the start size variance in pixels of each particle.
      *
      * @return The start size variance in pixels of each particle.
      */
-    inline float getStartSizeVar() const { return _startSizeVar; };
+    float getStartSizeVar() const { return _startSizeVar; }
     /** Sets the start size variance in pixels of each particle.
      *
      * @param sizeVar The start size variance in pixels of each particle.
      */
-    inline void setStartSizeVar(float sizeVar) { _startSizeVar = sizeVar; };
+    void setStartSizeVar(float sizeVar) { _startSizeVar = sizeVar; }
 
     /** Gets the end size in pixels of each particle.
      *
      * @return The end size in pixels of each particle.
      */
-    inline float getEndSize() const { return _endSize; };
+    float getEndSize() const { return _endSize; }
     /** Sets the end size in pixels of each particle.
      *
      * @param endSize The end size in pixels of each particle.
      */
-    inline void setEndSize(float endSize) { _endSize = endSize; };
+    void setEndSize(float endSize) { _endSize = endSize; }
 
     /** Gets the end size variance in pixels of each particle.
      *
      * @return The end size variance in pixels of each particle.
      */
-    inline float getEndSizeVar() const { return _endSizeVar; };
+    float getEndSizeVar() const { return _endSizeVar; }
     /** Sets the end size variance in pixels of each particle.
      *
      * @param sizeVar The end size variance in pixels of each particle.
      */
-    inline void setEndSizeVar(float sizeVar) { _endSizeVar = sizeVar; };
+    void setEndSizeVar(float sizeVar) { _endSizeVar = sizeVar; }
 
     /** Gets the start color of each particle.
      *
      * @return The start color of each particle.
      */
-    inline const Color4F& getStartColor() const { return _startColor; };
+    const Color4F& getStartColor() const { return _startColor; }
     /** Sets the start color of each particle.
      *
      * @param color The start color of each particle.
      */
-    inline void setStartColor(const Color4F& color) { _startColor = color; };
+    void setStartColor(const Color4F& color) { _startColor = color; }
 
     /** Gets the start color variance of each particle.
      *
      * @return The start color variance of each particle.
      */
-    inline const Color4F& getStartColorVar() const { return _startColorVar; };
+    const Color4F& getStartColorVar() const { return _startColorVar; }
     /** Sets the start color variance of each particle.
      *
      * @param color The start color variance of each particle.
      */
-    inline void setStartColorVar(const Color4F& color) { _startColorVar = color; };
+    void setStartColorVar(const Color4F& color) { _startColorVar = color; }
 
     /** Gets the end color and end color variation of each particle.
      *
      * @return The end color and end color variation of each particle.
      */
-    inline const Color4F& getEndColor() const { return _endColor; };
+    const Color4F& getEndColor() const { return _endColor; }
     /** Sets the end color and end color variation of each particle.
      *
      * @param color The end color and end color variation of each particle.
      */
-    inline void setEndColor(const Color4F& color) { _endColor = color; };
+    void setEndColor(const Color4F& color) { _endColor = color; }
 
     /** Gets the end color variance of each particle.
      *
      * @return The end color variance of each particle.
      */
-    inline const Color4F& getEndColorVar() const { return _endColorVar; };
+    const Color4F& getEndColorVar() const { return _endColorVar; }
     /** Sets the end color variance of each particle.
      *
      * @param color The end color variance of each particle.
      */
-    inline void setEndColorVar(const Color4F& color) { _endColorVar = color; };
+    void setEndColorVar(const Color4F& color) { _endColorVar = color; }
 
     /** Gets the start spin of each particle.
      *
      * @return The start spin of each particle.
      */
-    inline float getStartSpin() const { return _startSpin; };
+    float getStartSpin() const { return _startSpin; }
     /** Sets the start spin of each particle.
      *
      * @param spin The start spin of each particle.
      */
-    inline void setStartSpin(float spin) { _startSpin = spin; };
+    void setStartSpin(float spin) { _startSpin = spin; }
 
     /** Gets the start spin variance of each particle.
      *
      * @return The start spin variance of each particle.
      */
-    inline float getStartSpinVar() const { return _startSpinVar; };
+    float getStartSpinVar() const { return _startSpinVar; }
     /** Sets the start spin variance of each particle.
      *
      * @param pinVar The start spin variance of each particle.
      */
-    inline void setStartSpinVar(float pinVar) { _startSpinVar = pinVar; };
+    void setStartSpinVar(float pinVar) { _startSpinVar = pinVar; }
 
     /** Gets the end spin of each particle.
      *
      * @return The end spin of each particle.
      */
-    inline float getEndSpin() const { return _endSpin; };
+    float getEndSpin() const { return _endSpin; }
     /** Sets the end spin of each particle.
      *
      * @param endSpin The end spin of each particle.
      */
-    inline void setEndSpin(float endSpin) { _endSpin = endSpin; };
+    void setEndSpin(float endSpin) { _endSpin = endSpin; }
 
     /** Gets the end spin variance of each particle.
      *
      * @return The end spin variance of each particle.
      */
-    inline float getEndSpinVar() const { return _endSpinVar; };
+    float getEndSpinVar() const { return _endSpinVar; }
     /** Sets the end spin variance of each particle.
      *
      * @param endSpinVar The end spin variance of each particle.
      */
-    inline void setEndSpinVar(float endSpinVar) { _endSpinVar = endSpinVar; };
+    void setEndSpinVar(float endSpinVar) { _endSpinVar = endSpinVar; }
 
     /** Gets the emission rate of the particles.
      *
      * @return The emission rate of the particles.
      */
-    inline float getEmissionRate() const { return _emissionRate; };
+    float getEmissionRate() const { return _emissionRate; }
     /** Sets the emission rate of the particles.
      *
      * @param rate The emission rate of the particles.
      */
-    inline void setEmissionRate(float rate) { _emissionRate = rate; };
+    void setEmissionRate(float rate) { _emissionRate = rate; }
 
     /** Gets the maximum particles of the system.
      *
@@ -724,22 +724,22 @@ public:
     virtual void setTotalParticles(int totalParticles);
 
     /** does the alpha value modify color */
-    inline void setOpacityModifyRGB(bool opacityModifyRGB) override { _opacityModifyRGB = opacityModifyRGB; };
-    inline bool isOpacityModifyRGB() const override { return _opacityModifyRGB; };
-    CC_DEPRECATED_ATTRIBUTE inline bool getOpacityModifyRGB() const { return isOpacityModifyRGB(); }
+    void setOpacityModifyRGB(bool opacityModifyRGB) override { _opacityModifyRGB = opacityModifyRGB; }
+    bool isOpacityModifyRGB() const override { return _opacityModifyRGB; }
+    CC_DEPRECATED_ATTRIBUTE bool getOpacityModifyRGB() const { return isOpacityModifyRGB(); }
     
     /** Gets the particles movement type: Free or Grouped.
      @since v0.8
      *
      * @return The particles movement type.
      */
-    inline PositionType getPositionType() const { return _positionType; };
+    PositionType getPositionType() const { return _positionType; }
     /** Sets the particles movement type: Free or Grouped.
     @since v0.8
      *
      * @param type The particles movement type.
      */
-    inline void setPositionType(PositionType type) { _positionType = type; };
+    void setPositionType(PositionType type) { _positionType = type; }
     
     // Overrides
     virtual void onEnter() override;

--- a/cocos/2d/CCProgressTimer.h
+++ b/cocos/2d/CCProgressTimer.h
@@ -67,19 +67,19 @@ public:
      *
      * @return A Type
      */
-    inline Type getType() const { return _type; }
+    Type getType() const { return _type; }
 
     /** Percentages are from 0 to 100.
      *
      * @return Percentages.
      */
-    inline float getPercentage() const {return _percentage; }
+    float getPercentage() const { return _percentage; }
 
     /** The image to show the progress percentage, retain. 
      *
      * @return A sprite.
      */
-    inline Sprite* getSprite() const { return _sprite; }
+    Sprite* getSprite() const { return _sprite; }
     
     /** Set the initial percentage values. 
      *
@@ -103,7 +103,7 @@ public:
      *
      * @return If the direction is Anti-clockwise,it will return true.
      */
-    inline bool isReverseDirection() { return _reverseDirection; };
+    bool isReverseDirection() { return _reverseDirection; };
     
     /** Set the Reverse direction.
      *
@@ -145,13 +145,13 @@ public:
      *    Set the rate to be Vec2(0,1); and set the midpoint to = Vec2(0,.5f).
      * @param barChangeRate A Vec2.
      */
-    inline void setBarChangeRate(const Vec2& barChangeRate ) { _barChangeRate = barChangeRate; }
+    void setBarChangeRate(const Vec2& barChangeRate ) { _barChangeRate = barChangeRate; }
     
     /** Returns the BarChangeRate.
      *
      * @return A barChangeRate.
      */
-    inline Vec2 getBarChangeRate() const { return _barChangeRate; }
+    Vec2 getBarChangeRate() const { return _barChangeRate; }
 
     // Overrides
     virtual void draw(Renderer *renderer, const Mat4 &transform, uint32_t flags) override;

--- a/cocos/2d/CCRenderTexture.h
+++ b/cocos/2d/CCRenderTexture.h
@@ -192,68 +192,68 @@ public:
      *
      * @return Clear flags.
      */
-    inline unsigned int getClearFlags() const { return _clearFlags; };
+    unsigned int getClearFlags() const { return _clearFlags; }
     
     /** Set flags.
      *
      * @param clearFlags Valid flags: GL_COLOR_BUFFER_BIT, GL_DEPTH_BUFFER_BIT, GL_STENCIL_BUFFER_BIT.
      */
-    inline void setClearFlags(unsigned int clearFlags) { _clearFlags = clearFlags; };
+    void setClearFlags(unsigned int clearFlags) { _clearFlags = clearFlags; }
     
     /** Clear color value. Valid only when "autoDraw" is true. 
      *
      * @return Color value.
      */
-    inline const Color4F& getClearColor() const { return _clearColor; };
+    const Color4F& getClearColor() const { return _clearColor; }
     
     /** Set color value. 
      *
      * @param clearColor Color value.
      */
-    inline void setClearColor(const Color4F &clearColor) { _clearColor = clearColor; };
+    void setClearColor(const Color4F &clearColor) { _clearColor = clearColor; }
     
     /** Value for clearDepth. Valid only when "autoDraw" is true. 
      *
      * @return Value for clearDepth.
      */
-    inline float getClearDepth() const { return _clearDepth; };
+    float getClearDepth() const { return _clearDepth; }
     
     /** Set Value for clearDepth.
      *
      * @param clearDepth Value for clearDepth.
      */
-    inline void setClearDepth(float clearDepth) { _clearDepth = clearDepth; };
+    void setClearDepth(float clearDepth) { _clearDepth = clearDepth; }
     
     /** Value for clear Stencil. Valid only when "autoDraw" is true.
      *
      * @return Value for clear Stencil.
      */
-    inline int getClearStencil() const { return _clearStencil; };
+    int getClearStencil() const { return _clearStencil; }
     
     /** Set Value for clear Stencil.
      *
      * @param clearStencil Value for clear Stencil.
      */
-    inline void setClearStencil(int clearStencil) { _clearStencil = clearStencil; };
+    void setClearStencil(int clearStencil) { _clearStencil = clearStencil; }
     
     /** When enabled, it will render its children into the texture automatically. Disabled by default for compatibility reasons.
      * Will be enabled in the future.
      *
      * @return Return the autoDraw value.
      */
-    inline bool isAutoDraw() const { return _autoDraw; };
+    bool isAutoDraw() const { return _autoDraw; }
     
     /** Set a valve to control whether or not render its children into the texture automatically. 
      *
      * @param isAutoDraw Whether or not render its children into the texture automatically.
      */
-    inline void setAutoDraw(bool isAutoDraw) { _autoDraw = isAutoDraw; };
+    void setAutoDraw(bool isAutoDraw) { _autoDraw = isAutoDraw; }
 
     /** Gets the Sprite being used. 
      *
      * @return A Sprite.
      */
-    inline Sprite* getSprite() const { return _sprite; };
+    Sprite* getSprite() const { return _sprite; }
     
     /** Sets the Sprite being used. 
      *

--- a/cocos/2d/CCScene.h
+++ b/cocos/2d/CCScene.h
@@ -151,7 +151,7 @@ public:
      * @return The physics world of the scene.
      * @js NA
      */
-    inline PhysicsWorld* getPhysicsWorld() const { return _physicsWorld; }
+    PhysicsWorld* getPhysicsWorld() const { return _physicsWorld; }
 #endif
     
 #if CC_USE_3D_PHYSICS && CC_ENABLE_BULLET_INTEGRATION
@@ -159,7 +159,7 @@ public:
      * @return The 3d physics world of the scene.
      * @js NA
      */
-    inline Physics3DWorld* getPhysics3DWorld() { return _physics3DWorld; }
+    Physics3DWorld* getPhysics3DWorld() { return _physics3DWorld; }
     
     /** 
      * Set Physics3D debug draw camera.

--- a/cocos/2d/CCSprite.h
+++ b/cocos/2d/CCSprite.h
@@ -306,44 +306,44 @@ public:
      * @js  NA
      * @lua NA
      */
-    inline V3F_C4B_T2F_Quad getQuad() const { return _quad; }
+    V3F_C4B_T2F_Quad getQuad() const { return _quad; }
 
     /**
      * Returns whether or not the texture rectangle is rotated.
      */
-    inline bool isTextureRectRotated() const { return _rectRotated; }
+    bool isTextureRectRotated() const { return _rectRotated; }
 
     /**
      * Returns the index used on the TextureAtlas.
      */
-    inline ssize_t getAtlasIndex() const { return _atlasIndex; }
+    ssize_t getAtlasIndex() const { return _atlasIndex; }
 
     /**
      * Sets the index used on the TextureAtlas.
      *
      * @warning Don't modify this value unless you know what you are doing.
      */
-    inline void setAtlasIndex(ssize_t atlasIndex) { _atlasIndex = atlasIndex; }
+    void setAtlasIndex(ssize_t atlasIndex) { _atlasIndex = atlasIndex; }
 
     /**
      * Returns the rect of the Sprite in points.
      */
-    inline const Rect& getTextureRect() const { return _rect; }
+    const Rect& getTextureRect() const { return _rect; }
 
     /**
      * Gets the weak reference of the TextureAtlas when the sprite is rendered using via SpriteBatchNode.
      */
-    inline TextureAtlas* getTextureAtlas() const { return _textureAtlas; }
+    TextureAtlas* getTextureAtlas() const { return _textureAtlas; }
 
     /**
      * Sets the weak reference of the TextureAtlas when the sprite is rendered using via SpriteBatchNode.
      */
-    inline void setTextureAtlas(TextureAtlas *textureAtlas) { _textureAtlas = textureAtlas; }
+    void setTextureAtlas(TextureAtlas *textureAtlas) { _textureAtlas = textureAtlas; }
 
     /**
      * Gets the offset position of the sprite. Calculated automatically by editors like Zwoptex.
      */
-    inline const Vec2& getOffsetPosition() const { return _offsetPosition; }
+    const Vec2& getOffsetPosition() const { return _offsetPosition; }
 
 
     /**
@@ -428,12 +428,12 @@ public:
     *In lua: local setBlendFunc(local src, local dst).
     *@endcode
     */
-    inline void setBlendFunc(const BlendFunc &blendFunc) override { _blendFunc = blendFunc; }
+    void setBlendFunc(const BlendFunc &blendFunc) override { _blendFunc = blendFunc; }
     /**
     * @js  NA
     * @lua NA
     */
-    inline const BlendFunc& getBlendFunc() const override { return _blendFunc; }
+    const BlendFunc& getBlendFunc() const override { return _blendFunc; }
     /// @}
 
     /**

--- a/cocos/2d/CCSpriteBatchNode.h
+++ b/cocos/2d/CCSpriteBatchNode.h
@@ -90,13 +90,13 @@ public:
      *
      * @return The TextureAtlas object.
      */
-    inline TextureAtlas* getTextureAtlas() { return _textureAtlas; }
+    TextureAtlas* getTextureAtlas() { return _textureAtlas; }
 
     /** Sets the TextureAtlas object. 
      *
      * @param textureAtlas The TextureAtlas object.
      */
-    inline void setTextureAtlas(TextureAtlas* textureAtlas)
+    void setTextureAtlas(TextureAtlas* textureAtlas)
     { 
         if (textureAtlas != _textureAtlas)
         {
@@ -111,7 +111,7 @@ public:
      * 
      * @return An array with the descendants (children, gran children, etc.).
      */
-    inline const std::vector<Sprite*>& getDescendants() const { return _descendants; }
+    const std::vector<Sprite*>& getDescendants() const { return _descendants; }
 
     /** Increase the Atlas Capacity. */
     void increaseAtlasCapacity();

--- a/cocos/2d/CCSpriteFrame.h
+++ b/cocos/2d/CCSpriteFrame.h
@@ -104,7 +104,7 @@ public:
      *
      * @return The rect of the sprite frame, in pixels.
      */
-    inline const Rect& getRectInPixels() const { return _rectInPixels; }
+    const Rect& getRectInPixels() const { return _rectInPixels; }
     /** Set rect of the sprite frame.
      *
      * @param rectInPixels The rect of the sprite frame, in pixels.
@@ -115,18 +115,18 @@ public:
      *
      * @return Is rotated if true.
      */
-    inline bool isRotated() const { return _rotated; }
+    bool isRotated() const { return _rotated; }
     /** Set rotated of the sprite frame.
      *
      * @param rotated Rotated the sprite frame if true.
      */
-    inline void setRotated(bool rotated) { _rotated = rotated; }
+    void setRotated(bool rotated) { _rotated = rotated; }
 
     /** Get rect of the frame.
      *
      * @return The rect of the sprite frame.
      */
-    inline const Rect& getRect() const { return _rect; }
+    const Rect& getRect() const { return _rect; }
     /** Set rect of the frame.
      *
      * @param rect The rect of the sprite.
@@ -148,23 +148,23 @@ public:
      *
      * @return The original size of the trimmed image, in pixels.
      */
-    inline const Size& getOriginalSizeInPixels() const { return _originalSizeInPixels; }
+    const Size& getOriginalSizeInPixels() const { return _originalSizeInPixels; }
     /** Set original size of the trimmed image.
      *
      * @param sizeInPixels The original size of the trimmed image, in pixels.
      */
-    inline void setOriginalSizeInPixels(const Size& sizeInPixels) { _originalSizeInPixels = sizeInPixels; }
+    void setOriginalSizeInPixels(const Size& sizeInPixels) { _originalSizeInPixels = sizeInPixels; }
 
     /** Get original size of the trimmed image.
      *
      * @return The original size of the trimmed image.
      */
-    inline const Size& getOriginalSize() const { return _originalSize; }
+    const Size& getOriginalSize() const { return _originalSize; }
     /** Set original size of the trimmed image.
      *
      * @param sizeInPixels The original size of the trimmed image.
      */
-    inline void setOriginalSize(const Size& sizeInPixels) { _originalSize = sizeInPixels; }
+    void setOriginalSize(const Size& sizeInPixels) { _originalSize = sizeInPixels; }
 
     /** Get texture of the frame.
      *

--- a/cocos/2d/CCTMXLayer.h
+++ b/cocos/2d/CCTMXLayer.h
@@ -185,37 +185,37 @@ public:
      *
      * @return The layer name.
      */
-    inline const std::string& getLayerName(){ return _layerName; }
+    const std::string& getLayerName() { return _layerName; }
     
     /** Set the layer name.
      *
      * @param layerName The layer name.
      */
-    inline void setLayerName(const std::string& layerName){ _layerName = layerName; }
+    void setLayerName(const std::string& layerName) { _layerName = layerName; }
 
     /** Size of the layer in tiles.
      *
      * @return Size of the layer in tiles.
      */
-    inline const Size& getLayerSize() const { return _layerSize; };
+    const Size& getLayerSize() const { return _layerSize; }
     
     /** Set size of the layer in tiles.
      *
      * @param size Size of the layer in tiles.
      */
-    inline void setLayerSize(const Size& size) { _layerSize = size; };
+    void setLayerSize(const Size& size) { _layerSize = size; }
     
     /** Size of the map's tile (could be different from the tile's size).
      *
      * @return The size of the map's tile.
      */
-    inline const Size& getMapTileSize() const { return _mapTileSize; };
+    const Size& getMapTileSize() const { return _mapTileSize; }
     
     /** Set the size of the map's tile.
      *
      * @param size The size of the map's tile.
      */
-    inline void setMapTileSize(const Size& size) { _mapTileSize = size; };
+    void setMapTileSize(const Size& size) { _mapTileSize = size; }
     
     /** Pointer to the map of tiles.
      * @js NA
@@ -234,14 +234,14 @@ public:
      *
      * @return Tileset information for the layer.
      */
-    inline TMXTilesetInfo* getTileSet() const { return _tileSet; };
+    TMXTilesetInfo* getTileSet() const { return _tileSet; }
     
     /** Set tileset information for the layer.
      *
      * @param info The tileset information for the layer.
      * @js NA
      */
-    inline void setTileSet(TMXTilesetInfo* info) {
+    void setTileSet(TMXTilesetInfo* info) {
         CC_SAFE_RETAIN(info);
         CC_SAFE_RELEASE(_tileSet);
         _tileSet = info;
@@ -251,31 +251,31 @@ public:
      *
      * @return Layer orientation, which is the same as the map orientation.
      */
-    inline int getLayerOrientation() const { return _layerOrientation; };
+    int getLayerOrientation() const { return _layerOrientation; }
     
     /** Set layer orientation, which is the same as the map orientation.
      *
      * @param orientation Layer orientation,which is the same as the map orientation.
      */
-    inline void setLayerOrientation(int orientation) { _layerOrientation = orientation; };
+    void setLayerOrientation(int orientation) { _layerOrientation = orientation; }
     
     /** Properties from the layer. They can be added using Tiled.
      *
      * @return Properties from the layer. They can be added using Tiled.
      */
-    inline const ValueMap& getProperties() const { return _properties; };
+    const ValueMap& getProperties() const { return _properties; }
     
     /** Properties from the layer. They can be added using Tiled.
      *
      * @return Properties from the layer. They can be added using Tiled.
      */
-    inline ValueMap& getProperties() { return _properties; };
+    ValueMap& getProperties() { return _properties; }
     
     /** Set an Properties from to layer.
      *
      * @param properties It is used to set the layer Properties.
      */
-    inline void setProperties(const ValueMap& properties) {
+    void setProperties(const ValueMap& properties) {
         _properties = properties;
     };
     //

--- a/cocos/2d/CCTMXObjectGroup.h
+++ b/cocos/2d/CCTMXObjectGroup.h
@@ -59,13 +59,13 @@ public:
      *
      * @return The group name.
      */
-    inline const std::string& getGroupName() const { return _groupName; }
+    const std::string& getGroupName() const { return _groupName; }
     
     /** Set the group name. 
      *
      * @param groupName A string,it is used to set the group name.
      */
-    inline void setGroupName(const std::string& groupName){ _groupName = groupName; }
+    void setGroupName(const std::string& groupName) { _groupName = groupName; }
 
     /** Return the value for the specific property name. 
      *
@@ -90,26 +90,26 @@ public:
      *
      * @return The offset position of child objects.
      */
-    inline const Vec2& getPositionOffset() const { return _positionOffset; };
+    const Vec2& getPositionOffset() const { return _positionOffset; }
     
     /** Sets the offset position of child objects. 
      *
      * @param offset The offset position of child objects.
      */
-    inline void setPositionOffset(const Vec2& offset) { _positionOffset = offset; };
+    void setPositionOffset(const Vec2& offset) { _positionOffset = offset; }
     
     /** Gets the list of properties stored in a dictionary. 
      *
      * @return The list of properties stored in a dictionary.
      */
-    inline const ValueMap& getProperties() const { return _properties; };
-    inline ValueMap& getProperties() { return _properties; };
+    const ValueMap& getProperties() const { return _properties; }
+    ValueMap& getProperties() { return _properties; }
     
     /** Sets the list of properties.
      *
      * @param properties The list of properties.
      */
-    inline void setProperties(const ValueMap& properties) {
+    void setProperties(const ValueMap& properties) {
         _properties = properties;
     };
     
@@ -117,14 +117,14 @@ public:
      *
      * @return The array of the objects.
      */
-    inline const ValueVector& getObjects() const { return _objects; };
-    inline ValueVector& getObjects() { return _objects; };
+    const ValueVector& getObjects() const { return _objects; }
+    ValueVector& getObjects() { return _objects; }
     
     /** Sets the array of the objects.
      *
      * @param objects The array of the objects.
      */
-    inline void setObjects(const ValueVector& objects) {
+    void setObjects(const ValueVector& objects) {
         _objects = objects;
     };
     

--- a/cocos/2d/CCTMXTiledMap.h
+++ b/cocos/2d/CCTMXTiledMap.h
@@ -206,50 +206,50 @@ public:
      *
      * @return The map's size property measured in tiles.
      */
-    inline const Size& getMapSize() const { return _mapSize; };
+    const Size& getMapSize() const { return _mapSize; }
     
     /** Set the map's size property measured in tiles. 
      *
      * @param mapSize The map's size property measured in tiles.
      */
-    inline void setMapSize(const Size& mapSize) { _mapSize = mapSize; };
+    void setMapSize(const Size& mapSize) { _mapSize = mapSize; }
 
     /** The tiles's size property measured in pixels. 
      *
      * @return The tiles's size property measured in pixels.
      */
-    inline const Size& getTileSize() const { return _tileSize; };
+    const Size& getTileSize() const { return _tileSize; }
     
     /** Set the tiles's size property measured in pixels. 
      *
      * @param tileSize The tiles's size property measured in pixels.
      */
-    inline void setTileSize(const Size& tileSize) { _tileSize = tileSize; };
+    void setTileSize(const Size& tileSize) { _tileSize = tileSize; }
 
     /** Map orientation. 
      *
      * @return Map orientation.
      */
-    inline int getMapOrientation() const { return _mapOrientation; };
+    int getMapOrientation() const { return _mapOrientation; }
     
     /** Set map orientation. 
      *
      * @param mapOrientation The map orientation.
      */
-    inline void setMapOrientation(int mapOrientation) { _mapOrientation = mapOrientation; };
+    void setMapOrientation(int mapOrientation) { _mapOrientation = mapOrientation; }
 
     /** Get the Object groups. 
      *
      * @return The object groups.
      */
-    inline const Vector<TMXObjectGroup*>& getObjectGroups() const { return _objectGroups; };
-    inline Vector<TMXObjectGroup*>& getObjectGroups() { return _objectGroups; };
+    const Vector<TMXObjectGroup*>& getObjectGroups() const { return _objectGroups; }
+    Vector<TMXObjectGroup*>& getObjectGroups() { return _objectGroups; }
     
     /** Set the object groups. 
      *
      * @param groups The object groups.
      */
-    inline void setObjectGroups(const Vector<TMXObjectGroup*>& groups) {
+    void setObjectGroups(const Vector<TMXObjectGroup*>& groups) {
         _objectGroups = groups;
     };
     
@@ -257,13 +257,13 @@ public:
      *
      * @return Properties.
      */
-    inline ValueMap& getProperties() { return _properties; };
+    ValueMap& getProperties() { return _properties; }
     
     /** Set the properties.
      *
      * @param properties A  Type of ValueMap to set the properties.
      */
-    inline void setProperties(const ValueMap& properties) {
+    void setProperties(const ValueMap& properties) {
         _properties = properties;
     };
     

--- a/cocos/2d/CCTMXXMLParser.h
+++ b/cocos/2d/CCTMXXMLParser.h
@@ -206,71 +206,71 @@ public:
     };
 
     /// map orientation
-    inline int getOrientation() const { return _orientation; };
-    inline void setOrientation(int orientation) { _orientation = orientation; };
+    int getOrientation() const { return _orientation; }
+    void setOrientation(int orientation) { _orientation = orientation; }
     
     /// map staggeraxis
-    inline int getStaggerAxis() const { return _staggerAxis; };
-    inline void setStaggerAxis(int staggerAxis) { _staggerAxis = staggerAxis; };
+    int getStaggerAxis() const { return _staggerAxis; }
+    void setStaggerAxis(int staggerAxis) { _staggerAxis = staggerAxis; }
 
     /// map stagger index
-    inline int getStaggerIndex() const { return _staggerIndex; };
-    inline void setStaggerIndex(int staggerIndex) { _staggerIndex = staggerIndex; };
+    int getStaggerIndex() const { return _staggerIndex; }
+    void setStaggerIndex(int staggerIndex) { _staggerIndex = staggerIndex; }
 
     /// map hexsidelength
-    inline int getHexSideLength() const { return _hexSideLength; };
-    inline void setHexSideLength(int hexSideLength) { _hexSideLength = hexSideLength; };
+    int getHexSideLength() const { return _hexSideLength; }
+    void setHexSideLength(int hexSideLength) { _hexSideLength = hexSideLength; }
 
     /// map width & height
-    inline const Size& getMapSize() const { return _mapSize; };
-    inline void setMapSize(const Size& mapSize) { _mapSize = mapSize; };
+    const Size& getMapSize() const { return _mapSize; }
+    void setMapSize(const Size& mapSize) { _mapSize = mapSize; }
 
     /// tiles width & height
-    inline const Size& getTileSize() const { return _tileSize; };
-    inline void setTileSize(const Size& tileSize) { _tileSize = tileSize; };
+    const Size& getTileSize() const { return _tileSize; }
+    void setTileSize(const Size& tileSize) { _tileSize = tileSize; }
     
     /// Layers
-    inline const Vector<TMXLayerInfo*>& getLayers() const { return _layers; };
-    inline Vector<TMXLayerInfo*>& getLayers() { return _layers; };
-    inline void setLayers(const Vector<TMXLayerInfo*>& layers) {
+    const Vector<TMXLayerInfo*>& getLayers() const { return _layers; }
+    Vector<TMXLayerInfo*>& getLayers() { return _layers; }
+    void setLayers(const Vector<TMXLayerInfo*>& layers) {
         _layers = layers;
     };
 
     /// tilesets
-    inline const Vector<TMXTilesetInfo*>& getTilesets() const { return _tilesets; };
-    inline Vector<TMXTilesetInfo*>& getTilesets() { return _tilesets; };
-    inline void setTilesets(const Vector<TMXTilesetInfo*>& tilesets) {
+    const Vector<TMXTilesetInfo*>& getTilesets() const { return _tilesets; }
+    Vector<TMXTilesetInfo*>& getTilesets() { return _tilesets; }
+    void setTilesets(const Vector<TMXTilesetInfo*>& tilesets) {
         _tilesets = tilesets;
     };
 
     /// ObjectGroups
-    inline const Vector<TMXObjectGroup*>& getObjectGroups() const { return _objectGroups; };
-    inline Vector<TMXObjectGroup*>& getObjectGroups() { return _objectGroups; };
-    inline void setObjectGroups(const Vector<TMXObjectGroup*>& groups) {
+    const Vector<TMXObjectGroup*>& getObjectGroups() const { return _objectGroups; }
+    Vector<TMXObjectGroup*>& getObjectGroups() { return _objectGroups; }
+    void setObjectGroups(const Vector<TMXObjectGroup*>& groups) {
         _objectGroups = groups;
     };
 
     /// parent element
-    inline int getParentElement() const { return _parentElement; };
-    inline void setParentElement(int element) { _parentElement = element; };
+    int getParentElement() const { return _parentElement; }
+    void setParentElement(int element) { _parentElement = element; }
 
     /// parent GID
-    inline int getParentGID() const { return _parentGID; };
-    inline void setParentGID(int gid) { _parentGID = gid; };
+    int getParentGID() const { return _parentGID; }
+    void setParentGID(int gid) { _parentGID = gid; }
 
     /// layer attribs
-    inline int getLayerAttribs() const { return _layerAttribs; };
-    inline void setLayerAttribs(int layerAttribs) { _layerAttribs = layerAttribs; };
+    int getLayerAttribs() const { return _layerAttribs; }
+    void setLayerAttribs(int layerAttribs) { _layerAttribs = layerAttribs; }
 
     /// is storing characters?
-    inline bool isStoringCharacters() const { return _storingCharacters; };
-    CC_DEPRECATED_ATTRIBUTE inline bool getStoringCharacters() const { return isStoringCharacters(); };
-    inline void setStoringCharacters(bool storingCharacters) { _storingCharacters = storingCharacters; };
+    bool isStoringCharacters() const { return _storingCharacters; }
+    CC_DEPRECATED_ATTRIBUTE bool getStoringCharacters() const { return isStoringCharacters(); }
+    void setStoringCharacters(bool storingCharacters) { _storingCharacters = storingCharacters; }
 
     /// properties
-    inline const ValueMap& getProperties() const { return _properties; }
-    inline ValueMap& getProperties() { return _properties; }
-    inline void setProperties(const ValueMap& properties) {
+    const ValueMap& getProperties() const { return _properties; }
+    ValueMap& getProperties() { return _properties; }
+    void setProperties(const ValueMap& properties) {
         _properties = properties;
     };
     
@@ -291,11 +291,11 @@ public:
      */
     void textHandler(void *ctx, const char *ch, int len);
     
-    inline const std::string& getCurrentString() const { return _currentString; }
-    inline void setCurrentString(const std::string& currentString){ _currentString = currentString; }
-    inline const std::string& getTMXFileName() const { return _TMXFileName; }
-    inline void setTMXFileName(const std::string& fileName){ _TMXFileName = fileName; }
-    inline const std::string& getExternalTilesetFileName() const { return _externalTilesetFilename; }
+    const std::string& getCurrentString() const { return _currentString; }
+    void setCurrentString(const std::string& currentString){ _currentString = currentString; }
+    const std::string& getTMXFileName() const { return _TMXFileName; }
+    void setTMXFileName(const std::string& fileName){ _TMXFileName = fileName; }
+    const std::string& getExternalTilesetFileName() const { return _externalTilesetFilename; }
 
 protected:
     void internalInit(const std::string& tmxFileName, const std::string& resourcePath);

--- a/cocos/2d/CCTextFieldTTF.h
+++ b/cocos/2d/CCTextFieldTTF.h
@@ -152,17 +152,17 @@ public:
     /**
      * @lua NA
      */
-    inline TextFieldDelegate* getDelegate() const { return _delegate; };
+    TextFieldDelegate* getDelegate() const { return _delegate; }
     /**
      * @lua NA
      */
-    inline void setDelegate(TextFieldDelegate* delegate) { _delegate = delegate; };
+    void setDelegate(TextFieldDelegate* delegate) { _delegate = delegate; }
 
     /**
      * Query the currently inputed character count.
      *@return The total input character count.
      */
-    inline std::size_t getCharCount() const { return _charCount; };
+    std::size_t getCharCount() const { return _charCount; }
     
     /**
      * Query the color of place holder.

--- a/cocos/2d/CCTileMapAtlas.h
+++ b/cocos/2d/CCTileMapAtlas.h
@@ -94,13 +94,13 @@ public:
      * Query TGA image info.
      *@return The TGA image info.
      */
-    inline struct sImageTGA* getTGAInfo() const { return _TGAInfo; };
+    struct sImageTGA* getTGAInfo() const { return _TGAInfo; }
 
     /**
      * Set the TGA image info for TileMapAtlas
      *@param TGAInfo The TGA info in sImageTGA.
      */
-    inline void setTGAInfo(struct sImageTGA* TGAInfo) { _TGAInfo = TGAInfo; };
+    void setTGAInfo(struct sImageTGA* TGAInfo) { _TGAInfo = TGAInfo; }
 
 protected:
     void loadTGAfile(const std::string& file);

--- a/cocos/3d/CCMotionStreak3D.h
+++ b/cocos/3d/CCMotionStreak3D.h
@@ -78,23 +78,23 @@ public:
      *
      * @return float stroke.
      */
-    inline float getStroke() const { return _stroke; }
+    float getStroke() const { return _stroke; }
     /** Set stroke.
      *
      * @param stroke The width of stroke.
      */
-    inline void setStroke(float stroke) { _stroke = stroke; }
+    void setStroke(float stroke) { _stroke = stroke; }
 
     /** Is the starting position initialized or not.
      *
      * @return True if the starting position is initialized.
      */
-    inline bool isStartingPositionInitialized() const { return _startingPositionInitialized; }
+    bool isStartingPositionInitialized() const { return _startingPositionInitialized; }
     /** Sets the starting position initialized or not.
      *
      * @param bStartingPositionInitialized True if initialized the starting position.
      */
-    inline void setStartingPositionInitialized(bool bStartingPositionInitialized)
+    void setStartingPositionInitialized(bool bStartingPositionInitialized)
     {
         _startingPositionInitialized = bStartingPositionInitialized; 
     }

--- a/cocos/base/CCDirector.h
+++ b/cocos/base/CCDirector.h
@@ -155,26 +155,26 @@ public:
     // attribute
 
     /** Gets current running Scene. Director can only run one Scene at a time. */
-    inline Scene* getRunningScene() { return _runningScene; }
+    Scene* getRunningScene() { return _runningScene; }
 
     /** Gets the FPS value. */
-    inline float getAnimationInterval() { return _animationInterval; }
+    float getAnimationInterval() { return _animationInterval; }
     /** Sets the FPS value. FPS = 1/interval. */
     void setAnimationInterval(float interval);
 
     /** Whether or not displaying the FPS on the bottom-left corner of the screen. */
-    inline bool isDisplayStats() { return _displayStats; }
+    bool isDisplayStats() { return _displayStats; }
     /** Display the FPS on the bottom-left corner of the screen. */
-    inline void setDisplayStats(bool displayStats) { _displayStats = displayStats; }
+    void setDisplayStats(bool displayStats) { _displayStats = displayStats; }
     
     /** Get seconds per frame. */
-    inline float getSecondsPerFrame() { return _secondsPerFrame; }
+    float getSecondsPerFrame() { return _secondsPerFrame; }
 
     /** 
      * Get the GLView.
      * @lua NA
      */
-    inline GLView* getOpenGLView() { return _openGLView; }
+    GLView* getOpenGLView() { return _openGLView; }
     /** 
      * Sets the GLView. 
      * @lua NA
@@ -188,7 +188,7 @@ public:
     TextureCache* getTextureCache() const;
 
     /** Whether or not `_nextDeltaTimeZero` is set to 0. */
-    inline bool isNextDeltaTimeZero() { return _nextDeltaTimeZero; }
+    bool isNextDeltaTimeZero() { return _nextDeltaTimeZero; }
     /** 
      * Sets the delta time between current frame and next frame is 0.
      * This value will be used in Schedule, and will affect all functions that are using frame delta time, such as Actions.
@@ -197,16 +197,16 @@ public:
     void setNextDeltaTimeZero(bool nextDeltaTimeZero);
 
     /** Whether or not the Director is paused. */
-    inline bool isPaused() { return _paused; }
+    bool isPaused() { return _paused; }
 
     /** How many frames were called since the director started */
-    inline unsigned int getTotalFrames() { return _totalFrames; }
+    unsigned int getTotalFrames() { return _totalFrames; }
     
     /** Gets an OpenGL projection.
      * @since v0.8.2
      * @lua NA
      */
-    inline Projection getProjection() { return _projection; }
+    Projection getProjection() { return _projection; }
     /** Sets OpenGL projection. */
     void setProjection(Projection projection);
     
@@ -221,7 +221,7 @@ public:
      * If the new scene replaces the old one, the it will receive the "cleanup" message.
      * @since v0.99.0
      */
-    inline bool isSendCleanupToScene() { return _sendCleanupToScene; }
+    bool isSendCleanupToScene() { return _sendCleanupToScene; }
 
     /** This object will be visited after the main scene is visited.
      * This object MUST implement the "visit" function.
@@ -503,7 +503,7 @@ public:
     /**
      * returns whether or not the Director is in a valid state
      */
-    inline bool isValid() const { return !_invalid; }
+    bool isValid() const { return !_invalid; }
 
 protected:
     void reset();

--- a/cocos/base/CCEvent.h
+++ b/cocos/base/CCEvent.h
@@ -68,28 +68,28 @@ public:
      *
      * @return The event type.
      */
-	inline Type getType() const { return _type; };
+    Type getType() const { return _type; }
     
     /** Stops propagation for current event.
      */
-    inline void stopPropagation() { _isStopped = true; };
+    void stopPropagation() { _isStopped = true; }
     
     /** Checks whether the event has been stopped.
      *
      * @return True if the event has been stopped.
      */
-    inline bool isStopped() const { return _isStopped; };
+    bool isStopped() const { return _isStopped; }
     
     /** Gets current target of the event.
      * @return The target with which the event associates.
      * @note It's only available when the event listener is associated with node.
      *        It returns 0 when the listener is associated with fixed priority.
      */
-    inline Node* getCurrentTarget() { return _currentTarget; };
+    Node* getCurrentTarget() { return _currentTarget; }
     
 protected:
     /** Sets current target */
-    inline void setCurrentTarget(Node* target) { _currentTarget = target; };
+    void setCurrentTarget(Node* target) { _currentTarget = target; }
     
 	Type _type;     ///< Event type
     

--- a/cocos/base/CCEventCustom.h
+++ b/cocos/base/CCEventCustom.h
@@ -52,19 +52,19 @@ public:
      *
      * @param data The user data pointer, it's a void*.
      */
-    inline void setUserData(void* data) { _userData = data; };
+    void setUserData(void* data) { _userData = data; }
     
     /** Gets user data.
      *
      * @return The user data pointer, it's a void*.
      */
-    inline void* getUserData() const { return _userData; };
+    void* getUserData() const { return _userData; }
     
     /** Gets event name.
      *
      * @return The name of the event.
      */
-    inline const std::string& getEventName() const { return _eventName; };
+    const std::string& getEventName() const { return _eventName; }
 protected:
     void* _userData;       ///< User data
     std::string _eventName;

--- a/cocos/base/CCEventDispatcher.h
+++ b/cocos/base/CCEventDispatcher.h
@@ -218,10 +218,10 @@ protected:
         void clearFixedListeners();
         void clear();
         
-        inline std::vector<EventListener*>* getFixedPriorityListeners() const { return _fixedListeners; };
-        inline std::vector<EventListener*>* getSceneGraphPriorityListeners() const { return _sceneGraphListeners; };
-        inline ssize_t getGt0Index() const { return _gt0Index; };
-        inline void setGt0Index(ssize_t index) { _gt0Index = index; };
+        std::vector<EventListener*>* getFixedPriorityListeners() const { return _fixedListeners; }
+        std::vector<EventListener*>* getSceneGraphPriorityListeners() const { return _sceneGraphListeners; }
+        ssize_t getGt0Index() const { return _gt0Index; }
+        void setGt0Index(ssize_t index) { _gt0Index = index; }
     private:
         std::vector<EventListener*>* _fixedListeners;
         std::vector<EventListener*>* _sceneGraphListeners;

--- a/cocos/base/CCEventListener.h
+++ b/cocos/base/CCEventListener.h
@@ -102,13 +102,13 @@ public:
      *
      * @param enabled True if enables the listener.
      */
-    inline void setEnabled(bool enabled) { _isEnabled = enabled; };
+    void setEnabled(bool enabled) { _isEnabled = enabled; }
 
     /** Checks whether the listener is enabled.
      *
      * @return True if the listener is enabled.
      */
-    inline bool isEnabled() const { return _isEnabled; };
+    bool isEnabled() const { return _isEnabled; }
 
 protected:
 
@@ -120,45 +120,45 @@ protected:
      *           call `setEnabled(false)` instead.
      *        2) In `Node`'s onEnter and onExit, the `paused state` of the listeners which associated with that node will be automatically updated.
      */
-    inline void setPaused(bool paused) { _paused = paused; };
+    void setPaused(bool paused) { _paused = paused; }
 
     /** Checks whether the listener is paused */
-    inline bool isPaused() const { return _paused; };
+    bool isPaused() const { return _paused; }
 
     /** Marks the listener was registered by EventDispatcher */
-    inline void setRegistered(bool registered) { _isRegistered = registered; };
+    void setRegistered(bool registered) { _isRegistered = registered; }
 
     /** Checks whether the listener was registered by EventDispatcher */
-    inline bool isRegistered() const { return _isRegistered; };
+    bool isRegistered() const { return _isRegistered; }
 
     /** Gets the type of this listener
      *  @note It's different from `EventType`, e.g. TouchEvent has two kinds of event listeners - EventListenerOneByOne, EventListenerAllAtOnce
      */
-    inline Type getType() const { return _type; };
+    Type getType() const { return _type; }
 
     /** Gets the listener ID of this listener
      *  When event is being dispatched, listener ID is used as key for searching listeners according to event type.
      */
-    inline const ListenerID& getListenerID() const { return _listenerID; };
+    const ListenerID& getListenerID() const { return _listenerID; }
 
     /** Sets the fixed priority for this listener
      *  @note This method is only used for `fixed priority listeners`, it needs to access a non-zero value.
      *  0 is reserved for scene graph priority listeners
      */
-    inline void setFixedPriority(int fixedPriority) { _fixedPriority = fixedPriority; };
+    void setFixedPriority(int fixedPriority) { _fixedPriority = fixedPriority; }
 
     /** Gets the fixed priority of this listener
      *  @return 0 if it's a scene graph priority listener, non-zero for fixed priority listener
      */
-    inline int getFixedPriority() const { return _fixedPriority; };
+    int getFixedPriority() const { return _fixedPriority; }
 
     /** Sets the node associated with this listener */
-    inline void setAssociatedNode(Node* node) { _node = node; };
+    void setAssociatedNode(Node* node) { _node = node; }
 
     /** Gets the node associated with this listener
      *  @return nullptr if it's a fixed priority listener, otherwise return non-nullptr
      */
-    inline Node* getAssociatedNode() const { return _node; };
+    Node* getAssociatedNode() const { return _node; }
 
     ///////////////
     // Properties

--- a/cocos/base/CCEventMouse.h
+++ b/cocos/base/CCEventMouse.h
@@ -76,17 +76,17 @@ public:
      * @param scrollX The scroll data of x axis.
      * @param scrollY The scroll data of y axis.
      */
-    inline void setScrollData(float scrollX, float scrollY) { _scrollX = scrollX; _scrollY = scrollY; };
+    void setScrollData(float scrollX, float scrollY) { _scrollX = scrollX; _scrollY = scrollY; }
     /** Get mouse scroll data of x axis.
      * 
      * @return The scroll data of x axis.
      */
-    inline float getScrollX() const { return _scrollX; };
+    float getScrollX() const { return _scrollX; }
     /** Get mouse scroll data of y axis.
      *
      * @return The scroll data of y axis.
      */
-    inline float getScrollY() const { return _scrollY; };
+    float getScrollY() const { return _scrollY; }
 
     /** Set the cursor position.
      *
@@ -94,7 +94,7 @@ public:
      * @param y The y coordinate of cursor position.
      * @js setLocation
      */
-    inline void setCursorPosition(float x, float y) { 
+    void setCursorPosition(float x, float y) { 
         _x = x;
         _y = y;
         _prevPoint = _point;
@@ -112,25 +112,25 @@ public:
      * @param button a given mouse button.
      * @js setButton
      */
-    inline void setMouseButton(int button) { _mouseButton = button; };
+    void setMouseButton(int button) { _mouseButton = button; }
     /** Get mouse button.
      *
      * @return The mouse button.
      * @js getButton
      */
-    inline int getMouseButton() const { return _mouseButton; };
+    int getMouseButton() const { return _mouseButton; }
     /** Get the cursor position of x axis.
      *
      * @return The x coordinate of cursor position.
      * @js getLocationX
      */
-    inline float getCursorX() const { return _x; };
+    float getCursorX() const { return _x; }
     /** Get the cursor position of y axis.
      *
      * @return The y coordinate of cursor position.
      * @js getLocationY
      */
-    inline float getCursorY() const { return _y; };
+    float getCursorY() const { return _y; }
 
     /** Returns the current touch location in OpenGL coordinates.
      *

--- a/cocos/base/CCEventTouch.h
+++ b/cocos/base/CCEventTouch.h
@@ -66,13 +66,13 @@ public:
      *
      * @return The code of the event.
      */
-    inline EventCode getEventCode() const { return _eventCode; };
+    EventCode getEventCode() const { return _eventCode; }
     
     /** Get the touches.
      *
      * @return The touches of the event.
      */
-    inline const std::vector<Touch*>& getTouches() const { return _touches; };
+    const std::vector<Touch*>& getTouches() const { return _touches; }
 
 #if TOUCH_PERF_DEBUG
     /** Set the event code.

--- a/cocos/base/CCProfiling.h
+++ b/cocos/base/CCProfiling.h
@@ -127,7 +127,7 @@ public:
      * @js NA
      * @lua NA
      */
-    inline const std::chrono::high_resolution_clock::time_point& getStartTime(void) { return _startTime; };
+    const std::chrono::high_resolution_clock::time_point& getStartTime() { return _startTime; }
 
     /** resets the timer properties
      * @js NA

--- a/cocos/base/CCRefPtr.h
+++ b/cocos/base/CCRefPtr.h
@@ -86,42 +86,42 @@ template <typename T> class RefPtr
 {
 public:
     
-    inline RefPtr()
+    RefPtr()
         : _ptr(nullptr)
     {
         
     }
     
-    inline RefPtr(RefPtr<T> && other)
+    RefPtr(RefPtr<T> && other)
     {
         _ptr = other._ptr;
         other._ptr = nullptr;
     }
 
-    inline RefPtr(T * ptr)
+    RefPtr(T * ptr)
         : _ptr(ptr)
     {
         CC_REF_PTR_SAFE_RETAIN(_ptr);
     }
     
-    inline RefPtr(std::nullptr_t ptr)
+    RefPtr(std::nullptr_t ptr)
         : _ptr(nullptr)
     {
         
     }
     
-    inline RefPtr(const RefPtr<T> & other)
+    RefPtr(const RefPtr<T> & other)
         : _ptr(other._ptr)
     {
         CC_REF_PTR_SAFE_RETAIN(_ptr);
     }
     
-    inline ~RefPtr()
+    ~RefPtr()
     {
         CC_REF_PTR_SAFE_RELEASE_NULL(_ptr);
     }
     
-    inline RefPtr<T> & operator = (const RefPtr<T> & other)
+    RefPtr<T> & operator = (const RefPtr<T> & other)
     {
         if (other._ptr != _ptr)
         {
@@ -133,7 +133,7 @@ public:
         return *this;
     }
     
-    inline RefPtr<T> & operator = (RefPtr<T> && other)
+    RefPtr<T> & operator = (RefPtr<T> && other)
     {
         if (&other != this)
         {
@@ -145,7 +145,7 @@ public:
         return *this;
     }
     
-    inline RefPtr<T> & operator = (T * other)
+    RefPtr<T> & operator = (T * other)
     {
         if (other != _ptr)
         {
@@ -157,83 +157,83 @@ public:
         return *this;
     }
     
-    inline RefPtr<T> & operator = (std::nullptr_t other)
+    RefPtr<T> & operator = (std::nullptr_t other)
     {
         CC_REF_PTR_SAFE_RELEASE_NULL(_ptr);
         return *this;
     }
     
-    inline operator T * () const { return _ptr; }
+    operator T * () const { return _ptr; }
     
-    inline T & operator * () const
+    T & operator * () const
     {
         CCASSERT(_ptr, "Attempt to dereference a null pointer!");
         return *_ptr;
     }
     
-    inline T * operator->() const
+    T * operator->() const
     {
         CCASSERT(_ptr, "Attempt to dereference a null pointer!");
         return _ptr;
     }
     
-    inline T * get() const { return _ptr; }
+    T * get() const { return _ptr; }
     
     
-    inline bool operator == (const RefPtr<T> & other) const { return _ptr == other._ptr; }
+    bool operator == (const RefPtr<T> & other) const { return _ptr == other._ptr; }
     
-    inline bool operator == (const T * other) const { return _ptr == other; }
+    bool operator == (const T * other) const { return _ptr == other; }
     
-    inline bool operator == (typename std::remove_const<T>::type * other) const { return _ptr == other; }
+    bool operator == (typename std::remove_const<T>::type * other) const { return _ptr == other; }
     
-    inline bool operator == (const std::nullptr_t other) const { return _ptr == other; }
-    
-    
-    inline bool operator != (const RefPtr<T> & other) const { return _ptr != other._ptr; }
-    
-    inline bool operator != (const T * other) const { return _ptr != other; }
-    
-    inline bool operator != (typename std::remove_const<T>::type * other) const { return _ptr != other; }
-    
-    inline bool operator != (const std::nullptr_t other) const { return _ptr != other; }
+    bool operator == (const std::nullptr_t other) const { return _ptr == other; }
     
     
-    inline bool operator > (const RefPtr<T> & other) const { return _ptr > other._ptr; }
+    bool operator != (const RefPtr<T> & other) const { return _ptr != other._ptr; }
     
-    inline bool operator > (const T * other) const { return _ptr > other; }
+    bool operator != (const T * other) const { return _ptr != other; }
     
-    inline bool operator > (typename std::remove_const<T>::type * other) const { return _ptr > other; }
+    bool operator != (typename std::remove_const<T>::type * other) const { return _ptr != other; }
+    
+    bool operator != (const std::nullptr_t other) const { return _ptr != other; }
     
     
-    inline bool operator < (const RefPtr<T> & other) const { return _ptr < other._ptr; }
+    bool operator > (const RefPtr<T> & other) const { return _ptr > other._ptr; }
     
-    inline bool operator < (const T * other) const { return _ptr < other; }
+    bool operator > (const T * other) const { return _ptr > other; }
     
-    inline bool operator < (typename std::remove_const<T>::type * other) const { return _ptr < other; }
+    bool operator > (typename std::remove_const<T>::type * other) const { return _ptr > other; }
     
-        
-    inline bool operator >= (const RefPtr<T> & other) const { return _ptr >= other._ptr; }
     
-    inline bool operator >= (const T * other) const { return _ptr >= other; }
+    bool operator < (const RefPtr<T> & other) const { return _ptr < other._ptr; }
     
-    inline bool operator >= (typename std::remove_const<T>::type * other) const { return _ptr >= other; }
+    bool operator < (const T * other) const { return _ptr < other; }
+    
+    bool operator < (typename std::remove_const<T>::type * other) const { return _ptr < other; }
     
         
-    inline bool operator <= (const RefPtr<T> & other) const { return _ptr <= other._ptr; }
+    bool operator >= (const RefPtr<T> & other) const { return _ptr >= other._ptr; }
     
-    inline bool operator <= (const T * other) const { return _ptr <= other; }
+    bool operator >= (const T * other) const { return _ptr >= other; }
     
-    inline bool operator <= (typename std::remove_const<T>::type * other) const { return _ptr <= other; }
+    bool operator >= (typename std::remove_const<T>::type * other) const { return _ptr >= other; }
     
         
-    inline operator bool() const { return _ptr != nullptr; }
+    bool operator <= (const RefPtr<T> & other) const { return _ptr <= other._ptr; }
+    
+    bool operator <= (const T * other) const { return _ptr <= other; }
+    
+    bool operator <= (typename std::remove_const<T>::type * other) const { return _ptr <= other; }
+    
         
-    inline void reset()
+    operator bool() const { return _ptr != nullptr; }
+        
+    void reset()
     {
         CC_REF_PTR_SAFE_RELEASE_NULL(_ptr);
     }
         
-    inline void swap(RefPtr<T> & other)
+    void swap(RefPtr<T> & other)
     {
         if (&other != this)
         {
@@ -257,7 +257,7 @@ public:
      *      image = new cocos2d::Image();
      *      image->release();               // Required because new'd object already has a reference count of '1'.
      */
-    inline void weakAssign(const RefPtr<T> & other)
+    void weakAssign(const RefPtr<T> & other)
     {
         CC_REF_PTR_SAFE_RELEASE(_ptr);
         _ptr = other._ptr;

--- a/cocos/base/CCScheduler.h
+++ b/cocos/base/CCScheduler.h
@@ -51,9 +51,9 @@ protected:
     Timer();
 public:
     /** get interval in seconds */
-    inline float getInterval() const { return _interval; };
+    float getInterval() const { return _interval; }
     /** set interval in seconds */
-    inline void setInterval(float interval) { _interval = interval; };
+    void setInterval(float interval) { _interval = interval; }
     
     void setupTimerWithInterval(float seconds, unsigned int repeat, float delay);
     
@@ -84,7 +84,7 @@ public:
     /** Initializes a timer with a target, a selector and an interval in seconds, repeat in number of times to repeat, delay in seconds. */
     bool initWithSelector(Scheduler* scheduler, SEL_SCHEDULE selector, Ref* target, float seconds, unsigned int repeat, float delay);
     
-    inline SEL_SCHEDULE getSelector() const { return _selector; };
+    SEL_SCHEDULE getSelector() const { return _selector; }
     
     virtual void trigger(float dt) override;
     virtual void cancel() override;
@@ -103,8 +103,8 @@ public:
     // Initializes a timer with a target, a lambda and an interval in seconds, repeat in number of times to repeat, delay in seconds.
     bool initWithCallback(Scheduler* scheduler, const ccSchedulerFunc& callback, void *target, const std::string& key, float seconds, unsigned int repeat, float delay);
     
-    inline const ccSchedulerFunc& getCallback() const { return _callback; };
-    inline const std::string& getKey() const { return _key; };
+    const ccSchedulerFunc& getCallback() const { return _callback; }
+    const std::string& getKey() const { return _key; }
     
     virtual void trigger(float dt) override;
     virtual void cancel() override;
@@ -121,7 +121,7 @@ class CC_DLL TimerScriptHandler : public Timer
 {
 public:
     bool initWithScriptHandler(int handler, float seconds);
-    inline int getScriptHandler() const { return _scriptHandler; };
+    int getScriptHandler() const { return _scriptHandler; }
     
     virtual void trigger(float dt) override;
     virtual void cancel() override;
@@ -196,7 +196,7 @@ public:
      * Gets the time scale of schedule callbacks.
      * @see Scheduler::setTimeScale()
      */
-    inline float getTimeScale() { return _timeScale; }
+    float getTimeScale() { return _timeScale; }
     /** Modifies the time of all scheduled callbacks.
     You can use this property to create a 'slow motion' or 'fast forward' effect.
     Default is 1.0. To create a 'slow motion' effect, use values below 1.0.
@@ -204,7 +204,7 @@ public:
     @since v0.8
     @warning It will affect EVERY scheduled selector / action.
     */
-    inline void setTimeScale(float timeScale) { _timeScale = timeScale; }
+    void setTimeScale(float timeScale) { _timeScale = timeScale; }
 
     /** 'update' the scheduler.
      * You should NEVER call this method, unless you know what you are doing.

--- a/cocos/base/CCValue.h
+++ b/cocos/base/CCValue.h
@@ -187,7 +187,7 @@ public:
      * Checks if the Value is null.
      * @return True if the Value is null, false if not.
      */
-    inline bool isNull() const { return _type == Type::NONE; }
+    bool isNull() const { return _type == Type::NONE; }
 
     /** Value type wrapped by Value. */
     enum class Type
@@ -217,7 +217,7 @@ public:
     };
 
     /** Gets the value type. */
-    inline Type getType() const { return _type; }
+    Type getType() const { return _type; }
 
     /** Gets the description of the class. */
     std::string getDescription() const;

--- a/cocos/base/ccRandom.h
+++ b/cocos/base/ccRandom.h
@@ -45,14 +45,14 @@ NS_CC_BEGIN
 class CC_DLL RandomHelper {
 public:
     template<typename T>
-    static inline T random_real(T min, T max) {
+    static T random_real(T min, T max) {
         std::uniform_real_distribution<T> dist(min, max);
         auto &mt = RandomHelper::getEngine();
         return dist(mt);
     }
 
     template<typename T>
-    static inline T random_int(T min, T max) {
+    static T random_int(T min, T max) {
         std::uniform_int_distribution<T> dist(min, max);
         auto &mt = RandomHelper::getEngine();
         return dist(mt);

--- a/cocos/deprecated/CCDictionary.h
+++ b/cocos/deprecated/CCDictionary.h
@@ -97,7 +97,7 @@ public:
      *
      * @return  The string key of this element.
      */
-    inline const char* getStrKey() const
+    const char* getStrKey() const
     {
         CCASSERT(_strKey[0] != '\0', "Should not call this function for integer dictionary");
         return _strKey;
@@ -110,7 +110,7 @@ public:
      *
      * @return  The integer key of this element.
      */
-    inline intptr_t getIntKey() const
+    intptr_t getIntKey() const
     {
         CCASSERT(_strKey[0] == '\0', "Should not call this function for string dictionary");
         return _intKey;
@@ -121,7 +121,7 @@ public:
      *
      * @return  The object of this element.
      */
-    inline Ref* getObject() const { return _object; }
+    Ref* getObject() const { return _object; }
 
 private:
     // The max length of string key.

--- a/cocos/deprecated/CCNotificationCenter.h
+++ b/cocos/deprecated/CCNotificationCenter.h
@@ -116,7 +116,7 @@ public:
      *  @note Only supports Lua Binding now.
      *  @return The script handle.
      */
-    inline int getScriptHandler() const { return _scriptHandler; };
+    int getScriptHandler() const { return _scriptHandler; }
     
     /** @brief Gets observer script handler.
      *  @param name The name of this notification.

--- a/cocos/network/HttpRequest.h
+++ b/cocos/network/HttpRequest.h
@@ -121,7 +121,7 @@ public:
      *
      * @param type the request type.
      */
-    inline void setRequestType(Type type)
+    void setRequestType(Type type)
     {
         _requestType = type;
     }
@@ -131,7 +131,7 @@ public:
      *
      * @return HttpRequest::Type.
      */
-    inline Type getRequestType() const
+    Type getRequestType() const
     {
         return _requestType;
     }
@@ -142,7 +142,7 @@ public:
      *
      * @param url the string object.
      */
-    inline void setUrl(const std::string& url)
+    void setUrl(const std::string& url)
     {
         _url = url;
     }
@@ -152,7 +152,7 @@ public:
      *
      * @return const char* the pointer of _url.
      */
-    inline const char* getUrl() const
+    const char* getUrl() const
     {
         return _url.c_str();
     }
@@ -163,7 +163,7 @@ public:
      * @param buffer the buffer of request data, it support binary data.
      * @param len    the size of request data.
      */
-    inline void setRequestData(const char* buffer, size_t len)
+    void setRequestData(const char* buffer, size_t len)
     {
         _requestData.assign(buffer, buffer + len);
     }
@@ -173,7 +173,7 @@ public:
      *
      * @return char* the request data pointer.
      */
-    inline char* getRequestData()
+    char* getRequestData()
     {
         if(!_requestData.empty())
             return _requestData.data();
@@ -186,7 +186,7 @@ public:
      *
      * @return ssize_t the size of request data
      */
-    inline ssize_t getRequestDataSize() const
+    ssize_t getRequestDataSize() const
     {
         return _requestData.size();
     }
@@ -197,7 +197,7 @@ public:
      *
      * @param tag the string object.
      */
-    inline void setTag(const std::string& tag)
+    void setTag(const std::string& tag)
     {
         _tag = tag;
     }
@@ -208,7 +208,7 @@ public:
      *
      * @return const char* the pointer of _tag
      */
-    inline const char* getTag() const
+    const char* getTag() const
     {
         return _tag.c_str();
     }
@@ -220,7 +220,7 @@ public:
      *
      * @param pUserData the string pointer
      */
-    inline void setUserData(void* pUserData)
+    void setUserData(void* pUserData)
     {
         _pUserData = pUserData;
     }
@@ -231,7 +231,7 @@ public:
      *
      * @return void* the pointer of user-customed data.
      */
-    inline void* getUserData() const
+    void* getUserData() const
     {
         return _pUserData;
     };
@@ -243,7 +243,7 @@ public:
      * @param pTarget the target object pointer.
      * @param pSelector the callback function.
      */
-    CC_DEPRECATED_ATTRIBUTE inline void setResponseCallback(Ref* pTarget, SEL_CallFuncND pSelector)
+    CC_DEPRECATED_ATTRIBUTE void setResponseCallback(Ref* pTarget, SEL_CallFuncND pSelector)
     {
         doSetResponseCallback(pTarget, (SEL_HttpResponse)pSelector);
     }
@@ -255,7 +255,7 @@ public:
      * @param pTarget the target object pointer.
      * @param pSelector the SEL_HttpResponse function.
      */
-    inline void setResponseCallback(Ref* pTarget, SEL_HttpResponse pSelector)
+    void setResponseCallback(Ref* pTarget, SEL_HttpResponse pSelector)
     {
         doSetResponseCallback(pTarget, pSelector);
     }
@@ -265,7 +265,7 @@ public:
      *
      * @param callback the ccHttpRequestCallback function.
      */
-    inline void setResponseCallback(const ccHttpRequestCallback& callback)
+    void setResponseCallback(const ccHttpRequestCallback& callback)
     {
         _pCallback = callback;
     }
@@ -275,7 +275,7 @@ public:
      *
      * @return Ref* the target of callback selector function
      */
-    inline Ref* getTarget() const
+    Ref* getTarget() const
     {
         return _pTarget;
     }
@@ -304,7 +304,7 @@ public:
      *
      * @return _prxy the _prxy object
      */
-    inline _prxy getSelector() const
+    _prxy getSelector() const
     {
         return _prxy(_pSelector);
     }
@@ -314,7 +314,7 @@ public:
      *
      * @return const ccHttpRequestCallback& ccHttpRequestCallback callback function.
      */
-    inline const ccHttpRequestCallback& getCallback() const
+    const ccHttpRequestCallback& getCallback() const
     {
         return _pCallback;
     }
@@ -324,7 +324,7 @@ public:
      *
      * @param headers The string vector of custom-defined headers.
      */
-    inline void setHeaders(const std::vector<std::string>& headers)
+    void setHeaders(const std::vector<std::string>& headers)
        {
            _headers = headers;
        }
@@ -334,13 +334,13 @@ public:
      *
      * @return std::vector<std::string> the string vector of custom-defined headers.
      */
-    inline std::vector<std::string> getHeaders() const
+    std::vector<std::string> getHeaders() const
     {
         return _headers;
     }
 
 private:
-    inline void doSetResponseCallback(Ref* pTarget, SEL_HttpResponse pSelector)
+    void doSetResponseCallback(Ref* pTarget, SEL_HttpResponse pSelector)
     {
         if (_pTarget)
         {

--- a/cocos/network/HttpResponse.h
+++ b/cocos/network/HttpResponse.h
@@ -92,7 +92,7 @@ public:
      * There's no paired setter for it, because it's already set in class constructor
      * @return HttpRequest* the corresponding HttpRequest object which leads to this response.
      */
-    inline HttpRequest* getHttpRequest() const
+    HttpRequest* getHttpRequest() const
     {
         return _pHttpRequest;
     }
@@ -103,7 +103,7 @@ public:
      * If this getter returns false, you can call getResponseCode and getErrorBuffer to find more details.
      * @return bool the flag that represent whether the http request return successfully or not.
      */
-    inline bool isSucceed() const
+    bool isSucceed() const
     {
         return _succeed;
     }
@@ -112,7 +112,7 @@ public:
      * Get the http response data.
      * @return std::vector<char>* the pointer that point to the _responseData.
      */
-    inline std::vector<char>* getResponseData()
+    std::vector<char>* getResponseData()
     {
         return &_responseData;
     }
@@ -121,7 +121,7 @@ public:
      * Get the response headers.
      * @return std::vector<char>* the pointer that point to the _responseHeader.
      */
-    inline std::vector<char>* getResponseHeader()
+    std::vector<char>* getResponseHeader()
     {
         return &_responseHeader;
     }
@@ -132,7 +132,7 @@ public:
      * If _responseCode is not 200, you should check the meaning for _responseCode by the net.
      * @return long the value of _responseCode
      */
-    inline long getResponseCode() const
+    long getResponseCode() const
     {
         return _responseCode;
     }
@@ -141,7 +141,7 @@ public:
      * Get the error buffer which will tell you more about the reason why http request failed.
      * @return const char* the pointer that point to _errorBuffer.
      */
-    inline const char* getErrorBuffer() const
+    const char* getErrorBuffer() const
     {
         return _errorBuffer.c_str();
     }
@@ -155,7 +155,7 @@ public:
      * This setter is mainly used in HttpClient, users mustn't set it directly
      * @param value the flag represent whether the http request is successful or not.
      */
-    inline void setSucceed(bool value)
+    void setSucceed(bool value)
     {
         _succeed = value;
     }
@@ -164,7 +164,7 @@ public:
      * Set the http response data buffer, it is used by HttpClient.
      * @param data the pointer point to the response data buffer.
      */
-    inline void setResponseData(std::vector<char>* data)
+    void setResponseData(std::vector<char>* data)
     {
         _responseData = *data;
     }
@@ -173,7 +173,7 @@ public:
      * Set the http response headers buffer, it is used by HttpClient.
      * @param data the pointer point to the response headers buffer.
      */
-    inline void setResponseHeader(std::vector<char>* data)
+    void setResponseHeader(std::vector<char>* data)
     {
         _responseHeader = *data;
     }
@@ -183,7 +183,7 @@ public:
      * Set the http response code.
      * @param value the http response code that represent whether the request is successful or not.
      */
-    inline void setResponseCode(long value)
+    void setResponseCode(long value)
     {
         _responseCode = value;
     }
@@ -193,7 +193,7 @@ public:
      * Set the error buffer which will tell you more the reason why http request failed.
      * @param value a string pointer that point to the reason.
      */
-    inline void setErrorBuffer(const char* value)
+    void setErrorBuffer(const char* value)
     {
         _errorBuffer.clear();
         _errorBuffer.assign(value);
@@ -204,7 +204,7 @@ public:
      * @param value a string pointer that point to response data buffer.
      * @param n the defined size that the response data buffer would be copied.
      */
-    inline void setResponseDataString(const char* value, size_t n)
+    void setResponseDataString(const char* value, size_t n)
     {
         _responseDataString.clear();
         _responseDataString.assign(value, n);
@@ -214,7 +214,7 @@ public:
      * Get the string pointer that point to the response data.
      * @return const char* the string pointer that point to the response data.
      */
-    inline const char* getResponseDataString() const
+    const char* getResponseDataString() const
     {
         return _responseDataString.c_str();
     }

--- a/cocos/network/SocketIO.h
+++ b/cocos/network/SocketIO.h
@@ -268,7 +268,7 @@ public:
      * Get tag of SIOClient.
      * @return const char* the pointer point to the _tag.
      */
-    inline const char* getTag()
+    const char* getTag()
     {
         return _tag.c_str();
     };

--- a/cocos/physics/CCPhysicsBody.h
+++ b/cocos/physics/CCPhysicsBody.h
@@ -198,14 +198,14 @@ public:
      * 
      * @return A Vector<PhysicsShape*> object contains PhysicsShape pointer.
      */
-    inline const Vector<PhysicsShape*>& getShapes() const { return _shapes; }
+    const Vector<PhysicsShape*>& getShapes() const { return _shapes; }
 
     /**
      * Get the first shape of the body shapes.
      *
      * @return The first shape in this body.
      */
-    inline PhysicsShape* getFirstShape() const { return _shapes.size() >= 1 ? _shapes.at(0) : nullptr; }
+    PhysicsShape* getFirstShape() const { return _shapes.size() >= 1 ? _shapes.at(0) : nullptr; }
 
     /** 
      * get the shape of the body.
@@ -285,10 +285,10 @@ public:
     void removeFromWorld();
     
     /** get the world body added to. */
-    inline PhysicsWorld* getWorld() const { return _world; }
+    PhysicsWorld* getWorld() const { return _world; }
 
     /** get all joints the body have */
-    inline const std::vector<PhysicsJoint*>& getJoints() const { return _joints; }
+    const std::vector<PhysicsJoint*>& getJoints() const { return _joints; }
     
     /** get the node the body set to. */
     Node* getNode() const { return _owner; }
@@ -376,7 +376,7 @@ public:
      *
      * A dynamic body will effect with gravity.
      */
-    inline bool isDynamic() const { return _dynamic; }
+    bool isDynamic() const { return _dynamic; }
     /**
      * @brief Set dynamic to body.
      * 
@@ -392,7 +392,7 @@ public:
     void setMass(float mass);
     
     /** Get the body mass. */
-    inline float getMass() const { return _mass; }
+    float getMass() const { return _mass; }
 
     /**
      * @brief Add mass to body.
@@ -413,7 +413,7 @@ public:
     void setMoment(float moment);
     
     /** Get the body moment of inertia. */
-    inline float getMoment() const { return _moment; }
+    float getMoment() const { return _moment; }
     
     /**
      * @brief Add moment of inertia to body.
@@ -427,7 +427,7 @@ public:
     void addMoment(float moment);
     
     /** get linear damping. */
-    inline float getLinearDamping() const { return _linearDamping; }
+    float getLinearDamping() const { return _linearDamping; }
     
     /** 
      * Set linear damping.
@@ -435,10 +435,10 @@ public:
      * it is used to simulate fluid or air friction forces on the body.
      * @param damping The value is 0.0f to 1.0f.
      */
-    inline void setLinearDamping(float damping) { _linearDamping = damping; updateDamping(); }
+    void setLinearDamping(float damping) { _linearDamping = damping; updateDamping(); }
     
     /** Get angular damping. */
-    inline float getAngularDamping() const { return _angularDamping; }
+    float getAngularDamping() const { return _angularDamping; }
 
     /**
      * Set angular damping.
@@ -446,7 +446,7 @@ public:
      * It is used to simulate fluid or air friction forces on the body.
      * @param damping The value is 0.0f to 1.0f.
      */
-    inline void setAngularDamping(float damping) { _angularDamping = damping; updateDamping(); }
+    void setAngularDamping(float damping) { _angularDamping = damping; updateDamping(); }
     
     /** Whether the body is at rest. */
     bool isResting() const;
@@ -462,22 +462,22 @@ public:
     virtual void setEnabled(bool enable) override;
     
     /** Whether the body can rotation. */
-    inline bool isRotationEnabled() const { return _rotationEnabled; }
+    bool isRotationEnabled() const { return _rotationEnabled; }
     
     /** Set the body is allow rotation or not */
     void setRotationEnable(bool enable);
     
     /** Whether this physics body is affected by the physics world's gravitational force. */
-    inline bool isGravityEnabled() const { return _gravityEnabled; }
+    bool isGravityEnabled() const { return _gravityEnabled; }
     
     /** Set the body is affected by the physics world's gravitational force or not. */
     void setGravityEnable(bool enable);
     
     /** Get the body's tag. */
-    inline int getTag() const { return _tag; }
+    int getTag() const { return _tag; }
     
     /** set the body's tag. */
-    inline void setTag(int tag) { _tag = tag; }
+    void setTag(int tag) { _tag = tag; }
     
     /** Convert the world point to local. */
     Vec2 world2Local(const Vec2& point);
@@ -509,7 +509,7 @@ protected:
     
     void removeJoint(PhysicsJoint* joint);
 
-    inline void updateDamping() { _isDamping = _linearDamping != 0.0f ||  _angularDamping != 0.0f; }
+    void updateDamping() { _isDamping = _linearDamping != 0.0f ||  _angularDamping != 0.0f; }
 
     void addToPhysicsWorld();
     void removeFromPhysicsWorld();

--- a/cocos/physics/CCPhysicsContact.h
+++ b/cocos/physics/CCPhysicsContact.h
@@ -78,22 +78,22 @@ public:
     };
     
     /** Get contact shape A. */
-    inline PhysicsShape* getShapeA() const { return _shapeA; }
+    PhysicsShape* getShapeA() const { return _shapeA; }
     
     /** Get contact shape B. */
-    inline PhysicsShape* getShapeB() const { return _shapeB; }
+    PhysicsShape* getShapeB() const { return _shapeB; }
     
     /** Get contact data. */
-    inline const PhysicsContactData* getContactData() const { return _contactData; }
+    const PhysicsContactData* getContactData() const { return _contactData; }
     
     /** Get previous contact data */
-    inline const PhysicsContactData* getPreContactData() const { return _preContactData; }
+    const PhysicsContactData* getPreContactData() const { return _preContactData; }
     
     /** 
      * Get data. 
      * @lua NA
      */
-    inline void* getData() const { return _data; }
+    void* getData() const { return _data; }
     
     /**
      * @brief Set data to contact. 
@@ -102,7 +102,7 @@ public:
      *
      * @lua NA
      */
-    inline void setData(void* data) { _data = data; }
+    void setData(void* data) { _data = data; }
 
     /** Get the event code */
     EventCode getEventCode() const { return _eventCode; };
@@ -112,12 +112,12 @@ private:
     bool init(PhysicsShape* a, PhysicsShape* b);
     
     void setEventCode(EventCode eventCode) { _eventCode = eventCode; };
-    inline bool isNotificationEnabled() const { return _notificationEnable; }
-    inline void setNotificationEnable(bool enable) { _notificationEnable = enable; }
-    inline PhysicsWorld* getWorld() const { return _world; }
-    inline void setWorld(PhysicsWorld* world) { _world = world; }
-    inline void setResult(bool result) { _result = result; }
-    inline bool resetResult() { bool ret = _result; _result = true; return ret; }
+    bool isNotificationEnabled() const { return _notificationEnable; }
+    void setNotificationEnable(bool enable) { _notificationEnable = enable; }
+    PhysicsWorld* getWorld() const { return _world; }
+    void setWorld(PhysicsWorld* world) { _world = world; }
+    void setResult(bool result) { _result = result; }
+    bool resetResult() { bool ret = _result; _result = true; return ret; }
     
     void generateContactData();
 

--- a/cocos/physics/CCPhysicsJoint.h
+++ b/cocos/physics/CCPhysicsJoint.h
@@ -57,36 +57,36 @@ protected:
 
 public:
     /**Get physics body a connected to this joint.*/
-    inline PhysicsBody* getBodyA() const { return _bodyA; }
+    PhysicsBody* getBodyA() const { return _bodyA; }
     
     /**Get physics body b connected to this joint.*/
-    inline PhysicsBody* getBodyB() const { return _bodyB; }
+    PhysicsBody* getBodyB() const { return _bodyB; }
 
     /**Get the physics world.*/
-    inline PhysicsWorld* getWorld() const { return _world; }
+    PhysicsWorld* getWorld() const { return _world; }
     
     /**
      * Get this joint's tag.
      *
      * @return An integer number.
      */
-    inline int getTag() const { return _tag; }
+    int getTag() const { return _tag; }
     
     /**
      * Set this joint's tag.
      *
      * @param tag An integer number that identifies a PhysicsJoint.
      */
-    inline void setTag(int tag) { _tag = tag; }
+    void setTag(int tag) { _tag = tag; }
     
     /** Determines if the joint is enable. */
-    inline bool isEnabled() const { return _enable; }
+    bool isEnabled() const { return _enable; }
 
     /** Enable/Disable the joint. */
     void setEnable(bool enable);
     
     /** Determines if the collision is enable. */
-    inline bool isCollisionEnabled() const { return _collisionEnable; }
+    bool isCollisionEnabled() const { return _collisionEnable; }
     
     /** Enable/disable the collision between two bodies. */
     void setCollisionEnable(bool enable);

--- a/cocos/physics/CCPhysicsShape.h
+++ b/cocos/physics/CCPhysicsShape.h
@@ -96,28 +96,28 @@ public:
      *
      * @return A PhysicsBody object pointer.
      */
-    inline PhysicsBody* getBody() const { return _body; }
+    PhysicsBody* getBody() const { return _body; }
     
     /** 
      * Return this shape's type.
      *
      * @return A Type object.
      */
-    inline Type getType() const { return _type; }
+    Type getType() const { return _type; }
 
     /**
      * Return this shape's area.
      *
      * @return A float number.
      */
-    inline float getArea() const { return _area; }
+    float getArea() const { return _area; }
     
     /**
      * Get this shape's moment.
      *
      * @return A float number.
      */
-    inline float getMoment() const { return _moment; }
+    float getMoment() const { return _moment; }
     
     /**
      * Set this shape's moment.
@@ -133,21 +133,21 @@ public:
      *
      * @param tag An integer number that identifies a shape object.
      */
-    inline void setTag(int tag) { _tag = tag; }
+    void setTag(int tag) { _tag = tag; }
     
     /**
      * Get this shape's tag.
      *
      * @return An integer number.
      */
-    inline int getTag() const { return _tag; }
+    int getTag() const { return _tag; }
     
     /**
      * Get the mass of this shape.
      *
      * @return A float number.
      */
-    inline float getMass() const { return _mass; }
+    float getMass() const { return _mass; }
     
     /**
      * Set this shape's mass.
@@ -163,7 +163,7 @@ public:
      *
      * @return A float number.
      */
-    inline float getDensity() const { return _material.density; }
+    float getDensity() const { return _material.density; }
     
     /**
      * Set this shape's density.
@@ -179,7 +179,7 @@ public:
      *
      * @return A float number.
      */
-    inline float getRestitution() const { return _material.restitution; }
+    float getRestitution() const { return _material.restitution; }
     
     /**
      * Set this shape's restitution.
@@ -195,7 +195,7 @@ public:
      *
      * @return A float number.
      */
-    inline float getFriction() const { return _material.friction; }
+    float getFriction() const { return _material.friction; }
     
     /**
      * Set this shape's friction.
@@ -221,7 +221,7 @@ public:
      * @param material A PhysicsMaterial object.
      */
     void setMaterial(const PhysicsMaterial& material);
-    inline bool isSensor() const { return _sensor; }
+    bool isSensor() const { return _sensor; }
     void setSensor(bool sensor);
     
     /** 
@@ -283,14 +283,14 @@ public:
      * Every physics body in a scene can be assigned to up to 32 different categories, each corresponding to a bit in the bit mask. You define the mask values used in your game. In conjunction with the collisionBitMask and contactTestBitMask properties, you define which physics bodies interact with each other and when your game is notified of these interactions.
      * @param bitmask An integer number, the default value is 0xFFFFFFFF (all bits set).
      */
-    inline void setCategoryBitmask(int bitmask) { _categoryBitmask = bitmask; }
+    void setCategoryBitmask(int bitmask) { _categoryBitmask = bitmask; }
     
     /**
      * Get a mask that defines which categories this physics body belongs to.
      *
      * @return An integer number.
      */
-    inline int getCategoryBitmask() const { return _categoryBitmask; }
+    int getCategoryBitmask() const { return _categoryBitmask; }
     
     
     /**
@@ -299,14 +299,14 @@ public:
      * When two bodies share the same space, each body's category mask is tested against the other body's contact mask by performing a logical AND operation. If either comparison results in a non-zero value, an PhysicsContact object is created and passed to the physics world’s delegate. For best performance, only set bits in the contacts mask for interactions you are interested in.
      * @param bitmask An integer number, the default value is 0x00000000 (all bits cleared).
      */
-    inline void setContactTestBitmask(int bitmask) { _contactTestBitmask = bitmask; }
+    void setContactTestBitmask(int bitmask) { _contactTestBitmask = bitmask; }
     
     /**
      * Get a mask that defines which categories of bodies cause intersection notifications with this physics body.
      *
      * @return An integer number.
      */
-    inline int getContactTestBitmask() const { return _contactTestBitmask; }
+    int getContactTestBitmask() const { return _contactTestBitmask; }
 
     /**
      * A mask that defines which categories of physics bodies can collide with this physics body.
@@ -314,14 +314,14 @@ public:
      * When two physics bodies contact each other, a collision may occur. This body's collision mask is compared to the other body's category mask by performing a logical AND operation. If the result is a non-zero value, then this body is affected by the collision. Each body independently chooses whether it wants to be affected by the other body. For example, you might use this to avoid collision calculations that would make negligible changes to a body's velocity.
      * @param bitmask An integer number, the default value is 0xFFFFFFFF (all bits set).
      */
-    inline void setCollisionBitmask(int bitmask) { _collisionBitmask = bitmask; }
+    void setCollisionBitmask(int bitmask) { _collisionBitmask = bitmask; }
     
     /**
      * Get a mask that defines which categories of physics bodies can collide with this physics body.
      *
      * @return An integer number.
      */
-    inline int getCollisionBitmask() const { return _collisionBitmask; }
+    int getCollisionBitmask() const { return _collisionBitmask; }
     
     /**
      * Set the group of body.
@@ -336,7 +336,7 @@ public:
      *
      * @return An integer number.
      */
-    inline int getGroup() { return _group; }
+    int getGroup() { return _group; }
     
 protected:
     void setBody(PhysicsBody* body);

--- a/cocos/physics/CCPhysicsWorld.h
+++ b/cocos/physics/CCPhysicsWorld.h
@@ -228,14 +228,14 @@ public:
     * @attention This value is initialized in constructor
     * @return A Scene object reference.
     */
-    inline Scene& getScene() const { return *_scene; }
+    Scene& getScene() const { return *_scene; }
     
     /**
     * Get the gravity value of this physics world.
     *
     * @return A Vec2 object.
     */
-    inline Vec2 getGravity() const { return _gravity; }
+    Vec2 getGravity() const { return _gravity; }
     
     /**
     * set the gravity value of this physics world.
@@ -250,14 +250,14 @@ public:
      * @attention if you setAutoStep(false), this won't work.
      * @param speed  A float number. Speed is the rate at which the simulation executes. default value is 1.0.
      */
-    inline void setSpeed(float speed) { if(speed >= 0.0f) { _speed = speed; } }
+    void setSpeed(float speed) { if(speed >= 0.0f) { _speed = speed; } }
     
     /**
     * Get the speed of this physics world.
     *
     * @return A float number.
     */
-    inline float getSpeed() { return _speed; }
+    float getSpeed() { return _speed; }
     
     /**
      * Set the update rate of this physics world
@@ -267,7 +267,7 @@ public:
      * @attention if you setAutoStep(false), this won't work.
      * @param rate An integer number, default value is 1.0.
      */
-    inline void setUpdateRate(int rate) { if(rate > 0) { _updateRate = rate; } }
+    void setUpdateRate(int rate) { if(rate > 0) { _updateRate = rate; } }
 
 
     /**
@@ -275,7 +275,7 @@ public:
     *
     * @return An integer number.
     */
-    inline int getUpdateRate() { return _updateRate; }
+    int getUpdateRate() { return _updateRate; }
 
     /**
      * set the number of substeps in an update of the physics world.
@@ -290,7 +290,7 @@ public:
     *
     * @return An integer number.
     */
-    inline int getSubsteps() const { return _substeps; }
+    int getSubsteps() const { return _substeps; }
     
     /**
      * set the number of update of the physics world in a second.
@@ -299,7 +299,7 @@ public:
      */
     void setFixedUpdateRate(int updatesPerSecond) { if(updatesPerSecond > 0) { _fixedRate = updatesPerSecond; } }
     /** get the number of substeps */
-    inline int getFixedUpdateRate() const { return _fixedRate; }
+    int getFixedUpdateRate() const { return _fixedRate; }
 
     /**
     * Set the debug draw mask of this physics world.
@@ -314,7 +314,7 @@ public:
     *
     * @return An integer number.
     */
-    inline int getDebugDrawMask() { return _debugDrawMask; }
+    int getDebugDrawMask() { return _debugDrawMask; }
     
     /**
      * To control the step of physics.

--- a/cocos/platform/CCImage.h
+++ b/cocos/platform/CCImage.h
@@ -136,17 +136,17 @@ public:
     bool initWithRawData(const unsigned char * data, ssize_t dataLen, int width, int height, int bitsPerComponent, bool preMulti = false);
 
     // Getters
-    inline unsigned char *   getData()               { return _data; }
-    inline ssize_t           getDataLen()            { return _dataLen; }
-    inline Format            getFileType()           {return _fileType; }
-    inline Texture2D::PixelFormat getRenderFormat()  { return _renderFormat; }
-    inline int               getWidth()              { return _width; }
-    inline int               getHeight()             { return _height; }
-    inline int               getNumberOfMipmaps()    { return _numberOfMipmaps; }
-    inline MipmapInfo*       getMipmaps()            { return _mipmaps; }
-    inline bool              hasPremultipliedAlpha() { return _hasPremultipliedAlpha; }
-    CC_DEPRECATED_ATTRIBUTE inline bool isPremultipliedAlpha()  { return _hasPremultipliedAlpha;   }
-    inline std::string getFilePath() const { return _filePath; }
+    unsigned char *   getData()               { return _data; }
+    ssize_t           getDataLen()            { return _dataLen; }
+    Format            getFileType()           { return _fileType; }
+    Texture2D::PixelFormat getRenderFormat()  { return _renderFormat; }
+    int               getWidth()              { return _width; }
+    int               getHeight()             { return _height; }
+    int               getNumberOfMipmaps()    { return _numberOfMipmaps; }
+    MipmapInfo*       getMipmaps()            { return _mipmaps; }
+    bool              hasPremultipliedAlpha() { return _hasPremultipliedAlpha; }
+    CC_DEPRECATED_ATTRIBUTE bool isPremultipliedAlpha() { return _hasPremultipliedAlpha; }
+    std::string getFilePath() const { return _filePath; }
 
     int                      getBitPerPixel();
     bool                     hasAlpha();

--- a/cocos/renderer/CCCustomCommand.h
+++ b/cocos/renderer/CCCustomCommand.h
@@ -65,7 +65,7 @@ public:
     */
     void execute();
     //TODO: This function is not used, it should be removed.
-    inline bool isTranslucent() { return true; }
+    bool isTranslucent() { return true; }
     /**Callback function.*/
     std::function<void()> func;
 

--- a/cocos/renderer/CCGLProgram.h
+++ b/cocos/renderer/CCGLProgram.h
@@ -495,10 +495,10 @@ public:
     */
     void reset();
     /** returns the OpenGL Program object */
-    inline GLuint getProgram() const { return _program; }
+    GLuint getProgram() const { return _program; }
 
     /** returns the Uniform flags */
-    inline const UniformFlags& getUniformFlags() const { return _flags; }
+    const UniformFlags& getUniformFlags() const { return _flags; }
 
     //DEPRECATED
     CC_DEPRECATED_ATTRIBUTE bool initWithVertexShaderByteArray(const GLchar* vertexByteArray, const GLchar* fragByteArray)

--- a/cocos/renderer/CCGroupCommand.h
+++ b/cocos/renderer/CCGroupCommand.h
@@ -73,7 +73,7 @@ public:
     void init(float globalOrder);
     
     /**called by renderer, get the group ID.*/
-    inline int getRenderQueueID() const {return _renderQueueID;}
+    int getRenderQueueID() const { return _renderQueueID; }
     
 protected:
     int _renderQueueID;

--- a/cocos/renderer/CCPrimitiveCommand.h
+++ b/cocos/renderer/CCPrimitiveCommand.h
@@ -64,15 +64,15 @@ public:
     CC_DEPRECATED_ATTRIBUTE void init(float globalOrder, GLuint textureID, GLProgramState* glProgramState, BlendFunc blendType, Primitive* primitive,const Mat4& mv);
     
     /**Get the generated material ID.*/
-    inline uint32_t getMaterialID() const { return _materialID; }
+    uint32_t getMaterialID() const { return _materialID; }
     /**Get the texture ID used for drawing.*/
-    inline GLuint getTextureID() const { return _textureID; }
+    GLuint getTextureID() const { return _textureID; }
     /**Get the glprogramstate used for drawing.*/
-    inline GLProgramState* getGLProgramState() const { return _glProgramState; }
+    GLProgramState* getGLProgramState() const { return _glProgramState; }
     /**Get the blend function for drawing.*/
-    inline BlendFunc getBlendType() const { return _blendType; }
+    BlendFunc getBlendType() const { return _blendType; }
     /**Get the modelview matrix when draw the primitive.*/
-    inline const Mat4& getModelView() const { return _mv; }
+    const Mat4& getModelView() const { return _mv; }
     /**Execute and draw the command, called by renderer.*/
     void execute() const;
 protected:

--- a/cocos/renderer/CCRenderCommand.h
+++ b/cocos/renderer/CCRenderCommand.h
@@ -75,28 +75,28 @@ public:
     void init(float globalZOrder, const Mat4& modelViewTransform, uint32_t flags);
     
     /** Get global Z order. */
-    inline float getGlobalOrder() const { return _globalOrder; }
+    float getGlobalOrder() const { return _globalOrder; }
 
     /** Returns the Command type. */
-    inline Type getType() const { return _type; }
+    Type getType() const { return _type; }
     
     /** Returns whether is transparent. */
-    inline bool isTransparent() const { return _isTransparent; }
+    bool isTransparent() const { return _isTransparent; }
     
     /** Set transparent flag. */
-    inline void setTransparent(bool isTransparent) { _isTransparent = isTransparent; }
+    void setTransparent(bool isTransparent) { _isTransparent = isTransparent; }
     /**
      Get skip batching status, if a rendering is skip batching, it will be forced to be rendering separately.
      */
-    inline bool isSkipBatching() const { return _skipBatching; }
+    bool isSkipBatching() const { return _skipBatching; }
     /**Set skip batching.*/
-    inline void setSkipBatching(bool value) { _skipBatching = value; }
+    void setSkipBatching(bool value) { _skipBatching = value; }
     /**Whether the command should be rendered at 3D mode.*/
-    inline bool is3D() const { return _is3D; }
+    bool is3D() const { return _is3D; }
     /**Set the command rendered in 3D mode or not.*/
-    inline void set3D(bool value) { _is3D = value; }
+    void set3D(bool value) { _is3D = value; }
     /**Get the depth by current model view matrix.*/
-    inline float getDepth() const { return _depth; }
+    float getDepth() const { return _depth; }
     
 protected:
     /**Constructor.*/

--- a/cocos/renderer/CCRenderer.h
+++ b/cocos/renderer/CCRenderer.h
@@ -103,9 +103,9 @@ public:
     /**Realloc command queues and reserve with given size. Note: this clears any existing commands.*/
     void realloc(size_t reserveSize);
     /**Get a sub group of the render queue.*/
-    inline std::vector<RenderCommand*>& getSubQueue(QUEUE_GROUP group) { return _commands[group]; }
+    std::vector<RenderCommand*>& getSubQueue(QUEUE_GROUP group) { return _commands[group]; }
     /**Get the number of render commands contained in a subqueue.*/
-    inline ssize_t getSubQueueSize(QUEUE_GROUP group) const { return _commands[group].size();}
+    ssize_t getSubQueueSize(QUEUE_GROUP group) const { return _commands[group].size(); }
 
     /**Save the current DepthState, CullState, DepthWriteState render state.*/
     void saveRenderState();
@@ -201,7 +201,7 @@ public:
     void setDepthTest(bool enable);
     
     //This will not be used outside.
-    inline GroupCommandManager* getGroupCommandManager() const { return _groupCommandManager; };
+    GroupCommandManager* getGroupCommandManager() const { return _groupCommandManager; }
 
     /** returns whether or not a rectangle is visible or not */
     bool checkVisibility(const Mat4& transform, const Size& size);

--- a/cocos/renderer/CCTextureAtlas.h
+++ b/cocos/renderer/CCTextureAtlas.h
@@ -209,9 +209,9 @@ public:
     void listenRendererRecreated(EventCustom* event);
 
     /** Whether or not the array buffer of the VBO needs to be updated.*/
-    inline bool isDirty(void) { return _dirty; }
+    bool isDirty() { return _dirty; }
     /** Specify if the array buffer of the VBO needs to be updated. */
-    inline void setDirty(bool bDirty) { _dirty = bDirty; }
+    void setDirty(bool bDirty) { _dirty = bDirty; }
 
     /**Get quads total amount.
      * @js NA

--- a/cocos/renderer/CCTrianglesCommand.h
+++ b/cocos/renderer/CCTrianglesCommand.h
@@ -75,25 +75,25 @@ public:
     /**Apply the texture, shaders, programs, blend functions to GPU pipeline.*/
     void useMaterial() const;
     /**Get the material id of command.*/
-    inline uint32_t getMaterialID() const { return _materialID; }
+    uint32_t getMaterialID() const { return _materialID; }
     /**Get the openGL texture handle.*/
-    inline GLuint getTextureID() const { return _textureID; }
+    GLuint getTextureID() const { return _textureID; }
     /**Get a const reference of triangles.*/
-    inline const Triangles& getTriangles() const { return _triangles; }
+    const Triangles& getTriangles() const { return _triangles; }
     /**Get the vertex count in the triangles.*/
-    inline ssize_t getVertexCount() const { return _triangles.vertCount; }
+    ssize_t getVertexCount() const { return _triangles.vertCount; }
     /**Get the index count of the triangles.*/
-    inline ssize_t getIndexCount() const { return _triangles.indexCount; }
+    ssize_t getIndexCount() const { return _triangles.indexCount; }
     /**Get the vertex data pointer.*/
-    inline const V3F_C4B_T2F* getVertices() const { return _triangles.verts; }
+    const V3F_C4B_T2F* getVertices() const { return _triangles.verts; }
     /**Get the index data pointer.*/
-    inline const unsigned short* getIndices() const { return _triangles.indices; }
+    const unsigned short* getIndices() const { return _triangles.indices; }
     /**Get the glprogramstate.*/
-    inline GLProgramState* getGLProgramState() const { return _glProgramState; }
+    GLProgramState* getGLProgramState() const { return _glProgramState; }
     /**Get the blend function.*/
-    inline BlendFunc getBlendType() const { return _blendType; }
+    BlendFunc getBlendType() const { return _blendType; }
     /**Get the model view matrix.*/
-    inline const Mat4& getModelView() const { return _mv; }
+    const Mat4& getModelView() const { return _mv; }
     
 protected:
     /**Generate the material ID by textureID, glProgramState, and blend function.*/

--- a/extensions/Particle3D/PU/CCPUDynamicAttribute.h
+++ b/extensions/Particle3D/PU/CCPUDynamicAttribute.h
@@ -43,7 +43,7 @@ enum PUInterpolationType
 */
 struct PUControlPointSorter
 {
-    inline bool operator() (const Vec2& a, const Vec2& b)
+    bool operator() (const Vec2& a, const Vec2& b)
     {
         return a.x < b.x;
     }

--- a/extensions/Particle3D/PU/CCPUEmitter.h
+++ b/extensions/Particle3D/PU/CCPUEmitter.h
@@ -111,85 +111,85 @@ public:
 
         /** Todo
     */
-    inline const std::string& getEmitterType(void) const {return _emitterType;};
+    const std::string& getEmitterType() const { return _emitterType; }
     void setEmitterType(const std::string& emitterType) {_emitterType = emitterType;};
 
     /** Todo
     */
-    inline const std::string& getName(void) const {return _name;};
+    const std::string& getName() const { return _name; }
     void setName(const std::string& name) {_name = name;};
 
     /** Todo
     */
-    inline PUDynamicAttribute* getDynAngle(void) const {return _dynAngle;};
+    PUDynamicAttribute* getDynAngle() const { return _dynAngle; }
     void setDynAngle(PUDynamicAttribute* dynAngle);
 
     /** Todo
     */
-    inline PUDynamicAttribute* getDynEmissionRate(void) const {return _dynEmissionRate;};
+    PUDynamicAttribute* getDynEmissionRate() const { return _dynEmissionRate; }
     void setDynEmissionRate(PUDynamicAttribute* dynEmissionRate);
 
     /** Todo
     */
-    inline PUDynamicAttribute* getDynTotalTimeToLive(void) const {return _dynTotalTimeToLive;};
+    PUDynamicAttribute* getDynTotalTimeToLive() const { return _dynTotalTimeToLive; }
     void setDynTotalTimeToLive(PUDynamicAttribute* dynTotalTimeToLive);
 
     /** Todo
     */
-    inline PUDynamicAttribute* getDynParticleMass(void) const {return _dynParticleMass;};
+    PUDynamicAttribute* getDynParticleMass() const { return _dynParticleMass; }
     void setDynParticleMass(PUDynamicAttribute* dynParticleMass);
 
     /** Todo
     */
-    inline PUDynamicAttribute* getDynVelocity(void) const {return _dynVelocity;};
+    PUDynamicAttribute* getDynVelocity() const { return _dynVelocity; }
     void setDynVelocity(PUDynamicAttribute* dynVelocity);
 
     /** Todo
     */
-    inline PUDynamicAttribute* getDynDuration(void) const {return _dynDuration;};
+    PUDynamicAttribute* getDynDuration() const { return _dynDuration; }
     void setDynDuration(PUDynamicAttribute* dynDuration);
     void setDynDurationSet(bool durationSet);
 
     /** Todo
     */
-    inline PUDynamicAttribute* getDynRepeatDelay(void) const {return _dynRepeatDelay;};
+    PUDynamicAttribute* getDynRepeatDelay() const { return _dynRepeatDelay; }
     void setDynRepeatDelay(PUDynamicAttribute* dynRepeatDelay);
     void setDynRepeatDelaySet(bool repeatDelaySet);
 
     /** Todo
     */
-    inline PUDynamicAttribute* getDynParticleAllDimensions(void) const {return _dynParticleAllDimensions;};
+    PUDynamicAttribute* getDynParticleAllDimensions() const { return _dynParticleAllDimensions; }
     void setDynParticleAllDimensions(PUDynamicAttribute* dynParticleAllDimensions);
     void setDynParticleAllDimensionsSet(bool particleAllDimensionsSet);
 
     /** Todo
     */
-    inline PUDynamicAttribute* getDynParticleWidth(void) const {return _dynParticleWidth;};
+    PUDynamicAttribute* getDynParticleWidth() const { return _dynParticleWidth; }
     void setDynParticleWidth(PUDynamicAttribute* dynParticleWidth);
     void setDynParticleWidthSet(bool particleWidthSet);
 
     /** Todo
     */
-    inline PUDynamicAttribute* getDynParticleHeight(void) const {return _dynParticleHeight;};
+    PUDynamicAttribute* getDynParticleHeight() const { return _dynParticleHeight; }
     void setDynParticleHeight(PUDynamicAttribute* dynParticleHeight);
     void setDynParticleHeightSet(bool particleHeightSet);
 
     /** Todo
     */
-    inline PUDynamicAttribute* getDynParticleDepth(void) const {return _dynParticleDepth;};
+    PUDynamicAttribute* getDynParticleDepth() const { return _dynParticleDepth; }
     void setDynParticleDepth(PUDynamicAttribute* dynParticleDepth);
     void setDynParticleDepthSet(bool particleDepthSet);
 
     ///** Todo
     //*/
-    //inline ParticleType getEmitsType(void) const {return mEmitsType;};
+    //ParticleType getEmitsType() const { return mEmitsType; }
     //void setEmitsType(ParticleType emitsType) {mEmitsType = emitsType;};
 
     /** Todo
     */
-    inline const std::string& getEmitsName(void) const {return _emitsName;};
+    const std::string& getEmitsName() const { return _emitsName; }
     void setEmitsName(const std::string& emitsName);
-    inline PUParticle3D::ParticleType getEmitsType() const {return _emitsType;};
+    PUParticle3D::ParticleType getEmitsType() const { return _emitsType; }
     void setEmitsType(PUParticle3D::ParticleType type) {_emitsType = type;};
     Ref* getEmitsEntityPtr() const;
     bool isMarkedForEmission() const {return _isMarkedForEmission;};

--- a/extensions/Particle3D/PU/CCPUParticleSystem3D.h
+++ b/extensions/Particle3D/PU/CCPUParticleSystem3D.h
@@ -147,24 +147,24 @@ struct CC_DLL PUParticle3D : public Particle3D
 
         /** Sets the event flags.
     */
-    inline void setEventFlags(unsigned int flags) {eventFlags = flags;}
+    void setEventFlags(unsigned int flags) { eventFlags = flags; }
 
     /** As setEventFlags, except the flags passed as parameters are appended to the
         existing flags on this object.
     */
-    inline void addEventFlags(unsigned int flags) {eventFlags |= flags;}
+    void addEventFlags(unsigned int flags) { eventFlags |= flags; }
             
     /** The flags passed as parameters are removed from the existing flags.
     */
-    inline void removeEventFlags(unsigned int flags) {eventFlags &= ~flags;}
+    void removeEventFlags(unsigned int flags) { eventFlags &= ~flags; }
         
     /** Return the event flags.
     */
-    inline unsigned int getEventFlags() const {return eventFlags;}
+    unsigned int getEventFlags() const { return eventFlags; }
 
     /** Determines whether it has certain flags set.
     */
-    inline bool hasEventFlags(unsigned int flags) const {return (eventFlags & flags) != 0;}
+    bool hasEventFlags(unsigned int flags) const { return (eventFlags & flags) != 0; }
 
     unsigned int eventFlags;
 
@@ -268,7 +268,7 @@ public:
      */
     void rotationOffset(Vec3& pos);
 
-    inline float getTimeElapsedSinceStart(void) const {return _timeElapsedSinceStart;};
+    float getTimeElapsedSinceStart() const { return _timeElapsedSinceStart; }
 
     /**
      * default particle width

--- a/extensions/assets-manager/CCEventAssetsManagerEx.h
+++ b/extensions/assets-manager/CCEventAssetsManagerEx.h
@@ -56,21 +56,21 @@ public:
         ERROR_DECOMPRESS
     };
     
-    inline EventCode getEventCode() const { return _code; };
+    EventCode getEventCode() const { return _code; }
     
-    inline int getCURLECode() const { return _curle_code; };
+    int getCURLECode() const { return _curle_code; }
     
-    inline int getCURLMCode() const { return _curlm_code; };
+    int getCURLMCode() const { return _curlm_code; }
     
-    inline std::string getMessage() const { return _message; };
+    std::string getMessage() const { return _message; }
     
-    inline std::string getAssetId() const { return _assetId; };
+    std::string getAssetId() const { return _assetId; }
     
-    inline cocos2d::extension::AssetsManagerEx *getAssetsManagerEx() const { return _manager; };
+    cocos2d::extension::AssetsManagerEx *getAssetsManagerEx() const { return _manager; }
     
-    inline float getPercent() const { return _percent; };
+    float getPercent() const { return _percent; }
     
-    inline float getPercentByFile() const { return _percentByFile; };
+    float getPercentByFile() const { return _percentByFile; }
     
 CC_CONSTRUCTOR_ACCESS:
     /** Constructor */


### PR DESCRIPTION
This pull request removes unnecessary `inline` keywords from member functions defined inside a class definition for the following reasons:
- In C++, any function defined inside the body of a class definition becomes implicitly inline function without `inline` keyword. (For more information, please see this FAQ entry: https://isocpp.org/wiki/faq/inline-functions#inline-member-fns-more.)
- It makes no difference whether you put explicit `inline` or not. [MSDN](https://msdn.microsoft.com/en-us/library/bw1hbe6y.aspx) says: _"In the class declaration, the functions were declared without the inline keyword. The inline keyword can be specified in the class declaration; **the result is the same.**"_
- According to [LLVM Coding Standards](http://llvm.org/docs/CodingStandards.html#don-t-use-inline-when-defining-a-function-in-a-class-definition), LLVM does not recommend the use of `inline` keyword when defining a function in a class definition.

So we can get rid of some `inline` keywords. This will simplify the code for better readability and also keeps backward compatibility.

Thank you for your time and consideration.
