### PR TITLE
[Android]Override removeDirectory function in FileUtilsAndroid, fix "rm not found" error on OPPO ColorOS

### DIFF
--- a/cocos/platform/android/CCFileUtils-android.cpp
+++ b/cocos/platform/android/CCFileUtils-android.cpp
@@ -344,6 +344,15 @@ std::vector<std::string> FileUtilsAndroid::listFiles(const std::string& dirPath)
     return fileList;
 }
 
+bool FileUtilsAndroid::removeDirectory(const std::string& path) const
+{
+    if (path.empty())
+        return false;
+    
+    bool suc = removeDirectoryJNI(path.c_str());
+    return suc;
+}
+
 FileUtils::Status FileUtilsAndroid::getContents(const std::string& filename, ResizableBuffer* buffer) const
 {
     static const std::string apkprefix("assets/");

--- a/cocos/platform/android/CCFileUtils-android.cpp
+++ b/cocos/platform/android/CCFileUtils-android.cpp
@@ -349,8 +349,7 @@ bool FileUtilsAndroid::removeDirectory(const std::string& path) const
     if (path.empty())
         return false;
     
-    bool suc = removeDirectoryJNI(path.c_str());
-    return suc;
+    return removeDirectoryJNI(path.c_str());
 }
 
 FileUtils::Status FileUtilsAndroid::getContents(const std::string& filename, ResizableBuffer* buffer) const

--- a/cocos/platform/android/CCFileUtils-android.h
+++ b/cocos/platform/android/CCFileUtils-android.h
@@ -76,6 +76,8 @@ public:
     
     virtual long getFileSize(const std::string& filepath) const override;
     virtual std::vector<std::string> listFiles(const std::string& dirPath) const override;
+
+    virtual bool removeDirectory(const std::string& dirPath) const override;
 private:
     virtual bool isFileExistInternal(const std::string& strFilePath) const override;
     virtual bool isDirectoryExistInternal(const std::string& dirPath) const override;

--- a/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxHelper.java
+++ b/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxHelper.java
@@ -207,6 +207,39 @@ public class Cocos2dxHelper {
         
         return Cocos2dxHelper.sAssetsPath;
     }
+
+    //remove directory 
+    public static boolean RemoveDirectory(final String directory)
+    {
+        try{
+            File file = new File(directory);
+            RecursionDeleteFile(file);
+            return true;
+        }catch(Exception ex){
+            ex.printStackTrace();
+            return false;
+        }
+    }
+
+
+    private static void RecursionDeleteFile(File file)
+    {
+        if (file.isFile()) {
+            file.delete();
+            return;
+        }
+        if (file.isDirectory()) {
+            File[] childFile = file.listFiles();
+            if (childFile == null || childFile.length == 0) {
+                file.delete();
+                return;
+            }
+            for (File f : childFile) {
+                RecursionDeleteFile(f);
+            }
+            file.delete();
+        }
+    }
     
     public static ZipResourceFile getObbFile() {
         if (null == sOBBFile) {

--- a/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxHelper.java
+++ b/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxHelper.java
@@ -229,12 +229,12 @@ public class Cocos2dxHelper {
             return;
         }
         if (file.isDirectory()) {
-            File[] childFile = file.listFiles();
-            if (childFile == null || childFile.length == 0) {
+            File[] childrenFile = file.listFiles();
+            if (childrenFile == null || childrenFile.length == 0) {
                 file.delete();
                 return;
             }
-            for (File f : childFile) {
+            for (File f : childrenFile) {
                 recursionDeleteFile(f);
             }
             file.delete();

--- a/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxHelper.java
+++ b/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxHelper.java
@@ -209,11 +209,11 @@ public class Cocos2dxHelper {
     }
 
     //remove directory 
-    public static boolean RemoveDirectory(final String directory)
+    public static boolean removeDirectory(final String directory)
     {
         try{
             File file = new File(directory);
-            RecursionDeleteFile(file);
+            recursionDeleteFile(file);
             return true;
         }catch(Exception ex){
             ex.printStackTrace();
@@ -222,7 +222,7 @@ public class Cocos2dxHelper {
     }
 
 
-    private static void RecursionDeleteFile(File file)
+    private static void recursionDeleteFile(File file)
     {
         if (file.isFile()) {
             file.delete();
@@ -235,7 +235,7 @@ public class Cocos2dxHelper {
                 return;
             }
             for (File f : childFile) {
-                RecursionDeleteFile(f);
+                recursionDeleteFile(f);
             }
             file.delete();
         }

--- a/cocos/platform/android/jni/Java_org_cocos2dx_lib_Cocos2dxHelper.cpp
+++ b/cocos/platform/android/jni/Java_org_cocos2dx_lib_Cocos2dxHelper.cpp
@@ -159,7 +159,7 @@ void conversionEncodingJNI(const char* src, int byteSize, const char* fromCharse
 bool removeDirectoryJNI(const char* path)
 {
     JniMethodInfo methodInfo;
-    if (JniHelper::getStaticMethodInfo(methodInfo,className.c_str(),"RemoveDirectory","(Ljava/lang/String;)Z"))
+    if (JniHelper::getStaticMethodInfo(methodInfo,className.c_str(),"removeDirectory","(Ljava/lang/String;)Z"))
     {
         jstring stringArgPath = methodInfo.env->NewStringUTF(path);
         jboolean suc = methodInfo.env->CallStaticBooleanMethod(methodInfo.classID,methodInfo.methodID,stringArgPath);

--- a/cocos/platform/android/jni/Java_org_cocos2dx_lib_Cocos2dxHelper.cpp
+++ b/cocos/platform/android/jni/Java_org_cocos2dx_lib_Cocos2dxHelper.cpp
@@ -154,3 +154,21 @@ void conversionEncodingJNI(const char* src, int byteSize, const char* fromCharse
         methodInfo.env->DeleteLocalRef(methodInfo.classID);
     }
 }
+
+
+bool removeDirectoryJNI(const char* path)
+{
+    JniMethodInfo methodInfo;
+    if (JniHelper::getStaticMethodInfo(methodInfo,className.c_str(),"RemoveDirectory","(Ljava/lang/String;)Z"))
+    {
+        jstring stringArgPath = methodInfo.env->NewStringUTF(path);
+        jboolean suc = methodInfo.env->CallStaticBooleanMethod(methodInfo.classID,methodInfo.methodID,stringArgPath);
+
+        methodInfo.env->DeleteLocalRef(methodInfo.classID);
+        methodInfo.env->DeleteLocalRef(stringArgPath);
+
+        return suc;
+    }
+
+    return false;
+}

--- a/cocos/platform/android/jni/Java_org_cocos2dx_lib_Cocos2dxHelper.h
+++ b/cocos/platform/android/jni/Java_org_cocos2dx_lib_Cocos2dxHelper.h
@@ -34,6 +34,7 @@ extern const char * getApkPath();
 extern std::string getPackageNameJNI();
 extern int getObbAssetFileDescriptorJNI(const char* path, long* startOffset, long* size);
 extern void conversionEncodingJNI(const char* src, int byteSize, const char* fromCharset, char* dst, const char* newCharset);
+extern bool removeDirectoryJNI(const char* path);
 
 extern int getDeviceSampleRate();
 extern int getDeviceAudioBufferSizeInFrames();


### PR DESCRIPTION
Override removeDirectory function in FileUtilsAndroid, use JRE method instead of "rm -r path". Because We found that on OPPO's ColorOS, the environment variable PATH may not always correct, it could be ":/sbin" sometimes, then cause an error "rm not found", afterwards the directory could not be deleted.