### PR TITLE
Prevent removal of unknown touch in CCScrollView::onTouchCancelled.

### DIFF
--- a/extensions/GUI/CCScrollView/CCScrollView.cpp
+++ b/extensions/GUI/CCScrollView/CCScrollView.cpp
@@ -855,6 +855,10 @@ void ScrollView::onTouchCancelled(Touch* touch, Event* /*event*/)
     }
     
     auto touchIter = std::find(_touches.begin(), _touches.end(), touch);
+
+    if ( touchIter == _touches.end() )
+        return;
+    
     _touches.erase(touchIter);
     
     if (_touches.size() == 0)


### PR DESCRIPTION
Please review this pull request.