### PR TITLE
remove unnecessary `tmp` parameter in `uthash.h # HASH_ITER`.

### DIFF
--- a/cocos/2d/CCActionManager.cpp
+++ b/cocos/2d/CCActionManager.cpp
@@ -428,8 +428,7 @@ ssize_t ActionManager::getNumberOfRunningActions() const
 {
     ssize_t count = 0;
     struct _hashElement* element = nullptr;
-    struct _hashElement* tmp = nullptr;
-    HASH_ITER(hh, _targets, element, tmp)
+    HASH_ITER(hh, _targets, element)
     {
         count += (element->actions ? element->actions->num : 0);
     }

--- a/cocos/base/uthash.h
+++ b/cocos/base/uthash.h
@@ -857,13 +857,11 @@ do {                                                                            
             (HASH_BLOOM_BYTELEN)))
 
 #ifdef NO_DECLTYPE
-#define HASH_ITER(hh,head,el,tmp)                                                \
-for((el)=(head), (*(char**)(&(tmp)))=(char*)((head)?(head)->hh.next:NULL);       \
-  el; (el)=(tmp),(*(char**)(&(tmp)))=(char*)((tmp)?(tmp)->hh.next:NULL)) 
+#define HASH_ITER(hh,head,el)                                                    \
+  for( (el)=(head);  el;  (*(char**)(&(el)))=(char*)((el)?(el)->hh.next:NULL) )
 #else
-#define HASH_ITER(hh,head,el,tmp)                                                \
-for((el)=(head),(tmp)=DECLTYPE(el)((head)?(head)->hh.next:NULL);                 \
-  el; (el)=(tmp),(tmp)=DECLTYPE(el)((tmp)?(tmp)->hh.next:NULL))
+#define HASH_ITER(hh,head,el)                                                    \
+  for( (el)=(head);  el;  (el)=DECLTYPE(el)((el)?(el)->hh.next:NULL) )
 #endif
 
 /* obtain a count of items in the hash */

--- a/cocos/deprecated/CCDictionary.cpp
+++ b/cocos/deprecated/CCDictionary.cpp
@@ -102,10 +102,10 @@ __Array* __Dictionary::allKeys()
 
     __Array* array = __Array::createWithCapacity(iKeyCount);
 
-    DictElement *pElement, *tmp;
+    DictElement *pElement;
     if (_dictType == kDictStr)
     {
-        HASH_ITER(hh, _elements, pElement, tmp) 
+        HASH_ITER(hh, _elements, pElement)
         {
             __String* pOneKey = new (std::nothrow) __String(pElement->_strKey);
             array->addObject(pOneKey);
@@ -114,7 +114,7 @@ __Array* __Dictionary::allKeys()
     }
     else if (_dictType == kDictInt)
     {
-        HASH_ITER(hh, _elements, pElement, tmp) 
+        HASH_ITER(hh, _elements, pElement)
         {
             __Integer* pOneKey = new (std::nothrow) __Integer(static_cast<int>(pElement->_intKey));
             array->addObject(pOneKey);
@@ -131,11 +131,11 @@ __Array* __Dictionary::allKeysForObject(Ref* object)
     if (iKeyCount <= 0) return nullptr;
     __Array* array = __Array::create();
 
-    DictElement *pElement, *tmp;
+    DictElement *pElement;
 
     if (_dictType == kDictStr)
     {
-        HASH_ITER(hh, _elements, pElement, tmp) 
+        HASH_ITER(hh, _elements, pElement)
         {
             if (object == pElement->_object)
             {
@@ -147,7 +147,7 @@ __Array* __Dictionary::allKeysForObject(Ref* object)
     }
     else if (_dictType == kDictInt)
     {
-        HASH_ITER(hh, _elements, pElement, tmp) 
+        HASH_ITER(hh, _elements, pElement)
         {
             if (object == pElement->_object)
             {
@@ -332,8 +332,8 @@ void __Dictionary::removeObjectForElememt(DictElement* pElement)
 
 void __Dictionary::removeAllObjects()
 {
-    DictElement *pElement, *tmp;
-    HASH_ITER(hh, _elements, pElement, tmp) 
+    DictElement *pElement;
+    HASH_ITER(hh, _elements, pElement)
     {
         HASH_DEL(_elements, pElement);
         pElement->_object->release();
@@ -572,8 +572,7 @@ __Dictionary* __Dictionary::clone() const
     Clonable* obj = nullptr;
     if (_dictType == kDictInt)
     {
-        DictElement* tmp = nullptr;
-        HASH_ITER(hh, _elements, element, tmp)
+        HASH_ITER(hh, _elements, element)
         {
             obj = dynamic_cast<Clonable*>(element->getObject());
             if (obj)
@@ -592,8 +591,7 @@ __Dictionary* __Dictionary::clone() const
     }
     else if (_dictType == kDictStr)
     {
-        DictElement* tmp = nullptr;
-        HASH_ITER(hh, _elements, element, tmp)
+        HASH_ITER(hh, _elements, element)
         {
             obj = dynamic_cast<Clonable*>(element->getObject());
             if (obj)

--- a/cocos/deprecated/CCDictionary.h
+++ b/cocos/deprecated/CCDictionary.h
@@ -143,9 +143,8 @@ public:
  *        It's also safe to remove elements while traversing.
  */
 #define CCDICT_FOREACH(__dict__, __el__) \
-    DictElement* pTmp##__dict__##__el__ = nullptr; \
     if (__dict__) \
-    HASH_ITER(hh, (__dict__)->_elements, __el__, pTmp##__dict__##__el__)
+    HASH_ITER(hh, (__dict__)->_elements, __el__)
 
 
 

--- a/cocos/scripting/js-bindings/manual/chipmunk/js_bindings_chipmunk_manual.cpp
+++ b/cocos/scripting/js-bindings/manual/chipmunk/js_bindings_chipmunk_manual.cpp
@@ -1075,8 +1075,8 @@ void JSB_cpSpace_finalize(JSFreeOp *fop, JSObject *jsthis)
         cpSpace *space = (cpSpace*) proxy->handle;
 
         // Remove collision handlers, since the user might have forgotten to manually remove them
-        struct collision_handler *current = nullptr, *tmp = nullptr;
-        HASH_ITER(hh, collision_handler_hash, current, tmp)
+        struct collision_handler *current = nullptr;
+        HASH_ITER(hh, collision_handler_hash, current)
         {
             if( current->space == space )
             {

--- a/cocos/scripting/js-bindings/manual/cocos2d_specifics.cpp
+++ b/cocos/scripting/js-bindings/manual/cocos2d_specifics.cpp
@@ -985,8 +985,8 @@ void JSScheduleWrapper::removeAllTargets()
     dump();
 
     {
-        schedFunc_proxy_t *current, *tmp;
-        HASH_ITER(hh, _schedFunc_target_ht, current, tmp) {
+        schedFunc_proxy_t *current;
+        HASH_ITER(hh, _schedFunc_target_ht, current) {
             current->targets->clear();
             delete current->targets;
             HASH_DEL(_schedFunc_target_ht, current);
@@ -995,8 +995,8 @@ void JSScheduleWrapper::removeAllTargets()
     }
 
     {
-        schedTarget_proxy_t *current, *tmp;
-        HASH_ITER(hh, _schedObj_target_ht, current, tmp) {
+        schedTarget_proxy_t *current;
+        HASH_ITER(hh, _schedObj_target_ht, current) {
             current->targets->clear();
             delete current->targets;
             HASH_DEL(_schedObj_target_ht, current);
@@ -1014,8 +1014,8 @@ void JSScheduleWrapper::removeAllTargetsForMinPriority(int minPriority)
     dump();
 
     {
-        schedFunc_proxy_t *current, *tmp;
-        HASH_ITER(hh, _schedFunc_target_ht, current, tmp) {
+        schedFunc_proxy_t *current;
+        HASH_ITER(hh, _schedFunc_target_ht, current) {
             std::vector<Ref*> objectsNeedToBeReleased;
             auto targets = current->targets;
             for (const auto& pObj : *targets)
@@ -1044,8 +1044,8 @@ void JSScheduleWrapper::removeAllTargetsForMinPriority(int minPriority)
     }
 
     {
-        schedTarget_proxy_t *current, *tmp;
-        HASH_ITER(hh, _schedObj_target_ht, current, tmp) {
+        schedTarget_proxy_t *current;
+        HASH_ITER(hh, _schedObj_target_ht, current) {
             std::vector<Ref*> objectsNeedToBeReleased;
             auto targets = current->targets;
             for (const auto& pObj : *targets)
@@ -1092,8 +1092,8 @@ void JSScheduleWrapper::removeAllTargetsForJSObject(JS::HandleObject jsTargetObj
 
     if (removeNativeTargets == nullptr) return;
 
-    schedFunc_proxy_t *current, *tmp;
-    HASH_ITER(hh, _schedFunc_target_ht, current, tmp) {
+    schedFunc_proxy_t *current;
+    HASH_ITER(hh, _schedFunc_target_ht, current) {
         std::vector<Ref*> objectsNeedToBeReleased;
         auto targets = current->targets;
         for (const auto& pObj : *targets)
@@ -1141,9 +1141,9 @@ void JSScheduleWrapper::removeTargetForJSObject(JS::HandleObject jsTargetObj, JS
         }
     }
 
-    schedFunc_proxy_t *current, *tmp, *removed=nullptr;
+    schedFunc_proxy_t *current, *removed=nullptr;
 
-    HASH_ITER(hh, _schedFunc_target_ht, current, tmp) {
+    HASH_ITER(hh, _schedFunc_target_ht, current) {
         auto targets = current->targets;
         for (const auto& pObj : *targets)
         {
@@ -1176,9 +1176,9 @@ void JSScheduleWrapper::dump()
 #if COCOS2D_DEBUG > 1
     CCLOG("\n---------JSScheduleWrapper dump begin--------------\n");
     CCLOG("target hash count = %d, func hash count = %d", HASH_COUNT(_schedObj_target_ht), HASH_COUNT(_schedFunc_target_ht));
-    schedTarget_proxy_t *current, *tmp;
+    schedTarget_proxy_t *current;
     int nativeTargetsCount = 0;
-    HASH_ITER(hh, _schedObj_target_ht, current, tmp) {
+    HASH_ITER(hh, _schedObj_target_ht, current) {
         auto targets = current->targets;
         for (const auto& pObj : *targets)
         {
@@ -1189,9 +1189,9 @@ void JSScheduleWrapper::dump()
 
     CCLOG("\n-----------------------------\n");
 
-    schedFunc_proxy_t *current_func, *tmp_func;
+    schedFunc_proxy_t *current_func;
     int jsfuncTargetCount = 0;
-    HASH_ITER(hh, _schedFunc_target_ht, current_func, tmp_func)
+    HASH_ITER(hh, _schedFunc_target_ht, current_func)
     {
         auto targets = current_func->targets;
         for (const auto& pObj : *targets)


### PR DESCRIPTION
The `tmp` is unused macro parameter.

so, I just remove it.

and also solve redefinition problem `pTmp##__dict__##__el__` in `CCDictionary # CCDICT_FOREACH`.
(even though `CCDictionary` was deprecated codes)

---

(I've erased the wrong code and forcibly pushed it 2 times. plz ignore them)