### PR TITLE
synthesize the accessor of window property

### DIFF
--- a/templates/js-template-default/frameworks/runtime-src/proj.ios_mac/ios/AppController.h
+++ b/templates/js-template-default/frameworks/runtime-src/proj.ios_mac/ios/AppController.h
@@ -27,7 +27,6 @@
 
 @interface AppController : NSObject <UIApplicationDelegate>
 {
-    UIWindow *window;
     RootViewController    *viewController;
 }
 

--- a/templates/js-template-default/frameworks/runtime-src/proj.ios_mac/ios/AppController.mm
+++ b/templates/js-template-default/frameworks/runtime-src/proj.ios_mac/ios/AppController.mm
@@ -33,6 +33,8 @@
 
 @implementation AppController
 
+@synthesize window;
+
 #pragma mark -
 #pragma mark Application lifecycle
 

--- a/templates/lua-template-default/frameworks/runtime-src/proj.ios_mac/ios/AppController.h
+++ b/templates/lua-template-default/frameworks/runtime-src/proj.ios_mac/ios/AppController.h
@@ -27,7 +27,6 @@
 
 @interface AppController : NSObject <UIApplicationDelegate>
 {
-    UIWindow *window;
     RootViewController *viewController;
 }
 

--- a/templates/lua-template-default/frameworks/runtime-src/proj.ios_mac/ios/AppController.mm
+++ b/templates/lua-template-default/frameworks/runtime-src/proj.ios_mac/ios/AppController.mm
@@ -33,6 +33,8 @@
 
 @implementation AppController
 
+@synthesize window;
+
 #pragma mark -
 #pragma mark Application lifecycle
 


### PR DESCRIPTION
`AppController` class that implements `UIApplicationDelegate` protocol must have accessor methods for `window` property. If not, the following code will raises the exception.

```objc
UIWindow* window = [UIApplication sharedApplication].delegate.window;
```