### PR TITLE
prevent in-source-build at cmake project(Cocos2d-x)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,10 @@ project(Cocos2d-x)
 set(COCOS2DX_ROOT_PATH ${CMAKE_CURRENT_SOURCE_DIR})
 set(CMAKE_MODULE_PATH ${COCOS2DX_ROOT_PATH}/cmake/Modules/)
 
+# prevent in-source-build
+include(PreventInSourceBuilds)
+AssureOutOfSourceBuilds()
+
 # works before build libcocos2d
 include(CocosBuildSet)
 

--- a/cmake/Modules/PreventInSourceBuilds.cmake
+++ b/cmake/Modules/PreventInSourceBuilds.cmake
@@ -1,0 +1,47 @@
+# Adapated from ITKv4/CMake/PreventInSourceBuilds.cmake
+#
+# This function will prevent in-source builds
+function(AssureOutOfSourceBuilds)
+  # make sure the user doesn't play dirty with symlinks
+  get_filename_component(srcdir "${CMAKE_SOURCE_DIR}" REALPATH)
+  get_filename_component(bindir "${CMAKE_BINARY_DIR}" REALPATH)
+
+  # disallow in-source builds
+  if("${srcdir}" STREQUAL "${bindir}")
+    message("######################################################")
+    message("# Cocos2d-x should not be configured & built in the Cocos2d-x source directory")
+    message("# You must run cmake in a build directory.")
+    message("# For example:")
+    message("# mkdir Cocos ; cd Cocos")
+    message("# download & unpack the Cocos2d-x tarball")
+    message("# mkdir Cocos2d-x-Build")
+    message("# this will create the following directory structure")
+    message("#")
+    message("# Cocos")
+    message("#  +--Cocos2d-x")
+    message("#  +--Cocos2d-x-Build")
+    message("#")
+    message("# Then you can proceed to configure and build")
+    message("# by using the following commands")
+    message("#")
+    message("# cd Cocos2d-x-Build")
+    message("# cmake ../Cocos2d-x # or ccmake, or cmake-gui ")
+    message("# make")
+    message("#")
+    message("# NOTE: Given that you already tried to make an in-source build")
+    message("#       CMake have already created several files & directories")
+    message("#       in your source tree. run 'git status' to find them and")
+    message("#       remove them by doing:")
+    message("#")
+    message("#       cd Cocos/Cocos2d-x")
+    message("#       git clean -n -d")
+    message("#       git clean -f -d")
+    message("#       git checkout --")
+    message("#")
+    message("######################################################")
+    message(FATAL_ERROR "Quitting configuration")
+  endif()
+endfunction()
+
+AssureOutOfSourceBuilds()
+


### PR DESCRIPTION
when you do a in-source-build at `<cocos2d-x-root-path>`, you will get friendly comments:

```bash
######################################################
# Cocos2d-x should not be configured & built in the Cocos2d-x source directory
# You must run cmake in a build directory.
# For example:
# mkdir Cocos ; cd Cocos
# download & unpack the Cocos2d-x tarball
# mkdir Cocos2d-x-Build
# this will create the following directory structure
#
# Cocos
#  +--Cocos2d-x
#  +--Cocos2d-x-Build
#
# Then you can proceed to configure and build
# by using the following commands
#
# cd Cocos2d-x-Build
# cmake ../Cocos2d-x # or ccmake, or cmake-gui

....
```