### PR TITLE
Partial cursor support for text field with system font

### DIFF
--- a/cocos/2d/CCTextFieldTTF.cpp
+++ b/cocos/2d/CCTextFieldTTF.cpp
@@ -567,7 +567,7 @@ void TextFieldTTF::makeStringSupportCursor(std::string& displayText)
         {
             // \b - Next char not change x position
             if (_currentLabelType == LabelType::TTF)
-			    displayText.push_back((char) TextFormatter::NextCharNoChangeX);
+                displayText.push_back((char) TextFormatter::NextCharNoChangeX);
             displayText.push_back(_cursorChar);
         }
         else
@@ -582,8 +582,8 @@ void TextFieldTTF::makeStringSupportCursor(std::string& displayText)
             }
             std::string cursorChar;
             // \b - Next char not change x position
-			if (_currentLabelType == LabelType::TTF)
-				cursorChar.push_back((char)TextFormatter::NextCharNoChangeX);
+            if (_currentLabelType == LabelType::TTF)
+                cursorChar.push_back((char)TextFormatter::NextCharNoChangeX);
             cursorChar.push_back(_cursorChar);
             stringUTF8.insert(_cursorPosition, cursorChar);
 
@@ -681,24 +681,22 @@ const std::string& TextFieldTTF::getPlaceHolder() const
 
 void TextFieldTTF::setCursorEnabled(bool enabled)
 {
-	if (_cursorEnabled != enabled)
-	{
-	    _cursorEnabled = enabled;
-	    if (_cursorEnabled)
-	    {
-	        _cursorPosition = _charCount;
-	
-			if (_currentLabelType == LabelType::TTF)
-				scheduleUpdate();
-	    }
-	    else
-	    {
-	        _cursorPosition = 0;
-	
-			if (_currentLabelType == LabelType::TTF)
-				unscheduleUpdate();
-	    }
-	}
+    if (_cursorEnabled != enabled)
+    {
+        _cursorEnabled = enabled;
+        if (_cursorEnabled)
+        {
+            _cursorPosition = _charCount;
+            if (_currentLabelType == LabelType::TTF)
+                scheduleUpdate();
+        }
+        else
+        {
+            _cursorPosition = 0;
+            if (_currentLabelType == LabelType::TTF)
+                unscheduleUpdate();
+        }
+    }
 }
 
 // secureTextEntry

--- a/cocos/2d/CCTextFieldTTF.cpp
+++ b/cocos/2d/CCTextFieldTTF.cpp
@@ -566,7 +566,8 @@ void TextFieldTTF::makeStringSupportCursor(std::string& displayText)
         if (displayText.empty())
         {
             // \b - Next char not change x position
-            displayText.push_back((char)TextFormatter::NextCharNoChangeX);
+            if (_currentLabelType == LabelType::TTF)
+			    displayText.push_back((char) TextFormatter::NextCharNoChangeX);
             displayText.push_back(_cursorChar);
         }
         else
@@ -581,7 +582,8 @@ void TextFieldTTF::makeStringSupportCursor(std::string& displayText)
             }
             std::string cursorChar;
             // \b - Next char not change x position
-            cursorChar.push_back((char)TextFormatter::NextCharNoChangeX);
+			if (_currentLabelType == LabelType::TTF)
+				cursorChar.push_back((char)TextFormatter::NextCharNoChangeX);
             cursorChar.push_back(_cursorChar);
             stringUTF8.insert(_cursorPosition, cursorChar);
 
@@ -679,29 +681,24 @@ const std::string& TextFieldTTF::getPlaceHolder() const
 
 void TextFieldTTF::setCursorEnabled(bool enabled)
 {
-    if (_currentLabelType == LabelType::TTF)
-    {
-        if (_cursorEnabled != enabled)
-        {
-            _cursorEnabled = enabled;
-            if (_cursorEnabled)
-            {
-                _cursorPosition = _charCount;
-
-                scheduleUpdate();
-            }
-            else
-            {
-                _cursorPosition = 0;
-
-                unscheduleUpdate();
-            }
-        }
-    }
-    else
-    {
-        CCLOG("TextFieldTTF cursor worked only LabelType::TTF");
-    }
+	if (_cursorEnabled != enabled)
+	{
+	    _cursorEnabled = enabled;
+	    if (_cursorEnabled)
+	    {
+	        _cursorPosition = _charCount;
+	
+			if (_currentLabelType == LabelType::TTF)
+				scheduleUpdate();
+	    }
+	    else
+	    {
+	        _cursorPosition = 0;
+	
+			if (_currentLabelType == LabelType::TTF)
+				unscheduleUpdate();
+	    }
+	}
 }
 
 // secureTextEntry


### PR DESCRIPTION
Enables cursor support without cursor blinking an zero with of cursor symbol. In case of system font usage magical "/b" symbol won't be used, also update won't be scheduled.
Issue #18554