### PR TITLE
Fix -Wpessimizing-move warning when using Xcode 8

### DIFF
--- a/cocos/editor-support/cocostudio/CCDataReaderHelper.cpp
+++ b/cocos/editor-support/cocostudio/CCDataReaderHelper.cpp
@@ -147,7 +147,7 @@ static std::string readFileContent(const std::string& filename, bool binary) {
     if (binary)
         fs->getContents(filename, &s);
     else
-        s = std::move(fs->getStringFromFile(filename));
+        s = fs->getStringFromFile(filename);
     return s;
 };
 


### PR DESCRIPTION
This PR removes a superfluous `std::move` causing the following warning when building with `-Wpessimizing-move` compiler option on Xcode 8.0 (probably it can be reproduced on Xcode 7.3+):

```
cocos/editor-support/cocostudio/CCDataReaderHelper.cpp:150:13: warning: moving a temporary object prevents copy elision [-Wpessimizing-move]
        s = std::move(fs->getStringFromFile(filename));
            ^
cocos/editor-support/cocostudio/CCDataReaderHelper.cpp:150:13: note: remove std::move call here
        s = std::move(fs->getStringFromFile(filename));
            ^~~~~~~~~~                               ~
```
