### PR TITLE
Allow to unbind asynchronous texture loading callback with a custom key.

### DIFF
--- a/cocos/renderer/CCTextureCache.cpp
+++ b/cocos/renderer/CCTextureCache.cpp
@@ -99,10 +99,17 @@ std::string TextureCache::getDescription() const
 struct TextureCache::AsyncStruct
 {
 public:
-    AsyncStruct(const std::string& fn,const std::function<void(Texture2D*)>& f) : filename(fn), callback(f), pixelFormat(Texture2D::getDefaultAlphaPixelFormat()), loadSuccess(false) {}
+    AsyncStruct
+    ( const std::string& fn,const std::function<void(Texture2D*)>& f,
+      const std::string& key )
+      : filename(fn), callback(f),callbackKey( key ),
+        pixelFormat(Texture2D::getDefaultAlphaPixelFormat()),
+        loadSuccess(false)
+    {}
 
     std::string filename;
     std::function<void(Texture2D*)> callback;
+    std::string callbackKey;
     Image image;
     Image imageAlpha;
     Texture2D::PixelFormat pixelFormat;
@@ -133,9 +140,50 @@ public:
  - In addImageAsyncCallback, will deduplicate the request to ensure only create one texture.
 
  Does process all response in addImageAsyncCallback consume more time?
- - Convert image to texture faster than load image from disk, so this isn't a problem.
+ - Convert image to texture faster than load image from disk, so this isn't a
+ problem.
+
+ Call unbindImageAsync(path) to prevent the call to the callback when the
+ texture is loaded.
  */
 void TextureCache::addImageAsync(const std::string &path, const std::function<void(Texture2D*)>& callback)
+{
+    addImageAsync( path, callback, path );
+}
+
+/**
+ The addImageAsync logic follow the steps:
+ - find the image has been add or not, if not add an AsyncStruct to _requestQueue  (GL thread)
+ - get AsyncStruct from _requestQueue, load res and fill image data to AsyncStruct.image, then add AsyncStruct to _responseQueue (Load thread)
+ - on schedule callback, get AsyncStruct from _responseQueue, convert image to texture, then delete AsyncStruct (GL thread)
+ 
+ the Critical Area include these members:
+ - _requestQueue: locked by _requestMutex
+ - _responseQueue: locked by _responseMutex
+ 
+ the object's life time:
+ - AsyncStruct: construct and destruct in GL thread
+ - image data: new in Load thread, delete in GL thread(by Image instance)
+ 
+ Note:
+ - all AsyncStruct referenced in _asyncStructQueue, for unbind function use.
+ 
+ How to deal add image many times?
+ - At first, this situation is abnormal, we only ensure the logic is correct.
+ - If the image has been loaded, the after load image call will return immediately.
+ - If the image request is in queue already, there will be more than one request in queue,
+ - In addImageAsyncCallback, will deduplicate the request to ensure only create one texture.
+ 
+ Does process all response in addImageAsyncCallback consume more time?
+ - Convert image to texture faster than load image from disk, so this isn't a
+ problem.
+
+ The callbackKey allows to unbind the callback in cases where the loading of
+ path is requested by several sources simultaneously. Each source can then
+ unbind the callback independently as needed whilst a call to
+ unbindImageAsync(path) would be ambiguous.
+ */
+void TextureCache::addImageAsync(const std::string &path, const std::function<void(Texture2D*)>& callback, const std::string& callbackKey)
 {
     Texture2D *texture = nullptr;
 
@@ -173,8 +221,9 @@ void TextureCache::addImageAsync(const std::string &path, const std::function<vo
     ++_asyncRefCount;
 
     // generate async struct
-    AsyncStruct *data = new (std::nothrow) AsyncStruct(fullpath, callback);
-
+    AsyncStruct *data =
+      new (std::nothrow) AsyncStruct(fullpath, callback, callbackKey);
+    
     // add async struct into queue
     _asyncStructQueue.push_back(data);
     _requestMutex.lock();
@@ -184,16 +233,16 @@ void TextureCache::addImageAsync(const std::string &path, const std::function<vo
     _sleepCondition.notify_one();
 }
 
-void TextureCache::unbindImageAsync(const std::string& filename)
+void TextureCache::unbindImageAsync(const std::string& callbackKey)
 {
     if (_asyncStructQueue.empty())
     {
         return;
     }
-    std::string fullpath = FileUtils::getInstance()->fullPathForFilename(filename);
+
     for (auto& asyncStruct : _asyncStructQueue)
     {
-        if (asyncStruct->filename == fullpath)
+        if (asyncStruct->callbackKey == callbackKey)
         {
             asyncStruct->callback = nullptr;
         }

--- a/cocos/renderer/CCTextureCache.h
+++ b/cocos/renderer/CCTextureCache.h
@@ -123,6 +123,8 @@ public:
     */
     virtual void addImageAsync(const std::string &filepath, const std::function<void(Texture2D*)>& callback);
     
+    void addImageAsync(const std::string &path, const std::function<void(Texture2D*)>& callback, const std::string& callbackKey );
+
     /** Unbind a specified bound image asynchronous callback.
      * In the case an object who was bound to an image asynchronous callback was destroyed before the callback is invoked,
      * the object always need to unbind this callback manually.

--- a/tests/cpp-tests/Classes/TextureCacheTest/TextureCacheTest.cpp
+++ b/tests/cpp-tests/Classes/TextureCacheTest/TextureCacheTest.cpp
@@ -8,6 +8,7 @@ USING_NS_CC;
 TextureCacheTests::TextureCacheTests()
 {
     ADD_TEST_CASE(TextureCacheTest);
+    ADD_TEST_CASE(TextureCacheUnbindTest);
 }
 
 TextureCacheTest::TextureCacheTest()
@@ -129,4 +130,53 @@ void TextureCacheTest::addSprite()
     this->addChild(s13);
     this->addChild(s14);
     this->addChild(s15);
+}
+
+TextureCacheUnbindTest::TextureCacheUnbindTest()
+{
+    auto size = Director::getInstance()->getWinSize();
+
+    Label* nothing =
+      Label::createWithTTF
+      ("There should be\nnothing below", "fonts/arial.ttf", 15);
+    nothing->setPosition(Vec2(size.width / 4, 5 * size.height / 6));
+    this->addChild(nothing);
+    
+    Label* something =
+      Label::createWithTTF
+      ("There should be\na white square below", "fonts/arial.ttf", 15);
+    something->setPosition(Vec2(3 * size.width / 4, 5 * size.height / 6));
+    this->addChild(something);
+
+    auto cache = Director::getInstance()->getTextureCache();
+    
+    cache->removeTextureForKey("Images/texture2048x2048.png");
+
+    cache->addImageAsync
+      ("Images/texture2048x2048.png",
+       CC_CALLBACK_1(TextureCacheUnbindTest::textureLoadedA, this),
+       "A");
+    cache->addImageAsync
+      ("Images/texture2048x2048.png",
+       CC_CALLBACK_1(TextureCacheUnbindTest::textureLoadedB, this),
+       "B");
+    cache->unbindImageAsync("A");
+}
+
+void TextureCacheUnbindTest::textureLoadedA(Texture2D* texture)
+{
+  auto size = Director::getInstance()->getWinSize();
+  auto s = Sprite::create("Images/texture2048x2048.png");
+  s->setScale(0.15);
+  s->setPosition(size.width / 4, size.height / 2);
+  this->addChild(s);
+}
+
+void TextureCacheUnbindTest::textureLoadedB(Texture2D* texture)
+{
+  auto size = Director::getInstance()->getWinSize();
+  auto s = Sprite::create("Images/texture2048x2048.png");
+  s->setScale(0.15);
+  s->setPosition(3 * size.width / 4, size.height / 2);
+  this->addChild(s);
 }

--- a/tests/cpp-tests/Classes/TextureCacheTest/TextureCacheTest.h
+++ b/tests/cpp-tests/Classes/TextureCacheTest/TextureCacheTest.h
@@ -25,4 +25,16 @@ private:
     int _numberOfLoadedSprites;
 };
 
+class TextureCacheUnbindTest : public TestCase
+{
+public:
+    CREATE_FUNC(TextureCacheUnbindTest);
+
+    TextureCacheUnbindTest();
+
+private:
+    void textureLoadedA(cocos2d::Texture2D* texture);
+    void textureLoadedB(cocos2d::Texture2D* texture);
+};
+
 #endif // _TEXTURECACHE_TEST_H_


### PR DESCRIPTION
In order to unbind the callback passed to
`cocos2d::TextureCache::addImageAsync(path, callback)`, one has to
call `cocos2d::TextureCache::unbindImageAsync(path)`. In the cases
where the loading of the same texture is requested from several sources
simultaneously, then none of the source can unbind its own callback
unambiguously.
    
This commit adds an overload of the `addImageAsync` function taking an extra
argument identifying the callback, thus allowing to unbind it unambiguously
in cases where the loading of path is requested by several sources
simultaneously.
