### PR TITLE
Add linear layout alignment options

### DIFF
--- a/cocos/ui/UILayout.cpp
+++ b/cocos/ui/UILayout.cpp
@@ -75,6 +75,7 @@ _clippingRect(Rect::ZERO),
 _clippingParent(nullptr),
 _clippingRectDirty(true),
 _stencilStateManager(new StencilStateManager()),
+_alignment(Alignment::LEFT),
 _doLayoutDirty(true),
 _isInterceptTouch(false),
 _loopFocus(false),
@@ -1905,6 +1906,19 @@ void Layout::setCameraMask(unsigned short mask, bool applyChildren)
     if (_clippingStencil){
         _clippingStencil->setCameraMask(mask, applyChildren);
     }
+}
+
+void Layout::setAlignment(Layout::Alignment alignment)
+{
+    if (_alignment != alignment) {
+        _alignment = alignment;
+        _doLayoutDirty = true;
+    }
+}
+
+Layout::Alignment Layout::getAlignment() const
+{
+    return _alignment;
 }
     
 ResourceData Layout::getRenderFile()

--- a/cocos/ui/UILayout.h
+++ b/cocos/ui/UILayout.h
@@ -91,6 +91,24 @@ public:
      *
      */
     virtual void doLayout() = 0;
+
+    /**
+     * Alignment of the items. Used only in linear layouts.
+     */
+    enum class Alignment
+    {
+        LEFT = 0,
+        TOP = 0,
+        CENTER = 1,
+        RIGHT = 2,
+        BOTTOM = 2
+    };
+
+    /**
+     * Get the alignment of the contained items. Used only in linear layouts.
+     * @return The current alignment.
+     */
+    virtual Alignment getAlignment() const = 0;
 };
 
 #if (CC_TARGET_PLATFORM == CC_PLATFORM_WINRT)
@@ -461,6 +479,18 @@ public:
      */
     virtual void setCameraMask(unsigned short mask, bool applyChildren = true) override;
 
+    /**
+     * Set the alignment of the contained items. Used only in linear layouts.
+     * @param alignment Alignment to set
+     */
+    virtual void setAlignment(Alignment alignment);
+
+    /**
+     * Get the alignment of the contained items. Used only in linear layouts.
+     * @return The current alignment.
+     */
+    virtual Alignment getAlignment() const override;
+
     ResourceData getRenderFile();
 
 CC_CONSTRUCTOR_ACCESS:
@@ -642,6 +672,8 @@ protected:
     CustomCommand _afterVisitCmdStencil;
     CustomCommand _beforeVisitCmdScissor;
     CustomCommand _afterVisitCmdScissor;
+
+    Alignment _alignment;
     
     bool _doLayoutDirty;
     bool _isInterceptTouch;

--- a/cocos/ui/UILayoutManager.cpp
+++ b/cocos/ui/UILayoutManager.cpp
@@ -46,7 +46,35 @@ void LinearHorizontalLayoutManager::doLayout(LayoutProtocol* layout)
 {
     Size layoutSize = layout->getLayoutContentSize();
     Vector<Node*> container = layout->getLayoutElements();
-    float leftBoundary = 0.0f;
+
+    float leftBoundary;
+    if (layout->getAlignment() == Layout::Alignment::LEFT) {
+        leftBoundary = 0.0f;
+    }
+    else
+    {
+        float usedWidth = 0.0f;
+        for (auto& subWidget : container) {
+            Widget* child = dynamic_cast<Widget*>(subWidget);
+            if (child)
+            {
+                LinearLayoutParameter* layoutParameter = dynamic_cast<LinearLayoutParameter*>(child->getLayoutParameter());
+                if (layoutParameter)
+                {
+                    Size cs = child->getContentSize();
+                    Margin mg = layoutParameter->getMargin();
+                    usedWidth += cs.width + mg.left + mg.right;
+                }
+            }
+        }
+
+        if (layout->getAlignment() == Layout::Alignment::CENTER) {
+            leftBoundary = (layoutSize.width - usedWidth) / 2;
+        } else {
+            leftBoundary = layoutSize.width - usedWidth;
+        }
+    }
+
     for (auto& subWidget : container)
     {
         Widget* child = dynamic_cast<Widget*>(subWidget);
@@ -102,7 +130,34 @@ void LinearVerticalLayoutManager::doLayout(LayoutProtocol* layout)
 {
     Size layoutSize = layout->getLayoutContentSize();
     Vector<Node*> container = layout->getLayoutElements();
-    float topBoundary = layoutSize.height;
+
+    float topBoundary;
+    if (layout->getAlignment() == Layout::Alignment::TOP) {
+        topBoundary = layoutSize.height;
+    }
+    else
+    {
+        float usedHeight = 0.0f;
+        for (auto& subWidget : container) {
+            Widget* child = dynamic_cast<Widget*>(subWidget);
+            if (child)
+            {
+                LinearLayoutParameter* layoutParameter = dynamic_cast<LinearLayoutParameter*>(child->getLayoutParameter());
+                if (layoutParameter)
+                {
+                    Size cs = child->getContentSize();
+                    Margin mg = layoutParameter->getMargin();
+                    usedHeight += cs.height + mg.top + mg.bottom;
+                }
+            }
+        }
+
+        if (layout->getAlignment() == Layout::Alignment::CENTER) {
+            topBoundary = (layoutSize.height - usedHeight) / 2 + usedHeight;
+        } else {
+            topBoundary = usedHeight;
+        }
+    }
     
     for (auto& subWidget : container)
     {

--- a/tests/cpp-tests/CMakeLists.txt
+++ b/tests/cpp-tests/CMakeLists.txt
@@ -98,6 +98,8 @@ set(TESTS_SRC
   Classes/LabelTest/LabelTest.cpp
   Classes/LabelTest/LabelTestNew.cpp
   Classes/LayerTest/LayerTest.cpp
+  Classes/LayoutAlignmentTest/LayoutAlignmentTest.h
+  Classes/LayoutAlignmentTest/LayoutAlignmentTest.cpp
   Classes/LightTest/LightTest.cpp
   Classes/MaterialSystemTest/MaterialSystemTest
   Classes/MenuTest/MenuTest.cpp

--- a/tests/cpp-tests/Classes/LayoutAlignmentTest/LayoutAlignmentTest.cpp
+++ b/tests/cpp-tests/Classes/LayoutAlignmentTest/LayoutAlignmentTest.cpp
@@ -1,0 +1,175 @@
+#include "LayoutAlignmentTest.h"
+#include "../testResource.h"
+#include <ui/UIVBox.h>
+#include <ui/UIHBox.h>
+#include <ui/UIText.h>
+//#include <cocos/
+
+USING_NS_CC;
+using namespace cocos2d::ui;
+
+LayoutAlignmentTests::LayoutAlignmentTests()
+{
+    ADD_TEST_CASE(LayoutAlignmentHBoxTest);
+    ADD_TEST_CASE(LayoutAlignmentVBoxTest);
+}
+
+static void addTestLabelsToLayout(Layout* layout, const std::string& textString,
+                                  LinearLayoutParameter::LinearGravity gravity)
+{
+    Text* label1 = Text::create("Align", "fonts/Marker Felt.ttf", 12);
+    Text* label2 = Text::create(textString, "fonts/Marker Felt.ttf", 12);
+
+    label1->setTextColor(Color4B::WHITE);
+    label2->setTextColor(Color4B::WHITE);
+
+    LinearLayoutParameter *layoutParam = LinearLayoutParameter::create();
+    layoutParam->setGravity(gravity);
+
+    label1->setLayoutParameter(layoutParam);
+    label2->setLayoutParameter(layoutParam);
+
+    layout->addChild(label1);
+    layout->addChild(label2);
+}
+
+static void drawBoundingBox(DrawNode* drawNode, Node* node) {
+    Rect boundingBox = node->getBoundingBox();
+
+    Vec2 a = Vec2(boundingBox.getMinX(), boundingBox.getMinY());
+    Vec2 b = Vec2(boundingBox.getMaxX(), boundingBox.getMaxY());
+
+    drawNode->drawRect(a, b, Color4F::WHITE);
+}
+
+// HBox alignment
+
+LayoutAlignmentHBoxTest::LayoutAlignmentHBoxTest()
+{
+
+}
+
+LayoutAlignmentHBoxTest::~LayoutAlignmentHBoxTest()
+{
+}
+
+std::string LayoutAlignmentHBoxTest::title() const
+{
+    return "Layout Alignment Test";
+}
+
+void LayoutAlignmentHBoxTest::onEnter()
+{
+    TestCase::onEnter();
+
+    auto visibleSize = Director::getInstance()->getVisibleSize();
+
+    auto drawNode = DrawNode::create();
+    drawNode->setPosition(Vec2(0, 0));
+    drawNode->setContentSize(visibleSize);
+    this->addChild(drawNode);
+
+    Size boxSize(200, 50);
+    float boxMargin = 10;
+    Size boxOffset(0, boxSize.height + boxMargin);
+    Vec2 boxesOrigin((visibleSize.width - boxSize.width) / 2, 60);
+
+    auto hboxAlignedLeft = HBox::create();
+    hboxAlignedLeft->setPosition(boxesOrigin + 0 * boxOffset);
+    hboxAlignedLeft->setContentSize(boxSize);
+    hboxAlignedLeft->setAlignment(Layout::Alignment::LEFT);
+    addTestLabelsToLayout(hboxAlignedLeft, "Left",
+                          LinearLayoutParameter::LinearGravity::CENTER_VERTICAL);
+    this->addChild(hboxAlignedLeft);
+
+    auto hboxAlignedCenter = HBox::create();
+    hboxAlignedCenter->setPosition(boxesOrigin + 1 * boxOffset);
+    hboxAlignedCenter->setContentSize(boxSize);
+    hboxAlignedCenter->setAlignment(Layout::Alignment::CENTER);
+    addTestLabelsToLayout(hboxAlignedCenter, "Center",
+                          LinearLayoutParameter::LinearGravity::CENTER_VERTICAL);
+    this->addChild(hboxAlignedCenter);
+
+    auto hboxAlignedRight = HBox::create();
+    hboxAlignedRight->setPosition(boxesOrigin + 2 * boxOffset);
+    hboxAlignedRight->setContentSize(boxSize);
+    hboxAlignedRight->setAlignment(Layout::Alignment::RIGHT);
+    addTestLabelsToLayout(hboxAlignedRight, "Right",
+                          LinearLayoutParameter::LinearGravity::CENTER_VERTICAL);
+    this->addChild(hboxAlignedRight);
+
+    drawBoundingBox(drawNode, hboxAlignedLeft);
+    drawBoundingBox(drawNode, hboxAlignedCenter);
+    drawBoundingBox(drawNode, hboxAlignedRight);
+}
+
+std::string LayoutAlignmentHBoxTest::subtitle() const
+{
+    return "Alignment options for HBox";
+}
+
+
+// VBox alignment
+
+LayoutAlignmentVBoxTest::LayoutAlignmentVBoxTest()
+{
+}
+
+LayoutAlignmentVBoxTest::~LayoutAlignmentVBoxTest()
+{
+}
+
+std::string LayoutAlignmentVBoxTest::title() const
+{
+    return "Layout Alignment Test";
+}
+
+void LayoutAlignmentVBoxTest::onEnter()
+{
+    TestCase::onEnter();
+
+    auto visibleSize = Director::getInstance()->getVisibleSize();
+
+    auto drawNode = DrawNode::create();
+    drawNode->setPosition(Vec2(0, 0));
+    drawNode->setContentSize(visibleSize);
+    this->addChild(drawNode);
+
+    Size boxSize(50, 180);
+    float boxMargin = 10;
+    Size boxOffset(boxSize.width + boxMargin, 0);
+    Vec2 boxesOrigin((visibleSize.width - (boxSize + boxOffset * 2).width) / 2, 60);
+
+    auto vboxAlignedTop = VBox::create();
+    vboxAlignedTop->setPosition(boxesOrigin + 0 * boxOffset);
+    vboxAlignedTop->setContentSize(boxSize);
+    vboxAlignedTop->setAlignment(Layout::Alignment::TOP);
+    addTestLabelsToLayout(vboxAlignedTop, "Top",
+                          LinearLayoutParameter::LinearGravity::CENTER_HORIZONTAL);
+    this->addChild(vboxAlignedTop);
+
+    auto vboxAlignedCenter = VBox::create();
+    vboxAlignedCenter->setPosition(boxesOrigin + 1 * boxOffset);
+    vboxAlignedCenter->setContentSize(boxSize);
+    vboxAlignedCenter->setAlignment(Layout::Alignment::CENTER);
+    addTestLabelsToLayout(vboxAlignedCenter, "Center",
+                          LinearLayoutParameter::LinearGravity::CENTER_HORIZONTAL);
+    this->addChild(vboxAlignedCenter);
+
+    auto vboxAlignedBottom = VBox::create();
+    vboxAlignedBottom->setPosition(boxesOrigin + 2 * boxOffset);
+    vboxAlignedBottom->setContentSize(boxSize);
+    vboxAlignedBottom->setAlignment(Layout::Alignment::BOTTOM);
+    addTestLabelsToLayout(vboxAlignedBottom, "Bottom",
+                          LinearLayoutParameter::LinearGravity::CENTER_HORIZONTAL);
+    this->addChild(vboxAlignedBottom);
+
+    drawBoundingBox(drawNode, vboxAlignedTop);
+    drawBoundingBox(drawNode, vboxAlignedCenter);
+    drawBoundingBox(drawNode, vboxAlignedBottom);
+}
+
+std::string LayoutAlignmentVBoxTest::subtitle() const
+{
+    return "Alignment options for VBox";
+}

--- a/tests/cpp-tests/Classes/LayoutAlignmentTest/LayoutAlignmentTest.cpp
+++ b/tests/cpp-tests/Classes/LayoutAlignmentTest/LayoutAlignmentTest.cpp
@@ -3,7 +3,6 @@
 #include <ui/UIVBox.h>
 #include <ui/UIHBox.h>
 #include <ui/UIText.h>
-//#include <cocos/
 
 USING_NS_CC;
 using namespace cocos2d::ui;

--- a/tests/cpp-tests/Classes/LayoutAlignmentTest/LayoutAlignmentTest.h
+++ b/tests/cpp-tests/Classes/LayoutAlignmentTest/LayoutAlignmentTest.h
@@ -1,0 +1,36 @@
+#ifndef _LAYOUT_ALIGNMENT_TEST_H_
+#define _LAYOUT_ALIGNMENT_TEST_H_
+
+#include "../BaseTest.h"
+
+DEFINE_TEST_SUITE(LayoutAlignmentTests);
+
+class LayoutAlignmentHBoxTest : public TestCase
+{
+public:
+    CREATE_FUNC(LayoutAlignmentHBoxTest);
+    LayoutAlignmentHBoxTest();
+    virtual ~LayoutAlignmentHBoxTest();
+
+    virtual void onEnter() override;
+    virtual std::string title() const override;
+    virtual std::string subtitle() const override;
+
+protected:
+};
+
+class LayoutAlignmentVBoxTest : public TestCase
+{
+public:
+    CREATE_FUNC(LayoutAlignmentVBoxTest);
+    LayoutAlignmentVBoxTest();
+    virtual ~LayoutAlignmentVBoxTest();
+
+    virtual void onEnter() override;
+    virtual std::string title() const override;
+    virtual std::string subtitle() const override;
+
+protected:
+};
+
+#endif

--- a/tests/cpp-tests/Classes/controller.cpp
+++ b/tests/cpp-tests/Classes/controller.cpp
@@ -52,6 +52,7 @@ public:
 #if (CC_TARGET_PLATFORM == CC_PLATFORM_ANDROID)
         addTest("JNIHelper", []() { return new JNITests(); });
 #endif
+        addTest("Layout alignment", [](){return new LayoutAlignmentTests(); });
         addTest("Material System", [](){return new MaterialSystemTest(); });
         addTest("Navigation Mesh", [](){return new NavMeshTests(); });
         addTest("Node: BillBoard Test", [](){  return new BillBoardTests(); });

--- a/tests/cpp-tests/Classes/tests.h
+++ b/tests/cpp-tests/Classes/tests.h
@@ -52,6 +52,7 @@
 #include "LabelTest/LabelTest.h"
 #include "LabelTest/LabelTestNew.h"
 #include "LayerTest/LayerTest.h"
+#include "LayoutAlignmentTest/LayoutAlignmentTest.h"
 #include "LightTest/LightTest.h"
 #include "MaterialSystemTest/MaterialSystemTest.h"
 #include "MenuTest/MenuTest.h"


### PR DESCRIPTION
I've added a pair of methods that allow changing the alignment of linear layouts (HBox and VBox).

```
class CC_GUI_DLL LayoutProtocol
{
    // [...]
    /**
     * Alignment of the items. Used only in linear layouts.
     */
    enum class Alignment
    {
        LEFT = 0,
        TOP = 0,
        CENTER = 1,
        RIGHT = 2,
        BOTTOM = 2
    };

    /**
     * Get the alignment of the contained items. Used only in linear layouts.
     * @return The current alignment.
     */
    virtual Alignment getAlignment() const = 0;
}

class CC_GUI_DLL Layout : public Widget, public LayoutProtocol
{
    // [...]
    /**
     * Set the alignment of the contained items. Used only in linear layouts.
     * @param alignment Alignment to set
     */
    virtual void setAlignment(Alignment alignment);

    /**
     * Get the alignment of the contained items. Used only in linear layouts.
     * @return The current alignment.
     */
    virtual Alignment getAlignment() const override;
    // [...]
}
```

![](http://i.imgur.com/zykrD0F.png)
![](http://i.imgur.com/duEREhM.png)

I've not tested this patch on mobile devices, but there should not be anything platform specific on it.

This was ported, mostly line by line, from [a patch I made some time ago for cocos2D-html5](https://github.com/cocos2d/cocos2d-html5/pull/3408).