### PR TITLE
Disable subpixel rendering for label textures.

### DIFF
--- a/cocos/2d/CCLabel.cpp
+++ b/cocos/2d/CCLabel.cpp
@@ -1263,8 +1263,11 @@ void Label::createSpriteForSystemFont(const FontDefinition& fontDef)
     _textSprite->setCameraMask(getCameraMask());
     _textSprite->setGlobalZOrder(getGlobalZOrder());
     _textSprite->setAnchorPoint(Vec2::ANCHOR_BOTTOM_LEFT);
+    _textSprite->setSubpixelRendering(false);
+
     this->setContentSize(_textSprite->getContentSize());
     texture->release();
+
     if (_blendFuncDirty)
     {
         _textSprite->setBlendFunc(_blendFunc);
@@ -1296,6 +1299,7 @@ void Label::createShadowSpriteForSystemFont(const FontDefinition& fontDef)
         auto texture = new (std::nothrow) Texture2D;
         texture->initWithString(_utf8Text.c_str(), shadowFontDefinition);
         _shadowNode = Sprite::createWithTexture(texture);
+        _shadowNode->setSubpixelRendering(false);
         texture->release();
     }
 

--- a/cocos/2d/CCSprite.cpp
+++ b/cocos/2d/CCSprite.cpp
@@ -312,6 +312,7 @@ Sprite::Sprite(void)
 , _texture(nullptr)
 , _spriteFrame(nullptr)
 , _insideBounds(true)
+, _subpixelRendering( CC_NODE_RENDER_SUBPIXEL != 0 )
 , _centerRectNormalized(0,0,1,1)
 , _renderMode(Sprite::RenderMode::QUAD)
 , _trianglesVertex(nullptr)
@@ -1072,7 +1073,8 @@ void Sprite::draw(Renderer *renderer, const Mat4 &transform, uint32_t flags)
                                _blendFunc,
                                _polyInfo.triangles,
                                transform,
-                               flags);
+                               flags,
+                               _subpixelRendering);
 
         renderer->addCommand(&_trianglesCommand);
 
@@ -1421,6 +1423,11 @@ void Sprite::updateStretchFactor()
 
     // else:
     // Do nothing if renderMode is Polygon
+}
+
+void Sprite::setSubpixelRendering(bool enabled)
+{
+  _subpixelRendering = enabled;
 }
 
 void Sprite::setFlippedX(bool flippedX)

--- a/cocos/2d/CCSprite.h
+++ b/cocos/2d/CCSprite.h
@@ -398,6 +398,15 @@ public:
 
 
     /**
+     * Sets whether the sprite can be rendered on non integer coordinates or
+     * not.
+     * 
+     * @param enabled true if the sprite can be rendered on non integer
+     *        coordinates, false otherwise.
+     */
+    void setSubpixelRendering(bool enabled);
+    
+    /**
      * Returns the flag which indicates whether the sprite is flipped horizontally or not.
      *
      * It only flips the texture of the sprite, and not the texture of the sprite's children.
@@ -716,6 +725,8 @@ protected:
 
     bool _insideBounds;                     /// whether or not the sprite was inside bounds the previous frame
 
+    bool _subpixelRendering;                /// whether or not the sprite can be rendered on non integer coordinates.
+    
     std::string _fileName;
     int _fileType;
 

--- a/cocos/renderer/CCRenderer.cpp
+++ b/cocos/renderer/CCRenderer.cpp
@@ -704,10 +704,21 @@ void Renderer::fillVerticesAndIndices(const TrianglesCommand* cmd)
 
     // fill vertex, and convert them to world coordinates
     const Mat4& modelView = cmd->getModelView();
-    for(ssize_t i=0; i < cmd->getVertexCount(); ++i)
+    const ssize_t count = cmd->getVertexCount();
+    
+    for(ssize_t i=0; i < count; ++i)
     {
         modelView.transformPoint(&(_verts[i + _filledVertex].vertices));
     }
+
+    if ( !cmd->isSubpixelRenderingEnabled() )
+        for( ssize_t i=0; i != count; ++i )
+        {
+            V3F_C4B_T2F* const q( &_verts[ i + _filledVertex ] );
+            Vec3* const vec1( (Vec3*)&q->vertices );
+            vec1->x = ceil( vec1->x );
+            vec1->y = ceil( vec1->y );
+        }
 
     // fill index
     const unsigned short* indices = cmd->getIndices();

--- a/cocos/renderer/CCTrianglesCommand.cpp
+++ b/cocos/renderer/CCTrianglesCommand.cpp
@@ -42,13 +42,14 @@ TrianglesCommand::TrianglesCommand()
     _type = RenderCommand::Type::TRIANGLES_COMMAND;
 }
 
-void TrianglesCommand::init(float globalOrder, GLuint textureID, GLProgramState* glProgramState, BlendFunc blendType, const Triangles& triangles,const Mat4& mv, uint32_t flags)
+void TrianglesCommand::init(float globalOrder, GLuint textureID, GLProgramState* glProgramState, BlendFunc blendType, const Triangles& triangles,const Mat4& mv, uint32_t flags, bool subpixelRendering)
 {
     CCASSERT(glProgramState, "Invalid GLProgramState");
     CCASSERT(glProgramState->getVertexAttribsFlags() == 0, "No custom attributes are supported in QuadCommand");
 
     RenderCommand::init(globalOrder, mv, flags);
 
+    _subpixelRendering = subpixelRendering;
     _triangles = triangles;
     if(_triangles.indexCount % 3 != 0)
     {
@@ -69,6 +70,11 @@ void TrianglesCommand::init(float globalOrder, GLuint textureID, GLProgramState*
     }
 }
 
+void TrianglesCommand::init(float globalOrder, GLuint textureID, GLProgramState* glProgramState, BlendFunc blendType, const Triangles& triangles,const Mat4& mv, uint32_t flags)
+{
+    init(globalOrder, textureID, glProgramState, blendType, triangles, mv, flags, true);
+}
+
 void TrianglesCommand::init(float globalOrder, GLuint textureID, GLProgramState* glProgramState, BlendFunc blendType, const Triangles& triangles,const Mat4& mv)
 {
     init(globalOrder, textureID, glProgramState, blendType, triangles, mv, 0);
@@ -76,7 +82,12 @@ void TrianglesCommand::init(float globalOrder, GLuint textureID, GLProgramState*
 
 void TrianglesCommand::init(float globalOrder, Texture2D* texture, GLProgramState* glProgramState, BlendFunc blendType, const Triangles& triangles, const Mat4& mv, uint32_t flags)
 {
-    init(globalOrder, texture->getName(), glProgramState, blendType, triangles, mv, flags);
+    init(globalOrder, texture, glProgramState, blendType, triangles, mv, flags, true);
+}
+
+void TrianglesCommand::init(float globalOrder, Texture2D* texture, GLProgramState* glProgramState, BlendFunc blendType, const Triangles& triangles, const Mat4& mv, uint32_t flags, bool subpixelRendering)
+{
+    init(globalOrder, texture->getName(), glProgramState, blendType, triangles, mv, flags, subpixelRendering);
     _alphaTextureID = texture->getAlphaTextureName();
 }
 
@@ -120,6 +131,11 @@ void TrianglesCommand::useMaterial() const
     GL::blendFunc(_blendType.src, _blendType.dst);
     
     _glProgramState->apply(_mv);
+}
+
+bool TrianglesCommand::isSubpixelRenderingEnabled() const
+{
+    return _subpixelRendering;
 }
 
 NS_CC_END

--- a/cocos/renderer/CCTrianglesCommand.h
+++ b/cocos/renderer/CCTrianglesCommand.h
@@ -67,11 +67,14 @@ public:
      @param triangles Rendered triangles for the command.
      @param mv ModelView matrix for the command.
      @param flags to indicate that the command is using 3D rendering or not.
+     @param subpixelRendering enable rendering the triangles on non integer coordinates.
      */
+    void init(float globalOrder, GLuint textureID, GLProgramState* glProgramState, BlendFunc blendType, const Triangles& triangles,const Mat4& mv, uint32_t flags, bool subpixelRendering);
     void init(float globalOrder, GLuint textureID, GLProgramState* glProgramState, BlendFunc blendType, const Triangles& triangles,const Mat4& mv, uint32_t flags);
     /**Deprecated function, the params is similar as the upper init function, with flags equals 0.*/
     CC_DEPRECATED_ATTRIBUTE void init(float globalOrder, GLuint textureID, GLProgramState* glProgramState, BlendFunc blendType, const Triangles& triangles,const Mat4& mv);
     void init(float globalOrder, Texture2D* textureID, GLProgramState* glProgramState, BlendFunc blendType, const Triangles& triangles, const Mat4& mv, uint32_t flags);
+    void init(float globalOrder, Texture2D* textureID, GLProgramState* glProgramState, BlendFunc blendType, const Triangles& triangles,const Mat4& mv, uint32_t flags, bool subpixelRendering );
     /**Apply the texture, shaders, programs, blend functions to GPU pipeline.*/
     void useMaterial() const;
     /**Get the material id of command.*/
@@ -94,7 +97,8 @@ public:
     BlendFunc getBlendType() const { return _blendType; }
     /**Get the model view matrix.*/
     const Mat4& getModelView() const { return _mv; }
-    
+    /**Tells if the triangle can dbe rendered on non interger coordinates. */
+    bool isSubpixelRenderingEnabled() const;
 protected:
     /**Generate the material ID by textureID, glProgramState, and blend function.*/
     void generateMaterialID();
@@ -113,6 +117,9 @@ protected:
     Mat4 _mv;
 
     GLuint _alphaTextureID; // ANDROID ETC1 ALPHA supports.
+
+    /** Allows to render the triangle on non integer coordinates. */
+    bool _subpixelRendering;
 };
 
 NS_CC_END


### PR DESCRIPTION
Following [this discussion](http://discuss.cocos2d-x.org/t/set-nodes-position-on-integer-screen-coordinates/31071), this PR allows to disable rendering labels on non integer coordinates, thus avoiding the blurry rendering currently occurring on them.