### PR TITLE
[win32] suppress compile warnings 

### DIFF
--- a/cmake/Modules/CocosBuildHelpers.cmake
+++ b/cmake/Modules/CocosBuildHelpers.cmake
@@ -188,7 +188,7 @@ function(setup_cocos_app_config app_name)
         set_target_properties(${app_name} PROPERTIES MACOSX_BUNDLE 1)
     elseif(MSVC)
         # visual studio default is Console app, but we need Windows app
-        set_property(TARGET ${app_name} APPEND PROPERTY LINK_FLAGS "/SUBSYSTEM:WINDOWS")
+        set_property(TARGET ${app_name} APPEND_STRING PROPERTY LINK_FLAGS "/SUBSYSTEM:WINDOWS /IGNORE:4099")
     endif()
     # auto mark code files for IDE when mark app
     if(XCODE OR VS)

--- a/cocos/CMakeLists.txt
+++ b/cocos/CMakeLists.txt
@@ -153,7 +153,7 @@ endif()
 if(WINDOWS)
     # precompiled header. Compilation time speedup ~4x.
     target_sources(cocos2d PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/precheader.cpp")
-    set_target_properties(cocos2d PROPERTIES COMPILE_FLAGS "/Yuprecheader.h /FIprecheader.h")
+    set_property(TARGET cocos2d APPEND_STRING PROPERTY COMPILE_FLAGS "/Yuprecheader.h /FIprecheader.h /wd4244 /wd4305")
     set_source_files_properties("${CMAKE_CURRENT_SOURCE_DIR}/precheader.cpp" PROPERTIES COMPILE_FLAGS "/Ycprecheader.h")
     # compile c as c++. needed for precompiled header
     set_source_files_properties(${COCOS_SPINE_SRC} base/ccFPSImages.c PROPERTIES LANGUAGE CXX)

--- a/cocos/renderer/CCRenderer.h
+++ b/cocos/renderer/CCRenderer.h
@@ -57,7 +57,7 @@ class TrianglesCommand;
 class MeshCommand;
 class GroupCommand;
 class CallbackCommand;
-struct PipelineDescriptor;
+class PipelineDescriptor;
 class Texture2D;
 
 /** Class that knows how to sort `RenderCommand` objects.

--- a/tests/cpp-tests/CMakeLists.txt
+++ b/tests/cpp-tests/CMakeLists.txt
@@ -498,6 +498,6 @@ endif()
 if(WINDOWS)
     # precompiled header. Compilation time speedup ~4x.
     target_sources(${APP_NAME} PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/Classes/precheader.cpp")
-    set_target_properties(${APP_NAME} PROPERTIES COMPILE_FLAGS "/Yuprecheader.h /FIprecheader.h")
+    set_property(TARGET ${APP_NAME} APPEND_STRING PROPERTY COMPILE_FLAGS "/Yuprecheader.h /FIprecheader.h /wd4244 /wd4305")
     set_source_files_properties("${CMAKE_CURRENT_SOURCE_DIR}/Classes/precheader.cpp" PROPERTIES COMPILE_FLAGS "/Ycprecheader.h")
 endif()


### PR DESCRIPTION
Suppress warings in libcocos2d: 

- [LNK4099](https://docs.microsoft.com/en-us/cpp/error-messages/tool-errors/linker-tools-warning-lnk4099?view=vs-2019)
> PDB 'filename' was not found with 'object/library' or at 'path'; linking object as if no debug info
The linker was unable to find your .pdb file. Copy it into the directory that contains object/library.
- [C4244](https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-levels-3-and-4-c4244?view=vs-2019)
>  'conversion' conversion from 'type1' to 'type2', possible loss of data 
- [C4305](https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4305?view=vs-2019)
> This warning is issued when a value is converted to a smaller type in an initialization or as a constructor argument, resulting in a loss of information. 
