### PR TITLE
Fix typo in the SkeletonAnimation::createWithFile

### DIFF
--- a/cocos/editor-support/spine/SkeletonAnimation.h
+++ b/cocos/editor-support/spine/SkeletonAnimation.h
@@ -61,7 +61,7 @@ public:
 		return SkeletonAnimation::createWithJsonFile(skeletonJsonFile, atlas, scale);
 	}
 	// Use createWithJsonFile instead
-	CC_DEPRECATED_ATTRIBUTE static SkeletonAnimation* createWithile (const std::string& skeletonJsonFile, const std::string& atlasFile, float scale = 1)
+	CC_DEPRECATED_ATTRIBUTE static SkeletonAnimation* createWithFile (const std::string& skeletonJsonFile, const std::string& atlasFile, float scale = 1)
 	{
 		return SkeletonAnimation::createWithJsonFile(skeletonJsonFile, atlasFile, scale);
 	}


### PR DESCRIPTION
Same PR has been opened for spine-runtimes repo:
https://github.com/EsotericSoftware/spine-runtimes/pull/1045