### PR TITLE
Prevent the compilation of NavMeshTest if CC_USE_PHYSICS=0.

### DIFF
--- a/tests/cpp-tests/Classes/NavMeshTest/NavMeshTest.cpp
+++ b/tests/cpp-tests/Classes/NavMeshTest/NavMeshTest.cpp
@@ -39,7 +39,7 @@ struct AgentUserData
 
 NavMeshTests::NavMeshTests()
 {
-#if CC_USE_NAVMESH == 0
+#if ( CC_USE_NAVMESH == 0 ) || ( CC_USE_PHYSICS == 0 )
     ADD_TEST_CASE(NavMeshDisabled);
 #else
     ADD_TEST_CASE(NavMeshBasicTestDemo);
@@ -47,7 +47,7 @@ NavMeshTests::NavMeshTests()
 #endif
 };
 
-#if CC_USE_NAVMESH == 0
+#if ( CC_USE_NAVMESH == 0 ) || ( CC_USE_PHYSICS == 0 )
 void NavMeshDisabled::onEnter()
 {
     TTFConfig ttfConfig("fonts/arial.ttf", 16);

--- a/tests/cpp-tests/Classes/NavMeshTest/NavMeshTest.h
+++ b/tests/cpp-tests/Classes/NavMeshTest/NavMeshTest.h
@@ -31,7 +31,7 @@
 
 DEFINE_TEST_SUITE(NavMeshTests);
 
-#if CC_USE_NAVMESH == 0
+#if ( CC_USE_NAVMESH == 0 ) || ( CC_USE_PHYSICS == 0 )
 class NavMeshDisabled : public TestCase
 {
 public:


### PR DESCRIPTION
Please merge this commit fixing compilation errors in `NavMeshTast` when `CC_USE_PHYSICS=0`.