### PR TITLE
[linux] CCFileUtils::isFileExistInternal should reject a folder

### DIFF
--- a/cocos/platform/linux/CCFileUtils-linux.cpp
+++ b/cocos/platform/linux/CCFileUtils-linux.cpp
@@ -124,7 +124,7 @@ bool FileUtilsLinux::isFileExistInternal(const std::string& strFilePath) const
     }
 
     struct stat sts;
-    return (stat(strPath.c_str(), &sts) != -1) ? S_ISREG(sts.st_mode) : false;
+    return (stat(strPath.c_str(), &sts) == 0) && S_ISREG(sts.st_mode);
 }
 
 NS_CC_END

--- a/cocos/platform/linux/CCFileUtils-linux.cpp
+++ b/cocos/platform/linux/CCFileUtils-linux.cpp
@@ -124,7 +124,7 @@ bool FileUtilsLinux::isFileExistInternal(const std::string& strFilePath) const
     }
 
     struct stat sts;
-    return (stat(strPath.c_str(), &sts) != -1) ? true : false;
+    return (stat(strPath.c_str(), &sts) != -1) ? S_ISREG(sts.st_mode) : false;
 }
 
 NS_CC_END


### PR DESCRIPTION
ref https://github.com/cocos2d/cocos2d-x/issues/19058

`FileUtilsLinux::isFileExistInternal(path_of_a_directroy)` should return `false`