### PR TITLE
fix bug about delayed creation UIWebView on iOS

### DIFF
--- a/cocos/ui/UIWebViewImpl-ios.mm
+++ b/cocos/ui/UIWebViewImpl-ios.mm
@@ -152,6 +152,7 @@ static std::string getFixedBaseUrl(const std::string& baseUrl)
 }
 
 - (void)setVisible:(bool)visible {
+    if (!self.uiWebView) {[self setupWebView];}
     self.uiWebView.hidden = !visible;
 }
 
@@ -160,6 +161,7 @@ static std::string getFixedBaseUrl(const std::string& baseUrl)
 }
 
 - (void)setOpacityWebView:(float)opacity {
+    if (!self.uiWebView) {[self setupWebView];}
     self.uiWebView.alpha=opacity;
     [self.uiWebView setOpaque:NO];
 }
@@ -169,6 +171,8 @@ static std::string getFixedBaseUrl(const std::string& baseUrl)
 }
 
 -(void) setBackgroundTransparent{
+    if (!self.uiWebView) {[self setupWebView];}
+    [self.uiWebView setOpaque:NO];
     [self.uiWebView setBackgroundColor:[UIColor clearColor]];
 }
 


### PR DESCRIPTION
When calling `setBackgroundTransparent` **immediately** after creating `ui::Webview`, this function does not work. because `self.uiWebView` is a delayed creation view, That is to say, `self.uiWebView==nil`.
function `setOpacityWebView` is similar.
https://github.com/cocos2d/cocos2d-x/pull/17831#pullrequestreview-68472657