### PR TITLE
[android] all test projects allow cleartext HTTP traffic

### DIFF
--- a/tests/cpp-empty-test/proj.android/app/AndroidManifest.xml
+++ b/tests/cpp-empty-test/proj.android/app/AndroidManifest.xml
@@ -6,6 +6,7 @@
     <uses-feature android:glEsVersion="0x00020000" />
     
     <application
+        android:usesCleartextTraffic="true"
         android:label="@string/app_name"
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher">

--- a/tests/cpp-tests/proj.android/app/AndroidManifest.xml
+++ b/tests/cpp-tests/proj.android/app/AndroidManifest.xml
@@ -8,6 +8,7 @@
     <uses-permission android:name="android.permission.VIBRATE"/>
     
     <application
+        android:usesCleartextTraffic="true"
         android:label="@string/app_name"
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher">

--- a/tests/game-controller-test/proj.android/app/AndroidManifest.xml
+++ b/tests/game-controller-test/proj.android/app/AndroidManifest.xml
@@ -13,6 +13,7 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
     
     <application
+        android:usesCleartextTraffic="true"
         android:label="@string/app_name"
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher">

--- a/tests/js-tests/project/proj.android/app/AndroidManifest.xml
+++ b/tests/js-tests/project/proj.android/app/AndroidManifest.xml
@@ -14,6 +14,7 @@
     <uses-permission android:name="android.permission.VIBRATE"/>
 
     <application
+        android:usesCleartextTraffic="true"
         android:label="@string/app_name"
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher">

--- a/tests/lua-empty-test/project/proj.android/app/AndroidManifest.xml
+++ b/tests/lua-empty-test/project/proj.android/app/AndroidManifest.xml
@@ -7,6 +7,7 @@
     <uses-permission android:name="android.permission.INTERNET"/>
     
     <application
+        android:usesCleartextTraffic="true"
         android:label="@string/app_name"
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher">

--- a/tests/lua-game-controller-test/project/proj.android/app/AndroidManifest.xml
+++ b/tests/lua-game-controller-test/project/proj.android/app/AndroidManifest.xml
@@ -11,6 +11,7 @@
     <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
     
     <application
+        android:usesCleartextTraffic="true"
         android:label="@string/app_name"
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher">

--- a/tests/lua-tests/project/proj.android/app/AndroidManifest.xml
+++ b/tests/lua-tests/project/proj.android/app/AndroidManifest.xml
@@ -8,6 +8,7 @@
     <uses-permission android:name="android.permission.VIBRATE"/>
     
     <application
+        android:usesCleartextTraffic="true"
         android:label="@string/app_name"
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher">

--- a/tests/performance-tests/proj.android/app/AndroidManifest.xml
+++ b/tests/performance-tests/proj.android/app/AndroidManifest.xml
@@ -6,6 +6,7 @@
     <uses-feature android:glEsVersion="0x00020000" />
     
     <application
+        android:usesCleartextTraffic="true"
         android:label="@string/app_name"
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher">


### PR DESCRIPTION
[cpp test] 19/2 httpclient test failed due to `java.io.IOException: Cleartext HTTP traffic to * not permitted`  on MI MIX 2S

fix by enabling `cleartext HTTP traffic` by default 

doc https://android-developers.googleblog.com/2016/04/protecting-against-unintentional.html