### PR TITLE
Move skipBOM function outside to prevent shadowing warning

### DIFF
--- a/cocos/scripting/lua-bindings/manual/CCLuaStack.cpp
+++ b/cocos/scripting/lua-bindings/manual/CCLuaStack.cpp
@@ -844,20 +844,25 @@ int LuaStack::luaLoadChunksFromZIP(lua_State *L)
     return 1;
 }
 
+namespace {
+
+void skipBOM(const char*& chunk, int& chunkSize)
+{
+    // UTF-8 BOM? skip
+    if (static_cast<unsigned char>(chunk[0]) == 0xEF &&
+        static_cast<unsigned char>(chunk[1]) == 0xBB &&
+        static_cast<unsigned char>(chunk[2]) == 0xBF)
+    {
+        chunk += 3;
+        chunkSize -= 3;
+    }
+}
+
+} // end anonymous namespace
+
 int LuaStack::luaLoadBuffer(lua_State *L, const char *chunk, int chunkSize, const char *chunkName)
 {
     int r = 0;
-    
-    auto skipBOM = [](const char*& chunk, int& chunkSize){
-        // UTF-8 BOM? skip
-        if (static_cast<unsigned char>(chunk[0]) == 0xEF &&
-            static_cast<unsigned char>(chunk[1]) == 0xBB &&
-            static_cast<unsigned char>(chunk[2]) == 0xBF)
-        {
-            chunk += 3;
-            chunkSize -= 3;
-        }
-    };
 
     if (_xxteaEnabled && strncmp(chunk, _xxteaSign, _xxteaSignLen) == 0)
     {


### PR DESCRIPTION
I'm getting the following warning message when compiling libluacocos2d with Xcode 8.0:

```
cocos/scripting/lua-bindings/manual/CCLuaStack.cpp:851:36: declaration shadows a local variable [-Wshadow]

    auto skipBOM = [](const char*& chunk, int& chunkSize){
                  ^

cocos/scripting/lua-bindings/manual/CCLuaStack.cpp:851:48: declaration shadows a local variable [-Wshadow]

    auto skipBOM = [](const char*& chunk, int& chunkSize){
                                                      ^
```

This patch moves `skipBOM` function definition outside of `luaLoadBuffer` function to prevent those warnings.
Thanks!
