### PR TITLE
cmake support set iOS Deployment Target for root project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -179,3 +179,6 @@ tests/*/project/proj.android/.settings/org.eclipse.buildship.core.prefs
 # tmp folder for temp usage
 tmp/
 temp/
+
+# external libs zip
+*.zip

--- a/cmake/ios.toolchain.cmake
+++ b/cmake/ios.toolchain.cmake
@@ -35,8 +35,9 @@ set(UNIX True)
 set(APPLE True)
 set(IOS True)
 
-# Required as of cmake 2.8.10
-set(CMAKE_OSX_DEPLOYMENT_TARGET "" CACHE STRING "Force unset of the deployment target for iOS" FORCE)
+# support iOS on cmake 3.11+
+# cmake 3.11 milestone feature, https://gitlab.kitware.com/cmake/cmake/issues/17431 
+set(CMAKE_OSX_DEPLOYMENT_TARGET "8.0" CACHE STRING "set of the deployment target for iOS" FORCE)
 
 # Determine the cmake host system version so we know where to find the iOS SDKs
 find_program(CMAKE_UNAME uname /bin /usr/bin /usr/local/bin)


### PR DESCRIPTION
- refer to https://gitlab.kitware.com/cmake/cmake/issues/17431

> it's a cmake 3.11 milestone feature, so if using older version, nothing happy

---
![image](https://user-images.githubusercontent.com/26329291/51370450-1cfa6f00-1b32-11e9-96d4-0410779a0a74.png)
