### PR TITLE
Cpp test code for Pull request (Issue 17476)

### DIFF
--- a/tests/cpp-tests/Classes/NewEventDispatcherTest/NewEventDispatcherTest.cpp
+++ b/tests/cpp-tests/Classes/NewEventDispatcherTest/NewEventDispatcherTest.cpp
@@ -27,6 +27,7 @@ EventDispatcherTests::EventDispatcherTests()
     ADD_TEST_CASE(PauseResumeTargetTest);
     ADD_TEST_CASE(Issue4129);
     ADD_TEST_CASE(Issue4160);
+    ADD_TEST_CASE(Issue17476);
     ADD_TEST_CASE(DanglingNodePointersTest);
     ADD_TEST_CASE(RegisterAndUnregisterWhileEventHanldingTest);
     ADD_TEST_CASE(WindowEventsTest);
@@ -1207,6 +1208,92 @@ std::string Issue4160::title() const
 std::string Issue4160::subtitle() const
 {
     return "Touch the red block twice \n should not crash and the red one couldn't be touched";
+}
+
+// Issue17476
+Issue17476::Issue17476()
+{
+    Vec2 origin = Director::getInstance()->getVisibleOrigin();
+    Size size = Director::getInstance()->getVisibleSize();
+    
+    auto labelFirst = Label::createWithSystemFont("First\nClick\nHere\nThe\nIntersect", "Arial", 15);
+    labelFirst->setPosition(origin + Vec2(size.width / 2, size.height / 2));
+    addChild(labelFirst);
+
+    auto sprite1 = Sprite::create();
+    sprite1->setTexture("Images/CyanSquare.png");
+    sprite1->setPosition(origin+Vec2(size.width/2, size.height/2) + Vec2(-25, 0));
+    addChild(sprite1, -10);
+
+    auto listener1 = EventListenerTouchOneByOne::create();
+    listener1->setSwallowTouches(false);
+    listener1->onTouchBegan = [=](Touch* touch, Event* event) {
+        auto ptInSprite = sprite1->convertToNodeSpace(touch->getLocation());
+        if (sprite1->getTextureRect().containsPoint(ptInSprite))
+        {
+            CCLOG("Left Square On TouchBegan !");
+            sprite1->setColor(Color3B::RED);
+            return true;
+        }
+        else
+        {
+            return false;
+        }
+    };
+
+    listener1->onTouchEnded = [=](Touch* touch, Event* event) {
+        CCLOG("Left Square On TouchEnded !");
+        sprite1->setColor(Color3B::WHITE);
+        event->stopPropagation();
+    };
+    _eventDispatcher->addEventListenerWithSceneGraphPriority(listener1, sprite1);
+    
+    auto sprite2 = Sprite::create();
+    sprite2->setTexture("Images/MagentaSquare.png");
+    sprite2->setPosition(origin+Vec2(size.width/2, size.height/2) + Vec2(25, 0));
+    addChild(sprite2, -20);
+
+    auto listener2 = EventListenerTouchOneByOne::create();
+    listener2->setSwallowTouches(false);
+    listener2->onTouchBegan = [=](Touch* touch, Event* event) {
+        auto ptInSprite = sprite2->convertToNodeSpace(touch->getLocation());
+        if (sprite2->getTextureRect().containsPoint(ptInSprite))
+        {
+            CCLOG("Right Square On TouchBegan !");
+            sprite2->setColor(Color3B::RED);
+            return true;
+        }
+        else
+        {
+            return false;
+        }
+    };
+
+    listener2->onTouchEnded = [=](Touch* touch, Event* event) {
+        CCLOG("Right Square On TouchEnded !");
+        sprite2->setColor(Color3B::WHITE);
+        event->stopPropagation();
+    };
+    _eventDispatcher->addEventListenerWithSceneGraphPriority(listener2, sprite2);
+    
+    auto labelSecond = Label::createWithSystemFont("Second Step click Here, outside the squares", \
+        "Arial", 15);
+    labelSecond->setPosition(origin + Vec2(size.width / 2, size.height / 2) + Vec2(0, -90));
+    addChild(labelSecond);
+}
+
+Issue17476::~Issue17476()
+{
+}
+
+std::string Issue17476::title() const
+{
+    return "Issue 17476: _claimedTouches not cleared!";
+}
+
+std::string Issue17476::subtitle() const
+{
+    return "First Click the intersection of the two squares, Then click outside, you will find that the bottom square responsed to the second click !";
 }
 
 // DanglingNodePointersTest

--- a/tests/cpp-tests/Classes/NewEventDispatcherTest/NewEventDispatcherTest.h
+++ b/tests/cpp-tests/Classes/NewEventDispatcherTest/NewEventDispatcherTest.h
@@ -196,6 +196,19 @@ public:
 private:
 };
 
+class Issue17476 : public EventDispatcherTestDemo
+{
+public:
+    CREATE_FUNC(Issue17476);
+	Issue17476();
+    virtual ~Issue17476();
+    
+    virtual std::string title() const override;
+    virtual std::string subtitle() const override;
+    
+private:
+};
+
 class DanglingNodePointersTest : public EventDispatcherTestDemo
 {
 public:


### PR DESCRIPTION
It's only happend on Windows system, because the address for two click(touch) has the same address most times!
We have two squares,  A (Left) and square B(Right), A is above of B, Both A and B have one by one touch listeners, and it will not swallow touches.
Step 1, First click at the intersection of A and B, do not move, got a touch, suppose it's address is 0x12345678
    Touch press
        A - onTouchBegan, return true, Color changed, listener->_claimedTouches is true for A
        B - onTouchBegan, return true, Color changed, listener->_claimedTouches  is true for B
    Touch release
        A - onTouchEnded, call event->stopPropagation, Color recover, listener->_claimedTouches is cleared
        B - Because A stopPropagation, Color will not be recovered, listener->_claimedTouches is not cleared

Step 2, Second click outside the two squares A and B, do not move, the address has a great probability to be 0x12345678 on Windows system, when it's 0x12345678, the situation below happened !
    Touch press
        A - onTouchBegan, return false, Color not changed, listener->_claimedTouches is false
        B - onTouchBegan, return false, Color not changed, listener->_claimedTouches is still true
    Touch release
       A - not do anything, because the listener->_claimedTouches is false, the onTouchEnd is not called
       B - onTouchEnded is called, the Color recovered

More -
1, The listener->_claimedTouches is not cleared for all system once Step 1 is done
2, We can only test the Step 2 on Windows, it's because windows has a great probaility to have the same address for one by one touch ! and the listener->_claimedTouches record the address of the touch to flaged a touch begin!

CCEventListenerTouch.h (line 94)
std::vector<Touch*> _claimedTouches;

    