### PR TITLE
Use CurrentDirectory as defaultSearchRoot on Win32

### DIFF
--- a/cocos/platform/win32/CCFileUtils-win32.cpp
+++ b/cocos/platform/win32/CCFileUtils-win32.cpp
@@ -65,16 +65,15 @@ static void _checkPath()
     if (s_resourcePath.empty())
     {
         WCHAR utf16Path[CC_MAX_PATH] = { 0 };
-        GetModuleFileNameW(NULL, utf16Path, CC_MAX_PATH - 1);
-        WCHAR *pUtf16ExePath = &(utf16Path[0]);
+        int nNum = GetCurrentDirectoryW(CC_MAX_PATH - 2, utf16Path);
 
-        // We need only directory part without exe
-        WCHAR *pUtf16DirEnd = wcsrchr(pUtf16ExePath, L'\\');
-
-        char utf8ExeDir[CC_MAX_PATH] = { 0 };
-        int nNum = WideCharToMultiByte(CP_UTF8, 0, pUtf16ExePath, pUtf16DirEnd-pUtf16ExePath+1, utf8ExeDir, sizeof(utf8ExeDir), nullptr, nullptr);
-
-        s_resourcePath = convertPathFormatToUnixStyle(utf8ExeDir);
+        char utf8WorkingDir[CC_MAX_PATH] = { 0 };
+        nNum = WideCharToMultiByte(CP_UTF8, 0, utf16Path, nNum, utf8WorkingDir, sizeof(utf8WorkingDir), nullptr, nullptr);
+        if (nNum < (CC_MAX_PATH - 2)) {
+            utf8WorkingDir[nNum] = '\\';
+            utf8WorkingDir[nNum + 1] = '\0';
+            s_resourcePath = convertPathFormatToUnixStyle(utf8WorkingDir);
+        }
     }
 }
 


### PR DESCRIPTION
Default, CurrentDirectory equals to ExeDir, but it's more  flexible, and will not break compatible.