### PR TITLE
Remove unused functions

### DIFF
--- a/cocos/2d/CCDrawNode.cpp
+++ b/cocos/2d/CCDrawNode.cpp
@@ -76,11 +76,6 @@ static inline float v2fdot(const Vec2 &p0, const Vec2 &p1)
     return  p0.x * p1.x + p0.y * p1.y;
 }
 
-static inline Vec2 v2fforangle(float _a_)
-{
-    return v2f(cosf(_a_), sinf(_a_));
-}
-
 static inline Vec2 v2fnormalize(const Vec2 &p)
 {
     Vec2 r(p.x, p.y);

--- a/extensions/physics-nodes/CCPhysicsDebugNode.cpp
+++ b/extensions/physics-nodes/CCPhysicsDebugNode.cpp
@@ -68,19 +68,6 @@ static Vec2 cpVert2Point(const cpVect &vert)
     return Vec2(vert.x, vert.y);
 }
 
-static Vec2* cpVertArray2ccpArrayN(const cpVect* cpVertArray, unsigned int count)
-{
-    if (count == 0) return nullptr;
-    Vec2* pPoints = new (std::nothrow) Vec2[count];
-    
-    for (unsigned int i = 0; i < count; ++i)
-    {
-        pPoints[i].x = cpVertArray[i].x;
-        pPoints[i].y = cpVertArray[i].y;
-    }
-    return pPoints;
-}
-
 static void DrawShape(cpShape *shape, DrawNode *renderer)
 {
     cpBody *body = cpShapeGetBody(shape);


### PR DESCRIPTION
Hello, I get the following warnings during compilation with libcocos2d under Xcode 8.0.

```
cocos/2d/CCDrawNode.cpp:79:20: warning: unused function 'v2fforangle' [-Wunused-function]
extensions/physics-nodes/CCPhysicsDebugNode.cpp:71:14: warning: unused function 'cpVertArray2ccpArrayN' [-Wunused-function]
```

These functions don't seem to be used anywhere, and I think we can remove them because they are `static` function that has internal linkage. So this pull request removes them to prevent the compiler warnings.

Thanks.
