### PR TITLE
Fixed some potential crashes when loading big or invalid skeletons

### DIFF
--- a/cocos/editor-support/spine/SkeletonAnimation.cpp
+++ b/cocos/editor-support/spine/SkeletonAnimation.cpp
@@ -88,6 +88,10 @@ SkeletonAnimation* SkeletonAnimation::createWithJsonFile (const std::string& ske
 	spAtlas* atlas = spAtlas_createFromFile(atlasFile.c_str(), 0);
 	node->initWithJsonFile(skeletonJsonFile, atlas, scale);
 	node->autorelease();
+    	if(!node->getSkeleton() || !node->getSkeleton()->data)
+    	{
+        	return nullptr;
+    	}
 	return node;
 }
 

--- a/cocos/editor-support/spine/SkeletonAnimation.cpp
+++ b/cocos/editor-support/spine/SkeletonAnimation.cpp
@@ -88,10 +88,10 @@ SkeletonAnimation* SkeletonAnimation::createWithJsonFile (const std::string& ske
 	spAtlas* atlas = spAtlas_createFromFile(atlasFile.c_str(), 0);
 	node->initWithJsonFile(skeletonJsonFile, atlas, scale);
 	node->autorelease();
-    	if(!node->getSkeleton() || !node->getSkeleton()->data)
-    	{
-        	return nullptr;
-    	}
+    if(!node->getSkeleton() || !node->getSkeleton()->data)
+    {
+        CC_SAFE_RELEASE_NULL(node);
+    }
 	return node;
 }
 

--- a/cocos/editor-support/spine/SkeletonRenderer.cpp
+++ b/cocos/editor-support/spine/SkeletonRenderer.cpp
@@ -61,7 +61,7 @@ SkeletonRenderer* SkeletonRenderer::createWithFile (const std::string& skeletonD
 }
 
 void SkeletonRenderer::initialize () {
-	_worldVertices = new float[1000]; // Max number of vertices per mesh.
+	_worldVertices = new float[4096]; // Max number of vertices per mesh.
 	
 	_clipper = spSkeletonClipping_create();
 
@@ -77,21 +77,21 @@ void SkeletonRenderer::setSkeletonData (spSkeletonData *skeletonData, bool ownsS
 }
 
 SkeletonRenderer::SkeletonRenderer ()
-	: _atlas(nullptr), _attachmentLoader(nullptr), _debugSlots(false), _debugBones(false), _debugMeshes(false), _timeScale(1), _effect(nullptr) {
+	: _atlas(nullptr), _attachmentLoader(nullptr), _debugSlots(false), _debugBones(false), _debugMeshes(false), _timeScale(1), _skeleton(nullptr),_effect(nullptr) {
 }
 
 SkeletonRenderer::SkeletonRenderer (spSkeletonData *skeletonData, bool ownsSkeletonData)
-	: _atlas(nullptr), _attachmentLoader(nullptr), _debugSlots(false), _debugBones(false), _debugMeshes(false), _timeScale(1), _effect(nullptr) {
+	: _atlas(nullptr), _attachmentLoader(nullptr), _debugSlots(false), _debugBones(false), _debugMeshes(false), _timeScale(1), _skeleton(nullptr), _effect(nullptr) {
 	initWithData(skeletonData, ownsSkeletonData);
 }
 
 SkeletonRenderer::SkeletonRenderer (const std::string& skeletonDataFile, spAtlas* atlas, float scale)
-	: _atlas(nullptr), _attachmentLoader(nullptr), _debugSlots(false), _debugBones(false), _debugMeshes(false), _timeScale(1), _effect(nullptr) {
+	: _atlas(nullptr), _attachmentLoader(nullptr), _debugSlots(false), _debugBones(false), _debugMeshes(false), _timeScale(1), _skeleton(nullptr), _effect(nullptr) {
 	initWithJsonFile(skeletonDataFile, atlas, scale);
 }
 
 SkeletonRenderer::SkeletonRenderer (const std::string& skeletonDataFile, const std::string& atlasFile, float scale)
-	: _atlas(nullptr), _attachmentLoader(nullptr), _debugSlots(false), _debugBones(false), _debugMeshes(false), _timeScale(1), _effect(nullptr) {
+	: _atlas(nullptr), _attachmentLoader(nullptr), _debugSlots(false), _debugBones(false), _debugMeshes(false), _timeScale(1), _skeleton(nullptr), _effect(nullptr) {
 	initWithJsonFile(skeletonDataFile, atlasFile, scale);
 }
 
@@ -127,14 +127,23 @@ void SkeletonRenderer::initWithJsonFile (const std::string& skeletonDataFile, sp
 
 void SkeletonRenderer::initWithJsonFile (const std::string& skeletonDataFile, const std::string& atlasFile, float scale) {
 	_atlas = spAtlas_createFromFile(atlasFile.c_str(), 0);
-	CCASSERT(_atlas, "Error reading atlas file.");
-
+    
+    	if (!_atlas) {
+        	CCLOG("ERROR: reading atlas file: %s", atlasFile.c_str());
+		CCASSERT(_atlas, "Error reading atlas file.");
+    	}
+	
 	_attachmentLoader = SUPER(Cocos2dAttachmentLoader_create(_atlas));
 
 	spSkeletonJson* json = spSkeletonJson_createWithLoader(_attachmentLoader);
 	json->scale = scale;
 	spSkeletonData* skeletonData = spSkeletonJson_readSkeletonDataFile(json, skeletonDataFile.c_str());
-	CCASSERT(skeletonData, json->error ? json->error : "Error reading skeleton data file.");
+    
+    	if (!skeletonData) {
+        	CCLOG("ERROR reading skeleton data file: %s", skeletonDataFile.c_str());
+		CCASSERT(skeletonData, json->error ? json->error : "Error reading skeleton data file.");
+    	}
+	
 	spSkeletonJson_dispose(json);
 
 	setSkeletonData(skeletonData, true);

--- a/cocos/editor-support/spine/SkeletonRenderer.cpp
+++ b/cocos/editor-support/spine/SkeletonRenderer.cpp
@@ -128,21 +128,15 @@ void SkeletonRenderer::initWithJsonFile (const std::string& skeletonDataFile, sp
 void SkeletonRenderer::initWithJsonFile (const std::string& skeletonDataFile, const std::string& atlasFile, float scale) {
 	_atlas = spAtlas_createFromFile(atlasFile.c_str(), 0);
     
-    	if (!_atlas) {
-        	CCLOG("ERROR: reading atlas file: %s", atlasFile.c_str());
-		CCASSERT(_atlas, "Error reading atlas file.");
-    	}
-	
+    CCASSERT(_atlas, "Error reading atlas file.");
+
 	_attachmentLoader = SUPER(Cocos2dAttachmentLoader_create(_atlas));
 
 	spSkeletonJson* json = spSkeletonJson_createWithLoader(_attachmentLoader);
 	json->scale = scale;
 	spSkeletonData* skeletonData = spSkeletonJson_readSkeletonDataFile(json, skeletonDataFile.c_str());
     
-    	if (!skeletonData) {
-        	CCLOG("ERROR reading skeleton data file: %s", skeletonDataFile.c_str());
-		CCASSERT(skeletonData, json->error ? json->error : "Error reading skeleton data file.");
-    	}
+    CCASSERT(skeletonData, json->error ? json->error : "Error reading skeleton data file.");
 	
 	spSkeletonJson_dispose(json);
 


### PR DESCRIPTION
Increased size of world vertices for skeleton renderer to avoid some crashes. Added some null checks to avoid crashes and logs to determine the files that cause them.