### PR TITLE
Method to ckeck if any IME dispatcher is active.

### DIFF
--- a/cocos/base/CCIMEDispatcher.cpp
+++ b/cocos/base/CCIMEDispatcher.cpp
@@ -266,6 +266,13 @@ const std::string& IMEDispatcher::getContentText()
     return STD_STRING_EMPTY;
 }
 
+bool IMEDispatcher::isAnyDelegateAttachedWithIME() const
+{
+    if (!_impl)
+        return false;
+    return _impl->_delegateWithIme != nullptr;
+}
+
 //////////////////////////////////////////////////////////////////////////
 // dispatch keyboard message
 //////////////////////////////////////////////////////////////////////////

--- a/cocos/base/CCIMEDispatcher.h
+++ b/cocos/base/CCIMEDispatcher.h
@@ -78,6 +78,11 @@ public:
      * @lua NA
      */
     const std::string& getContentText();
+ 
+    /**
+    *@brief Returns if any delegate is attached with IME.
+    */
+    bool isAnyDelegateAttachedWithIME() const;
 
     //////////////////////////////////////////////////////////////////////////
     // dispatch keyboard notification


### PR DESCRIPTION
Useful feature to know if any text field or custom IME dispatcher is active.