### PR TITLE
Fix typos in local variables

### DIFF
--- a/cocos/3d/CCBundle3D.cpp
+++ b/cocos/3d/CCBundle3D.cpp
@@ -1017,11 +1017,11 @@ bool  Bundle3D::loadMaterialsJson(MaterialDatas& materialdatas)
         materialData.id = material_val[ID].GetString();
         if (material_val.HasMember(TEXTURES))
         {
-            const rapidjson::Value& testure_array = material_val[TEXTURES];
-            for (rapidjson::SizeType j = 0; j < testure_array.Size(); j++)
+            const rapidjson::Value& texture_array = material_val[TEXTURES];
+            for (rapidjson::SizeType j = 0; j < texture_array.Size(); j++)
             {
                 NTextureData  textureData;
-                const rapidjson::Value& texture_val = testure_array[j];
+                const rapidjson::Value& texture_val = texture_array[j];
                 std::string filename = texture_val[FILENAME].GetString();
                 textureData.filename = filename.empty() ? filename : _modelPath + filename;
                 textureData.type  = parseGLTextureType(texture_val["type"].GetString());

--- a/cocos/3d/CCTerrain.cpp
+++ b/cocos/3d/CCTerrain.cpp
@@ -364,8 +364,8 @@ float Terrain::getHeight(float x, float z, Vec3 * normal) const
             normal->normalize();
             //(*normal) = (1-u)*(1-v)*getNormal(i,j)+ (1-u)*v*getNormal(i,j+1) + u*(1-v)*getNormal(i+1,j)+ u*v*getNormal(i+1,j+1);
         }
-        float reuslt =  (1-u)*(1-v)*getImageHeight(i,j)*getScaleY() + (1-u)*v*getImageHeight(i,j+1)*getScaleY() + u*(1-v)*getImageHeight(i+1,j)*getScaleY() + u*v*getImageHeight(i+1,j+1)*getScaleY();
-        return reuslt;
+        float result = (1-u)*(1-v)*getImageHeight(i,j)*getScaleY() + (1-u)*v*getImageHeight(i,j+1)*getScaleY() + u*(1-v)*getImageHeight(i+1,j)*getScaleY() + u*v*getImageHeight(i+1,j+1)*getScaleY();
+        return result;
     }
 }
 

--- a/cocos/base/CCDirector.cpp
+++ b/cocos/base/CCDirector.cpp
@@ -242,8 +242,8 @@ void Director::setDefaultValues(void)
         Texture2D::setDefaultAlphaPixelFormat(Texture2D::PixelFormat::RGB5A1);
 
     // PVR v2 has alpha premultiplied ?
-    bool pvr_alpha_premultipled = conf->getValue("cocos2d.x.texture.pvrv2_has_alpha_premultiplied", Value(false)).asBool();
-    Image::setPVRImagesHavePremultipliedAlpha(pvr_alpha_premultipled);
+    bool pvr_alpha_premultiplied = conf->getValue("cocos2d.x.texture.pvrv2_has_alpha_premultiplied", Value(false)).asBool();
+    Image::setPVRImagesHavePremultipliedAlpha(pvr_alpha_premultiplied);
 }
 
 void Director::setGLDefaultValues()

--- a/cocos/network/CCDownloader-apple.mm
+++ b/cocos/network/CCDownloader-apple.mm
@@ -423,8 +423,8 @@ namespace cocos2d { namespace network {
             if (statusCode >= 400)
             {
                 std::vector<unsigned char> buf; // just a placeholder
-                const char *orignalURL = [task.originalRequest.URL.absoluteString cStringUsingEncoding:NSUTF8StringEncoding];
-                std::string errorMessage = cocos2d::StringUtils::format("Downloader: Failed to download %s with status code (%d)", orignalURL, (int)statusCode);
+                const char *originalURL = [task.originalRequest.URL.absoluteString cStringUsingEncoding:NSUTF8StringEncoding];
+                std::string errorMessage = cocos2d::StringUtils::format("Downloader: Failed to download %s with status code (%d)", originalURL, (int)statusCode);
 
                 _outer->onTaskFinish(*[wrapper get],
                                      cocos2d::network::DownloadTask::ERROR_IMPL_INTERNAL,

--- a/cocos/scripting/js-bindings/script/jsb_cocos2d.js
+++ b/cocos/scripting/js-bindings/script/jsb_cocos2d.js
@@ -2590,7 +2590,7 @@ cc.Texture2D.prototype.setTexParameters = function (texParams, magFilter, wrapS,
     this._setTexParameters(minFilter, magFilter, wrapS, wrapT);
 };
 
-cc.Texture2D.prototype.handleLoadedTexture = function (premultipled) {};
+cc.Texture2D.prototype.handleLoadedTexture = function (premultiplied) {};
 
 // 
 // MenuItem setCallback support target

--- a/cocos/scripting/lua-bindings/script/cocos2d/functions.lua
+++ b/cocos/scripting/lua-bindings/script/cocos2d/functions.lua
@@ -49,7 +49,7 @@ local function dump_value_(v)
     return tostring(v)
 end
 
-function dump(value, desciption, nesting)
+function dump(value, description, nesting)
     if type(nesting) ~= "number" then nesting = 3 end
 
     local lookupTable = {}
@@ -58,22 +58,22 @@ function dump(value, desciption, nesting)
     local traceback = string.split(debug.traceback("", 2), "\n")
     print("dump from: " .. string.trim(traceback[3]))
 
-    local function dump_(value, desciption, indent, nest, keylen)
-        desciption = desciption or "<var>"
+    local function dump_(value, description, indent, nest, keylen)
+        description = description or "<var>"
         local spc = ""
         if type(keylen) == "number" then
-            spc = string.rep(" ", keylen - string.len(dump_value_(desciption)))
+            spc = string.rep(" ", keylen - string.len(dump_value_(description)))
         end
         if type(value) ~= "table" then
-            result[#result +1 ] = string.format("%s%s%s = %s", indent, dump_value_(desciption), spc, dump_value_(value))
+            result[#result +1 ] = string.format("%s%s%s = %s", indent, dump_value_(description), spc, dump_value_(value))
         elseif lookupTable[tostring(value)] then
-            result[#result +1 ] = string.format("%s%s%s = *REF*", indent, dump_value_(desciption), spc)
+            result[#result +1 ] = string.format("%s%s%s = *REF*", indent, dump_value_(description), spc)
         else
             lookupTable[tostring(value)] = true
             if nest > nesting then
-                result[#result +1 ] = string.format("%s%s = *MAX NESTING*", indent, dump_value_(desciption))
+                result[#result +1 ] = string.format("%s%s = *MAX NESTING*", indent, dump_value_(description))
             else
-                result[#result +1 ] = string.format("%s%s = {", indent, dump_value_(desciption))
+                result[#result +1 ] = string.format("%s%s = {", indent, dump_value_(description))
                 local indent2 = indent.."    "
                 local keys = {}
                 local keylen = 0
@@ -99,7 +99,7 @@ function dump(value, desciption, nesting)
             end
         end
     end
-    dump_(value, desciption, "- ", 1)
+    dump_(value, description, "- ", 1)
 
     for i, line in ipairs(result) do
         print(line)


### PR DESCRIPTION
This pull request fixes some minor typos in local variables. It also doesn't break backward compatibility. Thanks!
