### PR TITLE
fix toupper function call

### DIFF
--- a/cocos/renderer/CCRenderState.cpp
+++ b/cocos/renderer/CCRenderState.cpp
@@ -481,7 +481,8 @@ static RenderState::Blend parseBlend(const std::string& value)
 {
     // Convert the string to uppercase for comparison.
     std::string upper(value);
-    std::transform(upper.begin(), upper.end(), upper.begin(), (int(*)(int))toupper);
+    std::transform(upper.begin(), upper.end(), upper.begin(), [](unsigned char c) {
+        return std::toupper(c);});
     if (upper == "ZERO")
         return RenderState::BLEND_ZERO;
     else if (upper == "ONE")

--- a/cocos/renderer/CCRenderState.cpp
+++ b/cocos/renderer/CCRenderState.cpp
@@ -27,6 +27,7 @@
 
 #include "renderer/CCRenderState.h"
 
+#include <cctype>
 #include <string>
 
 #include "renderer/CCTexture2D.h"


### PR DESCRIPTION
* Original pointer cast does nothing, as it doesn't change signature
* toupper arugment type should be unsigned char

Reference: https://en.cppreference.com/w/cpp/string/byte/toupper