### PR TITLE
Added capacity of dynamically toggle of debug rendering for Lables and Sprites

### DIFF
--- a/cocos/2d/CCLabel.cpp
+++ b/cocos/2d/CCLabel.cpp
@@ -49,7 +49,7 @@ NS_CC_BEGIN
 
 #if CC_LABEL_DEBUG_DRAW
 
-bool Label::_debugDrawEnabled = false;
+bool Label::_debugDrawEnabled = true;
 Color4F Label::_debugDrawColor = Color4F::WHITE;
 
 #endif

--- a/cocos/2d/CCLabel.cpp
+++ b/cocos/2d/CCLabel.cpp
@@ -47,6 +47,13 @@
 
 NS_CC_BEGIN
 
+#if CC_LABEL_DEBUG_DRAW
+
+bool Label::_debugDrawEnabled = false;
+Color4F Label::_debugDrawColor = Color4F::WHITE;
+
+#endif
+
 /**
  * LabelLetter used to update the quad in texture atlas without SpriteBatchNode.
  */
@@ -396,10 +403,16 @@ Label::Label(TextHAlignment hAlignment /* = TextHAlignment::LEFT */,
     _hAlignment = hAlignment;
     _vAlignment = vAlignment;
 
+    // CROWDSTAR START
 #if CC_LABEL_DEBUG_DRAW
-    _debugDrawNode = DrawNode::create();
-    addChild(_debugDrawNode);
+    _debugDrawNode = nullptr;
+    if (Label::_debugDrawEnabled)
+    {
+        _debugDrawNode = DrawNode::create();
+        addChild(_debugDrawNode);
+    }
 #endif
+    // CROWDSTAR END
 
     _purgeTextureListener = EventListenerCustom::create(FontAtlas::CMD_PURGE_FONTATLAS, [this](EventCustom* event){
         if (_fontAtlas && _currentLabelType == LabelType::TTF && event->getUserData() == _fontAtlas)
@@ -1468,17 +1481,22 @@ void Label::updateContent()
         _contentDirty = false;
     }
 
+    // CROWDSTAR START
 #if CC_LABEL_DEBUG_DRAW
-    _debugDrawNode->clear();
-    Vec2 vertices[4] =
+    if (Label::_debugDrawEnabled && _debugDrawNode)
     {
-        Vec2::ZERO,
-        Vec2(_contentSize.width, 0),
-        Vec2(_contentSize.width, _contentSize.height),
-        Vec2(0, _contentSize.height)
-    };
-    _debugDrawNode->drawPoly(vertices, 4, true, Color4F::WHITE);
+        _debugDrawNode->clear();
+        Vec2 vertices[4] =
+        {
+            Vec2::ZERO,
+            Vec2(_contentSize.width, 0),
+            Vec2(_contentSize.width, _contentSize.height),
+            Vec2(0, _contentSize.height)
+        };
+        _debugDrawNode->drawPoly(vertices, 4, true, Label::_debugDrawColor);
+    }
 #endif
+    // CROWDSTAR END
 }
 
 void Label::setBMFontSize(float fontSize)
@@ -1870,6 +1888,18 @@ float Label::getAdditionalKerning() const
 
     return _additionalKerning;
 }
+
+#if CC_LABEL_DEBUG_DRAW
+void Label::enableDebugDraw(const bool value)
+{
+    Label::_debugDrawEnabled = value;
+}
+
+void Label::setDebugDrawColor(Color4F& color)
+{
+    Label::_debugDrawColor = color;
+}
+#endif
 
 void Label::computeStringNumLines()
 {

--- a/cocos/2d/CCLabel.cpp
+++ b/cocos/2d/CCLabel.cpp
@@ -403,16 +403,17 @@ Label::Label(TextHAlignment hAlignment /* = TextHAlignment::LEFT */,
     _hAlignment = hAlignment;
     _vAlignment = vAlignment;
 
-    // CROWDSTAR START
 #if CC_LABEL_DEBUG_DRAW
-    _debugDrawNode = nullptr;
     if (Label::_debugDrawEnabled)
     {
         _debugDrawNode = DrawNode::create();
         addChild(_debugDrawNode);
     }
+    else
+    {
+        _debugDrawNode = nullptr;
+    }
 #endif
-    // CROWDSTAR END
 
     _purgeTextureListener = EventListenerCustom::create(FontAtlas::CMD_PURGE_FONTATLAS, [this](EventCustom* event){
         if (_fontAtlas && _currentLabelType == LabelType::TTF && event->getUserData() == _fontAtlas)
@@ -1481,7 +1482,6 @@ void Label::updateContent()
         _contentDirty = false;
     }
 
-    // CROWDSTAR START
 #if CC_LABEL_DEBUG_DRAW
     if (Label::_debugDrawEnabled && _debugDrawNode)
     {
@@ -1496,7 +1496,6 @@ void Label::updateContent()
         _debugDrawNode->drawPoly(vertices, 4, true, Label::_debugDrawColor);
     }
 #endif
-    // CROWDSTAR END
 }
 
 void Label::setBMFontSize(float fontSize)

--- a/cocos/2d/CCLabel.cpp
+++ b/cocos/2d/CCLabel.cpp
@@ -469,6 +469,18 @@ Label::~Label()
     CC_SAFE_RELEASE_NULL(_shadowNode);
 }
 
+#if CC_LABEL_DEBUG_DRAW
+void Label::enableDebugDraw(const bool value)
+{
+    Label::_debugDrawEnabled = value;
+}
+
+void Label::setDebugDrawColor(Color4F& color)
+{
+    Label::_debugDrawColor = color;
+}
+#endif
+
 void Label::reset()
 {
     CC_SAFE_RELEASE_NULL(_textSprite);
@@ -1887,18 +1899,6 @@ float Label::getAdditionalKerning() const
 
     return _additionalKerning;
 }
-
-#if CC_LABEL_DEBUG_DRAW
-void Label::enableDebugDraw(const bool value)
-{
-    Label::_debugDrawEnabled = value;
-}
-
-void Label::setDebugDrawColor(Color4F& color)
-{
-    Label::_debugDrawColor = color;
-}
-#endif
 
 void Label::computeStringNumLines()
 {

--- a/cocos/2d/CCLabel.h
+++ b/cocos/2d/CCLabel.h
@@ -585,6 +585,12 @@ public:
     float getAdditionalKerning() const;
 
     FontAtlas* getFontAtlas() { return _fontAtlas; }
+    
+#if CC_LABEL_DEBUG_DRAW
+    static void enableDebugDraw(const bool value);
+    static bool getDebugDrawEnabled() { return _debugDrawEnabled; }
+    static void setDebugDrawColor(Color4F& color);
+#endif
 
     virtual const BlendFunc& getBlendFunc() const override { return _blendFunc; }
     virtual void setBlendFunc(const BlendFunc &blendFunc) override;
@@ -779,6 +785,8 @@ protected:
 
 #if CC_LABEL_DEBUG_DRAW
     DrawNode* _debugDrawNode;
+    static bool _debugDrawEnabled;
+    static Color4F _debugDrawColor;
 #endif
 
     bool _enableWrap;

--- a/cocos/2d/CCLabel.h
+++ b/cocos/2d/CCLabel.h
@@ -585,12 +585,6 @@ public:
     float getAdditionalKerning() const;
 
     FontAtlas* getFontAtlas() { return _fontAtlas; }
-    
-#if CC_LABEL_DEBUG_DRAW
-    static void enableDebugDraw(const bool value);
-    static bool getDebugDrawEnabled() { return _debugDrawEnabled; }
-    static void setDebugDrawColor(Color4F& color);
-#endif
 
     virtual const BlendFunc& getBlendFunc() const override { return _blendFunc; }
     virtual void setBlendFunc(const BlendFunc &blendFunc) override;
@@ -635,6 +629,15 @@ CC_CONSTRUCTOR_ACCESS:
      * @lua NA
      */
     virtual ~Label();
+    
+#if CC_LABEL_DEBUG_DRAW
+    /// @name DebugDraw
+    /// @{
+    static void enableDebugDraw(const bool value);
+    static bool getDebugDrawEnabled() { return _debugDrawEnabled; }
+    static void setDebugDrawColor(Color4F& color);
+    /// @}
+#endif
 
     bool initWithTTF(const std::string& text, const std::string& fontFilePath, float fontSize,
                      const Size& dimensions = Size::ZERO, TextHAlignment hAlignment = TextHAlignment::LEFT,

--- a/cocos/2d/CCSprite.cpp
+++ b/cocos/2d/CCSprite.cpp
@@ -43,6 +43,13 @@ THE SOFTWARE.
 
 NS_CC_BEGIN
 
+#if CC_SPRITE_DEBUG_DRAW
+
+int Sprite::_debugDrawLevel = 0;
+Color4F Sprite::_debugDrawColor = Color4F::WHITE; //Color4F::RED
+
+#endif
+
 // MARK: create, init, dealloc
 Sprite* Sprite::createWithTexture(Texture2D *texture)
 {
@@ -190,6 +197,19 @@ bool Sprite::initWithFile(const std::string& filename)
     return false;
 }
 
+#if CC_SPRITE_DEBUG_DRAW
+void Sprite::SetDebugDrawLevel(int value)
+{
+    Sprite::_debugDrawLevel = value;
+}
+
+void Sprite::SetDebugDrawColor(const Color4F& color)
+{
+    Sprite::_debugDrawColor = color;
+}
+#endif
+
+
 bool Sprite::initWithFile(const std::string &filename, const Rect& rect)
 {
     CCASSERT(!filename.empty(), "Invalid filename");
@@ -322,8 +342,11 @@ Sprite::Sprite()
 , _stretchEnabled(true)
 {
 #if CC_SPRITE_DEBUG_DRAW
-    _debugDrawNode = DrawNode::create();
-    addChild(_debugDrawNode);
+    if (Sprite::_debugDrawLevel > 0)
+    {
+        _debugDrawNode = DrawNode::create();
+        addChild(_debugDrawNode, INT_MAX); // CROWDSTAR: Check seconds parameter INT_MAX
+    }
 #endif //CC_SPRITE_DEBUG_DRAW
 }
 
@@ -1081,26 +1104,29 @@ void Sprite::draw(Renderer *renderer, const Mat4 &transform, uint32_t flags)
                                flags);
 
         renderer->addCommand(&_trianglesCommand);
-
+        
 #if CC_SPRITE_DEBUG_DRAW
-        _debugDrawNode->clear();
-        auto count = _polyInfo.triangles.indexCount/3;
-        auto indices = _polyInfo.triangles.indices;
-        auto verts = _polyInfo.triangles.verts;
-        for(ssize_t i = 0; i < count; i++)
+        if (Sprite::_debugDrawLevel && _debugDrawNode)
         {
-            //draw 3 lines
-            Vec3 from =verts[indices[i*3]].vertices;
-            Vec3 to = verts[indices[i*3+1]].vertices;
-            _debugDrawNode->drawLine(Vec2(from.x, from.y), Vec2(to.x,to.y), Color4F::WHITE);
+            _debugDrawNode->clear();
+            auto count = _polyInfo.triangles.indexCount/3;
+            auto indices = _polyInfo.triangles.indices;
+            auto verts = _polyInfo.triangles.verts;
+            for(ssize_t i = 0; i < count; i++)
+            {
+                //draw 3 lines
+                Vec3 from =verts[indices[i*3]].vertices;
+                Vec3 to = verts[indices[i*3+1]].vertices;
+                _debugDrawNode->drawLine(Vec2(from.x, from.y), Vec2(to.x,to.y), Sprite::_debugDrawColor);
 
-            from =verts[indices[i*3+1]].vertices;
-            to = verts[indices[i*3+2]].vertices;
-            _debugDrawNode->drawLine(Vec2(from.x, from.y), Vec2(to.x,to.y), Color4F::WHITE);
+                from =verts[indices[i*3+1]].vertices;
+                to = verts[indices[i*3+2]].vertices;
+                _debugDrawNode->drawLine(Vec2(from.x, from.y), Vec2(to.x,to.y), Sprite::_debugDrawColor);
 
-            from =verts[indices[i*3+2]].vertices;
-            to = verts[indices[i*3]].vertices;
-            _debugDrawNode->drawLine(Vec2(from.x, from.y), Vec2(to.x,to.y), Color4F::WHITE);
+                from =verts[indices[i*3+2]].vertices;
+                to = verts[indices[i*3]].vertices;
+                _debugDrawNode->drawLine(Vec2(from.x, from.y), Vec2(to.x,to.y), Sprite::_debugDrawColor);
+            }
         }
 #endif //CC_SPRITE_DEBUG_DRAW
     }

--- a/cocos/2d/CCSprite.cpp
+++ b/cocos/2d/CCSprite.cpp
@@ -45,7 +45,7 @@ NS_CC_BEGIN
 
 #if CC_SPRITE_DEBUG_DRAW
 
-int Sprite::_debugDrawLevel = 0;
+int Sprite::_debugDrawLevel = 2;
 Color4F Sprite::_debugDrawColor = Color4F::WHITE; //Color4F::RED
 
 #endif

--- a/cocos/2d/CCSprite.cpp
+++ b/cocos/2d/CCSprite.cpp
@@ -198,12 +198,12 @@ bool Sprite::initWithFile(const std::string& filename)
 }
 
 #if CC_SPRITE_DEBUG_DRAW
-void Sprite::SetDebugDrawLevel(int value)
+void Sprite::setDebugDrawLevel(int value)
 {
     Sprite::_debugDrawLevel = value;
 }
 
-void Sprite::SetDebugDrawColor(const Color4F& color)
+void Sprite::setDebugDrawColor(const Color4F& color)
 {
     Sprite::_debugDrawColor = color;
 }
@@ -345,7 +345,11 @@ Sprite::Sprite()
     if (Sprite::_debugDrawLevel > 0)
     {
         _debugDrawNode = DrawNode::create();
-        addChild(_debugDrawNode, INT_MAX); // CROWDSTAR: Check seconds parameter INT_MAX
+        addChild(_debugDrawNode, INT_MAX);
+    }
+    else
+    {
+        _debugDrawNode = nullptr;
     }
 #endif //CC_SPRITE_DEBUG_DRAW
 }

--- a/cocos/2d/CCSprite.cpp
+++ b/cocos/2d/CCSprite.cpp
@@ -197,19 +197,6 @@ bool Sprite::initWithFile(const std::string& filename)
     return false;
 }
 
-#if CC_SPRITE_DEBUG_DRAW
-void Sprite::setDebugDrawLevel(int value)
-{
-    Sprite::_debugDrawLevel = value;
-}
-
-void Sprite::setDebugDrawColor(const Color4F& color)
-{
-    Sprite::_debugDrawColor = color;
-}
-#endif
-
-
 bool Sprite::initWithFile(const std::string &filename, const Rect& rect)
 {
     CCASSERT(!filename.empty(), "Invalid filename");
@@ -361,6 +348,18 @@ Sprite::~Sprite()
     CC_SAFE_RELEASE(_spriteFrame);
     CC_SAFE_RELEASE(_texture);
 }
+
+#if CC_SPRITE_DEBUG_DRAW
+void Sprite::setDebugDrawLevel(int value)
+{
+    Sprite::_debugDrawLevel = value;
+}
+
+void Sprite::setDebugDrawColor(const Color4F& color)
+{
+    Sprite::_debugDrawColor = color;
+}
+#endif
 
 /*
  * Texture methods

--- a/cocos/2d/CCSprite.cpp
+++ b/cocos/2d/CCSprite.cpp
@@ -45,7 +45,7 @@ NS_CC_BEGIN
 
 #if CC_SPRITE_DEBUG_DRAW
 
-int Sprite::_debugDrawLevel = 2;
+bool Sprite::_debugDrawEnabled = true;
 Color4F Sprite::_debugDrawColor = Color4F::WHITE; //Color4F::RED
 
 #endif
@@ -329,7 +329,7 @@ Sprite::Sprite()
 , _stretchEnabled(true)
 {
 #if CC_SPRITE_DEBUG_DRAW
-    if (Sprite::_debugDrawLevel > 0)
+    if (Sprite::_debugDrawEnabled)
     {
         _debugDrawNode = DrawNode::create();
         addChild(_debugDrawNode, INT_MAX);
@@ -350,9 +350,9 @@ Sprite::~Sprite()
 }
 
 #if CC_SPRITE_DEBUG_DRAW
-void Sprite::setDebugDrawLevel(int value)
+void Sprite::enableDebugDraw(const bool value)
 {
-    Sprite::_debugDrawLevel = value;
+    Sprite::_debugDrawEnabled = value;
 }
 
 void Sprite::setDebugDrawColor(const Color4F& color)
@@ -1109,7 +1109,7 @@ void Sprite::draw(Renderer *renderer, const Mat4 &transform, uint32_t flags)
         renderer->addCommand(&_trianglesCommand);
         
 #if CC_SPRITE_DEBUG_DRAW
-        if (Sprite::_debugDrawLevel && _debugDrawNode)
+        if (Sprite::_debugDrawEnabled && _debugDrawNode)
         {
             _debugDrawNode->clear();
             auto count = _polyInfo.triangles.indexCount/3;

--- a/cocos/2d/CCSprite.h
+++ b/cocos/2d/CCSprite.h
@@ -647,6 +647,12 @@ CC_CONSTRUCTOR_ACCESS :
      * @lua     init
      */
     virtual bool initWithFile(const std::string& filename, const Rect& rect);
+
+#if CC_SPRITE_DEBUG_DRAW
+    static void SetDebugDrawLevel(int value);
+    static int GetDebugDrawLevel() { return _debugDrawLevel; }
+    static void SetDebugDrawColor(const Color4F& color);
+#endif
     
 protected:
 
@@ -727,6 +733,12 @@ protected:
 
 private:
     CC_DISALLOW_COPY_AND_ASSIGN(Sprite);
+    
+#if CC_SPRITE_DEBUG_DRAW
+    static int _debugDrawLevel;	       /// Determine to draw or not debug sprite info (0 disabled, 1 bbox, 2 texture box)
+    static Color4F _debugDrawColor;    /// Color to be used to paint the debug bounding boxes
+#endif
+
 };
 
 

--- a/cocos/2d/CCSprite.h
+++ b/cocos/2d/CCSprite.h
@@ -649,9 +649,9 @@ CC_CONSTRUCTOR_ACCESS :
     virtual bool initWithFile(const std::string& filename, const Rect& rect);
 
 #if CC_SPRITE_DEBUG_DRAW
-    static void SetDebugDrawLevel(int value);
-    static int GetDebugDrawLevel() { return _debugDrawLevel; }
-    static void SetDebugDrawColor(const Color4F& color);
+    static void setDebugDrawLevel(int value);
+    static int getDebugDrawLevel() { return _debugDrawLevel; }
+    static void setDebugDrawColor(const Color4F& color);
 #endif
     
 protected:

--- a/cocos/2d/CCSprite.h
+++ b/cocos/2d/CCSprite.h
@@ -551,6 +551,15 @@ CC_CONSTRUCTOR_ACCESS :
      */
     Sprite();
     virtual ~Sprite();
+    
+#if CC_SPRITE_DEBUG_DRAW
+    /// @name DebugDraw
+    /// @{
+    static void setDebugDrawLevel(int value);
+    static int getDebugDrawLevel() { return _debugDrawLevel; }
+    static void setDebugDrawColor(const Color4F& color);
+    /// @}
+#endif
 
     /* Initializes an empty sprite with no parameters. */
     virtual bool init() override;
@@ -648,11 +657,7 @@ CC_CONSTRUCTOR_ACCESS :
      */
     virtual bool initWithFile(const std::string& filename, const Rect& rect);
 
-#if CC_SPRITE_DEBUG_DRAW
-    static void setDebugDrawLevel(int value);
-    static int getDebugDrawLevel() { return _debugDrawLevel; }
-    static void setDebugDrawColor(const Color4F& color);
-#endif
+
     
 protected:
 

--- a/cocos/2d/CCSprite.h
+++ b/cocos/2d/CCSprite.h
@@ -555,8 +555,8 @@ CC_CONSTRUCTOR_ACCESS :
 #if CC_SPRITE_DEBUG_DRAW
     /// @name DebugDraw
     /// @{
-    static void setDebugDrawLevel(int value);
-    static int getDebugDrawLevel() { return _debugDrawLevel; }
+    static void enableDebugDraw(const bool value);
+    static bool getDebugDrawEnabled() { return _debugDrawEnabled; }
     static void setDebugDrawColor(const Color4F& color);
     /// @}
 #endif
@@ -740,7 +740,7 @@ private:
     CC_DISALLOW_COPY_AND_ASSIGN(Sprite);
     
 #if CC_SPRITE_DEBUG_DRAW
-    static int _debugDrawLevel;	       /// Determine to draw or not debug sprite info (0 disabled, 1 bbox, 2 texture box)
+    static bool _debugDrawEnabled;	   /// Is debug drawing of sprites enabled or not
     static Color4F _debugDrawColor;    /// Color to be used to paint the debug bounding boxes
 #endif
 

--- a/cocos/base/ccConfig.h
+++ b/cocos/base/ccConfig.h
@@ -183,34 +183,26 @@ THE SOFTWARE.
  * 0 -- disabled
  * 1 -- draw bounding box code is enabled
  *
- * To activate bounding boxes, use Label::SetDebugDrawLevel(drawlevel), where
+ * To activate bounding boxes in runtime, use Label::eetDebugDrawLevel(drawlevel), where
  * 0 -- disabled
  * 1 -- draw bounding box
  * 2 -- draw texture box
  */
 #ifndef CC_SPRITE_DEBUG_DRAW
-#if defined(COCOS2D_DEBUG)
-    #define CC_SPRITE_DEBUG_DRAW 1 // Activate by default in DEBUG
-#else
     #define CC_SPRITE_DEBUG_DRAW 0
-#endif
 #endif
 
 /** @def CC_LABEL_DEBUG_DRAW
  * If enabled, all subclasses of Label will be able to draw a bounding box.
  * Useful for debugging purposes only. It is recommended to leave it disabled.
  * To enable set it to a value different than 0. Enabled by default in DEBUG,
- * To activate bounding boxes, use Label::EnableDebugDraw(true);
+ * To activate bounding boxes, use Label::enableDebugDraw(true);
  * Disabled by default in other configurations:
  * 0 -- disabled
  * 1 -- draw bounding box code is enabled
  */
 #ifndef CC_LABEL_DEBUG_DRAW
-#if defined(COCOS2D_DEBUG)
-    #define CC_LABEL_DEBUG_DRAW 1 // Activate by default in DEBUG
-#else
     #define CC_LABEL_DEBUG_DRAW 0
-#endif
 #endif
 
 /** @def CC_SPRITEBATCHNODE_DEBUG_DRAW

--- a/cocos/base/ccConfig.h
+++ b/cocos/base/ccConfig.h
@@ -180,24 +180,37 @@ THE SOFTWARE.
 /** @def CC_SPRITE_DEBUG_DRAW
  * If enabled, all subclasses of Sprite will draw a bounding box.
  * Useful for debugging purposes only. It is recommended to leave it disabled.
- * To enable set it to a value different than 0. Disabled by default:
+ * 0 -- disabled
+ * 1 -- draw bounding box code is enabled
+ *
+ * To activate bounding boxes, use Label::SetDebugDrawLevel(drawlevel), where
  * 0 -- disabled
  * 1 -- draw bounding box
  * 2 -- draw texture box
  */
 #ifndef CC_SPRITE_DEBUG_DRAW
-#define CC_SPRITE_DEBUG_DRAW 0
+#if defined(COCOS2D_DEBUG)
+    #define CC_SPRITE_DEBUG_DRAW 1 // Activate by default in DEBUG
+#else
+    #define CC_SPRITE_DEBUG_DRAW 0
+#endif
 #endif
 
 /** @def CC_LABEL_DEBUG_DRAW
- * If enabled, all subclasses of Label will draw a bounding box.
+ * If enabled, all subclasses of Label will be able to draw a bounding box.
  * Useful for debugging purposes only. It is recommended to leave it disabled.
- * To enable set it to a value different than 0. Disabled by default:
+ * To enable set it to a value different than 0. Enabled by default in DEBUG,
+ * To activate bounding boxes, use Label::EnableDebugDraw(true);
+ * Disabled by default in other configurations:
  * 0 -- disabled
- * 1 -- draw bounding box
+ * 1 -- draw bounding box code is enabled
  */
 #ifndef CC_LABEL_DEBUG_DRAW
-#define CC_LABEL_DEBUG_DRAW 0
+#if defined(COCOS2D_DEBUG)
+    #define CC_LABEL_DEBUG_DRAW 1 // Activate by default in DEBUG
+#else
+    #define CC_LABEL_DEBUG_DRAW 0
+#endif
 #endif
 
 /** @def CC_SPRITEBATCHNODE_DEBUG_DRAW

--- a/cocos/base/ccConfig.h
+++ b/cocos/base/ccConfig.h
@@ -180,13 +180,8 @@ THE SOFTWARE.
 /** @def CC_SPRITE_DEBUG_DRAW
  * If enabled, all subclasses of Sprite will draw a bounding box.
  * Useful for debugging purposes only. It is recommended to leave it disabled.
- * 0 -- disabled
- * 1 -- draw bounding box code is enabled
- *
- * To activate bounding boxes in runtime, use Label::eetDebugDrawLevel(drawlevel), where
- * 0 -- disabled
- * 1 -- draw bounding box
- * 2 -- draw texture box
+ * To enable set it to a value different than 0. Disabled by default.
+ * To toggle bounding boxes in runtime, use Sprite::enableDebugDraw(true)
  */
 #ifndef CC_SPRITE_DEBUG_DRAW
     #define CC_SPRITE_DEBUG_DRAW 0
@@ -195,11 +190,8 @@ THE SOFTWARE.
 /** @def CC_LABEL_DEBUG_DRAW
  * If enabled, all subclasses of Label will be able to draw a bounding box.
  * Useful for debugging purposes only. It is recommended to leave it disabled.
- * To enable set it to a value different than 0. Enabled by default in DEBUG,
- * To activate bounding boxes, use Label::enableDebugDraw(true);
- * Disabled by default in other configurations:
- * 0 -- disabled
- * 1 -- draw bounding box code is enabled
+ * To enable set it to a value different than 0. Disabled by default.
+ * To toggle bounding boxes in runtime, use Label::enableDebugDraw(true);
  */
 #ifndef CC_LABEL_DEBUG_DRAW
     #define CC_LABEL_DEBUG_DRAW 0

--- a/tests/cpp-tests/Classes/BaseTest.cpp
+++ b/tests/cpp-tests/Classes/BaseTest.cpp
@@ -192,8 +192,32 @@ void TestList::runThisTest()
             TestController::getInstance()->startAutoTest();
         });
         autoTestItem->setPosition(Vec2(VisibleRect::right().x - 60, VisibleRect::bottom().y + 50));
-
-        auto menu = Menu::create(closeItem, autoTestItem, nullptr);
+        
+#if CC_LABEL_DEBUG_DRAW
+        bool v = Label::getDebugDrawEnabled();
+        char str[20];
+        sprintf(str, "DebugDraw: %s", v ? "On" : "Off");
+        
+        auto toggleDebugDrawLabel = Label::createWithTTF(str, "fonts/arial.ttf",14);
+        _toggleDebugDrawItem = MenuItemLabel::create(toggleDebugDrawLabel, [&](Ref* sender){
+            bool v = !Label::getDebugDrawEnabled();
+            char str[20];
+            sprintf(str, "DebugDraw: %s", v ? "On" : "Off");
+            _toggleDebugDrawItem->setString(str);
+            Label::enableDebugDraw(v);
+#if CC_SPRITE_DEBUG_DRAW
+            Sprite::SetDebugDrawLevel(v ? 2 : 0);
+#endif // CC_SPRITE_DEBUG_DRAW
+        });
+        _toggleDebugDrawItem->setPosition(Vec2(VisibleRect::right().x - 60, VisibleRect::bottom().y + 70));
+#endif // CC_LABEL_DEBUG_DRAW
+        
+        
+        auto menu = Menu::create(closeItem, autoTestItem,
+#if CC_LABEL_DEBUG_DRAW
+                                 _toggleDebugDrawItem,
+#endif   // CC_LABEL_DEBUG_DRAW
+                                 nullptr);
         menu->setPosition(Vec2::ZERO);
         scene->addChild(menu, 1);
     }

--- a/tests/cpp-tests/Classes/BaseTest.cpp
+++ b/tests/cpp-tests/Classes/BaseTest.cpp
@@ -206,7 +206,7 @@ void TestList::runThisTest()
             _toggleDebugDrawItem->setString(str);
             Label::enableDebugDraw(v);
 #if CC_SPRITE_DEBUG_DRAW
-            Sprite::SetDebugDrawLevel(v ? 2 : 0);
+            Sprite::setDebugDrawLevel(v ? 2 : 0);
 #endif // CC_SPRITE_DEBUG_DRAW
         });
         _toggleDebugDrawItem->setPosition(Vec2(VisibleRect::right().x - 60, VisibleRect::bottom().y + 70));

--- a/tests/cpp-tests/Classes/BaseTest.cpp
+++ b/tests/cpp-tests/Classes/BaseTest.cpp
@@ -206,8 +206,9 @@ void TestList::runThisTest()
             _toggleDebugDrawItem->setString(str);
             Label::enableDebugDraw(v);
 #if CC_SPRITE_DEBUG_DRAW
-            Sprite::setDebugDrawLevel(v ? 2 : 0);
+            Sprite::enableDebugDraw(v);
 #endif // CC_SPRITE_DEBUG_DRAW
+            runThisTest(); // Reopen the test menu to apply the debug drawing 
         });
         _toggleDebugDrawItem->setPosition(Vec2(VisibleRect::right().x - 60, VisibleRect::bottom().y + 70));
 #endif // CC_LABEL_DEBUG_DRAW

--- a/tests/cpp-tests/Classes/BaseTest.h
+++ b/tests/cpp-tests/Classes/BaseTest.h
@@ -200,6 +200,10 @@ private:
     bool _shouldRestoreTableOffset;
     cocos2d::Vec2 _tableOffset;
     friend class TestController;
+    
+#if CC_LABEL_DEBUG_DRAW
+    cocos2d::MenuItemLabel* _toggleDebugDrawItem;
+#endif
 };
 
 


### PR DESCRIPTION
Added calls to enable and disable debug rendering of labels and sprites (also still requiring the pre-compilation options). Also added way to change the color used.

Code will be enabled by default for COCOS2D_DEBUG configurations

Added example to testcpp
