### PR TITLE
Fix typos in local variables

### DIFF
--- a/cocos/2d/CCDrawNode.cpp
+++ b/cocos/2d/CCDrawNode.cpp
@@ -506,16 +506,16 @@ void DrawNode::drawRect(const Vec2 &origin, const Vec2 &destination, const Color
 
 void DrawNode::drawPoly(const Vec2 *poli, unsigned int numberOfPoints, bool closePolygon, const Color4F &color)
 {
-    unsigned int vertext_count;
+    unsigned int vertex_count;
     if(closePolygon)
     {
-        vertext_count = 2 * numberOfPoints;
-        ensureCapacityGLLine(vertext_count);
+        vertex_count = 2 * numberOfPoints;
+        ensureCapacityGLLine(vertex_count);
     }
     else
     {
-        vertext_count = 2 * (numberOfPoints - 1);
-        ensureCapacityGLLine(vertext_count);
+        vertex_count = 2 * (numberOfPoints - 1);
+        ensureCapacityGLLine(vertex_count);
     }
     
     V2F_C4B_T2F *point = (V2F_C4B_T2F*)(_bufferGLLine + _bufferCountGLLine);
@@ -538,7 +538,7 @@ void DrawNode::drawPoly(const Vec2 *poli, unsigned int numberOfPoints, bool clos
         *(point+1) = b;
     }
     
-    _bufferCountGLLine += vertext_count;
+    _bufferCountGLLine += vertex_count;
 }
 
 void DrawNode::drawCircle(const Vec2& center, float radius, float angle, unsigned int segments, bool drawLineToCenter, float scaleX, float scaleY, const Color4F &color)

--- a/cocos/2d/CCRenderTexture.cpp
+++ b/cocos/2d/CCRenderTexture.cpp
@@ -531,7 +531,7 @@ void RenderTexture::onSaveToFile(const std::string& filename, bool isRGBA)
 }
 
 /* get buffer as Image */
-Image* RenderTexture::newImage(bool fliimage)
+Image* RenderTexture::newImage(bool flipImage)
 {
     CCASSERT(_pixelFormat == Texture2D::PixelFormat::RGBA8888, "only RGBA8888 can be saved as image");
 
@@ -581,7 +581,7 @@ Image* RenderTexture::newImage(bool fliimage)
         glReadPixels(0,0,savedBufferWidth, savedBufferHeight,GL_RGBA,GL_UNSIGNED_BYTE, tempData);
         glBindFramebuffer(GL_FRAMEBUFFER, _oldFBO);
 
-        if ( fliimage ) // -- flip is only required when saving image to file
+        if ( flipImage ) // -- flip is only required when saving image to file
         {
             // to get the actual texture data
             // #640 the image read from rendertexture is dirty

--- a/cocos/renderer/CCRenderer.cpp
+++ b/cocos/renderer/CCRenderer.cpp
@@ -898,7 +898,7 @@ bool Renderer::checkVisibility(const Mat4 &transform, const Size &size)
         return true;
 
     auto director = Director::getInstance();
-    Rect visiableRect(director->getVisibleOrigin(), director->getVisibleSize());
+    Rect visibleRect(director->getVisibleOrigin(), director->getVisibleSize());
     
     // transform center point to screen space
     float hSizeX = size.width/2;
@@ -912,11 +912,11 @@ bool Renderer::checkVisibility(const Mat4 &transform, const Size &size)
     float wshh = std::max(fabsf(hSizeX * transform.m[1] + hSizeY * transform.m[5]), fabsf(hSizeX * transform.m[1] - hSizeY * transform.m[5]));
     
     // enlarge visible rect half size in screen coord
-    visiableRect.origin.x -= wshw;
-    visiableRect.origin.y -= wshh;
-    visiableRect.size.width += wshw * 2;
-    visiableRect.size.height += wshh * 2;
-    bool ret = visiableRect.containsPoint(v2p);
+    visibleRect.origin.x -= wshw;
+    visibleRect.origin.y -= wshh;
+    visibleRect.size.width += wshw * 2;
+    visibleRect.size.height += wshh * 2;
+    bool ret = visibleRect.containsPoint(v2p);
     return ret;
 }
 

--- a/cocos/ui/UIButton.cpp
+++ b/cocos/ui/UIButton.cpp
@@ -312,11 +312,11 @@ void Button::loadTexturePressed(const std::string& selected,TextureResType texTy
 {
     _clickedFileName = selected;
     _pressedTexType = texType;
-    bool textureLoade = true;
+    bool textureLoaded = true;
     if (selected.empty())
     {
         _buttonClickedRenderer->resetRender();
-        textureLoade = false;
+        textureLoaded = false;
     }
     else
     {
@@ -332,7 +332,7 @@ void Button::loadTexturePressed(const std::string& selected,TextureResType texTy
             break;
         }
     }
-    this->setupPressedTexture(textureLoade);
+    this->setupPressedTexture(textureLoaded);
 }
 
 void Button::setupPressedTexture(bool textureLoaded)


### PR DESCRIPTION
This change set fixes several spelling errors in variable names. It also keeps backwards compatibility.