### PR TITLE
add new clang-tidy option

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -10,6 +10,7 @@ Checks: >
   performance-type-promotion-in-math-fn,
   readability-container-size-empty,
   readability-delete-null-pointer,
+  readability-redundant-control-flow,
 
 WarningsAsErrors: '*'
 HeaderFilterRegex: '/(?!external)/.*'

--- a/cocos/2d/CCActionInterval.cpp
+++ b/cocos/2d/CCActionInterval.cpp
@@ -2425,7 +2425,6 @@ DelayTime* DelayTime::clone() const
 
 void DelayTime::update(float /*time*/)
 {
-    return;
 }
 
 DelayTime* DelayTime::reverse() const

--- a/cocos/3d/CCOBB.cpp
+++ b/cocos/3d/CCOBB.cpp
@@ -178,7 +178,6 @@ static void _getEigenVectors(Mat4* vout, Vec3* dout, Mat4 a)
     v.transpose();
     *vout = v;
     *dout = d;
-    return;
 }
 
 static Mat4 _getOBBOrientation(const Vec3* vertPos, int num)

--- a/cocos/network/SocketIO.cpp
+++ b/cocos/network/SocketIO.cpp
@@ -441,8 +441,6 @@ void SIOClientImpl::handshake()
     HttpClient::getInstance()->send(request);
 
     request->release();
-
-    return;
 }
 
 void SIOClientImpl::handshakeResponse(HttpClient* /*sender*/, HttpResponse *response)
@@ -562,9 +560,6 @@ void SIOClientImpl::handshakeResponse(HttpClient* /*sender*/, HttpResponse *resp
     _timeout = timeout;
 
     openSocket();
-
-    return;
-
 }
 
 void SIOClientImpl::openSocket()
@@ -593,8 +588,6 @@ void SIOClientImpl::openSocket()
     {
         CC_SAFE_DELETE(_ws);
     }
-
-    return;
 }
 
 bool SIOClientImpl::init()
@@ -1004,8 +997,6 @@ void SIOClientImpl::onMessage(WebSocket* /*ws*/, const WebSocket::Data& data)
         }
         break;
     }
-
-    return;
 }
 
 void SIOClientImpl::onClose(WebSocket* /*ws*/)

--- a/tests/cpp-tests/Classes/PhysicsTest/PhysicsTest.cpp
+++ b/tests/cpp-tests/Classes/PhysicsTest/PhysicsTest.cpp
@@ -1593,8 +1593,6 @@ void PhysicsPositionRotationTest::onEnter()
     body->setRotationOffset(45);
     body->setTag(DRAG_BODYS_TAG);
     addChild(offsetPosNode);
-    
-    return;
 }
 
 std::string PhysicsPositionRotationTest::title() const


### PR DESCRIPTION
* readability-redundant-control-flow

Reference: https://releases.llvm.org/7.0.0/tools/clang/tools/extra/docs/clang-tidy/checks/readability-redundant-control-flow.html