### PR TITLE
Fix can't open URLs that have '&' character on Linux.

### DIFF
--- a/cocos/platform/linux/CCApplication-linux.cpp
+++ b/cocos/platform/linux/CCApplication-linux.cpp
@@ -143,7 +143,7 @@ std::string Application::getVersion()
 
 bool Application::openURL(const std::string &url)
 {
-    std::string op = std::string("xdg-open ").append(url);
+    std::string op = std::string("xdg-open '").append(url).append("'");
     return system(op.c_str()) == 0;
 }
 


### PR DESCRIPTION
See discussion: http://discuss.cocos2d-x.org/t/small-fix-for-application-openurl-linux/35993

> Url-addresses containing the "&" symbol do not open correctly in Linux.
> 
> Please, replace string in cocos/platform/linux/CCApplication-linux.cpp from
> 
> std::string op = std::string("xdg-open ").append(url);
> to
> 
> std::string op = std::string("xdg-open '").append(url).append("'");
> in method openURL.