### PR TITLE
Android Studio Gradle Warning for API 'variant.getMergeAssets()'

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+ <!-- uncommment lines to show your screenshot -->
+<!--
+<div align="center"><img width="100%" height="100%" style="margin:auto" src="Screenshot.png"></div>
+<hr>  -->
+
+
 <img src="http://www.cocos2d-x.org/attachments/801/cocos2dx_portrait.png" width=200>
 
 
@@ -15,7 +21,7 @@ It works on iOS, Android, OS X, Windows, Linux and Web platforms.
 
 **Cocos2d-x Framework Architecture**:
 
-![](docs/framework_architecture.jpg "")
+![](https://raw.githubusercontent.com/cocos2d/cocos2d-x/v3/docs/framework_architecture.jpg "")
 
 cocos2d-x is:
 

--- a/templates/cpp-template-default/proj.android/app/build.gradle
+++ b/templates/cpp-template-default/proj.android/app/build.gradle
@@ -114,7 +114,7 @@ android.applicationVariants.all { variant ->
     // delete previous files first
     delete "${buildDir}/intermediates/assets/${variant.dirName}"
 
-    variant.mergeAssets.doLast {
+    variant.mergeAssetsProvider.get().doLast {
         copy {
             from "${buildDir}/../../../Resources"
             into "${buildDir}/intermediates/assets/${variant.dirName}"


### PR DESCRIPTION
_Based on issue #19683_
- cocos2d-x version: 3.17.1
- devices test on:
- developing environments
   - NDK version: r16b
   - Xcode version:
   - VS version: 2015
   - browser type and version:
   - Android Studio version: 3.3.2
Steps to Reproduce:

1. Open proj.android in Android Studio
2. Build and run project
3. Gradle Warning will be appear:
API 'variant.getMergeAssets()' is obsolete and has been replaced with 'variant.getMergeAssetsProvider()'.
It will be removed at the end of 2019.