### PR TITLE
SpriteFrameCache: keep plist filenames when trying to remove sprite

### DIFF
--- a/cocos/2d/CCSpriteFrameCache.cpp
+++ b/cocos/2d/CCSpriteFrameCache.cpp
@@ -771,19 +771,12 @@ bool SpriteFrameCache::PlistFramesCache::eraseFrame(const std::string &frame)
 
 bool SpriteFrameCache::PlistFramesCache::eraseFrames(const std::vector<std::string> &frames)
 {
-    if (frames.empty()) return false;
-
-    for (auto frame : frames)
+    auto ret = false;
+    for (const auto & frame : frames)
     {
-        _spriteFrames.erase(frame);                             //drop SpriteFrame
-        auto itPlist = _indexFrame2plist.find(frame);
-        if (itPlist != _indexFrame2plist.end()) {
-            _indexPlist2Frames[itPlist->second].erase(frame);   //update index plist->[frameNames]
-            _indexFrame2plist.erase(itPlist);                   //update index frameName->plist
-        }
+        ret |= eraseFrame(frame);
     }
-
-    return true;
+    return ret;
 }
 
 bool SpriteFrameCache::PlistFramesCache::erasePlistIndex(const std::string &plist)

--- a/cocos/2d/CCSpriteFrameCache.cpp
+++ b/cocos/2d/CCSpriteFrameCache.cpp
@@ -96,22 +96,18 @@ bool SpriteFrameCache::PlistFramesCache::eraseFrames(const std::vector<std::stri
 bool SpriteFrameCache::PlistFramesCache::erasePlistIndex(const std::string &plist)
 {   
 
-    //update index frameName->plist, 
-    //need iterate every pair
-    for (auto itr = _indexFrame2plist.begin(); itr != _indexFrame2plist.end();)
+    auto it = _indexPlist2Frames.find(plist);
+    if (it == _indexPlist2Frames.end()) return false;
+
+    auto &frames = it->second;
+    for (auto f : frames)
     {
-        if (itr->second == plist)
-        {
-            // !!!!do not!!!! call `_spriteFrames.erase(itr);` to erase SpriteFrame
-            // it is done by other procedure
-            itr = _indexFrame2plist.erase(itr);                 //erase plist frame frameName->plist
-        }
-        else
-        {
-            itr++;
-        }
+        // !!do not!! call `_spriteFrames.erase(itr);` to erase SpriteFrame
+        // it shall be done by other procedure
+        _indexFrame2plist.erase(f);                             //erase plist frame frameName->plist
     }
-    return _indexPlist2Frames.erase(plist) > 0;                 //update index plist->[frameNames]
+    _indexPlist2Frames.erase(plist);                        //update index plist->[frameNames]
+    return true;
 }
 
 void SpriteFrameCache::PlistFramesCache::clear()

--- a/cocos/2d/CCSpriteFrameCache.h
+++ b/cocos/2d/CCSpriteFrameCache.h
@@ -34,6 +34,7 @@ THE SOFTWARE.
 #include <set>
 #include <map>
 #include <unordered_map>
+#include <mutex>
 #include <string>
 #include "2d/CCSpriteFrame.h"
 #include "base/CCRef.h"
@@ -116,18 +117,19 @@ protected:
         */
         void clear();
 
-        bool hasFrame(const std::string &frame) const;
-        inline bool hasPlist(const std::string &plist) const { return _indexPlist2Frames.find(plist) != _indexPlist2Frames.end(); }
+        inline bool hasFrame(const std::string &frame) const;
+        inline bool hasPlist(const std::string &plist) const;
 
-        inline SpriteFrame *at(const std::string &frame) { return _spriteFrames.at(frame); }
-        inline Map<std::string, SpriteFrame*>& getSpriteFrames() { return _spriteFrames; }
+        inline SpriteFrame *at(const std::string &frame);
+        inline Map<std::string, SpriteFrame*>& getSpriteFrames();
 
-        bool isPlistUsed(const std::string &plist) const;
+        inline bool isPlistUsed(const std::string &plist) const;
 
     private:
         Map<std::string, SpriteFrame*> _spriteFrames;
         std::unordered_map<std::string, std::set<std::string>> _indexPlist2Frames;
         std::unordered_map<std::string, std::string> _indexFrame2plist;
+        mutable std::mutex _mutex;
     };
 
 public:

--- a/cocos/2d/CCSpriteFrameCache.h
+++ b/cocos/2d/CCSpriteFrameCache.h
@@ -92,16 +92,25 @@ class CC_DLL SpriteFrameCache : public Ref
 protected:
     class PlistFramesCache {
     public:
-        PlistFramesCache() {}
-        void insertFrame(const std::string &plist, const std::string &frame);
+        PlistFramesCache() { }
+        void init() {
+            _spriteFrames.reserve(20); clear();
+        }
+        void insertFrame(const std::string &plist, const std::string &frame, SpriteFrame *frameObj);
         bool isPlistUsed(const std::string &plist) const;
         bool eraseFrame(const std::string &frame);
         bool eraseFrames(const std::vector<std::string> &frame);
         bool eraselist(const std::string &frame);
         void clear();
         bool hasFrame(const std::string &frame) const;
+
         inline bool hasPlist(const std::string &plist) const { return _plist2Frames.find(plist) != _plist2Frames.end(); }
+        inline SpriteFrame *at(const std::string &frame) { return _spriteFrames.at(frame); }
+
+        inline Map<std::string, SpriteFrame*>& getSpriteFrames() { return _spriteFrames; }
+
     private:
+        Map<std::string, SpriteFrame*> _spriteFrames;
         std::unordered_map<std::string, std::set<std::string>> _plist2Frames;
         std::unordered_map<std::string, std::string> _frame2plist;
     };
@@ -289,9 +298,8 @@ protected:
 
     void reloadSpriteFramesWithDictionary(ValueMap& dictionary, Texture2D *texture, const std::string &plist);
 
-    Map<std::string, SpriteFrame*> _spriteFrames;
     ValueMap _spriteFramesAliases;
-    PlistFramesCache _loadedPlistFiles;
+    PlistFramesCache _spriteFramesCache;
 };
 
 // end of _2d group

--- a/cocos/2d/CCSpriteFrameCache.h
+++ b/cocos/2d/CCSpriteFrameCache.h
@@ -99,10 +99,21 @@ protected:
         void init() {
             _spriteFrames.reserve(20); clear();
         }
+        /**  Record SpriteFrame with plist and frame name, add frame name 
+        *    and plist to index
+        */
         void insertFrame(const std::string &plist, const std::string &frame, SpriteFrame *frameObj);
+        /** Delete frame from cache, rebuild index
+        */
         bool eraseFrame(const std::string &frame);
+        /** Delete a list of frames from cache, rebuild index
+        */
         bool eraseFrames(const std::vector<std::string> &frame);
+        /** Delete frame from index and SpriteFrame is kept.
+        */
         bool erasePlistIndex(const std::string &frame);
+        /** Clear index and all SpriteFrames.
+        */
         void clear();
 
         bool hasFrame(const std::string &frame) const;

--- a/cocos/2d/CCSpriteFrameCache.h
+++ b/cocos/2d/CCSpriteFrameCache.h
@@ -32,6 +32,8 @@ THE SOFTWARE.
 #define __SPRITE_CCSPRITE_FRAME_CACHE_H__
 
 #include <set>
+#include <map>
+#include <unordered_map>
 #include <string>
 #include "2d/CCSpriteFrame.h"
 #include "base/CCRef.h"
@@ -87,6 +89,24 @@ class PolygonInfo;
  */
 class CC_DLL SpriteFrameCache : public Ref
 {
+protected:
+    class PlistFramesCache {
+    public:
+        PlistFramesCache() {}
+        void rememberFrame(const std::string &plist, const std::string &frame);
+        void forgetFrame(const std::string &plist, const std::string &frame);
+        bool isPlistUsed(const std::string &plist) const;
+        bool dropFrame(const std::string &frame);
+        bool dropFrames(const std::vector<std::string> &frame);
+        bool dropPlist(const std::string &frame);
+        void clear();
+        bool hasFrame(const std::string &frame) const;
+        inline bool hasPlist(const std::string &plist) const { return _plist2Frames.find(plist) != _plist2Frames.end(); }
+    private:
+        std::unordered_map<std::string, std::set<std::string>> _plist2Frames;
+        std::unordered_map<std::string, std::string> _frame2plist;
+    };
+
 public:
     /** Returns the shared instance of the Sprite Frame cache.
      *
@@ -246,11 +266,11 @@ protected:
 
     /*Adds multiple Sprite Frames with a dictionary. The texture will be associated with the created sprite frames.
      */
-    void addSpriteFramesWithDictionary(ValueMap& dictionary, Texture2D *texture);
+    void addSpriteFramesWithDictionary(ValueMap& dictionary, Texture2D *texture, const std::string &plist);
     
     /*Adds multiple Sprite Frames with a dictionary. The texture will be associated with the created sprite frames.
      */
-    void addSpriteFramesWithDictionary(ValueMap& dictionary, const std::string &texturePath);
+    void addSpriteFramesWithDictionary(ValueMap& dictionary, const std::string &texturePath, const std::string &plist);
     
     /** Removes multiple Sprite Frames from Dictionary.
     * @since v0.99.5
@@ -268,11 +288,11 @@ protected:
                                const std::vector<int> &triangleIndices,
                                PolygonInfo &polygonInfo);
 
-    void reloadSpriteFramesWithDictionary(ValueMap& dictionary, Texture2D *texture);
+    void reloadSpriteFramesWithDictionary(ValueMap& dictionary, Texture2D *texture, const std::string &plist);
 
     Map<std::string, SpriteFrame*> _spriteFrames;
     ValueMap _spriteFramesAliases;
-    std::set<std::string>*  _loadedFileNames;
+    PlistFramesCache _loadedPlistFiles;
 };
 
 // end of _2d group

--- a/cocos/2d/CCSpriteFrameCache.h
+++ b/cocos/2d/CCSpriteFrameCache.h
@@ -32,9 +32,7 @@ THE SOFTWARE.
 #define __SPRITE_CCSPRITE_FRAME_CACHE_H__
 
 #include <set>
-#include <map>
 #include <unordered_map>
-#include <mutex>
 #include <string>
 #include "2d/CCSpriteFrame.h"
 #include "base/CCRef.h"
@@ -129,7 +127,6 @@ protected:
         Map<std::string, SpriteFrame*> _spriteFrames;
         std::unordered_map<std::string, std::set<std::string>> _indexPlist2Frames;
         std::unordered_map<std::string, std::string> _indexFrame2plist;
-        mutable std::mutex _mutex;
     };
 
 public:

--- a/cocos/2d/CCSpriteFrameCache.h
+++ b/cocos/2d/CCSpriteFrameCache.h
@@ -90,6 +90,9 @@ class PolygonInfo;
 class CC_DLL SpriteFrameCache : public Ref
 {
 protected:
+    /**
+    * used to wrap plist & frame names & SpriteFrames
+    */
     class PlistFramesCache {
     public:
         PlistFramesCache() { }
@@ -97,22 +100,23 @@ protected:
             _spriteFrames.reserve(20); clear();
         }
         void insertFrame(const std::string &plist, const std::string &frame, SpriteFrame *frameObj);
-        bool isPlistUsed(const std::string &plist) const;
         bool eraseFrame(const std::string &frame);
         bool eraseFrames(const std::vector<std::string> &frame);
-        bool eraselist(const std::string &frame);
+        bool erasePlistIndex(const std::string &frame);
         void clear();
+
         bool hasFrame(const std::string &frame) const;
+        inline bool hasPlist(const std::string &plist) const { return _indexPlist2Frames.find(plist) != _indexPlist2Frames.end(); }
 
-        inline bool hasPlist(const std::string &plist) const { return _plist2Frames.find(plist) != _plist2Frames.end(); }
         inline SpriteFrame *at(const std::string &frame) { return _spriteFrames.at(frame); }
-
         inline Map<std::string, SpriteFrame*>& getSpriteFrames() { return _spriteFrames; }
+
+        bool isPlistUsed(const std::string &plist) const;
 
     private:
         Map<std::string, SpriteFrame*> _spriteFrames;
-        std::unordered_map<std::string, std::set<std::string>> _plist2Frames;
-        std::unordered_map<std::string, std::string> _frame2plist;
+        std::unordered_map<std::string, std::set<std::string>> _indexPlist2Frames;
+        std::unordered_map<std::string, std::string> _indexFrame2plist;
     };
 
 public:

--- a/cocos/2d/CCSpriteFrameCache.h
+++ b/cocos/2d/CCSpriteFrameCache.h
@@ -93,12 +93,11 @@ protected:
     class PlistFramesCache {
     public:
         PlistFramesCache() {}
-        void rememberFrame(const std::string &plist, const std::string &frame);
-        void forgetFrame(const std::string &plist, const std::string &frame);
+        void insertFrame(const std::string &plist, const std::string &frame);
         bool isPlistUsed(const std::string &plist) const;
-        bool dropFrame(const std::string &frame);
-        bool dropFrames(const std::vector<std::string> &frame);
-        bool dropPlist(const std::string &frame);
+        bool eraseFrame(const std::string &frame);
+        bool eraseFrames(const std::vector<std::string> &frame);
+        bool eraselist(const std::string &frame);
         void clear();
         bool hasFrame(const std::string &frame) const;
         inline bool hasPlist(const std::string &plist) const { return _plist2Frames.find(plist) != _plist2Frames.end(); }


### PR DESCRIPTION
ref https://github.com/cocos2d/cocos2d-x/issues/17949

- delete field `_loadedFileNames`
- connect `plist name` , `frame name`  and `SpriteFrame` together in `PlistFramesCache`.

`plist names` is kept when trying to remove any sprite.

