### PR TITLE
[3D] ccpass restore renderer states

### DIFF
--- a/cocos/3d/CCSprite3DMaterial.cpp
+++ b/cocos/3d/CCSprite3DMaterial.cpp
@@ -101,14 +101,14 @@ void Sprite3DMaterial::createBuiltInMaterial()
         _unLitMaterialSkin->_type = Sprite3DMaterial::MaterialType::UNLIT;
     }
 
-    _diffuseMaterialSkinProgState = new (std::nothrow) backend::ProgramState(def + CC3D_skinPositionNormalTexture_vert, def + CC3D_colorNormalTexture_frag);
+    _diffuseMaterialSkinProgState = new (std::nothrow) backend::ProgramState(def +  CC3D_skinPositionNormalTexture_vert, def + CC3D_colorNormalTexture_frag);
     _diffuseMaterialSkin = new (std::nothrow) Sprite3DMaterial();
     if (_diffuseMaterialSkin && _diffuseMaterialSkin->initWithProgramState(_diffuseMaterialSkinProgState))
     {
         _diffuseMaterialSkin->_type = Sprite3DMaterial::MaterialType::DIFFUSE;
     }
 
-    _diffuseMaterialProgState = new (std::nothrow) backend::ProgramState(def + CC3D_positionNormalTexture_vert, CC3D_colorNormalTexture_frag);
+    _diffuseMaterialProgState = new (std::nothrow) backend::ProgramState(def + normalMapDef + CC3D_positionNormalTexture_vert, def + normalMapDef + CC3D_colorNormalTexture_frag);
     _diffuseMaterial = new (std::nothrow) Sprite3DMaterial();
     if (_diffuseMaterial && _diffuseMaterial->initWithProgramState(_diffuseMaterialProgState))
     {

--- a/cocos/renderer/CCPass.cpp
+++ b/cocos/renderer/CCPass.cpp
@@ -276,6 +276,9 @@ void Pass::onBeforeVisitCmd()
     _rendererDepthCmpFunc = renderer->getDepthCompareFunction();
     _rendererCullMode = renderer->getCullMode();
     
+    _rendererDepthWrite = renderer->getDepthWrite();
+    _rendererWinding = renderer->getWinding();
+
     _renderState.bindPass(this);
     renderer->setDepthTest(true);
 }
@@ -287,6 +290,8 @@ void Pass::onAfterVisitCmd()
     renderer->setDepthTest(_rendererDepthTestEnabled);
     renderer->setDepthCompareFunction(_rendererDepthCmpFunc);
     renderer->setCullMode(_rendererCullMode);
+    renderer->setDepthWrite(_rendererDepthWrite);
+    renderer->setWinding(_rendererWinding);
 }
 
 

--- a/cocos/renderer/CCPass.h
+++ b/cocos/renderer/CCPass.h
@@ -190,6 +190,8 @@ private:
     bool _rendererDepthTestEnabled;
     backend::CompareFunction _rendererDepthCmpFunc;
     backend::CullMode _rendererCullMode;
+    backend::Winding _rendererWinding;
+    bool _rendererDepthWrite;
 };
 
 NS_CC_END

--- a/cocos/renderer/shaders/3D_positionNormalTexture.vert
+++ b/cocos/renderer/shaders/3D_positionNormalTexture.vert
@@ -47,12 +47,13 @@ varying vec3 v_normal;
 #endif
 
 uniform mat4 u_MVPMatrix;
+uniform mat4 u_MVMatrix;
 uniform mat4 u_PMatrix;
 uniform mat3 u_NormalMatrix;
 
 void main(void)
 {
-    vec4 ePosition = u_MVPMatrix * a_position;
+    vec4 ePosition = u_MVMatrix * a_position;
 #ifdef USE_NORMAL_MAPPING
     #if ((MAX_DIRECTIONAL_LIGHT_NUM > 0) || (MAX_POINT_LIGHT_NUM > 0) || (MAX_SPOT_LIGHT_NUM > 0))
         vec3 eTangent = normalize(u_NormalMatrix * a_tangent);


### PR DESCRIPTION
1. shader enable normalmap
2. save cullmode & winding
3. fix maxtrix name