### PR TITLE
Make extensions work out of the box in Linux

### DIFF
--- a/templates/cpp-template-default/CMakeLists.txt
+++ b/templates/cpp-template-default/CMakeLists.txt
@@ -111,7 +111,9 @@ endif()
 include_directories(
   /usr/local/include/GLFW
   /usr/include/GLFW
+  ${COCOS2D_ROOT}
   ${COCOS2D_ROOT}/cocos
+  ${COCOS2D_ROOT}/external
   ${COCOS2D_ROOT}/cocos/platform
   ${COCOS2D_ROOT}/cocos/audio/include/
   Classes


### PR DESCRIPTION
`extensions/GUI/CCControlExtension/CCControlStepper.h` contains the [line](https://github.com/cocos2d/cocos2d-x/blob/v3/extensions/GUI/CCControlExtension/CCControlStepper.h#L33):
````cpp
#include "extensions/ExtensionExport.h"
````
and `extensions/assets-manager/Manifest.h` contains the [line](https://github.com/cocos2d/cocos2d-x/blob/v3/extensions/assets-manager/Manifest.h#L37):
````cpp 
#include "json/document-wrapper.h"
````

These two headers, along with other files under the `extensions` directory assume that `${COCOS2D_ROOT}` and `${COCOS2D_ROOT}/external`, respectively, are in included in the list of paths used by the compiler when it searches for headers, but this is not reflected in `CMakeLists.txt` for Linux.

I think we should include these paths by default.