### PR TITLE
control key pressed event support for ui::TextFiled

### DIFF
--- a/cocos/2d/CCTextFieldTTF.cpp
+++ b/cocos/2d/CCTextFieldTTF.cpp
@@ -88,7 +88,7 @@ bool TextFieldDelegate::onVisit(TextFieldTTF* /*sender*/, Renderer* /*renderer*/
 //////////////////////////////////////////////////////////////////////////
 
 TextFieldTTF::TextFieldTTF()
-: _delegate(0)
+: _delegate(nullptr)
 , _charCount(0)
 , _inputText("")
 , _placeHolder("")   // prevent Label initWithString assertion

--- a/cocos/2d/CCTextFieldTTF.cpp
+++ b/cocos/2d/CCTextFieldTTF.cpp
@@ -73,6 +73,11 @@ bool TextFieldDelegate::onTextFieldDeleteBackward(TextFieldTTF* /*sender*/, cons
     return false;
 }
 
+bool cocos2d::TextFieldDelegate::onTextFieldControlKey(TextFieldTTF* /*sender*/, EventKeyboard::KeyCode /*keyCode*/)
+{
+    return false;
+}
+
 bool TextFieldDelegate::onVisit(TextFieldTTF* /*sender*/, Renderer* /*renderer*/, const Mat4& /*transform*/, uint32_t /*flags*/)
 {
     return false;
@@ -366,6 +371,11 @@ void TextFieldTTF::setCursorPosition(std::size_t cursorPosition)
     }
 }
 
+std::size_t cocos2d::TextFieldTTF::getCursorPosition() const
+{
+    return _cursorPosition;
+}
+
 void TextFieldTTF::setCursorFromPoint(const Vec2 &point, const Camera* camera)
 {
     if (_cursorEnabled)
@@ -612,10 +622,21 @@ void TextFieldTTF::setCursorChar(char cursor)
     }
 }
 
+char cocos2d::TextFieldTTF::getCursorChar() const
+{
+    return _cursorChar;
+}
+
 void TextFieldTTF::controlKey(EventKeyboard::KeyCode keyCode)
 {
     if (_cursorEnabled)
     {
+        if (_delegate && _delegate->onTextFieldControlKey(this, keyCode))
+        {
+            // delegate doesn't want to make anything by control key pressing
+            return;
+        }
+
         switch (keyCode)
         {
         case EventKeyboard::KeyCode::KEY_HOME:
@@ -705,6 +726,11 @@ void TextFieldTTF::setCursorEnabled(bool enabled)
     if (_currentLabelType == LabelType::TTF || _currentLabelType == LabelType::BMFONT) {
         unscheduleUpdate();
     }
+}
+
+bool cocos2d::TextFieldTTF::isCursorEnabled() const
+{
+    return _cursorEnabled;
 }
 
 // secureTextEntry

--- a/cocos/2d/CCTextFieldTTF.h
+++ b/cocos/2d/CCTextFieldTTF.h
@@ -71,6 +71,11 @@ public:
     virtual bool onTextFieldDeleteBackward(TextFieldTTF* sender, const char* delText, size_t nLen);
 
     /**
+     *@brief    If the sender doesn't want to make reaction to control key, return true.
+     */
+    virtual bool onTextFieldControlKey(TextFieldTTF* sender, EventKeyboard::KeyCode keyCode);
+
+    /**
      *@brief    If the sender doesn't want to draw, return true.
      * @js NA
      */
@@ -223,16 +228,34 @@ public:
     void setCursorEnabled(bool enabled);
 
     /**
+    * returns true if cursor is enabled.
+    * @js NA
+    */
+    bool isCursorEnabled() const;
+
+    /**
     * Set char showing cursor.
     * @js NA
     */
     void setCursorChar(char cursor);
 
     /**
+    * Get char showing cursor.
+    * @js NA
+    */
+    char getCursorChar() const;
+
+    /**
     * Set cursor position, if enabled
     * @js NA
     */
     void setCursorPosition(std::size_t cursorPosition);
+
+    /**
+    * Get cursor position
+    * @js NA
+    */
+    std::size_t getCursorPosition() const;
 
     /**
     * Set cursor position to hit letter, if enabled

--- a/cocos/ui/UITextField.h
+++ b/cocos/ui/UITextField.h
@@ -86,6 +86,8 @@ public:
     virtual bool onTextFieldDeleteBackward(TextFieldTTF * pSender,
                                            const char * delText,
                                            size_t nLen) override;
+    virtual bool onTextFieldControlKey(TextFieldTTF * pSender, 
+                                       EventKeyboard::KeyCode keyCode) override;
     void insertText(const char* text, size_t len) override;
     
     /**
@@ -213,6 +215,33 @@ public:
      * @return True if delete backward is enabled, false otherwise.
      */
     bool getDeleteBackward()const;
+
+    /**
+     * @brief Toggle enable control key pressed.
+     *
+     * @param keyCode pressed control key code if control key pressed, EventKeyboard::KeyCode::KEY_NONE otherwise.
+     */
+    void setControlKeyPressed(EventKeyboard::KeyCode keyCode);
+
+    /**
+     * @brief Toggle disable control key pressed, by dropping pressed key code to EventKeyboard::KeyCode::KEY_NONE value.
+     */
+    void resetControlKeyPressed();
+
+    /**
+    * @brief Query what control key was pressed.
+    *
+     * @return Pressed control key code.
+     */
+    EventKeyboard::KeyCode getControlKeyPressed()const;
+
+    /**
+    * @brief Query whether control key was pressed or not.
+    *
+     * @return True if control key was pressed, false otherwise.
+     */
+    bool isControlKeyPressed() const;
+
 protected:
     bool _maxLengthEnabled;
     int _maxLength;
@@ -220,6 +249,7 @@ protected:
     bool _detachWithIME;
     bool _insertText;
     bool _deleteBackward;
+    EventKeyboard::KeyCode _controlKeyPressedCode;
 };
 
 /**
@@ -232,6 +262,8 @@ typedef enum
     TEXTFIELD_EVENT_DETACH_WITH_IME,
     TEXTFIELD_EVENT_INSERT_TEXT,
     TEXTFIELD_EVENT_DELETE_BACKWARD,
+    TEXTFIELD_EVENT_DELETE,
+    TEXTFIELD_EVENT_CURSOR_POSITION_CHANGED,
 }TextFiledEventType;
 
 /**
@@ -263,6 +295,8 @@ public:
         DETACH_WITH_IME,
         INSERT_TEXT,
         DELETE_BACKWARD,
+        DELETE,
+        CURSOR_POSITION_CHANGED
     };
     /**
      * A callback which would be called when a TextField event happens.
@@ -557,6 +591,32 @@ public:
      * @param deleteBackward True is delete backward is enabled, false otherwise.
      */
     void setDeleteBackward(bool deleteBackward);
+
+    /**
+    * @brief Toggle enable control key pressed.
+    *
+    * @param keyCode pressed control key code if control key pressed, EventKeyboard::KeyCode::KEY_NONE otherwise.
+    */
+    void setControlKeyPressed(EventKeyboard::KeyCode keyCode);
+
+    /**
+     * @brief Toggle disable control key pressed, by dropping pressed key code to EventKeyboard::KeyCode::KEY_NONE value.
+     */
+    void resetControlKeyPressed();
+
+    /**
+    * @brief Query what control key was pressed.
+    *
+     * @return Pressed control key code.
+     */
+    EventKeyboard::KeyCode getControlKeyPressed()const;
+
+    /**
+    * @brief Query whether control key was pressed or not.
+    *
+     * @return True if control key was pressed, false otherwise.
+     */
+    bool isControlKeyPressed() const;
     
     /**
      * Add a event listener to TextField, when some predefined event happens, the callback will be called.
@@ -645,6 +705,12 @@ public:
      * @js NA
      */
     void setCursorPosition(std::size_t cursorPosition);
+
+    /**
+     * Get cursor position
+     * @js NA
+     */
+    std::size_t getCursorPosition() const;
     
     /**
      * Set cursor position to hit letter, if enabled
@@ -661,6 +727,7 @@ protected:
     void detachWithIMEEvent();
     void insertTextEvent();
     void deleteBackwardEvent();
+    void controlKeyEvent(EventKeyboard::KeyCode keyCode);
     virtual void onSizeChanged() override;
   
     void textfieldRendererScaleChangedWithSize();


### PR DESCRIPTION
support of control key pressed event enabled for ui::TextField. 
New event codes added for deleting symbol by 'del' key an changing position of cursor.