### PR TITLE
Fix: LabelLetter::isVisible always returns false

### DIFF
--- a/cocos/2d/CCLabel.cpp
+++ b/cocos/2d/CCLabel.cpp
@@ -157,6 +157,11 @@ public:
         _letterVisible = visible;
         updateColor();
     }
+
+    bool isVisible() const override
+    {
+        return _letterVisible;
+    }
     
     //LabelLetter doesn't need to draw directly.
     void draw(Renderer* /*renderer*/, const Mat4 & /*transform*/, uint32_t /*flags*/) override


### PR DESCRIPTION
LabelLetter::setVisible use _letterVisible instead of _visible property. So isVisible method returns always false.  

reference:
https://github.com/cocos2d/cocos2d-x/pull/14701

