### PR TITLE
Changing AsyncTaskPool/Scheduler to better leverage move semantics

### DIFF
--- a/cocos/base/CCAsyncTaskPool.h
+++ b/cocos/base/CCAsyncTaskPool.h
@@ -89,11 +89,19 @@ public:
      * @param type task type is io task, network task or others, each type of task has a thread to deal with it.
      * @param callback callback when the task is finished. The callback is called in the main thread instead of task thread.
      * @param callbackParam parameter used by the callback.
-     * @param f task can be lambda function.
+     * @param task: task can be lambda function to be performed off thread.
      * @lua NA
      */
-    template<class F>
-    inline void enqueue(TaskType type, const TaskCallBack& callback, void* callbackParam, F&& f);
+    void enqueue(TaskType type, TaskCallBack callback, void* callbackParam, std::function<void()> task);
+
+    /**
+    * Enqueue a asynchronous task.
+    *
+    * @param type task type is io task, network task or others, each type of task has a thread to deal with it.
+    * @param task: task can be lambda function to be performed off thread.
+    * @lua NA
+    */
+    void enqueue(AsyncTaskPool::TaskType type, std::function<void()> task);
     
 CC_CONSTRUCTOR_ACCESS:
     AsyncTaskPool();
@@ -132,7 +140,7 @@ protected:
                                           }
                                           
                                           task();
-                                          Director::getInstance()->getScheduler()->performFunctionInCocosThread([&, callback]{ callback.callback(callback.callbackParam); });
+                                          Director::getInstance()->getScheduler()->performFunctionInCocosThread(std::bind(callback.callback, callback.callbackParam));
                                       }
                                   }
                                   );
@@ -159,11 +167,13 @@ protected:
             while (_taskCallBacks.size())
                 _taskCallBacks.pop();
         }
-        template<class F>
-        void enqueue(const TaskCallBack& callback, void* callbackParam, F&& f)
+
+        void enqueue(TaskCallBack callback, void* callbackParam, std::function<void()> task)
         {
-            auto task = f;//std::bind(std::forward<F>(f), std::forward<Args>(args)...);
-            
+            AsyncTaskCallBack taskCallBack;
+            taskCallBack.callback = std::move(callback);
+            taskCallBack.callbackParam = callbackParam;
+
             {
                 std::unique_lock<std::mutex> lock(_queueMutex);
                 
@@ -174,11 +184,8 @@ protected:
                     return;
                 }
                 
-                AsyncTaskCallBack taskCallBack;
-                taskCallBack.callback = callback;
-                taskCallBack.callbackParam = callbackParam;
-                _tasks.emplace([task](){ task(); });
-                _taskCallBacks.emplace(taskCallBack);
+                _tasks.push(task);
+                _taskCallBacks.push(std::move(taskCallBack));
             }
             _condition.notify_one();
         }
@@ -188,7 +195,7 @@ protected:
         std::thread _thread;
         // the task queue
         std::queue< std::function<void()> > _tasks;
-        std::queue<AsyncTaskCallBack>            _taskCallBacks;
+        std::queue<AsyncTaskCallBack> _taskCallBacks;
         
         // synchronization
         std::mutex _queueMutex;
@@ -208,14 +215,17 @@ inline void AsyncTaskPool::stopTasks(TaskType type)
     threadTask.clear();
 }
 
-template<class F>
-inline void AsyncTaskPool::enqueue(AsyncTaskPool::TaskType type, const TaskCallBack& callback, void* callbackParam, F&& f)
+inline void AsyncTaskPool::enqueue(AsyncTaskPool::TaskType type, TaskCallBack callback, void* callbackParam, std::function<void()> task)
 {
     auto& threadTask = _threadTasks[(int)type];
     
-    threadTask.enqueue(callback, callbackParam, f);
+    threadTask.enqueue(std::move(callback), callbackParam, std::move(task));
 }
 
+inline void AsyncTaskPool::enqueue(AsyncTaskPool::TaskType type, std::function<void()> task)
+{
+    enqueue(type, [](void*) {}, nullptr, std::move(task));
+}
 
 NS_CC_END
 // end group

--- a/cocos/base/CCAsyncTaskPool.h
+++ b/cocos/base/CCAsyncTaskPool.h
@@ -184,7 +184,7 @@ protected:
                     return;
                 }
                 
-                _tasks.push(task);
+                _tasks.push(std::move(task));
                 _taskCallBacks.push(std::move(taskCallBack));
             }
             _condition.notify_one();

--- a/cocos/base/CCScheduler.h
+++ b/cocos/base/CCScheduler.h
@@ -431,7 +431,7 @@ public:
      @since v3.0
      @js NA
      */
-    void performFunctionInCocosThread( const std::function<void()> &function);
+    void performFunctionInCocosThread(std::function<void()> function);
     
     /**
      * Remove all pending functions queued to be performed with Scheduler::performFunctionInCocosThread

--- a/cocos/base/ccUtils.cpp
+++ b/cocos/base/ccUtils.cpp
@@ -138,7 +138,7 @@ void onCaptureScreen(const std::function<void(bool, const std::string&)>& afterC
                 startedCapture = false;
             };
 
-            AsyncTaskPool::getInstance()->enqueue(AsyncTaskPool::TaskType::TASK_IO, mainThread, nullptr, [image, outputFile]()
+            AsyncTaskPool::getInstance()->enqueue(AsyncTaskPool::TaskType::TASK_IO, std::move(mainThread), nullptr, [image, outputFile]()
             {
                 succeedSaveToFile = image->saveToFile(outputFile);
                 delete image;

--- a/extensions/assets-manager/AssetsManagerEx.cpp
+++ b/extensions/assets-manager/AssetsManagerEx.cpp
@@ -493,7 +493,7 @@ void AssetsManagerEx::decompressDownloadedZip(const std::string &customId, const
         }
         delete dataInner;
     };
-    AsyncTaskPool::getInstance()->enqueue(AsyncTaskPool::TaskType::TASK_OTHER, decompressFinished, (void*)asyncData, [this, asyncData]() {
+    AsyncTaskPool::getInstance()->enqueue(AsyncTaskPool::TaskType::TASK_OTHER, std::move(decompressFinished), (void*)asyncData, [this, asyncData]() {
         // Decompress all compressed files
         if (decompress(asyncData->zipFile))
         {

--- a/tools/tojs/cocos2dx.ini
+++ b/tools/tojs/cocos2dx.ini
@@ -140,7 +140,8 @@ skip = Node::[^setPosition$ setGLServerState description getUserObject .*UserDat
         Camera::[unproject isVisibleInFrustum],
         ClippingNode::[init],
         RenderState::[setStateBlock],
-        ComponentJS::[create getScriptObject update]
+        ComponentJS::[create getScriptObject update],
+        AsyncTaskPool::[enqueue]
 
 rename_functions = SpriteFrameCache::[addSpriteFramesWithFile=addSpriteFrames getSpriteFrameByName=getSpriteFrame],
     MenuItemFont::[setFontNameObj=setFontName setFontSizeObj=setFontSize getFontSizeObj=getFontSize getFontNameObj=getFontName],

--- a/tools/tolua/cocos2dx.ini
+++ b/tools/tolua/cocos2dx.ini
@@ -144,7 +144,8 @@ skip = Node::[setGLServerState description getUserObject .*UserData getGLServerS
         RenderState::[finalize setStateBlock],
         Properties::[createNonRefCounted],
         AutoPolygon::[trace reduce expand triangulate calculateUV generateTriangles generatePolygon],
-        PolygonInfo::[operator=]
+        PolygonInfo::[operator=],
+        AsyncTaskPool::[enqueue]
 
 rename_functions = SpriteFrameCache::[addSpriteFramesWithFile=addSpriteFrames getSpriteFrameByName=getSpriteFrame],
     ProgressTimer::[setReverseProgress=setReverseDirection],


### PR DESCRIPTION
Changing AsyncTaskPool/Scheduler to better leverage move semantics. This will allow us to avoid several lambda copy constructor calls, and improve performance in the engine around some of our multi-threading APIs. 

This change should be backwards compatible, and not break current API*. This change should not introduce any additional net copy constructor calls, and should overall reduce the number of copy constructor calls for lambda functions in the engine. 

\* Before AsyncTaskPool::enqueue was based off a generic parameter T, however we were assuming that T implemented operator() accepting no arguments. Internally in the engine, the parameter T could be trivially switched to std::function<void()>. I believe that any users using this code directly should continue to work, unless their lambda's had unused return values for some strange reason.