### PR TITLE
Avoid of type overflow while list size calculation.

### DIFF
--- a/cocos/ui/UIListView.cpp
+++ b/cocos/ui/UIListView.cpp
@@ -113,7 +113,7 @@ void ListView::updateInnerContainerSize()
         case Direction::VERTICAL:
         {
             size_t length = _items.size();
-            float totalHeight = (length - 1) * _itemsMargin;
+            float totalHeight = (length == 0) ? 0.0f : (length - 1) * _itemsMargin;
             for (auto& item : _items)
             {
                 totalHeight += item->getContentSize().height;
@@ -126,7 +126,7 @@ void ListView::updateInnerContainerSize()
         case Direction::HORIZONTAL:
         {
             size_t length = _items.size();
-            float totalWidth = (length - 1) * _itemsMargin;
+            float totalHeight = (length == 0) ? 0.0f : (length - 1) * _itemsMargin;
             for (auto& item : _items)
             {
                 totalWidth += item->getContentSize().width;


### PR DESCRIPTION
If _items container is empty `(length - 1) * _itemsMargin` will be large positive value. 
Using `size_t` causes type overflow and large positive sizes.
Using int will cause negative size values.
Direct check looks like the best way.