### PR TITLE
Fix space wrapping in CCLabelTextFormatter

### DIFF
--- a/cocos/2d/CCLabel.cpp
+++ b/cocos/2d/CCLabel.cpp
@@ -384,6 +384,7 @@ Label::Label(TextHAlignment hAlignment /* = TextHAlignment::LEFT */,
 , _boldEnabled(false)
 , _underlineNode(nullptr)
 , _strikethroughEnabled(false)
+, _trimLineSpaces(true)
 {
     setAnchorPoint(Vec2::ANCHOR_MIDDLE);
     reset();
@@ -525,6 +526,8 @@ void Label::reset()
     }
     _strikethroughEnabled = false;
     setRotationSkewX(0);        // reverse italics
+
+    _trimLineSpaces = true;
 }
 
 //  ETC1 ALPHA supports, for LabelType::BMFONT & LabelType::CHARMAP
@@ -1845,6 +1848,20 @@ float Label::getAdditionalKerning() const
     CCASSERT(_currentLabelType != LabelType::STRING_TEXTURE, "Not supported system font!");
 
     return _additionalKerning;
+}
+
+void Label::setTrimLineSpacesEnabled(bool enabled)
+{
+    if (_trimLineSpaces != enabled) {
+        _trimLineSpaces = enabled;
+
+        _contentDirty = true;
+    }
+}
+
+bool Label::isTrimLineSpacesEnabled() const
+{
+    return _trimLineSpaces;
 }
 
 void Label::computeStringNumLines()

--- a/cocos/2d/CCLabel.h
+++ b/cocos/2d/CCLabel.h
@@ -567,6 +567,14 @@ public:
      */
     float getAdditionalKerning() const;
 
+    /**
+     * Trims leading and trailing spaces on new lines.
+     *
+     * @warning Not support system font.
+     */
+    virtual void setTrimLineSpacesEnabled(bool enabled);
+    virtual bool isTrimLineSpacesEnabled() const;
+
     FontAtlas* getFontAtlas() { return _fontAtlas; }
 
     virtual const BlendFunc& getBlendFunc() const override { return _blendFunc; }
@@ -780,6 +788,8 @@ protected:
     bool _boldEnabled;
     DrawNode* _underlineNode;
     bool _strikethroughEnabled;
+
+    bool _trimLineSpaces;
 
 private:
     CC_DISALLOW_COPY_AND_ASSIGN(Label);

--- a/cocos/2d/CCLabelTextFormatter.cpp
+++ b/cocos/2d/CCLabelTextFormatter.cpp
@@ -198,8 +198,14 @@ bool Label::multilineTextWrap(const std::function<int(const std::u32string&, int
             }
 
             auto letterX = (nextLetterX + letterDef.offsetX * _bmfontScale) / contentScaleFactor;
-            if (_enableWrap && _maxLineWidth > 0.f && nextTokenX > 0.f && letterX + letterDef.width * _bmfontScale > _maxLineWidth
-                && !StringUtils::isUnicodeSpace(character) && nextChangeSize)
+            float trailingX = letterX;
+            if (StringUtils::isUnicodeSpace(character)) {
+                trailingX += letterDef.xAdvance * _bmfontScale / contentScaleFactor;
+            }
+            else {
+                trailingX += letterDef.width * _bmfontScale;
+            }
+            if (_enableWrap && _maxLineWidth > 0.f && nextTokenX > 0.f && letterX + letterDef.width * _bmfontScale > _maxLineWidth && nextChangeSize)
             {
                 _linesWidth.push_back(letterRight);
                 letterRight = 0.f;


### PR DESCRIPTION
Previously, if you insert spaces at the end of a long string, the line would not wrap. The fix introduces correct wrapping for spaces.