### PR TITLE
Fix typo in function name

### DIFF
--- a/cocos/scripting/lua-bindings/manual/lua_module_register.cpp
+++ b/cocos/scripting/lua-bindings/manual/lua_module_register.cpp
@@ -20,7 +20,7 @@ int lua_module_register(lua_State* L)
     register_network_module(L);
     register_cocosbuilder_module(L);
     register_cocostudio_module(L);
-    register_ui_moudle(L);
+    register_ui_module(L);
     register_extension_module(L);
     register_spine_module(L);
     register_cocos3d_module(L);

--- a/cocos/scripting/lua-bindings/manual/ui/lua_cocos2dx_ui_manual.cpp
+++ b/cocos/scripting/lua-bindings/manual/ui/lua_cocos2dx_ui_manual.cpp
@@ -1174,7 +1174,7 @@ static void extendEventListenerFocusEvent(lua_State* L)
     lua_pop(L, 1);
 }
 
-int register_ui_moudle(lua_State* L)
+int register_ui_module(lua_State* L)
 {
     lua_getglobal(L, "_G");
     if (lua_istable(L,-1))//stack:...,_G,

--- a/cocos/scripting/lua-bindings/manual/ui/lua_cocos2dx_ui_manual.hpp
+++ b/cocos/scripting/lua-bindings/manual/ui/lua_cocos2dx_ui_manual.hpp
@@ -46,7 +46,7 @@ TOLUA_API int register_all_cocos2dx_ui_manual(lua_State* L);
  * If you don't register the ui module, the package size would become smaller .
  * The current mechanism,this registering function is called in the lua_module_register.h
  */
-TOLUA_API int register_ui_moudle(lua_State* L);
+TOLUA_API int register_ui_module(lua_State* L);
 
 // end group
 /// @}

--- a/cocos/scripting/lua-bindings/script/init.lua
+++ b/cocos/scripting/lua-bindings/script/init.lua
@@ -92,7 +92,7 @@ require "cocos.network.DeprecatedNetworkClass"
 require "cocos.network.DeprecatedNetworkEnum"
 require "cocos.network.DeprecatedNetworkFunc"
 
--- register_ui_moudle
+-- register_ui_module
 if nil ~= ccui then
     require "cocos.ui.DeprecatedUIEnum"
     require "cocos.ui.DeprecatedUIFunc"


### PR DESCRIPTION
This PR just fixes a small typo in Lua bindings: `register_ui_moudle` -> `register_ui_module`.