### PR TITLE
refine travis, don't generate binding codes for cpp only target

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ matrix:
       sudo: required
     # android ndk-build
     - os: linux
-      env: BUILD_TARGET=android_ndk-build
+      env: BUILD_TARGET=android_cpp_ndk-build
       language: android
       sudo: required
     # android_lua ndk-build
@@ -35,7 +35,7 @@ matrix:
       sudo: required
     # android cmake
     - os: linux
-      env: BUILD_TARGET=android_cmake
+      env: BUILD_TARGET=android_cpp_cmake
       language: android
       sudo: required
     # android_lua cmake
@@ -61,12 +61,12 @@ matrix:
       osx_image: xcode9.3
       sudo: required
     - os: linux
-      env: BUILD_TARGET=android_cocos_new_test
+      env: BUILD_TARGET=android_cocos_new_cpp_test
       language: android
       sudo: required
     - os: linux
       dist: xenial
-      env: BUILD_TARGET=linux_cocos_new_test
+      env: BUILD_TARGET=linux_cocos_new_lua_test
       language: cpp
       sudo: required
 

--- a/tools/appveyor-scripts/before-build.ps1
+++ b/tools/appveyor-scripts/before-build.ps1
@@ -40,9 +40,11 @@ Download-Deps
 
 & python -m pip install retry
 
-# need to generate binding codes for all targets
-& $python -u .\tools\appveyor-scripts\setup_android.py --ndk_only
-Generate-Binding-Codes
+# don't need generate binding codes for cpp only target
+If ($env:build_type -ne "android_cpp_tests") {
+    & $python -u .\tools\appveyor-scripts\setup_android.py --ndk_only
+    Generate-Binding-Codes
+}
 
 If ($env:build_type -like "android*") {
     & choco install ninja

--- a/tools/travis-scripts/before-install.sh
+++ b/tools/travis-scripts/before-install.sh
@@ -11,9 +11,9 @@ CURL="curl --retry 999 --retry-max-time 0"
 function install_android_ndk()
 {
     sudo python -m pip install retry
-    if [ "$BUILD_TARGET" == "android_ndk-build" ]\
+    if [ "$BUILD_TARGET" == "android_cpp_ndk-build" ]\
         || [ "$BUILD_TARGET" == "android_lua_ndk-build" ]\
-        || [ "$BUILD_TARGET" == "android_cmake" ]\
+        || [ "$BUILD_TARGET" == "android_cpp_cmake" ]\
         || [ "$BUILD_TARGET" == "android_js_cmake" ]\
         || [ "$BUILD_TARGET" == "android_lua_cmake" ] ; then
         python $COCOS2DX_ROOT/tools/appveyor-scripts/setup_android.py
@@ -90,7 +90,7 @@ function install_environement_for_after_merge()
     download_deps
 }
 
-if [ "$BUILD_TARGET" == "android_cocos_new_test" ]; then
+if [ "$BUILD_TARGET" == "android_cocos_new_cpp_test" ]; then
     sudo apt-get update
     sudo apt-get install ninja-build
     ninja --version
@@ -100,7 +100,7 @@ if [ "$BUILD_TARGET" == "android_cocos_new_test" ]; then
     exit 0
 fi
 
-if [ "$BUILD_TARGET" == "linux_cocos_new_test" ]; then
+if [ "$BUILD_TARGET" == "linux_cocos_new_lua_test" ]; then
     download_deps
     install_linux_environment
     sudo python -m pip install retry

--- a/tools/travis-scripts/run-script.sh
+++ b/tools/travis-scripts/run-script.sh
@@ -94,7 +94,7 @@ function build_ios_cmake()
     exit 0
 }
 
-function build_android_ndk-build()
+function build_android_cpp_ndk-build()
 {
     # Build all samples
     echo "Building Android samples ..."
@@ -117,7 +117,7 @@ function build_android_ndk-build()
     # popd
 }
 
-function build_android_cmake()
+function build_android_cpp_cmake()
 {
     # Build all samples
     echo "Building Android samples ..."
@@ -287,47 +287,55 @@ function run_pull_request()
 {
     # linux
     if [ $BUILD_TARGET == 'linux' ]; then
+        genernate_binding_codes
         build_linux
     fi
 
     # android
-    if [ $BUILD_TARGET == 'android_ndk-build' ]; then
-        build_android_ndk-build
+    if [ $BUILD_TARGET == 'android_cpp_ndk-build' ]; then
+        build_android_cpp_ndk-build
     fi
 
     # android
-    if [ $BUILD_TARGET == 'android_cmake' ]; then
-        build_android_cmake
+    if [ $BUILD_TARGET == 'android_cpp_cmake' ]; then
+        build_android_cpp_cmake
     fi
 
     # android_lua
     if [ $BUILD_TARGET == 'android_lua_ndk-build' ]; then
+        genernate_binding_codes
         build_android_lua_ndk-build
     fi
 
     # android_lua
     if [ $BUILD_TARGET == 'android_lua_cmake' ]; then
+        genernate_binding_codes
         build_android_lua_cmake
     fi
 
     # android_js
     if [ $BUILD_TARGET == 'android_js_cmake' ]; then
+        genernate_binding_codes
         build_android_js_cmake
     fi
 
     if [ $BUILD_TARGET == 'mac' ]; then
+        genernate_binding_codes
         build_mac
     fi
 
     if [ $BUILD_TARGET == 'ios' ]; then
+        genernate_binding_codes
         build_ios
     fi
 
     if [ $BUILD_TARGET == 'mac_cmake' ]; then
+        genernate_binding_codes
         build_mac_cmake
     fi
 
     if [ $BUILD_TARGET == 'ios_cmake' ]; then
+        genernate_binding_codes
         build_ios_cmake
     fi
 }
@@ -362,10 +370,7 @@ if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
 
     echo "Building pull request ..."
 
-    # need to generate binding codes for all targets
-    genernate_binding_codes
-
-    if [ "$BUILD_TARGET" == "android_cocos_new_test" ]; then
+    if [ "$BUILD_TARGET" == "android_cocos_new_cpp_test" ]; then
         source ../environment.sh
         pushd $COCOS2DX_ROOT
         update_cocos_files
@@ -377,7 +382,8 @@ if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
         exit 0
     fi
 
-    if [ "$BUILD_TARGET" == "linux_cocos_new_test" ]; then
+    if [ "$BUILD_TARGET" == "linux_cocos_new_lua_test" ]; then
+        genernate_binding_codes
         pushd $COCOS2DX_ROOT
         update_cocos_files
         python -u tools/cocos2d-console/bin/cocos.py --agreement n new -l lua -p my.pack.qqqq cocos_new_test


### PR DESCRIPTION
- refine target name, include `cpp/lua/js` for specific language test