### PR TITLE
[android lua] improve performance of lua loader

### DIFF
--- a/cocos/platform/CCFileUtils.cpp
+++ b/cocos/platform/CCFileUtils.cpp
@@ -624,6 +624,7 @@ void FileUtils::purgeCachedEntries()
 {
     DECLARE_GUARD;
     _fullPathCache.clear();
+    _fullPathCacheDir.clear();
 }
 
 std::string FileUtils::getStringFromFile(const std::string& filename) const
@@ -935,6 +936,7 @@ void FileUtils::setSearchResolutionsOrder(const std::vector<std::string>& search
     bool existDefault = false;
 
     _fullPathCache.clear();
+    _fullPathCacheDir.clear();
     _searchResolutionsOrderArray.clear();
     for(const auto& iter : searchResolutionsOrder)
     {
@@ -1010,6 +1012,7 @@ void FileUtils::setDefaultResourceRootPath(const std::string& path)
     if (_defaultResRootPath != path)
     {
         _fullPathCache.clear();
+        _fullPathCacheDir.clear();
         _defaultResRootPath = path;
         if (!_defaultResRootPath.empty() && _defaultResRootPath[_defaultResRootPath.length()-1] != '/')
         {
@@ -1028,6 +1031,7 @@ void FileUtils::setSearchPaths(const std::vector<std::string>& searchPaths)
     _originalSearchPaths = searchPaths;
 
     _fullPathCache.clear();
+    _fullPathCacheDir.clear();
     _searchPathArray.clear();
 
     for (const auto& path : _originalSearchPaths)
@@ -1084,6 +1088,7 @@ void FileUtils::setFilenameLookupDictionary(const ValueMap& filenameLookupDict)
 {
     DECLARE_GUARD;
     _fullPathCache.clear();
+    _fullPathCacheDir.clear();
     _filenameLookupDict = filenameLookupDict;
 }
 
@@ -1115,7 +1120,6 @@ std::string FileUtils::getFullPathForFilenameWithinDirectory(const std::string& 
         ret += '/';
     }
     ret += filename;
-
     // if the file doesn't exist, return an empty string
     if (!isFileExistInternal(ret)) {
         ret = "";
@@ -1164,8 +1168,8 @@ bool FileUtils::isDirectoryExist(const std::string& dirPath) const
     }
 
     // Already Cached ?
-    auto cacheIter = _fullPathCache.find(dirPath);
-    if( cacheIter != _fullPathCache.end() )
+    auto cacheIter = _fullPathCacheDir.find(dirPath);
+    if( cacheIter != _fullPathCacheDir.end() )
     {
         return isDirectoryExistInternal(cacheIter->second);
     }
@@ -1179,7 +1183,7 @@ bool FileUtils::isDirectoryExist(const std::string& dirPath) const
             fullpath = fullPathForDirectory(searchIt + dirPath + resolutionIt);
             if (isDirectoryExistInternal(fullpath))
             {
-                _fullPathCache.emplace(dirPath, fullpath);
+                _fullPathCacheDir.emplace(dirPath, fullpath);
                 return true;
             }
         }

--- a/cocos/platform/android/CCFileUtils-android.cpp
+++ b/cocos/platform/android/CCFileUtils-android.cpp
@@ -213,7 +213,13 @@ bool FileUtilsAndroid::isDirectoryExistInternal(const std::string& dirPath) cons
         return false;
     }
 
-    const char* s = dirPath.c_str();
+    std::string dirPathCopy = dirPath;
+    if(dirPathCopy[dirPathCopy.length() - 1] == '/')
+    {
+        dirPathCopy[dirPathCopy.length() - 1] = '\0';
+    }
+
+    const char* s = dirPathCopy.c_str();
     
     // find absolute path in flash memory
     if (s[0] == '/')

--- a/cocos/platform/android/CCFileUtils-android.cpp
+++ b/cocos/platform/android/CCFileUtils-android.cpp
@@ -216,7 +216,7 @@ bool FileUtilsAndroid::isDirectoryExistInternal(const std::string& dirPath) cons
     std::string dirPathCopy = dirPath;
     if(dirPathCopy[dirPathCopy.length() - 1] == '/')
     {
-        dirPathCopy[dirPathCopy.length() - 1] = '\0';
+        dirPathCopy.erase(dirPathCopy.length() - 1);
     }
 
     const char* s = dirPathCopy.c_str();
@@ -321,6 +321,11 @@ std::vector<std::string> FileUtilsAndroid::listFiles(const std::string& dirPath)
     if (nullptr == assetmanager) {
         LOGD("... FileUtilsAndroid::assetmanager is nullptr");
         return fileList;
+    }
+
+    if(relativePath[relativePath.length() - 1] == '/')
+    {
+        relativePath.erase(relativePath.length() - 1);
     }
 
     auto *dir = AAssetManager_openDir(assetmanager, relativePath.c_str());

--- a/cocos/scripting/lua-bindings/manual/Cocos2dxLuaLoader.cpp
+++ b/cocos/scripting/lua-bindings/manual/Cocos2dxLuaLoader.cpp
@@ -96,7 +96,7 @@ extern "C"
                 pos = prefix.find_first_of("?", pos + filename.length() + 1);
             }
             chunkName = prefix + BYTECODE_FILE_EXT;
-            if (utils->isFileExist(chunkName) && !utils->isDirectoryExist(chunkName))
+            if (utils->isFileExist(chunkName)) // && !utils->isDirectoryExist(chunkName))
             {
                 chunk = utils->getDataFromFile(chunkName);
                 break;
@@ -104,7 +104,7 @@ extern "C"
             else
             {
                 chunkName = prefix + NOT_BYTECODE_FILE_EXT;
-                if (utils->isFileExist(chunkName) && !utils->isDirectoryExist(chunkName))
+                if (utils->isFileExist(chunkName) ) //&& !utils->isDirectoryExist(chunkName))
                 {
                     chunk = utils->getDataFromFile(chunkName);
                     break;
@@ -112,7 +112,7 @@ extern "C"
                 else
                 {
                     chunkName = prefix;
-                    if (utils->isFileExist(chunkName) && !utils->isDirectoryExist(chunkName))
+                    if (utils->isFileExist(chunkName)) // && !utils->isDirectoryExist(chunkName))
                     {
                         chunk = utils->getDataFromFile(chunkName);
                         break;

--- a/tests/cpp-tests/Classes/FileUtilsTest/FileUtilsTest.cpp
+++ b/tests/cpp-tests/Classes/FileUtilsTest/FileUtilsTest.cpp
@@ -48,6 +48,7 @@ FileUtilsTests::FileUtilsTests()
     ADD_TEST_CASE(TestWriteStringAsync);
     ADD_TEST_CASE(TestWriteDataAsync);
     ADD_TEST_CASE(TestListFiles);
+    ADD_TEST_CASE(TestIsFileExistRejectFolder);
 }
 
 // TestResolutionDirectories
@@ -1426,6 +1427,46 @@ std::string TestListFiles::title() const
 }
 
 std::string TestListFiles::subtitle() const
+{
+    return "";
+}
+
+
+
+void TestIsFileExistRejectFolder::onEnter()
+{
+    FileUtilsDemo::onEnter();
+
+    auto winSize = Director::getInstance()->getWinSize();
+
+    auto infoLabel = Label::createWithTTF("tests folder 'fonts/', expect to be false", "fonts/Thonburi.ttf", 18);
+    this->addChild(infoLabel);
+    infoLabel->setPosition(winSize.width / 2, winSize.height * 3 / 4);
+
+    auto cntLabel = Label::createWithTTF("waiting...", "fonts/Thonburi.ttf", 18);
+    this->addChild(cntLabel);
+    cntLabel->setPosition(winSize.width / 2, winSize.height / 3);
+    
+    auto exists = FileUtils::getInstance()->isFileExist("fonts/");
+    auto isDirectory = FileUtils::getInstance()->isDirectoryExist("fonts/");
+
+    char cntBuffer[200] = { 0 };
+    snprintf(cntBuffer, 200, "isDir: %s, isFile: %s,  %s", isDirectory ? "true": "false" , exists ? "true" : "false", exists ? "failure!" : "ok!" );
+    cntLabel->setString(cntBuffer);
+
+}
+
+void TestIsFileExistRejectFolder::onExit()
+{
+    FileUtilsDemo::onExit();
+}
+
+std::string TestIsFileExistRejectFolder::title() const
+{
+    return "FileUtils: isFileExist(direname)";
+}
+
+std::string TestIsFileExistRejectFolder::subtitle() const
 {
     return "";
 }

--- a/tests/cpp-tests/Classes/FileUtilsTest/FileUtilsTest.cpp
+++ b/tests/cpp-tests/Classes/FileUtilsTest/FileUtilsTest.cpp
@@ -1439,7 +1439,7 @@ void TestIsFileExistRejectFolder::onEnter()
 
     auto winSize = Director::getInstance()->getWinSize();
 
-    auto infoLabel = Label::createWithTTF("tests folder 'fonts/', expect to be false", "fonts/Thonburi.ttf", 18);
+    auto infoLabel = Label::createWithTTF("tests folder 'NavMesh/maps', expect to be false", "fonts/Thonburi.ttf", 18);
     this->addChild(infoLabel);
     infoLabel->setPosition(winSize.width / 2, winSize.height * 3 / 4);
 
@@ -1447,8 +1447,8 @@ void TestIsFileExistRejectFolder::onEnter()
     this->addChild(cntLabel);
     cntLabel->setPosition(winSize.width / 2, winSize.height / 3);
     
-    auto exists = FileUtils::getInstance()->isFileExist("fonts/");
-    auto isDirectory = FileUtils::getInstance()->isDirectoryExist("fonts/");
+    auto exists = FileUtils::getInstance()->isFileExist("NavMesh/maps");
+    auto isDirectory = FileUtils::getInstance()->isDirectoryExist("NavMesh/maps");
 
     char cntBuffer[200] = { 0 };
     snprintf(cntBuffer, 200, "isDir: %s, isFile: %s,  %s", isDirectory ? "true": "false" , exists ? "true" : "false", exists ? "failure!" : "ok!" );

--- a/tests/cpp-tests/Classes/FileUtilsTest/FileUtilsTest.h
+++ b/tests/cpp-tests/Classes/FileUtilsTest/FileUtilsTest.h
@@ -269,4 +269,15 @@ public:
     virtual std::string subtitle() const override;
 };
 
+class TestIsFileExistRejectFolder : public FileUtilsDemo
+{
+public:
+    CREATE_FUNC(TestIsFileExistRejectFolder);
+
+    virtual void onEnter() override;
+    virtual void onExit() override;
+    virtual std::string title() const override;
+    virtual std::string subtitle() const override;
+};
+
 #endif /* __FILEUTILSTEST_H__ */


### PR DESCRIPTION
- `isDirectoryExist()` cause performance drop. and it is not required to be invoked. 
- add a test case to ensure `isFileExist()` rejects folders. 