### PR TITLE
Fix deadlock in FileUtils::fullPathForFilename in Windows

### DIFF
--- a/cocos/platform/CCFileUtils.cpp
+++ b/cocos/platform/CCFileUtils.cpp
@@ -814,20 +814,9 @@ std::string FileUtils::getPathForFilename(const std::string& filename, const std
     return path;
 }
 
-std::string FileUtils::fullPathForFilename(const std::string &filename) const
+std::string FileUtils::fullPathForFilenameImpl(const std::string &filename) const
 {
-    
     DECLARE_GUARD;
-
-    if (filename.empty())
-    {
-        return "";
-    }
-
-    if (isAbsolutePath(filename))
-    {
-        return filename;
-    }
 
     // Already Cached ?
     auto cacheIter = _fullPathCache.find(filename);
@@ -856,13 +845,30 @@ std::string FileUtils::fullPathForFilename(const std::string &filename) const
 
         }
     }
+    // The file wasn't found, return empty string.
+    return "";    
+}
 
-    if(isPopupNotify()){
+std::string FileUtils::fullPathForFilename(const std::string &filename) const
+{
+    if (filename.empty())
+    {
+        return "";
+    }
+
+    if (isAbsolutePath(filename))
+    {
+        return filename;
+    }
+
+    std::string fullpath = fullPathForFilenameImpl(filename);
+
+    if(fullpath.empty() && isPopupNotify())
+    {
         CCLOG("cocos2d: fullPathForFilename: No file found at %s. Possible missing file.", filename.c_str());
     }
 
-    // The file wasn't found, return empty string.
-    return "";
+    return fullpath;
 }
 
 

--- a/cocos/platform/CCFileUtils.h
+++ b/cocos/platform/CCFileUtils.h
@@ -1007,6 +1007,11 @@ protected:
 
         AsyncTaskPool::getInstance()->enqueue(AsyncTaskPool::TaskType::TASK_IO, [](void*){}, nullptr, std::move(lambda));
     }
+private:
+    /**
+     *  Minimum scope to be thread safe needed by fullPathForFilename
+     */
+    std::string fullPathForFilenameImpl(const std::string &filename) const;
 };
 
 // end of support group


### PR DESCRIPTION
Fix deadlock in windows between ``FileUtils::_mutex`` and call to ``CCLOG`` (internally implemented using SendMessage which is blocking)

If ``FileUtils::fullPathForFilename`` is called from main thread and from a secondary thread, code may call to ``CCLOG``(internally ``SendMessage``) in secondary thread may be done while main thread is locked waiting to ``FileUtils::_mutex``. That way ``SendMessage`` cannot be handled nor mutex released

Fix is to reduce the scope where the mutex is locked