### PR TITLE
Adding async version of common CCFileUtil functions.

### DIFF
--- a/extensions/assets-manager/AssetsManagerEx.cpp
+++ b/extensions/assets-manager/AssetsManagerEx.cpp
@@ -672,7 +672,7 @@ void AssetsManagerEx::updateSucceed()
 {
     // Every thing is correctly downloaded, do the following
     // 1. rename temporary manifest to valid manifest
-    _fileUtils->renameFile(_storagePath, TEMP_MANIFEST_FILENAME, MANIFEST_FILENAME);
+    _fileUtils->renameFile(_storagePath, std::string(TEMP_MANIFEST_FILENAME), std::string(MANIFEST_FILENAME));
     // 2. swap the localManifest
     if (_localManifest != nullptr)
         _localManifest->release();

--- a/tests/cpp-tests/Classes/FileUtilsTest/FileUtilsTest.h
+++ b/tests/cpp-tests/Classes/FileUtilsTest/FileUtilsTest.h
@@ -170,4 +170,68 @@ public:
     virtual std::string subtitle() const override;
 };
 
+class TestIsFileExistAsync : public FileUtilsDemo
+{
+public:
+    CREATE_FUNC(TestIsFileExistAsync);
+    
+    virtual void onEnter() override;
+    virtual void onExit() override;
+    virtual std::string title() const override;
+    virtual std::string subtitle() const override;
+};
+
+class TestIsDirectoryExistAsync : public FileUtilsDemo
+{
+public:
+    CREATE_FUNC(TestIsDirectoryExistAsync);
+    
+    virtual void onEnter() override;
+    virtual void onExit() override;
+    virtual std::string title() const override;
+    virtual std::string subtitle() const override;
+};
+
+class TestFileFuncsAsync : public FileUtilsDemo
+{
+public:
+    CREATE_FUNC(TestFileFuncsAsync);
+    
+    virtual void onEnter() override;
+    virtual std::string title() const override;
+    virtual std::string subtitle() const override;
+};
+
+class TestDirectoryFuncsAsync : public FileUtilsDemo
+{
+public:
+    CREATE_FUNC(TestDirectoryFuncsAsync);
+    
+    virtual void onEnter() override;
+    virtual std::string title() const override;
+    virtual std::string subtitle() const override;
+};
+
+class TestWriteStringAsync : public FileUtilsDemo
+{
+public:
+    CREATE_FUNC(TestWriteStringAsync);
+    
+    virtual void onEnter() override;
+    virtual void onExit() override;
+    virtual std::string title() const override;
+    virtual std::string subtitle() const override;
+};
+
+class TestWriteDataAsync : public FileUtilsDemo
+{
+public:
+    CREATE_FUNC(TestWriteDataAsync);
+    
+    virtual void onEnter() override;
+    virtual void onExit() override;
+    virtual std::string title() const override;
+    virtual std::string subtitle() const override;
+};
+
 #endif /* __FILEUTILSTEST_H__ */


### PR DESCRIPTION
Following through on #16846. 

This adds "async" versions of the major FileUtil functions, that will be performed off thread, and callback to the main thread when complete with their result.

Important Notes:

I used the AsyncTaskPool under the task type IO.
In order to keep the details of the async mechanism self contained, I pulled the functionality to a function called performOperationOffthread. This way if we ever want to change the mechanism from AsyncTaskPool to another threading mechanism, it should be easy.
While FileUtils is not thread safe, I was able to work around this by calling "fullPathForFilename" on the main thread before calling the delegate functions.
I attempted several template meta-programming solutions to this problem before settling on the submitted approach. All of the template solutions were too complex, and non readable in my opinion.
You can see I am using a number of value types instead of const-references. This is intentional as we are moving this data between threads, and I want to leverage move semantics.

@minggo 