### PR TITLE
Toggle between windowed/fullscreen on desktop

### DIFF
--- a/build/cocos2d_tests.xcodeproj/project.pbxproj
+++ b/build/cocos2d_tests.xcodeproj/project.pbxproj
@@ -1266,6 +1266,7 @@
 		527B1F4519EFAE13000A1F82 /* Default-736h@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = 527B1F4319EFAE13000A1F82 /* Default-736h@3x.png */; };
 		52B47A341A534B2B004E4C60 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 52B47A331A534B2B004E4C60 /* Security.framework */; };
 		52B47A351A53A43A004E4C60 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 52B47A331A534B2B004E4C60 /* Security.framework */; };
+		53367D561DC22891005862DE /* WindowTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 53367D541DC22891005862DE /* WindowTest.cpp */; };
 		59620E8F1921E5CF002021B6 /* Bug-Child.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 59620E8D1921E5CF002021B6 /* Bug-Child.cpp */; };
 		59620E901921E5CF002021B6 /* Bug-Child.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 59620E8D1921E5CF002021B6 /* Bug-Child.cpp */; };
 		59E170151AB42EB10007F2BF /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 826294421AAF071500CB7CF7 /* Security.framework */; };
@@ -2538,6 +2539,8 @@
 		527B1F4219EFAE13000A1F82 /* Default-667h@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "Default-667h@2x.png"; sourceTree = "<group>"; };
 		527B1F4319EFAE13000A1F82 /* Default-736h@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "Default-736h@3x.png"; sourceTree = "<group>"; };
 		52B47A331A534B2B004E4C60 /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS8.1.sdk/System/Library/Frameworks/Security.framework; sourceTree = DEVELOPER_DIR; };
+		53367D541DC22891005862DE /* WindowTest.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WindowTest.cpp; sourceTree = "<group>"; };
+		53367D551DC22891005862DE /* WindowTest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WindowTest.h; sourceTree = "<group>"; };
 		59620E8D1921E5CF002021B6 /* Bug-Child.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = "Bug-Child.cpp"; sourceTree = "<group>"; };
 		59620E8E1921E5CF002021B6 /* Bug-Child.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "Bug-Child.h"; sourceTree = "<group>"; };
 		5EBEECAE1995247000429821 /* DrawNode3D.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = DrawNode3D.cpp; path = Sprite3DTest/DrawNode3D.cpp; sourceTree = "<group>"; };
@@ -3440,6 +3443,7 @@
 		1AC3592418CECF0A00F37B72 /* Classes */ = {
 			isa = PBXGroup;
 			children = (
+				53367D531DC22891005862DE /* WindowTest */,
 				504C94991D1C51BE00E4E9B3 /* VRTest */,
 				50921EAC1B746D5F00C085CC /* DownloaderTest */,
 				B6DD2FF91B04972B00E47F5F /* NavMeshTest */,
@@ -5157,6 +5161,15 @@
 				50FC18281C3371C000DD15A3 /* Test_Prefix.pch */,
 			);
 			path = proj.mac;
+			sourceTree = "<group>";
+		};
+		53367D531DC22891005862DE /* WindowTest */ = {
+			isa = PBXGroup;
+			children = (
+				53367D541DC22891005862DE /* WindowTest.cpp */,
+				53367D551DC22891005862DE /* WindowTest.h */,
+			);
+			path = WindowTest;
 			sourceTree = "<group>";
 		};
 		6886696E1AE8E8A000C2CFD9 /* SpritePolygonTest */ = {
@@ -6994,6 +7007,7 @@
 				1AC35B3318CECF0C00F37B72 /* Test.cpp in Sources */,
 				1AC35C2318CECF0C00F37B72 /* ParticleTest.cpp in Sources */,
 				295824591987415900F9746D /* UIScale9SpriteTest.cpp in Sources */,
+				53367D561DC22891005862DE /* WindowTest.cpp in Sources */,
 				1AC35C6118CECF0C00F37B72 /* TouchesTest.cpp in Sources */,
 				1AC35C6318CECF0C00F37B72 /* TransitionsTest.cpp in Sources */,
 				29080DB9191B595E0066F8DF /* UILoadingBarTest.cpp in Sources */,

--- a/cocos/platform/desktop/CCGLViewImpl-desktop.cpp
+++ b/cocos/platform/desktop/CCGLViewImpl-desktop.cpp
@@ -564,6 +564,80 @@ float GLViewImpl::getFrameZoomFactor() const
     return _frameZoomFactor;
 }
 
+bool GLViewImpl::isFullscreen() {
+    return (_monitor != nullptr);
+}
+
+void GLViewImpl::setFullscreen() {
+    if (this->isFullscreen()) {
+        return;
+    }
+    _monitor = glfwGetPrimaryMonitor();
+    if (nullptr == _monitor) {
+        return;
+    }
+    const GLFWvidmode* videoMode = glfwGetVideoMode(_monitor);
+    this->setFullscreen(*videoMode, _monitor);
+}
+
+void GLViewImpl::setFullscreen(int monitorIndex) {
+    // set fullscreen on specific monitor
+    int count = 0;
+    GLFWmonitor** monitors = glfwGetMonitors(&count);
+    if (monitorIndex < 0 || monitorIndex >= count) {
+        return;
+    }
+    GLFWmonitor* monitor = monitors[monitorIndex];
+    if (nullptr == monitor) {
+        return;
+    }
+    const GLFWvidmode* videoMode = glfwGetVideoMode(monitor);
+    this->setFullscreen(*videoMode, monitor);
+}
+
+void GLViewImpl::setFullscreen(const GLFWvidmode &videoMode, GLFWmonitor *monitor) {
+    _monitor = monitor;
+    glfwSetWindowMonitor(_mainWindow, _monitor, 0, 0, videoMode.width, videoMode.height, videoMode.refreshRate);
+}
+
+void GLViewImpl::setWindowed(int width, int height) {
+    if (!this->isFullscreen()) {
+        this->setFrameSize(width, height);
+    } else {
+        const GLFWvidmode* videoMode = glfwGetVideoMode(_monitor);
+        int xpos = 0, ypos = 0;
+        glfwGetMonitorPos(_monitor, &xpos, &ypos);
+        xpos += (videoMode->width - width) * 0.5;
+        ypos += (videoMode->height - height) * 0.5;
+        _monitor = nullptr;
+        glfwSetWindowMonitor(_mainWindow, nullptr, xpos, ypos, width, height, GLFW_DONT_CARE);
+#if (CC_TARGET_PLATFORM == CC_PLATFORM_MAC)
+        // on mac window will sometimes lose title when windowed
+        glfwSetWindowTitle(_mainWindow, _viewName.c_str());
+#endif
+    }
+}
+
+int GLViewImpl::getMonitorCount() {
+    int count = 0;
+    glfwGetMonitors(&count);
+    return count;
+}
+
+Size GLViewImpl::getMonitorSize() {
+    GLFWmonitor* monitor = _monitor;
+    if (nullptr == monitor) {
+        GLFWwindow* window = this->getWindow();
+        monitor = glfwGetWindowMonitor(window);
+    }
+    if (nullptr != monitor) {
+        const GLFWvidmode* videoMode = glfwGetVideoMode(monitor);
+        Size size = Size(videoMode->width, videoMode->height);
+        return size;
+    }
+    return Size::ZERO;
+}
+
 void GLViewImpl::updateFrameSize()
 {
     if (_screenSize.width > 0 && _screenSize.height > 0)

--- a/cocos/platform/desktop/CCGLViewImpl-desktop.cpp
+++ b/cocos/platform/desktop/CCGLViewImpl-desktop.cpp
@@ -564,7 +564,7 @@ float GLViewImpl::getFrameZoomFactor() const
     return _frameZoomFactor;
 }
 
-bool GLViewImpl::isFullscreen() {
+bool GLViewImpl::isFullscreen() const {
     return (_monitor != nullptr);
 }
 
@@ -618,13 +618,13 @@ void GLViewImpl::setWindowed(int width, int height) {
     }
 }
 
-int GLViewImpl::getMonitorCount() {
+int GLViewImpl::getMonitorCount() const {
     int count = 0;
     glfwGetMonitors(&count);
     return count;
 }
 
-Size GLViewImpl::getMonitorSize() {
+Size GLViewImpl::getMonitorSize() const {
     GLFWmonitor* monitor = _monitor;
     if (nullptr == monitor) {
         GLFWwindow* window = this->getWindow();

--- a/cocos/platform/desktop/CCGLViewImpl-desktop.h
+++ b/cocos/platform/desktop/CCGLViewImpl-desktop.h
@@ -79,6 +79,14 @@ public:
     void pollEvents() override;
     GLFWwindow* getWindow() const { return _mainWindow; }
 
+    bool isFullscreen();
+    void setFullscreen();
+    void setFullscreen(int monitorIndex);
+    void setFullscreen(const GLFWvidmode &videoMode, GLFWmonitor *monitor);
+    void setWindowed(int width, int height);
+    int getMonitorCount();
+    Size getMonitorSize();
+
     /* override functions */
     virtual bool isOpenGLReady() override;
     virtual void end() override;

--- a/cocos/platform/desktop/CCGLViewImpl-desktop.h
+++ b/cocos/platform/desktop/CCGLViewImpl-desktop.h
@@ -79,13 +79,13 @@ public:
     void pollEvents() override;
     GLFWwindow* getWindow() const { return _mainWindow; }
 
-    bool isFullscreen();
+    bool isFullscreen() const;
     void setFullscreen();
     void setFullscreen(int monitorIndex);
     void setFullscreen(const GLFWvidmode &videoMode, GLFWmonitor *monitor);
     void setWindowed(int width, int height);
-    int getMonitorCount();
-    Size getMonitorSize();
+    int getMonitorCount() const;
+    Size getMonitorSize() const;
 
     /* override functions */
     virtual bool isOpenGLReady() override;

--- a/tests/cpp-tests/CMakeLists.txt
+++ b/tests/cpp-tests/CMakeLists.txt
@@ -168,6 +168,12 @@ set(TESTS_SRC
   ${PLATFORM_SRC}
 )
 
+if(WIN32 OR MACOSX OR LINUX)
+  list(APPEND TESTS_SRC
+    Classes/WindowTest/WindowTest.cpp
+    )
+endif()
+
 if(USE_CHIPMUNK)
   include_directories(${CHIPMUNK_INCLUDE_DIRS})
 endif()

--- a/tests/cpp-tests/Classes/WindowTest/WindowTest.cpp
+++ b/tests/cpp-tests/Classes/WindowTest/WindowTest.cpp
@@ -15,10 +15,8 @@ std::string WindowTest::title() const {
 
 void WindowTestWindowed1::onEnter() {
     WindowTest::onEnter();
-#if (CC_TARGET_PLATFORM == CC_PLATFORM_WIN32) || (CC_TARGET_PLATFORM == CC_PLATFORM_LINUX) || (CC_TARGET_PLATFORM == CC_PLATFORM_MAC)
     GLViewImpl* view = (GLViewImpl*)Director::getInstance()->getOpenGLView();
     view->setWindowed(480, 320);
-#endif
 }
 
 std::string WindowTestWindowed1::subtitle() const {
@@ -27,10 +25,8 @@ std::string WindowTestWindowed1::subtitle() const {
 
 void WindowTestWindowed2::onEnter() {
     WindowTest::onEnter();
-#if (CC_TARGET_PLATFORM == CC_PLATFORM_WIN32) || (CC_TARGET_PLATFORM == CC_PLATFORM_LINUX) || (CC_TARGET_PLATFORM == CC_PLATFORM_MAC)
     GLViewImpl* view = (GLViewImpl*)Director::getInstance()->getOpenGLView();
     view->setWindowed(960, 640);
-#endif
 }
 
 std::string WindowTestWindowed2::subtitle() const {
@@ -39,10 +35,8 @@ std::string WindowTestWindowed2::subtitle() const {
 
 void WindowTestFullscreen1::onEnter() {
     WindowTest::onEnter();
-#if (CC_TARGET_PLATFORM == CC_PLATFORM_WIN32) || (CC_TARGET_PLATFORM == CC_PLATFORM_LINUX) || (CC_TARGET_PLATFORM == CC_PLATFORM_MAC)
     GLViewImpl* view = (GLViewImpl*)Director::getInstance()->getOpenGLView();
     view->setFullscreen();
-#endif
 }
 
 std::string WindowTestFullscreen1::subtitle() const {
@@ -51,10 +45,8 @@ std::string WindowTestFullscreen1::subtitle() const {
 
 void WindowTestFullscreen2::onEnter() {
     WindowTest::onEnter();
-#if (CC_TARGET_PLATFORM == CC_PLATFORM_WIN32) || (CC_TARGET_PLATFORM == CC_PLATFORM_LINUX) || (CC_TARGET_PLATFORM == CC_PLATFORM_MAC)
     GLViewImpl* view = (GLViewImpl*)Director::getInstance()->getOpenGLView();
     view->setFullscreen(1);
-#endif
 }
 
 std::string WindowTestFullscreen2::subtitle() const {

--- a/tests/cpp-tests/Classes/WindowTest/WindowTest.cpp
+++ b/tests/cpp-tests/Classes/WindowTest/WindowTest.cpp
@@ -1,0 +1,62 @@
+#include "WindowTest.h"
+
+USING_NS_CC;
+
+WindowTests::WindowTests() {
+    ADD_TEST_CASE(WindowTestWindowed1);
+    ADD_TEST_CASE(WindowTestWindowed2);
+    ADD_TEST_CASE(WindowTestFullscreen1);
+    ADD_TEST_CASE(WindowTestFullscreen2);
+}
+
+std::string WindowTest::title() const {
+    return "Window Test";
+}
+
+void WindowTestWindowed1::onEnter() {
+    WindowTest::onEnter();
+#if (CC_TARGET_PLATFORM == CC_PLATFORM_WIN32) || (CC_TARGET_PLATFORM == CC_PLATFORM_LINUX) || (CC_TARGET_PLATFORM == CC_PLATFORM_MAC)
+    GLViewImpl* view = (GLViewImpl*)Director::getInstance()->getOpenGLView();
+    view->setWindowed(480, 320);
+#endif
+}
+
+std::string WindowTestWindowed1::subtitle() const {
+    return "Windowed 480x320";
+}
+
+void WindowTestWindowed2::onEnter() {
+    WindowTest::onEnter();
+#if (CC_TARGET_PLATFORM == CC_PLATFORM_WIN32) || (CC_TARGET_PLATFORM == CC_PLATFORM_LINUX) || (CC_TARGET_PLATFORM == CC_PLATFORM_MAC)
+    GLViewImpl* view = (GLViewImpl*)Director::getInstance()->getOpenGLView();
+    view->setWindowed(960, 640);
+#endif
+}
+
+std::string WindowTestWindowed2::subtitle() const {
+    return "Windowed 960x640";
+}
+
+void WindowTestFullscreen1::onEnter() {
+    WindowTest::onEnter();
+#if (CC_TARGET_PLATFORM == CC_PLATFORM_WIN32) || (CC_TARGET_PLATFORM == CC_PLATFORM_LINUX) || (CC_TARGET_PLATFORM == CC_PLATFORM_MAC)
+    GLViewImpl* view = (GLViewImpl*)Director::getInstance()->getOpenGLView();
+    view->setFullscreen();
+#endif
+}
+
+std::string WindowTestFullscreen1::subtitle() const {
+    return "Fullscreen";
+}
+
+void WindowTestFullscreen2::onEnter() {
+    WindowTest::onEnter();
+#if (CC_TARGET_PLATFORM == CC_PLATFORM_WIN32) || (CC_TARGET_PLATFORM == CC_PLATFORM_LINUX) || (CC_TARGET_PLATFORM == CC_PLATFORM_MAC)
+    GLViewImpl* view = (GLViewImpl*)Director::getInstance()->getOpenGLView();
+    view->setFullscreen(1);
+#endif
+}
+
+std::string WindowTestFullscreen2::subtitle() const {
+    return "Fullscreen Monitor 2 (if present)";
+}

--- a/tests/cpp-tests/Classes/WindowTest/WindowTest.h
+++ b/tests/cpp-tests/Classes/WindowTest/WindowTest.h
@@ -1,0 +1,46 @@
+#ifndef __WINDOWTEST_H__
+#define __WINDOWTEST_H__
+
+#include "../BaseTest.h"
+
+DEFINE_TEST_SUITE(WindowTests);
+
+class WindowTest : public TestCase
+{
+public:
+    virtual std::string title() const override;
+};
+
+class WindowTestWindowed1 : public WindowTest
+{
+public:
+    CREATE_FUNC(WindowTestWindowed1);
+    virtual void onEnter() override;
+    virtual std::string subtitle() const override;
+};
+
+class WindowTestWindowed2 : public WindowTest
+{
+public:
+    CREATE_FUNC(WindowTestWindowed2);
+    virtual void onEnter() override;
+    virtual std::string subtitle() const override;
+};
+
+class WindowTestFullscreen1 : public WindowTest
+{
+public:
+    CREATE_FUNC(WindowTestFullscreen1);
+    virtual void onEnter() override;
+    virtual std::string subtitle() const override;
+};
+
+class WindowTestFullscreen2 : public WindowTest
+{
+public:
+    CREATE_FUNC(WindowTestFullscreen2);
+    virtual void onEnter() override;
+    virtual std::string subtitle() const override;
+};
+
+#endif /* __WINDOWTEST_H__ */

--- a/tests/cpp-tests/Classes/controller.cpp
+++ b/tests/cpp-tests/Classes/controller.cpp
@@ -103,6 +103,9 @@ public:
         addTest("VR Test", []() { return new VRTests(); });
         addTest("Zwoptex", []() { return new ZwoptexTests(); });
         addTest("SpriteFrameCache", []() { return new SpriteFrameCacheTests(); });
+#if (CC_TARGET_PLATFORM == CC_PLATFORM_MAC || CC_TARGET_PLATFORM == CC_PLATFORM_WIN32 || CC_TARGET_PLATFORM == CC_PLATFORM_LINUX)
+        addTest("Window Test", []() { return new WindowTests(); });
+#endif
     }
 };
 

--- a/tests/cpp-tests/Classes/tests.h
+++ b/tests/cpp-tests/Classes/tests.h
@@ -21,6 +21,9 @@
 #if (CC_TARGET_PLATFORM == CC_PLATFORM_ANDROID)
 #include "JNITest/JNITest.h"
 #endif
+#if (CC_TARGET_PLATFORM == CC_PLATFORM_MAC || CC_TARGET_PLATFORM == CC_PLATFORM_WIN32 || CC_TARGET_PLATFORM == CC_PLATFORM_LINUX)
+#include "WindowTest/WindowTest.h"
+#endif
 
 // sort them alphabetically. thanks
 #include "ActionManagerTest/ActionManagerTest.h"

--- a/tests/cpp-tests/proj.win32/cpp-tests.vcxproj
+++ b/tests/cpp-tests/proj.win32/cpp-tests.vcxproj
@@ -224,6 +224,7 @@ xcopy "$(OutDir)..\*.dll" "$(OutDir)" /D /Y</Command>
     <ClCompile Include="..\Classes\UnitTest\UnitTest.cpp" />
     <ClCompile Include="..\Classes\VisibleRect.cpp" />
     <ClCompile Include="..\Classes\VRTest\VRTest.cpp" />
+    <ClCompile Include="..\Classes\WindowTest\WindowTest.cpp" />
     <ClCompile Include="main.cpp" />
     <ClCompile Include="..\Classes\AppDelegate.cpp" />
     <ClCompile Include="..\Classes\controller.cpp" />
@@ -381,6 +382,7 @@ xcopy "$(OutDir)..\*.dll" "$(OutDir)" /D /Y</Command>
     <ClInclude Include="..\Classes\UnitTest\UnitTest.h" />
     <ClInclude Include="..\Classes\VisibleRect.h" />
     <ClInclude Include="..\Classes\VRTest\VRTest.h" />
+    <ClInclude Include="..\Classes\WindowTest\WindowTest.h" />
     <ClInclude Include="main.h" />
     <ClInclude Include="..\Classes\AppDelegate.h" />
     <ClInclude Include="..\Classes\controller.h" />

--- a/tests/cpp-tests/proj.win32/cpp-tests.vcxproj.filters
+++ b/tests/cpp-tests/proj.win32/cpp-tests.vcxproj.filters
@@ -292,6 +292,9 @@
     <Filter Include="Classes\VRTests">
       <UniqueIdentifier>{f88d1ce5-36f2-4dca-8ad6-b55a1becbfe8}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Classes\WindowTest">
+      <UniqueIdentifier>{b7379517-97f9-4b73-a75c-0706211e4264}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="main.cpp">
@@ -692,6 +695,9 @@
     <ClCompile Include="..\Classes\SpriteFrameCacheTest\SpriteFrameCacheTest.cpp" />
     <ClCompile Include="..\Classes\VRTest\VRTest.cpp">
       <Filter>Classes\VRTests</Filter>
+    </ClCompile>
+    <ClCompile Include="..\Classes\WindowTest\WindowTest.cpp">
+      <Filter>Classes\WindowTest</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
@@ -1287,6 +1293,9 @@
     <ClInclude Include="..\Classes\SpriteFrameCacheTest\SpriteFrameCacheTest.h" />
     <ClInclude Include="..\Classes\VRTest\VRTest.h">
       <Filter>Classes\VRTests</Filter>
+    </ClInclude>
+    <ClInclude Include="..\Classes\WindowTest\WindowTest.h">
+      <Filter>Classes\WindowTest</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
On desktop it's currently possible to create a window either fullscreen or windowed.

This PR adds the methods to GLViewImpl on desktop to toggle between fullscreen and windowed. It includes a test for these methods.
