### PR TITLE
Lua: have cc.Ray:intersects additionally return the distance

### DIFF
--- a/cocos/scripting/lua-bindings/manual/3d/lua_cocos2dx_3d_manual.cpp
+++ b/cocos/scripting/lua-bindings/manual/3d/lua_cocos2dx_3d_manual.cpp
@@ -2044,15 +2044,17 @@ int lua_cocos2dx_3d_Ray_intersects(lua_State* L)
         if (!ok)
             return 0;
 
-        bool ret = self->intersects(*arg0);
+        float distance;
+        bool ret = self->intersects(*arg0, &distance);
         tolua_pushboolean(L, ret);
-        return 1;
+        tolua_pushnumber(L, (lua_Number)distance);
+        return 2;
     }
     luaL_error(L, "%s has wrong number of arguments: %d, was expecting %d \n",  "cc.Ray:intersects",argc, 1);
     return 0;
 #if COCOS2D_DEBUG >= 1
 tolua_lerror:
-    tolua_error(L,"#ferror in function 'lua_cocos2dx_3d_get_OBB_center'.",&tolua_err);
+    tolua_error(L,"#ferror in function 'lua_cocos2dx_3d_Ray_intersects'.",&tolua_err);
     return 0;
 #endif
 }


### PR DESCRIPTION
cc.Ray:intersects now returns two results, an indication of hit or
not, plus the distance along the ray. The function can still be called
expecting a single argument and hence is backward compatible.

Also correct the debug error message
