### PR TITLE
Fixed variable order in initializer lists

### DIFF
--- a/cocos/network/HttpClient-android.cpp
+++ b/cocos/network/HttpClient-android.cpp
@@ -85,8 +85,8 @@ class HttpURLConnection
 {
 public:
     HttpURLConnection(HttpClient* httpClient)
-    :_httpURLConnection(nullptr)
-    ,_client(httpClient)
+    :_client(httpClient)
+    ,_httpURLConnection(nullptr)
     ,_requestmethod("")
     ,_responseCookies("")
     ,_cookieFileName("")

--- a/cocos/network/SocketIO.cpp
+++ b/cocos/network/SocketIO.cpp
@@ -102,7 +102,7 @@ private:
     std::vector<std::string> _typesMessage;
 };
 
-SocketIOPacket::SocketIOPacket() :_separator(":"), _endpointseparator("")
+SocketIOPacket::SocketIOPacket() :_endpointseparator(""), _separator(":")
 {
     _types.push_back("disconnect");
     _types.push_back("connect");
@@ -393,8 +393,8 @@ public:
 SIOClientImpl::SIOClientImpl(const std::string& host, int port) :
     _port(port),
     _host(host),
-    _connected(false),
     _uri(host + ":" + StringUtils::toString(port)),
+    _connected(false),
     _ws(nullptr)
 {
 }

--- a/cocos/platform/android/CCDevice-android.cpp
+++ b/cocos/platform/android/CCDevice-android.cpp
@@ -70,9 +70,9 @@ class BitmapDC
 public:
 
     BitmapDC()
-    : _data(nullptr)
-    , _width(0)
+    : _width(0)
     , _height(0)
+    , _data(nullptr)
     {
     }
 

--- a/cocos/platform/win8.1-universal/OpenGLES.cpp
+++ b/cocos/platform/win8.1-universal/OpenGLES.cpp
@@ -23,9 +23,9 @@ using namespace Windows::Foundation;
 using namespace Windows::Foundation::Collections;
 
 OpenGLES::OpenGLES() :
-    mEglConfig(nullptr),
     mEglDisplay(EGL_NO_DISPLAY),
-    mEglContext(EGL_NO_CONTEXT)
+    mEglContext(EGL_NO_CONTEXT),
+    mEglConfig(nullptr)
 {
     Initialize();
 }

--- a/cocos/ui/UIRichText.cpp
+++ b/cocos/ui/UIRichText.cpp
@@ -281,11 +281,11 @@ public:
             hasColor = true;
         }
         Attributes()
-        : bold(false)
+        : fontSize(-1)
+        , hasColor(false)
+        , bold(false)
         , italics(false)
         , line(StyleLine::NONE)
-        , hasColor(false)
-        , fontSize(-1)
         , effect(StyleEffect::NONE)
         {
         }
@@ -354,8 +354,8 @@ private:
 MyXMLVisitor::TagTables MyXMLVisitor::_tagTables;
 
 MyXMLVisitor::MyXMLVisitor(RichText* richText)
-: _richText(richText)
-, _fontElements(20)
+:  _fontElements(20)
+, _richText(richText)
 {
     MyXMLVisitor::setTagDescription("font", true, [](const ValueMap& tagAttrValueMap) {
         // supported attributes:

--- a/extensions/Particle3D/PU/CCPUDynamicAttribute.cpp
+++ b/extensions/Particle3D/PU/CCPUDynamicAttribute.cpp
@@ -170,9 +170,9 @@ PUDynamicAttributeCurved::PUDynamicAttributeCurved (PUInterpolationType interpol
 }
 //-----------------------------------------------------------------------
 PUDynamicAttributeCurved::PUDynamicAttributeCurved (const PUDynamicAttributeCurved& dynamicAttributeCurved) :
-    _interpolationType(dynamicAttributeCurved._interpolationType),
+    _range(dynamicAttributeCurved._range),
     _spline(dynamicAttributeCurved._spline),
-    _range(dynamicAttributeCurved._range)
+    _interpolationType(dynamicAttributeCurved._interpolationType)
 {
     _type = PUDynamicAttribute::DAT_CURVED;
 

--- a/templates/cpp-template-default/proj.win10/App/Cocos2dEngine/OpenGLES.cpp
+++ b/templates/cpp-template-default/proj.win10/App/Cocos2dEngine/OpenGLES.cpp
@@ -23,9 +23,9 @@ using namespace Windows::Foundation;
 using namespace Windows::Foundation::Collections;
 
 OpenGLES::OpenGLES() :
-    mEglConfig(nullptr),
     mEglDisplay(EGL_NO_DISPLAY),
-    mEglContext(EGL_NO_CONTEXT)
+    mEglContext(EGL_NO_CONTEXT),
+    mEglConfig(nullptr)
 {
     Initialize();
 }

--- a/templates/cpp-template-default/proj.win8.1-universal/App.Shared/OpenGLES.cpp
+++ b/templates/cpp-template-default/proj.win8.1-universal/App.Shared/OpenGLES.cpp
@@ -23,9 +23,9 @@ using namespace Windows::Foundation;
 using namespace Windows::Foundation::Collections;
 
 OpenGLES::OpenGLES() :
-    mEglConfig(nullptr),
     mEglDisplay(EGL_NO_DISPLAY),
-    mEglContext(EGL_NO_CONTEXT)
+    mEglContext(EGL_NO_CONTEXT),
+    mEglConfig(nullptr)
 {
     Initialize();
 }

--- a/templates/js-template-default/frameworks/runtime-src/proj.win8.1-universal/App.Shared/OpenGLES.cpp
+++ b/templates/js-template-default/frameworks/runtime-src/proj.win8.1-universal/App.Shared/OpenGLES.cpp
@@ -23,9 +23,9 @@ using namespace Windows::Foundation;
 using namespace Windows::Foundation::Collections;
 
 OpenGLES::OpenGLES() :
-    mEglConfig(nullptr),
     mEglDisplay(EGL_NO_DISPLAY),
-    mEglContext(EGL_NO_CONTEXT)
+    mEglContext(EGL_NO_CONTEXT),
+    mEglConfig(nullptr)
 {
     Initialize();
 }

--- a/templates/lua-template-default/frameworks/runtime-src/proj.win32/SimulatorWin.cpp
+++ b/templates/lua-template-default/frameworks/runtime-src/proj.win32/SimulatorWin.cpp
@@ -113,9 +113,9 @@ SimulatorWin *SimulatorWin::getInstance()
 }
 
 SimulatorWin::SimulatorWin()
-    : _app(nullptr)
-    , _hwnd(NULL)
+    : _hwnd(NULL)
     , _hwndConsole(NULL)
+    , _app(nullptr)
     , _writeDebugLogFile(nullptr)
 {
 }

--- a/tools/simulator/frameworks/runtime-src/proj.win32/SimulatorWin.cpp
+++ b/tools/simulator/frameworks/runtime-src/proj.win32/SimulatorWin.cpp
@@ -134,9 +134,9 @@ SimulatorWin *SimulatorWin::getInstance()
 }
 
 SimulatorWin::SimulatorWin()
-    : _app(nullptr)
-    , _hwnd(NULL)
+    : _hwnd(NULL)
     , _hwndConsole(NULL)
+    , _app(nullptr)
     , _writeDebugLogFile(nullptr)
 {
 }

--- a/tools/simulator/libsimulator/lib/PlayerTaskServiceProtocol.cpp
+++ b/tools/simulator/libsimulator/lib/PlayerTaskServiceProtocol.cpp
@@ -59,8 +59,8 @@ PlayerTask::PlayerTask(const std::string &name,
                        : _name(name)
                        , _executePath(executePath)
                        , _commandLineArguments(commandLineArguments)
-                       , _state(STATE_IDLE)
                        , _lifetime(0)
+                       , _state(STATE_IDLE)
                        , _resultCode(0)
 {
 }

--- a/tools/simulator/libsimulator/lib/platform/win32/PlayerWin.cpp
+++ b/tools/simulator/libsimulator/lib/platform/win32/PlayerWin.cpp
@@ -6,8 +6,8 @@ PLAYER_NS_BEGIN
 
 PlayerWin::PlayerWin()
     : PlayerProtocol()
-    , _messageBoxService(nullptr)
     , _menuService(nullptr)
+    , _messageBoxService(nullptr)
     , _editboxService(nullptr)
     , _taskService(nullptr)
     , _hwnd(NULL)


### PR DESCRIPTION
`cppcheck` is currently reporting wrong variable order in the initializer list of some constructors. On some cases this could cause wrong initial value assignment to these variables.

This pull request mitigates the following messages from `cppcheck`:
````
[cocos/network/HttpClient-android.cpp:89] -> [cocos/network/HttpClient-android.cpp:610]: (style, inconclusive) Member variable 'HttpURLConnection::_client' is in the wrong place in the initializer list.
[cocos/network/SocketIO.cpp:105] -> [cocos/network/SocketIO.cpp:88]: (style, inconclusive) Member variable 'SocketIOPacket::_endpointseparator' is in the wrong place in the initializer list.
[cocos/network/SocketIO.cpp:397] -> [cocos/network/SocketIO.cpp:349]: (style, inconclusive) Member variable 'SIOClientImpl::_uri' is in the wrong place in the initializer list.
[cocos/platform/android/CCDevice-android.cpp:74] -> [cocos/platform/android/CCDevice-android.cpp:142]: (style, inconclusive) Member variable 'BitmapDC::_width' is in the wrong place in the initializer list.
[cocos/platform/win8.1-universal/OpenGLES.cpp:27] -> [cocos/platform/win8.1-universal/OpenGLES.h:48]: (style, inconclusive) Member variable 'OpenGLES::mEglDisplay' is in the wrong place in the initializer list.
[cocos/ui/UIRichText.cpp:358] -> [cocos/ui/UIRichText.cpp:295]: (style, inconclusive) Member variable 'MyXMLVisitor::_fontElements' is in the wrong place in the initializer list.
[cocos/ui/UIRichText.cpp:287] -> [cocos/ui/UIRichText.cpp:266]: (style, inconclusive) Member variable 'Attributes::hasColor' is in the wrong place in the initializer list.
[cocos/ui/UIRichText.cpp:288] -> [cocos/ui/UIRichText.cpp:264]: (style, inconclusive) Member variable 'Attributes::fontSize' is in the wrong place in the initializer list.
[extensions/Particle3D/PU/CCPUDynamicAttribute.cpp:174] -> [extensions/Particle3D/PU/CCPUDynamicAttribute.h:241]: (style, inconclusive) Member variable 'PUDynamicAttributeCurved::_spline' is in the wrong place in the initializer list.
[extensions/Particle3D/PU/CCPUDynamicAttribute.cpp:175] -> [extensions/Particle3D/PU/CCPUDynamicAttribute.h:237]: (style, inconclusive) Member variable 'PUDynamicAttributeCurved::_range' is in the wrong place in the initializer list.
[templates/cpp-template-default/proj.win10/App/Cocos2dEngine/OpenGLES.cpp:27] -> [templates/cpp-template-default/proj.win10/App/Cocos2dEngine/OpenGLES.h:48]: (style, inconclusive) Member variable 'OpenGLES::mEglDisplay' is in the wrong place in the initializer list.
[templates/cpp-template-default/proj.win8.1-universal/App.Shared/OpenGLES.cpp:27] -> [templates/cpp-template-default/proj.win8.1-universal/App.Shared/OpenGLES.h:48]: (style, inconclusive) Member variable 'OpenGLES::mEglDisplay' is in the wrong place in the initializer list.
[templates/js-template-default/frameworks/runtime-src/proj.win8.1-universal/App.Shared/OpenGLES.cpp:27] -> [templates/js-template-default/frameworks/runtime-src/proj.win8.1-universal/App.Shared/OpenGLES.h:48]: (style, inconclusive) Member variable 'OpenGLES::mEglDisplay' is in the wrong place in the initializer list.
[templates/lua-template-default/frameworks/runtime-src/proj.win32/SimulatorWin.cpp:117] -> [templates/lua-template-default/frameworks/runtime-src/proj.win32/SimulatorWin.h:30]: (style, inconclusive) Member variable 'SimulatorWin::_hwnd' is in the wrong place in the initializer list.
[tools/simulator/frameworks/runtime-src/proj.win32/SimulatorWin.cpp:138] -> [tools/simulator/frameworks/runtime-src/proj.win32/SimulatorWin.h:30]: (style, inconclusive) Member variable 'SimulatorWin::_hwnd' is in the wrong place in the initializer list.
[tools/simulator/libsimulator/lib/PlayerTaskServiceProtocol.cpp:63] -> [tools/simulator/libsimulator/lib/PlayerTaskServiceProtocol.h:46]: (style, inconclusive) Member variable 'PlayerTask::_lifetime' is in the wrong place in the initializer list.
[tools/simulator/libsimulator/lib/platform/win32/PlayerWin.cpp:10] -> [tools/simulator/libsimulator/lib/platform/win32/PlayerWin.h:34]: (style, inconclusive) Member variable 'PlayerWin::_menuService' is in the wrong place in the initializer list.
````