### PR TITLE
Fix typo in function name

### DIFF
--- a/cocos/network/HttpClient-android.cpp
+++ b/cocos/network/HttpClient-android.cpp
@@ -890,7 +890,7 @@ HttpClient::~HttpClient()
 }
 
 //Lazy create semaphore & mutex & thread
-bool HttpClient::lazyInitThreadSemphore()
+bool HttpClient::lazyInitThreadSemaphore()
 {
     if (_isInited)
     {
@@ -909,7 +909,7 @@ bool HttpClient::lazyInitThreadSemphore()
 //Add a get task to queue
 void HttpClient::send(HttpRequest* request)
 {    
-    if (!lazyInitThreadSemphore()) 
+    if (!lazyInitThreadSemaphore()) 
     {
         return;
     }

--- a/cocos/network/HttpClient-apple.mm
+++ b/cocos/network/HttpClient-apple.mm
@@ -390,7 +390,7 @@ HttpClient::~HttpClient()
 }
 
 //Lazy create semaphore & mutex & thread
-bool HttpClient::lazyInitThreadSemphore()
+bool HttpClient::lazyInitThreadSemaphore()
 {
     if (_isInited)
     {
@@ -409,7 +409,7 @@ bool HttpClient::lazyInitThreadSemphore()
 //Add a get task to queue
 void HttpClient::send(HttpRequest* request)
 {
-    if (false == lazyInitThreadSemphore())
+    if (false == lazyInitThreadSemaphore())
     {
         return;
     }

--- a/cocos/network/HttpClient-winrt.cpp
+++ b/cocos/network/HttpClient-winrt.cpp
@@ -265,7 +265,7 @@ namespace network {
     }
 
     //Lazy create semaphore & mutex & thread
-    bool HttpClient::lazyInitThreadSemphore()
+    bool HttpClient::lazyInitThreadSemaphore()
     {
         if (s_requestQueue != nullptr) {
             return true;
@@ -285,7 +285,7 @@ namespace network {
     //Add a get task to queue
     void HttpClient::send(HttpRequest* request)
     {
-        if (false == lazyInitThreadSemphore())
+        if (false == lazyInitThreadSemaphore())
         {
             return;
         }

--- a/cocos/network/HttpClient.cpp
+++ b/cocos/network/HttpClient.cpp
@@ -416,7 +416,7 @@ HttpClient::~HttpClient()
 }
 
 //Lazy create semaphore & mutex & thread
-bool HttpClient::lazyInitThreadSemphore()
+bool HttpClient::lazyInitThreadSemaphore()
 {
     if (_isInited)
 	{
@@ -435,7 +435,7 @@ bool HttpClient::lazyInitThreadSemphore()
 //Add a get task to queue
 void HttpClient::send(HttpRequest* request)
 {    
-    if (false == lazyInitThreadSemphore()) 
+    if (false == lazyInitThreadSemaphore()) 
     {
         return;
     }

--- a/cocos/network/HttpClient.h
+++ b/cocos/network/HttpClient.h
@@ -158,7 +158,7 @@ private:
      * Init pthread mutex, semaphore, and create new thread for http requests
      * @return bool
      */
-    bool lazyInitThreadSemphore();
+    bool lazyInitThreadSemaphore();
     void networkThread();
     void networkThreadAlone(HttpRequest* request, HttpResponse* response);
     /** Poll function called from main thread to dispatch callbacks when http requests finished **/


### PR DESCRIPTION
This PR fixes a small typo with `HttpClient::lazyInitThreadSemaphore`:  `Semphore` to `Semaphore`. The function is private so it doesn't break backwards compatibility. Thanks!