### PR TITLE
[cpp-tests] Reverts code change by mistake.

### DIFF
--- a/tests/cpp-tests/Classes/AppDelegate.cpp
+++ b/tests/cpp-tests/Classes/AppDelegate.cpp
@@ -97,8 +97,13 @@ bool AppDelegate::applicationDidFinishLaunching()
     
     fileUtils->setSearchPaths(searchPaths);
 
+#if (CC_TARGET_PLATFORM == CC_PLATFORM_WP8)
+    // a bug in DirectX 11 level9-x on the device prevents ResolutionPolicy::NO_BORDER from working correctly
     glview->setDesignResolutionSize(designSize.width, designSize.height, ResolutionPolicy::SHOW_ALL);
-    
+#else
+    glview->setDesignResolutionSize(designSize.width, designSize.height, ResolutionPolicy::NO_BORDER);
+#endif
+
     // Enable Remote Console
     auto console = director->getConsole();
     console->listenOnTCP(5678);


### PR DESCRIPTION
The mistake was merged in https://github.com/cocos2d/cocos2d-x/pull/7619.
Fixed issue http://punchbox.info:3000/issues/26043