### PR TITLE
Remove unused local variable

### DIFF
--- a/cocos/2d/CCAutoPolygon.cpp
+++ b/cocos/2d/CCAutoPolygon.cpp
@@ -552,7 +552,6 @@ std::vector<Vec2> AutoPolygon::expand(const std::vector<Vec2>& points, const coc
     while(p2->IsHole()){
         p2 = p2->GetNext();
     }
-    auto end = p2->Contour.end();
     for(const auto& pt : p2->Contour)
     {
         outPoints.push_back(Vec2(pt.X/PRECISION, pt.Y/PRECISION));


### PR DESCRIPTION
Hello, I get this warning when compiling libcocos2d with Xcode 8.0:

```
cocos/2d/CCAutoPolygon.cpp:555:10: unused variable 'end' [-Wunused-variable]
```

This PR removes an unused variable `end` (which was used for iterating vector before commit cdee1e1) and fixes it.

Thanks!
