### PR TITLE
Reverts the code of creating thread pool, android doesn't need to create a thread pool in AudioEngine.cpp

### DIFF
--- a/cocos/audio/AudioEngine.cpp
+++ b/cocos/audio/AudioEngine.cpp
@@ -160,10 +160,12 @@ bool AudioEngine::lazyInit()
         }
     }
 
+#if (CC_TARGET_PLATFORM != CC_PLATFORM_ANDROID)
     if (_audioEngineImpl && s_threadPool == nullptr)
     {
         s_threadPool = new (std::nothrow) AudioEngineThreadPool();
     }
+#endif
 
     return true;
 }


### PR DESCRIPTION
This pull request fixed the mistake in https://github.com/cocos2d/cocos2d-x/pull/17079