### PR TITLE
[Android] Fix edit box font size and alignment

### DIFF
--- a/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxEditBox.java
+++ b/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxEditBox.java
@@ -230,6 +230,7 @@ public class Cocos2dxEditBox extends EditText {
                 gravity = (gravity & ~Gravity.TOP) | Gravity.BOTTOM ;
                 break;
             default:
+                setPadding(padding, 0, 0, padding/2);
                 gravity =(gravity & ~Gravity.TOP & ~Gravity.BOTTOM) | Gravity.CENTER_VERTICAL;
                 break;
         }

--- a/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxEditBox.java
+++ b/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxEditBox.java
@@ -121,7 +121,7 @@ public class Cocos2dxEditBox extends EditText {
 
     private static final int kTextVerticalAlignmentTop = 0;
     private static final int kTextVerticalAlignmentCenter = 1;
-    private static final int getkTextVerticalAlignmentBottom = 2;
+    private static final int kTextVerticalAlignmentBottom = 2;
 
     private int mInputFlagConstraints; 
     private int mInputModeConstraints;
@@ -201,7 +201,7 @@ public class Cocos2dxEditBox extends EditText {
                 gravity = gravity | Gravity.LEFT;
                 break;
             case kTextHorizontalAlignmentCenter:
-                gravity = gravity | Gravity.CENTER;
+                gravity = gravity | Gravity.CENTER_HORIZONTAL;
                 break;
             case kTextHorizontalAlignmentRight:
                 gravity = gravity | Gravity.RIGHT;
@@ -215,18 +215,22 @@ public class Cocos2dxEditBox extends EditText {
 
     public void setTextVerticalAlignment(int alignment) {
         int gravity = this.getGravity();
+        int padding = Cocos2dxEditBoxHelper.getPadding(mScaleX);
         switch (alignment) {
             case kTextVerticalAlignmentTop:
-                gravity = gravity | Gravity.TOP;
+                setPadding(padding, 3*padding/4, 0, 0);
+                gravity = Gravity.TOP;
                 break;
             case kTextVerticalAlignmentCenter:
-                gravity = gravity | Gravity.CENTER_VERTICAL;
+                setPadding(padding, 0, 0, padding/2);
+                gravity = Gravity.CENTER_VERTICAL;
                 break;
-            case getkTextVerticalAlignmentBottom:
-                gravity = gravity | Gravity.BOTTOM;
+            case kTextVerticalAlignmentBottom:
+                //TODO: Add appropriate padding when this alignment is used
+                gravity =Gravity.BOTTOM;
                 break;
             default:
-                gravity = gravity | Gravity.CENTER_VERTICAL;
+                gravity = Gravity.CENTER_VERTICAL;
                 break;
         }
 
@@ -265,7 +269,6 @@ public class Cocos2dxEditBox extends EditText {
         }
 
         this.setInputType(this.mInputModeConstraints | this.mInputFlagConstraints);
-
     }
 
     @Override

--- a/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxEditBox.java
+++ b/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxEditBox.java
@@ -208,7 +208,6 @@ public class Cocos2dxEditBox extends EditText {
                 break;
             default:
                 gravity = (gravity & ~Gravity.RIGHT) | Gravity.LEFT ;
-                gravity = gravity | Gravity.LEFT;
                 break;
         }
         this.setGravity(gravity);
@@ -232,7 +231,6 @@ public class Cocos2dxEditBox extends EditText {
                 break;
             default:
                 gravity =(gravity & ~Gravity.TOP & ~Gravity.BOTTOM) | Gravity.CENTER_VERTICAL;
-                gravity = Gravity.CENTER_VERTICAL;
                 break;
         }
 

--- a/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxEditBox.java
+++ b/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxEditBox.java
@@ -198,38 +198,40 @@ public class Cocos2dxEditBox extends EditText {
         int gravity = this.getGravity();
         switch (alignment) {
             case kTextHorizontalAlignmentLeft:
-                gravity = gravity | Gravity.LEFT;
+                gravity = (gravity & ~Gravity.RIGHT) | Gravity.LEFT ;
                 break;
             case kTextHorizontalAlignmentCenter:
-                gravity = gravity | Gravity.CENTER_HORIZONTAL;
+                gravity =(gravity & ~Gravity.RIGHT & ~Gravity.LEFT) | Gravity.CENTER_HORIZONTAL;
                 break;
             case kTextHorizontalAlignmentRight:
-                gravity = gravity | Gravity.RIGHT;
+                gravity = (gravity & ~Gravity.LEFT) | Gravity.RIGHT ;
                 break;
             default:
+                gravity = (gravity & ~Gravity.RIGHT) | Gravity.LEFT ;
                 gravity = gravity | Gravity.LEFT;
                 break;
         }
         this.setGravity(gravity);
     }
-
+    
     public void setTextVerticalAlignment(int alignment) {
         int gravity = this.getGravity();
         int padding = Cocos2dxEditBoxHelper.getPadding(mScaleX);
         switch (alignment) {
             case kTextVerticalAlignmentTop:
-                setPadding(padding, 3*padding/4, 0, 0);
-                gravity = Gravity.TOP;
+                setPadding(padding, padding*3/4, 0, 0);
+                gravity = (gravity & ~Gravity.BOTTOM) | Gravity.TOP ;
                 break;
             case kTextVerticalAlignmentCenter:
                 setPadding(padding, 0, 0, padding/2);
-                gravity = Gravity.CENTER_VERTICAL;
+                gravity =(gravity & ~Gravity.TOP & ~Gravity.BOTTOM) | Gravity.CENTER_VERTICAL;
                 break;
             case kTextVerticalAlignmentBottom:
                 //TODO: Add appropriate padding when this alignment is used
-                gravity =Gravity.BOTTOM;
+                gravity = (gravity & ~Gravity.TOP) | Gravity.BOTTOM ;
                 break;
             default:
+                gravity =(gravity & ~Gravity.TOP & ~Gravity.BOTTOM) | Gravity.CENTER_VERTICAL;
                 gravity = Gravity.CENTER_VERTICAL;
                 break;
         }

--- a/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxEditBoxHelper.java
+++ b/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxEditBoxHelper.java
@@ -51,7 +51,7 @@ public class Cocos2dxEditBoxHelper {
 
     private static SparseArray<Cocos2dxEditBox> mEditBoxArray;
     private static int mViewTag = 0;
-
+    private static float mPadding = 5.0f;
     //Call native methods
     private static native void editBoxEditingDidBegin(int index);
     public static void __editBoxEditingDidBegin(int index){
@@ -76,14 +76,8 @@ public class Cocos2dxEditBoxHelper {
         Cocos2dxEditBoxHelper.mEditBoxArray = new SparseArray<Cocos2dxEditBox>();
     }
 
-    public static int convertToSP(float point){
-        Resources r = mCocos2dxActivity.getResources();
-
-        int convertedValue = (int)TypedValue.applyDimension(
-                TypedValue.COMPLEX_UNIT_SP, point, r.getDisplayMetrics());
-
-        return  convertedValue;
-
+    public static int getPadding(float scaleX){
+        return (int)(mPadding*scaleX);
     }
 
     public static int createEditBox(final int left, final int top, final int width, final int height, final float scaleX) {
@@ -103,16 +97,7 @@ public class Cocos2dxEditBoxHelper {
                 editBox.setTextColor(Color.WHITE);
                 editBox.setSingleLine();
                 editBox.setOpenGLViewScaleX(scaleX);
-                Resources r = mCocos2dxActivity.getResources();
-                float density =  r.getDisplayMetrics().density;
-                int paddingBottom = (int)(height * 0.33f / density);
-                paddingBottom = convertToSP(paddingBottom  - 5 * scaleX / density);
-                paddingBottom = paddingBottom / 2;
-                int paddingTop = paddingBottom;
-                int paddingLeft = (int)(5 * scaleX / density);
-                paddingLeft = convertToSP(paddingLeft);
-
-                editBox.setPadding(paddingLeft,paddingTop, 0, paddingBottom);
+                editBox.setPadding(getPadding(scaleX), 0, 0, 0);
 
 
                 FrameLayout.LayoutParams lParams = new FrameLayout.LayoutParams(
@@ -268,8 +253,8 @@ public class Cocos2dxEditBoxHelper {
                     if (fontSize >= 0){
                         float density =  mCocos2dxActivity.getResources().getDisplayMetrics().density;
 //                        Log.e("XXX", "density is " + density);
-                        editBox.setTextSize(TypedValue.COMPLEX_UNIT_SP,
-                                fontSize / density );
+                        editBox.setTextSize(TypedValue.COMPLEX_UNIT_PX,
+                                fontSize);
                     }
                     editBox.setTypeface(tf);
                 }


### PR DESCRIPTION
https://github.com/cocos2d/cocos2d-x/issues/17795

Edit box alignment wasn't resetting the previous value before setting the new one.
Also fixed font size.

Tested on:
Galaxy S8
Nexus 6P
LG G5

![ezgif com-video-to-gif 7](https://cloud.githubusercontent.com/assets/11037660/25829451/6aaa98d6-3413-11e7-8b25-9b6644deec0c.gif)