### PR TITLE
Use resolved file name (through dictionary lookup) in font atlas creation

### DIFF
--- a/build/cocos2d_tests.xcodeproj/project.pbxproj
+++ b/build/cocos2d_tests.xcodeproj/project.pbxproj
@@ -8336,7 +8336,7 @@
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				INFOPLIST_FILE = "$(SRCROOT)/../tests/cpp-tests/proj.mac/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "@loader_path/../Frameworks";
-				USER_HEADER_SEARCH_PATHS = "$(inherited) $(SRCROOT)/../external/glfw3/include/mac";
+				USER_HEADER_SEARCH_PATHS = "$(inherited) $(SRCROOT)/../external/glfw3/include/mac $(SRCROOT)/../external/freetype2/include/mac/freetype2";
 			};
 			name = Debug;
 		};
@@ -8352,7 +8352,7 @@
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				INFOPLIST_FILE = "$(SRCROOT)/../tests/cpp-tests/proj.mac/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "@loader_path/../Frameworks";
-				USER_HEADER_SEARCH_PATHS = "$(inherited) $(SRCROOT)/../external/glfw3/include/mac";
+				USER_HEADER_SEARCH_PATHS = "$(inherited) $(SRCROOT)/../external/glfw3/include/mac $(SRCROOT)/../external/freetype2/include/mac/freetype2";
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;
@@ -8420,7 +8420,7 @@
 				SDKROOT = appletvos;
 				STRIP_PNG_TEXT = NO;
 				TVOS_DEPLOYMENT_TARGET = 9.1;
-				USER_HEADER_SEARCH_PATHS = "$(inherited) $(SRCROOT)/../external/curl/include/ios";
+				USER_HEADER_SEARCH_PATHS = "$(inherited) $(SRCROOT)/../external/curl/include/ios $(SRCROOT)/../external/freetype2/include/ios/freetype2";
 			};
 			name = Debug;
 		};
@@ -8444,7 +8444,7 @@
 				SDKROOT = appletvos;
 				STRIP_PNG_TEXT = NO;
 				TVOS_DEPLOYMENT_TARGET = 9.1;
-				USER_HEADER_SEARCH_PATHS = "$(inherited) $(SRCROOT)/../external/curl/include/ios";
+				USER_HEADER_SEARCH_PATHS = "$(inherited) $(SRCROOT)/../external/curl/include/ios $(SRCROOT)/../external/freetype2/include/ios/freetype2";
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;
@@ -8813,7 +8813,7 @@
 				SDKROOT = iphoneos;
 				STRIP_PNG_TEXT = NO;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				USER_HEADER_SEARCH_PATHS = "$(inherited) $(SRCROOT)/../external/curl/include/ios";
+				USER_HEADER_SEARCH_PATHS = "$(inherited) $(SRCROOT)/../external/curl/include/ios $(SRCROOT)/../external/freetype2/include/ios/freetype2";
 				VALID_ARCHS = "arm64 armv7";
 			};
 			name = Debug;
@@ -8840,7 +8840,7 @@
 				SDKROOT = iphoneos;
 				STRIP_PNG_TEXT = NO;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				USER_HEADER_SEARCH_PATHS = "$(inherited) $(SRCROOT)/../external/curl/include/ios";
+				USER_HEADER_SEARCH_PATHS = "$(inherited) $(SRCROOT)/../external/curl/include/ios $(SRCROOT)/../external/freetype2/include/ios/freetype2";
 				VALIDATE_PRODUCT = YES;
 				VALID_ARCHS = "arm64 armv7";
 			};

--- a/cocos/2d/CCFontAtlasCache.cpp
+++ b/cocos/2d/CCFontAtlasCache.cpp
@@ -30,6 +30,7 @@
 #include "2d/CCFontAtlas.h"
 #include "2d/CCFontCharMap.h"
 #include "2d/CCLabel.h"
+#include "platform/CCFileUtils.h"
 
 NS_CC_BEGIN
 
@@ -47,7 +48,8 @@ void FontAtlasCache::purgeCachedData()
 }
 
 FontAtlas* FontAtlasCache::getFontAtlasTTF(const _ttfConfig* config)
-{  
+{
+    auto realFontFilename = FileUtils::getInstance()->getNewFilename(config->fontFilePath);  // resolves real file path, to prevent storing multiple atlases for the same file.
     bool useDistanceField = config->distanceFieldEnabled;
     if(config->outlineSize > 0)
     {
@@ -57,10 +59,10 @@ FontAtlas* FontAtlasCache::getFontAtlasTTF(const _ttfConfig* config)
     char tmp[ATLAS_MAP_KEY_BUFFER];
     if (useDistanceField) {
         snprintf(tmp, ATLAS_MAP_KEY_BUFFER, "df %.2f %d %s", config->fontSize, config->outlineSize,
-                 config->fontFilePath.c_str());
+                 realFontFilename.c_str());
     } else {
         snprintf(tmp, ATLAS_MAP_KEY_BUFFER, "%.2f %d %s", config->fontSize, config->outlineSize,
-                 config->fontFilePath.c_str());
+                 realFontFilename.c_str());
     }
     std::string atlasName = tmp;
 
@@ -68,7 +70,7 @@ FontAtlas* FontAtlasCache::getFontAtlasTTF(const _ttfConfig* config)
 
     if ( it == _atlasMap.end() )
     {
-        auto font = FontFreeType::create(config->fontFilePath, config->fontSize, config->glyphs,
+        auto font = FontFreeType::create(realFontFilename, config->fontSize, config->glyphs,
             config->customGlyphs, useDistanceField, config->outlineSize);
         if (font)
         {
@@ -91,14 +93,15 @@ FontAtlas* FontAtlasCache::getFontAtlasTTF(const _ttfConfig* config)
 
 FontAtlas* FontAtlasCache::getFontAtlasFNT(const std::string& fontFileName, const Vec2& imageOffset /* = Vec2::ZERO */)
 {
+    auto realFontFilename = FileUtils::getInstance()->getNewFilename(fontFileName);  // resolves real file path, to prevent storing multiple atlases for the same file.
     char tmp[ATLAS_MAP_KEY_BUFFER];
-    snprintf(tmp, ATLAS_MAP_KEY_BUFFER, "%.2f %.2f %s", imageOffset.x, imageOffset.y, fontFileName.c_str());
+    snprintf(tmp, ATLAS_MAP_KEY_BUFFER, "%.2f %.2f %s", imageOffset.x, imageOffset.y, realFontFilename.c_str());
     std::string atlasName = tmp;
     
     auto it = _atlasMap.find(atlasName);
     if ( it == _atlasMap.end() )
     {
-        auto font = FontFNT::create(fontFileName,imageOffset);
+        auto font = FontFNT::create(realFontFilename, imageOffset);
 
         if(font)
         {

--- a/cocos/platform/CCFileUtils.h
+++ b/cocos/platform/CCFileUtils.h
@@ -627,6 +627,15 @@ public:
     /** Returns the full path cache. */
     const std::unordered_map<std::string, std::string>& getFullPathCache() const { return _fullPathCache; }
 
+    /**
+    *  Gets the new filename from the filename lookup dictionary.
+    *  It is possible to have a override names.
+    *  @param filename The original filename.
+    *  @return The new filename after searching in the filename lookup dictionary.
+    *          If the original filename wasn't in the dictionary, it will return the original filename.
+    */
+    virtual std::string getNewFilename(const std::string &filename) const;
+
 protected:
     /**
      *  The default constructor.
@@ -642,15 +651,6 @@ protected:
      *
      */
     virtual bool init();
-
-    /**
-     *  Gets the new filename from the filename lookup dictionary.
-     *  It is possible to have a override names.
-     *  @param filename The original filename.
-     *  @return The new filename after searching in the filename lookup dictionary.
-     *          If the original filename wasn't in the dictionary, it will return the original filename.
-     */
-    virtual std::string getNewFilename(const std::string &filename) const;
 
     /**
      *  Checks whether a file exists without considering search paths and resolution orders.

--- a/tests/cpp-tests/CMakeLists.txt
+++ b/tests/cpp-tests/CMakeLists.txt
@@ -2,6 +2,8 @@ set(APP_NAME cpp-tests)
 
 # Use same method as in cocos library
 cocos_find_package(CURL CURL REQUIRED)
+cocos_find_package(FONTCONFIG FONTCONFIG REQUIRED)
+cocos_find_package(FREETYPE FREETYPE REQUIRED)
 
 if(WIN32)
   set(PLATFORM_SRC proj.win32/main.cpp)
@@ -225,6 +227,8 @@ endif()
 target_link_libraries(${APP_NAME} cocos2d)
 
 cocos_use_pkg(${APP_NAME} CURL)
+cocos_use_pkg(${APP_NAME} FONTCONFIG)
+cocos_use_pkg(${APP_NAME} FREETYPE)
 
 if(MACOSX OR APPLE)
   set_target_properties(${APP_NAME} PROPERTIES

--- a/tests/cpp-tests/CMakeLists.txt
+++ b/tests/cpp-tests/CMakeLists.txt
@@ -1,9 +1,13 @@
 set(APP_NAME cpp-tests)
 
 # Use same method as in cocos library
-cocos_find_package(CURL CURL REQUIRED)
-cocos_find_package(FONTCONFIG FONTCONFIG REQUIRED)
+if(LINUX)
+  foreach(_pkg FONTCONFIG GTK3)
+    cocos_find_package(${_pkg} ${_pkg} REQUIRED)
+  endforeach()
+endif()
 cocos_find_package(FREETYPE FREETYPE REQUIRED)
+cocos_find_package(CURL CURL REQUIRED)
 
 if(WIN32)
   set(PLATFORM_SRC proj.win32/main.cpp)
@@ -226,9 +230,14 @@ endif()
 
 target_link_libraries(${APP_NAME} cocos2d)
 
-cocos_use_pkg(${APP_NAME} CURL)
-cocos_use_pkg(${APP_NAME} FONTCONFIG)
-cocos_use_pkg(${APP_NAME} FREETYPE)
+if(LINUX)
+  foreach(_pkg FONTCONFIG GTK3)
+    cocos_use_pkg(${APP_NAME} ${_pkg})
+  endforeach()
+endif()
+foreach(pkg FREETYPE CURL)
+  cocos_use_pkg(${APP_NAME} ${pkg})
+endforeach()
 
 if(MACOSX OR APPLE)
   set_target_properties(${APP_NAME} PROPERTIES

--- a/tests/cpp-tests/Classes/FontTest/FontTest.cpp
+++ b/tests/cpp-tests/Classes/FontTest/FontTest.cpp
@@ -1,5 +1,7 @@
 #include "FontTest.h"
 #include "../testResource.h"
+#include "2d/CCFontAtlasCache.h"
+#include "2d/CCFontFreeType.h"
 
 USING_NS_CC;
 
@@ -50,6 +52,8 @@ FontTests::FontTests()
     {
         addTestCase("FontTests", [&](){vAlignIdx = 2; return FontTest::create(fontFile); });
     }
+	ADD_TEST_CASE(FontNoReplacementTest);
+	ADD_TEST_CASE(FontReplacementTest);
 }
 
 void FontTest::showFont(const std::string& fontFile)
@@ -112,4 +116,142 @@ void FontTest::showFont(const std::string& fontFile)
 std::string FontTest::title() const
 {
     return "Font test";
+}
+
+FontNoReplacementTest* FontNoReplacementTest::create()
+{
+	auto ret = new (std::nothrow) FontNoReplacementTest;
+	if (ret && ret->init())
+	{
+		ret->autorelease();
+	}
+	else
+	{
+		delete ret;
+		ret = nullptr;
+	}
+
+	return ret;
+}
+
+FontNoReplacementTest::FontNoReplacementTest()
+{
+	_replace = false;
+}
+
+FontNoReplacementTest::~FontNoReplacementTest()
+{
+	// need to clear the caches since we change the lookup dictionary after the application init.
+	FontAtlasCache::unloadFontAtlasTTF("fonts/A Damn Mess.ttf");
+	FontFreeType::releaseFont("fonts/A Damn Mess.ttf");
+	FontAtlasCache::unloadFontAtlasTTF("fonts/Abberancy.ttf");
+	FontFreeType::releaseFont("fonts/Abberancy.ttf");
+	FontAtlasCache::unloadFontAtlasTTF("fonts/Abduction.ttf");
+	FontFreeType::releaseFont("fonts/Abduction.ttf");
+	FontAtlasCache::unloadFontAtlasTTF("fonts/Schwarzwald.ttf");
+	FontFreeType::releaseFont("fonts/Schwarzwald.ttf");
+	FileUtils::getInstance()->setFilenameLookupDictionary(ValueMap());
+}
+
+void FontNoReplacementTest::onEnter()
+{
+	TestCase::onEnter();
+
+	std::string suffix;
+	if (_replace)
+	{
+		ValueMap dict{
+			{ "fonts/A Damn Mess.ttf", Value("fonts/arial.ttf") },
+			{ "fonts/Abberancy.ttf", Value("fonts/arial.ttf") },
+			{ "fonts/Abduction.ttf", Value("fonts/arial.ttf") },
+			{ "fonts/Schwarzwald.ttf", Value("fonts/arial.ttf") }
+		};
+
+		FileUtils::getInstance()->setFilenameLookupDictionary(dict);
+		suffix = " replaced by arial.ttf";
+	}
+
+	auto s = Director::getInstance()->getWinSize();
+
+	auto blockSize = Size(s.width / 3, 200);
+	float fontSize = 26;
+
+	removeChildByTag(kTagLabel1, true);
+	removeChildByTag(kTagLabel2, true);
+	removeChildByTag(kTagLabel3, true);
+	removeChildByTag(kTagLabel4, true);
+	removeChildByTag(kTagColor1, true);
+	removeChildByTag(kTagColor2, true);
+	removeChildByTag(kTagColor3, true);
+
+	auto top = Label::createWithTTF("fonts/A Damn Mess.ttf" + suffix, "fonts/A Damn Mess.ttf", 24);
+	auto left = Label::createWithTTF("fonts/Abberancy.ttf" + suffix, "fonts/Abberancy.ttf", fontSize,
+		blockSize, TextHAlignment::LEFT, verticalAlignment[0]);
+	auto center = Label::createWithTTF("fonts/Abduction.ttf" + suffix, "fonts/Abduction.ttf", fontSize,
+		blockSize, TextHAlignment::CENTER, verticalAlignment[0]);
+	auto right = Label::createWithTTF("fonts/Schwarzwald.ttf" + suffix, "fonts/Schwarzwald.ttf", fontSize,
+		blockSize, TextHAlignment::RIGHT, verticalAlignment[0]);
+
+	auto leftColor = LayerColor::create(Color4B(100, 100, 100, 255), blockSize.width, blockSize.height);
+	auto centerColor = LayerColor::create(Color4B(200, 100, 100, 255), blockSize.width, blockSize.height);
+	auto rightColor = LayerColor::create(Color4B(100, 100, 200, 255), blockSize.width, blockSize.height);
+
+	leftColor->setIgnoreAnchorPointForPosition(false);
+	centerColor->setIgnoreAnchorPointForPosition(false);
+	rightColor->setIgnoreAnchorPointForPosition(false);
+
+	top->setAnchorPoint(Vec2(0.5, 1));
+	left->setAnchorPoint(Vec2(0, 0.5));
+	leftColor->setAnchorPoint(Vec2(0, 0.5));
+	center->setAnchorPoint(Vec2(0, 0.5));
+	centerColor->setAnchorPoint(Vec2(0, 0.5));
+	right->setAnchorPoint(Vec2(0, 0.5));
+	rightColor->setAnchorPoint(Vec2(0, 0.5));
+
+	top->setPosition(s.width / 2, s.height - 20);
+	left->setPosition(0, s.height / 2);
+	leftColor->setPosition(left->getPosition());
+	center->setPosition(blockSize.width, s.height / 2);
+	centerColor->setPosition(center->getPosition());
+	right->setPosition(blockSize.width * 2, s.height / 2);
+	rightColor->setPosition(right->getPosition());
+
+	this->addChild(leftColor, -1, kTagColor1);
+	this->addChild(left, 0, kTagLabel1);
+	this->addChild(rightColor, -1, kTagColor2);
+	this->addChild(right, 0, kTagLabel2);
+	this->addChild(centerColor, -1, kTagColor3);
+	this->addChild(center, 0, kTagLabel3);
+	this->addChild(top, 0, kTagLabel4);
+}
+
+std::string FontNoReplacementTest::title() const
+{
+	return "Font no replacement test";
+}
+
+FontReplacementTest* FontReplacementTest::create()
+{
+	auto ret = new (std::nothrow) FontReplacementTest;
+	if (ret && ret->init())
+	{
+		ret->autorelease();
+	}
+	else
+	{
+		delete ret;
+		ret = nullptr;
+	}
+
+	return ret;
+}
+
+FontReplacementTest::FontReplacementTest()
+{
+	_replace = true;
+}
+
+std::string FontReplacementTest::title() const
+{
+	return "Font replacement test";
 }

--- a/tests/cpp-tests/Classes/FontTest/FontTest.h
+++ b/tests/cpp-tests/Classes/FontTest/FontTest.h
@@ -31,4 +31,26 @@ public:
     virtual std::string title() const override;
 };
 
+class FontNoReplacementTest : public TestCase
+{
+public:
+	static FontNoReplacementTest* create();
+	~FontNoReplacementTest();
+	virtual void onEnter() override;
+	virtual std::string title() const override;
+protected:
+	FontNoReplacementTest();
+
+	bool _replace;
+};
+
+class FontReplacementTest : public FontNoReplacementTest
+{
+public:
+	static FontReplacementTest* create();
+	virtual std::string title() const override;
+protected:
+	FontReplacementTest();
+};
+
 #endif // _FONT_TEST_H_


### PR DESCRIPTION
If using the dictionary lookup mechanism of FileUtils, and multiple TTF files are replaced by the same one, FontAtlasCache was creating as many duplicate copies of the replacing font as there were of replaced fonts.

When using big TTF font, that can lead to a significant increase in memory used.

I've added 2 tests to FontTests. The first one is the reference test without any replacements, the second one have every font used being replaced by arial.

Without the change to FontAtlasCache, the second test takes more memory than the first one (since multiple atlases are created for arial, which is a bigger TTF file than the other), whereas with the change, the second test takes less memory (since only one atlas is created for arial).