### PR TITLE
Moved CC_SYNTHESIZE and CC_PROPERTY macros onto a single line

### DIFF
--- a/cocos/platform/CCPlatformMacros.h
+++ b/cocos/platform/CCPlatformMacros.h
@@ -129,12 +129,10 @@ CC_DEPRECATED_ATTRIBUTE static __TYPE__* node() \
  *            If you need protected or private, please declare.
  */
 #define CC_PROPERTY_READONLY(varType, varName, funName)\
-protected: varType varName;\
-public: virtual varType get##funName(void) const;
+protected: varType varName; public: virtual varType get##funName(void) const;
 
 #define CC_PROPERTY_READONLY_PASS_BY_REF(varType, varName, funName)\
-protected: varType varName;\
-public: virtual const varType& get##funName(void) const;
+protected: varType varName; public: virtual const varType& get##funName(void) const;
 
 /** @def CC_PROPERTY 
  * It is used to declare a protected variable.
@@ -149,14 +147,10 @@ public: virtual const varType& get##funName(void) const;
  *            If you need protected or private, please declare.
  */
 #define CC_PROPERTY(varType, varName, funName)\
-protected: varType varName;\
-public: virtual varType get##funName(void) const;\
-public: virtual void set##funName(varType var);
+protected: varType varName; public: virtual varType get##funName(void) const; virtual void set##funName(varType var);
 
 #define CC_PROPERTY_PASS_BY_REF(varType, varName, funName)\
-protected: varType varName;\
-public: virtual const varType& get##funName(void) const;\
-public: virtual void set##funName(const varType& var);
+protected: varType varName; public: virtual const varType& get##funName(void) const; virtual void set##funName(const varType& var);
 
 /** @def CC_SYNTHESIZE_READONLY 
  * It is used to declare a protected variable. We can use getter to read the variable.
@@ -169,12 +163,10 @@ public: virtual void set##funName(const varType& var);
  *            If you need protected or private, please declare.
  */
 #define CC_SYNTHESIZE_READONLY(varType, varName, funName)\
-protected: varType varName;\
-public: virtual varType get##funName(void) const { return varName; }
+protected: varType varName; public: virtual inline varType get##funName(void) const { return varName; }
 
 #define CC_SYNTHESIZE_READONLY_PASS_BY_REF(varType, varName, funName)\
-protected: varType varName;\
-public: virtual const varType& get##funName(void) const { return varName; }
+protected: varType varName; public: virtual inline const varType& get##funName(void) const { return varName; }
 
 /** @def CC_SYNTHESIZE 
  * It is used to declare a protected variable.
@@ -189,19 +181,13 @@ public: virtual const varType& get##funName(void) const { return varName; }
  *            If you need protected or private, please declare.
  */
 #define CC_SYNTHESIZE(varType, varName, funName)\
-protected: varType varName;\
-public: virtual varType get##funName(void) const { return varName; }\
-public: virtual void set##funName(varType var){ varName = var; }
+protected: varType varName; public: virtual inline varType get##funName(void) const { return varName; } virtual inline void set##funName(varType var){ varName = var; }
 
 #define CC_SYNTHESIZE_PASS_BY_REF(varType, varName, funName)\
-protected: varType varName;\
-public: virtual const varType& get##funName(void) const { return varName; }\
-public: virtual void set##funName(const varType& var){ varName = var; }
+protected: varType varName; public: virtual inline const varType& get##funName(void) const { return varName; } virtual inline void set##funName(const varType& var){ varName = var; }
 
 #define CC_SYNTHESIZE_RETAIN(varType, varName, funName)    \
-private: varType varName; \
-public: virtual varType get##funName(void) const { return varName; } \
-public: virtual void set##funName(varType var)   \
+private: varType varName; public: virtual inline varType get##funName(void) const { return varName; } virtual inline void set##funName(varType var) \
 { \
     if (varName != var) \
     { \


### PR DESCRIPTION
This permits comments to be visible in tooltips for the variable and it's associated accessor functions

e.g.
```
//The health of the entity, when this reaches zero the entity is dead
CC_SYNTHESIZE(float, m_health, Health)
```

Previously the above comment would only be displayed in the tooltip for the member variable