### PR TITLE
Fix typos in comments and strings

### DIFF
--- a/tests/cpp-tests/Classes/ActionsTest/ActionsTest.cpp
+++ b/tests/cpp-tests/Classes/ActionsTest/ActionsTest.cpp
@@ -2308,7 +2308,7 @@ void ActionFloatTest::onEnter()
 
     auto s = Director::getInstance()->getWinSize();
 
-    // create float action with duration and from to value, using lambda function we can easly animate any property of the Node.
+    // create float action with duration and from to value, using lambda function we can easily animate any property of the Node.
     auto actionFloat = ActionFloat::create(2.f, 0, 3, [this](float value) {
         _tamara->setScale(value);
     });

--- a/tests/cpp-tests/Classes/Box2DTest/Box2dTest.cpp
+++ b/tests/cpp-tests/Classes/Box2DTest/Box2dTest.cpp
@@ -147,7 +147,7 @@ void Box2DTest::draw(Renderer *renderer, const Mat4 &transform, uint32_t flags)
 
     GL::enableVertexAttribs( cocos2d::GL::VERTEX_ATTRIB_FLAG_POSITION );
     Director* director = Director::getInstance();
-    CCASSERT(nullptr != director, "Director is null when seting matrix stack");
+    CCASSERT(nullptr != director, "Director is null when setting matrix stack");
     director->pushMatrix(MATRIX_STACK_TYPE::MATRIX_STACK_MODELVIEW);
     
     _modelViewMV = director->getMatrix(MATRIX_STACK_TYPE::MATRIX_STACK_MODELVIEW);
@@ -162,7 +162,7 @@ void Box2DTest::draw(Renderer *renderer, const Mat4 &transform, uint32_t flags)
 void Box2DTest::onDraw()
 {
     Director* director = Director::getInstance();
-    CCASSERT(nullptr != director, "Director is null when seting matrix stack");
+    CCASSERT(nullptr != director, "Director is null when setting matrix stack");
 
     auto oldMV = director->getMatrix(MATRIX_STACK_TYPE::MATRIX_STACK_MODELVIEW);
     director->loadMatrix(MATRIX_STACK_TYPE::MATRIX_STACK_MODELVIEW, _modelViewMV);

--- a/tests/cpp-tests/Classes/Box2DTestBed/Box2dView.cpp
+++ b/tests/cpp-tests/Classes/Box2DTestBed/Box2dView.cpp
@@ -160,7 +160,7 @@ void Box2DView::draw(Renderer *renderer, const Mat4 &transform, uint32_t flags)
 void Box2DView::onDraw(const Mat4 &transform, uint32_t flags)
 {
     Director* director = Director::getInstance();
-    CCASSERT(nullptr != director, "Director is null when seting matrix stack");
+    CCASSERT(nullptr != director, "Director is null when setting matrix stack");
     director->pushMatrix(MATRIX_STACK_TYPE::MATRIX_STACK_MODELVIEW);
     director->loadMatrix(MATRIX_STACK_TYPE::MATRIX_STACK_MODELVIEW, transform);
 

--- a/tests/cpp-tests/Classes/Camera3DTest/Camera3DTest.cpp
+++ b/tests/cpp-tests/Classes/Camera3DTest/Camera3DTest.cpp
@@ -732,7 +732,7 @@ void CameraCullingDemo::onEnter()
     addChild(layer3D,0);
     _layer3D=layer3D;
     
-    // swich camera
+    // switch camera
     MenuItemFont::setFontName("fonts/arial.ttf");
     MenuItemFont::setFontSize(20);
     
@@ -1011,7 +1011,7 @@ void CameraArcBallDemo::onEnter()
     listener->onTouchesMoved = CC_CALLBACK_2(CameraArcBallDemo::onTouchsMoved, this);
     _eventDispatcher->addEventListenerWithSceneGraphPriority(listener, this);
 
-    // swich camera
+    // switch camera
     MenuItemFont::setFontName("fonts/arial.ttf");
     MenuItemFont::setFontSize(20);
     
@@ -1228,7 +1228,7 @@ void FogTestDemo::onEnter()
     listener->onTouchesMoved = CC_CALLBACK_2(FogTestDemo::onTouchesMoved, this);
     _eventDispatcher->addEventListenerWithSceneGraphPriority(listener, this);
 
-    // swich fog type
+    // switch fog type
     TTFConfig ttfConfig("fonts/arial.ttf", 20);
     
     auto label1 = Label::createWithTTF(ttfConfig,"Linear ");

--- a/tests/cpp-tests/Classes/ClippingNodeTest/ClippingNodeTest.cpp
+++ b/tests/cpp-tests/Classes/ClippingNodeTest/ClippingNodeTest.cpp
@@ -581,7 +581,7 @@ void RawStencilBufferTest::draw(Renderer *renderer, const Mat4 &transform, uint3
         ++iter;
         
         Director* director = Director::getInstance();
-        CCASSERT(nullptr != director, "Director is null when seting matrix stack");
+        CCASSERT(nullptr != director, "Director is null when setting matrix stack");
         director->pushMatrix(MATRIX_STACK_TYPE::MATRIX_STACK_MODELVIEW);
         
         _modelViewTransform = this->transform(transform);

--- a/tests/cpp-tests/Classes/CurlTest/CurlTest.cpp
+++ b/tests/cpp-tests/Classes/CurlTest/CurlTest.cpp
@@ -76,7 +76,7 @@ void CurlTest::onTouchesEnded(const std::vector<Touch*>& touches, Event  *event)
 		//code from http://curl.haxx.se/libcurl/c/getinmemory.html
         /* we pass our 'chunk' struct to the callback function */
         curl_easy_setopt(curl, CURLOPT_WRITEDATA, (void *)&chunk);
-		//If we don't provide a write function for curl, it will recieve error code 23 on windows.
+		//If we don't provide a write function for curl, it will receive error code 23 on windows.
         curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, WriteMemoryCallback);
 
         res = curl_easy_perform(curl);

--- a/tests/cpp-tests/Classes/DownloaderTest/DownloaderTest.cpp
+++ b/tests/cpp-tests/Classes/DownloaderTest/DownloaderTest.cpp
@@ -78,7 +78,7 @@ struct DownloaderTest : public TestCase
         auto bg = ui::Scale9Sprite::createWithSpriteFrameName("button_actived.png");
         bg->setContentSize(viewSize);
         
-        // add a titile on the top
+        // add a title on the top
         auto title = Label::createWithTTF(name,"fonts/arial.ttf",16);
         title->setTag(TAG_TITLE);
         title->setAnchorPoint(Vec2(0.5, 1));

--- a/tests/cpp-tests/Classes/DrawPrimitivesTest/DrawPrimitivesTest.cpp
+++ b/tests/cpp-tests/Classes/DrawPrimitivesTest/DrawPrimitivesTest.cpp
@@ -69,7 +69,7 @@ void DrawPrimitivesTest::onDraw(const Mat4 &transform, uint32_t flags)
     CHECK_GL_ERROR_DEBUG();
     
     // TIP:
-    // If you are going to use always thde same color or width, you don't
+    // If you are going to use always the same color or width, you don't
     // need to call it before every draw
     //
     // Remember: OpenGL is a state-machine.
@@ -404,7 +404,7 @@ Issue11942Test::Issue11942Test()
 
 string Issue11942Test::title() const
 {
-    return "Gihub Issue #11942";
+    return "GitHub Issue #11942";
 }
 
 string Issue11942Test::subtitle() const

--- a/tests/cpp-tests/Classes/FileUtilsTest/FileUtilsTest.cpp
+++ b/tests/cpp-tests/Classes/FileUtilsTest/FileUtilsTest.cpp
@@ -490,7 +490,7 @@ void TextWritePlist::onEnter()
     auto booleanObject = __Bool::create(true);
     dictInDict->setObject(booleanObject, "bool");
 
-    //add interger to the plist
+    //add integer to the plist
     auto intObject = __Integer::create(1024);
     dictInDict->setObject(intObject, "integer");
 
@@ -816,7 +816,7 @@ void TestWriteValueMap::onEnter()
     auto booleanObject = Value(true);
     valueMap["data3"] = booleanObject;
 
-    //add interger to the plist
+    //add integer to the plist
     auto intObject = Value(1024);
     valueMap["data4"] = intObject;
 
@@ -919,7 +919,7 @@ void TestWriteValueVector::onEnter()
     auto booleanObject = Value(true);
     array.push_back(booleanObject);
 
-    //add interger to the plist
+    //add integer to the plist
     auto intObject = Value(1024);
     array.push_back(intObject);
 

--- a/tests/cpp-tests/Classes/LabelTest/LabelTest.cpp
+++ b/tests/cpp-tests/Classes/LabelTest/LabelTest.cpp
@@ -818,7 +818,7 @@ std::string LabelGlyphDesigner::title() const
 
 std::string LabelGlyphDesigner::subtitle() const
 {
-    return "You should see a font with shawdows and outline";
+    return "You should see a font with shadows and outline";
 }
 
 //------------------------------------------------------------------
@@ -1334,7 +1334,7 @@ std::string BMFontInit::title() const
 
 std::string BMFontInit::subtitle() const
 {
-    return "Testing LabelBMFont::create() wihtout params";
+    return "Testing LabelBMFont::create() without params";
 }
 
 // TTFFontInit
@@ -1359,7 +1359,7 @@ std::string TTFFontInit::title() const
 
 std::string TTFFontInit::subtitle() const
 {
-    return "Testing LabelTTF::create() wihtout params";
+    return "Testing LabelTTF::create() without params";
 }
 
 TTFFontShadowAndStroke::TTFFontShadowAndStroke()

--- a/tests/cpp-tests/Classes/MaterialSystemTest/MaterialSystemTest.cpp
+++ b/tests/cpp-tests/Classes/MaterialSystemTest/MaterialSystemTest.cpp
@@ -404,7 +404,7 @@ void Material_parsePerformance::onEnter()
     
     addChild(slider);
     
-    auto label = Label::createWithSystemFont("Max parsing count is 10000, which may crash because of high memory comsumption.", "Helvetica", 10);
+    auto label = Label::createWithSystemFont("Max parsing count is 10000, which may crash because of high memory consumption.", "Helvetica", 10);
     label->setPosition(Vec2(screenSize.width / 2.0f, screenSize.height / 2.0f - 20));
     addChild(label);
     label = Label::createWithSystemFont("Slide to test parsing performance", "Helvetica", 10);

--- a/tests/cpp-tests/Classes/NewRendererTest/NewRendererTest.cpp
+++ b/tests/cpp-tests/Classes/NewRendererTest/NewRendererTest.cpp
@@ -410,7 +410,7 @@ std::string VBOFullTest::title() const
 
 std::string VBOFullTest::subtitle() const
 {
-    return "VBO full Test, everthing should render normally";
+    return "VBO full Test, everything should render normally";
 }
 
 CaptureScreenTest::CaptureScreenTest()

--- a/tests/cpp-tests/Classes/NodeTest/NodeTest.cpp
+++ b/tests/cpp-tests/Classes/NodeTest/NodeTest.cpp
@@ -409,7 +409,7 @@ SchedulerTest1::SchedulerTest1()
     //CCLOG("retain count after addChild is %d", layer->getReferenceCount());      // 2
     
     layer->schedule(CC_CALLBACK_1(SchedulerTest1::doSomething, this), "do_something_key");
-    //CCLOG("retain count after schedule is %d", layer->getReferenceCount());      // 3 : (object-c viersion), but win32 version is still 2, because Timer class don't save target.
+    //CCLOG("retain count after schedule is %d", layer->getReferenceCount());      // 3 : (objective-c version), but win32 version is still 2, because Timer class don't save target.
     
     layer->unschedule("do_something_key");
     //CCLOG("retain count after unschedule is %d", layer->getReferenceCount());        // STILL 3!  (win32 is '2')

--- a/tests/cpp-tests/Classes/ParticleTest/ParticleTest.cpp
+++ b/tests/cpp-tests/Classes/ParticleTest/ParticleTest.cpp
@@ -195,7 +195,7 @@ void DemoBigFlower::onEnter()
     _emitter->setRadialAccel(-120);
     _emitter->setRadialAccelVar(0);
 
-    // tagential
+    // tangential
     _emitter->setTangentialAccel(30);
     _emitter->setTangentialAccelVar(0);
 
@@ -279,7 +279,7 @@ void DemoRotFlower::onEnter()
     _emitter->setRadialAccel(-120);
     _emitter->setRadialAccelVar(0);
 
-    // tagential
+    // tangential
     _emitter->setTangentialAccel(30);
     _emitter->setTangentialAccelVar(0);
 
@@ -533,7 +533,7 @@ void DemoModernArt::onEnter()
     _emitter->setRadialAccel(70);
     _emitter->setRadialAccelVar(10);
 
-    // tagential
+    // tangential
     _emitter->setTangentialAccel(80);
     _emitter->setTangentialAccelVar(0);
 

--- a/tests/cpp-tests/Classes/PhysicsTest/PhysicsTest.cpp
+++ b/tests/cpp-tests/Classes/PhysicsTest/PhysicsTest.cpp
@@ -1764,7 +1764,7 @@ std::string PhysicsFixedUpdate::title() const
 
 std::string PhysicsFixedUpdate::subtitle() const
 {
-    return "The secend ball should not run across the wall";
+    return "The second ball should not run across the wall";
 }
 
 bool PhysicsTransformTest::onTouchBegan(Touch *touch, Event* /*event*/)

--- a/tests/cpp-tests/Classes/RenderTextureTest/RenderTextureTest.cpp
+++ b/tests/cpp-tests/Classes/RenderTextureTest/RenderTextureTest.cpp
@@ -17,7 +17,7 @@ RenderTextureTests::RenderTextureTests()
 };
 
 /**
-* Impelmentation of RenderTextureSave
+* Implementation of RenderTextureSave
 */
 RenderTextureSave::RenderTextureSave()
 {
@@ -136,7 +136,7 @@ void RenderTextureSave::onTouchesMoved(const std::vector<Touch*>& touches, Event
 }
 
 /**
- * Impelmentation of RenderTextureIssue937
+ * Implementation of RenderTextureIssue937
  */
 
 RenderTextureIssue937::RenderTextureIssue937()
@@ -201,7 +201,7 @@ std::string RenderTextureIssue937::subtitle() const
 }
 
 /**
-* Impelmentation of RenderTextureZbuffer
+* Implementation of RenderTextureZbuffer
 */
 
 RenderTextureZbuffer::RenderTextureZbuffer()

--- a/tests/cpp-tests/Classes/Scene3DTest/Scene3DTest.cpp
+++ b/tests/cpp-tests/Classes/Scene3DTest/Scene3DTest.cpp
@@ -122,7 +122,7 @@ enum GAME_SCENE {
     SCENE_COUNT,
 };
 
-/** Define the layers in scene, layer seperated by camera mask. */
+/** Define the layers in scene, layer separated by camera mask. */
 enum SCENE_LAYER {
     LAYER_BACKGROUND = 0,
     LAYER_DEFAULT,
@@ -146,10 +146,10 @@ enum GAME_CAMERAS_ORDER {
 };
 
 /*
- Defined s_CF and s_CM to avoid force convertion when call Camera::setCameraFlag
+ Defined s_CF and s_CM to avoid force conversion when call Camera::setCameraFlag
  and Node::setCameraMask.
  
- Useage:
+ Usage:
  -   Camera::setCameraFlag(s_CF[<SCENE_LAYER_INDEX>]);
  -   Node::setCameraMask(s_CM[<SCENE_LAYER_INDEX>]);
  
@@ -340,7 +340,7 @@ bool Scene3DTestScene::init()
         _descDlg->setVisible(false);
 
         ////////////////////////////////////////////////////////////////////////
-        // add touch envent callback
+        // add touch event callback
         auto listener = EventListenerTouchOneByOne::create();
         listener->onTouchBegan = CC_CALLBACK_2(Scene3DTestScene::onTouchBegan, this);
         listener->onTouchEnded = CC_CALLBACK_2(Scene3DTestScene::onTouchEnd, this);
@@ -456,7 +456,7 @@ void Scene3DTestScene::createUI()
     showPlayerDlgItem->setName("showPlayerDlgItem");
     showPlayerDlgItem->setPosition(VisibleRect::left().x + 30, VisibleRect::top().y - 30);
     
-    // create discription button
+    // create description button
     TTFConfig ttfConfig("fonts/arial.ttf", 20);
     auto descItem = MenuItemLabel::create(Label::createWithTTF(ttfConfig, "Description"),
                                           [this](Ref* sender)

--- a/tests/cpp-tests/Classes/SchedulerTest/SchedulerTest.cpp
+++ b/tests/cpp-tests/Classes/SchedulerTest/SchedulerTest.cpp
@@ -902,7 +902,7 @@ void TwoSchedulers::onEnter()
 
     defaultScheduler->scheduleUpdate(sched1, 0, false);
 
-    // Create a new ActionManager, and link it to the new scheudler
+    // Create a new ActionManager, and link it to the new scheduler
     actionManager1 = new (std::nothrow) ActionManager();
     sched1->scheduleUpdate(actionManager1, 0, false);
 
@@ -928,7 +928,7 @@ void TwoSchedulers::onEnter()
     sched2 = new (std::nothrow) Scheduler();
     defaultScheduler->scheduleUpdate(sched2, 0, false);
 
-    // Create a new ActionManager, and link it to the new scheudler
+    // Create a new ActionManager, and link it to the new scheduler
     actionManager2 = new (std::nothrow) ActionManager();
     sched2->scheduleUpdate(actionManager2, 0, false);
 

--- a/tests/cpp-tests/Classes/ShaderTest/ShaderTest2.cpp
+++ b/tests/cpp-tests/Classes/ShaderTest/ShaderTest2.cpp
@@ -107,7 +107,7 @@ public:
             _trianglesCommand.init(_globalZOrder, _texture->getName(), getGLProgramState(), _blendFunc, _polyInfo.triangles, transform, flags);
             renderer->addCommand(&_trianglesCommand);
 
-            // postive effects: oder >= 0
+            // positive effects: order >= 0
             for(auto it = std::begin(_effects)+idx; it != std::end(_effects); ++it) {
                 QuadCommand &q = std::get<2>(*it);
                 q.init(_globalZOrder, _texture->getName(), std::get<1>(*it)->getGLProgramState(), _blendFunc, &_quad, 1, transform, flags);

--- a/tests/cpp-tests/Classes/Sprite3DTest/Sprite3DTest.cpp
+++ b/tests/cpp-tests/Classes/Sprite3DTest/Sprite3DTest.cpp
@@ -1430,7 +1430,7 @@ Sprite3DWithOBBPerformanceTest::Sprite3DWithOBBPerformanceTest()
 }
 std::string Sprite3DWithOBBPerformanceTest::title() const
 {
-    return "OBB Collison Performance Test";
+    return "OBB Collision Performance Test";
 }
 std::string Sprite3DWithOBBPerformanceTest::subtitle() const
 {

--- a/tests/cpp-tests/Classes/SpriteFrameCacheTest/SpriteFrameCacheTest.cpp
+++ b/tests/cpp-tests/Classes/SpriteFrameCacheTest/SpriteFrameCacheTest.cpp
@@ -61,7 +61,7 @@ SpriteFrameCachePixelFormatTest::SpriteFrameCachePixelFormatTest()
         loadSpriteFrames("Images/sprite_frames_test/test_PVRTC2_NOALPHA.plist", Texture2D::PixelFormat::PVRTC2);
     }
     
-    // test loading atlases wihtout PixelFormat specified
+    // test loading atlases without PixelFormat specified
     Texture2D::setDefaultAlphaPixelFormat(Texture2D::PixelFormat::RGB5A1);
     loadSpriteFrames("Images/sprite_frames_test/test_NoFormat.plist", Texture2D::PixelFormat::RGB5A1);
     

--- a/tests/cpp-tests/Classes/SpriteTest/SpriteTest.cpp
+++ b/tests/cpp-tests/Classes/SpriteTest/SpriteTest.cpp
@@ -944,7 +944,7 @@ SpriteZVertex::SpriteZVertex()
     // If you are going to use it is better to use a 3D projection
     //
     // WARNING:
-    // The developer is resposible for ordering its sprites according to its Z if the sprite has
+    // The developer is responsible for ordering its sprites according to its Z if the sprite has
     // transparent parts.
     //
 
@@ -1034,7 +1034,7 @@ SpriteBatchNodeZVertex::SpriteBatchNodeZVertex()
     // If you are going to use it is better to use a 3D projection
     //
     // WARNING:
-    // The developer is resposible for ordering its sprites according to its Z if the sprite has
+    // The developer is responsible for ordering its sprites according to its Z if the sprite has
     // transparent parts.
     //
 
@@ -1898,7 +1898,7 @@ void SpriteFrameAliasNameTest::onEnter()
     // Animation using Sprite batch
     //
     // A SpriteBatchNode can reference one and only one texture (one .png file)
-    // Sprites that are contained in that texture can be instantiatied as Sprites and then added to the SpriteBatchNode
+    // Sprites that are contained in that texture can be instantiated as Sprites and then added to the SpriteBatchNode
     // All Sprites added to a SpriteBatchNode are drawn in one OpenGL ES draw call
     // If the Sprites are not added to a SpriteBatchNode then an OpenGL ES draw call will be needed for each one, which is less efficient
     //

--- a/tests/cpp-tests/Classes/Texture2dTest/Texture2dTest.cpp
+++ b/tests/cpp-tests/Classes/Texture2dTest/Texture2dTest.cpp
@@ -1302,7 +1302,7 @@ void TextureAlias::onEnter()
     sprite->setPosition(Vec2( s.width/3.0f, s.height/2.0f));
     addChild(sprite);
     
-    // this is the default filterting
+    // this is the default filtering
     sprite->getTexture()->setAntiAliasTexParameters();
     
     //
@@ -1749,7 +1749,7 @@ std::string TextureCache1::title() const
 
 std::string TextureCache1::subtitle() const
 {
-    return "4 images should appear: alias, antialias, alias, antilias";
+    return "4 images should appear: alias, antialias, alias, antialias";
 }
 
 // TextureDrawAtPoint
@@ -1793,7 +1793,7 @@ void TextureDrawAtPoint::draw(Renderer *renderer, const Mat4 &transform, uint32_
 void TextureDrawAtPoint::onDraw(const Mat4 &transform, uint32_t flags)
 {
     Director* director = Director::getInstance();
-    CCASSERT(nullptr != director, "Director is null when seting matrix stack");
+    CCASSERT(nullptr != director, "Director is null when setting matrix stack");
     director->pushMatrix(MATRIX_STACK_TYPE::MATRIX_STACK_MODELVIEW);
     director->loadMatrix(MATRIX_STACK_TYPE::MATRIX_STACK_MODELVIEW, transform);
 
@@ -1835,7 +1835,7 @@ void TextureDrawInRect::draw(Renderer *renderer, const Mat4 &transform, uint32_t
 void TextureDrawInRect::onDraw(const Mat4 &transform, uint32_t flags)
 {
     Director* director = Director::getInstance();
-    CCASSERT(nullptr != director, "Director is null when seting matrix stack");
+    CCASSERT(nullptr != director, "Director is null when setting matrix stack");
     director->pushMatrix(MATRIX_STACK_TYPE::MATRIX_STACK_MODELVIEW);
     director->loadMatrix(MATRIX_STACK_TYPE::MATRIX_STACK_MODELVIEW, transform);
     
@@ -2167,7 +2167,7 @@ std::string TextureATITCInterpolated::title() const
 }
 std::string TextureATITCInterpolated::subtitle() const
 {
-    return "ATITC RGBA Interpolated Alpha comrpessed texture test";
+    return "ATITC RGBA Interpolated Alpha compressed texture test";
 }
 
 static void addImageToDemo(TextureDemo& demo, float x, float y, const char* path, Texture2D::PixelFormat format)

--- a/tests/cpp-tests/Classes/TextureCacheTest/TextureCacheTest.cpp
+++ b/tests/cpp-tests/Classes/TextureCacheTest/TextureCacheTest.cpp
@@ -26,7 +26,7 @@ TextureCacheTest::TextureCacheTest()
     this->addChild(_labelLoading);
     this->addChild(_labelPercent);
 
-    // load textrues
+    // load textures
     Director::getInstance()->getTextureCache()->addImageAsync("Images/HelloWorld.png", CC_CALLBACK_1(TextureCacheTest::loadingCallBack, this));
     Director::getInstance()->getTextureCache()->addImageAsync("Images/grossini.png", CC_CALLBACK_1(TextureCacheTest::loadingCallBack, this));
     Director::getInstance()->getTextureCache()->addImageAsync("Images/grossini_dance_01.png", CC_CALLBACK_1(TextureCacheTest::loadingCallBack, this));

--- a/tests/cpp-tests/Classes/TileMapTest/TileMapTest.cpp
+++ b/tests/cpp-tests/Classes/TileMapTest/TileMapTest.cpp
@@ -1466,7 +1466,7 @@ TMXGIDObjectsTest::TMXGIDObjectsTest()
     Size CC_UNUSED s = map->getContentSize();
     CCLOG("Contentsize: %f, %f", s.width, s.height);
 
-    CCLOG("----> Iterating over all the group objets");
+    CCLOG("----> Iterating over all the group objects");
     
     auto drawNode = DrawNode::create();
     Color4F color(1.0, 1.0, 1.0, 1.0);

--- a/tests/cpp-tests/Classes/TileMapTest/TileMapTest2.cpp
+++ b/tests/cpp-tests/Classes/TileMapTest/TileMapTest2.cpp
@@ -1323,7 +1323,7 @@ TMXGIDObjectsTestNew::TMXGIDObjectsTestNew()
     Size CC_UNUSED s = map->getContentSize();
     CCLOG("Contentsize: %f, %f", s.width, s.height);
 
-    CCLOG("----> Iterating over all the group objets");
+    CCLOG("----> Iterating over all the group objects");
     
     auto drawNode = DrawNode::create();
     Color4F color(1.0, 1.0, 1.0, 1.0);

--- a/tests/cpp-tests/Classes/UnitTest/RefPtrTest.cpp
+++ b/tests/cpp-tests/Classes/UnitTest/RefPtrTest.cpp
@@ -56,7 +56,7 @@ void RefPtrTest::onEnter()
         CC_ASSERT(strcmp("World", ref1->getCString()) == 0);
         CC_ASSERT(2 == ref1->getReferenceCount());
         
-        // Assigment back to nullptr
+        // Assignment back to nullptr
         __String * world = ref1;
         CC_ASSERT(2 == world->getReferenceCount());
         

--- a/tests/cpp-tests/Classes/UnitTest/UnitTest.cpp
+++ b/tests/cpp-tests/Classes/UnitTest/UnitTest.cpp
@@ -92,8 +92,8 @@ void TemplateVectorTest::onEnter()
     for (ssize_t i = 0; i < size; ++i)
     {
         CCASSERT(vec2.at(i) == vec.at(i), "The element at the same index in vec2 and vec2 should be equal.");
-        CCASSERT(vec.at(i)->getReferenceCount() == 3, "The reference cound of element in vec is 3. ");
-        CCASSERT(vec2.at(i)->getReferenceCount() == 3, "The reference cound of element in vec2 is 3. ");
+        CCASSERT(vec.at(i)->getReferenceCount() == 3, "The reference count of element in vec is 3. ");
+        CCASSERT(vec2.at(i)->getReferenceCount() == 3, "The reference count of element in vec2 is 3. ");
     }
 
     // Test copy assignment operator
@@ -104,9 +104,9 @@ void TemplateVectorTest::onEnter()
     for (ssize_t i = 0; i < size; ++i)
     {
         CCASSERT(vec3.at(i) == vec2.at(i), "The element at the same index in vec3 and vec2 should be equal.");
-        CCASSERT(vec3.at(i)->getReferenceCount() == 4, "The reference cound of element in vec3 is 4. ");
-        CCASSERT(vec2.at(i)->getReferenceCount() == 4, "The reference cound of element in vec2 is 4. ");
-        CCASSERT(vec.at(i)->getReferenceCount() == 4, "The reference cound of element in vec is 4. ");
+        CCASSERT(vec3.at(i)->getReferenceCount() == 4, "The reference count of element in vec3 is 4. ");
+        CCASSERT(vec2.at(i)->getReferenceCount() == 4, "The reference count of element in vec2 is 4. ");
+        CCASSERT(vec.at(i)->getReferenceCount() == 4, "The reference count of element in vec is 4. ");
     }
 
     // Test move constructor
@@ -196,7 +196,7 @@ void TemplateVectorTest::onEnter()
     CCASSERT(vec6.at(2)->getTag() == 1011, "vec6's third element's tag is 1011.");
     CCASSERT(vec6.at(3)->getTag() == 1012, "vec6's fouth element's tag is 1012.");
     vec6.erase(3);
-    CCASSERT(vec6.at(3)->getTag() == 1013, "vec6's 4th elemetn's tag is 1013.");
+    CCASSERT(vec6.at(3)->getTag() == 1013, "vec6's 4th element's tag is 1013.");
     vec6.eraseObject(vec6.at(2));
     CCASSERT(vec6.at(2)->getTag() == 1013, "vec6's 3rd element's tag is 1013.");
     vec6.clear();


### PR DESCRIPTION
This pull request fixes various spelling mistakes in comments and strings within the test cases.