### PR TITLE
update web submodule for cocos2d-x 3.17

### DIFF
--- a/cocos/scripting/js-bindings/script/jsb_cocos2d.js
+++ b/cocos/scripting/js-bindings/script/jsb_cocos2d.js
@@ -27,7 +27,7 @@
 
 // CCConfig.js
 //
-cc.ENGINE_VERSION = "Cocos2d-JS v3.16";
+cc.ENGINE_VERSION = "Cocos2d-JS v3.17";
 
 cc.FIX_ARTIFACTS_BY_STRECHING_TEXEL = 0;
 cc.DIRECTOR_STATS_POSITION = {x: 0, y: 0};

--- a/tests/js-tests/src/tests_resources.js
+++ b/tests/js-tests/src/tests_resources.js
@@ -724,7 +724,7 @@ var g_tilemaps = [
 
 var g_spine = [
     "spine/spineboy.atlas",
-    "spine/spineboy.json",
+    "spine/spineboy-ess.json",
     "spine/spineboy.png",
     "spine/sprite.png",
     "spine/goblins.png",


### PR DESCRIPTION
the main change of web submodule is upgrade spine to 3.6.39, refer to https://github.com/cocos2d/cocos2d-html5/pull/3551

meanwhile the submodule update, will bring others bug fix out for web module. 