### PR TITLE
Avoid duplicate find action when already found.

### DIFF
--- a/cocos/2d/CCAnimationCache.cpp
+++ b/cocos/2d/CCAnimationCache.cpp
@@ -187,18 +187,20 @@ void AnimationCache::parseVersion2(const ValueMap& animations)
 
 void AnimationCache::addAnimationsWithDictionary(const ValueMap& dictionary,const std::string& plist)
 {
-    if ( dictionary.find("animations") == dictionary.end() )
+    auto anisItr = dictionary.find("animations");
+    if (anisItr == dictionary.end() )
     {
         CCLOG("cocos2d: AnimationCache: No animations were found in provided dictionary.");
         return;
     }
     
-    const Value& animations = dictionary.at("animations");
+    const Value& animations = anisItr->second;
     unsigned int version = 1;
 
-    if( dictionary.find("properties") != dictionary.end() )
+    auto propsItr = dictionary.find("properties");
+    if(propsItr != dictionary.end() )
     {
-        const ValueMap& properties = dictionary.at("properties").asValueMap();
+        const ValueMap& properties = propsItr->second.asValueMap();
         version = properties.at("format").asInt();
         const ValueVector& spritesheets = properties.at("spritesheets").asValueVector();
 

--- a/cocos/2d/CCFastTMXLayer.cpp
+++ b/cocos/2d/CCFastTMXLayer.cpp
@@ -720,8 +720,9 @@ void TMXLayer::removeChild(Node* node, bool cleanup)
 // TMXLayer - Properties
 Value TMXLayer::getProperty(const std::string& propertyName) const
 {
-    if (_properties.find(propertyName) != _properties.end())
-        return _properties.at(propertyName);
+    auto propItr = _properties.find(propertyName);
+    if (propItr != _properties.end())
+        return propItr->second;
     
     return Value();
 }

--- a/cocos/2d/CCFastTMXTiledMap.cpp
+++ b/cocos/2d/CCFastTMXTiledMap.cpp
@@ -237,16 +237,18 @@ TMXObjectGroup * TMXTiledMap::getObjectGroup(const std::string& groupName) const
 
 Value TMXTiledMap::getProperty(const std::string& propertyName) const
 {
-    if (_properties.find(propertyName) != _properties.end())
-        return _properties.at(propertyName);
+    auto propsItr = _properties.find(propertyName);
+    if (propsItr != _properties.end())
+        return propsItr->second;
     
     return Value();
 }
 
 Value TMXTiledMap::getPropertiesForGID(int GID) const
 {
-    if (_tileProperties.find(GID) != _tileProperties.end())
-        return _tileProperties.at(GID);
+    auto propsItr = _tileProperties.find(GID);
+    if (propsItr != _tileProperties.end())
+        return propsItr->second;
     
     return Value();
 }

--- a/cocos/2d/CCFontAtlasCache.cpp
+++ b/cocos/2d/CCFontAtlasCache.cpp
@@ -87,7 +87,7 @@ FontAtlas* FontAtlasCache::getFontAtlasTTF(const _ttfConfig* config)
         }
     }
     else
-        return _atlasMap[atlasName];
+        return it->second;
 
     return nullptr;
 }
@@ -115,7 +115,7 @@ FontAtlas* FontAtlasCache::getFontAtlasFNT(const std::string& fontFileName, cons
         }
     }
     else
-        return _atlasMap[atlasName];
+        return it->second;
     
     return nullptr;
 }
@@ -140,7 +140,7 @@ FontAtlas* FontAtlasCache::getFontAtlasCharMap(const std::string& plistFile)
         }
     }
     else
-        return _atlasMap[atlasName];
+        return it->second;
 
     return nullptr;
 }
@@ -167,7 +167,7 @@ FontAtlas* FontAtlasCache::getFontAtlasCharMap(Texture2D* texture, int itemWidth
         }
     }
     else
-        return _atlasMap[atlasName];
+        return it->second;
 
     return nullptr;
 }
@@ -194,7 +194,7 @@ FontAtlas* FontAtlasCache::getFontAtlasCharMap(const std::string& charMapFile, i
         }
     }
     else
-        return _atlasMap[atlasName];
+        return it->second;
 
     return nullptr;
 }

--- a/cocos/2d/CCSpriteFrameCache.cpp
+++ b/cocos/2d/CCSpriteFrameCache.cpp
@@ -158,9 +158,10 @@ void SpriteFrameCache::addSpriteFramesWithDictionary(ValueMap& dictionary, Textu
     Size textureSize;
 
     // get the format
-    if (dictionary.find("metadata") != dictionary.end())
+    auto metaItr = dictionary.find("metadata");
+    if (metaItr != dictionary.end())
     {
-        ValueMap& metadataDict = dictionary["metadata"].asValueMap();
+        ValueMap& metadataDict = metaItr->second.asValueMap();
         format = metadataDict["format"].asInt();
 
         if(metadataDict.find("size") != metadataDict.end())

--- a/cocos/base/CCConfiguration.cpp
+++ b/cocos/base/CCConfiguration.cpp
@@ -334,7 +334,7 @@ const Value& Configuration::getValue(const std::string& key, const Value& defaul
 {
     auto iter = _valueDict.find(key);
     if (iter != _valueDict.cend())
-        return _valueDict.at(key);
+        return iter->second;
 
     return defaultValue;
 }

--- a/cocos/renderer/CCTexture2D.cpp
+++ b/cocos/renderer/CCTexture2D.cpp
@@ -580,13 +580,14 @@ bool Texture2D::initWithMipmaps(MipmapInfo* mipmaps, int mipmapsNum, PixelFormat
     }
     
 
-    if(_pixelFormatInfoTables.find(pixelFormat) == _pixelFormatInfoTables.end())
+    auto formatItr = _pixelFormatInfoTables.find(pixelFormat);
+    if(formatItr == _pixelFormatInfoTables.end())
     {
         CCLOG("cocos2d: WARNING: unsupported pixelformat: %lx", (unsigned long)pixelFormat );
         return false;
     }
 
-    const PixelFormatInfo& info = _pixelFormatInfoTables.at(pixelFormat);
+    const PixelFormatInfo& info = formatItr->second;
 
     if (info.compressed && !Configuration::getInstance()->supportsPVRTC()
                         && !Configuration::getInstance()->supportsETC()


### PR DESCRIPTION
When already found in map, use it directly. 