### PR TITLE
Fix 60 fps for android

### DIFF
--- a/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxRenderer.java
+++ b/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxRenderer.java
@@ -36,7 +36,7 @@ public class Cocos2dxRenderer implements GLSurfaceView.Renderer {
     private final static long NANOSECONDSPERMICROSECOND = 1000000L;
 
     // The final animation interval which is used in 'onDrawFrame'
-    private static long sAnimationInterval = (long) (1.0 / 60 * Cocos2dxRenderer.NANOSECONDSPERSECOND);
+    private static long sAnimationInterval = (long) (1.0f / 60f * Cocos2dxRenderer.NANOSECONDSPERSECOND);
 
     // ===========================================================
     // Fields
@@ -86,7 +86,8 @@ public class Cocos2dxRenderer implements GLSurfaceView.Renderer {
          * No need to use algorithm in default(60 FPS) situation,
          * since onDrawFrame() was called by system 60 times per second by default.
          */
-        if (Cocos2dxRenderer.sAnimationInterval <= 1.0 / 60 * Cocos2dxRenderer.NANOSECONDSPERSECOND) {
+
+        if (Cocos2dxRenderer.sAnimationInterval <= 1.0f / 60f * Cocos2dxRenderer.NANOSECONDSPERSECOND) {
             Cocos2dxRenderer.nativeRender();
         } else {
             final long now = System.nanoTime();


### PR DESCRIPTION
Fixed issue with not stable 60 fps on android.

Reason: float and double calculation.

here is float calculation:

    public static void setAnimationInterval(float interval) {
        sAnimationInterval = (long) (interval * Cocos2dxRenderer.NANOSECONDSPERSECOND);
    }

here was double calculation:

    if (Cocos2dxRenderer.sAnimationInterval <= 1.0 / 60 * Cocos2dxRenderer.NANOSECONDSPERSECOND) {

double calculation is more precise and above condition is false if 60 fps is set.