### PR TITLE
Adds missing Scale9Sprite::initXXX overrided methods after refactoring Scale9 logic. Otherwise, `setupSlice9` will not be invoked.

### DIFF
--- a/cocos/2d/CCSprite.cpp
+++ b/cocos/2d/CCSprite.cpp
@@ -235,10 +235,10 @@ bool Sprite::initWithSpriteFrame(SpriteFrame *spriteFrame)
         return false;
     }
 
-    bool bRet = initWithTexture(spriteFrame->getTexture(), spriteFrame->getRect(), spriteFrame->isRotated());
+    bool ret = initWithTexture(spriteFrame->getTexture(), spriteFrame->getRect(), spriteFrame->isRotated());
     setSpriteFrame(spriteFrame);
 
-    return bRet;
+    return ret;
 }
 
 bool Sprite::initWithPolygon(const cocos2d::PolygonInfo &info)

--- a/cocos/ui/UIScale9Sprite.cpp
+++ b/cocos/ui/UIScale9Sprite.cpp
@@ -153,6 +153,16 @@ bool Scale9Sprite::initWithFile(const Rect& capInsets, const std::string& file)
     return ret;
 }
 
+bool Scale9Sprite::initWithFile(const std::string& file)
+{
+    return initWithFile(file, Rect::ZERO);
+}
+
+bool Scale9Sprite::initWithFile(const std::string& file, const Rect& rect)
+{
+    return initWithFile(file, rect, Rect::ZERO);
+}
+
 bool Scale9Sprite::initWithSpriteFrame(SpriteFrame* spriteFrame, const Rect& capInsets)
 {
     // calls super
@@ -167,6 +177,11 @@ bool Scale9Sprite::initWithSpriteFrameName(const std::string& spriteFrameName, c
     bool ret = Sprite::initWithSpriteFrameName(spriteFrameName);
     setupSlice9(getTexture(), capInsets);
     return ret;
+}
+
+bool Scale9Sprite::initWithSpriteFrameName(const std::string& spriteFrameName)
+{
+    return initWithSpriteFrameName(spriteFrameName, Rect::ZERO);
 }
 
 bool Scale9Sprite::init()

--- a/cocos/ui/UIScale9Sprite.cpp
+++ b/cocos/ui/UIScale9Sprite.cpp
@@ -493,8 +493,6 @@ void Scale9Sprite::resetRender()
 
 void Scale9Sprite::setupSlice9(Texture2D* texture, const Rect& capInsets)
 {
-    setCapInsets(capInsets);
-
     if (texture && texture->isContain9PatchInfo()) {
         auto& parsedCapInset = texture->getSpriteFrameCapInset(getSpriteFrame());
 
@@ -513,6 +511,11 @@ void Scale9Sprite::setupSlice9(Texture2D* texture, const Rect& capInsets)
             _isPatch9 = true;
             setCapInsets(parsedCapInset);
         }
+    }
+
+    if (!_isPatch9)
+    {
+        setCapInsets(capInsets);
     }
 }
 

--- a/cocos/ui/UIScale9Sprite.cpp
+++ b/cocos/ui/UIScale9Sprite.cpp
@@ -245,7 +245,16 @@ bool Scale9Sprite::initWithBatchNode(SpriteBatchNode *batchnode, const Rect &rec
 bool Scale9Sprite::initWithFile(const std::string& filename, const Rect& rect, const Rect& capInsets)
 {
     // calls super
-    bool ret = Sprite::initWithFile(filename, rect);
+    bool ret = false;
+    if (!rect.equals(Rect::ZERO))
+    {
+        ret = Sprite::initWithFile(filename, rect);
+    }
+    else // if rect is zero, use the whole texture size.
+    {
+        ret = Sprite::initWithFile(filename);
+    }
+    
     setCapInsets(capInsets);
     return ret;
 }

--- a/cocos/ui/UIScale9Sprite.h
+++ b/cocos/ui/UIScale9Sprite.h
@@ -252,6 +252,45 @@ namespace ui {
         virtual bool initWithSpriteFrameName(const std::string& spriteFrameName, const Rect& capInsets);
 
         //override function
+
+        /**
+         * Initializes a 9-slice sprite with a texture file and a delimitation zone. The
+         * texture will be broken down into a 3×3 grid of equal blocks.
+         * Once the sprite is created, you can then call its "setContentSize:" method
+         * to resize the sprite will all it's 9-slice goodness intract.
+         * It respects the anchorPoint too.
+         *
+         * @param file The name of the texture file.
+         * @param rect The rectangle that describes the sub-part of the texture that
+         * is the whole image. If the shape is the whole texture, set this to the
+         * texture's full rect.
+         * @return True if initializes success, false otherwise.
+         */
+        virtual bool initWithFile(const std::string& file, const Rect& rect) override;
+
+        /**
+         * Initializes a 9-slice sprite with a texture file. The whole texture will be
+         * broken down into a 3×3 grid of equal blocks.
+         * Once the sprite is created, you can then call its "setContentSize:" method
+         * to resize the sprite will all it's 9-slice goodness intract.
+         * It respects the anchorPoint too.
+         *
+         * @param file The name of the texture file.
+         * @return True if initializes success, false otherwise.
+         */
+        virtual bool initWithFile(const std::string& file) override;
+
+        /**
+         * Initializes a 9-slice sprite with an sprite frame name.
+         * Once the sprite is created, you can then call its "setContentSize:" method
+         * to resize the sprite will all it's 9-slice goodness intract.
+         * It respects the anchorPoint too.
+         *
+         * @param spriteFrameName The sprite frame name.
+         * @return True if initializes success, false otherwise.
+         */
+        virtual bool initWithSpriteFrameName(const std::string& spriteFrameName) override;
+
         virtual bool init() override;
 
         /**

--- a/cocos/ui/UIScale9Sprite.h
+++ b/cocos/ui/UIScale9Sprite.h
@@ -593,8 +593,6 @@ namespace ui {
 
         bool _isPatch9;
 
-        Rect _previousCenterRectNormalized;
-
         float _insetLeft;
         float _insetRight;
         float _insetTop;


### PR DESCRIPTION
Some fixes for Scale9Sprite:

* Adds missing Scale9Sprite::initXXX overrided methods after refactoring Scale9 logic. Otherwise, `setupSlice9` will not be invoked. Test case is: `1. Node: Scene3D -> Description -> Scale9Sprite`
* Call Sprite::initWithFile(filename) in Scale9Sprite::initWithFile(filename) rather than Scale9Sprite::initWithFile(filename, Rect::ZERO). Otherwise content size will be zero which is incorrect. Test case: `52: UI -> GUI Dynamic Create Test -> Scale9Sprite -> background display is wrong without this fix`
* setCapInsets in updateCapInset only when it’s in slice mode.
* setCapInsets should reset _insetLeft, _insetTop, _insetRight, _insetBottom member variables.
* Remove `_previousCenterRectNormalized`, just updateCapInset while switching to SLICE mode.
* Fixes JSTest -> ExtensionTest -> EditBoxTest: no background of editbox.
* Avoids an unused `setCapInsets` invocation in setupSlice9.