### PR TITLE
Removed unnecessary comments

### DIFF
--- a/cocos/2d/CCActionCamera.h
+++ b/cocos/2d/CCActionCamera.h
@@ -44,7 +44,7 @@ class Camera;
  *@brief Base class for Camera actions.
  *@ingroup Actions
  */
-class CC_DLL ActionCamera : public ActionInterval //<NSCopying> 
+class CC_DLL ActionCamera : public ActionInterval
 {
 public:
     /**
@@ -117,7 +117,7 @@ protected:
  * Orbits the camera around the center of the screen using spherical coordinates.
  * @ingroup Actions
  */
-class CC_DLL OrbitCamera : public ActionCamera //<NSCopying> 
+class CC_DLL OrbitCamera : public ActionCamera
 {
 public:
     /** Creates a OrbitCamera action with radius, delta-radius,  z, deltaZ, x, deltaX. 

--- a/cocos/2d/CCActionInstant.h
+++ b/cocos/2d/CCActionInstant.h
@@ -41,7 +41,7 @@ NS_CC_BEGIN
 /** @class ActionInstant
 * @brief Instant actions are immediate actions. They don't have a duration like the IntervalAction actions.
 **/
-class CC_DLL ActionInstant : public FiniteTimeAction //<NSCopying>
+class CC_DLL ActionInstant : public FiniteTimeAction
 {
 public:
     //
@@ -276,7 +276,7 @@ private:
 /** @class Place
 * @brief Places the node in a certain position.
 */
-class CC_DLL Place : public ActionInstant //<NSCopying>
+class CC_DLL Place : public ActionInstant
 {
 public:
 
@@ -315,7 +315,7 @@ private:
 /** @class CallFunc
 * @brief Calls a 'callback'.
 */
-class CC_DLL CallFunc : public ActionInstant //<NSCopying>
+class CC_DLL CallFunc : public ActionInstant
 {
 public:
     /** Creates the action with the callback of type std::function<void()>.

--- a/cocos/network/HttpRequest.h
+++ b/cocos/network/HttpRequest.h
@@ -292,7 +292,6 @@ public:
         _prxy( SEL_HttpResponse cb ) :_cb(cb) {}
         /** Destructor. */
         ~_prxy(){};
-        /** Destructor. */
         operator SEL_HttpResponse() const { return _cb; }
         CC_DEPRECATED_ATTRIBUTE operator SEL_CallFuncND()   const { return (SEL_CallFuncND) _cb; }
     protected:

--- a/extensions/GUI/CCControlExtension/CCControl.cpp
+++ b/extensions/GUI/CCControlExtension/CCControl.cpp
@@ -184,7 +184,6 @@ void Control::removeTargetWithActionForControlEvents(Ref* target, Handler action
 void Control::removeTargetWithActionForControlEvent(Ref* target, Handler action, EventType controlEvent)
 {
     // Retrieve all invocations for the given control event
-    //<Invocation*>
     auto& eventInvocationList = this->dispatchListforControlEvent(controlEvent);
     
     //remove all invocations if the target and action are null


### PR DESCRIPTION
This PR removes several unnecessary comments to avoid clutter. It also fixes the following warnings when compiling using clang with `-Wdocumentation` compiler option.

```
cocos/2d/CCActionCamera.h:47:51: warning: not a Doxygen trailing comment [-Wdocumentation]
class CC_DLL ActionCamera : public ActionInterval //<NSCopying> 
                                                  ^~~~~~~~~~~~
                                                  ///<
cocos/2d/CCActionCamera.h:120:48: warning: not a Doxygen trailing comment [-Wdocumentation]
class CC_DLL OrbitCamera : public ActionCamera //<NSCopying> 
                                               ^~~~~~~~~~~~
                                               ///<
cocos/2d/CCActionInstant.h:44:54: warning: not a Doxygen trailing comment [-Wdocumentation]
class CC_DLL ActionInstant : public FiniteTimeAction //<NSCopying>
                                                     ^~~~~~~~~~~~
                                                     ///<
cocos/2d/CCActionInstant.h:279:43: warning: not a Doxygen trailing comment [-Wdocumentation]
class CC_DLL Place : public ActionInstant //<NSCopying>
                                          ^~~~~~~~~~~~
                                          ///<
cocos/2d/CCActionInstant.h:318:46: warning: not a Doxygen trailing comment [-Wdocumentation]
class CC_DLL CallFunc : public ActionInstant //<NSCopying>
                                             ^~~~~~~~~~~~
                                             ///<
extensions/GUI/CCControlExtension/CCControl.cpp:187:5: warning: not a Doxygen trailing comment [-Wdocumentation]
    //<Invocation*>
    ^~~~~~~~~~~~~
    ///<
```

Thanks!
