### PR TITLE
fix error with xcode7: The document "LaunchScreen.storyboard" require…

### DIFF
--- a/templates/cpp-template-default/proj.ios_mac/ios/LaunchScreen.storyboard
+++ b/templates/cpp-template-default/proj.ios_mac/ios/LaunchScreen.storyboard
@@ -6,7 +6,6 @@
     <dependencies>
         <deployment version="1792" identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13173"/>
-        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
         <!--View Controller-->

--- a/templates/js-template-default/frameworks/runtime-src/proj.ios_mac/ios/LaunchScreen.storyboard
+++ b/templates/js-template-default/frameworks/runtime-src/proj.ios_mac/ios/LaunchScreen.storyboard
@@ -6,7 +6,6 @@
     <dependencies>
         <deployment version="1792" identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13173"/>
-        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
         <!--View Controller-->

--- a/templates/lua-template-default/frameworks/runtime-src/proj.ios_mac/ios/LaunchScreen.storyboard
+++ b/templates/lua-template-default/frameworks/runtime-src/proj.ios_mac/ios/LaunchScreen.storyboard
@@ -6,7 +6,6 @@
     <dependencies>
         <deployment version="1792" identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13173"/>
-        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
         <!--View Controller-->

--- a/tests/cpp-empty-test/proj.ios/LaunchScreen.storyboard
+++ b/tests/cpp-empty-test/proj.ios/LaunchScreen.storyboard
@@ -6,7 +6,6 @@
     <dependencies>
         <deployment version="1792" identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13173"/>
-        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
         <!--View Controller-->

--- a/tests/cpp-tests/proj.ios/LaunchScreen.storyboard
+++ b/tests/cpp-tests/proj.ios/LaunchScreen.storyboard
@@ -6,7 +6,6 @@
     <dependencies>
         <deployment version="1792" identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13173"/>
-        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
         <!--View Controller-->

--- a/tests/js-tests/project/proj.ios/LaunchScreen.storyboard
+++ b/tests/js-tests/project/proj.ios/LaunchScreen.storyboard
@@ -6,7 +6,6 @@
     <dependencies>
         <deployment version="1792" identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13173"/>
-        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
         <!--View Controller-->

--- a/tests/lua-empty-test/project/proj.ios/LaunchScreen.storyboard
+++ b/tests/lua-empty-test/project/proj.ios/LaunchScreen.storyboard
@@ -6,7 +6,6 @@
     <dependencies>
         <deployment version="1792" identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13173"/>
-        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
         <!--View Controller-->

--- a/tests/lua-tests/project/proj.ios_mac/ios/LaunchScreen.storyboard
+++ b/tests/lua-tests/project/proj.ios_mac/ios/LaunchScreen.storyboard
@@ -6,7 +6,6 @@
     <dependencies>
         <deployment version="1792" identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13173"/>
-        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
         <!--View Controller-->


### PR DESCRIPTION
fix error with xcode7: The document "LaunchScreen.storyboard" requires Xcode 8.0 or later


——if not merge this PR, maybe we should modify README.md

Build Requirements
Mac OS X 10.7+, Xcode 7+ -> Xcode 8+