### PR TITLE
Check lastDisplayTime before calculating deltaTime.

### DIFF
--- a/cocos/platform/ios/CCDirectorCaller-ios.mm
+++ b/cocos/platform/ios/CCDirectorCaller-ios.mm
@@ -75,7 +75,6 @@ static id s_sharedDirectorCaller;
     if (self)
     {
         isAppActive = [UIApplication sharedApplication].applicationState == UIApplicationStateActive;
-        lastDisplayTime = 0;
         NSNotificationCenter *nc = [NSNotificationCenter defaultCenter];
         [nc addObserver:self selector:@selector(appDidBecomeActive) name:UIApplicationDidBecomeActiveNotification object:nil];
         [nc addObserver:self selector:@selector(appDidBecomeInactive) name:UIApplicationWillResignActiveNotification object:nil];
@@ -108,6 +107,7 @@ static id s_sharedDirectorCaller;
     displayLink = [NSClassFromString(@"CADisplayLink") displayLinkWithTarget:self selector:@selector(doCaller:)];
     [displayLink setFrameInterval: self.interval];
     [displayLink addToRunLoop:[NSRunLoop currentRunLoop] forMode:NSDefaultRunLoopMode];
+    lastDisplayTime = ((CADisplayLink*)displayLink).timestamp;
 }
 
 -(void) stopMainLoop
@@ -126,6 +126,7 @@ static id s_sharedDirectorCaller;
     displayLink = [NSClassFromString(@"CADisplayLink") displayLinkWithTarget:self selector:@selector(doCaller:)];
     [displayLink setFrameInterval: self.interval];
     [displayLink addToRunLoop:[NSRunLoop currentRunLoop] forMode:NSDefaultRunLoopMode];
+    lastDisplayTime = ((CADisplayLink*)displayLink).timestamp;
 }
                       
 -(void) doCaller: (id) sender
@@ -138,10 +139,7 @@ static id s_sharedDirectorCaller;
         
         [EAGLContext setCurrentContext: cocos2dxContext];
 
-        CFTimeInterval dt = 0;
-        if (lastDisplayTime != 0) {
-            dt = ((CADisplayLink*)displayLink).timestamp - lastDisplayTime;
-        }
+        CFTimeInterval dt = ((CADisplayLink*)displayLink).timestamp - lastDisplayTime;
         lastDisplayTime = ((CADisplayLink*)displayLink).timestamp;
         director->mainLoop(dt);
     }

--- a/cocos/platform/ios/CCDirectorCaller-ios.mm
+++ b/cocos/platform/ios/CCDirectorCaller-ios.mm
@@ -52,7 +52,6 @@ static id s_sharedDirectorCaller;
     if (s_sharedDirectorCaller == nil)
     {
         s_sharedDirectorCaller = [CCDirectorCaller new];
-        ((CCDirectorCaller*) s_sharedDirectorCaller)->lastDisplayTime = 0;
     }
     
     return s_sharedDirectorCaller;
@@ -76,6 +75,7 @@ static id s_sharedDirectorCaller;
     if (self)
     {
         isAppActive = [UIApplication sharedApplication].applicationState == UIApplicationStateActive;
+        lastDisplayTime = 0;
         NSNotificationCenter *nc = [NSNotificationCenter defaultCenter];
         [nc addObserver:self selector:@selector(appDidBecomeActive) name:UIApplicationDidBecomeActiveNotification object:nil];
         [nc addObserver:self selector:@selector(appDidBecomeInactive) name:UIApplicationWillResignActiveNotification object:nil];

--- a/cocos/platform/ios/CCDirectorCaller-ios.mm
+++ b/cocos/platform/ios/CCDirectorCaller-ios.mm
@@ -51,7 +51,7 @@ static id s_sharedDirectorCaller;
 {
     if (s_sharedDirectorCaller == nil)
     {
-        s_sharedDirectorCaller = [CCDirectorCaller new];
+        s_sharedDirectorCaller = [[CCDirectorCaller alloc] init];
     }
     
     return s_sharedDirectorCaller;

--- a/cocos/platform/ios/CCDirectorCaller-ios.mm
+++ b/cocos/platform/ios/CCDirectorCaller-ios.mm
@@ -52,6 +52,7 @@ static id s_sharedDirectorCaller;
     if (s_sharedDirectorCaller == nil)
     {
         s_sharedDirectorCaller = [CCDirectorCaller new];
+        ((CCDirectorCaller*) s_sharedDirectorCaller)->lastDisplayTime = 0;
     }
     
     return s_sharedDirectorCaller;
@@ -137,7 +138,10 @@ static id s_sharedDirectorCaller;
         
         [EAGLContext setCurrentContext: cocos2dxContext];
 
-        CFTimeInterval dt = ((CADisplayLink*)displayLink).timestamp - lastDisplayTime;
+        CFTimeInterval dt = 0;
+        if (lastDisplayTime != 0) {
+            dt = ((CADisplayLink*)displayLink).timestamp - lastDisplayTime;
+        }
         lastDisplayTime = ((CADisplayLink*)displayLink).timestamp;
         director->mainLoop(dt);
     }


### PR DESCRIPTION
Fix issue which could generate invalid `dt` during the very first frame (after #17852 was merged).

This issue only happens on Release mode, given that on Debug mode we detect `big delta time` and set it to 1/60.