### PR TITLE
Multiresolution SHOW_ALL without black borders

### DIFF
--- a/cocos/base/CCDirector.cpp
+++ b/cocos/base/CCDirector.cpp
@@ -419,7 +419,8 @@ void Director::setOpenGLView(GLView *openGLView)
         _openGLView->retain();
 
         // set size
-        _winSizeInPoints = _openGLView->getDesignResolutionSize();
+//        _winSizeInPoints = _openGLView->getDesignResolutionSize();
+		_winSizeInPoints = _openGLView->getVisibleSize();
 
         _isStatusLabelUpdated = true;
 
@@ -797,7 +798,8 @@ Vec2 Director::convertToGL(const Vec2& uiPoint)
     // Calculate z=0 using -> transform*[0, 0, 0, 1]/w
     float zClip = transform.m[14]/transform.m[15];
 
-    Size glSize = _openGLView->getDesignResolutionSize();
+//    Size glSize = _openGLView->getDesignResolutionSize();
+	Size glSize = _openGLView->getVisibleSize();
     Vec4 clipCoord(2.0f*uiPoint.x/glSize.width - 1.0f, 1.0f - 2.0f*uiPoint.y/glSize.height, zClip, 1);
 
     Vec4 glCoord;
@@ -829,7 +831,8 @@ Vec2 Director::convertToUI(const Vec2& glPoint)
 	clipCoord.y = clipCoord.y / clipCoord.w;
 	clipCoord.z = clipCoord.z / clipCoord.w;
 
-    Size glSize = _openGLView->getDesignResolutionSize();
+//    Size glSize = _openGLView->getDesignResolutionSize();
+	Size glSize = _openGLView->getVisibleSize();
     float factor = 1.0f / glCoord.w;
     return Vec2(glSize.width * (clipCoord.x * 0.5f + 0.5f) * factor, glSize.height * (-clipCoord.y * 0.5f + 0.5f) * factor);
 }
@@ -842,6 +845,30 @@ const Size& Director::getWinSize(void) const
 Size Director::getWinSizeInPixels() const
 {
     return Size(_winSizeInPoints.width * _contentScaleFactor, _winSizeInPoints.height * _contentScaleFactor);
+}
+
+Size Director::getDesignSize() const
+{
+    if (_openGLView)
+    {
+        return _openGLView->getDesignResolutionSize();
+    }
+    else
+    {
+        return Size::ZERO;
+    }
+}
+
+Vec2 Director::getDesignOrigin() const
+{
+    if (_openGLView)
+    {
+        return _openGLView->getDesignOrigin();
+    }
+    else
+	{
+        return Vec2::ZERO;
+    }
 }
 
 Size Director::getVisibleSize() const

--- a/cocos/base/CCDirector.h
+++ b/cocos/base/CCDirector.h
@@ -247,6 +247,15 @@ public:
 
     /** Returns the size of the OpenGL view in pixels. */
     Size getWinSizeInPixels() const;
+	
+    /**
+     * Returns design size of the OpenGL view in points.
+     * The value has to be set via `GLView::setDesignResolutionSize()` before.
+     */
+    Size getDesignSize() const;
+    
+    /** Returns design origin coordinate of the OpenGL view in points. */
+    Vec2 getDesignOrigin() const;   
     
     /** 
      * Returns visible size of the OpenGL view in points.

--- a/cocos/platform/CCGLView.cpp
+++ b/cocos/platform/CCGLView.cpp
@@ -141,7 +141,8 @@ void GLView::updateDesignResolutionSize()
             _scaleX = _scaleY = MAX(_scaleX, _scaleY);
         }
         
-        else if (_resolutionPolicy == ResolutionPolicy::SHOW_ALL)
+        else if ((_resolutionPolicy == ResolutionPolicy::SHOW_ALL) ||
+			(_resolutionPolicy == ResolutionPolicy::COMPLETE_DESIGN))
         {
             _scaleX = _scaleY = MIN(_scaleX, _scaleY);
         }
@@ -157,15 +158,18 @@ void GLView::updateDesignResolutionSize()
         }
         
         // calculate the rect of viewport
-        float viewPortW = _designResolutionSize.width * _scaleX;
-        float viewPortH = _designResolutionSize.height * _scaleY;
+//        float viewPortW = _designResolutionSize.width * _scaleX;
+//        float viewPortH = _designResolutionSize.height * _scaleY;
+        float viewPortW = getVisibleSize().width * _scaleX;
+        float viewPortH = getVisibleSize().height * _scaleY;
         
         _viewPortRect.setRect((_screenSize.width - viewPortW) / 2, (_screenSize.height - viewPortH) / 2, viewPortW, viewPortH);
 
 
         // reset director's member variables to fit visible rect
         auto director = Director::getInstance();
-        director->_winSizeInPoints = getDesignResolutionSize();
+//        director->_winSizeInPoints = getDesignResolutionSize();
+		director->_winSizeInPoints = getVisibleSize();
         director->_isStatusLabelUpdated = true;
         director->setProjection(director->getProjection());
 
@@ -195,6 +199,20 @@ void GLView::setDesignResolutionSize(float width, float height, ResolutionPolicy
 const Size& GLView::getDesignResolutionSize() const 
 {
     return _designResolutionSize;
+}
+
+Vec2 GLView::getDesignOrigin() const
+{
+    if ((_resolutionPolicy == ResolutionPolicy::COMPLETE_DESIGN) ||
+        (_resolutionPolicy == ResolutionPolicy::NO_BORDER))
+    {
+        return Vec2((_screenSize.width/_scaleX - _designResolutionSize.width)/2,
+                    (_screenSize.height/_scaleY - _designResolutionSize.height)/2);
+    }
+    else
+    {
+        return Vec2::ZERO;
+    }
 }
 
 Size GLView::getFrameSize() const
@@ -227,27 +245,31 @@ Rect GLView::getSafeAreaRect() const
 
 Size GLView::getVisibleSize() const
 {
-    if (_resolutionPolicy == ResolutionPolicy::NO_BORDER)
+//    if (_resolutionPolicy == ResolutionPolicy::NO_BORDER)
+	if (_resolutionPolicy == ResolutionPolicy::SHOW_ALL)
     {
-        return Size(_screenSize.width/_scaleX, _screenSize.height/_scaleY);
+//        return Size(_screenSize.width/_scaleX, _screenSize.height/_scaleY);
+		return _designResolutionSize;
     }
     else 
     {
-        return _designResolutionSize;
+//        return _designResolutionSize;
+		return Size(_screenSize.width/_scaleX, _screenSize.height/_scaleY);
     }
 }
 
 Vec2 GLView::getVisibleOrigin() const
 {
-    if (_resolutionPolicy == ResolutionPolicy::NO_BORDER)
-    {
-        return Vec2((_designResolutionSize.width - _screenSize.width/_scaleX)/2, 
-                           (_designResolutionSize.height - _screenSize.height/_scaleY)/2);
-    }
-    else 
-    {
-        return Vec2::ZERO;
-    }
+//    if (_resolutionPolicy == ResolutionPolicy::NO_BORDER)
+//    {
+//        return Vec2((_designResolutionSize.width - _screenSize.width/_scaleX)/2, 
+//                           (_designResolutionSize.height - _screenSize.height/_scaleY)/2);
+//    }
+//    else 
+//    {
+//        return Vec2::ZERO;
+//    }
+	return Vec2::ZERO;
 }
 
 void GLView::setViewPortInPoints(float x , float y , float w , float h)

--- a/cocos/platform/CCGLView.h
+++ b/cocos/platform/CCGLView.h
@@ -71,6 +71,11 @@ enum class ResolutionPolicy
      * aspect ratios.
      */
     FIXED_WIDTH,
+    /** The entire design size is visible in the specified area without distortion while maintaining the original
+     * aspect ratio of the application. No Borders appear. (Own policy)
+	 * https://discuss.cocos2d-x.org/t/multiresolution-how-to-show-all-without-black-borders/26508/11
+     */
+    COMPLETE_DESIGN,
 
     UNKNOWN,
 };
@@ -268,7 +273,14 @@ public:
      */
     virtual const Size&  getDesignResolutionSize() const;
 
-    /**
+	/**
+	 * Get the design origin point of opengl viewport.
+     *
+     * @return The design origin point of opengl viewport.
+     */
+	virtual Vec2 getDesignOrigin() const;
+   
+   /**
      * Set opengl view port rectangle with points.
      *
      * @param x Set the points of x.


### PR DESCRIPTION
Hi,
I figured out this additional support for multi resolution might be useful
for everyone!

Currently, there are only full content-view with black border, full screen
view with cropped content, or if we need to add background image AND full
content view without cropping AND without black border, we have to
calculate it ourselves.

This changes will support the aforementioned full background without black
border AND full content view without cropping. All without affecting
existing code. I personally have used it in a number of my cocos2d-x
project and find it very useful. Please consider it for the community!
Thanks!

discussions available here:
https://discuss.cocos2d-x.org/t/multiresolution-how-to-show-all-without-black-borders/26508/11