### PR TITLE
fix android editor box use 'setSelection' when the beyond the border error

### DIFF
--- a/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxEditBoxHelper.java
+++ b/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxEditBoxHelper.java
@@ -335,7 +335,7 @@ public class Cocos2dxEditBoxHelper {
                 if (editBox != null) {
                     editBox.setChangedTextProgrammatically(true);
                     editBox.setText(text);
-                    int position = text.length();
+                    int position = editBox.getText().length();
                     editBox.setSelection(position);
                 }
             }


### PR DESCRIPTION
@dumganhar say:
It's probably editBox.setText sets a string longer than its max value.
And setText internally does a clip operation.
Therefore, the string returned by editBox.getText() may shorter than text.length().