### PR TITLE
disable auto URI encode in AsyncHttp client, fix #18949

### DIFF
--- a/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxDownloader.java
+++ b/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxDownloader.java
@@ -307,6 +307,10 @@ public class Cocos2dxDownloader {
         // downloader._httpClient.setMaxRetriesAndTimeout(3, timeoutInSeconds * 1000);
         downloader._httpClient.allowRetryExceptionClass(javax.net.ssl.SSLException.class);
 
+        //disable url auto decode
+        //fix https://github.com/cocos2d/cocos2d-x/issues/18949
+        downloader._httpClient.setURLEncodingEnabled(false);
+
         downloader._tempFileNameSufix = tempFileNameSufix;
         downloader._countOfMaxProcessingTasks = countOfMaxProcessingTasks;
         return downloader;


### PR DESCRIPTION
disable auto URI encode in AsyncHttp client