### PR TITLE
Misc. UIEditBoxImpl-winrt fixes

### DIFF
--- a/cocos/ui/UIEditBox/UIEditBoxImpl-winrt.cpp
+++ b/cocos/ui/UIEditBox/UIEditBoxImpl-winrt.cpp
@@ -87,10 +87,10 @@ namespace cocos2d {
       passwordBox->Width = _size.Width;
       passwordBox->Height = _size.Height;
       passwordBox->Foreground = ref new Media::SolidColorBrush(_color);
-      passwordBox->Password = _initialText;
       passwordBox->FontSize = _fontSize;
       passwordBox->FontFamily = ref new Media::FontFamily(_fontFamily);
       passwordBox->MaxLength = _maxLength;
+      passwordBox->Password = _initialText;
       _changeToken = passwordBox->PasswordChanged += ref new Windows::UI::Xaml::RoutedEventHandler(this, &cocos2d::ui::EditBoxWinRT::onPasswordChanged);
       return passwordBox;
     }
@@ -103,12 +103,12 @@ namespace cocos2d {
       textBox->Width = _size.Width;
       textBox->Height = _size.Height;
       textBox->Foreground = ref new Media::SolidColorBrush(_color);
-      textBox->Text = _initialText;
       textBox->FontSize = _fontSize;
       textBox->FontFamily = ref new Media::FontFamily(_fontFamily);
       textBox->MaxLength = _maxLength;
       textBox->AcceptsReturn = _multiline;
       textBox->TextWrapping = _multiline ? TextWrapping::Wrap : TextWrapping::NoWrap;
+      textBox->Text = _initialText;
       setInputScope(textBox);
       _changeToken = textBox->TextChanged += ref new Windows::UI::Xaml::Controls::TextChangedEventHandler(this, &cocos2d::ui::EditBoxWinRT::onTextChanged);
       return textBox;
@@ -238,7 +238,6 @@ namespace cocos2d {
       _password = false;
       switch ((EditBox::InputFlag)inputFlags) {
       case EditBox::InputFlag::PASSWORD:
-      case EditBox::InputFlag::SENSITIVE:
         _password = true;
         break;
       default:
@@ -352,10 +351,10 @@ namespace cocos2d {
       _system_control->setFontSize(_fontSize * cocos2d::Director::getInstance()->getOpenGLView()->getScaleY() /** scale.y*/);
 
       // fontFamily
-      auto font = cocos2d::FontFreeType::create(pFontName, fontSize /* TODO: Not sure if supposed to be scaled or unscaled */, cocos2d::GlyphCollection::DYNAMIC, nullptr);
+      auto font = cocos2d::FontFreeType::create(pFontName, fontSize, cocos2d::GlyphCollection::DYNAMIC, nullptr);
       if (font != nullptr) {
         std::string fontName = "ms-appx:///Assets/Resources/" + std::string(pFontName) +'#' + font->getFontFamily();
-        _system_control->setFontFamily(PlatformStringFromString(pFontName));
+        _system_control->setFontFamily(PlatformStringFromString(fontName));
       }
     }
 


### PR DESCRIPTION
- SENSITIVE doesn't imply password, fixes crash on static cast in onTextChanged (https://github.com/cocos2d/cocos2d-x/blob/v3/cocos/ui/UIEditBox/UIEditBoxImpl-winrt.cpp#L126)
- Fix type fontName instead of pFontName
- Set attributes that affect text content before setting initial text
