### PR TITLE
Fix different behaviour of WebView::shouldStartLoading callback

### DIFF
--- a/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxWebView.java
+++ b/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxWebView.java
@@ -110,7 +110,8 @@ public class Cocos2dxWebView extends WebView {
                 Log.d(TAG, "'shouldOverrideUrlLoading' failed");
             }
 
-            return result[0];
+            final boolean willOverrideLoading = !result[0];
+            return willOverrideLoading;
         }
 
         @Override


### PR DESCRIPTION
**Problem**:  from `cocos2d-x` documentation:
```
/**
 * Call before a web view begins loading.
 *
 * @param callback The web view that is about to load new content.
 * @return YES if the web view should begin loading content; otherwise, NO.
 */
void setOnShouldStartLoading(const std::function<bool(WebView *sender, const std::string &url)>& callback);
```
So if `OnShouldStartLoading` callback returns `false` then WebView stops loading content.
Unfortunately depending on the same return value of `OnShouldStartLoading` callback `WebView` behavior for redirect urls is different.

**Reason**: 
Lets assume `OnShouldStartLoading` returns `true` (load any url including redirects) and check native implementation:
iOS:
```Obj-C
- (BOOL)webView:(UIWebView *)webView shouldStartLoadWithRequest:(NSURLRequest *)request navigationType:(UIWebViewNavigationType)navigationType {
    NSString *url = [[request URL] absoluteString];
    if ([[[request URL] scheme] isEqualToString:self.jsScheme]) {
        self.onJsCallback([url UTF8String]);
        return NO;
    }
    if (self.shouldStartLoading && url) {
        return self.shouldStartLoading([url UTF8String]);
    }
    return YES;
}
```

[From Apple documentation](https://developer.apple.com/documentation/uikit/uiwebviewdelegate/1617945-webview?language=objc) about `webView:shouldStartLoadWithRequest:navigationType:`:
>Return Value
>YES if the web view should begin loading content; otherwise, NO .

So the implantation is correct:
- [x] return `NO` if URL has pre-set `jsScheme`
- [x] return `OnShouldStartLoading ` callback value (which would be YES)
- [x] return `YES` on default

Android:
```Java
class Cocos2dxWebViewClient extends WebViewClient {
        @Override
        public boolean shouldOverrideUrlLoading(WebView view, final String urlString) {
            Cocos2dxActivity activity = (Cocos2dxActivity)getContext();

            try {
                URI uri = URI.create(urlString);
                if (uri != null && uri.getScheme().equals(mJSScheme)) {
                    activity.runOnGLThread(new Runnable() {
                        @Override
                        public void run() {
                            Cocos2dxWebViewHelper._onJsCallback(mViewTag, urlString);
                        }
                    });
                    return true;
                }
            } catch (Exception e) {
                Log.d(TAG, "Failed to create URI from url");
            }

            boolean[] result = new boolean[] { true };
            CountDownLatch latch = new CountDownLatch(1);

            // run worker on cocos thread
            activity.runOnGLThread(new ShouldStartLoadingWorker(latch, result, mViewTag, urlString));

            // wait for result from cocos thread
            try {
                latch.await();
            } catch (InterruptedException ex) {
                Log.d(TAG, "'shouldOverrideUrlLoading' failed");
            }

            return result[0];
        }
        ...
    }
```

[From Android documentation](https://developer.android.com/reference/android/webkit/WebViewClient.html#shouldOverrideUrlLoading(android.webkit.WebView,%20java.lang.String)) about `WebViewClient . shouldOverrideUrlLoading `:
>Give the host application a chance to take over the control when a new url is about to be loaded in the current WebView. If WebViewClient is not provided, by default WebView will ask Activity Manager to choose the proper handler for the url. If WebViewClient is provided, return true means the host application handles the url, while return false means the current WebView handles the url. This method is not called for requests using the POST "method".

In other words this method should return `true` if application side would want to stop `WebView` loading process and `false` 

So the implementation is partly correct:
So the implantation is correct:
- [x] return `true` if URL has pre-set `jsScheme` (true means **stop** loading)
- [ ] return `OnShouldStartLoading ` callback value (which would be YES)
- [ ] return true on default (which will stop of url loading)

**Solution**: invert `result` value so behavior would be the same