### PR TITLE
cc.Follow not working on mobile

### DIFF
--- a/cocos/scripting/js-bindings/script/jsb_create_apis.js
+++ b/cocos/scripting/js-bindings/script/jsb_create_apis.js
@@ -427,8 +427,8 @@ cc.Speed.prototype._ctor = function(action, speed) {
 
 cc.Follow.prototype._ctor = function (followedNode, rect) {
     if(followedNode)
-        rect ? ret.initWithTarget(followedNode, rect)
-             : ret.initWithTarget(followedNode);
+        rect ? this.initWithTarget(followedNode, rect)
+             : this.initWithTarget(followedNode);
 };
 
 cc.OrbitCamera.prototype._ctor = function (t, radius, deltaRadius, angleZ, deltaAngleZ, angleX, deltaAngleX) {


### PR DESCRIPTION
When using a cc.Follow action, I've tested on mobile devices (Android & iOS) and it's not working. This change fixed the problem.