### PR TITLE
Fix/Optimize clean and sort of render groups.

### DIFF
--- a/cocos/renderer/CCGroupCommand.cpp
+++ b/cocos/renderer/CCGroupCommand.cpp
@@ -31,7 +31,7 @@ NS_CC_BEGIN
 
 GroupCommandManager::GroupCommandManager()
 {
-
+    init();
 }
 
 GroupCommandManager::~GroupCommandManager()
@@ -43,6 +43,7 @@ bool GroupCommandManager::init()
 {
     //0 is the default render group
     _groupMapping[0] = true;
+    _usedIDs.insert(0);
     return true;
 }
 
@@ -54,6 +55,7 @@ int GroupCommandManager::getGroupID()
         int groupID = *_unusedIDs.rbegin();
         _unusedIDs.pop_back();
         _groupMapping[groupID] = true;
+        _usedIDs.insert(groupID);
         return groupID;
     }
 
@@ -61,20 +63,23 @@ int GroupCommandManager::getGroupID()
 //    int newID = _groupMapping.size();
     int newID = Director::getInstance()->getRenderer()->createRenderQueue();
     _groupMapping[newID] = true;
-
+    _usedIDs.insert(newID);
     return newID;
 }
 
 void GroupCommandManager::releaseGroupID(int groupID)
 {
-    _groupMapping[groupID] = false;
-    _unusedIDs.push_back(groupID);
+    if (groupID > 0) {
+        _groupMapping[groupID] = false;
+        _usedIDs.erase(groupID);
+        _unusedIDs.push_back(groupID);
+    }
 }
 
 GroupCommand::GroupCommand()
 {
     _type = RenderCommand::Type::GROUP_COMMAND;
-    _renderQueueID = Director::getInstance()->getRenderer()->getGroupCommandManager()->getGroupID();
+    _renderQueueID = -1;
 }
 
 void GroupCommand::init(float globalOrder)

--- a/cocos/renderer/CCGroupCommand.h
+++ b/cocos/renderer/CCGroupCommand.h
@@ -28,6 +28,7 @@
 
 #include <vector>
 #include <unordered_map>
+#include <unordered_set>
 
 #include "base/CCRef.h"
 #include "renderer/CCRenderCommand.h"
@@ -45,7 +46,7 @@ class GroupCommandManager : public Ref
 public:
     int getGroupID();
     void releaseGroupID(int groupID);
-
+    std::unordered_set<int>& getUsedIDS() { return _usedIDs; }
 protected:
     friend class Renderer;
     GroupCommandManager();
@@ -53,6 +54,7 @@ protected:
     bool init();
     std::unordered_map<int, bool> _groupMapping;
     std::vector<int> _unusedIDs;
+    std::unordered_set<int> _usedIDs;
 };
 
 /**

--- a/cocos/renderer/CCRenderer.cpp
+++ b/cocos/renderer/CCRenderer.cpp
@@ -640,9 +640,8 @@ void Renderer::render()
     {
         //Process render commands
         //1. Sort render commands based on ID
-        for (auto &renderqueue : _renderGroups)
-        {
-            renderqueue.sort();
+        for (auto renderQueueID : _groupCommandManager->getUsedIDS()) {
+            _renderGroups[renderQueueID].sort();
         }
         visitRenderQueue(_renderGroups[0]);
     }
@@ -653,16 +652,9 @@ void Renderer::render()
 void Renderer::clean()
 {
     // Clear render group
-    for (size_t j = 0, size = _renderGroups.size() ; j < size; j++)
-    {
-        //commands are owned by nodes
-        // for (const auto &cmd : _renderGroups[j])
-        // {
-        //     cmd->releaseToCommandPool();
-        // }
-        _renderGroups[j].clear();
+    for (auto renderQueueID : _groupCommandManager->getUsedIDS()) {
+        _renderGroups[renderQueueID].clear();
     }
-
     // Clear batch commands
     _queuedTriangleCommands.clear();
     _filledVertex = 0;


### PR DESCRIPTION
This fix optimize how group commands works inside cocos2d render pipeline. Before this fix, all instances of a group command create a render queue, add him in `std::vector<RenderQueue> _renderGroups` of `Renderer`, and it never will be removed from it. Because of that, i removed the insertion from render group constructor, and it will be add only if this command will be used to render scene. Another optimization, is only iterate over render queues those in use.