### PR TITLE
[WinRT] Fix removeDirectory unicode.

### DIFF
--- a/cocos/platform/winrt/CCFileUtilsWinRT.cpp
+++ b/cocos/platform/winrt/CCFileUtilsWinRT.cpp
@@ -286,7 +286,7 @@ bool CCFileUtilsWinRT::removeDirectory(const std::string& path)
                 if (wfd.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)
                 {
                     temp += '/';
-                    ret = ret && this->removeDirectory(std::string(temp.begin(), temp.end()));
+                    ret = ret && this->removeDirectory(StringWideCharToUtf8(temp));
                 }
                 else
                 {


### PR DESCRIPTION
CCFileUtilsWinRT::removeDirectory need ut8 string.
temp is wstring(unicode).