### PR TITLE
fix: FastTMXLayer does not reflect opacity and anchor point

### DIFF
--- a/cocos/2d/CCFastTMXLayer.cpp
+++ b/cocos/2d/CCFastTMXLayer.cpp
@@ -152,8 +152,9 @@ void TMXLayer::draw(Renderer *renderer, const Mat4& transform, uint32_t flags)
     if( flags != 0 || _dirty || _quadsDirty || isViewProjectionUpdated)
     {
         Size s = Director::getInstance()->getVisibleSize();
-        auto rect = Rect(Camera::getVisitingCamera()->getPositionX() - s.width * 0.5f,
-                     Camera::getVisitingCamera()->getPositionY() - s.height * 0.5f,
+        Vec2 anchor = getAnchorPoint();
+        auto rect = Rect(Camera::getVisitingCamera()->getPositionX() - s.width * anchor.x,
+                     Camera::getVisitingCamera()->getPositionY() - s.height * anchor.y,
                      s.width,
                      s.height);
         

--- a/cocos/2d/CCFastTMXLayer.cpp
+++ b/cocos/2d/CCFastTMXLayer.cpp
@@ -442,6 +442,11 @@ void TMXLayer::updatePrimitives()
     }
 }
 
+void TMXLayer::setOpacity(GLubyte opacity) {
+    Node::setOpacity(opacity);
+    _quadsDirty = true;
+}
+
 void TMXLayer::updateTotalQuads()
 {
     if(_quadsDirty)
@@ -453,6 +458,15 @@ void TMXLayer::updateTotalQuads()
         _indices.resize(6 * int(_layerSize.width * _layerSize.height));
         _tileToQuadIndex.resize(int(_layerSize.width * _layerSize.height),-1);
         _indicesVertexZOffsets.clear();
+
+        auto color = Color4B::WHITE;
+        color.a = getDisplayedOpacity();
+
+        if (_texture->hasPremultipliedAlpha()) {
+            color.r *= color.a / 255.0f;
+            color.g *= color.a / 255.0f;
+            color.b *= color.a / 255.0f;
+        }
         
         int quadIndex = 0;
         for(int y = 0; y < _layerSize.height; ++y)
@@ -551,11 +565,11 @@ void TMXLayer::updateTotalQuads()
                 quad.tl.texCoords.v = top;
                 quad.tr.texCoords.u = right;
                 quad.tr.texCoords.v = top;
-                
-                quad.bl.colors = Color4B::WHITE;
-                quad.br.colors = Color4B::WHITE;
-                quad.tl.colors = Color4B::WHITE;
-                quad.tr.colors = Color4B::WHITE;
+
+                quad.bl.colors = color;
+                quad.br.colors = color;
+                quad.tl.colors = color;
+                quad.tr.colors = color;
                 
                 ++quadIndex;
             }

--- a/cocos/2d/CCFastTMXLayer.cpp
+++ b/cocos/2d/CCFastTMXLayer.cpp
@@ -152,7 +152,7 @@ void TMXLayer::draw(Renderer *renderer, const Mat4& transform, uint32_t flags)
     if( flags != 0 || _dirty || _quadsDirty || isViewProjectionUpdated)
     {
         Size s = Director::getInstance()->getVisibleSize();
-        Vec2 anchor = getAnchorPoint();
+        const Vec2 &anchor = getAnchorPoint();
         auto rect = Rect(Camera::getVisitingCamera()->getPositionX() - s.width * anchor.x,
                      Camera::getVisitingCamera()->getPositionY() - s.height * anchor.y,
                      s.width,

--- a/cocos/2d/CCFastTMXLayer.h
+++ b/cocos/2d/CCFastTMXLayer.h
@@ -297,6 +297,8 @@ protected:
     void updateVertexBuffer();
     void updateIndexBuffer();
     void updatePrimitives();
+
+    virtual void setOpacity(GLubyte opacity) override;
 protected:
     
     //! name of the layer


### PR DESCRIPTION
Fixed a bug that FastTMXLayer does not reflect opacity and anchor point.