### PR TITLE
Allow velocity to be applied to Chipmunk's kinematic bodies

### DIFF
--- a/cocos/physics/CCPhysicsBody.cpp
+++ b/cocos/physics/CCPhysicsBody.cpp
@@ -575,12 +575,6 @@ void PhysicsBody::addMoment(float moment)
 
 void PhysicsBody::setVelocity(const Vec2& velocity)
 {
-    if (!_dynamic)
-    {
-        CCLOG("physics warning: your can't set velocity for a static body.");
-        return;
-    }
-    
     cpBodySetVelocity(_cpBody, PhysicsHelper::point2cpv(velocity));
 }
 
@@ -601,12 +595,6 @@ Vec2 PhysicsBody::getVelocityAtWorldPoint(const Vec2& point)
 
 void PhysicsBody::setAngularVelocity(float velocity)
 {
-    if (!_dynamic)
-    {
-        CCLOG("physics warning: your can't set angular velocity for a static body.");
-        return;
-    }
-    
     cpBodySetAngularVelocity(_cpBody, velocity);
 }
 

--- a/cocos/physics/CCPhysicsBody.cpp
+++ b/cocos/physics/CCPhysicsBody.cpp
@@ -575,6 +575,12 @@ void PhysicsBody::addMoment(float moment)
 
 void PhysicsBody::setVelocity(const Vec2& velocity)
 {
+    if (cpBodyGetType(_cpBody) == CP_BODY_TYPE_STATIC)
+    {
+        CCLOG("physics warning: you can't set velocity for a static body.");
+        return;
+    }
+
     cpBodySetVelocity(_cpBody, PhysicsHelper::point2cpv(velocity));
 }
 
@@ -595,6 +601,12 @@ Vec2 PhysicsBody::getVelocityAtWorldPoint(const Vec2& point)
 
 void PhysicsBody::setAngularVelocity(float velocity)
 {
+    if (cpBodyGetType(_cpBody) == CP_BODY_TYPE_STATIC)
+    {
+        CCLOG("physics warning: you can't set angular velocity for a static body.");
+        return;
+    }
+
     cpBodySetAngularVelocity(_cpBody, velocity);
 }
 


### PR DESCRIPTION
According to [Chipmunk's API reference](https://chipmunk-physics.net/release/ChipmunkLatest-API-Reference/group__cp_body.html#gga3581b128fd3e2734952aeac8545fd5caa95e6c8d1ff2714d17bc4f2258407e58d), physical bodies of the type `CP_BODY_TYPE_KINEMATIC` can be moved like bodies of the type `CP_BODY_TYPE_DYNAMIC` by setting an angular or linear velocity. This, however, is not reflected in the engine code since the kinematic bodies are treated as static bodies instead by the `if` statements that were deleted in this pull request. These bodies are not really static bodies, they are kinematic bodies and get set as such in [line 322 of CCPhysicsBody.cpp](https://github.com/cocos2d/cocos2d-x/blob/v3/cocos/physics/CCPhysicsBody.cpp#L322) when `setDynamic(false)` is called.

It's also a recurring issue in the forums where developers have been asking how to create and use these kinematic bodies for some time. Threads such as [PhysicsBody: kinematic type](http://discuss.cocos2d-x.org/t/physicsbody-kinematic-type/22218), [How to create Chipmunk Kinematic body?](http://discuss.cocos2d-x.org/t/how-to-create-chipmunk-kinematic-body/30135), and [Is there static and kinematic physics body present in cocos2d-x v3.0 c++?](http://discuss.cocos2d-x.org/t/is-there-static-and-kinematic-physics-body-present-in-cocos2d-x-v3-0-c/18129) serve as an example.

I think we should be allowed to move these kinematic bodies by setting linear and angular velocities. So far I can't see any reason not to.