### PR TITLE
Fix animation duration calculation

### DIFF
--- a/cocos/2d/CCActionInterval.cpp
+++ b/cocos/2d/CCActionInterval.cpp
@@ -89,7 +89,7 @@ void ExtraAction::step(float /*dt*/)
 bool ActionInterval::initWithDuration(float d)
 {
 
-    _duration = abs(d) <= MATH_EPSILON ? MATH_EPSILON : d;
+    _duration = std::abs(d) <= MATH_EPSILON ? MATH_EPSILON : d;
     _elapsed = 0;
     _firstTick = true;
     _done = false;


### PR DESCRIPTION
The duration of action will be miscalculated when float abs(float)
is unavailble, replacing it with std::abs fixes the issue.