### PR TITLE
add cmake guide docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,3 +160,6 @@ tests/lua-tests/project/proj.tizen/res/
 
 # Ignore static libraries
 *.a
+
+# Ignore the CMake build folder, such as ios-build/linux-build
+*-build/

--- a/README.md
+++ b/README.md
@@ -114,11 +114,10 @@ Using CMake
 --------------------------------
 
 Now Cocos2d-x support another project build method, it's CMake! CMake have great benefits when cross-platform compiling. The most sample way to use is:
-```
-$ cd cocos2d-x
-$ mkdir cmake-build && cd cmake-build
-$ cmake ..
-```
+
+    $ cd cocos2d-x
+    $ mkdir cmake-build && cd cmake-build
+    $ cmake ..
 
 Documentations and samples
 -------------

--- a/README.md
+++ b/README.md
@@ -230,6 +230,18 @@ $ adb install ../tests/cpp-empty-test/proj.android/bin/CppEmptyTest-debug.apk
 
 Then click item on Android device to run tests. Available value of `-p` is the API level, cocos2d-x supports from level 14.
 
+Using CMake
+--------------------------------
+
+Now Cocos2d-x support another project build method, it's CMake! CMake have great benefits when cross-platform compiling. The most sample way to use is:
+```
+$ cd cocos2d-x
+$ mkdir cmake-build && cd cmake-build
+$ cmake ..
+```
+
+* [Detail CMake Guide](https://github.com/cocos2d/cocos2d-x/blob/v3/cmake/README.md)
+
 Learning Resources
 --------------------------------
 

--- a/README.md
+++ b/README.md
@@ -110,6 +110,16 @@ Or you can publish your game to `publish/html5/` folder:
 
     $ cocos run -p web -m release [--advanced]
 
+Using CMake
+--------------------------------
+
+Now Cocos2d-x support another project build method, it's CMake! CMake have great benefits when cross-platform compiling. The most sample way to use is:
+```
+$ cd cocos2d-x
+$ mkdir cmake-build && cd cmake-build
+$ cmake ..
+```
+
 Documentations and samples
 -------------
 * [All Docs in a single place!](http://cocos2d-x.org/docs/)
@@ -230,17 +240,7 @@ $ adb install ../tests/cpp-empty-test/proj.android/bin/CppEmptyTest-debug.apk
 
 Then click item on Android device to run tests. Available value of `-p` is the API level, cocos2d-x supports from level 14.
 
-Using CMake
---------------------------------
-
-Now Cocos2d-x support another project build method, it's CMake! CMake have great benefits when cross-platform compiling. The most sample way to use is:
-```
-$ cd cocos2d-x
-$ mkdir cmake-build && cd cmake-build
-$ cmake ..
-```
-
-* [Detail CMake Guide](https://github.com/cocos2d/cocos2d-x/blob/v3/cmake/README.md)
+* [Detail CMake Guide](cmake/README.md)
 
 Learning Resources
 --------------------------------

--- a/cmake/README.md
+++ b/cmake/README.md
@@ -34,8 +34,6 @@ cmake .. -G"Visual Studio 15 2017" -Tv141
 
 Execute `cmake --build .` to compile, or open `Cocos2d-x.sln` in Explorer to use the generated project. 
 
-Execute `cmake --build` to see the build menu.
-
 ### Generate macOS Project
 
 ```sh
@@ -56,7 +54,7 @@ open Cocos2d-x.xcodeproj
 
 ### CMake in Android Studio
 
-We use the Gradle to Android Applacition, and Gradle use CMake to build the native part, see the [property](https://github.com/cocos2d/cocos2d-x/blob/84be684e3858393a6f3efc50e3f95d4e0ac92a20/tests/cpp-empty-test/proj.android/gradle.properties#L38): `PROP_NDK_MODE`, it control the way of native build
+We use the Gradle to Android applacition, and Gradle use cmake to build the native code, see the [property](https://github.com/cocos2d/cocos2d-x/blob/84be684e3858393a6f3efc50e3f95d4e0ac92a20/tests/cpp-empty-test/proj.android/gradle.properties#L38): `PROP_NDK_MODE`, it control the way of native build
 
 ```sh
 # android cmake support
@@ -69,9 +67,9 @@ If you want to add cmake build arguments, please add it at [externalNativeBuild]
 
 ## Prebuilt Feature
 
-To solve the probelm compiling engine sources spends too long time, we add the feature of pre-builds libs. Using this feature you only need build engine sources once for a specific environment.
+To solve the problem that compiling engine sources spends too long time, we add the feature of pre-builds libs. Using this feature you only need build engine sources once for a specific environment.
 
-This is a example of build libs once, and use it in next build:
+### Next is a example of build libs once, and use it in next build:
 
 ```sh
 cocos new -l cpp -p my.pack.app1 test_app1
@@ -86,7 +84,7 @@ make TemplateCpp
 open bin/TemplateCpp.app
 ```
 
-add `-DUSE_COCOS_PREBUILT=ON` to use prebuilt libs.
+add `-DUSE_COCOS_PREBUILT=ON` to use prebuilt libs in another cmake build.
 
 ```sh
 cocos new -l cpp -p my.pack.app2 test_app2
@@ -97,7 +95,7 @@ open bin/TemplateCpp.app
 ```
 > Any other cpp project can use prebuilt in this way
 
-Using this feature on Android exists a little difference, for CMake can't find system environment when build in Gradle. so you need to [supply a path](https://github.com/cocos2d/cocos2d-x/blob/c087be314c2c56a757bf66163b173746b5d6ad34/tests/cpp-empty-test/proj.android/app/build.gradle#L34) as the location of prebuilt libs.
+Using this feature on Android exists a little difference, for CMake can't find system environment when build in Gradle. So you need to [supply a path](https://github.com/cocos2d/cocos2d-x/blob/c087be314c2c56a757bf66163b173746b5d6ad34/tests/cpp-empty-test/proj.android/app/build.gradle#L34) as the location of prebuilt libs.
 
 ## Build Options
 
@@ -136,7 +134,7 @@ Using this feature on Android exists a little difference, for CMake can't find s
 
 1. Any options in [SelectModule.cmake](./Modules/SelectModule.cmake) can be set manually. Do it if you know what you're doing.
 
-## Links
+## Useful Links
 
 * Official website: [cmake.org](https://cmake.org/)
 

--- a/cmake/README.md
+++ b/cmake/README.md
@@ -3,13 +3,11 @@
 
 CMake is an open-source, cross-platform family of tools designed to build, test and package software. CMake is used to control the software compilation process using simple platform and compiler independent configuration files, and generate native makefiles and workspaces that can be used in the compiler environment of your choice.
 
-## In Cocos2d-x
-
-1. CMake in Cocos2d-x support platform iOS, Android, macOS, Linux, Win32.
+## Requirement
 
 1. Open your terminal, input `cmake --version`, if the cmake version is lower than 3.1, please upgrade
 
-2. You should use out-of-source build, that is said you need to create a different directory from `$cocos2dx_root` to execute cmake command.
+2. You should use out-of-source build, that is said you need to create a different directory from `cocos2d-x` to execute cmake command.
 
 ## Step by Step
 
@@ -65,7 +63,7 @@ PROP_NDK_MODE=cmake
 
 If you want to add cmake build arguments, please add it at [externalNativeBuild](https://github.com/cocos2d/cocos2d-x/blob/84be684e3858393a6f3efc50e3f95d4e0ac92a20/tests/cpp-empty-test/proj.android/app/build.gradle#L25) block of [app/build.gradle] file.
 
-## Prebuilt Feature
+## Prebuilt feature
 
 To solve the problem that compiling engine sources spends too long time, we add the feature of pre-builds libs. Using this feature you only need build engine sources once for a specific environment.
 
@@ -77,14 +75,16 @@ mkdir app1_build && cd app1_build
 cmake ../test_app1 -DGEN_COCOS_PREBUILT=ON
 make prebuilt
 ```
-close option `GEN_COCOS_PREBUILT` and open `USE_COCOS_PREBUILT` to use prebuilt in the same project
+
+Close option `GEN_COCOS_PREBUILT` and open `USE_COCOS_PREBUILT` to use prebuilt in the same project
+
 ```sh
 cmake ../test_app1 -DGEN_COCOS_PREBUILT=OFF -DUSE_COCOS_PREBUILT=ON
 make TemplateCpp
 open bin/TemplateCpp.app
 ```
 
-add `-DUSE_COCOS_PREBUILT=ON` to use prebuilt libs in another cmake build.
+Add `-DUSE_COCOS_PREBUILT=ON` to use prebuilt libs in another cmake build.
 
 ```sh
 cocos new -l cpp -p my.pack.app2 test_app2

--- a/cmake/ios.toolchain.cmake
+++ b/cmake/ios.toolchain.cmake
@@ -91,7 +91,7 @@ endif (NOT DEFINED CMAKE_INSTALL_NAME_TOOL)
 
 # Setup iOS platform unless specified manually with IOS_PLATFORM
 if (NOT DEFINED IOS_PLATFORM)
-	set (IOS_PLATFORM "OS")
+	set (IOS_PLATFORM "SIMULATOR64")
 endif (NOT DEFINED IOS_PLATFORM)
 set (IOS_PLATFORM ${IOS_PLATFORM} CACHE STRING "Type of iOS Platform")
 


### PR DESCRIPTION
1. improve cmake docs, add using the prebuilt libs docs
2. change the default iOS build target from i386 to 64, make default value alway build success