### PR TITLE
[Win32,WinRT] Fix listFiles and listFilesRecursively use unicode.

### DIFF
--- a/cocos/platform/CCFileUtils.cpp
+++ b/cocos/platform/CCFileUtils.cpp
@@ -34,7 +34,6 @@ THE SOFTWARE.
 //#include "base/ccUtils.h"
 
 #include "tinyxml2/tinyxml2.h"
-#include "tinydir/tinydir.h"
 #ifdef MINIZIP_FROM_SYSTEM
 #include <minizip/unzip.h>
 #else // from our embedded sources
@@ -1167,107 +1166,12 @@ void FileUtils::getFileSize(const std::string &filepath, std::function<void(long
     }, std::move(callback));
 }
 
-std::vector<std::string> FileUtils::listFiles(const std::string& dirPath) const
-{
-    std::vector<std::string> files;
-#ifdef _MSC_VER
-    CCASSERT(false, "FileUtils not support listFiles");
-    return files;
-#else
-    std::string fullpath = fullPathForFilename(dirPath);
-    if (isDirectoryExist(fullpath))
-    {
-        tinydir_dir dir;
-        std::string fullpathstr = fullpath;
-
-        if (tinydir_open(&dir, &fullpathstr[0]) != -1)
-        {
-            while (dir.has_next)
-            {
-                tinydir_file file;
-                if (tinydir_readfile(&dir, &file) == -1)
-                {
-                    // Error getting file
-                    break;
-                }
-                std::string filepath = file.path;
-
-                if (file.is_dir)
-                {
-                    filepath.append("/");
-                }
-                files.push_back(filepath);
-                
-                if (tinydir_next(&dir) == -1)
-                {
-                    // Error getting next file
-                    break;
-                }
-            }
-        }
-        tinydir_close(&dir);
-    }
-    return files;
-#endif
-}
-
 void FileUtils::listFilesAsync(const std::string& dirPath, std::function<void(std::vector<std::string>)> callback) const
 {
     auto fullPath = fullPathForFilename(dirPath);
     performOperationOffthread([fullPath]() {
         return FileUtils::getInstance()->listFiles(fullPath);
     }, std::move(callback));
-}
-
-void FileUtils::listFilesRecursively(const std::string& dirPath, std::vector<std::string> *files) const
-{
-#ifdef _MSC_VER
-    CCASSERT(false, "FileUtils not support listFilesRecursively");
-    return;
-#else
-    std::string fullpath = fullPathForFilename(dirPath);
-    if (isDirectoryExist(fullpath))
-    {
-        tinydir_dir dir;
-        std::string fullpathstr = fullpath;
-
-        if (tinydir_open(&dir, &fullpathstr[0]) != -1)
-        {
-            while (dir.has_next)
-            {
-                tinydir_file file;
-                if (tinydir_readfile(&dir, &file) == -1)
-                {
-                    // Error getting file
-                    break;
-                }
-                std::string fileName = file.name;
-
-                if (fileName != "." && fileName != "..")
-                {
-                    std::string filepath = file.path;
-                    if (file.is_dir)
-                    {
-                        filepath.append("/");
-                        files->push_back(filepath);
-                        listFilesRecursively(filepath, files);
-                    }
-                    else
-                    {
-                        files->push_back(filepath);
-                    }
-                }
-                
-                if (tinydir_next(&dir) == -1)
-                {
-                    // Error getting next file
-                    break;
-                }
-            }
-        }
-        tinydir_close(&dir);
-    }
-#endif
 }
 
 void FileUtils::listFilesRecursivelyAsync(const std::string& dirPath, std::function<void(std::vector<std::string>)> callback) const
@@ -1330,7 +1234,20 @@ long FileUtils::getFileSize(const std::string &filepath)
     return 0;
 }
 
+std::vector<std::string> FileUtils::listFiles(const std::string& dirPath) const
+{
+    CCASSERT(false, "FileUtils not support listFiles");
+    return std::vector<std::string>();
+}
+
+void FileUtils::listFilesRecursively(const std::string& dirPath, std::vector<std::string> *files) const
+{
+    CCASSERT(false, "FileUtils not support listFilesRecursively");
+    return;
+}
+
 #else
+#include "tinydir/tinydir.h"
 // default implements for unix like os
 #include <sys/types.h>
 #include <errno.h>
@@ -1462,7 +1379,6 @@ std::string FileUtils::getSuitableFOpen(const std::string& filenameUtf8) const
     return filenameUtf8;
 }
 
-
 long FileUtils::getFileSize(const std::string &filepath)
 {
     CCASSERT(!filepath.empty(), "Invalid path");
@@ -1490,6 +1406,92 @@ long FileUtils::getFileSize(const std::string &filepath)
         return (long)(info.st_size);
     }
 }
+
+std::vector<std::string> FileUtils::listFiles(const std::string& dirPath) const
+{
+    std::vector<std::string> files;
+    std::string fullpath = fullPathForFilename(dirPath);
+    if (isDirectoryExist(fullpath))
+    {
+        tinydir_dir dir;
+        std::string fullpathstr = fullpath;
+
+        if (tinydir_open(&dir, &fullpathstr[0]) != -1)
+        {
+            while (dir.has_next)
+            {
+                tinydir_file file;
+                if (tinydir_readfile(&dir, &file) == -1)
+                {
+                    // Error getting file
+                    break;
+                }
+                std::string filepath = file.path;
+
+                if (file.is_dir)
+                {
+                    filepath.append("/");
+                }
+                files.push_back(filepath);
+
+                if (tinydir_next(&dir) == -1)
+                {
+                    // Error getting next file
+                    break;
+                }
+            }
+        }
+        tinydir_close(&dir);
+    }
+    return files;
+}
+
+void FileUtils::listFilesRecursively(const std::string& dirPath, std::vector<std::string> *files) const
+{
+    std::string fullpath = fullPathForFilename(dirPath);
+    if (isDirectoryExist(fullpath))
+    {
+        tinydir_dir dir;
+        std::string fullpathstr = fullpath;
+
+        if (tinydir_open(&dir, &fullpathstr[0]) != -1)
+        {
+            while (dir.has_next)
+            {
+                tinydir_file file;
+                if (tinydir_readfile(&dir, &file) == -1)
+                {
+                    // Error getting file
+                    break;
+                }
+                std::string fileName = file.name;
+
+                if (fileName != "." && fileName != "..")
+                {
+                    std::string filepath = file.path;
+                    if (file.is_dir)
+                    {
+                        filepath.append("/");
+                        files->push_back(filepath);
+                        listFilesRecursively(filepath, files);
+                    }
+                    else
+                    {
+                        files->push_back(filepath);
+                    }
+                }
+
+                if (tinydir_next(&dir) == -1)
+                {
+                    // Error getting next file
+                    break;
+                }
+            }
+        }
+        tinydir_close(&dir);
+    }
+}
+
 #endif
 
 //////////////////////////////////////////////////////////////////////////

--- a/cocos/platform/CCFileUtils.cpp
+++ b/cocos/platform/CCFileUtils.cpp
@@ -1170,7 +1170,7 @@ void FileUtils::getFileSize(const std::string &filepath, std::function<void(long
 std::vector<std::string> FileUtils::listFiles(const std::string& dirPath) const
 {
     std::vector<std::string> files;
-#ifdef UNICODE
+#ifdef _MSC_VER
     CCASSERT(false, "FileUtils not support listFiles");
     return files;
 #else
@@ -1221,7 +1221,7 @@ void FileUtils::listFilesAsync(const std::string& dirPath, std::function<void(st
 
 void FileUtils::listFilesRecursively(const std::string& dirPath, std::vector<std::string> *files) const
 {
-#ifdef UNICODE
+#ifdef _MSC_VER
     CCASSERT(false, "FileUtils not support listFilesRecursively");
     return;
 #else
@@ -1243,7 +1243,6 @@ void FileUtils::listFilesRecursively(const std::string& dirPath, std::vector<std
                 }
                 std::string fileName = file.name;
 
-                // Need check full name file on "." and "..", otherwise exclude file and folder begin '.'
                 if (fileName != "." && fileName != "..")
                 {
                     std::string filepath = file.path;

--- a/cocos/platform/win32/CCFileUtils-win32.cpp
+++ b/cocos/platform/win32/CCFileUtils-win32.cpp
@@ -240,7 +240,6 @@ void FileUtilsWin32::listFilesRecursively(const std::string& dirPath, std::vecto
                 }
                 std::string fileName = StringWideCharToUtf8(file.name);
 
-                // Need check full name file on "." and "..", otherwise exclude file and folder begin '.'
                 if (fileName != "." && fileName != "..")
                 {
                     std::string filepath = StringWideCharToUtf8(file.path);

--- a/cocos/platform/win32/CCFileUtils-win32.cpp
+++ b/cocos/platform/win32/CCFileUtils-win32.cpp
@@ -29,6 +29,7 @@ THE SOFTWARE.
 #include "platform/win32/CCFileUtils-win32.h"
 #include "platform/win32/CCUtils-win32.h"
 #include "platform/CCCommon.h"
+#include "tinydir/tinydir.h"
 #include <Shlobj.h>
 #include <cstdlib>
 #include <regex>
@@ -217,6 +218,92 @@ std::string FileUtilsWin32::getFullPathForDirectoryAndFilename(const std::string
     std::string unixFilename = convertPathFormatToUnixStyle(strFilename);
 
     return FileUtils::getFullPathForDirectoryAndFilename(unixDirectory, unixFilename);
+}
+
+void FileUtilsWin32::listFilesRecursively(const std::string& dirPath, std::vector<std::string> *files) const
+{
+    std::string fullpath = fullPathForFilename(dirPath);
+    if (isDirectoryExist(fullpath))
+    {
+        tinydir_dir dir;
+        std::wstring fullpathstr = StringUtf8ToWideChar(fullpath);
+
+        if (tinydir_open(&dir, &fullpathstr[0]) != -1)
+        {
+            while (dir.has_next)
+            {
+                tinydir_file file;
+                if (tinydir_readfile(&dir, &file) == -1)
+                {
+                    // Error getting file
+                    break;
+                }
+                std::string fileName = StringWideCharToUtf8(file.name);
+
+                // Need check full name file on "." and "..", otherwise exclude file and folder begin '.'
+                if (fileName != "." && fileName != "..")
+                {
+                    std::string filepath = StringWideCharToUtf8(file.path);
+                    if (file.is_dir)
+                    {
+                        filepath.append("/");
+                        files->push_back(filepath);
+                        listFilesRecursively(filepath, files);
+                    }
+                    else
+                    {
+                        files->push_back(filepath);
+                    }
+                }
+
+                if (tinydir_next(&dir) == -1)
+                {
+                    // Error getting next file
+                    break;
+                }
+            }
+        }
+        tinydir_close(&dir);
+    }
+}
+
+std::vector<std::string> FileUtilsWin32::listFiles(const std::string& dirPath) const
+{
+    std::string fullpath = fullPathForFilename(dirPath);
+    std::vector<std::string> files;
+    if (isDirectoryExist(fullpath))
+    {
+        tinydir_dir dir;
+        std::wstring fullpathstr = StringUtf8ToWideChar(fullpath);
+
+        if (tinydir_open(&dir, &fullpathstr[0]) != -1)
+        {
+            while (dir.has_next)
+            {
+                tinydir_file file;
+                if (tinydir_readfile(&dir, &file) == -1)
+                {
+                    // Error getting file
+                    break;
+                }
+
+                std::string filepath = StringWideCharToUtf8(file.path);
+                if (file.is_dir)
+                {
+                    filepath.append("/");
+                }
+                files.push_back(filepath);
+
+                if (tinydir_next(&dir) == -1)
+                {
+                    // Error getting next file
+                    break;
+                }
+            }
+        }
+        tinydir_close(&dir);
+    }
+    return files;
 }
 
 string FileUtilsWin32::getWritablePath() const

--- a/cocos/platform/win32/CCFileUtils-win32.h
+++ b/cocos/platform/win32/CCFileUtils-win32.h
@@ -132,6 +132,22 @@ protected:
      *  @return The full path of the file, if the file can't be found, it will return an empty string.
      */
     virtual std::string getFullPathForDirectoryAndFilename(const std::string& directory, const std::string& filename) const override;
+
+    /**
+    *  List all files in a directory.
+    *
+    *  @param dirPath The path of the directory, it could be a relative or an absolute path.
+    *  @return File paths in a string vector
+    */
+    virtual std::vector<std::string> listFiles(const std::string& dirPath) const;
+
+    /**
+    *  List all files recursively in a directory.
+    *
+    *  @param dirPath The path of the directory, it could be a relative or an absolute path.
+    *  @return File paths in a string vector
+    */
+    virtual void listFilesRecursively(const std::string& dirPath, std::vector<std::string> *files) const;
 };
 
 // end of platform group

--- a/cocos/platform/winrt/CCFileUtilsWinRT.cpp
+++ b/cocos/platform/winrt/CCFileUtilsWinRT.cpp
@@ -397,7 +397,6 @@ void CCFileUtilsWinRT::listFilesRecursively(const std::string& dirPath, std::vec
                 }
                 std::string fileName = StringWideCharToUtf8(file.name);
 
-                // Need check full name file on "." and "..", otherwise exclude file and folder begin '.'
                 if (fileName != "." && fileName != "..")
                 {
                     std::string filepath = StringWideCharToUtf8(file.path);

--- a/cocos/platform/winrt/CCFileUtilsWinRT.cpp
+++ b/cocos/platform/winrt/CCFileUtilsWinRT.cpp
@@ -26,6 +26,7 @@ THE SOFTWARE.
 #include <regex>
 #include "platform/winrt/CCWinRTUtils.h"
 #include "platform/CCCommon.h"
+#include "tinydir/tinydir.h"
 using namespace std;
 
 NS_CC_BEGIN
@@ -370,11 +371,96 @@ bool CCFileUtilsWinRT::renameFile(const std::string &path, const std::string &ol
     return renameFile(oldPath, newPath);
 }
 
-
 string CCFileUtilsWinRT::getWritablePath() const
 {
     auto localFolderPath = Windows::Storage::ApplicationData::Current->LocalFolder->Path;
     return convertPathFormatToUnixStyle(std::string(PlatformStringToString(localFolderPath)) + '\\');
+}
+
+void CCFileUtilsWinRT::listFilesRecursively(const std::string& dirPath, std::vector<std::string> *files) const
+{
+    std::string fullpath = fullPathForFilename(dirPath);
+    if (isDirectoryExist(fullpath))
+    {
+        tinydir_dir dir;
+        std::wstring fullpathstr = StringUtf8ToWideChar(fullpath);
+
+        if (tinydir_open(&dir, &fullpathstr[0]) != -1)
+        {
+            while (dir.has_next)
+            {
+                tinydir_file file;
+                if (tinydir_readfile(&dir, &file) == -1)
+                {
+                    // Error getting file
+                    break;
+                }
+                std::string fileName = StringWideCharToUtf8(file.name);
+
+                // Need check full name file on "." and "..", otherwise exclude file and folder begin '.'
+                if (fileName != "." && fileName != "..")
+                {
+                    std::string filepath = StringWideCharToUtf8(file.path);
+                    if (file.is_dir)
+                    {
+                        filepath.append("/");
+                        files->push_back(filepath);
+                        listFilesRecursively(filepath, files);
+                    }
+                    else
+                    {
+                        files->push_back(filepath);
+                    }
+                }
+
+                if (tinydir_next(&dir) == -1)
+                {
+                    // Error getting next file
+                    break;
+                }
+            }
+        }
+        tinydir_close(&dir);
+    }
+}
+
+std::vector<std::string> CCFileUtilsWinRT::listFiles(const std::string& dirPath) const
+{
+    std::string fullpath = fullPathForFilename(dirPath);
+    std::vector<std::string> files;
+    if (isDirectoryExist(fullpath))
+    {
+        tinydir_dir dir;
+        std::wstring fullpathstr = StringUtf8ToWideChar(fullpath);
+
+        if (tinydir_open(&dir, &fullpathstr[0]) != -1)
+        {
+            while (dir.has_next)
+            {
+                tinydir_file file;
+                if (tinydir_readfile(&dir, &file) == -1)
+                {
+                    // Error getting file
+                    break;
+                }
+
+                std::string filepath = StringWideCharToUtf8(file.path);
+                if (file.is_dir)
+                {
+                    filepath.append("/");
+                }
+                files.push_back(filepath);
+
+                if (tinydir_next(&dir) == -1)
+                {
+                    // Error getting next file
+                    break;
+                }
+            }
+        }
+        tinydir_close(&dir);
+    }
+    return files;
 }
 
 string CCFileUtilsWinRT::getAppPath()

--- a/cocos/platform/winrt/CCFileUtilsWinRT.h
+++ b/cocos/platform/winrt/CCFileUtilsWinRT.h
@@ -57,6 +57,22 @@ public:
 	virtual FileUtils::Status getContents(const std::string& filename, ResizableBuffer* buffer) override;
 	static std::string getAppPath();
 
+    /**
+    *  List all files in a directory.
+    *
+    *  @param dirPath The path of the directory, it could be a relative or an absolute path.
+    *  @return File paths in a string vector
+    */
+    virtual std::vector<std::string> listFiles(const std::string& dirPath) const;
+
+    /**
+    *  List all files recursively in a directory.
+    *
+    *  @param dirPath The path of the directory, it could be a relative or an absolute path.
+    *  @return File paths in a string vector
+    */
+    virtual void listFilesRecursively(const std::string& dirPath, std::vector<std::string> *files) const;
+
 private:
     virtual bool isFileExistInternal(const std::string& strFilePath) const override;
 


### PR DESCRIPTION
1. Incorrect convertation to unicode
if (length != fullpath.size()) correct only ASCII char.
2. For convert unicode exist api, to avoid errors.
3. Equal first char on '.' - error
Need check full name file on "." and "..", otherwise exclude file and
folder begin '.'

Now not use macro UNICODE, for easy use unicode convert api(Otherwise,
need to connect different versions WinRT and Win32 include).