### PR TITLE
Workaround fix for issue #17249

### DIFF
--- a/cocos/platform/desktop/CCGLViewImpl-desktop.cpp
+++ b/cocos/platform/desktop/CCGLViewImpl-desktop.cpp
@@ -348,6 +348,17 @@ GLViewImpl* GLViewImpl::createWithFullScreen(const std::string& viewName)
     return nullptr;
 }
 
+GLViewImpl* GLViewImpl::createWithFullScreen(const std::string& viewName, bool maxSize)
+{
+	auto ret = new (std::nothrow) GLViewImpl();
+	if(ret && ret->initWithFullScreen(viewName, maxSize)) {
+		ret->autorelease();
+		return ret;
+	}
+	CC_SAFE_DELETE(ret);
+	return nullptr;
+}
+
 GLViewImpl* GLViewImpl::createWithFullScreen(const std::string& viewName, const GLFWvidmode &videoMode, GLFWmonitor *monitor)
 {
     auto ret = new (std::nothrow) GLViewImpl();
@@ -460,6 +471,24 @@ bool GLViewImpl::initWithFullScreen(const std::string& viewName)
 
     const GLFWvidmode* videoMode = glfwGetVideoMode(_monitor);
     return initWithRect(viewName, Rect(0, 0, videoMode->width, videoMode->height), 1.0f, false);
+}
+
+bool GLViewImpl::initWithFullScreen(const std::string& viewName, bool maxSize)
+{
+	if (!maxSize)
+		return initWithFullScreen(viewName);
+	
+	//Get the monitor
+	_monitor = glfwGetPrimaryMonitor();
+	if (nullptr == _monitor)
+		return false;
+	
+	//Get all the possible video modes
+	int count;
+	const GLFWvidmode* modes = glfwGetVideoModes(_monitor, &count);
+	GLFWvidmode videoMode = *(modes + count - 1);//Select the last mode since they are in ascending order of refresh rate and then screen size
+	
+	return initWithRect(viewName, Rect(0, 0, videoMode.width, videoMode.height), 1.0f, false);
 }
 
 bool GLViewImpl::initWithFullscreen(const std::string &viewname, const GLFWvidmode &videoMode, GLFWmonitor *monitor)

--- a/cocos/platform/desktop/CCGLViewImpl-desktop.h
+++ b/cocos/platform/desktop/CCGLViewImpl-desktop.h
@@ -60,6 +60,7 @@ public:
     static GLViewImpl* create(const std::string& viewName, bool resizable);
     static GLViewImpl* createWithRect(const std::string& viewName, Rect size, float frameZoomFactor = 1.0f, bool resizable = false);
     static GLViewImpl* createWithFullScreen(const std::string& viewName);
+	static GLViewImpl* createWithFullScreen(const std::string& viewName, bool maxSize)
     static GLViewImpl* createWithFullScreen(const std::string& viewName, const GLFWvidmode &videoMode, GLFWmonitor *monitor);
 
     /*
@@ -126,6 +127,7 @@ protected:
 
     bool initWithRect(const std::string& viewName, Rect rect, float frameZoomFactor, bool resizable);
     bool initWithFullScreen(const std::string& viewName);
+	bool initWithFullScreen(const std::string& viewName, bool maxSize);
     bool initWithFullscreen(const std::string& viewname, const GLFWvidmode &videoMode, GLFWmonitor *monitor);
 
     bool initGlew();

--- a/cocos/platform/desktop/CCGLViewImpl-desktop.h
+++ b/cocos/platform/desktop/CCGLViewImpl-desktop.h
@@ -60,7 +60,7 @@ public:
     static GLViewImpl* create(const std::string& viewName, bool resizable);
     static GLViewImpl* createWithRect(const std::string& viewName, Rect size, float frameZoomFactor = 1.0f, bool resizable = false);
     static GLViewImpl* createWithFullScreen(const std::string& viewName);
-	static GLViewImpl* createWithFullScreen(const std::string& viewName, bool maxSize)
+	static GLViewImpl* createWithFullScreen(const std::string& viewName, bool maxSize);
     static GLViewImpl* createWithFullScreen(const std::string& viewName, const GLFWvidmode &videoMode, GLFWmonitor *monitor);
 
     /*


### PR DESCRIPTION
There is an issue with Mac OSX not wanting to create a proper fullscreen GLFW context, I have read elsewhere that there may be some issues with certain width/height combinations on Mac that cause OSX to not create the proper context and create some odd scaling issues. 

This issue appears mostly, though not always, (for me) when setting the display scaling option within Mac OSX to either "Larger Text" (1024 x 640) or "More Space" (1920 x 1200) on a Retina display (2800 x 1800)

Instead of just having a createWithFullScreen initializer with a viewName and optionally the video mode and monitor (which you can't retrieve without first creating a window or initializing GLFW yourself which would cause issues with Cocos2D-X trying to initialize it again) I created a new initializer which automatically tries to create a fullscreen window with the highest possible screen size the current primary display can offer

In my AppDelegate.cpp I've had to change the applicationDidFinishLaunching a bit when creating the glview in order to properly support the Retina Display and it's scaling.

```
if(!glview) {
#if (CC_TARGET_PLATFORM == CC_PLATFORM_WIN32) || (CC_TARGET_PLATFORM == CC_PLATFORM_MAC) || (CC_TARGET_PLATFORM == CC_PLATFORM_LINUX)
	glview = GLViewImpl::createWithFullScreen("Cocos2D-X", true);
	if (((GLViewImpl *)glview)->getRetinaFactor() > 1.0)
	{
		((GLViewImpl *)glview)->enableRetina(true);
		director->setContentScaleFactor(2.0);
	}
#else
        glview = GLViewImpl::create("Cocos2D-X");
#endif
        director->setOpenGLView(glview);
}
```

I have not yet tested this code on either Windows or Linux, nor have I tested this code on Mac with the primary screen not being a retina screen.