### PR TITLE
Android: Adds supporting edge screens

### DIFF
--- a/cocos/platform/android/CCGLViewImpl-android.cpp
+++ b/cocos/platform/android/CCGLViewImpl-android.cpp
@@ -42,6 +42,9 @@ PFNGLGENVERTEXARRAYSOESPROC glGenVertexArraysOESEXT = 0;
 PFNGLBINDVERTEXARRAYOESPROC glBindVertexArrayOESEXT = 0;
 PFNGLDELETEVERTEXARRAYSOESPROC glDeleteVertexArraysOESEXT = 0;
 
+#define DEFAULT_MARGIN_ANDROID				30.0f
+#define WIDE_SCREEN_ASPECT_RATIO_ANDROID	2.0f
+
 void initExtensions() {
      glGenVertexArraysOESEXT = (PFNGLGENVERTEXARRAYSOESPROC)eglGetProcAddress("glGenVertexArraysOES");
      glBindVertexArrayOESEXT = (PFNGLBINDVERTEXARRAYOESPROC)eglGetProcAddress("glBindVertexArrayOES");
@@ -125,6 +128,62 @@ void GLViewImpl::setIMEKeyboardState(bool bOpen)
     } else {
         JniHelper::callStaticVoidMethod("org.cocos2dx.lib.Cocos2dxGLSurfaceView", "closeIMEKeyboard");
     }
+}
+
+Rect GLViewImpl::getSafeAreaRect() const {
+    Rect safeAreaRect = GLView::getSafeAreaRect();
+    float deviceAspectRatio = 0;
+    if(safeAreaRect.size.height > safeAreaRect.size.width) {
+        deviceAspectRatio = safeAreaRect.size.height / safeAreaRect.size.width;
+    } else {
+        deviceAspectRatio = safeAreaRect.size.width / safeAreaRect.size.height;
+    }
+
+    float margin = DEFAULT_MARGIN_ANDROID / _scaleX;
+
+    bool isScreenRound = JniHelper::callStaticBooleanMethod("org/cocos2dx/lib/Cocos2dxHelper", "isScreenRound");
+    bool hasSoftKeys = JniHelper::callStaticBooleanMethod("org/cocos2dx/lib/Cocos2dxHelper", "hasSoftKeys");
+    if(isScreenRound) {
+        // edge screen (ex. Samsung Galaxy s7, s9, s9+, Note 9, Nokia 8 Sirocco, Sony Xperia XZ3, Oppo Find X...)
+        if(safeAreaRect.size.width < safeAreaRect.size.height) {
+            safeAreaRect.origin.y += margin * 2.f;
+            safeAreaRect.size.height -= (margin * 2.f);
+
+            safeAreaRect.origin.x += margin;
+            safeAreaRect.size.width -= (margin * 2.f);
+        } else {
+            safeAreaRect.origin.y += margin;
+            safeAreaRect.size.height -= (margin * 2.f);
+
+            // landscape: no changes with X-coords
+        }
+    } else if (deviceAspectRatio >= WIDE_SCREEN_ASPECT_RATIO_ANDROID) {
+        // almost all devices on the market have round corners if
+        // deviceAspectRatio more than 2 (@see "android.max_aspect" parameter in AndroidManifest.xml)
+        float bottomMarginIfPortrait = 0;
+        if(hasSoftKeys) {
+            bottomMarginIfPortrait = margin * 2.f;
+        }
+
+        if(safeAreaRect.size.width < safeAreaRect.size.height) {
+            // portrait: double margin space if device has soft menu
+            safeAreaRect.origin.y += bottomMarginIfPortrait;
+            safeAreaRect.size.height -= (bottomMarginIfPortrait + margin);
+        } else {
+            // landscape: ignore double margin at the bottom in any cases
+            // prepare signle margin for round corners
+            safeAreaRect.origin.y += margin;
+            safeAreaRect.size.height -= (margin * 2.f);
+        }
+    } else {
+        if(hasSoftKeys && (safeAreaRect.size.width < safeAreaRect.size.height)) {
+            // portrait: preserve only for soft system menu
+            safeAreaRect.origin.y += margin * 2.f;
+            safeAreaRect.size.height -= (margin * 2.f);
+        }
+    }
+
+    return safeAreaRect;
 }
 
 NS_CC_END

--- a/cocos/platform/android/CCGLViewImpl-android.cpp
+++ b/cocos/platform/android/CCGLViewImpl-android.cpp
@@ -139,21 +139,22 @@ Rect GLViewImpl::getSafeAreaRect() const {
         deviceAspectRatio = safeAreaRect.size.width / safeAreaRect.size.height;
     }
 
-    float margin = DEFAULT_MARGIN_ANDROID / _scaleX;
+    float marginX = DEFAULT_MARGIN_ANDROID / _scaleX;
+    float marginY = DEFAULT_MARGIN_ANDROID / _scaleY;
 
     bool isScreenRound = JniHelper::callStaticBooleanMethod("org/cocos2dx/lib/Cocos2dxHelper", "isScreenRound");
     bool hasSoftKeys = JniHelper::callStaticBooleanMethod("org/cocos2dx/lib/Cocos2dxHelper", "hasSoftKeys");
     if(isScreenRound) {
         // edge screen (ex. Samsung Galaxy s7, s9, s9+, Note 9, Nokia 8 Sirocco, Sony Xperia XZ3, Oppo Find X...)
         if(safeAreaRect.size.width < safeAreaRect.size.height) {
-            safeAreaRect.origin.y += margin * 2.f;
-            safeAreaRect.size.height -= (margin * 2.f);
+            safeAreaRect.origin.y += marginY * 2.f;
+            safeAreaRect.size.height -= (marginY * 2.f);
 
-            safeAreaRect.origin.x += margin;
-            safeAreaRect.size.width -= (margin * 2.f);
+            safeAreaRect.origin.x += marginX;
+            safeAreaRect.size.width -= (marginX * 2.f);
         } else {
-            safeAreaRect.origin.y += margin;
-            safeAreaRect.size.height -= (margin * 2.f);
+            safeAreaRect.origin.y += marginY;
+            safeAreaRect.size.height -= (marginY * 2.f);
 
             // landscape: no changes with X-coords
         }
@@ -162,24 +163,24 @@ Rect GLViewImpl::getSafeAreaRect() const {
         // deviceAspectRatio more than 2 (@see "android.max_aspect" parameter in AndroidManifest.xml)
         float bottomMarginIfPortrait = 0;
         if(hasSoftKeys) {
-            bottomMarginIfPortrait = margin * 2.f;
+            bottomMarginIfPortrait = marginY * 2.f;
         }
 
         if(safeAreaRect.size.width < safeAreaRect.size.height) {
             // portrait: double margin space if device has soft menu
             safeAreaRect.origin.y += bottomMarginIfPortrait;
-            safeAreaRect.size.height -= (bottomMarginIfPortrait + margin);
+            safeAreaRect.size.height -= (bottomMarginIfPortrait + marginY);
         } else {
             // landscape: ignore double margin at the bottom in any cases
             // prepare signle margin for round corners
-            safeAreaRect.origin.y += margin;
-            safeAreaRect.size.height -= (margin * 2.f);
+            safeAreaRect.origin.y += marginY;
+            safeAreaRect.size.height -= (marginY * 2.f);
         }
     } else {
         if(hasSoftKeys && (safeAreaRect.size.width < safeAreaRect.size.height)) {
             // portrait: preserve only for soft system menu
-            safeAreaRect.origin.y += margin * 2.f;
-            safeAreaRect.size.height -= (margin * 2.f);
+            safeAreaRect.origin.y += marginY * 2.f;
+            safeAreaRect.size.height -= (marginY * 2.f);
         }
     }
 

--- a/cocos/platform/android/CCGLViewImpl-android.h
+++ b/cocos/platform/android/CCGLViewImpl-android.h
@@ -49,6 +49,7 @@ public:
     void end() override;
     void swapBuffers() override;
     void setIMEKeyboardState(bool bOpen) override;
+	virtual Rect getSafeAreaRect() const override;
 
 protected:
     GLViewImpl();

--- a/cocos/platform/android/CCGLViewImpl-android.h
+++ b/cocos/platform/android/CCGLViewImpl-android.h
@@ -49,7 +49,7 @@ public:
     void end() override;
     void swapBuffers() override;
     void setIMEKeyboardState(bool bOpen) override;
-	virtual Rect getSafeAreaRect() const override;
+    virtual Rect getSafeAreaRect() const override;
 
 protected:
     GLViewImpl();

--- a/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxHelper.java
+++ b/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxHelper.java
@@ -47,6 +47,9 @@ import android.preference.PreferenceManager.OnActivityResultListener;
 import android.util.DisplayMetrics;
 import android.util.Log;
 import android.view.Display;
+import android.view.KeyCharacterMap;
+import android.view.KeyEvent;
+import android.view.ViewConfiguration;
 import android.view.WindowManager;
 
 import com.android.vending.expansion.zipfile.APKExpansionSupport;
@@ -750,6 +753,58 @@ public class Cocos2dxHelper {
             e.printStackTrace();
             return -1;
         }
+    }
+
+    /**
+     * Returns whether the screen has a round shape. Apps may choose to change styling based
+     * on this property, such as the alignment or layout of text or informational icons.
+     *
+     * @return true if the screen is rounded, false otherwise
+     */
+    public static boolean isScreenRound() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            if (sActivity.getResources().getConfiguration().isScreenRound()) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Queries about whether any physical keys exist on the
+     * any keyboard attached to the device and returns <code>true</code>
+     * if the device does not have physical keys
+     *
+     * @return Returns <code>true</code> if the device have no physical keys,
+     * otherwise <code>false</code> will returned.
+     */
+    public static boolean hasSoftKeys() {
+        boolean hasSoftwareKeys = true;
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
+            Display display = sActivity.getWindowManager().getDefaultDisplay();
+
+            DisplayMetrics realDisplayMetrics = new DisplayMetrics();
+            display.getRealMetrics(realDisplayMetrics);
+
+            int realHeight = realDisplayMetrics.heightPixels;
+            int realWidth = realDisplayMetrics.widthPixels;
+
+            DisplayMetrics displayMetrics = new DisplayMetrics();
+            display.getMetrics(displayMetrics);
+
+            int displayHeight = displayMetrics.heightPixels;
+            int displayWidth = displayMetrics.widthPixels;
+
+            hasSoftwareKeys = (realWidth - displayWidth) > 0 ||
+                    (realHeight - displayHeight) > 0;
+        } else {
+            boolean hasMenuKey = ViewConfiguration.get(sActivity).hasPermanentMenuKey();
+            boolean hasBackKey = KeyCharacterMap.deviceHasKey(KeyEvent.KEYCODE_BACK);
+            hasSoftwareKeys = !hasMenuKey && !hasBackKey;
+        }
+        return hasSoftwareKeys;
     }
 
     //Enhance API modification end     


### PR DESCRIPTION
For many reasons, the implementation can not resolve all Android devices with edge screens or rounded corners on the screens (primarily because there is no API for which all conflicts have been fixed), but my implementation supports most modern devices.