### PR TITLE
Mac edit box bug fixes

### DIFF
--- a/cocos/ui/UIEditBox/Mac/CCUIEditBoxMac.mm
+++ b/cocos/ui/UIEditBox/Mac/CCUIEditBoxMac.mm
@@ -63,6 +63,7 @@
 - (void)createMultiLineTextField
 {
     CCUIMultilineTextField *textView = [[[CCUIMultilineTextField alloc] initWithFrame:self.frameRect] autorelease];
+    [textView setVerticallyResizable:NO];
     self.textInput = textView;
 }
 
@@ -95,8 +96,7 @@
     [_textInput performSelector:@selector(setBackgroundColor:) withObject:[NSColor clearColor]];
  
     if (![_textInput isKindOfClass:[NSTextView class]]) {
-        [_textInput performSelector:@selector(setBordered:)
-                         withObject:[NSNumber numberWithBool:NO]];
+        [_textInput performSelector:@selector(setBordered:) withObject:nil];
     }
     _textInput.hidden = NO;
     _textInput.wantsLayer = YES;


### PR DESCRIPTION
- Don't allow multiline to overflow bounds of box (see below for screenshots)
- Fix bug w/ performSelector

**Before (Kind of hard to see, but notice there is a black border around the email box while editing)**
<img width="1072" alt="screen shot 2016-10-06 at 12 25 08 pm" src="https://cloud.githubusercontent.com/assets/6953200/19166348/5de89096-8bc4-11e6-9b02-d4c6f8344f49.png">
**After**
<img width="1072" alt="screen shot 2016-10-06 at 12 26 11 pm" src="https://cloud.githubusercontent.com/assets/6953200/19166330/5018cb0c-8bc4-11e6-9f23-30abac878ea9.png">
