### PR TITLE
Optimize range-for loop variable through const reference

### DIFF
--- a/cocos/2d/CCSpriteFrameCache.cpp
+++ b/cocos/2d/CCSpriteFrameCache.cpp
@@ -757,7 +757,7 @@ bool SpriteFrameCache::PlistFramesCache::erasePlistIndex(const std::string &plis
     if (it == _indexPlist2Frames.end()) return false;
 
     auto &frames = it->second;
-    for (auto f : frames)
+    for (const auto& f : frames)
     {
         // !!do not!! call `_spriteFrames.erase(f);` to erase SpriteFrame
         // only erase index here

--- a/cocos/2d/CCTMXXMLParser.cpp
+++ b/cocos/2d/CCTMXXMLParser.cpp
@@ -752,7 +752,7 @@ void TMXMapInfo::endElement(void* /*ctx*/, const char *name)
             }
 
             uint32_t* bufferPtr = reinterpret_cast<uint32_t*>(buffer);
-            for(auto gidToken : gidTokens) {
+            for(const auto& gidToken : gidTokens) {
                 auto tileGid = (uint32_t)strtoul(gidToken.c_str(), nullptr, 10);
                 *bufferPtr = tileGid;
                 bufferPtr++;

--- a/cocos/3d/CCAnimate3D.cpp
+++ b/cocos/3d/CCAnimate3D.cpp
@@ -392,7 +392,7 @@ void Animate3D::update(float t)
                     float prekeyTime = lastTime * getDuration() * _frameRate;
                     float keyTime = t * getDuration() * _frameRate;
                     std::vector<Animate3DDisplayedEventInfo*> eventInfos;
-                    for (auto keyFrame : _keyFrameUserInfos)
+                    for (const auto& keyFrame : _keyFrameUserInfos)
                     {
                         if ((!_playReverse && keyFrame.first >= prekeyTime && keyFrame.first < keyTime)
                             || (_playReverse && keyFrame.first >= keyTime && keyFrame.first < prekeyTime))

--- a/cocos/3d/CCAnimation3D.cpp
+++ b/cocos/3d/CCAnimation3D.cpp
@@ -87,8 +87,9 @@ Animation3D::Animation3D()
 
 Animation3D::~Animation3D()
 {
-    for (auto itor : _boneCurves) {
-        CC_SAFE_DELETE(itor.second);
+    for (const auto& itor : _boneCurves) {
+        Curve* curve = itor.second;
+        CC_SAFE_DELETE(curve);
     }
 }
 

--- a/cocos/3d/CCBundle3D.cpp
+++ b/cocos/3d/CCBundle3D.cpp
@@ -2210,7 +2210,7 @@ std::vector<Vec3> Bundle3D::getTrianglesList(const std::string& path)
     Bundle3D::destroyBundle(bundle);
     for (auto iter : meshs.meshDatas){
         int preVertexSize = iter->getPerVertexSize() / sizeof(float);
-        for (auto indexArray : iter->subMeshIndices){
+        for (const auto& indexArray : iter->subMeshIndices){
             for (auto i : indexArray){
                 trianglesList.push_back(Vec3(iter->vertex[i * preVertexSize], iter->vertex[i * preVertexSize + 1], iter->vertex[i * preVertexSize + 2]));
             }

--- a/cocos/3d/CCSkeleton3D.cpp
+++ b/cocos/3d/CCSkeleton3D.cpp
@@ -202,7 +202,7 @@ void Bone3D::updateLocalMat()
         Quaternion quat(Quaternion::ZERO);
         
         float total = 0.f;
-        for (auto it: _blendStates) {
+        for (const auto& it: _blendStates) {
             total += it.weight;
         }
         if (total)

--- a/cocos/3d/CCTerrain.cpp
+++ b/cocos/3d/CCTerrain.cpp
@@ -1335,7 +1335,7 @@ bool Terrain::Chunk::getIntersectPointWithRay(const Ray& ray, Vec3& intersectPoi
 
     float minDist = FLT_MAX;
     bool isFind = false;
-    for (auto triangle : _trianglesList)
+    for (const auto& triangle : _trianglesList)
     {
         Vec3 p;
         if (triangle.getIntersectPoint(ray, p))

--- a/cocos/editor-support/cocostudio/ActionTimeline/CCActionTimeline.cpp
+++ b/cocos/editor-support/cocostudio/ActionTimeline/CCActionTimeline.cpp
@@ -176,7 +176,7 @@ ActionTimeline* ActionTimeline::clone() const
     newAction->setDuration(_duration);
     newAction->setTimeSpeed(_timeSpeed);
 
-    for (auto timelines : _timelineMap)
+    for (const auto& timelines : _timelineMap)
     {
         for(auto timeline : timelines.second)
         {      
@@ -185,7 +185,7 @@ ActionTimeline* ActionTimeline::clone() const
         }
     }
     
-    for( auto info : _animationInfos)
+    for(const auto& info : _animationInfos)
     {
         newAction->addAnimationInfo(info.second);
     }
@@ -416,7 +416,7 @@ void ActionTimeline::emitFrameEndCallFuncs(int frameIndex)
     if (clipEndCallsIter != _frameEndCallFuncs.end())
     {
         auto clipEndCalls = (*clipEndCallsIter).second;
-        for (auto call : clipEndCalls)
+        for (const auto& call : clipEndCalls)
             (call).second();
     }
 }

--- a/cocos/editor-support/cocostudio/CCArmatureDataManager.cpp
+++ b/cocos/editor-support/cocostudio/CCArmatureDataManager.cpp
@@ -95,22 +95,22 @@ void ArmatureDataManager::removeArmatureFileInfo(const std::string& configFilePa
 {
     if (RelativeData *data = getRelativeData(configFilePath))
     {
-        for (std::string str : data->armatures)
+        for (const std::string& str : data->armatures)
         {
             removeArmatureData(str);
         }
 
-        for (std::string str : data->animations)
+        for (const std::string& str : data->animations)
         {
             removeAnimationData(str);
         }
 
-        for (std::string str : data->textures)
+        for (const std::string& str : data->textures)
         {
             removeTextureData(str);
         }
 
-        for (std::string str : data->plistFiles)
+        for (const std::string& str : data->plistFiles)
         {
             SpriteFrameCacheHelper::getInstance()->removeSpriteFrameFromFile(str);
         }

--- a/cocos/physics/CCPhysicsJoint.cpp
+++ b/cocos/physics/CCPhysicsJoint.cpp
@@ -180,7 +180,7 @@ bool PhysicsJoint::initJoint()
 
 void PhysicsJoint::flushDelayTasks()
 {
-    for (auto tsk : _delayTasks)
+    for (const auto& tsk : _delayTasks)
     {
         tsk();
     }

--- a/cocos/scripting/js-bindings/manual/js_manual_conversions.cpp
+++ b/cocos/scripting/js-bindings/manual/js_manual_conversions.cpp
@@ -2730,7 +2730,7 @@ jsval std_vector_string_to_jsval( JSContext *cx, const std::vector<std::string>&
     JS::RootedObject jsretArr(cx, JS_NewArrayObject(cx, v.size()));
 
     int i = 0;
-    for (const std::string obj : v)
+    for (const std::string& obj : v)
     {
         JS::RootedValue arrElement(cx);
         arrElement = std_string_to_jsval(cx, obj);

--- a/cocos/scripting/lua-bindings/manual/physics3d/lua_cocos2dx_physics3d_manual.cpp
+++ b/cocos/scripting/lua-bindings/manual/physics3d/lua_cocos2dx_physics3d_manual.cpp
@@ -760,7 +760,7 @@ int lua_cocos2dx_physics3d_Physics3DObject_setCollisionCallback(lua_State* L)
             {
                 int vecIndex = 1;
                 lua_newtable(L);
-                for (auto value : ci.collisionPointList)
+                for (const auto& value : ci.collisionPointList)
                 {
                     lua_pushnumber(L, vecIndex);
                     CollisionPoint_to_luaval(L, value);

--- a/extensions/Particle3D/PU/CCPURibbonTrailRender.cpp
+++ b/extensions/Particle3D/PU/CCPURibbonTrailRender.cpp
@@ -73,7 +73,7 @@ void PURibbonTrailRender::render( Renderer* renderer, const Mat4 &transform, Par
 
     const PUParticleSystem3D::ParticlePoolMap &emitterPool = static_cast<PUParticleSystem3D *>(particleSystem)->getEmittedEmitterParticlePool();
     if (!emitterPool.empty()){
-        for (auto iter : emitterPool){
+        for (const auto& iter : emitterPool){
             updateParticles(iter.second);
             needDraw = true;
         }
@@ -81,7 +81,7 @@ void PURibbonTrailRender::render( Renderer* renderer, const Mat4 &transform, Par
 
     const PUParticleSystem3D::ParticlePoolMap &systemPool = static_cast<PUParticleSystem3D *>(particleSystem)->getEmittedSystemParticlePool();
     if (!systemPool.empty()){
-        for (auto iter : systemPool){
+        for (const auto& iter : systemPool){
             updateParticles(iter.second);
             needDraw = true;
         }

--- a/extensions/Particle3D/PU/CCPUScriptCompiler.cpp
+++ b/extensions/Particle3D/PU/CCPUScriptCompiler.cpp
@@ -185,7 +185,7 @@ PUScriptCompiler::PUScriptCompiler():_current(nullptr),_nodes(nullptr), _PUParti
 }
 PUScriptCompiler::~PUScriptCompiler()
 {
-    for (auto iter : _compiledScripts){
+    for (const auto& iter : _compiledScripts){
         for (auto miter : iter.second){
             delete miter;
         }

--- a/extensions/assets-manager/AssetsManagerEx.cpp
+++ b/extensions/assets-manager/AssetsManagerEx.cpp
@@ -224,7 +224,7 @@ void AssetsManagerEx::loadLocalManifest(const std::string& /*manifestUrl*/)
     {
         std::vector<std::string> cacheSearchPaths = cachedManifest->getSearchPaths();
         std::vector<std::string> trimmedPaths = searchPaths;
-        for (auto path : cacheSearchPaths)
+        for (const auto& path : cacheSearchPaths)
         {
             const auto pos = std::find(trimmedPaths.begin(), trimmedPaths.end(), path);
             if (pos != trimmedPaths.end())
@@ -1133,7 +1133,7 @@ void AssetsManagerEx::destroyDownloadedVersion()
 void AssetsManagerEx::batchDownload()
 {
     _queue.clear();
-    for(auto iter : _downloadUnits)
+    for(const auto& iter : _downloadUnits)
     {
         const DownloadUnit& unit = iter.second;
         if (unit.size > 0)

--- a/tests/lua-tests/project/Classes/lua_test_bindings.cpp
+++ b/tests/lua-tests/project/Classes/lua_test_bindings.cpp
@@ -339,7 +339,7 @@ ValueTypeJudgeInTable* ValueTypeJudgeInTable::create(ValueMap valueMap)
     }
     
     int index = 0;
-    for (auto iter : valueMap)
+    for (const auto& iter : valueMap)
     {
         Value::Type type = iter.second.getType();
         if (type == Value::Type::STRING) {


### PR DESCRIPTION
With the help of clang-tidy, https://clang.llvm.org/extra/clang-tidy/checks/performance-for-range-copy.html

> Finds C++11 for ranges where the loop variable is copied in each iteration but it would suffice to obtain it by const reference.

> The check is only applied to loop variables of types that are expensive to copy which means they are not trivially copyable or have a non-trivial copy constructor or destructor.

> To ensure that it is safe to replace the copy with a const reference the following heuristic is employed:

>    The loop variable is const qualified.
>    The loop variable is not const, but only const methods or operators are invoked on it, or it is used as const reference or value argument in constructors or function calls.

A example is shown below.

```cpp
-        for (std::string str : data->armatures)
+        for (const std::string& str : data->armatures)
         {
             removeArmatureData(str);
         }
```