### PR TITLE
horizontal alignment support in RichText

### DIFF
--- a/cocos/ui/UIRichText.cpp
+++ b/cocos/ui/UIRichText.cpp
@@ -1800,8 +1800,6 @@ void RichText::formarRenderers()
                 iter->setAnchorPoint(Vec2::ZERO);
                 iter->setPosition(nextPosX, nextPosY);
                 this->addProtectedChild(iter, 1);
-                if ( dynamic_cast<Sprite*>(iter) )
-                    do{}while(0);
                 nextPosX += iter->getContentSize().width;
             }
             

--- a/cocos/ui/UIRichText.cpp
+++ b/cocos/ui/UIRichText.cpp
@@ -1826,21 +1826,25 @@ void RichText::formarRenderers()
     updateContentSizeWithTextureSize(_contentSize);
 }
 
+namespace {
+    float getPaddingAmount(const RichText::HorizontalAlignment alignment, const float leftOver) {
+        switch ( alignment ) {
+            case RichText::HorizontalAlignment::CENTER:
+                return leftOver / 2.f;
+            case RichText::HorizontalAlignment::RIGHT:
+                return leftOver;
+            default:
+                CCASSERT(false, "invalid horizontal alignment!");
+                return 0.f;
+        }
+    }
+}
+
 void RichText::doHorizontalAlignment(const Vector<cocos2d::Node*> &row, float rowWidth) {
     const auto alignment = static_cast<HorizontalAlignment>(_defaults.at(KEY_HORIZONTAL_ALIGNMENT).asInt());
     if ( alignment != HorizontalAlignment::LEFT ) {
         const auto leftOver = getContentSize().width - rowWidth;
-        const float leftPadding = [alignment, leftOver] {
-            switch ( alignment ) {
-                case HorizontalAlignment::CENTER:
-                    return leftOver / 2.f;
-                case HorizontalAlignment::RIGHT:
-                    return leftOver;
-                default:
-                    CCASSERT(false, "invalid horizontal alignment!");
-                    return 0.f;
-            }
-        }();
+        const float leftPadding = getPaddingAmount(alignment, leftOver);
         const Vec2 offset(leftPadding, 0.f);
         for ( auto& node : row ) {
             node->setPosition(node->getPosition() + offset);

--- a/cocos/ui/UIRichText.cpp
+++ b/cocos/ui/UIRichText.cpp
@@ -1712,7 +1712,7 @@ void RichText::handleImageRenderer(const std::string& filePath, const Color3B &/
             imageRenderer->setScaleY(height / currentSize.height);
         imageRenderer->setContentSize(Size(currentSize.width * imageRenderer->getScaleX(),
                                              currentSize.height * imageRenderer->getScaleY()));
-
+        imageRenderer->setScale(1.f, 1.f);
         handleCustomRenderer(imageRenderer);
         imageRenderer->addComponent(ListenerComponent::create(imageRenderer,
                                                               url,
@@ -1800,6 +1800,8 @@ void RichText::formarRenderers()
                 iter->setAnchorPoint(Vec2::ZERO);
                 iter->setPosition(nextPosX, nextPosY);
                 this->addProtectedChild(iter, 1);
+                if ( dynamic_cast<Sprite*>(iter) )
+                    do{}while(0);
                 nextPosX += iter->getContentSize().width;
             }
             

--- a/cocos/ui/UIRichText.cpp
+++ b/cocos/ui/UIRichText.cpp
@@ -1765,7 +1765,7 @@ void RichText::formarRenderers()
                 maxY = MAX(maxY, iSize.height);
             }
             nextPosY -= maxY;
-            rowWidthPairs.emplace_back(row, nextPosX);
+            rowWidthPairs.emplace_back(&element, nextPosX);
         }
         this->setContentSize(Size(newContentSizeWidth, -nextPosY));
         for ( auto& row : rowWidthPairs )
@@ -1803,7 +1803,7 @@ void RichText::formarRenderers()
                 nextPosX += iter->getContentSize().width;
             }
             
-            doHorizontalAlignment(*row, nextPosX);
+            doHorizontalAlignment(row, nextPosX);
         }
     }
     

--- a/cocos/ui/UIRichText.h
+++ b/cocos/ui/UIRichText.h
@@ -569,6 +569,7 @@ protected:
     int findSplitPositionForWord(cocos2d::Label* label, const std::string& text);
     int findSplitPositionForChar(cocos2d::Label* label, const std::string& text);
 	void doHorizontalAlignment(const Vector<Node*>& row, float rowWidth);
+	float stripTrailingWhitespace(const Vector<Node*>& row);
 
     bool _formatTextDirty;
     Vector<RichElement*> _richElements;

--- a/cocos/ui/UIRichText.h
+++ b/cocos/ui/UIRichText.h
@@ -348,6 +348,12 @@ public:
         WRAP_PER_CHAR
     };
     
+    enum class HorizontalAlignment {
+        LEFT,
+        CENTER,
+        RIGHT,
+    };
+    
     /**
      * @brief call to open a resource specified by a URL
      * @param url a URL
@@ -363,6 +369,7 @@ public:
     
     static const std::string KEY_VERTICAL_SPACE;                    /*!< key of vertical space */
     static const std::string KEY_WRAP_MODE;                         /*!< key of per word, or per char */
+    static const std::string KEY_HORIZONTAL_ALIGNMENT;              /*!< key of left, right, or center */
     static const std::string KEY_FONT_COLOR_STRING;                 /*!< key of font color */
     static const std::string KEY_FONT_SIZE;                         /*!< key of font size */
     static const std::string KEY_FONT_SMALL;                        /*!< key of font size small */
@@ -476,6 +483,8 @@ public:
 
     void setWrapMode(WrapMode wrapMode);                /*!< sets the wrapping mode: WRAP_PER_CHAR or WRAP_PER_WORD */
     WrapMode getWrapMode() const;                       /*!< returns the current wrapping mode */
+    void setHorizontalAlignment(HorizontalAlignment a); /*!< sets the horizontal alignment mode: LEFT, CENTER, or RIGHT */
+    HorizontalAlignment getHorizontalAlignment() const; /*!< returns the current horizontal alignment mode */
     void setFontColor(const std::string& color);        /*!< Set the font color. @param color the #RRGGBB hexadecimal notation. */
     std::string getFontColor();                         /*!< return the current font color */
     Color3B getFontColor3B();                           /*!< return the current font color */
@@ -559,6 +568,7 @@ protected:
     void addNewLine();
     int findSplitPositionForWord(cocos2d::Label* label, const std::string& text);
     int findSplitPositionForChar(cocos2d::Label* label, const std::string& text);
+	void doHorizontalAlignment(const Vector<Node*>& row, float rowWidth);
 
     bool _formatTextDirty;
     Vector<RichElement*> _richElements;

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIRichTextTest/UIRichTextTest.cpp
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIRichTextTest/UIRichTextTest.cpp
@@ -70,11 +70,18 @@ bool UIRichTextTest::init()
         Button* button2 = Button::create("cocosui/animationbuttonnormal.png", "cocosui/animationbuttonpressed.png");
         button2->setTouchEnabled(true);
         button2->setTitleText("wrap mode");
-        button2->setPosition(Vec2(widgetSize.width * 2 / 3, widgetSize.height / 2.0f + button2->getContentSize().height * 2.5));
+        button2->setPosition(Vec2(widgetSize.width / 2, widgetSize.height / 2.0f + button2->getContentSize().height * 2.5));
         button2->addTouchEventListener(CC_CALLBACK_2(UIRichTextTest::switchWrapMode, this));
         button2->setLocalZOrder(10);
         _widget->addChild(button2);
-
+		
+		Button* button3 = Button::create("cocosui/animationbuttonnormal.png", "cocosui/animationbuttonpressed.png");
+		button3->setTouchEnabled(true);
+		button3->setTitleText("alignment");
+		button3->setPosition(Vec2(widgetSize.width * 2 / 3, widgetSize.height / 2.0f + button2->getContentSize().height * 2.5));
+		button3->addTouchEventListener(CC_CALLBACK_2(UIRichTextTest::switchAlignment, this));
+		button3->setLocalZOrder(10);
+		_widget->addChild(button3);
 
         // RichText
         _richText = RichText::create();
@@ -151,6 +158,15 @@ void UIRichTextTest::switchWrapMode(Ref *pSender, Widget::TouchEventType type)
     }
 }
 
+void UIRichTextTest::switchAlignment(Ref *sender, Widget::TouchEventType type) {
+	if (type == Widget::TouchEventType::ENDED)
+	{
+		auto alignment = _richText->getHorizontalAlignment();
+		alignment = static_cast<RichText::HorizontalAlignment>((static_cast<std::underlying_type<RichText::HorizontalAlignment>::type>(alignment)+1) % 3);
+		_richText->setHorizontalAlignment(alignment);
+	}
+}
+
 //
 // UIRichTextXMLBasic
 //
@@ -178,11 +194,18 @@ bool UIRichTextXMLBasic::init()
         Button* button2 = Button::create("cocosui/animationbuttonnormal.png", "cocosui/animationbuttonpressed.png");
         button2->setTouchEnabled(true);
         button2->setTitleText("wrap mode");
-        button2->setPosition(Vec2(widgetSize.width * 2 / 3, widgetSize.height / 2.0f + button2->getContentSize().height * 2.5));
+        button2->setPosition(Vec2(widgetSize.width / 2, widgetSize.height / 2.0f + button2->getContentSize().height * 2.5));
         button2->addTouchEventListener(CC_CALLBACK_2(UIRichTextXMLBasic::switchWrapMode, this));
         button2->setLocalZOrder(10);
         _widget->addChild(button2);
 
+		Button* button3 = Button::create("cocosui/animationbuttonnormal.png", "cocosui/animationbuttonpressed.png");
+		button3->setTouchEnabled(true);
+		button3->setTitleText("alignment");
+		button3->setPosition(Vec2(widgetSize.width * 2 / 3, widgetSize.height / 2.0f + button2->getContentSize().height * 2.5));
+		button3->addTouchEventListener(CC_CALLBACK_2(UIRichTextXMLBasic::switchAlignment, this));
+		button3->setLocalZOrder(10);
+		_widget->addChild(button3);
 
         // RichText
         _richText = RichText::createWithXML("This is just a simple text. no xml tags here. testing the basics. testing word-wrapping. testing, testing, testing");
@@ -236,6 +259,15 @@ void UIRichTextXMLBasic::switchWrapMode(Ref *pSender, Widget::TouchEventType typ
     }
 }
 
+void UIRichTextXMLBasic::switchAlignment(Ref *sender, Widget::TouchEventType type) {
+    if (type == Widget::TouchEventType::ENDED)
+    {
+        auto alignment = _richText->getHorizontalAlignment();
+        alignment = static_cast<RichText::HorizontalAlignment>((static_cast<std::underlying_type<RichText::HorizontalAlignment>::type>(alignment)+1) % 3);
+        _richText->setHorizontalAlignment(alignment);
+    }
+}
+
 //
 // UIRichTextXMLSmallBig
 //
@@ -263,11 +295,18 @@ bool UIRichTextXMLSmallBig::init()
         Button* button2 = Button::create("cocosui/animationbuttonnormal.png", "cocosui/animationbuttonpressed.png");
         button2->setTouchEnabled(true);
         button2->setTitleText("wrap mode");
-        button2->setPosition(Vec2(widgetSize.width * 2 / 3, widgetSize.height / 2.0f + button2->getContentSize().height * 2.5));
+        button2->setPosition(Vec2(widgetSize.width / 2, widgetSize.height / 2.0f + button2->getContentSize().height * 2.5));
         button2->addTouchEventListener(CC_CALLBACK_2(UIRichTextXMLSmallBig::switchWrapMode, this));
         button2->setLocalZOrder(10);
         _widget->addChild(button2);
 
+		Button* button3 = Button::create("cocosui/animationbuttonnormal.png", "cocosui/animationbuttonpressed.png");
+		button3->setTouchEnabled(true);
+		button3->setTitleText("alignment");
+		button3->setPosition(Vec2(widgetSize.width * 2 / 3, widgetSize.height / 2.0f + button2->getContentSize().height * 2.5));
+		button3->addTouchEventListener(CC_CALLBACK_2(UIRichTextXMLSmallBig::switchAlignment, this));
+		button3->setLocalZOrder(10);
+		_widget->addChild(button3);
 
         // RichText
         _richText = RichText::createWithXML("Regular size.<small>smaller size.</small><big>bigger.<small>normal.</small>bigger</big>.normal.");
@@ -321,6 +360,15 @@ void UIRichTextXMLSmallBig::switchWrapMode(Ref *pSender, Widget::TouchEventType 
     }
 }
 
+void UIRichTextXMLSmallBig::switchAlignment(Ref *sender, Widget::TouchEventType type) {
+	if (type == Widget::TouchEventType::ENDED)
+	{
+		auto alignment = _richText->getHorizontalAlignment();
+		alignment = static_cast<RichText::HorizontalAlignment>((static_cast<std::underlying_type<RichText::HorizontalAlignment>::type>(alignment)+1) % 3);
+		_richText->setHorizontalAlignment(alignment);
+	}
+}
+
 //
 // UIRichTextXMLColor
 //
@@ -348,11 +396,18 @@ bool UIRichTextXMLColor::init()
         Button* button2 = Button::create("cocosui/animationbuttonnormal.png", "cocosui/animationbuttonpressed.png");
         button2->setTouchEnabled(true);
         button2->setTitleText("wrap mode");
-        button2->setPosition(Vec2(widgetSize.width * 2 / 3, widgetSize.height / 2.0f + button2->getContentSize().height * 2.5));
+        button2->setPosition(Vec2(widgetSize.width / 2, widgetSize.height / 2.0f + button2->getContentSize().height * 2.5));
         button2->addTouchEventListener(CC_CALLBACK_2(UIRichTextXMLColor::switchWrapMode, this));
         button2->setLocalZOrder(10);
         _widget->addChild(button2);
-
+		
+		Button* button3 = Button::create("cocosui/animationbuttonnormal.png", "cocosui/animationbuttonpressed.png");
+		button3->setTouchEnabled(true);
+		button3->setTitleText("alignment");
+		button3->setPosition(Vec2(widgetSize.width * 2 / 3, widgetSize.height / 2.0f + button2->getContentSize().height * 2.5));
+		button3->addTouchEventListener(CC_CALLBACK_2(UIRichTextXMLColor::switchAlignment, this));
+		button3->setLocalZOrder(10);
+		_widget->addChild(button3);
 
         // RichText
         _richText = RichText::createWithXML("Default color.<font color='#ff0000'>red.<font color='#00ff00'>green</font>red again.</font>default again");
@@ -406,6 +461,15 @@ void UIRichTextXMLColor::switchWrapMode(Ref *pSender, Widget::TouchEventType typ
     }
 }
 
+void UIRichTextXMLColor::switchAlignment(Ref *sender, Widget::TouchEventType type) {
+	if (type == Widget::TouchEventType::ENDED)
+	{
+		auto alignment = _richText->getHorizontalAlignment();
+		alignment = static_cast<RichText::HorizontalAlignment>((static_cast<std::underlying_type<RichText::HorizontalAlignment>::type>(alignment)+1) % 3);
+		_richText->setHorizontalAlignment(alignment);
+	}
+}
+
 //
 // UIRichTextXMLSUIB
 //
@@ -433,11 +497,18 @@ bool UIRichTextXMLSUIB::init()
         Button* button2 = Button::create("cocosui/animationbuttonnormal.png", "cocosui/animationbuttonpressed.png");
         button2->setTouchEnabled(true);
         button2->setTitleText("wrap mode");
-        button2->setPosition(Vec2(widgetSize.width * 2 / 3, widgetSize.height / 2.0f + button2->getContentSize().height * 2.5));
+        button2->setPosition(Vec2(widgetSize.width / 2, widgetSize.height / 2.0f + button2->getContentSize().height * 2.5));
         button2->addTouchEventListener(CC_CALLBACK_2(UIRichTextXMLSUIB::switchWrapMode, this));
         button2->setLocalZOrder(10);
         _widget->addChild(button2);
 
+		Button* button3 = Button::create("cocosui/animationbuttonnormal.png", "cocosui/animationbuttonpressed.png");
+		button3->setTouchEnabled(true);
+		button3->setTitleText("alignment");
+		button3->setPosition(Vec2(widgetSize.width * 2 / 3, widgetSize.height / 2.0f + button2->getContentSize().height * 2.5));
+		button3->addTouchEventListener(CC_CALLBACK_2(UIRichTextXMLSUIB::switchAlignment, this));
+		button3->setLocalZOrder(10);
+		_widget->addChild(button3);
 
         // RichText
         _richText = RichText::createWithXML("system font: <u>underline</u><i>italics</i><b>bold</b><del>strike-through</del>");
@@ -491,6 +562,15 @@ void UIRichTextXMLSUIB::switchWrapMode(Ref *pSender, Widget::TouchEventType type
     }
 }
 
+void UIRichTextXMLSUIB::switchAlignment(Ref *sender, Widget::TouchEventType type) {
+	if (type == Widget::TouchEventType::ENDED)
+	{
+		auto alignment = _richText->getHorizontalAlignment();
+		alignment = static_cast<RichText::HorizontalAlignment>((static_cast<std::underlying_type<RichText::HorizontalAlignment>::type>(alignment)+1) % 3);
+		_richText->setHorizontalAlignment(alignment);
+	}
+}
+
 //
 // UIRichTextXMLSUIB2
 //
@@ -518,11 +598,18 @@ bool UIRichTextXMLSUIB2::init()
         Button* button2 = Button::create("cocosui/animationbuttonnormal.png", "cocosui/animationbuttonpressed.png");
         button2->setTouchEnabled(true);
         button2->setTitleText("wrap mode");
-        button2->setPosition(Vec2(widgetSize.width * 2 / 3, widgetSize.height / 2.0f + button2->getContentSize().height * 2.5));
+        button2->setPosition(Vec2(widgetSize.width / 2, widgetSize.height / 2.0f + button2->getContentSize().height * 2.5));
         button2->addTouchEventListener(CC_CALLBACK_2(UIRichTextXMLSUIB2::switchWrapMode, this));
         button2->setLocalZOrder(10);
         _widget->addChild(button2);
 
+		Button* button3 = Button::create("cocosui/animationbuttonnormal.png", "cocosui/animationbuttonpressed.png");
+		button3->setTouchEnabled(true);
+		button3->setTitleText("alignment");
+		button3->setPosition(Vec2(widgetSize.width * 2 / 3, widgetSize.height / 2.0f + button2->getContentSize().height * 2.5));
+		button3->addTouchEventListener(CC_CALLBACK_2(UIRichTextXMLSUIB2::switchAlignment, this));
+		button3->setLocalZOrder(10);
+		_widget->addChild(button3);
 
         // RichText
         _richText = RichText::createWithXML("<font face='fonts/Marker Felt.ttf' size='24'>ttf font: <u>underline</u><i>italics</i><b>bold</b><del>strike-through</del></font>");
@@ -576,6 +663,15 @@ void UIRichTextXMLSUIB2::switchWrapMode(Ref *pSender, Widget::TouchEventType typ
     }
 }
 
+void UIRichTextXMLSUIB2::switchAlignment(Ref *sender, Widget::TouchEventType type) {
+	if (type == Widget::TouchEventType::ENDED)
+	{
+		auto alignment = _richText->getHorizontalAlignment();
+		alignment = static_cast<RichText::HorizontalAlignment>((static_cast<std::underlying_type<RichText::HorizontalAlignment>::type>(alignment)+1) % 3);
+		_richText->setHorizontalAlignment(alignment);
+	}
+}
+
 //
 // UIRichTextXMLSUIB3
 //
@@ -603,11 +699,18 @@ bool UIRichTextXMLSUIB3::init()
         Button* button2 = Button::create("cocosui/animationbuttonnormal.png", "cocosui/animationbuttonpressed.png");
         button2->setTouchEnabled(true);
         button2->setTitleText("wrap mode");
-        button2->setPosition(Vec2(widgetSize.width * 2 / 3, widgetSize.height / 2.0f + button2->getContentSize().height * 2.5));
+        button2->setPosition(Vec2(widgetSize.width / 2, widgetSize.height / 2.0f + button2->getContentSize().height * 2.5));
         button2->addTouchEventListener(CC_CALLBACK_2(UIRichTextXMLSUIB3::switchWrapMode, this));
         button2->setLocalZOrder(10);
         _widget->addChild(button2);
 
+		Button* button3 = Button::create("cocosui/animationbuttonnormal.png", "cocosui/animationbuttonpressed.png");
+		button3->setTouchEnabled(true);
+		button3->setTitleText("alignment");
+		button3->setPosition(Vec2(widgetSize.width * 2 / 3, widgetSize.height / 2.0f + button2->getContentSize().height * 2.5));
+		button3->addTouchEventListener(CC_CALLBACK_2(UIRichTextXMLSUIB3::switchAlignment, this));
+		button3->setLocalZOrder(10);
+		_widget->addChild(button3);
 
         // RichText
         _richText = RichText::createWithXML("<font face='fonts/Marker Felt.ttf' size='20'>ttf font: <i><u>italics and underline</u></i><del><b>bold and strike-through</b></del></font>");
@@ -661,6 +764,15 @@ void UIRichTextXMLSUIB3::switchWrapMode(Ref *pSender, Widget::TouchEventType typ
     }
 }
 
+void UIRichTextXMLSUIB3::switchAlignment(Ref *sender, Widget::TouchEventType type) {
+	if (type == Widget::TouchEventType::ENDED)
+	{
+		auto alignment = _richText->getHorizontalAlignment();
+		alignment = static_cast<RichText::HorizontalAlignment>((static_cast<std::underlying_type<RichText::HorizontalAlignment>::type>(alignment)+1) % 3);
+		_richText->setHorizontalAlignment(alignment);
+	}
+}
+
 //
 // UIRichTextXMLImg
 //
@@ -688,11 +800,18 @@ bool UIRichTextXMLImg::init()
         Button* button2 = Button::create("cocosui/animationbuttonnormal.png", "cocosui/animationbuttonpressed.png");
         button2->setTouchEnabled(true);
         button2->setTitleText("wrap mode");
-        button2->setPosition(Vec2(widgetSize.width * 2 / 3, widgetSize.height / 2.0f + button2->getContentSize().height * 2.5));
+        button2->setPosition(Vec2(widgetSize.width / 2, widgetSize.height / 2.0f + button2->getContentSize().height * 2.5));
         button2->addTouchEventListener(CC_CALLBACK_2(UIRichTextXMLImg::switchWrapMode, this));
         button2->setLocalZOrder(10);
         _widget->addChild(button2);
 
+		Button* button3 = Button::create("cocosui/animationbuttonnormal.png", "cocosui/animationbuttonpressed.png");
+		button3->setTouchEnabled(true);
+		button3->setTitleText("alignment");
+		button3->setPosition(Vec2(widgetSize.width * 2 / 3, widgetSize.height / 2.0f + button2->getContentSize().height * 2.5));
+		button3->addTouchEventListener(CC_CALLBACK_2(UIRichTextXMLImg::switchAlignment, this));
+		button3->setLocalZOrder(10);
+		_widget->addChild(button3);
 
         // RichText
         _richText = RichText::createWithXML("you should see an image here: <img src='cocosui/sliderballnormal.png'/> and this is text again. and this is the same image, but bigger: <img src='cocosui/sliderballnormal.png' width='30' height='30' /> and here goes text again");
@@ -746,6 +865,15 @@ void UIRichTextXMLImg::switchWrapMode(Ref *pSender, Widget::TouchEventType type)
     }
 }
 
+void UIRichTextXMLImg::switchAlignment(Ref *sender, Widget::TouchEventType type) {
+	if (type == Widget::TouchEventType::ENDED)
+	{
+		auto alignment = _richText->getHorizontalAlignment();
+		alignment = static_cast<RichText::HorizontalAlignment>((static_cast<std::underlying_type<RichText::HorizontalAlignment>::type>(alignment)+1) % 3);
+		_richText->setHorizontalAlignment(alignment);
+	}
+}
+
 //
 // UIRichTextXMLUrl
 //
@@ -773,11 +901,18 @@ bool UIRichTextXMLUrl::init()
         Button* button2 = Button::create("cocosui/animationbuttonnormal.png", "cocosui/animationbuttonpressed.png");
         button2->setTouchEnabled(true);
         button2->setTitleText("wrap mode");
-        button2->setPosition(Vec2(widgetSize.width * 2 / 3, widgetSize.height / 2.0f + button2->getContentSize().height * 2.5));
+        button2->setPosition(Vec2(widgetSize.width / 2, widgetSize.height / 2.0f + button2->getContentSize().height * 2.5));
         button2->addTouchEventListener(CC_CALLBACK_2(UIRichTextXMLUrl::switchWrapMode, this));
         button2->setLocalZOrder(10);
         _widget->addChild(button2);
 
+		Button* button3 = Button::create("cocosui/animationbuttonnormal.png", "cocosui/animationbuttonpressed.png");
+		button3->setTouchEnabled(true);
+		button3->setTitleText("alignment");
+		button3->setPosition(Vec2(widgetSize.width * 2 / 3, widgetSize.height / 2.0f + button2->getContentSize().height * 2.5));
+		button3->addTouchEventListener(CC_CALLBACK_2(UIRichTextXMLUrl::switchAlignment, this));
+		button3->setLocalZOrder(10);
+		_widget->addChild(button3);
 
         // RichText
         _richText = RichText::createWithXML("And this link will redirect you to google: <a href='http://www.google.com'>click me</a>");
@@ -831,6 +966,15 @@ void UIRichTextXMLUrl::switchWrapMode(Ref *pSender, Widget::TouchEventType type)
     }
 }
 
+void UIRichTextXMLUrl::switchAlignment(Ref *sender, Widget::TouchEventType type) {
+	if (type == Widget::TouchEventType::ENDED)
+	{
+		auto alignment = _richText->getHorizontalAlignment();
+		alignment = static_cast<RichText::HorizontalAlignment>((static_cast<std::underlying_type<RichText::HorizontalAlignment>::type>(alignment)+1) % 3);
+		_richText->setHorizontalAlignment(alignment);
+	}
+}
+
 //
 // UIRichTextXMLUrlImg
 //
@@ -858,11 +1002,18 @@ bool UIRichTextXMLUrlImg::init()
         Button* button2 = Button::create("cocosui/animationbuttonnormal.png", "cocosui/animationbuttonpressed.png");
         button2->setTouchEnabled(true);
         button2->setTitleText("wrap mode");
-        button2->setPosition(Vec2(widgetSize.width * 2 / 3, widgetSize.height / 2.0f + button2->getContentSize().height * 2.5));
+        button2->setPosition(Vec2(widgetSize.width / 2, widgetSize.height / 2.0f + button2->getContentSize().height * 2.5));
         button2->addTouchEventListener(CC_CALLBACK_2(UIRichTextXMLUrlImg::switchWrapMode, this));
         button2->setLocalZOrder(10);
         _widget->addChild(button2);
-        
+		
+		Button* button3 = Button::create("cocosui/animationbuttonnormal.png", "cocosui/animationbuttonpressed.png");
+		button3->setTouchEnabled(true);
+		button3->setTitleText("alignment");
+		button3->setPosition(Vec2(widgetSize.width * 2 / 3, widgetSize.height / 2.0f + button2->getContentSize().height * 2.5));
+		button3->addTouchEventListener(CC_CALLBACK_2(UIRichTextXMLUrlImg::switchAlignment, this));
+		button3->setLocalZOrder(10);
+		_widget->addChild(button3);
         
         // RichText
         _richText = RichText::createWithXML("And this link will redirect you to google: <a href='http://www.google.com'><img src=\"cocosui/ccicon.png\" height=\"48\" width=\"48\" /></a>");
@@ -916,6 +1067,15 @@ void UIRichTextXMLUrlImg::switchWrapMode(Ref *pSender, Widget::TouchEventType ty
     }
 }
 
+void UIRichTextXMLUrlImg::switchAlignment(Ref *sender, Widget::TouchEventType type) {
+	if (type == Widget::TouchEventType::ENDED)
+	{
+		auto alignment = _richText->getHorizontalAlignment();
+		alignment = static_cast<RichText::HorizontalAlignment>((static_cast<std::underlying_type<RichText::HorizontalAlignment>::type>(alignment)+1) % 3);
+		_richText->setHorizontalAlignment(alignment);
+	}
+}
+
 //
 // UIRichTextXMLFace
 //
@@ -943,11 +1103,18 @@ bool UIRichTextXMLFace::init()
         Button* button2 = Button::create("cocosui/animationbuttonnormal.png", "cocosui/animationbuttonpressed.png");
         button2->setTouchEnabled(true);
         button2->setTitleText("wrap mode");
-        button2->setPosition(Vec2(widgetSize.width * 2 / 3, widgetSize.height / 2.0f + button2->getContentSize().height * 2.5));
+        button2->setPosition(Vec2(widgetSize.width / 2, widgetSize.height / 2.0f + button2->getContentSize().height * 2.5));
         button2->addTouchEventListener(CC_CALLBACK_2(UIRichTextXMLFace::switchWrapMode, this));
         button2->setLocalZOrder(10);
         _widget->addChild(button2);
 
+		Button* button3 = Button::create("cocosui/animationbuttonnormal.png", "cocosui/animationbuttonpressed.png");
+		button3->setTouchEnabled(true);
+		button3->setTitleText("alignment");
+		button3->setPosition(Vec2(widgetSize.width * 2 / 3, widgetSize.height / 2.0f + button2->getContentSize().height * 2.5));
+		button3->addTouchEventListener(CC_CALLBACK_2(UIRichTextXMLFace::switchAlignment, this));
+		button3->setLocalZOrder(10);
+		_widget->addChild(button3);
 
         // RichText
         _richText = RichText::createWithXML("<font size='20' face='fonts/Marker Felt.ttf'>Marker Felt 20.<font face='fonts/arial.ttf'>Arial 20.</font></font><font face='font/Thonburi.ttf' size='24' color='#0000ff'>Thonburi 24 blue</font>");
@@ -1001,6 +1168,15 @@ void UIRichTextXMLFace::switchWrapMode(Ref *pSender, Widget::TouchEventType type
     }
 }
 
+void UIRichTextXMLFace::switchAlignment(Ref *sender, Widget::TouchEventType type) {
+	if (type == Widget::TouchEventType::ENDED)
+	{
+		auto alignment = _richText->getHorizontalAlignment();
+		alignment = static_cast<RichText::HorizontalAlignment>((static_cast<std::underlying_type<RichText::HorizontalAlignment>::type>(alignment)+1) % 3);
+		_richText->setHorizontalAlignment(alignment);
+	}
+}
+
 //
 // UIRichTextXMLBR
 //
@@ -1028,11 +1204,18 @@ bool UIRichTextXMLBR::init()
         Button* button2 = Button::create("cocosui/animationbuttonnormal.png", "cocosui/animationbuttonpressed.png");
         button2->setTouchEnabled(true);
         button2->setTitleText("wrap mode");
-        button2->setPosition(Vec2(widgetSize.width * 2 / 3, widgetSize.height / 2.0f + button2->getContentSize().height * 2.5));
+        button2->setPosition(Vec2(widgetSize.width / 2, widgetSize.height / 2.0f + button2->getContentSize().height * 2.5));
         button2->addTouchEventListener(CC_CALLBACK_2(UIRichTextXMLBR::switchWrapMode, this));
         button2->setLocalZOrder(10);
         _widget->addChild(button2);
 
+		Button* button3 = Button::create("cocosui/animationbuttonnormal.png", "cocosui/animationbuttonpressed.png");
+		button3->setTouchEnabled(true);
+		button3->setTitleText("alignment");
+		button3->setPosition(Vec2(widgetSize.width * 2 / 3, widgetSize.height / 2.0f + button2->getContentSize().height * 2.5));
+		button3->addTouchEventListener(CC_CALLBACK_2(UIRichTextXMLBR::switchAlignment, this));
+		button3->setLocalZOrder(10);
+		_widget->addChild(button3);
 
         // RichText
         _richText = RichText::createWithXML("this is one line.<br/>this should be in another line.<br/>and this is another line");
@@ -1084,6 +1267,15 @@ void UIRichTextXMLBR::switchWrapMode(Ref *pSender, Widget::TouchEventType type)
         wrapMode = (wrapMode == RichText::WRAP_PER_WORD) ? RichText::WRAP_PER_CHAR : RichText::WRAP_PER_WORD;
         _richText->setWrapMode(wrapMode);
     }
+}
+
+void UIRichTextXMLBR::switchAlignment(Ref *sender, Widget::TouchEventType type) {
+	if (type == Widget::TouchEventType::ENDED)
+	{
+		auto alignment = _richText->getHorizontalAlignment();
+		alignment = static_cast<RichText::HorizontalAlignment>((static_cast<std::underlying_type<RichText::HorizontalAlignment>::type>(alignment)+1) % 3);
+		_richText->setHorizontalAlignment(alignment);
+	}
 }
 
 //
@@ -1150,11 +1342,18 @@ bool UIRichTextXMLOutline::init()
         Button* button2 = Button::create("cocosui/animationbuttonnormal.png", "cocosui/animationbuttonpressed.png");
         button2->setTouchEnabled(true);
         button2->setTitleText("wrap mode");
-        button2->setPosition(Vec2(widgetSize.width * 2 / 3, widgetSize.height / 2.0f + button2->getContentSize().height * 2.5));
+        button2->setPosition(Vec2(widgetSize.width / 2, widgetSize.height / 2.0f + button2->getContentSize().height * 2.5));
         button2->addTouchEventListener(CC_CALLBACK_2(UIRichTextXMLOutline::switchWrapMode, this));
         button2->setLocalZOrder(10);
         _widget->addChild(button2);
-        
+		
+		Button* button3 = Button::create("cocosui/animationbuttonnormal.png", "cocosui/animationbuttonpressed.png");
+		button3->setTouchEnabled(true);
+		button3->setTitleText("alignment");
+		button3->setPosition(Vec2(widgetSize.width * 2 / 3, widgetSize.height / 2.0f + button2->getContentSize().height * 2.5));
+		button3->addTouchEventListener(CC_CALLBACK_2(UIRichTextXMLOutline::switchAlignment, this));
+		button3->setLocalZOrder(10);
+		_widget->addChild(button3);
         
         // RichText
         _richText = RichText::createWithXML("<font face='fonts/Marker Felt.ttf' size=\"24\"><outline color=\"#D2B48C\" size=\"2\">OUTLINE</outline></font>");
@@ -1208,6 +1407,15 @@ void UIRichTextXMLOutline::switchWrapMode(Ref *pSender, Widget::TouchEventType t
     }
 }
 
+void UIRichTextXMLOutline::switchAlignment(Ref *sender, Widget::TouchEventType type) {
+	if (type == Widget::TouchEventType::ENDED)
+	{
+		auto alignment = _richText->getHorizontalAlignment();
+		alignment = static_cast<RichText::HorizontalAlignment>((static_cast<std::underlying_type<RichText::HorizontalAlignment>::type>(alignment)+1) % 3);
+		_richText->setHorizontalAlignment(alignment);
+	}
+}
+
 //
 // UIRichTextXMLShadow
 //
@@ -1235,11 +1443,18 @@ bool UIRichTextXMLShadow::init()
         Button* button2 = Button::create("cocosui/animationbuttonnormal.png", "cocosui/animationbuttonpressed.png");
         button2->setTouchEnabled(true);
         button2->setTitleText("wrap mode");
-        button2->setPosition(Vec2(widgetSize.width * 2 / 3, widgetSize.height / 2.0f + button2->getContentSize().height * 2.5));
+        button2->setPosition(Vec2(widgetSize.width / 2, widgetSize.height / 2.0f + button2->getContentSize().height * 2.5));
         button2->addTouchEventListener(CC_CALLBACK_2(UIRichTextXMLShadow::switchWrapMode, this));
         button2->setLocalZOrder(10);
         _widget->addChild(button2);
-        
+		
+		Button* button3 = Button::create("cocosui/animationbuttonnormal.png", "cocosui/animationbuttonpressed.png");
+		button3->setTouchEnabled(true);
+		button3->setTitleText("alignment");
+		button3->setPosition(Vec2(widgetSize.width * 2 / 3, widgetSize.height / 2.0f + button2->getContentSize().height * 2.5));
+		button3->addTouchEventListener(CC_CALLBACK_2(UIRichTextXMLShadow::switchAlignment, this));
+		button3->setLocalZOrder(10);
+		_widget->addChild(button3);
         
         // RichText
         _richText = RichText::createWithXML("<font size=\"24\"><shadow color=\"#4169E1\" offsetWidth=\"8\" offsetHeight=\"-8\" blurRadius=\"2\">SHADOW</shadow></font>");
@@ -1293,6 +1508,15 @@ void UIRichTextXMLShadow::switchWrapMode(Ref *pSender, Widget::TouchEventType ty
     }
 }
 
+void UIRichTextXMLShadow::switchAlignment(Ref *sender, Widget::TouchEventType type) {
+	if (type == Widget::TouchEventType::ENDED)
+	{
+		auto alignment = _richText->getHorizontalAlignment();
+		alignment = static_cast<RichText::HorizontalAlignment>((static_cast<std::underlying_type<RichText::HorizontalAlignment>::type>(alignment)+1) % 3);
+		_richText->setHorizontalAlignment(alignment);
+	}
+}
+
 //
 // UIRichTextXMLGlow
 //
@@ -1320,11 +1544,18 @@ bool UIRichTextXMLGlow::init()
         Button* button2 = Button::create("cocosui/animationbuttonnormal.png", "cocosui/animationbuttonpressed.png");
         button2->setTouchEnabled(true);
         button2->setTitleText("wrap mode");
-        button2->setPosition(Vec2(widgetSize.width * 2 / 3, widgetSize.height / 2.0f + button2->getContentSize().height * 2.5));
+        button2->setPosition(Vec2(widgetSize.width / 2, widgetSize.height / 2.0f + button2->getContentSize().height * 2.5));
         button2->addTouchEventListener(CC_CALLBACK_2(UIRichTextXMLGlow::switchWrapMode, this));
         button2->setLocalZOrder(10);
         _widget->addChild(button2);
-        
+		
+		Button* button3 = Button::create("cocosui/animationbuttonnormal.png", "cocosui/animationbuttonpressed.png");
+		button3->setTouchEnabled(true);
+		button3->setTitleText("alignment");
+		button3->setPosition(Vec2(widgetSize.width * 2 / 3, widgetSize.height / 2.0f + button2->getContentSize().height * 2.5));
+		button3->addTouchEventListener(CC_CALLBACK_2(UIRichTextXMLGlow::switchAlignment, this));
+		button3->setLocalZOrder(10);
+		_widget->addChild(button3);
         
         // RichText
         _richText = RichText::createWithXML("<font face=\"fonts/Marker Felt.ttf\" size=\"24\"><glow color=\"#AFEEEE\">GLOW</glow></font>");
@@ -1378,6 +1609,15 @@ void UIRichTextXMLGlow::switchWrapMode(Ref *pSender, Widget::TouchEventType type
     }
 }
 
+void UIRichTextXMLGlow::switchAlignment(Ref *sender, Widget::TouchEventType type) {
+	if (type == Widget::TouchEventType::ENDED)
+	{
+		auto alignment = _richText->getHorizontalAlignment();
+		alignment = static_cast<RichText::HorizontalAlignment>((static_cast<std::underlying_type<RichText::HorizontalAlignment>::type>(alignment)+1) % 3);
+		_richText->setHorizontalAlignment(alignment);
+	}
+}
+
 //
 // UIRichTextXMLExtend
 //
@@ -1405,10 +1645,18 @@ bool UIRichTextXMLExtend::init()
         Button* button2 = Button::create("cocosui/animationbuttonnormal.png", "cocosui/animationbuttonpressed.png");
         button2->setTouchEnabled(true);
         button2->setTitleText("wrap mode");
-        button2->setPosition(Vec2(widgetSize.width * 2 / 3, widgetSize.height / 2.0f + button2->getContentSize().height * 2.5));
+        button2->setPosition(Vec2(widgetSize.width / 2, widgetSize.height / 2.0f + button2->getContentSize().height * 2.5));
         button2->addTouchEventListener(CC_CALLBACK_2(UIRichTextXMLExtend::switchWrapMode, this));
         button2->setLocalZOrder(10);
         _widget->addChild(button2);
+		
+		Button* button3 = Button::create("cocosui/animationbuttonnormal.png", "cocosui/animationbuttonpressed.png");
+		button3->setTouchEnabled(true);
+		button3->setTitleText("alignment");
+		button3->setPosition(Vec2(widgetSize.width * 2 / 3, widgetSize.height / 2.0f + button2->getContentSize().height * 2.5));
+		button3->addTouchEventListener(CC_CALLBACK_2(UIRichTextXMLExtend::switchAlignment, this));
+		button3->setLocalZOrder(10);
+		_widget->addChild(button3);
         
         /* Tag extension */
         RichText::setTagDescription("CloseNormal", false, [](const ValueMap& tagAttrValueMap) {
@@ -1497,4 +1745,13 @@ void UIRichTextXMLExtend::switchWrapMode(Ref *pSender, Widget::TouchEventType ty
         wrapMode = (wrapMode == RichText::WRAP_PER_WORD) ? RichText::WRAP_PER_CHAR : RichText::WRAP_PER_WORD;
         _richText->setWrapMode(wrapMode);
     }
+}
+
+void UIRichTextXMLExtend::switchAlignment(Ref *sender, Widget::TouchEventType type) {
+	if (type == Widget::TouchEventType::ENDED)
+	{
+		auto alignment = _richText->getHorizontalAlignment();
+		alignment = static_cast<RichText::HorizontalAlignment>((static_cast<std::underlying_type<RichText::HorizontalAlignment>::type>(alignment)+1) % 3);
+		_richText->setHorizontalAlignment(alignment);
+	}
 }

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIRichTextTest/UIRichTextTest.cpp
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIRichTextTest/UIRichTextTest.cpp
@@ -1459,7 +1459,7 @@ bool UIRichTextXMLShadow::init()
         // RichText
         _richText = RichText::createWithXML("<font size=\"24\"><shadow color=\"#4169E1\" offsetWidth=\"8\" offsetHeight=\"-8\" blurRadius=\"2\">SHADOW</shadow></font>");
         _richText->ignoreContentAdaptWithSize(false);
-        _richText->setContentSize(Size(100, 100));
+        _richText->setContentSize(Size(150, 100));
         
         _richText->setPosition(Vec2(widgetSize.width / 2, widgetSize.height / 2));
         _richText->setLocalZOrder(10);

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIRichTextTest/UIRichTextTest.h
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIRichTextTest/UIRichTextTest.h
@@ -15,6 +15,7 @@ public:
     bool init() override;
     void touchEvent(cocos2d::Ref* sender, cocos2d::ui::Widget::TouchEventType type);
     void switchWrapMode(cocos2d::Ref* sender, cocos2d::ui::Widget::TouchEventType type);
+    void switchAlignment(cocos2d::Ref* sender, cocos2d::ui::Widget::TouchEventType type);
 
 protected:
     cocos2d::ui::RichText* _richText;
@@ -28,6 +29,7 @@ public:
     bool init() override;
     void touchEvent(cocos2d::Ref* sender, cocos2d::ui::Widget::TouchEventType type);
     void switchWrapMode(cocos2d::Ref* sender, cocos2d::ui::Widget::TouchEventType type);
+    void switchAlignment(cocos2d::Ref* sender, cocos2d::ui::Widget::TouchEventType type);
 
 protected:
     cocos2d::ui::RichText* _richText;
@@ -41,6 +43,7 @@ public:
     bool init() override;
     void touchEvent(cocos2d::Ref* sender, cocos2d::ui::Widget::TouchEventType type);
     void switchWrapMode(cocos2d::Ref* sender, cocos2d::ui::Widget::TouchEventType type);
+    void switchAlignment(cocos2d::Ref* sender, cocos2d::ui::Widget::TouchEventType type);
 
 protected:
     cocos2d::ui::RichText* _richText;
@@ -54,6 +57,7 @@ public:
     bool init() override;
     void touchEvent(cocos2d::Ref* sender, cocos2d::ui::Widget::TouchEventType type);
     void switchWrapMode(cocos2d::Ref* sender, cocos2d::ui::Widget::TouchEventType type);
+    void switchAlignment(cocos2d::Ref* sender, cocos2d::ui::Widget::TouchEventType type);
 
 protected:
     cocos2d::ui::RichText* _richText;
@@ -67,6 +71,7 @@ public:
     bool init() override;
     void touchEvent(cocos2d::Ref* sender, cocos2d::ui::Widget::TouchEventType type);
     void switchWrapMode(cocos2d::Ref* sender, cocos2d::ui::Widget::TouchEventType type);
+    void switchAlignment(cocos2d::Ref* sender, cocos2d::ui::Widget::TouchEventType type);
 
 protected:
     cocos2d::ui::RichText* _richText;
@@ -80,6 +85,7 @@ public:
     bool init() override;
     void touchEvent(cocos2d::Ref* sender, cocos2d::ui::Widget::TouchEventType type);
     void switchWrapMode(cocos2d::Ref* sender, cocos2d::ui::Widget::TouchEventType type);
+    void switchAlignment(cocos2d::Ref* sender, cocos2d::ui::Widget::TouchEventType type);
 
 protected:
     cocos2d::ui::RichText* _richText;
@@ -93,6 +99,7 @@ public:
     bool init() override;
     void touchEvent(cocos2d::Ref* sender, cocos2d::ui::Widget::TouchEventType type);
     void switchWrapMode(cocos2d::Ref* sender, cocos2d::ui::Widget::TouchEventType type);
+    void switchAlignment(cocos2d::Ref* sender, cocos2d::ui::Widget::TouchEventType type);
 
 protected:
     cocos2d::ui::RichText* _richText;
@@ -106,6 +113,7 @@ public:
     bool init() override;
     void touchEvent(cocos2d::Ref* sender, cocos2d::ui::Widget::TouchEventType type);
     void switchWrapMode(cocos2d::Ref* sender, cocos2d::ui::Widget::TouchEventType type);
+    void switchAlignment(cocos2d::Ref* sender, cocos2d::ui::Widget::TouchEventType type);
 
 protected:
     cocos2d::ui::RichText* _richText;
@@ -119,6 +127,7 @@ public:
     bool init() override;
     void touchEvent(cocos2d::Ref* sender, cocos2d::ui::Widget::TouchEventType type);
     void switchWrapMode(cocos2d::Ref* sender, cocos2d::ui::Widget::TouchEventType type);
+    void switchAlignment(cocos2d::Ref* sender, cocos2d::ui::Widget::TouchEventType type);
 
 protected:
     cocos2d::ui::RichText* _richText;
@@ -132,7 +141,8 @@ public:
     bool init() override;
     void touchEvent(cocos2d::Ref* sender, cocos2d::ui::Widget::TouchEventType type);
     void switchWrapMode(cocos2d::Ref* sender, cocos2d::ui::Widget::TouchEventType type);
-    
+    void switchAlignment(cocos2d::Ref* sender, cocos2d::ui::Widget::TouchEventType type);
+
 protected:
     cocos2d::ui::RichText* _richText;
 };
@@ -145,6 +155,7 @@ public:
     bool init() override;
     void touchEvent(cocos2d::Ref* sender, cocos2d::ui::Widget::TouchEventType type);
     void switchWrapMode(cocos2d::Ref* sender, cocos2d::ui::Widget::TouchEventType type);
+    void switchAlignment(cocos2d::Ref* sender, cocos2d::ui::Widget::TouchEventType type);
 
 protected:
     cocos2d::ui::RichText* _richText;
@@ -158,6 +169,7 @@ public:
     bool init() override;
     void touchEvent(cocos2d::Ref* sender, cocos2d::ui::Widget::TouchEventType type);
     void switchWrapMode(cocos2d::Ref* sender, cocos2d::ui::Widget::TouchEventType type);
+    void switchAlignment(cocos2d::Ref* sender, cocos2d::ui::Widget::TouchEventType type);
 
 protected:
     cocos2d::ui::RichText* _richText;
@@ -182,7 +194,8 @@ public:
     bool init() override;
     void touchEvent(cocos2d::Ref* sender, cocos2d::ui::Widget::TouchEventType type);
     void switchWrapMode(cocos2d::Ref* sender, cocos2d::ui::Widget::TouchEventType type);
-    
+    void switchAlignment(cocos2d::Ref* sender, cocos2d::ui::Widget::TouchEventType type);
+
 protected:
     cocos2d::ui::RichText* _richText;
 };
@@ -195,7 +208,8 @@ public:
     bool init() override;
     void touchEvent(cocos2d::Ref* sender, cocos2d::ui::Widget::TouchEventType type);
     void switchWrapMode(cocos2d::Ref* sender, cocos2d::ui::Widget::TouchEventType type);
-    
+    void switchAlignment(cocos2d::Ref* sender, cocos2d::ui::Widget::TouchEventType type);
+
 protected:
     cocos2d::ui::RichText* _richText;
 };
@@ -208,7 +222,8 @@ public:
     bool init() override;
     void touchEvent(cocos2d::Ref* sender, cocos2d::ui::Widget::TouchEventType type);
     void switchWrapMode(cocos2d::Ref* sender, cocos2d::ui::Widget::TouchEventType type);
-    
+    void switchAlignment(cocos2d::Ref* sender, cocos2d::ui::Widget::TouchEventType type);
+
 protected:
     cocos2d::ui::RichText* _richText;
 };
@@ -221,7 +236,8 @@ public:
     bool init() override;
     void touchEvent(cocos2d::Ref* sender, cocos2d::ui::Widget::TouchEventType type);
     void switchWrapMode(cocos2d::Ref* sender, cocos2d::ui::Widget::TouchEventType type);
-    
+    void switchAlignment(cocos2d::Ref* sender, cocos2d::ui::Widget::TouchEventType type);
+
 protected:
     cocos2d::ui::RichText* _richText;
 };


### PR DESCRIPTION
RichText supports left, center, and right alignment. Added a button to the top of every test for changing the alignment.