### PR TITLE
Android Emulator Blank Screen 0x501 and 0x502 Problem Bugfix Update

### DIFF
--- a/cocos/renderer/CCGLProgram.cpp
+++ b/cocos/renderer/CCGLProgram.cpp
@@ -487,7 +487,7 @@ bool GLProgram::compileShader(GLuint * shader, GLenum type, const GLchar* source
         headersDef = (type == GL_VERTEX_SHADER ? "precision mediump float;\n precision mediump int;\n" : "precision mediump float;\n precision mediump int;\n");
 // Bugfix to make shader variables types constant to be understood by the current Android Virtual Devices or Emulators. This will also elimiate the 0x501 and 0x502 OpenGL Errors during emulation.
 #elif CC_TARGET_PLATFORM == CC_PLATFORM_ANDROID
-              headersDef = "#version 100\n precision mediump float;\n precision mediump int;\n";
+        headersDef = "#version 100\n precision mediump float;\n precision mediump int;\n";
 #elif (CC_TARGET_PLATFORM != CC_PLATFORM_WIN32 && CC_TARGET_PLATFORM != CC_PLATFORM_LINUX && CC_TARGET_PLATFORM != CC_PLATFORM_MAC)
         headersDef = (type == GL_VERTEX_SHADER ? "precision highp float;\n precision highp int;\n" : "precision mediump float;\n precision mediump int;\n");
 #endif

--- a/cocos/renderer/CCGLProgram.cpp
+++ b/cocos/renderer/CCGLProgram.cpp
@@ -484,7 +484,7 @@ bool GLProgram::compileShader(GLuint * shader, GLenum type, const GLchar* source
     std::string headersDef;
     if (compileTimeHeaders.empty()) {
 #if CC_TARGET_PLATFORM == CC_PLATFORM_WINRT
-// Bugfix to make shader variables types constant to be understood by the current Android Virtual Devices or Emulators. This will also elimiate the 0x501 and 0x502 OpenGL Errors during emulation.
+// Bugfix to make shader variables types constant to be understood by the current Android Virtual Devices or Emulators. This will also eliminate the 0x501 and 0x502 OpenGL Errors during emulation.
 #elif CC_TARGET_PLATFORM == CC_PLATFORM_ANDROID
         headersDef = (type == GL_VERTEX_SHADER ? "precision mediump float;\n precision mediump int;\n" : "precision mediump float;\n precision mediump int;\n");
 #elif (CC_TARGET_PLATFORM != CC_PLATFORM_WIN32 && CC_TARGET_PLATFORM != CC_PLATFORM_LINUX && CC_TARGET_PLATFORM != CC_PLATFORM_MAC)

--- a/cocos/renderer/CCGLProgram.cpp
+++ b/cocos/renderer/CCGLProgram.cpp
@@ -485,7 +485,7 @@ bool GLProgram::compileShader(GLuint * shader, GLenum type, const GLchar* source
     if (compileTimeHeaders.empty()) {
 #if CC_TARGET_PLATFORM == CC_PLATFORM_WINRT
         headersDef = (type == GL_VERTEX_SHADER ? "precision mediump float;\n precision mediump int;\n" : "precision mediump float;\n precision mediump int;\n");
-// Bugfix to make shader variables types constant to be understood by the current Android Virtual Devices or Emulators. This will also elimiate the 0x501 and 0x502 OpenGL Errors during emulation.
+// Bugfix to make shader variables types constant to be understood by the current Android Virtual Devices or Emulators. This will also eliminate the 0x501 and 0x502 OpenGL Errors during emulation.
 #elif CC_TARGET_PLATFORM == CC_PLATFORM_ANDROID
         headersDef = "#version 100\n precision mediump float;\n precision mediump int;\n";
 #elif (CC_TARGET_PLATFORM != CC_PLATFORM_WIN32 && CC_TARGET_PLATFORM != CC_PLATFORM_LINUX && CC_TARGET_PLATFORM != CC_PLATFORM_MAC)

--- a/cocos/renderer/CCGLProgram.cpp
+++ b/cocos/renderer/CCGLProgram.cpp
@@ -484,9 +484,10 @@ bool GLProgram::compileShader(GLuint * shader, GLenum type, const GLchar* source
     std::string headersDef;
     if (compileTimeHeaders.empty()) {
 #if CC_TARGET_PLATFORM == CC_PLATFORM_WINRT
-// Bugfix to make shader variables types constant to be understood by the current Android Virtual Devices or Emulators. This will also eliminate the 0x501 and 0x502 OpenGL Errors during emulation.
+        headersDef = (type == GL_VERTEX_SHADER ? "precision mediump float;\n precision mediump int;\n" : "precision mediump float;\n precision mediump int;\n");
+// Bugfix to make shader variables types constant to be understood by the current Android Virtual Devices or Emulators. This will also elimiate the 0x501 and 0x502 OpenGL Errors during emulation.
 #elif CC_TARGET_PLATFORM == CC_PLATFORM_ANDROID
-        headersDef = "#version 100\n precision mediump float;\n precision mediump int;\n";
+              headersDef = "#version 100\n precision mediump float;\n precision mediump int;\n";
 #elif (CC_TARGET_PLATFORM != CC_PLATFORM_WIN32 && CC_TARGET_PLATFORM != CC_PLATFORM_LINUX && CC_TARGET_PLATFORM != CC_PLATFORM_MAC)
         headersDef = (type == GL_VERTEX_SHADER ? "precision highp float;\n precision highp int;\n" : "precision mediump float;\n precision mediump int;\n");
 #endif

--- a/cocos/renderer/CCGLProgram.cpp
+++ b/cocos/renderer/CCGLProgram.cpp
@@ -486,7 +486,7 @@ bool GLProgram::compileShader(GLuint * shader, GLenum type, const GLchar* source
 #if CC_TARGET_PLATFORM == CC_PLATFORM_WINRT
 // Bugfix to make shader variables types constant to be understood by the current Android Virtual Devices or Emulators. This will also eliminate the 0x501 and 0x502 OpenGL Errors during emulation.
 #elif CC_TARGET_PLATFORM == CC_PLATFORM_ANDROID
-        headersDef = (type == GL_VERTEX_SHADER ? "precision mediump float;\n precision mediump int;\n" : "precision mediump float;\n precision mediump int;\n");
+        headersDef = "#version 100\n precision mediump float;\n precision mediump int;\n";
 #elif (CC_TARGET_PLATFORM != CC_PLATFORM_WIN32 && CC_TARGET_PLATFORM != CC_PLATFORM_LINUX && CC_TARGET_PLATFORM != CC_PLATFORM_MAC)
         headersDef = (type == GL_VERTEX_SHADER ? "precision highp float;\n precision highp int;\n" : "precision mediump float;\n precision mediump int;\n");
 #endif

--- a/cocos/renderer/CCGLProgram.cpp
+++ b/cocos/renderer/CCGLProgram.cpp
@@ -235,7 +235,7 @@ GLProgram::~GLProgram()
         GL::deleteProgram(_program);
     }
 
-    
+
     clearHashUniforms();
 }
 
@@ -484,6 +484,8 @@ bool GLProgram::compileShader(GLuint * shader, GLenum type, const GLchar* source
     std::string headersDef;
     if (compileTimeHeaders.empty()) {
 #if CC_TARGET_PLATFORM == CC_PLATFORM_WINRT
+// Bugfix to make shader variables types constant to be understood by the current Android Virtual Devices or Emulators. This will also elimiate the 0x501 and 0x502 OpenGL Errors during emulation.
+#elif CC_TARGET_PLATFORM == CC_PLATFORM_ANDROID
         headersDef = (type == GL_VERTEX_SHADER ? "precision mediump float;\n precision mediump int;\n" : "precision mediump float;\n precision mediump int;\n");
 #elif (CC_TARGET_PLATFORM != CC_PLATFORM_WIN32 && CC_TARGET_PLATFORM != CC_PLATFORM_LINUX && CC_TARGET_PLATFORM != CC_PLATFORM_MAC)
         headersDef = (type == GL_VERTEX_SHADER ? "precision highp float;\n precision highp int;\n" : "precision mediump float;\n precision mediump int;\n");
@@ -925,7 +927,7 @@ void GLProgram::setUniformsForBuiltins(const Mat4 &matrixMV)
 
     if (_flags.usesP)
         setUniformLocationWithMatrix4fv(_builtInUniforms[UNIFORM_P_MATRIX], matrixP.m, 1);
-    
+
     if (_flags.usesMultiViewP)
     {
         Mat4 mats[4];
@@ -944,7 +946,7 @@ void GLProgram::setUniformsForBuiltins(const Mat4 &matrixMV)
         Mat4 matrixMVP = matrixP * matrixMV;
         setUniformLocationWithMatrix4fv(_builtInUniforms[UNIFORM_MVP_MATRIX], matrixMVP.m, 1);
     }
-    
+
     if (_flags.usesMultiViewMVP)
     {
         Mat4 mats[4];
@@ -1022,4 +1024,3 @@ inline void GLProgram::clearHashUniforms()
 }
 
 NS_CC_END
-


### PR DESCRIPTION
I added some code to make the Android Emulator read GLSL files correctly by making the data types constant for uniform variables. If the Android Emulator cannot read the data types of the variables, it will say OpenGL Error 0x501 or 0x502 glUniform unable to find uniform variable depth. Other variables will be affected after depth. With this bugfix, the variables will be read correctly by the Android Emulator and render your game.

I removed too much lines earlier including the original lines for WINRT and have placed those back with the bugfix. I needed to remove the earlier pull request to avoid confusion.