### PR TITLE
add new clang-tidy option

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -8,6 +8,7 @@ Checks: >
   performance-inefficient-vector-operation,
   performance-move-const-arg,
   performance-type-promotion-in-math-fn,
+  readability-container-size-empty,
 
 WarningsAsErrors: '*'
 HeaderFilterRegex: '/(?!external)/.*'

--- a/cocos/2d/CCAtlasNode.cpp
+++ b/cocos/2d/CCAtlasNode.cpp
@@ -71,7 +71,7 @@ AtlasNode * AtlasNode::create(const std::string& tile, int tileWidth, int tileHe
 
 bool AtlasNode::initWithTileFile(const std::string& tile, int tileWidth, int tileHeight, int itemsToRender)
 {
-    CCASSERT(tile.size() > 0, "file size should not be empty");
+    CCASSERT(!tile.empty(), "file size should not be empty");
     Texture2D *texture = Director::getInstance()->getTextureCache()->addImage(tile);
     return initWithTexture(texture, tileWidth, tileHeight, itemsToRender);
 }

--- a/cocos/2d/CCClippingNode.cpp
+++ b/cocos/2d/CCClippingNode.cpp
@@ -332,7 +332,7 @@ void ClippingNode::setStencil(Node *stencil)
 
 bool ClippingNode::hasContent() const
 {
-    return _children.size() > 0;
+    return !_children.empty();
 }
 
 GLfloat ClippingNode::getAlphaThreshold() const

--- a/cocos/2d/CCFastTMXTiledMap.cpp
+++ b/cocos/2d/CCFastTMXTiledMap.cpp
@@ -60,7 +60,7 @@ TMXTiledMap* TMXTiledMap::createWithXML(const std::string& tmxString, const std:
 
 bool TMXTiledMap::initWithTMXFile(const std::string& tmxFile)
 {
-    CCASSERT(tmxFile.size()>0, "FastTMXTiledMap: tmx file should not be empty");
+    CCASSERT(!tmxFile.empty(), "FastTMXTiledMap: tmx file should not be empty");
     
     setContentSize(Size::ZERO);
 
@@ -198,7 +198,7 @@ void TMXTiledMap::buildWithMapInfo(TMXMapInfo* mapInfo)
 // public
 TMXLayer * TMXTiledMap::getLayer(const std::string& layerName) const
 {
-    CCASSERT(layerName.size() > 0, "Invalid layer name!");
+    CCASSERT(!layerName.empty(), "Invalid layer name!");
     
     for (auto& child : _children)
     {
@@ -218,9 +218,9 @@ TMXLayer * TMXTiledMap::getLayer(const std::string& layerName) const
 
 TMXObjectGroup * TMXTiledMap::getObjectGroup(const std::string& groupName) const
 {
-    CCASSERT(groupName.size() > 0, "Invalid group name!");
+    CCASSERT(!groupName.empty(), "Invalid group name!");
 
-    if (_objectGroups.size()>0)
+    if (!_objectGroups.empty())
     {
         for (const auto& objectGroup : _objectGroups)
         {

--- a/cocos/2d/CCMenuItem.cpp
+++ b/cocos/2d/CCMenuItem.cpp
@@ -334,7 +334,7 @@ bool MenuItemAtlasFont::initWithString(const std::string& value, const std::stri
 
 bool MenuItemAtlasFont::initWithString(const std::string& value, const std::string& charMapFile, int itemWidth, int itemHeight, char startCharMap, const ccMenuCallback& callback)
 {
-    CCASSERT( value.size() != 0, "value length must be greater than 0");
+    CCASSERT( !value.empty(), "value length must be greater than 0");
     LabelAtlas *label = LabelAtlas::create();
     label->initWithString(value, charMapFile, itemWidth, itemHeight, startCharMap);
     if (MenuItemLabel::initWithLabel(label, callback))
@@ -736,17 +736,17 @@ bool MenuItemImage::initWithNormalImage(const std::string& normalImage, const st
     Node *selectedSprite = nullptr;
     Node *disabledSprite = nullptr;
 
-    if (normalImage.size() >0)
+    if (!normalImage.empty())
     {
         normalSprite = Sprite::create(normalImage);
     }
 
-    if (selectedImage.size() >0)
+    if (!selectedImage.empty())
     {
         selectedSprite = Sprite::create(selectedImage);
     }
 
-    if(disabledImage.size() >0)
+    if(!disabledImage.empty())
     {
         disabledSprite = Sprite::create(disabledImage);
     }
@@ -952,7 +952,7 @@ void MenuItemToggle::cleanup()
 
 void MenuItemToggle::setSelectedIndex(unsigned int index)
 {
-    if( index != _selectedIndex && _subItems.size() > 0 )
+    if( index != _selectedIndex && !_subItems.empty() )
     {
         _selectedIndex = index;
         if (_selectedItem)

--- a/cocos/2d/CCSpriteBatchNode.cpp
+++ b/cocos/2d/CCSpriteBatchNode.cpp
@@ -467,7 +467,7 @@ ssize_t SpriteBatchNode::lowestAtlasIndexInChild(Sprite *sprite)
 {
     auto& children = sprite->getChildren();
 
-    if (children.size() == 0)
+    if (children.empty())
     {
         return sprite->getAtlasIndex();
     }

--- a/cocos/2d/CCSpriteFrameCache.cpp
+++ b/cocos/2d/CCSpriteFrameCache.cpp
@@ -343,7 +343,7 @@ void SpriteFrameCache::addSpriteFramesWithFileContent(const std::string& plist_c
 
 void SpriteFrameCache::addSpriteFramesWithFile(const std::string& plist, const std::string& textureFileName)
 {
-    CCASSERT(textureFileName.size()>0, "texture name should not be null");
+    CCASSERT(!textureFileName.empty(), "texture name should not be null");
     const std::string fullPath = FileUtils::getInstance()->fullPathForFilename(plist);
     ValueMap dict = FileUtils::getInstance()->getValueMapFromFile(fullPath);
     addSpriteFramesWithDictionary(dict, textureFileName, plist);
@@ -656,7 +656,7 @@ void SpriteFrameCache::reloadSpriteFramesWithDictionary(ValueMap& dictionary, Te
 
 bool SpriteFrameCache::reloadTexture(const std::string& plist)
 {
-    CCASSERT(plist.size()>0, "plist filename should not be nullptr");
+    CCASSERT(!plist.empty(), "plist filename should not be nullptr");
 
     if (_spriteFramesCache.isPlistUsed(plist)) {
         _spriteFramesCache.erasePlistIndex(plist);
@@ -784,7 +784,7 @@ bool SpriteFrameCache::PlistFramesCache::hasFrame(const std::string &frame) cons
 bool SpriteFrameCache::PlistFramesCache::isPlistUsed(const std::string &plist) const
 {
     auto frames = _indexPlist2Frames.find(plist);
-    return frames != _indexPlist2Frames.end() && frames->second.size() > 0;
+    return frames != _indexPlist2Frames.end() && !frames->second.empty();
 } 
 
 SpriteFrame * SpriteFrameCache::PlistFramesCache::at(const std::string &frame)

--- a/cocos/2d/CCTMXTiledMap.cpp
+++ b/cocos/2d/CCTMXTiledMap.cpp
@@ -61,7 +61,7 @@ TMXTiledMap* TMXTiledMap::createWithXML(const std::string& tmxString, const std:
 
 bool TMXTiledMap::initWithTMXFile(const std::string& tmxFile)
 {
-    CCASSERT(tmxFile.size()>0, "TMXTiledMap: tmx file should not be empty");
+    CCASSERT(!tmxFile.empty(), "TMXTiledMap: tmx file should not be empty");
 
     _tmxFile = tmxFile;
 
@@ -203,7 +203,7 @@ void TMXTiledMap::buildWithMapInfo(TMXMapInfo* mapInfo)
 // public
 TMXLayer * TMXTiledMap::getLayer(const std::string& layerName) const
 {
-    CCASSERT(layerName.size() > 0, "Invalid layer name!");
+    CCASSERT(!layerName.empty(), "Invalid layer name!");
     
     for (auto& child : _children)
     {
@@ -223,7 +223,7 @@ TMXLayer * TMXTiledMap::getLayer(const std::string& layerName) const
 
 TMXObjectGroup * TMXTiledMap::getObjectGroup(const std::string& groupName) const
 {
-    CCASSERT(groupName.size() > 0, "Invalid group name!");
+    CCASSERT(!groupName.empty(), "Invalid group name!");
 
     for (const auto objectGroup : _objectGroups)
     {

--- a/cocos/2d/CCTMXXMLParser.cpp
+++ b/cocos/2d/CCTMXXMLParser.cpp
@@ -293,7 +293,7 @@ void TMXMapInfo::startElement(void* /*ctx*/, const char *name, const char **atts
     {
         // If this is an external tileset then start parsing that
         std::string externalTilesetFilename = attributeDict["source"].asString();
-        if (externalTilesetFilename != "")
+        if (!externalTilesetFilename.empty())
         {
             _externalTilesetFilename = externalTilesetFilename;
 
@@ -444,7 +444,7 @@ void TMXMapInfo::startElement(void* /*ctx*/, const char *name, const char **atts
         }
         else 
         {
-            tileset->_sourceImage = _resources + (_resources.size() ? "/" : "") + imagename;
+            tileset->_sourceImage = _resources + (!_resources.empty() ? "/" : "") + imagename;
         }
     } 
     else if (elementName == "data")
@@ -452,7 +452,7 @@ void TMXMapInfo::startElement(void* /*ctx*/, const char *name, const char **atts
         std::string encoding = attributeDict["encoding"].asString();
         std::string compression = attributeDict["compression"].asString();
 
-        if (encoding == "")
+        if (encoding.empty())
         {
             tmxMapInfo->setLayerAttribs(tmxMapInfo->getLayerAttribs() | TMXLayerAttribNone);
             
@@ -482,7 +482,7 @@ void TMXMapInfo::startElement(void* /*ctx*/, const char *name, const char **atts
                 layerAttribs = tmxMapInfo->getLayerAttribs();
                 tmxMapInfo->setLayerAttribs(layerAttribs | TMXLayerAttribZlib);
             }
-            CCASSERT( compression == "" || compression == "gzip" || compression == "zlib", "TMX: unsupported compression method" );
+            CCASSERT( compression.empty() || compression == "gzip" || compression == "zlib", "TMX: unsupported compression method" );
         }
         else if (encoding == "csv")
         {

--- a/cocos/2d/CCTextFieldTTF.cpp
+++ b/cocos/2d/CCTextFieldTTF.cpp
@@ -114,7 +114,7 @@ TextFieldTTF * TextFieldTTF::textFieldWithPlaceHolder(const std::string& placeho
     if(ret && ret->initWithPlaceHolder("", dimensions, alignment, fontName, fontSize))
     {
         ret->autorelease();
-        if (placeholder.size()>0)
+        if (!placeholder.empty())
         {
             ret->setPlaceHolder(placeholder);
         }
@@ -130,7 +130,7 @@ TextFieldTTF * TextFieldTTF::textFieldWithPlaceHolder(const std::string& placeho
     if(ret && ret->initWithPlaceHolder("", fontName, fontSize))
     {
         ret->autorelease();
-        if (placeholder.size()>0)
+        if (!placeholder.empty())
         {
             ret->setPlaceHolder(placeholder);
         }

--- a/cocos/3d/CCAnimation3D.cpp
+++ b/cocos/3d/CCAnimation3D.cpp
@@ -120,7 +120,7 @@ bool Animation3D::init(const Animation3DData &data)
             _boneCurves[iter.first] = curve;
         }
         
-        if(iter.second.size() == 0) continue;
+        if(iter.second.empty()) continue;
         std::vector<float> keys;
         std::vector<float> values;
         for(const auto& keyIter : iter.second)
@@ -144,7 +144,7 @@ bool Animation3D::init(const Animation3DData &data)
             _boneCurves[iter.first] = curve;
         }
         
-        if(iter.second.size() == 0) continue;
+        if(iter.second.empty()) continue;
         std::vector<float> keys;
         std::vector<float> values;
         for(const auto& keyIter : iter.second)
@@ -169,7 +169,7 @@ bool Animation3D::init(const Animation3DData &data)
             _boneCurves[iter.first] = curve;
         }
         
-        if(iter.second.size() == 0) continue;
+        if(iter.second.empty()) continue;
         std::vector<float> keys;
         std::vector<float> values;
         for(const auto& keyIter : iter.second)

--- a/cocos/3d/CCBundle3D.cpp
+++ b/cocos/3d/CCBundle3D.cpp
@@ -253,7 +253,7 @@ bool Bundle3D::loadObj(MeshDatas& meshdatas, MaterialDatas& materialdatas, NodeD
             attrib.size = 3;
             attrib.type = GL_FLOAT;
             
-            if (mesh.positions.size())
+            if (!mesh.positions.empty())
             {
                 attrib.vertexAttrib = GLProgram::VERTEX_ATTRIB_POSITION;
                 attrib.attribSizeBytes = attrib.size * sizeof(float);
@@ -261,14 +261,14 @@ bool Bundle3D::loadObj(MeshDatas& meshdatas, MaterialDatas& materialdatas, NodeD
                 
             }
             bool hasnormal = false, hastex = false;
-            if (mesh.normals.size())
+            if (!mesh.normals.empty())
             {
                 hasnormal = true;
                 attrib.vertexAttrib = GLProgram::VERTEX_ATTRIB_NORMAL;
                 attrib.attribSizeBytes = attrib.size * sizeof(float);
                 meshdata->attribs.push_back(attrib);
             }
-            if (mesh.texcoords.size())
+            if (!mesh.texcoords.empty())
             {
                 hastex = true;
                 attrib.size = 2;
@@ -1544,7 +1544,7 @@ bool Bundle3D::loadAnimationDataBinary(const std::string& id, Animation3DData* a
     {
         // if id is not a null string, we need to add a suffix of "animation" for seeding.
         std::string id_ = id;
-        if(id != "") id_ = id + "animation";
+        if(!id.empty()) id_ = id + "animation";
         
         if (!seekToFirstType(BUNDLE_TYPE_ANIMATIONS, id_))
             return false;
@@ -1730,7 +1730,7 @@ NodeData* Bundle3D::parseNodesRecursivelyJson(const rapidjson::Value& jvalue, bo
             modelnodedata->subMeshId = part[MESHPARTID].GetString();
             modelnodedata->materialId = part[MATERIALID].GetString();
 
-            if (modelnodedata->subMeshId == "" || modelnodedata->materialId == "")
+            if (modelnodedata->subMeshId.empty() || modelnodedata->materialId.empty())
             {
                 CCLOG("warning: Node %s part is missing meshPartId or materialId", nodedata->id.c_str());
                 CC_SAFE_DELETE(modelnodedata);
@@ -1874,7 +1874,7 @@ NodeData* Bundle3D::parseNodesRecursivelyBinary(bool& skeleton, bool singleSprit
             modelnodedata->subMeshId = _binaryReader.readString();
             modelnodedata->materialId = _binaryReader.readString();
 
-            if (modelnodedata->subMeshId == "" || modelnodedata->materialId == "")
+            if (modelnodedata->subMeshId.empty() || modelnodedata->materialId.empty())
             {
                 std::string err = "Node " + nodedata->id + " part is missing meshPartId or materialId";
                 CCLOG("Node %s part is missing meshPartId or materialId", nodedata->id.c_str());
@@ -2158,7 +2158,7 @@ Reference* Bundle3D::seekToFirstType(unsigned int type, const std::string& id)
         if (ref->type == type)
         {
             // if id is not a null string, we also need to check the Reference's id.
-            if (id != "" && id != ref->id)
+            if (!id.empty() && id != ref->id)
             {
                 continue;
             }

--- a/cocos/3d/CCMesh.cpp
+++ b/cocos/3d/CCMesh.cpp
@@ -182,19 +182,19 @@ Mesh* Mesh::create(const std::vector<float>& positions, const std::vector<float>
     att.type = GL_FLOAT;
     att.attribSizeBytes = att.size * sizeof(float);
     
-    if (positions.size())
+    if (!positions.empty())
     {
         perVertexSizeInFloat += 3;
         att.vertexAttrib = GLProgram::VERTEX_ATTRIB_POSITION;
         attribs.push_back(att);
     }
-    if (normals.size())
+    if (!normals.empty())
     {
         perVertexSizeInFloat += 3;
         att.vertexAttrib = GLProgram::VERTEX_ATTRIB_NORMAL;
         attribs.push_back(att);
     }
-    if (texs.size())
+    if (!texs.empty())
     {
         perVertexSizeInFloat += 2;
         att.vertexAttrib = GLProgram::VERTEX_ATTRIB_TEX_COORD;
@@ -203,8 +203,8 @@ Mesh* Mesh::create(const std::vector<float>& positions, const std::vector<float>
         attribs.push_back(att);
     }
     
-    bool hasNormal = (normals.size() != 0);
-    bool hasTexCoord = (texs.size() != 0);
+    bool hasNormal = (!normals.empty());
+    bool hasTexCoord = (!texs.empty());
     //position, normal, texCoordinate into _vertexs
     size_t vertexNum = positions.size() / 3;
     for(size_t i = 0; i < vertexNum; i++)
@@ -416,7 +416,7 @@ void Mesh::draw(Renderer* renderer, float globalZOrder, const Mat4& transform, u
         if (_skin)
             programState->setUniformVec4v("u_matrixPalette", (GLsizei)_skin->getMatrixPaletteSize(), _skin->getMatrixPalette());
 
-        if (scene && scene->getLights().size() > 0)
+        if (scene && !scene->getLights().empty())
             setLightUniforms(pass, scene, color, lightMask);
     }
 
@@ -472,7 +472,7 @@ void Mesh::calculateAABB()
             //get skin root
             Bone3D* root = nullptr;
             Mat4 invBindPose;
-            if (_skin->_skinBones.size())
+            if (!_skin->_skinBones.empty())
             {
                 root = _skin->_skinBones.at(0);
                 while (root) {

--- a/cocos/3d/CCMeshSkin.cpp
+++ b/cocos/3d/CCMeshSkin.cpp
@@ -138,7 +138,7 @@ void MeshSkin::addSkinBone(Bone3D* bone)
 Bone3D* MeshSkin::getRootBone() const
 {
     Bone3D* root = nullptr;
-    if (_skinBones.size())
+    if (!_skinBones.empty())
     {
         root = _skinBones.at(0);
         while (root->getParentBone()) {

--- a/cocos/3d/CCObjLoader.cpp
+++ b/cocos/3d/CCObjLoader.cpp
@@ -436,11 +436,11 @@ namespace tinyobj {
             std::string linebuf(&buf[0]);
             
             // Trim newline '\r\n' or '\n'
-            if (linebuf.size() > 0) {
+            if (!linebuf.empty()) {
                 if (linebuf[linebuf.size() - 1] == '\n')
                     linebuf.erase(linebuf.size() - 1);
             }
-            if (linebuf.size() > 0) {
+            if (!linebuf.empty()) {
                 if (linebuf[linebuf.size() - 1] == '\r')
                     linebuf.erase(linebuf.size() - 1);
             }
@@ -700,11 +700,11 @@ namespace tinyobj {
             std::string linebuf(&buf[0]);
             
             // Trim newline '\r\n' or '\n'
-            if (linebuf.size() > 0) {
+            if (!linebuf.empty()) {
                 if (linebuf[linebuf.size() - 1] == '\n')
                     linebuf.erase(linebuf.size() - 1);
             }
-            if (linebuf.size() > 0) {
+            if (!linebuf.empty()) {
                 if (linebuf[linebuf.size() - 1] == '\r')
                     linebuf.erase(linebuf.size() - 1);
             }
@@ -850,7 +850,7 @@ namespace tinyobj {
                     token += strspn(token, " \t\r"); // skip tag
                 }
                 
-                assert(names.size() > 0);
+                assert(!names.empty());
                 
                 // names[0] must be 'g', so skip the 0th element.
                 if (names.size() > 1) {

--- a/cocos/3d/CCSkeleton3D.cpp
+++ b/cocos/3d/CCSkeleton3D.cpp
@@ -196,7 +196,7 @@ Bone3D::~Bone3D()
 
 void Bone3D::updateLocalMat()
 {
-    if (_blendStates.size())
+    if (!_blendStates.empty())
     {
         Vec3 translate, scale;
         Quaternion quat(Quaternion::ZERO);

--- a/cocos/3d/CCSprite3D.cpp
+++ b/cocos/3d/CCSprite3D.cpp
@@ -162,7 +162,7 @@ void Sprite3D::afterAsyncLoad(void* param)
             CC_SAFE_DELETE(materialdatas);
             CC_SAFE_DELETE(nodeDatas);
             
-            if (asyncParam->texPath != "")
+            if (!asyncParam->texPath.empty())
             {
                 setTexture(asyncParam->texPath);
             }
@@ -367,13 +367,13 @@ Sprite3D* Sprite3D::createSprite3DNode(NodeData* nodedata,ModelData* modeldata,c
         sprite->setName(nodedata->id);
         auto mesh = Mesh::create(nodedata->id, getMeshIndexData(modeldata->subMeshId));
         
-        if (_skeleton && modeldata->bones.size())
+        if (_skeleton && !modeldata->bones.empty())
         {
             auto skin = MeshSkin::create(_skeleton, modeldata->bones, modeldata->invBindPose);
             mesh->setSkin(skin);
         }
         
-        if (modeldata->materialId == "" && materialdatas.materials.size())
+        if (modeldata->materialId.empty() && !materialdatas.materials.empty())
         {
             const NTextureData* textureData = materialdatas.materials[0].getTextureData(NTextureData::Usage::Diffuse);
             mesh->setTexture(textureData->filename);
@@ -522,7 +522,7 @@ void Sprite3D::createNode(NodeData* nodedata, Node* root, const MaterialDatas& m
     {
         if(it)
         {
-            if(it->bones.size() > 0 || singleSprite)
+            if(!it->bones.empty() || singleSprite)
             {
                 if(singleSprite && root!=nullptr)
                     root->setName(nodedata->id);
@@ -530,14 +530,14 @@ void Sprite3D::createNode(NodeData* nodedata, Node* root, const MaterialDatas& m
                 if(mesh)
                 {
                     _meshes.pushBack(mesh);
-                    if (_skeleton && it->bones.size())
+                    if (_skeleton && !it->bones.empty())
                     {
                         auto skin = MeshSkin::create(_skeleton, it->bones, it->invBindPose);
                         mesh->setSkin(skin);
                     }
                     mesh->_visibleChanged = std::bind(&Sprite3D::onAABBDirty, this);
 
-                    if (it->materialId == "" && materialdatas.materials.size())
+                    if (it->materialId.empty() && !materialdatas.materials.empty())
                     {
                         const NTextureData* textureData = materialdatas.materials[0].getTextureData(NTextureData::Usage::Diffuse);
                         mesh->setTexture(textureData->filename);
@@ -608,7 +608,7 @@ void Sprite3D::createNode(NodeData* nodedata, Node* root, const MaterialDatas& m
             } 
         }
     }
-    if(nodedata->modelNodeDatas.size() ==0 )
+    if(nodedata->modelNodeDatas.empty() )
     {
         node= Node::create();
         if(node)
@@ -760,7 +760,7 @@ void Sprite3D::draw(Renderer *renderer, const Mat4 &transform, uint32_t flags)
 {
 #if CC_USE_CULLING
     // camera clipping
-    if(_children.size() == 0 && Camera::getVisitingCamera() && !Camera::getVisitingCamera()->isVisibleInFrustum(&getAABB()))
+    if(_children.empty() && Camera::getVisitingCamera() && !Camera::getVisitingCamera()->isVisibleInFrustum(&getAABB()))
         return;
 #endif
     
@@ -849,7 +849,7 @@ const AABB& Sprite3D::getAABB() const
     else
     {
         _aabb.reset();
-        if (_meshes.size())
+        if (!_meshes.empty())
         {
             Mat4 transform(nodeToWorldTransform);
             for (const auto& it : _meshes) {

--- a/cocos/3d/CCSprite3DMaterial.cpp
+++ b/cocos/3d/CCSprite3DMaterial.cpp
@@ -215,7 +215,7 @@ Sprite3DMaterial* Sprite3DMaterial::createBuiltInMaterial(MaterialType type, boo
 Sprite3DMaterial* Sprite3DMaterial::createWithFilename(const std::string& path)
 {
     auto validfilename = FileUtils::getInstance()->fullPathForFilename(path);
-    if (validfilename.size() > 0) {
+    if (!validfilename.empty()) {
         auto it = _materials.find(validfilename);
         if (it != _materials.end())
             return (Sprite3DMaterial*)it->second->clone();

--- a/cocos/base/CCEventDispatcher.cpp
+++ b/cocos/base/CCEventDispatcher.cpp
@@ -1005,7 +1005,7 @@ void EventDispatcher::dispatchTouchEvent(EventTouch* event)
                         }
                     }
                 }
-                else if (listener->_claimedTouches.size() > 0
+                else if (!listener->_claimedTouches.empty()
                          && ((removedIter = std::find(listener->_claimedTouches.begin(), listener->_claimedTouches.end(), touches)) != listener->_claimedTouches.end()))
                 {
                     isClaimed = true;
@@ -1082,7 +1082,7 @@ void EventDispatcher::dispatchTouchEvent(EventTouch* event)
     //
     // process standard handlers 2nd
     //
-    if (allAtOnceListeners && mutableTouches.size() > 0)
+    if (allAtOnceListeners && !mutableTouches.empty())
     {
         
         auto onTouchesEvent = [&](EventListener* l) -> bool{

--- a/cocos/base/CCProperties.cpp
+++ b/cocos/base/CCProperties.cpp
@@ -88,7 +88,7 @@ Properties::Properties(Data* data, ssize_t* dataIdx, const std::string& name, co
 
 Properties* Properties::createNonRefCounted(const std::string& url)
 {
-    if (url.size() == 0)
+    if (url.empty())
     {
         CCLOGERROR("Attempting to create a Properties object from an empty URL!");
         return nullptr;
@@ -1139,7 +1139,7 @@ Properties* getPropertiesFromNamespacePath(Properties* properties, const std::ve
 {
     // If the url references a specific namespace within the file,
     // return the specified namespace or notify the user if it cannot be found.
-    if (namespacePath.size() > 0)
+    if (!namespacePath.empty())
     {
         size_t size = namespacePath.size();
         properties->rewind();

--- a/cocos/editor-support/cocosbuilder/CCBAnimationManager.cpp
+++ b/cocos/editor-support/cocosbuilder/CCBAnimationManager.cpp
@@ -722,7 +722,7 @@ Sequence*  CCBAnimationManager::actionForCallbackChannel(CCBSequenceProperty* ch
             }
         }
     }
-    if(actions.size() < 1) return nullptr;
+    if(actions.empty()) return nullptr;
     
     return Sequence::create(actions);
 }
@@ -764,7 +764,7 @@ Sequence*  CCBAnimationManager::actionForSoundChannel(CCBSequenceProperty* chann
         actions.pushBack(CCBSoundEffect::actionWithSoundFile(soundFile, pitch, pan, gain));
     }
 
-    if(actions.size() < 1) return nullptr;
+    if(actions.empty()) return nullptr;
     
     return Sequence::create(actions);
 }

--- a/cocos/editor-support/cocostudio/ActionTimeline/CCActionTimeline.cpp
+++ b/cocos/editor-support/cocostudio/ActionTimeline/CCActionTimeline.cpp
@@ -194,7 +194,7 @@ ActionTimeline* ActionTimeline::clone() const
 
 void ActionTimeline::step(float delta)
 {
-    if (!_playing || _timelineMap.size() == 0 || _duration == 0)
+    if (!_playing || _timelineMap.empty() || _duration == 0)
     {
         return;
     }

--- a/cocos/editor-support/cocostudio/ActionTimeline/CCActionTimelineCache.cpp
+++ b/cocos/editor-support/cocostudio/ActionTimeline/CCActionTimelineCache.cpp
@@ -522,11 +522,11 @@ Timeline* ActionTimelineCache::loadTimelineWithFlatBuffers(const flatbuffers::Ti
     
     // property
     std::string property = flatbuffers->property()->c_str();
-    if(property == "")
+    if(property.empty())
         return nullptr;
     
     
-    if(property != "")
+    if(!property.empty())
     {
         timeline = Timeline::create();
         
@@ -800,7 +800,7 @@ Frame* ActionTimelineCache::loadEventFrameWithFlatBuffers(const flatbuffers::Eve
     
     std::string event = flatbuffers->value()->c_str();
     
-    if (event != "")
+    if (!event.empty())
         frame->setEvent(event);    
     
     int frameIndex = flatbuffers->frameIndex();

--- a/cocos/editor-support/cocostudio/ActionTimeline/CCBoneNode.cpp
+++ b/cocos/editor-support/cocostudio/ActionTimeline/CCBoneNode.cpp
@@ -518,7 +518,7 @@ cocos2d::Vector<BoneNode*> BoneNode::getAllSubBones() const
         boneStack.push(bone);
     }
 
-    while (boneStack.size() > 0)
+    while (!boneStack.empty())
     {
         auto top = boneStack.top();
         allBones.pushBack(top);

--- a/cocos/editor-support/cocostudio/ActionTimeline/CCSkeletonNode.cpp
+++ b/cocos/editor-support/cocostudio/ActionTimeline/CCSkeletonNode.cpp
@@ -348,7 +348,7 @@ void SkeletonNode::updateOrderedAllbones()
             boneStack.push(bone);
     }
 
-    while (boneStack.size() > 0)
+    while (!boneStack.empty())
     {
         auto top = boneStack.top();
         _subOrderedAllBones.pushBack(top);

--- a/cocos/editor-support/cocostudio/ActionTimeline/CCTimeLine.cpp
+++ b/cocos/editor-support/cocostudio/ActionTimeline/CCTimeLine.cpp
@@ -60,7 +60,7 @@ Timeline::~Timeline()
 
 void Timeline::gotoFrame(int frameIndex)
 {
-    if(_frames.size() == 0)
+    if(_frames.empty())
         return;
 
     binarySearchKeyFrame(frameIndex);
@@ -69,7 +69,7 @@ void Timeline::gotoFrame(int frameIndex)
 
 void Timeline::stepToFrame(int frameIndex)
 {
-    if(_frames.size() == 0)
+    if(_frames.empty())
         return;
 
     updateCurrentKeyFrame(frameIndex);

--- a/cocos/editor-support/cocostudio/ActionTimeline/CSLoader.cpp
+++ b/cocos/editor-support/cocostudio/ActionTimeline/CSLoader.cpp
@@ -1019,7 +1019,7 @@ Node* CSLoader::nodeWithFlatBuffers(const flatbuffers::NodeTree *nodetree, const
             std::string filePath = projectNodeOptions->fileName()->c_str();
             
             cocostudio::timeline::ActionTimeline* action = nullptr;
-            if (filePath != "" && FileUtils::getInstance()->isFileExist(filePath))
+            if (!filePath.empty() && FileUtils::getInstance()->isFileExist(filePath))
             {
                 Data buf = FileUtils::getInstance()->getDataFromFile(filePath);
                 node = createNode(buf, callback);
@@ -1052,7 +1052,7 @@ Node* CSLoader::nodeWithFlatBuffers(const flatbuffers::NodeTree *nodetree, const
         else
         {
             std::string customClassName = nodetree->customClassName()->c_str();
-            if (customClassName != "")
+            if (!customClassName.empty())
             {
                 classname = customClassName;
             }
@@ -1366,7 +1366,7 @@ Node* CSLoader::nodeWithFlatBuffersForSimulator(const flatbuffers::NodeTree *nod
         std::string filePath = projectNodeOptions->fileName()->c_str();
         
         cocostudio::timeline::ActionTimeline* action = nullptr;
-        if (filePath != "" && FileUtils::getInstance()->isFileExist(filePath))
+        if (!filePath.empty() && FileUtils::getInstance()->isFileExist(filePath))
         {
             node = createNodeWithFlatBuffersForSimulator(filePath);
             action = cocostudio::timeline::ActionTimelineCache::getInstance()->createActionWithFlatBuffersForSimulator(filePath);

--- a/cocos/editor-support/cocostudio/CCActionNode.cpp
+++ b/cocos/editor-support/cocostudio/CCActionNode.cpp
@@ -450,7 +450,7 @@ Spawn * ActionNode::refreshActionProperty()
     for (int n = 0; n < _frameArrayNum; n++)
     {
         auto cArray = _frameArray.at(n);
-        if (cArray->size() <= 0)
+        if (cArray->empty())
         {
             continue;
         }

--- a/cocos/editor-support/cocostudio/CCArmature.cpp
+++ b/cocos/editor-support/cocostudio/CCArmature.cpp
@@ -153,7 +153,7 @@ bool Armature::init(const std::string& name)
                     CC_BREAK_IF(!movData);
 
                     MovementBoneData *movBoneData = movData->getMovementBoneData(bone->getName());
-                    CC_BREAK_IF(!movBoneData || movBoneData->frameList.size() <= 0);
+                    CC_BREAK_IF(!movBoneData || movBoneData->frameList.empty());
 
                     FrameData *frameData = movBoneData->getFrameData(0);
                     CC_BREAK_IF(!frameData);

--- a/cocos/editor-support/cocostudio/CCArmatureAnimation.cpp
+++ b/cocos/editor-support/cocostudio/CCArmatureAnimation.cpp
@@ -229,7 +229,7 @@ void ArmatureAnimation::play(const std::string& animationName, int durationTo,  
         movementBoneData = static_cast<MovementBoneData *>(_movementData->movBoneDataDic.at(bone->getName()));
 
         Tween *tween = bone->getTween();
-        if(movementBoneData && movementBoneData->frameList.size() > 0)
+        if(movementBoneData && !movementBoneData->frameList.empty())
         {
             _tweenList.push_back(tween);
             movementBoneData->duration = _movementData->duration;
@@ -353,13 +353,13 @@ void ArmatureAnimation::update(float dt)
         tween->update(dt);
     }
 
-    if(_frameEventQueue.size() > 0 || _movementEventQueue.size() > 0)
+    if(!_frameEventQueue.empty() || !_movementEventQueue.empty())
     {
         _armature->retain();
         _armature->autorelease();
     }
 
-    while (_frameEventQueue.size() > 0)
+    while (!_frameEventQueue.empty())
     {
         FrameEvent *event = _frameEventQueue.front();
         _frameEventQueue.pop();
@@ -382,7 +382,7 @@ void ArmatureAnimation::update(float dt)
         CC_SAFE_DELETE(event);
     }
 
-    while (_movementEventQueue.size() > 0)
+    while (!_movementEventQueue.empty())
     {
         MovementEvent *event = _movementEventQueue.front();
         _movementEventQueue.pop();

--- a/cocos/editor-support/cocostudio/CCDataReaderHelper.cpp
+++ b/cocos/editor-support/cocostudio/CCDataReaderHelper.cpp
@@ -462,7 +462,7 @@ void DataReaderHelper::addDataAsyncCallBack(float /*dt*/)
         AsyncStruct *pAsyncStruct = pDataInfo->asyncStruct;
 
 
-        if (pAsyncStruct->imagePath != "" && pAsyncStruct->plistPath != "")
+        if (!pAsyncStruct->imagePath.empty() && !pAsyncStruct->plistPath.empty())
         {
             _getFileMutex.lock();
             ArmatureDataManager::getInstance()->addSpriteFrameFromFile(pAsyncStruct->plistPath, pAsyncStruct->imagePath, pDataInfo->filename);
@@ -1586,7 +1586,7 @@ MovementBoneData *DataReaderHelper::decodeMovementBone(const rapidjson::Value& j
 
     if (dataInfo->cocoStudioVersion < VERSION_COMBINED)
     {
-        if (movementBoneData->frameList.size() > 0)
+        if (!movementBoneData->frameList.empty())
         {
             FrameData *frameData = new (std::nothrow) FrameData();
             frameData->copy((FrameData *)movementBoneData->frameList.back());
@@ -2271,7 +2271,7 @@ void DataReaderHelper::decodeNode(BaseData *node, const rapidjson::Value& json, 
 
         if (dataInfo->cocoStudioVersion < VERSION_COMBINED)
         {
-            if (movementBoneData->frameList.size() > 0)
+            if (!movementBoneData->frameList.empty())
             {
                 auto frameData = movementBoneData->frameList.at(framesizemusone);
                 movementBoneData->addFrameData(frameData);

--- a/cocos/editor-support/cocostudio/CCDisplayFactory.cpp
+++ b/cocos/editor-support/cocostudio/CCDisplayFactory.cpp
@@ -207,7 +207,7 @@ void DisplayFactory::initSpriteDisplay(Bone *bone, DecorativeDisplay *decoDispla
 
 
 #if ENABLE_PHYSICS_BOX2D_DETECT || ENABLE_PHYSICS_CHIPMUNK_DETECT || ENABLE_PHYSICS_SAVE_CALCULATED_VERTEX
-    if (textureData && textureData->contourDataList.size() > 0)
+    if (textureData && !textureData->contourDataList.empty())
     {
 
         //! create ContourSprite

--- a/cocos/editor-support/cocostudio/CCSkin.cpp
+++ b/cocos/editor-support/cocostudio/CCSkin.cpp
@@ -89,7 +89,7 @@ Skin::Skin()
 
 bool Skin::initWithSpriteFrameName(const std::string& spriteFrameName)
 {
-    CCAssert(spriteFrameName != "", "");
+    CCAssert(!spriteFrameName.empty(), "");
 
     SpriteFrame *pFrame = SpriteFrameCache::getInstance()->getSpriteFrameByName(spriteFrameName);
     bool ret = true;

--- a/cocos/editor-support/cocostudio/WidgetReader/ButtonReader/ButtonReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/ButtonReader/ButtonReader.cpp
@@ -886,7 +886,7 @@ namespace cocostudio
         bool fileExist = false;
         std::string errorFilePath = "";
         std::string path = resourceData->path()->c_str();
-        if (path != "")
+        if (!path.empty())
         {
             if (FileUtils::getInstance()->isFileExist(path))
             {

--- a/cocos/editor-support/cocostudio/WidgetReader/GameMapReader/GameMapReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/GameMapReader/GameMapReader.cpp
@@ -179,7 +179,7 @@ namespace cocostudio
                 {
                     Size size = layerInfo->_layerSize;
                     auto& tilesets = mapInfo->getTilesets();
-                    if (tilesets.size()>0)
+                    if (!tilesets.empty())
                     {
                         TMXTilesetInfo* tileset = nullptr;
                         for (auto iter = tilesets.crbegin(); iter != tilesets.crend(); ++iter)

--- a/cocos/editor-support/cocostudio/WidgetReader/LayoutReader/LayoutReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/LayoutReader/LayoutReader.cpp
@@ -648,7 +648,7 @@ namespace cocostudio
         auto imageFileNameDic = options->backGroundImageData();
         int imageFileNameType = imageFileNameDic->resourceType();
         std::string imageFileName = imageFileNameDic->path()->c_str();
-        if (imageFileName != "")
+        if (!imageFileName.empty())
         {
             switch (imageFileNameType)
             {

--- a/cocos/editor-support/cocostudio/WidgetReader/ListViewReader/ListViewReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/ListViewReader/ListViewReader.cpp
@@ -462,7 +462,7 @@ namespace cocostudio
         auto imageFileNameDic = options->backGroundImageData();
         int imageFileNameType = imageFileNameDic->resourceType();
         std::string imageFileName = imageFileNameDic->path()->c_str();
-        if (imageFileName != "")
+        if (!imageFileName.empty())
         {
             switch (imageFileNameType)
             {
@@ -539,11 +539,11 @@ namespace cocostudio
         //         listView->setGravity(gravity);
         
         std::string directionType = options->directionType()->c_str();
-        if (directionType == "")
+        if (directionType.empty())
         {
             listView->setDirection(ListView::Direction::HORIZONTAL);
             std::string verticalType = options->verticalType()->c_str();
-            if (verticalType == "")
+            if (verticalType.empty())
             {
                 listView->setGravity(ListView::Gravity::TOP);
             }
@@ -560,7 +560,7 @@ namespace cocostudio
         {
             listView->setDirection(ListView::Direction::VERTICAL);
             std::string horizontalType = options->horizontalType()->c_str();
-            if (horizontalType == "")
+            if (horizontalType.empty())
             {
                 listView->setGravity(ListView::Gravity::LEFT);
             }

--- a/cocos/editor-support/cocostudio/WidgetReader/PageViewReader/PageViewReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/PageViewReader/PageViewReader.cpp
@@ -375,7 +375,7 @@ namespace cocostudio
         auto imageFileNameDic = options->backGroundImageData();
         int imageFileNameType = imageFileNameDic->resourceType();
         std::string imageFileName = imageFileNameDic->path()->c_str();
-        if (imageFileName != "")
+        if (!imageFileName.empty())
         {
             switch (imageFileNameType)
             {

--- a/cocos/editor-support/cocostudio/WidgetReader/ScrollViewReader/ScrollViewReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/ScrollViewReader/ScrollViewReader.cpp
@@ -476,7 +476,7 @@ namespace cocostudio
         auto imageFileNameDic = options->backGroundImageData();
         int imageFileNameType = imageFileNameDic->resourceType();
         std::string imageFileName = imageFileNameDic->path()->c_str();
-        if (imageFileName != "")
+        if (!imageFileName.empty())
         {
             switch (imageFileNameType)
             {

--- a/cocos/editor-support/cocostudio/WidgetReader/TabControlReader/TabControlReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/TabControlReader/TabControlReader.cpp
@@ -578,7 +578,7 @@ void TabHeaderReader::setPropsWithFlatBuffers(cocos2d::Node* node, const flatbuf
     bool fileExist = false;
     std::string errorFilePath = "";
     std::string path = resourceData->path()->c_str();
-    if (path != "")
+    if (!path.empty())
     {
         if (FileUtils::getInstance()->isFileExist(path))
         {

--- a/cocos/editor-support/cocostudio/WidgetReader/TextFieldReader/TextFieldReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/TextFieldReader/TextFieldReader.cpp
@@ -361,7 +361,7 @@ namespace cocostudio
         std::string errorFilePath = "";
         auto resourceData = options->fontResource();
         std::string path = resourceData->path()->c_str();
-        if (path != "")
+        if (!path.empty())
         {
             if (FileUtils::getInstance()->isFileExist(path))
             {

--- a/cocos/network/CCDownloader-curl.cpp
+++ b/cocos/network/CCDownloader-curl.cpp
@@ -532,7 +532,7 @@ namespace cocos2d { namespace network {
                     }
                 }
 
-                if (coTaskMap.size())
+                if (!coTaskMap.empty())
                 {
                     mcode = CURLM_CALL_MULTI_PERFORM;
                     while(CURLM_CALL_MULTI_PERFORM == mcode)
@@ -637,7 +637,7 @@ namespace cocos2d { namespace network {
                     TaskWrapper wrapper;
                     {
                         lock_guard<mutex> lock(_requestMutex);
-                        if (_requestQueue.size())
+                        if (!_requestQueue.empty())
                         {
                             wrapper = _requestQueue.front();
                             _requestQueue.pop_front();
@@ -681,7 +681,7 @@ namespace cocos2d { namespace network {
                     lock_guard<mutex> lock(_processMutex);
                     _processSet.insert(wrapper);
                 }
-            } while (coTaskMap.size());
+            } while (!coTaskMap.empty());
 
             curl_multi_cleanup(curlmHandle);
             this->stop();

--- a/cocos/network/HttpClient.cpp
+++ b/cocos/network/HttpClient.cpp
@@ -581,7 +581,7 @@ void HttpClient::processResponse(HttpResponse* response, char* responseMessage)
 void HttpClient::clearResponseAndRequestQueue()
 {
     _requestQueueMutex.lock();
-    if (_requestQueue.size())
+    if (!_requestQueue.empty())
     {
         for (auto it = _requestQueue.begin(); it != _requestQueue.end();)
         {

--- a/cocos/network/SocketIO.cpp
+++ b/cocos/network/SocketIO.cpp
@@ -151,7 +151,7 @@ std::string SocketIOPacket::toString()const
     encoded << this->_separator;
 
     // Add the endpoint for the namespace to be used if not the default namespace "" or "/", and as long as it is not an ACK, heartbeat, or disconnect packet
-    if (_endpoint != "/" && _endpoint != "" && _type != "ack" && _type != "heartbeat" && _type != "disconnect") {
+    if (_endpoint != "/" && !_endpoint.empty() && _type != "ack" && _type != "heartbeat" && _type != "disconnect") {
         encoded << _endpoint << _endpointseparator;
     }
     encoded << this->_separator;
@@ -819,7 +819,7 @@ void SIOClientImpl::onMessage(WebSocket* /*ws*/, const WebSocket::Data& data)
                 endpoint = payload;
             }
 
-            if (endpoint == "") endpoint = "/";
+            if (endpoint.empty()) endpoint = "/";
 
             c = getClient(endpoint);
 
@@ -934,14 +934,14 @@ void SIOClientImpl::onMessage(WebSocket* /*ws*/, const WebSocket::Data& data)
                 }
 
                 // we didn't find and endpoint and we are in the default namespace
-                if (endpoint == "") endpoint = "/";
+                if (endpoint.empty()) endpoint = "/";
 
                 c = getClient(endpoint);
 
                 payload = payload.substr(1);
 
                 if (endpoint != "/") payload = payload.substr(endpoint.size());
-                if (endpoint != "/" && payload != "") payload = payload.substr(1);
+                if (endpoint != "/" && !payload.empty()) payload = payload.substr(1);
 
                 switch (control2)
                 {
@@ -1208,7 +1208,7 @@ SIOClient* SocketIO::connect(const std::string& uri, SocketIO::SIODelegate& dele
     SIOClient *c = nullptr;
 
     std::string path = uriObj.getPath();
-    if (path == "")
+    if (path.empty())
         path = "/";
 
     if (socket == nullptr)

--- a/cocos/platform/CCFileUtils.cpp
+++ b/cocos/platform/CCFileUtils.cpp
@@ -941,7 +941,7 @@ void FileUtils::setSearchResolutionsOrder(const std::vector<std::string>& search
     for(const auto& iter : searchResolutionsOrder)
     {
         std::string resolutionDirectory = iter;
-        if (!existDefault && resolutionDirectory == "")
+        if (!existDefault && resolutionDirectory.empty())
         {
             existDefault = true;
         }
@@ -1116,7 +1116,7 @@ std::string FileUtils::getFullPathForFilenameWithinDirectory(const std::string& 
 {
     // get directory+filename, safely adding '/' as necessary
     std::string ret = directory;
-    if (directory.size() && directory[directory.size()-1] != '/'){
+    if (!directory.empty() && directory[directory.size()-1] != '/'){
         ret += '/';
     }
     ret += filename;

--- a/cocos/platform/CCGLView.cpp
+++ b/cocos/platform/CCGLView.cpp
@@ -331,7 +331,7 @@ void GLView::handleTouchesBegin(int num, intptr_t ids[], float xs[], float ys[])
         }
     }
 
-    if (touchEvent._touches.size() == 0)
+    if (touchEvent._touches.empty())
     {
         CCLOG("touchesBegan: size = 0");
         return;
@@ -388,7 +388,7 @@ void GLView::handleTouchesMove(int num, intptr_t ids[], float xs[], float ys[], 
         }
     }
 
-    if (touchEvent._touches.size() == 0)
+    if (touchEvent._touches.empty())
     {
         CCLOG("touchesMoved: size = 0");
         return;
@@ -442,7 +442,7 @@ void GLView::handleTouchesOfEndOrCancel(EventTouch::EventCode eventCode, int num
 
     }
 
-    if (touchEvent._touches.size() == 0)
+    if (touchEvent._touches.empty())
     {
         CCLOG("touchesEnded or touchesCancel: size = 0");
         return;

--- a/cocos/renderer/CCMaterial.cpp
+++ b/cocos/renderer/CCMaterial.cpp
@@ -53,7 +53,7 @@ static bool isValidUniform(const char* name);
 Material* Material::createWithFilename(const std::string& filepath)
 {
     auto validfilename = FileUtils::getInstance()->fullPathForFilename(filepath);
-    if (validfilename.size() > 0) {
+    if (!validfilename.empty()) {
         auto mat = new (std::nothrow) Material();
         if (mat && mat->initWithFile(validfilename))
         {

--- a/cocos/renderer/CCRenderer.cpp
+++ b/cocos/renderer/CCRenderer.cpp
@@ -477,7 +477,7 @@ void Renderer::visitRenderQueue(RenderQueue& queue)
     //Process Global-Z < 0 Objects
     //
     const auto& zNegQueue = queue.getSubQueue(RenderQueue::QUEUE_GROUP::GLOBALZ_NEG);
-    if (zNegQueue.size() > 0)
+    if (!zNegQueue.empty())
     {
         if(_isDepthTestFor2D)
         {
@@ -511,7 +511,7 @@ void Renderer::visitRenderQueue(RenderQueue& queue)
     //Process Opaque Object
     //
     const auto& opaqueQueue = queue.getSubQueue(RenderQueue::QUEUE_GROUP::OPAQUE_3D);
-    if (opaqueQueue.size() > 0)
+    if (!opaqueQueue.empty())
     {
         //Clear depth to achieve layered rendering
         glEnable(GL_DEPTH_TEST);
@@ -534,7 +534,7 @@ void Renderer::visitRenderQueue(RenderQueue& queue)
     //Process 3D Transparent object
     //
     const auto& transQueue = queue.getSubQueue(RenderQueue::QUEUE_GROUP::TRANSPARENT_3D);
-    if (transQueue.size() > 0)
+    if (!transQueue.empty())
     {
         glEnable(GL_DEPTH_TEST);
         glDepthMask(false);
@@ -558,7 +558,7 @@ void Renderer::visitRenderQueue(RenderQueue& queue)
     //Process Global-Z = 0 Queue
     //
     const auto& zZeroQueue = queue.getSubQueue(RenderQueue::QUEUE_GROUP::GLOBALZ_ZERO);
-    if (zZeroQueue.size() > 0)
+    if (!zZeroQueue.empty())
     {
         if(_isDepthTestFor2D)
         {
@@ -594,7 +594,7 @@ void Renderer::visitRenderQueue(RenderQueue& queue)
     //Process Global-Z > 0 Queue
     //
     const auto& zPosQueue = queue.getSubQueue(RenderQueue::QUEUE_GROUP::GLOBALZ_POS);
-    if (zPosQueue.size() > 0)
+    if (!zPosQueue.empty())
     {
         if(_isDepthTestFor2D)
         {

--- a/cocos/renderer/CCTextureCache.cpp
+++ b/cocos/renderer/CCTextureCache.cpp
@@ -404,7 +404,7 @@ Texture2D * TextureCache::addImage(const std::string &path)
     // Needed since addImageAsync calls this method from a different thread
 
     std::string fullpath = FileUtils::getInstance()->fullPathForFilename(path);
-    if (fullpath.size() == 0)
+    if (fullpath.empty())
     {
         return nullptr;
     }
@@ -527,7 +527,7 @@ bool TextureCache::reloadTexture(const std::string& fileName)
     Image * image = nullptr;
 
     std::string fullpath = FileUtils::getInstance()->fullPathForFilename(fileName);
-    if (fullpath.size() == 0)
+    if (fullpath.empty())
     {
         return false;
     }

--- a/cocos/renderer/CCTextureCube.cpp
+++ b/cocos/renderer/CCTextureCube.cpp
@@ -127,7 +127,7 @@ Image* createImage(const std::string& path)
     // Needed since addImageAsync calls this method from a different thread
 
     std::string fullpath = FileUtils::getInstance()->fullPathForFilename(path);
-    if (fullpath.size() == 0)
+    if (fullpath.empty())
     {
         return nullptr;
     }

--- a/cocos/scripting/js-bindings/manual/ScriptingCore.cpp
+++ b/cocos/scripting/js-bindings/manual/ScriptingCore.cpp
@@ -1411,7 +1411,7 @@ bool ScriptingCore::handleTouchesEvent(void* nativeObj, cocos2d::EventTouch::Eve
     js_type_class_t *typeClassEvent = nullptr;
     js_type_class_t *typeClassTouch = nullptr;
 
-    if (touches.size()>0)
+    if (!touches.empty())
         typeClassTouch = js_get_type_from_native<cocos2d::Touch>(touches[0]);
     typeClassEvent = js_get_type_from_native<cocos2d::EventTouch>((cocos2d::EventTouch*)event);
 

--- a/cocos/scripting/js-bindings/manual/cocos2d_specifics.cpp
+++ b/cocos/scripting/js-bindings/manual/cocos2d_specifics.cpp
@@ -4517,7 +4517,7 @@ bool js_cocos2dx_SpriteBatchNode_getDescendants(JSContext *cx, uint32_t argc, js
         JS::RootedValue jsret(cx);
 
         js_type_class_t *typeClass = nullptr;
-        if (ret.size() > 0)
+        if (!ret.empty())
             typeClass = js_get_type_from_native<cocos2d::Sprite>(ret[0]);
         for (size_t i = 0; i < vSize; i++)
         {

--- a/cocos/scripting/js-bindings/manual/network/jsb_socketio.cpp
+++ b/cocos/scripting/js-bindings/manual/network/jsb_socketio.cpp
@@ -87,7 +87,7 @@ public:
         JSContext* cx = ScriptingCore::getInstance()->getGlobalContext();
 
         jsval args;
-        if(data == "")
+        if(data.empty())
         {
             args = JSVAL_NULL;
         } else

--- a/cocos/scripting/lua-bindings/manual/CCLuaEngine.cpp
+++ b/cocos/scripting/lua-bindings/manual/CCLuaEngine.cpp
@@ -511,7 +511,7 @@ int LuaEngine::handleTouchesEvent(void* data)
         return 0;
     
     TouchesScriptData* touchesScriptData = static_cast<TouchesScriptData*>(data);
-    if (NULL == touchesScriptData->nativeObject || touchesScriptData->touches.size() == 0)
+    if (NULL == touchesScriptData->nativeObject || touchesScriptData->touches.empty())
         return 0;
     
     int handler = ScriptHandlerMgr::getInstance()->getObjectHandler((void*)touchesScriptData->nativeObject, ScriptHandlerMgr::HandlerType::TOUCHES);
@@ -687,7 +687,7 @@ int LuaEngine::handleEventTouches(ScriptHandlerMgr::HandlerType type,void* data)
         return 0;
     
     LuaEventTouchesData * touchesData = static_cast<LuaEventTouchesData*>(basicScriptData->value);
-    if (nullptr == touchesData->event || touchesData->touches.size() == 0)
+    if (nullptr == touchesData->event || touchesData->touches.empty())
         return 0;
     
     int handler = ScriptHandlerMgr::getInstance()->getObjectHandler((void*)basicScriptData->nativeObject, type);

--- a/cocos/ui/UIButton.cpp
+++ b/cocos/ui/UIButton.cpp
@@ -648,7 +648,7 @@ Size Button::getVirtualRendererSize() const
     if (nullptr != _titleRenderer)
     {
         Size titleSize = _titleRenderer->getContentSize();
-        if (!_normalTextureLoaded && _titleRenderer->getString().size() > 0)
+        if (!_normalTextureLoaded && !_titleRenderer->getString().empty())
         {
             return titleSize;
         }

--- a/cocos/ui/UIEditBox/UIEditBoxImpl-common.cpp
+++ b/cocos/ui/UIEditBox/UIEditBoxImpl-common.cpp
@@ -238,7 +238,7 @@ void EditBoxImplCommon::refreshInactiveText()
 
     refreshLabelAlignment();
     if (!_editingMode) {
-        if (_text.size() == 0) {
+        if (_text.empty()) {
             _label->setVisible(false);
             _labelPlaceHolder->setVisible(true);
         } else {

--- a/cocos/ui/UIRadioButton.cpp
+++ b/cocos/ui/UIRadioButton.cpp
@@ -314,7 +314,7 @@ void RadioButtonGroup::setAllowedNoSelection(bool allowedNoSelection)
     _allowedNoSelection = allowedNoSelection;
     if(!_allowedNoSelection && _selectedRadioButton == nullptr)
     {
-        if (_radioButtons.size() > 0)
+        if (!_radioButtons.empty())
         {
             setSelectedButton(_radioButtons.at(0));
         }

--- a/cocos/ui/UIRichText.cpp
+++ b/cocos/ui/UIRichText.cpp
@@ -544,7 +544,7 @@ std::string MyXMLVisitor::getFace() const
 {
     for (auto i = _fontElements.rbegin(), iRend = _fontElements.rend(); i != iRend; ++i)
     {
-        if (i->face.size() != 0)
+        if (!i->face.empty())
             return i->face;
     }
     return "fonts/Marker Felt.ttf";
@@ -554,7 +554,7 @@ std::string MyXMLVisitor::getURL() const
 {
     for (auto i = _fontElements.rbegin(), iRend = _fontElements.rend(); i != iRend; ++i)
     {
-        if (i->url.size() != 0)
+        if (!i->url.empty())
             return i->url;
     }
     return "";
@@ -789,7 +789,7 @@ void MyXMLVisitor::textHandler(void* /*ctx*/, const char *str, size_t len)
         flags |= RichElementText::UNDERLINE_FLAG;
     if (strikethrough)
         flags |= RichElementText::STRIKETHROUGH_FLAG;
-    if (url.size() > 0)
+    if (!url.empty())
         flags |= RichElementText::URL_FLAG;
     if (std::get<0>(outline))
         flags |= RichElementText::OUTLINE_FLAG;
@@ -1942,7 +1942,7 @@ void RichText::adaptRenderers()
 
 void RichText::pushToContainer(cocos2d::Node *renderer)
 {
-    if (_elementRenders.size() <= 0)
+    if (_elementRenders.empty())
     {
         return;
     }

--- a/extensions/GUI/CCScrollView/CCScrollView.cpp
+++ b/extensions/GUI/CCScrollView/CCScrollView.cpp
@@ -850,7 +850,7 @@ void ScrollView::onTouchEnded(Touch* touch, Event* /*event*/)
         _touches.erase(touchIter);
     } 
 
-    if (_touches.size() == 0)
+    if (_touches.empty())
     {
         _dragging = false;    
         _touchMoved = false;
@@ -871,7 +871,7 @@ void ScrollView::onTouchCancelled(Touch* touch, Event* /*event*/)
     
     _touches.erase(touchIter);
     
-    if (_touches.size() == 0)
+    if (_touches.empty())
     {
         _dragging = false;    
         _touchMoved = false;

--- a/extensions/Particle3D/PU/CCPUScriptParser.cpp
+++ b/extensions/Particle3D/PU/CCPUScriptParser.cpp
@@ -42,7 +42,7 @@ void traceScriptParserCell(PUConcreteNodeList& nodes,int level)
     for(const auto& node : nodes)
     {
         printf("%s,##%d\n",node->token.c_str(),level);
-        if(node->children.size() != 0)
+        if(!node->children.empty())
         {
             traceScriptParserCell(node->children,level+1);
         }

--- a/extensions/assets-manager/AssetsManager.cpp
+++ b/extensions/assets-manager/AssetsManager.cpp
@@ -168,7 +168,7 @@ AssetsManager::~AssetsManager()
 
 void AssetsManager::checkStoragePath()
 {
-    if (_storagePath.size() > 0 && _storagePath[_storagePath.size() - 1] != '/')
+    if (!_storagePath.empty() && _storagePath[_storagePath.size() - 1] != '/')
     {
         _storagePath.append("/");
     }
@@ -196,7 +196,7 @@ std::string AssetsManager::keyOfDownloadedVersion() const
 
 bool AssetsManager::checkUpdate()
 {
-    if (_versionFileUrl.size() == 0 || _isDownloading) return false;
+    if (_versionFileUrl.empty() || _isDownloading) return false;
     
     // Clear _version before assign new value.
     _version.clear();

--- a/extensions/assets-manager/AssetsManagerEx.cpp
+++ b/extensions/assets-manager/AssetsManagerEx.cpp
@@ -320,7 +320,7 @@ void AssetsManagerEx::setStoragePath(const std::string& storagePath)
 
 void AssetsManagerEx::adjustPath(std::string &path)
 {
-    if (path.size() > 0 && path[path.size() - 1] != '/')
+    if (!path.empty() && path[path.size() - 1] != '/')
     {
         path.append("/");
     }
@@ -548,7 +548,7 @@ void AssetsManagerEx::downloadVersion()
 
     std::string versionUrl = _localManifest->getVersionFileUrl();
 
-    if (versionUrl.size() > 0)
+    if (!versionUrl.empty())
     {
         _updateState = State::DOWNLOADING_VERSION;
         // Download version file asynchronously
@@ -616,7 +616,7 @@ void AssetsManagerEx::downloadManifest()
         manifestUrl = _localManifest->getManifestFileUrl();
     }
 
-    if (manifestUrl.size() > 0)
+    if (!manifestUrl.empty())
     {
         _updateState = State::DOWNLOADING_MANIFEST;
         // Download version file asynchronously
@@ -710,7 +710,7 @@ void AssetsManagerEx::startUpdate()
         
         // Check difference between local manifest and remote manifest
         std::unordered_map<std::string, Manifest::AssetDiff> diff_map = _localManifest->genDiff(_remoteManifest);
-        if (diff_map.size() == 0)
+        if (diff_map.empty())
         {
             updateSucceed();
         }
@@ -1161,7 +1161,7 @@ void AssetsManagerEx::queueDowload()
         return;
     }
     
-    while (_currConcurrentTask < _maxConcurrentTask && _queue.size() > 0)
+    while (_currConcurrentTask < _maxConcurrentTask && !_queue.empty())
     {
         std::string key = _queue.back();
         _queue.pop_back();
@@ -1184,7 +1184,7 @@ void AssetsManagerEx::queueDowload()
 void AssetsManagerEx::onDownloadUnitsFinished()
 {
     // Finished with error check
-    if (_failedUnits.size() > 0)
+    if (!_failedUnits.empty())
     {
         // Save current download manifest information for resuming
         _tempManifest->saveToFile(_tempManifestPath);

--- a/extensions/assets-manager/Manifest.cpp
+++ b/extensions/assets-manager/Manifest.cpp
@@ -82,7 +82,7 @@ Manifest::Manifest(const std::string& manifestUrl/* = ""*/)
 {
     // Init variables
     _fileUtils = FileUtils::getInstance();
-    if (manifestUrl.size() > 0)
+    if (!manifestUrl.empty())
         parse(manifestUrl);
 }
 
@@ -95,7 +95,7 @@ void Manifest::loadJson(const std::string& url)
         // Load file content
         content = _fileUtils->getStringFromFile(url);
         
-        if (content.size() == 0)
+        if (content.empty())
         {
             CCLOG("Fail to retrieve local file content: %s\n", url.c_str());
         }
@@ -275,7 +275,7 @@ std::vector<std::string> Manifest::getSearchPaths() const
     for (int i = (int)_searchPaths.size()-1; i >= 0; i--)
     {
         std::string path = _searchPaths[i];
-        if (path.size() > 0 && path[path.size() - 1] != '/')
+        if (!path.empty() && path[path.size() - 1] != '/')
             path.append("/");
         path = _manifestRoot + path;
         searchPaths.push_back(path);
@@ -297,7 +297,7 @@ void Manifest::prependSearchPaths()
     for (int i = (int)_searchPaths.size()-1; i >= 0; i--)
     {
         std::string path = _searchPaths[i];
-        if (path.size() > 0 && path[path.size() - 1] != '/')
+        if (!path.empty() && path[path.size() - 1] != '/')
             path.append("/");
         path = _manifestRoot + path;
         iter = searchPaths.begin();
@@ -502,7 +502,7 @@ void Manifest::loadManifest(const rapidjson::Document &json)
     {
         _packageUrl = json[KEY_PACKAGE_URL].GetString();
         // Append automatically "/"
-        if (_packageUrl.size() > 0 && _packageUrl[_packageUrl.size() - 1] != '/')
+        if (!_packageUrl.empty() && _packageUrl[_packageUrl.size() - 1] != '/')
         {
             _packageUrl.append("/");
         }

--- a/tests/cpp-tests/Classes/NavMeshTest/NavMeshTest.cpp
+++ b/tests/cpp-tests/Classes/NavMeshTest/NavMeshTest.cpp
@@ -115,7 +115,7 @@ void NavMeshBaseTestDemo::onTouchesBegan(const std::vector<cocos2d::Touch*>& tou
 
 void NavMeshBaseTestDemo::onTouchesMoved(const std::vector<cocos2d::Touch*>& touches, cocos2d::Event *event)
 {
-    if (touches.size() && _camera)
+    if (!touches.empty() && _camera)
     {
         auto touch = touches[0];
         auto delta = touch->getDelta();

--- a/tests/cpp-tests/Classes/Particle3DTest/Particle3DTest.cpp
+++ b/tests/cpp-tests/Classes/Particle3DTest/Particle3DTest.cpp
@@ -97,7 +97,7 @@ void Particle3DTestDemo::onTouchesBegan(const std::vector<Touch*>& touches, coco
 
 void Particle3DTestDemo::onTouchesMoved(const std::vector<Touch*>& touches, cocos2d::Event  *event)
 {
-    if (touches.size())
+    if (!touches.empty())
     {
         auto touch = touches[0];
         auto delta = touch->getDelta();

--- a/tests/cpp-tests/Classes/Physics3DTest/Physics3DTest.cpp
+++ b/tests/cpp-tests/Classes/Physics3DTest/Physics3DTest.cpp
@@ -143,7 +143,7 @@ void Physics3DTestDemo::onTouchesBegan(const std::vector<Touch*>& touches, cocos
 
 void Physics3DTestDemo::onTouchesMoved(const std::vector<Touch*>& touches, cocos2d::Event  *event)
 {
-    if (touches.size() && _camera)
+    if (!touches.empty() && _camera)
     {
         auto touch = touches[0];
         auto delta = touch->getDelta();

--- a/tests/cpp-tests/Classes/ReleasePoolTest/ReleasePoolTest.cpp
+++ b/tests/cpp-tests/Classes/ReleasePoolTest/ReleasePoolTest.cpp
@@ -43,7 +43,7 @@ public:
     
     ~TestObject()
     {
-        if (_name.size() > 0)
+        if (!_name.empty())
             CCLOG("TestObject:%s is destroyed", _name.c_str());
     }
     

--- a/tests/cpp-tests/Classes/Sprite3DTest/Sprite3DTest.cpp
+++ b/tests/cpp-tests/Classes/Sprite3DTest/Sprite3DTest.cpp
@@ -1509,7 +1509,7 @@ void Sprite3DWithOBBPerformanceTest::update(float dt)
         _obbt.getCorners(corners);
         _drawDebug->drawCube(corners, Color4F(0,0,1,1));
     }
-    if(_obb.size() > 0)
+    if(!_obb.empty())
     {
         _drawOBB->clear();
         auto obbSize = _obb.size();
@@ -2159,7 +2159,7 @@ void Sprite3DCubeMapTest::addNewSpriteWithCoords(Vec2 p)
 
 void Sprite3DCubeMapTest::onTouchesMoved(const std::vector<Touch*>& touches, cocos2d::Event  *event)
 {
-    if (touches.size())
+    if (!touches.empty())
     {
         auto touch = touches[0];
         auto delta = touch->getDelta();

--- a/tests/cpp-tests/Classes/SpritePolygonTest/SpritePolygonTest.cpp
+++ b/tests/cpp-tests/Classes/SpritePolygonTest/SpritePolygonTest.cpp
@@ -110,7 +110,7 @@ bool SpritePolygonTestCase::init()
 
 void SpritePolygonTestCase::updateDrawNode()
 {
-    if (_isDebugDraw && _drawNodes.size() > 0) {
+    if (_isDebugDraw && !_drawNodes.empty()) {
         for (int i = 0; i < _drawNodes.size(); i++)
         {
                 auto drawnode = _drawNodes.at(i);
@@ -327,7 +327,7 @@ void SpritePolygonTestSlider::changeEpsilon(cocos2d::Ref *pSender, cocos2d::ui::
         float epsilon = powf(slider->getPercent()/100.0,2)*19.0f + 1.0f;
         for(auto child : _children)
         {
-            if(child->getName().size())
+            if(!child->getName().empty())
             {
                 Sprite *sp = (Sprite*)child;
                 auto file = sp->getName();

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIPageViewTest/UIPageViewTest.cpp
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIPageViewTest/UIPageViewTest.cpp
@@ -571,7 +571,7 @@ bool UIPageViewDynamicAddAndRemoveTest::init()
         button2->setTitleColor(Color3B::RED);
         button2->addClickEventListener([=](Ref* sender)
         {
-            if (pageView->getItems().size() > 0)
+            if (!pageView->getItems().empty())
             {
                 pageView->removeItem(pageView->getItems().size()-1);
             }

--- a/tests/cpp-tests/Classes/UnitTest/UnitTest.cpp
+++ b/tests/cpp-tests/Classes/UnitTest/UnitTest.cpp
@@ -99,7 +99,7 @@ void TemplateVectorTest::onEnter()
     Vector<Node*> vec;
     CCASSERT(vec.empty(), "vec should be empty.");
     CCASSERT(vec.capacity() == 0, "vec.capacity should be 0.");
-    CCASSERT(vec.size() == 0, "vec.size should be 0.");
+    CCASSERT(vec.empty(), "vec.size should be 0.");
     CCASSERT(vec.max_size() > 0, "vec.max_size should > 0.");
 
     auto node1 = Node::create();
@@ -175,7 +175,7 @@ void TemplateVectorTest::onEnter()
     vec5.reserve(20);
     CCASSERT(vec5.capacity() == 20, "vec5's capacity should be 20.");
 
-    CCASSERT(vec5.size() == 0, "vec5's size should be 0.");
+    CCASSERT(vec5.empty(), "vec5's size should be 0.");
     CCASSERT(vec5.empty(), "vec5 is empty now.");
 
     auto toRemovedNode = Node::create();
@@ -385,7 +385,7 @@ void TemplateMapTest::onEnter()
     // Default constructor
     Map<std::string, Node*> map1;
     CCASSERT(map1.empty(), "map1 is empty.");
-    CCASSERT(map1.size() == 0, "map1's size is 0.");
+    CCASSERT(map1.empty(), "map1's size is 0.");
     CCASSERT(map1.keys().empty(), "map1's keys are empty.");
     CCASSERT(map1.keys(Node::create()).empty(), "map1's keys don't contain a empty Node.");
 
@@ -820,45 +820,45 @@ void UIHelperSubStringTest::onEnter()
         std::string source = "";
 
         // OK
-        CC_ASSERT(Helper::getSubStringOfUTF8String(source, 0, 0) == "");
-        CC_ASSERT(Helper::getSubStringOfUTF8String(source, 0, 1) == "");
+        CC_ASSERT(Helper::getSubStringOfUTF8String(source, 0, 0).empty());
+        CC_ASSERT(Helper::getSubStringOfUTF8String(source, 0, 1).empty());
 
         // Error: These cases cause "out of range" error
-        CC_ASSERT(Helper::getSubStringOfUTF8String(source, 1, 0) == "");
-        CC_ASSERT(Helper::getSubStringOfUTF8String(source, 1, 1) == "");
+        CC_ASSERT(Helper::getSubStringOfUTF8String(source, 1, 0).empty());
+        CC_ASSERT(Helper::getSubStringOfUTF8String(source, 1, 1).empty());
     }
     {
         // Ascii
         std::string source = "abc";
 
         // OK
-        CC_ASSERT(Helper::getSubStringOfUTF8String(source, 0, 0) == "");
-        CC_ASSERT(Helper::getSubStringOfUTF8String(source, 1, 0) == "");
-        CC_ASSERT(Helper::getSubStringOfUTF8String(source, 2, 0) == "");
-        CC_ASSERT(Helper::getSubStringOfUTF8String(source, 3, 0) == "");
+        CC_ASSERT(Helper::getSubStringOfUTF8String(source, 0, 0).empty());
+        CC_ASSERT(Helper::getSubStringOfUTF8String(source, 1, 0).empty());
+        CC_ASSERT(Helper::getSubStringOfUTF8String(source, 2, 0).empty());
+        CC_ASSERT(Helper::getSubStringOfUTF8String(source, 3, 0).empty());
         CC_ASSERT(Helper::getSubStringOfUTF8String(source, 0, 3) == "abc");
         CC_ASSERT(Helper::getSubStringOfUTF8String(source, 0, 4) == "abc");
         CC_ASSERT(Helper::getSubStringOfUTF8String(source, 1, 2) == "bc");
         CC_ASSERT(Helper::getSubStringOfUTF8String(source, 1, 3) == "bc");
         CC_ASSERT(Helper::getSubStringOfUTF8String(source, 2, 1) == "c");
         CC_ASSERT(Helper::getSubStringOfUTF8String(source, 2, 2) == "c");
-        CC_ASSERT(Helper::getSubStringOfUTF8String(source, 3, 1) == "");
-        CC_ASSERT(Helper::getSubStringOfUTF8String(source, 3, 2) == "");
+        CC_ASSERT(Helper::getSubStringOfUTF8String(source, 3, 1).empty());
+        CC_ASSERT(Helper::getSubStringOfUTF8String(source, 3, 2).empty());
 
         // Error: These cases cause "out of range" error
-        CC_ASSERT(Helper::getSubStringOfUTF8String(source, 4, 0) == "");
-        CC_ASSERT(Helper::getSubStringOfUTF8String(source, 4, 1) == "");
+        CC_ASSERT(Helper::getSubStringOfUTF8String(source, 4, 0).empty());
+        CC_ASSERT(Helper::getSubStringOfUTF8String(source, 4, 1).empty());
     }
     {
         // CJK characters
         std::string source = "这里是中文测试例";
 
         // OK
-        CC_ASSERT(Helper::getSubStringOfUTF8String(source, 0, 0) == "");
-        CC_ASSERT(Helper::getSubStringOfUTF8String(source, 1, 0) == "");
-        CC_ASSERT(Helper::getSubStringOfUTF8String(source, 7, 0) == "");
-        CC_ASSERT(Helper::getSubStringOfUTF8String(source, 8, 0) == "");
-        CC_ASSERT(Helper::getSubStringOfUTF8String(source, 8, 1) == "");
+        CC_ASSERT(Helper::getSubStringOfUTF8String(source, 0, 0).empty());
+        CC_ASSERT(Helper::getSubStringOfUTF8String(source, 1, 0).empty());
+        CC_ASSERT(Helper::getSubStringOfUTF8String(source, 7, 0).empty());
+        CC_ASSERT(Helper::getSubStringOfUTF8String(source, 8, 0).empty());
+        CC_ASSERT(Helper::getSubStringOfUTF8String(source, 8, 1).empty());
         CC_ASSERT(Helper::getSubStringOfUTF8String(source, 0, 1) == "\xe8\xbf\x99");
         CC_ASSERT(Helper::getSubStringOfUTF8String(source, 0, 4) == "\xe8\xbf\x99\xe9\x87\x8c\xe6\x98\xaf\xe4\xb8\xad");
         CC_ASSERT(Helper::getSubStringOfUTF8String(source, 0, 8) == "\xe8\xbf\x99\xe9\x87\x8c\xe6\x98\xaf\xe4\xb8\xad\xe6\x96\x87\xe6\xb5\x8b\xe8\xaf\x95\xe4\xbe\x8b");
@@ -868,41 +868,41 @@ void UIHelperSubStringTest::onEnter()
         CC_ASSERT(Helper::getSubStringOfUTF8String(source, 6, 100) == "\xe8\xaf\x95\xe4\xbe\x8b");
 
         // Error: These cases cause "out of range" error
-        CC_ASSERT(Helper::getSubStringOfUTF8String(source, 9, 0) == "");
-        CC_ASSERT(Helper::getSubStringOfUTF8String(source, 9, 1) == "");
+        CC_ASSERT(Helper::getSubStringOfUTF8String(source, 9, 0).empty());
+        CC_ASSERT(Helper::getSubStringOfUTF8String(source, 9, 1).empty());
     }
     {
         // Redundant UTF-8 sequence for Directory traversal attack (1)
         std::string source = "\xC0\xAF";
 
         // Error: Can't convert string to correct encoding such as UTF-32
-        CC_ASSERT(Helper::getSubStringOfUTF8String(source, 0, 0) == "");
-        CC_ASSERT(Helper::getSubStringOfUTF8String(source, 0, 1) == "");
-        CC_ASSERT(Helper::getSubStringOfUTF8String(source, 1, 0) == "");
-        CC_ASSERT(Helper::getSubStringOfUTF8String(source, 1, 1) == "");
-        CC_ASSERT(Helper::getSubStringOfUTF8String(source, 0, 2) == "");
+        CC_ASSERT(Helper::getSubStringOfUTF8String(source, 0, 0).empty());
+        CC_ASSERT(Helper::getSubStringOfUTF8String(source, 0, 1).empty());
+        CC_ASSERT(Helper::getSubStringOfUTF8String(source, 1, 0).empty());
+        CC_ASSERT(Helper::getSubStringOfUTF8String(source, 1, 1).empty());
+        CC_ASSERT(Helper::getSubStringOfUTF8String(source, 0, 2).empty());
     }
     {
         // Redundant UTF-8 sequence for Directory traversal attack (2)
         std::string source = "\xE0\x80\xAF";
 
         // Error: Can't convert string to correct encoding such as UTF-32
-        CC_ASSERT(Helper::getSubStringOfUTF8String(source, 0, 0) == "");
-        CC_ASSERT(Helper::getSubStringOfUTF8String(source, 0, 1) == "");
-        CC_ASSERT(Helper::getSubStringOfUTF8String(source, 1, 0) == "");
-        CC_ASSERT(Helper::getSubStringOfUTF8String(source, 1, 1) == "");
-        CC_ASSERT(Helper::getSubStringOfUTF8String(source, 0, 3) == "");
+        CC_ASSERT(Helper::getSubStringOfUTF8String(source, 0, 0).empty());
+        CC_ASSERT(Helper::getSubStringOfUTF8String(source, 0, 1).empty());
+        CC_ASSERT(Helper::getSubStringOfUTF8String(source, 1, 0).empty());
+        CC_ASSERT(Helper::getSubStringOfUTF8String(source, 1, 1).empty());
+        CC_ASSERT(Helper::getSubStringOfUTF8String(source, 0, 3).empty());
     }
     {
         // Redundant UTF-8 sequence for Directory traversal attack (3)
         std::string source = "\xF0\x80\x80\xAF";
 
         // Error: Can't convert string to correct encoding such as UTF-32
-        CC_ASSERT(Helper::getSubStringOfUTF8String(source, 0, 0) == "");
-        CC_ASSERT(Helper::getSubStringOfUTF8String(source, 0, 1) == "");
-        CC_ASSERT(Helper::getSubStringOfUTF8String(source, 1, 0) == "");
-        CC_ASSERT(Helper::getSubStringOfUTF8String(source, 1, 1) == "");
-        CC_ASSERT(Helper::getSubStringOfUTF8String(source, 0, 4) == "");
+        CC_ASSERT(Helper::getSubStringOfUTF8String(source, 0, 0).empty());
+        CC_ASSERT(Helper::getSubStringOfUTF8String(source, 0, 1).empty());
+        CC_ASSERT(Helper::getSubStringOfUTF8String(source, 1, 0).empty());
+        CC_ASSERT(Helper::getSubStringOfUTF8String(source, 1, 1).empty());
+        CC_ASSERT(Helper::getSubStringOfUTF8String(source, 0, 4).empty());
     }
 }
 

--- a/tests/cpp-tests/Classes/UnitTest/UnitTest.cpp
+++ b/tests/cpp-tests/Classes/UnitTest/UnitTest.cpp
@@ -949,8 +949,8 @@ void ParseUriTest::onEnter()
         std::string s("http://www.facebook.com/hello/world?query#fragment");
         Uri u = Uri::parse(s);
         EXPECT_EQ("http", u.getScheme());
-        EXPECT_EQ("", u.getUserName());
-        EXPECT_EQ("", u.getPassword());
+        EXPECT_TRUE(u.getUserName().empty());
+        EXPECT_TRUE(u.getPassword().empty());
         EXPECT_EQ("www.facebook.com", u.getHost());
         EXPECT_EQ(0, u.getPort());
         EXPECT_EQ("www.facebook.com", u.getAuthority());
@@ -964,8 +964,8 @@ void ParseUriTest::onEnter()
         std::string s("http://www.facebook.com:8080/hello/world?query#fragment");
         Uri u = Uri::parse(s);
         EXPECT_EQ("http", u.getScheme());
-        EXPECT_EQ("", u.getUserName());
-        EXPECT_EQ("", u.getPassword());
+        EXPECT_TRUE(u.getUserName().empty());
+        EXPECT_TRUE(u.getPassword().empty());
         EXPECT_EQ("www.facebook.com", u.getHost());
         EXPECT_EQ(8080, u.getPort());
         EXPECT_EQ("www.facebook.com:8080", u.getAuthority());
@@ -979,8 +979,8 @@ void ParseUriTest::onEnter()
         std::string s("http://127.0.0.1:8080/hello/world?query#fragment");
         Uri u = Uri::parse(s);
         EXPECT_EQ("http", u.getScheme());
-        EXPECT_EQ("", u.getUserName());
-        EXPECT_EQ("", u.getPassword());
+        EXPECT_TRUE(u.getUserName().empty());
+        EXPECT_TRUE(u.getPassword().empty());
         EXPECT_EQ("127.0.0.1", u.getHost());
         EXPECT_EQ(8080, u.getPort());
         EXPECT_EQ("127.0.0.1:8080", u.getAuthority());
@@ -994,8 +994,8 @@ void ParseUriTest::onEnter()
         std::string s("http://[::1]:8080/hello/world?query#fragment");
         Uri u = Uri::parse(s);
         EXPECT_EQ("http", u.getScheme());
-        EXPECT_EQ("", u.getUserName());
-        EXPECT_EQ("", u.getPassword());
+        EXPECT_TRUE(u.getUserName().empty());
+        EXPECT_TRUE(u.getPassword().empty());
         EXPECT_EQ("[::1]", u.getHost());
         EXPECT_EQ("::1", u.getHostName());
         EXPECT_EQ(8080, u.getPort());
@@ -1010,15 +1010,15 @@ void ParseUriTest::onEnter()
         std::string s("http://[2401:db00:20:7004:face:0:29:0]:8080/hello/world?query");
         Uri u = Uri::parse(s);
         EXPECT_EQ("http", u.getScheme());
-        EXPECT_EQ("", u.getUserName());
-        EXPECT_EQ("", u.getPassword());
+        EXPECT_TRUE(u.getUserName().empty());
+        EXPECT_TRUE(u.getPassword().empty());
         EXPECT_EQ("[2401:db00:20:7004:face:0:29:0]", u.getHost());
         EXPECT_EQ("2401:db00:20:7004:face:0:29:0", u.getHostName());
         EXPECT_EQ(8080, u.getPort());
         EXPECT_EQ("[2401:db00:20:7004:face:0:29:0]:8080", u.getAuthority());
         EXPECT_EQ("/hello/world", u.getPath());
         EXPECT_EQ("query", u.getQuery());
-        EXPECT_EQ("", u.getFragment());
+        EXPECT_TRUE(u.getFragment().empty());
         EXPECT_EQ(s, u.toString());  // canonical
     }
 
@@ -1026,15 +1026,15 @@ void ParseUriTest::onEnter()
         std::string s("http://[2401:db00:20:7004:face:0:29:0]/hello/world?query");
         Uri u = Uri::parse(s);
         EXPECT_EQ("http", u.getScheme());
-        EXPECT_EQ("", u.getUserName());
-        EXPECT_EQ("", u.getPassword());
+        EXPECT_TRUE(u.getUserName().empty());
+        EXPECT_TRUE(u.getPassword().empty());
         EXPECT_EQ("[2401:db00:20:7004:face:0:29:0]", u.getHost());
         EXPECT_EQ("2401:db00:20:7004:face:0:29:0", u.getHostName());
         EXPECT_EQ(0, u.getPort());
         EXPECT_EQ("[2401:db00:20:7004:face:0:29:0]", u.getAuthority());
         EXPECT_EQ("/hello/world", u.getPath());
         EXPECT_EQ("query", u.getQuery());
-        EXPECT_EQ("", u.getFragment());
+        EXPECT_TRUE(u.getFragment().empty());
         EXPECT_EQ(s, u.toString());  // canonical
     }
 
@@ -1048,8 +1048,8 @@ void ParseUriTest::onEnter()
         EXPECT_EQ(0, u.getPort());
         EXPECT_EQ("user:pass@host.com", u.getAuthority());
         EXPECT_EQ("/", u.getPath());
-        EXPECT_EQ("", u.getQuery());
-        EXPECT_EQ("", u.getFragment());
+        EXPECT_TRUE(u.getQuery().empty());
+        EXPECT_TRUE(u.getFragment().empty());
         EXPECT_EQ(s, u.toString());
     }
 
@@ -1058,13 +1058,13 @@ void ParseUriTest::onEnter()
         Uri u = Uri::parse(s);
         EXPECT_EQ("http", u.getScheme());
         EXPECT_EQ("user", u.getUserName());
-        EXPECT_EQ("", u.getPassword());
+        EXPECT_TRUE(u.getPassword().empty());
         EXPECT_EQ("host.com", u.getHost());
         EXPECT_EQ(0, u.getPort());
         EXPECT_EQ("user@host.com", u.getAuthority());
         EXPECT_EQ("/", u.getPath());
-        EXPECT_EQ("", u.getQuery());
-        EXPECT_EQ("", u.getFragment());
+        EXPECT_TRUE(u.getQuery().empty());
+        EXPECT_TRUE(u.getFragment().empty());
         EXPECT_EQ(s, u.toString());
     }
 
@@ -1073,13 +1073,13 @@ void ParseUriTest::onEnter()
         Uri u = Uri::parse(s);
         EXPECT_EQ("http", u.getScheme());
         EXPECT_EQ("user", u.getUserName());
-        EXPECT_EQ("", u.getPassword());
+        EXPECT_TRUE(u.getPassword().empty());
         EXPECT_EQ("host.com", u.getHost());
         EXPECT_EQ(0, u.getPort());
         EXPECT_EQ("user@host.com", u.getAuthority());
         EXPECT_EQ("/", u.getPath());
-        EXPECT_EQ("", u.getQuery());
-        EXPECT_EQ("", u.getFragment());
+        EXPECT_TRUE(u.getQuery().empty());
+        EXPECT_TRUE(u.getFragment().empty());
         EXPECT_EQ("http://user@host.com/", u.toString());
     }
 
@@ -1087,14 +1087,14 @@ void ParseUriTest::onEnter()
         std::string s("http://:pass@host.com/");
         Uri u = Uri::parse(s);
         EXPECT_EQ("http", u.getScheme());
-        EXPECT_EQ("", u.getUserName());
+        EXPECT_TRUE(u.getUserName().empty());
         EXPECT_EQ("pass", u.getPassword());
         EXPECT_EQ("host.com", u.getHost());
         EXPECT_EQ(0, u.getPort());
         EXPECT_EQ(":pass@host.com", u.getAuthority());
         EXPECT_EQ("/", u.getPath());
-        EXPECT_EQ("", u.getQuery());
-        EXPECT_EQ("", u.getFragment());
+        EXPECT_TRUE(u.getQuery().empty());
+        EXPECT_TRUE(u.getFragment().empty());
         EXPECT_EQ(s, u.toString());
     }
 
@@ -1102,14 +1102,14 @@ void ParseUriTest::onEnter()
         std::string s("http://@host.com/");
         Uri u = Uri::parse(s);
         EXPECT_EQ("http", u.getScheme());
-        EXPECT_EQ("", u.getUserName());
-        EXPECT_EQ("", u.getPassword());
+        EXPECT_TRUE(u.getUserName().empty());
+        EXPECT_TRUE(u.getPassword().empty());
         EXPECT_EQ("host.com", u.getHost());
         EXPECT_EQ(0, u.getPort());
         EXPECT_EQ("host.com", u.getAuthority());
         EXPECT_EQ("/", u.getPath());
-        EXPECT_EQ("", u.getQuery());
-        EXPECT_EQ("", u.getFragment());
+        EXPECT_TRUE(u.getQuery().empty());
+        EXPECT_TRUE(u.getFragment().empty());
         EXPECT_EQ("http://host.com/", u.toString());
     }
 
@@ -1117,14 +1117,14 @@ void ParseUriTest::onEnter()
         std::string s("http://:@host.com/");
         Uri u = Uri::parse(s);
         EXPECT_EQ("http", u.getScheme());
-        EXPECT_EQ("", u.getUserName());
-        EXPECT_EQ("", u.getPassword());
+        EXPECT_TRUE(u.getUserName().empty());
+        EXPECT_TRUE(u.getPassword().empty());
         EXPECT_EQ("host.com", u.getHost());
         EXPECT_EQ(0, u.getPort());
         EXPECT_EQ("host.com", u.getAuthority());
         EXPECT_EQ("/", u.getPath());
-        EXPECT_EQ("", u.getQuery());
-        EXPECT_EQ("", u.getFragment());
+        EXPECT_TRUE(u.getQuery().empty());
+        EXPECT_TRUE(u.getFragment().empty());
         EXPECT_EQ("http://host.com/", u.toString());
     }
 
@@ -1132,14 +1132,14 @@ void ParseUriTest::onEnter()
         std::string s("file:///etc/motd");
         Uri u = Uri::parse(s);
         EXPECT_EQ("file", u.getScheme());
-        EXPECT_EQ("", u.getUserName());
-        EXPECT_EQ("", u.getPassword());
-        EXPECT_EQ("", u.getHost());
+        EXPECT_TRUE(u.getUserName().empty());
+        EXPECT_TRUE(u.getPassword().empty());
+        EXPECT_TRUE(u.getHost().empty());
         EXPECT_EQ(0, u.getPort());
-        EXPECT_EQ("", u.getAuthority());
+        EXPECT_TRUE(u.getAuthority().empty());
         EXPECT_EQ("/etc/motd", u.getPath());
-        EXPECT_EQ("", u.getQuery());
-        EXPECT_EQ("", u.getFragment());
+        EXPECT_TRUE(u.getQuery().empty());
+        EXPECT_TRUE(u.getFragment().empty());
         EXPECT_EQ(s, u.toString());
     }
 
@@ -1147,14 +1147,14 @@ void ParseUriTest::onEnter()
         std::string s("file://etc/motd");
         Uri u = Uri::parse(s);
         EXPECT_EQ("file", u.getScheme());
-        EXPECT_EQ("", u.getUserName());
-        EXPECT_EQ("", u.getPassword());
+        EXPECT_TRUE(u.getUserName().empty());
+        EXPECT_TRUE(u.getPassword().empty());
         EXPECT_EQ("etc", u.getHost());
         EXPECT_EQ(0, u.getPort());
         EXPECT_EQ("etc", u.getAuthority());
         EXPECT_EQ("/motd", u.getPath());
-        EXPECT_EQ("", u.getQuery());
-        EXPECT_EQ("", u.getFragment());
+        EXPECT_TRUE(u.getQuery().empty());
+        EXPECT_TRUE(u.getFragment().empty());
         EXPECT_EQ(s, u.toString());
     }
 
@@ -1170,9 +1170,9 @@ void ParseUriTest::onEnter()
         EXPECT_EQ(3, params.size());
         EXPECT_EQ("foo", params["key1"]);
         EXPECT_NE(params.end(), params.find("key2"));
-        EXPECT_EQ("", params["key2"]);
+        EXPECT_TRUE(params["key2"].empty());
         EXPECT_NE(params.end(), params.find("key3"));
-        EXPECT_EQ("", params["key3"]);
+        EXPECT_TRUE(params["key3"].empty());
     }
 
     {
@@ -1194,7 +1194,7 @@ void ParseUriTest::onEnter()
         }
         EXPECT_EQ(2, params.size());
         EXPECT_NE(params.end(), params.find("key2"));
-        EXPECT_EQ("", params["key2"]);
+        EXPECT_TRUE(params["key2"].empty());
         EXPECT_EQ("foo", params["key3"]);
     }
 
@@ -1209,7 +1209,7 @@ void ParseUriTest::onEnter()
         }
         EXPECT_EQ(1, params.size());
         EXPECT_NE(params.end(), params.find("key3"));
-        EXPECT_EQ("", params["key3"]);
+        EXPECT_TRUE(params["key3"].empty());
     }
 
     {
@@ -1232,9 +1232,9 @@ void ParseUriTest::onEnter()
             EXPECT_EQ("ws", v.getScheme());
             EXPECT_EQ("localhost", v.getHost());
             EXPECT_EQ("localhost", v.getHostName());
-            EXPECT_EQ("", v.getPath());
+            EXPECT_TRUE(v.getPath().empty());
             EXPECT_EQ(90, v.getPort());
-            EXPECT_EQ("", v.getFragment());
+            EXPECT_TRUE(v.getFragment().empty());
             EXPECT_EQ("key1=foo=bar&key2=foobar&", v.getQuery());
             EXPECT_EQ(u, v);
         }
@@ -1247,9 +1247,9 @@ void ParseUriTest::onEnter()
             EXPECT_EQ("ws", v.getScheme());
             EXPECT_EQ("localhost", v.getHost());
             EXPECT_EQ("localhost", v.getHostName());
-            EXPECT_EQ("", v.getPath());
+            EXPECT_TRUE(v.getPath().empty());
             EXPECT_EQ(90, v.getPort());
-            EXPECT_EQ("", v.getFragment());
+            EXPECT_TRUE(v.getFragment().empty());
             EXPECT_EQ("key1=foo=bar&key2=foobar&", v.getQuery());
             EXPECT_EQ(u, v);
         }
@@ -1274,9 +1274,9 @@ void ParseUriTest::onEnter()
             EXPECT_EQ("ws", v.getScheme());
             EXPECT_EQ("localhost", v.getHost());
             EXPECT_EQ("localhost", v.getHostName());
-            EXPECT_EQ("", v.getPath());
+            EXPECT_TRUE(v.getPath().empty());
             EXPECT_EQ(90, v.getPort());
-            EXPECT_EQ("", v.getFragment());
+            EXPECT_TRUE(v.getFragment().empty());
             EXPECT_EQ("key1=foo=bar&key2=foobar&", v.getQuery());
             u = std::move(v);
         }
@@ -1290,9 +1290,9 @@ void ParseUriTest::onEnter()
             EXPECT_EQ("ws", v.getScheme());
             EXPECT_EQ("localhost", v.getHost());
             EXPECT_EQ("localhost", v.getHostName());
-            EXPECT_EQ("", v.getPath());
+            EXPECT_TRUE(v.getPath().empty());
             EXPECT_EQ(90, v.getPort());
-            EXPECT_EQ("", v.getFragment());
+            EXPECT_TRUE(v.getFragment().empty());
             EXPECT_EQ("key1=foo=bar&key2=foobar&", v.getQuery());
             u = v;
         }
@@ -1406,28 +1406,28 @@ void ParseUriTest::onEnter()
         EXPECT_EQ(u2.getPort(), 0);
         EXPECT_EQ(u2.getPath(), "/foo");
 
-        EXPECT_EQ(u3.getScheme(), "");
+        EXPECT_TRUE(u3.getScheme().empty());
         EXPECT_EQ(u3.getHost(), "localhost");
         EXPECT_EQ(u3.getPort(), 0);
         EXPECT_EQ(u3.getPath(), "/foo");
 
-        EXPECT_EQ(u4.getScheme(), "");
+        EXPECT_TRUE(u4.getScheme().empty());
         EXPECT_EQ(u4.getHost(), "localhost");
         EXPECT_EQ(u4.getPort(), 8080);
-        EXPECT_EQ(u4.getPath(), "");
-        EXPECT_EQ(u4.getPathEtc(), "");
+        EXPECT_TRUE(u4.getPath().empty());
+        EXPECT_TRUE(u4.getPathEtc().empty());
 
         EXPECT_EQ(u5.getScheme(), "bb");
         EXPECT_EQ(u5.getHost(), "localhost");
         EXPECT_EQ(u5.getPort(), 0);
-        EXPECT_EQ(u5.getPath(), "");
+        EXPECT_TRUE(u5.getPath().empty());
         EXPECT_EQ(u5.getPathEtc(), "?&foo=12:4&ccc=13");
         EXPECT_EQ(u5.getQuery(), "&foo=12:4&ccc=13");
 
         EXPECT_EQ(u6.getScheme(), "cc");
         EXPECT_EQ(u6.getHost(), "localhost");
         EXPECT_EQ(u6.getPort(), 91);
-        EXPECT_EQ(u6.getPath(), "");
+        EXPECT_TRUE(u6.getPath().empty());
         EXPECT_EQ(u6.getPathEtc(), "?&foo=321&bbb=1");
         EXPECT_EQ(u6.getQuery(), "&foo=321&bbb=1");
     }

--- a/tests/js-tests/project/Classes/js_Effect3D_bindings.cpp
+++ b/tests/js-tests/project/Classes/js_Effect3D_bindings.cpp
@@ -119,7 +119,7 @@ EffectSprite3D* EffectSprite3D::createFromObjFileAndTexture(const std::string &o
     if (sprite && sprite->initWithFile(objFilePath))
     {
         sprite->autorelease();
-        if(textureFilePath.size() > 0)
+        if(!textureFilePath.empty())
             sprite->setTexture(textureFilePath);
         return sprite;
     }

--- a/tools/travis-scripts/run-script.sh
+++ b/tools/travis-scripts/run-script.sh
@@ -44,7 +44,8 @@ function build_linux_clang_tidy()
     mkdir -p clang-tidy-build
     cd clang-tidy-build
     cmake ../.. -DCMAKE_EXPORT_COMPILE_COMMANDS=on
-    python $(dirname $(dirname $(readlink -f `which clang-tidy`)))/share/clang/run-clang-tidy.py
+    clang_tidy_script=$(dirname $(dirname $(readlink -f `which clang-tidy`)))/share/clang/run-clang-tidy.py 
+    python $clang_tidy_script '^((?!/cocos2d-x/external/).)*$'
 }
 
 function build_mac()

--- a/tools/travis-scripts/run-script.sh
+++ b/tools/travis-scripts/run-script.sh
@@ -45,6 +45,7 @@ function build_linux_clang_tidy()
     cd clang-tidy-build
     cmake ../.. -DCMAKE_EXPORT_COMPILE_COMMANDS=on
     clang_tidy_script=$(dirname $(dirname $(readlink -f `which clang-tidy`)))/share/clang/run-clang-tidy.py 
+    # run clang-tidy on all files except those in external directory
     python $clang_tidy_script '^((?!/cocos2d-x/external/).)*$'
 }
 


### PR DESCRIPTION
* readability-container-size-empty

Reference: https://releases.llvm.org/7.0.0/tools/clang/tools/extra/docs/clang-tidy/checks/readability-container-size-empty.html

> Checks whether a call to the `size()` method can be replaced with a call to `empty()`.

> The emptiness of a container should be checked using the `empty()` method instead of the `size()` method. It is not guaranteed that `size()` is a constant-time function, and it is generally more efficient and also shows clearer intent to use `empty()`. Furthermore some containers may implement the `empty()` method but not implement the `size()` method. Using `empty()` whenever possible makes it easier to switch to another container in the future.

