### PR TITLE
fix android webview keyback bug after opened a page

### DIFF
--- a/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxWebView.java
+++ b/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxWebView.java
@@ -50,7 +50,7 @@ public class Cocos2dxWebView extends WebView {
         this.mJSScheme = "";
 
         this.setFocusable(true);
-        this.setFocusableInTouchMode(true);
+        this.setFocusableInTouchMode(false);
 
         this.getSettings().setSupportZoom(false);
 


### PR DESCRIPTION
bug happen when:
1.implement keyback in a scene
2.implement webview in that scene and load a default URL
3.click any link and wait for it to load
4.press key back, the implemented keyback will not be called