### PR TITLE
Fix for trailing whitespace trimming in Labels and UIRichText

### DIFF
--- a/cocos/ui/UIRichText.cpp
+++ b/cocos/ui/UIRichText.cpp
@@ -1813,7 +1813,7 @@ void RichText::formatRenderers()
             for (auto& iter : element)
             {
                 iter->setAnchorPoint(Vec2::ZERO);
-                iter->setPosition(nextPosX, nextPosY);
+                iter->setPosition(nextPosX + iter->getPositionX(), nextPosY + iter->getPositionY());
                 this->addProtectedChild(iter, 1);
                 Size iSize = iter->getContentSize();
                 newContentSizeWidth += iSize.width;
@@ -1864,7 +1864,7 @@ void RichText::formatRenderers()
             for (auto& iter : row)
             {
                 iter->setAnchorPoint(Vec2::ZERO);
-                iter->setPosition(nextPosX, nextPosY);
+                iter->setPosition(nextPosX + iter->getPositionX(), nextPosY + iter->getPositionY());
                 this->addProtectedChild(iter, 1);
                 nextPosX += iter->getContentSize().width;
             }

--- a/cocos/ui/UIRichText.cpp
+++ b/cocos/ui/UIRichText.cpp
@@ -1716,6 +1716,12 @@ void RichText::handleTextRenderer(const std::string& text, const std::string& fo
             else
                 estimatedIdx = static_cast<int>(_leftSpaceWidth / fontSize);
 
+            // estimatedIdx should never be less than 0
+            if (estimatedIdx < 0)
+            {
+                estimatedIdx = 0;
+            }
+            
             int leftLength = 0;
             if (wrapMode == WRAP_PER_WORD)
                 leftLength = findSplitPositionForWord(textRenderer, utf8Text, estimatedIdx, _leftSpaceWidth, _customSize.width);
@@ -1729,11 +1735,15 @@ void RichText::handleTextRenderer(const std::string& text, const std::string& fo
                 pushToContainer(textRenderer);
             }
 
-            // skip spaces
             StringUtils::StringUTF8::CharUTF8Store& str = utf8Text.getString();
             int rightStart = leftLength;
-            while (rightStart < (int)str.size() && str[rightStart].isASCII() && std::isspace(str[rightStart]._char[0], std::locale()))
-                ++rightStart;
+
+            if (flags & RichElementText::TRIM_TRAILING_WHITESPACE)
+            {
+                // skip spaces
+                while (rightStart < (int)str.size() && str[rightStart].isASCII() && std::isspace(str[rightStart]._char[0], std::locale()))
+                    ++rightStart;
+            }
 
             // erase the chars which are processed
             str.erase(str.begin(), str.begin() + rightStart);

--- a/cocos/ui/UIRichText.h
+++ b/cocos/ui/UIRichText.h
@@ -116,7 +116,8 @@ public:
         URL_FLAG = 1 << 4,              /*!< url of anchor */
         OUTLINE_FLAG = 1 << 5,          /*!< outline effect */
         SHADOW_FLAG = 1 << 6,           /*!< shadow effect */
-        GLOW_FLAG = 1 << 7              /*!< glow effect */
+        GLOW_FLAG = 1 << 7,             /*!< glow effect */
+        TRIM_TRAILING_WHITESPACE = 1 << 8       /*!< trim right side spaces */
     };
     
     /**


### PR DESCRIPTION
[UIRichText.cpp] Allow user to select if they want to trim trailing spaces for a RichElementText. Also fixed crash if estimatedIdx is less than 0 in certain conditions.
[UIRichText.h] New flag added for enabling trailing space trimming.
[CCLabelTextFormatter.cpp] Only trim trailing whitespace if lines are being split. This will trim all whitespace up to the next non-whitespace token in a line.

Please refer to #18874 #18751 

Also fix for #18828 which is to use X and Y positions on custom nodes being drawn in the UIRichText.