### PR TITLE
Avoid variable shadowing

### DIFF
--- a/cocos/3d/CCSprite3D.cpp
+++ b/cocos/3d/CCSprite3D.cpp
@@ -199,12 +199,12 @@ bool Sprite3D::loadFromCache(const std::string& path)
         _skeleton = Skeleton3D::create(spritedata->nodedatas->skeleton);
         CC_SAFE_RETAIN(_skeleton);
 
-        auto size = spritedata->nodedatas->nodes.size();
+        const bool singleSprite = (spritedata->nodedatas->nodes.size() == 1);
         for(const auto& it : spritedata->nodedatas->nodes)
         {
             if(it)
             {
-                createNode(it, this, *(spritedata->materialdatas), size == 1);
+                createNode(it, this, *(spritedata->materialdatas), singleSprite);
             }
         }
         


### PR DESCRIPTION
I get the following warning message when compiling libcocos2d Mac/iOS with Xcode 8.2.1:

```
cocos/3d/CCSprite3D.cpp:219:29: warning: declaration shadows a local variable [-Wshadow]
        for (ssize_t i = 0, size = _meshes.size(); i < size; ++i) {
                            ^
cocos/3d/CCSprite3D.cpp:202:14: note: previous declaration is here
        auto size = spritedata->nodedatas->nodes.size();
             ^
```

This patch replaces the variable `size` with `singleSprite` at line 202 and 207 to avoid the variable shadowing.