### PR TITLE
Rename `MutiTouchTest` to `MultiTouchTest`

### DIFF
--- a/build/cocos2d_tests.xcodeproj/project.pbxproj
+++ b/build/cocos2d_tests.xcodeproj/project.pbxproj
@@ -421,8 +421,8 @@
 		1AC35C1618CECF0C00F37B72 /* MenuTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1AC35AAA18CECF0C00F37B72 /* MenuTest.cpp */; };
 		1AC35C1718CECF0C00F37B72 /* MotionStreakTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1AC35AAD18CECF0C00F37B72 /* MotionStreakTest.cpp */; };
 		1AC35C1818CECF0C00F37B72 /* MotionStreakTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1AC35AAD18CECF0C00F37B72 /* MotionStreakTest.cpp */; };
-		1AC35C1918CECF0C00F37B72 /* MutiTouchTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1AC35AB018CECF0C00F37B72 /* MutiTouchTest.cpp */; };
-		1AC35C1A18CECF0C00F37B72 /* MutiTouchTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1AC35AB018CECF0C00F37B72 /* MutiTouchTest.cpp */; };
+		1AC35C1918CECF0C00F37B72 /* MultiTouchTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1AC35AB018CECF0C00F37B72 /* MultiTouchTest.cpp */; };
+		1AC35C1A18CECF0C00F37B72 /* MultiTouchTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1AC35AB018CECF0C00F37B72 /* MultiTouchTest.cpp */; };
 		1AC35C1B18CECF0C00F37B72 /* NewEventDispatcherTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1AC35AB318CECF0C00F37B72 /* NewEventDispatcherTest.cpp */; };
 		1AC35C1C18CECF0C00F37B72 /* NewEventDispatcherTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1AC35AB318CECF0C00F37B72 /* NewEventDispatcherTest.cpp */; };
 		1AC35C1D18CECF0C00F37B72 /* NewRendererTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1AC35AB618CECF0C00F37B72 /* NewRendererTest.cpp */; };
@@ -881,7 +881,7 @@
 		507B414F1C31BEA60067B53E /* CCControlColourPickerTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1AC35A6618CECF0B00F37B72 /* CCControlColourPickerTest.cpp */; };
 		507B41501C31BEA60067B53E /* UITextAtlasTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 29080D75191B595E0066F8DF /* UITextAtlasTest.cpp */; };
 		507B41511C31BEA60067B53E /* ActionsEaseTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1AC3592C18CECF0A00F37B72 /* ActionsEaseTest.cpp */; };
-		507B41521C31BEA60067B53E /* MutiTouchTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1AC35AB018CECF0C00F37B72 /* MutiTouchTest.cpp */; };
+		507B41521C31BEA60067B53E /* MultiTouchTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1AC35AB018CECF0C00F37B72 /* MultiTouchTest.cpp */; };
 		507B41551C31BEA60067B53E /* testsAppDelegate.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1AC35C7218CECF1400F37B72 /* testsAppDelegate.mm */; };
 		507B41571C31BEA60067B53E /* AppDelegate.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1AC3593418CECF0A00F37B72 /* AppDelegate.cpp */; };
 		507B41581C31BEA60067B53E /* Bug-1159.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1AC3597718CECF0B00F37B72 /* Bug-1159.cpp */; };
@@ -2194,8 +2194,8 @@
 		1AC35AAB18CECF0C00F37B72 /* MenuTest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MenuTest.h; sourceTree = "<group>"; };
 		1AC35AAD18CECF0C00F37B72 /* MotionStreakTest.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MotionStreakTest.cpp; sourceTree = "<group>"; };
 		1AC35AAE18CECF0C00F37B72 /* MotionStreakTest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MotionStreakTest.h; sourceTree = "<group>"; };
-		1AC35AB018CECF0C00F37B72 /* MutiTouchTest.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; lineEnding = 0; path = MutiTouchTest.cpp; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.cpp; };
-		1AC35AB118CECF0C00F37B72 /* MutiTouchTest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MutiTouchTest.h; sourceTree = "<group>"; };
+		1AC35AB018CECF0C00F37B72 /* MultiTouchTest.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; lineEnding = 0; path = MultiTouchTest.cpp; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.cpp; };
+		1AC35AB118CECF0C00F37B72 /* MultiTouchTest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MultiTouchTest.h; sourceTree = "<group>"; };
 		1AC35AB318CECF0C00F37B72 /* NewEventDispatcherTest.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = NewEventDispatcherTest.cpp; sourceTree = "<group>"; };
 		1AC35AB418CECF0C00F37B72 /* NewEventDispatcherTest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NewEventDispatcherTest.h; sourceTree = "<group>"; };
 		1AC35AB618CECF0C00F37B72 /* NewRendererTest.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = NewRendererTest.cpp; sourceTree = "<group>"; };
@@ -3496,7 +3496,7 @@
 				1AC35AA618CECF0C00F37B72 /* LayerTest */,
 				1AC35AA918CECF0C00F37B72 /* MenuTest */,
 				1AC35AAC18CECF0C00F37B72 /* MotionStreakTest */,
-				1AC35AAF18CECF0C00F37B72 /* MutiTouchTest */,
+				1AC35AAF18CECF0C00F37B72 /* MultiTouchTest */,
 				1AC35AB218CECF0C00F37B72 /* NewEventDispatcherTest */,
 				1AC35AB518CECF0C00F37B72 /* NewRendererTest */,
 				1AC35AB818CECF0C00F37B72 /* NodeTest */,
@@ -4120,13 +4120,13 @@
 			path = MotionStreakTest;
 			sourceTree = "<group>";
 		};
-		1AC35AAF18CECF0C00F37B72 /* MutiTouchTest */ = {
+		1AC35AAF18CECF0C00F37B72 /* MultiTouchTest */ = {
 			isa = PBXGroup;
 			children = (
-				1AC35AB018CECF0C00F37B72 /* MutiTouchTest.cpp */,
-				1AC35AB118CECF0C00F37B72 /* MutiTouchTest.h */,
+				1AC35AB018CECF0C00F37B72 /* MultiTouchTest.cpp */,
+				1AC35AB118CECF0C00F37B72 /* MultiTouchTest.h */,
 			);
-			path = MutiTouchTest;
+			path = MultiTouchTest;
 			sourceTree = "<group>";
 		};
 		1AC35AB218CECF0C00F37B72 /* NewEventDispatcherTest */ = {
@@ -6927,7 +6927,7 @@
 				1AC35BE318CECF0C00F37B72 /* CCControlColourPickerTest.cpp in Sources */,
 				29080DB1191B595E0066F8DF /* UILayoutTest.cpp in Sources */,
 				1AC35B2318CECF0C00F37B72 /* ActionsEaseTest.cpp in Sources */,
-				1AC35C1918CECF0C00F37B72 /* MutiTouchTest.cpp in Sources */,
+				1AC35C1918CECF0C00F37B72 /* MultiTouchTest.cpp in Sources */,
 				29080DBD191B595E0066F8DF /* UIPageViewTest.cpp in Sources */,
 				1AC35B2918CECF0C00F37B72 /* AppDelegate.cpp in Sources */,
 				1AC35B3718CECF0C00F37B72 /* Bug-1159.cpp in Sources */,
@@ -7100,7 +7100,7 @@
 				507B414F1C31BEA60067B53E /* CCControlColourPickerTest.cpp in Sources */,
 				507B41501C31BEA60067B53E /* UITextAtlasTest.cpp in Sources */,
 				507B41511C31BEA60067B53E /* ActionsEaseTest.cpp in Sources */,
-				507B41521C31BEA60067B53E /* MutiTouchTest.cpp in Sources */,
+				507B41521C31BEA60067B53E /* MultiTouchTest.cpp in Sources */,
 				507B41551C31BEA60067B53E /* testsAppDelegate.mm in Sources */,
 				507B41571C31BEA60067B53E /* AppDelegate.cpp in Sources */,
 				507B41581C31BEA60067B53E /* Bug-1159.cpp in Sources */,
@@ -7329,7 +7329,7 @@
 				1AC35BE418CECF0C00F37B72 /* CCControlColourPickerTest.cpp in Sources */,
 				29080DD4191B595E0066F8DF /* UITextAtlasTest.cpp in Sources */,
 				1AC35B2418CECF0C00F37B72 /* ActionsEaseTest.cpp in Sources */,
-				1AC35C1A18CECF0C00F37B72 /* MutiTouchTest.cpp in Sources */,
+				1AC35C1A18CECF0C00F37B72 /* MultiTouchTest.cpp in Sources */,
 				1AC35C8718CECF1400F37B72 /* testsAppDelegate.mm in Sources */,
 				1AC35B2A18CECF0C00F37B72 /* AppDelegate.cpp in Sources */,
 				1AC35B3818CECF0C00F37B72 /* Bug-1159.cpp in Sources */,

--- a/tests/cpp-tests/CMakeLists.txt
+++ b/tests/cpp-tests/CMakeLists.txt
@@ -102,7 +102,7 @@ set(TESTS_SRC
   Classes/MaterialSystemTest/MaterialSystemTest
   Classes/MenuTest/MenuTest.cpp
   Classes/MotionStreakTest/MotionStreakTest.cpp
-  Classes/MutiTouchTest/MutiTouchTest.cpp
+  Classes/MultiTouchTest/MultiTouchTest.cpp
   Classes/NewAudioEngineTest/NewAudioEngineTest.cpp
   Classes/NewEventDispatcherTest/NewEventDispatcherTest.cpp
   Classes/NewRendererTest/NewRendererTest.cpp

--- a/tests/cpp-tests/Classes/MultiTouchTest/MultiTouchTest.cpp
+++ b/tests/cpp-tests/Classes/MultiTouchTest/MultiTouchTest.cpp
@@ -1,10 +1,10 @@
-#include "MutiTouchTest.h"
+#include "MultiTouchTest.h"
 
 USING_NS_CC;
 
-MutiTouchTests::MutiTouchTests()
+MultiTouchTests::MultiTouchTests()
 {
-    ADD_TEST_CASE(MutiTouchTest);
+    ADD_TEST_CASE(MultiTouchTest);
 }
 
 static const Color3B* s_TouchColors[5] = {
@@ -39,14 +39,14 @@ public:
     }
 };
 
-bool MutiTouchTest::init()
+bool MultiTouchTest::init()
 {
     if (TestCase::init())
     {
         auto listener = EventListenerTouchAllAtOnce::create();
-        listener->onTouchesBegan = CC_CALLBACK_2(MutiTouchTest::onTouchesBegan, this);
-        listener->onTouchesMoved = CC_CALLBACK_2(MutiTouchTest::onTouchesMoved, this);
-        listener->onTouchesEnded = CC_CALLBACK_2(MutiTouchTest::onTouchesEnded, this);
+        listener->onTouchesBegan = CC_CALLBACK_2(MultiTouchTest::onTouchesBegan, this);
+        listener->onTouchesMoved = CC_CALLBACK_2(MultiTouchTest::onTouchesMoved, this);
+        listener->onTouchesEnded = CC_CALLBACK_2(MultiTouchTest::onTouchesEnded, this);
         _eventDispatcher->addEventListenerWithSceneGraphPriority(listener, this);
         
         auto title = Label::createWithSystemFont("Please touch the screen!", "", 24);
@@ -60,7 +60,7 @@ bool MutiTouchTest::init()
 
 static Map<int, TouchPoint*> s_map;
 
-void MutiTouchTest::onTouchesBegan(const std::vector<Touch*>& touches, Event  *event)
+void MultiTouchTest::onTouchesBegan(const std::vector<Touch*>& touches, Event  *event)
 {
     for ( auto &item: touches )
     {
@@ -73,7 +73,7 @@ void MutiTouchTest::onTouchesBegan(const std::vector<Touch*>& touches, Event  *e
     }
 }
 
-void MutiTouchTest::onTouchesMoved(const std::vector<Touch*>& touches, Event  *event)
+void MultiTouchTest::onTouchesMoved(const std::vector<Touch*>& touches, Event  *event)
 {
     for( auto &item: touches)
     {
@@ -90,7 +90,7 @@ void MutiTouchTest::onTouchesMoved(const std::vector<Touch*>& touches, Event  *e
     }
 }
 
-void MutiTouchTest::onTouchesEnded(const std::vector<Touch*>& touches, Event  *event)
+void MultiTouchTest::onTouchesEnded(const std::vector<Touch*>& touches, Event  *event)
 {
     for ( auto &item: touches )
     {
@@ -101,7 +101,7 @@ void MutiTouchTest::onTouchesEnded(const std::vector<Touch*>& touches, Event  *e
     }
 }
 
-void MutiTouchTest::onTouchesCancelled(const std::vector<Touch*>& touches, Event  *event)
+void MultiTouchTest::onTouchesCancelled(const std::vector<Touch*>& touches, Event  *event)
 {
     onTouchesEnded(touches, event);
 }

--- a/tests/cpp-tests/Classes/MultiTouchTest/MultiTouchTest.h
+++ b/tests/cpp-tests/Classes/MultiTouchTest/MultiTouchTest.h
@@ -1,14 +1,14 @@
-#ifndef __MUTITOUCHTEST_H__
-#define __MUTITOUCHTEST_H__
+#ifndef __MULTITOUCHTEST_H__
+#define __MULTITOUCHTEST_H__
 
 #include "../BaseTest.h"
 
-DEFINE_TEST_SUITE(MutiTouchTests);
+DEFINE_TEST_SUITE(MultiTouchTests);
 
-class MutiTouchTest : public TestCase
+class MultiTouchTest : public TestCase
 {
 public:
-    CREATE_FUNC(MutiTouchTest);
+    CREATE_FUNC(MultiTouchTest);
 
     virtual bool init() override;
 
@@ -18,4 +18,4 @@ public:
     void onTouchesCancelled(const std::vector<cocos2d::Touch*>& touches, cocos2d::Event  *event);
 };
 
-#endif /* __MUTITOUCHTEST_H__ */
+#endif /* __MULTITOUCHTEST_H__ */

--- a/tests/cpp-tests/Classes/controller.cpp
+++ b/tests/cpp-tests/Classes/controller.cpp
@@ -84,7 +84,7 @@ public:
         addTest("Node: Text Input", [](){return new TextInputTests(); });
         addTest("Node: UI", [](){  return new UITests(); });
         addTest("Mouse", []() { return new MouseTests(); });
-        addTest("MultiTouch", []() { return new MutiTouchTests(); });
+        addTest("MultiTouch", []() { return new MultiTouchTests(); });
         addTest("Renderer", []() { return new NewRendererTests(); });
         addTest("ReleasePool", [](){ return new ReleasePoolTests(); });
         addTest("Rotate World", [](){return new RotateWorldTests(); });

--- a/tests/cpp-tests/Classes/tests.h
+++ b/tests/cpp-tests/Classes/tests.h
@@ -56,7 +56,7 @@
 #include "MaterialSystemTest/MaterialSystemTest.h"
 #include "MenuTest/MenuTest.h"
 #include "MotionStreakTest/MotionStreakTest.h"
-#include "MutiTouchTest/MutiTouchTest.h"
+#include "MultiTouchTest/MultiTouchTest.h"
 #include "NavMeshTest/NavMeshTest.h"
 #include "NewEventDispatcherTest/NewEventDispatcherTest.h"
 #include "NewRendererTest/NewRendererTest.h"

--- a/tests/cpp-tests/proj.android-studio/app/jni/Android.mk
+++ b/tests/cpp-tests/proj.android-studio/app/jni/Android.mk
@@ -87,7 +87,7 @@ LOCAL_SRC_FILES := main.cpp \
 ../../../Classes/MaterialSystemTest/MaterialSystemTest.cpp \
 ../../../Classes/MenuTest/MenuTest.cpp \
 ../../../Classes/MotionStreakTest/MotionStreakTest.cpp \
-../../../Classes/MutiTouchTest/MutiTouchTest.cpp \
+../../../Classes/MultiTouchTest/MultiTouchTest.cpp \
 ../../../Classes/NewAudioEngineTest/NewAudioEngineTest.cpp \
 ../../../Classes/NewEventDispatcherTest/NewEventDispatcherTest.cpp \
 ../../../Classes/NewRendererTest/NewRendererTest.cpp \

--- a/tests/cpp-tests/proj.android/jni/Android.mk
+++ b/tests/cpp-tests/proj.android/jni/Android.mk
@@ -87,7 +87,7 @@ LOCAL_SRC_FILES := main.cpp \
 ../../Classes/MaterialSystemTest/MaterialSystemTest.cpp \
 ../../Classes/MenuTest/MenuTest.cpp \
 ../../Classes/MotionStreakTest/MotionStreakTest.cpp \
-../../Classes/MutiTouchTest/MutiTouchTest.cpp \
+../../Classes/MultiTouchTest/MultiTouchTest.cpp \
 ../../Classes/NewAudioEngineTest/NewAudioEngineTest.cpp \
 ../../Classes/NewEventDispatcherTest/NewEventDispatcherTest.cpp \
 ../../Classes/NewRendererTest/NewRendererTest.cpp \

--- a/tests/cpp-tests/proj.tizen/project_def.prop
+++ b/tests/cpp-tests/proj.tizen/project_def.prop
@@ -87,7 +87,7 @@ USER_SRCS = src/main.cpp \
             ../Classes/MaterialSystemTest/MaterialSystemTest.cpp \
             ../Classes/MenuTest/MenuTest.cpp \
             ../Classes/MotionStreakTest/MotionStreakTest.cpp \
-            ../Classes/MutiTouchTest/MutiTouchTest.cpp \
+            ../Classes/MultiTouchTest/MultiTouchTest.cpp \
             ../Classes/NewAudioEngineTest/NewAudioEngineTest.cpp \
             ../Classes/NewEventDispatcherTest/NewEventDispatcherTest.cpp \
             ../Classes/NewRendererTest/NewRendererTest.cpp \

--- a/tests/cpp-tests/proj.win10/cpp-tests.vcxproj
+++ b/tests/cpp-tests/proj.win10/cpp-tests.vcxproj
@@ -381,7 +381,7 @@
     <ClInclude Include="..\Classes\MaterialSystemTest\MaterialSystemTest.h" />
     <ClInclude Include="..\Classes\MenuTest\MenuTest.h" />
     <ClInclude Include="..\Classes\MotionStreakTest\MotionStreakTest.h" />
-    <ClInclude Include="..\Classes\MutiTouchTest\MutiTouchTest.h" />
+    <ClInclude Include="..\Classes\MultiTouchTest\MultiTouchTest.h" />
     <ClInclude Include="..\Classes\NavMeshTest\NavMeshTest.h" />
     <ClInclude Include="..\Classes\NewAudioEngineTest\NewAudioEngineTest.h" />
     <ClInclude Include="..\Classes\NewEventDispatcherTest\NewEventDispatcherTest.h" />
@@ -562,7 +562,7 @@
     <ClCompile Include="..\Classes\MaterialSystemTest\MaterialSystemTest.cpp" />
     <ClCompile Include="..\Classes\MenuTest\MenuTest.cpp" />
     <ClCompile Include="..\Classes\MotionStreakTest\MotionStreakTest.cpp" />
-    <ClCompile Include="..\Classes\MutiTouchTest\MutiTouchTest.cpp" />
+    <ClCompile Include="..\Classes\MultiTouchTest\MultiTouchTest.cpp" />
     <ClCompile Include="..\Classes\NavMeshTest\NavMeshTest.cpp" />
     <ClCompile Include="..\Classes\NewAudioEngineTest\NewAudioEngineTest.cpp" />
     <ClCompile Include="..\Classes\NewEventDispatcherTest\NewEventDispatcherTest.cpp" />

--- a/tests/cpp-tests/proj.win10/cpp-tests.vcxproj.filters
+++ b/tests/cpp-tests/proj.win10/cpp-tests.vcxproj.filters
@@ -101,7 +101,7 @@
     <Filter Include="Classes\MotionStreakTest">
       <UniqueIdentifier>{618404c5-9e20-4c6b-ba9c-11699ba3c45c}</UniqueIdentifier>
     </Filter>
-    <Filter Include="Classes\MutiTouchTest">
+    <Filter Include="Classes\MultiTouchTest">
       <UniqueIdentifier>{a6a92123-dd2f-4c1e-9780-a8183491b3d2}</UniqueIdentifier>
     </Filter>
     <Filter Include="Classes\NewAudioEngineTest">
@@ -578,8 +578,8 @@
     <ClCompile Include="..\Classes\MotionStreakTest\MotionStreakTest.cpp">
       <Filter>Classes\MotionStreakTest</Filter>
     </ClCompile>
-    <ClCompile Include="..\Classes\MutiTouchTest\MutiTouchTest.cpp">
-      <Filter>Classes\MutiTouchTest</Filter>
+    <ClCompile Include="..\Classes\MultiTouchTest\MultiTouchTest.cpp">
+      <Filter>Classes\MultiTouchTest</Filter>
     </ClCompile>
     <ClCompile Include="..\Classes\NewEventDispatcherTest\NewEventDispatcherTest.cpp">
       <Filter>Classes\NewEventDispatcherTest</Filter>
@@ -1216,8 +1216,8 @@
     <ClInclude Include="..\Classes\MotionStreakTest\MotionStreakTest.h">
       <Filter>Classes\MotionStreakTest</Filter>
     </ClInclude>
-    <ClInclude Include="..\Classes\MutiTouchTest\MutiTouchTest.h">
-      <Filter>Classes\MutiTouchTest</Filter>
+    <ClInclude Include="..\Classes\MultiTouchTest\MultiTouchTest.h">
+      <Filter>Classes\MultiTouchTest</Filter>
     </ClInclude>
     <ClInclude Include="..\Classes\NewEventDispatcherTest\NewEventDispatcherTest.h">
       <Filter>Classes\NewEventDispatcherTest</Filter>

--- a/tests/cpp-tests/proj.win32/cpp-tests.vcxproj
+++ b/tests/cpp-tests/proj.win32/cpp-tests.vcxproj
@@ -296,7 +296,7 @@ xcopy "$(OutDir)..\*.dll" "$(OutDir)" /D /Y</Command>
     <ClCompile Include="..\Classes\Box2DTestBed\GLES-Render.cpp" />
     <ClCompile Include="..\Classes\Box2DTestBed\Test.cpp" />
     <ClCompile Include="..\Classes\Box2DTestBed\TestEntries.cpp" />
-    <ClCompile Include="..\Classes\MutiTouchTest\MutiTouchTest.cpp" />
+    <ClCompile Include="..\Classes\MultiTouchTest\MultiTouchTest.cpp" />
     <ClCompile Include="..\Classes\SpriteFrameCacheTest\SpriteFrameCacheTest.cpp" />
   </ItemGroup>
   <ItemGroup>
@@ -512,7 +512,7 @@ xcopy "$(OutDir)..\*.dll" "$(OutDir)" /D /Y</Command>
     <ClInclude Include="..\Classes\Box2DTestBed\Tests\VaryingRestitution.h" />
     <ClInclude Include="..\Classes\Box2DTestBed\Tests\VerticalStack.h" />
     <ClInclude Include="..\Classes\Box2DTestBed\Tests\Web.h" />
-    <ClInclude Include="..\Classes\MutiTouchTest\MutiTouchTest.h" />
+    <ClInclude Include="..\Classes\MultiTouchTest\MultiTouchTest.h" />
     <ClInclude Include="..\Classes\SpriteFrameCacheTest\SpriteFrameCacheTest.h" />
   </ItemGroup>
   <ItemGroup>

--- a/tests/cpp-tests/proj.win32/cpp-tests.vcxproj.filters
+++ b/tests/cpp-tests/proj.win32/cpp-tests.vcxproj.filters
@@ -175,7 +175,7 @@
     <Filter Include="Classes\Box2DTestBed\Tests">
       <UniqueIdentifier>{17c1844a-dd68-4ed5-a368-383253473518}</UniqueIdentifier>
     </Filter>
-    <Filter Include="Classes\MutiTouchTest">
+    <Filter Include="Classes\MultiTouchTest">
       <UniqueIdentifier>{b3be049f-74ff-44a5-8895-0766e4807671}</UniqueIdentifier>
     </Filter>
     <Filter Include="Classes\ExtensionsTest\NetworkTest">
@@ -507,8 +507,8 @@
     <ClCompile Include="..\Classes\Box2DTestBed\TestEntries.cpp">
       <Filter>Classes\Box2DTestBed</Filter>
     </ClCompile>
-    <ClCompile Include="..\Classes\MutiTouchTest\MutiTouchTest.cpp">
-      <Filter>Classes\MutiTouchTest</Filter>
+    <ClCompile Include="..\Classes\MultiTouchTest\MultiTouchTest.cpp">
+      <Filter>Classes\MultiTouchTest</Filter>
     </ClCompile>
     <ClCompile Include="..\Classes\ExtensionsTest\NetworkTest\HttpClientTest.cpp">
       <Filter>Classes\ExtensionsTest\NetworkTest</Filter>
@@ -1085,8 +1085,8 @@
     <ClInclude Include="..\Classes\Box2DTestBed\Tests\Web.h">
       <Filter>Classes\Box2DTestBed\Tests</Filter>
     </ClInclude>
-    <ClInclude Include="..\Classes\MutiTouchTest\MutiTouchTest.h">
-      <Filter>Classes\MutiTouchTest</Filter>
+    <ClInclude Include="..\Classes\MultiTouchTest\MultiTouchTest.h">
+      <Filter>Classes\MultiTouchTest</Filter>
     </ClInclude>
     <ClInclude Include="..\Classes\ExtensionsTest\NetworkTest\HttpClientTest.h">
       <Filter>Classes\ExtensionsTest\NetworkTest</Filter>

--- a/tests/lua-tests/src/mainMenu.lua
+++ b/tests/lua-tests/src/mainMenu.lua
@@ -124,7 +124,7 @@ local _allTests = {
     { isSupported = true,  name = "MaterialSystemTest"     , create_func   =        MaterialSystemTest },
     { isSupported = true,  name = "MenuTest"               , create_func   =                  MenuTestMain  }, 
     { isSupported = true,  name = "MotionStreakTest"       , create_func   =          MotionStreakTest      },
-    { isSupported = false,  name = "MutiTouchTest"          , create_func=          MutiTouchTestMain     },
+    { isSupported = false, name = "MultiTouchTest"         , create_func   =          MultiTouchTestMain    },
     { isSupported = true,  name = "NavMeshTest"            , create_func   =       NavMeshTest },
     { isSupported = true,  name = "NewEventDispatcherTest"  , create_func   =       NewEventDispatcherTest },
     { isSupported = true,  name = "NodeTest"               , create_func   =                  CocosNodeTest },


### PR DESCRIPTION
Hello, I fixed a misspelled test case (`MutiTouchTest` -> `MultiTouchTest`) and also fixed the `MultiTouchTest` filename in build projects.