### PR TITLE
Fixed FileUtils::getFileSize() on android platform

### DIFF
--- a/cocos/platform/android/CCFileUtils-android.cpp
+++ b/cocos/platform/android/CCFileUtils-android.cpp
@@ -251,6 +251,32 @@ bool FileUtilsAndroid::isAbsolutePath(const std::string& strPath) const
     return false;
 }
 
+long FileUtilsAndroid::getFileSize(const std::string& filepath)
+{
+    long size = FileUtils::getFileSize(filepath);
+    if (size != -1) {
+        return size;
+    }
+    
+    if (FileUtilsAndroid::assetmanager)
+    {
+        string relativePath = filepath;
+        if (filepath.find(_defaultResRootPath) == 0)
+        {
+            relativePath = filepath.substr(_defaultResRootPath.size());
+        }
+        
+        AAsset* asset = AAssetManager_open(FileUtilsAndroid::assetmanager, relativePath.data(), AASSET_MODE_UNKNOWN);
+        if (asset)
+        {
+            size = AAsset_getLength(asset);
+            AAsset_close(asset);
+        }
+    }
+    
+    return size;
+}
+
 FileUtils::Status FileUtilsAndroid::getContents(const std::string& filename, ResizableBuffer* buffer)
 {
     static const std::string apkprefix("assets/");

--- a/cocos/platform/android/CCFileUtils-android.h
+++ b/cocos/platform/android/CCFileUtils-android.h
@@ -70,6 +70,8 @@ public:
 
     virtual std::string getWritablePath() const override;
     virtual bool isAbsolutePath(const std::string& strPath) const override;
+    
+    virtual long getFileSize(const std::string& filepath) override;
 
 private:
     virtual bool isFileExistInternal(const std::string& strFilePath) const override;


### PR DESCRIPTION
Issue: cocos2d/cocos2d-x#17631

Description: FileUtils::getFileSize("anyInBundleFile.json") always returns -1 on android platform

How to check: on android build now FileUtils::getFileSize("Images/grossini.png") > 0