### PR TITLE
Stop removing .lua and .luac at the end of filename in LuaLoader

### DIFF
--- a/cocos/scripting/lua-bindings/manual/Cocos2dxLuaLoader.cpp
+++ b/cocos/scripting/lua-bindings/manual/Cocos2dxLuaLoader.cpp
@@ -77,17 +77,6 @@ extern "C"
             if (prefix[0] == '.' && prefix[1] == '/')
                 prefix = prefix.substr(2);
 
-            pos = prefix.rfind(BYTECODE_FILE_EXT);
-            if (pos != std::string::npos && pos == prefix.length() - BYTECODE_FILE_EXT.length())
-            {
-                prefix = prefix.substr(0, pos);
-            }
-            else
-            {
-                pos = prefix.rfind(NOT_BYTECODE_FILE_EXT);
-                if (pos != std::string::npos && pos == prefix.length() - NOT_BYTECODE_FILE_EXT.length())
-                    prefix = prefix.substr(0, pos);
-            }
             pos = prefix.find_first_of("?", 0);
             while (pos != std::string::npos)
             {


### PR DESCRIPTION
I've preformed some research and testing, so now you can safely stop this. Previous discussion and reasons you can found here: #18171. Note, that it MAY break some cocos-lua based projects, but there is trivial fix: do not use `.lua` and `.luac` directly in `require`.