### PR TITLE
Fix a crash bug when the UserDefault.xml file is empty.

### DIFF
--- a/cocos/base/CCUserDefault.cpp
+++ b/cocos/base/CCUserDefault.cpp
@@ -73,22 +73,23 @@ static tinyxml2::XMLElement* getXMLNodeForKey(const char* pKey, tinyxml2::XMLEle
 
         if (nullptr == *rootNode)
         {
+            // try to insert xml declaration
             if (!xmlDoc->FirstChild())
             {
-                tinyxml2::XMLDeclaration *pDeclaration = xmlDoc->NewDeclaration(nullptr);
-                if (nullptr != pDeclaration)
+                tinyxml2::XMLDeclaration *xmlDeclaration = xmlDoc->NewDeclaration(nullptr);
+                if (nullptr != xmlDeclaration)
                 {
-                    xmlDoc->LinkEndChild(pDeclaration);
+                    xmlDoc->LinkEndChild(xmlDeclaration);
                 }
             }
 
-            tinyxml2::XMLElement *pRootEle = xmlDoc->NewElement(USERDEFAULT_ROOT_NAME);
-            if (nullptr != pRootEle)
-            {
-                xmlDoc->LinkEndChild(pRootEle);
-            }
+            // create root element
+            tinyxml2::XMLElement *rootEle = xmlDoc->NewElement(USERDEFAULT_ROOT_NAME);
+            if (nullptr == rootEle)
+                break;
 
-            *rootNode = pRootEle;
+            xmlDoc->LinkEndChild(rootEle);
+            *rootNode = rootEle;
         }
 
         // find the node

--- a/cocos/editor-support/cocostudio/ActionTimeline/CCFrame.cpp
+++ b/cocos/editor-support/cocostudio/ActionTimeline/CCFrame.cpp
@@ -149,7 +149,8 @@ TextureFrame* TextureFrame::create()
 }
 
 TextureFrame::TextureFrame()
-    : _textureName("")
+    : _sprite(nullptr)
+    , _textureName("")
 {
 }
 

--- a/cocos/platform/CCFileUtils.cpp
+++ b/cocos/platform/CCFileUtils.cpp
@@ -86,6 +86,7 @@ public:
 public:
     DictMaker()
         : _resultType(SAX_RESULT_NONE)
+        , _state(SAX_NONE)
     {
     }
 


### PR DESCRIPTION
When the UserDefault.xml file in local disk has no content, the program will crash with using UserDefault::setStringForKey function.