### PR TITLE
Adds desktop helper methods for video modes and custom cursors

### DIFF
--- a/cocos/platform/desktop/CCGLViewImpl-desktop.cpp
+++ b/cocos/platform/desktop/CCGLViewImpl-desktop.cpp
@@ -572,8 +572,8 @@ void GLViewImpl::setCursorVisible( bool isVisible )
 void GLViewImpl::setCustomCursor(int width, int height, unsigned char* little_endian_non_premult_rgba_32b_pixels)
 {
     GLFWimage image;
-    image.width = 32;
-    image.height = 32;
+    image.width = width;
+    image.height = height;
     image.pixels = little_endian_non_premult_rgba_32b_pixels;
     GLFWcursor* cursor = glfwCreateCursor(&image, 0, 0);
     glfwSetCursor(this->getWindow(), cursor);

--- a/cocos/platform/desktop/CCGLViewImpl-desktop.cpp
+++ b/cocos/platform/desktop/CCGLViewImpl-desktop.cpp
@@ -569,7 +569,7 @@ void GLViewImpl::setCursorVisible( bool isVisible )
         glfwSetInputMode(_mainWindow, GLFW_CURSOR, GLFW_CURSOR_HIDDEN);
 }
 
-void GLViewImpl::set_custom_cursor(int width, int height, unsigned char* little_endian_non_premult_rgba_32b_pixels)
+void GLViewImpl::setCustomCursor(int width, int height, unsigned char* little_endian_non_premult_rgba_32b_pixels)
 {
     GLFWimage image;
     image.width = 32;
@@ -579,12 +579,12 @@ void GLViewImpl::set_custom_cursor(int width, int height, unsigned char* little_
     glfwSetCursor(this->getWindow(), cursor);
 }
 
-void GLViewImpl::set_cursor_pos(double x_pos, double y_pos)
+void GLViewImpl::setCursorPos(double x_pos, double y_pos)
 {
     glfwSetCursorPos(_mainWindow, x_pos, y_pos);
 }
 
-const GLFWvidmode* GLViewImpl::get_possible_video_modes(int& count)
+const GLFWvidmode* GLViewImpl::getPossibleVideoModes(int& count)
 {
     auto monitor = glfwGetPrimaryMonitor();
     if (!monitor) {
@@ -594,7 +594,7 @@ const GLFWvidmode* GLViewImpl::get_possible_video_modes(int& count)
     return glfwGetVideoModes(monitor, &count);
 }
 
-void GLViewImpl::set_video_mode(GLFWvidmode* mode, bool is_fullscreen)
+void GLViewImpl::setVideoMode(GLFWvidmode* mode, bool is_fullscreen)
 {
     //if no monitor, it's windowed
     GLFWmonitor* monitor;
@@ -607,12 +607,12 @@ void GLViewImpl::set_video_mode(GLFWvidmode* mode, bool is_fullscreen)
     glfwSetWindowMonitor(_mainWindow, monitor, 100, 100, mode->width, mode->height, mode->refreshRate);
 }
 
-GLFWmonitor** GLViewImpl::get_monitors(int& monitor_count){
+GLFWmonitor** GLViewImpl::getMonitors(int& monitor_count){
     GLFWmonitor** monitors = glfwGetMonitors(&monitor_count);
     return monitors;
 };
 
-const GLFWvidmode* GLViewImpl::get_video_mode()
+const GLFWvidmode* GLViewImpl::getVideoMode()
 {
     auto monitor = glfwGetPrimaryMonitor();
     if (!monitor) {

--- a/cocos/platform/desktop/CCGLViewImpl-desktop.h
+++ b/cocos/platform/desktop/CCGLViewImpl-desktop.h
@@ -111,13 +111,13 @@ public:
      */
     virtual void setCursorVisible(bool isVisible) override;
 
-    void set_custom_cursor(int width, int height, unsigned char* little_endian_non_premult_rgba_32b_pixels);
-    void set_cursor_pos(double x_pos, double y_pos);
-    const GLFWvidmode* get_possible_video_modes(int& count);
+    void setCustomCursor(int width, int height, unsigned char* little_endian_non_premult_rgba_32b_pixels);
+    void setCursorPos(double x_pos, double y_pos);
+    const GLFWvidmode* getPossibleVideoModes(int& count);
     //if is_fullscreen is false, we pass NULL as a monitor, as per glfw
-    void set_video_mode(GLFWvidmode* mode, bool is_fullscreen);
-    GLFWmonitor** get_monitors(int& monitor_count);
-    const GLFWvidmode* get_video_mode();
+    void setVideoMode(GLFWvidmode* mode, bool is_fullscreen);
+    GLFWmonitor** getMonitors(int& monitor_count);
+    const GLFWvidmode* getVideoMode();
     /** Retina support is disabled by default
      *  @note This method is only available on Mac.
      */

--- a/cocos/platform/desktop/CCGLViewImpl-desktop.h
+++ b/cocos/platform/desktop/CCGLViewImpl-desktop.h
@@ -111,13 +111,24 @@ public:
      */
     virtual void setCursorVisible(bool isVisible) override;
 
+    /*
+     * The cursor image data is 32-bit, little-endian, non-premultiplied RGBA,
+     * i.e.  eight bits per channel. The pixels are arranged canonically as
+     * sequential rows, starting from the top-left corner.
+     */
     void setCustomCursor(int width, int height, unsigned char* little_endian_non_premult_rgba_32b_pixels);
+    /*
+     * The callback functions receives the cursor position, measured in screen
+     * coordinates but relative to the top-left corner of the window client
+     * area
+     */
     void setCursorPos(double x_pos, double y_pos);
+
     const GLFWvidmode* getPossibleVideoModes(int& count);
-    //if is_fullscreen is false, we pass NULL as a monitor, as per glfw
     void setVideoMode(GLFWvidmode* mode, bool is_fullscreen);
     GLFWmonitor** getMonitors(int& monitor_count);
     const GLFWvidmode* getVideoMode();
+
     /** Retina support is disabled by default
      *  @note This method is only available on Mac.
      */

--- a/cocos/platform/desktop/CCGLViewImpl-desktop.h
+++ b/cocos/platform/desktop/CCGLViewImpl-desktop.h
@@ -110,6 +110,14 @@ public:
      * Hide or Show the mouse cursor if there is one.
      */
     virtual void setCursorVisible(bool isVisible) override;
+
+    void set_custom_cursor(int width, int height, unsigned char* little_endian_non_premult_rgba_32b_pixels);
+    void set_cursor_pos(double x_pos, double y_pos);
+    const GLFWvidmode* get_possible_video_modes(int& count);
+    //if is_fullscreen is false, we pass NULL as a monitor, as per glfw
+    void set_video_mode(GLFWvidmode* mode, bool is_fullscreen);
+    GLFWmonitor** get_monitors(int& monitor_count);
+    const GLFWvidmode* get_video_mode();
     /** Retina support is disabled by default
      *  @note This method is only available on Mac.
      */
@@ -128,6 +136,11 @@ public:
     id getCocoaWindow() override { return glfwGetCocoaWindow(_mainWindow); }
 #endif // #if (CC_TARGET_PLATFORM == CC_PLATFORM_MAC)
 
+    /**
+    * Lock or Unlock the system cursor
+    */
+    void setCursorLock(const bool isLocked);
+
 protected:
     GLViewImpl(bool initglfw = true);
     virtual ~GLViewImpl();
@@ -137,6 +150,8 @@ protected:
     bool initWithFullscreen(const std::string& viewname, const GLFWvidmode &videoMode, GLFWmonitor *monitor);
 
     bool initGlew();
+
+    bool _cursorLocked;
 
     void updateFrameSize();
 


### PR DESCRIPTION
Light wrappers around glfw's video and cursor for desktop, tested in Windows 10.

Example custom cursor usage:

```
    auto glviewimpl = static_cast<cocos2d::GLViewImpl*>(cocos2d::Director::getInstance()->getOpenGLView());

    static auto img = new cocos2d::Image();
    img->initWithImageFile("cursor.png");

    static auto img_pressed = new cocos2d::Image();
    img_pressed->initWithImageFile("cursor_pressed.png");

    glviewimpl->setCustomCursor(32, 32, img->getData());

    cocos2d::EventListenerMouse* mouse_listener = cocos2d::EventListenerMouse::create();
    mouse_listener->onMouseDown = [glviewimpl](cocos2d::EventMouse* evt) {
        glviewimpl->setCustomCursor(32, 32, img_pressed->getData());
    };
    mouse_listener->onMouseUp = [glviewimpl](cocos2d::EventMouse* evt) {
        glviewimpl->setCustomCursor(32, 32, img->getData());
    };
    cocos2d::Director::getInstance()->getEventDispatcher()->addEventListenerWithFixedPriority(mouse_listener, 1);
```

Example setting resolution and refresh rate:

```
    auto director = cocos2d::Director::getInstance();
    cocos2d::GLView* glview = director->getOpenGLView();

    auto desktop_glview = dynamic_cast<cocos2d::GLViewImpl*>(glview);

    glview->setFrameSize((float)width, (float)height);

    const GLFWvidmode* old_vidmode = desktop_glview->getVideoMode();
    int old_refresh_rate = old_vidmode->refreshRate;

    GLFWvidmode new_vidmode = *old_vidmode;
    new_vidmode.refreshRate = refresh_rate;
    new_vidmode.width = width;
    new_vidmode.height = height;
    bool is_fullscreen = desktop_glview->isFullscreen();
    desktop_glview->setVideoMode(&new_vidmode, is_fullscreen);
    director->setAnimationInterval(1 / float(refresh_rate));
```
