### PR TITLE
remove redundant semicolon

### DIFF
--- a/cocos/2d/CCActionCatmullRom.cpp
+++ b/cocos/2d/CCActionCatmullRom.cpp
@@ -38,7 +38,7 @@
 
 using namespace std;
 
-NS_CC_BEGIN;
+NS_CC_BEGIN
 
 /*
  *  Implementation of PointArray
@@ -526,4 +526,4 @@ CatmullRomBy* CatmullRomBy::reverse() const
     return CatmullRomBy::create(_duration, reverse);
 }
 
-NS_CC_END;
+NS_CC_END

--- a/cocos/2d/CCActionCatmullRom.h
+++ b/cocos/2d/CCActionCatmullRom.h
@@ -41,7 +41,7 @@
 #include "2d/CCActionInterval.h"
 #include "math/CCGeometry.h"
 
-NS_CC_BEGIN;
+NS_CC_BEGIN
 
 class Node;
 
@@ -343,6 +343,6 @@ extern CC_DLL Vec2 ccCardinalSplineAt(const Vec2 &p0, const Vec2 &p1, const Vec2
 // end of actions group
 /// @}
 
-NS_CC_END;
+NS_CC_END
 
 #endif // __CCACTION_CATMULLROM_H__

--- a/cocos/2d/CCActionEase.cpp
+++ b/cocos/2d/CCActionEase.cpp
@@ -159,33 +159,33 @@ ActionEase* CLASSNAME::reverse() const { \
     return REVERSE_CLASSNAME::create(_inner->reverse()); \
 }
 
-EASE_TEMPLATE_IMPL(EaseExponentialIn, tweenfunc::expoEaseIn, EaseExponentialOut);
-EASE_TEMPLATE_IMPL(EaseExponentialOut, tweenfunc::expoEaseOut, EaseExponentialIn);
-EASE_TEMPLATE_IMPL(EaseExponentialInOut, tweenfunc::expoEaseInOut, EaseExponentialInOut);
-EASE_TEMPLATE_IMPL(EaseSineIn, tweenfunc::sineEaseIn, EaseSineOut);
-EASE_TEMPLATE_IMPL(EaseSineOut, tweenfunc::sineEaseOut, EaseSineIn);
-EASE_TEMPLATE_IMPL(EaseSineInOut, tweenfunc::sineEaseInOut, EaseSineInOut);
-EASE_TEMPLATE_IMPL(EaseBounceIn, tweenfunc::bounceEaseIn, EaseBounceOut);
-EASE_TEMPLATE_IMPL(EaseBounceOut, tweenfunc::bounceEaseOut, EaseBounceIn);
-EASE_TEMPLATE_IMPL(EaseBounceInOut, tweenfunc::bounceEaseInOut, EaseBounceInOut);
-EASE_TEMPLATE_IMPL(EaseBackIn, tweenfunc::backEaseIn, EaseBackOut);
-EASE_TEMPLATE_IMPL(EaseBackOut, tweenfunc::backEaseOut, EaseBackIn);
-EASE_TEMPLATE_IMPL(EaseBackInOut, tweenfunc::backEaseInOut, EaseBackInOut);
-EASE_TEMPLATE_IMPL(EaseQuadraticActionIn, tweenfunc::quadraticIn, EaseQuadraticActionIn);
-EASE_TEMPLATE_IMPL(EaseQuadraticActionOut, tweenfunc::quadraticOut, EaseQuadraticActionOut);
-EASE_TEMPLATE_IMPL(EaseQuadraticActionInOut, tweenfunc::quadraticInOut, EaseQuadraticActionInOut);
-EASE_TEMPLATE_IMPL(EaseQuarticActionIn, tweenfunc::quartEaseIn, EaseQuarticActionIn);
-EASE_TEMPLATE_IMPL(EaseQuarticActionOut, tweenfunc::quartEaseOut, EaseQuarticActionOut);
-EASE_TEMPLATE_IMPL(EaseQuarticActionInOut, tweenfunc::quartEaseInOut, EaseQuarticActionInOut);
-EASE_TEMPLATE_IMPL(EaseQuinticActionIn, tweenfunc::quintEaseIn, EaseQuinticActionIn);
-EASE_TEMPLATE_IMPL(EaseQuinticActionOut, tweenfunc::quintEaseOut, EaseQuinticActionOut);
-EASE_TEMPLATE_IMPL(EaseQuinticActionInOut, tweenfunc::quintEaseInOut, EaseQuinticActionInOut);
-EASE_TEMPLATE_IMPL(EaseCircleActionIn, tweenfunc::circEaseIn, EaseCircleActionIn);
-EASE_TEMPLATE_IMPL(EaseCircleActionOut, tweenfunc::circEaseOut, EaseCircleActionOut);
-EASE_TEMPLATE_IMPL(EaseCircleActionInOut, tweenfunc::circEaseInOut, EaseCircleActionInOut);
-EASE_TEMPLATE_IMPL(EaseCubicActionIn, tweenfunc::cubicEaseIn, EaseCubicActionIn);
-EASE_TEMPLATE_IMPL(EaseCubicActionOut, tweenfunc::cubicEaseOut, EaseCubicActionOut);
-EASE_TEMPLATE_IMPL(EaseCubicActionInOut, tweenfunc::cubicEaseInOut, EaseCubicActionInOut);
+EASE_TEMPLATE_IMPL(EaseExponentialIn, tweenfunc::expoEaseIn, EaseExponentialOut)
+EASE_TEMPLATE_IMPL(EaseExponentialOut, tweenfunc::expoEaseOut, EaseExponentialIn)
+EASE_TEMPLATE_IMPL(EaseExponentialInOut, tweenfunc::expoEaseInOut, EaseExponentialInOut)
+EASE_TEMPLATE_IMPL(EaseSineIn, tweenfunc::sineEaseIn, EaseSineOut)
+EASE_TEMPLATE_IMPL(EaseSineOut, tweenfunc::sineEaseOut, EaseSineIn)
+EASE_TEMPLATE_IMPL(EaseSineInOut, tweenfunc::sineEaseInOut, EaseSineInOut)
+EASE_TEMPLATE_IMPL(EaseBounceIn, tweenfunc::bounceEaseIn, EaseBounceOut)
+EASE_TEMPLATE_IMPL(EaseBounceOut, tweenfunc::bounceEaseOut, EaseBounceIn)
+EASE_TEMPLATE_IMPL(EaseBounceInOut, tweenfunc::bounceEaseInOut, EaseBounceInOut)
+EASE_TEMPLATE_IMPL(EaseBackIn, tweenfunc::backEaseIn, EaseBackOut)
+EASE_TEMPLATE_IMPL(EaseBackOut, tweenfunc::backEaseOut, EaseBackIn)
+EASE_TEMPLATE_IMPL(EaseBackInOut, tweenfunc::backEaseInOut, EaseBackInOut)
+EASE_TEMPLATE_IMPL(EaseQuadraticActionIn, tweenfunc::quadraticIn, EaseQuadraticActionIn)
+EASE_TEMPLATE_IMPL(EaseQuadraticActionOut, tweenfunc::quadraticOut, EaseQuadraticActionOut)
+EASE_TEMPLATE_IMPL(EaseQuadraticActionInOut, tweenfunc::quadraticInOut, EaseQuadraticActionInOut)
+EASE_TEMPLATE_IMPL(EaseQuarticActionIn, tweenfunc::quartEaseIn, EaseQuarticActionIn)
+EASE_TEMPLATE_IMPL(EaseQuarticActionOut, tweenfunc::quartEaseOut, EaseQuarticActionOut)
+EASE_TEMPLATE_IMPL(EaseQuarticActionInOut, tweenfunc::quartEaseInOut, EaseQuarticActionInOut)
+EASE_TEMPLATE_IMPL(EaseQuinticActionIn, tweenfunc::quintEaseIn, EaseQuinticActionIn)
+EASE_TEMPLATE_IMPL(EaseQuinticActionOut, tweenfunc::quintEaseOut, EaseQuinticActionOut)
+EASE_TEMPLATE_IMPL(EaseQuinticActionInOut, tweenfunc::quintEaseInOut, EaseQuinticActionInOut)
+EASE_TEMPLATE_IMPL(EaseCircleActionIn, tweenfunc::circEaseIn, EaseCircleActionIn)
+EASE_TEMPLATE_IMPL(EaseCircleActionOut, tweenfunc::circEaseOut, EaseCircleActionOut)
+EASE_TEMPLATE_IMPL(EaseCircleActionInOut, tweenfunc::circEaseInOut, EaseCircleActionInOut)
+EASE_TEMPLATE_IMPL(EaseCubicActionIn, tweenfunc::cubicEaseIn, EaseCubicActionIn)
+EASE_TEMPLATE_IMPL(EaseCubicActionOut, tweenfunc::cubicEaseOut, EaseCubicActionOut)
+EASE_TEMPLATE_IMPL(EaseCubicActionInOut, tweenfunc::cubicEaseInOut, EaseCubicActionInOut)
 
 //
 // NOTE: Converting these macros into Templates is desirable, but please see
@@ -217,9 +217,9 @@ EaseRateAction* CLASSNAME::reverse() const { \
 }
 
 // NOTE: the original code used the same class for the `reverse()` method
-EASERATE_TEMPLATE_IMPL(EaseIn, tweenfunc::easeIn);
-EASERATE_TEMPLATE_IMPL(EaseOut, tweenfunc::easeOut);
-EASERATE_TEMPLATE_IMPL(EaseInOut, tweenfunc::easeInOut);
+EASERATE_TEMPLATE_IMPL(EaseIn, tweenfunc::easeIn)
+EASERATE_TEMPLATE_IMPL(EaseOut, tweenfunc::easeOut)
+EASERATE_TEMPLATE_IMPL(EaseInOut, tweenfunc::easeInOut)
 
 //
 // EaseElastic
@@ -265,9 +265,9 @@ EaseElastic* CLASSNAME::reverse() const { \
     return REVERSE_CLASSNAME::create(_inner->reverse(), _period); \
 }
 
-EASEELASTIC_TEMPLATE_IMPL(EaseElasticIn, tweenfunc::elasticEaseIn, EaseElasticOut);
-EASEELASTIC_TEMPLATE_IMPL(EaseElasticOut, tweenfunc::elasticEaseOut, EaseElasticIn);
-EASEELASTIC_TEMPLATE_IMPL(EaseElasticInOut, tweenfunc::elasticEaseInOut, EaseElasticInOut);
+EASEELASTIC_TEMPLATE_IMPL(EaseElasticIn, tweenfunc::elasticEaseIn, EaseElasticOut)
+EASEELASTIC_TEMPLATE_IMPL(EaseElasticOut, tweenfunc::elasticEaseOut, EaseElasticIn)
+EASEELASTIC_TEMPLATE_IMPL(EaseElasticInOut, tweenfunc::elasticEaseInOut, EaseElasticInOut)
 
 //
 // EaseBezierAction

--- a/cocos/2d/CCActionEase.h
+++ b/cocos/2d/CCActionEase.h
@@ -136,7 +136,7 @@ public: \
     virtual ActionEase* reverse() const override; \
 private: \
     CC_DISALLOW_COPY_AND_ASSIGN(CLASSNAME); \
-};
+}
 
 /**
  @class EaseExponentialIn
@@ -394,7 +394,7 @@ private: \
  \f${ time }^{ rate }\f$.
  @ingroup Actions
  */
-EASERATE_TEMPLATE_DECL_CLASS(EaseIn);
+EASERATE_TEMPLATE_DECL_CLASS(EaseIn)
 
 /**
  @class EaseOut
@@ -403,7 +403,7 @@ EASERATE_TEMPLATE_DECL_CLASS(EaseIn);
  \f${ time }^ { (1/rate) }\f$.
  @ingroup Actions
  */
-EASERATE_TEMPLATE_DECL_CLASS(EaseOut);
+EASERATE_TEMPLATE_DECL_CLASS(EaseOut)
 
 /**
  @class EaseInOut
@@ -414,7 +414,7 @@ EASERATE_TEMPLATE_DECL_CLASS(EaseOut);
  \f$1.0-0.5*{ 2-time }^{ rate }\f$.
  @ingroup Actions
  */
-EASERATE_TEMPLATE_DECL_CLASS(EaseInOut);
+EASERATE_TEMPLATE_DECL_CLASS(EaseInOut)
 
 /**
  @class EaseElastic
@@ -472,7 +472,7 @@ public: \
     virtual EaseElastic* reverse() const override; \
 private: \
     CC_DISALLOW_COPY_AND_ASSIGN(CLASSNAME); \
-};
+}
 
 /**
  @class EaseElasticIn

--- a/cocos/2d/CCAutoPolygon.cpp
+++ b/cocos/2d/CCAutoPolygon.cpp
@@ -59,7 +59,7 @@ PolygonInfo::PolygonInfo()
     triangles.indices = nullptr;
     triangles.vertCount = 0;
     triangles.indexCount = 0;
-};
+}
 
 PolygonInfo::PolygonInfo(const PolygonInfo& other)
 : triangles()
@@ -76,7 +76,7 @@ PolygonInfo::PolygonInfo(const PolygonInfo& other)
     triangles.indexCount = other.triangles.indexCount;
     memcpy(triangles.verts, other.triangles.verts, other.triangles.vertCount * sizeof(other.triangles.verts[0]));
     memcpy(triangles.indices, other.triangles.indices, other.triangles.indexCount * sizeof(other.triangles.indices[0]));
-};
+}
 
 PolygonInfo& PolygonInfo::operator= (const PolygonInfo& other)
 {

--- a/cocos/2d/CCDrawNode.cpp
+++ b/cocos/2d/CCDrawNode.cpp
@@ -133,7 +133,7 @@ bool Triangulate::isInsideTriangle(float Ax, float Ay,
     bCROSScp = bx*cpy - by*cpx;
     
     return ((aCROSSbp >= 0.0f) && (bCROSScp >= 0.0f) && (cCROSSap >= 0.0f));
-};
+}
 
 bool Triangulate::checkSnip(const Vec2 *verts,int u,int v,int w,int n,int *V)
 {

--- a/cocos/2d/CCDrawingPrimitives.h
+++ b/cocos/2d/CCDrawingPrimitives.h
@@ -263,7 +263,7 @@ namespace DrawPrimitives
      */
     CC_DEPRECATED_ATTRIBUTE void CC_DLL setPointSize(GLfloat pointSize);
 
-};
+}
 
 // end of global group
 /** @} */

--- a/cocos/2d/CCLayer.cpp
+++ b/cocos/2d/CCLayer.cpp
@@ -125,7 +125,7 @@ int Layer::executeScriptTouchesHandler(EventTouch::EventCode eventType, const st
     return 0;
 }
 
-bool Layer::ccTouchBegan(Touch* /*pTouch*/, Event* /*pEvent*/) {return false;};
+bool Layer::ccTouchBegan(Touch* /*pTouch*/, Event* /*pEvent*/) {return false;}
 void Layer::ccTouchMoved(Touch* /*pTouch*/, Event* /*pEvent*/) {}
 void Layer::ccTouchEnded(Touch* /*pTouch*/, Event* /*pEvent*/) {}
 void Layer::ccTouchCancelled(Touch* /*pTouch*/, Event* /*pEvent*/) {}

--- a/cocos/3d/CCBundleReader.cpp
+++ b/cocos/3d/CCBundleReader.cpp
@@ -33,12 +33,12 @@ BundleReader::BundleReader()
     _buffer = nullptr;
     _position = 0;
     _length = 0;
-};
+}
 
 BundleReader::~BundleReader()
 {
     
-};
+}
 
 void BundleReader::init(char* buffer, ssize_t length)
 {

--- a/cocos/base/CCEventMouse.cpp
+++ b/cocos/base/CCEventMouse.cpp
@@ -39,7 +39,7 @@ EventMouse::EventMouse(MouseEventType mouseEventCode)
 , _scrollY(0.0f)
 , _startPointCaptured(false)
 {
-};
+}
 
 // returns the current touch location in screen coordinates
 Vec2 EventMouse::getLocationInView() const 

--- a/cocos/base/CCScheduler.h
+++ b/cocos/base/CCScheduler.h
@@ -473,7 +473,7 @@ public:
      @since v0.99.3
      */
     template <class T>
-    CC_DEPRECATED_ATTRIBUTE void scheduleUpdateForTarget(T* target, int priority, bool paused) { scheduleUpdate(target, priority, paused); };
+    CC_DEPRECATED_ATTRIBUTE void scheduleUpdateForTarget(T* target, int priority, bool paused) { scheduleUpdate(target, priority, paused); }
     
     /** Unschedule a selector for a given target.
      If you want to unschedule the "update", use unscheduleUpdateForTarget.
@@ -488,13 +488,13 @@ public:
      @since v0.99.3
      @js NA
      */
-    CC_DEPRECATED_ATTRIBUTE bool isScheduledForTarget(Ref *target, SEL_SCHEDULE selector) { return isScheduled(selector, target); };
+    CC_DEPRECATED_ATTRIBUTE bool isScheduledForTarget(Ref *target, SEL_SCHEDULE selector) { return isScheduled(selector, target); }
     
     /** Unschedules the update selector for a given target
      @deprecated Please use 'Scheduler::unscheduleUpdate' instead.
      @since v0.99.3
      */
-    CC_DEPRECATED_ATTRIBUTE void unscheduleUpdateForTarget(Ref *target) { return unscheduleUpdate(target); };
+    CC_DEPRECATED_ATTRIBUTE void unscheduleUpdateForTarget(Ref *target) { return unscheduleUpdate(target); }
     
 protected:
     

--- a/cocos/base/ccRandom.h
+++ b/cocos/base/ccRandom.h
@@ -90,7 +90,7 @@ inline double random(double min, double max) {
  */
 inline int random() {
     return cocos2d::random(0, RAND_MAX);
-};
+}
 
 /**
  * Returns a random float between -1 and 1.
@@ -104,7 +104,7 @@ inline float rand_minus1_1() {
     return ((std::rand() / (float)RAND_MAX) * 2) -1;
 
 //    return cocos2d::random(-1.f, 1.f);
-};
+}
 
 /**
  * Returns a random float between 0 and 1.
@@ -118,7 +118,7 @@ inline float rand_0_1() {
     return std::rand() / (float)RAND_MAX;
 
 //    return cocos2d::random(0.f, 1.f);
-};
+}
 
 
 NS_CC_END

--- a/cocos/base/ccUTF8.cpp
+++ b/cocos/base/ccUTF8.cpp
@@ -272,7 +272,7 @@ bool utfConvert(
     to = std::move(working);
 
     return true;
-};
+}
 
 
 bool UTF8ToUTF16(const std::string& utf8, std::u16string& outUtf16)

--- a/cocos/deprecated/CCDeprecated.h
+++ b/cocos/deprecated/CCDeprecated.h
@@ -1083,7 +1083,7 @@ CC_DEPRECATED_ATTRIBUTE inline void CC_DLL ccGLBindTexture2DN(GLuint textureUnit
 CC_DEPRECATED_ATTRIBUTE inline void CC_DLL ccGLDeleteTexture(GLuint textureId) { GL::deleteTexture(textureId); }
 CC_DEPRECATED_ATTRIBUTE inline void CC_DLL ccGLDeleteTextureN(GLuint textureUnit, GLuint textureId) { GL::deleteTexture(textureId); }
 CC_DEPRECATED_ATTRIBUTE inline void CC_DLL ccGLBindVAO(GLuint vaoId) { GL::bindVAO(vaoId); }
-CC_DEPRECATED_ATTRIBUTE inline void CC_DLL ccGLEnable( int flags ) { /* ignore */ };
+CC_DEPRECATED_ATTRIBUTE inline void CC_DLL ccGLEnable( int flags ) { /* ignore */ }
 CC_DEPRECATED_ATTRIBUTE typedef int ccGLServerState;
 
 CC_DEPRECATED_ATTRIBUTE typedef Data CCData;

--- a/cocos/editor-support/cocosbuilder/CCBReader.cpp
+++ b/cocos/editor-support/cocosbuilder/CCBReader.cpp
@@ -1098,4 +1098,4 @@ void CCBReader::setResolutionScale(float scale)
     __ccbResolutionScale = scale;
 }
 
-};
+}

--- a/cocos/editor-support/cocosbuilder/CCControlButtonLoader.cpp
+++ b/cocos/editor-support/cocosbuilder/CCControlButtonLoader.cpp
@@ -27,7 +27,7 @@
 using namespace cocos2d;
 using namespace cocos2d::extension;
 
-namespace cocosbuilder {;
+namespace cocosbuilder {
 
 #define PROPERTY_ZOOMONTOUCHDOWN "zoomOnTouchDown"
 #define PROPERTY_TITLE_NORMAL "title|1"
@@ -139,4 +139,4 @@ void ControlButtonLoader::onHandlePropTypeColor3(Node * pNode, Node * pParent, c
     }
 }
 
-};
+}

--- a/cocos/editor-support/cocostudio/ActionTimeline/CCTimelineMacro.h
+++ b/cocos/editor-support/cocostudio/ActionTimeline/CCTimelineMacro.h
@@ -29,7 +29,7 @@ Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
 #ifdef __cplusplus
 #define NS_TIMELINE_BEGIN                     namespace cocostudio { namespace timeline{
 #define NS_TIMELINE_END                       }}
-#define USING_NS_TIMELINE                     using namespace cocostudio::timeline;
+#define USING_NS_TIMELINE                     using namespace cocostudio::timeline
 #else
 #define NS_TIMELINE_BEGIN 
 #define NS_TIMELINE_END 

--- a/cocos/editor-support/cocostudio/CCDataReaderHelper.cpp
+++ b/cocos/editor-support/cocostudio/CCDataReaderHelper.cpp
@@ -150,7 +150,7 @@ static std::string readFileContent(const std::string& filename, bool binary) {
     else
         s = fs->getStringFromFile(filename);
     return s;
-};
+}
 
 namespace cocostudio {
 

--- a/cocos/network/SocketIO.h
+++ b/cocos/network/SocketIO.h
@@ -189,7 +189,7 @@ private:
 
     friend class SIOClientImpl;
 private:
-    CC_DISALLOW_COPY_AND_ASSIGN(SocketIO)
+    CC_DISALLOW_COPY_AND_ASSIGN(SocketIO);
 };
 
 //c++11 style callbacks entities will be created using CC_CALLBACK (which uses std::bind)

--- a/cocos/platform/CCGLView.h
+++ b/cocos/platform/CCGLView.h
@@ -378,20 +378,20 @@ public:
      *
      * @param filename A path to image file, e.g., "icons/custom.png".
      */
-    virtual void setIcon(const std::string& filename) const {};
+    virtual void setIcon(const std::string& filename) const {}
 
     /** Set window icon (implemented for windows and linux).
      * Best icon (based on size) will be auto selected.
      * 
      * @param filelist The array contains icons.
      */
-    virtual void setIcon(const std::vector<std::string>& filelist) const {};
+    virtual void setIcon(const std::vector<std::string>& filelist) const {}
 
     /** Set default window icon (implemented for windows and linux).
      * On windows it will use icon from .exe file (if included).
      * On linux it will use default window icon.
      */
-    virtual void setDefaultIcon() const {};
+    virtual void setDefaultIcon() const {}
 
     /**
      * Get the opengl view port rectangle.

--- a/cocos/platform/CCPlatformMacros.h
+++ b/cocos/platform/CCPlatformMacros.h
@@ -130,10 +130,10 @@ CC_DEPRECATED_ATTRIBUTE static __TYPE__* node() \
  *            If you need protected or private, please declare.
  */
 #define CC_PROPERTY_READONLY(varType, varName, funName)\
-protected: varType varName; public: virtual varType get##funName(void) const;
+protected: varType varName; public: virtual varType get##funName(void) const
 
 #define CC_PROPERTY_READONLY_PASS_BY_REF(varType, varName, funName)\
-protected: varType varName; public: virtual const varType& get##funName(void) const;
+protected: varType varName; public: virtual const varType& get##funName(void) const
 
 /** @def CC_PROPERTY 
  * It is used to declare a protected variable.
@@ -148,10 +148,10 @@ protected: varType varName; public: virtual const varType& get##funName(void) co
  *            If you need protected or private, please declare.
  */
 #define CC_PROPERTY(varType, varName, funName)\
-protected: varType varName; public: virtual varType get##funName(void) const; virtual void set##funName(varType var);
+protected: varType varName; public: virtual varType get##funName(void) const; virtual void set##funName(varType var)
 
 #define CC_PROPERTY_PASS_BY_REF(varType, varName, funName)\
-protected: varType varName; public: virtual const varType& get##funName(void) const; virtual void set##funName(const varType& var);
+protected: varType varName; public: virtual const varType& get##funName(void) const; virtual void set##funName(const varType& var)
 
 /** @def CC_SYNTHESIZE_READONLY 
  * It is used to declare a protected variable. We can use getter to read the variable.
@@ -248,11 +248,11 @@ private: varType varName; public: virtual inline varType get##funName(void) cons
     || (defined(__clang__) && (__clang_major__ >= 3)) || (_MSC_VER >= 1800)
 #define CC_DISALLOW_COPY_AND_ASSIGN(TypeName) \
     TypeName(const TypeName &) = delete; \
-    TypeName &operator =(const TypeName &) = delete;
+    TypeName &operator =(const TypeName &) = delete
 #else
 #define CC_DISALLOW_COPY_AND_ASSIGN(TypeName) \
     TypeName(const TypeName &); \
-    TypeName &operator =(const TypeName &);
+    TypeName &operator =(const TypeName &)
 #endif
 
 /** @def CC_DISALLOW_IMPLICIT_CONSTRUCTORS(TypeName)

--- a/cocos/scripting/js-bindings/manual/ScriptingCore.cpp
+++ b/cocos/scripting/js-bindings/manual/ScriptingCore.cpp
@@ -306,7 +306,7 @@ bool JSBCore_platform(JSContext *cx, uint32_t argc, jsval *vp)
     args.rval().set(INT_TO_JSVAL((int)platform));
 
     return true;
-};
+}
 
 bool JSBCore_version(JSContext *cx, uint32_t argc, jsval *vp)
 {
@@ -324,7 +324,7 @@ bool JSBCore_version(JSContext *cx, uint32_t argc, jsval *vp)
     args.rval().set(STRING_TO_JSVAL(js_version));
 
     return true;
-};
+}
 
 bool JSBCore_os(JSContext *cx, uint32_t argc, jsval *vp)
 {
@@ -364,7 +364,7 @@ bool JSBCore_os(JSContext *cx, uint32_t argc, jsval *vp)
     args.rval().set(STRING_TO_JSVAL(os));
 
     return true;
-};
+}
 
 bool JSB_cleanScript(JSContext *cx, uint32_t argc, jsval *vp)
 {
@@ -383,7 +383,7 @@ bool JSB_cleanScript(JSContext *cx, uint32_t argc, jsval *vp)
     args.rval().setUndefined();
 
     return true;
-};
+}
 
 bool JSB_core_restartVM(JSContext *cx, uint32_t argc, jsval *vp)
 {
@@ -392,13 +392,13 @@ bool JSB_core_restartVM(JSContext *cx, uint32_t argc, jsval *vp)
     ScriptingCore::getInstance()->reset();
     args.rval().setUndefined();
     return true;
-};
+}
 
 bool JSB_closeWindow(JSContext *cx, uint32_t argc, jsval *vp)
 {
     Director::getInstance()->end();
     return true;
-};
+}
 
 void registerDefaultClasses(JSContext* cx, JS::HandleObject global) {
     // first, try to get the ns
@@ -940,7 +940,7 @@ void ScriptingCore::reportError(JSContext *cx, const char *message, JSErrorRepor
             report->filename ? report->filename : "<no filename=\"filename\">",
             (unsigned int) report->lineno,
             message);
-};
+}
 
 
 bool ScriptingCore::log(JSContext* cx, uint32_t argc, jsval *vp)

--- a/cocos/scripting/js-bindings/manual/cocos2d_specifics.cpp
+++ b/cocos/scripting/js-bindings/manual/cocos2d_specifics.cpp
@@ -184,7 +184,7 @@ bool JSTouchDelegate::onTouchBegan(Touch *touch, Event* /*event*/)
     }
 
     return bRet;
-};
+}
 // optional
 
 void JSTouchDelegate::onTouchMoved(Touch *touch, Event* /*event*/)

--- a/cocos/scripting/js-bindings/manual/js_bindings_core.cpp
+++ b/cocos/scripting/js-bindings/manual/js_bindings_core.cpp
@@ -49,7 +49,7 @@ static void reportError(JSContext *cx, const char *message, JSErrorReport *repor
             report->filename ? report->filename : "<no filename=\"filename\">",
             (unsigned int) report->lineno,
             message);
-};
+}
 
 
 // Hash of JSObject -> proxy

--- a/cocos/scripting/js-bindings/manual/jsb_helper.h
+++ b/cocos/scripting/js-bindings/manual/jsb_helper.h
@@ -37,12 +37,12 @@
 static JSClass js_class; \
 static JSObject* js_proto; \
 static JSObject* js_parent; \
-static void _js_register(JSContext* cx, JS::HandleObject global);
+static void _js_register(JSContext* cx, JS::HandleObject global)
 
 #define JS_BINDED_CLASS_GLUE_IMPL(klass) \
 JSClass klass::js_class = {}; \
 JSObject* klass::js_proto = NULL; \
-JSObject* klass::js_parent = NULL; \
+JSObject* klass::js_parent = NULL
 
 #define JS_BINDED_FUNC(klass, name) \
 bool name(JSContext *cx, unsigned argc, jsval *vp)
@@ -112,7 +112,7 @@ bool klass::_js_set_##propName(JSContext *cx, const JS::CallArgs& args)
 
 #define JS_BINDED_PROP_ACCESSOR(klass, propName) \
 JS_BINDED_PROP_GET(klass, propName); \
-JS_BINDED_PROP_SET(klass, propName);
+JS_BINDED_PROP_SET(klass, propName)
 
 #define JS_BINDED_PROP_DEF_GETTER(klass, propName) \
 JS_PSG(#propName, _js_get_##klass##_##propName, JSPROP_ENUMERATE | JSPROP_PERMANENT)

--- a/extensions/GUI/CCScrollView/CCScrollView.h
+++ b/extensions/GUI/CCScrollView/CCScrollView.h
@@ -54,12 +54,12 @@ public:
      * @js NA
      * @lua NA
      */
-    virtual void scrollViewDidScroll(ScrollView* view) {};
+    virtual void scrollViewDidScroll(ScrollView* view) {}
     /**
      * @js NA
      * @lua NA
      */
-    virtual void scrollViewDidZoom(ScrollView* view) {};
+    virtual void scrollViewDidZoom(ScrollView* view) {}
 };
 
 

--- a/extensions/Particle3D/CCParticle3DRender.cpp
+++ b/extensions/Particle3D/CCParticle3DRender.cpp
@@ -319,7 +319,7 @@ Particle3DRender::Particle3DRender()
     _stateBlock->setDepthTest(false);
     _stateBlock->setDepthWrite(false);
     _stateBlock->setBlend(true);
-};
+}
 
 Particle3DRender::~Particle3DRender()
 {

--- a/extensions/Particle3D/PU/CCPUEventHandler.cpp
+++ b/extensions/Particle3D/PU/CCPUEventHandler.cpp
@@ -35,7 +35,7 @@ _parentObserver(0),
 _eventHandlerScale(Vec3::ONE)
 {
     //mAliasType = AT_HANDLER;
-};
+}
 
 PUEventHandler::~PUEventHandler(  )
 {

--- a/extensions/Particle3D/PU/CCPUForceFieldAffector.cpp
+++ b/extensions/Particle3D/PU/CCPUForceFieldAffector.cpp
@@ -63,11 +63,11 @@ PUForceFieldAffector::PUForceFieldAffector() :
     _movementFrequencyCount(0.0f),
     _suppressGeneration(false)
 {
-};
+}
 //-----------------------------------------------------------------------
 PUForceFieldAffector::~PUForceFieldAffector()
 {
-};
+}
 //-----------------------------------------------------------------------
 PUForceField::ForceFieldType PUForceFieldAffector::getForceFieldType() const
 {

--- a/extensions/Particle3D/PU/CCPUGeometryRotator.cpp
+++ b/extensions/Particle3D/PU/CCPUGeometryRotator.cpp
@@ -45,7 +45,7 @@ PUGeometryRotator::PUGeometryRotator() :
 {
     _dynRotationSpeed = new (std::nothrow) PUDynamicAttributeFixed();
     (static_cast<PUDynamicAttributeFixed*>(_dynRotationSpeed))->setValue(DEFAULT_ROTATION_SPEED);
-};
+}
 //-----------------------------------------------------------------------
 PUGeometryRotator::~PUGeometryRotator()
 {

--- a/extensions/Particle3D/PU/CCPUOnTimeObserver.cpp
+++ b/extensions/Particle3D/PU/CCPUOnTimeObserver.cpp
@@ -37,7 +37,7 @@ const bool PUOnTimeObserver::DEFAULT_SINCE_START_SYSTEM = false;
 static bool almostEquals(float a, float b, float epsilon = std::numeric_limits<float>::epsilon())
 {
     return std::fabs(a - b) <= ( (std::fabs(a) < std::fabs(b) ? std::fabs(b) : std::fabs(a)) * epsilon);
-};
+}
 
 //-----------------------------------------------------------------------
 PUOnTimeObserver::PUOnTimeObserver(void) : PUObserver(),
@@ -45,7 +45,7 @@ PUOnTimeObserver::PUOnTimeObserver(void) : PUObserver(),
     _compare(CO_GREATER_THAN),
     _sinceStartSystem(DEFAULT_SINCE_START_SYSTEM)
 {
-};
+}
 //-----------------------------------------------------------------------
 void PUOnTimeObserver::preUpdateObserver(float deltaTime)
 {

--- a/extensions/Particle3D/PU/CCPUOnVelocityObserver.cpp
+++ b/extensions/Particle3D/PU/CCPUOnVelocityObserver.cpp
@@ -33,7 +33,7 @@ NS_CC_BEGIN
 static bool almostEquals(float a, float b, float epsilon = std::numeric_limits<float>::epsilon())
 {
     return std::fabs(a - b) <= ( (std::fabs(a) < std::fabs(b) ? std::fabs(b) : std::fabs(a)) * epsilon);
-};
+}
 
 // Constants
 const float PUOnVelocityObserver::DEFAULT_VELOCITY_THRESHOLD = 0.0f;
@@ -44,7 +44,7 @@ PUOnVelocityObserver::PUOnVelocityObserver(void) :
     _threshold(DEFAULT_VELOCITY_THRESHOLD),
     _compare(CO_LESS_THAN)
 {
-};
+}
 //-----------------------------------------------------------------------
 bool PUOnVelocityObserver::observe (PUParticle3D* particle, float /*timeElapsed*/)
 {

--- a/extensions/assets-manager/AssetsManager.cpp
+++ b/extensions/assets-manager/AssetsManager.cpp
@@ -38,7 +38,7 @@
 #include "unzip.h"
 #endif
 
-NS_CC_EXT_BEGIN;
+NS_CC_EXT_BEGIN
 
 using namespace std;
 using namespace cocos2d;
@@ -513,4 +513,4 @@ AssetsManager* AssetsManager::create(const char* packageUrl, const char* version
     return manager;
 }
 
-NS_CC_EXT_END;
+NS_CC_EXT_END

--- a/extensions/assets-manager/AssetsManager.h
+++ b/extensions/assets-manager/AssetsManager.h
@@ -205,7 +205,7 @@ public:
      * @js NA
      * @lua NA
      */
-    virtual void onError(AssetsManager::ErrorCode errorCode) {};
+    virtual void onError(AssetsManager::ErrorCode errorCode) {}
     /** @brief Call back function for recording downloading percent
         @param percent How much percent downloaded
         @warning    This call back function just for recording downloading percent.
@@ -214,18 +214,18 @@ public:
      * @js NA
      * @lua NA
      */
-    virtual void onProgress(int percent) {};
+    virtual void onProgress(int percent) {}
     /** @brief Call back function for success
      * @js NA
      * @lua NA
      */
-    virtual void onSuccess() {};
+    virtual void onSuccess() {}
 };
 
 // Deprecated declaration
 CC_DEPRECATED_ATTRIBUTE typedef AssetsManager CCAssetsManager;
 CC_DEPRECATED_ATTRIBUTE typedef AssetsManagerDelegateProtocol CCAssetsManagerDelegateProtocol;
 
-NS_CC_EXT_END;
+NS_CC_EXT_END
 
 #endif /* defined(__AssetsManager__) */

--- a/tests/cpp-tests/Classes/DownloaderTest/DownloaderTest.cpp
+++ b/tests/cpp-tests/Classes/DownloaderTest/DownloaderTest.cpp
@@ -369,4 +369,4 @@ DownloaderTests::DownloaderTests()
 {
     ADD_TEST_CASE(DownloaderTest);
     ADD_TEST_CASE(DownloaderMultiTask);
-};
+}

--- a/tests/cpp-tests/Classes/LabelTest/LabelTestNew.cpp
+++ b/tests/cpp-tests/Classes/LabelTest/LabelTestNew.cpp
@@ -142,7 +142,7 @@ NewLabelTests::NewLabelTests()
     ADD_TEST_CASE(LabelIssueLineGap);
     ADD_TEST_CASE(LabelIssue17902);
     ADD_TEST_CASE(LabelLetterColorsTest);
-};
+}
 
 LabelFNTColorAndOpacity::LabelFNTColorAndOpacity()
 {

--- a/tests/cpp-tests/Classes/NavMeshTest/NavMeshTest.cpp
+++ b/tests/cpp-tests/Classes/NavMeshTest/NavMeshTest.cpp
@@ -46,7 +46,7 @@ NavMeshTests::NavMeshTests()
     ADD_TEST_CASE(NavMeshBasicTestDemo);
     ADD_TEST_CASE(NavMeshAdvanceTestDemo);
 #endif
-};
+}
 
 #if ( CC_USE_NAVMESH == 0 ) || ( CC_USE_PHYSICS == 0 )
 void NavMeshDisabled::onEnter()

--- a/tests/cpp-tests/Classes/NewRendererTest/NewRendererTest.cpp
+++ b/tests/cpp-tests/Classes/NewRendererTest/NewRendererTest.cpp
@@ -41,7 +41,7 @@ NewRendererTests::NewRendererTests()
     ADD_TEST_CASE(RendererBatchQuadTri);
     ADD_TEST_CASE(RendererUniformBatch);
     ADD_TEST_CASE(RendererUniformBatch2);
-};
+}
 
 std::string MultiSceneTest::title() const
 {

--- a/tests/cpp-tests/Classes/Physics3DTest/Physics3DTest.cpp
+++ b/tests/cpp-tests/Classes/Physics3DTest/Physics3DTest.cpp
@@ -62,7 +62,7 @@ Physics3DTests::Physics3DTests()
     ADD_TEST_CASE(Physics3DColliderDemo);
     ADD_TEST_CASE(Physics3DTerrainDemo);
 #endif
-};
+}
 
 #if CC_USE_3D_PHYSICS == 0
 void Physics3DDemoDisabled::onEnter()

--- a/tests/cpp-tests/Classes/RenderTextureTest/RenderTextureTest.cpp
+++ b/tests/cpp-tests/Classes/RenderTextureTest/RenderTextureTest.cpp
@@ -38,7 +38,7 @@ RenderTextureTests::RenderTextureTests()
     ADD_TEST_CASE(RenderTexturePartTest);
     ADD_TEST_CASE(Issue16113Test);
     ADD_TEST_CASE(RenderTextureWithSprite3DIssue16894);
-};
+}
 
 /**
 * Implementation of RenderTextureSave

--- a/tests/cpp-tests/Classes/SchedulerTest/SchedulerTest.cpp
+++ b/tests/cpp-tests/Classes/SchedulerTest/SchedulerTest.cpp
@@ -61,7 +61,7 @@ SchedulerTests::SchedulerTests()
     ADD_TEST_CASE(SchedulerIssue17149);
     ADD_TEST_CASE(SchedulerRemoveEntryWhileUpdate);
     ADD_TEST_CASE(SchedulerRemoveSelectorDuringCall);
-};
+}
 
 //------------------------------------------------------------------
 //

--- a/tests/cpp-tests/Classes/Sprite3DTest/Sprite3DTest.cpp
+++ b/tests/cpp-tests/Classes/Sprite3DTest/Sprite3DTest.cpp
@@ -71,7 +71,7 @@ Sprite3DTests::Sprite3DTests()
     ADD_TEST_CASE(Sprite3DPropertyTest);
     ADD_TEST_CASE(Sprite3DNormalMappingTest);
     ADD_TEST_CASE(Issue16155Test);
-};
+}
 
 //------------------------------------------------------------------
 //

--- a/tests/cpp-tests/Classes/SpriteTest/SpriteTest.cpp
+++ b/tests/cpp-tests/Classes/SpriteTest/SpriteTest.cpp
@@ -137,7 +137,7 @@ SpriteTests::SpriteTests()
     ADD_TEST_CASE(SpriteSlice9Test9);
     ADD_TEST_CASE(SpriteSlice9Test10);
     ADD_TEST_CASE(Issue17119);
-};
+}
 
 //------------------------------------------------------------------
 //

--- a/tests/cpp-tests/Classes/Texture2dTest/Texture2dTest.cpp
+++ b/tests/cpp-tests/Classes/Texture2dTest/Texture2dTest.cpp
@@ -109,7 +109,7 @@ Texture2DTests::Texture2DTests()
     ADD_TEST_CASE(TextureConvertRGBA8888);
     ADD_TEST_CASE(TextureConvertI8);
     ADD_TEST_CASE(TextureConvertAI88);
-};
+}
 
 //------------------------------------------------------------------
 //

--- a/tests/cpp-tests/Classes/UnitTest/UnitTest.cpp
+++ b/tests/cpp-tests/Classes/UnitTest/UnitTest.cpp
@@ -83,7 +83,7 @@ UnitTests::UnitTests()
 #ifdef UNIT_TEST_FOR_OPTIMIZED_MATH_UTIL
     ADD_TEST_CASE(MathUtilTest);
 #endif
-};
+}
 
 std::string UnitTestDemo::title() const
 {


### PR DESCRIPTION
No code logic is touched.

This is a step to enable more compiler warnings.

It removes redundant semicolons like this,

```cpp
int i;;

void foo() 
{
};
```