### PR TITLE
Remove unnecessary return statement

### DIFF
--- a/cocos/platform/winrt/CCWinRTUtils.cpp
+++ b/cocos/platform/winrt/CCWinRTUtils.cpp
@@ -59,7 +59,6 @@ bool isWindowsPhone()
 #else
     return false;
 #endif
-    return false;
 }
 
 CC_DEPRECATED_ATTRIBUTE std::wstring CC_DLL CCUtf8ToUnicode(const char * pszUtf8Str, unsigned len /*= -1*/)


### PR DESCRIPTION
This return statement is unnecessary since the same return statement can be found above in the `#else` directive.