### PR TITLE
[cmake] add find_host_library into iOS toolchain file

### DIFF
--- a/cmake/ios.toolchain.cmake
+++ b/cmake/ios.toolchain.cmake
@@ -204,3 +204,12 @@ macro(find_host_package)
     set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
     set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
 endmacro(find_host_package)
+
+# This macro lets you find library on the host system
+macro(find_host_library)
+    set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY NEVER)
+
+    find_library(${ARGN})
+
+    set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+endmacro(find_host_library)


### PR DESCRIPTION
- you can use it like

```CMake
find_host_library(Xamarin_LIB # var to save result
  NAMES Xamarin.iOS # Xamarin.iOS.framework
  PATHS ${CMAKE_CURRENT_SOURCE_DIR}/tmp) # libs dir

message(STATUS "Xamarin_LIB: ${Xamarin_LIB}") # print find libs result
```

- the reason to add this is because iOS toolchain file changes the `find_library` default behavior by:

```
    set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
```