### PR TITLE
Fix `ZipUtils` include headers order

### DIFF
--- a/cocos/base/ZipUtils.cpp
+++ b/cocos/base/ZipUtils.cpp
@@ -24,14 +24,13 @@
  THE SOFTWARE.
  ****************************************************************************/
 
-// FIXME: hack, must be included before ziputils
+#include "base/ZipUtils.h"
+
 #ifdef MINIZIP_FROM_SYSTEM
 #include <minizip/unzip.h>
 #else // from our embedded sources
 #include "unzip.h"
 #endif
-
-#include "base/ZipUtils.h"
 
 #include <zlib.h>
 #include <assert.h>

--- a/cocos/base/ZipUtils.h
+++ b/cocos/base/ZipUtils.h
@@ -28,11 +28,9 @@ THE SOFTWARE.
 #define __SUPPORT_ZIPUTILS_H__
 /// @cond DO_NOT_SHOW
 
-#include <string>
-#include "platform/CCPlatformConfig.h"
 #include "platform/CCPlatformMacros.h"
-#include "platform/CCPlatformDefine.h"
 #include "platform/CCFileUtils.h"
+#include <string>
 
 #if (CC_TARGET_PLATFORM == CC_PLATFORM_ANDROID)
 #include "platform/android/CCFileUtils-android.h"


### PR DESCRIPTION
An old hack that changed the default order of included headers in `ZipUtils` causes issues when compiling cocos2d for Android 64-bit, throwing errors of missing `fgetpos` and `fsetpos` functions.