### PR TITLE
Make precheader files PRIVATE, otherwise they leak to the game project

### DIFF
--- a/cocos/CMakeLists.txt
+++ b/cocos/CMakeLists.txt
@@ -164,7 +164,7 @@ endif()
 
 if(WINDOWS)
     # precompiled header. Compilation time speedup ~4x.
-    target_sources(cocos2d PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/precheader.cpp")
+    target_sources(cocos2d PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/precheader.cpp")
     set_target_properties(cocos2d PROPERTIES COMPILE_FLAGS "/Yuprecheader.h /FIprecheader.h")
     set_source_files_properties("${CMAKE_CURRENT_SOURCE_DIR}/precheader.cpp" PROPERTIES COMPILE_FLAGS "/Ycprecheader.h")
     # compile c as c++. needed for precompiled header

--- a/cocos/scripting/js-bindings/CMakeLists.txt
+++ b/cocos/scripting/js-bindings/CMakeLists.txt
@@ -182,7 +182,7 @@ endif()
 
 if(WINDOWS)
     # precompiled header
-    target_sources(jscocos2d PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/precheader.cpp")
+    target_sources(jscocos2d PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/precheader.cpp")
     set_target_properties(jscocos2d PROPERTIES COMPILE_FLAGS "/Yuprecheader.h /FIprecheader.h")
     set_source_files_properties("${CMAKE_CURRENT_SOURCE_DIR}/precheader.cpp" PROPERTIES COMPILE_FLAGS "/Ycprecheader.h")
 endif()

--- a/tests/cpp-tests/CMakeLists.txt
+++ b/tests/cpp-tests/CMakeLists.txt
@@ -489,7 +489,7 @@ endif()
 
 if(WINDOWS)
     # precompiled header. Compilation time speedup ~4x.
-    target_sources(${APP_NAME} PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/Classes/precheader.cpp")
+    target_sources(${APP_NAME} PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/Classes/precheader.cpp")
     set_target_properties(${APP_NAME} PROPERTIES COMPILE_FLAGS "/Yuprecheader.h /FIprecheader.h")
     set_source_files_properties("${CMAKE_CURRENT_SOURCE_DIR}/Classes/precheader.cpp" PROPERTIES COMPILE_FLAGS "/Ycprecheader.h")
 endif()


### PR DESCRIPTION
Make precheader files PRIVATE, otherwise they leak to the game project (e.g. in Visual Studio, Internal\cocos2d\precheader.cpp visible/duplicate also in MyGame project).