### PR TITLE
refactor CCIMEDispatcher

### DIFF
--- a/cocos/base/CCIMEDelegate.h
+++ b/cocos/base/CCIMEDelegate.h
@@ -46,12 +46,12 @@ extern const std::string CC_DLL STD_STRING_EMPTY;
 /**
  * Keyboard notification event type.
  */
-typedef struct
+struct IMEKeyboardNotificationInfo
 {
     Rect  begin;              // the soft keyboard rectangle when animation begins
     Rect  end;                // the soft keyboard rectangle when animation ends
     float     duration;           // the soft keyboard animation duration
-} IMEKeyboardNotificationInfo;
+};
 
 /**
  *@brief    Input method editor delegate.
@@ -60,21 +60,21 @@ class CC_DLL IMEDelegate
 {
 public:
     /**
-     * Default constructor.
+     * Destructor.
      * @js NA
      * @lua NA
      */
     virtual ~IMEDelegate();
     
     /**
-     * Default destructor.
+     * Attach the delegate to IME. Return true if succesful.
      * @js NA
      * @lua NA
      */
     virtual bool attachWithIME();
     
     /**
-     * Determine whether the IME is detached or not.
+     * Detach the delegate from IME. Return true if succesful.
      * @js NA
      * @lua NA
      */
@@ -166,6 +166,7 @@ protected:
 
 protected:
     /**
+     * Default constructor.
      * @js NA
      * @lua NA
      */

--- a/cocos/base/CCIMEDispatcher.cpp
+++ b/cocos/base/CCIMEDispatcher.cpp
@@ -63,21 +63,10 @@ typedef std::list< IMEDelegate * >::iterator  DelegateIter;
 // Delegate List manage class
 //////////////////////////////////////////////////////////////////////////
 
-class IMEDispatcher::Impl
+struct IMEDispatcher::Impl
 {
-public:
-    Impl()
+    Impl() : _delegateWithIme(nullptr)
     {
-    }
-
-    ~Impl()
-    {
-
-    }
-
-    void init()
-    {
-        _delegateWithIme = 0;
     }
 
     DelegateIter findDelegate(IMEDelegate* delegate)
@@ -86,9 +75,7 @@ public:
         for (DelegateIter iter = _delegateList.begin(); iter != end; ++iter)
         {
             if (delegate == *iter)
-            {
                 return iter;
-            }
         }
         return end;
     }
@@ -104,7 +91,6 @@ public:
 IMEDispatcher::IMEDispatcher()
 : _impl(new IMEDispatcher::Impl)
 {
-    _impl->init();
 }
 
 IMEDispatcher::~IMEDispatcher()
@@ -137,11 +123,8 @@ bool IMEDispatcher::attachDelegateWithIME(IMEDelegate * delegate)
     {
         CC_BREAK_IF(! _impl || ! delegate);
 
-        DelegateIter end  = _impl->_delegateList.end();
-        DelegateIter iter = _impl->findDelegate(delegate);
-
         // if pDelegate is not in delegate list, return
-        CC_BREAK_IF(end == iter);
+        CC_BREAK_IF(_impl->findDelegate(delegate) == _impl->_delegateList.end());
 
         if (_impl->_delegateWithIme)
         {
@@ -155,10 +138,9 @@ bool IMEDispatcher::attachDelegateWithIME(IMEDelegate * delegate)
 
                 // detach first
                 IMEDelegate * oldDelegate = _impl->_delegateWithIme;
-                _impl->_delegateWithIme = 0;
                 oldDelegate->didDetachWithIME();
 
-                _impl->_delegateWithIme = *iter;
+                _impl->_delegateWithIme = delegate;
                 delegate->didAttachWithIME();
             }
             ret = true;
@@ -168,7 +150,7 @@ bool IMEDispatcher::attachDelegateWithIME(IMEDelegate * delegate)
         // delegate hasn't attached to IME yet
         CC_BREAK_IF(! delegate->canAttachWithIME());
 
-        _impl->_delegateWithIme = *iter;
+        _impl->_delegateWithIme = delegate;
         delegate->didAttachWithIME();
         ret = true;
     } while (0);
@@ -203,8 +185,6 @@ void IMEDispatcher::removeDelegate(IMEDelegate* delegate)
         DelegateIter iter = _impl->findDelegate(delegate);
         DelegateIter end  = _impl->_delegateList.end();
         CC_BREAK_IF(end == iter);
-
-        if (_impl->_delegateWithIme)
 
         if (*iter == _impl->_delegateWithIme)
         {
@@ -268,9 +248,7 @@ const std::string& IMEDispatcher::getContentText()
 
 bool IMEDispatcher::isAnyDelegateAttachedWithIME() const
 {
-    if (!_impl)
-        return false;
-    return _impl->_delegateWithIme != nullptr;
+    return _impl ? _impl->_delegateWithIme != nullptr : false;
 }
 
 //////////////////////////////////////////////////////////////////////////
@@ -281,15 +259,10 @@ void IMEDispatcher::dispatchKeyboardWillShow(IMEKeyboardNotificationInfo& info)
 {
     if (_impl)
     {
-        IMEDelegate * delegate = nullptr;
-        DelegateIter last = _impl->_delegateList.end();
-        for (DelegateIter first = _impl->_delegateList.begin(); first != last; ++first)
+        for (IMEDelegate *delegate : _impl->_delegateList)
         {
-            delegate = *(first);
             if (delegate)
-            {
                 delegate->keyboardWillShow(info);
-            }
         }
     }
 }
@@ -298,15 +271,10 @@ void IMEDispatcher::dispatchKeyboardDidShow(IMEKeyboardNotificationInfo& info)
 {
     if (_impl)
     {
-        IMEDelegate * delegate = nullptr;
-        DelegateIter last = _impl->_delegateList.end();
-        for (DelegateIter first = _impl->_delegateList.begin(); first != last; ++first)
+        for (IMEDelegate *delegate : _impl->_delegateList)
         {
-            delegate = *(first);
             if (delegate)
-            {
                 delegate->keyboardDidShow(info);
-            }
         }
     }
 }
@@ -315,15 +283,10 @@ void IMEDispatcher::dispatchKeyboardWillHide(IMEKeyboardNotificationInfo& info)
 {
     if (_impl)
     {
-        IMEDelegate * delegate = nullptr;
-        DelegateIter last = _impl->_delegateList.end();
-        for (DelegateIter first = _impl->_delegateList.begin(); first != last; ++first)
+        for (IMEDelegate *delegate : _impl->_delegateList)
         {
-            delegate = *(first);
             if (delegate)
-            {
                 delegate->keyboardWillHide(info);
-            }
         }
     }
 }
@@ -332,15 +295,10 @@ void IMEDispatcher::dispatchKeyboardDidHide(IMEKeyboardNotificationInfo& info)
 {
     if (_impl)
     {
-        IMEDelegate * delegate = nullptr;
-        DelegateIter last = _impl->_delegateList.end();
-        for (DelegateIter first = _impl->_delegateList.begin(); first != last; ++first)
+        for (IMEDelegate *delegate : _impl->_delegateList)
         {
-            delegate = *(first);
             if (delegate)
-            {
                 delegate->keyboardDidHide(info);
-            }
         }
     }
 }

--- a/cocos/base/CCIMEDispatcher.h
+++ b/cocos/base/CCIMEDispatcher.h
@@ -138,7 +138,7 @@ protected:
 private:
     IMEDispatcher();
     
-    class Impl;
+    struct Impl;
     Impl * _impl;
 };
 


### PR DESCRIPTION
I plan to add a new clang-tidy option here, but error message generated for these files are confusing. I ended up re-factoring them a bit.

* remove superfluous destructor
* use range-based for loop
* correct some documentation

```cpp
 if (_impl->_delegateWithIme)
```

The condition check above is not necessary, we are not dereferencing `_impl->_delegateWithIme` anyway.