### PR TITLE
refactor AudioEngine-Linux

### DIFF
--- a/cocos/audio/AudioEngine.cpp
+++ b/cocos/audio/AudioEngine.cpp
@@ -400,10 +400,7 @@ void AudioEngine::uncache(const std::string &filePath)
         _audioPathIDMap.erase(filePath);
     }
 
-    if (_audioEngineImpl)
-    {
-        _audioEngineImpl->uncache(filePath);
-    }
+    _audioEngineImpl->uncache(filePath);
 }
 
 void AudioEngine::uncacheAll()

--- a/cocos/audio/AudioEngine.cpp
+++ b/cocos/audio/AudioEngine.cpp
@@ -349,7 +349,7 @@ void AudioEngine::remove(int audioID)
             it->second.profileHelper->audioIDs.remove(audioID);
         }
         _audioPathIDMap[*it->second.filePath].remove(audioID);
-        _audioIDInfoMap.erase(audioID);
+        _audioIDInfoMap.erase(it);
     }
 }
 
@@ -394,7 +394,7 @@ void AudioEngine::uncache(const std::string &filePath)
                 {
                     itInfo->second.profileHelper->audioIDs.remove(audioID);
                 }
-                _audioIDInfoMap.erase(audioID);
+                _audioIDInfoMap.erase(itInfo);
             }
         }
         _audioPathIDMap.erase(filePath);

--- a/cocos/audio/linux/AudioEngine-linux.cpp
+++ b/cocos/audio/linux/AudioEngine-linux.cpp
@@ -72,8 +72,6 @@ AudioEngineImpl::AudioEngineImpl()
 AudioEngineImpl::~AudioEngineImpl()
 {
     FMOD_RESULT result;
-    result = pSystem->close();
-    ERRCHECKWITHEXIT(result);
     result = pSystem->release();
     ERRCHECKWITHEXIT(result);
 }
@@ -109,7 +107,7 @@ int AudioEngineImpl::play2d(const std::string &fileFullPath, bool loop, float vo
     int id = preload(fileFullPath, nullptr);
     if (id >= 0) {
         mapChannelInfo[id].loop=loop;
-        mapChannelInfo[id].channel->setPaused(true);
+        //mapChannelInfo[id].channel->setPaused(true);
         mapChannelInfo[id].volume = volume;
         AudioEngine::_audioIDInfoMap[id].state = AudioEngine::AudioState::PAUSED;
         resume(id);
@@ -287,8 +285,7 @@ void AudioEngineImpl::uncache(const std::string& path)
         }
         mapSound.erase(it);
     }
-    if (mapId.find(path) != mapId.end())
-        mapId.erase(path);
+    mapId.erase(path);
 }
 
 void AudioEngineImpl::uncacheAll()
@@ -320,10 +317,9 @@ int AudioEngineImpl::preload(const std::string& filePath, std::function<void(boo
     }
 
     int id = static_cast<int>(mapChannelInfo.size()) + 1;
-    if (mapId.find(filePath) == mapId.end())
-        mapId.insert({filePath, id});
-    else
-        id = mapId.at(filePath);
+    // std::map::insert returns std::pair<iter, bool>
+    auto channelInfoIter = mapId.insert({filePath, id});
+    id = channelInfoIter.first->second;
 
     auto& chanelInfo = mapChannelInfo[id];
     chanelInfo.sound = sound;

--- a/cocos/audio/linux/AudioEngine-linux.cpp
+++ b/cocos/audio/linux/AudioEngine-linux.cpp
@@ -107,6 +107,7 @@ int AudioEngineImpl::play2d(const std::string &fileFullPath, bool loop, float vo
     int id = preload(fileFullPath, nullptr);
     if (id >= 0) {
         mapChannelInfo[id].loop=loop;
+        // channel is null here. Don't dereference it. It's only set in resume(id).
         //mapChannelInfo[id].channel->setPaused(true);
         mapChannelInfo[id].volume = volume;
         AudioEngine::_audioIDInfoMap[id].state = AudioEngine::AudioState::PAUSED;


### PR DESCRIPTION
* use std::map::insert properly

```cpp
std::pair<iterator,bool> insert( value_type&& value );
```
From: https://en.cppreference.com/w/cpp/container/map/insert

> Inserts element(s) into the container, if the container doesn't already contain an element with an equivalent key. 

>  Returns a pair consisting of an iterator to the inserted element (or to the element that prevented the insertion) and a bool denoting whether the insertion took place.

```cpp
if (mapId.find(filePath) == mapId.end())
    mapId.insert({filePath, id});
```
This code is bad for performance. It will iterate the `mapId` twice. One in `mapId.find`, and the other in `mapId.insert`.

The new code only iterate the map once.

The performance might not matter here, but this pattern is not rare in the code. Unfortunately there is no tool to find this.