### PR TITLE
Removed COCOS2D_DEBUG from Android simulator on release build

### DIFF
--- a/tools/simulator/frameworks/runtime-src/proj.android/jni/Application.mk
+++ b/tools/simulator/frameworks/runtime-src/proj.android/jni/Application.mk
@@ -9,7 +9,6 @@ ifeq ($(NDK_DEBUG),1)
   APP_OPTIM := debug
 else
   APP_CPPFLAGS += -DNDEBUG
-  APP_CPPFLAGS += -DCOCOS2D_DEBUG=1
   APP_OPTIM := release
 endif
 


### PR DESCRIPTION
I don't think COCOS2D_DEBUG should be defined when building the project for Android simulator on release mode.

Related: #16559
