### PR TITLE
Remove semicolons before method bodies

### DIFF
--- a/cocos/platform/ios/CCEAGLView-ios.mm
+++ b/cocos/platform/ios/CCEAGLView-ios.mm
@@ -127,7 +127,7 @@ Copyright (C) 2008 Apple Inc. All Rights Reserved.
     return [self initWithFrame:frame pixelFormat:format depthFormat:0 preserveBackbuffer:NO sharegroup:nil multiSampling:NO numberOfSamples:0];
 }
 
-- (id) initWithFrame:(CGRect)frame pixelFormat:(NSString*)format depthFormat:(GLuint)depth preserveBackbuffer:(BOOL)retained sharegroup:(EAGLSharegroup*)sharegroup multiSampling:(BOOL)sampling numberOfSamples:(unsigned int)nSamples;
+- (id) initWithFrame:(CGRect)frame pixelFormat:(NSString*)format depthFormat:(GLuint)depth preserveBackbuffer:(BOOL)retained sharegroup:(EAGLSharegroup*)sharegroup multiSampling:(BOOL)sampling numberOfSamples:(unsigned int)nSamples
 {
     if((self = [super initWithFrame:frame]))
     {
@@ -178,7 +178,7 @@ Copyright (C) 2008 Apple Inc. All Rights Reserved.
     return self;
 }
 
-- (void)didMoveToWindow;
+- (void)didMoveToWindow
 {
     [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(onUIKeyboardNotification:)
@@ -559,23 +559,23 @@ Copyright (C) 2008 Apple Inc. All Rights Reserved.
 
 /* Text may have a selection, either zero-length (a caret) or ranged.  Editing operations are
  * always performed on the text from this selection.  nil corresponds to no selection. */
-- (void)setSelectedTextRange:(UITextRange *)aSelectedTextRange;
+- (void)setSelectedTextRange:(UITextRange *)aSelectedTextRange
 {
     CCLOG("UITextRange:setSelectedTextRange");
 }
-- (UITextRange *)selectedTextRange;
+- (UITextRange *)selectedTextRange
 {
     return [[[UITextRange alloc] init] autorelease];
 }
 
 #pragma mark UITextInput - Replacing and Returning Text
 
-- (NSString *)textInRange:(UITextRange *)range;
+- (NSString *)textInRange:(UITextRange *)range
 {
     CCLOG("textInRange");
     return @"";
 }
-- (void)replaceRange:(UITextRange *)range withText:(NSString *)theText;
+- (void)replaceRange:(UITextRange *)range withText:(NSString *)theText
 {
     CCLOG("replaceRange");
 }
@@ -592,27 +592,27 @@ Copyright (C) 2008 Apple Inc. All Rights Reserved.
  * Setting marked text either replaces the existing marked text or, if none is present,
  * inserts it from the current selection. */ 
 
-- (void)setMarkedTextRange:(UITextRange *)markedTextRange;
+- (void)setMarkedTextRange:(UITextRange *)markedTextRange
 {
     CCLOG("setMarkedTextRange");
 }
 
-- (UITextRange *)markedTextRange;
+- (UITextRange *)markedTextRange
 {
     CCLOG("markedTextRange");
     return nil; // Nil if no marked text.
 }
-- (void)setMarkedTextStyle:(NSDictionary *)markedTextStyle;
+- (void)setMarkedTextStyle:(NSDictionary *)markedTextStyle
 {
     CCLOG("setMarkedTextStyle");
     
 }
-- (NSDictionary *)markedTextStyle;
+- (NSDictionary *)markedTextStyle
 {
     CCLOG("markedTextStyle");
     return nil;
 }
-- (void)setMarkedText:(NSString *)markedText selectedRange:(NSRange)selectedRange;
+- (void)setMarkedText:(NSString *)markedText selectedRange:(NSRange)selectedRange
 {
     CCLOG("setMarkedText");
     if (markedText == markedText_) {
@@ -624,7 +624,7 @@ Copyright (C) 2008 Apple Inc. All Rights Reserved.
     markedText_ = markedText;
     [markedText_ retain];
 }
-- (void)unmarkText;
+- (void)unmarkText
 {
     CCLOG("unmarkText");
     if (nil == markedText_)
@@ -639,40 +639,40 @@ Copyright (C) 2008 Apple Inc. All Rights Reserved.
 
 #pragma mark Methods for creating ranges and positions.
 
-- (UITextRange *)textRangeFromPosition:(UITextPosition *)fromPosition toPosition:(UITextPosition *)toPosition;
+- (UITextRange *)textRangeFromPosition:(UITextPosition *)fromPosition toPosition:(UITextPosition *)toPosition
 {
     CCLOG("textRangeFromPosition");
     return nil;
 }
-- (UITextPosition *)positionFromPosition:(UITextPosition *)position offset:(NSInteger)offset;
+- (UITextPosition *)positionFromPosition:(UITextPosition *)position offset:(NSInteger)offset
 {
     CCLOG("positionFromPosition");
     return nil;
 }
-- (UITextPosition *)positionFromPosition:(UITextPosition *)position inDirection:(UITextLayoutDirection)direction offset:(NSInteger)offset;
+- (UITextPosition *)positionFromPosition:(UITextPosition *)position inDirection:(UITextLayoutDirection)direction offset:(NSInteger)offset
 {
     CCLOG("positionFromPosition");
     return nil;
 }
 
 /* Simple evaluation of positions */
-- (NSComparisonResult)comparePosition:(UITextPosition *)position toPosition:(UITextPosition *)other;
+- (NSComparisonResult)comparePosition:(UITextPosition *)position toPosition:(UITextPosition *)other
 {
     CCLOG("comparePosition");
     return (NSComparisonResult)0;
 }
-- (NSInteger)offsetFromPosition:(UITextPosition *)from toPosition:(UITextPosition *)toPosition;
+- (NSInteger)offsetFromPosition:(UITextPosition *)from toPosition:(UITextPosition *)toPosition
 {
     CCLOG("offsetFromPosition");
     return 0;
 }
 
-- (UITextPosition *)positionWithinRange:(UITextRange *)range farthestInDirection:(UITextLayoutDirection)direction;
+- (UITextPosition *)positionWithinRange:(UITextRange *)range farthestInDirection:(UITextLayoutDirection)direction
 {
     CCLOG("positionWithinRange");
     return nil;
 }
-- (UITextRange *)characterRangeByExtendingPosition:(UITextPosition *)position inDirection:(UITextLayoutDirection)direction;
+- (UITextRange *)characterRangeByExtendingPosition:(UITextPosition *)position inDirection:(UITextLayoutDirection)direction
 {
     CCLOG("characterRangeByExtendingPosition");
     return nil;
@@ -680,12 +680,12 @@ Copyright (C) 2008 Apple Inc. All Rights Reserved.
 
 #pragma mark Writing direction
 
-- (UITextWritingDirection)baseWritingDirectionForPosition:(UITextPosition *)position inDirection:(UITextStorageDirection)direction;
+- (UITextWritingDirection)baseWritingDirectionForPosition:(UITextPosition *)position inDirection:(UITextStorageDirection)direction
 {
     CCLOG("baseWritingDirectionForPosition");
     return UITextWritingDirectionNatural;
 }
-- (void)setBaseWritingDirection:(UITextWritingDirection)writingDirection forRange:(UITextRange *)range;
+- (void)setBaseWritingDirection:(UITextWritingDirection)writingDirection forRange:(UITextRange *)range
 {
     CCLOG("setBaseWritingDirection");
 }
@@ -693,12 +693,12 @@ Copyright (C) 2008 Apple Inc. All Rights Reserved.
 #pragma mark Geometry
 
 /* Geometry used to provide, for example, a correction rect. */
-- (CGRect)firstRectForRange:(UITextRange *)range;
+- (CGRect)firstRectForRange:(UITextRange *)range
 {
     CCLOG("firstRectForRange");
     return CGRectNull;
 }
-- (CGRect)caretRectForPosition:(UITextPosition *)position;
+- (CGRect)caretRectForPosition:(UITextPosition *)position
 {
     CCLOG("caretRectForPosition");
     return caretRect_;
@@ -707,17 +707,17 @@ Copyright (C) 2008 Apple Inc. All Rights Reserved.
 #pragma mark Hit testing
 
 /* JS - Find the closest position to a given point */
-- (UITextPosition *)closestPositionToPoint:(CGPoint)point;
+- (UITextPosition *)closestPositionToPoint:(CGPoint)point
 {
     CCLOG("closestPositionToPoint");
     return nil;
 }
-- (UITextPosition *)closestPositionToPoint:(CGPoint)point withinRange:(UITextRange *)range;
+- (UITextPosition *)closestPositionToPoint:(CGPoint)point withinRange:(UITextRange *)range
 {
     CCLOG("closestPositionToPoint");
     return nil;
 }
-- (UITextRange *)characterRangeAtPoint:(CGPoint)point;
+- (UITextRange *)characterRangeAtPoint:(CGPoint)point
 {
     CCLOG("characterRangeAtPoint");
     return nil;
@@ -731,7 +731,7 @@ Copyright (C) 2008 Apple Inc. All Rights Reserved.
 
 #pragma mark - UIKeyboard notification
 
-- (void)onUIKeyboardNotification:(NSNotification *)notif;
+- (void)onUIKeyboardNotification:(NSNotification *)notif
 {
     NSString * type = notif.name;
     

--- a/cocos/ui/UIEditBox/Mac/CCUIEditBoxMac.mm
+++ b/cocos/ui/UIEditBox/Mac/CCUIEditBoxMac.mm
@@ -292,7 +292,7 @@
     self.textInput.ccui_text = text;
 }
 
-- (BOOL)textShouldBeginEditing:(NSText *)textObject;        // YES means do it
+- (BOOL)textShouldBeginEditing:(NSText *)textObject        // YES means do it
 {
     _editState = YES;
     

--- a/cocos/ui/UIEditBox/iOS/CCUIEditBoxIOS.mm
+++ b/cocos/ui/UIEditBox/iOS/CCUIEditBoxIOS.mm
@@ -336,7 +336,7 @@
     return YES;
 }
 
-- (BOOL)textViewShouldEndEditing:(UITextView *)textView;
+- (BOOL)textViewShouldEndEditing:(UITextView *)textView
 {
     CCLOG("textFieldShouldEndEditing...");
     _editState = NO;


### PR DESCRIPTION
Hello. When building libcocos2d for iOS with Xcode 7.3.1 and `-Wsemicolon-before-method-body` compiler option, I'm getting the following warnings:

```
cocos/platform/ios/CCEAGLView-ios.mm:130:232: warning: semicolon before method body is ignored [-Wsemicolon-before-method-body]
cocos/platform/ios/CCEAGLView-ios.mm:181:24: warning: semicolon before method body is ignored [-Wsemicolon-before-method-body]
cocos/platform/ios/CCEAGLView-ios.mm:562:63: warning: semicolon before method body is ignored [-Wsemicolon-before-method-body]
cocos/platform/ios/CCEAGLView-ios.mm:566:35: warning: semicolon before method body is ignored [-Wsemicolon-before-method-body]
cocos/platform/ios/CCEAGLView-ios.mm:573:47: warning: semicolon before method body is ignored [-Wsemicolon-before-method-body]
cocos/platform/ios/CCEAGLView-ios.mm:578:71: warning: semicolon before method body is ignored [-Wsemicolon-before-method-body]
cocos/platform/ios/CCEAGLView-ios.mm:595:58: warning: semicolon before method body is ignored [-Wsemicolon-before-method-body]
cocos/platform/ios/CCEAGLView-ios.mm:600:33: warning: semicolon before method body is ignored [-Wsemicolon-before-method-body]
cocos/platform/ios/CCEAGLView-ios.mm:605:59: warning: semicolon before method body is ignored [-Wsemicolon-before-method-body]
cocos/platform/ios/CCEAGLView-ios.mm:610:34: warning: semicolon before method body is ignored [-Wsemicolon-before-method-body]
cocos/platform/ios/CCEAGLView-ios.mm:615:82: warning: semicolon before method body is ignored [-Wsemicolon-before-method-body]
cocos/platform/ios/CCEAGLView-ios.mm:627:19: warning: semicolon before method body is ignored [-Wsemicolon-before-method-body]
cocos/platform/ios/CCEAGLView-ios.mm:642:110: warning: semicolon before method body is ignored [-Wsemicolon-before-method-body]
cocos/platform/ios/CCEAGLView-ios.mm:647:93: warning: semicolon before method body is ignored [-Wsemicolon-before-method-body]
cocos/platform/ios/CCEAGLView-ios.mm:652:138: warning: semicolon before method body is ignored [-Wsemicolon-before-method-body]
cocos/platform/ios/CCEAGLView-ios.mm:652:138: warning: semicolon before method body is ignored [-Wsemicolon-before-method-body]
cocos/platform/ios/CCEAGLView-ios.mm:664:95: warning: semicolon before method body is ignored [-Wsemicolon-before-method-body]
cocos/platform/ios/CCEAGLView-ios.mm:670:114: warning: semicolon before method body is ignored [-Wsemicolon-before-method-body]
cocos/platform/ios/CCEAGLView-ios.mm:675:123: warning: semicolon before method body is ignored [-Wsemicolon-before-method-body]
cocos/platform/ios/CCEAGLView-ios.mm:683:131: warning: semicolon before method body is ignored [-Wsemicolon-before-method-body]
cocos/platform/ios/CCEAGLView-ios.mm:688:103: warning: semicolon before method body is ignored [-Wsemicolon-before-method-body]
cocos/platform/ios/CCEAGLView-ios.mm:696:49: warning: semicolon before method body is ignored [-Wsemicolon-before-method-body]
cocos/platform/ios/CCEAGLView-ios.mm:701:58: warning: semicolon before method body is ignored [-Wsemicolon-before-method-body]
cocos/platform/ios/CCEAGLView-ios.mm:710:58: warning: semicolon before method body is ignored [-Wsemicolon-before-method-body]
cocos/platform/ios/CCEAGLView-ios.mm:715:91: warning: semicolon before method body is ignored [-Wsemicolon-before-method-body]
cocos/platform/ios/CCEAGLView-ios.mm:720:54: warning: semicolon before method body is ignored [-Wsemicolon-before-method-body]
cocos/platform/ios/CCEAGLView-ios.mm:734:57: warning: semicolon before method body is ignored [-Wsemicolon-before-method-body]
cocos/ui/UIEditBox/iOS/CCUIEditBoxIOS.mm:339:56: warning: semicolon before method body is ignored [-Wsemicolon-before-method-body]
```

And also I get the same warning when compiling for Mac:

```
cocos/ui/UIEditBox/Mac/CCUIEditBoxMac.mm:295:52: warning: semicolon before method body is ignored [-Wsemicolon-before-method-body]
```

This gets rid of unneeded semicolons before Objective-C method bodies. Thanks.
