### PR TITLE
improvements for EditBox-win32

### DIFF
--- a/cocos/ui/UIEditBox/UIEditBoxImpl-win32.cpp
+++ b/cocos/ui/UIEditBox/UIEditBoxImpl-win32.cpp
@@ -53,16 +53,14 @@ namespace ui {
     void EditBoxImplWin::lazyInit()
     {
         s_hwndCocos = cocos2d::Director::getInstance()->getOpenGLView()->getWin32Window();
-        LONG style = GetWindowLong(s_hwndCocos, GWL_STYLE);
-        SetWindowLong(s_hwndCocos, GWL_STYLE, style | WS_CLIPCHILDREN);
+        LONG style = ::GetWindowLongW(s_hwndCocos, GWL_STYLE);
+        ::SetWindowLongW(s_hwndCocos, GWL_STYLE, style | WS_CLIPCHILDREN);
         s_isInitialized = true;
         s_previousFocusWnd = s_hwndCocos;
 
-        s_hInstance = GetModuleHandle(NULL);
+        s_hInstance = ::GetModuleHandleW(nullptr);
 
-
-        s_prevCocosWndProc = (WNDPROC)SetWindowLongPtr(s_hwndCocos, GWL_WNDPROC, (LONG_PTR)hookGLFWWindowProc);
-
+        s_prevCocosWndProc = (WNDPROC)SetWindowLongPtrW(s_hwndCocos, GWL_WNDPROC, (LONG_PTR)hookGLFWWindowProc);
     }
 
     EditBoxImpl* __createSystemEditBox(EditBox* pEditBox)
@@ -73,7 +71,8 @@ namespace ui {
     EditBoxImplWin::EditBoxImplWin(EditBox* pEditText)
         : EditBoxImplCommon(pEditText),
         _changedTextManually(false),
-        _hasFocus(false)
+        _hasFocus(false),
+        _endAction(EditBoxDelegate::EditBoxEndAction::UNKNOWN)
     {
         if (!s_isInitialized)
         {
@@ -81,14 +80,12 @@ namespace ui {
         }
 
         s_editboxChildID++;
-
     }
 
     EditBoxImplWin::~EditBoxImplWin()
     {
         this->cleanupEditCtrl();
     }
-
 
     bool EditBoxImplWin::isEditing()
     {
@@ -97,26 +94,26 @@ namespace ui {
 
     void EditBoxImplWin::cleanupEditCtrl()
     {
-        if (hwndEdit)
+        if (_hwndEdit)
         {
-            SetWindowLongPtr(hwndEdit, GWL_WNDPROC, (LONG_PTR)_prevWndProc);
-            DestroyWindow(hwndEdit);
+            SetWindowLongPtrW(_hwndEdit, GWL_WNDPROC, (LONG_PTR)_prevWndProc);
+            ::DestroyWindow(_hwndEdit);
             _hasFocus = false;
             _changedTextManually = false;
             _editingMode = false;
-            hwndEdit = NULL;
+            _hwndEdit = NULL;
         }
     }
 
-    void EditBoxImplWin::createSingleLineEditCtrl()
+    void EditBoxImplWin::createEditCtrl(bool singleLine)
     {
         this->cleanupEditCtrl();
-        if (!hwndEdit)
+        if (!_hwndEdit)
         {
-            hwndEdit = CreateWindowEx(
+            _hwndEdit = ::CreateWindowExW(
                 WS_EX_CLIENTEDGE, L"EDIT",   // predefined class 
                 NULL,         // no window title 
-                WS_CHILD | ES_LEFT | WS_BORDER | WS_EX_TRANSPARENT | WS_TABSTOP | ES_AUTOHSCROLL,
+                WS_CHILD | ES_LEFT | WS_BORDER | WS_EX_TRANSPARENT | WS_TABSTOP | ES_AUTOHSCROLL | (singleLine ? 0 : ES_MULTILINE),
                 0,
                 0,
                 0,
@@ -126,70 +123,40 @@ namespace ui {
                 s_hInstance,
                 this);        // pointer not needed 
 
-            SetWindowLongPtr(hwndEdit, GWL_USERDATA, (LONG_PTR)this);
-            _prevWndProc = (WNDPROC)SetWindowLongPtr(hwndEdit, GWL_WNDPROC, (LONG_PTR)WindowProc);
+            SetWindowLongPtrW(_hwndEdit, GWL_USERDATA, (LONG_PTR)this);
+            _prevWndProc = (WNDPROC)SetWindowLongPtrW(_hwndEdit, GWL_WNDPROC, (LONG_PTR)WindowProc);
 
-            ::SendMessageW(hwndEdit, EM_LIMITTEXT, this->_maxLength, 0);
+            ::SendMessageW(_hwndEdit, EM_LIMITTEXT, this->_maxLength, 0);
             s_previousFocusWnd = s_hwndCocos;
             this->setNativeFont(this->getNativeDefaultFontName(), this->_fontSize);
             this->setNativeText(this->_text.c_str());
         }
     }
 
-    void EditBoxImplWin::createMultilineEditCtrl()
+    void EditBoxImplWin::createNativeControl(const Rect& frame)
     {
-        this->cleanupEditCtrl();
-        if (!hwndEdit)
-        {
-            hwndEdit = CreateWindowEx(
-                WS_EX_CLIENTEDGE, L"EDIT",   // predefined class 
-                NULL,         // no window title 
-                WS_CHILD | ES_LEFT | WS_BORDER | WS_EX_TRANSPARENT | WS_TABSTOP | ES_MULTILINE | ES_AUTOVSCROLL,
-                0,
-                0,
-                0,
-                0,   // set size in WM_SIZE message 
-                s_hwndCocos,         // parent window 
-                (HMENU)s_editboxChildID,   // edit control ID 
-                s_hInstance,
-                this);        // pointer not needed 
-
-                              //register new window proc func
-            SetWindowLongPtr(hwndEdit, GWL_USERDATA, (LONG_PTR)this);
-            _prevWndProc = (WNDPROC)SetWindowLongPtr(hwndEdit, GWL_WNDPROC, (LONG_PTR)WindowProc);
-            s_previousFocusWnd = s_hwndCocos;
-            ::SendMessageW(hwndEdit, EM_LIMITTEXT, this->_maxLength, 0);
-            this->setNativeFont(this->getNativeDefaultFontName(), this->_fontSize);
-            this->setNativeText(this->_text.c_str());
-
-        }
+        this->createEditCtrl(false);
     }
 
-    void EditBoxImplWin::createNativeControl(const Rect & frame)
-    {
-
-        this->createMultilineEditCtrl();
-    }
-
-    void EditBoxImplWin::setNativeFont(const char * pFontName, int fontSize)
+    void EditBoxImplWin::setNativeFont(const char* pFontName, int fontSize)
     {
         auto glView = Director::getInstance()->getOpenGLView();
-        HFONT hFont = CreateFontW(static_cast<int>(fontSize * glView->getScaleX()), 0, 0, 0, FW_NORMAL, FALSE, FALSE, FALSE, DEFAULT_CHARSET, OUT_OUTLINE_PRECIS,
-            CLIP_DEFAULT_PRECIS, ANTIALIASED_QUALITY, VARIABLE_PITCH, TEXT("Arial"));
+        HFONT hFont = ::CreateFontW(static_cast<int>(fontSize * glView->getScaleX()), 0, 0, 0, FW_NORMAL, FALSE, FALSE, FALSE, DEFAULT_CHARSET, OUT_OUTLINE_PRECIS,
+            CLIP_DEFAULT_PRECIS, ANTIALIASED_QUALITY, VARIABLE_PITCH, L"Arial");
 
-        SendMessage(hwndEdit,             // Handle of edit control
+        ::SendMessageW(_hwndEdit,             // Handle of edit control
             WM_SETFONT,         // Message to change the font
             (WPARAM)hFont,     // handle of the font
             MAKELPARAM(TRUE, 0) // Redraw text
         );
     }
 
-    void EditBoxImplWin::setNativeFontColor(const Color4B & color)
+    void EditBoxImplWin::setNativeFontColor(const Color4B& color)
     {
         //not implemented yet
     }
 
-    void EditBoxImplWin::setNativePlaceholderFont(const char * pFontName, int fontSize)
+    void EditBoxImplWin::setNativePlaceholderFont(const char* pFontName, int fontSize)
     {
         //not implemented yet
     }
@@ -203,118 +170,145 @@ namespace ui {
     {
         if (_editBoxInputMode == cocos2d::ui::EditBox::InputMode::ANY)
         {
-            this->createMultilineEditCtrl();
+            this->createEditCtrl(false);
         }
         else if (_editBoxInputMode == cocos2d::ui::EditBox::InputMode::NUMERIC
             || _editBoxInputMode == cocos2d::ui::EditBox::InputMode::DECIMAL
             || _editBoxInputMode == cocos2d::ui::EditBox::InputMode::PHONE_NUMBER)
         {
-            this->createSingleLineEditCtrl();
-            ::SetWindowLongW(hwndEdit, GWL_STYLE, ::GetWindowLongW(hwndEdit, GWL_STYLE) | ES_NUMBER);
+            this->createEditCtrl(true);
+            ::SetWindowLongW(_hwndEdit, GWL_STYLE, ::GetWindowLongW(_hwndEdit, GWL_STYLE) | ES_NUMBER);
         }
         else
         {
-            this->createSingleLineEditCtrl();
+            this->createEditCtrl(true);
         }
 
         if (this->_editBoxInputFlag != cocos2d::ui::EditBox::InputFlag::PASSWORD)
         {
-            PostMessage(hwndEdit, EM_SETPASSWORDCHAR, (WPARAM)0, (LPARAM)0);
+            ::PostMessageW(_hwndEdit, EM_SETPASSWORDCHAR, (WPARAM)0, (LPARAM)0);
         }
     }
     void EditBoxImplWin::setNativeInputFlag(EditBox::InputFlag inputFlag)
     {
         if (inputFlag == EditBox::InputFlag::PASSWORD)
         {
-            this->createSingleLineEditCtrl();
+            this->createEditCtrl(true);
         }
-       
         else
         {
             if (_editBoxInputMode != cocos2d::ui::EditBox::InputMode::ANY)
             {
-                this->createSingleLineEditCtrl();
+                this->createEditCtrl(true);
 
                 if (inputFlag == EditBox::InputFlag::INITIAL_CAPS_ALL_CHARACTERS)
                 {
-                    ::SetWindowLongW(hwndEdit, GWL_STYLE, ::GetWindowLongW(hwndEdit, GWL_STYLE) | ES_UPPERCASE);
+                    ::SetWindowLongW(_hwndEdit, GWL_STYLE, ::GetWindowLongW(_hwndEdit, GWL_STYLE) | ES_UPPERCASE);
                 }
                 // Clear the password style
-                PostMessage(hwndEdit, EM_SETPASSWORDCHAR, (WPARAM)0, (LPARAM)0);
+                ::PostMessageW(_hwndEdit, EM_SETPASSWORDCHAR, (WPARAM)0, (LPARAM)0);
             }
         }
     }
+
     void EditBoxImplWin::setNativeReturnType(EditBox::KeyboardReturnType returnType)
     {
         //not implemented yet
     }
+
+    void EditBoxImplWin::setNativeTextHorizontalAlignment(TextHAlignment alignment)
+    {
+        LONG style = ::GetWindowLongW(_hwndEdit, GWL_STYLE);
+        switch (alignment)
+        {
+        case TextHAlignment::LEFT:
+            style |= ES_LEFT;
+            style &= ~ES_CENTER;
+            style &= ~ES_RIGHT;
+            break;
+        case TextHAlignment::CENTER:
+            style &= ~ES_LEFT;
+            style |= ES_CENTER;
+            style &= ~ES_RIGHT;
+            break;
+        case TextHAlignment::RIGHT:
+            style &= ~ES_LEFT;
+            style &= ~ES_CENTER;
+            style |= ES_RIGHT;
+            break;
+        }
+        ::SetWindowLongW(_hwndEdit, GWL_STYLE, style);
+    }
+
     void EditBoxImplWin::setNativeText(const char* pText)
     {
         std::u16string utf16Result;
         std::string text(pText);
         cocos2d::StringUtils::UTF8ToUTF16(text, utf16Result);
         this->_changedTextManually = true;
-        ::SetWindowTextW(hwndEdit, (LPCWSTR)utf16Result.c_str());
+        ::SetWindowTextW(_hwndEdit, (LPCWSTR)utf16Result.c_str());
         int textLen = text.size();
-        SendMessage(hwndEdit, EM_SETSEL, textLen, textLen);
+        ::SendMessageW(_hwndEdit, EM_SETSEL, textLen, textLen);
+
         if (_editBoxInputMode == cocos2d::ui::EditBox::InputMode::ANY)
         {
-            SendMessage(hwndEdit, EM_SCROLLCARET, 0, 0);
+            ::SendMessageW(_hwndEdit, EM_SCROLLCARET, 0, 0);
         }
     }
+
     void EditBoxImplWin::setNativePlaceHolder(const char* pText)
     {
         //not implemented yet
     }
+
     void EditBoxImplWin::setNativeVisible(bool visible)
     {
         if (visible)
         {
-            ::ShowWindow(hwndEdit, SW_SHOW);
+            ::ShowWindow(_hwndEdit, SW_SHOW);
         }
         else
         {
-            ::ShowWindow(hwndEdit, SW_HIDE);
+            ::ShowWindow(_hwndEdit, SW_HIDE);
         }
     }
-    void EditBoxImplWin::updateNativeFrame(const Rect& rect)
 
+    void EditBoxImplWin::updateNativeFrame(const Rect& rect)
     {
         ::SetWindowPos(
-            hwndEdit,
+            _hwndEdit,
             HWND_NOTOPMOST,
             rect.origin.x,
             rect.origin.y,
             rect.size.width,
             rect.size.height,
             SWP_NOZORDER);
-
     }
+
     const char* EditBoxImplWin::getNativeDefaultFontName()
     {
         return "Arial";
     }
+
     void EditBoxImplWin::nativeOpenKeyboard()
     {
-        ::PostMessage(hwndEdit, WM_SETFOCUS, (WPARAM)s_previousFocusWnd, 0);
+        ::PostMessageW(_hwndEdit, WM_SETFOCUS, (WPARAM)s_previousFocusWnd, 0);
 //        s_previousFocusWnd = hwndEdit;
         this->editBoxEditingDidBegin();
 
         auto rect = ui::Helper::convertBoundingBoxToScreen(_editBox);
         this->updateNativeFrame(rect);
-
     }
+
     void EditBoxImplWin::nativeCloseKeyboard()
     {
         //don't need to implement
     }
+
     void EditBoxImplWin::setNativeMaxLength(int maxLength)
     {
-
-        ::SendMessageW(hwndEdit, EM_LIMITTEXT, maxLength, 0);
-
+        ::SendMessageW(_hwndEdit, EM_LIMITTEXT, maxLength, 0);
     }
-
 
     void EditBoxImplWin::_WindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
     {
@@ -325,8 +319,32 @@ namespace ui {
             {
                 if (_editBoxInputMode != cocos2d::ui::EditBox::InputMode::ANY) {
                     if (s_previousFocusWnd != s_hwndCocos) {
+                        switch (_keyboardReturnType)
+                        {
+                        case EditBox::KeyboardReturnType::DEFAULT:
+                            _endAction = EditBoxDelegate::EditBoxEndAction::UNKNOWN;
+                            break;
+                        case EditBox::KeyboardReturnType::DONE:
+                            _endAction = EditBoxDelegate::EditBoxEndAction::RETURN;
+                            break;
+                        case EditBox::KeyboardReturnType::SEND:
+                            _endAction = EditBoxDelegate::EditBoxEndAction::RETURN;
+                            break;
+                        case EditBox::KeyboardReturnType::SEARCH:
+                            _endAction = EditBoxDelegate::EditBoxEndAction::RETURN;
+                            break;
+                        case EditBox::KeyboardReturnType::GO:
+                            _endAction = EditBoxDelegate::EditBoxEndAction::RETURN;
+                            break;
+                        case EditBox::KeyboardReturnType::NEXT:
+                            _endAction = EditBoxDelegate::EditBoxEndAction::TAB_TO_NEXT;
+                            break;
+                        default:
+                            _endAction = EditBoxDelegate::EditBoxEndAction::UNKNOWN;
+                            break;
+                        }
                         ::ShowWindow(s_previousFocusWnd, SW_HIDE);
-                        ::SendMessage(s_hwndCocos, WM_SETFOCUS, (WPARAM)s_previousFocusWnd, 0);
+                        ::SendMessageW(s_hwndCocos, WM_SETFOCUS, (WPARAM)s_previousFocusWnd, 0);
                         s_previousFocusWnd = s_hwndCocos;
                     }
                 }
@@ -335,38 +353,35 @@ namespace ui {
         case WM_SETFOCUS:
             if (hwnd != s_previousFocusWnd)
             {
-                ::PostMessage(hwnd, WM_ACTIVATE, (WPARAM)s_previousFocusWnd, 0);
-                ::PostMessage(hwnd, WM_SETCURSOR, (WPARAM)s_previousFocusWnd, 0);
-                s_previousFocusWnd = hwndEdit;
+                ::PostMessageW(hwnd, WM_ACTIVATE, (WPARAM)s_previousFocusWnd, 0);
+                ::PostMessageW(hwnd, WM_SETCURSOR, (WPARAM)s_previousFocusWnd, 0);
+                s_previousFocusWnd = _hwndEdit;
                 _hasFocus = true;
                 this->_changedTextManually = false;
             }
-           
             break;
         case WM_KILLFOCUS:
             _hasFocus = false;
             //when app enter background, this message also be called.
-            if (this->_editingMode && !IsWindowVisible(hwnd))
+            if (this->_editingMode && !::IsWindowVisible(hwnd))
             {
-                this->editBoxEditingDidEnd(this->getText());
+                this->editBoxEditingDidEnd(this->getText(), _endAction);
             }
             break;
         default:
             break;
-
         }
     }
 
-    std::string EditBoxImplWin::getText()const
+    std::string EditBoxImplWin::getText() const
     {
         std::u16string wstrResult;
         std::string utf8Result;
 
-
-        int inputLength = ::GetWindowTextLengthW(this->hwndEdit);
+        int inputLength = ::GetWindowTextLengthW(_hwndEdit);
         wstrResult.resize(inputLength);
 
-        ::GetWindowTextW(this->hwndEdit, (LPWSTR) const_cast<char16_t*>(wstrResult.c_str()), inputLength + 1);
+        ::GetWindowTextW(_hwndEdit, (LPWSTR)&wstrResult[0], inputLength + 1);
         bool conversionResult = cocos2d::StringUtils::UTF16ToUTF8(wstrResult, utf8Result);
         if (!conversionResult)
         {
@@ -381,7 +396,7 @@ namespace ui {
         {
         case WM_COMMAND:
             if (HIWORD(wParam) == EN_CHANGE) {
-                EditBoxImplWin* pThis = (EditBoxImplWin*)GetWindowLongPtr((HWND)lParam, GWLP_USERDATA);
+                EditBoxImplWin* pThis = (EditBoxImplWin*)GetWindowLongPtrW((HWND)lParam, GWLP_USERDATA);
                 if (pThis && !pThis->_changedTextManually)
                 {
                     pThis->editBoxEditingChanged(pThis->getText());
@@ -394,7 +409,7 @@ namespace ui {
             if (s_previousFocusWnd != s_hwndCocos) {
                 ::ShowWindow(s_previousFocusWnd, SW_HIDE);
 
-                EditBoxImplWin* pThis = (EditBoxImplWin*)GetWindowLongPtr(s_previousFocusWnd, GWLP_USERDATA);
+                EditBoxImplWin* pThis = (EditBoxImplWin*)GetWindowLongPtrW(s_previousFocusWnd, GWLP_USERDATA);
                 if (!pThis->_hasFocus)
                 {
                     if (pThis->_editingMode && !IsWindowVisible(s_previousFocusWnd))
@@ -404,7 +419,7 @@ namespace ui {
                 }
                 else
                 {
-                    ::PostMessage(s_hwndCocos, WM_SETFOCUS, (WPARAM)s_previousFocusWnd, 0);
+                    ::PostMessageW(s_hwndCocos, WM_SETFOCUS, (WPARAM)s_previousFocusWnd, 0);
                 }
                 s_previousFocusWnd = s_hwndCocos;
             }
@@ -414,19 +429,18 @@ namespace ui {
             break;
         }
 
-        return CallWindowProc(s_prevCocosWndProc, hwnd, uMsg, wParam, lParam);
+        return ::CallWindowProcW(s_prevCocosWndProc, hwnd, uMsg, wParam, lParam);
     }
 
     LRESULT EditBoxImplWin::WindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
     {
-        EditBoxImplWin* pThis = (EditBoxImplWin*)GetWindowLongPtr(hwnd, GWLP_USERDATA);
+        EditBoxImplWin* pThis = (EditBoxImplWin*)GetWindowLongPtrW(hwnd, GWLP_USERDATA);
         if (pThis)
         {
             pThis->_WindowProc(hwnd, uMsg, wParam, lParam);
         }
 
-        return CallWindowProc(pThis->_prevWndProc, hwnd, uMsg, wParam, lParam);
-
+        return ::CallWindowProcW(pThis->_prevWndProc, hwnd, uMsg, wParam, lParam);
     }
 }
 

--- a/cocos/ui/UIEditBox/UIEditBoxImpl-win32.cpp
+++ b/cocos/ui/UIEditBox/UIEditBoxImpl-win32.cpp
@@ -222,19 +222,13 @@ namespace ui {
         switch (alignment)
         {
         case TextHAlignment::LEFT:
-            style |= ES_LEFT;
-            style &= ~ES_CENTER;
-            style &= ~ES_RIGHT;
+            style = (style & ~ES_CENTER & ~ES_RIGHT) | ES_LEFT;
             break;
         case TextHAlignment::CENTER:
-            style &= ~ES_LEFT;
-            style |= ES_CENTER;
-            style &= ~ES_RIGHT;
+            style = (style & ~ES_LEFT & ~ES_RIGHT) | ES_CENTER;
             break;
         case TextHAlignment::RIGHT:
-            style &= ~ES_LEFT;
-            style &= ~ES_CENTER;
-            style |= ES_RIGHT;
+            style = (style & ~ES_LEFT & ~ES_CENTER) | ES_RIGHT;
             break;
         }
         ::SetWindowLongW(_hwndEdit, GWL_STYLE, style);

--- a/cocos/ui/UIEditBox/UIEditBoxImpl-win32.h
+++ b/cocos/ui/UIEditBox/UIEditBoxImpl-win32.h
@@ -52,8 +52,8 @@ namespace ui {
         virtual void setNativePlaceholderFontColor(const Color4B& color) override;
         virtual void setNativeInputMode(EditBox::InputMode inputMode) override;
         virtual void setNativeInputFlag(EditBox::InputFlag inputFlag) override;
-        virtual void setNativeReturnType(EditBox::KeyboardReturnType returnType)override;
-        virtual void setNativeTextHorizontalAlignment(cocos2d::TextHAlignment alignment) {}
+        virtual void setNativeReturnType(EditBox::KeyboardReturnType returnType) override;
+        virtual void setNativeTextHorizontalAlignment(TextHAlignment alignment) override;
         virtual void setNativeText(const char* pText) override;
         virtual void setNativePlaceHolder(const char* pText) override;
         virtual void setNativeVisible(bool visible) override;
@@ -61,22 +61,22 @@ namespace ui {
         virtual const char* getNativeDefaultFontName() override;
         virtual void nativeOpenKeyboard() override;
         virtual void nativeCloseKeyboard() override;
-        virtual void setNativeMaxLength(int maxLength);
+        virtual void setNativeMaxLength(int maxLength) override;
 
     private:
-        void createSingleLineEditCtrl();
-        void createMultilineEditCtrl();
+        void createEditCtrl(bool singleLine);
         void cleanupEditCtrl();
         std::string getText() const;
-        void  _WindowProc(HWND, UINT, WPARAM, LPARAM);
+        void _WindowProc(HWND, UINT, WPARAM, LPARAM);
 
         WNDPROC _prevWndProc;
         static LRESULT CALLBACK WindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam);
         static LRESULT CALLBACK hookGLFWWindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam);
 
-        HWND hwndEdit;
+        HWND _hwndEdit;
         bool _changedTextManually;
         bool _hasFocus;
+        EditBoxDelegate::EditBoxEndAction _endAction;
         static WNDPROC s_prevCocosWndProc;
 
         static HINSTANCE s_hInstance;
@@ -94,3 +94,4 @@ NS_CC_END
 #endif /* (CC_TARGET_PLATFORM == CC_PLATFORM_WIN32) */
 
 #endif /* __UIEditBoxIMPLWIN_H__ */
+

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIEditBoxTest.cpp
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIEditBoxTest.cpp
@@ -33,6 +33,7 @@ UIEditBoxTests::UIEditBoxTests()
 {
     ADD_TEST_CASE(UIEditBoxTest);
     ADD_TEST_CASE(UIEditBoxTestToggleVisibility);
+    ADD_TEST_CASE(UIEditBoxTestTextHorizontalAlignment);
 }
 
 // UIEditBoxTest
@@ -173,6 +174,7 @@ void UIEditBoxTest::editBoxReturn(ui::EditBox* editBox)
     }
 }
 
+// UIEditBoxTestToggleVisibility
 
 bool UIEditBoxTestToggleVisibility::init()
 {
@@ -301,4 +303,69 @@ void UIEditBoxTestToggleVisibility::editBoxReturn(ui::EditBox* editBox)
     {
         _TTFShowEditReturn->setString("Email EditBox return !");
     }
+}
+
+// UIEditBoxTestTextHorizontalAlignment
+
+bool UIEditBoxTestTextHorizontalAlignment::init()
+{
+    if (UIScene::init())
+    {
+        auto glview = Director::getInstance()->getOpenGLView();
+        auto visibleOrigin = glview->getVisibleOrigin();
+        auto visibleSize = glview->getVisibleSize();
+
+        auto pBg = Sprite::create("Images/HelloWorld.png");
+        pBg->setPosition(Vec2(visibleOrigin.x+visibleSize.width/2, visibleOrigin.y+visibleSize.height/2));
+        addChild(pBg);
+
+        auto editBoxSize = Size(visibleSize.width - 100, visibleSize.height * 0.1);
+
+        // top
+        std::string pNormalSprite = "extensions/green_edit.png";
+        ui::EditBox* editName = ui::EditBox::create(editBoxSize + Size(0,40), ui::Scale9Sprite::create(pNormalSprite));
+        editName->setPosition(Vec2(visibleOrigin.x+visibleSize.width/2-50, visibleOrigin.y+visibleSize.height*3/4));
+        editName->setFontColor(Color3B::RED);
+        editName->setPlaceHolder("Name:");
+        editName->setPlaceholderFontColor(Color3B::WHITE);
+        editName->setMaxLength(8);
+        editName->setFontSize(editBoxSize.height/2);
+        editName->setTextHorizontalAlignment(TextHAlignment::LEFT);
+        editName->setText("v👐👊💝");
+        editName->setReturnType(ui::EditBox::KeyboardReturnType::DONE);
+        addChild(editName);
+
+        // middle
+        ui::EditBox* editPassword = ui::EditBox::create(editBoxSize, "extensions/orange_edit.png");
+        editPassword->setPosition(Vec2(visibleOrigin.x+visibleSize.width/2-50, visibleOrigin.y+visibleSize.height/2));
+        editPassword->setFontColor(Color3B::GREEN);
+        editPassword->setPlaceHolder("Password:");
+        editPassword->setMaxLength(6);
+        editPassword->setInputFlag(ui::EditBox::InputFlag::PASSWORD);
+        editPassword->setInputMode(ui::EditBox::InputMode::SINGLE_LINE);
+        editPassword->setFontSize(editBoxSize.height/2);
+        editPassword->setTextHorizontalAlignment(TextHAlignment::CENTER);
+        addChild(editPassword);
+
+        // bottom
+        // Add an intermediate Node to test scaling and content size relative to world
+        Node* editEmailParent = Node::create();
+//        _editEmailParent->setScale(0.5);
+        editEmailParent->setPosition(Vec2(visibleOrigin.x+visibleSize.width/2-50, visibleOrigin.y+visibleSize.height/4));
+        addChild(editEmailParent);
+
+        auto bottomButtonSize = Size(editBoxSize.width, editBoxSize.height + 10);
+        ui::EditBox* editEmail = ui::EditBox::create(bottomButtonSize, "extensions/yellow_edit.png");
+        editEmail->setPlaceHolder("Email:");
+        editEmail->setInputMode(ui::EditBox::InputMode::EMAIL_ADDRESS);
+        editEmail->setVisible(true);
+        editEmailParent->addChild(editEmail);
+        //It is required to use setFontSize and setContentSize after adding it to the hierarchy, so that native EditBox get the right size
+        editEmail->setFontSize(30);
+        editEmail->setContentSize(bottomButtonSize);
+        editEmail->setTextHorizontalAlignment(TextHAlignment::RIGHT);
+
+        return true;
+    }
+    return false;
 }

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIEditBoxTest.h
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIEditBoxTest.h
@@ -72,4 +72,12 @@ protected:
     cocos2d::Node* _editEmailParent;
 };
 
+class UIEditBoxTestTextHorizontalAlignment : public UIScene
+{
+public:
+    CREATE_FUNC(UIEditBoxTestTextHorizontalAlignment);
+    
+    virtual bool init() override;
+};
+
 #endif /* defined(__cocos2d_tests__UIEditBoxTest__) */


### PR DESCRIPTION
1. add support for **setNativeTextHorizontalAlignment**
2. add support for **EditBoxEndAction**
3. merge `createSingleLineEditCtrl` and `createMultilineEditCtrl` into one function
4. add :: for Windows api calls and use wide-character versions explicitly
5. replace member variable `hwndEdit` with `_hwndEdit` to match the global coding style
6. replace `const_cast<char16_t*>(wstrResult.c_str())` with `(LPWSTR)&wstrResult[0]`