### PR TITLE
fix to problem with updating APK in Google Play keeping old OBB

### DIFF
--- a/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxHelper.java
+++ b/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxHelper.java
@@ -197,7 +197,7 @@ public class Cocos2dxHelper {
 
             String pathToOBB = Environment.getExternalStorageDirectory().getAbsolutePath() + "/Android/obb/" + Cocos2dxHelper.sPackageName;
 
-			// Listing all files inside the folder (pathToOBB) where OBB files are expected to be found.
+	    	// Listing all files inside the folder (pathToOBB) where OBB files are expected to be found.
             String[] fileNames = new File(pathToOBB).list(new FilenameFilter() { // Using filter to pick up only main OBB file name.
                 public boolean accept(File dir, String name) {
                     return name.startsWith("main.") && name.endsWith(".obb");  // It's possible to filter only by extension here to get path to patch OBB file also.
@@ -205,7 +205,7 @@ public class Cocos2dxHelper {
             });
 
             String fullPathToOBB = "";
-            if (fileNames.length > 0)  // If there is at least 1 element inside the array with OBB file names, then we may think fileNames[0] will have desired main OBB file name.
+            if (fileNames != null && fileNames.length > 0)  // If there is at least 1 element inside the array with OBB file names, then we may think fileNames[0] will have desired main OBB file name.
                 fullPathToOBB = pathToOBB + "/" + fileNames[0];  // Composing full file name for main OBB file.
 
             File obbFile = new File(fullPathToOBB);

--- a/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxHelper.java
+++ b/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxHelper.java
@@ -56,6 +56,7 @@ import com.enhance.gameservice.IGameTuningService;
 
 import java.io.IOException;
 import java.io.File;
+import java.io.FilenameFilter;
 import java.io.UnsupportedEncodingException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -193,16 +194,23 @@ public class Cocos2dxHelper {
     public static String getAssetsPath()
     {
         if (Cocos2dxHelper.sAssetsPath == "") {
-            int versionCode = 1;
-            try {
-                versionCode = Cocos2dxHelper.sActivity.getPackageManager().getPackageInfo(Cocos2dxHelper.sPackageName, 0).versionCode;
-            } catch (NameNotFoundException e) {
-                e.printStackTrace();
-            }
-            String pathToOBB = Environment.getExternalStorageDirectory().getAbsolutePath() + "/Android/obb/" + Cocos2dxHelper.sPackageName + "/main." + versionCode + "." + Cocos2dxHelper.sPackageName + ".obb";
-            File obbFile = new File(pathToOBB);
+
+            String pathToOBB = Environment.getExternalStorageDirectory().getAbsolutePath() + "/Android/obb/" + Cocos2dxHelper.sPackageName;
+
+			// Listing all files inside the folder (pathToOBB) where OBB files are expected to be found.
+            String[] fileNames = new File(pathToOBB).list(new FilenameFilter() { // Using filter to pick up only main OBB file name.
+                public boolean accept(File dir, String name) {
+                    return name.startsWith("main.") && name.endsWith(".obb");  // It's possible to filter only by extension here to get path to patch OBB file also.
+                }
+            });
+
+            String fullPathToOBB = "";
+            if (fileNames.length > 0)  // If there is at least 1 element inside the array with OBB file names, then we may think fileNames[0] will have desired main OBB file name.
+                fullPathToOBB = pathToOBB + "/" + fileNames[0];  // Composing full file name for main OBB file.
+
+            File obbFile = new File(fullPathToOBB);
             if (obbFile.exists())
-                Cocos2dxHelper.sAssetsPath = pathToOBB;
+                Cocos2dxHelper.sAssetsPath = fullPathToOBB;
             else
                 Cocos2dxHelper.sAssetsPath = Cocos2dxHelper.sActivity.getApplicationInfo().sourceDir;
         }


### PR DESCRIPTION
This patch fixes the problem when we are unable to keep OBB from previous version when we are uploading new .apk to Google Play.
It was discussed here:
http://discuss.cocos2d-x.org/t/problem-with-updating-apk-in-google-play-keeping-obb-from-previous-version-because-versioncode-changes/36039