### PR TITLE
Add option to set keyboard appearance for edit boxes

### DIFF
--- a/cocos/ui/UIEditBox/UIEditBox.cpp
+++ b/cocos/ui/UIEditBox/UIEditBox.cpp
@@ -418,6 +418,23 @@ EditBox::KeyboardReturnType EditBox::getReturnType() const
     return KeyboardReturnType::DEFAULT;
 }
 
+void EditBox::setKeyboardAppearance(EditBox::KeyboardAppearance keyboardAppearance)
+{
+    if (_editBoxImpl != nullptr)
+    {
+        _editBoxImpl->setKeyboardAppearance(keyboardAppearance);
+    }
+}
+
+EditBox::KeyboardAppearance EditBox::getKeyboardAppearance() const
+{
+    if (_editBoxImpl != nullptr)
+    {
+        return _editBoxImpl->getKeyboardAppearance();
+    }
+    return KeyboardAppearance::DEFAULT;
+}
+
 void EditBox::setTextHorizontalAlignment(TextHAlignment alignment)
 {
     if (_editBoxImpl != nullptr)

--- a/cocos/ui/UIEditBox/UIEditBox.h
+++ b/cocos/ui/UIEditBox/UIEditBox.h
@@ -210,6 +210,15 @@ namespace ui {
              */
             LOWERCASE_ALL_CHARACTERS
         };
+        
+        /**
+         * @brief The EditBox::KeyboardAppearance defines the keyboard's appearance
+         * while the edit box is active.
+         */
+        enum class KeyboardAppearance {
+            DEFAULT,
+            DARK
+        };
             
         /**
          * create a edit box with size.
@@ -483,7 +492,19 @@ namespace ui {
          * @return One of the EditBox::KeyboardReturnType constants.
          */
         KeyboardReturnType getReturnType() const;
-
+        
+        /**
+         * Set the keyboard appearance that is to be applied to the edit box.
+         * @param keyboardAppearance One of the EditBox::KeyboardAppearance constants.
+         */
+        void setKeyboardAppearance(KeyboardAppearance keyboardAppearance);
+        
+        /**
+         * Get the keyboard appearance that is to be applied to the edit box.
+         * @return One of the EditBox::KeyboardAppearance constants.
+         */
+        KeyboardAppearance getKeyboardAppearance() const;
+        
         /**
          * Set the text horizontal alignment.
          */

--- a/cocos/ui/UIEditBox/UIEditBoxImpl-common.cpp
+++ b/cocos/ui/UIEditBox/UIEditBoxImpl-common.cpp
@@ -51,6 +51,7 @@ EditBoxImplCommon::EditBoxImplCommon(EditBox* pEditText)
 , _editBoxInputMode(EditBox::InputMode::SINGLE_LINE)
 , _editBoxInputFlag(EditBox::InputFlag::INITIAL_CAPS_ALL_CHARACTERS)
 , _keyboardReturnType(EditBox::KeyboardReturnType::DEFAULT)
+, _keyboardAppearance(EditBox::KeyboardAppearance::DEFAULT)
 , _fontSize(-1)
 , _placeholderFontSize(-1)
 , _colText(Color3B::WHITE)
@@ -226,6 +227,11 @@ void EditBoxImplCommon::setReturnType(EditBox::KeyboardReturnType returnType)
 {
     _keyboardReturnType = returnType;
     this->setNativeReturnType(returnType);
+}
+    
+void EditBoxImplCommon::setKeyboardAppearance(EditBox::KeyboardAppearance keyboardAppearance) {
+    _keyboardAppearance = keyboardAppearance;
+    this->setNativeKeyboardAppearance(keyboardAppearance);
 }
     
 void EditBoxImplCommon::refreshInactiveText()

--- a/cocos/ui/UIEditBox/UIEditBoxImpl-common.h
+++ b/cocos/ui/UIEditBox/UIEditBoxImpl-common.h
@@ -59,6 +59,7 @@ public:
     virtual void setInputMode(EditBox::InputMode inputMode) override;
     virtual void setInputFlag(EditBox::InputFlag inputFlag) override;
     virtual void setReturnType(EditBox::KeyboardReturnType returnType) override;
+    virtual void setKeyboardAppearance(EditBox::KeyboardAppearance) override;
     virtual void setText(const char* pText) override;
     virtual void setPlaceHolder(const char* pText) override;
     virtual void setVisible(bool visible) override;
@@ -81,6 +82,7 @@ public:
     virtual EditBox::InputMode getInputMode() override { return _editBoxInputMode; }
     virtual EditBox::InputFlag getInputFlag() override { return _editBoxInputFlag; }
     virtual EditBox::KeyboardReturnType getReturnType() override { return _keyboardReturnType; }
+    virtual EditBox::KeyboardAppearance getKeyboardAppearance() override { return _keyboardAppearance; }
     virtual TextHAlignment getTextHorizontalAlignment() override { return _alignment; }
 
     virtual void refreshInactiveText();
@@ -118,6 +120,7 @@ public:
     virtual void setNativeInputMode(EditBox::InputMode inputMode) = 0;
     virtual void setNativeInputFlag(EditBox::InputFlag inputFlag) = 0;
     virtual void setNativeReturnType(EditBox::KeyboardReturnType returnType) = 0;
+    virtual void setNativeKeyboardAppearance(EditBox::KeyboardAppearance) {}
     virtual void setNativeTextHorizontalAlignment(cocos2d::TextHAlignment alignment) = 0;
     virtual void setNativeText(const char* pText) = 0;
     virtual void setNativePlaceHolder(const char* pText) = 0;
@@ -142,6 +145,7 @@ protected:
     EditBox::InputFlag    _editBoxInputFlag;
     EditBox::KeyboardReturnType  _keyboardReturnType;
     cocos2d::TextHAlignment _alignment;
+    EditBox::KeyboardAppearance _keyboardAppearance;
 
     std::string _text;
     std::string _placeHolder;

--- a/cocos/ui/UIEditBox/UIEditBoxImpl-ios.h
+++ b/cocos/ui/UIEditBox/UIEditBoxImpl-ios.h
@@ -63,6 +63,7 @@ public:
     virtual void setNativeInputMode(EditBox::InputMode inputMode) override;
     virtual void setNativeInputFlag(EditBox::InputFlag inputFlag) override;
     virtual void setNativeReturnType(EditBox::KeyboardReturnType returnType)override;
+    virtual void setNativeKeyboardAppearance(EditBox::KeyboardAppearance keyboardAppearance) override;
     virtual void setNativeTextHorizontalAlignment(cocos2d::TextHAlignment alignment) override;
     virtual void setNativeText(const char* pText) override;
     virtual void setNativePlaceHolder(const char* pText) override;

--- a/cocos/ui/UIEditBox/UIEditBoxImpl-ios.mm
+++ b/cocos/ui/UIEditBox/UIEditBoxImpl-ios.mm
@@ -158,6 +158,11 @@ void EditBoxImplIOS::setNativeReturnType(EditBox::KeyboardReturnType returnType)
 {
     [_systemControl setReturnType:returnType];
 }
+    
+void EditBoxImplIOS::setNativeKeyboardAppearance(EditBox::KeyboardAppearance keyboardAppearance)
+{
+    [_systemControl setKeyboardAppearance:keyboardAppearance];
+}
 
 void EditBoxImplIOS::setNativeTextHorizontalAlignment(cocos2d::TextHAlignment alignment)
 {

--- a/cocos/ui/UIEditBox/UIEditBoxImpl.h
+++ b/cocos/ui/UIEditBox/UIEditBoxImpl.h
@@ -56,6 +56,8 @@ namespace cocos2d {
             virtual int  getMaxLength() = 0;
             virtual void setTextHorizontalAlignment(TextHAlignment alignment) = 0;
             virtual void setReturnType(EditBox::KeyboardReturnType returnType) = 0;
+            virtual void setKeyboardAppearance(EditBox::KeyboardAppearance keyboardAppearance) = 0;
+            
             virtual bool isEditing() = 0;
             
             virtual void setText(const char* pText) = 0;
@@ -74,6 +76,7 @@ namespace cocos2d {
             virtual EditBox::InputMode getInputMode() = 0;
             virtual EditBox::InputFlag getInputFlag() = 0;
             virtual EditBox::KeyboardReturnType getReturnType() = 0;
+            virtual EditBox::KeyboardAppearance getKeyboardAppearance() = 0;
             virtual TextHAlignment getTextHorizontalAlignment() = 0;
 
             virtual void doAnimationWhenKeyboardMove(float duration, float distance) = 0;

--- a/cocos/ui/UIEditBox/iOS/CCUIEditBoxIOS.h
+++ b/cocos/ui/UIEditBox/iOS/CCUIEditBoxIOS.h
@@ -50,6 +50,7 @@
 - (void)setInputMode:(cocos2d::ui::EditBox::InputMode)inputMode;
 - (void)setInputFlag:(cocos2d::ui::EditBox::InputFlag)flag;
 - (void)setReturnType:(cocos2d::ui::EditBox::KeyboardReturnType)returnType;
+- (void)setKeyboardAppearance:(cocos2d::ui::EditBox::KeyboardAppearance)keyboardAppearance;
 - (void)setTextHorizontalAlignment:(cocos2d::TextHAlignment)alignment;
 
 - (void)setPlaceHolder:(NSString *)text;

--- a/cocos/ui/UIEditBox/iOS/CCUIEditBoxIOS.mm
+++ b/cocos/ui/UIEditBox/iOS/CCUIEditBoxIOS.mm
@@ -261,6 +261,15 @@
     }
 }
 
+- (void)setKeyboardAppearance:(cocos2d::ui::EditBox::KeyboardAppearance)keyboardAppearance
+{
+    UIKeyboardAppearance uiKeyboardAppearance = UIKeyboardAppearance::UIKeyboardAppearanceDefault;
+    if (keyboardAppearance == cocos2d::ui::EditBox::KeyboardAppearance::DARK) {
+        uiKeyboardAppearance = UIKeyboardAppearanceDark;
+    }
+    [self.textInput setKeyboardAppearance:uiKeyboardAppearance];
+}
+
 - (void)setTextHorizontalAlignment:(cocos2d::TextHAlignment)alignment
 {
     self.textInput.ccui_alignment = static_cast<NSTextAlignment>(alignment);


### PR DESCRIPTION
We have found it useful to change the theme of the soft keyboard. iOS has several keyboard appearances available. Here, I've added support for DEFAULT and DARK keyboard appearance types. `setKeyboardAppearance()` is not implemented for the other platforms because it doesn't make sense to update the keyboard theme on the other platforms.