### PR TITLE
Fixes cocos2d build for tvOS.

### DIFF
--- a/build/cocos2d_libs.xcodeproj/project.pbxproj
+++ b/build/cocos2d_libs.xcodeproj/project.pbxproj
@@ -4046,6 +4046,10 @@
 		52B47A301A5349A3004E4C60 /* HttpClient-apple.mm in Sources */ = {isa = PBXBuildFile; fileRef = 52B47A2B1A5349A3004E4C60 /* HttpClient-apple.mm */; };
 		52B47A311A5349A3004E4C60 /* HttpCookie.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 52B47A2C1A5349A3004E4C60 /* HttpCookie.cpp */; };
 		52B47A321A5349A3004E4C60 /* HttpCookie.h in Headers */ = {isa = PBXBuildFile; fileRef = 52B47A2D1A5349A3004E4C60 /* HttpCookie.h */; };
+		53E23A171E78B082009DD732 /* CCDevice-apple.h in Headers */ = {isa = PBXBuildFile; fileRef = 294D7D931D0E67B4002CE7B7 /* CCDevice-apple.h */; };
+		53E23A181E78B085009DD732 /* CCDevice-apple.mm in Sources */ = {isa = PBXBuildFile; fileRef = 294D7D921D0E67B4002CE7B7 /* CCDevice-apple.mm */; };
+		53E23A1D1E78B91E009DD732 /* util.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 463AE7361E4DA31C00926B3A /* util.cpp */; };
+		53E23A1E1E78B91F009DD732 /* util.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 463AE7361E4DA31C00926B3A /* util.cpp */; };
 		5E9F61261A3FFE3D0038DE01 /* CCFrustum.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5E9F61221A3FFE3D0038DE01 /* CCFrustum.cpp */; };
 		5E9F61271A3FFE3D0038DE01 /* CCFrustum.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5E9F61221A3FFE3D0038DE01 /* CCFrustum.cpp */; };
 		5E9F61281A3FFE3D0038DE01 /* CCFrustum.h in Headers */ = {isa = PBXBuildFile; fileRef = 5E9F61231A3FFE3D0038DE01 /* CCFrustum.h */; };
@@ -12537,6 +12541,7 @@
 				507B3D411C31BDD30067B53E /* CCEventMouse.h in Headers */,
 				507B3D431C31BDD30067B53E /* CCPhysicsJoint.h in Headers */,
 				507B3D441C31BDD30067B53E /* CCPUScriptParser.h in Headers */,
+				53E23A171E78B082009DD732 /* CCDevice-apple.h in Headers */,
 				507B3D451C31BDD30067B53E /* CCPUVortexAffectorTranslator.h in Headers */,
 				507B3D461C31BDD30067B53E /* poly2tri.h in Headers */,
 				507B3D481C31BDD30067B53E /* CCPhysicsBody.h in Headers */,
@@ -16043,6 +16048,7 @@
 				507B3B9E1C31BDD30067B53E /* UIWebViewImpl-ios.mm in Sources */,
 				507B3B9F1C31BDD30067B53E /* CCPUGeometryRotatorTranslator.cpp in Sources */,
 				507B3BA11C31BDD30067B53E /* b2GearJoint.cpp in Sources */,
+				53E23A1E1E78B91F009DD732 /* util.cpp in Sources */,
 				507B3BA21C31BDD30067B53E /* btGImpactQuantizedBvh.cpp in Sources */,
 				507B3BA31C31BDD30067B53E /* CCFastTMXLayer.cpp in Sources */,
 				507B3BA41C31BDD30067B53E /* CCParticleSystemQuad.cpp in Sources */,
@@ -16315,6 +16321,7 @@
 				507B3CA91C31BDD30067B53E /* CocosGUI.cpp in Sources */,
 				1A2B22B41E6E54EC001D5EC9 /* Uri.cpp in Sources */,
 				507B3CAA1C31BDD30067B53E /* CCPUForceFieldAffectorTranslator.cpp in Sources */,
+				53E23A181E78B085009DD732 /* CCDevice-apple.mm in Sources */,
 				507B3CAB1C31BDD30067B53E /* CCAABB.cpp in Sources */,
 				507B3CAC1C31BDD30067B53E /* b2Island.cpp in Sources */,
 				507B3CAD1C31BDD30067B53E /* CCPUCircleEmitterTranslator.cpp in Sources */,
@@ -16903,6 +16910,7 @@
 				5020A1511D49912500E80C72 /* Animation.c in Sources */,
 				15AE1AC619AAD40300C27E9E /* b2GearJoint.cpp in Sources */,
 				B6CAB3301AF9AA1A00B9B856 /* btGImpactQuantizedBvh.cpp in Sources */,
+				53E23A1D1E78B91E009DD732 /* util.cpp in Sources */,
 				B24AA986195A675C007B4522 /* CCFastTMXLayer.cpp in Sources */,
 				1A57022E180BCC1A0088DEC7 /* CCParticleSystemQuad.cpp in Sources */,
 				50ABBD901925AB4100A911A9 /* CCGLProgramCache.cpp in Sources */,
@@ -17467,10 +17475,12 @@
 					"\"$(SRCROOT)/../external/curl/prebuilt/ios\"",
 					"\"$(SRCROOT)/../external/websockets/prebuilt/ios\"",
 					"\"$(SRCROOT)/../external/chipmunk/prebuilt/ios\"",
+					"\"$(SRCROOT)/../external/openssl/prebuilt/ios\"",
 				);
 				OTHER_LDFLAGS = "-llibsql3";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = appletvos9.1;
+				SDKROOT = appletvos;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
 				USER_HEADER_SEARCH_PATHS = "$(inherited) $(SRCROOT)/../external/freetype2/include/ios $(SRCROOT)/../external/curl/include/ios $(SRCROOT)/../external/webp/include/ios $(SRCROOT)/../external/tiff/include/ios $(SRCROOT)/../external/jpeg/include/ios $(SRCROOT)/../external/png/include/ios $(SRCROOT)/../external/websockets/include/ios $(SRCROOT)/../external/freetype2/include/ios/freetype2 $(SRCROOT)/../external/openssl/include/ios";
 			};
 			name = Debug;
@@ -17499,10 +17509,12 @@
 					"\"$(SRCROOT)/../external/curl/prebuilt/ios\"",
 					"\"$(SRCROOT)/../external/websockets/prebuilt/ios\"",
 					"\"$(SRCROOT)/../external/chipmunk/prebuilt/ios\"",
+					"\"$(SRCROOT)/../external/openssl/prebuilt/ios\"",
 				);
 				OTHER_LDFLAGS = "-llibsql3";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = appletvos9.1;
+				SDKROOT = appletvos;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
 				USER_HEADER_SEARCH_PATHS = "$(inherited) $(SRCROOT)/../external/freetype2/include/ios $(SRCROOT)/../external/curl/include/ios $(SRCROOT)/../external/webp/include/ios $(SRCROOT)/../external/tiff/include/ios $(SRCROOT)/../external/jpeg/include/ios $(SRCROOT)/../external/png/include/ios $(SRCROOT)/../external/websockets/include/ios $(SRCROOT)/../external/freetype2/include/ios/freetype2 $(SRCROOT)/../external/openssl/include/ios";
 			};
 			name = Release;

--- a/cocos/platform/CCFileUtils.cpp
+++ b/cocos/platform/CCFileUtils.cpp
@@ -1297,6 +1297,7 @@ bool FileUtils::createDirectory(const std::string& path)
 
 bool FileUtils::removeDirectory(const std::string& path)
 {
+#if !defined(CC_TARGET_OS_TVOS)
     std::string command = "rm -r ";
     // Path may include space.
     command += "\"" + path + "\"";
@@ -1304,6 +1305,9 @@ bool FileUtils::removeDirectory(const std::string& path)
         return true;
     else
         return false;
+#else
+    return false;
+#endif
 }
 
 bool FileUtils::removeFile(const std::string &path)

--- a/cocos/platform/ios/CCEAGLView-ios.mm
+++ b/cocos/platform/ios/CCEAGLView-ios.mm
@@ -181,6 +181,7 @@ Copyright (C) 2008 Apple Inc. All Rights Reserved.
 
 - (void)didMoveToWindow
 {
+#if !defined(CC_TARGET_OS_TVOS)
     [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(onUIKeyboardNotification:)
                                                  name:UIKeyboardWillShowNotification object:nil];
@@ -195,6 +196,7 @@ Copyright (C) 2008 Apple Inc. All Rights Reserved.
     [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(onUIKeyboardNotification:)
                                                  name:UIKeyboardDidHideNotification object:nil];
+#endif
 }
 
 -(int) getWidth
@@ -733,6 +735,7 @@ Copyright (C) 2008 Apple Inc. All Rights Reserved.
 
 #pragma mark - UIKeyboard notification
 
+#if !defined(CC_TARGET_OS_TVOS)
 - (void)onUIKeyboardNotification:(NSNotification *)notif
 {
     NSString * type = notif.name;
@@ -748,12 +751,6 @@ Copyright (C) 2008 Apple Inc. All Rights Reserved.
     
     CGSize viewSize = self.frame.size;
 
-#if defined(CC_TARGET_OS_TVOS)
-    // statusBarOrientation not defined on tvOS, and also, orientation makes
-    // no sense on tvOS
-    begin.origin.y = viewSize.height - begin.origin.y - begin.size.height;
-    end.origin.y = viewSize.height - end.origin.y - end.size.height;
-#else
     CGFloat tmp;
     switch (getFixedOrientation([[UIApplication sharedApplication] statusBarOrientation]))
     {
@@ -796,20 +793,16 @@ Copyright (C) 2008 Apple Inc. All Rights Reserved.
         default:
             break;
     }
-#endif
 
     auto glview = cocos2d::Director::getInstance()->getOpenGLView();
     float scaleX = glview->getScaleX();
     float scaleY = glview->getScaleY();
-    
-    
     
     // Convert to pixel coordinate
     begin = CGRectApplyAffineTransform(begin, CGAffineTransformScale(CGAffineTransformIdentity, self.contentScaleFactor, self.contentScaleFactor));
     end = CGRectApplyAffineTransform(end, CGAffineTransformScale(CGAffineTransformIdentity, self.contentScaleFactor, self.contentScaleFactor));
     
     float offestY = glview->getViewPortRect().origin.y;
-    CCLOG("offestY = %f", offestY);
     if (offestY < 0.0f)
     {
         begin.origin.y += offestY;
@@ -845,12 +838,7 @@ Copyright (C) 2008 Apple Inc. All Rights Reserved.
         dispatcher->dispatchKeyboardDidShow(notiInfo);
         caretRect_ = end;
 
-#if defined(CC_TARGET_OS_TVOS)
-        // smallSystemFontSize not available on TVOS
-        int fontSize = 12;
-#else
         int fontSize = [UIFont smallSystemFontSize];
-#endif
         caretRect_.origin.y = viewSize.height - (caretRect_.origin.y + caretRect_.size.height + fontSize);
         caretRect_.size.height = 0;
         isKeyboardShown_ = YES;
@@ -866,6 +854,7 @@ Copyright (C) 2008 Apple Inc. All Rights Reserved.
         isKeyboardShown_ = NO;
     }
 }
+#endif
 
 #if !defined(CC_TARGET_OS_TVOS)
 UIInterfaceOrientation getFixedOrientation(UIInterfaceOrientation statusBarOrientation)

--- a/cocos/vr/CCVRGenericHeadTracker.cpp
+++ b/cocos/vr/CCVRGenericHeadTracker.cpp
@@ -33,7 +33,7 @@
 #include "platform/CCPlatformMacros.h"
 #include "platform/CCDevice.h"
 
-#if (CC_TARGET_PLATFORM == CC_PLATFORM_IOS)
+#if (CC_TARGET_PLATFORM == CC_PLATFORM_IOS) && !defined(CC_TARGET_OS_TVOS)
 #import <CoreMotion/CoreMotion.h>
 #elif (CC_TARGET_PLATFORM == CC_PLATFORM_ANDROID)
 #include <jni.h>
@@ -44,7 +44,7 @@ NS_CC_BEGIN
 
 //////
 
-#if (CC_TARGET_PLATFORM == CC_PLATFORM_IOS)
+#if (CC_TARGET_PLATFORM == CC_PLATFORM_IOS) && !defined(CC_TARGET_OS_TVOS)
 static Mat4 matrixFromRotationMatrix(const CMRotationMatrix& rotationMatrix)
 {
     return Mat4(rotationMatrix.m11,
@@ -127,7 +127,7 @@ Vec3 lowPass(const Vec3& input, const Vec3& prev)
 
 #endif // (CC_TARGET_PLATFORM == CC_PLATFORM_ANDROID)
 
-#if (CC_TARGET_PLATFORM == CC_PLATFORM_IOS) || (CC_TARGET_PLATFORM == CC_PLATFORM_ANDROID)
+#if (CC_TARGET_PLATFORM == CC_PLATFORM_IOS) && !defined(CC_TARGET_OS_TVOS) || (CC_TARGET_PLATFORM == CC_PLATFORM_ANDROID)
 
 static Mat4 getRotateEulerMatrix(float x, float y, float z)
 {
@@ -167,29 +167,29 @@ static Mat4 getRotateEulerMatrix(float x, float y, float z)
 VRGenericHeadTracker::VRGenericHeadTracker()
 : _localPosition(Vec3::ZERO)
 {
-#if (CC_TARGET_PLATFORM == CC_PLATFORM_IOS)
+#if (CC_TARGET_PLATFORM == CC_PLATFORM_IOS) && !defined(CC_TARGET_OS_TVOS)
     _motionMgr = [[CMMotionManager alloc] init];
 #endif
 
-#if (CC_TARGET_PLATFORM == CC_PLATFORM_IOS) || (CC_TARGET_PLATFORM == CC_PLATFORM_ANDROID)
+#if (CC_TARGET_PLATFORM == CC_PLATFORM_IOS) && !defined(CC_TARGET_OS_TVOS) || (CC_TARGET_PLATFORM == CC_PLATFORM_ANDROID)
     startTracking();
 #endif
 }
 
 VRGenericHeadTracker::~VRGenericHeadTracker()
 {
-#if (CC_TARGET_PLATFORM == CC_PLATFORM_IOS) || (CC_TARGET_PLATFORM == CC_PLATFORM_ANDROID)
+#if (CC_TARGET_PLATFORM == CC_PLATFORM_IOS) && !defined(CC_TARGET_OS_TVOS) || (CC_TARGET_PLATFORM == CC_PLATFORM_ANDROID)
     stopTracking();
 #endif
 
-#if (CC_TARGET_PLATFORM == CC_PLATFORM_IOS)
+#if (CC_TARGET_PLATFORM == CC_PLATFORM_IOS) && !defined(CC_TARGET_OS_TVOS)
     [(CMMotionManager*)_motionMgr release];
 #endif
 }
 
 void VRGenericHeadTracker::startTracking()
 {
-#if (CC_TARGET_PLATFORM == CC_PLATFORM_IOS)
+#if (CC_TARGET_PLATFORM == CC_PLATFORM_IOS) && !defined(CC_TARGET_OS_TVOS)
     CMMotionManager* motionMgr = (CMMotionManager*)_motionMgr;
     if (motionMgr.isDeviceMotionAvailable && !motionMgr.isDeviceMotionActive)
     {
@@ -218,7 +218,7 @@ void VRGenericHeadTracker::startTracking()
 
 void VRGenericHeadTracker::stopTracking()
 {
-#if (CC_TARGET_PLATFORM == CC_PLATFORM_IOS)
+#if (CC_TARGET_PLATFORM == CC_PLATFORM_IOS) && !defined(CC_TARGET_OS_TVOS)
     [(CMMotionManager*)_motionMgr stopDeviceMotionUpdates];
 #elif (CC_TARGET_PLATFORM == CC_PLATFORM_ANDROID)
     Device::setAccelerometerEnabled(false);
@@ -232,7 +232,7 @@ Vec3 VRGenericHeadTracker::getLocalPosition()
 
 Mat4 VRGenericHeadTracker::getLocalRotation()
 {
-#if (CC_TARGET_PLATFORM == CC_PLATFORM_IOS)
+#if (CC_TARGET_PLATFORM == CC_PLATFORM_IOS) && !defined(CC_TARGET_OS_TVOS)
     CMMotionManager* motionMgr = (CMMotionManager*)_motionMgr;
     CMDeviceMotion* motion = motionMgr.deviceMotion;
 


### PR DESCRIPTION
Fixes errors when building target "libcocos2d tvOS" for iPhone Simulator.

There are still errors when building for a tvOS device - these are caused by the external libs. Building for a device requires tvOS libs but currently only iOS libs are prebuilt. These libs are already set up on 3rd-party-libs-src and should be added to cocos2d-x-3rd-party-libs-bin.