### PR TITLE
fix issue #17397

### DIFF
--- a/cocos/audio/CMakeLists.txt
+++ b/cocos/audio/CMakeLists.txt
@@ -11,6 +11,10 @@ if(WINDOWS)
         audio/win32/AudioEngine-win32.cpp
         audio/win32/AudioCache.cpp
         audio/win32/AudioPlayer.cpp
+	audio/win32/AudioDecoder.cpp
+	audio/win32/AudioDecoderManager.cpp
+	audio/win32/AudioDecoderMp3.cpp
+	audio/win32/AudioDecoderOgg.cpp
     )
 
 ELSEIF(ANDROID)


### PR DESCRIPTION
cocos/audio/CMakeLists.txt add missing .cpp for win32 platform