### PR TITLE
Fixed typo. Added comments about GLFW 3.3 controller support.

### DIFF
--- a/cocos/base/CCController-linux-win32.cpp
+++ b/cocos/base/CCController-linux-win32.cpp
@@ -42,6 +42,15 @@ class CC_DLL ControllerImpl
 
 		ControllerImpl()
 		{
+			//FIXME: Once GLFW 3.3 is bundled with cocos2d-x and no extra
+			//controllers have been added here, remove all the code here.  If
+			//extra controllers were added, make sure to add them to the SDL
+			//Controller Database at
+			//https://github.com/gabomdq/SDL_GameControllerDB which GLFW uses
+			//for providing the new gamepad API. We are going to map the GLFW
+			//game pad events to Controller::Key key codes.
+
+
 			// Note: the controllers input profile were taken from the
 			// RetroArch joypad autoconfig project at:
 			// https://github.com/libretro/retroarch-joypad-autoconfig/tree/master/udev
@@ -4854,6 +4863,11 @@ class CC_DLL ControllerImpl
 		}
 
 	private:
+		//FIXME: Once GLFW 3.3 is bundled with cocos2d-x, remove these
+		//controller profiles and all the related code.  We will only need to
+		//provide a mapping from the GLFW gamepad key codes to the
+		//Controller::Key keycodes. So far an std::unordered_map<int,int>
+		//should suffice.
 		static std::map<std::string, std::pair< std::unordered_map<int, int>, std::unordered_map<int, int> > > s_controllerProfiles;
 };
 

--- a/cocos/base/CCController.h
+++ b/cocos/base/CCController.h
@@ -220,10 +220,14 @@ private:
     EventController *_axisEvent;
 
     #if ( CC_TARGET_PLATFORM == CC_PLATFORM_LINUX || CC_TARGET_PLATFORM == CC_PLATFORM_WIN32 )
+    //FIXME: Once GLFW 3.3 is bundled with cocos2d-x, remove these unordered
+    //maps. They won't be needed. We will only need to provide a mapping from
+    //the GLFW gamepad key codes to the Controller::Key.
+
     // Attach the controller profiles from CCController-linux-win32.cpp to each
     // of the Controller variables in order to minimize profile lookup time.
 
-    // Note: this increases memory usage unecessarily since the same maps are
+    // Note: this increases memory usage unnecessarily since the same maps are
     // already stored on ControllerImpl within the static member variable
     // "s_controllerProfiles", but on these platforms the increase in memory
     // usage is negligible.  Peformance over memory optimization was


### PR DESCRIPTION
No code changes in this pull request. Only comments.

GLFW recently added [gamepad](https://github.com/glfw/glfw/commit/953106e74ddaf925eb2d100ea67bb36bf89167d4) support. Once it's bundled with cocos2d-x, we just have to map those gamepad keys from GFLW to `Controller::Key` key codes. I just added reminders about the changes that need to be made.

GLFW will provide support for more controllers than the ones currently added to `CCController-linux-win32.cpp` by using the [SDL game controller database](https://github.com/gabomdq/SDL_GameControllerDB) and providing a unified input key codes similar to `Controller::Key`.
