### PR TITLE
Fix typo in ModelData: `matrial` to `material`

### DIFF
--- a/cocos/3d/CCBundle3D.cpp
+++ b/cocos/3d/CCBundle3D.cpp
@@ -316,7 +316,7 @@ bool Bundle3D::loadObj(MeshDatas& meshdatas, MaterialDatas& materialdatas, NodeD
                 meshdata->subMeshIds.push_back(str);
                 
                 auto modelnode = new (std::nothrow) ModelData();
-                modelnode->matrialId = submesh.first == -1 ? "" : materials[submesh.first].name;
+                modelnode->materialId = submesh.first == -1 ? "" : materials[submesh.first].name;
                 modelnode->subMeshId = str;
                 node->modelNodeDatas.push_back(modelnode);
             }
@@ -817,7 +817,7 @@ bool Bundle3D::loadNodes(NodeDatas& nodedatas)
         {
             auto node= new (std::nothrow) NodeData();
             auto modelnode = new (std::nothrow) ModelData();
-            modelnode->matrialId = "";
+            modelnode->materialId = "";
             modelnode->subMeshId = "";
             node->modelNodeDatas.push_back(modelnode);
             nodedatas.nodes.push_back(node);
@@ -855,7 +855,7 @@ bool Bundle3D::loadNodes(NodeDatas& nodedatas)
         nodedatas.skeleton.push_back(nodeDatas[skinData.rootBoneIndex]);
         auto node= new (std::nothrow) NodeData();
         auto modelnode = new (std::nothrow) ModelData();
-        modelnode->matrialId = "";
+        modelnode->materialId = "";
         modelnode->subMeshId = "";
         modelnode->bones = skinData.skinBoneNames;
         modelnode->invBindPose = skinData.inverseBindPoseMatrices;
@@ -1727,9 +1727,9 @@ NodeData* Bundle3D::parseNodesRecursivelyJson(const rapidjson::Value& jvalue, bo
             auto modelnodedata = new (std::nothrow) ModelData();
             const rapidjson::Value& part = parts[i];
             modelnodedata->subMeshId = part[MESHPARTID].GetString();
-            modelnodedata->matrialId = part[MATERIALID].GetString();
+            modelnodedata->materialId = part[MATERIALID].GetString();
 
-            if (modelnodedata->subMeshId == "" || modelnodedata->matrialId == "")
+            if (modelnodedata->subMeshId == "" || modelnodedata->materialId == "")
             {
                 CCLOG("warning: Node %s part is missing meshPartId or materialId", nodedata->id.c_str());
                 CC_SAFE_DELETE(modelnodedata);
@@ -1871,9 +1871,9 @@ NodeData* Bundle3D::parseNodesRecursivelyBinary(bool& skeleton, bool singleSprit
         {
             auto modelnodedata  = new (std::nothrow) ModelData();
             modelnodedata->subMeshId = _binaryReader.readString();
-            modelnodedata->matrialId = _binaryReader.readString();
+            modelnodedata->materialId = _binaryReader.readString();
 
-            if (modelnodedata->subMeshId == "" || modelnodedata->matrialId == "")
+            if (modelnodedata->subMeshId == "" || modelnodedata->materialId == "")
             {
                 std::string err = "Node " + nodedata->id + " part is missing meshPartId or materialId";
                 CCLOG("Node %s part is missing meshPartId or materialId", nodedata->id.c_str());

--- a/cocos/3d/CCBundle3DData.h
+++ b/cocos/3d/CCBundle3DData.h
@@ -59,7 +59,7 @@ struct MeshVertexAttrib
 struct ModelData
 {
     std::string subMeshId;
-    std::string matrialId;
+    std::string materialId;
     std::vector<std::string> bones;
     std::vector<Mat4>        invBindPose;
     

--- a/cocos/3d/CCSprite3D.cpp
+++ b/cocos/3d/CCSprite3D.cpp
@@ -372,14 +372,14 @@ Sprite3D* Sprite3D::createSprite3DNode(NodeData* nodedata,ModelData* modeldata,c
             mesh->setSkin(skin);
         }
         
-        if (modeldata->matrialId == "" && materialdatas.materials.size())
+        if (modeldata->materialId == "" && materialdatas.materials.size())
         {
             const NTextureData* textureData = materialdatas.materials[0].getTextureData(NTextureData::Usage::Diffuse);
             mesh->setTexture(textureData->filename);
         }
         else
         {
-            const NMaterialData*  materialData=materialdatas.getMaterialData(modeldata->matrialId);
+            const NMaterialData* materialData = materialdatas.getMaterialData(modeldata->materialId);
             if(materialData)
             {
                 const NTextureData* textureData = materialData->getTextureData(NTextureData::Usage::Diffuse);
@@ -536,14 +536,14 @@ void Sprite3D::createNode(NodeData* nodedata, Node* root, const MaterialDatas& m
                     }
                     mesh->_visibleChanged = std::bind(&Sprite3D::onAABBDirty, this);
 
-                    if (it->matrialId == "" && materialdatas.materials.size())
+                    if (it->materialId == "" && materialdatas.materials.size())
                     {
                         const NTextureData* textureData = materialdatas.materials[0].getTextureData(NTextureData::Usage::Diffuse);
                         mesh->setTexture(textureData->filename);
                     }
                     else
                     {
-                        const NMaterialData*  materialData=materialdatas.getMaterialData(it->matrialId);
+                        const NMaterialData* materialData = materialdatas.getMaterialData(it->materialId);
                         if(materialData)
                         {
                             const NTextureData* textureData = materialData->getTextureData(NTextureData::Usage::Diffuse);


### PR DESCRIPTION
Hello, I found a minor spelling mistake in the `ModelData`, so this PR changes the `matrialId` to `materialId`.