### PR TITLE
Fix minor typos in naming

### DIFF
--- a/cocos/2d/CCParticleSystem.cpp
+++ b/cocos/2d/CCParticleSystem.cpp
@@ -78,7 +78,7 @@ NS_CC_BEGIN
 //
 
 
-inline void nomalize_point(float x, float y, particle_point* out)
+inline void normalize_point(float x, float y, particle_point* out)
 {
     float n = x * x + y * y;
     // Already normalized.
@@ -904,7 +904,7 @@ void ParticleSystem::update(float dt)
                 // radial acceleration
                 if (_particleData.posx[i] || _particleData.posy[i])
                 {
-                    nomalize_point(_particleData.posx[i], _particleData.posy[i], &radial);
+                    normalize_point(_particleData.posx[i], _particleData.posy[i], &radial);
                 }
                 tangential = radial;
                 radial.x *= _particleData.modeA.radialAccel[i];

--- a/cocos/3d/CCTerrain.cpp
+++ b/cocos/3d/CCTerrain.cpp
@@ -149,7 +149,7 @@ void Terrain::onDraw(const Mat4 &transform, uint32_t /*flags*/)
 
     _stateBlock->bind();
 
-    GL::enableVertexAttribs(1<<_positionLocation | 1 << _texcordLocation | 1<<_normalLocation);
+    GL::enableVertexAttribs(1<<_positionLocation | 1 << _texcoordLocation | 1<<_normalLocation);
     glProgram->setUniformsForBuiltins(transform);
     _glProgramState->applyUniforms();
     glUniform3f(_lightDirLocation,_lightDir.x,_lightDir.y,_lightDir.z);
@@ -815,7 +815,7 @@ void Terrain::cacheUniformAttribLocation()
 {
 
     _positionLocation = glGetAttribLocation(this->getGLProgram()->getProgram(),"a_position");
-    _texcordLocation = glGetAttribLocation(this->getGLProgram()->getProgram(),"a_texCoord");
+    _texcoordLocation = glGetAttribLocation(this->getGLProgram()->getProgram(),"a_texCoord");
     _normalLocation = glGetAttribLocation(this->getGLProgram()->getProgram(),"a_normal");
     _alphaMapLocation = -1;
     for(int i =0;i<4;++i)

--- a/cocos/3d/CCTerrain.h
+++ b/cocos/3d/CCTerrain.h
@@ -508,7 +508,7 @@ protected:
     Mat4 _terrainModelMatrix;
     GLuint _normalLocation;
     GLuint _positionLocation;
-    GLuint _texcordLocation;
+    GLuint _texcoordLocation;
     float _maxHeight;
     float _minHeight;
     CrackFixedType _crackFixedType;

--- a/cocos/ui/UILayout.cpp
+++ b/cocos/ui/UILayout.cpp
@@ -74,7 +74,7 @@ _clippingStencil(nullptr),
 _clippingRect(Rect::ZERO),
 _clippingParent(nullptr),
 _clippingRectDirty(true),
-_stencileStateManager(new StencilStateManager()),
+_stencilStateManager(new StencilStateManager()),
 _doLayoutDirty(true),
 _isInterceptTouch(false),
 _loopFocus(false),
@@ -87,7 +87,7 @@ _isFocusPassing(false)
 Layout::~Layout()
 {
     CC_SAFE_RELEASE(_clippingStencil);
-    CC_SAFE_DELETE(_stencileStateManager);
+    CC_SAFE_DELETE(_stencilStateManager);
 }
     
 void Layout::onEnter()
@@ -268,13 +268,13 @@ void Layout::stencilClippingVisit(Renderer *renderer, const Mat4& parentTransfor
     renderer->pushGroup(_groupCommand.getRenderQueueID());
     
     _beforeVisitCmdStencil.init(_globalZOrder);
-    _beforeVisitCmdStencil.func = CC_CALLBACK_0(StencilStateManager::onBeforeVisit, _stencileStateManager);
+    _beforeVisitCmdStencil.func = CC_CALLBACK_0(StencilStateManager::onBeforeVisit, _stencilStateManager);
     renderer->addCommand(&_beforeVisitCmdStencil);
     
     _clippingStencil->visit(renderer, _modelViewTransform, flags);
     
     _afterDrawStencilCmd.init(_globalZOrder);
-    _afterDrawStencilCmd.func = CC_CALLBACK_0(StencilStateManager::onAfterDrawStencil, _stencileStateManager);
+    _afterDrawStencilCmd.func = CC_CALLBACK_0(StencilStateManager::onAfterDrawStencil, _stencilStateManager);
     renderer->addCommand(&_afterDrawStencilCmd);
     
     int i = 0;      // used by _children
@@ -322,7 +322,7 @@ void Layout::stencilClippingVisit(Renderer *renderer, const Mat4& parentTransfor
 
     
     _afterVisitCmdStencil.init(_globalZOrder);
-    _afterVisitCmdStencil.func = CC_CALLBACK_0(StencilStateManager::onAfterVisit, _stencileStateManager);
+    _afterVisitCmdStencil.func = CC_CALLBACK_0(StencilStateManager::onAfterVisit, _stencilStateManager);
     renderer->addCommand(&_afterVisitCmdStencil);
     
     renderer->popGroup();

--- a/cocos/ui/UILayout.h
+++ b/cocos/ui/UILayout.h
@@ -634,7 +634,7 @@ protected:
     bool _clippingRectDirty;
     
     //clipping
-    StencilStateManager *_stencileStateManager;
+    StencilStateManager *_stencilStateManager;
 
     GroupCommand _groupCommand;
     CustomCommand _beforeVisitCmdStencil;


### PR DESCRIPTION
This PR fixes the following spelling mistakes in naming:

- `nomalize_point` -> `normalize_point`
- `_texcordLocation` -> `_texcoordLocation`
- `_stencileStateManager` -> `_stencilStateManager`

Also the changeset doesn't break backwards compatibility.
Thank you for your time.