### PR TITLE
Keep the same performer of CCDownloader

### DIFF
--- a/cocos/network/CCDownloader-curl.cpp
+++ b/cocos/network/CCDownloader-curl.cpp
@@ -811,7 +811,7 @@ namespace cocos2d { namespace network {
                 coTask._fp = nullptr;
                 do
                 {
-                    if (0 == coTask._fileName.length())
+                    if (0 == coTask._fileName.length() || DownloadTask::ERROR_NO_ERROR != coTask._errCode)
                     {
                         break;
                     }


### PR DESCRIPTION
it need not rename the temp file after downloading fail by downloader-curl,  it is different with downloader-android or downloader-iOS.