### PR TITLE
add an empty create() method for UICCTextField

### DIFF
--- a/cocos/ui/UITextField.cpp
+++ b/cocos/ui/UITextField.cpp
@@ -46,6 +46,20 @@ UICCTextField::~UICCTextField()
 {
 }
 
+UICCTextField * UICCTextField::create()
+{
+    UICCTextField *pRet = new (std::nothrow) UICCTextField();
+    
+    if(pRet)
+    {
+        pRet->autorelease();
+        return pRet;
+    }
+    CC_SAFE_DELETE(pRet);
+    
+    return nullptr;
+}
+
 UICCTextField * UICCTextField::create(const std::string& placeholder, const std::string& fontName, float fontSize)
 {
     UICCTextField *pRet = new (std::nothrow) UICCTextField();
@@ -332,7 +346,7 @@ void TextField::onEnter()
 
 void TextField::initRenderer()
 {
-    _textFieldRenderer = UICCTextField::create("input words here", "Thonburi", 20);
+    _textFieldRenderer = UICCTextField::create();
     addProtectedChild(_textFieldRenderer, TEXTFIELD_RENDERER_Z, -1);
 }
 

--- a/cocos/ui/UITextField.cpp
+++ b/cocos/ui/UITextField.cpp
@@ -32,6 +32,20 @@ NS_CC_BEGIN
 
 namespace ui {
 
+UICCTextField * UICCTextField::create()
+{
+    UICCTextField *ret = new (std::nothrow) UICCTextField();
+
+    if(ret)
+    {
+        ret->autorelease();
+        return ret;
+    }
+    CC_SAFE_DELETE(ret);
+
+    return nullptr;
+}
+    
 UICCTextField::UICCTextField()
 : _maxLengthEnabled(false)
 , _maxLength(0)
@@ -44,20 +58,6 @@ UICCTextField::UICCTextField()
 
 UICCTextField::~UICCTextField()
 {
-}
-
-UICCTextField * UICCTextField::create()
-{
-    UICCTextField *pRet = new (std::nothrow) UICCTextField();
-    
-    if(pRet)
-    {
-        pRet->autorelease();
-        return pRet;
-    }
-    CC_SAFE_DELETE(pRet);
-    
-    return nullptr;
 }
 
 UICCTextField * UICCTextField::create(const std::string& placeholder, const std::string& fontName, float fontSize)

--- a/cocos/ui/UITextField.cpp
+++ b/cocos/ui/UITextField.cpp
@@ -37,13 +37,9 @@ UICCTextField * UICCTextField::create()
     UICCTextField *ret = new (std::nothrow) UICCTextField();
 
     if(ret)
-    {
         ret->autorelease();
-        return ret;
-    }
-    CC_SAFE_DELETE(ret);
 
-    return nullptr;
+    return ret;
 }
     
 UICCTextField::UICCTextField()

--- a/cocos/ui/UITextField.h
+++ b/cocos/ui/UITextField.h
@@ -47,6 +47,13 @@ class CC_GUI_DLL UICCTextField: public TextFieldTTF, public TextFieldDelegate
 {
 public:
     /**
+     * @brief Create an empty UICCTextField.
+     *
+     * @return A UICCTextField instance.
+     */
+    static UICCTextField* create();
+    
+    /**
      * Default constructor
      */
     UICCTextField();
@@ -57,13 +64,6 @@ public:
     ~UICCTextField();
     
     virtual void onEnter() override;
-    
-    /**
-     * @brief Create an empty UICCTextField.
-     *
-     * @return A UICCTextField instance.
-     */
-    static UICCTextField* create();
     
     /**
      * Create a UICCTextField instance with a placeholder, a fontName and a fontSize.

--- a/cocos/ui/UITextField.h
+++ b/cocos/ui/UITextField.h
@@ -59,6 +59,13 @@ public:
     virtual void onEnter() override;
     
     /**
+     *@brief Create an empty UICCTextField.
+     
+     *@return A UICCTextField instance.
+     */
+    static UICCTextField* create();
+    
+    /**
      * Create a UICCTextField instance with a placeholder, a fontName and a fontSize.
      *@param placeholder Placeholder in string.
      *@param fontName Font name in string.

--- a/cocos/ui/UITextField.h
+++ b/cocos/ui/UITextField.h
@@ -59,9 +59,9 @@ public:
     virtual void onEnter() override;
     
     /**
-     *@brief Create an empty UICCTextField.
-     
-     *@return A UICCTextField instance.
+     * @brief Create an empty UICCTextField.
+     *
+     * @return A UICCTextField instance.
      */
     static UICCTextField* create();
     


### PR DESCRIPTION
A create method with parameters is used In an empty init method, It will do something useless, and cause issues like https://github.com/cocos2d/cocos2d-x/issues/18403