### PR TITLE
Fix polygon sprite bug of resetting flip and color information

### DIFF
--- a/cocos/2d/CCSprite.cpp
+++ b/cocos/2d/CCSprite.cpp
@@ -1433,23 +1433,7 @@ void Sprite::setFlippedX(bool flippedX)
     if (_flippedX != flippedX)
     {
         _flippedX = flippedX;
-
-        if (_renderMode == RenderMode::QUAD_BATCHNODE)
-        {
-            setDirty(true);
-        }
-        else if (_renderMode == RenderMode::POLYGON)
-        {
-            for (ssize_t i = 0; i < _polyInfo.triangles.vertCount; i++) {
-                auto& v = _polyInfo.triangles.verts[i].vertices;
-                v.x = _contentSize.width -v.x;
-            }
-        }
-        else
-        {
-            // RenderMode:: Quad or Slice9
-            updatePoly();
-        }
+        flipX();
     }
 }
 
@@ -1463,29 +1447,51 @@ void Sprite::setFlippedY(bool flippedY)
     if (_flippedY != flippedY)
     {
         _flippedY = flippedY;
-
-        if (_renderMode == RenderMode::QUAD_BATCHNODE)
-        {
-            setDirty(true);
-        }
-        else if (_renderMode == RenderMode::POLYGON)
-        {
-            for (ssize_t i = 0; i < _polyInfo.triangles.vertCount; i++) {
-                auto& v = _polyInfo.triangles.verts[i].vertices;
-                v.y = _contentSize.height -v.y;
-            }
-        }
-        else
-        {
-            // RenderMode:: Quad or Slice9
-            updatePoly();
-        }
+        flipY();
     }
 }
 
 bool Sprite::isFlippedY(void) const
 {
     return _flippedY;
+}
+
+void Sprite::flipX() {
+    if (_renderMode == RenderMode::QUAD_BATCHNODE)
+    {
+        setDirty(true);
+    }
+    else if (_renderMode == RenderMode::POLYGON)
+    {
+        for (ssize_t i = 0; i < _polyInfo.triangles.vertCount; i++) {
+            auto& v = _polyInfo.triangles.verts[i].vertices;
+            v.x = _contentSize.width -v.x;
+        }
+    }
+    else
+    {
+        // RenderMode:: Quad or Slice9
+        updatePoly();
+    }
+}
+
+void Sprite::flipY() {
+    if (_renderMode == RenderMode::QUAD_BATCHNODE)
+    {
+        setDirty(true);
+    }
+    else if (_renderMode == RenderMode::POLYGON)
+    {
+        for (ssize_t i = 0; i < _polyInfo.triangles.vertCount; i++) {
+            auto& v = _polyInfo.triangles.verts[i].vertices;
+            v.y = _contentSize.height -v.y;
+        }
+    }
+    else
+    {
+        // RenderMode:: Quad or Slice9
+        updatePoly();
+    }
 }
 
 //
@@ -1591,6 +1597,9 @@ void Sprite::setSpriteFrame(SpriteFrame *spriteFrame)
     {
         _polyInfo = spriteFrame->getPolygonInfo();
         _renderMode = RenderMode::POLYGON;
+        if (_flippedX) flipX();
+        if (_flippedY) flipY();
+        updateColor();
     }
     if (spriteFrame->hasAnchorPoint())
     {

--- a/cocos/2d/CCSprite.h
+++ b/cocos/2d/CCSprite.h
@@ -661,6 +661,9 @@ protected:
     void updatePoly();
     void updateStretchFactor();
 
+    virtual void flipX();
+    virtual void flipY();
+
     //
     // Data used when the sprite is rendered using a SpriteSheet
     //


### PR DESCRIPTION
Fix polygon sprite (`CCSprite`) bug of resetting flip and color information when `setSpriteFrame(SpriteFrame *spriteFrame)` is called.

This pull request fixes issue #15696.