### PR TITLE
Revert "Remove ccglstatecache (#19013)"

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,5 @@
 cocos2d-x-3.17.1 Nov.19 2018
 
-[REFINE]        Renderer: remove ccGLStateCache
 [REFINE]        Renderer: properly reduce clear buffer times to save energy
 [REFINE]        Engine: improve the reuse logic of sprite frames cache
 [REFINE]        Engine: add `GLView::setCursor` for desktop platforms

--- a/build/cocos2d_libs.xcodeproj/project.pbxproj
+++ b/build/cocos2d_libs.xcodeproj/project.pbxproj
@@ -2048,6 +2048,7 @@
 		507B3B4B1C31BDD30067B53E /* CCBillBoard.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B60C5BD219AC68B10056FBDE /* CCBillBoard.cpp */; };
 		507B3B4C1C31BDD30067B53E /* Particle3DReader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18956BB01A9DFBFD006E9155 /* Particle3DReader.cpp */; };
 		507B3B4D1C31BDD30067B53E /* CCSprite3DMaterial.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 15AE180319AAD2F700C27E9E /* CCSprite3DMaterial.cpp */; };
+		507B3B4E1C31BDD30067B53E /* ccGLStateCache.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 50ABBD701925AB4100A911A9 /* ccGLStateCache.cpp */; };
 		507B3B501C31BDD30067B53E /* CCPUDoEnableComponentEventHandlerTranslator.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B665E1021AA80A6500DDB1C5 /* CCPUDoEnableComponentEventHandlerTranslator.cpp */; };
 		507B3B511C31BDD30067B53E /* CCTransition.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1A5701D8180BCB8C0088DEC7 /* CCTransition.cpp */; };
 		507B3B531C31BDD30067B53E /* CCEventAssetsManagerEx.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 15B3707019EE414C00ABE682 /* CCEventAssetsManagerEx.cpp */; };
@@ -2532,6 +2533,7 @@
 		507B3DEB1C31BDD30067B53E /* CCActionPageTurn3D.h in Headers */ = {isa = PBXBuildFile; fileRef = 1A57005A180BC5A10088DEC7 /* CCActionPageTurn3D.h */; };
 		507B3DEC1C31BDD30067B53E /* UIHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = 2905F9F518CF08D000240AA3 /* UIHelper.h */; };
 		507B3DED1C31BDD30067B53E /* CCNavMeshUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = B677B0C81B18492D006762CB /* CCNavMeshUtils.h */; };
+		507B3DEE1C31BDD30067B53E /* ccGLStateCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 50ABBD711925AB4100A911A9 /* ccGLStateCache.h */; };
 		507B3DEF1C31BDD30067B53E /* CCPUBaseForceAffector.h in Headers */ = {isa = PBXBuildFile; fileRef = B665E0DB1AA80A6500DDB1C5 /* CCPUBaseForceAffector.h */; };
 		507B3DF01C31BDD30067B53E /* CCPUNoise.h in Headers */ = {isa = PBXBuildFile; fileRef = B665E1591AA80A6500DDB1C5 /* CCPUNoise.h */; };
 		507B3DF11C31BDD30067B53E /* CocosGUI.h in Headers */ = {isa = PBXBuildFile; fileRef = 2905F9EA18CF08D000240AA3 /* CocosGUI.h */; };
@@ -3220,6 +3222,10 @@
 		50ABBD981925AB4100A911A9 /* CCGLProgramStateCache.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 50ABBD6E1925AB4100A911A9 /* CCGLProgramStateCache.cpp */; };
 		50ABBD991925AB4100A911A9 /* CCGLProgramStateCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 50ABBD6F1925AB4100A911A9 /* CCGLProgramStateCache.h */; };
 		50ABBD9A1925AB4100A911A9 /* CCGLProgramStateCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 50ABBD6F1925AB4100A911A9 /* CCGLProgramStateCache.h */; };
+		50ABBD9B1925AB4100A911A9 /* ccGLStateCache.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 50ABBD701925AB4100A911A9 /* ccGLStateCache.cpp */; };
+		50ABBD9C1925AB4100A911A9 /* ccGLStateCache.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 50ABBD701925AB4100A911A9 /* ccGLStateCache.cpp */; };
+		50ABBD9D1925AB4100A911A9 /* ccGLStateCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 50ABBD711925AB4100A911A9 /* ccGLStateCache.h */; };
+		50ABBD9E1925AB4100A911A9 /* ccGLStateCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 50ABBD711925AB4100A911A9 /* ccGLStateCache.h */; };
 		50ABBD9F1925AB4100A911A9 /* CCGroupCommand.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 50ABBD721925AB4100A911A9 /* CCGroupCommand.cpp */; };
 		50ABBDA01925AB4100A911A9 /* CCGroupCommand.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 50ABBD721925AB4100A911A9 /* CCGroupCommand.cpp */; };
 		50ABBDA11925AB4100A911A9 /* CCGroupCommand.h in Headers */ = {isa = PBXBuildFile; fileRef = 50ABBD731925AB4100A911A9 /* CCGroupCommand.h */; };
@@ -5394,6 +5400,8 @@
 		50ABBD6D1925AB4100A911A9 /* CCGLProgramState.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CCGLProgramState.h; sourceTree = "<group>"; };
 		50ABBD6E1925AB4100A911A9 /* CCGLProgramStateCache.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CCGLProgramStateCache.cpp; sourceTree = "<group>"; };
 		50ABBD6F1925AB4100A911A9 /* CCGLProgramStateCache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CCGLProgramStateCache.h; sourceTree = "<group>"; };
+		50ABBD701925AB4100A911A9 /* ccGLStateCache.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ccGLStateCache.cpp; sourceTree = "<group>"; };
+		50ABBD711925AB4100A911A9 /* ccGLStateCache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ccGLStateCache.h; sourceTree = "<group>"; };
 		50ABBD721925AB4100A911A9 /* CCGroupCommand.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CCGroupCommand.cpp; sourceTree = "<group>"; };
 		50ABBD731925AB4100A911A9 /* CCGroupCommand.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CCGroupCommand.h; sourceTree = "<group>"; };
 		50ABBD741925AB4100A911A9 /* CCQuadCommand.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CCQuadCommand.cpp; sourceTree = "<group>"; };
@@ -7988,6 +7996,8 @@
 				50ABBD6D1925AB4100A911A9 /* CCGLProgramState.h */,
 				50ABBD6E1925AB4100A911A9 /* CCGLProgramStateCache.cpp */,
 				50ABBD6F1925AB4100A911A9 /* CCGLProgramStateCache.h */,
+				50ABBD701925AB4100A911A9 /* ccGLStateCache.cpp */,
+				50ABBD711925AB4100A911A9 /* ccGLStateCache.h */,
 				50ABBD721925AB4100A911A9 /* CCGroupCommand.cpp */,
 				50ABBD731925AB4100A911A9 /* CCGroupCommand.h */,
 				B29594B21926D5EC003EEF37 /* CCMeshCommand.cpp */,
@@ -9782,6 +9792,7 @@
 				B665E2641AA80A6500DDB1C5 /* CCPUDoExpireEventHandler.h in Headers */,
 				1A40D1091E8E56C6002E363A /* allocators.h in Headers */,
 				50864CE21C7BC1B100B3BAB1 /* cpVect.h in Headers */,
+				50ABBD9D1925AB4100A911A9 /* ccGLStateCache.h in Headers */,
 				B665E3241AA80A6500DDB1C5 /* CCPUOnCollisionObserver.h in Headers */,
 				50ABBEB91925AB6F00A911A9 /* ccUTF8.h in Headers */,
 				15AE191A19AAD35000C27E9E /* CCSSceneReader.h in Headers */,
@@ -10058,6 +10069,7 @@
 				5020A1D91D49912500E80C72 /* RegionAttachment.h in Headers */,
 				507B3DEC1C31BDD30067B53E /* UIHelper.h in Headers */,
 				507B3DED1C31BDD30067B53E /* CCNavMeshUtils.h in Headers */,
+				507B3DEE1C31BDD30067B53E /* ccGLStateCache.h in Headers */,
 				507B3DEF1C31BDD30067B53E /* CCPUBaseForceAffector.h in Headers */,
 				507B3DF01C31BDD30067B53E /* CCPUNoise.h in Headers */,
 				507B3DF11C31BDD30067B53E /* CocosGUI.h in Headers */,
@@ -10870,6 +10882,7 @@
 				1A570088180BC5A10088DEC7 /* CCActionPageTurn3D.h in Headers */,
 				15AE1B9319AADA9A00C27E9E /* UIHelper.h in Headers */,
 				B677B0DC1B18492D006762CB /* CCNavMeshUtils.h in Headers */,
+				50ABBD9E1925AB4100A911A9 /* ccGLStateCache.h in Headers */,
 				B665E2111AA80A6500DDB1C5 /* CCPUBaseForceAffector.h in Headers */,
 				B665E30D1AA80A6500DDB1C5 /* CCPUNoise.h in Headers */,
 				15AE1B9619AADA9A00C27E9E /* CocosGUI.h in Headers */,
@@ -12150,6 +12163,7 @@
 				D0FD03531A3B51AA00825BB5 /* CCAllocatorGlobalNewDelete.cpp in Sources */,
 				B6DD2FE51B04825B00E47F5F /* DetourPathQueue.cpp in Sources */,
 				B665E39A1AA80A6500DDB1C5 /* CCPUPointEmitterTranslator.cpp in Sources */,
+				50ABBD9B1925AB4100A911A9 /* ccGLStateCache.cpp in Sources */,
 				15AE188119AAD33D00C27E9E /* CCBReader.cpp in Sources */,
 				501216A01AC473AD009A4BEA /* CCMaterial.cpp in Sources */,
 				50ABBDB91925AB4100A911A9 /* CCTextureAtlas.cpp in Sources */,
@@ -12560,6 +12574,7 @@
 				507B3B4B1C31BDD30067B53E /* CCBillBoard.cpp in Sources */,
 				507B3B4C1C31BDD30067B53E /* Particle3DReader.cpp in Sources */,
 				507B3B4D1C31BDD30067B53E /* CCSprite3DMaterial.cpp in Sources */,
+				507B3B4E1C31BDD30067B53E /* ccGLStateCache.cpp in Sources */,
 				507B3B501C31BDD30067B53E /* CCPUDoEnableComponentEventHandlerTranslator.cpp in Sources */,
 				507B3B511C31BDD30067B53E /* CCTransition.cpp in Sources */,
 				507B3B531C31BDD30067B53E /* CCEventAssetsManagerEx.cpp in Sources */,
@@ -13228,6 +13243,7 @@
 				B60C5BD519AC68B10056FBDE /* CCBillBoard.cpp in Sources */,
 				18956BB31A9DFBFD006E9155 /* Particle3DReader.cpp in Sources */,
 				15AE184519AAD2F700C27E9E /* CCSprite3DMaterial.cpp in Sources */,
+				50ABBD9C1925AB4100A911A9 /* ccGLStateCache.cpp in Sources */,
 				B665E25F1AA80A6500DDB1C5 /* CCPUDoEnableComponentEventHandlerTranslator.cpp in Sources */,
 				1A5701E7180BCB8C0088DEC7 /* CCTransition.cpp in Sources */,
 				15B3707D19EE414C00ABE682 /* CCEventAssetsManagerEx.cpp in Sources */,

--- a/cocos/2d/CCCamera.cpp
+++ b/cocos/2d/CCCamera.cpp
@@ -33,6 +33,7 @@
 #include "renderer/CCRenderer.h"
 #include "renderer/CCQuadCommand.h"
 #include "renderer/CCGLProgramCache.h"
+#include "renderer/ccGLStateCache.h"
 #include "renderer/CCFrameBuffer.h"
 #include "renderer/CCRenderState.h"
 

--- a/cocos/2d/CCCameraBackgroundBrush.cpp
+++ b/cocos/2d/CCCameraBackgroundBrush.cpp
@@ -26,9 +26,9 @@
 #include "2d/CCCameraBackgroundBrush.h"
 #include "2d/CCCamera.h"
 #include "base/ccMacros.h"
-#include "base/ccUtils.h"
 #include "base/CCConfiguration.h"
 #include "base/CCDirector.h"
+#include "renderer/ccGLStateCache.h"
 #include "renderer/CCGLProgram.h"
 #include "renderer/CCGLProgramCache.h"
 #include "renderer/CCGLProgramState.h"
@@ -115,7 +115,7 @@ CameraBackgroundDepthBrush::~CameraBackgroundDepthBrush()
     if (Configuration::getInstance()->supportsShareableVAO())
     {
         glDeleteVertexArrays(1, &_vao);
-        glBindVertexArray(0);
+        GL::bindVAO(0);
         _vao = 0;
     }
 #if CC_ENABLE_CACHE_TEXTURE_DATA
@@ -168,7 +168,7 @@ void CameraBackgroundDepthBrush::initBuffer()
     if (supportVAO)
     {
         glGenVertexArrays(1, &_vao);
-        glBindVertexArray(_vao);
+        GL::bindVAO(_vao);
     }
 
     glGenBuffers(1, &_vertexBuffer);
@@ -196,7 +196,7 @@ void CameraBackgroundDepthBrush::initBuffer()
     }
 
     if (supportVAO)
-        glBindVertexArray(0);
+        GL::bindVAO(0);
 
     glBindBuffer(GL_ARRAY_BUFFER, 0);
     glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
@@ -227,13 +227,11 @@ void CameraBackgroundDepthBrush::drawBackground(Camera* /*camera*/)
     
     auto supportVAO = Configuration::getInstance()->supportsShareableVAO();
     if (supportVAO)
-        glBindVertexArray(_vao);
+        GL::bindVAO(_vao);
     else
     {
         glBindBuffer(GL_ARRAY_BUFFER, _vertexBuffer);
-        glEnableVertexAttribArray(GLProgram::VERTEX_ATTRIB_POSITION);
-        glEnableVertexAttribArray(GLProgram::VERTEX_ATTRIB_COLOR);
-        glEnableVertexAttribArray(GLProgram::VERTEX_ATTRIB_TEX_COORD);
+        GL::enableVertexAttribs(GL::VERTEX_ATTRIB_FLAG_POS_COLOR_TEX);
 
         // vertices
         glVertexAttribPointer(GLProgram::VERTEX_ATTRIB_POSITION, 3, GL_FLOAT, GL_FALSE, sizeof(V3F_C4B_T2F), (GLvoid*)offsetof(V3F_C4B_T2F, vertices));
@@ -250,7 +248,7 @@ void CameraBackgroundDepthBrush::drawBackground(Camera* /*camera*/)
     glDrawElements(GL_TRIANGLES, 6, GL_UNSIGNED_SHORT, nullptr);
     
     if (supportVAO)
-        glBindVertexArray(0);
+        GL::bindVAO(0);
     else
     {
         glBindBuffer(GL_ARRAY_BUFFER, 0);
@@ -305,7 +303,7 @@ bool CameraBackgroundColorBrush::init()
 
 void CameraBackgroundColorBrush::drawBackground(Camera* camera)
 {
-    utils::setBlending(BlendFunc::ALPHA_NON_PREMULTIPLIED.src, BlendFunc::ALPHA_NON_PREMULTIPLIED.dst);
+    GL::blendFunc(BlendFunc::ALPHA_NON_PREMULTIPLIED.src, BlendFunc::ALPHA_NON_PREMULTIPLIED.dst);
 
     CameraBackgroundDepthBrush::drawBackground(camera);
 }
@@ -379,7 +377,7 @@ CameraBackgroundSkyBoxBrush::~CameraBackgroundSkyBoxBrush()
     if (Configuration::getInstance()->supportsShareableVAO())
     {
         glDeleteVertexArrays(1, &_vao);
-        glBindVertexArray(0);
+        GL::bindVAO(0);
         _vao = 0;
     }
 #if CC_ENABLE_CACHE_TEXTURE_DATA
@@ -482,11 +480,11 @@ void CameraBackgroundSkyBoxBrush::drawBackground(Camera* camera)
     
     if (Configuration::getInstance()->supportsShareableVAO())
     {
-        glBindVertexArray(_vao);
+        GL::bindVAO(_vao);
     }
     else
     {
-        glEnableVertexAttribArray(GLProgram::VERTEX_ATTRIB_POSITION);
+        GL::enableVertexAttribs(GL::VERTEX_ATTRIB_FLAG_POSITION);
         
         glBindBuffer(GL_ARRAY_BUFFER, _vertexBuffer);
         glVertexAttribPointer(GLProgram::VERTEX_ATTRIB_POSITION, 3, GL_FLOAT, GL_FALSE, sizeof(Vec3), nullptr);
@@ -498,7 +496,7 @@ void CameraBackgroundSkyBoxBrush::drawBackground(Camera* camera)
     
     if (Configuration::getInstance()->supportsShareableVAO())
     {
-        glBindVertexArray(0);
+        GL::bindVAO(0);
     }
     else
     {
@@ -533,14 +531,14 @@ void CameraBackgroundSkyBoxBrush::initBuffer()
     if (Configuration::getInstance()->supportsShareableVAO() && _vao)
     {
         glDeleteVertexArrays(1, &_vao);
-        glBindVertexArray(0);
+        GL::bindVAO(0);
         _vao = 0;
     }
     
     if (Configuration::getInstance()->supportsShareableVAO())
     {
         glGenVertexArrays(1, &_vao);
-        glBindVertexArray(_vao);
+        GL::bindVAO(_vao);
     }
     
     // init vertex buffer object
@@ -572,7 +570,7 @@ void CameraBackgroundSkyBoxBrush::initBuffer()
         glEnableVertexAttribArray(GLProgram::VERTEX_ATTRIB_POSITION);
         _glProgramState->applyAttributes(false);
         
-        glBindVertexArray(0);
+        GL::bindVAO(0);
     }
 }
 

--- a/cocos/2d/CCClippingNode.cpp
+++ b/cocos/2d/CCClippingNode.cpp
@@ -29,6 +29,7 @@
 #include "2d/CCClippingNode.h"
 #include "2d/CCDrawingPrimitives.h"
 #include "renderer/CCGLProgramCache.h"
+#include "renderer/ccGLStateCache.h"
 #include "renderer/CCRenderer.h"
 #include "renderer/CCRenderState.h"
 #include "base/CCDirector.h"

--- a/cocos/2d/CCDrawingPrimitives.cpp
+++ b/cocos/2d/CCDrawingPrimitives.cpp
@@ -44,6 +44,7 @@ THE SOFTWARE.
 
 #include "2d/CCActionCatmullRom.h"
 #include "base/CCDirector.h"
+#include "renderer/ccGLStateCache.h"
 #include "renderer/CCGLProgramCache.h"
 #include "renderer/CCRenderer.h"
 #include "platform/CCGL.h"
@@ -110,7 +111,7 @@ void drawPoint(const Vec2& point)
     p.x = point.x;
     p.y = point.y;
 
-    glEnableVertexAttribArray(GLProgram::VERTEX_ATTRIB_POSITION);
+    GL::enableVertexAttribs( GL::VERTEX_ATTRIB_FLAG_POSITION );
     s_shader->use();
     s_shader->setUniformsForBuiltins();
 
@@ -128,7 +129,7 @@ void drawPoints( const Vec2 *points, unsigned int numberOfPoints )
 {
     lazy_init();
 
-    glEnableVertexAttribArray(GLProgram::VERTEX_ATTRIB_POSITION);
+    GL::enableVertexAttribs( GL::VERTEX_ATTRIB_FLAG_POSITION );
     s_shader->use();
     s_shader->setUniformsForBuiltins();
     s_shader->setUniformLocationWith4fv(s_colorLocation, (GLfloat*) &s_color.r, 1);
@@ -154,7 +155,7 @@ void drawLine(const Vec2& origin, const Vec2& destination)
     s_shader->setUniformsForBuiltins();
     s_shader->setUniformLocationWith4fv(s_colorLocation, (GLfloat*) &s_color.r, 1);
 
-    glEnableVertexAttribArray(GLProgram::VERTEX_ATTRIB_POSITION);
+    GL::enableVertexAttribs( GL::VERTEX_ATTRIB_FLAG_POSITION );
     glVertexAttribPointer(GLProgram::VERTEX_ATTRIB_POSITION, 2, GL_FLOAT, GL_FALSE, 0, vertices);
     glDrawArrays(GL_LINES, 0, 2);
 
@@ -189,7 +190,8 @@ void drawPoly(const Vec2 *poli, unsigned int numberOfPoints, bool closePolygon)
     s_shader->setUniformsForBuiltins();
     s_shader->setUniformLocationWith4fv(s_colorLocation, (GLfloat*) &s_color.r, 1);
 
-    glEnableVertexAttribArray(GLProgram::VERTEX_ATTRIB_POSITION);
+    GL::enableVertexAttribs( GL::VERTEX_ATTRIB_FLAG_POSITION );
+
     glVertexAttribPointer(GLProgram::VERTEX_ATTRIB_POSITION, 2, GL_FLOAT, GL_FALSE, 0, poli);
 
     if( closePolygon )
@@ -208,7 +210,8 @@ void drawSolidPoly(const Vec2 *poli, unsigned int numberOfPoints, Color4F color)
     s_shader->setUniformsForBuiltins();
     s_shader->setUniformLocationWith4fv(s_colorLocation, (GLfloat*) &color.r, 1);
 
-    glEnableVertexAttribArray(GLProgram::VERTEX_ATTRIB_POSITION);
+    GL::enableVertexAttribs( GL::VERTEX_ATTRIB_FLAG_POSITION );
+
     glVertexAttribPointer(GLProgram::VERTEX_ATTRIB_POSITION, 2, GL_FLOAT, GL_FALSE, 0, poli);
     glDrawArrays(GL_TRIANGLE_FAN, 0, (GLsizei) numberOfPoints);
 
@@ -244,7 +247,8 @@ void drawCircle( const Vec2& center, float radius, float angle, unsigned int seg
     s_shader->setUniformsForBuiltins();
     s_shader->setUniformLocationWith4fv(s_colorLocation, (GLfloat*) &s_color.r, 1);
 
-    glEnableVertexAttribArray(GLProgram::VERTEX_ATTRIB_POSITION);
+    GL::enableVertexAttribs( GL::VERTEX_ATTRIB_FLAG_POSITION );
+
     glVertexAttribPointer(GLProgram::VERTEX_ATTRIB_POSITION, 2, GL_FLOAT, GL_FALSE, 0, vertices);
     glDrawArrays(GL_LINE_STRIP, 0, (GLsizei) segments+additionalSegment);
 
@@ -283,7 +287,8 @@ void drawSolidCircle( const Vec2& center, float radius, float angle, unsigned in
     s_shader->setUniformsForBuiltins();
     s_shader->setUniformLocationWith4fv(s_colorLocation, (GLfloat*) &s_color.r, 1);
     
-    glEnableVertexAttribArray(GLProgram::VERTEX_ATTRIB_POSITION);
+    GL::enableVertexAttribs( GL::VERTEX_ATTRIB_FLAG_POSITION );
+    
     glVertexAttribPointer(GLProgram::VERTEX_ATTRIB_POSITION, 2, GL_FLOAT, GL_FALSE, 0, vertices);
 
     glDrawArrays(GL_TRIANGLE_FAN, 0, (GLsizei) segments+1);
@@ -318,7 +323,8 @@ void drawQuadBezier(const Vec2& origin, const Vec2& control, const Vec2& destina
     s_shader->setUniformsForBuiltins();
     s_shader->setUniformLocationWith4fv(s_colorLocation, (GLfloat*) &s_color.r, 1);
 
-    glEnableVertexAttribArray(GLProgram::VERTEX_ATTRIB_POSITION);
+    GL::enableVertexAttribs( GL::VERTEX_ATTRIB_FLAG_POSITION );
+
     glVertexAttribPointer(GLProgram::VERTEX_ATTRIB_POSITION, 2, GL_FLOAT, GL_FALSE, 0, vertices);
     glDrawArrays(GL_LINE_STRIP, 0, (GLsizei) segments + 1);
     CC_SAFE_DELETE_ARRAY(vertices);
@@ -369,7 +375,8 @@ void drawCardinalSpline( PointArray *config, float tension,  unsigned int segmen
     s_shader->setUniformsForBuiltins();
     s_shader->setUniformLocationWith4fv(s_colorLocation, (GLfloat*)&s_color.r, 1);
 
-    glEnableVertexAttribArray(GLProgram::VERTEX_ATTRIB_POSITION);
+    GL::enableVertexAttribs( GL::VERTEX_ATTRIB_FLAG_POSITION );
+
     glVertexAttribPointer(GLProgram::VERTEX_ATTRIB_POSITION, 2, GL_FLOAT, GL_FALSE, 0, vertices);
     glDrawArrays(GL_LINE_STRIP, 0, (GLsizei) segments + 1);
 
@@ -397,7 +404,8 @@ void drawCubicBezier(const Vec2& origin, const Vec2& control1, const Vec2& contr
     s_shader->setUniformsForBuiltins();
     s_shader->setUniformLocationWith4fv(s_colorLocation, (GLfloat*) &s_color.r, 1);
 
-    glEnableVertexAttribArray(GLProgram::VERTEX_ATTRIB_POSITION);
+    GL::enableVertexAttribs( GL::VERTEX_ATTRIB_FLAG_POSITION );
+
     glVertexAttribPointer(GLProgram::VERTEX_ATTRIB_POSITION, 2, GL_FLOAT, GL_FALSE, 0, vertices);
     glDrawArrays(GL_LINE_STRIP, 0, (GLsizei) segments + 1);
     CC_SAFE_DELETE_ARRAY(vertices);

--- a/cocos/2d/CCFastTMXLayer.cpp
+++ b/cocos/2d/CCFastTMXLayer.cpp
@@ -41,6 +41,7 @@ THE SOFTWARE.
 #include "2d/CCCamera.h"
 #include "renderer/CCTextureCache.h"
 #include "renderer/CCGLProgramCache.h"
+#include "renderer/ccGLStateCache.h"
 #include "renderer/CCRenderer.h"
 #include "renderer/CCVertexIndexBuffer.h"
 #include "base/CCDirector.h"
@@ -186,11 +187,10 @@ void TMXLayer::draw(Renderer *renderer, const Mat4& transform, uint32_t flags)
 
 void TMXLayer::onDraw(Primitive *primitive)
 {
-    glActiveTexture(GL_TEXTURE0);
-    glBindTexture(GL_TEXTURE_2D, _texture->getName());
+    GL::bindTexture2D(_texture->getName());
     getGLProgramState()->apply(_modelViewTransform);
     
-    glBindVertexArray(0);
+    GL::bindVAO(0);
     primitive->draw();
     glBindBuffer(GL_ARRAY_BUFFER, 0);
     glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
@@ -292,7 +292,7 @@ void TMXLayer::updateTiles(const Rect& culledRect)
 
 void TMXLayer::updateVertexBuffer()
 {
-    glBindVertexArray(0);
+    GL::bindVAO(0);
     if(nullptr == _vData)
     {
         _vertexBuffer = VertexBuffer::create(sizeof(V3F_C4B_T2F), (int)_totalQuads.size() * 4);

--- a/cocos/2d/CCGrid.cpp
+++ b/cocos/2d/CCGrid.cpp
@@ -32,6 +32,7 @@ THE SOFTWARE.
 #include "2d/CCGrabber.h"
 #include "renderer/CCGLProgram.h"
 #include "renderer/CCGLProgramCache.h"
+#include "renderer/ccGLStateCache.h"
 #include "renderer/CCRenderer.h"
 #include "renderer/CCRenderState.h"
 #include "renderer/CCTexture2D.h"
@@ -208,6 +209,8 @@ void GridBase::set2DProjection()
     director->multiplyMatrix(MATRIX_STACK_TYPE::MATRIX_STACK_PROJECTION, orthoMatrix);
 
     director->loadIdentityMatrix(MATRIX_STACK_TYPE::MATRIX_STACK_MODELVIEW);
+
+    GL::setProjectionMatrixDirty();
 }
 
 void GridBase::setGridRect(const cocos2d::Rect &rect)
@@ -253,8 +256,7 @@ void GridBase::afterDraw(cocos2d::Node * /*target*/)
 //        kmGLTranslatef(-offset.x, -offset.y, 0);
 //    }
 
-    glActiveTexture(GL_TEXTURE0);
-    glBindTexture(GL_TEXTURE_2D, _texture->getName());
+    GL::bindTexture2D(_texture->getName());
 
     // restore projection for default FBO .fixed bug #543 #544
     //TODO:         Director::getInstance()->setProjection(Director::getInstance()->getProjection());
@@ -417,8 +419,7 @@ void Grid3D::blit(void)
 {
     int n = _gridSize.width * _gridSize.height;
 
-    glEnableVertexAttribArray(GLProgram::VERTEX_ATTRIB_POSITION);
-    glEnableVertexAttribArray(GLProgram::VERTEX_ATTRIB_TEX_COORD);
+    GL::enableVertexAttribs( GL::VERTEX_ATTRIB_FLAG_POSITION | GL::VERTEX_ATTRIB_FLAG_TEX_COORD );
     _shaderProgram->use();
     _shaderProgram->setUniformsForBuiltins();
 
@@ -664,8 +665,7 @@ void TiledGrid3D::blit(void)
     //
     // Attributes
     //
-    glEnableVertexAttribArray(GLProgram::VERTEX_ATTRIB_POSITION);
-    glEnableVertexAttribArray(GLProgram::VERTEX_ATTRIB_TEX_COORD);
+    GL::enableVertexAttribs( GL::VERTEX_ATTRIB_FLAG_POSITION | GL::VERTEX_ATTRIB_FLAG_TEX_COORD );
 
     // position
     glVertexAttribPointer(GLProgram::VERTEX_ATTRIB_POSITION, 3, GL_FLOAT, GL_FALSE, 0, _vertices);

--- a/cocos/2d/CCLabel.cpp
+++ b/cocos/2d/CCLabel.cpp
@@ -38,11 +38,11 @@
 #include "base/ccUTF8.h"
 #include "platform/CCFileUtils.h"
 #include "renderer/CCRenderer.h"
+#include "renderer/ccGLStateCache.h"
 #include "base/CCDirector.h"
 #include "base/CCEventListenerCustom.h"
 #include "base/CCEventDispatcher.h"
 #include "base/CCEventCustom.h"
-#include "base/ccUtils.h"
 #include "2d/CCFontFNT.h"
 
 NS_CC_BEGIN
@@ -1546,7 +1546,7 @@ void Label::onDraw(const Mat4& transform, bool /*transformUpdated*/)
 {
     auto glprogram = getGLProgram();
     glprogram->use();
-    utils::setBlending(_blendFunc.src, _blendFunc.dst);
+    GL::blendFunc(_blendFunc.src, _blendFunc.dst);
 
     if (_shadowEnabled)
     {

--- a/cocos/2d/CCLayer.cpp
+++ b/cocos/2d/CCLayer.cpp
@@ -29,9 +29,9 @@ THE SOFTWARE.
 #include <stdarg.h>
 #include "2d/CCLayer.h"
 #include "base/CCScriptSupport.h"
-#include "base/ccUtils.h"
 #include "platform/CCDevice.h"
 #include "renderer/CCRenderer.h"
+#include "renderer/ccGLStateCache.h"
 #include "renderer/CCGLProgramState.h"
 #include "base/CCDirector.h"
 #include "base/CCEventDispatcher.h"
@@ -620,8 +620,7 @@ void LayerColor::onDraw(const Mat4& transform, uint32_t /*flags*/)
     getGLProgram()->use();
     getGLProgram()->setUniformsForBuiltins(transform);
     
-    glEnableVertexAttribArray(GLProgram::VERTEX_ATTRIB_POSITION);
-    glEnableVertexAttribArray(GLProgram::VERTEX_ATTRIB_COLOR);
+    GL::enableVertexAttribs( GL::VERTEX_ATTRIB_FLAG_POSITION | GL::VERTEX_ATTRIB_FLAG_COLOR );
     
     //
     // Attributes
@@ -630,7 +629,7 @@ void LayerColor::onDraw(const Mat4& transform, uint32_t /*flags*/)
     glVertexAttribPointer(GLProgram::VERTEX_ATTRIB_POSITION, 3, GL_FLOAT, GL_FALSE, 0, _noMVPVertices);
     glVertexAttribPointer(GLProgram::VERTEX_ATTRIB_COLOR, 4, GL_FLOAT, GL_FALSE, 0, _squareColors);
 
-    utils::setBlending(_blendFunc.src, _blendFunc.dst);
+    GL::blendFunc( _blendFunc.src, _blendFunc.dst );
 
     glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
 
@@ -951,7 +950,7 @@ void LayerRadialGradient::onDraw(const Mat4& transform, uint32_t /*flags*/)
     program->setUniformLocationWith1f(_uniformLocationExpand, _expand);
     
     
-    glEnableVertexAttribArray(GLProgram::VERTEX_ATTRIB_POSITION);
+    GL::enableVertexAttribs( GL::VERTEX_ATTRIB_FLAG_POSITION);
     
     //
     // Attributes
@@ -959,7 +958,7 @@ void LayerRadialGradient::onDraw(const Mat4& transform, uint32_t /*flags*/)
     glBindBuffer(GL_ARRAY_BUFFER, 0);
     glVertexAttribPointer(GLProgram::VERTEX_ATTRIB_POSITION, 2, GL_FLOAT, GL_FALSE, 0, _vertices);
     
-    utils::setBlending(_blendFunc.src, _blendFunc.dst);
+    GL::blendFunc(_blendFunc.src, _blendFunc.dst);
     
     glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
     

--- a/cocos/2d/CCLayer.cpp
+++ b/cocos/2d/CCLayer.cpp
@@ -620,13 +620,13 @@ void LayerColor::onDraw(const Mat4& transform, uint32_t /*flags*/)
     getGLProgram()->use();
     getGLProgram()->setUniformsForBuiltins(transform);
     
+    glEnableVertexAttribArray(GLProgram::VERTEX_ATTRIB_POSITION);
+    glEnableVertexAttribArray(GLProgram::VERTEX_ATTRIB_COLOR);
+    
     //
     // Attributes
     //
     glBindBuffer(GL_ARRAY_BUFFER, 0);
-    glEnableVertexAttribArray(GLProgram::VERTEX_ATTRIB_POSITION);
-    glDisableVertexAttribArray(GLProgram::VERTEX_ATTRIB_TEX_COORD);
-    glEnableVertexAttribArray(GLProgram::VERTEX_ATTRIB_COLOR);
     glVertexAttribPointer(GLProgram::VERTEX_ATTRIB_POSITION, 3, GL_FLOAT, GL_FALSE, 0, _noMVPVertices);
     glVertexAttribPointer(GLProgram::VERTEX_ATTRIB_COLOR, 4, GL_FLOAT, GL_FALSE, 0, _squareColors);
 

--- a/cocos/2d/CCMotionStreak.cpp
+++ b/cocos/2d/CCMotionStreak.cpp
@@ -28,8 +28,8 @@ THE SOFTWARE.
 #include "2d/CCMotionStreak.h"
 #include "math/CCVertex.h"
 #include "base/CCDirector.h"
-#include "base/ccUtils.h"
 #include "renderer/CCTextureCache.h"
+#include "renderer/ccGLStateCache.h"
 #include "renderer/CCTexture2D.h"
 #include "renderer/CCRenderer.h"
 #include "renderer/CCGLProgramState.h"
@@ -383,13 +383,10 @@ void MotionStreak::onDraw(const Mat4 &transform, uint32_t /*flags*/)
     getGLProgram()->use();
     getGLProgram()->setUniformsForBuiltins(transform);
 
-    glEnableVertexAttribArray(GLProgram::VERTEX_ATTRIB_POSITION);
-    glEnableVertexAttribArray(GLProgram::VERTEX_ATTRIB_TEX_COORD);
-    glEnableVertexAttribArray(GLProgram::VERTEX_ATTRIB_COLOR);
-    utils::setBlending(_blendFunc.src, _blendFunc.dst);
+    GL::enableVertexAttribs(GL::VERTEX_ATTRIB_FLAG_POS_COLOR_TEX );
+    GL::blendFunc( _blendFunc.src, _blendFunc.dst );
 
-    glActiveTexture(GL_TEXTURE0);
-    glBindTexture(GL_TEXTURE_2D, _texture->getName());
+    GL::bindTexture2D( _texture );
 
     glVertexAttribPointer(GLProgram::VERTEX_ATTRIB_POSITION, 2, GL_FLOAT, GL_FALSE, 0, _vertices);
     glVertexAttribPointer(GLProgram::VERTEX_ATTRIB_TEX_COORD, 2, GL_FLOAT, GL_FALSE, 0, _texCoords);

--- a/cocos/2d/CCMotionStreak.cpp
+++ b/cocos/2d/CCMotionStreak.cpp
@@ -390,12 +390,6 @@ void MotionStreak::onDraw(const Mat4 &transform, uint32_t /*flags*/)
 
     glActiveTexture(GL_TEXTURE0);
     glBindTexture(GL_TEXTURE_2D, _texture->getName());
-    auto alphaTexID = _texture->getAlphaTextureName();
-    if (alphaTexID > 0)
-    {
-        glActiveTexture(GL_TEXTURE0 + 1);
-        glBindTexture(GL_TEXTURE_2D, alphaTexID);
-    }
 
     glVertexAttribPointer(GLProgram::VERTEX_ATTRIB_POSITION, 2, GL_FLOAT, GL_FALSE, 0, _vertices);
     glVertexAttribPointer(GLProgram::VERTEX_ATTRIB_TEX_COORD, 2, GL_FLOAT, GL_FALSE, 0, _texCoords);

--- a/cocos/2d/CCParticleSystemQuad.cpp
+++ b/cocos/2d/CCParticleSystemQuad.cpp
@@ -35,6 +35,7 @@ THE SOFTWARE.
 #include "2d/CCSpriteFrame.h"
 #include "2d/CCParticleBatchNode.h"
 #include "renderer/CCTextureAtlas.h"
+#include "renderer/ccGLStateCache.h"
 #include "renderer/CCRenderer.h"
 #include "base/CCDirector.h"
 #include "base/CCEventType.h"
@@ -63,7 +64,7 @@ ParticleSystemQuad::~ParticleSystemQuad()
         if (Configuration::getInstance()->supportsShareableVAO())
         {
             glDeleteVertexArrays(1, &_VAOname);
-            glBindVertexArray(0);
+            GL::bindVAO(0);
         }
     }
 }
@@ -547,10 +548,10 @@ void ParticleSystemQuad::setupVBOandVAO()
     // clean VAO
     glDeleteBuffers(2, &_buffersVBO[0]);
     glDeleteVertexArrays(1, &_VAOname);
-    glBindVertexArray(0);
+    GL::bindVAO(0);
     
     glGenVertexArrays(1, &_VAOname);
-    glBindVertexArray(_VAOname);
+    GL::bindVAO(_VAOname);
 
 #define kQuadSize sizeof(_quads[0].bl)
 
@@ -575,7 +576,7 @@ void ParticleSystemQuad::setupVBOandVAO()
     glBufferData(GL_ELEMENT_ARRAY_BUFFER, sizeof(_indices[0]) * _totalParticles * 6, _indices, GL_STATIC_DRAW);
 
     // Must unbind the VAO before changing the element buffer.
-    glBindVertexArray(0);
+    GL::bindVAO(0);
     glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
     glBindBuffer(GL_ARRAY_BUFFER, 0);
 
@@ -679,7 +680,7 @@ void ParticleSystemQuad::setBatchNode(ParticleBatchNode * batchNode)
             if (Configuration::getInstance()->supportsShareableVAO())
             {
                 glDeleteVertexArrays(1, &_VAOname);
-                glBindVertexArray(0);
+                GL::bindVAO(0);
                 _VAOname = 0;
             }
         }

--- a/cocos/2d/CCProgressTimer.cpp
+++ b/cocos/2d/CCProgressTimer.cpp
@@ -31,8 +31,8 @@ THE SOFTWARE.
 #include "base/ccMacros.h"
 #include "base/CCDirector.h"
 #include "2d/CCSprite.h"
+#include "renderer/ccGLStateCache.h"
 #include "renderer/CCRenderer.h"
-#include "base/ccUtils.h"
 
 NS_CC_BEGIN
 
@@ -509,14 +509,11 @@ void ProgressTimer::onDraw(const Mat4 &transform, uint32_t /*flags*/)
     getGLProgram()->use();
     getGLProgram()->setUniformsForBuiltins(transform);
 
-    utils::setBlending(_sprite->getBlendFunc().src, _sprite->getBlendFunc().dst);
+    GL::blendFunc( _sprite->getBlendFunc().src, _sprite->getBlendFunc().dst );
 
-    glEnableVertexAttribArray(GLProgram::VERTEX_ATTRIB_POSITION);
-    glEnableVertexAttribArray(GLProgram::VERTEX_ATTRIB_TEX_COORD);
-    glEnableVertexAttribArray(GLProgram::VERTEX_ATTRIB_COLOR);
+    GL::enableVertexAttribs(GL::VERTEX_ATTRIB_FLAG_POS_COLOR_TEX );
 
-    glActiveTexture(GL_TEXTURE0);
-    glBindTexture(GL_TEXTURE_2D, _sprite->getTexture()->getName());
+    GL::bindTexture2D( _sprite->getTexture() );
 
     glVertexAttribPointer( GLProgram::VERTEX_ATTRIB_POSITION, 2, GL_FLOAT, GL_FALSE, sizeof(_vertexData[0]) , &_vertexData[0].vertices);
     glVertexAttribPointer( GLProgram::VERTEX_ATTRIB_TEX_COORD, 2, GL_FLOAT, GL_FALSE, sizeof(_vertexData[0]), &_vertexData[0].texCoords);

--- a/cocos/2d/CCProgressTimer.cpp
+++ b/cocos/2d/CCProgressTimer.cpp
@@ -517,12 +517,6 @@ void ProgressTimer::onDraw(const Mat4 &transform, uint32_t /*flags*/)
 
     glActiveTexture(GL_TEXTURE0);
     glBindTexture(GL_TEXTURE_2D, _sprite->getTexture()->getName());
-    auto alphaTexID = _sprite->getTexture()->getAlphaTextureName();
-    if (alphaTexID > 0)
-    {
-        glActiveTexture(GL_TEXTURE0 + 1);
-        glBindTexture(GL_TEXTURE_2D, alphaTexID);
-    }
 
     glVertexAttribPointer( GLProgram::VERTEX_ATTRIB_POSITION, 2, GL_FLOAT, GL_FALSE, sizeof(_vertexData[0]) , &_vertexData[0].vertices);
     glVertexAttribPointer( GLProgram::VERTEX_ATTRIB_TEX_COORD, 2, GL_FLOAT, GL_FALSE, sizeof(_vertexData[0]), &_vertexData[0].texCoords);

--- a/cocos/2d/libcocos2d.vcxproj
+++ b/cocos/2d/libcocos2d.vcxproj
@@ -647,6 +647,7 @@ xcopy /Y /Q "$(ProjectDir)..\..\external\uv\prebuilt\win32\*.*" "$(OutDir)"</Com
     <ClCompile Include="..\renderer\CCGLProgramCache.cpp" />
     <ClCompile Include="..\renderer\CCGLProgramState.cpp" />
     <ClCompile Include="..\renderer\CCGLProgramStateCache.cpp" />
+    <ClCompile Include="..\renderer\ccGLStateCache.cpp" />
     <ClCompile Include="..\renderer\CCGroupCommand.cpp" />
     <ClCompile Include="..\renderer\CCMaterial.cpp" />
     <ClCompile Include="..\renderer\CCMeshCommand.cpp" />
@@ -1287,6 +1288,7 @@ xcopy /Y /Q "$(ProjectDir)..\..\external\uv\prebuilt\win32\*.*" "$(OutDir)"</Com
     <ClInclude Include="..\renderer\CCGLProgramCache.h" />
     <ClInclude Include="..\renderer\CCGLProgramState.h" />
     <ClInclude Include="..\renderer\CCGLProgramStateCache.h" />
+    <ClInclude Include="..\renderer\ccGLStateCache.h" />
     <ClInclude Include="..\renderer\CCGroupCommand.h" />
     <ClInclude Include="..\renderer\CCMaterial.h" />
     <ClInclude Include="..\renderer\CCMeshCommand.h" />

--- a/cocos/2d/libcocos2d.vcxproj.filters
+++ b/cocos/2d/libcocos2d.vcxproj.filters
@@ -670,6 +670,9 @@
     <ClCompile Include="..\renderer\CCGLProgramStateCache.cpp">
       <Filter>renderer</Filter>
     </ClCompile>
+    <ClCompile Include="..\renderer\ccGLStateCache.cpp">
+      <Filter>renderer</Filter>
+    </ClCompile>
     <ClCompile Include="..\renderer\CCGroupCommand.cpp">
       <Filter>renderer</Filter>
     </ClCompile>
@@ -2413,6 +2416,9 @@
       <Filter>renderer</Filter>
     </ClInclude>
     <ClInclude Include="..\renderer\CCGLProgramStateCache.h">
+      <Filter>renderer</Filter>
+    </ClInclude>
+    <ClInclude Include="..\renderer\ccGLStateCache.h">
       <Filter>renderer</Filter>
     </ClInclude>
     <ClInclude Include="..\renderer\CCGroupCommand.h">

--- a/cocos/2d/libcocos2d_win10/libcocos2d.vcxproj
+++ b/cocos/2d/libcocos2d_win10/libcocos2d.vcxproj
@@ -643,6 +643,7 @@
     <ClCompile Include="..\..\renderer\CCGLProgramCache.cpp" />
     <ClCompile Include="..\..\renderer\CCGLProgramState.cpp" />
     <ClCompile Include="..\..\renderer\CCGLProgramStateCache.cpp" />
+    <ClCompile Include="..\..\renderer\ccGLStateCache.cpp" />
     <ClCompile Include="..\..\renderer\CCGroupCommand.cpp" />
     <ClCompile Include="..\..\renderer\CCMaterial.cpp" />
     <ClCompile Include="..\..\renderer\CCMeshCommand.cpp" />
@@ -1329,6 +1330,7 @@
     <ClInclude Include="..\..\renderer\CCGLProgramCache.h" />
     <ClInclude Include="..\..\renderer\CCGLProgramState.h" />
     <ClInclude Include="..\..\renderer\CCGLProgramStateCache.h" />
+    <ClInclude Include="..\..\renderer\ccGLStateCache.h" />
     <ClInclude Include="..\..\renderer\CCGroupCommand.h" />
     <ClInclude Include="..\..\renderer\CCMaterial.h" />
     <ClInclude Include="..\..\renderer\CCMeshCommand.h" />

--- a/cocos/2d/libcocos2d_win10/libcocos2d.vcxproj.filters
+++ b/cocos/2d/libcocos2d_win10/libcocos2d.vcxproj.filters
@@ -1581,6 +1581,9 @@
     <ClCompile Include="..\..\renderer\CCGLProgramStateCache.cpp">
       <Filter>renderer</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\renderer\ccGLStateCache.cpp">
+      <Filter>renderer</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\renderer\CCGroupCommand.cpp">
       <Filter>renderer</Filter>
     </ClCompile>
@@ -3477,6 +3480,9 @@
       <Filter>renderer</Filter>
     </ClInclude>
     <ClInclude Include="..\..\renderer\CCGLProgramStateCache.h">
+      <Filter>renderer</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\renderer\ccGLStateCache.h">
       <Filter>renderer</Filter>
     </ClInclude>
     <ClInclude Include="..\..\renderer\CCGroupCommand.h">

--- a/cocos/3d/CCMeshVertexIndexData.cpp
+++ b/cocos/3d/CCMeshVertexIndexData.cpp
@@ -40,6 +40,7 @@
 #include "base/CCEventDispatcher.h"
 #include "base/CCEventType.h"
 #include "base/CCDirector.h"
+#include "renderer/ccGLStateCache.h"
 
 
 using namespace std;

--- a/cocos/3d/CCMotionStreak3D.cpp
+++ b/cocos/3d/CCMotionStreak3D.cpp
@@ -28,8 +28,8 @@ THE SOFTWARE.
 #include "3d/CCMotionStreak3D.h"
 #include "math/CCVertex.h"
 #include "base/CCDirector.h"
-#include "base/ccUtils.h"
 #include "renderer/CCTextureCache.h"
+#include "renderer/ccGLStateCache.h"
 #include "renderer/CCTexture2D.h"
 #include "renderer/CCRenderer.h"
 #include "renderer/CCGLProgramState.h"
@@ -387,13 +387,10 @@ void MotionStreak3D::onDraw(const Mat4 &transform, uint32_t /*flags*/)
     getGLProgram()->use();
     getGLProgram()->setUniformsForBuiltins(transform);
 
-    glEnableVertexAttribArray(GLProgram::VERTEX_ATTRIB_POSITION);
-    glEnableVertexAttribArray(GLProgram::VERTEX_ATTRIB_TEX_COORD);
-    glEnableVertexAttribArray(GLProgram::VERTEX_ATTRIB_COLOR);
-    utils::setBlending(_blendFunc.src, _blendFunc.dst);
+    GL::enableVertexAttribs(GL::VERTEX_ATTRIB_FLAG_POS_COLOR_TEX );
+    GL::blendFunc( _blendFunc.src, _blendFunc.dst );
 
-    glActiveTexture(GL_TEXTURE0);
-    glBindTexture(GL_TEXTURE_2D, _texture->getName());
+    GL::bindTexture2D( _texture->getName() );
     
     glDisable(GL_CULL_FACE);
     RenderState::StateBlock::_defaultState->setCullFace(false);

--- a/cocos/3d/CCSkybox.cpp
+++ b/cocos/3d/CCSkybox.cpp
@@ -26,6 +26,7 @@
 #include "base/ccMacros.h"
 #include "base/CCConfiguration.h"
 #include "base/CCDirector.h"
+#include "renderer/ccGLStateCache.h"
 #include "renderer/CCGLProgram.h"
 #include "renderer/CCGLProgramCache.h"
 #include "renderer/CCGLProgramState.h"
@@ -56,7 +57,7 @@ Skybox::~Skybox()
     if (Configuration::getInstance()->supportsShareableVAO())
     {
         glDeleteVertexArrays(1, &_vao);
-        glBindVertexArray(0);
+        GL::bindVAO(0);
         _vao = 0;
     }
 
@@ -107,7 +108,7 @@ void Skybox::initBuffers()
     if (Configuration::getInstance()->supportsShareableVAO())
     {
         glGenVertexArrays(1, &_vao);
-        glBindVertexArray(_vao);
+        GL::bindVAO(_vao);
     }
 	// The skybox is rendered using a purpose-built shader which makes use of
 	// the shader language's inherent support for cubemaps. Hence there is no
@@ -152,7 +153,7 @@ void Skybox::initBuffers()
         glEnableVertexAttribArray(GLProgram::VERTEX_ATTRIB_POSITION);
         getGLProgramState()->applyAttributes(false);
 
-        glBindVertexArray(0);
+        GL::bindVAO(0);
     }
 }
 
@@ -200,11 +201,11 @@ void Skybox::onDraw(const Mat4& transform, uint32_t /*flags*/)
 
     if (Configuration::getInstance()->supportsShareableVAO())
     {
-        glBindVertexArray(_vao);
+        GL::bindVAO(_vao);
     }
     else
     {
-        glEnableVertexAttribArray(GLProgram::VERTEX_ATTRIB_POSITION);
+        GL::enableVertexAttribs(GL::VERTEX_ATTRIB_FLAG_POSITION);
 
         glBindBuffer(GL_ARRAY_BUFFER, _vertexBuffer);
         glVertexAttribPointer(GLProgram::VERTEX_ATTRIB_POSITION, 3, GL_FLOAT, GL_FALSE, sizeof(Vec3), nullptr);
@@ -216,7 +217,7 @@ void Skybox::onDraw(const Mat4& transform, uint32_t /*flags*/)
 
     if (Configuration::getInstance()->supportsShareableVAO())
     {
-        glBindVertexArray(0);
+        GL::bindVAO(0);
     }
     else
     {

--- a/cocos/3d/CCTerrain.cpp
+++ b/cocos/3d/CCTerrain.cpp
@@ -34,6 +34,8 @@ USING_NS_CC;
 #include "renderer/CCGLProgramState.h"
 #include "renderer/CCRenderer.h"
 #include "renderer/CCGLProgramStateCache.h"
+#include "renderer/ccGLStateCache.h"
+#include "renderer/CCRenderState.h"
 #include "base/CCDirector.h"
 #include "base/CCEventType.h"
 #include "2d/CCCamera.h"
@@ -148,26 +150,21 @@ void Terrain::onDraw(const Mat4 &transform, uint32_t /*flags*/)
 
     _stateBlock->bind();
 
-    glEnableVertexAttribArray(_positionLocation);
-    glEnableVertexAttribArray(_texcoordLocation);
-    glEnableVertexAttribArray(_normalLocation);
+    GL::enableVertexAttribs(1<<_positionLocation | 1 << _texcoordLocation | 1<<_normalLocation);
     glProgram->setUniformsForBuiltins(transform);
     _glProgramState->applyUniforms();
     glUniform3f(_lightDirLocation,_lightDir.x,_lightDir.y,_lightDir.z);
     if(!_alphaMap)
     {
-        glActiveTexture(GL_TEXTURE0);
-        glBindTexture(GL_TEXTURE_2D, _detailMapTextures[0]->getName());
+        GL::bindTexture2D(_detailMapTextures[0]->getName());
         //getGLProgramState()->setUniformTexture("")
         glUniform1i(_detailMapLocation[0],0);
         glUniform1i(_alphaIsHasAlphaMapLocation,0);
-    }
-    else
+    }else
     {
         for(int i =0;i<_maxDetailMapValue;++i)
         {
-            glActiveTexture(GL_TEXTURE0 + i);
-            glBindTexture(GL_TEXTURE_2D, _detailMapTextures[i]->getName());
+            GL::bindTexture2DN(i,_detailMapTextures[i]->getName());
             glUniform1i(_detailMapLocation[i],i);
 
             glUniform1f(_detailMapSizeLocation[i],_terrainData._detailMaps[i]._detailMapSize);
@@ -175,15 +172,13 @@ void Terrain::onDraw(const Mat4 &transform, uint32_t /*flags*/)
 
         glUniform1i(_alphaIsHasAlphaMapLocation,1);
 
-        glActiveTexture(GL_TEXTURE0 + 4);
-        glBindTexture(GL_TEXTURE_2D, _alphaMap->getName());
+        GL::bindTexture2DN(4, _alphaMap->getName());
         glUniform1i(_alphaMapLocation,4);
     }
     if (_lightMap)
     {
         glUniform1i(_lightMapCheckLocation, 1);
-        glActiveTexture(GL_TEXTURE0 + 5);
-        glBindTexture(GL_TEXTURE_2D, _lightMap->getName());
+        GL::bindTexture2DN(5, _lightMap->getName());
         glUniform1i(_lightMapLocation, 5);
     }else
     {

--- a/cocos/Android.mk
+++ b/cocos/Android.mk
@@ -185,6 +185,7 @@ renderer/CCTrianglesCommand.cpp \
 renderer/CCVertexAttribBinding.cpp \
 renderer/CCVertexIndexBuffer.cpp \
 renderer/CCVertexIndexData.cpp \
+renderer/ccGLStateCache.cpp \
 renderer/CCFrameBuffer.cpp \
 renderer/ccShaders.cpp \
 vr/CCVRDistortion.cpp \

--- a/cocos/base/CCDirector.cpp
+++ b/cocos/base/CCDirector.cpp
@@ -46,12 +46,12 @@ THE SOFTWARE.
 #include "renderer/CCGLProgramCache.h"
 #include "renderer/CCGLProgramStateCache.h"
 #include "renderer/CCTextureCache.h"
+#include "renderer/ccGLStateCache.h"
 #include "renderer/CCRenderer.h"
 #include "renderer/CCRenderState.h"
 #include "renderer/CCFrameBuffer.h"
 #include "2d/CCCamera.h"
 #include "base/CCUserDefault.h"
-#include "base/ccUtils.h"
 #include "base/ccFPSImages.h"
 #include "base/CCScheduler.h"
 #include "base/ccMacros.h"
@@ -683,6 +683,7 @@ void Director::setProjection(Projection projection)
     }
 
     _projection = projection;
+    GL::setProjectionMatrixDirty();
 
     _eventDispatcher->dispatchEvent(_eventProjectionChanged);
 }
@@ -713,11 +714,11 @@ void Director::setAlphaBlending(bool on)
 {
     if (on)
     {
-        utils::setBlending(CC_BLEND_SRC, CC_BLEND_DST);
+        GL::blendFunc(CC_BLEND_SRC, CC_BLEND_DST);
     }
     else
     {
-        utils::setBlending(GL_ONE, GL_ZERO);
+        GL::blendFunc(GL_ONE, GL_ZERO);
     }
 
     CHECK_GL_ERROR_DEBUG();
@@ -1099,7 +1100,9 @@ void Director::reset()
     
     // cocos2d-x specific data structures
     UserDefault::destroyInstance();
-    resetMatrixStack();
+    
+    GL::invalidateStateCache();
+
     RenderState::finalize();
     
     destroyTextureCache();

--- a/cocos/base/CCStencilStateManager.cpp
+++ b/cocos/base/CCStencilStateManager.cpp
@@ -27,6 +27,7 @@
 #include "base/CCStencilStateManager.h"
 #include "base/CCDirector.h"
 #include "renderer/CCGLProgramCache.h"
+#include "renderer/ccGLStateCache.h"
 #include "renderer/CCRenderer.h"
 #include "renderer/CCRenderState.h"
 #if (CC_TARGET_PLATFORM == CC_PLATFORM_MAC || CC_TARGET_PLATFORM == CC_PLATFORM_WIN32 || CC_TARGET_PLATFORM == CC_PLATFORM_LINUX)
@@ -88,7 +89,7 @@ void StencilStateManager::drawFullScreenQuadClearStencil()
     glProgram->setUniformLocationWith4fv(colorLocation, (GLfloat*) &color.r, 1);
     
     glBindBuffer(GL_ARRAY_BUFFER, 0);
-    glEnableVertexAttribArray(GLProgram::VERTEX_ATTRIB_POSITION);
+    GL::enableVertexAttribs( GL::VERTEX_ATTRIB_FLAG_POSITION );
     glVertexAttribPointer(GLProgram::VERTEX_ATTRIB_POSITION, 2, GL_FLOAT, GL_FALSE, 0, vertices);
     glDrawArrays(GL_TRIANGLE_FAN, 0, 4);
     

--- a/cocos/base/ccUtils.cpp
+++ b/cocos/base/ccUtils.cpp
@@ -37,7 +37,6 @@ THE SOFTWARE.
 #include "renderer/CCCustomCommand.h"
 #include "renderer/CCRenderer.h"
 #include "renderer/CCTextureCache.h"
-#include "renderer/CCRenderState.h"
 
 #include "platform/CCImage.h"
 #include "platform/CCFileUtils.h"
@@ -525,24 +524,6 @@ LanguageType getLanguageTypeByISO2(const char* code)
         ret = LanguageType::BELARUSIAN;
     }
     return ret;
-}
-
-void setBlending(GLenum sfactor, GLenum dfactor)
-{
-    if (sfactor == GL_ONE && dfactor == GL_ZERO)
-    {
-        glDisable(GL_BLEND);
-        RenderState::StateBlock::_defaultState->setBlend(false);
-    }
-    else
-    {
-        glEnable(GL_BLEND);
-        glBlendFunc(sfactor, dfactor);
-
-        RenderState::StateBlock::_defaultState->setBlend(true);
-        RenderState::StateBlock::_defaultState->setBlendSrc((RenderState::Blend)sfactor);
-        RenderState::StateBlock::_defaultState->setBlendDst((RenderState::Blend)dfactor);
-    }
 }
 
 }

--- a/cocos/base/ccUtils.cpp
+++ b/cocos/base/ccUtils.cpp
@@ -544,18 +544,6 @@ void setBlending(GLenum sfactor, GLenum dfactor)
         RenderState::StateBlock::_defaultState->setBlendDst((RenderState::Blend)dfactor);
     }
 }
-    
-void enableVertexAttributes(uint32_t flags)
-{
-    for (int i = 0; flags > 0; i++)
-    {
-        int flag = 1 << i;
-        if (flag & flags)
-            glEnableVertexAttribArray(i);
-        
-        flags &= ~flag;
-    }
-}
 
 }
 

--- a/cocos/base/ccUtils.h
+++ b/cocos/base/ccUtils.h
@@ -188,8 +188,6 @@ namespace utils
     * @lua NA
     */
     CC_DLL LanguageType getLanguageTypeByISO2(const char* code);
-
-    CC_DLL void setBlending(GLenum sfactor, GLenum dfactor);
 }
 
 NS_CC_END

--- a/cocos/base/ccUtils.h
+++ b/cocos/base/ccUtils.h
@@ -190,7 +190,6 @@ namespace utils
     CC_DLL LanguageType getLanguageTypeByISO2(const char* code);
 
     CC_DLL void setBlending(GLenum sfactor, GLenum dfactor);
-    CC_DLL void enableVertexAttributes(uint32_t flags);
 }
 
 NS_CC_END

--- a/cocos/cocos2d.h
+++ b/cocos/cocos2d.h
@@ -175,6 +175,7 @@ THE SOFTWARE.
 #include "renderer/CCVertexIndexBuffer.h"
 #include "renderer/CCVertexIndexData.h"
 #include "renderer/CCFrameBuffer.h"
+#include "renderer/ccGLStateCache.h"
 #include "renderer/ccShaders.h"
 
 // physics

--- a/cocos/deprecated/CCDeprecated.h
+++ b/cocos/deprecated/CCDeprecated.h
@@ -92,6 +92,7 @@
 #include "renderer/CCGLProgram.h"
 #include "renderer/CCGLProgramCache.h"
 #include "renderer/CCTextureAtlas.h"
+#include "renderer/ccGLStateCache.h"
 
 NS_CC_BEGIN
 
@@ -904,6 +905,12 @@ CC_DEPRECATED_ATTRIBUTE extern const char*    kCCAttributeNameColor;
 CC_DEPRECATED_ATTRIBUTE extern const char*    kCCAttributeNamePosition;
 CC_DEPRECATED_ATTRIBUTE extern const char*    kCCAttributeNameTexCoord;
 
+CC_DEPRECATED_ATTRIBUTE const int kCCVertexAttribFlag_None = GL::VERTEX_ATTRIB_FLAG_NONE;
+CC_DEPRECATED_ATTRIBUTE const int kCCVertexAttribFlag_Position = GL::VERTEX_ATTRIB_FLAG_POSITION;
+CC_DEPRECATED_ATTRIBUTE const int kCCVertexAttribFlag_Color = GL::VERTEX_ATTRIB_FLAG_COLOR;
+CC_DEPRECATED_ATTRIBUTE const int kCCVertexAttribFlag_TexCoords = GL::VERTEX_ATTRIB_FLAG_TEX_COORD;
+CC_DEPRECATED_ATTRIBUTE const int kCCVertexAttribFlag_PosColorTex = GL::VERTEX_ATTRIB_FLAG_POS_COLOR_TEX;
+
 CC_DEPRECATED_ATTRIBUTE const ProgressTimer::Type kCCProgressTimerTypeRadial = ProgressTimer::Type::RADIAL;
 CC_DEPRECATED_ATTRIBUTE const ProgressTimer::Type kCCProgressTimerTypeBar = ProgressTimer::Type::BAR;
 CC_DEPRECATED_ATTRIBUTE typedef ProgressTimer::Type ProgressTimerType;
@@ -1064,6 +1071,18 @@ CC_DEPRECATED_ATTRIBUTE void CC_DLL ccDrawColor4F( GLfloat r, GLfloat g, GLfloat
 CC_DEPRECATED_ATTRIBUTE void CC_DLL ccPointSize( GLfloat pointSize );
 
 
+CC_DEPRECATED_ATTRIBUTE inline void CC_DLL ccGLInvalidateStateCache() { GL::invalidateStateCache(); }
+CC_DEPRECATED_ATTRIBUTE inline void CC_DLL ccGLUseProgram(GLuint program) { GL::useProgram(program); }
+CC_DEPRECATED_ATTRIBUTE inline void CC_DLL ccGLDeleteProgram(GLuint program){ GL::deleteProgram(program); }
+CC_DEPRECATED_ATTRIBUTE inline void CC_DLL ccGLBlendFunc(GLenum sfactor, GLenum dfactor) { GL::blendFunc(sfactor, dfactor); }
+CC_DEPRECATED_ATTRIBUTE inline void CC_DLL ccGLBlendResetToCache() { GL::blendResetToCache(); }
+CC_DEPRECATED_ATTRIBUTE inline void CC_DLL ccSetProjectionMatrixDirty() { GL::setProjectionMatrixDirty(); }
+CC_DEPRECATED_ATTRIBUTE inline void CC_DLL ccGLEnableVertexAttribs(unsigned int flags) { GL::enableVertexAttribs(flags); }
+CC_DEPRECATED_ATTRIBUTE inline void CC_DLL ccGLBindTexture2D(GLuint textureId) { GL::bindTexture2D(textureId); }
+CC_DEPRECATED_ATTRIBUTE inline void CC_DLL ccGLBindTexture2DN(GLuint textureUnit, GLuint textureId) { GL::bindTexture2DN(textureUnit, textureId); }
+CC_DEPRECATED_ATTRIBUTE inline void CC_DLL ccGLDeleteTexture(GLuint textureId) { GL::deleteTexture(textureId); }
+CC_DEPRECATED_ATTRIBUTE inline void CC_DLL ccGLDeleteTextureN(GLuint textureUnit, GLuint textureId) { GL::deleteTexture(textureId); }
+CC_DEPRECATED_ATTRIBUTE inline void CC_DLL ccGLBindVAO(GLuint vaoId) { GL::bindVAO(vaoId); }
 CC_DEPRECATED_ATTRIBUTE inline void CC_DLL ccGLEnable( int flags ) { /* ignore */ };
 CC_DEPRECATED_ATTRIBUTE typedef int ccGLServerState;
 

--- a/cocos/editor-support/cocostudio/ActionTimeline/CCBoneNode.cpp
+++ b/cocos/editor-support/cocostudio/ActionTimeline/CCBoneNode.cpp
@@ -24,8 +24,8 @@ THE SOFTWARE.
 ****************************************************************************/
 
 #include "base/CCDirector.h"
-#include "base/ccUtils.h"
 #include "renderer/CCRenderer.h"
+#include "renderer/ccGLStateCache.h"
 #include "renderer/CCGLProgram.h"
 #include "renderer/CCGLProgramState.h"
 
@@ -485,14 +485,13 @@ void BoneNode::onDraw(const cocos2d::Mat4 &transform, uint32_t /*flags*/)
     getGLProgram()->use();
     getGLProgram()->setUniformsForBuiltins(transform);
 
-    glEnableVertexAttribArray(cocos2d::GLProgram::VERTEX_ATTRIB_POSITION);
-    glEnableVertexAttribArray(cocos2d::GLProgram::VERTEX_ATTRIB_COLOR);
+    cocos2d::GL::enableVertexAttribs(cocos2d::GL::VERTEX_ATTRIB_FLAG_POSITION | cocos2d::GL::VERTEX_ATTRIB_FLAG_COLOR);
 
     glBindBuffer(GL_ARRAY_BUFFER, 0);
     glVertexAttribPointer(cocos2d::GLProgram::VERTEX_ATTRIB_POSITION, 3, GL_FLOAT, GL_FALSE, 0, _noMVPVertices);
     glVertexAttribPointer(cocos2d::GLProgram::VERTEX_ATTRIB_COLOR, 4, GL_FLOAT, GL_FALSE, 0, _squareColors);
 
-    cocos2d::utils::setBlending(_blendFunc.src, _blendFunc.dst);
+    cocos2d::GL::blendFunc(_blendFunc.src, _blendFunc.dst);
 
     glDrawArrays(GL_TRIANGLE_FAN, 0, 4);
 

--- a/cocos/editor-support/cocostudio/ActionTimeline/CCSkeletonNode.cpp
+++ b/cocos/editor-support/cocostudio/ActionTimeline/CCSkeletonNode.cpp
@@ -27,9 +27,11 @@ THE SOFTWARE.
 #include "base/CCDirector.h"
 #include "math/TransformUtils.h"
 #include "renderer/CCRenderer.h"
+#include "renderer/ccGLStateCache.h"
 #include "renderer/CCGLProgramState.h"
-#include "base/ccUtils.h"
 #include <stack>
+
+using namespace cocos2d::GL;
 
 NS_TIMELINE_BEGIN
 
@@ -234,14 +236,13 @@ void SkeletonNode::batchDrawAllSubBones(const cocos2d::Mat4 &transform)
     getGLProgram()->use();
     getGLProgram()->setUniformsForBuiltins(transform);
 
-    glEnableVertexAttribArray(cocos2d::GLProgram::VERTEX_ATTRIB_POSITION);
-    glEnableVertexAttribArray(cocos2d::GLProgram::VERTEX_ATTRIB_COLOR);
+    cocos2d::GL::enableVertexAttribs(cocos2d::GL::VERTEX_ATTRIB_FLAG_POSITION | cocos2d::GL::VERTEX_ATTRIB_FLAG_COLOR);
 
     glBindBuffer(GL_ARRAY_BUFFER, 0);
     glVertexAttribPointer(cocos2d::GLProgram::VERTEX_ATTRIB_POSITION, 3, GL_FLOAT, GL_FALSE, 0, vetices);
     glVertexAttribPointer(cocos2d::GLProgram::VERTEX_ATTRIB_COLOR, 4, GL_FLOAT, GL_FALSE, 0, veticesColor);
 
-    cocos2d::utils::setBlending(_blendFunc.src, _blendFunc.dst);
+    cocos2d::GL::blendFunc(_blendFunc.src, _blendFunc.dst);
 
 #ifdef CC_STUDIO_ENABLED_VIEW
     glLineWidth(1);
@@ -268,14 +269,13 @@ void SkeletonNode::onDraw(const cocos2d::Mat4 &transform, uint32_t /*flags*/)
     getGLProgram()->use();
     getGLProgram()->setUniformsForBuiltins(transform);
 
-    glEnableVertexAttribArray(cocos2d::GLProgram::VERTEX_ATTRIB_POSITION);
-    glEnableVertexAttribArray(cocos2d::GLProgram::VERTEX_ATTRIB_COLOR);
+    cocos2d::GL::enableVertexAttribs(cocos2d::GL::VERTEX_ATTRIB_FLAG_POSITION | cocos2d::GL::VERTEX_ATTRIB_FLAG_COLOR);
 
     glBindBuffer(GL_ARRAY_BUFFER, 0);
     glVertexAttribPointer(cocos2d::GLProgram::VERTEX_ATTRIB_POSITION, 3, GL_FLOAT, GL_FALSE, 0, _noMVPVertices);
     glVertexAttribPointer(cocos2d::GLProgram::VERTEX_ATTRIB_COLOR, 4, GL_FLOAT, GL_FALSE, 0, _squareColors);
 
-    cocos2d::utils::setBlending(_blendFunc.src, _blendFunc.dst);
+    cocos2d::GL::blendFunc(_blendFunc.src, _blendFunc.dst);
 
     glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
     glDrawArrays(GL_TRIANGLE_STRIP, 4, 4);

--- a/cocos/editor-support/spine/SkeletonTwoColorBatch.cpp
+++ b/cocos/editor-support/spine/SkeletonTwoColorBatch.cpp
@@ -31,8 +31,6 @@
 #include <spine/extension.h>
 #include <algorithm>
 
-#include "base/ccUtils.h"
-
 USING_NS_CC;
 #define EVENT_AFTER_DRAW_RESET_POSITION "director_after_draw"
 using std::max;
@@ -92,17 +90,14 @@ void TwoColorTrianglesCommand::generateMaterialID() {
 
 void TwoColorTrianglesCommand::useMaterial() const {
 	//Set texture
-    glActiveTexture(GL_TEXTURE0);
-    glBindTexture(GL_TEXTURE_2D, _textureID);
+	GL::bindTexture2D(_textureID);
 	
-	if (_alphaTextureID > 0)
-    {
+	if (_alphaTextureID > 0) {
 		// ANDROID ETC1 ALPHA supports.
-        glActiveTexture(GL_TEXTURE0 + 1);
-        glBindTexture(GL_TEXTURE_2D, _alphaTextureID);
+		GL::bindTexture2DN(1, _alphaTextureID);
 	}
 	//set blend mode
-    cocos2d::utils::setBlending(_blendType.src, _blendType.dst);
+	GL::blendFunc(_blendType.src, _blendType.dst);
 	
 	_glProgramState->apply(_mv);
 }

--- a/cocos/navmesh/CCNavMeshDebugDraw.cpp
+++ b/cocos/navmesh/CCNavMeshDebugDraw.cpp
@@ -26,6 +26,7 @@
 #if CC_USE_NAVMESH
 
 #include "renderer/CCGLProgramCache.h"
+#include "renderer/ccGLStateCache.h"
 #include "renderer/CCRenderer.h"
 #include "renderer/CCRenderState.h"
 #include "base/CCDirector.h"
@@ -140,8 +141,7 @@ void NavMeshDebugDraw::drawImplement(const cocos2d::Mat4& transform, uint32_t /*
     _program->setUniformsForBuiltins(transform);
 
     glBindBuffer(GL_ARRAY_BUFFER, _vbo);
-    glEnableVertexAttribArray(GLProgram::VERTEX_ATTRIB_POSITION);
-    glEnableVertexAttribArray(GLProgram::VERTEX_ATTRIB_COLOR);
+    GL::enableVertexAttribs(GL::VERTEX_ATTRIB_FLAG_POSITION | GL::VERTEX_ATTRIB_FLAG_COLOR);
     glVertexAttribPointer(GLProgram::VERTEX_ATTRIB_POSITION, 3, GL_FLOAT, GL_FALSE, sizeof(V3F_C4F), (GLvoid *)offsetof(V3F_C4F, position));
     glVertexAttribPointer(GLProgram::VERTEX_ATTRIB_COLOR, 4, GL_FLOAT, GL_FALSE, sizeof(V3F_C4F), (GLvoid *)offsetof(V3F_C4F, color));
     if (_dirtyBuffer){

--- a/cocos/physics3d/CCPhysics3DDebugDrawer.cpp
+++ b/cocos/physics3d/CCPhysics3DDebugDrawer.cpp
@@ -27,10 +27,10 @@
 #include "base/CCConfiguration.h"
 #include "base/ccMacros.h"
 #include "base/CCDirector.h"
-#include "base/ccUtils.h"
 #include "renderer/CCGLProgram.h"
 #include "renderer/CCRenderer.h"
 #include "renderer/CCRenderState.h"
+#include "renderer/ccGLStateCache.h"
 #include "renderer/CCGLProgramCache.h"
 
 #if CC_USE_3D_PHYSICS
@@ -134,7 +134,7 @@ void Physics3DDebugDrawer::drawImplementation( const Mat4 &transform, uint32_t /
     _program->setUniformsForBuiltins(transform);
     glEnable(GL_DEPTH_TEST);
 
-    utils::setBlending(_blendFunc.src, _blendFunc.dst);
+    GL::blendFunc(_blendFunc.src, _blendFunc.dst);
 
     if (_dirty)
     {
@@ -144,12 +144,11 @@ void Physics3DDebugDrawer::drawImplementation( const Mat4 &transform, uint32_t /
     }
     if (Configuration::getInstance()->supportsShareableVAO())
     {
-        glBindVertexArray(_vao);
+        GL::bindVAO(_vao);
     }
     else
     {
-        glEnableVertexAttribArray(GLProgram::VERTEX_ATTRIB_POSITION);
-        glEnableVertexAttribArray(GLProgram::VERTEX_ATTRIB_COLOR);
+        GL::enableVertexAttribs(GL::VERTEX_ATTRIB_FLAG_POSITION | GL::VERTEX_ATTRIB_FLAG_COLOR);
 
         glBindBuffer(GL_ARRAY_BUFFER, _vbo);
         // vertex
@@ -176,7 +175,7 @@ void Physics3DDebugDrawer::init()
     if (Configuration::getInstance()->supportsShareableVAO())
     {
         glGenVertexArrays(1, &_vao);
-        glBindVertexArray(_vao);
+        GL::bindVAO(_vao);
     }
 
     glGenBuffers(1, &_vbo);
@@ -193,7 +192,7 @@ void Physics3DDebugDrawer::init()
 
     if (Configuration::getInstance()->supportsShareableVAO())
     {
-        glBindVertexArray(0);
+        GL::bindVAO(0);
     }
 }
 

--- a/cocos/platform/android/javaactivity-android.cpp
+++ b/cocos/platform/android/javaactivity-android.cpp
@@ -34,6 +34,7 @@ THE SOFTWARE.
 #include "base/CCEventDispatcher.h"
 #include "renderer/CCGLProgramCache.h"
 #include "renderer/CCTextureCache.h"
+#include "renderer/ccGLStateCache.h"
 #include "2d/CCDrawingPrimitives.h"
 #include "platform/android/jni/JniHelper.h"
 #include "network/CCDownloader-android.h"
@@ -97,7 +98,7 @@ JNIEXPORT void Java_org_cocos2dx_lib_Cocos2dxRenderer_nativeInit(JNIEnv*  env, j
     }
     else
     {
-        cocos2d::Director::getInstance()->resetMatrixStack();
+        cocos2d::GL::invalidateStateCache();
         cocos2d::GLProgramCache::getInstance()->reloadDefaultGLPrograms();
         cocos2d::DrawPrimitives::init();
         cocos2d::VolatileTextureMgr::reloadAllTextures();

--- a/cocos/renderer/CCBatchCommand.cpp
+++ b/cocos/renderer/CCBatchCommand.cpp
@@ -25,10 +25,10 @@
 
 
 #include "renderer/CCBatchCommand.h"
+#include "renderer/ccGLStateCache.h"
 #include "renderer/CCTextureAtlas.h"
 #include "renderer/CCTexture2D.h"
 #include "renderer/CCGLProgram.h"
-#include "base/ccUtils.h"
 
 NS_CC_BEGIN
 
@@ -70,9 +70,8 @@ void BatchCommand::execute()
     // Set material
     _shader->use();
     _shader->setUniformsForBuiltins(_mv);
-    glActiveTexture(GL_TEXTURE0);
-    glBindTexture(GL_TEXTURE_2D, _textureID);
-    utils::setBlending(_blendType.src, _blendType.dst);
+    GL::bindTexture2D(_textureID);
+    GL::blendFunc(_blendType.src, _blendType.dst);
 
     // Draw
     _textureAtlas->drawQuads();

--- a/cocos/renderer/CCGLProgram.cpp
+++ b/cocos/renderer/CCGLProgram.cpp
@@ -35,6 +35,7 @@ THE SOFTWARE.
 
 #include "base/CCDirector.h"
 #include "base/ccUTF8.h"
+#include "renderer/ccGLStateCache.h"
 #include "platform/CCFileUtils.h"
 
 // helper functions
@@ -232,7 +233,7 @@ GLProgram::~GLProgram()
 
     if (_program)
     {
-        glDeleteProgram(_program);
+        GL::deleteProgram(_program);
     }
 
 
@@ -617,7 +618,7 @@ bool GLProgram::link()
     if (status == GL_FALSE)
     {
         CCLOG("cocos2d: ERROR: Failed to link program: %i", _program);
-        glDeleteProgram(_program);
+        GL::deleteProgram(_program);
         _program = 0;
     }
     else
@@ -633,7 +634,7 @@ bool GLProgram::link()
 
 void GLProgram::use()
 {
-    glUseProgram(_program);
+    GL::useProgram(_program);
 }
 
 static std::string logForOpenGLShader(GLuint shader)

--- a/cocos/renderer/CCGLProgramState.cpp
+++ b/cocos/renderer/CCGLProgramState.cpp
@@ -32,6 +32,7 @@ THE SOFTWARE.
 #include "renderer/CCGLProgram.h"
 #include "renderer/CCGLProgramStateCache.h"
 #include "renderer/CCGLProgramCache.h"
+#include "renderer/ccGLStateCache.h"
 #include "renderer/CCTexture2D.h"
 #include "base/CCEventCustom.h"
 #include "base/CCEventListenerCustom.h"
@@ -116,14 +117,12 @@ void UniformValue::apply()
         switch (_uniform->type) {
             case GL_SAMPLER_2D:
                 _glprogram->setUniformLocationWith1i(_uniform->location, _value.tex.textureUnit);
-                glActiveTexture(GL_TEXTURE0 + _value.tex.textureUnit);
-                glBindTexture(GL_TEXTURE_2D, _value.tex.textureId);
+                GL::bindTexture2DN(_value.tex.textureUnit, _value.tex.textureId);
                 break;
 
             case GL_SAMPLER_CUBE:
                 _glprogram->setUniformLocationWith1i(_uniform->location, _value.tex.textureUnit);
-                glActiveTexture(GL_TEXTURE0 + _value.tex.textureUnit);
-                glBindTexture(GL_TEXTURE_CUBE_MAP, _value.tex.textureId);
+                GL::bindTextureN(_value.tex.textureUnit, _value.tex.textureId, GL_TEXTURE_CUBE_MAP);
                 break;
 
             case GL_INT:
@@ -572,17 +571,7 @@ void GLProgramState::applyAttributes(bool applyAttribFlags)
     if(_vertexAttribsFlags) {
         // enable/disable vertex attribs
         if (applyAttribFlags)
-        {
-            auto flags = _vertexAttribsFlags;
-            for (int i = 0; flags > 0; i++)
-            {
-                int flag = 1 << i;
-                if (flag & flags)
-                    glEnableVertexAttribArray(i);
-                
-                flags &= ~flag;
-            }
-        }
+            GL::enableVertexAttribs(_vertexAttribsFlags);
         // set attributes
         for(auto &attribute : _attributes)
         {

--- a/cocos/renderer/CCMeshCommand.cpp
+++ b/cocos/renderer/CCMeshCommand.cpp
@@ -32,6 +32,7 @@
 #include "base/CCEventDispatcher.h"
 #include "base/CCEventType.h"
 #include "2d/CCLight.h"
+#include "renderer/ccGLStateCache.h"
 #include "renderer/CCGLProgramState.h"
 #include "renderer/CCRenderer.h"
 #include "renderer/CCTextureAtlas.h"
@@ -166,8 +167,7 @@ void MeshCommand::applyRenderState()
     CCASSERT(_stateBlock, "StateBlock must be non null");
 
     // blend and texture
-    glActiveTexture(GL_TEXTURE0);
-    glBindTexture(GL_TEXTURE_2D, _textureID);
+    GL::bindTexture2D(_textureID);
 
     _stateBlock->bind();
 }
@@ -198,7 +198,7 @@ void MeshCommand::preBatchDraw()
             buildVAO();
         if (_vao)
         {
-            glBindVertexArray(_vao);
+            GL::bindVAO(_vao);
         }
         else
         {
@@ -247,7 +247,7 @@ void MeshCommand::postBatchDraw()
     {
         if (_vao)
         {
-            glBindVertexArray(0);
+            GL::bindVAO(0);
         }
         else
         {
@@ -305,7 +305,7 @@ void MeshCommand::buildVAO()
 
     releaseVAO();
     glGenVertexArrays(1, &_vao);
-    glBindVertexArray(_vao);
+    GL::bindVAO(_vao);
     glBindBuffer(GL_ARRAY_BUFFER, _vertexBuffer);
     auto flags = programState->getVertexAttribsFlags();
     for (int i = 0; flags > 0; i++) {
@@ -318,7 +318,7 @@ void MeshCommand::buildVAO()
     
     glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, _indexBuffer);
     
-    glBindVertexArray(0);
+    GL::bindVAO(0);
     glBindBuffer(GL_ARRAY_BUFFER, 0);
     glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
 }
@@ -328,7 +328,7 @@ void MeshCommand::releaseVAO()
     {
         glDeleteVertexArrays(1, &_vao);
         _vao = 0;
-        glBindVertexArray(0);
+        GL::bindVAO(0);
     }
 }
 

--- a/cocos/renderer/CCPass.cpp
+++ b/cocos/renderer/CCPass.cpp
@@ -32,6 +32,7 @@
 #include "renderer/CCGLProgramState.h"
 #include "renderer/CCGLProgram.h"
 #include "renderer/CCTexture2D.h"
+#include "renderer/ccGLStateCache.h"
 #include "renderer/CCTechnique.h"
 #include "renderer/CCMaterial.h"
 #include "renderer/CCVertexAttribBinding.h"

--- a/cocos/renderer/CCPrimitiveCommand.cpp
+++ b/cocos/renderer/CCPrimitiveCommand.cpp
@@ -25,10 +25,10 @@
 
 #include "renderer/CCPrimitiveCommand.h"
 
+#include "renderer/ccGLStateCache.h"
 #include "renderer/CCGLProgram.h"
 #include "renderer/CCGLProgramState.h"
 #include "renderer/CCRenderer.h"
-#include "base/ccUtils.h"
 
 #include "base/CCDirector.h"
 
@@ -77,11 +77,10 @@ void PrimitiveCommand::init(float globalOrder, GLuint textureID, GLProgramState*
 void PrimitiveCommand::execute() const
 {
     //Set texture
-    glActiveTexture(GL_TEXTURE0);
-    glBindTexture(GL_TEXTURE_2D, _textureID);
+    GL::bindTexture2D(_textureID);
     
     //set blend mode
-    utils::setBlending(_blendType.src, _blendType.dst);
+    GL::blendFunc(_blendType.src, _blendType.dst);
     
     _glProgramState->apply(_mv);
     

--- a/cocos/renderer/CCQuadCommand.cpp
+++ b/cocos/renderer/CCQuadCommand.cpp
@@ -26,6 +26,7 @@
 
 #include "renderer/CCQuadCommand.h"
 
+#include "renderer/ccGLStateCache.h"
 #include "renderer/CCGLProgram.h"
 #include "renderer/CCMaterial.h"
 #include "renderer/CCTechnique.h"

--- a/cocos/renderer/CCRenderState.cpp
+++ b/cocos/renderer/CCRenderState.cpp
@@ -31,7 +31,8 @@
 
 #include "renderer/CCTexture2D.h"
 #include "renderer/CCPass.h"
-#include "base/ccUtils.h"
+#include "renderer/ccGLStateCache.h"
+
 
 NS_CC_BEGIN
 
@@ -104,11 +105,7 @@ void RenderState::bind(Pass* pass)
     CC_ASSERT(pass);
 
     if (_texture)
-    {
-        glActiveTexture(GL_TEXTURE0);
-        glBindTexture(GL_TEXTURE_2D, _texture->getName());
-    }
-    
+        GL::bindTexture2D(_texture->getName());
 
     // Get the combined modified state bits for our RenderState hierarchy.
     long stateOverrideBits = _state ? _state->_bits : 0;
@@ -249,7 +246,7 @@ void RenderState::StateBlock::bindNoRestore()
     }
     if ((_bits & RS_BLEND_FUNC) && (_blendSrc != _defaultState->_blendSrc || _blendDst != _defaultState->_blendDst))
     {
-        utils::setBlending((GLenum)_blendSrc, (GLenum)_blendDst);
+        GL::blendFunc((GLenum)_blendSrc, (GLenum)_blendDst);
         _defaultState->_blendSrc = _blendSrc;
         _defaultState->_blendDst = _blendDst;
     }
@@ -344,7 +341,7 @@ void RenderState::StateBlock::restore(long stateOverrideBits)
     }
     if (!(stateOverrideBits & RS_BLEND_FUNC) && (_defaultState->_bits & RS_BLEND_FUNC))
     {
-        utils::setBlending(GL_ONE, GL_ZERO);
+        GL::blendFunc(GL_ONE, GL_ZERO);
         _defaultState->_bits &= ~RS_BLEND_FUNC;
         _defaultState->_blendSrc = RenderState::BLEND_ONE;
         _defaultState->_blendDst = RenderState::BLEND_ZERO;

--- a/cocos/renderer/CCRenderer.cpp
+++ b/cocos/renderer/CCRenderer.cpp
@@ -38,6 +38,7 @@
 #include "renderer/CCTechnique.h"
 #include "renderer/CCPass.h"
 #include "renderer/CCRenderState.h"
+#include "renderer/ccGLStateCache.h"
 
 #include "base/CCConfiguration.h"
 #include "base/CCDirector.h"
@@ -237,7 +238,7 @@ Renderer::~Renderer()
     if (Configuration::getInstance()->supportsShareableVAO())
     {
         glDeleteVertexArrays(1, &_buffersVAO);
-        glBindVertexArray(0);
+        GL::bindVAO(0);
     }
 #if CC_ENABLE_CACHE_TEXTURE_DATA
     Director::getInstance()->getEventDispatcher()->removeEventListener(_cacheTextureListener);
@@ -276,7 +277,7 @@ void Renderer::setupVBOAndVAO()
 {
     //generate vbo and vao for trianglesCommand
     glGenVertexArrays(1, &_buffersVAO);
-    glBindVertexArray(_buffersVAO);
+    GL::bindVAO(_buffersVAO);
 
     glGenBuffers(2, &_buffersVBO[0]);
 
@@ -306,7 +307,7 @@ void Renderer::setupVBOAndVAO()
     glBufferData(GL_ELEMENT_ARRAY_BUFFER, sizeof(_indices[0]) * INDEX_VBO_SIZE, _indices, GL_STATIC_DRAW);
 
     // Must unbind the VAO before changing the element buffer.
-    glBindVertexArray(0);
+    GL::bindVAO(0);
     glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
     glBindBuffer(GL_ARRAY_BUFFER, 0);
 
@@ -329,7 +330,7 @@ void Renderer::setupVBO()
 void Renderer::mapBuffers()
 {
     // Avoid changing the element buffer for whatever VAO might be bound.
-    glBindVertexArray(0);
+    GL::bindVAO(0);
 
     glBindBuffer(GL_ARRAY_BUFFER, _buffersVBO[0]);
     glBufferData(GL_ARRAY_BUFFER, sizeof(_verts[0]) * VBO_SIZE, _verts, GL_DYNAMIC_DRAW);
@@ -793,7 +794,7 @@ void Renderer::drawBatchedTriangles()
     if (conf->supportsShareableVAO() && conf->supportsMapBuffer())
     {
         //Bind VAO
-        glBindVertexArray(_buffersVAO);
+        GL::bindVAO(_buffersVAO);
         //Set VBO data
         glBindBuffer(GL_ARRAY_BUFFER, _buffersVBO[0]);
 
@@ -825,9 +826,7 @@ void Renderer::drawBatchedTriangles()
 
         glBufferData(GL_ARRAY_BUFFER, sizeof(_verts[0]) * _filledVertex , _verts, GL_DYNAMIC_DRAW);
 
-        glEnableVertexAttribArray(GLProgram::VERTEX_ATTRIB_POSITION);
-        glEnableVertexAttribArray(GLProgram::VERTEX_ATTRIB_COLOR);
-        glEnableVertexAttribArray(GLProgram::VERTEX_ATTRIB_TEX_COORD);
+        GL::enableVertexAttribs(GL::VERTEX_ATTRIB_FLAG_POS_COLOR_TEX);
 
         // vertices
         glVertexAttribPointer(GLProgram::VERTEX_ATTRIB_POSITION, 3, GL_FLOAT, GL_FALSE, kQuadSize, (GLvoid*) offsetof(V3F_C4B_T2F, vertices));
@@ -856,7 +855,7 @@ void Renderer::drawBatchedTriangles()
     if (conf->supportsShareableVAO() && conf->supportsMapBuffer())
     {
         //Unbind VAO
-        glBindVertexArray(0);
+        GL::bindVAO(0);
     }
     else
     {

--- a/cocos/renderer/CCTexture2D.cpp
+++ b/cocos/renderer/CCTexture2D.cpp
@@ -45,6 +45,7 @@ THE SOFTWARE.
 #include "platform/CCPlatformMacros.h"
 #include "base/CCDirector.h"
 #include "renderer/CCGLProgram.h"
+#include "renderer/ccGLStateCache.h"
 #include "renderer/CCGLProgramCache.h"
 #include "base/CCNinePatchImageParser.h"
 
@@ -463,7 +464,7 @@ Texture2D::~Texture2D()
 
     if(_name)
     {
-        glDeleteTextures(1, &_name);
+        GL::deleteTexture(_name);
     }
 }
 
@@ -471,7 +472,7 @@ void Texture2D::releaseGLTexture()
 {
     if(_name)
     {
-        glDeleteTextures(1, &_name);
+        GL::deleteTexture(_name);
     }
     _name = 0;
 }
@@ -625,13 +626,12 @@ bool Texture2D::initWithMipmaps(MipmapInfo* mipmaps, int mipmapsNum, PixelFormat
 
     if(_name != 0)
     {
-        glDeleteTextures(1, &_name);
+        GL::deleteTexture(_name);
         _name = 0;
     }
 
     glGenTextures(1, &_name);
-    glActiveTexture(GL_TEXTURE0);
-    glBindTexture(GL_TEXTURE_2D, _name);
+    GL::bindTexture2D(_name);
 
     if (mipmapsNum == 1)
     {
@@ -718,8 +718,7 @@ bool Texture2D::updateWithData(const void *data,int offsetX,int offsetY,int widt
 {
     if (_name)
     {
-        glActiveTexture(GL_TEXTURE0);
-        glBindTexture(GL_TEXTURE_2D, _name);
+        GL::bindTexture2D(_name);
         const PixelFormatInfo& info = _pixelFormatInfoTables.at(_pixelFormat);
         glTexSubImage2D(GL_TEXTURE_2D,0,offsetX,offsetY,width,height,info.format, info.type,data);
 
@@ -1191,13 +1190,12 @@ void Texture2D::drawAtPoint(const Vec2& point)
         point.x,            height  + point.y,
         width + point.x,    height  + point.y };
 
-    glEnableVertexAttribArray(GLProgram::VERTEX_ATTRIB_POSITION);
-    glEnableVertexAttribArray(GLProgram::VERTEX_ATTRIB_TEX_COORD);
+    GL::enableVertexAttribs( GL::VERTEX_ATTRIB_FLAG_POSITION | GL::VERTEX_ATTRIB_FLAG_TEX_COORD );
     _shaderProgram->use();
     _shaderProgram->setUniformsForBuiltins();
 
-    glActiveTexture(GL_TEXTURE0);
-    glBindTexture(GL_TEXTURE_2D, _name);
+    GL::bindTexture2D( _name );
+
 
     glVertexAttribPointer(GLProgram::VERTEX_ATTRIB_POSITION, 2, GL_FLOAT, GL_FALSE, 0, vertices);
     glVertexAttribPointer(GLProgram::VERTEX_ATTRIB_TEX_COORD, 2, GL_FLOAT, GL_FALSE, 0, coordinates);
@@ -1218,13 +1216,11 @@ void Texture2D::drawInRect(const Rect& rect)
         rect.origin.x,                            rect.origin.y + rect.size.height,        /*0.0f,*/
         rect.origin.x + rect.size.width,        rect.origin.y + rect.size.height,        /*0.0f*/ };
 
-    glEnableVertexAttribArray(GLProgram::VERTEX_ATTRIB_POSITION);
-    glEnableVertexAttribArray(GLProgram::VERTEX_ATTRIB_TEX_COORD);
+    GL::enableVertexAttribs( GL::VERTEX_ATTRIB_FLAG_POSITION | GL::VERTEX_ATTRIB_FLAG_TEX_COORD );
     _shaderProgram->use();
     _shaderProgram->setUniformsForBuiltins();
 
-    glActiveTexture(GL_TEXTURE0);
-    glBindTexture(GL_TEXTURE_2D, _name);
+    GL::bindTexture2D( _name );
 
     glVertexAttribPointer(GLProgram::VERTEX_ATTRIB_POSITION, 2, GL_FLOAT, GL_FALSE, 0, vertices);
     glVertexAttribPointer(GLProgram::VERTEX_ATTRIB_TEX_COORD, 2, GL_FLOAT, GL_FALSE, 0, coordinates);
@@ -1245,8 +1241,7 @@ void Texture2D::PVRImagesHavePremultipliedAlpha(bool haveAlphaPremultiplied)
 void Texture2D::generateMipmap()
 {
     CCASSERT(_pixelsWide == ccNextPOT(_pixelsWide) && _pixelsHigh == ccNextPOT(_pixelsHigh), "Mipmap texture only works in POT textures");
-    glActiveTexture(GL_TEXTURE0);
-    glBindTexture(GL_TEXTURE_2D, _name);
+    GL::bindTexture2D( _name );
     glGenerateMipmap(GL_TEXTURE_2D);
     _hasMipmaps = true;
 #if CC_ENABLE_CACHE_TEXTURE_DATA
@@ -1265,8 +1260,7 @@ void Texture2D::setTexParameters(const TexParams &texParams)
         (_pixelsHigh == ccNextPOT(_pixelsHigh) || texParams.wrapT == GL_CLAMP_TO_EDGE),
         "GL_CLAMP_TO_EDGE should be used in NPOT dimensions");
 
-    glActiveTexture(GL_TEXTURE0);
-    glBindTexture(GL_TEXTURE_2D, _name);
+    GL::bindTexture2D( _name );
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, texParams.minFilter );
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, texParams.magFilter );
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, texParams.wrapS );
@@ -1291,8 +1285,7 @@ void Texture2D::setAliasTexParameters()
         return;
     }
 
-    glActiveTexture(GL_TEXTURE0);
-    glBindTexture(GL_TEXTURE_2D, _name);
+    GL::bindTexture2D( _name );
 
     if( ! _hasMipmaps )
     {
@@ -1324,8 +1317,7 @@ void Texture2D::setAntiAliasTexParameters()
         return;
     }
 
-    glActiveTexture(GL_TEXTURE0);
-    glBindTexture(GL_TEXTURE_2D, _name);
+    GL::bindTexture2D( _name );
 
     if( ! _hasMipmaps )
     {

--- a/cocos/renderer/CCTextureAtlas.cpp
+++ b/cocos/renderer/CCTextureAtlas.cpp
@@ -39,6 +39,7 @@ THE SOFTWARE.
 #include "base/CCEventListenerCustom.h"
 #include "renderer/CCTextureCache.h"
 #include "renderer/CCGLProgram.h"
+#include "renderer/ccGLStateCache.h"
 #include "renderer/CCRenderer.h"
 #include "renderer/CCTexture2D.h"
 #include "platform/CCGL.h"
@@ -71,7 +72,7 @@ TextureAtlas::~TextureAtlas()
     if (Configuration::getInstance()->supportsShareableVAO())
     {
         glDeleteVertexArrays(1, &_VAOname);
-        glBindVertexArray(0);
+        GL::bindVAO(0);
     }
     CC_SAFE_RELEASE(_texture);
     
@@ -255,7 +256,7 @@ void TextureAtlas::setupIndices()
 void TextureAtlas::setupVBOandVAO()
 {
     glGenVertexArrays(1, &_VAOname);
-    glBindVertexArray(_VAOname);
+    GL::bindVAO(_VAOname);
 
 #define kQuadSize sizeof(_quads[0].bl)
 
@@ -280,7 +281,7 @@ void TextureAtlas::setupVBOandVAO()
     glBufferData(GL_ELEMENT_ARRAY_BUFFER, sizeof(_indices[0]) * _capacity * 6, _indices, GL_STATIC_DRAW);
 
     // Must unbind the VAO before changing the element buffer.
-    glBindVertexArray(0);
+    GL::bindVAO(0);
     glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
     glBindBuffer(GL_ARRAY_BUFFER, 0);
 
@@ -297,7 +298,7 @@ void TextureAtlas::setupVBO()
 void TextureAtlas::mapBuffers()
 {
     // Avoid changing the element buffer for whatever VAO might be bound.
-    glBindVertexArray(0);
+	GL::bindVAO(0);
     
     glBindBuffer(GL_ARRAY_BUFFER, _buffersVBO[0]);
     glBufferData(GL_ARRAY_BUFFER, sizeof(_quads[0]) * _capacity, _quads, GL_DYNAMIC_DRAW);
@@ -612,8 +613,7 @@ void TextureAtlas::drawNumberOfQuads(ssize_t numberOfQuads, ssize_t start)
     if(!numberOfQuads)
         return;
     
-    glActiveTexture(GL_TEXTURE0);
-    glBindTexture(GL_TEXTURE_2D, _texture->getName());
+    GL::bindTexture2D(_texture);
 
     auto conf = Configuration::getInstance();
     if (conf->supportsShareableVAO() && conf->supportsMapBuffer())
@@ -643,7 +643,7 @@ void TextureAtlas::drawNumberOfQuads(ssize_t numberOfQuads, ssize_t start)
             _dirty = false;
         }
 
-        glBindVertexArray(_VAOname);
+        GL::bindVAO(_VAOname);
 
 #if CC_REBIND_INDICES_BUFFER
         glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, _buffersVBO[1]);
@@ -651,7 +651,7 @@ void TextureAtlas::drawNumberOfQuads(ssize_t numberOfQuads, ssize_t start)
 
         glDrawElements(GL_TRIANGLES, (GLsizei) numberOfQuads*6, GL_UNSIGNED_SHORT, (GLvoid*) (start*6*sizeof(_indices[0])) );
         
-        glBindVertexArray(0);
+        GL::bindVAO(0);
         
 #if CC_REBIND_INDICES_BUFFER
         glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
@@ -675,9 +675,7 @@ void TextureAtlas::drawNumberOfQuads(ssize_t numberOfQuads, ssize_t start)
             _dirty = false;
         }
 
-        glEnableVertexAttribArray(GLProgram::VERTEX_ATTRIB_POSITION);
-        glEnableVertexAttribArray(GLProgram::VERTEX_ATTRIB_COLOR);
-        glEnableVertexAttribArray(GLProgram::VERTEX_ATTRIB_TEX_COORD);
+        GL::enableVertexAttribs(GL::VERTEX_ATTRIB_FLAG_POS_COLOR_TEX);
 
         // vertices
         glVertexAttribPointer(GLProgram::VERTEX_ATTRIB_POSITION, 3, GL_FLOAT, GL_FALSE, kQuadSize, (GLvoid*) offsetof(V3F_C4B_T2F, vertices));

--- a/cocos/renderer/CCTextureAtlas.cpp
+++ b/cocos/renderer/CCTextureAtlas.cpp
@@ -614,12 +614,6 @@ void TextureAtlas::drawNumberOfQuads(ssize_t numberOfQuads, ssize_t start)
     
     glActiveTexture(GL_TEXTURE0);
     glBindTexture(GL_TEXTURE_2D, _texture->getName());
-    auto alphaTexID = _texture->getAlphaTextureName();
-    if (alphaTexID > 0)
-    {
-        glActiveTexture(GL_TEXTURE0 + 1);
-        glBindTexture(GL_TEXTURE_2D, alphaTexID);
-    }
 
     auto conf = Configuration::getInstance();
     if (conf->supportsShareableVAO() && conf->supportsMapBuffer())

--- a/cocos/renderer/CCTextureCube.cpp
+++ b/cocos/renderer/CCTextureCube.cpp
@@ -27,6 +27,8 @@
 #include "platform/CCImage.h"
 #include "platform/CCFileUtils.h"
 
+#include "renderer/ccGLStateCache.h"
+
 NS_CC_BEGIN
 
 unsigned char* getImageData(Image* img, Texture2D::PixelFormat&  ePixFmt)
@@ -191,8 +193,7 @@ bool TextureCube::init(const std::string& positive_x, const std::string& negativ
     GLuint handle;
     glGenTextures(1, &handle);
 
-    glActiveTexture(GL_TEXTURE0);
-    glBindTexture(GL_TEXTURE_CUBE_MAP, handle);
+    GL::bindTextureN(0, handle, GL_TEXTURE_CUBE_MAP);
 
     for (int i = 0; i < 6; i++)
     {
@@ -236,8 +237,7 @@ bool TextureCube::init(const std::string& positive_x, const std::string& negativ
 
     _name = handle;
 
-    glActiveTexture(GL_TEXTURE0);
-    glBindTexture(GL_TEXTURE_CUBE_MAP, 0);
+    GL::bindTextureN(0, 0, GL_TEXTURE_CUBE_MAP);
 
     for (auto img: images)
     {
@@ -251,16 +251,14 @@ void TextureCube::setTexParameters(const TexParams& texParams)
 {
     CCASSERT(_name != 0, __FUNCTION__);
 
-    glActiveTexture(GL_TEXTURE0);
-    glBindTexture(GL_TEXTURE_CUBE_MAP, _name);
+    GL::bindTextureN(0, _name, GL_TEXTURE_CUBE_MAP);
 
     glTexParameteri(GL_TEXTURE_CUBE_MAP, GL_TEXTURE_MIN_FILTER, texParams.minFilter);
     glTexParameteri(GL_TEXTURE_CUBE_MAP, GL_TEXTURE_MAG_FILTER, texParams.magFilter);
     glTexParameteri(GL_TEXTURE_CUBE_MAP, GL_TEXTURE_WRAP_S, texParams.wrapS);
     glTexParameteri(GL_TEXTURE_CUBE_MAP, GL_TEXTURE_WRAP_T, texParams.wrapT);
 
-    glActiveTexture(GL_TEXTURE0);
-    glBindTexture(GL_TEXTURE_CUBE_MAP, 0);
+    GL::bindTextureN(0, 0, GL_TEXTURE_CUBE_MAP);
 }
 
 bool TextureCube::reloadTexture()

--- a/cocos/renderer/CCTrianglesCommand.cpp
+++ b/cocos/renderer/CCTrianglesCommand.cpp
@@ -24,12 +24,12 @@
  ****************************************************************************/
 
 #include "renderer/CCTrianglesCommand.h"
+#include "renderer/ccGLStateCache.h"
 #include "renderer/CCGLProgram.h"
 #include "renderer/CCGLProgramState.h"
 #include "xxhash.h"
 #include "renderer/CCRenderer.h"
 #include "renderer/CCTexture2D.h"
-#include "base//ccUtils.h"
 
 NS_CC_BEGIN
 
@@ -116,16 +116,14 @@ void TrianglesCommand::generateMaterialID()
 void TrianglesCommand::useMaterial() const
 {
     //Set texture
-    glActiveTexture(GL_TEXTURE0);
-    glBindTexture(GL_TEXTURE_2D, _textureID);
+    GL::bindTexture2D(_textureID);
     
     if (_alphaTextureID > 0)
     { // ANDROID ETC1 ALPHA supports.
-        glActiveTexture(GL_TEXTURE0 + 1);
-        glBindTexture(GL_TEXTURE_2D, _alphaTextureID);
+        GL::bindTexture2DN(1, _alphaTextureID);
     }
     //set blend mode
-    utils::setBlending(_blendType.src, _blendType.dst);
+    GL::blendFunc(_blendType.src, _blendType.dst);
     
     _glProgramState->apply(_mv);
 }

--- a/cocos/renderer/CCVertexAttribBinding.cpp
+++ b/cocos/renderer/CCVertexAttribBinding.cpp
@@ -25,7 +25,6 @@
 #include "platform/CCGL.h"
 #include "base/CCConfiguration.h"
 #include "3d/CCMeshVertexIndexData.h"
-#include "base/ccUtils.h"
 
 NS_CC_BEGIN
 
@@ -148,7 +147,7 @@ bool VertexAttribBinding::init(MeshIndexData* meshIndexData, GLProgramState* glP
         glBindVertexArray(_handle);
         glBindBuffer(GL_ARRAY_BUFFER, meshVertexData->getVertexBuffer()->getVBO());
 
-        utils::enableVertexAttributes(_vertexAttribsFlags);
+        enableVertexAttributes(_vertexAttribsFlags);
 
         glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, meshIndexData->getIndexBuffer()->getVBO());
 
@@ -181,7 +180,7 @@ void VertexAttribBinding::bind()
         glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, _meshIndexData->getIndexBuffer()->getVBO());
 
         // Software mode
-        utils::enableVertexAttributes(_vertexAttribsFlags);
+        enableVertexAttributes(_vertexAttribsFlags);
         // set attributes
         for(auto &attribute : _attributes)
         {
@@ -224,6 +223,19 @@ void VertexAttribBinding::parseAttributes()
     {
         VertexAttribValue value(&attrib.second);
         _attributes[attrib.first] = value;
+    }
+}
+
+void VertexAttribBinding::enableVertexAttributes(uint32_t flags) const
+{
+    auto tmpFlags = flags;
+    for (int i = 0; tmpFlags > 0; i++)
+    {
+        int flag = 1 << i;
+        if (flag & tmpFlags)
+            glEnableVertexAttribArray(i);
+        
+        tmpFlags &= ~flag;
     }
 }
 

--- a/cocos/renderer/CCVertexAttribBinding.h
+++ b/cocos/renderer/CCVertexAttribBinding.h
@@ -89,6 +89,9 @@ public:
 
 
 private:
+
+    bool init(MeshIndexData* meshIndexData, GLProgramState* glProgramState);
+
     /**
      * Constructor.
      */
@@ -103,12 +106,10 @@ private:
      * Hidden copy assignment operator.
      */
     VertexAttribBinding& operator=(const VertexAttribBinding&);
-    
-    bool init(MeshIndexData* meshIndexData, GLProgramState* glProgramState);
+
     void setVertexAttribPointer(const std::string& name, GLint size, GLenum type, GLboolean normalized, GLsizei stride, GLvoid* pointer);
     VertexAttribValue* getVertexAttribValue(const std::string &name);
     void parseAttributes();
-    void enableVertexAttributes(uint32_t flags) const;
 
 
     GLuint _handle;

--- a/cocos/renderer/CCVertexAttribBinding.h
+++ b/cocos/renderer/CCVertexAttribBinding.h
@@ -108,6 +108,8 @@ private:
     void setVertexAttribPointer(const std::string& name, GLint size, GLenum type, GLboolean normalized, GLsizei stride, GLvoid* pointer);
     VertexAttribValue* getVertexAttribValue(const std::string &name);
     void parseAttributes();
+    void enableVertexAttributes(uint32_t flags) const;
+
 
     GLuint _handle;
 

--- a/cocos/renderer/CCVertexIndexData.cpp
+++ b/cocos/renderer/CCVertexIndexData.cpp
@@ -24,6 +24,7 @@
  ****************************************************************************/
 
 #include "renderer/CCVertexIndexData.h"
+#include "renderer/ccGLStateCache.h"
 #include "renderer/CCVertexIndexBuffer.h"
 
 NS_CC_BEGIN
@@ -115,12 +116,13 @@ VertexData::~VertexData()
 
 void VertexData::use()
 {
-
+    uint32_t flags(0);
     for(auto& element : _vertexStreams)
     {
-        glEnableVertexAttribArray(element.second._stream._semantic);
+        flags = flags | (1 << element.second._stream._semantic);
     }
     
+    GL::enableVertexAttribs(flags);
 
     int lastVBO = -1;
     for(auto& element : _vertexStreams)

--- a/cocos/renderer/CMakeLists.txt
+++ b/cocos/renderer/CMakeLists.txt
@@ -2,6 +2,7 @@ set(COCOS_RENDERER_HEADER
     renderer/CCTextureCache.h
     renderer/CCRenderer.h
     renderer/CCMaterial.h
+    renderer/ccGLStateCache.h
     renderer/CCRenderCommandPool.h
     renderer/ccShaders.h
     renderer/CCMeshCommand.h
@@ -55,6 +56,7 @@ set(COCOS_RENDERER_SRC
     renderer/CCVertexAttribBinding.cpp
     renderer/CCVertexIndexBuffer.cpp
     renderer/CCVertexIndexData.cpp
+    renderer/ccGLStateCache.cpp
     renderer/ccShaders.cpp
     renderer/CCFrameBuffer.cpp
     )

--- a/cocos/renderer/ccGLStateCache.cpp
+++ b/cocos/renderer/ccGLStateCache.cpp
@@ -1,0 +1,280 @@
+/****************************************************************************
+Copyright (c) 2011      Ricardo Quesada
+Copyright (c) 2010-2012 cocos2d-x.org
+Copyright (c) 2011      Zynga Inc.
+Copyright (c) 2013-2016 Chukong Technologies Inc.
+Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
+
+http://www.cocos2d-x.org
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+****************************************************************************/
+
+#include "renderer/ccGLStateCache.h"
+
+#include "renderer/CCGLProgram.h"
+#include "renderer/CCRenderState.h"
+#include "base/CCDirector.h"
+#include "base/ccConfig.h"
+#include "base/CCConfiguration.h"
+
+NS_CC_BEGIN
+
+static const int MAX_ATTRIBUTES = 16;
+static const int MAX_ACTIVE_TEXTURE = 16;
+
+namespace
+{
+    static GLuint s_currentProjectionMatrix = -1;
+    static uint32_t s_attributeFlags = 0;  // 32 attributes max
+
+#if CC_ENABLE_GL_STATE_CACHE
+
+    static GLuint    s_currentShaderProgram = -1;
+    static GLuint    s_currentBoundTexture[MAX_ACTIVE_TEXTURE] =  {(GLuint)-1,(GLuint)-1,(GLuint)-1,(GLuint)-1, (GLuint)-1,(GLuint)-1,(GLuint)-1,(GLuint)-1, (GLuint)-1,(GLuint)-1,(GLuint)-1,(GLuint)-1, (GLuint)-1,(GLuint)-1,(GLuint)-1,(GLuint)-1, };
+    static GLenum    s_blendingSource = -1;
+    static GLenum    s_blendingDest = -1;
+    static int       s_GLServerState = 0;
+    static GLuint    s_VAO = 0;
+    static GLenum    s_activeTexture = -1;
+
+#endif // CC_ENABLE_GL_STATE_CACHE
+}
+
+// GL State Cache functions
+
+namespace GL {
+
+void invalidateStateCache( void )
+{
+    Director::getInstance()->resetMatrixStack();
+    s_currentProjectionMatrix = -1;
+    s_attributeFlags = 0;
+
+#if CC_ENABLE_GL_STATE_CACHE
+    s_currentShaderProgram = -1;
+    for( int i=0; i < MAX_ACTIVE_TEXTURE; i++ )
+    {
+        s_currentBoundTexture[i] = -1;
+    }
+
+    s_blendingSource = -1;
+    s_blendingDest = -1;
+    s_GLServerState = 0;
+    s_VAO = 0;
+    
+#endif // CC_ENABLE_GL_STATE_CACHE
+}
+
+void deleteProgram( GLuint program )
+{
+#if CC_ENABLE_GL_STATE_CACHE
+    if(program == s_currentShaderProgram)
+    {
+        s_currentShaderProgram = -1;
+    }
+#endif // CC_ENABLE_GL_STATE_CACHE
+
+    glDeleteProgram( program );
+}
+
+void useProgram( GLuint program )
+{
+#if CC_ENABLE_GL_STATE_CACHE
+    if( program != s_currentShaderProgram ) {
+        s_currentShaderProgram = program;
+        glUseProgram(program);
+    }
+#else
+    glUseProgram(program);
+#endif // CC_ENABLE_GL_STATE_CACHE
+}
+
+static void SetBlending(GLenum sfactor, GLenum dfactor)
+{
+	if (sfactor == GL_ONE && dfactor == GL_ZERO)
+    {
+		glDisable(GL_BLEND);
+        RenderState::StateBlock::_defaultState->setBlend(false);
+	}
+    else
+    {
+		glEnable(GL_BLEND);
+		glBlendFunc(sfactor, dfactor);
+
+        RenderState::StateBlock::_defaultState->setBlend(true);
+        RenderState::StateBlock::_defaultState->setBlendSrc((RenderState::Blend)sfactor);
+        RenderState::StateBlock::_defaultState->setBlendDst((RenderState::Blend)dfactor);
+    }
+}
+
+void blendFunc(GLenum sfactor, GLenum dfactor)
+{
+#if CC_ENABLE_GL_STATE_CACHE
+    if (sfactor != s_blendingSource || dfactor != s_blendingDest)
+    {
+        s_blendingSource = sfactor;
+        s_blendingDest = dfactor;
+        SetBlending(sfactor, dfactor);
+    }
+#else
+    SetBlending( sfactor, dfactor );
+#endif // CC_ENABLE_GL_STATE_CACHE
+}
+
+void blendResetToCache(void)
+{
+	glBlendEquation(GL_FUNC_ADD);
+#if CC_ENABLE_GL_STATE_CACHE
+	SetBlending(s_blendingSource, s_blendingDest);
+#else
+	SetBlending(CC_BLEND_SRC, CC_BLEND_DST);
+#endif // CC_ENABLE_GL_STATE_CACHE
+}
+
+void bindTexture2D(GLuint textureId)
+{
+    GL::bindTexture2DN(0, textureId);
+}
+
+void bindTexture2D(Texture2D* texture)
+{
+    GL::bindTexture2DN(0, texture->getName());
+    auto alphaTexID = texture->getAlphaTextureName();
+    if (alphaTexID > 0) {
+        GL::bindTexture2DN(1, alphaTexID);
+    }
+}
+
+void bindTexture2DN(GLuint textureUnit, GLuint textureId)
+{
+#if CC_ENABLE_GL_STATE_CACHE
+	CCASSERT(textureUnit < MAX_ACTIVE_TEXTURE, "textureUnit is too big");
+	if (s_currentBoundTexture[textureUnit] != textureId)
+	{
+		s_currentBoundTexture[textureUnit] = textureId;
+		activeTexture(GL_TEXTURE0 + textureUnit);
+		glBindTexture(GL_TEXTURE_2D, textureId);
+	}
+#else
+	glActiveTexture(GL_TEXTURE0 + textureUnit);
+	glBindTexture(GL_TEXTURE_2D, textureId);
+#endif
+}
+
+void bindTextureN(GLuint textureUnit, GLuint textureId, GLuint textureType/* = GL_TEXTURE_2D*/)
+{
+#if CC_ENABLE_GL_STATE_CACHE
+    CCASSERT(textureUnit < MAX_ACTIVE_TEXTURE, "textureUnit is too big");
+    if (s_currentBoundTexture[textureUnit] != textureId)
+    {
+        s_currentBoundTexture[textureUnit] = textureId;
+        activeTexture(GL_TEXTURE0 + textureUnit);
+        glBindTexture(textureType, textureId);
+    }
+#else
+    glActiveTexture(GL_TEXTURE0 + textureUnit);
+    glBindTexture(textureType, textureId);
+#endif
+}
+
+
+void deleteTexture(GLuint textureId)
+{
+#if CC_ENABLE_GL_STATE_CACHE
+    for (size_t i = 0; i < MAX_ACTIVE_TEXTURE; ++i)
+    {
+        if (s_currentBoundTexture[i] == textureId)
+        {
+            s_currentBoundTexture[i] = -1;
+        }
+    }
+#endif // CC_ENABLE_GL_STATE_CACHE
+    
+	glDeleteTextures(1, &textureId);
+}
+
+void deleteTextureN(GLuint /*textureUnit*/, GLuint textureId)
+{
+    deleteTexture(textureId);
+}
+
+void activeTexture(GLenum texture)
+{
+#if CC_ENABLE_GL_STATE_CACHE
+    if(s_activeTexture != texture) {
+        s_activeTexture = texture;
+        glActiveTexture(s_activeTexture);
+    }
+#else
+    glActiveTexture(texture);
+#endif
+}
+
+void bindVAO(GLuint vaoId)
+{
+    if (Configuration::getInstance()->supportsShareableVAO())
+    {
+    
+#if CC_ENABLE_GL_STATE_CACHE
+        if (s_VAO != vaoId)
+        {
+            s_VAO = vaoId;
+            glBindVertexArray(vaoId);
+        }
+#else
+        glBindVertexArray(vaoId);
+#endif // CC_ENABLE_GL_STATE_CACHE
+    
+    }
+}
+
+// GL Vertex Attrib functions
+
+void enableVertexAttribs(uint32_t flags)
+{
+    bindVAO(0);
+
+    // hardcoded!
+    for(int i=0; i < MAX_ATTRIBUTES; i++) {
+        unsigned int bit = 1 << i;
+        //FIXME:Cache is disabled, try to enable cache as before
+        bool enabled = (flags & bit) != 0;
+        bool enabledBefore = (s_attributeFlags & bit) != 0;
+        if(enabled != enabledBefore) 
+        {
+            if( enabled )
+                glEnableVertexAttribArray(i);
+            else
+                glDisableVertexAttribArray(i);
+        }
+    }
+    s_attributeFlags = flags;
+}
+
+// GL Uniforms functions
+
+void setProjectionMatrixDirty( void )
+{
+    s_currentProjectionMatrix = -1;
+}
+
+} // Namespace GL
+
+NS_CC_END

--- a/cocos/renderer/ccGLStateCache.h
+++ b/cocos/renderer/ccGLStateCache.h
@@ -1,0 +1,193 @@
+/****************************************************************************
+ Copyright (c) 2011      Ricardo Quesada
+ Copyright (c) 2010-2012 cocos2d-x.org
+ Copyright (c) 2011      Zynga Inc.
+ Copyright (c) 2013-2016 Chukong Technologies Inc.
+ Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
+
+http://www.cocos2d-x.org
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+****************************************************************************/
+
+#ifndef __CCGLSTATE_H__
+#define __CCGLSTATE_H__
+
+#include <cstdint>
+
+#include "platform/CCGL.h"
+#include "platform/CCPlatformMacros.h"
+
+NS_CC_BEGIN
+
+/**
+ * @addtogroup renderer
+ * @{
+ */
+
+class GLProgram;
+class Texture2D;
+namespace GL {
+
+/** Vertex attrib flags. */
+enum {
+    VERTEX_ATTRIB_FLAG_NONE       = 0,
+
+    VERTEX_ATTRIB_FLAG_POSITION   = 1 << 0,
+    VERTEX_ATTRIB_FLAG_COLOR      = 1 << 1,
+    VERTEX_ATTRIB_FLAG_TEX_COORD = 1 << 2,
+    VERTEX_ATTRIB_FLAG_NORMAL = 1 << 3,
+    VERTEX_ATTRIB_FLAG_BLEND_WEIGHT = 1 << 4,
+    VERTEX_ATTRIB_FLAG_BLEND_INDEX = 1 << 5,
+    
+    VERTEX_ATTRIB_FLAG_POS_COLOR_TEX = (VERTEX_ATTRIB_FLAG_POSITION | VERTEX_ATTRIB_FLAG_COLOR | VERTEX_ATTRIB_FLAG_TEX_COORD),
+};
+
+/** 
+ * Invalidates the GL state cache.
+ *
+ * If CC_ENABLE_GL_STATE_CACHE it will reset the GL state cache.
+ * @since v2.0.0
+ */
+void CC_DLL invalidateStateCache(void);
+
+/** 
+ * Uses the GL program in case program is different than the current one.
+
+ * If CC_ENABLE_GL_STATE_CACHE is disabled, it will the glUseProgram() directly.
+ * @since v2.0.0
+ */
+void CC_DLL useProgram(GLuint program);
+
+/** 
+ * Deletes the GL program. If it is the one that is being used, it invalidates it.
+ *
+ * If CC_ENABLE_GL_STATE_CACHE is disabled, it will the glDeleteProgram() directly.
+ * @since v2.0.0
+ */
+void CC_DLL deleteProgram(GLuint program);
+
+/** 
+ * Uses a blending function in case it not already used.
+ *
+ * If CC_ENABLE_GL_STATE_CACHE is disabled, it will the glBlendFunc() directly.
+ * @since v2.0.0
+ */
+void CC_DLL blendFunc(GLenum sfactor, GLenum dfactor);
+
+/** 
+ * Resets the blending mode back to the cached state in case you used glBlendFuncSeparate() or glBlendEquation().
+ *
+ * If CC_ENABLE_GL_STATE_CACHE is disabled, it will just set the default blending mode using GL_FUNC_ADD.
+ * @since v2.0.0
+ */
+void CC_DLL blendResetToCache(void);
+
+/** 
+ * Sets the projection matrix as dirty.
+ * @since v2.0.0
+ */
+void CC_DLL setProjectionMatrixDirty(void);
+
+/** 
+ * Will enable the vertex attribs that are passed as flags.
+ * Possible flags:
+ * 
+ *    * VERTEX_ATTRIB_FLAG_POSITION
+ *    * VERTEX_ATTRIB_FLAG_COLOR
+ *    * VERTEX_ATTRIB_FLAG_TEX_COORDS
+ * 
+ * These flags can be ORed. The flags that are not present, will be disabled.
+ * 
+ * @since v2.0.0
+ */
+void CC_DLL enableVertexAttribs(uint32_t flags);
+
+/** 
+ * If the texture is not already bound to texture unit 0, it binds it.
+ *
+ * If CC_ENABLE_GL_STATE_CACHE is disabled, it will call glBindTexture() directly.
+ * @since v2.0.0
+ */
+void CC_DLL bindTexture2D(GLuint textureId);
+
+/**
+* If the texture is not already bound to texture unit 0, it binds it.
+*
+* If CC_ENABLE_GL_STATE_CACHE is disabled, it will call glBindTexture() directly.
+*
+* @remark: It will bind alpha texture to support ETC1 alpha channel.
+* @since v3.13
+*/
+void CC_DLL bindTexture2D(Texture2D* texture);
+
+/** 
+ * If the texture is not already bound to a given unit, it binds it.
+ *
+ * If CC_ENABLE_GL_STATE_CACHE is disabled, it will call glBindTexture() directly.
+ * @since v2.1.0
+ */
+void CC_DLL bindTexture2DN(GLuint textureUnit, GLuint textureId);
+
+/** If the texture is not already bound to a given unit, it binds it.
+ * If CC_ENABLE_GL_STATE_CACHE is disabled, it will call glBindTexture() directly.
+ * @since v3.6
+ */
+void CC_DLL bindTextureN(GLuint textureUnit, GLuint textureId, GLuint textureType = GL_TEXTURE_2D);
+
+/** 
+ * It will delete a given texture. If the texture was bound, it will invalidate the cached.
+ *
+ * If CC_ENABLE_GL_STATE_CACHE is disabled, it will call glDeleteTextures() directly.
+ * @since v2.0.0
+ */
+void CC_DLL deleteTexture(GLuint textureId);
+
+/** 
+ * It will delete a given texture. If the texture was bound, it will invalidate the cached for the given texture unit.
+ *
+ * If CC_ENABLE_GL_STATE_CACHE is disabled, it will call glDeleteTextures() directly.
+ * @since v2.1.0
+ */
+CC_DEPRECATED_ATTRIBUTE void CC_DLL deleteTextureN(GLuint textureUnit, GLuint textureId);
+
+/** 
+ * Select active texture unit.
+ *
+ * If CC_ENABLE_GL_STATE_CACHE is disabled, it will call glActiveTexture() directly.
+ * @since v3.0
+ */
+void CC_DLL activeTexture(GLenum texture);
+
+/** 
+ * If the vertex array is not already bound, it binds it.
+ *
+ * If CC_ENABLE_GL_STATE_CACHE is disabled, it will call glBindVertexArray() directly.
+ * @since v2.0.0
+ */
+void CC_DLL bindVAO(GLuint vaoId);
+
+// end of support group
+/// @}
+
+} // Namespace GL
+NS_CC_END
+    
+
+#endif /* __CCGLSTATE_H__ */

--- a/cocos/scripting/js-bindings/manual/cocos2d_specifics.cpp
+++ b/cocos/scripting/js-bindings/manual/cocos2d_specifics.cpp
@@ -43,6 +43,7 @@
 #include "base/CCEventDispatcher.h"
 #include "base/CCScheduler.h"
 #include "platform/CCFileUtils.h"
+#include "renderer/ccGLStateCache.h"
 #include "scripting/js-bindings/manual/js_bindings_config.h"
 #include "scripting/js-bindings/auto/jsb_cocos2dx_auto.hpp"
 #include "scripting/js-bindings/manual/jsb_event_dispatcher_manual.h"
@@ -3253,7 +3254,7 @@ bool js_cocos2dx_ccGLEnableVertexAttribs(JSContext *cx, uint32_t argc, jsval *vp
         ok &= jsval_to_uint32(cx, args.get(0), &arg0);
         JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
 
-        glEnableVertexAttribArray(arg0);
+        GL::enableVertexAttribs(arg0);
         args.rval().setUndefined();
         return true;
     }

--- a/cocos/scripting/lua-bindings/manual/cocos2d/LuaOpengl.cpp
+++ b/cocos/scripting/lua-bindings/manual/cocos2d/LuaOpengl.cpp
@@ -35,7 +35,7 @@
 #include "2d/CCActionCatmullRom.h"
 #include "2d/CCDrawingPrimitives.h"
 #include "renderer/CCRenderer.h"
-#include "platform/CCGL.h"
+#include "renderer/ccGLStateCache.h"
 
 using namespace cocos2d;
 
@@ -4405,7 +4405,7 @@ static int tolua_Cocos2d_glEnableVertexAttribs00(lua_State* tolua_S)
 #endif
     {
         int arg0 = (int)tolua_tonumber(tolua_S, 1, 0);
-        glEnableVertexAttribArray(arg0);
+        GL::enableVertexAttribs(arg0);
     }
     return 0;
 #ifndef TOLUA_RELEASE

--- a/cocos/scripting/lua-bindings/manual/cocos2d/LuaOpengl.cpp
+++ b/cocos/scripting/lua-bindings/manual/cocos2d/LuaOpengl.cpp
@@ -36,7 +36,6 @@
 #include "2d/CCDrawingPrimitives.h"
 #include "renderer/CCRenderer.h"
 #include "platform/CCGL.h"
-#include "base/ccUtils.h"
 
 using namespace cocos2d;
 
@@ -4406,7 +4405,7 @@ static int tolua_Cocos2d_glEnableVertexAttribs00(lua_State* tolua_S)
 #endif
     {
         int arg0 = (int)tolua_tonumber(tolua_S, 1, 0);
-        cocos2d::utils::enableVertexAttributes(arg0);
+        glEnableVertexAttribArray(arg0);
     }
     return 0;
 #ifndef TOLUA_RELEASE

--- a/cocos/ui/UILayout.cpp
+++ b/cocos/ui/UILayout.cpp
@@ -28,6 +28,7 @@ THE SOFTWARE.
 #include "ui/UIScale9Sprite.h"
 #include "renderer/CCGLProgram.h"
 #include "renderer/CCGLProgramCache.h"
+#include "renderer/ccGLStateCache.h"
 #include "renderer/CCRenderState.h"
 #include "base/CCDirector.h"
 #include "2d/CCDrawingPrimitives.h"

--- a/cocos/vr/CCVRGenericRenderer.cpp
+++ b/cocos/vr/CCVRGenericRenderer.cpp
@@ -30,6 +30,7 @@
 #include "vr/CCVRGenericHeadTracker.h"
 #include "renderer/CCRenderer.h"
 #include "renderer/CCGLProgramState.h"
+#include "renderer/ccGLStateCache.h"
 #include "base/CCDirector.h"
 #include "2d/CCScene.h"
 #include "2d/CCCamera.h"
@@ -125,8 +126,7 @@ void VRGenericRenderer::render(Scene* scene, Renderer* renderer)
     _fb->restoreFBO();
 
     auto texture = _fb->getRenderTarget()->getTexture();
-    glActiveTexture(GL_TEXTURE0);
-    glBindTexture(GL_TEXTURE_2D, texture->getName());
+    GL::bindTexture2D(texture->getName());
     _glProgramState->apply(Mat4::IDENTITY);
 
     GLint origViewport[4];

--- a/templates/cocos2dx_files.json
+++ b/templates/cocos2dx_files.json
@@ -1268,6 +1268,8 @@
         "cocos/renderer/CCVertexIndexData.cpp", 
         "cocos/renderer/CCVertexIndexData.h", 
         "cocos/renderer/CMakeLists.txt", 
+        "cocos/renderer/ccGLStateCache.cpp", 
+        "cocos/renderer/ccGLStateCache.h", 
         "cocos/renderer/ccShader_3D_Color.frag", 
         "cocos/renderer/ccShader_3D_ColorNormal.frag", 
         "cocos/renderer/ccShader_3D_ColorNormalTex.frag", 

--- a/tests/cpp-tests/Classes/Box2DTestBed/Box2dView.cpp
+++ b/tests/cpp-tests/Classes/Box2DTestBed/Box2dView.cpp
@@ -188,7 +188,7 @@ void Box2DView::onDraw(const Mat4 &transform, uint32_t flags)
     director->pushMatrix(MATRIX_STACK_TYPE::MATRIX_STACK_MODELVIEW);
     director->loadMatrix(MATRIX_STACK_TYPE::MATRIX_STACK_MODELVIEW, transform);
 
-    glEnableVertexAttribArray(GLProgram::VERTEX_ATTRIB_POSITION);
+    GL::enableVertexAttribs( cocos2d::GL::VERTEX_ATTRIB_FLAG_POSITION );
     m_test->Step(&settings);
     m_test->m_world->DrawDebugData();
     CHECK_GL_ERROR_DEBUG();

--- a/tests/cpp-tests/Classes/ClippingNodeTest/ClippingNodeTest.cpp
+++ b/tests/cpp-tests/Classes/ClippingNodeTest/ClippingNodeTest.cpp
@@ -663,7 +663,8 @@ void RawStencilBufferTest::onBeforeDrawClip(int planeIndex, const Vec2& pt)
     glProgram->setUniformsForBuiltins();
     glProgram->setUniformLocationWith4fv(colorLocation, (GLfloat*) &color.r, 1);
     
-    glEnableVertexAttribArray(GLProgram::VERTEX_ATTRIB_POSITION);
+    GL::enableVertexAttribs( GL::VERTEX_ATTRIB_FLAG_POSITION );
+    
     glVertexAttribPointer(GLProgram::VERTEX_ATTRIB_POSITION, 2, GL_FLOAT, GL_FALSE, 0, vertices);
     glDrawArrays(GL_TRIANGLE_FAN, 0, 4);
     
@@ -692,7 +693,8 @@ void RawStencilBufferTest::onBeforeDrawSprite(int planeIndex, const Vec2& pt)
     glProgram->setUniformsForBuiltins();
     glProgram->setUniformLocationWith4fv(colorLocation, (GLfloat*) &color.r, 1);
 
-    glEnableVertexAttribArray(GLProgram::VERTEX_ATTRIB_POSITION);
+    GL::enableVertexAttribs( GL::VERTEX_ATTRIB_FLAG_POSITION );
+
     glVertexAttribPointer(GLProgram::VERTEX_ATTRIB_POSITION, 2, GL_FLOAT, GL_FALSE, 0, vertices);
     glDrawArrays(GL_TRIANGLE_FAN, 0, 4);
 
@@ -892,7 +894,8 @@ void RawStencilBufferTest6::setupStencilForClippingOnPlane(GLint plane)
     glProgram->setUniformsForBuiltins();
     glProgram->setUniformLocationWith4fv(colorLocation, (GLfloat*) &color.r, 1);
 
-    glEnableVertexAttribArray(GLProgram::VERTEX_ATTRIB_POSITION);
+    GL::enableVertexAttribs( GL::VERTEX_ATTRIB_FLAG_POSITION );
+
     glVertexAttribPointer(GLProgram::VERTEX_ATTRIB_POSITION, 2, GL_FLOAT, GL_FALSE, 0, vertices);
     glDrawArrays(GL_TRIANGLE_FAN, 0, 4);
 

--- a/tests/cpp-tests/Classes/NodeTest/NodeTest.cpp
+++ b/tests/cpp-tests/Classes/NodeTest/NodeTest.cpp
@@ -993,14 +993,10 @@ void MySprite::onDraw(const Mat4 &transform, uint32_t flags)
     getGLProgram()->use();
     getGLProgram()->setUniformsForBuiltins(transform);
 
-    cocos2d::utils::setBlending(_blendFunc.src, _blendFunc.dst);
+    GL::blendFunc( _blendFunc.src, _blendFunc.dst );
 
-    glActiveTexture(GL_TEXTURE0);
-    glBindTexture(GL_TEXTURE_2D, _texture->getName());
-    
-    glEnableVertexAttribArray(GLProgram::VERTEX_ATTRIB_POSITION);
-    glEnableVertexAttribArray(GLProgram::VERTEX_ATTRIB_TEX_COORD);
-    glEnableVertexAttribArray(GLProgram::VERTEX_ATTRIB_COLOR);
+    GL::bindTexture2D( _texture->getName() );
+    GL::enableVertexAttribs( GL::VERTEX_ATTRIB_FLAG_POS_COLOR_TEX );
 
     #define kQuadSize sizeof(_quad.bl)
     size_t offset = (size_t)&_quad;

--- a/tests/cpp-tests/Classes/Sprite3DTest/DrawNode3D.cpp
+++ b/tests/cpp-tests/Classes/Sprite3DTest/DrawNode3D.cpp
@@ -50,7 +50,7 @@ DrawNode3D::~DrawNode3D()
     if (Configuration::getInstance()->supportsShareableVAO())
     {
         glDeleteVertexArrays(1, &_vao);
-        glBindVertexArray(0);
+        GL::bindVAO(0);
         _vao = 0;
     }
 }
@@ -92,7 +92,7 @@ bool DrawNode3D::init()
     if (Configuration::getInstance()->supportsShareableVAO())
     {
         glGenVertexArrays(1, &_vao);
-        glBindVertexArray(_vao);
+        GL::bindVAO(_vao);
     }
     
     glGenBuffers(1, &_vbo);
@@ -109,7 +109,7 @@ bool DrawNode3D::init()
     
     if (Configuration::getInstance()->supportsShareableVAO())
     {
-        glBindVertexArray(0);
+        GL::bindVAO(0);
     }
     
     CHECK_GL_ERROR_DEBUG();
@@ -143,7 +143,7 @@ void DrawNode3D::onDraw(const Mat4 &transform, uint32_t flags)
     glProgram->setUniformsForBuiltins(transform);
     glEnable(GL_DEPTH_TEST);
     RenderState::StateBlock::_defaultState->setDepthTest(true);
-    cocos2d::utils::setBlending(_blendFunc.src, _blendFunc.dst);
+    GL::blendFunc(_blendFunc.src, _blendFunc.dst);
 
     if (_dirty)
     {
@@ -153,12 +153,11 @@ void DrawNode3D::onDraw(const Mat4 &transform, uint32_t flags)
     }
     if (Configuration::getInstance()->supportsShareableVAO())
     {
-        glBindVertexArray(_vao);
+        GL::bindVAO(_vao);
     }
     else
     {
-        glEnableVertexAttribArray(GLProgram::VERTEX_ATTRIB_POSITION);
-        glEnableVertexAttribArray(GLProgram::VERTEX_ATTRIB_COLOR);
+        GL::enableVertexAttribs(GL::VERTEX_ATTRIB_FLAG_POS_COLOR_TEX);
 
         glBindBuffer(GL_ARRAY_BUFFER, _vbo);
         // vertex

--- a/tests/js-tests/project/Classes/js_DrawNode3D_bindings.cpp
+++ b/tests/js-tests/project/Classes/js_DrawNode3D_bindings.cpp
@@ -132,7 +132,7 @@ DrawNode3D::~DrawNode3D()
     if (Configuration::getInstance()->supportsShareableVAO())
     {
         glDeleteVertexArrays(1, &_vao);
-        glBindVertexArray(0);
+        GL::bindVAO(0);
         _vao = 0;
     }
 }
@@ -174,7 +174,7 @@ bool DrawNode3D::init()
     if (Configuration::getInstance()->supportsShareableVAO())
     {
         glGenVertexArrays(1, &_vao);
-        glBindVertexArray(_vao);
+        GL::bindVAO(_vao);
     }
     
     glGenBuffers(1, &_vbo);
@@ -191,7 +191,7 @@ bool DrawNode3D::init()
     
     if (Configuration::getInstance()->supportsShareableVAO())
     {
-        glBindVertexArray(0);
+        GL::bindVAO(0);
     }
     
     CHECK_GL_ERROR_DEBUG();
@@ -224,7 +224,7 @@ void DrawNode3D::onDraw(const Mat4 &transform, uint32_t flags)
     glProgram->use();
     glProgram->setUniformsForBuiltins(transform);
     glEnable(GL_DEPTH_TEST);
-    glBlendFunc(_blendFunc.src, _blendFunc.dst);
+    GL::blendFunc(_blendFunc.src, _blendFunc.dst);
 
     if (_dirty)
     {
@@ -234,12 +234,11 @@ void DrawNode3D::onDraw(const Mat4 &transform, uint32_t flags)
     }
     if (Configuration::getInstance()->supportsShareableVAO())
     {
-        glBindVertexArray(_vao);
+        GL::bindVAO(_vao);
     }
     else
     {
-        glEnableVertexAttribArray(GLProgram::VERTEX_ATTRIB_POSITION);
-        glEnableVertexAttribArray(GLProgram::VERTEX_ATTRIB_COLOR);
+        GL::enableVertexAttribs(GL::VERTEX_ATTRIB_FLAG_POS_COLOR_TEX);
 
         glBindBuffer(GL_ARRAY_BUFFER, _vbo);
         // vertex

--- a/tests/js-tests/project/Classes/js_DrawNode3D_bindings.cpp
+++ b/tests/js-tests/project/Classes/js_DrawNode3D_bindings.cpp
@@ -224,7 +224,7 @@ void DrawNode3D::onDraw(const Mat4 &transform, uint32_t flags)
     glProgram->use();
     glProgram->setUniformsForBuiltins(transform);
     glEnable(GL_DEPTH_TEST);
-    cocos2d::utils::setBlending(_blendFunc.src, _blendFunc.dst);
+    glBlendFunc(_blendFunc.src, _blendFunc.dst);
 
     if (_dirty)
     {

--- a/tests/lua-empty-test/project/proj.mac/main.cpp
+++ b/tests/lua-empty-test/project/proj.mac/main.cpp
@@ -23,7 +23,7 @@
  THE SOFTWARE.
  ****************************************************************************/
 
-#include "../Classes/AppDelegate.h"
+#include "AppDelegate.h"
 #include "cocos2d.h"
 
 USING_NS_CC;

--- a/tests/lua-tests/project/Classes/lua_test_bindings.cpp
+++ b/tests/lua-tests/project/Classes/lua_test_bindings.cpp
@@ -134,7 +134,7 @@ DrawNode3D::~DrawNode3D()
     if (Configuration::getInstance()->supportsShareableVAO())
     {
         glDeleteVertexArrays(1, &_vao);
-        glBindVertexArray(0);
+        GL::bindVAO(0);
         _vao = 0;
     }
 }
@@ -176,7 +176,7 @@ bool DrawNode3D::init()
     if (Configuration::getInstance()->supportsShareableVAO())
     {
         glGenVertexArrays(1, &_vao);
-        glBindVertexArray(_vao);
+        GL::bindVAO(_vao);
     }
     
     glGenBuffers(1, &_vbo);
@@ -193,7 +193,7 @@ bool DrawNode3D::init()
     
     if (Configuration::getInstance()->supportsShareableVAO())
     {
-        glBindVertexArray(0);
+        GL::bindVAO(0);
     }
     
     CHECK_GL_ERROR_DEBUG();
@@ -226,7 +226,7 @@ void DrawNode3D::onDraw(const Mat4 &transform, uint32_t flags)
     glProgram->use();
     glProgram->setUniformsForBuiltins(transform);
     glEnable(GL_DEPTH_TEST);
-    utils::setBlending(_blendFunc.src, _blendFunc.dst);
+    GL::blendFunc(_blendFunc.src, _blendFunc.dst);
     
     if (_dirty)
     {
@@ -236,12 +236,11 @@ void DrawNode3D::onDraw(const Mat4 &transform, uint32_t flags)
     }
     if (Configuration::getInstance()->supportsShareableVAO())
     {
-        glBindVertexArray(_vao);
+        GL::bindVAO(_vao);
     }
     else
     {
-        glEnableVertexAttribArray(GLProgram::VERTEX_ATTRIB_POSITION);
-        glEnableVertexAttribArray(GLProgram::VERTEX_ATTRIB_COLOR);
+        GL::enableVertexAttribs(GL::VERTEX_ATTRIB_FLAG_POS_COLOR_TEX);
         
         glBindBuffer(GL_ARRAY_BUFFER, _vbo);
         // vertex


### PR DESCRIPTION
- To keep forward compatibility, revert this renderer logic changes

this modify will comes again with multi renderer background, for at that time we didn't need to consider compatibility strictly.