### PR TITLE
Fix actions with zero duration on NDK 16.

### DIFF
--- a/cocos/2d/CCActionInterval.cpp
+++ b/cocos/2d/CCActionInterval.cpp
@@ -126,9 +126,9 @@ void ActionInterval::step(float dt)
     }
     
     
-    float updateDt = MAX (0,                                  // needed for rewind. elapsed could be negative
-                           MIN(1, _elapsed / _duration)
-                           );
+    float updateDt = std::max(0.0f,                                  // needed for rewind. elapsed could be negative
+                              std::min(1.0f, _elapsed / _duration)
+                              );
 
     if (sendUpdateEventToScript(updateDt, this)) return;
     


### PR DESCRIPTION
On `CCActionInterval.cpp`, using the v3.17 candidate:

```
float updateDt = MAX (0,                                  // needed for rewind. elapsed could be negative
                       MIN(1, _elapsed / _duration)
                       );
```

If `_elapsed` and `_duration` are 0, Xcode 9.1 (iOS 11) will return `updateDt` = 1, while Android NDK r16b will return `updateDt` = _nan_.

This was spotted with the introduction of Android NDK 16, but other compilers/architectures might have similar issues, as the behaviour is strictly undefined.

This PR addresses the issue by using std::max/min, making the behaviour consistent between those two platforms (and similar to previous NDK).