### PR TITLE
Update CCNode.cpp

### DIFF
--- a/cocos/2d/CCNode.cpp
+++ b/cocos/2d/CCNode.cpp
@@ -1645,7 +1645,7 @@ void Node::update(float fDelta)
     {
         _componentContainer->visit(fDelta);
     }
-    this->release();
+	this->release();
 }
 
 // MARK: coordinates

--- a/cocos/2d/CCNode.cpp
+++ b/cocos/2d/CCNode.cpp
@@ -1630,6 +1630,7 @@ void Node::pauseSchedulerAndActions()
 // override me
 void Node::update(float fDelta)
 {
+    this->retain();
 #if CC_ENABLE_SCRIPT_BINDING
     if (0 != _updateScriptHandler)
     {
@@ -1644,6 +1645,7 @@ void Node::update(float fDelta)
     {
         _componentContainer->visit(fDelta);
     }
+    this->release();
 }
 
 // MARK: coordinates

--- a/cocos/2d/CCNode.cpp
+++ b/cocos/2d/CCNode.cpp
@@ -1630,15 +1630,14 @@ void Node::pauseSchedulerAndActions()
 // override me
 void Node::update(float fDelta)
 {
+	this->retain();
 #if CC_ENABLE_SCRIPT_BINDING
     if (0 != _updateScriptHandler)
     {
         //only lua use
-        this->retain();
         SchedulerScriptData data(_updateScriptHandler,fDelta);
         ScriptEvent event(kScheduleEvent,&data);
         ScriptEngineManager::getInstance()->getScriptEngine()->sendEvent(&event);
-        this->release();
     }
 #endif
     
@@ -1646,6 +1645,7 @@ void Node::update(float fDelta)
     {
         _componentContainer->visit(fDelta);
     }
+    this->release();
 }
 
 // MARK: coordinates

--- a/cocos/2d/CCNode.cpp
+++ b/cocos/2d/CCNode.cpp
@@ -1630,14 +1630,15 @@ void Node::pauseSchedulerAndActions()
 // override me
 void Node::update(float fDelta)
 {
-    this->retain();
 #if CC_ENABLE_SCRIPT_BINDING
     if (0 != _updateScriptHandler)
     {
         //only lua use
+        this->retain();
         SchedulerScriptData data(_updateScriptHandler,fDelta);
         ScriptEvent event(kScheduleEvent,&data);
         ScriptEngineManager::getInstance()->getScriptEngine()->sendEvent(&event);
+        this->release();
     }
 #endif
     
@@ -1645,7 +1646,6 @@ void Node::update(float fDelta)
     {
         _componentContainer->visit(fDelta);
     }
-    this->release();
 }
 
 // MARK: coordinates


### PR DESCRIPTION
Retain the node before update for lua, in case the lua update remove self and cause crashes !

Example(lua):
node = cc.Node:create()
node:onUpdate(handler(self, self.nodeUpdate))
node.nodeUpdate = function(self, dt)
    self:removeFromParent()             -- Cause crashes, _componentContainer has been a wild pointer !
end

Crash Point:
void Node::update(float fDelta)
{
#if CC_ENABLE_SCRIPT_BINDING
if (0 != _updateScriptHandler)
    {
    //only lua use
    SchedulerScriptData data(_updateScriptHandler,fDelta);
    ScriptEvent event(kScheduleEvent,&data);
    ScriptEngineManager::getInstance()->getScriptEngine()->sendEvent(&event);
}
#endif
    
    if (_componentContainer && !_componentContainer->isEmpty())  -- Crash
    {
        _componentContainer->visit(fDelta);
    }
}
