### PR TITLE
Fixed memory leak when using TTF labels

### DIFF
--- a/cocos/2d/CCLabel.cpp
+++ b/cocos/2d/CCLabel.cpp
@@ -438,7 +438,6 @@ Label::~Label()
     if (_fontAtlas)
     {
         Node::removeAllChildrenWithCleanup(true);
-        CC_SAFE_RELEASE_NULL(_reusedLetter);
         _batchNodes.clear();
         FontAtlasCache::releaseFontAtlas(_fontAtlas);
     }
@@ -447,6 +446,7 @@ Label::~Label()
 
     CC_SAFE_RELEASE_NULL(_textSprite);
     CC_SAFE_RELEASE_NULL(_shadowNode);
+    CC_SAFE_RELEASE_NULL(_reusedLetter);
 }
 
 void Label::reset()

--- a/cocos/2d/CCLabel.cpp
+++ b/cocos/2d/CCLabel.cpp
@@ -438,6 +438,7 @@ Label::~Label()
     if (_fontAtlas)
     {
         Node::removeAllChildrenWithCleanup(true);
+        CC_SAFE_RELEASE_NULL(_reusedLetter);
         _batchNodes.clear();
         FontAtlasCache::releaseFontAtlas(_fontAtlas);
     }
@@ -446,7 +447,6 @@ Label::~Label()
 
     CC_SAFE_RELEASE_NULL(_textSprite);
     CC_SAFE_RELEASE_NULL(_shadowNode);
-    CC_SAFE_RELEASE_NULL(_reusedLetter);
 }
 
 void Label::reset()
@@ -1373,7 +1373,7 @@ void Label::updateContent()
         if (_fontAtlas)
         {
             _batchNodes.clear();
-
+            CC_SAFE_RELEASE_NULL(_reusedLetter);
             FontAtlasCache::releaseFontAtlas(_fontAtlas);
             _fontAtlas = nullptr;
         }


### PR DESCRIPTION
This patch removes a memory leak that happened in Labels created using createWithTTF() method.

Tested on iOS (simulator & device (iPhone 6S, iOS 11.1.2).