### PR TITLE
https downloader timeout on win/mac

### DIFF
--- a/cocos/network/CCDownloader-curl.cpp
+++ b/cocos/network/CCDownloader-curl.cpp
@@ -39,6 +39,8 @@
 // member function with suffix "Proc" designed called in DownloaderCURL::_threadProc
 // member function without suffix designed called in main thread
 
+#define CC_DOWNLOADER_WAIT_DNS 50 //wait until DNS query done
+
 namespace cocos2d { namespace network {
     using namespace std;
 
@@ -511,7 +513,7 @@ namespace cocos2d { namespace network {
                     // do wait action
                     if(maxfd == -1)
                     {
-                        this_thread::sleep_for(chrono::milliseconds(50));
+                        this_thread::sleep_for(chrono::milliseconds(CC_DOWNLOADER_WAIT_DNS));
                         rc = 0;
                     }
                     else

--- a/cocos/network/CCDownloader-curl.cpp
+++ b/cocos/network/CCDownloader-curl.cpp
@@ -381,11 +381,14 @@ namespace cocos2d { namespace network {
             }
 
             static const long LOW_SPEED_LIMIT = 1;
-            static const long LOW_SPEED_TIME = 5;
+            static const long LOW_SPEED_TIME = 10;
             curl_easy_setopt(handle, CURLOPT_LOW_SPEED_LIMIT, LOW_SPEED_LIMIT);
             curl_easy_setopt(handle, CURLOPT_LOW_SPEED_TIME, LOW_SPEED_TIME);
 
-            static const int MAX_REDIRS = 2;
+            curl_easy_setopt(handle, CURLOPT_SSL_VERIFYHOST, 0);
+            curl_easy_setopt(handle, CURLOPT_SSL_VERIFYPEER, 0);
+
+            static const int MAX_REDIRS = 5;
             if (MAX_REDIRS)
             {
                 curl_easy_setopt(handle, CURLOPT_FOLLOWLOCATION, true);
@@ -518,7 +521,7 @@ namespace cocos2d { namespace network {
                         timeout.tv_sec = timeoutMS / 1000;
                         timeout.tv_usec = (timeoutMS % 1000) * 1000;
 
-                        rc = select(maxfd+1, &fdread, &fdwrite, &fdexcep, &timeout);
+                        rc = select(maxfd+1, &fdread, &fdwrite, &fdexcep, 50);
                     }
 
                     if (rc < 0)

--- a/cocos/network/CCDownloader-curl.cpp
+++ b/cocos/network/CCDownloader-curl.cpp
@@ -511,7 +511,7 @@ namespace cocos2d { namespace network {
                     // do wait action
                     if(maxfd == -1)
                     {
-                        this_thread::sleep_for(chrono::milliseconds(timeoutMS));
+                        this_thread::sleep_for(chrono::milliseconds(50));
                         rc = 0;
                     }
                     else
@@ -521,7 +521,7 @@ namespace cocos2d { namespace network {
                         timeout.tv_sec = timeoutMS / 1000;
                         timeout.tv_usec = (timeoutMS % 1000) * 1000;
 
-                        rc = select(maxfd+1, &fdread, &fdwrite, &fdexcep, 50);
+                        rc = select(maxfd+1, &fdread, &fdwrite, &fdexcep, &timeout);
                     }
 
                     if (rc < 0)

--- a/cocos/network/CCDownloader-curl.cpp
+++ b/cocos/network/CCDownloader-curl.cpp
@@ -39,7 +39,7 @@
 // member function with suffix "Proc" designed called in DownloaderCURL::_threadProc
 // member function without suffix designed called in main thread
 
-#define CC_DOWNLOADER_WAIT_DNS 50 //wait until DNS query done
+#define CC_CURL_POLL_TIMEOUT_MS 50 //wait until DNS query done
 
 namespace cocos2d { namespace network {
     using namespace std;
@@ -513,7 +513,7 @@ namespace cocos2d { namespace network {
                     // do wait action
                     if(maxfd == -1)
                     {
-                        this_thread::sleep_for(chrono::milliseconds(CC_DOWNLOADER_WAIT_DNS));
+                        this_thread::sleep_for(chrono::milliseconds(CC_CURL_POLL_TIMEOUT_MS));
                         rc = 0;
                     }
                     else


### PR DESCRIPTION
timeout error occurs when trying to download HTTPS content on windows.
the original polling `sleep`(delay) time is too long and should be separated from `select` timeout.
