### PR TITLE
Call 'update' method in 'stop/stopAll' to cleanup immediately

### DIFF
--- a/cocos/audio/apple/AudioEngine-inl.mm
+++ b/cocos/audio/apple/AudioEngine-inl.mm
@@ -504,6 +504,9 @@ void AudioEngineImpl::stop(int audioID)
     //Note: Don't set the flag to false here, it should be set in 'update' function.
     // Otherwise, the state got from alSourceState may be wrong
 //    _alSourceUsed[player->_alSource] = false;
+
+    // Call 'update' method to cleanup immediately since the schedule may be cancelled without any notification.
+    update(0.0f);
 }
 
 void AudioEngineImpl::stopAll()
@@ -518,6 +521,9 @@ void AudioEngineImpl::stopAll()
 //    {
 //        _alSourceUsed[_alSources[index]] = false;
 //    }
+
+    // Call 'update' method to cleanup immediately since the schedule may be cancelled without any notification.
+    update(0.0f);
 }
 
 float AudioEngineImpl::getDuration(int audioID)

--- a/cocos/audio/win32/AudioEngine-win32.cpp
+++ b/cocos/audio/win32/AudioEngine-win32.cpp
@@ -360,6 +360,9 @@ void AudioEngineImpl::stop(int audioID)
     //Note: Don't set the flag to false here, it should be set in 'update' function.
     // Otherwise, the state got from alSourceState may be wrong
 //    _alSourceUsed[player->_alSource] = false;
+
+    // Call 'update' method to cleanup immediately since the schedule may be cancelled without any notification.
+    update(0.0f);
 }
 
 void AudioEngineImpl::stopAll()
@@ -374,6 +377,9 @@ void AudioEngineImpl::stopAll()
 //    {
 //        _alSourceUsed[_alSources[index]] = false;
 //    }
+
+    // Call 'update' method to cleanup immediately since the schedule may be cancelled without any notification.
+    update(0.0f);
 }
 
 float AudioEngineImpl::getDuration(int audioID)


### PR DESCRIPTION
Since AudioEngineImp uses schedule to remove unused audio players, schedule may be cancelled by `Scheduler::unscheduleAll`, `AudioPlayer`s will not be released for ever.