### PR TITLE
Fix endian detection on Android (fixes node render order)

### DIFF
--- a/cocos/base/ccMacros.h
+++ b/cocos/base/ccMacros.h
@@ -296,6 +296,9 @@ CC_ASSERT(__gl_error_code == GL_NO_ERROR, "Error"); \
   #endif
 #else
   #include <sys/param.h>
+  #if (CC_TARGET_PLATFORM == CC_PLATFORM_ANDROID)
+    #include <sys/endian.h>
+  #endif // CC_TARGET_PLATFORM == CC_PLATFORM_ANDROID
   #if ((defined(__LITTLE_ENDIAN__) && !defined(__BIG_ENDIAN__)) || \
          (defined(__BYTE_ORDER) && __BYTE_ORDER == __LITTLE_ENDIAN)) 
     #define CC_LITTLE_ENDIAN 1


### PR DESCRIPTION
When compiling for Android, the preprocessor defines for byte order are
are not included in the sys/param.h chain. By including sys/endian.h we
we can ensure that the necessary macros are included.

It is especially important that endian-ness is correctly detected as the
node render order uses this information to sort #16262. Without this
fix, nodes will be rendered in the incorrect order on 64-bit Android
devices (on 32-bit, a different algorithm is used that is not
sensitive to byte order).

I'm not sure if this is the best fix or if there are additional platforms
that are affected. I've only tested this on iOS and Android.