### PR TITLE
fix ui::EditBox typing bug on retina display on mac

### DIFF
--- a/cocos/platform/desktop/CCGLViewImpl-desktop.cpp
+++ b/cocos/platform/desktop/CCGLViewImpl-desktop.cpp
@@ -441,14 +441,6 @@ void GLViewImpl::enableRetina(bool enabled)
 {
 #if (CC_TARGET_PLATFORM == CC_PLATFORM_MAC)
     _isRetinaEnabled = enabled;
-    if (_isRetinaEnabled)
-    {
-        _retinaFactor = 1;
-    }
-    else
-    {
-        _retinaFactor = 2;
-    }
     updateFrameSize();
 #endif
 }
@@ -666,10 +658,9 @@ void GLViewImpl::updateFrameSize()
         }
         else
         {
-            if (_isInRetinaMonitor)
-            {
-                _retinaFactor = 1;
-            }
+            _retinaFactor = 1;
+            _isRetinaEnabled = false;
+
             glfwSetWindowSize(_mainWindow, _screenSize.width * _retinaFactor * _frameZoomFactor, _screenSize.height *_retinaFactor * _frameZoomFactor);
 
             _isInRetinaMonitor = false;

--- a/cocos/ui/UIEditBox/UIEditBoxImpl-mac.h
+++ b/cocos/ui/UIEditBox/UIEditBoxImpl-mac.h
@@ -77,7 +77,6 @@ public:
 private:
     NSFont*    constructFont(const char* fontName, int fontSize);
     
-    bool              _inRetinaMode;
     UIEditBoxImplMac* _sysEdit;
 };
 

--- a/cocos/ui/UIEditBox/UIEditBoxImpl-mac.mm
+++ b/cocos/ui/UIEditBox/UIEditBoxImpl-mac.mm
@@ -32,6 +32,7 @@
 #include "base/ccUTF8.h"
 #include "ui/UIEditBox/UIEditBox.h"
 #include "ui/UIEditBox/Mac/CCUIEditBoxMac.h"
+#include "platform/desktop/CCGLViewImpl-desktop.h"
 
 NS_CC_BEGIN
 
@@ -46,9 +47,6 @@ EditBoxImplMac::EditBoxImplMac(EditBox* pEditText)
 : EditBoxImplCommon(pEditText)
 , _sysEdit(nullptr)
 {
-    //! TODO: Retina on Mac
-    //! _inRetinaMode = [[CCEAGLView sharedEGLView] contentScaleFactor] == 2.0f ? true : false;
-    _inRetinaMode = false;
 }
 
 EditBoxImplMac::~EditBoxImplMac()
@@ -77,8 +75,8 @@ NSFont* EditBoxImplMac::constructFont(const char *fontName, int fontSize)
 {
     NSString * fntName = [NSString stringWithUTF8String:fontName];
     fntName = [[fntName lastPathComponent] stringByDeletingPathExtension];
-    float retinaFactor = _inRetinaMode ? 2.0f : 1.0f;
     auto glview = cocos2d::Director::getInstance()->getOpenGLView();
+    float retinaFactor = ((GLViewImpl*)glview)->isRetinaEnabled() ? 2.0f : 1.0f;
     float scaleFactor = glview->getScaleX();
     
     if (fontSize == -1)
@@ -196,13 +194,14 @@ void EditBoxImplMac::setNativeVisible(bool visible)
 void EditBoxImplMac::updateNativeFrame(const cocos2d::Rect &rect)
 {
     GLView* eglView = Director::getInstance()->getOpenGLView();
+    float factor = ((GLViewImpl*)eglView)->isRetinaEnabled() ? 2.0f : 1.0f;
     auto viewPortRect = eglView->getViewPortRect();
     // Coordinate System on OSX has its origin at the lower left corner.
 //    https://developer.apple.com/library/ios/documentation/General/Conceptual/Devpedia-CocoaApp/CoordinateSystem.html
     auto screenPosY = viewPortRect.size.height - rect.origin.y - rect.size.height;
-    [_sysEdit updateFrame:CGRectMake(rect.origin.x,
-                                     screenPosY,
-                                     rect.size.width, rect.size.height)];
+    [_sysEdit updateFrame:CGRectMake(rect.origin.x / factor,
+                                     screenPosY / factor,
+                                     rect.size.width / factor, rect.size.height / factor)];
 }
     
 const char* EditBoxImplMac::getNativeDefaultFontName()


### PR DESCRIPTION
The associated NSTextField/NSTextView is mispositioned when the user clicks EditBox to edit on retina display with retina mode enabled (i.e. set by GLViewImpl#enableRetina) on mac.

The fix has been tested for both retina display and non-retina display on mac. For retina display both retina mode and non-retina mode work.