### PR TITLE
Correct the Skybox fov

### DIFF
--- a/cocos/3d/CCSkybox.cpp
+++ b/cocos/3d/CCSkybox.cpp
@@ -109,11 +109,29 @@ void Skybox::initBuffers()
         glGenVertexArrays(1, &_vao);
         GL::bindVAO(_vao);
     }
+	// The skybox is rendered using a purpose-built shader which makes use of
+	// the shader language's inherent support for cubemaps. Hence there is no
+	// need to build a cube mesh. All that is needed is a single quad that
+	// covers the entire screen. The vertex shader will draw the appropriate
+	// view of the cubemap onto that quad.
+	//
+	// The vertex shader does not apply either the model/view matrix or the
+	// projection matrix, so the appropriate quad is one with unit coordinates
+	// in the x and y dimensions. Such a quad will exacly cover the screen.
+	// To ensure that the skybox is rendered behind all other objects, z needs
+	// to be 1.0, but the vertex shader overwrites z to 1.0, so - for the sake
+	// of z-buffering - it is unimportant what we set it to for the verticies
+	// of the quad.
+	//
+	// The quad vertex positions are also used in deriving a direction
+	// vector for the cubemap lookup. We choose z = -1 which matches the
+	// negative-z pointing direction of the camera and gives a field of
+	// view of 90deg in both x and y (the field of view should be adjusted
+	// to match the camera, but isn't currently).
 
     // init vertex buffer object
     Vec3 vexBuf[] =
     {
-        Vec3(1, -1, 1),  Vec3(1, 1, 1),  Vec3(-1, 1, 1),  Vec3(-1, -1, 1),
         Vec3(1, -1, -1), Vec3(1, 1, -1), Vec3(-1, 1, -1), Vec3(-1, -1, -1)
     };
 
@@ -122,13 +140,7 @@ void Skybox::initBuffers()
     glBufferData(GL_ARRAY_BUFFER, sizeof(vexBuf), vexBuf, GL_STATIC_DRAW);
 
     // init index buffer object
-    const unsigned char idxBuf[] = {  2, 1, 0, 3, 2, 0, // font
-        1, 5, 4, 1, 4, 0, // right
-        4, 5, 6, 4, 6, 7, // back
-        7, 6, 2, 7, 2, 3, // left
-        2, 6, 5, 2, 5, 1, // up
-        3, 0, 4, 3, 4, 7  // down
-    };
+    const unsigned char idxBuf[] = {0, 1, 2, 0, 2, 3};
 
     glGenBuffers(1, &_indexBuffer);
     glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, _indexBuffer);
@@ -195,7 +207,7 @@ void Skybox::onDraw(const Mat4& transform, uint32_t flags)
         glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, _indexBuffer);
     }
 
-    glDrawElements(GL_TRIANGLES, (GLsizei)36, GL_UNSIGNED_BYTE, nullptr);
+    glDrawElements(GL_TRIANGLES, (GLsizei)6, GL_UNSIGNED_BYTE, nullptr);
 
     if (Configuration::getInstance()->supportsShareableVAO())
     {
@@ -207,7 +219,7 @@ void Skybox::onDraw(const Mat4& transform, uint32_t flags)
         glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
     }
 
-    CC_INCREMENT_GL_DRAWN_BATCHES_AND_VERTICES(1, 8);
+    CC_INCREMENT_GL_DRAWN_BATCHES_AND_VERTICES(1, 4);
 
     CHECK_GL_ERROR_DEBUG();
 }

--- a/tests/cpp-tests/Classes/Scene3DTest/Scene3DTest.cpp
+++ b/tests/cpp-tests/Classes/Scene3DTest/Scene3DTest.cpp
@@ -380,7 +380,6 @@ void Scene3DTestScene::createWorld3D()
     _skyBox = Skybox::create();
     _skyBox->setCameraMask(s_CM[LAYER_BACKGROUND]);
     _skyBox->setTexture(_textureCube);
-    _skyBox->setScale(700.f);
 
     // create terrain
     Terrain::DetailMap r("TerrainTest/dirt.jpg");

--- a/tests/js-tests/src/Sprite3DTest/Sprite3DTest.js
+++ b/tests/js-tests/src/Sprite3DTest/Sprite3DTest.js
@@ -1596,7 +1596,6 @@ var Sprite3DCubeMapTest = Sprite3DTestDemo.extend({
         var skybox = jsb.Skybox.create();
         skybox.setTexture(textureCube);
         this.addChild(skybox);
-        skybox.setScale(700);
 
         this.addChild(camera);
         this.setCameraMask(2);

--- a/tests/lua-tests/src/Scene3DTest/Scene3DTest.lua
+++ b/tests/lua-tests/src/Scene3DTest/Scene3DTest.lua
@@ -350,7 +350,6 @@ function Scene3DTest:create3DWorld()
     self._skyBox = cc.Skybox:create()
     self._skyBox:setCameraMask(s_CM[GAME_LAYER.LAYER_SKYBOX])
     self._skyBox:setTexture(self._textureCube)
-    self._skyBox:setScale(700.0)
     self:addChild(self._skyBox)
 
     local targetPlatform = cc.Application:getInstance():getTargetPlatform()

--- a/tests/lua-tests/src/Sprite3DTest/Sprite3DTest.lua
+++ b/tests/lua-tests/src/Sprite3DTest/Sprite3DTest.lua
@@ -1179,7 +1179,6 @@ function Sprite3DCubeMapTest:addNewSpriteWithCoords(pos)
 
     self._skyBox:setTexture(self._textureCube)
     self:addChild(self._skyBox)
-    self._skyBox:setScale(700)
 
     self:addChild(camera)
     self:setCameraMask(2)


### PR DESCRIPTION
The Skybox implementation didn't correctly account for the camera's field of view and aspect ratio. This
showed particularly badly if the camera was pointed down and rotated, which produced a deformation
of the image as it rotated. On of these commits corrects that.

Also, while analysing this, it was noticed that the skybox implementation was using an unnecessarily
complicated mesh with faces that were never rendered. That is corrected in one of the other commits.

The one other commit removes all setScale applied to skyboxes from the test code. The skybox
implementation makes no use of the MVP transform and hence is uneffected by scaling operations.
