### PR TITLE
update [fix warnings] ,correct old warning fix for spine

### DIFF
--- a/cocos/editor-support/spine/SkeletonJson.c
+++ b/cocos/editor-support/spine/SkeletonJson.c
@@ -408,14 +408,14 @@ static spAnimation* _spSkeletonJson_readAnimation (spSkeletonJson* self, Json* r
 					if (!vertices) {
 						if (weighted) {
 							deform2 = tempDeform;
-							memset(deform, 0, sizeof(float) * deformLength);
+							memset(deform2, 0, sizeof(float) * deformLength);
 						} else
 							deform2 = attachment->vertices;
 					} else {
 						int v, start = Json_getInt(valueMap, "offset", 0);
 						Json* vertex;
 						deform2 = tempDeform;
-						memset(deform, 0, sizeof(float) * start);
+						memset(deform2, 0, sizeof(float) * start);
 						if (self->scale == 1) {
 							for (vertex = vertices->child, v = start; vertex; vertex = vertex->next, ++v)
 								deform2[v] = vertex->valueFloat;
@@ -423,7 +423,7 @@ static spAnimation* _spSkeletonJson_readAnimation (spSkeletonJson* self, Json* r
 							for (vertex = vertices->child, v = start; vertex; vertex = vertex->next, ++v)
 								deform2[v] = vertex->valueFloat * self->scale;
 						}
-						memset(deform + v, 0, sizeof(float) * (deformLength - v));
+						memset(deform2 + v, 0, sizeof(float) * (deformLength - v));
 						if (!weighted) {
 							float* verticesAttachment = attachment->vertices;
 							for (v = 0; v < deformLength; ++v)

--- a/cocos/editor-support/spine/SkeletonRenderer.cpp
+++ b/cocos/editor-support/spine/SkeletonRenderer.cpp
@@ -253,7 +253,7 @@ void SkeletonRenderer::draw (Renderer* renderer, const Mat4& transform, uint32_t
 				trianglesTwoColor.indexCount = attachmentVertices->_triangles->indexCount;
 				trianglesTwoColor.verts = twoColorBatch->allocateVertices(attachmentVertices->_triangles->vertCount);
 				trianglesTwoColor.vertCount = attachmentVertices->_triangles->vertCount;
-				for (int ii = 0; i < trianglesTwoColor.vertCount; ii++) {
+				for (int ii = 0; ii < trianglesTwoColor.vertCount; ii++) {
 					trianglesTwoColor.verts[ii].texCoords = attachmentVertices->_triangles->verts[ii].texCoords;
 				}
 				spVertexAttachment_computeWorldVertices(SUPER(attachment), slot, 0, trianglesTwoColor.vertCount * sizeof(V3F_C4B_C4B_T2F) / 4, (float*)trianglesTwoColor.verts, 0, 7);


### PR DESCRIPTION
fix warnings #18499 have some defect,  at that commit, variable name is modified, but some places where the variable was quoted were not modified at the same time.