### PR TITLE
Added support for BMFont in TextField

### DIFF
--- a/cocos/2d/CCLabel.cpp
+++ b/cocos/2d/CCLabel.cpp
@@ -1779,13 +1779,15 @@ Sprite* Label::getLetter(int letterIndex)
                 }
                 else
                 {
+                    this->updateBMFontScale();
                     letter = LabelLetter::createWithTexture(_fontAtlas->getTexture(textureID), uvRect);
                     letter->setTextureAtlas(_batchNodes.at(textureID)->getTextureAtlas());
                     letter->setAtlasIndex(letterInfo.atlasIndex);
-                    auto px = letterInfo.positionX + uvRect.size.width / 2 + _linesOffsetX[letterInfo.lineIndex];
-                    auto py = letterInfo.positionY - uvRect.size.height / 2 + _letterOffsetY;
+                    auto px = letterInfo.positionX + _bmfontScale * uvRect.size.width / 2 + _linesOffsetX[letterInfo.lineIndex];
+                    auto py = letterInfo.positionY - _bmfontScale * uvRect.size.height / 2 + _letterOffsetY;
                     letter->setPosition(px,py);
                     letter->setOpacity(_realOpacity);
+                    this->updateLetterSpriteScale(letter);
                 }
                 
                 addChild(letter);

--- a/cocos/2d/CCTextFieldTTF.cpp
+++ b/cocos/2d/CCTextFieldTTF.cpp
@@ -170,9 +170,8 @@ bool TextFieldTTF::initWithPlaceHolder(const std::string& placeholder, const std
         setSystemFontSize(fontSize);
 
     } while (false);
-
-
-    Label::setTextColor(_colorSpaceHolder);
+    
+    setTextColorInternally(_colorSpaceHolder);
     Label::setString(_placeHolder);
 
 #if (CC_TARGET_PLATFORM == CC_PLATFORM_MAC || CC_TARGET_PLATFORM == CC_PLATFORM_WIN32 || CC_TARGET_PLATFORM == CC_PLATFORM_LINUX)
@@ -270,7 +269,7 @@ void TextFieldTTF::insertText(const char * text, size_t len)
             stringUTF8.replace(_inputText);
             stringUTF8.insert(_cursorPosition, insert);
 
-            setCursorPosition(_cursorPosition + countInsertChar);            
+            setCursorPosition(_cursorPosition + countInsertChar);
 
             setString(stringUTF8.getAsCharSequence());
         }
@@ -422,12 +421,22 @@ void TextFieldTTF::setAttachWithIME(bool isAttachWithIME)
     }
 }
 
+void TextFieldTTF::setTextColorInternally(const Color4B& color)
+{
+    if (_currentLabelType == LabelType::BMFONT) {
+        Label::setColor(Color3B(color));
+        return;
+    }
+    
+    Label::setTextColor(color);
+}
+
 void TextFieldTTF::setTextColor(const Color4B &color)
 {
     _colorText = color;
-    if (!_inputText.empty()) 
+    if (!_inputText.empty())
     {
-        Label::setTextColor(_colorText);
+        setTextColorInternally(color);
     }
 }
 
@@ -454,6 +463,9 @@ void TextFieldTTF::update(float delta)
 
         if (sprite)
         {
+            if (_currentLabelType == LabelType::BMFONT) {
+                sprite->setColor(getColor());
+            }
             if (_cursorShowingTime >= 0.0f)
             {
                 sprite->setOpacity(255);
@@ -474,14 +486,7 @@ const Color4B& TextFieldTTF::getColorSpaceHolder()
 
 void TextFieldTTF::setColorSpaceHolder(const Color3B& color)
 {
-    _colorSpaceHolder.r = color.r;
-    _colorSpaceHolder.g = color.g;
-    _colorSpaceHolder.b = color.b;
-    _colorSpaceHolder.a = 255;
-    if (_inputText.empty())
-    {
-        Label::setTextColor(_colorSpaceHolder);
-    }
+    setColorSpaceHolder(Color4B(color));
 }
 
 void TextFieldTTF::setColorSpaceHolder(const Color4B& color)
@@ -489,7 +494,7 @@ void TextFieldTTF::setColorSpaceHolder(const Color4B& color)
     _colorSpaceHolder = color;
     if (_inputText.empty())
     {
-        Label::setTextColor(_colorSpaceHolder);
+        setTextColorInternally(_colorSpaceHolder);
     }
 }
 
@@ -539,14 +544,13 @@ void TextFieldTTF::setString(const std::string &text)
     // if there is no input text, display placeholder instead
     if (_inputText.empty() && (!_cursorEnabled || !_isAttachWithIME))
     {
-        Label::setTextColor(_colorSpaceHolder);
+        setTextColorInternally(_colorSpaceHolder);
         Label::setString(_placeHolder);
     }
     else
     {
         makeStringSupportCursor(displayText);
-
-        Label::setTextColor(_colorText);
+        setTextColorInternally(_colorText);
         Label::setString(displayText);
     }
     _charCount = charCount;
@@ -669,7 +673,7 @@ void TextFieldTTF::setPlaceHolder(const std::string& text)
     _placeHolder = text;
     if (_inputText.empty() && !_isAttachWithIME)
     {
-        Label::setTextColor(_colorSpaceHolder);
+        setTextColorInternally(_colorSpaceHolder);
         Label::setString(_placeHolder);
     }
 }
@@ -681,21 +685,24 @@ const std::string& TextFieldTTF::getPlaceHolder() const
 
 void TextFieldTTF::setCursorEnabled(bool enabled)
 {
-    if (_cursorEnabled != enabled)
+    if (_cursorEnabled == enabled)
     {
-        _cursorEnabled = enabled;
-        if (_cursorEnabled)
-        {
-            _cursorPosition = _charCount;
-            if (_currentLabelType == LabelType::TTF)
-                scheduleUpdate();
+        return;
+    }
+    
+    _cursorEnabled = enabled;
+    if (_cursorEnabled)
+    {
+        _cursorPosition = _charCount;
+        if (_currentLabelType == LabelType::TTF || _currentLabelType == LabelType::BMFONT) {
+            scheduleUpdate();
         }
-        else
-        {
-            _cursorPosition = 0;
-            if (_currentLabelType == LabelType::TTF)
-                unscheduleUpdate();
-        }
+        return;
+    }
+    
+    _cursorPosition = 0;
+    if (_currentLabelType == LabelType::TTF || _currentLabelType == LabelType::BMFONT) {
+            unscheduleUpdate();
     }
 }
 
@@ -733,3 +740,4 @@ bool TextFieldTTF::isSecureTextEntry() const
 }
 
 NS_CC_END
+

--- a/cocos/2d/CCTextFieldTTF.cpp
+++ b/cocos/2d/CCTextFieldTTF.cpp
@@ -570,7 +570,7 @@ void TextFieldTTF::makeStringSupportCursor(std::string& displayText)
         if (displayText.empty())
         {
             // \b - Next char not change x position
-            if (_currentLabelType == LabelType::TTF)
+            if (_currentLabelType == LabelType::TTF || _currentLabelType == LabelType::BMFONT)
                 displayText.push_back((char) TextFormatter::NextCharNoChangeX);
             displayText.push_back(_cursorChar);
         }
@@ -586,7 +586,7 @@ void TextFieldTTF::makeStringSupportCursor(std::string& displayText)
             }
             std::string cursorChar;
             // \b - Next char not change x position
-            if (_currentLabelType == LabelType::TTF)
+            if (_currentLabelType == LabelType::TTF || _currentLabelType == LabelType::BMFONT)
                 cursorChar.push_back((char)TextFormatter::NextCharNoChangeX);
             cursorChar.push_back(_cursorChar);
             stringUTF8.insert(_cursorPosition, cursorChar);
@@ -702,7 +702,7 @@ void TextFieldTTF::setCursorEnabled(bool enabled)
     
     _cursorPosition = 0;
     if (_currentLabelType == LabelType::TTF || _currentLabelType == LabelType::BMFONT) {
-            unscheduleUpdate();
+        unscheduleUpdate();
     }
 }
 

--- a/cocos/2d/CCTextFieldTTF.h
+++ b/cocos/2d/CCTextFieldTTF.h
@@ -279,6 +279,7 @@ protected:
     void makeStringSupportCursor(std::string& displayText);
     void updateCursorDisplayText();
     void setAttachWithIME(bool isAttachWithIME);
+    void setTextColorInternally(const Color4B& color);
 
 private:
     class LengthStack;

--- a/cocos/ui/UITextField.cpp
+++ b/cocos/ui/UITextField.cpp
@@ -446,6 +446,9 @@ void TextField::setFontSize(int size)
     {
         _textFieldRenderer->setSystemFontSize(size);
     }
+    else if (_fontType == FontType::BMFONT) {
+        _textFieldRenderer->setBMFontSize(size);
+    }
     else
     {
         TTFConfig config = _textFieldRenderer->getTTFConfig();
@@ -466,11 +469,17 @@ void TextField::setFontName(const std::string& name)
 {
     if(FileUtils::getInstance()->isFileExist(name))
     {
-        TTFConfig config = _textFieldRenderer->getTTFConfig();
-        config.fontFilePath = name;
-        config.fontSize = _fontSize;
-        _textFieldRenderer->setTTFConfig(config);
-        _fontType = FontType::TTF;
+        if (name.find(".fnt") != std::string::npos) {
+            _textFieldRenderer->setBMFontFilePath(name);
+            _fontType = FontType::BMFONT;
+        }
+        else {
+            TTFConfig config = _textFieldRenderer->getTTFConfig();
+            config.fontFilePath = name;
+            config.fontSize = _fontSize;
+            _textFieldRenderer->setTTFConfig(config);
+            _fontType = FontType::TTF;
+        }
     }
     else
     {

--- a/cocos/ui/UITextField.cpp
+++ b/cocos/ui/UITextField.cpp
@@ -469,7 +469,9 @@ void TextField::setFontName(const std::string& name)
 {
     if(FileUtils::getInstance()->isFileExist(name))
     {
-        if (name.find(".fnt") != std::string::npos) {
+        std::string lcName = name;
+        std::transform(lcName.begin(), lcName.end(), lcName.begin(), ::tolower);
+        if(lcName.substr(lcName.length() - 4) == ".fnt") {
             _textFieldRenderer->setBMFontFilePath(name);
             _fontType = FontType::BMFONT;
         }

--- a/cocos/ui/UITextField.cpp
+++ b/cocos/ui/UITextField.cpp
@@ -316,6 +316,20 @@ TextField* TextField::create(const std::string &placeholder, const std::string &
     return nullptr;
 }
     
+TextField* TextField::createWithBMFont(const std::string &placeholder, const std::string &fontName)
+{
+    TextField* widget = new (std::nothrow) TextField();
+    if (widget && widget->init())
+    {
+        widget->setFontName(fontName);
+        widget->setPlaceHolder(placeholder);
+        widget->autorelease();
+        return widget;
+    }
+    CC_SAFE_DELETE(widget);
+    return nullptr;
+}
+    
 bool TextField::init()
 {
     if (Widget::init())

--- a/cocos/ui/UITextField.cpp
+++ b/cocos/ui/UITextField.cpp
@@ -316,20 +316,6 @@ TextField* TextField::create(const std::string &placeholder, const std::string &
     return nullptr;
 }
     
-TextField* TextField::createWithBMFont(const std::string &placeholder, const std::string &fontName)
-{
-    TextField* widget = new (std::nothrow) TextField();
-    if (widget && widget->init())
-    {
-        widget->setFontName(fontName);
-        widget->setPlaceHolder(placeholder);
-        widget->autorelease();
-        return widget;
-    }
-    CC_SAFE_DELETE(widget);
-    return nullptr;
-}
-    
 bool TextField::init()
 {
     if (Widget::init())

--- a/cocos/ui/UITextField.h
+++ b/cocos/ui/UITextField.h
@@ -694,7 +694,8 @@ private:
     enum class FontType
     {
         SYSTEM,
-        TTF
+        TTF,
+        BMFONT
     };
 
     std::string _fontName;

--- a/cocos/ui/UITextField.h
+++ b/cocos/ui/UITextField.h
@@ -300,6 +300,15 @@ public:
                              int fontSize);
     
     /**
+     * @brief Create a TextField with a placeholder and a font name.
+     *
+     * @param placeholder The placeholder string.
+     * @param fontName The font name.
+     * @return A TextField instance.
+     */
+    static TextField* createWithBMFont(const std::string& placeholder, const std::string& fontName);
+    
+    /**
      * @brief Set the touch size
      * The touch size is used for @see `hitTest`.
      * @param size A delimitation zone.

--- a/cocos/ui/UITextField.h
+++ b/cocos/ui/UITextField.h
@@ -300,15 +300,6 @@ public:
                              int fontSize);
     
     /**
-     * @brief Create a TextField with a placeholder and a font name.
-     *
-     * @param placeholder The placeholder string.
-     * @param fontName The font name.
-     * @return A TextField instance.
-     */
-    static TextField* createWithBMFont(const std::string& placeholder, const std::string& fontName);
-    
-    /**
      * @brief Set the touch size
      * The touch size is used for @see `hitTest`.
      * @param size A delimitation zone.

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UITextFieldTest/UITextFieldTest.cpp
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UITextFieldTest/UITextFieldTest.cpp
@@ -446,8 +446,8 @@ bool UITextFieldTest_BMFont::init()
         _uiLayer->addChild(alert);
         
         // Create the textfield
-        TextField* textField = TextField::create("input words here","fonts/markerFelt.fnt",25);
-        
+        TextField* textField = TextField::create("input words here","fonts/bitmapFontTest3.fnt",14);
+        textField->setCursorEnabled(true);
         textField->setPosition(Vec2(widgetSize.width / 2.0f, widgetSize.height / 2.0f));
         textField->addEventListener(CC_CALLBACK_2(UITextFieldTest_BMFont::textFieldEvent, this));
         _uiLayer->addChild(textField);

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UITextFieldTest/UITextFieldTest.cpp
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UITextFieldTest/UITextFieldTest.cpp
@@ -446,7 +446,7 @@ bool UITextFieldTest_BMFont::init()
         _uiLayer->addChild(alert);
         
         // Create the textfield
-        TextField* textField = TextField::create("input words here","fonts/bitmapFontTest3.fnt",14);
+        TextField* textField = TextField::createWithBMFont("input words here","fonts/bitmapFontTest3.fnt");
         textField->setCursorEnabled(true);
         textField->setPosition(Vec2(widgetSize.width / 2.0f, widgetSize.height / 2.0f));
         textField->addEventListener(CC_CALLBACK_2(UITextFieldTest_BMFont::textFieldEvent, this));

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UITextFieldTest/UITextFieldTest.cpp
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UITextFieldTest/UITextFieldTest.cpp
@@ -10,6 +10,7 @@ UITextFieldTests::UITextFieldTests()
     ADD_TEST_CASE(UITextFieldTest_Password);
     ADD_TEST_CASE(UITextFieldTest_LineWrap);
     ADD_TEST_CASE(UITextFieldTest_TrueTypeFont);
+    ADD_TEST_CASE(UITextFieldTest_BMFont);
     ADD_TEST_CASE(UITextFieldTest_PlaceHolderColor);
 }
 
@@ -390,6 +391,82 @@ void UITextFieldTest_TrueTypeFont::textFieldEvent(Ref *pSender, TextField::Event
             Size screenSize = Director::getInstance()->getWinSize();
             textField->runAction(MoveTo::create(0.225f,
                                                   Vec2(screenSize.width / 2.0f, screenSize.height / 2.0f + textField->getContentSize().height / 2.0f)));
+            _displayValueLabel->setString(StringUtils::format("attach with IME"));
+        }
+            break;
+            
+        case TextField::EventType::DETACH_WITH_IME:
+        {
+            TextField* textField = dynamic_cast<TextField*>(pSender);
+            Size screenSize = Director::getInstance()->getWinSize();
+            textField->runAction(MoveTo::create(0.175f, Vec2(screenSize.width / 2.0f, screenSize.height / 2.0f)));
+            _displayValueLabel->setString(StringUtils::format("detach with IME"));
+        }
+            break;
+            
+        case TextField::EventType::INSERT_TEXT:
+            _displayValueLabel->setString(StringUtils::format("insert words"));
+            break;
+            
+        case TextField::EventType::DELETE_BACKWARD:
+            _displayValueLabel->setString(StringUtils::format("delete word"));
+            break;
+            
+        default:
+            break;
+    }
+}
+
+// UITextFieldTest_BMFont
+UITextFieldTest_BMFont::UITextFieldTest_BMFont()
+: _displayValueLabel(nullptr)
+{
+    
+}
+
+UITextFieldTest_BMFont::~UITextFieldTest_BMFont()
+{
+}
+
+bool UITextFieldTest_BMFont::init()
+{
+    if (UIScene::init())
+    {
+        Size widgetSize = _widget->getContentSize();
+        
+        // Add a label in which the textfield events will be displayed
+        _displayValueLabel = Text::create("BMFont Test - No Event","fonts/Marker Felt.ttf",32);
+        _displayValueLabel->setAnchorPoint(Vec2(0.5f, -1.0f));
+        _displayValueLabel->setPosition(Vec2(widgetSize.width / 2.0f, widgetSize.height / 2.0f + _displayValueLabel->getContentSize().height * 1.5f));
+        _uiLayer->addChild(_displayValueLabel);
+        
+        // Add the alert
+        Text* alert = Text::create("TextField","fonts/Marker Felt.ttf",30);
+        alert->setPosition(Vec2(widgetSize.width / 2.0f, widgetSize.height / 2.0f - alert->getContentSize().height * 3.075f));
+        _uiLayer->addChild(alert);
+        
+        // Create the textfield
+        TextField* textField = TextField::create("input words here","fonts/markerFelt.fnt",25);
+        
+        textField->setPosition(Vec2(widgetSize.width / 2.0f, widgetSize.height / 2.0f));
+        textField->addEventListener(CC_CALLBACK_2(UITextFieldTest_BMFont::textFieldEvent, this));
+        _uiLayer->addChild(textField);
+        
+        return true;
+    }
+    return false;
+}
+
+void UITextFieldTest_BMFont::textFieldEvent(Ref *pSender, TextField::EventType type)
+{
+    switch (type)
+    {
+        case TextField::EventType::ATTACH_WITH_IME:
+        {
+            TextField* textField = dynamic_cast<TextField*>(pSender);
+            Size screenSize = Director::getInstance()->getWinSize();
+            textField->runAction(MoveTo::create(0.225f,
+                                                Vec2(screenSize.width / 2.0f, screenSize.height / 2.0f + textField->getContentSize().height / 2.0f)));
             _displayValueLabel->setString(StringUtils::format("attach with IME"));
         }
             break;

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UITextFieldTest/UITextFieldTest.cpp
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UITextFieldTest/UITextFieldTest.cpp
@@ -446,7 +446,7 @@ bool UITextFieldTest_BMFont::init()
         _uiLayer->addChild(alert);
         
         // Create the textfield
-        TextField* textField = TextField::createWithBMFont("input words here","fonts/bitmapFontTest3.fnt");
+        TextField* textField = TextField::create("input words here","fonts/bitmapFontTest3.fnt",14);
         textField->setCursorEnabled(true);
         textField->setPosition(Vec2(widgetSize.width / 2.0f, widgetSize.height / 2.0f));
         textField->addEventListener(CC_CALLBACK_2(UITextFieldTest_BMFont::textFieldEvent, this));

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UITextFieldTest/UITextFieldTest.cpp
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UITextFieldTest/UITextFieldTest.cpp
@@ -446,7 +446,7 @@ bool UITextFieldTest_BMFont::init()
         _uiLayer->addChild(alert);
         
         // Create the textfield
-        TextField* textField = TextField::create("input words here","fonts/bitmapFontTest3.fnt",14);
+        TextField* textField = TextField::create("BMFont Text","fonts/bitmapFontTest3.fnt",30);
         textField->setCursorEnabled(true);
         textField->setPosition(Vec2(widgetSize.width / 2.0f, widgetSize.height / 2.0f));
         textField->addEventListener(CC_CALLBACK_2(UITextFieldTest_BMFont::textFieldEvent, this));

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UITextFieldTest/UITextFieldTest.h
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UITextFieldTest/UITextFieldTest.h
@@ -104,6 +104,21 @@ protected:
     cocos2d::ui::Text* _displayValueLabel;
 };
 
+class UITextFieldTest_BMFont : public UIScene
+{
+public:
+    CREATE_FUNC(UITextFieldTest_BMFont);
+    
+    UITextFieldTest_BMFont();
+    ~UITextFieldTest_BMFont();
+    virtual bool init() override;
+    void textFieldEvent(cocos2d::Ref* sender, cocos2d::ui::TextField::EventType type);
+    
+protected:
+    
+    cocos2d::ui::Text* _displayValueLabel;
+};
+
 class UITextFieldTest_PlaceHolderColor : public UIScene
 {
 public:


### PR DESCRIPTION
# What

The cocos2d::ui::TextField class did not support BMFont. This PR adds that functionality and a test case as well.

# How to test
- [ ] Get this pr
- [ ] Build the test cases
- [ ] View the new textfield test case: 51:Node: UI -> 1. UI Dynamic Create Test -> 13. TextField test -> UITextFieldTest_BMFont
- [ ] See that the textfield uses a BMFont (marker felt) and renders fine

# Notes
I also changed the class TextFieldTTF, which already supported TTF and System fonts. The name of that class is ambiguous, I assumed it only supported TTF fonts. I think it should be renamed, as it clearly supports more font types. Did not to that in this PR though, as the change would be too big.