### PR TITLE
add new clang-tidy option

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -11,6 +11,7 @@ Checks: >
   readability-container-size-empty,
   readability-delete-null-pointer,
   readability-redundant-control-flow,
+  readability-redundant-string-cstr,
 
 WarningsAsErrors: '*'
 HeaderFilterRegex: '/(?!external)/.*'

--- a/cocos/audio/linux/SimpleAudioEngine.cpp
+++ b/cocos/audio/linux/SimpleAudioEngine.cpp
@@ -84,7 +84,7 @@ void SimpleAudioEngine::stopBackgroundMusic(bool releaseData)
 {
     AudioEngine::stop(g_SimpleAudioEngineLinux->musicid);
     if (releaseData) {
-        AudioEngine::uncache(g_SimpleAudioEngineLinux->musicpath.c_str());
+        AudioEngine::uncache(g_SimpleAudioEngineLinux->musicpath);
     }
 }
 

--- a/cocos/base/CCDataVisitor.cpp
+++ b/cocos/base/CCDataVisitor.cpp
@@ -203,7 +203,7 @@ void PrettyPrinter::visit(const __Set *p)
         if (i > 0) {
             _result += "\n";
         }
-        _result += _indentStr.c_str();
+        _result += _indentStr;
         PrettyPrinter v(_indentLevel);
 //FIXME:james        (*it)->acceptVisitor(v);
         _result += v.getResult();

--- a/cocos/editor-support/cocostudio/FlatBuffersSerialize.cpp
+++ b/cocos/editor-support/cocostudio/FlatBuffersSerialize.cpp
@@ -577,7 +577,7 @@ Offset<NodeAction> FlatBuffersSerialize::createNodeAction(const tinyxml2::XMLEle
         }
         else if (name == "ActivedAnimationName")
         {
-            currentAnimationName = value.c_str();
+            currentAnimationName = value;
         }
         
         attribute = attribute->Next();

--- a/cocos/network/SocketIO.cpp
+++ b/cocos/network/SocketIO.cpp
@@ -720,7 +720,7 @@ void SIOClientImpl::send(SocketIOPacket *packet)
     if (_connected)
     {
         CCLOGINFO("-->SEND:%s", req.data());
-        _ws->send(req.data());
+        _ws->send(req);
     }
     else
         CCLOGINFO("Cant send the message (%s) because disconnected", req.c_str());
@@ -757,7 +757,7 @@ void SIOClientImpl::onOpen(WebSocket* /*ws*/)
     if (_version == SocketIOPacket::SocketIOVersion::V10x)
     {
         std::string s = "5";//That's a ping https://github.com/Automattic/engine.io-parser/blob/1b8e077b2218f4947a69f5ad18be2a512ed54e93/lib/index.js#L21
-        _ws->send(s.data());
+        _ws->send(s);
     }
 
     Director::getInstance()->getScheduler()->schedule(CC_SCHEDULE_SELECTOR(SIOClientImpl::heartbeat), this, (_heartbeat * .9f), false);

--- a/cocos/platform/linux/CCDevice-linux.cpp
+++ b/cocos/platform/linux/CCDevice-linux.cpp
@@ -349,7 +349,7 @@ public:
         std::string lowerCasePath = fontPath;
         std::transform(lowerCasePath.begin(), lowerCasePath.end(), lowerCasePath.begin(), ::tolower);
         if ( lowerCasePath.find(".ttf") != std::string::npos ) {
-            fontPath = cocos2d::FileUtils::getInstance()->fullPathForFilename(fontPath.c_str());
+            fontPath = cocos2d::FileUtils::getInstance()->fullPathForFilename(fontPath);
 
             FILE *f = fopen(fontPath.c_str(), "r");
             if ( f ) {

--- a/cocos/scripting/js-bindings/manual/3d/jsb_cocos2dx_3d_manual.cpp
+++ b/cocos/scripting/js-bindings/manual/3d/jsb_cocos2dx_3d_manual.cpp
@@ -239,7 +239,7 @@ bool jsval_to_TerrainData(JSContext* cx, JS::HandleValue v, Terrain::TerrainData
         JS::ToNumber(cx, js_mapHeight, &mapHeight);
     JSB_PRECONDITION2(ok, cx, false, "Error processing arguments");
 
-    ret->_heightMapSrc = heightMap.c_str();
+    ret->_heightMapSrc = heightMap;
     char* tmp = (char*)malloc(sizeof(char) * (alphaMap.size() + 1));
     strcpy(tmp, alphaMap.c_str());
     tmp[alphaMap.size()] = '\0';

--- a/cocos/scripting/lua-bindings/manual/CCLuaStack.cpp
+++ b/cocos/scripting/lua-bindings/manual/CCLuaStack.cpp
@@ -801,7 +801,7 @@ int LuaStack::luaLoadChunksFromZIP(lua_State *L)
             std::string filename = zip->getFirstFilename();
             while (filename.length()) {
                 ssize_t bufferSize = 0;
-                unsigned char *zbuffer = zip->getFileData(filename.c_str(), &bufferSize);
+                unsigned char *zbuffer = zip->getFileData(filename, &bufferSize);
                 if (bufferSize) {
                     // remove .lua or .luac extension
                     size_t pos = filename.find_last_of('.');

--- a/cocos/scripting/lua-bindings/manual/cocos2d/lua_cocos2dx_manual.cpp
+++ b/cocos/scripting/lua-bindings/manual/cocos2d/lua_cocos2dx_manual.cpp
@@ -3779,7 +3779,7 @@ static int tolua_cocos2dx_FileUtils_getStringFromFile(lua_State* tolua_S)
         if (ok)
         {
             std::string fullPathName = FileUtils::getInstance()->fullPathForFilename(arg0);
-            __String* contentsOfFile = __String::createWithContentsOfFile(fullPathName.c_str());
+            __String* contentsOfFile = __String::createWithContentsOfFile(fullPathName);
             if (nullptr != contentsOfFile)
             {
                 const char* tolua_ret = contentsOfFile->getCString();

--- a/cocos/scripting/lua-bindings/manual/cocos2d/lua_cocos2dx_physics_manual.cpp
+++ b/cocos/scripting/lua-bindings/manual/cocos2d/lua_cocos2dx_physics_manual.cpp
@@ -135,7 +135,7 @@ int lua_cocos2dx_physics_PhysicsWorld_getScene(lua_State* tolua_S)
             auto iter = g_luaType.find(hashName);
             std::string className = "";
             if(iter != g_luaType.end()){
-                className = iter->second.c_str();
+                className = iter->second;
             } else {
                 className = "cc.Scene";
             }

--- a/extensions/assets-manager/AssetsManager.cpp
+++ b/extensions/assets-manager/AssetsManager.cpp
@@ -226,7 +226,7 @@ void AssetsManager::downloadAndUncompress()
             Director::getInstance()->getScheduler()->performFunctionInCocosThread([&, this] {
                 
                 // Record new version code.
-                UserDefault::getInstance()->setStringForKey(this->keyOfVersion().c_str(), this->_version.c_str());
+                UserDefault::getInstance()->setStringForKey(this->keyOfVersion().c_str(), this->_version);
                 
                 // Unrecord downloaded version code.
                 UserDefault::getInstance()->setStringForKey(this->keyOfDownloadedVersion().c_str(), "");

--- a/tests/cpp-tests/Classes/Box2DTestBed/Box2dView.cpp
+++ b/tests/cpp-tests/Classes/Box2DTestBed/Box2dView.cpp
@@ -92,7 +92,7 @@ bool Box2dTestBed::initWithEntryID(int entryId)
     view->setScale(15);
     view->setAnchorPoint( Vec2(0,0) );
     view->setPosition(visibleOrigin.x+visibleSize.width/2, visibleOrigin.y+visibleSize.height/3);
-    auto label = Label::createWithTTF(view->title().c_str(), "fonts/arial.ttf", 28);
+    auto label = Label::createWithTTF(view->title(), "fonts/arial.ttf", 28);
     addChild(label, 1);
     label->setPosition(visibleOrigin.x+visibleSize.width/2, visibleOrigin.y+visibleSize.height-50);
     

--- a/tests/cpp-tests/Classes/DataVisitorTest/DataVisitorTest.cpp
+++ b/tests/cpp-tests/Classes/DataVisitorTest/DataVisitorTest.cpp
@@ -69,14 +69,14 @@ void PrettyPrinterDemo::onEnter()
     TestCase::onEnter();
     auto s = Director::getInstance()->getWinSize();
     
-    auto label = Label::createWithTTF(title().c_str(), "fonts/arial.ttf", 28);
+    auto label = Label::createWithTTF(title(), "fonts/arial.ttf", 28);
     label->setPosition(s.width/2, s.height * 4/5);
     this->addChild(label, 1);
     
     std::string strSubtitle = subtitle();
     if(strSubtitle.empty() == false)
     {
-        auto subLabel = Label::createWithTTF(strSubtitle.c_str(), "fonts/Thonburi.ttf", 16);
+        auto subLabel = Label::createWithTTF(strSubtitle, "fonts/Thonburi.ttf", 16);
         subLabel->setPosition(s.width/2, s.height * 3/5);
         this->addChild(subLabel, 1);
     }

--- a/tests/cpp-tests/Classes/ExtensionsTest/NetworkTest/SocketIOTest.cpp
+++ b/tests/cpp-tests/Classes/ExtensionsTest/NetworkTest/SocketIOTest.cpp
@@ -120,7 +120,7 @@ void SocketIOTest::testevent(SIOClient *client, const std::string& data) {
 	std::stringstream s;
 	s << client->getTag() << " received event testevent with data: " << data.c_str();
 
-	_sioClientStatus->setString(s.str().c_str());
+	_sioClientStatus->setString(s.str());
 
 }
 
@@ -131,7 +131,7 @@ void SocketIOTest::echotest(SIOClient *client, const std::string& data) {
 	std::stringstream s;
 	s << client->getTag() << " received event echotest with data: " << data.c_str();
 
-	_sioClientStatus->setString(s.str().c_str());
+	_sioClientStatus->setString(s.str());
 
 }
 
@@ -143,7 +143,7 @@ void SocketIOTest::message(network::SIOClient* client, const std::string& data)
 
 	std::stringstream s;
 	s << client->getTag() << " received message with content: " << data.c_str();
-	_sioClientStatus->setString(s.str().c_str());
+	_sioClientStatus->setString(s.str());
 
 }
 
@@ -153,7 +153,7 @@ void SocketIOTest::json(network::SIOClient* client, const std::string& data)
 
 	std::stringstream s;
 	s << client->getTag() << " received json message with content: " << data.c_str();
-	_sioClientStatus->setString(s.str().c_str());
+	_sioClientStatus->setString(s.str());
 
 }
 
@@ -163,7 +163,7 @@ void SocketIOTest::connect(network::SIOClient* client, const std::string& data)
 
 	std::stringstream s;
 	s << client->getTag() << " connected!";
-	_sioClientStatus->setString(s.str().c_str());
+	_sioClientStatus->setString(s.str());
 
 }
 
@@ -173,7 +173,7 @@ void SocketIOTest::disconnect(network::SIOClient* client, const std::string& dat
 
 	std::stringstream s;
 	s << client->getTag() << " disconnected by server!";
-	_sioClientStatus->setString(s.str().c_str());
+	_sioClientStatus->setString(s.str());
 
 	this->closedSocketAction(client);
 
@@ -271,7 +271,7 @@ void SocketIOTest::onMenuTestClientDisconnectClicked(cocos2d::Ref *sender)
 		s << "Socket.io Test Client not initialized!";
 	}
 
-	_sioClientStatus->setString(s.str().c_str());
+	_sioClientStatus->setString(s.str());
 
 }
 
@@ -288,7 +288,7 @@ void SocketIOTest::onMenuTestEndpointDisconnectClicked(cocos2d::Ref *sender)
 		s << "Socket.io Test Endpoint not initialized!";
 	}
 
-	_sioClientStatus->setString(s.str().c_str());
+	_sioClientStatus->setString(s.str());
 
 }
 
@@ -300,7 +300,7 @@ void SocketIOTest::onClose(network::SIOClient* client)
 
 	std::stringstream s;
 	s << client->getTag() << " closed!";
-	_sioClientStatus->setString(s.str().c_str());
+	_sioClientStatus->setString(s.str());
 
 	this->closedSocketAction(client);
 
@@ -312,5 +312,5 @@ void SocketIOTest::onError(network::SIOClient* client, const std::string& data)
 
 	std::stringstream s;
 	s << client->getTag() << " received error with content: " << data.c_str();
-	_sioClientStatus->setString(s.str().c_str());
+	_sioClientStatus->setString(s.str());
 }

--- a/tests/cpp-tests/Classes/ExtensionsTest/NetworkTest/WebSocketDelayTest.cpp
+++ b/tests/cpp-tests/Classes/ExtensionsTest/NetworkTest/WebSocketDelayTest.cpp
@@ -213,6 +213,6 @@ void WebSocketDelayTest::onMenuSendTextClicked(cocos2d::Ref *sender)
     {
         std::string warningStr = "send text websocket instance wasn't ready...";
         log("%s", warningStr.c_str());
-        _sendTextStatus->setString(warningStr.c_str());
+        _sendTextStatus->setString(warningStr);
     }
 }

--- a/tests/cpp-tests/Classes/ExtensionsTest/NetworkTest/WebSocketTest.cpp
+++ b/tests/cpp-tests/Classes/ExtensionsTest/NetworkTest/WebSocketTest.cpp
@@ -197,7 +197,7 @@ void WebSocketTest::onMessage(network::WebSocket* ws, const network::WebSocket::
         std::string textStr = std::string("response text msg: ")+data.bytes+", "+times;
         log("%s", textStr.c_str());
         
-        _sendTextStatus->setString(textStr.c_str());
+        _sendTextStatus->setString(textStr);
     }
     else
     {
@@ -220,7 +220,7 @@ void WebSocketTest::onMessage(network::WebSocket* ws, const network::WebSocket::
         
         binaryStr += std::string(", ")+times;
         log("%s", binaryStr.c_str());
-        _sendBinaryStatus->setString(binaryStr.c_str());
+        _sendBinaryStatus->setString(binaryStr);
     }
 }
 
@@ -285,7 +285,7 @@ void WebSocketTest::onMenuSendTextClicked(cocos2d::Ref *sender)
     {
         std::string warningStr = "send text websocket instance wasn't ready...";
         log("%s", warningStr.c_str());
-        _sendTextStatus->setString(warningStr.c_str());
+        _sendTextStatus->setString(warningStr);
     }
 }
 
@@ -307,7 +307,7 @@ void WebSocketTest::onMenuSendMultipleTextClicked(cocos2d::Ref *sender)
     {
         std::string warningStr = "send text websocket instance wasn't ready...";
         log("%s", warningStr.c_str());
-        _sendTextStatus->setString(warningStr.c_str());
+        _sendTextStatus->setString(warningStr);
     }
 }
 
@@ -327,7 +327,7 @@ void WebSocketTest::onMenuSendBinaryClicked(cocos2d::Ref *sender)
     {
         std::string warningStr = "send binary websocket instance wasn't ready...";
         log("%s", warningStr.c_str());
-        _sendBinaryStatus->setString(warningStr.c_str());
+        _sendBinaryStatus->setString(warningStr);
     }
 }
 

--- a/tests/cpp-tests/Classes/FileUtilsTest/FileUtilsTest.cpp
+++ b/tests/cpp-tests/Classes/FileUtilsTest/FileUtilsTest.cpp
@@ -563,7 +563,7 @@ void TextWritePlist::onEnter()
     else
         log("write plist file failed");
 
-    auto label = Label::createWithTTF(fullPath.c_str(), "fonts/Thonburi.ttf", 6);
+    auto label = Label::createWithTTF(fullPath, "fonts/Thonburi.ttf", 6);
     this->addChild(label);
     auto winSize = Director::getInstance()->getWinSize();
     label->setPosition(winSize.width/2, winSize.height/3);
@@ -593,7 +593,7 @@ std::string TextWritePlist::title() const
 
 std::string TextWritePlist::subtitle() const
 {
-    std::string writablePath = FileUtils::getInstance()->getWritablePath().c_str();
+    std::string writablePath = FileUtils::getInstance()->getWritablePath();
     return ("See plist file at your writablePath");
 }
 
@@ -617,7 +617,7 @@ void TestWriteString::onEnter()
     // writeTest
     std::string writeDataStr = "the string data will be write into a file";
     std::string fullPath = writablePath + fileName;
-    if (FileUtils::getInstance()->writeStringToFile(writeDataStr, fullPath.c_str()))
+    if (FileUtils::getInstance()->writeStringToFile(writeDataStr, fullPath))
     {
         log("see the plist file at %s", fullPath.c_str());
         writeResult->setString("write success:" + writeDataStr);
@@ -793,7 +793,7 @@ void TestWriteData::onEnter()
     Data writeData;
     writeData.copy((unsigned char *)writeDataStr.c_str(), writeDataStr.size());
     std::string fullPath = writablePath + fileName;
-    if (FileUtils::getInstance()->writeDataToFile(writeData, fullPath.c_str()))
+    if (FileUtils::getInstance()->writeDataToFile(writeData, fullPath))
     {
         log("see the plist file at %s", fullPath.c_str());
         writeResult->setString("write success:" + writeDataStr);
@@ -881,7 +881,7 @@ void TestWriteValueMap::onEnter()
     // end with /
     std::string writablePath = FileUtils::getInstance()->getWritablePath();
     std::string fullPath = writablePath + "testWriteValueMap.plist";
-    if (FileUtils::getInstance()->writeValueMapToFile(valueMap, fullPath.c_str()))
+    if (FileUtils::getInstance()->writeValueMapToFile(valueMap, fullPath))
     {
         log("see the plist file at %s", fullPath.c_str());
         writeResult->setString("write success");
@@ -892,7 +892,7 @@ void TestWriteValueMap::onEnter()
         writeResult->setString("write failed");
     }
 
-    ValueMap readValueMap = FileUtils::getInstance()->getValueMapFromFile(fullPath.c_str());
+    ValueMap readValueMap = FileUtils::getInstance()->getValueMapFromFile(fullPath);
     std::string readDataStr = "read data:\n";
     // read value map data
     ValueMap readMapInMap = readValueMap["data0"].asValueMap();
@@ -984,7 +984,7 @@ void TestWriteValueVector::onEnter()
     // end with /
     std::string writablePath = FileUtils::getInstance()->getWritablePath();
     std::string fullPath = writablePath + "testWriteValueVector.plist";
-    if (FileUtils::getInstance()->writeValueVectorToFile(array, fullPath.c_str()))
+    if (FileUtils::getInstance()->writeValueVectorToFile(array, fullPath))
     {
         log("see the plist file at %s", fullPath.c_str());
         writeResult->setString("write success");
@@ -995,7 +995,7 @@ void TestWriteValueVector::onEnter()
         writeResult->setString("write failed");
     }
 
-    ValueVector readArray = FileUtils::getInstance()->getValueVectorFromFile(fullPath.c_str());
+    ValueVector readArray = FileUtils::getInstance()->getValueVectorFromFile(fullPath);
     std::string readDataStr = "read data:\n";
     // read value map data
     ValueMap readMapInArray = readArray.at(0).asValueMap();

--- a/tests/cpp-tests/Classes/InputTest/MouseTest.cpp
+++ b/tests/cpp-tests/Classes/InputTest/MouseTest.cpp
@@ -74,7 +74,7 @@ void MouseEventTest::onMouseDown(Event *event)
     EventMouse* e = (EventMouse*)event;
     std::string str = "Mouse Down detected, Key: ";
     str += tostr(static_cast<int>(e->getMouseButton()));
-    _labelAction->setString(str.c_str());
+    _labelAction->setString(str);
 }
 
 void MouseEventTest::onMouseUp(Event *event)
@@ -82,7 +82,7 @@ void MouseEventTest::onMouseUp(Event *event)
     EventMouse* e = (EventMouse*)event;
     std::string str = "Mouse Up detected, Key: ";
     str += tostr(static_cast<int>(e->getMouseButton()));
-    _labelAction->setString(str.c_str());
+    _labelAction->setString(str);
 }
 
 void MouseEventTest::onMouseMove(Event *event)
@@ -90,7 +90,7 @@ void MouseEventTest::onMouseMove(Event *event)
     EventMouse* e = (EventMouse*)event;
     std::string str = "MousePosition X:";
     str = str + tostr(e->getCursorX()) + " Y:" + tostr(e->getCursorY());
-    _labelPosition->setString(str.c_str());
+    _labelPosition->setString(str);
 }
 
 void MouseEventTest::onMouseScroll(Event *event)
@@ -98,7 +98,7 @@ void MouseEventTest::onMouseScroll(Event *event)
     EventMouse* e = (EventMouse*)event;
     std::string str = "Mouse Scroll detected, X: ";
     str = str + tostr(e->getScrollX()) + " Y: " + tostr(e->getScrollY());
-    _labelAction->setString(str.c_str());
+    _labelAction->setString(str);
 }
 
 std::string MouseEventTest::title() const

--- a/tests/cpp-tests/Classes/NewEventDispatcherTest/NewEventDispatcherTest.cpp
+++ b/tests/cpp-tests/Classes/NewEventDispatcherTest/NewEventDispatcherTest.cpp
@@ -392,7 +392,7 @@ void CustomEventTest::onEnter()
         char* buf = static_cast<char*>(event->getUserData());
         str += buf;
         str += " times";
-        statusLabel->setString(str.c_str());
+        statusLabel->setString(str);
     });
     
     _eventDispatcher->addEventListenerWithFixedPriority(_listener, 1);
@@ -418,7 +418,7 @@ void CustomEventTest::onEnter()
         char* buf = static_cast<char*>(event->getUserData());
         str += buf;
         str += " times";
-        statusLabel2->setString(str.c_str());
+        statusLabel2->setString(str);
     });
     
     _eventDispatcher->addEventListenerWithFixedPriority(_listener2, 1);

--- a/tests/cpp-tests/Classes/Texture2dTest/Texture2dTest.cpp
+++ b/tests/cpp-tests/Classes/Texture2dTest/Texture2dTest.cpp
@@ -1943,7 +1943,7 @@ void TextureMemoryAlloc::updateImage(cocos2d::Ref *sender)
             break;
 	}
 
-    _background = Sprite::create(file.c_str());
+    _background = Sprite::create(file);
     addChild(_background, -10);
 	
     _background->setVisible(false);

--- a/tests/cpp-tests/Classes/TileMapTest/TileMapTest.cpp
+++ b/tests/cpp-tests/Classes/TileMapTest/TileMapTest.cpp
@@ -1362,10 +1362,10 @@ TMXOrthoFromXMLTest::TMXOrthoFromXMLTest()
     std::string resources = "TileMaps";        // partial paths are OK as resource paths.
     std::string file = resources + "/orthogonal-test1.tmx";
 
-    auto str = __String::createWithContentsOfFile(FileUtils::getInstance()->fullPathForFilename(file.c_str()).c_str());
+    auto str = __String::createWithContentsOfFile(FileUtils::getInstance()->fullPathForFilename(file));
     CCASSERT(str != nullptr, "Unable to open file");
 
-    auto map = TMXTiledMap::createWithXML(str->getCString() ,resources.c_str());
+    auto map = TMXTiledMap::createWithXML(str->getCString() ,resources);
     addChild(map, 0, kTagTileMap);
 
     auto s = map->getContentSize();

--- a/tests/cpp-tests/Classes/TileMapTest/TileMapTest2.cpp
+++ b/tests/cpp-tests/Classes/TileMapTest/TileMapTest2.cpp
@@ -1235,10 +1235,10 @@ TMXOrthoFromXMLTestNew::TMXOrthoFromXMLTestNew()
     std::string resources = "TileMaps";        // partial paths are OK as resource paths.
     std::string file = resources + "/orthogonal-test1.tmx";
 
-    auto str = __String::createWithContentsOfFile(FileUtils::getInstance()->fullPathForFilename(file.c_str()).c_str());
+    auto str = __String::createWithContentsOfFile(FileUtils::getInstance()->fullPathForFilename(file));
     CCASSERT(str != nullptr, "Unable to open file");
 
-    auto map = cocos2d::experimental::TMXTiledMap::createWithXML(str->getCString() ,resources.c_str());
+    auto map = cocos2d::experimental::TMXTiledMap::createWithXML(str->getCString() ,resources);
     addChild(map, 0, kTagTileMap);
 
     auto s = map->getContentSize();


### PR DESCRIPTION
* readability-redundant-string-cstr

Reference: https://releases.llvm.org/7.0.0/tools/clang/tools/extra/docs/clang-tidy/checks/readability-redundant-string-cstr.html