### PR TITLE
[CCFileUtils] win32 getFileSize

### DIFF
--- a/cocos/platform/win32/CCFileUtils-win32.cpp
+++ b/cocos/platform/win32/CCFileUtils-win32.cpp
@@ -36,6 +36,9 @@ THE SOFTWARE.
 #include <regex>
 #include <sstream>
 
+#include <sys/types.h>  
+#include <sys/stat.h>  
+
 using namespace std;
 
 #define DECLARE_GUARD std::lock_guard<std::recursive_mutex> mutexGuard(_mutex)
@@ -269,6 +272,16 @@ void FileUtilsWin32::listFilesRecursively(const std::string& dirPath, std::vecto
         }
         tinydir_close(&dir);
     }
+}
+
+long FileUtilsWin32::getFileSize(const std::string &filepath) const
+{
+    struct _stat tmp;
+    if (_stat(filepath.c_str(), &tmp)!=0)
+    {
+        return (long)tmp.st_size;
+    }
+    return 0;
 }
 
 std::vector<std::string> FileUtilsWin32::listFiles(const std::string& dirPath) const

--- a/cocos/platform/win32/CCFileUtils-win32.cpp
+++ b/cocos/platform/win32/CCFileUtils-win32.cpp
@@ -277,7 +277,7 @@ void FileUtilsWin32::listFilesRecursively(const std::string& dirPath, std::vecto
 long FileUtilsWin32::getFileSize(const std::string &filepath) const
 {
     struct _stat tmp;
-    if (_stat(filepath.c_str(), &tmp)!=0)
+    if (_stat(filepath.c_str(), &tmp) == 0)
     {
         return (long)tmp.st_size;
     }

--- a/cocos/platform/win32/CCFileUtils-win32.h
+++ b/cocos/platform/win32/CCFileUtils-win32.h
@@ -112,6 +112,8 @@ protected:
 
 	virtual FileUtils::Status getContents(const std::string& filename, ResizableBuffer* buffer) const override;
 
+    virtual long getFileSize(const std::string &filepath) const override;
+
     /**
      *  Gets full path for filename, resolution directory and search path.
      *


### PR DESCRIPTION
autotest crash, `getFileSize` is not implemented on windows