### PR TITLE
[Improve]use STL emplace when possible

### DIFF
--- a/cocos/2d/CCTMXXMLParser.cpp
+++ b/cocos/2d/CCTMXXMLParser.cpp
@@ -227,7 +227,7 @@ void TMXMapInfo::startElement(void *ctx, const char *name, const char **atts)
         {
             std::string key = atts[i];
             std::string value = atts[i+1];
-            attributeDict.insert(std::make_pair(key, Value(value)));
+            attributeDict.emplace(key, Value(value));
         }
     }
     if (elementName == "map")
@@ -537,7 +537,7 @@ void TMXMapInfo::startElement(void *ctx, const char *name, const char **atts)
             // The parent element is the map
             Value value = attributeDict["value"];
             std::string key = attributeDict["name"].asString();
-            tmxMapInfo->getProperties().insert(std::make_pair(key, value));
+            tmxMapInfo->getProperties().emplace(key, value);
         }
         else if ( tmxMapInfo->getParentElement() == TMXPropertyLayer )
         {
@@ -546,7 +546,7 @@ void TMXMapInfo::startElement(void *ctx, const char *name, const char **atts)
             Value value = attributeDict["value"];
             std::string key = attributeDict["name"].asString();
             // Add the property to the layer
-            layer->getProperties().insert(std::make_pair(key, value));
+            layer->getProperties().emplace(key, value);
         }
         else if ( tmxMapInfo->getParentElement() == TMXPropertyObjectGroup ) 
         {
@@ -554,7 +554,7 @@ void TMXMapInfo::startElement(void *ctx, const char *name, const char **atts)
             TMXObjectGroup* objectGroup = tmxMapInfo->getObjectGroups().back();
             Value value = attributeDict["value"];
             std::string key = attributeDict["name"].asString();
-            objectGroup->getProperties().insert(std::make_pair(key, value));
+            objectGroup->getProperties().emplace(key, value);
         }
         else if ( tmxMapInfo->getParentElement() == TMXPropertyObject )
         {

--- a/cocos/base/CCEventDispatcher.cpp
+++ b/cocos/base/CCEventDispatcher.cpp
@@ -413,7 +413,7 @@ void EventDispatcher::associateNodeAndEventListener(Node* node, EventListener* l
     else
     {
         listeners = new (std::nothrow) std::vector<EventListener*>();
-        _nodeListenersMap.insert(std::make_pair(node, listeners));
+        _nodeListenersMap.emplace(node, listeners);
     }
     
     listeners->push_back(listener);
@@ -469,7 +469,7 @@ void EventDispatcher::forceAddEventListener(EventListener* listener)
     {
         
         listeners = new (std::nothrow) EventListenerVector();
-        _listenerMap.insert(std::make_pair(listenerID, listeners));
+        _listenerMap.emplace(listenerID, listeners);
     }
     else
     {
@@ -1543,7 +1543,7 @@ void EventDispatcher::setDirty(const EventListener::ListenerID& listenerID, Dirt
     auto iter = _priorityDirtyFlagMap.find(listenerID);
     if (iter == _priorityDirtyFlagMap.end())
     {
-        _priorityDirtyFlagMap.insert(std::make_pair(listenerID, flag));
+        _priorityDirtyFlagMap.emplace(listenerID, flag);
     }
     else
     {

--- a/cocos/base/CCMap.h
+++ b/cocos/base/CCMap.h
@@ -276,7 +276,7 @@ public:
         CCASSERT(object != nullptr, "Object is nullptr!");
         object->retain();
         erase(key);
-        _data.insert(std::make_pair(key, object));
+        _data.emplace(key, object);
     }
     
     /** 

--- a/cocos/base/ObjectFactory.cpp
+++ b/cocos/base/ObjectFactory.cpp
@@ -120,7 +120,7 @@ Ref* ObjectFactory::createObject(const std::string &name)
 
 void ObjectFactory::registerType(const TInfo &t)
 {
-    _typeMap.insert(std::make_pair(t._class, t));
+    _typeMap.emplace(t._class, t);
 }
 
 NS_CC_END

--- a/cocos/editor-support/cocostudio/ActionTimeline/CCActionTimelineCache.cpp
+++ b/cocos/editor-support/cocostudio/ActionTimeline/CCActionTimelineCache.cpp
@@ -504,7 +504,7 @@ ActionTimeline* ActionTimelineCache::createActionWithDataBuffer(const cocos2d::D
         Timeline* timeline = loadTimelineWithFlatBuffers(timelineFlatBuf);
         if (timeline)
         {
-            properTimelineMap.insert(std::make_pair(timelineFlatBuf->property()->c_str(), timeline));
+            properTimelineMap.emplace(timelineFlatBuf->property()->c_str(), timeline);
         }
     }
 
@@ -998,7 +998,7 @@ ActionTimeline* ActionTimelineCache::createActionWithFlatBuffersForSimulator(con
         Timeline* timeline = loadTimelineWithFlatBuffers(timelineFlatBuf);
         if (timeline)
         {
-            properTimelineMap.insert(std::make_pair(timelineFlatBuf->property()->c_str(), timeline));
+            properTimelineMap.emplace(timelineFlatBuf->property()->c_str(), timeline);
         }
     }
 

--- a/cocos/editor-support/cocostudio/ActionTimeline/CCSkeletonNode.cpp
+++ b/cocos/editor-support/cocostudio/ActionTimeline/CCSkeletonNode.cpp
@@ -318,7 +318,7 @@ const cocos2d::Map<std::string, BoneNode*>& SkeletonNode::getAllSubBonesMap() co
 
 void SkeletonNode::addSkinGroup(std::string groupName, std::map<std::string, std::string> boneSkinNameMap)
 {
-    _skinGroupMap.insert(std::make_pair(groupName, boneSkinNameMap));
+    _skinGroupMap.emplace(groupName, boneSkinNameMap);
 }
 
 void SkeletonNode::checkSubBonesDirty()

--- a/cocos/editor-support/cocostudio/TriggerMng.cpp
+++ b/cocos/editor-support/cocostudio/TriggerMng.cpp
@@ -418,7 +418,7 @@ void TriggerMng::addArmatureMovementCallBack(Armature *pAr, Ref *pTarget, SEL_Mo
 		amd = new (std::nothrow) ArmatureMovementDispatcher();
         pAr->getAnimation()->setMovementEventCallFunc(CC_CALLBACK_0(ArmatureMovementDispatcher::animationEvent, amd, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
         amd->addAnimationEventCallBack(pTarget, mecf);
-		_movementDispatches->insert(std::make_pair(pAr, amd));
+		_movementDispatches->emplace(pAr, amd);
 
 	}
 	else
@@ -514,7 +514,7 @@ ArmatureMovementDispatcher::~ArmatureMovementDispatcher(void)
 
   void ArmatureMovementDispatcher::addAnimationEventCallBack(Ref *pTarget, SEL_MovementEventCallFunc mecf)
   {
-	  _mapEventAnimation->insert(std::make_pair(pTarget, mecf));
+	  _mapEventAnimation->emplace(pTarget, mecf);
   }
 
   void ArmatureMovementDispatcher::removeAnnimationEventCallBack(Ref *pTarget, SEL_MovementEventCallFunc mecf)

--- a/cocos/platform/CCFileUtils.cpp
+++ b/cocos/platform/CCFileUtils.cpp
@@ -795,7 +795,7 @@ std::string FileUtils::fullPathForFilename(const std::string &filename) const
             if (!fullpath.empty())
             {
                 // Using the filename passed in as key.
-                _fullPathCache.insert(std::make_pair(filename, fullpath));
+                _fullPathCache.emplace(filename, fullpath);
                 return fullpath;
             }
 
@@ -1015,7 +1015,7 @@ bool FileUtils::isDirectoryExist(const std::string& dirPath) const
             fullpath = fullPathForFilename(searchIt + dirPath + resolutionIt);
             if (isDirectoryExistInternal(fullpath))
             {
-                _fullPathCache.insert(std::make_pair(dirPath, fullpath));
+                _fullPathCache.emplace(dirPath, fullpath);
                 return true;
             }
         }

--- a/cocos/platform/CCGLView.cpp
+++ b/cocos/platform/CCGLView.cpp
@@ -320,7 +320,7 @@ void GLView::handleTouchesBegin(int num, intptr_t ids[], float xs[], float ys[])
             
             CCLOGINFO("x = %f y = %f", touch->getLocationInView().x, touch->getLocationInView().y);
             
-            g_touchIdReorderMap.insert(std::make_pair(id, unusedIndex));
+            g_touchIdReorderMap.emplace(id, unusedIndex);
             touchEvent._touches.push_back(touch);
         }
     }

--- a/cocos/renderer/CCGLProgram.cpp
+++ b/cocos/renderer/CCGLProgram.cpp
@@ -695,7 +695,7 @@ bool GLProgram::updateUniformLocation(GLint location, const GLvoid* data, unsign
     {
         GLvoid* value = malloc(bytes);
         memcpy(value, data, bytes );
-        _hashForUniforms.insert(std::make_pair(location, std::make_pair(value, bytes)));
+        _hashForUniforms.emplace(location, std::make_pair(value, bytes));
     }
     else
     {

--- a/cocos/renderer/CCGLProgramCache.cpp
+++ b/cocos/renderer/CCGLProgramCache.cpp
@@ -141,165 +141,165 @@ void GLProgramCache::loadDefaultGLPrograms()
     // Position Texture Color shader
     GLProgram *p = new (std::nothrow) GLProgram();
     loadDefaultGLProgram(p, kShaderType_PositionTextureColor);
-    _programs.insert( std::make_pair( GLProgram::SHADER_NAME_POSITION_TEXTURE_COLOR, p ) );
+    _programs.emplace(GLProgram::SHADER_NAME_POSITION_TEXTURE_COLOR, p);
 
     // Position Texture Color without MVP shader
     p = new (std::nothrow) GLProgram();
     loadDefaultGLProgram(p, kShaderType_PositionTextureColor_noMVP);
-    _programs.insert( std::make_pair( GLProgram::SHADER_NAME_POSITION_TEXTURE_COLOR_NO_MVP, p ) );
+    _programs.emplace(GLProgram::SHADER_NAME_POSITION_TEXTURE_COLOR_NO_MVP, p);
 
     // Position Texture Color alpha test
     p = new (std::nothrow) GLProgram();
     loadDefaultGLProgram(p, kShaderType_PositionTextureColorAlphaTest);
-    _programs.insert( std::make_pair(GLProgram::SHADER_NAME_POSITION_TEXTURE_ALPHA_TEST, p) );
+    _programs.emplace(GLProgram::SHADER_NAME_POSITION_TEXTURE_ALPHA_TEST, p);
 
     // Position Texture Color alpha test
     p = new (std::nothrow) GLProgram();
     loadDefaultGLProgram(p, kShaderType_PositionTextureColorAlphaTestNoMV);
-    _programs.insert( std::make_pair(GLProgram::SHADER_NAME_POSITION_TEXTURE_ALPHA_TEST_NO_MV, p) );
+    _programs.emplace(GLProgram::SHADER_NAME_POSITION_TEXTURE_ALPHA_TEST_NO_MV, p);
     //
     // Position, Color shader
     //
     p = new (std::nothrow) GLProgram();
     loadDefaultGLProgram(p, kShaderType_PositionColor);
-    _programs.insert( std::make_pair(GLProgram::SHADER_NAME_POSITION_COLOR, p) );
+    _programs.emplace(GLProgram::SHADER_NAME_POSITION_COLOR, p);
 
     // Position, Color, PointSize shader
     p = new (std::nothrow) GLProgram();
     loadDefaultGLProgram(p, kShaderType_PositionColorTextureAsPointsize);
-    _programs.insert( std::make_pair(GLProgram::SHADER_NAME_POSITION_COLOR_TEXASPOINTSIZE, p) );
+    _programs.emplace(GLProgram::SHADER_NAME_POSITION_COLOR_TEXASPOINTSIZE, p);
 
     //
     // Position, Color shader no MVP
     //
     p = new (std::nothrow) GLProgram();
     loadDefaultGLProgram(p, kShaderType_PositionColor_noMVP);
-    _programs.insert( std::make_pair(GLProgram::SHADER_NAME_POSITION_COLOR_NO_MVP, p) );
+    _programs.emplace(GLProgram::SHADER_NAME_POSITION_COLOR_NO_MVP, p);
 
     //
     // Position Texture shader
     //
     p = new (std::nothrow) GLProgram();
     loadDefaultGLProgram(p, kShaderType_PositionTexture);
-    _programs.insert( std::make_pair( GLProgram::SHADER_NAME_POSITION_TEXTURE, p) );
+    _programs.emplace(GLProgram::SHADER_NAME_POSITION_TEXTURE, p);
 
     //
     // Position, Texture attribs, 1 Color as uniform shader
     //
     p = new (std::nothrow) GLProgram();
     loadDefaultGLProgram(p, kShaderType_PositionTexture_uColor);
-    _programs.insert( std::make_pair( GLProgram::SHADER_NAME_POSITION_TEXTURE_U_COLOR, p) );
+    _programs.emplace(GLProgram::SHADER_NAME_POSITION_TEXTURE_U_COLOR, p);
 
     //
     // Position Texture A8 Color shader
     //
     p = new (std::nothrow) GLProgram();
     loadDefaultGLProgram(p, kShaderType_PositionTextureA8Color);
-    _programs.insert( std::make_pair(GLProgram::SHADER_NAME_POSITION_TEXTURE_A8_COLOR, p) );
+    _programs.emplace(GLProgram::SHADER_NAME_POSITION_TEXTURE_A8_COLOR, p);
 
     //
     // Position and 1 color passed as a uniform (to simulate glColor4ub )
     //
     p = new (std::nothrow) GLProgram();
     loadDefaultGLProgram(p, kShaderType_Position_uColor);
-    _programs.insert( std::make_pair(GLProgram::SHADER_NAME_POSITION_U_COLOR, p) );
+    _programs.emplace(GLProgram::SHADER_NAME_POSITION_U_COLOR, p);
 
     //
     // Position, Length(TexCoords, Color (used by Draw Node basically )
     //
     p = new (std::nothrow) GLProgram();
     loadDefaultGLProgram(p, kShaderType_PositionLengthTextureColor);
-    _programs.insert( std::make_pair(GLProgram::SHADER_NAME_POSITION_LENGTH_TEXTURE_COLOR, p) );
+    _programs.emplace(GLProgram::SHADER_NAME_POSITION_LENGTH_TEXTURE_COLOR, p);
 
     p = new (std::nothrow) GLProgram();
     loadDefaultGLProgram(p, kShaderType_LabelDistanceFieldNormal);
-    _programs.insert( std::make_pair(GLProgram::SHADER_NAME_LABEL_DISTANCEFIELD_NORMAL, p) );
+    _programs.emplace(GLProgram::SHADER_NAME_LABEL_DISTANCEFIELD_NORMAL, p);
 
     p = new (std::nothrow) GLProgram();
     loadDefaultGLProgram(p, kShaderType_LabelDistanceFieldGlow);
-    _programs.insert( std::make_pair(GLProgram::SHADER_NAME_LABEL_DISTANCEFIELD_GLOW, p) );
+    _programs.emplace(GLProgram::SHADER_NAME_LABEL_DISTANCEFIELD_GLOW, p);
 
     p = new (std::nothrow) GLProgram();
     loadDefaultGLProgram(p, kShaderType_UIGrayScale);
-    _programs.insert(std::make_pair(GLProgram::SHADER_NAME_POSITION_GRAYSCALE, p));
+    _programs.emplace(GLProgram::SHADER_NAME_POSITION_GRAYSCALE, p);
 
     p = new (std::nothrow) GLProgram();
     loadDefaultGLProgram(p, kShaderType_LabelNormal);
-    _programs.insert( std::make_pair(GLProgram::SHADER_NAME_LABEL_NORMAL, p) );
+    _programs.emplace(GLProgram::SHADER_NAME_LABEL_NORMAL, p);
 
     p = new (std::nothrow) GLProgram();
     loadDefaultGLProgram(p, kShaderType_LabelOutline);
-    _programs.insert( std::make_pair(GLProgram::SHADER_NAME_LABEL_OUTLINE, p) );
+    _programs.emplace(GLProgram::SHADER_NAME_LABEL_OUTLINE, p);
 
     p = new (std::nothrow) GLProgram();
     loadDefaultGLProgram(p, kShaderType_3DPosition);
-    _programs.insert( std::make_pair(GLProgram::SHADER_3D_POSITION, p) );
+    _programs.emplace(GLProgram::SHADER_3D_POSITION, p);
 
     p = new (std::nothrow) GLProgram();
     loadDefaultGLProgram(p, kShaderType_3DPositionTex);
-    _programs.insert( std::make_pair(GLProgram::SHADER_3D_POSITION_TEXTURE, p) );
+    _programs.emplace(GLProgram::SHADER_3D_POSITION_TEXTURE, p);
 
     p = new (std::nothrow) GLProgram();
     loadDefaultGLProgram(p, kShaderType_3DSkinPositionTex);
-    _programs.insert(std::make_pair(GLProgram::SHADER_3D_SKINPOSITION_TEXTURE, p));
+    _programs.emplace(GLProgram::SHADER_3D_SKINPOSITION_TEXTURE, p);
 
     p = new (std::nothrow) GLProgram();
     loadDefaultGLProgram(p, kShaderType_3DPositionNormal);
-    _programs.insert( std::make_pair(GLProgram::SHADER_3D_POSITION_NORMAL, p) );
+    _programs.emplace(GLProgram::SHADER_3D_POSITION_NORMAL, p);
 
     p = new (std::nothrow) GLProgram();
     loadDefaultGLProgram(p, kShaderType_3DPositionNormalTex);
-    _programs.insert( std::make_pair(GLProgram::SHADER_3D_POSITION_NORMAL_TEXTURE, p) );
+    _programs.emplace(GLProgram::SHADER_3D_POSITION_NORMAL_TEXTURE, p);
 
     p = new (std::nothrow) GLProgram();
     loadDefaultGLProgram(p, kShaderType_3DSkinPositionNormalTex);
-    _programs.insert(std::make_pair(GLProgram::SHADER_3D_SKINPOSITION_NORMAL_TEXTURE, p));
+    _programs.emplace(GLProgram::SHADER_3D_SKINPOSITION_NORMAL_TEXTURE, p);
 
     p = new (std::nothrow) GLProgram();
     loadDefaultGLProgram(p, kShaderType_3DPositionBumpedNormalTex);
-    _programs.insert(std::make_pair(GLProgram::SHADER_3D_POSITION_BUMPEDNORMAL_TEXTURE, p));
+    _programs.emplace(GLProgram::SHADER_3D_POSITION_BUMPEDNORMAL_TEXTURE, p);
 
     p = new (std::nothrow) GLProgram();
     loadDefaultGLProgram(p, kShaderType_3DSkinPositionBumpedNormalTex);
-    _programs.insert(std::make_pair(GLProgram::SHADER_3D_SKINPOSITION_BUMPEDNORMAL_TEXTURE, p));
+    _programs.emplace(GLProgram::SHADER_3D_SKINPOSITION_BUMPEDNORMAL_TEXTURE, p);
 
     p = new (std::nothrow) GLProgram();
     loadDefaultGLProgram(p, kShaderType_3DParticleColor);
-    _programs.insert(std::make_pair(GLProgram::SHADER_3D_PARTICLE_COLOR, p));
+    _programs.emplace(GLProgram::SHADER_3D_PARTICLE_COLOR, p);
 
     p = new (std::nothrow) GLProgram();
     loadDefaultGLProgram(p, kShaderType_3DParticleTex);
-    _programs.insert(std::make_pair(GLProgram::SHADER_3D_PARTICLE_TEXTURE, p));
+    _programs.emplace(GLProgram::SHADER_3D_PARTICLE_TEXTURE, p);
 
     p = new (std::nothrow) GLProgram();
     loadDefaultGLProgram(p, kShaderType_3DSkyBox);
-    _programs.insert(std::make_pair(GLProgram::SHADER_3D_SKYBOX, p));
+    _programs.emplace(GLProgram::SHADER_3D_SKYBOX, p);
 
     p = new (std::nothrow) GLProgram();
     loadDefaultGLProgram(p, kShaderType_3DTerrain);
-    _programs.insert(std::make_pair(GLProgram::SHADER_3D_TERRAIN, p));
+    _programs.emplace(GLProgram::SHADER_3D_TERRAIN, p);
     
     p = new (std::nothrow) GLProgram();
     loadDefaultGLProgram(p, kShaderType_CameraClear);
-    _programs.insert(std::make_pair(GLProgram::SHADER_CAMERA_CLEAR, p));
+    _programs.emplace(GLProgram::SHADER_CAMERA_CLEAR, p);
 
     /// ETC1 ALPHA supports.
     p = new(std::nothrow) GLProgram();
     loadDefaultGLProgram(p, kShaderType_ETC1ASPositionTextureColor);
-    _programs.insert(std::make_pair(GLProgram::SHADER_NAME_ETC1AS_POSITION_TEXTURE_COLOR, p));
+    _programs.emplace(GLProgram::SHADER_NAME_ETC1AS_POSITION_TEXTURE_COLOR, p);
 
     p = new(std::nothrow) GLProgram();
     loadDefaultGLProgram(p, kShaderType_ETC1ASPositionTextureColor_noMVP);
-    _programs.insert(std::make_pair(GLProgram::SHADER_NAME_ETC1AS_POSITION_TEXTURE_COLOR_NO_MVP, p));
+    _programs.emplace(GLProgram::SHADER_NAME_ETC1AS_POSITION_TEXTURE_COLOR_NO_MVP, p);
 
     /// ETC1 Gray supports.
     p = new(std::nothrow) GLProgram();
     loadDefaultGLProgram(p, kShaderType_ETC1ASPositionTextureGray);
-    _programs.insert(std::make_pair(GLProgram::SHADER_NAME_ETC1AS_POSITION_TEXTURE_GRAY, p));
+    _programs.emplace(GLProgram::SHADER_NAME_ETC1AS_POSITION_TEXTURE_GRAY, p);
 
     p = new(std::nothrow) GLProgram();
     loadDefaultGLProgram(p, kShaderType_ETC1ASPositionTextureGray_noMVP);
-    _programs.insert(std::make_pair(GLProgram::SHADER_NAME_ETC1AS_POSITION_TEXTURE_GRAY_NO_MVP, p));
+    _programs.emplace(GLProgram::SHADER_NAME_ETC1AS_POSITION_TEXTURE_GRAY_NO_MVP, p);
 }
 
 void GLProgramCache::reloadDefaultGLPrograms()

--- a/cocos/renderer/CCTextureCache.cpp
+++ b/cocos/renderer/CCTextureCache.cpp
@@ -305,7 +305,7 @@ void TextureCache::addImageAsyncCallBack(float dt)
                 VolatileTextureMgr::addImageTexture(texture, asyncStruct->filename);
 #endif
                 // cache the texture. retain it, since it is added in the map
-                _textures.insert(std::make_pair(asyncStruct->filename, texture));
+                _textures.emplace(asyncStruct->filename, texture);
                 texture->retain();
 
                 texture->autorelease();
@@ -378,7 +378,7 @@ Texture2D * TextureCache::addImage(const std::string &path)
                 VolatileTextureMgr::addImageTexture(texture, fullpath);
 #endif
                 // texture already retained, no need to re-retain it
-                _textures.insert(std::make_pair(fullpath, texture));
+                _textures.emplace(fullpath, texture);
 
                 //-- ANDROID ETC1 ALPHA SUPPORTS.
                 std::string alphaFullPath = path + s_etc1AlphaFileSuffix;
@@ -444,7 +444,7 @@ Texture2D* TextureCache::addImage(Image *image, const std::string &key)
         {
             if (texture->initWithImage(image))
             {
-                _textures.insert(std::make_pair(key, texture));
+                _textures.emplace(key, texture);
             }
             else
             {
@@ -669,7 +669,7 @@ void TextureCache::renameTextureWithKey(const std::string& srcName, const std::s
             if (ret)
             {
                 tex->initWithImage(image);
-                _textures.insert(std::make_pair(fullpath, tex));
+                _textures.emplace(fullpath, tex);
                 _textures.erase(it);
             }
             CC_SAFE_DELETE(image);

--- a/extensions/Particle3D/PU/CCPUScriptCompiler.cpp
+++ b/extensions/Particle3D/PU/CCPUScriptCompiler.cpp
@@ -69,7 +69,7 @@ std::string PUObjectAbstractNode::getValue() const
 
 void PUObjectAbstractNode::addVariable(const std::string &inName)
 {
-    _env.insert(std::make_pair(inName, ""));
+    _env.emplace(inName, "");
 }
 
 void PUObjectAbstractNode::setVariable(const std::string &inName, const std::string &value)


### PR DESCRIPTION
* replaced some unordered_map::insert(std::make_pair(foo, bar)) with unordered_map::emplace(foo, bar)
* replaced some vector::push_back(std::make_pair(foo, bar)) with vector::emplace_back(foo, bar)

The old way will construct a std::pair first then call move constructor when putting it into the container, while using emplace will construct the pair in-place in the container which will make it a little bit faster. Also, the emplace way is shorter & more concise.