### PR TITLE
win32/lua: vcxproj template link target error

### DIFF
--- a/templates/lua-template-default/frameworks/runtime-src/proj.win32/HelloLua.vcxproj
+++ b/templates/lua-template-default/frameworks/runtime-src/proj.win32/HelloLua.vcxproj
@@ -160,7 +160,7 @@ xcopy "$(ProjectDir)..\..\..\src" "$(LocalDebuggerWorkingDirectory)\src" /D /E /
       <AdditionalDependencies>libcurl.lib;%(AdditionalDependencies);$(_COCOS_LIB_WIN32_BEGIN);$(_COCOS_LIB_WIN32_END)</AdditionalDependencies>
       <IgnoreSpecificDefaultLibraries>libcmt.lib</IgnoreSpecificDefaultLibraries>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <OutputFile>$(ProjectDir)../../../simulator/win32/$(TargetName)$(TargetExt)</OutputFile>
+      <OutputFile>$(ProjectDir)../../../publish/win32/$(TargetName)$(TargetExt)</OutputFile>
     </Link>
     <ResourceCompile>
       <Culture>0x0409</Culture>


### PR DESCRIPTION
ref: https://github.com/cocos2d/cocos2d-x/issues/17623
project `link target` mismatch `output dir`