### PR TITLE
EventListenerTouchOneByOne::_claimedTouches cleanup bugfix

### DIFF
--- a/cocos/base/CCEventDispatcher.cpp
+++ b/cocos/base/CCEventDispatcher.cpp
@@ -999,7 +999,7 @@ void EventDispatcher::dispatchTouchEvent(EventTouch* event)
                     if (listener->onTouchBegan)
                     {
                         isClaimed = listener->onTouchBegan(touches, event);
-                        if (isClaimed && listener->_isRegistered)
+                        if (isClaimed && listener->_isRegistered && listener->_isEnabled && !listener->_paused)
                         {
                             listener->_claimedTouches.push_back(touches);
                         }


### PR DESCRIPTION
Bug description:
Touch pointer won't be added to `_claimedTouches` in `EventListenerTouchOneByOne` if touch listener became unregistered after `onTouchBegan` call, but it still wll be added if it was disabled or paused. And so it won't be removed in future.
For example if I will remove node connected with listener from scene onTouchBegan, but won't destroy it and add to scene after some time, than It's listener will keep invalid pointer to old touch (because listener won't be processed by dispatcher on ending or cancelling touch).