### PR TITLE
Adding 'addImageAsyncImmediate' to CCTextureCache. 

### DIFF
--- a/cocos/renderer/CCTextureCache.h
+++ b/cocos/renderer/CCTextureCache.h
@@ -136,6 +136,17 @@ public:
      */
     virtual void unbindAllImageAsync();
 
+
+    /** Returns a Texture2D object given a file image. This function will create a new worker thread and immediatly begin loading the image
+      * If the file image was not previously loaded, it will create a new Texture2D object and it will return it.
+      * Otherwise it will load a texture in a new thread, and when the image is loaded, the callback will be called with the Texture2D as a parameter.
+      * The callback will be called from the main thread, so it is safe to create any cocos2d object from the callback.
+      * Supported image extensions: .png, .jpg
+     @param filepath A null terminated string.
+     @param callback A callback function would be invoked after the image is loaded.
+      */
+    virtual void addImageAsyncImmediate(const std::string &filename, const std::function<void(Texture2D*)>& callback);
+
     /** Returns a Texture2D object given an Image.
     * If the image was not previously loaded, it will create a new Texture2D object and it will return it.
     * Otherwise it will return a reference of a previously loaded image.
@@ -220,6 +231,7 @@ private:
     void addImageAsyncCallBack(float dt);
     void loadImage();
     void parseNinePatchImage(Image* image, Texture2D* texture, const std::string& path);
+
 public:
 protected:
     struct AsyncStruct;
@@ -227,6 +239,7 @@ protected:
     std::thread* _loadingThread;
 
     std::deque<AsyncStruct*> _asyncStructQueue;
+    std::deque<AsyncStruct*> _immediateAsyncStructQueue;
     std::deque<AsyncStruct*> _requestQueue;
     std::deque<AsyncStruct*> _responseQueue;
 
@@ -242,6 +255,7 @@ protected:
     std::unordered_map<std::string, Texture2D*> _textures;
 
     static std::string s_etc1AlphaFileSuffix;
+    Texture2D* loadTexture(AsyncStruct* asyncStruct);
 };
 
 #if CC_ENABLE_CACHE_TEXTURE_DATA

--- a/tests/cpp-tests/Classes/TextureCacheTest/TextureCacheTest.cpp
+++ b/tests/cpp-tests/Classes/TextureCacheTest/TextureCacheTest.cpp
@@ -8,6 +8,7 @@ USING_NS_CC;
 TextureCacheTests::TextureCacheTests()
 {
     ADD_TEST_CASE(TextureCacheTest);
+    ADD_TEST_CASE(TextureCacheImmediateTest);
 }
 
 TextureCacheTest::TextureCacheTest()
@@ -129,4 +130,104 @@ void TextureCacheTest::addSprite()
     this->addChild(s13);
     this->addChild(s14);
     this->addChild(s15);
+}
+
+
+TextureCacheImmediateTest::TextureCacheImmediateTest()
+: _numberOfSprites(20)
+, _numberOfLoadedSprites(0)
+{
+    TextureCache::getInstance()->removeAllTextures();
+    Director::getInstance()->getTextureCache()->addImageAsyncImmediate("Images/HelloWorld.png", CC_CALLBACK_1(TextureCacheImmediateTest::loadingCallBack, this));
+    Director::getInstance()->getTextureCache()->addImageAsyncImmediate("Images/grossini.png", CC_CALLBACK_1(TextureCacheImmediateTest::loadingCallBack, this));
+    Director::getInstance()->getTextureCache()->addImageAsyncImmediate("Images/grossini_dance_01.png", CC_CALLBACK_1(TextureCacheImmediateTest::loadingCallBack, this));
+    Director::getInstance()->getTextureCache()->addImageAsync("Images/grossini_dance_02.png", CC_CALLBACK_1(TextureCacheImmediateTest::loadingCallBack, this));
+    Director::getInstance()->getTextureCache()->addImageAsync("Images/grossini_dance_03.png", CC_CALLBACK_1(TextureCacheImmediateTest::loadingCallBack, this));
+    Director::getInstance()->getTextureCache()->addImageAsync("Images/grossini_dance_04.png", CC_CALLBACK_1(TextureCacheImmediateTest::loadingCallBack, this));
+    Director::getInstance()->getTextureCache()->addImageAsync("Images/grossini_dance_05.png", CC_CALLBACK_1(TextureCacheImmediateTest::loadingCallBack, this));
+    Director::getInstance()->getTextureCache()->addImageAsync("Images/grossini_dance_06.png", CC_CALLBACK_1(TextureCacheImmediateTest::loadingCallBack, this));
+    Director::getInstance()->getTextureCache()->addImageAsync("Images/grossini_dance_07.png", CC_CALLBACK_1(TextureCacheImmediateTest::loadingCallBack, this));
+    Director::getInstance()->getTextureCache()->addImageAsyncImmediate("Images/grossini_dance_08.png", CC_CALLBACK_1(TextureCacheImmediateTest::loadingCallBack, this));
+    Director::getInstance()->getTextureCache()->addImageAsyncImmediate("Images/grossini_dance_09.png", CC_CALLBACK_1(TextureCacheImmediateTest::loadingCallBack, this));
+    Director::getInstance()->getTextureCache()->addImageAsyncImmediate("Images/grossini_dance_10.png", CC_CALLBACK_1(TextureCacheImmediateTest::loadingCallBack, this));
+    Director::getInstance()->getTextureCache()->addImageAsyncImmediate("Images/grossini_dance_11.png", CC_CALLBACK_1(TextureCacheImmediateTest::loadingCallBack, this));
+    Director::getInstance()->getTextureCache()->addImageAsyncImmediate("Images/grossini_dance_12.png", CC_CALLBACK_1(TextureCacheImmediateTest::loadingCallBack, this));
+    Director::getInstance()->getTextureCache()->addImageAsyncImmediate("Images/grossini_dance_13.png", CC_CALLBACK_1(TextureCacheImmediateTest::loadingCallBack, this));
+    Director::getInstance()->getTextureCache()->addImageAsync("Images/grossini_dance_14.png", CC_CALLBACK_1(TextureCacheImmediateTest::loadingCallBack, this));
+    Director::getInstance()->getTextureCache()->addImageAsync("Images/background1.png", CC_CALLBACK_1(TextureCacheImmediateTest::loadingCallBack, this));
+    Director::getInstance()->getTextureCache()->addImageAsync("Images/background2.png", CC_CALLBACK_1(TextureCacheImmediateTest::loadingCallBack, this));
+    Director::getInstance()->getTextureCache()->addImageAsyncImmediate("Images/background3.png", CC_CALLBACK_1(TextureCacheImmediateTest::loadingCallBack, this));
+    Director::getInstance()->getTextureCache()->addImageAsyncImmediate("Images/blocks.png", CC_CALLBACK_1(TextureCacheImmediateTest::loadingCallBack, this));
+}
+
+void TextureCacheImmediateTest::loadingCallBack(cocos2d::Texture2D *texture) 
+{
+    ++_numberOfLoadedSprites;
+    if (_numberOfLoadedSprites == _numberOfSprites)
+    {
+        auto size = Director::getInstance()->getWinSize();
+
+        // create sprites
+
+        auto bg = Sprite::create("Images/HelloWorld.png");
+        bg->setPosition(Vec2(size.width / 2, size.height / 2));
+
+        auto s1 = Sprite::create("Images/grossini.png");
+        auto s2 = Sprite::create("Images/grossini_dance_01.png");
+        auto s3 = Sprite::create("Images/grossini_dance_02.png");
+        auto s4 = Sprite::create("Images/grossini_dance_03.png");
+        auto s5 = Sprite::create("Images/grossini_dance_04.png");
+        auto s6 = Sprite::create("Images/grossini_dance_05.png");
+        auto s7 = Sprite::create("Images/grossini_dance_06.png");
+        auto s8 = Sprite::create("Images/grossini_dance_07.png");
+        auto s9 = Sprite::create("Images/grossini_dance_08.png");
+        auto s10 = Sprite::create("Images/grossini_dance_09.png");
+        auto s11 = Sprite::create("Images/grossini_dance_10.png");
+        auto s12 = Sprite::create("Images/grossini_dance_11.png");
+        auto s13 = Sprite::create("Images/grossini_dance_12.png");
+        auto s14 = Sprite::create("Images/grossini_dance_13.png");
+        auto s15 = Sprite::create("Images/grossini_dance_14.png");
+
+        // just loading textures to slow down
+        Sprite::create("Images/background1.png");
+        Sprite::create("Images/background2.png");
+        Sprite::create("Images/background3.png");
+        Sprite::create("Images/blocks.png");
+
+        s1->setPosition(Vec2(50, 50));
+        s2->setPosition(Vec2(60, 50));
+        s3->setPosition(Vec2(70, 50));
+        s4->setPosition(Vec2(80, 50));
+        s5->setPosition(Vec2(90, 50));
+        s6->setPosition(Vec2(100, 50));
+
+        s7->setPosition(Vec2(50, 180));
+        s8->setPosition(Vec2(60, 180));
+        s9->setPosition(Vec2(70, 180));
+        s10->setPosition(Vec2(80, 180));
+        s11->setPosition(Vec2(90, 180));
+        s12->setPosition(Vec2(100, 180));
+
+        s13->setPosition(Vec2(50, 270));
+        s14->setPosition(Vec2(60, 270));
+        s15->setPosition(Vec2(70, 270));
+
+        this->addChild(bg);
+        
+        this->addChild(s1);
+        this->addChild(s2);
+        this->addChild(s3);
+        this->addChild(s4);
+        this->addChild(s5);
+        this->addChild(s6);
+        this->addChild(s7);
+        this->addChild(s8);
+        this->addChild(s9);
+        this->addChild(s10);
+        this->addChild(s11);
+        this->addChild(s12);
+        this->addChild(s13);
+        this->addChild(s14);
+        this->addChild(s15);
+    }
 }

--- a/tests/cpp-tests/Classes/TextureCacheTest/TextureCacheTest.h
+++ b/tests/cpp-tests/Classes/TextureCacheTest/TextureCacheTest.h
@@ -25,4 +25,17 @@ private:
     int _numberOfLoadedSprites;
 };
 
+class TextureCacheImmediateTest : public TestCase 
+{
+public: 
+	CREATE_FUNC(TextureCacheImmediateTest);
+
+	TextureCacheImmediateTest();
+	virtual float getDuration() const override { return 3.5f; }
+private:
+	void loadingCallBack(cocos2d::Texture2D *texture);
+	int _numberOfSprites;
+    int _numberOfLoadedSprites;
+};
+
 #endif // _TEXTURECACHE_TEST_H_


### PR DESCRIPTION
This will allow engine users to load multiple textures async across multiple threads, or load a texture before other textures in the texture loading queue.

In several of our cocos2d-x projects, we found that increasing the number of texture loading threads would reduce our loading times by a measurable amount. We found that the cleanest way to accomplish this was adding a "loadImageAsyncImmediate" function, which will spin up a new thread dedicated to loading that texture. This is designed to mimic the architecture of HttpClient::sendImmediate. 

This feature should be almost entirely additive, and have minimal impact to users who do not opt-in to this new functionality. 

Benefits: 
- On systems with a high core count, using this may yield solid performance gains in texture load times.
- Engine users can prioritize texture loads over others.
