### PR TITLE
Fix bug where any new PhysicsShape added to PhysicsBody might have the wrong scale as setScale() might not be called in beforeSimulation() if _recordScaleX and _recordScaleY are not changed.

### DIFF
--- a/cocos/physics/CCPhysicsBody.cpp
+++ b/cocos/physics/CCPhysicsBody.cpp
@@ -425,6 +425,13 @@ PhysicsShape* PhysicsBody::addShape(PhysicsShape* shape, bool addMassAndMoment/*
         }
         
         _shapes.pushBack(shape);
+
+        // Update scale as well, otherwise if a PhysicsShape is added, it will not be scaled properly.
+        // What is updated here are those that are not updated in .
+        // Since adding a physics body does not affect _recordScaleX, and _recordScaleY,
+        // the setScale() will not be called in beforeSimulation().
+        // However, we need to update it so that the new PhysicsShape is updated.
+        setScale(_recordScaleX, _recordScaleY);
     }
     
     return shape;


### PR DESCRIPTION
In PhysicsBody's beforeUpdate, it checks if _recordScaleX or _recordScaleY has been changed before calling setScale(). If _recordScaleX and _recordScaleY are not changed, and a new PhysicsShape is added, the new PhysicsShape will not be scaled since setScale() will not be called.