### PR TITLE
fix double free issues when js/lua-tests exit on iOS

### DIFF
--- a/cocos/base/CCDirector.cpp
+++ b/cocos/base/CCDirector.cpp
@@ -199,6 +199,14 @@ Director::~Director(void)
     ObjectFactory::destroyInstance();
 
     s_SharedDirector = nullptr;
+
+#if CC_ENABLE_SCRIPT_BINDING
+    ScriptEngineManager::destroyInstance();
+#endif
+
+#if (CC_TARGET_PLATFORM == CC_PLATFORM_IOS)
+    exit(0);
+#endif
 }
 
 void Director::setDefaultValues(void)

--- a/cocos/base/CCRef.cpp
+++ b/cocos/base/CCRef.cpp
@@ -64,15 +64,15 @@ Ref::Ref()
 Ref::~Ref()
 {
 #if CC_ENABLE_SCRIPT_BINDING
-    // if the object is referenced by Lua engine, remove it
-    if (_luaID)
+    ScriptEngineProtocol* pEngine = ScriptEngineManager::getInstance()->getScriptEngine();
+    if (pEngine != nullptr && _luaID)
     {
-        ScriptEngineManager::getInstance()->getScriptEngine()->removeScriptObjectByObject(this);
+        // if the object is referenced by Lua engine, remove it
+        pEngine->removeScriptObjectByObject(this);
     }
 #if !CC_ENABLE_GC_FOR_NATIVE_OBJECTS
     else
     {
-        ScriptEngineProtocol* pEngine = ScriptEngineManager::getInstance()->getScriptEngine();
         if (pEngine != nullptr && pEngine->getScriptType() == kScriptTypeJavascript)
         {
             pEngine->removeScriptObjectByObject(this);

--- a/cocos/platform/CCApplicationProtocol.h
+++ b/cocos/platform/CCApplicationProtocol.h
@@ -28,7 +28,6 @@ THE SOFTWARE.
 #define __CC_APPLICATION_PROTOCOL_H__
 
 #include "platform/CCPlatformMacros.h"
-#include "base/CCScriptSupport.h"
 #include "base/CCAutoreleasePool.h"
 #include "base/ccTypes.h"
 
@@ -67,9 +66,6 @@ public:
      * @lua NA
      */
     virtual ~ApplicationProtocol(){
-#if CC_ENABLE_SCRIPT_BINDING
-        ScriptEngineManager::destroyInstance();
-#endif
         /** clean auto release pool. */
         PoolManager::destroyInstance();
     }

--- a/cocos/scripting/js-bindings/manual/ScriptingCore.cpp
+++ b/cocos/scripting/js-bindings/manual/ScriptingCore.cpp
@@ -396,17 +396,7 @@ bool JSB_core_restartVM(JSContext *cx, uint32_t argc, jsval *vp)
 
 bool JSB_closeWindow(JSContext *cx, uint32_t argc, jsval *vp)
 {
-    EventListenerCustom* _event = Director::getInstance()->getEventDispatcher()->addCustomEventListener(Director::EVENT_AFTER_DRAW, [&](EventCustom *event) {
-        Director::getInstance()->getEventDispatcher()->removeEventListener(_event);
-        CC_SAFE_RELEASE(_event);
-        
-        ScriptingCore::getInstance()->cleanup();
-    });
-    _event->retain();
     Director::getInstance()->end();
-#if (CC_TARGET_PLATFORM == CC_PLATFORM_IOS)
-    exit(0);
-#endif
     return true;
 };
 

--- a/templates/cpp-template-default/Classes/HelloWorldScene.cpp
+++ b/templates/cpp-template-default/Classes/HelloWorldScene.cpp
@@ -124,11 +124,7 @@ void HelloWorld::menuCloseCallback(Ref* pSender)
     //Close the cocos2d-x game scene and quit the application
     Director::getInstance()->end();
 
-    #if (CC_TARGET_PLATFORM == CC_PLATFORM_IOS)
-    exit(0);
-#endif
-
-    /*To navigate back to native iOS screen(if present) without quitting the application  ,do not use Director::getInstance()->end() and exit(0) as given above,instead trigger a custom event created in RootViewController.mm as below*/
+    /*To navigate back to native iOS screen(if present) without quitting the application  ,do not use Director::getInstance()->end() as given above,instead trigger a custom event created in RootViewController.mm as below*/
 
     //EventCustom customEndEvent("game_scene_close_event");
     //_eventDispatcher->dispatchEvent(&customEndEvent);

--- a/templates/js-template-default/frameworks/runtime-src/Classes/AppDelegate.cpp
+++ b/templates/js-template-default/frameworks/runtime-src/Classes/AppDelegate.cpp
@@ -95,7 +95,6 @@ AppDelegate::~AppDelegate()
 #elif USE_SIMPLE_AUDIO_ENGINE
     SimpleAudioEngine::end();
 #endif
-    ScriptEngineManager::destroyInstance();
 }
 
 void AppDelegate::initGLContextAttrs()

--- a/tests/cpp-empty-test/Classes/HelloWorldScene.cpp
+++ b/tests/cpp-empty-test/Classes/HelloWorldScene.cpp
@@ -100,8 +100,4 @@ bool HelloWorld::init()
 void HelloWorld::menuCloseCallback(Ref* sender)
 {
     Director::getInstance()->end();
-
-#if (CC_TARGET_PLATFORM == CC_PLATFORM_IOS)
-    exit(0);
-#endif
 }

--- a/tests/cpp-tests/Classes/BaseTest.cpp
+++ b/tests/cpp-tests/Classes/BaseTest.cpp
@@ -184,9 +184,6 @@ void TestList::runThisTest()
             TestController::getInstance()->stopAutoTest();
             TestController::destroyInstance();
             Director::getInstance()->end();
-#if (CC_TARGET_PLATFORM == CC_PLATFORM_IOS)
-            exit(0);
-#endif
         });
         closeItem->setPosition(VisibleRect::right().x - 30, VisibleRect::top().y - 30);
 

--- a/tests/cpp-tests/Classes/ExtensionsTest/NetworkTest/WebSocketTest.cpp
+++ b/tests/cpp-tests/Classes/ExtensionsTest/NetworkTest/WebSocketTest.cpp
@@ -346,9 +346,6 @@ WebSocketCloseTest::WebSocketCloseTest()
 
     auto closeItem = MenuItemImage::create(s_pathClose, s_pathClose, [](Ref* sender){
         Director::getInstance()->end();
-#if (CC_TARGET_PLATFORM == CC_PLATFORM_IOS)
-        exit(0);
-#endif
     });
     closeItem->setPosition(VisibleRect::right().x / 2, VisibleRect::top().y * 2 / 3);
 

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIVideoPlayerTest/UIVideoPlayerTest.cpp
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIVideoPlayerTest/UIVideoPlayerTest.cpp
@@ -93,10 +93,6 @@ bool VideoPlayerTest::init()
 void VideoPlayerTest::menuCloseCallback(Ref* sender)
 {
     Director::getInstance()->end();
-
-#if (CC_TARGET_PLATFORM == CC_PLATFORM_IOS)
-    exit(0);
-#endif
 }
 
 void VideoPlayerTest::menuFullScreenCallback(Ref* sender)

--- a/tests/game-controller-test/Classes/GameControllerTest.cpp
+++ b/tests/game-controller-test/Classes/GameControllerTest.cpp
@@ -473,8 +473,4 @@ void GameControllerTest::createControllerSprite(ControllerHolder& holder)
 void GameControllerTest::menuCloseCallback(Ref* sender)
 {
     Director::getInstance()->end();
-
-#if (CC_TARGET_PLATFORM == CC_PLATFORM_IOS)
-    exit(0);
-#endif
 }

--- a/tests/js-tests/project/Classes/AppDelegate.cpp
+++ b/tests/js-tests/project/Classes/AppDelegate.cpp
@@ -88,7 +88,6 @@ AppDelegate::AppDelegate()
 
 AppDelegate::~AppDelegate()
 {
-    ScriptEngineManager::destroyInstance();
 }
 
 void AppDelegate::initGLContextAttrs()

--- a/tests/lua-empty-test/project/Classes/AppDelegate.cpp
+++ b/tests/lua-empty-test/project/Classes/AppDelegate.cpp
@@ -42,7 +42,6 @@ AppDelegate::~AppDelegate()
 {
     // end simple audio engine here, or it may crashed on win32
     SimpleAudioEngine::getInstance()->end();
-    //CCScriptEngineManager::destroyInstance();
 }
 
 void AppDelegate::initGLContextAttrs()

--- a/tests/lua-game-controller-test/project/Classes/AppDelegate.cpp
+++ b/tests/lua-game-controller-test/project/Classes/AppDelegate.cpp
@@ -43,7 +43,6 @@ AppDelegate::~AppDelegate()
 {
     // end simple audio engine here, or it may crashed on win32
     SimpleAudioEngine::getInstance()->end();
-    //CCScriptEngineManager::destroyInstance();
 }
 
 bool AppDelegate::applicationDidFinishLaunching()

--- a/tests/lua-tests/src/mainMenu.lua
+++ b/tests/lua-tests/src/mainMenu.lua
@@ -199,10 +199,6 @@ function CreateTestMenu()
     CloseMenu:setPosition(0, 0)
     CloseMenu:addChild(CloseItem)
     menuLayer:addChild(CloseMenu)
-    local targetPlatform = cc.Application:getInstance():getTargetPlatform()       
-    if (cc.PLATFORM_OS_IPHONE == targetPlatform) or (cc.PLATFORM_OS_IPAD == targetPlatform) then
-        CloseMenu:setVisible(false)
-    end
 
     -- add menu items for tests
     local MainMenu = cc.Menu:create()

--- a/tests/performance-tests/Classes/tests/BaseTest.cpp
+++ b/tests/performance-tests/Classes/tests/BaseTest.cpp
@@ -184,9 +184,6 @@ void TestList::runThisTest()
             TestController::getInstance()->stopAutoTest();
             TestController::destroyInstance();
             Director::getInstance()->end();
-#if (CC_TARGET_PLATFORM == CC_PLATFORM_IOS)
-            exit(0);
-#endif
         });
         closeItem->setPosition(VisibleRect::right().x - 30, VisibleRect::top().y - 30);
 


### PR DESCRIPTION
- `exit(0)` in `JSB_closeWindow` case ScriptEngine static memory freed, so when the `ScriptEngineManager::destroyInstance` called later in AppDelegate destructor, double free occurs