### PR TITLE
Added MotionStreak::followNode for easier setup

### DIFF
--- a/cocos/2d/CCMotionStreak.cpp
+++ b/cocos/2d/CCMotionStreak.cpp
@@ -112,10 +112,10 @@ bool MotionStreak::initWithFade(float fade, float minSeg, float stroke, const Co
 
     _stroke = stroke;
     _fadeDelta = 1.0f/fade;
-    
+
     double fps = 1/Director::getInstance()->getAnimationInterval();
     _maxPoints = (int)(fade*fps)+2;
-    
+
     _nuPoints = 0;
     _pointState = (float *)malloc(sizeof(float) * _maxPoints);
     _pointVertexes = (Vec2*)malloc(sizeof(Vec2) * _maxPoints);
@@ -201,7 +201,7 @@ void MotionStreak::tintWithColor(const Color3B& colors)
     setColor(colors);
 
     // Fast assignation
-    for(unsigned int i = 0; i<_nuPoints*2; i++) 
+    for(unsigned int i = 0; i<_nuPoints*2; i++)
     {
         *((Color3B*) (_colorPointer+i*4)) = colors;
     }
@@ -258,7 +258,7 @@ void MotionStreak::update(float delta)
     {
         return;
     }
-    
+
     delta *= _fadeDelta;
 
     unsigned int newIdx, newIdx2, i, i2;
@@ -307,6 +307,11 @@ void MotionStreak::update(float delta)
         }
     }
     _nuPoints-=mov;
+
+    if (_followNode)
+    {
+        _positionR = _parent->convertToNodeSpace(_followNode->convertToWorldSpace(_followPoint));
+    }
 
     // Append new point
     bool appendNewPoint = true;
@@ -378,7 +383,7 @@ void MotionStreak::reset()
 }
 
 void MotionStreak::onDraw(const Mat4 &transform, uint32_t /*flags*/)
-{  
+{
     getGLProgram()->use();
     getGLProgram()->setUniformsForBuiltins(transform);
 
@@ -402,6 +407,27 @@ void MotionStreak::draw(Renderer *renderer, const Mat4 &transform, uint32_t flag
     _customCommand.init(_globalZOrder, transform, flags);
     _customCommand.func = CC_CALLBACK_0(MotionStreak::onDraw, this, transform, flags);
     renderer->addCommand(&_customCommand);
+}
+
+void MotionStreak::followNode(Node *node, const Vec2& point)
+{
+    if (node)
+    {
+        _startingPositionInitialized = true;
+        _followNode = node;
+        _followPoint = point;
+    }
+    #ifdef COCOS2D_DEBUG
+    else
+    {
+        CCLOG("Warning: MotionStreak cannot follow a node set to nullptr");
+    }
+    #endif
+}
+
+void MotionStreak::stopFollowNode()
+{
+    _followNode = nullptr;
 }
 
 NS_CC_END

--- a/cocos/2d/CCMotionStreak.cpp
+++ b/cocos/2d/CCMotionStreak.cpp
@@ -51,6 +51,7 @@ MotionStreak::MotionStreak()
 , _vertices(nullptr)
 , _colorPointer(nullptr)
 , _texCoords(nullptr)
+, _followNode(nullptr)
 {
 }
 

--- a/cocos/2d/CCMotionStreak.h
+++ b/cocos/2d/CCMotionStreak.h
@@ -56,7 +56,7 @@ public:
      */
     static MotionStreak* create(float timeToFade, float minSeg, float strokeWidth, const Color3B& strokeColor, const std::string& imagePath);
     /** Creates and initializes a motion streak with fade in seconds, minimum segments, stroke's width, color, texture.
-     * 
+     *
      * @param timeToFade The fade time, in seconds.
      * @param minSeg The minimum segments.
      * @param strokeWidth The width of stroke.
@@ -76,8 +76,8 @@ public:
      */
     void reset();
 
-    /** When fast mode is enabled, new points are added faster but with lower precision. 
-     * 
+    /** When fast mode is enabled, new points are added faster but with lower precision.
+     *
      * @return True if fast mode is enabled.
      */
     bool isFastMode() const { return _fastMode; }
@@ -108,7 +108,7 @@ public:
      */
     void setStartingPositionInitialized(bool bStartingPositionInitialized)
     {
-        _startingPositionInitialized = bStartingPositionInitialized; 
+        _startingPositionInitialized = bStartingPositionInitialized;
     }
 
     // Overrides
@@ -146,14 +146,17 @@ public:
     virtual void setOpacity(GLubyte opacity) override;
     virtual void setOpacityModifyRGB(bool value) override;
     virtual bool isOpacityModifyRGB() const override;
-    
+
+    void followNode(Node* node, const Vec2& point);
+    void stopFollowNode();
+
 CC_CONSTRUCTOR_ACCESS:
     MotionStreak();
     virtual ~MotionStreak();
-    
+
     /** initializes a motion streak with fade in seconds, minimum segments, stroke's width, color and texture filename */
     bool initWithFade(float fade, float minSeg, float stroke, const Color3B& color, const std::string& path);
-    
+
     /** initializes a motion streak with fade in seconds, minimum segments, stroke's width, color and texture  */
     bool initWithFade(float fade, float minSeg, float stroke, const Color3B& color, Texture2D* texture);
 
@@ -185,7 +188,11 @@ protected:
     Vec2* _vertices;
     GLubyte* _colorPointer;
     Tex2F* _texCoords;
-    
+
+     // followNode
+     Vec2 _followPoint;
+     Node *_followNode;
+
     CustomCommand _customCommand;
 
 private:


### PR DESCRIPTION
Setting up MotionStreak to follow a node does not seem intuitive enough in my opinion.

This patch is based on @zawasp's [patch](https://github.com/zawasp/cocos2d-x/commit/41214636ba620777e6910b7c310be56fdd0088ba), although slightly modified.

Assuming we want a MotionStreak node to follow another node, coding that with this patch is reduced to the following:

````cpp
auto streak = MotionStreak::create(.3, 3, 16, Color3B::RED, "Images/streak.png" );
addChild(streak);

// to start following another node:
streak->followNode(existing_node, Vec2(10,10));

// to stop following a node:
// streak->stopFollowNode();
````