### PR TITLE
fix return value in EditBoxImpl-linux and remove some redundant semicolon

### DIFF
--- a/cocos/ui/UIEditBox/UIEditBoxImpl-linux.h
+++ b/cocos/ui/UIEditBox/UIEditBoxImpl-linux.h
@@ -56,23 +56,23 @@ public:
     
 
     virtual bool isEditing() override;
-    virtual void createNativeControl(const Rect& frame) override {};
-    virtual void setNativeFont(const char* pFontName, int fontSize) override {};
-    virtual void setNativeFontColor(const Color4B& color) override {};
-    virtual void setNativePlaceholderFont(const char* pFontName, int fontSize) override {};
-    virtual void setNativePlaceholderFontColor(const Color4B& color) override {};
-    virtual void setNativeInputMode(EditBox::InputMode inputMode) override {};
-    virtual void setNativeInputFlag(EditBox::InputFlag inputFlag) override {};
-    virtual void setNativeReturnType(EditBox::KeyboardReturnType returnType)override {};
-    virtual void setNativeTextHorizontalAlignment(cocos2d::TextHAlignment alignment) {};
-    virtual void setNativeText(const char* pText) override {};
-    virtual void setNativePlaceHolder(const char* pText) override {};
-    virtual void setNativeVisible(bool visible) override {};
-    virtual void updateNativeFrame(const Rect& rect) override {};
-    virtual const char* getNativeDefaultFontName() override {};
+    virtual void createNativeControl(const Rect& frame) override {}
+    virtual void setNativeFont(const char* pFontName, int fontSize) override {}
+    virtual void setNativeFontColor(const Color4B& color) override {}
+    virtual void setNativePlaceholderFont(const char* pFontName, int fontSize) override {}
+    virtual void setNativePlaceholderFontColor(const Color4B& color) override {}
+    virtual void setNativeInputMode(EditBox::InputMode inputMode) override {}
+    virtual void setNativeInputFlag(EditBox::InputFlag inputFlag) override {}
+    virtual void setNativeReturnType(EditBox::KeyboardReturnType returnType)override {}
+    virtual void setNativeTextHorizontalAlignment(cocos2d::TextHAlignment alignment) {}
+    virtual void setNativeText(const char* pText) override {}
+    virtual void setNativePlaceHolder(const char* pText) override {}
+    virtual void setNativeVisible(bool visible) override {}
+    virtual void updateNativeFrame(const Rect& rect) override {}
+    virtual const char* getNativeDefaultFontName() override { return nullptr; }
     virtual void nativeOpenKeyboard() override;
-    virtual void nativeCloseKeyboard() override {};
-    virtual void setNativeMaxLength(int maxLength) override {};
+    virtual void nativeCloseKeyboard() override {}
+    virtual void setNativeMaxLength(int maxLength) override {}
 
     
 private:


### PR DESCRIPTION
```cpp
virtual const char* getNativeDefaultFontName() override {};
```
has a return type of `const char*` but doesn't return anything.

Also remove some redundant semicolon, warned `-pedantic`.

I am not sure whether it should return something else instead of `nullptr`.