### PR TITLE
Fixing issue where ScriptingCore::evalString would always return fals…

### DIFF
--- a/cocos/scripting/js-bindings/manual/ScriptingCore.cpp
+++ b/cocos/scripting/js-bindings/manual/ScriptingCore.cpp
@@ -520,8 +520,8 @@ void ScriptingCore::string_report(JS::HandleValue val) {
 bool ScriptingCore::evalString(const char *string, JS::MutableHandleValue outVal, const char *filename, JSContext* cx, JS::HandleObject global)
 {
     JSAutoCompartment ac(cx, global);
-    JS::PersistentRootedScript script(cx);
-    if (script == nullptr) {
+    JS::RootedScript script(cx);
+    if (&script == nullptr) {
         return false;
     }
     

--- a/cocos/scripting/js-bindings/manual/ScriptingCore.cpp
+++ b/cocos/scripting/js-bindings/manual/ScriptingCore.cpp
@@ -521,10 +521,6 @@ bool ScriptingCore::evalString(const char *string, JS::MutableHandleValue outVal
 {
     JSAutoCompartment ac(cx, global);
     JS::RootedScript script(cx);
-    if (&script == nullptr) {
-        return false;
-    }
-    
     JS::CompileOptions op(cx);
     op.setUTF8(true);
     


### PR DESCRIPTION
…e, and not evaluate the string, due to an improper null check.
