### PR TITLE
Fix the vertical clipping of BMFont labels

### DIFF
--- a/cocos/2d/CCLabel.cpp
+++ b/cocos/2d/CCLabel.cpp
@@ -928,7 +928,7 @@ bool Label::updateQuads()
                 }
                 if (py - letterDef.height * _bmfontScale < _tailoredBottomY)
                 {
-                    _reusedRect.size.height = (py < _tailoredBottomY) ? 0.f : (py - _tailoredBottomY);
+                    _reusedRect.size.height = (py < _tailoredBottomY) ? 0.f : (py - _tailoredBottomY) / _bmfontScale;
                 }
             }
 

--- a/cocos/2d/CCLabel.cpp
+++ b/cocos/2d/CCLabel.cpp
@@ -921,8 +921,9 @@ bool Label::updateQuads()
                 if (py > _tailoredTopY)
                 {
                     auto clipTop = py - _tailoredTopY;
-                    _reusedRect.origin.y += clipTop;
-                    _reusedRect.size.height -= clipTop;
+                    const float letterClipTop = clipTop / _bmfontScale;
+                    _reusedRect.origin.y += letterClipTop;
+                    _reusedRect.size.height -= letterClipTop;
                     py -= clipTop;
                 }
                 if (py - letterDef.height * _bmfontScale < _tailoredBottomY)


### PR DESCRIPTION
In some particular cases, when using a BMFont in a label and setting dimensions which are smaller than the contents of the label, the vertical clipping isn't computed properly and the label shows garbage, corresponding to contiguous characters in the texture. I guess it may also be related to other reported issues if the referenced character is at the border of the texture (maybe #17371 or #10422). I initially faced the issue with characters that extended below the base line (like the "j") in the bottom line of the label, but then I found that it also happens when reducing the label dimension enough.

In my case I could reproduce it with the following code:
```
cocos2d::Label* label = cocos2d::Label::createWithBMFont("example.fnt", "j");
label->setBMFontSize(23.0f);
const cocos2d::Size& sceneSize = scene->getContentSize();
label->setPosition(sceneSize.width * 0.5f, sceneSize.height * 0.5f);
label->setVerticalAlignment(cocos2d::TextVAlignment::TOP);
label->setDimensions(20.0f, 10.0f);
scene->addChild(label, 1000);
```

The problem is that the clipping computation doesn't take into account the BMFont scale, making the result depend on the content scale factor. Adding this factor in the computations changed the height at which the bottom of the characters is clipped, removing some incorrect offsets and not showing garbage anymore.

I'm not sure the new clipping height is the desired one, since it falls below the bottom of the content size, but at least it shows a consistent behavior among scale factors. I've tried to fix this but it seems that there are some inconsistencies in the way tokenLowestY is computed, mixing screen-space and design-space coordinates. Overall it feels like this code needs some double-checking by someone who knows it better than me.

The following table shows the differences visually, for labels with bottom, middle and top alignments, and different vertical dimensions. The pink rectangle shows the content size of the label:

Content scale factor | 1 | 2 | 3
-- | -- | -- | --
Original | ![0-original-1](https://user-images.githubusercontent.com/32454050/37475905-140198ee-2874-11e8-96e2-ba1cff2b95e0.png) | ![0-original-2](https://user-images.githubusercontent.com/32454050/37475909-167fadcc-2874-11e8-885a-8a7bcc49dce1.png) | ![0-original-3](https://user-images.githubusercontent.com/32454050/37475915-18893020-2874-11e8-8722-6dd07037b66f.png)
After fixing top clipping | ![1-topclip-fixed-1](https://user-images.githubusercontent.com/32454050/37475971-3a9a9190-2874-11e8-8901-b37ac1ddeee5.png) | ![1-topclip-fixed-2](https://user-images.githubusercontent.com/32454050/37475972-3aceeb52-2874-11e8-9423-f43d6e7bcc74.png) | ![1-topclip-fixed-3](https://user-images.githubusercontent.com/32454050/37475973-3aeeb9e6-2874-11e8-9044-cb46bcd6e3b4.png)
After fixing bottom clipping | ![2-bottomclip-fixed-1](https://user-images.githubusercontent.com/32454050/37475991-4976af46-2874-11e8-953d-4dbe085c38eb.png) | ![2-bottomclip-fixed-2](https://user-images.githubusercontent.com/32454050/37475992-49a85c80-2874-11e8-8a60-3c981b81ed71.png) | ![2-bottomclip-fixed-3](https://user-images.githubusercontent.com/32454050/37475993-49e125ce-2874-11e8-90f5-c3573b37acfd.png)