### PR TITLE
fix Memory Leak: ObjectFactory destroyInstance

### DIFF
--- a/cocos/base/CCDirector.cpp
+++ b/cocos/base/CCDirector.cpp
@@ -60,6 +60,7 @@ THE SOFTWARE.
 #include "base/CCAutoreleasePool.h"
 #include "base/CCConfiguration.h"
 #include "base/CCAsyncTaskPool.h"
+#include "base/ObjectFactory.h"
 #include "platform/CCApplication.h"
 
 #if CC_ENABLE_SCRIPT_BINDING
@@ -230,6 +231,7 @@ Director::~Director(void)
     CC_SAFE_RELEASE(_eventDispatcher);
     
     Configuration::destroyInstance();
+    ObjectFactory destroyInstance();
 
     s_SharedDirector = nullptr;
 }


### PR DESCRIPTION
`ObjectFactory destroyInstance` function not called
#8498 
#17412 
#17684  