### PR TITLE
Updates PR #17476 (Remove _claimedTouches Flags for listeners)

### DIFF
--- a/cocos/base/CCEventDispatcher.cpp
+++ b/cocos/base/CCEventDispatcher.cpp
@@ -973,7 +973,30 @@ void EventDispatcher::dispatchTouchEvent(EventTouch* event)
     //
     if (oneByOneListeners)
     {
-        auto mutableTouchesIter = mutableTouches.begin();
+        if (event->getEventCode() == EventTouch::EventCode::BEGAN)
+        {
+            auto fixedPriorityListeners = oneByOneListeners->getFixedPriorityListeners();
+            auto sceneGraphPriorityListeners = oneByOneListeners->getSceneGraphPriorityListeners();
+            if (fixedPriorityListeners != nullptr)
+            {
+                for (auto lIter = fixedPriorityListeners->begin(); lIter != fixedPriorityListeners->end(); lIter++)
+                {
+                    EventListenerTouchOneByOne* listener = static_cast<EventListenerTouchOneByOne*>(*lIter);
+                    listener->_claimedTouches.clear();
+                }
+            }
+
+            if (sceneGraphPriorityListeners != nullptr)
+            {
+                for (auto lIter = sceneGraphPriorityListeners->begin(); lIter != sceneGraphPriorityListeners->end(); lIter++)
+                {
+                    EventListenerTouchOneByOne* listener = static_cast<EventListenerTouchOneByOne*>(*lIter);
+                    listener->_claimedTouches.clear();
+                }
+            }
+        }
+		
+      	auto mutableTouchesIter = mutableTouches.begin();
         
         for (auto& touches : originalTouches)
         {

--- a/cocos/base/CCEventDispatcher.cpp
+++ b/cocos/base/CCEventDispatcher.cpp
@@ -979,23 +979,23 @@ void EventDispatcher::dispatchTouchEvent(EventTouch* event)
             auto sceneGraphPriorityListeners = oneByOneListeners->getSceneGraphPriorityListeners();
             if (fixedPriorityListeners != nullptr)
             {
-                for (auto lIter = fixedPriorityListeners->begin(); lIter != fixedPriorityListeners->end(); lIter++)
+                for (auto l : (*fixedPriorityListeners))
                 {
-                    EventListenerTouchOneByOne* listener = static_cast<EventListenerTouchOneByOne*>(*lIter);
+                    EventListenerTouchOneByOne* listener = static_cast<EventListenerTouchOneByOne*>(l);
                     listener->_claimedTouches.clear();
                 }
             }
 
             if (sceneGraphPriorityListeners != nullptr)
             {
-                for (auto lIter = sceneGraphPriorityListeners->begin(); lIter != sceneGraphPriorityListeners->end(); lIter++)
+                for (auto l : (*sceneGraphPriorityListeners))
                 {
-                    EventListenerTouchOneByOne* listener = static_cast<EventListenerTouchOneByOne*>(*lIter);
+                    EventListenerTouchOneByOne* listener = static_cast<EventListenerTouchOneByOne*>(l);
                     listener->_claimedTouches.clear();
                 }
             }
         }
-		
+
       	auto mutableTouchesIter = mutableTouches.begin();
         
         for (auto& touches : originalTouches)
@@ -1027,7 +1027,7 @@ void EventDispatcher::dispatchTouchEvent(EventTouch* event)
                         }
                     }
                 }
-                else if (listener->_claimedTouches.size() > 0
+                else if (!listener->_claimedTouches.empty()
                          && ((removedIter = std::find(listener->_claimedTouches.begin(), listener->_claimedTouches.end(), touches)) != listener->_claimedTouches.end()))
                 {
                     isClaimed = true;
@@ -1104,7 +1104,7 @@ void EventDispatcher::dispatchTouchEvent(EventTouch* event)
     //
     // process standard handlers 2nd
     //
-    if (allAtOnceListeners && mutableTouches.size() > 0)
+    if (allAtOnceListeners && !mutableTouches.empty())
     {
         
         auto onTouchesEvent = [&](EventListener* l) -> bool{

--- a/tests/cpp-tests/Classes/NewEventDispatcherTest/NewEventDispatcherTest.cpp
+++ b/tests/cpp-tests/Classes/NewEventDispatcherTest/NewEventDispatcherTest.cpp
@@ -27,6 +27,7 @@ EventDispatcherTests::EventDispatcherTests()
     ADD_TEST_CASE(PauseResumeTargetTest);
     ADD_TEST_CASE(Issue4129);
     ADD_TEST_CASE(Issue4160);
+    ADD_TEST_CASE(Issue17476);
     ADD_TEST_CASE(DanglingNodePointersTest);
     ADD_TEST_CASE(RegisterAndUnregisterWhileEventHanldingTest);
     ADD_TEST_CASE(WindowEventsTest);
@@ -1207,6 +1208,92 @@ std::string Issue4160::title() const
 std::string Issue4160::subtitle() const
 {
     return "Touch the red block twice \n should not crash and the red one couldn't be touched";
+}
+
+// Issue17476
+Issue17476::Issue17476()
+{
+    Vec2 origin = Director::getInstance()->getVisibleOrigin();
+    Size size = Director::getInstance()->getVisibleSize();
+    
+    auto labelFirst = Label::createWithSystemFont("First\nClick\nHere\nThe\nIntersect", "Arial", 15);
+    labelFirst->setPosition(origin + Vec2(size.width / 2, size.height / 2));
+    addChild(labelFirst);
+
+    auto sprite1 = Sprite::create();
+    sprite1->setTexture("Images/CyanSquare.png");
+    sprite1->setPosition(origin+Vec2(size.width/2, size.height/2) + Vec2(-25, 0));
+    addChild(sprite1, -10);
+
+    auto listener1 = EventListenerTouchOneByOne::create();
+    listener1->setSwallowTouches(false);
+    listener1->onTouchBegan = [=](Touch* touch, Event* event) {
+        auto ptInSprite = sprite1->convertToNodeSpace(touch->getLocation());
+        if (sprite1->getTextureRect().containsPoint(ptInSprite))
+        {
+            CCLOG("Left Square On TouchBegan !");
+            sprite1->setColor(Color3B::RED);
+            return true;
+        }
+        else
+        {
+            return false;
+        }
+    };
+
+    listener1->onTouchEnded = [=](Touch* touch, Event* event) {
+        CCLOG("Left Square On TouchEnded !");
+        sprite1->setColor(Color3B::WHITE);
+        event->stopPropagation();
+    };
+    _eventDispatcher->addEventListenerWithSceneGraphPriority(listener1, sprite1);
+    
+    auto sprite2 = Sprite::create();
+    sprite2->setTexture("Images/MagentaSquare.png");
+    sprite2->setPosition(origin+Vec2(size.width/2, size.height/2) + Vec2(25, 0));
+    addChild(sprite2, -20);
+
+    auto listener2 = EventListenerTouchOneByOne::create();
+    listener2->setSwallowTouches(false);
+    listener2->onTouchBegan = [=](Touch* touch, Event* event) {
+        auto ptInSprite = sprite2->convertToNodeSpace(touch->getLocation());
+        if (sprite2->getTextureRect().containsPoint(ptInSprite))
+        {
+            CCLOG("Right Square On TouchBegan !");
+            sprite2->setColor(Color3B::RED);
+            return true;
+        }
+        else
+        {
+            return false;
+        }
+    };
+
+    listener2->onTouchEnded = [=](Touch* touch, Event* event) {
+        CCLOG("Right Square On TouchEnded !");
+        sprite2->setColor(Color3B::WHITE);
+        event->stopPropagation();
+    };
+    _eventDispatcher->addEventListenerWithSceneGraphPriority(listener2, sprite2);
+    
+    auto labelSecond = Label::createWithSystemFont("Second Step click Here, outside the squares", \
+        "Arial", 15);
+    labelSecond->setPosition(origin + Vec2(size.width / 2, size.height / 2) + Vec2(0, -90));
+    addChild(labelSecond);
+}
+
+Issue17476::~Issue17476()
+{
+}
+
+std::string Issue17476::title() const
+{
+    return "Issue 17476: _claimedTouches not cleared!";
+}
+
+std::string Issue17476::subtitle() const
+{
+    return "First Click the intersection of the two squares, Then click outside, you will find that the bottom square responsed to the second click !";
 }
 
 // DanglingNodePointersTest

--- a/tests/cpp-tests/Classes/NewEventDispatcherTest/NewEventDispatcherTest.h
+++ b/tests/cpp-tests/Classes/NewEventDispatcherTest/NewEventDispatcherTest.h
@@ -196,6 +196,19 @@ public:
 private:
 };
 
+class Issue17476 : public EventDispatcherTestDemo
+{
+public:
+    CREATE_FUNC(Issue17476);
+	Issue17476();
+    virtual ~Issue17476();
+    
+    virtual std::string title() const override;
+    virtual std::string subtitle() const override;
+    
+private:
+};
+
 class DanglingNodePointersTest : public EventDispatcherTestDemo
 {
 public:


### PR DESCRIPTION
PR #17476
Uses range loop for clearing claimed touches in the next touch begin event.

Image We have two sprite squares, A (Left) and square B(Right), A is above of B, Both A and B have one by one touch listeners, and it will not swallow touches.

Click at the intersection of A and B, do not move
Touch press
A - onTouchBegan, return true, listener->_claimedTouches is true for A
B - onTouchBegan, return true, listener->_claimedTouches is true for B
Touch release
A - onTouchEnded, we manually call event->stopPropagation() in the onTouchEnd function !!! listener->_claimedTouches is cleared
B - Because A stopPropagation, listener->_claimedTouches is not cleared

In this case, Because A stop propagation for touch end, the listener->_claimedTouches for B will not be cleared forever ! because B has touch begin, which record the touch in listener->_claimedTouches, but it has not touch end !

