### PR TITLE
Corrected bugs with cursor in TextField

### DIFF
--- a/cocos/2d/CCTextFieldTTF.cpp
+++ b/cocos/2d/CCTextFieldTTF.cpp
@@ -662,7 +662,7 @@ const std::string& TextFieldTTF::getString() const
 void TextFieldTTF::setPlaceHolder(const std::string& text)
 {
     _placeHolder = text;
-    if (_inputText.empty())
+    if (_inputText.empty() && !_isAttachWithIME)
     {
         Label::setTextColor(_colorSpaceHolder);
         Label::setString(_placeHolder);

--- a/cocos/ui/UITextField.cpp
+++ b/cocos/ui/UITextField.cpp
@@ -139,29 +139,6 @@ void UICCTextField::insertText(const char*  text, size_t len)
         }
     }
     TextFieldTTF::insertText(input_text.c_str(), len);
-    
-    // password
-    if (this->isSecureTextEntry())
-    {
-        if (TextFieldTTF::getCharCount() > 0)
-        {
-            setPasswordText(getString());
-        }
-    }
-}
-
-void UICCTextField::deleteBackward()
-{
-    TextFieldTTF::deleteBackward();
-    
-    if (TextFieldTTF::getCharCount() > 0)
-    {
-        // password
-        if (this->isSecureTextEntry())
-        {
-            setPasswordText(_inputText);
-        }
-    }
 }
 
 void UICCTextField::openIME()

--- a/cocos/ui/UITextField.h
+++ b/cocos/ui/UITextField.h
@@ -79,7 +79,6 @@ public:
                                            const char * delText,
                                            size_t nLen) override;
     void insertText(const char* text, size_t len) override;
-    void deleteBackward() override;
     
     /**
      * Open up the IME.


### PR DESCRIPTION
1. Fixed bug in ccui TextFiled with cursor, when secure input enabled (if enable secure text entry and cursor, it will not be show)
2. Fixed bug in TextFiledTTF with setting placeholder text when field is empty and keyboard attached(this leads to displaying placeholder text && incorrect cursor positioning), code example:

```
    auto input = cocos2d::ui::TextField::create();
    
    input->addEventListener([=](Ref* sender, Ref*, cocos2d::ui::TextField::EventType type) {
        if(type == cocos2d::ui::TextField::EventType::ATTACH_WITH_IME)
            input->setPlaceHolder("Some string");
    });
```
