### PR TITLE
refactor CCBundle3DData

### DIFF
--- a/cocos/3d/CCBundle3DData.h
+++ b/cocos/3d/CCBundle3DData.h
@@ -64,10 +64,8 @@ struct ModelData
     std::vector<std::string> bones;
     std::vector<Mat4>        invBindPose;
     
-    virtual ~ModelData()
-    {
-        resetData();
-    }
+    virtual ~ModelData() {}
+
     virtual void resetData()
     {
         bones.clear();
@@ -187,10 +185,6 @@ public:
     , numIndex(0)
     , attribCount(0)
     {
-    }
-    ~MeshData()
-    {
-        resetData();
     }
 };
 
@@ -326,7 +320,7 @@ struct NTextureData
      Usage type;
      GLenum wrapS;
      GLenum wrapT;
-} ;
+};
 struct NMaterialData
 {
     std::vector<NTextureData> textures;
@@ -440,14 +434,9 @@ public:
 */
 struct Reference
 {
-public:
     std::string id;
     unsigned int type;
     unsigned int offset;
-
-    Reference(){}
-
-    ~Reference(){}
 };
 
 NS_CC_END


### PR DESCRIPTION
* remove superfluous constructor and non-virtual destructor

destructor should be trivial if it doesn't manage resource. A vector
member clears itself automatically. No need to call `clear` in
destructor.

This close the issue: https://github.com/cocos2d/cocos2d-x/issues/19754