### PR TITLE
Fix small .mtl files not being loaded

### DIFF
--- a/cocos/3d/CCObjLoader.cpp
+++ b/cocos/3d/CCObjLoader.cpp
@@ -640,13 +640,16 @@ namespace tinyobj {
             filepath = matId;
         }
         
+        std::string err = "";
+        
         std::istringstream matIStream(cocos2d::FileUtils::getInstance()->getStringFromFile(filepath));
-        std::string err = LoadMtl(matMap, materials, matIStream);
         if (!matIStream) {
             std::stringstream ss;
             ss << "WARN: Material file [ " << filepath << " ] not found. Created a default material.";
             err += ss.str();
         }
+        err += LoadMtl(matMap, materials, matIStream);
+
         return err;
     }
     


### PR DESCRIPTION
In the case of a simple MTL file such as 

> newmtl cube
>   Ns 10.0000
>   Ni 1.5000
>   d 1.0000
>   Tr 0.0000
>   Tf 1.0000 1.0000 1.0000 
>   illum 2
>   Ka 0.0000 0.0000 0.0000
>   Kd 0.5880 0.5880 0.5880
>   Ks 0.0000 0.0000 0.0000
>   Ke 0.0000 0.0000 0.0000
>   map_Ka cube.png
>   map_Kd cube.png

The entire istringstream would be consumed by LoadMTL and result in a 'not found' error due to the null check being in the wrong place