### PR TITLE
Checking, does the touch is within the height of the line, not the he…

### DIFF
--- a/cocos/2d/CCTextFieldTTF.cpp
+++ b/cocos/2d/CCTextFieldTTF.cpp
@@ -387,7 +387,7 @@ void TextFieldTTF::setCursorFromPoint(const Vec2 &point, const Camera* camera)
                     auto sprite = getLetter(latterPosition);
                     if (sprite)
                     {
-                        rect.size = sprite->getContentSize();
+                        rect.size = Size(sprite->getContentSize().width, _lineHeight);
                         if (isScreenPointInRect(point, camera, sprite->getWorldToNodeTransform(), rect, nullptr))
                         {
                             setCursorPosition(latterPosition);


### PR DESCRIPTION
Between the lines there were spaces when clicking on which the cursor (see in "51: Node: Text Input", test No 4) was not placed in the specified position. This is because the analysis of the click rect takes place over the area of the sprite of the particular font symbol, which is usually less than the height of the line. To eliminate this behavior, I set the height of the line as the vertical size of the analyzed rect.