### PR TITLE
[DON'T MERGE] Initial update so that Sprites work as before (with one exception)

### DIFF
--- a/cocos/2d/CCSprite.cpp
+++ b/cocos/2d/CCSprite.cpp
@@ -289,7 +289,7 @@ bool Sprite::initWithTexture(Texture2D *texture, const Rect& rect, bool rotated)
         _quad.tr.colors = Color4B::WHITE;
         
         // shader state
-        // setGLProgramState(GLProgramState::getOrCreateWithGLProgramName(GLProgram::SHADER_NAME_POSITION_TEXTURE_COLOR_NO_MVP)); 
+        setGLProgramState(GLProgramState::getOrCreateWithGLProgramName(GLProgram::SHADER_NAME_POSITION_TEXTURE_COLOR_NO_MVP));
 
         // update texture (calls updateBlendFunc)
         setTexture(texture);
@@ -365,12 +365,18 @@ void Sprite::setTexture(const std::string &filename)
 
 void Sprite::setTexture(Texture2D *texture)
 {
-    setGLProgramState(GLProgramState::getOrCreateWithGLProgramName(GLProgram::SHADER_NAME_POSITION_TEXTURE_COLOR_NO_MVP, texture));
-
     // If batchnode, then texture id should be the same
     CCASSERT(! _batchNode || (texture &&  texture->getName() == _batchNode->getTexture()->getName()), "CCSprite: Batched sprites should use the same texture as the batchnode");
     // accept texture==nil as argument
     CCASSERT( !texture || dynamic_cast<Texture2D*>(texture), "setTexture expects a Texture2D. Invalid argument");
+    // ETC1Alpha -> other not supported
+    CCASSERT(_texture->getAlphaTextureName() == 0 && texture->getAlphaTextureName() != 0
+             , "Setting a non-ETC1Alpha texture on a Sprite that has an ETC1Alpha texture is not currently supported!");
+    if (texture->getAlphaTextureName() != 0)
+    {
+        setGLProgramState(GLProgramState::getOrCreateWithGLProgramName(GLProgram::SHADER_NAME_POSITION_TEXTURE_COLOR_NO_MVP, texture));
+    }
+    // TODO: Need to fix this so that it supports all textures AND custom shaders
 
     if (texture == nullptr)
     {

--- a/cocos/2d/CCSprite.cpp
+++ b/cocos/2d/CCSprite.cpp
@@ -370,9 +370,9 @@ void Sprite::setTexture(Texture2D *texture)
     // accept texture==nil as argument
     CCASSERT( !texture || dynamic_cast<Texture2D*>(texture), "setTexture expects a Texture2D. Invalid argument");
     // ETC1Alpha -> other not supported
-    CCASSERT(_texture->getAlphaTextureName() == 0 && texture->getAlphaTextureName() != 0
+    CCASSERT( ! (texture && texture->getAlphaTextureName() == 0 && _texture && _texture->getAlphaTextureName() != 0)
              , "Setting a non-ETC1Alpha texture on a Sprite that has an ETC1Alpha texture is not currently supported!");
-    if (texture->getAlphaTextureName() != 0)
+    if ( texture && texture->getAlphaTextureName() != 0 )
     {
         setGLProgramState(GLProgramState::getOrCreateWithGLProgramName(GLProgram::SHADER_NAME_POSITION_TEXTURE_COLOR_NO_MVP, texture));
     }

--- a/tests/cpp-tests/Classes/SpriteTest/SpriteTest.cpp
+++ b/tests/cpp-tests/Classes/SpriteTest/SpriteTest.cpp
@@ -303,8 +303,8 @@ void Sprite1ETC1AlphaChangeTest::changeSpriteTexture()
         _sprite1->setTexture("Images/etc1-alpha.pkm");
         _sprite1->setTag(11);
     } else {
+        _sprite1->setTexture("Images/r1.png");
         _sprite1->setTag(1);
-        _sprite1->setTexture("grossini_dance_01.png");
     }
 }
 

--- a/tests/cpp-tests/Classes/SpriteTest/SpriteTest.cpp
+++ b/tests/cpp-tests/Classes/SpriteTest/SpriteTest.cpp
@@ -284,35 +284,33 @@ bool Sprite1ETC1AlphaChangeTest::init()
     if (!SpriteTestDemo::init())
         return false;
 
-    _background = Sprite::create("Images/background2.png");
     auto s = Director::getInstance()->getWinSize();
+
+    _background = Sprite::create("Images/background2.png");
     _background->setPosition(Vec2(s.width / 2, s.height / 2));
     this->addChild(_background);
 
-    auto _sprite1 = Sprite::create("Images/etc1-alpha.pkm");
+    _sprite1 = Sprite::create("Images/etc1-alpha.pkm");
     _sprite1->setPosition(Vec2(s.width / 2, s.height / 2));
     _background->addChild(_sprite1);
 
     return true;
 }
 
-void Sprite1ETC1AlphaChangeTest::changeSpriteWithCoords(Vec2 p)
+void Sprite1ETC1AlphaChangeTest::changeSpriteTexture()
 {
-    if (_sprite1->getTag() == 0) {
-        _sprite1->setTexture("grossini_dance_01.png");
-    } else {
+    if (_sprite1->getTag() == 1) {
         _sprite1->setTexture("Images/etc1-alpha.pkm");
+        _sprite1->setTag(11);
+    } else {
+        _sprite1->setTag(1);
+        _sprite1->setTexture("grossini_dance_01.png");
     }
 }
 
 void Sprite1ETC1AlphaChangeTest::onTouchesEnded(const std::vector<Touch*>& touches, Event* event)
 {
-    for (auto touch : touches)
-    {
-        auto location = touch->getLocation();
-
-        changeSpriteWithCoords(location);
-    }
+    changeSpriteTexture();
 }
 
 std::string Sprite1ETC1AlphaChangeTest::title() const

--- a/tests/cpp-tests/Classes/SpriteTest/SpriteTest.cpp
+++ b/tests/cpp-tests/Classes/SpriteTest/SpriteTest.cpp
@@ -57,6 +57,7 @@ SpriteTests::SpriteTests()
 {
     ADD_TEST_CASE(Sprite1);
     ADD_TEST_CASE(Sprite1ETC1Alpha);
+    ADD_TEST_CASE(Sprite1ETC1AlphaChangeTest);
     ADD_TEST_CASE(SpriteBatchNode1);
     ADD_TEST_CASE(SpriteAnchorPoint);
     ADD_TEST_CASE(SpriteBatchNodeAnchorPoint);
@@ -263,6 +264,65 @@ std::string Sprite1ETC1Alpha::title() const
 std::string Sprite1ETC1Alpha::subtitle() const
 {
     return "Tap screen to add more sprites";
+}
+
+//------------------------------------------------------------------
+//
+// Sprite1ETC1AlphaChangeTest
+//
+//------------------------------------------------------------------
+
+Sprite1ETC1AlphaChangeTest::Sprite1ETC1AlphaChangeTest()
+{
+    auto listener = EventListenerTouchAllAtOnce::create();
+    listener->onTouchesEnded = CC_CALLBACK_2(Sprite1ETC1AlphaChangeTest::onTouchesEnded, this);
+    _eventDispatcher->addEventListenerWithSceneGraphPriority(listener, this);
+}
+
+bool Sprite1ETC1AlphaChangeTest::init()
+{
+    if (!SpriteTestDemo::init())
+        return false;
+
+    _background = Sprite::create("Images/background2.png");
+    auto s = Director::getInstance()->getWinSize();
+    _background->setPosition(Vec2(s.width / 2, s.height / 2));
+    this->addChild(_background);
+
+    auto _sprite1 = Sprite::create("Images/etc1-alpha.pkm");
+    _sprite1->setPosition(Vec2(s.width / 2, s.height / 2));
+    _background->addChild(_sprite1);
+
+    return true;
+}
+
+void Sprite1ETC1AlphaChangeTest::changeSpriteWithCoords(Vec2 p)
+{
+    if (_sprite1->getTag() == 0) {
+        _sprite1->setTexture("grossini_dance_01.png");
+    } else {
+        _sprite1->setTexture("Images/etc1-alpha.pkm");
+    }
+}
+
+void Sprite1ETC1AlphaChangeTest::onTouchesEnded(const std::vector<Touch*>& touches, Event* event)
+{
+    for (auto touch : touches)
+    {
+        auto location = touch->getLocation();
+
+        changeSpriteWithCoords(location);
+    }
+}
+
+std::string Sprite1ETC1AlphaChangeTest::title() const
+{
+    return "Testing Sprite ETC1Alpha change texture to non-ETC1Alpha support";
+}
+
+std::string Sprite1ETC1AlphaChangeTest::subtitle() const
+{
+    return "Tap screen to change texture";
 }
 
 //------------------------------------------------------------------

--- a/tests/cpp-tests/Classes/SpriteTest/SpriteTest.h
+++ b/tests/cpp-tests/Classes/SpriteTest/SpriteTest.h
@@ -66,6 +66,22 @@ public:
     cocos2d::Sprite* _background;
 };
 
+class Sprite1ETC1AlphaChangeTest : public SpriteTestDemo
+{
+public:
+    CREATE_FUNC(Sprite1ETC1AlphaChangeTest);
+    Sprite1ETC1AlphaChangeTest();
+    bool init() override;
+    virtual std::string title() const override;
+    virtual std::string subtitle() const override;
+
+    void changeSpriteWithCoords(cocos2d::Vec2 p);
+    void onTouchesEnded(const std::vector<cocos2d::Touch*>& touches, cocos2d::Event* event);
+
+    cocos2d::Sprite* _background;
+    cocos2d::Sprite* _sprite1;
+};
+
 class SpriteBatchNode1: public SpriteTestDemo
 {
 public:

--- a/tests/cpp-tests/Classes/SpriteTest/SpriteTest.h
+++ b/tests/cpp-tests/Classes/SpriteTest/SpriteTest.h
@@ -75,7 +75,7 @@ public:
     virtual std::string title() const override;
     virtual std::string subtitle() const override;
 
-    void changeSpriteWithCoords(cocos2d::Vec2 p);
+    void changeSpriteTexture();
     void onTouchesEnded(const std::vector<cocos2d::Touch*>& touches, cocos2d::Event* event);
 
     cocos2d::Sprite* _background;


### PR DESCRIPTION
There's an issue still when you change texture from ETC1Alpha to another texture type.

The fundamental issue I see with the PR [16118](https://github.com/cocos2d/cocos2d-x/pull/16118)  is that ETC1 is treated as a normal use case when I think that it should almost have its own SpriteETC1Alpha class derived from Sprite overriding a couple of the methods.

However, people probably would like to be able to create a sprite and then set it's texture to some texture type (e.g. ETC1Alpha) and then later change it to a different texture type and vice versa.

This PR will attempt to find the best way to support that as well as allow for setting custom shader commands. If this is not straightforward then documentation may be necessary to note that if one wants to change a Sprite from one texture type to another may be required to update the GLProgramState manually after every setTexture call.
