### PR TITLE
Add websocket latency test

### DIFF
--- a/build/cocos2d_tests.xcodeproj/project.pbxproj
+++ b/build/cocos2d_tests.xcodeproj/project.pbxproj
@@ -1203,6 +1203,9 @@
 		ED545A771B68A1B600C3958E /* libiconv.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = ED545A721B68A1AC00C3958E /* libiconv.dylib */; };
 		ED545A781B68A1B800C3958E /* libiconv.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = ED545A721B68A1AC00C3958E /* libiconv.dylib */; };
 		ED545A791B68A1B900C3958E /* libiconv.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = ED545A721B68A1AC00C3958E /* libiconv.dylib */; };
+		ED95C36921411F0D00E06058 /* WebSocketDelayTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = ED95C36721411E4A00E06058 /* WebSocketDelayTest.cpp */; };
+		ED95C36A21411F0F00E06058 /* WebSocketDelayTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = ED95C36721411E4A00E06058 /* WebSocketDelayTest.cpp */; };
+		ED95C36B21411F1200E06058 /* WebSocketDelayTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = ED95C36721411E4A00E06058 /* WebSocketDelayTest.cpp */; };
 		EDCC747F17C455FD007B692C /* IOKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EDCC747E17C455FD007B692C /* IOKit.framework */; };
 		FA94B0A31B8EF69A0074B261 /* libiconv.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = ED545A721B68A1AC00C3958E /* libiconv.dylib */; };
 		FA94B0A41B8EF69A0074B261 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 52B47A331A534B2B004E4C60 /* Security.framework */; };
@@ -2351,6 +2354,8 @@
 		D60AE43317F7FFE100757E4B /* CoreMotion.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreMotion.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk/System/Library/Frameworks/CoreMotion.framework; sourceTree = DEVELOPER_DIR; };
 		ED545A6C1B68A18300C3958E /* libiconv.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libiconv.dylib; path = usr/lib/libiconv.dylib; sourceTree = SDKROOT; };
 		ED545A721B68A1AC00C3958E /* libiconv.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libiconv.dylib; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk/usr/lib/libiconv.dylib; sourceTree = DEVELOPER_DIR; };
+		ED95C36721411E4A00E06058 /* WebSocketDelayTest.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WebSocketDelayTest.cpp; sourceTree = "<group>"; };
+		ED95C36821411E4A00E06058 /* WebSocketDelayTest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebSocketDelayTest.h; sourceTree = "<group>"; };
 		EDCC747E17C455FD007B692C /* IOKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = IOKit.framework; path = System/Library/Frameworks/IOKit.framework; sourceTree = SDKROOT; };
 		FA94B0B41B8EF69A0074B261 /* perf test 3.11 iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "perf test 3.11 iOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		FA94B1C71B8EF76D0074B261 /* perf test 3.11 Mac.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "perf test 3.11 Mac.app"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -3562,6 +3567,8 @@
 		1AC35A7D18CECF0B00F37B72 /* NetworkTest */ = {
 			isa = PBXGroup;
 			children = (
+				ED95C36721411E4A00E06058 /* WebSocketDelayTest.cpp */,
+				ED95C36821411E4A00E06058 /* WebSocketDelayTest.h */,
 				1AC35A7E18CECF0B00F37B72 /* HttpClientTest.cpp */,
 				1AC35A7F18CECF0B00F37B72 /* HttpClientTest.h */,
 				1AC35A8018CECF0B00F37B72 /* SocketIOTest.cpp */,
@@ -6384,6 +6391,7 @@
 				1AC35B5B18CECF0C00F37B72 /* CurlTest.cpp in Sources */,
 				1AC35BFF18CECF0C00F37B72 /* CustomTableViewCell.cpp in Sources */,
 				29080DDF191B595E0066F8DF /* UITextTest.cpp in Sources */,
+				ED95C36B21411F1200E06058 /* WebSocketDelayTest.cpp in Sources */,
 				3E9E75D0199324CB005B7047 /* Camera3DTest.cpp in Sources */,
 				29080DC1191B595E0066F8DF /* UIRichTextTest.cpp in Sources */,
 				1AC35B2B18CECF0C00F37B72 /* BaseTest.cpp in Sources */,
@@ -6570,6 +6578,7 @@
 				507B41B71C31BEA60067B53E /* Bug-899.cpp in Sources */,
 				507B41B81C31BEA60067B53E /* NewEventDispatcherTest.cpp in Sources */,
 				507B41BE1C31BEA60067B53E /* Test.cpp in Sources */,
+				ED95C36A21411F0F00E06058 /* WebSocketDelayTest.cpp in Sources */,
 				507B41BF1C31BEA60067B53E /* ParticleTest.cpp in Sources */,
 				507B41C01C31BEA60067B53E /* TouchesTest.cpp in Sources */,
 				507B41C21C31BEA60067B53E /* TransitionsTest.cpp in Sources */,
@@ -6748,6 +6757,7 @@
 				1AC35BF818CECF0C00F37B72 /* SocketIOTest.cpp in Sources */,
 				1AC35C5018CECF0C00F37B72 /* SpriteTest.cpp in Sources */,
 				3E2BDAD019BEA3410055CDCD /* NewAudioEngineTest.cpp in Sources */,
+				ED95C36921411F0D00E06058 /* WebSocketDelayTest.cpp in Sources */,
 				1AC35C0418CECF0C00F37B72 /* FileUtilsTest.cpp in Sources */,
 				1AC35B5C18CECF0C00F37B72 /* CurlTest.cpp in Sources */,
 				1AC35C0018CECF0C00F37B72 /* CustomTableViewCell.cpp in Sources */,

--- a/tests/cpp-tests/CMakeLists.txt
+++ b/tests/cpp-tests/CMakeLists.txt
@@ -146,6 +146,7 @@ list(APPEND GAME_HEADER
      Classes/ExtensionsTest/TableViewTest/CustomTableViewCell.h
      Classes/ExtensionsTest/TableViewTest/TableViewTestScene.h
      Classes/ExtensionsTest/NetworkTest/WebSocketTest.h
+     Classes/ExtensionsTest/NetworkTest/WebSocketDelayTest.h
      Classes/ExtensionsTest/NetworkTest/SocketIOTest.h
      Classes/ExtensionsTest/NetworkTest/HttpClientTest.h
      Classes/Sprite3DTest/Sprite3DTest.h
@@ -254,6 +255,7 @@ list(APPEND GAME_SOURCE
      Classes/ExtensionsTest/NetworkTest/HttpClientTest.cpp
      Classes/ExtensionsTest/NetworkTest/SocketIOTest.cpp
      Classes/ExtensionsTest/NetworkTest/WebSocketTest.cpp
+     Classes/ExtensionsTest/NetworkTest/WebSocketDelayTest.cpp
      Classes/ExtensionsTest/TableViewTest/CustomTableViewCell.cpp
      Classes/ExtensionsTest/TableViewTest/TableViewTestScene.cpp
      Classes/FileUtilsTest/FileUtilsTest.cpp

--- a/tests/cpp-tests/Classes/ExtensionsTest/NetworkTest/WebSocketDelayTest.cpp
+++ b/tests/cpp-tests/Classes/ExtensionsTest/NetworkTest/WebSocketDelayTest.cpp
@@ -161,7 +161,7 @@ void WebSocketDelayTest::onMessage(network::WebSocket* ws, const network::WebSoc
         log("%s", textStr.c_str());
         doReceiveText();
         memset(times, 0, 100);
-        snprintf(times, 100, "total delay %llf seconds", _totalDelayMircoSec/ 1000000.0);
+        snprintf(times, 100, "total delay %f seconds", (float)(_totalDelayMircoSec/ 1000000.0));
         _progressStatus->setString(times);
     }
 }

--- a/tests/cpp-tests/Classes/ExtensionsTest/NetworkTest/WebSocketDelayTest.cpp
+++ b/tests/cpp-tests/Classes/ExtensionsTest/NetworkTest/WebSocketDelayTest.cpp
@@ -1,0 +1,218 @@
+/****************************************************************************
+ Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
+ 
+ http://www.cocos2d-x.org
+ 
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+ 
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+ 
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+ ****************************************************************************/
+
+#include "WebSocketDelayTest.h"
+#include "../ExtensionsTest.h"
+#include "testResource.h"
+
+USING_NS_CC;
+USING_NS_CC_EXT;
+
+#define SEND_TEXT_TIMES 100
+
+WebSocketDelayTest::WebSocketDelayTest()
+: _wsiSendText(nullptr)
+, _sendTextStatus(nullptr)
+, _progressStatus(nullptr)
+, _sendTextTimes(0)
+{
+    auto winSize = Director::getInstance()->getWinSize();
+    
+    const int MARGIN = 40;
+    const int SPACE = 35;
+    
+    auto menuRequest = Menu::create();
+    menuRequest->setPosition(Vec2::ZERO);
+    addChild(menuRequest);
+    
+    // Send Text
+    char cmdLabel[60] = { 0 };
+    snprintf(cmdLabel, 60, "Send %d Text", SEND_TEXT_TIMES);
+    auto labelSendText = Label::createWithTTF(cmdLabel, "fonts/arial.ttf", 20);
+    auto itemSendText = MenuItemLabel::create(labelSendText, CC_CALLBACK_1(WebSocketDelayTest::onMenuSendTextClicked, this));
+    itemSendText->setPosition(Vec2(winSize.width / 2, winSize.height - MARGIN - SPACE));
+    menuRequest->addChild(itemSendText);
+    
+    // Send Text Status Label
+    _sendTextStatus = Label::createWithTTF("Waiting connection...", "fonts/arial.ttf", 16, Size(160, 100), TextHAlignment::CENTER, TextVAlignment::TOP);
+    _sendTextStatus->setAnchorPoint(Vec2(0, 0));
+    _sendTextStatus->setPosition(Vec2(VisibleRect::left().x, VisibleRect::rightBottom().y + 25));
+    this->addChild(_sendTextStatus);
+   
+
+    // Error Label
+    _progressStatus = Label::createWithTTF(".", "fonts/arial.ttf", 16, Size(160, 100), TextHAlignment::CENTER, TextVAlignment::TOP);
+    _progressStatus->setAnchorPoint(Vec2(0, 0));
+    _progressStatus->setPosition(Vec2(VisibleRect::left().x + 320, VisibleRect::rightBottom().y + 25));
+    this->addChild(_progressStatus);
+    
+    auto startTestLabel = Label::createWithTTF("DO Connect!", "fonts/arial.ttf", 16);
+    auto startTestItem = MenuItemLabel::create(startTestLabel, CC_CALLBACK_1(WebSocketDelayTest::startTestCallback, this));
+    startTestItem->setPosition(Vec2(VisibleRect::center().x - 150, VisibleRect::bottom().y + 150));
+    _startTestMenu = Menu::create(startTestItem, nullptr);
+    _startTestMenu->setPosition(Vec2::ZERO);
+    this->addChild(_startTestMenu, 1);
+}
+
+WebSocketDelayTest::~WebSocketDelayTest()
+{
+
+}
+
+void WebSocketDelayTest::onExit()
+{
+    if (_wsiSendText)
+    {
+        _wsiSendText->closeAsync();
+    }
+
+    Node::onExit();
+}
+
+void WebSocketDelayTest::startTestCallback(Ref* sender)
+{
+    removeChild(_startTestMenu);
+    _startTestMenu = nullptr;
+
+    _wsiSendText = new network::WebSocket();
+    
+    std::vector<std::string> protocols;
+    protocols.push_back("myprotocol_1");
+    protocols.push_back("myprotocol_2");
+    if (!_wsiSendText->init(*this, "wss://echo.websocket.org", &protocols, "cacert.pem"))
+    {
+        CC_SAFE_DELETE(_wsiSendText);
+    }
+    else
+    {
+        retain(); // Retain self to avoid WebSocketDelayTest instance be deleted immediately, it will be released in WebSocketDelayTest::onClose.
+
+    }
+
+}
+
+void WebSocketDelayTest::doSendText()
+{
+    _sendTextTimes += 1;
+    if (_sendTextTimes > SEND_TEXT_TIMES) 
+    {
+        _sendTextStatus->setString("Test Done!");
+        return;
+    }
+
+    char statueBuffer[80] = { 0 };
+    snprintf(statueBuffer, 80, "Sending #%d/%d text", _sendTextTimes, SEND_TEXT_TIMES);
+    _sendTextStatus->setString(statueBuffer);
+    _sendTimeMircoSec = getNowMircroSeconds();
+    _wsiSendText->send("Hello WebSocket, I'm a text message.");
+}
+
+void WebSocketDelayTest::doReceiveText()
+{
+    _receiveTimeMircoSec = getNowMircroSeconds();
+    if(_sendTimeMircoSec > 0)
+        _totalDelayMircoSec += (_receiveTimeMircoSec - _sendTimeMircoSec);
+    doSendText(); //send next 
+}
+
+// Delegate methods
+void WebSocketDelayTest::onOpen(network::WebSocket* ws)
+{
+    char status[256] = {0};
+    sprintf(status, "Opened, url: %s, protocol: %s", ws->getUrl().c_str(), ws->getProtocol().c_str());
+
+    log("Websocket (%p) was opened, url: %s, protocol: %s", ws, ws->getUrl().c_str(), ws->getProtocol().c_str());
+    if (ws == _wsiSendText)
+    {
+        _sendTextStatus->setString(status);
+
+    }
+}
+
+void WebSocketDelayTest::onMessage(network::WebSocket* ws, const network::WebSocket::Data& data)
+{
+    if (!data.isBinary)
+    {
+        _receiveTextTimes++;
+        char times[100] = {0};
+        sprintf(times, "%d", _receiveTextTimes);
+        std::string textStr = std::string("response text msg: ")+data.bytes+", "+times;
+        log("%s", textStr.c_str());
+        doReceiveText();
+        memset(times, 0, 100);
+        snprintf(times, 100, "total delay %llf seconds", _totalDelayMircoSec/ 1000000.0);
+        _progressStatus->setString(times);
+    }
+}
+
+void WebSocketDelayTest::onClose(network::WebSocket* ws)
+{
+    log("onClose: websocket instance (%p) closed.", ws);
+    if (ws == _wsiSendText)
+    {
+        _wsiSendText = nullptr;
+        _sendTextStatus->setString("Send Text WS was closed");
+    }
+    // Delete websocket instance.
+    CC_SAFE_DELETE(ws);
+    log("WebSocketDelayTest ref: %u", _referenceCount);
+    release();
+}
+
+void WebSocketDelayTest::onError(network::WebSocket* ws, const network::WebSocket::ErrorCode& error)
+{
+    log("Error was fired, error code: %d", static_cast<int>(error));
+    char buf[100] = {0};
+    sprintf(buf, "An error was fired, code: %d", static_cast<int>(error));
+
+    if (ws == _wsiSendText)
+    {
+        _sendTextStatus->setString(buf);
+    }
+
+    _sendTimeMircoSec = 0;
+}
+
+// Menu Callbacks
+void WebSocketDelayTest::onMenuSendTextClicked(cocos2d::Ref *sender)
+{
+    if (! _wsiSendText)
+    {
+        return;
+    }
+
+    if (_wsiSendText->getReadyState() == network::WebSocket::State::OPEN)
+    {
+        
+        _sendTextTimes = 0;
+        _receiveTextTimes = 0;
+        doSendText();
+    }
+    else
+    {
+        std::string warningStr = "send text websocket instance wasn't ready...";
+        log("%s", warningStr.c_str());
+        _sendTextStatus->setString(warningStr.c_str());
+    }
+}

--- a/tests/cpp-tests/Classes/ExtensionsTest/NetworkTest/WebSocketDelayTest.h
+++ b/tests/cpp-tests/Classes/ExtensionsTest/NetworkTest/WebSocketDelayTest.h
@@ -1,0 +1,55 @@
+#pragma once
+
+#include "cocos2d.h"
+#include "extensions/cocos-ext.h"
+#include "network/WebSocket.h"
+#include "BaseTest.h"
+
+#include <chrono>
+
+class WebSocketDelayTest : public TestCase
+, public cocos2d::network::WebSocket::Delegate
+{
+public:
+    CREATE_FUNC(WebSocketDelayTest);
+
+    WebSocketDelayTest();
+    virtual ~WebSocketDelayTest();
+
+    virtual void onExit() override;
+    
+    virtual void onOpen(cocos2d::network::WebSocket* ws)override;
+    virtual void onMessage(cocos2d::network::WebSocket* ws, const cocos2d::network::WebSocket::Data& data)override;
+    virtual void onClose(cocos2d::network::WebSocket* ws)override;
+    virtual void onError(cocos2d::network::WebSocket* ws, const cocos2d::network::WebSocket::ErrorCode& error)override;
+    
+    // Menu Callbacks
+    void onMenuSendTextClicked(cocos2d::Ref *sender);
+
+    virtual std::string title() const override { return "WebSocket Delay Test"; }
+    void startTestCallback(cocos2d::Ref* sender);
+
+    int64_t getNowMircroSeconds()
+    {
+        auto now = std::chrono::high_resolution_clock::now();
+        return std::chrono::duration_cast<std::chrono::microseconds>(now.time_since_epoch()).count();
+    }
+
+    void doSendText();
+    void doReceiveText();
+
+private:
+    cocos2d::network::WebSocket* _wsiSendText;
+    
+    cocos2d::Label* _sendTextStatus;
+    cocos2d::Label* _progressStatus;
+    cocos2d::Menu* _startTestMenu;
+   
+    int64_t _totalDelayMircoSec = 0;
+    int64_t _sendTimeMircoSec = 0;
+    int64_t _receiveTimeMircoSec = 0;
+
+    int _sendTextTimes = 0;
+    int _receiveTextTimes = 0;
+};
+

--- a/tests/cpp-tests/Classes/ExtensionsTest/NetworkTest/WebSocketTest.cpp
+++ b/tests/cpp-tests/Classes/ExtensionsTest/NetworkTest/WebSocketTest.cpp
@@ -26,6 +26,8 @@
 #include "../ExtensionsTest.h"
 #include "testResource.h"
 
+#include "WebSocketDelayTest.h"
+
 USING_NS_CC;
 USING_NS_CC_EXT;
 
@@ -33,6 +35,7 @@ WebSocketTests::WebSocketTests()
 {
     ADD_TEST_CASE(WebSocketTest);
     ADD_TEST_CASE(WebSocketCloseTest);
+    ADD_TEST_CASE(WebSocketDelayTest);
 }
 
 WebSocketTest::WebSocketTest()

--- a/tests/cpp-tests/proj.android/app/jni/Android.mk
+++ b/tests/cpp-tests/proj.android/app/jni/Android.mk
@@ -57,6 +57,7 @@ LOCAL_SRC_FILES := main.cpp \
 ../../../Classes/ExtensionsTest/NetworkTest/HttpClientTest.cpp \
 ../../../Classes/ExtensionsTest/NetworkTest/SocketIOTest.cpp \
 ../../../Classes/ExtensionsTest/NetworkTest/WebSocketTest.cpp \
+../../../Classes/ExtensionsTest/NetworkTest/WebSocketDelayTest.cpp \
 ../../../Classes/ExtensionsTest/TableViewTest/CustomTableViewCell.cpp \
 ../../../Classes/ExtensionsTest/TableViewTest/TableViewTestScene.cpp \
 ../../../Classes/FileUtilsTest/FileUtilsTest.cpp \

--- a/tests/cpp-tests/proj.win32/cpp-tests.vcxproj
+++ b/tests/cpp-tests/proj.win32/cpp-tests.vcxproj
@@ -175,6 +175,7 @@ xcopy "$(OutDir)..\*.dll" "$(OutDir)" /D /Y</Command>
     <ClCompile Include="..\Classes\ExtensionsTest\AssetsManagerExTest\AssetsManagerExTest.cpp" />
     <ClCompile Include="..\Classes\ExtensionsTest\NetworkTest\HttpClientTest.cpp" />
     <ClCompile Include="..\Classes\ExtensionsTest\NetworkTest\SocketIOTest.cpp" />
+    <ClCompile Include="..\Classes\ExtensionsTest\NetworkTest\WebSocketDelayTest.cpp" />
     <ClCompile Include="..\Classes\ExtensionsTest\NetworkTest\WebSocketTest.cpp" />
     <ClCompile Include="..\Classes\ExtensionsTest\TableViewTest\CustomTableViewCell.cpp" />
     <ClCompile Include="..\Classes\ExtensionsTest\TableViewTest\TableViewTestScene.cpp" />
@@ -320,6 +321,7 @@ xcopy "$(OutDir)..\*.dll" "$(OutDir)" /D /Y</Command>
     <ClInclude Include="..\Classes\ExtensionsTest\AssetsManagerExTest\AssetsManagerExTest.h" />
     <ClInclude Include="..\Classes\ExtensionsTest\NetworkTest\HttpClientTest.h" />
     <ClInclude Include="..\Classes\ExtensionsTest\NetworkTest\SocketIOTest.h" />
+    <ClInclude Include="..\Classes\ExtensionsTest\NetworkTest\WebSocketDelayTest.h" />
     <ClInclude Include="..\Classes\ExtensionsTest\NetworkTest\WebSocketTest.h" />
     <ClInclude Include="..\Classes\ExtensionsTest\TableViewTest\CustomTableViewCell.h" />
     <ClInclude Include="..\Classes\ExtensionsTest\TableViewTest\TableViewTestScene.h" />

--- a/tests/cpp-tests/proj.win32/cpp-tests.vcxproj.filters
+++ b/tests/cpp-tests/proj.win32/cpp-tests.vcxproj.filters
@@ -642,6 +642,9 @@
     <ClCompile Include="..\Classes\precheader.cpp">
       <Filter>Classes</Filter>
     </ClCompile>
+    <ClCompile Include="..\Classes\ExtensionsTest\NetworkTest\WebSocketDelayTest.cpp">
+      <Filter>Classes\ExtensionsTest\NetworkTest</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="main.h">
@@ -1198,6 +1201,9 @@
     </ClInclude>
     <ClInclude Include="..\Classes\precheader.h">
       <Filter>Classes</Filter>
+    </ClInclude>
+    <ClInclude Include="..\Classes\ExtensionsTest\NetworkTest\WebSocketDelayTest.h">
+      <Filter>Classes\ExtensionsTest\NetworkTest</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
The latency value is calculated by `send dispatch delay  + network transfer time+ receive dispatch delay`. 
Since the `network transfer time` is much larger than the other two in the normal case, and it's not concerned here, we can set up a *[WebSocket Echo Server](https://github.com/PsichiX/simple-websocket-echo-server)* on the local machine and connect to it to reduce the `network transfer time`.  This would make the test result more reliable.