### PR TITLE
add new clang-tidy option

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -9,6 +9,7 @@ Checks: >
   performance-move-const-arg,
   performance-type-promotion-in-math-fn,
   readability-container-size-empty,
+  readability-delete-null-pointer,
 
 WarningsAsErrors: '*'
 HeaderFilterRegex: '/(?!external)/.*'

--- a/cocos/2d/CCFontAtlas.cpp
+++ b/cocos/2d/CCFontAtlas.cpp
@@ -433,8 +433,7 @@ bool FontAtlas::prepareLetterDefinitions(const std::u32string& utf32Text)
             tempDef.V = tempDef.V / scaleFactor;
         }
         else{
-            if(bitmap)
-                delete[] bitmap;
+            delete[] bitmap;
             if (tempDef.xAdvance)
                 tempDef.validDefinition = true;
             else

--- a/cocos/3d/CCTerrain.cpp
+++ b/cocos/3d/CCTerrain.cpp
@@ -1583,10 +1583,10 @@ void Terrain::QuadTree::preCalculateAABB(const Mat4 & worldTransform)
 
 Terrain::QuadTree::~QuadTree()
 {
-    if(_tl) delete _tl;
-    if(_tr) delete _tr;
-    if(_bl) delete _bl;
-    if(_br) delete _br;
+    delete _tl;
+    delete _tr;
+    delete _bl;
+    delete _br;
 }
 
 Terrain::TerrainData::TerrainData(const std::string& heightMapsrc , const std::string& textureSrc, const Size & chunksize, float height, float scale)

--- a/cocos/base/CCDirector.cpp
+++ b/cocos/base/CCDirector.cpp
@@ -1343,8 +1343,7 @@ void Director::createStatsLabel()
     Image* image = new (std::nothrow) Image();
     bool isOK = image ? image->initWithImageData(data, dataLength) : false;
     if (! isOK) {
-        if(image)
-            delete image;
+        delete image;
         CCLOGERROR("%s", "Fails: init fps_images");
         return;
     }

--- a/cocos/base/CCUserDefault.cpp
+++ b/cocos/base/CCUserDefault.cpp
@@ -195,7 +195,7 @@ bool UserDefault::getBoolForKey(const char* pKey, bool defaultValue)
         ret = (! strcmp(value, "true"));
     }
 
-    if (doc) delete doc;
+    delete doc;
 
     return ret;
 }
@@ -225,10 +225,7 @@ int UserDefault::getIntegerForKey(const char* pKey, int defaultValue)
         ret = atoi(value);
     }
 
-    if(doc)
-    {
-        delete doc;
-    }
+    delete doc;
 
 
     return ret;
@@ -271,7 +268,7 @@ double UserDefault::getDoubleForKey(const char* pKey, double defaultValue)
         ret = utils::atof(value);
     }
 
-    if (doc) delete doc;
+    delete doc;
 
     return ret;
 }
@@ -301,7 +298,7 @@ string UserDefault::getStringForKey(const char* pKey, const std::string & defaul
         ret = string(value);
     }
 
-    if (doc) delete doc;
+    delete doc;
 
     return ret;
 }
@@ -336,7 +333,7 @@ Data UserDefault::getDataForKey(const char* pKey, const Data& defaultValue)
         }
     }
     
-    if (doc) delete doc;
+    delete doc;
     
     return ret;    
 }
@@ -447,8 +444,7 @@ void UserDefault::destroyInstance()
 
 void UserDefault::setDelegate(UserDefault *delegate)
 {
-    if (_userDefault)
-        delete _userDefault;
+    delete _userDefault;
 
     _userDefault = delegate;
 }

--- a/cocos/base/ZipUtils.cpp
+++ b/cocos/base/ZipUtils.cpp
@@ -523,7 +523,7 @@ ZipFile *ZipFile::createWithBuffer(const void* buffer, uLong size)
     if (zip && zip->initWithBuffer(buffer, size)) {
         return zip;
     } else {
-        if (zip) delete zip;
+        delete zip;
         return nullptr;
     }
 }

--- a/cocos/platform/CCFileUtils.cpp
+++ b/cocos/platform/CCFileUtils.cpp
@@ -547,8 +547,7 @@ void FileUtils::destroyInstance()
 
 void FileUtils::setDelegate(FileUtils *delegate)
 {
-    if (s_sharedFileUtils)
-        delete s_sharedFileUtils;
+    delete s_sharedFileUtils;
 
     s_sharedFileUtils = delegate;
 }

--- a/cocos/scripting/js-bindings/manual/cocos2d_specifics.cpp
+++ b/cocos/scripting/js-bindings/manual/cocos2d_specifics.cpp
@@ -5608,8 +5608,7 @@ void js_cocos2d_PolygonInfo_finalize(JSFreeOp *fop, JSObject *obj) {
     if (proxy)
     {
         cocos2d::PolygonInfo *nobj = static_cast<cocos2d::PolygonInfo *>(proxy->ptr);
-        if (nobj)
-            delete nobj;
+        delete nobj;
         jsb_remove_proxy(proxy);
     }
 }
@@ -5766,8 +5765,7 @@ void js_cocos2d_AutoPolygon_finalize(JSFreeOp *fop, JSObject *obj) {
     auto proxy = jsb_get_js_proxy(jsobj);
     if (proxy) {
         cocos2d::AutoPolygon *nobj = static_cast<cocos2d::AutoPolygon *>(proxy->ptr);
-        if (nobj)
-            delete nobj;
+        delete nobj;
         jsb_remove_proxy(proxy);
     }
 }

--- a/cocos/scripting/js-bindings/manual/component/CCComponentJS.cpp
+++ b/cocos/scripting/js-bindings/manual/component/CCComponentJS.cpp
@@ -104,10 +104,7 @@ ComponentJS::~ComponentJS()
             jsb_remove_proxy(proxy);
     }
     // Delete rooted object
-    if (jsObj != nullptr)
-    {
-        delete jsObj;
-    }
+    delete jsObj;
 }
 
 void* ComponentJS::getScriptObject() const

--- a/extensions/Particle3D/PU/CCPUEmitter.cpp
+++ b/extensions/Particle3D/PU/CCPUEmitter.cpp
@@ -131,41 +131,30 @@ PUEmitter::~PUEmitter()
 {
     _particleSystem = nullptr;
 
-    if (_dynEmissionRate)
-        delete _dynEmissionRate;
+    delete _dynEmissionRate;
 
-    if (_dynTotalTimeToLive)
-        delete _dynTotalTimeToLive;
+    delete _dynTotalTimeToLive;
 
-    if (_dynParticleMass)
-        delete _dynParticleMass;
+    delete _dynParticleMass;
 
-    if (_dynVelocity)
-        delete _dynVelocity;
+    delete _dynVelocity;
 
-    if (_dynDuration)
-        delete _dynDuration;
+    delete _dynDuration;
 
-    if (_dynRepeatDelay)
-        delete _dynRepeatDelay;
+    delete _dynRepeatDelay;
 
-    if (_dynParticleAllDimensions)
-        delete _dynParticleAllDimensions;
+    delete _dynParticleAllDimensions;
 
-    if (_dynParticleWidth)
-        delete _dynParticleWidth;
+    delete _dynParticleWidth;
 
-    if (_dynParticleHeight)
-        delete _dynParticleHeight;
+    delete _dynParticleHeight;
 
-    if (_dynParticleDepth)
-        delete _dynParticleDepth;
+    delete _dynParticleDepth;
 
     //if (mEmissionRateCameraDependency)
     //	mCameraDependencyFactory.destroy(mEmissionRateCameraDependency);
 
-    if (_dynAngle)
-        delete _dynAngle;
+    delete _dynAngle;
 }
 
 void PUEmitter::updateEmitter(Particle3D* /*particle*/, float /*deltaTime*/)
@@ -516,48 +505,42 @@ void PUEmitter::setEmitsName(const std::string& emitsName)
 //-----------------------------------------------------------------------
 void PUEmitter::setDynEmissionRate(PUDynamicAttribute* dynEmissionRate)
 {
-    if (_dynEmissionRate)
-        delete _dynEmissionRate;
+    delete _dynEmissionRate;
 
     _dynEmissionRate = dynEmissionRate;
 }
 //-----------------------------------------------------------------------
 void PUEmitter::setDynTotalTimeToLive(PUDynamicAttribute* dynTotalTimeToLive)
 {
-    if (_dynTotalTimeToLive)
-        delete _dynTotalTimeToLive;
+    delete _dynTotalTimeToLive;
 
     _dynTotalTimeToLive = dynTotalTimeToLive;
 }
 //-----------------------------------------------------------------------
 void PUEmitter::setDynParticleMass(PUDynamicAttribute* dynParticleMass)
 {
-    if (_dynParticleMass)
-        delete _dynParticleMass;
+    delete _dynParticleMass;
 
     _dynParticleMass = dynParticleMass;
 }
 //-----------------------------------------------------------------------
 void PUEmitter::setDynAngle(PUDynamicAttribute* dynAngle)
 {
-    if (_dynAngle)
-        delete _dynAngle;
+    delete _dynAngle;
 
     _dynAngle = dynAngle;
 }
 //-----------------------------------------------------------------------
 void PUEmitter::setDynVelocity(PUDynamicAttribute* dynVelocity)
 {
-    if (_dynVelocity)
-        delete _dynVelocity;
+    delete _dynVelocity;
 
     _dynVelocity = dynVelocity;
 }
 //-----------------------------------------------------------------------
 void PUEmitter::setDynDuration(PUDynamicAttribute* dynDuration)
 {
-    if (_dynDuration)
-        delete _dynDuration;
+    delete _dynDuration;
 
     _dynDuration = dynDuration;
     _dynDurationSet = true;
@@ -571,8 +554,7 @@ void PUEmitter::setDynDurationSet(bool durationSet)
 //-----------------------------------------------------------------------
 void PUEmitter::setDynRepeatDelay(PUDynamicAttribute* dynRepeatDelay)
 {
-    if (_dynRepeatDelay)
-        delete _dynRepeatDelay;
+    delete _dynRepeatDelay;
 
     _dynRepeatDelay = dynRepeatDelay;
     _dynRepeatDelaySet = true;
@@ -586,8 +568,7 @@ void PUEmitter::setDynRepeatDelaySet(bool repeatDelaySet)
 //-----------------------------------------------------------------------
 void PUEmitter::setDynParticleAllDimensions(PUDynamicAttribute* dynParticleAllDimensions)
 {
-    if (_dynParticleAllDimensions)
-        delete _dynParticleAllDimensions;
+    delete _dynParticleAllDimensions;
 
     _dynParticleAllDimensions = dynParticleAllDimensions;
     _dynParticleAllDimensionsSet = true;
@@ -600,8 +581,7 @@ void PUEmitter::setDynParticleAllDimensionsSet(bool particleAllDimensionsSet)
 //-----------------------------------------------------------------------
 void PUEmitter::setDynParticleWidth(PUDynamicAttribute* dynParticleWidth)
 {
-    if (_dynParticleWidth)
-        delete _dynParticleWidth;
+    delete _dynParticleWidth;
 
     _dynParticleWidth = dynParticleWidth;
     _dynParticleWidthSet = true;
@@ -614,8 +594,7 @@ void PUEmitter::setDynParticleWidthSet(bool particleWidthSet)
 //-----------------------------------------------------------------------
 void PUEmitter::setDynParticleHeight(PUDynamicAttribute* dynParticleHeight)
 {
-    if (_dynParticleHeight)
-        delete _dynParticleHeight;
+    delete _dynParticleHeight;
 
     _dynParticleHeight = dynParticleHeight;
     _dynParticleHeightSet = true;
@@ -628,8 +607,7 @@ void PUEmitter::setDynParticleHeightSet(bool particleHeightSet)
 //-----------------------------------------------------------------------
 void PUEmitter::setDynParticleDepth(PUDynamicAttribute* dynParticleDepth)
 {
-    if (_dynParticleDepth)
-        delete _dynParticleDepth;
+    delete _dynParticleDepth;
 
     _dynParticleDepth = dynParticleDepth;
     _dynParticleDepthSet = true;

--- a/extensions/Particle3D/PU/CCPUForceField.cpp
+++ b/extensions/Particle3D/PU/CCPUForceField.cpp
@@ -166,10 +166,7 @@ PUForceField::PUForceField(void) :
 //-----------------------------------------------------------------------
 PUForceField::~PUForceField(void)
 {
-    if (_forceFieldCalculationFactory)
-    {
-        delete _forceFieldCalculationFactory;
-    }
+    delete _forceFieldCalculationFactory;
 }
 //-----------------------------------------------------------------------
 void PUForceField::initialise(ForceFieldType type,
@@ -236,10 +233,7 @@ PUForceFieldCalculationFactory* PUForceField::getForceFieldCalculationFactory() 
 //-----------------------------------------------------------------------
 void PUForceField::setForceFieldCalculationFactory(PUForceFieldCalculationFactory* forceFieldCalculationFactory)
 {
-    if (_forceFieldCalculationFactory)
-    {
-        delete _forceFieldCalculationFactory;
-    }
+    delete _forceFieldCalculationFactory;
     _forceFieldCalculationFactory = forceFieldCalculationFactory;
 }
 //-----------------------------------------------------------------------


### PR DESCRIPTION
* readability-delete-null-pointer

> Checks the if statements where a pointer’s existence is checked and then deletes the pointer. The check is unnecessary as deleting a null pointer has no effect.

```cpp
int *p;
if (p)
  delete p;
```

Reference: http://releases.llvm.org/7.0.0/tools/clang/tools/extra/docs/clang-tidy/checks/readability-delete-null-pointer.html