### PR TITLE
Fixed Scheduler bug occured when unschedule target during update.

### DIFF
--- a/cocos/base/CCScheduler.cpp
+++ b/cocos/base/CCScheduler.cpp
@@ -541,7 +541,10 @@ void Scheduler::removeUpdateFromHash(struct _listEntry *entry)
         if (!_updateHashLocked)
             CC_SAFE_DELETE(element->entry);
         else
+        {
+            element->entry->markedForDeletion = true;
             _updateDeleteVector.push_back(element->entry);
+        }
 
         // hash entry
         HASH_DEL(_hashForUpdates, element);

--- a/tests/cpp-tests/Classes/SchedulerTest/SchedulerTest.h
+++ b/tests/cpp-tests/Classes/SchedulerTest/SchedulerTest.h
@@ -380,4 +380,29 @@ private:
     void *_memoryPool;
 };
 
+class SchedulerRemoveEntryWhileUpdate: public SchedulerTestLayer
+{
+public:
+    CREATE_FUNC(SchedulerRemoveEntryWhileUpdate);
+    
+    virtual std::string title() const override;
+    virtual std::string subtitle() const override;
+    virtual void onEnter() override;
+    virtual void onExit() override;
+    
+private:
+    class TestClass
+    {
+    public:
+        TestClass(int index, TestClass *nextObj, cocos2d::Scheduler* scheduler);
+        void update(float dt);
+    private:
+        TestClass *_nextObj;
+        int _index;
+        cocos2d::Scheduler *_scheduler;
+        bool _cleanedUp;
+    };
+    std::vector<TestClass *> _testvector;
+};
+
 #endif


### PR DESCRIPTION
After #17198 
Sometimes, unscheduled target's update function is called.
When one target unscheduled its next target in scheduler's doubly linked list, uscheduled next target's update function will be called.
Please refer the test case.