### PR TITLE
Fix gradlew build

### DIFF
--- a/cocos/platform/android/libcocos2dx-with-controller/AndroidManifest.xml
+++ b/cocos/platform/android/libcocos2dx-with-controller/AndroidManifest.xml
@@ -1,5 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" package="org.cocos2dx.lib">
 
+    <uses-permission android:name="android.permission.VIBRATE" />
+
     <application android:allowBackup="true">
 
     </application>

--- a/cocos/platform/android/libcocos2dx/AndroidManifest.xml
+++ b/cocos/platform/android/libcocos2dx/AndroidManifest.xml
@@ -1,5 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" package="org.cocos2dx.lib">
 
+    <uses-permission android:name="android.permission.VIBRATE" />
+
     <application android:allowBackup="true">
 
     </application>

--- a/templates/cpp-template-default/proj.android/app/AndroidManifest.xml
+++ b/templates/cpp-template-default/proj.android/app/AndroidManifest.xml
@@ -3,6 +3,8 @@
     package="org.cocos2dx.hellocpp"
     android:installLocation="auto">
 
+    <uses-permission android:name="android.permission.INTERNET"/>
+    
     <uses-feature android:glEsVersion="0x00020000" />
     
     <application
@@ -28,6 +30,4 @@
         </activity>
     </application>
 
-    <uses-permission android:name="android.permission.INTERNET"/>
-    
 </manifest>

--- a/templates/cpp-template-default/proj.android/app/proguard-rules.pro
+++ b/templates/cpp-template-default/proj.android/app/proguard-rules.pro
@@ -21,7 +21,7 @@
 -dontwarn org.cocos2dx.**
 -keep public class com.chukong.** { *; }
 -dontwarn com.chukong.**
--keep public com.huawei.android.** { *; }
+-keep public class com.huawei.android.** { *; }
 -dontwarn com.huawei.android.**
 
 # Proguard Apache HTTP for release


### PR DESCRIPTION
Fixed **gradlew build** errors. Now it it possible to compile the template for Android with command line (e.g. travis).