### PR TITLE
Fix implicit conversion warnings

### DIFF
--- a/cocos/2d/CCParticleBatchNode.cpp
+++ b/cocos/2d/CCParticleBatchNode.cpp
@@ -271,9 +271,9 @@ void ParticleBatchNode::reorderChild(Node * aChild, int zOrder)
 
             // Find new AtlasIndex
             int newAtlasIndex = 0;
-            for(int i=0, size = _children.size(); i < size; ++i)
+            for (const auto& iter : _children)
             {
-                ParticleSystem* node = static_cast<ParticleSystem*>(_children.at(i));
+                auto node = static_cast<ParticleSystem*>(iter);
                 if( node == child )
                 {
                     newAtlasIndex = child->getAtlasIndex();

--- a/cocos/3d/CCMeshSkin.cpp
+++ b/cocos/3d/CCMeshSkin.cpp
@@ -89,9 +89,9 @@ Bone3D* MeshSkin::getBoneByName(const std::string& id) const
 
 int MeshSkin::getBoneIndex(Bone3D* bone) const
 {
-    for (int i = 0, size = _skinBones.size(); i < size; ++i) {
+    for (ssize_t i = 0, size = _skinBones.size(); i < size; ++i) {
         if (_skinBones.at(i) == bone)
-            return i;
+            return static_cast<int>(i);
     }
 
     return -1;

--- a/cocos/3d/CCSkeleton3D.cpp
+++ b/cocos/3d/CCSkeleton3D.cpp
@@ -303,9 +303,9 @@ Bone3D* Skeleton3D::getRootBone(int index) const
 
 int Skeleton3D::getBoneIndex(Bone3D* bone) const
 {
-    for (int i = 0, size = _bones.size(); i < size; ++i) {
+    for (ssize_t i = 0, size = _bones.size(); i < size; ++i) {
         if (_bones.at(i) == bone)
-            return i;
+            return static_cast<int>(i);
     }
 
     return -1;

--- a/cocos/network/SocketIO.cpp
+++ b/cocos/network/SocketIO.cpp
@@ -463,9 +463,9 @@ void SIOClientImpl::handshakeResponse(HttpClient* /*sender*/, HttpResponse *resp
     std::stringstream s;
     s.str("");
 
-    for (unsigned int i = 0, size = buffer->size(); i < size; ++i)
+    for (const auto& iter : *buffer)
     {
-        s << (*buffer)[i];
+        s << iter;
     }
 
     CCLOGINFO("SIOClientImpl::handshake() dump data: %s", s.str().c_str());


### PR DESCRIPTION
Hello, I get the following warnings when building libcocos2d Mac on Xcode 8.2.1.

```
cocos/2d/CCParticleBatchNode.cpp:274:33: implicit conversion loses integer precision: 'ssize_t' (aka 'long') to 'int' [-Wshorten-64-to-32]
cocos/3d/CCMeshSkin.cpp:92:28: implicit conversion loses integer precision: 'ssize_t' (aka 'long') to 'int' [-Wshorten-64-to-32]
cocos/3d/CCSkeleton3D.cpp:306:28: implicit conversion loses integer precision: 'ssize_t' (aka 'long') to 'int' [-Wshorten-64-to-32]
cocos/network/SocketIO.cpp:466:37: implicit conversion loses integer precision: 'size_type' (aka 'unsigned long') to 'unsigned int' [-Wshorten-64-to-32]
```

This patch fixes them. Thanks!