### PR TITLE
fix PhysicsBox::getSize()

### DIFF
--- a/cocos/physics/CCPhysicsShape.cpp
+++ b/cocos/physics/CCPhysicsShape.cpp
@@ -534,8 +534,8 @@ bool PhysicsShapeBox::init(const Size& size, const PhysicsMaterial& material/* =
 Size PhysicsShapeBox::getSize() const
 {
     cpShape* shape = _cpShapes.front();
-    return PhysicsHelper::cpv2size(cpv(cpvdist(cpPolyShapeGetVert(shape, 1), cpPolyShapeGetVert(shape, 2)),
-                                       cpvdist(cpPolyShapeGetVert(shape, 0), cpPolyShapeGetVert(shape, 1))));
+    return PhysicsHelper::cpv2size(cpv(cpvdist(cpPolyShapeGetVert(shape, 0), cpPolyShapeGetVert(shape, 1)),
+                                       cpvdist(cpPolyShapeGetVert(shape, 1), cpPolyShapeGetVert(shape, 2))));
 }
 
 // PhysicsShapePolygon

--- a/tests/cpp-tests/Classes/PhysicsTest/PhysicsTest.cpp
+++ b/tests/cpp-tests/Classes/PhysicsTest/PhysicsTest.cpp
@@ -28,6 +28,7 @@ PhysicsTests::PhysicsTests()
     ADD_TEST_CASE(PhysicsTransformTest);
     ADD_TEST_CASE(PhysicsIssue9959);
     ADD_TEST_CASE(PhysicsIssue15932);
+    ADD_TEST_CASE(PhysicsBoxGetSizeTest);
 }
 
 namespace
@@ -1893,6 +1894,28 @@ std::string PhysicsIssue15932::title() const
 std::string PhysicsIssue15932::subtitle() const
 {
     return "addComponent()/removeComponent() should not crash";
+}
+
+void PhysicsBoxGetSizeTest::onEnter()
+{
+    PhysicsDemo::onEnter();
+
+    const auto size1 = Size(100, 50);
+    PhysicsBody *pb=PhysicsBody::createBox(size1,PhysicsMaterial());
+    this->addComponent(pb);
+    const auto size2 = dynamic_cast<PhysicsShapeBox*>(pb->getFirstShape())->getSize();
+	
+    auto s = VisibleRect::getVisibleRect().size;
+    char buffer[128];
+    sprintf(buffer, "create size w:%d h:%d\nget size w:%d, h:%d", (int)size1.width, (int)size1.height, (int)size2.width, (int)size2.height);
+    auto label = Label::createWithTTF(buffer, "fonts/arial.ttf", 24);
+    this->addChild(label);
+    label->setPosition(Vec2(s.width / 2, s.height - 100));
+}
+
+std::string PhysicsBoxGetSizeTest::title() const
+{
+    return "PhysicsShapeBox::getSize() Test";
 }
 
 #endif

--- a/tests/cpp-tests/Classes/PhysicsTest/PhysicsTest.h
+++ b/tests/cpp-tests/Classes/PhysicsTest/PhysicsTest.h
@@ -277,4 +277,13 @@ public:
     virtual std::string subtitle() const override;
 };
 
+class PhysicsBoxGetSizeTest : public PhysicsDemo
+{
+public:
+    CREATE_FUNC(PhysicsBoxGetSizeTest);
+
+    void onEnter() override;
+    virtual std::string title() const override;
+};
+
 #endif // #if CC_USE_PHYSICS


### PR DESCRIPTION
- cocos2d-x version: 3.15

Order of vertices in chipmunk was changed.