### PR TITLE
Fix android compile fail bug

### DIFF
--- a/templates/cpp-template-default/proj.android-studio/app/src/org/cocos2dx/cpp/AppActivity.java
+++ b/templates/cpp-template-default/proj.android-studio/app/src/org/cocos2dx/cpp/AppActivity.java
@@ -23,6 +23,7 @@ THE SOFTWARE.
 ****************************************************************************/
 package org.cocos2dx.cpp;
 
+import android.os.Bundle;
 import org.cocos2dx.lib.Cocos2dxActivity;
 
 public class AppActivity extends Cocos2dxActivity {

--- a/templates/cpp-template-default/proj.android/src/org/cocos2dx/cpp/AppActivity.java
+++ b/templates/cpp-template-default/proj.android/src/org/cocos2dx/cpp/AppActivity.java
@@ -26,6 +26,7 @@ THE SOFTWARE.
 ****************************************************************************/
 package org.cocos2dx.cpp;
 
+import android.os.Bundle;
 import org.cocos2dx.lib.Cocos2dxActivity;
 
 public class AppActivity extends Cocos2dxActivity {

--- a/templates/js-template-default/frameworks/runtime-src/proj.android-studio/app/src/org/cocos2dx/javascript/AppActivity.java
+++ b/templates/js-template-default/frameworks/runtime-src/proj.android-studio/app/src/org/cocos2dx/javascript/AppActivity.java
@@ -23,6 +23,7 @@ THE SOFTWARE.
 ****************************************************************************/
 package org.cocos2dx.javascript;
 
+import android.os.Bundle;
 import org.cocos2dx.lib.Cocos2dxActivity;
 import org.cocos2dx.lib.Cocos2dxGLSurfaceView;
 

--- a/templates/js-template-default/frameworks/runtime-src/proj.android/src/org/cocos2dx/javascript/AppActivity.java
+++ b/templates/js-template-default/frameworks/runtime-src/proj.android/src/org/cocos2dx/javascript/AppActivity.java
@@ -26,6 +26,7 @@ THE SOFTWARE.
 ****************************************************************************/
 package org.cocos2dx.javascript;
 
+import android.os.Bundle;
 import org.cocos2dx.lib.Cocos2dxActivity;
 import org.cocos2dx.lib.Cocos2dxGLSurfaceView;
 

--- a/templates/lua-template-default/frameworks/runtime-src/proj.android-studio/app/src/org/cocos2dx/lua/AppActivity.java
+++ b/templates/lua-template-default/frameworks/runtime-src/proj.android-studio/app/src/org/cocos2dx/lua/AppActivity.java
@@ -25,8 +25,8 @@ THE SOFTWARE.
 ****************************************************************************/
 package org.cocos2dx.lua;
 
+import android.os.Bundle;
 import org.cocos2dx.lib.Cocos2dxActivity;
-
 
 public class AppActivity extends Cocos2dxActivity{
     @Override

--- a/templates/lua-template-default/frameworks/runtime-src/proj.android/src/org/cocos2dx/lua/AppActivity.java
+++ b/templates/lua-template-default/frameworks/runtime-src/proj.android/src/org/cocos2dx/lua/AppActivity.java
@@ -25,8 +25,8 @@ THE SOFTWARE.
 ****************************************************************************/
 package org.cocos2dx.lua;
 
+import android.os.Bundle;
 import org.cocos2dx.lib.Cocos2dxActivity;
-
 
 public class AppActivity extends Cocos2dxActivity{
     @Override


### PR DESCRIPTION
Newest version of cocos2dx run "cocos compile -p android --android-studio" failed on reason:

```
{PROJECT_NAME}/frameworks/runtime-src/proj.android-studio/app/src/org/cocos2dx/javascript/AppActivity.java:31: error: cannot find symbol
    protected void onCreate(Bundle savedInstanceState) {
                            ^
  symbol:   class Bundle
  location: class AppActivity
```
because of the method ```protected void onCreate(Bundle savedInstanceState)``` was override but Bundle class not imported.

Add "import android.os.Bundle" would be ok.