### PR TITLE
Fix variable name typo in Sprite3DTest.js

### DIFF
--- a/tests/js-tests/src/Sprite3DTest/Sprite3DTest.js
+++ b/tests/js-tests/src/Sprite3DTest/Sprite3DTest.js
@@ -320,7 +320,7 @@ var Sprite3DWithSkinTest = Sprite3DTestDemo.extend({
             if(rand2 < 0.33)
                 speed = animate.getSpeed() + Math.random();
             else if(rand2 < 0.66)            
-                spped = animate.getSpeed() - 0.5 * Math.random();
+                speed = animate.getSpeed() - 0.5 * Math.random();
 
             animate.setSpeed(inverse ? -speed : speed);
             sprite.runAction(new cc.RepeatForever(animate));
@@ -1153,7 +1153,7 @@ var Sprite3DWithSkinOutlineTest = Sprite3DTestDemo.extend({
             if(rand2 < 0.33)
                 speed = animate.getSpeed() + Math.random();
             else if(rand2 < 0.66)            
-                spped = animate.getSpeed() - 0.5 * Math.random();
+                speed = animate.getSpeed() - 0.5 * Math.random();
 
             animate.setSpeed(inverse ? -speed : speed);
             sprite.runAction(new cc.RepeatForever(animate));


### PR DESCRIPTION
This pull request fixed a typo where "speed" was misspelled as "spped" in `Sprite3DTest.js`.