### PR TITLE
Remove consecutive return statement

### DIFF
--- a/cocos/platform/winrt/CCWinRTUtils.cpp
+++ b/cocos/platform/winrt/CCWinRTUtils.cpp
@@ -51,15 +51,14 @@ bool isWindowsPhone()
 {
 #if _MSC_VER >= 1900
     if (Windows::Foundation::Metadata::ApiInformation::IsTypePresent("Windows.Phone.UI.Input.HardwareButtons"))
-    {
         return true;
-    }
+    else
+        return false;
 #elif (WINAPI_FAMILY == WINAPI_FAMILY_PHONE_APP)
     return true;
 #else
     return false;
 #endif
-    return false;
 }
 
 CC_DEPRECATED_ATTRIBUTE std::wstring CC_DLL CCUtf8ToUnicode(const char * pszUtf8Str, unsigned len /*= -1*/)


### PR DESCRIPTION
It's better to put the return statement on [line 62](https://github.com/cocos2d/cocos2d-x/pull/16874/files#diff-55b5d25136c1f5635fda840661b86055L62) in the `else` branch of the `if` statement above to avoid consecutive `return` statements.