### PR TITLE
android_allowBackup2

### DIFF
--- a/cocos/platform/android/libcocos2dx-with-controller/AndroidManifest.xml
+++ b/cocos/platform/android/libcocos2dx-with-controller/AndroidManifest.xml
@@ -2,8 +2,4 @@
 
     <uses-permission android:name="android.permission.VIBRATE" />
 
-    <application android:allowBackup="true">
-
-    </application>
-
 </manifest>

--- a/cocos/platform/android/libcocos2dx/AndroidManifest.xml
+++ b/cocos/platform/android/libcocos2dx/AndroidManifest.xml
@@ -2,8 +2,4 @@
 
     <uses-permission android:name="android.permission.VIBRATE" />
 
-    <application android:allowBackup="true">
-
-    </application>
-
 </manifest>


### PR DESCRIPTION
This option should be set only on application level.
Having it on library level it is impossible to set android:allowBackup="false" in application