### PR TITLE
Avoid unnecessary file reads and parsing if plist file isn't loaded in SpriteFrameCache.

### DIFF
--- a/cocos/2d/CCSpriteFrameCache.cpp
+++ b/cocos/2d/CCSpriteFrameCache.cpp
@@ -509,20 +509,22 @@ void SpriteFrameCache::removeSpriteFrameByName(const std::string& name)
 
 void SpriteFrameCache::removeSpriteFramesFromFile(const std::string& plist)
 {
-    std::string fullPath = FileUtils::getInstance()->fullPathForFilename(plist);
-    ValueMap dict = FileUtils::getInstance()->getValueMapFromFile(fullPath);
-    if (dict.empty())
-    {
-        CCLOG("cocos2d:SpriteFrameCache:removeSpriteFramesFromFile: create dict by %s fail.",plist.c_str());
-        return;
-    }
-    removeSpriteFramesFromDictionary(dict);
-
-    // remove it from the cache
     set<string>::iterator ret = _loadedFileNames->find(plist);
-    if (ret != _loadedFileNames->end())
-    {
-        _loadedFileNames->erase(ret);
+    if (ret != _loadedFileNames->end()) {
+        std::string fullPath = FileUtils::getInstance()->fullPathForFilename(plist);
+        ValueMap dict = FileUtils::getInstance()->getValueMapFromFile(fullPath);
+        if (dict.empty())
+        {
+            CCLOG("cocos2d:SpriteFrameCache:removeSpriteFramesFromFile: create dict by %s fail.",plist.c_str());
+            return;
+        }
+        removeSpriteFramesFromDictionary(dict);
+        
+        // remove it from the cache
+        if (ret != _loadedFileNames->end())
+        {
+            _loadedFileNames->erase(ret);
+        }
     }
 }
 


### PR DESCRIPTION
This is just a small performance improvement I found when cleaning up several spritesheets during context switching (from gameplay to menus and vice-versa).