### PR TITLE
Fixes ResizableBufferAdapter<Data>::resize doesn't consider the situation of new size which is lower than old size.

### DIFF
--- a/cocos/platform/CCFileUtils.h
+++ b/cocos/platform/CCFileUtils.h
@@ -103,7 +103,8 @@ class ResizableBufferAdapter<Data> : public ResizableBuffer {
 public:
     explicit ResizableBufferAdapter(BufferType* buffer) : _buffer(buffer) {}
     virtual void resize(size_t size) override {
-        if (static_cast<size_t>(_buffer->getSize()) < size) {
+        size_t oldSize = static_cast<size_t>(_buffer->getSize());
+        if (oldSize != size) {
             auto old = _buffer->getBytes();
             void* buffer = realloc(old, size);
             if (buffer)

--- a/tests/cpp-tests/Classes/UnitTest/UnitTest.cpp
+++ b/tests/cpp-tests/Classes/UnitTest/UnitTest.cpp
@@ -52,6 +52,7 @@ UnitTests::UnitTests()
     ADD_TEST_CASE(UTFConversionTest);
     ADD_TEST_CASE(UIHelperSubStringTest);
     ADD_TEST_CASE(ParseUriTest);
+    ADD_TEST_CASE(ResizableBufferAdapterTest);
 #ifdef UNIT_TEST_FOR_OPTIMIZED_MATH_UTIL
     ADD_TEST_CASE(MathUtilTest);
 #endif
@@ -1664,3 +1665,29 @@ std::string MathUtilTest::subtitle() const
 {
     return "MathUtilTest";
 }
+
+// ResizableBufferAdapterTest
+
+void ResizableBufferAdapterTest::onEnter()
+{
+    UnitTestDemo::onEnter();
+
+    Data data;
+    ResizableBufferAdapter<Data> buffer(&data);
+
+    FileUtils::getInstance()->getContents("effect1.wav", &buffer);
+    EXPECT_EQ(data.getSize(), 10026);
+
+    FileUtils::getInstance()->getContents("effect2.ogg", &buffer);
+    EXPECT_EQ(data.getSize(), 4278);
+
+    FileUtils::getInstance()->getContents("effect1.wav", &buffer);
+    EXPECT_EQ(data.getSize(), 10026);
+}
+
+std::string ResizableBufferAdapterTest::subtitle() const
+{
+    return "ResiziableBufferAdapter<Data> Test";
+}
+
+

--- a/tests/cpp-tests/Classes/UnitTest/UnitTest.h
+++ b/tests/cpp-tests/Classes/UnitTest/UnitTest.h
@@ -71,4 +71,13 @@ public:
     virtual std::string subtitle() const override;
 };
 
+class ResizableBufferAdapterTest : public UnitTestDemo
+{
+public:
+    CREATE_FUNC(ResizableBufferAdapterTest);
+    virtual void onEnter() override;
+    virtual std::string subtitle() const override;
+};
+
+
 #endif /* __UNIT_TEST__ */


### PR DESCRIPTION
Fixed https://github.com/cocos-creator/cocos2d-x-lite/issues/1023