### PR TITLE
fix a compile warning on win32(warning C4477)

### DIFF
--- a/cocos/base/CCConsole.cpp
+++ b/cocos/base/CCConsole.cpp
@@ -530,7 +530,11 @@ bool Console::listenOnTCP(int port)
 #endif
 
     if ( (n = getaddrinfo(nullptr, serv, &hints, &res)) != 0) {
-        fprintf(stderr,"net_listen error for %s: %s", serv, gai_strerror(n));
+#if (CC_TARGET_PLATFORM == CC_PLATFORM_WIN32)
+        fprintf(stderr, "net_listen error for %s: %s", serv, gai_strerrorA(n));
+#else
+        fprintf(stderr, "net_listen error for %s: %s", serv, gai_strerror(n));
+#endif
         return false;
     }
 


### PR DESCRIPTION
warning C4477: 'fprintf' : format string '%s' requires an argument of type 'char *', but variadic argument 2 has type 'WCHAR *'
note: consider using '%ls' in the format string
note: consider using '%lls' in the format string
note: consider using '%Ls' in the format string
note: consider using '%ws' in the format string