### PR TITLE
cocos2d::Sequence::isDone() checks that the last action is actually done

### DIFF
--- a/cocos/2d/CCActionInterval.cpp
+++ b/cocos/2d/CCActionInterval.cpp
@@ -422,6 +422,11 @@ Sequence* Sequence::reverse() const
         return nullptr;
 }
 
+bool Sequence::isDone() const
+{
+  return (_last == 1) && _actions[1]->isDone();
+}
+
 //
 // Repeat
 //

--- a/cocos/2d/CCActionInterval.h
+++ b/cocos/2d/CCActionInterval.h
@@ -182,6 +182,7 @@ public:
     //
     virtual Sequence* clone() const override;
     virtual Sequence* reverse() const override;
+    virtual bool isDone() const override;
     virtual void startWithTarget(Node *target) override;
     virtual void stop(void) override;
     /**

--- a/tests/cpp-tests/Classes/ActionsTest/ActionsTest.cpp
+++ b/tests/cpp-tests/Classes/ActionsTest/ActionsTest.cpp
@@ -92,6 +92,7 @@ ActionsTests::ActionsTests()
     ADD_TEST_CASE(ActionFloatTest);
     ADD_TEST_CASE(Issue14936_1);
     ADD_TEST_CASE(Issue14936_2);
+    ADD_TEST_CASE(SequenceWithFinalInstant);
 }
 
 std::string ActionsDemo::title() const
@@ -2394,3 +2395,59 @@ std::string ActionFloatTest::subtitle() const
 }
 
 
+
+//------------------------------------------------------------------
+//
+// SequenceWithFinalInstant
+//
+//------------------------------------------------------------------
+void SequenceWithFinalInstant::onEnter()
+{
+    ActionsDemo::onEnter();
+
+    _manager = new cocos2d::ActionManager();
+    _manager->autorelease();
+    _manager->retain();
+    
+    _target = cocos2d::Node::create();
+    _target->setActionManager( _manager );
+    _target->retain();
+    _target->onEnter();
+
+    bool called( false );
+    const auto f
+      ( [ &called ]() -> void
+        {
+          cocos2d::log("Callback called.");
+          called = true;
+        } );
+    
+    const auto action =
+      cocos2d::Sequence::create
+      (cocos2d::DelayTime::create(0.05),
+       cocos2d::CallFunc::create(f),
+       nullptr);
+
+    _target->runAction(action);
+    _manager->update(0);
+    _manager->update(0.05 - FLT_EPSILON);
+
+    if ( action->isDone() && !called )
+      cocos2d::log
+        ("Action says it is done but is not."
+         " called=%d, elapsed=%f, duration=%f",
+         (int)called, action->getElapsed(), action->getDuration());
+    else
+      cocos2d::log("Everything went fine.");
+}
+
+void SequenceWithFinalInstant::onExit()
+{
+  _target->release();
+  _manager->release();
+}
+
+std::string SequenceWithFinalInstant::subtitle() const
+{
+    return "Instant action should be run. See console.";
+}

--- a/tests/cpp-tests/Classes/ActionsTest/ActionsTest.h
+++ b/tests/cpp-tests/Classes/ActionsTest/ActionsTest.h
@@ -620,4 +620,19 @@ private:
     int _count;
 };
 
+class SequenceWithFinalInstant : public ActionsDemo
+{
+public:
+    CREATE_FUNC(SequenceWithFinalInstant);
+
+    virtual std::string subtitle() const override;
+    virtual void onEnter() override;
+    virtual void onExit() override;
+
+private:
+    cocos2d::ActionManager* _manager;
+    cocos2d::Node* _target;
+
+};
+
 #endif


### PR DESCRIPTION
Due to approximations of float values, a call to `cocos2d::Sequence::isDone()` may return true even if the last action has not been executed.

This commit adds a test case reproducing the bug by creating a sequence made of one delay and one function call. The sequence is updated of the duration of the delay minus `FLT_EPSILON`. In this state, `isDone()` compares the elapsed time and the duration then returns `true`.

This commit adds a fix for this bug by testing that the last action is actually done in `cocos2d::Sequence::isDone()`.