### PR TITLE
Correct handling of the explicitly passed delta time

### DIFF
--- a/cocos/base/CCDirector.cpp
+++ b/cocos/base/CCDirector.cpp
@@ -335,24 +335,30 @@ void Director::drawScene()
 
 void Director::calculateDeltaTime()
 {
+    auto now = std::chrono::steady_clock::now();
+
     // new delta time. Re-fixed issue #1277
     if (_nextDeltaTimeZero)
     {
         _deltaTime = 0;
         _nextDeltaTimeZero = false;
-        _lastUpdate = std::chrono::steady_clock::now();
     }
     else
     {
         // delta time may passed by invoke mainLoop(dt)
-        if (!_deltaTimePassedByCaller)
+        if (_deltaTimePassedByCaller)
         {
-            auto now = std::chrono::steady_clock::now();
-            _deltaTime = std::chrono::duration_cast<std::chrono::microseconds>(now - _lastUpdate).count() / 1000000.0f;
-            _lastUpdate = now;
+            _deltaTimePassedByCaller = false;
         }
+        else
+        {
+            _deltaTime = std::chrono::duration_cast<std::chrono::microseconds>(now - _lastUpdate).count() / 1000000.0f;
+        }
+
         _deltaTime = MAX(0, _deltaTime);
     }
+
+    _lastUpdate = now;
 
 #if COCOS2D_DEBUG
     // If we are debugging our code, prevent big delta time


### PR DESCRIPTION
As disscussed in [this pull request](https://github.com/cocos2d/cocos2d-x/pull/18898#issuecomment-400297229):
If we call `mainLopp(dt)` then `_deltaTimePassedByCaller` variable becomes `true`.
But it won't be reset to `false` any more. So we can't use `mainLopp(dt)` to pass some custom **dt** only once.
