### PR TITLE
[linux] Fix FileUtils::getContents with folder

### DIFF
--- a/cocos/platform/CCFileUtils.cpp
+++ b/cocos/platform/CCFileUtils.cpp
@@ -669,7 +669,7 @@ FileUtils::Status FileUtils::getContents(const std::string& filename, ResizableB
     if (fullPath.empty())
         return Status::NotExists;
 
-    std::string suitableFullPath = fs->getSuitableFOpen(fullPath).c_str();
+    std::string suitableFullPath = fs->getSuitableFOpen(fullPath);
 
     struct stat statBuf;
     if (stat(suitableFullPath.c_str(), &statBuf) == -1) {

--- a/cocos/platform/CCFileUtils.cpp
+++ b/cocos/platform/CCFileUtils.cpp
@@ -676,7 +676,7 @@ FileUtils::Status FileUtils::getContents(const std::string& filename, ResizableB
         return Status::ReadFailed;
     }
 
-    if (!(statBuf.st_dev & S_IFREG)) { 
+    if (!(statBuf.st_mode & S_IFREG)) { 
         return Status::NotRegularFileType;
     }
 

--- a/cocos/platform/CCFileUtils.h
+++ b/cocos/platform/CCFileUtils.h
@@ -203,7 +203,8 @@ public:
         ReadFailed = 3, // Read failed
         NotInitialized = 4, // FileUtils is not initializes
         TooLarge = 5, // The file is too large (great than 2^32-1)
-        ObtainSizeFailed = 6 // Failed to obtain the file size.
+        ObtainSizeFailed = 6, // Failed to obtain the file size.
+        NotRegularFileType = 7 // File type is not S_IFREG
     };
 
     /**


### PR DESCRIPTION
ref https://github.com/cocos2d/cocos2d-x/issues/18834

`getContents` return an error code when the path is a directory.