### PR TITLE
Fix several bugs with button's title

### DIFF
--- a/cocos/2d/CCLabel.cpp
+++ b/cocos/2d/CCLabel.cpp
@@ -484,7 +484,7 @@ void Label::reset()
     _bmFontPath = "";
     _systemFontDirty = false;
     _systemFont = "Helvetica";
-    _systemFontSize = 12;
+    _systemFontSize = CC_DEFAULT_FONT_LABEL_SIZE;
 
     if (_horizontalKernings)
     {

--- a/cocos/2d/CCLabel.h
+++ b/cocos/2d/CCLabel.h
@@ -40,6 +40,7 @@ NS_CC_BEGIN
  * @{
  */
 
+#define CC_DEFAULT_FONT_LABEL_SIZE  12
 
 /**
  * @struct TTFConfig
@@ -61,7 +62,7 @@ typedef struct _ttfConfig
     bool underline;
     bool strikethrough;
 
-    _ttfConfig(const std::string& filePath = "",float size = 12, const GlyphCollection& glyphCollection = GlyphCollection::DYNAMIC,
+    _ttfConfig(const std::string& filePath = "",float size = CC_DEFAULT_FONT_LABEL_SIZE, const GlyphCollection& glyphCollection = GlyphCollection::DYNAMIC,
         const char *customGlyphCollection = nullptr, bool useDistanceField = false, int outline = 0,
                bool useItalics = false, bool useBold = false, bool useUnderline = false, bool useStrikethrough = false)
         : fontFilePath(filePath)
@@ -123,6 +124,14 @@ public:
          */
         RESIZE_HEIGHT
     };
+    
+    enum class LabelType {
+        TTF,
+        BMFONT,
+        CHARMAP,
+        STRING_TEXTURE
+    };
+    
     /// @name Creators
     /// @{
 
@@ -544,6 +553,20 @@ public:
 
     void setLineSpacing(float height);
     float getLineSpacing() const;
+    
+    /**
+     Returns type of label
+     
+     @warning Not support system font.
+     @return the type of label
+     @since v3.18.0
+     */
+    LabelType getLabelType() const { return _currentLabelType; }
+    
+    /**
+     Returns font size
+     */
+    float getRenderingFontSize()const;
 
     /**
      * Sets the additional kerning of the Label.
@@ -625,13 +648,6 @@ protected:
         int lineIndex;
     };
 
-    enum class LabelType {
-        TTF,
-        BMFONT,
-        CHARMAP,
-        STRING_TEXTURE
-    };
-
     virtual void setFontAtlas(FontAtlas* atlas, bool distanceFieldEnabled = false, bool useA8Shader = false);
     bool getFontLetterDef(char32_t character, FontLetterDefinition& letterDef) const;
 
@@ -647,7 +663,6 @@ protected:
     void shrinkLabelToContentSize(const std::function<bool(void)>& lambda);
     bool isHorizontalClamp();
     bool isVerticalClamp();
-    float getRenderingFontSize()const;
     void rescaleWithOriginalFontSize();
 
     void updateLabelLetters();

--- a/cocos/ui/UIButton.cpp
+++ b/cocos/ui/UIButton.cpp
@@ -72,8 +72,6 @@ _disabledFileName(""),
 _normalTexType(TextureResType::LOCAL),
 _pressedTexType(TextureResType::LOCAL),
 _disabledTexType(TextureResType::LOCAL),
-_fontSize(10),
-_type(FontType::SYSTEM),
 _fontName("")
 {
     setTouchEnabled(true);
@@ -115,18 +113,15 @@ bool Button::init(const std::string &normalImage,
                   const std::string& disableImage,
                   TextureResType texType)
 {
-    bool ret = true;
-    do
-    {
-        if (!Widget::init())
-        {
-            ret = false;
-            break;
-        }
 
-        this->loadTextures(normalImage, selectedImage, disableImage,texType);
-    } while (0);
-    return ret;
+    // invoke an overridden init() at first
+    if (!init()) {
+        return false;
+    }
+
+    loadTextures(normalImage, selectedImage, disableImage, texType);
+    
+    return true;
 }
 
 bool Button::init()
@@ -150,6 +145,15 @@ void Button::initRenderer()
     addProtectedChild(_buttonNormalRenderer, NORMAL_RENDERER_Z, -1);
     addProtectedChild(_buttonClickedRenderer, PRESSED_RENDERER_Z, -1);
     addProtectedChild(_buttonDisabledRenderer, DISABLED_RENDERER_Z, -1);
+}
+    
+bool Button::createTitleRendererIfNull() {
+    if( !_titleRenderer ) {
+        createTitleRenderer();
+        return true;
+    }
+    
+    return false;
 }
 
 void Button::createTitleRenderer()
@@ -702,53 +706,45 @@ void Button::setPressedActionEnabled(bool enabled)
 
 void Button::setTitleAlignment(TextHAlignment hAlignment)
 {
-    if (nullptr == _titleRenderer)
-    {
-        this->createTitleRenderer();
-    }
+    createTitleRendererIfNull();
     _titleRenderer->setAlignment(hAlignment);
 }
 
 void Button::setTitleAlignment(TextHAlignment hAlignment, TextVAlignment vAlignment)
 {
-    if (nullptr == _titleRenderer)
-    {
-        this->createTitleRenderer();
-    }
+    createTitleRendererIfNull();
     _titleRenderer->setAlignment(hAlignment, vAlignment);
 }
 
 void Button::setTitleText(const std::string& text)
 {
-    if (text == getTitleText())
-    {
+    if (text.compare(getTitleText()) == 0) {
         return;
     }
-    if(nullptr == _titleRenderer)
-    {
-        this->createTitleRenderer();
+    
+    createTitleRendererIfNull();
+    
+    if(getTitleFontSize() <= 0) {
+        setTitleFontSize(CC_DEFAULT_FONT_LABEL_SIZE);
     }
     _titleRenderer->setString(text);
-    this->setTitleFontSize(_fontSize);
+
     updateContentSize();
     updateTitleLocation();
 }
 
 std::string Button::getTitleText() const
 {
-    if(nullptr == _titleRenderer)
-    {
+    if(!_titleRenderer) {
         return "";
     }
+    
     return _titleRenderer->getString();
 }
 
 void Button::setTitleColor(const Color3B& color)
 {
-    if(nullptr == _titleRenderer)
-    {
-        this->createTitleRenderer();
-    }
+    createTitleRendererIfNull();
     _titleRenderer->setTextColor(Color4B(color));
 }
 
@@ -763,32 +759,30 @@ Color3B Button::getTitleColor() const
 
 void Button::setTitleFontSize(float size)
 {
-    if (nullptr == _titleRenderer)
-    {
-        this->createTitleRenderer();
-    }
+    createTitleRendererIfNull();
 
-    _fontSize = size;
-    if (_type == FontType::SYSTEM)
-    {
-        _titleRenderer->setSystemFontSize(_fontSize);
-    }
-    else if (_type == FontType::TTF)
-    {
+    Label::LabelType titleLabelType = _titleRenderer->getLabelType();
+    if(titleLabelType == Label::LabelType::TTF) {
         TTFConfig config = _titleRenderer->getTTFConfig();
-        config.fontSize = _fontSize;
+        config.fontSize = size;
         _titleRenderer->setTTFConfig(config);
+    } else if (titleLabelType == Label::LabelType::STRING_TEXTURE) {
+        // the system font
+        _titleRenderer->setSystemFontSize(size);
     }
+    
     //we can't change font size of BMFont.
-    if(FontType::BMFONT != _type)
-    {
+    if(titleLabelType != Label::LabelType::BMFONT) {
         updateContentSize();
     }
 }
 
-float Button::getTitleFontSize() const
-{
-    return _fontSize;
+float Button::getTitleFontSize() const {
+    if(_titleRenderer) {
+        return _titleRenderer->getRenderingFontSize();
+    }
+    
+    return -1;
 }
 
 void Button::setZoomScale(float scale)
@@ -803,40 +797,23 @@ float Button::getZoomScale()const
 
 void Button::setTitleFontName(const std::string& fontName)
 {
-    if(nullptr == _titleRenderer)
-    {
-        this->createTitleRenderer();
-    }
-    if(FileUtils::getInstance()->isFileExist(fontName))
-    {
+    createTitleRendererIfNull();
+    
+    if(FileUtils::getInstance()->isFileExist(fontName)) {
         std::string lowerCasedFontName = fontName;
         std::transform(lowerCasedFontName.begin(), lowerCasedFontName.end(), lowerCasedFontName.begin(), ::tolower);
-        if (lowerCasedFontName.find(".fnt") != std::string::npos)
-        {
+        if (lowerCasedFontName.find(".fnt") != std::string::npos) {
             _titleRenderer->setBMFontFilePath(fontName);
-            _type = FontType::BMFONT;
-        }
-        else
-        {
+        } else {
             TTFConfig config = _titleRenderer->getTTFConfig();
             config.fontFilePath = fontName;
-            config.fontSize = _fontSize;
             _titleRenderer->setTTFConfig(config);
-            _type = FontType::TTF;
         }
-    }
-    else
-    {
+    } else {
         _titleRenderer->setSystemFontName(fontName);
-        if (_type == FontType::TTF)
-        {
-            _titleRenderer->requestSystemFontRefresh();
-        }
-        _titleRenderer->setSystemFontSize(_fontSize);
-        _type = FontType::SYSTEM;
     }
     _fontName = fontName;
-    this->updateContentSize();
+    updateContentSize();
 }
 
 Label* Button::getTitleRenderer()const
@@ -846,25 +823,18 @@ Label* Button::getTitleRenderer()const
 
 std::string Button::getTitleFontName() const
 {
-    if (nullptr != _titleRenderer)
-    {
-        if (this->_type == FontType::SYSTEM)
-        {
+    if (_titleRenderer) {
+        Label::LabelType titleLabelType = _titleRenderer->getLabelType();
+        if (titleLabelType == Label::LabelType::STRING_TEXTURE) {
             return _titleRenderer->getSystemFontName();
-        }
-        else if (this->_type == FontType::TTF)
-        {
+        } else if (titleLabelType == Label::LabelType::TTF) {
             return  _titleRenderer->getTTFConfig().fontFilePath;
-        }
-        else
-        {
+        } else if (titleLabelType == Label::LabelType::BMFONT) {
             return _titleRenderer->getBMFontFilePath();
         }
     }
-    else
-    {
-        return _fontName;
-    }
+    
+    return "";
 }
 
 std::string Button::getDescription() const

--- a/cocos/ui/UIButton.cpp
+++ b/cocos/ui/UIButton.cpp
@@ -115,7 +115,7 @@ bool Button::init(const std::string &normalImage,
 {
 
     // invoke an overridden init() at first
-    if (!init()) {
+    if (!Widget::init()) {
         return false;
     }
 

--- a/cocos/ui/UIButton.h
+++ b/cocos/ui/UIButton.h
@@ -343,7 +343,8 @@ protected:
     virtual void adaptRenderers() override;
     void updateTitleLocation();
     void updateContentSize();
-    void createTitleRenderer();
+    virtual void createTitleRenderer();
+    bool createTitleRendererIfNull();
 
     virtual Widget* createCloneInstance() override;
     virtual void copySpecialProperties(Widget* model) override;
@@ -383,15 +384,6 @@ protected:
     TextureResType _disabledTexType;
 
 private:
-    enum class FontType
-    {
-        SYSTEM,
-        TTF,
-        BMFONT
-    };
-
-    int _fontSize;
-    FontType _type;
     std::string _fontName;
 };
 


### PR DESCRIPTION
1. when using `setTitleLabel()` the button didn't resolve the corresponded parameters;
2. bug with measurement accuracy (ignores the fractional part) of the system font and ttf-fonts sizes;
3. bug with the size of the button title (by default) did not match the value size of the label's typeface;
4. removes high coupling the typeface parameters of button because it already contains the used label.

Tested on existing cpp-tests