### PR TITLE
Add missing <functional> header to use std::function

### DIFF
--- a/cocos/audio/win32/AudioCache.h
+++ b/cocos/audio/win32/AudioCache.h
@@ -29,10 +29,11 @@
 
 #if CC_TARGET_PLATFORM == CC_PLATFORM_WIN32
 
-#include <string>
-#include <mutex>
-#include <vector>
+#include <functional>
 #include <memory>
+#include <mutex>
+#include <string>
+#include <vector>
 #ifdef OPENAL_PLAIN_INCLUDES
 #include <al.h>
 #else

--- a/cocos/audio/win32/AudioPlayer.h
+++ b/cocos/audio/win32/AudioPlayer.h
@@ -29,9 +29,10 @@
 
 #if CC_TARGET_PLATFORM == CC_PLATFORM_WIN32
 
-#include <string>
 #include <condition_variable>
+#include <functional>
 #include <mutex>
+#include <string>
 #include <thread>
 #ifdef OPENAL_PLAIN_INCLUDES
 #include <al.h>


### PR DESCRIPTION
This will be necessary to use std::function in VS2019; note that the standard requires including <functional> for std::function. (I cleaned up <mutex> and <thread> to not include <functional> which is causing builds of cocos2d-x to fail).