### PR TITLE
AVAudioSessionErrorCodeCannotStartPlaying error could be occured

### DIFF
--- a/cocos/audio/apple/AudioEngine-inl.mm
+++ b/cocos/audio/apple/AudioEngine-inl.mm
@@ -158,6 +158,11 @@ void AudioEngineInterruptionListenerCallback(void* user_data, UInt32 interruptio
                 ALOGD("AVAudioSessionInterruptionTypeEnded, application == UIApplicationStateActive, alcMakeContextCurrent(s_ALContext)");
                 NSError *error = nil;
                 [[AVAudioSession sharedInstance] setActive:YES error:&error];
+                if(error != nil){
+                    ALOGE("AVAudioSessionInterruptionTypeEnded, AVAudioSession setActive fail, %d",(int)error.code);
+                    return;
+                }
+                
                 alcMakeContextCurrent(s_ALContext);
                 if (Director::getInstance()->isPaused())
                 {
@@ -196,6 +201,10 @@ void AudioEngineInterruptionListenerCallback(void* user_data, UInt32 interruptio
                 return;
             }
             [[AVAudioSession sharedInstance] setActive:YES error:&error];
+            if(error != nil){
+                ALOGE("UIApplicationDidBecomeActiveNotification, AVAudioSession setActive fail, %d",(int)error.code);
+                return;
+            }
             alcMakeContextCurrent(s_ALContext);
         }
         else if (isAudioSessionInterrupted)


### PR DESCRIPTION
AVAudioSessionErrorCodeCannotStartPlaying error be could occured when AVAudioSession setActive, and a log "AUIOClient_StartIO failed (561015905)" will be print in Output view of Xcode, then the App is mute from then on.
https://developer.apple.com/documentation/avfoundation/avaudiosessionerrorcode/avaudiosessionerrorcodecannotstartplaying?language=occ