### PR TITLE
Fixing serious XMLHTTP leak when CC_ENABLE_GC_FOR_NATIVE_OBJECTS enabled

### DIFF
--- a/cocos/scripting/js-bindings/manual/cocos2d_specifics.cpp
+++ b/cocos/scripting/js-bindings/manual/cocos2d_specifics.cpp
@@ -688,8 +688,6 @@ void js_remove_object_root(JS::HandleValue target)
     JSContext *cx = engine->getGlobalContext();
     JS::RootedObject global(cx, engine->getGlobalObject());
     JSAutoCompartment(cx, global);
-    JS::RootedObject targetObj(cx, target.toObjectOrNull());
-    js_proxy_t *pTarget = jsb_get_js_proxy(targetObj);
 
     JS::RootedObject jsbObj(cx);
     get_or_create_js_obj(cx, global, "jsb", &jsbObj);

--- a/cocos/scripting/js-bindings/manual/cocos2d_specifics.cpp
+++ b/cocos/scripting/js-bindings/manual/cocos2d_specifics.cpp
@@ -667,7 +667,7 @@ void js_add_object_root(JS::HandleValue target)
     }
 
     JS::RootedObject root(cx);
-    get_or_create_js_obj(cx, jsbObj, "jsb._root", &root);
+    get_or_create_js_obj(cx, jsbObj, "_root", &root);
     JS::RootedValue valRoot(cx, OBJECT_TO_JSVAL(root));
 
     JS::RootedValue retval(cx);
@@ -690,10 +690,6 @@ void js_remove_object_root(JS::HandleValue target)
     JSAutoCompartment(cx, global);
     JS::RootedObject targetObj(cx, target.toObjectOrNull());
     js_proxy_t *pTarget = jsb_get_js_proxy(targetObj);
-    if (!pTarget)
-    {
-        return;
-    }
 
     JS::RootedObject jsbObj(cx);
     get_or_create_js_obj(cx, global, "jsb", &jsbObj);

--- a/cocos/scripting/js-bindings/manual/network/XMLHTTPRequest.cpp
+++ b/cocos/scripting/js-bindings/manual/network/XMLHTTPRequest.cpp
@@ -328,7 +328,7 @@ void MinXmlHttpRequest::_clearCallbacks()
 
 MinXmlHttpRequest::MinXmlHttpRequest()
 : _url()
-{ 
+{
     MinXmlHttpRequest(ScriptingCore::getInstance()->getGlobalContext());
 }
 

--- a/cocos/scripting/js-bindings/manual/network/XMLHTTPRequest.cpp
+++ b/cocos/scripting/js-bindings/manual/network/XMLHTTPRequest.cpp
@@ -248,6 +248,7 @@ void MinXmlHttpRequest::handle_requestResponse(cocos2d::network::HttpClient *sen
                 callback.set(_onloadendCallback);
                 _notify(callback, JS::HandleValueArray::empty());
             }
+            _clearCallbacks();
             return;
         }
     }
@@ -291,6 +292,7 @@ void MinXmlHttpRequest::handle_requestResponse(cocos2d::network::HttpClient *sen
         callback.set(_onloadendCallback);
         _notify(callback, JS::HandleValueArray::empty());
     }
+    _clearCallbacks();
 }
 /**
  * @brief   Send out request and fire callback when done.
@@ -303,9 +305,30 @@ void MinXmlHttpRequest::_sendRequest(JSContext *cx)
     _httpRequest->release();
 }
 
+#define REMOVE_CALLBACK(x) \
+if (x)\
+{ \
+    JS::RootedValue callback(_cx); \
+    callback.set(OBJECT_TO_JSVAL(x)); \
+    js_remove_object_root(callback); \
+    x = nullptr; \
+} \
+
+void MinXmlHttpRequest::_clearCallbacks()
+{ 
+    JSB_AUTOCOMPARTMENT_WITH_GLOBAL_OBJCET
+    REMOVE_CALLBACK(_onreadystateCallback)
+    REMOVE_CALLBACK(_onloadstartCallback)
+    REMOVE_CALLBACK(_onabortCallback)
+    REMOVE_CALLBACK(_onerrorCallback)
+    REMOVE_CALLBACK(_onloadCallback)
+    REMOVE_CALLBACK(_onloadendCallback)
+    REMOVE_CALLBACK(_ontimeoutCallback)
+}
+
 MinXmlHttpRequest::MinXmlHttpRequest()
 : _url()
-{
+{ 
     MinXmlHttpRequest(ScriptingCore::getInstance()->getGlobalContext());
 }
 
@@ -352,49 +375,7 @@ MinXmlHttpRequest::MinXmlHttpRequest(JSContext *cx)
  */
 MinXmlHttpRequest::~MinXmlHttpRequest()
 {
-    JS::RootedValue callback(_cx);
-    if (_onreadystateCallback)
-    {
-        callback.set(OBJECT_TO_JSVAL(_onreadystateCallback));
-        js_remove_object_root(callback);
-    }
-    if (_onloadstartCallback)
-    {
-        callback.set(OBJECT_TO_JSVAL(_onloadstartCallback));
-        js_remove_object_root(callback);
-    }
-    if (_onabortCallback)
-    {
-        callback.set(OBJECT_TO_JSVAL(_onabortCallback));
-        js_remove_object_root(callback);
-    }
-    if (_onerrorCallback)
-    {
-        callback.set(OBJECT_TO_JSVAL(_onerrorCallback));
-        js_remove_object_root(callback);
-    }
-    if (_onloadCallback)
-    {
-        callback.set(OBJECT_TO_JSVAL(_onloadCallback));
-        js_remove_object_root(callback);
-    }
-    if (_onloadendCallback)
-    {
-        callback.set(OBJECT_TO_JSVAL(_onloadendCallback));
-        js_remove_object_root(callback);
-    }
-    if (_ontimeoutCallback)
-    {
-        callback.set(OBJECT_TO_JSVAL(_ontimeoutCallback));
-        js_remove_object_root(callback);
-    }
-
-    if (_httpRequest)
-    {
-        // We don't need to release _httpRequest here since it will be released in the http callback.
-//        _httpRequest->release();
-    }
-
+    _clearCallbacks();
     CC_SAFE_FREE(_data);
     CC_SAFE_RELEASE_NULL(_scheduler);
 }
@@ -890,6 +871,7 @@ void MinXmlHttpRequest::update(float dt)
         {
             JS::RootedObject callback(_cx, _ontimeoutCallback);
             _notify(callback, JS::HandleValueArray::empty());
+            _clearCallbacks();
         }
         _elapsedTime = 0;
         _readyState = UNSENT;
@@ -916,6 +898,7 @@ JS_BINDED_FUNC_IMPL(MinXmlHttpRequest, abort)
     {
         JS::RootedObject callback(cx, _onabortCallback);
         _notify(callback, JS::HandleValueArray::empty());
+        _clearCallbacks();
     }
 
     return true;

--- a/cocos/scripting/js-bindings/manual/network/XMLHTTPRequest.h
+++ b/cocos/scripting/js-bindings/manual/network/XMLHTTPRequest.h
@@ -96,6 +96,7 @@ private:
     void _setHttpRequestData(const char *data, size_t len);
     void _sendRequest(JSContext *cx);
     void _notify(JS::HandleObject callback, JS::HandleValueArray args);
+    void _clearCallbacks();
 
     std::string                       _url;
     JSContext*                        _cx;


### PR DESCRIPTION
Fixing issue where XMLHttpRequests would not have their destruction fire if CC_ENABLE_GC_FOR_NATIVE_OBJECTS was set. This will cause the entire XMLHttpRequest to leak, including the **entire data payload** on the XMLHttpRequest. If your game makes a lot of these requests, it can add up very quickly. 

This is being caused by an improper rooting strategy. Basically, we are rooting the callbacks of the XMLHttpRequest, and unrooting them when ~MinXMLHttpRequest() fires. _HOWEVER_, ~MinXMLHttpRequest won't fire, because the GC will never clean up the XMLHttpRequest, because it's callback's are rooted, and these callbacks usually reference the XMLHttpRequest, creating a reference cycle. 

Since the callbacks are rooted, and usually reference the XMLHttpRequest, the GC won't see the XMLHttpRequest as garbage and won't clean it up.

The way I've chosen to fix this is to unroot ALL callbacks once certain event's have happened. For example, once the request is complete, I will unroot all pending callbacks.

This required some changes to the root and unroot functions in cocos2d_specifics. The unroot function didn't work, because 

- The root function will add a reference to jsb._root, but the unroot function attempts to remove references from jsb.jsb._root, which fails
- The unroot function also won't unroot anything that don't have a proxy from jsb_get_js_proxy, even though you can root things without a js proxy in the add root function. 

I can reproduce this issue in cocos2d-x-lite, and was also to reproduce it as in issue in a cocos creator made app. I view this as critical for cocos2d-x-lite and cocos creator, as CC_ENABLE_GC_FOR_NATIVE_OBJECTS is enabled by default in that version of the engine. I was able to reproduce this on iOS and win32. 

**REPRODUCTION STEPS**
With CC_ENABLE_GC_FOR_NATIVE_OBJECTS set to 1 in ccConfig.h, In XHRTest.js, add a call to cc.sys.garbageCollect(); to onEnter;
Run the test multiple times, notice that ~MinXMLHttpRequest never fires
apply this patch
Repeat the above action, notice that the destructor will fire. 

@pandamicro @minggo 