### PR TITLE
Allow visit Sprite without camera for render to texture

### DIFF
--- a/cocos/2d/CCSprite.cpp
+++ b/cocos/2d/CCSprite.cpp
@@ -1054,7 +1054,10 @@ void Sprite::draw(Renderer *renderer, const Mat4 &transform, uint32_t flags)
     // Don't calculate the culling if the transform was not updated
     auto visitingCamera = Camera::getVisitingCamera();
     auto defaultCamera = Camera::getDefaultCamera();
-    if (visitingCamera == defaultCamera) {
+    if (visitingCamera == NULL) {
+        _insideBounds = true;
+    }
+    else if (visitingCamera == defaultCamera) {
         _insideBounds = ((flags & FLAGS_TRANSFORM_DIRTY) || visitingCamera->isViewProjectionUpdated()) ? renderer->checkVisibility(transform, _contentSize) : _insideBounds;
     }
     else

--- a/cocos/2d/CCSprite.cpp
+++ b/cocos/2d/CCSprite.cpp
@@ -1054,7 +1054,7 @@ void Sprite::draw(Renderer *renderer, const Mat4 &transform, uint32_t flags)
     // Don't calculate the culling if the transform was not updated
     auto visitingCamera = Camera::getVisitingCamera();
     auto defaultCamera = Camera::getDefaultCamera();
-    if (visitingCamera == NULL) {
+    if (visitingCamera == nullptr) {
         _insideBounds = true;
     }
     else if (visitingCamera == defaultCamera) {


### PR DESCRIPTION
A fix to allow render to texture like this 
```
        Director::getInstance()->setProjection(Director::Projection::_2D);
        m_renderTarget->beginWithClear(1, 0, 0, 0.2, m_depthClear, 0);
        m_sprite->visit(Director::getInstance()->getRenderer(), Mat4::IDENTITY, 0);
        m_renderTarget->end();
        Director::getInstance()->setProjection(Director::Projection::_3D);
```
otherwise, crashes

PS: I have disabled the default camera in my Scene with

```
    _defaultCamera->setScene(NULL);
    removeChild(_defaultCamera);
    _defaultCamera = NULL;
```