### PR TITLE
[CCLabel] trucate label text if too long

### DIFF
--- a/cocos/2d/CCLabel.cpp
+++ b/cocos/2d/CCLabel.cpp
@@ -677,6 +677,13 @@ void Label::setString(const std::string& text)
         {
             _utf32Text  = utf32String;
         }
+
+        CCASSERT(_utf32Text.length() <= CC_LABEL_MAX_LENGTH, "Length of text should be less then 16384");
+        if (_utf32Text.length() > CC_LABEL_MAX_LENGTH)
+        {
+            cocos2d::log("Error: Label text is too long %d > %d and it will be truncated!", _utf32Text.length(), CC_LABEL_MAX_LENGTH - 1);
+            _utf32Text = _utf32Text.substr(0, CC_LABEL_MAX_LENGTH);
+        }
     }
 }
 

--- a/cocos/2d/CCLabel.cpp
+++ b/cocos/2d/CCLabel.cpp
@@ -681,7 +681,7 @@ void Label::setString(const std::string& text)
         CCASSERT(_utf32Text.length() <= CC_LABEL_MAX_LENGTH, "Length of text should be less then 16384");
         if (_utf32Text.length() > CC_LABEL_MAX_LENGTH)
         {
-            cocos2d::log("Error: Label text is too long %d > %d and it will be truncated!", _utf32Text.length(), CC_LABEL_MAX_LENGTH - 1);
+            cocos2d::log("Error: Label text is too long %d > %d and it will be truncated!", _utf32Text.length(), CC_LABEL_MAX_LENGTH);
             _utf32Text = _utf32Text.substr(0, CC_LABEL_MAX_LENGTH);
         }
     }

--- a/cocos/base/ccConfig.h
+++ b/cocos/base/ccConfig.h
@@ -417,4 +417,6 @@ THE SOFTWARE.
 #define CC_STRIP_FPS 0
 #endif
 
+#define CC_LABEL_MAX_LENGTH ((1<<16)/4)
+
 #endif // __CCCONFIG_H__


### PR DESCRIPTION
ref: https://github.com/cocos2d/cocos2d-x/issues/18755

- in debug mode, abort if text too long
- in release mode, truncate text within the limit. 