### PR TITLE
Let ScrollView swallow touch events variable.

### DIFF
--- a/extensions/GUI/CCScrollView/CCScrollView.cpp
+++ b/extensions/GUI/CCScrollView/CCScrollView.cpp
@@ -206,6 +206,14 @@ void ScrollView::setTouchEnabled(bool enabled)
     }
 }
 
+void ScrollView::setSwallowTouches(bool needSwallow)
+{
+    if (_touchListener != nullptr)
+    {
+        _touchListener->setSwallowTouches(needSwallow);
+    }
+}
+
 void ScrollView::setContentOffset(Vec2 offset, bool animated/* = false*/)
 {
     if (animated)

--- a/extensions/GUI/CCScrollView/CCScrollView.h
+++ b/extensions/GUI/CCScrollView/CCScrollView.h
@@ -196,6 +196,7 @@ public:
 
     void setTouchEnabled(bool enabled);
 	bool isTouchEnabled() const;
+    void setSwallowTouches(bool needSwallow);
     bool isDragging() const {return _dragging;}
     bool isTouchMoved() const { return _touchMoved; }
     bool isBounceable() const { return _bounceable; }


### PR DESCRIPTION
SwallowTouch became true on defaut, and can not be changed by below commit. 
Https://github.com/cocos2d/cocos2d-x/commit/07051a035725728c07276579d3826ebb9ed43188

I added a method that can change it.
