### PR TITLE
Fixed math error (#16837) in Lua function radian2angle

### DIFF
--- a/cocos/scripting/lua-bindings/script/cocos2d/functions.lua
+++ b/cocos/scripting/lua-bindings/script/cocos2d/functions.lua
@@ -338,9 +338,8 @@ function math.angle2radian(angle)
     return angle * pi_div_180
 end
 
-local pi_mul_180 = math.pi * 180
 function math.radian2angle(radian)
-    return radian / pi_mul_180
+    return radian * 180 / math.pi
 end
 
 function io.exists(path)


### PR DESCRIPTION
Fixed the math issue described in #16837. 

> math mistake in cocos/scripting/lua-bindings/script/cocos2d/functions.lua
> ...
> radian2angle should be radian * 180 / math.pi but not radian / (math.pi * 180)