### PR TITLE
Use cocos2d::Rect to avoid ambiguity

### DIFF
--- a/cocos/editor-support/spine/SkeletonRenderer.cpp
+++ b/cocos/editor-support/spine/SkeletonRenderer.cpp
@@ -317,7 +317,7 @@ AttachmentVertices* SkeletonRenderer::getAttachmentVertices (spMeshAttachment* a
 	return (AttachmentVertices*)attachment->rendererObject;
 }
 
-Rect SkeletonRenderer::getBoundingBox () const {
+cocos2d::Rect SkeletonRenderer::getBoundingBox () const {
 	float minX = FLT_MAX, minY = FLT_MAX, maxX = -FLT_MAX, maxY = -FLT_MAX;
 	float scaleX = getScaleX(), scaleY = getScaleY();
 	for (int i = 0; i < _skeleton->slotsCount; ++i) {
@@ -343,8 +343,8 @@ Rect SkeletonRenderer::getBoundingBox () const {
 		}
 	}
 	Vec2 position = getPosition();
-    if (minX == FLT_MAX) minX = minY = maxX = maxY = 0;    
-	return Rect(position.x + minX, position.y + minY, maxX - minX, maxY - minY);
+    if (minX == FLT_MAX) minX = minY = maxX = maxY = 0;
+	return cocos2d::Rect(position.x + minX, position.y + minY, maxX - minX, maxY - minY);
 }
 
 // --- Convenience methods for Skeleton_* functions.


### PR DESCRIPTION
This was causing an issue when compiling on OS X:
```
$PROJECT/cocos2d/cocos/editor-support/spine/SkeletonRenderer.cpp:320:1: error: reference to 'Rect'
      is ambiguous
Rect SkeletonRenderer::getBoundingBox () const {
^
/usr/include/MacTypes.h:550:41: note: candidate found by name lookup is 'Rect'
typedef struct Rect                     Rect;
                                        ^
$PROJECT/cocos2d/cocos/2d/CCSprite.h:45:7: note: candidate found by name lookup is 'cocos2d::Rect'
class Rect;
      ^
$PROJECT/cocos2d/cocos/editor-support/spine/SkeletonRenderer.cpp:347:9: error: reference to 'Rect'
      is ambiguous
        return Rect(position.x + minX, position.y + minY, maxX - minX, maxY - minY);
               ^
/usr/include/MacTypes.h:550:41: note: candidate found by name lookup is 'Rect'
typedef struct Rect                     Rect;
                                        ^
$PROJECT/cocos2d/cocos/2d/CCSprite.h:45:7: note: candidate found by name lookup is 'cocos2d::Rect'
class Rect;
      ^
2 errors generated.
make[2]: *** [cocos2d/cocos/CMakeFiles/cocos2dInternal.dir/editor-support/spine/SkeletonRenderer.cpp.o] Error 1
make[2]: *** Waiting for unfinished jobs....
make[1]: *** [cocos2d/cocos/CMakeFiles/cocos2dInternal.dir/all] Error 2
make: *** [all] Error 2
```

This patch fixes the issue for me on OSX, and I am able to compile and run https://github.com/olehermanse/MathGameCpp using `cmake` and `make`, without XCode.