### PR TITLE
correct usage of reference count of LabelAtlas

### DIFF
--- a/cocos/2d/CCFontAtlasCache.cpp
+++ b/cocos/2d/CCFontAtlasCache.cpp
@@ -42,7 +42,10 @@ void FontAtlasCache::purgeCachedData()
     auto atlasMapCopy = _atlasMap;
     for (auto&& atlas : atlasMapCopy)
     {
-        atlas.second->purgeTexturesAtlas();
+        auto refCount = atlas.second->getReferenceCount();
+        atlas.second->release();
+        if (refCount != 1)
+            atlas.second->purgeTexturesAtlas();
     }
     _atlasMap.clear();
 }
@@ -83,10 +86,7 @@ FontAtlas* FontAtlasCache::getFontAtlasTTF(const _ttfConfig* config)
         }
     }
     else
-    {
-        _atlasMap[atlasName]->retain();
         return _atlasMap[atlasName];
-    }
 
     return nullptr;
 }
@@ -114,10 +114,7 @@ FontAtlas* FontAtlasCache::getFontAtlasFNT(const std::string& fontFileName, cons
         }
     }
     else
-    {
-        _atlasMap[atlasName]->retain();
         return _atlasMap[atlasName];
-    }
     
     return nullptr;
 }
@@ -142,10 +139,7 @@ FontAtlas* FontAtlasCache::getFontAtlasCharMap(const std::string& plistFile)
         }
     }
     else
-    {
-        _atlasMap[atlasName]->retain();
         return _atlasMap[atlasName];
-    }
 
     return nullptr;
 }
@@ -172,10 +166,7 @@ FontAtlas* FontAtlasCache::getFontAtlasCharMap(Texture2D* texture, int itemWidth
         }
     }
     else
-    {
-        _atlasMap[atlasName]->retain();
         return _atlasMap[atlasName];
-    }
 
     return nullptr;
 }
@@ -202,10 +193,7 @@ FontAtlas* FontAtlasCache::getFontAtlasCharMap(const std::string& charMapFile, i
         }
     }
     else
-    {
-        _atlasMap[atlasName]->retain();
         return _atlasMap[atlasName];
-    }
 
     return nullptr;
 }

--- a/cocos/2d/CCFontFreeType.cpp
+++ b/cocos/2d/CCFontFreeType.cpp
@@ -219,7 +219,7 @@ FontAtlas * FontFreeType::createFontAtlas()
                 _fontAtlas->prepareLetterDefinitions(utf32);
             }
         }
-        this->autorelease();
+//        this->autorelease();
     }
     
     return _fontAtlas;

--- a/cocos/2d/CCLabel.cpp
+++ b/cocos/2d/CCLabel.cpp
@@ -588,22 +588,16 @@ void Label::setFontAtlas(FontAtlas* atlas,bool distanceFieldEnabled /* = false *
     }
 
     if (atlas == _fontAtlas)
-    {
-        if (_fontAtlas)
-        {
-            FontAtlasCache::releaseFontAtlas(_fontAtlas);
-        }
         return;
-    }
 
+    CC_SAFE_RETAIN(atlas);
     if (_fontAtlas)
     {
         _batchNodes.clear();
         FontAtlasCache::releaseFontAtlas(_fontAtlas);
-        _fontAtlas = nullptr;
     }
-
     _fontAtlas = atlas;
+    
     if (_reusedLetter == nullptr)
     {
         _reusedLetter = Sprite::create();


### PR DESCRIPTION
I found `LabelNewTest` will crash in the test case: `LabelTTFCJKWrappingTest`. Then i check the commit history, found it is caused by https://github.com/cocos2d/cocos2d-x/pull/17756. After doing more research, i found `FontAtlasCache::getFontAtlasXXX()` has bad logic in reference count usage, so send this PR to fix it. This PR also fix crash of the test case.