### PR TITLE
cocos2d::Data: prevent use after free.

### DIFF
--- a/cocos/base/CCData.cpp
+++ b/cocos/base/CCData.cpp
@@ -134,7 +134,7 @@ void Data::fastSet(unsigned char* bytes, const ssize_t size)
 
 void Data::clear()
 {
-    if(!_bytes) free(_bytes);
+    if(_bytes) free(_bytes);
     _bytes = nullptr;
     _size = 0;
 }

--- a/cocos/base/CCData.cpp
+++ b/cocos/base/CCData.cpp
@@ -82,7 +82,7 @@ Data& Data::operator= (Data&& other)
 
 void Data::move(Data& other)
 {
-    clear();
+    if( !isNull() && _bytes != other._bytes) clear();
     
     _bytes = other._bytes;
     _size = other._size;
@@ -108,14 +108,22 @@ ssize_t Data::getSize() const
 
 void Data::copy(const unsigned char* bytes, const ssize_t size)
 {
-    clear();
+    if (!isNull() && bytes != _bytes)
+    {
+        clear();
+    }
+    else
+    {
+        //do not free if bytes == _bytes
+        _bytes = nullptr;
+    }
 
     if (size > 0)
     {
-        _size = size;
         _bytes = (unsigned char*)malloc(sizeof(unsigned char) * _size);
         memcpy(_bytes, bytes, _size);
     }
+    _size = size;
 }
 
 void Data::fastSet(unsigned char* bytes, const ssize_t size)

--- a/cocos/base/CCData.cpp
+++ b/cocos/base/CCData.cpp
@@ -82,7 +82,7 @@ Data& Data::operator= (Data&& other)
 
 void Data::move(Data& other)
 {
-    if( !isNull() && _bytes != other._bytes) clear();
+    if(_bytes != other._bytes) clear();
     
     _bytes = other._bytes;
     _size = other._size;
@@ -108,7 +108,7 @@ ssize_t Data::getSize() const
 
 void Data::copy(const unsigned char* bytes, const ssize_t size)
 {
-    if (!isNull() && bytes != _bytes)
+    if (bytes != _bytes)
     {
         clear();
     }
@@ -134,7 +134,7 @@ void Data::fastSet(unsigned char* bytes, const ssize_t size)
 
 void Data::clear()
 {
-    free(_bytes);
+    if(!_bytes) free(_bytes);
     _bytes = nullptr;
     _size = 0;
 }

--- a/cocos/base/CCData.cpp
+++ b/cocos/base/CCData.cpp
@@ -106,28 +106,34 @@ ssize_t Data::getSize() const
     return _size;
 }
 
-void Data::copy(const unsigned char* bytes, const ssize_t size)
+ssize_t Data::copy(const unsigned char* bytes, const ssize_t size)
 {
+    CCASSERT(size >= 0, "copy size should be non-negative");
+
+    if (size <= 0) return 0;
+
     if (bytes != _bytes)
     {
         clear();
     }
     else
     {
-        //do not free if bytes == _bytes
-        _bytes = nullptr;
+        _size = size;
+        return _size;
     }
-
+    
     if (size > 0)
     {
         _bytes = (unsigned char*)malloc(sizeof(unsigned char) * _size);
         memcpy(_bytes, bytes, _size);
     }
     _size = size;
+    return _size;
 }
 
 void Data::fastSet(unsigned char* bytes, const ssize_t size)
 {
+    CCASSERT(size >= 0, "fastSet size should be non-negative");
     _bytes = bytes;
     _size = size;
 }

--- a/cocos/base/CCData.cpp
+++ b/cocos/base/CCData.cpp
@@ -109,24 +109,17 @@ ssize_t Data::getSize() const
 ssize_t Data::copy(const unsigned char* bytes, const ssize_t size)
 {
     CCASSERT(size >= 0, "copy size should be non-negative");
+    CCASSERT(bytes, "bytes should not be nullptr");
 
     if (size <= 0) return 0;
 
     if (bytes != _bytes)
     {
         clear();
-    }
-    else
-    {
-        _size = size;
-        return _size;
-    }
-    
-    if (size > 0)
-    {
         _bytes = (unsigned char*)malloc(sizeof(unsigned char) * _size);
         memcpy(_bytes, bytes, _size);
     }
+
     _size = size;
     return _size;
 }
@@ -134,6 +127,7 @@ ssize_t Data::copy(const unsigned char* bytes, const ssize_t size)
 void Data::fastSet(unsigned char* bytes, const ssize_t size)
 {
     CCASSERT(size >= 0, "fastSet size should be non-negative");
+    CCASSERT(bytes, "bytes should not be nullptr");
     _bytes = bytes;
     _size = size;
 }

--- a/cocos/base/CCData.h
+++ b/cocos/base/CCData.h
@@ -97,8 +97,9 @@ public:
      *  @note This method will copy the whole buffer.
      *        Developer should free the pointer after invoking this method.
      *  @see Data::fastSet
+     * @return The size of bytes copied, return 0 if size <= 0
      */
-    void copy(const unsigned char* bytes, const ssize_t size);
+    ssize_t copy(const unsigned char* bytes, const ssize_t size);
 
     /** Fast set the buffer pointer and its size. Please use it carefully.
      *  @param bytes The buffer pointer, note that it have to be allocated by 'malloc' or 'calloc',


### PR DESCRIPTION
prevent free `_bytes` when src and dest are identical. 