### PR TITLE
Slice9 Sprite with triangles, not quads

### DIFF
--- a/build/cocos2d_tests.xcodeproj/project.pbxproj
+++ b/build/cocos2d_tests.xcodeproj/project.pbxproj
@@ -5824,9 +5824,6 @@
 					507B43541C31FB340067B53E = {
 						CreatedOnToolsVersion = 7.2;
 					};
-					A07A517F1783A1D20073F6A7 = {
-						DevelopmentTeam = V9GM3JGLHY;
-					};
 				};
 			};
 			buildConfigurationList = C01FCF4E08A954540054247B /* Build configuration list for PBXProject "cocos2d_tests" */;
@@ -8798,7 +8795,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				DEVELOPMENT_TEAM = V9GM3JGLHY;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_BITCODE = NO;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "../tests/cpp-tests/proj.ios/Prefix.pch";
@@ -8825,7 +8822,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				DEVELOPMENT_TEAM = V9GM3JGLHY;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_BITCODE = NO;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "../tests/cpp-tests/proj.ios/Prefix.pch";

--- a/build/cocos2d_tests.xcodeproj/project.pbxproj
+++ b/build/cocos2d_tests.xcodeproj/project.pbxproj
@@ -5824,6 +5824,9 @@
 					507B43541C31FB340067B53E = {
 						CreatedOnToolsVersion = 7.2;
 					};
+					A07A517F1783A1D20073F6A7 = {
+						DevelopmentTeam = V9GM3JGLHY;
+					};
 				};
 			};
 			buildConfigurationList = C01FCF4E08A954540054247B /* Build configuration list for PBXProject "cocos2d_tests" */;
@@ -8795,7 +8798,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = V9GM3JGLHY;
 				ENABLE_BITCODE = NO;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "../tests/cpp-tests/proj.ios/Prefix.pch";
@@ -8822,7 +8825,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = V9GM3JGLHY;
 				ENABLE_BITCODE = NO;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "../tests/cpp-tests/proj.ios/Prefix.pch";

--- a/cocos/2d/CCSprite.cpp
+++ b/cocos/2d/CCSprite.cpp
@@ -649,7 +649,9 @@ void Sprite::updatePoly()
             Rect(x2, y2,  x2_s, y2_s),      // top-right
         };
 
-        V3F_C4B_T2F_Quad tmpQuad;
+        // needed in order to get color from "_quad"
+        V3F_C4B_T2F_Quad tmpQuad = _quad;
+
         for (int i=0; i<_numberOfSlices; ++i) {
             setTextureCoords(texRects[i], &tmpQuad);
             setVertexCoords(verticesRects[i], &tmpQuad);
@@ -694,14 +696,7 @@ void Sprite::setCenterRectNormalized(const cocos2d::Rect &rectTopLeft)
                 // 9 quads, each needs 6 vertices = 54
                 _trianglesIndex = (unsigned short*) malloc(sizeof(*_trianglesIndex) * 6 * 9);
 
-                for (int i=0; i<16; ++i) {
-                    _trianglesVertex[i].colors = Color4B::WHITE;
-                    _trianglesVertex[i].colors = Color4B::WHITE;
-                    _trianglesVertex[i].colors = Color4B::WHITE;
-                    _trianglesVertex[i].colors = Color4B::WHITE;
-                }
-
-                // CCW
+                // populate indices in CCW direction
                 for (int i=0; i<9; ++i) {
                     _trianglesIndex[i * 6 + 0] = (i * 4 / 3) + 4;
                     _trianglesIndex[i * 6 + 1] = (i * 4 / 3) + 0;

--- a/cocos/2d/CCSprite.cpp
+++ b/cocos/2d/CCSprite.cpp
@@ -889,8 +889,8 @@ void Sprite::populateTriangle(int quadIndex, const V3F_C4B_T2F_Quad& quad)
     // convert Quad intro Triangle since it takes less memory
 
     // Triangles are ordered like the following:
-    // Numbers: Quad Index
-    // Letters: triangles' vertices
+    //   Numbers: Quad Index
+    //   Letters: triangles' vertices
     //
     //  M-----N-----O-----P
     //  |     |     |     |
@@ -908,19 +908,34 @@ void Sprite::populateTriangle(int quadIndex, const V3F_C4B_T2F_Quad& quad)
     //
     // So, if QuadIndex == 4, then it should update vertices J,K,F,G
 
-    const int index_bl = quadIndex * 4 / 3;
-    const int index_br = index_bl + 1;
-    const int index_tl = index_bl + 4;
-    const int index_tr = index_bl + 5;
+    // Optimization: I don't need to copy all the vertices all the time. just the 4 "quads" from the corners.
+    if (quadIndex == 0 || quadIndex == 2 || quadIndex == 6 || quadIndex == 8)
+    {
+        if (_flippedX) {
+            if (quadIndex % 3 == 0)
+                quadIndex += 2;
+            else
+                quadIndex -= 2;
+        }
 
-    // FIXME:
-    // I don't need to copy all the vertices all the time.
-    // I have to copy the left/bottom border all the time
-    // but the top and right borders are only needed on the top row, right-most column.
-    _trianglesVertex[index_tl] = quad.tl;
-    _trianglesVertex[index_tr] = quad.tr;
-    _trianglesVertex[index_bl] = quad.bl;
-    _trianglesVertex[index_br] = quad.br;
+        if (_flippedY) {
+            if (quadIndex <= 2)
+                quadIndex += 6;
+            else
+                quadIndex -= 6;
+        }
+
+        const int index_bl = quadIndex * 4 / 3;
+        const int index_br = index_bl + 1;
+        const int index_tl = index_bl + 4;
+        const int index_tr = index_bl + 5;
+        
+
+        _trianglesVertex[index_tr] = quad.tr;
+        _trianglesVertex[index_br] = quad.br;
+        _trianglesVertex[index_tl] = quad.tl;
+        _trianglesVertex[index_bl] = quad.bl;
+    }
 }
 
 

--- a/cocos/2d/CCSprite.cpp
+++ b/cocos/2d/CCSprite.cpp
@@ -313,7 +313,8 @@ Sprite::Sprite(void)
 , _insideBounds(true)
 , _centerRectNormalized(0,0,1,1)
 , _numberOfSlices(1)
-, _quads(nullptr)
+, _trianglesVertex(nullptr)
+, _trianglesIndex(nullptr)
 , _strechFactor(Vec2::ONE)
 , _originalContentSize(Size::ZERO)
 , _strechEnabled(true)
@@ -326,7 +327,8 @@ Sprite::Sprite(void)
 
 Sprite::~Sprite()
 {
-    CC_SAFE_FREE(_quads);
+    CC_SAFE_FREE(_trianglesVertex);
+    CC_SAFE_FREE(_trianglesIndex);
     CC_SAFE_RELEASE(_spriteFrame);
     CC_SAFE_RELEASE(_texture);
 }
@@ -438,7 +440,6 @@ void Sprite::updatePoly()
     // C) 9-sliced, streched
     //    the sprite is 9-sliced and streched.
     if (_numberOfSlices == 1) {
-        setTextureCoords(_rect, &_quad);
         Rect copyRect;
         if (_strechEnabled) {
             // case B)
@@ -451,12 +452,13 @@ void Sprite::updatePoly()
                             _rect.size.width,
                             _rect.size.height);
         }
+        setTextureCoords(_rect, &_quad);
         setVertexCoords(copyRect, &_quad);
         _polyInfo.setQuad(&_quad);
     } else {
         // case C)
 
-        // in theory it can support 3 slices as well, but let's stick to 9 only
+        // in theory it can support 3 or 6 slices as well, but let's stick to 9 only
         CCASSERT(_numberOfSlices == 9, "Invalid number of slices");
 
 
@@ -647,11 +649,21 @@ void Sprite::updatePoly()
             Rect(x2, y2,  x2_s, y2_s),      // top-right
         };
 
+        V3F_C4B_T2F_Quad tmpQuad;
         for (int i=0; i<_numberOfSlices; ++i) {
-            setTextureCoords(texRects[i], &_quads[i]);
-            setVertexCoords(verticesRects[i], &_quads[i]);
+            setTextureCoords(texRects[i], &tmpQuad);
+            setVertexCoords(verticesRects[i], &tmpQuad);
+            populateTriangle(i, tmpQuad);
         }
-        _polyInfo.setQuads(_quads, _numberOfSlices);
+        TrianglesCommand::Triangles triangles;
+        triangles.verts = _trianglesVertex;
+        triangles.vertCount = 16;
+        triangles.indices = _trianglesIndex;
+        triangles.indexCount = 6 * 9;   // 9 quads, each needs 6 vertices
+
+        // probably we can update the _trianglesCommand directly
+        // to avoid memcpy'ing stuff
+        _polyInfo.setTriangles(triangles);
     }
 }
 
@@ -667,21 +679,36 @@ void Sprite::setCenterRectNormalized(const cocos2d::Rect &rectTopLeft)
         // convert it to 1-slice
         if (rect.equals(Rect(0,0,1,1))) {
             _numberOfSlices = 1;
-            free(_quads);
-            _quads = nullptr;
+            free(_trianglesVertex);
+            free(_trianglesIndex);
+            _trianglesVertex = nullptr;
+            _trianglesIndex = nullptr;
         }
         else
         {
             // convert it to 9-slice if it isn't already
             if (_numberOfSlices != 9) {
                 _numberOfSlices = 9;
-                _quads = (V3F_C4B_T2F_Quad*) malloc(sizeof(*_quads) * 9);
+                // 9 quads + 7 exterior points = 16
+                _trianglesVertex = (V3F_C4B_T2F*) malloc(sizeof(*_trianglesVertex) * (9 + 3 + 4));
+                // 9 quads, each needs 6 vertices = 54
+                _trianglesIndex = (unsigned short*) malloc(sizeof(*_trianglesIndex) * 6 * 9);
 
+                for (int i=0; i<16; ++i) {
+                    _trianglesVertex[i].colors = Color4B::WHITE;
+                    _trianglesVertex[i].colors = Color4B::WHITE;
+                    _trianglesVertex[i].colors = Color4B::WHITE;
+                    _trianglesVertex[i].colors = Color4B::WHITE;
+                }
+
+                // CCW
                 for (int i=0; i<9; ++i) {
-                    _quads[i].bl.colors = Color4B::WHITE;
-                    _quads[i].br.colors = Color4B::WHITE;
-                    _quads[i].tl.colors = Color4B::WHITE;
-                    _quads[i].tr.colors = Color4B::WHITE;
+                    _trianglesIndex[i * 6 + 0] = (i * 4 / 3) + 4;
+                    _trianglesIndex[i * 6 + 1] = (i * 4 / 3) + 0;
+                    _trianglesIndex[i * 6 + 2] = (i * 4 / 3) + 5;
+                    _trianglesIndex[i * 6 + 3] = (i * 4 / 3) + 1;
+                    _trianglesIndex[i * 6 + 4] = (i * 4 / 3) + 5;
+                    _trianglesIndex[i * 6 + 5] = (i * 4 / 3) + 0;
                 }
             }
         }
@@ -778,12 +805,12 @@ void Sprite::setTextureCoords(const Rect& rectInPoints, V3F_C4B_T2F_Quad* outQua
 #endif // CC_FIX_ARTIFACTS_BY_STRECHING_TEXEL
 
 
-    if ((_flippedX && !_rectRotated) || (_flippedY && _rectRotated))
+    if ((!_rectRotated && _flippedX) || (_rectRotated && _flippedY))
     {
         std::swap(left, right);
     }
 
-    if ((_flippedY && !_rectRotated) || (_flippedX && _rectRotated))
+    if ((!_rectRotated && _flippedY) || (_rectRotated && _flippedX))
     {
         std::swap(top, bottom);
     }
@@ -859,6 +886,46 @@ void Sprite::setVertexCoords(const Rect& rect, V3F_C4B_T2F_Quad* outQuad)
         outQuad->tl.vertices.set(x1, y2, 0.0f);
         outQuad->tr.vertices.set(x2, y2, 0.0f);
     }
+}
+
+void Sprite::populateTriangle(int quadIndex, const V3F_C4B_T2F_Quad& quad)
+{
+    CCASSERT(quadIndex < 9, "Invalid quadIndex");
+    // convert Quad intro Triangle since it takes less memory
+
+    // Triangles are ordered like the following:
+    // Numbers: Quad Index
+    // Letters: triangles' vertices
+    //
+    //  M-----N-----O-----P
+    //  |     |     |     |
+    //  |  6  |  7  |  8  |
+    //  |     |     |     |
+    //  I-----J-----K-----L
+    //  |     |     |     |
+    //  |  3  |  4  |  5  |
+    //  |     |     |     |
+    //  E-----F-----G-----H
+    //  |     |     |     |
+    //  |  0  |  1  |  2  |
+    //  |     |     |     |
+    //  A-----B-----C-----D
+    //
+    // So, if QuadIndex == 4, then it should update vertices J,K,F,G
+
+    const int index_bl = quadIndex * 4 / 3;
+    const int index_br = index_bl + 1;
+    const int index_tl = index_bl + 4;
+    const int index_tr = index_bl + 5;
+
+    // FIXME:
+    // I don't need to copy all the vertices all the time.
+    // I have to copy the left/bottom border all the time
+    // but the top and right borders are only needed on the top row, right-most column.
+    _trianglesVertex[index_tl] = quad.tl;
+    _trianglesVertex[index_tr] = quad.tr;
+    _trianglesVertex[index_bl] = quad.bl;
+    _trianglesVertex[index_br] = quad.br;
 }
 
 

--- a/cocos/2d/CCSprite.h
+++ b/cocos/2d/CCSprite.h
@@ -631,6 +631,7 @@ protected:
     virtual void setTextureCoords(const Rect& rect);
     virtual void setTextureCoords(const Rect& rect, V3F_C4B_T2F_Quad* outQuad);
     virtual void setVertexCoords(const Rect& rect, V3F_C4B_T2F_Quad* outQuad);
+    void populateTriangle(int quadIndex, const V3F_C4B_T2F_Quad& quad);
     virtual void updateBlendFunc();
     virtual void setReorderChildDirtyRecursively();
     virtual void setDirtyRecursively(bool value);
@@ -680,7 +681,8 @@ protected:
 
     // vertex coords, texture coords and color info
     V3F_C4B_T2F_Quad _quad;
-    V3F_C4B_T2F_Quad* _quads;
+    V3F_C4B_T2F* _trianglesVertex;
+    unsigned short* _trianglesIndex;
     PolygonInfo  _polyInfo;
 
     // opacity and RGB protocol


### PR DESCRIPTION
more efficient sprite rendering:

 - less vertices: 16 vs. 54
 - less memory alloced: 16 verts vs. 54.