### PR TITLE
Optimize calls to std::string::find() and friends

### DIFF
--- a/cocos/2d/CCFontAtlas.cpp
+++ b/cocos/2d/CCFontAtlas.cpp
@@ -487,9 +487,9 @@ std::string FontAtlas::getFontName() const
 {
     std::string fontName = _fontFreeType ? _fontFreeType->getFontName() : "";
     if(fontName.empty()) return fontName;
-    auto idx = fontName.rfind("/");
+    auto idx = fontName.rfind('/');
     if (idx != std::string::npos) { return fontName.substr(idx + 1); }
-    idx = fontName.rfind("\\");
+    idx = fontName.rfind('\\');
     if (idx != std::string::npos) { return fontName.substr(idx + 1); }
     return fontName;
 }

--- a/cocos/2d/CCFontCharMap.cpp
+++ b/cocos/2d/CCFontCharMap.cpp
@@ -35,7 +35,7 @@ NS_CC_BEGIN
 FontCharMap * FontCharMap::create(const std::string& plistFile)
 {
     std::string pathStr = FileUtils::getInstance()->fullPathForFilename(plistFile);
-    std::string relPathStr = pathStr.substr(0, pathStr.find_last_of("/"))+"/";
+    std::string relPathStr = pathStr.substr(0, pathStr.find_last_of('/'))+"/";
 
     ValueMap dict = FileUtils::getInstance()->getValueMapFromFile(pathStr);
 

--- a/cocos/2d/CCLabelAtlas.cpp
+++ b/cocos/2d/CCLabelAtlas.cpp
@@ -105,7 +105,7 @@ LabelAtlas* LabelAtlas::create(const std::string& string, const std::string& fnt
 bool LabelAtlas::initWithString(const std::string& theString, const std::string& fntFile)
 {
     std::string pathStr = FileUtils::getInstance()->fullPathForFilename(fntFile);
-    std::string relPathStr = pathStr.substr(0, pathStr.find_last_of("/"))+"/";
+    std::string relPathStr = pathStr.substr(0, pathStr.find_last_of('/'))+"/";
     
     ValueMap dict = FileUtils::getInstance()->getValueMapFromFile(pathStr);
 

--- a/cocos/2d/CCSpriteFrameCache.cpp
+++ b/cocos/2d/CCSpriteFrameCache.cpp
@@ -410,7 +410,7 @@ void SpriteFrameCache::addSpriteFramesWithFile(const std::string& plist)
         texturePath = plist;
 
         // remove .xxx
-        size_t startPos = texturePath.find_last_of("."); 
+        size_t startPos = texturePath.find_last_of('.'); 
         texturePath = texturePath.erase(startPos);
 
         // append .png
@@ -712,7 +712,7 @@ bool SpriteFrameCache::reloadTexture(const std::string& plist)
         texturePath = plist;
 
         // remove .xxx
-        size_t startPos = texturePath.find_last_of(".");
+        size_t startPos = texturePath.find_last_of('.');
         texturePath = texturePath.erase(startPos);
 
         // append .png

--- a/cocos/2d/CCTMXXMLParser.cpp
+++ b/cocos/2d/CCTMXXMLParser.cpp
@@ -298,9 +298,9 @@ void TMXMapInfo::startElement(void* /*ctx*/, const char *name, const char **atts
             _externalTilesetFilename = externalTilesetFilename;
 
             // Tileset file will be relative to the map file. So we need to convert it to an absolute path
-            if (_TMXFileName.find_last_of("/") != string::npos)
+            if (_TMXFileName.find_last_of('/') != string::npos)
             {
-                string dir = _TMXFileName.substr(0, _TMXFileName.find_last_of("/") + 1);
+                string dir = _TMXFileName.substr(0, _TMXFileName.find_last_of('/') + 1);
                 externalTilesetFilename = dir + externalTilesetFilename;
             }
             else 
@@ -434,12 +434,12 @@ void TMXMapInfo::startElement(void* /*ctx*/, const char *name, const char **atts
 
         if (!_externalTilesetFullPath.empty())
         {
-            string dir = _externalTilesetFullPath.substr(0, _externalTilesetFullPath.find_last_of("/") + 1);
+            string dir = _externalTilesetFullPath.substr(0, _externalTilesetFullPath.find_last_of('/') + 1);
             tileset->_sourceImage = dir + imagename;
         }
-        else if (_TMXFileName.find_last_of("/") != string::npos)
+        else if (_TMXFileName.find_last_of('/') != string::npos)
         {
-            string dir = _TMXFileName.substr(0, _TMXFileName.find_last_of("/") + 1);
+            string dir = _TMXFileName.substr(0, _TMXFileName.find_last_of('/') + 1);
             tileset->_sourceImage = dir + imagename;
         }
         else 

--- a/cocos/3d/CCBundle3D.cpp
+++ b/cocos/3d/CCBundle3D.cpp
@@ -225,7 +225,7 @@ bool Bundle3D::loadObj(MeshDatas& meshdatas, MaterialDatas& materialdatas, NodeD
         int i = 0;
         char str[20];
         std::string dir = "";
-        auto last = fullPath.rfind("/");
+        auto last = fullPath.rfind('/');
         if (last != std::string::npos)
             dir = fullPath.substr(0, last + 1);
         for (auto& material : materials) {

--- a/cocos/base/CCConsole.cpp
+++ b/cocos/base/CCConsole.cpp
@@ -454,7 +454,7 @@ void Console::Command::commandGeneric(int fd, const std::string& args)
 {
     // The first argument (including the empty)
     std::string key(args);
-    auto pos = args.find(" ");
+    auto pos = args.find(' ');
     if ((pos != std::string::npos) && (0 < pos)) {
         key = args.substr(0, pos);
     }

--- a/cocos/base/CCProperties.cpp
+++ b/cocos/base/CCProperties.cpp
@@ -1117,12 +1117,12 @@ void calculateNamespacePath(const std::string& urlString, std::string& fileStrin
 {
     // If the url references a specific namespace within the file,
     // calculate the full namespace path to the final namespace.
-    size_t loc = urlString.rfind("#");
+    size_t loc = urlString.rfind('#');
     if (loc != std::string::npos)
     {
         fileString = urlString.substr(0, loc);
         std::string namespacePathString = urlString.substr(loc + 1);
-        while ((loc = namespacePathString.find("/")) != std::string::npos)
+        while ((loc = namespacePathString.find('/')) != std::string::npos)
         {
             namespacePath.push_back(namespacePathString.substr(0, loc));
             namespacePathString = namespacePathString.substr(loc + 1);

--- a/cocos/base/ZipUtils.cpp
+++ b/cocos/base/ZipUtils.cpp
@@ -627,7 +627,7 @@ std::vector<std::string> ZipFile::listFiles(const std::string &pathname) const
         if(filename.substr(0, dirname.length()) == dirname)
         {
             std::string suffix = filename.substr(dirname.length());
-            auto pos = suffix.find("/");
+            auto pos = suffix.find('/');
             if (pos == std::string::npos)
             {
                 fileSet.insert(suffix);

--- a/cocos/base/ccUtils.cpp
+++ b/cocos/base/ccUtils.cpp
@@ -124,7 +124,7 @@ void onCaptureScreen(const std::function<void(bool, const std::string&)>& afterC
             }
             else
             {
-                CCASSERT(filename.find("/") == std::string::npos, "The existence of a relative path is not guaranteed!");
+                CCASSERT(filename.find('/') == std::string::npos, "The existence of a relative path is not guaranteed!");
                 outputFile = FileUtils::getInstance()->getWritablePath() + filename;
             }
 

--- a/cocos/editor-support/cocosbuilder/CCBReader.cpp
+++ b/cocos/editor-support/cocosbuilder/CCBReader.cpp
@@ -951,7 +951,7 @@ bool CCBReader::readSequences()
 
 std::string CCBReader::lastPathComponent(const char* pPath) {
     std::string path(pPath);
-    size_t slashPos = path.find_last_of("/");
+    size_t slashPos = path.find_last_of('/');
     if(slashPos != std::string::npos) {
         return path.substr(slashPos + 1, path.length() - slashPos);
     }
@@ -960,7 +960,7 @@ std::string CCBReader::lastPathComponent(const char* pPath) {
 
 std::string CCBReader::deletePathExtension(const char* pPath) {
     std::string path(pPath);
-    size_t dotPos = path.find_last_of(".");
+    size_t dotPos = path.find_last_of('.');
     if(dotPos != std::string::npos) {
         return path.substr(0, dotPos);
     }

--- a/cocos/editor-support/cocostudio/CCActionManagerEx.cpp
+++ b/cocos/editor-support/cocostudio/CCActionManagerEx.cpp
@@ -63,7 +63,7 @@ void ActionManagerEx::initWithDictionary(const char* jsonName,const rapidjson::V
 {
     std::string path = jsonName;
     this->_studioVersionNumber = version;
-    ssize_t pos = path.find_last_of("/");
+    ssize_t pos = path.find_last_of('/');
     std::string fileName = path.substr(pos+1,path.length());
     cocos2d::Vector<ActionObject*> actionList;
     int actionCount = DICTOOL->getArrayCount_json(dic, "actionlist");
@@ -83,7 +83,7 @@ void ActionManagerEx::initWithDictionary(const char* jsonName,const rapidjson::V
                                          stExpCocoNode*     pCocoNode)
     {
         std::string path = file;
-        ssize_t pos = path.find_last_of("/");
+        ssize_t pos = path.find_last_of('/');
         std::string fileName = path.substr(pos+1,path.length());
         cocos2d::Vector<ActionObject*> actionList;
         
@@ -116,7 +116,7 @@ void ActionManagerEx::initWithDictionary(const char* jsonName,const rapidjson::V
 ActionObject* ActionManagerEx::getActionByName(const char* jsonName,const char* actionName)
 {
     std::string path = jsonName;
-    ssize_t pos = path.find_last_of("/");
+    ssize_t pos = path.find_last_of('/');
     std::string fileName = path.substr(pos+1,path.length());
     auto iterator = _actionDic.find(fileName);
     if (iterator == _actionDic.end())

--- a/cocos/editor-support/cocostudio/CCDataReaderHelper.cpp
+++ b/cocos/editor-support/cocostudio/CCDataReaderHelper.cpp
@@ -296,7 +296,7 @@ void DataReaderHelper::addDataFromFile(const std::string& filePath)
 
     //! find the base file path
     std::string basefilePath = filePath;
-    size_t pos = basefilePath.find_last_of("/");
+    size_t pos = basefilePath.find_last_of('/');
 
     if (pos != std::string::npos)
     {
@@ -362,7 +362,7 @@ void DataReaderHelper::addDataFromFileAsync(const std::string& imagePath, const 
 
     //! find the base file path
     std::string basefilePath = filePath;
-    size_t pos = basefilePath.find_last_of("/");
+    size_t pos = basefilePath.find_last_of('/');
 
     if (pos != std::string::npos)
     {
@@ -1305,7 +1305,7 @@ void DataReaderHelper::addDataFromJsonCache(const std::string& fileContent, Data
             }
 
             std::string filePath = path;
-            filePath = filePath.erase(filePath.find_last_of("."));
+            filePath = filePath.erase(filePath.find_last_of('.'));
 
             if (dataInfo->asyncStruct)
             {
@@ -1844,7 +1844,7 @@ void DataReaderHelper::decodeNode(BaseData *node, const rapidjson::Value& json, 
                             }
 
                             std::string filePath = path;
-                            filePath = filePath.erase(filePath.find_last_of("."));
+                            filePath = filePath.erase(filePath.find_last_of('.'));
 
                             if (dataInfo->asyncStruct)
                             {

--- a/cocos/editor-support/cocostudio/CCDatas.cpp
+++ b/cocos/editor-support/cocostudio/CCDatas.cpp
@@ -147,7 +147,7 @@ std::string DisplayData::changeDisplayToTexture(const std::string& displayName)
 {
     // remove .xxx
     std::string textureName = displayName;
-    size_t startPos = textureName.find_last_of(".");
+    size_t startPos = textureName.find_last_of('.');
 
     if(startPos != std::string::npos)
     {

--- a/cocos/editor-support/cocostudio/CCDisplayFactory.cpp
+++ b/cocos/editor-support/cocostudio/CCDisplayFactory.cpp
@@ -144,7 +144,7 @@ void DisplayFactory::createSpriteDisplay(Bone *bone, DecorativeDisplay *decoDisp
     SpriteDisplayData *displayData = (SpriteDisplayData *)decoDisplay->getDisplayData();
 
     std::string textureName = displayData->displayName;
-    size_t startPos = textureName.find_last_of(".");
+    size_t startPos = textureName.find_last_of('.');
 
     if(startPos != std::string::npos)
     {
@@ -191,7 +191,7 @@ void DisplayFactory::initSpriteDisplay(Bone *bone, DecorativeDisplay *decoDispla
 {
     //! remove .xxx
     std::string textureName = displayName;
-    size_t startPos = textureName.find_last_of(".");
+    size_t startPos = textureName.find_last_of('.');
 
     if(startPos != std::string::npos)
     {

--- a/cocos/editor-support/cocostudio/CCSGUIReader.cpp
+++ b/cocos/editor-support/cocostudio/CCSGUIReader.cpp
@@ -117,19 +117,19 @@ int GUIReader::getVersionInteger(const char *str)
     {
         return 0;
     }
-    size_t pos = strVersion.find_first_of(".");
+    size_t pos = strVersion.find_first_of('.');
     std::string t = strVersion.substr(0,pos);
     strVersion = strVersion.substr(pos+1,strVersion.length()-1);
     
-    pos = strVersion.find_first_of(".");
+    pos = strVersion.find_first_of('.');
     std::string h = strVersion.substr(0,pos);
     strVersion = strVersion.substr(pos+1,strVersion.length()-1);
     
-    pos = strVersion.find_first_of(".");
+    pos = strVersion.find_first_of('.');
     std::string te = strVersion.substr(0,pos);
     strVersion = strVersion.substr(pos+1,strVersion.length()-1);
     
-    pos = strVersion.find_first_of(".");
+    pos = strVersion.find_first_of('.');
     std::string s = strVersion.substr(0,pos);
     
     int it = atoi(t.c_str());

--- a/cocos/editor-support/cocostudio/WidgetReader/ArmatureNodeReader/ArmatureNodeReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/ArmatureNodeReader/ArmatureNodeReader.cpp
@@ -160,7 +160,7 @@ void ArmatureNodeReader::setPropsWithFlatBuffers(cocos2d::Node *node,
         
         std::string fullpath = FileUtils::getInstance()->fullPathForFilename(filepath);
         
-        std::string dirpath = fullpath.substr(0, fullpath.find_last_of("/"));
+        std::string dirpath = fullpath.substr(0, fullpath.find_last_of('/'));
         FileUtils::getInstance()->addSearchPath(dirpath);
         
         ArmatureDataManager::getInstance()->addArmatureFileInfo(fullpath);
@@ -201,9 +201,9 @@ cocos2d::Node*  ArmatureNodeReader::createNodeWithFlatBuffers(const flatbuffers:
 std::string ArmatureNodeReader::getArmatureName(const std::string& exporJsonPath)
 {
 	//FileUtils.getFileData(exporJsonPath, "r", size)   // need read armature name in exportJsonPath
-	size_t end = exporJsonPath.find_last_of(".");
-	size_t start = exporJsonPath.find_last_of("\\") + 1;
-	size_t start1 = exporJsonPath.find_last_of("/") + 1;
+	size_t end = exporJsonPath.find_last_of('.');
+	size_t start = exporJsonPath.find_last_of('\\') + 1;
+	size_t start1 = exporJsonPath.find_last_of('/') + 1;
 	if (start < start1)
 		start = start1;
 

--- a/cocos/editor-support/cocostudio/WidgetReader/TextFieldReader/TextFieldReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/TextFieldReader/TextFieldReader.cpp
@@ -324,7 +324,7 @@ namespace cocostudio
         {
             ILocalizationManager* lm = LocalizationHelper::getCurrentManager();
             std::string localizedTxt = lm->getLocalizationString(text);
-            std::string::size_type newlineIndex = localizedTxt.find("\n");
+            std::string::size_type newlineIndex = localizedTxt.find('\n');
             if (newlineIndex != std::string::npos)
                 localizedTxt = localizedTxt.substr(0, newlineIndex);
             textField->setString(localizedTxt);

--- a/cocos/network/SocketIO.cpp
+++ b/cocos/network/SocketIO.cpp
@@ -489,7 +489,7 @@ void SIOClientImpl::handshakeResponse(HttpClient* /*sender*/, HttpResponse *resp
     std::string sid = "";
     int heartbeat = 0, timeout = 0;
 
-    if (res.find("}") != std::string::npos) {
+    if (res.find('}') != std::string::npos) {
 
         CCLOGINFO("SIOClientImpl::handshake() Socket.IO 1.x detected");
         _version = SocketIOPacket::SocketIOVersion::V10x;
@@ -500,29 +500,29 @@ void SIOClientImpl::handshakeResponse(HttpClient* /*sender*/, HttpResponse *resp
         std::string temp = res.substr(a, res.size() - a);
 
         // find the sid
-        a = temp.find(":");
-        b = temp.find(",");
+        a = temp.find(':');
+        b = temp.find(',');
 
         sid = temp.substr(a + 2, b - (a + 3));
 
         temp = temp.erase(0, b + 1);
 
         // chomp past the upgrades
-        b = temp.find(",");
+        b = temp.find(',');
 
         temp = temp.erase(0, b + 1);
 
         // get the pingInterval / heartbeat
-        a = temp.find(":");
-        b = temp.find(",");
+        a = temp.find(':');
+        b = temp.find(',');
 
         std::string heartbeat_str = temp.substr(a + 1, b - a);
         heartbeat = atoi(heartbeat_str.c_str()) / 1000;
         temp = temp.erase(0, b + 1);
 
         // get the timeout
-        a = temp.find(":");
-        b = temp.find("}");
+        a = temp.find(':');
+        b = temp.find('}');
 
         std::string timeout_str = temp.substr(a + 1, b - a);
         timeout = atoi(timeout_str.c_str()) / 1000;
@@ -536,20 +536,20 @@ void SIOClientImpl::handshakeResponse(HttpClient* /*sender*/, HttpResponse *resp
         // sample: 3GYzE9md2Ig-lm3cf8Rv:60:60:websocket,htmlfile,xhr-polling,jsonp-polling
         size_t pos = 0;
 
-        pos = res.find(":");
+        pos = res.find(':');
         if (pos != std::string::npos)
         {
             sid = res.substr(0, pos);
             res.erase(0, pos + 1);
         }
 
-        pos = res.find(":");
+        pos = res.find(':');
         if (pos != std::string::npos)
         {
             heartbeat = atoi(res.substr(pos + 1, res.size()).c_str());
         }
 
-        pos = res.find(":");
+        pos = res.find(':');
         if (pos != std::string::npos)
         {
             timeout = atoi(res.substr(pos + 1, res.size()).c_str());
@@ -795,20 +795,20 @@ void SIOClientImpl::onMessage(WebSocket* /*ws*/, const WebSocket::Data& data)
 
             std::string::size_type pos, pos2;
 
-            pos = payload.find(":");
+            pos = payload.find(':');
             if (pos != std::string::npos)
             {
                 payload.erase(0, pos + 1);
             }
 
-            pos = payload.find(":");
+            pos = payload.find(':');
             if (pos != std::string::npos)
             {
                 msgid = atoi(payload.substr(0, pos + 1).c_str());
             }
             payload.erase(0, pos + 1);
 
-            pos = payload.find(":");
+            pos = payload.find(':');
             if (pos != std::string::npos)
             {
                 endpoint = payload.substr(0, pos);
@@ -860,8 +860,8 @@ void SIOClientImpl::onMessage(WebSocket* /*ws*/, const WebSocket::Data& data)
                 if (c)
                 {
                     eventname = "";
-                    pos = s_data.find(":");
-                    pos2 = s_data.find(",");
+                    pos = s_data.find(':');
+                    pos2 = s_data.find(',');
                     if (pos2 > pos)
                     {
                         eventname = s_data.substr(pos + 2, pos2 - (pos + 3));
@@ -917,8 +917,8 @@ void SIOClientImpl::onMessage(WebSocket* /*ws*/, const WebSocket::Data& data)
 
                 std::string endpoint = "";
 
-                std::string::size_type a = payload.find("/");
-                std::string::size_type b = payload.find("[");
+                std::string::size_type a = payload.find('/');
+                std::string::size_type b = payload.find('[');
 
                 if (b != std::string::npos)
                 {
@@ -961,8 +961,8 @@ void SIOClientImpl::onMessage(WebSocket* /*ws*/, const WebSocket::Data& data)
                 {
                     CCLOGINFO("Event Received (%s)", payload.c_str());
 
-                    std::string::size_type payloadFirstSlashPos = payload.find("\"");
-                    std::string::size_type payloadSecondSlashPos = payload.substr(payloadFirstSlashPos + 1).find("\"");
+                    std::string::size_type payloadFirstSlashPos = payload.find('\"');
+                    std::string::size_type payloadSecondSlashPos = payload.substr(payloadFirstSlashPos + 1).find('\"');
 
                     std::string eventname = payload.substr(payloadFirstSlashPos + 1,
                                                            payloadSecondSlashPos - payloadFirstSlashPos + 1);

--- a/cocos/platform/CCFileUtils.cpp
+++ b/cocos/platform/CCFileUtils.cpp
@@ -797,7 +797,7 @@ std::string FileUtils::getPathForFilename(const std::string& filename, const std
 {
     std::string file = filename;
     std::string file_path = "";
-    size_t pos = filename.find_last_of("/");
+    size_t pos = filename.find_last_of('/');
     if (pos != std::string::npos)
     {
         file_path = filename.substr(0, pos+1);

--- a/cocos/platform/linux/CCFileUtils-linux.cpp
+++ b/cocos/platform/linux/CCFileUtils-linux.cpp
@@ -78,7 +78,7 @@ bool FileUtilsLinux::init()
 
     fullpath[length] = '\0';
     std::string appPath = fullpath;
-    _defaultResRootPath = appPath.substr(0, appPath.find_last_of("/"));
+    _defaultResRootPath = appPath.substr(0, appPath.find_last_of('/'));
     _defaultResRootPath += CC_RESOURCE_FOLDER_LINUX;
 
     // Set writable path to $XDG_CONFIG_HOME or ~/.config/<app name>/ if $XDG_CONFIG_HOME not exists.
@@ -91,7 +91,7 @@ bool FileUtilsLinux::init()
         xdgConfigPath  = xdg_config_path;
     }
     _writablePath = xdgConfigPath;
-    _writablePath += appPath.substr(appPath.find_last_of("/"));
+    _writablePath += appPath.substr(appPath.find_last_of('/'));
     _writablePath += "/";
 
     return FileUtils::init();

--- a/cocos/scripting/js-bindings/manual/cocos2d_specifics.cpp
+++ b/cocos/scripting/js-bindings/manual/cocos2d_specifics.cpp
@@ -5255,7 +5255,7 @@ void get_or_create_js_obj(const std::string &name, JS::MutableHandleObject jsObj
     JS::RootedObject prop(cx);
 
     size_t start = 0;
-    size_t found = name.find_first_of(".", start);
+    size_t found = name.find_first_of('.', start);
     std::string subProp;
 
     while (found != std::string::npos)
@@ -5268,7 +5268,7 @@ void get_or_create_js_obj(const std::string &name, JS::MutableHandleObject jsObj
         }
 
         start = found+1;
-        found = name.find_first_of(".", start);
+        found = name.find_first_of('.', start);
     }
     if (start < name.length())
     {

--- a/cocos/scripting/js-bindings/manual/cocosbuilder/js_bindings_ccbreader.cpp
+++ b/cocos/scripting/js-bindings/manual/cocosbuilder/js_bindings_ccbreader.cpp
@@ -33,10 +33,10 @@ using namespace cocosbuilder;
 
 static void removeSelector(std::string &str) {
     size_t found;
-    found = str.find(":");
+    found = str.find(':');
     while (found!=std::string::npos){
         str.replace(found, found+1, "");
-        found = str.find(":");
+        found = str.find(':');
     }
 }
 

--- a/cocos/scripting/js-bindings/manual/network/XMLHTTPRequest.cpp
+++ b/cocos/scripting/js-bindings/manual/network/XMLHTTPRequest.cpp
@@ -73,7 +73,7 @@ void MinXmlHttpRequest::_gotHeader(string& header)
     char * cstr = new (std::nothrow) char [header.length()+1];
 
     // check for colon.
-    size_t found_header_field = header.find_first_of(":");
+    size_t found_header_field = header.find_first_of(':');
 
     if (found_header_field != std::string::npos)
     {

--- a/cocos/scripting/lua-bindings/manual/Cocos2dxLuaLoader.cpp
+++ b/cocos/scripting/lua-bindings/manual/Cocos2dxLuaLoader.cpp
@@ -51,11 +51,11 @@ extern "C"
                 filename = filename.substr(0, pos);
         }
 
-        pos = filename.find_first_of(".");
+        pos = filename.find_first_of('.');
         while (pos != std::string::npos)
         {
             filename.replace(pos, 1, "/");
-            pos = filename.find_first_of(".");
+            pos = filename.find_first_of('.');
         }
 
         // search file in package.path
@@ -68,7 +68,7 @@ extern "C"
         std::string searchpath(lua_tostring(L, -1));
         lua_pop(L, 1);
         size_t begin = 0;
-        size_t next = searchpath.find_first_of(";", 0);
+        size_t next = searchpath.find_first_of(';', 0);
 
         do
         {
@@ -89,11 +89,11 @@ extern "C"
                 if (pos != std::string::npos && pos == prefix.length() - NOT_BYTECODE_FILE_EXT.length())
                     prefix = prefix.substr(0, pos);
             }
-            pos = prefix.find_first_of("?", 0);
+            pos = prefix.find_first_of('?', 0);
             while (pos != std::string::npos)
             {
                 prefix.replace(pos, 1, filename);
-                pos = prefix.find_first_of("?", pos + filename.length() + 1);
+                pos = prefix.find_first_of('?', pos + filename.length() + 1);
             }
             chunkName = prefix + BYTECODE_FILE_EXT;
             if (utils->isFileExist(chunkName)) // && !utils->isDirectoryExist(chunkName))
@@ -121,7 +121,7 @@ extern "C"
             }
 
             begin = next + 1;
-            next = searchpath.find_first_of(";", begin);
+            next = searchpath.find_first_of(';', begin);
         } while (begin < searchpath.length());
         if (chunk.getSize() > 0)
         {

--- a/cocos/scripting/lua-bindings/manual/network/lua_xml_http_request.cpp
+++ b/cocos/scripting/lua-bindings/manual/network/lua_xml_http_request.cpp
@@ -168,7 +168,7 @@ void LuaMinXmlHttpRequest::_gotHeader(const std::string& header)
     char * cstr = new (std::nothrow) char [header.length()+1];
     
     // check for colon.
-    size_t found_header_field = header.find_first_of(":");
+    size_t found_header_field = header.find_first_of(':');
     
     if (found_header_field != std::string::npos)
     {

--- a/extensions/Particle3D/PU/CCPUParticleSystem3D.cpp
+++ b/extensions/Particle3D/PU/CCPUParticleSystem3D.cpp
@@ -277,11 +277,11 @@ bool PUParticleSystem3D::initWithFilePath( const std::string &filePath )
 {
     std::string fullPath = FileUtils::getInstance()->fullPathForFilename(filePath);
     convertToUnixStylePath(fullPath);
-    std::string::size_type pos = fullPath.find_last_of("/");
+    std::string::size_type pos = fullPath.find_last_of('/');
     std::string materialFolder = "materials";
     if (pos != std::string::npos){
         std::string temp = fullPath.substr(0, pos);
-        pos = temp.find_last_of("/");
+        pos = temp.find_last_of('/');
         if (pos != std::string::npos){
             materialFolder = temp.substr(0, pos + 1) + materialFolder;
         }

--- a/extensions/Particle3D/PU/CCPURendererTranslator.cpp
+++ b/extensions/Particle3D/PU/CCPURendererTranslator.cpp
@@ -74,12 +74,12 @@ void PURendererTranslator::translate(PUScriptCompiler* compiler, PUAbstractNode 
          PUMaterial *material = PUMaterialCache::Instance()->getMaterial(system->getMaterialName());
          std::string texFolder = "textures/";
          if (material){
-             std::string::size_type pos = obj->file.find_last_of("/");
+             std::string::size_type pos = obj->file.find_last_of('/');
              //if (pos != std::string::npos)
              //    texFolder = obj->file.substr(0, pos + 1) + texFolder;
              if (pos != std::string::npos){
                  std::string temp = obj->file.substr(0, pos);
-                 pos = temp.find_last_of("/");
+                 pos = temp.find_last_of('/');
                  if (pos != std::string::npos){
                      texFolder = temp.substr(0, pos + 1) + texFolder;
                  }
@@ -261,7 +261,7 @@ void PURendererTranslator::translate(PUScriptCompiler* compiler, PUAbstractNode 
                             std::string val;
                             if(getString(*prop->values.front(), &val))
                             {
-                                std::string::size_type pos = val.find_last_of(".");
+                                std::string::size_type pos = val.find_last_of('.');
                                 val = val.substr(0, pos + 1) + std::string("c3b");
                                 if (material) 
                                     _renderer = PUParticle3DModelRender::create(val, texFolder + material->textureFile);

--- a/extensions/assets-manager/AssetsManager.cpp
+++ b/extensions/assets-manager/AssetsManager.cpp
@@ -328,7 +328,7 @@ bool AssetsManager::uncompress()
             
             size_t startIndex=0;
             
-            size_t index=fileNameStr.find("/",startIndex);
+            size_t index=fileNameStr.find('/',startIndex);
             
             while(index != std::string::npos)
             {
@@ -356,7 +356,7 @@ bool AssetsManager::uncompress()
                 
                 startIndex=index+1;
                 
-                index=fileNameStr.find("/",startIndex);
+                index=fileNameStr.find('/',startIndex);
                 
             }
 

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIRadioButtonTest/UIRadioButtonTest.cpp
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIRadioButtonTest/UIRadioButtonTest.cpp
@@ -304,7 +304,7 @@ void UIRadioButtonTwoGroupsTest::addLog(const std::string& log)
     
     if(_numberOfLogLines > 10)
     {
-        size_t pos = existingLog.find("\n") + 1;
+        size_t pos = existingLog.find('\n') + 1;
         std::string newLog = existingLog.substr(pos);
         existingLog = newLog;
         --_numberOfLogLines;


### PR DESCRIPTION
https://clang.llvm.org/extra/clang-tidy/checks/performance-faster-string-find.html

Optimize calls to std::string::find() and friends when the needle passed is a single character string literal. The character literal overload is more efficient.

Examples:

```cpp
str.find("A");

// becomes

str.find('A');
```