### PR TITLE
[Label] use freetype api to support bold - improvement && tests case

### DIFF
--- a/cocos/2d/CCFontAtlasCache.cpp
+++ b/cocos/2d/CCFontAtlasCache.cpp
@@ -58,11 +58,11 @@ FontAtlas* FontAtlasCache::getFontAtlasTTF(const _ttfConfig* config)
 
     char tmp[ATLAS_MAP_KEY_BUFFER];
     if (useDistanceField) {
-        snprintf(tmp, ATLAS_MAP_KEY_BUFFER, "df %.2f %d %s", config->fontSize, config->outlineSize,
-                 realFontFilename.c_str());
+        snprintf(tmp, ATLAS_MAP_KEY_BUFFER, "df %.2f %d %s %d", config->fontSize, config->outlineSize,
+                 realFontFilename.c_str(), config->bold ? 1 : 0);
     } else {
-        snprintf(tmp, ATLAS_MAP_KEY_BUFFER, "%.2f %d %s", config->fontSize, config->outlineSize,
-                 realFontFilename.c_str());
+        snprintf(tmp, ATLAS_MAP_KEY_BUFFER, "%.2f %d %s %d", config->fontSize, config->outlineSize,
+                 realFontFilename.c_str(), config->bold ? 1 : 0);
     }
     std::string atlasName = tmp;
 
@@ -71,7 +71,7 @@ FontAtlas* FontAtlasCache::getFontAtlasTTF(const _ttfConfig* config)
     if ( it == _atlasMap.end() )
     {
         auto font = FontFreeType::create(realFontFilename, config->fontSize, config->glyphs,
-            config->customGlyphs, useDistanceField, config->outlineSize);
+            config->customGlyphs, useDistanceField, config->outlineSize, config->bold);
         if (font)
         {
             auto tempAtlas = font->createFontAtlas();

--- a/cocos/2d/CCFontFreeType.cpp
+++ b/cocos/2d/CCFontFreeType.cpp
@@ -58,7 +58,7 @@ FontFreeType * FontFreeType::create(const std::string &fontName, float fontSize,
 
     if (bold)
     {
-        tempFont->_boldSize = CC_CONTENT_SCALE_FACTOR() * 64;
+        tempFont->_boldSize = static_cast<int>(64.f * CC_CONTENT_SCALE_FACTOR());
     }
 
     if (!tempFont)
@@ -179,7 +179,7 @@ bool FontFreeType::createFontObject(const std::string &fontName, float fontSize)
 
     // set the requested font size
     int dpi = 72;
-    int fontSizePoints = (int)(64.f * fontSize * CC_CONTENT_SCALE_FACTOR());
+    int fontSizePoints = static_cast<int>(64.f * fontSize * CC_CONTENT_SCALE_FACTOR());
     if (FT_Set_Char_Size(face, fontSizePoints, fontSizePoints, dpi, dpi))
         return false;
     

--- a/cocos/2d/CCFontFreeType.cpp
+++ b/cocos/2d/CCFontFreeType.cpp
@@ -26,6 +26,7 @@ THE SOFTWARE.
 #include "2d/CCFontFreeType.h"
 #include FT_BBOX_H
 #include FT_BITMAP_H
+#include FT_OUTLINE_H
 #include "edtaa3func.h"
 #include "2d/CCFontAtlas.h"
 #include "base/CCDirector.h"

--- a/cocos/2d/CCFontFreeType.cpp
+++ b/cocos/2d/CCFontFreeType.cpp
@@ -25,6 +25,7 @@ THE SOFTWARE.
 
 #include "2d/CCFontFreeType.h"
 #include FT_BBOX_H
+#include FT_BITMAP_H
 #include "edtaa3func.h"
 #include "2d/CCFontAtlas.h"
 #include "base/CCDirector.h"
@@ -49,9 +50,15 @@ typedef struct _DataRef
 
 static std::unordered_map<std::string, DataRef> s_cacheFontData;
 
-FontFreeType * FontFreeType::create(const std::string &fontName, float fontSize, GlyphCollection glyphs, const char *customGlyphs,bool distanceFieldEnabled /* = false */,float outline /* = 0 */)
+FontFreeType * FontFreeType::create(const std::string &fontName, float fontSize, GlyphCollection glyphs, const char *customGlyphs,
+    bool distanceFieldEnabled /* = false */,float outline /* = 0 */,bool bold /* = false */)
 {
     FontFreeType *tempFont =  new (std::nothrow) FontFreeType(distanceFieldEnabled,outline);
+
+    if (bold)
+    {
+        tempFont->_boldSize = CC_CONTENT_SCALE_FACTOR() * 64;
+    }
 
     if (!tempFont)
         return nullptr;
@@ -105,6 +112,7 @@ FontFreeType::FontFreeType(bool distanceFieldEnabled /* = false */, float outlin
 , _fontAtlas(nullptr)
 , _encoding(FT_ENCODING_UNICODE)
 , _usedGlyphs(GlyphCollection::ASCII)
+, _boldSize(0)
 {
     if (outline > 0.0f)
     {
@@ -308,6 +316,11 @@ unsigned char* FontFreeType::getGlyphBitmap(uint64_t theChar, long &outWidth, lo
                 break;
         }
 
+        if (_boldSize > 0)
+        {
+            FT_Bitmap_Embolden(getFTLibrary(), &_fontRef->glyph->bitmap, _boldSize, 0);
+        }
+
         auto& metrics = _fontRef->glyph->metrics;
         outRect.origin.x = metrics.horiBearingX >> 6;
         outRect.origin.y = -(metrics.horiBearingY >> 6);
@@ -351,7 +364,7 @@ unsigned char* FontFreeType::getGlyphBitmap(uint64_t theChar, long &outWidth, lo
             auto blendWidth = MAX(outlineMaxX, glyphMaxX) - blendImageMinX;
             auto blendHeight = blendImageMaxY - MIN(outlineMinY, glyphMinY);
 
-            outRect.origin.x = blendImageMinX;
+            outRect.origin.x = blendImageMinX + _outlineSize;
             outRect.origin.y = -blendImageMaxY + _outlineSize;
 
             unsigned char *blendImage = nullptr;
@@ -427,6 +440,12 @@ unsigned char * FontFreeType::getGlyphBitmapWithOutline(uint64_t theChar, FT_BBo
                 if (glyph->format == FT_GLYPH_FORMAT_OUTLINE)
                 {
                     FT_Outline *outline = &reinterpret_cast<FT_OutlineGlyph>(glyph)->outline;
+
+                    if (_boldSize > 0)
+                    {
+                        FT_Outline_EmboldenXY(outline, _boldSize, 0);
+                    }
+                    
                     FT_Glyph_Get_CBox(glyph,FT_GLYPH_BBOX_GRIDFIT,&bbox);
                     long width = (bbox.xMax - bbox.xMin)>>6;
                     long rows = (bbox.yMax - bbox.yMin)>>6;

--- a/cocos/2d/CCFontFreeType.h
+++ b/cocos/2d/CCFontFreeType.h
@@ -54,7 +54,7 @@ public:
     static const int DistanceMapSpread;
 
     static FontFreeType* create(const std::string &fontName, float fontSize, GlyphCollection glyphs,
-        const char *customGlyphs,bool distanceFieldEnabled = false, float outline = 0);
+        const char *customGlyphs,bool distanceFieldEnabled = false, float outline = 0, bool bold = false);
 
     static void shutdownFreeType();
 
@@ -102,6 +102,7 @@ private:
     FT_Stroker _stroker;
     FT_Encoding _encoding;
 
+    int _boldSize;
     std::string _fontName;
     bool _distanceFieldEnabled;
     float _outlineSize;

--- a/cocos/2d/CCLabel.cpp
+++ b/cocos/2d/CCLabel.cpp
@@ -1144,22 +1144,22 @@ void Label::enableItalics()
 
 void Label::enableBold()
 {
-    if (!_boldEnabled)
+    if (_currentLabelType == LabelType::TTF) 
+    {
+        // use freetype to support bold only for ttf
+        if (_fontConfig.bold == false)
+        {
+            _fontConfig.bold = true;
+            setTTFConfig(_fontConfig);
+        }
+    }
+    else if (!_boldEnabled)
     {
         // bold is implemented with outline
         enableShadow(Color4B::WHITE, Size(0.9f, 0), 0);
         // add one to kerning
         setAdditionalKerning(_additionalKerning+1);
         _boldEnabled = true;
-    }
-}
-
-void cocos2d::Label::setBold(bool bold)
-{
-    if (_currentLabelType == LabelType::TTF && _fontConfig.bold != bold)
-    {
-        _fontConfig.bold = bold;
-        setTTFConfig(_fontConfig);
     }
 }
 
@@ -1225,7 +1225,15 @@ void Label::disableEffect(LabelEffect effect)
             setRotationSkewX(0);
             break;
         case cocos2d::LabelEffect::BOLD:
-            if (_boldEnabled) {
+            if (_currentLabelType == LabelType::TTF) // only for ttf
+            {
+                if (_fontConfig.bold == true)
+                {
+                    _fontConfig.bold = false;
+                    setTTFConfig(_fontConfig);
+                }
+            }
+            else if (_boldEnabled) {
                 _boldEnabled = false;
                 _additionalKerning -= 1;
                 disableEffect(LabelEffect::SHADOW);

--- a/cocos/2d/CCLabel.cpp
+++ b/cocos/2d/CCLabel.cpp
@@ -1000,8 +1000,6 @@ bool Label::setTTFConfigInternal(const TTFConfig& ttfConfig)
 
     if (_fontConfig.italics)
         this->enableItalics();
-    if (_fontConfig.bold)
-        this->enableBold();
     if (_fontConfig.underline)
         this->enableUnderline();
     if (_fontConfig.strikethrough)
@@ -1149,22 +1147,22 @@ void Label::enableItalics()
 
 void Label::enableBold()
 {
-    if (!_boldEnabled)
+    if (_currentLabelType == LabelType::TTF) 
     {
-        _boldEnabled = true;
-        if (_currentLabelType == LabelType::TTF && _fontConfig.bold == false)
+        // use freetype to support bold only for ttf
+        if (_fontConfig.bold == false)
         {
-            // use freetype to support bold only for ttf
             _fontConfig.bold = true;
             setTTFConfig(_fontConfig);
         }
-        else
-        {
-            // bold is implemented with outline
-            enableShadow(Color4B::WHITE, Size(0.9f, 0), 0);
-            // add one to kerning
-            setAdditionalKerning(_additionalKerning+1);
-        }
+    }
+    else if (!_boldEnabled)
+    {
+        // bold is implemented with outline
+        enableShadow(Color4B::WHITE, Size(0.9f, 0), 0);
+        // add one to kerning
+        setAdditionalKerning(_additionalKerning+1);
+        _boldEnabled = true;
     }
 }
 
@@ -1230,18 +1228,18 @@ void Label::disableEffect(LabelEffect effect)
             setRotationSkewX(0);
             break;
         case cocos2d::LabelEffect::BOLD:
-            if (_boldEnabled) {
-                _boldEnabled = false;
-                if (_currentLabelType == LabelType::TTF)
+            if (_currentLabelType == LabelType::TTF) // only for ttf
+            {
+                if (_fontConfig.bold == true)
                 {
-                    _fontConfig.bold = false; // only for ttf
+                    _fontConfig.bold = false;
                     setTTFConfig(_fontConfig);
                 }
-                else
-                {
-                    _additionalKerning -= 1;
-                    disableEffect(LabelEffect::SHADOW);
-                }
+            }
+            else if (_boldEnabled) {
+                _boldEnabled = false;
+                _additionalKerning -= 1;
+                disableEffect(LabelEffect::SHADOW);
             }
             break;
         case cocos2d::LabelEffect::UNDERLINE:
@@ -1548,8 +1546,7 @@ void Label::onDraw(const Mat4& transform, bool /*transformUpdated*/)
 
     if (_shadowEnabled)
     {
-        // freetype api to support bold when TTF
-        if (_boldEnabled && (_currentLabelType != LabelType::TTF))
+        if (_boldEnabled)
             onDrawShadow(glprogram, _textColorF);
         else
             onDrawShadow(glprogram, _shadowColor4F);

--- a/cocos/2d/CCLabel.cpp
+++ b/cocos/2d/CCLabel.cpp
@@ -1154,7 +1154,7 @@ void Label::enableBold()
     }
 }
 
-void cocos2d::Label::setBold(bool bold /*= true*/)
+void cocos2d::Label::setBold(bool bold)
 {
     if (_currentLabelType == LabelType::TTF && _fontConfig.bold != bold)
     {

--- a/cocos/2d/CCLabel.cpp
+++ b/cocos/2d/CCLabel.cpp
@@ -997,8 +997,6 @@ bool Label::setTTFConfigInternal(const TTFConfig& ttfConfig)
 
     if (_fontConfig.italics)
         this->enableItalics();
-    if (_fontConfig.bold)
-        this->enableBold();
     if (_fontConfig.underline)
         this->enableUnderline();
     if (_fontConfig.strikethrough)
@@ -1153,6 +1151,15 @@ void Label::enableBold()
         // add one to kerning
         setAdditionalKerning(_additionalKerning+1);
         _boldEnabled = true;
+    }
+}
+
+void cocos2d::Label::setBold(bool bold /*= true*/)
+{
+    if (_currentLabelType == LabelType::TTF && _fontConfig.bold != bold)
+    {
+        _fontConfig.bold = bold;
+        setTTFConfig(_fontConfig);
     }
 }
 

--- a/cocos/2d/CCLabel.h
+++ b/cocos/2d/CCLabel.h
@@ -777,6 +777,7 @@ protected:
     Overflow _overflow;
     float _originalFontSize;
 
+    // TTF font enable flag is _fontConfig.bold
     bool _boldEnabled;
     DrawNode* _underlineNode;
     bool _strikethroughEnabled;

--- a/cocos/2d/CCLabel.h
+++ b/cocos/2d/CCLabel.h
@@ -364,6 +364,11 @@ public:
     void enableBold();
 
     /**
+     * triggle bold, use freetype to support bold only for ttf
+     */
+    void setBold(bool bold = true);
+
+    /**
      * Enable underline
      */
     void enableUnderline();

--- a/cocos/2d/CCLabel.h
+++ b/cocos/2d/CCLabel.h
@@ -364,11 +364,6 @@ public:
     void enableBold();
 
     /**
-     * set bold effect, use freetype to support bold only for ttf
-     */
-    void setBold(bool bold);
-
-    /**
      * Enable underline
      */
     void enableUnderline();

--- a/cocos/2d/CCLabel.h
+++ b/cocos/2d/CCLabel.h
@@ -364,9 +364,9 @@ public:
     void enableBold();
 
     /**
-     * triggle bold, use freetype to support bold only for ttf
+     * set bold effect, use freetype to support bold only for ttf
      */
-    void setBold(bool bold = true);
+    void setBold(bool bold);
 
     /**
      * Enable underline

--- a/tests/cpp-tests/Classes/LabelTest/LabelTestNew.cpp
+++ b/tests/cpp-tests/Classes/LabelTest/LabelTestNew.cpp
@@ -1188,6 +1188,14 @@ LabelOutlineAndGlowTest::LabelOutlineAndGlowTest()
     label4->setTextColor( Color4B::RED );
     label4->enableOutline(Color4B::BLUE);
     addChild(label4);
+
+    ttfConfig.outlineSize = 3;
+    auto label5 = Label::createWithTTF(ttfConfig,"Outline and Bold", TextHAlignment::CENTER, size.width);
+    label5->setPosition( Vec2(size.width/2, size.height*0.24) );
+    label5->setTextColor( Color4B::RED );
+    label5->enableOutline(Color4B::BLUE);
+    label5->enableBold();
+    addChild(label5);
 }
 
 std::string LabelOutlineAndGlowTest::title() const
@@ -1197,7 +1205,7 @@ std::string LabelOutlineAndGlowTest::title() const
 
 std::string LabelOutlineAndGlowTest::subtitle() const
 {
-    return "Testing outline and glow of label";
+    return "Testing outline, glow and bold of label";
 }
 
 LabelShadowTest::LabelShadowTest()

--- a/tests/cpp-tests/Classes/LabelTest/LabelTestNew.cpp
+++ b/tests/cpp-tests/Classes/LabelTest/LabelTestNew.cpp
@@ -105,6 +105,7 @@ NewLabelTests::NewLabelTests()
     ADD_TEST_CASE(LabelUnderlineMultiline);
     ADD_TEST_CASE(LabelItalics);
     ADD_TEST_CASE(LabelBold);
+    ADD_TEST_CASE(LabelBoldAndOutline);
 
     ADD_TEST_CASE(LabelLocalizationTest);
 
@@ -3003,6 +3004,68 @@ std::string LabelBold::subtitle() const
 
 ///
 
+LabelBoldAndOutline::LabelBoldAndOutline()
+{
+    auto s = Director::getInstance()->getWinSize();
+
+    // LabelSystemFont
+    _label1a = Label::createWithSystemFont("System Font Text", "Arial", 30);
+    _label1a->setPosition(Vec2(s.width/2, s.height*2/3));
+    _label1a->enableBold();
+    _label1a->enableOutline(Color4B::BLUE, 2);
+    addChild(_label1a);
+
+    // LabelTTF
+    TTFConfig ttfConfig("fonts/arial.ttf",24);
+    ttfConfig.bold = true;
+    ttfConfig.outlineSize = 2;
+    _label2a = Label::createWithTTF(ttfConfig, "TTF Font Text", TextHAlignment::CENTER,s.width);
+    addChild(_label2a);
+    _label2a->setPosition(Vec2(s.width/2, s.height*1/2));
+    _label2a->enableOutline(Color4B::BLUE);
+
+    auto menuItem = MenuItemFont::create("switch bold", [&](cocos2d::Ref* sender) {
+        if(_label2a->getTTFConfig().bold){
+            _label2a->disableEffect(LabelEffect::BOLD);
+            _label1a->disableEffect(LabelEffect::BOLD);
+        }
+        else
+        {
+            _label2a->enableBold();
+            _label1a->enableBold();
+        }
+    });
+    menuItem->setFontSizeObj(12);
+    auto menuItem2 = MenuItemFont::create("switch outline", [&](cocos2d::Ref* sender) {
+        if(_label2a->getTTFConfig().outlineSize > 0){
+            _label2a->disableEffect(LabelEffect::OUTLINE);
+            _label1a->disableEffect(LabelEffect::OUTLINE);
+        }
+        else
+        {
+            _label2a->enableOutline(Color4B::BLUE, 2);
+            _label1a->enableOutline(Color4B::BLUE, 2);
+        }
+    });
+    menuItem2->setFontSizeObj(12);
+    menuItem2->setPosition(0.0, s.height * 0.1f);
+    auto menu = Menu::create(menuItem, menuItem2, nullptr);
+    addChild(menu);
+    menu->setPosition(s.width * 0.9, s.height * 0.3f);
+}
+
+std::string LabelBoldAndOutline::title() const
+{
+    return "Testing Bold and Outline";
+}
+
+std::string LabelBoldAndOutline::subtitle() const
+{
+    return "";
+}
+
+///
+
 LabelUnderline::LabelUnderline()
 {
     auto s = Director::getInstance()->getWinSize();
@@ -3435,5 +3498,3 @@ std::string LabelIssue17902::subtitle() const
 {
     return "";
 }
-
-

--- a/tests/cpp-tests/Classes/LabelTest/LabelTestNew.cpp
+++ b/tests/cpp-tests/Classes/LabelTest/LabelTestNew.cpp
@@ -3008,50 +3008,37 @@ LabelBoldAndOutline::LabelBoldAndOutline()
 {
     auto s = Director::getInstance()->getWinSize();
 
-    // LabelSystemFont
-    _label1a = Label::createWithSystemFont("System Font Text", "Arial", 30);
-    _label1a->setPosition(Vec2(s.width/2, s.height*2/3));
-    _label1a->enableBold();
-    _label1a->enableOutline(Color4B::BLUE, 2);
-    addChild(_label1a);
-
     // LabelTTF
-    TTFConfig ttfConfig("fonts/arial.ttf",24);
+    TTFConfig ttfConfig("fonts/arial.ttf", 24);
     ttfConfig.bold = true;
-    ttfConfig.outlineSize = 2;
-    _label2a = Label::createWithTTF(ttfConfig, "TTF Font Text", TextHAlignment::CENTER,s.width);
+    _label2a = Label::createWithTTF(ttfConfig, "abcdefghijklmnopqrstuvwxyz\nABCDEFGHIGKLMNOPQRSTUVWXYZ", TextHAlignment::CENTER,s.width);
     addChild(_label2a);
     _label2a->setPosition(Vec2(s.width/2, s.height*1/2));
-    _label2a->enableOutline(Color4B::BLUE);
 
-    auto menuItem = MenuItemFont::create("switch bold", [&](cocos2d::Ref* sender) {
+    auto menuItem = MenuItemFont::create("enable/disable bold", [&](cocos2d::Ref* sender) {
         if(_label2a->getTTFConfig().bold){
             _label2a->disableEffect(LabelEffect::BOLD);
-            _label1a->disableEffect(LabelEffect::BOLD);
         }
         else
         {
             _label2a->enableBold();
-            _label1a->enableBold();
         }
     });
     menuItem->setFontSizeObj(12);
-    auto menuItem2 = MenuItemFont::create("switch outline", [&](cocos2d::Ref* sender) {
+    auto menuItem2 = MenuItemFont::create("enable/disable outline", [&](cocos2d::Ref* sender) {
         if(_label2a->getTTFConfig().outlineSize > 0){
             _label2a->disableEffect(LabelEffect::OUTLINE);
-            _label1a->disableEffect(LabelEffect::OUTLINE);
         }
         else
         {
             _label2a->enableOutline(Color4B::BLUE, 2);
-            _label1a->enableOutline(Color4B::BLUE, 2);
         }
     });
     menuItem2->setFontSizeObj(12);
     menuItem2->setPosition(0.0, s.height * 0.1f);
     auto menu = Menu::create(menuItem, menuItem2, nullptr);
     addChild(menu);
-    menu->setPosition(s.width * 0.9, s.height * 0.3f);
+    menu->setPosition(s.width * 0.8, s.height * 0.3f);
 }
 
 std::string LabelBoldAndOutline::title() const

--- a/tests/cpp-tests/Classes/LabelTest/LabelTestNew.h
+++ b/tests/cpp-tests/Classes/LabelTest/LabelTestNew.h
@@ -805,6 +805,19 @@ public:
     cocos2d::Label* _label2a;
 };
 
+class LabelBoldAndOutline : public AtlasDemoNew
+{
+public:
+    CREATE_FUNC(LabelBoldAndOutline);
+
+    LabelBoldAndOutline();
+    virtual std::string title() const override;
+    virtual std::string subtitle() const override;
+
+    cocos2d::Label* _label1a;
+    cocos2d::Label* _label2a;
+};
+
 class LabelUnderline : public AtlasDemoNew
 {
 public:


### PR DESCRIPTION
> label enable blod use shadow to achive, so bold and outline can not use in same time.
> use freetype api to support bold

This feature is submitted at #17436 months ago, this is a good feature, but the author didn't response for a long time. So I decide to submit it again, improve it, and add a test case.
