### PR TITLE
Fix mismatched memory deallocators

### DIFF
--- a/cocos/2d/CCFastTMXLayer.cpp
+++ b/cocos/2d/CCFastTMXLayer.cpp
@@ -130,7 +130,7 @@ TMXLayer::~TMXLayer()
 {
     CC_SAFE_RELEASE(_tileSet);
     CC_SAFE_RELEASE(_texture);
-    CC_SAFE_DELETE_ARRAY(_tiles);
+    CC_SAFE_FREE(_tiles);
     CC_SAFE_RELEASE(_vData);
     CC_SAFE_RELEASE(_vertexBuffer);
     CC_SAFE_RELEASE(_indexBuffer);

--- a/cocos/2d/CCTMXLayer.cpp
+++ b/cocos/2d/CCTMXLayer.cpp
@@ -152,7 +152,7 @@ void TMXLayer::releaseMap()
 {
     if (_tiles)
     {
-        delete [] _tiles;
+        free(_tiles);
         _tiles = nullptr;
     }
 

--- a/cocos/editor-support/spine/SkeletonRenderer.cpp
+++ b/cocos/editor-support/spine/SkeletonRenderer.cpp
@@ -98,7 +98,7 @@ SkeletonRenderer::~SkeletonRenderer () {
 	spSkeleton_dispose(_skeleton);
 	if (_atlas) spAtlas_dispose(_atlas);
 	if (_attachmentLoader) spAttachmentLoader_dispose(_attachmentLoader);
-	delete _worldVertices;
+	delete [] _worldVertices;
 }
 
 void SkeletonRenderer::initWithData (spSkeletonData* skeletonData, bool ownsSkeletonData) {


### PR DESCRIPTION
Valgrind also reports a mismatched memory deallocator when deallocating an experimental::TMXLayer:

```
==8331== Mismatched free() / delete / delete []
==8331==    at 0x4C2B1C6: operator delete(void*) (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==8331==    by 0x15ABB44: cocos2d::experimental::TMXLayer::~TMXLayer() (CCFastTMXLayer.cpp:133)
```

Just like in pull request #16560, the memory which `_tiles` points to gets allocated on [CCTMXXMLParser.cpp:457](https://github.com/cocos2d/cocos2d-x/blob/v3/cocos/2d/CCTMXXMLParser.cpp#L457) using `malloc`, and therefore a `free` must be used.

Another mismatched memory deallocator was found by valgrind: 

```
==3357== Mismatched free() / delete / delete []
==3357==    at 0x4C2B1C6: operator delete(void*) (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==3357==    by 0x199EDB9: spine::SkeletonRenderer::~SkeletonRenderer() (SkeletonRenderer.cpp:101)
```

In this last case, the memory `_worldVertices` points to gets allocated on [SkeletonRenderer.cpp#L64](https://github.com/cocos2d/cocos2d-x/blob/v3/cocos/editor-support/spine/SkeletonRenderer.cpp#L64). A `delete []` must be used in this case.
