### PR TITLE
add clang-tidy-bugprone options

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -18,6 +18,9 @@ Checks: >
   bugprone-dangling-handle,
   bugprone-fold-init-type,
   bugprone-forward-declaration-namespace,
+  bugprone-forwarding-reference-overload,
+  bugprone-inaccurate-erase,
+  bugprone-incorrect-roundings,
 
 WarningsAsErrors: '*'
 HeaderFilterRegex: '/(?!external)/.*'

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -13,6 +13,11 @@ Checks: >
   readability-redundant-control-flow,
   readability-redundant-string-cstr,
   readability-string-compare,
+  bugprone-argument-comment,
+  bugprone-bool-pointer-implicit-conversion,
+  bugprone-dangling-handle,
+  bugprone-fold-init-type,
+  bugprone-forward-declaration-namespace,
 
 WarningsAsErrors: '*'
 HeaderFilterRegex: '/(?!external)/.*'

--- a/cocos/platform/linux/CCDevice-linux.cpp
+++ b/cocos/platform/linux/CCDevice-linux.cpp
@@ -34,6 +34,7 @@ THE SOFTWARE.
 #include <stdio.h>
 
 #include <algorithm>
+#include <cmath>
 #include <vector>
 #include <map>
 #include <string>
@@ -98,7 +99,7 @@ int Device::getDPI()
          */
         double xres = ((((double) DisplayWidth(dpy,scr)) * 25.4) / 
             ((double) DisplayWidthMM(dpy,scr)));
-        dpi = (int) (xres + 0.5);
+        dpi = std::lround(xres);
         //printf("dpi = %d\n", dpi);
         XCloseDisplay (dpy);
     }

--- a/tests/cpp-tests/Classes/BillBoardTest/BillBoardTest.cpp
+++ b/tests/cpp-tests/Classes/BillBoardTest/BillBoardTest.cpp
@@ -28,6 +28,7 @@
 #include "3d/CCBillBoard.h"
 
 #include <algorithm>
+#include <cmath>
 #include "../testResource.h"
 
 USING_NS_CC;
@@ -134,7 +135,7 @@ BillBoardTest::BillBoardTest()
     for (unsigned int i = 0; i < 4; ++i)
     {
         Layer *layer = Layer::create();
-        auto billboard = BillBoard::create(imgs[(unsigned int)(CCRANDOM_0_1() * 1 + 0.5)]);
+        auto billboard = BillBoard::create(imgs[(unsigned int)(std::lround(CCRANDOM_0_1()))]);
         billboard->setScale(0.5f);
         billboard->setPosition3D(Vec3(0.0f, 0.0f,  CCRANDOM_MINUS1_1() * 150.0f));
         billboard->setOpacity(CCRANDOM_0_1() * 128 + 128);
@@ -238,7 +239,7 @@ void BillBoardTest::addNewBillBoardWithCoords(Vec3 p)
     std::string imgs[3] = {"Images/Icon.png", "Images/r2.png"};
     for (unsigned int i = 0; i < 10; ++i)
     {
-        auto billboard = BillBoard::create(imgs[(unsigned int)(CCRANDOM_0_1() * 1 + 0.5)]);
+        auto billboard = BillBoard::create(imgs[(unsigned int)(std::lround(CCRANDOM_0_1()))]);
         billboard->setScale(0.5f);
         billboard->setPosition3D(Vec3(p.x, p.y, -150.0f + 30 * i));
         billboard->setOpacity(CCRANDOM_0_1() * 128 + 128);


### PR DESCRIPTION
* bugprone-argument-comment
* bugprone-bool-pointer-implicit-conversion
* bugprone-dangling-handle
* bugprone-fold-init-type
* bugprone-forward-declaration-namespace

No warnings was found in the code, so no code is touched. Push to check if ci can find more warnings.