### PR TITLE
 README for default cocos projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+ <!-- uncommment lines to show your screenshot -->
+<!--
+<div align="center"><img width="100%" height="100%" style="margin:auto" src="Screenshot.png"></div>
+<hr>  -->
+
+
 <img src="http://www.cocos2d-x.org/attachments/801/cocos2dx_portrait.png" width=200>
 
 
@@ -15,7 +21,7 @@ It works on iOS, Android, OS X, Windows, Linux and Web platforms.
 
 **Cocos2d-x Framework Architecture**:
 
-![](docs/framework_architecture.jpg "")
+![](https://raw.githubusercontent.com/cocos2d/cocos2d-x/v3/docs/framework_architecture.jpg "")
 
 cocos2d-x is:
 


### PR DESCRIPTION
You can add README, .gitignore and default Screenshot.png files into default cpp/lua or js templates in cocos2d-x. It's important when you pushing your project to GitHub and introducing the cocos2d-x to GitHub users and game developers.
[init.zip](https://github.com/cocos2d/cocos2d-x/files/3124686/init.zip)
