### PR TITLE
Correct last update time

### DIFF
--- a/cocos/base/CCDirector.cpp
+++ b/cocos/base/CCDirector.cpp
@@ -376,6 +376,7 @@ void Director::calculateDeltaTime()
     {
         _deltaTime = 0;
         _nextDeltaTimeZero = false;
+        _lastUpdate = std::chrono::steady_clock::now();
     }
     else
     {


### PR DESCRIPTION
If next delta time was zeroed (via setNextDeltaTimeZero) the last update time was not corrected.