### PR TITLE
[Label] use freetype api to support bold

### DIFF
--- a/cocos/2d/CCFontAtlasCache.cpp
+++ b/cocos/2d/CCFontAtlasCache.cpp
@@ -58,11 +58,11 @@ FontAtlas* FontAtlasCache::getFontAtlasTTF(const _ttfConfig* config)
 
     char tmp[ATLAS_MAP_KEY_BUFFER];
     if (useDistanceField) {
-        snprintf(tmp, ATLAS_MAP_KEY_BUFFER, "df %.2f %d %s", config->fontSize, config->outlineSize,
-                 realFontFilename.c_str());
+        snprintf(tmp, ATLAS_MAP_KEY_BUFFER, "df %.2f %d %s %d", config->fontSize, config->outlineSize,
+                 realFontFilename.c_str(), config->bold ? 1 : 0);
     } else {
-        snprintf(tmp, ATLAS_MAP_KEY_BUFFER, "%.2f %d %s", config->fontSize, config->outlineSize,
-                 realFontFilename.c_str());
+        snprintf(tmp, ATLAS_MAP_KEY_BUFFER, "%.2f %d %s %d", config->fontSize, config->outlineSize,
+                 realFontFilename.c_str(), config->bold ? 1 : 0);
     }
     std::string atlasName = tmp;
 
@@ -71,7 +71,7 @@ FontAtlas* FontAtlasCache::getFontAtlasTTF(const _ttfConfig* config)
     if ( it == _atlasMap.end() )
     {
         auto font = FontFreeType::create(realFontFilename, config->fontSize, config->glyphs,
-            config->customGlyphs, useDistanceField, config->outlineSize);
+            config->customGlyphs, useDistanceField, config->outlineSize, config->bold);
         if (font)
         {
             auto tempAtlas = font->createFontAtlas();

--- a/cocos/2d/CCFontFreeType.cpp
+++ b/cocos/2d/CCFontFreeType.cpp
@@ -26,6 +26,7 @@ THE SOFTWARE.
 #include "2d/CCFontFreeType.h"
 #include FT_BBOX_H
 #include FT_BITMAP_H
+#include FT_OUTLINE_H
 #include "edtaa3func.h"
 #include "2d/CCFontAtlas.h"
 #include "base/CCDirector.h"

--- a/cocos/2d/CCFontFreeType.cpp
+++ b/cocos/2d/CCFontFreeType.cpp
@@ -25,6 +25,7 @@ THE SOFTWARE.
 
 #include "2d/CCFontFreeType.h"
 #include FT_BBOX_H
+#include FT_BITMAP_H
 #include "edtaa3func.h"
 #include "2d/CCFontAtlas.h"
 #include "base/CCDirector.h"
@@ -49,9 +50,15 @@ typedef struct _DataRef
 
 static std::unordered_map<std::string, DataRef> s_cacheFontData;
 
-FontFreeType * FontFreeType::create(const std::string &fontName, float fontSize, GlyphCollection glyphs, const char *customGlyphs,bool distanceFieldEnabled /* = false */,float outline /* = 0 */)
+FontFreeType * FontFreeType::create(const std::string &fontName, float fontSize, GlyphCollection glyphs, const char *customGlyphs,
+    bool distanceFieldEnabled /* = false */,float outline /* = 0 */,bool bold /* = false */)
 {
     FontFreeType *tempFont =  new (std::nothrow) FontFreeType(distanceFieldEnabled,outline);
+
+    if (bold)
+    {
+        tempFont->_boldSize = CC_CONTENT_SCALE_FACTOR() * 64;
+    }
 
     if (!tempFont)
         return nullptr;
@@ -105,6 +112,7 @@ FontFreeType::FontFreeType(bool distanceFieldEnabled /* = false */, float outlin
 , _fontAtlas(nullptr)
 , _encoding(FT_ENCODING_UNICODE)
 , _usedGlyphs(GlyphCollection::ASCII)
+, _boldSize(0)
 {
     if (outline > 0.0f)
     {
@@ -308,6 +316,11 @@ unsigned char* FontFreeType::getGlyphBitmap(uint64_t theChar, long &outWidth, lo
                 break;
         }
 
+        if (_boldSize > 0)
+        {
+            FT_Bitmap_Embolden(getFTLibrary(), &_fontRef->glyph->bitmap, _boldSize, 0);
+        }
+
         auto& metrics = _fontRef->glyph->metrics;
         outRect.origin.x = metrics.horiBearingX >> 6;
         outRect.origin.y = -(metrics.horiBearingY >> 6);
@@ -351,7 +364,7 @@ unsigned char* FontFreeType::getGlyphBitmap(uint64_t theChar, long &outWidth, lo
             auto blendWidth = MAX(outlineMaxX, glyphMaxX) - blendImageMinX;
             auto blendHeight = blendImageMaxY - MIN(outlineMinY, glyphMinY);
 
-            outRect.origin.x = blendImageMinX;
+            outRect.origin.x = blendImageMinX + _outlineSize;
             outRect.origin.y = -blendImageMaxY + _outlineSize;
 
             unsigned char *blendImage = nullptr;
@@ -427,6 +440,12 @@ unsigned char * FontFreeType::getGlyphBitmapWithOutline(uint64_t theChar, FT_BBo
                 if (glyph->format == FT_GLYPH_FORMAT_OUTLINE)
                 {
                     FT_Outline *outline = &reinterpret_cast<FT_OutlineGlyph>(glyph)->outline;
+
+                    if (_boldSize > 0)
+                    {
+                        FT_Outline_EmboldenXY(outline, _boldSize, 0);
+                    }
+                    
                     FT_Glyph_Get_CBox(glyph,FT_GLYPH_BBOX_GRIDFIT,&bbox);
                     long width = (bbox.xMax - bbox.xMin)>>6;
                     long rows = (bbox.yMax - bbox.yMin)>>6;

--- a/cocos/2d/CCFontFreeType.h
+++ b/cocos/2d/CCFontFreeType.h
@@ -54,7 +54,7 @@ public:
     static const int DistanceMapSpread;
 
     static FontFreeType* create(const std::string &fontName, float fontSize, GlyphCollection glyphs,
-        const char *customGlyphs,bool distanceFieldEnabled = false, float outline = 0);
+        const char *customGlyphs,bool distanceFieldEnabled = false, float outline = 0, bool bold = false);
 
     static void shutdownFreeType();
 
@@ -102,6 +102,7 @@ private:
     FT_Stroker _stroker;
     FT_Encoding _encoding;
 
+    int _boldSize;
     std::string _fontName;
     bool _distanceFieldEnabled;
     float _outlineSize;

--- a/cocos/2d/CCLabel.cpp
+++ b/cocos/2d/CCLabel.cpp
@@ -1144,22 +1144,22 @@ void Label::enableItalics()
 
 void Label::enableBold()
 {
-    if (!_boldEnabled)
+    if (_currentLabelType == LabelType::TTF) 
+    {
+        // use freetype to support bold only for ttf
+        if (_fontConfig.bold == false)
+        {
+            _fontConfig.bold = true;
+            setTTFConfig(_fontConfig);
+        }
+    }
+    else if (!_boldEnabled)
     {
         // bold is implemented with outline
         enableShadow(Color4B::WHITE, Size(0.9f, 0), 0);
         // add one to kerning
         setAdditionalKerning(_additionalKerning+1);
         _boldEnabled = true;
-    }
-}
-
-void cocos2d::Label::setBold(bool bold)
-{
-    if (_currentLabelType == LabelType::TTF && _fontConfig.bold != bold)
-    {
-        _fontConfig.bold = bold;
-        setTTFConfig(_fontConfig);
     }
 }
 
@@ -1225,7 +1225,15 @@ void Label::disableEffect(LabelEffect effect)
             setRotationSkewX(0);
             break;
         case cocos2d::LabelEffect::BOLD:
-            if (_boldEnabled) {
+            if (_currentLabelType == LabelType::TTF) // only for ttf
+            {
+                if (_fontConfig.bold == true)
+                {
+                    _fontConfig.bold = false;
+                    setTTFConfig(_fontConfig);
+                }
+            }
+            else if (_boldEnabled) {
                 _boldEnabled = false;
                 _additionalKerning -= 1;
                 disableEffect(LabelEffect::SHADOW);

--- a/cocos/2d/CCLabel.cpp
+++ b/cocos/2d/CCLabel.cpp
@@ -1154,7 +1154,7 @@ void Label::enableBold()
     }
 }
 
-void cocos2d::Label::setBold(bool bold /*= true*/)
+void cocos2d::Label::setBold(bool bold)
 {
     if (_currentLabelType == LabelType::TTF && _fontConfig.bold != bold)
     {

--- a/cocos/2d/CCLabel.cpp
+++ b/cocos/2d/CCLabel.cpp
@@ -997,8 +997,6 @@ bool Label::setTTFConfigInternal(const TTFConfig& ttfConfig)
 
     if (_fontConfig.italics)
         this->enableItalics();
-    if (_fontConfig.bold)
-        this->enableBold();
     if (_fontConfig.underline)
         this->enableUnderline();
     if (_fontConfig.strikethrough)
@@ -1153,6 +1151,15 @@ void Label::enableBold()
         // add one to kerning
         setAdditionalKerning(_additionalKerning+1);
         _boldEnabled = true;
+    }
+}
+
+void cocos2d::Label::setBold(bool bold /*= true*/)
+{
+    if (_currentLabelType == LabelType::TTF && _fontConfig.bold != bold)
+    {
+        _fontConfig.bold = bold;
+        setTTFConfig(_fontConfig);
     }
 }
 

--- a/cocos/2d/CCLabel.h
+++ b/cocos/2d/CCLabel.h
@@ -364,6 +364,11 @@ public:
     void enableBold();
 
     /**
+     * triggle bold, use freetype to support bold only for ttf
+     */
+    void setBold(bool bold = true);
+
+    /**
      * Enable underline
      */
     void enableUnderline();

--- a/cocos/2d/CCLabel.h
+++ b/cocos/2d/CCLabel.h
@@ -364,11 +364,6 @@ public:
     void enableBold();
 
     /**
-     * set bold effect, use freetype to support bold only for ttf
-     */
-    void setBold(bool bold);
-
-    /**
      * Enable underline
      */
     void enableUnderline();

--- a/cocos/2d/CCLabel.h
+++ b/cocos/2d/CCLabel.h
@@ -364,9 +364,9 @@ public:
     void enableBold();
 
     /**
-     * triggle bold, use freetype to support bold only for ttf
+     * set bold effect, use freetype to support bold only for ttf
      */
-    void setBold(bool bold = true);
+    void setBold(bool bold);
 
     /**
      * Enable underline


### PR DESCRIPTION
label enable blod use shadow to achive, so bold and outline can not use in same time.
![](https://cloud.githubusercontent.com/assets/4133961/23546881/8225655a-003c-11e7-973f-4b812347fd55.png)

use freetype api to support bold
![](https://cloud.githubusercontent.com/assets/4133961/23546902/916abe16-003c-11e7-9749-21e9e4dd87ad.png)
