### PR TITLE
Support for using CCRef as a std::shared_ptr

### DIFF
--- a/cocos/base/CCRef.cpp
+++ b/cocos/base/CCRef.cpp
@@ -146,7 +146,11 @@ void Ref::release()
 #if CC_REF_LEAK_DETECTION
         untrackRef(this);
 #endif
-        delete this;
+        
+        // if the weak reference is not expired, the object is still managed by a shared_ptr
+        if(_self_weak_ref.expired()) {
+            delete this;
+        }
     }
 }
 

--- a/cocos/base/CCRef.h
+++ b/cocos/base/CCRef.h
@@ -129,6 +129,7 @@ public:
      *
      * @returns A shared_ptr of this as a Ref.
      * @js NA
+     * @lua NA
      */
     std::shared_ptr<cocos2d::Ref> shared_ptr() {
         if(!_self_weak_ref.expired()) {
@@ -150,6 +151,7 @@ public:
      *
      * @returns A shared_ptr of this type template.
      * @js NA
+     * @lua NA
      */
     template <class T> std::shared_ptr<T> shared_ptr() {
         if(!_self_weak_ref.expired()) {

--- a/cocos/base/CCRef.h
+++ b/cocos/base/CCRef.h
@@ -28,6 +28,7 @@ THE SOFTWARE.
 
 #include "platform/CCPlatformMacros.h"
 #include "base/ccConfig.h"
+#include <memory>
 
 #define CC_REF_LEAK_DETECTION 0
 

--- a/cocos/base/CCRef.h
+++ b/cocos/base/CCRef.h
@@ -123,6 +123,49 @@ public:
      * @js NA
      */
     unsigned int getReferenceCount() const;
+    
+    /**
+     * Returns a shared_ptr of this Ref.
+     *
+     * @returns A shared_ptr of this as a Ref.
+     * @js NA
+     */
+    std::shared_ptr<cocos2d::Ref> shared_ptr() {
+        if(!_self_weak_ref.expired()) {
+            return _self_weak_ref.lock();
+        }
+        
+        auto shared_ptr = std::shared_ptr<cocos2d::Ref>(this, [=](cocos2d::Ref* ref)
+        {
+            if(ref->getReferenceCount() == 0) {
+                delete ref;
+            }
+        });
+        _self_weak_ref = shared_ptr;
+        return shared_ptr;
+    }
+    
+    /**
+     * Template version of shared_ptr
+     *
+     * @returns A shared_ptr of this type template.
+     * @js NA
+     */
+    template <class T> std::shared_ptr<T> shared_ptr() {
+        if(!_self_weak_ref.expired()) {
+            return std::static_pointer_cast<T>(_self_weak_ref.lock());
+        }
+        
+        auto shared_ptr = std::shared_ptr<cocos2d::Ref>(this, [=](cocos2d::Ref* ref)
+        {
+            auto cc_ref = static_cast<cocos2d::Ref*>(ref);
+            if(cc_ref->getReferenceCount() == 0) {
+                delete cc_ref;
+            }
+        });
+        _self_weak_ref = shared_ptr;
+        return std::static_pointer_cast<T>(shared_ptr);
+    }
 
 protected:
     /**
@@ -145,6 +188,9 @@ public:
 protected:
     /// count of references
     unsigned int _referenceCount;
+    
+    /// weak ptr of self
+    std::weak_ptr<cocos2d::Ref> _self_weak_ref{};
 
     friend class AutoreleasePool;
 

--- a/cocos/base/ZipUtils.cpp
+++ b/cocos/base/ZipUtils.cpp
@@ -23,6 +23,9 @@
  THE SOFTWARE.
  ****************************************************************************/
 
+// FIXME: hack, this needs to be before minizip/unzip...
+#include <string> 
+
 // FIXME: hack, must be included before ziputils
 #ifdef MINIZIP_FROM_SYSTEM
 #include <minizip/unzip.h>

--- a/cocos/base/ZipUtils.h
+++ b/cocos/base/ZipUtils.h
@@ -27,6 +27,7 @@ THE SOFTWARE.
 #define __SUPPORT_ZIPUTILS_H__
 /// @cond DO_NOT_SHOW
 
+#include <cstdio>
 #include <string>
 #include "platform/CCPlatformConfig.h"
 #include "platform/CCPlatformMacros.h"


### PR DESCRIPTION
Often it is desirable to use a cocos2d::Ref in c++ lambda functions.  However the c++ shared memory model std::shared_ptr works fundamentally different than the cocos2d one (retain, release, etc).  Often I find I want to use lambda functions with a cocos2d::Ref in a capture list, but the memory model falls apart at this point.  This addition adds support to cocos2d::Ref that allows the object to be maintained by both the cocos2d-x memory model and the c++ std::shared_ptr model.  

The following code works great when copying this request object around as copy semantics preserve the memory of the cocos2d::Ref in the capture list:

```
auto async_request = AsyncHttpRequest.MakeRequest("http://www.example.com", [shared_label = this->label->shared_ptr<cocos2d::Label>()](bool did_succeed) {

	if(did_succeed)
		shared_label.get()->setString("success");
	else
		shared_label.get()->setString("failed");
});
```

In this example, the cocos2d::label in the capture list will only get deallocated when BOTH it's cocos2d-x retain count reaches zero, AND when the shared_ptr reference count reaches zero as well.  

