### PR TITLE
fix an Accelerometer second to microsecond convertion error in Android platform

### DIFF
--- a/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxAccelerometer.java
+++ b/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxAccelerometer.java
@@ -79,7 +79,7 @@ public class Cocos2dxAccelerometer implements SensorEventListener {
             this.mSensorManager.registerListener(this, this.mAccelerometer, SensorManager.SENSOR_DELAY_GAME);
         } else {
             //convert seconds to microseconds
-            this.mSensorManager.registerListener(this, this.mAccelerometer, (int)(interval*100000));
+            this.mSensorManager.registerListener(this, this.mAccelerometer, (int)(interval*1000000));
         }
     }
       


### PR DESCRIPTION
fix an Accelerometer second to microsecond convertion error in Android platform
1 second = 1000000 microsecond