### PR TITLE
Memory leak in setFontAtlas, if set equal font in Label.

### DIFF
--- a/cocos/2d/CCLabel.cpp
+++ b/cocos/2d/CCLabel.cpp
@@ -584,6 +584,10 @@ void Label::setFontAtlas(FontAtlas* atlas,bool distanceFieldEnabled /* = false *
 
     if (atlas == _fontAtlas)
     {
+        if (_fontAtlas)
+        {
+            FontAtlasCache::releaseFontAtlas(_fontAtlas);
+        }
         return;
     }
 


### PR DESCRIPTION
setCharMap, setBMFontFilePath and setTTFConfigInternal use getFontAtlas.
getFontAtlas retain font atlas always.
setFontAtlas not release, if atlas equal current.

For example call Label::setTTFConfig for equal ttfConfig.