### PR TITLE
reset stencil program when alpha threshold is set to 1

### DIFF
--- a/cocos/2d/CCClippingNode.cpp
+++ b/cocos/2d/CCClippingNode.cpp
@@ -56,7 +56,8 @@ static void setProgram(Node *n, GLProgram *p)
 
 ClippingNode::ClippingNode()
 : _stencil(nullptr)
-,_stencilStateManager(new StencilStateManager())
+, _stencilStateManager(new StencilStateManager())
+, _originStencilProgram(nullptr)
 {
 }
 
@@ -228,7 +229,6 @@ void ClippingNode::visit(Renderer *renderer, const Mat4 &parentTransform, uint32
         // we need to recursively apply this shader to all the nodes in the stencil node
         // FIXME: we should have a way to apply shader to all nodes without having to do this
         setProgram(_stencil, program);
-        
 #endif
 
     }
@@ -324,6 +324,9 @@ void ClippingNode::setStencil(Node *stencil)
             _stencil->onEnterTransitionDidFinish();
         }
     }
+    
+    if (_stencil != nullptr)
+        _originStencilProgram = _stencil->getGLProgram();
 }
 
 bool ClippingNode::hasContent() const
@@ -338,6 +341,14 @@ GLfloat ClippingNode::getAlphaThreshold() const
 
 void ClippingNode::setAlphaThreshold(GLfloat alphaThreshold)
 {
+#if CC_CLIPPING_NODE_OPENGLES
+    if (alphaThreshold == 1 && alphaThreshold != _stencilStateManager->getAlphaThreshold())
+    {
+        // should reset program used by _stencil
+        setProgram(_stencil, _originStencilProgram);
+    }
+#endif
+    
     _stencilStateManager->setAlphaThreshold(alphaThreshold);
 }
 

--- a/cocos/2d/CCClippingNode.h
+++ b/cocos/2d/CCClippingNode.h
@@ -156,6 +156,7 @@ CC_CONSTRUCTOR_ACCESS:
 
 protected:
     Node* _stencil;
+    GLProgram* _originStencilProgram;
    
     StencilStateManager* _stencilStateManager;
     


### PR DESCRIPTION
if alpha threshold is set to a value != 1.0 first, and is set to 1 again, then the program used by _stencil is not reset which will cause problem