### PR TITLE
Fix removing single symbol to the right of the cursor by Backspace

### DIFF
--- a/cocos/2d/CCTextFieldTTF.cpp
+++ b/cocos/2d/CCTextFieldTTF.cpp
@@ -305,6 +305,12 @@ void TextFieldTTF::deleteBackward()
         return;
     }
 
+    if (_cursorEnabled && (_cursorPosition == 0))
+    {
+        // Nothing to delete. Cursor is at the beginning of string.
+        return;
+    }
+
     // get the delete byte number
     size_t deleteLen = 1;    // default, erase 1 byte
 


### PR DESCRIPTION
Fixed the problem when the string contains only one symbol and the cursor is at the beginning of the string this symbol is removed when Backspace key is pressed.