### PR TITLE
Fix for COCOS2D_DEBUG is always 1 on Android

### DIFF
--- a/cmake/Modules/CocosConfigDefine.cmake
+++ b/cmake/Modules/CocosConfigDefine.cmake
@@ -96,7 +96,7 @@ endif()
 
  # Set macro definitions for special platforms
  function(use_cocos2dx_compile_define target)
-    target_compile_definitions(${target} PUBLIC "COCOS2D_DEBUG$<$<CONFIG:Debug>:=1>")
+    target_compile_definitions(${target} PUBLIC $<$<CONFIG:Debug>:COCOS2D_DEBUG=1>)
     if(APPLE)
         target_compile_definitions(${target} PUBLIC __APPLE__)
         target_compile_definitions(${target} PUBLIC USE_FILE32API)


### PR DESCRIPTION
Looks like `-DCOCOS2D_DEBUG` and `-DCOCOS2D_DEBUG=1` are equal. We should define `COCOS2D_DEBUG=1` only in debug mode I think

Related #19289 