### PR TITLE
Minor fix for TextureCache::addImage(image, key).

### DIFF
--- a/cocos/renderer/CCTextureCache.cpp
+++ b/cocos/renderer/CCTextureCache.cpp
@@ -438,20 +438,24 @@ Texture2D* TextureCache::addImage(Image *image, const std::string &key)
             break;
         }
 
-        // prevents overloading the autorelease pool
         texture = new (std::nothrow) Texture2D();
-        texture->initWithImage(image);
 
         if (texture)
         {
-            _textures.insert(std::make_pair(key, texture));
-            texture->retain();
-
-            texture->autorelease();
+            if (texture->initWithImage(image))
+            {
+                _textures.insert(std::make_pair(key, texture));
+            }
+            else
+            {
+                CC_SAFE_RELEASE(texture);
+                texture = nullptr;
+                CCLOG("cocos2d: initWithImage failed!");
+            }
         }
         else
         {
-            CCLOG("cocos2d: Couldn't add UIImage in TextureCache");
+            CCLOG("cocos2d: Allocating memory for Texture2D failed!");
         }
 
     } while (0);
@@ -715,6 +719,9 @@ void VolatileTextureMgr::addImageTexture(Texture2D *tt, const std::string& image
 
 void VolatileTextureMgr::addImage(Texture2D *tt, Image *image)
 {
+    if (tt == nullptr || image == nullptr)
+        return;
+    
     VolatileTexture *vt = findVolotileTexture(tt);
     image->retain();
     vt->_uiImage = image;


### PR DESCRIPTION
- Removes insignificant log: `prevents overloading the autorelease pool`, it is copied from `cocos2d-iphone` here

<img width="908" alt="prevent-stuff" src="https://cloud.githubusercontent.com/assets/493372/18862374/4266c2b4-84be-11e6-814b-e6a508629ad7.png">
- Removes unused `retain -> autorelease` code
- Checks the return value of `texture->initWithImage`, if it returns false, texture should be released and set to nullptr.
- More specific log output in TextureCache::addImage(image, key)
- Checks arguments validation for VolatileTextureMgr::addImage
