### PR TITLE
[android] Fixes that android studio project will be created with a default package name ‘org.cocos2dx.MyLuaGame’.

### DIFF
--- a/templates/lua-template-default/frameworks/runtime-src/proj.android-studio/app/build.gradle
+++ b/templates/lua-template-default/frameworks/runtime-src/proj.android-studio/app/build.gradle
@@ -7,7 +7,7 @@ android {
     buildToolsVersion "25.0.0"
 
     defaultConfig {
-        applicationId "org.cocos2dx.MyLuaGame"
+        applicationId "org.cocos2dx.hellolua"
         minSdkVersion 10
         targetSdkVersion PROP_TARGET_SDK_VERSION
         versionCode 1


### PR DESCRIPTION
Fixed http://punchbox.info:3000/issues/26257