### PR TITLE
minor refactoring of AudioEngine

### DIFF
--- a/cocos/audio/AudioEngine.cpp
+++ b/cocos/audio/AudioEngine.cpp
@@ -90,9 +90,10 @@ public:
     AudioEngineThreadPool(int threads = 4)
         : _stop(false)
     {
+        _workers.reserve(threads);
         for (int index = 0; index < threads; ++index)
         {
-            _workers.emplace_back(std::thread(std::bind(&AudioEngineThreadPool::threadFunc, this)));
+            _workers.emplace_back(std::bind(&AudioEngineThreadPool::threadFunc, this));
         }
     }
 
@@ -138,7 +139,9 @@ private:
                 }
             }
 
-            task();
+            if (task) {
+                task();
+            }
         }
     }
 
@@ -152,11 +155,8 @@ private:
 
 void AudioEngine::end()
 {
-    if (s_threadPool)
-    {
-        delete s_threadPool;
-        s_threadPool = nullptr;
-    }
+    delete s_threadPool;
+    s_threadPool = nullptr;
 
     delete _audioEngineImpl;
     _audioEngineImpl = nullptr;


### PR DESCRIPTION
* emplace_back accept constructor args directly
* use reserve
* remove superfluous null pointer check
* add null pointer check around `task()`