### PR TITLE
a commit about render texture destroy test cases, revert it

### DIFF
--- a/cocos/2d/CCRenderTexture.cpp
+++ b/cocos/2d/CCRenderTexture.cpp
@@ -796,12 +796,6 @@ void RenderTexture::draw(Renderer *renderer, const Mat4 &transform, uint32_t fla
     }
 }
 
-void RenderTexture::setGlobalZOrder(float globalZOrder)
-{
-    Node::setGlobalZOrder(globalZOrder);
-    _sprite->setGlobalZOrder(globalZOrder);
-}
-
 void RenderTexture::begin()
 {
     Director* director = Director::getInstance();
@@ -836,8 +830,7 @@ void RenderTexture::begin()
     renderer->addCommand(&_groupCommand);
     renderer->pushGroup(_groupCommand.getRenderQueueID());
 
-    // Begine command should be the first command of the command group.
-    _beginCommand.init(INT_MIN);
+    _beginCommand.init(_globalZOrder);
     _beginCommand.func = CC_CALLBACK_0(RenderTexture::onBegin, this);
 
     Director::getInstance()->getRenderer()->addCommand(&_beginCommand);
@@ -845,8 +838,7 @@ void RenderTexture::begin()
 
 void RenderTexture::end()
 {
-    // End command should be the last command of the command group.
-    _endCommand.init(INT_MAX);
+    _endCommand.init(_globalZOrder);
     _endCommand.func = CC_CALLBACK_0(RenderTexture::onEnd, this);
 
     Director* director = Director::getInstance();

--- a/cocos/2d/CCRenderTexture.h
+++ b/cocos/2d/CCRenderTexture.h
@@ -265,7 +265,6 @@ public:
     // Overrides
     virtual void visit(Renderer *renderer, const Mat4 &parentTransform, uint32_t parentFlags) override;
     virtual void draw(Renderer *renderer, const Mat4 &transform, uint32_t flags) override;
-    virtual void setGlobalZOrder(float globalZOrder) override;
 
     /** Flag: Use stack matrix computed from scene hierarchy or generate new modelView and projection matrix.
      *


### PR DESCRIPTION
… with global z order (#18629)"

This reverts commit 38864456bf14ac88cb3b69e8715f6d0f505efecd.

Seriously, it causes awful crash issues. when running the __Node:RenderTexture -> 1:Touch the screen__ test case. on all the tests project, include cpp-tests, js-tests, lua-tests.