### PR TITLE
Fix some local variable names in tests

### DIFF
--- a/tests/cpp-tests/Classes/BugsTest/Bug-15594.cpp
+++ b/tests/cpp-tests/Classes/BugsTest/Bug-15594.cpp
@@ -24,8 +24,8 @@ bool Bug15594Layer::init()
 
         auto animation = Animation3D::create("Images/bugs/bug15594.c3t");
         auto animate = Animate3D::create(animation);
-        auto repeate = RepeatForever::create(animate);
-        sprite3d->runAction(repeate);
+        auto repeat = RepeatForever::create(animate);
+        sprite3d->runAction(repeat);
         return true;
     }
 

--- a/tests/cpp-tests/Classes/ClippingNodeTest/ClippingNodeTest.cpp
+++ b/tests/cpp-tests/Classes/ClippingNodeTest/ClippingNodeTest.cpp
@@ -343,10 +343,10 @@ void HoleDemo::setup()
     
     _outerClipper = ClippingNode::create();
     _outerClipper->retain();
-    AffineTransform tranform = AffineTransform::IDENTITY;
-    tranform = AffineTransformScale(tranform, target->getScale(), target->getScale());
+    AffineTransform transform = AffineTransform::IDENTITY;
+    transform = AffineTransformScale(transform, target->getScale(), target->getScale());
 
-    _outerClipper->setContentSize( SizeApplyAffineTransform(target->getContentSize(), tranform));
+    _outerClipper->setContentSize(SizeApplyAffineTransform(target->getContentSize(), transform));
     _outerClipper->setAnchorPoint( Vec2(0.5, 0.5) );
     _outerClipper->setPosition(Vec2(this->getContentSize()) * 0.5f);
     _outerClipper->runAction(RepeatForever::create(RotateBy::create(1, 45)));

--- a/tests/cpp-tests/Classes/DataVisitorTest/DataVisitorTest.cpp
+++ b/tests/cpp-tests/Classes/DataVisitorTest/DataVisitorTest.cpp
@@ -58,26 +58,26 @@ void PrettyPrinterDemo::onEnter()
     }
     
     // Test code
-    PrettyPrinter vistor;
+    PrettyPrinter visitor;
     
     // print dictionary
     auto dict = __Dictionary::createWithContentsOfFile("animations/animations.plist");
-    dict->acceptVisitor(vistor);
-    log("%s", vistor.getResult().c_str());
+    dict->acceptVisitor(visitor);
+    log("%s", visitor.getResult().c_str());
     log("-------------------------------");
     
     __Set myset;
     for (int i = 0; i < 30; ++i) {
         myset.addObject(__String::createWithFormat("str: %d", i));
     }
-    vistor.clear();
-    myset.acceptVisitor(vistor);
-    log("%s", vistor.getResult().c_str());
+    visitor.clear();
+    myset.acceptVisitor(visitor);
+    log("%s", visitor.getResult().c_str());
     log("-------------------------------");
     
-    vistor.clear();
+    visitor.clear();
     addSprite();
 //    dict = Director::getInstance()->getTextureCache()->snapshotTextures();
-//    dict->acceptVisitor(vistor);
-//    log("%s", vistor.getResult().c_str());
+//    dict->acceptVisitor(visitor);
+//    log("%s", visitor.getResult().c_str());
 }

--- a/tests/cpp-tests/Classes/PhysicsTest/PhysicsTest.cpp
+++ b/tests/cpp-tests/Classes/PhysicsTest/PhysicsTest.cpp
@@ -1201,12 +1201,12 @@ void PhysicsDemoSlice::clipPoly(PhysicsShapePolygon* shape, Vec2 normal, float d
     
     Vec2 center = PhysicsShape::getPolygonCenter(points, pointsCount);
     Node* node = Node::create();
-    PhysicsBody* polyon = PhysicsBody::createPolygon(points, pointsCount, PHYSICSBODY_MATERIAL_DEFAULT, -center);
+    PhysicsBody* polygon = PhysicsBody::createPolygon(points, pointsCount, PHYSICSBODY_MATERIAL_DEFAULT, -center);
     node->setPosition(center);
-    node->addComponent(polyon);
-    polyon->setVelocity(body->getVelocityAtWorldPoint(center));
-    polyon->setAngularVelocity(body->getAngularVelocity());
-    polyon->setTag(_sliceTag);
+    node->addComponent(polygon);
+    polygon->setVelocity(body->getVelocityAtWorldPoint(center));
+    polygon->setAngularVelocity(body->getAngularVelocity());
+    polygon->setTag(_sliceTag);
     addChild(node);
     
     delete[] points;

--- a/tests/cpp-tests/Classes/ShaderTest/ShaderTest2.cpp
+++ b/tests/cpp-tests/Classes/ShaderTest/ShaderTest2.cpp
@@ -546,11 +546,11 @@ bool EffectSpriteLamp::init()
         lampEffect->setKBump(2);
         _sprite->setEffect(lampEffect);
         _effect = lampEffect;
-        auto listerner = EventListenerTouchAllAtOnce::create();
-        listerner->onTouchesBegan = CC_CALLBACK_2(EffectSpriteLamp::onTouchesBegan, this);
-        listerner->onTouchesMoved = CC_CALLBACK_2(EffectSpriteLamp::onTouchesMoved, this);
-        listerner->onTouchesEnded = CC_CALLBACK_2(EffectSpriteLamp::onTouchesEnded, this);
-        _eventDispatcher->addEventListenerWithSceneGraphPriority(listerner, this);
+        auto listener = EventListenerTouchAllAtOnce::create();
+        listener->onTouchesBegan = CC_CALLBACK_2(EffectSpriteLamp::onTouchesBegan, this);
+        listener->onTouchesMoved = CC_CALLBACK_2(EffectSpriteLamp::onTouchesMoved, this);
+        listener->onTouchesEnded = CC_CALLBACK_2(EffectSpriteLamp::onTouchesEnded, this);
+        _eventDispatcher->addEventListenerWithSceneGraphPriority(listener, this);
         return true;
     }
     return false;

--- a/tests/js-tests/src/Camera3DTest/Camera3DTest.js
+++ b/tests/js-tests/src/Camera3DTest/Camera3DTest.js
@@ -365,11 +365,11 @@ var Camera3DTest = (function(){
             layer3D.setCameraMask(2);
         },
 
-        addNewSpriteWithCoords:function(postion, file, playAnimation, scale, bindCamera){
+        addNewSpriteWithCoords:function(position, file, playAnimation, scale, bindCamera){
             var sprite = new jsb.Sprite3D(file);
             this._layer3D.addChild(sprite);
             var globalZOrder = sprite.getGlobalZOrder();
-            sprite.setPosition3D(postion);
+            sprite.setPosition3D(position);
             sprite.setGlobalZOrder(globalZOrder);
             if(playAnimation){
                 var animation = new jsb.Animation3D(file, "Take 001");

--- a/tests/lua-tests/src/AccelerometerTest/AccelerometerTest.lua
+++ b/tests/lua-tests/src/AccelerometerTest/AccelerometerTest.lua
@@ -42,8 +42,8 @@ local function AccelerometerMainLayer()
             target:setPosition(cc.p(ptNowX , ptNowY))
         end
 
-        local listerner  = cc.EventListenerAcceleration:create(accelerometerListener)
-        layer:getEventDispatcher():addEventListenerWithSceneGraphPriority(listerner,ball)
+        local listener = cc.EventListenerAcceleration:create(accelerometerListener)
+        layer:getEventDispatcher():addEventListenerWithSceneGraphPriority(listener, ball)
     end
 
     local function onExit()

--- a/tests/lua-tests/src/NewEventDispatcherTest/NewEventDispatcherTest.lua
+++ b/tests/lua-tests/src/NewEventDispatcherTest/NewEventDispatcherTest.lua
@@ -751,9 +751,9 @@ function SpriteAccelerationEventTest:onEnter()
         target:setPosition(cc.p(ptNowX , ptNowY))
     end
 
-    local listerner  = cc.EventListenerAcceleration:create(accelerometerListener)
+    local listener = cc.EventListenerAcceleration:create(accelerometerListener)
 
-    self:getEventDispatcher():addEventListenerWithSceneGraphPriority(listerner,sprite)
+    self:getEventDispatcher():addEventListenerWithSceneGraphPriority(listener, sprite)
 end
 
 function SpriteAccelerationEventTest:onExit()

--- a/tests/lua-tests/src/PhysicsTest/PhysicsTest.lua
+++ b/tests/lua-tests/src/PhysicsTest/PhysicsTest.lua
@@ -1036,14 +1036,14 @@ local function PhysicsDemoSlice()
     
         local center = cc.PhysicsShape:getPolygonCenter(points)
         local node = cc.Node:create()
-        local polyon = cc.PhysicsBody:createPolygon(points, 
-                                                    cc.PHYSICSBODY_MATERIAL_DEFAULT, 
-                                                    cc.p(-center.x, -center.y))
+        local polygon = cc.PhysicsBody:createPolygon(points, 
+                                                     cc.PHYSICSBODY_MATERIAL_DEFAULT, 
+                                                     cc.p(-center.x, -center.y))
         node:setPosition(center)
-        node:setPhysicsBody(polyon)
-        polyon:setVelocity(body:getVelocityAtWorldPoint(center))
-        polyon:setAngularVelocity(body:getAngularVelocity())
-        polyon.tag = sliceTag
+        node:setPhysicsBody(polygon)
+        polygon:setVelocity(body:getVelocityAtWorldPoint(center))
+        polygon:setAngularVelocity(body:getAngularVelocity())
+        polygon.tag = sliceTag
         layer:addChild(node)
       end
 

--- a/tests/lua-tests/src/Sprite3DTest/Sprite3DTest.lua
+++ b/tests/lua-tests/src/Sprite3DTest/Sprite3DTest.lua
@@ -184,9 +184,9 @@ function Sprite3DWithSkinTest.addNewSpriteWithCoords(parent,x,y)
         end
         animate:setTag(110)
         animate:setQuality(Sprite3DWithSkinTest._animateQuality)
-        local repeate = cc.RepeatForever:create(animate)
-        repeate:setTag(110)
-        sprite:runAction(repeate)
+        local repeat = cc.RepeatForever:create(animate)
+        repeat:setTag(110)
+        sprite:runAction(repeat)
     end
 end
 


### PR DESCRIPTION
This PR corrects the following spelling mistakes in variable names:

- `listerner ` -> `listener `
- `polyon ` -> `polygon `
- `postion ` -> `position `
- `repeate` -> `repeat`
- `tranform` -> `transform`
- `vistor ` -> `visitor `

Thank you for your time.