### PR TITLE
fix ios downloader progress bug

### DIFF
--- a/cocos/network/CCDownloader-apple.mm
+++ b/cocos/network/CCDownloader-apple.mm
@@ -614,11 +614,10 @@ namespace cocos2d { namespace network {
 {
 //    NSLog(@"DownloaderAppleImpl downloadTask: \"%@\" received: %lld total: %lld", downloadTask.originalRequest.URL, totalBytesWritten, totalBytesExpectedToWrite);
 
-    if (nullptr == _outer)
+    if (nullptr == _outer || totalBytesExpectedToWrite == NSURLSessionTransferSizeUnknown)
     {
         return;
     }
-
     DownloadTaskWrapper *wrapper = [self.taskDict objectForKey:downloadTask];
 
     std::function<int64_t(void *, int64_t)> transferDataToBuffer;   // just a placeholder


### PR DESCRIPTION
fix bug:when downloader's http request didn't return Content-Length header, downloader will return a negative progress value