### PR TITLE
Fixed memory leaks in CCLabel.cpp

### DIFF
--- a/cocos/2d/CCLabel.cpp
+++ b/cocos/2d/CCLabel.cpp
@@ -635,6 +635,11 @@ bool Label::setBMFontFilePath(const std::string& bmfontFilePath, const Vec2& ima
         return false;
     }
 
+    if (newAtlas == _fontAtlas)
+    {
+        FontAtlasCache::releaseFontAtlas(_fontAtlas);
+    }
+
     //assign the default fontSize
     if (std::abs(fontSize) < FLT_EPSILON) {
         FontFNT *bmFont = (FontFNT*)newAtlas->getFont();
@@ -974,6 +979,11 @@ bool Label::setTTFConfigInternal(const TTFConfig& ttfConfig)
     {
         reset();
         return false;
+    }
+
+    if (newAtlas == _fontAtlas)
+    {
+        FontAtlasCache::releaseFontAtlas(_fontAtlas);
     }
 
     _currentLabelType = LabelType::TTF;


### PR DESCRIPTION
@flener pointed out that there's a memory leak when executing:

````cpp
auto ttf = Label::createWithTTF("TTF", "fonts/Marker Felt.ttf", 24);
ttf->setPosition(visibleSize/2);
ttf->setOverflow(Label::Overflow::SHRINK);
ttf->setDimensions(ttf->getContentSize().width,ttf->getContentSize().height);
this->addChild(ttf);
````

Turns out `valgrind` also finds a memory leak when doing the same but with bitmap fonts:

````cpp
auto bmf = Label::createWithBMFont("fonts/konqa32.fnt", "BMF");
bmf->setPosition(visibleSize/4);
bmf->setOverflow(Label::Overflow::SHRINK);
bmf->setDimensions(bmf->getContentSize().width,bmf->getContentSize().height);
addChild(bmf);
````

This pull request fixes #17639. See @flener's report [in the forums](http://discuss.cocos2d-x.org/t/bug-report-memory-leak-on-label-setdimentions/36018) for more information. Both cases boil down to be the same issue.

Issue #17380 could be related.