### PR TITLE
Fix RenderTexture DepthAndStencil issue on Android.

### DIFF
--- a/cocos/2d/CCRenderTexture.cpp
+++ b/cocos/2d/CCRenderTexture.cpp
@@ -60,6 +60,7 @@ RenderTexture::RenderTexture()
 , _autoDraw(false)
 , _sprite(nullptr)
 , _saveFileCallback(nullptr)
+, _depthAndStencilFormat(0)
 {
 #if CC_ENABLE_CACHE_TEXTURE_DATA
     // Listen this event to save render texture before come to background.
@@ -118,6 +119,18 @@ void RenderTexture::listenToBackground(EventCustom* /*event*/)
     
     glDeleteFramebuffers(1, &_FBO);
     _FBO = 0;
+
+    if (_depthRenderBufffer)
+    {
+        glDeleteRenderbuffers(1, &_depthRenderBufffer);
+        _depthRenderBufffer = 0;
+    }
+    
+    if (_stencilRenderBufffer)
+    {
+        glDeleteRenderbuffers(1, &_stencilRenderBufffer);
+        _stencilRenderBufffer = 0;
+    }
 #endif
 }
 
@@ -126,9 +139,18 @@ void RenderTexture::listenToForeground(EventCustom* /*event*/)
 #if CC_ENABLE_CACHE_TEXTURE_DATA
     // -- regenerate frame buffer object and attach the texture
     glGetIntegerv(GL_FRAMEBUFFER_BINDING, &_oldFBO);
+
+    GLint oldRBO;
+    glGetIntegerv(GL_RENDERBUFFER_BINDING, &oldRBO);
     
     glGenFramebuffers(1, &_FBO);
     glBindFramebuffer(GL_FRAMEBUFFER, _FBO);
+
+    const Size& s = _texture->getContentSizeInPixels();
+    if (_depthAndStencilFormat != 0)
+    {
+        setupDepthAndStencil(s.width, s.height);
+    }
     
     _texture->setAliasTexParameters();
     
@@ -138,7 +160,9 @@ void RenderTexture::listenToForeground(EventCustom* /*event*/)
     }
     
     glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, _texture->getName(), 0);
+    glBindRenderbuffer(GL_RENDERBUFFER, oldRBO);
     glBindFramebuffer(GL_FRAMEBUFFER, _oldFBO);
+
 #endif
 }
 
@@ -259,19 +283,55 @@ bool RenderTexture::initWithWidthAndHeight(int w, int h, Texture2D::PixelFormat 
 
         if (depthStencilFormat != 0)
         {
-            
-                        
+	    _depthAndStencilFormat = depthStencilFormat;
+            setupDepthAndStencil(powW, powH);
+        }
+
+        // check if it worked (probably worth doing :) )
+        CCASSERT(glCheckFramebufferStatus(GL_FRAMEBUFFER) == GL_FRAMEBUFFER_COMPLETE, "Could not attach texture to framebuffer");
+
+        _texture->setAliasTexParameters();
+
+        // retained
+        setSprite(Sprite::createWithTexture(_texture));
+
+        _texture->release();
+        _sprite->setFlippedY(true);
+
+        _sprite->setBlendFunc( BlendFunc::ALPHA_PREMULTIPLIED );
+        _sprite->setOpacityModifyRGB(true);
+
+        glBindRenderbuffer(GL_RENDERBUFFER, oldRBO);
+        glBindFramebuffer(GL_FRAMEBUFFER, _oldFBO);
+        
+        // Disabled by default.
+        _autoDraw = false;
+        
+        // add sprite for backward compatibility
+        addChild(_sprite);
+        
+        ret = true;
+    } while (0);
+    
+    CC_SAFE_FREE(data);
+    
+    return ret;
+}
+
+void RenderTexture::setupDepthAndStencil(int powW, int powH)
+{
+                                    
 #if(CC_TARGET_PLATFORM == CC_PLATFORM_ANDROID)
             if(Configuration::getInstance()->supportsOESPackedDepthStencil())
             {
                 //create and attach depth buffer
                 glGenRenderbuffers(1, &_depthRenderBuffer);
                 glBindRenderbuffer(GL_RENDERBUFFER, _depthRenderBuffer);
-                glRenderbufferStorage(GL_RENDERBUFFER, depthStencilFormat, (GLsizei)powW, (GLsizei)powH);
+                glRenderbufferStorage(GL_RENDERBUFFER, _depthAndStencilFormat, (GLsizei)powW, (GLsizei)powH);
                 glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER, _depthRenderBuffer);
 
                 // if depth format is the one with stencil part, bind same render buffer as stencil attachment
-                if (depthStencilFormat == GL_DEPTH24_STENCIL8)
+                if (_depthAndStencilFormat == GL_DEPTH24_STENCIL8)
                 {
                     glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_STENCIL_ATTACHMENT, GL_RENDERBUFFER, _depthRenderBuffer);
                 }
@@ -304,48 +364,16 @@ bool RenderTexture::initWithWidthAndHeight(int w, int h, Texture2D::PixelFormat 
             //create and attach depth buffer
             glGenRenderbuffers(1, &_depthRenderBuffer);
             glBindRenderbuffer(GL_RENDERBUFFER, _depthRenderBuffer);
-            glRenderbufferStorage(GL_RENDERBUFFER, depthStencilFormat, (GLsizei)powW, (GLsizei)powH);
+            glRenderbufferStorage(GL_RENDERBUFFER, _depthAndStencilFormat, (GLsizei)powW, (GLsizei)powH);
             glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER, _depthRenderBuffer);
             
             // if depth format is the one with stencil part, bind same render buffer as stencil attachment
-            if (depthStencilFormat == GL_DEPTH24_STENCIL8)
+            if (_depthAndStencilFormat == GL_DEPTH24_STENCIL8)
             {
                 glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_STENCIL_ATTACHMENT, GL_RENDERBUFFER, _depthRenderBuffer);
             }
 
 #endif
-            
-        }
-
-        // check if it worked (probably worth doing :) )
-        CCASSERT(glCheckFramebufferStatus(GL_FRAMEBUFFER) == GL_FRAMEBUFFER_COMPLETE, "Could not attach texture to framebuffer");
-
-        _texture->setAliasTexParameters();
-
-        // retained
-        setSprite(Sprite::createWithTexture(_texture));
-
-        _texture->release();
-        _sprite->setFlippedY(true);
-
-        _sprite->setBlendFunc( BlendFunc::ALPHA_PREMULTIPLIED );
-        _sprite->setOpacityModifyRGB(true);
-
-        glBindRenderbuffer(GL_RENDERBUFFER, oldRBO);
-        glBindFramebuffer(GL_FRAMEBUFFER, _oldFBO);
-        
-        // Disabled by default.
-        _autoDraw = false;
-        
-        // add sprite for backward compatibility
-        addChild(_sprite);
-        
-        ret = true;
-    } while (0);
-    
-    CC_SAFE_FREE(data);
-    
-    return ret;
 }
 
 void RenderTexture::setSprite(Sprite* sprite)

--- a/cocos/2d/CCRenderTexture.cpp
+++ b/cocos/2d/CCRenderTexture.cpp
@@ -120,16 +120,16 @@ void RenderTexture::listenToBackground(EventCustom* /*event*/)
     glDeleteFramebuffers(1, &_FBO);
     _FBO = 0;
 
-    if (_depthRenderBufffer)
+    if (_depthRenderBuffer)
     {
-        glDeleteRenderbuffers(1, &_depthRenderBufffer);
-        _depthRenderBufffer = 0;
+        glDeleteRenderbuffers(1, &_depthRenderBuffer);
+        _depthRenderBuffer = 0;
     }
     
-    if (_stencilRenderBufffer)
+    if (_stencilRenderBuffer)
     {
-        glDeleteRenderbuffers(1, &_stencilRenderBufffer);
-        _stencilRenderBufffer = 0;
+        glDeleteRenderbuffers(1, &_stencilRenderBuffer);
+        _stencilRenderBuffer = 0;
     }
 #endif
 }

--- a/cocos/2d/CCRenderTexture.h
+++ b/cocos/2d/CCRenderTexture.h
@@ -326,6 +326,7 @@ protected:
     Texture2D* _textureCopy;    // a copy of _texture
     Image*     _UITextureImage;
     Texture2D::PixelFormat _pixelFormat;
+    GLuint _depthAndStencilFormat;
     
     // code for "auto" update
     GLbitfield   _clearFlags;
@@ -362,6 +363,8 @@ protected:
     void onClearDepth();
 
     void onSaveToFile(const std::string& fileName, bool isRGBA = true);
+
+    void setupDepthAndStencil(int powW, int powH);
     
     Mat4 _oldTransMatrix, _oldProjMatrix;
     Mat4 _transformMatrix, _projectionMatrix;


### PR DESCRIPTION
Fixing issue where Stencil and Depths buffers would not function for a render texture if you backgrounded an application, and then resumed.

When we background an application on Android, we destroy our FBO, and when we come back to the foreground we re-create it. However, we _only_ recreate the FBO. If our FBO had any depth or stencil renderbuffer attachments, we do not recreate/reattach them. This PR will fix this.

To recreate:

On Android, create a RenderTexture, set AutoDraw to true, add as a child a CCClippingNode that is clipping something.
Verify that the clipping node works.
Background the app.
Without this change, the stencil buffer will not be in the correct state, and you will see something incorrect. With this change, you will see the correct result.

This was tested on a galaxy s7, though I believe it should happen on all Android. 