### PR TITLE
add 'makeRef' for easier making a RefPtr

### DIFF
--- a/cocos/base/CCRefPtr.h
+++ b/cocos/base/CCRefPtr.h
@@ -269,7 +269,13 @@ private:
     // NOTE: We can ensure T is derived from cocos2d::Ref at compile time here.
     static_assert(std::is_base_of<Ref, typename std::remove_const<T>::type>::value, "T must be derived from Ref");
 };
-    
+
+template <class T> inline
+RefPtr<T> makeRef(T *ptr)
+{
+    return RefPtr<T>(ptr);
+}
+
 template<class T> inline
 bool operator<(const RefPtr<T>& r, std::nullptr_t)
 {


### PR DESCRIPTION
For example:
`    __String *str = __String::create("Hello world!");`
`    auto strRef = RefPtr<__String>(str);`

Now we can refactor it like this

`    __String *str = __String::create("Hello world!");`
`    auto strRef = makeRef(str);`