### PR TITLE
Fix no-break space size

### DIFF
--- a/cocos/2d/CCLabel.cpp
+++ b/cocos/2d/CCLabel.cpp
@@ -1866,7 +1866,7 @@ void Label::computeStringNumLines()
     size_t stringLen = _utf32Text.length();
     for (size_t i = 0; i < stringLen - 1; ++i)
     {
-        if (_utf32Text[i] == (char32_t)TextFormatter::NewLine)
+        if (_utf32Text[i] == StringUtils::UnicodeCharacters::NewLine)
         {
             quantityOfLines++;
         }

--- a/cocos/2d/CCLabel.h
+++ b/cocos/2d/CCLabel.h
@@ -81,13 +81,6 @@ typedef struct _ttfConfig
     }
 } TTFConfig;
 
-enum class TextFormatter : char
-{
-    NewLine = '\n',
-    CarriageReturn = '\r',
-    NextCharNoChangeX = '\b'
-};
-
 class Sprite;
 class SpriteBatchNode;
 class DrawNode;
@@ -639,6 +632,7 @@ protected:
     };
 
     virtual void setFontAtlas(FontAtlas* atlas, bool distanceFieldEnabled = false, bool useA8Shader = false);
+    bool getFontLetterDef(char32_t character, FontLetterDefinition& letterDef) const;
 
     void computeStringNumLines();
 
@@ -676,8 +670,8 @@ protected:
     bool isHorizontalClamped(float letterPositionX, int lineIndex);
     void restoreFontSize();
     void updateLetterSpriteScale(Sprite* sprite);
-    int getFirstCharLen(const std::u32string& utf32Text, int startIndex, int textLen);
-    int getFirstWordLen(const std::u32string& utf32Text, int startIndex, int textLen);
+    int getFirstCharLen(const std::u32string& utf32Text, int startIndex, int textLen) const;
+    int getFirstWordLen(const std::u32string& utf32Text, int startIndex, int textLen) const;
 
     void reset();
 

--- a/cocos/2d/CCLabelTextFormatter.cpp
+++ b/cocos/2d/CCLabelTextFormatter.cpp
@@ -72,54 +72,65 @@ void Label::computeAlignmentOffset()
     }
 }
 
-int Label::getFirstCharLen(const std::u32string& /*utf32Text*/, int /*startIndex*/, int /*textLen*/)
+int Label::getFirstCharLen(const std::u32string& /*utf32Text*/, int /*startIndex*/, int /*textLen*/) const
 {
     return 1;
 }
 
-int Label::getFirstWordLen(const std::u32string& utf32Text, int startIndex, int textLen)
+int Label::getFirstWordLen(const std::u32string& utf32Text, int startIndex, int textLen) const
 {
-    auto character = utf32Text[startIndex];
-    if (StringUtils::isCJKUnicode(character) || StringUtils::isUnicodeSpace(character) || character == (char32_t)TextFormatter::NewLine)
-    {
-        return 1;
-    }
-
-    int len = 1;
+    int len = 0;
+    auto nextLetterX = 0;
     FontLetterDefinition letterDef;
-    if(!_fontAtlas->getLetterDefinitionForChar(character, letterDef)) {
-        return len;
-    }
-    auto nextLetterX = letterDef.xAdvance * _bmfontScale + _additionalKerning;
-
     auto contentScaleFactor = CC_CONTENT_SCALE_FACTOR();
-    for (int index = startIndex + 1; index < textLen; ++index)
+
+    for (int index = startIndex; index < textLen; ++index)
     {
-        character = utf32Text[index];
-        if (!_fontAtlas->getLetterDefinitionForChar(character, letterDef))
-        {
-            break;
-        }
+        char32_t character = utf32Text[index];
 
-        auto letterX = (nextLetterX + letterDef.offsetX * _bmfontScale) / contentScaleFactor;
-        if (_maxLineWidth > 0.f && letterX + letterDef.width * _bmfontScale > _maxLineWidth
-            && !StringUtils::isUnicodeSpace(character))
-        {
-            return len;
-        }
-
-        nextLetterX += letterDef.xAdvance * _bmfontScale + _additionalKerning;
-
-        if (character == (char16_t)TextFormatter::NewLine
+        if (character == StringUtils::UnicodeCharacters::NewLine
             || StringUtils::isUnicodeSpace(character)
             || StringUtils::isCJKUnicode(character))
         {
             break;
         }
+
+        if (!getFontLetterDef(character, letterDef))
+        {
+            break;
+        }
+
+        if (_maxLineWidth > 0.f)
+        {
+            auto letterX = (nextLetterX + letterDef.offsetX * _bmfontScale) / contentScaleFactor;
+
+            if (letterX + letterDef.width * _bmfontScale > _maxLineWidth)
+                break;
+        }
+
+        nextLetterX += letterDef.xAdvance * _bmfontScale + _additionalKerning;
+
         len++;
     }
 
+    if (len == 0 && textLen)
+        len = 1;
+
     return len;
+}
+
+bool Label::getFontLetterDef(char32_t character, FontLetterDefinition& letterDef) const
+{
+    if (character == StringUtils::UnicodeCharacters::NoBreakSpace)
+    {
+        // change no-break space to regular space
+        // reason: some fonts have issue with no-break space:
+        //   * no letter definition
+        //   * not normal big width
+        character = StringUtils::UnicodeCharacters::Space;
+    }
+
+    return _fontAtlas->getLetterDefinitionForChar(character, letterDef);
 }
 
 void Label::updateBMFontScale()
@@ -155,8 +166,8 @@ bool Label::multilineTextWrap(const std::function<int(const std::u32string&, int
 
     for (int index = 0; index < textLen; )
     {
-        auto character = _utf32Text[index];
-        if (character == (char32_t)TextFormatter::NewLine)
+        char32_t character = _utf32Text[index];
+        if (character == StringUtils::UnicodeCharacters::NewLine)
         {
             _linesWidth.push_back(letterRight);
             letterRight = 0.f;
@@ -178,22 +189,23 @@ bool Label::multilineTextWrap(const std::function<int(const std::u32string&, int
         {
             int letterIndex = index + tmp;
             character = _utf32Text[letterIndex];
-            if (character == (char16_t)TextFormatter::CarriageReturn)
+            if (character == StringUtils::UnicodeCharacters::CarriageReturn)
             {
                 recordPlaceholderInfo(letterIndex, character);
                 continue;
             }
             // \b - Next char not change x position
-            if (character == (char16_t)TextFormatter::NextCharNoChangeX)
+            if (character == StringUtils::UnicodeCharacters::NextCharNoChangeX)
             {
                 nextChangeSize = false;
                 recordPlaceholderInfo(letterIndex, character);
                 continue;
             }
-            if (!_fontAtlas->getLetterDefinitionForChar(character, letterDef))
+
+            if (!getFontLetterDef(character, letterDef))
             {
                 recordPlaceholderInfo(letterIndex, character);
-                CCLOG("LabelTextFormatter error:can't find letter definition in font file for letter: %c", character);
+                CCLOG("LabelTextFormatter error: can't find letter definition in font file for letter: 0x%x", character);
                 continue;
             }
 

--- a/cocos/2d/CCTextFieldTTF.cpp
+++ b/cocos/2d/CCTextFieldTTF.cpp
@@ -244,7 +244,7 @@ void TextFieldTTF::insertText(const char * text, size_t len)
     std::string insert(text, len);
 
     // insert \n means input end
-    int pos = static_cast<int>(insert.find((char)TextFormatter::NewLine));
+    int pos = static_cast<int>(insert.find(StringUtils::AsciiCharacters::NewLine));
     if ((int)insert.npos != pos)
     {
         len = pos;
@@ -571,7 +571,7 @@ void TextFieldTTF::makeStringSupportCursor(std::string& displayText)
         {
             // \b - Next char not change x position
             if (_currentLabelType == LabelType::TTF || _currentLabelType == LabelType::BMFONT)
-                displayText.push_back((char) TextFormatter::NextCharNoChangeX);
+                displayText.push_back(StringUtils::AsciiCharacters::NextCharNoChangeX);
             displayText.push_back(_cursorChar);
         }
         else
@@ -587,7 +587,7 @@ void TextFieldTTF::makeStringSupportCursor(std::string& displayText)
             std::string cursorChar;
             // \b - Next char not change x position
             if (_currentLabelType == LabelType::TTF || _currentLabelType == LabelType::BMFONT)
-                cursorChar.push_back((char)TextFormatter::NextCharNoChangeX);
+                cursorChar.push_back(StringUtils::AsciiCharacters::NextCharNoChangeX);
             cursorChar.push_back(_cursorChar);
             stringUTF8.insert(_cursorPosition, cursorChar);
 

--- a/cocos/base/ccUTF8.cpp
+++ b/cocos/base/ccUTF8.cpp
@@ -50,10 +50,10 @@ std::string format(const char* format, ...)
     va_end(args);
 
     if (nret >= 0) {
-        if (nret < (int)buffer.length()) {
+        if ((unsigned int)nret < buffer.length()) {
             buffer.resize(nret);
         }
-        else if (nret > (int)buffer.length()) { // VS2015/2017 or later Visual Studio Version
+        else if ((unsigned int)nret > buffer.length()) { // VS2015/2017 or later Visual Studio Version
             buffer.resize(nret);
 
             va_start(args, format);

--- a/cocos/base/ccUTF8.cpp
+++ b/cocos/base/ccUTF8.cpp
@@ -50,10 +50,10 @@ std::string format(const char* format, ...)
     va_end(args);
 
     if (nret >= 0) {
-        if (nret < buffer.length()) {
+        if (nret < (int)buffer.length()) {
             buffer.resize(nret);
         }
-        else if (nret > buffer.length()) { // VS2015/2017 or later Visual Studio Version
+        else if (nret > (int)buffer.length()) { // VS2015/2017 or later Visual Studio Version
             buffer.resize(nret);
 
             va_start(args, format);

--- a/cocos/base/ccUTF8.h
+++ b/cocos/base/ccUTF8.h
@@ -39,6 +39,21 @@ NS_CC_BEGIN
 
 namespace StringUtils {
 
+namespace UnicodeCharacters {
+    const char32_t NewLine                = 0x000A; // 10
+    const char32_t CarriageReturn         = 0x000D; // 13
+    const char32_t NextCharNoChangeX      = 0x0008; // 8
+    const char32_t Space                  = 0x0020; // 32
+    const char32_t NoBreakSpace           = 0x00A0; // 160
+}
+
+namespace AsciiCharacters {
+    const char NewLine                    = '\n';
+    const char CarriageReturn             = '\r';
+    const char NextCharNoChangeX          = '\b';
+    const char Space                      = ' ';
+}
+
 template<typename T>
 std::string toString(T arg)
 {

--- a/cocos/physics3d/CCPhysics3DWorld.h
+++ b/cocos/physics3d/CCPhysics3DWorld.h
@@ -36,7 +36,7 @@
 class btDynamicsWorld;
 class btDefaultCollisionConfiguration;
 class btCollisionDispatcher;
-class btDbvtBroadphase;
+struct btDbvtBroadphase;
 class btSequentialImpulseConstraintSolver;
 class btGhostPairCallback;
 class btRigidBody;

--- a/tests/cpp-tests/Classes/ConsoleTest/ConsoleTest.cpp
+++ b/tests/cpp-tests/Classes/ConsoleTest/ConsoleTest.cpp
@@ -72,7 +72,7 @@ std::string BaseTestConsole::title() const
 ConsoleCustomCommand::ConsoleCustomCommand()
 {
     _console = Director::getInstance()->getConsole();
-    static struct Console::Command commands[] = {
+    static Console::Command commands[] = {
         {"hello", "This is just a user generated command", [](int fd, const std::string& args) {
             const char msg[] = "how are you?\nArguments passed: ";
             send(fd, msg, sizeof(msg),0);

--- a/tests/cpp-tests/Classes/LabelTest/LabelTestNew.cpp
+++ b/tests/cpp-tests/Classes/LabelTest/LabelTestNew.cpp
@@ -92,6 +92,7 @@ NewLabelTests::NewLabelTests()
     ADD_TEST_CASE(LabelIssue9500Test);
     ADD_TEST_CASE(LabelWrapByWordTest);
     ADD_TEST_CASE(LabelWrapByCharTest);
+    ADD_TEST_CASE(LabelWrapNoBreakSpaceTest);
     ADD_TEST_CASE(LabelShrinkByWordTest);
     ADD_TEST_CASE(LabelShrinkByCharTest);
     ADD_TEST_CASE(LabelResizeTest);
@@ -2515,6 +2516,30 @@ std::string LabelWrapByCharTest::subtitle() const
 {
     return "";
 }
+
+/////////////////////////////////////////////////
+
+LabelWrapNoBreakSpaceTest::LabelWrapNoBreakSpaceTest()
+{
+    _label->setLineBreakWithoutSpace(false);
+    const char* no_break_space_utf8 = "\xC2\xA0"; // 0xA0 - no-break space
+    auto str = StringUtils::format("The price is $%s1.25", no_break_space_utf8);
+    _label->setString(str);
+    _label->setVerticalAlignment(TextVAlignment::TOP);
+    _label->setOverflow(Label::Overflow::RESIZE_HEIGHT);
+}
+
+std::string LabelWrapNoBreakSpaceTest::title() const
+{
+    return "Wrap Test: No break space";
+}
+
+std::string LabelWrapNoBreakSpaceTest::subtitle() const
+{
+    return "";
+}
+
+/////////////////////////////////////////////////
 
 LabelShrinkByWordTest::LabelShrinkByWordTest()
 {

--- a/tests/cpp-tests/Classes/LabelTest/LabelTestNew.h
+++ b/tests/cpp-tests/Classes/LabelTest/LabelTestNew.h
@@ -704,6 +704,17 @@ public:
     virtual std::string subtitle() const override;
 };
 
+class LabelWrapNoBreakSpaceTest : public LabelLayoutBaseTest
+{
+public:
+    CREATE_FUNC(LabelWrapNoBreakSpaceTest);
+
+    LabelWrapNoBreakSpaceTest();
+
+    virtual std::string title() const override;
+    virtual std::string subtitle() const override;
+};
+
 class LabelShrinkByWordTest : public LabelLayoutBaseTest
 {
 public:


### PR DESCRIPTION
Some fonts have an issue with no-break space:

- no letter definition
- not normal big width

Added test to reproduce the issue:
![image](https://user-images.githubusercontent.com/1271541/35475080-c33477bc-03a0-11e8-8cb1-c14f25a38518.png)

After fix:
![image](https://user-images.githubusercontent.com/1271541/35475050-5279d7e2-03a0-11e8-9364-72f1b03d7d73.png)
