### PR TITLE
Replace unsigned int with size_t to avoid implicit conversion

### DIFF
--- a/cocos/base/CCDirector.cpp
+++ b/cocos/base/CCDirector.cpp
@@ -468,16 +468,16 @@ void Director::resetMatrixStack()
     initMatrixStack();
 }
 
-void Director::initProjectionMatrixStack(unsigned int stackCount)
+void Director::initProjectionMatrixStack(size_t stackCount)
 {
     _projectionMatrixStackList.clear();
     std::stack<Mat4> projectionMatrixStack;
     projectionMatrixStack.push(Mat4::IDENTITY);
-    for (unsigned int i = 0; i < stackCount; ++i)
+    for (size_t i = 0; i < stackCount; ++i)
         _projectionMatrixStackList.push_back(projectionMatrixStack);
 }
 
-unsigned int Director::getProjectionMatrixStackSize()
+size_t Director::getProjectionMatrixStackSize()
 {
     return _projectionMatrixStackList.size();
 }
@@ -502,7 +502,7 @@ void Director::popMatrix(MATRIX_STACK_TYPE type)
     }
 }
 
-void Director::popProjectionMatrix(unsigned int index)
+void Director::popProjectionMatrix(size_t index)
 {
     _projectionMatrixStackList[index].pop();
 }
@@ -527,7 +527,7 @@ void Director::loadIdentityMatrix(MATRIX_STACK_TYPE type)
     }
 }
 
-void Director::loadProjectionIdentityMatrix(unsigned int index)
+void Director::loadProjectionIdentityMatrix(size_t index)
 {
     _projectionMatrixStackList[index].top() = Mat4::IDENTITY;
 }
@@ -552,7 +552,7 @@ void Director::loadMatrix(MATRIX_STACK_TYPE type, const Mat4& mat)
     }
 }
 
-void Director::loadProjectionMatrix(const Mat4& mat, unsigned int index)
+void Director::loadProjectionMatrix(const Mat4& mat, size_t index)
 {
     _projectionMatrixStackList[index].top() = mat;
 }
@@ -577,7 +577,7 @@ void Director::multiplyMatrix(MATRIX_STACK_TYPE type, const Mat4& mat)
     }
 }
 
-void Director::multiplyProjectionMatrix(const Mat4& mat, unsigned int index)
+void Director::multiplyProjectionMatrix(const Mat4& mat, size_t index)
 {
     _projectionMatrixStackList[index].top() *= mat;
 }
@@ -602,7 +602,7 @@ void Director::pushMatrix(MATRIX_STACK_TYPE type)
     }
 }
 
-void Director::pushProjectionMatrix(unsigned int index)
+void Director::pushProjectionMatrix(size_t index)
 {
     _projectionMatrixStackList[index].push(_projectionMatrixStackList[index].top());
 }
@@ -626,7 +626,7 @@ const Mat4& Director::getMatrix(MATRIX_STACK_TYPE type) const
     return  _modelViewMatrixStack.top();
 }
 
-const Mat4& Director::getProjectionMatrix(unsigned int index) const
+const Mat4& Director::getProjectionMatrix(size_t index) const
 {
     return _projectionMatrixStackList[index].top();
 }

--- a/cocos/base/CCDirector.h
+++ b/cocos/base/CCDirector.h
@@ -462,7 +462,7 @@ public:
      * @param index The index of projection matrix stack.
      * @js NA
      */
-    void pushProjectionMatrix(unsigned int index);
+    void pushProjectionMatrix(size_t index);
 
     /** Pops the top matrix of the specified type of matrix stack.
      * @js NA
@@ -473,7 +473,7 @@ public:
      * @param index The index of projection matrix stack.
      * @js NA
      */
-    void popProjectionMatrix(unsigned int index);
+    void popProjectionMatrix(size_t index);
 
     /** Adds an identity matrix to the top of specified type of matrix stack.
      * @js NA
@@ -484,7 +484,7 @@ public:
      * @param index The index of projection matrix stack.
      * @js NA
      */
-    void loadProjectionIdentityMatrix(unsigned int index);
+    void loadProjectionIdentityMatrix(size_t index);
 
     /**
      * Adds a matrix to the top of specified type of matrix stack.
@@ -502,7 +502,7 @@ public:
      * @param index The index of projection matrix stack.
      * @js NA
      */
-    void loadProjectionMatrix(const Mat4& mat, unsigned int index);
+    void loadProjectionMatrix(const Mat4& mat, size_t index);
 
     /**
      * Multiplies a matrix to the top of specified type of matrix stack.
@@ -520,7 +520,7 @@ public:
      * @param index The index of projection matrix stack.
      * @js NA
      */
-    void multiplyProjectionMatrix(const Mat4& mat, unsigned int index);
+    void multiplyProjectionMatrix(const Mat4& mat, size_t index);
 
     /**
      * Gets the top matrix of specified type of matrix stack.
@@ -533,7 +533,7 @@ public:
      * @param index The index of projection matrix stack.
      * @js NA
      */
-    const Mat4& getProjectionMatrix(unsigned int index) const;
+    const Mat4& getProjectionMatrix(size_t index) const;
 
     /**
      * Clear all types of matrix stack, and add identity matrix to these matrix stacks.
@@ -546,13 +546,13 @@ public:
      * @param stackCount The size of projection matrix stack.
      * @js NA
      */
-    void initProjectionMatrixStack(unsigned int stackCount);
+    void initProjectionMatrixStack(size_t stackCount);
 
     /**
      * Get the size of projection matrix stack.
      * @js NA
      */
-    unsigned int getProjectionMatrixStackSize();
+    size_t getProjectionMatrixStackSize();
 
     /**
      * returns the cocos2d thread id.

--- a/cocos/renderer/CCGLProgram.cpp
+++ b/cocos/renderer/CCGLProgram.cpp
@@ -925,9 +925,8 @@ void GLProgram::setUniformsForBuiltins(const Mat4 &matrixMV)
     if (_flags.usesMultiViewP)
     {
         Mat4 mats[4];
-        unsigned int stackSize = _director->getProjectionMatrixStackSize() <= 4?
-                                 _director->getProjectionMatrixStackSize(): 4;
-        for (unsigned int i = 0; i < stackSize; ++i) {
+        const auto stackSize = std::min<size_t>(_director->getProjectionMatrixStackSize(), 4);
+        for (size_t i = 0; i < stackSize; ++i) {
             mats[i] = _director->getProjectionMatrix(i);
         }
         setUniformLocationWithMatrix4fv(_builtInUniforms[UNIFORM_MULTIVIEW_P_MATRIX], mats[0].m, 4);
@@ -945,9 +944,8 @@ void GLProgram::setUniformsForBuiltins(const Mat4 &matrixMV)
     if (_flags.usesMultiViewMVP)
     {
         Mat4 mats[4];
-        unsigned int stackSize = _director->getProjectionMatrixStackSize() <= 4?
-                                 _director->getProjectionMatrixStackSize(): 4;
-        for (unsigned int i = 0; i < stackSize; ++i) {
+        const auto stackSize = std::min<size_t>(_director->getProjectionMatrixStackSize(), 4);
+        for (size_t i = 0; i < stackSize; ++i) {
             mats[i] = _director->getProjectionMatrix(i) * matrixMV;
         }
         setUniformLocationWithMatrix4fv(_builtInUniforms[UNIFORM_MULTIVIEW_MVP_MATRIX], mats[0].m, 4);


### PR DESCRIPTION
When I try to compile libcocos2d for macOS x86_64 with Xcode 8.2.1, I get a warning about implicit conversion loses integer precision, such as the following:

```
cocos/base/CCDirector.cpp:482:12: warning: implicit conversion loses integer precision: 'size_type' (aka 'unsigned long') to 'unsigned int' [-Wshorten-64-to-32]
    return _projectionMatrixStackList.size();
    ~~~~~~ ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

At least in this case, the type of size/index for ProjectionMatrixStack seems to prefer `size_t` instead of `unsigned int` because the `Director::_projectionMatrixStackList` is constituted of `std::vector` that uses `size_t` as a `size_type`. So this PR replaces `unsigned int` with `size_t` to avoid the implicit conversion warning. Related PR: https://github.com/cocos2d/cocos2d-x/pull/16723

Thank you for your time!