### PR TITLE
refactor CCScene

### DIFF
--- a/cocos/2d/CCScene.cpp
+++ b/cocos/2d/CCScene.cpp
@@ -52,28 +52,16 @@ THE SOFTWARE.
 NS_CC_BEGIN
 
 Scene::Scene()
+: _defaultCamera(Camera::create())
+, _event(Director::getInstance()->getEventDispatcher()->addCustomEventListener(Director::EVENT_PROJECTION_CHANGED, std::bind(&Scene::onProjectionChanged, this, std::placeholders::_1)))
 {
-#if CC_USE_3D_PHYSICS && CC_ENABLE_BULLET_INTEGRATION
-    _physics3DWorld = nullptr;
-    _physics3dDebugCamera = nullptr;
-#endif
-#if CC_USE_NAVMESH
-    _navMesh = nullptr;
-    _navMeshDebugCamera = nullptr;
-#endif
-#if CC_USE_PHYSICS
-    _physicsWorld = nullptr;
-#endif
     _ignoreAnchorPointForPosition = true;
     setAnchorPoint(Vec2(0.5f, 0.5f));
     
-    _cameraOrderDirty = true;
-    
     //create default camera
-    _defaultCamera = Camera::create();
+
     addChild(_defaultCamera);
     
-    _event = Director::getInstance()->getEventDispatcher()->addCustomEventListener(Director::EVENT_PROJECTION_CHANGED, std::bind(&Scene::onProjectionChanged, this, std::placeholders::_1));
     _event->retain();
     
     Camera::_visitingCamera = nullptr;

--- a/cocos/2d/CCScene.h
+++ b/cocos/2d/CCScene.h
@@ -156,7 +156,7 @@ protected:
     
     std::vector<Camera*> _cameras; //weak ref to Camera
     Camera*              _defaultCamera; //weak ref, default camera created by scene, _cameras[0], Caution that the default camera can not be added to _cameras before onEnter is called
-    bool                 _cameraOrderDirty; // order is dirty, need sort
+    bool                 _cameraOrderDirty = true; // order is dirty, need sort
     EventListenerCustom*       _event;
 
     std::vector<BaseLight *> _lights;
@@ -201,12 +201,12 @@ protected:
     void addChildToPhysicsWorld(Node* child);
 
 #if CC_USE_PHYSICS
-    PhysicsWorld* _physicsWorld;
+    PhysicsWorld* _physicsWorld = nullptr;
 #endif
     
 #if CC_USE_3D_PHYSICS && CC_ENABLE_BULLET_INTEGRATION
-    Physics3DWorld*            _physics3DWorld;
-    Camera*                    _physics3dDebugCamera; //
+    Physics3DWorld*            _physics3DWorld = nullptr;
+    Camera*                    _physics3dDebugCamera = nullptr;
 #endif
 #endif // (CC_USE_PHYSICS || CC_USE_3D_PHYSICS)
     
@@ -222,8 +222,8 @@ public:
     void setNavMeshDebugCamera(Camera *camera);
 
 protected:
-    NavMesh*        _navMesh;
-    Camera *        _navMeshDebugCamera;
+    NavMesh*        _navMesh = nullptr;
+    Camera *        _navMeshDebugCamera = nullptr;
 #endif
     
 #if (CC_USE_PHYSICS || (CC_USE_3D_PHYSICS && CC_ENABLE_BULLET_INTEGRATION) || CC_USE_NAVMESH)

--- a/cocos/2d/CCScene.h
+++ b/cocos/2d/CCScene.h
@@ -155,9 +155,9 @@ protected:
     friend class Renderer;
     
     std::vector<Camera*> _cameras; //weak ref to Camera
-    Camera*              _defaultCamera; //weak ref, default camera created by scene, _cameras[0], Caution that the default camera can not be added to _cameras before onEnter is called
+    Camera*              _defaultCamera = nullptr; //weak ref, default camera created by scene, _cameras[0], Caution that the default camera can not be added to _cameras before onEnter is called
     bool                 _cameraOrderDirty = true; // order is dirty, need sort
-    EventListenerCustom*       _event;
+    EventListenerCustom*       _event = nullptr;
 
     std::vector<BaseLight *> _lights;
     


### PR DESCRIPTION
* use member initializer list
* add const to member function

```cpp
, _event(Director::getInstance()->getEventDispatcher()->addCustomEventListener(Director::EVENT_PROJECTION_CHANGED, std::bind(&Scene::onProjectionChanged, this, std::placeholders::_1)))
```

C++ allows us to use member functions in member initializer list, right? I am not very sure of when I am allowed to do this.