### PR TITLE
arithmetic operators for Color4F

### DIFF
--- a/cocos/base/ccTypes.cpp
+++ b/cocos/base/ccTypes.cpp
@@ -249,6 +249,14 @@ Color4F& operator*=(Color4F& lhs, float rhs) {
 	lhs.a *= rhs;
 	return lhs;
 }
+Color4F operator*(Color4F lhs, const Color4F& rhs) {
+    return lhs *= rhs;
+}
+
+Color4F operator*(Color4F lhs, float rhs) {
+    return lhs *= rhs;
+}
+
 Color4F& operator/=(Color4F& lhs, const Color4F& rhs) {
 	lhs.r /= rhs.r;
 	lhs.g /= rhs.g;
@@ -262,6 +270,13 @@ Color4F& operator/=(Color4F& lhs, float rhs) {
 	lhs.b /= rhs;
 	lhs.a /= rhs;
 	return lhs;
+}
+Color4F operator/(Color4F lhs, const Color4F& rhs) {
+    return lhs /= rhs;
+}
+
+Color4F operator/(Color4F lhs, float rhs) {
+    return lhs /= rhs;
 }
 
 /**

--- a/cocos/base/ccTypes.cpp
+++ b/cocos/base/ccTypes.cpp
@@ -214,6 +214,56 @@ bool Color4F::operator!=(const Color4B& right) const
     return !(*this == right);
 }
 
+Color4F& operator+=(Color4F& lhs, const Color4F& rhs) {
+	lhs.r += rhs.r;
+	lhs.g += rhs.g;
+	lhs.b += rhs.b;
+	lhs.a += rhs.a;
+	return lhs;
+}
+Color4F operator+(Color4F lhs, const Color4F& rhs) {
+	return lhs += rhs;
+}
+Color4F& operator-=(Color4F& lhs, const Color4F& rhs) {
+	lhs.r -= rhs.r;
+	lhs.g -= rhs.g;
+	lhs.b -= rhs.b;
+	lhs.a -= rhs.a;
+	return lhs;
+}
+Color4F operator-(Color4F lhs, const Color4F& rhs) {
+	return lhs -= rhs;
+}
+
+Color4F& operator*=(Color4F& lhs, const Color4F& rhs) {
+	lhs.r *= rhs.r;
+	lhs.g *= rhs.g;
+	lhs.b *= rhs.b;
+	lhs.a *= rhs.a;
+	return lhs;
+}
+Color4F& operator*=(Color4F& lhs, float rhs) {
+	lhs.r *= rhs;
+	lhs.g *= rhs;
+	lhs.b *= rhs;
+	lhs.a *= rhs;
+	return lhs;
+}
+Color4F& operator/=(Color4F& lhs, const Color4F& rhs) {
+	lhs.r /= rhs.r;
+	lhs.g /= rhs.g;
+	lhs.b /= rhs.b;
+	lhs.a /= rhs.a;
+	return lhs;
+}
+Color4F& operator/=(Color4F& lhs, float rhs) {
+	lhs.r /= rhs;
+	lhs.g /= rhs;
+	lhs.b /= rhs;
+	lhs.a /= rhs;
+	return lhs;
+}
+
 /**
  * Color constants
  */

--- a/cocos/base/ccTypes.h
+++ b/cocos/base/ccTypes.h
@@ -167,21 +167,20 @@ struct CC_DLL Color4F
 
 Color4F& operator+=(Color4F& lhs, const Color4F& rhs);
 Color4F operator+(Color4F lhs, const Color4F& rhs);
+
 Color4F& operator-=(Color4F& lhs, const Color4F& rhs);
 Color4F operator-(Color4F lhs, const Color4F& rhs);
 
 Color4F& operator*=(Color4F& lhs, const Color4F& rhs);
+Color4F operator*(Color4F lhs, const Color4F& rhs);
 Color4F& operator*=(Color4F& lhs, float rhs);
-template<typename T>
-Color4F operator*(Color4F lhs, const T& rhs) {
-    return lhs *= rhs;
-}
+Color4F operator*(Color4F lhs, float rhs);
+
 Color4F& operator/=(Color4F& lhs, const Color4F& rhs);
+Color4F operator/(Color4F lhs, const Color4F& rhs);
 Color4F& operator/=(Color4F& lhs, float rhs);
-template<typename T>
-Color4F operator/(Color4F lhs, const T& rhs) {
-    return lhs /= rhs;
-}
+Color4F operator/(Color4F lhs, float rhs);
+
 
 /** A vertex composed of 2 floats: x, y
  @since v3.0

--- a/cocos/base/ccTypes.h
+++ b/cocos/base/ccTypes.h
@@ -165,6 +165,24 @@ struct CC_DLL Color4F
     static const Color4F GRAY;
 };
 
+Color4F& operator+=(Color4F& lhs, const Color4F& rhs);
+Color4F operator+(Color4F lhs, const Color4F& rhs);
+Color4F& operator-=(Color4F& lhs, const Color4F& rhs);
+Color4F operator-(Color4F lhs, const Color4F& rhs);
+
+Color4F& operator*=(Color4F& lhs, const Color4F& rhs);
+Color4F& operator*=(Color4F& lhs, float rhs);
+template<typename T>
+Color4F operator*(Color4F lhs, const T& rhs) {
+    return lhs *= rhs;
+}
+Color4F& operator/=(Color4F& lhs, const Color4F& rhs);
+Color4F& operator/=(Color4F& lhs, float rhs);
+template<typename T>
+Color4F operator/(Color4F lhs, const T& rhs) {
+    return lhs /= rhs;
+}
+
 /** A vertex composed of 2 floats: x, y
  @since v3.0
  */


### PR DESCRIPTION
It is very intuitive and useful to be able to do component-wise and scalar arithmetic on float vectors that represent color.  This is already present and very useful in other color representations, such as GLSL's `vec4`.  This pull request allows for the following types of expressions:
```
auto blendedColor = colorA + colorB; // additively blend colorA and colorB
colorC /= 2.f; // halve the brightness and alpha of colorC, useful for fading
```
This expressive power makes more complex color calculations, like blending or interpolation, much easier to read and write:
```
Color4F interpolateTwoColors(const Color4F& a, const Color4F& b, float time) {
    return (b - a)*time + a; // same lerp formula as for simple data types
}
```

Similar operators could be useful for Color3B and Color4B, but they might end up being less intuitive and more unwieldy due to the high probability for integer overflow/underflow.