### PR TITLE
[external] update to v152

### DIFF
--- a/cocos/scripting/lua-bindings/manual/CCLuaStack.cpp
+++ b/cocos/scripting/lua-bindings/manual/CCLuaStack.cpp
@@ -136,7 +136,7 @@ bool LuaStack::init(void)
     toluafix_open(_state);
 
     // Register our version of the global "print" function
-    const luaL_reg global_functions [] = {
+    const luaL_Reg global_functions [] = {
         {"print", lua_print},
         {"release_print",lua_release_print},
         {nullptr, nullptr}

--- a/cocos/scripting/lua-bindings/manual/network/lua_downloader.cpp
+++ b/cocos/scripting/lua-bindings/manual/network/lua_downloader.cpp
@@ -311,7 +311,7 @@ static int lua_downloader_tostring(lua_State *L)
     return 1;
 }
 
-static const struct luaL_reg downloaderStaticFns[] = {
+static const struct luaL_Reg downloaderStaticFns[] = {
     { "new", lua_downloader_new }, 
     /* 
      * cocos2d::Downloader is not a subclass of cocos2d::Ref, 
@@ -322,7 +322,7 @@ static const struct luaL_reg downloaderStaticFns[] = {
     };
 
 
-static const struct luaL_reg downloaderMemberFns[] = {
+static const struct luaL_Reg downloaderMemberFns[] = {
     { "createDownloadDataTask", lua_downloader_createDownloadDataTask },
     { "createDownloadFileTask", lua_downloader_createDownloadFileTask },
     { "setOnFileTaskSuccess",   lua_downloader_setOnFileTaskSuccess },

--- a/external/config.json
+++ b/external/config.json
@@ -1,6 +1,6 @@
 {
-    "version": "v3-deps-151",
-    "zip_file_size": "146180003",
+    "version": "v3-deps-152",
+    "zip_file_size": "144236187",
     "repo_name": "cocos2d-x-3rd-party-libs-bin",
     "repo_parent": "https://github.com/cocos2d/",
     "move_dirs": {


### PR DESCRIPTION
- upgrade luajit from 2.1.0-beta2 to 2.1.0-beta3
- fix some include path

If we compile `lua-tests` with cmake & luajit, it crashes for around 30/100 chances on boot. This issue is resolved by upgrading luajit to a newer version. 