### PR TITLE
[bugfix] add mesh command callbacks

### DIFF
--- a/cocos/3d/CCTerrain.h
+++ b/cocos/3d/CCTerrain.h
@@ -530,8 +530,6 @@ protected:
     StateBlock _stateBlock;
     StateBlock _stateBlockOld;
 private:
-    CallbackCommand _beforeDraw;
-    CallbackCommand _afterDraw;
     backend::VertexLayout _vertexLayout;
     backend::ProgramState *_programState = nullptr;
     //uniform locations

--- a/cocos/renderer/CCMeshCommand.h
+++ b/cocos/renderer/CCMeshCommand.h
@@ -57,6 +57,8 @@ public:
     */
     using IndexFormat = backend::IndexFormat;
 
+    typedef std::function<void()> CallBackFunc;
+
     MeshCommand();
     virtual ~MeshCommand();
 
@@ -66,11 +68,22 @@ public:
     */
     void init(float globalZOrder);
 
+    void setBeforeCallback(const CallBackFunc &before) { _beforeCallback = before; }
+
+    void setAfterCallback(const CallBackFunc &after){ _afterCallback = after; }
+
+    const CallBackFunc &getBeforeCallback() { return _beforeCallback; }
+
+    const CallBackFunc &getAfterCallback() { return _afterCallback; }
+
 #if CC_ENABLE_CACHE_TEXTURE_DATA
     void listenRendererRecreated(EventCustom* event);
 #endif
 
 protected:
+
+    CallBackFunc _beforeCallback;
+    CallBackFunc _afterCallback;
 
 #if CC_ENABLE_CACHE_TEXTURE_DATA
     EventListenerCustom* _rendererRecreatedListener;

--- a/cocos/renderer/CCMeshCommand.h
+++ b/cocos/renderer/CCMeshCommand.h
@@ -68,8 +68,14 @@ public:
     */
     void init(float globalZOrder);
 
+    /**
+    * set a callback which will be invoke before rendering
+    */
     void setBeforeCallback(const CallBackFunc &before) { _beforeCallback = before; }
 
+    /**
+    * set a callback which will be invoke after rendering
+    */
     void setAfterCallback(const CallBackFunc &after){ _afterCallback = after; }
 
     const CallBackFunc &getBeforeCallback() { return _beforeCallback; }
@@ -82,8 +88,8 @@ public:
 
 protected:
 
-    CallBackFunc _beforeCallback;
-    CallBackFunc _afterCallback;
+    CallBackFunc _beforeCallback    = nullptr;
+    CallBackFunc _afterCallback     = nullptr;
 
 #if CC_ENABLE_CACHE_TEXTURE_DATA
     EventListenerCustom* _rendererRecreatedListener;

--- a/cocos/renderer/CCPass.cpp
+++ b/cocos/renderer/CCPass.cpp
@@ -101,8 +101,8 @@ bool Pass::initWithProgramState(Technique* technique, backend::ProgramState *pro
 
 Pass::Pass()
 {
-    _beforeVisitCmd.func = CC_CALLBACK_0(Pass::onBeforeVisitCmd, this);
-    _afterVisitCmd.func = CC_CALLBACK_0(Pass::onAfterVisitCmd, this);
+    _meshCommand.setBeforeCallback(CC_CALLBACK_0(Pass::onBeforeVisitCmd, this));
+    _meshCommand.setAfterCallback(CC_CALLBACK_0(Pass::onAfterVisitCmd, this));
 }
 
 Pass::~Pass()
@@ -249,12 +249,7 @@ void Pass::draw(float globalZOrder, backend::Buffer* vertexBuffer, backend::Buff
 
     auto *renderer = Director::getInstance()->getRenderer();
 
-    _beforeVisitCmd.init(globalZOrder);
-    _afterVisitCmd.init(globalZOrder);
-
-    renderer->addCommand(&_beforeVisitCmd);
     renderer->addCommand(&_meshCommand);
-    renderer->addCommand(&_afterVisitCmd);
 }
 
 void Pass::onBeforeVisitCmd()

--- a/cocos/renderer/CCPass.h
+++ b/cocos/renderer/CCPass.h
@@ -159,9 +159,6 @@ private:
 
     backend::ProgramState* _programState = nullptr;
 
-    CallbackCommand _beforeVisitCmd;
-    CallbackCommand _afterVisitCmd;
-
     backend::UniformLocation _locMVPMatrix;
     backend::UniformLocation _locMVMatrix;
     backend::UniformLocation _locPMatrix;

--- a/cocos/renderer/CCRenderer.cpp
+++ b/cocos/renderer/CCRenderer.cpp
@@ -671,8 +671,14 @@ void Renderer::drawCustomCommand(RenderCommand *command)
 
 void Renderer::drawMeshCommand(RenderCommand *command)
 {
+    auto cmd = static_cast<MeshCommand*>(command);
+
+    if (cmd->getBeforeCallback()) cmd->getBeforeCallback()();
+
     //MeshCommand and CustomCommand are identical while rendering.
     drawCustomCommand(command);
+
+    if (cmd->getAfterCallback()) cmd->getAfterCallback()();
 }
 
 

--- a/extensions/Particle3D/PU/CCPUBillboardChain.cpp
+++ b/extensions/Particle3D/PU/CCPUBillboardChain.cpp
@@ -687,8 +687,8 @@ void PUBillboardChain::init( const std::string &texFile )
     _stateBlock.setCullFaceSide(backend::CullMode::BACK);
     _stateBlock.setCullFace(true);
 
-    _beforeCommand.func = CC_CALLBACK_0(PUBillboardChain::onBeforeDraw, this);
-    _afterCommand.func  = CC_CALLBACK_0(PUBillboardChain::onAfterDraw,  this);
+    _meshCommand.setBeforeCallback(CC_CALLBACK_0(PUBillboardChain::onBeforeDraw, this));
+    _meshCommand.setAfterCallback(CC_CALLBACK_0(PUBillboardChain::onAfterDraw, this));
 }
 
 void PUBillboardChain::render( Renderer* renderer, const Mat4 &transform, ParticleSystem3D* particleSystem )
@@ -703,12 +703,12 @@ void PUBillboardChain::render( Renderer* renderer, const Mat4 &transform, Partic
 
         _meshCommand.setVertexBuffer(_vertexBuffer);
         _meshCommand.setIndexBuffer(_indexBuffer, MeshCommand::IndexFormat::U_SHORT);
+        _meshCommand.setIndexDrawInfo(0, _indices.size());
 
         if (!_vertices.empty() && !_indices.empty())
         {
-            _beforeCommand.init(0.0);
             _meshCommand.init(0.0);
-            _afterCommand.init(0.0);
+            _stateBlock.setBlendFunc(particleSystem->getBlendFunc());
 
             auto &projectionMatrix = Director::getInstance()->getMatrix(MATRIX_STACK_TYPE::MATRIX_STACK_PROJECTION);
             _programState->setUniform(_locPMatrix, &projectionMatrix.m, sizeof(projectionMatrix.m));
@@ -717,18 +717,11 @@ void PUBillboardChain::render( Renderer* renderer, const Mat4 &transform, Partic
             {
                 _programState->setTexture(_locTexture, 0, _texture->getBackendTexture());
             }
-            _stateBlock.setBlendFunc(particleSystem->getBlendFunc());
+
             auto uColor = Vec4(1, 1, 1, 1);
             _programState->setUniform(_locColor, &uColor, sizeof(uColor));
 
-            _stateBlock.bind(&_meshCommand.getPipelineDescriptor());
-
-
-            _meshCommand.setIndexDrawInfo(0, _indices.size());
-
-            renderer->addCommand(&_beforeCommand);
             renderer->addCommand(&_meshCommand);
-            renderer->addCommand(&_afterCommand);
         }
     }
 }

--- a/extensions/Particle3D/PU/CCPUBillboardChain.h
+++ b/extensions/Particle3D/PU/CCPUBillboardChain.h
@@ -325,8 +325,6 @@ protected:
         Vec4 color;
     };
     MeshCommand             _meshCommand;
-    CallbackCommand         _beforeCommand;
-    CallbackCommand         _afterCommand;
     RenderState::StateBlock _stateBlock;
     Texture2D*              _texture        = nullptr;
     backend::ProgramState*  _programState   = nullptr;

--- a/extensions/Particle3D/PU/CCPURender.cpp
+++ b/extensions/Particle3D/PU/CCPURender.cpp
@@ -245,15 +245,13 @@ void PUParticle3DQuadRender::render(Renderer* renderer, const Mat4 &transform, P
 
         _stateBlock.setBlendFunc(particleSystem->getBlendFunc());
         
-        _beforeCommand.init(0.0);
-        _afterCommand.init(0.0);
-        _customCommand.init(0.0);
-        _customCommand.setSkipBatching(true);
-        _customCommand.setTransparent(true);
+        _meshCommand.init(0.0);
+        _meshCommand.setSkipBatching(true);
+        _meshCommand.setTransparent(true);
 
-        _customCommand.setVertexBuffer(_vertexBuffer);
-        _customCommand.setIndexBuffer(_indexBuffer, CustomCommand::IndexFormat::U_SHORT);
-        _customCommand.setIndexDrawInfo(0, index);
+        _meshCommand.setVertexBuffer(_vertexBuffer);
+        _meshCommand.setIndexBuffer(_indexBuffer, MeshCommand::IndexFormat::U_SHORT);
+        _meshCommand.setIndexDrawInfo(0, index);
 
         if (_texture)
         {
@@ -266,16 +264,14 @@ void PUParticle3DQuadRender::render(Renderer* renderer, const Mat4 &transform, P
         auto &projectionMatrix = Director::getInstance()->getMatrix(MATRIX_STACK_TYPE::MATRIX_STACK_PROJECTION);
         _programState->setUniform(_locPMatrix, &projectionMatrix.m, sizeof(projectionMatrix.m));
 
-        renderer->addCommand(&_beforeCommand);
-        renderer->addCommand(&_customCommand);
-        renderer->addCommand(&_afterCommand);
+        renderer->addCommand(&_meshCommand);
     }
 }
 
 void PUParticle3DEntityRender::onBeforeDraw()
 {
     auto *renderer = Director::getInstance()->getRenderer();
-    auto &pipelineDescriptor = _customCommand.getPipelineDescriptor();
+    auto &pipelineDescriptor = _meshCommand.getPipelineDescriptor();
     _rendererDepthTestEnabled = renderer->getDepthTest();
     _rendererDepthCmpFunc = renderer->getDepthCompareFunction();
     _rendererCullMode = renderer->getCullMode();
@@ -605,7 +601,7 @@ bool PUParticle3DEntityRender::initRender( const std::string &texFile )
         _programState = new backend::ProgramState(CC3D_particle_vert, CC3D_particleColor_frag);
     }
     
-    auto &pipelineDescriptor = _customCommand.getPipelineDescriptor();
+    auto &pipelineDescriptor = _meshCommand.getPipelineDescriptor();
     pipelineDescriptor.programState = _programState;
     auto &layout = pipelineDescriptor.vertexLayout;
 
@@ -618,16 +614,16 @@ bool PUParticle3DEntityRender::initRender( const std::string &texFile )
     _locPMatrix = _programState->getUniformLocation("u_PMatrix");
     _locTexture = _programState->getUniformLocation("u_texture");
 
-    _customCommand.setTransparent(true);
-    _customCommand.setSkipBatching(true);
+    _meshCommand.setTransparent(true);
+    _meshCommand.setSkipBatching(true);
 
     _stateBlock.setDepthTest(true);
     _stateBlock.setDepthWrite(false);
     _stateBlock.setCullFaceSide(backend::CullMode::BACK);
     _stateBlock.setCullFace(true);
 
-    _beforeCommand.func = CC_CALLBACK_0(PUParticle3DEntityRender::onBeforeDraw, this);
-    _afterCommand.func = CC_CALLBACK_0(PUParticle3DEntityRender::onAfterDraw, this);
+    _meshCommand.setBeforeCallback(CC_CALLBACK_0(PUParticle3DEntityRender::onBeforeDraw, this));
+    _meshCommand.setAfterCallback(CC_CALLBACK_0(PUParticle3DEntityRender::onAfterDraw, this));
 
     return true;
 }
@@ -762,11 +758,9 @@ void PUParticle3DBoxRender::render( Renderer* renderer, const Mat4 &transform, P
         auto &projectionMatrix = Director::getInstance()->getMatrix(MATRIX_STACK_TYPE::MATRIX_STACK_PROJECTION);
         _programState->setUniform(_locPMatrix, &projectionMatrix.m, sizeof(projectionMatrix.m));
 
-        _customCommand.setIndexDrawInfo(0, _indices.size());
+        _meshCommand.setIndexDrawInfo(0, _indices.size());
 
-        renderer->addCommand(&_beforeCommand);
-        renderer->addCommand(&_customCommand);
-        renderer->addCommand(&_afterCommand);
+        renderer->addCommand(&_meshCommand);
     }
 }
 
@@ -908,16 +902,14 @@ void PUSphereRender::render( Renderer* renderer, const Mat4 &transform, Particle
     }
 
     if (!_vertices.empty() && !_indices.empty()){
-        _customCommand.init(0.0f);
-        _beforeCommand.init(0.0f);
-        _afterCommand.init(0.0f);
+        _meshCommand.init(0.0f);
 
         _vertexBuffer->updateData(&_vertices[0], vertexindex * sizeof(_vertices[0]));
         _indexBuffer->updateData(&_indices[0], index * sizeof(_indices[0]));
 
-        _customCommand.setVertexBuffer(_vertexBuffer);
-        _customCommand.setIndexBuffer(_indexBuffer, CustomCommand::IndexFormat::U_SHORT);
-        _customCommand.setIndexDrawInfo(0, index);
+        _meshCommand.setVertexBuffer(_vertexBuffer);
+        _meshCommand.setIndexBuffer(_indexBuffer, MeshCommand::IndexFormat::U_SHORT);
+        _meshCommand.setIndexDrawInfo(0, index);
 
         auto uColor = Vec4(1, 1, 1, 1);
         _programState->setUniform(_locColor, &uColor, sizeof(uColor));
@@ -930,9 +922,7 @@ void PUSphereRender::render( Renderer* renderer, const Mat4 &transform, Particle
         auto &projectionMatrix = Director::getInstance()->getMatrix(MATRIX_STACK_TYPE::MATRIX_STACK_PROJECTION);
         _programState->setUniform(_locPMatrix, &projectionMatrix.m, sizeof(projectionMatrix.m));
 
-        renderer->addCommand(&_beforeCommand);
-        renderer->addCommand(&_customCommand);
-        renderer->addCommand(&_afterCommand);
+        renderer->addCommand(&_meshCommand);
     }
 }
 

--- a/extensions/Particle3D/PU/CCPURender.h
+++ b/extensions/Particle3D/PU/CCPURender.h
@@ -89,9 +89,7 @@ protected:
         Vec4 color;
     };
     
-    CustomCommand           _customCommand;
-    CallbackCommand         _beforeCommand;
-    CallbackCommand         _afterCommand;
+    MeshCommand           _meshCommand;
 
     RenderState::StateBlock     _stateBlock;
     Texture2D*                  _texture        = nullptr;


### PR DESCRIPTION
Commands are reordered after `renderer->addCommand(*)`,  `CallbackCommand` does not guarantee to act as a callback. 

Add `before` and `after` hooks to `MeshCommand` 