### PR TITLE
fix android problem with 24 bit depth buffer on some devices

### DIFF
--- a/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxActivity.java
+++ b/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxActivity.java
@@ -361,6 +361,17 @@ public abstract class Cocos2dxActivity extends Activity implements Cocos2dxHelpe
                     EGL10.EGL_NONE
                 },
                 {
+                     // GL ES 2 with user set
+                     EGL10.EGL_RED_SIZE, mConfigAttributes[0],
+                     EGL10.EGL_GREEN_SIZE, mConfigAttributes[1],
+                     EGL10.EGL_BLUE_SIZE, mConfigAttributes[2],
+                     EGL10.EGL_ALPHA_SIZE, mConfigAttributes[3],
+                     EGL10.EGL_DEPTH_SIZE, mConfigAttributes[4] >= 24 ? 16 : mConfigAttributes[4],
+                     EGL10.EGL_STENCIL_SIZE, mConfigAttributes[5],
+                     EGL10.EGL_RENDERABLE_TYPE, EGL_OPENGL_ES2_BIT,
+                     EGL10.EGL_NONE
+                },
+                {
                     // GL ES 2 by default
                     EGL10.EGL_RENDERABLE_TYPE, EGL_OPENGL_ES2_BIT,
                     EGL10.EGL_NONE


### PR DESCRIPTION
some android devices can't use 24bit depth buffer so try to use 16 if 24 is not supported