### PR TITLE
Fix include guard in CCEventListenerMouse.h

### DIFF
--- a/cocos/base/CCEventListenerMouse.h
+++ b/cocos/base/CCEventListenerMouse.h
@@ -74,4 +74,3 @@ NS_CC_END
 /// @}
 
 #endif /* defined(__cocos2d_libs__CCMouseEventListener__) */
-

--- a/cocos/base/CCEventListenerMouse.h
+++ b/cocos/base/CCEventListenerMouse.h
@@ -24,11 +24,11 @@
 
  ****************************************************************************/
 
-#include "base/CCEventListener.h"
-#include "base/CCEventMouse.h"
-
 #ifndef __cocos2d_libs__CCMouseEventListener__
 #define __cocos2d_libs__CCMouseEventListener__
+
+#include "base/CCEventListener.h"
+#include "base/CCEventMouse.h"
 
 /**
  * @addtogroup base
@@ -74,3 +74,4 @@ NS_CC_END
 /// @}
 
 #endif /* defined(__cocos2d_libs__CCMouseEventListener__) */
+


### PR DESCRIPTION
Nothing more to say. It fixes warning in Kdevelop.