### PR TITLE
fixed #17922: [android] AudioEngine may crash while audio's over and stop state is triggered at the same time.

### DIFF
--- a/cocos/audio/android/AudioEngine-inl.cpp
+++ b/cocos/audio/android/AudioEngine-inl.cpp
@@ -23,6 +23,8 @@
  ****************************************************************************/
 #if CC_TARGET_PLATFORM == CC_PLATFORM_ANDROID
 
+#define LOG_TAG "AudioEngineImpl"
+
 #include "audio/android/AudioEngine-inl.h"
 
 #include <unistd.h>

--- a/cocos/audio/android/AudioEngine-inl.cpp
+++ b/cocos/audio/android/AudioEngine-inl.cpp
@@ -261,7 +261,7 @@ int AudioEngineImpl::play2d(const std::string &filePath ,bool loop ,float volume
             player->setId(audioId);
             _audioPlayers.insert(std::make_pair(audioId, player));
 
-            player->setPlayEventCallback([this, player](IAudioPlayer::State state){
+            player->setPlayEventCallback([this, player, filePath](IAudioPlayer::State state){
 
                 if (state != IAudioPlayer::State::OVER && state != IAudioPlayer::State::STOPPED)
                 {
@@ -270,12 +270,14 @@ int AudioEngineImpl::play2d(const std::string &filePath ,bool loop ,float volume
                 }
 
                 int id = player->getId();
-                std::string filePath = *AudioEngine::_audioIDInfoMap[id].filePath;
 
                 ALOGV("Removing player id=%d, state:%d", id, (int)state);
 
                 AudioEngine::remove(id);
-                _audioPlayers.erase(id);
+                if (_audioPlayers.find(id) != _audioPlayers.end())
+                {
+                    _audioPlayers.erase(id);
+                }
 
                 auto iter = _callbackMap.find(id);
                 if (iter != _callbackMap.end())

--- a/cocos/audio/android/PcmAudioPlayer.cpp
+++ b/cocos/audio/android/PcmAudioPlayer.cpp
@@ -68,9 +68,10 @@ bool PcmAudioPlayer::prepare(const std::string &url, const PcmData &decResult)
 
     _track->onStateChanged = [this, callerThreadId](Track::State state) {
         // It maybe in sub thread
-        auto func = [this, state](){
+        Track::State prevState = _track->getPrevState();
+        auto func = [this, state, prevState](){
             // It's in caller's thread
-            if (state == Track::State::OVER && _track->getPrevState() != Track::State::STOPPED)
+            if (state == Track::State::OVER && prevState != Track::State::STOPPED)
             {
                 if (_playEventCallback != nullptr)
                 {
@@ -158,26 +159,26 @@ void PcmAudioPlayer::setPlayEventCallback(const PlayEventCallback &playEventCall
 void PcmAudioPlayer::play()
 {
     // put track to AudioMixerController
-    ALOGV("PcmAudioPlayer (%p) play (%s) ...", this, _url.c_str());
+    ALOGV("PcmAudioPlayer (%p) play, url: %s", this, _url.c_str());
     _controller->addTrack(_track);
     _track->setState(Track::State::PLAYING);
 }
 
 void PcmAudioPlayer::pause()
 {
-    ALOGV("PcmAudioPlayer (%p) pause ...", this);
+    ALOGV("PcmAudioPlayer (%p) pause, url: %s", this, _url.c_str());
     _track->setState(Track::State::PAUSED);
 }
 
 void PcmAudioPlayer::resume()
 {
-    ALOGV("PcmAudioPlayer (%p) resume ...", this);
+    ALOGV("PcmAudioPlayer (%p) resume, url: %s", this, _url.c_str());
     _track->setState(Track::State::RESUMED);
 }
 
 void PcmAudioPlayer::stop()
 {
-    ALOGV("PcmAudioPlayer (%p) stop ...", this);
+    ALOGV("PcmAudioPlayer (%p) stop, url: %s", this, _url.c_str());
     _track->setState(Track::State::STOPPED);
 }
 


### PR DESCRIPTION
The Pull Request #17748 didn't resolve the issue since _track->getPrevState() will be wrong while in scheduler callback. We need to capture it in lambda.
My Pull Request also merges PR #17716 to make filePath captured by lambda.