### PR TITLE
[tolua]Lua bindings-generator support android-ndk-r9d android-ndk-r10d android-ndk-r10e (win32 support android-ndk-r9d android-ndk-r10d android-ndk-r10e android-ndk-r11c android-ndk-r13b android-ndk-r14b)

### DIFF
--- a/tools/tojs/cocos2dx.ini
+++ b/tools/tojs/cocos2dx.ini
@@ -7,10 +7,10 @@ prefix = cocos2dx
 # all classes will be embedded in that namespace
 target_namespace = cc
 
-android_headers = -I%(androidndkdir)s/platforms/android-14/arch-arm/usr/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/4.8/libs/armeabi-v7a/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/4.8/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/4.9/libs/armeabi-v7a/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/4.9/include
+android_headers = -I%(androidndkdir)s/platforms/android-14/arch-arm/usr/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/%(gnu_libstdc_version)s/libs/armeabi-v7a/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/%(gnu_libstdc_version)s/include
 android_flags = -D_SIZE_T_DEFINED_
 
-clang_headers = -I%(clangllvmdir)s/%(clang_include)s
+clang_headers = -I%(clangllvmdir)s/%(clang_lib_version)s/clang/%(clang_version)s/include 
 clang_flags = -nostdinc -x c++ -std=c++11 -U __SSE__
 
 cocos_headers = -I%(cocosdir)s/cocos -I%(cocosdir)s/cocos/platform/android -I%(cocosdir)s/external

--- a/tools/tojs/cocos2dx_3d.ini
+++ b/tools/tojs/cocos2dx_3d.ini
@@ -7,10 +7,10 @@ prefix = cocos2dx_3d
 # all classes will be embedded in that namespace
 target_namespace = jsb
 
-android_headers = -I%(androidndkdir)s/platforms/android-14/arch-arm/usr/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/4.7/libs/armeabi-v7a/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/4.7/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/4.8/libs/armeabi-v7a/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/4.8/include
+android_headers = -I%(androidndkdir)s/platforms/android-14/arch-arm/usr/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/%(gnu_libstdc_version)s/libs/armeabi-v7a/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/%(gnu_libstdc_version)s/include
 android_flags = -D_SIZE_T_DEFINED_ 
 
-clang_headers = -I%(clangllvmdir)s/%(clang_include)s 
+clang_headers = -I%(clangllvmdir)s/%(clang_lib_version)s/clang/%(clang_version)s/include 
 clang_flags = -nostdinc -x c++ -std=c++11 -U __SSE__
 
 cocos_headers = -I%(cocosdir)s/cocos -I%(cocosdir)s/cocos/platform/android -I%(cocosdir)s/external

--- a/tools/tojs/cocos2dx_3d_ext.ini
+++ b/tools/tojs/cocos2dx_3d_ext.ini
@@ -7,10 +7,10 @@ prefix = cocos2dx_3d_extension
 # all classes will be embedded in that namespace
 target_namespace = jsb
 
-android_headers = -I%(androidndkdir)s/platforms/android-14/arch-arm/usr/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/4.8/libs/armeabi-v7a/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/4.8/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/4.9/libs/armeabi-v7a/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/4.9/include
+android_headers = -I%(androidndkdir)s/platforms/android-14/arch-arm/usr/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/%(gnu_libstdc_version)s/libs/armeabi-v7a/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/%(gnu_libstdc_version)s/include
 android_flags = -D_SIZE_T_DEFINED_
 
-clang_headers = -I%(clangllvmdir)s/%(clang_include)s 
+clang_headers = -I%(clangllvmdir)s/%(clang_lib_version)s/clang/%(clang_version)s/include
 clang_flags = -nostdinc -x c++ -std=c++11 -U __SSE__
 
 cocos_headers = -I%(cocosdir)s -I%(cocosdir)s/cocos -I%(cocosdir)s/cocos/platform/android -I%(cocosdir)s/external

--- a/tools/tojs/cocos2dx_audioengine.ini
+++ b/tools/tojs/cocos2dx_audioengine.ini
@@ -9,10 +9,10 @@ target_namespace = jsb
 
 macro_judgement  = #if (CC_TARGET_PLATFORM == CC_PLATFORM_WINRT || CC_TARGET_PLATFORM == CC_PLATFORM_ANDROID || CC_TARGET_PLATFORM == CC_PLATFORM_IOS || CC_TARGET_PLATFORM == CC_PLATFORM_MAC || CC_TARGET_PLATFORM == CC_PLATFORM_WIN32)
 
-android_headers = -I%(androidndkdir)s/platforms/android-14/arch-arm/usr/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/4.8/libs/armeabi-v7a/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/4.8/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/4.9/libs/armeabi-v7a/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/4.9/include
+android_headers = -I%(androidndkdir)s/platforms/android-14/arch-arm/usr/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/%(gnu_libstdc_version)s/libs/armeabi-v7a/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/%(gnu_libstdc_version)s/include
 android_flags = -D_SIZE_T_DEFINED_ 
 
-clang_headers = -I%(clangllvmdir)s/%(clang_include)s 
+clang_headers = -I%(clangllvmdir)s/%(clang_lib_version)s/clang/%(clang_version)s/include 
 clang_flags = -nostdinc -x c++ -std=c++11 -U __SSE__
 
 cocos_headers = -I%(cocosdir)s -I%(cocosdir)s/cocos -I%(cocosdir)s/cocos/platform/android -I%(cocosdir)s/external

--- a/tools/tojs/cocos2dx_builder.ini
+++ b/tools/tojs/cocos2dx_builder.ini
@@ -7,10 +7,10 @@ prefix = cocos2dx_builder
 # all classes will be embedded in that namespace
 target_namespace = cc
 
-android_headers = -I%(androidndkdir)s/platforms/android-14/arch-arm/usr/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/4.8/libs/armeabi-v7a/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/4.8/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/4.9/libs/armeabi-v7a/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/4.9/include
+android_headers = -I%(androidndkdir)s/platforms/android-14/arch-arm/usr/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/%(gnu_libstdc_version)s/libs/armeabi-v7a/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/%(gnu_libstdc_version)s/include
 android_flags = -D_SIZE_T_DEFINED_ 
 
-clang_headers = -I%(clangllvmdir)s/%(clang_include)s 
+clang_headers = -I%(clangllvmdir)s/%(clang_lib_version)s/clang/%(clang_version)s/include 
 clang_flags = -nostdinc -x c++ -std=c++11 -U __SSE__
 
 cocos_headers = -I%(cocosdir)s -I%(cocosdir)s/cocos -I%(cocosdir)s/cocos/editor-support -I%(cocosdir)s/cocos/platform/android -I%(cocosdir)s/external

--- a/tools/tojs/cocos2dx_experimental_video.ini
+++ b/tools/tojs/cocos2dx_experimental_video.ini
@@ -9,10 +9,10 @@ target_namespace = ccui
 
 macro_judgement  = #if (CC_TARGET_PLATFORM == CC_PLATFORM_ANDROID || CC_TARGET_PLATFORM == CC_PLATFORM_IOS) && !defined(CC_TARGET_OS_TVOS)
 
-android_headers = -I%(androidndkdir)s/platforms/android-14/arch-arm/usr/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/4.8/libs/armeabi-v7a/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/4.8/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/4.9/libs/armeabi-v7a/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/4.9/include
+android_headers = -I%(androidndkdir)s/platforms/android-14/arch-arm/usr/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/%(gnu_libstdc_version)s/libs/armeabi-v7a/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/%(gnu_libstdc_version)s/include
 android_flags = -D_SIZE_T_DEFINED_ 
 
-clang_headers = -I%(clangllvmdir)s/%(clang_include)s 
+clang_headers = -I%(clangllvmdir)s/%(clang_lib_version)s/clang/%(clang_version)s/include 
 clang_flags = -nostdinc -x c++ -std=c++11 -U __SSE__
 
 cocos_headers = -I%(cocosdir)s/cocos -I%(cocosdir)s/cocos/editor-support -I%(cocosdir)s/cocos/platform/android

--- a/tools/tojs/cocos2dx_experimental_webView.ini
+++ b/tools/tojs/cocos2dx_experimental_webView.ini
@@ -9,10 +9,10 @@ target_namespace = ccui
 
 macro_judgement  = #if (CC_TARGET_PLATFORM == CC_PLATFORM_ANDROID || CC_TARGET_PLATFORM == CC_PLATFORM_IOS) && !defined(CC_TARGET_OS_TVOS)
 
-android_headers = -I%(androidndkdir)s/platforms/android-14/arch-arm/usr/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/4.8/libs/armeabi-v7a/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/4.8/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/4.9/libs/armeabi-v7a/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/4.9/include
+android_headers = -I%(androidndkdir)s/platforms/android-14/arch-arm/usr/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/%(gnu_libstdc_version)s/libs/armeabi-v7a/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/%(gnu_libstdc_version)s/include
 android_flags = -D_SIZE_T_DEFINED_ 
 
-clang_headers = -I%(clangllvmdir)s/%(clang_include)s 
+clang_headers = -I%(clangllvmdir)s/%(clang_lib_version)s/clang/%(clang_version)s/include 
 clang_flags = -nostdinc -x c++ -std=c++11 -U __SSE__
 
 cocos_headers = -I%(cocosdir)s/cocos -I%(cocosdir)s/cocos/editor-support -I%(cocosdir)s/cocos/platform/android

--- a/tools/tojs/cocos2dx_extension.ini
+++ b/tools/tojs/cocos2dx_extension.ini
@@ -7,10 +7,10 @@ prefix = cocos2dx_extension
 # all classes will be embedded in that namespace
 target_namespace = cc
 
-android_headers = -I%(androidndkdir)s/platforms/android-14/arch-arm/usr/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/4.8/libs/armeabi-v7a/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/4.8/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/4.9/libs/armeabi-v7a/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/4.9/include
+android_headers = -I%(androidndkdir)s/platforms/android-14/arch-arm/usr/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/%(gnu_libstdc_version)s/libs/armeabi-v7a/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/%(gnu_libstdc_version)s/include
 android_flags = -D_SIZE_T_DEFINED_ 
 
-clang_headers = -I%(clangllvmdir)s/%(clang_include)s 
+clang_headers = -I%(clangllvmdir)s/%(clang_lib_version)s/clang/%(clang_version)s/include 
 clang_flags = -nostdinc -x c++ -std=c++11 -U __SSE__
 
 cocos_headers = -I%(cocosdir)s -I%(cocosdir)s/cocos/editor-support -I%(cocosdir)s/cocos -I%(cocosdir)s/cocos/platform/android -I%(cocosdir)s/external

--- a/tools/tojs/cocos2dx_navmesh.ini
+++ b/tools/tojs/cocos2dx_navmesh.ini
@@ -9,10 +9,10 @@ target_namespace = jsb
 
 macro_judgement  = #if CC_USE_NAVMESH
 
-android_headers = -I%(androidndkdir)s/platforms/android-14/arch-arm/usr/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/4.8/libs/armeabi-v7a/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/4.8/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/4.9/libs/armeabi-v7a/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/4.9/include
+android_headers = -I%(androidndkdir)s/platforms/android-14/arch-arm/usr/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/%(gnu_libstdc_version)s/libs/armeabi-v7a/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/%(gnu_libstdc_version)s/include
 android_flags = -D_SIZE_T_DEFINED_ 
 
-clang_headers = -I%(clangllvmdir)s/%(clang_include)s 
+clang_headers = -I%(clangllvmdir)s/%(clang_lib_version)s/clang/%(clang_version)s/include 
 clang_flags = -nostdinc -x c++ -std=c++11 -D CC_USE_NAVMESH
 
 win32_clang_flags = -U __SSE__

--- a/tools/tojs/cocos2dx_network.ini
+++ b/tools/tojs/cocos2dx_network.ini
@@ -7,10 +7,10 @@ prefix = cocos2dx_network
 # all classes will be embedded in that namespace
 target_namespace = jsb
 
-android_headers = -I%(androidndkdir)s/platforms/android-14/arch-arm/usr/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/4.8/libs/armeabi-v7a/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/4.8/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/4.9/libs/armeabi-v7a/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/4.9/include
+android_headers = -I%(androidndkdir)s/platforms/android-14/arch-arm/usr/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/%(gnu_libstdc_version)s/libs/armeabi-v7a/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/%(gnu_libstdc_version)s/include
 android_flags = -D_SIZE_T_DEFINED_ 
 
-clang_headers = -I%(clangllvmdir)s/%(clang_include)s 
+clang_headers = -I%(clangllvmdir)s/%(clang_lib_version)s/clang/%(clang_version)s/include 
 clang_flags = -nostdinc -x c++ -std=c++11 -U __SSE__
 
 cocos_headers = -I%(cocosdir)s -I%(cocosdir)s/cocos -I%(cocosdir)s/cocos/platform/android -I%(cocosdir)s/external

--- a/tools/tojs/cocos2dx_physics3d.ini
+++ b/tools/tojs/cocos2dx_physics3d.ini
@@ -9,10 +9,10 @@ target_namespace = jsb
 
 macro_judgement  = #if CC_USE_3D_PHYSICS && CC_ENABLE_BULLET_INTEGRATION
 
-android_headers = -I%(androidndkdir)s/platforms/android-14/arch-arm/usr/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/4.8/libs/armeabi-v7a/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/4.8/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/4.9/libs/armeabi-v7a/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/4.9/include
+android_headers = -I%(androidndkdir)s/platforms/android-14/arch-arm/usr/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/%(gnu_libstdc_version)s/libs/armeabi-v7a/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/%(gnu_libstdc_version)s/include
 android_flags = -D_SIZE_T_DEFINED_
 
-clang_headers = -I%(clangllvmdir)s/%(clang_include)s 
+clang_headers = -I%(clangllvmdir)s/%(clang_lib_version)s/clang/%(clang_version)s/include 
 clang_flags = -nostdinc -x c++ -std=c++11 -D CC_ENABLE_BULLET_INTEGRATION -D CC_USE_3D_PHYSICS
 
 win32_clang_flags = -U __SSE__

--- a/tools/tojs/cocos2dx_spine.ini
+++ b/tools/tojs/cocos2dx_spine.ini
@@ -3,10 +3,10 @@ prefix = cocos2dx_spine
 
 target_namespace = sp
 
-android_headers = -I%(androidndkdir)s/platforms/android-14/arch-arm/usr/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/4.8/libs/armeabi-v7a/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/4.8/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/4.9/libs/armeabi-v7a/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/4.9/include
+android_headers = -I%(androidndkdir)s/platforms/android-14/arch-arm/usr/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/%(gnu_libstdc_version)s/libs/armeabi-v7a/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/%(gnu_libstdc_version)s/include
 android_flags = -D_SIZE_T_DEFINED_ 
 
-clang_headers = -I%(clangllvmdir)s/%(clang_include)s 
+clang_headers = -I%(clangllvmdir)s/%(clang_lib_version)s/clang/%(clang_version)s/include 
 clang_flags = -nostdinc -x c++ -std=c++11 -U __SSE__ -DNO_JS_ASSERT -DUINT32_MAX=0xffffffff
 
 cocos_headers = -I%(cocosdir)s/cocos -I%(cocosdir)s/cocos/editor-support -I%(cocosdir)s/cocos/platform/android -I%(cocosdir)s/external/spidermonkey/include/android -I%(cocosdir)s/external

--- a/tools/tojs/cocos2dx_studio.ini
+++ b/tools/tojs/cocos2dx_studio.ini
@@ -7,10 +7,10 @@ prefix = cocos2dx_studio
 # all classes will be embedded in that namespace
 target_namespace = ccs
 
-android_headers = -I%(androidndkdir)s/platforms/android-14/arch-arm/usr/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/4.8/libs/armeabi-v7a/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/4.8/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/4.9/libs/armeabi-v7a/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/4.9/include
+android_headers = -I%(androidndkdir)s/platforms/android-14/arch-arm/usr/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/%(gnu_libstdc_version)s/libs/armeabi-v7a/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/%(gnu_libstdc_version)s/include
 android_flags = -D_SIZE_T_DEFINED_ 
 
-clang_headers = -I%(clangllvmdir)s/%(clang_include)s 
+clang_headers = -I%(clangllvmdir)s/%(clang_lib_version)s/clang/%(clang_version)s/include 
 clang_flags = -nostdinc -x c++ -std=c++11 -U __SSE__ -DNO_JS_ASSERT -DUINT32_MAX=0xffffffff
 
 cocos_headers = -I%(cocosdir)s/external -I%(cocosdir)s/cocos -I%(cocosdir)s/cocos/editor-support -I%(cocosdir)s/cocos/platform/android -I%(jsbdir)s/manual -I%(cocosdir)s/external/spidermonkey/include/android

--- a/tools/tojs/cocos2dx_ui.ini
+++ b/tools/tojs/cocos2dx_ui.ini
@@ -10,10 +10,10 @@ target_namespace = ccui
 # the native namespace in which this module locates, this parameter is used for avoid conflict of the same class name in different modules, as "cocos2d::Label" <-> "cocos2d::ui::Label".
 cpp_namespace = cocos2d::ui
 
-android_headers = -I%(androidndkdir)s/platforms/android-14/arch-arm/usr/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/4.8/libs/armeabi-v7a/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/4.8/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/4.9/libs/armeabi-v7a/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/4.9/include
+android_headers = -I%(androidndkdir)s/platforms/android-14/arch-arm/usr/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/%(gnu_libstdc_version)s/libs/armeabi-v7a/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/%(gnu_libstdc_version)s/include
 android_flags = -D_SIZE_T_DEFINED_ 
 
-clang_headers = -I%(clangllvmdir)s/%(clang_include)s 
+clang_headers = -I%(clangllvmdir)s/%(clang_lib_version)s/clang/%(clang_version)s/include 
 clang_flags = -nostdinc -x c++ -std=c++11 -U __SSE__
 
 cocos_headers = -I%(cocosdir)s/cocos -I%(cocosdir)s/cocos/editor-support -I%(cocosdir)s/cocos/platform/android -I%(cocosdir)s/external

--- a/tools/tojs/genbindings.py
+++ b/tools/tojs/genbindings.py
@@ -76,21 +76,24 @@ def main():
         sys.exit(1)
 
     if platform == 'win32':
-        x86_llvm_path = os.path.abspath(os.path.join(ndk_root, 'toolchains/llvm-3.6/prebuilt', '%s' % cur_platform))
+        x86_llvm_path = os.path.abspath(os.path.join(ndk_root, 'toolchains/llvm-3.4/prebuilt', '%s' % cur_platform))
         if not os.path.exists(x86_llvm_path):
-            x86_llvm_path = os.path.abspath(os.path.join(ndk_root, 'toolchains/llvm-3.5/prebuilt', '%s' % cur_platform))
-        if not os.path.exists(x86_llvm_path):
-            x86_llvm_path = os.path.abspath(os.path.join(ndk_root, 'toolchains/llvm/prebuilt', '%s' % cur_platform))
+            x86_llvm_path = os.path.abspath(os.path.join(ndk_root, 'toolchains/llvm-3.3/prebuilt', '%s' % cur_platform))
     else:
-        x86_llvm_path = os.path.abspath(os.path.join(ndk_root, 'toolchains/llvm-3.6/prebuilt', '%s-%s' % (cur_platform, 'x86')))
+        x86_llvm_path = os.path.abspath(os.path.join(ndk_root, 'toolchains/llvm-3.4/prebuilt', '%s-%s' % (cur_platform, 'x86')))
         if not os.path.exists(x86_llvm_path):
-            x86_llvm_path = os.path.abspath(os.path.join(ndk_root, 'toolchains/llvm-3.5/prebuilt', '%s-%s' % (cur_platform, 'x86')))
-        if not os.path.exists(x86_llvm_path):
-            x86_llvm_path = os.path.abspath(os.path.join(ndk_root, 'toolchains/llvm/prebuilt', '%s-%s' % (cur_platform, 'x86')))
+            x86_llvm_path = os.path.abspath(os.path.join(ndk_root, 'toolchains/llvm-3.3/prebuilt', '%s-%s' % (cur_platform, 'x86')))
 
-    x64_llvm_path = os.path.abspath(os.path.join(ndk_root, 'toolchains/llvm-3.6/prebuilt', '%s-%s' % (cur_platform, 'x86_64')))
+    x64_llvm_path = os.path.abspath(os.path.join(ndk_root, 'toolchains/llvm-3.4/prebuilt', '%s-%s' % (cur_platform, 'x86_64')))
+    if not os.path.exists(x64_llvm_path):
+        x64_llvm_path = os.path.abspath(os.path.join(ndk_root, 'toolchains/llvm-3.3/prebuilt', '%s-%s' % (cur_platform, 'x86_64')))
+
     if not os.path.exists(x64_llvm_path):
         x64_llvm_path = os.path.abspath(os.path.join(ndk_root, 'toolchains/llvm-3.5/prebuilt', '%s-%s' % (cur_platform, 'x86_64')))
+        
+    if not os.path.exists(x64_llvm_path):
+        x64_llvm_path = os.path.abspath(os.path.join(ndk_root, 'toolchains/llvm-3.6/prebuilt', '%s-%s' % (cur_platform, 'x86_64')))
+
     if not os.path.exists(x64_llvm_path):
         x64_llvm_path = os.path.abspath(os.path.join(ndk_root, 'toolchains/llvm/prebuilt', '%s-%s' % (cur_platform, 'x86_64')))
 
@@ -116,14 +119,22 @@ def main():
     config.set('DEFAULT', 'jsbdir', jsb_root)
     config.set('DEFAULT', 'cxxgeneratordir', cxx_generator_root)
     config.set('DEFAULT', 'extra_flags', '')
+    config.set('DEFAULT', 'clang_lib_version', 'lib')
+    config.set('DEFAULT', 'gnu_libstdc_version', '4.8')
     
-    if '3.' in llvm_path:
-        if '3.6' in llvm_path:
-            config.set('DEFAULT', 'clang_include', 'lib/clang/3.6/include')
-        else:
-            config.set('DEFAULT', 'clang_include', 'lib/clang/3.5/include')
+    
+    if '3.3' in llvm_path:
+        config.set('DEFAULT', 'clang_version', '3.3')
+    elif '3.4' in llvm_path:
+        config.set('DEFAULT', 'clang_version', '3.4')
+    elif '3.5' in llvm_path:
+        config.set('DEFAULT', 'clang_version', '3.5')
+    elif '3.6' in llvm_path:
+        config.set('DEFAULT', 'clang_version', '3.6')
     else:
-        config.set('DEFAULT', 'clang_include', 'lib64/clang/3.8/include')
+        config.set('DEFAULT', 'clang_version', '3.8')
+        config.set('DEFAULT', 'clang_lib_version', 'lib64')
+        config.set('DEFAULT', 'gnu_libstdc_version', '4.9')
 
     # To fix parse error on windows, we must difine __WCHAR_MAX__ and undefine __MINGW32__ .
     if platform == 'win32':

--- a/tools/tolua/cocos2dx.ini
+++ b/tools/tolua/cocos2dx.ini
@@ -7,10 +7,10 @@ prefix = cocos2dx
 # all classes will be embedded in that namespace
 target_namespace = cc
 
-android_headers = -I%(androidndkdir)s/platforms/android-14/arch-arm/usr/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/4.7/libs/armeabi-v7a/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/4.7/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/4.8/libs/armeabi-v7a/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/4.8/include
+android_headers = -I%(androidndkdir)s/platforms/android-14/arch-arm/usr/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/%(gnu_libstdc_version)s/libs/armeabi-v7a/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/%(gnu_libstdc_version)s/include
 android_flags = -D_SIZE_T_DEFINED_
 
-clang_headers = -I%(clangllvmdir)s/lib/clang/%(clang_version)s/include
+clang_headers = -I%(clangllvmdir)s/%(clang_lib_version)s/clang/%(clang_version)s/include
 clang_flags = -nostdinc -x c++ -std=c++11 -U __SSE__
 
 cocos_headers = -I%(cocosdir)s/cocos -I%(cocosdir)s/cocos/platform/android -I%(cocosdir)s/cocos/editor-support -I%(cocosdir)s/external
@@ -100,7 +100,7 @@ skip = Node::[setGLServerState description getUserObject .*UserData getGLServerS
         TextureCache::[addPVRTCImage addImageAsync],
         Timer::[getSelector createWithScriptHandler],
         *::[copyWith.* onEnter.* onExit.* ^description$ getObjectType (g|s)etDelegate onTouch.* onAcc.* onKey.* onRegisterTouchListener],
-        FileUtils::[getFileData getDataFromFile writeDataToFile getFullPathCache getContents listFilesAsync listFilesRecursivelyAsync],
+        FileUtils::[getFileData getDataFromFile writeDataToFile getFullPathCache getContents],
         Application::[^application.* ^run$],
         Camera::[getEyeXYZ getCenterXYZ getUpXYZ],
         ccFontDefinition::[*],
@@ -144,8 +144,7 @@ skip = Node::[setGLServerState description getUserObject .*UserData getGLServerS
         RenderState::[finalize setStateBlock],
         Properties::[createNonRefCounted],
         AutoPolygon::[trace reduce expand triangulate calculateUV generateTriangles generatePolygon],
-        PolygonInfo::[operator=],
-        AsyncTaskPool::[enqueue]
+        PolygonInfo::[operator=]
 
 rename_functions = SpriteFrameCache::[addSpriteFramesWithFile=addSpriteFrames getSpriteFrameByName=getSpriteFrame],
     ProgressTimer::[setReverseProgress=setReverseDirection],

--- a/tools/tolua/cocos2dx_3d.ini
+++ b/tools/tolua/cocos2dx_3d.ini
@@ -7,10 +7,10 @@ prefix = cocos2dx_3d
 # all classes will be embedded in that namespace
 target_namespace = cc
 
-android_headers = -I%(androidndkdir)s/platforms/android-14/arch-arm/usr/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/4.7/libs/armeabi-v7a/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/4.7/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/4.8/libs/armeabi-v7a/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/4.8/include
+android_headers = -I%(androidndkdir)s/platforms/android-14/arch-arm/usr/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/%(gnu_libstdc_version)s/libs/armeabi-v7a/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/%(gnu_libstdc_version)s/include
 android_flags = -D_SIZE_T_DEFINED_ 
 
-clang_headers = -I%(clangllvmdir)s/lib/clang/%(clang_version)s/include 
+clang_headers = -I%(clangllvmdir)s/%(clang_lib_version)s/clang/%(clang_version)s/include
 clang_flags = -nostdinc -x c++ -std=c++11 -U __SSE__
 
 cocos_headers = -I%(cocosdir)s/cocos -I%(cocosdir)s/cocos/platform/android -I%(cocosdir)s/external

--- a/tools/tolua/cocos2dx_audioengine.ini
+++ b/tools/tolua/cocos2dx_audioengine.ini
@@ -9,10 +9,10 @@ target_namespace = ccexp
 
 macro_judgement  = #if CC_TARGET_PLATFORM == CC_PLATFORM_ANDROID || CC_TARGET_PLATFORM == CC_PLATFORM_IOS || CC_TARGET_PLATFORM == CC_PLATFORM_MAC || CC_TARGET_PLATFORM == CC_PLATFORM_WIN32 || CC_TARGET_PLATFORM == CC_PLATFORM_TIZEN
 
-android_headers = -I%(androidndkdir)s/platforms/android-14/arch-arm/usr/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/4.7/libs/armeabi-v7a/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/4.7/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/4.8/libs/armeabi-v7a/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/4.8/include
+android_headers = -I%(androidndkdir)s/platforms/android-14/arch-arm/usr/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/%(gnu_libstdc_version)s/libs/armeabi-v7a/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/%(gnu_libstdc_version)s/include
 android_flags = -D_SIZE_T_DEFINED_ 
 
-clang_headers = -I%(clangllvmdir)s/lib/clang/%(clang_version)s/include 
+clang_headers = -I%(clangllvmdir)s/%(clang_lib_version)s/clang/%(clang_version)s/include
 clang_flags = -nostdinc -x c++ -std=c++11 -U __SSE__
 
 cocos_headers = -I%(cocosdir)s -I%(cocosdir)s/cocos -I%(cocosdir)s/cocos/platform/android -I%(cocosdir)s/external

--- a/tools/tolua/cocos2dx_cocosbuilder.ini
+++ b/tools/tolua/cocos2dx_cocosbuilder.ini
@@ -7,10 +7,10 @@ prefix = cocos2dx_cocosbuilder
 # all classes will be embedded in that namespace
 target_namespace = cc
 
-android_headers = -I%(androidndkdir)s/platforms/android-14/arch-arm/usr/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/4.7/libs/armeabi-v7a/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/4.7/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/4.8/libs/armeabi-v7a/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/4.8/include
+android_headers = -I%(androidndkdir)s/platforms/android-14/arch-arm/usr/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/%(gnu_libstdc_version)s/libs/armeabi-v7a/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/%(gnu_libstdc_version)s/include
 android_flags = -D_SIZE_T_DEFINED_ 
 
-clang_headers = -I%(clangllvmdir)s/lib/clang/%(clang_version)s/include 
+clang_headers = -I%(clangllvmdir)s/%(clang_lib_version)s/clang/%(clang_version)s/include
 clang_flags = -nostdinc -x c++ -std=c++11 -U __SSE__
 
 cocos_headers = -I%(cocosdir)s -I%(cocosdir)s/cocos -I%(cocosdir)s/cocos/editor-support -I%(cocosdir)s/cocos/platform/android -I%(cocosdir)s/external

--- a/tools/tolua/cocos2dx_cocosdenshion.ini
+++ b/tools/tolua/cocos2dx_cocosdenshion.ini
@@ -7,10 +7,10 @@ prefix = cocos2dx_cocosdenshion
 # all classes will be embedded in that namespace
 target_namespace = cc
 
-android_headers = -I%(androidndkdir)s/platforms/android-14/arch-arm/usr/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/4.7/libs/armeabi-v7a/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/4.7/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/4.8/libs/armeabi-v7a/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/4.8/include
+android_headers = -I%(androidndkdir)s/platforms/android-14/arch-arm/usr/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/%(gnu_libstdc_version)s/libs/armeabi-v7a/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/%(gnu_libstdc_version)s/include
 android_flags = -D_SIZE_T_DEFINED_ 
 
-clang_headers = -I%(clangllvmdir)s/lib/clang/%(clang_version)s/include 
+clang_headers = -I%(clangllvmdir)s/%(clang_lib_version)s/clang/%(clang_version)s/include
 clang_flags = -nostdinc -x c++ -std=c++11 -U __SSE__
 
 cocos_headers = -I%(cocosdir)s -I%(cocosdir)s/cocos -I%(cocosdir)s/cocos/platform/android -I%(cocosdir)s/external

--- a/tools/tolua/cocos2dx_controller.ini
+++ b/tools/tolua/cocos2dx_controller.ini
@@ -9,10 +9,10 @@ target_namespace = cc
 
 macro_judgement  = #if (CC_TARGET_PLATFORM == CC_PLATFORM_ANDROID || CC_TARGET_PLATFORM == CC_PLATFORM_IOS)
 
-android_headers = -I%(androidndkdir)s/platforms/android-14/arch-arm/usr/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/4.7/libs/armeabi-v7a/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/4.7/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/4.8/libs/armeabi-v7a/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/4.8/include
+android_headers = -I%(androidndkdir)s/platforms/android-14/arch-arm/usr/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/%(gnu_libstdc_version)s/libs/armeabi-v7a/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/%(gnu_libstdc_version)s/include
 android_flags = -D_SIZE_T_DEFINED_ 
 
-clang_headers = -I%(clangllvmdir)s/lib/clang/%(clang_version)s/include 
+clang_headers = -I%(clangllvmdir)s/%(clang_lib_version)s/clang/%(clang_version)s/include -I%(androidndkdir)s/sources/cxx-stl/llvm-libc++/include
 clang_flags = -nostdinc -x c++ -std=c++11 -U __SSE__
 
 cocos_headers = -I%(cocosdir)s/cocos -I%(cocosdir)s/cocos/base -I%(cocosdir)s/cocos/platform/android -I%(cocosdir)s/external

--- a/tools/tolua/cocos2dx_csloader.ini
+++ b/tools/tolua/cocos2dx_csloader.ini
@@ -7,10 +7,10 @@ prefix = cocos2dx_csloader
 # all classes will be embedded in that namespace
 target_namespace = cc
 
-android_headers = -I%(androidndkdir)s/platforms/android-14/arch-arm/usr/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/4.7/libs/armeabi-v7a/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/4.7/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/4.8/libs/armeabi-v7a/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/4.8/include
+android_headers = -I%(androidndkdir)s/platforms/android-14/arch-arm/usr/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/%(gnu_libstdc_version)s/libs/armeabi-v7a/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/%(gnu_libstdc_version)s/include
 android_flags = -D_SIZE_T_DEFINED_ 
 
-clang_headers = -I%(clangllvmdir)s/lib/clang/%(clang_version)s/include 
+clang_headers = -I%(clangllvmdir)s/%(clang_lib_version)s/clang/%(clang_version)s/include
 clang_flags = -nostdinc -x c++ -std=c++11 -U __SSE__
 
 cocos_headers = -I%(cocosdir)s/cocos -I%(cocosdir)s/cocos/editor-support -I%(cocosdir)s/cocos/platform/android -I%(cocosdir)s/external

--- a/tools/tolua/cocos2dx_experimental.ini
+++ b/tools/tolua/cocos2dx_experimental.ini
@@ -7,10 +7,10 @@ prefix = cocos2dx_experimental
 # all classes will be embedded in that namespace
 target_namespace = ccexp
 
-android_headers = -I%(androidndkdir)s/platforms/android-14/arch-arm/usr/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/4.7/libs/armeabi-v7a/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/4.7/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/4.8/libs/armeabi-v7a/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/4.8/include
+android_headers = -I%(androidndkdir)s/platforms/android-14/arch-arm/usr/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/%(gnu_libstdc_version)s/libs/armeabi-v7a/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/%(gnu_libstdc_version)s/include
 android_flags = -D_SIZE_T_DEFINED_ 
 
-clang_headers = -I%(clangllvmdir)s/lib/clang/%(clang_version)s/include 
+clang_headers = -I%(clangllvmdir)s/%(clang_lib_version)s/clang/%(clang_version)s/include
 clang_flags = -nostdinc -x c++ -std=c++11 -U __SSE__
 
 cocos_headers = -I%(cocosdir)s/cocos -I%(cocosdir)s/cocos/editor-support -I%(cocosdir)s/cocos/platform/android -I%(cocosdir)s/external

--- a/tools/tolua/cocos2dx_experimental_video.ini
+++ b/tools/tolua/cocos2dx_experimental_video.ini
@@ -9,10 +9,10 @@ target_namespace = ccexp
 
 macro_judgement  = #if (CC_TARGET_PLATFORM == CC_PLATFORM_ANDROID || CC_TARGET_PLATFORM == CC_PLATFORM_IOS) && !defined(CC_TARGET_OS_TVOS)
 
-android_headers = -I%(androidndkdir)s/platforms/android-14/arch-arm/usr/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/4.7/libs/armeabi-v7a/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/4.7/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/4.8/libs/armeabi-v7a/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/4.8/include
+android_headers = -I%(androidndkdir)s/platforms/android-14/arch-arm/usr/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/%(gnu_libstdc_version)s/libs/armeabi-v7a/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/%(gnu_libstdc_version)s/include
 android_flags = -D_SIZE_T_DEFINED_ 
 
-clang_headers = -I%(clangllvmdir)s/lib/clang/%(clang_version)s/include 
+clang_headers = -I%(clangllvmdir)s/%(clang_lib_version)s/clang/%(clang_version)s/include
 clang_flags = -nostdinc -x c++ -std=c++11 -U __SSE__
 
 cocos_headers = -I%(cocosdir)s/cocos -I%(cocosdir)s/cocos/editor-support -I%(cocosdir)s/cocos/platform/android -I%(cocosdir)s/external

--- a/tools/tolua/cocos2dx_experimental_webview.ini
+++ b/tools/tolua/cocos2dx_experimental_webview.ini
@@ -9,10 +9,10 @@ target_namespace = ccexp
 
 macro_judgement  = #if (CC_TARGET_PLATFORM == CC_PLATFORM_ANDROID || CC_TARGET_PLATFORM == CC_PLATFORM_IOS) && !defined(CC_TARGET_OS_TVOS)
 
-android_headers = -I%(androidndkdir)s/platforms/android-14/arch-arm/usr/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/4.7/libs/armeabi-v7a/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/4.7/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/4.8/libs/armeabi-v7a/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/4.8/include
+android_headers = -I%(androidndkdir)s/platforms/android-14/arch-arm/usr/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/%(gnu_libstdc_version)s/libs/armeabi-v7a/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/%(gnu_libstdc_version)s/include
 android_flags = -D_SIZE_T_DEFINED_ 
 
-clang_headers = -I%(clangllvmdir)s/lib/clang/%(clang_version)s/include 
+clang_headers = -I%(clangllvmdir)s/%(clang_lib_version)s/clang/%(clang_version)s/include
 clang_flags = -nostdinc -x c++ -std=c++11 -U __SSE__
 
 cocos_headers = -I%(cocosdir)s/cocos -I%(cocosdir)s/cocos/editor-support -I%(cocosdir)s/cocos/platform/android -I%(cocosdir)s/external

--- a/tools/tolua/cocos2dx_extension.ini
+++ b/tools/tolua/cocos2dx_extension.ini
@@ -7,10 +7,10 @@ prefix = cocos2dx_extension
 # all classes will be embedded in that namespace
 target_namespace = cc
 
-android_headers = -I%(androidndkdir)s/platforms/android-14/arch-arm/usr/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/4.7/libs/armeabi-v7a/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/4.7/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/4.8/libs/armeabi-v7a/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/4.8/include
+android_headers = -I%(androidndkdir)s/platforms/android-14/arch-arm/usr/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/%(gnu_libstdc_version)s/libs/armeabi-v7a/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/%(gnu_libstdc_version)s/include
 android_flags = -D_SIZE_T_DEFINED_ 
 
-clang_headers = -I%(clangllvmdir)s/lib/clang/%(clang_version)s/include 
+clang_headers = -I%(clangllvmdir)s/%(clang_lib_version)s/clang/%(clang_version)s/include
 clang_flags = -nostdinc -x c++ -std=c++11 -U __SSE__
 
 cocos_headers = -I%(cocosdir)s -I%(cocosdir)s/cocos/editor-support -I%(cocosdir)s/cocos -I%(cocosdir)s/cocos/platform/android -I%(cocosdir)s/external -I%(cocosdir)s/external/json

--- a/tools/tolua/cocos2dx_navmesh.ini
+++ b/tools/tolua/cocos2dx_navmesh.ini
@@ -9,10 +9,10 @@ target_namespace = cc
 
 macro_judgement  = #if CC_USE_NAVMESH
 
-android_headers = -I%(androidndkdir)s/platforms/android-14/arch-arm/usr/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/4.7/libs/armeabi-v7a/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/4.7/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/4.8/libs/armeabi-v7a/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/4.8/include
+android_headers = -I%(androidndkdir)s/platforms/android-14/arch-arm/usr/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/%(gnu_libstdc_version)s/libs/armeabi-v7a/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/%(gnu_libstdc_version)s/include
 android_flags = -D_SIZE_T_DEFINED_ 
 
-clang_headers = -I%(clangllvmdir)s/lib/clang/%(clang_version)s/include 
+clang_headers = -I%(clangllvmdir)s/%(clang_lib_version)s/clang/%(clang_version)s/include
 clang_flags = -nostdinc -x c++ -std=c++11 -D CC_USE_NAVMESH
 
 win32_clang_flags = -U __SSE__

--- a/tools/tolua/cocos2dx_physics.ini
+++ b/tools/tolua/cocos2dx_physics.ini
@@ -9,10 +9,10 @@ target_namespace = cc
 
 macro_judgement  = #if CC_USE_PHYSICS
 
-android_headers = -I%(androidndkdir)s/platforms/android-14/arch-arm/usr/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/4.7/libs/armeabi-v7a/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/4.7/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/4.8/libs/armeabi-v7a/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/4.8/include
+android_headers = -I%(androidndkdir)s/platforms/android-14/arch-arm/usr/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/%(gnu_libstdc_version)s/libs/armeabi-v7a/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/%(gnu_libstdc_version)s/include
 android_flags = -D_SIZE_T_DEFINED_ 
 
-clang_headers = -I%(clangllvmdir)s/lib/clang/%(clang_version)s/include 
+clang_headers = -I%(clangllvmdir)s/%(clang_lib_version)s/clang/%(clang_version)s/include
 clang_flags = -nostdinc -x c++ -std=c++11 -U __SSE__
 
 cocos_headers = -I%(cocosdir)s/cocos -I%(cocosdir)s/cocos/platform/android -I%(cocosdir)s/external

--- a/tools/tolua/cocos2dx_physics3d.ini
+++ b/tools/tolua/cocos2dx_physics3d.ini
@@ -9,10 +9,10 @@ target_namespace = cc
 
 macro_judgement  = #if CC_USE_3D_PHYSICS && CC_ENABLE_BULLET_INTEGRATION
 
-android_headers = -I%(androidndkdir)s/platforms/android-14/arch-arm/usr/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/4.7/libs/armeabi-v7a/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/4.7/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/4.8/libs/armeabi-v7a/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/4.8/include
+android_headers = -I%(androidndkdir)s/platforms/android-14/arch-arm/usr/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/%(gnu_libstdc_version)s/libs/armeabi-v7a/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/%(gnu_libstdc_version)s/include
 android_flags = -D_SIZE_T_DEFINED_ 
 
-clang_headers = -I%(clangllvmdir)s/lib/clang/%(clang_version)s/include 
+clang_headers = -I%(clangllvmdir)s/%(clang_lib_version)s/clang/%(clang_version)s/include
 clang_flags = -nostdinc -x c++ -std=c++11 -D CC_ENABLE_BULLET_INTEGRATION
 
 win32_clang_flags = -U __SSE__

--- a/tools/tolua/cocos2dx_spine.ini
+++ b/tools/tolua/cocos2dx_spine.ini
@@ -7,10 +7,10 @@ prefix = cocos2dx_spine
 # all classes will be embedded in that namespace
 target_namespace = sp
 
-android_headers = -I%(androidndkdir)s/platforms/android-14/arch-arm/usr/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/4.7/libs/armeabi-v7a/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/4.7/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/4.8/libs/armeabi-v7a/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/4.8/include
+android_headers = -I%(androidndkdir)s/platforms/android-14/arch-arm/usr/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/%(gnu_libstdc_version)s/libs/armeabi-v7a/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/%(gnu_libstdc_version)s/include
 android_flags = -D_SIZE_T_DEFINED_ 
 
-clang_headers = -I%(clangllvmdir)s/lib/clang/%(clang_version)s/include 
+clang_headers = -I%(clangllvmdir)s/%(clang_lib_version)s/clang/%(clang_version)s/include
 clang_flags = -nostdinc -x c++ -std=c++11 -U __SSE__
 
 cocos_headers = -I%(cocosdir)s/cocos -I%(cocosdir)s/cocos/editor-support -I%(cocosdir)s/cocos/platform/android -I%(cocosdir)s/external

--- a/tools/tolua/cocos2dx_studio.ini
+++ b/tools/tolua/cocos2dx_studio.ini
@@ -10,10 +10,10 @@ target_namespace = ccs
 # the native namespace in which this module locates, this parameter is used for avoid conflict of the same class name in different modules, as "cocos2d::Label" <-> "cocos2d::ui::Label".
 cpp_namespace = cocostudio
 
-android_headers = -I%(androidndkdir)s/platforms/android-14/arch-arm/usr/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/4.7/libs/armeabi-v7a/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/4.7/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/4.8/libs/armeabi-v7a/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/4.8/include
+android_headers = -I%(androidndkdir)s/platforms/android-14/arch-arm/usr/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/%(gnu_libstdc_version)s/libs/armeabi-v7a/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/%(gnu_libstdc_version)s/include
 android_flags = -D_SIZE_T_DEFINED_
 
-clang_headers = -I%(clangllvmdir)s/lib/clang/%(clang_version)s/include
+clang_headers = -I%(clangllvmdir)s/%(clang_lib_version)s/clang/%(clang_version)s/include
 clang_flags = -nostdinc -x c++ -std=c++11 -U __SSE__
 
 cocos_headers = -I%(cocosdir)s/external -I%(cocosdir)s/cocos -I%(cocosdir)s/cocos/editor-support -I%(cocosdir)s/cocos/platform/android -I%(cocosdir)s/external/lua/luajit/include -I%(cocosdir)s/external/lua/tolua -I%(cocosdir)s/cocos/scripting/lua-bindings/manual

--- a/tools/tolua/cocos2dx_ui.ini
+++ b/tools/tolua/cocos2dx_ui.ini
@@ -10,10 +10,10 @@ target_namespace = ccui
 # the native namespace in which this module locates, this parameter is used for avoid conflict of the same class name in different modules, as "cocos2d::Label" <-> "cocos2d::ui::Label".
 cpp_namespace = cocos2d::ui
 
-android_headers = -I%(androidndkdir)s/platforms/android-14/arch-arm/usr/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/4.7/libs/armeabi-v7a/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/4.7/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/4.8/libs/armeabi-v7a/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/4.8/include
+android_headers = -I%(androidndkdir)s/platforms/android-14/arch-arm/usr/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/%(gnu_libstdc_version)s/libs/armeabi-v7a/include -I%(androidndkdir)s/sources/cxx-stl/gnu-libstdc++/%(gnu_libstdc_version)s/include
 android_flags = -D_SIZE_T_DEFINED_ 
 
-clang_headers = -I%(clangllvmdir)s/lib/clang/%(clang_version)s/include 
+clang_headers = -I%(clangllvmdir)s/%(clang_lib_version)s/clang/%(clang_version)s/include
 clang_flags = -nostdinc -x c++ -std=c++11 -U __SSE__
 
 cocos_headers = -I%(cocosdir)s/cocos -I%(cocosdir)s/cocos/editor-support -I%(cocosdir)s/cocos/platform/android

--- a/tools/tolua/genbindings.py
+++ b/tools/tolua/genbindings.py
@@ -88,6 +88,15 @@ def main():
     if not os.path.exists(x64_llvm_path):
         x64_llvm_path = os.path.abspath(os.path.join(ndk_root, 'toolchains/llvm-3.3/prebuilt', '%s-%s' % (cur_platform, 'x86_64')))
 
+    if not os.path.exists(x64_llvm_path):
+        x64_llvm_path = os.path.abspath(os.path.join(ndk_root, 'toolchains/llvm-3.5/prebuilt', '%s-%s' % (cur_platform, 'x86_64')))
+        
+    if not os.path.exists(x64_llvm_path):
+        x64_llvm_path = os.path.abspath(os.path.join(ndk_root, 'toolchains/llvm-3.6/prebuilt', '%s-%s' % (cur_platform, 'x86_64')))
+
+    if not os.path.exists(x64_llvm_path):
+        x64_llvm_path = os.path.abspath(os.path.join(ndk_root, 'toolchains/llvm/prebuilt', '%s-%s' % (cur_platform, 'x86_64')))
+
     if os.path.isdir(x86_llvm_path):
         llvm_path = x86_llvm_path
     elif os.path.isdir(x64_llvm_path):
@@ -108,11 +117,22 @@ def main():
     config.set('DEFAULT', 'cocosdir', cocos_root)
     config.set('DEFAULT', 'cxxgeneratordir', cxx_generator_root)
     config.set('DEFAULT', 'extra_flags', '')
+    config.set('DEFAULT', 'clang_lib_version', 'lib')
+    config.set('DEFAULT', 'gnu_libstdc_version', '4.8')
     
-    if '3.4' in llvm_path:
-        config.set('DEFAULT', 'clang_version', '3.4')
-    else:
+    
+    if '3.3' in llvm_path:
         config.set('DEFAULT', 'clang_version', '3.3')
+    elif '3.4' in llvm_path:
+        config.set('DEFAULT', 'clang_version', '3.4')
+    elif '3.5' in llvm_path:
+        config.set('DEFAULT', 'clang_version', '3.5')
+    elif '3.6' in llvm_path:
+        config.set('DEFAULT', 'clang_version', '3.6')
+    else:
+    	config.set('DEFAULT', 'clang_version', '3.8')
+    	config.set('DEFAULT', 'clang_lib_version', 'lib64')
+    	config.set('DEFAULT', 'gnu_libstdc_version', '4.9')
 
     # To fix parse error on windows, we must difine __WCHAR_MAX__ and undefine __MINGW32__ .
     if platform == 'win32':


### PR DESCRIPTION
[tolua]Lua bindings-generator support android-ndk-r9d android-ndk-r10d android-ndk-r10e
(win32 support android-ndk-r9d android-ndk-r10d android-ndk-r10e android-ndk-r11c android-ndk-r13b android-ndk-r14b)

macOS下android-ndk-r13b android-ndk-r14b生成时cocos2dx_physics3d.ini会出错其它正确，目前只能测试到这些，其它NDK版本未测试，但相比原来的版本兼容性已经好很多。