### PR TITLE
remove redundant user-defined copy constructor and destructor

### DIFF
--- a/cocos/3d/CCAABB.cpp
+++ b/cocos/3d/CCAABB.cpp
@@ -37,11 +37,6 @@ AABB::AABB(const Vec3& min, const Vec3& max)
     set(min, max);
 }
 
-AABB::AABB(const AABB& box)
-{
-	set(box._min,box._max);
-}
-
 Vec3 AABB::getCenter()
 {
     Vec3 center;

--- a/cocos/3d/CCAABB.h
+++ b/cocos/3d/CCAABB.h
@@ -56,11 +56,6 @@ public:
     AABB(const Vec3& min, const Vec3& max);
     
     /**
-     * Constructor.
-     */
-    AABB(const AABB& box);
-    
-    /**
      * Gets the center point of the bounding box.
      */
     Vec3 getCenter();

--- a/cocos/math/Vec2.h
+++ b/cocos/math/Vec2.h
@@ -94,18 +94,6 @@ public:
     Vec2(const Vec2& p1, const Vec2& p2);
 
     /**
-     * Constructs a new vector that is a copy of the specified vector.
-     *
-     * @param copy The vector to copy.
-     */
-    Vec2(const Vec2& copy);
-
-    /**
-     * Destructor.
-     */
-    ~Vec2();
-
-    /**
      * Indicates whether this vector contains all zeros.
      *
      * @return true if this vector contains all zeros, false otherwise.

--- a/cocos/math/Vec2.inl
+++ b/cocos/math/Vec2.inl
@@ -42,15 +42,6 @@ inline Vec2::Vec2(const Vec2& p1, const Vec2& p2)
     set(p1, p2);
 }
 
-inline Vec2::Vec2(const Vec2& copy)
-{
-    set(copy);
-}
-
-inline Vec2::~Vec2()
-{
-}
-
 inline bool Vec2::isZero() const
 {
     return x == 0.0f && y == 0.0f;

--- a/cocos/math/Vec3.cpp
+++ b/cocos/math/Vec3.cpp
@@ -45,11 +45,6 @@ Vec3::Vec3(const Vec3& p1, const Vec3& p2)
     set(p1, p2);
 }
 
-Vec3::Vec3(const Vec3& copy)
-{
-    set(copy);
-}
-
 Vec3 Vec3::fromColor(unsigned int color)
 {
     float components[3];
@@ -63,10 +58,6 @@ Vec3 Vec3::fromColor(unsigned int color)
 
     Vec3 value(components);
     return value;
-}
-
-Vec3::~Vec3()
-{
 }
 
 float Vec3::angle(const Vec3& v1, const Vec3& v2)

--- a/cocos/math/Vec3.h
+++ b/cocos/math/Vec3.h
@@ -94,13 +94,6 @@ public:
     Vec3(const Vec3& p1, const Vec3& p2);
 
     /**
-     * Constructs a new vector that is a copy of the specified vector.
-     *
-     * @param copy The vector to copy.
-     */
-    Vec3(const Vec3& copy);
-
-    /**
      * Creates a new vector from an integer interpreted as an RGB value.
      * E.g. 0xff0000 represents red or the vector (1, 0, 0).
      *
@@ -109,11 +102,6 @@ public:
      * @return A vector corresponding to the interpreted RGB color.
      */
     static Vec3 fromColor(unsigned int color);
-
-    /**
-     * Destructor.
-     */
-    ~Vec3();
 
     /**
      * Indicates whether this vector contains all zeros.


### PR DESCRIPTION
Remove redundant user-defined copy constructor and destructor, as compiler auto-generated ones are working fine. 

It also helps to get rid of compiler warnings when when compile it on C++11 standard. C++11 has a rule of five. If user defines any one of copy constructor, copy assignment operator, move constructor, move assignment operator, or destructor, all of them need to explicitly written.