### PR TITLE
lua: generate bindings for Sprite3DMaterial

### DIFF
--- a/tests/lua-tests/src/Sprite3DTest/Sprite3DTest.lua
+++ b/tests/lua-tests/src/Sprite3DTest/Sprite3DTest.lua
@@ -1295,6 +1295,63 @@ end
 function Sprite3DNormalMappingTest:onExit()
 end
 
+----------------------------------------
+----Sprite3DMaterialTest
+----------------------------------------
+local Sprite3DMaterialTest = class("Sprite3DMaterialTest", function ()
+    local layer = cc.Layer:create()
+    Helper.initWithLayer(layer)
+    return layer
+end)
+
+function Sprite3DMaterialTest:ctor()
+    -- body
+    self:init()
+end
+
+function Sprite3DMaterialTest:init()
+    Helper.titleLabel:setString(self:title())
+    Helper.subtitleLabel:setString(self:subtitle())
+
+    self:registerScriptHandler(function (event)
+        if event == "enter" then
+            self:onEnter()
+        elseif event == "exit" then
+            self:onExit()
+        end
+    end)
+end
+
+function Sprite3DMaterialTest:title()
+    return "Testing Sprite3DMaterial"
+end
+
+function Sprite3DMaterialTest:subtitle()
+    return ""
+end
+
+function Sprite3DMaterialTest:onEnter()
+
+    local material = cc.Sprite3DMaterial:createWithFilename("Sprite3DTest/outline.material")
+    local sprite = cc.Sprite3D:create("Sprite3DTest/sphere_bumped.c3b")
+        :setScale(20.0)
+        :setPosition(cc.p(0,0))
+        :setRotation3D(cc.vec3(90.0, 0.0, 0.0))
+        :setCameraMask(2)
+        :setMaterial(material)
+    self:addChild(sprite)
+
+
+    local camera = cc.Camera:create()
+        :setPosition3D(cc.vec3(0.0, 0.0, 100.0))
+        :lookAt(cc.vec3(0.0, 0.0, 0.0))
+        :setCameraFlag(cc.CameraFlag.USER1)
+    self:addChild(camera)
+end
+
+function Sprite3DMaterialTest:onExit()
+end
+
 function Sprite3DTest()
     local scene = cc.Scene:create()
 
@@ -1311,6 +1368,7 @@ function Sprite3DTest()
         AsyncLoadSprite3DTest.create,
         Sprite3DCubeMapTest.create,
         Sprite3DNormalMappingTest.create,
+        Sprite3DMaterialTest.create,
     }
 
     scene:addChild(Sprite3DBasicTest.create())

--- a/tools/tolua/cocos2dx_3d.ini
+++ b/tools/tolua/cocos2dx_3d.ini
@@ -26,7 +26,7 @@ headers = %(cocosdir)s/cocos/cocos2d.h %(cocosdir)s/cocos/3d/CCBundle3D.h
 
 # what classes to produce code for. You can use regular expressions here. When testing the regular
 # expression, it will be enclosed in "^$", like this: "^Menu*$".
-classes = Animate3D Sprite3D Animation3D Skeleton3D ^Mesh$ AttachNode BillBoard Sprite3DCache TextureCube Skybox Terrain Bundle3D
+classes = Animate3D Sprite3D Animation3D Skeleton3D ^Mesh$ AttachNode BillBoard Sprite3DCache TextureCube Skybox Terrain Bundle3D Sprite3DMaterial
 
 # what should we skip? in the format ClassName::[function function]
 # ClassName is a regular expression, but will be used like this: "^ClassName$" functions are also


### PR DESCRIPTION
Add Sprite3DMaterial to the list of classes for autogeneration of
lua bindings.

Add a new test case to the end of Sprite3DTest.lua showing the
use of outline.material
