### PR TITLE
Remove unnecessary const return qualifiers

### DIFF
--- a/cocos/math/Mat4.h
+++ b/cocos/math/Mat4.h
@@ -876,7 +876,7 @@ public:
      * @param mat The matrix to add.
      * @return The matrix sum.
      */
-    inline const Mat4 operator+(const Mat4& mat) const;
+    inline Mat4 operator+(const Mat4& mat) const;
     
     /**
      * Adds the given matrix to this matrix.
@@ -894,7 +894,7 @@ public:
      * @param mat The matrix to subtract.
      * @return The matrix difference.
      */
-    inline const Mat4 operator-(const Mat4& mat) const;
+    inline Mat4 operator-(const Mat4& mat) const;
 
     /**
      * Subtracts the given matrix from this matrix.
@@ -911,7 +911,7 @@ public:
      * 
      * @return The negation of this matrix.
      */
-    inline const Mat4 operator-() const;
+    inline Mat4 operator-() const;
 
     /**
      * Calculates the matrix product of this matrix with the given matrix.
@@ -921,7 +921,7 @@ public:
      * @param mat The matrix to multiply by.
      * @return The matrix product.
      */
-    inline const Mat4 operator*(const Mat4& mat) const;
+    inline Mat4 operator*(const Mat4& mat) const;
 
     /**
      * Right-multiplies this matrix by the given matrix.
@@ -963,7 +963,7 @@ inline Vec3& operator*=(Vec3& v, const Mat4& m);
  * @param v The vector to transform.
  * @return The resulting transformed vector.
  */
-inline const Vec3 operator*(const Mat4& m, const Vec3& v);
+inline Vec3 operator*(const Mat4& m, const Vec3& v);
 
 /**
  * Transforms the given vector by the given matrix.
@@ -985,7 +985,7 @@ inline Vec4& operator*=(Vec4& v, const Mat4& m);
  * @param v The vector to transform.
  * @return The resulting transformed vector.
  */
-inline const Vec4 operator*(const Mat4& m, const Vec4& v);
+inline Vec4 operator*(const Mat4& m, const Vec4& v);
 
 NS_CC_MATH_END
 /**

--- a/cocos/math/Mat4.inl
+++ b/cocos/math/Mat4.inl
@@ -22,7 +22,7 @@
 
 NS_CC_MATH_BEGIN
 
-inline const Mat4 Mat4::operator+(const Mat4& mat) const
+inline Mat4 Mat4::operator+(const Mat4& mat) const
 {
     Mat4 result(*this);
     result.add(mat);
@@ -35,7 +35,7 @@ inline Mat4& Mat4::operator+=(const Mat4& mat)
     return *this;
 }
 
-inline const Mat4 Mat4::operator-(const Mat4& mat) const
+inline Mat4 Mat4::operator-(const Mat4& mat) const
 {
     Mat4 result(*this);
     result.subtract(mat);
@@ -48,14 +48,14 @@ inline Mat4& Mat4::operator-=(const Mat4& mat)
     return *this;
 }
 
-inline const Mat4 Mat4::operator-() const
+inline Mat4 Mat4::operator-() const
 {
     Mat4 mat(*this);
     mat.negate();
     return mat;
 }
 
-inline const Mat4 Mat4::operator*(const Mat4& mat) const
+inline Mat4 Mat4::operator*(const Mat4& mat) const
 {
     Mat4 result(*this);
     result.multiply(mat);
@@ -74,7 +74,7 @@ inline Vec3& operator*=(Vec3& v, const Mat4& m)
     return v;
 }
 
-inline const Vec3 operator*(const Mat4& m, const Vec3& v)
+inline Vec3 operator*(const Mat4& m, const Vec3& v)
 {
     Vec3 x;
     m.transformVector(v, &x);
@@ -87,7 +87,7 @@ inline Vec4& operator*=(Vec4& v, const Mat4& m)
     return v;
 }
 
-inline const Vec4 operator*(const Mat4& m, const Vec4& v)
+inline Vec4 operator*(const Mat4& m, const Vec4& v)
 {
     Vec4 x;
     m.transformVector(v, &x);

--- a/cocos/math/Quaternion.h
+++ b/cocos/math/Quaternion.h
@@ -359,7 +359,7 @@ public:
      * @param q The quaternion to multiply.
      * @return The quaternion product.
      */
-    inline const Quaternion operator*(const Quaternion& q) const;
+    inline Quaternion operator*(const Quaternion& q) const;
 
     /**
      * Calculates the quaternion product of this quaternion with the given vec3.

--- a/cocos/math/Quaternion.inl
+++ b/cocos/math/Quaternion.inl
@@ -22,7 +22,7 @@
 
 NS_CC_MATH_BEGIN
 
-inline const Quaternion Quaternion::operator*(const Quaternion& q) const
+inline Quaternion Quaternion::operator*(const Quaternion& q) const
 {
     Quaternion result(*this);
     result.multiply(q);

--- a/cocos/math/Vec2.h
+++ b/cocos/math/Vec2.h
@@ -350,7 +350,7 @@ public:
      * @param v The vector to add.
      * @return The vector sum.
      */
-    inline const Vec2 operator+(const Vec2& v) const;
+    inline Vec2 operator+(const Vec2& v) const;
 
     /**
      * Adds the given vector to this vector.
@@ -368,7 +368,7 @@ public:
      * @param v The vector to add.
      * @return The vector sum.
      */
-    inline const Vec2 operator-(const Vec2& v) const;
+    inline Vec2 operator-(const Vec2& v) const;
 
     /**
      * Subtracts the given vector from this vector.
@@ -385,7 +385,7 @@ public:
      * 
      * @return The negation of this vector.
      */
-    inline const Vec2 operator-() const;
+    inline Vec2 operator-() const;
 
     /**
      * Calculates the scalar product of this vector with the given value.
@@ -395,7 +395,7 @@ public:
      * @param s The value to scale by.
      * @return The scaled vector.
      */
-    inline const Vec2 operator*(float s) const;
+    inline Vec2 operator*(float s) const;
 
     /**
      * Scales this vector by the given value.
@@ -413,7 +413,7 @@ public:
      * @param s the constant to divide this vector with
      * @return a smaller vector
      */
-    inline const Vec2 operator/(float s) const;
+    inline Vec2 operator/(float s) const;
 
     /**
      * Determines if this vector is less than the given vector.
@@ -755,7 +755,7 @@ public:
  * @param v The vector to scale.
  * @return The scaled vector.
  */
-inline const Vec2 operator*(float x, const Vec2& v);
+inline Vec2 operator*(float x, const Vec2& v);
 
 typedef Vec2 Point;
 

--- a/cocos/math/Vec2.inl
+++ b/cocos/math/Vec2.inl
@@ -139,7 +139,7 @@ inline void Vec2::smooth(const Vec2& target, float elapsedTime, float responseTi
     }
 }
 
-inline const Vec2 Vec2::operator+(const Vec2& v) const
+inline Vec2 Vec2::operator+(const Vec2& v) const
 {
     Vec2 result(*this);
     result.add(v);
@@ -152,7 +152,7 @@ inline Vec2& Vec2::operator+=(const Vec2& v)
     return *this;
 }
 
-inline const Vec2 Vec2::operator-(const Vec2& v) const
+inline Vec2 Vec2::operator-(const Vec2& v) const
 {
     Vec2 result(*this);
     result.subtract(v);
@@ -165,14 +165,14 @@ inline Vec2& Vec2::operator-=(const Vec2& v)
     return *this;
 }
 
-inline const Vec2 Vec2::operator-() const
+inline Vec2 Vec2::operator-() const
 {
     Vec2 result(*this);
     result.negate();
     return result;
 }
 
-inline const Vec2 Vec2::operator*(float s) const
+inline Vec2 Vec2::operator*(float s) const
 {
     Vec2 result(*this);
     result.scale(s);
@@ -185,7 +185,7 @@ inline Vec2& Vec2::operator*=(float s)
     return *this;
 }
 
-inline const Vec2 Vec2::operator/(const float s) const
+inline Vec2 Vec2::operator/(const float s) const
 {
     return Vec2(this->x / s, this->y / s);
 }
@@ -218,7 +218,7 @@ inline bool Vec2::operator!=(const Vec2& v) const
     return x!=v.x || y!=v.y;
 }
 
-inline const Vec2 operator*(float x, const Vec2& v)
+inline Vec2 operator*(float x, const Vec2& v)
 {
     Vec2 result(v);
     result.scale(x);

--- a/cocos/math/Vec3.h
+++ b/cocos/math/Vec3.h
@@ -376,7 +376,7 @@ public:
      * @param v The vector to add.
      * @return The vector sum.
      */
-    inline const Vec3 operator+(const Vec3& v) const;
+    inline Vec3 operator+(const Vec3& v) const;
 
     /**
      * Adds the given vector to this vector.
@@ -394,7 +394,7 @@ public:
      * @param v The vector to subtract.
      * @return The vector difference.
      */
-    inline const Vec3 operator-(const Vec3& v) const;
+    inline Vec3 operator-(const Vec3& v) const;
 
     /**
      * Subtracts the given vector from this vector.
@@ -411,7 +411,7 @@ public:
      * 
      * @return The negation of this vector.
      */
-    inline const Vec3 operator-() const;
+    inline Vec3 operator-() const;
 
     /**
      * Calculates the scalar product of this vector with the given value.
@@ -421,7 +421,7 @@ public:
      * @param s The value to scale by.
      * @return The scaled vector.
      */
-    inline const Vec3 operator*(float s) const;
+    inline Vec3 operator*(float s) const;
 
     /**
      * Scales this vector by the given value.
@@ -439,7 +439,7 @@ public:
      * @param s the constant to divide this vector with
      * @return a smaller vector
      */
-    inline const Vec3 operator/(float s) const;
+    inline Vec3 operator/(float s) const;
 
     /** Returns true if the vector's scalar components are all greater
      that the ones of the vector it is compared against.
@@ -498,7 +498,7 @@ public:
  * @param v The vector to scale.
  * @return The scaled vector.
  */
-inline const Vec3 operator*(float x, const Vec3& v);
+inline Vec3 operator*(float x, const Vec3& v);
 
 //typedef Vec3 Point3;
 

--- a/cocos/math/Vec3.inl
+++ b/cocos/math/Vec3.inl
@@ -119,7 +119,7 @@ inline void Vec3::subtract(const Vec3& v)
     z -= v.z;
 }
 
-inline const Vec3 Vec3::operator+(const Vec3& v) const
+inline Vec3 Vec3::operator+(const Vec3& v) const
 {
     Vec3 result(*this);
     result.add(v);
@@ -132,7 +132,7 @@ inline Vec3& Vec3::operator+=(const Vec3& v)
     return *this;
 }
 
-inline const Vec3 Vec3::operator-(const Vec3& v) const
+inline Vec3 Vec3::operator-(const Vec3& v) const
 {
     Vec3 result(*this);
     result.subtract(v);
@@ -145,14 +145,14 @@ inline Vec3& Vec3::operator-=(const Vec3& v)
     return *this;
 }
 
-inline const Vec3 Vec3::operator-() const
+inline Vec3 Vec3::operator-() const
 {
     Vec3 result(*this);
     result.negate();
     return result;
 }
 
-inline const Vec3 Vec3::operator*(float s) const
+inline Vec3 Vec3::operator*(float s) const
 {
     Vec3 result(*this);
     result.scale(s);
@@ -165,7 +165,7 @@ inline Vec3& Vec3::operator*=(float s)
     return *this;
 }
 
-inline const Vec3 Vec3::operator/(const float s) const
+inline Vec3 Vec3::operator/(const float s) const
 {
     return Vec3(this->x / s, this->y / s, this->z / s);
 }
@@ -180,7 +180,7 @@ inline bool Vec3::operator!=(const Vec3& v) const
     return x!=v.x || y!=v.y || z!=v.z;
 }
 
-inline const Vec3 operator*(float x, const Vec3& v)
+inline Vec3 operator*(float x, const Vec3& v)
 {
     Vec3 result(v);
     result.scale(x);

--- a/cocos/math/Vec4.h
+++ b/cocos/math/Vec4.h
@@ -343,7 +343,7 @@ public:
      * @param v The vector to add.
      * @return The vector sum.
      */
-    inline const Vec4 operator+(const Vec4& v) const;
+    inline Vec4 operator+(const Vec4& v) const;
 
     /**
      * Adds the given vector to this vector.
@@ -361,7 +361,7 @@ public:
      * @param v The vector to add.
      * @return The vector sum.
      */
-    inline const Vec4 operator-(const Vec4& v) const;
+    inline Vec4 operator-(const Vec4& v) const;
 
     /**
      * Subtracts the given vector from this vector.
@@ -378,7 +378,7 @@ public:
      * 
      * @return The negation of this vector.
      */
-    inline const Vec4 operator-() const;
+    inline Vec4 operator-() const;
 
     /**
      * Calculates the scalar product of this vector with the given value.
@@ -388,7 +388,7 @@ public:
      * @param s The value to scale by.
      * @return The scaled vector.
      */
-    inline const Vec4 operator*(float s) const;
+    inline Vec4 operator*(float s) const;
 
     /**
      * Scales this vector by the given value.
@@ -406,7 +406,7 @@ public:
      * @param s the constant to divide this vector with
      * @return a smaller vector
      */
-    inline const Vec4 operator/(float s) const;
+    inline Vec4 operator/(float s) const;
 
     /**
      * Determines if this vector is less than the given vector.
@@ -456,7 +456,7 @@ public:
  * @param v The vector to scale.
  * @return The scaled vector.
  */
-inline const Vec4 operator*(float x, const Vec4& v);
+inline Vec4 operator*(float x, const Vec4& v);
 
 NS_CC_MATH_END
 /**

--- a/cocos/math/Vec4.inl
+++ b/cocos/math/Vec4.inl
@@ -23,7 +23,7 @@
 
 NS_CC_MATH_BEGIN
 
-inline const Vec4 Vec4::operator+(const Vec4& v) const
+inline Vec4 Vec4::operator+(const Vec4& v) const
 {
     Vec4 result(*this);
     result.add(v);
@@ -36,7 +36,7 @@ inline Vec4& Vec4::operator+=(const Vec4& v)
     return *this;
 }
 
-inline const Vec4 Vec4::operator-(const Vec4& v) const
+inline Vec4 Vec4::operator-(const Vec4& v) const
 {
     Vec4 result(*this);
     result.subtract(v);
@@ -49,14 +49,14 @@ inline Vec4& Vec4::operator-=(const Vec4& v)
     return *this;
 }
 
-inline const Vec4 Vec4::operator-() const
+inline Vec4 Vec4::operator-() const
 {
     Vec4 result(*this);
     result.negate();
     return result;
 }
 
-inline const Vec4 Vec4::operator*(float s) const
+inline Vec4 Vec4::operator*(float s) const
 {
     Vec4 result(*this);
     result.scale(s);
@@ -69,7 +69,7 @@ inline Vec4& Vec4::operator*=(float s)
     return *this;
 }
 
-inline const Vec4 Vec4::operator/(const float s) const
+inline Vec4 Vec4::operator/(const float s) const
 {
     return Vec4(this->x / s, this->y / s, this->z / s, this->w / s);
 }
@@ -104,7 +104,7 @@ inline bool Vec4::operator!=(const Vec4& v) const
     return x!=v.x || y!=v.y || z!=v.z || w!=v.w;
 }
 
-inline const Vec4 operator*(float x, const Vec4& v)
+inline Vec4 operator*(float x, const Vec4& v)
 {
     Vec4 result(v);
     result.scale(x);

--- a/cocos/ui/UITabControl.cpp
+++ b/cocos/ui/UITabControl.cpp
@@ -565,7 +565,7 @@ namespace ui
         _tabLabelRender->setPosition(_contentSize * 0.5f);
     }
 
-    const std::string TabHeader::getTitleText() const
+    std::string TabHeader::getTitleText() const
     {
         if (nullptr == _tabLabelRender)
         {
@@ -658,7 +658,7 @@ namespace ui
         return _tabLabelRender;
     }
 
-    const std::string TabHeader::getTitleFontName() const
+    std::string TabHeader::getTitleFontName() const
     {
         if (this->_fontType == FontType::SYSTEM)
         {

--- a/cocos/ui/UITabControl.h
+++ b/cocos/ui/UITabControl.h
@@ -111,7 +111,7 @@ namespace ui {
          * get the TabHeader text
          *@return he TabHeader text
          */
-        const std::string getTitleText() const;
+        std::string getTitleText() const;
         
         /**
          * Change the color of he TabHeader text
@@ -147,7 +147,7 @@ namespace ui {
          * get the font name of TabHeader text
          *@return font name in std::string
          */
-        const std::string getTitleFontName() const;
+        std::string getTitleFontName() const;
         
         /**
          * get the index this header in the TabControl


### PR DESCRIPTION
This PR gets rid of `const` qualifiers from return types which are copy and not reference, for the same reason PR #15132. Thanks.
