### PR TITLE
use GLsizei to avoid overflow

### DIFF
--- a/cocos/renderer/CCRenderer.h
+++ b/cocos/renderer/CCRenderer.h
@@ -249,8 +249,8 @@ protected:
     // Internal structure that has the information for the batches
     struct TriBatchToDraw {
         TrianglesCommand* cmd;  // needed for the Material
-        GLushort indicesToDraw;
-        GLushort offset;
+        GLsizei indicesToDraw;
+        GLsizei offset;
     };
     // capacity of the array of TriBatches
     int _triBatchesToDrawCapacity;


### PR DESCRIPTION
```c++
void Renderer::processRenderCommand(RenderCommand* command)
{
        ...
        // flush own queue when buffer is full
        if(_filledVertex + cmd->getVertexCount() > VBO_SIZE || _filledIndex + cmd->getIndexCount() > INDEX_VBO_SIZE)
        {
            CCASSERT(cmd->getVertexCount()>= 0 && cmd->getVertexCount() < VBO_SIZE, "VBO for vertex is not big enough, please break the data down or use customized render command");
            CCASSERT(cmd->getIndexCount()>= 0 && cmd->getIndexCount() < INDEX_VBO_SIZE, "VBO for index is not big enough, please break the data down or use customized render command");
            drawBatchedTriangles();
        }
       ...
}
```
VVBO_SIZE = 65536
INDEX_VBO_SIZE = VBO_SIZE * 6 / 4 = 98304 
so when `_filledIndex + cmd->getIndexCount()` > max value of glushort, drawBatchedTriangles() will not be invoked. `TrianglesCommand. indicesToDraw` in used in `Renderer::drawBatchedTriangles()` like this
```c++
void Renderer::drawBatchedTriangles()
{
    ...
    for(const auto& cmd : _queuedTriangleCommands)
    {
        // in the same batch ?
        if (batchable && (prevMaterialID == currentMaterialID || firstCommand))
        {
            CC_ASSERT(firstCommand || _triBatchesToDraw[batchesTotal].cmd->getMaterialID() == cmd->getMaterialID() && "argh... error in logic");
            _triBatchesToDraw[batchesTotal].indicesToDraw += cmd->getIndexCount();
            _triBatchesToDraw[batchesTotal].cmd = cmd;
        }
        else
        {
            // is this the first one?
            if (!firstCommand) {
                batchesTotal++;
                _triBatchesToDraw[batchesTotal].offset = _triBatchesToDraw[batchesTotal-1].offset + _triBatchesToDraw[batchesTotal-1].indicesToDraw;
            }

            _triBatchesToDraw[batchesTotal].cmd = cmd;
            _triBatchesToDraw[batchesTotal].indicesToDraw = (int) cmd->getIndexCount(); // may cause overflow
           
            ...
        }
        ...
```