### PR TITLE
 correct lua template cmake build

### DIFF
--- a/cocos/scripting/js-bindings/CMakeLists.txt
+++ b/cocos/scripting/js-bindings/CMakeLists.txt
@@ -165,14 +165,8 @@ target_include_directories(jscocos2d
         INTERFACE ${cocos_root}/cocos/scripting/js-bindings/manual
 )
 
-# ignore part warnings on binding codes. tocheck: not take effect?
-
 if(WINDOWS)
     target_compile_definitions(jscocos2d PRIVATE _USRJSSTATIC)
-else()
-    target_compile_options(jscocos2d PRIVATE 
-        -Wno-deprecated
-    )
 endif()
 
 set_target_properties(jscocos2d

--- a/templates/lua-template-default/CMakeLists.txt
+++ b/templates/lua-template-default/CMakeLists.txt
@@ -144,6 +144,11 @@ endif()
 target_link_libraries(${APP_NAME} luacocos2d)
 target_include_directories(${APP_NAME} PRIVATE ${RUNTIME_SRC_ROOT}/Classes)
 
+if(WINDOWS OR MACOSX)
+    add_subdirectory(${COCOS2DX_ROOT_PATH}/tools/simulator/libsimulator ${ENGINE_BINARY_PATH}/cocos/simulatorlib)
+    target_link_libraries(${APP_NAME} simulatorlib)
+endif()
+
 # mark app resources, resource will be copy auto after mark
 setup_cocos_app_config(${APP_NAME})
 if(APPLE)

--- a/templates/lua-template-default/CMakeLists.txt
+++ b/templates/lua-template-default/CMakeLists.txt
@@ -33,7 +33,6 @@ set(CMAKE_MODULE_PATH ${COCOS2DX_ROOT_PATH}/cmake/Modules/)
 
 include(CocosBuildSet)
 set(BUILD_LUA_LIBS ON)
-set(BUILD_SIMU_LIB ON)
 add_subdirectory(${COCOS2DX_ROOT_PATH}/cocos ${ENGINE_BINARY_PATH}/cocos/core)
 
 # script and source files info, not need to compile
@@ -72,7 +71,6 @@ if(ANDROID)
 elseif(LINUX)
     list(APPEND GAME_SOURCE ${RUNTIME_SRC_ROOT}/proj.linux/main.cpp)
 elseif(WINDOWS)
-    add_definitions(-D_USRLIBSIMSTATIC)
     list(APPEND GAME_HEADER
          ${RUNTIME_SRC_ROOT}/proj.win32/main.h
          ${RUNTIME_SRC_ROOT}/proj.win32/stdafx.h

--- a/tests/cpp-tests/CMakeLists.txt
+++ b/tests/cpp-tests/CMakeLists.txt
@@ -345,7 +345,7 @@ if(ANDROID OR IOS)
          )
 endif()
 
-if(WIN32 OR MACOSX OR LINUX)
+if(WINDOWS OR MACOSX OR LINUX)
     list(APPEND GAME_HEADER
          Classes/WindowTest/WindowTest.h
          Classes/BugsTest/Bug-14327.h

--- a/tools/simulator/libsimulator/CMakeLists.txt
+++ b/tools/simulator/libsimulator/CMakeLists.txt
@@ -24,16 +24,7 @@
 
 set(SIMULATOR_LIB_PATH ${COCOS2DX_ROOT_PATH}/tools/simulator/libsimulator/lib)
 
-if(MACOSX)
-    # add define for mac os GLFW_EXPOSE_NATIVE_NSGL
-    add_definitions(-DGLFW_EXPOSE_NATIVE_NSGL)
-elseif(WINDOWS)
-    add_definitions(-DUNICODE -D_UNICODE)
-    add_definitions(-D_USRLIBSIMSTATIC -DGLFW_EXPOSE_NATIVE_WIN32 -D_SILENCE_STDEXT_HASH_DEPRECATION_WARNINGS)
-    include_directories(${SIMULATOR_LIB_PATH}/../proj.win32)
-endif()
-
-if(WIN32)
+if(WINDOWS)
     set(PLATFORM_HEADER
         ${SIMULATOR_LIB_PATH}/../proj.win32/stdafx.h
         ${SIMULATOR_LIB_PATH}/../proj.win32/targetver.h
@@ -189,23 +180,25 @@ set(SIMULATOR_SOURCE
     ${PLATFORM_SOURCE}
     )
 
-include_directories(
-        ${SIMULATOR_LIB_PATH}
-        ${SIMULATOR_LIB_PATH}/platform/${PLATFORM_FOLDER}
-        ${SIMULATOR_LIB_PATH}/protobuf-lite
-        ${SIMULATOR_LIB_PATH}/runtime
-        ${COCOS2DX_ROOT_PATH}/cocos/editor-support
-)
 
 set(LIB_SOURCE ${SIMULATOR_SOURCE} ${SIMULATOR_HEADER})
 
-add_library(simulator STATIC
-            ${LIB_SOURCE}
-            )
+add_library(simulatorlib STATIC ${LIB_SOURCE})
+target_link_libraries(simulatorlib cocos2d)
 
-target_use_simulator_depend_libs(simulator)
+if(WINDOWS)
+    target_compile_options(simulatorlib PRIVATE _USRLIBSIMSTATIC)
+endif()
 
-set_target_properties(simulator
+target_include_directories(simulatorlib
+        PRIVATE ${SIMULATOR_LIB_PATH}
+        PRIVATE ${SIMULATOR_LIB_PATH}/platform/${PLATFORM_FOLDER}
+        PRIVATE ${SIMULATOR_LIB_PATH}/protobuf-lite
+        PRIVATE ${SIMULATOR_LIB_PATH}/runtime
+        PRIVATE ${COCOS2DX_ROOT_PATH}/cocos/editor-support
+)
+
+set_target_properties(simulatorlib
                       PROPERTIES
                       ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
                       LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
@@ -213,5 +206,5 @@ set_target_properties(simulator
                       )
 
 if(XCODE OR VS)
-    cocos_mark_code_files("simulator")
+    cocos_mark_code_files("simulatorlib")
 endif()

--- a/tools/simulator/libsimulator/CMakeLists.txt
+++ b/tools/simulator/libsimulator/CMakeLists.txt
@@ -187,7 +187,13 @@ add_library(simulatorlib STATIC ${LIB_SOURCE})
 target_link_libraries(simulatorlib cocos2d)
 
 if(WINDOWS)
-    target_compile_options(simulatorlib PRIVATE _USRLIBSIMSTATIC)
+    target_compile_definitions(simulatorlib
+        PUBLIC _USRLIBSIMSTATIC
+        PRIVATE _SILENCE_STDEXT_HASH_DEPRECATION_WARNINGS
+    )
+    target_include_directories(simulatorlib
+        PRIVATE ${SIMULATOR_LIB_PATH}/../proj.win32
+    )
 endif()
 
 target_include_directories(simulatorlib

--- a/tools/simulator/libsimulator/lib/platform/mac/PlayerFileDialogServiceMac.mm
+++ b/tools/simulator/libsimulator/lib/platform/mac/PlayerFileDialogServiceMac.mm
@@ -25,6 +25,14 @@
 #import <AppKit/AppKit.h>
 #include "PlayerFileDialogServiceMac.h"
 
+#ifndef GLFW_EXPOSE_NATIVE_NSGL
+#define GLFW_EXPOSE_NATIVE_NSGL
+#endif
+#ifndef GLFW_EXPOSE_NATIVE_COCOA
+#define GLFW_EXPOSE_NATIVE_COCOA
+#endif
+// (CC_TARGET_PLATFORM == CC_PLATFORM_MAC)
+
 #include "glfw3.h"
 #include "glfw3native.h"
 

--- a/tools/simulator/libsimulator/lib/platform/win32/SimulatorWin.cpp
+++ b/tools/simulator/libsimulator/lib/platform/win32/SimulatorWin.cpp
@@ -43,6 +43,14 @@
 
 #include "SimulatorWin.h"
 
+#ifndef GLFW_EXPOSE_NATIVE_WIN32
+#define GLFW_EXPOSE_NATIVE_WIN32
+#endif
+#ifndef GLFW_EXPOSE_NATIVE_WGL
+#define GLFW_EXPOSE_NATIVE_WGL
+#endif
+/* (CC_TARGET_PLATFORM == CC_PLATFORM_WIN32) */
+
 #include "glfw3.h"
 #include "glfw3native.h"
 


### PR DESCRIPTION
 __Lua template__ is so special, it depend on simulator library. so that user can switch windows size by View menu

- add `cmake .. -GXcode` to build, this project works well
- build by generated `makefile` don't works, for `*.xib` issues

<img width="852" alt="lua-template" src="https://user-images.githubusercontent.com/26329291/48126522-4db16300-e2bc-11e8-8b33-d5368a4be785.png">
