### PR TITLE
Add Chipmunk JS binding for segmentQuery

### DIFF
--- a/cocos/scripting/js-bindings/manual/chipmunk/js_bindings_chipmunk_registration.cpp
+++ b/cocos/scripting/js-bindings/manual/chipmunk/js_bindings_chipmunk_registration.cpp
@@ -67,6 +67,7 @@ void jsb_register_chipmunk(JSContext* cx, JS::HandleObject object)
     JS_DefineFunction(cx, chipmunk, "momentForSegment", JSB_cpMomentForSegment, 4, JSPROP_PERMANENT | JSPROP_ENUMERATE);
 
     JS::RootedObject space(cx, JSB_cpSpace_object);
+    JS_DefineFunction(cx, space, "segmentQuery", JSB_cpSpace_segmentQuery, 5, JSPROP_PERMANENT | JSPROP_ENUMERATE);
     JS_DefineFunction(cx, space, "segmentQueryFirst", JSB_cpSpace_segmentQueryFirst, 4, JSPROP_PERMANENT | JSPROP_ENUMERATE);
     JS_DefineFunction(cx, space, "pointQueryNearest", JSB_cpSpace_pointQueryNearest, 3, JSPROP_PERMANENT | JSPROP_ENUMERATE);
 


### PR DESCRIPTION
This registers the Chipmunk `segmentQuery` function on the JSB `cpSpace` object. Everything else was already set up, but the function isn't registered for some reason. Please let me know if there is a specific reason for this to not be there. Maybe there's some other API for this that I've missed?

I've tested this on an iOS 10.3.3 device, I unfortunately don't have any other devices to test this on. 


