### PR TITLE
fix memory leak in CCUserDefault

### DIFF
--- a/cocos/base/CCUserDefault.cpp
+++ b/cocos/base/CCUserDefault.cpp
@@ -321,7 +321,7 @@ Data UserDefault::getDataForKey(const char* pKey, const Data& defaultValue)
         encodedData = (const char*)(node->FirstChild()->Value());
     }
     
-    Data ret = defaultValue;
+    Data ret;
     
     if (encodedData)
     {
@@ -331,6 +331,10 @@ Data UserDefault::getDataForKey(const char* pKey, const Data& defaultValue)
         if (decodedData) {
             ret.fastSet(decodedData, decodedDataLen);
         }
+    }
+    else
+    {
+        ret = defaultValue;
     }
     
     delete doc;


### PR DESCRIPTION
fastSet makes the Data object managing a new memory area in
[bytes, bytes + size), but it doesn't releasing the old data
it managed. Failure to release the old data causes memory leak.

The default constructed Data manages null memory, so calling
fastSet on it is fine.

Because `Data ret = defaultValue;` malloc new memory, we might
have better performance without it.

This fix issue: #19852