### PR TITLE
feature to be able to define function to generate the sprite frame name

### DIFF
--- a/cocos/2d/CCSpriteFrameCache.cpp
+++ b/cocos/2d/CCSpriteFrameCache.cpp
@@ -50,6 +50,8 @@ NS_CC_BEGIN
 
 static SpriteFrameCache *_sharedSpriteFrameCache = nullptr;
 
+SpriteFrameNameGenerator SpriteFrameCache::_spriteFrameNameGenerator = nullptr;
+
 SpriteFrameCache* SpriteFrameCache::getInstance()
 {
     if (! _sharedSpriteFrameCache)
@@ -59,6 +61,11 @@ SpriteFrameCache* SpriteFrameCache::getInstance()
     }
 
     return _sharedSpriteFrameCache;
+}
+
+void SpriteFrameCache::SetSpriteFrameNameGenerator(SpriteFrameNameGenerator generator)
+{
+    SpriteFrameCache::_spriteFrameNameGenerator = generator;
 }
 
 void SpriteFrameCache::destroyInstance()
@@ -177,7 +184,11 @@ void SpriteFrameCache::addSpriteFramesWithDictionary(ValueMap& dictionary, Textu
     for (auto& iter : framesDict)
     {
         ValueMap& frameDict = iter.second.asValueMap();
-        std::string spriteFrameName = iter.first;
+        
+        std::string spriteFrameName =  SpriteFrameCache::_spriteFrameNameGenerator ?
+            _spriteFrameNameGenerator(plist, iter.first) :
+            iter.first;
+      
         SpriteFrame* spriteFrame = _spriteFramesCache.at(spriteFrameName);
         if (spriteFrame)
         {

--- a/cocos/2d/CCSpriteFrameCache.h
+++ b/cocos/2d/CCSpriteFrameCache.h
@@ -45,6 +45,8 @@ class Sprite;
 class Texture2D;
 class PolygonInfo;
 
+typedef std::function<std::string(std::string, std::string)> SpriteFrameNameGenerator;
+
 /**
  * @addtogroup _2d
  * @{
@@ -156,6 +158,15 @@ public:
      * @js NA
      */
     CC_DEPRECATED_ATTRIBUTE static void purgeSharedSpriteFrameCache() { return SpriteFrameCache::destroyInstance(); }
+    
+    /** Sets a function to generate the sprite frame name. This allows to set a specific way to
+     * manage the frame naming in the game, for example to identify the original plist, or follow
+     * a certain naming convention
+     *
+     * @param Function pointer to a sprite frame name generator
+     * @return void
+     */
+    static void SetSpriteFrameNameGenerator(SpriteFrameNameGenerator generator);
 
     /** Destructor.
      * @js NA
@@ -319,6 +330,8 @@ protected:
 
     ValueMap _spriteFramesAliases;
     PlistFramesCache _spriteFramesCache;
+
+    static SpriteFrameNameGenerator _spriteFrameNameGenerator;
 };
 
 // end of _2d group


### PR DESCRIPTION
This feature, adds the posibility to set a function to generate the sprite frame name. For example to identify the original plist, or follow a certain naming convention
