### PR TITLE
Fix typo in variable name

### DIFF
--- a/cocos/ui/UIAbstractCheckButton.cpp
+++ b/cocos/ui/UIAbstractCheckButton.cpp
@@ -73,7 +73,7 @@ AbstractCheckButton::~AbstractCheckButton()
 }
 
 bool AbstractCheckButton::init(const std::string& backGround,
-                    const std::string& backGroundSeleted,
+                    const std::string& backGroundSelected,
                     const std::string& cross,
                     const std::string& backGroundDisabled,
                     const std::string& frontCrossDisabled,
@@ -89,7 +89,7 @@ bool AbstractCheckButton::init(const std::string& backGround,
         }
         
         setSelected(false);
-        loadTextures(backGround, backGroundSeleted, cross, backGroundDisabled, frontCrossDisabled,texType);
+        loadTextures(backGround, backGroundSelected, cross, backGroundDisabled, frontCrossDisabled, texType);
     } while (0);
     return ret;
 }

--- a/cocos/ui/UIAbstractCheckButton.h
+++ b/cocos/ui/UIAbstractCheckButton.h
@@ -171,7 +171,7 @@ public:
 CC_CONSTRUCTOR_ACCESS:
     virtual bool init() override;
     virtual bool init(const std::string& backGround,
-                      const std::string& backGroundSeleted,
+                      const std::string& backGroundSelected,
                       const std::string& cross,
                       const std::string& backGroundDisabled,
                       const std::string& frontCrossDisabled,

--- a/cocos/ui/UICheckBox.cpp
+++ b/cocos/ui/UICheckBox.cpp
@@ -54,7 +54,7 @@ CheckBox* CheckBox::create()
 }
     
 CheckBox* CheckBox::create(const std::string& backGround,
-                           const std::string& backGroundSeleted,
+                           const std::string& backGroundSelected,
                            const std::string& cross,
                            const std::string& backGroundDisabled,
                            const std::string& frontCrossDisabled,
@@ -62,7 +62,7 @@ CheckBox* CheckBox::create(const std::string& backGround,
 {
     CheckBox *pWidget = new (std::nothrow) CheckBox;
     if (pWidget && pWidget->init(backGround,
-                                 backGroundSeleted,
+                                 backGroundSelected,
                                  cross,
                                  backGroundDisabled,
                                  frontCrossDisabled,

--- a/cocos/ui/UIRadioButton.cpp
+++ b/cocos/ui/UIRadioButton.cpp
@@ -55,7 +55,7 @@ RadioButton* RadioButton::create()
 }
 
 RadioButton* RadioButton::create(const std::string& backGround,
-                           const std::string& backGroundSeleted,
+                           const std::string& backGroundSelected,
                            const std::string& cross,
                            const std::string& backGroundDisabled,
                            const std::string& frontCrossDisabled,
@@ -63,7 +63,7 @@ RadioButton* RadioButton::create(const std::string& backGround,
 {
     RadioButton *pWidget = new (std::nothrow) RadioButton;
     if (pWidget && pWidget->init(backGround,
-                                 backGroundSeleted,
+                                 backGroundSelected,
                                  cross,
                                  backGroundDisabled,
                                  frontCrossDisabled,


### PR DESCRIPTION
`backGroundSelected` parameter is seemingly misspelled as `backGroundSeleted`. This patch fixes it.