### PR TITLE
Removed unnecessary assignments

### DIFF
--- a/cocos/2d/CCParticleExamples.cpp
+++ b/cocos/2d/CCParticleExamples.cpp
@@ -41,14 +41,13 @@ static Texture2D* getDefaultTexture()
     Image* image = nullptr;
     do 
     {
-        bool ret = false;
         const std::string key = "/__firePngData";
         texture = Director::getInstance()->getTextureCache()->getTextureForKey(key);
         CC_BREAK_IF(texture != nullptr);
 
         image = new (std::nothrow) Image();
         CC_BREAK_IF(nullptr == image);
-        ret = image->initWithImageData(__firePngData, sizeof(__firePngData));
+        bool ret = image->initWithImageData(__firePngData, sizeof(__firePngData));
         CC_BREAK_IF(!ret);
 
         texture = Director::getInstance()->getTextureCache()->addImage(image, key);

--- a/cocos/audio/android/AudioDecoder.cpp
+++ b/cocos/audio/android/AudioDecoder.cpp
@@ -401,7 +401,6 @@ bool AudioDecoder::decodeToPcm()
     SLMetadataInfo *keyInfo, *value;
     for (i = 0; i < itemCount; i++)
     {
-        keyInfo = nullptr;
         keySize = 0;
         value = nullptr;
         valueSize = 0;

--- a/cocos/editor-support/cocostudio/CCArmatureDataManager.cpp
+++ b/cocos/editor-support/cocostudio/CCArmatureDataManager.cpp
@@ -132,9 +132,7 @@ void ArmatureDataManager::addArmatureData(const std::string& id, ArmatureData *a
 
 ArmatureData *ArmatureDataManager::getArmatureData(const std::string& id)
 {
-    ArmatureData *armatureData = nullptr;
-    armatureData = (ArmatureData *)_armarureDatas.at(id);
-    return armatureData;
+    return dynamic_cast<ArmatureData*>(_armarureDatas.at(id));
 }
 
 void ArmatureDataManager::removeArmatureData(const std::string& id)
@@ -154,9 +152,7 @@ void ArmatureDataManager::addAnimationData(const std::string& id, AnimationData 
 
 AnimationData *ArmatureDataManager::getAnimationData(const std::string& id)
 {
-    AnimationData *animationData = nullptr;
-    animationData = (AnimationData *)_animationDatas.at(id);
-    return animationData;
+    return dynamic_cast<AnimationData*>(_animationDatas.at(id));
 }
 
 void ArmatureDataManager::removeAnimationData(const std::string& id)
@@ -177,9 +173,7 @@ void ArmatureDataManager::addTextureData(const std::string& id, TextureData *tex
 
 TextureData *ArmatureDataManager::getTextureData(const std::string& id)
 {
-    TextureData *textureData = nullptr;
-    textureData = (TextureData *)_textureDatas.at(id);
-    return textureData;
+    return dynamic_cast<TextureData*>(_textureDatas.at(id));
 }
 
 

--- a/cocos/editor-support/cocostudio/CCDataReaderHelper.cpp
+++ b/cocos/editor-support/cocostudio/CCDataReaderHelper.cpp
@@ -1947,10 +1947,9 @@ void DataReaderHelper::decodeNode(BaseData *node, const rapidjson::Value& json, 
     {
         stExpCocoNode* children = cocoNode->GetChildArray(cocoLoader);
         stExpCocoNode* child = &children[1];
-        const char *str = nullptr;
 
         std::string key = child->GetName(cocoLoader);
-        str = child->GetValue(cocoLoader);
+        const char *str = child->GetValue(cocoLoader);
         DisplayData *displayData = nullptr;
         if (key.compare(A_DISPLAY_TYPE) == 0)
         {

--- a/cocos/editor-support/cocostudio/CCSGUIReader.cpp
+++ b/cocos/editor-support/cocostudio/CCSGUIReader.cpp
@@ -930,9 +930,8 @@ void WidgetPropertiesReader0250::setPropsForLabelAtlasFromJsonDictionary(Widget*
     if (sv && cmf && iw && ih && scm && (strcmp(DICTOOL->getStringValue_json(options, "charMapFile"), "") != 0))
     {
         std::string tp_c = m_strFilePath;
-        const char* cmf_tp = nullptr;
         const char* cmft = DICTOOL->getStringValue_json(options, "charMapFile");
-        cmf_tp = tp_c.append(cmft).c_str();
+        const char* cmf_tp = tp_c.append(cmft).c_str();
         
         labelAtlas->setProperty(DICTOOL->getStringValue_json(options, "stringValue"),cmf_tp,DICTOOL->getIntValue_json(options, "itemWidth"),DICTOOL->getIntValue_json(options,"itemHeight"),DICTOOL->getStringValue_json(options, "startCharMap"));
         labelAtlas->setProperty(DICTOOL->getStringValue_json(options, "stringValue"),cmf_tp,DICTOOL->getIntValue_json(options, "itemWidth") / CC_CONTENT_SCALE_FACTOR() ,DICTOOL->getIntValue_json(options,"itemHeight") / CC_CONTENT_SCALE_FACTOR(), DICTOOL->getStringValue_json(options, "startCharMap"));
@@ -1184,9 +1183,8 @@ void WidgetPropertiesReader0250::setPropsForLabelBMFontFromJsonDictionary(Widget
     cocos2d::ui::TextBMFont* labelBMFont = static_cast<cocos2d::ui::TextBMFont*>(widget);
     
     std::string tp_c = m_strFilePath;
-    const char* cmf_tp = nullptr;
     const char* cmft = DICTOOL->getStringValue_json(options, "fileName");
-    cmf_tp = tp_c.append(cmft).c_str();
+    const char* cmf_tp = tp_c.append(cmft).c_str();
     
     labelBMFont->setFntFile(cmf_tp);
     

--- a/cocos/network/HttpClient-android.cpp
+++ b/cocos/network/HttpClient-android.cpp
@@ -578,10 +578,8 @@ private:
         {
             return nullptr;
         }
-        char *ret = nullptr;
         std::string strValue = cocos2d::StringUtils::getStringUTFCharsJNI(env, jstr);
-        ret = strdup(strValue.c_str());
-        return ret;
+        return strdup(strValue.c_str());
     }
 
     int getCStrFromJByteArray(jbyteArray jba, JNIEnv* env, char** ppData)
@@ -592,10 +590,8 @@ private:
             return 0;
         }
 
-        char* str = nullptr;
-
-        int len  = env->GetArrayLength(jba);
-        str = (char*)malloc(sizeof(char)*len);
+        int len = env->GetArrayLength(jba);
+        char* str = (char*)malloc(sizeof(char)*len);
         env->GetByteArrayRegion(jba, 0, len, (jbyte*)str);
 
         *ppData = str;

--- a/cocos/network/SocketIO.cpp
+++ b/cocos/network/SocketIO.cpp
@@ -1164,10 +1164,8 @@ SIOClient* SocketIO::connect(const std::string& uri, SocketIO::SIODelegate& dele
     std::stringstream s;
     s << host << ":" << port;
 
-    SIOClientImpl* socket = nullptr;
+    SIOClientImpl *socket = SocketIO::getInstance()->getSocket(s.str());
     SIOClient *c = nullptr;
-
-    socket = SocketIO::getInstance()->getSocket(s.str());
 
     if(socket == nullptr)
     {
@@ -1199,11 +1197,8 @@ SIOClient* SocketIO::connect(const std::string& uri, SocketIO::SIODelegate& dele
             c->disconnect();
 
             CCLOG("SocketIO: recreate a new socket, new client, connect");
-            SIOClientImpl* newSocket = nullptr;
-            SIOClient *newC = nullptr;
-
-            newSocket = SIOClientImpl::create(host, port);
-            newC = new (std::nothrow) SIOClient(host, port, path, newSocket, delegate);
+            SIOClientImpl* newSocket = SIOClientImpl::create(host, port);
+            SIOClient *newC = new (std::nothrow) SIOClient(host, port, path, newSocket, delegate);
 
             newSocket->addClient(path, newC);
             newSocket->connect();

--- a/cocos/platform/winrt/CCFreeTypeFont.cpp
+++ b/cocos/platform/winrt/CCFreeTypeFont.cpp
@@ -460,12 +460,11 @@ FT_Error CCFreeTypeFont::initWordGlyphs(std::vector<TGlyph>& glyphs, const std::
 	FT_UInt			previous = 0;
 	FT_Error		error = 0;
 	PGlyph			glyph;
-    unsigned int    numGlyphs = 0;
-    wchar_t *       pwszBuffer = nullptr;
+	unsigned int    numGlyphs = 0;
 
 	int num_chars = static_cast<int>(text.size());
 	int nBufLen  = num_chars + 1;
-	pwszBuffer = new wchar_t[nBufLen];
+	wchar_t * pwszBuffer = new wchar_t[nBufLen];
     if(!pwszBuffer)
     {
         return -1;

--- a/cocos/renderer/CCGLProgramState.cpp
+++ b/cocos/renderer/CCGLProgramState.cpp
@@ -329,8 +329,7 @@ GLProgramState* GLProgramState::getOrCreateWithGLProgramName(const std::string& 
 
 GLProgramState* GLProgramState::create(GLProgram *glprogram)
 {
-    GLProgramState* ret = nullptr;
-    ret = new (std::nothrow) GLProgramState();
+    GLProgramState* ret = new (std::nothrow) GLProgramState();
     if(ret && ret->init(glprogram))
     {
         ret->autorelease();

--- a/cocos/ui/UIWidget.cpp
+++ b/cocos/ui/UIWidget.cpp
@@ -1212,18 +1212,12 @@ void Widget::copyClonedWidgetChildren(Widget* model)
 
 GLProgramState* Widget::getNormalGLProgramState(Texture2D* texture)const
 {
-    GLProgramState *glState = nullptr;
-
-    glState = GLProgramState::getOrCreateWithGLProgramName(GLProgram::SHADER_NAME_POSITION_TEXTURE_COLOR_NO_MVP, texture);
-    return glState;
+    return GLProgramState::getOrCreateWithGLProgramName(GLProgram::SHADER_NAME_POSITION_TEXTURE_COLOR_NO_MVP, texture);
 }
 
 GLProgramState* Widget::getGrayGLProgramState(Texture2D* texture)const
 {
-    GLProgramState *glState = nullptr;
-
-    glState = GLProgramState::getOrCreateWithGLProgramName(GLProgram::SHADER_NAME_POSITION_GRAYSCALE, texture);
-    return glState;
+    return GLProgramState::getOrCreateWithGLProgramName(GLProgram::SHADER_NAME_POSITION_GRAYSCALE, texture);
 }
 
 void Widget::copySpecialProperties(Widget* /*model*/)


### PR DESCRIPTION
`cppcheck` reported more unnecessary assignments since the last time I scanned.

This pull request mitigates the following `cppcheck` messages:

````
[cocos/2d/CCParticleExamples.cpp:44] -> [cocos/2d/CCParticleExamples.cpp:51]: (style) Variable 'ret' is reassigned a value before the old one has been used.
[cocos/audio/android/AudioDecoder.cpp:404] -> [cocos/audio/android/AudioDecoder.cpp:414]: (style) Variable 'keyInfo' is reassigned a value before the old one has been used.
[cocos/editor-support/cocostudio/CCArmatureDataManager.cpp:135] -> [cocos/editor-support/cocostudio/CCArmatureDataManager.cpp:136]: (style) Variable 'armatureData' is reassigned a value before the old one has been used.
[cocos/editor-support/cocostudio/CCArmatureDataManager.cpp:157] -> [cocos/editor-support/cocostudio/CCArmatureDataManager.cpp:158]: (style) Variable 'animationData' is reassigned a value before the old one has been used.
[cocos/editor-support/cocostudio/CCArmatureDataManager.cpp:180] -> [cocos/editor-support/cocostudio/CCArmatureDataManager.cpp:181]: (style) Variable 'textureData' is reassigned a value before the old one has been used.
[cocos/editor-support/cocostudio/CCDataReaderHelper.cpp:1950] -> [cocos/editor-support/cocostudio/CCDataReaderHelper.cpp:1953]: (style) Variable 'str' is reassigned a value before the old one has been used.
[cocos/editor-support/cocostudio/CCSGUIReader.cpp:933] -> [cocos/editor-support/cocostudio/CCSGUIReader.cpp:935]: (style) Variable 'cmf_tp' is reassigned a value before the old one has been used.
[cocos/editor-support/cocostudio/CCSGUIReader.cpp:1187] -> [cocos/editor-support/cocostudio/CCSGUIReader.cpp:1189]: (style) Variable 'cmf_tp' is reassigned a value before the old one has been used.
[cocos/network/HttpClient-android.cpp:581] -> [cocos/network/HttpClient-android.cpp:583]: (style) Variable 'ret' is reassigned a value before the old one has been used.
[cocos/network/HttpClient-android.cpp:595] -> [cocos/network/HttpClient-android.cpp:598]: (style) Variable 'str' is reassigned a value before the old one has been used.
[cocos/network/SocketIO.cpp:1167] -> [cocos/network/SocketIO.cpp:1170]: (style) Variable 'socket' is reassigned a value before the old one has been used.
[cocos/network/SocketIO.cpp:1202] -> [cocos/network/SocketIO.cpp:1205]: (style) Variable 'newSocket' is reassigned a value before the old one has been used.
[cocos/network/SocketIO.cpp:1203] -> [cocos/network/SocketIO.cpp:1206]: (style) Variable 'newC' is reassigned a value before the old one has been used.
[cocos/platform/winrt/CCFreeTypeFont.cpp:464] -> [cocos/platform/winrt/CCFreeTypeFont.cpp:468]: (style) Variable 'pwszBuffer' is reassigned a value before the old one has been used.
[cocos/renderer/CCGLProgramState.cpp:332] -> [cocos/renderer/CCGLProgramState.cpp:333]: (style) Variable 'ret' is reassigned a value before the old one has been used.
[cocos/ui/UIWidget.cpp:1215] -> [cocos/ui/UIWidget.cpp:1217]: (style) Variable 'glState' is reassigned a value before the old one has been used.
[cocos/ui/UIWidget.cpp:1223] -> [cocos/ui/UIWidget.cpp:1225]: (style) Variable 'glState' is reassigned a value before the old one has been used.
````