### PR TITLE
Do not wrap label on non-wrappable spaces (fixes #16939)

### DIFF
--- a/cocos/2d/CCLabelTextFormatter.cpp
+++ b/cocos/2d/CCLabelTextFormatter.cpp
@@ -80,7 +80,7 @@ int Label::getFirstCharLen(const std::u16string& /*utf16Text*/, int /*startIndex
 int Label::getFirstWordLen(const std::u16string& utf16Text, int startIndex, int textLen)
 {
     auto character = utf16Text[startIndex];
-    if (StringUtils::isCJKUnicode(character) || StringUtils::isUnicodeSpace(character) || character == (char16_t)TextFormatter::NewLine)
+    if (StringUtils::isCJKUnicode(character) || StringUtils::isUnicodeWrappableSpace(character) || character == (char16_t)TextFormatter::NewLine)
     {
         return 1;
     }
@@ -99,7 +99,7 @@ int Label::getFirstWordLen(const std::u16string& utf16Text, int startIndex, int 
 
         auto letterX = (nextLetterX + letterDef.offsetX * _bmfontScale) / contentScaleFactor;
         if (_maxLineWidth > 0.f && letterX + letterDef.width * _bmfontScale > _maxLineWidth
-            && !StringUtils::isUnicodeSpace(character))
+            && !StringUtils::isUnicodeWrappableSpace(character))
         {
             if(len >= 2) {
                 return len -1;
@@ -108,7 +108,7 @@ int Label::getFirstWordLen(const std::u16string& utf16Text, int startIndex, int 
 
         nextLetterX += letterDef.xAdvance * _bmfontScale + _additionalKerning;
 
-        if (character == (char16_t)TextFormatter::NewLine || StringUtils::isUnicodeSpace(character) || StringUtils::isCJKUnicode(character))
+        if (character == (char16_t)TextFormatter::NewLine || StringUtils::isUnicodeWrappableSpace(character) || StringUtils::isCJKUnicode(character))
         {
             break;
         }
@@ -195,7 +195,7 @@ bool Label::multilineTextWrap(const std::function<int(const std::u16string&, int
 
             auto letterX = (nextLetterX + letterDef.offsetX * _bmfontScale) / contentScaleFactor;
             if (_enableWrap && _maxLineWidth > 0.f && nextTokenX > 0.f && letterX + letterDef.width * _bmfontScale > _maxLineWidth
-                && !StringUtils::isUnicodeSpace(character) && nextChangeSize)
+                && !StringUtils::isUnicodeWrappableSpace(character) && nextChangeSize)
             {
                 _linesWidth.push_back(letterRight);
                 letterRight = 0.f;

--- a/cocos/base/ccUTF8.cpp
+++ b/cocos/base/ccUTF8.cpp
@@ -96,9 +96,32 @@ static void trimUTF16VectorFromIndex(std::vector<char16_t>& str, int index)
  * */
 bool isUnicodeSpace(char16_t ch)
 {
-    return  (ch >= 0x0009 && ch <= 0x000D) || ch == 0x0020 || ch == 0x0085 || ch == 0x00A0 || ch == 0x1680
-    || (ch >= 0x2000 && ch <= 0x200A) || ch == 0x2028 || ch == 0x2029 || ch == 0x202F
-    ||  ch == 0x205F || ch == 0x3000;
+    return (ch >= 0x0009 && ch <= 0x000D)   // Tabulation, Line Feed, Line Tabulation
+                                            // Form Feed, Carriage Return
+         || ch == 0x0020                    // Space
+         || ch == 0x0085                    // Next Line
+         || ch == 0x00A0                    // No Break Space
+         || ch == 0x1680                    // Ogham Space Mark
+         || (ch >= 0x2000 && ch <= 0x200A)  // EN Quad, EM Quad, EN Space, EM Space,
+                                            // Three-per-em Space, Four-per-em Space,
+                                            // Six-per-em Space, Figure Space,
+                                            // Punctuation Space, Thin Space,
+                                            // Hair Space
+         || ch == 0x2028                    // Line Separator
+         || ch == 0x2029                    // Paragraph Separator
+         || ch == 0x202F                    // Narrow no break Space
+         || ch == 0x205F                    // Medium Mathematical Space
+         || ch == 0x3000;                   // Ideographic Space
+}
+
+bool isUnicodeWrappableSpace(char16_t ch)
+{
+    return isUnicodeSpace(ch)
+            && ch != 0x00A0     // no-break Space
+            && ch != 0x2007     // Figure Space
+            && ch != 0x202F     // Narrow no-break Space
+            && ch != 0x2060     // Word Joiner
+            && ch != 0xFEFF;    // Zero Width non-breaking Space
 }
 
 bool isCJKUnicode(char16_t ch)

--- a/cocos/base/ccUTF8.h
+++ b/cocos/base/ccUTF8.h
@@ -148,6 +148,18 @@ CC_DLL void trimUTF16Vector(std::vector<char16_t>& str);
 CC_DLL bool isUnicodeSpace(char16_t ch);
 
 /**
+ *  @brief Whether the character is a wrappable whitespace character.
+ *  @param ch    The unicode character.
+ *  @returns     Whether the character is a wrappable whitespace character.
+ *
+ *  @see http://en.wikipedia.org/wiki/Whitespace_character#Unicode
+ *  @note not all non-breaking spaces are non-wrappable, and not all non-wrappable
+ *  spaces are non-breaking spaces.
+ *
+ */
+CC_DLL bool isUnicodeWrappableSpace(char16_t ch);
+
+/**
  *  @brief Whether the character is a Chinese/Japanese/Korean character.
  *  @param ch    The unicode character.
  *  @returns     Whether the character is a Chinese character.


### PR DESCRIPTION
When a label is drawn and wrapping is enabled, text should not wrap on non-wrappable spaces.
Please note that no-break spaces and non-wrappable spaces are two different sets of unicode characters. The code prevents labels' text to wrap on non-wrappable spaces.