### PR TITLE
Fix Rewrite MathUtilNeon64::crossVec3 to work around compiler bug

### DIFF
--- a/cocos/math/MathUtilNeon64.inl
+++ b/cocos/math/MathUtilNeon64.inl
@@ -24,23 +24,23 @@ class MathUtilNeon64
 {
 public:
     inline static void addMatrix(const float* m, float scalar, float* dst);
-    
+
     inline static void addMatrix(const float* m1, const float* m2, float* dst);
-    
+
     inline static void subtractMatrix(const float* m1, const float* m2, float* dst);
-    
+
     inline static void multiplyMatrix(const float* m, float scalar, float* dst);
-    
+
     inline static void multiplyMatrix(const float* m1, const float* m2, float* dst);
-    
+
     inline static void negateMatrix(const float* m, float* dst);
-    
+
     inline static void transposeMatrix(const float* m, float* dst);
-    
+
     inline static void transformVec4(const float* m, float x, float y, float z, float w, float* dst);
-    
+
     inline static void transformVec4(const float* m, const float* v, float* dst);
-    
+
     inline static void crossVec3(const float* v1, const float* v2, float* dst);
 };
 
@@ -54,7 +54,7 @@ inline void MathUtilNeon64::addMatrix(const float* m, float scalar, float* dst)
 	    "fadd v9.4s, v1.4s, v4.4s			\n\t" // DST->M[m4-m7] = M[m4-m7] + s
 	    "fadd v10.4s, v2.4s, v4.4s			\n\t" // DST->M[m8-m11] = M[m8-m11] + s
 	    "fadd v11.4s, v3.4s, v4.4s			\n\t" // DST->M[m12-m15] = M[m12-m15] + s
-	
+
         "st4 {v8.4s, v9.4s, v10.4s, v11.4s}, [%0] 	\n\t"    // Result in V9
 	    :
         : "r"(dst), "r"(m), "r"(&scalar)
@@ -73,7 +73,7 @@ inline void MathUtilNeon64::addMatrix(const float* m1, const float* m2, float* d
         "fadd   v14.4s, v2.4s, v10.4s         \n\t" // DST->M[m8-m11] = M1[m8-m11] + M2[m8-m11]
         "fadd   v15.4s, v3.4s, v11.4s         \n\t" // DST->M[m12-m15] = M1[m12-m15] + M2[m12-m15]
 
-        "st4    {v12.4s, v13.4s, v14.4s, v15.4s}, [%0]    \n\t" // DST->M[m0-m7] DST->M[m8-m15] 
+        "st4    {v12.4s, v13.4s, v14.4s, v15.4s}, [%0]    \n\t" // DST->M[m0-m7] DST->M[m8-m15]
         :
         : "r"(dst), "r"(m1), "r"(m2)
         : "v0", "v1", "v2", "v3", "v8", "v9", "v10", "v11", "v12", "v13", "v14", "v15", "memory"
@@ -84,7 +84,7 @@ inline void MathUtilNeon64::subtractMatrix(const float* m1, const float* m2, flo
 {
     asm volatile(
         "ld4     {v0.4s, v1.4s, v2.4s, v3.4s},     [%1]  \n\t" // M1[m0-m7] M1[m8-m15]
-        "ld4     {v8.4s, v9.4s, v10.4s, v11.4s},   [%2]  \n\t" // M2[m0-m7] M2[m8-m15] 
+        "ld4     {v8.4s, v9.4s, v10.4s, v11.4s},   [%2]  \n\t" // M2[m0-m7] M2[m8-m15]
 
         "fsub   v12.4s, v0.4s, v8.4s         \n\t" // DST->M[m0-m3] = M1[m0-m3] - M2[m0-m3]
         "fsub   v13.4s, v1.4s, v9.4s         \n\t" // DST->M[m4-m7] = M1[m4-m7] - M2[m4-m7]
@@ -101,7 +101,7 @@ inline void MathUtilNeon64::subtractMatrix(const float* m1, const float* m2, flo
 inline void MathUtilNeon64::multiplyMatrix(const float* m, float scalar, float* dst)
 {
     asm volatile(
-        "ld1     {v0.s}[0],         [%2]            \n\t" //s  
+        "ld1     {v0.s}[0],         [%2]            \n\t" //s
         "ld4     {v4.4s, v5.4s, v6.4s, v7.4s}, [%1]       \n\t" //M[m0-m7] M[m8-m15]
 
         "fmul     v8.4s, v4.4s, v0.s[0]               \n\t" // DST->M[m0-m3] = M[m0-m3] * s
@@ -171,8 +171,8 @@ inline void MathUtilNeon64::negateMatrix(const float* m, float* dst)
 inline void MathUtilNeon64::transposeMatrix(const float* m, float* dst)
 {
     asm volatile(
-        "ld4 {v0.4s, v1.4s, v2.4s, v3.4s}, [%1]    \n\t" // DST->M[m0, m4, m8, m12] = M[m0-m3] 
-							 //DST->M[m1, m5, m9, m12] = M[m4-m7] 
+        "ld4 {v0.4s, v1.4s, v2.4s, v3.4s}, [%1]    \n\t" // DST->M[m0, m4, m8, m12] = M[m0-m3]
+							 //DST->M[m1, m5, m9, m12] = M[m4-m7]
         "st1 {v0.4s, v1.4s, v2.4s, v3.4s}, [%0]    \n\t"
         :
         : "r"(dst), "r"(m)
@@ -189,7 +189,7 @@ inline void MathUtilNeon64::transformVec4(const float* m, float x, float y, floa
         "ld1    {v0.s}[3],        [%4]    \n\t"    // V[w]
         "ld1    {v9.4s, v10.4s, v11.4s, v12.4s}, [%5]   \n\t"    // M[m0-m7] M[m8-m15]
 
-	
+
         "fmul v13.4s, v9.4s, v0.s[0]           \n\t"      // DST->V = M[m0-m3] * V[x]
         "fmla v13.4s, v10.4s, v0.s[1]           \n\t"    // DST->V += M[m4-m7] * V[y]
         "fmla v13.4s, v11.4s, v0.s[2]           \n\t"    // DST->V += M[m8-m11] * V[z]
@@ -225,40 +225,28 @@ inline void MathUtilNeon64::transformVec4(const float* m, const float* v, float*
 
 inline void MathUtilNeon64::crossVec3(const float* v1, const float* v2, float* dst)
 {
-        asm volatile(
-        "ld1 {v0.2s},  [%2]           \n\t"
-        "ld1 {v0.s}[2],  [%1]           \n\t"
-        "mov v0.s[3], v0.s[0]         \n\t" // q0 = (v1y, v1z, v1x, v1x)
-
-        "ld1 {v1.4s},  [%3]           \n\t"
-        "mov v1.s[3], v1.s[0]           \n\t" // q1 = (v2x, v2y, v2z, v2x)
-
-        "fmul v2.4s, v0.4s, v1.4s            \n\t" // x = v1y * v2z, y = v1z * v2x
-
-
-        "mov v0.s[0], v0.s[1]           \n\t"
-        "mov v0.s[1], v0.s[2]           \n\t"
-        "mov v0.s[2], v0.s[3]           \n\t"
-
-        "mov v1.s[3], v1.s[2]           \n\t"
-
-        "fmul v0.4s, v0.4s, v1.4s            \n\t"
-
-        "mov v0.s[3], v0.s[1]           \n\t"
-        "mov v0.s[1], v0.s[2]           \n\t"
-        "mov v0.s[2], v0.s[0]           \n\t"
-
-        "fsub v2.4s, v0.4s, v2.4s            \n\t"
-
-        "mov v2.s[0], v2.s[1]           \n\t"
-        "mov v2.s[1], v2.s[2]           \n\t"
-        "mov v2.s[2], v2.s[3]           \n\t"
-
-        "st1 {v2.2s},       [%0], 8      \n\t" // V[x, y]
-        "st1 {v2.s}[2],     [%0]         \n\t" // V[z]
-        :
-        : "r"(dst), "r"(v1), "r"((v1+1)), "r"(v2), "r"((v2+1))
-        : "v0", "v1", "v2", "memory"
+    asm volatile(
+        "ld1 {v0.4s},  [%1]            \n\t" // q0 = (v1x, v1y, v1z, ?)
+        "mov v0.s[3], v0.s[1]          \n\t" // q0 = (v1x, v1y, v1z, v1y)
+        "mov v0.s[1], v0.s[2]          \n\t" // q0 = (v1x, v1z, v1z, v1y)
+        "mov v0.s[2], v0.s[0]          \n\t" // q0 = (v1x, v1z, v1x, v1y)
+        "mov v0.s[0], v0.s[3]          \n\t" // q0 = (v1y, v1z, v1x, v1y)
+        "ld1 {v1.4s},  [%2]            \n\t" // q1 = (v2x, v2y, v2z, ?)
+        "mov v1.s[3], v1.s[0]          \n\t" // q1 = (v2x, v2y, v2z, v2x)
+        "fmul v2.4s, v0.4s, v1.4s      \n\t" // q2 = v1.yzxy * v2.xyzx
+        "ext v0.16b, v0.16b, v0.16b, 4 \n\t" // q0 = v1.zxyy
+        "mov v1.s[3], v1.s[2]          \n\t" // q1 = v2.xyzz
+        "fmul v0.4s, v0.4s, v1.4s      \n\t" // q0 = v1.zxyy * v2.xyzz
+        "mov v0.s[3], v0.s[1]          \n\t"
+        "mov v0.s[1], v0.s[2]          \n\t"
+        "mov v0.s[2], v0.s[0]          \n\t" // q0 = v1.zyzx  * v2.xzxy
+        "fsub v2.4s, v0.4s, v2.4s      \n\t" // q2 = (v1.zyzx  * v2.xzxy) - (v1.yzxy * v2.xyzx)
+        "ext v2.16b, v2.16b, v2.16b, 4 \n\t" // q2 = (v1.yzxz  * v2.zxyx) - (v1.zxyy * v2.yzxx)
+        "st1 {v2.2s},       [%0], 8    \n\t" // store q2.xy in [%0] (equal to dst), increment %0 address by 8 bytes
+        "st1 {v2.s}[2],     [%0]       \n\t" // store q.z in [%0] (equal to dst + 2)
+        :                                    // no output parameters
+        : "r"(dst), "r"(v1), "r"(v2)         // input parameters
+        : "v0", "v1", "v2", "memory"         // clobbered registers
     );
 }
 


### PR DESCRIPTION
Our release builds, compiled with LLVM 9.x and Neon64 instructions, behave incorrectly under certain circumstances. After inspecting the assembly code and its differences with the debug build, we discovered a bug in the code generation of  Mat4::createLookAt related to MathUtilNeon64::crossVec3. Currently, this function uses assembly code which assigns the register %1 to v1, %2 to (v1 + 1) and performs two loads to store and shuffle v1.xyz in a Neon register. When inlined in the assembly of  Mat4::createLookAt, we noticed that the compiler incorrectly computes the address (v1 + 1), by using an OR instead of ADD. This leads to a wrong result.
We worked around this issue by partially rewriting MathUtilNeon64::crossVec3. Now it uses a single load of v1 instead of two, and mov instructions to shuffle the register elements. Also, we added comments to the assembly code and, as minor optimization, used the ext instruction to perform vector rotations instead of repeated mov.
In future, we would recommend using compiler instrinsics for all SIMD code or, alternatively, replacing the math library with an industry standard one.

For reference, the faulty assembly code in Mat4::createLookAt is
```
  orr	        x12, x11, #0x4   // WRONG! should be add 
  add      x13, sp,   #32
  orr	        x9, x13,  #0x4    // WRONG! should be add. Also, unused in the assembly code
  add      x10, sp,   #16
  ld1.2s  { v0 }, [x12]
  ld1.s    { v0 }[2], [x11]
```