### PR TITLE
update from origin

### DIFF
--- a/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxAccelerometer.java
+++ b/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxAccelerometer.java
@@ -86,7 +86,7 @@ public class Cocos2dxAccelerometer implements SensorEventListener {
             this.mSensorManager.registerListener(this, this.mAccelerometer, SensorManager.SENSOR_DELAY_GAME);
         } else {
             //convert seconds to microseconds
-            this.mSensorManager.registerListener(this, this.mAccelerometer, (int)(interval*100000));
+            this.mSensorManager.registerListener(this, this.mAccelerometer, (int)(interval*1000000));
         }
     }
 

--- a/cocos/platform/android/jni/Java_org_cocos2dx_lib_Cocos2dxAccelerometer.cpp
+++ b/cocos/platform/android/jni/Java_org_cocos2dx_lib_Cocos2dxAccelerometer.cpp
@@ -14,7 +14,7 @@ extern "C" {
         a.x = -((double)x / TG3_GRAVITY_EARTH);
         a.y = -((double)y / TG3_GRAVITY_EARTH);
         a.z = -((double)z / TG3_GRAVITY_EARTH);
-        a.timestamp = (double)timeStamp;
+        a.timestamp = (double)timeStamp / 1e9;
 
         EventAcceleration event(a);
         Director::getInstance()->getEventDispatcher()->dispatchEvent(&event);

--- a/cocos/platform/tizen/CCDevice-tizen.cpp
+++ b/cocos/platform/tizen/CCDevice-tizen.cpp
@@ -78,7 +78,7 @@ static void accelerometer_sensor_cb(sensor_h _sensor, sensor_event_s *sensor_dat
     _acceleration->x = sensor_data->values[0] / GRAVITY_EARTH;
     _acceleration->y = sensor_data->values[1] / GRAVITY_EARTH;
     _acceleration->z = sensor_data->values[2] / GRAVITY_EARTH;
-    _acceleration->timestamp = sensor_data->timestamp;
+    _acceleration->timestamp = (double)sensor_data->timestamp / 1e3;
 
     double tmp = _acceleration->x;
     Application *app = Application::getInstance();


### PR DESCRIPTION
unify sensor timestamp units in Android / Tizen / iOS
Android use nanosecond
Tizen use millisecond
iOs use second