### PR TITLE
Fixes ConsoleUploadFile test could not work on android.

### DIFF
--- a/cocos/base/CCConsole.cpp
+++ b/cocos/base/CCConsole.cpp
@@ -1346,23 +1346,24 @@ static char invalid_filename_char[] = {':', '/', '\\', '?', '%', '*', '<', '>', 
 void Console::commandUpload(int fd)
 {
     ssize_t n, rc;
-    char buf[512], c;
+    char buf[512] = {0};
+    char c = 0;
     char *ptr = buf;
     //read file name
     for( n = 0; n < sizeof(buf) - 1; n++ )
     {
-        if( (rc = recv(fd, &c, 1, 0)) ==1 ) 
+        if( (rc = recv(fd, &c, 1, 0)) == 1 )
         {
             for(char x : invalid_filename_char)
             {
-                if(c == x)
+                if (c == x)
                 {
                     const char err[] = "upload: invalid file name!\n";
                     Console::Utility::sendToConsole(fd, err, strlen(err));
                     return;
                 }
             }
-            if(c == ' ') 
+            if (c == ' ')
             {
                 break;
             }
@@ -1393,8 +1394,8 @@ void Console::commandUpload(int fd)
         Console::Utility::sendToConsole(fd, err, strlen(err));
         return;
     }
-    
-    while (true) 
+
+    while (true)
     {
         char data[4];
         for(int i = 0; i < 4; i++)
@@ -1410,9 +1411,9 @@ void Console::commandUpload(int fd)
         unsigned char *decode;
         unsigned char *in = (unsigned char *)data;
         int dt = base64Decode(in, 4, &decode);
-        for(int i = 0; i < dt; i++)
+        if (dt > 0)
         {
-            fwrite(decode+i, 1, 1, fp);
+            fwrite(decode, dt, 1, fp);
         }
         free(decode);
     }

--- a/tests/cpp-tests/Classes/ConsoleTest/ConsoleTest.cpp
+++ b/tests/cpp-tests/Classes/ConsoleTest/ConsoleTest.cpp
@@ -112,12 +112,11 @@ std::string ConsoleCustomCommand::subtitle() const
 ConsoleUploadFile::ConsoleUploadFile()
 {
     std::srand ((unsigned)time(nullptr));
-    int _id = rand()%100000;
+    int id = rand()%100000;
     char buf[32];
-    sprintf(buf, "%d", _id);
-    _target_file_name = std::string("grossini") + buf;
+    sprintf(buf, "%d", id);
+    _targetFileName = std::string("grossini") + buf + ".png";
 
-    _src_file_path = FileUtils::getInstance()->fullPathForFilename(s_pathGrossini);
     std::thread t = std::thread( &ConsoleUploadFile::uploadFile, this);
     t.detach();
 }
@@ -135,6 +134,14 @@ ConsoleUploadFile::~ConsoleUploadFile()
 
 void ConsoleUploadFile::uploadFile()
 {
+    Data srcFileData = FileUtils::getInstance()->getDataFromFile(s_pathGrossini);
+    if (srcFileData.isNull())
+    {
+        CCLOGERROR("ConsoleUploadFile: could not open file %s", s_pathGrossini);
+    }
+
+    std::string targetFileName = _targetFileName;
+
     struct addrinfo hints;
     struct addrinfo *result, *rp;
     int sfd, s;
@@ -155,13 +162,13 @@ void ConsoleUploadFile::uploadFile()
     std::string nodeName;
     if (Director::getInstance()->getConsole()->isIpv6Server())
         nodeName = "::1";
-	else
+    else
         nodeName = "localhost";
 
     s = getaddrinfo(nodeName.c_str(), "5678", &hints, &result);
     if (s != 0) 
     {
-       CCLOG("ConsoleUploadFile: getaddrinfo error");
+        CCLOG("ConsoleUploadFile: getaddrinfo error");
         return;
     }
 
@@ -193,38 +200,45 @@ void ConsoleUploadFile::uploadFile()
 
     freeaddrinfo(result);           /* No longer needed */
 
-    
-    FILE* fp = fopen(_src_file_path.c_str(), "rb");
-    if(!fp)
-    {
-        CCLOG("ConsoleUploadFile: could not open file %s", _src_file_path.c_str());
-        return;
-    }
-    
     std::string tmp = "upload";
 
     tmp += " ";
-    tmp += _target_file_name;
+    tmp += targetFileName;
     tmp += " ";
-    char cmd[512];
+    char cmd[512] = {0};
 
     strcpy(cmd, tmp.c_str());
     send(sfd,cmd,strlen(cmd),0);
+
+    size_t offset = 0;
+    auto readBuffer = [&offset](char* buf, size_t bytes, const Data& data) -> ssize_t {
+        if (offset >= data.getSize())
+            return 0;
+        ssize_t actualReadBytes = (offset + bytes) > data.getSize() ? (data.getSize() - offset) : bytes;
+        if (actualReadBytes > 0)
+        {
+            memcpy(buf, data.getBytes() + offset, actualReadBytes);
+            offset += actualReadBytes;
+        }
+        return actualReadBytes;
+    };
+
     while(true)
     {
         char buffer[3], *out;
         unsigned char *in;
         in = (unsigned char *)buffer;
         // copy the file into the buffer:
-        size_t ret = fread(buffer, 1, 3, fp);
+        ssize_t ret = readBuffer(buffer, 3, srcFileData);
         if (ret > 0)
         {
-            base64Encode(in, (unsigned int)ret, &out);
-            send(sfd, out, 4, 0);
+            int len = base64Encode(in, (unsigned int)ret, &out);
+            send(sfd, out, len, 0);
             free(out);
             if(ret < 3)
             {
                 //eof
+                log("Reach the end, total send: %d bytes", (int)offset);
                 break;
             }
         }
@@ -236,16 +250,16 @@ void ConsoleUploadFile::uploadFile()
     }
     char l = '\n';
     send(sfd, &l, 1, 0);
-    // terminate
-    fclose (fp);
-   
+
+    // Sleep 1s to wait server to receive all data.
+    std::this_thread::sleep_for(std::chrono::seconds(1));
+
 #if (CC_TARGET_PLATFORM == CC_PLATFORM_WIN32) || (CC_TARGET_PLATFORM == CC_PLATFORM_WINRT)
-        closesocket(sfd);
-        WSACleanup();
+    closesocket(sfd);
+    WSACleanup();
 #else
-        close(sfd);
+    close(sfd);
 #endif
-    return;
 }
 
 std::string ConsoleUploadFile::title() const
@@ -259,6 +273,6 @@ std::string ConsoleUploadFile::subtitle() const
     
     std::string writablePath = sharedFileUtils->getWritablePath();
 
-    return "file uploaded to:" + writablePath + _target_file_name;
+    return "file uploaded to:" + writablePath + _targetFileName;
 }
 

--- a/tests/cpp-tests/Classes/ConsoleTest/ConsoleTest.h
+++ b/tests/cpp-tests/Classes/ConsoleTest/ConsoleTest.h
@@ -72,10 +72,10 @@ protected:
     virtual ~ConsoleUploadFile();
 
     void uploadFile();
-    std::string _src_file_path;
-    std::string _target_file_name;
 private:
     CC_DISALLOW_COPY_AND_ASSIGN(ConsoleUploadFile);
+
+    std::string _targetFileName;
 };
 
 #endif // _CONSOLE_TEST_H_


### PR DESCRIPTION
* Should not use fread to read file from assets, uses FileUtils::getDataFromFile instead.
* Client socket should not be closed immediatelly after ::send. Otherwise, sever may will receive “Connection reset by peer - Errno 104” error on some platforms. It could be 100% reproduced on Android.