### PR TITLE
Removed unnecessary assignments

### DIFF
--- a/cocos/audio/android/AudioDecoder.cpp
+++ b/cocos/audio/android/AudioDecoder.cpp
@@ -392,7 +392,6 @@ bool AudioDecoder::decodeToPcm()
     SLMetadataInfo *keyInfo, *value;
     for (i = 0; i < itemCount; i++)
     {
-        keyInfo = nullptr;
         keySize = 0;
         value = nullptr;
         valueSize = 0;

--- a/cocos/audio/win32/AudioCache.cpp
+++ b/cocos/audio/win32/AudioCache.cpp
@@ -224,9 +224,8 @@ void AudioCache::readDataTask()
     if (_pcmDataSize <= PCMDATA_CACHEMAXSIZE)
     {
         _pcmData = malloc(_pcmDataSize);
-        auto alError = alGetError();
         alGenBuffers(1, &_alBufferId);
-        alError = alGetError();
+        auto alError = alGetError();
         if (alError != AL_NO_ERROR) {
             log("%s: attaching audio to buffer fail: %x\n", __FUNCTION__, alError);
             goto ExitThread;

--- a/cocos/audio/win32/AudioEngine-win32.cpp
+++ b/cocos/audio/win32/AudioEngine-win32.cpp
@@ -83,12 +83,11 @@ bool AudioEngineImpl::init()
         s_ALDevice = alcOpenDevice(NULL);
         
         if (s_ALDevice) {
-            auto alError = alGetError();
             s_ALContext = alcCreateContext(s_ALDevice, NULL);
             alcMakeContextCurrent(s_ALContext);
             
             alGenSources(MAX_AUDIOINSTANCES, _alSources);
-            alError = alGetError();
+            auto alError = alGetError();
             if(alError != AL_NO_ERROR){
                 ALOGE("%s:generating sources fail! error = %x\n", __FUNCTION__, alError);
                 break;

--- a/cocos/audio/win32/AudioPlayer.cpp
+++ b/cocos/audio/win32/AudioPlayer.cpp
@@ -102,9 +102,8 @@ bool AudioPlayer::play2d(AudioCache* cache)
         _streamingSource = true;
         alSourcei(_alSource, AL_LOOPING, AL_FALSE);
 
-        auto alError = alGetError();
         alGenBuffers(QUEUEBUFFER_NUM, _bufferIds);
-        alError = alGetError();
+        auto alError = alGetError();
         if (alError == AL_NO_ERROR) {
             for (int index = 0; index < QUEUEBUFFER_NUM; ++index) {
                 alBufferData(_bufferIds[index], _audioCache->_alBufferFormat, _audioCache->_queBuffers[index], _audioCache->_queBufferSize[index], _audioCache->_sampleRate);

--- a/cocos/audio/winrt/AudioEngine-winrt.cpp
+++ b/cocos/audio/winrt/AudioEngine-winrt.cpp
@@ -43,10 +43,7 @@ AudioEngineImpl::~AudioEngineImpl()
 
 bool AudioEngineImpl::init()
 {
-    bool ret = false;
-
-    ret = true;
-    return ret;
+    return true;
 }
 
 AudioCache* AudioEngineImpl::preload(const std::string& filePath, std::function<void(bool)> callback)

--- a/cocos/deprecated/CCString.cpp
+++ b/cocos/deprecated/CCString.cpp
@@ -82,13 +82,12 @@ bool __String::initWithFormatAndValist(const char* format, va_list ap)
 
 bool __String::initWithFormat(const char* format, ...)
 {
-    bool bRet = false;
     _string.clear();
 
     va_list ap;
     va_start(ap, format);
 
-    bRet = initWithFormatAndValist(format, ap);
+    bool bRet = initWithFormatAndValist(format, ap);
 
     va_end(ap);
 

--- a/cocos/editor-support/cocostudio/ActionTimeline/CCActionTimelineCache.cpp
+++ b/cocos/editor-support/cocostudio/ActionTimeline/CCActionTimelineCache.cpp
@@ -964,12 +964,10 @@ ActionTimeline* ActionTimelineCache::createActionWithFlatBuffersForSimulator(con
     fbs->_isSimulator = true;
     auto builder = fbs->createFlatBuffersWithXMLFileForSimulator(fileName);
     
-    ActionTimeline* action = ActionTimeline::create();
-    
     auto csparsebinary = GetCSParseBinary(builder->GetBufferPointer());
     auto nodeAction = csparsebinary->action();
     
-    action = ActionTimeline::create();
+    auto action = ActionTimeline::create();
     
     int duration = nodeAction->duration();
     action->setDuration(duration);

--- a/cocos/editor-support/cocostudio/ActionTimeline/CSLoader.cpp
+++ b/cocos/editor-support/cocostudio/ActionTimeline/CSLoader.cpp
@@ -329,11 +329,10 @@ Node* CSLoader::createNodeWithVisibleSize(const std::string &filename, const ccN
 
 std::string CSLoader::getExtentionName(const std::string& name)
 {
-    std::string result = "";
 
     std::string path = name;
     size_t pos = path.find_last_of('.');
-    result = path.substr(pos + 1, path.length());
+    std::string result = path.substr(pos + 1, path.length());
 
     return result;
 }

--- a/cocos/network/SocketIO.cpp
+++ b/cocos/network/SocketIO.cpp
@@ -493,7 +493,6 @@ void SIOClientImpl::handshakeResponse(HttpClient* /*sender*/, HttpResponse *resp
         temp = temp.erase(0, b + 1);
 
         // chomp past the upgrades
-        a = temp.find(":");
         b = temp.find(",");
 
         temp = temp.erase(0, b + 1);

--- a/cocos/platform/CCImage.cpp
+++ b/cocos/platform/CCImage.cpp
@@ -888,9 +888,8 @@ bool Image::encodeWithWIC(const std::string& filePath, bool isToRGB, GUID contai
         std::swap(pSaveData[ind - 2], pSaveData[ind]);
     }
 
-    bool bRet = false;
     WICImageLoader img;
-    bRet = img.encodeImageData(filePath, pSaveData, saveLen, targetFormat, _width, _height, containerFormat);
+    bool bRet = img.encodeImageData(filePath, pSaveData, saveLen, targetFormat, _width, _height, containerFormat);
 
     delete[] pSaveData;
     return bRet;


### PR DESCRIPTION
`cppcheck` is reporting that there are variables getting new values reassigned to them while their previous were never used. 

````
[cocos/audio/win32/AudioCache.cpp:227] -> [audio/win32/AudioCache.cpp:229]: (style, inconclusive) Variable 'alError' is reassigned a value before the old one has been used if variable is no semaphore variable.
[cocos/audio/win32/AudioEngine-win32.cpp:86] -> [audio/win32/AudioEngine-win32.cpp:91]: (style, inconclusive) Variable 'alError' is reassigned a value before the old one has been used if variable is no semaphore variable.
[cocos/audio/win32/AudioPlayer.cpp:105] -> [audio/win32/AudioPlayer.cpp:107]: (style, inconclusive) Variable 'alError' is reassigned a value before the old one has been used if variable is no semaphore variable.
[cocos/editor-support/cocostudio/ActionTimeline/CSLoader.cpp:332] -> [editor-support/cocostudio/ActionTimeline/CSLoader.cpp:336]: (style, inconclusive) Variable 'result' is reassigned a value before the old one has been used if variable is no semaphore variable.
[cocos/network/SocketIO.cpp:496] -> [network/SocketIO.cpp:502]: (style, inconclusive) Variable 'a' is reassigned a value before the old one has been used if variable is no semaphore variable.
````

This pull request mitigates those messages.