### PR TITLE
Update AssetsManagerEx.cpp

### DIFF
--- a/extensions/assets-manager/AssetsManagerEx.cpp
+++ b/extensions/assets-manager/AssetsManagerEx.cpp
@@ -799,6 +799,7 @@ void AssetsManagerEx::update()
         }
             break;
         case State::PREDOWNLOAD_MANIFEST:
+        case State::DOWNLOADING_MANIFEST:
         {
             downloadManifest();
         }


### PR DESCRIPTION
If we met downloading project.manifest error, we call update again, we need to ```downloadManifest()``` again.