### PR TITLE
[Win32,WinRT] Fix old bag, Manifest not save.

### DIFF
--- a/extensions/assets-manager/Manifest.cpp
+++ b/extensions/assets-manager/Manifest.cpp
@@ -545,10 +545,8 @@ void Manifest::saveToFile(const std::string &filepath)
     rapidjson::StringBuffer buffer;
     rapidjson::PrettyWriter<rapidjson::StringBuffer> writer(buffer);
     _json.Accept(writer);
-    
-    std::ofstream output(filepath, std::ofstream::out);
-    if(!output.bad())
-        output << buffer.GetString() << std::endl;
+
+    FileUtils::getInstance()->writeStringToFile(buffer.GetString(), filepath);
 }
 
 NS_CC_EXT_END


### PR DESCRIPTION
Manifest::saveToFile not save, if path contains not asii chars.
std::ofstream not use unicode api.

Now use FileUtils api for write file.