### PR TITLE
Make cocos' Android.mk self containing (#18392)

### DIFF
--- a/cocos/Android.mk
+++ b/cocos/Android.mk
@@ -310,6 +310,8 @@ LOCAL_STATIC_LIBRARIES += audioengine_static
 
 include $(BUILD_STATIC_LIBRARY)
 #==============================================================
+$(call import-add-path,$(LOCAL_PATH))
+$(call import-add-path,$(LOCAL_PATH)/../external)
 $(call import-module,android/cpufeatures)
 $(call import-module,freetype2/prebuilt/android)
 $(call import-module,platform/android)


### PR DESCRIPTION
PROBLEM
-------

cocos makefile is not self-containing.

From the perspective of a developer that link his target with
`cocos2dx_static` library, it should specify in his `Android.mk` only
a path to a makefile that defines that module, by

a) using `import-add-path` and `import-module`

    $(call import-add-path, <path-to-cocos-root>)
    $(call import-module, cocos)

  or ...

b) using directly an `include` command

    include <path-to-cocos-root>/cocos/Android.mk

Unfortunately the current configuration of cocos' Android.mk doesn't
specify (using `import-add-path`) locations of modules that it uses.
In result, every dev that uses cocos to create Android app has to
populate NDK_MODULE_PATH at his Android.mk files by adding two lines:

    $(call import-add-path, <path-to-cocos-root>/cocos)
    $(call import-add-path, <path-to-cocos-root>/external)

Those lines have to be placed at cocos/Android.mk file.

The current configuration of build script breaks a good practice of
hiding internal details from clients of library or component. In fact
the script exposes internal dependencies and require from a dev to make
them out.


SOLUTION
-------

This commit adds corresponding `import-add-path` commands to Android.mk
files.

HOW TO TEST
---------------

1. Create cocos2d-x app.

2. Import in your Android.mk file a `cocos` module using one of
aforementioned approaches.

3. The app should compile without a error message like the one below:

    Android NDK: jni/../../cocos2d/cocos/Android.mk: Cannot find module with tag 'freetype2/prebuilt/android' in import path
    Android NDK: Are you sure your NDK_MODULE_PATH variable is properly defined ?

Issue: https://github.com/cocos2d/cocos2d-x/issues/18392