### PR TITLE
small BillBoard optimizations

### DIFF
--- a/cocos/3d/CCBillBoard.cpp
+++ b/cocos/3d/CCBillBoard.cpp
@@ -103,6 +103,11 @@ void BillBoard::visit(Renderer *renderer, const Mat4& parentTransform, uint32_t 
         return;
     }
     bool visibleByCamera = isVisitableByVisitingCamera();
+    // quick return if not visible by camera and has no children.
+    if (!visibleByCamera && _children.empty())
+    {
+        return;
+    }
     
     uint32_t flags = processParentFlags(parentTransform, parentFlags);
     
@@ -186,8 +191,8 @@ bool BillBoard::calculateBillboardTransform()
         }
         camDir.normalize();
         
-        Quaternion rotationQuaternion;
-        this->getNodeToWorldTransform().getRotation(&rotationQuaternion);
+        //Quaternion rotationQuaternion;
+        //this->getNodeToWorldTransform().getRotation(&rotationQuaternion);
         
         Mat4 rotationMatrix;
         rotationMatrix.setIdentity();

--- a/cocos/3d/CCBillBoard.cpp
+++ b/cocos/3d/CCBillBoard.cpp
@@ -190,10 +190,7 @@ bool BillBoard::calculateBillboardTransform()
             camDir.set(camWorldMat.m[8], camWorldMat.m[9], camWorldMat.m[10]);
         }
         camDir.normalize();
-        
-        //Quaternion rotationQuaternion;
-        //this->getNodeToWorldTransform().getRotation(&rotationQuaternion);
-        
+
         Mat4 rotationMatrix;
         rotationMatrix.setIdentity();
 


### PR DESCRIPTION
-Quick return in visit if it is not visible and has no children.  
-Comment out getNodeToWorldTransform because it is dead code (doesn't do anything)
Reference issue: https://github.com/cocos2d/cocos2d-x/issues/17690