### PR TITLE
Linux Application::openURL return fixed

### DIFF
--- a/cocos/platform/linux/CCApplication-linux.cpp
+++ b/cocos/platform/linux/CCApplication-linux.cpp
@@ -144,7 +144,7 @@ std::string Application::getVersion()
 bool Application::openURL(const std::string &url)
 {
     std::string op = std::string("xdg-open ").append(url);
-    return system(op.c_str())!=-1;
+    return system(op.c_str()) == 0;
 }
 
 //////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
about `std::system` *[cppreference.com](http://en.cppreference.com/w/cpp/utility/program/system) *[cplusplus.com](http://www.cplusplus.com/reference/cstdlib/system/)
about *[xdg-open](https://linux.die.net/man/1/xdg-open)

according this specifications `std::system` returns status code returned by the called command, and `xdg-open` returns 0 if success. So non zero exit code indicates failure and `Application::openURL` should return `false`.