### PR TITLE
Add const keyward to Node::isScheduled and Scheduler::isScheduled

### DIFF
--- a/cocos/base/CCScheduler.cpp
+++ b/cocos/base/CCScheduler.cpp
@@ -500,7 +500,7 @@ void Scheduler::schedulePerFrame(const ccSchedulerFunc& callback, void *target, 
     }
 }
 
-bool Scheduler::isScheduled(const std::string& key, void *target)
+bool Scheduler::isScheduled(const std::string& key, void *target) const
 {
     CCASSERT(!key.empty(), "Argument key must not be empty");
     CCASSERT(target, "Argument target must be non-nullptr");
@@ -1003,7 +1003,7 @@ void Scheduler::schedule(SEL_SCHEDULE selector, Ref *target, float interval, boo
     this->schedule(selector, target, interval, CC_REPEAT_FOREVER, 0.0f, paused);
 }
 
-bool Scheduler::isScheduled(SEL_SCHEDULE selector, Ref *target)
+bool Scheduler::isScheduled(SEL_SCHEDULE selector, Ref *target) const
 {
     CCASSERT(selector, "Argument selector must be non-nullptr");
     CCASSERT(target, "Argument target must be non-nullptr");

--- a/cocos/base/CCScheduler.h
+++ b/cocos/base/CCScheduler.h
@@ -363,7 +363,7 @@ public:
      @return True if the specified callback is invoked, false if not.
      @since v3.0.0
      */
-    bool isScheduled(const std::string& key, void *target);
+    bool isScheduled(const std::string& key, void *target) const;
     
     /** Checks whether a selector for a given target is scheduled.
      @param selector The selector to be checked.
@@ -371,7 +371,7 @@ public:
      @return True if the specified selector is invoked, false if not.
      @since v3.0
      */
-    bool isScheduled(SEL_SCHEDULE selector, Ref *target);
+    bool isScheduled(SEL_SCHEDULE selector, Ref *target) const;
     
     /////////////////////////////////////
     


### PR DESCRIPTION
Methods with "is" or "get" prefixes should ensure that the method has no side effects.