### PR TITLE
Improved the way placeholder text color and font is set for edit boxes on iOS

### DIFF
--- a/cocos/ui/UIEditBox/iOS/CCUIEditBoxIOS.mm
+++ b/cocos/ui/UIEditBox/iOS/CCUIEditBoxIOS.mm
@@ -137,12 +137,12 @@
 
 - (void)setPlaceholderFont:(UIFont *)font
 {
-    self.textInput.ccui_placeholderLabel.font = font;
+    self.textInput.ccui_placeholderFont = font;
 }
 
 - (void)setPlaceholderTextColor:(UIColor *)color
 {
-    self.textInput.ccui_placeholderLabel.textColor = color;
+    self.textInput.ccui_placeholderTextColor = color;
 }
 
 - (void)setInputMode:(cocos2d::ui::EditBox::InputMode)inputMode

--- a/cocos/ui/UIEditBox/iOS/CCUIEditBoxIOS.mm
+++ b/cocos/ui/UIEditBox/iOS/CCUIEditBoxIOS.mm
@@ -91,6 +91,7 @@
     // Migrate properties
     textInput.ccui_textColor = _textInput.ccui_textColor ?: [UIColor whiteColor];
     textInput.ccui_text = _textInput.ccui_text ?: @"";
+    textInput.ccui_placeholder = _textInput.ccui_placeholder ?: @"";
     textInput.ccui_placeholderFont = _textInput.ccui_placeholderFont ?: nil;
     textInput.ccui_placeholderTextColor = _textInput.ccui_placeholderTextColor ?: nil;
     textInput.ccui_font = _textInput.ccui_font ?: [UIFont systemFontOfSize:self.frameRect.size.height*2/3];

--- a/cocos/ui/UIEditBox/iOS/CCUIEditBoxIOS.mm
+++ b/cocos/ui/UIEditBox/iOS/CCUIEditBoxIOS.mm
@@ -93,6 +93,8 @@
     textInput.ccui_text = _textInput.ccui_text ?: @"";
     textInput.ccui_placeholder = _textInput.ccui_placeholder ?: @"";
     textInput.ccui_font = _textInput.ccui_font ?: [UIFont systemFontOfSize:self.frameRect.size.height*2/3];
+    textInput.ccui_placeholderFont = _textInput.ccui_placeholderFont;
+    textInput.ccui_placeholderTextColor = _textInput.ccui_placeholderTextColor;
     
     [_textInput resignFirstResponder];
     [_textInput removeFromSuperview];

--- a/cocos/ui/UIEditBox/iOS/CCUIEditBoxIOS.mm
+++ b/cocos/ui/UIEditBox/iOS/CCUIEditBoxIOS.mm
@@ -91,7 +91,8 @@
     // Migrate properties
     textInput.ccui_textColor = _textInput.ccui_textColor ?: [UIColor whiteColor];
     textInput.ccui_text = _textInput.ccui_text ?: @"";
-    textInput.ccui_placeholder = _textInput.ccui_placeholder ?: @"";
+    textInput.ccui_placeholderFont = _textInput.ccui_placeholderFont ?: nil;
+    textInput.ccui_placeholderTextColor = _textInput.ccui_placeholderTextColor ?: nil;
     textInput.ccui_font = _textInput.ccui_font ?: [UIFont systemFontOfSize:self.frameRect.size.height*2/3];
     
     [_textInput resignFirstResponder];

--- a/cocos/ui/UIEditBox/iOS/CCUIEditBoxIOS.mm
+++ b/cocos/ui/UIEditBox/iOS/CCUIEditBoxIOS.mm
@@ -91,8 +91,7 @@
     // Migrate properties
     textInput.ccui_textColor = _textInput.ccui_textColor ?: [UIColor whiteColor];
     textInput.ccui_text = _textInput.ccui_text ?: @"";
-    textInput.ccui_placeholderFont = _textInput.ccui_placeholderFont ?: nil;
-    textInput.ccui_placeholderTextColor = _textInput.ccui_placeholderTextColor ?: nil;
+    textInput.ccui_placeholder = _textInput.ccui_placeholder ?: @"";
     textInput.ccui_font = _textInput.ccui_font ?: [UIFont systemFontOfSize:self.frameRect.size.height*2/3];
     
     [_textInput resignFirstResponder];

--- a/cocos/ui/UIEditBox/iOS/CCUIEditBoxIOS.mm
+++ b/cocos/ui/UIEditBox/iOS/CCUIEditBoxIOS.mm
@@ -93,8 +93,8 @@
     textInput.ccui_text = _textInput.ccui_text ?: @"";
     textInput.ccui_placeholder = _textInput.ccui_placeholder ?: @"";
     textInput.ccui_font = _textInput.ccui_font ?: [UIFont systemFontOfSize:self.frameRect.size.height*2/3];
-    textInput.ccui_placeholderFont = _textInput.ccui_placeholderFont;
-    textInput.ccui_placeholderTextColor = _textInput.ccui_placeholderTextColor;
+    textInput.ccui_placeholderFont = _textInput.ccui_placeholderFont ?: textInput.ccui_font;
+    textInput.ccui_placeholderTextColor = _textInput.ccui_placeholderTextColor ?: [UIColor lightGrayColor];
     
     [_textInput resignFirstResponder];
     [_textInput removeFromSuperview];

--- a/cocos/ui/UIEditBox/iOS/CCUIEditBoxIOS.mm
+++ b/cocos/ui/UIEditBox/iOS/CCUIEditBoxIOS.mm
@@ -91,7 +91,6 @@
     // Migrate properties
     textInput.ccui_textColor = _textInput.ccui_textColor ?: [UIColor whiteColor];
     textInput.ccui_text = _textInput.ccui_text ?: @"";
-    textInput.ccui_placeholder = _textInput.ccui_placeholder ?: @"";
     textInput.ccui_placeholderFont = _textInput.ccui_placeholderFont ?: nil;
     textInput.ccui_placeholderTextColor = _textInput.ccui_placeholderTextColor ?: nil;
     textInput.ccui_font = _textInput.ccui_font ?: [UIFont systemFontOfSize:self.frameRect.size.height*2/3];

--- a/cocos/ui/UIEditBox/iOS/CCUISingleLineTextField.h
+++ b/cocos/ui/UIEditBox/iOS/CCUISingleLineTextField.h
@@ -27,7 +27,11 @@
 #import <UIKit/UIKit.h>
 #import "ui/UIEditBox/iOS/UITextField+CCUITextInput.h"
 
-/** TODO: Missing doc - Why is this subclass necessary?
- */
+#pragma mark - UISingleLineTextField implementation
+
 @interface CCUISingleLineTextField : UITextField
+
+@property (nonatomic, retain) UIColor *placeholderTextColor;
+@property (nonatomic, retain) UIFont *placeholderFont;
+
 @end

--- a/cocos/ui/UIEditBox/iOS/CCUISingleLineTextField.h
+++ b/cocos/ui/UIEditBox/iOS/CCUISingleLineTextField.h
@@ -29,11 +29,9 @@
 
 #pragma mark - UISingleLineTextField implementation
 
-@interface CCUISingleLineTextField : UITextField {
-    NSMutableDictionary *_placeholderDefinition;
-}
+@interface CCUISingleLineTextField : UITextField
 
-@property (nonatomic, retain, setter=setPlaceholderTextColor:) UIColor *placeholderTextColor;
-@property (nonatomic, retain, setter=setPlaceholderFont:) UIFont *placeholderFont;
+@property (nonatomic, retain) UIColor *placeholderTextColor;
+@property (nonatomic, retain) UIFont *placeholderFont;
 
 @end

--- a/cocos/ui/UIEditBox/iOS/CCUISingleLineTextField.h
+++ b/cocos/ui/UIEditBox/iOS/CCUISingleLineTextField.h
@@ -29,9 +29,11 @@
 
 #pragma mark - UISingleLineTextField implementation
 
-@interface CCUISingleLineTextField : UITextField
+@interface CCUISingleLineTextField : UITextField {
+    NSMutableDictionary *_placeholderDefinition;
+}
 
-@property (nonatomic, retain) UIColor *placeholderTextColor;
-@property (nonatomic, retain) UIFont *placeholderFont;
+@property (nonatomic, retain, setter=setPlaceholderTextColor:) UIColor *placeholderTextColor;
+@property (nonatomic, retain, setter=setPlaceholderFont:) UIFont *placeholderFont;
 
 @end

--- a/cocos/ui/UIEditBox/iOS/CCUISingleLineTextField.mm
+++ b/cocos/ui/UIEditBox/iOS/CCUISingleLineTextField.mm
@@ -29,8 +29,53 @@
 
 #include "base/CCDirector.h"
 
+/**
+ * http://stackoverflow.com/questions/18244790/changing-uitextfield-placeholder-font
+ */
+
 
 @implementation CCUISingleLineTextField
+
+#pragma mark - Init & Dealloc
+
+- (instancetype)initWithFrame:(CGRect)frame
+{
+    self = [super initWithFrame:frame];
+    if (self) {
+        _placeholderFont = self.font;
+        _placeholderTextColor = [UIColor lightGrayColor];
+    }
+    return self;
+}
+
+#pragma mark - Properties
+
+- (UIColor *)placeholderTextColor
+{
+    return _placeholderTextColor;
+}
+
+- (UIFont *)placeholderFont
+{
+    return _placeholderFont;
+}
+
+#pragma mark - Public methods
+
+- (void)drawPlaceholderInRect:(CGRect)rect {
+	NSDictionary *attributes = @{
+		NSForegroundColorAttributeName:_placeholderTextColor,
+		NSFontAttributeName:_placeholderFont
+	};
+    
+    // center vertically
+    CGSize textSize = [self.placeholder sizeWithAttributes:attributes];
+    CGFloat hdif = rect.size.height - textSize.height;
+    hdif = MAX(0, hdif);
+    rect.origin.y += ceil(hdif/2.0);
+
+    [[self placeholder] drawInRect:rect withAttributes:attributes];
+}
 
 - (CGRect)textRectForBounds:(CGRect)bounds
 {

--- a/cocos/ui/UIEditBox/iOS/CCUISingleLineTextField.mm
+++ b/cocos/ui/UIEditBox/iOS/CCUISingleLineTextField.mm
@@ -42,10 +42,18 @@
 {
     self = [super initWithFrame:frame];
     if (self) {
-        _placeholderFont = self.font;
-        _placeholderTextColor = [UIColor lightGrayColor];
+        _placeholderFont = [self.font retain];
+        _placeholderTextColor = [[UIColor lightGrayColor] retain];
     }
     return self;
+}
+
+- (void)dealloc
+{
+    [_placeholderFont release];
+    [_placeholderTextColor release];
+
+    [super dealloc];
 }
 
 #pragma mark - Properties

--- a/cocos/ui/UIEditBox/iOS/CCUISingleLineTextField.mm
+++ b/cocos/ui/UIEditBox/iOS/CCUISingleLineTextField.mm
@@ -42,8 +42,10 @@
 {
     self = [super initWithFrame:frame];
     if (self) {
-        _placeholderFont = self.font;
-        _placeholderTextColor = [UIColor lightGrayColor];
+        _placeholderDefinition = [[NSMutableDictionary alloc]
+                                  initWithObjectsAndKeys:
+                                  self.font, NSFontAttributeName,
+                                  [UIColor lightGrayColor], NSForegroundColorAttributeName, nil];
     }
     return self;
 }
@@ -52,29 +54,34 @@
 
 - (UIColor *)placeholderTextColor
 {
-    return _placeholderTextColor;
+    return [_placeholderDefinition objectForKey:NSForegroundColorAttributeName];
 }
 
 - (UIFont *)placeholderFont
 {
-    return _placeholderFont;
+    return [_placeholderDefinition objectForKey:NSFontAttributeName];
+}
+
+-(void)setPlaceholderFont:(UIFont *)placeholderFont
+{
+    [_placeholderDefinition setObject:placeholderFont forKey:NSFontAttributeName];
+}
+
+-(void)setPlaceholderTextColor:(UIColor *)placeholderTextColor
+{
+    [_placeholderDefinition setObject:placeholderTextColor forKey:NSForegroundColorAttributeName];
 }
 
 #pragma mark - Public methods
 
 - (void)drawPlaceholderInRect:(CGRect)rect {
-	NSDictionary *attributes = @{
-		NSForegroundColorAttributeName:_placeholderTextColor,
-		NSFontAttributeName:_placeholderFont
-	};
-    
-    // center vertically
-    CGSize textSize = [self.placeholder sizeWithAttributes:attributes];
-    CGFloat hdif = rect.size.height - textSize.height;
-    hdif = MAX(0, hdif);
-    rect.origin.y += ceil(hdif/2.0);
-
-    [[self placeholder] drawInRect:rect withAttributes:attributes];
+        // center vertically
+        CGSize textSize = [self.placeholder sizeWithAttributes:_placeholderDefinition];
+        CGFloat hdif = rect.size.height - textSize.height;
+        hdif = MAX(0, hdif);
+        rect.origin.y += ceil(hdif/2.0);
+        
+        [[self placeholder] drawInRect:rect withAttributes:_placeholderDefinition];
 }
 
 - (CGRect)textRectForBounds:(CGRect)bounds

--- a/cocos/ui/UIEditBox/iOS/CCUISingleLineTextField.mm
+++ b/cocos/ui/UIEditBox/iOS/CCUISingleLineTextField.mm
@@ -42,10 +42,8 @@
 {
     self = [super initWithFrame:frame];
     if (self) {
-        _placeholderDefinition = [[NSMutableDictionary alloc]
-                                  initWithObjectsAndKeys:
-                                  self.font, NSFontAttributeName,
-                                  [UIColor lightGrayColor], NSForegroundColorAttributeName, nil];
+        _placeholderFont = self.font;
+        _placeholderTextColor = [UIColor lightGrayColor];
     }
     return self;
 }
@@ -54,34 +52,29 @@
 
 - (UIColor *)placeholderTextColor
 {
-    return [_placeholderDefinition objectForKey:NSForegroundColorAttributeName];
+    return _placeholderTextColor;
 }
 
 - (UIFont *)placeholderFont
 {
-    return [_placeholderDefinition objectForKey:NSFontAttributeName];
-}
-
--(void)setPlaceholderFont:(UIFont *)placeholderFont
-{
-    [_placeholderDefinition setObject:placeholderFont forKey:NSFontAttributeName];
-}
-
--(void)setPlaceholderTextColor:(UIColor *)placeholderTextColor
-{
-    [_placeholderDefinition setObject:placeholderTextColor forKey:NSForegroundColorAttributeName];
+    return _placeholderFont;
 }
 
 #pragma mark - Public methods
 
 - (void)drawPlaceholderInRect:(CGRect)rect {
-        // center vertically
-        CGSize textSize = [self.placeholder sizeWithAttributes:_placeholderDefinition];
-        CGFloat hdif = rect.size.height - textSize.height;
-        hdif = MAX(0, hdif);
-        rect.origin.y += ceil(hdif/2.0);
-        
-        [[self placeholder] drawInRect:rect withAttributes:_placeholderDefinition];
+	NSDictionary *attributes = @{
+		NSForegroundColorAttributeName:_placeholderTextColor,
+		NSFontAttributeName:_placeholderFont
+	};
+    
+    // center vertically
+    CGSize textSize = [self.placeholder sizeWithAttributes:attributes];
+    CGFloat hdif = rect.size.height - textSize.height;
+    hdif = MAX(0, hdif);
+    rect.origin.y += ceil(hdif/2.0);
+
+    [[self placeholder] drawInRect:rect withAttributes:attributes];
 }
 
 - (CGRect)textRectForBounds:(CGRect)bounds

--- a/cocos/ui/UIEditBox/iOS/CCUISingleLineTextField.mm
+++ b/cocos/ui/UIEditBox/iOS/CCUISingleLineTextField.mm
@@ -38,16 +38,6 @@
 
 #pragma mark - Init & Dealloc
 
-- (instancetype)initWithFrame:(CGRect)frame
-{
-    self = [super initWithFrame:frame];
-    if (self) {
-        _placeholderFont = [self.font retain];
-        _placeholderTextColor = [[UIColor lightGrayColor] retain];
-    }
-    return self;
-}
-
 - (void)dealloc
 {
     [_placeholderFont release];

--- a/cocos/ui/UIEditBox/iOS/CCUITextInput.h
+++ b/cocos/ui/UIEditBox/iOS/CCUITextInput.h
@@ -34,9 +34,10 @@ static const int CC_EDIT_BOX_PADDING = 5;
 
 @property (nonatomic, retain, setter=ccui_setText:) NSString *ccui_text;
 @property (nonatomic, retain, setter=ccui_setPlaceholder:) NSString *ccui_placeholder;
-@property (nonatomic, retain, setter=ccui_setPlaceholderLabel:) UILabel *ccui_placeholderLabel;
 @property (nonatomic, retain, setter=ccui_setTextColor:) UIColor *ccui_textColor;
 @property (nonatomic, retain, setter=ccui_setFont:) UIFont *ccui_font;
+@property (nonatomic, retain, setter=ccui_setPlaceholderTextColor:) UIColor *ccui_placeholderTextColor;
+@property (nonatomic, retain, setter=ccui_setPlaceholderFont:) UIFont *ccui_placeholderFont;
 @property (nonatomic, assign, setter=ccui_setSecureTextEntry:) BOOL ccui_secureTextEntry;
 @property (nonatomic, assign, setter=ccui_setTextHorizontalAlignment:) NSTextAlignment ccui_alignment;
 

--- a/cocos/ui/UIEditBox/iOS/UITextField+CCUITextInput.mm
+++ b/cocos/ui/UIEditBox/iOS/UITextField+CCUITextInput.mm
@@ -76,6 +76,40 @@
   self.textAlignment = ccui_alignment;
 }
 
+- (UIColor *)ccui_placeholderTextColor
+{
+    SEL selector = @selector(placeholderTextColor);
+    if ([self respondsToSelector:selector]) {
+        return [self performSelector:selector];
+    }
+    return nil;
+}
+
+- (void)ccui_setPlaceholderTextColor:(UIColor *)ccui_placeholderTextColor
+{
+    SEL selector = @selector(setPlaceholderTextColor:);
+    if ([self respondsToSelector:selector]) {
+        [self performSelector:selector withObject:ccui_placeholderTextColor];
+    }
+}
+
+- (UIFont *)ccui_placeholderFont
+{
+    SEL selector = @selector(placeholderFont);
+    if ([self respondsToSelector:selector]) {
+        return [self performSelector:selector];
+    }
+    return nil;
+}
+
+- (void)ccui_setPlaceholderFont:(UIFont *)ccui_placeholderFont
+{
+    SEL selector = @selector(setPlaceholderFont:);
+    if ([self respondsToSelector:selector]) {
+        [self performSelector:selector withObject:ccui_placeholderFont];
+    }
+}
+
 - (BOOL)ccui_secureTextEntry
 {
     return self.secureTextEntry;

--- a/cocos/ui/UIEditBox/iOS/UITextView+CCUITextInput.mm
+++ b/cocos/ui/UIEditBox/iOS/UITextView+CCUITextInput.mm
@@ -46,15 +46,6 @@
     return nil;
 }
 
-- (UILabel *)ccui_placeholderLabel
-{
-    SEL selector = @selector(placeHolderLabel);
-    if ([self respondsToSelector:selector]) {
-        return [self performSelector:selector];
-    }
-    return nil;
-}
-
 - (void)ccui_setPlaceholder:(NSString *)ccui_placeholder
 {
     SEL selector = @selector(setPlaceholder:);
@@ -85,12 +76,46 @@
 
 - (NSTextAlignment)ccui_alignment
 {
-  return self.textAlignment;
+    return self.textAlignment;
 }
 
 - (void)ccui_setTextHorizontalAlignment:(NSTextAlignment)ccui_alignment
 {
-  self.textAlignment = ccui_alignment;
+    self.textAlignment = ccui_alignment;
+}
+
+- (UIColor *)ccui_placeholderTextColor
+{
+    SEL selector = @selector(placeHolderLabel);
+    if ([self respondsToSelector:selector]) {
+        return ((UILabel *)[self performSelector:selector]).textColor;
+    }
+    return nil;
+}
+
+- (void)ccui_setPlaceholderTextColor:(UIColor *)ccui_placeholderTextColor
+{
+    SEL selector = @selector(placeHolderLabel);
+    if ([self respondsToSelector:selector]) {
+        ((UILabel *)[self performSelector:selector]).textColor = ccui_placeholderTextColor;
+    }
+}
+
+- (UIFont *)ccui_placeholderFont
+{
+    SEL selector = @selector(placeHolderLabel);
+    if ([self respondsToSelector:selector]) {
+        return ((UILabel *)[self performSelector:selector]).font;
+    }
+    return nil;
+}
+
+- (void)ccui_setPlaceholderFont:(UIFont *)ccui_placeholderFont
+{
+    SEL selector = @selector(placeHolderLabel);
+    if ([self respondsToSelector:selector]) {
+        ((UILabel *)[self performSelector:selector]).font = ccui_placeholderFont;
+    }
 }
 
 - (BOOL)ccui_secureTextEntry


### PR DESCRIPTION
Previously we submitted https://github.com/cocos2d/cocos2d-x/pull/16821, which added the ability to set placeholder font and color for multiline text views. This PR adds this ability to single line text fields, as well as cleaning up the code for implementing it for multiline text views. 