### PR TITLE
Sync editbox improvement from cocos creator

### DIFF
--- a/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxEditBox.java
+++ b/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxEditBox.java
@@ -119,6 +119,10 @@ public class Cocos2dxEditBox extends EditText {
     private static final int kTextHorizontalAlignmentCenter = 1;
     private static final int kTextHorizontalAlignmentRight = 2;
 
+    private static final int kTextVerticalAlignmentTop = 0;
+    private static final int kTextVerticalAlignmentCenter = 1;
+    private static final int getkTextVerticalAlignmentBottom = 2;
+
     private int mInputFlagConstraints; 
     private int mInputModeConstraints;
     private  int mMaxLength;
@@ -191,26 +195,50 @@ public class Cocos2dxEditBox extends EditText {
     }
 
     public void setTextHorizontalAlignment(int alignment) {
+        int gravity = this.getGravity();
         switch (alignment) {
             case kTextHorizontalAlignmentLeft:
-                this.setGravity(Gravity.LEFT);
+                gravity = gravity | Gravity.LEFT;
                 break;
             case kTextHorizontalAlignmentCenter:
-                this.setGravity(Gravity.CENTER);
+                gravity = gravity | Gravity.CENTER;
                 break;
             case kTextHorizontalAlignmentRight:
-                this.setGravity(Gravity.RIGHT);
+                gravity = gravity | Gravity.RIGHT;
                 break;
             default:
-                this.setGravity(Gravity.LEFT);
+                gravity = gravity | Gravity.LEFT;
                 break;
         }
+        this.setGravity(gravity);
+    }
+
+    public void setTextVerticalAlignment(int alignment) {
+        int gravity = this.getGravity();
+        switch (alignment) {
+            case kTextVerticalAlignmentTop:
+                gravity = gravity | Gravity.TOP;
+                break;
+            case kTextVerticalAlignmentCenter:
+                gravity = gravity | Gravity.CENTER_VERTICAL;
+                break;
+            case getkTextVerticalAlignmentBottom:
+                gravity = gravity | Gravity.BOTTOM;
+                break;
+            default:
+                gravity = gravity | Gravity.CENTER_VERTICAL;
+                break;
+        }
+
+        this.setGravity(gravity);
     }
 
     public  void setInputMode(int inputMode){
-
+        this.setTextHorizontalAlignment(kTextHorizontalAlignmentLeft);
+        this.setTextVerticalAlignment(kTextVerticalAlignmentCenter);
         switch (inputMode) {
             case kEditBoxInputModeAny:
+                this.setTextVerticalAlignment(kTextVerticalAlignmentTop);
                 this.mInputModeConstraints = InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_FLAG_MULTI_LINE;
                 break;
             case kEditBoxInputModeEmailAddr:

--- a/cocos/ui/UIEditBox/Mac/CCUIPasswordTextField.h
+++ b/cocos/ui/UIEditBox/Mac/CCUIPasswordTextField.h
@@ -26,9 +26,8 @@
 #import <AppKit/AppKit.h>
 #include "ui/UIEditBox/Mac/CCUITextInput.h"
 
-@interface CCUIPasswordTextField : NSSecureTextField<CCUITextInput>
+@interface CCUIPasswordTextField : NSTextField<CCUITextInput>
 {
-    NSMutableDictionary* _placeholderAttributes;
 }
 
 @end

--- a/cocos/ui/UIEditBox/Mac/CCUIPasswordTextField.m
+++ b/cocos/ui/UIEditBox/Mac/CCUIPasswordTextField.m
@@ -26,6 +26,78 @@
 #import "ui/UIEditBox/Mac/CCUIPasswordTextField.h"
 #include "ui/UIEditBox/Mac/CCUITextFieldFormatter.h"
 
+@interface RSVerticallyCenteredSecureTextFieldCell : NSSecureTextFieldCell
+{
+    BOOL mIsEditingOrSelecting;
+}
+
+@end
+
+@implementation RSVerticallyCenteredSecureTextFieldCell
+
+- (NSRect)drawingRectForBounds:(NSRect)theRect
+{
+    // Get the parent's idea of where we should draw
+    NSRect newRect = [super drawingRectForBounds:theRect];
+
+    // When the text field is being
+    // edited or selected, we have to turn off the magic because it screws up
+    // the configuration of the field editor.  We sneak around this by
+    // intercepting selectWithFrame and editWithFrame and sneaking a
+    // reduced, centered rect in at the last minute.
+    if (mIsEditingOrSelecting == NO)
+    {
+        // Get our ideal size for current text
+        NSSize textSize = [self cellSizeForBounds:theRect];
+
+        // Center that in the proposed rect
+        float heightDelta = newRect.size.height - textSize.height;
+        if (heightDelta > 0)
+        {
+            newRect.size.height -= heightDelta;
+            newRect.origin.y += (heightDelta / 2);
+        }
+    }
+
+    return newRect;
+}
+
+- (void)selectWithFrame:(NSRect)aRect
+                 inView:(NSView *)controlView
+                 editor:(NSText *)textObj
+               delegate:(id)anObject
+                  start:(long)selStart
+                 length:(long)selLength
+{
+    aRect = [self drawingRectForBounds:aRect];
+    mIsEditingOrSelecting = YES;
+    [super selectWithFrame:aRect
+                    inView:controlView
+                    editor:textObj
+                  delegate:anObject
+                     start:selStart
+                    length:selLength];
+    mIsEditingOrSelecting = NO;
+}
+
+- (void)editWithFrame:(NSRect)aRect
+               inView:(NSView *)controlView
+               editor:(NSText *)textObj
+             delegate:(id)anObject
+                event:(NSEvent *)theEvent
+{
+    aRect = [self drawingRectForBounds:aRect];
+    mIsEditingOrSelecting = YES;
+    [super editWithFrame:aRect
+                  inView:controlView
+                  editor:textObj
+                delegate:anObject
+                   event:theEvent];
+    mIsEditingOrSelecting = NO;
+}
+
+@end
+
 @interface CCUIPasswordTextField()
 @property (nonatomic, retain) NSMutableDictionary *placeholderAttributes;
 
@@ -34,32 +106,26 @@
 @implementation CCUIPasswordTextField
 {
 }
-
-@synthesize placeholderAttributes = _placeholderAttributes;
-
 -(id) initWithFrame:(NSRect)frameRect
 {
     if ([super initWithFrame:frameRect]) {
-        NSFont* font = [NSFont systemFontOfSize:frameRect.size.height * 3 /2];
-        self.placeholderAttributes = [NSMutableDictionary dictionaryWithObjectsAndKeys:
-                                      font, NSFontAttributeName,
-                                      [NSColor grayColor], NSForegroundColorAttributeName,
-                                      nil];
+     
+        [self setLineBreakMode:NSLineBreakByTruncatingTail];
+
     }
     
     return self;
 }
 
-- (void)dealloc
++(void)load
 {
-    self.placeholderAttributes = nil;
-    
-    [super dealloc];
+    [self setCellClass:[RSVerticallyCenteredSecureTextFieldCell class]];
 }
+
 
 -(void)ccui_setPlaceholderFont:(NSFont *)font
 {
-    [self.placeholderAttributes setObject:font forKey:NSFontAttributeName];
+    //TODO:
 }
 
 -(NSString*)ccui_placeholder
@@ -69,27 +135,22 @@
 
 -(NSFont*)ccui_placeholderFont
 {
-    return [self.placeholderAttributes objectForKey:NSFontAttributeName];
+    return [NSFont systemFontOfSize:self.bounds.size.height * 3.0 / 2.0];
 }
 
 -(NSColor*)ccui_placeholderColor
 {
-    return [self.placeholderAttributes objectForKey:NSForegroundColorAttributeName];
+    return [NSColor whiteColor];
 }
 
 -(void)ccui_setPlaceholder:(NSString *)text
 {
-    NSAttributedString *as = [[NSAttributedString alloc] initWithString:text
-                                                             attributes:self.placeholderAttributes];
-    
-    [[self cell] setPlaceholderAttributedString:as];
-    
-    [as release];
+    //TODO:
 }
 
 -(void)ccui_setPlaceholderColor:(NSColor *)color
 {
-    [self.placeholderAttributes setObject:color forKey:NSForegroundColorAttributeName];
+    //TODO;
 }
 
 #pragma mark - CCUITextInput

--- a/cocos/ui/UIEditBox/Mac/CCUISingleLineTextField.h
+++ b/cocos/ui/UIEditBox/Mac/CCUISingleLineTextField.h
@@ -28,7 +28,6 @@
 
 @interface CCUISingleLineTextField : NSTextField<CCUITextInput>
 {
-    NSMutableDictionary* _placeholderAttributes;
 }
 
 @end

--- a/cocos/ui/UIEditBox/Mac/CCUISingleLineTextField.m
+++ b/cocos/ui/UIEditBox/Mac/CCUISingleLineTextField.m
@@ -26,53 +26,107 @@
 #import "ui/UIEditBox/Mac/CCUISingleLineTextField.h"
 #include "ui/UIEditBox/Mac/CCUITextFieldFormatter.h"
 
-@interface CCUISingleLineTextField()
-@property (nonatomic, retain) NSMutableDictionary *placeholderAttributes;
+@interface RSVerticallyCenteredTextFieldCell : NSTextFieldCell
+{
+    BOOL mIsEditingOrSelecting;
+}
 
 @end
+
+@implementation RSVerticallyCenteredTextFieldCell
+
+- (NSRect)drawingRectForBounds:(NSRect)theRect
+{
+    // Get the parent's idea of where we should draw
+    NSRect newRect = [super drawingRectForBounds:theRect];
+    
+    // When the text field is being
+    // edited or selected, we have to turn off the magic because it screws up
+    // the configuration of the field editor.  We sneak around this by
+    // intercepting selectWithFrame and editWithFrame and sneaking a
+    // reduced, centered rect in at the last minute.
+    if (mIsEditingOrSelecting == NO)
+    {
+        // Get our ideal size for current text
+        NSSize textSize = [self cellSizeForBounds:theRect];
+        
+        // Center that in the proposed rect
+        float heightDelta = newRect.size.height - textSize.height;
+        if (heightDelta > 0)
+        {
+            newRect.size.height -= heightDelta;
+            newRect.origin.y += (heightDelta / 2);
+        }
+    }
+    
+    return newRect;
+}
+
+- (void)selectWithFrame:(NSRect)aRect
+                 inView:(NSView *)controlView
+                 editor:(NSText *)textObj
+               delegate:(id)anObject
+                  start:(long)selStart
+                 length:(long)selLength
+{
+    aRect = [self drawingRectForBounds:aRect];
+    mIsEditingOrSelecting = YES;
+    [super selectWithFrame:aRect
+                    inView:controlView
+                    editor:textObj
+                  delegate:anObject
+                     start:selStart
+                    length:selLength];
+    mIsEditingOrSelecting = NO;
+}
+
+- (void)editWithFrame:(NSRect)aRect
+               inView:(NSView *)controlView
+               editor:(NSText *)textObj
+             delegate:(id)anObject
+                event:(NSEvent *)theEvent
+{
+    aRect = [self drawingRectForBounds:aRect];
+    mIsEditingOrSelecting = YES;
+    [super editWithFrame:aRect
+                  inView:controlView
+                  editor:textObj
+                delegate:anObject
+                   event:theEvent];
+    mIsEditingOrSelecting = NO;
+}
+
+@end
+
 
 @implementation CCUISingleLineTextField
 {
 }
 
-@synthesize placeholderAttributes = _placeholderAttributes;
-
 -(id) initWithFrame:(NSRect)frameRect
 {
     if ([super initWithFrame:frameRect]) {
-        NSFont* font = [NSFont systemFontOfSize:frameRect.size.height * 3 /2];
-        self.placeholderAttributes = [NSMutableDictionary dictionaryWithObjectsAndKeys:
-                                      font, NSFontAttributeName,
-                                      [NSColor grayColor], NSForegroundColorAttributeName,
-                                      nil];
         [self setLineBreakMode:NSLineBreakByTruncatingTail];
     }
     
     return self;
 }
 
-- (void)dealloc
++(void)load
 {
-    self.placeholderAttributes = nil;
-    
-    [super dealloc];
+    [self setCellClass:[RSVerticallyCenteredTextFieldCell class]];
 }
 
 -(void)ccui_setPlaceholderFont:(NSFont *)font
 {
-    [self.placeholderAttributes setObject:font forKey:NSFontAttributeName];
+    //TODO:
 }
 
 
 
 -(void)ccui_setPlaceholder:(NSString *)text
 {
-    NSAttributedString *as = [[NSAttributedString alloc] initWithString:text
-                                                             attributes:self.placeholderAttributes];
-    
-    [[self cell] setPlaceholderAttributedString:as];
-    
-    [as release];
+    //TODO:
 }
 
 -(NSString*)ccui_placeholder
@@ -82,17 +136,18 @@
 
 -(NSFont*)ccui_placeholderFont
 {
-    return [self.placeholderAttributes objectForKey:NSFontAttributeName];
+    //FIXME:
+    return [NSFont systemFontOfSize:self.bounds.size.height * 3.0 / 2.0];
 }
 
 -(NSColor*)ccui_placeholderColor
 {
-    return [self.placeholderAttributes objectForKey:NSForegroundColorAttributeName];
+    return [NSColor whiteColor];
 }
 
 -(void)ccui_setPlaceholderColor:(NSColor *)color
 {
-    [self.placeholderAttributes setObject:color forKey:NSForegroundColorAttributeName];
+    //TODO:
 }
 
 - (NSString *)ccui_text

--- a/cocos/ui/UIEditBox/UIEditBoxImpl-common.cpp
+++ b/cocos/ui/UIEditBox/UIEditBoxImpl-common.cpp
@@ -86,25 +86,45 @@ void EditBoxImplCommon::initInactiveLabels(const Size& size)
     const char* pDefaultFontName = this->getNativeDefaultFontName();
 
     _label = Label::create();
-    _label->setAnchorPoint(Vec2(0, 0.5f));
-    _label->setColor(Color3B::WHITE);
+    _label->setAnchorPoint(Vec2(0,1));
+    _label->setOverflow(Label::Overflow::CLAMP);
     _label->setVisible(false);
     _editBox->addChild(_label, kLabelZOrder);
     
     _labelPlaceHolder = Label::create();
-    _labelPlaceHolder->setAnchorPoint(Vec2(0, 0.5f));
+    _labelPlaceHolder->setAnchorPoint(Vec2(0, 1.0f));
     _labelPlaceHolder->setColor(Color3B::GRAY);
+    _labelPlaceHolder->enableWrap(false);
     _editBox->addChild(_labelPlaceHolder, kLabelZOrder);
     
     setFont(pDefaultFontName, size.height*2/3);
     setPlaceholderFont(pDefaultFontName, size.height*2/3);
 }
 
-void EditBoxImplCommon::placeInactiveLabels()
+void EditBoxImplCommon::placeInactiveLabels(const Size& size)
 {
-    _label->setPosition(CC_EDIT_BOX_PADDING, _contentSize.height / 2.0f);
-    _labelPlaceHolder->setPosition(CC_EDIT_BOX_PADDING, _contentSize.height / 2.0f);
-    refreshLabelAlignment();
+    _label->setDimensions(size.width, size.height);
+    
+    auto placeholderSize = _labelPlaceHolder->getContentSize();
+    
+    if(_editBoxInputMode == EditBox::InputMode::ANY){
+        _label->setPosition(Vec2(CC_EDIT_BOX_PADDING, size.height - CC_EDIT_BOX_PADDING));
+        _label->setVerticalAlignment(TextVAlignment::TOP);
+        _label->enableWrap(true);
+        
+        _labelPlaceHolder->setPosition(Vec2(CC_EDIT_BOX_PADDING,
+                                            size.height - CC_EDIT_BOX_PADDING));
+        _labelPlaceHolder->setVerticalAlignment(TextVAlignment::TOP);
+    }
+    else {
+        _label->enableWrap(false);
+        _label->setPosition(Vec2(CC_EDIT_BOX_PADDING, size.height));
+        _label->setVerticalAlignment(TextVAlignment::CENTER);
+        
+        _labelPlaceHolder->setPosition(Vec2(CC_EDIT_BOX_PADDING,
+                                            (size.height + placeholderSize.height) / 2));
+        _labelPlaceHolder->setVerticalAlignment(TextVAlignment::CENTER);
+    }
 }
 
 void EditBoxImplCommon::setInactiveText(const char* pText)
@@ -176,6 +196,7 @@ void EditBoxImplCommon::setInputMode(EditBox::InputMode inputMode)
 {
     _editBoxInputMode = inputMode;
     this->setNativeInputMode(inputMode);
+    this->placeInactiveLabels(_editBox->getContentSize());
 }
 
 void EditBoxImplCommon::setMaxLength(int maxLength)
@@ -227,9 +248,6 @@ void EditBoxImplCommon::refreshInactiveText()
 
 void EditBoxImplCommon::refreshLabelAlignment()
 {
-    _label->setWidth(_contentSize.width);
-    _labelPlaceHolder->setWidth(_contentSize.width);
-
     _label->setHorizontalAlignment(_alignment);
     _labelPlaceHolder->setHorizontalAlignment(_alignment);
 }
@@ -273,7 +291,7 @@ void EditBoxImplCommon::setContentSize(const Size& size)
 {
     _contentSize = size;
     CCLOG("[Edit text] content size = (%f, %f)", size.width, size.height);
-    placeInactiveLabels();
+    placeInactiveLabels(size);
 }
 
 void EditBoxImplCommon::draw(Renderer* /*renderer*/, const Mat4& /*transform*/, uint32_t flags)

--- a/cocos/ui/UIEditBox/UIEditBoxImpl-common.h
+++ b/cocos/ui/UIEditBox/UIEditBoxImpl-common.h
@@ -119,7 +119,7 @@ private:
     void         initInactiveLabels(const Size& size);
     void         setInactiveText(const char* pText);
     void         refreshLabelAlignment();
-    void         placeInactiveLabels();
+    void         placeInactiveLabels(const Size& size);
     virtual void doAnimationWhenKeyboardMove(float duration, float distance)override {};
 
     Label* _label;

--- a/cocos/ui/UIEditBox/iOS/CCUIMultilineTextField.mm
+++ b/cocos/ui/UIEditBox/iOS/CCUIMultilineTextField.mm
@@ -82,8 +82,13 @@ CGFloat const UI_PLACEHOLDER_TEXT_CHANGED_ANIMATION_DURATION = 0.25;
 - (UILabel *)placeHolderLabel
 {
     if (_placeHolderLabel == nil) {
-        
-        _placeHolderLabel = [[UILabel alloc] initWithFrame:CGRectMake(8,8,self.bounds.size.width - 16,0)];
+        auto glview = cocos2d::Director::getInstance()->getOpenGLView();
+        float padding = CC_EDIT_BOX_PADDING * glview->getScaleX() / glview->getContentScaleFactor();
+
+        _placeHolderLabel = [[UILabel alloc] initWithFrame:CGRectMake(padding,
+                                                                      padding,
+                                                                      self.bounds.size.width - padding * 2,
+                                                                      0)];
         _placeHolderLabel.lineBreakMode = NSLineBreakByWordWrapping;
         _placeHolderLabel.numberOfLines = 0;
         _placeHolderLabel.font = self.font;

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIEditBoxTest.cpp
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIEditBoxTest.cpp
@@ -82,7 +82,8 @@ bool UIEditBoxTest::init()
         addChild(button);
 
         // middle
-        _editPassword = ui::EditBox::create(editBoxSize, "extensions/orange_edit.png");
+        _editPassword = ui::EditBox::create(Size(editBoxSize.width,
+                                                 editBoxSize.height + 20), "extensions/orange_edit.png");
         _editPassword->setPosition(Vec2(visibleOrigin.x+visibleSize.width/2-50, visibleOrigin.y+visibleSize.height/2));
         _editPassword->setFontColor(Color3B::GREEN);
         _editPassword->setPlaceHolder("Password:");

--- a/tests/lua-tests/src/TextInputTest/TextInputTest.lua
+++ b/tests/lua-tests/src/TextInputTest/TextInputTest.lua
@@ -21,6 +21,7 @@ function TextInput.create()
     layer:addChild(editPasswd)
     editPasswd:setPosition( cc.p(250,100) )
     editPasswd:setPlaceHolder("click to input password")
+    editPasswd:setInputMode(cc.EDITBOX_INPUT_MODE_SINGLELINE);
     return layer
 end
 


### PR DESCRIPTION
port the Editbox improvement from Creator.

Fix single line EditBox and multi-line Editbox text alignment.

Now the single line Editbox will be center align vertically and the multi-line Editbox will be top align vertically by default.

It also fix a misusage of Password EditBox on lua tests.