### PR TITLE
Don't count spaces at the end of line as part of the line width

### DIFF
--- a/cocos/2d/CCLabelTextFormatter.cpp
+++ b/cocos/2d/CCLabelTextFormatter.cpp
@@ -235,7 +235,10 @@ bool Label::multilineTextWrap(const std::function<int(const std::u32string&, int
                     nextLetterX += _horizontalKernings[letterIndex + 1];
                 nextLetterX += letterDef.xAdvance * _bmfontScale + _additionalKerning;
 
-                tokenRight = nextLetterX / contentScaleFactor;
+                if (tokenLen != 1 || !StringUtils::isUnicodeSpace(character))
+                {
+                    tokenRight = nextLetterX / contentScaleFactor;
+                }
             }
             nextChangeSize = true;
 


### PR DESCRIPTION
Currently, the label text formatting counts the space used by the spaces at the end of a line as part of the line width. This makes the center and right alignment not to work properly.

The screenshots below show the Cocos test "29:Node: Label - New API" -> "52:Clamp content Test: Word Wrap" with different alignments, before and after this change.

-|Left|Center|Right
-|-|-|-
Original|![original-left](https://user-images.githubusercontent.com/32454050/37975997-c4266892-31e0-11e8-960e-821175542f86.png)|![original-center](https://user-images.githubusercontent.com/32454050/37975995-c408c788-31e0-11e8-92e1-0a7e444b72d2.png)|![original-right](https://user-images.githubusercontent.com/32454050/37975998-c44779ba-31e0-11e8-856c-599cb1a72bc2.png)
Fixed|![fixed-left](https://user-images.githubusercontent.com/32454050/37976065-ea317ec8-31e0-11e8-9b1f-025bb6bc8b87.png)|![fixed-center](https://user-images.githubusercontent.com/32454050/37976070-ec43e0e8-31e0-11e8-8b70-8fd9d7815460.png)|![fixed-right](https://user-images.githubusercontent.com/32454050/37976074-ee3deab0-31e0-11e8-9447-87bd81c4d2e7.png)
