### PR TITLE
Fix spelling mistake in test case

### DIFF
--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UITextTest/UITextTest.cpp
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UITextTest/UITextTest.cpp
@@ -10,7 +10,7 @@ UITextTests::UITextTests()
     ADD_TEST_CASE(UITextTest_LineWrap);
     ADD_TEST_CASE(UILabelTest_Effect);
     ADD_TEST_CASE(UITextTest_TTF);
-    ADD_TEST_CASE(UITextTest_IgnoreConentSize);
+    ADD_TEST_CASE(UITextTest_IgnoreContentSize);
     ADD_TEST_CASE(UITextTest_Clone);
     ADD_TEST_CASE(Issue16073Test);
 }
@@ -220,9 +220,9 @@ bool UITextTest_TTF::init()
     return false;
 }
 
-// UITextTest_IgnoreConentSize
+// UITextTest_IgnoreContentSize
 
-bool UITextTest_IgnoreConentSize::init()
+bool UITextTest_IgnoreContentSize::init()
 {
     if (UIScene::init())
     {
@@ -266,7 +266,7 @@ bool UITextTest_IgnoreConentSize::init()
     return false;
 }
 
-// UITextTest_IgnoreConentSize
+// UITextTest_IgnoreContentSize
 
 bool UITextTest_Clone::init()
 {

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UITextTest/UITextTest.h
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UITextTest/UITextTest.h
@@ -63,10 +63,10 @@ public:
     virtual bool init() override;
 };
 
-class UITextTest_IgnoreConentSize : public UIScene
+class UITextTest_IgnoreContentSize : public UIScene
 {
 public:
-    CREATE_FUNC(UITextTest_IgnoreConentSize);
+    CREATE_FUNC(UITextTest_IgnoreContentSize);
 
     virtual bool init() override;
 };

--- a/tests/js-tests/src/GUITest/UISceneManager.js
+++ b/tests/js-tests/src/GUITest/UISceneManager.js
@@ -276,9 +276,9 @@
                 }
             },
             {
-                title: "UITextTest_IgnoreConentSize",
+                title: "UITextTest_IgnoreContentSize",
                 func: function(){
-                    return new UITextTest_IgnoreConentSize();
+                    return new UITextTest_IgnoreContentSize();
                 }
             },
             {

--- a/tests/js-tests/src/GUITest/UITextTest/UITextTest.js
+++ b/tests/js-tests/src/GUITest/UITextTest/UITextTest.js
@@ -138,7 +138,7 @@ var UITextTest_TTF = UIMainLayer.extend({
 });
 
 //2015-01-14
-var UITextTest_IgnoreConentSize = UIMainLayer.extend({
+var UITextTest_IgnoreContentSize = UIMainLayer.extend({
 
     init: function(){
         if(this._super()){


### PR DESCRIPTION
This PR corrects a small spelling mistake `Conent` to `Content` in the UI test cases.