### PR TITLE
Rename backend::Texture2D

### DIFF
--- a/cocos/2d/CCRenderTexture.h
+++ b/cocos/2d/CCRenderTexture.h
@@ -38,7 +38,7 @@ NS_CC_BEGIN
 
 namespace backend
 {
-    class Texture;
+    class TextureBackend;
 }
 
 class EventCustom;

--- a/cocos/renderer/CCPass.cpp
+++ b/cocos/renderer/CCPass.cpp
@@ -277,12 +277,12 @@ VertexAttribBinding* Pass::getVertexAttributeBinding() const
     return _vertexAttribBinding;
 }
 
-void Pass::setUniformTexture(uint32_t slot, backend::Texture *tex)
+void Pass::setUniformTexture(uint32_t slot, backend::TextureBackend *tex)
 {
     _programState->setTexture(_locTexture, slot, tex);
 }
 
-void Pass::setUniformNormTexture(uint32_t slot, backend::Texture *tex)
+void Pass::setUniformNormTexture(uint32_t slot, backend::TextureBackend *tex)
 {
     _programState->setTexture(_locNormalTexture, slot, tex);
 }

--- a/cocos/renderer/CCPass.h
+++ b/cocos/renderer/CCPass.h
@@ -101,8 +101,8 @@ public:
 
     void updateMVPUniform(const Mat4& modelView);
     
-    void setUniformTexture(uint32_t slot, backend::Texture *);      //u_texture
-    void setUniformNormTexture(uint32_t slot, backend::Texture *);  //u_texture
+    void setUniformTexture(uint32_t slot, backend::TextureBackend *);      //u_texture
+    void setUniformNormTexture(uint32_t slot, backend::TextureBackend *);  //u_texture
 
     void setUniformColor(const void *, size_t);                 //ucolor
     void setUniformMatrixPalette(const void *, size_t);         //u_matrixPalette

--- a/cocos/renderer/CCTexture2D.cpp
+++ b/cocos/renderer/CCTexture2D.cpp
@@ -140,7 +140,7 @@ Texture2D::Texture2D()
 {
     backend::TextureDescriptor textureDescriptor;
     textureDescriptor.textureFormat = PixelFormat::NONE;
-    _texture = static_cast<backend::TextureBackend2D*>(backend::Device::getInstance()->newTexture(textureDescriptor));
+    _texture = static_cast<backend::Texture2DBackend*>(backend::Device::getInstance()->newTexture(textureDescriptor));
 }
 
 Texture2D::~Texture2D()
@@ -173,7 +173,7 @@ int Texture2D::getPixelsHigh() const
     return _pixelsHigh;
 }
 
-backend::Texture* Texture2D::getBackendTexture() const
+backend::TextureBackend* Texture2D::getBackendTexture() const
 {
     return _texture;
 }
@@ -570,11 +570,11 @@ bool Texture2D::initWithString(const char *text, const FontDefinition& textDefin
     return ret;
 }
 
-bool Texture2D::initWithBackendTexture(backend::Texture *texture)
+bool Texture2D::initWithBackendTexture(backend::TextureBackend *texture)
 {
     CC_SAFE_RETAIN(texture);
     CC_SAFE_RELEASE(_texture);
-    _texture = dynamic_cast<backend::TextureBackend2D*>(texture);
+    _texture = dynamic_cast<backend::Texture2DBackend*>(texture);
     CC_ASSERT(_texture);
     _pixelsWide = _contentSize.width = _texture->getWidth();
     _pixelsHigh = _contentSize.height = _texture->getHeight();

--- a/cocos/renderer/CCTexture2D.cpp
+++ b/cocos/renderer/CCTexture2D.cpp
@@ -140,7 +140,7 @@ Texture2D::Texture2D()
 {
     backend::TextureDescriptor textureDescriptor;
     textureDescriptor.textureFormat = PixelFormat::NONE;
-    _texture = static_cast<backend::Texture2D*>(backend::Device::getInstance()->newTexture(textureDescriptor));
+    _texture = static_cast<backend::TextureBackend2D*>(backend::Device::getInstance()->newTexture(textureDescriptor));
 }
 
 Texture2D::~Texture2D()
@@ -574,7 +574,7 @@ bool Texture2D::initWithBackendTexture(backend::Texture *texture)
 {
     CC_SAFE_RETAIN(texture);
     CC_SAFE_RELEASE(_texture);
-    _texture = dynamic_cast<backend::Texture2D*>(texture);
+    _texture = dynamic_cast<backend::TextureBackend2D*>(texture);
     CC_ASSERT(_texture);
     _pixelsWide = _contentSize.width = _texture->getWidth();
     _pixelsHigh = _contentSize.height = _texture->getHeight();

--- a/cocos/renderer/CCTexture2D.h
+++ b/cocos/renderer/CCTexture2D.h
@@ -49,7 +49,7 @@ namespace ui
 }
 
 namespace backend {
-    class Texture2D;
+    class TextureBackend2D;
     class Texture;
     class ProgramState;
 }
@@ -376,7 +376,7 @@ protected:
     int _pixelsHigh;
 
     /** texture name */
-    backend::Texture2D* _texture;
+    backend::TextureBackend2D* _texture;
     
 
     /** texture max S */

--- a/cocos/renderer/CCTexture2D.h
+++ b/cocos/renderer/CCTexture2D.h
@@ -49,8 +49,8 @@ namespace ui
 }
 
 namespace backend {
-    class TextureBackend2D;
-    class Texture;
+    class Texture2DBackend;
+    class TextureBackend;
     class ProgramState;
 }
 
@@ -228,7 +228,7 @@ public:
     bool initWithString(const char *text, const FontDefinition& textDefinition);
     
     //TODO: minggo: is it resaonable?
-    bool initWithBackendTexture(backend::Texture* texture);
+    bool initWithBackendTexture(backend::TextureBackend* texture);
 
 
     void setTexParameters(const TexParams &params);
@@ -293,7 +293,7 @@ public:
     /** Gets the height of the texture in pixels. */
     int getPixelsHigh() const;
     
-    backend::Texture* getBackendTexture() const;
+    backend::TextureBackend* getBackendTexture() const;
     
     /** Gets max S. */
     float getMaxS() const;
@@ -376,7 +376,7 @@ protected:
     int _pixelsHigh;
 
     /** texture name */
-    backend::TextureBackend2D* _texture;
+    backend::Texture2DBackend* _texture;
     
 
     /** texture max S */

--- a/cocos/renderer/CCTextureCube.cpp
+++ b/cocos/renderer/CCTextureCube.cpp
@@ -215,7 +215,7 @@ bool TextureCube::init(const std::string& positive_x, const std::string& negativ
     textureDescriptor.samplerDescriptor.magFilter = backend::SamplerFilter::LINEAR;
     textureDescriptor.samplerDescriptor.sAddressMode = backend::SamplerAddressMode::CLAMP_TO_EDGE;
     textureDescriptor.samplerDescriptor.tAddressMode = backend::SamplerAddressMode::CLAMP_TO_EDGE;
-    _texture = static_cast<backend::TextureCubemap*>(backend::Device::getInstance()->newTexture(textureDescriptor));
+    _texture = static_cast<backend::TextureBackendCubemap*>(backend::Device::getInstance()->newTexture(textureDescriptor));
     CCASSERT(_texture != nullptr, "TextureCubemap: texture can not be nullptr");
 
     for (int i = 0; i < 6; i++)

--- a/cocos/renderer/CCTextureCube.cpp
+++ b/cocos/renderer/CCTextureCube.cpp
@@ -215,7 +215,7 @@ bool TextureCube::init(const std::string& positive_x, const std::string& negativ
     textureDescriptor.samplerDescriptor.magFilter = backend::SamplerFilter::LINEAR;
     textureDescriptor.samplerDescriptor.sAddressMode = backend::SamplerAddressMode::CLAMP_TO_EDGE;
     textureDescriptor.samplerDescriptor.tAddressMode = backend::SamplerAddressMode::CLAMP_TO_EDGE;
-    _texture = static_cast<backend::TextureBackendCubemap*>(backend::Device::getInstance()->newTexture(textureDescriptor));
+    _texture = static_cast<backend::TextureCubemapBackend*>(backend::Device::getInstance()->newTexture(textureDescriptor));
     CCASSERT(_texture != nullptr, "TextureCubemap: texture can not be nullptr");
 
     for (int i = 0; i < 6; i++)

--- a/cocos/renderer/CCTextureCube.h
+++ b/cocos/renderer/CCTextureCube.h
@@ -65,7 +65,7 @@ public:
     */
     void setTexParameters(const Texture2D::TexParams&);
 
-    backend::Texture* getBackendTexture() { return _texture; }
+    backend::TextureBackend* getBackendTexture() { return _texture; }
 
     /** reload texture cube after GLESContext reconstructed.*/
     bool reloadTexture();
@@ -86,7 +86,7 @@ protected:
               const std::string& positive_z, const std::string& negative_z);
 private:
     std::vector<std::string> _imgPath;
-    backend::TextureBackendCubemap *_texture = nullptr;
+    backend::TextureCubemapBackend *_texture = nullptr;
 };
 
 // end of 3d group

--- a/cocos/renderer/CCTextureCube.h
+++ b/cocos/renderer/CCTextureCube.h
@@ -86,7 +86,7 @@ protected:
               const std::string& positive_z, const std::string& negative_z);
 private:
     std::vector<std::string> _imgPath;
-    backend::TextureCubemap *_texture = nullptr;
+    backend::TextureBackendCubemap *_texture = nullptr;
 };
 
 // end of 3d group

--- a/cocos/renderer/CCTrianglesCommand.h
+++ b/cocos/renderer/CCTrianglesCommand.h
@@ -39,7 +39,7 @@ NS_CC_BEGIN
  if the material id is the same, these TrianglesCommands could be batched to save draw call.
 */
 namespace backend {
-    class Texture;
+    class TextureBackend;
     class Program;
 }
 
@@ -116,7 +116,7 @@ protected:
     // Cached value to determine to generate material id or not.
     BlendFunc _blendType = BlendFunc::DISABLE;
     backend::Program* _program = nullptr;
-    backend::Texture* _texture = nullptr;
+    backend::TextureBackend* _texture = nullptr;
 };
 
 NS_CC_END

--- a/cocos/renderer/backend/Device.h
+++ b/cocos/renderer/backend/Device.h
@@ -38,7 +38,7 @@ public:
     // Create a buffer, not auto released.
     virtual Buffer* newBuffer(uint32_t size, BufferType type, BufferUsage usage) = 0;
     // Create a texture, not auto released.
-    virtual Texture* newTexture(const TextureDescriptor& descriptor) = 0;
+    virtual TextureBackend* newTexture(const TextureDescriptor& descriptor) = 0;
     // Create a auto released depth stencil state.
     virtual DepthStencilState* createDepthStencilState(const DepthStencilDescriptor& descriptor) = 0;
     // Create a auto released blend state.

--- a/cocos/renderer/backend/ProgramState.cpp
+++ b/cocos/renderer/backend/ProgramState.cpp
@@ -102,7 +102,7 @@ UniformBuffer& UniformBuffer::operator=(UniformBuffer&& rhs)
     return *this;
 }
 
-TextureInfo::TextureInfo(const std::vector<uint32_t>& _slots, const std::vector<backend::Texture*> _textures)
+TextureInfo::TextureInfo(const std::vector<uint32_t>& _slots, const std::vector<backend::TextureBackend*> _textures)
 : slot(_slots)
 , textures(_textures)
 {
@@ -411,7 +411,7 @@ void ProgramState::setFragmentUniform(int location, const void* data, uint32_t s
     _fragmentUniformInfos[location].data.assign((char *)data, (char *)data + size);
 }
 
-void ProgramState::setTexture(const backend::UniformLocation& uniformLocation, uint32_t slot, backend::Texture* texture)
+void ProgramState::setTexture(const backend::UniformLocation& uniformLocation, uint32_t slot, backend::TextureBackend* texture)
 {
     switch (uniformLocation.shaderStage)
     {
@@ -430,7 +430,7 @@ void ProgramState::setTexture(const backend::UniformLocation& uniformLocation, u
     }
 }
 
-void ProgramState::setTextureArray(const backend::UniformLocation& uniformLocation, const std::vector<uint32_t>& slots, const std::vector<backend::Texture*> textures)
+void ProgramState::setTextureArray(const backend::UniformLocation& uniformLocation, const std::vector<uint32_t>& slots, const std::vector<backend::TextureBackend*> textures)
 {
     switch (uniformLocation.shaderStage)
     {
@@ -449,7 +449,7 @@ void ProgramState::setTextureArray(const backend::UniformLocation& uniformLocati
     }
 }
 
-void ProgramState::setTexture(int location, uint32_t slot, backend::Texture* texture, std::unordered_map<int, TextureInfo>& textureInfo)
+void ProgramState::setTexture(int location, uint32_t slot, backend::TextureBackend* texture, std::unordered_map<int, TextureInfo>& textureInfo)
 {
     if(location < 0)
         return;
@@ -463,7 +463,7 @@ void ProgramState::setTexture(int location, uint32_t slot, backend::Texture* tex
     textureInfo[location] = std::move(info);
 }
 
-void ProgramState::setTextureArray(int location, const std::vector<uint32_t>& slots, const std::vector<backend::Texture*> textures, std::unordered_map<int, TextureInfo>& textureInfo)
+void ProgramState::setTextureArray(int location, const std::vector<uint32_t>& slots, const std::vector<backend::TextureBackend*> textures, std::unordered_map<int, TextureInfo>& textureInfo)
 {
     assert(slots.size() == textures.size());
     TextureInfo info;

--- a/cocos/renderer/backend/ProgramState.h
+++ b/cocos/renderer/backend/ProgramState.h
@@ -13,7 +13,7 @@
 
 CC_BACKEND_BEGIN
 
-class Texture;
+class TextureBackend;
 
 struct UniformBuffer
 {
@@ -33,7 +33,7 @@ struct UniformBuffer
 
 struct TextureInfo
 {
-    TextureInfo(const std::vector<uint32_t>& _slots, const std::vector<backend::Texture*> _textures);
+    TextureInfo(const std::vector<uint32_t>& _slots, const std::vector<backend::TextureBackend*> _textures);
     TextureInfo() = default;
     TextureInfo(const TextureInfo &);
     ~TextureInfo();
@@ -44,7 +44,7 @@ struct TextureInfo
     void releaseTextures();
     
     std::vector<uint32_t> slot;
-    std::vector<backend::Texture*> textures;
+    std::vector<backend::TextureBackend*> textures;
 #if CC_ENABLE_CACHE_TEXTURE_DATA
     int location = -1;
 #endif
@@ -77,8 +77,8 @@ public:
     void setCallbackUniform(const backend::UniformLocation&, const UniformCallback &);
 
     //set textures
-    void setTexture(const backend::UniformLocation& uniformLocation, uint32_t slot, backend::Texture* texture);
-    void setTextureArray(const backend::UniformLocation& uniformLocation, const std::vector<uint32_t>& slots, const std::vector<backend::Texture*> textures);
+    void setTexture(const backend::UniformLocation& uniformLocation, uint32_t slot, backend::TextureBackend* texture);
+    void setTextureArray(const backend::UniformLocation& uniformLocation, const std::vector<uint32_t>& slots, const std::vector<backend::TextureBackend*> textures);
 
     inline const std::unordered_map<int, TextureInfo>& getVertexTextureInfos() const { return _vertexTextureInfos; }
     inline const std::unordered_map<int, TextureInfo>& getFragmentTextureInfos() const { return _fragmentTextureInfos; }
@@ -154,8 +154,8 @@ protected:
     void setFragmentUniform(int location, const void* data, uint32_t size);
     void createVertexUniformBuffer();
     void createFragmentUniformBuffer();
-    void setTexture(int location, uint32_t slot, backend::Texture* texture, std::unordered_map<int, TextureInfo>& textureInfo);
-    void setTextureArray(int location, const std::vector<uint32_t>& slots, const std::vector<backend::Texture*> textures, std::unordered_map<int, TextureInfo>& textureInfo);
+    void setTexture(int location, uint32_t slot, backend::TextureBackend* texture, std::unordered_map<int, TextureInfo>& textureInfo);
+    void setTextureArray(int location, const std::vector<uint32_t>& slots, const std::vector<backend::TextureBackend*> textures, std::unordered_map<int, TextureInfo>& textureInfo);
     void resetUniforms();
     
 #ifdef CC_USE_METAL

--- a/cocos/renderer/backend/RenderPassDescriptor.h
+++ b/cocos/renderer/backend/RenderPassDescriptor.h
@@ -8,7 +8,7 @@
 
 CC_BACKEND_BEGIN
 
-class Texture;
+class TextureBackend;
 
 struct RenderPassDescriptor
 {
@@ -24,9 +24,9 @@ struct RenderPassDescriptor
     bool needClearColor = false;
     bool needClearDepth = false;
     bool needClearStencil = false;
-    Texture* depthAttachmentTexture = nullptr;
-    Texture* stencilAttachmentTexture = nullptr;
-    Texture* colorAttachmentsTexture[MAX_COLOR_ATTCHMENT] = { nullptr };
+    TextureBackend* depthAttachmentTexture = nullptr;
+    TextureBackend* stencilAttachmentTexture = nullptr;
+    TextureBackend* colorAttachmentsTexture[MAX_COLOR_ATTCHMENT] = { nullptr };
 };
 
 CC_BACKEND_END

--- a/cocos/renderer/backend/Texture.cpp
+++ b/cocos/renderer/backend/Texture.cpp
@@ -93,12 +93,12 @@ void Texture::updateTextureDescriptor(const cocos2d::backend::TextureDescriptor 
     _height = descriptor.height;
 }
 
-Texture2D::Texture2D(const TextureDescriptor& descriptor)
+TextureBackend2D::TextureBackend2D(const TextureDescriptor& descriptor)
     : Texture(descriptor)
 {
 }
 
-TextureCubemap::TextureCubemap(const TextureDescriptor &descriptor)
+TextureBackendCubemap::TextureBackendCubemap(const TextureDescriptor &descriptor)
     : Texture(descriptor)
 {
 

--- a/cocos/renderer/backend/Texture.cpp
+++ b/cocos/renderer/backend/Texture.cpp
@@ -70,7 +70,7 @@ namespace
     }
 }
 
-Texture::Texture(const TextureDescriptor& descriptor)
+TextureBackend::TextureBackend(const TextureDescriptor& descriptor)
     : _bitsPerElement(computeBitsPerElement(descriptor.textureFormat))
     , _textureType(descriptor.textureType)
     , _textureFormat(descriptor.textureFormat)
@@ -80,10 +80,10 @@ Texture::Texture(const TextureDescriptor& descriptor)
 {
 }
 
-Texture::~Texture()
+TextureBackend::~TextureBackend()
 {}
 
-void Texture::updateTextureDescriptor(const cocos2d::backend::TextureDescriptor &descriptor)
+void TextureBackend::updateTextureDescriptor(const cocos2d::backend::TextureDescriptor &descriptor)
 {
     _bitsPerElement = computeBitsPerElement(descriptor.textureFormat);
     _textureType = descriptor.textureType;
@@ -93,13 +93,13 @@ void Texture::updateTextureDescriptor(const cocos2d::backend::TextureDescriptor 
     _height = descriptor.height;
 }
 
-TextureBackend2D::TextureBackend2D(const TextureDescriptor& descriptor)
-    : Texture(descriptor)
+Texture2DBackend::Texture2DBackend(const TextureDescriptor& descriptor)
+    : TextureBackend(descriptor)
 {
 }
 
-TextureBackendCubemap::TextureBackendCubemap(const TextureDescriptor &descriptor)
-    : Texture(descriptor)
+TextureCubemapBackend::TextureCubemapBackend(const TextureDescriptor &descriptor)
+    : TextureBackend(descriptor)
 {
 
 }

--- a/cocos/renderer/backend/Texture.h
+++ b/cocos/renderer/backend/Texture.h
@@ -49,7 +49,7 @@ protected:
 };
 
 
-class Texture2D : public Texture
+class TextureBackend2D : public Texture
 {
 public:
     virtual void updateData(uint8_t* data, uint32_t width , uint32_t height, uint32_t level) = 0;
@@ -61,16 +61,16 @@ public:
     inline uint32_t getHeight() const { return _height; }
 
 protected:
-    Texture2D(const TextureDescriptor& descriptor);
+    TextureBackend2D(const TextureDescriptor& descriptor);
 };
 
-class TextureCubemap : public Texture
+class TextureBackendCubemap : public Texture
 {
 public:
     virtual void updateFaceData(TextureCubeFace side, void *data) = 0;
         
 protected:
-    TextureCubemap(const TextureDescriptor& descriptor);
+    TextureBackendCubemap(const TextureDescriptor& descriptor);
 };
 
 CC_BACKEND_END

--- a/cocos/renderer/backend/Texture.h
+++ b/cocos/renderer/backend/Texture.h
@@ -19,7 +19,7 @@ struct TextureDescriptor
     SamplerDescriptor samplerDescriptor;
 };
 
-class Texture : public Ref
+class TextureBackend : public Ref
 {
 public:
     virtual void updateSamplerDescriptor(const SamplerDescriptor &sampler) = 0;
@@ -33,8 +33,8 @@ public:
     inline bool hasMipmaps() const { return _hasMipmaps; }
 
 protected:
-    Texture(const TextureDescriptor& descriptor);
-    virtual ~Texture();
+    TextureBackend(const TextureDescriptor& descriptor);
+    virtual ~TextureBackend();
         
     // The bytes of all components.
     uint8_t _bitsPerElement = 0;
@@ -49,7 +49,7 @@ protected:
 };
 
 
-class TextureBackend2D : public Texture
+class Texture2DBackend : public TextureBackend
 {
 public:
     virtual void updateData(uint8_t* data, uint32_t width , uint32_t height, uint32_t level) = 0;
@@ -61,16 +61,16 @@ public:
     inline uint32_t getHeight() const { return _height; }
 
 protected:
-    TextureBackend2D(const TextureDescriptor& descriptor);
+    Texture2DBackend(const TextureDescriptor& descriptor);
 };
 
-class TextureBackendCubemap : public Texture
+class TextureCubemapBackend : public TextureBackend
 {
 public:
     virtual void updateFaceData(TextureCubeFace side, void *data) = 0;
         
 protected:
-    TextureBackendCubemap(const TextureDescriptor& descriptor);
+    TextureCubemapBackend(const TextureDescriptor& descriptor);
 };
 
 CC_BACKEND_END

--- a/cocos/renderer/backend/metal/CommandBufferMTL.mm
+++ b/cocos/renderer/backend/metal/CommandBufferMTL.mm
@@ -154,7 +154,7 @@ namespace
         return mtlDescritpor;
     }
     
-    id<MTLTexture> getMTLTexture(Texture* texture)
+    id<MTLTexture> getMTLTexture(TextureBackend* texture)
     {
         switch (texture->getTextureType())
         {
@@ -168,7 +168,7 @@ namespace
         }
     }
     
-    id<MTLSamplerState> getMTLSamplerState(Texture* texture)
+    id<MTLSamplerState> getMTLSamplerState(TextureBackend* texture)
     {
         switch (texture->getTextureType())
         {

--- a/cocos/renderer/backend/metal/DeviceMTL.h
+++ b/cocos/renderer/backend/metal/DeviceMTL.h
@@ -22,7 +22,7 @@ public:
     
     virtual CommandBuffer* newCommandBuffer() override;
     virtual Buffer* newBuffer(unsigned int size, BufferType type, BufferUsage usage) override;
-    virtual Texture* newTexture(const TextureDescriptor& descriptor) override;
+    virtual TextureBackend* newTexture(const TextureDescriptor& descriptor) override;
     virtual DepthStencilState* createDepthStencilState(const DepthStencilDescriptor& descriptor) override;
     virtual BlendState* createBlendState(const BlendDescriptor& descriptor) override;
     virtual RenderPipeline* newRenderPipeline(const RenderPipelineDescriptor& descriptor) override;

--- a/cocos/renderer/backend/metal/DeviceMTL.mm
+++ b/cocos/renderer/backend/metal/DeviceMTL.mm
@@ -72,7 +72,7 @@ Buffer* DeviceMTL::newBuffer(unsigned int size, BufferType type, BufferUsage usa
     return new (std::nothrow) BufferMTL(_mtlDevice, size, type, usage);
 }
 
-Texture* DeviceMTL::newTexture(const TextureDescriptor& descriptor)
+TextureBackend* DeviceMTL::newTexture(const TextureDescriptor& descriptor)
 {
     switch(descriptor.textureType)
     {

--- a/cocos/renderer/backend/metal/TextureMTL.h
+++ b/cocos/renderer/backend/metal/TextureMTL.h
@@ -6,7 +6,7 @@
 
 CC_BACKEND_BEGIN
 
-class TextureMTL : public backend::TextureBackend2D
+class TextureMTL : public backend::Texture2DBackend
 {
 public:
     TextureMTL(id<MTLDevice> mtlDevice, const TextureDescriptor& descriptor);
@@ -41,7 +41,7 @@ private:
     unsigned int _bytesPerRow = 0;
 };
 
-class TextureCubeMTL : public backend::TextureBackendCubemap
+class TextureCubeMTL : public backend::TextureCubemapBackend
 {
 public:
     TextureCubeMTL(id<MTLDevice> mtlDevice, const TextureDescriptor& descriptor);

--- a/cocos/renderer/backend/metal/TextureMTL.h
+++ b/cocos/renderer/backend/metal/TextureMTL.h
@@ -6,7 +6,7 @@
 
 CC_BACKEND_BEGIN
 
-class TextureMTL : public backend::Texture2D
+class TextureMTL : public backend::TextureBackend2D
 {
 public:
     TextureMTL(id<MTLDevice> mtlDevice, const TextureDescriptor& descriptor);

--- a/cocos/renderer/backend/metal/TextureMTL.h
+++ b/cocos/renderer/backend/metal/TextureMTL.h
@@ -41,7 +41,7 @@ private:
     unsigned int _bytesPerRow = 0;
 };
 
-class TextureCubeMTL : public backend::TextureCubemap
+class TextureCubeMTL : public backend::TextureBackendCubemap
 {
 public:
     TextureCubeMTL(id<MTLDevice> mtlDevice, const TextureDescriptor& descriptor);

--- a/cocos/renderer/backend/metal/TextureMTL.mm
+++ b/cocos/renderer/backend/metal/TextureMTL.mm
@@ -331,7 +331,7 @@ void TextureMTL::generateMipmaps()
 }
 
 TextureCubeMTL::TextureCubeMTL(id<MTLDevice> mtlDevice, const TextureDescriptor& descriptor)
-: backend::TextureCubemap(descriptor)
+: backend::TextureBackendCubemap(descriptor)
 {
     _mtlDevice = mtlDevice;
     updateTextureDescriptor(descriptor);

--- a/cocos/renderer/backend/metal/TextureMTL.mm
+++ b/cocos/renderer/backend/metal/TextureMTL.mm
@@ -165,7 +165,7 @@ namespace
 }
 
 TextureMTL::TextureMTL(id<MTLDevice> mtlDevice, const TextureDescriptor& descriptor)
-: backend::Texture2D(descriptor)
+: backend::TextureBackend2D(descriptor)
 {
     _mtlDevice = mtlDevice;
     updateTextureDescriptor(descriptor);

--- a/cocos/renderer/backend/metal/TextureMTL.mm
+++ b/cocos/renderer/backend/metal/TextureMTL.mm
@@ -165,7 +165,7 @@ namespace
 }
 
 TextureMTL::TextureMTL(id<MTLDevice> mtlDevice, const TextureDescriptor& descriptor)
-: backend::TextureBackend2D(descriptor)
+: backend::Texture2DBackend(descriptor)
 {
     _mtlDevice = mtlDevice;
     updateTextureDescriptor(descriptor);
@@ -331,7 +331,7 @@ void TextureMTL::generateMipmaps()
 }
 
 TextureCubeMTL::TextureCubeMTL(id<MTLDevice> mtlDevice, const TextureDescriptor& descriptor)
-: backend::TextureBackendCubemap(descriptor)
+: backend::TextureCubemapBackend(descriptor)
 {
     _mtlDevice = mtlDevice;
     updateTextureDescriptor(descriptor);

--- a/cocos/renderer/backend/metal/TextureMTL.mm
+++ b/cocos/renderer/backend/metal/TextureMTL.mm
@@ -184,7 +184,7 @@ void TextureMTL::updateSamplerDescriptor(const SamplerDescriptor &sampler)
 
 void TextureMTL::updateTextureDescriptor(const cocos2d::backend::TextureDescriptor &descriptor)
 {
-    Texture::updateTextureDescriptor(descriptor);
+    TextureBackend::updateTextureDescriptor(descriptor);
     createTexture(_mtlDevice, descriptor);
     updateSamplerDescriptor(descriptor.samplerDescriptor);
     if (PixelFormat::RGB888 == _textureFormat)
@@ -345,7 +345,7 @@ TextureCubeMTL::~TextureCubeMTL()
 
 void TextureCubeMTL::updateTextureDescriptor(const cocos2d::backend::TextureDescriptor &descriptor)
 {
-    Texture::updateTextureDescriptor(descriptor);
+    TextureBackend::updateTextureDescriptor(descriptor);
     createTexture(_mtlDevice, descriptor);
     updateSamplerDescriptor(descriptor.samplerDescriptor);
     

--- a/cocos/renderer/backend/opengl/CommandBufferGL.cpp
+++ b/cocos/renderer/backend/opengl/CommandBufferGL.cpp
@@ -17,7 +17,7 @@ CC_BACKEND_BEGIN
 namespace
 {
 
-    GLuint getHandler(Texture *texture)
+    GLuint getHandler(TextureBackend *texture)
     {
         switch (texture->getTextureType())
         {
@@ -31,7 +31,7 @@ namespace
         }
     }
 
-    void applyTexture(Texture* texture, int slot)
+    void applyTexture(TextureBackend* texture, int slot)
     {
         switch (texture->getTextureType())
         {

--- a/cocos/renderer/backend/opengl/DeviceGL.cpp
+++ b/cocos/renderer/backend/opengl/DeviceGL.cpp
@@ -46,7 +46,7 @@ Buffer* DeviceGL::newBuffer(unsigned int size, BufferType type, BufferUsage usag
     return new (std::nothrow) BufferGL(size, type, usage);
 }
 
-Texture* DeviceGL::newTexture(const TextureDescriptor& descriptor)
+TextureBackend* DeviceGL::newTexture(const TextureDescriptor& descriptor)
 {
     switch (descriptor.textureType)
     {

--- a/cocos/renderer/backend/opengl/DeviceGL.h
+++ b/cocos/renderer/backend/opengl/DeviceGL.h
@@ -10,7 +10,7 @@ public:
 
     virtual CommandBuffer* newCommandBuffer() override;
     virtual Buffer* newBuffer(unsigned int size, BufferType type, BufferUsage usage) override;
-    virtual Texture* newTexture(const TextureDescriptor& descriptor) override;
+    virtual TextureBackend* newTexture(const TextureDescriptor& descriptor) override;
     virtual DepthStencilState* createDepthStencilState(const DepthStencilDescriptor& descriptor) override;
     virtual BlendState* createBlendState(const BlendDescriptor& descriptor) override;
     virtual RenderPipeline* newRenderPipeline(const RenderPipelineDescriptor& descriptor) override;

--- a/cocos/renderer/backend/opengl/TextureGL.cpp
+++ b/cocos/renderer/backend/opengl/TextureGL.cpp
@@ -51,7 +51,7 @@ void TextureInfoGL::applySamplerDescriptor(const SamplerDescriptor& descriptor, 
     }
 }
 
-Texture2DGL::Texture2DGL(const TextureDescriptor& descriptor) : TextureBackend2D(descriptor)
+Texture2DGL::Texture2DGL(const TextureDescriptor& descriptor) : Texture2DBackend(descriptor)
 {
     glGenTextures(1, &_textureInfo.texture);
 
@@ -78,7 +78,7 @@ void Texture2DGL::initWithZeros()
 
 void Texture2DGL::updateTextureDescriptor(const cocos2d::backend::TextureDescriptor &descriptor)
 {
-    Texture::updateTextureDescriptor(descriptor);
+    TextureBackend::updateTextureDescriptor(descriptor);
     UtilsGL::toGLTypes(descriptor.textureFormat, _textureInfo.internalFormat, _textureInfo.format, _textureInfo.type, _isCompressed);
 
     bool isPow2 = ISPOW2(_width) && ISPOW2(_height);
@@ -311,7 +311,7 @@ void Texture2DGL::getBytes(int x, int y, int width, int height, bool flipImage, 
 }
 
 TextureCubeGL::TextureCubeGL(const TextureDescriptor& descriptor)
-    :TextureBackendCubemap(descriptor)
+    :TextureCubemapBackend(descriptor)
 {
     assert(_width == _height);
     _textureType = TextureType::TEXTURE_CUBE;

--- a/cocos/renderer/backend/opengl/TextureGL.cpp
+++ b/cocos/renderer/backend/opengl/TextureGL.cpp
@@ -51,7 +51,7 @@ void TextureInfoGL::applySamplerDescriptor(const SamplerDescriptor& descriptor, 
     }
 }
 
-Texture2DGL::Texture2DGL(const TextureDescriptor& descriptor) : Texture2D(descriptor)
+Texture2DGL::Texture2DGL(const TextureDescriptor& descriptor) : TextureBackend2D(descriptor)
 {
     glGenTextures(1, &_textureInfo.texture);
 
@@ -311,7 +311,7 @@ void Texture2DGL::getBytes(int x, int y, int width, int height, bool flipImage, 
 }
 
 TextureCubeGL::TextureCubeGL(const TextureDescriptor& descriptor)
-    :TextureCubemap(descriptor)
+    :TextureBackendCubemap(descriptor)
 {
     assert(_width == _height);
     _textureType = TextureType::TEXTURE_CUBE;

--- a/cocos/renderer/backend/opengl/TextureGL.h
+++ b/cocos/renderer/backend/opengl/TextureGL.h
@@ -23,7 +23,7 @@ struct TextureInfoGL
     GLuint texture = 0;
 };
 
-class Texture2DGL : public backend::Texture2D
+class Texture2DGL : public backend::TextureBackend2D
 {
 public:
     Texture2DGL(const TextureDescriptor& descriptor);
@@ -50,7 +50,7 @@ private:
     EventListener* _backToForegroundListener = nullptr;
 };
 
-class TextureCubeGL: public backend::TextureCubemap
+class TextureCubeGL: public backend::TextureBackendCubemap
 {
 public:
     TextureCubeGL(const TextureDescriptor& descriptor);

--- a/cocos/renderer/backend/opengl/TextureGL.h
+++ b/cocos/renderer/backend/opengl/TextureGL.h
@@ -23,7 +23,7 @@ struct TextureInfoGL
     GLuint texture = 0;
 };
 
-class Texture2DGL : public backend::TextureBackend2D
+class Texture2DGL : public backend::Texture2DBackend
 {
 public:
     Texture2DGL(const TextureDescriptor& descriptor);
@@ -50,7 +50,7 @@ private:
     EventListener* _backToForegroundListener = nullptr;
 };
 
-class TextureCubeGL: public backend::TextureBackendCubemap
+class TextureCubeGL: public backend::TextureCubemapBackend
 {
 public:
     TextureCubeGL(const TextureDescriptor& descriptor);

--- a/cocos/scripting/lua-bindings/auto/lua_cocos2dx_3d_auto.cpp
+++ b/cocos/scripting/lua-bindings/auto/lua_cocos2dx_3d_auto.cpp
@@ -1213,8 +1213,8 @@ int lua_cocos2dx_3d_TextureCube_getBackendTexture(lua_State* tolua_S)
             tolua_error(tolua_S,"invalid arguments in function 'lua_cocos2dx_3d_TextureCube_getBackendTexture'", nullptr);
             return 0;
         }
-        cocos2d::backend::Texture* ret = cobj->getBackendTexture();
-        object_to_luaval<cocos2d::backend::Texture>(tolua_S, "ccb.Texture",(cocos2d::backend::Texture*)ret);
+        cocos2d::backend::TextureBackend* ret = cobj->getBackendTexture();
+        object_to_luaval<cocos2d::backend::TextureBackend>(tolua_S, "ccb.TextureBackend",(cocos2d::backend::TextureBackend*)ret);
         return 1;
     }
     luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "cc.TextureCube:getBackendTexture",argc, 0);

--- a/cocos/scripting/lua-bindings/auto/lua_cocos2dx_auto.cpp
+++ b/cocos/scripting/lua-bindings/auto/lua_cocos2dx_auto.cpp
@@ -591,383 +591,6 @@ int lua_register_cocos2dx_Console(lua_State* tolua_S)
     return 1;
 }
 
-int lua_cocos2dx_Texture2D_getHeight(lua_State* tolua_S)
-{
-    int argc = 0;
-    cocos2d::backend::Texture2D* cobj = nullptr;
-    bool ok  = true;
-
-#if COCOS2D_DEBUG >= 1
-    tolua_Error tolua_err;
-#endif
-
-
-#if COCOS2D_DEBUG >= 1
-    if (!tolua_isusertype(tolua_S,1,"ccb.Texture2D",0,&tolua_err)) goto tolua_lerror;
-#endif
-
-    cobj = (cocos2d::backend::Texture2D*)tolua_tousertype(tolua_S,1,0);
-
-#if COCOS2D_DEBUG >= 1
-    if (!cobj) 
-    {
-        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_cocos2dx_Texture2D_getHeight'", nullptr);
-        return 0;
-    }
-#endif
-
-    argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
-    {
-        if(!ok)
-        {
-            tolua_error(tolua_S,"invalid arguments in function 'lua_cocos2dx_Texture2D_getHeight'", nullptr);
-            return 0;
-        }
-        unsigned int ret = cobj->getHeight();
-        tolua_pushnumber(tolua_S,(lua_Number)ret);
-        return 1;
-    }
-    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ccb.Texture2D:getHeight",argc, 0);
-    return 0;
-
-#if COCOS2D_DEBUG >= 1
-    tolua_lerror:
-    tolua_error(tolua_S,"#ferror in function 'lua_cocos2dx_Texture2D_getHeight'.",&tolua_err);
-#endif
-
-    return 0;
-}
-int lua_cocos2dx_Texture2D_getWidth(lua_State* tolua_S)
-{
-    int argc = 0;
-    cocos2d::backend::Texture2D* cobj = nullptr;
-    bool ok  = true;
-
-#if COCOS2D_DEBUG >= 1
-    tolua_Error tolua_err;
-#endif
-
-
-#if COCOS2D_DEBUG >= 1
-    if (!tolua_isusertype(tolua_S,1,"ccb.Texture2D",0,&tolua_err)) goto tolua_lerror;
-#endif
-
-    cobj = (cocos2d::backend::Texture2D*)tolua_tousertype(tolua_S,1,0);
-
-#if COCOS2D_DEBUG >= 1
-    if (!cobj) 
-    {
-        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_cocos2dx_Texture2D_getWidth'", nullptr);
-        return 0;
-    }
-#endif
-
-    argc = lua_gettop(tolua_S)-1;
-    if (argc == 0) 
-    {
-        if(!ok)
-        {
-            tolua_error(tolua_S,"invalid arguments in function 'lua_cocos2dx_Texture2D_getWidth'", nullptr);
-            return 0;
-        }
-        unsigned int ret = cobj->getWidth();
-        tolua_pushnumber(tolua_S,(lua_Number)ret);
-        return 1;
-    }
-    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ccb.Texture2D:getWidth",argc, 0);
-    return 0;
-
-#if COCOS2D_DEBUG >= 1
-    tolua_lerror:
-    tolua_error(tolua_S,"#ferror in function 'lua_cocos2dx_Texture2D_getWidth'.",&tolua_err);
-#endif
-
-    return 0;
-}
-int lua_cocos2dx_Texture2D_updateData(lua_State* tolua_S)
-{
-    int argc = 0;
-    cocos2d::backend::Texture2D* cobj = nullptr;
-    bool ok  = true;
-
-#if COCOS2D_DEBUG >= 1
-    tolua_Error tolua_err;
-#endif
-
-
-#if COCOS2D_DEBUG >= 1
-    if (!tolua_isusertype(tolua_S,1,"ccb.Texture2D",0,&tolua_err)) goto tolua_lerror;
-#endif
-
-    cobj = (cocos2d::backend::Texture2D*)tolua_tousertype(tolua_S,1,0);
-
-#if COCOS2D_DEBUG >= 1
-    if (!cobj) 
-    {
-        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_cocos2dx_Texture2D_updateData'", nullptr);
-        return 0;
-    }
-#endif
-
-    argc = lua_gettop(tolua_S)-1;
-    if (argc == 4) 
-    {
-        unsigned char* arg0;
-        unsigned int arg1;
-        unsigned int arg2;
-        unsigned int arg3;
-
-        #pragma warning NO CONVERSION TO NATIVE FOR unsigned char*
-		ok = false;
-
-        ok &= luaval_to_uint32(tolua_S, 3,&arg1, "ccb.Texture2D:updateData");
-
-        ok &= luaval_to_uint32(tolua_S, 4,&arg2, "ccb.Texture2D:updateData");
-
-        ok &= luaval_to_uint32(tolua_S, 5,&arg3, "ccb.Texture2D:updateData");
-        if(!ok)
-        {
-            tolua_error(tolua_S,"invalid arguments in function 'lua_cocos2dx_Texture2D_updateData'", nullptr);
-            return 0;
-        }
-        cobj->updateData(arg0, arg1, arg2, arg3);
-        lua_settop(tolua_S, 1);
-        return 1;
-    }
-    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ccb.Texture2D:updateData",argc, 4);
-    return 0;
-
-#if COCOS2D_DEBUG >= 1
-    tolua_lerror:
-    tolua_error(tolua_S,"#ferror in function 'lua_cocos2dx_Texture2D_updateData'.",&tolua_err);
-#endif
-
-    return 0;
-}
-int lua_cocos2dx_Texture2D_updateCompressedData(lua_State* tolua_S)
-{
-    int argc = 0;
-    cocos2d::backend::Texture2D* cobj = nullptr;
-    bool ok  = true;
-
-#if COCOS2D_DEBUG >= 1
-    tolua_Error tolua_err;
-#endif
-
-
-#if COCOS2D_DEBUG >= 1
-    if (!tolua_isusertype(tolua_S,1,"ccb.Texture2D",0,&tolua_err)) goto tolua_lerror;
-#endif
-
-    cobj = (cocos2d::backend::Texture2D*)tolua_tousertype(tolua_S,1,0);
-
-#if COCOS2D_DEBUG >= 1
-    if (!cobj) 
-    {
-        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_cocos2dx_Texture2D_updateCompressedData'", nullptr);
-        return 0;
-    }
-#endif
-
-    argc = lua_gettop(tolua_S)-1;
-    if (argc == 5) 
-    {
-        unsigned char* arg0;
-        unsigned int arg1;
-        unsigned int arg2;
-        unsigned int arg3;
-        unsigned int arg4;
-
-        #pragma warning NO CONVERSION TO NATIVE FOR unsigned char*
-		ok = false;
-
-        ok &= luaval_to_uint32(tolua_S, 3,&arg1, "ccb.Texture2D:updateCompressedData");
-
-        ok &= luaval_to_uint32(tolua_S, 4,&arg2, "ccb.Texture2D:updateCompressedData");
-
-        ok &= luaval_to_uint32(tolua_S, 5,&arg3, "ccb.Texture2D:updateCompressedData");
-
-        ok &= luaval_to_uint32(tolua_S, 6,&arg4, "ccb.Texture2D:updateCompressedData");
-        if(!ok)
-        {
-            tolua_error(tolua_S,"invalid arguments in function 'lua_cocos2dx_Texture2D_updateCompressedData'", nullptr);
-            return 0;
-        }
-        cobj->updateCompressedData(arg0, arg1, arg2, arg3, arg4);
-        lua_settop(tolua_S, 1);
-        return 1;
-    }
-    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ccb.Texture2D:updateCompressedData",argc, 5);
-    return 0;
-
-#if COCOS2D_DEBUG >= 1
-    tolua_lerror:
-    tolua_error(tolua_S,"#ferror in function 'lua_cocos2dx_Texture2D_updateCompressedData'.",&tolua_err);
-#endif
-
-    return 0;
-}
-int lua_cocos2dx_Texture2D_updateSubData(lua_State* tolua_S)
-{
-    int argc = 0;
-    cocos2d::backend::Texture2D* cobj = nullptr;
-    bool ok  = true;
-
-#if COCOS2D_DEBUG >= 1
-    tolua_Error tolua_err;
-#endif
-
-
-#if COCOS2D_DEBUG >= 1
-    if (!tolua_isusertype(tolua_S,1,"ccb.Texture2D",0,&tolua_err)) goto tolua_lerror;
-#endif
-
-    cobj = (cocos2d::backend::Texture2D*)tolua_tousertype(tolua_S,1,0);
-
-#if COCOS2D_DEBUG >= 1
-    if (!cobj) 
-    {
-        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_cocos2dx_Texture2D_updateSubData'", nullptr);
-        return 0;
-    }
-#endif
-
-    argc = lua_gettop(tolua_S)-1;
-    if (argc == 6) 
-    {
-        unsigned int arg0;
-        unsigned int arg1;
-        unsigned int arg2;
-        unsigned int arg3;
-        unsigned int arg4;
-        unsigned char* arg5;
-
-        ok &= luaval_to_uint32(tolua_S, 2,&arg0, "ccb.Texture2D:updateSubData");
-
-        ok &= luaval_to_uint32(tolua_S, 3,&arg1, "ccb.Texture2D:updateSubData");
-
-        ok &= luaval_to_uint32(tolua_S, 4,&arg2, "ccb.Texture2D:updateSubData");
-
-        ok &= luaval_to_uint32(tolua_S, 5,&arg3, "ccb.Texture2D:updateSubData");
-
-        ok &= luaval_to_uint32(tolua_S, 6,&arg4, "ccb.Texture2D:updateSubData");
-
-        #pragma warning NO CONVERSION TO NATIVE FOR unsigned char*
-		ok = false;
-        if(!ok)
-        {
-            tolua_error(tolua_S,"invalid arguments in function 'lua_cocos2dx_Texture2D_updateSubData'", nullptr);
-            return 0;
-        }
-        cobj->updateSubData(arg0, arg1, arg2, arg3, arg4, arg5);
-        lua_settop(tolua_S, 1);
-        return 1;
-    }
-    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ccb.Texture2D:updateSubData",argc, 6);
-    return 0;
-
-#if COCOS2D_DEBUG >= 1
-    tolua_lerror:
-    tolua_error(tolua_S,"#ferror in function 'lua_cocos2dx_Texture2D_updateSubData'.",&tolua_err);
-#endif
-
-    return 0;
-}
-int lua_cocos2dx_Texture2D_updateCompressedSubData(lua_State* tolua_S)
-{
-    int argc = 0;
-    cocos2d::backend::Texture2D* cobj = nullptr;
-    bool ok  = true;
-
-#if COCOS2D_DEBUG >= 1
-    tolua_Error tolua_err;
-#endif
-
-
-#if COCOS2D_DEBUG >= 1
-    if (!tolua_isusertype(tolua_S,1,"ccb.Texture2D",0,&tolua_err)) goto tolua_lerror;
-#endif
-
-    cobj = (cocos2d::backend::Texture2D*)tolua_tousertype(tolua_S,1,0);
-
-#if COCOS2D_DEBUG >= 1
-    if (!cobj) 
-    {
-        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_cocos2dx_Texture2D_updateCompressedSubData'", nullptr);
-        return 0;
-    }
-#endif
-
-    argc = lua_gettop(tolua_S)-1;
-    if (argc == 7) 
-    {
-        unsigned int arg0;
-        unsigned int arg1;
-        unsigned int arg2;
-        unsigned int arg3;
-        unsigned int arg4;
-        unsigned int arg5;
-        unsigned char* arg6;
-
-        ok &= luaval_to_uint32(tolua_S, 2,&arg0, "ccb.Texture2D:updateCompressedSubData");
-
-        ok &= luaval_to_uint32(tolua_S, 3,&arg1, "ccb.Texture2D:updateCompressedSubData");
-
-        ok &= luaval_to_uint32(tolua_S, 4,&arg2, "ccb.Texture2D:updateCompressedSubData");
-
-        ok &= luaval_to_uint32(tolua_S, 5,&arg3, "ccb.Texture2D:updateCompressedSubData");
-
-        ok &= luaval_to_uint32(tolua_S, 6,&arg4, "ccb.Texture2D:updateCompressedSubData");
-
-        ok &= luaval_to_uint32(tolua_S, 7,&arg5, "ccb.Texture2D:updateCompressedSubData");
-
-        #pragma warning NO CONVERSION TO NATIVE FOR unsigned char*
-		ok = false;
-        if(!ok)
-        {
-            tolua_error(tolua_S,"invalid arguments in function 'lua_cocos2dx_Texture2D_updateCompressedSubData'", nullptr);
-            return 0;
-        }
-        cobj->updateCompressedSubData(arg0, arg1, arg2, arg3, arg4, arg5, arg6);
-        lua_settop(tolua_S, 1);
-        return 1;
-    }
-    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ccb.Texture2D:updateCompressedSubData",argc, 7);
-    return 0;
-
-#if COCOS2D_DEBUG >= 1
-    tolua_lerror:
-    tolua_error(tolua_S,"#ferror in function 'lua_cocos2dx_Texture2D_updateCompressedSubData'.",&tolua_err);
-#endif
-
-    return 0;
-}
-static int lua_cocos2dx_Texture2D_finalize(lua_State* tolua_S)
-{
-    printf("luabindings: finalizing LUA object (Texture2D)");
-    return 0;
-}
-
-int lua_register_cocos2dx_Texture2D(lua_State* tolua_S)
-{
-    tolua_usertype(tolua_S,"ccb.Texture2D");
-    tolua_cclass(tolua_S,"Texture2D","ccb.Texture2D","ccb.Texture",nullptr);
-
-    tolua_beginmodule(tolua_S,"Texture2D");
-        tolua_function(tolua_S,"getHeight",lua_cocos2dx_Texture2D_getHeight);
-        tolua_function(tolua_S,"getWidth",lua_cocos2dx_Texture2D_getWidth);
-        tolua_function(tolua_S,"updateData",lua_cocos2dx_Texture2D_updateData);
-        tolua_function(tolua_S,"updateCompressedData",lua_cocos2dx_Texture2D_updateCompressedData);
-        tolua_function(tolua_S,"updateSubData",lua_cocos2dx_Texture2D_updateSubData);
-        tolua_function(tolua_S,"updateCompressedSubData",lua_cocos2dx_Texture2D_updateCompressedSubData);
-    tolua_endmodule(tolua_S);
-    std::string typeName = typeid(cocos2d::backend::Texture2D).name();
-    g_luaType[typeName] = "ccb.Texture2D";
-    g_typeCast["Texture2D"] = "ccb.Texture2D";
-    return 1;
-}
-
 int lua_cocos2dx_EventListener_setEnabled(lua_State* tolua_S)
 {
     int argc = 0;
@@ -1450,10 +1073,1522 @@ int lua_register_cocos2dx_ShaderCache(lua_State* tolua_S)
     return 1;
 }
 
-int lua_cocos2dx_PipelineDescriptor_constructor(lua_State* tolua_S)
+int lua_cocos2dx_Texture2D_getMaxT(lua_State* tolua_S)
 {
     int argc = 0;
-    cocos2d::PipelineDescriptor* cobj = nullptr;
+    cocos2d::Texture2D* cobj = nullptr;
+    bool ok  = true;
+
+#if COCOS2D_DEBUG >= 1
+    tolua_Error tolua_err;
+#endif
+
+
+#if COCOS2D_DEBUG >= 1
+    if (!tolua_isusertype(tolua_S,1,"cc.Texture2D",0,&tolua_err)) goto tolua_lerror;
+#endif
+
+    cobj = (cocos2d::Texture2D*)tolua_tousertype(tolua_S,1,0);
+
+#if COCOS2D_DEBUG >= 1
+    if (!cobj) 
+    {
+        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_cocos2dx_Texture2D_getMaxT'", nullptr);
+        return 0;
+    }
+#endif
+
+    argc = lua_gettop(tolua_S)-1;
+    if (argc == 0) 
+    {
+        if(!ok)
+        {
+            tolua_error(tolua_S,"invalid arguments in function 'lua_cocos2dx_Texture2D_getMaxT'", nullptr);
+            return 0;
+        }
+        double ret = cobj->getMaxT();
+        tolua_pushnumber(tolua_S,(lua_Number)ret);
+        return 1;
+    }
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "cc.Texture2D:getMaxT",argc, 0);
+    return 0;
+
+#if COCOS2D_DEBUG >= 1
+    tolua_lerror:
+    tolua_error(tolua_S,"#ferror in function 'lua_cocos2dx_Texture2D_getMaxT'.",&tolua_err);
+#endif
+
+    return 0;
+}
+int lua_cocos2dx_Texture2D_setAlphaTexture(lua_State* tolua_S)
+{
+    int argc = 0;
+    cocos2d::Texture2D* cobj = nullptr;
+    bool ok  = true;
+
+#if COCOS2D_DEBUG >= 1
+    tolua_Error tolua_err;
+#endif
+
+
+#if COCOS2D_DEBUG >= 1
+    if (!tolua_isusertype(tolua_S,1,"cc.Texture2D",0,&tolua_err)) goto tolua_lerror;
+#endif
+
+    cobj = (cocos2d::Texture2D*)tolua_tousertype(tolua_S,1,0);
+
+#if COCOS2D_DEBUG >= 1
+    if (!cobj) 
+    {
+        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_cocos2dx_Texture2D_setAlphaTexture'", nullptr);
+        return 0;
+    }
+#endif
+
+    argc = lua_gettop(tolua_S)-1;
+    if (argc == 1) 
+    {
+        cocos2d::Texture2D* arg0;
+
+        ok &= luaval_to_object<cocos2d::Texture2D>(tolua_S, 2, "cc.Texture2D",&arg0, "cc.Texture2D:setAlphaTexture");
+        if(!ok)
+        {
+            tolua_error(tolua_S,"invalid arguments in function 'lua_cocos2dx_Texture2D_setAlphaTexture'", nullptr);
+            return 0;
+        }
+        cobj->setAlphaTexture(arg0);
+        lua_settop(tolua_S, 1);
+        return 1;
+    }
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "cc.Texture2D:setAlphaTexture",argc, 1);
+    return 0;
+
+#if COCOS2D_DEBUG >= 1
+    tolua_lerror:
+    tolua_error(tolua_S,"#ferror in function 'lua_cocos2dx_Texture2D_setAlphaTexture'.",&tolua_err);
+#endif
+
+    return 0;
+}
+int lua_cocos2dx_Texture2D_getStringForFormat(lua_State* tolua_S)
+{
+    int argc = 0;
+    cocos2d::Texture2D* cobj = nullptr;
+    bool ok  = true;
+
+#if COCOS2D_DEBUG >= 1
+    tolua_Error tolua_err;
+#endif
+
+
+#if COCOS2D_DEBUG >= 1
+    if (!tolua_isusertype(tolua_S,1,"cc.Texture2D",0,&tolua_err)) goto tolua_lerror;
+#endif
+
+    cobj = (cocos2d::Texture2D*)tolua_tousertype(tolua_S,1,0);
+
+#if COCOS2D_DEBUG >= 1
+    if (!cobj) 
+    {
+        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_cocos2dx_Texture2D_getStringForFormat'", nullptr);
+        return 0;
+    }
+#endif
+
+    argc = lua_gettop(tolua_S)-1;
+    if (argc == 0) 
+    {
+        if(!ok)
+        {
+            tolua_error(tolua_S,"invalid arguments in function 'lua_cocos2dx_Texture2D_getStringForFormat'", nullptr);
+            return 0;
+        }
+        const char* ret = cobj->getStringForFormat();
+        tolua_pushstring(tolua_S,(const char*)ret);
+        return 1;
+    }
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "cc.Texture2D:getStringForFormat",argc, 0);
+    return 0;
+
+#if COCOS2D_DEBUG >= 1
+    tolua_lerror:
+    tolua_error(tolua_S,"#ferror in function 'lua_cocos2dx_Texture2D_getStringForFormat'.",&tolua_err);
+#endif
+
+    return 0;
+}
+int lua_cocos2dx_Texture2D_initWithImage(lua_State* tolua_S)
+{
+    int argc = 0;
+    cocos2d::Texture2D* cobj = nullptr;
+    bool ok  = true;
+#if COCOS2D_DEBUG >= 1
+    tolua_Error tolua_err;
+#endif
+
+#if COCOS2D_DEBUG >= 1
+    if (!tolua_isusertype(tolua_S,1,"cc.Texture2D",0,&tolua_err)) goto tolua_lerror;
+#endif
+    cobj = (cocos2d::Texture2D*)tolua_tousertype(tolua_S,1,0);
+#if COCOS2D_DEBUG >= 1
+    if (!cobj)
+    {
+        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_cocos2dx_Texture2D_initWithImage'", nullptr);
+        return 0;
+    }
+#endif
+    argc = lua_gettop(tolua_S)-1;
+    do{
+        if (argc == 2) {
+            cocos2d::Image* arg0;
+            ok &= luaval_to_object<cocos2d::Image>(tolua_S, 2, "cc.Image",&arg0, "cc.Texture2D:initWithImage");
+
+            if (!ok) { break; }
+            cocos2d::backend::PixelFormat arg1;
+            ok &= luaval_to_int32(tolua_S, 3,(int *)&arg1, "cc.Texture2D:initWithImage");
+
+            if (!ok) { break; }
+            bool ret = cobj->initWithImage(arg0, arg1);
+            tolua_pushboolean(tolua_S,(bool)ret);
+            return 1;
+        }
+    }while(0);
+    ok  = true;
+    do{
+        if (argc == 1) {
+            cocos2d::Image* arg0;
+            ok &= luaval_to_object<cocos2d::Image>(tolua_S, 2, "cc.Image",&arg0, "cc.Texture2D:initWithImage");
+
+            if (!ok) { break; }
+            bool ret = cobj->initWithImage(arg0);
+            tolua_pushboolean(tolua_S,(bool)ret);
+            return 1;
+        }
+    }while(0);
+    ok  = true;
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n",  "cc.Texture2D:initWithImage",argc, 1);
+    return 0;
+
+#if COCOS2D_DEBUG >= 1
+    tolua_lerror:
+    tolua_error(tolua_S,"#ferror in function 'lua_cocos2dx_Texture2D_initWithImage'.",&tolua_err);
+#endif
+
+    return 0;
+}
+int lua_cocos2dx_Texture2D_getMaxS(lua_State* tolua_S)
+{
+    int argc = 0;
+    cocos2d::Texture2D* cobj = nullptr;
+    bool ok  = true;
+
+#if COCOS2D_DEBUG >= 1
+    tolua_Error tolua_err;
+#endif
+
+
+#if COCOS2D_DEBUG >= 1
+    if (!tolua_isusertype(tolua_S,1,"cc.Texture2D",0,&tolua_err)) goto tolua_lerror;
+#endif
+
+    cobj = (cocos2d::Texture2D*)tolua_tousertype(tolua_S,1,0);
+
+#if COCOS2D_DEBUG >= 1
+    if (!cobj) 
+    {
+        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_cocos2dx_Texture2D_getMaxS'", nullptr);
+        return 0;
+    }
+#endif
+
+    argc = lua_gettop(tolua_S)-1;
+    if (argc == 0) 
+    {
+        if(!ok)
+        {
+            tolua_error(tolua_S,"invalid arguments in function 'lua_cocos2dx_Texture2D_getMaxS'", nullptr);
+            return 0;
+        }
+        double ret = cobj->getMaxS();
+        tolua_pushnumber(tolua_S,(lua_Number)ret);
+        return 1;
+    }
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "cc.Texture2D:getMaxS",argc, 0);
+    return 0;
+
+#if COCOS2D_DEBUG >= 1
+    tolua_lerror:
+    tolua_error(tolua_S,"#ferror in function 'lua_cocos2dx_Texture2D_getMaxS'.",&tolua_err);
+#endif
+
+    return 0;
+}
+int lua_cocos2dx_Texture2D_hasPremultipliedAlpha(lua_State* tolua_S)
+{
+    int argc = 0;
+    cocos2d::Texture2D* cobj = nullptr;
+    bool ok  = true;
+
+#if COCOS2D_DEBUG >= 1
+    tolua_Error tolua_err;
+#endif
+
+
+#if COCOS2D_DEBUG >= 1
+    if (!tolua_isusertype(tolua_S,1,"cc.Texture2D",0,&tolua_err)) goto tolua_lerror;
+#endif
+
+    cobj = (cocos2d::Texture2D*)tolua_tousertype(tolua_S,1,0);
+
+#if COCOS2D_DEBUG >= 1
+    if (!cobj) 
+    {
+        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_cocos2dx_Texture2D_hasPremultipliedAlpha'", nullptr);
+        return 0;
+    }
+#endif
+
+    argc = lua_gettop(tolua_S)-1;
+    if (argc == 0) 
+    {
+        if(!ok)
+        {
+            tolua_error(tolua_S,"invalid arguments in function 'lua_cocos2dx_Texture2D_hasPremultipliedAlpha'", nullptr);
+            return 0;
+        }
+        bool ret = cobj->hasPremultipliedAlpha();
+        tolua_pushboolean(tolua_S,(bool)ret);
+        return 1;
+    }
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "cc.Texture2D:hasPremultipliedAlpha",argc, 0);
+    return 0;
+
+#if COCOS2D_DEBUG >= 1
+    tolua_lerror:
+    tolua_error(tolua_S,"#ferror in function 'lua_cocos2dx_Texture2D_hasPremultipliedAlpha'.",&tolua_err);
+#endif
+
+    return 0;
+}
+int lua_cocos2dx_Texture2D_getPixelsHigh(lua_State* tolua_S)
+{
+    int argc = 0;
+    cocos2d::Texture2D* cobj = nullptr;
+    bool ok  = true;
+
+#if COCOS2D_DEBUG >= 1
+    tolua_Error tolua_err;
+#endif
+
+
+#if COCOS2D_DEBUG >= 1
+    if (!tolua_isusertype(tolua_S,1,"cc.Texture2D",0,&tolua_err)) goto tolua_lerror;
+#endif
+
+    cobj = (cocos2d::Texture2D*)tolua_tousertype(tolua_S,1,0);
+
+#if COCOS2D_DEBUG >= 1
+    if (!cobj) 
+    {
+        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_cocos2dx_Texture2D_getPixelsHigh'", nullptr);
+        return 0;
+    }
+#endif
+
+    argc = lua_gettop(tolua_S)-1;
+    if (argc == 0) 
+    {
+        if(!ok)
+        {
+            tolua_error(tolua_S,"invalid arguments in function 'lua_cocos2dx_Texture2D_getPixelsHigh'", nullptr);
+            return 0;
+        }
+        int ret = cobj->getPixelsHigh();
+        tolua_pushnumber(tolua_S,(lua_Number)ret);
+        return 1;
+    }
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "cc.Texture2D:getPixelsHigh",argc, 0);
+    return 0;
+
+#if COCOS2D_DEBUG >= 1
+    tolua_lerror:
+    tolua_error(tolua_S,"#ferror in function 'lua_cocos2dx_Texture2D_getPixelsHigh'.",&tolua_err);
+#endif
+
+    return 0;
+}
+int lua_cocos2dx_Texture2D_getAlphaTextureName(lua_State* tolua_S)
+{
+    int argc = 0;
+    cocos2d::Texture2D* cobj = nullptr;
+    bool ok  = true;
+
+#if COCOS2D_DEBUG >= 1
+    tolua_Error tolua_err;
+#endif
+
+
+#if COCOS2D_DEBUG >= 1
+    if (!tolua_isusertype(tolua_S,1,"cc.Texture2D",0,&tolua_err)) goto tolua_lerror;
+#endif
+
+    cobj = (cocos2d::Texture2D*)tolua_tousertype(tolua_S,1,0);
+
+#if COCOS2D_DEBUG >= 1
+    if (!cobj) 
+    {
+        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_cocos2dx_Texture2D_getAlphaTextureName'", nullptr);
+        return 0;
+    }
+#endif
+
+    argc = lua_gettop(tolua_S)-1;
+    if (argc == 0) 
+    {
+        if(!ok)
+        {
+            tolua_error(tolua_S,"invalid arguments in function 'lua_cocos2dx_Texture2D_getAlphaTextureName'", nullptr);
+            return 0;
+        }
+        bool ret = cobj->getAlphaTextureName();
+        tolua_pushboolean(tolua_S,(bool)ret);
+        return 1;
+    }
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "cc.Texture2D:getAlphaTextureName",argc, 0);
+    return 0;
+
+#if COCOS2D_DEBUG >= 1
+    tolua_lerror:
+    tolua_error(tolua_S,"#ferror in function 'lua_cocos2dx_Texture2D_getAlphaTextureName'.",&tolua_err);
+#endif
+
+    return 0;
+}
+int lua_cocos2dx_Texture2D_getBitsPerPixelForFormat(lua_State* tolua_S)
+{
+    int argc = 0;
+    cocos2d::Texture2D* cobj = nullptr;
+    bool ok  = true;
+#if COCOS2D_DEBUG >= 1
+    tolua_Error tolua_err;
+#endif
+
+#if COCOS2D_DEBUG >= 1
+    if (!tolua_isusertype(tolua_S,1,"cc.Texture2D",0,&tolua_err)) goto tolua_lerror;
+#endif
+    cobj = (cocos2d::Texture2D*)tolua_tousertype(tolua_S,1,0);
+#if COCOS2D_DEBUG >= 1
+    if (!cobj)
+    {
+        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_cocos2dx_Texture2D_getBitsPerPixelForFormat'", nullptr);
+        return 0;
+    }
+#endif
+    argc = lua_gettop(tolua_S)-1;
+    do{
+        if (argc == 1) {
+            cocos2d::backend::PixelFormat arg0;
+            ok &= luaval_to_int32(tolua_S, 2,(int *)&arg0, "cc.Texture2D:getBitsPerPixelForFormat");
+
+            if (!ok) { break; }
+            unsigned int ret = cobj->getBitsPerPixelForFormat(arg0);
+            tolua_pushnumber(tolua_S,(lua_Number)ret);
+            return 1;
+        }
+    }while(0);
+    ok  = true;
+    do{
+        if (argc == 0) {
+            unsigned int ret = cobj->getBitsPerPixelForFormat();
+            tolua_pushnumber(tolua_S,(lua_Number)ret);
+            return 1;
+        }
+    }while(0);
+    ok  = true;
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n",  "cc.Texture2D:getBitsPerPixelForFormat",argc, 0);
+    return 0;
+
+#if COCOS2D_DEBUG >= 1
+    tolua_lerror:
+    tolua_error(tolua_S,"#ferror in function 'lua_cocos2dx_Texture2D_getBitsPerPixelForFormat'.",&tolua_err);
+#endif
+
+    return 0;
+}
+int lua_cocos2dx_Texture2D_setMaxS(lua_State* tolua_S)
+{
+    int argc = 0;
+    cocos2d::Texture2D* cobj = nullptr;
+    bool ok  = true;
+
+#if COCOS2D_DEBUG >= 1
+    tolua_Error tolua_err;
+#endif
+
+
+#if COCOS2D_DEBUG >= 1
+    if (!tolua_isusertype(tolua_S,1,"cc.Texture2D",0,&tolua_err)) goto tolua_lerror;
+#endif
+
+    cobj = (cocos2d::Texture2D*)tolua_tousertype(tolua_S,1,0);
+
+#if COCOS2D_DEBUG >= 1
+    if (!cobj) 
+    {
+        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_cocos2dx_Texture2D_setMaxS'", nullptr);
+        return 0;
+    }
+#endif
+
+    argc = lua_gettop(tolua_S)-1;
+    if (argc == 1) 
+    {
+        double arg0;
+
+        ok &= luaval_to_number(tolua_S, 2,&arg0, "cc.Texture2D:setMaxS");
+        if(!ok)
+        {
+            tolua_error(tolua_S,"invalid arguments in function 'lua_cocos2dx_Texture2D_setMaxS'", nullptr);
+            return 0;
+        }
+        cobj->setMaxS(arg0);
+        lua_settop(tolua_S, 1);
+        return 1;
+    }
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "cc.Texture2D:setMaxS",argc, 1);
+    return 0;
+
+#if COCOS2D_DEBUG >= 1
+    tolua_lerror:
+    tolua_error(tolua_S,"#ferror in function 'lua_cocos2dx_Texture2D_setMaxS'.",&tolua_err);
+#endif
+
+    return 0;
+}
+int lua_cocos2dx_Texture2D_initWithString(lua_State* tolua_S)
+{
+    int argc = 0;
+    cocos2d::Texture2D* cobj = nullptr;
+    bool ok  = true;
+#if COCOS2D_DEBUG >= 1
+    tolua_Error tolua_err;
+#endif
+
+#if COCOS2D_DEBUG >= 1
+    if (!tolua_isusertype(tolua_S,1,"cc.Texture2D",0,&tolua_err)) goto tolua_lerror;
+#endif
+    cobj = (cocos2d::Texture2D*)tolua_tousertype(tolua_S,1,0);
+#if COCOS2D_DEBUG >= 1
+    if (!cobj)
+    {
+        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_cocos2dx_Texture2D_initWithString'", nullptr);
+        return 0;
+    }
+#endif
+    argc = lua_gettop(tolua_S)-1;
+    do{
+        if (argc == 2) {
+            const char* arg0;
+            std::string arg0_tmp; ok &= luaval_to_std_string(tolua_S, 2, &arg0_tmp, "cc.Texture2D:initWithString"); arg0 = arg0_tmp.c_str();
+
+            if (!ok) { break; }
+            cocos2d::FontDefinition arg1;
+            ok &= luaval_to_fontdefinition(tolua_S, 3, &arg1, "cc.Texture2D:initWithString");
+
+            if (!ok) { break; }
+            bool ret = cobj->initWithString(arg0, arg1);
+            tolua_pushboolean(tolua_S,(bool)ret);
+            return 1;
+        }
+    }while(0);
+    ok  = true;
+    do{
+        if (argc == 3) {
+            const char* arg0;
+            std::string arg0_tmp; ok &= luaval_to_std_string(tolua_S, 2, &arg0_tmp, "cc.Texture2D:initWithString"); arg0 = arg0_tmp.c_str();
+
+            if (!ok) { break; }
+            std::string arg1;
+            ok &= luaval_to_std_string(tolua_S, 3,&arg1, "cc.Texture2D:initWithString");
+
+            if (!ok) { break; }
+            double arg2;
+            ok &= luaval_to_number(tolua_S, 4,&arg2, "cc.Texture2D:initWithString");
+
+            if (!ok) { break; }
+            bool ret = cobj->initWithString(arg0, arg1, arg2);
+            tolua_pushboolean(tolua_S,(bool)ret);
+            return 1;
+        }
+    }while(0);
+    ok  = true;
+    do{
+        if (argc == 4) {
+            const char* arg0;
+            std::string arg0_tmp; ok &= luaval_to_std_string(tolua_S, 2, &arg0_tmp, "cc.Texture2D:initWithString"); arg0 = arg0_tmp.c_str();
+
+            if (!ok) { break; }
+            std::string arg1;
+            ok &= luaval_to_std_string(tolua_S, 3,&arg1, "cc.Texture2D:initWithString");
+
+            if (!ok) { break; }
+            double arg2;
+            ok &= luaval_to_number(tolua_S, 4,&arg2, "cc.Texture2D:initWithString");
+
+            if (!ok) { break; }
+            cocos2d::Size arg3;
+            ok &= luaval_to_size(tolua_S, 5, &arg3, "cc.Texture2D:initWithString");
+
+            if (!ok) { break; }
+            bool ret = cobj->initWithString(arg0, arg1, arg2, arg3);
+            tolua_pushboolean(tolua_S,(bool)ret);
+            return 1;
+        }
+    }while(0);
+    ok  = true;
+    do{
+        if (argc == 5) {
+            const char* arg0;
+            std::string arg0_tmp; ok &= luaval_to_std_string(tolua_S, 2, &arg0_tmp, "cc.Texture2D:initWithString"); arg0 = arg0_tmp.c_str();
+
+            if (!ok) { break; }
+            std::string arg1;
+            ok &= luaval_to_std_string(tolua_S, 3,&arg1, "cc.Texture2D:initWithString");
+
+            if (!ok) { break; }
+            double arg2;
+            ok &= luaval_to_number(tolua_S, 4,&arg2, "cc.Texture2D:initWithString");
+
+            if (!ok) { break; }
+            cocos2d::Size arg3;
+            ok &= luaval_to_size(tolua_S, 5, &arg3, "cc.Texture2D:initWithString");
+
+            if (!ok) { break; }
+            cocos2d::TextHAlignment arg4;
+            ok &= luaval_to_int32(tolua_S, 6,(int *)&arg4, "cc.Texture2D:initWithString");
+
+            if (!ok) { break; }
+            bool ret = cobj->initWithString(arg0, arg1, arg2, arg3, arg4);
+            tolua_pushboolean(tolua_S,(bool)ret);
+            return 1;
+        }
+    }while(0);
+    ok  = true;
+    do{
+        if (argc == 6) {
+            const char* arg0;
+            std::string arg0_tmp; ok &= luaval_to_std_string(tolua_S, 2, &arg0_tmp, "cc.Texture2D:initWithString"); arg0 = arg0_tmp.c_str();
+
+            if (!ok) { break; }
+            std::string arg1;
+            ok &= luaval_to_std_string(tolua_S, 3,&arg1, "cc.Texture2D:initWithString");
+
+            if (!ok) { break; }
+            double arg2;
+            ok &= luaval_to_number(tolua_S, 4,&arg2, "cc.Texture2D:initWithString");
+
+            if (!ok) { break; }
+            cocos2d::Size arg3;
+            ok &= luaval_to_size(tolua_S, 5, &arg3, "cc.Texture2D:initWithString");
+
+            if (!ok) { break; }
+            cocos2d::TextHAlignment arg4;
+            ok &= luaval_to_int32(tolua_S, 6,(int *)&arg4, "cc.Texture2D:initWithString");
+
+            if (!ok) { break; }
+            cocos2d::TextVAlignment arg5;
+            ok &= luaval_to_int32(tolua_S, 7,(int *)&arg5, "cc.Texture2D:initWithString");
+
+            if (!ok) { break; }
+            bool ret = cobj->initWithString(arg0, arg1, arg2, arg3, arg4, arg5);
+            tolua_pushboolean(tolua_S,(bool)ret);
+            return 1;
+        }
+    }while(0);
+    ok  = true;
+    do{
+        if (argc == 7) {
+            const char* arg0;
+            std::string arg0_tmp; ok &= luaval_to_std_string(tolua_S, 2, &arg0_tmp, "cc.Texture2D:initWithString"); arg0 = arg0_tmp.c_str();
+
+            if (!ok) { break; }
+            std::string arg1;
+            ok &= luaval_to_std_string(tolua_S, 3,&arg1, "cc.Texture2D:initWithString");
+
+            if (!ok) { break; }
+            double arg2;
+            ok &= luaval_to_number(tolua_S, 4,&arg2, "cc.Texture2D:initWithString");
+
+            if (!ok) { break; }
+            cocos2d::Size arg3;
+            ok &= luaval_to_size(tolua_S, 5, &arg3, "cc.Texture2D:initWithString");
+
+            if (!ok) { break; }
+            cocos2d::TextHAlignment arg4;
+            ok &= luaval_to_int32(tolua_S, 6,(int *)&arg4, "cc.Texture2D:initWithString");
+
+            if (!ok) { break; }
+            cocos2d::TextVAlignment arg5;
+            ok &= luaval_to_int32(tolua_S, 7,(int *)&arg5, "cc.Texture2D:initWithString");
+
+            if (!ok) { break; }
+            bool arg6;
+            ok &= luaval_to_boolean(tolua_S, 8,&arg6, "cc.Texture2D:initWithString");
+
+            if (!ok) { break; }
+            bool ret = cobj->initWithString(arg0, arg1, arg2, arg3, arg4, arg5, arg6);
+            tolua_pushboolean(tolua_S,(bool)ret);
+            return 1;
+        }
+    }while(0);
+    ok  = true;
+    do{
+        if (argc == 8) {
+            const char* arg0;
+            std::string arg0_tmp; ok &= luaval_to_std_string(tolua_S, 2, &arg0_tmp, "cc.Texture2D:initWithString"); arg0 = arg0_tmp.c_str();
+
+            if (!ok) { break; }
+            std::string arg1;
+            ok &= luaval_to_std_string(tolua_S, 3,&arg1, "cc.Texture2D:initWithString");
+
+            if (!ok) { break; }
+            double arg2;
+            ok &= luaval_to_number(tolua_S, 4,&arg2, "cc.Texture2D:initWithString");
+
+            if (!ok) { break; }
+            cocos2d::Size arg3;
+            ok &= luaval_to_size(tolua_S, 5, &arg3, "cc.Texture2D:initWithString");
+
+            if (!ok) { break; }
+            cocos2d::TextHAlignment arg4;
+            ok &= luaval_to_int32(tolua_S, 6,(int *)&arg4, "cc.Texture2D:initWithString");
+
+            if (!ok) { break; }
+            cocos2d::TextVAlignment arg5;
+            ok &= luaval_to_int32(tolua_S, 7,(int *)&arg5, "cc.Texture2D:initWithString");
+
+            if (!ok) { break; }
+            bool arg6;
+            ok &= luaval_to_boolean(tolua_S, 8,&arg6, "cc.Texture2D:initWithString");
+
+            if (!ok) { break; }
+            int arg7;
+            ok &= luaval_to_int32(tolua_S, 9,(int *)&arg7, "cc.Texture2D:initWithString");
+
+            if (!ok) { break; }
+            bool ret = cobj->initWithString(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7);
+            tolua_pushboolean(tolua_S,(bool)ret);
+            return 1;
+        }
+    }while(0);
+    ok  = true;
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n",  "cc.Texture2D:initWithString",argc, 3);
+    return 0;
+
+#if COCOS2D_DEBUG >= 1
+    tolua_lerror:
+    tolua_error(tolua_S,"#ferror in function 'lua_cocos2dx_Texture2D_initWithString'.",&tolua_err);
+#endif
+
+    return 0;
+}
+int lua_cocos2dx_Texture2D_setMaxT(lua_State* tolua_S)
+{
+    int argc = 0;
+    cocos2d::Texture2D* cobj = nullptr;
+    bool ok  = true;
+
+#if COCOS2D_DEBUG >= 1
+    tolua_Error tolua_err;
+#endif
+
+
+#if COCOS2D_DEBUG >= 1
+    if (!tolua_isusertype(tolua_S,1,"cc.Texture2D",0,&tolua_err)) goto tolua_lerror;
+#endif
+
+    cobj = (cocos2d::Texture2D*)tolua_tousertype(tolua_S,1,0);
+
+#if COCOS2D_DEBUG >= 1
+    if (!cobj) 
+    {
+        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_cocos2dx_Texture2D_setMaxT'", nullptr);
+        return 0;
+    }
+#endif
+
+    argc = lua_gettop(tolua_S)-1;
+    if (argc == 1) 
+    {
+        double arg0;
+
+        ok &= luaval_to_number(tolua_S, 2,&arg0, "cc.Texture2D:setMaxT");
+        if(!ok)
+        {
+            tolua_error(tolua_S,"invalid arguments in function 'lua_cocos2dx_Texture2D_setMaxT'", nullptr);
+            return 0;
+        }
+        cobj->setMaxT(arg0);
+        lua_settop(tolua_S, 1);
+        return 1;
+    }
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "cc.Texture2D:setMaxT",argc, 1);
+    return 0;
+
+#if COCOS2D_DEBUG >= 1
+    tolua_lerror:
+    tolua_error(tolua_S,"#ferror in function 'lua_cocos2dx_Texture2D_setMaxT'.",&tolua_err);
+#endif
+
+    return 0;
+}
+int lua_cocos2dx_Texture2D_getPath(lua_State* tolua_S)
+{
+    int argc = 0;
+    cocos2d::Texture2D* cobj = nullptr;
+    bool ok  = true;
+
+#if COCOS2D_DEBUG >= 1
+    tolua_Error tolua_err;
+#endif
+
+
+#if COCOS2D_DEBUG >= 1
+    if (!tolua_isusertype(tolua_S,1,"cc.Texture2D",0,&tolua_err)) goto tolua_lerror;
+#endif
+
+    cobj = (cocos2d::Texture2D*)tolua_tousertype(tolua_S,1,0);
+
+#if COCOS2D_DEBUG >= 1
+    if (!cobj) 
+    {
+        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_cocos2dx_Texture2D_getPath'", nullptr);
+        return 0;
+    }
+#endif
+
+    argc = lua_gettop(tolua_S)-1;
+    if (argc == 0) 
+    {
+        if(!ok)
+        {
+            tolua_error(tolua_S,"invalid arguments in function 'lua_cocos2dx_Texture2D_getPath'", nullptr);
+            return 0;
+        }
+        std::string ret = cobj->getPath();
+        lua_pushlstring(tolua_S,ret.c_str(),ret.length());
+        return 1;
+    }
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "cc.Texture2D:getPath",argc, 0);
+    return 0;
+
+#if COCOS2D_DEBUG >= 1
+    tolua_lerror:
+    tolua_error(tolua_S,"#ferror in function 'lua_cocos2dx_Texture2D_getPath'.",&tolua_err);
+#endif
+
+    return 0;
+}
+int lua_cocos2dx_Texture2D_drawInRect(lua_State* tolua_S)
+{
+    int argc = 0;
+    cocos2d::Texture2D* cobj = nullptr;
+    bool ok  = true;
+
+#if COCOS2D_DEBUG >= 1
+    tolua_Error tolua_err;
+#endif
+
+
+#if COCOS2D_DEBUG >= 1
+    if (!tolua_isusertype(tolua_S,1,"cc.Texture2D",0,&tolua_err)) goto tolua_lerror;
+#endif
+
+    cobj = (cocos2d::Texture2D*)tolua_tousertype(tolua_S,1,0);
+
+#if COCOS2D_DEBUG >= 1
+    if (!cobj) 
+    {
+        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_cocos2dx_Texture2D_drawInRect'", nullptr);
+        return 0;
+    }
+#endif
+
+    argc = lua_gettop(tolua_S)-1;
+    if (argc == 2) 
+    {
+        cocos2d::Rect arg0;
+        double arg1;
+
+        ok &= luaval_to_rect(tolua_S, 2, &arg0, "cc.Texture2D:drawInRect");
+
+        ok &= luaval_to_number(tolua_S, 3,&arg1, "cc.Texture2D:drawInRect");
+        if(!ok)
+        {
+            tolua_error(tolua_S,"invalid arguments in function 'lua_cocos2dx_Texture2D_drawInRect'", nullptr);
+            return 0;
+        }
+        cobj->drawInRect(arg0, arg1);
+        lua_settop(tolua_S, 1);
+        return 1;
+    }
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "cc.Texture2D:drawInRect",argc, 2);
+    return 0;
+
+#if COCOS2D_DEBUG >= 1
+    tolua_lerror:
+    tolua_error(tolua_S,"#ferror in function 'lua_cocos2dx_Texture2D_drawInRect'.",&tolua_err);
+#endif
+
+    return 0;
+}
+int lua_cocos2dx_Texture2D_getContentSize(lua_State* tolua_S)
+{
+    int argc = 0;
+    cocos2d::Texture2D* cobj = nullptr;
+    bool ok  = true;
+
+#if COCOS2D_DEBUG >= 1
+    tolua_Error tolua_err;
+#endif
+
+
+#if COCOS2D_DEBUG >= 1
+    if (!tolua_isusertype(tolua_S,1,"cc.Texture2D",0,&tolua_err)) goto tolua_lerror;
+#endif
+
+    cobj = (cocos2d::Texture2D*)tolua_tousertype(tolua_S,1,0);
+
+#if COCOS2D_DEBUG >= 1
+    if (!cobj) 
+    {
+        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_cocos2dx_Texture2D_getContentSize'", nullptr);
+        return 0;
+    }
+#endif
+
+    argc = lua_gettop(tolua_S)-1;
+    if (argc == 0) 
+    {
+        if(!ok)
+        {
+            tolua_error(tolua_S,"invalid arguments in function 'lua_cocos2dx_Texture2D_getContentSize'", nullptr);
+            return 0;
+        }
+        cocos2d::Size ret = cobj->getContentSize();
+        size_to_luaval(tolua_S, ret);
+        return 1;
+    }
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "cc.Texture2D:getContentSize",argc, 0);
+    return 0;
+
+#if COCOS2D_DEBUG >= 1
+    tolua_lerror:
+    tolua_error(tolua_S,"#ferror in function 'lua_cocos2dx_Texture2D_getContentSize'.",&tolua_err);
+#endif
+
+    return 0;
+}
+int lua_cocos2dx_Texture2D_setAliasTexParameters(lua_State* tolua_S)
+{
+    int argc = 0;
+    cocos2d::Texture2D* cobj = nullptr;
+    bool ok  = true;
+
+#if COCOS2D_DEBUG >= 1
+    tolua_Error tolua_err;
+#endif
+
+
+#if COCOS2D_DEBUG >= 1
+    if (!tolua_isusertype(tolua_S,1,"cc.Texture2D",0,&tolua_err)) goto tolua_lerror;
+#endif
+
+    cobj = (cocos2d::Texture2D*)tolua_tousertype(tolua_S,1,0);
+
+#if COCOS2D_DEBUG >= 1
+    if (!cobj) 
+    {
+        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_cocos2dx_Texture2D_setAliasTexParameters'", nullptr);
+        return 0;
+    }
+#endif
+
+    argc = lua_gettop(tolua_S)-1;
+    if (argc == 0) 
+    {
+        if(!ok)
+        {
+            tolua_error(tolua_S,"invalid arguments in function 'lua_cocos2dx_Texture2D_setAliasTexParameters'", nullptr);
+            return 0;
+        }
+        cobj->setAliasTexParameters();
+        lua_settop(tolua_S, 1);
+        return 1;
+    }
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "cc.Texture2D:setAliasTexParameters",argc, 0);
+    return 0;
+
+#if COCOS2D_DEBUG >= 1
+    tolua_lerror:
+    tolua_error(tolua_S,"#ferror in function 'lua_cocos2dx_Texture2D_setAliasTexParameters'.",&tolua_err);
+#endif
+
+    return 0;
+}
+int lua_cocos2dx_Texture2D_setAntiAliasTexParameters(lua_State* tolua_S)
+{
+    int argc = 0;
+    cocos2d::Texture2D* cobj = nullptr;
+    bool ok  = true;
+
+#if COCOS2D_DEBUG >= 1
+    tolua_Error tolua_err;
+#endif
+
+
+#if COCOS2D_DEBUG >= 1
+    if (!tolua_isusertype(tolua_S,1,"cc.Texture2D",0,&tolua_err)) goto tolua_lerror;
+#endif
+
+    cobj = (cocos2d::Texture2D*)tolua_tousertype(tolua_S,1,0);
+
+#if COCOS2D_DEBUG >= 1
+    if (!cobj) 
+    {
+        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_cocos2dx_Texture2D_setAntiAliasTexParameters'", nullptr);
+        return 0;
+    }
+#endif
+
+    argc = lua_gettop(tolua_S)-1;
+    if (argc == 0) 
+    {
+        if(!ok)
+        {
+            tolua_error(tolua_S,"invalid arguments in function 'lua_cocos2dx_Texture2D_setAntiAliasTexParameters'", nullptr);
+            return 0;
+        }
+        cobj->setAntiAliasTexParameters();
+        lua_settop(tolua_S, 1);
+        return 1;
+    }
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "cc.Texture2D:setAntiAliasTexParameters",argc, 0);
+    return 0;
+
+#if COCOS2D_DEBUG >= 1
+    tolua_lerror:
+    tolua_error(tolua_S,"#ferror in function 'lua_cocos2dx_Texture2D_setAntiAliasTexParameters'.",&tolua_err);
+#endif
+
+    return 0;
+}
+int lua_cocos2dx_Texture2D_generateMipmap(lua_State* tolua_S)
+{
+    int argc = 0;
+    cocos2d::Texture2D* cobj = nullptr;
+    bool ok  = true;
+
+#if COCOS2D_DEBUG >= 1
+    tolua_Error tolua_err;
+#endif
+
+
+#if COCOS2D_DEBUG >= 1
+    if (!tolua_isusertype(tolua_S,1,"cc.Texture2D",0,&tolua_err)) goto tolua_lerror;
+#endif
+
+    cobj = (cocos2d::Texture2D*)tolua_tousertype(tolua_S,1,0);
+
+#if COCOS2D_DEBUG >= 1
+    if (!cobj) 
+    {
+        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_cocos2dx_Texture2D_generateMipmap'", nullptr);
+        return 0;
+    }
+#endif
+
+    argc = lua_gettop(tolua_S)-1;
+    if (argc == 0) 
+    {
+        if(!ok)
+        {
+            tolua_error(tolua_S,"invalid arguments in function 'lua_cocos2dx_Texture2D_generateMipmap'", nullptr);
+            return 0;
+        }
+        cobj->generateMipmap();
+        lua_settop(tolua_S, 1);
+        return 1;
+    }
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "cc.Texture2D:generateMipmap",argc, 0);
+    return 0;
+
+#if COCOS2D_DEBUG >= 1
+    tolua_lerror:
+    tolua_error(tolua_S,"#ferror in function 'lua_cocos2dx_Texture2D_generateMipmap'.",&tolua_err);
+#endif
+
+    return 0;
+}
+int lua_cocos2dx_Texture2D_getAlphaTexture(lua_State* tolua_S)
+{
+    int argc = 0;
+    cocos2d::Texture2D* cobj = nullptr;
+    bool ok  = true;
+
+#if COCOS2D_DEBUG >= 1
+    tolua_Error tolua_err;
+#endif
+
+
+#if COCOS2D_DEBUG >= 1
+    if (!tolua_isusertype(tolua_S,1,"cc.Texture2D",0,&tolua_err)) goto tolua_lerror;
+#endif
+
+    cobj = (cocos2d::Texture2D*)tolua_tousertype(tolua_S,1,0);
+
+#if COCOS2D_DEBUG >= 1
+    if (!cobj) 
+    {
+        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_cocos2dx_Texture2D_getAlphaTexture'", nullptr);
+        return 0;
+    }
+#endif
+
+    argc = lua_gettop(tolua_S)-1;
+    if (argc == 0) 
+    {
+        if(!ok)
+        {
+            tolua_error(tolua_S,"invalid arguments in function 'lua_cocos2dx_Texture2D_getAlphaTexture'", nullptr);
+            return 0;
+        }
+        cocos2d::Texture2D* ret = cobj->getAlphaTexture();
+        object_to_luaval<cocos2d::Texture2D>(tolua_S, "cc.Texture2D",(cocos2d::Texture2D*)ret);
+        return 1;
+    }
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "cc.Texture2D:getAlphaTexture",argc, 0);
+    return 0;
+
+#if COCOS2D_DEBUG >= 1
+    tolua_lerror:
+    tolua_error(tolua_S,"#ferror in function 'lua_cocos2dx_Texture2D_getAlphaTexture'.",&tolua_err);
+#endif
+
+    return 0;
+}
+int lua_cocos2dx_Texture2D_getPixelFormat(lua_State* tolua_S)
+{
+    int argc = 0;
+    cocos2d::Texture2D* cobj = nullptr;
+    bool ok  = true;
+
+#if COCOS2D_DEBUG >= 1
+    tolua_Error tolua_err;
+#endif
+
+
+#if COCOS2D_DEBUG >= 1
+    if (!tolua_isusertype(tolua_S,1,"cc.Texture2D",0,&tolua_err)) goto tolua_lerror;
+#endif
+
+    cobj = (cocos2d::Texture2D*)tolua_tousertype(tolua_S,1,0);
+
+#if COCOS2D_DEBUG >= 1
+    if (!cobj) 
+    {
+        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_cocos2dx_Texture2D_getPixelFormat'", nullptr);
+        return 0;
+    }
+#endif
+
+    argc = lua_gettop(tolua_S)-1;
+    if (argc == 0) 
+    {
+        if(!ok)
+        {
+            tolua_error(tolua_S,"invalid arguments in function 'lua_cocos2dx_Texture2D_getPixelFormat'", nullptr);
+            return 0;
+        }
+        int ret = (int)cobj->getPixelFormat();
+        tolua_pushnumber(tolua_S,(lua_Number)ret);
+        return 1;
+    }
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "cc.Texture2D:getPixelFormat",argc, 0);
+    return 0;
+
+#if COCOS2D_DEBUG >= 1
+    tolua_lerror:
+    tolua_error(tolua_S,"#ferror in function 'lua_cocos2dx_Texture2D_getPixelFormat'.",&tolua_err);
+#endif
+
+    return 0;
+}
+int lua_cocos2dx_Texture2D_getBackendTexture(lua_State* tolua_S)
+{
+    int argc = 0;
+    cocos2d::Texture2D* cobj = nullptr;
+    bool ok  = true;
+
+#if COCOS2D_DEBUG >= 1
+    tolua_Error tolua_err;
+#endif
+
+
+#if COCOS2D_DEBUG >= 1
+    if (!tolua_isusertype(tolua_S,1,"cc.Texture2D",0,&tolua_err)) goto tolua_lerror;
+#endif
+
+    cobj = (cocos2d::Texture2D*)tolua_tousertype(tolua_S,1,0);
+
+#if COCOS2D_DEBUG >= 1
+    if (!cobj) 
+    {
+        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_cocos2dx_Texture2D_getBackendTexture'", nullptr);
+        return 0;
+    }
+#endif
+
+    argc = lua_gettop(tolua_S)-1;
+    if (argc == 0) 
+    {
+        if(!ok)
+        {
+            tolua_error(tolua_S,"invalid arguments in function 'lua_cocos2dx_Texture2D_getBackendTexture'", nullptr);
+            return 0;
+        }
+        cocos2d::backend::Texture* ret = cobj->getBackendTexture();
+        object_to_luaval<cocos2d::backend::Texture>(tolua_S, "ccb.Texture",(cocos2d::backend::Texture*)ret);
+        return 1;
+    }
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "cc.Texture2D:getBackendTexture",argc, 0);
+    return 0;
+
+#if COCOS2D_DEBUG >= 1
+    tolua_lerror:
+    tolua_error(tolua_S,"#ferror in function 'lua_cocos2dx_Texture2D_getBackendTexture'.",&tolua_err);
+#endif
+
+    return 0;
+}
+int lua_cocos2dx_Texture2D_getContentSizeInPixels(lua_State* tolua_S)
+{
+    int argc = 0;
+    cocos2d::Texture2D* cobj = nullptr;
+    bool ok  = true;
+
+#if COCOS2D_DEBUG >= 1
+    tolua_Error tolua_err;
+#endif
+
+
+#if COCOS2D_DEBUG >= 1
+    if (!tolua_isusertype(tolua_S,1,"cc.Texture2D",0,&tolua_err)) goto tolua_lerror;
+#endif
+
+    cobj = (cocos2d::Texture2D*)tolua_tousertype(tolua_S,1,0);
+
+#if COCOS2D_DEBUG >= 1
+    if (!cobj) 
+    {
+        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_cocos2dx_Texture2D_getContentSizeInPixels'", nullptr);
+        return 0;
+    }
+#endif
+
+    argc = lua_gettop(tolua_S)-1;
+    if (argc == 0) 
+    {
+        if(!ok)
+        {
+            tolua_error(tolua_S,"invalid arguments in function 'lua_cocos2dx_Texture2D_getContentSizeInPixels'", nullptr);
+            return 0;
+        }
+        const cocos2d::Size& ret = cobj->getContentSizeInPixels();
+        size_to_luaval(tolua_S, ret);
+        return 1;
+    }
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "cc.Texture2D:getContentSizeInPixels",argc, 0);
+    return 0;
+
+#if COCOS2D_DEBUG >= 1
+    tolua_lerror:
+    tolua_error(tolua_S,"#ferror in function 'lua_cocos2dx_Texture2D_getContentSizeInPixels'.",&tolua_err);
+#endif
+
+    return 0;
+}
+int lua_cocos2dx_Texture2D_getPixelsWide(lua_State* tolua_S)
+{
+    int argc = 0;
+    cocos2d::Texture2D* cobj = nullptr;
+    bool ok  = true;
+
+#if COCOS2D_DEBUG >= 1
+    tolua_Error tolua_err;
+#endif
+
+
+#if COCOS2D_DEBUG >= 1
+    if (!tolua_isusertype(tolua_S,1,"cc.Texture2D",0,&tolua_err)) goto tolua_lerror;
+#endif
+
+    cobj = (cocos2d::Texture2D*)tolua_tousertype(tolua_S,1,0);
+
+#if COCOS2D_DEBUG >= 1
+    if (!cobj) 
+    {
+        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_cocos2dx_Texture2D_getPixelsWide'", nullptr);
+        return 0;
+    }
+#endif
+
+    argc = lua_gettop(tolua_S)-1;
+    if (argc == 0) 
+    {
+        if(!ok)
+        {
+            tolua_error(tolua_S,"invalid arguments in function 'lua_cocos2dx_Texture2D_getPixelsWide'", nullptr);
+            return 0;
+        }
+        int ret = cobj->getPixelsWide();
+        tolua_pushnumber(tolua_S,(lua_Number)ret);
+        return 1;
+    }
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "cc.Texture2D:getPixelsWide",argc, 0);
+    return 0;
+
+#if COCOS2D_DEBUG >= 1
+    tolua_lerror:
+    tolua_error(tolua_S,"#ferror in function 'lua_cocos2dx_Texture2D_getPixelsWide'.",&tolua_err);
+#endif
+
+    return 0;
+}
+int lua_cocos2dx_Texture2D_drawAtPoint(lua_State* tolua_S)
+{
+    int argc = 0;
+    cocos2d::Texture2D* cobj = nullptr;
+    bool ok  = true;
+
+#if COCOS2D_DEBUG >= 1
+    tolua_Error tolua_err;
+#endif
+
+
+#if COCOS2D_DEBUG >= 1
+    if (!tolua_isusertype(tolua_S,1,"cc.Texture2D",0,&tolua_err)) goto tolua_lerror;
+#endif
+
+    cobj = (cocos2d::Texture2D*)tolua_tousertype(tolua_S,1,0);
+
+#if COCOS2D_DEBUG >= 1
+    if (!cobj) 
+    {
+        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_cocos2dx_Texture2D_drawAtPoint'", nullptr);
+        return 0;
+    }
+#endif
+
+    argc = lua_gettop(tolua_S)-1;
+    if (argc == 2) 
+    {
+        cocos2d::Vec2 arg0;
+        double arg1;
+
+        ok &= luaval_to_vec2(tolua_S, 2, &arg0, "cc.Texture2D:drawAtPoint");
+
+        ok &= luaval_to_number(tolua_S, 3,&arg1, "cc.Texture2D:drawAtPoint");
+        if(!ok)
+        {
+            tolua_error(tolua_S,"invalid arguments in function 'lua_cocos2dx_Texture2D_drawAtPoint'", nullptr);
+            return 0;
+        }
+        cobj->drawAtPoint(arg0, arg1);
+        lua_settop(tolua_S, 1);
+        return 1;
+    }
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "cc.Texture2D:drawAtPoint",argc, 2);
+    return 0;
+
+#if COCOS2D_DEBUG >= 1
+    tolua_lerror:
+    tolua_error(tolua_S,"#ferror in function 'lua_cocos2dx_Texture2D_drawAtPoint'.",&tolua_err);
+#endif
+
+    return 0;
+}
+int lua_cocos2dx_Texture2D_hasMipmaps(lua_State* tolua_S)
+{
+    int argc = 0;
+    cocos2d::Texture2D* cobj = nullptr;
+    bool ok  = true;
+
+#if COCOS2D_DEBUG >= 1
+    tolua_Error tolua_err;
+#endif
+
+
+#if COCOS2D_DEBUG >= 1
+    if (!tolua_isusertype(tolua_S,1,"cc.Texture2D",0,&tolua_err)) goto tolua_lerror;
+#endif
+
+    cobj = (cocos2d::Texture2D*)tolua_tousertype(tolua_S,1,0);
+
+#if COCOS2D_DEBUG >= 1
+    if (!cobj) 
+    {
+        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_cocos2dx_Texture2D_hasMipmaps'", nullptr);
+        return 0;
+    }
+#endif
+
+    argc = lua_gettop(tolua_S)-1;
+    if (argc == 0) 
+    {
+        if(!ok)
+        {
+            tolua_error(tolua_S,"invalid arguments in function 'lua_cocos2dx_Texture2D_hasMipmaps'", nullptr);
+            return 0;
+        }
+        bool ret = cobj->hasMipmaps();
+        tolua_pushboolean(tolua_S,(bool)ret);
+        return 1;
+    }
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "cc.Texture2D:hasMipmaps",argc, 0);
+    return 0;
+
+#if COCOS2D_DEBUG >= 1
+    tolua_lerror:
+    tolua_error(tolua_S,"#ferror in function 'lua_cocos2dx_Texture2D_hasMipmaps'.",&tolua_err);
+#endif
+
+    return 0;
+}
+int lua_cocos2dx_Texture2D_initWithBackendTexture(lua_State* tolua_S)
+{
+    int argc = 0;
+    cocos2d::Texture2D* cobj = nullptr;
+    bool ok  = true;
+
+#if COCOS2D_DEBUG >= 1
+    tolua_Error tolua_err;
+#endif
+
+
+#if COCOS2D_DEBUG >= 1
+    if (!tolua_isusertype(tolua_S,1,"cc.Texture2D",0,&tolua_err)) goto tolua_lerror;
+#endif
+
+    cobj = (cocos2d::Texture2D*)tolua_tousertype(tolua_S,1,0);
+
+#if COCOS2D_DEBUG >= 1
+    if (!cobj) 
+    {
+        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_cocos2dx_Texture2D_initWithBackendTexture'", nullptr);
+        return 0;
+    }
+#endif
+
+    argc = lua_gettop(tolua_S)-1;
+    if (argc == 1) 
+    {
+        cocos2d::backend::Texture* arg0;
+
+        ok &= luaval_to_object<cocos2d::backend::Texture>(tolua_S, 2, "ccb.Texture",&arg0, "cc.Texture2D:initWithBackendTexture");
+        if(!ok)
+        {
+            tolua_error(tolua_S,"invalid arguments in function 'lua_cocos2dx_Texture2D_initWithBackendTexture'", nullptr);
+            return 0;
+        }
+        bool ret = cobj->initWithBackendTexture(arg0);
+        tolua_pushboolean(tolua_S,(bool)ret);
+        return 1;
+    }
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "cc.Texture2D:initWithBackendTexture",argc, 1);
+    return 0;
+
+#if COCOS2D_DEBUG >= 1
+    tolua_lerror:
+    tolua_error(tolua_S,"#ferror in function 'lua_cocos2dx_Texture2D_initWithBackendTexture'.",&tolua_err);
+#endif
+
+    return 0;
+}
+int lua_cocos2dx_Texture2D_setDefaultAlphaPixelFormat(lua_State* tolua_S)
+{
+    int argc = 0;
+    bool ok  = true;
+
+#if COCOS2D_DEBUG >= 1
+    tolua_Error tolua_err;
+#endif
+
+#if COCOS2D_DEBUG >= 1
+    if (!tolua_isusertable(tolua_S,1,"cc.Texture2D",0,&tolua_err)) goto tolua_lerror;
+#endif
+
+    argc = lua_gettop(tolua_S) - 1;
+
+    if (argc == 1)
+    {
+        cocos2d::backend::PixelFormat arg0;
+        ok &= luaval_to_int32(tolua_S, 2,(int *)&arg0, "cc.Texture2D:setDefaultAlphaPixelFormat");
+        if(!ok)
+        {
+            tolua_error(tolua_S,"invalid arguments in function 'lua_cocos2dx_Texture2D_setDefaultAlphaPixelFormat'", nullptr);
+            return 0;
+        }
+        cocos2d::Texture2D::setDefaultAlphaPixelFormat(arg0);
+        lua_settop(tolua_S, 1);
+        return 1;
+    }
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d\n ", "cc.Texture2D:setDefaultAlphaPixelFormat",argc, 1);
+    return 0;
+#if COCOS2D_DEBUG >= 1
+    tolua_lerror:
+    tolua_error(tolua_S,"#ferror in function 'lua_cocos2dx_Texture2D_setDefaultAlphaPixelFormat'.",&tolua_err);
+#endif
+    return 0;
+}
+int lua_cocos2dx_Texture2D_getDefaultAlphaPixelFormat(lua_State* tolua_S)
+{
+    int argc = 0;
+    bool ok  = true;
+
+#if COCOS2D_DEBUG >= 1
+    tolua_Error tolua_err;
+#endif
+
+#if COCOS2D_DEBUG >= 1
+    if (!tolua_isusertable(tolua_S,1,"cc.Texture2D",0,&tolua_err)) goto tolua_lerror;
+#endif
+
+    argc = lua_gettop(tolua_S) - 1;
+
+    if (argc == 0)
+    {
+        if(!ok)
+        {
+            tolua_error(tolua_S,"invalid arguments in function 'lua_cocos2dx_Texture2D_getDefaultAlphaPixelFormat'", nullptr);
+            return 0;
+        }
+        int ret = (int)cocos2d::Texture2D::getDefaultAlphaPixelFormat();
+        tolua_pushnumber(tolua_S,(lua_Number)ret);
+        return 1;
+    }
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d\n ", "cc.Texture2D:getDefaultAlphaPixelFormat",argc, 0);
+    return 0;
+#if COCOS2D_DEBUG >= 1
+    tolua_lerror:
+    tolua_error(tolua_S,"#ferror in function 'lua_cocos2dx_Texture2D_getDefaultAlphaPixelFormat'.",&tolua_err);
+#endif
+    return 0;
+}
+int lua_cocos2dx_Texture2D_constructor(lua_State* tolua_S)
+{
+    int argc = 0;
+    cocos2d::Texture2D* cobj = nullptr;
     bool ok  = true;
 
 #if COCOS2D_DEBUG >= 1
@@ -1467,41 +2602,71 @@ int lua_cocos2dx_PipelineDescriptor_constructor(lua_State* tolua_S)
     {
         if(!ok)
         {
-            tolua_error(tolua_S,"invalid arguments in function 'lua_cocos2dx_PipelineDescriptor_constructor'", nullptr);
+            tolua_error(tolua_S,"invalid arguments in function 'lua_cocos2dx_Texture2D_constructor'", nullptr);
             return 0;
         }
-        cobj = new cocos2d::PipelineDescriptor();
-        tolua_pushusertype(tolua_S,(void*)cobj,"cc.PipelineDescriptor");
-        tolua_register_gc(tolua_S,lua_gettop(tolua_S));
+        cobj = new cocos2d::Texture2D();
+        cobj->autorelease();
+        int ID =  (int)cobj->_ID ;
+        int* luaID =  &cobj->_luaID ;
+        toluafix_pushusertype_ccobject(tolua_S, ID, luaID, (void*)cobj,"cc.Texture2D");
         return 1;
     }
-    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "cc.PipelineDescriptor:PipelineDescriptor",argc, 0);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "cc.Texture2D:Texture2D",argc, 0);
     return 0;
 
 #if COCOS2D_DEBUG >= 1
-    tolua_error(tolua_S,"#ferror in function 'lua_cocos2dx_PipelineDescriptor_constructor'.",&tolua_err);
+    tolua_error(tolua_S,"#ferror in function 'lua_cocos2dx_Texture2D_constructor'.",&tolua_err);
 #endif
 
     return 0;
 }
 
-static int lua_cocos2dx_PipelineDescriptor_finalize(lua_State* tolua_S)
+static int lua_cocos2dx_Texture2D_finalize(lua_State* tolua_S)
 {
-    printf("luabindings: finalizing LUA object (PipelineDescriptor)");
+    printf("luabindings: finalizing LUA object (Texture2D)");
     return 0;
 }
 
-int lua_register_cocos2dx_PipelineDescriptor(lua_State* tolua_S)
+int lua_register_cocos2dx_Texture2D(lua_State* tolua_S)
 {
-    tolua_usertype(tolua_S,"cc.PipelineDescriptor");
-    tolua_cclass(tolua_S,"PipelineDescriptor","cc.PipelineDescriptor","",nullptr);
+    tolua_usertype(tolua_S,"cc.Texture2D");
+    tolua_cclass(tolua_S,"Texture2D","cc.Texture2D","cc.Ref",nullptr);
 
-    tolua_beginmodule(tolua_S,"PipelineDescriptor");
-        tolua_function(tolua_S,"new",lua_cocos2dx_PipelineDescriptor_constructor);
+    tolua_beginmodule(tolua_S,"Texture2D");
+        tolua_function(tolua_S,"new",lua_cocos2dx_Texture2D_constructor);
+        tolua_function(tolua_S,"getMaxT",lua_cocos2dx_Texture2D_getMaxT);
+        tolua_function(tolua_S,"setAlphaTexture",lua_cocos2dx_Texture2D_setAlphaTexture);
+        tolua_function(tolua_S,"getStringForFormat",lua_cocos2dx_Texture2D_getStringForFormat);
+        tolua_function(tolua_S,"initWithImage",lua_cocos2dx_Texture2D_initWithImage);
+        tolua_function(tolua_S,"getMaxS",lua_cocos2dx_Texture2D_getMaxS);
+        tolua_function(tolua_S,"hasPremultipliedAlpha",lua_cocos2dx_Texture2D_hasPremultipliedAlpha);
+        tolua_function(tolua_S,"getPixelsHigh",lua_cocos2dx_Texture2D_getPixelsHigh);
+        tolua_function(tolua_S,"getAlphaTextureName",lua_cocos2dx_Texture2D_getAlphaTextureName);
+        tolua_function(tolua_S,"getBitsPerPixelForFormat",lua_cocos2dx_Texture2D_getBitsPerPixelForFormat);
+        tolua_function(tolua_S,"setMaxS",lua_cocos2dx_Texture2D_setMaxS);
+        tolua_function(tolua_S,"initWithString",lua_cocos2dx_Texture2D_initWithString);
+        tolua_function(tolua_S,"setMaxT",lua_cocos2dx_Texture2D_setMaxT);
+        tolua_function(tolua_S,"getPath",lua_cocos2dx_Texture2D_getPath);
+        tolua_function(tolua_S,"drawInRect",lua_cocos2dx_Texture2D_drawInRect);
+        tolua_function(tolua_S,"getContentSize",lua_cocos2dx_Texture2D_getContentSize);
+        tolua_function(tolua_S,"setAliasTexParameters",lua_cocos2dx_Texture2D_setAliasTexParameters);
+        tolua_function(tolua_S,"setAntiAliasTexParameters",lua_cocos2dx_Texture2D_setAntiAliasTexParameters);
+        tolua_function(tolua_S,"generateMipmap",lua_cocos2dx_Texture2D_generateMipmap);
+        tolua_function(tolua_S,"getAlphaTexture",lua_cocos2dx_Texture2D_getAlphaTexture);
+        tolua_function(tolua_S,"getPixelFormat",lua_cocos2dx_Texture2D_getPixelFormat);
+        tolua_function(tolua_S,"getBackendTexture",lua_cocos2dx_Texture2D_getBackendTexture);
+        tolua_function(tolua_S,"getContentSizeInPixels",lua_cocos2dx_Texture2D_getContentSizeInPixels);
+        tolua_function(tolua_S,"getPixelsWide",lua_cocos2dx_Texture2D_getPixelsWide);
+        tolua_function(tolua_S,"drawAtPoint",lua_cocos2dx_Texture2D_drawAtPoint);
+        tolua_function(tolua_S,"hasMipmaps",lua_cocos2dx_Texture2D_hasMipmaps);
+        tolua_function(tolua_S,"initWithBackendTexture",lua_cocos2dx_Texture2D_initWithBackendTexture);
+        tolua_function(tolua_S,"setDefaultAlphaPixelFormat", lua_cocos2dx_Texture2D_setDefaultAlphaPixelFormat);
+        tolua_function(tolua_S,"getDefaultAlphaPixelFormat", lua_cocos2dx_Texture2D_getDefaultAlphaPixelFormat);
     tolua_endmodule(tolua_S);
-    std::string typeName = typeid(cocos2d::PipelineDescriptor).name();
-    g_luaType[typeName] = "cc.PipelineDescriptor";
-    g_typeCast["PipelineDescriptor"] = "cc.PipelineDescriptor";
+    std::string typeName = typeid(cocos2d::Texture2D).name();
+    g_luaType[typeName] = "cc.Texture2D";
+    g_typeCast["Texture2D"] = "cc.Texture2D";
     return 1;
 }
 
@@ -100242,7 +101407,6 @@ TOLUA_API int register_all_cocos2dx(lua_State* tolua_S)
 	lua_register_cocos2dx_TransitionZoomFlipAngular(tolua_S);
 	lua_register_cocos2dx_EaseRateAction(tolua_S);
 	lua_register_cocos2dx_EaseIn(tolua_S);
-	lua_register_cocos2dx_PipelineDescriptor(tolua_S);
 	lua_register_cocos2dx_EaseExponentialInOut(tolua_S);
 	lua_register_cocos2dx_CardinalSplineTo(tolua_S);
 	lua_register_cocos2dx_CatmullRomTo(tolua_S);
@@ -100284,7 +101448,7 @@ TOLUA_API int register_all_cocos2dx(lua_State* tolua_S)
 	lua_register_cocos2dx_TransitionShrinkGrow(tolua_S);
 	lua_register_cocos2dx_ClippingNode(tolua_S);
 	lua_register_cocos2dx_ActionFloat(tolua_S);
-	lua_register_cocos2dx_MenuItemLabel(tolua_S);
+	lua_register_cocos2dx_ParticleFlower(tolua_S);
 	lua_register_cocos2dx_EaseCircleActionIn(tolua_S);
 	lua_register_cocos2dx_Image(tolua_S);
 	lua_register_cocos2dx_LayerMultiplex(tolua_S);
@@ -100305,6 +101469,7 @@ TOLUA_API int register_all_cocos2dx(lua_State* tolua_S)
 	lua_register_cocos2dx_TMXObjectGroup(tolua_S);
 	lua_register_cocos2dx_ParticleGalaxy(tolua_S);
 	lua_register_cocos2dx_Twirl(tolua_S);
+	lua_register_cocos2dx_MenuItemLabel(tolua_S);
 	lua_register_cocos2dx_EaseQuinticActionIn(tolua_S);
 	lua_register_cocos2dx_LayerColor(tolua_S);
 	lua_register_cocos2dx_FadeOutBLTiles(tolua_S);
@@ -100345,7 +101510,6 @@ TOLUA_API int register_all_cocos2dx(lua_State* tolua_S)
 	lua_register_cocos2dx_Ripple3D(tolua_S);
 	lua_register_cocos2dx_Lens3D(tolua_S);
 	lua_register_cocos2dx_EventListenerFocus(tolua_S);
-	lua_register_cocos2dx_ParticleFlower(tolua_S);
 	lua_register_cocos2dx_Spawn(tolua_S);
 	lua_register_cocos2dx_EaseQuarticActionInOut(tolua_S);
 	lua_register_cocos2dx_ShakyTiles3D(tolua_S);

--- a/cocos/scripting/lua-bindings/auto/lua_cocos2dx_auto.cpp
+++ b/cocos/scripting/lua-bindings/auto/lua_cocos2dx_auto.cpp
@@ -2257,8 +2257,8 @@ int lua_cocos2dx_Texture2D_getBackendTexture(lua_State* tolua_S)
             tolua_error(tolua_S,"invalid arguments in function 'lua_cocos2dx_Texture2D_getBackendTexture'", nullptr);
             return 0;
         }
-        cocos2d::backend::Texture* ret = cobj->getBackendTexture();
-        object_to_luaval<cocos2d::backend::Texture>(tolua_S, "ccb.Texture",(cocos2d::backend::Texture*)ret);
+        cocos2d::backend::TextureBackend* ret = cobj->getBackendTexture();
+        object_to_luaval<cocos2d::backend::TextureBackend>(tolua_S, "ccb.TextureBackend",(cocos2d::backend::TextureBackend*)ret);
         return 1;
     }
     luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "cc.Texture2D:getBackendTexture",argc, 0);
@@ -2493,9 +2493,9 @@ int lua_cocos2dx_Texture2D_initWithBackendTexture(lua_State* tolua_S)
     argc = lua_gettop(tolua_S)-1;
     if (argc == 1) 
     {
-        cocos2d::backend::Texture* arg0;
+        cocos2d::backend::TextureBackend* arg0;
 
-        ok &= luaval_to_object<cocos2d::backend::Texture>(tolua_S, 2, "ccb.Texture",&arg0, "cc.Texture2D:initWithBackendTexture");
+        ok &= luaval_to_object<cocos2d::backend::TextureBackend>(tolua_S, 2, "ccb.TextureBackend",&arg0, "cc.Texture2D:initWithBackendTexture");
         if(!ok)
         {
             tolua_error(tolua_S,"invalid arguments in function 'lua_cocos2dx_Texture2D_initWithBackendTexture'", nullptr);
@@ -90058,11 +90058,11 @@ int lua_cocos2dx_Pass_setUniformNormTexture(lua_State* tolua_S)
     if (argc == 2) 
     {
         unsigned int arg0;
-        cocos2d::backend::Texture* arg1;
+        cocos2d::backend::TextureBackend* arg1;
 
         ok &= luaval_to_uint32(tolua_S, 2,&arg0, "cc.Pass:setUniformNormTexture");
 
-        ok &= luaval_to_object<cocos2d::backend::Texture>(tolua_S, 3, "ccb.Texture",&arg1, "cc.Pass:setUniformNormTexture");
+        ok &= luaval_to_object<cocos2d::backend::TextureBackend>(tolua_S, 3, "ccb.TextureBackend",&arg1, "cc.Pass:setUniformNormTexture");
         if(!ok)
         {
             tolua_error(tolua_S,"invalid arguments in function 'lua_cocos2dx_Pass_setUniformNormTexture'", nullptr);
@@ -90474,11 +90474,11 @@ int lua_cocos2dx_Pass_setUniformTexture(lua_State* tolua_S)
     if (argc == 2) 
     {
         unsigned int arg0;
-        cocos2d::backend::Texture* arg1;
+        cocos2d::backend::TextureBackend* arg1;
 
         ok &= luaval_to_uint32(tolua_S, 2,&arg0, "cc.Pass:setUniformTexture");
 
-        ok &= luaval_to_object<cocos2d::backend::Texture>(tolua_S, 3, "ccb.Texture",&arg1, "cc.Pass:setUniformTexture");
+        ok &= luaval_to_object<cocos2d::backend::TextureBackend>(tolua_S, 3, "ccb.TextureBackend",&arg1, "cc.Pass:setUniformTexture");
         if(!ok)
         {
             tolua_error(tolua_S,"invalid arguments in function 'lua_cocos2dx_Pass_setUniformTexture'", nullptr);

--- a/cocos/scripting/lua-bindings/auto/lua_cocos2dx_auto.hpp
+++ b/cocos/scripting/lua-bindings/auto/lua_cocos2dx_auto.hpp
@@ -2217,4 +2217,25 @@ int register_all_cocos2dx(lua_State* tolua_S);
 
 
 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 #endif // __cocos2dx_h__

--- a/cocos/scripting/lua-bindings/auto/lua_cocos2dx_backend_auto.cpp
+++ b/cocos/scripting/lua-bindings/auto/lua_cocos2dx_backend_auto.cpp
@@ -704,13 +704,13 @@ int lua_cocos2dx_backend_ProgramState_setTexture(lua_State* tolua_S)
     {
         cocos2d::backend::UniformLocation arg0;
         unsigned int arg1;
-        cocos2d::backend::Texture* arg2;
+        cocos2d::backend::TextureBackend* arg2;
 
         ok &= luaval_to_uniformLocation(tolua_S, 2, arg0, "ccb.ProgramState:setTexture");
 
         ok &= luaval_to_uint32(tolua_S, 3,&arg1, "ccb.ProgramState:setTexture");
 
-        ok &= luaval_to_object<cocos2d::backend::Texture>(tolua_S, 4, "ccb.Texture",&arg2, "ccb.ProgramState:setTexture");
+        ok &= luaval_to_object<cocos2d::backend::TextureBackend>(tolua_S, 4, "ccb.TextureBackend",&arg2, "ccb.ProgramState:setTexture");
         if(!ok)
         {
             tolua_error(tolua_S,"invalid arguments in function 'lua_cocos2dx_backend_ProgramState_setTexture'", nullptr);
@@ -995,10 +995,10 @@ int lua_register_cocos2dx_backend_ProgramState(lua_State* tolua_S)
     return 1;
 }
 
-int lua_cocos2dx_backend_Texture_getTextureFormat(lua_State* tolua_S)
+int lua_cocos2dx_backend_TextureBackend_getTextureFormat(lua_State* tolua_S)
 {
     int argc = 0;
-    cocos2d::backend::Texture* cobj = nullptr;
+    cocos2d::backend::TextureBackend* cobj = nullptr;
     bool ok  = true;
 
 #if COCOS2D_DEBUG >= 1
@@ -1007,15 +1007,15 @@ int lua_cocos2dx_backend_Texture_getTextureFormat(lua_State* tolua_S)
 
 
 #if COCOS2D_DEBUG >= 1
-    if (!tolua_isusertype(tolua_S,1,"ccb.Texture",0,&tolua_err)) goto tolua_lerror;
+    if (!tolua_isusertype(tolua_S,1,"ccb.TextureBackend",0,&tolua_err)) goto tolua_lerror;
 #endif
 
-    cobj = (cocos2d::backend::Texture*)tolua_tousertype(tolua_S,1,0);
+    cobj = (cocos2d::backend::TextureBackend*)tolua_tousertype(tolua_S,1,0);
 
 #if COCOS2D_DEBUG >= 1
     if (!cobj) 
     {
-        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_cocos2dx_backend_Texture_getTextureFormat'", nullptr);
+        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_cocos2dx_backend_TextureBackend_getTextureFormat'", nullptr);
         return 0;
     }
 #endif
@@ -1025,27 +1025,27 @@ int lua_cocos2dx_backend_Texture_getTextureFormat(lua_State* tolua_S)
     {
         if(!ok)
         {
-            tolua_error(tolua_S,"invalid arguments in function 'lua_cocos2dx_backend_Texture_getTextureFormat'", nullptr);
+            tolua_error(tolua_S,"invalid arguments in function 'lua_cocos2dx_backend_TextureBackend_getTextureFormat'", nullptr);
             return 0;
         }
         int ret = (int)cobj->getTextureFormat();
         tolua_pushnumber(tolua_S,(lua_Number)ret);
         return 1;
     }
-    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ccb.Texture:getTextureFormat",argc, 0);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ccb.TextureBackend:getTextureFormat",argc, 0);
     return 0;
 
 #if COCOS2D_DEBUG >= 1
     tolua_lerror:
-    tolua_error(tolua_S,"#ferror in function 'lua_cocos2dx_backend_Texture_getTextureFormat'.",&tolua_err);
+    tolua_error(tolua_S,"#ferror in function 'lua_cocos2dx_backend_TextureBackend_getTextureFormat'.",&tolua_err);
 #endif
 
     return 0;
 }
-int lua_cocos2dx_backend_Texture_getTextureType(lua_State* tolua_S)
+int lua_cocos2dx_backend_TextureBackend_getTextureType(lua_State* tolua_S)
 {
     int argc = 0;
-    cocos2d::backend::Texture* cobj = nullptr;
+    cocos2d::backend::TextureBackend* cobj = nullptr;
     bool ok  = true;
 
 #if COCOS2D_DEBUG >= 1
@@ -1054,15 +1054,15 @@ int lua_cocos2dx_backend_Texture_getTextureType(lua_State* tolua_S)
 
 
 #if COCOS2D_DEBUG >= 1
-    if (!tolua_isusertype(tolua_S,1,"ccb.Texture",0,&tolua_err)) goto tolua_lerror;
+    if (!tolua_isusertype(tolua_S,1,"ccb.TextureBackend",0,&tolua_err)) goto tolua_lerror;
 #endif
 
-    cobj = (cocos2d::backend::Texture*)tolua_tousertype(tolua_S,1,0);
+    cobj = (cocos2d::backend::TextureBackend*)tolua_tousertype(tolua_S,1,0);
 
 #if COCOS2D_DEBUG >= 1
     if (!cobj) 
     {
-        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_cocos2dx_backend_Texture_getTextureType'", nullptr);
+        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_cocos2dx_backend_TextureBackend_getTextureType'", nullptr);
         return 0;
     }
 #endif
@@ -1072,27 +1072,27 @@ int lua_cocos2dx_backend_Texture_getTextureType(lua_State* tolua_S)
     {
         if(!ok)
         {
-            tolua_error(tolua_S,"invalid arguments in function 'lua_cocos2dx_backend_Texture_getTextureType'", nullptr);
+            tolua_error(tolua_S,"invalid arguments in function 'lua_cocos2dx_backend_TextureBackend_getTextureType'", nullptr);
             return 0;
         }
         int ret = (int)cobj->getTextureType();
         tolua_pushnumber(tolua_S,(lua_Number)ret);
         return 1;
     }
-    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ccb.Texture:getTextureType",argc, 0);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ccb.TextureBackend:getTextureType",argc, 0);
     return 0;
 
 #if COCOS2D_DEBUG >= 1
     tolua_lerror:
-    tolua_error(tolua_S,"#ferror in function 'lua_cocos2dx_backend_Texture_getTextureType'.",&tolua_err);
+    tolua_error(tolua_S,"#ferror in function 'lua_cocos2dx_backend_TextureBackend_getTextureType'.",&tolua_err);
 #endif
 
     return 0;
 }
-int lua_cocos2dx_backend_Texture_updateSamplerDescriptor(lua_State* tolua_S)
+int lua_cocos2dx_backend_TextureBackend_updateSamplerDescriptor(lua_State* tolua_S)
 {
     int argc = 0;
-    cocos2d::backend::Texture* cobj = nullptr;
+    cocos2d::backend::TextureBackend* cobj = nullptr;
     bool ok  = true;
 
 #if COCOS2D_DEBUG >= 1
@@ -1101,15 +1101,15 @@ int lua_cocos2dx_backend_Texture_updateSamplerDescriptor(lua_State* tolua_S)
 
 
 #if COCOS2D_DEBUG >= 1
-    if (!tolua_isusertype(tolua_S,1,"ccb.Texture",0,&tolua_err)) goto tolua_lerror;
+    if (!tolua_isusertype(tolua_S,1,"ccb.TextureBackend",0,&tolua_err)) goto tolua_lerror;
 #endif
 
-    cobj = (cocos2d::backend::Texture*)tolua_tousertype(tolua_S,1,0);
+    cobj = (cocos2d::backend::TextureBackend*)tolua_tousertype(tolua_S,1,0);
 
 #if COCOS2D_DEBUG >= 1
     if (!cobj) 
     {
-        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_cocos2dx_backend_Texture_updateSamplerDescriptor'", nullptr);
+        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_cocos2dx_backend_TextureBackend_updateSamplerDescriptor'", nullptr);
         return 0;
     }
 #endif
@@ -1119,30 +1119,30 @@ int lua_cocos2dx_backend_Texture_updateSamplerDescriptor(lua_State* tolua_S)
     {
         cocos2d::backend::SamplerDescriptor arg0;
 
-        ok &= luaval_to_samplerDescriptor(tolua_S, 2, arg0, "ccb.Texture:updateSamplerDescriptor");
+        ok &= luaval_to_samplerDescriptor(tolua_S, 2, arg0, "ccb.TextureBackend:updateSamplerDescriptor");
         if(!ok)
         {
-            tolua_error(tolua_S,"invalid arguments in function 'lua_cocos2dx_backend_Texture_updateSamplerDescriptor'", nullptr);
+            tolua_error(tolua_S,"invalid arguments in function 'lua_cocos2dx_backend_TextureBackend_updateSamplerDescriptor'", nullptr);
             return 0;
         }
         cobj->updateSamplerDescriptor(arg0);
         lua_settop(tolua_S, 1);
         return 1;
     }
-    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ccb.Texture:updateSamplerDescriptor",argc, 1);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ccb.TextureBackend:updateSamplerDescriptor",argc, 1);
     return 0;
 
 #if COCOS2D_DEBUG >= 1
     tolua_lerror:
-    tolua_error(tolua_S,"#ferror in function 'lua_cocos2dx_backend_Texture_updateSamplerDescriptor'.",&tolua_err);
+    tolua_error(tolua_S,"#ferror in function 'lua_cocos2dx_backend_TextureBackend_updateSamplerDescriptor'.",&tolua_err);
 #endif
 
     return 0;
 }
-int lua_cocos2dx_backend_Texture_updateTextureDescriptor(lua_State* tolua_S)
+int lua_cocos2dx_backend_TextureBackend_updateTextureDescriptor(lua_State* tolua_S)
 {
     int argc = 0;
-    cocos2d::backend::Texture* cobj = nullptr;
+    cocos2d::backend::TextureBackend* cobj = nullptr;
     bool ok  = true;
 
 #if COCOS2D_DEBUG >= 1
@@ -1151,15 +1151,15 @@ int lua_cocos2dx_backend_Texture_updateTextureDescriptor(lua_State* tolua_S)
 
 
 #if COCOS2D_DEBUG >= 1
-    if (!tolua_isusertype(tolua_S,1,"ccb.Texture",0,&tolua_err)) goto tolua_lerror;
+    if (!tolua_isusertype(tolua_S,1,"ccb.TextureBackend",0,&tolua_err)) goto tolua_lerror;
 #endif
 
-    cobj = (cocos2d::backend::Texture*)tolua_tousertype(tolua_S,1,0);
+    cobj = (cocos2d::backend::TextureBackend*)tolua_tousertype(tolua_S,1,0);
 
 #if COCOS2D_DEBUG >= 1
     if (!cobj) 
     {
-        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_cocos2dx_backend_Texture_updateTextureDescriptor'", nullptr);
+        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_cocos2dx_backend_TextureBackend_updateTextureDescriptor'", nullptr);
         return 0;
     }
 #endif
@@ -1173,27 +1173,27 @@ int lua_cocos2dx_backend_Texture_updateTextureDescriptor(lua_State* tolua_S)
 		ok = false;
         if(!ok)
         {
-            tolua_error(tolua_S,"invalid arguments in function 'lua_cocos2dx_backend_Texture_updateTextureDescriptor'", nullptr);
+            tolua_error(tolua_S,"invalid arguments in function 'lua_cocos2dx_backend_TextureBackend_updateTextureDescriptor'", nullptr);
             return 0;
         }
         cobj->updateTextureDescriptor(arg0);
         lua_settop(tolua_S, 1);
         return 1;
     }
-    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ccb.Texture:updateTextureDescriptor",argc, 1);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ccb.TextureBackend:updateTextureDescriptor",argc, 1);
     return 0;
 
 #if COCOS2D_DEBUG >= 1
     tolua_lerror:
-    tolua_error(tolua_S,"#ferror in function 'lua_cocos2dx_backend_Texture_updateTextureDescriptor'.",&tolua_err);
+    tolua_error(tolua_S,"#ferror in function 'lua_cocos2dx_backend_TextureBackend_updateTextureDescriptor'.",&tolua_err);
 #endif
 
     return 0;
 }
-int lua_cocos2dx_backend_Texture_getTextureUsage(lua_State* tolua_S)
+int lua_cocos2dx_backend_TextureBackend_getTextureUsage(lua_State* tolua_S)
 {
     int argc = 0;
-    cocos2d::backend::Texture* cobj = nullptr;
+    cocos2d::backend::TextureBackend* cobj = nullptr;
     bool ok  = true;
 
 #if COCOS2D_DEBUG >= 1
@@ -1202,15 +1202,15 @@ int lua_cocos2dx_backend_Texture_getTextureUsage(lua_State* tolua_S)
 
 
 #if COCOS2D_DEBUG >= 1
-    if (!tolua_isusertype(tolua_S,1,"ccb.Texture",0,&tolua_err)) goto tolua_lerror;
+    if (!tolua_isusertype(tolua_S,1,"ccb.TextureBackend",0,&tolua_err)) goto tolua_lerror;
 #endif
 
-    cobj = (cocos2d::backend::Texture*)tolua_tousertype(tolua_S,1,0);
+    cobj = (cocos2d::backend::TextureBackend*)tolua_tousertype(tolua_S,1,0);
 
 #if COCOS2D_DEBUG >= 1
     if (!cobj) 
     {
-        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_cocos2dx_backend_Texture_getTextureUsage'", nullptr);
+        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_cocos2dx_backend_TextureBackend_getTextureUsage'", nullptr);
         return 0;
     }
 #endif
@@ -1220,27 +1220,27 @@ int lua_cocos2dx_backend_Texture_getTextureUsage(lua_State* tolua_S)
     {
         if(!ok)
         {
-            tolua_error(tolua_S,"invalid arguments in function 'lua_cocos2dx_backend_Texture_getTextureUsage'", nullptr);
+            tolua_error(tolua_S,"invalid arguments in function 'lua_cocos2dx_backend_TextureBackend_getTextureUsage'", nullptr);
             return 0;
         }
         int ret = (int)cobj->getTextureUsage();
         tolua_pushnumber(tolua_S,(lua_Number)ret);
         return 1;
     }
-    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ccb.Texture:getTextureUsage",argc, 0);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ccb.TextureBackend:getTextureUsage",argc, 0);
     return 0;
 
 #if COCOS2D_DEBUG >= 1
     tolua_lerror:
-    tolua_error(tolua_S,"#ferror in function 'lua_cocos2dx_backend_Texture_getTextureUsage'.",&tolua_err);
+    tolua_error(tolua_S,"#ferror in function 'lua_cocos2dx_backend_TextureBackend_getTextureUsage'.",&tolua_err);
 #endif
 
     return 0;
 }
-int lua_cocos2dx_backend_Texture_hasMipmaps(lua_State* tolua_S)
+int lua_cocos2dx_backend_TextureBackend_hasMipmaps(lua_State* tolua_S)
 {
     int argc = 0;
-    cocos2d::backend::Texture* cobj = nullptr;
+    cocos2d::backend::TextureBackend* cobj = nullptr;
     bool ok  = true;
 
 #if COCOS2D_DEBUG >= 1
@@ -1249,15 +1249,15 @@ int lua_cocos2dx_backend_Texture_hasMipmaps(lua_State* tolua_S)
 
 
 #if COCOS2D_DEBUG >= 1
-    if (!tolua_isusertype(tolua_S,1,"ccb.Texture",0,&tolua_err)) goto tolua_lerror;
+    if (!tolua_isusertype(tolua_S,1,"ccb.TextureBackend",0,&tolua_err)) goto tolua_lerror;
 #endif
 
-    cobj = (cocos2d::backend::Texture*)tolua_tousertype(tolua_S,1,0);
+    cobj = (cocos2d::backend::TextureBackend*)tolua_tousertype(tolua_S,1,0);
 
 #if COCOS2D_DEBUG >= 1
     if (!cobj) 
     {
-        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_cocos2dx_backend_Texture_hasMipmaps'", nullptr);
+        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_cocos2dx_backend_TextureBackend_hasMipmaps'", nullptr);
         return 0;
     }
 #endif
@@ -1267,27 +1267,27 @@ int lua_cocos2dx_backend_Texture_hasMipmaps(lua_State* tolua_S)
     {
         if(!ok)
         {
-            tolua_error(tolua_S,"invalid arguments in function 'lua_cocos2dx_backend_Texture_hasMipmaps'", nullptr);
+            tolua_error(tolua_S,"invalid arguments in function 'lua_cocos2dx_backend_TextureBackend_hasMipmaps'", nullptr);
             return 0;
         }
         bool ret = cobj->hasMipmaps();
         tolua_pushboolean(tolua_S,(bool)ret);
         return 1;
     }
-    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ccb.Texture:hasMipmaps",argc, 0);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ccb.TextureBackend:hasMipmaps",argc, 0);
     return 0;
 
 #if COCOS2D_DEBUG >= 1
     tolua_lerror:
-    tolua_error(tolua_S,"#ferror in function 'lua_cocos2dx_backend_Texture_hasMipmaps'.",&tolua_err);
+    tolua_error(tolua_S,"#ferror in function 'lua_cocos2dx_backend_TextureBackend_hasMipmaps'.",&tolua_err);
 #endif
 
     return 0;
 }
-int lua_cocos2dx_backend_Texture_generateMipmaps(lua_State* tolua_S)
+int lua_cocos2dx_backend_TextureBackend_generateMipmaps(lua_State* tolua_S)
 {
     int argc = 0;
-    cocos2d::backend::Texture* cobj = nullptr;
+    cocos2d::backend::TextureBackend* cobj = nullptr;
     bool ok  = true;
 
 #if COCOS2D_DEBUG >= 1
@@ -1296,15 +1296,15 @@ int lua_cocos2dx_backend_Texture_generateMipmaps(lua_State* tolua_S)
 
 
 #if COCOS2D_DEBUG >= 1
-    if (!tolua_isusertype(tolua_S,1,"ccb.Texture",0,&tolua_err)) goto tolua_lerror;
+    if (!tolua_isusertype(tolua_S,1,"ccb.TextureBackend",0,&tolua_err)) goto tolua_lerror;
 #endif
 
-    cobj = (cocos2d::backend::Texture*)tolua_tousertype(tolua_S,1,0);
+    cobj = (cocos2d::backend::TextureBackend*)tolua_tousertype(tolua_S,1,0);
 
 #if COCOS2D_DEBUG >= 1
     if (!cobj) 
     {
-        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_cocos2dx_backend_Texture_generateMipmaps'", nullptr);
+        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_cocos2dx_backend_TextureBackend_generateMipmaps'", nullptr);
         return 0;
     }
 #endif
@@ -1314,27 +1314,27 @@ int lua_cocos2dx_backend_Texture_generateMipmaps(lua_State* tolua_S)
     {
         if(!ok)
         {
-            tolua_error(tolua_S,"invalid arguments in function 'lua_cocos2dx_backend_Texture_generateMipmaps'", nullptr);
+            tolua_error(tolua_S,"invalid arguments in function 'lua_cocos2dx_backend_TextureBackend_generateMipmaps'", nullptr);
             return 0;
         }
         cobj->generateMipmaps();
         lua_settop(tolua_S, 1);
         return 1;
     }
-    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ccb.Texture:generateMipmaps",argc, 0);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ccb.TextureBackend:generateMipmaps",argc, 0);
     return 0;
 
 #if COCOS2D_DEBUG >= 1
     tolua_lerror:
-    tolua_error(tolua_S,"#ferror in function 'lua_cocos2dx_backend_Texture_generateMipmaps'.",&tolua_err);
+    tolua_error(tolua_S,"#ferror in function 'lua_cocos2dx_backend_TextureBackend_generateMipmaps'.",&tolua_err);
 #endif
 
     return 0;
 }
-int lua_cocos2dx_backend_Texture_getBytes(lua_State* tolua_S)
+int lua_cocos2dx_backend_TextureBackend_getBytes(lua_State* tolua_S)
 {
     int argc = 0;
-    cocos2d::backend::Texture* cobj = nullptr;
+    cocos2d::backend::TextureBackend* cobj = nullptr;
     bool ok  = true;
 
 #if COCOS2D_DEBUG >= 1
@@ -1343,15 +1343,15 @@ int lua_cocos2dx_backend_Texture_getBytes(lua_State* tolua_S)
 
 
 #if COCOS2D_DEBUG >= 1
-    if (!tolua_isusertype(tolua_S,1,"ccb.Texture",0,&tolua_err)) goto tolua_lerror;
+    if (!tolua_isusertype(tolua_S,1,"ccb.TextureBackend",0,&tolua_err)) goto tolua_lerror;
 #endif
 
-    cobj = (cocos2d::backend::Texture*)tolua_tousertype(tolua_S,1,0);
+    cobj = (cocos2d::backend::TextureBackend*)tolua_tousertype(tolua_S,1,0);
 
 #if COCOS2D_DEBUG >= 1
     if (!cobj) 
     {
-        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_cocos2dx_backend_Texture_getBytes'", nullptr);
+        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_cocos2dx_backend_TextureBackend_getBytes'", nullptr);
         return 0;
     }
 #endif
@@ -1366,15 +1366,15 @@ int lua_cocos2dx_backend_Texture_getBytes(lua_State* tolua_S)
         bool arg4;
         std::function<void (const unsigned char *, int, int)> arg5;
 
-        ok &= luaval_to_int32(tolua_S, 2,(int *)&arg0, "ccb.Texture:getBytes");
+        ok &= luaval_to_int32(tolua_S, 2,(int *)&arg0, "ccb.TextureBackend:getBytes");
 
-        ok &= luaval_to_int32(tolua_S, 3,(int *)&arg1, "ccb.Texture:getBytes");
+        ok &= luaval_to_int32(tolua_S, 3,(int *)&arg1, "ccb.TextureBackend:getBytes");
 
-        ok &= luaval_to_int32(tolua_S, 4,(int *)&arg2, "ccb.Texture:getBytes");
+        ok &= luaval_to_int32(tolua_S, 4,(int *)&arg2, "ccb.TextureBackend:getBytes");
 
-        ok &= luaval_to_int32(tolua_S, 5,(int *)&arg3, "ccb.Texture:getBytes");
+        ok &= luaval_to_int32(tolua_S, 5,(int *)&arg3, "ccb.TextureBackend:getBytes");
 
-        ok &= luaval_to_boolean(tolua_S, 6,&arg4, "ccb.Texture:getBytes");
+        ok &= luaval_to_boolean(tolua_S, 6,&arg4, "ccb.TextureBackend:getBytes");
 
         do {
 			// Lambda binding for lua is not supported.
@@ -1383,54 +1383,54 @@ int lua_cocos2dx_backend_Texture_getBytes(lua_State* tolua_S)
 		;
         if(!ok)
         {
-            tolua_error(tolua_S,"invalid arguments in function 'lua_cocos2dx_backend_Texture_getBytes'", nullptr);
+            tolua_error(tolua_S,"invalid arguments in function 'lua_cocos2dx_backend_TextureBackend_getBytes'", nullptr);
             return 0;
         }
         cobj->getBytes(arg0, arg1, arg2, arg3, arg4, arg5);
         lua_settop(tolua_S, 1);
         return 1;
     }
-    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ccb.Texture:getBytes",argc, 6);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ccb.TextureBackend:getBytes",argc, 6);
     return 0;
 
 #if COCOS2D_DEBUG >= 1
     tolua_lerror:
-    tolua_error(tolua_S,"#ferror in function 'lua_cocos2dx_backend_Texture_getBytes'.",&tolua_err);
+    tolua_error(tolua_S,"#ferror in function 'lua_cocos2dx_backend_TextureBackend_getBytes'.",&tolua_err);
 #endif
 
     return 0;
 }
-static int lua_cocos2dx_backend_Texture_finalize(lua_State* tolua_S)
+static int lua_cocos2dx_backend_TextureBackend_finalize(lua_State* tolua_S)
 {
-    printf("luabindings: finalizing LUA object (Texture)");
+    printf("luabindings: finalizing LUA object (TextureBackend)");
     return 0;
 }
 
-int lua_register_cocos2dx_backend_Texture(lua_State* tolua_S)
+int lua_register_cocos2dx_backend_TextureBackend(lua_State* tolua_S)
 {
-    tolua_usertype(tolua_S,"ccb.Texture");
-    tolua_cclass(tolua_S,"Texture","ccb.Texture","cc.Ref",nullptr);
+    tolua_usertype(tolua_S,"ccb.TextureBackend");
+    tolua_cclass(tolua_S,"TextureBackend","ccb.TextureBackend","cc.Ref",nullptr);
 
-    tolua_beginmodule(tolua_S,"Texture");
-        tolua_function(tolua_S,"getTextureFormat",lua_cocos2dx_backend_Texture_getTextureFormat);
-        tolua_function(tolua_S,"getTextureType",lua_cocos2dx_backend_Texture_getTextureType);
-        tolua_function(tolua_S,"updateSamplerDescriptor",lua_cocos2dx_backend_Texture_updateSamplerDescriptor);
-        tolua_function(tolua_S,"updateTextureDescriptor",lua_cocos2dx_backend_Texture_updateTextureDescriptor);
-        tolua_function(tolua_S,"getTextureUsage",lua_cocos2dx_backend_Texture_getTextureUsage);
-        tolua_function(tolua_S,"hasMipmaps",lua_cocos2dx_backend_Texture_hasMipmaps);
-        tolua_function(tolua_S,"generateMipmaps",lua_cocos2dx_backend_Texture_generateMipmaps);
-        tolua_function(tolua_S,"getBytes",lua_cocos2dx_backend_Texture_getBytes);
+    tolua_beginmodule(tolua_S,"TextureBackend");
+        tolua_function(tolua_S,"getTextureFormat",lua_cocos2dx_backend_TextureBackend_getTextureFormat);
+        tolua_function(tolua_S,"getTextureType",lua_cocos2dx_backend_TextureBackend_getTextureType);
+        tolua_function(tolua_S,"updateSamplerDescriptor",lua_cocos2dx_backend_TextureBackend_updateSamplerDescriptor);
+        tolua_function(tolua_S,"updateTextureDescriptor",lua_cocos2dx_backend_TextureBackend_updateTextureDescriptor);
+        tolua_function(tolua_S,"getTextureUsage",lua_cocos2dx_backend_TextureBackend_getTextureUsage);
+        tolua_function(tolua_S,"hasMipmaps",lua_cocos2dx_backend_TextureBackend_hasMipmaps);
+        tolua_function(tolua_S,"generateMipmaps",lua_cocos2dx_backend_TextureBackend_generateMipmaps);
+        tolua_function(tolua_S,"getBytes",lua_cocos2dx_backend_TextureBackend_getBytes);
     tolua_endmodule(tolua_S);
-    std::string typeName = typeid(cocos2d::backend::Texture).name();
-    g_luaType[typeName] = "ccb.Texture";
-    g_typeCast["Texture"] = "ccb.Texture";
+    std::string typeName = typeid(cocos2d::backend::TextureBackend).name();
+    g_luaType[typeName] = "ccb.TextureBackend";
+    g_typeCast["TextureBackend"] = "ccb.TextureBackend";
     return 1;
 }
 
-int lua_cocos2dx_backend_TextureBackend2D_getHeight(lua_State* tolua_S)
+int lua_cocos2dx_backend_Texture2DBackend_getHeight(lua_State* tolua_S)
 {
     int argc = 0;
-    cocos2d::backend::TextureBackend2D* cobj = nullptr;
+    cocos2d::backend::Texture2DBackend* cobj = nullptr;
     bool ok  = true;
 
 #if COCOS2D_DEBUG >= 1
@@ -1439,15 +1439,15 @@ int lua_cocos2dx_backend_TextureBackend2D_getHeight(lua_State* tolua_S)
 
 
 #if COCOS2D_DEBUG >= 1
-    if (!tolua_isusertype(tolua_S,1,"ccb.TextureBackend2D",0,&tolua_err)) goto tolua_lerror;
+    if (!tolua_isusertype(tolua_S,1,"ccb.Texture2DBackend",0,&tolua_err)) goto tolua_lerror;
 #endif
 
-    cobj = (cocos2d::backend::TextureBackend2D*)tolua_tousertype(tolua_S,1,0);
+    cobj = (cocos2d::backend::Texture2DBackend*)tolua_tousertype(tolua_S,1,0);
 
 #if COCOS2D_DEBUG >= 1
     if (!cobj) 
     {
-        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_cocos2dx_backend_TextureBackend2D_getHeight'", nullptr);
+        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_cocos2dx_backend_Texture2DBackend_getHeight'", nullptr);
         return 0;
     }
 #endif
@@ -1457,27 +1457,27 @@ int lua_cocos2dx_backend_TextureBackend2D_getHeight(lua_State* tolua_S)
     {
         if(!ok)
         {
-            tolua_error(tolua_S,"invalid arguments in function 'lua_cocos2dx_backend_TextureBackend2D_getHeight'", nullptr);
+            tolua_error(tolua_S,"invalid arguments in function 'lua_cocos2dx_backend_Texture2DBackend_getHeight'", nullptr);
             return 0;
         }
         unsigned int ret = cobj->getHeight();
         tolua_pushnumber(tolua_S,(lua_Number)ret);
         return 1;
     }
-    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ccb.TextureBackend2D:getHeight",argc, 0);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ccb.Texture2DBackend:getHeight",argc, 0);
     return 0;
 
 #if COCOS2D_DEBUG >= 1
     tolua_lerror:
-    tolua_error(tolua_S,"#ferror in function 'lua_cocos2dx_backend_TextureBackend2D_getHeight'.",&tolua_err);
+    tolua_error(tolua_S,"#ferror in function 'lua_cocos2dx_backend_Texture2DBackend_getHeight'.",&tolua_err);
 #endif
 
     return 0;
 }
-int lua_cocos2dx_backend_TextureBackend2D_getWidth(lua_State* tolua_S)
+int lua_cocos2dx_backend_Texture2DBackend_getWidth(lua_State* tolua_S)
 {
     int argc = 0;
-    cocos2d::backend::TextureBackend2D* cobj = nullptr;
+    cocos2d::backend::Texture2DBackend* cobj = nullptr;
     bool ok  = true;
 
 #if COCOS2D_DEBUG >= 1
@@ -1486,15 +1486,15 @@ int lua_cocos2dx_backend_TextureBackend2D_getWidth(lua_State* tolua_S)
 
 
 #if COCOS2D_DEBUG >= 1
-    if (!tolua_isusertype(tolua_S,1,"ccb.TextureBackend2D",0,&tolua_err)) goto tolua_lerror;
+    if (!tolua_isusertype(tolua_S,1,"ccb.Texture2DBackend",0,&tolua_err)) goto tolua_lerror;
 #endif
 
-    cobj = (cocos2d::backend::TextureBackend2D*)tolua_tousertype(tolua_S,1,0);
+    cobj = (cocos2d::backend::Texture2DBackend*)tolua_tousertype(tolua_S,1,0);
 
 #if COCOS2D_DEBUG >= 1
     if (!cobj) 
     {
-        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_cocos2dx_backend_TextureBackend2D_getWidth'", nullptr);
+        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_cocos2dx_backend_Texture2DBackend_getWidth'", nullptr);
         return 0;
     }
 #endif
@@ -1504,27 +1504,27 @@ int lua_cocos2dx_backend_TextureBackend2D_getWidth(lua_State* tolua_S)
     {
         if(!ok)
         {
-            tolua_error(tolua_S,"invalid arguments in function 'lua_cocos2dx_backend_TextureBackend2D_getWidth'", nullptr);
+            tolua_error(tolua_S,"invalid arguments in function 'lua_cocos2dx_backend_Texture2DBackend_getWidth'", nullptr);
             return 0;
         }
         unsigned int ret = cobj->getWidth();
         tolua_pushnumber(tolua_S,(lua_Number)ret);
         return 1;
     }
-    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ccb.TextureBackend2D:getWidth",argc, 0);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ccb.Texture2DBackend:getWidth",argc, 0);
     return 0;
 
 #if COCOS2D_DEBUG >= 1
     tolua_lerror:
-    tolua_error(tolua_S,"#ferror in function 'lua_cocos2dx_backend_TextureBackend2D_getWidth'.",&tolua_err);
+    tolua_error(tolua_S,"#ferror in function 'lua_cocos2dx_backend_Texture2DBackend_getWidth'.",&tolua_err);
 #endif
 
     return 0;
 }
-int lua_cocos2dx_backend_TextureBackend2D_updateData(lua_State* tolua_S)
+int lua_cocos2dx_backend_Texture2DBackend_updateData(lua_State* tolua_S)
 {
     int argc = 0;
-    cocos2d::backend::TextureBackend2D* cobj = nullptr;
+    cocos2d::backend::Texture2DBackend* cobj = nullptr;
     bool ok  = true;
 
 #if COCOS2D_DEBUG >= 1
@@ -1533,15 +1533,15 @@ int lua_cocos2dx_backend_TextureBackend2D_updateData(lua_State* tolua_S)
 
 
 #if COCOS2D_DEBUG >= 1
-    if (!tolua_isusertype(tolua_S,1,"ccb.TextureBackend2D",0,&tolua_err)) goto tolua_lerror;
+    if (!tolua_isusertype(tolua_S,1,"ccb.Texture2DBackend",0,&tolua_err)) goto tolua_lerror;
 #endif
 
-    cobj = (cocos2d::backend::TextureBackend2D*)tolua_tousertype(tolua_S,1,0);
+    cobj = (cocos2d::backend::Texture2DBackend*)tolua_tousertype(tolua_S,1,0);
 
 #if COCOS2D_DEBUG >= 1
     if (!cobj) 
     {
-        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_cocos2dx_backend_TextureBackend2D_updateData'", nullptr);
+        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_cocos2dx_backend_Texture2DBackend_updateData'", nullptr);
         return 0;
     }
 #endif
@@ -1557,34 +1557,34 @@ int lua_cocos2dx_backend_TextureBackend2D_updateData(lua_State* tolua_S)
         #pragma warning NO CONVERSION TO NATIVE FOR unsigned char*
 		ok = false;
 
-        ok &= luaval_to_uint32(tolua_S, 3,&arg1, "ccb.TextureBackend2D:updateData");
+        ok &= luaval_to_uint32(tolua_S, 3,&arg1, "ccb.Texture2DBackend:updateData");
 
-        ok &= luaval_to_uint32(tolua_S, 4,&arg2, "ccb.TextureBackend2D:updateData");
+        ok &= luaval_to_uint32(tolua_S, 4,&arg2, "ccb.Texture2DBackend:updateData");
 
-        ok &= luaval_to_uint32(tolua_S, 5,&arg3, "ccb.TextureBackend2D:updateData");
+        ok &= luaval_to_uint32(tolua_S, 5,&arg3, "ccb.Texture2DBackend:updateData");
         if(!ok)
         {
-            tolua_error(tolua_S,"invalid arguments in function 'lua_cocos2dx_backend_TextureBackend2D_updateData'", nullptr);
+            tolua_error(tolua_S,"invalid arguments in function 'lua_cocos2dx_backend_Texture2DBackend_updateData'", nullptr);
             return 0;
         }
         cobj->updateData(arg0, arg1, arg2, arg3);
         lua_settop(tolua_S, 1);
         return 1;
     }
-    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ccb.TextureBackend2D:updateData",argc, 4);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ccb.Texture2DBackend:updateData",argc, 4);
     return 0;
 
 #if COCOS2D_DEBUG >= 1
     tolua_lerror:
-    tolua_error(tolua_S,"#ferror in function 'lua_cocos2dx_backend_TextureBackend2D_updateData'.",&tolua_err);
+    tolua_error(tolua_S,"#ferror in function 'lua_cocos2dx_backend_Texture2DBackend_updateData'.",&tolua_err);
 #endif
 
     return 0;
 }
-int lua_cocos2dx_backend_TextureBackend2D_updateCompressedData(lua_State* tolua_S)
+int lua_cocos2dx_backend_Texture2DBackend_updateCompressedData(lua_State* tolua_S)
 {
     int argc = 0;
-    cocos2d::backend::TextureBackend2D* cobj = nullptr;
+    cocos2d::backend::Texture2DBackend* cobj = nullptr;
     bool ok  = true;
 
 #if COCOS2D_DEBUG >= 1
@@ -1593,15 +1593,15 @@ int lua_cocos2dx_backend_TextureBackend2D_updateCompressedData(lua_State* tolua_
 
 
 #if COCOS2D_DEBUG >= 1
-    if (!tolua_isusertype(tolua_S,1,"ccb.TextureBackend2D",0,&tolua_err)) goto tolua_lerror;
+    if (!tolua_isusertype(tolua_S,1,"ccb.Texture2DBackend",0,&tolua_err)) goto tolua_lerror;
 #endif
 
-    cobj = (cocos2d::backend::TextureBackend2D*)tolua_tousertype(tolua_S,1,0);
+    cobj = (cocos2d::backend::Texture2DBackend*)tolua_tousertype(tolua_S,1,0);
 
 #if COCOS2D_DEBUG >= 1
     if (!cobj) 
     {
-        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_cocos2dx_backend_TextureBackend2D_updateCompressedData'", nullptr);
+        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_cocos2dx_backend_Texture2DBackend_updateCompressedData'", nullptr);
         return 0;
     }
 #endif
@@ -1618,36 +1618,36 @@ int lua_cocos2dx_backend_TextureBackend2D_updateCompressedData(lua_State* tolua_
         #pragma warning NO CONVERSION TO NATIVE FOR unsigned char*
 		ok = false;
 
-        ok &= luaval_to_uint32(tolua_S, 3,&arg1, "ccb.TextureBackend2D:updateCompressedData");
+        ok &= luaval_to_uint32(tolua_S, 3,&arg1, "ccb.Texture2DBackend:updateCompressedData");
 
-        ok &= luaval_to_uint32(tolua_S, 4,&arg2, "ccb.TextureBackend2D:updateCompressedData");
+        ok &= luaval_to_uint32(tolua_S, 4,&arg2, "ccb.Texture2DBackend:updateCompressedData");
 
-        ok &= luaval_to_uint32(tolua_S, 5,&arg3, "ccb.TextureBackend2D:updateCompressedData");
+        ok &= luaval_to_uint32(tolua_S, 5,&arg3, "ccb.Texture2DBackend:updateCompressedData");
 
-        ok &= luaval_to_uint32(tolua_S, 6,&arg4, "ccb.TextureBackend2D:updateCompressedData");
+        ok &= luaval_to_uint32(tolua_S, 6,&arg4, "ccb.Texture2DBackend:updateCompressedData");
         if(!ok)
         {
-            tolua_error(tolua_S,"invalid arguments in function 'lua_cocos2dx_backend_TextureBackend2D_updateCompressedData'", nullptr);
+            tolua_error(tolua_S,"invalid arguments in function 'lua_cocos2dx_backend_Texture2DBackend_updateCompressedData'", nullptr);
             return 0;
         }
         cobj->updateCompressedData(arg0, arg1, arg2, arg3, arg4);
         lua_settop(tolua_S, 1);
         return 1;
     }
-    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ccb.TextureBackend2D:updateCompressedData",argc, 5);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ccb.Texture2DBackend:updateCompressedData",argc, 5);
     return 0;
 
 #if COCOS2D_DEBUG >= 1
     tolua_lerror:
-    tolua_error(tolua_S,"#ferror in function 'lua_cocos2dx_backend_TextureBackend2D_updateCompressedData'.",&tolua_err);
+    tolua_error(tolua_S,"#ferror in function 'lua_cocos2dx_backend_Texture2DBackend_updateCompressedData'.",&tolua_err);
 #endif
 
     return 0;
 }
-int lua_cocos2dx_backend_TextureBackend2D_updateSubData(lua_State* tolua_S)
+int lua_cocos2dx_backend_Texture2DBackend_updateSubData(lua_State* tolua_S)
 {
     int argc = 0;
-    cocos2d::backend::TextureBackend2D* cobj = nullptr;
+    cocos2d::backend::Texture2DBackend* cobj = nullptr;
     bool ok  = true;
 
 #if COCOS2D_DEBUG >= 1
@@ -1656,15 +1656,15 @@ int lua_cocos2dx_backend_TextureBackend2D_updateSubData(lua_State* tolua_S)
 
 
 #if COCOS2D_DEBUG >= 1
-    if (!tolua_isusertype(tolua_S,1,"ccb.TextureBackend2D",0,&tolua_err)) goto tolua_lerror;
+    if (!tolua_isusertype(tolua_S,1,"ccb.Texture2DBackend",0,&tolua_err)) goto tolua_lerror;
 #endif
 
-    cobj = (cocos2d::backend::TextureBackend2D*)tolua_tousertype(tolua_S,1,0);
+    cobj = (cocos2d::backend::Texture2DBackend*)tolua_tousertype(tolua_S,1,0);
 
 #if COCOS2D_DEBUG >= 1
     if (!cobj) 
     {
-        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_cocos2dx_backend_TextureBackend2D_updateSubData'", nullptr);
+        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_cocos2dx_backend_Texture2DBackend_updateSubData'", nullptr);
         return 0;
     }
 #endif
@@ -1679,41 +1679,41 @@ int lua_cocos2dx_backend_TextureBackend2D_updateSubData(lua_State* tolua_S)
         unsigned int arg4;
         unsigned char* arg5;
 
-        ok &= luaval_to_uint32(tolua_S, 2,&arg0, "ccb.TextureBackend2D:updateSubData");
+        ok &= luaval_to_uint32(tolua_S, 2,&arg0, "ccb.Texture2DBackend:updateSubData");
 
-        ok &= luaval_to_uint32(tolua_S, 3,&arg1, "ccb.TextureBackend2D:updateSubData");
+        ok &= luaval_to_uint32(tolua_S, 3,&arg1, "ccb.Texture2DBackend:updateSubData");
 
-        ok &= luaval_to_uint32(tolua_S, 4,&arg2, "ccb.TextureBackend2D:updateSubData");
+        ok &= luaval_to_uint32(tolua_S, 4,&arg2, "ccb.Texture2DBackend:updateSubData");
 
-        ok &= luaval_to_uint32(tolua_S, 5,&arg3, "ccb.TextureBackend2D:updateSubData");
+        ok &= luaval_to_uint32(tolua_S, 5,&arg3, "ccb.Texture2DBackend:updateSubData");
 
-        ok &= luaval_to_uint32(tolua_S, 6,&arg4, "ccb.TextureBackend2D:updateSubData");
+        ok &= luaval_to_uint32(tolua_S, 6,&arg4, "ccb.Texture2DBackend:updateSubData");
 
         #pragma warning NO CONVERSION TO NATIVE FOR unsigned char*
 		ok = false;
         if(!ok)
         {
-            tolua_error(tolua_S,"invalid arguments in function 'lua_cocos2dx_backend_TextureBackend2D_updateSubData'", nullptr);
+            tolua_error(tolua_S,"invalid arguments in function 'lua_cocos2dx_backend_Texture2DBackend_updateSubData'", nullptr);
             return 0;
         }
         cobj->updateSubData(arg0, arg1, arg2, arg3, arg4, arg5);
         lua_settop(tolua_S, 1);
         return 1;
     }
-    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ccb.TextureBackend2D:updateSubData",argc, 6);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ccb.Texture2DBackend:updateSubData",argc, 6);
     return 0;
 
 #if COCOS2D_DEBUG >= 1
     tolua_lerror:
-    tolua_error(tolua_S,"#ferror in function 'lua_cocos2dx_backend_TextureBackend2D_updateSubData'.",&tolua_err);
+    tolua_error(tolua_S,"#ferror in function 'lua_cocos2dx_backend_Texture2DBackend_updateSubData'.",&tolua_err);
 #endif
 
     return 0;
 }
-int lua_cocos2dx_backend_TextureBackend2D_updateCompressedSubData(lua_State* tolua_S)
+int lua_cocos2dx_backend_Texture2DBackend_updateCompressedSubData(lua_State* tolua_S)
 {
     int argc = 0;
-    cocos2d::backend::TextureBackend2D* cobj = nullptr;
+    cocos2d::backend::Texture2DBackend* cobj = nullptr;
     bool ok  = true;
 
 #if COCOS2D_DEBUG >= 1
@@ -1722,15 +1722,15 @@ int lua_cocos2dx_backend_TextureBackend2D_updateCompressedSubData(lua_State* tol
 
 
 #if COCOS2D_DEBUG >= 1
-    if (!tolua_isusertype(tolua_S,1,"ccb.TextureBackend2D",0,&tolua_err)) goto tolua_lerror;
+    if (!tolua_isusertype(tolua_S,1,"ccb.Texture2DBackend",0,&tolua_err)) goto tolua_lerror;
 #endif
 
-    cobj = (cocos2d::backend::TextureBackend2D*)tolua_tousertype(tolua_S,1,0);
+    cobj = (cocos2d::backend::Texture2DBackend*)tolua_tousertype(tolua_S,1,0);
 
 #if COCOS2D_DEBUG >= 1
     if (!cobj) 
     {
-        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_cocos2dx_backend_TextureBackend2D_updateCompressedSubData'", nullptr);
+        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_cocos2dx_backend_Texture2DBackend_updateCompressedSubData'", nullptr);
         return 0;
     }
 #endif
@@ -1746,68 +1746,68 @@ int lua_cocos2dx_backend_TextureBackend2D_updateCompressedSubData(lua_State* tol
         unsigned int arg5;
         unsigned char* arg6;
 
-        ok &= luaval_to_uint32(tolua_S, 2,&arg0, "ccb.TextureBackend2D:updateCompressedSubData");
+        ok &= luaval_to_uint32(tolua_S, 2,&arg0, "ccb.Texture2DBackend:updateCompressedSubData");
 
-        ok &= luaval_to_uint32(tolua_S, 3,&arg1, "ccb.TextureBackend2D:updateCompressedSubData");
+        ok &= luaval_to_uint32(tolua_S, 3,&arg1, "ccb.Texture2DBackend:updateCompressedSubData");
 
-        ok &= luaval_to_uint32(tolua_S, 4,&arg2, "ccb.TextureBackend2D:updateCompressedSubData");
+        ok &= luaval_to_uint32(tolua_S, 4,&arg2, "ccb.Texture2DBackend:updateCompressedSubData");
 
-        ok &= luaval_to_uint32(tolua_S, 5,&arg3, "ccb.TextureBackend2D:updateCompressedSubData");
+        ok &= luaval_to_uint32(tolua_S, 5,&arg3, "ccb.Texture2DBackend:updateCompressedSubData");
 
-        ok &= luaval_to_uint32(tolua_S, 6,&arg4, "ccb.TextureBackend2D:updateCompressedSubData");
+        ok &= luaval_to_uint32(tolua_S, 6,&arg4, "ccb.Texture2DBackend:updateCompressedSubData");
 
-        ok &= luaval_to_uint32(tolua_S, 7,&arg5, "ccb.TextureBackend2D:updateCompressedSubData");
+        ok &= luaval_to_uint32(tolua_S, 7,&arg5, "ccb.Texture2DBackend:updateCompressedSubData");
 
         #pragma warning NO CONVERSION TO NATIVE FOR unsigned char*
 		ok = false;
         if(!ok)
         {
-            tolua_error(tolua_S,"invalid arguments in function 'lua_cocos2dx_backend_TextureBackend2D_updateCompressedSubData'", nullptr);
+            tolua_error(tolua_S,"invalid arguments in function 'lua_cocos2dx_backend_Texture2DBackend_updateCompressedSubData'", nullptr);
             return 0;
         }
         cobj->updateCompressedSubData(arg0, arg1, arg2, arg3, arg4, arg5, arg6);
         lua_settop(tolua_S, 1);
         return 1;
     }
-    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ccb.TextureBackend2D:updateCompressedSubData",argc, 7);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ccb.Texture2DBackend:updateCompressedSubData",argc, 7);
     return 0;
 
 #if COCOS2D_DEBUG >= 1
     tolua_lerror:
-    tolua_error(tolua_S,"#ferror in function 'lua_cocos2dx_backend_TextureBackend2D_updateCompressedSubData'.",&tolua_err);
+    tolua_error(tolua_S,"#ferror in function 'lua_cocos2dx_backend_Texture2DBackend_updateCompressedSubData'.",&tolua_err);
 #endif
 
     return 0;
 }
-static int lua_cocos2dx_backend_TextureBackend2D_finalize(lua_State* tolua_S)
+static int lua_cocos2dx_backend_Texture2DBackend_finalize(lua_State* tolua_S)
 {
-    printf("luabindings: finalizing LUA object (TextureBackend2D)");
+    printf("luabindings: finalizing LUA object (Texture2DBackend)");
     return 0;
 }
 
-int lua_register_cocos2dx_backend_TextureBackend2D(lua_State* tolua_S)
+int lua_register_cocos2dx_backend_Texture2DBackend(lua_State* tolua_S)
 {
-    tolua_usertype(tolua_S,"ccb.TextureBackend2D");
-    tolua_cclass(tolua_S,"TextureBackend2D","ccb.TextureBackend2D","ccb.Texture",nullptr);
+    tolua_usertype(tolua_S,"ccb.Texture2DBackend");
+    tolua_cclass(tolua_S,"Texture2DBackend","ccb.Texture2DBackend","ccb.TextureBackend",nullptr);
 
-    tolua_beginmodule(tolua_S,"TextureBackend2D");
-        tolua_function(tolua_S,"getHeight",lua_cocos2dx_backend_TextureBackend2D_getHeight);
-        tolua_function(tolua_S,"getWidth",lua_cocos2dx_backend_TextureBackend2D_getWidth);
-        tolua_function(tolua_S,"updateData",lua_cocos2dx_backend_TextureBackend2D_updateData);
-        tolua_function(tolua_S,"updateCompressedData",lua_cocos2dx_backend_TextureBackend2D_updateCompressedData);
-        tolua_function(tolua_S,"updateSubData",lua_cocos2dx_backend_TextureBackend2D_updateSubData);
-        tolua_function(tolua_S,"updateCompressedSubData",lua_cocos2dx_backend_TextureBackend2D_updateCompressedSubData);
+    tolua_beginmodule(tolua_S,"Texture2DBackend");
+        tolua_function(tolua_S,"getHeight",lua_cocos2dx_backend_Texture2DBackend_getHeight);
+        tolua_function(tolua_S,"getWidth",lua_cocos2dx_backend_Texture2DBackend_getWidth);
+        tolua_function(tolua_S,"updateData",lua_cocos2dx_backend_Texture2DBackend_updateData);
+        tolua_function(tolua_S,"updateCompressedData",lua_cocos2dx_backend_Texture2DBackend_updateCompressedData);
+        tolua_function(tolua_S,"updateSubData",lua_cocos2dx_backend_Texture2DBackend_updateSubData);
+        tolua_function(tolua_S,"updateCompressedSubData",lua_cocos2dx_backend_Texture2DBackend_updateCompressedSubData);
     tolua_endmodule(tolua_S);
-    std::string typeName = typeid(cocos2d::backend::TextureBackend2D).name();
-    g_luaType[typeName] = "ccb.TextureBackend2D";
-    g_typeCast["TextureBackend2D"] = "ccb.TextureBackend2D";
+    std::string typeName = typeid(cocos2d::backend::Texture2DBackend).name();
+    g_luaType[typeName] = "ccb.Texture2DBackend";
+    g_typeCast["Texture2DBackend"] = "ccb.Texture2DBackend";
     return 1;
 }
 
-int lua_cocos2dx_backend_TextureBackendCubemap_updateFaceData(lua_State* tolua_S)
+int lua_cocos2dx_backend_TextureCubemapBackend_updateFaceData(lua_State* tolua_S)
 {
     int argc = 0;
-    cocos2d::backend::TextureBackendCubemap* cobj = nullptr;
+    cocos2d::backend::TextureCubemapBackend* cobj = nullptr;
     bool ok  = true;
 
 #if COCOS2D_DEBUG >= 1
@@ -1816,15 +1816,15 @@ int lua_cocos2dx_backend_TextureBackendCubemap_updateFaceData(lua_State* tolua_S
 
 
 #if COCOS2D_DEBUG >= 1
-    if (!tolua_isusertype(tolua_S,1,"ccb.TextureBackendCubemap",0,&tolua_err)) goto tolua_lerror;
+    if (!tolua_isusertype(tolua_S,1,"ccb.TextureCubemapBackend",0,&tolua_err)) goto tolua_lerror;
 #endif
 
-    cobj = (cocos2d::backend::TextureBackendCubemap*)tolua_tousertype(tolua_S,1,0);
+    cobj = (cocos2d::backend::TextureCubemapBackend*)tolua_tousertype(tolua_S,1,0);
 
 #if COCOS2D_DEBUG >= 1
     if (!cobj) 
     {
-        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_cocos2dx_backend_TextureBackendCubemap_updateFaceData'", nullptr);
+        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_cocos2dx_backend_TextureCubemapBackend_updateFaceData'", nullptr);
         return 0;
     }
 #endif
@@ -1835,46 +1835,46 @@ int lua_cocos2dx_backend_TextureBackendCubemap_updateFaceData(lua_State* tolua_S
         cocos2d::backend::TextureCubeFace arg0;
         void* arg1;
 
-        ok &= luaval_to_int32(tolua_S, 2,(int *)&arg0, "ccb.TextureBackendCubemap:updateFaceData");
+        ok &= luaval_to_int32(tolua_S, 2,(int *)&arg0, "ccb.TextureCubemapBackend:updateFaceData");
 
         #pragma warning NO CONVERSION TO NATIVE FOR void*
 		ok = false;
         if(!ok)
         {
-            tolua_error(tolua_S,"invalid arguments in function 'lua_cocos2dx_backend_TextureBackendCubemap_updateFaceData'", nullptr);
+            tolua_error(tolua_S,"invalid arguments in function 'lua_cocos2dx_backend_TextureCubemapBackend_updateFaceData'", nullptr);
             return 0;
         }
         cobj->updateFaceData(arg0, arg1);
         lua_settop(tolua_S, 1);
         return 1;
     }
-    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ccb.TextureBackendCubemap:updateFaceData",argc, 2);
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ccb.TextureCubemapBackend:updateFaceData",argc, 2);
     return 0;
 
 #if COCOS2D_DEBUG >= 1
     tolua_lerror:
-    tolua_error(tolua_S,"#ferror in function 'lua_cocos2dx_backend_TextureBackendCubemap_updateFaceData'.",&tolua_err);
+    tolua_error(tolua_S,"#ferror in function 'lua_cocos2dx_backend_TextureCubemapBackend_updateFaceData'.",&tolua_err);
 #endif
 
     return 0;
 }
-static int lua_cocos2dx_backend_TextureBackendCubemap_finalize(lua_State* tolua_S)
+static int lua_cocos2dx_backend_TextureCubemapBackend_finalize(lua_State* tolua_S)
 {
-    printf("luabindings: finalizing LUA object (TextureBackendCubemap)");
+    printf("luabindings: finalizing LUA object (TextureCubemapBackend)");
     return 0;
 }
 
-int lua_register_cocos2dx_backend_TextureBackendCubemap(lua_State* tolua_S)
+int lua_register_cocos2dx_backend_TextureCubemapBackend(lua_State* tolua_S)
 {
-    tolua_usertype(tolua_S,"ccb.TextureBackendCubemap");
-    tolua_cclass(tolua_S,"TextureBackendCubemap","ccb.TextureBackendCubemap","ccb.Texture",nullptr);
+    tolua_usertype(tolua_S,"ccb.TextureCubemapBackend");
+    tolua_cclass(tolua_S,"TextureCubemapBackend","ccb.TextureCubemapBackend","ccb.TextureBackend",nullptr);
 
-    tolua_beginmodule(tolua_S,"TextureBackendCubemap");
-        tolua_function(tolua_S,"updateFaceData",lua_cocos2dx_backend_TextureBackendCubemap_updateFaceData);
+    tolua_beginmodule(tolua_S,"TextureCubemapBackend");
+        tolua_function(tolua_S,"updateFaceData",lua_cocos2dx_backend_TextureCubemapBackend_updateFaceData);
     tolua_endmodule(tolua_S);
-    std::string typeName = typeid(cocos2d::backend::TextureBackendCubemap).name();
-    g_luaType[typeName] = "ccb.TextureBackendCubemap";
-    g_typeCast["TextureBackendCubemap"] = "ccb.TextureBackendCubemap";
+    std::string typeName = typeid(cocos2d::backend::TextureCubemapBackend).name();
+    g_luaType[typeName] = "ccb.TextureCubemapBackend";
+    g_typeCast["TextureCubemapBackend"] = "ccb.TextureCubemapBackend";
     return 1;
 }
 
@@ -2206,13 +2206,14 @@ TOLUA_API int register_all_cocos2dx_backend(lua_State* tolua_S)
 	lua_register_cocos2dx_backend_SamplerAddressMode(tolua_S);
 	lua_register_cocos2dx_backend_ProgramState(tolua_S);
 	lua_register_cocos2dx_backend_IndexFormat(tolua_S);
+	lua_register_cocos2dx_backend_TextureBackend(tolua_S);
+	lua_register_cocos2dx_backend_TextureCubemapBackend(tolua_S);
 	lua_register_cocos2dx_backend_SamplerFilter(tolua_S);
 	lua_register_cocos2dx_backend_TextureCubeFace(tolua_S);
 	lua_register_cocos2dx_backend_VertexLayout(tolua_S);
 	lua_register_cocos2dx_backend_BlendFactor(tolua_S);
 	lua_register_cocos2dx_backend_VertexFormat(tolua_S);
 	lua_register_cocos2dx_backend_VertexStepMode(tolua_S);
-	lua_register_cocos2dx_backend_Texture(tolua_S);
 	lua_register_cocos2dx_backend_StencilOperation(tolua_S);
 	lua_register_cocos2dx_backend_CompareFunction(tolua_S);
 	lua_register_cocos2dx_backend_BufferUsage(tolua_S);
@@ -2224,8 +2225,7 @@ TOLUA_API int register_all_cocos2dx_backend(lua_State* tolua_S)
 	lua_register_cocos2dx_backend_Program(tolua_S);
 	lua_register_cocos2dx_backend_BlendOperation(tolua_S);
 	lua_register_cocos2dx_backend_ShaderStage(tolua_S);
-	lua_register_cocos2dx_backend_TextureBackendCubemap(tolua_S);
-	lua_register_cocos2dx_backend_TextureBackend2D(tolua_S);
+	lua_register_cocos2dx_backend_Texture2DBackend(tolua_S);
 
 	tolua_endmodule(tolua_S);
 	return 1;

--- a/cocos/scripting/lua-bindings/auto/lua_cocos2dx_backend_auto.cpp
+++ b/cocos/scripting/lua-bindings/auto/lua_cocos2dx_backend_auto.cpp
@@ -1427,6 +1427,457 @@ int lua_register_cocos2dx_backend_Texture(lua_State* tolua_S)
     return 1;
 }
 
+int lua_cocos2dx_backend_TextureBackend2D_getHeight(lua_State* tolua_S)
+{
+    int argc = 0;
+    cocos2d::backend::TextureBackend2D* cobj = nullptr;
+    bool ok  = true;
+
+#if COCOS2D_DEBUG >= 1
+    tolua_Error tolua_err;
+#endif
+
+
+#if COCOS2D_DEBUG >= 1
+    if (!tolua_isusertype(tolua_S,1,"ccb.TextureBackend2D",0,&tolua_err)) goto tolua_lerror;
+#endif
+
+    cobj = (cocos2d::backend::TextureBackend2D*)tolua_tousertype(tolua_S,1,0);
+
+#if COCOS2D_DEBUG >= 1
+    if (!cobj) 
+    {
+        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_cocos2dx_backend_TextureBackend2D_getHeight'", nullptr);
+        return 0;
+    }
+#endif
+
+    argc = lua_gettop(tolua_S)-1;
+    if (argc == 0) 
+    {
+        if(!ok)
+        {
+            tolua_error(tolua_S,"invalid arguments in function 'lua_cocos2dx_backend_TextureBackend2D_getHeight'", nullptr);
+            return 0;
+        }
+        unsigned int ret = cobj->getHeight();
+        tolua_pushnumber(tolua_S,(lua_Number)ret);
+        return 1;
+    }
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ccb.TextureBackend2D:getHeight",argc, 0);
+    return 0;
+
+#if COCOS2D_DEBUG >= 1
+    tolua_lerror:
+    tolua_error(tolua_S,"#ferror in function 'lua_cocos2dx_backend_TextureBackend2D_getHeight'.",&tolua_err);
+#endif
+
+    return 0;
+}
+int lua_cocos2dx_backend_TextureBackend2D_getWidth(lua_State* tolua_S)
+{
+    int argc = 0;
+    cocos2d::backend::TextureBackend2D* cobj = nullptr;
+    bool ok  = true;
+
+#if COCOS2D_DEBUG >= 1
+    tolua_Error tolua_err;
+#endif
+
+
+#if COCOS2D_DEBUG >= 1
+    if (!tolua_isusertype(tolua_S,1,"ccb.TextureBackend2D",0,&tolua_err)) goto tolua_lerror;
+#endif
+
+    cobj = (cocos2d::backend::TextureBackend2D*)tolua_tousertype(tolua_S,1,0);
+
+#if COCOS2D_DEBUG >= 1
+    if (!cobj) 
+    {
+        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_cocos2dx_backend_TextureBackend2D_getWidth'", nullptr);
+        return 0;
+    }
+#endif
+
+    argc = lua_gettop(tolua_S)-1;
+    if (argc == 0) 
+    {
+        if(!ok)
+        {
+            tolua_error(tolua_S,"invalid arguments in function 'lua_cocos2dx_backend_TextureBackend2D_getWidth'", nullptr);
+            return 0;
+        }
+        unsigned int ret = cobj->getWidth();
+        tolua_pushnumber(tolua_S,(lua_Number)ret);
+        return 1;
+    }
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ccb.TextureBackend2D:getWidth",argc, 0);
+    return 0;
+
+#if COCOS2D_DEBUG >= 1
+    tolua_lerror:
+    tolua_error(tolua_S,"#ferror in function 'lua_cocos2dx_backend_TextureBackend2D_getWidth'.",&tolua_err);
+#endif
+
+    return 0;
+}
+int lua_cocos2dx_backend_TextureBackend2D_updateData(lua_State* tolua_S)
+{
+    int argc = 0;
+    cocos2d::backend::TextureBackend2D* cobj = nullptr;
+    bool ok  = true;
+
+#if COCOS2D_DEBUG >= 1
+    tolua_Error tolua_err;
+#endif
+
+
+#if COCOS2D_DEBUG >= 1
+    if (!tolua_isusertype(tolua_S,1,"ccb.TextureBackend2D",0,&tolua_err)) goto tolua_lerror;
+#endif
+
+    cobj = (cocos2d::backend::TextureBackend2D*)tolua_tousertype(tolua_S,1,0);
+
+#if COCOS2D_DEBUG >= 1
+    if (!cobj) 
+    {
+        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_cocos2dx_backend_TextureBackend2D_updateData'", nullptr);
+        return 0;
+    }
+#endif
+
+    argc = lua_gettop(tolua_S)-1;
+    if (argc == 4) 
+    {
+        unsigned char* arg0;
+        unsigned int arg1;
+        unsigned int arg2;
+        unsigned int arg3;
+
+        #pragma warning NO CONVERSION TO NATIVE FOR unsigned char*
+		ok = false;
+
+        ok &= luaval_to_uint32(tolua_S, 3,&arg1, "ccb.TextureBackend2D:updateData");
+
+        ok &= luaval_to_uint32(tolua_S, 4,&arg2, "ccb.TextureBackend2D:updateData");
+
+        ok &= luaval_to_uint32(tolua_S, 5,&arg3, "ccb.TextureBackend2D:updateData");
+        if(!ok)
+        {
+            tolua_error(tolua_S,"invalid arguments in function 'lua_cocos2dx_backend_TextureBackend2D_updateData'", nullptr);
+            return 0;
+        }
+        cobj->updateData(arg0, arg1, arg2, arg3);
+        lua_settop(tolua_S, 1);
+        return 1;
+    }
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ccb.TextureBackend2D:updateData",argc, 4);
+    return 0;
+
+#if COCOS2D_DEBUG >= 1
+    tolua_lerror:
+    tolua_error(tolua_S,"#ferror in function 'lua_cocos2dx_backend_TextureBackend2D_updateData'.",&tolua_err);
+#endif
+
+    return 0;
+}
+int lua_cocos2dx_backend_TextureBackend2D_updateCompressedData(lua_State* tolua_S)
+{
+    int argc = 0;
+    cocos2d::backend::TextureBackend2D* cobj = nullptr;
+    bool ok  = true;
+
+#if COCOS2D_DEBUG >= 1
+    tolua_Error tolua_err;
+#endif
+
+
+#if COCOS2D_DEBUG >= 1
+    if (!tolua_isusertype(tolua_S,1,"ccb.TextureBackend2D",0,&tolua_err)) goto tolua_lerror;
+#endif
+
+    cobj = (cocos2d::backend::TextureBackend2D*)tolua_tousertype(tolua_S,1,0);
+
+#if COCOS2D_DEBUG >= 1
+    if (!cobj) 
+    {
+        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_cocos2dx_backend_TextureBackend2D_updateCompressedData'", nullptr);
+        return 0;
+    }
+#endif
+
+    argc = lua_gettop(tolua_S)-1;
+    if (argc == 5) 
+    {
+        unsigned char* arg0;
+        unsigned int arg1;
+        unsigned int arg2;
+        unsigned int arg3;
+        unsigned int arg4;
+
+        #pragma warning NO CONVERSION TO NATIVE FOR unsigned char*
+		ok = false;
+
+        ok &= luaval_to_uint32(tolua_S, 3,&arg1, "ccb.TextureBackend2D:updateCompressedData");
+
+        ok &= luaval_to_uint32(tolua_S, 4,&arg2, "ccb.TextureBackend2D:updateCompressedData");
+
+        ok &= luaval_to_uint32(tolua_S, 5,&arg3, "ccb.TextureBackend2D:updateCompressedData");
+
+        ok &= luaval_to_uint32(tolua_S, 6,&arg4, "ccb.TextureBackend2D:updateCompressedData");
+        if(!ok)
+        {
+            tolua_error(tolua_S,"invalid arguments in function 'lua_cocos2dx_backend_TextureBackend2D_updateCompressedData'", nullptr);
+            return 0;
+        }
+        cobj->updateCompressedData(arg0, arg1, arg2, arg3, arg4);
+        lua_settop(tolua_S, 1);
+        return 1;
+    }
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ccb.TextureBackend2D:updateCompressedData",argc, 5);
+    return 0;
+
+#if COCOS2D_DEBUG >= 1
+    tolua_lerror:
+    tolua_error(tolua_S,"#ferror in function 'lua_cocos2dx_backend_TextureBackend2D_updateCompressedData'.",&tolua_err);
+#endif
+
+    return 0;
+}
+int lua_cocos2dx_backend_TextureBackend2D_updateSubData(lua_State* tolua_S)
+{
+    int argc = 0;
+    cocos2d::backend::TextureBackend2D* cobj = nullptr;
+    bool ok  = true;
+
+#if COCOS2D_DEBUG >= 1
+    tolua_Error tolua_err;
+#endif
+
+
+#if COCOS2D_DEBUG >= 1
+    if (!tolua_isusertype(tolua_S,1,"ccb.TextureBackend2D",0,&tolua_err)) goto tolua_lerror;
+#endif
+
+    cobj = (cocos2d::backend::TextureBackend2D*)tolua_tousertype(tolua_S,1,0);
+
+#if COCOS2D_DEBUG >= 1
+    if (!cobj) 
+    {
+        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_cocos2dx_backend_TextureBackend2D_updateSubData'", nullptr);
+        return 0;
+    }
+#endif
+
+    argc = lua_gettop(tolua_S)-1;
+    if (argc == 6) 
+    {
+        unsigned int arg0;
+        unsigned int arg1;
+        unsigned int arg2;
+        unsigned int arg3;
+        unsigned int arg4;
+        unsigned char* arg5;
+
+        ok &= luaval_to_uint32(tolua_S, 2,&arg0, "ccb.TextureBackend2D:updateSubData");
+
+        ok &= luaval_to_uint32(tolua_S, 3,&arg1, "ccb.TextureBackend2D:updateSubData");
+
+        ok &= luaval_to_uint32(tolua_S, 4,&arg2, "ccb.TextureBackend2D:updateSubData");
+
+        ok &= luaval_to_uint32(tolua_S, 5,&arg3, "ccb.TextureBackend2D:updateSubData");
+
+        ok &= luaval_to_uint32(tolua_S, 6,&arg4, "ccb.TextureBackend2D:updateSubData");
+
+        #pragma warning NO CONVERSION TO NATIVE FOR unsigned char*
+		ok = false;
+        if(!ok)
+        {
+            tolua_error(tolua_S,"invalid arguments in function 'lua_cocos2dx_backend_TextureBackend2D_updateSubData'", nullptr);
+            return 0;
+        }
+        cobj->updateSubData(arg0, arg1, arg2, arg3, arg4, arg5);
+        lua_settop(tolua_S, 1);
+        return 1;
+    }
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ccb.TextureBackend2D:updateSubData",argc, 6);
+    return 0;
+
+#if COCOS2D_DEBUG >= 1
+    tolua_lerror:
+    tolua_error(tolua_S,"#ferror in function 'lua_cocos2dx_backend_TextureBackend2D_updateSubData'.",&tolua_err);
+#endif
+
+    return 0;
+}
+int lua_cocos2dx_backend_TextureBackend2D_updateCompressedSubData(lua_State* tolua_S)
+{
+    int argc = 0;
+    cocos2d::backend::TextureBackend2D* cobj = nullptr;
+    bool ok  = true;
+
+#if COCOS2D_DEBUG >= 1
+    tolua_Error tolua_err;
+#endif
+
+
+#if COCOS2D_DEBUG >= 1
+    if (!tolua_isusertype(tolua_S,1,"ccb.TextureBackend2D",0,&tolua_err)) goto tolua_lerror;
+#endif
+
+    cobj = (cocos2d::backend::TextureBackend2D*)tolua_tousertype(tolua_S,1,0);
+
+#if COCOS2D_DEBUG >= 1
+    if (!cobj) 
+    {
+        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_cocos2dx_backend_TextureBackend2D_updateCompressedSubData'", nullptr);
+        return 0;
+    }
+#endif
+
+    argc = lua_gettop(tolua_S)-1;
+    if (argc == 7) 
+    {
+        unsigned int arg0;
+        unsigned int arg1;
+        unsigned int arg2;
+        unsigned int arg3;
+        unsigned int arg4;
+        unsigned int arg5;
+        unsigned char* arg6;
+
+        ok &= luaval_to_uint32(tolua_S, 2,&arg0, "ccb.TextureBackend2D:updateCompressedSubData");
+
+        ok &= luaval_to_uint32(tolua_S, 3,&arg1, "ccb.TextureBackend2D:updateCompressedSubData");
+
+        ok &= luaval_to_uint32(tolua_S, 4,&arg2, "ccb.TextureBackend2D:updateCompressedSubData");
+
+        ok &= luaval_to_uint32(tolua_S, 5,&arg3, "ccb.TextureBackend2D:updateCompressedSubData");
+
+        ok &= luaval_to_uint32(tolua_S, 6,&arg4, "ccb.TextureBackend2D:updateCompressedSubData");
+
+        ok &= luaval_to_uint32(tolua_S, 7,&arg5, "ccb.TextureBackend2D:updateCompressedSubData");
+
+        #pragma warning NO CONVERSION TO NATIVE FOR unsigned char*
+		ok = false;
+        if(!ok)
+        {
+            tolua_error(tolua_S,"invalid arguments in function 'lua_cocos2dx_backend_TextureBackend2D_updateCompressedSubData'", nullptr);
+            return 0;
+        }
+        cobj->updateCompressedSubData(arg0, arg1, arg2, arg3, arg4, arg5, arg6);
+        lua_settop(tolua_S, 1);
+        return 1;
+    }
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ccb.TextureBackend2D:updateCompressedSubData",argc, 7);
+    return 0;
+
+#if COCOS2D_DEBUG >= 1
+    tolua_lerror:
+    tolua_error(tolua_S,"#ferror in function 'lua_cocos2dx_backend_TextureBackend2D_updateCompressedSubData'.",&tolua_err);
+#endif
+
+    return 0;
+}
+static int lua_cocos2dx_backend_TextureBackend2D_finalize(lua_State* tolua_S)
+{
+    printf("luabindings: finalizing LUA object (TextureBackend2D)");
+    return 0;
+}
+
+int lua_register_cocos2dx_backend_TextureBackend2D(lua_State* tolua_S)
+{
+    tolua_usertype(tolua_S,"ccb.TextureBackend2D");
+    tolua_cclass(tolua_S,"TextureBackend2D","ccb.TextureBackend2D","ccb.Texture",nullptr);
+
+    tolua_beginmodule(tolua_S,"TextureBackend2D");
+        tolua_function(tolua_S,"getHeight",lua_cocos2dx_backend_TextureBackend2D_getHeight);
+        tolua_function(tolua_S,"getWidth",lua_cocos2dx_backend_TextureBackend2D_getWidth);
+        tolua_function(tolua_S,"updateData",lua_cocos2dx_backend_TextureBackend2D_updateData);
+        tolua_function(tolua_S,"updateCompressedData",lua_cocos2dx_backend_TextureBackend2D_updateCompressedData);
+        tolua_function(tolua_S,"updateSubData",lua_cocos2dx_backend_TextureBackend2D_updateSubData);
+        tolua_function(tolua_S,"updateCompressedSubData",lua_cocos2dx_backend_TextureBackend2D_updateCompressedSubData);
+    tolua_endmodule(tolua_S);
+    std::string typeName = typeid(cocos2d::backend::TextureBackend2D).name();
+    g_luaType[typeName] = "ccb.TextureBackend2D";
+    g_typeCast["TextureBackend2D"] = "ccb.TextureBackend2D";
+    return 1;
+}
+
+int lua_cocos2dx_backend_TextureBackendCubemap_updateFaceData(lua_State* tolua_S)
+{
+    int argc = 0;
+    cocos2d::backend::TextureBackendCubemap* cobj = nullptr;
+    bool ok  = true;
+
+#if COCOS2D_DEBUG >= 1
+    tolua_Error tolua_err;
+#endif
+
+
+#if COCOS2D_DEBUG >= 1
+    if (!tolua_isusertype(tolua_S,1,"ccb.TextureBackendCubemap",0,&tolua_err)) goto tolua_lerror;
+#endif
+
+    cobj = (cocos2d::backend::TextureBackendCubemap*)tolua_tousertype(tolua_S,1,0);
+
+#if COCOS2D_DEBUG >= 1
+    if (!cobj) 
+    {
+        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_cocos2dx_backend_TextureBackendCubemap_updateFaceData'", nullptr);
+        return 0;
+    }
+#endif
+
+    argc = lua_gettop(tolua_S)-1;
+    if (argc == 2) 
+    {
+        cocos2d::backend::TextureCubeFace arg0;
+        void* arg1;
+
+        ok &= luaval_to_int32(tolua_S, 2,(int *)&arg0, "ccb.TextureBackendCubemap:updateFaceData");
+
+        #pragma warning NO CONVERSION TO NATIVE FOR void*
+		ok = false;
+        if(!ok)
+        {
+            tolua_error(tolua_S,"invalid arguments in function 'lua_cocos2dx_backend_TextureBackendCubemap_updateFaceData'", nullptr);
+            return 0;
+        }
+        cobj->updateFaceData(arg0, arg1);
+        lua_settop(tolua_S, 1);
+        return 1;
+    }
+    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "ccb.TextureBackendCubemap:updateFaceData",argc, 2);
+    return 0;
+
+#if COCOS2D_DEBUG >= 1
+    tolua_lerror:
+    tolua_error(tolua_S,"#ferror in function 'lua_cocos2dx_backend_TextureBackendCubemap_updateFaceData'.",&tolua_err);
+#endif
+
+    return 0;
+}
+static int lua_cocos2dx_backend_TextureBackendCubemap_finalize(lua_State* tolua_S)
+{
+    printf("luabindings: finalizing LUA object (TextureBackendCubemap)");
+    return 0;
+}
+
+int lua_register_cocos2dx_backend_TextureBackendCubemap(lua_State* tolua_S)
+{
+    tolua_usertype(tolua_S,"ccb.TextureBackendCubemap");
+    tolua_cclass(tolua_S,"TextureBackendCubemap","ccb.TextureBackendCubemap","ccb.Texture",nullptr);
+
+    tolua_beginmodule(tolua_S,"TextureBackendCubemap");
+        tolua_function(tolua_S,"updateFaceData",lua_cocos2dx_backend_TextureBackendCubemap_updateFaceData);
+    tolua_endmodule(tolua_S);
+    std::string typeName = typeid(cocos2d::backend::TextureBackendCubemap).name();
+    g_luaType[typeName] = "ccb.TextureBackendCubemap";
+    g_typeCast["TextureBackendCubemap"] = "ccb.TextureBackendCubemap";
+    return 1;
+}
+
 int lua_cocos2dx_backend_VertexLayout_getVertexStepMode(lua_State* tolua_S)
 {
     int argc = 0;
@@ -1773,6 +2224,8 @@ TOLUA_API int register_all_cocos2dx_backend(lua_State* tolua_S)
 	lua_register_cocos2dx_backend_Program(tolua_S);
 	lua_register_cocos2dx_backend_BlendOperation(tolua_S);
 	lua_register_cocos2dx_backend_ShaderStage(tolua_S);
+	lua_register_cocos2dx_backend_TextureBackendCubemap(tolua_S);
+	lua_register_cocos2dx_backend_TextureBackend2D(tolua_S);
 
 	tolua_endmodule(tolua_S);
 	return 1;

--- a/cocos/scripting/lua-bindings/auto/lua_cocos2dx_backend_auto.hpp
+++ b/cocos/scripting/lua-bindings/auto/lua_cocos2dx_backend_auto.hpp
@@ -42,4 +42,13 @@ int register_all_cocos2dx_backend(lua_State* tolua_S);
 
 
 
+
+
+
+
+
+
+
+
+
 #endif // __cocos2dx_backend_h__

--- a/cocos/scripting/lua-bindings/manual/cocos2d/lua_cocos2dx_manual.cpp
+++ b/cocos/scripting/lua-bindings/manual/cocos2d/lua_cocos2dx_manual.cpp
@@ -3806,10 +3806,10 @@ static int tolua_cocos2dx_Texture2D_setTexParameters(lua_State* tolua_S)
         }
 #endif
 
-        arg1 = utils::toBackendSamplerFilter((GLuint)tolua_tonumber(tolua_S, 2, 0));
-        arg2 = utils::toBackendSamplerFilter((GLuint)tolua_tonumber(tolua_S, 3, 0));
-        arg3 = utils::toBackendAddressMode((GLuint)tolua_tonumber(tolua_S, 4, 0));
-        arg4 = utils::toBackendAddressMode((GLuint)tolua_tonumber(tolua_S, 5, 0));
+        arg1 = (backend::SamplerFilter)(int)tolua_tonumber(tolua_S, 2, 0);
+        arg2 = (backend::SamplerFilter)(int)tolua_tonumber(tolua_S, 3, 0);
+        arg3 = (backend::SamplerAddressMode)(int)tolua_tonumber(tolua_S, 4, 0);
+        arg4 = (backend::SamplerAddressMode)(int)tolua_tonumber(tolua_S, 5, 0);
 
         Texture2D::TexParams param(arg1, arg2, arg3, arg4);
 
@@ -3818,12 +3818,12 @@ static int tolua_cocos2dx_Texture2D_setTexParameters(lua_State* tolua_S)
         return 0;
     }
 
-    luaL_error(tolua_S, "'setSamplerDescriptor' function of Texture2D wrong number of arguments: %d, was expecting %d\n", argc,4);
+    luaL_error(tolua_S, "'setTexParameters' function of Texture2D wrong number of arguments: %d, was expecting %d\n", argc,4);
     return 0;
 
 #if COCOS2D_DEBUG >= 1
 tolua_lerror:
-    tolua_error(tolua_S,"#ferror in function 'setSamplerDescriptor'.",&tolua_err);
+    tolua_error(tolua_S,"#ferror in function 'setTexParameters'.",&tolua_err);
     return 0;
 #endif
 }
@@ -4018,7 +4018,7 @@ static void extendTexture2D(lua_State* tolua_S)
     lua_rawget(tolua_S, LUA_REGISTRYINDEX);
     if (lua_istable(tolua_S,-1))
     {
-        lua_pushstring(tolua_S,"setSamplerDescriptor");
+        lua_pushstring(tolua_S,"setTexParameters");
         lua_pushcfunction(tolua_S,tolua_cocos2dx_Texture2D_setTexParameters );
         lua_rawset(tolua_S,-3);
     }

--- a/tests/lua-tests/src/NodeTest/NodeTest.lua
+++ b/tests/lua-tests/src/NodeTest/NodeTest.lua
@@ -369,7 +369,8 @@ local function StressTest2()
     sublayer:addChild(sp1, 1)
 
     local fire = cc.ParticleFire:create()
-    fire:setTexture(cc.Director:getInstance():getTextureCache():addImage("Images/fire.png"))
+    local fireTexture = cc.Director:getInstance():getTextureCache():addImage("Images/fire.png")
+    fire:setTexture(fireTexture)
     fire:setPosition(80, s.height / 2 - 50)
 
     local copy_seq3 = seq3:clone()

--- a/tools/tolua/cocos2dx_backend.ini
+++ b/tools/tolua/cocos2dx_backend.ini
@@ -28,7 +28,7 @@ headers = %(cocosdir)s/cocos/renderer/backend/Types.h %(cocosdir)s/cocos/rendere
 
 # what classes to produce code for. You can use regular expressions here. When testing the regular
 # expression, it will be enclosed in "^$", like this: "^Menu*$".
-classes = VertexLayout BufferUsage BufferType ShaderStage VertexFormat PixelFormat TextureUsage IndexFormat VertexStepMode PrimitiveType TextureType SamplerAddressMode SamplerFilter StencilOperation CompareFunction BlendOperation BlendFactor ColorWriteMask SamplerDescriptor CullMode Winding UniformInfo UniformLocation AttributeBindInfo TextureCubeFace ProgramState Texture Program TextureBackend2D TextureBackendCubemap
+classes = VertexLayout BufferUsage BufferType ShaderStage VertexFormat PixelFormat TextureUsage IndexFormat VertexStepMode PrimitiveType TextureType SamplerAddressMode SamplerFilter StencilOperation CompareFunction BlendOperation BlendFactor ColorWriteMask SamplerDescriptor CullMode Winding UniformInfo UniformLocation AttributeBindInfo TextureCubeFace ProgramState TextureBackend Program Texture2DBackend TextureCubemapBackend
 
 # what should we skip? in the format ClassName::[function function]
 # ClassName is a regular expression, but will be used like this: "^ClassName$" functions are also

--- a/tools/tolua/cocos2dx_backend.ini
+++ b/tools/tolua/cocos2dx_backend.ini
@@ -28,7 +28,7 @@ headers = %(cocosdir)s/cocos/renderer/backend/Types.h %(cocosdir)s/cocos/rendere
 
 # what classes to produce code for. You can use regular expressions here. When testing the regular
 # expression, it will be enclosed in "^$", like this: "^Menu*$".
-classes = VertexLayout BufferUsage BufferType ShaderStage VertexFormat PixelFormat TextureUsage IndexFormat VertexStepMode PrimitiveType TextureType SamplerAddressMode SamplerFilter StencilOperation CompareFunction BlendOperation BlendFactor ColorWriteMask SamplerDescriptor CullMode Winding UniformInfo UniformLocation AttributeBindInfo TextureCubeFace ProgramState Texture Program
+classes = VertexLayout BufferUsage BufferType ShaderStage VertexFormat PixelFormat TextureUsage IndexFormat VertexStepMode PrimitiveType TextureType SamplerAddressMode SamplerFilter StencilOperation CompareFunction BlendOperation BlendFactor ColorWriteMask SamplerDescriptor CullMode Winding UniformInfo UniformLocation AttributeBindInfo TextureCubeFace ProgramState Texture Program TextureBackend2D TextureBackendCubemap
 
 # what should we skip? in the format ClassName::[function function]
 # ClassName is a regular expression, but will be used like this: "^ClassName$" functions are also


### PR DESCRIPTION
`cocos2d::backend::Texture2D` & `cocos2d::Texture2D` is easy to confuse

Rename 
- `backend::Texture2D` to `backend::Texture2DBackend`
- `backend::Texture` to `backend::TextureBackend`
- `backend::TextureCubemap` to `backend::TextureCubemapBackend`