### PR TITLE
Let FMOD autodetect the best output mode for Linux

### DIFF
--- a/cocos/audio/linux/AudioEngine-linux.cpp
+++ b/cocos/audio/linux/AudioEngine-linux.cpp
@@ -63,7 +63,7 @@ bool AudioEngineImpl::init()
     result = FMOD::System_Create(&pSystem);
     ERRCHECKWITHEXIT(result);
 
-    result = pSystem->setOutput(FMOD_OUTPUTTYPE_PULSEAUDIO);
+    result = pSystem->setOutput(FMOD_OUTPUTTYPE_AUTODETECT);
     ERRCHECKWITHEXIT(result);
 
     result = pSystem->init(32, FMOD_INIT_NORMAL, 0);


### PR DESCRIPTION
@filippovdaniil is right. Letting FMOD autodetect the best output mode makes it work with ALSA as well as PulseAudio. I tested this in Arch Linux and @filippovdaniil tested it in Debian. 

Related: Issue #16627