### PR TITLE
Added support for larger tilemaps in CCFastTMXTiledMap

### DIFF
--- a/cocos/2d/CCFastTMXLayer.cpp
+++ b/cocos/2d/CCFastTMXLayer.cpp
@@ -313,7 +313,11 @@ void TMXLayer::updateIndexBuffer()
 {
     if(nullptr == _indexBuffer)
     {
+#ifdef CC_FAST_TILEMAP_32_BIT_INDICES
+        _indexBuffer = IndexBuffer::create(IndexBuffer::IndexType::INDEX_TYPE_UINT_32, (int)_indices.size());
+#else
         _indexBuffer = IndexBuffer::create(IndexBuffer::IndexType::INDEX_TYPE_SHORT_16, (int)_indices.size());
+#endif
         CC_SAFE_RETAIN(_indexBuffer);
     }
     _indexBuffer->updateIndices(&_indices[0], (int)_indices.size(), 0);

--- a/cocos/2d/CCFastTMXLayer.h
+++ b/cocos/2d/CCFastTMXLayer.h
@@ -334,7 +334,11 @@ protected:
     bool _quadsDirty;
     std::vector<int> _tileToQuadIndex;
     std::vector<V3F_C4B_T2F_Quad> _totalQuads;
+#ifdef CC_FAST_TILEMAP_32_BIT_INDICES
+    std::vector<GLuint> _indices;
+#else
     std::vector<GLushort> _indices;
+#endif
     std::map<int/*vertexZ*/, int/*offset to _indices by quads*/> _indicesVertexZOffsets;
     std::unordered_map<int/*vertexZ*/, int/*number to quads*/> _indicesVertexZNumber;
     std::vector<PrimitiveCommand> _renderCommands;


### PR DESCRIPTION
Added a compiler flag for larger tilemaps, by using 32 bit indices. If the compiler flag CC_FAST_TILEMAP_32_BIT_INDICES is defined, the tilemap can render maps bigger than 128x128 tiles. Perhaps there are other ways to do this (via CCConfiguration), but this allows the developer to use bigger maps without having to change the source code.

I made this PR because of the forum post: http://discuss.cocos2d-x.org/t/experimental-tmxtiledmap-maps-bigger-than-128x128-with-32-bit-indices/33876