### PR TITLE
fix: Scale9Sprite test case 18

### DIFF
--- a/cocos/2d/CCSprite.cpp
+++ b/cocos/2d/CCSprite.cpp
@@ -529,19 +529,20 @@ void Sprite::updatePoly()
         //
         // textCoords Data: Y must be inverted.
         //
-        const float u0 = oox + osw * 0;
-        const float u1 = oox + osw * cx1;
-        const float u2 = oox + osw * cx2;
-        const float v0 = ooy + osh - (osh * cy1);
-        const float v1 = ooy + osh * (1 - cy2);
-        const float v2 = ooy + osh * 0;
-
         const float w0 = osw * cx1;
         const float w1 = osw * (cx2-cx1);
         const float w2 = osw * (1-cx2);
         const float h0 = osh * cy1;
         const float h1 = osh * (cy2-cy1);
         const float h2 = osh * (1-cy2);
+
+        const float u0 = oox;
+        const float u1 = u0 + w0;
+        const float u2 = u1 + w1;
+        const float v2 = ooy;
+        const float v1 = v2 + h2;
+        const float v0 = v1 + h1;
+
 
         const Rect texRects_normal[9] = {
             Rect(u0, v0,    w0, h0),   // bottom-left

--- a/cocos/2d/CCSprite.cpp
+++ b/cocos/2d/CCSprite.cpp
@@ -235,7 +235,7 @@ bool Sprite::initWithSpriteFrame(SpriteFrame *spriteFrame)
         return false;
     }
 
-    bool bRet = initWithTexture(spriteFrame->getTexture(), spriteFrame->getRect());
+    bool bRet = initWithTexture(spriteFrame->getTexture(), spriteFrame->getRect(), spriteFrame->isRotated());
     setSpriteFrame(spriteFrame);
 
     return bRet;
@@ -511,8 +511,8 @@ void Sprite::updatePoly()
         // "O"riginal rect
         const float oox = _rect.origin.x;
         const float ooy = _rect.origin.y;
-        const float osw = _rect.size.width;
-        const float osh = _rect.size.height;
+        float osw = _rect.size.width;
+        float osh = _rect.size.height;
 
         if (_rectRotated) {
             std::swap(cx1, cy1);
@@ -523,6 +523,7 @@ void Sprite::updatePoly()
             cy2 = 1 - cy2;
             cy1 = 1 - cy1;
             std::swap(cy1, cy2);
+            std::swap(osw, osh);
         }
 
         //
@@ -584,7 +585,8 @@ void Sprite::updatePoly()
         cy1 = _centerRectNormalized.origin.y;
         cx2 = _centerRectNormalized.origin.x + _centerRectNormalized.size.width;
         cy2 = _centerRectNormalized.origin.y + _centerRectNormalized.size.height;
-
+        if (_rectRotated)
+            std::swap(osw, osh);
 
         // sizes
         float x0_s = osw * cx1;

--- a/cocos/ui/UIScale9Sprite.cpp
+++ b/cocos/ui/UIScale9Sprite.cpp
@@ -501,8 +501,10 @@ void Scale9Sprite::setCapInsets(const cocos2d::Rect &insetsCopy)
 
     // use _rect coordinates. recenter origin to calculate the
     // intersecting rectangle
-    insets.origin.x -= _offsetPosition.x;
-    insets.origin.y -= _offsetPosition.y;
+    // can't use _offsetPosition since it is calculated using bottom-left as origin,
+    // and the center rect is calculated using top-left
+    insets.origin.x -= (_originalContentSize.width - _rect.size.width) / 2 + _unflippedOffsetPositionFromCenter.x;
+    insets.origin.y -= (_originalContentSize.height - _rect.size.height) / 2 - _unflippedOffsetPositionFromCenter.y;
 
     // intersecting rectangle
     const float x1 = std::max(insets.origin.x, 0.0f);


### PR DESCRIPTION
Bug calculating rotated frames.
the width was being used instead of the height and vice-versa