### PR TITLE
[windows] use PostMessage to replace SendMessage

### DIFF
--- a/cocos/base/CCConsole.cpp
+++ b/cocos/base/CCConsole.cpp
@@ -114,7 +114,7 @@ namespace {
         if (Director::getInstance()->getOpenGLView())
         {
             HWND hwnd = Director::getInstance()->getOpenGLView()->getWin32Window();
-            SendMessage(hwnd,
+            PostMessage(hwnd,
                         WM_COPYDATA,
                         (WPARAM)(HWND)hwnd,
                         (LPARAM)(LPVOID)&myCDS);

--- a/cocos/platform/win32/CCDevice-win32.cpp
+++ b/cocos/platform/win32/CCDevice-win32.cpp
@@ -31,6 +31,8 @@ THE SOFTWARE.
 #include "platform/CCFileUtils.h"
 #include "platform/CCStdC.h"
 
+#include <thread>
+
 NS_CC_BEGIN
 
 int Device::getDPI()

--- a/cocos/platform/win32/CCDevice-win32.cpp
+++ b/cocos/platform/win32/CCDevice-win32.cpp
@@ -176,7 +176,7 @@ public:
                 {
                     if (AddFontResource(pwszBuffer))
                     {
-                        SendMessage(_wnd, WM_FONTCHANGE, 0, 0);
+                        PostMessage(_wnd, WM_FONTCHANGE, 0, 0);
                     }
                     delete[] pwszBuffer;
                     pwszBuffer = nullptr;
@@ -432,7 +432,7 @@ private:
             if (pwszBuffer)
             {
                 RemoveFontResource(pwszBuffer);
-                SendMessage(_wnd, WM_FONTCHANGE, 0, 0);
+                PostMessage(_wnd, WM_FONTCHANGE, 0, 0);
                 delete[] pwszBuffer;
                 pwszBuffer = nullptr;
             }

--- a/cocos/platform/win32/CCDevice-win32.cpp
+++ b/cocos/platform/win32/CCDevice-win32.cpp
@@ -174,12 +174,14 @@ public:
                 wchar_t * pwszBuffer = utf8ToUtf16(_curFontPath);
                 if (pwszBuffer)
                 {
-                    if (AddFontResource(pwszBuffer))
-                    {
-                        PostMessage(_wnd, WM_FONTCHANGE, 0, 0);
-                    }
-                    delete[] pwszBuffer;
-                    pwszBuffer = nullptr;
+                    std::thread([&pwszBuffer, this]() {
+                        if (AddFontResource(pwszBuffer))
+                        {
+                            PostMessage(_wnd, WM_FONTCHANGE, 0, 0);
+                        }
+                        delete[] pwszBuffer;
+                        pwszBuffer = nullptr;
+                    }).detach();
                 }
             }
 
@@ -431,10 +433,12 @@ private:
             wchar_t * pwszBuffer = utf8ToUtf16(_curFontPath);
             if (pwszBuffer)
             {
-                RemoveFontResource(pwszBuffer);
-                PostMessage(_wnd, WM_FONTCHANGE, 0, 0);
-                delete[] pwszBuffer;
-                pwszBuffer = nullptr;
+                std::thread([&pwszBuffer, this]() {
+                    RemoveFontResource(pwszBuffer);
+                    PostMessage(_wnd, WM_FONTCHANGE, 0, 0);
+                    delete[] pwszBuffer;
+                    pwszBuffer = nullptr;
+                }).detach();
             }
             _curFontPath.clear();
         }

--- a/cocos/platform/win32/CCDevice-win32.cpp
+++ b/cocos/platform/win32/CCDevice-win32.cpp
@@ -171,18 +171,18 @@ public:
             if (fontPath.size() > 0)
             {
                 _curFontPath = fontPath;
-                wchar_t * pwszBuffer = utf8ToUtf16(_curFontPath);
-                if (pwszBuffer)
-                {
-                    std::thread([&pwszBuffer, this]() {
+                std::thread([fontPath, wnd = _wnd, this]() {
+                    wchar_t * pwszBuffer = utf8ToUtf16(fontPath);
+                    if (pwszBuffer)
+                    {
                         if (AddFontResource(pwszBuffer))
                         {
-                            PostMessage(_wnd, WM_FONTCHANGE, 0, 0);
+                            PostMessage(wnd, WM_FONTCHANGE, 0, 0);
                         }
                         delete[] pwszBuffer;
                         pwszBuffer = nullptr;
-                    }).detach();
-                }
+                    }
+                }).detach();
             }
 
             _font = nullptr;
@@ -430,16 +430,16 @@ private:
         // release temp font resource
         if (_curFontPath.size() > 0)
         {
-            wchar_t * pwszBuffer = utf8ToUtf16(_curFontPath);
-            if (pwszBuffer)
-            {
-                std::thread([&pwszBuffer, this]() {
+            std::thread([curFontPath = _curFontPath, wnd = _wnd, this]() {
+                wchar_t * pwszBuffer = utf8ToUtf16(curFontPath);
+                if (pwszBuffer)
+                {
                     RemoveFontResource(pwszBuffer);
-                    PostMessage(_wnd, WM_FONTCHANGE, 0, 0);
+                    PostMessage(wnd, WM_FONTCHANGE, 0, 0);
                     delete[] pwszBuffer;
                     pwszBuffer = nullptr;
-                }).detach();
-            }
+                }
+            }).detach();
             _curFontPath.clear();
         }
     }


### PR DESCRIPTION

- use PostMessage in CCLOG, which will not block thread. 
- spawn new threads to execute `RemoveFontResource` & `AddFontResource` to speed up font loading progress