### PR TITLE
fixed #16737: NodeTest (stress test #2: no leaks) is broken.

### DIFF
--- a/cocos/2d/CCActionEase.cpp
+++ b/cocos/2d/CCActionEase.cpp
@@ -148,7 +148,7 @@ CLASSNAME* CLASSNAME::create(cocos2d::ActionInterval *action) \
 } \
 CLASSNAME* CLASSNAME::clone() const \
 { \
-    if(_inner) return CLASSNAME::create(_inner); \
+    if(_inner) return CLASSNAME::create(_inner->clone()); \
     return nullptr; \
 } \
 void CLASSNAME::update(float time) { \
@@ -205,7 +205,7 @@ CLASSNAME* CLASSNAME::create(cocos2d::ActionInterval *action, float rate) \
 } \
 CLASSNAME* CLASSNAME::clone() const \
 { \
-    if(_inner) return CLASSNAME::create(_inner, _rate); \
+    if(_inner) return CLASSNAME::create(_inner->clone(), _rate); \
     return nullptr; \
 } \
 void CLASSNAME::update(float time) { \
@@ -254,7 +254,7 @@ CLASSNAME* CLASSNAME::create(cocos2d::ActionInterval *action, float period /* = 
 } \
 CLASSNAME* CLASSNAME::clone() const \
 { \
-    if(_inner) return CLASSNAME::create(_inner, _period); \
+    if(_inner) return CLASSNAME::create(_inner->clone(), _period); \
     return nullptr; \
 } \
 void CLASSNAME::update(float time) { \

--- a/cocos/2d/CCActionEase.h
+++ b/cocos/2d/CCActionEase.h
@@ -130,9 +130,9 @@ CC_CONSTRUCTOR_ACCESS: \
     CLASSNAME() { } \
 public: \
     static CLASSNAME* create(ActionInterval* action); \
-    CLASSNAME* clone() const override; \
-    void update(float time) override; \
-    ActionEase* reverse() const override; \
+    virtual CLASSNAME* clone() const override; \
+    virtual void update(float time) override; \
+    virtual ActionEase* reverse() const override; \
 private: \
     CC_DISALLOW_COPY_AND_ASSIGN(CLASSNAME); \
 };
@@ -379,9 +379,9 @@ CC_CONSTRUCTOR_ACCESS: \
     CLASSNAME() { } \
 public: \
     static CLASSNAME* create(ActionInterval* action, float rate); \
-    CLASSNAME* clone() const override; \
-    void update(float time) override; \
-    EaseRateAction* reverse() const override; \
+    virtual CLASSNAME* clone() const override; \
+    virtual void update(float time) override; \
+    virtual EaseRateAction* reverse() const override; \
 private: \
     CC_DISALLOW_COPY_AND_ASSIGN(CLASSNAME); \
 };
@@ -466,9 +466,9 @@ CC_CONSTRUCTOR_ACCESS: \
     CLASSNAME() { } \
 public: \
     static CLASSNAME* create(ActionInterval* action, float rate = 0.3f); \
-    CLASSNAME* clone() const override; \
-    void update(float time) override; \
-    EaseElastic* reverse() const override; \
+    virtual CLASSNAME* clone() const override; \
+    virtual void update(float time) override; \
+    virtual EaseElastic* reverse() const override; \
 private: \
     CC_DISALLOW_COPY_AND_ASSIGN(CLASSNAME); \
 };


### PR DESCRIPTION
Fixed the issue #16737
'clone' method must invoke the inner object's clone method rather than its raw pointer.
It's broken after https://github.com/cocos2d/cocos2d-x/pull/16335 was merged.
