### PR TITLE
Add new methods to get the number of actions running in a given node with a specific tag.

### DIFF
--- a/cocos/2d/CCActionManager.cpp
+++ b/cocos/2d/CCActionManager.cpp
@@ -90,7 +90,7 @@ void ActionManager::actionAllocWithHashElement(tHashElement *element)
 
 void ActionManager::removeActionAtIndex(ssize_t index, tHashElement *element)
 {
-    Action *action = static_cast<Action *>(element->actions->arr[index]);
+    Action *action = static_cast<Action*>(element->actions->arr[index]);
 
     if (action == element->currentAction && (! element->currentActionSalvaged))
     {
@@ -415,7 +415,7 @@ size_t ActionManager::getNumberOfRunningActionsInTargetByTag(const Node *target,
     auto limit = element->actions->num;
     for(int i = 0; i < limit; ++i)
     {
-        auto action = static_cast<Action *>element->actions->arr[i];
+        auto action = static_cast<Action*>(element->actions->arr[i]);
         if(action->getTag() == tag)
             ++count;
     }

--- a/cocos/2d/CCActionManager.cpp
+++ b/cocos/2d/CCActionManager.cpp
@@ -90,7 +90,7 @@ void ActionManager::actionAllocWithHashElement(tHashElement *element)
 
 void ActionManager::removeActionAtIndex(ssize_t index, tHashElement *element)
 {
-    Action *action = (Action*)element->actions->arr[index];
+    Action *action = static_cast<Action *>(element->actions->arr[index]);
 
     if (action == element->currentAction && (! element->currentActionSalvaged))
     {
@@ -275,7 +275,7 @@ void ActionManager::removeActionByTag(int tag, Node *target)
         auto limit = element->actions->num;
         for (int i = 0; i < limit; ++i)
         {
-            Action *action = (Action*)element->actions->arr[i];
+            Action *action = static_cast<Action*>(element->actions->arr[i]);
 
             if (action->getTag() == (int)tag && action->getOriginalTarget() == target)
             {
@@ -303,8 +303,8 @@ void ActionManager::removeAllActionsByTag(int tag, Node *target)
         auto limit = element->actions->num;
         for (int i = 0; i < limit;)
         {
-            Action *action = (Action*)element->actions->arr[i];
-            
+            Action *action = static_cast<Action*>(element->actions->arr[i]);
+
             if (action->getTag() == (int)tag && action->getOriginalTarget() == target)
             {
                 removeActionAtIndex(i, element);
@@ -338,7 +338,7 @@ void ActionManager::removeActionsByFlags(unsigned int flags, Node *target)
         auto limit = element->actions->num;
         for (int i = 0; i < limit;)
         {
-            Action *action = (Action*)element->actions->arr[i];
+            Action *action = static_cast<Action*>(element->actions->arr[i]);
 
             if ((action->getFlags() & flags) != 0 && action->getOriginalTarget() == target)
             {
@@ -371,7 +371,7 @@ Action* ActionManager::getActionByTag(int tag, const Node *target) const
             auto limit = element->actions->num;
             for (int i = 0; i < limit; ++i)
             {
-                Action *action = (Action*)element->actions->arr[i];
+                Action *action = static_cast<Action*>(element->actions->arr[i]);
 
                 if (action->getTag() == (int)tag)
                 {
@@ -415,7 +415,7 @@ size_t ActionManager::getNumberOfRunningActionsInTargetByTag(const Node *target,
     auto limit = element->actions->num;
     for(int i = 0; i < limit; ++i)
     {
-        auto action = (Action *)element->actions->arr[i];
+        auto action = static_cast<Action *>element->actions->arr[i];
         if(action->getTag() == tag)
             ++count;
     }
@@ -438,7 +438,7 @@ void ActionManager::update(float dt)
             for (_currentTarget->actionIndex = 0; _currentTarget->actionIndex < _currentTarget->actions->num;
                 _currentTarget->actionIndex++)
             {
-                _currentTarget->currentAction = (Action*)_currentTarget->actions->arr[_currentTarget->actionIndex];
+                _currentTarget->currentAction = static_cast<Action*>(_currentTarget->actions->arr[_currentTarget->actionIndex]);
                 if (_currentTarget->currentAction == nullptr)
                 {
                     continue;

--- a/cocos/2d/CCActionManager.cpp
+++ b/cocos/2d/CCActionManager.cpp
@@ -398,6 +398,32 @@ ssize_t ActionManager::getNumberOfRunningActionsInTarget(const Node *target) con
     return 0;
 }
 
+// FIXME: Passing "const O *" instead of "const O&" because HASH_FIND_IT requires the address of a pointer
+// and, it is not possible to get the address of a reference
+size_t ActionManager::getNumberOfRunningActionsInTargetByTag(const Node *target,
+                                                             int tag)
+{
+    CCASSERT(tag != Action::INVALID_TAG, "Invalid tag value!");
+
+    tHashElement *element = nullptr;
+    HASH_FIND_PTR(_targets, &target, element);
+
+    if(!element || !element->actions)
+        return 0;
+
+    int count = 0;
+    auto limit = element->actions->num;
+    for(int i = 0; i < limit; ++i)
+    {
+        auto action = (Action *)element->actions->arr[i];
+        if(action->getTag() == tag)
+            ++count;
+    }
+
+    return count;
+}
+
+
 // main loop
 void ActionManager::update(float dt)
 {

--- a/cocos/2d/CCActionManager.h
+++ b/cocos/2d/CCActionManager.h
@@ -145,6 +145,24 @@ public:
      */
     CC_DEPRECATED_ATTRIBUTE ssize_t numberOfRunningActionsInTarget(Node *target) const { return getNumberOfRunningActionsInTarget(target); }
 
+
+    /** Returns the numbers of actions that are running in a
+     *  certain target with a specific tag.
+     * Like getNumberOfRunningActionsInTarget Composable actions
+     * are counted as 1 action. Example:
+     * - If you are running 1 Sequence of 7 actions, it will return 1.
+     * - If you are running 7 Sequences of 2 actions, it will return 7.
+     *
+     * @param target    A certain target.
+     * @param tag       Tag that will be searched.
+     * @return  The numbers of actions that are running in a certain target
+     *          with a specific tag.
+     * @see getNumberOfRunningActionsInTarget
+     * @js NA
+     */
+    size_t getNumberOfRunningActionsInTargetByTag(const Node *target, int tag);
+
+
     /** Pauses the target: all running actions and newly added actions will be paused.
      *
      * @param target    A certain target.

--- a/cocos/2d/CCNode.cpp
+++ b/cocos/2d/CCNode.cpp
@@ -1462,6 +1462,12 @@ ssize_t Node::getNumberOfRunningActions() const
     return _actionManager->getNumberOfRunningActionsInTarget(this);
 }
 
+ssize_t Node::getNumberOfRunningActionsByTag(int tag) const
+{
+    return _actionManager->getNumberOfRunningActionsInTargetByTag(this, tag);
+}
+
+
 // MARK: Callbacks
 
 void Node::setScheduler(Scheduler* scheduler)

--- a/cocos/2d/CCNode.h
+++ b/cocos/2d/CCNode.h
@@ -1285,6 +1285,23 @@ public:
      */
     ssize_t getNumberOfRunningActions() const;
 
+    /**
+     * Returns the numbers of actions that are running plus the ones that are
+     * schedule to run (actions in actionsToAdd and actions arrays) with a
+     * specific tag.
+     *
+     * Composable actions are counted as 1 action. Example:
+     *    If you are running 1 Sequence of 7 actions, it will return 1.
+     *    If you are running 7 Sequences of 2 actions, it will return 7.
+     *
+     * @param  tag The tag that will be searched.
+     *
+     * @return The number of actions that are running plus the
+     *         ones that are schedule to run with specific tag.
+     */
+    ssize_t getNumberOfRunningActionsByTag(int tag) const;
+
+
     /** @deprecated Use getNumberOfRunningActions() instead */
     CC_DEPRECATED_ATTRIBUTE ssize_t numberOfRunningActions() const { return getNumberOfRunningActions(); };
 


### PR DESCRIPTION
This is useful for cases that we want to know how many
animations with a **specific** tag is running in our target.
For example:

auto tag1Count = this->getNumberOfRunningActionsByTag(kMyTag1);
auto tag2Count = this->getNumberOfRunningActionsByTag(kMyTag2);

While this could be achieved (more or less) with callbacks
to increment the tagCount at start of action and decrement
at the end the proposed API is much more concise and less error
prone.