### PR TITLE
Add a preprocessor test to disable the logs even in debug.

### DIFF
--- a/cocos/network/HttpAsynConnection-apple.m
+++ b/cocos/network/HttpAsynConnection-apple.m
@@ -64,7 +64,7 @@
 
 - (void) startRequest:(NSURLRequest *)request
 {
-#ifdef COCOS2D_DEBUG
+#if defined( COCOS2D_DEBUG ) && ( COCOS2D_LOG_LEVEL != 0 )
     NSLog(@"Starting to load %@", srcURL);
 #endif
     
@@ -96,7 +96,7 @@
  **/
 - (void) connection:(NSURLConnection *)connection 
  didReceiveResponse:(NSURLResponse *)response {
-#ifdef COCOS2D_DEBUG
+#if defined( COCOS2D_DEBUG ) && ( COCOS2D_LOG_LEVEL != 0 )
     NSLog(@"Received response from request to url %@", srcURL);
 #endif
     

--- a/cocos/platform/CCPlatformMacros.h
+++ b/cocos/platform/CCPlatformMacros.h
@@ -224,7 +224,7 @@ public: virtual void set##funName(varType var)   \
 
 /// @name Cocos2d debug
 /// @{
-#if !defined(COCOS2D_DEBUG) || COCOS2D_DEBUG == 0
+#if !defined(COCOS2D_DEBUG) || COCOS2D_DEBUG == 0 || COCOS2D_LOG_LEVEL == 0
 #define CCLOG(...)       do {} while (0)
 #define CCLOGINFO(...)   do {} while (0)
 #define CCLOGERROR(...)  do {} while (0)


### PR DESCRIPTION
Having asserts enabled in debug builds is nice to find various coding mistakes but having a lot of logs can be annoying. This commit adds a preprocessor test allowing to turn off the logs and keep the asserts in debug builds.