### PR TITLE
[android] Fix crash caused by JNIEnv null pointer in getStringUTFCharsJNI function

### DIFF
--- a/cocos/base/ccUTF8.cpp
+++ b/cocos/base/ccUTF8.cpp
@@ -309,7 +309,7 @@ bool UTF32ToUTF16(const std::u32string& utf32, std::u16string& outUtf16)
 std::string getStringUTFCharsJNI(JNIEnv* env, jstring srcjStr, bool* ret)
 {
     std::string utf8Str;
-    if(srcjStr != nullptr)
+    if(srcjStr != nullptr && env != nullptr)
     {
         const unsigned short * unicodeChar = ( const unsigned short *)env->GetStringChars(srcjStr, nullptr);
         size_t unicodeCharLength = env->GetStringLength(srcjStr);


### PR DESCRIPTION
![tmp_crash_android_getstring](https://user-images.githubusercontent.com/33505774/46208345-f6cf7a00-c35c-11e8-9c75-e3efa617605c.png)
