### PR TITLE
fix: cocos2d::Sprite don't call update_blend_func in the case of using same texture file

### DIFF
--- a/cocos/2d/CCSprite.cpp
+++ b/cocos/2d/CCSprite.cpp
@@ -399,11 +399,14 @@ void Sprite::setTexture(Texture2D *texture)
         }
     }
 
-    if ((_renderMode != RenderMode::QUAD_BATCHNODE) && (_texture != texture))
+    if (_renderMode != RenderMode::QUAD_BATCHNODE)
     {
-        CC_SAFE_RETAIN(texture);
-        CC_SAFE_RELEASE(_texture);
-        _texture = texture;
+        if (_texture != texture)
+        {
+            CC_SAFE_RETAIN(texture);
+            CC_SAFE_RELEASE(_texture);
+            _texture = texture;
+        }
         updateBlendFunc();
     }
 }


### PR DESCRIPTION
Fixed the bug that BlendFunc is not initialized when the same texture file is initialized by Sprite :: initWithTexture.

For example,

```c++

cocos2d::ui::ImageView image;
image.loadTexture("hoge.png");  // using Sprite::initWithTexture

...
image.loadTexture("hoge.png");  // bug : clear blend func!!
```
