### PR TITLE
Fix scroll teleport bug when bouncing in the right side of view.

### DIFF
--- a/cocos/ui/UIScrollView.cpp
+++ b/cocos/ui/UIScrollView.cpp
@@ -491,6 +491,7 @@ void ScrollView::startAutoScroll(const Vec2& deltaMove, float timeInSec, bool at
         Vec2 afterOutOfBoundary = getHowMuchOutOfBoundary(adjustedDeltaMove);
         if(currentOutOfBoundary.x * afterOutOfBoundary.x > 0 || currentOutOfBoundary.y * afterOutOfBoundary.y > 0)
         {
+            _autoScrollBrakingStartPosition = getInnerContainerPosition();
             _autoScrollBraking = true;
         }
     }


### PR DESCRIPTION
We have been using this fix since v3.12. 
Although it is not fully tested against the test app, it probably addresses issue #18616.

I'm putting this PR up for further testing.