### PR TITLE
Issue #16188: Fix lua-script Sprite:playAnimationOnce(animation, args) blink bug.

### DIFF
--- a/cocos/scripting/lua-bindings/script/framework/extends/SpriteEx.lua
+++ b/cocos/scripting/lua-bindings/script/framework/extends/SpriteEx.lua
@@ -27,7 +27,7 @@ local Sprite = cc.Sprite
 function Sprite:playAnimationOnce(animation, args)
     local actions = {}
 
-    local showDelay = args.showDelay or 0
+    local showDelay = args.showDelay
     if showDelay then
         self:setVisible(false)
         actions[#actions + 1] = cc.DelayTime:create(showDelay)


### PR DESCRIPTION
cocos2dx-v3.12
lua project
cocos/framework/extends/SpriteEx.lua
function Sprite:playAnimationOnce(animation, args)

```
local showDelay = args.showDelay or 0
if showDelay then
    self:setVisible(false)
    actions[#actions + 1] = cc.DelayTime:create(showDelay)
    actions[#actions + 1] = cc.Show:create()
end
```

showDelay is always not-nil, because `if 0 then` would be true in lua. it'll make sprite setVisible(false) always, then the sprite would blink once (animation-image disappear first, then appear at once).

If I want Role to do an Attack animation, the sequence would be like:
Blink -> Attack
That was so ugly.

change `local showDelay = args.showDelay or 0` to `local showDelay = args.showDelay` would be OK.
