### PR TITLE
ShaderTest wrong culling calculation

### DIFF
--- a/tests/cpp-tests/Classes/ShaderTest/ShaderTest2.cpp
+++ b/tests/cpp-tests/Classes/ShaderTest/ShaderTest2.cpp
@@ -81,10 +81,19 @@ public:
     void draw(Renderer *renderer, const Mat4 &transform, uint32_t flags) override
     {
 #if CC_USE_CULLING
-        // Don't do calculate the culling if the transform was not updated
-        _insideBounds = (flags & FLAGS_TRANSFORM_DIRTY) ? renderer->checkVisibility(transform, _contentSize) : _insideBounds;
-
-        if(_insideBounds)
+        // Don't calculate the culling if the transform was not updated
+    auto visitingCamera = Camera::getVisitingCamera();
+    auto defaultCamera = Camera::getDefaultCamera();
+    if (visitingCamera == defaultCamera) {
+        _insideBounds = ((flags & FLAGS_TRANSFORM_DIRTY) || visitingCamera->isViewProjectionUpdated()) ? renderer->checkVisibility(transform, _contentSize) : _insideBounds;
+    }
+    else
+    {
+            // XXX: this always return true since
+        _insideBounds = renderer->checkVisibility(transform, _contentSize);
+    }
+    
+    if(_insideBounds)
 #endif
         {
             // negative effects: order < 0


### PR DESCRIPTION
I took the code for EffectSprite from test, and it didn't work with that culling check. So I took whole block of culling check from Sprite::draw() method, and it fixed my problem.