### PR TITLE
fixed vertex counter for statistic in drawing of batched triangles

### DIFF
--- a/cocos/renderer/CCRenderer.cpp
+++ b/cocos/renderer/CCRenderer.cpp
@@ -848,8 +848,9 @@ void Renderer::drawBatchedTriangles()
         _triBatchesToDraw[i].cmd->useMaterial();
         glDrawElements(GL_TRIANGLES, (GLsizei) _triBatchesToDraw[i].indicesToDraw, GL_UNSIGNED_SHORT, (GLvoid*) (_triBatchesToDraw[i].offset*sizeof(_indices[0])) );
         _drawnBatches++;
-        _drawnVertices += _triBatchesToDraw[i].indicesToDraw;
     }
+ 
+    _drawnVertices += _filledVertex;
 
     /************** 4: Cleanup *************/
     if (conf->supportsShareableVAO() && conf->supportsMapBuffer())


### PR DESCRIPTION
In drawing of batched triangles a count of indices (not vertices) appends to a general count for statistic. Therefore for one sprite gl verts is equal six (not four).