### PR TITLE
Fixes label wrong blending and improves performance while enabling outline.

### DIFF
--- a/cocos/renderer/ccShader_Label_outline.frag
+++ b/cocos/renderer/ccShader_Label_outline.frag
@@ -15,13 +15,28 @@ uniform vec4 u_textColor;
 void main()
 {
     vec4 sample = texture2D(CC_Texture0, v_texCoord);
-    float fontAlpha = sample.a; 
-    float outlineAlpha = sample.r; 
-    if ((fontAlpha + outlineAlpha) > 0.0){
-        vec4 color = u_textColor * fontAlpha + u_effectColor * (1.0 - fontAlpha);
-        gl_FragColor = v_fragmentColor * vec4( color.rgb,max(fontAlpha,outlineAlpha)*color.a);
+    float fontAlpha = sample.a; // sample.a == 1 indicates text, a == 0 indicates outline 
+    float outlineAlpha = sample.r; // sample.r always > 0
+
+    if (u_effectColor.a > 0.0) // draw outline
+    {
+        if (fontAlpha < 1.0)
+        {
+            gl_FragColor = v_fragmentColor * vec4(u_effectColor.rgb, u_effectColor.a * outlineAlpha);
+        }
+        else
+        {
+            discard; // While drawing outline, text should not be drawn since it will be drawn in next step.
+                     // discard this pixel could improve a little and fix wrong alpha blending if text contains
+                     // alpha channel.
+        }
     }
-    else {
+    else if (fontAlpha > 0.0) // draw text
+    {
+        gl_FragColor = v_fragmentColor * vec4(u_textColor.rgb, u_textColor.a * fontAlpha);
+    }
+    else // discard the pixel in texture rectangle which is transparent
+    {
         discard;
     }
 }


### PR DESCRIPTION
The old outline shader will cause wrong blending while enabling outline for label.
You could refer to the following screenshot to compare.

The old label display:

![old](https://cloud.githubusercontent.com/assets/493372/19463652/703155ae-9528-11e6-9fe7-3fb04a0d808b.png)

The label after this fix:
![after-fix](https://cloud.githubusercontent.com/assets/493372/19463653/712577d8-9528-11e6-937b-bbb9279b403e.png)

Please notice the blue color and its alpha depth.

The Reproduced Code:

``` c++
    auto label = Label::createWithTTF("Hello World", "fonts/arial.ttf", 70);

    // position the label on the center of the screen
    label->setPosition(origin.x + visibleSize.width/2,
                            origin.y + visibleSize.height - label->getContentSize().height);

    label->enableOutline(Color4B(0, 255, 0, 100), 10); // Set 100 alpha for outline
    label->setTextColor(Color4B(0, 0, 255, 100)); // Also set 100 alpha for text
    // add the label as a child to this layer
    this->addChild(label, 1);
```

For more easily to find this blending problem, you could set both outline and text color to green, and see the difference.

The old outline shader:

![screen shot 2016-10-18 at 11 57 23](https://cloud.githubusercontent.com/assets/493372/19463887/5175c2a6-952a-11e6-8b66-2810e9c749d7.png)

The new outline shader:

![screen shot 2016-10-18 at 12 00 22](https://cloud.githubusercontent.com/assets/493372/19463910/7be04bb0-952a-11e6-889f-0475a5e5157d.png)
