### PR TITLE
fixed #17989: touch stops responding on android devices.

### DIFF
--- a/cocos/base/CCEventType.h
+++ b/cocos/base/CCEventType.h
@@ -44,8 +44,5 @@
 // This message is posted in cocos/platform/android/jni/Java_org_cocos2dx_lib_Cocos2dxRenderer.cpp and cocos\platform\wp8-xaml\cpp\Cocos2dRenderer.cpp.
 #define EVENT_COME_TO_BACKGROUND    "event_come_to_background"
 
-// The name of an event which indicates there will be a file being read.
-#define EVENT_BEFORE_READ_FILE "event_before_read_file"
-
 /// @endcond
 #endif // __CCEVENT_TYPE_H__

--- a/cocos/platform/android/CCFileUtils-android.cpp
+++ b/cocos/platform/android/CCFileUtils-android.cpp
@@ -30,12 +30,10 @@ THE SOFTWARE.
 #include "platform/CCCommon.h"
 #include "platform/android/jni/JniHelper.h"
 #include "platform/android/jni/Java_org_cocos2dx_lib_Cocos2dxHelper.h"
+#include "platform/android/jni/Java_org_cocos2dx_lib_Cocos2dxEngineDataManager.h"
 #include "android/asset_manager.h"
 #include "android/asset_manager_jni.h"
 #include "base/ZipUtils.h"
-#include "base/CCDirector.h"
-#include "base/CCEventDispatcher.h"
-#include "base/CCEventType.h"
 
 #include <stdlib.h>
 #include <sys/stat.h>
@@ -283,7 +281,7 @@ long FileUtilsAndroid::getFileSize(const std::string& filepath)
 
 FileUtils::Status FileUtilsAndroid::getContents(const std::string& filename, ResizableBuffer* buffer)
 {
-    Director::getInstance()->getEventDispatcher()->dispatchCustomEvent(EVENT_BEFORE_READ_FILE);
+    EngineDataManager::onBeforeReadFile();
 
     static const std::string apkprefix("assets/");
     if (filename.empty())

--- a/cocos/platform/android/jni/Java_org_cocos2dx_lib_Cocos2dxEngineDataManager.cpp
+++ b/cocos/platform/android/jni/Java_org_cocos2dx_lib_Cocos2dxEngineDataManager.cpp
@@ -1021,7 +1021,7 @@ void EngineDataManager::onBeforeSetNextScene(EventCustom* event)
     _isReplaceScene = true;
 }
 
-void EngineDataManager::onBeforeReadFile(EventCustom* event)
+void EngineDataManager::onBeforeReadFile()
 {
     _isReadFile = true;
 }
@@ -1376,7 +1376,6 @@ void EngineDataManager::init()
     dispatcher->addCustomEventListener(Director::EVENT_BEFORE_SET_NEXT_SCENE, std::bind(onBeforeSetNextScene, std::placeholders::_1));
     dispatcher->addCustomEventListener(EVENT_COME_TO_FOREGROUND, std::bind(onEnterForeground, std::placeholders::_1));
     dispatcher->addCustomEventListener(EVENT_COME_TO_BACKGROUND, std::bind(onEnterBackground, std::placeholders::_1));
-    dispatcher->addCustomEventListener(EVENT_BEFORE_READ_FILE, std::bind(onBeforeReadFile, std::placeholders::_1));
 
     notifyGameStatus(GameStatus::LAUNCH_BEGIN, 5, -1);
 

--- a/cocos/platform/android/jni/Java_org_cocos2dx_lib_Cocos2dxEngineDataManager.h
+++ b/cocos/platform/android/jni/Java_org_cocos2dx_lib_Cocos2dxEngineDataManager.h
@@ -55,6 +55,8 @@ public:
 
     static void notifyGameStatus(GameStatus type, int cpuLevel, int gpuLevel);
     static void setAnimationInterval(float interval, SetIntervalReason reason);
+    // Used in FileUtilsAndroid::getContents
+    static void onBeforeReadFile();
 
 private:
     static void notifyContinuousFrameLost(int frameLostCycle, int continueFrameLostThreshold, int times);
@@ -68,7 +70,6 @@ private:
     static void onAfterDrawScene(EventCustom* event);
     static void onEnterForeground(EventCustom* event);
     static void onEnterBackground(EventCustom* event);
-    static void onBeforeReadFile(EventCustom* event);
 
     static int getTotalParticleCount();
 


### PR DESCRIPTION
It's caused by `FileUtils::getContents` is invoked in different threads and we use EventDispatcher::dispatchCustomEvent in `FileUtilsAndroid::getContents` to send an event to EngineDataManager.
Since EngineDataManager class is only for internal use and EventDispatcher isn't thread-safe, we make `EngineDataManager::onBeforeReadFile` public and invoke it `FileUtilsAndroid::getContents`.