### PR TITLE
Bug in mp3reader.cpp

### DIFF
--- a/cocos/audio/android/mp3reader.cpp
+++ b/cocos/audio/android/mp3reader.cpp
@@ -31,7 +31,7 @@
 #include <stdlib.h>
 #include <assert.h>
 #include <stdint.h>
-#include <string>
+#include <string.h>
 #include <vector>
 #include "audio/android/cutils/log.h"
 

--- a/cocos/base/allocator/CCAllocatorStrategyGlobalSmallBlock.h
+++ b/cocos/base/allocator/CCAllocatorStrategyGlobalSmallBlock.h
@@ -32,7 +32,7 @@
  Do not use Console::log or any other methods that use NEW inside of this
  allocator. Failure to do so will result in recursive memory allocation.
  ****************************************************************************/
-
+#include <string.h>
 #include "base/allocator/CCAllocatorMacros.h"
 #include "base/allocator/CCAllocatorBase.h"
 #include "base/allocator/CCAllocatorGlobal.h"


### PR DESCRIPTION
This directive  #include <string.h> is used for memset(b, c, l).
Without it the attempt to install .apk (ex. cocos run . -p android --android-studio) is crashed.
Found in the downloaded from http://cocos2d-x.org/download version cocos2d-x-3.16