### PR TITLE
use error macro to replace constant value 1410L

### DIFF
--- a/cocos/audio/win32/MciPlayer.cpp
+++ b/cocos/audio/win32/MciPlayer.cpp
@@ -39,7 +39,7 @@ MciPlayer::MciPlayer()
         wc.lpszClassName  = _T(WIN_CLASS_NAME);                 // Set The Class Name
 
         if (! RegisterClass(&wc)
-            && 1410 != GetLastError())
+            && ERROR_CLASS_ALREADY_EXISTS != GetLastError())
         {
             return;
         }


### PR DESCRIPTION
I think using error macros is easier to understand. 