### PR TITLE
Inform eventdispatcher on node reordering (fixes #16992)

### DIFF
--- a/cocos/2d/CCNode.cpp
+++ b/cocos/2d/CCNode.cpp
@@ -1150,6 +1150,7 @@ void Node::sortAllChildren()
     {
         sortNodes(_children);
         _reorderChildDirty = false;
+        _eventDispatcher->setDirtyForNode(this);
     }
 }
 


### PR DESCRIPTION
When changing the order of a node associated to the scene graph priority listener, inform eventdispatcher of the change