### PR TITLE
Fix typo in AudioState

### DIFF
--- a/cocos/audio/AudioEngine.cpp
+++ b/cocos/audio/AudioEngine.cpp
@@ -393,7 +393,7 @@ void AudioEngine::uncacheAll()
 float AudioEngine::getDuration(int audioID)
 {
     auto it = _audioIDInfoMap.find(audioID);
-    if (it != _audioIDInfoMap.end() && it->second.state != AudioState::INITIALZING)
+    if (it != _audioIDInfoMap.end() && it->second.state != AudioState::INITIALIZING)
     {
         if (it->second.duration == TIME_UNKNOWN)
         {
@@ -408,7 +408,7 @@ float AudioEngine::getDuration(int audioID)
 bool AudioEngine::setCurrentTime(int audioID, float time)
 {
     auto it = _audioIDInfoMap.find(audioID);
-    if (it != _audioIDInfoMap.end() && it->second.state != AudioState::INITIALZING){
+    if (it != _audioIDInfoMap.end() && it->second.state != AudioState::INITIALIZING) {
         return _audioEngineImpl->setCurrentTime(audioID, time);
     }
 
@@ -418,7 +418,7 @@ bool AudioEngine::setCurrentTime(int audioID, float time)
 float AudioEngine::getCurrentTime(int audioID)
 {
     auto it = _audioIDInfoMap.find(audioID);
-    if (it != _audioIDInfoMap.end() && it->second.state != AudioState::INITIALZING){
+    if (it != _audioIDInfoMap.end() && it->second.state != AudioState::INITIALIZING) {
         return _audioEngineImpl->getCurrentTime(audioID);
     }
     return 0.0f;

--- a/cocos/audio/include/AudioEngine.h
+++ b/cocos/audio/include/AudioEngine.h
@@ -95,7 +95,7 @@ public:
     enum class AudioState
     {
         ERROR  = -1,
-        INITIALZING,
+        INITIALIZING,
         PLAYING,
         PAUSED
     };
@@ -326,7 +326,7 @@ protected:
         AudioInfo()
             : profileHelper(nullptr)
             , duration(TIME_UNKNOWN)
-            , state(AudioState::INITIALZING)
+            , state(AudioState::INITIALIZING)
         {
 
         }

--- a/cocos/audio/winrt/AudioCachePlayer.cpp
+++ b/cocos/audio/winrt/AudioCachePlayer.cpp
@@ -210,7 +210,7 @@ AudioPlayer::AudioPlayer()
     , _finishCallback(nullptr)
     , _xaMasterVoice(nullptr)
     , _xaSourceVoice(nullptr)
-    , _state(AudioPlayerState::INITIALZING)
+    , _state(AudioPlayerState::INITIALIZING)
 {
     init();
 }

--- a/cocos/audio/winrt/AudioCachePlayer.h
+++ b/cocos/audio/winrt/AudioCachePlayer.h
@@ -37,7 +37,7 @@ typedef struct AudioInfo
 enum class AudioPlayerState
 {
     ERRORED = -1,
-    INITIALZING,
+    INITIALIZING,
     READY,
     PLAYING,
     PAUSED,

--- a/cocos/scripting/js-bindings/script/jsb_audioengine.js
+++ b/cocos/scripting/js-bindings/script/jsb_audioengine.js
@@ -26,7 +26,7 @@ if (!jsb || !jsb.AudioEngine) return;
 
 jsb.AudioEngine.AudioState = {
     ERROR: -1,
-    INITIALZING: 0,
+    INITIALIZING: 0,
     PLAYING: 1,
     PAUSED: 2
 };


### PR DESCRIPTION
Hello, I found a small mistake in the `AudioState` enum class and renamed it `INITIALZING` to `INITIALIZING`.