### PR TITLE
Fix for Non-TTF Label Shadow, it makes it follow label opacity

### DIFF
--- a/cocos/2d/CCLabel.cpp
+++ b/cocos/2d/CCLabel.cpp
@@ -1505,7 +1505,7 @@ void Label::onDrawShadow(GLProgram* glProgram, const Color4F& shadowColor)
     {
         Color3B oldColor = _realColor;
         GLubyte oldOPacity = _displayedOpacity;
-        _displayedOpacity = shadowColor.a * 255;
+        _displayedOpacity = shadowColor.a * (oldOPacity / 255.0f) * 255;
         setColor(Color3B(shadowColor));
 
         glProgram->setUniformsForBuiltins(_shadowTransform);


### PR DESCRIPTION
Bug: If FadeTo action applied to Label with non-TTF font with shadow, shadow stay opaque and doesn't fade as label.