### PR TITLE
Add reason for edit end to UIEditBoxDelegate

### DIFF
--- a/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxEditBox.java
+++ b/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxEditBox.java
@@ -109,6 +109,11 @@ public class Cocos2dxEditBox extends EditText {
     private final int kKeyboardReturnTypeSend = 2;
     private final int kKeyboardReturnTypeSearch = 3;
     private final int kKeyboardReturnTypeGo = 4;
+    private final int kKeyboardReturnTypeNext = 5;
+
+    public static final int kEndActionUnknown = 0;
+    public static final int kEndActionNext = 1;
+    public static final int kEndActionReturn = 3;
 
     private int mInputFlagConstraints;
     private int mInputModeConstraints;
@@ -117,7 +122,8 @@ public class Cocos2dxEditBox extends EditText {
     //OpenGL view scaleX
     private  float mScaleX;
 
-
+    // package private
+    int endAction = kEndActionUnknown;
 
 
     public  Cocos2dxEditBox(Context context){
@@ -170,6 +176,9 @@ public class Cocos2dxEditBox extends EditText {
                 break;
             case kKeyboardReturnTypeGo:
                 this.setImeOptions(EditorInfo.IME_ACTION_GO | EditorInfo.IME_FLAG_NO_EXTRACT_UI);
+                break;
+            case kKeyboardReturnTypeNext:
+                this.setImeOptions(EditorInfo.IME_ACTION_NEXT | EditorInfo.IME_FLAG_NO_EXTRACT_UI);
                 break;
             default:
                 this.setImeOptions(EditorInfo.IME_ACTION_NONE | EditorInfo.IME_FLAG_NO_EXTRACT_UI);

--- a/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxEditBoxHelper.java
+++ b/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxEditBoxHelper.java
@@ -63,9 +63,9 @@ public class Cocos2dxEditBoxHelper {
         editBoxEditingChanged(index, text);
     }
 
-    private static native void editBoxEditingDidEnd(int index, String text);
-    public static void __editBoxEditingDidEnd(int index, String text){
-        editBoxEditingDidEnd(index, text);
+    private static native void editBoxEditingDidEnd(int index, String text, int action);
+    public static void __editBoxEditingDidEnd(int index, String text, int action) {
+        editBoxEditingDidEnd(index, text, action);
     }
 
 
@@ -163,6 +163,7 @@ public class Cocos2dxEditBoxHelper {
                             mCocos2dxActivity.runOnGLThread(new Runnable() {
                                 @Override
                                 public void run() {
+                                    editBox.endAction = Cocos2dxEditBox.kEndActionUnknown;
                                     Cocos2dxEditBoxHelper.__editBoxEditingDidBegin(index);
                                 }
                             });
@@ -178,7 +179,8 @@ public class Cocos2dxEditBoxHelper {
                             mCocos2dxActivity.runOnGLThread(new Runnable() {
                                 @Override
                                 public void run() {
-                                    Cocos2dxEditBoxHelper.__editBoxEditingDidEnd(index, text);
+                                    int action = editBox.endAction;
+                                    Cocos2dxEditBoxHelper.__editBoxEditingDidEnd(index, text, action);
                                 }
                             });
                             mCocos2dxActivity.hideVirtualButton();
@@ -207,7 +209,11 @@ public class Cocos2dxEditBoxHelper {
                 editBox.setOnEditorActionListener(new TextView.OnEditorActionListener() {
                     @Override
                     public boolean onEditorAction(TextView v, int actionId, KeyEvent event) {
-                        if (actionId == EditorInfo.IME_ACTION_DONE) {
+                        if (actionId == EditorInfo.IME_ACTION_NEXT) {
+                            editBox.endAction = Cocos2dxEditBox.kEndActionNext;
+                            Cocos2dxEditBoxHelper.closeKeyboardOnUiThread(index);
+                            return true;
+                        } else if (actionId == EditorInfo.IME_ACTION_DONE) {
                             Cocos2dxEditBoxHelper.closeKeyboardOnUiThread(index);
                         }
                         return false;

--- a/cocos/platform/winrt/InputEvent.cpp
+++ b/cocos/platform/winrt/InputEvent.cpp
@@ -169,6 +169,24 @@ void UIEditBoxEvent::execute()
     }
 }
 
+UIEditBoxEndEvent::UIEditBoxEndEvent(Platform::Object^ sender, Platform::String^ text, int action, Windows::Foundation::EventHandler<cocos2d::EndEventArgs^>^ handle)
+  : m_sender(sender)
+  , m_text(text)
+  , m_action(action)
+  , m_handler(handle)
+{
+
+}
+
+void UIEditBoxEndEvent::execute()
+{
+  if (m_handler.Get())
+  {
+    auto args = ref new EndEventArgs(m_action, m_text.Get());
+    m_handler.Get()->Invoke(m_sender.Get(), args);
+  }
+}
+
 NS_CC_END
 
 

--- a/cocos/platform/winrt/InputEvent.h
+++ b/cocos/platform/winrt/InputEvent.h
@@ -137,10 +137,32 @@ public:
 
     virtual void execute();
 
-private:
+protected:
     Platform::Agile<Platform::Object^> m_sender;
     Platform::Agile<Platform::String^> m_text;
     Platform::Agile<Windows::Foundation::EventHandler<Platform::String^>^> m_handler;
+};
+
+ref class EndEventArgs sealed {
+public:
+    EndEventArgs(int action, Platform::String^ text) : m_text(text), m_action(action) {}
+    int GetAction() { return m_action; }
+    Platform::String^ GetText() { return m_text; }
+private:
+    int m_action;
+    Platform::String^ m_text;
+};
+
+class UIEditBoxEndEvent : public cocos2d::InputEvent
+{
+public:
+  UIEditBoxEndEvent(Platform::Object^ sender, Platform::String^ text, int action, Windows::Foundation::EventHandler<EndEventArgs^>^ handle);
+  virtual void execute();
+protected:
+  int m_action;
+  Platform::Agile<Platform::Object^> m_sender;
+  Platform::Agile<Platform::String^> m_text;
+  Platform::Agile<Windows::Foundation::EventHandler<EndEventArgs^>^> m_handler;
 };
 
 NS_CC_END

--- a/cocos/ui/UIEditBox/Mac/CCUIEditBoxMac.h
+++ b/cocos/ui/UIEditBox/Mac/CCUIEditBoxMac.h
@@ -57,6 +57,7 @@
 - (void)closeKeyboard;
 
 - (NSString *)getDefaultFontName;
+- (cocos2d::ui::EditBoxDelegate::EditBoxEndAction)getEndAction:(NSNotification *)notification;
 
 - (void)setInputMode:(cocos2d::ui::EditBox::InputMode)inputMode;
 - (void)setInputFlag:(cocos2d::ui::EditBox::InputFlag)inputFlag;

--- a/cocos/ui/UIEditBox/Mac/CCUIEditBoxMac.mm
+++ b/cocos/ui/UIEditBox/Mac/CCUIEditBoxMac.mm
@@ -171,8 +171,8 @@
 - (void)controlTextDidEndEditing:(NSNotification *)notification
 {
     _editState = NO;
-    
-    getEditBoxImplMac()->editBoxEditingDidEnd([self getText]);
+
+    getEditBoxImplMac()->editBoxEditingDidEnd([self getText], [self getEndAction:notification]);
 }
 
 - (void)setMaxLength:(int)length
@@ -303,8 +303,22 @@
 - (void)textDidEndEditing:(NSNotification *)notification
 {
     _editState = NO;
-    
-    getEditBoxImplMac()->editBoxEditingDidEnd([self getText]);
+
+    getEditBoxImplMac()->editBoxEditingDidEnd([self getText], [self getEndAction:notification]);
+}
+
+- (cocos2d::ui::EditBoxDelegate::EditBoxEndAction)getEndAction:(NSNotification *)notification
+{
+    auto type = cocos2d::ui::EditBoxDelegate::EditBoxEndAction::UNKNOWN;
+    NSUInteger reasonForEnding = [[[notification userInfo] objectForKey:@"NSTextMovement"] unsignedIntValue];
+    if (reasonForEnding == NSTabTextMovement) {
+        type = cocos2d::ui::EditBoxDelegate::EditBoxEndAction::TAB_TO_NEXT;
+    } else if (reasonForEnding == NSBacktabTextMovement) {
+        type = cocos2d::ui::EditBoxDelegate::EditBoxEndAction::TAB_TO_PREVIOUS;
+    } else if (reasonForEnding == NSReturnTextMovement) {
+        type = cocos2d::ui::EditBoxDelegate::EditBoxEndAction::RETURN;
+    }
+    return type;
 }
 
 - (void)textDidChange:(NSNotification *)notification

--- a/cocos/ui/UIEditBox/UIEditBox.h
+++ b/cocos/ui/UIEditBox/UIEditBox.h
@@ -52,6 +52,17 @@ namespace ui {
     class CC_GUI_DLL EditBoxDelegate
     {
     public:
+
+        /**
+         * Reason for ending edit (for platforms where it is known)
+         */
+        enum class EditBoxEndAction {
+            UNKNOWN,
+            TAB_TO_NEXT,
+            TAB_TO_PREVIOUS,
+            RETURN
+        };
+
         virtual ~EditBoxDelegate() {};
             
         /**
@@ -64,8 +75,9 @@ namespace ui {
         /**
          * This method is called when an edit box loses focus after keyboard is hidden.
          * @param editBox The edit box object that generated the event.
+         * @deprecated Use editBoxEditingDidEndWithAction() instead to receive reason for end
          */
-        virtual void editBoxEditingDidEnd(EditBox* editBox) {};
+        CC_DEPRECATED_ATTRIBUTE virtual void editBoxEditingDidEnd(EditBox* editBox) {};
             
         /**
          * This method is called when the edit box text was changed.
@@ -79,7 +91,13 @@ namespace ui {
          * @param editBox The edit box object that generated the event.
          */
         virtual void editBoxReturn(EditBox* editBox) = 0;
-            
+
+        /**
+         * This method is called when an edit box loses focus after keyboard is hidden.
+         * @param editBox The edit box object that generated the event.
+         * @param type The reason why editing ended.
+         */
+        virtual void editBoxEditingDidEndWithAction(EditBox* editBox, EditBoxEndAction action) {};
     };
         
     /**

--- a/cocos/ui/UIEditBox/UIEditBox.h
+++ b/cocos/ui/UIEditBox/UIEditBox.h
@@ -122,7 +122,8 @@ namespace ui {
             DONE,
             SEND,
             SEARCH,
-            GO
+            GO,
+            NEXT
         };
             
         /**

--- a/cocos/ui/UIEditBox/UIEditBoxImpl-android.cpp
+++ b/cocos/ui/UIEditBox/UIEditBoxImpl-android.cpp
@@ -47,7 +47,7 @@ namespace ui {
 #define  LOGD(...)  __android_log_print(ANDROID_LOG_ERROR,"",__VA_ARGS__)
 static void editBoxEditingDidBegin(int index);
 static void editBoxEditingDidChanged(int index, const std::string& text);
-static void editBoxEditingDidEnd(int index, const std::string& text);
+static void editBoxEditingDidEnd(int index, const std::string& text, int action);
 extern "C"{
     JNIEXPORT void JNICALL Java_org_cocos2dx_lib_Cocos2dxEditBoxHelper_editBoxEditingDidBegin(JNIEnv *env, jclass, jint index) {
         editBoxEditingDidBegin(index);
@@ -58,9 +58,9 @@ extern "C"{
         editBoxEditingDidChanged(index, textString);
     }
 
-    JNIEXPORT void JNICALL Java_org_cocos2dx_lib_Cocos2dxEditBoxHelper_editBoxEditingDidEnd(JNIEnv *env, jclass, jint index, jstring text) {
+    JNIEXPORT void JNICALL Java_org_cocos2dx_lib_Cocos2dxEditBoxHelper_editBoxEditingDidEnd(JNIEnv *env, jclass, jint index, jstring text, jint action) {
         std::string textString = StringUtils::getStringUTFCharsJNI(env,text);
-        editBoxEditingDidEnd(index, textString);
+        editBoxEditingDidEnd(index, textString, action);
     }
 }
 
@@ -223,12 +223,12 @@ void editBoxEditingDidChanged(int index, const std::string& text)
     }
 }
 
-void editBoxEditingDidEnd(int index, const std::string& text)
+void editBoxEditingDidEnd(int index, const std::string& text, int action)
 {
     auto it = s_allEditBoxes.find(index);
     if (it != s_allEditBoxes.end())
     {
-        s_allEditBoxes[index]->editBoxEditingDidEnd(text);
+        s_allEditBoxes[index]->editBoxEditingDidEnd(text, static_cast<cocos2d::ui::EditBoxDelegate::EditBoxEndAction>(action));
     }
 }
 

--- a/cocos/ui/UIEditBox/UIEditBoxImpl-common.cpp
+++ b/cocos/ui/UIEditBox/UIEditBoxImpl-common.cpp
@@ -314,7 +314,7 @@ void EditBoxImplCommon::editBoxEditingDidBegin()
 #endif
 }
 
-void EditBoxImplCommon::editBoxEditingDidEnd(const std::string& text)
+  void EditBoxImplCommon::editBoxEditingDidEnd(const std::string& text, EditBoxDelegate::EditBoxEndAction action)
 {
     // LOGD("textFieldShouldEndEditing...");
     _text = text;
@@ -322,6 +322,7 @@ void EditBoxImplCommon::editBoxEditingDidEnd(const std::string& text)
     cocos2d::ui::EditBoxDelegate *pDelegate = _editBox->getDelegate();
     if (pDelegate != nullptr)
     {
+        pDelegate->editBoxEditingDidEndWithAction(_editBox, action);
         pDelegate->editBoxEditingDidEnd(_editBox);
         pDelegate->editBoxReturn(_editBox);
     }

--- a/cocos/ui/UIEditBox/UIEditBoxImpl-common.h
+++ b/cocos/ui/UIEditBox/UIEditBoxImpl-common.h
@@ -92,8 +92,8 @@ public:
     
     void editBoxEditingDidBegin();
     void editBoxEditingChanged(const std::string& text);
-    void editBoxEditingDidEnd(const std::string& text);
-    
+    void editBoxEditingDidEnd(const std::string& text, EditBoxDelegate::EditBoxEndAction action = EditBoxDelegate::EditBoxEndAction::UNKNOWN);
+
     virtual bool isEditing() override = 0;
     virtual void createNativeControl(const Rect& frame) = 0;
     virtual void setNativeFont(const char* pFontName, int fontSize) = 0;

--- a/cocos/ui/UIEditBox/UIEditBoxImpl-winrt.h
+++ b/cocos/ui/UIEditBox/UIEditBoxImpl-winrt.h
@@ -42,7 +42,7 @@ namespace ui {
   public:
     EditBoxWinRT(Windows::Foundation::EventHandler<Platform::String^>^ beginHandler,
       Windows::Foundation::EventHandler<Platform::String^>^ changeHandler,
-      Windows::Foundation::EventHandler<Platform::String^>^ endHandler);
+      Windows::Foundation::EventHandler<cocos2d::EndEventArgs^>^ endHandler);
 
     void closeKeyboard();
     bool isEditing();
@@ -95,7 +95,7 @@ namespace ui {
 
     Windows::Foundation::EventHandler<Platform::String^>^ _beginHandler = nullptr;
     Windows::Foundation::EventHandler<Platform::String^>^ _changeHandler = nullptr;
-    Windows::Foundation::EventHandler<Platform::String^>^ _endHandler = nullptr;
+    Windows::Foundation::EventHandler<EndEventArgs^>^ _endHandler = nullptr;
 
     Windows::Foundation::EventRegistrationToken _unfocusToken;
     Windows::Foundation::EventRegistrationToken _changeToken;

--- a/cocos/ui/UIEditBox/iOS/CCUIEditBoxIOS.h
+++ b/cocos/ui/UIEditBox/iOS/CCUIEditBoxIOS.h
@@ -39,11 +39,13 @@
 @property (nonatomic, assign) cocos2d::ui::EditBox::InputFlag dataInputMode;
 @property (nonatomic, assign) cocos2d::ui::EditBox::KeyboardReturnType keyboardReturnType;
 @property (nonatomic, readonly, getter = isEditState) BOOL editState;
+@property (nonatomic, readwrite) BOOL returnPressed;
 
 - (instancetype)initWithFrame:(CGRect)frameRect editBox:(void *)editBox;
 - (void)doAnimationWhenKeyboardMoveWithDuration:(float)duration distance:(float)distance;
 
 - (NSString *)getDefaultFontName;
+- (cocos2d::ui::EditBoxDelegate::EditBoxEndAction)getEndAction;
 
 - (void)setInputMode:(cocos2d::ui::EditBox::InputMode)inputMode;
 - (void)setInputFlag:(cocos2d::ui::EditBox::InputFlag)flag;

--- a/cocos/ui/UIEditBox/iOS/CCUIEditBoxIOS.mm
+++ b/cocos/ui/UIEditBox/iOS/CCUIEditBoxIOS.mm
@@ -265,6 +265,20 @@
     return self.textInput.ccui_font.fontName ?: @"";
 }
 
+- (cocos2d::ui::EditBoxDelegate::EditBoxEndAction)getEndAction
+{
+    cocos2d::ui::EditBoxDelegate::EditBoxEndAction action = cocos2d::ui::EditBoxDelegate::EditBoxEndAction::UNKNOWN;
+    if (self.returnPressed) {
+        if (self.keyboardReturnType == cocos2d::ui::EditBox::KeyboardReturnType::NEXT) {
+            action = cocos2d::ui::EditBoxDelegate::EditBoxEndAction::TAB_TO_NEXT;
+        } else if (self.keyboardReturnType == cocos2d::ui::EditBox::KeyboardReturnType::GO ||
+                 self.keyboardReturnType == cocos2d::ui::EditBox::KeyboardReturnType::SEND) {
+            action = cocos2d::ui::EditBoxDelegate::EditBoxEndAction::RETURN;
+        }
+    }
+    return action;
+}
+
 - (void)setPlaceHolder:(NSString *)text
 {
     self.textInput.ccui_placeholder = text;
@@ -305,6 +319,7 @@
 - (BOOL)textFieldShouldReturn:(UITextField *)sender
 {
     if (sender == self.textInput) {
+        self.returnPressed = YES;
         [sender resignFirstResponder];
     }
     return NO;
@@ -324,6 +339,7 @@
 {
     CCLOG("textFieldShouldBeginEditing...");
     _editState = YES;
+    _returnPressed = NO;
     
     auto view = cocos2d::Director::getInstance()->getOpenGLView();
     CCEAGLView *eaglview = (CCEAGLView *) view->getEAGLView();
@@ -341,9 +357,9 @@
     CCLOG("textFieldShouldEndEditing...");
     _editState = NO;
     getEditBoxImplIOS()->refreshInactiveText();
-    
+
     const char* inputText = [textView.text UTF8String];
-    getEditBoxImplIOS()->editBoxEditingDidEnd(inputText);
+    getEditBoxImplIOS()->editBoxEditingDidEnd(inputText, [self getEndAction]);
     
     return YES;
 }
@@ -422,8 +438,8 @@
     CCLOG("textFieldShouldEndEditing...");
     _editState = NO;
     const char* inputText = [sender.text UTF8String];
-    
-    getEditBoxImplIOS()->editBoxEditingDidEnd(inputText);
+
+    getEditBoxImplIOS()->editBoxEditingDidEnd(inputText, [self getEndAction]);
     
     return YES;
 }

--- a/cocos/ui/UIEditBox/iOS/CCUIEditBoxIOS.mm
+++ b/cocos/ui/UIEditBox/iOS/CCUIEditBoxIOS.mm
@@ -239,6 +239,10 @@
             self.textInput.returnKeyType = UIReturnKeyGo;
             break;
             
+        case cocos2d::ui::EditBox::KeyboardReturnType::NEXT:
+            self.textInput.returnKeyType = UIReturnKeyNext;
+            break;
+
         default:
             self.textInput.returnKeyType = UIReturnKeyDefault;
             break;

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIEditBoxTest.cpp
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIEditBoxTest.cpp
@@ -143,6 +143,11 @@ void UIEditBoxTest::editBoxEditingDidEnd(cocos2d::ui::EditBox* editBox)
     log("editBox %p DidEnd !", editBox);
 }
 
+void UIEditBoxTest::editBoxEditingDidEndWithAction(cocos2d::ui::EditBox* editBox, cocos2d::ui::EditBoxDelegate::EditBoxEndAction action)
+{
+    log("editBox %p DidEnd with action %d!", editBox, action);
+}
+
 void UIEditBoxTest::editBoxTextChanged(cocos2d::ui::EditBox* editBox, const std::string& text)
 {
     log("editBox %p TextChanged, text: %s ", editBox, text.c_str());

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIEditBoxTest.h
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIEditBoxTest.h
@@ -38,6 +38,7 @@ public:
     
     virtual void editBoxEditingDidBegin(cocos2d::ui::EditBox* editBox)override;
     virtual void editBoxEditingDidEnd(cocos2d::ui::EditBox* editBox)override;
+    virtual void editBoxEditingDidEndWithAction(cocos2d::ui::EditBox* editBox, cocos2d::ui::EditBoxDelegate::EditBoxEndAction action)override;
     virtual void editBoxTextChanged(cocos2d::ui::EditBox* editBox, const std::string& text)override;
     virtual void editBoxReturn(cocos2d::ui::EditBox* editBox)override;
 


### PR DESCRIPTION
- Adds "NEXT" action button for iOS and Android for easier form
- navigation

Can now respond to editBoxDidEndWithAction to advance focus to next field, as in:

```
void UIEditBoxTest::editBoxEditingDidEndWithAction(cocos2d::ui::EditBox* editBox, cocos2d::ui::EditBoxDelegate::EditBoxEndAction action)
{
  if (action == cocos2d::ui::EditBoxDelegate::EditBoxEndAction::TAB_TO_NEXT) {
      Director::getInstance()->getScheduler()->performFunctionInCocosThread([this] {
          _editEmail->touchDownAction(nullptr, cocos2d::ui::Widget::TouchEventType::ENDED);
      });
  }
}
```
