### PR TITLE
new clang-tidy option: readability-string-compare

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -12,6 +12,7 @@ Checks: >
   readability-delete-null-pointer,
   readability-redundant-control-flow,
   readability-redundant-string-cstr,
+  readability-string-compare,
 
 WarningsAsErrors: '*'
 HeaderFilterRegex: '/(?!external)/.*'

--- a/cocos/2d/CCFastTMXTiledMap.cpp
+++ b/cocos/2d/CCFastTMXTiledMap.cpp
@@ -205,7 +205,7 @@ TMXLayer * TMXTiledMap::getLayer(const std::string& layerName) const
         TMXLayer* layer = dynamic_cast<TMXLayer*>(child);
         if(layer)
         {
-            if(layerName.compare( layer->getLayerName()) == 0)
+            if(layerName == layer->getLayerName())
             {
                 return layer;
             }

--- a/cocos/2d/CCLabel.cpp
+++ b/cocos/2d/CCLabel.cpp
@@ -667,7 +667,7 @@ bool Label::setBMFontFilePath(const std::string& bmfontFilePath, const Vec2& ima
 
 void Label::setString(const std::string& text)
 {
-    if (text.compare(_utf8Text))
+    if (text != _utf8Text)
     {
         _utf8Text = text;
         _contentDirty = true;

--- a/cocos/2d/CCLabelBMFont.cpp
+++ b/cocos/2d/CCLabelBMFont.cpp
@@ -159,7 +159,7 @@ void LabelBMFont::setLineBreakWithoutSpace( bool breakWithoutSpace )
 // LabelBMFont - FntFile
 void LabelBMFont::setFntFile(const std::string& fntFile, const Vec2& imageOffset /* = Vec2::ZERO */)
 {
-    if (_fntFile.compare(fntFile) != 0)
+    if (_fntFile != fntFile)
     {
         _fntFile = fntFile;
         _label->setBMFontFilePath(fntFile,imageOffset);

--- a/cocos/2d/CCNode.cpp
+++ b/cocos/2d/CCNode.cpp
@@ -812,7 +812,7 @@ Node* Node::getChildByName(const std::string& name) const
     for (const auto& child : _children)
     {
         // Different strings may have the same hash code, but can use it to compare first for speed
-        if(child->_hashOfName == hash && child->_name.compare(name) == 0)
+        if(child->_hashOfName == hash && child->_name == name)
             return child;
     }
     return nullptr;

--- a/cocos/2d/CCTMXTiledMap.cpp
+++ b/cocos/2d/CCTMXTiledMap.cpp
@@ -210,7 +210,7 @@ TMXLayer * TMXTiledMap::getLayer(const std::string& layerName) const
         TMXLayer* layer = dynamic_cast<TMXLayer*>(child);
         if(layer)
         {
-            if(layerName.compare( layer->getLayerName()) == 0)
+            if(layerName == layer->getLayerName())
             {
                 return layer;
             }

--- a/cocos/base/CCConsole.cpp
+++ b/cocos/base/CCConsole.cpp
@@ -1165,7 +1165,7 @@ void Console::commandDebugMsg(int fd, const std::string& /*args*/)
 
 void Console::commandDebugMsgSubCommandOnOff(int /*fd*/, const std::string& args)
 {
-    _sendDebugStrings = (args.compare("on") == 0);
+    _sendDebugStrings = (args == "on");
 }
 
 void Console::commandDirectorSubCommandPause(int /*fd*/, const std::string& /*args*/)
@@ -1233,7 +1233,7 @@ void Console::commandFps(int fd, const std::string& /*args*/)
 
 void Console::commandFpsSubCommandOnOff(int /*fd*/, const std::string& args)
 {
-    bool state = (args.compare("on") == 0);
+    bool state = (args == "on");
     Director *dir = Director::getInstance();
     Scheduler *sched = dir->getScheduler();
     sched->performFunctionInCocosThread( std::bind(&Director::setDisplayStats, dir, state));

--- a/cocos/base/CCController-linux-win32.cpp
+++ b/cocos/base/CCController-linux-win32.cpp
@@ -4740,7 +4740,7 @@ class CC_DLL ControllerImpl
 			// Check if we already have an available input controller profile. If so, attach it it to the controller.
 			for (const auto & it : s_controllerProfiles)
 			{
-				if ( deviceName.compare(it.first) == 0 )
+				if ( deviceName == it.first )
 				{
 					// Found controller profile. Attach it to the controller:
 					CCLOG("ControllerImpl: Found input profile for controller: %s", deviceName.c_str());

--- a/cocos/deprecated/CCString.cpp
+++ b/cocos/deprecated/CCString.cpp
@@ -210,7 +210,7 @@ bool __String::isEqual(const Ref* pObject)
     const __String* pStr = dynamic_cast<const __String*>(pObject);
     if (pStr != nullptr)
     {
-        if (0 == _string.compare(pStr->_string))
+        if (pStr->_string == _string)
         {
             bRet = true;
         }

--- a/cocos/editor-support/cocosbuilder/CCBAnimationManager.cpp
+++ b/cocos/editor-support/cocosbuilder/CCBAnimationManager.cpp
@@ -284,7 +284,7 @@ int CCBAnimationManager::getSequenceId(const char* pSequenceName)
     string seqName(pSequenceName);
     for (auto& seq : _sequences)
     {
-        if (seqName.compare(seq->getName()) == 0)
+        if (seqName == seq->getName())
         {
             return seq->getSequenceId();
         }

--- a/cocos/editor-support/cocostudio/CCComRender.cpp
+++ b/cocos/editor-support/cocostudio/CCComRender.cpp
@@ -245,7 +245,7 @@ bool ComRender::serialize(void* r)
                             for (int i = 0; i < count; ++i)
                             {
                                 std::string key = tpChildArray[i].GetName(&tCocoLoader);
-                                if (key.compare("armature_data") == 0)
+                                if (key == "armature_data")
                                 {
                                     int length = tpChildArray[i].GetChildNum();
                                     stExpCocoNode *armature_dataArray = tpChildArray[i].GetChildArray(&tCocoLoader);
@@ -260,7 +260,7 @@ bool ComRender::serialize(void* r)
                                     {
                                         std::string key1 = armature_data[j].GetName(&tCocoLoader);
                                         const char *str1 = armature_data[j].GetValue(&tCocoLoader);
-                                        if (key.compare("name") == 0)
+                                        if (key == "name")
                                         {
                                             if (str1 != nullptr)
                                             {

--- a/cocos/editor-support/cocostudio/CCDataReaderHelper.cpp
+++ b/cocos/editor-support/cocostudio/CCDataReaderHelper.cpp
@@ -1756,12 +1756,12 @@ void DataReaderHelper::decodeNode(BaseData *node, const rapidjson::Value& json, 
                 for (int i = 0; i < nCount; ++i)
                 {
                     key = tpChildArray[i].GetName(&tCocoLoader);
-                    if (key.compare(CONTENT_SCALE) == 0)
+                    if (key == CONTENT_SCALE)
                     {
                         std::string value = tpChildArray[i].GetValue(&tCocoLoader);
                         dataInfo->contentScale = utils::atof(value.c_str());
                     }
-                    else if ( 0 == key.compare(ARMATURE_DATA))
+                    else if ( ARMATURE_DATA == key)
                     {
                         pDataArray = tpChildArray[i].GetChildArray(&tCocoLoader);
                         length = tpChildArray[i].GetChildNum();
@@ -1781,7 +1781,7 @@ void DataReaderHelper::decodeNode(BaseData *node, const rapidjson::Value& json, 
                             }
                         }
                     }
-                    else if ( 0 == key.compare(ANIMATION_DATA))
+                    else if ( ANIMATION_DATA == key)
                     {
                         pDataArray = tpChildArray[i].GetChildArray(&tCocoLoader);
                         length = tpChildArray[i].GetChildNum();
@@ -1801,7 +1801,7 @@ void DataReaderHelper::decodeNode(BaseData *node, const rapidjson::Value& json, 
                             }
                         }
                     }
-                    else if (key.compare(TEXTURE_DATA) == 0)
+                    else if (key == TEXTURE_DATA)
                     {
                         pDataArray = tpChildArray[i].GetChildArray(&tCocoLoader);
                         length = tpChildArray[i].GetChildNum();
@@ -1828,7 +1828,7 @@ void DataReaderHelper::decodeNode(BaseData *node, const rapidjson::Value& json, 
                     for (int i = 0; i < nCount; ++i)
                     {
                         key = tpChildArray[i].GetName(&tCocoLoader);
-                        if( 0 != key.compare(CONFIG_FILE_PATH))
+                        if( CONFIG_FILE_PATH != key)
                         {
                             continue;
                         }
@@ -1910,7 +1910,7 @@ void DataReaderHelper::decodeNode(BaseData *node, const rapidjson::Value& json, 
             child = &pBoneChildren[i];
             key = child->GetName(cocoLoader);
             str = child->GetValue(cocoLoader);
-            if (key.compare(A_NAME) == 0)
+            if (key == A_NAME)
             {
                 //DICTOOL->getStringValue_json(json, A_NAME);
                 if(str != nullptr)
@@ -1918,7 +1918,7 @@ void DataReaderHelper::decodeNode(BaseData *node, const rapidjson::Value& json, 
                     boneData->name = str;
                 }
             }
-            else if (key.compare(A_PARENT) == 0)
+            else if (key == A_PARENT)
             {
                 //DICTOOL->getStringValue_json(json, A_PARENT);
                 if(str != nullptr)
@@ -1926,7 +1926,7 @@ void DataReaderHelper::decodeNode(BaseData *node, const rapidjson::Value& json, 
                     boneData->parentName = str;
                 }
             }
-            else if (key.compare(DISPLAY_DATA) == 0)
+            else if (key == DISPLAY_DATA)
             {
                 int count = child->GetChildNum();
                 stExpCocoNode *pDisplayData = child->GetChildArray(cocoLoader);
@@ -1952,7 +1952,7 @@ void DataReaderHelper::decodeNode(BaseData *node, const rapidjson::Value& json, 
         std::string key = child->GetName(cocoLoader);
         const char *str = child->GetValue(cocoLoader);
         DisplayData *displayData = nullptr;
-        if (key.compare(A_DISPLAY_TYPE) == 0)
+        if (key == A_DISPLAY_TYPE)
         {
             str = child->GetValue(cocoLoader);
             DisplayType displayType = (DisplayType)(atoi(str));
@@ -1982,27 +1982,27 @@ void DataReaderHelper::decodeNode(BaseData *node, const rapidjson::Value& json, 
                             {
                                 key = SkinDataValue[i].GetName(cocoLoader);
                                 str = SkinDataValue[i].GetValue(cocoLoader);
-                                if (key.compare(A_X) == 0)
+                                if (key == A_X)
                                 {
                                     sdd->skinData.x = utils::atof(str) * s_PositionReadScale;
                                 }
-                                else if (key.compare(A_Y) == 0)
+                                else if (key == A_Y)
                                 {
                                     sdd->skinData.y = utils::atof(str) * s_PositionReadScale;
                                 }
-                                else if (key.compare(A_SCALE_X) == 0)
+                                else if (key == A_SCALE_X)
                                 {
                                     sdd->skinData.scaleX = utils::atof(str);
                                 }
-                                else if (key.compare(A_SCALE_Y) == 0)
+                                else if (key == A_SCALE_Y)
                                 {
                                     sdd->skinData.scaleY = utils::atof(str);
                                 }
-                                else if (key.compare(A_SKEW_X) == 0)
+                                else if (key == A_SKEW_X)
                                 {
                                     sdd->skinData.skewX = utils::atof(str);
                                 }
-                                else if (key.compare(A_SKEW_Y) == 0)
+                                else if (key == A_SKEW_Y)
                                 {
                                     sdd->skinData.skewY = utils::atof(str);
                                 }
@@ -2035,7 +2035,7 @@ void DataReaderHelper::decodeNode(BaseData *node, const rapidjson::Value& json, 
                     {
                         key = pDisplayData[i].GetName(cocoLoader);
                         str = pDisplayData[i].GetValue(cocoLoader);
-                        if (key.compare(A_PLIST) == 0)
+                        if (key == A_PLIST)
                         {
                             const char *plist = str;
                             if(plist != nullptr)
@@ -2078,14 +2078,14 @@ void DataReaderHelper::decodeNode(BaseData *node, const rapidjson::Value& json, 
             child = &pAnimationData[i];
             key = child->GetName(cocoLoader);
             str = child->GetValue(cocoLoader);
-            if (key.compare(A_NAME) == 0)
+            if (key == A_NAME)
             {
                 if(str != nullptr)
                 {
                     aniData->name = str;
                 }
             }
-            else if (key.compare(MOVEMENT_DATA) == 0)
+            else if (key == MOVEMENT_DATA)
             {
                 int movcount = child->GetChildNum();
                 stExpCocoNode* movArray =  child->GetChildArray(cocoLoader);
@@ -2116,14 +2116,14 @@ void DataReaderHelper::decodeNode(BaseData *node, const rapidjson::Value& json, 
             child = &pMoveDataArray[i];
             key = child->GetName(cocoLoader);
             str = child->GetValue(cocoLoader);
-            if (key.compare(A_NAME) == 0)
+            if (key == A_NAME)
             {
                 if(str != nullptr)
                 {
                     movementData->name = str;
                 }
             }
-            else if (key.compare(A_LOOP) == 0)
+            else if (key == A_LOOP)
             {
                 movementData->loop = true;
                 if(str != nullptr)
@@ -2134,7 +2134,7 @@ void DataReaderHelper::decodeNode(BaseData *node, const rapidjson::Value& json, 
                     }
                 }
             }
-            else if (key.compare(A_DURATION_TWEEN) == 0)
+            else if (key == A_DURATION_TWEEN)
             {
                 movementData->durationTween = 0;
                 if(str != nullptr)
@@ -2142,7 +2142,7 @@ void DataReaderHelper::decodeNode(BaseData *node, const rapidjson::Value& json, 
                     movementData->durationTween = atoi(str);
                 }
             }
-            else if (key.compare(A_DURATION_TO) == 0)
+            else if (key == A_DURATION_TO)
             {
                 movementData->durationTo = 0;
                 if(str != nullptr)
@@ -2150,7 +2150,7 @@ void DataReaderHelper::decodeNode(BaseData *node, const rapidjson::Value& json, 
                     movementData->durationTo = atoi(str);
                 }
             }
-            else if (key.compare(A_DURATION) == 0)
+            else if (key == A_DURATION)
             {
                 movementData->duration = 0;
                 if(str != nullptr)
@@ -2158,7 +2158,7 @@ void DataReaderHelper::decodeNode(BaseData *node, const rapidjson::Value& json, 
                     movementData->duration = atoi(str);
                 }
             }
-            else if (key.compare(A_MOVEMENT_SCALE) == 0)
+            else if (key == A_MOVEMENT_SCALE)
             {
                 movementData->scale = 1.0;
                 if(str != nullptr)
@@ -2166,7 +2166,7 @@ void DataReaderHelper::decodeNode(BaseData *node, const rapidjson::Value& json, 
                     movementData->scale = utils::atof(str);
                 }
             }
-            else if (key.compare(A_TWEEN_EASING) == 0)
+            else if (key == A_TWEEN_EASING)
             {
                 movementData->tweenEasing = cocos2d::tweenfunc::Linear;
                 if(str != nullptr)
@@ -2174,7 +2174,7 @@ void DataReaderHelper::decodeNode(BaseData *node, const rapidjson::Value& json, 
                     movementData->tweenEasing = (TweenType)(atoi(str));
                 }
             }
-            else if (key.compare(MOVEMENT_BONE_DATA) == 0)
+            else if (key == MOVEMENT_BONE_DATA)
             {
                 int count = child->GetChildNum();
                 stExpCocoNode *pMoveBoneData = child->GetChildArray(cocoLoader);
@@ -2204,21 +2204,21 @@ void DataReaderHelper::decodeNode(BaseData *node, const rapidjson::Value& json, 
             movebonechild = &pMovementBoneDataArray[i];
             std::string key = movebonechild->GetName(cocoLoader);
             str = movebonechild->GetValue(cocoLoader);
-            if (key.compare(A_NAME) == 0)
+            if (key == A_NAME)
             {
                 if(str != nullptr)
                 {
                     movementBoneData->name = str;
                 }
             }
-            else if (key.compare(A_MOVEMENT_DELAY) == 0)
+            else if (key == A_MOVEMENT_DELAY)
             {
                 if(str != nullptr)
                 {
                     movementBoneData->delay = utils::atof(str);
                 }
             }
-            else if (key.compare(FRAME_DATA) == 0)
+            else if (key == FRAME_DATA)
             {
                 int count =movebonechild->GetChildNum();
                 stExpCocoNode *pFrameDataArray = movebonechild->GetChildArray(cocoLoader);
@@ -2296,7 +2296,7 @@ void DataReaderHelper::decodeNode(BaseData *node, const rapidjson::Value& json, 
         {
             std::string key = pFrameDataArray[i].GetName(cocoLoader);
             str = pFrameDataArray[i].GetValue(cocoLoader);
-            if (key.compare(A_TWEEN_EASING) == 0)
+            if (key == A_TWEEN_EASING)
             {
                 frameData->tweenEasing = cocos2d::tweenfunc::Linear;
                 if(str != nullptr)
@@ -2304,28 +2304,28 @@ void DataReaderHelper::decodeNode(BaseData *node, const rapidjson::Value& json, 
                     frameData->tweenEasing = (TweenType)(atoi(str));
                 }
             }
-            else if (key.compare(A_DISPLAY_INDEX) == 0)
+            else if (key == A_DISPLAY_INDEX)
             {
                 if(str != nullptr)
                 {
                     frameData->displayIndex = atoi(str);
                 }
             }
-            else if (key.compare(A_BLEND_SRC) == 0)
+            else if (key == A_BLEND_SRC)
             {
                 if(str != nullptr)
                 {
                     frameData->blendFunc.src = (GLenum)(atoi(str));
                 }
             }
-            else if (key.compare(A_BLEND_DST) == 0)
+            else if (key == A_BLEND_DST)
             {
                 if(str != nullptr)
                 {
                     frameData->blendFunc.dst = (GLenum)(atoi(str));
                 }
             }
-            else if (key.compare(A_TWEEN_FRAME) == 0)
+            else if (key == A_TWEEN_FRAME)
             {
                 frameData->isTween = true;
                 if(str != nullptr)
@@ -2336,14 +2336,14 @@ void DataReaderHelper::decodeNode(BaseData *node, const rapidjson::Value& json, 
                     }
                 }
             }
-            else if (key.compare(A_EVENT) == 0)
+            else if (key == A_EVENT)
             {
                 if(str != nullptr)
                 {
                     frameData->strEvent = str;
                 }
             }
-            else if (key.compare(A_DURATION) == 0)
+            else if (key == A_DURATION)
             {
                 if (dataInfo->cocoStudioVersion < VERSION_COMBINED)
                 {
@@ -2354,7 +2354,7 @@ void DataReaderHelper::decodeNode(BaseData *node, const rapidjson::Value& json, 
                     }
                 }
             }
-            else if (key.compare(A_FRAME_INDEX) == 0)
+            else if (key == A_FRAME_INDEX)
             {
                 if (dataInfo->cocoStudioVersion >= VERSION_COMBINED)
                 {
@@ -2364,7 +2364,7 @@ void DataReaderHelper::decodeNode(BaseData *node, const rapidjson::Value& json, 
                     }
                 }
             }
-            else if (key.compare(A_EASING_PARAM) == 0)
+            else if (key == A_EASING_PARAM)
             {
                 int count = pFrameDataArray[i].GetChildNum();
                 if (count != 0 )
@@ -2404,42 +2404,42 @@ void DataReaderHelper::decodeNode(BaseData *node, const rapidjson::Value& json, 
         {
             std::string key = pTextureDataArray[i].GetName(cocoLoader);
             str = pTextureDataArray[i].GetValue(cocoLoader);
-            if (key.compare(A_NAME) == 0)
+            if (key == A_NAME)
             {
                 if(str != nullptr)
                 {
                     textureData->name = str;
                 }
             }
-            else if (key.compare(A_WIDTH) == 0)
+            else if (key == A_WIDTH)
             {
                 if(str != nullptr)
                 {
                     textureData->width = utils::atof(str);
                 }
             }
-            else if (key.compare(A_HEIGHT) == 0)
+            else if (key == A_HEIGHT)
             {
                 if(str != nullptr)
                 {
                     textureData->height = utils::atof(str);
                 }
             }
-            else if (key.compare(A_PIVOT_X) == 0)
+            else if (key == A_PIVOT_X)
             {
                 if(str != nullptr)
                 {
                     textureData->pivotX = utils::atof(str);
                 }
             }
-            else if (key.compare(A_PIVOT_Y) == 0)
+            else if (key == A_PIVOT_Y)
             {
                 if(str != nullptr)
                 {
                     textureData->pivotY = utils::atof(str);
                 }
             }
-            else if (key.compare(CONTOUR_DATA) == 0)
+            else if (key == CONTOUR_DATA)
             {
                 int count = pTextureDataArray[i].GetChildNum();
                 stExpCocoNode *pContourArray = pTextureDataArray[i].GetChildArray(cocoLoader);
@@ -2466,7 +2466,7 @@ void DataReaderHelper::decodeNode(BaseData *node, const rapidjson::Value& json, 
         {
             std::string key = verTexPointArray[i].GetName(cocoLoader);
             str = verTexPointArray[i].GetValue(cocoLoader);
-            if (key.compare(VERTEX_POINT) == 0)
+            if (key == VERTEX_POINT)
             {
                 int count = verTexPointArray[i].GetChildNum();
                 stExpCocoNode *pVerTexPointArray = verTexPointArray[i].GetChildArray(cocoLoader);
@@ -2497,35 +2497,35 @@ void DataReaderHelper::decodeNode(BaseData *node, const rapidjson::Value& json, 
             child = &NodeArray[i];
             std::string key = child->GetName(cocoLoader);
             str = child->GetValue(cocoLoader);
-            if (key.compare(A_X) == 0)
+            if (key == A_X)
             {
                 node->x = utils::atof(str) * dataInfo->contentScale;
             }
-            else if (key.compare(A_Y) == 0)
+            else if (key == A_Y)
             {
                 node->y = utils::atof(str) * dataInfo->contentScale;
             }
-            else if (key.compare(A_Z) == 0)
+            else if (key == A_Z)
             {
                 node->zOrder = atoi(str);
             }
-            else if (key.compare(A_SKEW_X) == 0)
+            else if (key == A_SKEW_X)
             {
                 node->skewX = utils::atof(str);
             }
-            else if (key.compare(A_SKEW_Y) == 0)
+            else if (key == A_SKEW_Y)
             {
                 node->skewY = utils::atof(str);
             }
-            else if (key.compare(A_SCALE_X) == 0)
+            else if (key == A_SCALE_X)
             {
                 node->scaleX = utils::atof(str);
             }
-            else if (key.compare(A_SCALE_Y) == 0)
+            else if (key == A_SCALE_Y)
             {
                 node->scaleY = utils::atof(str);
             }
-            else if (key.compare(COLOR_INFO) == 0)
+            else if (key == COLOR_INFO)
             {
                 if (!isVersionL)
                 {

--- a/cocos/editor-support/cocostudio/TriggerMng.cpp
+++ b/cocos/editor-support/cocostudio/TriggerMng.cpp
@@ -221,7 +221,7 @@ void TriggerMng::buildJson(rapidjson::Document &document, cocostudio::CocoLoader
             std::string key1 = pTriggerArray[i1].GetName(pCocoLoader);
             const char *str1 = pTriggerArray[i1].GetValue(pCocoLoader);
             
-            if (key1.compare("actions") == 0)
+            if (key1 == "actions")
             {
                 rapidjson::Value actionsItem(rapidjson::kArrayType);
                 
@@ -237,14 +237,14 @@ void TriggerMng::buildJson(rapidjson::Document &document, cocostudio::CocoLoader
                     {
                         std::string key2 = pActionArray[i3].GetName(pCocoLoader);
                         const char *str2 = pActionArray[i3].GetValue(pCocoLoader);
-                        if (key2.compare("classname") == 0)
+                        if (key2 == "classname")
                         {
                             if (str2 != nullptr)
                             {
                                 action.AddMember("classname", rapidjson::Value(str2,allocator), allocator);
                             }
                         }
-                        else if (key2.compare("dataitems") == 0)
+                        else if (key2 == "dataitems")
                         {
                             rapidjson::Value dataitems(rapidjson::kArrayType);
                             size = pActionArray[i3].GetChildNum();
@@ -258,7 +258,7 @@ void TriggerMng::buildJson(rapidjson::Document &document, cocostudio::CocoLoader
                                 {
                                     std::string key3 = pDataItemArray[i5].GetName(pCocoLoader);
                                     const char *str3 = pDataItemArray[i5].GetValue(pCocoLoader);
-                                    if (key3.compare("key") == 0)
+                                    if (key3 == "key")
                                     {
                                         if (str3 != nullptr)
                                         {
@@ -297,7 +297,7 @@ void TriggerMng::buildJson(rapidjson::Document &document, cocostudio::CocoLoader
                 
                 vElemItem.AddMember("actions", actionsItem, allocator);
             }
-            else if (key1.compare("conditions") == 0)
+            else if (key1 == "conditions")
             {
                 rapidjson::Value condsItem(rapidjson::kArrayType);
                 
@@ -313,14 +313,14 @@ void TriggerMng::buildJson(rapidjson::Document &document, cocostudio::CocoLoader
                     {
                         std::string key4 = pConditionArray[i7].GetName(pCocoLoader);
                         const char *str4 = pConditionArray[i7].GetValue(pCocoLoader);
-                        if (key4.compare("classname") == 0)
+                        if (key4 == "classname")
                         {
                             if (str4 != nullptr)
                             {
                                 cond.AddMember("classname", rapidjson::Value(str4,allocator), allocator);
                             }
                         }
-                        else if (key4.compare("dataitems") == 0)
+                        else if (key4 == "dataitems")
                         {
                             rapidjson::Value dataitems(rapidjson::kArrayType);
                             size = pConditionArray[i7].GetChildNum();
@@ -334,7 +334,7 @@ void TriggerMng::buildJson(rapidjson::Document &document, cocostudio::CocoLoader
                                 {
                                     std::string key5 = pDataItemArray[i9].GetName(pCocoLoader);
                                     const char *str5 = pDataItemArray[i9].GetValue(pCocoLoader);
-                                    if (key5.compare("key") == 0)
+                                    if (key5 == "key")
                                     {
                                         if (str5 != nullptr)
                                         {
@@ -373,7 +373,7 @@ void TriggerMng::buildJson(rapidjson::Document &document, cocostudio::CocoLoader
                 
                 vElemItem.AddMember("conditions", condsItem, allocator);
             }
-            else if (key1.compare("events") == 0)
+            else if (key1 == "events")
             {
                 rapidjson::Value eventsItem(rapidjson::kArrayType);
                 
@@ -385,7 +385,7 @@ void TriggerMng::buildJson(rapidjson::Document &document, cocostudio::CocoLoader
                     stExpCocoNode *pEventArray = pEventsArray->GetChildArray(pCocoLoader);
                     std::string key6 = pEventArray[0].GetName(pCocoLoader);
                     const char *str6 = pEventArray[0].GetValue(pCocoLoader);
-                    if (key6.compare("id") == 0 && str6 != nullptr)
+                    if (key6 == "id" && str6 != nullptr)
                     {
                         event.AddMember("id", atoi(str6), allocator);
                         eventsItem.PushBack(event, allocator);
@@ -393,7 +393,7 @@ void TriggerMng::buildJson(rapidjson::Document &document, cocostudio::CocoLoader
                 }
                 vElemItem.AddMember("events", eventsItem, allocator);
             }
-            else if (key1.compare("id") == 0)
+            else if (key1 == "id")
             {
                 if (str1 != nullptr)
                 {

--- a/cocos/editor-support/cocostudio/TriggerObj.cpp
+++ b/cocos/editor-support/cocostudio/TriggerObj.cpp
@@ -252,14 +252,14 @@ void TriggerObj::serialize(cocostudio::CocoLoader *pCocoLoader, cocostudio::stEx
     {
         std::string key = pTriggerObjArray[i0].GetName(pCocoLoader);
         const char* str0 = pTriggerObjArray[i0].GetValue(pCocoLoader);
-        if (key.compare("id") == 0)
+        if (key == "id")
         {
             if (str0 != nullptr)
             {
                 _id = atoi(str0); 
             }
         }
-        else if (key.compare("conditions") == 0)
+        else if (key == "conditions")
         {
             count = pTriggerObjArray[i0].GetChildNum();
             stExpCocoNode *pConditionsArray = pTriggerObjArray[i0].GetChildArray(pCocoLoader);
@@ -279,7 +279,7 @@ void TriggerObj::serialize(cocostudio::CocoLoader *pCocoLoader, cocostudio::stEx
                 _cons.pushBack(con);
             }
         }
-        else if (key.compare("actions") == 0)
+        else if (key == "actions")
         {
             count = pTriggerObjArray[i0].GetChildNum();
             stExpCocoNode *pActionsArray = pTriggerObjArray[i0].GetChildArray(pCocoLoader);
@@ -299,7 +299,7 @@ void TriggerObj::serialize(cocostudio::CocoLoader *pCocoLoader, cocostudio::stEx
                 _acts.pushBack(act);
             }
         }
-        else if (key.compare("events") == 0)
+        else if (key == "events")
         {
             count = pTriggerObjArray[i0].GetChildNum();
             stExpCocoNode *pEventsArray = pTriggerObjArray[i0].GetChildArray(pCocoLoader);

--- a/cocos/editor-support/cocostudio/WidgetReader/NodeReaderDefine.h
+++ b/cocos/editor-support/cocostudio/WidgetReader/NodeReaderDefine.h
@@ -48,6 +48,6 @@ cocos2d::ObjectFactory::TInfo className::__Type(#className, &className::createIn
 #define CREATE_CLASS_NODE_READER_INFO(className) \
 cocos2d::ObjectFactory::TInfo(#className, &className::createInstance) \
 
-#define FLATSTR_TO_BOOL(str) (str.compare("True") == 0) ? true : false
+#define FLATSTR_TO_BOOL(str) (str == "True") ? true : false
 
 #endif /* defined(__cocos2d_libs__NodeReaderDefine__) */

--- a/cocos/editor-support/cocostudio/WidgetReader/ScrollViewReader/ScrollViewReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/ScrollViewReader/ScrollViewReader.cpp
@@ -208,15 +208,15 @@ namespace cocostudio
             {
                 bounceEnabled = FLATSTR_TO_BOOL(value);
             }
-            else if (name.compare("BarEnabled") == 0)
+            else if (name == "BarEnabled")
             {
                 scrollbarEnabled = FLATSTR_TO_BOOL(value);
             }
-            else if (name.compare("BarAutoHide") == 0)
+            else if (name == "BarAutoHide")
             {
                 scrollbarAutoHide = FLATSTR_TO_BOOL(value);
             }
-            else if (name.compare("BarAutoHideTime") == 0)
+            else if (name == "BarAutoHideTime")
             {
                 scrollbarAutoHideTime = atof(value.c_str());
             }

--- a/cocos/editor-support/cocostudio/WidgetReader/TabControlReader/TabControlReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/TabControlReader/TabControlReader.cpp
@@ -145,7 +145,7 @@ flatbuffers::Offset<flatbuffers::Table> TabControlReader::createOptionsWithFlatB
                 
                 if (attriname == "ctype")
                 {
-                    if (value.compare("TabItemObjectData") == 0)
+                    if (value == "TabItemObjectData")
                     {
                         auto itemOption = TabItemReader::getInstance()->createTabItemOptionWithFlatBuffers(child, builder);
                         tabItems.push_back(itemOption);
@@ -284,11 +284,11 @@ flatbuffers::Offset<flatbuffers::Table> TabHeaderReader::createOptionsWithFlatBu
         std::string attriname = attribute->Name();
         std::string value = attribute->Value();
         
-        if (attriname.compare("FontSize") == 0)
+        if (attriname == "FontSize")
         {
             fontsize = atoi(value.c_str());
         }
-        else if (attriname.compare("TitleText") == 0)
+        else if (attriname == "TitleText")
         {
             text = value;
         }
@@ -958,15 +958,15 @@ flatbuffers::Offset<flatbuffers::TabItemOption> TabItemReader::createTabItemOpti
     while (child)
     {
         std::string attriName = child->Name();
-        if (attriName.compare("Children") == 0)
+        if (attriName == "Children")
         {
             containerChildrenData = const_cast<tinyxml2::XMLElement*>(child);
         }
-        if (attriName.compare("Header") == 0)
+        if (attriName == "Header")
         {
             header = TabHeaderReader::getInstance()->createOptionsWithFlatBuffers(child, builder);
         }
-        else if (attriName.compare("Container") == 0)
+        else if (attriName == "Container")
         {
             containerData = const_cast<tinyxml2::XMLElement*>(child);
         }

--- a/cocos/renderer/CCMaterial.cpp
+++ b/cocos/renderer/CCMaterial.cpp
@@ -465,7 +465,7 @@ const Vector<Technique*>& Material::getTechniques() const
 Technique* Material::getTechniqueByName(const std::string& name)
 {
     for(const auto& technique : _techniques) {
-        if (technique->getName().compare(name)==0)
+        if (technique->getName() == name)
             return technique;
     }
     return nullptr;

--- a/cocos/renderer/CCRenderState.cpp
+++ b/cocos/renderer/CCRenderState.cpp
@@ -454,7 +454,7 @@ void RenderState::StateBlock::cloneInto(StateBlock* state) const
 
 static bool parseBoolean(const std::string& value)
 {
-    return (value.compare("true")==0);
+    return value == "true";
 }
 
 //static int parseInt(const std::string& value)
@@ -637,39 +637,39 @@ static RenderState::FrontFace parseFrontFace(const std::string& value)
 
 void RenderState::StateBlock::setState(const std::string& name, const std::string& value)
 {
-    if (name.compare("blend") == 0)
+    if (name == "blend")
     {
         setBlend(parseBoolean(value));
     }
-    else if (name.compare("blendSrc") == 0)
+    else if (name == "blendSrc")
     {
         setBlendSrc(parseBlend(value));
     }
-    else if (name.compare("blendDst") == 0)
+    else if (name == "blendDst")
     {
         setBlendDst(parseBlend(value));
     }
-    else if (name.compare("cullFace") == 0)
+    else if (name == "cullFace")
     {
         setCullFace(parseBoolean(value));
     }
-    else if (name.compare("cullFaceSide") == 0)
+    else if (name == "cullFaceSide")
     {
         setCullFaceSide(parseCullFaceSide(value));
     }
-    else if (name.compare("frontFace") == 0)
+    else if (name == "frontFace")
     {
         setFrontFace(parseFrontFace(value));
     }
-    else if (name.compare("depthTest") == 0)
+    else if (name == "depthTest")
     {
         setDepthTest(parseBoolean(value));
     }
-    else if (name.compare("depthWrite") == 0)
+    else if (name == "depthWrite")
     {
         setDepthWrite(parseBoolean(value));
     }
-    else if (name.compare("depthFunc") == 0)
+    else if (name == "depthFunc")
     {
         setDepthFunction(parseDepthFunc(value));
     }

--- a/cocos/scripting/js-bindings/manual/network/XMLHTTPRequest.cpp
+++ b/cocos/scripting/js-bindings/manual/network/XMLHTTPRequest.cpp
@@ -202,8 +202,8 @@ void MinXmlHttpRequest::_setHttpRequestHeader()
 void MinXmlHttpRequest::_setHttpRequestData(const char *data, size_t len)
 {
     if (len > 0 &&
-        (_meth.compare("post") == 0 || _meth.compare("POST") == 0 ||
-         _meth.compare("put") == 0 || _meth.compare("PUT") == 0))
+        (_meth == "post" || _meth == "POST" ||
+         _meth == "put" || _meth == "PUT"))
     {
         _httpRequest->setRequestData(data, len);
     }
@@ -860,10 +860,10 @@ JS_BINDED_FUNC_IMPL(MinXmlHttpRequest, open)
 
         {
             auto requestType =
-              (_meth.compare("get") == 0 || _meth.compare("GET") == 0) ? cocos2d::network::HttpRequest::Type::GET : (
-              (_meth.compare("post") == 0 || _meth.compare("POST") == 0) ? cocos2d::network::HttpRequest::Type::POST : (
-              (_meth.compare("put") == 0 || _meth.compare("PUT") == 0) ? cocos2d::network::HttpRequest::Type::PUT : (
-              (_meth.compare("delete") == 0 || _meth.compare("DELETE") == 0) ? cocos2d::network::HttpRequest::Type::DELETE : (
+              (_meth == "get" || _meth == "GET") ? cocos2d::network::HttpRequest::Type::GET : (
+              (_meth == "post" || _meth == "POST") ? cocos2d::network::HttpRequest::Type::POST : (
+              (_meth == "put" || _meth == "PUT") ? cocos2d::network::HttpRequest::Type::PUT : (
+              (_meth == "delete" || _meth == "DELETE") ? cocos2d::network::HttpRequest::Type::DELETE : (
                 cocos2d::network::HttpRequest::Type::UNKNOWN))));
 
             _httpRequest->setRequestType(requestType);

--- a/cocos/scripting/lua-bindings/manual/network/lua_xml_http_request.cpp
+++ b/cocos/scripting/lua-bindings/manual/network/lua_xml_http_request.cpp
@@ -849,19 +849,19 @@ static int lua_cocos2dx_XMLHttpRequest_open(lua_State* L)
         
         if (nullptr != self->getHttpRequest())
         {
-            if (method.compare("post") == 0 || method.compare("POST") == 0)
+            if (method == "post" || method == "POST")
             {
                 self->getHttpRequest()->setRequestType(network::HttpRequest::Type::POST);
             }
-            else if(method.compare("get") == 0 || method.compare("GET") == 0)
+            else if(method == "get" || method == "GET")
             {
                 self->getHttpRequest()->setRequestType(network::HttpRequest::Type::GET);
             }
-            else if(method.compare("put") == 0 || method.compare("PUT") == 0)
+            else if(method == "put" || method == "PUT")
             {
                 self->getHttpRequest()->setRequestType(network::HttpRequest::Type::PUT);
             }
-            else if(method.compare("delete") == 0 || method.compare("DELETE") == 0)
+            else if(method == "delete" || method == "DELETE")
             {
                 self->getHttpRequest()->setRequestType(network::HttpRequest::Type::DELETE);
             }
@@ -929,8 +929,8 @@ static int lua_cocos2dx_XMLHttpRequest_send(lua_State* L)
     }
     
     if (size > 0 &&
-        (self->getMethod().compare("post") == 0 || self->getMethod().compare("POST") == 0
-         || self->getMethod().compare("put") == 0 || self->getMethod().compare("PUT") == 0 )&&
+        (self->getMethod() == "post" || self->getMethod() == "POST"
+         || self->getMethod() == "put" || self->getMethod() == "PUT" )&&
         nullptr != self->getHttpRequest())
     {
         self->getHttpRequest()->setRequestData(data,size);

--- a/cocos/ui/UIButton.cpp
+++ b/cocos/ui/UIButton.cpp
@@ -716,7 +716,7 @@ void Button::setTitleAlignment(TextHAlignment hAlignment, TextVAlignment vAlignm
 
 void Button::setTitleText(const std::string& text)
 {
-    if (text.compare(getTitleText()) == 0) {
+    if (text == getTitleText()) {
         return;
     }
     

--- a/tests/cpp-tests/Classes/MaterialSystemTest/MaterialSystemTest.cpp
+++ b/tests/cpp-tests/Classes/MaterialSystemTest/MaterialSystemTest.cpp
@@ -169,12 +169,12 @@ class EffectAutoBindingResolver : public GLProgramState::AutoBindingResolver
 
 bool EffectAutoBindingResolver::resolveAutoBinding(GLProgramState* glProgramState, Node* node, const std::string& uniform, const std::string& autoBinding)
 {
-    if (autoBinding.compare("DYNAMIC_RADIUS")==0)
+    if (autoBinding == "DYNAMIC_RADIUS")
     {
         glProgramState->setUniformCallback(uniform, CC_CALLBACK_2(EffectAutoBindingResolver::callbackRadius, this));
         return true;
     }
-    else if (autoBinding.compare("OUTLINE_COLOR")==0)
+    else if (autoBinding == "OUTLINE_COLOR")
     {
         glProgramState->setUniformCallback(uniform, CC_CALLBACK_2(EffectAutoBindingResolver::callbackColor, this));
         return true;


### PR DESCRIPTION
Change code like,

```cpp
str1.compare(str2) == 0;
```

to

```cpp
str1 == str2;
```


Reference: http://releases.llvm.org/7.0.0/tools/clang/tools/extra/docs/clang-tidy/checks/readability-string-compare.html