### PR TITLE
Fix crash TextFieldTTF::setCursorFromPoint

### DIFF
--- a/cocos/2d/CCTextFieldTTF.cpp
+++ b/cocos/2d/CCTextFieldTTF.cpp
@@ -382,14 +382,17 @@ void TextFieldTTF::setCursorFromPoint(const Vec2 &point, const Camera* camera)
             int latterPosition = 0;
             for (; latterPosition < _lengthOfString; ++latterPosition)
             {
-                if (_lettersInfo[latterPosition].valid)
+                if (_lettersInfo[latterPosition].valid && _lettersInfo[latterPosition].atlasIndex >= 0)
                 {
                     auto sprite = getLetter(latterPosition);
-                    rect.size = sprite->getContentSize();
-                    if (isScreenPointInRect(point, camera, sprite->getWorldToNodeTransform(), rect, nullptr))
+                    if (sprite)
                     {
-                        setCursorPosition(latterPosition);
-                        break;
+                        rect.size = sprite->getContentSize();
+                        if (isScreenPointInRect(point, camera, sprite->getWorldToNodeTransform(), rect, nullptr))
+                        {
+                            setCursorPosition(latterPosition);
+                            break;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
A similar problem of
https://github.com/cocos2d/cocos2d-x/issues/15926
And fix it in https://github.com/cocos2d/cocos2d-x/commit/afaa9be8262e64fbc090cf2c202871efe779b94e