### PR TITLE
go on, Copy resources to "Resources/" on win32

### DIFF
--- a/cocos/2d/libcocos2d.vcxproj
+++ b/cocos/2d/libcocos2d.vcxproj
@@ -15,6 +15,7 @@
     <ProjectGuid>{98A51BA8-FC3A-415B-AC8F-8C7BD464E93E}</ProjectGuid>
     <RootNamespace>cocos2d-x.win32</RootNamespace>
     <Keyword>Win32Proj</Keyword>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">

--- a/cocos/2d/libcocos2d_win10/libcocos2d.vcxproj
+++ b/cocos/2d/libcocos2d_win10/libcocos2d.vcxproj
@@ -1505,9 +1505,6 @@
     <None Include="..\cocos2d.def" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\..\external\Box2D\proj-win10\libbox2d.vcxproj">
-      <Project>{0c32d479-46d5-46c3-9aa9-0a8ff8320516}</Project>
-    </ProjectReference>
     <ProjectReference Include="..\..\..\external\recast\proj.win10\librecast.vcxproj">
       <Project>{f551524d-8a70-4b2f-a7c2-28ae61150022}</Project>
     </ProjectReference>

--- a/cocos/editor-support/spine/proj.win32/libSpine.vcxproj
+++ b/cocos/editor-support/spine/proj.win32/libSpine.vcxproj
@@ -112,6 +112,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{B7C2A162-DEC9-4418-972E-240AB3CBFCAE}</ProjectGuid>
     <RootNamespace>libSpine</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/cocos/scripting/js-bindings/proj.win32/libjscocos2d.vcxproj
+++ b/cocos/scripting/js-bindings/proj.win32/libjscocos2d.vcxproj
@@ -124,6 +124,7 @@
     <ProjectGuid>{39379840-825A-45A0-B363-C09FFEF864BD}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>libjscocos2d</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/cocos/scripting/lua-bindings/proj.win32/libluacocos2d.vcxproj
+++ b/cocos/scripting/lua-bindings/proj.win32/libluacocos2d.vcxproj
@@ -234,6 +234,7 @@
     <ProjectGuid>{9F2D6CE6-C893-4400-B50C-6DB70CC2562F}</ProjectGuid>
     <RootNamespace>libluacocos2d</RootNamespace>
     <Keyword>Win32Proj</Keyword>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">

--- a/external/config.json
+++ b/external/config.json
@@ -1,5 +1,5 @@
 {
-    "version": "v3-deps-146",
+    "version": "v3-deps-147",
     "zip_file_size": "146254799",
     "repo_name": "cocos2d-x-3rd-party-libs-bin",
     "repo_parent": "https://github.com/cocos2d/",

--- a/external/config.json
+++ b/external/config.json
@@ -1,5 +1,5 @@
 {
-    "version": "v3-deps-147",
+    "version": "v3-deps-148",
     "zip_file_size": "146254799",
     "repo_name": "cocos2d-x-3rd-party-libs-bin",
     "repo_parent": "https://github.com/cocos2d/",

--- a/templates/cpp-template-default/proj.win32/HelloCpp.vcxproj
+++ b/templates/cpp-template-default/proj.win32/HelloCpp.vcxproj
@@ -164,9 +164,6 @@ xcopy "$(ProjectDir)..\Resources" "$(OutDir)\Resources\" /D /E /I /F /Y
     <ProjectReference Include="..\cocos2d\cocos\editor-support\spine\proj.win32\libSpine.vcxproj">
       <Project>{b7c2a162-dec9-4418-972e-240ab3cbfcae}</Project>
     </ProjectReference>
-    <ProjectReference Include="..\cocos2d\external\Box2D\proj.win32\libbox2d.vcxproj">
-      <Project>{929480e7-23c0-4df6-8456-096d71547116}</Project>
-    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="game.rc" />

--- a/templates/js-template-default/frameworks/runtime-src/proj.win32/HelloJavascript.sln
+++ b/templates/js-template-default/frameworks/runtime-src/proj.win32/HelloJavascript.sln
@@ -13,8 +13,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "External", "External", "{8C
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "libSpine", "..\..\cocos2d-x\cocos\editor-support\spine\proj.win32\libSpine.vcxproj", "{B7C2A162-DEC9-4418-972E-240AB3CBFCAE}"
 EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "libbox2d", "..\..\cocos2d-x\external\Box2D\proj.win32\libbox2d.vcxproj", "{929480E7-23C0-4DF6-8456-096D71547116}"
-EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "libcocos2d", "..\..\cocos2d-x\cocos\2d\libcocos2d.vcxproj", "{98A51BA8-FC3A-415B-AC8F-8C7BD464E93E}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "libjscocos2d", "..\..\cocos2d-x\cocos\scripting\js-bindings\proj.win32\libjscocos2d.vcxproj", "{39379840-825A-45A0-B363-C09FFEF864BD}"

--- a/templates/js-template-default/frameworks/runtime-src/proj.win32/HelloJavascript.vcxproj
+++ b/templates/js-template-default/frameworks/runtime-src/proj.win32/HelloJavascript.vcxproj
@@ -121,11 +121,11 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup>
     <CustomBuildStep>
-      <Command>xcopy "$(ProjectDir)..\..\cocos2d-x\cocos\scripting\js-bindings\script" "$(OutDir)\script" /D /E /I /F /Y
-xcopy "$(ProjectDir)..\..\..\src" "$(OutDir)\src" /D /E /I /F /Y
-xcopy "$(ProjectDir)..\..\..\res" "$(OutDir)\res" /D /E /I /F /Y
-copy "$(ProjectDir)..\..\..\main.js" "$(OutDir)\" /Y
-copy "$(ProjectDir)..\..\..\project.json" "$(OutDir)\" /Y</Command>
+      <Command>xcopy "$(ProjectDir)..\..\cocos2d-x\cocos\scripting\js-bindings\script" "$(OutDir)\Resources\script\" /D /E /I /F /Y
+xcopy "$(ProjectDir)..\..\..\src" "$(OutDir)\Resources\src\" /D /E /I /F /Y
+xcopy "$(ProjectDir)..\..\..\res" "$(OutDir)\Resources\res\" /D /E /I /F /Y
+copy "$(ProjectDir)..\..\..\main.js" "$(OutDir)\Resources\" /Y
+copy "$(ProjectDir)..\..\..\project.json" "$(OutDir)\Resources\" /Y</Command>
       <Outputs>$(TargetName).cab</Outputs>
       <Inputs>$(TargetFileName)</Inputs>
     </CustomBuildStep>

--- a/templates/lua-template-default/frameworks/runtime-src/proj.win32/HelloLua.sln
+++ b/templates/lua-template-default/frameworks/runtime-src/proj.win32/HelloLua.sln
@@ -12,8 +12,6 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "libcocos2d", "..\..\cocos2d
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "libluacocos2d", "..\..\cocos2d-x\cocos\scripting\lua-bindings\proj.win32\libluacocos2d.vcxproj", "{9F2D6CE6-C893-4400-B50C-6DB70CC2562F}"
 EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "libbox2d", "..\..\cocos2d-x\external\Box2D\proj.win32\libbox2d.vcxproj", "{929480E7-23C0-4DF6-8456-096D71547116}"
-EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "libSpine", "..\..\cocos2d-x\cocos\editor-support\spine\proj.win32\libSpine.vcxproj", "{B7C2A162-DEC9-4418-972E-240AB3CBFCAE}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "libsimulator", "..\..\cocos2d-x\tools\simulator\libsimulator\proj.win32\libsimulator.vcxproj", "{001B324A-BB91-4E83-875C-C92F75C40857}"

--- a/templates/lua-template-default/frameworks/runtime-src/proj.win32/HelloLua.vcxproj
+++ b/templates/lua-template-default/frameworks/runtime-src/proj.win32/HelloLua.vcxproj
@@ -130,8 +130,8 @@
     <CustomBuildStep>
       <Command>if not exist "$(LocalDebuggerWorkingDirectory)" mkdir "$(LocalDebuggerWorkingDirectory)"
 xcopy /Y /Q "$(OutDir)*.dll" "$(LocalDebuggerWorkingDirectory)"
-xcopy "$(ProjectDir)..\..\..\res" "$(LocalDebuggerWorkingDirectory)\res" /D /E /I /F /Y
-xcopy "$(ProjectDir)..\..\..\src" "$(LocalDebuggerWorkingDirectory)\src" /D /E /I /F /Y</Command>
+xcopy "$(ProjectDir)..\..\..\res" "$(LocalDebuggerWorkingDirectory)\Resources\res\" /D /E /I /F /Y
+xcopy "$(ProjectDir)..\..\..\src" "$(LocalDebuggerWorkingDirectory)\Resources\src\" /D /E /I /F /Y</Command>
       <Outputs>$(TargetName).cab</Outputs>
       <Inputs>$(TargetFileName)</Inputs>
     </CustomBuildStep>

--- a/tests/cpp-empty-test/proj.win10/cpp-empty-test.vcxproj
+++ b/tests/cpp-empty-test/proj.win10/cpp-empty-test.vcxproj
@@ -356,9 +356,6 @@ xcopy "$(EngineRoot)cocos\platform\win8.1-universal\pch.h" "$(EngineRoot)templat
     <ProjectReference Include="..\..\..\cocos\editor-support\spine\proj.win10\libSpine.vcxproj">
       <Project>{4b3ba10a-941f-4e08-8a50-8a7fcb822bb8}</Project>
     </ProjectReference>
-    <ProjectReference Include="..\..\..\external\Box2D\proj-win10\libbox2d.vcxproj">
-      <Project>{0c32d479-46d5-46c3-9aa9-0a8ff8320516}</Project>
-    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <Page Include="..\..\..\cocos\platform\win8.1-universal\OpenGLESPage.xaml" />

--- a/tests/cpp-empty-test/proj.win32/cpp-empty-test.vcxproj
+++ b/tests/cpp-empty-test/proj.win32/cpp-empty-test.vcxproj
@@ -14,6 +14,7 @@
     <ProjectGuid>{B8BF9E81-35FD-4582-BA1C-B85FA365BABB}</ProjectGuid>
     <RootNamespace>cpp-empty-test-win32</RootNamespace>
     <Keyword>Win32Proj</Keyword>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">

--- a/tests/cpp-tests/CMakeLists.txt
+++ b/tests/cpp-tests/CMakeLists.txt
@@ -475,6 +475,8 @@ if(APPLE)
         set_xcode_property(${APP_NAME} ASSETCATALOG_COMPILER_APPICON_NAME "AppIcon-${APP_NAME}")
     endif()
 elseif(WINDOWS)
+    # "too large PDB" error often occurs in cpp-tests when using default "/Zi"
+    target_compile_options(${APP_NAME} PRIVATE /Z7)
     cocos_copy_target_dll(${APP_NAME} COPY_TO ${APP_RES_DIR}/..)
 endif()
 

--- a/tests/cpp-tests/proj.win10/cpp-tests.vcxproj
+++ b/tests/cpp-tests/proj.win10/cpp-tests.vcxproj
@@ -594,9 +594,6 @@
     <ProjectReference Include="..\..\..\cocos\editor-support\spine\proj.win10\libSpine.vcxproj">
       <Project>{4b3ba10a-941f-4e08-8a50-8a7fcb822bb8}</Project>
     </ProjectReference>
-    <ProjectReference Include="..\..\..\external\Box2D\proj-win10\libbox2d.vcxproj">
-      <Project>{0c32d479-46d5-46c3-9aa9-0a8ff8320516}</Project>
-    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <Page Include="..\..\..\cocos\platform\win8.1-universal\OpenGLESPage.xaml" />

--- a/tests/cpp-tests/proj.win32/cpp-tests.vcxproj
+++ b/tests/cpp-tests/proj.win32/cpp-tests.vcxproj
@@ -14,6 +14,7 @@
     <ProjectGuid>{76A39BB2-9B84-4C65-98A5-654D86B86F2A}</ProjectGuid>
     <RootNamespace>test_win32</RootNamespace>
     <Keyword>Win32Proj</Keyword>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">

--- a/tests/game-controller-test/proj.win32/game-controller-test.vcxproj
+++ b/tests/game-controller-test/proj.win32/game-controller-test.vcxproj
@@ -14,6 +14,7 @@
     <ProjectGuid>{1FA2BD06-2F52-48F6-8468-C0CC33127F5E}</ProjectGuid>
     <RootNamespace>test_win32</RootNamespace>
     <Keyword>Win32Proj</Keyword>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">

--- a/tests/js-tests/project/proj.win32/js-tests.vcxproj
+++ b/tests/js-tests/project/proj.win32/js-tests.vcxproj
@@ -13,6 +13,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{D0F06A44-A245-4D13-A498-0120C203B539}</ProjectGuid>
     <RootNamespace>js-tests</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">

--- a/tests/js-tests/project/proj.win32/js-tests.vcxproj
+++ b/tests/js-tests/project/proj.win32/js-tests.vcxproj
@@ -118,16 +118,16 @@ xcopy /Y /Q "$(ProjectDir)..\..\..\..\external\websockets\prebuilt\win32\*.*" "$
     <PreBuildEvent>
       <Command>if not exist "$(OutDir)" mkdir "$(OutDir)"
 
-mkdir "$(OutDir)\script"
-mkdir "$(OutDir)\src"
-mkdir "$(OutDir)\res"
+mkdir "$(OutDir)\Resources\script"
+mkdir "$(OutDir)\Resources\src"
+mkdir "$(OutDir)\Resources\res"
 xcopy "$(OutDir)..\*.dll" "$(OutDir)" /D /Y
-xcopy "$(ProjectDir)..\..\..\..\cocos\scripting\js-bindings\script\*" "$(OutDir)\script" /e /Y
-xcopy "$(ProjectDir)..\..\src" "$(OutDir)\src\" /e /Y
-xcopy "$(ProjectDir)..\..\..\cpp-tests\Resources" "$(OutDir)\res\" /e /Y
-copy "$(ProjectDir)..\..\main.js" "$(OutDir)"
-copy "$(ProjectDir)..\..\project.json" "$(OutDir)"
-xcopy "$(ProjectDir)..\..\resjs" "$(OutDir)\res\resjs\" /e /Y</Command>
+xcopy "$(ProjectDir)..\..\..\..\cocos\scripting\js-bindings\script\*" "$(OutDir)\Resources\script\" /e /Y
+xcopy "$(ProjectDir)..\..\src" "$(OutDir)\Resources\src\" /e /Y
+xcopy "$(ProjectDir)..\..\..\cpp-tests\Resources" "$(OutDir)\Resources\res\" /e /Y
+copy "$(ProjectDir)..\..\main.js" "$(OutDir)\Resources\"
+copy "$(ProjectDir)..\..\project.json" "$(OutDir)\Resources\"
+xcopy "$(ProjectDir)..\..\resjs" "$(OutDir)\Resources\res\resjs\" /e /Y</Command>
     </PreBuildEvent>
     <PreBuildEvent>
       <Message>Copy js and resource files.</Message>
@@ -180,16 +180,16 @@ xcopy /Y /Q "$(ProjectDir)..\..\..\..\external\websockets\prebuilt\win32\*.*" "$
     <PreBuildEvent>
       <Command>if not exist "$(OutDir)" mkdir "$(OutDir)"
 
-mkdir "$(OutDir)\script"
-mkdir "$(OutDir)\src"
-mkdir "$(OutDir)\res"
+mkdir "$(OutDir)\Resources\script"
+mkdir "$(OutDir)\Resources\src"
+mkdir "$(OutDir)\Resources\res"
 xcopy "$(OutDir)..\*.dll" "$(OutDir)" /D /Y
-xcopy "$(ProjectDir)..\..\..\..\cocos\scripting\js-bindings\script\*" "$(OutDir)\script" /e /Y
-xcopy "$(ProjectDir)..\..\src" "$(OutDir)\src\" /e /Y
-xcopy "$(ProjectDir)..\..\..\cpp-tests\Resources" "$(OutDir)\res\" /e /Y
-copy "$(ProjectDir)..\..\main.js" "$(OutDir)"
-copy "$(ProjectDir)..\..\project.json" "$(OutDir)"
-xcopy "$(ProjectDir)..\..\resjs" "$(OutDir)\res\" /e /Y</Command>
+xcopy "$(ProjectDir)..\..\..\..\cocos\scripting\js-bindings\script\*" "$(OutDir)\Resources\script" /e /Y
+xcopy "$(ProjectDir)..\..\src" "$(OutDir)\Resources\src\" /e /Y
+xcopy "$(ProjectDir)..\..\..\cpp-tests\Resources" "$(OutDir)\Resources\res\" /e /Y
+copy "$(ProjectDir)..\..\main.js" "$(OutDir)\Resources\"
+copy "$(ProjectDir)..\..\project.json" "$(OutDir)\Resources\"
+xcopy "$(ProjectDir)..\..\resjs" "$(OutDir)\Resources\res\" /e /Y</Command>
       <Message>Copy js and resource files.</Message>
     </PreBuildEvent>
   </ItemDefinitionGroup>

--- a/tests/js-tests/project/proj.win32/js-tests.vcxproj
+++ b/tests/js-tests/project/proj.win32/js-tests.vcxproj
@@ -103,11 +103,6 @@
       <Culture>0x0409</Culture>
       <AdditionalIncludeDirectories>$(MSBuildProgramFiles32)\Microsoft SDKs\Windows\v7.1A\include;$(IntDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ResourceCompile>
-    <PreLinkEvent>
-      <Command>if not exist "$(OutDir)" mkdir "$(OutDir)"
-xcopy /Y /Q "$(ProjectDir)..\..\..\..\external\spidermonkey\prebuilt\win32\*.*" "$(OutDir)"
-xcopy /Y /Q "$(ProjectDir)..\..\..\..\external\websockets\prebuilt\win32\*.*" "$(OutDir)"</Command>
-    </PreLinkEvent>
     <Link>
       <AdditionalDependencies>mozjs-33.lib;ws2_32.lib;sqlite3.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>$(OutDir);$(SolutionDir)$(Configuration).win32;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
@@ -115,7 +110,7 @@ xcopy /Y /Q "$(ProjectDir)..\..\..\..\external\websockets\prebuilt\win32\*.*" "$
       <SubSystem>Windows</SubSystem>
       <TargetMachine>MachineX86</TargetMachine>
     </Link>
-    <PreBuildEvent>
+    <PostBuildEvent>
       <Command>if not exist "$(OutDir)" mkdir "$(OutDir)"
 
 mkdir "$(OutDir)\Resources\script"
@@ -128,10 +123,10 @@ xcopy "$(ProjectDir)..\..\..\cpp-tests\Resources" "$(OutDir)\Resources\res\" /e 
 copy "$(ProjectDir)..\..\main.js" "$(OutDir)\Resources\"
 copy "$(ProjectDir)..\..\project.json" "$(OutDir)\Resources\"
 xcopy "$(ProjectDir)..\..\resjs" "$(OutDir)\Resources\res\resjs\" /e /Y</Command>
-    </PreBuildEvent>
-    <PreBuildEvent>
+    </PostBuildEvent>
+    <PostBuildEvent>
       <Message>Copy js and resource files.</Message>
-    </PreBuildEvent>
+    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <Midl>
@@ -165,11 +160,6 @@ xcopy "$(ProjectDir)..\..\resjs" "$(OutDir)\Resources\res\resjs\" /e /Y</Command
       <Culture>0x0409</Culture>
       <AdditionalIncludeDirectories>$(MSBuildProgramFiles32)\Microsoft SDKs\Windows\v7.1A\include;$(IntDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ResourceCompile>
-    <PreLinkEvent>
-      <Command>if not exist "$(OutDir)" mkdir "$(OutDir)"
-xcopy /Y /Q "$(ProjectDir)..\..\..\..\external\spidermonkey\prebuilt\win32\*.*" "$(OutDir)"
-xcopy /Y /Q "$(ProjectDir)..\..\..\..\external\websockets\prebuilt\win32\*.*" "$(OutDir)"</Command>
-    </PreLinkEvent>
     <Link>
       <AdditionalDependencies>mozjs-33.lib;ws2_32.lib;sqlite3.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>$(OutDir);$(SolutionDir)$(Configuration).win32;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
@@ -177,7 +167,7 @@ xcopy /Y /Q "$(ProjectDir)..\..\..\..\external\websockets\prebuilt\win32\*.*" "$
       <TargetMachine>MachineX86</TargetMachine>
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
-    <PreBuildEvent>
+    <PostBuildEvent>
       <Command>if not exist "$(OutDir)" mkdir "$(OutDir)"
 
 mkdir "$(OutDir)\Resources\script"
@@ -191,7 +181,10 @@ copy "$(ProjectDir)..\..\main.js" "$(OutDir)\Resources\"
 copy "$(ProjectDir)..\..\project.json" "$(OutDir)\Resources\"
 xcopy "$(ProjectDir)..\..\resjs" "$(OutDir)\Resources\res\" /e /Y</Command>
       <Message>Copy js and resource files.</Message>
-    </PreBuildEvent>
+    </PostBuildEvent>
+    <PostBuildEvent>
+      <Message>Copy js and resource files.</Message>
+    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="..\Classes\js_DrawNode3D_bindings.cpp" />

--- a/tests/lua-empty-test/project/proj.win32/lua-empty-test.vcxproj
+++ b/tests/lua-empty-test/project/proj.win32/lua-empty-test.vcxproj
@@ -111,12 +111,12 @@
       <TargetMachine>MachineX86</TargetMachine>
       <IgnoreSpecificDefaultLibraries>libcmt.lib;%(IgnoreSpecificDefaultLibraries)</IgnoreSpecificDefaultLibraries>
     </Link>
-    <PreBuildEvent>
+    <PostBuildEvent>
       <Command>xcopy "$(ProjectDir)..\..\res" "$(OutDir)Resources\res\" /D /E /I /F /Y
 xcopy "$(ProjectDir)..\..\src" "$(OutDir)Resources\src\" /D /E /I /F /Y
 xcopy "$(ProjectDir)..\..\..\..\cocos\scripting\lua-bindings\script" "$(OutDir)Resources\src\cocos\" /D /E /I /F /Y
 xcopy "$(OutDir)..\*.dll" "$(OutDir)" /D /Y</Command>
-    </PreBuildEvent>
+    </PostBuildEvent>
     <PreLinkEvent>
       <Command>
       </Command>
@@ -166,12 +166,12 @@ xcopy "$(OutDir)..\*.dll" "$(OutDir)" /D /Y</Command>
       <Command>
       </Command>
     </PreLinkEvent>
-    <PreBuildEvent>
+    <PostBuildEvent>
       <Command>xcopy "$(ProjectDir)..\..\res" "$(OutDir)Resources\res\" /D /E /I /F /Y
 xcopy "$(ProjectDir)..\..\src" "$(OutDir)Resources\src\" /D /E /I /F /Y
 xcopy "$(ProjectDir)..\..\..\..\cocos\scripting\lua-bindings\script" "$(OutDir)Resources\src\cocos" /D /E /I /F /Y
 xcopy "$(OutDir)..\*.dll" "$(OutDir)" /D /Y</Command>
-    </PreBuildEvent>
+    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="..\Classes\AppDelegate.cpp" />

--- a/tests/lua-empty-test/project/proj.win32/lua-empty-test.vcxproj
+++ b/tests/lua-empty-test/project/proj.win32/lua-empty-test.vcxproj
@@ -13,6 +13,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{13E55395-94A2-4CD9-BFC2-1A051F80C17D}</ProjectGuid>
     <RootNamespace>lua-empty-test.win32</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">

--- a/tests/lua-empty-test/project/proj.win32/lua-empty-test.vcxproj
+++ b/tests/lua-empty-test/project/proj.win32/lua-empty-test.vcxproj
@@ -112,9 +112,9 @@
       <IgnoreSpecificDefaultLibraries>libcmt.lib;%(IgnoreSpecificDefaultLibraries)</IgnoreSpecificDefaultLibraries>
     </Link>
     <PreBuildEvent>
-      <Command>xcopy "$(ProjectDir)..\..\res" "$(OutDir)res" /D /E /I /F /Y
-xcopy "$(ProjectDir)..\..\src" "$(OutDir)src" /D /E /I /F /Y
-xcopy "$(ProjectDir)..\..\..\..\cocos\scripting\lua-bindings\script" "$(OutDir)src\cocos" /D /E /I /F /Y
+      <Command>xcopy "$(ProjectDir)..\..\res" "$(OutDir)Resources\res\" /D /E /I /F /Y
+xcopy "$(ProjectDir)..\..\src" "$(OutDir)Resources\src\" /D /E /I /F /Y
+xcopy "$(ProjectDir)..\..\..\..\cocos\scripting\lua-bindings\script" "$(OutDir)Resources\src\cocos\" /D /E /I /F /Y
 xcopy "$(OutDir)..\*.dll" "$(OutDir)" /D /Y</Command>
     </PreBuildEvent>
     <PreLinkEvent>
@@ -167,9 +167,9 @@ xcopy "$(OutDir)..\*.dll" "$(OutDir)" /D /Y</Command>
       </Command>
     </PreLinkEvent>
     <PreBuildEvent>
-      <Command>xcopy "$(ProjectDir)..\..\res" "$(OutDir)res" /D /E /I /F /Y
-xcopy "$(ProjectDir)..\..\src" "$(OutDir)src" /D /E /I /F /Y
-xcopy "$(ProjectDir)..\..\..\..\cocos\scripting\lua-bindings\script" "$(OutDir)src\cocos" /D /E /I /F /Y
+      <Command>xcopy "$(ProjectDir)..\..\res" "$(OutDir)Resources\res\" /D /E /I /F /Y
+xcopy "$(ProjectDir)..\..\src" "$(OutDir)Resources\src\" /D /E /I /F /Y
+xcopy "$(ProjectDir)..\..\..\..\cocos\scripting\lua-bindings\script" "$(OutDir)Resources\src\cocos" /D /E /I /F /Y
 xcopy "$(OutDir)..\*.dll" "$(OutDir)" /D /Y</Command>
     </PreBuildEvent>
   </ItemDefinitionGroup>

--- a/tests/lua-tests/project/proj.win32/lua-tests.win32.vcxproj
+++ b/tests/lua-tests/project/proj.win32/lua-tests.win32.vcxproj
@@ -13,6 +13,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{4E6A7A0E-DDD8-4BAA-8B22-C964069364ED}</ProjectGuid>
     <ProjectName>lua-tests</ProjectName>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/tests/lua-tests/project/proj.win32/lua-tests.win32.vcxproj
+++ b/tests/lua-tests/project/proj.win32/lua-tests.win32.vcxproj
@@ -112,11 +112,11 @@
       </DllDataFileName>
     </Midl>
     <PreBuildEvent>
-      <Command>xcopy "$(ProjectDir)..\..\res" "$(OutDir)res" /D /E /I /F /Y
-xcopy "$(ProjectDir)..\..\src" "$(OutDir)src" /D /E /I /F /Y
-xcopy "$(ProjectDir)..\..\..\..\tests\cpp-tests\Resources" "$(OutDir)res" /D /E /I /F /Y
-xcopy "$(ProjectDir)..\..\..\..\cocos\scripting\lua-bindings\script" "$(OutDir)src\cocos" /D /E /I /F /Y
-xcopy "$(ProjectDir)..\..\..\..\external\lua\luasocket\script" "$(OutDir)script" /D /E /I /F /Y
+      <Command>xcopy "$(ProjectDir)..\..\res" "$(OutDir)Resources\res\" /D /E /I /F /Y
+xcopy "$(ProjectDir)..\..\src" "$(OutDir)Resources\src\" /D /E /I /F /Y
+xcopy "$(ProjectDir)..\..\..\..\tests\cpp-tests\Resources" "$(OutDir)Resources\res\" /D /E /I /F /Y
+xcopy "$(ProjectDir)..\..\..\..\cocos\scripting\lua-bindings\script" "$(OutDir)Resources\src\cocos\" /D /E /I /F /Y
+xcopy "$(ProjectDir)..\..\..\..\external\lua\luasocket\script" "$(OutDir)Resources\script\" /D /E /I /F /Y
 xcopy "$(OutDir)..\*.dll" "$(OutDir)" /D /Y</Command>
       <Message>copy files</Message>
     </PreBuildEvent>
@@ -174,11 +174,11 @@ xcopy "$(OutDir)..\*.dll" "$(OutDir)" /D /Y</Command>
       </Command>
     </PreLinkEvent>
     <CustomBuildStep>
-      <Command>xcopy "$(ProjectDir)..\..\res" "$(OutDir)res" /D /E /I /F /Y
-xcopy "$(ProjectDir)..\..\src" "$(OutDir)src" /D /E /I /F /Y
-xcopy "$(ProjectDir)..\..\..\..\tests\cpp-tests\Resources" "$(OutDir)res" /D /E /I /F /Y
-xcopy "$(ProjectDir)..\..\..\..\cocos\scripting\lua-bindings\script" "$(OutDir)src\cocos" /D /E /I /F /Y
-xcopy "$(ProjectDir)..\..\..\..\external\lua\luasocket\script" "$(OutDir)script" /D /E /I /F /Y
+      <Command>xcopy "$(ProjectDir)..\..\res" "$(OutDir)Resources\res\" /D /E /I /F /Y
+xcopy "$(ProjectDir)..\..\src" "$(OutDir)Resources\src\" /D /E /I /F /Y
+xcopy "$(ProjectDir)..\..\..\..\tests\cpp-tests\Resources" "$(OutDir)Resources\res\" /D /E /I /F /Y
+xcopy "$(ProjectDir)..\..\..\..\cocos\scripting\lua-bindings\script" "$(OutDir)Resources\src\cocos\" /D /E /I /F /Y
+xcopy "$(ProjectDir)..\..\..\..\external\lua\luasocket\script" "$(OutDir)Resources\script\" /D /E /I /F /Y
 xcopy "$(OutDir)..\*.dll" "$(OutDir)" /D /Y</Command>
     </CustomBuildStep>
     <CustomBuildStep>

--- a/tests/lua-tests/project/proj.win32/lua-tests.win32.vcxproj
+++ b/tests/lua-tests/project/proj.win32/lua-tests.win32.vcxproj
@@ -111,7 +111,7 @@
       <DllDataFileName>
       </DllDataFileName>
     </Midl>
-    <PreBuildEvent>
+    <PostBuildEvent>
       <Command>xcopy "$(ProjectDir)..\..\res" "$(OutDir)Resources\res\" /D /E /I /F /Y
 xcopy "$(ProjectDir)..\..\src" "$(OutDir)Resources\src\" /D /E /I /F /Y
 xcopy "$(ProjectDir)..\..\..\..\tests\cpp-tests\Resources" "$(OutDir)Resources\res\" /D /E /I /F /Y
@@ -119,7 +119,7 @@ xcopy "$(ProjectDir)..\..\..\..\cocos\scripting\lua-bindings\script" "$(OutDir)R
 xcopy "$(ProjectDir)..\..\..\..\external\lua\luasocket\script" "$(OutDir)Resources\script\" /D /E /I /F /Y
 xcopy "$(OutDir)..\*.dll" "$(OutDir)" /D /Y</Command>
       <Message>copy files</Message>
-    </PreBuildEvent>
+    </PostBuildEvent>
     <PreLinkEvent>
       <Command>
       </Command>
@@ -164,11 +164,11 @@ xcopy "$(OutDir)..\*.dll" "$(OutDir)" /D /Y</Command>
       <DllDataFileName>
       </DllDataFileName>
     </Midl>
-    <PreBuildEvent>
+    <PostBuildEvent>
       <Command>
       </Command>
       <Message>copy files</Message>
-    </PreBuildEvent>
+    </PostBuildEvent>
     <PreLinkEvent>
       <Command>
       </Command>

--- a/tests/performance-tests/proj.win32/performance-tests.vcxproj
+++ b/tests/performance-tests/proj.win32/performance-tests.vcxproj
@@ -14,6 +14,7 @@
     <ProjectGuid>{2778C02D-DDD0-4A92-A6AA-C3E2B7EDE3FF}</ProjectGuid>
     <RootNamespace>test_win32</RootNamespace>
     <Keyword>Win32Proj</Keyword>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">


### PR DESCRIPTION
improve https://github.com/cocos2d/cocos2d-x/pull/19153

with `_defaultResRootPath ` changed, you will have to adapt js/lua resources copy too, or you will get file not found error. so I don't think it's elegent to do this work "Copy resources to "Resources/" on win32".

please give your options @crazyhappygame 