### PR TITLE
fix twice copy lua scripts error

### DIFF
--- a/templates/lua-template-default/CMakeLists.txt
+++ b/templates/lua-template-default/CMakeLists.txt
@@ -42,13 +42,9 @@ set(res_res_folders
 set(res_src_folders
     "${CMAKE_CURRENT_SOURCE_DIR}/src"
     )
-set(res_script_folders
-    "${COCOS2DX_ROOT_PATH}/cocos/scripting/lua-bindings/script"
-    )
 if(APPLE OR VS)
     cocos_mark_multi_resources(res_res RES_TO "Resources/res" FOLDERS ${res_res_folders})
     cocos_mark_multi_resources(res_src RES_TO "Resources/src" FOLDERS ${res_src_folders})
-    cocos_mark_multi_resources(res_script RES_TO "Resources/src/cocos" FOLDERS ${res_script_folders})
     set(cc_common_res ${res_res} ${res_src} ${res_script})
 endif()
 
@@ -171,5 +167,4 @@ if(LINUX OR WINDOWS)
     set(APP_RES_DIR "$<TARGET_FILE_DIR:${APP_NAME}>/Resources")
     cocos_copy_target_res(${APP_NAME} COPY_TO ${APP_RES_DIR}/res FOLDERS ${res_res_folders})
     cocos_copy_target_res(${APP_NAME} COPY_TO ${APP_RES_DIR}/src FOLDERS ${res_src_folders})
-    cocos_copy_target_res(${APP_NAME} COPY_TO ${APP_RES_DIR}/src/cocos FOLDERS ${res_script_folders})
 endif()


### PR DESCRIPTION
fix Xcode `Version 10.2.1 (10E1001)` throw errors when build new lua project by cmake.

---
In `templates/lua-template-default/cocos-project-template.json` existed:
```
        "append_dir": [
            {
                "from": "cocos/scripting/lua-bindings/script",
                "to": "src/cocos",
                "exclude": []
            },
```
then `cocos new -l lua` will copy above files to `src/cocos`, so that twice copy caused by
```
cocos_mark_multi_resources(res_src RES_TO "Resources/src" FOLDERS ${res_src_folders})
cocos_mark_multi_resources(res_script RES_TO "Resources/src/cocos" FOLDERS ${res_script_folders})
```