### PR TITLE
fix for #16876

### DIFF
--- a/tests/cpp-empty-test/proj.ios/AppController.mm
+++ b/tests/cpp-empty-test/proj.ios/AppController.mm
@@ -72,8 +72,6 @@ static AppDelegate s_sharedApplication;
         // use this method on ios6
         [window setRootViewController:viewController];
     }
-    
-    [window makeKeyAndVisible];
 
     [[UIApplication sharedApplication] setStatusBarHidden: YES];
     
@@ -82,6 +80,9 @@ static AppDelegate s_sharedApplication;
     cocos2d::Director::getInstance()->setOpenGLView(glview);
     
     app->run();
+    
+    [window makeKeyAndVisible];
+    
     return YES;
 }
 


### PR DESCRIPTION
fix for https://github.com/cocos2d/cocos2d-x/issues/16876
also call `[window makeKeyAndVisible];` after app init action seems more correct.

Tested on:
iPod 4th gen iOS 6.1.6
iPod 5th gen iOS 7.1
Simulator iPhone 4s iOS 8.3
iPad mini 2 iOS 9.3.5
iPhone 6 iOS 10.1.1