### PR TITLE
spine res name update, because files name changed before

### DIFF
--- a/tests/cpp-tests/Classes/MaterialSystemTest/MaterialSystemTest.cpp
+++ b/tests/cpp-tests/Classes/MaterialSystemTest/MaterialSystemTest.cpp
@@ -464,7 +464,7 @@ void Material_invalidate::onEnter()
     sprite->runAction(repeat);
 
     // SPINE
-    auto skeletonNode = spine::SkeletonAnimation::createWithJsonFile("spine/goblins_mesh.json", "spine/goblins.atlas", 1.5f);
+    auto skeletonNode = spine::SkeletonAnimation::createWithJsonFile("spine/goblins-pro.json", "spine/goblins.atlas", 1.5f);
     skeletonNode->setAnimation(0, "walk", true);
     skeletonNode->setSkin("goblin");
 
@@ -533,7 +533,7 @@ void Material_renderState::onEnter()
     sprite->runAction(repeat);
 
     // SPINE
-    auto skeletonNode = spine::SkeletonAnimation::createWithJsonFile("spine/goblins_mesh.json", "spine/goblins.atlas", 1.5f);
+    auto skeletonNode = spine::SkeletonAnimation::createWithJsonFile("spine/goblins-pro.json", "spine/goblins.atlas", 1.5f);
     skeletonNode->setAnimation(0, "walk", true);
     skeletonNode->setSkin("goblin");
 

--- a/tests/cpp-tests/Classes/Scene3DTest/Scene3DTest.cpp
+++ b/tests/cpp-tests/Classes/Scene3DTest/Scene3DTest.cpp
@@ -704,7 +704,7 @@ void Scene3DTestScene::createDetailDlg()
     
     // add a spine ffd animation on it
     auto skeletonNode =
-        SkeletonAnimationCullingFix::createWithFile("spine/goblins_mesh.json", "spine/goblins.atlas", 1.5f);
+        SkeletonAnimationCullingFix::createWithFile("spine/goblins-pro.json", "spine/goblins.atlas", 1.5f);
     skeletonNode->setAnimation(0, "walk", true);
     skeletonNode->setSkin("goblin");
     

--- a/tests/js-tests/src/tests_resources.js
+++ b/tests/js-tests/src/tests_resources.js
@@ -705,7 +705,7 @@ var g_spine = [
     "spine/sprite.png",
     "spine/goblins.png",
     "spine/goblins.atlas",
-    "spine/goblins_mesh.json"
+    "spine/goblins-pro.json"
 ];
 
 if (!cc.sys.isNative) {

--- a/tests/lua-tests/src/Scene3DTest/Scene3DTest.lua
+++ b/tests/lua-tests/src/Scene3DTest/Scene3DTest.lua
@@ -510,7 +510,7 @@ function Scene3DTest:createDetailDlg()
     self._detailDlg:addChild(title)
     
     -- add a spine ffd animation on it
-    local skeletonNode = sp.SkeletonAnimation:create("spine/goblins_mesh.json", "spine/goblins.atlas", 1.5)
+    local skeletonNode = sp.SkeletonAnimation:create("spine/goblins-pro.json", "spine/goblins.atlas", 1.5)
     skeletonNode:setAnimation(0, "walk", true)
     skeletonNode:setSkin("goblin")
 


### PR DESCRIPTION
spine resource name update, because files name changed in old commits, however the name in code __didn't changed completely__.

without this update, `1.Node: Scene3D` in `cpp-tests`  project will crash when loading spine resource: __spine/goblins_mesh.json__.