### PR TITLE
Fix typo in Sprite (strech -> stretch)

### DIFF
--- a/cocos/2d/CCSprite.cpp
+++ b/cocos/2d/CCSprite.cpp
@@ -316,9 +316,9 @@ Sprite::Sprite(void)
 , _renderMode(Sprite::RenderMode::QUAD)
 , _trianglesVertex(nullptr)
 , _trianglesIndex(nullptr)
-, _strechFactor(Vec2::ONE)
+, _stretchFactor(Vec2::ONE)
 , _originalContentSize(Size::ZERO)
-, _strechEnabled(true)
+, _stretchEnabled(true)
 {
 #if CC_SPRITE_DEBUG_DRAW
     _debugDrawNode = DrawNode::create();
@@ -442,9 +442,9 @@ void Sprite::updatePoly()
     //    the sprite is 9-sliced and stretched.
     if (_renderMode == RenderMode::QUAD || _renderMode == RenderMode::QUAD_BATCHNODE) {
         Rect copyRect;
-        if (_strechEnabled) {
+        if (_stretchEnabled) {
             // case B)
-            copyRect = Rect(0, 0, _rect.size.width * _strechFactor.x, _rect.size.height * _strechFactor.y);
+            copyRect = Rect(0, 0, _rect.size.width * _stretchFactor.x, _rect.size.height * _stretchFactor.y);
         } else {
             // case A)
             // modify origin to put the sprite in the correct offset
@@ -591,10 +591,10 @@ void Sprite::updatePoly()
 
         // sizes
         float x0_s = osw * cx1;
-        float x1_s = osw * (cx2-cx1) * _strechFactor.x;
+        float x1_s = osw * (cx2-cx1) * _stretchFactor.x;
         float x2_s = osw * (1-cx2);
         float y0_s = osh * cy1;
-        float y1_s = osh * (cy2-cy1) * _strechFactor.y;
+        float y1_s = osh * (cy2-cy1) * _stretchFactor.y;
         float y2_s = osh * (1-cy2);
 
 
@@ -864,8 +864,8 @@ void Sprite::setVertexCoords(const Rect& rect, V3F_C4B_T2F_Quad* outQuad)
     // FIXME: Stretching should be applied to the "offset" as well
     // but probably it should be calculated in the caller function. It will be tidier
     if (_renderMode == RenderMode::QUAD) {
-        _offsetPosition.x *= _strechFactor.x;
-        _offsetPosition.y *= _strechFactor.y;
+        _offsetPosition.x *= _stretchFactor.x;
+        _offsetPosition.y *= _stretchFactor.y;
     }
 
     // rendering using batch node
@@ -1355,10 +1355,10 @@ void Sprite::setContentSize(const Size& size)
     updatePoly();
 }
 
-void Sprite::setStrechEnabled(bool enabled)
+void Sprite::setStretchEnabled(bool enabled)
 {
-    if (_strechEnabled != enabled) {
-        _strechEnabled = enabled;
+    if (_stretchEnabled != enabled) {
+        _stretchEnabled = enabled;
 
         // disabled centerrect / number of slices if disabled
         if (!enabled)
@@ -1369,9 +1369,19 @@ void Sprite::setStrechEnabled(bool enabled)
     }
 }
 
+void Sprite::setStrechEnabled(bool enabled)
+{
+    setStretchEnabled(enabled);
+}
+
+bool Sprite::isStretchEnabled() const
+{
+    return _stretchEnabled;
+}
+
 bool Sprite::isStrechEnabled() const
 {
-    return _strechEnabled;
+    return isStretchEnabled();
 }
 
 void Sprite::updateStretchFactor()
@@ -1385,8 +1395,8 @@ void Sprite::updateStretchFactor()
         const float x_factor = size.width / _originalContentSize.width;
         const float y_factor = size.height / _originalContentSize.height;
 
-        _strechFactor = Vec2(std::max(0.0f, x_factor),
-                             std::max(0.0f, y_factor));
+        _stretchFactor = Vec2(std::max(0.0f, x_factor),
+                              std::max(0.0f, y_factor));
     }
     else if (_renderMode == RenderMode::SLICE9)
     {
@@ -1405,8 +1415,8 @@ void Sprite::updateStretchFactor()
         const float x_factor = (adjustedWidth - x1 - x3) / x2;
         const float y_factor = (adjustedHeight - y1 - y3) / y2;
 
-        _strechFactor = Vec2(std::max(0.0f, x_factor),
-                             std::max(0.0f, y_factor));
+        _stretchFactor = Vec2(std::max(0.0f, x_factor),
+                              std::max(0.0f, y_factor));
     }
 
     // else:

--- a/cocos/2d/CCSprite.h
+++ b/cocos/2d/CCSprite.h
@@ -469,10 +469,16 @@ public:
     void setPolygonInfo(const PolygonInfo& info);
 
     /** whether or not contentSize stretches the sprite's texture */
-    void setStrechEnabled(bool enabled);
+    void setStretchEnabled(bool enabled);
+
+    /** @deprecated Use setStretchEnabled() instead. */
+    CC_DEPRECATED_ATTRIBUTE void setStrechEnabled(bool enabled);
 
     /** returns whether or not contentSize stretches the sprite's texture */
-    bool isStrechEnabled() const;
+    bool isStretchEnabled() const;
+
+    /** @deprecated Use isStretchEnabled() instead. */
+    CC_DEPRECATED_ATTRIBUTE bool isStrechEnabled() const;
 
     //
     // Overrides
@@ -687,7 +693,7 @@ protected:
 
     Rect _centerRectNormalized;             /// Rectangle to implement "slice 9"
     RenderMode _renderMode;                 /// render mode used by the Sprite: Quad, Slice9, Polygon or Quad_Batchnode
-    Vec2 _strechFactor;                     /// strech factor to match the contentSize. for 1- and 9- slice sprites
+    Vec2 _stretchFactor;                    /// stretch factor to match the contentSize. for 1- and 9- slice sprites
     Size _originalContentSize;              /// original content size
 
 
@@ -713,7 +719,7 @@ protected:
     std::string _fileName;
     int _fileType;
 
-    bool _strechEnabled;
+    bool _stretchEnabled;
 
 private:
     CC_DISALLOW_COPY_AND_ASSIGN(Sprite);

--- a/cocos/ui/UIScale9Sprite.cpp
+++ b/cocos/ui/UIScale9Sprite.cpp
@@ -431,7 +431,7 @@ void Scale9Sprite::setScale9Enabled(bool enabled)
 
     // only enable stretch when scale9 is enabled
     // for backward compatibility, since Sprite stretches the texture no matter the rendering type
-    setStrechEnabled(enabled);
+    setStretchEnabled(enabled);
 }
 
 bool Scale9Sprite::isScale9Enabled() const

--- a/tests/cpp-tests/Classes/SpriteTest/SpriteTest.cpp
+++ b/tests/cpp-tests/Classes/SpriteTest/SpriteTest.cpp
@@ -5773,7 +5773,7 @@ Issue17119::Issue17119()
     addChild(s4);
     s4->setPosition(s.width/2+s.width/3, s.height/2-s.height/3);
     s4->setContentSize(s2->getContentSize()*1.5);
-    s4->setStrechEnabled(false);
+    s4->setStretchEnabled(false);
     auto p4 = Sprite::create("Images/r1.png");
     p4->setScale(0.25f);
     p4->setPosition(s3->getPosition());


### PR DESCRIPTION
This pull request fixes several spelling mistakes inside `Sprite` class, it does the following:

- Renames two variables
  - `_strechFactor` -> `_stretchFactor`
  - `_strechEnabled ` -> `_stretchEnabled`
- Replaces two functions with correctly spelled names
  - `setStrechEnabled` -> `setStretchEnabled`
  - `isStrechEnabled` -> `isStretchEnabled`
- Marks the misspelled functions as deprecated for backwards compatibility

Thank you for your time!