### PR TITLE
luaoc static function return type BOOL

### DIFF
--- a/cocos/scripting/lua-bindings/manual/platform/ios/CCLuaObjcBridge.mm
+++ b/cocos/scripting/lua-bindings/manual/platform/ios/CCLuaObjcBridge.mm
@@ -122,25 +122,25 @@ int LuaObjcBridge::callObjcStaticMethod(lua_State *L)
         lua_pushboolean(L, 1);
         if (returnLength > 0)
         {
-            if (strcmp(returnType, "@") == 0)
+            if (strcmp(returnType, @encode(id)) == 0)
             {
                 id ret;
                 [invocation getReturnValue:&ret];
                 pushValue(L, ret);
             }
-            else if (strcmp(returnType, "B") == 0) // BOOL
+            else if (strcmp(returnType, @encode(BOOL)) == 0) // BOOL
             {
                 char ret;
                 [invocation getReturnValue:&ret];
                 lua_pushboolean(L, ret);
             }
-            else if (strcmp(returnType, "i") == 0) // int
+            else if (strcmp(returnType, @encode(int)) == 0) // int
             {
                 int ret;
                 [invocation getReturnValue:&ret];
                 lua_pushinteger(L, ret);
             }
-            else if (strcmp(returnType, "f") == 0) // float
+            else if (strcmp(returnType, @encode(float)) == 0) // float
             {
                 float ret;
                 [invocation getReturnValue:&ret];

--- a/cocos/scripting/lua-bindings/manual/platform/ios/CCLuaObjcBridge.mm
+++ b/cocos/scripting/lua-bindings/manual/platform/ios/CCLuaObjcBridge.mm
@@ -128,7 +128,7 @@ int LuaObjcBridge::callObjcStaticMethod(lua_State *L)
                 [invocation getReturnValue:&ret];
                 pushValue(L, ret);
             }
-            else if (strcmp(returnType, "c") == 0) // BOOL
+            else if (strcmp(returnType, "B") == 0) // BOOL
             {
                 char ret;
                 [invocation getReturnValue:&ret];


### PR DESCRIPTION
Call the luaoc bridge function , when the oc function return type is BOOL, I get the returnType from 

> const char *returnType = [methodSig methodReturnType];

is "B". 
Platform : iOS 10.3.