### PR TITLE
fix concave polygon bug in DrawNode

### DIFF
--- a/cocos/2d/CCDrawNode.cpp
+++ b/cocos/2d/CCDrawNode.cpp
@@ -98,6 +98,120 @@ static inline Tex2F __t(const Vec2 &v)
     return *(Tex2F*)&v;
 }
 
+static const float EPSILON=0.0000000001f;
+float Triangulate::Area(const Vec2 *verts,int n)
+{
+    float A=0.0f;
+    for(int p=n-1,q=0; q<n; p=q++)
+    {
+        A+= verts[p].x*verts[q].y - verts[q].x*verts[p].y;
+    }
+    return A*0.5f;
+}
+
+/*
+ InsideTriangle decides if a point P is Inside of the triangle
+ defined by A, B, C.
+ */
+bool Triangulate::InsideTriangle(float Ax, float Ay,
+                                 float Bx, float By,
+                                 float Cx, float Cy,
+                                 float Px, float Py)
+
+{
+    float ax, ay, bx, by, cx, cy, apx, apy, bpx, bpy, cpx, cpy;
+    float cCROSSap, bCROSScp, aCROSSbp;
+    ax = Cx - Bx;  ay = Cy - By;
+    bx = Ax - Cx;  by = Ay - Cy;
+    cx = Bx - Ax;  cy = By - Ay;
+    apx= Px - Ax;  apy= Py - Ay;
+    bpx= Px - Bx;  bpy= Py - By;
+    cpx= Px - Cx;  cpy= Py - Cy;
+    
+    aCROSSbp = ax*bpy - ay*bpx;
+    cCROSSap = cx*apy - cy*apx;
+    bCROSScp = bx*cpy - by*cpx;
+    
+    return ((aCROSSbp >= 0.0f) && (bCROSScp >= 0.0f) && (cCROSSap >= 0.0f));
+};
+
+bool Triangulate::Snip(const Vec2 *verts,int u,int v,int w,int n,int *V)
+{
+    int p;
+    float Ax, Ay, Bx, By, Cx, Cy, Px, Py;
+    
+    Ax = verts[V[u]].x;
+    Ay = verts[V[u]].y;
+    
+    Bx = verts[V[v]].x;
+    By = verts[V[v]].y;
+    
+    Cx = verts[V[w]].x;
+    Cy = verts[V[w]].y;
+    
+    if ( EPSILON > (((Bx-Ax)*(Cy-Ay)) - ((By-Ay)*(Cx-Ax))) ) return false;
+    
+    for (p=0;p<n;p++)
+    {
+        if( (p == u) || (p == v) || (p == w) ) continue;
+        Px = verts[V[p]].x;
+        Py = verts[V[p]].y;
+        if (InsideTriangle(Ax,Ay,Bx,By,Cx,Cy,Px,Py)) return false;
+    }
+    
+    return true;
+}
+
+V2F_C4B_T2F_Triangle * Triangulate::Process(const Vec2 *verts,V2F_C4B_T2F_Triangle * triangles,int n,const Color4F &fillColor)
+{
+    if ( n < 3 ) return triangles;
+    
+    int *V = new int[n];
+    /* we want a counter-clockwise polygon in V */
+    if ( 0.0f < Area(verts,n) )
+        for (int v=0; v<n; v++) V[v] = v;
+    else
+        for(int v=0; v<n; v++) V[v] = (n-1)-v;
+    
+    int nv = n;
+    /*  remove nv-2 Vertices, creating 1 triangle every time */
+    int count = 2*nv;   /* error detection */
+    for(int m=0, v=nv-1; nv>2; )
+    {
+        /* if we loop, it is probably a non-simple polygon */
+        if (0 >= (count--))
+        {
+            //** Triangulate: ERROR - probable bad polygon!
+            return triangles;
+        }
+        /* three consecutive vertices in current polygon, <u,v,w> */
+        int u = v  ; if (nv <= u) u = 0;     /* previous */
+        v = u+1; if (nv <= v) v = 0;     /* new v    */
+        int w = v+1; if (nv <= w) w = 0;     /* next     */
+        
+        if ( Snip(verts,u,v,w,nv,V) )
+        {
+            int a,b,c,s,t;
+            /* true names of the vertices */
+            a = V[u]; b = V[v]; c = V[w];
+            
+            V2F_C4B_T2F_Triangle tmp = {
+                {verts[a], Color4B(fillColor), __t(v2fzero)},
+                {verts[b], Color4B(fillColor), __t(v2fzero)},
+                {verts[c], Color4B(fillColor), __t(v2fzero)},
+            };
+            *triangles++ = tmp;
+            m++;
+            /* remove v from remaining polygon */
+            for(s=v,t=v+1;t<nv;s++,t++) V[s] = V[t]; nv--;
+            /* resest error detection counter */
+            count = 2*nv;
+        }
+    }
+    delete []V;
+    return triangles;
+}
+
 // implementation of DrawNode
 
 DrawNode::DrawNode(GLfloat lineWidth)
@@ -764,16 +878,7 @@ void DrawNode::drawPolygon(const Vec2 *verts, int count, const Color4F &fillColo
     V2F_C4B_T2F_Triangle *triangles = (V2F_C4B_T2F_Triangle *)(_buffer + _bufferCount);
     V2F_C4B_T2F_Triangle *cursor = triangles;
     
-    for (int i = 0; i < count-2; i++)
-    {
-        V2F_C4B_T2F_Triangle tmp = {
-            {verts[0], Color4B(fillColor), __t(v2fzero)},
-            {verts[i+1], Color4B(fillColor), __t(v2fzero)},
-            {verts[i+2], Color4B(fillColor), __t(v2fzero)},
-        };
-        
-        *cursor++ = tmp;
-    }
+    cursor = Triangulate::Process(verts,cursor,count,fillColor);
     
     if(outline)
     {

--- a/cocos/2d/CCDrawNode.h
+++ b/cocos/2d/CCDrawNode.h
@@ -41,6 +41,10 @@ NS_CC_BEGIN
 
 static const int DEFAULT_LINE_WIDTH = 2;
 
+/*
+ * Code of Triangulate copied & pasted from http://www.flipcode.com/archives/Efficient_Polygon_Triangulation.shtml,
+ * Added some changes for cocos2d
+ */
 class Triangulate
 {
 public:

--- a/cocos/2d/CCDrawNode.h
+++ b/cocos/2d/CCDrawNode.h
@@ -47,20 +47,20 @@ public:
     
     // triangulate a contour/polygon, places results in STL vector
     // as series of triangles.
-    static V2F_C4B_T2F_Triangle * Process(const Vec2 *verts,V2F_C4B_T2F_Triangle * triangles,int n,const Color4F &fillColor);
+    static V2F_C4B_T2F_Triangle * processTriangles(const Vec2 *verts,V2F_C4B_T2F_Triangle * triangles,int n,const Color4F &fillColor);
 
     // compute area of a contour/polygon
-    static float Area(const Vec2 *verts,int n);
+    static float computeArea(const Vec2 *verts,int n);
     
     // decide if point Px/Py is inside triangle defined by
     // (Ax,Ay) (Bx,By) (Cx,Cy)
-    static bool InsideTriangle(float Ax, float Ay,
+    static bool isInsideTriangle(float Ax, float Ay,
                                float Bx, float By,
                                float Cx, float Cy,
                                float Px, float Py);
     
 private:
-    static bool Snip(const Vec2 *verts,int u,int v,int w,int n,int *V);
+    static bool checkSnip(const Vec2 *verts,int u,int v,int w,int n,int *V);
 };
 
 class PointArray;

--- a/cocos/2d/CCDrawNode.h
+++ b/cocos/2d/CCDrawNode.h
@@ -41,6 +41,28 @@ NS_CC_BEGIN
 
 static const int DEFAULT_LINE_WIDTH = 2;
 
+class Triangulate
+{
+public:
+    
+    // triangulate a contour/polygon, places results in STL vector
+    // as series of triangles.
+    static V2F_C4B_T2F_Triangle * Process(const Vec2 *verts,V2F_C4B_T2F_Triangle * triangles,int n,const Color4F &fillColor);
+
+    // compute area of a contour/polygon
+    static float Area(const Vec2 *verts,int n);
+    
+    // decide if point Px/Py is inside triangle defined by
+    // (Ax,Ay) (Bx,By) (Cx,Cy)
+    static bool InsideTriangle(float Ax, float Ay,
+                               float Bx, float By,
+                               float Cx, float Cy,
+                               float Px, float Py);
+    
+private:
+    static bool Snip(const Vec2 *verts,int u,int v,int w,int n,int *V);
+};
+
 class PointArray;
 /**
  * @addtogroup _2d

--- a/tests/cpp-tests/Classes/DrawPrimitivesTest/DrawPrimitivesTest.cpp
+++ b/tests/cpp-tests/Classes/DrawPrimitivesTest/DrawPrimitivesTest.cpp
@@ -43,6 +43,7 @@ DrawPrimitivesTests::DrawPrimitivesTests()
     ADD_TEST_CASE(DrawNodeTest);
     ADD_TEST_CASE(PrimitivesCommandTest);
     ADD_TEST_CASE(Issue11942Test);
+    ADD_TEST_CASE(Issue19641Test);
 }
 
 string DrawPrimitivesBaseTest::title() const
@@ -265,10 +266,6 @@ DrawNodeTest::DrawNodeTest()
     Vec2 points[] = { Vec2(s.height/4,0), Vec2(s.width,s.height/5), Vec2(s.width/3*2,s.height) };
     draw->drawPolygon(points, sizeof(points)/sizeof(points[0]), Color4F(1,0,0,0.5), 4, Color4F(0,0,1,0.5));
     
-    // Draw concave polygons
-    Vec2 concavePoints[] = { Vec2(0,130), Vec2(140,130), Vec2(140,160),Vec2(120,145),Vec2(30,145),Vec2(0,160) };
-    draw->drawPolygon(concavePoints, sizeof(concavePoints)/sizeof(concavePoints[0]), Color4F(1,0,0,0.5), 4, Color4F(0,0,1,0.5));
-    
     // star poly (triggers buggs)
     {
         const float o=80;
@@ -438,6 +435,30 @@ string Issue11942Test::title() const
 string Issue11942Test::subtitle() const
 {
     return "drawCircle() with width";
+}
+
+//
+// Issue19641Tes
+// Test draw a concave polygon
+//
+Issue19641Test::Issue19641Test()
+{
+    auto draw = DrawNode::create();
+    addChild(draw, 10);
+    
+    auto s = Director::getInstance()->getWinSize();
+    Vec2 concavePoints[] = { Vec2(s.width/2-70,130), Vec2(s.width/2+70,130), Vec2(s.width/2+70,160), Vec2(s.width/2+50,145), Vec2(s.width/2-40,145), Vec2(s.width/2-70,160) };
+    draw->drawPolygon(concavePoints, sizeof(concavePoints)/sizeof(concavePoints[0]), Color4F(1,0,0,0.5), 4, Color4F(0,1,0,0.5));
+}
+
+string Issue19641Test::title() const
+{
+    return "GitHub Issue #19641";
+}
+
+string Issue19641Test::subtitle() const
+{
+    return "draw a concave polygon";
 }
 
 

--- a/tests/cpp-tests/Classes/DrawPrimitivesTest/DrawPrimitivesTest.cpp
+++ b/tests/cpp-tests/Classes/DrawPrimitivesTest/DrawPrimitivesTest.cpp
@@ -265,6 +265,10 @@ DrawNodeTest::DrawNodeTest()
     Vec2 points[] = { Vec2(s.height/4,0), Vec2(s.width,s.height/5), Vec2(s.width/3*2,s.height) };
     draw->drawPolygon(points, sizeof(points)/sizeof(points[0]), Color4F(1,0,0,0.5), 4, Color4F(0,0,1,0.5));
     
+    // Draw concave polygons
+    Vec2 concavePoints[] = { Vec2(0,130), Vec2(140,130), Vec2(140,160),Vec2(120,145),Vec2(30,145),Vec2(0,160) };
+    draw->drawPolygon(concavePoints, sizeof(concavePoints)/sizeof(concavePoints[0]), Color4F(1,0,0,0.5), 4, Color4F(0,0,1,0.5));
+    
     // star poly (triggers buggs)
     {
         const float o=80;

--- a/tests/cpp-tests/Classes/DrawPrimitivesTest/DrawPrimitivesTest.h
+++ b/tests/cpp-tests/Classes/DrawPrimitivesTest/DrawPrimitivesTest.h
@@ -96,4 +96,16 @@ public:
 
 };
 
+class Issue19641Test : public DrawPrimitivesBaseTest
+{
+public:
+    CREATE_FUNC(Issue19641Test);
+    
+    Issue19641Test();
+    
+    virtual std::string title() const override;
+    virtual std::string subtitle() const override;
+    
+};
+
 #endif


### PR DESCRIPTION
There is a bug when I draw a concave polygon by DrawNode:drawPolygon.
The shape was wrong。
I found a solution at this page: 
http://www.flipcode.com/archives/Efficient_Polygon_Triangulation.shtml.
I added a test code in DrawPrimitivesTest.cpp , and I have tested it , it shows right.