### PR TITLE
add new CMakeLists.txt to cpp-template-default

### DIFF
--- a/templates/cpp-template-default/CMakeLists.txt
+++ b/templates/cpp-template-default/CMakeLists.txt
@@ -63,16 +63,16 @@ endif()
 # Compiler options
 if(MSVC)
   if(CMAKE_BUILD_TYPE STREQUAL "Debug")
-    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /NODEFAULTLIB:msvcrt /NODEFAULTLIB:libcmt")
+  	set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /NODEFAULTLIB:msvcrt /NODEFAULTLIB:libcmt")
   else()
-    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /NODEFAULTLIB:libcmt")
+	set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /NODEFAULTLIB:libcmt")
   endif()
   ADD_DEFINITIONS(-D_CRT_SECURE_NO_WARNINGS -D_SCL_SECURE_NO_WARNINGS
                   -wd4251 -wd4244 -wd4334 -wd4005 -wd4820 -wd4710
                   -wd4514 -wd4056 -wd4996 -wd4099)
 else()
-  if(CMAKE_BUILD_TYPE MATCHES Debug)
-    ADD_DEFINITIONS(-DCOCOS2D_DEBUG=1)
+  if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+	ADD_DEFINITIONS(-DCOCOS2D_DEBUG=1)
   endif()
   set(CMAKE_C_FLAGS_DEBUG "-g -Wall")
   set(CMAKE_CXX_FLAGS_DEBUG ${CMAKE_C_FLAGS_DEBUG})
@@ -83,100 +83,157 @@ else()
   endif()
 endif(MSVC)
 
-set(PLATFORM_SPECIFIC_SRC)
-set(PLATFORM_SPECIFIC_HEADERS)
-
-if(MACOSX OR APPLE)
-    set(PLATFORM_SPECIFIC_SRC
-      proj.ios_mac/mac/main.cpp
-    )
-elseif(LINUX)
-    set(PLATFORM_SPECIFIC_SRC
-      proj.linux/main.cpp
-    )
-elseif ( WIN32 )
-    set(PLATFORM_SPECIFIC_SRC
-      proj.win32/main.cpp
-    )
-    set(PLATFORM_SPECIFIC_HEADERS
-      proj.win32/main.h
-      proj.win32/resource.h
-    )
-elseif(ANDROID)
-    set(PLATFORM_SPECIFIC_SRC
-      proj.android-studio/app/jni/hellocpp/main.cpp
-    )
-endif()
-
-include_directories(
-  /usr/local/include/GLFW
-  /usr/include/GLFW
-  ${COCOS2D_ROOT}
-  ${COCOS2D_ROOT}/cocos
-  ${COCOS2D_ROOT}/external
-  ${COCOS2D_ROOT}/cocos/platform
-  ${COCOS2D_ROOT}/cocos/audio/include/
-  Classes
-)
-if ( WIN32 )
-  include_directories(
-  ${COCOS2D_ROOT}/external/glfw3/include/win32
-  ${COCOS2D_ROOT}/external/win32-specific/gles/include/OGLES
-)
-endif( WIN32 )
-
-set(GAME_SRC
-  Classes/AppDelegate.cpp
-  Classes/HelloWorldScene.cpp
-  ${PLATFORM_SPECIFIC_SRC}
-)
-
-set(GAME_HEADERS
-  Classes/AppDelegate.h
-  Classes/HelloWorldScene.h
-  ${PLATFORM_SPECIFIC_HEADERS}
-)
-
-
-# Configure libcocos2d
+# libcocos2d
 set(BUILD_CPP_EMPTY_TEST OFF CACHE BOOL "turn off build cpp-empty-test")
 set(BUILD_CPP_TESTS OFF CACHE BOOL "turn off build cpp-tests")
 set(BUILD_LUA_LIBS OFF CACHE BOOL "turn off build lua related targets")
 set(BUILD_JS_LIBS OFF CACHE BOOL "turn off build js related targets")
 add_subdirectory(${COCOS2D_ROOT})
 
+if(ANDROID)
+    set(PLATFORM_SPECIFIC_SRC proj.android/jni/main.cpp)
+    set(RES_PREFIX "/Resources")
+elseif(WINDOWS)
+    set(PLATFORM_SPECIFIC_SRC proj.win32/main.cpp)
+    set(PLATFORM_SPECIFIC_HEADERS
+            proj.win32/main.h
+            proj.win32/resource.h
+            )
+    set(RES_PREFIX "")
+elseif(IOS)
+    set(PLATFORM_SPECIFIC_SRC
+            proj.ios_mac/ios/main.m
+            proj.ios_mac/ios/AppController.mm
+            proj.ios_mac/ios/RootViewController.mm
+            )
 
-# MyGame
-if( ANDROID )
+elseif(MACOSX OR APPLE)
+    set(PLATFORM_SPECIFIC_SRC proj.ios_mac/mac/main.cpp)
+    
+    set(MACOSX_BUNDLE_BUNDLE_NAME "\${PRODUCT_NAME}")
+    set(MACOSX_BUNDLE_INFO_PLIST proj.ios_mac/mac/Info.plist)
+    set(MACOSX_BUNDLE_ICON_FILE Icon)
+    set(MACOSX_BUNDLE_GUI_IDENTIFIER org.cocos2dx.hellocpp)
+    set(MACOSX_BUNDLE_SHORT_VERSION_STRING 1.0)
+    set(MACOSX_BUNDLE_BUNDLE_VERSION 1)
+    set(MACOSX_BUNDLE_COPYRIGHT "Copyright © 2017. All rights reserved.")
+
+    file(GLOB_RECURSE RES_FILES Resources/*)
+    cocos_mark_resources(FILES ${RES_FILES} BASEDIR Resources)
+    file(GLOB_RECURSE RES_ICON proj.ios_mac/mac/Icon.icns)
+    cocos_mark_resources(FILES ${RES_ICON} BASEDIR proj.ios_mac/mac)
+
+    list(APPEND PLATFORM_SPECIFIC_SRC ${RES_FILES} ${RES_ICON})
+
+elseif(LINUX)
+    set(PLATFORM_SPECIFIC_SRC proj.linux/main.cpp)
+    set(RES_PREFIX "/Resources")
+else()
+    message( FATAL_ERROR "Unsupported platform, CMake will exit" )
+
+endif()
+
+include_directories(
+	/usr/local/include/GLFW
+	/usr/include/GLFW
+	${COCOS2D_ROOT}
+	${COCOS2D_ROOT}/cocos
+	${COCOS2D_ROOT}/external
+	${COCOS2D_ROOT}/cocos/platform
+	${COCOS2D_ROOT}/cocos/audio/include/
+	Classes
+)
+if ( WINDOWS )
+    include_directories(
+            ${COCOS2D_ROOT}/external/glfw3/include/${PLATFORM_FOLDER}
+            ${COCOS2D_ROOT}/external/${PLATFORM_FOLDER}-specific/gles/include/OGLES
+    )
+elseif ( MACOSX OR APPLE )
+    include_directories(
+            ${COCOS2D_ROOT}/external/glfw3/include/mac
+    )
+endif ()
+
+set(GAME_SRC
+        ${PLATFORM_SPECIFIC_SRC}
+        Classes/AppDelegate.cpp
+        Classes/HelloWorldScene.cpp
+        )
+
+set(GAME_HEADERS
+        ${PLATFORM_SPECIFIC_HEADERS}
+        Classes/AppDelegate.h
+        Classes/HelloWorldScene.h
+        )
+
+# add the executable
+if(ANDROID)
     add_library(${APP_NAME} SHARED ${GAME_SRC} ${GAME_HEADERS})
-    IF(CMAKE_BUILD_TYPE MATCHES RELEASE)
+    IF(CMAKE_BUILD_TYPE STREQUAL "Release")
         ADD_CUSTOM_COMMAND(TARGET ${APP_NAME} POST_BUILD COMMAND ${CMAKE_STRIP} lib${APP_NAME}.so)
     ENDIF()
+elseif(MSVC)
+	add_executable(${APP_NAME} ${GAME_SRC} ${GAME_HEADERS} proj.win32/game.rc)
 else()
     add_executable(${APP_NAME} ${GAME_SRC} ${GAME_HEADERS})
 endif()
 
 target_link_libraries(${APP_NAME} cocos2d)
 
-set(APP_BIN_DIR "${CMAKE_BINARY_DIR}/bin")
 
-set_target_properties(${APP_NAME} PROPERTIES
-     RUNTIME_OUTPUT_DIRECTORY  "${APP_BIN_DIR}")
+if(MSVC)
 
-if ( WIN32 )
-  #also copying dlls to binary directory for the executable to run
-  pre_build(${APP_NAME}
-    COMMAND ${CMAKE_COMMAND} -E remove_directory ${APP_BIN_DIR}/Resources
-    COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_SOURCE_DIR}/Resources ${APP_BIN_DIR}/Resources
-    COMMAND ${CMAKE_COMMAND} -E copy ${COCOS2D_ROOT}/external/win32-specific/gles/prebuilt/glew32.dll ${APP_BIN_DIR}/${CMAKE_BUILD_TYPE}
-	COMMAND ${CMAKE_COMMAND} -E copy ${COCOS2D_ROOT}/external/win32-specific/zlib/prebuilt/zlib1.dll ${APP_BIN_DIR}/${CMAKE_BUILD_TYPE}
+	set(APP_BIN_DIR "${CMAKE_BINARY_DIR}/bin/${PLATFORM_FOLDER}/$<CONFIG>")
+
+    #get our resources
+    add_custom_command(TARGET ${APP_NAME} PRE_BUILD
+            COMMAND ${CMAKE_COMMAND} -E copy_directory
+            ${CMAKE_CURRENT_SOURCE_DIR}/Resources ${APP_BIN_DIR})
+	    
+    # create a list of dlls to copy
+	file(GLOB THIRD_PARTY_DLLS
+		"${COCOS2D_ROOT}/external/${PLATFORM_FOLDER}-specific/gles/prebuilt/glew32.dll"
+		"${COCOS2D_ROOT}/external/${PLATFORM_FOLDER}-specific/zlib/prebuilt/zlib1.dll"
+		"${COCOS2D_ROOT}/external/${PLATFORM_FOLDER}-specific/OggDecoder/prebuilt/libogg.dll"
+		"${COCOS2D_ROOT}/external/${PLATFORM_FOLDER}-specific/OggDecoder/prebuilt/libvorbis.dll"
+		"${COCOS2D_ROOT}/external/${PLATFORM_FOLDER}-specific/OggDecoder/prebuilt/libvorbisfile.dll"
+		"${COCOS2D_ROOT}/external/${PLATFORM_FOLDER}-specific/MP3Decoder/prebuilt/libmpg123.dll"
+		"${COCOS2D_ROOT}/external/${PLATFORM_FOLDER}-specific/OpenalSoft/prebuilt/OpenAL32.dll"
+		"${COCOS2D_ROOT}/external/${PLATFORM_FOLDER}-specific/icon/prebuilt/iconv.dll"
+		"${COCOS2D_ROOT}/external/tiff/prebuilt/${PLATFORM_FOLDER}/libtiff.dll"
 	)
-elseif( ANDROID )
+	
+	list(SORT THIRD_PARTY_DLLS)
+
+	# do the copying
+	foreach( file_i ${THIRD_PARTY_DLLS})
+		add_custom_command(TARGET ${APP_NAME} PRE_BUILD
+			COMMAND ${CMAKE_COMMAND} -E copy
+			${file_i} 
+			${APP_BIN_DIR}
+		)
+	endforeach( file_i )
+
+    #Visual Studio Defaults to wrong type
+    set_target_properties(${APP_NAME} PROPERTIES LINK_FLAGS "/SUBSYSTEM:WINDOWS"
+									RUNTIME_OUTPUT_DIRECTORY  "${APP_BIN_DIR}")
+
+elseif(MACOSX OR APPLE)
+    set_target_properties(${APP_NAME} PROPERTIES
+            MACOSX_BUNDLE 1
+            LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib/$<CONFIG>"
+            ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib/$<CONFIG>"
+            RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin/$<CONFIG>"
+            )
 
 else()
-  pre_build(${APP_NAME}
-    COMMAND ${CMAKE_COMMAND} -E remove_directory ${APP_BIN_DIR}/Resources
-    COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_SOURCE_DIR}/Resources ${APP_BIN_DIR}/Resources
-    )
+
+    set(APP_BIN_DIR "${CMAKE_BINARY_DIR}/bin/$<CONFIG>")
+
+    set_target_properties(${APP_NAME} PROPERTIES
+            RUNTIME_OUTPUT_DIRECTORY  "${APP_BIN_DIR}")
+    add_custom_command(TARGET ${APP_NAME} POST_BUILD
+            COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_SOURCE_DIR}/Resources $<TARGET_FILE_DIR:${APP_NAME}>${RES_PREFIX}
+            )
 
 endif()


### PR DESCRIPTION
New `CmakeLists.txt` for `cpp-template-default` based on `cpp-empty-test/CMakeLists.txt`. 

It can:
build and run binary on `linux+gcc`
build and run valid .app (bundle) on `macOS+clang`
build and run valid .exe on `VisualStudio+nmake` (`cmake -G "NMake Makefiles"`)
generate valid `Xcode` project for `macOS` (`cmake -G Xcode`)
generate valid `Visual Studio` project for `win32`  (`cmake -G "Visual Studio 14"`)

Full backward compatibility.  `ANDROID` target not changed.

Full history on https://gist.github.com/MrCapone/ccdc1826cb7362086107e8096bfe6f90

fixes issue https://github.com/cocos2d/cocos2d-x/issues/16900