### PR TITLE
unscheduleAll() does not unschedule scheduled with performFunctionInCocosThread.

### DIFF
--- a/cocos/base/CCScheduler.cpp
+++ b/cocos/base/CCScheduler.cpp
@@ -629,11 +629,6 @@ void Scheduler::unscheduleAllWithMinPriority(int minPriority)
 #if CC_ENABLE_SCRIPT_BINDING
     _scriptHandlerEntries.clear();
 #endif
-    
-    {
-        std::unique_lock<std::mutex> lock(_performMutex);
-        _functionsToPerform.clear();
-    }
 }
 
 void Scheduler::unscheduleAllForTarget(void *target)
@@ -828,6 +823,12 @@ void Scheduler::performFunctionInCocosThread(const std::function<void ()> &funct
     _functionsToPerform.push_back(function);
 
     _performMutex.unlock();
+}
+
+void Scheduler::removeAllFunctionsToBePerformedInCocosThread()
+{
+    std::unique_lock<std::mutex> lock(_performMutex);
+    _functionsToPerform.clear();
 }
 
 // main loop

--- a/cocos/base/CCScheduler.cpp
+++ b/cocos/base/CCScheduler.cpp
@@ -629,6 +629,11 @@ void Scheduler::unscheduleAllWithMinPriority(int minPriority)
 #if CC_ENABLE_SCRIPT_BINDING
     _scriptHandlerEntries.clear();
 #endif
+    
+    {
+        std::unique_lock<std::mutex> lock(_performMutex);
+        _functionsToPerform.clear();
+    }
 }
 
 void Scheduler::unscheduleAllForTarget(void *target)

--- a/cocos/base/CCScheduler.h
+++ b/cocos/base/CCScheduler.h
@@ -430,6 +430,15 @@ public:
      */
     void performFunctionInCocosThread( const std::function<void()> &function);
     
+    /**
+     * Remove all pending functions queued to be performed with Scheduler::performFunctionInCocosThread
+     * Functions unscheduled in this manner will not be executed
+     * This function is thread safe
+     * @since v3.14
+     * @js NA
+     */
+    void removeAllFunctionsToBePerformedInCocosThread();
+    
     /////////////////////////////////////
     
     // Deprecated methods:

--- a/tests/cpp-tests/Classes/SchedulerTest/SchedulerTest.cpp
+++ b/tests/cpp-tests/Classes/SchedulerTest/SchedulerTest.cpp
@@ -1160,6 +1160,12 @@ void SchedulerRemoveAllFunctionsToBePerformedInCocosThread::onEnter()
     this->scheduleUpdate();
 }
 
+void SchedulerRemoveAllFunctionsToBePerformedInCocosThread::onExit()
+{
+    SchedulerTestLayer::onExit();
+    this->unscheduleUpdate();
+}
+
 void SchedulerRemoveAllFunctionsToBePerformedInCocosThread::update(float dt) {
     Director::getInstance()->getScheduler()->performFunctionInCocosThread([this] () {
         _sprite->setVisible(false);

--- a/tests/cpp-tests/Classes/SchedulerTest/SchedulerTest.cpp
+++ b/tests/cpp-tests/Classes/SchedulerTest/SchedulerTest.cpp
@@ -29,6 +29,7 @@ SchedulerTests::SchedulerTests()
     ADD_TEST_CASE(ScheduleCallbackTest);
     ADD_TEST_CASE(ScheduleUpdatePriority);
     ADD_TEST_CASE(SchedulerIssue10232);
+    ADD_TEST_CASE(SchedulerRemoveAllFunctionsToBePerformedInCocosThread)
 };
 
 //------------------------------------------------------------------
@@ -1147,4 +1148,43 @@ std::string SchedulerIssue10232::title() const
 std::string SchedulerIssue10232::subtitle() const
 {
     return "Should not crash";
+}
+
+void SchedulerRemoveAllFunctionsToBePerformedInCocosThread::onEnter()
+{
+    SchedulerTestLayer::onEnter();
+    
+    _sprite = Sprite::create("Images/grossinis_sister1.png");
+    _sprite->setPosition(VisibleRect::center());
+    this->addChild(_sprite);
+    this->scheduleUpdate();
+}
+
+void SchedulerRemoveAllFunctionsToBePerformedInCocosThread::update(float dt) {
+    Director::getInstance()->getScheduler()->performFunctionInCocosThread([this] () {
+        _sprite->setVisible(false);
+    });
+    Director::getInstance()->getScheduler()->performFunctionInCocosThread([this] () {
+        _sprite->setVisible(false);
+    });
+    Director::getInstance()->getScheduler()->performFunctionInCocosThread([this] () {
+        _sprite->setVisible(false);
+    });
+    Director::getInstance()->getScheduler()->performFunctionInCocosThread([this] () {
+        _sprite->setVisible(false);
+    });
+    Director::getInstance()->getScheduler()->performFunctionInCocosThread([this] () {
+        _sprite->setVisible(false);
+    });
+    Director::getInstance()->getScheduler()->removeAllFunctionsToBePerformedInCocosThread();
+}
+
+std::string SchedulerRemoveAllFunctionsToBePerformedInCocosThread::title() const
+{
+    return "Removing pending main thread tasks";
+}
+
+std::string SchedulerRemoveAllFunctionsToBePerformedInCocosThread::subtitle() const
+{
+    return "Sprite should be visible";
 }

--- a/tests/cpp-tests/Classes/SchedulerTest/SchedulerTest.h
+++ b/tests/cpp-tests/Classes/SchedulerTest/SchedulerTest.h
@@ -326,4 +326,18 @@ public:
     void update(float dt) override;
 };
 
+class SchedulerRemoveAllFunctionsToBePerformedInCocosThread : public SchedulerTestLayer
+{
+public:
+    CREATE_FUNC(SchedulerRemoveAllFunctionsToBePerformedInCocosThread);
+    
+    virtual std::string title() const override;
+    virtual std::string subtitle() const override;
+    void onEnter() override;
+    void update(float dt) override;
+    
+private:
+    cocos2d::Sprite *_sprite;
+};
+
 #endif

--- a/tests/cpp-tests/Classes/SchedulerTest/SchedulerTest.h
+++ b/tests/cpp-tests/Classes/SchedulerTest/SchedulerTest.h
@@ -334,6 +334,7 @@ public:
     virtual std::string title() const override;
     virtual std::string subtitle() const override;
     void onEnter() override;
+    void onExit() override;
     void update(float dt) override;
     
 private:


### PR DESCRIPTION
Fixing issue where Scheduler::unscheduleAll() would not unschedule functions scheduled with Scheduler::performFunctionInCocosThread.

If I were to schedule a function via Scheduler::performFunctionInCocosThread, and then call unscheduleAll, the scheduled function will still be called. 

This causes issues for my team, as we call Director::getInstance()->restart in cocos2d-js regularly,  and we can have crashes when our custom functions scheduled with Scheduler::performFunctionInCocosThread attempt to call back into the destroyed and recreated javascript context.

In general, it seems like a reasonable expectation that scheduleAll will unschedule functions scheduled with performFunctionInCocosThread. 