### PR TITLE
Fix variable shadowing warnings

### DIFF
--- a/cocos/platform/CCFileUtils.cpp
+++ b/cocos/platform/CCFileUtils.cpp
@@ -571,8 +571,8 @@ bool FileUtils::writeStringToFile(const std::string& dataStr, const std::string&
 
 void FileUtils::writeStringToFile(std::string dataStr, const std::string& fullPath, std::function<void(bool)> callback)
 {
-    performOperationOffthread([fullPath](const std::string& dataStr) -> bool {
-            return FileUtils::getInstance()->writeStringToFile(dataStr, fullPath);
+    performOperationOffthread([fullPath](const std::string& dataStrIn) -> bool {
+        return FileUtils::getInstance()->writeStringToFile(dataStrIn, fullPath);
     }, std::move(callback),std::move(dataStr));
 }
 
@@ -603,8 +603,8 @@ bool FileUtils::writeDataToFile(const Data& data, const std::string& fullPath)
 
 void FileUtils::writeDataToFile(Data data, const std::string& fullPath, std::function<void(bool)> callback)
 {
-    performOperationOffthread([fullPath](const Data& data) -> bool {
-            return FileUtils::getInstance()->writeDataToFile(data, fullPath);
+    performOperationOffthread([fullPath](const Data& dataIn) -> bool {
+        return FileUtils::getInstance()->writeDataToFile(dataIn, fullPath);
     }, std::move(callback), std::move(data));
 }
 
@@ -753,15 +753,15 @@ unsigned char* FileUtils::getFileDataFromZip(const std::string& zipFilePath, con
 void FileUtils::writeValueMapToFile(ValueMap dict, const std::string& fullPath, std::function<void(bool)> callback)
 {
     
-    performOperationOffthread([fullPath](const ValueMap& dict) -> bool {
-            return FileUtils::getInstance()->writeValueMapToFile(dict, fullPath);
+    performOperationOffthread([fullPath](const ValueMap& dictIn) -> bool {
+        return FileUtils::getInstance()->writeValueMapToFile(dictIn, fullPath);
     }, std::move(callback), std::move(dict));
 }
 
 void FileUtils::writeValueVectorToFile(ValueVector vecData, const std::string& fullPath, std::function<void(bool)> callback)
 {
-    performOperationOffthread([fullPath] (const ValueVector& vecData) -> bool {
-            return FileUtils::getInstance()->writeValueVectorToFile(vecData, fullPath);
+    performOperationOffthread([fullPath] (const ValueVector& vecDataIn) -> bool {
+        return FileUtils::getInstance()->writeValueVectorToFile(vecDataIn, fullPath);
     }, std::move(callback), std::move(vecData));
 }
 

--- a/cocos/platform/CCFileUtils.h
+++ b/cocos/platform/CCFileUtils.h
@@ -918,9 +918,9 @@ protected:
 #else
         // As cocos2d-x uses c++11, we will use std::bind to leverage move sematics to
         // move our arguments into our lambda, to potentially avoid copying. 
-        auto lambda = std::bind([](const T& action, const R& callback, const ARGS& ...args)
+        auto lambda = std::bind([](const T& actionIn, const R& callbackIn, const ARGS& ...argsIn)
         {
-            Director::getInstance()->getScheduler()->performFunctionInCocosThread(std::bind(callback, action(args...)));
+            Director::getInstance()->getScheduler()->performFunctionInCocosThread(std::bind(callbackIn, actionIn(argsIn...)));
         }, std::forward<T>(action), std::forward<R>(callback), std::forward<ARGS>(args)...);
         
 #endif


### PR DESCRIPTION
I get the following warnings when compiling the latest v3 branch on Xcode 8.2.1:

```
cocos/platform/CCFileUtils.cpp:574:61: declaration shadows a local variable [-Wshadow]
cocos/platform/CCFileUtils.cpp:606:54: declaration shadows a local variable [-Wshadow]
cocos/platform/CCFileUtils.cpp:756:58: declaration shadows a local variable [-Wshadow]
cocos/platform/CCFileUtils.cpp:763:62: declaration shadows a local variable [-Wshadow]
cocos/platform/CCFileUtils.h:921:45: declaration shadows a local variable [-Wshadow]
cocos/platform/CCFileUtils.h:921:62: declaration shadows a local variable [-Wshadow]
cocos/platform/CCFileUtils.h:921:87: declaration shadows a local variable [-Wshadow]
```

This patch renames several variables which defined inside lambda expression to prevent variable shadowing. Thanks.