### PR TITLE
Prevent unexpected calls to unscheduled selector in long updates.

### DIFF
--- a/cocos/base/CCScheduler.cpp
+++ b/cocos/base/CCScheduler.cpp
@@ -63,7 +63,6 @@ typedef struct _hashSelectorEntry
     void                *target;
     int                 timerIndex;
     Timer               *currentTimer;
-    bool                currentTimerSalvaged;
     bool                paused;
     UT_hash_handle      hh;
 } tHashTimerEntry;
@@ -79,7 +78,9 @@ Timer::Timer()
 , _repeat(0)
 , _delay(0.0f)
 , _interval(0.0f)
+, _aborted(false)
 {
+
 }
 
 void Timer::setupTimerWithInterval(float seconds, unsigned int repeat, float delay)
@@ -125,7 +126,7 @@ void Timer::update(float dt)
     
     // if _interval == 0, should trigger once every frame
     float interval = (_interval > 0) ? _interval : _elapsed;
-    while (_elapsed >= interval)
+    while ((_elapsed >= interval) && !_aborted)
     {
         trigger(interval);
         _elapsed -= interval;
@@ -349,10 +350,10 @@ void Scheduler::unschedule(const std::string &key, void *target)
 
             if (timer && key == timer->getKey())
             {
-                if (timer == element->currentTimer && (! element->currentTimerSalvaged))
+                if (timer == element->currentTimer && (! timer->isAborted()))
                 {
-                    element->currentTimer->retain();
-                    element->currentTimerSalvaged = true;
+                    timer->retain();
+                    timer->setAborted();
                 }
 
                 ccArrayRemoveObjectAtIndex(element->timers, i, true);
@@ -632,10 +633,10 @@ void Scheduler::unscheduleAllForTarget(void *target)
     if (element)
     {
         if (ccArrayContainsObject(element->timers, element->currentTimer)
-            && (! element->currentTimerSalvaged))
+            && (! element->currentTimer->isAborted()))
         {
             element->currentTimer->retain();
-            element->currentTimerSalvaged = true;
+            element->currentTimer->setAborted();
         }
         ccArrayRemoveAllObjects(element->timers);
 
@@ -873,11 +874,13 @@ void Scheduler::update(float dt)
             for (elt->timerIndex = 0; elt->timerIndex < elt->timers->num; ++(elt->timerIndex))
             {
                 elt->currentTimer = (Timer*)(elt->timers->arr[elt->timerIndex]);
-                elt->currentTimerSalvaged = false;
+                CCASSERT
+                  ( !elt->currentTimer->isAborted(),
+                    "An aborted timer should not be updated" );
 
                 elt->currentTimer->update(dt);
 
-                if (elt->currentTimerSalvaged)
+                if (elt->currentTimer->isAborted())
                 {
                     // The currentTimer told the remove itself. To prevent the timer from
                     // accidentally deallocating itself before finishing its step, we retained
@@ -1046,9 +1049,6 @@ void Scheduler::unschedule(SEL_SCHEDULE selector, Ref *target)
         return;
     }
     
-    //CCASSERT(target);
-    //CCASSERT(selector);
-    
     tHashTimerEntry *element = nullptr;
     HASH_FIND_PTR(_hashForTimers, &target, element);
     
@@ -1060,10 +1060,10 @@ void Scheduler::unschedule(SEL_SCHEDULE selector, Ref *target)
             
             if (timer && selector == timer->getSelector())
             {
-                if (timer == element->currentTimer && (! element->currentTimerSalvaged))
+                if (timer == element->currentTimer && (! timer->isAborted()))
                 {
-                    element->currentTimer->retain();
-                    element->currentTimerSalvaged = true;
+                    timer->retain();
+                    timer->setAborted();
                 }
                 
                 ccArrayRemoveObjectAtIndex(element->timers, i, true);

--- a/cocos/base/CCScheduler.h
+++ b/cocos/base/CCScheduler.h
@@ -56,6 +56,8 @@ public:
     void setInterval(float interval) { _interval = interval; }
     
     void setupTimerWithInterval(float seconds, unsigned int repeat, float delay);
+    void setAborted() { _aborted = true; }
+    bool isAborted() const { return _aborted; }
     
     virtual void trigger(float dt) = 0;
     virtual void cancel() = 0;
@@ -73,6 +75,7 @@ protected:
     unsigned int _repeat; //0 = once, 1 is 2 x executed
     float _delay;
     float _interval;
+    bool _aborted;
 };
 
 

--- a/tests/cpp-tests/Classes/SchedulerTest/SchedulerTest.h
+++ b/tests/cpp-tests/Classes/SchedulerTest/SchedulerTest.h
@@ -405,4 +405,21 @@ private:
     std::vector<TestClass *> _testvector;
 };
 
+class SchedulerRemoveSelectorDuringCall: public SchedulerTestLayer
+{
+public:
+    CREATE_FUNC(SchedulerRemoveSelectorDuringCall);
+    
+    virtual std::string title() const override;
+    virtual std::string subtitle() const override;
+    virtual void onEnter() override;
+    virtual void onExit() override;
+    
+private:
+    void callback( float );
+
+private:
+    bool _scheduled;
+};
+
 #endif


### PR DESCRIPTION
If the delta time dt passed to cocos2d::Timer::update(float) is longer than the
interval of the timer, then the timer will be triggered several times even if
the selector is unscheduled during the call.

This commit adds a flag in cocos2d::Timer stop the update loop if the selector
has been unscheduled.