### PR TITLE
fix duplicate attribute setting error 

### DIFF
--- a/cocos/renderer/CCRenderer.cpp
+++ b/cocos/renderer/CCRenderer.cpp
@@ -798,8 +798,9 @@ backend::RenderPipeline* Renderer::getRenderPipeline(const backend::RenderPipeli
             continue;
         
         const auto& attributes = vertexLayout.getAttributes();
-        for (const auto& attribute : attributes)
+        for (const auto& it : attributes)
         {
+            auto &attribute = it.second;
             /*
              stepFunction:1     stride:15       offest:10       format:5        needNormalized:1
                 bit31           bit30 ~ bit16   bit15 ~ bit6    bit5 ~ bit1     bit0

--- a/cocos/renderer/backend/VertexLayout.cpp
+++ b/cocos/renderer/backend/VertexLayout.cpp
@@ -1,10 +1,11 @@
 #include "VertexLayout.h"
+#include <cassert>
 
 CC_BACKEND_BEGIN
 
 void VertexLayout::setAtrribute(const std::string &name, unsigned int index, VertexFormat format, unsigned int offset, bool needToBeNormallized)
 {
-    _attributes.push_back({name, index, format, offset, needToBeNormallized});
+    _attributes[name] = {name, index, format, offset, needToBeNormallized};
 }
 
 void VertexLayout::setLayout(unsigned int stride, VertexStepMode stepMode)

--- a/cocos/renderer/backend/VertexLayout.h
+++ b/cocos/renderer/backend/VertexLayout.h
@@ -7,6 +7,7 @@
 #include <string>
 #include <cstdint>
 #include <vector>
+#include <unordered_map>
 
 CC_BACKEND_BEGIN
 
@@ -15,6 +16,7 @@ class VertexLayout
 public:
     struct Attribute
     {
+        Attribute() = default;
         Attribute(const std::string& _name, unsigned int _index, VertexFormat _format, unsigned int _offset, bool needToBeNormallized)
         : name(_name)
         , format(_format)
@@ -38,11 +40,11 @@ public:
     
     inline unsigned int getStride() const { return _stride; }
     inline VertexStepMode getVertexStepMode() const { return _stepMode; }
-    inline const std::vector<Attribute>& getAttributes() const { return _attributes; }
+    inline const std::unordered_map<std::string, Attribute>& getAttributes() const { return _attributes; }
     inline bool isValid() const { return _stride != 0; }
     
 private:
-    std::vector<Attribute> _attributes;
+    std::unordered_map<std::string, Attribute> _attributes;
     unsigned int _stride = 0;
     VertexStepMode _stepMode = VertexStepMode::VERTEX;
 };

--- a/cocos/renderer/backend/opengl/ProgramGL.cpp
+++ b/cocos/renderer/backend/opengl/ProgramGL.cpp
@@ -174,8 +174,9 @@ void ProgramGL::computeAttributeInfos(const RenderPipelineDescriptor& descriptor
         VertexAttributeArray vertexAttributeArray;
         
         const auto& attributes = vertexLayout.getAttributes();
-        for (const auto& attribute : attributes)
+        for (const auto& it : attributes)
         {
+            auto &attribute = it.second;
             AttributeInfo attributeInfo;
             
             if (!getAttributeLocation(attribute.name, attributeInfo.location))


### PR DESCRIPTION
setting the same attribute multiple times will leave duplicate items in `_attributes`