### PR TITLE
Performance tweak: use range-based for-loops instead of iterator-based for-loops.

### DIFF
--- a/cocos/2d/CCAutoPolygon.cpp
+++ b/cocos/2d/CCAutoPolygon.cpp
@@ -514,9 +514,9 @@ std::vector<Vec2> AutoPolygon::expand(const std::vector<Vec2>& points, const coc
     ClipperLib::Path subj;
     ClipperLib::PolyTree solution;
     ClipperLib::PolyTree out;
-    for(const auto& it : points)
+    for(const auto& pt : points)
     {
-        subj << ClipperLib::IntPoint(it.x* PRECISION, it.y * PRECISION);
+        subj << ClipperLib::IntPoint(pt.x* PRECISION, pt.y * PRECISION);
     }
     ClipperLib::ClipperOffset co;
     co.AddPath(subj, ClipperLib::jtMiter, ClipperLib::etClosedPolygon);
@@ -569,9 +569,9 @@ TrianglesCommand::Triangles AutoPolygon::triangulate(const std::vector<Vec2>& po
         return TrianglesCommand::Triangles();
     }
     std::vector<p2t::Point*> p2points;
-    for(const auto& it : points)
+    for(const auto& pt : points)
     {
-        p2t::Point * p = new (std::nothrow) p2t::Point(it.x, it.y);
+        p2t::Point * p = new (std::nothrow) p2t::Point(pt.x, pt.y);
         p2points.push_back(p);
     }
     p2t::CDT cdt(p2points);
@@ -704,6 +704,7 @@ PolygonInfo AutoPolygon::generateTriangles(const Rect& rect, const float& epsilo
     ret.rect = realRect;
     return ret;
 }
+
 PolygonInfo AutoPolygon::generatePolygon(const std::string& filename, const Rect& rect, const float epsilon, const float threshold)
 {
     AutoPolygon ap(filename);

--- a/cocos/2d/CCAutoPolygon.cpp
+++ b/cocos/2d/CCAutoPolygon.cpp
@@ -514,9 +514,9 @@ std::vector<Vec2> AutoPolygon::expand(const std::vector<Vec2>& points, const coc
     ClipperLib::Path subj;
     ClipperLib::PolyTree solution;
     ClipperLib::PolyTree out;
-    for(std::vector<Vec2>::const_iterator it = points.begin(); it<points.end(); ++it)
+    for(const auto& it : points)
     {
-        subj << ClipperLib::IntPoint(it-> x* PRECISION, it->y * PRECISION);
+        subj << ClipperLib::IntPoint(it.x* PRECISION, it.y * PRECISION);
     }
     ClipperLib::ClipperOffset co;
     co.AddPath(subj, ClipperLib::jtMiter, ClipperLib::etClosedPolygon);
@@ -553,9 +553,9 @@ std::vector<Vec2> AutoPolygon::expand(const std::vector<Vec2>& points, const coc
         p2 = p2->GetNext();
     }
     auto end = p2->Contour.end();
-    for(std::vector<ClipperLib::IntPoint>::const_iterator pt = p2->Contour.begin(); pt < end; ++pt)
+    for(const auto& pt : p2->Contour)
     {
-        outPoints.push_back(Vec2(pt->X/PRECISION, pt->Y/PRECISION));
+        outPoints.push_back(Vec2(pt.X/PRECISION, pt.Y/PRECISION));
     }
     return outPoints;
 }
@@ -569,9 +569,9 @@ TrianglesCommand::Triangles AutoPolygon::triangulate(const std::vector<Vec2>& po
         return TrianglesCommand::Triangles();
     }
     std::vector<p2t::Point*> p2points;
-    for(std::vector<Vec2>::const_iterator it = points.begin(); it<points.end(); ++it)
+    for(const auto& it : points)
     {
-        p2t::Point * p = new (std::nothrow) p2t::Point(it->x, it->y);
+        p2t::Point * p = new (std::nothrow) p2t::Point(it.x, it.y);
         p2points.push_back(p);
     }
     p2t::CDT cdt(p2points);
@@ -585,11 +585,11 @@ TrianglesCommand::Triangles AutoPolygon::triangulate(const std::vector<Vec2>& po
     unsigned short idx = 0;
     unsigned short vdx = 0;
 
-    for(std::vector<p2t::Triangle*>::const_iterator ite = tris.begin(); ite != tris.end(); ++ite)
+    for(const auto& ite : tris)
     {
         for(int i = 0; i < 3; i++)
         {
-            auto p = (*ite)->GetPoint(i);
+            auto p = ite->GetPoint(i);
             auto v3 = Vec3(p->x, p->y, 0);
             bool found = false;
             size_t j;

--- a/cocos/2d/CCAutoPolygon.cpp
+++ b/cocos/2d/CCAutoPolygon.cpp
@@ -514,7 +514,7 @@ std::vector<Vec2> AutoPolygon::expand(const std::vector<Vec2>& points, const coc
     ClipperLib::Path subj;
     ClipperLib::PolyTree solution;
     ClipperLib::PolyTree out;
-    for(std::vector<Vec2>::const_iterator it = points.begin(); it<points.end(); it++)
+    for(std::vector<Vec2>::const_iterator it = points.begin(); it<points.end(); ++it)
     {
         subj << ClipperLib::IntPoint(it-> x* PRECISION, it->y * PRECISION);
     }
@@ -553,7 +553,7 @@ std::vector<Vec2> AutoPolygon::expand(const std::vector<Vec2>& points, const coc
         p2 = p2->GetNext();
     }
     auto end = p2->Contour.end();
-    for(std::vector<ClipperLib::IntPoint>::const_iterator pt = p2->Contour.begin(); pt < end; pt++)
+    for(std::vector<ClipperLib::IntPoint>::const_iterator pt = p2->Contour.begin(); pt < end; ++pt)
     {
         outPoints.push_back(Vec2(pt->X/PRECISION, pt->Y/PRECISION));
     }
@@ -569,7 +569,7 @@ TrianglesCommand::Triangles AutoPolygon::triangulate(const std::vector<Vec2>& po
         return TrianglesCommand::Triangles();
     }
     std::vector<p2t::Point*> p2points;
-    for(std::vector<Vec2>::const_iterator it = points.begin(); it<points.end(); it++)
+    for(std::vector<Vec2>::const_iterator it = points.begin(); it<points.end(); ++it)
     {
         p2t::Point * p = new (std::nothrow) p2t::Point(it->x, it->y);
         p2points.push_back(p);
@@ -585,7 +585,7 @@ TrianglesCommand::Triangles AutoPolygon::triangulate(const std::vector<Vec2>& po
     unsigned short idx = 0;
     unsigned short vdx = 0;
 
-    for(std::vector<p2t::Triangle*>::const_iterator ite = tris.begin(); ite != tris.end(); ite++)
+    for(std::vector<p2t::Triangle*>::const_iterator ite = tris.begin(); ite != tris.end(); ++ite)
     {
         for(int i = 0; i < 3; i++)
         {

--- a/cocos/audio/win32/SimpleAudioEngine.cpp
+++ b/cocos/audio/win32/SimpleAudioEngine.cpp
@@ -78,12 +78,10 @@ void SimpleAudioEngine::end()
 {
     sharedMusic().Close();
 
-    EffectList::iterator p = sharedList().begin();
-    while (p != sharedList().end())
+    for (auto& iter : sharedList())
     {
-        delete p->second;
-        p->second = nullptr;
-        ++p;
+        delete iter.second;
+        iter.second = nullptr;
     }   
     sharedList().clear();
     return;
@@ -204,10 +202,9 @@ void SimpleAudioEngine::pauseEffect(unsigned int nSoundId)
 
 void SimpleAudioEngine::pauseAllEffects()
 {
-    EffectList::iterator iter;
-    for (iter = sharedList().begin(); iter != sharedList().end(); ++iter)
+    for (auto& iter : sharedList())
     {
-        iter->second->Pause();
+        iter.second->Pause();
     }
 }
 
@@ -222,19 +219,17 @@ void SimpleAudioEngine::resumeEffect(unsigned int nSoundId)
 
 void SimpleAudioEngine::resumeAllEffects()
 {
-    EffectList::iterator iter;
-    for (iter = sharedList().begin(); iter != sharedList().end(); ++iter)
+    for (auto& iter : sharedList())
     {
-        iter->second->Resume();
+        iter.second->Resume();
     }
 }
 
 void SimpleAudioEngine::stopAllEffects()
 {
-    EffectList::iterator iter;
-    for (iter = sharedList().begin(); iter != sharedList().end(); ++iter)
+    for (auto& iter : sharedList())
     {
-        iter->second->Stop();
+        iter.second->Stop();
     }
 }
 

--- a/cocos/audio/win32/SimpleAudioEngine.cpp
+++ b/cocos/audio/win32/SimpleAudioEngine.cpp
@@ -83,7 +83,7 @@ void SimpleAudioEngine::end()
     {
         delete p->second;
         p->second = nullptr;
-        p++;
+        ++p;
     }   
     sharedList().clear();
     return;
@@ -205,7 +205,7 @@ void SimpleAudioEngine::pauseEffect(unsigned int nSoundId)
 void SimpleAudioEngine::pauseAllEffects()
 {
     EffectList::iterator iter;
-    for (iter = sharedList().begin(); iter != sharedList().end(); iter++)
+    for (iter = sharedList().begin(); iter != sharedList().end(); ++iter)
     {
         iter->second->Pause();
     }
@@ -223,7 +223,7 @@ void SimpleAudioEngine::resumeEffect(unsigned int nSoundId)
 void SimpleAudioEngine::resumeAllEffects()
 {
     EffectList::iterator iter;
-    for (iter = sharedList().begin(); iter != sharedList().end(); iter++)
+    for (iter = sharedList().begin(); iter != sharedList().end(); ++iter)
     {
         iter->second->Resume();
     }
@@ -232,7 +232,7 @@ void SimpleAudioEngine::resumeAllEffects()
 void SimpleAudioEngine::stopAllEffects()
 {
     EffectList::iterator iter;
-    for (iter = sharedList().begin(); iter != sharedList().end(); iter++)
+    for (iter = sharedList().begin(); iter != sharedList().end(); ++iter)
     {
         iter->second->Stop();
     }

--- a/cocos/editor-support/cocosbuilder/CCNodeLoaderLibrary.cpp
+++ b/cocos/editor-support/cocosbuilder/CCNodeLoaderLibrary.cpp
@@ -70,7 +70,7 @@ NodeLoader * NodeLoaderLibrary::getNodeLoader(const char* pClassName) {
 
 void NodeLoaderLibrary::purge(bool pReleaseNodeLoaders) {
     if(pReleaseNodeLoaders) {
-        for(NodeLoaderMap::iterator it = this->_nodeLoaders.begin(); it != this->_nodeLoaders.end(); it++) {
+        for(NodeLoaderMap::iterator it = this->_nodeLoaders.begin(); it != this->_nodeLoaders.end(); ++it) {
             it->second->release();
         }
     }

--- a/cocos/editor-support/cocosbuilder/CCNodeLoaderLibrary.cpp
+++ b/cocos/editor-support/cocosbuilder/CCNodeLoaderLibrary.cpp
@@ -70,8 +70,8 @@ NodeLoader * NodeLoaderLibrary::getNodeLoader(const char* pClassName) {
 
 void NodeLoaderLibrary::purge(bool pReleaseNodeLoaders) {
     if(pReleaseNodeLoaders) {
-        for(NodeLoaderMap::iterator it = this->_nodeLoaders.begin(); it != this->_nodeLoaders.end(); ++it) {
-            it->second->release();
+        for(auto& it : this->_nodeLoaders) {
+            it.second->release();
         }
     }
     this->_nodeLoaders.clear();

--- a/cocos/editor-support/cocostudio/CCActionManagerEx.cpp
+++ b/cocos/editor-support/cocostudio/CCActionManagerEx.cpp
@@ -167,7 +167,7 @@ ActionObject* ActionManagerEx::stopActionByName(const char* jsonName,const char*
 void ActionManagerEx::releaseActions()
 {
     std::unordered_map<std::string, cocos2d::Vector<ActionObject*>>::iterator iter;
-    for (iter = _actionDic.begin(); iter != _actionDic.end(); iter++)
+    for (iter = _actionDic.begin(); iter != _actionDic.end(); ++iter)
     {
         cocos2d::Vector<ActionObject*> objList = iter->second;
         ssize_t listCount = objList.size();

--- a/cocos/editor-support/cocostudio/CCActionManagerEx.cpp
+++ b/cocos/editor-support/cocostudio/CCActionManagerEx.cpp
@@ -166,10 +166,9 @@ ActionObject* ActionManagerEx::stopActionByName(const char* jsonName,const char*
     
 void ActionManagerEx::releaseActions()
 {
-    std::unordered_map<std::string, cocos2d::Vector<ActionObject*>>::iterator iter;
-    for (iter = _actionDic.begin(); iter != _actionDic.end(); ++iter)
+    for (auto& iter : _actionDic)
     {
-        cocos2d::Vector<ActionObject*> objList = iter->second;
+        cocos2d::Vector<ActionObject*> objList = iter.second;
         ssize_t listCount = objList.size();
         for (ssize_t i = 0; i < listCount; i++) {
             ActionObject* action = objList.at(i);

--- a/cocos/editor-support/cocostudio/CCDataReaderHelper.cpp
+++ b/cocos/editor-support/cocostudio/CCDataReaderHelper.cpp
@@ -504,18 +504,18 @@ void DataReaderHelper::addDataAsyncCallBack(float dt)
 
 void DataReaderHelper::removeConfigFile(const std::string& configFile)
 {
-    std::vector<std::string>::iterator it = _configFileList.end();
-    for (std::vector<std::string>::iterator i = _configFileList.begin(); i != _configFileList.end(); ++i)
+    std::vector<std::string>::iterator it = _configFileList.begin();
+    for (auto& i : _configFileList)
     {
-        if (*i == configFile)
-        {
-            it = i;
-        }
-    }
-
-    if (it != _configFileList.end())
-    {
-        _configFileList.erase(it);
+		if (i == configFile)
+		{
+			if (it != _configFileList.end())
+			{
+				_configFileList.erase(it);
+			}
+			break;
+		}
+		++it;
     }
 }
 

--- a/cocos/editor-support/cocostudio/CCDataReaderHelper.cpp
+++ b/cocos/editor-support/cocostudio/CCDataReaderHelper.cpp
@@ -504,21 +504,16 @@ void DataReaderHelper::addDataAsyncCallBack(float dt)
 
 void DataReaderHelper::removeConfigFile(const std::string& configFile)
 {
-    std::vector<std::string>::iterator it = _configFileList.begin();
-    for (auto& i : _configFileList)
+    auto it_end = _configFileList.end();
+    for (auto it = _configFileList.begin(); it != it_end; ++it)
     {
-		if (i == configFile)
-		{
-			if (it != _configFileList.end())
-			{
-				_configFileList.erase(it);
-			}
-			break;
-		}
-		++it;
+        if (*it == configFile)
+        {
+            _configFileList.erase(it);
+            break;
+        }
     }
 }
-
 
 
 void DataReaderHelper::addDataFromCache(const std::string& pFileContent, DataInfo *dataInfo)

--- a/cocos/editor-support/cocostudio/CCDataReaderHelper.cpp
+++ b/cocos/editor-support/cocostudio/CCDataReaderHelper.cpp
@@ -505,7 +505,7 @@ void DataReaderHelper::addDataAsyncCallBack(float dt)
 void DataReaderHelper::removeConfigFile(const std::string& configFile)
 {
     std::vector<std::string>::iterator it = _configFileList.end();
-    for (std::vector<std::string>::iterator i = _configFileList.begin(); i != _configFileList.end(); i++)
+    for (std::vector<std::string>::iterator i = _configFileList.begin(); i != _configFileList.end(); ++i)
     {
         if (*i == configFile)
         {

--- a/cocos/network/HttpClient-android.cpp
+++ b/cocos/network/HttpClient-android.cpp
@@ -467,7 +467,7 @@ private:
         std::vector<CookiesInfo> cookiesInfoVec;
         cookiesInfoVec.clear();
 
-        for (; iter != cookiesVec.end(); iter++)
+        for (; iter != cookiesVec.end(); ++iter)
         {
             std::string cookies = *iter;
             if (cookies.find("#HttpOnly_") != std::string::npos)
@@ -505,7 +505,7 @@ private:
         std::vector<CookiesInfo>::iterator cookiesIter = cookiesInfoVec.begin();
         std::string sendCookiesInfo = "";
         int cookiesCount = 0;
-        for (; cookiesIter != cookiesInfoVec.end(); cookiesIter++)
+        for (; cookiesIter != cookiesInfoVec.end(); ++cookiesIter)
         {
             if (_url.find(cookiesIter->domain) != std::string::npos)
             {

--- a/cocos/network/HttpClient-android.cpp
+++ b/cocos/network/HttpClient-android.cpp
@@ -133,16 +133,16 @@ public:
         if(!headers.empty())
         {
             /* append custom headers one by one */
-            for (auto& it : headers)
+            for (auto& header : headers)
             {
-                int len = it.length();
-                int pos = it.find(':');
+                int len = header.length();
+                int pos = header.find(':');
                 if (-1 == pos || pos >= len)
                 {
                     continue;
                 }
-                std::string str1 = it.substr(0, pos);
-                std::string str2 = it.substr(pos + 1, len - pos - 1);
+                std::string str1 = header.substr(0, pos);
+                std::string str2 = header.substr(pos + 1, len - pos - 1);
                 addRequestHeader(str1.c_str(), str2.c_str());
             }
         }
@@ -499,13 +499,13 @@ private:
 
         std::string sendCookiesInfo = "";
         int cookiesCount = 0;
-        for (auto& cookiesIter : cookiesInfoVec)
+        for (auto& cookieInfo : cookiesInfoVec)
         {
-            if (_url.find(cookiesIter.domain) != std::string::npos)
+            if (_url.find(cookieInfo.domain) != std::string::npos)
             {
-                std::string keyValue = cookiesIter.key;
+                std::string keyValue = cookieInfo.key;
                 keyValue.append("=");
-                keyValue.append(cookiesIter.value);
+                keyValue.append(cookieInfo.value);
                 if (cookiesCount != 0)
                     sendCookiesInfo.append(";");
                 

--- a/cocos/network/HttpClient-android.cpp
+++ b/cocos/network/HttpClient-android.cpp
@@ -133,18 +133,16 @@ public:
         if(!headers.empty())
         {
             /* append custom headers one by one */
-            for (HttpRequestHeadersIter it = headers.begin(); it != headers.end(); ++it)
+            for (auto& it : headers)
             {
-                std::string val = *it;
-                
-                int len = val.length();
-                int pos = val.find(':');
+                int len = it.length();
+                int pos = it.find(':');
                 if (-1 == pos || pos >= len)
                 {
                     continue;
                 }
-                std::string str1 = val.substr(0, pos);
-                std::string str2 = val.substr(pos + 1, len - pos - 1);
+                std::string str1 = it.substr(0, pos);
+                std::string str2 = it.substr(pos + 1, len - pos - 1);
                 addRequestHeader(str1.c_str(), str2.c_str());
             }
         }
@@ -462,14 +460,11 @@ private:
         if (cookiesVec.empty())
             return;
         
-        HttpCookiesIter iter = cookiesVec.begin();
-        
         std::vector<CookiesInfo> cookiesInfoVec;
         cookiesInfoVec.clear();
 
-        for (; iter != cookiesVec.end(); ++iter)
+        for (auto& cookies : cookiesVec)
         {
-            std::string cookies = *iter;
             if (cookies.find("#HttpOnly_") != std::string::npos)
             {
                 cookies = cookies.substr(10);
@@ -502,16 +497,15 @@ private:
             cookiesInfoVec.push_back(co);
         }
 
-        std::vector<CookiesInfo>::iterator cookiesIter = cookiesInfoVec.begin();
         std::string sendCookiesInfo = "";
         int cookiesCount = 0;
-        for (; cookiesIter != cookiesInfoVec.end(); ++cookiesIter)
+        for (auto& cookiesIter : cookiesInfoVec)
         {
-            if (_url.find(cookiesIter->domain) != std::string::npos)
+            if (_url.find(cookiesIter.domain) != std::string::npos)
             {
-                std::string keyValue = cookiesIter->key;
+                std::string keyValue = cookiesIter.key;
                 keyValue.append("=");
-                keyValue.append(cookiesIter->value);
+                keyValue.append(cookiesIter.value);
                 if (cookiesCount != 0)
                     sendCookiesInfo.append(";");
                 

--- a/cocos/platform/linux/CCDevice-linux.cpp
+++ b/cocos/platform/linux/CCDevice-linux.cpp
@@ -262,14 +262,14 @@ public:
                         textLines.push_back(currentLine);
                         currentLine.reset();
                         currentPaintPosition = 0;
-                        for ( auto& it : tempGlyphs ) {
+                        for ( auto& glyph : tempGlyphs ) {
                             if ( currentLine.glyphs.empty() ) {
-                                currentPaintPosition = -it.bearingX;
-                                it.kerning = 0;
+                                currentPaintPosition = -glyph.bearingX;
+                                glyph.kerning = 0;
                             }
-                            it.paintPosition = currentPaintPosition + it.bearingX + it.kerning;
-                            currentLine.glyphs.push_back(it);
-                            currentPaintPosition += it.kerning + it.horizAdvance;
+                            glyph.paintPosition = currentPaintPosition + glyph.bearingX + glyph.kerning;
+                            currentLine.glyphs.push_back(glyph);
+                            currentPaintPosition += glyph.kerning + glyph.horizAdvance;
                         }
                     } else {
                         // the current word is too big to fit into one line, insert line break right here

--- a/cocos/platform/linux/CCDevice-linux.cpp
+++ b/cocos/platform/linux/CCDevice-linux.cpp
@@ -262,7 +262,7 @@ public:
                         textLines.push_back(currentLine);
                         currentLine.reset();
                         currentPaintPosition = 0;
-                        for ( it = tempGlyphs.begin(); it != tempGlyphs.end(); it++ ) {
+                        for ( it = tempGlyphs.begin(); it != tempGlyphs.end(); ++it ) {
                             if ( currentLine.glyphs.empty() ) {
                                 currentPaintPosition = -(*it).bearingX;
                                 (*it).kerning = 0;

--- a/cocos/platform/linux/CCDevice-linux.cpp
+++ b/cocos/platform/linux/CCDevice-linux.cpp
@@ -262,14 +262,14 @@ public:
                         textLines.push_back(currentLine);
                         currentLine.reset();
                         currentPaintPosition = 0;
-                        for ( it = tempGlyphs.begin(); it != tempGlyphs.end(); ++it ) {
+                        for ( auto& it : tempGlyphs ) {
                             if ( currentLine.glyphs.empty() ) {
-                                currentPaintPosition = -(*it).bearingX;
-                                (*it).kerning = 0;
+                                currentPaintPosition = -it.bearingX;
+                                it.kerning = 0;
                             }
-                            (*it).paintPosition = currentPaintPosition + (*it).bearingX + (*it).kerning;
-                            currentLine.glyphs.push_back((*it));
-                            currentPaintPosition += (*it).kerning + (*it).horizAdvance;
+                            it.paintPosition = currentPaintPosition + it.bearingX + it.kerning;
+                            currentLine.glyphs.push_back(it);
+                            currentPaintPosition += it.kerning + it.horizAdvance;
                         }
                     } else {
                         // the current word is too big to fit into one line, insert line break right here

--- a/cocos/scripting/js-bindings/manual/ScriptingCore.cpp
+++ b/cocos/scripting/js-bindings/manual/ScriptingCore.cpp
@@ -666,8 +666,7 @@ void ScriptingCore::createGlobalContext() {
 
     runScript("script/jsb_prepare.js");
 
-    for (std::vector<sc_register_sth>::iterator it = registrationList.begin(); it != registrationList.end(); ++it) {
-        sc_register_sth callback = *it;
+    for (auto& callback : registrationList) {
         callback(_cx, global);
     }
     

--- a/cocos/scripting/js-bindings/manual/ScriptingCore.cpp
+++ b/cocos/scripting/js-bindings/manual/ScriptingCore.cpp
@@ -666,7 +666,7 @@ void ScriptingCore::createGlobalContext() {
 
     runScript("script/jsb_prepare.js");
 
-    for (std::vector<sc_register_sth>::iterator it = registrationList.begin(); it != registrationList.end(); it++) {
+    for (std::vector<sc_register_sth>::iterator it = registrationList.begin(); it != registrationList.end(); ++it) {
         sc_register_sth callback = *it;
         callback(_cx, global);
     }


### PR DESCRIPTION
The following error messages related to the ++ and -- operators are shown by `cppcheck`:

```
[2d/CCAutoPolygon.cpp:517]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[2d/CCAutoPolygon.cpp:556]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[2d/CCAutoPolygon.cpp:572]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[2d/CCAutoPolygon.cpp:588]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[audio/win32/SimpleAudioEngine.cpp:86]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[audio/win32/SimpleAudioEngine.cpp:208]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[audio/win32/SimpleAudioEngine.cpp:226]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[audio/win32/SimpleAudioEngine.cpp:235]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[editor-support/cocosbuilder/CCNodeLoaderLibrary.cpp:73]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[editor-support/cocostudio/CCActionManagerEx.cpp:170]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[editor-support/cocostudio/CCDataReaderHelper.cpp:508]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[network/HttpClient-android.cpp:470]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[network/HttpClient-android.cpp:508]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[platform/linux/CCDevice-linux.cpp:265]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[scripting/js-bindings/manual/ScriptingCore.cpp:669]: (performance) Prefer prefix ++/-- operators for non-primitive types.
```

This pull request is rather self-explanatory, but prefixing ++ for non-primitive data types will yield a performance boost. 
