### PR TITLE
iPhone X home indicator handling

### DIFF
--- a/templates/cpp-template-default/proj.ios_mac/ios/RootViewController.mm
+++ b/templates/cpp-template-default/proj.ios_mac/ios/RootViewController.mm
@@ -107,8 +107,15 @@
 }
 
 // Controls the application's preferred home indicator auto-hiding when this view controller is shown.
+// (better use preferredScreenEdgesDeferringSystemGestures for controlling the home indicator)
 - (BOOL)prefersHomeIndicatorAutoHidden {
-    return YES;
+    return NO;
+}
+
+// HOME Indicator need to be tapped twice 
+-(UIRectEdge)preferredScreenEdgesDeferringSystemGestures
+{
+    return UIRectEdgeBottom; 
 }
 
 - (void)didReceiveMemoryWarning {

--- a/templates/js-template-default/frameworks/runtime-src/proj.ios_mac/ios/RootViewController.mm
+++ b/templates/js-template-default/frameworks/runtime-src/proj.ios_mac/ios/RootViewController.mm
@@ -107,8 +107,15 @@
 }
 
 // Controls the application's preferred home indicator auto-hiding when this view controller is shown.
+// (better use preferredScreenEdgesDeferringSystemGestures for controlling the home indicator)
 - (BOOL)prefersHomeIndicatorAutoHidden {
-    return YES;
+    return NO;
+}
+
+// HOME Indicator need to be tapped twice 
+-(UIRectEdge)preferredScreenEdgesDeferringSystemGestures
+{
+    return UIRectEdgeBottom; 
 }
 
 - (void)didReceiveMemoryWarning {

--- a/templates/lua-template-default/frameworks/runtime-src/proj.ios_mac/ios/RootViewController.mm
+++ b/templates/lua-template-default/frameworks/runtime-src/proj.ios_mac/ios/RootViewController.mm
@@ -107,8 +107,15 @@
 }
 
 // Controls the application's preferred home indicator auto-hiding when this view controller is shown.
+// (better use preferredScreenEdgesDeferringSystemGestures for controlling the home indicator)
 - (BOOL)prefersHomeIndicatorAutoHidden {
-    return YES;
+    return NO;
+}
+
+// HOME Indicator need to be tapped twice 
+-(UIRectEdge)preferredScreenEdgesDeferringSystemGestures
+{
+    return UIRectEdgeBottom; 
 }
 
 - (void)didReceiveMemoryWarning {


### PR DESCRIPTION
Don’t hide the home indicator, instead „disable“ it. So the user has to double tap it to use it. It’s tinted to be nearly invisible over the content.