### PR TITLE
Remove _claimedTouches Flags for listeners

### DIFF
--- a/cocos/base/CCEventDispatcher.cpp
+++ b/cocos/base/CCEventDispatcher.cpp
@@ -973,7 +973,30 @@ void EventDispatcher::dispatchTouchEvent(EventTouch* event)
     //
     if (oneByOneListeners)
     {
-        auto mutableTouchesIter = mutableTouches.begin();
+        if (event->getEventCode() == EventTouch::EventCode::BEGAN)
+        {
+            auto fixedPriorityListeners = oneByOneListeners->getFixedPriorityListeners();
+            auto sceneGraphPriorityListeners = oneByOneListeners->getSceneGraphPriorityListeners();
+            if (fixedPriorityListeners != nullptr)
+            {
+                for (auto lIter = fixedPriorityListeners->begin(); lIter != fixedPriorityListeners->end(); lIter++)
+                {
+                    EventListenerTouchOneByOne* listener = static_cast<EventListenerTouchOneByOne*>(*lIter);
+                    listener->_claimedTouches.clear();
+                }
+            }
+
+            if (sceneGraphPriorityListeners != nullptr)
+            {
+                for (auto lIter = sceneGraphPriorityListeners->begin(); lIter != sceneGraphPriorityListeners->end(); lIter++)
+                {
+                    EventListenerTouchOneByOne* listener = static_cast<EventListenerTouchOneByOne*>(*lIter);
+                    listener->_claimedTouches.clear();
+                }
+            }
+        }
+		
+      	auto mutableTouchesIter = mutableTouches.begin();
         
         for (auto& touches : originalTouches)
         {


### PR DESCRIPTION
Image We have two sprite squares, A (Left) and square B(Right), A is above of B, Both A and B have one by one touch listeners, and it will not swallow touches.

Click at the intersection of A and B, do not move
Touch press
A - onTouchBegan, return true, listener->_claimedTouches is true for A
B - onTouchBegan, return true, listener->_claimedTouches is true for B
Touch release
A - onTouchEnded, we manually call event->stopPropagation() in the onTouchEnd function !!!  listener->_claimedTouches is cleared
B - Because A stopPropagation, listener->_claimedTouches is not cleared

In this case, Because A stop propagation for touch end, the listener->_claimedTouches  for B will not be cleared forever ! because B has touch begin, which record the touch in listener->_claimedTouches, but it has not touch end !

https://github.com/cocos2d/cocos2d-x/pull/17483 is the Test case which only happend on Windows