### PR TITLE
Refine jni helper

### DIFF
--- a/cocos/base/ccUTF8.h
+++ b/cocos/base/ccUTF8.h
@@ -32,7 +32,7 @@
 #include <sstream>
 
 #if (CC_TARGET_PLATFORM == CC_PLATFORM_ANDROID) 
-#include "platform/android/jni/JniHelper.h"
+#include <jni.h>
 #endif
 
 NS_CC_BEGIN

--- a/cocos/platform/android/jni/JniHelper-inl.h
+++ b/cocos/platform/android/jni/JniHelper-inl.h
@@ -1,0 +1,494 @@
+﻿/****************************************************************************
+ Copyright (c) 2010-2012 cocos2d-x.org
+ Copyright (c) 2015 Victor Komarov
+ Copyright (c) 2017 Jeff Wang
+
+ http://www.cocos2d-x.org
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+****************************************************************************/
+#ifndef __ANDROID_JNI_HELPER_INL_H__
+#define __ANDROID_JNI_HELPER_INL_H__
+
+#include <type_traits>
+#include "base/ccUTF8.h"
+
+NS_CC_BEGIN
+
+template <class Ty> struct CStyleArrayWrapper {
+    explicit CStyleArrayWrapper(const Ty *e, size_t s) : elem(e), size(s) { }
+    const Ty *elem;
+    size_t size;
+};
+
+template <class Ty>
+inline CStyleArrayWrapper<Ty> makeCStyleArray(const Ty *e, size_t s) {
+    return CStyleArrayWrapper<Ty>(e, s);
+}
+
+//
+// LocalRefWrapper
+//
+struct LocalRefWrapper {
+    explicit LocalRefWrapper(JNIEnv* env, jobject obj) : _env(env), _obj(obj) { }
+    ~LocalRefWrapper() { _env->DeleteLocalRef(_obj); }
+    inline jobject get() const { return _obj; }
+
+private:
+    LocalRefWrapper(const LocalRefWrapper&) = delete;
+    LocalRefWrapper(LocalRefWrapper&&) = delete;
+    LocalRefWrapper& operator=(const LocalRefWrapper&) = delete;
+    LocalRefWrapper& operator=(LocalRefWrapper&&) = delete;
+
+protected:
+    JNIEnv* _env;
+    jobject _obj;
+};
+
+namespace JniHelperDetail {
+
+    //
+    // CharSequence
+    //
+    template <char... Chars>
+    struct CharSequence {
+        static const char value[sizeof...(Chars) + 1];
+    };
+
+    template <char... Chars>
+    const char CharSequence<Chars...>::value[sizeof...(Chars) + 1] = {
+        Chars..., '\0'
+    };
+
+    //
+    // SequenceConcatenator
+    //
+    template <class Seq1, class... SeqN>
+    struct SequenceConcatenator;
+
+    template <char... Chars>
+    struct SequenceConcatenator<CharSequence<Chars...> > {
+        typedef CharSequence<Chars...> Result;
+    };
+
+    template <char... Chars1, char... Chars2>
+    struct SequenceConcatenator<CharSequence<Chars1...>, CharSequence<Chars2...> > {
+        typedef CharSequence<Chars1..., Chars2...> Result;
+    };
+
+    template <char... Chars1, char... Chars2, class... Rest>
+    struct SequenceConcatenator<CharSequence<Chars1...>, CharSequence<Chars2...>, Rest...> {
+        typedef typename SequenceConcatenator<CharSequence<Chars1..., Chars2...>, Rest...>::Result Result;
+    };
+
+    // IntegralConverter
+    template <size_t Bytes, bool IsSigned> struct IntegralConverter;
+
+    // jboolean: unsigned 8 bits
+    template <> struct IntegralConverter<1, false> {
+        typedef CharSequence<'Z'> Signature;
+        typedef jbooleanArray ArrayType;
+        typedef jboolean ElementType;
+
+        static inline jboolean callStaticMethodV(JNIEnv* env, jclass clazz, jmethodID methodID, va_list args) {
+            return env->CallStaticBooleanMethodV(clazz, methodID, args);
+        }
+        static inline ElementType* getArrayElements(JNIEnv* env, ArrayType arr, jboolean* isCopy) {
+            return env->GetBooleanArrayElements(arr, isCopy);
+        }
+        static inline void releaseArrayElements(JNIEnv* env, ArrayType arr, ElementType* elems, jint mode) {
+            env->ReleaseBooleanArrayElements(arr, elems, mode);
+        }
+        static inline ArrayType newArray(JNIEnv* env, jsize length) {
+            return env->NewBooleanArray(length);
+        }
+        static inline void setArrayRegion(JNIEnv* env, ArrayType arr, jsize start, jsize len, const ElementType* buf) {
+            env->SetBooleanArrayRegion(arr, start, len, buf);
+        }
+    };
+
+    // jbyte: signed 8 bits
+    template <> struct IntegralConverter<1, true> {
+        typedef CharSequence<'B'> Signature;
+        typedef jbyteArray ArrayType;
+        typedef jbyte ElementType;
+
+        static inline jbyte callStaticMethodV(JNIEnv* env, jclass clazz, jmethodID methodID, va_list args) {
+            return env->CallStaticByteMethodV(clazz, methodID, args);
+        }
+        static inline ElementType* getArrayElements(JNIEnv* env, ArrayType arr, jboolean* isCopy) {
+            return env->GetByteArrayElements(arr, isCopy);
+        }
+        static inline void releaseArrayElements(JNIEnv* env, ArrayType arr, ElementType* elems, jint mode) {
+            env->ReleaseByteArrayElements(arr, elems, mode);
+        }
+        static inline ArrayType newArray(JNIEnv* env, jsize length) {
+            return env->NewByteArray(length);
+        }
+        static inline void setArrayRegion(JNIEnv* env, ArrayType arr, jsize start, jsize len, const ElementType* buf) {
+            env->SetByteArrayRegion(arr, start, len, buf);
+        }
+    };
+
+    // jchar: unsigned 16 bits
+    template <> struct IntegralConverter<2, false> {
+        typedef CharSequence<'C'> Signature;
+        typedef jcharArray ArrayType;
+        typedef jchar ElementType;
+
+        static inline jchar callStaticMethodV(JNIEnv* env, jclass clazz, jmethodID methodID, va_list args) {
+            return env->CallStaticCharMethodV(clazz, methodID, args);
+        }
+        static inline ElementType* getArrayElements(JNIEnv* env, ArrayType arr, jboolean* isCopy) {
+            return env->GetCharArrayElements(arr, isCopy);
+        }
+        static inline void releaseArrayElements(JNIEnv* env, ArrayType arr, ElementType* elems, jint mode) {
+            env->ReleaseCharArrayElements(arr, elems, mode);
+        }
+        static inline ArrayType newArray(JNIEnv* env, jsize length) {
+            return env->NewCharArray(length);
+        }
+        static inline void setArrayRegion(JNIEnv* env, ArrayType arr, jsize start, jsize len, const ElementType* buf) {
+            env->SetCharArrayRegion(arr, start, len, buf);
+        }
+    };
+
+    // jshort: signed 16 bits
+    template <> struct IntegralConverter<2, true> {
+        typedef CharSequence<'S'> Signature;
+        typedef jshortArray ArrayType;
+        typedef jshort ElementType;
+
+        static inline jshort callStaticMethodV(JNIEnv* env, jclass clazz, jmethodID methodID, va_list args) {
+            return env->CallStaticShortMethodV(clazz, methodID, args);
+        }
+        static inline ElementType* getArrayElements(JNIEnv* env, ArrayType arr, jboolean* isCopy) {
+            return env->GetShortArrayElements(arr, isCopy);
+        }
+        static inline void releaseArrayElements(JNIEnv* env, ArrayType arr, ElementType* elems, jint mode) {
+            env->ReleaseShortArrayElements(arr, elems, mode);
+        }
+        static inline ArrayType newArray(JNIEnv* env, jsize length) {
+            return env->NewShortArray(length);
+        }
+        static inline void setArrayRegion(JNIEnv* env, ArrayType arr, jsize start, jsize len, const ElementType* buf) {
+            env->SetShortArrayRegion(arr, start, len, buf);
+        }
+    };
+
+    // jint signed 32 bits
+    // unsigned 32 bits not defined in jni
+    template <bool IsSigned> struct IntegralConverter<4, IsSigned> {
+        typedef CharSequence<'I'> Signature;
+        typedef jintArray ArrayType;
+        typedef jint ElementType;
+
+        static inline jint callStaticMethodV(JNIEnv* env, jclass clazz, jmethodID methodID, va_list args) {
+            return env->CallStaticIntMethodV(clazz, methodID, args);
+        }
+        static inline ElementType* getArrayElements(JNIEnv* env, ArrayType arr, jboolean* isCopy) {
+            return env->GetIntArrayElements(arr, isCopy);
+        }
+        static inline void releaseArrayElements(JNIEnv* env, ArrayType arr, ElementType* elems, jint mode) {
+            env->ReleaseIntArrayElements(arr, elems, mode);
+        }
+        static inline ArrayType newArray(JNIEnv* env, jsize length) {
+            return env->NewIntArray(length);
+        }
+        static inline void setArrayRegion(JNIEnv* env, ArrayType arr, jsize start, jsize len, const ElementType* buf) {
+            env->SetIntArrayRegion(arr, start, len, buf);
+        }
+    };
+
+    // jlong: signed 64 bits
+    // unsigned 64 bits not defined in jni
+    template <bool IsSigned> struct IntegralConverter<8, IsSigned> {
+        typedef CharSequence<'J'> Signature;
+        typedef jlongArray ArrayType;
+        typedef jlong ElementType;
+
+        static inline jlong callStaticMethodV(JNIEnv* env, jclass clazz, jmethodID methodID, va_list args) {
+            return env->CallStaticLongMethodV(clazz, methodID, args);
+        }
+        static inline ElementType* getArrayElements(JNIEnv* env, ArrayType arr, jboolean* isCopy) {
+            return env->GetLongArrayElements(arr, isCopy);
+        }
+        static inline void releaseArrayElements(JNIEnv* env, ArrayType arr, ElementType* elems, jint mode) {
+            env->ReleaseLongArrayElements(arr, elems, mode);
+        }
+        static inline ArrayType newArray(JNIEnv* env, jsize length) {
+            return env->NewLongArray(length);
+        }
+        static inline void setArrayRegion(JNIEnv* env, ArrayType arr, jsize start, jsize len, const ElementType* buf) {
+            env->SetLongArrayRegion(arr, start, len, buf);
+        }
+    };
+
+    // FloatConverter
+    template <size_t Bytes> struct FloatConverter;
+
+    // jfloat: 32-bit IEEE 754
+    template <> struct FloatConverter<4> {
+        typedef CharSequence<'F'> Signature;
+        typedef jfloatArray ArrayType;
+        typedef jfloat ElementType;
+
+        static inline jfloat callStaticMethodV(JNIEnv* env, jclass clazz, jmethodID methodID, va_list args) {
+            return env->CallStaticFloatMethodV(clazz, methodID, args);
+        }
+        static inline ElementType* getArrayElements(JNIEnv* env, ArrayType arr, jboolean* isCopy) {
+            return env->GetFloatArrayElements(arr, isCopy);
+        }
+        static inline void releaseArrayElements(JNIEnv* env, ArrayType arr, ElementType* elems, jint mode) {
+            env->ReleaseFloatArrayElements(arr, elems, mode);
+        }
+        static inline ArrayType newArray(JNIEnv* env, jsize length) {
+            return env->NewFloatArray(length);
+        }
+        static inline void setArrayRegion(JNIEnv* env, ArrayType arr, jsize start, jsize len, const ElementType* buf) {
+            env->SetFloatArrayRegion(arr, start, len, buf);
+        }
+    };
+
+    // jdouble: 64-bit IEEE 754
+    template <> struct FloatConverter<8> {
+        typedef CharSequence<'D'> Signature;
+        typedef jdoubleArray ArrayType;
+        typedef jdouble ElementType;
+
+        static inline jdouble callStaticMethodV(JNIEnv* env, jclass clazz, jmethodID methodID, va_list args) {
+            return env->CallStaticDoubleMethodV(clazz, methodID, args);
+        }
+        static inline ElementType* getArrayElements(JNIEnv* env, ArrayType arr, jboolean* isCopy) {
+            return env->GetDoubleArrayElements(arr, isCopy);
+        }
+        static inline void releaseArrayElements(JNIEnv* env, ArrayType arr, ElementType* elems, jint mode) {
+            env->ReleaseDoubleArrayElements(arr, elems, mode);
+        }
+        static inline ArrayType newArray(JNIEnv* env, jsize length) {
+            return env->NewDoubleArray(length);
+        }
+        static inline void setArrayRegion(JNIEnv* env, ArrayType arr, jsize start, jsize len, const ElementType* buf) {
+            env->SetDoubleArrayRegion(arr, start, len, buf);
+        }
+    };
+
+    //
+    // TypeConverter
+    // typedefs Signature ArrayType ElementType;
+    // wraps CallStaticXXXMethodV GetXXXArrayElements ReleaseXXXArrayElements newXXXArray SetXXXArrayRegion
+    //
+    template <class Ret> struct TypeConverter;
+
+    template <> struct TypeConverter<void> {
+        typedef CharSequence<'V'> Signature;
+
+        static inline void callStaticMethodV(JNIEnv* env, jclass clazz, jmethodID methodID, va_list args) {
+            env->CallStaticVoidMethodV(clazz, methodID, args);
+        }
+    };
+
+    template <> struct TypeConverter<bool> : IntegralConverter<1, false> {
+        static inline bool callStaticMethodV(JNIEnv* env, jclass clazz, jmethodID methodID, va_list args) {
+            return JNI_TRUE == env->CallStaticBooleanMethodV(clazz, methodID, args);
+        }
+    };
+    template <> struct TypeConverter<char> : IntegralConverter<1, true> { };
+    template <> struct TypeConverter<signed char> : IntegralConverter<1, true> { };
+    template <> struct TypeConverter<unsigned char> : IntegralConverter<1, true> { };
+    template <> struct TypeConverter<signed short> : IntegralConverter<sizeof(signed short), true> { };
+    template <> struct TypeConverter<unsigned short> : IntegralConverter<sizeof(unsigned short), false> { };
+    template <> struct TypeConverter<signed int> : IntegralConverter<sizeof(signed int), true> { };
+    template <> struct TypeConverter<unsigned int> : IntegralConverter<sizeof(unsigned int), false> { };
+    template <> struct TypeConverter<signed long> : IntegralConverter<sizeof(signed long), true> { };
+    template <> struct TypeConverter<unsigned long> : IntegralConverter<sizeof(unsigned int), false> { };
+    template <> struct TypeConverter<int64_t> : IntegralConverter<sizeof(int64_t), true> { };
+    template <> struct TypeConverter<uint64_t> : IntegralConverter<sizeof(uint64_t), false>{};
+    template <> struct TypeConverter<float> : FloatConverter<sizeof(float)> { };
+    template <> struct TypeConverter<double> : FloatConverter<sizeof(double)> { };
+
+    template <> struct TypeConverter<char*> {
+        typedef CharSequence<'L', 'j', 'a', 'v', 'a', '/', 'l', 'a', 'n', 'g', '/', 'S', 't', 'r', 'i', 'n', 'g', ';'> Signature;
+    };
+    template <> struct TypeConverter<const char*> : TypeConverter<char*> { };
+    template <size_t Size> struct TypeConverter<char [Size]> : TypeConverter<char*> { };
+    template <size_t Size> struct TypeConverter<const char [Size]> : TypeConverter<char*> { };
+
+    template <> struct TypeConverter<std::string> {
+        typedef CharSequence<'L', 'j', 'a', 'v', 'a', '/', 'l', 'a', 'n', 'g', '/', 'S', 't', 'r', 'i', 'n', 'g', ';'> Signature;
+
+        static std::string callStaticMethodV(JNIEnv* env, jclass clazz, jmethodID methodID, va_list args) {
+            LocalRefWrapper jret(env, env->CallStaticObjectMethodV(clazz, methodID, args));
+            return StringUtils::getStringUTFCharsJNI(env, (jstring)jret.get());
+        }
+    };
+
+    template <class Ty> struct TypeConverter<CStyleArrayWrapper<Ty> > {
+        typedef typename SequenceConcatenator<CharSequence<'['>,
+            typename TypeConverter<Ty>::Signature>::Result Signature;
+    };
+
+    template <class Ty> struct TypeConverter<std::vector<Ty> > : TypeConverter<CStyleArrayWrapper<Ty> > {
+        static std::vector<Ty> callStaticMethodV(JNIEnv* env, jclass clazz, jmethodID methodID, va_list args) {
+            typedef TypeConverter<Ty> ElemTypeWrapper;
+            typedef typename ElemTypeWrapper::ArrayType ArrayType;
+            LocalRefWrapper jarr(env, env->CallStaticObjectMethodV(clazz, methodID, args));
+            jsize len = env->GetArrayLength((ArrayType)jarr.get());
+            std::vector<Ty> ret(len);
+            if (len > 0) {
+                auto elems = ElemTypeWrapper::getArrayElements(env, (ArrayType)jarr.get(), nullptr);
+                for (jsize i = 0; i < len; ++i) ret.push_back(elems[i]);
+                ElemTypeWrapper::releaseArrayElements(env, (ArrayType)jarr.get(), elems, 0);
+            }
+            return ret;
+        }
+    };
+
+    //
+    // SignatureParser
+    // parses signature during compiling time
+    //
+    template <class Ty> struct SignatureParser;
+
+    template <class Ret, class... Args> struct SignatureParser<Ret (Args...)> {
+        typedef typename SequenceConcatenator<CharSequence<'('>,
+            typename TypeConverter<typename std::remove_reference<typename std::remove_const<Args>::type>::type>::Signature...,
+            CharSequence<')'>,
+            typename TypeConverter<Ret>::Signature>::Result Result;
+    };
+
+    //
+    // MethodInvoker
+    //
+    template <class Ret> struct MethodInvoker {
+        static Ret callStatic(JNIEnv* env, jclass clazz, jmethodID methodID, ...) {
+            va_list args;
+            va_start(args, methodID);
+            Ret ret = TypeConverter<Ret>::callStaticMethodV(env, clazz, methodID, args);
+            va_end(args);
+            return ret;
+        }
+    };
+
+    // specialization for void, because va_end is necessary, but it is not allowed to declare a variable of type void
+    template <> struct MethodInvoker<void> {
+        static void callStatic(JNIEnv* env, jclass clazz, jmethodID methodID, ...) {
+            va_list args;
+            va_start(args, methodID);
+            TypeConverter<void>::callStaticMethodV(env, clazz, methodID, args);
+            va_end(args);
+        }
+    };
+
+    //
+    // ArgumentWrapper
+    //
+    template <class Ty> class ArgumentWrapper {
+        static_assert(std::is_arithmetic<Ty>::value, "ArgumentWrapper<Ty> : only arithmetic type supported");
+        Ty _arg;
+
+    public:
+        explicit ArgumentWrapper(JNIEnv*, Ty arg) : _arg(arg) { }
+        inline Ty get() const { return _arg; };
+    };
+
+    template <> class ArgumentWrapper<const char*> : LocalRefWrapper {
+        ArgumentWrapper(const ArgumentWrapper&) = delete;
+        ArgumentWrapper(ArgumentWrapper&&) = delete;
+        ArgumentWrapper& operator=(const ArgumentWrapper&) = delete;
+        ArgumentWrapper& operator=(ArgumentWrapper&&) = delete;
+
+    public:
+        explicit ArgumentWrapper(JNIEnv* env, const char* str)
+            : LocalRefWrapper(env, StringUtils::newStringUTFJNI(env, str != nullptr ? str : "")) {
+        }
+
+        explicit ArgumentWrapper(JNIEnv* env, const std::string& str)
+            : LocalRefWrapper(env, StringUtils::newStringUTFJNI(env, str.c_str())) {
+        }
+
+        inline jstring get() const { return (jstring)_obj; };
+    };
+
+    // convertArray, in case of sizeof(Ty) == sizeof(ElementType)
+    template <class Ty>
+    static typename std::enable_if<sizeof(Ty) == sizeof(typename TypeConverter<Ty>::ElementType), typename TypeConverter<Ty>::ArrayType>::type
+        convertArray(JNIEnv* env, const Ty *elem, size_t size) {
+        typedef typename TypeConverter<Ty>::ArrayType ArrayType;
+        typedef typename TypeConverter<Ty>::ElementType ElementType;
+        ArrayType ret = TypeConverter<ElementType>::newArray(env, size);
+        TypeConverter<ElementType>::setArrayRegion(env, ret, 0, size, reinterpret_cast<const ElementType*>(elem));
+        return ret;
+    }
+
+    // convertArray, in case of sizeof(Ty) != sizeof(ElementType)
+    template <class Ty>
+    static typename std::enable_if<sizeof(Ty) != sizeof(typename TypeConverter<Ty>::ElementType), typename TypeConverter<Ty>::ArrayType>::type
+        convertArray(JNIEnv* env, const Ty *elem, size_t size) {
+        typedef typename TypeConverter<Ty>::ArrayType ArrayType;
+        typedef typename TypeConverter<Ty>::ElementType ElementType;
+        ArrayType ret = TypeConverter<ElementType>::newArray(env, size);
+        std::vector<ElementType> temp;
+        temp.resize(size);
+        for (size_t i = 0; i < size; ++i) { temp[i] = static_cast<ElementType>(elem[i]); }
+        TypeConverter<ElementType>::setArrayRegion(env, ret, 0, size, temp.data());
+        return ret;
+    }
+
+    template <class Ty> class ArgumentWrapper<std::vector<Ty> > : LocalRefWrapper {
+        ArgumentWrapper(const ArgumentWrapper&) = delete;
+        ArgumentWrapper(ArgumentWrapper&&) = delete;
+        ArgumentWrapper& operator=(const ArgumentWrapper&) = delete;
+        ArgumentWrapper& operator=(ArgumentWrapper&&) = delete;
+
+    public:
+        static_assert(std::is_arithmetic<Ty>::value, "ArgumentWrapper<std::vector<Ty> > : only arithmetic elements supported");
+
+        typedef typename TypeConverter<Ty>::ArrayType ArrayType;
+        typedef typename TypeConverter<Ty>::ElementType ElementType;
+
+        explicit ArgumentWrapper(JNIEnv* env, const std::vector<Ty>& vec)
+            : LocalRefWrapper(env, convertArray(env, vec.data(), vec.size())) {
+        }
+        explicit ArgumentWrapper(JNIEnv* env, const CStyleArrayWrapper<Ty>& arr)
+            : LocalRefWrapper(env, convertArray(env, arr.elem, arr.size)) {
+        }
+        inline ArrayType get() const { return (ArrayType)_obj; };
+    };
+
+    //
+    // ArgumentConverter
+    //
+    template <class Ty> struct ArgumentConverter { typedef Ty Type; };
+
+    template <> struct ArgumentConverter<std::string> { typedef const char* Type; };
+    template <size_t Size> struct ArgumentConverter<char [Size]> { typedef const char* Type; };
+    template <size_t Size> struct ArgumentConverter<const char [Size]> { typedef const char* Type; };
+
+    template <class Ty> struct ArgumentConverter<CStyleArrayWrapper<Ty> > : ArgumentConverter<std::vector<Ty> > { };
+
+    template <class Ty> struct ArgumentConverter<const Ty> : ArgumentConverter<Ty> { };
+    template <class Ty> struct ArgumentConverter<Ty&> : ArgumentConverter<Ty> { };
+    template <class Ty> struct ArgumentConverter<const Ty&> : ArgumentConverter<Ty> { };
+    template <class Ty> struct ArgumentConverter<Ty&&> : ArgumentConverter<Ty> { };
+}
+
+NS_CC_END
+
+#endif // __ANDROID_JNI_HELPER_INL_H__

--- a/cocos/platform/android/jni/JniHelper.cpp
+++ b/cocos/platform/android/jni/JniHelper.cpp
@@ -27,8 +27,6 @@ THE SOFTWARE.
 #include <string.h>
 #include <pthread.h>
 
-#include "base/ccUTF8.h"
-
 #define  LOG_TAG    "JniHelper"
 #define  LOGD(...)  __android_log_print(ANDROID_LOG_DEBUG,LOG_TAG,__VA_ARGS__)
 #define  LOGE(...)  __android_log_print(ANDROID_LOG_ERROR,LOG_TAG,__VA_ARGS__)
@@ -54,7 +52,7 @@ jclass _getClassID(const char *className) {
     }
 
     env->DeleteLocalRef(_jstrClassName);
-        
+
     return _clazz;
 }
 
@@ -68,7 +66,7 @@ namespace cocos2d {
     jmethodID JniHelper::loadclassMethod_methodID = nullptr;
     jobject JniHelper::classloader = nullptr;
     std::function<void()> JniHelper::classloaderCallback = nullptr;
-    
+
     jobject JniHelper::_activity = nullptr;
 
     JavaVM* JniHelper::getJavaVM() {
@@ -89,13 +87,13 @@ namespace cocos2d {
         JNIEnv* _env = nullptr;
         // get jni environment
         jint ret = jvm->GetEnv((void**)&_env, JNI_VERSION_1_4);
-        
+
         switch (ret) {
         case JNI_OK :
             // Success!
             pthread_setspecific(g_key, _env);
             return _env;
-                
+
         case JNI_EDETACHED :
             // Thread not attached
             if (jvm->AttachCurrentThread(&_env, nullptr) < 0)
@@ -108,7 +106,7 @@ namespace cocos2d {
                 pthread_setspecific(g_key, _env);
                 return _env;
             }
-                
+
         case JNI_EVERSION :
             // Cannot recover from this error
             LOGE("JNI interface version 1.4 not supported");
@@ -124,7 +122,7 @@ namespace cocos2d {
             _env = JniHelper::cacheEnv(_psJavaVM);
         return _env;
     }
-    
+
     jobject JniHelper::getActivity() {
         return _activity;
     }
@@ -164,7 +162,7 @@ namespace cocos2d {
     }
 
     bool JniHelper::getStaticMethodInfo(JniMethodInfo &methodinfo,
-                                        const char *className, 
+                                        const char *className,
                                         const char *methodName,
                                         const char *paramCode) {
         if ((nullptr == className) ||
@@ -178,7 +176,7 @@ namespace cocos2d {
             LOGE("Failed to get JNIEnv");
             return false;
         }
-            
+
         jclass classID = _getClassID(className);
         if (! classID) {
             LOGE("Failed to find class %s", className);
@@ -192,7 +190,7 @@ namespace cocos2d {
             env->ExceptionClear();
             return false;
         }
-            
+
         methodinfo.classID = classID;
         methodinfo.env = env;
         methodinfo.methodID = methodID;
@@ -275,7 +273,7 @@ namespace cocos2d {
         if (jstr == nullptr) {
             return "";
         }
-        
+
         JNIEnv *env = JniHelper::getEnv();
         if (!env) {
             return "";
@@ -286,29 +284,8 @@ namespace cocos2d {
         return strValue;
     }
 
-    jstring JniHelper::convert(LocalRefMapType& localRefs, cocos2d::JniMethodInfo& t, const char* x) {
-        jstring ret = cocos2d::StringUtils::newStringUTFJNI(t.env, x ? x : "");
-        localRefs[t.env].push_back(ret);
-        return ret;
-    }
-
-    jstring JniHelper::convert(LocalRefMapType& localRefs, cocos2d::JniMethodInfo& t, const std::string& x) {
-        return convert(localRefs, t, x.c_str());
-    }
-
-    void JniHelper::deleteLocalRefs(JNIEnv* env, LocalRefMapType& localRefs) {
-        if (!env) {
-            return;
-        }
-
-        for (const auto& ref : localRefs[env]) {
-            env->DeleteLocalRef(ref);
-        }
-        localRefs[env].clear();
-    }
-
-    void JniHelper::reportError(const std::string& className, const std::string& methodName, const std::string& signature) {
-        LOGE("Failed to find static java method. Class name: %s, method name: %s, signature: %s ",  className.c_str(), methodName.c_str(), signature.c_str());
+    void JniHelper::reportError(const char* className, const char* methodName, const char* signature) {
+        LOGE("Failed to find static java method. Class name: %s, method name: %s, signature: %s ",  className, methodName, signature);
     }
 
 } //namespace cocos2d

--- a/cocos/platform/android/jni/JniHelper.h
+++ b/cocos/platform/android/jni/JniHelper.h
@@ -28,10 +28,10 @@ THE SOFTWARE.
 #include <jni.h>
 #include <string>
 #include <vector>
-#include <unordered_map>
 #include <functional>
 #include "platform/CCPlatformMacros.h"
 #include "math/Vec3.h"
+#include "JniHelper-inl.h"
 
 NS_CC_BEGIN
 
@@ -45,9 +45,6 @@ typedef struct JniMethodInfo_
 class CC_DLL JniHelper
 {
 public:
-
-    typedef std::unordered_map<JNIEnv*, std::vector<jobject>> LocalRefMapType;
-
     static void setJavaVM(JavaVM *javaVM);
     static JavaVM* getJavaVM();
     static JNIEnv* getEnv();
@@ -72,159 +69,75 @@ public:
     template <typename... Ts>
     static void callStaticVoidMethod(const std::string& className, 
                                      const std::string& methodName, 
-                                     Ts... xs) {
-        cocos2d::JniMethodInfo t;
-        std::string signature = "(" + std::string(getJNISignature(xs...)) + ")V";
-        if (cocos2d::JniHelper::getStaticMethodInfo(t, className.c_str(), methodName.c_str(), signature.c_str())) {
-            LocalRefMapType localRefs;
-            t.env->CallStaticVoidMethod(t.classID, t.methodID, convert(localRefs, t, xs)...);
-            t.env->DeleteLocalRef(t.classID);
-            deleteLocalRefs(t.env, localRefs);
-        } else {
-            reportError(className, methodName, signature);
-        }
+                                     const Ts&... xs) {
+        callStaticMethod<void>(className.c_str(), methodName.c_str(), xs...); 
     }
 
     template <typename... Ts>
-    static bool callStaticBooleanMethod(const std::string& className, 
+    static bool callStaticBooleanMethod(const std::string& className,        
                                         const std::string& methodName, 
-                                        Ts... xs) {
-        jboolean jret = JNI_FALSE;
-        cocos2d::JniMethodInfo t;
-        std::string signature = "(" + std::string(getJNISignature(xs...)) + ")Z";
-        if (cocos2d::JniHelper::getStaticMethodInfo(t, className.c_str(), methodName.c_str(), signature.c_str())) {
-            LocalRefMapType localRefs;
-            jret = t.env->CallStaticBooleanMethod(t.classID, t.methodID, convert(localRefs, t, xs)...);
-            t.env->DeleteLocalRef(t.classID);
-            deleteLocalRefs(t.env, localRefs);
-        } else {
-            reportError(className, methodName, signature);
-        }
-        return (jret == JNI_TRUE);
+                                        const Ts&... xs) {
+        return callStaticMethod<bool>(className.c_str(), methodName.c_str(), xs...); 
     }
 
     template <typename... Ts>
     static int callStaticIntMethod(const std::string& className, 
                                    const std::string& methodName, 
-                                   Ts... xs) {
-        jint ret = 0;
-        cocos2d::JniMethodInfo t;
-        std::string signature = "(" + std::string(getJNISignature(xs...)) + ")I";
-        if (cocos2d::JniHelper::getStaticMethodInfo(t, className.c_str(), methodName.c_str(), signature.c_str())) {
-            LocalRefMapType localRefs;
-            ret = t.env->CallStaticIntMethod(t.classID, t.methodID, convert(localRefs, t, xs)...);
-            t.env->DeleteLocalRef(t.classID);
-            deleteLocalRefs(t.env, localRefs);
-        } else {
-            reportError(className, methodName, signature);
-        }
-        return ret;
+                                   const Ts&... xs) {
+        return callStaticMethod<int>(className.c_str(), methodName.c_str(), xs...); 
     }
 
     template <typename... Ts>
     static float callStaticFloatMethod(const std::string& className, 
                                        const std::string& methodName, 
-                                       Ts... xs) {
-        jfloat ret = 0.0;
-        cocos2d::JniMethodInfo t;
-        std::string signature = "(" + std::string(getJNISignature(xs...)) + ")F";
-        if (cocos2d::JniHelper::getStaticMethodInfo(t, className.c_str(), methodName.c_str(), signature.c_str())) {
-            LocalRefMapType localRefs;
-            ret = t.env->CallStaticFloatMethod(t.classID, t.methodID, convert(localRefs, t, xs)...);
-            t.env->DeleteLocalRef(t.classID);
-            deleteLocalRefs(t.env, localRefs);
-        } else {
-            reportError(className, methodName, signature);
-        }
-        return ret;
+                                       const Ts&... xs) {
+        return callStaticMethod<float>(className.c_str(), methodName.c_str(), xs...); 
     }
 
     template <typename... Ts>
-    static float* callStaticFloatArrayMethod(const std::string& className, 
-                                       const std::string& methodName, 
-                                       Ts... xs) {
-        static float ret[32];
-        cocos2d::JniMethodInfo t;
-        std::string signature = "(" + std::string(getJNISignature(xs...)) + ")[F";
-        if (cocos2d::JniHelper::getStaticMethodInfo(t, className.c_str(), methodName.c_str(), signature.c_str())) {
-            LocalRefMapType localRefs;
-            jfloatArray array = (jfloatArray) t.env->CallStaticObjectMethod(t.classID, t.methodID, convert(localRefs, t, xs)...);
-            jsize len = t.env->GetArrayLength(array);
-            if (len <= 32) {
-                jfloat* elems = t.env->GetFloatArrayElements(array, 0);
-                if (elems) {
-                    memcpy(ret, elems, sizeof(float) * len);
-                    t.env->ReleaseFloatArrayElements(array, elems, 0);
-                };
-            }
-            t.env->DeleteLocalRef(t.classID);
-            deleteLocalRefs(t.env, localRefs);
-            return &ret[0];
-        } else {
-            reportError(className, methodName, signature);
-        }
-        return nullptr;
+    static inline double callStaticDoubleMethod(const std::string& className, 
+                                                const std::string& methodName, 
+                                                const Ts&... xs) {
+        return callStaticMethod<double>(className.c_str(), methodName.c_str(), xs...); 
     }
 
     template <typename... Ts>
-    static Vec3 callStaticVec3Method(const std::string& className, 
-                                       const std::string& methodName, 
-                                       Ts... xs) {
+    static inline std::string callStaticStringMethod(const std::string& className, 
+                                                     const std::string& methodName, 
+                                                     const Ts&... xs) {
+        return callStaticMethod<std::string>(className.c_str(), methodName.c_str(), xs...); 
+    }
+
+    template <typename Ret, typename... Args>
+    static Ret callStaticMethod(const char* className, const char* methodName, const Args& ...args) {
+        typedef typename JniHelperDetail::SignatureParser<Ret (Args...)>::Result SignatureSequence;
+        const char* signature = SignatureSequence::value;
+        JniMethodInfo t;
+        if (getStaticMethodInfo(t, className, methodName, signature)) {
+            LocalRefWrapper clazz(t.env, t.classID);
+            return JniHelperDetail::MethodInvoker<Ret>::callStatic(t.env, t.classID, t.methodID,
+                JniHelperDetail::ArgumentWrapper<typename JniHelperDetail::ArgumentConverter<Args>::Type>(t.env, args).get()...);
+        } else {
+            reportError(className, methodName, signature);
+            return Ret();
+        }
+    }
+
+    template <typename... Args>
+    static Vec3 callStaticVec3Method(const char* className, const char* methodName, const Args& ...args) {
+        typedef typename JniHelperDetail::SignatureParser<std::vector<float> (Args...)>::Result SignatureSequence;
+        const char* signature = SignatureSequence::value;
         Vec3 ret;
-        cocos2d::JniMethodInfo t;
-        std::string signature = "(" + std::string(getJNISignature(xs...)) + ")[F";
-        if (cocos2d::JniHelper::getStaticMethodInfo(t, className.c_str(), methodName.c_str(), signature.c_str())) {
-            LocalRefMapType localRefs;
-            jfloatArray array = (jfloatArray) t.env->CallStaticObjectMethod(t.classID, t.methodID, convert(localRefs, t, xs)...);
-            jsize len = t.env->GetArrayLength(array);
-            if (len == 3) {
-                jfloat* elems = t.env->GetFloatArrayElements(array, 0);
-                ret.x = elems[0];
-                ret.y = elems[1];
-                ret.z = elems[2];
-                t.env->ReleaseFloatArrayElements(array, elems, 0);
+        JniMethodInfo t;
+        if (getStaticMethodInfo(t, className, methodName, signature)) {
+            LocalRefWrapper clazz(t.env, t.classID);
+            auto arr = JniHelperDetail::MethodInvoker<std::vector<float> >::callStatic(t.env, t.classID, t.methodID,
+                JniHelperDetail::ArgumentWrapper<typename JniHelperDetail::ArgumentConverter<Args>::Type>(t.env, args).get()...);
+            if (arr.size() == 3) {
+                ret.x = arr[0];
+                ret.y = arr[1];
+                ret.z = arr[2];
             }
-            t.env->DeleteLocalRef(t.classID);
-            deleteLocalRefs(t.env, localRefs);
-        } else {
-            reportError(className, methodName, signature);
-        }
-        return ret;
-    }
-
-    template <typename... Ts>
-    static double callStaticDoubleMethod(const std::string& className, 
-                                         const std::string& methodName, 
-                                         Ts... xs) {
-        jdouble ret = 0.0;
-        cocos2d::JniMethodInfo t;
-        std::string signature = "(" + std::string(getJNISignature(xs...)) + ")D";
-        if (cocos2d::JniHelper::getStaticMethodInfo(t, className.c_str(), methodName.c_str(), signature.c_str())) {
-            LocalRefMapType localRefs;
-            ret = t.env->CallStaticDoubleMethod(t.classID, t.methodID, convert(localRefs, t, xs)...);
-            t.env->DeleteLocalRef(t.classID);
-            deleteLocalRefs(t.env, localRefs);
-        } else {
-            reportError(className, methodName, signature);
-        }
-        return ret;
-    }
-
-    template <typename... Ts>
-    static std::string callStaticStringMethod(const std::string& className, 
-                                              const std::string& methodName, 
-                                              Ts... xs) {
-        std::string ret;
-
-        cocos2d::JniMethodInfo t;
-        std::string signature = "(" + std::string(getJNISignature(xs...)) + ")Ljava/lang/String;";
-        if (cocos2d::JniHelper::getStaticMethodInfo(t, className.c_str(), methodName.c_str(), signature.c_str())) {
-            LocalRefMapType localRefs;
-            jstring jret = (jstring)t.env->CallStaticObjectMethod(t.classID, t.methodID, convert(localRefs, t, xs)...);
-            ret = cocos2d::JniHelper::jstring2string(jret);
-            t.env->DeleteLocalRef(t.classID);
-            t.env->DeleteLocalRef(jret);
-            deleteLocalRefs(t.env, localRefs);
         } else {
             reportError(className, methodName, signature);
         }
@@ -240,73 +153,10 @@ private:
                                                  const char *paramCode);
 
     static JavaVM* _psJavaVM;
-    
+
     static jobject _activity;
 
-    static jstring convert(LocalRefMapType& localRefs, cocos2d::JniMethodInfo& t, const char* x);
-
-    static jstring convert(LocalRefMapType& localRefs, cocos2d::JniMethodInfo& t, const std::string& x);
-
-    template <typename T>
-    static T convert(LocalRefMapType& localRefs, cocos2d::JniMethodInfo&, T x) {
-        return x;
-    }
-
-    static void deleteLocalRefs(JNIEnv* env, LocalRefMapType& localRefs);
-
-    static std::string getJNISignature() {
-        return "";
-    }
-
-    static std::string getJNISignature(bool) {
-        return "Z";
-    }
-
-    static std::string getJNISignature(char) {
-        return "C";
-    }
-
-    static std::string getJNISignature(short) {
-        return "S";
-    }
-
-    static std::string getJNISignature(int) {
-        return "I";
-    }
-
-    static std::string getJNISignature(long) {
-        return "J";
-    }
-
-    static std::string getJNISignature(float) {
-        return "F";
-    }
-
-   static  std::string getJNISignature(double) {
-        return "D";
-    }
-
-    static std::string getJNISignature(const char*) {
-        return "Ljava/lang/String;";
-    }
-
-    static std::string getJNISignature(const std::string&) {
-        return "Ljava/lang/String;";
-    }
-
-    template <typename T>
-    static std::string getJNISignature(T x) {
-        // This template should never be instantiated
-        static_assert(sizeof(x) == 0, "Unsupported argument type");
-        return "";
-    }
-
-    template <typename T, typename... Ts>
-    static std::string getJNISignature(T x, Ts... xs) {
-        return getJNISignature(x) + getJNISignature(xs...);
-    }
-
-    static void reportError(const std::string& className, const std::string& methodName, const std::string& signature);
+    static void reportError(const char* className, const char* methodName, const char* signature);
 };
 
 NS_CC_END


### PR DESCRIPTION
#18348 
1. deduct JNI signature during **compiling time**
2. refactor all JniHelper::callStaticXXXMethod in one template callStaticMethod, but not break compatibility
3. add support for `std::vector` as parameters and return value