### PR TITLE
Mitigate cppcheck message

### DIFF
--- a/cocos/audio/win32/AudioEngine-win32.cpp
+++ b/cocos/audio/win32/AudioEngine-win32.cpp
@@ -143,12 +143,12 @@ bool AudioEngineImpl::init()
         s_ALDevice = alcOpenDevice(nullptr);
 
         if (s_ALDevice) {
-            auto alError = alGetError();
+            alGetError();
             s_ALContext = alcCreateContext(s_ALDevice, nullptr);
             alcMakeContextCurrent(s_ALContext);
 
             alGenSources(MAX_AUDIOINSTANCES, _alSources);
-            alError = alGetError();
+            auto alError = alGetError();
             if(alError != AL_NO_ERROR)
             {
                 ALOGE("%s:generating sources failed! error = %x\n", __FUNCTION__, alError);


### PR DESCRIPTION
@minggo from what @kompjoefriek said in #16914 I think it's safe to not store the value of `alGetError()` in [line 146](https://github.com/cocos2d/cocos2d-x/blob/v3/cocos/audio/win32/AudioEngine-win32.cpp#L146), but store it in the following call to `alGetError()`.

This pull request mitigates the following `cppcheck` message:
````
[cocos/audio/win32/AudioEngine-win32.cpp:146] -> [cocos/audio/win32/AudioEngine-win32.cpp:151]: (style, inconclusive) Variable 'alError' is reassigned a value before the old one has been used if variable is no semaphore variable.
````