### PR TITLE
Fix VAO in CameraBackgroundBrush

### DIFF
--- a/cocos/2d/CCCameraBackgroundBrush.cpp
+++ b/cocos/2d/CCCameraBackgroundBrush.cpp
@@ -159,24 +159,24 @@ bool CameraBackgroundDepthBrush::init()
     
     if (supportVAO)
     {
-        GL::enableVertexAttribs(GL::VERTEX_ATTRIB_FLAG_POS_COLOR_TEX);
-        
         // vertices
+        glEnableVertexAttribArray(GLProgram::VERTEX_ATTRIB_POSITION);
         glVertexAttribPointer(GLProgram::VERTEX_ATTRIB_POSITION, 3, GL_FLOAT, GL_FALSE, sizeof(V3F_C4B_T2F), (GLvoid*)offsetof( V3F_C4B_T2F, vertices));
-        
+
         // colors
+        glEnableVertexAttribArray(GLProgram::VERTEX_ATTRIB_COLOR);
         glVertexAttribPointer(GLProgram::VERTEX_ATTRIB_COLOR, 4, GL_UNSIGNED_BYTE, GL_TRUE, sizeof(V3F_C4B_T2F), (GLvoid*)offsetof( V3F_C4B_T2F, colors));
-        
+
         // tex coords
+        glEnableVertexAttribArray(GLProgram::VERTEX_ATTRIB_TEX_COORD);
         glVertexAttribPointer(GLProgram::VERTEX_ATTRIB_TEX_COORD, 2, GL_FLOAT, GL_FALSE, sizeof(V3F_C4B_T2F), (GLvoid*)offsetof( V3F_C4B_T2F, texCoords));
     }
-    
-    glBindBuffer(GL_ARRAY_BUFFER, 0);
-    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
-    
+
     if (supportVAO)
         GL::bindVAO(0);
-    
+
+    glBindBuffer(GL_ARRAY_BUFFER, 0);
+    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
     return true;
 }
 


### PR DESCRIPTION
I'm getting this OpenGL error on Android, once per frame: `I/Adreno-ES20: <validate_vertex_attrib_state:60>: validate_vertex_attrib_state: No vertex attrib is enabled in a draw call!`

These started since #18066 when drawing CameraBackgroundBrush with VAO support. The issue seems to be in `CameraBackgroundDepthBrush::init()` the call to `GL::enableVertexAttribs` that unbinds the VAO.