### PR TITLE
Fix typos in comments and strings

### DIFF
--- a/cocos/2d/CCAutoPolygon.h
+++ b/cocos/2d/CCAutoPolygon.h
@@ -158,7 +158,7 @@ public:
     
     /**
      * reduce the amount of points so its faster for GPU to process and draw
-     * based on Ramer-Douglas-Puecker algorithm
+     * based on Ramer-Douglas-Peucker algorithm
      * @param   points  a vector of Vec2 points as input
      * @param   rect    a texture rect for specify an area of the image to avoid over reduction
      * @param   epsilon the perpendicular distance where points smaller than this value will be discarded

--- a/cocos/2d/CCFontAtlas.cpp
+++ b/cocos/2d/CCFontAtlas.cpp
@@ -270,13 +270,13 @@ void FontAtlas::findNewCharacters(const std::u16string& u16Text, std::unordered_
         // will affect the memory validity, it means after `newChars` is destroyed, the memory of `u16Text` holds
         // will be a dead region. `u16text` represents the variable in `Label::_utf16Text`, when somewhere
         // allocates memory by `malloc, realloc, new, new[]`, the generated memory address may be the same
-        // as `Label::_utf16Text` holds. If doing a `memset` or other memory operations, the orignal `Label::_utf16Text`
+        // as `Label::_utf16Text` holds. If doing a `memset` or other memory operations, the original `Label::_utf16Text`
         // will be in an unknown state. Meanwhile, a bunch lots of logic which depends on `Label::_utf16Text`
         // will be broken.
         
         // newChars = u16Text;
         
-        // Using `append` method is a workaround for this issue. So please be carefuly while using the assignment operator
+        // Using `append` method is a workaround for this issue. So please be carefully while using the assignment operator
         // of `std::u16string`.
         newChars.append(u16Text);
     }

--- a/cocos/editor-support/cocostudio/CCSkin.cpp
+++ b/cocos/editor-support/cocostudio/CCSkin.cpp
@@ -99,7 +99,7 @@ bool Skin::initWithSpriteFrameName(const std::string& spriteFrameName)
     }
     else
     {
-        CCLOG("Cann't find CCSpriteFrame with %s. Please check your .plist file", spriteFrameName.c_str());
+        CCLOG("Can't find CCSpriteFrame with %s. Please check your .plist file", spriteFrameName.c_str());
         ret = false;
     }
 

--- a/cocos/editor-support/cocostudio/WidgetReader/SliderReader/SliderReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/SliderReader/SliderReader.cpp
@@ -185,7 +185,7 @@ namespace cocostudio
         std::string pressedFileName = this->getResourcePath(pressedDic, P_Path, (Widget::TextureResType)pressedType);
         slider->loadSlidBallTexturePressed(pressedFileName, (Widget::TextureResType)pressedType);
         
-        //loading silder ball disable texture
+        //loading slider ball disable texture
         const rapidjson::Value& disabledDic = DICTOOL->getSubDictionary_json(options, P_BallDisabledData);
         int disabledType = DICTOOL->getIntValue_json(disabledDic, P_ResourceType);
         std::string disabledFileName = this->getResourcePath(disabledDic, P_Path, (Widget::TextureResType)disabledType);
@@ -680,7 +680,7 @@ namespace cocostudio
         //    slider->addChild(label);
         //}
         
-        //loading silder ball disable texture
+        //loading slider ball disable texture
         bool disabledFileExist = false;
         std::string disabledErrorFilePath = "";
         auto disabledDic = options->ballDisabledData();

--- a/cocos/platform/android/java/src/org/cocos2dx/lib/ResizeLayout.java
+++ b/cocos/platform/android/java/src/org/cocos2dx/lib/ResizeLayout.java
@@ -48,7 +48,7 @@ public class ResizeLayout extends FrameLayout {
         super.onLayout(changed, l, t, r, b);
         if(mEnableForceDoLayout){
             /*This is a hot-fix for some android devices which don't do layout when the main window
-            * is paned.  We refersh the layout in 24 frames per seconds.
+            * is paned. We refresh the layout in 24 frames per seconds.
             * When the editBox is lose focus or when user begin to type, the do layout is disabled.
             */
             final Handler handler = new Handler();

--- a/cocos/platform/linux/CCApplication-linux.cpp
+++ b/cocos/platform/linux/CCApplication-linux.cpp
@@ -44,7 +44,7 @@ static long getCurrentMillSecond() {
     struct timeval stCurrentTime;
 
     gettimeofday(&stCurrentTime,NULL);
-    lLastTime = stCurrentTime.tv_sec*1000+stCurrentTime.tv_usec*0.001; //millseconds
+    lLastTime = stCurrentTime.tv_sec*1000+stCurrentTime.tv_usec*0.001; // milliseconds
     return lLastTime;
 }
 

--- a/cocos/platform/mac/CCApplication-mac.mm
+++ b/cocos/platform/mac/CCApplication-mac.mm
@@ -42,7 +42,7 @@ static long getCurrentMillSecond()
     struct timeval stCurrentTime;
     
     gettimeofday(&stCurrentTime,NULL);
-    lLastTime = stCurrentTime.tv_sec*1000+stCurrentTime.tv_usec*0.001; //millseconds
+    lLastTime = stCurrentTime.tv_sec*1000+stCurrentTime.tv_usec*0.001; // milliseconds
     return lLastTime;
 }
 

--- a/cocos/renderer/CCTexture2D.cpp
+++ b/cocos/renderer/CCTexture2D.cpp
@@ -1499,7 +1499,7 @@ void Texture2D::setAlphaTexture(Texture2D* alphaTexture)
     if (alphaTexture != nullptr) {
         this->_alphaTexture = alphaTexture;
         this->_alphaTexture->retain();
-        this->_hasPremultipliedAlpha = true; // PremultipliedAlpha shoud be true.
+        this->_hasPremultipliedAlpha = true; // PremultipliedAlpha should be true.
     }
 }
 NS_CC_END

--- a/extensions/GUI/CCControlExtension/CCControlHuePicker.cpp
+++ b/extensions/GUI/CCControlExtension/CCControlHuePicker.cpp
@@ -142,7 +142,7 @@ void ControlHuePicker::updateSliderPosition(Vec2 location)
     float angle             = atan2f(dy, dx);
     float angleDeg          = CC_RADIANS_TO_DEGREES(angle) + 180.0f;
     
-    // use the position / slider width to determin the percentage the dragger is at
+    // use the position / slider width to determine the percentage the dragger is at
     setHue(angleDeg);
     
     // send Control callback

--- a/extensions/GUI/CCControlExtension/CCControlSaturationBrightnessPicker.cpp
+++ b/extensions/GUI/CCControlExtension/CCControlSaturationBrightnessPicker.cpp
@@ -151,7 +151,7 @@ void ControlSaturationBrightnessPicker::updateSliderPosition(Vec2 sliderPosition
     if (sliderPosition.y < _startPos.y + boxPos)                        sliderPosition.y = _startPos.y + boxPos;
     else if (sliderPosition.y > _startPos.y + boxPos + boxSize)        sliderPosition.y = _startPos.y + boxPos + boxSize;
     
-    // Use the position / slider width to determin the percentage the dragger is at
+    // Use the position / slider width to determine the percentage the dragger is at
     _saturation = 1.0f - fabs((_startPos.x + (float)boxPos - sliderPosition.x)/(float)boxSize);
     _brightness = fabs((_startPos.y + (float)boxPos - sliderPosition.y)/(float)boxSize);
 }


### PR DESCRIPTION
This pull request fixes various spelling mistakes in docs, comments and strings.
