### PR TITLE
remove APP_SHORT_COMMANDS setting

### DIFF
--- a/templates/cpp-template-default/proj.android/jni/Application.mk
+++ b/templates/cpp-template-default/proj.android/jni/Application.mk
@@ -4,7 +4,8 @@ APP_CPPFLAGS := -frtti -DCC_ENABLE_CHIPMUNK_INTEGRATION=1 -std=c++11 -fsigned-ch
 APP_LDFLAGS := -latomic
 
 APP_ABI := armeabi
-APP_SHORT_COMMANDS := true
+# developers report it will cause error on Windows
+# APP_SHORT_COMMANDS := true
 
 
 ifeq ($(NDK_DEBUG),1)

--- a/templates/js-template-default/frameworks/runtime-src/proj.android/jni/Application.mk
+++ b/templates/js-template-default/frameworks/runtime-src/proj.android/jni/Application.mk
@@ -7,7 +7,8 @@ APP_CPPFLAGS := -frtti -DCC_ENABLE_CHIPMUNK_INTEGRATION=1 -std=c++11 -fsigned-ch
 APP_LDFLAGS := -latomic
 
 APP_ABI := armeabi
-APP_SHORT_COMMANDS := true
+# developers report it will cause error on Windows
+# APP_SHORT_COMMANDS := true
 
 USE_ARM_MODE := 1
 

--- a/templates/lua-template-default/frameworks/runtime-src/proj.android/jni/Application.mk
+++ b/templates/lua-template-default/frameworks/runtime-src/proj.android/jni/Application.mk
@@ -4,7 +4,8 @@ APP_CPPFLAGS := -frtti -DCC_ENABLE_CHIPMUNK_INTEGRATION=1 -std=c++11 -fsigned-ch
 APP_LDFLAGS := -latomic
 
 APP_ABI := armeabi
-APP_SHORT_COMMANDS := true
+# developers report it will cause error on Windows
+# APP_SHORT_COMMANDS := true
 
 
 ifeq ($(NDK_DEBUG),1)


### PR DESCRIPTION
some developers report it will cause error on Windows though i can not reproduce it. It is strange, the setting is used to resolve command length limitation on Windows.