### PR TITLE
Prevent signed/unsigned mismatch

### DIFF
--- a/cocos/scripting/lua-bindings/manual/CCLuaStack.cpp
+++ b/cocos/scripting/lua-bindings/manual/CCLuaStack.cpp
@@ -811,9 +811,9 @@ int LuaStack::luaLoadChunksFromZIP(lua_State *L)
                         }
                     }
                     // replace path separator '/' '\' to '.'
-                    for (int i=0; i<filename.size(); i++) {
-                        if (filename[i] == '/' || filename[i] == '\\') {
-                            filename[i] = '.';
+                    for (auto & character : filename) {
+                        if (character == '/' || character == '\\') {
+                            character = '.';
                         }
                     }
                     CCLOG("[luaLoadChunksFromZIP] add %s to preload", filename.c_str());


### PR DESCRIPTION
Hello, when building Lua-bindings with Visual Studio 2015, I get the following warning message:

```
9>..\manual\CCLuaStack.cpp(814): warning C4018: '<' : signed/unsigned mismatch
```

So this PR replaces index-based for loop with range-based one to prevent the signed/unsigned mismatch warning.

Thanks!