### PR TITLE
Fix warnings about implicit conversion loses integer precision

### DIFF
--- a/cocos/3d/CCTerrain.cpp
+++ b/cocos/3d/CCTerrain.cpp
@@ -436,7 +436,7 @@ void Terrain::calculateNormal()
             _indices.push_back (nLocIndex + _imageWidth+1);
         }
     }
-    for (unsigned int i = 0, size = _indices.size(); i < size; i += 3) {
+    for (size_t i = 0, size = _indices.size(); i < size; i += 3) {
         unsigned int Index0 = _indices[i];
         unsigned int Index1 = _indices[i + 1];
         unsigned int Index2 = _indices[i + 2];
@@ -450,8 +450,8 @@ void Terrain::calculateNormal()
         _vertices[Index2]._normal += Normal;
     }
 
-    for (unsigned int i = 0, size = _vertices.size(); i < size; ++i) {
-        _vertices[i]._normal.normalize();
+    for (auto &vertex : _vertices) {
+        vertex._normal.normalize();
     }
     //global indices no need at all
     _indices.clear();


### PR DESCRIPTION
I get two warnings when compiling libcocos2d for Mac using Xcode 8.2.1 and this patch fixes the warnings below.

```
cocos/3d/CCTerrain.cpp:439:37: implicit conversion loses integer precision: 'size_type' (aka 'unsigned long') to 'unsigned int' [-Wshorten-64-to-32]
cocos/3d/CCTerrain.cpp:453:37: implicit conversion loses integer precision: 'size_type' (aka 'unsigned long') to 'unsigned int' [-Wshorten-64-to-32]
```