### PR TITLE
standardize pause & resume logic on GLSurfaceView

### DIFF
--- a/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxActivity.java
+++ b/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxActivity.java
@@ -287,6 +287,7 @@ public abstract class Cocos2dxActivity extends Activity implements Cocos2dxHelpe
 
         // Cocos2dxGLSurfaceView
         this.mGLSurfaceView = this.onCreateView();
+        this.mGLSurfaceView.setPreserveEGLContextOnPause(true);
 
         // ...add to FrameLayout
         mFrameLayout.addView(this.mGLSurfaceView);

--- a/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxGLSurfaceView.java
+++ b/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxGLSurfaceView.java
@@ -199,7 +199,7 @@ public class Cocos2dxGLSurfaceView extends GLSurfaceView {
             }
         });
         this.setRenderMode(RENDERMODE_WHEN_DIRTY);
-        //super.onPause();
+        super.onPause();
     }
 
     @Override


### PR DESCRIPTION
refer to

   https://stackoverflow.com/questions/2112768/prevent-onpause-from-trashing-opengl-context

This will reduce below issues when Activity onResume

```
call to OpenGL ES API with no current context (logged once per thread)
``` 