### PR TITLE
add ui/gl thread helper methods for windows 10 platform.

### DIFF
--- a/cocos/platform/winrt/CCGLViewImpl-winrt.cpp
+++ b/cocos/platform/winrt/CCGLViewImpl-winrt.cpp
@@ -630,8 +630,24 @@ void GLViewImpl::QueueEvent(std::shared_ptr<InputEvent>& event)
     mInputEvents.push(event);
 }
 
+void GLViewImpl::RunOnGLThread(Windows::UI::Core::DispatchedHandler ^ handler)
+{
+    mDispatchHandlers.push(handler);
+}
+
+void GLViewImpl::RunOnUIThread(Windows::UI::Core::DispatchedHandler ^ handler)
+{
+    m_dispatcher->RunAsync(Windows::UI::Core::CoreDispatcherPriority::Normal, handler);
+}
+
 void GLViewImpl::ProcessEvents()
 {
+    Windows::UI::Core::DispatchedHandler^ handler;
+    while (mDispatchHandlers.try_pop(handler)) 
+    {
+        handler->Invoke();
+    }
+
     std::shared_ptr<InputEvent> e;
     while (mInputEvents.try_pop(e))
     {

--- a/cocos/platform/winrt/CCGLViewImpl-winrt.h
+++ b/cocos/platform/winrt/CCGLViewImpl-winrt.h
@@ -104,6 +104,9 @@ public:
 	void QueueWinRTKeyboardEvent(WinRTKeyboardEventType type, Windows::UI::Core::KeyEventArgs^ args);
 	void QueueEvent(std::shared_ptr<InputEvent>& event);
 
+    void RunOnGLThread(Windows::UI::Core::DispatchedHandler^ handler);
+    void RunOnUIThread(Windows::UI::Core::DispatchedHandler^ handler);
+
     bool ShowMessageBox(Platform::String^ title, Platform::String^ message);
 
 	int Run();
@@ -180,6 +183,7 @@ private:
     bool m_appShouldExit;
 
     Concurrency::concurrent_queue<std::shared_ptr<InputEvent>> mInputEvents;
+    Concurrency::concurrent_queue<Windows::UI::Core::DispatchedHandler^> mDispatchHandlers;
 
     Platform::Agile<Windows::UI::Core::CoreDispatcher> m_dispatcher;
     Platform::Agile<Windows::UI::Xaml::Controls::Panel> m_panel;


### PR DESCRIPTION
Helper method usage:

    cocos2d::GLViewImpl::sharedOpenGLView()->RunOnUIThread(ref new Windows::UI::Core::DispatchedHandler([this] {
        ...
    }));

    cocos2d::GLViewImpl::sharedOpenGLView()->RunOnGLThread(ref new Windows::UI::Core::DispatchedHandler([this] {
        ...
    }));