### PR TITLE
Flag the end of ActionInstant and ActionInterval.

### DIFF
--- a/cocos/2d/CCActionInstant.cpp
+++ b/cocos/2d/CCActionInstant.cpp
@@ -40,9 +40,15 @@ NS_CC_BEGIN
 //
 // InstantAction
 //
+void ActionInstant::startWithTarget(Node *target)
+{
+    FiniteTimeAction::startWithTarget(target);
+    _done = false;
+}
+
 bool ActionInstant::isDone() const
 {
-    return true;
+    return _done;
 }
 
 void ActionInstant::step(float /*dt*/)
@@ -56,6 +62,7 @@ void ActionInstant::step(float /*dt*/)
     }
 #endif
     update(updateDt);
+    _done = true;
 }
 
 void ActionInstant::update(float /*time*/)

--- a/cocos/2d/CCActionInstant.h
+++ b/cocos/2d/CCActionInstant.h
@@ -59,6 +59,8 @@ public:
         return nullptr;
     }
 
+    virtual void startWithTarget(Node *target) override;
+    
     virtual bool isDone() const override;
     /**
      * @param dt In seconds.
@@ -68,6 +70,9 @@ public:
      * @param time In seconds.
      */
     virtual void update(float time) override;
+
+private:
+    bool _done;
 };
 
 /** @class Show

--- a/cocos/2d/CCActionInterval.cpp
+++ b/cocos/2d/CCActionInterval.cpp
@@ -89,17 +89,10 @@ bool ActionInterval::initWithDuration(float d)
 {
     _duration = d;
 
-    // prevent division by 0
-    // This comparison could be in step:, but it might decrease the performance
-    // by 3% in heavy based action games.
-    if (_duration <= FLT_EPSILON)
-    {
-        _duration = FLT_EPSILON;
-    }
-
     _elapsed = 0;
     _firstTick = true;
-
+    _done = false;
+    
     return true;
 }
 
@@ -117,8 +110,7 @@ bool ActionInterval::sendUpdateEventToScript(float dt, Action *actionObject)
 
 bool ActionInterval::isDone() const
 {
-    // fix #14936 _duration is not 0, but _elapsed is 0.
-    return (_elapsed + FLT_EPSILON) >= _duration;
+    return _done;
 }
 
 void ActionInterval::step(float dt)
@@ -141,6 +133,8 @@ void ActionInterval::step(float dt)
     if (sendUpdateEventToScript(updateDt, this)) return;
     
     this->update(updateDt);
+
+    _done = _elapsed >= _duration;
 }
 
 void ActionInterval::setAmplitudeRate(float /*amp*/)
@@ -162,6 +156,7 @@ void ActionInterval::startWithTarget(Node *target)
     FiniteTimeAction::startWithTarget(target);
     _elapsed = 0.0f;
     _firstTick = true;
+    _done = false;
 }
 
 //
@@ -420,11 +415,6 @@ Sequence* Sequence::reverse() const
         return Sequence::createWithTwoActions(_actions[1]->reverse(), _actions[0]->reverse());
     else
         return nullptr;
-}
-
-bool Sequence::isDone() const
-{
-  return (_last == 1) && _actions[1]->isDone();
 }
 
 //

--- a/cocos/2d/CCActionInterval.h
+++ b/cocos/2d/CCActionInterval.h
@@ -114,8 +114,9 @@ CC_CONSTRUCTOR_ACCESS:
 
 protected:
     float _elapsed;
-    bool   _firstTick;
-
+    bool _firstTick;
+    bool _done;
+    
 protected:
     bool sendUpdateEventToScript(float dt, Action *actionObject);
 };
@@ -182,7 +183,6 @@ public:
     //
     virtual Sequence* clone() const override;
     virtual Sequence* reverse() const override;
-    virtual bool isDone() const override;
     virtual void startWithTarget(Node *target) override;
     virtual void stop(void) override;
     /**

--- a/tests/cpp-tests/Classes/ActionsTest/ActionsTest.cpp
+++ b/tests/cpp-tests/Classes/ActionsTest/ActionsTest.cpp
@@ -2337,6 +2337,7 @@ void Issue14936_1::onEnter() {
     auto visibleSize = cocos2d::Director::getInstance()->getVisibleSize();
 
     _count = 0;
+
     auto counterLabel = Label::createWithTTF("0", "fonts/Marker Felt.ttf", 16.0f);
     counterLabel->setPosition(origin.x + visibleSize.width / 2, origin.y + visibleSize.height / 2);
     addChild(counterLabel);
@@ -2438,7 +2439,17 @@ void SequenceWithFinalInstant::onEnter()
          " called=%d, elapsed=%f, duration=%f",
          (int)called, action->getElapsed(), action->getDuration());
     else
-      cocos2d::log("Everything went fine.");
+      cocos2d::log("First step: everything went fine.");
+    
+    _manager->update(FLT_EPSILON);
+
+    if ( action->isDone() && called )
+      cocos2d::log("Second step: everything went fine.");
+    else
+      cocos2d::log
+        ("Action says it is done but is not."
+         " called=%d, elapsed=%f, duration=%f",
+         (int)called, action->getElapsed(), action->getDuration());
 }
 
 void SequenceWithFinalInstant::onExit()


### PR DESCRIPTION
Following #17437 and #17545.

This commit adds a flag to `ActionInstant` and `ActionInterval` to mark the end of the action.

`ActionInstant` sets the flag to true only when the action has actually been updated.

`ActionInterval` sets the flag to true only when the elapsed time becomes equal or greater than the action's duration.

`ActionInterval` does not overrides zero durations with `FLT_EPSILON` anymore. Thus a `Spawn` or a `Sequence` of several `ActionInstant` has a duration equal to zero, as expected.