### PR TITLE
cocos2d::Data fastSet accept nullptr as argument

### DIFF
--- a/cocos/base/CCData.cpp
+++ b/cocos/base/CCData.cpp
@@ -127,7 +127,7 @@ ssize_t Data::copy(const unsigned char* bytes, const ssize_t size)
 void Data::fastSet(unsigned char* bytes, const ssize_t size)
 {
     CCASSERT(size >= 0, "fastSet size should be non-negative");
-    CCASSERT(bytes, "bytes should not be nullptr");
+    //CCASSERT(bytes, "bytes should not be nullptr");
     _bytes = bytes;
     _size = size;
 }


### PR DESCRIPTION
It's common usage in code 

```cpp
bool FileUtils::writeStringToFile(..
  data.fastSet(data.c_str(), data.size()); 
  //..
  data.fastSet(nullptr, 0);
  return rv;
}
```