### PR TITLE
fixed GLViewImpl::getMonitorSize() for desktop platforms

### DIFF
--- a/cocos/platform/desktop/CCGLViewImpl-desktop.cpp
+++ b/cocos/platform/desktop/CCGLViewImpl-desktop.cpp
@@ -546,6 +546,9 @@ Size GLViewImpl::getMonitorSize() const {
         GLFWwindow* window = this->getWindow();
         monitor = glfwGetWindowMonitor(window);
     }
+    if (nullptr == monitor) {
+        monitor = glfwGetPrimaryMonitor();
+    }
     if (nullptr != monitor) {
         const GLFWvidmode* videoMode = glfwGetVideoMode(monitor);
         Size size = Size(videoMode->width, videoMode->height);


### PR DESCRIPTION
When application was created windowed `glfwGetWindowMonitor` may return NULL. So return of `getMonitorSize()` will be ZERO. glfwGetPrimaryMonitor was added on glfw 3.0 so you can use it.