### PR TITLE
[bugfix] motionstreak & DrawNode3D on GL

### DIFF
--- a/cocos/2d/CCMotionStreak.cpp
+++ b/cocos/2d/CCMotionStreak.cpp
@@ -133,11 +133,18 @@ bool MotionStreak::initWithFade(float fade, float minSeg, float stroke, const Co
     _pointState = (float *)malloc(sizeof(float) * _maxPoints);
     _pointVertexes = (Vec2*)malloc(sizeof(Vec2) * _maxPoints);
 
+    const size_t VERTEX_SIZE = sizeof(Vec2) + sizeof(Tex2F) + sizeof(uint8_t) * 4;
+
     _vertexCount = _maxPoints * 2;
     _vertices = (Vec2*)malloc(sizeof(Vec2) * _vertexCount);
     _texCoords = (Tex2F*)malloc(sizeof(Tex2F) * _vertexCount);
     _colorPointer =  (uint8_t*)malloc(sizeof(uint8_t) * 4 * _vertexCount);
-    _customCommand.createVertexBuffer(sizeof(Vec2) + sizeof(Tex2F) + sizeof(uint8_t) * 4, _vertexCount, CustomCommand::BufferUsage::DYNAMIC);
+    _customCommand.createVertexBuffer(VERTEX_SIZE, _vertexCount, CustomCommand::BufferUsage::DYNAMIC);
+
+    std::vector<uint8_t> zeros;
+    zeros.resize(VERTEX_SIZE * _vertexCount);
+    std::fill(zeros.begin(), zeros.end(), 0);
+    _customCommand.updateVertexBuffer(zeros.data(), zeros.size());
 
     setTexture(texture);
     setColor(color);

--- a/cocos/renderer/backend/opengl/BufferGL.cpp
+++ b/cocos/renderer/backend/opengl/BufferGL.cpp
@@ -44,7 +44,19 @@ void BufferGL::updateSubData(void* data, unsigned int offset, unsigned int size)
     if (!_bufferAllocated)
     {
         CCASSERT(offset == 0, "offset should be zero when allocate buffer");
-        updateData(data, size);
+        if (size < _size)
+        {
+            //ensure the size parameter of `updateData` is not less then `_size`
+            uint8_t *zeros = new uint8_t[_size]();
+            updateData(zeros, _size);
+            delete[] zeros;
+            updateSubData(data, offset, size);
+        }
+        else
+        {
+            updateData(data, size);
+        }
+
         return;
     }
 

--- a/cocos/renderer/backend/opengl/BufferGL.cpp
+++ b/cocos/renderer/backend/opengl/BufferGL.cpp
@@ -17,7 +17,7 @@ BufferGL::~BufferGL()
 
 void BufferGL::updateData(void* data, unsigned int size)
 {
-    assert(size);
+    assert(size && size <= _size);
     
     if (_buffer)
     {
@@ -33,7 +33,6 @@ void BufferGL::updateData(void* data, unsigned int size)
         }
         CHECK_GL_ERROR_DEBUG();
         _bufferAllocated = true;
-        _size = size;
     }
 }
 
@@ -47,7 +46,7 @@ void BufferGL::updateSubData(void* data, unsigned int offset, unsigned int size)
         CCASSERT(offset == 0, "offset should be zero when allocate buffer");
         if (size < _size)
         {
-            //ensure the size parameter of `updateData` is not less then `_size`
+            //ensure the size parameter of `updateData` is not less than `_size`
             uint8_t *zeros = new uint8_t[_size]();
             updateData(zeros, _size);
             delete[] zeros;
@@ -57,7 +56,6 @@ void BufferGL::updateSubData(void* data, unsigned int offset, unsigned int size)
         {
             updateData(data, size);
         }
-
         return;
     }
 
@@ -68,7 +66,6 @@ void BufferGL::updateSubData(void* data, unsigned int offset, unsigned int size)
         {
             glBindBuffer(GL_ARRAY_BUFFER, _buffer);
             glBufferSubData(GL_ARRAY_BUFFER, offset, size, data);
-            
         }
         else
         {

--- a/cocos/renderer/backend/opengl/BufferGL.cpp
+++ b/cocos/renderer/backend/opengl/BufferGL.cpp
@@ -32,7 +32,7 @@ void BufferGL::updateData(void* data, unsigned int size)
             glBufferData(GL_ELEMENT_ARRAY_BUFFER, size, data, GL_STATIC_DRAW);
         }
         CHECK_GL_ERROR_DEBUG();
-        _bufferAllocated = true;
+        _bufferAllocated = size;
     }
 }
 
@@ -41,9 +41,8 @@ void BufferGL::updateSubData(void* data, unsigned int offset, unsigned int size)
     assert(offset + size <= _size);
     
     //invoke updateData if buffer is not allocated
-    if (!_bufferAllocated)
+    if (0 == _bufferAllocated)
     {
-        CCASSERT(offset == 0, "offset should be zero when allocate buffer");
         if (size < _size)
         {
             //ensure the size parameter of `updateData` is not less than `_size`
@@ -58,6 +57,8 @@ void BufferGL::updateSubData(void* data, unsigned int offset, unsigned int size)
         }
         return;
     }
+
+    assert(offset + size <= _bufferAllocated);
 
     if (_buffer)
     {

--- a/cocos/renderer/backend/opengl/BufferGL.cpp
+++ b/cocos/renderer/backend/opengl/BufferGL.cpp
@@ -38,28 +38,10 @@ void BufferGL::updateData(void* data, unsigned int size)
 
 void BufferGL::updateSubData(void* data, unsigned int offset, unsigned int size)
 {
-    assert(offset + size <= _size);
-    
-    //invoke updateData if buffer is not allocated
-    if (0 == _bufferAllocated)
-    {
-        if (size < _size)
-        {
-            //ensure the size parameter of `updateData` is not less than `_size`
-            uint8_t *zeros = new uint8_t[_size]();
-            updateData(zeros, _size);
-            delete[] zeros;
-            updateSubData(data, offset, size);
-        }
-        else
-        {
-            updateData(data, size);
-        }
-        return;
-    }
 
-    assert(offset + size <= _bufferAllocated);
-
+    CCASSERT(_bufferAllocated != 0, "updateData should be invoke before updateSubData");
+    CCASSERT(offset + size <= _bufferAllocated, "buffer size overflow");
+ 
     if (_buffer)
     {
         CHECK_GL_ERROR_DEBUG();

--- a/cocos/renderer/backend/opengl/BufferGL.cpp
+++ b/cocos/renderer/backend/opengl/BufferGL.cpp
@@ -33,6 +33,7 @@ void BufferGL::updateData(void* data, unsigned int size)
         }
         CHECK_GL_ERROR_DEBUG();
         _bufferAllocated = true;
+        _size = size;
     }
 }
 

--- a/cocos/renderer/backend/opengl/BufferGL.h
+++ b/cocos/renderer/backend/opengl/BufferGL.h
@@ -19,7 +19,7 @@ public:
     
 private:
     GLuint _buffer = 0;
-    bool _bufferAllocated = false;
+    unsigned int _bufferAllocated = 0;
 };
 
 CC_BACKEND_END

--- a/tests/cpp-tests/Classes/Sprite3DTest/DrawNode3D.cpp
+++ b/tests/cpp-tests/Classes/Sprite3DTest/DrawNode3D.cpp
@@ -58,7 +58,15 @@ void DrawNode3D::ensureCapacity(int count)
 {
     CCASSERT(count>=0, "capacity must be >= 0");
     
-    _bufferLines.reserve(_bufferLines.size() + count);
+    const int EXTENDED_SIZE = _bufferLines.size() + count;
+
+    _bufferLines.reserve(EXTENDED_SIZE);
+
+    if (!_customCommand.getVertexBuffer() || _customCommand.getVertexBuffer()->getSize() < (EXTENDED_SIZE * sizeof(_bufferLines[0])))
+    {
+        _customCommand.createVertexBuffer(sizeof(V3F_C4B), EXTENDED_SIZE, CustomCommand::BufferUsage::DYNAMIC);
+    }
+
 }
 
 bool DrawNode3D::init()
@@ -119,12 +127,8 @@ void DrawNode3D::draw(Renderer *renderer, const Mat4 &transform, uint32_t flags)
 
     if (_isDirty && !_bufferLines.empty())
     {
-        if (_customCommand.getVertexBuffer()->getSize() < (_bufferLines.size() * sizeof(_bufferLines[0])))
-        {
-            _customCommand.createVertexBuffer(sizeof(V3F_C4B), _bufferLines.size(),CustomCommand::BufferUsage::DYNAMIC);
-        }
-
         _customCommand.updateVertexBuffer(_bufferLines.data(), (unsigned int)(_bufferLines.size() * sizeof(_bufferLines[0])));
+        _customCommand.setVertexDrawInfo(0, _bufferLines.size());
         _isDirty = false;
     }
 

--- a/tests/cpp-tests/Classes/Sprite3DTest/DrawNode3D.cpp
+++ b/tests/cpp-tests/Classes/Sprite3DTest/DrawNode3D.cpp
@@ -64,7 +64,7 @@ void DrawNode3D::ensureCapacity(int count)
 
     if (!_customCommand.getVertexBuffer() || _customCommand.getVertexBuffer()->getSize() < (EXTENDED_SIZE * sizeof(_bufferLines[0])))
     {
-        _customCommand.createVertexBuffer(sizeof(V3F_C4B), EXTENDED_SIZE, CustomCommand::BufferUsage::DYNAMIC);
+        _customCommand.createVertexBuffer(sizeof(V3F_C4B), EXTENDED_SIZE + (EXTENDED_SIZE >> 1), CustomCommand::BufferUsage::DYNAMIC);
     }
 
 }

--- a/tests/cpp-tests/Classes/Sprite3DTest/DrawNode3D.cpp
+++ b/tests/cpp-tests/Classes/Sprite3DTest/DrawNode3D.cpp
@@ -119,6 +119,11 @@ void DrawNode3D::draw(Renderer *renderer, const Mat4 &transform, uint32_t flags)
 
     if (_isDirty && !_bufferLines.empty())
     {
+        if (_customCommand.getVertexBuffer()->getSize() < (_bufferLines.size() * sizeof(_bufferLines[0])))
+        {
+            _customCommand.createVertexBuffer(sizeof(V3F_C4B), _bufferLines.size(),CustomCommand::BufferUsage::DYNAMIC);
+        }
+
         _customCommand.updateVertexBuffer(_bufferLines.data(), (unsigned int)(_bufferLines.size() * sizeof(_bufferLines[0])));
         _isDirty = false;
     }

--- a/tests/cpp-tests/Classes/Sprite3DTest/DrawNode3D.cpp
+++ b/tests/cpp-tests/Classes/Sprite3DTest/DrawNode3D.cpp
@@ -24,7 +24,7 @@
  ****************************************************************************/
 
 #include "DrawNode3D.h"
-
+#include "renderer/backend/Buffer.h"
 NS_CC_BEGIN
 
 


### PR DESCRIPTION
`updateBuffer` should be called before `updateSubData`