### PR TITLE
Fix minor typos in comments and docs

### DIFF
--- a/cocos/2d/CCDrawNode.cpp
+++ b/cocos/2d/CCDrawNode.cpp
@@ -221,7 +221,7 @@ bool DrawNode::init()
         // color
         glEnableVertexAttribArray(GLProgram::VERTEX_ATTRIB_COLOR);
         glVertexAttribPointer(GLProgram::VERTEX_ATTRIB_COLOR, 4, GL_UNSIGNED_BYTE, GL_TRUE, sizeof(V2F_C4B_T2F), (GLvoid *)offsetof(V2F_C4B_T2F, colors));
-        // texcood
+        // texcoord
         glEnableVertexAttribArray(GLProgram::VERTEX_ATTRIB_TEX_COORD);
         glVertexAttribPointer(GLProgram::VERTEX_ATTRIB_TEX_COORD, 2, GL_FLOAT, GL_FALSE, sizeof(V2F_C4B_T2F), (GLvoid *)offsetof(V2F_C4B_T2F, texCoords));
         
@@ -236,7 +236,7 @@ bool DrawNode::init()
         // color
         glEnableVertexAttribArray(GLProgram::VERTEX_ATTRIB_COLOR);
         glVertexAttribPointer(GLProgram::VERTEX_ATTRIB_COLOR, 4, GL_UNSIGNED_BYTE, GL_TRUE, sizeof(V2F_C4B_T2F), (GLvoid *)offsetof(V2F_C4B_T2F, colors));
-        // texcood
+        // texcoord
         glEnableVertexAttribArray(GLProgram::VERTEX_ATTRIB_TEX_COORD);
         glVertexAttribPointer(GLProgram::VERTEX_ATTRIB_TEX_COORD, 2, GL_FLOAT, GL_FALSE, sizeof(V2F_C4B_T2F), (GLvoid *)offsetof(V2F_C4B_T2F, texCoords));
         
@@ -346,7 +346,7 @@ void DrawNode::onDraw(const Mat4 &transform, uint32_t /*flags*/)
         glVertexAttribPointer(GLProgram::VERTEX_ATTRIB_POSITION, 2, GL_FLOAT, GL_FALSE, sizeof(V2F_C4B_T2F), (GLvoid *)offsetof(V2F_C4B_T2F, vertices));
         // color
         glVertexAttribPointer(GLProgram::VERTEX_ATTRIB_COLOR, 4, GL_UNSIGNED_BYTE, GL_TRUE, sizeof(V2F_C4B_T2F), (GLvoid *)offsetof(V2F_C4B_T2F, colors));
-        // texcood
+        // texcoord
         glVertexAttribPointer(GLProgram::VERTEX_ATTRIB_TEX_COORD, 2, GL_FLOAT, GL_FALSE, sizeof(V2F_C4B_T2F), (GLvoid *)offsetof(V2F_C4B_T2F, texCoords));
     }
 
@@ -389,7 +389,7 @@ void DrawNode::onDrawGLLine(const Mat4 &transform, uint32_t /*flags*/)
         glVertexAttribPointer(GLProgram::VERTEX_ATTRIB_POSITION, 2, GL_FLOAT, GL_FALSE, sizeof(V2F_C4B_T2F), (GLvoid *)offsetof(V2F_C4B_T2F, vertices));
         // color
         glVertexAttribPointer(GLProgram::VERTEX_ATTRIB_COLOR, 4, GL_UNSIGNED_BYTE, GL_TRUE, sizeof(V2F_C4B_T2F), (GLvoid *)offsetof(V2F_C4B_T2F, colors));
-        // texcood
+        // texcoord
         glVertexAttribPointer(GLProgram::VERTEX_ATTRIB_TEX_COORD, 2, GL_FLOAT, GL_FALSE, sizeof(V2F_C4B_T2F), (GLvoid *)offsetof(V2F_C4B_T2F, texCoords));
     }
 

--- a/cocos/2d/CCLabel.cpp
+++ b/cocos/2d/CCLabel.cpp
@@ -820,7 +820,7 @@ bool Label::alignText()
         {
             return true;
         }
-        // optimize for one-texture-only sceneario
+        // optimize for one-texture-only scenario
         // if multiple textures, then we should count how many chars
         // are per texture
         if (_batchNodes.size()==1)

--- a/cocos/editor-support/cocostudio/CCDataReaderHelper.h
+++ b/cocos/editor-support/cocostudio/CCDataReaderHelper.h
@@ -123,7 +123,7 @@ public:
 
     /**
      * Translate XML export from Dragon Bone flash tool to datas, and save them.
-     * When you add a new xml, the data already saved will be keeped.
+     * When you add a new xml, the data already saved will be kept.
      *
      * @param xmlPath The cache of the xml
      */

--- a/cocos/network/SocketIO.h
+++ b/cocos/network/SocketIO.h
@@ -121,7 +121,7 @@ public:
          */
         virtual void onMessage(SIOClient* client, const std::string& data) { CCLOG("SIODelegate onMessage fired with data: %s", data.c_str()); };
         /**
-         * Pure virtual callback function, this function should be overrided by the subclass.
+         * Pure virtual callback function, this function should be overridden by the subclass.
          *
          * This function would be called when the related SIOClient object disconnect or receive disconnect signal.
          *
@@ -129,7 +129,7 @@ public:
          */
         virtual void onClose(SIOClient* client) = 0;
         /**
-         * Pure virtual callback function, this function should be overrided by the subclass.
+         * Pure virtual callback function, this function should be overridden by the subclass.
          *
          * This function would be called when the related SIOClient object receive error signal or didn't connect the endpoint but do some network operation, eg.,send and emit,etc.
          *

--- a/cocos/renderer/CCGLProgram.h
+++ b/cocos/renderer/CCGLProgram.h
@@ -366,7 +366,7 @@ public:
     */
     
     /** @{
-     Create or Initializes the GLProgram with a vertex and fragment with bytes array, with shader headers defination(eg. #version ... or #extension ...), with compileTimeDefines(eg. #define ...).
+     Create or Initializes the GLProgram with a vertex and fragment with bytes array, with shader headers definition(eg. #version ... or #extension ...), with compileTimeDefines(eg. #define ...).
      * @js initWithString.
      * @lua initWithString.
      */
@@ -391,7 +391,7 @@ public:
     */
 
     /** @{
-     Create or Initializes the GLProgram with a vertex and fragment with contents of filenames, with shader headers defination(eg. #version ... or #extension ...), with compileTimeDefines(eg. #define ...).
+     Create or Initializes the GLProgram with a vertex and fragment with contents of filenames, with shader headers definition(eg. #version ... or #extension ...), with compileTimeDefines(eg. #define ...).
      * @js init
      * @lua init
      */

--- a/cocos/scripting/js-bindings/manual/ScriptingCore.h
+++ b/cocos/scripting/js-bindings/manual/ScriptingCore.h
@@ -511,7 +511,7 @@ public:
     JSObject* getGlobalObject() { return _global->get(); }
     
     /**@~english
-     * Checks whether a C++ function is overrided in js prototype chain
+     * Checks whether a C++ function is overridden in js prototype chain
      * @param obj @~english The js object
      * @param name @~english The function name
      * @param native @~english The native function

--- a/cocos/scripting/lua-bindings/script/cocos2d/DeprecatedCocos2dFunc.lua
+++ b/cocos/scripting/lua-bindings/script/cocos2d/DeprecatedCocos2dFunc.lua
@@ -291,7 +291,7 @@ CCLabelAtlas.create = CCLabelAtlasDeprecated.create
 
 
 ---------------------------
---global functions wil be deprecated, begin
+--global functions will be deprecated, begin
 local function CCRectMake(x,y,width,height)
     deprecatedTip("CCRectMake(x,y,width,height)","cc.rect(x,y,width,height) in lua")
     return cc.rect(x,y,width,height)
@@ -345,7 +345,7 @@ local function ccc4FEqual(a,b)
     return a:equals(b)
 end
 _G.ccc4FEqual = ccc4FEqual
---global functions wil be deprecated, end
+--global functions will be deprecated, end
 
 
 --functions of _G will be deprecated begin

--- a/cocos/ui/UIScale9Sprite.h
+++ b/cocos/ui/UIScale9Sprite.h
@@ -143,7 +143,7 @@ namespace ui {
         /**
          * Creates a 9-slice sprite with an sprite frame.
          * Once the sprite is created, you can then call its "setContentSize:" method
-         * to resize the sprite will all it's 9-slice goodness intract.
+         * to resize the sprite will all it's 9-slice goodness interact.
          * It respects the anchorPoint too.
          *
          * @see initWithSpriteFrame(SpriteFrame *spriteFrame)
@@ -155,7 +155,7 @@ namespace ui {
         /**
          * Creates a 9-slice sprite with an sprite frame and the centre of its zone.
          * Once the sprite is created, you can then call its "setContentSize:" method
-         * to resize the sprite will all it's 9-slice goodness intract.
+         * to resize the sprite will all it's 9-slice goodness interact.
          * It respects the anchorPoint too.
          *
          * @see initWithSpriteFrame(SpriteFrame *spriteFrame, const Rect& capInsets)
@@ -168,7 +168,7 @@ namespace ui {
         /**
          * Creates a 9-slice sprite with an sprite frame name.
          * Once the sprite is created, you can then call its "setContentSize:" method
-         * to resize the sprite will all it's 9-slice goodness intract.
+         * to resize the sprite will all it's 9-slice goodness interact.
          * It respects the anchorPoint too.
          *
          * @see initWithSpriteFrameName(const char *spriteFrameName)
@@ -180,7 +180,7 @@ namespace ui {
         /**
          * Creates a 9-slice sprite with an sprite frame name and the centre of its zone.
          * Once the sprite is created, you can then call its "setContentSize:" method
-         * to resize the sprite will all it's 9-slice goodness intract.
+         * to resize the sprite will all it's 9-slice goodness interact.
          * It respects the anchorPoint too.
          *
          * @see initWithSpriteFrameName(const char *spriteFrameName, const Rect& capInsets)
@@ -200,7 +200,7 @@ namespace ui {
          * Initializes a 9-slice sprite with a texture file, a delimitation zone and
          * with the specified cap insets.
          * Once the sprite is created, you can then call its "setContentSize:" method
-         * to resize the sprite will all it's 9-slice goodness intract.
+         * to resize the sprite will all it's 9-slice goodness interact.
          * It respects the anchorPoint too.
          *
          * @param file The name of the texture file.
@@ -216,7 +216,7 @@ namespace ui {
          * Initializes a 9-slice sprite with a texture file and with the specified cap
          * insets.
          * Once the sprite is created, you can then call its "setContentSize:" method
-         * to resize the sprite will all it's 9-slice goodness intract.
+         * to resize the sprite will all it's 9-slice goodness interact.
          * It respects the anchorPoint too.
          *
          * @param file The name of the texture file.
@@ -229,7 +229,7 @@ namespace ui {
          * Initializes a 9-slice sprite with an sprite frame and with the specified
          * cap insets.
          * Once the sprite is created, you can then call its "setContentSize:" method
-         * to resize the sprite will all it's 9-slice goodness intract.
+         * to resize the sprite will all it's 9-slice goodness interact.
          * It respects the anchorPoint too.
          *
          * @param spriteFrame The sprite frame object.
@@ -242,7 +242,7 @@ namespace ui {
          * Initializes a 9-slice sprite with an sprite frame name and with the specified
          * cap insets.
          * Once the sprite is created, you can then call its "setContentSize:" method
-         * to resize the sprite will all it's 9-slice goodness intract.
+         * to resize the sprite will all it's 9-slice goodness interact.
          * It respects the anchorPoint too.
          *
          * @param spriteFrameName The sprite frame name.
@@ -257,7 +257,7 @@ namespace ui {
          * Initializes a 9-slice sprite with a texture file and a delimitation zone. The
          * texture will be broken down into a 3×3 grid of equal blocks.
          * Once the sprite is created, you can then call its "setContentSize:" method
-         * to resize the sprite will all it's 9-slice goodness intract.
+         * to resize the sprite will all it's 9-slice goodness interact.
          * It respects the anchorPoint too.
          *
          * @param file The name of the texture file.
@@ -272,7 +272,7 @@ namespace ui {
          * Initializes a 9-slice sprite with a texture file. The whole texture will be
          * broken down into a 3×3 grid of equal blocks.
          * Once the sprite is created, you can then call its "setContentSize:" method
-         * to resize the sprite will all it's 9-slice goodness intract.
+         * to resize the sprite will all it's 9-slice goodness interact.
          * It respects the anchorPoint too.
          *
          * @param file The name of the texture file.
@@ -283,7 +283,7 @@ namespace ui {
         /**
          * Initializes a 9-slice sprite with an sprite frame name.
          * Once the sprite is created, you can then call its "setContentSize:" method
-         * to resize the sprite will all it's 9-slice goodness intract.
+         * to resize the sprite will all it's 9-slice goodness interact.
          * It respects the anchorPoint too.
          *
          * @param spriteFrameName The sprite frame name.
@@ -296,7 +296,7 @@ namespace ui {
         /**
          * @brief Initializes a 9-slice sprite with an sprite instance.
          * Once the sprite is created, you can then call its "setContentSize:" method
-         * to resize the sprite will all it's 9-slice goodness intract.
+         * to resize the sprite will all it's 9-slice goodness interact.
          * It respects the anchorPoint too.
          *
          * @param sprite The sprite instance.
@@ -310,7 +310,7 @@ namespace ui {
         /**
          * @brief Initializes a 9-slice sprite with an sprite instance.
          * Once the sprite is created, you can then call its "setContentSize:" method
-         * to resize the sprite will all it's 9-slice goodness intract.
+         * to resize the sprite will all it's 9-slice goodness interact.
          * It respects the anchorPoint too.
          *
          * @param sprite The sprite instance.
@@ -323,7 +323,7 @@ namespace ui {
         /**
          * @brief Initializes a 9-slice sprite with an sprite instance.
          * Once the sprite is created, you can then call its "setContentSize:" method
-         * to resize the sprite will all it's 9-slice goodness intract.
+         * to resize the sprite will all it's 9-slice goodness interact.
          * It respects the anchorPoint too.
          *
          * @param sprite The sprite instance.
@@ -344,7 +344,7 @@ namespace ui {
         /**
          * @brief Initializes a 9-slice sprite with a sprite batchnode.
          * Once the sprite is created, you can then call its "setContentSize:" method
-         * to resize the sprite will all it's 9-slice goodness intract.
+         * to resize the sprite will all it's 9-slice goodness interact.
          * It respects the anchorPoint too.
          *
          * @deprecated Use @see `init` instead.
@@ -361,7 +361,7 @@ namespace ui {
         /**
          * @brief Initializes a 9-slice sprite with a sprite batch node.
          * Once the sprite is created, you can then call its "setContentSize:" method
-         * to resize the sprite will all it's 9-slice goodness intract.
+         * to resize the sprite will all it's 9-slice goodness interact.
          * It respects the anchorPoint too.
          *
          * @deprecated Use @see `init` instead.

--- a/extensions/Particle3D/PU/CCPUPointEmitterTranslator.cpp
+++ b/extensions/Particle3D/PU/CCPUPointEmitterTranslator.cpp
@@ -36,7 +36,7 @@ PUPointEmitterTranslator::PUPointEmitterTranslator()
 //-------------------------------------------------------------------------
 bool PUPointEmitterTranslator::translateChildProperty( PUScriptCompiler* /*compiler*/, PUAbstractNode* /*node*/ )
 {
-    // No Propertys
+    // No properties
     return false;
 }
 

--- a/tests/cpp-empty-test/Classes/AppMacros.h
+++ b/tests/cpp-empty-test/Classes/AppMacros.h
@@ -11,7 +11,7 @@
      We check current device frame size to decide which resource need to be selected.
      So if you want to test this situation which said in title '[Situation 1]',
      you should change ios simulator to different device(e.g. iphone, iphone-retina3.5, iphone-retina4.0, ipad, ipad-retina),
-     or change the window size in "proj.XXX/main.cpp" by "CCEGLView::setFrameSize" if you are using win32 or linux plaform
+     or change the window size in "proj.XXX/main.cpp" by "CCEGLView::setFrameSize" if you are using win32 or linux platform
      and modify "proj.mac/AppController.mm" by changing the window rectangle.
 
    [Situation 2] Using one resource to match different design resolutions.


### PR DESCRIPTION
This pull request fixes some minor typos and spelling mistakes in comments and documentation.