### PR TITLE
Fix _BSD_SOURCE deprecated warning

### DIFF
--- a/cocos/scripting/lua-bindings/CMakeLists.txt
+++ b/cocos/scripting/lua-bindings/CMakeLists.txt
@@ -44,7 +44,7 @@ elseif(UNIX)
     # because we have -std=c99
     add_definitions(-D_POSIX_C_SOURCE=200809L)
     if(LINUX)
-        add_definitions(-D_BSD_SOURCE)
+        add_definitions(-D_BSD_SOURCE -D_DEFAULT_SOURCE)
     endif()
     if(APPLE)
         add_definitions(-D_DARWIN_C_SOURCE)


### PR DESCRIPTION
To define `_BSD_SOURCE` macro is deprecated since glibc 2.20.

```
In file included from /usr/include/assert.h:35:0,
                 from /home/user/local/cocos2d-x/external/lua/lua/lapi.c:8:
/usr/include/features.h:148:3: warning: #warning "_BSD_SOURCE and _SVID_SOURCE are deprecated, use _DEFAULT_SOURCE" [-Wcpp]
 # warning "_BSD_SOURCE and _SVID_SOURCE are deprecated, use _DEFAULT_SOURCE"
   ^~~~~~~
```

According to the [man page](http://man7.org/linux/man-pages/man7/feature_test_macros.7.html) `_BSD_SOURCE` section, to define both `_BSD_SOURCE` and `_DEFAULT_SOURCE` suppresses the warnings and keeps backward compatibility.
This PR adds it.
I compile cocos2d-x using Linux gcc 6.2.1 and glibc 2.24.
