### PR TITLE
Fix bug ：expoEaseInOut

### DIFF
--- a/cocos/2d/CCTweenFunction.cpp
+++ b/cocos/2d/CCTweenFunction.cpp
@@ -307,9 +307,12 @@ float expoEaseInOut(float time)
     {
         time = 0.5f * powf(2, 10 * (time - 1));
     }
-    else
+    else if (time < 2)
     {
         time = 0.5f * (-powf(2, -10 * (time - 1)) + 2);
+    } else
+    {
+        time = 1.0f;
     }
 
     return time;


### PR DESCRIPTION
When the parameter in function expoEaseInOut is 1.0 , it return 0.99995
