### PR TITLE
FontAtlas::prepareLetterDefinitions's memory leak.

### DIFF
--- a/cocos/2d/CCFontAtlas.cpp
+++ b/cocos/2d/CCFontAtlas.cpp
@@ -415,6 +415,8 @@ bool FontAtlas::prepareLetterDefinitions(const std::u32string& utf32Text)
             tempDef.V = tempDef.V / scaleFactor;
         }
         else{
+            if(bitmap)
+                delete[] bitmap;
             if (tempDef.xAdvance)
                 tempDef.validDefinition = true;
             else


### PR DESCRIPTION
when FontFreeType::getGlyphBitmap return a zero-size char array.
to reproduce:
```
auto pLabel = Label::create("{1} + {2}", "TTF/xxxx.TTF", 24);
pLabel->enableOutline(Color4B(0xFF, 0xFF, 0xFF, 255), 1);
addChild(pLabel);
```