### PR TITLE
Fix implicit conversion warning

### DIFF
--- a/cocos/platform/CCFileUtils.cpp
+++ b/cocos/platform/CCFileUtils.cpp
@@ -1229,9 +1229,9 @@ bool FileUtils::createDirectory(const std::string& path)
 
     // Create path recursively
     subpath = "";
-    for (int i = 0, size = dirs.size(); i < size; ++i)
+    for (const auto& iter : dirs)
     {
-        subpath += dirs[i];
+        subpath += iter;
         dir = opendir(subpath.c_str());
 
         if (!dir)


### PR DESCRIPTION
This PR suppresses a implicit conversion warning in Xcode 8.2.1 as shown below:

```
cocos/platform/CCFileUtils.cpp:1232:28: implicit conversion loses integer precision: 'size_type' (aka 'unsigned long') to 'int' [-Wshorten-64-to-32]
```
