### PR TITLE
Remove extra semicolon after member function definition

### DIFF
--- a/cocos/2d/CCFastTMXLayer.h
+++ b/cocos/2d/CCFastTMXLayer.h
@@ -210,7 +210,7 @@ public:
         CC_SAFE_RETAIN(info);
         CC_SAFE_RELEASE(_tileSet);
         _tileSet = info;
-    };
+    }
     
     /** Layer orientation, which is the same as the map orientation.
      *
@@ -243,7 +243,7 @@ public:
     void setProperties(const ValueMap& properties)
     {
         _properties = properties;
-    };
+    }
 
     /** Returns the tile (Sprite) at a given a tile coordinate.
      * The returned Sprite will be already added to the TMXLayer. Don't add it again.

--- a/cocos/2d/CCFastTMXTiledMap.h
+++ b/cocos/2d/CCFastTMXTiledMap.h
@@ -186,7 +186,7 @@ public:
      */
     void setObjectGroups(const Vector<TMXObjectGroup*>& groups) {
         _objectGroups = groups;
-    };
+    }
     
     /** Get properties.
      *
@@ -200,7 +200,7 @@ public:
      */
     void setProperties(const ValueMap& properties) {
         _properties = properties;
-    };
+    }
 
     virtual std::string getDescription() const override;
 

--- a/cocos/2d/CCTMXLayer.h
+++ b/cocos/2d/CCTMXLayer.h
@@ -127,7 +127,7 @@ public:
      */
     CC_DEPRECATED_ATTRIBUTE uint32_t tileGIDAt(const Vec2& tileCoordinate, TMXTileFlags* flags = nullptr){
         return getTileGIDAt(tileCoordinate, flags);
-    };
+    }
 
     /** Sets the tile gid (gid = tile global id) at a given tile coordinate.
      * The Tile GID can be obtained by using the method "tileGIDAt" or by using the TMX editor -> Tileset Mgr +1.
@@ -245,7 +245,7 @@ public:
         CC_SAFE_RETAIN(info);
         CC_SAFE_RELEASE(_tileSet);
         _tileSet = info;
-    };
+    }
     
     /** Layer orientation, which is the same as the map orientation.
      *
@@ -277,7 +277,7 @@ public:
      */
     void setProperties(const ValueMap& properties) {
         _properties = properties;
-    };
+    }
     //
     // Override
     //

--- a/cocos/2d/CCTMXObjectGroup.h
+++ b/cocos/2d/CCTMXObjectGroup.h
@@ -111,7 +111,7 @@ public:
      */
     void setProperties(const ValueMap& properties) {
         _properties = properties;
-    };
+    }
     
     /** Gets the array of the objects. 
      *
@@ -126,7 +126,7 @@ public:
      */
     void setObjects(const ValueVector& objects) {
         _objects = objects;
-    };
+    }
     
 protected:
     /** name of the group */

--- a/cocos/2d/CCTMXTiledMap.h
+++ b/cocos/2d/CCTMXTiledMap.h
@@ -251,7 +251,7 @@ public:
      */
     void setObjectGroups(const Vector<TMXObjectGroup*>& groups) {
         _objectGroups = groups;
-    };
+    }
     
     /** Properties. 
      *
@@ -265,7 +265,7 @@ public:
      */
     void setProperties(const ValueMap& properties) {
         _properties = properties;
-    };
+    }
     
     /** Get the description.
      * @js NA

--- a/cocos/2d/CCTMXXMLParser.h
+++ b/cocos/2d/CCTMXXMLParser.h
@@ -203,7 +203,7 @@ public:
     ValueMapIntKey& getTileProperties() { return _tileProperties; };
     void setTileProperties(const ValueMapIntKey& tileProperties) {
         _tileProperties = tileProperties;
-    };
+    }
 
     /// map orientation
     int getOrientation() const { return _orientation; }
@@ -234,21 +234,21 @@ public:
     Vector<TMXLayerInfo*>& getLayers() { return _layers; }
     void setLayers(const Vector<TMXLayerInfo*>& layers) {
         _layers = layers;
-    };
+    }
 
     /// tilesets
     const Vector<TMXTilesetInfo*>& getTilesets() const { return _tilesets; }
     Vector<TMXTilesetInfo*>& getTilesets() { return _tilesets; }
     void setTilesets(const Vector<TMXTilesetInfo*>& tilesets) {
         _tilesets = tilesets;
-    };
+    }
 
     /// ObjectGroups
     const Vector<TMXObjectGroup*>& getObjectGroups() const { return _objectGroups; }
     Vector<TMXObjectGroup*>& getObjectGroups() { return _objectGroups; }
     void setObjectGroups(const Vector<TMXObjectGroup*>& groups) {
         _objectGroups = groups;
-    };
+    }
 
     /// parent element
     int getParentElement() const { return _parentElement; }
@@ -272,7 +272,7 @@ public:
     ValueMap& getProperties() { return _properties; }
     void setProperties(const ValueMap& properties) {
         _properties = properties;
-    };
+    }
     
     // implement pure virtual methods of SAXDelegator
     /**

--- a/cocos/3d/CCTerrain.h
+++ b/cocos/3d/CCTerrain.h
@@ -185,7 +185,7 @@ private:
         {
             _position = v1;
             _texcoord = v2;
-        };
+        }
         /*the vertex's attributes*/
         cocos2d::Vec3 _position;
         cocos2d::Tex2F _texcoord;

--- a/cocos/base/CCScheduler.h
+++ b/cocos/base/CCScheduler.h
@@ -447,7 +447,7 @@ public:
     CC_DEPRECATED_ATTRIBUTE void scheduleSelector(SEL_SCHEDULE selector, Ref *target, float interval, unsigned int repeat, float delay, bool paused)
     {
         schedule(selector, target, interval, repeat, delay, paused);
-    };
+    }
     
     /** Calls scheduleSelector with CC_REPEAT_FOREVER and a 0 delay.
      *  @deprecated Please use `Scheduler::schedule` instead.
@@ -456,7 +456,7 @@ public:
     CC_DEPRECATED_ATTRIBUTE void scheduleSelector(SEL_SCHEDULE selector, Ref *target, float interval, bool paused)
     {
         schedule(selector, target, interval, paused);
-    };
+    }
     
     /** Schedules the 'update' selector for a given target with a given priority.
      The 'update' selector will be called every frame.

--- a/cocos/editor-support/cocosbuilder/CCScale9SpriteLoader.h
+++ b/cocos/editor-support/cocosbuilder/CCScale9SpriteLoader.h
@@ -34,7 +34,7 @@ protected:
         pNode->setAnchorPoint(cocos2d::Vec2::ZERO);
         
         return pNode;
-    };
+    }
     /**
      * @js NA
      * @lua NA

--- a/cocos/math/Vec2.h
+++ b/cocos/math/Vec2.h
@@ -478,7 +478,7 @@ public:
      */
     inline float getLength() const {
         return sqrtf(x*x + y*y);
-    };
+    }
 
     /** Calculates the square length of a Vec2 (not calling sqrt() )
      @return float
@@ -488,7 +488,7 @@ public:
      */
     inline float getLengthSq() const {
         return dot(*this); //x*x + y*y;
-    };
+    }
 
     /** Calculates the square distance between two points (not calling sqrt() )
      @return float
@@ -498,7 +498,7 @@ public:
      */
     inline float getDistanceSq(const Vec2& other) const {
         return (*this - other).getLengthSq();
-    };
+    }
 
     /** Calculates the distance between two points
      @return float
@@ -508,7 +508,7 @@ public:
      */
     inline float getDistance(const Vec2& other) const {
         return (*this - other).getLength();
-    };
+    }
 
     /** @returns the angle in radians between this vector and the x axis
      @since v2.1.4
@@ -517,7 +517,7 @@ public:
      */
     inline float getAngle() const {
         return atan2f(y, x);
-    };
+    }
 
     /** @returns the angle in radians between two vector directions
      @since v2.1.4
@@ -534,7 +534,7 @@ public:
      */
     inline float cross(const Vec2& other) const {
         return x*other.y - y*other.x;
-    };
+    }
 
     /** Calculates perpendicular of v, rotated 90 degrees counter-clockwise -- cross(v, perp(v)) >= 0
      @return Vec2
@@ -544,7 +544,7 @@ public:
      */
     inline Vec2 getPerp() const {
         return Vec2(-y, x);
-    };
+    }
     
     /** Calculates midpoint between two points.
      @return Vec2
@@ -589,7 +589,7 @@ public:
      */
     inline Vec2 getRPerp() const {
         return Vec2(y, -x);
-    };
+    }
 
     /** Calculates the projection of this over other.
      @return Vec2
@@ -599,7 +599,7 @@ public:
      */
     inline Vec2 project(const Vec2& other) const {
         return other * (dot(other)/other.dot(other));
-    };
+    }
 
     /** Complex multiplication of two points ("rotates" two points).
      @return Vec2 vector with an angle of this.getAngle() + other.getAngle(),
@@ -610,7 +610,7 @@ public:
      */
     inline Vec2 rotate(const Vec2& other) const {
         return Vec2(x*other.x - y*other.y, x*other.y + y*other.x);
-    };
+    }
 
     /** Unrotates two points.
      @return Vec2 vector with an angle of this.getAngle() - other.getAngle(),
@@ -621,7 +621,7 @@ public:
      */
     inline Vec2 unrotate(const Vec2& other) const {
         return Vec2(x*other.x + y*other.y, y*other.x - x*other.y);
-    };
+    }
 
     /** Linear Interpolation between two points a and b
      @returns
@@ -634,7 +634,7 @@ public:
      */
     inline Vec2 lerp(const Vec2& other, float alpha) const {
         return *this * (1.f - alpha) + other * alpha;
-    };
+    }
 
     /** Rotates a point counter clockwise by the angle around a pivot
      @param pivot is the pivot, naturally

--- a/cocos/network/HttpRequest.h
+++ b/cocos/network/HttpRequest.h
@@ -234,7 +234,7 @@ public:
     void* getUserData() const
     {
         return _pUserData;
-    };
+    }
     
     /**
      * Set the target and related callback selector.

--- a/cocos/network/SocketIO.h
+++ b/cocos/network/SocketIO.h
@@ -271,7 +271,7 @@ public:
     const char* getTag()
     {
         return _tag.c_str();
-    };
+    }
 
 };
 

--- a/cocos/ui/UILayoutParameter.h
+++ b/cocos/ui/UILayoutParameter.h
@@ -142,7 +142,7 @@ public:
     LayoutParameter() : _margin(Margin())
     {
         _layoutParameterType = Type::NONE;
-    };
+    }
     
     /**
      * Default destructor.
@@ -252,7 +252,7 @@ public:
     : _linearGravity(LinearGravity::NONE)
     {
         _layoutParameterType = Type::LINEAR;
-    };
+    }
     
     /**
      * Default destructor.
@@ -344,7 +344,7 @@ public:
     _put(false)
     {
         _layoutParameterType = Type::RELATIVE;
-    };
+    }
     
     /**
      * Default destructor

--- a/extensions/Particle3D/CCParticleSystem3D.h
+++ b/extensions/Particle3D/CCParticleSystem3D.h
@@ -75,7 +75,7 @@ public:
         //_locked.erase(_locked.begin());
         _released.splice(_released.end(), _locked, _locked.begin());
         return p;
-    };
+    }
 
     void lockLatestData(){
         _locked.push_back(*_releasedIter);
@@ -84,7 +84,7 @@ public:
         {
             --_releasedIter;
         }
-    };
+    }
 
     void lockData(T *data){
         PoolIterator tempIter = _releasedIter;
@@ -104,27 +104,27 @@ public:
         //_locked.insert(_locked.end(), _released.begin(), _released.end());
         //_released.clear();
         _releasedIter = _released.begin();
-    };
+    }
 
     T* getFirst(){
         _releasedIter = _released.begin();
         if (_releasedIter == _released.end()) return nullptr;
         return *_releasedIter;
-    };
+    }
 
     T* getNext(){
         if (_releasedIter == _released.end()) return nullptr;
         ++_releasedIter;
         if (_releasedIter == _released.end()) return nullptr;
         return *_releasedIter;
-    };
+    }
 
     const PoolList& getActiveDataList() const { return _released; };
     const PoolList& getUnActiveDataList() const { return _locked; };
 
     void addData(T* data){
         _locked.push_back(data); 
-    };
+    }
 
     bool empty() const { return _released.empty(); };
 
@@ -134,7 +134,7 @@ public:
             delete iter;
         }
         _locked.clear();
-    };
+    }
 
 private:
 

--- a/extensions/Particle3D/PU/CCPUDoExpireEventHandler.h
+++ b/extensions/Particle3D/PU/CCPUDoExpireEventHandler.h
@@ -59,7 +59,7 @@ public:
 CC_CONSTRUCTOR_ACCESS:
     PUDoExpireEventHandler(void) : PUEventHandler()
     {
-    };
+    }
     virtual ~PUDoExpireEventHandler(void) {};
 };
 

--- a/extensions/Particle3D/PU/CCPUDoFreezeEventHandler.h
+++ b/extensions/Particle3D/PU/CCPUDoFreezeEventHandler.h
@@ -51,7 +51,7 @@ public:
 CC_CONSTRUCTOR_ACCESS:
     PUDoFreezeEventHandler(void) : PUEventHandler()
     {
-    };
+    }
     virtual ~PUDoFreezeEventHandler(void) {};
 };
 

--- a/extensions/Particle3D/PU/CCPUDoStopSystemEventHandler.h
+++ b/extensions/Particle3D/PU/CCPUDoStopSystemEventHandler.h
@@ -53,7 +53,7 @@ public:
 CC_CONSTRUCTOR_ACCESS:
     PUDoStopSystemEventHandler(void) : PUEventHandler()
     {
-    };
+    }
     virtual ~PUDoStopSystemEventHandler(void) {};
 };
 

--- a/extensions/Particle3D/PU/CCPUForceField.h
+++ b/extensions/Particle3D/PU/CCPUForceField.h
@@ -47,7 +47,7 @@ public:
         _persistence(1.0f),
         _worldSize(DEFAULT_WORLDSIZE)
     {
-    };
+    }
     virtual ~PUForceFieldCalculationFactory(void){};
 
     /** Generates the force field

--- a/extensions/Particle3D/PU/CCPUOnClearObserver.h
+++ b/extensions/Particle3D/PU/CCPUOnClearObserver.h
@@ -64,7 +64,7 @@ CC_CONSTRUCTOR_ACCESS:
     PUOnClearObserver(void) : PUObserver(),
         _continue(false)
     {
-    };
+    }
     virtual ~PUOnClearObserver(void) {};
 
 protected:

--- a/extensions/Particle3D/PU/CCPUOnCollisionObserver.h
+++ b/extensions/Particle3D/PU/CCPUOnCollisionObserver.h
@@ -46,7 +46,7 @@ public:
 CC_CONSTRUCTOR_ACCESS:
     PUOnCollisionObserver(void) : PUObserver()
     {
-    };
+    }
     virtual ~PUOnCollisionObserver(void) {};
 };
 

--- a/extensions/Particle3D/PU/CCPUOnEmissionObserver.h
+++ b/extensions/Particle3D/PU/CCPUOnEmissionObserver.h
@@ -48,7 +48,7 @@ public:
 CC_CONSTRUCTOR_ACCESS:
     PUOnEmissionObserver(void) : PUObserver()
     {
-    };
+    }
     virtual ~PUOnEmissionObserver(void) {};
 };
 

--- a/extensions/Particle3D/PU/CCPUOnExpireObserver.h
+++ b/extensions/Particle3D/PU/CCPUOnExpireObserver.h
@@ -51,7 +51,7 @@ public:
 CC_CONSTRUCTOR_ACCESS:
     PUOnExpireObserver(void) : PUObserver()
     {
-    };
+    }
     virtual ~PUOnExpireObserver(void) {};
 };
 

--- a/extensions/Particle3D/PU/CCPUOnQuotaObserver.h
+++ b/extensions/Particle3D/PU/CCPUOnQuotaObserver.h
@@ -52,7 +52,7 @@ CC_CONSTRUCTOR_ACCESS:
     PUOnQuotaObserver(void) : PUObserver(),
         _result(false)
     {
-    };
+    }
     virtual ~PUOnQuotaObserver(void) {};
 
 protected:

--- a/extensions/Particle3D/PU/CCPURibbonTrailRender.h
+++ b/extensions/Particle3D/PU/CCPURibbonTrailRender.h
@@ -70,7 +70,7 @@ public:
                 addedToTrail = false;
             }
         }
-    };
+    }
 };
 
 // particle render for quad

--- a/extensions/Particle3D/PU/CCPUScriptTranslator.h
+++ b/extensions/Particle3D/PU/CCPUScriptTranslator.h
@@ -1224,7 +1224,7 @@ public:
     virtual void translate(PUScriptCompiler* compiler, PUAbstractNode *node)
     {
         // No own implementation
-    };
+    }
     
     /** Only parses a certain child property
      */
@@ -1232,7 +1232,7 @@ public:
     {
         // No own implementation
         return false;
-    };
+    }
     
     /** Only parses a certain child objec
      */
@@ -1240,7 +1240,7 @@ public:
     {
         // No own implementation
         return false;
-    };
+    }
     
     /** Parse Vector2
      */


### PR DESCRIPTION
When using libcocos2d in my project with Xcode 8.0 and Clang at the highest warning level (e.g. `-Weverything`), I get the following warnings:

```
cocos/2d/CCFastTMXLayer.h:197:74: warning: extra ';' after member function definition [-Wextra-semi]
cocos/2d/CCFastTMXLayer.h:213:6: warning: extra ';' after member function definition [-Wextra-semi]
cocos/2d/CCFastTMXTiledMap.h:189:6: warning: extra ';' after member function definition [-Wextra-semi]
cocos/2d/CCFastTMXTiledMap.h:203:6: warning: extra ';' after member function definition [-Wextra-semi]
cocos/2d/CCTMXLayer.h:130:6: warning: extra ';' after member function definition [-Wextra-semi]
cocos/2d/CCTMXLayer.h:248:6: warning: extra ';' after member function definition [-Wextra-semi]
cocos/2d/CCTMXLayer.h:280:6: warning: extra ';' after member function definition [-Wextra-semi]
cocos/2d/CCTMXObjectGroup.h:114:6: warning: extra ';' after member function definition [-Wextra-semi]
cocos/2d/CCTMXObjectGroup.h:129:6: warning: extra ';' after member function definition [-Wextra-semi]
cocos/2d/CCTMXTiledMap.h:254:6: warning: extra ';' after member function definition [-Wextra-semi]
cocos/2d/CCTMXTiledMap.h:268:6: warning: extra ';' after member function definition [-Wextra-semi]
cocos/2d/CCTMXXMLParser.h:206:6: warning: extra ';' after member function definition [-Wextra-semi]
cocos/2d/CCTMXXMLParser.h:237:6: warning: extra ';' after member function definition [-Wextra-semi]
cocos/2d/CCTMXXMLParser.h:244:6: warning: extra ';' after member function definition [-Wextra-semi]
cocos/2d/CCTMXXMLParser.h:251:6: warning: extra ';' after member function definition [-Wextra-semi]
cocos/2d/CCTMXXMLParser.h:275:6: warning: extra ';' after member function definition [-Wextra-semi]
cocos/3d/CCTerrain.h:188:10: warning: extra ';' after member function definition [-Wextra-semi]
cocos/base/CCScheduler.h:450:6: warning: extra ';' after member function definition [-Wextra-semi]
cocos/base/CCScheduler.h:459:6: warning: extra ';' after member function definition [-Wextra-semi]
...
```

This PR removes some extra semicolons at the end of a function definition because those semicolons are superfluous in C++. Thanks!
