### PR TITLE
[TileMapTest] fix depth test

### DIFF
--- a/cocos/base/CCDirector.cpp
+++ b/cocos/base/CCDirector.cpp
@@ -673,8 +673,6 @@ void Director::setDepthTest(bool on)
     }
     else
         _renderer->setDepthTest(false);
-
-    _renderer->setDepthWrite(on);
 }
 
 void Director::setClearColor(const Color4F& clearColor)


### PR DESCRIPTION
[TileMapTest] Depth write state setting should not be depended on the depth test flag