### PR TITLE
ClassLoader.loadClass use 'Binary names'.

### DIFF
--- a/cocos/audio/android/jni/cddandroidAndroidJavaEngine.cpp
+++ b/cocos/audio/android/jni/cddandroidAndroidJavaEngine.cpp
@@ -39,7 +39,7 @@ THE SOFTWARE.
 #define  LOGD(...)  __android_log_print(ANDROID_LOG_DEBUG,LOG_TAG,__VA_ARGS__)
 
 // Java class
-static const std::string helperClassName = "org/cocos2dx/lib/Cocos2dxHelper";
+static const std::string helperClassName = "org.cocos2dx.lib.Cocos2dxHelper";
 
 using namespace cocos2d;
 using namespace cocos2d::experimental;

--- a/cocos/audio/android/utils/Utils.cpp
+++ b/cocos/audio/android/utils/Utils.cpp
@@ -29,7 +29,7 @@ namespace cocos2d { namespace experimental {
 
 int getSDKVersion()
 {
-    return JniHelper::callStaticIntMethod("org/cocos2dx/lib/Cocos2dxHelper", "getSDKVersion");
+    return JniHelper::callStaticIntMethod("org.cocos2dx.lib.Cocos2dxHelper", "getSDKVersion");
 }
 
 }} // end of namespace cocos2d { namespace experimental

--- a/cocos/base/CCController-android.cpp
+++ b/cocos/base/CCController-android.cpp
@@ -157,7 +157,7 @@ Controller::Controller()
 }
 
 void Controller::receiveExternalKeyEvent(int externalKeyCode,bool receive) {
-    JniHelper::callStaticVoidMethod("org/cocos2dx/lib/GameControllerHelper", "receiveExternalKeyEvent", _deviceId, externalKeyCode, receive);
+    JniHelper::callStaticVoidMethod("org.cocos2dx.lib.GameControllerHelper", "receiveExternalKeyEvent", _deviceId, externalKeyCode, receive);
 }
 
 NS_CC_END

--- a/cocos/base/CCUserDefault-android.cpp
+++ b/cocos/base/CCUserDefault-android.cpp
@@ -44,7 +44,7 @@ THE SOFTWARE.
 #include "tinyxml2.h"
 #endif
 
-static const std::string helperClassName = "org/cocos2dx/lib/Cocos2dxHelper";
+static const std::string helperClassName = "org.cocos2dx.lib.Cocos2dxHelper";
 
 using namespace std;
 NS_CC_BEGIN

--- a/cocos/network/CCDownloader-android.cpp
+++ b/cocos/network/CCDownloader-android.cpp
@@ -31,6 +31,7 @@
 #include <mutex>
 
 #define JCLS_DOWNLOADER "org/cocos2dx/lib/Cocos2dxDownloader"
+#define J_BINARY_CLS_DOWNLOADER "org.cocos2dx.lib.Cocos2dxDownloader"
 #define JCLS_TASK       "com/loopj/android/http/RequestHandle"
 #define JARG_STR        "Ljava/lang/String;"
 #define JARG_DOWNLOADER "L" JCLS_DOWNLOADER ";"
@@ -98,7 +99,7 @@ namespace cocos2d { namespace network {
             DLLOG("Construct DownloaderAndroid: %p", this);
             JniMethodInfo methodInfo;
             if (JniHelper::getStaticMethodInfo(methodInfo,
-                                               JCLS_DOWNLOADER,
+                                               J_BINARY_CLS_DOWNLOADER,
                                                "createDownloader",
                                                "(II" JARG_STR "I)" JARG_DOWNLOADER))
             {
@@ -128,7 +129,7 @@ namespace cocos2d { namespace network {
             {
                 JniMethodInfo methodInfo;
                 if (JniHelper::getStaticMethodInfo(methodInfo,
-                                                   JCLS_DOWNLOADER,
+                                                   J_BINARY_CLS_DOWNLOADER,
                                                    "cancelAllRequests",
                                                    "(" JARG_DOWNLOADER ")V"))
                 {
@@ -154,7 +155,7 @@ namespace cocos2d { namespace network {
 
             JniMethodInfo methodInfo;
             if (JniHelper::getStaticMethodInfo(methodInfo,
-                                               JCLS_DOWNLOADER,
+                                               J_BINARY_CLS_DOWNLOADER,
                                                "createTask",
                                                "(" JARG_DOWNLOADER "I" JARG_STR JARG_STR")V"))
             {

--- a/cocos/network/HttpClient-android.cpp
+++ b/cocos/network/HttpClient-android.cpp
@@ -110,7 +110,7 @@ public:
 
         JniMethodInfo methodInfo;
         if (JniHelper::getStaticMethodInfo(methodInfo,
-                                           "org/cocos2dx/lib/Cocos2dxHttpURLConnection",
+                                           "org.cocos2dx.lib.Cocos2dxHttpURLConnection",
                                            "setRequestMethod",
                                            "(Ljava/net/HttpURLConnection;Ljava/lang/String;)V"))
         {
@@ -158,7 +158,7 @@ public:
         int suc = 0;
         JniMethodInfo methodInfo;
         if (JniHelper::getStaticMethodInfo(methodInfo,
-                                           "org/cocos2dx/lib/Cocos2dxHttpURLConnection",
+                                           "org.cocos2dx.lib.Cocos2dxHttpURLConnection",
                                            "connect",
                                            "(Ljava/net/HttpURLConnection;)I"))
         {
@@ -174,7 +174,7 @@ public:
     {
         JniMethodInfo methodInfo;
         if (JniHelper::getStaticMethodInfo(methodInfo,
-                                           "org/cocos2dx/lib/Cocos2dxHttpURLConnection",
+                                           "org.cocos2dx.lib.Cocos2dxHttpURLConnection",
                                            "disconnect",
                                            "(Ljava/net/HttpURLConnection;)V"))
         {
@@ -189,7 +189,7 @@ public:
         int responseCode = 0;
         JniMethodInfo methodInfo;
         if (JniHelper::getStaticMethodInfo(methodInfo,
-                                           "org/cocos2dx/lib/Cocos2dxHttpURLConnection",
+                                           "org.cocos2dx.lib.Cocos2dxHttpURLConnection",
                                            "getResponseCode",
                                            "(Ljava/net/HttpURLConnection;)I"))
         {
@@ -206,7 +206,7 @@ public:
         char* message = nullptr;
         JniMethodInfo methodInfo;
         if (JniHelper::getStaticMethodInfo(methodInfo,
-                                           "org/cocos2dx/lib/Cocos2dxHttpURLConnection",
+                                           "org.cocos2dx.lib.Cocos2dxHttpURLConnection",
                                            "getResponseMessage",
                                            "(Ljava/net/HttpURLConnection;)Ljava/lang/String;"))
         {
@@ -227,7 +227,7 @@ public:
     {
         JniMethodInfo methodInfo;
         if (JniHelper::getStaticMethodInfo(methodInfo,
-                                           "org/cocos2dx/lib/Cocos2dxHttpURLConnection",
+                                           "org.cocos2dx.lib.Cocos2dxHttpURLConnection",
                                            "sendRequest",
                                            "(Ljava/net/HttpURLConnection;[B)V"))
         {
@@ -274,7 +274,7 @@ public:
         char* headers = nullptr;
         JniMethodInfo methodInfo;
         if (JniHelper::getStaticMethodInfo(methodInfo,
-                                           "org/cocos2dx/lib/Cocos2dxHttpURLConnection",
+                                           "org.cocos2dx.lib.Cocos2dxHttpURLConnection",
                                            "getResponseHeaders",
                                            "(Ljava/net/HttpURLConnection;)Ljava/lang/String;"))
         {
@@ -301,7 +301,7 @@ public:
         char* content = nullptr;
         JniMethodInfo methodInfo;
         if (JniHelper::getStaticMethodInfo(methodInfo,
-                                           "org/cocos2dx/lib/Cocos2dxHttpURLConnection",
+                                           "org.cocos2dx.lib.Cocos2dxHttpURLConnection",
                                            "getResponseContent",
                                            "(Ljava/net/HttpURLConnection;)[B"))
         {
@@ -324,7 +324,7 @@ public:
         char* value = nullptr;
         JniMethodInfo methodInfo;
         if (JniHelper::getStaticMethodInfo(methodInfo,
-                                           "org/cocos2dx/lib/Cocos2dxHttpURLConnection",
+                                           "org.cocos2dx.lib.Cocos2dxHttpURLConnection",
                                            "getResponseHeaderByKey",
                                            "(Ljava/net/HttpURLConnection;Ljava/lang/String;)Ljava/lang/String;"))
         {
@@ -347,7 +347,7 @@ public:
         int contentLength = 0;
         JniMethodInfo methodInfo;
         if (JniHelper::getStaticMethodInfo(methodInfo,
-                                           "org/cocos2dx/lib/Cocos2dxHttpURLConnection",
+                                           "org.cocos2dx.lib.Cocos2dxHttpURLConnection",
                                            "getResponseHeaderByKeyInt",
                                            "(Ljava/net/HttpURLConnection;Ljava/lang/String;)I"))
         {
@@ -366,7 +366,7 @@ public:
         char* header = nullptr;
         JniMethodInfo methodInfo;
         if (JniHelper::getStaticMethodInfo(methodInfo,
-                                           "org/cocos2dx/lib/Cocos2dxHttpURLConnection",
+                                           "org.cocos2dx.lib.Cocos2dxHttpURLConnection",
                                            "getResponseHeaderByIdx",
                                            "(Ljava/net/HttpURLConnection;I)Ljava/lang/String;"))
         {
@@ -402,7 +402,7 @@ private:
     {
         JniMethodInfo methodInfo;
         if (JniHelper::getStaticMethodInfo(methodInfo,
-            "org/cocos2dx/lib/Cocos2dxHttpURLConnection",
+            "org.cocos2dx.lib.Cocos2dxHttpURLConnection",
             "createHttpURLConnection",
             "(Ljava/lang/String;)Ljava/net/HttpURLConnection;"))
         {
@@ -420,7 +420,7 @@ private:
     {
         JniMethodInfo methodInfo;
         if (JniHelper::getStaticMethodInfo(methodInfo,
-            "org/cocos2dx/lib/Cocos2dxHttpURLConnection",
+            "org.cocos2dx.lib.Cocos2dxHttpURLConnection",
             "addRequestHeader",
             "(Ljava/net/HttpURLConnection;Ljava/lang/String;Ljava/lang/String;)V"))
         {
@@ -523,7 +523,7 @@ private:
     {
         JniMethodInfo methodInfo;
         if (JniHelper::getStaticMethodInfo(methodInfo,
-            "org/cocos2dx/lib/Cocos2dxHttpURLConnection",
+            "org.cocos2dx.lib.Cocos2dxHttpURLConnection",
             "setReadAndConnectTimeout",
             "(Ljava/net/HttpURLConnection;II)V"))
         {
@@ -542,7 +542,7 @@ private:
 
         JniMethodInfo methodInfo;
         if (JniHelper::getStaticMethodInfo(methodInfo,
-            "org/cocos2dx/lib/Cocos2dxHttpURLConnection",
+            "org.cocos2dx.lib.Cocos2dxHttpURLConnection",
             "setVerifySSL",
             "(Ljava/net/HttpURLConnection;Ljava/lang/String;)V"))
         {

--- a/cocos/platform/android/CCApplication-android.cpp
+++ b/cocos/platform/android/CCApplication-android.cpp
@@ -47,7 +47,7 @@ extern "C" size_t __ctype_get_mb_cur_max(void) {
 }
 #endif
 
-static const std::string helperClassName = "org/cocos2dx/lib/Cocos2dxHelper";
+static const std::string helperClassName = "org.cocos2dx.lib.Cocos2dxHelper";
 
 NS_CC_BEGIN
 

--- a/cocos/platform/android/CCCommon-android.cpp
+++ b/cocos/platform/android/CCCommon-android.cpp
@@ -39,7 +39,7 @@ NS_CC_BEGIN
 
 void MessageBox(const char * pszMsg, const char * pszTitle)
 {
-    JniHelper::callStaticVoidMethod("org/cocos2dx/lib/Cocos2dxHelper", "showDialog", pszTitle, pszMsg);
+    JniHelper::callStaticVoidMethod("org.cocos2dx.lib.Cocos2dxHelper", "showDialog", pszTitle, pszMsg);
 }
 
 void LuaLog(const char * pszFormat)

--- a/cocos/platform/android/CCDevice-android.cpp
+++ b/cocos/platform/android/CCDevice-android.cpp
@@ -35,7 +35,7 @@ THE SOFTWARE.
 #include "platform/android/jni/JniHelper.h"
 #include "platform/CCFileUtils.h"
 
-static const std::string helperClassName = "org/cocos2dx/lib/Cocos2dxHelper";
+static const std::string helperClassName = "org.cocos2dx.lib.Cocos2dxHelper";
 
 NS_CC_BEGIN
 
@@ -88,7 +88,7 @@ public:
                       const FontDefinition& textDefinition )
     {
            JniMethodInfo methodInfo;
-           if (! JniHelper::getStaticMethodInfo(methodInfo, "org/cocos2dx/lib/Cocos2dxBitmap", "createTextBitmapShadowStroke",
+           if (! JniHelper::getStaticMethodInfo(methodInfo, "org.cocos2dx.lib.Cocos2dxBitmap", "createTextBitmapShadowStroke",
                "([BLjava/lang/String;IIIIIIIIZFFFFZIIIIFZI)Z"))
            {
                CCLOG("%s %d: error to get methodInfo", __FILE__, __LINE__);

--- a/cocos/platform/android/CCEnhanceAPI-android.cpp
+++ b/cocos/platform/android/CCEnhanceAPI-android.cpp
@@ -25,7 +25,7 @@
 #define  LOG_TAG    "CCEnhanceAPI_android Debug"
 #define  LOGD(...)  __android_log_print(ANDROID_LOG_DEBUG,LOG_TAG,__VA_ARGS__)
 
-#define CLASS_NAME "org/cocos2dx/lib/Cocos2dxHelper"
+#define CLASS_NAME "org.cocos2dx.lib.Cocos2dxHelper"
 
 // FIXME: using ndk-r10c will cause the next function could not be found. It may be a bug of ndk-r10c.
 // Here is the workaround method to fix the problem.

--- a/cocos/platform/android/CCFileUtils-android.cpp
+++ b/cocos/platform/android/CCFileUtils-android.cpp
@@ -339,7 +339,7 @@ string FileUtilsAndroid::getWritablePath() const
     // Fix for Nexus 10 (Android 4.2 multi-user environment)
     // the path is retrieved through Java Context.getCacheDir() method
     string dir("");
-    string tmp = JniHelper::callStaticStringMethod("org/cocos2dx/lib/Cocos2dxHelper", "getCocos2dxWritablePath");
+    string tmp = JniHelper::callStaticStringMethod("org.cocos2dx.lib.Cocos2dxHelper", "getCocos2dxWritablePath");
 
     if (tmp.length() > 0)
     {

--- a/cocos/platform/android/CCGLViewImpl-android.cpp
+++ b/cocos/platform/android/CCGLViewImpl-android.cpp
@@ -111,7 +111,7 @@ bool GLViewImpl::isOpenGLReady()
 
 void GLViewImpl::end()
 {
-    JniHelper::callStaticVoidMethod("org/cocos2dx/lib/Cocos2dxHelper", "terminateProcess");
+    JniHelper::callStaticVoidMethod("org.cocos2dx.lib.Cocos2dxHelper", "terminateProcess");
 }
 
 void GLViewImpl::swapBuffers()
@@ -121,9 +121,9 @@ void GLViewImpl::swapBuffers()
 void GLViewImpl::setIMEKeyboardState(bool bOpen)
 {
     if (bOpen) {
-        JniHelper::callStaticVoidMethod("org/cocos2dx/lib/Cocos2dxGLSurfaceView", "openIMEKeyboard");
+        JniHelper::callStaticVoidMethod("org.cocos2dx.lib.Cocos2dxGLSurfaceView", "openIMEKeyboard");
     } else {
-        JniHelper::callStaticVoidMethod("org/cocos2dx/lib/Cocos2dxGLSurfaceView", "closeIMEKeyboard");
+        JniHelper::callStaticVoidMethod("org.cocos2dx.lib.Cocos2dxGLSurfaceView", "closeIMEKeyboard");
     }
 }
 

--- a/cocos/platform/android/jni/Java_org_cocos2dx_lib_Cocos2dxBitmap.cpp
+++ b/cocos/platform/android/jni/Java_org_cocos2dx_lib_Cocos2dxBitmap.cpp
@@ -31,7 +31,7 @@ THE SOFTWARE.
 #include "platform/CCFileUtils.h"
 #include "base/ccUTF8.h"
 
-static const std::string className = "org/cocos2dx/lib/Cocos2dxBitmap";
+static const std::string className = "org.cocos2dx.lib.Cocos2dxBitmap";
 
 using namespace cocos2d;
 

--- a/cocos/platform/android/jni/Java_org_cocos2dx_lib_Cocos2dxEngineDataManager.cpp
+++ b/cocos/platform/android/jni/Java_org_cocos2dx_lib_Cocos2dxEngineDataManager.cpp
@@ -122,8 +122,8 @@ std::string& toLowercase(std::string& s)
 namespace {
 
 const char* ENGINE_DATA_MANAGER_VERSION = "5";
-const char* CLASS_NAME_ENGINE_DATA_MANAGER = "org/cocos2dx/lib/Cocos2dxEngineDataManager";
-const char* CLASS_NAME_RENDERER = "org/cocos2dx/lib/Cocos2dxRenderer";
+const char* CLASS_NAME_ENGINE_DATA_MANAGER = "org.cocos2dx.lib.Cocos2dxEngineDataManager";
+const char* CLASS_NAME_RENDERER = "org.cocos2dx.lib.Cocos2dxRenderer";
 
 bool _isInitialized = false;
 bool _isSupported = false;

--- a/cocos/platform/android/jni/Java_org_cocos2dx_lib_Cocos2dxHelper.cpp
+++ b/cocos/platform/android/jni/Java_org_cocos2dx_lib_Cocos2dxHelper.cpp
@@ -37,7 +37,7 @@ THE SOFTWARE.
 #define  LOG_TAG    "Java_org_cocos2dx_lib_Cocos2dxHelper.cpp"
 #define  LOGD(...)  __android_log_print(ANDROID_LOG_DEBUG,LOG_TAG,__VA_ARGS__)
 
-static const std::string className = "org/cocos2dx/lib/Cocos2dxHelper";
+static const std::string className = "org.cocos2dx.lib.Cocos2dxHelper";
 
 static EditTextCallback s_editTextCallback = nullptr;
 static void* s_ctx = nullptr;

--- a/cocos/storage/local-storage/LocalStorage-android.cpp
+++ b/cocos/storage/local-storage/LocalStorage-android.cpp
@@ -43,7 +43,7 @@
 USING_NS_CC;
 static int _initialized = 0;
 
-static std::string className = "org/cocos2dx/lib/Cocos2dxLocalStorage";
+static std::string className = "org.cocos2dx.lib.Cocos2dxLocalStorage";
 
 static void splitFilename (std::string& str)
 {
@@ -91,7 +91,7 @@ bool localStorageGetItem( const std::string& key, std::string *outItem )
     assert( _initialized );
     JniMethodInfo t;
 
-    if (JniHelper::getStaticMethodInfo(t, "org/cocos2dx/lib/Cocos2dxLocalStorage", "getItem", "(Ljava/lang/String;)Ljava/lang/String;"))
+    if (JniHelper::getStaticMethodInfo(t, className.c_str(), "getItem", "(Ljava/lang/String;)Ljava/lang/String;"))
     {
         jstring jkey = t.env->NewStringUTF(key.c_str());
         jstring jret = (jstring)t.env->CallStaticObjectMethod(t.classID, t.methodID, jkey);

--- a/cocos/ui/UIEditBox/UIEditBoxImpl-android.cpp
+++ b/cocos/ui/UIEditBox/UIEditBoxImpl-android.cpp
@@ -41,7 +41,7 @@
 
 NS_CC_BEGIN
 
-static const std::string editBoxClassName = "org/cocos2dx/lib/Cocos2dxEditBoxHelper";
+static const std::string editBoxClassName = "org.cocos2dx.lib.Cocos2dxEditBoxHelper";
 
 namespace ui {
 

--- a/cocos/ui/UIVideoPlayer-android.cpp
+++ b/cocos/ui/UIVideoPlayer-android.cpp
@@ -38,7 +38,7 @@
 
 //-----------------------------------------------------------------------------------------------------------
 
-static const std::string videoHelperClassName = "org/cocos2dx/lib/Cocos2dxVideoHelper";
+static const std::string videoHelperClassName = "org.cocos2dx.lib.Cocos2dxVideoHelper";
 
 USING_NS_CC;
 

--- a/cocos/ui/UIWebViewImpl-android.cpp
+++ b/cocos/ui/UIWebViewImpl-android.cpp
@@ -38,7 +38,7 @@
 #include "platform/CCFileUtils.h"
 #include "ui/UIHelper.h"
 
-static const std::string className = "org/cocos2dx/lib/Cocos2dxWebViewHelper";
+static const std::string className = "org.cocos2dx.lib.Cocos2dxWebViewHelper";
 
 #define  LOGD(...)  __android_log_print(ANDROID_LOG_DEBUG,"",__VA_ARGS__)
 

--- a/cocos/vr/CCVRGenericHeadTracker.cpp
+++ b/cocos/vr/CCVRGenericHeadTracker.cpp
@@ -212,8 +212,8 @@ void VRGenericHeadTracker::startTracking()
 #elif (CC_TARGET_PLATFORM == CC_PLATFORM_ANDROID)
     _deviceToDisplay = getRotateEulerMatrix(0.f, 0.f, -90.f);
     _worldToInertialReferenceFrame = getRotateEulerMatrix(-90.f, 0.f, 90.f);
-    JniHelper::callStaticVoidMethod("org/cocos2dx/lib/Cocos2dxHelper", "enableAccelerometer");
-    JniHelper::callStaticVoidMethod("org/cocos2dx/lib/Cocos2dxHelper", "enableCompass");
+    JniHelper::callStaticVoidMethod("org.cocos2dx.lib.Cocos2dxHelper", "enableAccelerometer");
+    JniHelper::callStaticVoidMethod("org.cocos2dx.lib.Cocos2dxHelper", "enableCompass");
 #endif
 }
 
@@ -251,8 +251,8 @@ Mat4 VRGenericHeadTracker::getLocalRotation()
     static Vec3 prevAccel = Vec3(0,0,0);
     static Vec3 prevCompass = Vec3(0,0,0);
 
-    Vec3 accel = JniHelper::callStaticVec3Method("org/cocos2dx/lib/Cocos2dxHelper", "getAccelValue");
-    Vec3 compass = JniHelper::callStaticVec3Method("org/cocos2dx/lib/Cocos2dxHelper", "getCompassValue");
+    Vec3 accel = JniHelper::callStaticVec3Method("org.cocos2dx.lib.Cocos2dxHelper", "getAccelValue");
+    Vec3 compass = JniHelper::callStaticVec3Method("org.cocos2dx.lib.Cocos2dxHelper", "getCompassValue");
 
 //    CCLOG("accel: %f, %f, %f.... compass: %f, %f, %f", accel.x, accel.y, accel.z, compass.x, compass.y, compass.z);
     prevAccel = lowPass(accel, prevAccel);

--- a/tests/cpp-tests/Classes/JNITest/JNITest.cpp
+++ b/tests/cpp-tests/Classes/JNITest/JNITest.cpp
@@ -48,7 +48,7 @@ JNITest::JNITest()
     checkLabel->setPosition(VisibleRect::center());
     addChild(checkLabel);
 
-    const std::string classPath = "org/cocos2dx/cpp_tests/JNITest";
+    const std::string classPath = "org.cocos2dx.cpp_tests.JNITest";
 
     JniHelper::callStaticVoidMethod(classPath, "voidMethod1");
 

--- a/tools/simulator/libsimulator/proj.android/hellolua/Runtime_android.cpp
+++ b/tools/simulator/libsimulator/proj.android/hellolua/Runtime_android.cpp
@@ -30,7 +30,7 @@
 using namespace std;
 using namespace cocos2d;
 
-static std::string className = "org/cocos2dx/lua/AppActivity";
+static std::string className = "org.cocos2dx.lua.AppActivity";
 
 void setActivityPathForAndroid(const std::string& path)
 {


### PR DESCRIPTION
JniHelper::getStaticMethodInfo's implement using Cocos2dxActivity's classloader to load Class.
In Android [doc](https://developer.android.com/reference/java/lang/ClassLoader#name), loadClass method's param is 'Binary names' style('a.b.c').

All place using `JniHelper::getStaticMethodInfo'` or `JniHelper::callStaticXXXXMethod`  need change.

This will fix following warning:
> W dalvikvm: dvmFindClassByName rejecting 'org/cocos2dx/lib/Cocos2dxHttpURLConnection'

PS:   JNIEnv::FindClass 's param style is 'a/b/c'.