### PR TITLE
Signal the scroll once the list is updated in cocos2d::extension::TableView

### DIFF
--- a/extensions/GUI/CCScrollView/CCTableView.cpp
+++ b/extensions/GUI/CCScrollView/CCTableView.cpp
@@ -481,10 +481,6 @@ void TableView::scrollViewDidScroll(ScrollView* /*view*/)
         });
     }
     
-    if(_tableViewDelegate != nullptr) {
-        _tableViewDelegate->scrollViewDidScroll(this);
-    }
-
     ssize_t startIdx = 0, endIdx = 0, idx = 0, maxIdx = 0;
     Vec2 offset = this->getContentOffset() * -1;
     maxIdx = MAX(countOfItems-1, 0);
@@ -581,6 +577,10 @@ void TableView::scrollViewDidScroll(ScrollView* /*view*/)
             continue;
         }
         this->updateCellAtIndex(i);
+    }
+
+    if(_tableViewDelegate != nullptr) {
+        _tableViewDelegate->scrollViewDidScroll(this);
     }
 }
 


### PR DESCRIPTION
This commit moves the call of `TableViewDelegate::scrollViewDidScroll` such that it becomes the last step in `TableView::scrollViewDidScroll`. Since the delegate may want to read the state of the table's cells or the view's position, it seems necessary to notify it once that the view has updated its state.