### PR TITLE
fix : win32 system label has wrong scale factor

### DIFF
--- a/cocos/ui/UIEditBox/UIEditBoxImpl-win32.cpp
+++ b/cocos/ui/UIEditBox/UIEditBoxImpl-win32.cpp
@@ -72,7 +72,6 @@ namespace ui {
 
     EditBoxImplWin::EditBoxImplWin(EditBox* pEditText)
         : EditBoxImplCommon(pEditText),
-        _fontSize(40),
         _changedTextManually(false),
         _hasFocus(false)
     {
@@ -174,9 +173,8 @@ namespace ui {
 
     void EditBoxImplWin::setNativeFont(const char * pFontName, int fontSize)
     {
-        float factor = Director::getInstance()->getContentScaleFactor();
-        this->_fontSize = fontSize;
-        HFONT hFont = CreateFontW(static_cast<int>(fontSize * factor), 0, 0, 0, FW_NORMAL, FALSE, FALSE, FALSE, DEFAULT_CHARSET, OUT_OUTLINE_PRECIS,
+        auto glView = Director::getInstance()->getOpenGLView();
+        HFONT hFont = CreateFontW(static_cast<int>(fontSize * glView->getScaleX()), 0, 0, 0, FW_NORMAL, FALSE, FALSE, FALSE, DEFAULT_CHARSET, OUT_OUTLINE_PRECIS,
             CLIP_DEFAULT_PRECIS, ANTIALIASED_QUALITY, VARIABLE_PITCH, TEXT("Arial"));
 
         SendMessage(hwndEdit,             // Handle of edit control

--- a/cocos/ui/UIEditBox/UIEditBoxImpl-win32.cpp
+++ b/cocos/ui/UIEditBox/UIEditBoxImpl-win32.cpp
@@ -174,9 +174,9 @@ namespace ui {
 
     void EditBoxImplWin::setNativeFont(const char * pFontName, int fontSize)
     {
-        //not implemented yet
+        float factor = Director::getInstance()->getContentScaleFactor();
         this->_fontSize = fontSize;
-        HFONT hFont = CreateFontW(fontSize, 0, 0, 0, FW_NORMAL, FALSE, FALSE, FALSE, DEFAULT_CHARSET, OUT_OUTLINE_PRECIS,
+        HFONT hFont = CreateFontW(static_cast<int>(fontSize * factor), 0, 0, 0, FW_NORMAL, FALSE, FALSE, FALSE, DEFAULT_CHARSET, OUT_OUTLINE_PRECIS,
             CLIP_DEFAULT_PRECIS, ANTIALIASED_QUALITY, VARIABLE_PITCH, TEXT("Arial"));
 
         SendMessage(hwndEdit,             // Handle of edit control

--- a/cocos/ui/UIEditBox/UIEditBoxImpl-win32.h
+++ b/cocos/ui/UIEditBox/UIEditBoxImpl-win32.h
@@ -75,8 +75,6 @@ namespace ui {
         static LRESULT CALLBACK hookGLFWWindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam);
 
         HWND hwndEdit;
-        //FIXME: fontSize should be in parent class
-        int _fontSize;
         bool _changedTextManually;
         bool _hasFocus;
         static WNDPROC s_prevCocosWndProc;


### PR DESCRIPTION
How to reproduce:
1. new a c++ project
2. open `AppDelegate.cpp`, in function `bool AppDelegate::applicationDidFinishLaunching()`, modify
```c++
glview = GLViewImpl::createWithRect("projectname",
    cocos2d::Rect(0, 0, designResolutionSize.width, designResolutionSize.height));
```
to
```c++
glview = GLViewImpl::createWithRect("projectname",
    cocos2d::Rect(0, 0, designResolutionSize.width * 2, designResolutionSize.height * 2));
```
3. open `HelloWorld.cpp`, add the codes below into `bool HelloWorld::init()`
```c++
ui::EditBox *editBox = ui::EditBox::create(Size(120.0f, 20.0f), ui::Scale9Sprite::create());
this->addChild(editBox);
editBox->setPosition(Vec2(origin.x + visibleSize.width * 0.5f, origin.y + visibleSize.height * 0.5f));
```