### PR TITLE
alBufferData instead of alBufferDataStatic for small audio file on Apple

### DIFF
--- a/tests/cpp-tests/Classes/NewAudioEngineTest/NewAudioEngineTest.cpp
+++ b/tests/cpp-tests/Classes/NewAudioEngineTest/NewAudioEngineTest.cpp
@@ -852,7 +852,7 @@ bool AudioSwitchStateTest::init()
             AudioEngine::play2d("audio/SoundEffectsFX009/FX082.mp3");
             AudioEngine::play2d("audio/LuckyDay.mp3");
             
-        }, 0.1f, "AudioSwitchStateTest");
+        }, 0.01f, "AudioSwitchStateTest");
         
         return true;
     }


### PR DESCRIPTION
- Based on https://github.com/ironhidegames/cocos2d-x/pull/2

- Tested on iPhone X (iOS 11.2.2), `AudioSwitchStateTest ` case, not crash for 30 minutes

--- 

refer to https://github.com/cocos2d/cocos2d-x/issues/18948#issuecomment-419071695

> don't use alBufferDataStaticProc, so we let openAL perform a copy of the audio data, and let him handle the memory of this datas, while we clean our pcmData immediately