### PR TITLE
Fix accelerometer on Android on reverse landscape/portrait.

### DIFF
--- a/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxAccelerometer.java
+++ b/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxAccelerometer.java
@@ -127,6 +127,12 @@ public class Cocos2dxAccelerometer implements SensorEventListener {
                 y = -tmp;
             }
 
+            // Invert axes for reverse landscape and reverse portrait
+            int rotation =  Cocos2dxHelper.getActivity().getWindowManager().getDefaultDisplay().getRotation();
+            if (rotation == Surface.ROTATION_180 || rotation == Surface.ROTATION_270) {
+                x = -x;
+                y = -y;
+            }
 
             Cocos2dxGLSurfaceView.queueAccelerometer(x,y,z,sensorEvent.timestamp);
 


### PR DESCRIPTION
The accelerometer should adjust when the screen is on reverse landscape or reverse portrait (upside down). This is already done on iOS:

https://github.com/cocos2d/cocos2d-x/blob/b633260020cba97a4160eb2a6f81b270b424657b/cocos/platform/ios/CCDevice-ios.mm#L250-L266

This PR makes the accelerometer behave in the same way on Android too.