### PR TITLE
fix : win32 system label has wrong scale factor

### DIFF
--- a/cocos/ui/UIEditBox/UIEditBoxImpl-win32.cpp
+++ b/cocos/ui/UIEditBox/UIEditBoxImpl-win32.cpp
@@ -367,7 +367,7 @@ namespace ui {
         int inputLength = ::GetWindowTextLengthW(this->hwndEdit);
         wstrResult.resize(inputLength);
 
-        ::GetWindowTextW(this->hwndEdit, (LPWSTR) const_cast<char16_t*>(wstrResult.c_str()), inputLength + 1);
+        ::GetWindowTextW(this->hwndEdit, (LPWSTR)&wstrResult[0], inputLength + 1);
         bool conversionResult = cocos2d::StringUtils::UTF16ToUTF8(wstrResult, utf8Result);
         if (!conversionResult)
         {

--- a/cocos/ui/UIEditBox/UIEditBoxImpl-win32.cpp
+++ b/cocos/ui/UIEditBox/UIEditBoxImpl-win32.cpp
@@ -72,7 +72,6 @@ namespace ui {
 
     EditBoxImplWin::EditBoxImplWin(EditBox* pEditText)
         : EditBoxImplCommon(pEditText),
-        _fontSize(40),
         _changedTextManually(false),
         _hasFocus(false)
     {
@@ -174,9 +173,8 @@ namespace ui {
 
     void EditBoxImplWin::setNativeFont(const char * pFontName, int fontSize)
     {
-        //not implemented yet
-        this->_fontSize = fontSize;
-        HFONT hFont = CreateFontW(static_cast<int>(fontSize * Director::getInstance()->getContentScaleFactor()), 0, 0, 0,
+        float nativeSize = fontSize * Director::getInstance()->getContentScaleFactor();
+        HFONT hFont = ::CreateFontW(static_cast<int>(nativeSize), 0, 0, 0,
             FW_NORMAL, FALSE, FALSE, FALSE, DEFAULT_CHARSET, OUT_OUTLINE_PRECIS,
             CLIP_DEFAULT_PRECIS, ANTIALIASED_QUALITY, VARIABLE_PITCH, TEXT("Arial"));
 

--- a/cocos/ui/UIEditBox/UIEditBoxImpl-win32.cpp
+++ b/cocos/ui/UIEditBox/UIEditBoxImpl-win32.cpp
@@ -73,7 +73,8 @@ namespace ui {
     EditBoxImplWin::EditBoxImplWin(EditBox* pEditText)
         : EditBoxImplCommon(pEditText),
         _changedTextManually(false),
-        _hasFocus(false)
+        _hasFocus(false),
+        _endAction(EditBoxDelegate::EditBoxEndAction::UNKNOWN)
     {
         if (!s_isInitialized)
         {
@@ -326,6 +327,30 @@ namespace ui {
             {
                 if (_editBoxInputMode != cocos2d::ui::EditBox::InputMode::ANY) {
                     if (s_previousFocusWnd != s_hwndCocos) {
+                        switch (_keyboardReturnType)
+                        {
+                        case cocos2d::ui::EditBox::KeyboardReturnType::DEFAULT:
+                            _endAction = EditBoxDelegate::EditBoxEndAction::UNKNOWN;
+                            break;
+                        case cocos2d::ui::EditBox::KeyboardReturnType::DONE:
+                            _endAction = EditBoxDelegate::EditBoxEndAction::RETURN;
+                            break;
+                        case cocos2d::ui::EditBox::KeyboardReturnType::SEND:
+                            _endAction = EditBoxDelegate::EditBoxEndAction::RETURN;
+                            break;
+                        case cocos2d::ui::EditBox::KeyboardReturnType::SEARCH:
+                            _endAction = EditBoxDelegate::EditBoxEndAction::RETURN;
+                            break;
+                        case cocos2d::ui::EditBox::KeyboardReturnType::GO:
+                            _endAction = EditBoxDelegate::EditBoxEndAction::RETURN;
+                            break;
+                        case cocos2d::ui::EditBox::KeyboardReturnType::NEXT:
+                            _endAction = EditBoxDelegate::EditBoxEndAction::TAB_TO_NEXT;
+                            break;
+                        default:
+                            _endAction = EditBoxDelegate::EditBoxEndAction::UNKNOWN;
+                            break;
+                        }
                         ::ShowWindow(s_previousFocusWnd, SW_HIDE);
                         ::SendMessage(s_hwndCocos, WM_SETFOCUS, (WPARAM)s_previousFocusWnd, 0);
                         s_previousFocusWnd = s_hwndCocos;
@@ -349,7 +374,7 @@ namespace ui {
             //when app enter background, this message also be called.
             if (this->_editingMode && !IsWindowVisible(hwnd))
             {
-                this->editBoxEditingDidEnd(this->getText());
+                this->editBoxEditingDidEnd(this->getText(), _endAction);
             }
             break;
         default:

--- a/cocos/ui/UIEditBox/UIEditBoxImpl-win32.cpp
+++ b/cocos/ui/UIEditBox/UIEditBoxImpl-win32.cpp
@@ -176,7 +176,8 @@ namespace ui {
     {
         //not implemented yet
         this->_fontSize = fontSize;
-        HFONT hFont = CreateFontW(fontSize, 0, 0, 0, FW_NORMAL, FALSE, FALSE, FALSE, DEFAULT_CHARSET, OUT_OUTLINE_PRECIS,
+        HFONT hFont = CreateFontW(static_cast<int>(fontSize * Director::getInstance()->getContentScaleFactor()), 0, 0, 0,
+            FW_NORMAL, FALSE, FALSE, FALSE, DEFAULT_CHARSET, OUT_OUTLINE_PRECIS,
             CLIP_DEFAULT_PRECIS, ANTIALIASED_QUALITY, VARIABLE_PITCH, TEXT("Arial"));
 
         SendMessage(hwndEdit,             // Handle of edit control

--- a/cocos/ui/UIEditBox/UIEditBoxImpl-win32.h
+++ b/cocos/ui/UIEditBox/UIEditBoxImpl-win32.h
@@ -75,8 +75,6 @@ namespace ui {
         static LRESULT CALLBACK hookGLFWWindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam);
 
         HWND hwndEdit;
-        //FIXME: fontSize should be in parent class
-        int _fontSize;
         bool _changedTextManually;
         bool _hasFocus;
         static WNDPROC s_prevCocosWndProc;
@@ -96,3 +94,4 @@ NS_CC_END
 #endif /* (CC_TARGET_PLATFORM == CC_PLATFORM_WIN32) */
 
 #endif /* __UIEditBoxIMPLWIN_H__ */
+

--- a/cocos/ui/UIEditBox/UIEditBoxImpl-win32.h
+++ b/cocos/ui/UIEditBox/UIEditBoxImpl-win32.h
@@ -77,6 +77,7 @@ namespace ui {
         HWND hwndEdit;
         bool _changedTextManually;
         bool _hasFocus;
+        EditBoxDelegate::EditBoxEndAction _endAction;
         static WNDPROC s_prevCocosWndProc;
 
         static HINSTANCE s_hInstance;


### PR DESCRIPTION
1. fix win32 system label of editbox has wrong scale factor.
2. implement endAction for win32

here are the steps to reproduce 1:
1. new a c++ project
2. open `AppDelegate.cpp`, in function `bool AppDelegate::applicationDidFinishLaunching()`, modify
```c++
glview = GLViewImpl::createWithRect("projectname",
    cocos2d::Rect(0, 0, designResolutionSize.width, designResolutionSize.height));
```
to
```c++
glview = GLViewImpl::createWithRect("projectname",
    cocos2d::Rect(0, 0, designResolutionSize.width * 2, designResolutionSize.height * 2));
```
3. open `HelloWorld.cpp`, add the codes below into `bool HelloWorld::init()`
```c++
ui::EditBox *editBox = ui::EditBox::create(Size(120.0f, 20.0f), ui::Scale9Sprite::create());
this->addChild(editBox);
editBox->setPosition(Vec2(origin.x + visibleSize.width * 0.5f, origin.y + visibleSize.height * 0.5f));
```