### PR TITLE
Fix for Label and UIRichEdit text trailing space trimming

### DIFF
--- a/cocos/ui/UIRichText.cpp
+++ b/cocos/ui/UIRichText.cpp
@@ -1716,12 +1716,6 @@ void RichText::handleTextRenderer(const std::string& text, const std::string& fo
             else
                 estimatedIdx = static_cast<int>(_leftSpaceWidth / fontSize);
 
-            // estimatedIdx should never be less than 0
-            if (estimatedIdx < 0)
-            {
-                estimatedIdx = 0;
-            }
-            
             int leftLength = 0;
             if (wrapMode == WRAP_PER_WORD)
                 leftLength = findSplitPositionForWord(textRenderer, utf8Text, estimatedIdx, _leftSpaceWidth, _customSize.width);
@@ -1735,15 +1729,11 @@ void RichText::handleTextRenderer(const std::string& text, const std::string& fo
                 pushToContainer(textRenderer);
             }
 
+            // skip spaces
             StringUtils::StringUTF8::CharUTF8Store& str = utf8Text.getString();
             int rightStart = leftLength;
-
-            if (flags & RichElementText::TRIM_TRAILING_WHITESPACE)
-            {
-                // skip spaces
-                while (rightStart < (int)str.size() && str[rightStart].isASCII() && std::isspace(str[rightStart]._char[0], std::locale()))
-                    ++rightStart;
-            }
+            while (rightStart < (int)str.size() && str[rightStart].isASCII() && std::isspace(str[rightStart]._char[0], std::locale()))
+                ++rightStart;
 
             // erase the chars which are processed
             str.erase(str.begin(), str.begin() + rightStart);

--- a/cocos/ui/UIRichText.cpp
+++ b/cocos/ui/UIRichText.cpp
@@ -1813,7 +1813,7 @@ void RichText::formatRenderers()
             for (auto& iter : element)
             {
                 iter->setAnchorPoint(Vec2::ZERO);
-                iter->setPosition(nextPosX + iter->getPositionX(), nextPosY + iter->getPositionY());
+                iter->setPosition(nextPosX, nextPosY);
                 this->addProtectedChild(iter, 1);
                 Size iSize = iter->getContentSize();
                 newContentSizeWidth += iSize.width;
@@ -1864,7 +1864,7 @@ void RichText::formatRenderers()
             for (auto& iter : row)
             {
                 iter->setAnchorPoint(Vec2::ZERO);
-                iter->setPosition(nextPosX + iter->getPositionX(), nextPosY + iter->getPositionY());
+                iter->setPosition(nextPosX, nextPosY);
                 this->addProtectedChild(iter, 1);
                 nextPosX += iter->getContentSize().width;
             }

--- a/cocos/ui/UIRichText.cpp
+++ b/cocos/ui/UIRichText.cpp
@@ -1729,7 +1729,6 @@ void RichText::handleTextRenderer(const std::string& text, const std::string& fo
                 pushToContainer(textRenderer);
             }
 
-            // skip spaces
             StringUtils::StringUTF8::CharUTF8Store& str = utf8Text.getString();
 
             // erase the chars which are processed

--- a/cocos/ui/UIRichText.cpp
+++ b/cocos/ui/UIRichText.cpp
@@ -1731,12 +1731,9 @@ void RichText::handleTextRenderer(const std::string& text, const std::string& fo
 
             // skip spaces
             StringUtils::StringUTF8::CharUTF8Store& str = utf8Text.getString();
-            int rightStart = leftLength;
-            while (rightStart < (int)str.size() && str[rightStart].isASCII() && std::isspace(str[rightStart]._char[0], std::locale()))
-                ++rightStart;
 
             // erase the chars which are processed
-            str.erase(str.begin(), str.begin() + rightStart);
+            str.erase(str.begin(), str.begin() + leftLength);
             currentText = utf8Text.getAsCharSequence();
         }
     }

--- a/cocos/ui/UIRichText.cpp
+++ b/cocos/ui/UIRichText.cpp
@@ -1813,7 +1813,7 @@ void RichText::formatRenderers()
             for (auto& iter : element)
             {
                 iter->setAnchorPoint(Vec2::ZERO);
-                iter->setPosition(nextPosX, nextPosY);
+                iter->setPosition(nextPosX + iter->getPositionX(), nextPosY + iter->getPositionY());
                 this->addProtectedChild(iter, 1);
                 Size iSize = iter->getContentSize();
                 newContentSizeWidth += iSize.width;
@@ -1864,7 +1864,7 @@ void RichText::formatRenderers()
             for (auto& iter : row)
             {
                 iter->setAnchorPoint(Vec2::ZERO);
-                iter->setPosition(nextPosX, nextPosY);
+                iter->setPosition(nextPosX + iter->getPositionX(), nextPosY + iter->getPositionY());
                 this->addProtectedChild(iter, 1);
                 nextPosX += iter->getContentSize().width;
             }

--- a/cocos/ui/UIRichText.cpp
+++ b/cocos/ui/UIRichText.cpp
@@ -1716,6 +1716,12 @@ void RichText::handleTextRenderer(const std::string& text, const std::string& fo
             else
                 estimatedIdx = static_cast<int>(_leftSpaceWidth / fontSize);
 
+            // estimatedIdx should never be less than 0
+            if (estimatedIdx < 0)
+            {
+                estimatedIdx = 0;
+            }
+            
             int leftLength = 0;
             if (wrapMode == WRAP_PER_WORD)
                 leftLength = findSplitPositionForWord(textRenderer, utf8Text, estimatedIdx, _leftSpaceWidth, _customSize.width);
@@ -1729,11 +1735,15 @@ void RichText::handleTextRenderer(const std::string& text, const std::string& fo
                 pushToContainer(textRenderer);
             }
 
-            // skip spaces
             StringUtils::StringUTF8::CharUTF8Store& str = utf8Text.getString();
             int rightStart = leftLength;
-            while (rightStart < (int)str.size() && str[rightStart].isASCII() && std::isspace(str[rightStart]._char[0], std::locale()))
-                ++rightStart;
+
+            if (flags & RichElementText::TRIM_TRAILING_WHITESPACE)
+            {
+                // skip spaces
+                while (rightStart < (int)str.size() && str[rightStart].isASCII() && std::isspace(str[rightStart]._char[0], std::locale()))
+                    ++rightStart;
+            }
 
             // erase the chars which are processed
             str.erase(str.begin(), str.begin() + rightStart);

--- a/cocos/ui/UIRichText.h
+++ b/cocos/ui/UIRichText.h
@@ -116,8 +116,7 @@ public:
         URL_FLAG = 1 << 4,              /*!< url of anchor */
         OUTLINE_FLAG = 1 << 5,          /*!< outline effect */
         SHADOW_FLAG = 1 << 6,           /*!< shadow effect */
-        GLOW_FLAG = 1 << 7,             /*!< glow effect */
-        TRIM_TRAILING_WHITESPACE = 1 << 8       /*!< trim right side spaces */
+        GLOW_FLAG = 1 << 7              /*!< glow effect */
     };
     
     /**

--- a/cocos/ui/UIRichText.h
+++ b/cocos/ui/UIRichText.h
@@ -116,7 +116,8 @@ public:
         URL_FLAG = 1 << 4,              /*!< url of anchor */
         OUTLINE_FLAG = 1 << 5,          /*!< outline effect */
         SHADOW_FLAG = 1 << 6,           /*!< shadow effect */
-        GLOW_FLAG = 1 << 7              /*!< glow effect */
+        GLOW_FLAG = 1 << 7,             /*!< glow effect */
+        TRIM_TRAILING_WHITESPACE = 1 << 8       /*!< trim right side spaces */
     };
     
     /**

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIRichTextTest/UIRichTextTest.cpp
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIRichTextTest/UIRichTextTest.cpp
@@ -1,26 +1,26 @@
 /****************************************************************************
- Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
- 
- http://www.cocos2d-x.org
- 
- Permission is hereby granted, free of charge, to any person obtaining a copy
- of this software and associated documentation files (the "Software"), to deal
- in the Software without restriction, including without limitation the rights
- to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- copies of the Software, and to permit persons to whom the Software is
- furnished to do so, subject to the following conditions:
- 
- The above copyright notice and this permission notice shall be included in
- all copies or substantial portions of the Software.
- 
- THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- THE SOFTWARE.
- ****************************************************************************/
+Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
+
+http://www.cocos2d-x.org
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+****************************************************************************/
 
 #include "UIRichTextTest.h"
 #include "editor-support/cocostudio/CCArmatureDataManager.h"
@@ -48,6 +48,7 @@ UIRichTextTests::UIRichTextTests()
     ADD_TEST_CASE(UIRichTextXMLShadow);
     ADD_TEST_CASE(UIRichTextXMLGlow);
     ADD_TEST_CASE(UIRichTextXMLExtend);
+    ADD_TEST_CASE(UIRichTextXMLSpace);
 }
 
 
@@ -59,24 +60,24 @@ bool UIRichTextTest::init()
     if (UIScene::init())
     {
         Size widgetSize = _widget->getContentSize();
-        
+
         auto config = Configuration::getInstance();
         config->loadConfigFile("configs/config-test-ok.plist");
-        
-        
+
+
         std::string str1 = config->getValue("Chinese").asString();
         std::string str2 = config->getValue("Japanese").asString();
         CCLOG("str1:%s ascii length = %ld, utf8 length = %ld, substr = %s",
-              str1.c_str(),
-              static_cast<long>(str1.length()),
-              StringUtils::getCharacterCountInUTF8String(str1),
-              Helper::getSubStringOfUTF8String(str1, 0, 5).c_str());
+            str1.c_str(),
+            static_cast<long>(str1.length()),
+            StringUtils::getCharacterCountInUTF8String(str1),
+            Helper::getSubStringOfUTF8String(str1, 0, 5).c_str());
         CCLOG("str2:%s ascii length = %ld, utf8 length = %ld, substr = %s",
-              str2.c_str(),
-              static_cast<long>(str2.length()),
-              StringUtils::getCharacterCountInUTF8String(str2),
-              Helper::getSubStringOfUTF8String(str2, 0, 2).c_str());
-        
+            str2.c_str(),
+            static_cast<long>(str2.length()),
+            StringUtils::getCharacterCountInUTF8String(str2),
+            Helper::getSubStringOfUTF8String(str2, 0, 2).c_str());
+
         // Add the alert
         Text *alert = Text::create("RichText", "fonts/Marker Felt.ttf", 30);
         alert->setColor(Color3B(159, 168, 176));
@@ -98,32 +99,32 @@ bool UIRichTextTest::init()
         button2->addTouchEventListener(CC_CALLBACK_2(UIRichTextTest::switchWrapMode, this));
         button2->setLocalZOrder(10);
         _widget->addChild(button2);
-		
-		Button* button3 = Button::create("cocosui/animationbuttonnormal.png", "cocosui/animationbuttonpressed.png");
-		button3->setTouchEnabled(true);
-		button3->setTitleText("alignment");
-		button3->setPosition(Vec2(widgetSize.width * 2 / 3, widgetSize.height / 2.0f + button2->getContentSize().height * 2.5));
-		button3->addTouchEventListener(CC_CALLBACK_2(UIRichTextTest::switchAlignment, this));
-		button3->setLocalZOrder(10);
-		_widget->addChild(button3);
+
+        Button* button3 = Button::create("cocosui/animationbuttonnormal.png", "cocosui/animationbuttonpressed.png");
+        button3->setTouchEnabled(true);
+        button3->setTitleText("alignment");
+        button3->setPosition(Vec2(widgetSize.width * 2 / 3, widgetSize.height / 2.0f + button2->getContentSize().height * 2.5));
+        button3->addTouchEventListener(CC_CALLBACK_2(UIRichTextTest::switchAlignment, this));
+        button3->setLocalZOrder(10);
+        _widget->addChild(button3);
 
         // RichText
         _richText = RichText::create();
         _richText->ignoreContentAdaptWithSize(false);
         _richText->setContentSize(Size(100, 100));
-        
+
         RichElementText* re1 = RichElementText::create(1, Color3B::WHITE, 255, str1, "SimSun", 10);
         RichElementText* re2 = RichElementText::create(2, Color3B::YELLOW, 255, "And this is yellow. ", "Helvetica", 10);
         RichElementText* re3 = RichElementText::create(3, Color3B::GRAY, 255, str2, "Yu Mincho", 10);
         RichElementText* re4 = RichElementText::create(4, Color3B::GREEN, 255, "And green with TTF support. ", "fonts/Marker Felt.ttf", 10);
         RichElementText* re5 = RichElementText::create(5, Color3B::RED, 255, "Last one is red ", "Helvetica", 10);
-        
+
         RichElementImage* reimg = RichElementImage::create(6, Color3B::WHITE, 255, "cocosui/sliderballnormal.png");
-        
+
         cocostudio::ArmatureDataManager::getInstance()->addArmatureFileInfo("cocosui/100/100.ExportJson");
         cocostudio::Armature *pAr = cocostudio::Armature::create("100");
         pAr->getAnimation()->play("Animation1");
-        
+
         RichElementCustomNode* recustom = RichElementCustomNode::create(1, Color3B::WHITE, 255, pAr);
         RichElementText* re6 = RichElementText::create(7, Color3B::ORANGE, 255, "Have fun!! ", "Helvetica", 10);
         _richText->pushBackElement(re1);
@@ -134,16 +135,16 @@ bool UIRichTextTest::init()
         _richText->insertElement(reimg, 2);
         _richText->pushBackElement(recustom);
         _richText->pushBackElement(re6);
-        
+
         _richText->setPosition(Vec2(widgetSize.width / 2, widgetSize.height / 2));
         _richText->setLocalZOrder(10);
-        
-        
+
+
         _widget->addChild(_richText);
-        
+
         // test remove all children, this call won't effect the test
         _richText->removeAllChildren();
-        
+
         return true;
     }
     return false;
@@ -153,22 +154,22 @@ void UIRichTextTest::touchEvent(Ref *pSender, Widget::TouchEventType type)
 {
     switch (type)
     {
-        case Widget::TouchEventType::ENDED:
+    case Widget::TouchEventType::ENDED:
+    {
+        if (_richText->isIgnoreContentAdaptWithSize())
         {
-            if (_richText->isIgnoreContentAdaptWithSize())
-            {
-                _richText->ignoreContentAdaptWithSize(false);
-                _richText->setContentSize(Size(100, 100));
-            }
-            else
-            {
-                _richText->ignoreContentAdaptWithSize(true);
-            }
+            _richText->ignoreContentAdaptWithSize(false);
+            _richText->setContentSize(Size(100, 100));
         }
-            break;
-            
-        default:
-            break;
+        else
+        {
+            _richText->ignoreContentAdaptWithSize(true);
+        }
+    }
+    break;
+
+    default:
+        break;
     }
 }
 
@@ -183,12 +184,12 @@ void UIRichTextTest::switchWrapMode(Ref *pSender, Widget::TouchEventType type)
 }
 
 void UIRichTextTest::switchAlignment(Ref *sender, Widget::TouchEventType type) {
-	if (type == Widget::TouchEventType::ENDED)
-	{
-		auto alignment = _richText->getHorizontalAlignment();
-		alignment = static_cast<RichText::HorizontalAlignment>((static_cast<std::underlying_type<RichText::HorizontalAlignment>::type>(alignment)+1) % 3);
-		_richText->setHorizontalAlignment(alignment);
-	}
+    if (type == Widget::TouchEventType::ENDED)
+    {
+        auto alignment = _richText->getHorizontalAlignment();
+        alignment = static_cast<RichText::HorizontalAlignment>((static_cast<std::underlying_type<RichText::HorizontalAlignment>::type>(alignment) + 1) % 3);
+        _richText->setHorizontalAlignment(alignment);
+    }
 }
 
 //
@@ -223,13 +224,13 @@ bool UIRichTextXMLBasic::init()
         button2->setLocalZOrder(10);
         _widget->addChild(button2);
 
-		Button* button3 = Button::create("cocosui/animationbuttonnormal.png", "cocosui/animationbuttonpressed.png");
-		button3->setTouchEnabled(true);
-		button3->setTitleText("alignment");
-		button3->setPosition(Vec2(widgetSize.width * 2 / 3, widgetSize.height / 2.0f + button2->getContentSize().height * 2.5));
-		button3->addTouchEventListener(CC_CALLBACK_2(UIRichTextXMLBasic::switchAlignment, this));
-		button3->setLocalZOrder(10);
-		_widget->addChild(button3);
+        Button* button3 = Button::create("cocosui/animationbuttonnormal.png", "cocosui/animationbuttonpressed.png");
+        button3->setTouchEnabled(true);
+        button3->setTitleText("alignment");
+        button3->setPosition(Vec2(widgetSize.width * 2 / 3, widgetSize.height / 2.0f + button2->getContentSize().height * 2.5));
+        button3->addTouchEventListener(CC_CALLBACK_2(UIRichTextXMLBasic::switchAlignment, this));
+        button3->setLocalZOrder(10);
+        _widget->addChild(button3);
 
         // RichText
         _richText = RichText::createWithXML("This is just a simple text. no xml tags here. testing the basics. testing word-wrapping. testing, testing, testing");
@@ -254,22 +255,22 @@ void UIRichTextXMLBasic::touchEvent(Ref *pSender, Widget::TouchEventType type)
 {
     switch (type)
     {
-        case Widget::TouchEventType::ENDED:
+    case Widget::TouchEventType::ENDED:
+    {
+        if (_richText->isIgnoreContentAdaptWithSize())
         {
-            if (_richText->isIgnoreContentAdaptWithSize())
-            {
-                _richText->ignoreContentAdaptWithSize(false);
-                _richText->setContentSize(Size(100, 100));
-            }
-            else
-            {
-                _richText->ignoreContentAdaptWithSize(true);
-            }
+            _richText->ignoreContentAdaptWithSize(false);
+            _richText->setContentSize(Size(100, 100));
         }
-            break;
+        else
+        {
+            _richText->ignoreContentAdaptWithSize(true);
+        }
+    }
+    break;
 
-        default:
-            break;
+    default:
+        break;
     }
 }
 
@@ -287,7 +288,7 @@ void UIRichTextXMLBasic::switchAlignment(Ref *sender, Widget::TouchEventType typ
     if (type == Widget::TouchEventType::ENDED)
     {
         auto alignment = _richText->getHorizontalAlignment();
-        alignment = static_cast<RichText::HorizontalAlignment>((static_cast<std::underlying_type<RichText::HorizontalAlignment>::type>(alignment)+1) % 3);
+        alignment = static_cast<RichText::HorizontalAlignment>((static_cast<std::underlying_type<RichText::HorizontalAlignment>::type>(alignment) + 1) % 3);
         _richText->setHorizontalAlignment(alignment);
     }
 }
@@ -324,13 +325,13 @@ bool UIRichTextXMLSmallBig::init()
         button2->setLocalZOrder(10);
         _widget->addChild(button2);
 
-		Button* button3 = Button::create("cocosui/animationbuttonnormal.png", "cocosui/animationbuttonpressed.png");
-		button3->setTouchEnabled(true);
-		button3->setTitleText("alignment");
-		button3->setPosition(Vec2(widgetSize.width * 2 / 3, widgetSize.height / 2.0f + button2->getContentSize().height * 2.5));
-		button3->addTouchEventListener(CC_CALLBACK_2(UIRichTextXMLSmallBig::switchAlignment, this));
-		button3->setLocalZOrder(10);
-		_widget->addChild(button3);
+        Button* button3 = Button::create("cocosui/animationbuttonnormal.png", "cocosui/animationbuttonpressed.png");
+        button3->setTouchEnabled(true);
+        button3->setTitleText("alignment");
+        button3->setPosition(Vec2(widgetSize.width * 2 / 3, widgetSize.height / 2.0f + button2->getContentSize().height * 2.5));
+        button3->addTouchEventListener(CC_CALLBACK_2(UIRichTextXMLSmallBig::switchAlignment, this));
+        button3->setLocalZOrder(10);
+        _widget->addChild(button3);
 
         // RichText
         _richText = RichText::createWithXML("Regular size.<small>smaller size.</small><big>bigger.<small>normal.</small>bigger</big>.normal.");
@@ -355,22 +356,22 @@ void UIRichTextXMLSmallBig::touchEvent(Ref *pSender, Widget::TouchEventType type
 {
     switch (type)
     {
-        case Widget::TouchEventType::ENDED:
+    case Widget::TouchEventType::ENDED:
+    {
+        if (_richText->isIgnoreContentAdaptWithSize())
         {
-            if (_richText->isIgnoreContentAdaptWithSize())
-            {
-                _richText->ignoreContentAdaptWithSize(false);
-                _richText->setContentSize(Size(100, 100));
-            }
-            else
-            {
-                _richText->ignoreContentAdaptWithSize(true);
-            }
+            _richText->ignoreContentAdaptWithSize(false);
+            _richText->setContentSize(Size(100, 100));
         }
-            break;
-            
-        default:
-            break;
+        else
+        {
+            _richText->ignoreContentAdaptWithSize(true);
+        }
+    }
+    break;
+
+    default:
+        break;
     }
 }
 
@@ -385,12 +386,12 @@ void UIRichTextXMLSmallBig::switchWrapMode(Ref *pSender, Widget::TouchEventType 
 }
 
 void UIRichTextXMLSmallBig::switchAlignment(Ref *sender, Widget::TouchEventType type) {
-	if (type == Widget::TouchEventType::ENDED)
-	{
-		auto alignment = _richText->getHorizontalAlignment();
-		alignment = static_cast<RichText::HorizontalAlignment>((static_cast<std::underlying_type<RichText::HorizontalAlignment>::type>(alignment)+1) % 3);
-		_richText->setHorizontalAlignment(alignment);
-	}
+    if (type == Widget::TouchEventType::ENDED)
+    {
+        auto alignment = _richText->getHorizontalAlignment();
+        alignment = static_cast<RichText::HorizontalAlignment>((static_cast<std::underlying_type<RichText::HorizontalAlignment>::type>(alignment) + 1) % 3);
+        _richText->setHorizontalAlignment(alignment);
+    }
 }
 
 //
@@ -424,14 +425,14 @@ bool UIRichTextXMLColor::init()
         button2->addTouchEventListener(CC_CALLBACK_2(UIRichTextXMLColor::switchWrapMode, this));
         button2->setLocalZOrder(10);
         _widget->addChild(button2);
-		
-		Button* button3 = Button::create("cocosui/animationbuttonnormal.png", "cocosui/animationbuttonpressed.png");
-		button3->setTouchEnabled(true);
-		button3->setTitleText("alignment");
-		button3->setPosition(Vec2(widgetSize.width * 2 / 3, widgetSize.height / 2.0f + button2->getContentSize().height * 2.5));
-		button3->addTouchEventListener(CC_CALLBACK_2(UIRichTextXMLColor::switchAlignment, this));
-		button3->setLocalZOrder(10);
-		_widget->addChild(button3);
+
+        Button* button3 = Button::create("cocosui/animationbuttonnormal.png", "cocosui/animationbuttonpressed.png");
+        button3->setTouchEnabled(true);
+        button3->setTitleText("alignment");
+        button3->setPosition(Vec2(widgetSize.width * 2 / 3, widgetSize.height / 2.0f + button2->getContentSize().height * 2.5));
+        button3->addTouchEventListener(CC_CALLBACK_2(UIRichTextXMLColor::switchAlignment, this));
+        button3->setLocalZOrder(10);
+        _widget->addChild(button3);
 
         // RichText
         _richText = RichText::createWithXML("Default color.<font color='#ff0000'>red.<font color='#00ff00'>green</font>red again.</font>default again");
@@ -456,22 +457,22 @@ void UIRichTextXMLColor::touchEvent(Ref *pSender, Widget::TouchEventType type)
 {
     switch (type)
     {
-        case Widget::TouchEventType::ENDED:
+    case Widget::TouchEventType::ENDED:
+    {
+        if (_richText->isIgnoreContentAdaptWithSize())
         {
-            if (_richText->isIgnoreContentAdaptWithSize())
-            {
-                _richText->ignoreContentAdaptWithSize(false);
-                _richText->setContentSize(Size(100, 100));
-            }
-            else
-            {
-                _richText->ignoreContentAdaptWithSize(true);
-            }
+            _richText->ignoreContentAdaptWithSize(false);
+            _richText->setContentSize(Size(100, 100));
         }
-            break;
-            
-        default:
-            break;
+        else
+        {
+            _richText->ignoreContentAdaptWithSize(true);
+        }
+    }
+    break;
+
+    default:
+        break;
     }
 }
 
@@ -486,12 +487,12 @@ void UIRichTextXMLColor::switchWrapMode(Ref *pSender, Widget::TouchEventType typ
 }
 
 void UIRichTextXMLColor::switchAlignment(Ref *sender, Widget::TouchEventType type) {
-	if (type == Widget::TouchEventType::ENDED)
-	{
-		auto alignment = _richText->getHorizontalAlignment();
-		alignment = static_cast<RichText::HorizontalAlignment>((static_cast<std::underlying_type<RichText::HorizontalAlignment>::type>(alignment)+1) % 3);
-		_richText->setHorizontalAlignment(alignment);
-	}
+    if (type == Widget::TouchEventType::ENDED)
+    {
+        auto alignment = _richText->getHorizontalAlignment();
+        alignment = static_cast<RichText::HorizontalAlignment>((static_cast<std::underlying_type<RichText::HorizontalAlignment>::type>(alignment) + 1) % 3);
+        _richText->setHorizontalAlignment(alignment);
+    }
 }
 
 //
@@ -526,13 +527,13 @@ bool UIRichTextXMLSUIB::init()
         button2->setLocalZOrder(10);
         _widget->addChild(button2);
 
-		Button* button3 = Button::create("cocosui/animationbuttonnormal.png", "cocosui/animationbuttonpressed.png");
-		button3->setTouchEnabled(true);
-		button3->setTitleText("alignment");
-		button3->setPosition(Vec2(widgetSize.width * 2 / 3, widgetSize.height / 2.0f + button2->getContentSize().height * 2.5));
-		button3->addTouchEventListener(CC_CALLBACK_2(UIRichTextXMLSUIB::switchAlignment, this));
-		button3->setLocalZOrder(10);
-		_widget->addChild(button3);
+        Button* button3 = Button::create("cocosui/animationbuttonnormal.png", "cocosui/animationbuttonpressed.png");
+        button3->setTouchEnabled(true);
+        button3->setTitleText("alignment");
+        button3->setPosition(Vec2(widgetSize.width * 2 / 3, widgetSize.height / 2.0f + button2->getContentSize().height * 2.5));
+        button3->addTouchEventListener(CC_CALLBACK_2(UIRichTextXMLSUIB::switchAlignment, this));
+        button3->setLocalZOrder(10);
+        _widget->addChild(button3);
 
         // RichText
         _richText = RichText::createWithXML("system font: <u>underline</u><i>italics</i><b>bold</b><del>strike-through</del>");
@@ -557,22 +558,22 @@ void UIRichTextXMLSUIB::touchEvent(Ref *pSender, Widget::TouchEventType type)
 {
     switch (type)
     {
-        case Widget::TouchEventType::ENDED:
+    case Widget::TouchEventType::ENDED:
+    {
+        if (_richText->isIgnoreContentAdaptWithSize())
         {
-            if (_richText->isIgnoreContentAdaptWithSize())
-            {
-                _richText->ignoreContentAdaptWithSize(false);
-                _richText->setContentSize(Size(100, 100));
-            }
-            else
-            {
-                _richText->ignoreContentAdaptWithSize(true);
-            }
+            _richText->ignoreContentAdaptWithSize(false);
+            _richText->setContentSize(Size(100, 100));
         }
-            break;
-            
-        default:
-            break;
+        else
+        {
+            _richText->ignoreContentAdaptWithSize(true);
+        }
+    }
+    break;
+
+    default:
+        break;
     }
 }
 
@@ -587,12 +588,12 @@ void UIRichTextXMLSUIB::switchWrapMode(Ref *pSender, Widget::TouchEventType type
 }
 
 void UIRichTextXMLSUIB::switchAlignment(Ref *sender, Widget::TouchEventType type) {
-	if (type == Widget::TouchEventType::ENDED)
-	{
-		auto alignment = _richText->getHorizontalAlignment();
-		alignment = static_cast<RichText::HorizontalAlignment>((static_cast<std::underlying_type<RichText::HorizontalAlignment>::type>(alignment)+1) % 3);
-		_richText->setHorizontalAlignment(alignment);
-	}
+    if (type == Widget::TouchEventType::ENDED)
+    {
+        auto alignment = _richText->getHorizontalAlignment();
+        alignment = static_cast<RichText::HorizontalAlignment>((static_cast<std::underlying_type<RichText::HorizontalAlignment>::type>(alignment) + 1) % 3);
+        _richText->setHorizontalAlignment(alignment);
+    }
 }
 
 //
@@ -627,13 +628,13 @@ bool UIRichTextXMLSUIB2::init()
         button2->setLocalZOrder(10);
         _widget->addChild(button2);
 
-		Button* button3 = Button::create("cocosui/animationbuttonnormal.png", "cocosui/animationbuttonpressed.png");
-		button3->setTouchEnabled(true);
-		button3->setTitleText("alignment");
-		button3->setPosition(Vec2(widgetSize.width * 2 / 3, widgetSize.height / 2.0f + button2->getContentSize().height * 2.5));
-		button3->addTouchEventListener(CC_CALLBACK_2(UIRichTextXMLSUIB2::switchAlignment, this));
-		button3->setLocalZOrder(10);
-		_widget->addChild(button3);
+        Button* button3 = Button::create("cocosui/animationbuttonnormal.png", "cocosui/animationbuttonpressed.png");
+        button3->setTouchEnabled(true);
+        button3->setTitleText("alignment");
+        button3->setPosition(Vec2(widgetSize.width * 2 / 3, widgetSize.height / 2.0f + button2->getContentSize().height * 2.5));
+        button3->addTouchEventListener(CC_CALLBACK_2(UIRichTextXMLSUIB2::switchAlignment, this));
+        button3->setLocalZOrder(10);
+        _widget->addChild(button3);
 
         // RichText
         _richText = RichText::createWithXML("<font face='fonts/Marker Felt.ttf' size='24'>ttf font: <u>underline</u><i>italics</i><b>bold</b><del>strike-through</del></font>");
@@ -658,22 +659,22 @@ void UIRichTextXMLSUIB2::touchEvent(Ref *pSender, Widget::TouchEventType type)
 {
     switch (type)
     {
-        case Widget::TouchEventType::ENDED:
+    case Widget::TouchEventType::ENDED:
+    {
+        if (_richText->isIgnoreContentAdaptWithSize())
         {
-            if (_richText->isIgnoreContentAdaptWithSize())
-            {
-                _richText->ignoreContentAdaptWithSize(false);
-                _richText->setContentSize(Size(100, 100));
-            }
-            else
-            {
-                _richText->ignoreContentAdaptWithSize(true);
-            }
+            _richText->ignoreContentAdaptWithSize(false);
+            _richText->setContentSize(Size(100, 100));
         }
-            break;
-            
-        default:
-            break;
+        else
+        {
+            _richText->ignoreContentAdaptWithSize(true);
+        }
+    }
+    break;
+
+    default:
+        break;
     }
 }
 
@@ -688,12 +689,12 @@ void UIRichTextXMLSUIB2::switchWrapMode(Ref *pSender, Widget::TouchEventType typ
 }
 
 void UIRichTextXMLSUIB2::switchAlignment(Ref *sender, Widget::TouchEventType type) {
-	if (type == Widget::TouchEventType::ENDED)
-	{
-		auto alignment = _richText->getHorizontalAlignment();
-		alignment = static_cast<RichText::HorizontalAlignment>((static_cast<std::underlying_type<RichText::HorizontalAlignment>::type>(alignment)+1) % 3);
-		_richText->setHorizontalAlignment(alignment);
-	}
+    if (type == Widget::TouchEventType::ENDED)
+    {
+        auto alignment = _richText->getHorizontalAlignment();
+        alignment = static_cast<RichText::HorizontalAlignment>((static_cast<std::underlying_type<RichText::HorizontalAlignment>::type>(alignment) + 1) % 3);
+        _richText->setHorizontalAlignment(alignment);
+    }
 }
 
 //
@@ -728,13 +729,13 @@ bool UIRichTextXMLSUIB3::init()
         button2->setLocalZOrder(10);
         _widget->addChild(button2);
 
-		Button* button3 = Button::create("cocosui/animationbuttonnormal.png", "cocosui/animationbuttonpressed.png");
-		button3->setTouchEnabled(true);
-		button3->setTitleText("alignment");
-		button3->setPosition(Vec2(widgetSize.width * 2 / 3, widgetSize.height / 2.0f + button2->getContentSize().height * 2.5));
-		button3->addTouchEventListener(CC_CALLBACK_2(UIRichTextXMLSUIB3::switchAlignment, this));
-		button3->setLocalZOrder(10);
-		_widget->addChild(button3);
+        Button* button3 = Button::create("cocosui/animationbuttonnormal.png", "cocosui/animationbuttonpressed.png");
+        button3->setTouchEnabled(true);
+        button3->setTitleText("alignment");
+        button3->setPosition(Vec2(widgetSize.width * 2 / 3, widgetSize.height / 2.0f + button2->getContentSize().height * 2.5));
+        button3->addTouchEventListener(CC_CALLBACK_2(UIRichTextXMLSUIB3::switchAlignment, this));
+        button3->setLocalZOrder(10);
+        _widget->addChild(button3);
 
         // RichText
         _richText = RichText::createWithXML("<font face='fonts/Marker Felt.ttf' size='20'>ttf font: <i><u>italics and underline</u></i><del><b>bold and strike-through</b></del></font>");
@@ -759,22 +760,22 @@ void UIRichTextXMLSUIB3::touchEvent(Ref *pSender, Widget::TouchEventType type)
 {
     switch (type)
     {
-        case Widget::TouchEventType::ENDED:
+    case Widget::TouchEventType::ENDED:
+    {
+        if (_richText->isIgnoreContentAdaptWithSize())
         {
-            if (_richText->isIgnoreContentAdaptWithSize())
-            {
-                _richText->ignoreContentAdaptWithSize(false);
-                _richText->setContentSize(Size(100, 100));
-            }
-            else
-            {
-                _richText->ignoreContentAdaptWithSize(true);
-            }
+            _richText->ignoreContentAdaptWithSize(false);
+            _richText->setContentSize(Size(100, 100));
         }
-            break;
-            
-        default:
-            break;
+        else
+        {
+            _richText->ignoreContentAdaptWithSize(true);
+        }
+    }
+    break;
+
+    default:
+        break;
     }
 }
 
@@ -789,12 +790,12 @@ void UIRichTextXMLSUIB3::switchWrapMode(Ref *pSender, Widget::TouchEventType typ
 }
 
 void UIRichTextXMLSUIB3::switchAlignment(Ref *sender, Widget::TouchEventType type) {
-	if (type == Widget::TouchEventType::ENDED)
-	{
-		auto alignment = _richText->getHorizontalAlignment();
-		alignment = static_cast<RichText::HorizontalAlignment>((static_cast<std::underlying_type<RichText::HorizontalAlignment>::type>(alignment)+1) % 3);
-		_richText->setHorizontalAlignment(alignment);
-	}
+    if (type == Widget::TouchEventType::ENDED)
+    {
+        auto alignment = _richText->getHorizontalAlignment();
+        alignment = static_cast<RichText::HorizontalAlignment>((static_cast<std::underlying_type<RichText::HorizontalAlignment>::type>(alignment) + 1) % 3);
+        _richText->setHorizontalAlignment(alignment);
+    }
 }
 
 //
@@ -829,13 +830,13 @@ bool UIRichTextXMLImg::init()
         button2->setLocalZOrder(10);
         _widget->addChild(button2);
 
-		Button* button3 = Button::create("cocosui/animationbuttonnormal.png", "cocosui/animationbuttonpressed.png");
-		button3->setTouchEnabled(true);
-		button3->setTitleText("alignment");
-		button3->setPosition(Vec2(widgetSize.width * 2 / 3, widgetSize.height / 2.0f + button2->getContentSize().height * 2.5));
-		button3->addTouchEventListener(CC_CALLBACK_2(UIRichTextXMLImg::switchAlignment, this));
-		button3->setLocalZOrder(10);
-		_widget->addChild(button3);
+        Button* button3 = Button::create("cocosui/animationbuttonnormal.png", "cocosui/animationbuttonpressed.png");
+        button3->setTouchEnabled(true);
+        button3->setTitleText("alignment");
+        button3->setPosition(Vec2(widgetSize.width * 2 / 3, widgetSize.height / 2.0f + button2->getContentSize().height * 2.5));
+        button3->addTouchEventListener(CC_CALLBACK_2(UIRichTextXMLImg::switchAlignment, this));
+        button3->setLocalZOrder(10);
+        _widget->addChild(button3);
 
         // RichText
         _richText = RichText::createWithXML("you should see an image here: <img src='cocosui/sliderballnormal.png'/> and this is text again. and this is the same image, but bigger: <img src='cocosui/sliderballnormal.png' width='30' height='30' /> and here goes text again");
@@ -860,22 +861,22 @@ void UIRichTextXMLImg::touchEvent(Ref *pSender, Widget::TouchEventType type)
 {
     switch (type)
     {
-        case Widget::TouchEventType::ENDED:
+    case Widget::TouchEventType::ENDED:
+    {
+        if (_richText->isIgnoreContentAdaptWithSize())
         {
-            if (_richText->isIgnoreContentAdaptWithSize())
-            {
-                _richText->ignoreContentAdaptWithSize(false);
-                _richText->setContentSize(Size(100, 100));
-            }
-            else
-            {
-                _richText->ignoreContentAdaptWithSize(true);
-            }
+            _richText->ignoreContentAdaptWithSize(false);
+            _richText->setContentSize(Size(100, 100));
         }
-            break;
-            
-        default:
-            break;
+        else
+        {
+            _richText->ignoreContentAdaptWithSize(true);
+        }
+    }
+    break;
+
+    default:
+        break;
     }
 }
 
@@ -890,12 +891,12 @@ void UIRichTextXMLImg::switchWrapMode(Ref *pSender, Widget::TouchEventType type)
 }
 
 void UIRichTextXMLImg::switchAlignment(Ref *sender, Widget::TouchEventType type) {
-	if (type == Widget::TouchEventType::ENDED)
-	{
-		auto alignment = _richText->getHorizontalAlignment();
-		alignment = static_cast<RichText::HorizontalAlignment>((static_cast<std::underlying_type<RichText::HorizontalAlignment>::type>(alignment)+1) % 3);
-		_richText->setHorizontalAlignment(alignment);
-	}
+    if (type == Widget::TouchEventType::ENDED)
+    {
+        auto alignment = _richText->getHorizontalAlignment();
+        alignment = static_cast<RichText::HorizontalAlignment>((static_cast<std::underlying_type<RichText::HorizontalAlignment>::type>(alignment) + 1) % 3);
+        _richText->setHorizontalAlignment(alignment);
+    }
 }
 
 //
@@ -930,13 +931,13 @@ bool UIRichTextXMLUrl::init()
         button2->setLocalZOrder(10);
         _widget->addChild(button2);
 
-		Button* button3 = Button::create("cocosui/animationbuttonnormal.png", "cocosui/animationbuttonpressed.png");
-		button3->setTouchEnabled(true);
-		button3->setTitleText("alignment");
-		button3->setPosition(Vec2(widgetSize.width * 2 / 3, widgetSize.height / 2.0f + button2->getContentSize().height * 2.5));
-		button3->addTouchEventListener(CC_CALLBACK_2(UIRichTextXMLUrl::switchAlignment, this));
-		button3->setLocalZOrder(10);
-		_widget->addChild(button3);
+        Button* button3 = Button::create("cocosui/animationbuttonnormal.png", "cocosui/animationbuttonpressed.png");
+        button3->setTouchEnabled(true);
+        button3->setTitleText("alignment");
+        button3->setPosition(Vec2(widgetSize.width * 2 / 3, widgetSize.height / 2.0f + button2->getContentSize().height * 2.5));
+        button3->addTouchEventListener(CC_CALLBACK_2(UIRichTextXMLUrl::switchAlignment, this));
+        button3->setLocalZOrder(10);
+        _widget->addChild(button3);
 
         // RichText
         _richText = RichText::createWithXML("This link will redirect you to google: <a href='http://www.google.com'>click me</a>");
@@ -961,22 +962,22 @@ void UIRichTextXMLUrl::touchEvent(Ref *pSender, Widget::TouchEventType type)
 {
     switch (type)
     {
-        case Widget::TouchEventType::ENDED:
+    case Widget::TouchEventType::ENDED:
+    {
+        if (_richText->isIgnoreContentAdaptWithSize())
         {
-            if (_richText->isIgnoreContentAdaptWithSize())
-            {
-                _richText->ignoreContentAdaptWithSize(false);
-                _richText->setContentSize(Size(100, 100));
-            }
-            else
-            {
-                _richText->ignoreContentAdaptWithSize(true);
-            }
+            _richText->ignoreContentAdaptWithSize(false);
+            _richText->setContentSize(Size(100, 100));
         }
-            break;
-            
-        default:
-            break;
+        else
+        {
+            _richText->ignoreContentAdaptWithSize(true);
+        }
+    }
+    break;
+
+    default:
+        break;
     }
 }
 
@@ -991,12 +992,12 @@ void UIRichTextXMLUrl::switchWrapMode(Ref *pSender, Widget::TouchEventType type)
 }
 
 void UIRichTextXMLUrl::switchAlignment(Ref *sender, Widget::TouchEventType type) {
-	if (type == Widget::TouchEventType::ENDED)
-	{
-		auto alignment = _richText->getHorizontalAlignment();
-		alignment = static_cast<RichText::HorizontalAlignment>((static_cast<std::underlying_type<RichText::HorizontalAlignment>::type>(alignment)+1) % 3);
-		_richText->setHorizontalAlignment(alignment);
-	}
+    if (type == Widget::TouchEventType::ENDED)
+    {
+        auto alignment = _richText->getHorizontalAlignment();
+        alignment = static_cast<RichText::HorizontalAlignment>((static_cast<std::underlying_type<RichText::HorizontalAlignment>::type>(alignment) + 1) % 3);
+        _richText->setHorizontalAlignment(alignment);
+    }
 }
 
 //
@@ -1007,14 +1008,14 @@ bool UIRichTextXMLUrlImg::init()
     if (UIScene::init())
     {
         Size widgetSize = _widget->getContentSize();
-        
+
         // Add the alert
         Text *alert = Text::create("RichText", "fonts/Marker Felt.ttf", 30);
         alert->setColor(Color3B(159, 168, 176));
         alert->setPosition(Vec2(widgetSize.width / 2.0f, widgetSize.height / 2.0f - alert->getContentSize().height * 3.125));
         _widget->addChild(alert);
-        
-        
+
+
         Button* button = Button::create("cocosui/animationbuttonnormal.png", "cocosui/animationbuttonpressed.png");
         button->setTouchEnabled(true);
         button->setTitleText("switch");
@@ -1022,7 +1023,7 @@ bool UIRichTextXMLUrlImg::init()
         button->addTouchEventListener(CC_CALLBACK_2(UIRichTextXMLUrlImg::touchEvent, this));
         button->setLocalZOrder(10);
         _widget->addChild(button);
-        
+
         Button* button2 = Button::create("cocosui/animationbuttonnormal.png", "cocosui/animationbuttonpressed.png");
         button2->setTouchEnabled(true);
         button2->setTitleText("wrap mode");
@@ -1030,29 +1031,29 @@ bool UIRichTextXMLUrlImg::init()
         button2->addTouchEventListener(CC_CALLBACK_2(UIRichTextXMLUrlImg::switchWrapMode, this));
         button2->setLocalZOrder(10);
         _widget->addChild(button2);
-		
-		Button* button3 = Button::create("cocosui/animationbuttonnormal.png", "cocosui/animationbuttonpressed.png");
-		button3->setTouchEnabled(true);
-		button3->setTitleText("alignment");
-		button3->setPosition(Vec2(widgetSize.width * 2 / 3, widgetSize.height / 2.0f + button2->getContentSize().height * 2.5));
-		button3->addTouchEventListener(CC_CALLBACK_2(UIRichTextXMLUrlImg::switchAlignment, this));
-		button3->setLocalZOrder(10);
-		_widget->addChild(button3);
-        
+
+        Button* button3 = Button::create("cocosui/animationbuttonnormal.png", "cocosui/animationbuttonpressed.png");
+        button3->setTouchEnabled(true);
+        button3->setTitleText("alignment");
+        button3->setPosition(Vec2(widgetSize.width * 2 / 3, widgetSize.height / 2.0f + button2->getContentSize().height * 2.5));
+        button3->addTouchEventListener(CC_CALLBACK_2(UIRichTextXMLUrlImg::switchAlignment, this));
+        button3->setLocalZOrder(10);
+        _widget->addChild(button3);
+
         // RichText
         _richText = RichText::createWithXML("This link will redirect you to google: <a href='http://www.google.com'><img src=\"cocosui/ccicon.png\" height=\"48\" width=\"48\" /></a>");
         _richText->ignoreContentAdaptWithSize(false);
         _richText->setContentSize(Size(100, 100));
-        
+
         _richText->setPosition(Vec2(widgetSize.width / 2, widgetSize.height / 2));
         _richText->setLocalZOrder(10);
-        
-        
+
+
         _widget->addChild(_richText);
-        
+
         // test remove all children, this call won't effect the test
         _richText->removeAllChildren();
-        
+
         return true;
     }
     return false;
@@ -1062,22 +1063,22 @@ void UIRichTextXMLUrlImg::touchEvent(Ref *pSender, Widget::TouchEventType type)
 {
     switch (type)
     {
-        case Widget::TouchEventType::ENDED:
+    case Widget::TouchEventType::ENDED:
+    {
+        if (_richText->isIgnoreContentAdaptWithSize())
         {
-            if (_richText->isIgnoreContentAdaptWithSize())
-            {
-                _richText->ignoreContentAdaptWithSize(false);
-                _richText->setContentSize(Size(100, 100));
-            }
-            else
-            {
-                _richText->ignoreContentAdaptWithSize(true);
-            }
+            _richText->ignoreContentAdaptWithSize(false);
+            _richText->setContentSize(Size(100, 100));
         }
-            break;
-            
-        default:
-            break;
+        else
+        {
+            _richText->ignoreContentAdaptWithSize(true);
+        }
+    }
+    break;
+
+    default:
+        break;
     }
 }
 
@@ -1092,12 +1093,12 @@ void UIRichTextXMLUrlImg::switchWrapMode(Ref *pSender, Widget::TouchEventType ty
 }
 
 void UIRichTextXMLUrlImg::switchAlignment(Ref *sender, Widget::TouchEventType type) {
-	if (type == Widget::TouchEventType::ENDED)
-	{
-		auto alignment = _richText->getHorizontalAlignment();
-		alignment = static_cast<RichText::HorizontalAlignment>((static_cast<std::underlying_type<RichText::HorizontalAlignment>::type>(alignment)+1) % 3);
-		_richText->setHorizontalAlignment(alignment);
-	}
+    if (type == Widget::TouchEventType::ENDED)
+    {
+        auto alignment = _richText->getHorizontalAlignment();
+        alignment = static_cast<RichText::HorizontalAlignment>((static_cast<std::underlying_type<RichText::HorizontalAlignment>::type>(alignment) + 1) % 3);
+        _richText->setHorizontalAlignment(alignment);
+    }
 }
 
 //
@@ -1132,13 +1133,13 @@ bool UIRichTextXMLFace::init()
         button2->setLocalZOrder(10);
         _widget->addChild(button2);
 
-		Button* button3 = Button::create("cocosui/animationbuttonnormal.png", "cocosui/animationbuttonpressed.png");
-		button3->setTouchEnabled(true);
-		button3->setTitleText("alignment");
-		button3->setPosition(Vec2(widgetSize.width * 2 / 3, widgetSize.height / 2.0f + button2->getContentSize().height * 2.5));
-		button3->addTouchEventListener(CC_CALLBACK_2(UIRichTextXMLFace::switchAlignment, this));
-		button3->setLocalZOrder(10);
-		_widget->addChild(button3);
+        Button* button3 = Button::create("cocosui/animationbuttonnormal.png", "cocosui/animationbuttonpressed.png");
+        button3->setTouchEnabled(true);
+        button3->setTitleText("alignment");
+        button3->setPosition(Vec2(widgetSize.width * 2 / 3, widgetSize.height / 2.0f + button2->getContentSize().height * 2.5));
+        button3->addTouchEventListener(CC_CALLBACK_2(UIRichTextXMLFace::switchAlignment, this));
+        button3->setLocalZOrder(10);
+        _widget->addChild(button3);
 
         // RichText
         _richText = RichText::createWithXML("<font size='20' face='fonts/Marker Felt.ttf'>Marker Felt 20.<font face='fonts/arial.ttf'>Arial 20.</font></font><font face='font/Thonburi.ttf' size='24' color='#0000ff'>Thonburi 24 blue</font>");
@@ -1163,22 +1164,22 @@ void UIRichTextXMLFace::touchEvent(Ref *pSender, Widget::TouchEventType type)
 {
     switch (type)
     {
-        case Widget::TouchEventType::ENDED:
+    case Widget::TouchEventType::ENDED:
+    {
+        if (_richText->isIgnoreContentAdaptWithSize())
         {
-            if (_richText->isIgnoreContentAdaptWithSize())
-            {
-                _richText->ignoreContentAdaptWithSize(false);
-                _richText->setContentSize(Size(100, 100));
-            }
-            else
-            {
-                _richText->ignoreContentAdaptWithSize(true);
-            }
+            _richText->ignoreContentAdaptWithSize(false);
+            _richText->setContentSize(Size(100, 100));
         }
-            break;
-            
-        default:
-            break;
+        else
+        {
+            _richText->ignoreContentAdaptWithSize(true);
+        }
+    }
+    break;
+
+    default:
+        break;
     }
 }
 
@@ -1193,12 +1194,12 @@ void UIRichTextXMLFace::switchWrapMode(Ref *pSender, Widget::TouchEventType type
 }
 
 void UIRichTextXMLFace::switchAlignment(Ref *sender, Widget::TouchEventType type) {
-	if (type == Widget::TouchEventType::ENDED)
-	{
-		auto alignment = _richText->getHorizontalAlignment();
-		alignment = static_cast<RichText::HorizontalAlignment>((static_cast<std::underlying_type<RichText::HorizontalAlignment>::type>(alignment)+1) % 3);
-		_richText->setHorizontalAlignment(alignment);
-	}
+    if (type == Widget::TouchEventType::ENDED)
+    {
+        auto alignment = _richText->getHorizontalAlignment();
+        alignment = static_cast<RichText::HorizontalAlignment>((static_cast<std::underlying_type<RichText::HorizontalAlignment>::type>(alignment) + 1) % 3);
+        _richText->setHorizontalAlignment(alignment);
+    }
 }
 
 //
@@ -1233,13 +1234,13 @@ bool UIRichTextXMLBR::init()
         button2->setLocalZOrder(10);
         _widget->addChild(button2);
 
-		Button* button3 = Button::create("cocosui/animationbuttonnormal.png", "cocosui/animationbuttonpressed.png");
-		button3->setTouchEnabled(true);
-		button3->setTitleText("alignment");
-		button3->setPosition(Vec2(widgetSize.width * 2 / 3, widgetSize.height / 2.0f + button2->getContentSize().height * 2.5));
-		button3->addTouchEventListener(CC_CALLBACK_2(UIRichTextXMLBR::switchAlignment, this));
-		button3->setLocalZOrder(10);
-		_widget->addChild(button3);
+        Button* button3 = Button::create("cocosui/animationbuttonnormal.png", "cocosui/animationbuttonpressed.png");
+        button3->setTouchEnabled(true);
+        button3->setTitleText("alignment");
+        button3->setPosition(Vec2(widgetSize.width * 2 / 3, widgetSize.height / 2.0f + button2->getContentSize().height * 2.5));
+        button3->addTouchEventListener(CC_CALLBACK_2(UIRichTextXMLBR::switchAlignment, this));
+        button3->setLocalZOrder(10);
+        _widget->addChild(button3);
 
         // RichText
         _richText = RichText::createWithXML("this is one line.<br/>this should be in another line.<br/>and this is another line");
@@ -1264,22 +1265,22 @@ void UIRichTextXMLBR::touchEvent(Ref *pSender, Widget::TouchEventType type)
 {
     switch (type)
     {
-        case Widget::TouchEventType::ENDED:
+    case Widget::TouchEventType::ENDED:
+    {
+        if (_richText->isIgnoreContentAdaptWithSize())
         {
-            if (_richText->isIgnoreContentAdaptWithSize())
-            {
-                _richText->ignoreContentAdaptWithSize(false);
-                _richText->setContentSize(Size(100, 100));
-            }
-            else
-            {
-                _richText->ignoreContentAdaptWithSize(true);
-            }
+            _richText->ignoreContentAdaptWithSize(false);
+            _richText->setContentSize(Size(100, 100));
         }
-            break;
-            
-        default:
-            break;
+        else
+        {
+            _richText->ignoreContentAdaptWithSize(true);
+        }
+    }
+    break;
+
+    default:
+        break;
     }
 }
 
@@ -1294,12 +1295,12 @@ void UIRichTextXMLBR::switchWrapMode(Ref *pSender, Widget::TouchEventType type)
 }
 
 void UIRichTextXMLBR::switchAlignment(Ref *sender, Widget::TouchEventType type) {
-	if (type == Widget::TouchEventType::ENDED)
-	{
-		auto alignment = _richText->getHorizontalAlignment();
-		alignment = static_cast<RichText::HorizontalAlignment>((static_cast<std::underlying_type<RichText::HorizontalAlignment>::type>(alignment)+1) % 3);
-		_richText->setHorizontalAlignment(alignment);
-	}
+    if (type == Widget::TouchEventType::ENDED)
+    {
+        auto alignment = _richText->getHorizontalAlignment();
+        alignment = static_cast<RichText::HorizontalAlignment>((static_cast<std::underlying_type<RichText::HorizontalAlignment>::type>(alignment) + 1) % 3);
+        _richText->setHorizontalAlignment(alignment);
+    }
 }
 
 //
@@ -1334,7 +1335,7 @@ bool UIRichTextXMLInvalid::init()
             // test remove all children, this call won't effect the test
             _richText->removeAllChildren();
         }
-        return true;        
+        return true;
     }
     return false;
 }
@@ -1347,14 +1348,14 @@ bool UIRichTextXMLOutline::init()
     if (UIScene::init())
     {
         Size widgetSize = _widget->getContentSize();
-        
+
         // Add the alert
         Text *alert = Text::create("Outline", "fonts/Marker Felt.ttf", 30);
         alert->setColor(Color3B(159, 168, 176));
         alert->setPosition(Vec2(widgetSize.width / 2.0f, widgetSize.height / 2.0f - alert->getContentSize().height * 3.125));
         _widget->addChild(alert);
-        
-        
+
+
         Button* button = Button::create("cocosui/animationbuttonnormal.png", "cocosui/animationbuttonpressed.png");
         button->setTouchEnabled(true);
         button->setTitleText("switch");
@@ -1362,7 +1363,7 @@ bool UIRichTextXMLOutline::init()
         button->addTouchEventListener(CC_CALLBACK_2(UIRichTextXMLOutline::touchEvent, this));
         button->setLocalZOrder(10);
         _widget->addChild(button);
-        
+
         Button* button2 = Button::create("cocosui/animationbuttonnormal.png", "cocosui/animationbuttonpressed.png");
         button2->setTouchEnabled(true);
         button2->setTitleText("wrap mode");
@@ -1370,29 +1371,29 @@ bool UIRichTextXMLOutline::init()
         button2->addTouchEventListener(CC_CALLBACK_2(UIRichTextXMLOutline::switchWrapMode, this));
         button2->setLocalZOrder(10);
         _widget->addChild(button2);
-		
-		Button* button3 = Button::create("cocosui/animationbuttonnormal.png", "cocosui/animationbuttonpressed.png");
-		button3->setTouchEnabled(true);
-		button3->setTitleText("alignment");
-		button3->setPosition(Vec2(widgetSize.width * 2 / 3, widgetSize.height / 2.0f + button2->getContentSize().height * 2.5));
-		button3->addTouchEventListener(CC_CALLBACK_2(UIRichTextXMLOutline::switchAlignment, this));
-		button3->setLocalZOrder(10);
-		_widget->addChild(button3);
-        
+
+        Button* button3 = Button::create("cocosui/animationbuttonnormal.png", "cocosui/animationbuttonpressed.png");
+        button3->setTouchEnabled(true);
+        button3->setTitleText("alignment");
+        button3->setPosition(Vec2(widgetSize.width * 2 / 3, widgetSize.height / 2.0f + button2->getContentSize().height * 2.5));
+        button3->addTouchEventListener(CC_CALLBACK_2(UIRichTextXMLOutline::switchAlignment, this));
+        button3->setLocalZOrder(10);
+        _widget->addChild(button3);
+
         // RichText
         _richText = RichText::createWithXML("<font face='fonts/Marker Felt.ttf' size=\"24\"><outline color=\"#D2B48C\" size=\"2\">OUTLINE</outline></font>");
         _richText->ignoreContentAdaptWithSize(false);
         _richText->setContentSize(Size(100, 100));
-        
+
         _richText->setPosition(Vec2(widgetSize.width / 2, widgetSize.height / 2));
         _richText->setLocalZOrder(10);
-        
-        
+
+
         _widget->addChild(_richText);
-        
+
         // test remove all children, this call won't effect the test
         _richText->removeAllChildren();
-        
+
         return true;
     }
     return false;
@@ -1402,22 +1403,22 @@ void UIRichTextXMLOutline::touchEvent(Ref *pSender, Widget::TouchEventType type)
 {
     switch (type)
     {
-        case Widget::TouchEventType::ENDED:
+    case Widget::TouchEventType::ENDED:
+    {
+        if (_richText->isIgnoreContentAdaptWithSize())
         {
-            if (_richText->isIgnoreContentAdaptWithSize())
-            {
-                _richText->ignoreContentAdaptWithSize(false);
-                _richText->setContentSize(Size(100, 100));
-            }
-            else
-            {
-                _richText->ignoreContentAdaptWithSize(true);
-            }
+            _richText->ignoreContentAdaptWithSize(false);
+            _richText->setContentSize(Size(100, 100));
         }
-            break;
-            
-        default:
-            break;
+        else
+        {
+            _richText->ignoreContentAdaptWithSize(true);
+        }
+    }
+    break;
+
+    default:
+        break;
     }
 }
 
@@ -1432,12 +1433,12 @@ void UIRichTextXMLOutline::switchWrapMode(Ref *pSender, Widget::TouchEventType t
 }
 
 void UIRichTextXMLOutline::switchAlignment(Ref *sender, Widget::TouchEventType type) {
-	if (type == Widget::TouchEventType::ENDED)
-	{
-		auto alignment = _richText->getHorizontalAlignment();
-		alignment = static_cast<RichText::HorizontalAlignment>((static_cast<std::underlying_type<RichText::HorizontalAlignment>::type>(alignment)+1) % 3);
-		_richText->setHorizontalAlignment(alignment);
-	}
+    if (type == Widget::TouchEventType::ENDED)
+    {
+        auto alignment = _richText->getHorizontalAlignment();
+        alignment = static_cast<RichText::HorizontalAlignment>((static_cast<std::underlying_type<RichText::HorizontalAlignment>::type>(alignment) + 1) % 3);
+        _richText->setHorizontalAlignment(alignment);
+    }
 }
 
 //
@@ -1448,14 +1449,14 @@ bool UIRichTextXMLShadow::init()
     if (UIScene::init())
     {
         Size widgetSize = _widget->getContentSize();
-        
+
         // Add the alert
         Text *alert = Text::create("Shadow", "fonts/Marker Felt.ttf", 30);
         alert->setColor(Color3B(159, 168, 176));
         alert->setPosition(Vec2(widgetSize.width / 2.0f, widgetSize.height / 2.0f - alert->getContentSize().height * 3.125));
         _widget->addChild(alert);
-        
-        
+
+
         Button* button = Button::create("cocosui/animationbuttonnormal.png", "cocosui/animationbuttonpressed.png");
         button->setTouchEnabled(true);
         button->setTitleText("switch");
@@ -1463,7 +1464,7 @@ bool UIRichTextXMLShadow::init()
         button->addTouchEventListener(CC_CALLBACK_2(UIRichTextXMLShadow::touchEvent, this));
         button->setLocalZOrder(10);
         _widget->addChild(button);
-        
+
         Button* button2 = Button::create("cocosui/animationbuttonnormal.png", "cocosui/animationbuttonpressed.png");
         button2->setTouchEnabled(true);
         button2->setTitleText("wrap mode");
@@ -1471,29 +1472,29 @@ bool UIRichTextXMLShadow::init()
         button2->addTouchEventListener(CC_CALLBACK_2(UIRichTextXMLShadow::switchWrapMode, this));
         button2->setLocalZOrder(10);
         _widget->addChild(button2);
-		
-		Button* button3 = Button::create("cocosui/animationbuttonnormal.png", "cocosui/animationbuttonpressed.png");
-		button3->setTouchEnabled(true);
-		button3->setTitleText("alignment");
-		button3->setPosition(Vec2(widgetSize.width * 2 / 3, widgetSize.height / 2.0f + button2->getContentSize().height * 2.5));
-		button3->addTouchEventListener(CC_CALLBACK_2(UIRichTextXMLShadow::switchAlignment, this));
-		button3->setLocalZOrder(10);
-		_widget->addChild(button3);
-        
+
+        Button* button3 = Button::create("cocosui/animationbuttonnormal.png", "cocosui/animationbuttonpressed.png");
+        button3->setTouchEnabled(true);
+        button3->setTitleText("alignment");
+        button3->setPosition(Vec2(widgetSize.width * 2 / 3, widgetSize.height / 2.0f + button2->getContentSize().height * 2.5));
+        button3->addTouchEventListener(CC_CALLBACK_2(UIRichTextXMLShadow::switchAlignment, this));
+        button3->setLocalZOrder(10);
+        _widget->addChild(button3);
+
         // RichText
         _richText = RichText::createWithXML("<font size=\"24\"><shadow color=\"#4169E1\" offsetWidth=\"8\" offsetHeight=\"-8\" blurRadius=\"2\">SHADOW</shadow></font>");
         _richText->ignoreContentAdaptWithSize(false);
         _richText->setContentSize(Size(150, 100));
-        
+
         _richText->setPosition(Vec2(widgetSize.width / 2, widgetSize.height / 2));
         _richText->setLocalZOrder(10);
-        
-        
+
+
         _widget->addChild(_richText);
-        
+
         // test remove all children, this call won't effect the test
         _richText->removeAllChildren();
-        
+
         return true;
     }
     return false;
@@ -1503,22 +1504,22 @@ void UIRichTextXMLShadow::touchEvent(Ref *pSender, Widget::TouchEventType type)
 {
     switch (type)
     {
-        case Widget::TouchEventType::ENDED:
+    case Widget::TouchEventType::ENDED:
+    {
+        if (_richText->isIgnoreContentAdaptWithSize())
         {
-            if (_richText->isIgnoreContentAdaptWithSize())
-            {
-                _richText->ignoreContentAdaptWithSize(false);
-                _richText->setContentSize(Size(100, 100));
-            }
-            else
-            {
-                _richText->ignoreContentAdaptWithSize(true);
-            }
+            _richText->ignoreContentAdaptWithSize(false);
+            _richText->setContentSize(Size(100, 100));
         }
-            break;
-            
-        default:
-            break;
+        else
+        {
+            _richText->ignoreContentAdaptWithSize(true);
+        }
+    }
+    break;
+
+    default:
+        break;
     }
 }
 
@@ -1533,12 +1534,12 @@ void UIRichTextXMLShadow::switchWrapMode(Ref *pSender, Widget::TouchEventType ty
 }
 
 void UIRichTextXMLShadow::switchAlignment(Ref *sender, Widget::TouchEventType type) {
-	if (type == Widget::TouchEventType::ENDED)
-	{
-		auto alignment = _richText->getHorizontalAlignment();
-		alignment = static_cast<RichText::HorizontalAlignment>((static_cast<std::underlying_type<RichText::HorizontalAlignment>::type>(alignment)+1) % 3);
-		_richText->setHorizontalAlignment(alignment);
-	}
+    if (type == Widget::TouchEventType::ENDED)
+    {
+        auto alignment = _richText->getHorizontalAlignment();
+        alignment = static_cast<RichText::HorizontalAlignment>((static_cast<std::underlying_type<RichText::HorizontalAlignment>::type>(alignment) + 1) % 3);
+        _richText->setHorizontalAlignment(alignment);
+    }
 }
 
 //
@@ -1549,14 +1550,14 @@ bool UIRichTextXMLGlow::init()
     if (UIScene::init())
     {
         Size widgetSize = _widget->getContentSize();
-        
+
         // Add the alert
         Text *alert = Text::create("Glow", "fonts/Marker Felt.ttf", 30);
         alert->setColor(Color3B(159, 168, 176));
         alert->setPosition(Vec2(widgetSize.width / 2.0f, widgetSize.height / 2.0f - alert->getContentSize().height * 3.125));
         _widget->addChild(alert);
-        
-        
+
+
         Button* button = Button::create("cocosui/animationbuttonnormal.png", "cocosui/animationbuttonpressed.png");
         button->setTouchEnabled(true);
         button->setTitleText("switch");
@@ -1564,7 +1565,7 @@ bool UIRichTextXMLGlow::init()
         button->addTouchEventListener(CC_CALLBACK_2(UIRichTextXMLGlow::touchEvent, this));
         button->setLocalZOrder(10);
         _widget->addChild(button);
-        
+
         Button* button2 = Button::create("cocosui/animationbuttonnormal.png", "cocosui/animationbuttonpressed.png");
         button2->setTouchEnabled(true);
         button2->setTitleText("wrap mode");
@@ -1572,29 +1573,29 @@ bool UIRichTextXMLGlow::init()
         button2->addTouchEventListener(CC_CALLBACK_2(UIRichTextXMLGlow::switchWrapMode, this));
         button2->setLocalZOrder(10);
         _widget->addChild(button2);
-		
-		Button* button3 = Button::create("cocosui/animationbuttonnormal.png", "cocosui/animationbuttonpressed.png");
-		button3->setTouchEnabled(true);
-		button3->setTitleText("alignment");
-		button3->setPosition(Vec2(widgetSize.width * 2 / 3, widgetSize.height / 2.0f + button2->getContentSize().height * 2.5));
-		button3->addTouchEventListener(CC_CALLBACK_2(UIRichTextXMLGlow::switchAlignment, this));
-		button3->setLocalZOrder(10);
-		_widget->addChild(button3);
-        
+
+        Button* button3 = Button::create("cocosui/animationbuttonnormal.png", "cocosui/animationbuttonpressed.png");
+        button3->setTouchEnabled(true);
+        button3->setTitleText("alignment");
+        button3->setPosition(Vec2(widgetSize.width * 2 / 3, widgetSize.height / 2.0f + button2->getContentSize().height * 2.5));
+        button3->addTouchEventListener(CC_CALLBACK_2(UIRichTextXMLGlow::switchAlignment, this));
+        button3->setLocalZOrder(10);
+        _widget->addChild(button3);
+
         // RichText
         _richText = RichText::createWithXML("<font face=\"fonts/Marker Felt.ttf\" size=\"24\"><glow color=\"#AFEEEE\">GLOW</glow></font>");
         _richText->ignoreContentAdaptWithSize(false);
         _richText->setContentSize(Size(100, 100));
-        
+
         _richText->setPosition(Vec2(widgetSize.width / 2, widgetSize.height / 2));
         _richText->setLocalZOrder(10);
-        
-        
+
+
         _widget->addChild(_richText);
-        
+
         // test remove all children, this call won't effect the test
         _richText->removeAllChildren();
-        
+
         return true;
     }
     return false;
@@ -1604,22 +1605,22 @@ void UIRichTextXMLGlow::touchEvent(Ref *pSender, Widget::TouchEventType type)
 {
     switch (type)
     {
-        case Widget::TouchEventType::ENDED:
+    case Widget::TouchEventType::ENDED:
+    {
+        if (_richText->isIgnoreContentAdaptWithSize())
         {
-            if (_richText->isIgnoreContentAdaptWithSize())
-            {
-                _richText->ignoreContentAdaptWithSize(false);
-                _richText->setContentSize(Size(100, 100));
-            }
-            else
-            {
-                _richText->ignoreContentAdaptWithSize(true);
-            }
+            _richText->ignoreContentAdaptWithSize(false);
+            _richText->setContentSize(Size(100, 100));
         }
-            break;
-            
-        default:
-            break;
+        else
+        {
+            _richText->ignoreContentAdaptWithSize(true);
+        }
+    }
+    break;
+
+    default:
+        break;
     }
 }
 
@@ -1634,12 +1635,12 @@ void UIRichTextXMLGlow::switchWrapMode(Ref *pSender, Widget::TouchEventType type
 }
 
 void UIRichTextXMLGlow::switchAlignment(Ref *sender, Widget::TouchEventType type) {
-	if (type == Widget::TouchEventType::ENDED)
-	{
-		auto alignment = _richText->getHorizontalAlignment();
-		alignment = static_cast<RichText::HorizontalAlignment>((static_cast<std::underlying_type<RichText::HorizontalAlignment>::type>(alignment)+1) % 3);
-		_richText->setHorizontalAlignment(alignment);
-	}
+    if (type == Widget::TouchEventType::ENDED)
+    {
+        auto alignment = _richText->getHorizontalAlignment();
+        alignment = static_cast<RichText::HorizontalAlignment>((static_cast<std::underlying_type<RichText::HorizontalAlignment>::type>(alignment) + 1) % 3);
+        _richText->setHorizontalAlignment(alignment);
+    }
 }
 
 //
@@ -1650,14 +1651,14 @@ bool UIRichTextXMLExtend::init()
     if (UIScene::init())
     {
         Size widgetSize = _widget->getContentSize();
-        
+
         // Add the alert
         Text *alert = Text::create("Extend", "fonts/Marker Felt.ttf", 30);
         alert->setColor(Color3B(159, 168, 176));
         alert->setPosition(Vec2(widgetSize.width / 2.0f, widgetSize.height / 2.0f - alert->getContentSize().height * 3.125));
         _widget->addChild(alert);
-        
-        
+
+
         Button* button = Button::create("cocosui/animationbuttonnormal.png", "cocosui/animationbuttonpressed.png");
         button->setTouchEnabled(true);
         button->setTitleText("switch");
@@ -1665,7 +1666,7 @@ bool UIRichTextXMLExtend::init()
         button->addTouchEventListener(CC_CALLBACK_2(UIRichTextXMLExtend::touchEvent, this));
         button->setLocalZOrder(10);
         _widget->addChild(button);
-        
+
         Button* button2 = Button::create("cocosui/animationbuttonnormal.png", "cocosui/animationbuttonpressed.png");
         button2->setTouchEnabled(true);
         button2->setTitleText("wrap mode");
@@ -1673,15 +1674,15 @@ bool UIRichTextXMLExtend::init()
         button2->addTouchEventListener(CC_CALLBACK_2(UIRichTextXMLExtend::switchWrapMode, this));
         button2->setLocalZOrder(10);
         _widget->addChild(button2);
-		
-		Button* button3 = Button::create("cocosui/animationbuttonnormal.png", "cocosui/animationbuttonpressed.png");
-		button3->setTouchEnabled(true);
-		button3->setTitleText("alignment");
-		button3->setPosition(Vec2(widgetSize.width * 2 / 3, widgetSize.height / 2.0f + button2->getContentSize().height * 2.5));
-		button3->addTouchEventListener(CC_CALLBACK_2(UIRichTextXMLExtend::switchAlignment, this));
-		button3->setLocalZOrder(10);
-		_widget->addChild(button3);
-        
+
+        Button* button3 = Button::create("cocosui/animationbuttonnormal.png", "cocosui/animationbuttonpressed.png");
+        button3->setTouchEnabled(true);
+        button3->setTitleText("alignment");
+        button3->setPosition(Vec2(widgetSize.width * 2 / 3, widgetSize.height / 2.0f + button2->getContentSize().height * 2.5));
+        button3->addTouchEventListener(CC_CALLBACK_2(UIRichTextXMLExtend::switchAlignment, this));
+        button3->setLocalZOrder(10);
+        _widget->addChild(button3);
+
         /* Tag extension */
         RichText::setTagDescription("CloseNormal", false, [](const ValueMap& tagAttrValueMap) {
             RichElementImage* richElement = RichElementImage::create(0, Color3B::WHITE, 255, "cocosui/CloseNormal.png");
@@ -1691,7 +1692,7 @@ bool UIRichTextXMLExtend::init()
             RichElementImage* richElement = RichElementImage::create(0, Color3B::WHITE, 255, "cocosui/CloseSelected.png");
             return make_pair(ValueMap(), richElement);
         });
-        
+
         /* Defaults */
         ValueMap defaults;
         defaults[RichText::KEY_FONT_COLOR_STRING] = "#FFF";
@@ -1714,25 +1715,25 @@ bool UIRichTextXMLExtend::init()
         defaults[RichText::KEY_ANCHOR_TEXT_SHADOW_OFFSET_HEIGHT] = -4.0f;
         defaults[RichText::KEY_ANCHOR_TEXT_SHADOW_BLUR_RADIUS] = 0;
         defaults[RichText::KEY_ANCHOR_TEXT_GLOW_COLOR] = "#AFEEEE";
-        
+
         // RichText
         _richText = RichText::createWithXML("<span>CloseNormal-tag:<br /><CloseNormal /><br /><br />CloseSelected-tag:<br /><CloseSelected></CloseSelected></span>",
-                                            defaults,
-                                            [](const std::string& url) {
+            defaults,
+            [](const std::string& url) {
             Application::getInstance()->openURL(url);
         });
         _richText->ignoreContentAdaptWithSize(false);
         _richText->setContentSize(Size(100, 100));
-        
+
         _richText->setPosition(Vec2(widgetSize.width / 2, widgetSize.height / 2));
         _richText->setLocalZOrder(10);
-        
-        
+
+
         _widget->addChild(_richText);
-        
+
         // test remove all children, this call won't effect the test
         _richText->removeAllChildren();
-        
+
         return true;
     }
     return false;
@@ -1742,22 +1743,22 @@ void UIRichTextXMLExtend::touchEvent(Ref *pSender, Widget::TouchEventType type)
 {
     switch (type)
     {
-        case Widget::TouchEventType::ENDED:
+    case Widget::TouchEventType::ENDED:
+    {
+        if (_richText->isIgnoreContentAdaptWithSize())
         {
-            if (_richText->isIgnoreContentAdaptWithSize())
-            {
-                _richText->ignoreContentAdaptWithSize(false);
-                _richText->setContentSize(Size(100, 100));
-            }
-            else
-            {
-                _richText->ignoreContentAdaptWithSize(true);
-            }
+            _richText->ignoreContentAdaptWithSize(false);
+            _richText->setContentSize(Size(100, 100));
         }
-            break;
-            
-        default:
-            break;
+        else
+        {
+            _richText->ignoreContentAdaptWithSize(true);
+        }
+    }
+    break;
+
+    default:
+        break;
     }
 }
 
@@ -1772,10 +1773,109 @@ void UIRichTextXMLExtend::switchWrapMode(Ref *pSender, Widget::TouchEventType ty
 }
 
 void UIRichTextXMLExtend::switchAlignment(Ref *sender, Widget::TouchEventType type) {
-	if (type == Widget::TouchEventType::ENDED)
-	{
-		auto alignment = _richText->getHorizontalAlignment();
-		alignment = static_cast<RichText::HorizontalAlignment>((static_cast<std::underlying_type<RichText::HorizontalAlignment>::type>(alignment)+1) % 3);
-		_richText->setHorizontalAlignment(alignment);
-	}
+    if (type == Widget::TouchEventType::ENDED)
+    {
+        auto alignment = _richText->getHorizontalAlignment();
+        alignment = static_cast<RichText::HorizontalAlignment>((static_cast<std::underlying_type<RichText::HorizontalAlignment>::type>(alignment) + 1) % 3);
+        _richText->setHorizontalAlignment(alignment);
+    }
+}
+
+//
+// UIRichTextXMLSpace
+//
+bool UIRichTextXMLSpace::init()
+{
+    if (UIScene::init())
+    {
+        Size widgetSize = _widget->getContentSize();
+
+        // Add the alert
+        Text *alert = Text::create("Space", "fonts/Marker Felt.ttf", 30);
+        alert->setColor(Color3B(159, 168, 176));
+        alert->setPosition(Vec2(widgetSize.width / 2.0f, widgetSize.height / 2.0f - alert->getContentSize().height * 3.125));
+        _widget->addChild(alert);
+
+
+        Button* button = Button::create("cocosui/animationbuttonnormal.png", "cocosui/animationbuttonpressed.png");
+        button->setTouchEnabled(true);
+        button->setTitleText("switch");
+        button->setPosition(Vec2(widgetSize.width * 1 / 3, widgetSize.height / 2.0f + button->getContentSize().height * 2.5));
+        button->addTouchEventListener(CC_CALLBACK_2(UIRichTextXMLSpace::touchEvent, this));
+        button->setLocalZOrder(10);
+        _widget->addChild(button);
+
+        Button* button2 = Button::create("cocosui/animationbuttonnormal.png", "cocosui/animationbuttonpressed.png");
+        button2->setTouchEnabled(true);
+        button2->setTitleText("wrap mode");
+        button2->setPosition(Vec2(widgetSize.width / 2, widgetSize.height / 2.0f + button2->getContentSize().height * 2.5));
+        button2->addTouchEventListener(CC_CALLBACK_2(UIRichTextXMLSpace::switchWrapMode, this));
+        button2->setLocalZOrder(10);
+        _widget->addChild(button2);
+
+        Button* button3 = Button::create("cocosui/animationbuttonnormal.png", "cocosui/animationbuttonpressed.png");
+        button3->setTouchEnabled(true);
+        button3->setTitleText("alignment");
+        button3->setPosition(Vec2(widgetSize.width * 2 / 3, widgetSize.height / 2.0f + button2->getContentSize().height * 2.5));
+        button3->addTouchEventListener(CC_CALLBACK_2(UIRichTextXMLSpace::switchAlignment, this));
+        button3->setLocalZOrder(10);
+        _widget->addChild(button3);
+
+        // RichText
+        _richText = RichText::createWithXML("words should be divided with space.<br /><br /><font face='fonts/Marker Felt.ttf' color='#ffff00'>HELLO </font><font color='#ffff00'>WORLD</font><br /><br /><font color='#ff00ff'>HELLO</font><font face='fonts/Marker Felt.ttf' color='#ff00ff'> WORLD</font>");
+        _richText->ignoreContentAdaptWithSize(false);
+        _richText->setContentSize(Size(50, 100));
+        _richText->setPosition(Vec2(widgetSize.width / 2, widgetSize.height / 2));
+        _richText->setLocalZOrder(10);
+
+        _widget->addChild(_richText);
+
+        // test remove all children, this call won't effect the test
+        _richText->removeAllChildren();
+
+        return true;
+    }
+    return false;
+}
+
+void UIRichTextXMLSpace::touchEvent(Ref *pSender, Widget::TouchEventType type)
+{
+    switch (type)
+    {
+    case Widget::TouchEventType::ENDED:
+    {
+        if (_richText->isIgnoreContentAdaptWithSize())
+        {
+            _richText->ignoreContentAdaptWithSize(false);
+            _richText->setContentSize(Size(50, 100));
+        }
+        else
+        {
+            _richText->ignoreContentAdaptWithSize(true);
+        }
+    }
+    break;
+
+    default:
+        break;
+    }
+}
+
+void UIRichTextXMLSpace::switchWrapMode(Ref *pSender, Widget::TouchEventType type)
+{
+    if (type == Widget::TouchEventType::ENDED)
+    {
+        auto wrapMode = _richText->getWrapMode();
+        wrapMode = (wrapMode == RichText::WRAP_PER_WORD) ? RichText::WRAP_PER_CHAR : RichText::WRAP_PER_WORD;
+        _richText->setWrapMode(wrapMode);
+    }
+}
+
+void UIRichTextXMLSpace::switchAlignment(Ref *sender, Widget::TouchEventType type) {
+    if (type == Widget::TouchEventType::ENDED)
+    {
+        auto alignment = _richText->getHorizontalAlignment();
+        alignment = static_cast<RichText::HorizontalAlignment>((static_cast<std::underlying_type<RichText::HorizontalAlignment>::type>(alignment) + 1) % 3);
+        _richText->setHorizontalAlignment(alignment);
+    }
 }

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIRichTextTest/UIRichTextTest.h
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIRichTextTest/UIRichTextTest.h
@@ -266,4 +266,18 @@ protected:
     cocos2d::ui::RichText* _richText;
 };
 
+class UIRichTextXMLSpace : public UIScene
+{
+public:
+    CREATE_FUNC(UIRichTextXMLSpace);
+    
+    bool init() override;
+    void touchEvent(cocos2d::Ref* sender, cocos2d::ui::Widget::TouchEventType type);
+    void switchWrapMode(cocos2d::Ref* sender, cocos2d::ui::Widget::TouchEventType type);
+    void switchAlignment(cocos2d::Ref* sender, cocos2d::ui::Widget::TouchEventType type);
+
+protected:
+    cocos2d::ui::RichText* _richText;
+};
+
 #endif /* defined(__TestCpp__UIRichTextTest__) */


### PR DESCRIPTION
[UIRichText.cpp]  Allow user to select if they want to trim trailing spaces for a  RichElementText. Also fixed crash if estimatedIdx is less than 0 in  certain conditions. [UIRichText.h] New flag added for enabling trailing space trimming. [CCLabelTextFormatter.cpp] Only trim trailing whitespace if lines are  being split. This will trim all whitespace up to the next non-whitespace  token in a line. 

Please refer to #18874 


