### PR TITLE
Add allow-arbitrary-loads option for cmake ios

### DIFF
--- a/cmake/Modules/CocosBuildHelpers.cmake
+++ b/cmake/Modules/CocosBuildHelpers.cmake
@@ -231,7 +231,7 @@ macro(cocos_pak_xcode cocos_target)
     cocos_fake_set(COCOS_APP_LONG_VERSION_STRING "1.0.0")
     cocos_fake_set(COCOS_APP_SHORT_VERSION_STRING "1.0")
     cocos_fake_set(COCOS_APP_CUSTOM_FONT "")
-    cocos_fake_set(ALLOWARBITRARYLOADS "false")
+    cocos_fake_set(COCOS_APP_ALLOWARBITRARYLOADS "false")
     # set bundle info
     set_target_properties(${cocos_target}
                           PROPERTIES

--- a/cmake/Modules/CocosBuildHelpers.cmake
+++ b/cmake/Modules/CocosBuildHelpers.cmake
@@ -216,6 +216,7 @@ macro(cocos_pak_xcode cocos_target)
         LONG_VERSION_STRING
         SHORT_VERSION_STRING
         CUSTOM_FONT
+        ALLOWARBITRARYLOADS
         )
     set(multiValueArgs)
     cmake_parse_arguments(COCOS_APP "" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
@@ -230,6 +231,7 @@ macro(cocos_pak_xcode cocos_target)
     cocos_fake_set(COCOS_APP_LONG_VERSION_STRING "1.0.0")
     cocos_fake_set(COCOS_APP_SHORT_VERSION_STRING "1.0")
     cocos_fake_set(COCOS_APP_CUSTOM_FONT "")
+    cocos_fake_set(ALLOWARBITRARYLOADS "false")
     # set bundle info
     set_target_properties(${cocos_target}
                           PROPERTIES
@@ -244,6 +246,7 @@ macro(cocos_pak_xcode cocos_target)
     set(MACOSX_BUNDLE_LONG_VERSION_STRING ${COCOS_APP_LONG_VERSION_STRING})
     set(MACOSX_BUNDLE_SHORT_VERSION_STRING ${COCOS_APP_SHORT_VERSION_STRING})
     set(MACOSX_CUSTOM_FONT_FILE ${COCOS_APP_CUSTOM_FONT})
+    set(MACOSX_CUSTOM_ALLOWARBITRARYLOADS ${COCOS_APP_ALLOWARBITRARYLOADS})
 
     message(STATUS "cocos package: ${cocos_target}, plist file: ${COCOS_APP_INFO_PLIST}")
 

--- a/cmake/Modules/iOSBundleInfo.plist.in
+++ b/cmake/Modules/iOSBundleInfo.plist.in
@@ -51,5 +51,10 @@
     <array>
         ${MACOSX_CUSTOM_FONT_FILE}
     </array>
+    <key>NSAppTransportSecurity</key>
+    <dict>
+        <key>NSAllowsArbitraryLoads</key>
+        <${MACOSX_CUSTOM_ALLOWARBITRARYLOADS}/>
+    </dict>
 </dict>
 </plist>

--- a/tests/cpp-empty-test/CMakeLists.txt
+++ b/tests/cpp-empty-test/CMakeLists.txt
@@ -133,7 +133,7 @@ if(APPLE)
                               MACOSX_BUNDLE_INFO_PLIST "${CMAKE_CURRENT_SOURCE_DIR}/proj.mac/Info.plist"
                               )
     elseif(IOS)
-        cocos_pak_xcode(${APP_NAME} INFO_PLIST "iOSBundleInfo.plist.in")
+        cocos_pak_xcode(${APP_NAME} INFO_PLIST "iOSBundleInfo.plist.in" ALLOWARBITRARYLOADS "true")
         set_xcode_property(${APP_NAME} ASSETCATALOG_COMPILER_APPICON_NAME "AppIcon-${APP_NAME}")
         set_xcode_property(${APP_NAME} CODE_SIGN_IDENTITY "iPhone Developer")
         set_xcode_property(${APP_NAME} DEVELOPMENT_TEAM "")

--- a/tests/cpp-tests/CMakeLists.txt
+++ b/tests/cpp-tests/CMakeLists.txt
@@ -477,7 +477,7 @@ if(APPLE)
             string(APPEND GAME_CUSTOM_FONT "\n<string>${font}</string>")
         endforeach()
 
-        cocos_pak_xcode(${APP_NAME} INFO_PLIST "iOSBundleInfo.plist.in" CUSTOM_FONT ${GAME_CUSTOM_FONT})
+        cocos_pak_xcode(${APP_NAME} INFO_PLIST "iOSBundleInfo.plist.in" CUSTOM_FONT ${GAME_CUSTOM_FONT} ALLOWARBITRARYLOADS "true")
         set_xcode_property(${APP_NAME} ASSETCATALOG_COMPILER_APPICON_NAME "AppIcon-${APP_NAME}")
         set_xcode_property(${APP_NAME} DEVELOPMENT_TEAM "")
         set_xcode_property(${APP_NAME} CODE_SIGN_IDENTITY "iPhone Developer")

--- a/tests/lua-empty-test/project/CMakeLists.txt
+++ b/tests/lua-empty-test/project/CMakeLists.txt
@@ -105,7 +105,7 @@ if(APPLE)
                               MACOSX_BUNDLE_INFO_PLIST "${CMAKE_CURRENT_SOURCE_DIR}/proj.mac/Info.plist"
                               )
     elseif(IOS)
-        cocos_pak_xcode(${APP_NAME} INFO_PLIST "iOSBundleInfo.plist.in")
+        cocos_pak_xcode(${APP_NAME} INFO_PLIST "iOSBundleInfo.plist.in" ALLOWARBITRARYLOADS "true")
         set_xcode_property(${APP_NAME} ASSETCATALOG_COMPILER_APPICON_NAME "AppIcon-${APP_NAME}")
         set_xcode_property(${APP_NAME} DEVELOPMENT_TEAM "")
         set_xcode_property(${APP_NAME} CODE_SIGN_IDENTITY "iPhone Developer")

--- a/tests/lua-tests/project/CMakeLists.txt
+++ b/tests/lua-tests/project/CMakeLists.txt
@@ -113,7 +113,7 @@ if(APPLE)
                               MACOSX_BUNDLE_INFO_PLIST "${CMAKE_CURRENT_SOURCE_DIR}/proj.ios_mac/mac/Info.plist"
                               )
     elseif(IOS)
-        cocos_pak_xcode(${APP_NAME} INFO_PLIST "iOSBundleInfo.plist.in")
+        cocos_pak_xcode(${APP_NAME} INFO_PLIST "iOSBundleInfo.plist.in" ALLOWARBITRARYLOADS "true")
         set_xcode_property(${APP_NAME} ASSETCATALOG_COMPILER_APPICON_NAME "AppIcon-${APP_NAME}")
         set_xcode_property(${APP_NAME} DEVELOPMENT_TEAM "")
         set_xcode_property(${APP_NAME} CODE_SIGN_IDENTITY "iPhone Developer")


### PR DESCRIPTION
[`NSAllowsArbitraryLoads`](https://developer.apple.com/documentation/bundleresources/information_property_list/nsapptransportsecurity/nsallowsarbitraryloads) is set to `false` by default. 

Set NSAllowsArbitraryLoads to `true` in projects cpp-test/lua-tests/lua-empty-tests/cpp-empty-tests