### PR TITLE
 cocos2dInternal cleaned from warnings on Linux with gcc-6.2

### DIFF
--- a/cocos/2d/CCCameraBackgroundBrush.cpp
+++ b/cocos/2d/CCCameraBackgroundBrush.cpp
@@ -95,9 +95,17 @@ CameraBackgroundDepthBrush::~CameraBackgroundDepthBrush()
 CameraBackgroundDepthBrush* CameraBackgroundDepthBrush::create(float depth)
 {
     auto ret = new (std::nothrow) CameraBackgroundDepthBrush();
-    ret->_depth = depth;
-    ret->init();
-    ret->autorelease();
+    
+    if (nullptr != ret && ret->init())
+    {
+        ret->_depth = depth;
+        ret->autorelease();
+    }
+    else
+    {
+        CC_SAFE_DELETE(ret);
+    }
+
     return ret;
 }
 
@@ -218,11 +226,18 @@ void CameraBackgroundColorBrush::setColor(const Color4F& color)
 CameraBackgroundColorBrush* CameraBackgroundColorBrush::create(const Color4F& color, float depth)
 {
     auto ret = new (std::nothrow) CameraBackgroundColorBrush();
-    ret->init();
-    ret->setColor(color);
-    ret->setDepth(depth);
-    
-    ret->autorelease();
+
+    if (nullptr != ret && ret->init())
+    {
+        ret->setColor(color);
+        ret->setDepth(depth);
+        ret->autorelease();
+    }
+    else
+    {
+        CC_SAFE_DELETE(ret);
+    }
+
     return ret;
 }
 
@@ -264,35 +279,64 @@ CameraBackgroundSkyBoxBrush::~CameraBackgroundSkyBoxBrush()
     }
 }
 
-CameraBackgroundSkyBoxBrush* CameraBackgroundSkyBoxBrush::create(const std::string& positive_x, const std::string& negative_x, const std::string& positive_y, const std::string& negative_y, const std::string& positive_z, const std::string& negative_z)
+CameraBackgroundSkyBoxBrush* CameraBackgroundSkyBoxBrush::create(
+    const std::string& positive_x,
+    const std::string& negative_x,
+    const std::string& positive_y,
+    const std::string& negative_y,
+    const std::string& positive_z,
+    const std::string& negative_z
+    )
 {
-    auto texture = TextureCube::create(positive_x, negative_x, positive_y, negative_y, positive_z, negative_z);
-    if (texture == nullptr)
-        return nullptr;
-    
-    Texture2D::TexParams tRepeatParams;
-    tRepeatParams.magFilter = GL_LINEAR;
-    tRepeatParams.minFilter = GL_LINEAR;
-    tRepeatParams.wrapS = GL_CLAMP_TO_EDGE;
-    tRepeatParams.wrapT = GL_CLAMP_TO_EDGE;
-    texture->setTexParameters(tRepeatParams);
-    
-    auto ret = new(std::nothrow)CameraBackgroundSkyBoxBrush();
-    
-    ret->init();
-    ret->setTexture(texture);
-    
-    ret->autorelease();
+    CameraBackgroundSkyBoxBrush* ret = nullptr;
+
+    auto texture = TextureCube::create(positive_x,
+                                       negative_x,
+                                       positive_y,
+                                       negative_y,
+                                       positive_z,
+                                       negative_z);
+
+    if (texture != nullptr)
+    {
+
+        Texture2D::TexParams tRepeatParams;
+        tRepeatParams.magFilter = GL_LINEAR;
+        tRepeatParams.minFilter = GL_LINEAR;
+        tRepeatParams.wrapS = GL_CLAMP_TO_EDGE;
+        tRepeatParams.wrapT = GL_CLAMP_TO_EDGE;
+        texture->setTexParameters(tRepeatParams);
+
+        ret = new (std::nothrow) CameraBackgroundSkyBoxBrush;
+
+        if (nullptr != ret && ret->init())
+        {
+            ret->setTexture(texture);
+            ret->autorelease();
+        }
+        else
+        {
+            CC_SAFE_DELETE(texture);
+            CC_SAFE_DELETE(ret);
+        }
+    }
+
     return ret;
 }
 
 CameraBackgroundSkyBoxBrush* CameraBackgroundSkyBoxBrush::create()
 {
-    auto ret = new(std::nothrow)CameraBackgroundSkyBoxBrush();
+    auto ret = new (std::nothrow) CameraBackgroundSkyBoxBrush();
     
-    ret->init();
-    
-    ret->autorelease();
+    if (nullptr != ret && ret->init())
+    {
+        ret->autorelease();
+    }
+    else
+    {
+        CC_SAFE_DELETE(ret);
+    }
+
     return ret;
 }
 

--- a/cocos/2d/CCFontAtlas.cpp
+++ b/cocos/2d/CCFontAtlas.cpp
@@ -209,7 +209,7 @@ void FontAtlas::conversionU16TOGB2312(const std::u16string& u16Text, std::unorde
 #else
         if (_iconv == nullptr)
         {
-            _iconv = iconv_open("gb2312", "utf-16le");
+            _iconv = iconv_open("GBK//TRANSLIT", "UTF-16LE");
         }
 
         if (_iconv == (iconv_t)-1)

--- a/cocos/2d/CCTMXTiledMap.cpp
+++ b/cocos/2d/CCTMXTiledMap.cpp
@@ -125,46 +125,51 @@ TMXLayer * TMXTiledMap::parseLayer(TMXLayerInfo *layerInfo, TMXMapInfo *mapInfo)
 
 TMXTilesetInfo * TMXTiledMap::tilesetForLayer(TMXLayerInfo *layerInfo, TMXMapInfo *mapInfo)
 {
-    Size size = layerInfo->_layerSize;
+    TMXTilesetInfo* tileset = nullptr;
+
+    const auto height = static_cast<uint32_t>(layerInfo->_layerSize.height);
+    const auto width  = static_cast<uint32_t>(layerInfo->_layerSize.width);
+
     auto& tilesets = mapInfo->getTilesets();
-    if (tilesets.size()>0)
+
+    for (auto iter = tilesets.crbegin(), iterCrend = tilesets.crend();
+         iter != iterCrend;
+         ++iter)
     {
-        TMXTilesetInfo* tileset = nullptr;
-        for (auto iter = tilesets.crbegin(), iterCrend = tilesets.crend(); iter != iterCrend; ++iter)
+        tileset = *iter;
+
+        if (tileset)
         {
-            tileset = *iter;
-            if (tileset)
+            for (uint32_t y = 0; y < height; y++)
             {
-                for( int y=0; y < size.height; y++ )
+                for(uint32_t x = 0; x < width; x++)
                 {
-                    for( int x=0; x < size.width; x++ )
+                    auto pos = x + width * y;
+                    auto gid = layerInfo->_tiles[ pos ];
+
+                    // FIXME:: gid == 0 --> empty tile
+                    if( gid != 0 ) 
                     {
-                        int pos = static_cast<int>(x + size.width * y);
-                        int gid = layerInfo->_tiles[ pos ];
-
-                        // gid are stored in little endian.
-                        // if host is big endian, then swap
-                        //if( o == CFByteOrderBigEndian )
-                        //    gid = CFSwapInt32( gid );
-                        /* We support little endian.*/
-
-                        // FIXME:: gid == 0 --> empty tile
-                        if( gid != 0 ) 
+                        // Optimization: quick return
+                        // if the layer is invalid (more than 1 tileset per layer)
+                        // an CCAssert will be thrown later
+                        if (tileset->_firstGid < 0
+                            || ((gid & kTMXFlippedMask)
+                                >= static_cast<uint32_t>(tileset->_firstGid))
+                        )
                         {
-                            // Optimization: quick return
-                            // if the layer is invalid (more than 1 tileset per layer) an CCAssert will be thrown later
-                            if( (gid & kTMXFlippedMask) >= tileset->_firstGid )
-                                return tileset;
+                            return tileset;
                         }
                     }
-                }        
-            }
+                }
+            }        
         }
     }
 
     // If all the tiles are 0, return empty tileset
     CCLOG("cocos2d: Warning: TMX Layer '%s' has no tiles", layerInfo->_name.c_str());
-    return nullptr;
+
+    return tileset;
 }
 
 void TMXTiledMap::buildWithMapInfo(TMXMapInfo* mapInfo)
@@ -228,15 +233,11 @@ TMXObjectGroup * TMXTiledMap::getObjectGroup(const std::string& groupName) const
 {
     CCASSERT(groupName.size() > 0, "Invalid group name!");
 
-    if (_objectGroups.size()>0)
+    for (const auto objectGroup : _objectGroups)
     {
-        TMXObjectGroup* objectGroup = nullptr;
-        for (const auto& objectGroup : _objectGroups)
+        if (objectGroup && objectGroup->getGroupName() == groupName)
         {
-            if (objectGroup && objectGroup->getGroupName() == groupName)
-            {
-                return objectGroup;
-            }
+            return objectGroup;
         }
     }
 

--- a/cocos/2d/CCTransition.cpp
+++ b/cocos/2d/CCTransition.cpp
@@ -1299,7 +1299,9 @@ TransitionCrossFade* TransitionCrossFade::create(float t, Scene* scene)
     return nullptr;
 }
 
-void TransitionCrossFade::draw(Renderer *renderer, const Mat4 &transform, uint32_t flags)
+void TransitionCrossFade::draw(Renderer* /*renderer*/,
+                               const Mat4 & /*transform*/,
+                               uint32_t /*flags*/)
 {
     // override draw since both scenes (textures) are rendered in 1 scene
 }

--- a/cocos/2d/CCTransitionProgress.cpp
+++ b/cocos/2d/CCTransitionProgress.cpp
@@ -122,7 +122,7 @@ void TransitionProgress::setupTransition()
     _to = 0;
 }
 
-ProgressTimer* TransitionProgress::progressTimerNodeWithRenderTexture(RenderTexture* texture)
+ProgressTimer* TransitionProgress::progressTimerNodeWithRenderTexture(RenderTexture* /*texture*/)
 {
     CCASSERT(false, "override me - abstract class");
     return nullptr;

--- a/cocos/3d/CCAttachNode.cpp
+++ b/cocos/3d/CCAttachNode.cpp
@@ -74,7 +74,7 @@ const Mat4& AttachNode::getNodeToParentTransform() const
     return _transformToParent;
 }
 
-void AttachNode::visit(Renderer *renderer, const Mat4& parentTransform, uint32_t parentFlags)
+void AttachNode::visit(Renderer *renderer, const Mat4& parentTransform, uint32_t /*parentFlags*/)
 {
     Node::visit(renderer, parentTransform, Node::FLAGS_DIRTY_MASK);
 }

--- a/cocos/3d/CCBillBoard.cpp
+++ b/cocos/3d/CCBillBoard.cpp
@@ -222,7 +222,7 @@ bool BillBoard::calculateBillbaordTransform()
     return false;
 }
 
-void BillBoard::draw(Renderer *renderer, const Mat4 &transform, uint32_t flags)
+void BillBoard::draw(Renderer *renderer, const Mat4 & /*transform*/, uint32_t flags)
 {
     //FIXME: frustum culling here
     flags |= Node::FLAGS_RENDER_AS_3D;

--- a/cocos/3d/CCBundle3D.cpp
+++ b/cocos/3d/CCBundle3D.cpp
@@ -224,9 +224,11 @@ bool Bundle3D::loadObj(MeshDatas& meshdatas, MaterialDatas& materialdatas, NodeD
         int i = 0;
         char str[20];
         std::string dir = "";
+        
         auto last = fullPath.rfind("/");
-        if (last != -1)
+        if (last != std::string::npos)
             dir = fullPath.substr(0, last + 1);
+
         for (auto& material : materials) {
             NMaterialData materialdata;
             
@@ -330,7 +332,7 @@ bool Bundle3D::loadObj(MeshDatas& meshdatas, MaterialDatas& materialdatas, NodeD
     return false;
 }
 
-bool Bundle3D::loadSkinData(const std::string& id, SkinData* skindata)
+bool Bundle3D::loadSkinData(const std::string& /*id*/, SkinData* skindata)
 {
     skindata->resetData();
 

--- a/cocos/3d/CCBundle3D.h
+++ b/cocos/3d/CCBundle3D.h
@@ -113,14 +113,14 @@ protected:
     bool loadMaterialsBinary(MaterialDatas& materialdatas);
     bool loadMaterialsBinary_0_1(MaterialDatas& materialdatas);
     bool loadMaterialsBinary_0_2(MaterialDatas& materialdatas);
-    bool loadMeshDataJson(MeshData* meshdata){return true;}
-    bool loadMeshDataJson_0_1(MeshData* meshdata){return true;}
-    bool loadMeshDataJson_0_2(MeshData* meshdata){return true;}
+    bool loadMeshDataJson(MeshData *) { return true; }
+    bool loadMeshDataJson_0_1(MeshData *) { return true; }
+    bool loadMeshDataJson_0_2(MeshData *) { return true; }
     bool loadSkinDataJson(SkinData* skindata);
     bool loadSkinDataBinary(SkinData* skindata);
-    bool loadMaterialDataJson(MaterialData* materialdata){return true;}
-    bool loadMaterialDataJson_0_1(MaterialData* materialdata){return true;}
-    bool loadMaterialDataJson_0_2(MaterialData* materialdata){return true;}
+    bool loadMaterialDataJson(MaterialData *) { return true; }
+    bool loadMaterialDataJson_0_1(MaterialData *) { return true; }
+    bool loadMaterialDataJson_0_2(MaterialData *) { return true; }
     bool loadAnimationDataJson(const std::string& id,Animation3DData* animationdata);
     bool loadAnimationDataBinary(const std::string& id,Animation3DData* animationdata);
 

--- a/cocos/3d/CCBundleReader.h
+++ b/cocos/3d/CCBundleReader.h
@@ -183,7 +183,7 @@ inline bool BundleReader::read<char>(char *ptr)
 * specialization for std::string
 */
 template<>
-inline bool BundleReader::read<std::string>(std::string *ptr)
+inline bool BundleReader::read<std::string>(std::string* /*ptr*/)
 {
     CCLOG("can not read std::string, use readString() instead");
     return false;

--- a/cocos/3d/CCMesh.cpp
+++ b/cocos/3d/CCMesh.cpp
@@ -229,13 +229,18 @@ Mesh* Mesh::create(const std::vector<float>& positions, const std::vector<float>
     return create(vertices, perVertexSizeInFloat, indices, attribs);
 }
 
-Mesh* Mesh::create(const std::vector<float>& vertices, int perVertexSizeInFloat, const IndexArray& indices, const std::vector<MeshVertexAttrib>& attribs)
+Mesh* Mesh::create(const std::vector<float>& vertices,
+                   int /*perVertexSizeInFloat*/,
+                   const IndexArray& indices,
+                   const std::vector<MeshVertexAttrib>& attribs)
 {
     MeshData meshdata;
+
     meshdata.attribs = attribs;
     meshdata.vertex = vertices;
     meshdata.subMeshIndices.push_back(indices);
     meshdata.subMeshIds.push_back("");
+    
     auto meshvertexdata = MeshVertexData::create(meshdata);
     auto indexData = meshvertexdata->getMeshIndexDataByIndex(0);
     
@@ -372,7 +377,7 @@ Material* Mesh::getMaterial() const
     return _material;
 }
 
-void Mesh::draw(Renderer* renderer, float globalZOrder, const Mat4& transform, uint32_t flags, unsigned int lightMask, const Vec4& color, bool forceDepthWrite)
+void Mesh::draw(Renderer* renderer, float globalZOrder, const Mat4& transform, uint32_t flags, unsigned int lightMask, const Vec4& color, bool /*forceDepthWrite*/)
 {
     if (! isVisible())
         return;

--- a/cocos/3d/CCMesh.h
+++ b/cocos/3d/CCMesh.h
@@ -63,8 +63,15 @@ public:
     /**create mesh from positions, normals, and so on, single SubMesh*/
     static Mesh* create(const std::vector<float>& positions, const std::vector<float>& normals, const std::vector<float>& texs, const IndexArray& indices);
     /**create mesh with vertex attributes*/
-    CC_DEPRECATED_ATTRIBUTE static Mesh* create(const std::vector<float>& vertices, int perVertexSizeInFloat, const IndexArray& indices, int numIndex, const std::vector<MeshVertexAttrib>& attribs, int attribCount){ return create(vertices, perVertexSizeInFloat, indices, attribs); }
-    
+    CC_DEPRECATED_ATTRIBUTE
+        static Mesh* create(const std::vector<float>& vertices,
+                            int perVertexSizeInFloat,
+                            const IndexArray& indices,
+                            int /*numIndex*/,
+                            const std::vector<MeshVertexAttrib>& attribs,
+                            int /*attribCount*/)
+        { return create(vertices, perVertexSizeInFloat, indices, attribs); }
+
     /**
      * @lua NA
      */

--- a/cocos/3d/CCMotionStreak3D.cpp
+++ b/cocos/3d/CCMotionStreak3D.cpp
@@ -241,7 +241,7 @@ const BlendFunc& MotionStreak3D::getBlendFunc(void) const
     return _blendFunc;
 }
 
-void MotionStreak3D::setOpacity(GLubyte opacity)
+void MotionStreak3D::setOpacity(GLubyte /*opacity*/)
 {
     CCASSERT(false, "Set opacity no supported");
 }
@@ -376,7 +376,7 @@ void MotionStreak3D::reset()
     _nuPoints = 0;
 }
 
-void MotionStreak3D::onDraw(const Mat4 &transform, uint32_t flags)
+void MotionStreak3D::onDraw(const Mat4 & transform, uint32_t /*flags*/)
 {  
     getGLProgram()->use();
     getGLProgram()->setUniformsForBuiltins(transform);

--- a/cocos/3d/CCMotionStreak3D.h
+++ b/cocos/3d/CCMotionStreak3D.h
@@ -103,8 +103,8 @@ public:
     virtual void setPosition(const Vec2& position) override;
     virtual void setPosition(float x, float y) override;
     virtual void setPosition3D(const Vec3& position) override;
-    virtual void setRotation3D(const Vec3& rotation) override {}
-    virtual void setRotationQuat(const Quaternion& quat) override {}
+    virtual void setRotation3D(const Vec3& /*rotation*/) override {}
+    virtual void setRotationQuat(const Quaternion& /*quat*/) override {}
     
     virtual const Vec2& getPosition() const override;
     virtual void getPosition(float* x, float* y) const override;

--- a/cocos/3d/CCSkybox.cpp
+++ b/cocos/3d/CCSkybox.cpp
@@ -165,7 +165,7 @@ void Skybox::draw(Renderer* renderer, const Mat4& transform, uint32_t flags)
     renderer->addCommand(&_customCommand);
 }
 
-void Skybox::onDraw(const Mat4& transform, uint32_t flags)
+void Skybox::onDraw(const Mat4& transform, uint32_t /*flags*/)
 {
     auto camera = Camera::getVisitingCamera();
     

--- a/cocos/3d/CCTerrain.cpp
+++ b/cocos/3d/CCTerrain.cpp
@@ -126,7 +126,7 @@ void Terrain::draw(cocos2d::Renderer *renderer, const cocos2d::Mat4 &transform, 
     renderer->addCommand(&_customCommand);
 }
 
-void Terrain::onDraw(const Mat4 &transform, uint32_t flags)
+void Terrain::onDraw(const Mat4 &transform, uint32_t /*flags*/)
 {
     auto modelMatrix = getNodeToWorldTransform();
     if(memcmp(&modelMatrix,&_terrainModelMatrix,sizeof(Mat4))!=0)
@@ -979,7 +979,7 @@ void Terrain::Chunk::bindAndDraw()
     CC_INCREMENT_GL_DRAWN_BATCHES_AND_VERTICES(1, _chunkIndices._size);
 }
 
-void Terrain::Chunk::generate(int imgWidth, int imageHei, int m, int n, const unsigned char * data)
+void Terrain::Chunk::generate(int imgWidth, int imageHei, int m, int n, const unsigned char* /*data*/)
 {
     _posY = m;
     _posX = n;

--- a/cocos/audio/linux/AudioEngine-linux.cpp
+++ b/cocos/audio/linux/AudioEngine-linux.cpp
@@ -33,7 +33,8 @@ bool ERRCHECK(FMOD_RESULT result)
 FMOD_RESULT F_CALLBACK channelCallback(FMOD_CHANNELCONTROL *channelcontrol,
                                        FMOD_CHANNELCONTROL_TYPE controltype,
                                        FMOD_CHANNELCONTROL_CALLBACK_TYPE callbacktype,
-                                       void *commandData1, void *commandData2)
+                                       void* /*commandData1*/,
+                                       void* /*commandData2*/)
 {
     if (controltype == FMOD_CHANNELCONTROL_CHANNEL && callbacktype == FMOD_CHANNELCONTROL_CALLBACK_END) {
         g_AudioEngineImpl->onSoundFinished((FMOD::Channel *)channelcontrol);
@@ -316,7 +317,7 @@ int AudioEngineImpl::preload(const std::string& filePath, std::function<void(boo
     return id;
 }
 
-void AudioEngineImpl::update(float dt)
+void AudioEngineImpl::update(float /*dt*/)
 {
     pSystem->update();
 }

--- a/cocos/audio/linux/SimpleAudioEngine.cpp
+++ b/cocos/audio/linux/SimpleAudioEngine.cpp
@@ -147,7 +147,7 @@ void SimpleAudioEngine::setEffectsVolume(float volume)
  *     - no pitch effect on Samsung Galaxy S2 with OpenSL backend enabled;
  *     - no pitch/pan/gain on win32.
  */
-unsigned int SimpleAudioEngine::playEffect(const char* filePath, bool loop, float pitch, float pan, float gain)
+unsigned int SimpleAudioEngine::playEffect(const char* filePath, bool loop, float /*pitch*/, float /*pan*/, float gain)
 {
     return AudioEngine::play2d(filePath, loop, gain);
 }

--- a/cocos/base/CCConfiguration.cpp
+++ b/cocos/base/CCConfiguration.cpp
@@ -325,11 +325,16 @@ Animate3DQuality Configuration::getAnimate3DQuality() const
 //
 // generic getters for properties
 //
-const Value& Configuration::getValue(const std::string& key, const Value& defaultValue) const
+const Value& Configuration::getValue(const std::string & key,
+                                     const Value& defaultValue) const
 {
     auto iter = _valueDict.find(key);
+
     if (iter != _valueDict.cend())
-        return _valueDict.at(key);
+    {
+        return iter->second;
+    }
+
 	return defaultValue;
 }
 

--- a/cocos/base/CCConsole.cpp
+++ b/cocos/base/CCConsole.cpp
@@ -336,7 +336,7 @@ void Console::Command::delSubCommand(const std::string& subCmdName)
     }
 }
 
-void Console::Command::commandHelp(int fd, const std::string& args)
+void Console::Command::commandHelp(int fd, const std::string & /*args*/)
 {
     if (! help.empty()) {
         Console::Utility::mydprintf(fd, "%s\n", help.c_str());
@@ -1002,7 +1002,7 @@ void Console::createCommandVersion()
 // commands
 //
 
-void Console::commandAllocator(int fd, const std::string& args)
+void Console::commandAllocator(int fd, const std::string & /*args*/)
 {
 #if CC_ENABLE_ALLOCATOR_DIAGNOSTICS
     auto info = allocator::AllocatorDiagnostics::instance()->diagnostics();
@@ -1012,7 +1012,7 @@ void Console::commandAllocator(int fd, const std::string& args)
 #endif
 }
 
-void Console::commandConfig(int fd, const std::string& args)
+void Console::commandConfig(int fd, const std::string & /*args*/)
 {
     Scheduler *sched = Director::getInstance()->getScheduler();
     sched->performFunctionInCocosThread( [=](){
@@ -1021,17 +1021,17 @@ void Console::commandConfig(int fd, const std::string& args)
     });
 }
 
-void Console::commandDebugMsg(int fd, const std::string& args)
+void Console::commandDebugMsg(int fd, const std::string & /*args*/)
 {
     Console::Utility::mydprintf(fd, "Debug message is: %s\n", _sendDebugStrings ? "on" : "off");
 }
 
-void Console::commandDebugMsgSubCommandOnOff(int fd, const std::string& args)
+void Console::commandDebugMsgSubCommandOnOff(int /*fd*/, const std::string & args)
 {
     _sendDebugStrings = (args.compare("on") == 0);
 }
 
-void Console::commandDirectorSubCommandPause(int fd, const std::string& args)
+void Console::commandDirectorSubCommandPause(int /*fd*/, const std::string & /*args*/)
 {
     auto director = Director::getInstance();
     Scheduler *sched = director->getScheduler();
@@ -1040,13 +1040,13 @@ void Console::commandDirectorSubCommandPause(int fd, const std::string& args)
     });
 }
 
-void Console::commandDirectorSubCommandResume(int fd, const std::string& args)
+void Console::commandDirectorSubCommandResume(int /*fd*/, const std::string & /*args*/)
 {
     auto director = Director::getInstance();
     director->resume();
 }
 
-void Console::commandDirectorSubCommandStop(int fd, const std::string& args)
+void Console::commandDirectorSubCommandStop(int /*fd*/, const std::string & /*args*/)
 {
     auto director = Director::getInstance();
     Scheduler *sched = director->getScheduler();
@@ -1055,19 +1055,19 @@ void Console::commandDirectorSubCommandStop(int fd, const std::string& args)
     });
 }
 
-void Console::commandDirectorSubCommandStart(int fd, const std::string& args)
+void Console::commandDirectorSubCommandStart(int /*fd*/, const std::string & /*args*/)
 {
     auto director = Director::getInstance();
     director->startAnimation();
 }
 
-void Console::commandDirectorSubCommandEnd(int fd, const std::string& args)
+void Console::commandDirectorSubCommandEnd(int /*fd*/, const std::string & /*args*/)
 {
     auto director = Director::getInstance();
     director->end();
 }
 
-void Console::commandExit(int fd, const std::string& args)
+void Console::commandExit(int fd, const std::string & /*args*/)
 {
     FD_CLR(fd, &_read_set);
     _fds.erase(std::remove(_fds.begin(), _fds.end(), fd), _fds.end());
@@ -1078,23 +1078,23 @@ void Console::commandExit(int fd, const std::string& args)
 #endif
 }
 
-void Console::commandFileUtils(int fd, const std::string& args)
+void Console::commandFileUtils(int fd, const std::string & /*args*/)
 {
     Scheduler *sched = Director::getInstance()->getScheduler();
     sched->performFunctionInCocosThread( std::bind(&Console::printFileUtils, this, fd) );
 }
 
-void Console::commandFileUtilsSubCommandFlush(int fd, const std::string& args)
+void Console::commandFileUtilsSubCommandFlush(int /*fd*/, const std::string & /*args*/)
 {
     FileUtils::getInstance()->purgeCachedEntries();
 }
 
-void Console::commandFps(int fd, const std::string& args)
+void Console::commandFps(int fd, const std::string & /*args*/)
 {
     Console::Utility::mydprintf(fd, "FPS is: %s\n", Director::getInstance()->isDisplayStats() ? "on" : "off");
 }
 
-void Console::commandFpsSubCommandOnOff(int fd, const std::string& args)
+void Console::commandFpsSubCommandOnOff(int /*fd*/, const std::string & args)
 {
     bool state = (args.compare("on") == 0);
     Director *dir = Director::getInstance();
@@ -1102,12 +1102,12 @@ void Console::commandFpsSubCommandOnOff(int fd, const std::string& args)
     sched->performFunctionInCocosThread( std::bind(&Director::setDisplayStats, dir, state));
 }
 
-void Console::commandHelp(int fd, const std::string& args)
+void Console::commandHelp(int fd, const std::string & /*args*/)
 {
     sendHelp(fd, _commands, "\nAvailable commands:\n");
 }
 
-void Console::commandProjection(int fd, const std::string& args)
+void Console::commandProjection(int fd, const std::string & /*args*/)
 {
     auto director = Director::getInstance();
     char buf[20];
@@ -1130,7 +1130,7 @@ void Console::commandProjection(int fd, const std::string& args)
     Console::Utility::mydprintf(fd, "Current projection: %s\n", buf);
 }
 
-void Console::commandProjectionSubCommand2d(int fd, const std::string& args)
+void Console::commandProjectionSubCommand2d(int /*fd*/, const std::string & /*args*/)
 {
     auto director = Director::getInstance();
     Scheduler *sched = director->getScheduler();
@@ -1139,7 +1139,7 @@ void Console::commandProjectionSubCommand2d(int fd, const std::string& args)
     } );
 }
 
-void Console::commandProjectionSubCommand3d(int fd, const std::string& args)
+void Console::commandProjectionSubCommand3d(int /*fd*/, const std::string & /*args*/)
 {
     auto director = Director::getInstance();
     Scheduler *sched = director->getScheduler();
@@ -1148,7 +1148,7 @@ void Console::commandProjectionSubCommand3d(int fd, const std::string& args)
     } );
 }
 
-void Console::commandResolution(int fd, const std::string& args)
+void Console::commandResolution(int /*fd*/, const std::string & args)
 {
     int width, height, policy;
     
@@ -1161,7 +1161,7 @@ void Console::commandResolution(int fd, const std::string& args)
     } );
 }
 
-void Console::commandResolutionSubCommandEmpty(int fd, const std::string& args)
+void Console::commandResolutionSubCommandEmpty(int fd, const std::string & /*args*/)
 {
     auto director = Director::getInstance();
     Size points = director->getWinSize();
@@ -1188,13 +1188,13 @@ void Console::commandResolutionSubCommandEmpty(int fd, const std::string& args)
               );
 }
 
-void Console::commandSceneGraph(int fd, const std::string& args)
+void Console::commandSceneGraph(int fd, const std::string & /*args*/)
 {
     Scheduler *sched = Director::getInstance()->getScheduler();
     sched->performFunctionInCocosThread( std::bind(&Console::printSceneGraphBoot, this, fd) );
 }
 
-void Console::commandTextures(int fd, const std::string& args)
+void Console::commandTextures(int fd, const std::string & /*args*/)
 {
     Scheduler *sched = Director::getInstance()->getScheduler();
     sched->performFunctionInCocosThread( [=](){
@@ -1203,7 +1203,7 @@ void Console::commandTextures(int fd, const std::string& args)
     });
 }
 
-void Console::commandTexturesSubCommandFlush(int fd, const std::string& args)
+void Console::commandTexturesSubCommandFlush(int /*fd*/, const std::string & /*args*/)
 {
     Scheduler *sched = Director::getInstance()->getScheduler();
     sched->performFunctionInCocosThread( [](){
@@ -1211,7 +1211,7 @@ void Console::commandTexturesSubCommandFlush(int fd, const std::string& args)
     });
 }
 
-void Console::commandTouchSubCommandTap(int fd, const std::string& args)
+void Console::commandTouchSubCommandTap(int fd, const std::string & args)
 {
     auto argv = Console::Utility::split(args,' ');
     
@@ -1236,7 +1236,7 @@ void Console::commandTouchSubCommandTap(int fd, const std::string& args)
     }
 }
 
-void Console::commandTouchSubCommandSwipe(int fd, const std::string& args)
+void Console::commandTouchSubCommandSwipe(int fd, const std::string & args)
 {
     auto argv = Console::Utility::split(args,' ');
     
@@ -1337,34 +1337,39 @@ static char invalid_filename_char[] = {':', '/', '\\', '?', '%', '*', '<', '>', 
 
 void Console::commandUpload(int fd)
 {
-    ssize_t n, rc;
     char buf[512], c;
-    char *ptr = buf;
+
     //read file name
-    for( n = 0; n < sizeof(buf) - 1; n++ )
+    size_t n = 0;
+
+    while (n < sizeof(buf) - 1)
     {
-        if( (rc = recv(fd, &c, 1, 0)) ==1 ) 
+        ssize_t rc = recv(fd, &c, 1, 0);
+
+        if (rc == 1) 
         {
-            for(char x : invalid_filename_char)
+            for (char x : invalid_filename_char)
             {
-                if(c == x)
+                if (c == x)
                 {
                     const char err[] = "upload: invalid file name!\n";
                     Console::Utility::sendToConsole(fd, err, strlen(err));
                     return;
                 }
             }
-            if(c == ' ') 
+            
+            if (c == ' ') 
             {
                 break;
             }
-            *ptr++ = c;
+
+            buf[n++] = c;
         } 
-        else if( rc == 0 ) 
+        else if (rc == 0) 
         {
             break;
         } 
-        else if( errno == EINTR ) 
+        else if (errno == EINTR) 
         {
             continue;
         } 
@@ -1373,7 +1378,8 @@ void Console::commandUpload(int fd)
             break;
         }
     }
-    *ptr = 0;
+
+    buf[n] = 0;
 
     static std::string writablePath = FileUtils::getInstance()->getWritablePath();
     std::string filepath = writablePath + std::string(buf);
@@ -1411,7 +1417,7 @@ void Console::commandUpload(int fd)
     fclose(fp);
 }
 
-void Console::commandVersion(int fd, const std::string& args)
+void Console::commandVersion(int fd, const std::string & /*args*/)
 {
     Console::Utility::mydprintf(fd, "%s\n", cocos2dVersion());
 }

--- a/cocos/base/CCDirector.cpp
+++ b/cocos/base/CCDirector.cpp
@@ -223,14 +223,23 @@ void Director::setDefaultValues(void)
 
     // GL projection
     std::string projection = conf->getValue("cocos2d.x.gl.projection", Value("3d")).asString();
+
     if (projection == "3d")
+    {
         _projection = Projection::_3D;
+    }
     else if (projection == "2d")
+    {
         _projection = Projection::_2D;
+    }
     else if (projection == "custom")
+    {
         _projection = Projection::CUSTOM;
+    }
     else
+    {
         CCASSERT(false, "Invalid projection value");
+    }
 
     // Default pixel format for PNG images with alpha
     std::string pixel_format = conf->getValue("cocos2d.x.texture.pixel_format_for_png", Value("rgba8888")).asString();

--- a/cocos/base/allocator/CCAllocatorStrategyDefault.h
+++ b/cocos/base/allocator/CCAllocatorStrategyDefault.h
@@ -46,7 +46,7 @@ public:
         return malloc(size);
     }
     
-    CC_ALLOCATOR_INLINE void deallocate(void* address, size_t size = 0)
+    CC_ALLOCATOR_INLINE void deallocate(void* address, size_t /*size*/ = 0)
     {
         if (nullptr != address)
             free(address);

--- a/cocos/base/allocator/CCAllocatorStrategyFixedBlock.h
+++ b/cocos/base/allocator/CCAllocatorStrategyFixedBlock.h
@@ -80,6 +80,8 @@ public:
         _highestCount = 0;
         AllocatorDiagnostics::instance()->trackAllocator(this);
         AllocatorBase::setTag(tag ? tag : typeid(AllocatorStrategyFixedBlock).name());
+#else
+        CC_UNUSED_PARAM(tag);
 #endif
     }
     

--- a/cocos/base/allocator/CCAllocatorStrategyGlobalSmallBlock.h
+++ b/cocos/base/allocator/CCAllocatorStrategyGlobalSmallBlock.h
@@ -125,7 +125,7 @@ public:
     
     virtual ~AllocatorStrategyGlobalSmallBlock()
     {
-        for (int i = 0; i <= kMaxSmallBlockPower; ++i)
+        for (unsigned i = 0; i <= kMaxSmallBlockPower; ++i)
             if (_smallBlockAllocators[i])
                 ccAllocatorGlobal.deallocate(_smallBlockAllocators[i]);
         

--- a/cocos/base/ccUTF8.cpp
+++ b/cocos/base/ccUTF8.cpp
@@ -482,10 +482,10 @@ unsigned short* cc_utf8_to_utf16(const char* str_old, int length/* = -1*/, int* 
     return ret;
 }
 
-char * cc_utf16_to_utf8 (const unsigned short  *str,
-                  int             len,
-                  long            *items_read,
-                  long            *items_written)
+char * cc_utf16_to_utf8 (const unsigned short* str,
+                         int                   len,
+                         long*                 /*items_read*/,
+                         long*                 /*items_written*/)
 {
     if (str == nullptr)
         return nullptr;

--- a/cocos/deprecated/CCDeprecated.h
+++ b/cocos/deprecated/CCDeprecated.h
@@ -1080,9 +1080,9 @@ CC_DEPRECATED_ATTRIBUTE inline void CC_DLL ccGLEnableVertexAttribs(unsigned int 
 CC_DEPRECATED_ATTRIBUTE inline void CC_DLL ccGLBindTexture2D(GLuint textureId) { GL::bindTexture2D(textureId); }
 CC_DEPRECATED_ATTRIBUTE inline void CC_DLL ccGLBindTexture2DN(GLuint textureUnit, GLuint textureId) { GL::bindTexture2DN(textureUnit, textureId); }
 CC_DEPRECATED_ATTRIBUTE inline void CC_DLL ccGLDeleteTexture(GLuint textureId) { GL::deleteTexture(textureId); }
-CC_DEPRECATED_ATTRIBUTE inline void CC_DLL ccGLDeleteTextureN(GLuint textureUnit, GLuint textureId) { GL::deleteTexture(textureId); }
+CC_DEPRECATED_ATTRIBUTE inline void CC_DLL ccGLDeleteTextureN(GLuint /*textureUnit*/, GLuint textureId) { GL::deleteTexture(textureId); }
 CC_DEPRECATED_ATTRIBUTE inline void CC_DLL ccGLBindVAO(GLuint vaoId) { GL::bindVAO(vaoId); }
-CC_DEPRECATED_ATTRIBUTE inline void CC_DLL ccGLEnable( int flags ) { /* ignore */ };
+CC_DEPRECATED_ATTRIBUTE inline void CC_DLL ccGLEnable( int /*flags*/ ) { /* ignore */ };
 CC_DEPRECATED_ATTRIBUTE typedef int ccGLServerState;
 
 CC_DEPRECATED_ATTRIBUTE typedef Data CCData;

--- a/cocos/editor-support/cocosbuilder/CCBAnimationManager.cpp
+++ b/cocos/editor-support/cocosbuilder/CCBAnimationManager.cpp
@@ -999,7 +999,7 @@ CCBSetSpriteFrame* CCBSetSpriteFrame::reverse() const
 	return this->clone();
 }
 
-void CCBSetSpriteFrame::update(float time)
+void CCBSetSpriteFrame::update(float /*time*/)
 {
     static_cast<Sprite*>(_target)->setSpriteFrame(_spriteFrame);
 }
@@ -1050,7 +1050,7 @@ CCBSoundEffect* CCBSoundEffect::reverse() const
 	return this->clone();
 }
 
-void CCBSoundEffect::update(float time)
+void CCBSoundEffect::update(float /*time*/)
 {
     CocosDenshion::SimpleAudioEngine::getInstance()->playEffect(_soundFile.c_str());
 }

--- a/cocos/editor-support/cocosbuilder/CCBMemberVariableAssigner.h
+++ b/cocos/editor-support/cocosbuilder/CCBMemberVariableAssigner.h
@@ -29,7 +29,7 @@ class CC_DLL CCBMemberVariableAssigner {
          * @js NA
          * @lua NA
          */
-        virtual ~CCBMemberVariableAssigner() {};
+        virtual ~CCBMemberVariableAssigner() {}
 
         /**
          *  The callback function of assigning member variable.
@@ -49,7 +49,10 @@ class CC_DLL CCBMemberVariableAssigner {
          *  @param value                The value of the property.
          *  @return Whether the assignment was successful.
          */
-        virtual bool onAssignCCBCustomProperty(cocos2d::Ref* target, const char* memberVariableName, const cocos2d::Value& value) { return false; };
+        virtual bool onAssignCCBCustomProperty(cocos2d::Ref* /*target*/,
+                                               const char* /*memberVariableName*/,
+                                               const cocos2d::Value & /*value*/)
+        { return false; }
 };
 
 }

--- a/cocos/editor-support/cocosbuilder/CCBReader.cpp
+++ b/cocos/editor-support/cocosbuilder/CCBReader.cpp
@@ -348,7 +348,9 @@ bool CCBReader::readHeader()
     int magicBytes = *((int*)(this->_bytes + this->_currentByte));
     this->_currentByte += 4;
 
-    if(CC_SWAP_INT32_BIG_TO_HOST(magicBytes) != (*reinterpret_cast<const int*>("ccbi"))) {
+    if (CC_SWAP_INT32_BIG_TO_HOST(magicBytes)
+        != *reinterpret_cast<const uint32_t*>("ccbi"))
+    {
         return false; 
     }
 

--- a/cocos/editor-support/cocosbuilder/CCBSelectorResolver.h
+++ b/cocos/editor-support/cocosbuilder/CCBSelectorResolver.h
@@ -24,9 +24,9 @@ class CC_DLL CCBSelectorResolver {
      * @js NA
      * @lua NA
      */
-    virtual ~CCBSelectorResolver() {};
+    virtual ~CCBSelectorResolver() {}
     virtual cocos2d::SEL_MenuHandler onResolveCCBCCMenuItemSelector(cocos2d::Ref * pTarget, const char* pSelectorName) = 0;
-    virtual cocos2d::SEL_CallFuncN onResolveCCBCCCallFuncSelector(cocos2d::Ref * pTarget, const char* pSelectorName) { return NULL; };
+    virtual cocos2d::SEL_CallFuncN onResolveCCBCCCallFuncSelector(cocos2d::Ref* /*pTarget*/, const char* /*pSelectorName*/) { return NULL; }
     virtual cocos2d::extension::Control::Handler onResolveCCBCCControlSelector(cocos2d::Ref * pTarget, const char* pSelectorName) = 0;
 };
 
@@ -37,7 +37,7 @@ public:
      * @js NA
      * @lua NA
      */
-    virtual ~CCBScriptOwnerProtocol() {};
+    virtual ~CCBScriptOwnerProtocol() {}
     virtual CCBSelectorResolver * createNew() = 0;
 };
 

--- a/cocos/editor-support/cocosbuilder/CCMenuLoader.h
+++ b/cocos/editor-support/cocosbuilder/CCMenuLoader.h
@@ -24,7 +24,8 @@ public:
     CCB_STATIC_NEW_AUTORELEASE_OBJECT_METHOD(MenuLoader, loader);
 
 protected:
-    virtual cocos2d::Menu * createNode(cocos2d::Node * pParent, cocosbuilder::CCBReader * ccbReader)
+    virtual cocos2d::Menu * createNode(cocos2d::Node* /*pParent*/,
+                                       cocosbuilder::CCBReader* /*ccbReader*/)
     {
         cocos2d::Menu * pMenu = cocos2d::Menu::create();
         

--- a/cocos/editor-support/cocosbuilder/CCNode+CCBRelativePositioning.cpp
+++ b/cocos/editor-support/cocosbuilder/CCNode+CCBRelativePositioning.cpp
@@ -5,7 +5,10 @@ using namespace cocos2d;
 
 namespace cocosbuilder {
 
-CC_DLL Vec2 getAbsolutePosition(const Vec2 &pt, CCBReader::PositionType type, const Size &containerSize, const std::string& propName)
+CC_DLL Vec2 getAbsolutePosition(const Vec2 & pt,
+                                CCBReader::PositionType type,
+                                const Size & containerSize,
+                                const std::string & /*propName*/)
 {
     Vec2 absPt;
     if (type == CCBReader::PositionType::RELATIVE_BOTTOM_LEFT)
@@ -43,7 +46,11 @@ CC_DLL Vec2 getAbsolutePosition(const Vec2 &pt, CCBReader::PositionType type, co
     return absPt;
 }
 
-CC_DLL void setRelativeScale(Node *pNode, float scaleX, float scaleY, CCBReader::ScaleType type, const std::string& propName)
+CC_DLL void setRelativeScale(Node* pNode,
+                             float scaleX,
+                             float scaleY,
+                             CCBReader::ScaleType type,
+                             const std::string & /*propName*/)
 {
     CCASSERT(pNode, "pNode should not be null");
     

--- a/cocos/editor-support/cocosbuilder/CCNodeLoader.cpp
+++ b/cocos/editor-support/cocosbuilder/CCNodeLoader.cpp
@@ -397,7 +397,7 @@ Vec2 NodeLoader::parsePropTypePosition(Node * pNode, Node * pParent, CCBReader *
     return pt;
 }
 
-Vec2 NodeLoader::parsePropTypePoint(Node * pNode, Node * pParent, CCBReader * ccbReader) 
+Vec2 NodeLoader::parsePropTypePoint(Node* /*pNode*/, Node* /*pParent*/, CCBReader* ccbReader) 
 {
     float x = ccbReader->readFloat();
     float y = ccbReader->readFloat();
@@ -405,14 +405,14 @@ Vec2 NodeLoader::parsePropTypePoint(Node * pNode, Node * pParent, CCBReader * cc
     return Vec2(x, y);
 }
 
-Vec2 NodeLoader::parsePropTypePointLock(Node * pNode, Node * pParent, CCBReader * ccbReader) {
+Vec2 NodeLoader::parsePropTypePointLock(Node* /*pNode*/, Node* /*pParent*/, CCBReader * ccbReader) {
     float x = ccbReader->readFloat();
     float y = ccbReader->readFloat();
 
     return Vec2(x, y);
 }
 
-Size NodeLoader::parsePropTypeSize(Node * pNode, Node * pParent, CCBReader * ccbReader) {
+Size NodeLoader::parsePropTypeSize(Node* /*pNode*/, Node* pParent, CCBReader * ccbReader) {
     float width = ccbReader->readFloat();
     float height = ccbReader->readFloat();
 
@@ -469,7 +469,7 @@ Size NodeLoader::parsePropTypeSize(Node * pNode, Node * pParent, CCBReader * ccb
 
 
 
-float * NodeLoader::parsePropTypeFloatXY(Node * pNode, Node * pParent, CCBReader * ccbReader) {
+float * NodeLoader::parsePropTypeFloatXY(Node* /*pNode*/, Node* /*pParent*/, CCBReader * ccbReader) {
     float x = ccbReader->readFloat();
     float y = ccbReader->readFloat();
 
@@ -480,7 +480,7 @@ float * NodeLoader::parsePropTypeFloatXY(Node * pNode, Node * pParent, CCBReader
     return floatXY;
 }
 
-float * NodeLoader::parsePropTypeScaleLock(Node * pNode, Node * pParent, CCBReader * ccbReader, const char *pPropertyName) {
+float * NodeLoader::parsePropTypeScaleLock(Node* pNode, Node* /*pParent*/, CCBReader * ccbReader, const char *pPropertyName) {
     float x = ccbReader->readFloat();
     float y = ccbReader->readFloat();
     
@@ -511,11 +511,11 @@ float * NodeLoader::parsePropTypeScaleLock(Node * pNode, Node * pParent, CCBRead
     return scaleLock;
 }
 
-float NodeLoader::parsePropTypeFloat(Node * pNode, Node * pParent, CCBReader * ccbReader) {
+float NodeLoader::parsePropTypeFloat(Node* /*pNode*/, Node* /*pParent*/, CCBReader* ccbReader) {
     return ccbReader->readFloat();
 }
 
-float NodeLoader::parsePropTypeDegrees(Node * pNode, Node * pParent, CCBReader * ccbReader, const char *pPropertyName) {
+float NodeLoader::parsePropTypeDegrees(Node * pNode, Node* /*pParent*/, CCBReader * ccbReader, const char *pPropertyName) {
     float ret = ccbReader->readFloat();
     if (ccbReader->getAnimatedProperties()->find(pPropertyName) != ccbReader->getAnimatedProperties()->end())
     {
@@ -525,7 +525,7 @@ float NodeLoader::parsePropTypeDegrees(Node * pNode, Node * pParent, CCBReader *
     return ret;
 }
 
-float NodeLoader::parsePropTypeFloatScale(Node * pNode, Node * pParent, CCBReader * ccbReader) 
+float NodeLoader::parsePropTypeFloatScale(Node* /*pNode*/, Node* /*pParent*/, CCBReader * ccbReader) 
 {
     float f = ccbReader->readFloat();
 
@@ -539,17 +539,17 @@ float NodeLoader::parsePropTypeFloatScale(Node * pNode, Node * pParent, CCBReade
     return f;
 }
 
-int NodeLoader::parsePropTypeInteger(Node * pNode, Node * pParent, CCBReader * ccbReader) 
+int NodeLoader::parsePropTypeInteger(Node* /*pNode*/, Node* /*pParent*/, CCBReader * ccbReader) 
 {
     return ccbReader->readInt(true);
 }
 
-int NodeLoader::parsePropTypeIntegerLabeled(Node * pNode, Node * pParent, CCBReader * ccbReader) 
+int NodeLoader::parsePropTypeIntegerLabeled(Node* /*pNode*/, Node* /*pParent*/, CCBReader * ccbReader) 
 {
     return ccbReader->readInt(true);
 }
 
-float * NodeLoader::parsePropTypeFloatVar(Node * pNode, Node * pParent, CCBReader * ccbReader) 
+float * NodeLoader::parsePropTypeFloatVar(Node* /*pNode*/, Node* /*pParent*/, CCBReader * ccbReader) 
 {
     float f = ccbReader->readFloat();
     float fVar = ccbReader->readFloat();
@@ -561,7 +561,7 @@ float * NodeLoader::parsePropTypeFloatVar(Node * pNode, Node * pParent, CCBReade
     return arr;
 }
 
-bool NodeLoader::parsePropTypeCheck(Node * pNode, Node * pParent, CCBReader * ccbReader, const char *pPropertyName) 
+bool NodeLoader::parsePropTypeCheck(Node* pNode, Node* /*pParent*/, CCBReader * ccbReader, const char *pPropertyName) 
 {
     bool ret = ccbReader->readBool();
     
@@ -574,7 +574,7 @@ bool NodeLoader::parsePropTypeCheck(Node * pNode, Node * pParent, CCBReader * cc
 }
 
 
-SpriteFrame * NodeLoader::parsePropTypeSpriteFrame(Node * pNode, Node * pParent, CCBReader * ccbReader, const char *pPropertyName) 
+SpriteFrame * NodeLoader::parsePropTypeSpriteFrame(Node * pNode, Node* /*pParent*/, CCBReader * ccbReader, const char *pPropertyName) 
 {
     std::string spriteSheet = ccbReader->readCachedString();
     std::string spriteFile = ccbReader->readCachedString();
@@ -614,7 +614,7 @@ SpriteFrame * NodeLoader::parsePropTypeSpriteFrame(Node * pNode, Node * pParent,
     return spriteFrame;
 }
 
-Animation * NodeLoader::parsePropTypeAnimation(Node * pNode, Node * pParent, CCBReader * ccbReader) {
+Animation * NodeLoader::parsePropTypeAnimation(Node* /*pNode*/, Node* /*pParent*/, CCBReader * ccbReader) {
     std::string animationFile = ccbReader->getCCBRootPath() + ccbReader->readCachedString();
     std::string animation = ccbReader->readCachedString();
     
@@ -638,7 +638,7 @@ Animation * NodeLoader::parsePropTypeAnimation(Node * pNode, Node * pParent, CCB
     return ccAnimation;
 }
 
-Texture2D * NodeLoader::parsePropTypeTexture(Node * pNode, Node * pParent, CCBReader * ccbReader) {
+Texture2D * NodeLoader::parsePropTypeTexture(Node* /*pNode*/, Node* /*pParent*/, CCBReader * ccbReader) {
     std::string spriteFile = ccbReader->getCCBRootPath() + ccbReader->readCachedString();
     
     if (!spriteFile.empty())
@@ -651,7 +651,7 @@ Texture2D * NodeLoader::parsePropTypeTexture(Node * pNode, Node * pParent, CCBRe
     }
 }
 
-unsigned char NodeLoader::parsePropTypeByte(Node * pNode, Node * pParent, CCBReader * ccbReader, const char *pPropertyName) 
+unsigned char NodeLoader::parsePropTypeByte(Node * pNode, Node* /*pParent*/, CCBReader * ccbReader, const char *pPropertyName) 
 {
     unsigned char ret = ccbReader->readByte();
     
@@ -663,7 +663,7 @@ unsigned char NodeLoader::parsePropTypeByte(Node * pNode, Node * pParent, CCBRea
     return ret;
 }
 
-Color3B NodeLoader::parsePropTypeColor3(Node * pNode, Node * pParent, CCBReader * ccbReader, const char *pPropertyName) {
+Color3B NodeLoader::parsePropTypeColor3(Node * pNode, Node* /*pParent*/, CCBReader * ccbReader, const char *pPropertyName) {
     unsigned char r = ccbReader->readByte();
     unsigned char g = ccbReader->readByte();
     unsigned char b = ccbReader->readByte();
@@ -682,7 +682,7 @@ Color3B NodeLoader::parsePropTypeColor3(Node * pNode, Node * pParent, CCBReader 
     return color;
 }
 
-Color4F * NodeLoader::parsePropTypeColor4FVar(Node * pNode, Node * pParent, CCBReader * ccbReader) {
+Color4F * NodeLoader::parsePropTypeColor4FVar(Node* /*pNode*/, Node* /*pParent*/, CCBReader * ccbReader) {
     float red = ccbReader->readFloat();
     float green = ccbReader->readFloat();
     float blue = ccbReader->readFloat();
@@ -706,7 +706,7 @@ Color4F * NodeLoader::parsePropTypeColor4FVar(Node * pNode, Node * pParent, CCBR
     return colors;
 }
 
-bool * NodeLoader::parsePropTypeFlip(Node * pNode, Node * pParent, CCBReader * ccbReader) {
+bool * NodeLoader::parsePropTypeFlip(Node* /*pNode*/, Node* /*pParent*/, CCBReader * ccbReader) {
     bool flipX = ccbReader->readBool();
     bool flipY = ccbReader->readBool();
 
@@ -717,7 +717,7 @@ bool * NodeLoader::parsePropTypeFlip(Node * pNode, Node * pParent, CCBReader * c
     return arr;
 }
 
-BlendFunc NodeLoader::parsePropTypeBlendFunc(Node * pNode, Node * pParent, CCBReader * ccbReader) 
+BlendFunc NodeLoader::parsePropTypeBlendFunc(Node* /*pNode*/, Node* /*pParent*/, CCBReader * ccbReader) 
 {
     int source = ccbReader->readInt(false);
     int destination = ccbReader->readInt(false);
@@ -729,20 +729,20 @@ BlendFunc NodeLoader::parsePropTypeBlendFunc(Node * pNode, Node * pParent, CCBRe
     return blendFunc;
 }
 
-std::string NodeLoader::parsePropTypeFntFile(Node * pNode, Node * pParent, CCBReader * ccbReader) 
+std::string NodeLoader::parsePropTypeFntFile(Node* /*pNode*/, Node* /*pParent*/, CCBReader * ccbReader) 
 {
     return ccbReader->readCachedString();
 }
 
-std::string NodeLoader::parsePropTypeString(Node * pNode, Node * pParent, CCBReader * ccbReader) {
+std::string NodeLoader::parsePropTypeString(Node* /*pNode*/, Node* /*pParent*/, CCBReader * ccbReader) {
     return ccbReader->readCachedString();
 }
 
-std::string NodeLoader::parsePropTypeText(Node * pNode, Node * pParent, CCBReader * ccbReader) {
+std::string NodeLoader::parsePropTypeText(Node* /*pNode*/, Node* /*pParent*/, CCBReader * ccbReader) {
     return ccbReader->readCachedString();
 }
 
-std::string NodeLoader::parsePropTypeFontTTF(Node * pNode, Node * pParent, CCBReader * ccbReader) {
+std::string NodeLoader::parsePropTypeFontTTF(Node* /*pNode*/, Node* /*pParent*/, CCBReader * ccbReader) {
     std::string fontTTF = ccbReader->readCachedString();
 
     // String * ttfEnding = String::create(".ttf");
@@ -759,7 +759,7 @@ std::string NodeLoader::parsePropTypeFontTTF(Node * pNode, Node * pParent, CCBRe
     return fontTTF;
 }
 
-BlockData * NodeLoader::parsePropTypeBlock(Node * pNode, Node * pParent, CCBReader * ccbReader)
+BlockData * NodeLoader::parsePropTypeBlock(Node * pNode, Node* /*pParent*/, CCBReader * ccbReader)
 {
     std::string selectorName = ccbReader->readCachedString();
     CCBReader::TargetType selectorTarget = static_cast<CCBReader::TargetType>(ccbReader->readInt(false));
@@ -839,7 +839,7 @@ BlockData * NodeLoader::parsePropTypeBlock(Node * pNode, Node * pParent, CCBRead
     return nullptr;
 }
 
-BlockControlData * NodeLoader::parsePropTypeBlockControl(Node * pNode, Node * pParent, CCBReader * ccbReader)
+BlockControlData * NodeLoader::parsePropTypeBlockControl(Node * pNode, Node* /*pParent*/, CCBReader * ccbReader)
 {
     std::string selectorName = ccbReader->readCachedString();
     CCBReader::TargetType selectorTarget = static_cast<CCBReader::TargetType>(ccbReader->readInt(false));
@@ -922,7 +922,7 @@ BlockControlData * NodeLoader::parsePropTypeBlockControl(Node * pNode, Node * pP
     return nullptr;
 }
 
-Node * NodeLoader::parsePropTypeCCBFile(Node * pNode, Node * pParent, CCBReader * pCCBReader) {
+Node * NodeLoader::parsePropTypeCCBFile(Node* /*pNode*/, Node * pParent, CCBReader * pCCBReader) {
     std::string ccbFileName = pCCBReader->getCCBRootPath() + pCCBReader->readCachedString();
 
     /* Change path extension to .ccbi. */
@@ -1004,7 +1004,7 @@ Node * NodeLoader::parsePropTypeCCBFile(Node * pNode, Node * pParent, CCBReader 
 
 
 
-void NodeLoader::onHandlePropTypePosition(Node * pNode, Node * pParent, const char* pPropertyName, Vec2 pPosition, CCBReader * ccbReader) {
+void NodeLoader::onHandlePropTypePosition(Node * pNode, Node* /*pParent*/, const char* pPropertyName, Vec2 pPosition, CCBReader* /*ccbReader*/) {
     if(strcmp(pPropertyName, PROPERTY_POSITION) == 0) {
         pNode->setPosition(pPosition);
     } else {
@@ -1012,7 +1012,12 @@ void NodeLoader::onHandlePropTypePosition(Node * pNode, Node * pParent, const ch
     }
 }
 
-void NodeLoader::onHandlePropTypePoint(Node * pNode, Node * pParent, const char* pPropertyName, Vec2 pPoint, CCBReader * ccbReader) {
+void NodeLoader::onHandlePropTypePoint(Node* pNode,
+                                       Node* /*pParent*/,
+                                       const char* pPropertyName,
+                                       Vec2 pPoint,
+                                       CCBReader* /*ccbReader*/)
+{
     if(strcmp(pPropertyName, PROPERTY_ANCHORPOINT) == 0) {
         pNode->setAnchorPoint(pPoint);
     } else {
@@ -1020,11 +1025,20 @@ void NodeLoader::onHandlePropTypePoint(Node * pNode, Node * pParent, const char*
     }
 }
 
-void NodeLoader::onHandlePropTypePointLock(Node * pNode, Node * pParent, const char* pPropertyName, Vec2 pPointLock, CCBReader * ccbReader) {
+void NodeLoader::onHandlePropTypePointLock(Node* /*pNode*/,
+                                           Node* /*pParent*/,
+                                           const char* pPropertyName,
+                                           Vec2 /*pPointLock*/,
+                                           CCBReader* /*ccbReader*/) {
     ASSERT_FAIL_UNEXPECTED_PROPERTY(pPropertyName);
 }
 
-void NodeLoader::onHandlePropTypeSize(Node * pNode, Node * pParent, const char* pPropertyName, Size pSize, CCBReader * ccbReader) {
+void NodeLoader::onHandlePropTypeSize(Node* pNode,
+                                      Node* /*pParent*/,
+                                      const char* pPropertyName,
+                                      Size pSize,
+                                      CCBReader* /*ccbReader*/)
+{
     if(strcmp(pPropertyName, PROPERTY_CONTENTSIZE) == 0) {
         pNode->setContentSize(pSize);
     } else {
@@ -1032,7 +1046,7 @@ void NodeLoader::onHandlePropTypeSize(Node * pNode, Node * pParent, const char* 
     }
 }
 
-void NodeLoader::onHandlePropTypeFloatXY(Node * pNode, Node * pParent, const char* pPropertyName, float * pFloat, CCBReader * ccbReader) {
+void NodeLoader::onHandlePropTypeFloatXY(Node * pNode, Node* /*pParent*/, const char* pPropertyName, float * pFloat, CCBReader* /*ccbReader*/) {
     if(strcmp(pPropertyName, PROPERTY_SKEW) == 0) {
         pNode->setSkewX(pFloat[0]);
         pNode->setSkewY(pFloat[1]);
@@ -1042,7 +1056,7 @@ void NodeLoader::onHandlePropTypeFloatXY(Node * pNode, Node * pParent, const cha
 }
 
 
-void NodeLoader::onHandlePropTypeScaleLock(Node * pNode, Node * pParent, const char* pPropertyName, float * pScaleLock, CCBReader * ccbReader) {
+void NodeLoader::onHandlePropTypeScaleLock(Node * pNode, Node* /*pParent*/, const char* pPropertyName, float * pScaleLock, CCBReader* /*ccbReader*/) {
     if(strcmp(pPropertyName, PROPERTY_SCALE) == 0) {
         pNode->setScaleX(pScaleLock[0]);
         pNode->setScaleY(pScaleLock[1]);
@@ -1051,14 +1065,14 @@ void NodeLoader::onHandlePropTypeScaleLock(Node * pNode, Node * pParent, const c
     }
 }
 
-void NodeLoader::onHandlePropTypeFloat(Node * pNode, Node * pParent, const char* pPropertyName, float pFloat, CCBReader * ccbReader) {
+void NodeLoader::onHandlePropTypeFloat(Node* /*pNode*/, Node* /*pParent*/, const char* pPropertyName, float pFloat, CCBReader* /*ccbReader*/) {
 //    ASSERT_FAIL_UNEXPECTED_PROPERTY(pPropertyName);
     // It may be a custom property, add it to custom property dictionary.
     _customProperties[pPropertyName] = Value(pFloat);
 }
 
 
-void NodeLoader::onHandlePropTypeDegrees(Node * pNode, Node * pParent, const char* pPropertyName, float pDegrees, CCBReader * ccbReader) {
+void NodeLoader::onHandlePropTypeDegrees(Node * pNode, Node* /*pParent*/, const char* pPropertyName, float pDegrees, CCBReader* /*ccbReader*/) {
     if(strcmp(pPropertyName, PROPERTY_ROTATION) == 0) {
         pNode->setRotation(pDegrees);
     } else if(strcmp(pPropertyName, PROPERTY_ROTATIONX) == 0) {
@@ -1071,11 +1085,16 @@ void NodeLoader::onHandlePropTypeDegrees(Node * pNode, Node * pParent, const cha
     }
 }
 
-void NodeLoader::onHandlePropTypeFloatScale(Node * pNode, Node * pParent, const char* pPropertyName, float pFloatScale, CCBReader * ccbReader) {
+void NodeLoader::onHandlePropTypeFloatScale(Node* /*pNode*/,
+                                            Node* /*pParent*/,
+                                            const char* pPropertyName,
+                                            float /*pFloatScale*/,
+                                            CCBReader* /*ccbReader*/)
+{
     ASSERT_FAIL_UNEXPECTED_PROPERTY(pPropertyName);
 }
 
-void NodeLoader::onHandlePropTypeInteger(Node * pNode, Node * pParent, const char* pPropertyName, int pInteger, CCBReader * ccbReader) {
+void NodeLoader::onHandlePropTypeInteger(Node * pNode, Node* /*pParent*/, const char* pPropertyName, int pInteger, CCBReader* /*ccbReader*/) {
     if(strcmp(pPropertyName, PROPERTY_TAG) == 0) {
         pNode->setTag(pInteger);
     } else {
@@ -1085,15 +1104,25 @@ void NodeLoader::onHandlePropTypeInteger(Node * pNode, Node * pParent, const cha
     }
 }
 
-void NodeLoader::onHandlePropTypeIntegerLabeled(Node * pNode, Node * pParent, const char* pPropertyName, int pIntegerLabeled, CCBReader * ccbReader) {
+void NodeLoader::onHandlePropTypeIntegerLabeled(Node* /*pNode*/,
+                                                Node* /*pParent*/,
+                                                const char* pPropertyName,
+                                                int /*pIntegerLabeled*/,
+                                                CCBReader* /*ccbReader*/)
+{
     ASSERT_FAIL_UNEXPECTED_PROPERTY(pPropertyName);
 }
 
-void NodeLoader::onHandlePropTypeFloatVar(Node * pNode, Node * pParent, const char* pPropertyName, float * pFloatVar, CCBReader * ccbReader) {
+void NodeLoader::onHandlePropTypeFloatVar(Node* /*pNode*/,
+                                          Node* /*pParent*/,
+                                          const char* pPropertyName,
+                                          float* /*pFloatVar*/,
+                                          CCBReader* /*ccbReader*/)
+{
     ASSERT_FAIL_UNEXPECTED_PROPERTY(pPropertyName);
 }
 
-void NodeLoader::onHandlePropTypeCheck(Node * pNode, Node * pParent, const char* pPropertyName, bool pCheck, CCBReader * ccbReader) {
+void NodeLoader::onHandlePropTypeCheck(Node * pNode, Node* /*pParent*/, const char* pPropertyName, bool pCheck, CCBReader* /*ccbReader*/) {
     if(strcmp(pPropertyName, PROPERTY_VISIBLE) == 0) {
         pNode->setVisible(pCheck);
     } else if(strcmp(pPropertyName, PROPERTY_IGNOREANCHORPOINTFORPOSITION) == 0) {
@@ -1105,65 +1134,140 @@ void NodeLoader::onHandlePropTypeCheck(Node * pNode, Node * pParent, const char*
     }
 }
 
-void NodeLoader::onHandlePropTypeSpriteFrame(Node * pNode, Node * pParent, const char* pPropertyName, SpriteFrame * pSpriteFrame, CCBReader * ccbReader) {
+void NodeLoader::onHandlePropTypeSpriteFrame(Node* /*pNode*/,
+                                             Node* /*pParent*/,
+                                             const char* pPropertyName,
+                                             SpriteFrame* /*pSpriteFrame*/,
+                                             CCBReader* /*ccbReader*/)
+{
     ASSERT_FAIL_UNEXPECTED_PROPERTY(pPropertyName);
 }
 
-void NodeLoader::onHandlePropTypeAnimation(Node * pNode, Node * pParent, const char* pPropertyName, Animation * pAnimation, CCBReader * ccbReader) {
+void NodeLoader::onHandlePropTypeAnimation(Node* /*pNode*/,
+                                           Node* /*pParent*/,
+                                           const char* pPropertyName,
+                                           Animation* /*pAnimation*/,
+                                           CCBReader* /*ccbReader*/)
+{
     ASSERT_FAIL_UNEXPECTED_PROPERTY(pPropertyName);
 }
 
-void NodeLoader::onHandlePropTypeTexture(Node * pNode, Node * pParent, const char* pPropertyName, Texture2D * pTexture2D, CCBReader * ccbReader) {
+void NodeLoader::onHandlePropTypeTexture(Node* /*pNode*/,
+                                         Node* /*pParent*/,
+                                         const char* pPropertyName,
+                                         Texture2D* /*pTexture2D*/,
+                                         CCBReader* /*ccbReader*/)
+{
     ASSERT_FAIL_UNEXPECTED_PROPERTY(pPropertyName);
 }
 
-void NodeLoader::onHandlePropTypeByte(Node * pNode, Node * pParent, const char* pPropertyName, unsigned char pByte, CCBReader * ccbReader) {
+void NodeLoader::onHandlePropTypeByte(Node* /*pNode*/,
+                                      Node* /*pParent*/,
+                                      const char* pPropertyName,
+                                      unsigned char /*pByte*/,
+                                      CCBReader* /*ccbReader*/)
+{
     ASSERT_FAIL_UNEXPECTED_PROPERTY(pPropertyName);
 }
 
-void NodeLoader::onHandlePropTypeColor3(Node * pNode, Node * pParent, const char* pPropertyName, Color3B pColor3B, CCBReader * ccbReader) {
+void NodeLoader::onHandlePropTypeColor3(Node* /*pNode*/,
+                                        Node* /*pParent*/,
+                                        const char* pPropertyName,
+                                        Color3B /*pColor3B*/,
+                                        CCBReader* /*ccbReader*/)
+{
     ASSERT_FAIL_UNEXPECTED_PROPERTY(pPropertyName);
 }
 
-void NodeLoader::onHandlePropTypeColor4FVar(Node * pNode, Node * pParent, const char* pPropertyName, Color4F * pColor4FVar, CCBReader * ccbReader) {
+void NodeLoader::onHandlePropTypeColor4FVar(Node* /*pNode*/,
+                                            Node* /*pParent*/,
+                                            const char* pPropertyName,
+                                            Color4F * /*pColor4FVar*/,
+                                            CCBReader* /*ccbReader*/)
+{
     ASSERT_FAIL_UNEXPECTED_PROPERTY(pPropertyName);
 }
 
-void NodeLoader::onHandlePropTypeFlip(Node * pNode, Node * pParent, const char* pPropertyName, bool * pFlip, CCBReader * ccbReader) {
+void NodeLoader::onHandlePropTypeFlip(Node* /*pNode*/,
+                                      Node* /*pParent*/,
+                                      const char* pPropertyName,
+                                      bool* /*pFlip*/,
+                                      CCBReader* /*ccbReader*/)
+{
     ASSERT_FAIL_UNEXPECTED_PROPERTY(pPropertyName);
 }
 
-void NodeLoader::onHandlePropTypeBlendFunc(Node * pNode, Node * pParent, const char* pPropertyName, BlendFunc pBlendFunc, CCBReader * ccbReader) {
+void NodeLoader::onHandlePropTypeBlendFunc(Node* /*pNode*/,
+                                           Node* /*pParent*/,
+                                           const char* pPropertyName,
+                                           BlendFunc /*pBlendFunc*/,
+                                           CCBReader* /*ccbReader*/)
+{
     ASSERT_FAIL_UNEXPECTED_PROPERTY(pPropertyName);
 }
 
-void NodeLoader::onHandlePropTypeFntFile(Node * pNode, Node * pParent, const char* pPropertyName, const char* pFntFile, CCBReader * ccbReader) {
+void NodeLoader::onHandlePropTypeFntFile(Node* /*pNode*/,
+                                         Node* /*pParent*/,
+                                         const char* pPropertyName,
+                                         const char* /*pFntFile*/,
+                                         CCBReader* /*ccbReader*/)
+{
     ASSERT_FAIL_UNEXPECTED_PROPERTY(pPropertyName);
 }
 
-void NodeLoader::onHandlePropTypeString(Node * pNode, Node * pParent, const char* pPropertyName, const char * pString, CCBReader * ccbReader) {
+void NodeLoader::onHandlePropTypeString(Node* /*pNode*/,
+                                        Node* /*pParent*/,
+                                        const char* pPropertyName,
+                                        const char* pString,
+                                        CCBReader* /*ccbReader*/)
+{
 //    ASSERT_FAIL_UNEXPECTED_PROPERTY(pPropertyName);
     // It may be a custom property, add it to custom property dictionary.
     _customProperties[pPropertyName] = Value(pString);
 }
 
-void NodeLoader::onHandlePropTypeText(Node * pNode, Node * pParent, const char* pPropertyName, const char * pText, CCBReader * ccbReader) {
+void NodeLoader::onHandlePropTypeText(Node* /*pNode*/,
+                                      Node* /*pParent*/,
+                                      const char* pPropertyName,
+                                      const char* /*pText*/,
+                                      CCBReader* /*ccbReader*/)
+{
     ASSERT_FAIL_UNEXPECTED_PROPERTY(pPropertyName);
 }
 
-void NodeLoader::onHandlePropTypeFontTTF(Node * pNode, Node * pParent, const char* pPropertyName, const char * pFontTTF, CCBReader * ccbReader) {
+void NodeLoader::onHandlePropTypeFontTTF(Node* /*pNode*/,
+                                         Node* /*pParent*/,
+                                         const char* pPropertyName,
+                                         const char* /*pFontTTF*/,
+                                         CCBReader* /*ccbReader*/)
+{
     ASSERT_FAIL_UNEXPECTED_PROPERTY(pPropertyName);
 }
 
-void NodeLoader::onHandlePropTypeBlock(Node * pNode, Node * pParent, const char* pPropertyName, BlockData * pBlockData, CCBReader * ccbReader) {
+void NodeLoader::onHandlePropTypeBlock(Node* /*pNode*/,
+                                       Node* /*pParent*/,
+                                       const char* pPropertyName,
+                                       BlockData* /*pBlockData*/,
+                                       CCBReader* /*ccbReader*/)
+{
     ASSERT_FAIL_UNEXPECTED_PROPERTY(pPropertyName);
 }
 
-void NodeLoader::onHandlePropTypeBlockControl(Node * pNode, Node * pParent, const char* pPropertyName, BlockControlData * pBlockControlData, CCBReader * ccbReader) {
+void NodeLoader::onHandlePropTypeBlockControl(Node* /*pNode*/,
+                                              Node* /*pParent*/,
+                                              const char* pPropertyName,
+                                              BlockControlData* /*pBlockControlData*/,
+                                              CCBReader* /*ccbReader*/)
+{
     ASSERT_FAIL_UNEXPECTED_PROPERTY(pPropertyName);
 }
 
-void NodeLoader::onHandlePropTypeCCBFile(Node * pNode, Node * pParent, const char* pPropertyName, Node * pCCBFileNode, CCBReader * ccbReader) {
+void NodeLoader::onHandlePropTypeCCBFile(Node* /*pNode*/,
+                                         Node* /*pParent*/,
+                                         const char* pPropertyName,
+                                         Node* /*pCCBFileNode*/,
+                                         CCBReader* /*ccbReader*/)
+{
     ASSERT_FAIL_UNEXPECTED_PROPERTY(pPropertyName);
 }
 

--- a/cocos/editor-support/cocosbuilder/CCNodeLoader.h
+++ b/cocos/editor-support/cocosbuilder/CCNodeLoader.h
@@ -22,7 +22,7 @@ namespace cocosbuilder {
 #define ASSERT_FAIL_UNEXPECTED_PROPERTY(PROPERTY) cocos2d::log("Unexpected property: '%s'!\n", PROPERTY); assert(false)
 #define ASSERT_FAIL_UNEXPECTED_PROPERTYTYPE(PROPERTYTYPE) cocos2d::log("Unexpected property type: '%d'!\n", PROPERTYTYPE); assert(false)
 
-#define CCB_VIRTUAL_NEW_AUTORELEASE_CREATECCNODE_METHOD(T) virtual T * createNode(cocos2d::Node * pParent, cocosbuilder::CCBReader * ccbReader) { \
+#define CCB_VIRTUAL_NEW_AUTORELEASE_CREATECCNODE_METHOD(T) virtual T * createNode(cocos2d::Node* /*pParent*/, cocosbuilder::CCBReader* /*ccbReader*/) { \
     return T::create(); \
 }
 

--- a/cocos/editor-support/cocosbuilder/CCScale9SpriteLoader.h
+++ b/cocos/editor-support/cocosbuilder/CCScale9SpriteLoader.h
@@ -28,7 +28,9 @@ protected:
      * @js NA
      * @lua NA
      */
-    virtual cocos2d::ui::Scale9Sprite * createNode(cocos2d::Node * pParent, cocosbuilder::CCBReader * ccbReader) {
+    virtual cocos2d::ui::Scale9Sprite * createNode(cocos2d::Node* /*pParent*/,
+                                                   cocosbuilder::CCBReader* /*ccbReader*/)
+    {
         cocos2d::ui::Scale9Sprite* pNode = cocos2d::ui::Scale9Sprite::create();
         
         pNode->setAnchorPoint(cocos2d::Vec2::ZERO);

--- a/cocos/editor-support/cocostudio/ActionTimeline/CCBoneNode.cpp
+++ b/cocos/editor-support/cocostudio/ActionTimeline/CCBoneNode.cpp
@@ -441,7 +441,7 @@ void BoneNode::updateColor()
     _transformUpdated = _transformDirty = _inverseDirty = _contentSizeDirty = true;
 }
 
-void BoneNode::updateDisplayedColor(const cocos2d::Color3B& parentColor)
+void BoneNode::updateDisplayedColor(const cocos2d::Color3B & /*parentColor*/)
 {
     if (_cascadeColorEnabled)
     {
@@ -452,7 +452,7 @@ void BoneNode::updateDisplayedColor(const cocos2d::Color3B& parentColor)
     }
 }
 
-void BoneNode::updateDisplayedOpacity(GLubyte parentOpacity)
+void BoneNode::updateDisplayedOpacity(GLubyte /*parentOpacity*/)
 {
     if (_cascadeOpacityEnabled)
     {
@@ -479,7 +479,7 @@ void BoneNode::disableCascadeColor()
     }
 }
 
-void BoneNode::onDraw(const cocos2d::Mat4 &transform, uint32_t flags)
+void BoneNode::onDraw(const cocos2d::Mat4 &transform, uint32_t /*flags*/)
 {
     getGLProgram()->use();
     getGLProgram()->setUniformsForBuiltins(transform);

--- a/cocos/editor-support/cocostudio/ActionTimeline/CCFrame.cpp
+++ b/cocos/editor-support/cocostudio/ActionTimeline/CCFrame.cpp
@@ -114,7 +114,7 @@ VisibleFrame::VisibleFrame()
 {
 }
 
-void VisibleFrame::onEnter(Frame *nextFrame, int currentFrameIndex)
+void VisibleFrame::onEnter(Frame* /*nextFrame*/, int /*currentFrameIndex*/)
 {
     if (_node)
     {
@@ -160,7 +160,7 @@ void TextureFrame::setNode(Node* node)
     _sprite = dynamic_cast<Sprite*>(node);
 }
 
-void TextureFrame::onEnter(Frame *nextFrame, int currentFrameIndex)
+void TextureFrame::onEnter(Frame* /*nextFrame*/, int /*currentFrameIndex*/)
 {
     if(_sprite)
     {
@@ -208,7 +208,7 @@ RotationFrame::RotationFrame()
 {
 }
 
-void RotationFrame::onEnter(Frame *nextFrame, int currentFrameIndex)
+void RotationFrame::onEnter(Frame* nextFrame, int /*currentFrameIndex*/)
 {
     if (_node == nullptr)
     {
@@ -263,7 +263,7 @@ SkewFrame::SkewFrame()
 {
 }
 
-void SkewFrame::onEnter(Frame *nextFrame, int currentFrameIndex)
+void SkewFrame::onEnter(Frame *nextFrame, int /*currentFrameIndex*/)
 {
     if (_node == nullptr)
     {
@@ -323,7 +323,7 @@ RotationSkewFrame::RotationSkewFrame()
 {
 }
 
-void RotationSkewFrame::onEnter(Frame *nextFrame, int currentFrameIndex)
+void RotationSkewFrame::onEnter(Frame *nextFrame, int /*currentFrameIndex*/)
 {
     if (_node == nullptr)
     {
@@ -382,7 +382,7 @@ PositionFrame::PositionFrame()
 {
 }
 
-void PositionFrame::onEnter(Frame *nextFrame, int currentFrameIndex)
+void PositionFrame::onEnter(Frame *nextFrame, int /*currentFrameIndex*/)
 {
     if (_node == nullptr)
     {
@@ -441,7 +441,7 @@ ScaleFrame::ScaleFrame()
 {
 }
 
-void ScaleFrame::onEnter(Frame *nextFrame, int currentFrameIndex)
+void ScaleFrame::onEnter(Frame *nextFrame, int /*currentFrameIndex*/)
 {
     if (_node == nullptr)
     {
@@ -500,7 +500,7 @@ AnchorPointFrame::AnchorPointFrame()
 {
 }
 
-void AnchorPointFrame::onEnter(Frame *nextFrame, int currentFrameIndex)
+void AnchorPointFrame::onEnter(Frame *nextFrame, int /*currentFrameIndex*/)
 {
     if (_node == nullptr)
     {
@@ -561,7 +561,7 @@ InnerActionFrame::InnerActionFrame()
 
 }
 
-void InnerActionFrame::onEnter(Frame *nextFrame, int currentFrameIndex)
+void InnerActionFrame::onEnter(Frame* /*nextFrame*/, int /*currentFrameIndex*/)
 {
     if (_node == nullptr)
     {
@@ -690,7 +690,7 @@ ColorFrame::ColorFrame()
 {
 }
 
-void ColorFrame::onEnter(Frame *nextFrame, int currentFrameIndex)
+void ColorFrame::onEnter(Frame *nextFrame, int /*currentFrameIndex*/)
 {
     if (_node == nullptr)
     {
@@ -748,7 +748,7 @@ AlphaFrame::AlphaFrame()
 {
 }
 
-void AlphaFrame::onEnter(Frame *nextFrame, int currentFrameIndex)
+void AlphaFrame::onEnter(Frame *nextFrame, int /*currentFrameIndex*/)
 {
     if (_node == nullptr)
     {
@@ -812,7 +812,7 @@ void EventFrame::setNode(cocos2d::Node* node)
     _action = _timeline->getActionTimeline();
 }
 
-void EventFrame::onEnter(Frame *nextFrame, int currentFrameIndex)
+void EventFrame::onEnter(Frame* /*nextFrame*/, int currentFrameIndex)
 {
     if (static_cast<int>(_frameIndex) < _action->getStartFrame() || static_cast<int>(_frameIndex) > _action->getEndFrame())
         return;
@@ -851,7 +851,7 @@ ZOrderFrame::ZOrderFrame()
 {
 }
 
-void ZOrderFrame::onEnter(Frame *nextFrame, int currentFrameIndex)
+void ZOrderFrame::onEnter(Frame* /*nextFrame*/, int /*currentFrameIndex*/)
 {
     if(_node)
         _node->setLocalZOrder(_zorder);
@@ -887,7 +887,7 @@ BlendFuncFrame::BlendFuncFrame()
 {
 }
 
-void BlendFuncFrame::onEnter(Frame *nextFrame, int currentFrameIndex)
+void BlendFuncFrame::onEnter(Frame* /*nextFrame*/, int /*currentFrameIndex*/)
 {
     if(_node)
     {
@@ -929,7 +929,7 @@ PlayableFrame::PlayableFrame()
     
 }
 
-void PlayableFrame::onEnter(Frame *nextFrame, int currentFrameINdex)
+void PlayableFrame::onEnter(Frame* /*nextFrame*/, int /*currentFrameIndex*/)
 {
     auto playableNode = dynamic_cast<PlayableProtocol*>(_node);
     if (nullptr == playableNode) // may be a playable component

--- a/cocos/editor-support/cocostudio/ActionTimeline/CCFrame.h
+++ b/cocos/editor-support/cocostudio/ActionTimeline/CCFrame.h
@@ -72,7 +72,7 @@ protected:
     Frame();
     virtual ~Frame();
     
-    virtual void onApply(float percent) {};
+    virtual void onApply(float /*percent*/) {}
     //update percent depends _tweenType, and return the Calculated percent
     virtual float tweenPercent(float percent);
     

--- a/cocos/editor-support/cocostudio/ActionTimeline/CCSkeletonNode.cpp
+++ b/cocos/editor-support/cocostudio/ActionTimeline/CCSkeletonNode.cpp
@@ -263,7 +263,7 @@ void SkeletonNode::batchDrawAllSubBones(const cocos2d::Mat4 &transform)
 }
 
 
-void SkeletonNode::onDraw(const cocos2d::Mat4 &transform, uint32_t flags)
+void SkeletonNode::onDraw(const cocos2d::Mat4 &transform, uint32_t /*flags*/)
 {
     getGLProgram()->use();
     getGLProgram()->setUniformsForBuiltins(transform);

--- a/cocos/editor-support/cocostudio/CCActionFrame.cpp
+++ b/cocos/editor-support/cocostudio/CCActionFrame.cpp
@@ -78,12 +78,12 @@ int ActionFrame::getEasingType()
 	return (int)_easingType;
 }
 
-ActionInterval* ActionFrame::getAction(float fDuration)
+ActionInterval* ActionFrame::getAction(float /*fDuration*/)
 {
 	log("Need a definition of <getAction> for ActionFrame");
 	return nullptr;
 }
-ActionInterval* ActionFrame::getAction(float fDuration,ActionFrame* srcFrame)
+ActionInterval* ActionFrame::getAction(float fDuration, ActionFrame* /*srcFrame*/)
 {
 	return this->getAction(fDuration);
 }

--- a/cocos/editor-support/cocostudio/CCActionObject.cpp
+++ b/cocos/editor-support/cocostudio/CCActionObject.cpp
@@ -262,7 +262,7 @@ void ActionObject::updateToFrameByTime(float fTime)
 	}
 }
 
-void ActionObject::simulationActionUpdate(float dt)
+void ActionObject::simulationActionUpdate(float /*dt*/)
 {
 	bool isEnd = true;
     

--- a/cocos/editor-support/cocostudio/CCArmatureAnimation.h
+++ b/cocos/editor-support/cocostudio/CCArmatureAnimation.h
@@ -107,7 +107,7 @@ public:
     virtual float getSpeedScale() const;
 
     //! The animation update speed
-    CC_DEPRECATED_ATTRIBUTE virtual void setAnimationInternal(float animationInternal) {}
+    CC_DEPRECATED_ATTRIBUTE virtual void setAnimationInternal(float /*animationInternal*/) {}
 
     using ProcessBase::play;
     /**

--- a/cocos/editor-support/cocostudio/CCComController.cpp
+++ b/cocos/editor-support/cocostudio/CCComController.cpp
@@ -69,7 +69,7 @@ void ComController::onRemove()
 {
 }
 
-void ComController::update(float delta)
+void ComController::update(float /*delta*/)
 {
 }
 

--- a/cocos/editor-support/cocostudio/CCDataReaderHelper.cpp
+++ b/cocos/editor-support/cocostudio/CCDataReaderHelper.cpp
@@ -442,7 +442,7 @@ void DataReaderHelper::addDataFromFileAsync(const std::string& imagePath, const 
     _sleepCondition.notify_one();
 }
 
-void DataReaderHelper::addDataAsyncCallBack(float dt)
+void DataReaderHelper::addDataAsyncCallBack(float /*dt*/)
 {
     // the data is generated in loading thread
     std::queue<DataInfo *> *dataQueue = _dataQueue;
@@ -637,7 +637,9 @@ ArmatureData *DataReaderHelper::decodeArmature(tinyxml2::XMLElement *armatureXML
     return armatureData;
 }
 
-BoneData *DataReaderHelper::decodeBone(tinyxml2::XMLElement *boneXML, tinyxml2::XMLElement *parentXml, DataInfo *dataInfo)
+BoneData *DataReaderHelper::decodeBone(tinyxml2::XMLElement* boneXML,
+                                       tinyxml2::XMLElement* /*parentXml*/,
+                                       DataInfo* dataInfo)
 {
     BoneData *boneData = new (std::nothrow) BoneData();
     boneData->init();
@@ -665,7 +667,7 @@ BoneData *DataReaderHelper::decodeBone(tinyxml2::XMLElement *boneXML, tinyxml2::
     return boneData;
 }
 
-DisplayData *DataReaderHelper::decodeBoneDisplay(tinyxml2::XMLElement *displayXML, DataInfo *dataInfo)
+DisplayData *DataReaderHelper::decodeBoneDisplay(tinyxml2::XMLElement* displayXML, DataInfo* /*dataInfo*/)
 {
     int _isArmature = 0;
 
@@ -938,7 +940,10 @@ MovementBoneData *DataReaderHelper::decodeMovementBone(tinyxml2::XMLElement *mov
     return movBoneData;
 }
 
-FrameData *DataReaderHelper::decodeFrame(tinyxml2::XMLElement *frameXML,  tinyxml2::XMLElement *parentFrameXml, BoneData *boneData, DataInfo *dataInfo)
+FrameData *DataReaderHelper::decodeFrame(tinyxml2::XMLElement *frameXML,
+                                         tinyxml2::XMLElement *parentFrameXml,
+                                         BoneData* /*boneData*/,
+                                         DataInfo* dataInfo)
 {
     float x = 0, y = 0, scale_x = 0, scale_y = 0, skew_x = 0, skew_y = 0, tweenRotate = 0;
     int duration = 0, displayIndex = 0, zOrder = 0, tweenEasing = 0, blendType = 0;
@@ -1182,7 +1187,7 @@ TextureData *DataReaderHelper::decodeTexture(tinyxml2::XMLElement *textureXML, D
     return textureData;
 }
 
-ContourData *DataReaderHelper::decodeContour(tinyxml2::XMLElement *contourXML, DataInfo *dataInfo)
+ContourData *DataReaderHelper::decodeContour(tinyxml2::XMLElement* contourXML, DataInfo* /*dataInfo*/)
 {
     ContourData *contourData = new (std::nothrow) ContourData();
     contourData->init();
@@ -2461,11 +2466,10 @@ void DataReaderHelper::decodeNode(BaseData *node, const rapidjson::Value& json, 
 
         int length = cocoNode->GetChildNum();
         stExpCocoNode *verTexPointArray = cocoNode->GetChildArray(cocoLoader);
-        const char *str = nullptr;
+
         for (int i = 0; i < length; ++i)
         {
             std::string key = verTexPointArray[i].GetName(cocoLoader);
-            str = verTexPointArray[i].GetValue(cocoLoader);
             if (key.compare(VERTEX_POINT) == 0)
             {
                 int count = verTexPointArray[i].GetChildNum();

--- a/cocos/editor-support/cocostudio/CCDisplayFactory.cpp
+++ b/cocos/editor-support/cocostudio/CCDisplayFactory.cpp
@@ -236,7 +236,7 @@ void DisplayFactory::createArmatureDisplay(Bone *bone, DecorativeDisplay *decoDi
 
     decoDisplay->setDisplay(armature);
 }
-void DisplayFactory::updateArmatureDisplay(Bone *bone, Node *display, float dt)
+void DisplayFactory::updateArmatureDisplay(Bone* /*bone*/, Node* display, float dt)
 {
     Armature *armature = (Armature *)display;
     if(armature)
@@ -248,7 +248,7 @@ void DisplayFactory::updateArmatureDisplay(Bone *bone, Node *display, float dt)
 
 
 
-void DisplayFactory::addParticleDisplay(Bone *bone, DecorativeDisplay *decoDisplay, DisplayData *displayData)
+void DisplayFactory::addParticleDisplay(Bone* bone, DecorativeDisplay* decoDisplay, DisplayData *displayData)
 {
     ParticleDisplayData *adp = ParticleDisplayData::create();
     adp->copy((ParticleDisplayData *)displayData);
@@ -256,7 +256,7 @@ void DisplayFactory::addParticleDisplay(Bone *bone, DecorativeDisplay *decoDispl
 
     createParticleDisplay(bone, decoDisplay);
 }
-void DisplayFactory::createParticleDisplay(Bone *bone, DecorativeDisplay *decoDisplay)
+void DisplayFactory::createParticleDisplay(Bone* bone, DecorativeDisplay* decoDisplay)
 {
     ParticleDisplayData *displayData = (ParticleDisplayData *)decoDisplay->getDisplayData();
     ParticleSystem *system = ParticleSystemQuad::create(displayData->displayName);
@@ -272,7 +272,7 @@ void DisplayFactory::createParticleDisplay(Bone *bone, DecorativeDisplay *decoDi
 
     decoDisplay->setDisplay(system);
 }
-void DisplayFactory::updateParticleDisplay(Bone *bone, Node *display, float dt)
+void DisplayFactory::updateParticleDisplay(Bone* bone, Node* display, float dt)
 {
     ParticleSystem *system = (ParticleSystem *)display;
     BaseData node;

--- a/cocos/editor-support/cocostudio/CCInputDelegate.h
+++ b/cocos/editor-support/cocostudio/CCInputDelegate.h
@@ -106,15 +106,15 @@ public:
     /**
      * @js NA
      */
-    virtual void onAcceleration(cocos2d::Acceleration* acc, cocos2d::Event* event) {};
+    virtual void onAcceleration(cocos2d::Acceleration* /*acc*/, cocos2d::Event* /*event*/) {}
     /**
      * @js NA
      */
-    virtual void onKeyPressed(cocos2d::EventKeyboard::KeyCode keyCode, cocos2d::Event* event) {};
+    virtual void onKeyPressed(cocos2d::EventKeyboard::KeyCode /*keyCode*/, cocos2d::Event* /*event*/) {}
     /**
      * @js NA
      */
-    virtual void onKeyReleased(cocos2d::EventKeyboard::KeyCode keyCode, cocos2d::Event* event) {};
+    virtual void onKeyReleased(cocos2d::EventKeyboard::KeyCode /*keyCode*/, cocos2d::Event* /*event*/) {}
     /**
      * @js NA
      */

--- a/cocos/editor-support/cocostudio/CCProcessBase.cpp
+++ b/cocos/editor-support/cocostudio/CCProcessBase.cpp
@@ -71,7 +71,7 @@ void ProcessBase::stop()
     _isPlaying = false;
 }
 
-void ProcessBase::play(int durationTo, int durationTween,  int loop, int tweenEasing)
+void ProcessBase::play(int durationTo, int /*durationTween*/, int /*loop*/, int tweenEasing)
 {
     _isComplete = false;
     _isPause = false;

--- a/cocos/editor-support/cocostudio/CCSGUIReader.cpp
+++ b/cocos/editor-support/cocostudio/CCSGUIReader.cpp
@@ -1196,16 +1196,16 @@ void WidgetPropertiesReader0250::setPropsForLabelBMFontFromJsonDictionary(Widget
     setColorPropsForWidgetFromJsonDictionary(widget,options);
 }
     
-void WidgetPropertiesReader0250::setPropsForAllWidgetFromJsonDictionary(WidgetReaderProtocol *reader, Widget *widget, const rapidjson::Value &options)
+void WidgetPropertiesReader0250::setPropsForAllWidgetFromJsonDictionary(WidgetReaderProtocol* /*reader*/,
+                                                                        Widget* /*widget*/,
+                                                                        const rapidjson::Value & /*options*/)
 {
-    
 }
 
-void WidgetPropertiesReader0250::setPropsForAllCustomWidgetFromJsonDictionary(const std::string &classType,
-                                                                              cocos2d::ui::Widget *widget,
-                                                                              const rapidjson::Value &customOptions)
+void WidgetPropertiesReader0250::setPropsForAllCustomWidgetFromJsonDictionary(const std::string & /*classType*/,
+                                                                              cocos2d::ui::Widget* /*widget*/,
+                                                                              const rapidjson::Value & /*customOptions*/)
 {
-    
 }
 
 

--- a/cocos/editor-support/cocostudio/CCSGUIReader.h
+++ b/cocos/editor-support/cocostudio/CCSGUIReader.h
@@ -154,17 +154,20 @@ public:
     virtual cocos2d::ui::Widget* widgetFromJsonDictionary(const rapidjson::Value& dic) override;
     
     //added for binary parsing
-    virtual cocos2d::ui::Widget* createWidgetFromBinary(CocoLoader* cocoLoader,
-                                                        stExpCocoNode*	pCocoNode,
-                                                        const char* fileName)override{return nullptr;}
+    virtual cocos2d::ui::Widget* createWidgetFromBinary(CocoLoader* /*cocoLoader*/,
+                                                        stExpCocoNode* /*pCocoNode*/,
+                                                        const char* /*fileName*/) override
+    { return nullptr; }
     
-    virtual cocos2d::ui::Widget* widgetFromBinary(CocoLoader* cocoLoader,
-                                                  stExpCocoNode*	pCocoNode) override {return nullptr;}
+    virtual cocos2d::ui::Widget* widgetFromBinary(CocoLoader* /*cocoLoader*/,
+                                                  stExpCocoNode* /*pCocoNode*/) override
+    { return nullptr; }
     
-    virtual void setPropsForAllWidgetFromBinary(WidgetReaderProtocol* reader,
-                                                cocos2d::ui::Widget* widget,
-                                                CocoLoader* cocoLoader,
-                                                stExpCocoNode*	pCocoNode) override {}
+    virtual void setPropsForAllWidgetFromBinary(WidgetReaderProtocol* /*reader*/,
+                                                cocos2d::ui::Widget* /*widget*/,
+                                                CocoLoader* /*cocoLoader*/,
+                                                stExpCocoNode* /*pCocoNode*/) override
+    {}
 
     virtual void setPropsForWidgetFromJsonDictionary(cocos2d::ui::Widget* widget,const rapidjson::Value& options);
     
@@ -214,10 +217,11 @@ public:
                                                 CocoLoader* cocoLoader,
                                                 stExpCocoNode*	pCocoNode) override;
     
-    virtual void setPropsForAllCustomWidgetFromBinary(const std::string& classType,
-                                                      cocos2d::ui::Widget* widget,
-                                                      CocoLoader* cocoLoader,
-                                                      stExpCocoNode*	pCocoNode) {
+    virtual void setPropsForAllCustomWidgetFromBinary(const std::string & /*classType*/,
+                                                      cocos2d::ui::Widget* /*widget*/,
+                                                      CocoLoader* /*cocoLoader*/,
+                                                      stExpCocoNode* /*pCocoNode*/)
+    {
         //TODO: custom property
     }
     

--- a/cocos/editor-support/cocostudio/CCSSceneReader.cpp
+++ b/cocos/editor-support/cocostudio/CCSSceneReader.cpp
@@ -90,7 +90,7 @@ cocos2d::Node* SceneReader::createNodeWithSceneFile(const std::string &fileName,
                     _node = Node::create();
                     int  nCount = 0;
                     std::vector<Component*> _vecComs;
-                    ComRender *pRender = nullptr;
+                    //ComRender *pRender = nullptr;
                     std::string key = tpChildArray[15].GetName(&tCocoLoader);
                     if (key == "components")
                     {
@@ -122,7 +122,7 @@ cocos2d::Node* SceneReader::createNodeWithSceneFile(const std::string &fileName,
                                 ComRender *pTRender = dynamic_cast<ComRender*>(pCom);
                                 if (pTRender != nullptr)
                                 {
-                                    pRender = pTRender;
+                                    //pRender = pTRender;
                                 }
                                 else
                                 {

--- a/cocos/editor-support/cocostudio/CCSkin.cpp
+++ b/cocos/editor-support/cocostudio/CCSkin.cpp
@@ -229,7 +229,9 @@ Mat4 Skin::getNodeToWorldTransformAR() const
     return TransformConcat( _bone->getArmature()->getNodeToWorldTransform(),displayTransform);
 }
 
-void Skin::draw(Renderer *renderer, const Mat4 &transform, uint32_t flags)
+void Skin::draw(Renderer* renderer,
+                const Mat4 & /*transform*/,
+                uint32_t flags)
 {
     auto mv = Director::getInstance()->getMatrix(MATRIX_STACK_TYPE::MATRIX_STACK_MODELVIEW);
 

--- a/cocos/editor-support/cocostudio/TriggerMng.cpp
+++ b/cocos/editor-support/cocostudio/TriggerMng.cpp
@@ -23,7 +23,6 @@ THE SOFTWARE.
 ****************************************************************************/
 
 #include "editor-support/cocostudio/TriggerMng.h"
-#include "json/filereadstream.h"
 #include "json/prettywriter.h"
 #include "json/stringbuffer.h"
 #include "base/CCDirector.h"

--- a/cocos/editor-support/cocostudio/TriggerMng.cpp
+++ b/cocos/editor-support/cocostudio/TriggerMng.cpp
@@ -516,7 +516,7 @@ ArmatureMovementDispatcher::~ArmatureMovementDispatcher(void)
 	  _mapEventAnimation->emplace(pTarget, mecf);
   }
 
-  void ArmatureMovementDispatcher::removeAnnimationEventCallBack(Ref *pTarget, SEL_MovementEventCallFunc mecf)
+  void ArmatureMovementDispatcher::removeAnnimationEventCallBack(Ref* pTarget, SEL_MovementEventCallFunc /*mecf*/)
   {
 	  _mapEventAnimation->erase(pTarget);
   }

--- a/cocos/editor-support/cocostudio/TriggerMng.cpp
+++ b/cocos/editor-support/cocostudio/TriggerMng.cpp
@@ -517,7 +517,7 @@ ArmatureMovementDispatcher::~ArmatureMovementDispatcher(void)
 	  _mapEventAnimation->emplace(pTarget, mecf);
   }
 
-  void ArmatureMovementDispatcher::removeAnnimationEventCallBack(Ref *pTarget, SEL_MovementEventCallFunc mecf)
+  void ArmatureMovementDispatcher::removeAnnimationEventCallBack(Ref* pTarget, SEL_MovementEventCallFunc /*mecf*/)
   {
 	  _mapEventAnimation->erase(pTarget);
   }

--- a/cocos/editor-support/cocostudio/TriggerObj.cpp
+++ b/cocos/editor-support/cocostudio/TriggerObj.cpp
@@ -46,24 +46,23 @@ bool BaseTriggerCondition::detect()
     return true;
 }
 
-void BaseTriggerCondition::serialize(const rapidjson::Value &val)
+void BaseTriggerCondition::serialize(const rapidjson::Value & /*val*/)
 {
 }
     
-void BaseTriggerCondition::serialize(cocostudio::CocoLoader *cocoLoader, cocostudio::stExpCocoNode *cocoNode)
+void BaseTriggerCondition::serialize(cocostudio::CocoLoader* /*cocoLoader*/, cocostudio::stExpCocoNode* /*cocoNode*/)
 {
-    
 }
 
 void BaseTriggerCondition::removeAll()
 {
 }
 
-BaseTriggerAction::BaseTriggerAction(void)
+BaseTriggerAction::BaseTriggerAction()
 {
 }
 
-BaseTriggerAction::~BaseTriggerAction(void)
+BaseTriggerAction::~BaseTriggerAction()
 {
 }
 
@@ -77,11 +76,12 @@ void BaseTriggerAction::done()
 
 }
 
-void BaseTriggerAction::serialize(const rapidjson::Value &val)
+void BaseTriggerAction::serialize(const rapidjson::Value & /*val*/)
 {
 }
 
-void BaseTriggerAction::serialize(cocostudio::CocoLoader *cocoLoader, cocostudio::stExpCocoNode *cocoNode)
+void BaseTriggerAction::serialize(cocostudio::CocoLoader* /*cocoLoader*/,
+                                  cocostudio::stExpCocoNode* /*cocoNode*/)
 {
 }
 
@@ -89,13 +89,13 @@ void BaseTriggerAction::removeAll()
 {
 }
 
-TriggerObj::TriggerObj(void)
+TriggerObj::TriggerObj()
 :_id(UINT_MAX)
 ,_enabled(true)
 {
 }
 
-TriggerObj::~TriggerObj(void)
+TriggerObj::~TriggerObj()
 {
 }
 

--- a/cocos/editor-support/cocostudio/TriggerObj.cpp
+++ b/cocos/editor-support/cocostudio/TriggerObj.cpp
@@ -229,12 +229,15 @@ void TriggerObj::serialize(const rapidjson::Value &val)
         sprintf(buf, "%d", event);
         std::string custom_event_name(buf);
 
-        EventListenerCustom* listener = EventListenerCustom::create(custom_event_name, [=](EventCustom* evt){
-            if (detect())
-            {
-                done();
-            }
-        });
+        EventListenerCustom* listener =
+            EventListenerCustom::create(custom_event_name,
+                                        [=](EventCustom* /*evt*/) {
+                                            if (detect())
+                                            {
+                                                done();
+                                            }
+                                        });
+
         _listeners.pushBack(listener);
         TriggerMng::getInstance()->addEventListenerWithFixedPriority(listener, 1);
     }  
@@ -245,26 +248,26 @@ void TriggerObj::serialize(cocostudio::CocoLoader *pCocoLoader, cocostudio::stEx
 {
     int length = pCocoNode->GetChildNum();
     int count = 0;
-    int num = 0;
     stExpCocoNode *pTriggerObjArray = pCocoNode->GetChildArray(pCocoLoader);
+
     for (int i0 = 0; i0 < length; ++i0)
     {
         std::string key = pTriggerObjArray[i0].GetName(pCocoLoader);
         const char* str0 = pTriggerObjArray[i0].GetValue(pCocoLoader);
-        if (key.compare("id") == 0)
+
+        if (key == "id")
         {
             if (str0 != nullptr)
             {
                 _id = atoi(str0); 
             }
         }
-        else if (key.compare("conditions") == 0)
+        else if (key == "conditions")
         {
             count = pTriggerObjArray[i0].GetChildNum();
             stExpCocoNode *pConditionsArray = pTriggerObjArray[i0].GetChildArray(pCocoLoader);
             for (int i1 = 0; i1 < count; ++i1)
             {
-                num = pConditionsArray[i1].GetChildNum();
                 stExpCocoNode *pConditionArray = pConditionsArray[i1].GetChildArray(pCocoLoader);
                 const char *classname = pConditionArray[0].GetValue(pCocoLoader);
                 if (classname == nullptr)
@@ -278,13 +281,12 @@ void TriggerObj::serialize(cocostudio::CocoLoader *pCocoLoader, cocostudio::stEx
                 _cons.pushBack(con);
             }
         }
-        else if (key.compare("actions") == 0)
+        else if (key == "actions")
         {
             count = pTriggerObjArray[i0].GetChildNum();
             stExpCocoNode *pActionsArray = pTriggerObjArray[i0].GetChildArray(pCocoLoader);
             for (int i2 = 0; i2 < count; ++i2)
             {
-                num = pActionsArray[i2].GetChildNum();
                 stExpCocoNode *pActionArray = pActionsArray[i2].GetChildArray(pCocoLoader);
                 const char *classname = pActionArray[0].GetValue(pCocoLoader);
                 if (classname == nullptr)
@@ -298,13 +300,12 @@ void TriggerObj::serialize(cocostudio::CocoLoader *pCocoLoader, cocostudio::stEx
                 _acts.pushBack(act);
             }
         }
-        else if (key.compare("events") == 0)
+        else if (key == "events")
         {
             count = pTriggerObjArray[i0].GetChildNum();
             stExpCocoNode *pEventsArray = pTriggerObjArray[i0].GetChildArray(pCocoLoader);
             for (int i3 = 0; i3 < count; ++i3)
             {
-                num = pEventsArray[i3].GetChildNum();
                 stExpCocoNode *pEventArray = pEventsArray[i3].GetChildArray(pCocoLoader);
                 const char *str1 = pEventArray[0].GetValue(pCocoLoader);
                 if (str1 == nullptr)
@@ -320,12 +321,14 @@ void TriggerObj::serialize(cocostudio::CocoLoader *pCocoLoader, cocostudio::stEx
                 sprintf(buf, "%d", event);
                 std::string custom_event_name(buf);
                 
-                EventListenerCustom* listener = EventListenerCustom::create(custom_event_name, [=](EventCustom* evt){
-                    if (detect())
-                    {
-                        done();
-                    }
-                });
+                EventListenerCustom* listener =
+                    EventListenerCustom::create(custom_event_name,
+                                                [=](EventCustom* /*evt*/) {
+                                                    if (detect())
+                                                    {
+                                                        done();
+                                                    }
+                                                });
                 _listeners.pushBack(listener);
                 TriggerMng::getInstance()->addEventListenerWithFixedPriority(listener, 1);
             }

--- a/cocos/editor-support/cocostudio/WidgetCallBackHandlerProtocol.h
+++ b/cocos/editor-support/cocostudio/WidgetCallBackHandlerProtocol.h
@@ -37,9 +37,9 @@ namespace cocostudio {
         WidgetCallBackHandlerProtocol() {};
         virtual ~WidgetCallBackHandlerProtocol() {};
         
-        virtual cocos2d::ui::Widget::ccWidgetTouchCallback onLocateTouchCallback(const std::string &callBackName){ return nullptr; };
-        virtual cocos2d::ui::Widget::ccWidgetClickCallback onLocateClickCallback(const std::string &callBackName){ return nullptr; };
-        virtual cocos2d::ui::Widget::ccWidgetEventCallback onLocateEventCallback(const std::string &callBackName){ return nullptr; };
+        virtual cocos2d::ui::Widget::ccWidgetTouchCallback onLocateTouchCallback(const std::string & /*callBackName*/) { return nullptr; }
+        virtual cocos2d::ui::Widget::ccWidgetClickCallback onLocateClickCallback(const std::string & /*callBackName*/) { return nullptr; }
+        virtual cocos2d::ui::Widget::ccWidgetEventCallback onLocateEventCallback(const std::string & /*callBackName*/) { return nullptr; }
     };
 
 }

--- a/cocos/editor-support/cocostudio/WidgetReader/ArmatureNodeReader/ArmatureNodeReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/ArmatureNodeReader/ArmatureNodeReader.cpp
@@ -125,15 +125,12 @@ void ArmatureNodeReader::setPropsWithFlatBuffers(cocos2d::Node *node,
 	auto* custom = static_cast<Armature*>(node);
 	auto options = (flatbuffers::CSArmatureNodeOption*)nodeOptions;
     
-    bool fileExist = false;
     std::string errorFilePath = "";
 
 	std::string filepath(options->fileData()->path()->c_str());    
     
     if (FileUtils::getInstance()->isFileExist(filepath))
     {
-        fileExist = true;
-        
         std::string fullpath = FileUtils::getInstance()->fullPathForFilename(filepath);
         
         std::string dirpath = fullpath.substr(0, fullpath.find_last_of("/"));
@@ -153,7 +150,6 @@ void ArmatureNodeReader::setPropsWithFlatBuffers(cocos2d::Node *node,
     else
     {
         errorFilePath = filepath;
-        fileExist = false;
     }
 }
 
@@ -180,10 +176,12 @@ std::string ArmatureNodeReader::getArmatureName(const std::string& exporJsonPath
 	size_t end = exporJsonPath.find_last_of(".");
 	size_t start = exporJsonPath.find_last_of("\\") + 1;
 	size_t start1 = exporJsonPath.find_last_of("/") + 1;
+
 	if (start < start1)
 		start = start1;
 
-	if (start == -1)
+	if (start == std::string::npos)
 		start = 0;
+
 	return  exporJsonPath.substr(start, end - start);
 }

--- a/cocos/editor-support/cocostudio/WidgetReader/ComAudioReader/ComAudioReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/ComAudioReader/ComAudioReader.cpp
@@ -194,4 +194,9 @@ namespace cocostudio
         return component;
     }
     
+    cocos2d::Node* createNodeWithFlatBuffers(const flatbuffers::Table*)
+    {
+        return nullptr;
+    }
+
 }

--- a/cocos/editor-support/cocostudio/WidgetReader/ComAudioReader/ComAudioReader.h
+++ b/cocos/editor-support/cocostudio/WidgetReader/ComAudioReader/ComAudioReader.h
@@ -50,7 +50,7 @@ namespace cocostudio
                                                                              flatbuffers::FlatBufferBuilder* builder);
         void setPropsWithFlatBuffers(cocos2d::Node* node, const flatbuffers::Table* comAudioOptions);
         cocos2d::Component* createComAudioWithFlatBuffers(const flatbuffers::Table* comAudioOptions);
-        cocos2d::Node* createNodeWithFlatBuffers(const flatbuffers::Table* nodeOptions) { return nullptr; };
+        cocos2d::Node* createNodeWithFlatBuffers(const flatbuffers::Table* nodeOptions);
     };
 }
 

--- a/cocos/editor-support/cocostudio/WidgetReader/GameMapReader/GameMapReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/GameMapReader/GameMapReader.cpp
@@ -186,16 +186,19 @@ namespace cocostudio
                             tileset = *iter;
                             if (tileset)
                             {
-                                for( int y=0; y < size.height; y++ )
+                                for (unsigned y = 0, height = size.height; y < height; y++)
                                 {
-                                    for( int x=0; x < size.width; x++ )
+                                    for (unsigned x = 0, width = size.width; x < width; x++)
                                     {
-                                        int pos = static_cast<int>(x + size.width * y);
-                                        int gid = layerInfo->_tiles[ pos ];
+                                        auto pos = x + width * y;
+                                        auto gid = layerInfo->_tiles[ pos ];
                                         
                                         if( gid != 0 )
                                         {
-                                            if( (gid & kTMXFlippedMask) >= tileset->_firstGid )
+                                            if (tileset->_firstGid < 0
+                                                || ((gid & kTMXFlippedMask)
+                                                    >= static_cast<unsigned>(tileset->_firstGid))
+                                            )
                                             {
                                                 valid = true;
                                                 break;

--- a/cocos/editor-support/cocostudio/WidgetReader/ProjectNodeReader/ProjectNodeReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/ProjectNodeReader/ProjectNodeReader.cpp
@@ -136,4 +136,10 @@ namespace cocostudio
         
         nodeReader->setPropsWithFlatBuffers(node, (Table*)options->nodeOptions());
     }
+
+    cocos2d::Node* createNodeWithFlatBuffers(const flatbuffers::Table*)
+    {
+        return nullptr;
+    }
+
 }

--- a/cocos/editor-support/cocostudio/WidgetReader/ProjectNodeReader/ProjectNodeReader.h
+++ b/cocos/editor-support/cocostudio/WidgetReader/ProjectNodeReader/ProjectNodeReader.h
@@ -48,7 +48,7 @@ namespace cocostudio
                                                                              flatbuffers::FlatBufferBuilder* builder);
 
         void setPropsWithFlatBuffers(cocos2d::Node* node, const flatbuffers::Table* projectNodeOptions);
-        cocos2d::Node* createNodeWithFlatBuffers(const flatbuffers::Table* nodeOptions) { return nullptr; };
+        cocos2d::Node* createNodeWithFlatBuffers(const flatbuffers::Table* nodeOptions);
     };
 }
 

--- a/cocos/editor-support/cocostudio/WidgetReader/SpriteReader/SpriteReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/SpriteReader/SpriteReader.cpp
@@ -180,7 +180,6 @@ namespace cocostudio
         int resourceType = fileNameData->resourceType();
         std::string path = fileNameData->path()->c_str();
         
-        bool fileExist = false;
         std::string errorFilePath = "";
         
         switch (resourceType)
@@ -190,12 +189,10 @@ namespace cocostudio
                 if (FileUtils::getInstance()->isFileExist(path))
                 {
                     sprite->setTexture(path);
-                    fileExist = true;
                 }
                 else
                 {
                     errorFilePath = path;
-                    fileExist = false;
                 }
                 break;
             }
@@ -207,7 +204,6 @@ namespace cocostudio
                 if (spriteFrame)
                 {
                     sprite->setSpriteFrame(spriteFrame);
-                    fileExist = true;
                 }
                 else
                 {
@@ -225,7 +221,6 @@ namespace cocostudio
                     {
                         errorFilePath = plist;
                     }
-                    fileExist = false;
                 }
                 break;
             }

--- a/cocos/editor-support/cocostudio/WidgetReader/TabControlReader/TabControlReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/TabControlReader/TabControlReader.cpp
@@ -986,19 +986,21 @@ flatbuffers::Offset<flatbuffers::TabItemOption> TabItemReader::createTabItemOpti
     return  *(&options);
 }
 
-void TabItemReader::setPropsWithFlatBuffers(cocos2d::Node* node, const flatbuffers::Table* nodeOption)
+void TabItemReader::setPropsWithFlatBuffers(cocos2d::Node* /*node*/, const flatbuffers::Table* /*nodeOption*/)
 {
     // do nothing
 }
 
-cocos2d::Node* TabItemReader::createNodeWithFlatBuffers(const flatbuffers::Table* nodeOptions)
+cocos2d::Node* TabItemReader::createNodeWithFlatBuffers(const flatbuffers::Table* /*nodeOptions*/)
 {
     // do nothing
     return nullptr;
 }
 
 flatbuffers::Offset<flatbuffers::Table> TabItemReader::createOptionsWithFlatBuffers(
-                                                                                    const tinyxml2::XMLElement* objectData, flatbuffers::FlatBufferBuilder* builder)
+    const tinyxml2::XMLElement* /*objectData*/,
+    flatbuffers::FlatBufferBuilder* /*builder*/
+)
 {
     
     // nothing

--- a/cocos/editor-support/cocostudio/WidgetReader/TextAtlasReader/TextAtlasReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/TextAtlasReader/TextAtlasReader.cpp
@@ -255,13 +255,10 @@ namespace cocostudio
             {
                 const char* cmfPath = cmftDic->path()->c_str();
                 
-                bool fileExist = false;
                 std::string errorFilePath = "";
                 
                 if (FileUtils::getInstance()->isFileExist(cmfPath))
                 {
-                    fileExist = true;
-                    
                     std::string stringValue = options->stringValue()->c_str();
                     int itemWidth = options->itemWidth();
                     int itemHeight = options->itemHeight();
@@ -274,7 +271,6 @@ namespace cocostudio
                 else
                 {
                     errorFilePath = cmfPath;
-                    fileExist = false;
                 }
                 break;
             }

--- a/cocos/editor-support/spine/Cocos2dAttachmentLoader.cpp
+++ b/cocos/editor-support/spine/Cocos2dAttachmentLoader.cpp
@@ -77,7 +77,9 @@ void _Cocos2dAttachmentLoader_configureAttachment (spAttachmentLoader* loader, s
 	}
 }
 
-void _Cocos2dAttachmentLoader_disposeAttachment (spAttachmentLoader* loader, spAttachment* attachment) {
+void _Cocos2dAttachmentLoader_disposeAttachment (spAttachmentLoader* /*loader*/,
+                                                 spAttachment* attachment)
+{
 	switch (attachment->type) {
 	case SP_ATTACHMENT_REGION: {
 		spRegionAttachment* regionAttachment = SUB_CAST(spRegionAttachment, attachment);

--- a/cocos/editor-support/spine/SkeletonBatch.cpp
+++ b/cocos/editor-support/spine/SkeletonBatch.cpp
@@ -58,7 +58,7 @@ namespace spine {
         _firstCommand = new Command();
         _command = _firstCommand;
 
-        Director::getInstance()->getEventDispatcher()->addCustomEventListener(EVENT_AFTER_DRAW_RESET_POSITION, [this](EventCustom* eventCustom){
+        Director::getInstance()->getEventDispatcher()->addCustomEventListener(EVENT_AFTER_DRAW_RESET_POSITION, [this](EventCustom* /*eventCustom*/){
             this->update(0);
         });;
     }
@@ -74,13 +74,19 @@ namespace spine {
         }
     }
 
-    void SkeletonBatch::update (float delta) {
+    void SkeletonBatch::update(float /*delta*/) {
         _command = _firstCommand;
     }
 
-    void SkeletonBatch::addCommand (cocos2d::Renderer* renderer, float globalZOrder, GLuint textureID, GLProgramState* glProgramState,
-                                    BlendFunc blendFunc, const TrianglesCommand::Triangles& triangles, const Mat4& transform, uint32_t transformFlags
-                                    ) {
+    void SkeletonBatch::addCommand(cocos2d::Renderer* renderer,
+                                   float globalZOrder,
+                                   GLuint textureID,
+                                   GLProgramState* glProgramState,
+                                   BlendFunc blendFunc,
+                                   const TrianglesCommand::Triangles & triangles,
+                                   const Mat4 & transform,
+                                   uint32_t /*transformFlags*/)
+    {
         if (_command->triangles->verts) {
             free(_command->triangles->verts);
             _command->triangles->verts = NULL;

--- a/cocos/navmesh/CCNavMeshAgent.cpp
+++ b/cocos/navmesh/CCNavMeshAgent.cpp
@@ -327,7 +327,7 @@ void NavMeshAgent::preUpdate(float delta)
     }
 }
 
-void NavMeshAgent::postUpdate(float delta)
+void NavMeshAgent::postUpdate(float /*delta*/)
 {
     if ((_syncFlag & AGENT_TO_NODE) != 0)
         syncToNode();

--- a/cocos/navmesh/CCNavMeshDebugDraw.cpp
+++ b/cocos/navmesh/CCNavMeshDebugDraw.cpp
@@ -53,9 +53,13 @@ NavMeshDebugDraw::NavMeshDebugDraw()
     glGenBuffers(1, &_vbo);
 }
 
-void NavMeshDebugDraw::vertex(const float x, const float y, const float z, unsigned int color, const float u, const float v)
+void NavMeshDebugDraw::vertex(const float /*x*/,
+                              const float /*y*/,
+                              const float /*z*/,
+                              unsigned int /*color*/,
+                              const float /*u*/,
+                              const float /*v*/)
 {
-
 }
 
 void NavMeshDebugDraw::vertex(const float* pos, unsigned int color, const float* uv)
@@ -134,7 +138,7 @@ GLenum NavMeshDebugDraw::getPrimitiveType(duDebugDrawPrimitives prim)
     }
 }
 
-void NavMeshDebugDraw::drawImplement(const cocos2d::Mat4& transform, uint32_t flags)
+void NavMeshDebugDraw::drawImplement(const cocos2d::Mat4& transform, uint32_t /*flags*/)
 {
     _program->use();
     _program->setUniformsForBuiltins(transform);

--- a/cocos/navmesh/CCNavMeshObstacle.cpp
+++ b/cocos/navmesh/CCNavMeshObstacle.cpp
@@ -54,7 +54,7 @@ NavMeshObstacle::NavMeshObstacle()
 : _radius(0.0f)
 , _height(0.0f)
 , _tileCache(nullptr)
-, _obstacleID(-1)
+, _obstacleID(UNDEFINED_OBSTACLE_ID)
 , _syncFlag(NODE_AND_NODE)
 {
 
@@ -73,11 +73,11 @@ bool NavMeshObstacle::initWith(float radius, float height)
     return true;
 }
 
-void cocos2d::NavMeshObstacle::removeFrom(dtTileCache *tileCache)
+void cocos2d::NavMeshObstacle::removeFrom(dtTileCache* /*tileCache*/)
 {
     _tileCache->removeObstacle(_obstacleID);
     _tileCache = nullptr;
-    _obstacleID = -1;
+    _obstacleID = UNDEFINED_OBSTACLE_ID;
 }
 
 void cocos2d::NavMeshObstacle::addTo(dtTileCache *tileCache)
@@ -89,7 +89,7 @@ void cocos2d::NavMeshObstacle::addTo(dtTileCache *tileCache)
 
 void cocos2d::NavMeshObstacle::onExit()
 {
-    if (_obstacleID == -1) return;
+    if (_obstacleID == UNDEFINED_OBSTACLE_ID) return;
     Component::onExit();
     auto scene = _owner->getScene();
     if (scene && scene->getNavMesh()){
@@ -99,7 +99,7 @@ void cocos2d::NavMeshObstacle::onExit()
 
 void cocos2d::NavMeshObstacle::onEnter()
 {
-    if (_obstacleID != -1) return;
+    if (_obstacleID != UNDEFINED_OBSTACLE_ID) return;
     Component::onEnter();
     auto scene = _owner->getScene();
     if (scene && scene->getNavMesh()){
@@ -107,13 +107,13 @@ void cocos2d::NavMeshObstacle::onEnter()
     }
 }
 
-void cocos2d::NavMeshObstacle::postUpdate(float delta)
+void cocos2d::NavMeshObstacle::postUpdate(float /*delta*/)
 {
     if ((_syncFlag & OBSTACLE_TO_NODE) != 0)
         syncToNode();
 }
 
-void cocos2d::NavMeshObstacle::preUpdate(float delta)
+void cocos2d::NavMeshObstacle::preUpdate(float /*delta*/)
 {
     if ((_syncFlag & NODE_TO_OBSTACLE) != 0)
         syncToObstacle();

--- a/cocos/navmesh/CCNavMeshObstacle.h
+++ b/cocos/navmesh/CCNavMeshObstacle.h
@@ -112,6 +112,9 @@ private:
     NavMeshObstacleSyncFlag _syncFlag;
     dtObstacleRef _obstacleID;
     dtTileCache *_tileCache;
+
+    static const dtObstacleRef UNDEFINED_OBSTACLE_ID =
+        static_cast<dtObstacleRef>(-1);
 };
 
 /** @} */

--- a/cocos/network/CCDownloader.cpp
+++ b/cocos/network/CCDownloader.cpp
@@ -81,7 +81,7 @@ namespace cocos2d { namespace network {
                                        int64_t bytesReceived,
                                        int64_t totalBytesReceived,
                                        int64_t totalBytesExpected,
-                                       std::function<int64_t(void *buffer, int64_t len)>& transferDataToBuffer)
+                                       std::function<int64_t(void *buffer, int64_t len)>& /*transferDataToBuffer*/)
         {
             if (onTaskProgress)
             {

--- a/cocos/network/SocketIO.cpp
+++ b/cocos/network/SocketIO.cpp
@@ -993,9 +993,9 @@ void SIOClientImpl::onClose(WebSocket* ws)
     this->release();
 }
 
-void SIOClientImpl::onError(WebSocket* ws, const WebSocket::ErrorCode& error)
+void SIOClientImpl::onError(WebSocket* /*ws*/, const WebSocket::ErrorCode & error)
 {
-    CC_UNUSED_PARAM(ws);
+    CC_UNUSED_PARAM(error);
     CCLOGERROR("Websocket error received: %d", static_cast<int>(error));
 }
 

--- a/cocos/network/SocketIO.h
+++ b/cocos/network/SocketIO.h
@@ -60,6 +60,7 @@ in the onClose method the pointer should be set to NULL or used to connect to a 
 #define __CC_SOCKETIO_H__
 
 #include <string>
+#include <unordered_map>
 #include "platform/CCPlatformMacros.h"
 #include "base/CCMap.h"
 

--- a/cocos/network/SocketIO.h
+++ b/cocos/network/SocketIO.h
@@ -110,7 +110,11 @@ public:
          *
          * @param client the connected SIOClient object.
          */
-        virtual void onConnect(SIOClient* client) { CC_UNUSED_PARAM(client); CCLOG("SIODelegate onConnect fired"); };
+        virtual void onConnect(SIOClient* client)
+        {
+            CC_UNUSED_PARAM(client);
+            CCLOG("SIODelegate onConnect fired");
+        }
         /**
          * This is kept for backwards compatibility, message is now fired as a socket.io event "message"
          *
@@ -119,7 +123,11 @@ public:
          * @param client the connected SIOClient object.
          * @param data the message,it could be json message
          */
-        virtual void onMessage(SIOClient* client, const std::string& data) { CC_UNUSED_PARAM(client); CCLOG("SIODelegate onMessage fired with data: %s", data.c_str()); };
+        virtual void onMessage(SIOClient* /*client*/, const std::string & data)
+        {
+            CC_UNUSED_PARAM(data);
+            CCLOG("SIODelegate onMessage fired with data: %s", data.c_str());
+        }
         /**
          * Pure virtual callback function, this function should be overrided by the subclass.
          *
@@ -144,7 +152,14 @@ public:
          * @param eventName the event's name.
          * @param data the event's data information.
          */
-        virtual void fireEventToScript(SIOClient* client, const std::string& eventName, const std::string& data) { CC_UNUSED_PARAM(client); CCLOG("SIODelegate event '%s' fired with data: %s", eventName.c_str(), data.c_str()); };
+        virtual void fireEventToScript(SIOClient* /*client*/,
+                                       const std::string& eventName,
+                                       const std::string& data)
+        {
+            CC_UNUSED_PARAM(eventName);
+            CC_UNUSED_PARAM(data);
+            CCLOG("SIODelegate event '%s' fired with data: %s", eventName.c_str(), data.c_str());
+        }
     };
 
     /**

--- a/cocos/network/SocketIO.h
+++ b/cocos/network/SocketIO.h
@@ -109,7 +109,11 @@ public:
          *
          * @param client the connected SIOClient object.
          */
-        virtual void onConnect(SIOClient* client) { CC_UNUSED_PARAM(client); CCLOG("SIODelegate onConnect fired"); };
+        virtual void onConnect(SIOClient* client)
+        {
+            CC_UNUSED_PARAM(client);
+            CCLOG("SIODelegate onConnect fired");
+        }
         /**
          * This is kept for backwards compatibility, message is now fired as a socket.io event "message"
          *
@@ -118,7 +122,11 @@ public:
          * @param client the connected SIOClient object.
          * @param data the message,it could be json message
          */
-        virtual void onMessage(SIOClient* client, const std::string& data) { CC_UNUSED_PARAM(client); CCLOG("SIODelegate onMessage fired with data: %s", data.c_str()); };
+        virtual void onMessage(SIOClient* /*client*/, const std::string & data)
+        {
+            CC_UNUSED_PARAM(data);
+            CCLOG("SIODelegate onMessage fired with data: %s", data.c_str());
+        }
         /**
          * Pure virtual callback function, this function should be overrided by the subclass.
          *
@@ -143,7 +151,14 @@ public:
          * @param eventName the event's name.
          * @param data the event's data information.
          */
-        virtual void fireEventToScript(SIOClient* client, const std::string& eventName, const std::string& data) { CC_UNUSED_PARAM(client); CCLOG("SIODelegate event '%s' fired with data: %s", eventName.c_str(), data.c_str()); };
+        virtual void fireEventToScript(SIOClient* /*client*/,
+                                       const std::string& eventName,
+                                       const std::string& data)
+        {
+            CC_UNUSED_PARAM(eventName);
+            CC_UNUSED_PARAM(data);
+            CCLOG("SIODelegate event '%s' fired with data: %s", eventName.c_str(), data.c_str());
+        }
     };
 
     /**

--- a/cocos/network/WebSocket.cpp
+++ b/cocos/network/WebSocket.cpp
@@ -90,7 +90,10 @@ static void printWebSocketLog(int level, const char *line)
     printf("%s%s\n", buf, line);
 #endif
 
-#endif // #if COCOS2D_DEBUG > 0
+#else // #if COCOS2D_DEBUG > 0
+    CC_UNUSED_PARAM(level);
+    CC_UNUSED_PARAM(line);
+#endif
 }
 
 NS_CC_BEGIN
@@ -604,6 +607,7 @@ void WebSocket::onSubThreadStarted()
     // libwebsockets official said it's probably an issue of user code
     // since 'libwebsockets' passed AutoBahn stressed Test.
 
+    CC_UNUSED_PARAM(exts);
 //    info.extensions = exts;
 
     info.gid = -1;
@@ -927,9 +931,11 @@ void WebSocket::onConnectionClosed()
     });
 }
 
-int WebSocket::onSocketCallback(struct lws *wsi,
-                     int reason,
-                     void *user, void *in, ssize_t len)
+int WebSocket::onSocketCallback(struct lws* /*wsi*/,
+                                int         reason,
+                                void*       /*user*/,
+                                void*       in,
+                                ssize_t     len)
 {
     //LOGD("socket callback for %d reason\n", reason);
 

--- a/cocos/physics/CCPhysicsWorld.cpp
+++ b/cocos/physics/CCPhysicsWorld.cpp
@@ -94,7 +94,7 @@ public:
 
 bool PhysicsWorldCallback::continues = true;
 
-cpBool PhysicsWorldCallback::collisionBeginCallbackFunc(cpArbiter *arb, struct cpSpace *space, PhysicsWorld *world)
+cpBool PhysicsWorldCallback::collisionBeginCallbackFunc(cpArbiter *arb, struct cpSpace* /*space*/, PhysicsWorld *world)
 {
     CP_ARBITER_GET_SHAPES(arb, a, b);
     
@@ -109,17 +109,17 @@ cpBool PhysicsWorldCallback::collisionBeginCallbackFunc(cpArbiter *arb, struct c
     return world->collisionBeginCallback(*contact);
 }
 
-cpBool PhysicsWorldCallback::collisionPreSolveCallbackFunc(cpArbiter *arb, cpSpace *space, PhysicsWorld *world)
+cpBool PhysicsWorldCallback::collisionPreSolveCallbackFunc(cpArbiter *arb, cpSpace* /*space*/, PhysicsWorld *world)
 {
     return world->collisionPreSolveCallback(*static_cast<PhysicsContact*>(cpArbiterGetUserData(arb)));
 }
 
-void PhysicsWorldCallback::collisionPostSolveCallbackFunc(cpArbiter *arb, cpSpace *space, PhysicsWorld *world)
+void PhysicsWorldCallback::collisionPostSolveCallbackFunc(cpArbiter *arb, cpSpace* /*space*/, PhysicsWorld *world)
 {
     world->collisionPostSolveCallback(*static_cast<PhysicsContact*>(cpArbiterGetUserData(arb)));
 }
 
-void PhysicsWorldCallback::collisionSeparateCallbackFunc(cpArbiter *arb, cpSpace *space, PhysicsWorld *world)
+void PhysicsWorldCallback::collisionSeparateCallbackFunc(cpArbiter *arb, cpSpace* /*space*/, PhysicsWorld *world)
 {
     PhysicsContact* contact = static_cast<PhysicsContact*>(cpArbiterGetUserData(arb));
     
@@ -146,6 +146,7 @@ void PhysicsWorldCallback::rayCastCallbackFunc(cpShape *shape, cpVect point, cpV
         PhysicsHelper::cpv2point(point),
         PhysicsHelper::cpv2point(normal),
         static_cast<float>(alpha),
+        nullptr
     };
     
     PhysicsWorldCallback::continues = info->func(*info->world, callbackInfo, info->data);
@@ -164,14 +165,14 @@ void PhysicsWorldCallback::queryRectCallbackFunc(cpShape *shape, RectQueryCallba
     PhysicsWorldCallback::continues = info->func(*info->world, *physicsShape, info->data);
 }
 
-void PhysicsWorldCallback::getShapesAtPointFunc(cpShape *shape, cpVect point, cpFloat distance, cpVect gradient, Vector<PhysicsShape*>* arr)
+void PhysicsWorldCallback::getShapesAtPointFunc(cpShape *shape, cpVect /*point*/, cpFloat /*distance*/, cpVect /*gradient*/, Vector<PhysicsShape*>* arr)
 {
     PhysicsShape *physicsShape = static_cast<PhysicsShape*>(cpShapeGetUserData(shape));
     CC_ASSERT(physicsShape != nullptr);
     arr->pushBack(physicsShape);
 }
 
-void PhysicsWorldCallback::queryPointFunc(cpShape *shape, cpVect point, cpFloat distance, cpVect gradient, PointQueryCallbackInfo *info)
+void PhysicsWorldCallback::queryPointFunc(cpShape *shape, cpVect /*point*/, cpFloat /*distance*/, cpVect /*gradient*/, PointQueryCallbackInfo *info)
 {
     PhysicsShape *physicsShape = static_cast<PhysicsShape*>(cpShapeGetUserData(shape));
     CC_ASSERT(physicsShape != nullptr);
@@ -188,7 +189,7 @@ static inline cpSpaceDebugColor LAColor(float l, float a){
     return color;
 }
 
-static void DrawCircle(cpVect p, cpFloat a, cpFloat r, cpSpaceDebugColor outline, cpSpaceDebugColor fill, cpDataPointer data)
+static void DrawCircle(cpVect p, cpFloat /*a*/, cpFloat r, cpSpaceDebugColor outline, cpSpaceDebugColor fill, cpDataPointer data)
 {
     const Color4F fillColor(fill.r, fill.g, fill.b, fill.a);
     const Color4F outlineColor(outline.r, outline.g, outline.b, outline.a);
@@ -208,7 +209,7 @@ static void DrawCircle(cpVect p, cpFloat a, cpFloat r, cpSpaceDebugColor outline
     drawNode->drawPolygon(seg, CIRCLE_SEG_NUM, fillColor, 1, outlineColor);
 }
 
-static void DrawFatSegment(cpVect a, cpVect b, cpFloat r, cpSpaceDebugColor outline, cpSpaceDebugColor fill, cpDataPointer data)
+static void DrawFatSegment(cpVect a, cpVect b, cpFloat r, cpSpaceDebugColor outline, cpSpaceDebugColor /*fill*/, cpDataPointer data)
 {
     const Color4F outlineColor(outline.r, outline.g, outline.b, outline.a);
     DrawNode* drawNode = static_cast<DrawNode*>(data);
@@ -222,7 +223,7 @@ static void DrawSegment(cpVect a, cpVect b, cpSpaceDebugColor color, cpDataPoint
     DrawFatSegment(a, b, 0.0, color, color, data);
 }
 
-static void DrawPolygon(int count, const cpVect *verts, cpFloat r, cpSpaceDebugColor outline, cpSpaceDebugColor fill, cpDataPointer data)
+static void DrawPolygon(int count, const cpVect *verts, cpFloat /*r*/, cpSpaceDebugColor outline, cpSpaceDebugColor fill, cpDataPointer data)
 {
     const Color4F fillColor(fill.r, fill.g, fill.b, fill.a);
     const Color4F outlineColor(outline.r, outline.g, outline.b, outline.a);
@@ -237,14 +238,14 @@ static void DrawPolygon(int count, const cpVect *verts, cpFloat r, cpSpaceDebugC
     delete[] seg;
 }
 
-static void DrawDot(cpFloat size, cpVect pos, cpSpaceDebugColor color, cpDataPointer data)
+static void DrawDot(cpFloat /*size*/, cpVect pos, cpSpaceDebugColor color, cpDataPointer data)
 {
     const Color4F dotColor(color.r, color.g, color.b, color.a);
     DrawNode* drawNode = static_cast<DrawNode*>(data);
     drawNode->drawDot(PhysicsHelper::cpv2point(pos), 2, dotColor);
 }
 
-static cpSpaceDebugColor ColorForShape(cpShape *shape, cpDataPointer data)
+static cpSpaceDebugColor ColorForShape(cpShape *shape, cpDataPointer /*data*/)
 {
     if(cpShapeGetSensor(shape)){
         return LAColor(1.0f, 0.3f);

--- a/cocos/physics3d/CCPhysics3DDebugDrawer.cpp
+++ b/cocos/physics3d/CCPhysics3DDebugDrawer.cpp
@@ -55,7 +55,11 @@ void Physics3DDebugDrawer::drawLine( const btVector3& from,const btVector3& to,c
     _dirty = true;
 }
 
-void Physics3DDebugDrawer::drawContactPoint( const btVector3& PointOnB,const btVector3& normalOnB,btScalar distance,int lifeTime,const btVector3& color )
+void Physics3DDebugDrawer::drawContactPoint(const btVector3& PointOnB,
+                                            const btVector3& normalOnB,
+                                            btScalar distance,
+                                            int /*lifeTime*/,
+                                            const btVector3& color)
 {
     drawLine(PointOnB, PointOnB + normalOnB * distance, color);
 }
@@ -63,9 +67,10 @@ void Physics3DDebugDrawer::drawContactPoint( const btVector3& PointOnB,const btV
 void Physics3DDebugDrawer::reportErrorWarning( const char* warningString )
 {
     CCLOG("%s", warningString);
+    CC_UNUSED_PARAM(warningString);
 }
 
-void Physics3DDebugDrawer::draw3dText( const btVector3& location,const char* textString )
+void Physics3DDebugDrawer::draw3dText(const btVector3& /*location*/, const char* /*textString*/)
 {
 
 }
@@ -127,7 +132,7 @@ void Physics3DDebugDrawer::ensureCapacity( int count )
     }
 }
 
-void Physics3DDebugDrawer::drawImplementation( const Mat4 &transform, uint32_t flags )
+void Physics3DDebugDrawer::drawImplementation(const Mat4 & transform, uint32_t /*flags*/)
 {
     _program->use();
     _program->setUniformsForBuiltins(transform);

--- a/cocos/physics3d/CCPhysics3DObject.cpp
+++ b/cocos/physics3d/CCPhysics3DObject.cpp
@@ -379,7 +379,7 @@ public:
     ~btCollider(){};
 
     ///this method is mainly for expert/internal use only.
-    virtual void addOverlappingObjectInternal(btBroadphaseProxy* otherProxy, btBroadphaseProxy* thisProxy = nullptr) override
+    virtual void addOverlappingObjectInternal(btBroadphaseProxy* otherProxy, btBroadphaseProxy* /*thisProxy*/ = nullptr) override
     {
         btCollisionObject* otherObject = (btCollisionObject*)otherProxy->m_clientObject;
         btAssert(otherObject);
@@ -395,7 +395,7 @@ public:
     }
 
     ///this method is mainly for expert/internal use only.
-    virtual void removeOverlappingObjectInternal(btBroadphaseProxy* otherProxy, btDispatcher* dispatcher, btBroadphaseProxy* thisProxy = nullptr) override
+    virtual void removeOverlappingObjectInternal(btBroadphaseProxy* otherProxy, btDispatcher* /*dispatcher*/, btBroadphaseProxy* /*thisProxy*/ = nullptr) override
     {
         btCollisionObject* otherObject = (btCollisionObject*)otherProxy->m_clientObject;
         btAssert(otherObject);

--- a/cocos/platform/CCFileUtils.cpp
+++ b/cocos/platform/CCFileUtils.cpp
@@ -1260,11 +1260,11 @@ std::string FileUtils::getFileExtension(const std::string& filePath) const
     return fileExtension;
 }
 
-void FileUtils::valueMapCompact(ValueMap& valueMap)
+void FileUtils::valueMapCompact(ValueMap & /*valueMap*/)
 {
 }
 
-void FileUtils::valueVectorCompact(ValueVector& valueVector)
+void FileUtils::valueVectorCompact(ValueVector & /*valueVector*/)
 {
 }
 

--- a/cocos/platform/CCImage.cpp
+++ b/cocos/platform/CCImage.cpp
@@ -607,33 +607,24 @@ bool Image::isPng(const unsigned char * data, ssize_t dataLen)
 }
 
 
-bool Image::isEtc(const unsigned char * data, ssize_t dataLen)
+bool Image::isEtc(const unsigned char * data, ssize_t /*dataLen*/)
 {
-    return etc1_pkm_is_valid((etc1_byte*)data) ? true : false;
+    return etc1_pkm_is_valid(static_cast<const etc1_byte*>(data));
 }
 
 
-bool Image::isS3TC(const unsigned char * data, ssize_t dataLen)
+bool Image::isS3TC(const unsigned char * data, ssize_t /*dataLen*/)
 {
+    const S3TCTexHeader* header = reinterpret_cast<const S3TCTexHeader*>(data);
 
-    S3TCTexHeader *header = (S3TCTexHeader *)data;
-    
-    if (strncmp(header->fileCode, "DDS", 3) != 0)
-    {
-        return false;
-    }
-    return true;
+    return (strncmp(header->fileCode, "DDS", 3) == 0);
 }
 
-bool Image::isATITC(const unsigned char *data, ssize_t dataLen)
+bool Image::isATITC(const unsigned char *data, ssize_t /*dataLen*/)
 {
-    ATITCTexHeader *header = (ATITCTexHeader *)data;
+    const ATITCTexHeader* header = reinterpret_cast<const ATITCTexHeader*>(data);
     
-    if (strncmp(&header->identifier[1], "KTX", 3) != 0)
-    {
-        return false;
-    }
-    return true;
+    return (strncmp(&header->identifier[1], "KTX", 3) == 0);
 }
 
 bool Image::isJpg(const unsigned char * data, ssize_t dataLen)
@@ -1329,7 +1320,7 @@ bool Image::initWithTiffData(const unsigned char * data, ssize_t dataLen)
 
 namespace
 {
-    bool testFormatForPvr2TCSupport(PVR2TexturePixelFormat format)
+    bool testFormatForPvr2TCSupport(PVR2TexturePixelFormat /*format*/)
     {
         return true;
     }
@@ -1722,6 +1713,8 @@ bool Image::initWithETCData(const unsigned char * data, ssize_t dataLen)
         _data = static_cast<unsigned char*>(malloc(_dataLen * sizeof(unsigned char)));
         memcpy(_data, static_cast<const unsigned char*>(data) + ETC_PKM_HEADER_SIZE, _dataLen);
         return true;
+#else
+        CC_UNUSED_PARAM(dataLen);
 #endif
     }
     else
@@ -2144,7 +2137,7 @@ bool Image::initWithWebpData(const unsigned char * data, ssize_t dataLen)
 }
 
 
-bool Image::initWithRawData(const unsigned char * data, ssize_t dataLen, int width, int height, int bitsPerComponent, bool preMulti)
+bool Image::initWithRawData(const unsigned char * data, ssize_t /*dataLen*/, int width, int height, int /*bitsPerComponent*/, bool preMulti)
 {
     bool ret = false;
     do 

--- a/cocos/platform/CCThread.cpp
+++ b/cocos/platform/CCThread.cpp
@@ -36,7 +36,7 @@ void* ThreadHelper::createAutoreleasePool()
     return nullptr;
 }
 
-void ThreadHelper::releaseAutoreleasePool(void* autoreleasePool)
+void ThreadHelper::releaseAutoreleasePool(void* /*autoreleasePool*/)
 {
     
 }

--- a/cocos/platform/desktop/CCGLViewImpl-desktop.cpp
+++ b/cocos/platform/desktop/CCGLViewImpl-desktop.cpp
@@ -526,6 +526,8 @@ void GLViewImpl::enableRetina(bool enabled)
         _retinaFactor = 2;
     }
     updateFrameSize();
+#else
+    CC_UNUSED_PARAM(enabled);
 #endif
 }
 
@@ -722,7 +724,7 @@ void GLViewImpl::onGLFWError(int errorID, const char* errorDesc)
     CCLOGERROR("%s", _glfwError.c_str());
 }
 
-void GLViewImpl::onGLFWMouseCallBack(GLFWwindow* window, int button, int action, int modify)
+void GLViewImpl::onGLFWMouseCallBack(GLFWwindow* /*window*/, int button, int action, int /*modify*/)
 {
     if(GLFW_MOUSE_BUTTON_LEFT == button)
     {
@@ -811,7 +813,7 @@ void GLViewImpl::onGLFWMouseMoveCallBack(GLFWwindow* window, double x, double y)
     Director::getInstance()->getEventDispatcher()->dispatchEvent(&event);
 }
 
-void GLViewImpl::onGLFWMouseScrollCallback(GLFWwindow* window, double x, double y)
+void GLViewImpl::onGLFWMouseScrollCallback(GLFWwindow* /*window*/, double x, double y)
 {
     EventMouse event(EventMouse::MouseEventType::MOUSE_SCROLL);
     //Because OpenGL and cocos2d-x uses different Y axis, we need to convert the coordinate here
@@ -822,7 +824,7 @@ void GLViewImpl::onGLFWMouseScrollCallback(GLFWwindow* window, double x, double 
     Director::getInstance()->getEventDispatcher()->dispatchEvent(&event);
 }
 
-void GLViewImpl::onGLFWKeyCallback(GLFWwindow *window, int key, int scancode, int action, int mods)
+void GLViewImpl::onGLFWKeyCallback(GLFWwindow* /*window*/, int key, int /*scancode*/, int action, int /*mods*/)
 {
     if (GLFW_REPEAT != action)
     {
@@ -854,7 +856,7 @@ void GLViewImpl::onGLFWKeyCallback(GLFWwindow *window, int key, int scancode, in
     }
 }
 
-void GLViewImpl::onGLFWCharCallback(GLFWwindow *window, unsigned int character)
+void GLViewImpl::onGLFWCharCallback(GLFWwindow* /*window*/, unsigned int character)
 {
     char16_t wcharString[2] = { (char16_t) character, 0 };
     std::string utf8String;
@@ -879,7 +881,7 @@ void GLViewImpl::onGLFWCharCallback(GLFWwindow *window, unsigned int character)
     }
 }
 
-void GLViewImpl::onGLFWWindowPosCallback(GLFWwindow *windows, int x, int y)
+void GLViewImpl::onGLFWWindowPosCallback(GLFWwindow* /*windows*/, int /*x*/, int /*y*/)
 {
     Director::getInstance()->setViewport();
 }
@@ -913,7 +915,7 @@ void GLViewImpl::onGLFWframebuffersize(GLFWwindow* window, int w, int h)
     }
 }
 
-void GLViewImpl::onGLFWWindowSizeFunCallback(GLFWwindow *window, int width, int height)
+void GLViewImpl::onGLFWWindowSizeFunCallback(GLFWwindow* /*window*/, int width, int height)
 {
     if (width && height && _resolutionPolicy != ResolutionPolicy::UNKNOWN)
     {
@@ -929,7 +931,7 @@ void GLViewImpl::onGLFWWindowSizeFunCallback(GLFWwindow *window, int width, int 
     }
 }
 
-void GLViewImpl::onGLFWWindowIconifyCallback(GLFWwindow* window, int iconified)
+void GLViewImpl::onGLFWWindowIconifyCallback(GLFWwindow* /*window*/, int iconified)
 {
     if (iconified == GL_TRUE)
     {
@@ -941,7 +943,7 @@ void GLViewImpl::onGLFWWindowIconifyCallback(GLFWwindow* window, int iconified)
     }
 }
 
-void GLViewImpl::onGLFWWindowFocusCallback(GLFWwindow* window, int focused)
+void GLViewImpl::onGLFWWindowFocusCallback(GLFWwindow* /*window*/, int focused)
 {
     if (focused == GL_TRUE)
     {

--- a/cocos/platform/linux/CCDevice-linux.cpp
+++ b/cocos/platform/linux/CCDevice-linux.cpp
@@ -104,12 +104,12 @@ int Device::getDPI()
     return dpi;
 }
 
-void Device::setAccelerometerEnabled(bool isEnabled)
+void Device::setAccelerometerEnabled(bool /*isEnabled*/)
 {
 
 }
 
-void Device::setAccelerometerInterval(float interval)
+void Device::setAccelerometerInterval(float /*interval*/)
 {
 
 }
@@ -172,7 +172,7 @@ public:
         return 0;
     }
 
-    bool isBreakPoint(FT_UInt currentCharacter, FT_UInt previousCharacter) {
+    bool isBreakPoint(FT_UInt /*currentCharacter*/, FT_UInt previousCharacter) {
         if ( previousCharacter == '-' || previousCharacter == '/' || previousCharacter == '\\' ) {
             // we can insert a line break after one of these characters
             return true;
@@ -180,7 +180,7 @@ public:
         return false;
     }
 
-    bool divideString(FT_Face face, const char* sText, int iMaxWidth, int iMaxHeight) {
+    bool divideString(FT_Face face, const char* sText, int iMaxWidth, int /*iMaxHeight*/) {
         const char* pText = sText;
         textLines.clear();
         iMaxLineWidth = 0;
@@ -310,7 +310,7 @@ public:
     /**
      * compute the start pos of every line
      */
-    int computeLineStart(FT_Face face, Device::TextAlign eAlignMask, int line) {
+    int computeLineStart(FT_Face /*face*/, Device::TextAlign eAlignMask, int line) {
                 int lineWidth = textLines.at(line).lineWidth;
         if (eAlignMask == Device::TextAlign::CENTER || eAlignMask == Device::TextAlign::TOP || eAlignMask == Device::TextAlign::BOTTOM) {
             return (iMaxLineWidth - lineWidth) / 2;
@@ -438,21 +438,23 @@ public:
                     continue;
                 }
 
-                FT_Bitmap& bitmap = face->glyph->bitmap;
+                FT_Bitmap & bitmap = face->glyph->bitmap;
+
                 int yoffset = iCurYCursor - (face->glyph->metrics.horiBearingY >> 6);
                 int xoffset = iCurXCursor + glyph.paintPosition;
 
-                for (int y = 0; y < bitmap.rows; ++y) {
-                    int iY = yoffset + y;
-                    if (iY>=iMaxLineHeight) {
-                        //exceed the height truncate
-                        break;
-                    }
-                    iY *= iMaxLineWidth;
+                const int max_rows_with_offset =
+                    std::min(static_cast<int>(bitmap.rows) + yoffset, iMaxLineHeight);
+                const int width = bitmap.width;
 
-                    int bitmap_y = y * bitmap.width;
+                for (int y = yoffset; y < max_rows_with_offset; ++y)
+                {
+                    int iY = y * iMaxLineWidth;
 
-                    for (int x = 0; x < bitmap.width; ++x) {
+                    int bitmap_y = y * width;
+
+                    for (int x = 0; x < width; ++x)
+                    {
                         unsigned char cTemp = bitmap.buffer[bitmap_y + x];
                         if (cTemp == 0) {
                             continue;

--- a/cocos/platform/linux/CCDevice-linux.cpp
+++ b/cocos/platform/linux/CCDevice-linux.cpp
@@ -421,8 +421,7 @@ public:
         int txtHeight = (lineHeight * textLines.size());
         iMaxLineHeight = MAX(txtHeight, textDefinition._dimensions.height);
 
-        _data = (unsigned char*)malloc(sizeof(unsigned char) * (iMaxLineWidth * iMaxLineHeight * 4));
-        memset(_data,0, iMaxLineWidth * iMaxLineHeight*4);
+        _data = (unsigned char*)calloc(iMaxLineWidth * iMaxLineHeight * 4, sizeof(unsigned char));
 
         int iCurYCursor = computeLineStartY(face, eAlignMask, txtHeight, iMaxLineHeight);
 
@@ -447,23 +446,18 @@ public:
                     std::min(static_cast<int>(bitmap.rows) + yoffset, iMaxLineHeight);
                 const int width = bitmap.width;
 
-                for (int y = yoffset; y < max_rows_with_offset; ++y)
+                for (int y = yoffset, bitmap_pos = 0; y < max_rows_with_offset; ++y)
                 {
                     int iY = y * iMaxLineWidth;
 
-                    int bitmap_y = y * width;
-
-                    for (int x = 0; x < width; ++x)
+                    for (int x = 0; x < width; ++x, ++bitmap_pos)
                     {
-                        unsigned char cTemp = bitmap.buffer[bitmap_y + x];
-                        if (cTemp == 0) {
-                            continue;
-                        }
-
                         int iX = xoffset + x;
+
                         //FIXME:wrong text color
-                        int iTemp = cTemp << 24 | cTemp << 16 | cTemp << 8 | cTemp;
-                        *(int*) &_data[(iY + iX) * 4 + 0] = iTemp;
+                        uint32_t iTemp = bitmap.buffer[bitmap_pos];
+                        iTemp = iTemp << 24 | iTemp << 16 | iTemp << 8 | iTemp;
+                        reinterpret_cast<uint32_t*>(_data)[iY + iX] = iTemp;
                     }
                 }
             }

--- a/cocos/platform/linux/CCDevice-linux.cpp
+++ b/cocos/platform/linux/CCDevice-linux.cpp
@@ -442,22 +442,22 @@ public:
                 int yoffset = iCurYCursor - (face->glyph->metrics.horiBearingY >> 6);
                 int xoffset = iCurXCursor + glyph.paintPosition;
 
-                const int max_rows_with_offset =
-                    std::min(static_cast<int>(bitmap.rows) + yoffset, iMaxLineHeight);
-                const int width = bitmap.width;
+                const int max_y_with_offset
+                    = std::min(static_cast<int>(bitmap.rows) + yoffset, iMaxLineHeight)
+                    * iMaxLineWidth;
 
-                for (int y = yoffset, bitmap_pos = 0; y < max_rows_with_offset; ++y)
+                const int max_x_with_offset = xoffset + bitmap.width;
+
+                unsigned bitmap_pos = 0;
+
+                for (int y = yoffset * iMaxLineWidth; y < max_y_with_offset; y += iMaxLineWidth)
                 {
-                    int iY = y * iMaxLineWidth;
-
-                    for (int x = 0; x < width; ++x, ++bitmap_pos)
+                    for (int x = xoffset; x < max_x_with_offset; ++x)
                     {
-                        int iX = xoffset + x;
-
                         //FIXME:wrong text color
-                        uint32_t iTemp = bitmap.buffer[bitmap_pos];
+                        uint32_t iTemp = bitmap.buffer[bitmap_pos++];
                         iTemp = iTemp << 24 | iTemp << 16 | iTemp << 8 | iTemp;
-                        reinterpret_cast<uint32_t*>(_data)[iY + iX] = iTemp;
+                        reinterpret_cast<uint32_t*>(_data)[y + x] = iTemp;
                     }
                 }
             }

--- a/cocos/renderer/CCFrameBuffer.h
+++ b/cocos/renderer/CCFrameBuffer.h
@@ -190,8 +190,8 @@ private:
     Color4F _clearColor;
     float   _clearDepth;
     int8_t  _clearStencil;
-    int _width;
-    int _height;
+    unsigned int _width;
+    unsigned int _height;
     RenderTargetBase* _rt;
     RenderTargetDepthStencil* _rtDepthStencil;
     bool _isDefault;

--- a/cocos/renderer/CCGLProgram.cpp
+++ b/cocos/renderer/CCGLProgram.cpp
@@ -198,7 +198,10 @@ GLProgram* GLProgram::createWithFilenames(const std::string& vShaderFilename, co
     return createWithFilenames(vShaderFilename, fShaderFilename, EMPTY_DEFINE, compileTimeDefines);
 }
 
-GLProgram* GLProgram::createWithFilenames(const std::string& vShaderFilename, const std::string& fShaderFilename, const std::string& compileTimeHeaders, const std::string& compileTimeDefines)
+GLProgram* GLProgram::createWithFilenames(const std::string& vShaderFilename,
+                                          const std::string& fShaderFilename,
+                                          const std::string& /*compileTimeHeaders*/,
+                                          const std::string& compileTimeDefines)
 {
     auto ret = new (std::nothrow) GLProgram();
     if(ret && ret->initWithFilenames(vShaderFilename, fShaderFilename, compileTimeDefines)) {

--- a/cocos/renderer/CCGLProgramCache.cpp
+++ b/cocos/renderer/CCGLProgramCache.cpp
@@ -127,9 +127,10 @@ bool GLProgramCache::init()
 {
     loadDefaultGLPrograms();
     
-    auto listener = EventListenerCustom::create(Configuration::CONFIG_FILE_LOADED, [this](EventCustom* event){
-        reloadDefaultGLProgramsRelativeToLights();
-    });
+    auto listener = EventListenerCustom::create(Configuration::CONFIG_FILE_LOADED,
+                                                [this](EventCustom* /*event*/){
+                                                    reloadDefaultGLProgramsRelativeToLights();
+                                                });
     
     Director::getInstance()->getEventDispatcher()->addEventListenerWithFixedPriority(listener, -1);
     

--- a/cocos/renderer/CCRenderState.cpp
+++ b/cocos/renderer/CCRenderState.cpp
@@ -455,27 +455,6 @@ static bool parseBoolean(const std::string& value)
     return (value.compare("true")==0);
 }
 
-static int parseInt(const std::string& value)
-{
-    // Android NDK 10 doesn't support std::stoi a/ std::stoul
-#if CC_TARGET_PLATFORM != CC_PLATFORM_ANDROID
-    return std::stoi(value);
-#else
-    return atoi(value.c_str());
-#endif
-}
-
-static unsigned int parseUInt(const std::string& value)
-{
-    // Android NDK 10 doesn't support std::stoi a/ std::stoul
-#if CC_TARGET_PLATFORM != CC_PLATFORM_ANDROID
-    return (unsigned int)std::stoul(value);
-#else
-    return (unsigned int)atoi(value.c_str());
-#endif
-
-}
-
 static RenderState::Blend parseBlend(const std::string& value)
 {
     // Convert the string to uppercase for comparison.
@@ -576,62 +555,6 @@ static RenderState::FrontFace parseFrontFace(const std::string& value)
     }
 }
 
-static RenderState::StencilFunction parseStencilFunc(const std::string& value)
-{
-    // Convert string to uppercase for comparison
-    std::string upper(value);
-    std::transform(upper.begin(), upper.end(), upper.begin(), (int(*)(int))toupper);
-    if (upper == "NEVER")
-        return RenderState::STENCIL_NEVER;
-    else if (upper == "LESS")
-        return RenderState::STENCIL_LESS;
-    else if (upper == "EQUAL")
-        return RenderState::STENCIL_EQUAL;
-    else if (upper == "LEQUAL")
-        return RenderState::STENCIL_LEQUAL;
-    else if (upper == "GREATER")
-        return RenderState::STENCIL_GREATER;
-    else if (upper == "NOTEQUAL")
-        return RenderState::STENCIL_NOTEQUAL;
-    else if (upper == "GEQUAL")
-        return RenderState::STENCIL_GEQUAL;
-    else if (upper == "ALWAYS")
-        return RenderState::STENCIL_ALWAYS;
-    else
-    {
-        CCLOG("Unsupported stencil function value (%s). Will default to STENCIL_ALWAYS if errors are treated as warnings)", value.c_str());
-        return RenderState::STENCIL_ALWAYS;
-    }
-}
-
-static RenderState::StencilOperation parseStencilOp(const std::string& value)
-{
-    // Convert string to uppercase for comparison
-    std::string upper(value);
-    std::transform(upper.begin(), upper.end(), upper.begin(), (int(*)(int))toupper);
-    if (upper == "KEEP")
-        return RenderState::STENCIL_OP_KEEP;
-    else if (upper == "ZERO")
-        return RenderState::STENCIL_OP_ZERO;
-    else if (upper == "REPLACE")
-        return RenderState::STENCIL_OP_REPLACE;
-    else if (upper == "INCR")
-        return RenderState::STENCIL_OP_INCR;
-    else if (upper == "DECR")
-        return RenderState::STENCIL_OP_DECR;
-    else if (upper == "INVERT")
-        return RenderState::STENCIL_OP_INVERT;
-    else if (upper == "INCR_WRAP")
-        return RenderState::STENCIL_OP_INCR_WRAP;
-    else if (upper == "DECR_WRAP")
-        return RenderState::STENCIL_OP_DECR_WRAP;
-    else
-    {
-        CCLOG("Unsupported stencil operation value (%s). Will default to STENCIL_OP_KEEP if errors are treated as warnings)", value.c_str());
-        return RenderState::STENCIL_OP_KEEP;
-    }
-}
-
 void RenderState::StateBlock::setState(const std::string& name, const std::string& value)
 {
     if (name.compare("blend") == 0)
@@ -670,38 +593,6 @@ void RenderState::StateBlock::setState(const std::string& name, const std::strin
     {
         setDepthFunction(parseDepthFunc(value));
     }
-//    else if (name.compare("stencilTest") == 0)
-//    {
-//        setStencilTest(parseBoolean(value));
-//    }
-//    else if (name.compare("stencilWrite") == 0)
-//    {
-//        setStencilWrite(parseUInt(value));
-//    }
-//    else if (name.compare("stencilFunc") == 0)
-//    {
-//        setStencilFunction(parseStencilFunc(value), _stencilFunctionRef, _stencilFunctionMask);
-//    }
-//    else if (name.compare("stencilFuncRef") == 0)
-//    {
-//        setStencilFunction(_stencilFunction, parseInt(value), _stencilFunctionMask);
-//    }
-//    else if (name.compare("stencilFuncMask") == 0)
-//    {
-//        setStencilFunction(_stencilFunction, _stencilFunctionRef, parseUInt(value));
-//    }
-//    else if (name.compare("stencilOpSfail") == 0)
-//    {
-//        setStencilOperation(parseStencilOp(value), _stencilOpDpfail, _stencilOpDppass);
-//    }
-//    else if (name.compare("stencilOpDpfail") == 0)
-//    {
-//        setStencilOperation(_stencilOpSfail, parseStencilOp(value), _stencilOpDppass);
-//    }
-//    else if (name.compare("stencilOpDppass") == 0)
-//    {
-//        setStencilOperation(_stencilOpSfail, _stencilOpDpfail, parseStencilOp(value));
-//    }
     else
     {
         CCLOG("Unsupported render state string '%s'.", name.c_str());

--- a/cocos/renderer/CCRenderer.cpp
+++ b/cocos/renderer/CCRenderer.cpp
@@ -736,13 +736,16 @@ void Renderer::drawBatchedTriangles()
     _triBatchesToDraw[0].indicesToDraw = 0;
     _triBatchesToDraw[0].cmd = nullptr;
 
+    using materialid_type =
+        decltype(static_cast<TrianglesCommand*>(nullptr)->getMaterialID());
+
+    materialid_type prevMaterialID = static_cast<materialid_type>(-1);
     int batchesTotal = 0;
-    int prevMaterialID = -1;
     bool firstCommand = true;
 
     for(const auto& cmd : _queuedTriangleCommands)
     {
-        auto currentMaterialID = cmd->getMaterialID();
+        materialid_type currentMaterialID = cmd->getMaterialID();
         const bool batchable = !cmd->isSkipBatching();
 
         fillVerticesAndIndices(cmd);
@@ -750,7 +753,11 @@ void Renderer::drawBatchedTriangles()
         // in the same batch ?
         if (batchable && (prevMaterialID == currentMaterialID || firstCommand))
         {
-            CC_ASSERT(firstCommand || _triBatchesToDraw[batchesTotal].cmd->getMaterialID() == cmd->getMaterialID() && "argh... error in logic");
+            CC_ASSERT((firstCommand
+                       || (_triBatchesToDraw[batchesTotal].cmd->getMaterialID()
+                           == cmd->getMaterialID()))
+                      && "argh... error in logic");
+
             _triBatchesToDraw[batchesTotal].indicesToDraw += cmd->getIndexCount();
             _triBatchesToDraw[batchesTotal].cmd = cmd;
         }

--- a/cocos/renderer/CCTexture2D.cpp
+++ b/cocos/renderer/CCTexture2D.cpp
@@ -553,7 +553,12 @@ bool Texture2D::hasPremultipliedAlpha() const
     return _hasPremultipliedAlpha;
 }
 
-bool Texture2D::initWithData(const void *data, ssize_t dataLen, Texture2D::PixelFormat pixelFormat, int pixelsWide, int pixelsHigh, const Size& contentSize)
+bool Texture2D::initWithData(const void *data,
+                             ssize_t dataLen,
+                             Texture2D::PixelFormat pixelFormat,
+                             int pixelsWide,
+                             int pixelsHigh,
+                             const Size & /*contentSize*/)
 {
     CCASSERT(dataLen>0 && pixelsWide>0 && pixelsHigh>0, "Invalid size");
 

--- a/cocos/renderer/CCTextureAtlas.cpp
+++ b/cocos/renderer/CCTextureAtlas.cpp
@@ -211,7 +211,7 @@ bool TextureAtlas::initWithTexture(Texture2D *texture, ssize_t capacity)
     return true;
 }
 
-void TextureAtlas::listenRendererRecreated(EventCustom* event)
+void TextureAtlas::listenRendererRecreated(EventCustom* /*event*/)
 {  
     if (Configuration::getInstance()->supportsShareableVAO())
     {

--- a/cocos/renderer/CCTextureCache.cpp
+++ b/cocos/renderer/CCTextureCache.cpp
@@ -255,7 +255,7 @@ void TextureCache::loadImage()
     }
 }
 
-void TextureCache::addImageAsyncCallBack(float dt)
+void TextureCache::addImageAsyncCallBack(float /*dt*/)
 {
     Texture2D *texture = nullptr;
     AsyncStruct *asyncStruct = nullptr;

--- a/cocos/renderer/ccGLStateCache.cpp
+++ b/cocos/renderer/ccGLStateCache.cpp
@@ -209,7 +209,7 @@ void deleteTexture(GLuint textureId)
 	glDeleteTextures(1, &textureId);
 }
 
-void deleteTextureN(GLuint textureUnit, GLuint textureId)
+void deleteTextureN(GLuint /*textureUnit*/, GLuint textureId)
 {
     deleteTexture(textureId);
 }

--- a/cocos/ui/UIEditBox/UIEditBox.cpp
+++ b/cocos/ui/UIEditBox/UIEditBox.cpp
@@ -61,7 +61,7 @@ EditBox::~EditBox(void)
 }
 
 
-void EditBox::touchDownAction(Ref *sender, TouchEventType controlEvent)
+void EditBox::touchDownAction(Ref* /*sender*/, TouchEventType controlEvent)
 {
     if (controlEvent == Widget::TouchEventType::ENDED) {
         _editBoxImpl->openKeyboard();
@@ -87,7 +87,10 @@ EditBox* EditBox::create(const Size& size,
 }
     
     
-EditBox* EditBox::create(const cocos2d::Size &size, cocos2d::ui::Scale9Sprite *normalSprite, ui::Scale9Sprite *pressedSprite, Scale9Sprite* disabledSprite)
+EditBox* EditBox::create(const cocos2d::Size &      size,
+                         cocos2d::ui::Scale9Sprite* normalSprite,
+                         ui::Scale9Sprite*          /*pressedSprite*/,
+                         Scale9Sprite*              /*disabledSprite*/)
 {
     EditBox* pRet = new (std::nothrow) EditBox();
     
@@ -499,12 +502,11 @@ void EditBox::keyboardWillShow(IMEKeyboardNotificationInfo& info)
     }
 }
 
-void EditBox::keyboardDidShow(IMEKeyboardNotificationInfo& info)
+void EditBox::keyboardDidShow(IMEKeyboardNotificationInfo & /*info*/)
 {
-	
 }
 
-void EditBox::keyboardWillHide(IMEKeyboardNotificationInfo& info)
+void EditBox::keyboardWillHide(IMEKeyboardNotificationInfo & info)
 {
     // CCLOG("CCEditBox::keyboardWillHide");
     if (_editBoxImpl != nullptr)
@@ -513,9 +515,8 @@ void EditBox::keyboardWillHide(IMEKeyboardNotificationInfo& info)
     }
 }
 
-void EditBox::keyboardDidHide(IMEKeyboardNotificationInfo& info)
+void EditBox::keyboardDidHide(IMEKeyboardNotificationInfo & /*info*/)
 {
-	
 }
 
 #if CC_ENABLE_SCRIPT_BINDING

--- a/cocos/ui/UIEditBox/UIEditBox.h
+++ b/cocos/ui/UIEditBox/UIEditBox.h
@@ -63,13 +63,13 @@ namespace ui {
             RETURN
         };
 
-        virtual ~EditBoxDelegate() {};
+        virtual ~EditBoxDelegate() {}
             
         /**
          * This method is called when an edit box gains focus after keyboard is shown.
          * @param editBox The edit box object that generated the event.
          */
-        virtual void editBoxEditingDidBegin(EditBox* editBox) {};
+        virtual void editBoxEditingDidBegin(EditBox* /*editBox*/) {}
             
             
         /**
@@ -77,14 +77,14 @@ namespace ui {
          * @param editBox The edit box object that generated the event.
          * @deprecated Use editBoxEditingDidEndWithAction() instead to receive reason for end
          */
-        CC_DEPRECATED_ATTRIBUTE virtual void editBoxEditingDidEnd(EditBox* editBox) {};
+        CC_DEPRECATED_ATTRIBUTE virtual void editBoxEditingDidEnd(EditBox* /*editBox*/) {}
             
         /**
          * This method is called when the edit box text was changed.
          * @param editBox The edit box object that generated the event.
          * @param text The new text.
          */
-        virtual void editBoxTextChanged(EditBox* editBox, const std::string& text) {};
+        virtual void editBoxTextChanged(EditBox* /*editBox*/, const std::string & /*text*/) {}
             
         /**
          * This method is called when the return button was pressed or the outside area of keyboard was touched.
@@ -97,7 +97,9 @@ namespace ui {
          * @param editBox The edit box object that generated the event.
          * @param type The reason why editing ended.
          */
-        virtual void editBoxEditingDidEndWithAction(EditBox* editBox, EditBoxEndAction action) {};
+        virtual void editBoxEditingDidEndWithAction(EditBox* /*editBox*/,
+                                                    EditBoxEndAction /*action*/)
+        {}
     };
         
     /**

--- a/cocos/ui/UIEditBox/UIEditBoxImpl-common.cpp
+++ b/cocos/ui/UIEditBox/UIEditBoxImpl-common.cpp
@@ -276,7 +276,9 @@ void EditBoxImplCommon::setContentSize(const Size& size)
     placeInactiveLabels();
 }
 
-void EditBoxImplCommon::draw(Renderer *renderer, const Mat4 &transform, uint32_t flags)
+void EditBoxImplCommon::draw(Renderer* /*renderer*/,
+                             const Mat4 & /*transform*/,
+                             uint32_t flags)
 {
     if(flags)
     {
@@ -285,7 +287,7 @@ void EditBoxImplCommon::draw(Renderer *renderer, const Mat4 &transform, uint32_t
     }
 }
 
-void EditBoxImplCommon::onEnter(void)
+void EditBoxImplCommon::onEnter()
 {
     const char* pText = getText();
     if (pText) {
@@ -307,7 +309,7 @@ void EditBoxImplCommon::closeKeyboard()
     this->nativeCloseKeyboard();
 }
 
-void EditBoxImplCommon::onEndEditing(const std::string& text)
+void EditBoxImplCommon::onEndEditing(const std::string & /*text*/)
 {
     this->setNativeVisible(false);
     

--- a/cocos/ui/UIEditBox/UIEditBoxImpl-common.h
+++ b/cocos/ui/UIEditBox/UIEditBoxImpl-common.h
@@ -73,8 +73,8 @@ public:
     
     virtual void setContentSize(const Size& size) override;
     
-    virtual void setAnchorPoint(const Vec2& anchorPoint) override {}
-    virtual void setPosition(const Vec2& pos) override {}
+    virtual void setAnchorPoint(const Vec2 & /*anchorPoint*/) override {}
+    virtual void setPosition(const Vec2 & /*pos*/) override {}
     
     /**
      * @js NA
@@ -112,7 +112,7 @@ public:
     virtual const char* getNativeDefaultFontName() = 0;
     virtual void nativeOpenKeyboard() = 0;
     virtual void nativeCloseKeyboard() = 0;
-    virtual void setNativeMaxLength(int maxLength) {};
+    virtual void setNativeMaxLength(int /*maxLength*/) {}
 
 
 private:
@@ -120,7 +120,8 @@ private:
     void         setInactiveText(const char* pText);
     void         refreshLabelAlignment();
     void         placeInactiveLabels();
-    virtual void doAnimationWhenKeyboardMove(float duration, float distance)override {};
+    virtual void doAnimationWhenKeyboardMove(float /*duration*/,
+                                             float /*distance*/) override {}
 
     Label* _label;
     Label* _labelPlaceHolder;

--- a/cocos/ui/UIEditBox/UIEditBoxImpl-linux.cpp
+++ b/cocos/ui/UIEditBox/UIEditBoxImpl-linux.cpp
@@ -33,7 +33,7 @@
 #include <gtk/gtk.h>
 
 // destroy dialog when lost focus
-static void dialogFocusOutCallback(GtkWidget* widget, gpointer user_data)
+static void dialogFocusOutCallback(GtkWidget* widget, gpointer /*user_data*/)
 {
     gtk_widget_destroy(widget);
 }

--- a/cocos/ui/UIEditBox/UIEditBoxImpl-linux.h
+++ b/cocos/ui/UIEditBox/UIEditBoxImpl-linux.h
@@ -55,27 +55,27 @@ public:
     
 
     virtual bool isEditing() override;
-    virtual void createNativeControl(const Rect& frame) override {};
-    virtual void setNativeFont(const char* pFontName, int fontSize) override {};
-    virtual void setNativeFontColor(const Color4B& color) override {};
-    virtual void setNativePlaceholderFont(const char* pFontName, int fontSize) override {};
-    virtual void setNativePlaceholderFontColor(const Color4B& color) override {};
-    virtual void setNativeInputMode(EditBox::InputMode inputMode) override {};
-    virtual void setNativeInputFlag(EditBox::InputFlag inputFlag) override {};
-    virtual void setNativeReturnType(EditBox::KeyboardReturnType returnType)override {};
-    virtual void setNativeTextHorizontalAlignment(cocos2d::TextHAlignment alignment) {};
-    virtual void setNativeText(const char* pText) override {};
-    virtual void setNativePlaceHolder(const char* pText) override {};
-    virtual void setNativeVisible(bool visible) override {};
-    virtual void updateNativeFrame(const Rect& rect) override {};
-    virtual const char* getNativeDefaultFontName() override {};
+    virtual void createNativeControl(const Rect & /*frame*/) override {}
+    virtual void setNativeFont(const char* /*pFontName*/, int /*fontSize*/) override {}
+    virtual void setNativeFontColor(const Color4B & /*color*/) override {}
+    virtual void setNativePlaceholderFont(const char* /*pFontName*/, int /*fontSize*/) override {}
+    virtual void setNativePlaceholderFontColor(const Color4B & /*color*/) override {}
+    virtual void setNativeInputMode(EditBox::InputMode /*inputMode*/) override {}
+    virtual void setNativeInputFlag(EditBox::InputFlag /*inputFlag*/) override {}
+    virtual void setNativeReturnType(EditBox::KeyboardReturnType /*returnType*/) override {}
+    virtual void setNativeTextHorizontalAlignment(cocos2d::TextHAlignment /*alignment*/) {}
+    virtual void setNativeText(const char* /*pText*/) override {}
+    virtual void setNativePlaceHolder(const char* /*pText*/) override {}
+    virtual void setNativeVisible(bool /*visible*/) override {}
+    virtual void updateNativeFrame(const Rect & /*rect*/) override {}
+    virtual const char* getNativeDefaultFontName() override { /*FIXME: is that right? */ return "sans-serif"; }
     virtual void nativeOpenKeyboard() override;
-    virtual void nativeCloseKeyboard() override {};
-    virtual void setNativeMaxLength(int maxLength) override {};
+    virtual void nativeCloseKeyboard() override {}
+    virtual void setNativeMaxLength(int /*maxLength*/) override {}
 
     
 private:
-    virtual void doAnimationWhenKeyboardMove(float duration, float distance)override {}
+    virtual void doAnimationWhenKeyboardMove(float /*duration*/, float /*distance*/) override {}
 };
 
 

--- a/cocos/ui/UIEditBox/UIEditBoxImpl.h
+++ b/cocos/ui/UIEditBox/UIEditBoxImpl.h
@@ -74,7 +74,7 @@ namespace cocos2d {
             /**
              * check the editbox's position, update it when needed
              */
-            virtual void updatePosition(float dt){};
+            virtual void updatePosition(float /*dt*/) {}
             /**
              * @js NA
              * @lua NA

--- a/cocos/ui/UILayout.cpp
+++ b/cocos/ui/UILayout.cpp
@@ -428,7 +428,7 @@ Layout::ClippingType Layout::getClippingType()const
     return _clippingType;
 }
     
-void Layout::setStencilClippingSize(const Size &size)
+void Layout::setStencilClippingSize(const Size & /*size*/)
 {
     if (_clippingEnabled && _clippingType == ClippingType::STENCIL)
     {

--- a/cocos/ui/UIPageView.cpp
+++ b/cocos/ui/UIPageView.cpp
@@ -110,7 +110,7 @@ void PageView::setDirection(PageView::Direction direction)
     }
 }
 
-void PageView::addWidgetToPage(Widget *widget, ssize_t pageIdx, bool forceCreate)
+void PageView::addWidgetToPage(Widget *widget, ssize_t pageIdx, bool /*forceCreate*/)
 {
     insertCustomItem(widget, pageIdx);
 }
@@ -170,7 +170,7 @@ void PageView::scrollToItem(ssize_t itemIndex, float time)
     ListView::scrollToItem(itemIndex, Vec2::ANCHOR_MIDDLE, Vec2::ANCHOR_MIDDLE, time >= 0 ? time : _scrollTime);
 }
 
-void PageView::setCustomScrollThreshold(float threshold)
+void PageView::setCustomScrollThreshold(float /*threshold*/)
 {
     CCLOG("PageView::setCustomScrollThreshold() has no effect!");
 }
@@ -180,7 +180,7 @@ float PageView::getCustomScrollThreshold()const
     return 0;
 }
 
-void PageView::setUsingCustomScrollThreshold(bool flag)
+void PageView::setUsingCustomScrollThreshold(bool /*flag*/)
 {
     CCLOG("PageView::setUsingCustomScrollThreshold() has no effect!");
 }
@@ -298,11 +298,12 @@ void PageView::addEventListenerPageView(Ref *target, SEL_PageViewEvent selector)
     _pageViewEventListener = target;
     _pageViewEventSelector = selector;
 
-    ccScrollViewCallback scrollViewCallback = [=](Ref* ref, ScrollView::EventType type) -> void{
+    ccScrollViewCallback scrollViewCallback = [=](Ref* /*ref*/, ScrollView::EventType type) -> void {
         if (type == ScrollView::EventType::AUTOSCROLL_ENDED && _previousPageIndex != _currentPageIndex) {
             pageTurningEvent();
         }
     };
+
     this->addEventListener(scrollViewCallback);
 }
 
@@ -328,7 +329,7 @@ void PageView::pageTurningEvent()
 void PageView::addEventListener(const ccPageViewCallback& callback)
 {
     _eventCallback = callback;
-    ccScrollViewCallback scrollViewCallback = [=](Ref* ref, ScrollView::EventType type) -> void{
+    ccScrollViewCallback scrollViewCallback = [=](Ref* /*ref*/, ScrollView::EventType type) -> void{
         if (type == ScrollView::EventType::AUTOSCROLL_ENDED && _previousPageIndex != _currentPageIndex) {
             pageTurningEvent();
         }

--- a/cocos/ui/UIRichText.cpp
+++ b/cocos/ui/UIRichText.cpp
@@ -75,7 +75,7 @@ public:
         _touchListener->release();
     }
 
-    void onTouchesEnded(const std::vector<Touch*>& touches, Event *event)
+    void onTouchesEnded(const std::vector<Touch*>& touches, Event* /*event*/)
     {
         for (const auto& touch: touches)
         {
@@ -357,7 +357,7 @@ MyXMLVisitor::MyXMLVisitor(RichText* richText)
 : _richText(richText)
 , _fontElements(20)
 {
-    MyXMLVisitor::setTagDescription("font", true, [](const ValueMap& tagAttrValueMap) {
+    MyXMLVisitor::setTagDescription("font", true, [](const ValueMap & tagAttrValueMap) {
         // supported attributes:
         // size, color, align, face
         ValueMap attrValueMap;
@@ -375,47 +375,47 @@ MyXMLVisitor::MyXMLVisitor(RichText* richText)
         return make_pair(attrValueMap, nullptr);
     });
     
-    MyXMLVisitor::setTagDescription("b", true, [](const ValueMap& tagAttrValueMap) {
+    MyXMLVisitor::setTagDescription("b", true, [](const ValueMap & /*tagAttrValueMap*/) {
         // no supported attributes
         ValueMap attrValueMap;
         attrValueMap[RichText::KEY_TEXT_BOLD] = true;
         return make_pair(attrValueMap, nullptr);
     });
     
-    MyXMLVisitor::setTagDescription("i", true, [](const ValueMap& tagAttrValueMap) {
+    MyXMLVisitor::setTagDescription("i", true, [](const ValueMap & /*tagAttrValueMap*/) {
         // no supported attributes
         ValueMap attrValueMap;
         attrValueMap[RichText::KEY_TEXT_ITALIC] = true;
         return make_pair(attrValueMap, nullptr);
     });
     
-    MyXMLVisitor::setTagDescription("del", true, [](const ValueMap& tagAttrValueMap) {
+    MyXMLVisitor::setTagDescription("del", true, [](const ValueMap & /*tagAttrValueMap*/) {
         // no supported attributes
         ValueMap attrValueMap;
         attrValueMap[RichText::KEY_TEXT_LINE] = RichText::VALUE_TEXT_LINE_DEL;
         return make_pair(attrValueMap, nullptr);
     });
     
-    MyXMLVisitor::setTagDescription("u", true, [](const ValueMap& tagAttrValueMap) {
+    MyXMLVisitor::setTagDescription("u", true, [](const ValueMap & /*tagAttrValueMap*/) {
         // no supported attributes
         ValueMap attrValueMap;
         attrValueMap[RichText::KEY_TEXT_LINE] = RichText::VALUE_TEXT_LINE_UNDER;
         return make_pair(attrValueMap, nullptr);
     });
     
-    MyXMLVisitor::setTagDescription("small", true, [](const ValueMap& tagAttrValueMap) {
+    MyXMLVisitor::setTagDescription("small", true, [](const ValueMap & /*tagAttrValueMap*/) {
         ValueMap attrValueMap;
         attrValueMap[RichText::KEY_FONT_SMALL] = true;
         return make_pair(attrValueMap, nullptr);
     });
     
-    MyXMLVisitor::setTagDescription("big", true, [](const ValueMap& tagAttrValueMap) {
+    MyXMLVisitor::setTagDescription("big", true, [](const ValueMap & /*tagAttrValueMap*/) {
         ValueMap attrValueMap;
         attrValueMap[RichText::KEY_FONT_BIG] = true;
         return make_pair(attrValueMap, nullptr);
     });
     
-    MyXMLVisitor::setTagDescription("img", false, [](const ValueMap& tagAttrValueMap) {
+    MyXMLVisitor::setTagDescription("img", false, [](const ValueMap & tagAttrValueMap) {
         // supported attributes:
         // src, height, width
         std::string src;
@@ -441,7 +441,7 @@ MyXMLVisitor::MyXMLVisitor(RichText* richText)
         return make_pair(ValueMap(), elementImg);
     });
     
-    MyXMLVisitor::setTagDescription("a", true, [](const ValueMap& tagAttrValueMap) {
+    MyXMLVisitor::setTagDescription("a", true, [](const ValueMap & tagAttrValueMap) {
         // supported attributes:
         ValueMap attrValueMap;
         
@@ -451,12 +451,12 @@ MyXMLVisitor::MyXMLVisitor(RichText* richText)
         return make_pair(attrValueMap, nullptr);
     });
     
-    MyXMLVisitor::setTagDescription("br", false, [](const ValueMap& tagAttrValueMap)  {
+    MyXMLVisitor::setTagDescription("br", false, [](const ValueMap & /*tagAttrValueMap*/)  {
         RichElementNewLine* richElement = RichElementNewLine::create(0, Color3B::WHITE, 255);
         return make_pair(ValueMap(), richElement);
     });
     
-    MyXMLVisitor::setTagDescription("outline", true, [](const ValueMap& tagAttrValueMap) {
+    MyXMLVisitor::setTagDescription("outline", true, [](const ValueMap & tagAttrValueMap) {
         // supported attributes:
         // color, size
         ValueMap attrValueMap;
@@ -471,7 +471,7 @@ MyXMLVisitor::MyXMLVisitor(RichText* richText)
         return make_pair(attrValueMap, nullptr);
     });
     
-    MyXMLVisitor::setTagDescription("shadow", true, [](const ValueMap& tagAttrValueMap) {
+    MyXMLVisitor::setTagDescription("shadow", true, [](const ValueMap & tagAttrValueMap) {
         // supported attributes:
         // color, offsetWidth, offsetHeight, blurRadius
         ValueMap attrValueMap;
@@ -492,7 +492,7 @@ MyXMLVisitor::MyXMLVisitor(RichText* richText)
         return make_pair(attrValueMap, nullptr);
     });
     
-    MyXMLVisitor::setTagDescription("glow", true, [](const ValueMap& tagAttrValueMap) {
+    MyXMLVisitor::setTagDescription("glow", true, [](const ValueMap & tagAttrValueMap) {
         // supported attributes:
         // color
         ValueMap attrValueMap;
@@ -619,7 +619,7 @@ std::tuple<bool, Color3B> MyXMLVisitor::getGlow() const
     return std::make_tuple(false, Color3B::WHITE);
 }
 
-void MyXMLVisitor::startElement(void *ctx, const char *elementName, const char **atts)
+void MyXMLVisitor::startElement(void* /*ctx*/, const char *elementName, const char **atts)
 {
     auto it = _tagTables.find(elementName);
     if (it != _tagTables.end()) {
@@ -743,7 +743,7 @@ void MyXMLVisitor::startElement(void *ctx, const char *elementName, const char *
     }
 }
 
-void MyXMLVisitor::endElement(void *ctx, const char *elementName)
+void MyXMLVisitor::endElement(void* /*ctx*/, const char *elementName)
 {
     auto it = _tagTables.find(elementName);
     if (it != _tagTables.end()) {
@@ -754,7 +754,7 @@ void MyXMLVisitor::endElement(void *ctx, const char *elementName)
     }
 }
 
-void MyXMLVisitor::textHandler(void *ctx, const char *str, size_t len)
+void MyXMLVisitor::textHandler(void* /*ctx*/, const char *str, size_t len)
 {
     std::string text(str, len);
     auto color = getColor();
@@ -1680,7 +1680,12 @@ void RichText::handleTextRenderer(const std::string& text, const std::string& fo
     }
 }
     
-void RichText::handleImageRenderer(const std::string& filePath, const Color3B &color, GLubyte opacity, int width, int height, const std::string& url)
+void RichText::handleImageRenderer(const std::string& filePath,
+                                   const Color3B & /*color*/,
+                                   GLubyte /*opacity*/,
+                                   int width,
+                                   int height,
+                                   const std::string & url)
 {
     Sprite* imageRenderer = Sprite::create(filePath);
     if (imageRenderer)

--- a/cocos/ui/UIScale9Sprite.cpp
+++ b/cocos/ui/UIScale9Sprite.cpp
@@ -524,7 +524,6 @@ namespace ui {
 
             auto capInsets = CC_RECT_POINTS_TO_PIXELS(_capInsetsInternal);
             auto textureRect = CC_RECT_POINTS_TO_PIXELS(_spriteRect);
-            auto spriteRectSize = _spriteRect.size;
             auto originalSize = CC_SIZE_POINTS_TO_PIXELS(_originalSize);
             auto offset = CC_POINT_POINTS_TO_PIXELS(_offset);
             

--- a/cocos/ui/UIScrollView.cpp
+++ b/cocos/ui/UIScrollView.cpp
@@ -168,7 +168,7 @@ void ScrollView::setInnerContainerSize(const Size &size)
 {
     float innerSizeWidth = _contentSize.width;
     float innerSizeHeight = _contentSize.height;
-    Size originalInnerSize = _innerContainer->getContentSize();
+
     if (size.width < _contentSize.width)
     {
         CCLOG("Inner width <= scrollview width, it will be force sized!");
@@ -861,7 +861,7 @@ void ScrollView::gatherTouchMove(const Vec2& delta)
     _touchMovePreviousTimestamp = timestamp;
 }
 
-void ScrollView::handlePressLogic(Touch *touch)
+void ScrollView::handlePressLogic(Touch* /*touch*/)
 {
     _bePressed = true;
     _autoScrolling = false;

--- a/cocos/ui/UISlider.cpp
+++ b/cocos/ui/UISlider.cpp
@@ -456,7 +456,7 @@ void Slider::setPercent(int percent)
     }
 }
     
-bool Slider::hitTest(const cocos2d::Vec2 &pt, const Camera *camera, Vec3 *p) const
+bool Slider::hitTest(const cocos2d::Vec2 &pt, const Camera *camera, Vec3* /*p*/) const
 {
     Rect rect;
     rect.size = _slidBallNormalRenderer->getContentSize();
@@ -479,7 +479,7 @@ bool Slider::onTouchBegan(Touch *touch, Event *unusedEvent)
     return pass;
 }
 
-void Slider::onTouchMoved(Touch *touch, Event *unusedEvent)
+void Slider::onTouchMoved(Touch *touch, Event* /*unusedEvent*/)
 {
     _touchMovePosition = touch->getLocation();
     setPercent(getPercentWithBallPos(_touchMovePosition));

--- a/cocos/ui/UITextField.cpp
+++ b/cocos/ui/UITextField.cpp
@@ -71,13 +71,13 @@ void UICCTextField::onEnter()
 }
 
 
-bool UICCTextField::onTextFieldAttachWithIME(TextFieldTTF *pSender)
+bool UICCTextField::onTextFieldAttachWithIME(TextFieldTTF* /*pSender*/)
 {
     setAttachWithIME(true);
     return false;
 }
 
-bool UICCTextField::onTextFieldInsertText(TextFieldTTF *pSender, const char *text, size_t nLen)
+bool UICCTextField::onTextFieldInsertText(TextFieldTTF* /*pSender*/, const char *text, size_t nLen)
 {
     if (nLen == 1 && strcmp(text, "\n") == 0)
     {
@@ -95,13 +95,13 @@ bool UICCTextField::onTextFieldInsertText(TextFieldTTF *pSender, const char *tex
     return false;
 }
 
-bool UICCTextField::onTextFieldDeleteBackward(TextFieldTTF *pSender, const char *delText, size_t nLen)
+bool UICCTextField::onTextFieldDeleteBackward(TextFieldTTF* /*pSender*/, const char* /*delText*/, size_t /*nLen*/)
 {
     setDeleteBackward(true);
     return false;
 }
 
-bool UICCTextField::onTextFieldDetachWithIME(TextFieldTTF *pSender)
+bool UICCTextField::onTextFieldDetachWithIME(TextFieldTTF* /*pSender*/)
 {
     setDetachWithIME(true);
     return false;
@@ -370,7 +370,7 @@ void TextField::setTouchAreaEnabled(bool enable)
     _useTouchArea = enable;
 }
     
-bool TextField::hitTest(const Vec2 &pt, const Camera* camera, Vec3 *p) const
+bool TextField::hitTest(const Vec2 &pt, const Camera* camera, Vec3* /*p*/) const
 {
     if (false == _useTouchArea)
     {
@@ -582,7 +582,7 @@ const char* TextField::getPasswordStyleText()const
     return _textFieldRenderer->getPasswordTextStyle().c_str();
 }
 
-void TextField::update(float dt)
+void TextField::update(float /*dt*/)
 {
     if (getDetachWithIME())
     {

--- a/cocos/ui/UIWidget.cpp
+++ b/cocos/ui/UIWidget.cpp
@@ -76,7 +76,7 @@ Widget::FocusNavigationController::~FocusNavigationController()
     this->removeKeyboardEventListener();
 }
 
-void Widget::FocusNavigationController::onKeypadKeyPressed(EventKeyboard::KeyCode  keyCode, Event *event)
+void Widget::FocusNavigationController::onKeypadKeyPressed(EventKeyboard::KeyCode keyCode, Event* /*event*/)
 {
     if (_enableFocusNavigation && _firstFocusedWidget)
     {
@@ -770,7 +770,7 @@ bool Widget::isSwallowTouches()const
     return false;
 }
 
-bool Widget::onTouchBegan(Touch *touch, Event *unusedEvent)
+bool Widget::onTouchBegan(Touch *touch, Event* /*unusedEvent*/)
 {
     _hitted = false;
     if (isVisible() && isEnabled() && isAncestorsEnabled() && isAncestorsVisible(this) )
@@ -814,7 +814,7 @@ void Widget::propagateTouchEvent(cocos2d::ui::Widget::TouchEventType event, coco
     }
 }
 
-void Widget::onTouchMoved(Touch *touch, Event *unusedEvent)
+void Widget::onTouchMoved(Touch *touch, Event* /*unusedEvent*/)
 {
     _touchMovePosition = touch->getLocation();
 
@@ -831,7 +831,7 @@ void Widget::onTouchMoved(Touch *touch, Event *unusedEvent)
     moveEvent();
 }
 
-void Widget::onTouchEnded(Touch *touch, Event *unusedEvent)
+void Widget::onTouchEnded(Touch *touch, Event* /*unusedEvent*/)
 {
     _touchEndPosition = touch->getLocation();
 
@@ -856,7 +856,7 @@ void Widget::onTouchEnded(Touch *touch, Event *unusedEvent)
     }
 }
 
-void Widget::onTouchCancelled(Touch *touch, Event *unusedEvent)
+void Widget::onTouchCancelled(Touch* /*touch*/, Event* /*unusedEvent*/)
 {
     setHighlighted(false);
     cancelUpEvent();
@@ -1213,9 +1213,8 @@ GLProgramState* Widget::getGrayGLProgramState(Texture2D* texture)const
     return glState;
 }
 
-void Widget::copySpecialProperties(Widget* model)
+void Widget::copySpecialProperties(Widget* /*model*/)
 {
-
 }
 
 void Widget::copyProperties(Widget *widget)

--- a/cocos/vr/CCVRGenericRenderer.cpp
+++ b/cocos/vr/CCVRGenericRenderer.cpp
@@ -59,10 +59,8 @@ VRGenericRenderer::~VRGenericRenderer()
     CC_SAFE_DELETE(_rightDistortionMesh);
 }
 
-void VRGenericRenderer::setup(GLView* glview)
+void VRGenericRenderer::setup(GLView* /*glview*/)
 {
-//    CC_UNUSED(glview);
-
     // set origin to 0,0 in case origin is not 0,0
     auto vp = Camera::getDefaultViewport();
 

--- a/extensions/GUI/CCControlExtension/CCControl.h
+++ b/extensions/GUI/CCControlExtension/CCControl.h
@@ -155,10 +155,10 @@ public:
      */
     virtual Vec2 getTouchLocation(Touch* touch);
 
-    virtual bool onTouchBegan(Touch *touch, Event *event) override { return false; };
-    virtual void onTouchMoved(Touch *touch, Event *event) override {};
-    virtual void onTouchEnded(Touch *touch, Event *event) override {};
-    virtual void onTouchCancelled(Touch *touch, Event *event) override {};
+    virtual bool onTouchBegan(Touch* /*touch*/, Event* /*event*/) override { return false; }
+    virtual void onTouchMoved(Touch* /*touch*/, Event* /*event*/) override {}
+    virtual void onTouchEnded(Touch* /*touch*/, Event* /*event*/) override {}
+    virtual void onTouchCancelled(Touch* /*touch*/, Event* /*event*/) override {}
     
     /**
      * Returns a boolean value that indicates whether a touch is inside the bounds

--- a/extensions/GUI/CCScrollView/CCScrollView.h
+++ b/extensions/GUI/CCScrollView/CCScrollView.h
@@ -53,12 +53,12 @@ public:
      * @js NA
      * @lua NA
      */
-    virtual void scrollViewDidScroll(ScrollView* view) {};
+    virtual void scrollViewDidScroll(ScrollView* /*view*/) {}
     /**
      * @js NA
      * @lua NA
      */
-    virtual void scrollViewDidZoom(ScrollView* view) {};
+    virtual void scrollViewDidZoom(ScrollView* /*view*/) {}
 };
 
 

--- a/extensions/assets-manager/Manifest.cpp
+++ b/extensions/assets-manager/Manifest.cpp
@@ -23,7 +23,6 @@
  ****************************************************************************/
 
 #include "Manifest.h"
-#include "json/filereadstream.h"
 #include "json/prettywriter.h"
 #include "json/stringbuffer.h"
 


### PR DESCRIPTION
Mainly:
- unused parameters
- signed-unsigned comparisons
- missing breakets