### PR TITLE
 FIX ios bug : You don’t have permission to save the file “Documents_temp”

### DIFF
--- a/extensions/assets-manager/AssetsManagerEx.cpp
+++ b/extensions/assets-manager/AssetsManagerEx.cpp
@@ -314,7 +314,8 @@ void AssetsManagerEx::setStoragePath(const std::string& storagePath)
     _fileUtils->createDirectory(_storagePath);
     
     _tempStoragePath = _storagePath;
-    _tempStoragePath.insert(_storagePath.size() - 1, TEMP_PACKAGE_SUFFIX);
+    _tempStoragePath.insert(_storagePath.size(), TEMP_PACKAGE_SUFFIX);
+    adjustPath(_tempStoragePath);
     _fileUtils->createDirectory(_tempStoragePath);
 }
 

--- a/extensions/assets-manager/AssetsManagerEx.cpp
+++ b/extensions/assets-manager/AssetsManagerEx.cpp
@@ -38,7 +38,7 @@
 
 NS_CC_EXT_BEGIN
 
-#define TEMP_PACKAGE_SUFFIX     "_temp"
+#define TEMP_FOLDERNAME     "_temp"
 #define VERSION_FILENAME        "version.manifest"
 #define TEMP_MANIFEST_FILENAME  "project.manifest.temp"
 #define MANIFEST_FILENAME       "project.manifest"
@@ -314,7 +314,7 @@ void AssetsManagerEx::setStoragePath(const std::string& storagePath)
     _fileUtils->createDirectory(_storagePath);
     
     _tempStoragePath = _storagePath;
-    _tempStoragePath.insert(_storagePath.size(), TEMP_PACKAGE_SUFFIX);
+    _tempStoragePath.append(TEMP_FOLDERNAME);
     adjustPath(_tempStoragePath);
     _fileUtils->createDirectory(_tempStoragePath);
 }


### PR DESCRIPTION
The iOS side, eg:Writable directory is `**/Documents/`,old code will get `**/Documents_temp/`, However, due to the sandbox mechanism of iOS, you do not have the permission of this directory, so instead fixed it to `**/Documents/_temp/`