### PR TITLE
[ci skip]fix some error for Android Studio project

### DIFF
--- a/templates/cpp-template-default/proj.android-studio/app/build.gradle
+++ b/templates/cpp-template-default/proj.android-studio/app/build.gradle
@@ -21,10 +21,12 @@ android {
                     arguments 'NDK_TOOLCHAIN_VERSION=4.9'
                     arguments 'APP_PLATFORM=android-'+PROP_TARGET_SDK_VERSION
                     
-                    def module_paths = [project.file("../../cocos2d"),
-                                        project.file("../../cocos2d/cocos"),
-                                        project.file("../../cocos2d/external")]
+                    def module_paths = [project.file("../../cocos2d").absolutePath,
+                                        project.file("../../cocos2d/cocos").absolutePath,
+                                        project.file("../../cocos2d/external").absolutePath]
                     if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+                        // should use '/'
+                        module_paths = module_paths.collect {it.replaceAll('\\\\', '/')}
                         arguments 'NDK_MODULE_PATH=' + module_paths.join(";")
                     }
                     else {

--- a/templates/js-template-default/frameworks/runtime-src/proj.android-studio/app/build.gradle
+++ b/templates/js-template-default/frameworks/runtime-src/proj.android-studio/app/build.gradle
@@ -21,10 +21,12 @@ android {
                     arguments 'NDK_TOOLCHAIN_VERSION=4.9'
                     arguments 'APP_PLATFORM=android-'+PROP_TARGET_SDK_VERSION
 
-                    def module_paths = [project.file("../../../cocos2d-x"),
-                                        project.file("../../../cocos2d-x/cocos"),
-                                        project.file("../../../cocos2d-x/external")]
+                    def module_paths = [project.file("../../../cocos2d-x").absolutePath,
+                                        project.file("../../../cocos2d-x/cocos").absolutePath,
+                                        project.file("../../../cocos2d-x/external").absolutePath]
                     if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+                        // should use '/'
+                        module_paths = module_paths.collect {it.replaceAll('\\\\', '/')}
                         arguments 'NDK_MODULE_PATH=' + module_paths.join(";")
                     }
                     else {

--- a/templates/lua-template-default/frameworks/runtime-src/proj.android-studio/app/build.gradle
+++ b/templates/lua-template-default/frameworks/runtime-src/proj.android-studio/app/build.gradle
@@ -21,10 +21,12 @@ android {
                     arguments 'NDK_TOOLCHAIN_VERSION=4.9'
                     arguments 'APP_PLATFORM=android-'+PROP_TARGET_SDK_VERSION
 
-                    def module_paths = [project.file("../../../cocos2d-x"),
-                                        project.file("../../../cocos2d-x/cocos"),
-                                        project.file("../../../cocos2d-x/external")]
+                    def module_paths = [project.file("../../../cocos2d-x").absolutePath,
+                                        project.file("../../../cocos2d-x/cocos").absolutePath,
+                                        project.file("../../../cocos2d-x/external").absolutePath]
                     if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+                        // should use '/'
+                        module_paths = module_paths.collect {it.replaceAll('\\\\', '/')}
                         arguments 'NDK_MODULE_PATH=' + module_paths.join(";")
                     }
                     else {

--- a/tests/cpp-empty-test/proj.android-studio/app/build.gradle
+++ b/tests/cpp-empty-test/proj.android-studio/app/build.gradle
@@ -21,10 +21,12 @@ android {
                     arguments 'NDK_TOOLCHAIN_VERSION=4.9'
                     arguments 'APP_PLATFORM=android-'+PROP_TARGET_SDK_VERSION
 
-                    def module_paths = [project.file("../../../.."),
-                                        project.file("../../../../cocos"),
-                                        project.file("../../../../external")]
+                    def module_paths = [project.file("../../../..").absolutePath,
+                                        project.file("../../../../cocos").absolutePath,
+                                        project.file("../../../../external").absolutePath]
                     if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+                        // should use '/'
+                        module_paths = module_paths.collect {it.replaceAll('\\\\', '/')}
                         arguments 'NDK_MODULE_PATH=' + module_paths.join(";")
                     }
                     else {

--- a/tests/cpp-tests/proj.android-studio/app/build.gradle
+++ b/tests/cpp-tests/proj.android-studio/app/build.gradle
@@ -21,10 +21,12 @@ android {
                     arguments 'NDK_TOOLCHAIN_VERSION=4.9'
                     arguments 'APP_PLATFORM=android-'+PROP_TARGET_SDK_VERSION
 
-                    def module_paths = [project.file("../../../.."),
-                                        project.file("../../../../cocos"),
-                                        project.file("../../../../external")]
+                    def module_paths = [project.file("../../../..").absolutePath,
+                                        project.file("../../../../cocos").absolutePath,
+                                        project.file("../../../../external").absolutePath]
                     if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+                        // should use '/'
+                        module_paths = module_paths.collect {it.replaceAll('\\\\', '/')}
                         arguments 'NDK_MODULE_PATH=' + module_paths.join(";")
                     }
                     else {

--- a/tests/js-tests/project/proj.android-studio/app/build.gradle
+++ b/tests/js-tests/project/proj.android-studio/app/build.gradle
@@ -21,10 +21,12 @@ android {
                     arguments 'NDK_TOOLCHAIN_VERSION=4.9'
                     arguments 'APP_PLATFORM=android-'+PROP_TARGET_SDK_VERSION
                     
-                    def module_paths = [project.file("../../../.."),
-                                        project.file("../../../../cocos"),
-                                        project.file("../../../../external")]
+                    def module_paths = [project.file("../../../../..").absolutePath,
+                                        project.file("../../../../../cocos").absolutePath,
+                                        project.file("../../../../../external").absolutePath]
                     if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+                        // should use '/'
+                        module_paths = module_paths.collect {it.replaceAll('\\\\', '/')}
                         arguments 'NDK_MODULE_PATH=' + module_paths.join(";")
                     }
                     else {

--- a/tests/js-tests/project/proj.android-studio/app/jni/Application.mk
+++ b/tests/js-tests/project/proj.android-studio/app/jni/Application.mk
@@ -6,6 +6,7 @@ APP_STL := gnustl_static
 APP_CPPFLAGS := -frtti -DCC_ENABLE_CHIPMUNK_INTEGRATION=1 -std=c++11 -fsigned-char
 APP_LDFLAGS := -latomic
 APP_ABI := armeabi
+APP_SHORT_COMMANDS := true
 
 ifeq ($(NDK_DEBUG),1)
   APP_CPPFLAGS += -DCOCOS2D_DEBUG=1

--- a/tests/js-tests/project/proj.android/jni/Application.mk
+++ b/tests/js-tests/project/proj.android/jni/Application.mk
@@ -6,7 +6,7 @@ APP_STL := gnustl_static
 APP_CPPFLAGS := -frtti -DCC_ENABLE_CHIPMUNK_INTEGRATION=1 -std=c++11 -fsigned-char
 APP_LDFLAGS := -latomic
 APP_ABI := armeabi
-#APP_ABI := arm64-v8a
+APP_SHORT_COMMANDS := true
 
 
 ifeq ($(NDK_DEBUG),1)

--- a/tests/lua-empty-test/project/proj.android-studio/app/build.gradle
+++ b/tests/lua-empty-test/project/proj.android-studio/app/build.gradle
@@ -21,10 +21,12 @@ android {
                     arguments 'NDK_TOOLCHAIN_VERSION=4.9'
                     arguments 'APP_PLATFORM=android-'+PROP_TARGET_SDK_VERSION
                     
-                    def module_paths = [project.file("../../../../.."),
-                                        project.file("../../../../../cocos"),
-                                        project.file("../../../../../external")]
+                    def module_paths = [project.file("../../../../..").absolutePath,
+                                        project.file("../../../../../cocos").absolutePath,
+                                        project.file("../../../../../external").absolutePath]
                     if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+                        // should use '/'
+                        module_paths = module_paths.collect {it.replaceAll('\\\\', '/')}
                         arguments 'NDK_MODULE_PATH=' + module_paths.join(";")
                     }
                     else {

--- a/tests/lua-empty-test/project/proj.android-studio/app/jni/Application.mk
+++ b/tests/lua-empty-test/project/proj.android-studio/app/jni/Application.mk
@@ -3,6 +3,7 @@ APP_STL := gnustl_static
 APP_CPPFLAGS := -frtti -DCC_ENABLE_CHIPMUNK_INTEGRATION=1 -std=c++11 -fsigned-char
 APP_LDFLAGS := -latomic
 APP_ABI := armeabi
+APP_SHORT_COMMANDS := true
 
 
 ifeq ($(NDK_DEBUG),1)

--- a/tests/lua-empty-test/project/proj.android/jni/Application.mk
+++ b/tests/lua-empty-test/project/proj.android/jni/Application.mk
@@ -3,7 +3,7 @@ APP_STL := gnustl_static
 APP_CPPFLAGS := -frtti -DCC_ENABLE_CHIPMUNK_INTEGRATION=1 -std=c++11 -fsigned-char
 APP_LDFLAGS := -latomic
 APP_ABI := armeabi
-#APP_ABI := arm64-v8a
+APP_SHORT_COMMANDS := true
 
 
 ifeq ($(NDK_DEBUG),1)

--- a/tests/lua-tests/project/proj.android-studio/app/build.gradle
+++ b/tests/lua-tests/project/proj.android-studio/app/build.gradle
@@ -21,10 +21,12 @@ android {
                     arguments 'NDK_TOOLCHAIN_VERSION=4.9'
                     arguments 'APP_PLATFORM=android-'+PROP_TARGET_SDK_VERSION
                     
-                    def module_paths = [project.file("../../../../.."),
-                                        project.file("../../../../../cocos"),
-                                        project.file("../../../../../external")]
+                    def module_paths = [project.file("../../../../..").absolutePath,
+                                        project.file("../../../../../cocos").absolutePath,
+                                        project.file("../../../../../external").absolutePath]
                     if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+                        // should use '/'
+                        module_paths = module_paths.collect {it.replaceAll('\\\\', '/')}
                         arguments 'NDK_MODULE_PATH=' + module_paths.join(";")
                     }
                     else {

--- a/tests/lua-tests/project/proj.android/jni/Application.mk
+++ b/tests/lua-tests/project/proj.android/jni/Application.mk
@@ -3,7 +3,6 @@ APP_STL := gnustl_static
 APP_CPPFLAGS := -frtti -DCC_ENABLE_CHIPMUNK_INTEGRATION=1 -std=c++11 -fsigned-char
 APP_LDFLAGS := -latomic
 APP_ABI := armeabi
-#APP_ABI := arm64-v8a
 APP_SHORT_COMMANDS := true
 
 


### PR DESCRIPTION
NDK_MODULE_PATH requires the path using`/` on Windows, or it may meet problem. For example, if i put engine into root of `c:`, it will not find some module path. Can refer to [this doc](https://chromium.googlesource.com/android_tools/+/master-backup/ndk/docs/IMPORT-MODULE.html#56) for detail information.

APP_SHORT_COMMANDS needs to be enabled, it is useful on Windows,  where the command line accepts a maximum of only of 8191 characters. More detail information can refer to [this doc](https://developer.android.com/ndk/guides/android_mk.html).