### PR TITLE
Some fixes for search paths:

### DIFF
--- a/cocos/platform/CCFileUtils.cpp
+++ b/cocos/platform/CCFileUtils.cpp
@@ -860,9 +860,11 @@ std::string FileUtils::fullPathFromRelativeFile(const std::string &filename, con
 void FileUtils::setSearchResolutionsOrder(const std::vector<std::string>& searchResolutionsOrder)
 {
     bool existDefault = false;
+    std::vector<std::string> searchResolutionOrderCopied = searchResolutionsOrder;
+
     _fullPathCache.clear();
     _searchResolutionsOrderArray.clear();
-    for(const auto& iter : searchResolutionsOrder)
+    for(const auto& iter : searchResolutionOrderCopied)
     {
         std::string resolutionDirectory = iter;
         if (!existDefault && resolutionDirectory == "")
@@ -904,7 +906,7 @@ const std::vector<std::string>& FileUtils::getSearchResolutionsOrder() const
 
 const std::vector<std::string>& FileUtils::getSearchPaths() const
 {
-    return _searchPathArray;
+    return _originalSearchPaths;
 }
 
 void FileUtils::setWritablePath(const std::string& writablePath)
@@ -912,36 +914,54 @@ void FileUtils::setWritablePath(const std::string& writablePath)
     _writablePath = writablePath;
 }
 
+const std::string& FileUtils::getDefaultResourceRootPath() const
+{
+    return _defaultResRootPath;
+}
+
 void FileUtils::setDefaultResourceRootPath(const std::string& path)
 {
-    _defaultResRootPath = path;
+    if (_defaultResRootPath != path)
+    {
+        _fullPathCache.clear();
+        _defaultResRootPath = path;
+        if (!_defaultResRootPath.empty() && _defaultResRootPath[_defaultResRootPath.length()-1] != '/')
+        {
+            _defaultResRootPath += '/';
+        }
+
+        // Updates search paths
+        setSearchPaths(_originalSearchPaths);
+    }
 }
 
 void FileUtils::setSearchPaths(const std::vector<std::string>& searchPaths)
 {
     bool existDefaultRootPath = false;
+    _originalSearchPaths = searchPaths;
 
     _fullPathCache.clear();
     _searchPathArray.clear();
-    for (const auto& iter : searchPaths)
+
+    for (const auto& path : _originalSearchPaths)
     {
         std::string prefix;
-        std::string path;
+        std::string fullPath;
 
-        if (!isAbsolutePath(iter))
+        if (!isAbsolutePath(path))
         { // Not an absolute path
             prefix = _defaultResRootPath;
         }
-        path = prefix + (iter);
+        fullPath = prefix + path;
         if (!path.empty() && path[path.length()-1] != '/')
         {
-            path += "/";
+            fullPath += "/";
         }
         if (!existDefaultRootPath && path == _defaultResRootPath)
         {
             existDefaultRootPath = true;
         }
-        _searchPathArray.push_back(path);
+        _searchPathArray.push_back(fullPath);
     }
 
     if (!existDefaultRootPath)
@@ -962,10 +982,21 @@ void FileUtils::addSearchPath(const std::string &searchpath,const bool front)
     {
         path += "/";
     }
+
     if (front) {
+        _originalSearchPaths.insert(_originalSearchPaths.begin(), searchpath);
         _searchPathArray.insert(_searchPathArray.begin(), path);
     } else {
-        _searchPathArray.push_back(path);
+        _originalSearchPaths.push_back(searchpath);
+
+        if (!_searchPathArray.empty() && _searchPathArray[_searchPathArray.size()-1] == _defaultResRootPath)
+        {
+            _searchPathArray.insert(_searchPathArray.begin() + _searchPathArray.size() -1, path);
+        }
+        else
+        {
+            _searchPathArray.push_back(path);
+        }
     }
 }
 

--- a/cocos/platform/CCFileUtils.cpp
+++ b/cocos/platform/CCFileUtils.cpp
@@ -859,12 +859,16 @@ std::string FileUtils::fullPathFromRelativeFile(const std::string &filename, con
 
 void FileUtils::setSearchResolutionsOrder(const std::vector<std::string>& searchResolutionsOrder)
 {
+    if (_searchResolutionsOrderArray == searchResolutionsOrder)
+    {
+        return;
+    }
+
     bool existDefault = false;
-    std::vector<std::string> searchResolutionOrderCopied = searchResolutionsOrder;
 
     _fullPathCache.clear();
     _searchResolutionsOrderArray.clear();
-    for(const auto& iter : searchResolutionOrderCopied)
+    for(const auto& iter : searchResolutionsOrder)
     {
         std::string resolutionDirectory = iter;
         if (!existDefault && resolutionDirectory == "")

--- a/cocos/platform/CCFileUtils.cpp
+++ b/cocos/platform/CCFileUtils.cpp
@@ -910,6 +910,11 @@ const std::vector<std::string>& FileUtils::getSearchResolutionsOrder() const
 
 const std::vector<std::string>& FileUtils::getSearchPaths() const
 {
+    return _searchPathArray;
+}
+
+const std::vector<std::string>& FileUtils::getOriginalSearchPaths() const
+{
     return _originalSearchPaths;
 }
 

--- a/cocos/platform/CCFileUtils.h
+++ b/cocos/platform/CCFileUtils.h
@@ -462,11 +462,20 @@ public:
     /**
      *  Gets the array of search paths.
      *
-     *  @return The array of search paths.
+     *  @return The array of search paths which may contain the prefix of default resource root path. 
+     *  @note In best practise, getter function should return the value of setter function passes in.
+     *        But since we should not break the compatibility, we keep using the old logic. 
+     *        Therefore, If you want to get the original search paths, please call 'getOriginalSearchPaths()' instead.
      *  @see fullPathForFilename(const char*).
      *  @lua NA
      */
     virtual const std::vector<std::string>& getSearchPaths() const;
+
+    /**
+     *  Gets the original search path array set by 'setSearchPaths' or 'addSearchPath'.
+     *  @return The array of the original search paths
+     */
+    virtual const std::vector<std::string>& getOriginalSearchPaths() const;
 
     /**
      *  Gets the writable path.

--- a/cocos/platform/CCFileUtils.h
+++ b/cocos/platform/CCFileUtils.h
@@ -443,6 +443,11 @@ public:
     virtual void setSearchPaths(const std::vector<std::string>& searchPaths);
 
     /**
+     * Get default resource root path.
+     */
+    const std::string& getDefaultResourceRootPath() const;
+
+    /**
      * Set default resource root path.
      */
     void setDefaultResourceRootPath(const std::string& path);
@@ -872,6 +877,11 @@ protected:
      * The lower index of the element in this vector, the higher priority for this search path.
      */
     std::vector<std::string> _searchPathArray;
+
+    /**
+     * The search paths which was set by 'setSearchPaths' / 'addSearchPath'.
+     */
+    std::vector<std::string> _originalSearchPaths;
 
     /**
      *  The default root path of resources.

--- a/tests/cpp-tests/Classes/FileUtilsTest/FileUtilsTest.cpp
+++ b/tests/cpp-tests/Classes/FileUtilsTest/FileUtilsTest.cpp
@@ -136,6 +136,25 @@ void TestSearchPath::onEnter()
             fclose(fp);
         }
     }
+
+    // Save old resource root path
+    std::string oldDefaultRootPath = sharedFileUtils->getDefaultResourceRootPath();
+    sharedFileUtils->setDefaultResourceRootPath("extensions");
+    auto sp1 = Sprite::create("orange_edit.png");
+    sp1->setPosition(VisibleRect::center());
+    addChild(sp1);
+
+    // Recover resource root path
+    sharedFileUtils->setDefaultResourceRootPath(oldDefaultRootPath);
+
+    auto oldSearchPaths = sharedFileUtils->getSearchPaths();
+    sharedFileUtils->addSearchPath("Images");
+    auto sp2 = Sprite::create("btn-about-normal.png");
+    sp2->setPosition(VisibleRect::center() + Vec2(0, -50));
+    addChild(sp2);
+
+    // Recover old search paths
+    sharedFileUtils->setSearchPaths(oldSearchPaths);
 }
 
 void TestSearchPath::onExit()
@@ -155,7 +174,7 @@ std::string TestSearchPath::title() const
 
 std::string TestSearchPath::subtitle() const
 {
-    return "See the console";
+    return "See the console, can see a orange box and a 'about' picture";
 }
 
 // TestFilenameLookup


### PR DESCRIPTION
1. Adds ‘_originalSearchPaths’ variable, ’getOriginalSearchPaths’ returns the original values set by ‘setSearchPaths’  or ‘addSearchPath’.
2. Adds a getter function ‘getDefaultResourceRootPath’.
3. ‘setDefaultResourceRootPath’ should also update search paths and remove file path cache internally.
4. ‘setSearchPaths’  supports to pass self (_originalSearchPath), could be used in ‘setDefaultResourceRootPath’ to update the final ’_searchPathArray’ for searching full path.
5. ‘addSearchPath’ fix, the default resource root path should be the last element in ‘_searchPathArray’.
6. 'setSearchResolutionsOrder' supports to pass self '_searchResolutionsOrderArray' as parameter.