### PR TITLE
Reverts add search path logic in PR #17435 .

### DIFF
--- a/cocos/platform/CCFileUtils.cpp
+++ b/cocos/platform/CCFileUtils.cpp
@@ -997,15 +997,7 @@ void FileUtils::addSearchPath(const std::string &searchpath,const bool front)
         _searchPathArray.insert(_searchPathArray.begin(), path);
     } else {
         _originalSearchPaths.push_back(searchpath);
-
-        if (!_searchPathArray.empty() && _searchPathArray[_searchPathArray.size()-1] == _defaultResRootPath)
-        {
-            _searchPathArray.insert(_searchPathArray.begin() + _searchPathArray.size() -1, path);
-        }
-        else
-        {
-            _searchPathArray.push_back(path);
-        }
+        _searchPathArray.push_back(path);
     }
 }
 


### PR DESCRIPTION
Reverted code added in https://github.com/cocos2d/cocos2d-x/pull/17435

If the last search path is _defaultResRootPath, addSearchPath(path) should not force that the last path is still default resource root path.
I made this mistake and broke the compatibiliy, since I thought resource root path definitely is low priority while search in most case. However, I should not make this assumption.

Anyway, dear developers, thanks for all of you review cocos2d-x source code. I accept any suggestion, any blame. I think everyone makes mistake more or less.
The key point is that `PLEASE DON'T MAKE THE SAME MISTAKE SECOND TIME, THIRD TIME`.
So please don't blame our developers who makes mistakes. We need to work together with all our developers to make our engine better and better.

And in fact, I never think that I deal with cocos2d-x source code as my 'own branch' although I contributed lots of code to it. I didn't push any code to repo directly since I sent Pull Requests. Every one could review code and comment in pull request. We encourage more communication with our developers in github or the forum. You could say GOOD , BAD or SHIT, but please do your best to respect every developer who made a contribution.

Thanks all of you. Good luck!