### PR TITLE
[Label] Fix distance map computation

### DIFF
--- a/cocos/2d/CCFontFreeType.cpp
+++ b/cocos/2d/CCFontFreeType.cpp
@@ -477,7 +477,7 @@ unsigned char * makeDistanceMap( unsigned char *img, long width, long height)
     {
         for (j = 0; j < height; ++j)
         {
-            data[j * outWidth + FontFreeType::DistanceMapSpread + i] = img[j * width + i] / 255.0;
+            data[(j + FontFreeType::DistanceMapSpread) * outWidth + FontFreeType::DistanceMapSpread + i] = img[j * width + i] / 255.0;
         }
     }
 


### PR DESCRIPTION
**Problem:**

Distance map was not computed correctly. Some characters were "cut" and were not shown properly. You can see a label displaying the problem in the image below (notice S, O, P and T characters for example):

<img width="617" alt="captura de pantalla 2017-04-07 a las 13 24 58" src="https://cloud.githubusercontent.com/assets/1990532/24798354/c0b7f0b6-1b95-11e7-8145-d4b444e73bcb.png">

Here you can see the distance map texture generated for that text:

<img width="986" alt="captura de pantalla 2017-04-07 a las 11 26 52" src="https://cloud.githubusercontent.com/assets/1990532/24798397/03451bac-1b96-11e7-9178-ca1d98e25006.png">

You can see 2 problems in the generated texture:
1- The distance map spread added to each char glyph is greater below the glyph than above the glyph when it should be the same.
2- Glyphs are not fading out correctly producing hard edges instead of a smooth gradient.

**Fixes:**
- Commit ef6c5feb63d76bce3747c3b3582d8d6168a8b795 fixes the first problem. 

You can see in the generated texture how the spread now is equal below and above the glyph:

<img width="986" alt="captura de pantalla 2017-04-07 a las 11 30 15" src="https://cloud.githubusercontent.com/assets/1990532/24798573/f2e3389c-1b96-11e7-8ee9-d0d79c0e450e.png">

- Commit 504b26834b8c354737b3f2349312c1663b3af325 fixes the second problem. It uses the same solution applied in [freetype-gl](https://github.com/rougier/freetype-gl).

You can see in the generated texture how the hard edges disappear and now there is a smooth gradient.

<img width="953" alt="captura de pantalla 2017-04-07 a las 11 35 15" src="https://cloud.githubusercontent.com/assets/1990532/24798637/484ebc66-1b97-11e7-9574-5e0eec413b6a.png">

**Final result:**

<img width="594" alt="captura de pantalla 2017-04-07 a las 13 25 30" src="https://cloud.githubusercontent.com/assets/1990532/24798642/4f89133c-1b97-11e7-9e2d-a95b4c2261d0.png">

 
