### PR TITLE
Fix AudioEngine thread concurrency crash

### DIFF
--- a/cocos/audio/apple/AudioEngine-inl.mm
+++ b/cocos/audio/apple/AudioEngine-inl.mm
@@ -215,6 +215,7 @@ ALvoid AudioEngineImpl::myAlSourceNotificationCallback(ALuint sid, ALuint notifi
         return;
 
     AudioPlayer* player = nullptr;
+    s_instance->_threadMutex.lock();
     for (const auto& e : s_instance->_audioPlayers)
     {
         player = e.second;
@@ -223,6 +224,7 @@ ALvoid AudioEngineImpl::myAlSourceNotificationCallback(ALuint sid, ALuint notifi
             player->wakeupRotateThread();
         }
     }
+    s_instance->_threadMutex.unlock();
 }
 
 AudioEngineImpl::AudioEngineImpl()


### PR DESCRIPTION
Fix `AudioEngine` thread concurrency crash between `myAlSourceNotificationCallback(ALuint sid, ALuint notificationID, ALvoid* userData)` and `_play2d(AudioCache *cache, int audioID)` when iterating over `_audioPlayers` instance variable.

This crash happens when you have multiple audio tracks running at the same time and frequently call `_play2d(AudioCache *cache, int audioID)`.