### PR TITLE
win32: fileutils removeDirectory() failure

### DIFF
--- a/cocos/platform/win32/CCFileUtils-win32.cpp
+++ b/cocos/platform/win32/CCFileUtils-win32.cpp
@@ -479,7 +479,12 @@ bool FileUtilsWin32::removeFile(const std::string &filepath) const
 
 bool FileUtilsWin32::removeDirectory(const std::string& dirPath) const
 {
-    std::wstring wpath = StringUtf8ToWideChar(dirPath);
+    std::string dirPathCopy = dirPath;
+    if (dirPath.length() > 0 && dirPath[dirPath.length() - 1] != '/' && dirPath[dirPath.length() - 1] != '\\')
+    {
+        dirPathCopy.append("/");
+    }
+    std::wstring wpath = StringUtf8ToWideChar(dirPathCopy);
     std::wstring files = wpath + L"*.*";
     WIN32_FIND_DATA wfd;
     HANDLE  search = FindFirstFileEx(files.c_str(), FindExInfoStandard, &wfd, FindExSearchNameMatch, NULL, 0);


### PR DESCRIPTION
when trying to remove dirs like `test0`, without postfix `/`, the function will build a pattern
like `"test0*.*"` rather than `"test0/*.*"`, which leads to `removeDirectory("test0")` not working.