### PR TITLE
[cpp-test] remove bad test case

### DIFF
--- a/tests/cpp-tests/Classes/Sprite3DTest/Sprite3DTest.cpp
+++ b/tests/cpp-tests/Classes/Sprite3DTest/Sprite3DTest.cpp
@@ -64,7 +64,6 @@ Sprite3DTests::Sprite3DTests()
     ADD_TEST_CASE(NodeAnimationTest);
     ADD_TEST_CASE(Issue9767);
     ADD_TEST_CASE(Sprite3DClippingTest);
-//    ADD_TEST_CASE(Sprite3DTestMeshLight); //TODO coulsonwang missing attibute data in Sprite3DTest/mesh_model.c3b
     ADD_TEST_CASE(Animate3DCallbackTest);
     ADD_TEST_CASE(CameraBackgroundClearTest);
     ADD_TEST_CASE(Sprite3DVertexColorTest);
@@ -2349,37 +2348,6 @@ std::string Animate3DCallbackTest::subtitle() const
     return "";
 }
 
-Sprite3DTestMeshLight::Sprite3DTestMeshLight()
-{
-    auto s = Director::getInstance()->getWinSize();
-
-    auto _sprite = Sprite3D::create("Sprite3DTest/mesh_model.c3b");
-    _sprite->setPosition(Vec2(0, 0));
-    _sprite->setScale(0.05f);
-    _sprite->setCameraMask(2);
-
-    PointLight * light = PointLight::create(Vec3(0, 0, 400), Color3B(255, 255, 255), 1000.0f);
-
-    //setup camera
-    auto camera = Camera::createPerspective(40, s.width / s.height, 0.01f, 1000.f);
-    camera->setCameraFlag(CameraFlag::USER1);
-    camera->setPosition3D(Vec3(0.f, 30.f, 100.f));
-    camera->lookAt(Vec3(0.f, 0.f, 0.f));
-    addChild(camera);
-
-    addChild(_sprite);
-    addChild(light);
-}
-
-std::string Sprite3DTestMeshLight::title() const
-{
-    return "3D mesh with light without texture";
-}
-
-std::string Sprite3DTestMeshLight::subtitle() const
-{
-    return "";
-}
 
 Sprite3DVertexColorTest::Sprite3DVertexColorTest()
 {

--- a/tests/cpp-tests/Classes/Sprite3DTest/Sprite3DTest.h
+++ b/tests/cpp-tests/Classes/Sprite3DTest/Sprite3DTest.h
@@ -531,18 +531,6 @@ protected:
     cocos2d::Sprite3D* _sprite3d;
 };
 
-class Sprite3DTestMeshLight : public Sprite3DTestDemo
-{
-public:
-    CREATE_FUNC(Sprite3DTestMeshLight);
-    Sprite3DTestMeshLight();
-    virtual std::string title() const override;
-    virtual std::string subtitle() const override;
-
-protected:
-    cocos2d::Sprite3D* _sprite;
-};
-
 class CameraBackgroundClearTest : public Sprite3DTestDemo
 {
 public:


### PR DESCRIPTION
Remove test `Sprite3D tests/3D mesh with light without texture`
Since the vertex data of "Sprite3DTest/mesh_model.c3b" is incorrect, which can cause a crash in metal. 