### PR TITLE
Fix cocos2d::EditBox padding

### DIFF
--- a/cocos/ui/UIEditBox/UIEditBoxImpl-common.cpp
+++ b/cocos/ui/UIEditBox/UIEditBoxImpl-common.cpp
@@ -144,12 +144,12 @@ void EditBoxImplCommon::setInactiveText(const char* pText)
         _label->setString(pText);
     }
     // Clip the text width to fit to the text box
-    float fMaxWidth = _editBox->getContentSize().width;
-    float fMaxHeight = _editBox->getContentSize().height;
+    const auto& editBoxSize = _editBox->getContentSize();
+    const auto maxSize = applyPadding(cocos2d::Size(editBoxSize.width, editBoxSize.height));
     Size labelSize = _label->getContentSize();
-    if(labelSize.width > fMaxWidth || labelSize.height > fMaxHeight)
+    if(labelSize.width > maxSize.width || labelSize.height > maxSize.height)
     {
-        _label->setDimensions(fMaxWidth, fMaxHeight);
+        _label->setDimensions(maxSize.width, maxSize.height);
     }
 }
     
@@ -201,7 +201,7 @@ void EditBoxImplCommon::setInputMode(EditBox::InputMode inputMode)
 {
     _editBoxInputMode = inputMode;
     this->setNativeInputMode(inputMode);
-    this->placeInactiveLabels(_editBox->getContentSize());
+    this->placeInactiveLabels(applyPadding(_editBox->getContentSize()));
 }
 
 void EditBoxImplCommon::setMaxLength(int maxLength)
@@ -282,9 +282,9 @@ void EditBoxImplCommon::setVisible(bool visible)
 
 void EditBoxImplCommon::setContentSize(const Size& size)
 {
-    _contentSize = size;
-    CCLOG("[Edit text] content size = (%f, %f)", size.width, size.height);
-    placeInactiveLabels(size);
+    _contentSize = applyPadding(size);
+    CCLOG("[Edit text] content size = (%f, %f)", _contentSize.width, _contentSize.height);
+    placeInactiveLabels(_contentSize);
 }
 
 void EditBoxImplCommon::draw(Renderer* /*renderer*/, const Mat4& /*transform*/, uint32_t flags)
@@ -411,6 +411,11 @@ void EditBoxImplCommon::editBoxEditingChanged(const std::string& text)
 }
 
 
+}
+
+Size ui::EditBoxImplCommon::applyPadding(const Size& sizeToCorrect) const {
+  constexpr auto paddingLeftRight = CC_EDIT_BOX_PADDING * 2;
+  return Size(sizeToCorrect.width - paddingLeftRight, sizeToCorrect.height);
 }
 
 NS_CC_END

--- a/cocos/ui/UIEditBox/UIEditBoxImpl-common.h
+++ b/cocos/ui/UIEditBox/UIEditBoxImpl-common.h
@@ -136,6 +136,8 @@ protected:
     void         placeInactiveLabels(const Size& size);
     virtual void doAnimationWhenKeyboardMove(float duration, float distance)override {};
 
+    Size applyPadding(const Size& size) const;
+  
     Label* _label;
     Label* _labelPlaceHolder;
     EditBox::InputMode    _editBoxInputMode;


### PR DESCRIPTION
**Problem:**
<img width="882" alt="1" src="https://user-images.githubusercontent.com/2925354/34082427-f831f64c-e366-11e7-972a-eb6ac49204b1.png">
`cocos2d::EditBox` has padding: `static const int CC_EDIT_BOX_PADDING = 5;` and it does not count it when applying width size for labels
**Steps to reproduce:** simply create edit box and enter more characters then you can see on screen
**Solution:** track all changes of content size and apply padding:
<img width="882" alt="2" src="https://user-images.githubusercontent.com/2925354/34082438-2ca97c74-e367-11e7-876b-be021a221384.png">