### PR TITLE
be safe to handle operator=

### DIFF
--- a/cocos/base/CCData.cpp
+++ b/cocos/base/CCData.cpp
@@ -62,21 +62,21 @@ Data::~Data()
 
 Data& Data::operator= (const Data& other)
 {
-	if (this != &other)
-	{
-		CCLOGINFO("In the copy assignment of Data.");
-		copy(other._bytes, other._size);
-	}
+    if (this != &other)
+    {
+        CCLOGINFO("In the copy assignment of Data.");
+        copy(other._bytes, other._size);
+    }
     return *this;
 }
 
 Data& Data::operator= (Data&& other)
 {
-	if (this != &other)
-	{
-		CCLOGINFO("In the move assignment of Data.");
-		move(other);
-	}
+    if (this != &other)
+    {
+        CCLOGINFO("In the move assignment of Data.");
+        move(other);
+    }
     return *this;
 }
 

--- a/cocos/base/CCData.cpp
+++ b/cocos/base/CCData.cpp
@@ -62,15 +62,21 @@ Data::~Data()
 
 Data& Data::operator= (const Data& other)
 {
-    CCLOGINFO("In the copy assignment of Data.");
-    copy(other._bytes, other._size);
+	if (this != &other)
+	{
+		CCLOGINFO("In the copy assignment of Data.");
+		copy(other._bytes, other._size);
+	}
     return *this;
 }
 
 Data& Data::operator= (Data&& other)
 {
-    CCLOGINFO("In the move assignment of Data.");
-    move(other);
+	if (this != &other)
+	{
+		CCLOGINFO("In the move assignment of Data.");
+		move(other);
+	}
     return *this;
 }
 

--- a/cocos/renderer/CCGLProgramState.cpp
+++ b/cocos/renderer/CCGLProgramState.cpp
@@ -273,15 +273,18 @@ void UniformValue::setMat4(const Mat4& value)
 
 UniformValue& UniformValue::operator=(const UniformValue& o)
 {
-    _uniform = o._uniform;
-    _glprogram = o._glprogram;
-    _type = o._type;
-    _value = o._value;
-    
-    if (_uniform->type == GL_SAMPLER_2D)
-    {
-        CC_SAFE_RETAIN(_value.tex.texture);
-    }
+	if (this != &o)
+	{
+		_uniform = o._uniform;
+		_glprogram = o._glprogram;
+		_type = o._type;
+		_value = o._value;
+
+		if (_uniform->type == GL_SAMPLER_2D)
+		{
+			CC_SAFE_RETAIN(_value.tex.texture);
+		}
+	}
     return *this;
 }
 

--- a/cocos/renderer/CCGLProgramState.cpp
+++ b/cocos/renderer/CCGLProgramState.cpp
@@ -273,18 +273,18 @@ void UniformValue::setMat4(const Mat4& value)
 
 UniformValue& UniformValue::operator=(const UniformValue& o)
 {
-	if (this != &o)
-	{
-		_uniform = o._uniform;
-		_glprogram = o._glprogram;
-		_type = o._type;
-		_value = o._value;
+    if (this != &o)
+    {
+        _uniform = o._uniform;
+        _glprogram = o._glprogram;
+        _type = o._type;
+        _value = o._value;
 
-		if (_uniform->type == GL_SAMPLER_2D)
-		{
-			CC_SAFE_RETAIN(_value.tex.texture);
-		}
-	}
+        if (_uniform->type == GL_SAMPLER_2D)
+        {
+            CC_SAFE_RETAIN(_value.tex.texture);
+        }
+    }
     return *this;
 }
 


### PR DESCRIPTION
1、CCData will crash if this equals to other, because CCData::_bytes has been free before memcpy. 
2、CCGLProgramState::_value.tex.texture will leak if this equals to other.