### PR TITLE
issue #17305 fix

### DIFF
--- a/cocos/audio/win32/AudioCache.h
+++ b/cocos/audio/win32/AudioCache.h
@@ -32,7 +32,11 @@
 #include <mutex>
 #include <vector>
 #include <memory>
+#ifdef OPENAL_PLAIN_INCLUDES
+#include <al.h>
+#else
 #include <AL/al.h>
+#endif
 #include "platform/CCPlatformMacros.h"
 #include "audio/apple/AudioMacros.h"
 


### PR DESCRIPTION
commit: `cocos/audio/win32/AudioCache.h fixed include <AL/al.h>`

fixes #17305

fix based on https://github.com/cocos2d/cocos2d-x/blob/v3/cmake/Modules/BuildModules.cmake#L30

Tested on visual studio 2015: CMake generated project and default proj.win32