### PR TITLE
Suppress warning C4101 on MSVC

### DIFF
--- a/cocos/scripting/js-bindings/manual/ScriptingCore.h
+++ b/cocos/scripting/js-bindings/manual/ScriptingCore.h
@@ -561,9 +561,8 @@ bool jsb_get_reserved_slot(JSObject *obj, uint32_t idx, jsval& ret);
 template <class T>
 js_type_class_t *jsb_register_class(JSContext *cx, JSClass *jsClass, JS::HandleObject proto, JS::HandleObject parentProto)
 {
-    TypeTest<T> t;
     js_type_class_t *p = nullptr;
-    std::string typeName = t.s_name();
+    std::string typeName = TypeTest<T>::s_name();
     if (_js_global_type_map.find(typeName) == _js_global_type_map.end())
     {
         JS::RootedObject protoRoot(cx, proto);

--- a/cocos/scripting/lua-bindings/manual/cocos2d/lua_cocos2dx_manual.cpp
+++ b/cocos/scripting/lua-bindings/manual/cocos2d/lua_cocos2dx_manual.cpp
@@ -3201,9 +3201,8 @@ int tolua_cocos2dx_DrawNode_drawCardinalSpline(lua_State* tolua_S)
     cocos2d::DrawNode* self = nullptr;
     bool ok  = true;
 
-    tolua_Error tolua_err;
-
 #if COCOS2D_DEBUG >= 1
+    tolua_Error tolua_err;
     if (!tolua_isusertype(tolua_S,1,"cc.DrawNode",0,&tolua_err)) goto tolua_lerror;
 #endif
 
@@ -3267,9 +3266,8 @@ int tolua_cocos2dx_DrawNode_drawCatmullRom(lua_State* tolua_S)
     cocos2d::DrawNode* self = nullptr;
     bool ok  = true;
 
-    tolua_Error tolua_err;
-
 #if COCOS2D_DEBUG >= 1
+    tolua_Error tolua_err;
     if (!tolua_isusertype(tolua_S,1,"cc.DrawNode",0,&tolua_err)) goto tolua_lerror;
 #endif
 


### PR DESCRIPTION
This patch fixes the following warnings [C4101](https://msdn.microsoft.com/en-us/library/c733d5h9.aspx) when building with Visual Studio 2015:

```
cocos\scripting/js-bindings/manual/ScriptingCore.h(564): warning C4101: 't' : unreferenced local variable
..\manual\cocos2d\lua_cocos2dx_manual.cpp(3204): warning C4101: 'tolua_err' : unreferenced local variable
..\manual\cocos2d\lua_cocos2dx_manual.cpp(3270): warning C4101: 'tolua_err' : unreferenced local variable
```

Thanks!
