### PR TITLE
Bugfix for aviod reading outside of the buffer.

### DIFF
--- a/cocos/base/CCConsole.cpp
+++ b/cocos/base/CCConsole.cpp
@@ -181,16 +181,17 @@ void log(const char * format, ...)
 
     do
     {
-        std::copy(buf + pos, buf + pos + MAX_LOG_LENGTH, tempBuf);
+        int dataSize = std::min(MAX_LOG_LENGTH, len - pos);
+        std::copy(buf + pos, buf + pos + dataSize, tempBuf);
 
-        tempBuf[MAX_LOG_LENGTH] = 0;
+        tempBuf[dataSize] = 0;
 
         MultiByteToWideChar(CP_UTF8, 0, tempBuf, -1, wszBuf, sizeof(wszBuf));
         OutputDebugStringW(wszBuf);
         WideCharToMultiByte(CP_ACP, 0, wszBuf, -1, tempBuf, sizeof(tempBuf), nullptr, FALSE);
         printf("%s", tempBuf);
 
-        pos += MAX_LOG_LENGTH;
+        pos += dataSize;
 
     } while (pos < len);
     SendLogToWindow(buf);


### PR DESCRIPTION
Bugfix for aviod reading outside of the buffer. If new will allocate memory at the end of the heap - reading of MAX_LOG_LENGTH from memory would cause access violation reading location.