### PR TITLE
Fix Skybox DepthFunc

### DIFF
--- a/cocos/3d/CCSkybox.cpp
+++ b/cocos/3d/CCSkybox.cpp
@@ -58,6 +58,12 @@ Skybox* Skybox::create(const std::string& positive_x, const std::string& negativ
 
 bool Skybox::init()
 {
+    _customCommand.setTransparent(false);
+    _customCommand.set3D(true);
+
+    _customCommand.setBeforeCallback(CC_CALLBACK_0(Skybox::onBeforeDraw, this));
+    _customCommand.setAfterCallback(CC_CALLBACK_0(Skybox::onAfterDraw, this));
+
     // create and set our custom shader
 
     _programState = new backend::ProgramState(CC3D_skybox_vert, CC3D_skybox_frag);
@@ -140,18 +146,8 @@ void Skybox::initBuffers()
 void Skybox::draw(Renderer* renderer, const Mat4& transform, uint32_t flags)
 {
     _customCommand.init(_globalZOrder);
-    _customCommand.setTransparent(false);
-    _customCommand.set3D(true);
 
-    _beforeCommand.init(_globalZOrder);
-    _afterCommand.init(_globalZOrder);
-
-    _beforeCommand.func = CC_CALLBACK_0(Skybox::onBeforeDraw, this);
-    _afterCommand.func = CC_CALLBACK_0(Skybox::onAfterDraw, this);
-
-    renderer->addCommand(&_beforeCommand);
     renderer->addCommand(&_customCommand);
-    renderer->addCommand(&_afterCommand);
 
     auto camera = Camera::getVisitingCamera();
 
@@ -192,7 +188,7 @@ void Skybox::onBeforeDraw()
     _rendererCullMode = renderer->getCullMode();
 
     renderer->setDepthTest(true);
-    renderer->setDepthCompareFunction(backend::CompareFunction::LESS);
+    renderer->setDepthCompareFunction(backend::CompareFunction::LESS_EQUAL);
     renderer->setCullMode(CullMode::BACK);
 }
 

--- a/cocos/3d/CCSkybox.h
+++ b/cocos/3d/CCSkybox.h
@@ -29,7 +29,6 @@
 #include "base/ccTypes.h"
 #include "platform/CCPlatformMacros.h"
 #include "renderer/CCCustomCommand.h"
-#include "renderer/CCCallbackCommand.h"
 #include "2d/CCNode.h"
 #include "renderer/backend/ProgramState.h"
 
@@ -104,9 +103,6 @@ protected:
     
     backend::ProgramState *_programState = nullptr;
     CustomCommand _customCommand;
-    CallbackCommand _beforeCommand;
-    CallbackCommand _afterCommand;
-
     TextureCube*  _texture;
 private:
     CC_DISALLOW_COPY_AND_ASSIGN(Skybox);

--- a/cocos/renderer/CCRenderer.h
+++ b/cocos/renderer/CCRenderer.h
@@ -306,8 +306,8 @@ protected:
     std::unordered_map<unsigned int, backend::RenderPipeline*> _renderPipelineCache;
 
     Viewport _viewport;
-    CullMode _cullMode = CullMode::NONE;
-    Winding _winding = Winding::CLOCK_WISE;
+    CullMode _cullMode  = CullMode::NONE;
+    Winding _winding    = Winding::COUNTER_CLOCK_WISE; //default front face is CCW in GL
 
     std::stack<int> _commandGroupStack;
     


### PR DESCRIPTION
1. Fix depthFunc of SkyBox to `backend::CompareFunction::LESS_EQUAL`

2. Renderer default FrontFace is set to CCW

>  On a freshly created OpenGL Context, the default front-face is [GL_CCW](https://www.khronos.org/opengl/wiki/Face_Culling).

