### PR TITLE
fix memory leak in `UserDefault::deleteValueForKey`

### DIFF
--- a/cocos/base/CCUserDefault.cpp
+++ b/cocos/base/CCUserDefault.cpp
@@ -522,6 +522,7 @@ void UserDefault::deleteValueForKey(const char* key)
     // if node not exist, don't need to delete
     if (!node)
     {
+        CC_SAFE_DELETE(doc);
         return;
     }
 


### PR DESCRIPTION
fix memory leak in `UserDefault::deleteValueForKey` when `key` not found