### PR TITLE
need to generate binding codes for all targets

### DIFF
--- a/tools/appveyor-scripts/before-build.ps1
+++ b/tools/appveyor-scripts/before-build.ps1
@@ -40,10 +40,11 @@ Download-Deps
 
 & python -m pip install retry
 
-If ($env:build_type -eq "windows32") {
-    & $python -u .\tools\appveyor-scripts\setup_android.py --ndk_only
-    Generate-Binding-Codes
-} elseif ($env:build_type -like "android*") {
+# need to generate binding codes for all targets
+& $python -u .\tools\appveyor-scripts\setup_android.py --ndk_only
+Generate-Binding-Codes
+
+If ($env:build_type -like "android*") {
     & choco install ninja
     & ninja --version
     & $python -u .\tools\appveyor-scripts\setup_android.py

--- a/tools/travis-scripts/before-install.sh
+++ b/tools/travis-scripts/before-install.sh
@@ -103,6 +103,8 @@ fi
 if [ "$BUILD_TARGET" == "linux_cocos_new_test" ]; then
     download_deps
     install_linux_environment
+    sudo python -m pip install retry
+    # set android ndk environment by setup_android.py
     python $COCOS2DX_ROOT/tools/appveyor-scripts/setup_android.py --ndk_only
     exit 0
 fi

--- a/tools/travis-scripts/before-install.sh
+++ b/tools/travis-scripts/before-install.sh
@@ -103,6 +103,7 @@ fi
 if [ "$BUILD_TARGET" == "linux_cocos_new_test" ]; then
     download_deps
     install_linux_environment
+    python $COCOS2DX_ROOT/tools/appveyor-scripts/setup_android.py --ndk_only
     exit 0
 fi
 

--- a/tools/travis-scripts/run-script.sh
+++ b/tools/travis-scripts/run-script.sh
@@ -285,11 +285,6 @@ function generate_pull_request_for_binding_codes_and_cocosfiles()
 
 function run_pull_request()
 {
-    echo "Building pull request ..."
-
-    # need to generate binding codes for all targets
-    genernate_binding_codes
-
     # linux
     if [ $BUILD_TARGET == 'linux' ]; then
         build_linux
@@ -327,6 +322,14 @@ function run_pull_request()
     if [ $BUILD_TARGET == 'ios' ]; then
         build_ios
     fi
+
+    if [ $BUILD_TARGET == 'mac_cmake' ]; then
+        build_mac_cmake
+    fi
+
+    if [ $BUILD_TARGET == 'ios_cmake' ]; then
+        build_ios_cmake
+    fi
 }
 
 function run_after_merge()
@@ -356,6 +359,12 @@ function run_after_merge()
 
 # build pull request
 if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
+
+    echo "Building pull request ..."
+
+    # need to generate binding codes for all targets
+    genernate_binding_codes
+
     if [ "$BUILD_TARGET" == "android_cocos_new_test" ]; then
         source ../environment.sh
         pushd $COCOS2DX_ROOT
@@ -380,15 +389,6 @@ if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
         cd linux-build
         cmake ..
         cmake --build .
-        exit 0
-    fi
-    if [ $BUILD_TARGET == 'mac_cmake' ]; then
-        build_mac_cmake
-        exit 0
-    fi
-
-    if [ $BUILD_TARGET == 'ios_cmake' ]; then
-        build_ios_cmake
         exit 0
     fi
 


### PR DESCRIPTION
1. Like https://github.com/cocos2d/cocos2d-x/pull/19421 did, when interface changed, the travis task need to generate binding codes firstly, and then build.
2. Or build task will failed, for bindings issues, refer to https://travis-ci.org/cocos2d/cocos2d-x/builds/496361752?utm_source=github_status&utm_medium=notification 