### PR TITLE
allow set alpha premultiplied value for texture

### DIFF
--- a/cocos/renderer/CCTexture2D.cpp
+++ b/cocos/renderer/CCTexture2D.cpp
@@ -554,6 +554,11 @@ bool Texture2D::hasPremultipliedAlpha() const
     return _hasPremultipliedAlpha;
 }
 
+void Texture2D::setPremultipliedAlpha(bool premultiplied)
+{
+    _hasPremultipliedAlpha = premultiplied;
+}
+
 bool Texture2D::initWithData(const void *data, ssize_t dataLen, Texture2D::PixelFormat pixelFormat, int pixelsWide, int pixelsHigh, const Size& /*contentSize*/)
 {
     CCASSERT(dataLen>0 && pixelsWide>0 && pixelsHigh>0, "Invalid size");

--- a/cocos/renderer/CCTexture2D.h
+++ b/cocos/renderer/CCTexture2D.h
@@ -372,6 +372,9 @@ public:
     /** Whether or not the texture has their Alpha premultiplied. */
     bool hasPremultipliedAlpha() const;
     
+    /** Allow set alpha premultiplied value when know that from outer. */
+    void setPremultipliedAlpha(bool premultiplied);
+    
     /** Whether or not the texture has mip maps.*/
     bool hasMipmaps() const;
 

--- a/tests/cpp-tests/Classes/RenderTextureTest/RenderTextureTest.h
+++ b/tests/cpp-tests/Classes/RenderTextureTest/RenderTextureTest.h
@@ -175,6 +175,21 @@ public:
     virtual std::string subtitle() const override;
 
 private:
+    bool _premultiplied;
+    cocos2d::RenderTexture* _rend;
+    cocos2d::Sprite* _spriteDraw;
+};
+
+class Issue16113Test2 : public RenderTextureTest
+{
+public:
+    CREATE_FUNC(Issue16113Test2);
+    Issue16113Test2();
+    virtual std::string title() const override;
+    virtual std::string subtitle() const override;
+    
+private:
+    bool _premultiplied;
     cocos2d::RenderTexture* _rend;
     cocos2d::Sprite* _spriteDraw;
 };


### PR DESCRIPTION
allow set premultiplied value manually, this will solve render texture grey border

issues like this:

![image](https://user-images.githubusercontent.com/26329291/58094482-61db0300-7c03-11e9-9070-f7ded54eb40e.png)

- render a white label in white layer to render texture, but grey border appears
- set premultiplied value to `true` fixed it, after that render texture become to whole white.
