### PR TITLE
Avoid crash on large file download.

### DIFF
--- a/cocos/network/CCDownloader-apple.mm
+++ b/cocos/network/CCDownloader-apple.mm
@@ -414,9 +414,9 @@ namespace cocos2d { namespace network {
             std::string errorString;
 
             const int64_t buflen = [wrapper totalBytesReceived];
-            char buf[buflen];
+            std::vector<unsigned char> data((size_t)buflen);
+            char* buf = (char*)data.data();
             [wrapper transferDataToBuffer:buf lengthOfBuffer:buflen];
-            std::vector<unsigned char> data(buf, buf + buflen);
 
             _outer->onTaskFinish(*[wrapper get],
                                  cocos2d::network::DownloadTask::ERROR_NO_ERROR,


### PR DESCRIPTION
Downloading large file to memory could cause stack overflow and crash, because old code created buffer `char buf[buflen];` on stack.
New code creates buffer in heap.