### PR TITLE
Add setting for default value to enable antialias

### DIFF
--- a/cocos/renderer/CCTexture2D.cpp
+++ b/cocos/renderer/CCTexture2D.cpp
@@ -120,6 +120,10 @@ const Texture2D::PixelFormatInfoMap Texture2D::_pixelFormatInfoTables(TexturePix
 // Default is: RGBA8888 (32-bit textures)
 static Texture2D::PixelFormat g_defaultAlphaPixelFormat = Texture2D::PixelFormat::DEFAULT;
 
+// The default value whether to apply antialias
+// Default is: true
+static bool g_defaultAntialiasEnabled = true;
+
 //////////////////////////////////////////////////////////////////////////
 //convertor function
 
@@ -442,7 +446,7 @@ Texture2D::Texture2D()
 , _hasPremultipliedAlpha(false)
 , _hasMipmaps(false)
 , _shaderProgram(nullptr)
-, _antialiasEnabled(true)
+, _antialiasEnabled(g_defaultAntialiasEnabled)
 , _ninePatchInfo(nullptr)
 , _valid(true)
 , _alphaTexture(nullptr)
@@ -1415,6 +1419,16 @@ void Texture2D::setDefaultAlphaPixelFormat(Texture2D::PixelFormat format)
 Texture2D::PixelFormat Texture2D::getDefaultAlphaPixelFormat()
 {
     return g_defaultAlphaPixelFormat;
+}
+
+void Texture2D::setDefaultAntialiasEnabled(bool enabled)
+{
+    g_defaultAntialiasEnabled = enabled;
+}
+
+bool Texture2D::getDefaultAntialiasEnabled()
+{
+    return g_defaultAntialiasEnabled;
 }
 
 unsigned int Texture2D::getBitsPerPixelForFormat(Texture2D::PixelFormat format) const

--- a/cocos/renderer/CCTexture2D.h
+++ b/cocos/renderer/CCTexture2D.h
@@ -179,6 +179,15 @@ public:
      */
     static Texture2D::PixelFormat getDefaultAlphaPixelFormat();
     CC_DEPRECATED_ATTRIBUTE static Texture2D::PixelFormat defaultAlphaPixelFormat() { return Texture2D::getDefaultAlphaPixelFormat(); };
+    
+    /** sets the default value whether to enable antialias.
+     @param enabled
+     */
+    static void setDefaultAntialiasEnabled(bool enabled);
+    
+    /** Returns whether antialias is enabled or not.
+     */
+    static bool getDefaultAntialiasEnabled();
 
     /** Treats (or not) PVR files as if they have alpha premultiplied.
      


### PR DESCRIPTION
I developed a retro-styled game. So I'd like to disable antialias when I scale textures.

I added the setting whether to enable antialias for all textures.

```cpp
// Disable antialias for all textures
Texture2D::setDefaultAntialiasEnabled(false);
```

Could you review this? 🙇 

![antialias](https://cloud.githubusercontent.com/assets/147051/22553123/f329de20-e99e-11e6-817f-b2a66f454eb5.png)
