### PR TITLE
Fix compile shader error on windows

### DIFF
--- a/cocos/renderer/CCGLProgram.cpp
+++ b/cocos/renderer/CCGLProgram.cpp
@@ -487,7 +487,7 @@ bool GLProgram::compileShader(GLuint * shader, GLenum type, const GLchar* source
 #if CC_TARGET_PLATFORM == CC_PLATFORM_WINRT
         headersDef = (type == GL_VERTEX_SHADER ? "precision mediump float;\n precision mediump int;\n" : "precision mediump float;\n precision mediump int;\n");
 // Bugfix to make shader variables types constant to be understood by the current Android Virtual Devices or Emulators. This will also eliminate the 0x501 and 0x502 OpenGL Errors during emulation.
-#elif CC_TARGET_PLATFORM == CC_PLATFORM_ANDROID
+#elif CC_TARGET_PLATFORM == CC_PLATFORM_ANDROID || CC_TARGET_PLATFORM == CC_PLATFORM_WIN32
         headersDef = "#version 100\n precision mediump float;\n precision mediump int;\n";
 #elif (CC_TARGET_PLATFORM != CC_PLATFORM_WIN32 && CC_TARGET_PLATFORM != CC_PLATFORM_LINUX && CC_TARGET_PLATFORM != CC_PLATFORM_MAC)
         headersDef = (type == GL_VERTEX_SHADER ? "precision highp float;\n precision highp int;\n" : "precision mediump float;\n precision mediump int;\n");


### PR DESCRIPTION
The error happens when running JavaScript project on windows.
Error trace:

> cocos2d: ERROR: Failed to compile shader:
> uniform mat4 CC_PMatrix;
> uniform mat4 CC_MultiViewPMatrix[4];
> uniform mat4 CC_MVMatrix;
> uniform mat4 CC_MVPMatrix;
> uniform mat4 CC_MultiViewMVPMatrix[4];
> uniform mat3 CC_NormalMatrix;
> uniform vec4 CC_Time;
> uniform vec4 CC_SinTime;
> uniform vec4 CC_CosTime;
> uniform vec4 CC_Random01;
> uniform sampler2D CC_Texture0;
> uniform sampler2D CC_Texture1;
> uniform sampler2D CC_Texture2;
> uniform sampler2D CC_Texture3;
> //CC INCLUDES END
> 
> attribute vec4 a_position; 
> attribute vec2 a_texCoord; 
> attribute vec4 a_color;  
> varying lowp vec4 v_fragmentColor; 
> varying mediump vec2 v_texCoord; 
> void main() 
> { 
>     gl_Position = CC_PMatrix * a_position;  
>     v_fragmentColor = a_color; 
>     v_texCoord = a_texCoord; 
> }
> cocos2d: 0(20) : error C0000: syntax error, unexpected identifier, expecting "::" at token "lowp"
> 
> cocos2d: ERROR: Failed to compile vertex shader
> cocos2d: ERROR: Failed to link program: 106