### PR TITLE
Performance tweak: Use range-based for-loops and allocate std::vector size() and *end() on the stack where favorable.

### DIFF
--- a/cocos/2d/CCActionCatmullRom.cpp
+++ b/cocos/2d/CCActionCatmullRom.cpp
@@ -67,10 +67,9 @@ bool PointArray::initWithCapacity(ssize_t capacity)
 PointArray* PointArray::clone() const
 {
     vector<Vec2*> *newArray = new (std::nothrow) vector<Vec2*>();
-    vector<Vec2*>::iterator iter;
-    for (iter = _controlPoints->begin(); iter != _controlPoints->end(); ++iter)
+    for (auto& controlPoint : *_controlPoints)
     {
-        newArray->push_back(new Vec2((*iter)->x, (*iter)->y));
+        newArray->push_back(new Vec2(controlPoint->x, controlPoint->y));
     }
     
     PointArray *points = new (std::nothrow) PointArray();
@@ -85,10 +84,9 @@ PointArray::~PointArray()
 {
     CCLOGINFO("deallocing PointArray: %p", this);
 
-    vector<Vec2*>::iterator iter;
-    for (iter = _controlPoints->begin(); iter != _controlPoints->end(); ++iter)
+    for (auto& controlPoint : *_controlPoints)
     {
-        delete *iter;
+        delete controlPoint;
     }
     delete _controlPoints;
 }
@@ -106,9 +104,9 @@ void PointArray::setControlPoints(vector<Vec2*> *controlPoints)
     
     // delete old points
     vector<Vec2*>::iterator iter;
-    for (iter = _controlPoints->begin(); iter != _controlPoints->end(); ++iter)
+    for (auto& controlPoint : *_controlPoints)
     {
-        delete *iter;
+        delete controlPoint;
     }
     delete _controlPoints;
     
@@ -155,9 +153,8 @@ ssize_t PointArray::count() const
 PointArray* PointArray::reverse() const
 {
     vector<Vec2*> *newArray = new (std::nothrow) vector<Vec2*>();
-    vector<Vec2*>::reverse_iterator iter;
     Vec2 *point = nullptr;
-    for (iter = _controlPoints->rbegin(); iter != _controlPoints->rend(); ++iter)
+    for (auto iter = _controlPoints->rbegin(), iterRend = _controlPoints->rend(); iter != iterRend; ++iter)
     {
         point = *iter;
         newArray->push_back(new Vec2(point->x, point->y));

--- a/cocos/2d/CCActionInterval.cpp
+++ b/cocos/2d/CCActionInterval.cpp
@@ -2695,7 +2695,7 @@ Animate* Animate::reverse() const
    
     if (!oldArray.empty())
     {
-        for (auto iter = oldArray.crbegin(); iter != oldArray.crend(); ++iter)
+        for (auto iter = oldArray.crbegin(), iterCrend = oldArray.crend(); iter != iterCrend; ++iter)
         {
             AnimationFrame* animFrame = *iter;
             if (!animFrame)

--- a/cocos/2d/CCAnimationCache.cpp
+++ b/cocos/2d/CCAnimationCache.cpp
@@ -86,16 +86,16 @@ void AnimationCache::parseVersion1(const ValueMap& animations)
 {
     SpriteFrameCache *frameCache = SpriteFrameCache::getInstance();
 
-    for (auto iter = animations.cbegin(); iter != animations.cend(); ++iter)
+    for (const auto& anim : animations)
     {
-        const ValueMap& animationDict = iter->second.asValueMap();
+        const ValueMap& animationDict = anim.second.asValueMap();
         const ValueVector& frameNames = animationDict.at("frames").asValueVector();
         float delay = animationDict.at("delay").asFloat();
         Animation* animation = nullptr;
 
         if ( frameNames.empty() )
         {
-            CCLOG("cocos2d: AnimationCache: Animation '%s' found in dictionary without any frames - cannot add to animation cache.", iter->first.c_str());
+            CCLOG("cocos2d: AnimationCache: Animation '%s' found in dictionary without any frames - cannot add to animation cache.", anim.first.c_str());
             continue;
         }
 
@@ -107,7 +107,7 @@ void AnimationCache::parseVersion1(const ValueMap& animations)
             SpriteFrame* spriteFrame = frameCache->getSpriteFrameByName(frameName.asString());
 
             if ( ! spriteFrame ) {
-                CCLOG("cocos2d: AnimationCache: Animation '%s' refers to frame '%s' which is not currently in the SpriteFrameCache. This frame will not be added to the animation.", iter->first.c_str(), frameName.asString().c_str());
+                CCLOG("cocos2d: AnimationCache: Animation '%s' refers to frame '%s' which is not currently in the SpriteFrameCache. This frame will not be added to the animation.", anim.first.c_str(), frameName.asString().c_str());
 
                 continue;
             }
@@ -118,17 +118,17 @@ void AnimationCache::parseVersion1(const ValueMap& animations)
 
         if ( frames.empty() )
         {
-            CCLOG("cocos2d: AnimationCache: None of the frames for animation '%s' were found in the SpriteFrameCache. Animation is not being added to the Animation Cache.", iter->first.c_str());
+            CCLOG("cocos2d: AnimationCache: None of the frames for animation '%s' were found in the SpriteFrameCache. Animation is not being added to the Animation Cache.", anim.first.c_str());
             continue;
         }
         else if ( frames.size() != frameNameSize )
         {
-            CCLOG("cocos2d: AnimationCache: An animation in your dictionary refers to a frame which is not in the SpriteFrameCache. Some or all of the frames for the animation '%s' may be missing.", iter->first.c_str());
+            CCLOG("cocos2d: AnimationCache: An animation in your dictionary refers to a frame which is not in the SpriteFrameCache. Some or all of the frames for the animation '%s' may be missing.", anim.first.c_str());
         }
 
         animation = Animation::create(frames, delay, 1);
 
-        AnimationCache::getInstance()->addAnimation(animation, iter->first);
+        AnimationCache::getInstance()->addAnimation(animation, anim.first);
     }
 }
 
@@ -136,10 +136,10 @@ void AnimationCache::parseVersion2(const ValueMap& animations)
 {
     SpriteFrameCache *frameCache = SpriteFrameCache::getInstance();
 
-    for (auto iter = animations.cbegin(); iter != animations.cend(); ++iter)
+    for (const auto& anim : animations)
     {
-        std::string name = iter->first;
-        ValueMap& animationDict = const_cast<ValueMap&>(iter->second.asValueMap());
+        std::string name = anim.first;
+        ValueMap& animationDict = const_cast<ValueMap&>(anim.second.asValueMap());
 
         const Value& loops = animationDict["loops"];
         bool restoreOriginalFrame = animationDict["restoreOriginalFrame"].asBool();

--- a/cocos/2d/CCAutoPolygon.cpp
+++ b/cocos/2d/CCAutoPolygon.cpp
@@ -445,7 +445,7 @@ std::vector<cocos2d::Vec2> AutoPolygon::rdp(const std::vector<cocos2d::Vec2>& v,
     int index = -1;
     float dist = 0;
     //not looping first and last point
-    for(size_t i = 1; i < v.size()-1; i++)
+    for(size_t i = 1, size = v.size(); i < size-1; ++i)
     {
         float cdist = perpendicularDistance(v[i], v.front(), v.back());
         if(cdist > dist)
@@ -586,7 +586,7 @@ TrianglesCommand::Triangles AutoPolygon::triangulate(const std::vector<Vec2>& po
 
     for(const auto& ite : tris)
     {
-        for(int i = 0; i < 3; i++)
+        for(int i = 0; i < 3; ++i)
         {
             auto p = ite->GetPoint(i);
             auto v3 = Vec3(p->x, p->y, 0);
@@ -662,7 +662,7 @@ void AutoPolygon::calculateUV(const Rect& rect, V3F_C4B_T2F* verts, const ssize_
     float texHeight = _height;
 
     auto end = &verts[count];
-    for(auto i = verts; i != end; i++)
+    for(auto i = verts; i != end; ++i)
     {
         // for every point, offset with the center point
         float u = (i->vertices.x*_scaleFactor + rect.origin.x) / texWidth;

--- a/cocos/2d/CCClippingNode.cpp
+++ b/cocos/2d/CCClippingNode.cpp
@@ -245,7 +245,7 @@ void ClippingNode::visit(Renderer *renderer, const Mat4 &parentTransform, uint32
     {
         sortAllChildren();
         // draw children zOrder < 0
-        for( ; i < _children.size(); i++ )
+        for(auto size = _children.size(); i < size; ++i)
         {
             auto node = _children.at(i);
             
@@ -257,8 +257,8 @@ void ClippingNode::visit(Renderer *renderer, const Mat4 &parentTransform, uint32
         // self draw
         if (visibleByCamera)
             this->draw(renderer, _modelViewTransform, flags);
-        
-        for(auto it=_children.cbegin()+i; it != _children.cend(); ++it)
+
+        for(auto it=_children.cbegin()+i, itCend = _children.cend(); it != itCend; ++it)
             (*it)->visit(renderer, _modelViewTransform, flags);
     }
     else if (visibleByCamera)

--- a/cocos/2d/CCComponentContainer.cpp
+++ b/cocos/2d/CCComponentContainer.cpp
@@ -105,12 +105,11 @@ void ComponentContainer::removeAll()
 {
     if (!_componentMap.empty())
     {
-        for (auto iter = _componentMap.begin(); iter != _componentMap.end(); ++iter)
+        for (auto& iter : _componentMap)
         {
-            auto component = iter->second;
-            component->onRemove();
-            component->setOwner(nullptr);
-            component->release();
+            iter.second->onRemove();
+            iter.second->setOwner(nullptr);
+            iter.second->release();
         }
         
         _componentMap.clear();
@@ -123,10 +122,9 @@ void ComponentContainer::visit(float delta)
     if (!_componentMap.empty())
     {
         CC_SAFE_RETAIN(_owner);
-        auto iterEnd = _componentMap.end();
-        for (auto iter = _componentMap.begin(); iter != iterEnd; ++iter)
+        for (auto& iter : _componentMap)
         {
-            iter->second->update(delta);
+            iter.second->update(delta);
         }
         CC_SAFE_RELEASE(_owner);
     }
@@ -134,17 +132,17 @@ void ComponentContainer::visit(float delta)
 
 void ComponentContainer::onEnter()
 {
-    for (auto iter = _componentMap.begin(); iter != _componentMap.end(); ++iter)
+    for (auto& iter : _componentMap)
     {
-        iter->second->onEnter();
+        iter.second->onEnter();
     }
 }
 
 void ComponentContainer::onExit()
 {
-    for (auto iter = _componentMap.begin(); iter != _componentMap.end(); ++iter)
+    for (auto& iter : _componentMap)
     {
-        iter->second->onExit();
+        iter.second->onExit();
     }
 }
 

--- a/cocos/2d/CCFastTMXLayer.cpp
+++ b/cocos/2d/CCFastTMXLayer.cpp
@@ -556,10 +556,10 @@ void TMXLayer::updateTotalQuads()
         }
         
         int offset = 0;
-        for(auto iter = _indicesVertexZOffsets.begin(); iter != _indicesVertexZOffsets.end(); ++iter)
+        for(auto& vertexZOffset : _indicesVertexZOffsets)
         {
-            std::swap(offset, iter->second);
-            offset += iter->second;
+            std::swap(offset, vertexZOffset.second);
+            offset += vertexZOffset.second;
         }
         updateVertexBuffer();
         

--- a/cocos/2d/CCFastTMXTiledMap.cpp
+++ b/cocos/2d/CCFastTMXTiledMap.cpp
@@ -117,8 +117,8 @@ TMXTilesetInfo * TMXTiledMap::tilesetForLayer(TMXLayerInfo *layerInfo, TMXMapInf
 {
     Size size = layerInfo->_layerSize;
     auto& tilesets = mapInfo->getTilesets();
-    
-    for (auto iter = tilesets.crbegin(); iter != tilesets.crend(); ++iter)
+
+    for (auto iter = tilesets.crbegin(), iterCrend = tilesets.crend(); iter != iterCrend; ++iter)
     {
         TMXTilesetInfo* tilesetInfo = *iter;
         if (tilesetInfo)
@@ -219,9 +219,8 @@ TMXObjectGroup * TMXTiledMap::getObjectGroup(const std::string& groupName) const
     if (_objectGroups.size()>0)
     {
         TMXObjectGroup* objectGroup = nullptr;
-        for (auto iter = _objectGroups.cbegin(); iter != _objectGroups.cend(); ++iter)
+        for (const auto& objectGroup : _objectGroups)
         {
-            objectGroup = *iter;
             if (objectGroup && objectGroup->getGroupName() == groupName)
             {
                 return objectGroup;

--- a/cocos/2d/CCLabel.cpp
+++ b/cocos/2d/CCLabel.cpp
@@ -797,9 +797,10 @@ bool Label::alignText()
     do {
         _fontAtlas->prepareLetterDefinitions(_utf16Text);
         auto& textures = _fontAtlas->getTextures();
-        if (textures.size() > static_cast<size_t>(_batchNodes.size()))
+        auto size = textures.size();
+        if (size > static_cast<size_t>(_batchNodes.size()))
         {
-            for (auto index = static_cast<size_t>(_batchNodes.size()); index < textures.size(); ++index)
+            for (auto index = static_cast<size_t>(_batchNodes.size()); index < size; ++index)
             {
                 auto batchNode = SpriteBatchNode::createWithTexture(textures.at(index));
                 if (batchNode)
@@ -1656,7 +1657,7 @@ void Label::visit(Renderer *renderer, const Mat4 &parentTransform, uint32_t pare
 
         int i = 0;
         // draw children zOrder < 0
-        for (; i < _children.size(); i++)
+        for (auto size = _children.size(); i < size; ++i)
         {
             auto node = _children.at(i);
 
@@ -1668,7 +1669,7 @@ void Label::visit(Renderer *renderer, const Mat4 &parentTransform, uint32_t pare
         
         this->drawSelf(visibleByCamera, renderer, flags);
 
-        for (auto it = _children.cbegin() + i; it != _children.cend(); ++it)
+        for (auto it = _children.cbegin() + i, itCend = _children.cend(); it != itCend; ++it)
         {
             (*it)->visit(renderer, _modelViewTransform, flags);
         }

--- a/cocos/2d/CCNode.cpp
+++ b/cocos/2d/CCNode.cpp
@@ -1237,7 +1237,7 @@ void Node::visit(Renderer* renderer, const Mat4 &parentTransform, uint32_t paren
     {
         sortAllChildren();
         // draw children zOrder < 0
-        for( ; i < _children.size(); i++ )
+        for(auto size = _children.size(); i < size; ++i)
         {
             auto node = _children.at(i);
 
@@ -1250,7 +1250,7 @@ void Node::visit(Renderer* renderer, const Mat4 &parentTransform, uint32_t paren
         if (visibleByCamera)
             this->draw(renderer, _modelViewTransform, flags);
 
-        for(auto it=_children.cbegin()+i; it != _children.cend(); ++it)
+        for(auto it=_children.cbegin()+i, itCend = _children.cend(); it != itCend; ++it)
             (*it)->visit(renderer, _modelViewTransform, flags);
     }
     else if (visibleByCamera)

--- a/cocos/2d/CCNodeGrid.cpp
+++ b/cocos/2d/CCNodeGrid.cpp
@@ -148,7 +148,7 @@ void NodeGrid::visit(Renderer *renderer, const Mat4 &parentTransform, uint32_t p
     {
         sortAllChildren();
         // draw children zOrder < 0
-        for( ; i < _children.size(); i++ )
+        for(auto size = _children.size(); i < size; ++i)
         {
             auto node = _children.at(i);
 
@@ -161,7 +161,7 @@ void NodeGrid::visit(Renderer *renderer, const Mat4 &parentTransform, uint32_t p
         if (visibleByCamera)
             this->draw(renderer, _modelViewTransform, dirty);
 
-        for(auto it=_children.cbegin()+i; it != _children.cend(); ++it) {
+        for(auto it=_children.cbegin()+i, itCend = _children.cend(); it != itCend; ++it) {
             (*it)->visit(renderer, _modelViewTransform, dirty);
         }
     }

--- a/cocos/2d/CCParticleBatchNode.cpp
+++ b/cocos/2d/CCParticleBatchNode.cpp
@@ -271,7 +271,7 @@ void ParticleBatchNode::reorderChild(Node * aChild, int zOrder)
 
             // Find new AtlasIndex
             int newAtlasIndex = 0;
-            for( int i=0;i < _children.size();i++)
+            for(int i=0, size = _children.size(); i < size; ++i)
             {
                 ParticleSystem* node = static_cast<ParticleSystem*>(_children.at(i));
                 if( node == child )

--- a/cocos/2d/CCProtectedNode.cpp
+++ b/cocos/2d/CCProtectedNode.cpp
@@ -294,7 +294,7 @@ void ProtectedNode::visit(Renderer* renderer, const Mat4 &parentTransform, uint3
     //
     // draw children and protectedChildren zOrder < 0
     //
-    for( ; i < _children.size(); i++ )
+    for(auto size = _children.size(); i < size; ++i)
     {
         auto node = _children.at(i);
         
@@ -303,8 +303,8 @@ void ProtectedNode::visit(Renderer* renderer, const Mat4 &parentTransform, uint3
         else
             break;
     }
-    
-    for( ; j < _protectedChildren.size(); j++ )
+
+    for(auto size = _protectedChildren.size(); j < size; ++j)
     {
         auto node = _protectedChildren.at(j);
         
@@ -323,10 +323,10 @@ void ProtectedNode::visit(Renderer* renderer, const Mat4 &parentTransform, uint3
     //
     // draw children and protectedChildren zOrder >= 0
     //
-    for(auto it=_protectedChildren.cbegin()+j; it != _protectedChildren.cend(); ++it)
+    for(auto it=_protectedChildren.cbegin()+j, itCend = _protectedChildren.cend(); it != itCend; ++it)
         (*it)->visit(renderer, _modelViewTransform, flags);
-    
-    for(auto it=_children.cbegin()+i; it != _children.cend(); ++it)
+
+    for(auto it=_children.cbegin()+i, itCend = _children.cend(); it != itCend; ++it)
         (*it)->visit(renderer, _modelViewTransform, flags);
     
     // FIX ME: Why need to set _orderOfArrival to 0??

--- a/cocos/2d/CCSpriteBatchNode.cpp
+++ b/cocos/2d/CCSpriteBatchNode.cpp
@@ -587,7 +587,7 @@ void SpriteBatchNode::removeSpriteFromAtlas(Sprite *sprite)
         auto next = std::next(it);
 
         Sprite *spr = nullptr;
-        for(; next != _descendants.end(); ++next) {
+        for(auto nextEnd = _descendants.end(); next != nextEnd; ++next) {
             spr = *next;
             spr->setAtlasIndex( spr->getAtlasIndex() - 1 );
         }
@@ -704,7 +704,7 @@ SpriteBatchNode * SpriteBatchNode::addSpriteWithoutQuad(Sprite*child, int z, int
 
     // FIXME:: optimize with a binary search
     auto it = _descendants.begin();
-    for (; it != _descendants.end(); ++it)
+    for (auto itEnd = _descendants.end(); it != itEnd; ++it)
     {
         if((*it)->getAtlasIndex() >= z)
             break;

--- a/cocos/2d/CCSpriteFrameCache.cpp
+++ b/cocos/2d/CCSpriteFrameCache.cpp
@@ -174,10 +174,10 @@ void SpriteFrameCache::addSpriteFramesWithDictionary(ValueMap& dictionary, Textu
     auto textureFileName = Director::getInstance()->getTextureCache()->getTextureFilePath(texture);
     Image* image = nullptr;
     NinePatchImageParser parser;
-    for (auto iter = framesDict.begin(); iter != framesDict.end(); ++iter)
+    for (auto& iter : framesDict)
     {
-        ValueMap& frameDict = iter->second.asValueMap();
-        std::string spriteFrameName = iter->first;
+        ValueMap& frameDict = iter.second.asValueMap();
+        std::string spriteFrameName = iter.first;
         SpriteFrame* spriteFrame = _spriteFrames.at(spriteFrameName);
         if (spriteFrame)
         {
@@ -461,14 +461,14 @@ void SpriteFrameCache::removeUnusedSpriteFrames()
     bool removed = false;
     std::vector<std::string> toRemoveFrames;
     
-    for (auto iter = _spriteFrames.begin(); iter != _spriteFrames.end(); ++iter)
+    for (auto& iter : _spriteFrames)
     {
-        SpriteFrame* spriteFrame = iter->second;
+        SpriteFrame* spriteFrame = iter.second;
         if( spriteFrame->getReferenceCount() == 1 )
         {
-            toRemoveFrames.push_back(iter->first);
+            toRemoveFrames.push_back(iter.first);
             spriteFrame->getTexture()->removeSpriteFrameCapInset(spriteFrame);
-            CCLOG("cocos2d: SpriteFrameCache: removing unused frame: %s", iter->first.c_str());
+            CCLOG("cocos2d: SpriteFrameCache: removing unused frame: %s", iter.first.c_str());
             removed = true;
         }
     }
@@ -544,11 +544,11 @@ void SpriteFrameCache::removeSpriteFramesFromDictionary(ValueMap& dictionary)
     ValueMap framesDict = dictionary["frames"].asValueMap();
     std::vector<std::string> keysToRemove;
 
-    for (auto iter = framesDict.cbegin(); iter != framesDict.cend(); ++iter)
+    for (const auto& iter : framesDict)
     {
-        if (_spriteFrames.at(iter->first))
+        if (_spriteFrames.at(iter.first))
         {
-            keysToRemove.push_back(iter->first);
+            keysToRemove.push_back(iter.first);
         }
     }
 
@@ -559,9 +559,9 @@ void SpriteFrameCache::removeSpriteFramesFromTexture(Texture2D* texture)
 {
     std::vector<std::string> keysToRemove;
 
-    for (auto iter = _spriteFrames.cbegin(); iter != _spriteFrames.cend(); ++iter)
+    for (auto& iter : _spriteFrames)
     {
-        std::string key = iter->first;
+        std::string key = iter.first;
         SpriteFrame* frame = _spriteFrames.at(key);
         if (frame && (frame->getTexture() == texture))
         {
@@ -606,10 +606,10 @@ void SpriteFrameCache::reloadSpriteFramesWithDictionary(ValueMap& dictionary, Te
     // check the format
     CCASSERT(format >= 0 && format <= 3, "format is not supported for SpriteFrameCache addSpriteFramesWithDictionary:textureFilename:");
 
-    for (auto iter = framesDict.begin(); iter != framesDict.end(); ++iter)
+    for (auto& iter : framesDict)
     {
-        ValueMap& frameDict = iter->second.asValueMap();
-        std::string spriteFrameName = iter->first;
+        ValueMap& frameDict = iter.second.asValueMap();
+        std::string spriteFrameName = iter.first;
 
         auto it = _spriteFrames.find(spriteFrameName);
         if (it != _spriteFrames.end())

--- a/cocos/2d/CCTMXTiledMap.cpp
+++ b/cocos/2d/CCTMXTiledMap.cpp
@@ -130,7 +130,7 @@ TMXTilesetInfo * TMXTiledMap::tilesetForLayer(TMXLayerInfo *layerInfo, TMXMapInf
     if (tilesets.size()>0)
     {
         TMXTilesetInfo* tileset = nullptr;
-        for (auto iter = tilesets.crbegin(); iter != tilesets.crend(); ++iter)
+        for (auto iter = tilesets.crbegin(), iterCrend = tilesets.crend(); iter != iterCrend; ++iter)
         {
             tileset = *iter;
             if (tileset)
@@ -231,9 +231,8 @@ TMXObjectGroup * TMXTiledMap::getObjectGroup(const std::string& groupName) const
     if (_objectGroups.size()>0)
     {
         TMXObjectGroup* objectGroup = nullptr;
-        for (auto iter = _objectGroups.cbegin(); iter != _objectGroups.cend(); ++iter)
+        for (const auto& objectGroup : _objectGroups)
         {
-            objectGroup = *iter;
             if (objectGroup && objectGroup->getGroupName() == groupName)
             {
                 return objectGroup;

--- a/cocos/3d/CCBillBoard.cpp
+++ b/cocos/3d/CCBillBoard.cpp
@@ -126,7 +126,7 @@ void BillBoard::visit(Renderer *renderer, const Mat4& parentTransform, uint32_t 
     {
         sortAllChildren();
         // draw children zOrder < 0
-        for( ; i < _children.size(); i++ )
+        for(auto size = _children.size(); i < size; ++i)
         {
             auto node = _children.at(i);
             
@@ -138,8 +138,8 @@ void BillBoard::visit(Renderer *renderer, const Mat4& parentTransform, uint32_t 
         // self draw
         if (visibleByCamera)
             this->draw(renderer, _modelViewTransform, flags);
-        
-        for(auto it=_children.cbegin()+i; it != _children.cend(); ++it)
+
+        for(auto it=_children.cbegin()+i, itCend = _children.cend(); it != itCend; ++it)
             (*it)->visit(renderer, _modelViewTransform, flags);
     }
     else if (visibleByCamera)

--- a/cocos/3d/CCBundle3D.cpp
+++ b/cocos/3d/CCBundle3D.cpp
@@ -99,7 +99,7 @@ void getChildMap(std::map<int, std::vector<int> >& map, SkinData* skinData, cons
     // get transform matrix
     Mat4 transform;
     const rapidjson::Value& parent_transform = val[OLDTRANSFORM];
-    for (rapidjson::SizeType j = 0; j < parent_transform.Size(); j++)
+    for (rapidjson::SizeType j = 0, size = parent_transform.Size(); j < size; ++j)
     {
         transform.m[j] = parent_transform[j].GetDouble();
     }
@@ -126,7 +126,7 @@ void getChildMap(std::map<int, std::vector<int> >& map, SkinData* skinData, cons
         return;
 
     const rapidjson::Value& children = val[CHILDREN];
-    for (rapidjson::SizeType i = 0; i < children.Size(); i++)
+    for (rapidjson::SizeType i = 0, size = children.Size(); i < size; ++i)
     {
         // get child bone name
         const rapidjson::Value& child = children[i];
@@ -237,7 +237,7 @@ bool Bundle3D::loadObj(MeshDatas& meshdatas, MaterialDatas& materialdatas, NodeD
             tex.wrapS = GL_CLAMP_TO_EDGE;
             tex.wrapT = GL_CLAMP_TO_EDGE;
             
-            sprintf(str, "%d", i++);
+            sprintf(str, "%d", ++i);
             materialdata.textures.push_back(tex);
             materialdata.id = str;
             material.name = str;
@@ -278,7 +278,7 @@ bool Bundle3D::loadObj(MeshDatas& meshdatas, MaterialDatas& materialdatas, NodeD
             }
             
             auto vertexNum = mesh.positions.size() / 3;
-            for(unsigned int k = 0; k < vertexNum; k++)
+            for(unsigned int k = 0; k < vertexNum; ++k)
             {
                 meshdata->vertex.push_back(mesh.positions[k * 3]);
                 meshdata->vertex.push_back(mesh.positions[k * 3 + 1]);
@@ -300,7 +300,7 @@ bool Bundle3D::loadObj(MeshDatas& meshdatas, MaterialDatas& materialdatas, NodeD
             
             //split into submesh according to material
             std::map<int, std::vector<unsigned short> > subMeshMap;
-            for (size_t k = 0; k < mesh.material_ids.size(); k++) {
+            for (size_t k = 0, size = mesh.material_ids.size(); k < size; ++k) {
                 int id = mesh.material_ids[k];
                 size_t idx = k * 3;
                 subMeshMap[id].push_back(mesh.indices[idx]);
@@ -313,7 +313,7 @@ bool Bundle3D::loadObj(MeshDatas& meshdatas, MaterialDatas& materialdatas, NodeD
             for (auto& submesh : subMeshMap) {
                 meshdata->subMeshIndices.push_back(submesh.second);
                 meshdata->subMeshAABB.push_back(calculateAABB(meshdata->vertex, meshdata->getPerVertexSize(), submesh.second));
-                sprintf(str, "%d", i++);
+                sprintf(str, "%d", ++i);
                 meshdata->subMeshIds.push_back(str);
                 
                 auto modelnode = new (std::nothrow) ModelData();
@@ -398,7 +398,7 @@ bool  Bundle3D::loadMeshDatasBinary(MeshDatas& meshdatas)
         return false;
     }
     MeshData*   meshData = nullptr;
-    for(unsigned int i = 0; i < meshSize ; i++ )
+    for(unsigned int i = 0; i < meshSize ; ++i)
     {
          unsigned int attribSize=0;
         // read mesh data
@@ -410,7 +410,7 @@ bool  Bundle3D::loadMeshDatasBinary(MeshDatas& meshdatas)
         meshData = new (std::nothrow) MeshData();
         meshData->attribCount = attribSize;
         meshData->attribs.resize(meshData->attribCount);
-        for (ssize_t j = 0; j < meshData->attribCount; j++)
+        for (ssize_t j = 0; j < meshData->attribCount; ++j)
         {
             std::string attribute="";
             unsigned int vSize;
@@ -526,7 +526,7 @@ bool Bundle3D::loadMeshDatasBinary_0_1(MeshDatas& meshdatas)
         // backward compatibility
         VERTEX_ATTRIB_TEX_COORDS = VERTEX_ATTRIB_TEX_COORD,
     };
-    for (unsigned int i = 0; i < attribSize; i++)
+    for (unsigned int i = 0; i < attribSize; ++i)
     {
         unsigned int vUsage, vSize;
         if (_binaryReader.read(&vUsage, 4, 1) != 1 || _binaryReader.read(&vSize, 4, 1) != 1)
@@ -641,7 +641,7 @@ bool Bundle3D::loadMeshDatasBinary_0_2(MeshDatas& meshdatas)
         // backward compatibility
         VERTEX_ATTRIB_TEX_COORDS = VERTEX_ATTRIB_TEX_COORD,
     };
-    for (unsigned int i = 0; i < attribSize; i++)
+    for (unsigned int i = 0; i < attribSize; ++i)
     {
         unsigned int vUsage, vSize;
         if (_binaryReader.read(&vUsage, 4, 1) != 1 || _binaryReader.read(&vSize, 4, 1) != 1)
@@ -735,7 +735,7 @@ bool Bundle3D::loadMeshDatasBinary_0_2(MeshDatas& meshdatas)
 bool  Bundle3D::loadMeshDatasJson(MeshDatas& meshdatas)
 {
     const rapidjson::Value& mesh_data_array = _jsonReader[MESHES];
-    for (rapidjson::SizeType index = 0; index < mesh_data_array.Size(); index++)
+    for (rapidjson::SizeType index = 0, mesh_data_array_size = mesh_data_array.Size(); index < mesh_data_array_size; ++index)
     {
         MeshData*   meshData = new (std::nothrow) MeshData();
         const rapidjson::Value& mesh_data = mesh_data_array[index];
@@ -744,7 +744,7 @@ bool  Bundle3D::loadMeshDatasJson(MeshDatas& meshdatas)
         MeshVertexAttrib tempAttrib;
         meshData->attribCount=mesh_vertex_attribute.Size();
         meshData->attribs.resize(meshData->attribCount);
-        for (rapidjson::SizeType i = 0; i < mesh_vertex_attribute.Size(); i++)
+        for (rapidjson::SizeType i = 0, mesh_vertex_attribute_size = mesh_vertex_attribute.Size(); i < mesh_vertex_attribute_size; ++i)
         {
             const rapidjson::Value& mesh_vertex_attribute_val = mesh_vertex_attribute[i];
 
@@ -761,22 +761,23 @@ bool  Bundle3D::loadMeshDatasJson(MeshDatas& meshdatas)
         // mesh vertices
         ////////////////////////////////////////////////////////////////////////////////////////////////
         const rapidjson::Value& mesh_data_vertex_array = mesh_data[VERTICES];
-        meshData->vertexSizeInFloat=mesh_data_vertex_array.Size();
-        for (rapidjson::SizeType i = 0; i < mesh_data_vertex_array.Size(); i++)
+        auto mesh_data_vertex_array_size = mesh_data_vertex_array.Size();
+        meshData->vertexSizeInFloat = mesh_data_vertex_array_size;
+        for (rapidjson::SizeType i = 0; i < mesh_data_vertex_array_size; ++i)
         {
             meshData->vertex.push_back(mesh_data_vertex_array[i].GetDouble());
         }
         // mesh part
         ////////////////////////////////////////////////////////////////////////////////////////////////
         const rapidjson::Value& mesh_part_array = mesh_data[PARTS];
-        for (rapidjson::SizeType i = 0; i < mesh_part_array.Size(); i++)
+        for (rapidjson::SizeType i = 0, mesh_part_array_size = mesh_part_array.Size(); i < mesh_part_array_size; ++i)
         {
             std::vector<unsigned short>      indexArray;
             const rapidjson::Value& mesh_part = mesh_part_array[i];
             meshData->subMeshIds.push_back(mesh_part[ID].GetString());
             // index_number
             const rapidjson::Value& indices_val_array = mesh_part[INDICES];
-            for (rapidjson::SizeType j = 0; j < indices_val_array.Size(); j++)
+            for (rapidjson::SizeType j = 0, indices_val_array_size = indices_val_array.Size(); j < indices_val_array_size; ++j)
                 indexArray.push_back((unsigned short)indices_val_array[j].GetUint());
 
             meshData->subMeshIndices.push_back(indexArray);
@@ -827,19 +828,21 @@ bool Bundle3D::loadNodes(NodeDatas& nodedatas)
         auto nodeDatas = new (std::nothrow) NodeData*[skinData.skinBoneNames.size() + skinData.nodeBoneNames.size()];
         int index = 0;
         size_t i;
-        for (i = 0; i < skinData.skinBoneNames.size(); i++)
+        auto skinBoneSize = skinData.skinBoneNames.size();
+        auto nodeBoneSize = skinData.nodeBoneNames.size();
+        for (i = 0; i < skinBoneSize; ++i)
         {
             nodeDatas[index] = new (std::nothrow) NodeData();
             nodeDatas[index]->id = skinData.skinBoneNames[i];
             nodeDatas[index]->transform = skinData.skinBoneOriginMatrices[i];
-            index++;
+            ++index;
         }
-        for (i = 0; i < skinData.nodeBoneNames.size(); i++)
+        for (i = 0; i < nodeBoneSize; ++i)
         {
             nodeDatas[index] = new (std::nothrow) NodeData();
             nodeDatas[index]->id = skinData.nodeBoneNames[i];
             nodeDatas[index]->transform = skinData.nodeBoneOriginMatrices[i];
-            index++;
+            ++index;
         }
         for (const auto& it : skinData.boneChild)
         {
@@ -915,7 +918,7 @@ bool Bundle3D::loadMaterialsBinary(MaterialDatas& materialdatas)
         return false;
     unsigned int materialnum = 1;
     _binaryReader.read(&materialnum, 4, 1);
-    for (unsigned int i = 0; i < materialnum; i++)
+    for (unsigned int i = 0; i < materialnum; ++i)
     {
         NMaterialData materialData;
         materialData.id = _binaryReader.readString();
@@ -926,7 +929,7 @@ bool Bundle3D::loadMaterialsBinary(MaterialDatas& materialdatas)
         
         unsigned int textureNum = 1;
         _binaryReader.read(&textureNum, 4, 1);
-        for (unsigned int j = 0; j < textureNum; j++)
+        for (unsigned int j = 0; j < textureNum; ++j)
         {
             NTextureData  textureData;
             textureData.id = _binaryReader.readString();
@@ -985,7 +988,7 @@ bool Bundle3D::loadMaterialsBinary_0_2(MaterialDatas& materialdatas)
     unsigned int materialnum = 1;
     _binaryReader.read(&materialnum, 4, 1);
 
-    for (unsigned int i = 0; i < materialnum; i++)
+    for (unsigned int i = 0; i < materialnum; ++i)
     {
         NMaterialData materialData;
 
@@ -1010,7 +1013,7 @@ bool  Bundle3D::loadMaterialsJson(MaterialDatas& materialdatas)
     if (!_jsonReader.HasMember(MATERIALS))
         return false;
     const rapidjson::Value& material_array = _jsonReader[MATERIALS];
-    for (rapidjson::SizeType i = 0; i < material_array.Size(); i++)
+    for (rapidjson::SizeType i = 0; i < material_array.Size(); ++i)
     {
         NMaterialData materialData;
         const rapidjson::Value& material_val = material_array[i];
@@ -1018,7 +1021,7 @@ bool  Bundle3D::loadMaterialsJson(MaterialDatas& materialdatas)
         if (material_val.HasMember(TEXTURES))
         {
             const rapidjson::Value& texture_array = material_val[TEXTURES];
-            for (rapidjson::SizeType j = 0; j < texture_array.Size(); j++)
+            for (rapidjson::SizeType j = 0; j < texture_array.Size(); ++j)
             {
                 NTextureData  textureData;
                 const rapidjson::Value& texture_val = texture_array[j];
@@ -1136,7 +1139,7 @@ bool Bundle3D::loadMeshDataJson_0_1(MeshDatas& meshdatas)
     const rapidjson::Value& mesh_vertex_attribute = mesh_data_val[ATTRIBUTES];
     meshdata->attribCount = mesh_vertex_attribute.Size();
     meshdata->attribs.resize(meshdata->attribCount);
-    for (rapidjson::SizeType i = 0; i < mesh_vertex_attribute.Size(); i++)
+    for (rapidjson::SizeType i = 0; i < mesh_vertex_attribute.Size(); ++i)
     {
         const rapidjson::Value& mesh_vertex_attribute_val = mesh_vertex_attribute[i];
 
@@ -1151,7 +1154,7 @@ bool Bundle3D::loadMeshDataJson_0_1(MeshDatas& meshdatas)
     meshdata->vertex.resize(meshdata->vertexSizeInFloat);
 
     const rapidjson::Value& mesh_data_body_vertices = mesh_data_body_array_0[VERTICES];
-    for (rapidjson::SizeType i = 0; i < mesh_data_body_vertices.Size(); i++)
+    for (rapidjson::SizeType i = 0; i < mesh_data_body_vertices.Size(); ++i)
         meshdata->vertex[i] = mesh_data_body_vertices[i].GetDouble();
 
     // index_number
@@ -1162,7 +1165,7 @@ bool Bundle3D::loadMeshDataJson_0_1(MeshDatas& meshdatas)
     indices.resize(indexnum);
 
     const rapidjson::Value& indices_val_array = mesh_data_body_array_0[INDICES];
-    for (rapidjson::SizeType i = 0; i < indices_val_array.Size(); i++)
+    for (rapidjson::SizeType i = 0; i < indices_val_array.Size(); ++i)
         indices[i] = (unsigned short)indices_val_array[i].GetUint();
 
     meshdata->subMeshIndices.push_back(indices);
@@ -1181,7 +1184,7 @@ bool Bundle3D::loadMeshDataJson_0_2(MeshDatas& meshdatas)
     const rapidjson::Value& mesh_vertex_attribute = mesh_array_0[ATTRIBUTES];
     meshdata->attribCount = mesh_vertex_attribute.Size();
     meshdata->attribs.resize(meshdata->attribCount);
-    for (rapidjson::SizeType i = 0; i < mesh_vertex_attribute.Size(); i++)
+    for (rapidjson::SizeType i = 0; i < mesh_vertex_attribute.Size(); ++i)
     {
         const rapidjson::Value& mesh_vertex_attribute_val = mesh_vertex_attribute[i];
 
@@ -1199,12 +1202,12 @@ bool Bundle3D::loadMeshDataJson_0_2(MeshDatas& meshdatas)
     meshdata->vertex.resize(meshdata->vertexSizeInFloat);
 
     const rapidjson::Value& mesh_data_body_vertices = mesh_data_vertex_0[VERTICES];
-    for (rapidjson::SizeType i = 0; i < mesh_data_body_vertices.Size(); i++)
+    for (rapidjson::SizeType i = 0; i < mesh_data_body_vertices.Size(); ++i)
         meshdata->vertex[i] = mesh_data_body_vertices[i].GetDouble();
 
     // submesh
     const rapidjson::Value& mesh_submesh_array = mesh_array_0[SUBMESH];
-    for (rapidjson::SizeType i = 0; i < mesh_submesh_array.Size(); i++)
+    for (rapidjson::SizeType i = 0; i < mesh_submesh_array.Size(); ++i)
     {
         const rapidjson::Value& mesh_submesh_val = mesh_submesh_array[i];
         //std::string id = mesh_submesh_val[ID].GetString();
@@ -1217,7 +1220,7 @@ bool Bundle3D::loadMeshDataJson_0_2(MeshDatas& meshdatas)
         indices.resize(indexnum);
 
         const rapidjson::Value& indices_val_array = mesh_submesh_val[INDICES];
-        for (rapidjson::SizeType j = 0; j < indices_val_array.Size(); j++)
+        for (rapidjson::SizeType j = 0; j < indices_val_array.Size(); ++j)
             indices[j] = (unsigned short)indices_val_array[j].GetUint();
 
         meshdata->subMeshIndices.push_back(indices);
@@ -1240,7 +1243,7 @@ bool Bundle3D::loadSkinDataJson(SkinData* skindata)
         return false;
 
     const rapidjson::Value& skin_data_bones = skin_data_array_val_0[BONES];
-    for (rapidjson::SizeType i = 0; i < skin_data_bones.Size(); i++)
+    for (rapidjson::SizeType i = 0; i < skin_data_bones.Size(); ++i)
     {
         const rapidjson::Value& skin_data_bone = skin_data_bones[i];
         std::string name = skin_data_bone[NODE].GetString();
@@ -1248,7 +1251,7 @@ bool Bundle3D::loadSkinDataJson(SkinData* skindata)
 
         Mat4 mat_bind_pos;
         const rapidjson::Value& bind_pos = skin_data_bone[BINDSHAPE];
-        for (rapidjson::SizeType j = 0; j < bind_pos.Size(); j++)
+        for (rapidjson::SizeType j = 0; j < bind_pos.Size(); ++j)
         {
             mat_bind_pos.m[j] = bind_pos[j].GetDouble();
         }
@@ -1294,7 +1297,7 @@ bool Bundle3D::loadSkinDataBinary(SkinData* skindata)
     
     // bone names and bind pos
     float bindpos[16];
-    for (unsigned int i = 0; i < boneNum; i++)
+    for (unsigned int i = 0; i < boneNum; ++i)
     {
         std::string skinBoneName = _binaryReader.readString();
         skindata->skinBoneNames.push_back(skinBoneName);
@@ -1405,7 +1408,7 @@ bool Bundle3D::loadMaterialDataJson_0_2(MaterialDatas& materialdatas)
     NMaterialData materialData;
     const rapidjson::Value& material_array = _jsonReader[MATERIAL];
 
-    for (rapidjson::SizeType i = 0; i < material_array.Size(); i++)
+    for (rapidjson::SizeType i = 0; i < material_array.Size(); ++i)
     {
         NTextureData  textureData;
         const rapidjson::Value& material_val = material_array[i];
@@ -1437,7 +1440,7 @@ bool Bundle3D::loadAnimationDataJson(const std::string& id, Animation3DData* ani
 
     if(!id.empty())
     {
-        for (rapidjson::SizeType i = 0; i < animation_data_array.Size(); i++)
+        for (rapidjson::SizeType i = 0; i < animation_data_array.Size(); ++i)
         {
             if(animation_data_array[i][ID].GetString() == id)
             {
@@ -1454,7 +1457,7 @@ bool Bundle3D::loadAnimationDataJson(const std::string& id, Animation3DData* ani
     animationdata->_totalTime = animation_data_array_val_0[LENGTH].GetDouble();
 
     const rapidjson::Value&  bones =  animation_data_array_val_0[BONES];
-    for (rapidjson::SizeType i = 0; i <  bones.Size(); i++)
+    for (rapidjson::SizeType i = 0; i <  bones.Size(); ++i)
     {
         const rapidjson::Value&  bone =  bones[i];
         std::string bone_name =  bone[BONEID].GetString();
@@ -1467,7 +1470,7 @@ bool Bundle3D::loadAnimationDataJson(const std::string& id, Animation3DData* ani
             animationdata->_scaleKeys[bone_name].reserve(keyframe_size);
             animationdata->_translationKeys[bone_name].reserve(keyframe_size);
             
-            for (rapidjson::SizeType j = 0; j < keyframe_size; j++)
+            for (rapidjson::SizeType j = 0; j < keyframe_size; ++j)
             {
                 const rapidjson::Value&  bone_keyframe =  bone_keyframes[j];
 
@@ -1530,7 +1533,7 @@ bool Bundle3D::loadAnimationDataBinary(const std::string& id, Animation3DData* a
     }
     
     bool has_found =false;
-    for(unsigned int k = 0; k < animNum ; k++ )
+    for(unsigned int k = 0; k < animNum ; ++k )
     {
         animationdata->resetData();
         std::string animId = _binaryReader.readString();
@@ -1653,7 +1656,7 @@ bool Bundle3D::loadNodesJson(NodeDatas& nodedatas)
     if(!nodes.IsArray()) return false;
 
     // traverse the nodes again
-    for (rapidjson::SizeType i = 0; i < nodes.Size(); i++)
+    for (rapidjson::SizeType i = 0; i < nodes.Size(); ++i)
     {
         const rapidjson::Value& jnode = nodes[i];
         std::string id = jnode[ID].GetString();
@@ -1677,7 +1680,7 @@ NodeData* Bundle3D::parseNodesRecursivelyJson(const rapidjson::Value& jvalue, bo
     Mat4 transform;
     const rapidjson::Value& jtransform = jvalue[TRANSFORM];
 
-    for (rapidjson::SizeType j = 0; j < jtransform.Size(); j++)
+    for (rapidjson::SizeType j = 0; j < jtransform.Size(); ++j)
     {
         transform.m[j] = jtransform[j].GetDouble();
     }
@@ -1692,7 +1695,7 @@ NodeData* Bundle3D::parseNodesRecursivelyJson(const rapidjson::Value& jvalue, bo
         const rapidjson::Value& parts = jvalue[PARTS];
        
 
-        for (rapidjson::SizeType i = 0; i < parts.Size(); i++)
+        for (rapidjson::SizeType i = 0; i < parts.Size(); ++i)
         {
             auto modelnodedata = new (std::nothrow) ModelData();
             const rapidjson::Value& part = parts[i];
@@ -1711,7 +1714,7 @@ NodeData* Bundle3D::parseNodesRecursivelyJson(const rapidjson::Value& jvalue, bo
             {
                 const rapidjson::Value& bones = part[BONES];
 
-                for (rapidjson::SizeType j = 0; j < bones.Size(); j++) 
+                for (rapidjson::SizeType j = 0; j < bones.Size(); ++j)
                 {
                     const rapidjson::Value& bone = bones[j];
 
@@ -1729,7 +1732,7 @@ NodeData* Bundle3D::parseNodesRecursivelyJson(const rapidjson::Value& jvalue, bo
                     Mat4 invbindpos;
                     const rapidjson::Value& jinvbindpos = bone[TRANSFORM];
 
-                    for (rapidjson::SizeType k = 0; k < jinvbindpos.Size(); k++)
+                    for (rapidjson::SizeType k = 0; k < jinvbindpos.Size(); ++k)
                     {
                         invbindpos.m[k] = jinvbindpos[k].GetDouble();
                     }
@@ -1765,7 +1768,7 @@ NodeData* Bundle3D::parseNodesRecursivelyJson(const rapidjson::Value& jvalue, bo
     if (jvalue.HasMember(CHILDREN))
     {
         const rapidjson::Value& children = jvalue[CHILDREN];
-        for (rapidjson::SizeType i = 0; i <  children.Size(); i++)
+        for (rapidjson::SizeType i = 0; i <  children.Size(); ++i)
         {
             const rapidjson::Value& child = children[i];
 
@@ -1789,7 +1792,7 @@ bool Bundle3D::loadNodesBinary(NodeDatas& nodedatas)
     }
 
     // traverse the nodes again
-    for (rapidjson::SizeType i = 0; i < nodeSize; i++)
+    for (rapidjson::SizeType i = 0; i < nodeSize; ++i)
     {
         bool skeleton = false;
         NodeData* nodedata = parseNodesRecursivelyBinary(skeleton, nodeSize == 1);
@@ -1837,7 +1840,7 @@ NodeData* Bundle3D::parseNodesRecursivelyBinary(bool& skeleton, bool singleSprit
     
     if (partsSize > 0)
     {
-        for (unsigned int i = 0; i < partsSize; i++)
+        for (unsigned int i = 0; i < partsSize; ++i)
         {
             auto modelnodedata  = new (std::nothrow) ModelData();
             modelnodedata->subMeshId = _binaryReader.readString();
@@ -1864,7 +1867,7 @@ NodeData* Bundle3D::parseNodesRecursivelyBinary(bool& skeleton, bool singleSprit
 
             if (bonesSize > 0)
             {
-                for (unsigned int j = 0; j < bonesSize; j++)
+                for (unsigned int j = 0; j < bonesSize; ++j)
                 {
                     std::string name = _binaryReader.readString();
                     modelnodedata->bones.push_back(name);
@@ -1889,7 +1892,7 @@ NodeData* Bundle3D::parseNodesRecursivelyBinary(bool& skeleton, bool singleSprit
                 CC_SAFE_DELETE(nodedata);
                 return nullptr;
             }
-            for(unsigned int j = 0; j < uvMapping; j++)
+            for(unsigned int j = 0; j < uvMapping; ++j)
             {
                 unsigned int textureIndexSize=0;
                 if (_binaryReader.read(&textureIndexSize, 4, 1) != 1)
@@ -1899,7 +1902,7 @@ NodeData* Bundle3D::parseNodesRecursivelyBinary(bool& skeleton, bool singleSprit
                     CC_SAFE_DELETE(nodedata);
                     return nullptr;
                 }
-                for(unsigned int k = 0; k < textureIndexSize; k++)
+                for(unsigned int k = 0; k < textureIndexSize; ++k)
                 {
                     unsigned int index=0;
                     if (_binaryReader.read(&index, 4, 1) != 1)
@@ -1940,7 +1943,7 @@ NodeData* Bundle3D::parseNodesRecursivelyBinary(bool& skeleton, bool singleSprit
     }
     if (childrenSize > 0)
     {
-        for (unsigned int i = 0; i <  childrenSize; i++)
+        for (unsigned int i = 0; i <  childrenSize; ++i)
         {
             NodeData* tempdata = parseNodesRecursivelyBinary(skeleton, singleSprite);
             nodedata->children.push_back(tempdata);

--- a/cocos/3d/CCMeshSkin.cpp
+++ b/cocos/3d/CCMeshSkin.cpp
@@ -86,8 +86,7 @@ Bone3D* MeshSkin::getBoneByName(const std::string& id) const
 
 int MeshSkin::getBoneIndex(Bone3D* bone) const
 {
-    int i = 0;
-    for (; i < _skinBones.size(); i++) {
+    for (int i = 0, size = _skinBones.size(); i < size; ++i) {
         if (_skinBones.at(i) == bone)
             return i;
     }
@@ -147,7 +146,7 @@ Bone3D* MeshSkin::getRootBone() const
 
 const Mat4& MeshSkin::getInvBindPose(const Bone3D* bone)
 {
-    for (ssize_t i = 0; i < _skinBones.size(); i++) {
+    for (ssize_t i = 0, size = _skinBones.size(); i < size; ++i) {
         if (_skinBones.at(i) == bone)
         {
             return _invBindPoses.at(i);

--- a/cocos/3d/CCMeshVertexIndexData.cpp
+++ b/cocos/3d/CCMeshVertexIndexData.cpp
@@ -102,7 +102,7 @@ MeshVertexData* MeshVertexData::create(const MeshData& meshdata)
     }
     
     bool needCalcAABB = (meshdata.subMeshAABB.size() != meshdata.subMeshIndices.size());
-    for (size_t i = 0; i < meshdata.subMeshIndices.size(); i++) {
+    for (size_t i = 0, size = meshdata.subMeshIndices.size(); i < size; ++i) {
 
         auto& index = meshdata.subMeshIndices[i];
         auto indexBuffer = IndexBuffer::create(IndexBuffer::IndexType::INDEX_TYPE_SHORT_16, (int)(index.size()));

--- a/cocos/3d/CCObjLoader.cpp
+++ b/cocos/3d/CCObjLoader.cpp
@@ -372,7 +372,7 @@ namespace tinyobj {
         }
         
         // Flatten vertices and indices
-        for (size_t i = 0; i < faceGroup.size(); i++) {
+        for (size_t i = 0, size = faceGroup.size(); i < size; ++i) {
             const std::vector<vertex_index> &face = faceGroup[i];
             
             vertex_index i0 = face[0];
@@ -414,7 +414,7 @@ namespace tinyobj {
     
     static std::string& replacePathSeperator(std::string& path)
     {
-        for (std::string::size_type i = 0; i < path.size(); i++) {
+        for (std::string::size_type i = 0, size = path.size(); i < size; ++i) {
             if (path[i] == '\\')
                 path[i] = '/';
         }
@@ -762,9 +762,12 @@ namespace tinyobj {
                 token += strspn(token, " \t");
                 
                 std::vector<vertex_index> face;
+                auto first = static_cast<int>(v.size() / 3);
+                auto second = static_cast<int>(vn.size() / 3);
+                auto third = static_cast<int>(vt.size() / 2);
                 while (!isNewLine(token[0])) {
                     vertex_index vi =
-                    parseTriple(token, static_cast<int>(v.size() / 3), static_cast<int>(vn.size() / 3), static_cast<int>(vt.size() / 2));
+                    parseTriple(token, first, second, third);
                     face.push_back(vi);
                     size_t n = strspn(token, " \t\r");
                     token += n;

--- a/cocos/3d/CCSkeleton3D.cpp
+++ b/cocos/3d/CCSkeleton3D.cpp
@@ -303,12 +303,11 @@ Bone3D* Skeleton3D::getRootBone(int index) const
 
 int Skeleton3D::getBoneIndex(Bone3D* bone) const
 {
-    int i = 0;
-    for (; i < _bones.size(); i++) {
+    for (int i = 0, size = _bones.size(); i < size; ++i) {
         if (_bones.at(i) == bone)
             return i;
     }
-    
+
     return -1;
 }
 

--- a/cocos/3d/CCSprite3D.cpp
+++ b/cocos/3d/CCSprite3D.cpp
@@ -198,12 +198,13 @@ bool Sprite3D::loadFromCache(const std::string& path)
         }
         _skeleton = Skeleton3D::create(spritedata->nodedatas->skeleton);
         CC_SAFE_RETAIN(_skeleton);
-        
+
+        auto size = spritedata->nodedatas->nodes.size();
         for(const auto& it : spritedata->nodedatas->nodes)
         {
             if(it)
             {
-                createNode(it, this, *(spritedata->materialdatas), spritedata->nodedatas->nodes.size() == 1);
+                createNode(it, this, *(spritedata->materialdatas), size == 1);
             }
         }
         
@@ -214,8 +215,8 @@ bool Sprite3D::loadFromCache(const std::string& path)
                 createAttachSprite3DNode(it,*(spritedata->materialdatas));
             }
         }
-        
-        for (ssize_t i = 0; i < _meshes.size(); i++) {
+
+        for (ssize_t i = 0, size = _meshes.size(); i < size; ++i) {
             // cloning is needed in order to have one state per sprite
             auto glstate = spritedata->glProgramStates.at(i);
             _meshes.at(i)->setGLProgramState(glstate->clone());
@@ -337,11 +338,12 @@ bool Sprite3D::initFrom(const NodeDatas& nodeDatas, const MeshDatas& meshdatas, 
     _skeleton = Skeleton3D::create(nodeDatas.skeleton);
     CC_SAFE_RETAIN(_skeleton);
     
+    auto size = nodeDatas.nodes.size();
     for(const auto& it : nodeDatas.nodes)
     {
         if(it)
         {
-            createNode(it, this, materialdatas, nodeDatas.nodes.size() == 1);
+            createNode(it, this, materialdatas, size == 1);
         }
     }
     for(const auto& it : nodeDatas.skeleton)
@@ -355,6 +357,7 @@ bool Sprite3D::initFrom(const NodeDatas& nodeDatas, const MeshDatas& meshdatas, 
     
     return true;
 }
+
 Sprite3D* Sprite3D::createSprite3DNode(NodeData* nodedata,ModelData* modeldata,const MaterialDatas& materialdatas)
 {
     auto sprite = new (std::nothrow) Sprite3D();
@@ -462,7 +465,7 @@ void Sprite3D::setMaterial(Material *material, int meshIndex)
 
     if (meshIndex == -1)
     {
-        for (ssize_t i = 0; i < _meshes.size(); i++)
+        for (ssize_t i = 0, size = _meshes.size(); i < size; ++i)
         {
             _meshes.at(i)->setMaterial(i == 0 ? material : material->clone());
         }
@@ -628,9 +631,11 @@ void Sprite3D::createNode(NodeData* nodedata, Node* root, const MaterialDatas& m
             } 
         }
     }
+
+    auto size = nodedata->children.size();
     for(const auto& it : nodedata->children)
     {
-        createNode(it,node, materialdatas, nodedata->children.size() == 1);
+        createNode(it,node, materialdatas, size == 1);
     }
 }
 
@@ -726,7 +731,7 @@ void Sprite3D::visit(cocos2d::Renderer *renderer, const cocos2d::Mat4 &parentTra
     {
         sortAllChildren();
         // draw children zOrder < 0
-        for( ; i < _children.size(); i++ )
+        for(auto size = _children.size() ; i < size; i++ )
         {
             auto node = _children.at(i);
             
@@ -739,7 +744,7 @@ void Sprite3D::visit(cocos2d::Renderer *renderer, const cocos2d::Mat4 &parentTra
         if (visibleByCamera)
             this->draw(renderer, _modelViewTransform, flags);
         
-        for(auto it=_children.cbegin()+i; it != _children.cend(); ++it)
+        for(auto it=_children.cbegin()+i, itCend = _children.cend(); it != itCend; ++it)
             (*it)->visit(renderer, _modelViewTransform, flags);
     }
     else if (visibleByCamera)

--- a/cocos/3d/CCSprite3DMaterial.cpp
+++ b/cocos/3d/CCSprite3DMaterial.cpp
@@ -310,14 +310,14 @@ Texture2D* Sprite3DMaterialCache::getSprite3DMaterial(const std::string& key)
 
 void Sprite3DMaterialCache::removeAllSprite3DMaterial()
 {
-    for (auto itr = _materials.begin(); itr != _materials.end(); itr++) {
-        CC_SAFE_RELEASE_NULL(itr->second);
+    for (auto& itr : _materials) {
+        CC_SAFE_RELEASE_NULL(itr.second);
     }
     _materials.clear();
 }
 void Sprite3DMaterialCache::removeUnusedSprite3DMaterial()
 {
-    for( auto it=_materials.cbegin(); it!=_materials.cend(); /* nothing */) {
+    for(auto it=_materials.cbegin(), itCend = _materials.cend(); it != itCend; /* nothing */) {
         auto value = it->second;
         if( value->getReferenceCount() == 1 ) {
             CCLOG("cocos2d: GLProgramStateCache: removing unused GLProgramState");

--- a/cocos/3d/CCTerrain.cpp
+++ b/cocos/3d/CCTerrain.cpp
@@ -161,7 +161,7 @@ void Terrain::onDraw(const Mat4 &transform, uint32_t flags)
         glUniform1i(_alphaIsHasAlphaMapLocation,0);
     }else
     {
-        for(int i =0;i<_maxDetailMapValue;i++)
+        for(int i =0;i<_maxDetailMapValue;++i)
         {
             GL::bindTexture2DN(i,_detailMapTextures[i]->getName());
             glUniform1i(_detailMapLocation[i],i);
@@ -305,7 +305,7 @@ void Terrain::setChunksLOD(const Vec3& cameraPos)
             auto center = aabb.getCenter();
             float dist = Vec2(center.x, center.z).distance(Vec2(cameraPos.x, cameraPos.z));
             _chunkesArray[m][n]->_currentLod = 3;
-            for(int i =0;i<3;i++)
+            for(int i =0;i<3;++i)
             {
                 if(dist<=_lodDistance[i])
                 {
@@ -398,7 +398,7 @@ void Terrain::loadVertices()
 {
     _maxHeight = -99999;
     _minHeight = 99999;
-    for(int i =0;i<_imageHeight;i++)
+    for(int i =0;i<_imageHeight;++i)
     {
         for(int j =0;j<_imageWidth;j++)
         {
@@ -436,7 +436,7 @@ void Terrain::calculateNormal()
             _indices.push_back (nLocIndex + _imageWidth+1);
         }
     }
-    for (unsigned int i = 0 ; i < _indices.size() ; i += 3) {
+    for (unsigned int i = 0, size = _indices.size(); i < size; i += 3) {
         unsigned int Index0 = _indices[i];
         unsigned int Index1 = _indices[i + 1];
         unsigned int Index2 = _indices[i + 2];
@@ -450,7 +450,7 @@ void Terrain::calculateNormal()
         _vertices[Index2]._normal += Normal;
     }
 
-    for (unsigned int i = 0 ; i < _vertices.size() ; i++) {
+    for (unsigned int i = 0, size = _vertices.size(); i < size; ++i) {
         _vertices[i]._normal.normalize();
     }
     //global indices no need at all
@@ -481,14 +481,14 @@ Terrain::~Terrain()
     CC_SAFE_RELEASE(_lightMap);
     CC_SAFE_RELEASE(_heightMapImage);
     delete _quadRoot;
-    for(int i=0;i<4;i++)
+    for(int i=0;i<4;++i)
     {
         if(_detailMapTextures[i])
         {
             _detailMapTextures[i]->release();
         }
     }
-    for(int i = 0;i<MAX_CHUNKES;i++)
+    for(int i = 0;i<MAX_CHUNKES;++i)
     {
         for(int j = 0;j<MAX_CHUNKES;j++)
         {
@@ -499,12 +499,12 @@ Terrain::~Terrain()
         }
     }
 
-    for(size_t i =0;i<_chunkLodIndicesSet.size();i++)
+    for(size_t i =0, size = _chunkLodIndicesSet.size(); i < size; ++i)
     {
         glDeleteBuffers(1,&(_chunkLodIndicesSet[i]._chunkIndices._indices));
     }
 
-    for(size_t i =0;i<_chunkLodIndicesSkirtSet.size();i++)
+    for(size_t i =0, size = _chunkLodIndicesSkirtSet.size(); i < size; ++i)
     {
         glDeleteBuffers(1,&(_chunkLodIndicesSkirtSet[i]._chunkIndices._indices));
     }
@@ -543,7 +543,7 @@ cocos2d::Vec3 Terrain::getIntersectionPoint(const Ray & ray) const
 
 bool Terrain::getIntersectionPoint(const Ray & ray_, Vec3 & intersectionPoint) const
 {
-	// convert ray from world space to local space
+    // convert ray from world space to local space
     Ray ray(ray_);
     getWorldToNodeTransform().transformPoint(&(ray._origin));
 
@@ -635,7 +635,7 @@ void Terrain::resetHeightMap(const std::string& heightMap)
     _heightMapImage->release();
     _vertices.clear();
     free(_data);
-    for(int i = 0;i<MAX_CHUNKES;i++)
+    for(int i = 0;i<MAX_CHUNKES;++i)
     {
         for(int j = 0;j<MAX_CHUNKES;j++)
         {
@@ -674,7 +674,7 @@ std::vector<float> Terrain::getHeightData() const
 {
     std::vector<float> data;
     data.resize(_imageWidth * _imageHeight);
-    for (int i = 0; i < _imageHeight; i++) {
+    for (int i = 0; i < _imageHeight; ++i) {
         for (int j = 0; j < _imageWidth; j++) {
             int idx = i * _imageWidth + j;
             data[idx] = (_vertices[idx]._position.y);
@@ -730,7 +730,7 @@ Terrain::ChunkIndices Terrain::lookForIndicesLOD(int neighborLod[4], int selfLod
         int test[5];
         memcpy(test,neighborLod,sizeof(int [4]));
         test[4] = selfLod;
-        for(size_t i =0;i<_chunkLodIndicesSet.size();i++)
+        for(size_t i =0, size = _chunkLodIndicesSet.size(); i < size; ++i)
         {
             if(memcmp(test,_chunkLodIndicesSet[i]._relativeLod,sizeof(test))==0)
             {
@@ -766,8 +766,7 @@ Terrain::ChunkIndices Terrain::lookForIndicesLODSkrit(int selfLod, bool * result
     (*result) = false;
     return badResult;
     }
-
-    for(size_t i =0;i<_chunkLodIndicesSkirtSet.size();i++)
+    for(size_t i = 0, size = _chunkLodIndicesSkirtSet.size(); i < size; ++i)
     {
         if(_chunkLodIndicesSkirtSet[i]._selfLod == selfLod)
         {
@@ -819,7 +818,7 @@ void Terrain::cacheUniformAttribLocation()
     _texcordLocation = glGetAttribLocation(this->getGLProgram()->getProgram(),"a_texCoord");
     _normalLocation = glGetAttribLocation(this->getGLProgram()->getProgram(),"a_normal");
     _alphaMapLocation = -1;
-    for(int i =0;i<4;i++)
+    for(int i =0;i<4;++i)
     {
         _detailMapLocation[i] = -1;
         _detailMapSizeLocation[i] = -1;
@@ -832,7 +831,7 @@ void Terrain::cacheUniformAttribLocation()
         _detailMapLocation[0] = glGetUniformLocation(glProgram->getProgram(),"u_texture0");
     }else
     {
-        for(int i =0;i<_maxDetailMapValue;i++)
+        for(int i =0;i<_maxDetailMapValue;++i)
         {
             char str[20];
             sprintf(str,"u_texture%d",i);
@@ -849,7 +848,7 @@ void Terrain::cacheUniformAttribLocation()
 
 bool Terrain::initTextures()
 {
-    for (int i = 0; i < 4; i++)
+    for (int i = 0; i < 4; ++i)
     {
         _detailMapTextures[i] = nullptr;
     }
@@ -883,7 +882,7 @@ bool Terrain::initTextures()
         _alphaMap->setTexParameters(texParam);
         delete image;
 
-        for(int i =0;i<_terrainData._detailMapAmount;i++)
+        for(int i =0;i<_terrainData._detailMapAmount;++i)
         {
             auto textImage = new (std::nothrow)Image();
             textImage->initWithImageFile(_terrainData._detailMaps[i]._detailMapSrc);
@@ -936,7 +935,7 @@ void Terrain::Chunk::finish()
 
     calculateSlope();
 
-    for(int i =0;i<4;i++)
+    for(int i =0;i<4;++i)
     {
         int step = 1<<_currentLod;
         //reserve the indices size, the first part is the core part of the chunk, the second part & third part is for fix crack
@@ -988,7 +987,7 @@ void Terrain::Chunk::generate(int imgWidth, int imageHei, int m, int n, const un
     {
     case CrackFixedType::SKIRT:
         {
-            for(int i=_size.height*m;i<=_size.height*(m+1);i++)
+            for(int i=_size.height*m;i<=_size.height*(m+1);++i)
             {
                 if(i>=imageHei) break;
                 for(int j=_size.width*n;j<=_size.width*(n+1);j++)
@@ -1003,7 +1002,7 @@ void Terrain::Chunk::generate(int imgWidth, int imageHei, int m, int n, const un
             float skirtHeight =  _terrain->_skirtRatio *_terrain->_terrainData._mapScale*8;
             //#1
             _terrain->_skirtVerticesOffset[0] = (int)_originalVertices.size();
-            for(int i =_size.height*m;i<=_size.height*(m+1);i++)
+            for(int i =_size.height*m;i<=_size.height*(m+1);++i)
             {
                 auto v = _terrain->_vertices[i*imgWidth +_size.width*(n+1)];
                 v._position.y -= skirtHeight;
@@ -1021,7 +1020,7 @@ void Terrain::Chunk::generate(int imgWidth, int imageHei, int m, int n, const un
 
             //#3
             _terrain->_skirtVerticesOffset[2] = (int)_originalVertices.size();
-            for(int i =_size.height*m;i<=_size.height*(m+1);i++)
+            for(int i =_size.height*m;i<=_size.height*(m+1);++i)
             {
                 auto v = _terrain->_vertices[i*imgWidth + _size.width*n];
                 v._position.y -= skirtHeight;
@@ -1041,7 +1040,7 @@ void Terrain::Chunk::generate(int imgWidth, int imageHei, int m, int n, const un
         break;
     case CrackFixedType::INCREASE_LOWER:
         {
-            for(int i=_size.height*m;i<=_size.height*(m+1);i++)
+            for(int i=_size.height*m;i<=_size.height*(m+1);++i)
             {
                 if(i>=imageHei) break;
                 for(int j=_size.width*n;j<=_size.width*(n+1);j++)
@@ -1055,7 +1054,7 @@ void Terrain::Chunk::generate(int imgWidth, int imageHei, int m, int n, const un
         break;
     }
     //store triangle:
-    for (int i = 0; i < _size.height; i++)
+    for (int i = 0; i < _size.height; ++i)
     {
         for (int j = 0; j < _size.width; j++)
         {
@@ -1080,7 +1079,7 @@ Terrain::Chunk::Chunk()
     _back = nullptr;
     _front = nullptr;
     _oldLod = -1;
-    for(int i =0;i<4;i++)
+    for(int i =0;i<4;++i)
     {
         _neighborOldLOD[i] = -1;
     }
@@ -1293,7 +1292,7 @@ void Terrain::Chunk::updateIndicesLOD()
 void Terrain::Chunk::calculateAABB()
 {
     std::vector<Vec3>pos;
-    for(size_t i =0;i<_originalVertices.size();i++)
+    for(size_t i = 0, size = _originalVertices.size(); i < size; ++i)
     {
         pos.push_back(_originalVertices[i]._position);
     }
@@ -1304,7 +1303,7 @@ void Terrain::Chunk::calculateSlope()
 {
     //find max slope
     auto lowest = _originalVertices[0]._position;
-    for(size_t i = 0;i<_originalVertices.size();i++)
+    for(size_t i = 0, size = _originalVertices.size(); i < size; ++i)
     {
         if(_originalVertices[i]._position.y< lowest.y)
         {
@@ -1312,7 +1311,7 @@ void Terrain::Chunk::calculateSlope()
         }
     }
     auto highest = _originalVertices[0]._position;
-    for(size_t i = 0;i<_originalVertices.size();i++)
+    for(size_t i = 0, size = _originalVertices.size(); i < size; ++i)
     {
         if(_originalVertices[i]._position.y> highest.y)
         {

--- a/cocos/audio/linux/AudioEngine-linux.cpp
+++ b/cocos/audio/linux/AudioEngine-linux.cpp
@@ -170,8 +170,8 @@ bool AudioEngineImpl::stop(int audioID)
 
 void AudioEngineImpl::stopAll()
 {
-    for (auto it = mapChannelInfo.begin(); it != mapChannelInfo.end(); ++it) {
-        ChannelInfo & audioRef = it->second;
+    for (auto& it : mapChannelInfo) {
+        ChannelInfo & audioRef = it.second;
         audioRef.channel->stop();
         audioRef.channel = nullptr;
     }
@@ -269,8 +269,8 @@ void AudioEngineImpl::uncache(const std::string& path)
 
 void AudioEngineImpl::uncacheAll()
 {
-    for (auto it = mapSound.cbegin(); it != mapSound.cend(); ++it) {
-        auto sound = it->second;
+    for (const auto& it : mapSound) {
+        auto sound = it.second;
         if (sound) {
             sound->release();
         }

--- a/cocos/audio/winrt/Audio.cpp
+++ b/cocos/audio/winrt/Audio.cpp
@@ -141,7 +141,7 @@ void Audio::ReleaseResources()
         m_soundEffectMasteringVoice = nullptr;
     }
 
-    for (auto& EffectIter = m_soundEffects)
+    for (auto& EffectIter : m_soundEffects)
 	{
         if (EffectIter.second.m_soundEffectSourceVoice != nullptr)
         {

--- a/cocos/audio/winrt/Audio.cpp
+++ b/cocos/audio/winrt/Audio.cpp
@@ -141,13 +141,12 @@ void Audio::ReleaseResources()
         m_soundEffectMasteringVoice = nullptr;
     }
 
-    EffectList::iterator EffectIter = m_soundEffects.begin();
-    for (; EffectIter != m_soundEffects.end(); EffectIter++)
+    for (auto& EffectIter = m_soundEffects)
 	{
-        if (EffectIter->second.m_soundEffectSourceVoice != nullptr) 
+        if (EffectIter.second.m_soundEffectSourceVoice != nullptr)
         {
-            EffectIter->second.m_soundEffectSourceVoice->DestroyVoice();
-            EffectIter->second.m_soundEffectSourceVoice = nullptr;
+            EffectIter.second.m_soundEffectSourceVoice->DestroyVoice();
+            EffectIter.second.m_soundEffectSourceVoice = nullptr;
         }
 	}
     m_soundEffects.clear();
@@ -272,11 +271,10 @@ void Audio::SetSoundEffectVolume(float volume)
         return;
     }
 
-    EffectList::iterator iter;
-	for (iter = m_soundEffects.begin(); iter != m_soundEffects.end(); iter++)
+	for (auto& iter : m_soundEffects)
 	{
-        if (iter->first != m_backgroundID)
-            iter->second.m_soundEffectSourceVoice->SetVolume(m_soundEffctVolume);
+        if (iter.first != m_backgroundID)
+            iter.second.m_soundEffectSourceVoice->SetVolume(m_soundEffctVolume);
 	}
 }
 
@@ -414,11 +412,10 @@ void Audio::PauseAllSoundEffects()
         return;
     }
 
-    EffectList::iterator iter;
-	for (iter = m_soundEffects.begin(); iter != m_soundEffects.end(); iter++)
+	for (auto& iter : m_soundEffects)
 	{
-        if (iter->first != m_backgroundID)
-            PauseSoundEffect(iter->first);
+        if (iter.first != m_backgroundID)
+            PauseSoundEffect(iter.first);
 	}
 }
 
@@ -428,11 +425,10 @@ void Audio::ResumeAllSoundEffects()
         return;
     }
 
-    EffectList::iterator iter;
-	for (iter = m_soundEffects.begin(); iter != m_soundEffects.end(); iter++)
+	for (auto& iter : m_soundEffects)
 	{
-        if (iter->first != m_backgroundID)
-            ResumeSoundEffect(iter->first);
+        if (iter.first != m_backgroundID)
+            ResumeSoundEffect(iter.first);
 	}
 }
 

--- a/cocos/base/CCConfiguration.cpp
+++ b/cocos/base/CCConfiguration.cpp
@@ -384,12 +384,12 @@ void Configuration::loadConfigFile(const std::string& filename)
 	// Add all keys in the existing dictionary
     
 	const auto& dataMap = dataIter->second.asValueMap();
-    for (auto dataMapIter = dataMap.cbegin(); dataMapIter != dataMap.cend(); ++dataMapIter)
+    for (const auto& dataMapIter : dataMap)
     {
-        if (_valueDict.find(dataMapIter->first) == _valueDict.cend())
-            _valueDict[dataMapIter->first] = dataMapIter->second;
+        if (_valueDict.find(dataMapIter.first) == _valueDict.cend())
+            _valueDict[dataMapIter.first] = dataMapIter.second;
         else
-            CCLOG("Key already present. Ignoring '%s'",dataMapIter->first.c_str());
+            CCLOG("Key already present. Ignoring '%s'",dataMapIter.first.c_str());
     }
     
     //light info

--- a/cocos/base/CCConsole.cpp
+++ b/cocos/base/CCConsole.cpp
@@ -1471,9 +1471,9 @@ void Console::printFileUtils(int fd)
 void Console::sendHelp(int fd, const std::map<std::string, Command>& commands, const char* msg)
 {
     Console::Utility::sendToConsole(fd, msg, strlen(msg));
-    for(auto it=commands.begin();it!=commands.end();++it)
+    for(auto& it : commands)
     {
-        auto command = it->second;
+        auto command = it.second;
         if (command.help.empty()) continue;
         
         Console::Utility::mydprintf(fd, "\t%s", command.name.c_str());

--- a/cocos/base/CCDataVisitor.cpp
+++ b/cocos/base/CCDataVisitor.cpp
@@ -196,11 +196,9 @@ void PrettyPrinter::visit(const __Set *p)
     
     setIndentLevel(_indentLevel+1);
 
-    int i = 0;
     __Set* tmp = const_cast<__Set*>(p);
-    __SetIterator it = tmp->begin();
 
-    for (; it != tmp->end(); ++it, ++i) {
+    for (int i = 0, tmp_size = tmp->count(); i < tmp_size; ++i) {
         if (i > 0) {
             _result += "\n";
         }

--- a/cocos/base/CCEventDispatcher.cpp
+++ b/cocos/base/CCEventDispatcher.cpp
@@ -717,9 +717,9 @@ void EventDispatcher::setPriority(EventListener* listener, int fixedPriority)
     if (listener == nullptr)
         return;
     
-    for (auto iter = _listenerMap.begin(); iter != _listenerMap.end(); ++iter)
+    for (auto& iter : _listenerMap)
     {
-        auto fixedPriorityListeners = iter->second->getFixedPriorityListeners();
+        auto fixedPriorityListeners = iter.second->getFixedPriorityListeners();
         if (fixedPriorityListeners)
         {
             auto found = std::find(fixedPriorityListeners->begin(), fixedPriorityListeners->end(), listener);
@@ -846,7 +846,7 @@ void EventDispatcher::dispatchTouchEventToListeners(EventListenerVector* listene
             // get a copy of cameras, prevent it's been modified in listener callback
             // if camera's depth is greater, process it earlier
             auto cameras = scene->getCameras();
-            for (auto rit = cameras.rbegin(); rit != cameras.rend(); ++rit)
+            for (auto rit = cameras.rbegin(), ritRend = cameras.rend(); rit != ritRend; ++rit)
             {
                 Camera* camera = *rit;
                 if (camera->isVisible() == false)
@@ -970,9 +970,8 @@ void EventDispatcher::dispatchTouchEvent(EventTouch* event)
     if (oneByOneListeners)
     {
         auto mutableTouchesIter = mutableTouches.begin();
-        auto touchesIter = originalTouches.begin();
         
-        for (; touchesIter != originalTouches.end(); ++touchesIter)
+        for (auto& touches : originalTouches)
         {
             bool isSwallowed = false;
 
@@ -994,15 +993,15 @@ void EventDispatcher::dispatchTouchEvent(EventTouch* event)
                 {
                     if (listener->onTouchBegan)
                     {
-                        isClaimed = listener->onTouchBegan(*touchesIter, event);
+                        isClaimed = listener->onTouchBegan(touches, event);
                         if (isClaimed && listener->_isRegistered)
                         {
-                            listener->_claimedTouches.push_back(*touchesIter);
+                            listener->_claimedTouches.push_back(touches);
                         }
                     }
                 }
                 else if (listener->_claimedTouches.size() > 0
-                         && ((removedIter = std::find(listener->_claimedTouches.begin(), listener->_claimedTouches.end(), *touchesIter)) != listener->_claimedTouches.end()))
+                         && ((removedIter = std::find(listener->_claimedTouches.begin(), listener->_claimedTouches.end(), touches)) != listener->_claimedTouches.end()))
                 {
                     isClaimed = true;
                     
@@ -1011,13 +1010,13 @@ void EventDispatcher::dispatchTouchEvent(EventTouch* event)
                         case EventTouch::EventCode::MOVED:
                             if (listener->onTouchMoved)
                             {
-                                listener->onTouchMoved(*touchesIter, event);
+                                listener->onTouchMoved(touches, event);
                             }
                             break;
                         case EventTouch::EventCode::ENDED:
                             if (listener->onTouchEnded)
                             {
-                                listener->onTouchEnded(*touchesIter, event);
+                                listener->onTouchEnded(touches, event);
                             }
                             if (listener->_isRegistered)
                             {
@@ -1027,7 +1026,7 @@ void EventDispatcher::dispatchTouchEvent(EventTouch* event)
                         case EventTouch::EventCode::CANCELLED:
                             if (listener->onTouchCancelled)
                             {
-                                listener->onTouchCancelled(*touchesIter, event);
+                                listener->onTouchCancelled(touches, event);
                             }
                             if (listener->_isRegistered)
                             {
@@ -1047,8 +1046,8 @@ void EventDispatcher::dispatchTouchEvent(EventTouch* event)
                     return true;
                 }
                 
-                CCASSERT((*touchesIter)->getID() == (*mutableTouchesIter)->getID(),
-                         "touchesIter ID should be equal to mutableTouchesIter's ID.");
+                CCASSERT(touches->getID() == (*mutableTouchesIter)->getID(),
+                         "touches ID should be equal to mutableTouchesIter's ID.");
                 
                 if (isClaimed && listener->_isRegistered && listener->_needSwallow)
                 {

--- a/cocos/base/CCMap.h
+++ b/cocos/base/CCMap.h
@@ -192,9 +192,9 @@ public:
         {
             keys.reserve(_data.size());
             
-            for (auto iter = _data.cbegin(); iter != _data.cend(); ++iter)
+            for (const auto& iter : _data)
             {
-                keys.push_back(iter->first);
+                keys.push_back(iter.first);
             }
         }
         return keys;
@@ -209,11 +209,11 @@ public:
         {
             keys.reserve(_data.size() / 10);
             
-            for (auto iter = _data.cbegin(); iter != _data.cend(); ++iter)
+            for (const auto& iter : _data)
             {
-                if (iter->second == object)
+                if (iter.second == object)
                 {
-                    keys.push_back(iter->first);
+                    keys.push_back(iter.first);
                 }
             }
         }
@@ -330,9 +330,9 @@ public:
      */
     void clear()
     {
-        for (auto iter = _data.cbegin(); iter != _data.cend(); ++iter)
+        for (const auto& iter : _data)
         {
-            iter->second->release();
+            iter.second->release();
         }
         
         _data.clear();
@@ -407,9 +407,9 @@ protected:
     /** Retains all the objects in the map */
     void addRefForAllObjects()
     {
-        for (auto iter = _data.begin(); iter != _data.end(); ++iter)
+        for (auto& iter : _data)
         {
-            iter->second->retain();
+            iter.second->retain();
         }
     }
     

--- a/cocos/base/CCProfiling.cpp
+++ b/cocos/base/CCProfiling.cpp
@@ -86,9 +86,9 @@ Profiler::~Profiler(void)
 
 void Profiler::displayTimers()
 {
-    for (auto iter = _activeTimers.begin(); iter != _activeTimers.end(); ++iter)
+    for (auto& iter : _activeTimers)
     {
-        ProfilingTimer* timer = iter->second;
+        ProfilingTimer* timer = iter.second;
         log("%s", timer->getDescription().c_str());
     }
 }

--- a/cocos/base/CCProperties.cpp
+++ b/cocos/base/CCProperties.cpp
@@ -664,9 +664,9 @@ Properties* Properties::getNamespace(const char* id, bool searchNames, bool recu
 {
     CCASSERT(id, "invalid id");
 
-    for (std::vector<Properties*>::const_iterator it = _namespaces.begin(); it < _namespaces.end(); ++it)
+    for (const auto& it : _namespaces)
     {
-        Properties* p = *it;
+        Properties* p = it;
         if (strcmp(searchNames ? p->_namespace.c_str() : p->_id.c_str(), id) == 0)
             return p;
         
@@ -697,9 +697,9 @@ bool Properties::exists(const char* name) const
     if (name == NULL)
         return false;
 
-    for (std::vector<Property>::const_iterator itr = _properties.begin(); itr != _properties.end(); ++itr)
+    for (const auto& itr : _properties)
     {
-        if (itr->name == name)
+        if (itr.name == name)
             return true;
     }
 
@@ -787,11 +787,11 @@ const char* Properties::getString(const char* name, const char* defaultValue) co
             return getVariable(variable, defaultValue);
         }
 
-        for (std::vector<Property>::const_iterator itr = _properties.begin(); itr != _properties.end(); ++itr)
+        for (const auto& itr : _properties)
         {
-            if (itr->name == name)
+            if (itr.name == name)
             {
-                value = itr->value.c_str();
+                value = itr.value.c_str();
                 break;
             }
         }
@@ -821,12 +821,12 @@ bool Properties::setString(const char* name, const char* value)
 {
     if (name)
     {
-        for (std::vector<Property>::iterator itr = _properties.begin(); itr != _properties.end(); ++itr)
+        for (auto& itr : _properties)
         {
-            if (itr->name == name)
+            if (itr.name == name)
             {
                 // Update the first property that matches this name
-                itr->value = value ? value : "";
+                itr.value = value ? value : "";
                 return true;
             }
         }

--- a/cocos/base/CCValue.cpp
+++ b/cocos/base/CCValue.cpp
@@ -808,10 +808,10 @@ static std::string visitMap(const T& v, int depth)
 
     ret << getTabs(depth) << "{\n";
 
-    for (auto iter = v.begin(); iter != v.end(); ++iter)
+    for (auto& iter : v)
     {
-        ret << getTabs(depth + 1) << iter->first << ": ";
-        ret << visit(iter->second, depth + 1);
+        ret << getTabs(depth + 1) << iter.first << ": ";
+        ret << visit(iter.second, depth + 1);
     }
 
     ret << getTabs(depth) << "}\n";

--- a/cocos/base/CCVector.h
+++ b/cocos/base/CCVector.h
@@ -448,8 +448,8 @@ public:
      */
     void clear()
     {
-        for( auto it = std::begin(_data); it != std::end(_data); ++it ) {
-            (*it)->release();
+        for( auto& it : _data) {
+            it->release();
         }
         _data.clear();
     }

--- a/cocos/network/CCDownloader-curl.cpp
+++ b/cocos/network/CCDownloader-curl.cpp
@@ -624,7 +624,8 @@ namespace cocos2d { namespace network {
                 }
 
                 // process tasks in _requestList
-                while (0 == countOfMaxProcessingTasks || coTaskMap.size() < countOfMaxProcessingTasks)
+                auto size = coTaskMap.size();
+                while (0 == countOfMaxProcessingTasks || size < countOfMaxProcessingTasks)
                 {
                     // get task wrapper from request queue
                     TaskWrapper wrapper;

--- a/cocos/network/HttpClient-apple.mm
+++ b/cocos/network/HttpClient-apple.mm
@@ -156,12 +156,12 @@ static int processTask(HttpClient* client, HttpRequest* request, NSString* reque
     if(!headers.empty())
     {
         /* append custom headers one by one */
-        for (std::vector<std::string>::iterator it = headers.begin(); it != headers.end(); ++it)
+        for (auto& header : headers)
         {
-            unsigned long i = it->find(':', 0);
-            unsigned long length = it->size();
-            std::string field = it->substr(0, i);
-            std::string value = it->substr(i+1, length-i);
+            unsigned long i = header.find(':', 0);
+            unsigned long length = header.size();
+            std::string field = header.substr(0, i);
+            std::string value = header.substr(i+1, length-i);
             NSString *headerField = [NSString stringWithUTF8String:field.c_str()];
             NSString *headerValue = [NSString stringWithUTF8String:value.c_str()];
             [nsrequest setValue:headerValue forHTTPHeaderField:headerField];

--- a/cocos/network/HttpClient.cpp
+++ b/cocos/network/HttpClient.cpp
@@ -253,8 +253,8 @@ public:
         if(!headers.empty())
         {
             /* append custom headers one by one */
-            for (std::vector<std::string>::iterator it = headers.begin(); it != headers.end(); ++it)
-                _headers = curl_slist_append(_headers,it->c_str());
+            for (auto& header : headers)
+                _headers = curl_slist_append(_headers,header.c_str());
             /* set custom headers for curl */
             if (!setOption(CURLOPT_HTTPHEADER, _headers))
                 return false;

--- a/cocos/network/HttpConnection-winrt.cpp
+++ b/cocos/network/HttpConnection-winrt.cpp
@@ -38,9 +38,9 @@ namespace network {
     static void formatHeaders(std::vector<std::string>& headers)
     {
 #if defined(_XBOX_ONE)
-        for(auto iter = headers.begin(); iter != headers.end(); ++iter)
+        for(auto& header : headers)
         {
-            (*iter) += "\r\n";
+            header += "\r\n";
         }
 
         // append default headers
@@ -664,13 +664,13 @@ namespace network {
         std::string cookieInfo = "";
         int cCnt = 0;
 
-        for(auto iter = cookies->begin(); iter != cookies->end(); iter++)
+        for(auto& cookie : *cookies)
         {
-            if(url.find(iter->domain) != std::string::npos)
+            if(url.find(cookie.domain) != std::string::npos)
             {
-                std::string keyVal = iter->name;
+                std::string keyVal = cookie.name;
                 keyVal.append("=");
-                keyVal.append(iter->value);
+                keyVal.append(cookie.value);
                 if(cCnt != 0) {
                     cookieInfo.append(";");
                 }

--- a/cocos/network/HttpCookie.cpp
+++ b/cocos/network/HttpCookie.cpp
@@ -47,10 +47,8 @@ void HttpCookie::readFile()
 
         _cookies.clear();
 
-        for(auto iter = cookiesVec.begin();iter != cookiesVec.end(); iter++)
+        for(auto& cookie : cookiesVec)
         {
-            std::string cookie = *iter;
-
             if(cookie.length() == 0)
                 continue;
 
@@ -95,10 +93,10 @@ const std::vector<CookiesInfo>* HttpCookie::getCookies() const
 
 const CookiesInfo* HttpCookie::getMatchCookie(const std::string& url) const
 {
-    for(auto iter = _cookies.begin(); iter != _cookies.end(); iter++)
+    for(auto& cookie : _cookies)
     {
-        if(url.find(iter->domain) != std::string::npos)
-            return &(*iter);
+        if(url.find(cookie.domain) != std::string::npos)
+            return &cookie;
     }
 
     return nullptr;
@@ -106,11 +104,11 @@ const CookiesInfo* HttpCookie::getMatchCookie(const std::string& url) const
 
 void HttpCookie::updateOrAddCookie(CookiesInfo* cookie)
 {
-    for(auto iter = _cookies.begin(); iter != _cookies.end(); iter++)
+    for(auto& _cookie : _cookies)
     {
-        if(cookie->domain == iter->domain)
+        if(cookie->domain == _cookie.domain)
         {
-            *iter = *cookie;
+            _cookie = *cookie;
             return;
         }
     }
@@ -128,22 +126,22 @@ void HttpCookie::writeFile()
           out);
 
     std::string line;
-    for(auto iter = _cookies.begin(); iter != _cookies.end(); iter++)
+    for(auto& cookie : _cookies)
     {
         line.clear();
-        line.append(iter->domain);
+        line.append(cookie.domain);
         line.append(1, '\t');
-        iter->tailmatch ? line.append("TRUE") : line.append("FALSE");
+        cookie.tailmatch ? line.append("TRUE") : line.append("FALSE");
         line.append(1, '\t');
-        line.append(iter->path);
+        line.append(cookie.path);
         line.append(1, '\t');
-        iter->secure ? line.append("TRUE") : line.append("FALSE");
+        cookie.secure ? line.append("TRUE") : line.append("FALSE");
         line.append(1, '\t');
-        line.append(iter->expires);
+        line.append(cookie.expires);
         line.append(1, '\t');
-        line.append(iter->name);
+        line.append(cookie.name);
         line.append(1, '\t');
-        line.append(iter->value);
+        line.append(cookie.value);
         //line.append(1, '\n');
 
         fprintf(out, "%s\n", line.c_str());

--- a/cocos/network/SocketIO.cpp
+++ b/cocos/network/SocketIO.cpp
@@ -452,9 +452,9 @@ void SIOClientImpl::handshakeResponse(HttpClient *sender, HttpResponse *response
         CCLOGERROR("SIOClientImpl::handshake() failed");
         CCLOGERROR("error buffer: %s", response->getErrorBuffer());
 
-        for (auto iter = _clients.begin(); iter != _clients.end(); ++iter)
+        for (auto& client : _clients)
         {
-            iter->second->getDelegate()->onError(iter->second, response->getErrorBuffer());
+            client.second->getDelegate()->onError(client.second, response->getErrorBuffer());
         }
 
         return;
@@ -466,7 +466,7 @@ void SIOClientImpl::handshakeResponse(HttpClient *sender, HttpResponse *response
     std::stringstream s;
     s.str("");
 
-    for (unsigned int i = 0; i < buffer->size(); i++)
+    for (unsigned int i = 0, size = buffer->size(); i < size; ++i)
     {
         s << (*buffer)[i];
     }
@@ -733,9 +733,9 @@ void SIOClientImpl::onOpen(WebSocket* ws)
 
     Director::getInstance()->getScheduler()->schedule(CC_SCHEDULE_SELECTOR(SIOClientImpl::heartbeat), this, (_heartbeat * .9f), false);
 
-    for (auto iter = _clients.begin(); iter != _clients.end(); ++iter)
+    for (auto& client : _clients)
     {
-        iter->second->onOpen();
+        client.second->onOpen();
     }
 
     CCLOGINFO("SIOClientImpl::onOpen socket connected!");
@@ -978,9 +978,9 @@ void SIOClientImpl::onClose(WebSocket* ws)
     CC_UNUSED_PARAM(ws);
     if (!_clients.empty())
     {
-        for (auto iter = _clients.begin(); iter != _clients.end(); ++iter)
+        for (auto& client : _clients)
         {
-            iter->second->socketClosed();
+            client.second->socketClosed();
         }
         // discard this client
         _connected = false;

--- a/cocos/network/WebSocket.cpp
+++ b/cocos/network/WebSocket.cpp
@@ -427,13 +427,14 @@ bool WebSocket::init(const Delegate& delegate,
     if (protocols && protocols->size() > 0)
     {
         int i = 0;
-        for (std::vector<std::string>::const_iterator iter = protocols->begin(); iter != protocols->end(); ++iter, ++i)
+        for (auto& protocol : *protocols)
         {
-            char* name = new (std::nothrow) char[(*iter).length()+1];
-            strcpy(name, (*iter).c_str());
+            char* name = new (std::nothrow) char[protocol.length()+1];
+            strcpy(name, protocol.c_str());
             _wsProtocols[i].name = name;
             _wsProtocols[i].callback = WebSocketCallbackWrapper::onSocketCallback;
             _wsProtocols[i].rx_buffer_size = WS_RX_BUFFER_SIZE;
+            ++i;
         }
     }
     else

--- a/cocos/physics/CCPhysicsBody.cpp
+++ b/cocos/physics/CCPhysicsBody.cpp
@@ -109,10 +109,8 @@ PhysicsBody::PhysicsBody()
 
 PhysicsBody::~PhysicsBody()
 {
-    for (auto it = _joints.begin(); it != _joints.end(); ++it)
+    for (auto& joint : _joints)
     {
-        PhysicsJoint* joint = *it;
-        
         PhysicsBody* other = joint->getBodyA() == this ? joint->getBodyB() : joint->getBodyA();
         other->removeJoint(joint);
         delete joint;
@@ -349,7 +347,7 @@ void PhysicsBody::setRotation(float rotation)
 
 void PhysicsBody::setScale(float scaleX, float scaleY)
 {
-    for (auto shape : _shapes)
+    for (auto& shape : _shapes)
     {
         _area -= shape->getArea();
         if (!_massSetByUser)

--- a/cocos/platform/CCFileUtils.cpp
+++ b/cocos/platform/CCFileUtils.cpp
@@ -1126,7 +1126,7 @@ bool FileUtils::createDirectory(const std::string& path)
 
     // Create path recursively
     subpath = "";
-    for (int i = 0; i < dirs.size(); ++i)
+    for (int i = 0, size = dirs.size(); i < size; ++i)
     {
         subpath += dirs[i];
         dir = opendir(subpath.c_str());

--- a/cocos/platform/apple/CCFileUtils-apple.mm
+++ b/cocos/platform/apple/CCFileUtils-apple.mm
@@ -98,8 +98,8 @@ static id convertCCValueToNSObject(const cocos2d::Value &value)
         case Value::Type::MAP: {
             NSMutableDictionary *dictionary = [NSMutableDictionary dictionary];
             const ValueMap &map = value.asValueMap();
-            for (auto iter = map.begin(); iter != map.end(); ++iter) {
-                addCCValueToNSDictionary(iter->first, iter->second, dictionary);
+            for (auto& iter : map) {
+                addCCValueToNSDictionary(iter.first, iter.second, dictionary);
             }
             return dictionary;
         }
@@ -369,9 +369,9 @@ bool FileUtils::writeValueMapToFile(const ValueMap& dict, const std::string& ful
     //CCLOG("iOS||Mac Dictionary %d write to file %s", dict->_ID, fullPath.c_str());
     NSMutableDictionary *nsDict = [NSMutableDictionary dictionary];
 
-    for (auto iter = dict.begin(); iter != dict.end(); ++iter)
+    for (auto& iter : dict)
     {
-        addCCValueToNSDictionary(iter->first, iter->second, nsDict);
+        addCCValueToNSDictionary(iter.first, iter.second, nsDict);
     }
 
     NSString *file = [NSString stringWithUTF8String:fullPath.c_str()];
@@ -401,7 +401,7 @@ void FileUtilsApple::valueMapCompact(ValueMap& valueMap)
             default:
                 break;
         }
-        itr++;
+        ++itr;
     }
 }
 
@@ -427,7 +427,7 @@ void FileUtilsApple::valueVectorCompact(ValueVector& valueVector)
             default:
                 break;
         }
-        itr++;
+        ++itr;
     }
 }
 

--- a/cocos/platform/win32/CCFileUtils-win32.cpp
+++ b/cocos/platform/win32/CCFileUtils-win32.cpp
@@ -350,7 +350,7 @@ bool FileUtilsWin32::createDirectory(const std::string& dirPath)
     if ((GetFileAttributes(path.c_str())) == INVALID_FILE_ATTRIBUTES)
     {
         subpath = L"";
-        for (unsigned int i = 0; i < dirs.size(); ++i)
+        for (unsigned int i = 0, size = dirs.size(); i < size; ++i)
         {
             subpath += dirs[i];
 

--- a/cocos/platform/winrt/CCFileUtilsWinRT.cpp
+++ b/cocos/platform/winrt/CCFileUtilsWinRT.cpp
@@ -251,7 +251,7 @@ bool CCFileUtilsWinRT::createDirectory(const std::string& path)
     if (!(GetFileAttributesEx(StringUtf8ToWideChar(path).c_str(), GetFileExInfoStandard, &wfad)))
     {
         subpath = "";
-        for (unsigned int i = 0; i < dirs.size(); ++i)
+        for (unsigned int i = 0, size = dirs.size(); i < size; ++i)
         {
             subpath += dirs[i];
             if (i > 0 && !isDirectoryExist(subpath))

--- a/cocos/platform/winrt/CCFreeTypeFont.cpp
+++ b/cocos/platform/winrt/CCFreeTypeFont.cpp
@@ -56,7 +56,7 @@ CCFreeTypeFont::~CCFreeTypeFont()
 
 void CCFreeTypeFont::reset()
 {
-    for(auto line:m_lines)
+    for(auto& line : m_lines)
     {
         line->glyphs.clear();
         delete line;
@@ -194,10 +194,10 @@ unsigned char* CCFreeTypeFont::getBitmap(Device::TextAlign eAlignMask, int &widt
     }
     memset(pBuffer, 0, size);
 
-    for (auto line = m_lines.begin() ; line != m_lines.end(); ++line)
+    for (auto& line : m_lines)
     {
-        FT_Vector pen = getPenForAlignment(*line, eAlignMask, lineNumber, totalLines);
-        drawText(*line, pBuffer, &pen);
+        FT_Vector pen = getPenForAlignment(line, eAlignMask, lineNumber, totalLines);
+        drawText(line, pBuffer, &pen);
         lineNumber++;
     }
     width = m_width;
@@ -277,14 +277,14 @@ void  CCFreeTypeFont::drawText(FTLineInfo* pInfo, unsigned char* pBuffer, FT_Vec
 {
 
     auto glyphs = pInfo->glyphs;
-    for (auto glyph = glyphs.begin() ; glyph != glyphs.end(); ++glyph)
+    for (auto& glyph : glyphs)
     {
-        FT_Glyph image = glyph->image;
+        FT_Glyph image = glyph.image;
         FT_Error error = FT_Glyph_To_Bitmap(&image, FT_RENDER_MODE_NORMAL, 0, 1);
         if (!error)
         {
             FT_BitmapGlyph  bit = (FT_BitmapGlyph)image;
-            draw_bitmap(pBuffer, &bit->bitmap, pen->x + glyph->pos.x + bit->left,pen->y - bit->top);
+            draw_bitmap(pBuffer, &bit->bitmap, pen->x + glyph.pos.x + bit->left,pen->y - bit->top);
             FT_Done_Glyph(image);
         }
     }
@@ -434,22 +434,22 @@ void CCFreeTypeFont::initWords(const char* text)
         lines.push_back(line);
     }
 
-    for (auto it = lines.begin() ; it != lines.end(); ++it)
+    for (auto& line : lines)
     {
         std::size_t prev = 0, pos;
-        while ((pos = it->find_first_of(" ';", prev)) != std::string::npos)
+        while ((pos = line.find_first_of(" ';", prev)) != std::string::npos)
         {
             if (pos > prev)
-                words.push_back(it->substr(prev, pos-prev));
+                words.push_back(line.substr(prev, pos-prev));
             prev = pos+1;
         }
-        if (prev < it->length())
-            words.push_back(it->substr(prev, std::string::npos));
+        if (prev < line.length())
+            words.push_back(line.substr(prev, std::string::npos));
     }
 
-    for (auto it = words.begin() ; it != words.end(); ++it)
+    for (auto& word : words)
     {
-        std::string foo(*it);
+        std::string foo(word);
     }
 }
 
@@ -541,14 +541,14 @@ void  CCFreeTypeFont::compute_bbox(std::vector<TGlyph>& glyphs, FT_BBox  *abbox)
 
     /* for each glyph image, compute its bounding box, */
     /* translate it, and grow the string bbox          */
-    for (auto glyph = glyphs.begin() ; glyph != glyphs.end(); ++glyph)
+    for (auto& glyph : glyphs)
     {
-        FT_Glyph_Get_CBox(glyph->image, ft_glyph_bbox_pixels, &glyph_bbox);
+        FT_Glyph_Get_CBox(glyph.image, ft_glyph_bbox_pixels, &glyph_bbox);
 
-        glyph_bbox.xMin += glyph->pos.x;
-        glyph_bbox.xMax += glyph->pos.x;
-        glyph_bbox.yMin += glyph->pos.y;
-        glyph_bbox.yMax += glyph->pos.y;
+        glyph_bbox.xMin += glyph.pos.x;
+        glyph_bbox.xMax += glyph.pos.x;
+        glyph_bbox.yMin += glyph.pos.y;
+        glyph_bbox.yMax += glyph.pos.y;
 
         if (glyph_bbox.xMin < bbox.xMin)
             bbox.xMin = glyph_bbox.xMin;
@@ -583,7 +583,7 @@ unsigned char* CCFreeTypeFont::loadFont(const char *pFontName, ssize_t *size)
 	std::string lowerCase(pFontName);
 	std::string path(pFontName);
 
-    for (unsigned int i = 0; i < lowerCase.length(); ++i)
+    for (unsigned int i = 0, length = lowerCase.length(); i < length; ++i)
     {
         lowerCase[i] = tolower(lowerCase[i]);
     }
@@ -636,7 +636,7 @@ unsigned char* CCFreeTypeFont::loadSystemFont(const char *pFontName, ssize_t *si
     UINT32 fontFileReferenceKeySize;
     void *fragmentContext = nullptr;
 
-    for (unsigned int i = 0; i < aName.length(); ++i)
+    for (unsigned int i = 0, length = aName.length(); i < length; ++i)
     {
         aName[i] = tolower(aName[i]);
     }

--- a/cocos/platform/winrt/CCPrecompiledShaders.cpp
+++ b/cocos/platform/winrt/CCPrecompiledShaders.cpp
@@ -207,9 +207,9 @@ void CCPrecompiledShaders::savePrecompiledPrograms(Windows::Storage::StorageFold
         dataWriter->WriteString(L"#define PRECOMPILED_SHADERS\n\n");
 
 
-        for (auto iter = m_programs.begin(); iter != m_programs.end(); ++iter) 
+        for (auto& iter : m_programs)
         {
-            CompiledProgram* p = (CompiledProgram*)iter->second;
+            CompiledProgram* p = (CompiledProgram*)iter.second;
             Platform::String^ keyName = PlatformStringFromString(p->key);
             Platform::String^ programName = SHADER_NAME_PREFIX + keyName;
 

--- a/cocos/renderer/CCGLProgramCache.cpp
+++ b/cocos/renderer/CCGLProgramCache.cpp
@@ -116,8 +116,8 @@ GLProgramCache::GLProgramCache()
 
 GLProgramCache::~GLProgramCache()
 {
-    for( auto it = _programs.begin(); it != _programs.end(); ++it ) {
-        (it->second)->release();
+    for(auto& program : _programs) {
+        program.second->release();
     }
 
     CCLOGINFO("deallocing GLProgramCache: %p", this);

--- a/cocos/renderer/CCRenderCommandPool.h
+++ b/cocos/renderer/CCRenderCommandPool.h
@@ -46,10 +46,10 @@ public:
 //            CCLOG("All RenderCommand should not be used when Pool is released!");
 //        }
         _freePool.clear();
-        for (typename std::list<T*>::iterator iter = _allocatedPoolBlocks.begin(); iter != _allocatedPoolBlocks.end(); ++iter)
+        for (auto& allocatedPoolBlock : _allocatedPoolBlocks)
         {
-            delete[] *iter;
-            *iter = nullptr;
+            delete[] allocatedPoolBlock;
+            allocatedPoolBlock = nullptr;
         }
         _allocatedPoolBlocks.clear();
     }

--- a/cocos/renderer/CCRenderer.cpp
+++ b/cocos/renderer/CCRenderer.cpp
@@ -492,9 +492,9 @@ void Renderer::visitRenderQueue(RenderQueue& queue)
         glDisable(GL_CULL_FACE);
         RenderState::StateBlock::_defaultState->setCullFace(false);
         
-        for (auto it = zNegQueue.cbegin(); it != zNegQueue.cend(); ++it)
+        for (const auto& zNegNext : zNegQueue)
         {
-            processRenderCommand(*it);
+            processRenderCommand(zNegNext);
         }
         flush();
     }
@@ -515,10 +515,9 @@ void Renderer::visitRenderQueue(RenderQueue& queue)
         RenderState::StateBlock::_defaultState->setBlend(false);
         RenderState::StateBlock::_defaultState->setCullFace(true);
 
-
-        for (auto it = opaqueQueue.cbegin(); it != opaqueQueue.cend(); ++it)
+        for (const auto& opaqueNext : opaqueQueue)
         {
-            processRenderCommand(*it);
+            processRenderCommand(opaqueNext);
         }
         flush();
     }
@@ -540,9 +539,9 @@ void Renderer::visitRenderQueue(RenderQueue& queue)
         RenderState::StateBlock::_defaultState->setCullFace(true);
 
 
-        for (auto it = transQueue.cbegin(); it != transQueue.cend(); ++it)
+        for (const auto& transNext : transQueue)
         {
-            processRenderCommand(*it);
+            processRenderCommand(transNext);
         }
         flush();
     }
@@ -576,9 +575,9 @@ void Renderer::visitRenderQueue(RenderQueue& queue)
         glDisable(GL_CULL_FACE);
         RenderState::StateBlock::_defaultState->setCullFace(false);
         
-        for (auto it = zZeroQueue.cbegin(); it != zZeroQueue.cend(); ++it)
+        for (const auto& zZeroNext : zZeroQueue)
         {
-            processRenderCommand(*it);
+            processRenderCommand(zZeroNext);
         }
         flush();
     }
@@ -612,9 +611,9 @@ void Renderer::visitRenderQueue(RenderQueue& queue)
         glDisable(GL_CULL_FACE);
         RenderState::StateBlock::_defaultState->setCullFace(false);
         
-        for (auto it = zPosQueue.cbegin(); it != zPosQueue.cend(); ++it)
+        for (const auto& zPosNext : zPosQueue)
         {
-            processRenderCommand(*it);
+            processRenderCommand(zPosNext);
         }
         flush();
     }
@@ -647,7 +646,7 @@ void Renderer::render()
 void Renderer::clean()
 {
     // Clear render group
-    for (size_t j = 0 ; j < _renderGroups.size(); j++)
+    for (size_t j = 0, size = _renderGroups.size() ; j < size; j++)
     {
         //commands are owned by nodes
         // for (const auto &cmd : _renderGroups[j])
@@ -741,9 +740,8 @@ void Renderer::drawBatchedTriangles()
     int prevMaterialID = -1;
     bool firstCommand = true;
 
-    for(auto it = std::begin(_queuedTriangleCommands); it != std::end(_queuedTriangleCommands); ++it)
+    for(const auto& cmd : _queuedTriangleCommands)
     {
-        const auto& cmd = *it;
         auto currentMaterialID = cmd->getMaterialID();
         const bool batchable = !cmd->isSkipBatching();
 

--- a/cocos/renderer/CCTextureCache.cpp
+++ b/cocos/renderer/CCTextureCache.cpp
@@ -72,8 +72,8 @@ TextureCache::~TextureCache()
 {
     CCLOGINFO("deallocing TextureCache: %p", this);
 
-    for (auto it = _textures.begin(); it != _textures.end(); ++it)
-        (it->second)->release();
+    for (auto& texture : _textures)
+        texture.second->release();
 
     CC_SAFE_DELETE(_loadingThread);
 }
@@ -191,11 +191,11 @@ void TextureCache::unbindImageAsync(const std::string& filename)
         return;
     }
     std::string fullpath = FileUtils::getInstance()->fullPathForFilename(filename);
-    for (auto it = _asyncStructQueue.begin(); it != _asyncStructQueue.end(); ++it)
+    for (auto& asyncStruct : _asyncStructQueue)
     {
-        if ((*it)->filename == fullpath)
+        if (asyncStruct->filename == fullpath)
         {
-            (*it)->callback = nullptr;
+            asyncStruct->callback = nullptr;
         }
     }
 }
@@ -207,9 +207,9 @@ void TextureCache::unbindAllImageAsync()
         return;
 
     }
-    for (auto it = _asyncStructQueue.begin(); it != _asyncStructQueue.end(); ++it)
+    for (auto& asyncStruct : _asyncStructQueue)
     {
-        (*it)->callback = nullptr;
+        asyncStruct->callback = nullptr;
     }
 }
 
@@ -510,8 +510,8 @@ bool TextureCache::reloadTexture(const std::string& fileName)
 
 void TextureCache::removeAllTextures()
 {
-    for (auto it = _textures.begin(); it != _textures.end(); ++it) {
-        (it->second)->release();
+    for (auto& texture : _textures) {
+        texture.second->release();
     }
     _textures.clear();
 }
@@ -619,19 +619,19 @@ std::string TextureCache::getCachedTextureInfo() const
     unsigned int count = 0;
     unsigned int totalBytes = 0;
 
-    for (auto it = _textures.begin(); it != _textures.end(); ++it) {
+    for (auto& texture : _textures) {
 
         memset(buftmp, 0, sizeof(buftmp));
 
 
-        Texture2D* tex = it->second;
+        Texture2D* tex = texture.second;
         unsigned int bpp = tex->getBitsPerPixelForFormat();
         // Each texture takes up width * height * bytesPerPixel bytes.
         auto bytes = tex->getPixelsWide() * tex->getPixelsHigh() * bpp / 8;
         totalBytes += bytes;
         count++;
         snprintf(buftmp, sizeof(buftmp) - 1, "\"%s\" rc=%lu id=%lu %lu x %lu @ %ld bpp => %lu KB\n",
-            it->first.c_str(),
+            texture.first.c_str(),
             (long)tex->getReferenceCount(),
             (long)tex->getName(),
             (long)tex->getPixelsWide(),
@@ -731,10 +731,9 @@ void VolatileTextureMgr::addImage(Texture2D *tt, Image *image)
 VolatileTexture* VolatileTextureMgr::findVolotileTexture(Texture2D *tt)
 {
     VolatileTexture *vt = nullptr;
-    auto i = _textures.begin();
-    while (i != _textures.end())
+    for (const auto& texture : _textures)
     {
-        VolatileTexture *v = *i++;
+        VolatileTexture *v = texture;
         if (v->_texture == tt)
         {
             vt = v;
@@ -803,10 +802,9 @@ void VolatileTextureMgr::setTexParameters(Texture2D *t, const Texture2D::TexPara
 
 void VolatileTextureMgr::removeTexture(Texture2D *t)
 {
-    auto i = _textures.begin();
-    while (i != _textures.end())
+    for (auto& item : _textures)
     {
-        VolatileTexture *vt = *i++;
+        VolatileTexture *vt = item;
         if (vt->_texture == t)
         {
             _textures.remove(vt);
@@ -821,17 +819,16 @@ void VolatileTextureMgr::reloadAllTextures()
     _isReloading = true;
 
     // we need to release all of the glTextures to avoid collisions of texture id's when reloading the textures onto the GPU
-    for (auto iter = _textures.begin(); iter != _textures.end(); ++iter)
+    for (auto& item : _textures)
     {
-        (*iter)->_texture->releaseGLTexture();
+        item._texture->releaseGLTexture();
     }
 
     CCLOG("reload all texture");
-    auto iter = _textures.begin();
 
-    while (iter != _textures.end())
+    for (auto& texture : _textures)
     {
-        VolatileTexture *vt = *iter++;
+        VolatileTexture *vt = texture;
 
         switch (vt->_cashedImageType)
         {

--- a/cocos/renderer/CCTextureCache.cpp
+++ b/cocos/renderer/CCTextureCache.cpp
@@ -821,7 +821,7 @@ void VolatileTextureMgr::reloadAllTextures()
     // we need to release all of the glTextures to avoid collisions of texture id's when reloading the textures onto the GPU
     for (auto& item : _textures)
     {
-        item._texture->releaseGLTexture();
+        item->_texture->releaseGLTexture();
     }
 
     CCLOG("reload all texture");

--- a/cocos/ui/UILayout.cpp
+++ b/cocos/ui/UILayout.cpp
@@ -272,21 +272,21 @@ void Layout::stencilClippingVisit(Renderer *renderer, const Mat4& parentTransfor
     //
     // draw children and protectedChildren zOrder < 0
     //
-    for( ; i < _children.size(); i++ )
+    for(auto size = _children.size(); i < size; i++)
     {
         auto node = _children.at(i);
         
-        if ( node && node->getLocalZOrder() < 0 )
+        if (node && node->getLocalZOrder() < 0)
             node->visit(renderer, _modelViewTransform, flags);
         else
             break;
     }
     
-    for( ; j < _protectedChildren.size(); j++ )
+    for(auto size = _protectedChildren.size(); j < size; j++)
     {
         auto node = _protectedChildren.at(j);
         
-        if ( node && node->getLocalZOrder() < 0 )
+        if (node && node->getLocalZOrder() < 0)
             node->visit(renderer, _modelViewTransform, flags);
         else
             break;
@@ -300,10 +300,10 @@ void Layout::stencilClippingVisit(Renderer *renderer, const Mat4& parentTransfor
     //
     // draw children and protectedChildren zOrder >= 0
     //
-    for(auto it=_protectedChildren.cbegin()+j; it != _protectedChildren.cend(); ++it)
+    for(auto it=_protectedChildren.cbegin()+j, itCend = _protectedChildren.cend(); it != itCend; ++it)
         (*it)->visit(renderer, _modelViewTransform, flags);
     
-    for(auto it=_children.cbegin()+i; it != _children.cend(); ++it)
+    for(auto it=_children.cbegin()+i, itCend = _children.cend(); it != itCend; ++it)
         (*it)->visit(renderer, _modelViewTransform, flags);
 
     

--- a/cocos/ui/UIPageViewIndicator.cpp
+++ b/cocos/ui/UIPageViewIndicator.cpp
@@ -117,7 +117,7 @@ void PageViewIndicator::rearrange()
     float totalSizeValue = sizeValue * numberOfItems + _spaceBetweenIndexNodes * (numberOfItems - 1);
 
     float posValue = -(totalSizeValue / 2) + (sizeValue / 2);
-    for(auto indexNode : _indexNodes) {
+    for(auto& indexNode : _indexNodes) {
         Vec2 position;
         if(horizontal)
         {
@@ -147,7 +147,7 @@ void PageViewIndicator::setIndexNodesColor(const Color3B& indexNodesColor)
 {
     _indexNodesColor = indexNodesColor;
     
-    for(auto indexNode : _indexNodes) {
+    for(auto& indexNode : _indexNodes) {
         indexNode->setColor(indexNodesColor);
     }
 }
@@ -161,7 +161,7 @@ void PageViewIndicator::setIndexNodesScale(float indexNodesScale)
     _indexNodesScale = indexNodesScale;
     
     _currentIndexNode->setScale(indexNodesScale);
-    for(auto indexNode : _indexNodes) {
+    for(auto& indexNode : _indexNodes) {
         indexNode->setScale(_indexNodesScale);
     }
     
@@ -178,13 +178,13 @@ void PageViewIndicator::setIndexNodesTexture(const std::string& texName, Widget:
     {
         case Widget::TextureResType::LOCAL:
             _currentIndexNode->setTexture(texName);
-            for(auto indexNode : _indexNodes) {
+            for(auto& indexNode : _indexNodes) {
                 indexNode->setTexture(texName);
             }
             break;
         case Widget::TextureResType::PLIST:
             _currentIndexNode->setSpriteFrame(texName);
-            for(auto indexNode : _indexNodes) {
+            for(auto& indexNode : _indexNodes) {
                 indexNode->setSpriteFrame(texName);
             }
             break;
@@ -237,7 +237,7 @@ void PageViewIndicator::decreaseNumberOfPages()
 
 void PageViewIndicator::clear()
 {
-    for(auto indexNode : _indexNodes)
+    for(auto& indexNode : _indexNodes)
     {
         removeProtectedChild(indexNode);
     }

--- a/cocos/ui/UIRichText.cpp
+++ b/cocos/ui/UIRichText.cpp
@@ -511,7 +511,7 @@ MyXMLVisitor::~MyXMLVisitor()
 
 Color3B MyXMLVisitor::getColor() const
 {
-    for (auto i = _fontElements.rbegin(); i != _fontElements.rend(); ++i)
+    for (auto i = _fontElements.rbegin(), iRend = _fontElements.rend(); i != iRend; ++i)
     {
         if (i->hasColor)
             return i->color;
@@ -521,7 +521,7 @@ Color3B MyXMLVisitor::getColor() const
 
 float MyXMLVisitor::getFontSize() const
 {
-    for (auto i = _fontElements.rbegin(); i != _fontElements.rend(); ++i)
+    for (auto i = _fontElements.rbegin(), iRend = _fontElements.rend(); i != iRend; ++i)
     {
         if (i->fontSize != -1)
             return i->fontSize;
@@ -531,7 +531,7 @@ float MyXMLVisitor::getFontSize() const
 
 std::string MyXMLVisitor::getFace() const
 {
-    for (auto i = _fontElements.rbegin(); i != _fontElements.rend(); ++i)
+    for (auto i = _fontElements.rbegin(), iRend = _fontElements.rend(); i != iRend; ++i)
     {
         if (i->face.size() != 0)
             return i->face;
@@ -541,7 +541,7 @@ std::string MyXMLVisitor::getFace() const
 
 std::string MyXMLVisitor::getURL() const
 {
-    for (auto i = _fontElements.rbegin(); i != _fontElements.rend(); ++i)
+    for (auto i = _fontElements.rbegin(), iRend = _fontElements.rend(); i != iRend; ++i)
     {
         if (i->url.size() != 0)
             return i->url;
@@ -551,7 +551,7 @@ std::string MyXMLVisitor::getURL() const
 
 bool MyXMLVisitor::getBold() const
 {
-    for (auto i = _fontElements.rbegin(); i != _fontElements.rend(); ++i)
+    for (auto i = _fontElements.rbegin(), iRend = _fontElements.rend(); i != iRend; ++i)
     {
         if (i->bold)
             return true;
@@ -561,7 +561,7 @@ bool MyXMLVisitor::getBold() const
 
 bool MyXMLVisitor::getItalics() const
 {
-    for (auto i = _fontElements.rbegin(); i != _fontElements.rend(); ++i)
+    for (auto i = _fontElements.rbegin(), iRend = _fontElements.rend(); i != iRend; ++i)
     {
         if (i->italics)
             return true;
@@ -571,7 +571,7 @@ bool MyXMLVisitor::getItalics() const
 
 bool MyXMLVisitor::getUnderline() const
 {
-    for (auto i = _fontElements.rbegin(); i != _fontElements.rend(); ++i)
+    for (auto i = _fontElements.rbegin(), iRend = _fontElements.rend(); i != iRend; ++i)
     {
         if (i->line == StyleLine::UNDERLINE)
             return true;
@@ -581,7 +581,7 @@ bool MyXMLVisitor::getUnderline() const
 
 bool MyXMLVisitor::getStrikethrough() const
 {
-    for (auto i = _fontElements.rbegin(); i != _fontElements.rend(); ++i)
+    for (auto i = _fontElements.rbegin(), iRend = _fontElements.rend(); i != iRend; ++i)
     {
         if (i->line == StyleLine::STRIKETHROUGH)
             return true;
@@ -591,7 +591,7 @@ bool MyXMLVisitor::getStrikethrough() const
 
 std::tuple<bool, Color3B, int> MyXMLVisitor::getOutline() const
 {
-    for (auto i = _fontElements.rbegin(); i != _fontElements.rend(); ++i)
+    for (auto i = _fontElements.rbegin(), iRend = _fontElements.rend(); i != iRend; ++i)
     {
         if (i->effect == StyleEffect::OUTLINE)
             return std::make_tuple(true, i->outlineColor, i->outlineSize);
@@ -601,7 +601,7 @@ std::tuple<bool, Color3B, int> MyXMLVisitor::getOutline() const
 
 std::tuple<bool, Color3B, cocos2d::Size, int> MyXMLVisitor::getShadow() const
 {
-    for (auto i = _fontElements.rbegin(); i != _fontElements.rend(); ++i)
+    for (auto i = _fontElements.rbegin(), iRend = _fontElements.rend(); i != iRend; ++i)
     {
         if (i->effect == StyleEffect::SHADOW)
             return std::make_tuple(true, i->shadowColor, i->shadowOffset, i->shadowBlurRadius);
@@ -611,7 +611,7 @@ std::tuple<bool, Color3B, cocos2d::Size, int> MyXMLVisitor::getShadow() const
 
 std::tuple<bool, Color3B> MyXMLVisitor::getGlow() const
 {
-    for (auto i = _fontElements.rbegin(); i != _fontElements.rend(); ++i)
+    for (auto i = _fontElements.rbegin(), iRend = _fontElements.rend(); i != iRend; ++i)
     {
         if (i->effect == StyleEffect::GLOW)
             return std::make_tuple(true, i->glowColor);
@@ -1329,7 +1329,7 @@ void RichText::formatText()
         if (_ignoreSize)
         {
             addNewLine();
-            for (ssize_t i=0; i<_richElements.size(); i++)
+            for (ssize_t i=0, size = _richElements.size(); i<size; ++i)
             {
                 RichElement* element = _richElements.at(i);
                 Node* elementRenderer = nullptr;
@@ -1417,7 +1417,7 @@ void RichText::formatText()
         else
         {
             addNewLine();
-            for (ssize_t i=0; i<_richElements.size(); i++)
+            for (ssize_t i=0, size = _richElements.size(); i<size; ++i)
             {
                 RichElement* element = static_cast<RichElement*>(_richElements.at(i));
                 switch (element->_type)
@@ -1472,7 +1472,7 @@ static int getPrevWord(const std::string& text, int idx)
 
 static bool isWrappable(const std::string& text)
 {
-    for (size_t i = 0; i < text.length(); ++i)
+    for (size_t i = 0, size = text.length(); i < size; ++i)
     {
         if (!std::isalnum(text[i], std::locale()))
             return true;
@@ -1733,7 +1733,7 @@ void RichText::formarRenderers()
             Vector<Node*>* row = element;
             float nextPosX = 0.0f;
             float maxY = 0.0f;
-            for (ssize_t j=0; j<row->size(); j++)
+            for (ssize_t j=0, size = row->size(); j<size; j++)
             {
                 Node* l = row->at(j);
                 l->setAnchorPoint(Vec2::ZERO);
@@ -1753,11 +1753,11 @@ void RichText::formarRenderers()
         float newContentSizeHeight = 0.0f;
         float *maxHeights = new (std::nothrow) float[_elementRenders.size()];
         
-        for (size_t i=0; i<_elementRenders.size(); i++)
+        for (size_t i=0, size = _elementRenders.size(); i<size; i++)
         {
             Vector<Node*>* row = (_elementRenders[i]);
             float maxHeight = 0.0f;
-            for (ssize_t j=0; j<row->size(); j++)
+            for (ssize_t j=0, size = row->size(); j<size; j++)
             {
                 Node* l = row->at(j);
                 maxHeight = MAX(l->getContentSize().height, maxHeight);
@@ -1767,13 +1767,13 @@ void RichText::formarRenderers()
         }
         
         float nextPosY = _customSize.height;
-        for (size_t i=0; i<_elementRenders.size(); i++)
+        for (size_t i=0, size = _elementRenders.size(); i<size; i++)
         {
             Vector<Node*>* row = (_elementRenders[i]);
             float nextPosX = 0.0f;
             nextPosY -= (maxHeights[i] + _defaults.at(KEY_VERTICAL_SPACE).asFloat());
             
-            for (ssize_t j=0; j<row->size(); j++)
+            for (ssize_t j=0, size = row->size(); j<size; j++)
             {
                 Node* l = row->at(j);
                 l->setAnchorPoint(Vec2::ZERO);

--- a/cocos/ui/UIScale9Sprite.cpp
+++ b/cocos/ui/UIScale9Sprite.cpp
@@ -779,7 +779,7 @@ namespace ui {
         //
         // draw children and protectedChildren zOrder < 0
         //
-        for( ; i < _children.size(); i++ )
+        for(auto size = _children.size(); i < size; i++)
         {
             auto node = _children.at(i);
 
@@ -804,7 +804,7 @@ namespace ui {
             _scale9Image->visit(renderer, _modelViewTransform, flags);
         }
 
-        for(auto it=_children.cbegin()+i; it != _children.cend(); ++it)
+        for(auto it=_children.cbegin()+i, itCend = _children.cend(); it != itCend; ++it)
             (*it)->visit(renderer, _modelViewTransform, flags);
 
         // FIX ME: Why need to set _orderOfArrival to 0??

--- a/cocos/ui/UIWidget.cpp
+++ b/cocos/ui/UIWidget.cpp
@@ -1259,9 +1259,9 @@ void Widget::copyProperties(Widget *widget)
     copySpecialProperties(widget);
 
     Map<int, LayoutParameter*>& layoutParameterDic = widget->_layoutParameterDictionary;
-    for (auto iter = layoutParameterDic.begin(); iter != layoutParameterDic.end(); ++iter)
+    for (auto& iter : layoutParameterDic)
     {
-        setLayoutParameter(iter->second->clone());
+        setLayoutParameter(iter.second->clone());
     }
 }
 


### PR DESCRIPTION
Basically this is the same as #16642, but on a bigger scale. All the files changed in this pull request were identified by using the following commands in Linux:

```
$ cd "${COCOS_GIT_ROOT}"/cocos
$ find . -type f -exec grep -Iq . {} \; -and -print0 | xargs -0 grep -P "^\s*for\s*\(.*end\s*\(|^\s*for\s*\(.*size\s*\(|^\s*while\s*\(.*end\s*\(|^\s*while\s*\(.*size\s*\("
```

The only files that I didn't take a look at were those under the `cocos/editor-support`, `cocos/deprecated` and `cocos/scripting` directories, but they can be identified by using the above commands.
