### PR TITLE
[Win32] Fix AudioDecoder fopen unicode.

### DIFF
--- a/cocos/audio/win32/AudioDecoderMp3.cpp
+++ b/cocos/audio/win32/AudioDecoderMp3.cpp
@@ -91,7 +91,7 @@ namespace cocos2d { namespace experimental {
                 break;
             }
 
-            if (mpg123_open(_mpg123handle, fullPath.c_str()) != MPG123_OK
+            if (mpg123_open(_mpg123handle, FileUtils::getInstance()->getSuitableFOpen(fullPath).c_str()) != MPG123_OK
                 || mpg123_getformat(_mpg123handle, &rate, &channel, &mp3Encoding) != MPG123_OK)
             {
                 ALOGE("Trouble with mpg123: %s\n", mpg123_strerror(_mpg123handle) );

--- a/cocos/audio/win32/AudioDecoderOgg.cpp
+++ b/cocos/audio/win32/AudioDecoderOgg.cpp
@@ -42,7 +42,7 @@ namespace cocos2d { namespace experimental {
     bool AudioDecoderOgg::open(const char* path)
     {
         std::string fullPath = FileUtils::getInstance()->fullPathForFilename(path);
-        if (0 == ov_fopen(fullPath.c_str(), &_vf))
+        if (0 == ov_fopen(FileUtils::getInstance()->getSuitableFOpen(fullPath).c_str(), &_vf))
         {
             // header
             vorbis_info* vi = ov_info(&_vf, -1);


### PR DESCRIPTION
If use fopen to need convert utf8 string FileUtils::getSuitableFOpen.
ov_fopen and mpg123_open use fopen.