### PR TITLE
Processing Lua file(UTF8+BOM) that is encrypted will crash

### DIFF
--- a/cocos/scripting/lua-bindings/manual/CCLuaStack.cpp
+++ b/cocos/scripting/lua-bindings/manual/CCLuaStack.cpp
@@ -874,8 +874,10 @@ int LuaStack::luaLoadBuffer(lua_State *L, const char *chunk, int chunkSize, cons
                                               (unsigned char*)_xxteaKey,
                                               (xxtea_long)_xxteaKeyLen,
                                               &len);
-        skipBOM((const char*&)result, (int&)len);
-        r = luaL_loadbuffer(L, (char*)result, len, chunkName);
+        unsigned char* content = result;
+        xxtea_long contentSize = len;
+        skipBOM((const char*&)content, (int&)contentSize);
+        r = luaL_loadbuffer(L, (char*)content, contentSize, chunkName);
         free(result);
     }
     else


### PR DESCRIPTION
Processing Lua file(UTF8+BOM) that is encrypted will crash when free the buffer pointer that is changed
pointer address.