### PR TITLE
CameraBackgroundSkyBoxBrush didn't need release vao vbo.

### DIFF
--- a/cocos/2d/CCCameraBackgroundBrush.cpp
+++ b/cocos/2d/CCCameraBackgroundBrush.cpp
@@ -330,6 +330,9 @@ CameraBackgroundSkyBoxBrush::CameraBackgroundSkyBoxBrush()
     _backToForegroundListener = EventListenerCustom::create(EVENT_RENDERER_RECREATED,
                                                             [this](EventCustom*)
                                                             {
+                                                                _vao = 0;
+                                                                _vertexBuffer = 0;
+                                                                _indexBuffer = 0;
                                                                 initBuffer();
                                                             }
                                                             );


### PR DESCRIPTION
When Android opengl context recreated, our `EVENT_RENDERER_RECREATED` event listener don't need to release old VAO VBO buffer.

For example:
when `CameraBackgroundSkyBoxBrush` init, it call `glGenBuffers` and gets [5, 6]
other nodes using VBO call `glGenBuffers` may get [7, 8]
...
Then app recreate, `EVENT_RENDERER_RECREATED` emitted, event listener's order may be:
other nodes call `glGenBuffers`, get [5, 6]
`CameraBackgroundSkyBoxBrush::initBuffer`, release [5, 6], call `glGenBuffers` gets [7, 8].

So the other node's vbo buffer is released by `CameraBackgroundSkyBoxBrush`.