### PR TITLE
Font atlas texture initialization delayed

### DIFF
--- a/cocos/2d/CCFontAtlas.cpp
+++ b/cocos/2d/CCFontAtlas.cpp
@@ -71,8 +71,6 @@ FontAtlas::FontAtlas(Font &theFont)
         {
             _letterPadding += 2 * FontFreeType::DistanceMapSpread;    
         }
-        
-        reinit();
 
 #if CC_ENABLE_CACHE_TEXTURE_DATA
         auto eventDispatcher = Director::getInstance()->getEventDispatcher();
@@ -343,7 +341,10 @@ bool FontAtlas::prepareLetterDefinitions(const std::u32string& utf32Text)
     {
         return false;
     } 
-    
+ 
+    if (!_currentPageData)
+        reinit();     
+ 
     std::unordered_map<unsigned int, unsigned int> codeMapOfNewChar;
     findNewCharacters(utf32Text, codeMapOfNewChar);
     if (codeMapOfNewChar.empty())


### PR DESCRIPTION
If you will try to create CCLabel with True Type font, enabling it's outline and change it's font size with separate commands you will create multiple textures for font atlases, one for label second for label with outline, and third for label with another font size. 
Moving texture initialization from constructor and calling it later, right before usage will cause large memory economy, because even if atlases will be created they won't create textures of allocate memory for current page data.