### PR TITLE
[JavaScript] cc.PI2 was only present in html5 release, added it into JSB

### DIFF
--- a/cocos/scripting/js-bindings/script/jsb_cocos2d.js
+++ b/cocos/scripting/js-bindings/script/jsb_cocos2d.js
@@ -305,6 +305,12 @@ cc.PI = Math.PI;
  * @constant
  * @type Number
  */
+cc.PI2 = Math.PI * 2;
+
+/**
+ * @constant
+ * @type Number
+ */
 cc.FLT_MAX = parseFloat('3.402823466e+38F');
 
 /**


### PR DESCRIPTION
The constant cc.PI2 was not present in JSB, which could result in some inconsistency between desktop and mobile usage