### PR TITLE
Feature/sprite etc1 alpha support test

### DIFF
--- a/cocos/2d/CCSprite.cpp
+++ b/cocos/2d/CCSprite.cpp
@@ -403,11 +403,9 @@ void Sprite::setProgramState(backend::ProgramState *programState)
 
 void Sprite::setTexture(Texture2D *texture)
 {
-    if(_programState == nullptr)
-    {
-        auto isETC1 = texture && texture->getAlphaTextureName();
-        updateShaders(positionTextureColor_vert, (isETC1) ? etc1_frag : positionTextureColor_frag);
-    }
+    auto isETC1 = texture && texture->getAlphaTextureName();
+    updateShaders(positionTextureColor_vert, (isETC1) ? etc1_frag : positionTextureColor_frag);
+    
     CCASSERT(! _batchNode || (texture &&  texture == _batchNode->getTexture()), "CCSprite: Batched sprites should use the same texture as the batchnode");
     // accept texture==nil as argument
     CCASSERT( !texture || dynamic_cast<Texture2D*>(texture), "setTexture expects a Texture2D. Invalid argument");

--- a/cocos/2d/CCSprite.cpp
+++ b/cocos/2d/CCSprite.cpp
@@ -403,9 +403,11 @@ void Sprite::setProgramState(backend::ProgramState *programState)
 
 void Sprite::setTexture(Texture2D *texture)
 {
-    auto isETC1 = texture && texture->getAlphaTextureName();
-    updateShaders(positionTextureColor_vert, (isETC1) ? etc1_frag : positionTextureColor_frag);
-    
+    if(_programState == nullptr)
+    {
+        auto isETC1 = texture && texture->getAlphaTextureName();
+        updateShaders(positionTextureColor_vert, (isETC1) ? etc1_frag : positionTextureColor_frag);
+    }
     CCASSERT(! _batchNode || (texture &&  texture == _batchNode->getTexture()), "CCSprite: Batched sprites should use the same texture as the batchnode");
     // accept texture==nil as argument
     CCASSERT( !texture || dynamic_cast<Texture2D*>(texture), "setTexture expects a Texture2D. Invalid argument");

--- a/cocos/renderer/CCTexture2D.cpp
+++ b/cocos/renderer/CCTexture2D.cpp
@@ -364,7 +364,7 @@ bool Texture2D::initWithMipmaps(MipmapInfo* mipmaps, int mipmapsNum, PixelFormat
 
     size_t dataLen = mipmaps[0].len;
     unsigned char *outData = data;
-    size_t outDataLen;
+    size_t outDataLen = dataLen;
     
     if(renderFormat != pixelFormat) //need conversion
     {
@@ -374,7 +374,7 @@ bool Texture2D::initWithMipmaps(MipmapInfo* mipmaps, int mipmapsNum, PixelFormat
 #endif
         if(convertedFormat == renderFormat) pixelFormat = renderFormat;
     }
-
+    textureDescriptor.datalen = outDataLen;
     backend::StringUtils::PixelFormat format = static_cast<backend::StringUtils::PixelFormat>(pixelFormat);
     CCASSERT(format != backend::StringUtils::PixelFormat::NONE, "PixelFormat should not be NONE");
     

--- a/cocos/renderer/backend/Texture.h
+++ b/cocos/renderer/backend/Texture.h
@@ -16,6 +16,7 @@ struct TextureDescriptor
     uint32_t width = 0;
     uint32_t height = 0;
     uint32_t depth = 0;
+    uint32_t datalen = 0;
     bool compressed = false;
     SamplerDescriptor samplerDescriptor;
 };
@@ -61,7 +62,7 @@ protected:
     Texture2D(const TextureDescriptor& descriptor);
     uint32_t _width = 0;
     uint32_t _height = 0;
-
+    uint32_t _datalen = 0;
 };
 
 class TextureCubemap : public Texture

--- a/cocos/renderer/backend/opengl/TextureGL.cpp
+++ b/cocos/renderer/backend/opengl/TextureGL.cpp
@@ -76,6 +76,7 @@ void Texture2DGL::updateTextureDescriptor(const cocos2d::backend::TextureDescrip
     UtilsGL::toGLTypes(descriptor.textureFormat, _textureInfo.internalFormat, _textureInfo.format, _textureInfo.type, _isCompressed);
     _width = descriptor.width;
     _height = descriptor.height;
+    _datalen = descriptor.datalen;
     updateSamplerDescriptor(descriptor.samplerDescriptor);
     initWithZeros();
 }
@@ -159,8 +160,7 @@ void Texture2DGL::updateData(uint8_t* data)
 
     if(_isCompressed)
     {
-        auto datalen = _width * _height * _bitsPerElement / 8;
-        glCompressedTexImage2D(GL_TEXTURE_2D, 0, _textureInfo.internalFormat, (GLsizei)_width, (GLsizei)_height, 0, datalen, data);
+        glCompressedTexImage2D(GL_TEXTURE_2D, 0, _textureInfo.internalFormat, (GLsizei)_width, (GLsizei)_height, 0, _datalen, data);
     }
     else
     {


### PR DESCRIPTION
1. no need to update shader when it had been set before; 
2. set compressed texture data length correctly.