### PR TITLE
Fix warning for silently converting int to float

### DIFF
--- a/cocos/ui/UITabControl.h
+++ b/cocos/ui/UITabControl.h
@@ -290,7 +290,7 @@ namespace ui {
         * get tab header's width
         * @return header's width
         */
-        float getHeaderWidth() const { return _headerWidth; }
+        float getHeaderWidth() const { return (float)_headerWidth; }
 
         /**
         * set header height, affect all tab


### PR DESCRIPTION
Could use a static_cast but it doesn't seem to be the style