### PR TITLE
Fix CameraBackgroundColorBrush cannot use alpha

### DIFF
--- a/cocos/2d/CCCameraBackgroundBrush.cpp
+++ b/cocos/2d/CCCameraBackgroundBrush.cpp
@@ -279,9 +279,25 @@ bool CameraBackgroundColorBrush::init()
     return true;
 }
 
+void CameraBackgroundColorBrush::drawBackground(Camera* camera)
+{
+    GL::blendFunc(_blendFunc.src, _blendFunc.dst);
+
+    CameraBackgroundDepthBrush::drawBackground(camera);
+}
+
 void CameraBackgroundColorBrush::setColor(const Color4F& color)
 {
     _quad.bl.colors = _quad.br.colors = _quad.tl.colors = _quad.tr.colors = Color4B(color);
+    
+    if (color.a != 1.f)
+    {
+        _blendFunc = BlendFunc::ALPHA_NON_PREMULTIPLIED;
+    }
+    else
+    {
+        _blendFunc = BlendFunc::ALPHA_PREMULTIPLIED;
+    }
     
     if (_vertexBuffer)
     {

--- a/cocos/2d/CCCameraBackgroundBrush.cpp
+++ b/cocos/2d/CCCameraBackgroundBrush.cpp
@@ -281,7 +281,7 @@ bool CameraBackgroundColorBrush::init()
 
 void CameraBackgroundColorBrush::drawBackground(Camera* camera)
 {
-    GL::blendFunc(_blendFunc.src, _blendFunc.dst);
+    GL::blendFunc(BlendFunc::ALPHA_NON_PREMULTIPLIED.src, BlendFunc::ALPHA_NON_PREMULTIPLIED.dst);
 
     CameraBackgroundDepthBrush::drawBackground(camera);
 }
@@ -289,15 +289,6 @@ void CameraBackgroundColorBrush::drawBackground(Camera* camera)
 void CameraBackgroundColorBrush::setColor(const Color4F& color)
 {
     _quad.bl.colors = _quad.br.colors = _quad.tl.colors = _quad.tr.colors = Color4B(color);
-    
-    if (color.a != 1.f)
-    {
-        _blendFunc = BlendFunc::ALPHA_NON_PREMULTIPLIED;
-    }
-    else
-    {
-        _blendFunc = BlendFunc::ALPHA_PREMULTIPLIED;
-    }
     
     if (_vertexBuffer)
     {

--- a/cocos/2d/CCCameraBackgroundBrush.h
+++ b/cocos/2d/CCCameraBackgroundBrush.h
@@ -202,7 +202,6 @@ CC_CONSTRUCTOR_ACCESS:
     
 protected:
     Color4F _color;
-    BlendFunc _blendFunc;
 };
 
 class TextureCube;

--- a/cocos/2d/CCCameraBackgroundBrush.h
+++ b/cocos/2d/CCCameraBackgroundBrush.h
@@ -184,6 +184,11 @@ public:
     static CameraBackgroundColorBrush* create(const Color4F& color, float depth);
     
     /**
+     * Draw background
+     */
+    virtual void drawBackground(Camera* camera) override;
+    
+    /**
      * Set clear color
      * @param color Color used to clear the color buffer
      */
@@ -197,6 +202,7 @@ CC_CONSTRUCTOR_ACCESS:
     
 protected:
     Color4F _color;
+    BlendFunc _blendFunc;
 };
 
 class TextureCube;

--- a/cocos/renderer/ccShader_CameraClear.frag
+++ b/cocos/renderer/ccShader_CameraClear.frag
@@ -3,13 +3,13 @@ const char* ccCameraClearFrag = R"(
 
 #ifdef GL_ES
 varying mediump vec2 v_texCoord;
-varying mediump vec3 v_color;
+varying mediump vec4 v_color;
 #else
 varying vec2 v_texCoord;
-varying vec3 v_color;
+varying vec4 v_color;
 #endif
 void main()
 {
-    gl_FragColor = vec4(v_color, 1.0);
+    gl_FragColor = v_color;
 }
 )";

--- a/cocos/renderer/ccShader_CameraClear.vert
+++ b/cocos/renderer/ccShader_CameraClear.vert
@@ -5,13 +5,13 @@ uniform float depth;
 
 attribute vec4 a_position;
 attribute vec2 a_texCoord;
-attribute vec3 a_color;
+attribute vec4 a_color;
 #ifdef GL_ES
 varying mediump vec2 v_texCoord;
-varying mediump vec3 v_color;
+varying mediump vec4 v_color;
 #else
 varying vec2 v_texCoord;
-varying vec3 v_color;
+varying vec4 v_color;
 #endif
 void main()
 {

--- a/tests/cpp-tests/Classes/Camera3DTest/Camera3DTest.cpp
+++ b/tests/cpp-tests/Classes/Camera3DTest/Camera3DTest.cpp
@@ -25,6 +25,7 @@ THE SOFTWARE.
 
 #include "Camera3DTest.h"
 #include "testResource.h"
+#include "ui/UISlider.h"
 
 USING_NS_CC;
 
@@ -43,6 +44,7 @@ Camera3DTests::Camera3DTests()
     ADD_TEST_CASE(FogTestDemo);
     ADD_TEST_CASE(CameraArcBallDemo);
     ADD_TEST_CASE(CameraFrameBufferTest);
+    ADD_TEST_CASE(BackgroundColorBrushTest);
 }
 
 //------------------------------------------------------------------
@@ -1474,4 +1476,86 @@ void CameraFrameBufferTest::onEnter()
     camera->setFrameBufferObject(fbo);
     fbo->setClearColor(Color4F(1,1,1,1));
     addChild(camera);
+}
+
+BackgroundColorBrushTest::BackgroundColorBrushTest()
+{
+}
+
+BackgroundColorBrushTest::~BackgroundColorBrushTest()
+{
+}
+
+std::string BackgroundColorBrushTest::title() const
+{
+    return "CameraBackgroundColorBrush Test";
+}
+
+std::string BackgroundColorBrushTest::subtitle() const
+{
+    return "right side object colored by CameraBG";
+}
+
+void BackgroundColorBrushTest::onEnter()
+{
+    CameraBaseTest::onEnter();
+    
+    auto s = Director::getInstance()->getWinSize();
+    
+    {
+        // 1st Camera
+        auto camera = Camera::createPerspective(60, (GLfloat)s.width/s.height, 1, 1000);
+        camera->setPosition3D(Vec3(0, 0, 200));
+        camera->lookAt(Vec3::ZERO);
+        camera->setDepth(-2);
+        camera->setCameraFlag(CameraFlag::USER1);
+        addChild(camera);
+        
+        // 3D model
+        auto model = Sprite3D::create("Sprite3DTest/boss1.obj");
+        model->setScale(4);
+        model->setPosition3D(Vec3(20, 0, 0));
+        model->setTexture("Sprite3DTest/boss.png");
+        model->setCameraMask(static_cast<unsigned short>(CameraFlag::USER1));
+        addChild(model);
+        model->runAction(RepeatForever::create(RotateBy::create(1.f, Vec3(10, 20, 30))));
+    }
+    
+    {
+        auto base = Node::create();
+        base->setContentSize(s);
+        base->setCameraMask(static_cast<unsigned short>(CameraFlag::USER2));
+        addChild(base);
+        
+        // 2nd Camera
+        auto camera = Camera::createPerspective(60, (GLfloat)s.width/s.height, 1, 1000);
+        auto colorBrush = CameraBackgroundBrush::createColorBrush(Color4F(.1f, .1f, 1.f, .5f), 1.f);
+        camera->setBackgroundBrush(colorBrush);
+        camera->setPosition3D(Vec3(0, 0, 200));
+        camera->lookAt(Vec3::ZERO);
+        camera->setDepth(-1);
+        camera->setCameraFlag(CameraFlag::USER2);
+        base->addChild(camera);
+        
+        // for alpha setting
+        auto slider = ui::Slider::create();
+        slider->loadBarTexture("cocosui/sliderTrack.png");
+        slider->loadSlidBallTextures("cocosui/sliderThumb.png", "cocosui/sliderThumb.png", "");
+        slider->loadProgressBarTexture("cocosui/sliderProgress.png");
+        slider->setPosition(Vec2(s.width/2, s.height/4));
+        slider->setPercent(50);
+        slider->addEventListener([slider, colorBrush](Ref*, ui::Slider::EventType){
+            colorBrush->setColor(Color4F(.1f, .1f, 1.f, (float)slider->getPercent()/100.f));
+        });
+        addChild(slider);
+        
+        // 3D model for 2nd camera
+        auto model = Sprite3D::create("Sprite3DTest/boss1.obj");
+        model->setScale(4);
+        model->setPosition3D(Vec3(-20, 0, 0));
+        model->setTexture("Sprite3DTest/boss.png");
+        model->setCameraMask(static_cast<unsigned short>(CameraFlag::USER2));
+        base->addChild(model);
+        model->runAction(RepeatForever::create(RotateBy::create(1.f, Vec3(10, 20, 30))));
+    }
 }

--- a/tests/cpp-tests/Classes/Camera3DTest/Camera3DTest.h
+++ b/tests/cpp-tests/Classes/Camera3DTest/Camera3DTest.h
@@ -267,4 +267,18 @@ public:
     virtual void onEnter() override;
 };
 
+class BackgroundColorBrushTest : public CameraBaseTest
+{
+public:
+    CREATE_FUNC(BackgroundColorBrushTest);
+    BackgroundColorBrushTest(void);
+    virtual ~BackgroundColorBrushTest(void);
+    
+    // overrides
+    virtual std::string title() const override;
+    virtual std::string subtitle() const override;
+    
+    virtual void onEnter() override;
+};
+
 #endif


### PR DESCRIPTION
`static CameraBackgroundColorBrush* createColorBrush(const Color4F& color, float depth)` 
this accepts alpha contained color value, but the alpha value dose not apply, because of thats shader.