### PR TITLE
refactor CCGeometry

### DIFF
--- a/cocos/math/CCGeometry.cpp
+++ b/cocos/math/CCGeometry.cpp
@@ -35,7 +35,7 @@ NS_CC_BEGIN
 
 // implementation of Size
 
-Size::Size() : width(0), height(0)
+Size::Size() : Size(0.0f, 0.0f)
 {
 }
 
@@ -43,18 +43,8 @@ Size::Size(float w, float h) : width(w), height(h)
 {
 }
 
-Size::Size(const Size& other) : width(other.width), height(other.height)
-{
-}
-
 Size::Size(const Vec2& point) : width(point.x), height(point.y)
 {
-}
-
-Size& Size::operator= (const Size& other)
-{
-    setSize(other.width, other.height);
-    return *this;
 }
 
 Size& Size::operator= (const Vec2& point)
@@ -101,28 +91,18 @@ const Size Size::ZERO = Size(0, 0);
 // implementation of Rect
 
 Rect::Rect()
+: Rect(0.0f, 0.0f, 0.0f, 0.0f)
 {
-    setRect(0.0f, 0.0f, 0.0f, 0.0f);
 }
 
 Rect::Rect(float x, float y, float width, float height)
+: origin(x, y), size(width, height)
 {
-    setRect(x, y, width, height);
 }
+
 Rect::Rect(const Vec2& pos, const Size& dimension)
+: origin(pos), size(dimension)
 {
-    setRect(pos.x, pos.y, dimension.width, dimension.height);
-}
-
-Rect::Rect(const Rect& other)
-{
-    setRect(other.origin.x, other.origin.y, other.size.width, other.size.height);
-}
-
-Rect& Rect::operator= (const Rect& other)
-{
-    setRect(other.origin.x, other.origin.y, other.size.width, other.size.height);
-    return *this;
 }
 
 void Rect::setRect(float x, float y, float width, float height)

--- a/cocos/math/CCGeometry.h
+++ b/cocos/math/CCGeometry.h
@@ -46,7 +46,7 @@ public:
     /**Height of the Size.*/
     float height;
 public:
-    /**Conversion from Vec2 to Size.*/
+    /**Conversion from Size to Vec2.*/
     operator Vec2() const
     {
         return Vec2(width, height);
@@ -63,15 +63,9 @@ public:
      */
     Size();
     Size(float width, float height);
-    Size(const Size& other);
     explicit Size(const Vec2& point);
     /**@}*/
 
-    /**
-     * @js NA
-     * @lua NA
-     */
-    Size& operator= (const Size& other);
     /**
      * @js NA
      * @lua NA
@@ -119,7 +113,7 @@ public:
     /**Low left point of rect.*/
     Vec2 origin;
     /**Width and height of the rect.*/
-    Size  size;
+    Size size;
 
 public:
     /**
@@ -137,17 +131,6 @@ public:
      * @js NA
      */
     Rect(const Vec2& pos, const Size& dimension);
-    /**
-    Copy constructor.
-     * @js NA
-     * @lua NA
-     */
-    Rect(const Rect& other);
-    /**
-     * @js NA
-     * @lua NA
-     */
-    Rect& operator= (const Rect& other);
     /**
     Set the x, y, width and height of Rect.
      * @js NA


### PR DESCRIPTION
* remove redundant copy constructor and copy assignment operator
* use delegate constructor to simply code
* fix a documentation error

*redundant copy constructor and copy assignment operator* makes the class non trivially copyable. 