### PR TITLE
Fix implicit conversion warning

### DIFF
--- a/cocos/2d/CCTMXXMLParser.cpp
+++ b/cocos/2d/CCTMXXMLParser.cpp
@@ -786,7 +786,7 @@ void TMXMapInfo::endElement(void *ctx, const char *name)
     }
 }
 
-void TMXMapInfo::textHandler(void *ctx, const char *ch, int len)
+void TMXMapInfo::textHandler(void *ctx, const char *ch, size_t len)
 {
     CC_UNUSED_PARAM(ctx);
     TMXMapInfo *tmxMapInfo = this;

--- a/cocos/2d/CCTMXXMLParser.h
+++ b/cocos/2d/CCTMXXMLParser.h
@@ -279,17 +279,17 @@ public:
      * @js NA
      * @lua NA
      */
-    void startElement(void *ctx, const char *name, const char **atts);
+    void startElement(void *ctx, const char *name, const char **atts) override;
     /**
      * @js NA
      * @lua NA
      */
-    void endElement(void *ctx, const char *name);
+    void endElement(void *ctx, const char *name) override;
     /**
      * @js NA
      * @lua NA
      */
-    void textHandler(void *ctx, const char *ch, int len);
+    void textHandler(void *ctx, const char *ch, size_t len) override;
     
     const std::string& getCurrentString() const { return _currentString; }
     void setCurrentString(const std::string& currentString){ _currentString = currentString; }

--- a/cocos/platform/CCFileUtils.cpp
+++ b/cocos/platform/CCFileUtils.cpp
@@ -292,7 +292,7 @@ public:
         _state = SAX_NONE;
     }
 
-    void textHandler(void *ctx, const char *ch, int len)
+    void textHandler(void *ctx, const char *ch, size_t len) override
     {
         CC_UNUSED_PARAM(ctx);
         if (_state == SAX_NONE)

--- a/cocos/platform/CCSAXParser.cpp
+++ b/cocos/platform/CCSAXParser.cpp
@@ -163,7 +163,7 @@ bool SAXParser::parseIntrusive(char* xmlData, size_t dataLength)
 
     rapidxml::xml_sax3_parser<> parser(&printer);
     try {
-        parser.parse<>(xmlData, dataLength);
+        parser.parse<>(xmlData, static_cast<int>(dataLength));
         return true;
     }
     catch (rapidxml::parse_error& e)

--- a/cocos/platform/CCSAXParser.cpp
+++ b/cocos/platform/CCSAXParser.cpp
@@ -83,7 +83,7 @@ bool XmlSaxHander::VisitExit( const tinyxml2::XMLElement& element )
 bool XmlSaxHander::Visit( const tinyxml2::XMLText& text )
 {
     //log("Visit %s",text.Value());
-    SAXParser::textHandler(_ccsaxParserImp, (const CC_XML_CHAR *)text.Value(), static_cast<int>(strlen(text.Value())));
+    SAXParser::textHandler(_ccsaxParserImp, (const CC_XML_CHAR *)text.Value(), strlen(text.Value()));
     return true;
 }
 
@@ -184,7 +184,7 @@ void SAXParser::endElement(void *ctx, const CC_XML_CHAR *name)
 {
     ((SAXParser*)(ctx))->_delegator->endElement(ctx, (char*)name);
 }
-void SAXParser::textHandler(void *ctx, const CC_XML_CHAR *name, int len)
+void SAXParser::textHandler(void *ctx, const CC_XML_CHAR *name, size_t len)
 {
     ((SAXParser*)(ctx))->_delegator->textHandler(ctx, (char*)name, len);
 }

--- a/cocos/platform/CCSAXParser.h
+++ b/cocos/platform/CCSAXParser.h
@@ -57,7 +57,7 @@ public:
      * @js NA
      * @lua NA
      */
-    virtual void textHandler(void *ctx, const char *s, int len) = 0;
+    virtual void textHandler(void *ctx, const char *s, size_t len) = 0;
 };
 
 class CC_DLL SAXParser
@@ -114,7 +114,7 @@ public:
      * @js NA
      * @lua NA
      */
-    static void textHandler(void *ctx, const CC_XML_CHAR *name, int len);
+    static void textHandler(void *ctx, const CC_XML_CHAR *name, size_t len);
 };
 
 // end of platform group

--- a/cocos/scripting/js-bindings/manual/cocos2d_specifics.cpp
+++ b/cocos/scripting/js-bindings/manual/cocos2d_specifics.cpp
@@ -4715,7 +4715,7 @@ void __JSPlistDelegator::endElement(void *ctx, const char *name) {
     }
 }
 
-void __JSPlistDelegator::textHandler(void *ctx, const char *ch, int len) {
+void __JSPlistDelegator::textHandler(void *ctx, const char *ch, size_t len) {
     CC_UNUSED_PARAM(ctx);
     std::string text((char*)ch, 0, len);
 

--- a/cocos/scripting/js-bindings/manual/cocos2d_specifics.hpp
+++ b/cocos/scripting/js-bindings/manual/cocos2d_specifics.hpp
@@ -280,9 +280,9 @@ public:
     std::string parseText(const std::string& text);
 
     // implement pure virtual methods of SAXDelegator
-    void startElement(void *ctx, const char *name, const char **atts);
-    void endElement(void *ctx, const char *name);
-    void textHandler(void *ctx, const char *ch, int len);
+    void startElement(void *ctx, const char *name, const char **atts) override;
+    void endElement(void *ctx, const char *name) override;
+    void textHandler(void *ctx, const char *ch, size_t len) override;
 
 private:
     cocos2d::SAXParser _parser;

--- a/cocos/ui/UIRichText.cpp
+++ b/cocos/ui/UIRichText.cpp
@@ -334,7 +334,7 @@ public:
 
     void endElement(void *ctx, const char *name) override;
 
-    void textHandler(void *ctx, const char *s, int len) override;
+    void textHandler(void *ctx, const char *s, size_t len) override;
 
     
     void pushBackFontElement(const Attributes& attribs);
@@ -754,7 +754,7 @@ void MyXMLVisitor::endElement(void *ctx, const char *elementName)
     }
 }
 
-void MyXMLVisitor::textHandler(void *ctx, const char *str, int len)
+void MyXMLVisitor::textHandler(void *ctx, const char *str, size_t len)
 {
     std::string text(str, len);
     auto color = getColor();


### PR DESCRIPTION
Hello, I now get two warnings when building libcocos2d for Mac using Xcode 7.3.1. This fix tries to address the warnings.

```
cocos/platform/CCSAXParser.cpp:114:73: warning: implicit conversion loses integer precision: 'size_t' (aka 'unsigned long') to 'int' [-Wshorten-64-to-32]
        SAXParser::textHandler(_ccsaxParserImp, (const CC_XML_CHAR *)s, len);
        ~~~~~~~~~                                                       ^~~
cocos/platform/CCSAXParser.cpp:166:33: warning: implicit conversion loses integer precision: 'size_t' (aka 'unsigned long') to 'int' [-Wshorten-64-to-32]
        parser.parse<>(xmlData, dataLength);
        ~~~~~~                  ^~~~~~~~~~
```
