### PR TITLE
Fix inconsistent shrinking in Label

### DIFF
--- a/cocos/2d/CCLabel.cpp
+++ b/cocos/2d/CCLabel.cpp
@@ -939,7 +939,7 @@ bool Label::updateQuads()
                     if(_overflow == Overflow::CLAMP){
                         _reusedRect.size.width = 0;
                     }else if(_overflow == Overflow::SHRINK){
-                        if (_contentSize.width > letterDef.width) {
+                        if (_contentSize.width > letterDef.width || getRenderingFontSize() > 1) {
                             ret = false;
                             break;
                         }else{

--- a/cocos/2d/CCLabel.cpp
+++ b/cocos/2d/CCLabel.cpp
@@ -932,7 +932,7 @@ bool Label::updateQuads()
             }
 
             auto lineIndex = _lettersInfo[ctr].lineIndex;
-            auto px = _lettersInfo[ctr].positionX + letterDef.width/2 * _bmfontScale + _linesOffsetX[lineIndex];
+            auto px = _lettersInfo[ctr].positionX + letterDef.width/2 * _bmfontScale;
 
             if(_labelWidth > 0.f){
                 if (this->isHorizontalClamped(px, lineIndex)) {

--- a/cocos/2d/CCLabel.cpp
+++ b/cocos/2d/CCLabel.cpp
@@ -932,7 +932,7 @@ bool Label::updateQuads()
             }
 
             auto lineIndex = _lettersInfo[ctr].lineIndex;
-            auto px = _lettersInfo[ctr].positionX + letterDef.width/2 * _bmfontScale;
+            auto px = _lettersInfo[ctr].positionX + (letterDef.xAdvance - letterDef.offsetX) * _bmfontScale / CC_CONTENT_SCALE_FACTOR();
 
             if(_labelWidth > 0.f){
                 if (this->isHorizontalClamped(px, lineIndex)) {

--- a/cocos/2d/CCLabelTextFormatter.cpp
+++ b/cocos/2d/CCLabelTextFormatter.cpp
@@ -316,7 +316,7 @@ bool Label::isHorizontalClamp()
         {
             auto& letterDef = _fontAtlas->_letterDefinitions[_lettersInfo[ctr].utf32Char];
 
-            auto px = _lettersInfo[ctr].positionX + letterDef.width/2 * _bmfontScale;
+            auto px = _lettersInfo[ctr].positionX + (letterDef.xAdvance - letterDef.offsetX) * _bmfontScale / CC_CONTENT_SCALE_FACTOR();
             auto lineIndex = _lettersInfo[ctr].lineIndex;
 
             if(_labelWidth > 0.f){

--- a/cocos/2d/CCLabelTextFormatter.cpp
+++ b/cocos/2d/CCLabelTextFormatter.cpp
@@ -235,7 +235,7 @@ bool Label::multilineTextWrap(const std::function<int(const std::u32string&, int
                     nextLetterX += _horizontalKernings[letterIndex + 1];
                 nextLetterX += letterDef.xAdvance * _bmfontScale + _additionalKerning;
 
-                tokenRight = nextLetterX / contentScaleFactor;
+                tokenRight = letterX + (letterDef.xAdvance - letterDef.offsetX) * _bmfontScale / contentScaleFactor;
             }
             nextChangeSize = true;
 


### PR DESCRIPTION
This PR fixes several issues related to shrinking and horizontal line computation.

I started investigating it because I found a label which didn't render at all when aligned to the right, but it showed properly when aligned to the left. It turned out to be because of discrepancies in the line width computation, which lead to a non-converging state. You can see in the attached screenshots that it also makes the shrinking behave consistently in all alignments.

While looking for the solution I also fixed a condition to allow the text to continue shrinking instead of making it just disappear, and I also changed the line width computation to make sure the text is painted inside the specified dimensions.

In my case I could reproduce the disappearing label with the following code, but I guess it depends on the font parameters:
```
cocos2d::Label* label;
if (ttf)
{
    label = cocos2d::Label::createWithTTF("mm", "font.ttf", 18);
    label->setColor(cocos2d::Color3B(0,0,0));
} else {
    label = cocos2d::Label::createWithBMFont("font.fnt", "mm");
}
label->setOverflow(cocos2d::Label::Overflow::SHRINK);
label->setDimensions(6, 14);
label->enableWrap(false);
label->setAlignment(cocos2d::TextHAlignment::RIGHT);
label->setPosition(100, 100);
scene->addChild(label, 1000);
```

The following table shows the differences visually, with one line per commit. The labels with black letters are TTF and the ones with white letters are BMF. The pink rectangle shows the content size of the label.
* The labels in columns show the same configuration with different label width. The 3 columns show left, center and right alignment.
* The labels in the middle show some manually configured cases that showed strange behavior at some point.

Content scale factor | 1 | 2 | 3
-- | -- | -- | --
Original | ![0-base-1](https://user-images.githubusercontent.com/32454050/37762187-e83c0f80-2dbb-11e8-8a9e-0d9b46419fba.png) | ![0-base-2](https://user-images.githubusercontent.com/32454050/37762190-e85a931a-2dbb-11e8-8b71-b233896243dc.png) | ![0-base-3](https://user-images.githubusercontent.com/32454050/37762193-e87b7b70-2dbb-11e8-89a0-cdff99035539.png)
After fixing computation consistency | ![1-consistency-1](https://user-images.githubusercontent.com/32454050/37762227-f87ec4d2-2dbb-11e8-9fd6-5ac2ea22c987.png) | ![1-consistency-2](https://user-images.githubusercontent.com/32454050/37762228-f8b2183c-2dbb-11e8-9e50-0ca34035ec11.png) | ![1-consistency-3](https://user-images.githubusercontent.com/32454050/37762229-f8f19962-2dbb-11e8-92b2-cbddad08172d.png)
After not discarding letters that can still be shrinked | ![2-nodiscard-1](https://user-images.githubusercontent.com/32454050/37762349-5344054e-2dbc-11e8-875a-f228e69b6981.png) | ![2-nodiscard-2](https://user-images.githubusercontent.com/32454050/37762350-5363b4ca-2dbc-11e8-8d7c-714e9e186491.png) | ![2-nodiscard-3](https://user-images.githubusercontent.com/32454050/37762351-53858672-2dbc-11e8-93b6-b59fee407e67.png)
After adjusting the line width computation | ![3-fixed-1](https://user-images.githubusercontent.com/32454050/37762365-5d6e0e16-2dbc-11e8-8da9-8446fa7979ea.png) | ![3-fixed-2](https://user-images.githubusercontent.com/32454050/37762366-5d919ea8-2dbc-11e8-91a0-b9abcc4e216e.png) | ![3-fixed-3](https://user-images.githubusercontent.com/32454050/37762367-5db44624-2dbc-11e8-97a9-69313b56548e.png)