### PR TITLE
Fix bug of returning UNKNOWN event for return type key SEARCH/SEND in EditBox.

### DIFF
--- a/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxEditBoxHelper.java
+++ b/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxEditBoxHelper.java
@@ -204,7 +204,8 @@ public class Cocos2dxEditBoxHelper {
                             editBox.endAction = Cocos2dxEditBox.kEndActionNext;
                             Cocos2dxEditBoxHelper.closeKeyboardOnUiThread(index);
                             return true;
-                        } else if (actionId == EditorInfo.IME_ACTION_DONE) {
+                        } else if (actionId == EditorInfo.IME_ACTION_DONE || actionId == EditorInfo.IME_ACTION_SEND || actionId == EditorInfo.IME_ACTION_SEARCH) {
+                            editBox.endAction = Cocos2dxEditBox.kEndActionReturn;
                             Cocos2dxEditBoxHelper.closeKeyboardOnUiThread(index);
                         }
                         return false;

--- a/cocos/ui/UIEditBox/iOS/CCUIEditBoxIOS.mm
+++ b/cocos/ui/UIEditBox/iOS/CCUIEditBoxIOS.mm
@@ -293,7 +293,8 @@
         if (self.keyboardReturnType == cocos2d::ui::EditBox::KeyboardReturnType::NEXT) {
             action = cocos2d::ui::EditBoxDelegate::EditBoxEndAction::TAB_TO_NEXT;
         } else if (self.keyboardReturnType == cocos2d::ui::EditBox::KeyboardReturnType::GO ||
-                 self.keyboardReturnType == cocos2d::ui::EditBox::KeyboardReturnType::SEND) {
+                   self.keyboardReturnType == cocos2d::ui::EditBox::KeyboardReturnType::SEND ||
+                   self.keyboardReturnType == cocos2d::ui::EditBox::KeyboardReturnType::SEARCH) {
             action = cocos2d::ui::EditBoxDelegate::EditBoxEndAction::RETURN;
         }
     }


### PR DESCRIPTION
If you set and `EditBox` return type to `SEARCH` (Android and iOS) or `SEND` (Android) and click on the corresponding keyboard button, you get `UNKNOWN` event.

This pull request fixes this issue.