### PR TITLE
Fix incorrect function name for calculateBillboardTransform

### DIFF
--- a/cocos/3d/CCBillBoard.cpp
+++ b/cocos/3d/CCBillBoard.cpp
@@ -110,7 +110,7 @@ void BillBoard::visit(Renderer *renderer, const Mat4& parentTransform, uint32_t 
     flags |= FLAGS_RENDER_AS_3D;
     
     //Update Billboard transform
-    bool dirty = calculateBillbaordTransform();
+    bool dirty = calculateBillboardTransform();
     if(dirty)
     {
         flags |= FLAGS_TRANSFORM_DIRTY;
@@ -150,7 +150,7 @@ void BillBoard::visit(Renderer *renderer, const Mat4& parentTransform, uint32_t 
     director->popMatrix(MATRIX_STACK_TYPE::MATRIX_STACK_MODELVIEW);
 }
 
-bool BillBoard::calculateBillbaordTransform()
+bool BillBoard::calculateBillboardTransform()
 {
     //Get camera world position
     auto camera = Camera::getVisitingCamera();
@@ -220,6 +220,11 @@ bool BillBoard::calculateBillbaordTransform()
     }
     
     return false;
+}
+
+bool BillBoard::calculateBillbaordTransform()
+{
+    return calculateBillboardTransform();
 }
 
 void BillBoard::draw(Renderer *renderer, const Mat4 &/*transform*/, uint32_t flags)

--- a/cocos/3d/CCBillBoard.h
+++ b/cocos/3d/CCBillBoard.h
@@ -113,7 +113,10 @@ protected:
     /**
      * calculate a model matrix which keep original translate & scaling but always face to the camera
      */
-    bool calculateBillbaordTransform();
+    bool calculateBillboardTransform();
+
+    /** @deprecated Use calculateBillboardTransform instead. */
+    CC_DEPRECATED_ATTRIBUTE bool calculateBillbaordTransform();
     
     Mat4 _camWorldMat;
     Mat4 _mvTransform;


### PR DESCRIPTION
There is a spelling mistake in function name, `calculateBillbaordTransform` should be `calculateBillboardTransform`. This patch fixes it, but keeps the old function for backwards compatibility. Thanks!