### PR TITLE
fixed #17665: [android] Crash while launching on the devices only support OpenGL ES 2.

### DIFF
--- a/cocos/platform/android/Android.mk
+++ b/cocos/platform/android/Android.mk
@@ -27,8 +27,7 @@ LOCAL_C_INCLUDES := $(LOCAL_PATH) \
                     $(LOCAL_PATH)/.. \
                     $(LOCAL_PATH)/../.. \
 
-LOCAL_EXPORT_LDLIBS := -lGLESv1_CM \
-                       -lGLESv2 \
+LOCAL_EXPORT_LDLIBS := -lGLESv2 \
                        -lEGL \
                        -llog \
                        -landroid

--- a/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxActivity.java
+++ b/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxActivity.java
@@ -405,7 +405,7 @@ public abstract class Cocos2dxActivity extends Activity implements Cocos2dxHelpe
             EGLContext context = egl.eglCreateContext(
                 display, eglConfig, EGL10.EGL_NO_CONTEXT, attributes);
 
-            if (context == null) {
+            if (context == null || EGL10.EGL_NO_CONTEXT == context) {
                 attributes = new int[] {EGL_CONTEXT_CLIENT_VERSION, 2, EGL10.EGL_NONE };
                 context = egl.eglCreateContext(
                     display, eglConfig, EGL10.EGL_NO_CONTEXT, attributes);


### PR DESCRIPTION
egl.eglCreateContext may return non-null but EGL10.EGL_NO_CONTEXT value.
It will cause create a EGL env with a EGL_NO_CONTEXT egl context which will cause crash.