### PR TITLE
Correct spelling of function name `getAncestorWidget`

### DIFF
--- a/cocos/ui/UIWidget.cpp
+++ b/cocos/ui/UIWidget.cpp
@@ -690,7 +690,7 @@ void Widget::updateChildrenDisplayedRGBA()
 }
 
 
-Widget* Widget::getAncensterWidget(Node* node)
+Widget* Widget::getAncestorWidget(Node* node)
 {
     if (nullptr == node)
     {
@@ -709,8 +709,13 @@ Widget* Widget::getAncensterWidget(Node* node)
     }
     else
     {
-        return this->getAncensterWidget(parent->getParent());
+        return this->getAncestorWidget(parent->getParent());
     }
+}
+
+Widget* Widget::getAncensterWidget(Node* node)
+{
+    return getAncestorWidget(node);
 }
 
 bool Widget::isAncestorsVisible(Node* node)
@@ -730,7 +735,7 @@ bool Widget::isAncestorsVisible(Node* node)
 
 bool Widget::isAncestorsEnabled()
 {
-    Widget* parentWidget = this->getAncensterWidget(this);
+    Widget* parentWidget = this->getAncestorWidget(this);
     if (parentWidget == nullptr)
     {
         return true;

--- a/cocos/ui/UIWidget.h
+++ b/cocos/ui/UIWidget.h
@@ -920,8 +920,11 @@ protected:
     void updateContentSizeWithTextureSize(const Size& size);
     
     bool isAncestorsEnabled();
-    Widget* getAncensterWidget(Node* node);
+    Widget* getAncestorWidget(Node* node);
     bool isAncestorsVisible(Node* node);
+
+    /** @deprecated Use getAncestorWidget instead. */
+    CC_DEPRECATED_ATTRIBUTE Widget* getAncensterWidget(Node* node);
 
     void cleanupWidget();
     LayoutComponent* getOrCreateLayoutComponent();


### PR DESCRIPTION
This corrects spelling mistake in `getAncestorWidget` function. It also keeps the old one `getAncensterWidget` as a deprecated function for backwards compatibility.