### PR TITLE
mark cocos2dx activity as "singleTask" on android

### DIFF
--- a/templates/cpp-template-default/proj.android/app/AndroidManifest.xml
+++ b/templates/cpp-template-default/proj.android/app/AndroidManifest.xml
@@ -21,7 +21,9 @@
             android:screenOrientation="landscape"
             android:configChanges="orientation|keyboardHidden|screenSize"
             android:label="@string/app_name"
-            android:theme="@android:style/Theme.NoTitleBar.Fullscreen" >
+            android:theme="@android:style/Theme.NoTitleBar.Fullscreen"
+            android:launchMode="singleTask"
+            android:taskAffinity=""  >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/templates/js-template-default/frameworks/runtime-src/proj.android/app/AndroidManifest.xml
+++ b/templates/js-template-default/frameworks/runtime-src/proj.android/app/AndroidManifest.xml
@@ -19,7 +19,9 @@
             android:screenOrientation="landscape"
             android:configChanges="orientation|keyboardHidden|screenSize"
             android:label="@string/app_name"
-            android:theme="@android:style/Theme.NoTitleBar.Fullscreen" >
+            android:theme="@android:style/Theme.NoTitleBar.Fullscreen"
+            android:launchMode="singleTask"
+            android:taskAffinity=""  >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/templates/lua-template-default/frameworks/runtime-src/proj.android/app/AndroidManifest.xml
+++ b/templates/lua-template-default/frameworks/runtime-src/proj.android/app/AndroidManifest.xml
@@ -19,7 +19,9 @@
             android:screenOrientation="landscape"
             android:configChanges="orientation|keyboardHidden|screenSize"
             android:label="@string/app_name"
-            android:theme="@android:style/Theme.NoTitleBar.Fullscreen" >
+            android:theme="@android:style/Theme.NoTitleBar.Fullscreen"
+            android:launchMode="singleTask"
+            android:taskAffinity=""  >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/tests/cpp-empty-test/proj.android/app/AndroidManifest.xml
+++ b/tests/cpp-empty-test/proj.android/app/AndroidManifest.xml
@@ -19,7 +19,9 @@
             android:screenOrientation="landscape"
             android:configChanges="orientation|keyboardHidden|screenSize"
             android:label="@string/app_name"
-            android:theme="@android:style/Theme.NoTitleBar.Fullscreen" >
+            android:theme="@android:style/Theme.NoTitleBar.Fullscreen"
+            android:launchMode="singleTask"
+            android:taskAffinity=""  >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/tests/cpp-tests/proj.android/app/AndroidManifest.xml
+++ b/tests/cpp-tests/proj.android/app/AndroidManifest.xml
@@ -21,7 +21,9 @@
             android:screenOrientation="landscape"
             android:configChanges="orientation|keyboardHidden|screenSize"
             android:label="@string/app_name"
-            android:theme="@android:style/Theme.NoTitleBar.Fullscreen" >
+            android:theme="@android:style/Theme.NoTitleBar.Fullscreen"
+            android:launchMode="singleTask"
+            android:taskAffinity=""  >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/tests/js-tests/project/proj.android/app/AndroidManifest.xml
+++ b/tests/js-tests/project/proj.android/app/AndroidManifest.xml
@@ -27,7 +27,9 @@
             android:screenOrientation="landscape"
             android:configChanges="orientation|keyboardHidden|screenSize"
             android:label="@string/app_name"
-            android:theme="@android:style/Theme.NoTitleBar.Fullscreen" >
+            android:theme="@android:style/Theme.NoTitleBar.Fullscreen"
+            android:launchMode="singleTask"
+            android:taskAffinity=""  >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/tests/lua-empty-test/project/proj.android/app/AndroidManifest.xml
+++ b/tests/lua-empty-test/project/proj.android/app/AndroidManifest.xml
@@ -20,7 +20,9 @@
             android:screenOrientation="landscape"
             android:configChanges="orientation|keyboardHidden|screenSize"
             android:label="@string/app_name"
-            android:theme="@android:style/Theme.NoTitleBar.Fullscreen" >
+            android:theme="@android:style/Theme.NoTitleBar.Fullscreen"
+            android:launchMode="singleTask"
+            android:taskAffinity=""  >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/tests/lua-game-controller-test/project/proj.android/app/AndroidManifest.xml
+++ b/tests/lua-game-controller-test/project/proj.android/app/AndroidManifest.xml
@@ -24,7 +24,9 @@
             android:screenOrientation="landscape"
             android:configChanges="orientation|keyboardHidden|screenSize"
             android:label="@string/app_name"
-            android:theme="@android:style/Theme.NoTitleBar.Fullscreen" >
+            android:theme="@android:style/Theme.NoTitleBar.Fullscreen"
+            android:launchMode="singleTask"
+            android:taskAffinity=""  >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/tests/lua-tests/project/proj.android/app/AndroidManifest.xml
+++ b/tests/lua-tests/project/proj.android/app/AndroidManifest.xml
@@ -21,7 +21,9 @@
             android:screenOrientation="landscape"
             android:configChanges="orientation|keyboardHidden|screenSize"
             android:label="@string/app_name"
-            android:theme="@android:style/Theme.NoTitleBar.Fullscreen" >
+            android:theme="@android:style/Theme.NoTitleBar.Fullscreen"
+            android:launchMode="singleTask"
+            android:taskAffinity=""  >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 


### PR DESCRIPTION
this PR prevent the side effect from https://github.com/cocos2d/cocos2d-x/pull/18247

the issue is game will exit with exception, when cocos2dx activity isn't the first Activity 

### How to reproduce

1. add a start activity for cocos2dx game
2. jump to cocos2dx activity by `Intent`
3. cocos2dx activity finished directly, because `!isTaskRoot()` is triggered