### PR TITLE
fix #18130

### DIFF
--- a/cocos/platform/android/jni/Java_org_cocos2dx_lib_Cocos2dxHelper.cpp
+++ b/cocos/platform/android/jni/Java_org_cocos2dx_lib_Cocos2dxHelper.cpp
@@ -148,6 +148,7 @@ void conversionEncodingJNI(const char* src, int byteSize, const char* fromCharse
         methodInfo.env->DeleteLocalRef(strArray);
         methodInfo.env->DeleteLocalRef(stringArg1);
         methodInfo.env->DeleteLocalRef(stringArg2);
+        methodInfo.env->DeleteLocalRef(newArray);
         methodInfo.env->DeleteLocalRef(methodInfo.classID);
     }
 }


### PR DESCRIPTION
fix #18130

- cocos2d-x version: 3.13.1
- devices test on: 网易MOMO
- developing environments
   - NDK version: r10e

Steps to Reproduce:
in file `Java_org_cocos2dx_lib_Cocos2dxHelper.cpp`
When the function `conversionEncodingJNI` is called more than 512 times, it will crashes.
error messages are
E/dalvikvm( 3307): JNI ERROR (app bug): local reference table overflow (max=512)


line 144
```c++
jbyteArray newArray = (jbyteArray)methodInfo.env->CallStaticObjectMethod(methodInfo.classID, methodInfo.methodID, strArray, stringArg1, stringArg2);
```
The value `newArray` has not been released.

---------

Steps to Reproduce:
1. new a c++ project
2. open `HelloWorld.cpp`, add modify codes like below
```c++
#if CC_TARGET_PLATFORM == CC_PLATFORM_ANDROID
#include "platform/android/jni/Java_org_cocos2dx_lib_Cocos2dxHelper.h"
#else
void conversionEncodingJNI(const char* src, int byteSize, const char* fromCharset, char* dst, const char* newCharset) { }
#endif

bool HelloWorld::init() {
    if (!Scene::init()) {
        return false;
    }

    std::u32string u32Text = std::u32string(5000U, 0x20);
    size_t strLen = u32Text.length();
    auto gb2312StrSize = strLen * 2;
    auto gb2312Text = new (std::nothrow) char[gb2312StrSize];
    memset(gb2312Text, 0, gb2312StrSize);

    for (int i = 0; i < 600; ++i) {  // more than 512 times
        conversionEncodingJNI((const char *)u32Text.c_str(), gb2312StrSize, "UTF-32LE", gb2312Text, "GB2312");
    }
    delete[] gb2312Text;

// other codes.....
```


it won't crash after using this PR
