### PR TITLE
Remove autorelease mark from UIWebViewWrapper and manage memory manually

### DIFF
--- a/cocos/ui/UIWebViewImpl-ios.mm
+++ b/cocos/ui/UIWebViewImpl-ios.mm
@@ -68,7 +68,7 @@ static std::string getFixedBaseUrl(const std::string& baseUrl)
 @property(nonatomic, readonly, getter=canGoBack) BOOL canGoBack;
 @property(nonatomic, readonly, getter=canGoForward) BOOL canGoForward;
 
-+ (instancetype)webViewWrapper;
++ (instancetype)newWebViewWrapper;
 
 - (void)setVisible:(bool)visible;
 
@@ -115,8 +115,8 @@ static std::string getFixedBaseUrl(const std::string& baseUrl)
     
 }
 
-+ (instancetype)webViewWrapper {
-    return [[[self alloc] init] autorelease];
++ (instancetype) newWebViewWrapper {
+    return [[self alloc] init];
 }
 
 - (instancetype)init {
@@ -133,6 +133,7 @@ static std::string getFixedBaseUrl(const std::string& baseUrl)
 - (void)dealloc {
     self.uiWebView.delegate = nil;
     [self.uiWebView removeFromSuperview];
+    [self.uiWebView release];
     self.uiWebView = nil;
     self.jsScheme = nil;
     [super dealloc];
@@ -140,7 +141,7 @@ static std::string getFixedBaseUrl(const std::string& baseUrl)
 
 - (void)setupWebView {
     if (!self.uiWebView) {
-        self.uiWebView = [[[UIWebView alloc] init] autorelease];
+        self.uiWebView = [[UIWebView alloc] init];
         self.uiWebView.delegate = self;
     }
     if (!self.uiWebView.superview) {
@@ -291,9 +292,8 @@ namespace experimental {
     namespace ui{
 
 WebViewImpl::WebViewImpl(WebView *webView)
-        : _uiWebViewWrapper([UIWebViewWrapper webViewWrapper]),
+        : _uiWebViewWrapper([UIWebViewWrapper newWebViewWrapper]),
         _webView(webView) {
-    [_uiWebViewWrapper retain];
             
     _uiWebViewWrapper.shouldStartLoading = [this](std::string url) {
         if (this->_webView->_onShouldStartLoading) {


### PR DESCRIPTION
By default `cocos2d-x` application has only one (default) `autorelease pool`:
```
int main(int argc, char *argv[]) {
    @autoreleasepool {
        return UIApplicationMain(argc, argv, nil, @"AppController");
    }
}
```
So every `[obj autorelease]` message sent to object will add it to main `autorelease pool` that will be released after app finishes. The goal of this commit is to manage `WebViewImpl::_uiWebViewWrapper` and `UIWebViewWrapper.uiWebView`  manually, so they are released every time `WebView` is removed from screen