### PR TITLE
To use some HTTP client library those use `send(null)` like `superage…

### DIFF
--- a/cocos/scripting/js-bindings/manual/network/XMLHTTPRequest.cpp
+++ b/cocos/scripting/js-bindings/manual/network/XMLHTTPRequest.cpp
@@ -835,6 +835,8 @@ JS_BINDED_FUNC_IMPL(MinXmlHttpRequest, send)
                 return false;
             }
         }
+        else if(args.get(0).isNullOrUndefined()){
+        }
         else
         {
             return false;


### PR DESCRIPTION
To use some HTTP client library those use `XMLHttpRequest.send(null)` like `superagent`,`XMLHTTPRequest` should send a empty request instead of abort.