### PR TITLE
make RichText supports img tag with Sprite Frame name

### DIFF
--- a/cocos/ui/UIRichText.h
+++ b/cocos/ui/UIRichText.h
@@ -221,9 +221,10 @@ public:
      * @param opacity A opacity in GLubyte.
      * @param filePath A image file name.
      * @param url uniform resource locator
+     * @param texType texture type, may be a valid file path, or a sprite frame name
      * @return True if initialize success, false otherwise.
      */
-    bool init(int tag, const Color3B& color, GLubyte opacity, const std::string& filePath, const std::string& url = "");
+    bool init(int tag, const Color3B& color, GLubyte opacity, const std::string& filePath, const std::string& url = "", Widget::TextureResType texType = Widget::TextureResType::LOCAL);
 
     
     /**
@@ -234,9 +235,10 @@ public:
      * @param opacity A opacity in GLubyte.
      * @param filePath A image file name.
      * @param url uniform resource locator
+     * @param texType texture type, may be a valid file path, or a sprite frame name
      * @return A RichElementImage instance.
      */
-    static RichElementImage* create(int tag, const Color3B& color, GLubyte opacity, const std::string& filePath, const std::string& url = "");
+    static RichElementImage* create(int tag, const Color3B& color, GLubyte opacity, const std::string& filePath, const std::string& url = "", Widget::TextureResType texType = Widget::TextureResType::LOCAL);
 
     void setWidth(int width);
     void setHeight(int height);
@@ -244,7 +246,7 @@ public:
 protected:
     std::string _filePath;
     Rect _textureRect;
-    int _textureType;
+    Widget::TextureResType _textureType;
     friend class RichText;
     int _width;
     int _height;


### PR DESCRIPTION
this feature is added to support Creator editor because Creator only supports img tag using sprite frame from texture atlas