### PR TITLE
Boby - Possible fix for the Draw Batch Triangles Crashes

### DIFF
--- a/cocos/renderer/CCRenderer.h
+++ b/cocos/renderer/CCRenderer.h
@@ -258,8 +258,12 @@ protected:
     // the TriBatches
     TriBatchToDraw* _triBatchesToDraw;
 
+    // used as offset in in the process of concatenating triangles for batched drawing
     int _filledVertex;
     int _filledIndex;
+    // used for the flushing logic if vertex number is high and flushing is needed
+    int _filledVertex2;
+    int _filledIndex2;
 
     bool _glViewAssigned;
 


### PR DESCRIPTION
@minggo, @slackmoehrle Please check this pull request and ping other developers that you think might need to have a look at it.

Background: We are facing a lot of crashes related to the Renderer::drawBatchedTriangles function. Example issue: https://github.com/cocos2d/cocos2d-x/issues/18785 

In order to fix it I've created a sample code that seems to fix the crashes. Using this fix, the index doesn't get out of bounds, but when the bounds are exceeded some elements are not drawn any more. Though I think that not drawing elements is a better solution then a crash(or maybe leave this to the developer to decide).

Note that this is just a small proof of concept on how the crash might be solved so please leave any comments you have regarding the fix and what should be changed in order to be able to merge in the main branch. Please also express any concerns that you have related to the current implementation: did I overlook something? can this cause any major issues that slipped my mind?

Let me know what you think. Thank you!