### PR TITLE
add clang-tidy support

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,7 +1,7 @@
 ---
 Checks: "-*,\
+performance-faster-string-find,\
 performance-for-range-copy,\
-readability-const-return-type,\
 "
 WarningsAsErrors: '*'
 HeaderFilterRegex: '/(?!external)/.*'

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,11 @@
 ---
-Checks:          'clang-diagnostic-*,clang-analyzer-*,-*,performance-faster-string-find,performance-for-range-copy,'
+Checks: >
+  clang-diagnostic-*,
+  clang-analyzer-*,
+  -*,
+  performance-faster-string-find,
+  performance-for-range-copy,
+
 WarningsAsErrors: '*'
 HeaderFilterRegex: '/(?!external)/.*'
 AnalyzeTemporaryDtors: false

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,8 +1,38 @@
 ---
-Checks: "-*,\
-performance-faster-string-find,\
-performance-for-range-copy,\
-"
+Checks:          'clang-diagnostic-*,clang-analyzer-*,-*,performance-faster-string-find,performance-for-range-copy,'
 WarningsAsErrors: '*'
 HeaderFilterRegex: '/(?!external)/.*'
+AnalyzeTemporaryDtors: false
+FormatStyle:     none
+CheckOptions:    
+  - key:             cert-dcl16-c.NewSuffixes
+    value:           'L;LL;LU;LLU'
+  - key:             cppcoreguidelines-non-private-member-variables-in-classes.IgnoreClassesWithAllMemberVariablesBeingPublic
+    value:           '1'
+  - key:             google-readability-braces-around-statements.ShortStatementLines
+    value:           '1'
+  - key:             google-readability-function-size.StatementThreshold
+    value:           '800'
+  - key:             google-readability-namespace-comments.ShortNamespaceLines
+    value:           '10'
+  - key:             google-readability-namespace-comments.SpacesBeforeComments
+    value:           '2'
+  - key:             modernize-loop-convert.MaxCopySize
+    value:           '16'
+  - key:             modernize-loop-convert.MinConfidence
+    value:           reasonable
+  - key:             modernize-loop-convert.NamingStyle
+    value:           CamelCase
+  - key:             modernize-pass-by-value.IncludeStyle
+    value:           llvm
+  - key:             modernize-replace-auto-ptr.IncludeStyle
+    value:           llvm
+  - key:             modernize-use-nullptr.NullMacros
+    value:           'NULL'
+  - key:             performance-faster-string-find.StringLikeClasses
+    value:           'std::basic_string'
+  - key:             performance-for-range-copy.AllowedTypes
+    value:           ''
+  - key:             performance-for-range-copy.WarnOnAllAutoCopies
+    value:           '0'
 ...

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,8 @@
+---
+Checks: "-*,\
+performance-for-range-copy,\
+readability-const-return-type,\
+"
+WarningsAsErrors: '*'
+HeaderFilterRegex: '/(?!external)/.*'
+...

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,7 +1,5 @@
 ---
 Checks: >
-  clang-diagnostic-*,
-  clang-analyzer-*,
   -*,
   performance-faster-string-find,
   performance-for-range-copy,
@@ -10,35 +8,3 @@ WarningsAsErrors: '*'
 HeaderFilterRegex: '/(?!external)/.*'
 AnalyzeTemporaryDtors: false
 FormatStyle:     none
-CheckOptions:    
-  - key:             cert-dcl16-c.NewSuffixes
-    value:           'L;LL;LU;LLU'
-  - key:             cppcoreguidelines-non-private-member-variables-in-classes.IgnoreClassesWithAllMemberVariablesBeingPublic
-    value:           '1'
-  - key:             google-readability-braces-around-statements.ShortStatementLines
-    value:           '1'
-  - key:             google-readability-function-size.StatementThreshold
-    value:           '800'
-  - key:             google-readability-namespace-comments.ShortNamespaceLines
-    value:           '10'
-  - key:             google-readability-namespace-comments.SpacesBeforeComments
-    value:           '2'
-  - key:             modernize-loop-convert.MaxCopySize
-    value:           '16'
-  - key:             modernize-loop-convert.MinConfidence
-    value:           reasonable
-  - key:             modernize-loop-convert.NamingStyle
-    value:           CamelCase
-  - key:             modernize-pass-by-value.IncludeStyle
-    value:           llvm
-  - key:             modernize-replace-auto-ptr.IncludeStyle
-    value:           llvm
-  - key:             modernize-use-nullptr.NullMacros
-    value:           'NULL'
-  - key:             performance-faster-string-find.StringLikeClasses
-    value:           'std::basic_string'
-  - key:             performance-for-range-copy.AllowedTypes
-    value:           ''
-  - key:             performance-for-range-copy.WarnOnAllAutoCopies
-    value:           '0'
-...

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,12 @@ matrix:
         - secure: M5lyDs0qai15mWHzJdkh0WPfVJJmVZu6SWtYULxatukGPXVwoQvmEtYAwAW+iz6aM+tXksQ/mk6nW5L8UFbHm+n6yrsa5bZU9sGXjilPE8p8bLFYDmIbPRazU+E6pBP3J2CDoAm0XnWkiYQ8feTxKTo6ysLnHAEjyaHTw0+Q1GM=
       sudo: required
       language: cpp
+    # clang-tidy
+    - os: linux
+      dist: xenial
+      env: BUILD_TARGET=linux_clang_tidy
+      language: cpp
+      sudo: required
     # mac_cmake
     - os: osx
       env: BUILD_TARGET=mac_cmake
@@ -67,12 +73,6 @@ matrix:
     - os: linux
       dist: xenial
       env: BUILD_TARGET=linux_cocos_new_lua_test
-      language: cpp
-      sudo: required
-    # clang-tidy
-    - os: linux
-      dist: xenial
-      env: BUILD_TARGET=linux_clang_tidy
       language: cpp
       sudo: required
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -69,6 +69,12 @@ matrix:
       env: BUILD_TARGET=linux_cocos_new_lua_test
       language: cpp
       sudo: required
+    # clang-tidy
+    - os: linux
+      dist: xenial
+      env: BUILD_TARGET=linux_clang_tidy
+      language: cpp
+      sudo: required
 
 script:
 - tools/travis-scripts/run-script.sh

--- a/tools/travis-scripts/before-install.sh
+++ b/tools/travis-scripts/before-install.sh
@@ -65,6 +65,9 @@ function install_environement_for_pull_request()
         if [ "$BUILD_TARGET" == "linux" ]; then
             install_linux_environment
         fi
+        if [ "$BUILD_TARGET" == "linux_clang_tidy" ]; then
+            install_linux_environment
+        fi
     fi
 
     if [ "$TRAVIS_OS_NAME" == "osx" ]; then

--- a/tools/travis-scripts/run-script.sh
+++ b/tools/travis-scripts/run-script.sh
@@ -44,7 +44,7 @@ function build_linux_clang_tidy()
     mkdir -p clang-tidy-build
     cd clang-tidy-build
     cmake ../.. -DCMAKE_EXPORT_COMPILE_COMMANDS=on
-    python /usr/local/clang-7.0.0/share/clang/run-clang-tidy.py -config=$COCOS2DX_ROOT/.clang-tidy
+    python /usr/local/clang-7.0.0/share/clang/run-clang-tidy.py
 }
 
 function build_mac()

--- a/tools/travis-scripts/run-script.sh
+++ b/tools/travis-scripts/run-script.sh
@@ -44,7 +44,7 @@ function build_linux_clang_tidy()
     mkdir -p clang-tidy-build
     cd clang-tidy-build
     cmake ../.. -DCMAKE_EXPORT_COMPILE_COMMANDS=on
-    python /usr/local/clang-7.0.0/share/clang/run-clang-tidy.py
+    python $(dirname $(dirname $(readlink -f `which clang-tidy`)))/share/clang/run-clang-tidy.py
 }
 
 function build_mac()

--- a/tools/travis-scripts/run-script.sh
+++ b/tools/travis-scripts/run-script.sh
@@ -303,7 +303,6 @@ function run_pull_request()
 
     # linux_clang_tidy_test
     if [ $BUILD_TARGET == 'linux_clang_tidy' ]; then
-        genernate_binding_codes
         build_linux_clang_tidy
     fi
 

--- a/tools/travis-scripts/run-script.sh
+++ b/tools/travis-scripts/run-script.sh
@@ -37,6 +37,16 @@ function build_linux()
     cmake --build .
 }
 
+function build_linux_clang_tidy()
+{
+    echo "Building clang tidy test on Linux ..."
+    cd $COCOS2DX_ROOT/build
+    mkdir -p clang-tidy-build
+    cd clang-tidy-build
+    cmake ../.. -DCMAKE_EXPORT_COMPILE_COMMANDS=on
+    python /usr/local/clang-7.0.0/share/clang/run-clang-tidy.py -config=$COCOS2DX_ROOT/.clang-tidy
+}
+
 function build_mac()
 {
     NUM_OF_CORES=`getconf _NPROCESSORS_ONLN`
@@ -289,6 +299,12 @@ function run_pull_request()
     if [ $BUILD_TARGET == 'linux' ]; then
         genernate_binding_codes
         build_linux
+    fi
+
+    # linux_clang_tidy_test
+    if [ $BUILD_TARGET == 'linux_clang_tidy' ]; then
+        genernate_binding_codes
+        build_linux_clang_tidy
     fi
 
     # android


### PR DESCRIPTION
Only two options are enabled (hard-coded in script)

* performance-faster-string-find
* performance-for-range-copy

Treat warnings as errors are enabled.

Another try.