### PR TITLE
fixed two scheduler bugs (fixes #17149)

### DIFF
--- a/cocos/base/CCScheduler.cpp
+++ b/cocos/base/CCScheduler.cpp
@@ -465,7 +465,7 @@ void Scheduler::schedulePerFrame(const ccSchedulerFunc& callback, void *target, 
     if (hashElement)
     {
         // check if priority has changed
-        if ((*hashElement->list)->priority != priority)
+        if (hashElement->entry->priority != priority)
         {
             if (_updateHashLocked)
             {

--- a/cocos/base/CCScheduler.cpp
+++ b/cocos/base/CCScheduler.cpp
@@ -472,6 +472,7 @@ void Scheduler::schedulePerFrame(const ccSchedulerFunc& callback, void *target, 
                 CCLOG("warning: you CANNOT change update priority in scheduled function");
                 hashElement->entry->markedForDeletion = false;
                 hashElement->entry->paused = paused;
+                hashElement->entry->callback = callback;
                 return;
             }
             else
@@ -484,6 +485,7 @@ void Scheduler::schedulePerFrame(const ccSchedulerFunc& callback, void *target, 
         {
             hashElement->entry->markedForDeletion = false;
             hashElement->entry->paused = paused;
+            hashElement->entry->callback = callback;
             return;
         }
     }


### PR DESCRIPTION
1. Fixed that Scheduler checks target's priority change incorrectly.
2. Fixed Scheduler bug occured when objects that have same address are inserted and removed in same tick. (refer the #17149)

thanks.