### PR TITLE
Android setMultipleTouchEnabled

### DIFF
--- a/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxGLSurfaceView.java
+++ b/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxGLSurfaceView.java
@@ -68,6 +68,16 @@ public class Cocos2dxGLSurfaceView extends GLSurfaceView {
 
     private boolean mSoftKeyboardShown = false;
 
+    public boolean isMultipleTouchEnabled() {
+        return mMultipleTouchEnabled;
+    }
+
+    public void setMultipleTouchEnabled(boolean multipleTouchEnabled) {
+        this.mMultipleTouchEnabled = multipleTouchEnabled;
+    }
+
+    private boolean mMultipleTouchEnabled = true;
+
 
     // ===========================================================
     // Constructors
@@ -218,6 +228,9 @@ public class Cocos2dxGLSurfaceView extends GLSurfaceView {
         switch (pMotionEvent.getAction() & MotionEvent.ACTION_MASK) {
             case MotionEvent.ACTION_POINTER_DOWN:
                 final int indexPointerDown = pMotionEvent.getAction() >> MotionEvent.ACTION_POINTER_INDEX_SHIFT;
+                if (!mMultipleTouchEnabled && indexPointerDown != 0) {
+                    break;
+                }
                 final int idPointerDown = pMotionEvent.getPointerId(indexPointerDown);
                 final float xPointerDown = pMotionEvent.getX(indexPointerDown);
                 final float yPointerDown = pMotionEvent.getY(indexPointerDown);
@@ -255,6 +268,9 @@ public class Cocos2dxGLSurfaceView extends GLSurfaceView {
 
             case MotionEvent.ACTION_POINTER_UP:
                 final int indexPointUp = pMotionEvent.getAction() >> MotionEvent.ACTION_POINTER_INDEX_SHIFT;
+                if (!mMultipleTouchEnabled && indexPointUp != 0) {
+                    break;
+                }
                 final int idPointerUp = pMotionEvent.getPointerId(indexPointUp);
                 final float xPointerUp = pMotionEvent.getX(indexPointUp);
                 final float yPointerUp = pMotionEvent.getY(indexPointUp);

--- a/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxGLSurfaceView.java
+++ b/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxGLSurfaceView.java
@@ -58,6 +58,9 @@ public class Cocos2dxGLSurfaceView extends GLSurfaceView {
     private Cocos2dxRenderer mCocos2dxRenderer;
     private Cocos2dxEditBox mCocos2dxEditText;
 
+    private boolean mSoftKeyboardShown = false;
+    private boolean mMultipleTouchEnabled = true;
+
     public boolean isSoftKeyboardShown() {
         return mSoftKeyboardShown;
     }
@@ -66,8 +69,6 @@ public class Cocos2dxGLSurfaceView extends GLSurfaceView {
         this.mSoftKeyboardShown = softKeyboardShown;
     }
 
-    private boolean mSoftKeyboardShown = false;
-
     public boolean isMultipleTouchEnabled() {
         return mMultipleTouchEnabled;
     }
@@ -75,9 +76,6 @@ public class Cocos2dxGLSurfaceView extends GLSurfaceView {
     public void setMultipleTouchEnabled(boolean multipleTouchEnabled) {
         this.mMultipleTouchEnabled = multipleTouchEnabled;
     }
-
-    private boolean mMultipleTouchEnabled = true;
-
 
     // ===========================================================
     // Constructors
@@ -258,6 +256,24 @@ public class Cocos2dxGLSurfaceView extends GLSurfaceView {
                 break;
 
             case MotionEvent.ACTION_MOVE:
+                if (!mMultipleTouchEnabled) {
+                    // handle only touch with id == 0
+                    for (int i = 0; i < pointerNumber; i++) {
+                        if (ids[i] == 0) {
+                            final int[] idsMove = new int[]{0};
+                            final float[] xsMove = new float[]{xs[i]};
+                            final float[] ysMove = new float[]{ys[i]};
+                            this.queueEvent(new Runnable() {
+                                @Override
+                                public void run() {
+                                    Cocos2dxGLSurfaceView.this.mCocos2dxRenderer.handleActionMove(idsMove, xsMove, ysMove);
+                                }
+                            });
+                            break;
+                        }
+                    }
+                    break;
+                }
                 this.queueEvent(new Runnable() {
                     @Override
                     public void run() {
@@ -298,6 +314,24 @@ public class Cocos2dxGLSurfaceView extends GLSurfaceView {
                 break;
 
             case MotionEvent.ACTION_CANCEL:
+                if (!mMultipleTouchEnabled) {
+                    // handle only touch with id == 0
+                    for (int i = 0; i < pointerNumber; i++) {
+                        if (ids[i] == 0) {
+                            final int[] idsCancel = new int[]{0};
+                            final float[] xsCancel = new float[]{xs[i]};
+                            final float[] ysCancel = new float[]{ys[i]};
+                            this.queueEvent(new Runnable() {
+                                @Override
+                                public void run() {
+                                    Cocos2dxGLSurfaceView.this.mCocos2dxRenderer.handleActionCancel(idsCancel, xsCancel, ysCancel);
+                                }
+                            });
+                            break;
+                        }
+                    }
+                    break;
+                }
                 this.queueEvent(new Runnable() {
                     @Override
                     public void run() {

--- a/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxGLSurfaceView.java
+++ b/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxGLSurfaceView.java
@@ -272,14 +272,14 @@ public class Cocos2dxGLSurfaceView extends GLSurfaceView {
                             break;
                         }
                     }
-                    break;
+                } else {
+                    this.queueEvent(new Runnable() {
+                        @Override
+                        public void run() {
+                            Cocos2dxGLSurfaceView.this.mCocos2dxRenderer.handleActionMove(ids, xs, ys);
+                        }
+                    });
                 }
-                this.queueEvent(new Runnable() {
-                    @Override
-                    public void run() {
-                        Cocos2dxGLSurfaceView.this.mCocos2dxRenderer.handleActionMove(ids, xs, ys);
-                    }
-                });
                 break;
 
             case MotionEvent.ACTION_POINTER_UP:
@@ -330,14 +330,14 @@ public class Cocos2dxGLSurfaceView extends GLSurfaceView {
                             break;
                         }
                     }
-                    break;
+                } else {
+                    this.queueEvent(new Runnable() {
+                        @Override
+                        public void run() {
+                            Cocos2dxGLSurfaceView.this.mCocos2dxRenderer.handleActionCancel(ids, xs, ys);
+                        }
+                    });
                 }
-                this.queueEvent(new Runnable() {
-                    @Override
-                    public void run() {
-                        Cocos2dxGLSurfaceView.this.mCocos2dxRenderer.handleActionCancel(ids, xs, ys);
-                    }
-                });
                 break;
         }
 


### PR DESCRIPTION
On iOS switching between single or multitouch app is done with a single call to `[eaglView setMultipleTouchEnabled:NO];` but there is no simple equivalent on Android.

This PR adds this feature to `Cocos2dxGLSurfaceView` which can then be easily called on `AppActivity` with `this.getGLSurfaceView().setMultipleTouchEnabled(false);`.

This is a recurring situation that has been discussed [here](http://discuss.cocos2d-x.org/t/disabling-multitouch-in-android/9649/3), [here](http://discuss.cocos2d-x.org/t/single-touch-problem/17921/7) and [here](http://discuss.cocos2d-x.org/t/about-the-single-touch-by-android/17957). There was also an very similar PR #4654 that was closed but not merged.