### PR TITLE
Fix infinite loop when counting text lines on Android

### DIFF
--- a/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxBitmap.java
+++ b/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxBitmap.java
@@ -92,8 +92,14 @@ public final class Cocos2dxBitmap {
         int length = text.length();
 
         while(index < length) {
-            index += paint.breakText(text, index, length, true, maxWidth, null);
-            lineCount++;
+            final int charsToAdvance = paint.breakText(text, index, length, true, maxWidth, null);
+            if(charsToAdvance == 0) {
+                index++;
+            }
+            else {
+                index += charsToAdvance;
+                lineCount++;
+            }
         }
 
         float actualHeight = (Math.abs(paint.ascent()) + Math.abs(paint.descent()));


### PR DESCRIPTION
In some situations, breakText() can return 0, which leads to an infinite loop. In that case we just increase the index so the measuring doesn't get stuck.

This is a simple example that reproduces this issue:
```
cocos2d::Label* label = cocos2d::Label::createWithSystemFont("\n", "arial", 16, cocos2d::Size(100, 100));
label->enableWrap(false);
label->setOverflow(cocos2d::Label::Overflow::SHRINK);
scene->addChild(label);
```