### PR TITLE
Fixed EditBox placeholder font not being set correctly for multiline …

### DIFF
--- a/cocos/ui/UIEditBox/UIEditBoxImpl-ios.mm
+++ b/cocos/ui/UIEditBox/UIEditBoxImpl-ios.mm
@@ -114,12 +114,18 @@ void EditBoxImplIOS::setNativeFontColor(const Color4B& color)
 
 void EditBoxImplIOS::setNativePlaceholderFont(const char* pFontName, int fontSize)
 {
-    //TODO::
+    UIFont* textFont = constructFont(pFontName, fontSize);
+    if (textFont != nil) {
+        [_systemControl setPlaceholderFont:textFont];
+    }
 }
 
 void EditBoxImplIOS::setNativePlaceholderFontColor(const Color4B& color)
 {
-    //TODO::
+    [_systemControl setPlaceholderTextColor:[UIColor colorWithRed:color.r / 255.0f
+                                                         green:color.g / 255.0f
+                                                          blue:color.b / 255.0f
+                                                         alpha:color.a / 255.f]];
 }
 
 void EditBoxImplIOS::setNativeInputMode(EditBox::InputMode inputMode)

--- a/cocos/ui/UIEditBox/iOS/CCUIEditBoxIOS.mm
+++ b/cocos/ui/UIEditBox/iOS/CCUIEditBoxIOS.mm
@@ -135,6 +135,16 @@
     self.textInput.ccui_textColor = color;
 }
 
+- (void)setPlaceholderFont:(UIFont *)font
+{
+    self.textInput.ccui_placeholderLabel.font = font;
+}
+
+- (void)setPlaceholderTextColor:(UIColor *)color
+{
+    self.textInput.ccui_placeholderLabel.textColor = color;
+}
+
 - (void)setInputMode:(cocos2d::ui::EditBox::InputMode)inputMode
 {
     //multiline input

--- a/cocos/ui/UIEditBox/iOS/CCUITextInput.h
+++ b/cocos/ui/UIEditBox/iOS/CCUITextInput.h
@@ -34,6 +34,7 @@ static const int CC_EDIT_BOX_PADDING = 5;
 
 @property (nonatomic, retain, setter=ccui_setText:) NSString *ccui_text;
 @property (nonatomic, retain, setter=ccui_setPlaceholder:) NSString *ccui_placeholder;
+@property (nonatomic, retain, setter=ccui_setPlaceholderLabel:) UILabel *ccui_placeholderLabel;
 @property (nonatomic, retain, setter=ccui_setTextColor:) UIColor *ccui_textColor;
 @property (nonatomic, retain, setter=ccui_setFont:) UIFont *ccui_font;
 @property (nonatomic, assign, setter=ccui_setSecureTextEntry:) BOOL ccui_secureTextEntry;

--- a/cocos/ui/UIEditBox/iOS/UITextView+CCUITextInput.mm
+++ b/cocos/ui/UIEditBox/iOS/UITextView+CCUITextInput.mm
@@ -46,6 +46,15 @@
     return nil;
 }
 
+- (UILabel *)ccui_placeholderLabel
+{
+    SEL selector = @selector(placeHolderLabel);
+    if ([self respondsToSelector:selector]) {
+        return [self performSelector:selector];
+    }
+    return nil;
+}
+
 - (void)ccui_setPlaceholder:(NSString *)ccui_placeholder
 {
     SEL selector = @selector(setPlaceholder:);


### PR DESCRIPTION
…text fields on iOS.

EditBoxImplIOS::setNativePlaceholderFontColor(const Color4B& color) and EditBoxImplIOS::setNativePlaceholderFont(const char* pFontName, int fontSize) were marked as TODOs. This PR will provided an implementation.