### PR TITLE
fix android AudioEngine Crash (#18124)

### DIFF
--- a/cocos/audio/android/AudioEngine-inl.cpp
+++ b/cocos/audio/android/AudioEngine-inl.cpp
@@ -212,7 +212,7 @@ void AudioEngineImpl::onEnterBackground(EventCustom* event)
         if (dynamic_cast<UrlAudioPlayer*>(player) != nullptr
             && player->getState() == IAudioPlayer::State::PLAYING)
         {
-            _urlAudioPlayersNeedResume.push_back(player);
+            _urlAudioPlayersNeedResume.emplace(e.first, player);
             player->pause();
         }
     }
@@ -228,9 +228,9 @@ void AudioEngineImpl::onEnterForeground(EventCustom* event)
     }
 
     // resume UrlAudioPlayers
-    for (auto&& player : _urlAudioPlayersNeedResume)
+    for (auto&& iter : _urlAudioPlayersNeedResume)
     {
-        player->resume();
+        iter.second->resume();
     }
     _urlAudioPlayersNeedResume.clear();
 }
@@ -279,6 +279,10 @@ int AudioEngineImpl::play2d(const std::string &filePath ,bool loop ,float volume
                 if (_audioPlayers.find(id) != _audioPlayers.end())
                 {
                     _audioPlayers.erase(id);
+                }
+                if (_urlAudioPlayersNeedResume.find(id) != _urlAudioPlayersNeedResume.end())
+                {
+                    _urlAudioPlayersNeedResume.erase(id);
                 }
 
                 auto iter = _callbackMap.find(id);

--- a/cocos/audio/android/AudioEngine-inl.h
+++ b/cocos/audio/android/AudioEngine-inl.h
@@ -90,7 +90,7 @@ private:
     std::unordered_map<int, std::function<void (int, const std::string &)>> _callbackMap;
 
     // UrlAudioPlayers which need to resumed while entering foreground
-    std::vector<IAudioPlayer*> _urlAudioPlayersNeedResume;
+    std::unordered_map<int, IAudioPlayer*> _urlAudioPlayersNeedResume;
 
     AudioPlayerProvider* _audioPlayerProvider;
     EventListener* _onPauseListener;


### PR DESCRIPTION
Sync https://github.com/cocos2d/cocos2d-x/pull/18124

* *fix android AudioEngine Crash

switch to background when sound effect is about to end, it's maybe crashed when switch to foreground again

* use "emplace" instead of "insert"