### PR TITLE
Added restrictions to ui edit box input characters

### DIFF
--- a/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxEditBoxHelper.java
+++ b/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxEditBoxHelper.java
@@ -392,6 +392,29 @@ public class Cocos2dxEditBoxHelper {
         });
     }
 
+    public static void setInputRestriction(final int index, final int inputRestriction) {
+        mCocos2dxActivity.runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                Cocos2dxEditBox editBox = mEditBoxArray.get(index);
+                if (editBox != null) {
+                    editBox.setInputRestriction(inputRestriction);
+                }
+            }
+        });
+    }
+
+    public static void setUneditableTextLength(final int index, final int uneditableTextLength) {
+        mCocos2dxActivity.runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                Cocos2dxEditBox editBox = mEditBoxArray.get(index);
+                if (editBox != null) {
+                    editBox.setUneditableTextLength(uneditableTextLength);
+                }
+            }
+        });
+    }
 
     public static void setEditBoxViewRect(final int index, final int left, final int top, final int maxWidth, final int maxHeight) {
         mCocos2dxActivity.runOnUiThread(new Runnable() {

--- a/cocos/platform/android/jni/Java_org_cocos2dx_lib_Cocos2dxHelper.cpp
+++ b/cocos/platform/android/jni/Java_org_cocos2dx_lib_Cocos2dxHelper.cpp
@@ -38,6 +38,7 @@ THE SOFTWARE.
 #define  LOGD(...)  __android_log_print(ANDROID_LOG_DEBUG,LOG_TAG,__VA_ARGS__)
 
 static const std::string className = "org.cocos2dx.lib.Cocos2dxHelper";
+static const std::string editBoxClassName = "org.cocos2dx.lib.Cocos2dxEditBoxHelper";
 
 static EditTextCallback s_editTextCallback = nullptr;
 static void* s_ctx = nullptr;
@@ -131,6 +132,27 @@ int getDeviceAudioBufferSizeInFrames()
 {
     return __deviceAudioBufferSizeInFrames;
 }
+
+void setInputRestrictionEditBoxJNI(int index, int inputRestriction) 
+{
+    JniMethodInfo t;
+
+    if (JniHelper::getStaticMethodInfo(t, editBoxClassName.c_str(), "setInputRestriction", "(II)V")) {
+        t.env->CallStaticVoidMethod(t.classID, t.methodID, index, inputRestriction);
+        t.env->DeleteLocalRef(t.classID);
+    }
+}
+
+void setUneditableTextLengthEditBoxJNI(int index, int uneditableTextLength) 
+{
+    JniMethodInfo t;
+
+    if (JniHelper::getStaticMethodInfo(t, editBoxClassName.c_str(), "setUneditableTextLength", "(II)V")) {
+        t.env->CallStaticVoidMethod(t.classID, t.methodID, index, uneditableTextLength);
+        t.env->DeleteLocalRef(t.classID);
+    }
+}
+
 
 void conversionEncodingJNI(const char* src, int byteSize, const char* fromCharset, char* dst, const char* newCharset)
 {

--- a/cocos/platform/android/jni/Java_org_cocos2dx_lib_Cocos2dxHelper.h
+++ b/cocos/platform/android/jni/Java_org_cocos2dx_lib_Cocos2dxHelper.h
@@ -38,4 +38,7 @@ extern void conversionEncodingJNI(const char* src, int byteSize, const char* fro
 extern int getDeviceSampleRate();
 extern int getDeviceAudioBufferSizeInFrames();
 
+extern void setInputRestrictionEditBoxJNI(int index, int inputRestriction);
+extern void setUneditableTextLengthEditBoxJNI(int index, int uneditableTextLength);
+
 #endif /* __Java_org_cocos2dx_lib_Cocos2dxHelper_H__ */

--- a/cocos/ui/UIEditBox/UIEditBox.cpp
+++ b/cocos/ui/UIEditBox/UIEditBox.cpp
@@ -81,6 +81,22 @@ void EditBox::openKeyboard() const
 {
     _editBoxImpl->openKeyboard();
 }
+    
+void EditBox::setInputRestriction(int inputRestriction)
+{
+    if (_editBoxImpl)
+    {
+        _editBoxImpl->setInputRestriction(inputRestriction);
+    }
+}
+
+void EditBox::setUneditableTextLength(int uneditableTextLength)
+{
+    if (_editBoxImpl)
+    {
+        _editBoxImpl->setUneditableTextLength(uneditableTextLength);
+    }
+}
 
 void EditBox::touchDownAction(Ref* /*sender*/, TouchEventType controlEvent)
 {

--- a/cocos/ui/UIEditBox/UIEditBox.h
+++ b/cocos/ui/UIEditBox/UIEditBox.h
@@ -124,6 +124,17 @@ namespace ui {
             GO,
             NEXT
         };
+        
+        /**
+         * @brief The EditBox::InputRestrictionFlag defines the flags to set how input is restricted
+         * to enter.
+         */
+        enum class InputRestrictionFlag
+        {
+            ALNUM = 1 << 2,
+            SPACE = 1 << 3,
+            PUNCT = 1 << 4
+        };
 
         /**
          * @brief The EditBox::InputMode defines the type of text that the user is allowed
@@ -664,6 +675,19 @@ namespace ui {
         void touchDownAction(Ref *sender, TouchEventType controlEvent);
 
         void openKeyboard() const;
+        
+        /**
+         * Adds a type of input restriction. For example just accept alpha-numeric keys
+         *
+         * @param inputRestriction Combination of masks to set, use the values set
+         * in the InputRestrictionFlag enum
+         */
+        void setInputRestriction(int inputRestriction);
+        
+        /**
+         * Makes that the first 'uneditableTextLength' characters can't be changed by the user
+         */
+        void setUneditableTextLength(int uneditableTextLength);
 
     protected:
         virtual void releaseUpEvent() override;

--- a/cocos/ui/UIEditBox/UIEditBoxImpl-android.cpp
+++ b/cocos/ui/UIEditBox/UIEditBoxImpl-android.cpp
@@ -31,6 +31,7 @@
 
 #include "ui/UIEditBox/UIEditBox.h"
 #include <jni.h>
+#include "platform/android/jni/Java_org_cocos2dx_lib_Cocos2dxHelper.h"
 #include "platform/android/jni/JniHelper.h"
 #include "2d/CCLabel.h"
 #include "base/ccUTF8.h"
@@ -211,6 +212,16 @@ void EditBoxImplAndroid::nativeOpenKeyboard()
 void EditBoxImplAndroid::nativeCloseKeyboard()
 {
     JniHelper::callStaticVoidMethod(editBoxClassName, "closeKeyboard", _editBoxIndex);
+}
+
+void EditBoxImplAndroid::setNativeInputRestriction(int inputRestriction)
+{
+    setInputRestrictionEditBoxJNI(_editBoxIndex, inputRestriction);
+}
+
+void EditBoxImplAndroid::setNativeUneditableTextLength(int uneditableTextLength)
+{
+    setUneditableTextLengthEditBoxJNI(_editBoxIndex, uneditableTextLength);
 }
 
 void editBoxEditingDidBegin(int index)

--- a/cocos/ui/UIEditBox/UIEditBoxImpl-android.h
+++ b/cocos/ui/UIEditBox/UIEditBoxImpl-android.h
@@ -73,6 +73,9 @@ public:
     virtual void nativeOpenKeyboard() override;
     virtual void nativeCloseKeyboard() override;
     virtual void setNativeMaxLength(int maxLength) override;
+
+    virtual void setNativeInputRestriction(int inputRestriction) override;
+    virtual void setNativeUneditableTextLength(int uneditableTextLength) override;
     
 private:
     int _editBoxIndex;

--- a/cocos/ui/UIEditBox/UIEditBoxImpl-common.cpp
+++ b/cocos/ui/UIEditBox/UIEditBoxImpl-common.cpp
@@ -61,6 +61,8 @@ EditBoxImplCommon::EditBoxImplCommon(EditBox* pEditText)
 , _placeholderFontSize(-1)
 , _colText(Color3B::WHITE)
 , _colPlaceHolder(Color3B::GRAY)
+, _inputRestriction(0)
+, _uneditableTextLength(0)
 , _maxLength(-1)
 , _editingMode(false)
 {
@@ -323,6 +325,20 @@ void EditBoxImplCommon::closeKeyboard()
     this->nativeCloseKeyboard();
     _editingMode = false;
 }
+
+
+void EditBoxImplCommon::setInputRestriction(int inputRestriction)
+{
+    this->setNativeInputRestriction(inputRestriction);
+    _inputRestriction = inputRestriction;
+}
+
+void EditBoxImplCommon::setUneditableTextLength(int uneditableTextLength)
+{
+    this->setNativeUneditableTextLength(uneditableTextLength);
+    _uneditableTextLength = uneditableTextLength;
+}
+
 
 void EditBoxImplCommon::onEndEditing(const std::string& /*text*/)
 {

--- a/cocos/ui/UIEditBox/UIEditBoxImpl-common.h
+++ b/cocos/ui/UIEditBox/UIEditBoxImpl-common.h
@@ -105,6 +105,12 @@ public:
     virtual void openKeyboard() override;
     virtual void closeKeyboard() override;
 
+    virtual void setInputRestriction(int inputRestriction) override;
+    virtual void setUneditableTextLength(int uneditableTextLength) override;
+
+    virtual int  getInputRestriction() override { return _inputRestriction; }
+    virtual int  getUneditableTextLength() override { return _uneditableTextLength; }
+
     virtual void onEndEditing(const std::string& text);
 
     void editBoxEditingDidBegin();
@@ -128,6 +134,10 @@ public:
     virtual const char* getNativeDefaultFontName() = 0;
     virtual void nativeOpenKeyboard() = 0;
     virtual void nativeCloseKeyboard() = 0;
+    
+    virtual void setNativeInputRestriction(int inputRestriction) = 0;
+    virtual void setNativeUneditableTextLength(int uneditableTextLength) = 0;
+  
     virtual void setNativeMaxLength(int maxLength) {};
 
 
@@ -142,6 +152,7 @@ protected:
     Label* _labelPlaceHolder;
     EditBox::InputMode    _editBoxInputMode;
     EditBox::InputFlag    _editBoxInputFlag;
+    int                   _editBoxInputRestriction;
     EditBox::KeyboardReturnType  _keyboardReturnType;
     TextHAlignment _alignment;
 
@@ -157,6 +168,8 @@ protected:
     Color4B _colText;
     Color4B _colPlaceHolder;
 
+    int _inputRestriction;
+    int _uneditableTextLength;
     int   _maxLength;
     Size _contentSize;
     bool _editingMode;

--- a/cocos/ui/UIEditBox/UIEditBoxImpl-ios.h
+++ b/cocos/ui/UIEditBox/UIEditBoxImpl-ios.h
@@ -73,6 +73,9 @@ public:
     virtual void nativeOpenKeyboard() override;
     virtual void nativeCloseKeyboard() override;
     
+    virtual void setNativeInputRestriction(int inputRestriction) override;
+    virtual void setNativeUneditableTextLength(int uneditableTextLength) override;
+    
     //need to remove siri text
     virtual const char* getText(void)override;
 

--- a/cocos/ui/UIEditBox/UIEditBoxImpl-ios.mm
+++ b/cocos/ui/UIEditBox/UIEditBoxImpl-ios.mm
@@ -213,7 +213,17 @@ void EditBoxImplIOS::nativeCloseKeyboard()
 {
     [_systemControl closeKeyboard];
 }
-    
+
+void EditBoxImplIOS::setNativeInputRestriction(int inputRestriction)
+{
+    //no-op all done in CCUIEditBoxIOS.mm using getInputRestriction()
+}
+
+void EditBoxImplIOS::setNativeUneditableTextLength(int uneditableTextLength)
+{
+    //no-op all done in CCUIEditBoxIOS.mm using getUneditableTextLength()
+}
+
 UIFont* EditBoxImplIOS::constructFont(const char *fontName, int fontSize)
 {
     CCASSERT(fontName != nullptr, "fontName can't be nullptr");

--- a/cocos/ui/UIEditBox/UIEditBoxImpl-linux.cpp
+++ b/cocos/ui/UIEditBox/UIEditBoxImpl-linux.cpp
@@ -103,6 +103,14 @@ bool EditBoxImplLinux::isEditing()
     return false;
 }
 
+void EditBoxImplLinux::setNativeInputRestriction(int inputRestriction) {
+	// not implemented yet
+}
+
+void EditBoxImplLinux::setNativeUneditableTextLength(int uneditableTextLength) {
+	// not implemented yet
+}
+
 void EditBoxImplLinux::nativeOpenKeyboard()
 {
     std::string text = this->getText();

--- a/cocos/ui/UIEditBox/UIEditBoxImpl-linux.h
+++ b/cocos/ui/UIEditBox/UIEditBoxImpl-linux.h
@@ -74,6 +74,8 @@ public:
     virtual void nativeCloseKeyboard() override {};
     virtual void setNativeMaxLength(int maxLength) override {};
 
+    virtual void setNativeInputRestriction(int inputRestriction) override;
+    virtual void setNativeUneditableTextLength(int uneditableTextLength) override;
     
 private:
     virtual void doAnimationWhenKeyboardMove(float duration, float distance)override {}

--- a/cocos/ui/UIEditBox/UIEditBoxImpl-mac.h
+++ b/cocos/ui/UIEditBox/UIEditBoxImpl-mac.h
@@ -73,6 +73,9 @@ public:
     virtual void nativeOpenKeyboard() override;
     virtual void nativeCloseKeyboard() override;
     virtual void setNativeMaxLength(int maxLength) override;
+    
+    virtual void setNativeInputRestriction(int inputRestriction) override;
+    virtual void setNativeUneditableTextLength(int uneditableTextLength) override;
 
 private:
     NSFont*    constructFont(const char* fontName, int fontSize);

--- a/cocos/ui/UIEditBox/UIEditBoxImpl-mac.mm
+++ b/cocos/ui/UIEditBox/UIEditBoxImpl-mac.mm
@@ -222,6 +222,16 @@ void EditBoxImplMac::nativeCloseKeyboard()
     [_sysEdit closeKeyboard];
 }
 
+void EditBoxImplMac::setNativeInputRestriction(int inputRestriction)
+{
+    //no-op all done in CCUIEditBoxMac.mm using getInputRestriction()
+}
+
+void EditBoxImplMac::setNativeUneditableTextLength(int uneditableTextLength)
+{
+    //no-op all done in CCUIEditBoxMac.mm using getUneditableTextLength()
+}
+
 }
 
 NS_CC_END

--- a/cocos/ui/UIEditBox/UIEditBoxImpl-tizen.cpp
+++ b/cocos/ui/UIEditBox/UIEditBoxImpl-tizen.cpp
@@ -444,6 +444,17 @@ void EditBoxImplTizen::closeKeyboard()
 
 }
 
+void EditBoxImplTizen::setNativeInputRestriction(int inputRestriction) 
+{ 
+    // not implemented yet     
+}
+
+void EditBoxImplTizen::setNativeUneditableTextLength(int uneditableTextLength) 
+{ 
+    // not implemented yet     
+} 
+
+
 }
 
 NS_CC_END

--- a/cocos/ui/UIEditBox/UIEditBoxImpl-tizen.h
+++ b/cocos/ui/UIEditBox/UIEditBoxImpl-tizen.h
@@ -106,6 +106,9 @@ public:
     virtual void openKeyboard();
     virtual void closeKeyboard();
 
+    virtual void setNativeInputRestriction(int inputRestriction) override;
+    virtual void setNativeUneditableTextLength(int uneditableTextLength) override;
+    
 private:
     Label* _label;
     Label* _labelPlaceHolder;

--- a/cocos/ui/UIEditBox/UIEditBoxImpl-win32.cpp
+++ b/cocos/ui/UIEditBox/UIEditBoxImpl-win32.cpp
@@ -301,6 +301,16 @@ namespace ui {
         //don't need to implement
     }
 
+    void EditBoxImplWin::setNativeInputRestriction(int inputRestriction) 
+    { 
+        // not implemented yet     
+    }
+
+    void EditBoxImplWin::setNativeUneditableTextLength(int uneditableTextLength) 
+    { 
+        // not implemented yet     
+    } 
+
     void EditBoxImplWin::setNativeMaxLength(int maxLength)
     {
         ::SendMessageW(_hwndEdit, EM_LIMITTEXT, maxLength, 0);

--- a/cocos/ui/UIEditBox/UIEditBoxImpl-win32.h
+++ b/cocos/ui/UIEditBox/UIEditBoxImpl-win32.h
@@ -63,6 +63,9 @@ namespace ui {
         virtual void nativeOpenKeyboard() override;
         virtual void nativeCloseKeyboard() override;
         virtual void setNativeMaxLength(int maxLength) override;
+    
+        virtual void setNativeInputRestriction(int inputRestriction) override;
+        virtual void setNativeUneditableTextLength(int uneditableTextLength) override;
 
     private:
         void createEditCtrl(bool singleLine);

--- a/cocos/ui/UIEditBox/UIEditBoxImpl-winrt.cpp
+++ b/cocos/ui/UIEditBox/UIEditBoxImpl-winrt.cpp
@@ -280,6 +280,16 @@ namespace cocos2d {
       _maxLength = maxLength;
     }
 
+    void EditBoxWinRT::setNativeInputRestriction(int inputRestriction) 
+    { 
+        // not implemented yet     
+    }
+
+    void EditBoxWinRT::setNativeUneditableTextLength(int uneditableTextLength) 
+    { 
+        // not implemented yet     
+    } 
+
     void EditBoxWinRT::_setTextHorizontalAlignment(TextBox^ textBox)
     {
       switch (_alignment) {

--- a/cocos/ui/UIEditBox/UIEditBoxImpl-winrt.h
+++ b/cocos/ui/UIEditBox/UIEditBoxImpl-winrt.h
@@ -142,6 +142,9 @@ namespace ui {
     virtual void nativeCloseKeyboard() override;
     virtual void setNativeMaxLength(int maxLength) override;
 
+    virtual void setNativeInputRestriction(int inputRestriction) override;
+    virtual void setNativeUneditableTextLength(int uneditableTextLength) override;
+
   private:
     cocos2d::Vec2 convertDesignCoordToXamlCoord(const cocos2d::Vec2& designCoord);
     virtual void doAnimationWhenKeyboardMove(float duration, float distance) override { CCLOG("Warning! doAnimationWhenKeyboardMove not supported on WinRT"); }

--- a/cocos/ui/UIEditBox/UIEditBoxImpl.h
+++ b/cocos/ui/UIEditBox/UIEditBoxImpl.h
@@ -82,6 +82,12 @@ namespace cocos2d {
             virtual void openKeyboard() = 0;
             virtual void closeKeyboard() = 0;
             
+            virtual void setInputRestriction(int inputRestriction) = 0;
+            virtual void setUneditableTextLength(int uneditableTextLength) = 0;
+
+            virtual int  getInputRestriction() = 0;
+            virtual int  getUneditableTextLength() = 0;
+            
             virtual void setPosition(const Vec2& pos) = 0;
             virtual void setVisible(bool visible) = 0;
             virtual void setContentSize(const Size& size) = 0;

--- a/cocos/ui/UIEditBox/iOS/CCUIEditBoxIOS.mm
+++ b/cocos/ui/UIEditBox/iOS/CCUIEditBoxIOS.mm
@@ -389,7 +389,36 @@
 
 - (BOOL)textView:(UITextView *)textView shouldChangeTextInRange:(NSRange)range replacementText:(NSString *)text
 {
-    int maxLength = getEditBoxImplIOS()->getMaxLength();
+    auto editBox = getEditBoxImplIOS();
+    
+    if (editBox->getUneditableTextLength() > 0) {
+        if (range.location < editBox->getUneditableTextLength() )
+        {
+            return NO;
+        }
+    }
+    
+    if (editBox->getInputRestriction() != 0)
+    {
+        bool alNumRestriction = (editBox->getInputRestriction() & (int) cocos2d::ui::EditBox::InputRestrictionFlag::ALNUM) == (int) cocos2d::ui::EditBox::InputRestrictionFlag::ALNUM;
+        bool spaceRestriction = (editBox->getInputRestriction() & (int) cocos2d::ui::EditBox::InputRestrictionFlag::SPACE) == (int) cocos2d::ui::EditBox::InputRestrictionFlag::SPACE;
+        bool punctRestriction = (editBox->getInputRestriction() & (int) cocos2d::ui::EditBox::InputRestrictionFlag::PUNCT) == (int) cocos2d::ui::EditBox::InputRestrictionFlag::PUNCT;
+        
+        if (alNumRestriction || spaceRestriction || punctRestriction) {
+            for (NSInteger charIdx=0; charIdx < text.length; charIdx++)
+            {
+                auto c = [text characterAtIndex:charIdx];
+                if ((alNumRestriction && isalnum(c) ) ||
+                    (spaceRestriction && isspace(c) ) ||
+                    (punctRestriction && (ispunct(c)  || c=='\n') )){
+                        continue;
+                    }
+                return NO;
+            }
+        }
+    }
+    
+    int maxLength = editBox->getMaxLength();
     if (maxLength < 0)
     {
         return YES;
@@ -477,7 +506,36 @@
  */
 - (BOOL)textField:(UITextField *)textField shouldChangeCharactersInRange:(NSRange)range replacementString:(NSString *)string
 {
-    int maxLength = getEditBoxImplIOS()->getMaxLength();
+    auto editBox = getEditBoxImplIOS();
+    
+    if (editBox->getUneditableTextLength() > 0) {
+        if (range.location < editBox->getUneditableTextLength() )
+        {
+            return NO;
+        }
+    }
+    
+    if (editBox->getInputRestriction() != 0)
+    {
+        bool alNumRestriction = (editBox->getInputRestriction() & (int) cocos2d::ui::EditBox::InputRestrictionFlag::ALNUM) == (int) cocos2d::ui::EditBox::InputRestrictionFlag::ALNUM;
+        bool spaceRestriction = (editBox->getInputRestriction() & (int) cocos2d::ui::EditBox::InputRestrictionFlag::SPACE) == (int) cocos2d::ui::EditBox::InputRestrictionFlag::SPACE;
+        bool punctRestriction = (editBox->getInputRestriction() & (int) cocos2d::ui::EditBox::InputRestrictionFlag::PUNCT) == (int) cocos2d::ui::EditBox::InputRestrictionFlag::PUNCT;
+        
+        if (alNumRestriction || spaceRestriction || punctRestriction) {
+            for (NSInteger charIdx=0; charIdx < string.length; charIdx++)
+            {
+                auto c = [string characterAtIndex:charIdx];
+                if ((alNumRestriction && isalnum(c) ) ||
+                    (spaceRestriction && isspace(c) ) ||
+                    (punctRestriction && (ispunct(c)  || c=='\n') )){
+                    continue;
+                }
+                return NO;
+            }
+        }
+    }
+    
+    int maxLength = editBox->getMaxLength();
     if (maxLength < 0) {
         return YES;
     }

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIEditBoxTest.cpp
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIEditBoxTest.cpp
@@ -36,6 +36,7 @@ UIEditBoxTests::UIEditBoxTests()
     ADD_TEST_CASE(UIEditBoxTestToggleVisibility);
     ADD_TEST_CASE(UIEditBoxTestTextHorizontalAlignment);
     ADD_TEST_CASE(UIEditBoxTestPressedAndDisabled);
+    ADD_TEST_CASE(UIEditBoxTestRestrictions);
 }
 
 // UIEditBoxTest
@@ -386,4 +387,52 @@ bool UIEditBoxTestPressedAndDisabled::init() {
     editbox->setEnabled(false);
 
     return true;
+}
+
+// UIEditBoxTestRestrictions
+bool UIEditBoxTestRestrictions::init()
+{
+    if (UIScene::init())
+    {
+        auto glview = Director::getInstance()->getOpenGLView();
+        auto visibleOrigin = glview->getVisibleOrigin();
+        auto visibleSize = glview->getVisibleSize();
+        
+        auto pBg = Sprite::create("Images/HelloWorld.png");
+        pBg->setPosition(Vec2(visibleOrigin.x+visibleSize.width/2, visibleOrigin.y+visibleSize.height/2));
+        addChild(pBg);
+        
+        auto editBoxSize = Size(visibleSize.width - 100, visibleSize.height * 0.1);
+        
+        // top
+        std::string pNormalSprite = "extensions/green_edit.png";
+        _editbox = ui::EditBox::create(editBoxSize + Size(0,40), ui::Scale9Sprite::create(pNormalSprite));
+        _editbox->setPosition(Vec2(visibleOrigin.x+visibleSize.width/2-50, visibleOrigin.y+visibleSize.height*3/4));
+        _editbox->setFontColor(Color3B::RED);
+        _editbox->setPlaceHolder("Only Alphanumeric characters");
+        _editbox->setPlaceholderFontColor(Color3B::WHITE);
+        _editbox->setMaxLength(25);
+        _editbox->setFontSize(editBoxSize.height/2);
+        _editbox->setText("Only alphanumeric test");
+        _editbox->setReturnType(ui::EditBox::KeyboardReturnType::DONE);
+        _editbox->setVisible(true);
+        _editbox->setInputRestriction( (int) EditBox::InputRestrictionFlag::ALNUM );
+        addChild(_editbox);
+        
+        _editbox2 = ui::EditBox::create(editBoxSize + Size(0,40), ui::Scale9Sprite::create(pNormalSprite));
+        _editbox2->setPosition(Vec2(visibleOrigin.x+visibleSize.width/2-50, visibleOrigin.y+visibleSize.height*1/4));
+        _editbox2->setFontColor(Color3B::RED);
+        _editbox2->setPlaceHolder("Name:");
+        _editbox2->setPlaceholderFontColor(Color3B::WHITE);
+        _editbox2->setMaxLength(25);
+        _editbox2->setFontSize(editBoxSize.height/2);
+        _editbox2->setText("Can't edit: can edit");
+        _editbox2->setReturnType(ui::EditBox::KeyboardReturnType::DONE);
+        _editbox2->setVisible(true);
+        _editbox2->setUneditableTextLength(11);
+        addChild(_editbox2);
+        
+        return true;
+    }
+    return false;
 }

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIEditBoxTest.cpp
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIEditBoxTest.cpp
@@ -416,7 +416,7 @@ bool UIEditBoxTestRestrictions::init()
         _editbox->setText("Only alphanumeric test");
         _editbox->setReturnType(ui::EditBox::KeyboardReturnType::DONE);
         _editbox->setVisible(true);
-        _editbox->setInputRestriction( (int) EditBox::InputRestrictionFlag::ALNUM );
+        _editbox->setInputRestriction( static_cast<int> (ui::EditBox::InputRestrictionFlag::ALNUM ));
         addChild(_editbox);
         
         _editbox2 = ui::EditBox::create(editBoxSize + Size(0,40), ui::Scale9Sprite::create(pNormalSprite));

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIEditBoxTest.h
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIEditBoxTest.h
@@ -88,4 +88,14 @@ public:
     virtual bool init() override;
 };
 
+class UIEditBoxTestRestrictions : public UIScene
+{
+public:
+    CREATE_FUNC(UIEditBoxTestRestrictions);
+    virtual bool init() override;
+    
+    cocos2d::ui::EditBox* _editbox;
+    cocos2d::ui::EditBox* _editbox2;
+};
+
 #endif /* defined(__cocos2d_tests__UIEditBoxTest__) */


### PR DESCRIPTION
Added tu UIEditBox methods to set restrictions options:

- setInputRestriction(int inputRestriction). Sets that only certain type of characters are accepted in the text box
- setUneditableTextLength(int uneditableTextLength): Feature to not allow user to edit the first characters of a text box

Implemented for iOS, android and Mac devices

Added example to cpp-tests