### PR TITLE
Correct spelling of "intersect"

### DIFF
--- a/cocos/3d/CCTerrain.cpp
+++ b/cocos/3d/CCTerrain.cpp
@@ -572,7 +572,7 @@ bool Terrain::getIntersectionPoint(const Ray & ray_, Vec3 & intersectionPoint) c
                 {
                     if (closeList.find(chunk) == closeList.end())
                     {
-                        if (chunk->getInsterctPointWithRay(ray, tmpIntersectionPoint))
+                        if (chunk->getIntersectPointWithRay(ray, tmpIntersectionPoint))
                         {
                             float dist = (ray._origin - tmpIntersectionPoint).length();
                             if (intersectionDist > dist)
@@ -1324,7 +1324,7 @@ void Terrain::Chunk::calculateSlope()
     _slope = (highest.y - lowest.y)/dist;
 }
 
-bool Terrain::Chunk::getInsterctPointWithRay(const Ray& ray, Vec3 &interscetPoint)
+bool Terrain::Chunk::getIntersectPointWithRay(const Ray& ray, Vec3& intersectPoint)
 {
     if (!ray.intersects(_aabb))
         return false;
@@ -1334,12 +1334,12 @@ bool Terrain::Chunk::getInsterctPointWithRay(const Ray& ray, Vec3 &interscetPoin
     for (auto triangle : _trianglesList)
     {
         Vec3 p;
-        if (triangle.getInsterctPoint(ray, p))
+        if (triangle.getIntersectPoint(ray, p))
         {
             float dist = ray._origin.distance(p);
             if (dist<minDist)
             {
-            interscetPoint = p;
+            intersectPoint = p;
             minDist = dist;
             }
             isFind =true;
@@ -1347,6 +1347,11 @@ bool Terrain::Chunk::getInsterctPointWithRay(const Ray& ray, Vec3 &interscetPoin
     }
 
     return isFind;
+}
+
+bool Terrain::Chunk::getInsterctPointWithRay(const Ray& ray, Vec3& intersectPoint)
+{
+    return getIntersectPointWithRay(ray, intersectPoint);
 }
 
 void Terrain::Chunk::updateVerticesForLOD()
@@ -1652,7 +1657,7 @@ void Terrain::Triangle::transform(const cocos2d::Mat4& matrix)
 }
 
 //Please refer to 3D Math Primer for Graphics and Game Development
-bool Terrain::Triangle::getInsterctPoint(const Ray &ray, Vec3& interScetPoint)const
+bool Terrain::Triangle::getIntersectPoint(const Ray& ray, Vec3& intersectPoint) const
 {
     // E1
     Vec3 E1 = _p2 - _p1;
@@ -1707,8 +1712,13 @@ bool Terrain::Triangle::getInsterctPoint(const Ray &ray, Vec3& interScetPoint)co
     u *= fInvDet;
     v *= fInvDet;
 
-    interScetPoint = ray._origin + ray._direction * t;
+    intersectPoint = ray._origin + ray._direction * t;
     return true;
+}
+
+bool Terrain::Triangle::getInsterctPoint(const Ray& ray, Vec3& intersectPoint) const
+{
+    return getIntersectPoint(ray, intersectPoint);
 }
 
 NS_CC_END

--- a/cocos/3d/CCTerrain.h
+++ b/cocos/3d/CCTerrain.h
@@ -115,7 +115,11 @@ public:
     struct Triangle
     {
         Triangle(const Vec3& p1, const Vec3& p2, const Vec3& p3);
-        bool getInsterctPoint(const Ray &ray, Vec3& interScetPoint) const;
+        bool getIntersectPoint(const Ray& ray, Vec3& intersectPoint) const;
+
+        /** @deprecated Use getIntersectPoint instead. */
+        CC_DEPRECATED_ATTRIBUTE bool getInsterctPoint(const Ray& ray, Vec3& interScetPoint) const;
+
         void transform(const Mat4& matrix);
         Vec3 _p1, _p2, _p3;
     };
@@ -232,7 +236,10 @@ private:
         /**calculate the average slop of chunk*/
         void calculateSlope();
 
-        bool getInsterctPointWithRay(const Ray& ray, Vec3 &interscetPoint);
+        bool getIntersectPointWithRay(const Ray& ray, Vec3& intersectPoint);
+
+        /** @deprecated Use getIntersectPointWithRay instead. */
+        CC_DEPRECATED_ATTRIBUTE bool getInsterctPointWithRay(const Ray& ray, Vec3& intersectPoint);
 
         /**current LOD of the chunk*/
         int _currentLod;


### PR DESCRIPTION
This PR corrects the spelling of the word `intersect`:
- `getInsterctPointWithRay` -> `getIntersectPointWithRay`
- `getInsterctPoint` -> `getIntersectPoint`
- `interscetPoint` -> `intersectPoint`
- `interScetPoint` -> `intersectPoint`

It also keeps misspelled functions as a deprecated API for backwards compatibility.