### PR TITLE
Update default GLContextAttrs in CCGLView.cpp

### DIFF
--- a/cocos/platform/CCGLView.cpp
+++ b/cocos/platform/CCGLView.cpp
@@ -91,7 +91,7 @@ namespace {
 }
 
 //default context attributions are set as follows
-GLContextAttrs GLView::_glContextAttrs = {5, 6, 5, 0, 16, 0};
+GLContextAttrs GLView::_glContextAttrs = {8, 8, 8, 8, 24, 8};
 
 void GLView::setGLContextAttrs(GLContextAttrs& glContextAttrs)
 {


### PR DESCRIPTION
Kind of fix 10457.
It is a random outdated issue. 

It will not hurt to update the default GLContextAttrs to a more relevant {8, 8, 8, 8, 24, 8} and since this is set to {8, 8, 8, 8, 24, 8} in the default template in any case.

> void AppDelegate::initGLContextAttrs()
> {
>     // set OpenGL context attributes: red,green,blue,alpha,depth,stencil
>     GLContextAttrs glContextAttrs = {8, 8, 8, 8, 24, 8};
> 
>     GLView::setGLContextAttrs(glContextAttrs);
> }