### PR TITLE
clang-tidy: performance-unnecessary-value-param

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -10,6 +10,7 @@ Checks: >
   performance-move-constructor-init,
   performance-type-promotion-in-math-fn,
   performance-unnecessary-copy-initialization,
+  -performance-unnecessary-value-param,
   readability-container-size-empty,
   readability-delete-null-pointer,
   readability-redundant-control-flow,

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -10,7 +10,7 @@ Checks: >
   performance-move-constructor-init,
   performance-type-promotion-in-math-fn,
   performance-unnecessary-copy-initialization,
-  -performance-unnecessary-value-param,
+  performance-unnecessary-value-param,
   readability-container-size-empty,
   readability-delete-null-pointer,
   readability-redundant-control-flow,

--- a/cocos/2d/CCActionInterval.cpp
+++ b/cocos/2d/CCActionInterval.cpp
@@ -2802,10 +2802,10 @@ void TargetedAction::setForcedTarget(Node* forcedTarget)
 
 // ActionFloat
 
-ActionFloat* ActionFloat::create(float duration, float from, float to, ActionFloatCallback callback)
+ActionFloat* ActionFloat::create(float duration, float from, float to, const ActionFloatCallback& callback)
 {
     auto ref = new (std::nothrow) ActionFloat();
-    if (ref && ref->initWithDuration(duration, from, to, std::move(callback)))
+    if (ref && ref->initWithDuration(duration, from, to, callback))
     {
         ref->autorelease();
         return ref;
@@ -2815,13 +2815,13 @@ ActionFloat* ActionFloat::create(float duration, float from, float to, ActionFlo
     return nullptr;
 }
 
-bool ActionFloat::initWithDuration(float duration, float from, float to, ActionFloatCallback callback)
+bool ActionFloat::initWithDuration(float duration, float from, float to, const ActionFloatCallback& callback)
 {
     if (ActionInterval::initWithDuration(duration))
     {
         _from = from;
         _to = to;
-        _callback = std::move(callback);
+        _callback = callback;
         return true;
     }
     return false;

--- a/cocos/2d/CCActionInterval.cpp
+++ b/cocos/2d/CCActionInterval.cpp
@@ -30,6 +30,8 @@ THE SOFTWARE.
 
 #include <stdarg.h>
 
+#include <utility>
+
 #include "2d/CCSprite.h"
 #include "2d/CCNode.h"
 #include "2d/CCSpriteFrame.h"
@@ -2803,7 +2805,7 @@ void TargetedAction::setForcedTarget(Node* forcedTarget)
 ActionFloat* ActionFloat::create(float duration, float from, float to, ActionFloatCallback callback)
 {
     auto ref = new (std::nothrow) ActionFloat();
-    if (ref && ref->initWithDuration(duration, from, to, callback))
+    if (ref && ref->initWithDuration(duration, from, to, std::move(callback)))
     {
         ref->autorelease();
         return ref;
@@ -2819,7 +2821,7 @@ bool ActionFloat::initWithDuration(float duration, float from, float to, ActionF
     {
         _from = from;
         _to = to;
-        _callback = callback;
+        _callback = std::move(callback);
         return true;
     }
     return false;

--- a/cocos/2d/CCActionInterval.h
+++ b/cocos/2d/CCActionInterval.h
@@ -1650,7 +1650,7 @@ public:
      *
      * @return An autoreleased ActionFloat object
      */
-    static ActionFloat* create(float duration, float from, float to, ActionFloatCallback callback);
+    static ActionFloat* create(float duration, float from, float to, const ActionFloatCallback& callback);
 
     /**
      * Overridden ActionInterval methods
@@ -1664,7 +1664,7 @@ CC_CONSTRUCTOR_ACCESS:
     ActionFloat() {};
     virtual ~ActionFloat() {};
 
-    bool initWithDuration(float duration, float from, float to, ActionFloatCallback callback);
+    bool initWithDuration(float duration, float from, float to, const ActionFloatCallback& callback);
 
 protected:
     /* From value */

--- a/cocos/2d/CCNode.cpp
+++ b/cocos/2d/CCNode.cpp
@@ -818,7 +818,7 @@ Node* Node::getChildByName(const std::string& name) const
     return nullptr;
 }
 
-void Node::enumerateChildren(const std::string &name, std::function<bool (Node *)> callback) const
+void Node::enumerateChildren(const std::string &name, const std::function<bool (Node *)>& callback) const
 {
     CCASSERT(!name.empty(), "Invalid name");
     CCASSERT(callback != nullptr, "Invalid callback function");
@@ -869,7 +869,7 @@ void Node::enumerateChildren(const std::string &name, std::function<bool (Node *
     }
 }
 
-bool Node::doEnumerateRecursive(const Node* node, const std::string &name, std::function<bool (Node *)> callback) const
+bool Node::doEnumerateRecursive(const Node* node, const std::string &name, const std::function<bool (Node *)>& callback) const
 {
     bool ret =false;
     
@@ -894,7 +894,7 @@ bool Node::doEnumerateRecursive(const Node* node, const std::string &name, std::
     return ret;
 }
 
-bool Node::doEnumerate(std::string name, std::function<bool (Node *)> callback) const
+bool Node::doEnumerate(std::string name, const std::function<bool (Node *)>& callback) const
 {
     // name may be xxx/yyy, should find its parent
     size_t pos = name.find('/');

--- a/cocos/2d/CCNode.h
+++ b/cocos/2d/CCNode.h
@@ -834,7 +834,7 @@ public:
      *
      * @since v3.2
      */
-    virtual void enumerateChildren(const std::string &name, std::function<bool(Node* node)> callback) const;
+    virtual void enumerateChildren(const std::string &name, const std::function<bool(Node* node)>& callback) const;
     /**
      * Returns the array of the node's children.
      *
@@ -1886,8 +1886,8 @@ protected:
     virtual void disableCascadeColor();
     virtual void updateColor() {}
     
-    bool doEnumerate(std::string name, std::function<bool (Node *)> callback) const;
-    bool doEnumerateRecursive(const Node* node, const std::string &name, std::function<bool (Node *)> callback) const;
+    bool doEnumerate(std::string name, const std::function<bool (Node *)>& callback) const;
+    bool doEnumerateRecursive(const Node* node, const std::string &name, const std::function<bool (Node *)>& callback) const;
     
     //check whether this camera mask is visible by the current visiting camera
     bool isVisitableByVisitingCamera() const;

--- a/cocos/2d/CCRenderTexture.cpp
+++ b/cocos/2d/CCRenderTexture.cpp
@@ -27,6 +27,8 @@ THE SOFTWARE.
 
 #include "2d/CCRenderTexture.h"
 
+#include <utility>
+
 #include "base/ccUtils.h"
 #include "platform/CCFileUtils.h"
 #include "base/CCEventType.h"
@@ -506,7 +508,7 @@ void RenderTexture::visit(Renderer *renderer, const Mat4 &parentTransform, uint3
     // setOrderOfArrival(0);
 }
 
-bool RenderTexture::saveToFileAsNonPMA(const std::string& filename, bool isRGBA, std::function<void(RenderTexture*, const std::string&)> callback)
+bool RenderTexture::saveToFileAsNonPMA(const std::string& filename, bool isRGBA, const std::function<void(RenderTexture*, const std::string&)>& callback)
 {
     std::string basename(filename);
     std::transform(basename.begin(), basename.end(), basename.begin(), ::tolower);
@@ -528,7 +530,7 @@ bool RenderTexture::saveToFileAsNonPMA(const std::string& filename, bool isRGBA,
     return saveToFileAsNonPMA(filename, Image::Format::JPG, false, callback);
 }
 
-bool RenderTexture::saveToFile(const std::string& filename, bool isRGBA, std::function<void (RenderTexture*, const std::string&)> callback)
+bool RenderTexture::saveToFile(const std::string& filename, bool isRGBA, const std::function<void (RenderTexture*, const std::string&)>& callback)
 {
     std::string basename(filename);
     std::transform(basename.begin(), basename.end(), basename.begin(), ::tolower);
@@ -556,7 +558,7 @@ bool RenderTexture::saveToFileAsNonPMA(const std::string& fileName, Image::Forma
         "the image can only be saved as JPG or PNG format");
     if (isRGBA && format == Image::Format::JPG) CCLOG("RGBA is not supported for JPG format");
 
-    _saveFileCallback = callback;
+    _saveFileCallback = std::move(callback);
 
     std::string fullpath = FileUtils::getInstance()->getWritablePath() + fileName;
     _saveToFileCommand.init(_globalZOrder);
@@ -572,7 +574,7 @@ bool RenderTexture::saveToFile(const std::string& fileName, Image::Format format
              "the image can only be saved as JPG or PNG format");
     if (isRGBA && format == Image::Format::JPG) CCLOG("RGBA is not supported for JPG format");
     
-    _saveFileCallback = callback;
+    _saveFileCallback = std::move(callback);
     
     std::string fullpath = FileUtils::getInstance()->getWritablePath() + fileName;
     _saveToFileCommand.init(_globalZOrder);

--- a/cocos/2d/CCRenderTexture.cpp
+++ b/cocos/2d/CCRenderTexture.cpp
@@ -552,13 +552,13 @@ bool RenderTexture::saveToFile(const std::string& filename, bool isRGBA, const s
     return saveToFile(filename, Image::Format::JPG, false, callback);
 }
 
-bool RenderTexture::saveToFileAsNonPMA(const std::string& fileName, Image::Format format, bool isRGBA, std::function<void(RenderTexture*, const std::string&)> callback)
+bool RenderTexture::saveToFileAsNonPMA(const std::string& fileName, Image::Format format, bool isRGBA, const std::function<void(RenderTexture*, const std::string&)>& callback)
 {
     CCASSERT(format == Image::Format::JPG || format == Image::Format::PNG,
         "the image can only be saved as JPG or PNG format");
     if (isRGBA && format == Image::Format::JPG) CCLOG("RGBA is not supported for JPG format");
 
-    _saveFileCallback = std::move(callback);
+    _saveFileCallback = callback;
 
     std::string fullpath = FileUtils::getInstance()->getWritablePath() + fileName;
     _saveToFileCommand.init(_globalZOrder);
@@ -568,13 +568,13 @@ bool RenderTexture::saveToFileAsNonPMA(const std::string& fileName, Image::Forma
     return true;
 }
 
-bool RenderTexture::saveToFile(const std::string& fileName, Image::Format format, bool isRGBA, std::function<void (RenderTexture*, const std::string&)> callback)
+bool RenderTexture::saveToFile(const std::string& fileName, Image::Format format, bool isRGBA, const std::function<void (RenderTexture*, const std::string&)>& callback)
 {
     CCASSERT(format == Image::Format::JPG || format == Image::Format::PNG,
              "the image can only be saved as JPG or PNG format");
     if (isRGBA && format == Image::Format::JPG) CCLOG("RGBA is not supported for JPG format");
     
-    _saveFileCallback = std::move(callback);
+    _saveFileCallback = callback;
     
     std::string fullpath = FileUtils::getInstance()->getWritablePath() + fileName;
     _saveToFileCommand.init(_globalZOrder);

--- a/cocos/2d/CCRenderTexture.h
+++ b/cocos/2d/CCRenderTexture.h
@@ -159,7 +159,7 @@ public:
      * @param callback When the file is save finished,it will callback this function.
      * @return Returns true if the operation is successful.
      */
-    bool saveToFileAsNonPMA(const std::string& filename, bool isRGBA = true, std::function<void(RenderTexture*, const std::string&)> callback = nullptr);
+    bool saveToFileAsNonPMA(const std::string& filename, bool isRGBA = true, const std::function<void(RenderTexture*, const std::string&)>& callback = nullptr);
 
 
     /** Saves the texture into a file using JPEG format. The file will be saved in the Documents folder.
@@ -170,7 +170,7 @@ public:
      * @param callback When the file is save finished,it will callback this function.
      * @return Returns true if the operation is successful.
      */
-    bool saveToFile(const std::string& filename, bool isRGBA = true, std::function<void (RenderTexture*, const std::string&)> callback = nullptr);
+    bool saveToFile(const std::string& filename, bool isRGBA = true, const std::function<void (RenderTexture*, const std::string&)>& callback = nullptr);
 
     /** saves the texture into a file in non-PMA. The format could be JPG or PNG. The file will be saved in the Documents folder.
         Returns true if the operation is successful.

--- a/cocos/2d/CCRenderTexture.h
+++ b/cocos/2d/CCRenderTexture.h
@@ -184,7 +184,7 @@ public:
      * @param callback When the file is save finished,it will callback this function.
      * @return Returns true if the operation is successful.
      */
-    bool saveToFileAsNonPMA(const std::string& fileName, Image::Format format, bool isRGBA, std::function<void(RenderTexture*, const std::string&)> callback);
+    bool saveToFileAsNonPMA(const std::string& fileName, Image::Format format, bool isRGBA, const std::function<void(RenderTexture*, const std::string&)>& callback);
 
     /** saves the texture into a file. The format could be JPG or PNG. The file will be saved in the Documents folder.
         Returns true if the operation is successful.
@@ -198,7 +198,7 @@ public:
      * @param callback When the file is save finished,it will callback this function.
      * @return Returns true if the operation is successful.
      */
-    bool saveToFile(const std::string& filename, Image::Format format, bool isRGBA = true, std::function<void (RenderTexture*, const std::string&)> callback = nullptr);
+    bool saveToFile(const std::string& filename, Image::Format format, bool isRGBA = true, const std::function<void (RenderTexture*, const std::string&)>& callback = nullptr);
     
     /** Listen "come to background" message, and save render texture.
      * It only has effect on Android.

--- a/cocos/2d/CCTMXXMLParser.cpp
+++ b/cocos/2d/CCTMXXMLParser.cpp
@@ -28,13 +28,14 @@ THE SOFTWARE.
 ****************************************************************************/
 
 #include "2d/CCTMXXMLParser.h"
-#include <unordered_map>
-#include <sstream>
 #include "2d/CCTMXTiledMap.h"
+#include "base/CCDirector.h"
 #include "base/ZipUtils.h"
 #include "base/base64.h"
-#include "base/CCDirector.h"
 #include "platform/CCFileUtils.h"
+#include <sstream>
+#include <unordered_map>
+#include <utility>
 
 using namespace std;
 
@@ -65,7 +66,7 @@ ValueMap& TMXLayerInfo::getProperties()
 
 void TMXLayerInfo::setProperties(ValueMap var)
 {
-    _properties = var;
+    _properties = std::move(var);
 }
 
 // implementation TMXTilesetInfo

--- a/cocos/2d/CCTMXXMLParser.cpp
+++ b/cocos/2d/CCTMXXMLParser.cpp
@@ -64,9 +64,9 @@ ValueMap& TMXLayerInfo::getProperties()
     return _properties;
 }
 
-void TMXLayerInfo::setProperties(ValueMap var)
+void TMXLayerInfo::setProperties(const ValueMap& var)
 {
-    _properties = std::move(var);
+    _properties = var;
 }
 
 // implementation TMXTilesetInfo

--- a/cocos/2d/CCTMXXMLParser.h
+++ b/cocos/2d/CCTMXXMLParser.h
@@ -106,7 +106,7 @@ public:
      */
     virtual ~TMXLayerInfo();
 
-    void setProperties(ValueMap properties);
+    void setProperties(const ValueMap& properties);
     ValueMap& getProperties();
 
     ValueMap            _properties;

--- a/cocos/3d/CCTerrain.cpp
+++ b/cocos/3d/CCTerrain.cpp
@@ -700,7 +700,7 @@ void Terrain::setAlphaMap(cocos2d::Texture2D * newAlphaMapTexture)
     _alphaMap = newAlphaMapTexture;
 }
 
-void Terrain::setDetailMap(unsigned int index, DetailMap detailMap)
+void Terrain::setDetailMap(unsigned int index, const DetailMap& detailMap)
 {
     if(index>4)
     {

--- a/cocos/3d/CCTerrain.h
+++ b/cocos/3d/CCTerrain.h
@@ -369,7 +369,7 @@ public:
     /** set the alpha map*/
     void setAlphaMap(cocos2d::Texture2D * newAlphaMapTexture);
     /**set the Detail Map */
-    void setDetailMap(unsigned int index, DetailMap detailMap);
+    void setDetailMap(unsigned int index, const DetailMap& detailMap);
 
     // Overrides, internal use only
     virtual void draw(cocos2d::Renderer* renderer, const cocos2d::Mat4 &transform, uint32_t flags) override;

--- a/cocos/audio/AudioEngine.cpp
+++ b/cocos/audio/AudioEngine.cpp
@@ -530,7 +530,7 @@ AudioProfile* AudioEngine::getProfile(const std::string &name)
     }
 }
 
-void AudioEngine::preload(const std::string& filePath, std::function<void(bool isSuccess)> callback)
+void AudioEngine::preload(const std::string& filePath, const std::function<void(bool isSuccess)>& callback)
 {
     if (!isEnabled())
     {

--- a/cocos/audio/include/AudioEngine.h
+++ b/cocos/audio/include/AudioEngine.h
@@ -291,7 +291,7 @@ public:
      * @param filePath The file path of an audio.
      * @param callback A callback which will be called after loading is finished.
      */
-    static void preload(const std::string& filePath, std::function<void(bool isSuccess)> callback);
+    static void preload(const std::string& filePath, const std::function<void(bool isSuccess)>& callback);
 
     /**
      * Gets playing audio count.

--- a/cocos/audio/linux/AudioEngine-linux.cpp
+++ b/cocos/audio/linux/AudioEngine-linux.cpp
@@ -301,7 +301,7 @@ void AudioEngineImpl::uncacheAll()
     mapId.clear();
 }
 
-int AudioEngineImpl::preload(const std::string& filePath, std::function<void(bool isSuccess)> callback)
+int AudioEngineImpl::preload(const std::string& filePath, const std::function<void(bool isSuccess)>& callback)
 {
     FMOD::Sound * sound = findSound(filePath);
     if (!sound) {

--- a/cocos/audio/linux/AudioEngine-linux.h
+++ b/cocos/audio/linux/AudioEngine-linux.h
@@ -65,7 +65,7 @@ public:
     void uncacheAll();
     
 
-    int preload(const std::string& filePath, std::function<void(bool isSuccess)> callback);
+    int preload(const std::string& filePath, const std::function<void(bool isSuccess)>& callback);
     
     void update(float dt);
     

--- a/cocos/base/ObjectFactory.cpp
+++ b/cocos/base/ObjectFactory.cpp
@@ -23,8 +23,9 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 ****************************************************************************/
 
-#include <functional>
 #include "base/ObjectFactory.h"
+#include <functional>
+#include <utility>
 
 
 NS_CC_BEGIN
@@ -47,7 +48,7 @@ ObjectFactory::TInfo::TInfo(const std::string& type, Instance ins)
 ObjectFactory::TInfo::TInfo(const std::string& type, InstanceFunc ins)
     :_class(type)
     ,_fun(nullptr)
-    ,_func(ins)
+    ,_func(std::move(ins))
 {
     ObjectFactory::getInstance()->registerType(*this);
 }

--- a/cocos/base/ObjectFactory.cpp
+++ b/cocos/base/ObjectFactory.cpp
@@ -45,10 +45,10 @@ ObjectFactory::TInfo::TInfo(const std::string& type, Instance ins)
     ObjectFactory::getInstance()->registerType(*this);
 }
 
-ObjectFactory::TInfo::TInfo(const std::string& type, InstanceFunc ins)
+ObjectFactory::TInfo::TInfo(const std::string& type, const InstanceFunc& ins)
     :_class(type)
     ,_fun(nullptr)
-    ,_func(std::move(ins))
+    ,_func(ins)
 {
     ObjectFactory::getInstance()->registerType(*this);
 }

--- a/cocos/base/ObjectFactory.h
+++ b/cocos/base/ObjectFactory.h
@@ -43,7 +43,7 @@ public:
     {
         TInfo();
         TInfo(const std::string& type, Instance ins = nullptr);
-        TInfo(const std::string& type, InstanceFunc ins = nullptr);
+        TInfo(const std::string& type, const InstanceFunc& ins = nullptr);
         TInfo(const TInfo &t);
         ~TInfo();
         TInfo& operator= (const TInfo &t);

--- a/cocos/editor-support/cocosbuilder/CCBAnimationManager.cpp
+++ b/cocos/editor-support/cocosbuilder/CCBAnimationManager.cpp
@@ -140,7 +140,7 @@ void CCBAnimationManager::addDocumentCallbackNode(Node *node)
     _documentCallbackNodes.pushBack(node);
 }
 
-void CCBAnimationManager::addDocumentCallbackName(std::string name)
+void CCBAnimationManager::addDocumentCallbackName(const std::string& name)
 {
     _documentCallbackNames.push_back(Value(name));
 }
@@ -170,7 +170,7 @@ void CCBAnimationManager::addDocumentOutletNode(Node *node)
     _documentOutletNodes.pushBack(node);
 }
 
-void CCBAnimationManager::addDocumentOutletName(std::string name)
+void CCBAnimationManager::addDocumentOutletName(const std::string& name)
 {
     _documentOutletNames.push_back(Value(name));
 }

--- a/cocos/editor-support/cocosbuilder/CCBAnimationManager.h
+++ b/cocos/editor-support/cocosbuilder/CCBAnimationManager.h
@@ -76,11 +76,11 @@ public:
     
 
     void addDocumentCallbackNode(cocos2d::Node *node);
-    void addDocumentCallbackName(std::string name);
+    void addDocumentCallbackName(const std::string& name);
     void addDocumentCallbackControlEvents(cocos2d::extension::Control::EventType eventType);
     
     void addDocumentOutletNode(cocos2d::Node *node);
-    void addDocumentOutletName(std::string name);
+    void addDocumentOutletName(const std::string& name);
 
     void setDocumentControllerName(const std::string &name);
     

--- a/cocos/editor-support/cocosbuilder/CCBReader.cpp
+++ b/cocos/editor-support/cocosbuilder/CCBReader.cpp
@@ -192,9 +192,9 @@ CCBReader::CCBAnimationManagerMapPtr CCBReader::getAnimationManagers()
     return _animationManagers;
 }
 
-void CCBReader::setAnimationManagers(CCBAnimationManagerMapPtr x)
+void CCBReader::setAnimationManagers(const CCBAnimationManagerMapPtr& x)
 {
-    _animationManagers = std::move(x);
+    _animationManagers = x;
 }
 
 CCBMemberVariableAssigner * CCBReader::getCCBMemberVariableAssigner() {
@@ -321,7 +321,7 @@ void CCBReader::cleanUpNodeGraph(Node *node)
     }
 }
 
-Node* CCBReader::readFileWithCleanUp(bool bCleanUp, CCBAnimationManagerMapPtr am)
+Node* CCBReader::readFileWithCleanUp(bool bCleanUp, const CCBAnimationManagerMapPtr& am)
 {
     if (! readHeader())
     {
@@ -338,7 +338,7 @@ Node* CCBReader::readFileWithCleanUp(bool bCleanUp, CCBAnimationManagerMapPtr am
         return nullptr;
     }
     
-    setAnimationManagers(std::move(am));
+    setAnimationManagers(am);
 
     Node *pNode = readNodeGraph(nullptr);
 

--- a/cocos/editor-support/cocosbuilder/CCBReader.cpp
+++ b/cocos/editor-support/cocosbuilder/CCBReader.cpp
@@ -31,16 +31,17 @@
 #include "2d/CCSpriteFrameCache.h"
 #include "renderer/CCTextureCache.h"
 
+#include "editor-support/cocosbuilder/CCBAnimationManager.h"
+#include "editor-support/cocosbuilder/CCBKeyframe.h"
+#include "editor-support/cocosbuilder/CCBMemberVariableAssigner.h"
 #include "editor-support/cocosbuilder/CCBReader.h"
+#include "editor-support/cocosbuilder/CCBSelectorResolver.h"
+#include "editor-support/cocosbuilder/CCBSequenceProperty.h"
 #include "editor-support/cocosbuilder/CCNodeLoader.h"
 #include "editor-support/cocosbuilder/CCNodeLoaderLibrary.h"
 #include "editor-support/cocosbuilder/CCNodeLoaderListener.h"
-#include "editor-support/cocosbuilder/CCBMemberVariableAssigner.h"
-#include "editor-support/cocosbuilder/CCBSelectorResolver.h"
-#include "editor-support/cocosbuilder/CCBAnimationManager.h"
-#include "editor-support/cocosbuilder/CCBSequenceProperty.h"
-#include "editor-support/cocosbuilder/CCBKeyframe.h"
 #include <sstream>
+#include <utility>
 
 using namespace cocos2d;
 using namespace cocos2d::extension;
@@ -193,7 +194,7 @@ CCBReader::CCBAnimationManagerMapPtr CCBReader::getAnimationManagers()
 
 void CCBReader::setAnimationManagers(CCBAnimationManagerMapPtr x)
 {
-    _animationManagers = x;
+    _animationManagers = std::move(x);
 }
 
 CCBMemberVariableAssigner * CCBReader::getCCBMemberVariableAssigner() {
@@ -255,7 +256,7 @@ Node* CCBReader::readNodeGraphFromFile(const char *pCCBFileName, Ref *pOwner, co
 
 Node* CCBReader::readNodeGraphFromData(std::shared_ptr<cocos2d::Data> data, Ref *pOwner, const Size &parentSize)
 {
-    _data = data;
+    _data = std::move(data);
     _bytes =_data->getBytes();
     _currentByte = 0;
     _currentBit = 0;
@@ -337,7 +338,7 @@ Node* CCBReader::readFileWithCleanUp(bool bCleanUp, CCBAnimationManagerMapPtr am
         return nullptr;
     }
     
-    setAnimationManagers(am);
+    setAnimationManagers(std::move(am));
 
     Node *pNode = readNodeGraph(nullptr);
 

--- a/cocos/editor-support/cocosbuilder/CCBReader.cpp
+++ b/cocos/editor-support/cocosbuilder/CCBReader.cpp
@@ -1069,7 +1069,7 @@ Vector<CCBAnimationManager*>& CCBReader::getAnimationManagersForNodes()
     return _animationManagersForNodes;
 }
 
-void CCBReader::addOwnerOutletName(std::string name)
+void CCBReader::addOwnerOutletName(const std::string& name)
 {
     _ownerOutletNames.push_back(name);
 }

--- a/cocos/editor-support/cocosbuilder/CCBReader.h
+++ b/cocos/editor-support/cocosbuilder/CCBReader.h
@@ -337,7 +337,7 @@ public:
      * @js NA
      * @lua NA
      */
-    void setAnimationManagers(CCBAnimationManagerMapPtr x);
+    void setAnimationManagers(const CCBAnimationManagerMapPtr& x);
     /**
      * @js NA
      * @lua NA
@@ -370,7 +370,7 @@ public:
      * @js NA
      * @lua NA
      */
-    cocos2d::Node* readFileWithCleanUp(bool bCleanUp, CCBAnimationManagerMapPtr am);
+    cocos2d::Node* readFileWithCleanUp(bool bCleanUp, const CCBAnimationManagerMapPtr& am);
     
     void addOwnerOutletName(const std::string& name);
     void addOwnerOutletNode(cocos2d::Node *node);

--- a/cocos/editor-support/cocosbuilder/CCBReader.h
+++ b/cocos/editor-support/cocosbuilder/CCBReader.h
@@ -372,7 +372,7 @@ public:
      */
     cocos2d::Node* readFileWithCleanUp(bool bCleanUp, CCBAnimationManagerMapPtr am);
     
-    void addOwnerOutletName(std::string name);
+    void addOwnerOutletName(const std::string& name);
     void addOwnerOutletNode(cocos2d::Node *node);
 
 private:

--- a/cocos/editor-support/cocostudio/ActionTimeline/CCActionTimeline.cpp
+++ b/cocos/editor-support/cocostudio/ActionTimeline/CCActionTimeline.cpp
@@ -25,6 +25,8 @@ THE SOFTWARE.
 
 #include "editor-support/cocostudio/ActionTimeline/CCActionTimeline.h"
 
+#include <utility>
+
 #include "editor-support/cocostudio/CCComExtensionData.h"
 
 USING_NS_CC;
@@ -94,7 +96,7 @@ bool ActionTimeline::init()
     return true;
 }
 
-void ActionTimeline::play(std::string name, bool loop)
+void ActionTimeline::play(const std::string& name, bool loop)
 {
     if (_animationInfos.find(name) == _animationInfos.end())
     {
@@ -233,7 +235,7 @@ void ActionTimeline::step(float delta)
 }
 
 typedef std::function<void(Node*)> tCallBack;
-void foreachNodeDescendant(Node* parent, tCallBack callback)
+void foreachNodeDescendant(Node* parent, const tCallBack& callback)
 {
     callback(parent);
 
@@ -312,7 +314,7 @@ void ActionTimeline::addAnimationInfo(const AnimationInfo& animationInfo)
     addFrameEndCallFunc(animationInfo.endIndex, animationInfo.name, animationInfo.clipEndCallBack);
 }
 
-void ActionTimeline::removeAnimationInfo(std::string animationName)
+void ActionTimeline::removeAnimationInfo(const std::string& animationName)
 {
     auto clipIter = _animationInfos.find(animationName);
     if (clipIter == _animationInfos.end())
@@ -335,7 +337,7 @@ const AnimationInfo& ActionTimeline::getAnimationInfo(const std::string &animati
     return _animationInfos.find(animationName)->second;
 }
 
-void ActionTimeline::setAnimationEndCallFunc(const std::string animationName, std::function<void()> func)
+void ActionTimeline::setAnimationEndCallFunc(const std::string& animationName, const std::function<void()>& func)
 {
     auto clipIter = _animationInfos.find(animationName);
     if (clipIter == _animationInfos.end())
@@ -349,7 +351,7 @@ void ActionTimeline::setAnimationEndCallFunc(const std::string animationName, st
 
 void ActionTimeline::setFrameEventCallFunc(std::function<void(Frame *)> listener)
 {
-    _frameEventListener = listener;
+    _frameEventListener = std::move(listener);
 }
 
 void ActionTimeline::clearFrameEventCallFunc()
@@ -359,7 +361,7 @@ void ActionTimeline::clearFrameEventCallFunc()
 
 void ActionTimeline::setLastFrameCallFunc(std::function<void()> listener)
 {
-    _lastFrameListener = listener;
+    _lastFrameListener = std::move(listener);
 }
 
 void ActionTimeline::clearLastFrameCallFunc()
@@ -375,7 +377,7 @@ void ActionTimeline::emitFrameEvent(Frame* frame)
     }
 }
 
-void ActionTimeline::addFrameEndCallFunc(int frameIndex, const std::string& funcKey, std::function<void()> func)
+void ActionTimeline::addFrameEndCallFunc(int frameIndex, const std::string& funcKey, const std::function<void()>& func)
 {
     if (func != nullptr)
     {

--- a/cocos/editor-support/cocostudio/ActionTimeline/CCActionTimeline.cpp
+++ b/cocos/editor-support/cocostudio/ActionTimeline/CCActionTimeline.cpp
@@ -349,9 +349,9 @@ void ActionTimeline::setAnimationEndCallFunc(const std::string& animationName, c
     addFrameEndCallFunc(clipIter->second.endIndex, animationName, func);
 }
 
-void ActionTimeline::setFrameEventCallFunc(std::function<void(Frame *)> listener)
+void ActionTimeline::setFrameEventCallFunc(const std::function<void(Frame *)>& listener)
 {
-    _frameEventListener = std::move(listener);
+    _frameEventListener = listener;
 }
 
 void ActionTimeline::clearFrameEventCallFunc()
@@ -359,9 +359,9 @@ void ActionTimeline::clearFrameEventCallFunc()
     _frameEventListener = nullptr;
 }
 
-void ActionTimeline::setLastFrameCallFunc(std::function<void()> listener)
+void ActionTimeline::setLastFrameCallFunc(const std::function<void()>& listener)
 {
-    _lastFrameListener = std::move(listener);
+    _lastFrameListener = listener;
 }
 
 void ActionTimeline::clearLastFrameCallFunc()

--- a/cocos/editor-support/cocostudio/ActionTimeline/CCActionTimeline.h
+++ b/cocos/editor-support/cocostudio/ActionTimeline/CCActionTimeline.h
@@ -82,7 +82,7 @@ public:
     ActionTimeline();
     virtual ~ActionTimeline();
 
-    virtual void play(std::string animationName, bool loop);
+    virtual void play(const std::string& animationName, bool loop);
 
     virtual bool init();
 
@@ -155,14 +155,14 @@ public:
     
     /** AnimationInfo*/
     virtual void addAnimationInfo(const AnimationInfo& animationInfo);
-    virtual void removeAnimationInfo(std::string animationName);
+    virtual void removeAnimationInfo(const std::string& animationName);
     virtual bool IsAnimationInfoExists(const std::string& animationName);
     virtual const AnimationInfo& getAnimationInfo(const std::string& animationName);
     /**add a frame end call back to animation's end frame
      * @param animationName  @addFrameEndCallFunc, make the animationName as funcKey
      * @param func the callback function
      */
-    virtual void setAnimationEndCallFunc(const std::string animationName, std::function<void()> func);
+    virtual void setAnimationEndCallFunc(const std::string& animationName, const std::function<void()>& func);
 
     /** Set ActionTimeline's frame event callback function */
     void setFrameEventCallFunc(std::function<void(Frame *)> listener);
@@ -177,7 +177,7 @@ public:
      * @param funcKey for identity the callback function
      * @param func the callback function
      */
-    virtual void addFrameEndCallFunc(int frameIndex, const std::string& funcKey, std::function<void()> func);
+    virtual void addFrameEndCallFunc(int frameIndex, const std::string& funcKey, const std::function<void()>& func);
     // remove callback function after frameIndex which identified with funcKey
     virtual void removeFrameEndCallFunc(int frameIndex, const std::string& funcKey);
     // clear callback functions after frameIndex

--- a/cocos/editor-support/cocostudio/ActionTimeline/CCActionTimeline.h
+++ b/cocos/editor-support/cocostudio/ActionTimeline/CCActionTimeline.h
@@ -165,11 +165,11 @@ public:
     virtual void setAnimationEndCallFunc(const std::string& animationName, const std::function<void()>& func);
 
     /** Set ActionTimeline's frame event callback function */
-    void setFrameEventCallFunc(std::function<void(Frame *)> listener);
+    void setFrameEventCallFunc(const std::function<void(Frame *)>& listener);
     void clearFrameEventCallFunc();
 
     /** Last frame callback will call when arriving last frame */
-    void setLastFrameCallFunc(std::function<void()> listener);
+    void setLastFrameCallFunc(const std::function<void()>& listener);
     void clearLastFrameCallFunc();
 
     /** add a callback function after played frameIndex

--- a/cocos/editor-support/cocostudio/ActionTimeline/CCActionTimelineCache.cpp
+++ b/cocos/editor-support/cocostudio/ActionTimeline/CCActionTimelineCache.cpp
@@ -423,7 +423,7 @@ ActionTimeline* ActionTimelineCache::createActionWithFlatBuffersFile(const std::
     return action->clone();
 }
 
-ActionTimeline* ActionTimelineCache::createActionWithDataBuffer(Data data, const std::string &fileName)
+ActionTimeline* ActionTimelineCache::createActionWithDataBuffer(const Data& data, const std::string &fileName)
 {
     ActionTimeline* action = _animationActions.at(fileName);
     if (action == NULL)

--- a/cocos/editor-support/cocostudio/ActionTimeline/CCActionTimelineCache.h
+++ b/cocos/editor-support/cocostudio/ActionTimeline/CCActionTimelineCache.h
@@ -85,7 +85,7 @@ public:
     ActionTimeline* loadAnimationActionWithContent(const std::string&fileName, const std::string& content);
     
     ActionTimeline* createActionWithFlatBuffersFile(const std::string& fileName);
-    ActionTimeline* createActionWithDataBuffer(cocos2d::Data data, const std::string &fileName);
+    ActionTimeline* createActionWithDataBuffer(const cocos2d::Data& data, const std::string &fileName);
 
     ActionTimeline* loadAnimationActionWithFlatBuffersFile(const std::string& fileName);
     ActionTimeline* loadAnimationWithDataBuffer(const cocos2d::Data& data, const std::string& fileName);

--- a/cocos/editor-support/cocostudio/ActionTimeline/CCSkeletonNode.cpp
+++ b/cocos/editor-support/cocostudio/ActionTimeline/CCSkeletonNode.cpp
@@ -317,7 +317,7 @@ const cocos2d::Map<std::string, BoneNode*>& SkeletonNode::getAllSubBonesMap() co
     return _subBonesMap;
 }
 
-void SkeletonNode::addSkinGroup(std::string groupName, std::map<std::string, std::string> boneSkinNameMap)
+void SkeletonNode::addSkinGroup(const std::string& groupName, const std::map<std::string, std::string>& boneSkinNameMap)
 {
     _skinGroupMap.emplace(groupName, boneSkinNameMap);
 }

--- a/cocos/editor-support/cocostudio/ActionTimeline/CCSkeletonNode.h
+++ b/cocos/editor-support/cocostudio/ActionTimeline/CCSkeletonNode.h
@@ -69,7 +69,7 @@ public:
     *@param: groupName, key
     *@param: boneSkinNameMap, map <name of bone, name of skin to display which added to bone>
     */
-    void addSkinGroup(std::string groupName, std::map<std::string, std::string> boneSkinNameMap);
+    void addSkinGroup(const std::string& groupName, const std::map<std::string, std::string>& boneSkinNameMap);
 
     cocos2d::Rect getBoundingBox() const override;
 

--- a/cocos/editor-support/cocostudio/CCArmatureAnimation.cpp
+++ b/cocos/editor-support/cocostudio/CCArmatureAnimation.cpp
@@ -24,11 +24,13 @@ THE SOFTWARE.
 ****************************************************************************/
 
 #include "editor-support/cocostudio/CCArmatureAnimation.h"
+
 #include "editor-support/cocostudio/CCArmature.h"
-#include "editor-support/cocostudio/CCBone.h"
 #include "editor-support/cocostudio/CCArmatureDefine.h"
-#include "editor-support/cocostudio/CCUtilMath.h"
+#include "editor-support/cocostudio/CCBone.h"
 #include "editor-support/cocostudio/CCDatas.h"
+#include "editor-support/cocostudio/CCUtilMath.h"
+#include <utility>
 
 using namespace cocos2d;
 
@@ -484,11 +486,11 @@ void ArmatureAnimation::setFrameEventCallFunc(Ref *target, SEL_FrameEventCallFun
 
 void ArmatureAnimation::setMovementEventCallFunc(std::function<void(Armature *armature, MovementEventType movementType, const std::string& movementID)> listener)
 {
-    _movementEventListener = listener;
+    _movementEventListener = std::move(listener);
 }
 void ArmatureAnimation::setFrameEventCallFunc(std::function<void(Bone *bone, const std::string& frameEventName, int originFrameIndex, int currentFrameIndex)> listener)
 {
-    _frameEventListener = listener;
+    _frameEventListener = std::move(listener);
 }
 
 void ArmatureAnimation::setUserObject(Ref *pUserObject)

--- a/cocos/editor-support/cocostudio/CCArmatureAnimation.cpp
+++ b/cocos/editor-support/cocostudio/CCArmatureAnimation.cpp
@@ -484,13 +484,13 @@ void ArmatureAnimation::setFrameEventCallFunc(Ref *target, SEL_FrameEventCallFun
     _frameEventCallFunc = callFunc;
 }
 
-void ArmatureAnimation::setMovementEventCallFunc(std::function<void(Armature *armature, MovementEventType movementType, const std::string& movementID)> listener)
+void ArmatureAnimation::setMovementEventCallFunc(const std::function<void(Armature *armature, MovementEventType movementType, const std::string& movementID)>& listener)
 {
-    _movementEventListener = std::move(listener);
+    _movementEventListener = listener;
 }
-void ArmatureAnimation::setFrameEventCallFunc(std::function<void(Bone *bone, const std::string& frameEventName, int originFrameIndex, int currentFrameIndex)> listener)
+void ArmatureAnimation::setFrameEventCallFunc(const std::function<void(Bone *bone, const std::string& frameEventName, int originFrameIndex, int currentFrameIndex)>& listener)
 {
-    _frameEventListener = std::move(listener);
+    _frameEventListener = listener;
 }
 
 void ArmatureAnimation::setUserObject(Ref *pUserObject)

--- a/cocos/editor-support/cocostudio/CCArmatureAnimation.h
+++ b/cocos/editor-support/cocostudio/CCArmatureAnimation.h
@@ -194,8 +194,8 @@ public:
      */
     CC_DEPRECATED_ATTRIBUTE void setFrameEventCallFunc(cocos2d::Ref *target, SEL_FrameEventCallFunc callFunc);
     
-    void setMovementEventCallFunc(std::function<void(Armature *armature, MovementEventType movementType, const std::string& movementID)> listener);
-    void setFrameEventCallFunc(std::function<void(Bone *bone, const std::string& frameEventName, int originFrameIndex, int currentFrameIndex)> listener);
+    void setMovementEventCallFunc(const std::function<void(Armature *armature, MovementEventType movementType, const std::string& movementID)>& listener);
+    void setFrameEventCallFunc(const std::function<void(Bone *bone, const std::string& frameEventName, int originFrameIndex, int currentFrameIndex)>& listener);
 
     virtual void setAnimationData(AnimationData *data) 
     {

--- a/cocos/editor-support/cocostudio/CCSGUIReader.cpp
+++ b/cocos/editor-support/cocostudio/CCSGUIReader.cpp
@@ -187,13 +187,13 @@ void GUIReader::registerTypeAndCallBack(const std::string& classType,
 }
 
 void GUIReader::registerTypeAndCallBack(const std::string& classType,
-                                        ObjectFactory::InstanceFunc ins,
+                                        const ObjectFactory::InstanceFunc& ins,
                                         Ref *object,
                                         SEL_ParseEvent callBack)
 {
     ObjectFactory* factoryCreate = ObjectFactory::getInstance();
 
-    ObjectFactory::TInfo t(classType, std::move(ins));
+    ObjectFactory::TInfo t(classType, ins);
     factoryCreate->registerType(t);
 
     if (object)

--- a/cocos/editor-support/cocostudio/CCSGUIReader.cpp
+++ b/cocos/editor-support/cocostudio/CCSGUIReader.cpp
@@ -24,13 +24,14 @@ THE SOFTWARE.
 ****************************************************************************/
 #include "editor-support/cocostudio/CCSGUIReader.h"
 
-#include <fstream>
-#include <iostream>
-#include "ui/CocosGUI.h"
-#include "platform/CCFileUtils.h"
 #include "2d/CCSpriteFrameCache.h"
 #include "base/CCDirector.h"
 #include "base/ccUtils.h"
+#include "platform/CCFileUtils.h"
+#include "ui/CocosGUI.h"
+#include <fstream>
+#include <iostream>
+#include <utility>
 
 #include "editor-support/cocostudio/CCActionManagerEx.h"
 #include "editor-support/cocostudio/WidgetReader/ButtonReader/ButtonReader.h"
@@ -192,7 +193,7 @@ void GUIReader::registerTypeAndCallBack(const std::string& classType,
 {
     ObjectFactory* factoryCreate = ObjectFactory::getInstance();
 
-    ObjectFactory::TInfo t(classType, ins);
+    ObjectFactory::TInfo t(classType, std::move(ins));
     factoryCreate->registerType(t);
 
     if (object)

--- a/cocos/editor-support/cocostudio/CCSGUIReader.h
+++ b/cocos/editor-support/cocostudio/CCSGUIReader.h
@@ -86,7 +86,7 @@ public:
                                  SEL_ParseEvent callBack);
 
     void registerTypeAndCallBack(const std::string& classType,
-                                 cocos2d::ObjectFactory::InstanceFunc ins,
+                                 const cocos2d::ObjectFactory::InstanceFunc& ins,
                                  Ref* object,
                                  SEL_ParseEvent callBack);
 protected:

--- a/cocos/editor-support/cocostudio/CCSSceneReader.cpp
+++ b/cocos/editor-support/cocostudio/CCSSceneReader.cpp
@@ -211,7 +211,7 @@ Node* SceneReader::nodeByTag(Node *parent, int tag)
     return _retNode;
 }
     
-cocos2d::Component* SceneReader::createComponent(const std::string classname)
+cocos2d::Component* SceneReader::createComponent(const std::string& classname)
 {
     std::string name = this->getComponentClassName(classname);
     Ref *object = ObjectFactory::getInstance()->createObject(name);

--- a/cocos/editor-support/cocostudio/CCSSceneReader.h
+++ b/cocos/editor-support/cocostudio/CCSSceneReader.h
@@ -73,7 +73,7 @@ CC_CONSTRUCTOR_ACCESS:
 private:
     std::string getComponentClassName(const std::string& name);
 
-    cocos2d::Component* createComponent(const std::string classname);
+    cocos2d::Component* createComponent(const std::string& classname);
 
     
     cocos2d::Node* createObject(const rapidjson::Value& dict, cocos2d::Node* parent, AttachComponentType attachComponent);

--- a/cocos/editor-support/cocostudio/FlatBuffersSerialize.cpp
+++ b/cocos/editor-support/cocostudio/FlatBuffersSerialize.cpp
@@ -325,7 +325,7 @@ std::string FlatBuffersSerialize::serializeFlatBuffersWithXMLFile(const std::str
 
 // NodeTree
 Offset<NodeTree> FlatBuffersSerialize::createNodeTree(const tinyxml2::XMLElement *objectData,
-                                                      std::string classType)
+                                                      const std::string& classType)
 {
     std::string classname = classType.substr(0, classType.find("ObjectData"));
 //    CCLOG("classname = %s", classname.c_str());
@@ -434,7 +434,7 @@ Offset<NodeTree> FlatBuffersSerialize::createNodeTree(const tinyxml2::XMLElement
     
 }
 
-int FlatBuffersSerialize::getResourceType(std::string key)
+int FlatBuffersSerialize::getResourceType(const std::string& key)
 {
     if(key == "Normal" || key == "Default")
     {
@@ -1410,7 +1410,7 @@ FlatBufferBuilder* FlatBuffersSerialize::createFlatBuffersWithXMLFileForSimulato
 }
 
 Offset<NodeTree> FlatBuffersSerialize::createNodeTreeForSimulator(const tinyxml2::XMLElement *objectData,
-                                                                  std::string classType)
+                                                                  const std::string& classType)
 {
     std::string classname = classType.substr(0, classType.find("ObjectData"));
 //    CCLOG("classname = %s", classname.c_str());

--- a/cocos/editor-support/cocostudio/FlatBuffersSerialize.h
+++ b/cocos/editor-support/cocostudio/FlatBuffersSerialize.h
@@ -116,7 +116,7 @@ public:
 
     // NodeTree
     flatbuffers::Offset<flatbuffers::NodeTree> createNodeTree(const tinyxml2::XMLElement* objectData,
-                                                              std::string classType);
+                                                              const std::string& classType);
     
     // NodeAction
     flatbuffers::Offset<flatbuffers::NodeAction> createNodeAction(const tinyxml2::XMLElement* objectData);
@@ -137,14 +137,14 @@ public:
     flatbuffers::Offset<flatbuffers::AnimationInfo> createAnimationInfo(const tinyxml2::XMLElement* objectData);
     /**/
     
-    int getResourceType(std::string key);
+    int getResourceType(const std::string& key);
     std::string getGUIClassName(const std::string &name);
     std::string getWidgetReaderClassName(cocos2d::ui::Widget *widget);
     
     /* create flat buffers with XML */
     flatbuffers::FlatBufferBuilder* createFlatBuffersWithXMLFileForSimulator(const std::string& xmlFileName);
     flatbuffers::Offset<flatbuffers::NodeTree> createNodeTreeForSimulator(const tinyxml2::XMLElement* objectData,
-                                                                          std::string classType);
+                                                                          const std::string& classType);
     flatbuffers::Offset<flatbuffers::ProjectNodeOptions> createProjectNodeOptionsForSimulator(const tinyxml2::XMLElement* objectData);
 	/**/
     std::string getCsdVersion() { return _csdVersion; }

--- a/cocos/editor-support/cocostudio/WidgetReader/ButtonReader/ButtonReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/ButtonReader/ButtonReader.cpp
@@ -967,7 +967,7 @@ namespace cocostudio
         return button;
     }
     
-    int ButtonReader::getResourceType(std::string key)
+    int ButtonReader::getResourceType(const std::string& key)
     {
         if(key == "Normal" || key == "Default")
         {

--- a/cocos/editor-support/cocostudio/WidgetReader/ButtonReader/ButtonReader.h
+++ b/cocos/editor-support/cocostudio/WidgetReader/ButtonReader/ButtonReader.h
@@ -53,7 +53,7 @@ namespace cocostudio
         void setPropsWithFlatBuffers(cocos2d::Node* node, const flatbuffers::Table* buttonOptions);
         cocos2d::Node* createNodeWithFlatBuffers(const flatbuffers::Table* buttonOptions);
         
-        int getResourceType(std::string key);    
+        int getResourceType(const std::string& key);
         
     };
 }

--- a/cocos/editor-support/cocostudio/WidgetReader/CheckBoxReader/CheckBoxReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/CheckBoxReader/CheckBoxReader.cpp
@@ -775,7 +775,7 @@ namespace cocostudio
         return checkBox;
     }
 
-    int CheckBoxReader::getResourceType(std::string key)
+    int CheckBoxReader::getResourceType(const std::string& key)
     {
         if(key == "Normal" || key == "Default")
         {

--- a/cocos/editor-support/cocostudio/WidgetReader/CheckBoxReader/CheckBoxReader.h
+++ b/cocos/editor-support/cocostudio/WidgetReader/CheckBoxReader/CheckBoxReader.h
@@ -50,7 +50,7 @@ namespace cocostudio
                                                                              flatbuffers::FlatBufferBuilder* builder);
         void setPropsWithFlatBuffers(cocos2d::Node* node, const flatbuffers::Table* checkBoxOptions);
         cocos2d::Node* createNodeWithFlatBuffers(const flatbuffers::Table* checkBoxOptions);
-		virtual int getResourceType(std::string key);
+		virtual int getResourceType(const std::string& key);
     };
 }
 

--- a/cocos/editor-support/cocostudio/WidgetReader/GameNode3DReader/GameNode3DReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/GameNode3DReader/GameNode3DReader.cpp
@@ -440,7 +440,7 @@ namespace cocostudio
         return node;
     }
 
-    int GameNode3DReader::getResourceType(std::string key)
+    int GameNode3DReader::getResourceType(const std::string& key)
     {
         if (key == "Normal" || key == "Default")
         {

--- a/cocos/editor-support/cocostudio/WidgetReader/GameNode3DReader/GameNode3DReader.h
+++ b/cocos/editor-support/cocostudio/WidgetReader/GameNode3DReader/GameNode3DReader.h
@@ -58,7 +58,7 @@ namespace cocostudio
         cocos2d::Node* createNodeWithFlatBuffers(const flatbuffers::Table* node3DOptions);
         
     protected:
-        int getResourceType(std::string key);
+        int getResourceType(const std::string& key);
     };
 }
 

--- a/cocos/editor-support/cocostudio/WidgetReader/ImageViewReader/ImageViewReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/ImageViewReader/ImageViewReader.cpp
@@ -422,7 +422,7 @@ namespace cocostudio
         return imageView;
     }
     
-    int ImageViewReader::getResourceType(std::string key)
+    int ImageViewReader::getResourceType(const std::string& key)
     {
         if(key == "Normal" || key == "Default")
         {

--- a/cocos/editor-support/cocostudio/WidgetReader/ImageViewReader/ImageViewReader.h
+++ b/cocos/editor-support/cocostudio/WidgetReader/ImageViewReader/ImageViewReader.h
@@ -53,7 +53,7 @@ namespace cocostudio
         void setPropsWithFlatBuffers(cocos2d::Node* node, const flatbuffers::Table* imageViewOptions);
         cocos2d::Node* createNodeWithFlatBuffers(const flatbuffers::Table* imageViewOptions);
         
-        int getResourceType(std::string key);
+        int getResourceType(const std::string& key);
     };
 }
 

--- a/cocos/editor-support/cocostudio/WidgetReader/LayoutReader/LayoutReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/LayoutReader/LayoutReader.cpp
@@ -746,7 +746,7 @@ namespace cocostudio
         return layout;
     }
     
-    int LayoutReader::getResourceType(std::string key)
+    int LayoutReader::getResourceType(const std::string& key)
     {
         if(key == "Normal" || key == "Default")
         {

--- a/cocos/editor-support/cocostudio/WidgetReader/LayoutReader/LayoutReader.h
+++ b/cocos/editor-support/cocostudio/WidgetReader/LayoutReader/LayoutReader.h
@@ -52,7 +52,7 @@ namespace cocostudio
         void setPropsWithFlatBuffers(cocos2d::Node* node, const flatbuffers::Table* layoutOptions);
         cocos2d::Node* createNodeWithFlatBuffers(const flatbuffers::Table* layoutOptions);
         
-        int getResourceType(std::string key);
+        int getResourceType(const std::string& key);
     };
     
 }

--- a/cocos/editor-support/cocostudio/WidgetReader/ListViewReader/ListViewReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/ListViewReader/ListViewReader.cpp
@@ -609,7 +609,7 @@ namespace cocostudio
         return listView;
     }
     
-    int ListViewReader::getResourceType(std::string key)
+    int ListViewReader::getResourceType(const std::string& key)
     {
         if(key == "Normal" || key == "Default")
         {

--- a/cocos/editor-support/cocostudio/WidgetReader/ListViewReader/ListViewReader.h
+++ b/cocos/editor-support/cocostudio/WidgetReader/ListViewReader/ListViewReader.h
@@ -51,7 +51,7 @@ namespace cocostudio
         void setPropsWithFlatBuffers(cocos2d::Node* node, const flatbuffers::Table* listViewOptions);
         cocos2d::Node* createNodeWithFlatBuffers(const flatbuffers::Table* listViewOptions);
         
-        int getResourceType(std::string key);
+        int getResourceType(const std::string& key);
         
     };
 }

--- a/cocos/editor-support/cocostudio/WidgetReader/LoadingBarReader/LoadingBarReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/LoadingBarReader/LoadingBarReader.cpp
@@ -355,7 +355,7 @@ namespace cocostudio
         return loadingBar;
     }
     
-    int LoadingBarReader::getResourceType(std::string key)
+    int LoadingBarReader::getResourceType(const std::string& key)
     {
         if(key == "Normal" || key == "Default")
         {

--- a/cocos/editor-support/cocostudio/WidgetReader/LoadingBarReader/LoadingBarReader.h
+++ b/cocos/editor-support/cocostudio/WidgetReader/LoadingBarReader/LoadingBarReader.h
@@ -51,7 +51,7 @@ namespace cocostudio
         void setPropsWithFlatBuffers(cocos2d::Node* node, const flatbuffers::Table* loadingBarOptions);
         cocos2d::Node* createNodeWithFlatBuffers(const flatbuffers::Table* loadingBarOptions);
         
-        int getResourceType(std::string key);
+        int getResourceType(const std::string& key);
         
     };
 }

--- a/cocos/editor-support/cocostudio/WidgetReader/PageViewReader/PageViewReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/PageViewReader/PageViewReader.cpp
@@ -472,7 +472,7 @@ namespace cocostudio
         return pageView;
     }
     
-    int PageViewReader::getResourceType(std::string key)
+    int PageViewReader::getResourceType(const std::string& key)
     {
         if(key == "Normal" || key == "Default")
         {

--- a/cocos/editor-support/cocostudio/WidgetReader/PageViewReader/PageViewReader.h
+++ b/cocos/editor-support/cocostudio/WidgetReader/PageViewReader/PageViewReader.h
@@ -51,7 +51,7 @@ namespace cocostudio
         void setPropsWithFlatBuffers(cocos2d::Node* node, const flatbuffers::Table* pageViewOptions);
         cocos2d::Node* createNodeWithFlatBuffers(const flatbuffers::Table* pageViewOptions);
         
-        int getResourceType(std::string key);
+        int getResourceType(const std::string& key);
         
     };
 }

--- a/cocos/editor-support/cocostudio/WidgetReader/ScrollViewReader/ScrollViewReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/ScrollViewReader/ScrollViewReader.cpp
@@ -591,7 +591,7 @@ namespace cocostudio
         return scrollView;
     }
 
-    int ScrollViewReader::getResourceType(std::string key)
+    int ScrollViewReader::getResourceType(const std::string& key)
     {
         if (key == "Normal" || key == "Default")
         {

--- a/cocos/editor-support/cocostudio/WidgetReader/ScrollViewReader/ScrollViewReader.h
+++ b/cocos/editor-support/cocostudio/WidgetReader/ScrollViewReader/ScrollViewReader.h
@@ -51,7 +51,7 @@ namespace cocostudio
         void setPropsWithFlatBuffers(cocos2d::Node* node, const flatbuffers::Table* scrollViewOptions);
         cocos2d::Node* createNodeWithFlatBuffers(const flatbuffers::Table* scrollViewOptions);
         
-        int getResourceType(std::string key);
+        int getResourceType(const std::string& key);
 
     };
 }

--- a/cocos/editor-support/cocostudio/WidgetReader/SliderReader/SliderReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/SliderReader/SliderReader.cpp
@@ -862,7 +862,7 @@ namespace cocostudio
         return slider;
     }
     
-    int SliderReader::getResourceType(std::string key)
+    int SliderReader::getResourceType(const std::string& key)
     {
         if(key == "Normal" || key == "Default")
         {

--- a/cocos/editor-support/cocostudio/WidgetReader/SliderReader/SliderReader.h
+++ b/cocos/editor-support/cocostudio/WidgetReader/SliderReader/SliderReader.h
@@ -51,7 +51,7 @@ namespace cocostudio
         void setPropsWithFlatBuffers(cocos2d::Node* node, const flatbuffers::Table* sliderOptions);
         cocos2d::Node* createNodeWithFlatBuffers(const flatbuffers::Table* sliderOptions);
         
-        int getResourceType(std::string key);
+        int getResourceType(const std::string& key);
 
     };
 }

--- a/cocos/editor-support/cocostudio/WidgetReader/SpriteReader/SpriteReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/SpriteReader/SpriteReader.cpp
@@ -273,7 +273,7 @@ namespace cocostudio
         return sprite;
     }
     
-    int SpriteReader::getResourceType(std::string key)
+    int SpriteReader::getResourceType(const std::string& key)
     {
         if(key == "Normal" || key == "Default")
         {

--- a/cocos/editor-support/cocostudio/WidgetReader/SpriteReader/SpriteReader.h
+++ b/cocos/editor-support/cocostudio/WidgetReader/SpriteReader/SpriteReader.h
@@ -51,7 +51,7 @@ namespace cocostudio
         void setPropsWithFlatBuffers(cocos2d::Node* node, const flatbuffers::Table* spriteOptions);
         cocos2d::Node* createNodeWithFlatBuffers(const flatbuffers::Table* spriteOptions);
         
-        int getResourceType(std::string key);        
+        int getResourceType(const std::string& key);
     };
 }
 

--- a/cocos/editor-support/cocostudio/WidgetReader/TabControlReader/TabControlReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/TabControlReader/TabControlReader.cpp
@@ -902,7 +902,7 @@ cocos2d::Node* TabHeaderReader::createNodeWithFlatBuffers(const flatbuffers::Tab
     return node;
 }
 
-int TabHeaderReader::getResourceType(std::string key)
+int TabHeaderReader::getResourceType(const std::string& key)
 {
     if (key == "Normal" || key == "Default")
     {

--- a/cocos/editor-support/cocostudio/WidgetReader/TabControlReader/TabControlReader.h
+++ b/cocos/editor-support/cocostudio/WidgetReader/TabControlReader/TabControlReader.h
@@ -72,7 +72,7 @@ public:
     cocos2d::Node* createNodeWithFlatBuffers(const flatbuffers::Table* nodeOptions) override;
 private:
     static TabHeaderReader* _tabheaderReaderInstance;
-    int    getResourceType(std::string key);
+    int    getResourceType(const std::string& key);
 };
 
 class TabItemReader : public cocos2d::Ref, public cocostudio::NodeReaderProtocol

--- a/cocos/editor-support/cocostudio/WidgetReader/UserCameraReader/UserCameraReader.cpp
+++ b/cocos/editor-support/cocostudio/WidgetReader/UserCameraReader/UserCameraReader.cpp
@@ -483,7 +483,7 @@ namespace cocostudio
         return camera;
     }
 
-    int UserCameraReader::getResourceType(std::string key)
+    int UserCameraReader::getResourceType(const std::string& key)
     {
         if (key == "Normal" || key == "Default")
         {

--- a/cocos/editor-support/cocostudio/WidgetReader/UserCameraReader/UserCameraReader.h
+++ b/cocos/editor-support/cocostudio/WidgetReader/UserCameraReader/UserCameraReader.h
@@ -57,7 +57,7 @@ namespace cocostudio
         cocos2d::Node* createNodeWithFlatBuffers(const flatbuffers::Table* userCameraOptions);
         
     protected:
-        int getResourceType(std::string key);
+        int getResourceType(const std::string& key);
         cocos2d::Vec2 getVec2Attribute(const tinyxml2::XMLAttribute* attribute) const;
     };
 }

--- a/cocos/network/CCDownloader-curl.cpp
+++ b/cocos/network/CCDownloader-curl.cpp
@@ -256,7 +256,7 @@ namespace cocos2d { namespace network {
             DLLOG("Destruct DownloaderCURL::Impl %p %d", this, _thread.joinable());
         }
 
-        void addTask(std::shared_ptr<const DownloadTask> task, DownloadTaskCURL* coTask)
+        void addTask(const std::shared_ptr<const DownloadTask>& task, DownloadTaskCURL* coTask)
         {
             if (DownloadTask::ERROR_NO_ERROR == coTask->_errCode)
             {

--- a/cocos/network/SocketIO.cpp
+++ b/cocos/network/SocketIO.cpp
@@ -1130,9 +1130,9 @@ void SIOClient::setConnected(bool connected)
     _connected = connected;
 }
 
-void SIOClient::on(const std::string& eventName, SIOEvent e)
+void SIOClient::on(const std::string& eventName, const SIOEvent& e)
 {
-    _eventRegistry[eventName] = std::move(e);
+    _eventRegistry[eventName] = e;
 }
 
 void SIOClient::fireEvent(const std::string& eventName, const std::string& data)

--- a/cocos/network/SocketIO.cpp
+++ b/cocos/network/SocketIO.cpp
@@ -29,15 +29,16 @@
  ****************************************************************************/
 
 #include "network/SocketIO.h"
-#include "network/Uri.h"
-#include <algorithm>
-#include <sstream>
-#include <iterator>
-#include "base/ccUTF8.h"
 #include "base/CCDirector.h"
 #include "base/CCScheduler.h"
-#include "network/WebSocket.h"
+#include "base/ccUTF8.h"
 #include "network/HttpClient.h"
+#include "network/Uri.h"
+#include "network/WebSocket.h"
+#include <algorithm>
+#include <iterator>
+#include <sstream>
+#include <utility>
 
 #include "json/rapidjson.h"
 #include "json/document-wrapper.h"
@@ -1131,7 +1132,7 @@ void SIOClient::setConnected(bool connected)
 
 void SIOClient::on(const std::string& eventName, SIOEvent e)
 {
-    _eventRegistry[eventName] = e;
+    _eventRegistry[eventName] = std::move(e);
 }
 
 void SIOClient::fireEvent(const std::string& eventName, const std::string& data)

--- a/cocos/network/SocketIO.h
+++ b/cocos/network/SocketIO.h
@@ -276,7 +276,7 @@ public:
      * @param eventName the name of event.
      * @param e the callback function.
      */
-    void on(const std::string& eventName, SIOEvent e);
+    void on(const std::string& eventName, const SIOEvent& e);
 
     /**
      * Set tag of SIOClient.

--- a/cocos/physics/CCPhysicsWorld.cpp
+++ b/cocos/physics/CCPhysicsWorld.cpp
@@ -395,7 +395,7 @@ void PhysicsWorld::collisionSeparateCallback(PhysicsContact& contact)
     _eventDispatcher->dispatchEvent(&contact);
 }
 
-void PhysicsWorld::rayCast(PhysicsRayCastCallbackFunc func, const Vec2& point1, const Vec2& point2, void* data)
+void PhysicsWorld::rayCast(const PhysicsRayCastCallbackFunc& func, const Vec2& point1, const Vec2& point2, void* data)
 {
     CCASSERT(func != nullptr, "func shouldn't be nullptr");
     
@@ -418,7 +418,7 @@ void PhysicsWorld::rayCast(PhysicsRayCastCallbackFunc func, const Vec2& point1, 
     }
 }
 
-void PhysicsWorld::queryRect(PhysicsQueryRectCallbackFunc func, const Rect& rect, void* data)
+void PhysicsWorld::queryRect(const PhysicsQueryRectCallbackFunc& func, const Rect& rect, void* data)
 {
     CCASSERT(func != nullptr, "func shouldn't be nullptr");
     
@@ -439,7 +439,7 @@ void PhysicsWorld::queryRect(PhysicsQueryRectCallbackFunc func, const Rect& rect
     }
 }
 
-void PhysicsWorld::queryPoint(PhysicsQueryPointCallbackFunc func, const Vec2& point, void* data)
+void PhysicsWorld::queryPoint(const PhysicsQueryPointCallbackFunc& func, const Vec2& point, void* data)
 {
     CCASSERT(func != nullptr, "func shouldn't be nullptr");
     

--- a/cocos/physics/CCPhysicsWorld.h
+++ b/cocos/physics/CCPhysicsWorld.h
@@ -167,7 +167,7 @@ public:
     * @param   end   A Vec2 object contains the end position of the ray.
     * @param   data   User defined data, it is passed to func. 
     */
-    void rayCast(PhysicsRayCastCallbackFunc func, const Vec2& start, const Vec2& end, void* data);
+    void rayCast(const PhysicsRayCastCallbackFunc& func, const Vec2& start, const Vec2& end, void* data);
     
     /**
     * Searches for physics shapes that contains in the rect. 
@@ -177,7 +177,7 @@ public:
     * @param   rect   A Rect object contains a rectangle's x, y, width and height.
     * @param   data   User defined data, it is passed to func. 
     */
-    void queryRect(PhysicsQueryRectCallbackFunc func, const Rect& rect, void* data);
+    void queryRect(const PhysicsQueryRectCallbackFunc& func, const Rect& rect, void* data);
     
     /**
     * Searches for physics shapes that contains the point. 
@@ -187,7 +187,7 @@ public:
     * @param   point   A Vec2 object contains the position of the point.
     * @param   data   User defined data, it is passed to func. 
     */
-    void queryPoint(PhysicsQueryPointCallbackFunc func, const Vec2& point, void* data);
+    void queryPoint(const PhysicsQueryPointCallbackFunc& func, const Vec2& point, void* data);
     
     /**
     * Get physics shapes that contains the point. 

--- a/cocos/scripting/js-bindings/auto/jsb_cocos2dx_auto.cpp
+++ b/cocos/scripting/js-bindings/auto/jsb_cocos2dx_auto.cpp
@@ -19069,7 +19069,7 @@ bool js_cocos2dx_FileUtils_getStringFromFile(JSContext *cx, uint32_t argc, jsval
 			    {
 			        JS::RootedObject jstarget(cx, args.thisv().toObjectOrNull());
 			        std::shared_ptr<JSFunctionWrapper> func(new JSFunctionWrapper(cx, jstarget, args.get(1), args.thisv()));
-			        auto lambda = [=](std::string larg0) -> void {
+			        auto lambda = [=](const std::string& larg0) -> void {
 			            JSB_AUTOCOMPARTMENT_WITH_GLOBAL_OBJCET
 			            jsval largv[1];
 			            largv[0] = std_string_to_jsval(cx, larg0);

--- a/cocos/scripting/js-bindings/auto/jsb_cocos2dx_extension_auto.cpp
+++ b/cocos/scripting/js-bindings/auto/jsb_cocos2dx_extension_auto.cpp
@@ -6737,7 +6737,7 @@ bool js_cocos2dx_extension_AssetsManagerEx_setVerifyCallback(JSContext *cx, uint
 		    {
 		        JS::RootedObject jstarget(cx, args.thisv().toObjectOrNull());
 		        std::shared_ptr<JSFunctionWrapper> func(new JSFunctionWrapper(cx, jstarget, args.get(0), args.thisv()));
-		        auto lambda = [=](const std::string& larg0, cocos2d::extension::ManifestAsset larg1) -> bool {
+		        auto lambda = [=](const std::string& larg0, const cocos2d::extension::ManifestAsset& larg1) -> bool {
 		            JSB_AUTOCOMPARTMENT_WITH_GLOBAL_OBJCET
 		            jsval largv[2];
 		            largv[0] = std_string_to_jsval(cx, larg0);

--- a/cocos/scripting/js-bindings/manual/extension/jsb_cocos2dx_extension_manual.cpp
+++ b/cocos/scripting/js-bindings/manual/extension/jsb_cocos2dx_extension_manual.cpp
@@ -156,7 +156,7 @@ public:
     }
 
 private:
-    void callJSDelegate(ScrollView* view, std::string jsFunctionName)
+    void callJSDelegate(ScrollView* view, const std::string& jsFunctionName)
     {
         js_proxy_t * p = jsb_get_native_proxy(view);
         if (!p) return;
@@ -165,7 +165,7 @@ private:
         ScriptingCore::getInstance()->executeFunctionWithOwner(OBJECT_TO_JSVAL(_JSDelegate), jsFunctionName.c_str(), 1, &arg);
     }
 
-    void callJSDelegate(TableView* table, TableViewCell* cell, std::string jsFunctionName)
+    void callJSDelegate(TableView* table, TableViewCell* cell, const std::string& jsFunctionName)
     {
         js_proxy_t * p = jsb_get_native_proxy(table);
         if (!p) return;
@@ -292,7 +292,7 @@ public:
     }
 
 private:
-    bool callJSDelegate(TableView* table, std::string jsFunctionName, JS::MutableHandleValue retVal)
+    bool callJSDelegate(TableView* table, const std::string& jsFunctionName, JS::MutableHandleValue retVal)
     {
         js_proxy_t * p = jsb_get_native_proxy(table);
         if (!p) return false;
@@ -323,7 +323,7 @@ private:
         return false;
     }
 
-    bool callJSDelegate(TableView* table, ssize_t idx, std::string jsFunctionName, JS::MutableHandleValue retVal)
+    bool callJSDelegate(TableView* table, ssize_t idx, const std::string& jsFunctionName, JS::MutableHandleValue retVal)
     {
         js_proxy_t * p = jsb_get_native_proxy(table);
         if (!p) return false;

--- a/cocos/scripting/js-bindings/manual/network/jsb_socketio.cpp
+++ b/cocos/scripting/js-bindings/manual/network/jsb_socketio.cpp
@@ -23,7 +23,9 @@
  */
 
 #include "scripting/js-bindings/manual/network/jsb_socketio.h"
+
 #include "scripting/js-bindings/manual/jsb_helper.h"
+#include <utility>
 
 #include "network/WebSocket.h"
 #include "network/SocketIO.h"
@@ -116,7 +118,7 @@ public:
 
     void addEvent(const std::string& eventName, std::shared_ptr<JSFunctionWrapper> callback)
     {
-        _eventRegistry[eventName] = callback;
+        _eventRegistry[eventName] = std::move(callback);
     }
 
 private:

--- a/cocos/ui/UIRichText.cpp
+++ b/cocos/ui/UIRichText.cpp
@@ -347,7 +347,7 @@ public:
     
     void pushBackElement(RichElement* element);
     
-    static void setTagDescription(const std::string& tag, bool isFontElement, RichText::VisitEnterHandler handleVisitEnter);
+    static void setTagDescription(const std::string& tag, bool isFontElement, const RichText::VisitEnterHandler& handleVisitEnter);
     
     static void removeTagDescription(const std::string& tag);
     
@@ -821,9 +821,9 @@ void MyXMLVisitor::pushBackElement(RichElement* element)
     _richText->pushBackElement(element);
 }
 
-void MyXMLVisitor::setTagDescription(const std::string& tag, bool isFontElement, RichText::VisitEnterHandler handleVisitEnter)
+void MyXMLVisitor::setTagDescription(const std::string& tag, bool isFontElement, const RichText::VisitEnterHandler& handleVisitEnter)
 {
-    MyXMLVisitor::_tagTables[tag] = {isFontElement, std::move(handleVisitEnter)};
+    MyXMLVisitor::_tagTables[tag] = {isFontElement, handleVisitEnter};
 }
 
 void MyXMLVisitor::removeTagDescription(const std::string& tag)
@@ -1326,9 +1326,9 @@ std::string RichText::stringWithColor4B(const cocos2d::Color4B& color4b)
     return std::string(buf, 9);
 }
 
-void RichText::setTagDescription(const std::string& tag, bool isFontElement, VisitEnterHandler handleVisitEnter)
+void RichText::setTagDescription(const std::string& tag, bool isFontElement, const VisitEnterHandler& handleVisitEnter)
 {
-    MyXMLVisitor::setTagDescription(tag, isFontElement, std::move(handleVisitEnter));
+    MyXMLVisitor::setTagDescription(tag, isFontElement, handleVisitEnter);
 }
 
 void RichText::removeTagDescription(const std::string& tag)

--- a/cocos/ui/UIRichText.cpp
+++ b/cocos/ui/UIRichText.cpp
@@ -25,10 +25,11 @@
 
 #include "ui/UIRichText.h"
 
-#include <sstream>
-#include <vector>
-#include <locale>
 #include <algorithm>
+#include <locale>
+#include <sstream>
+#include <utility>
+#include <vector>
 
 #include "platform/CCFileUtils.h"
 #include "platform/CCApplication.h"
@@ -50,14 +51,14 @@ class ListenerComponent : public Component
 public:
     static const std::string COMPONENT_NAME;    /*!< component name */
 
-    static ListenerComponent* create(Node* parent, const std::string& url, const RichText::OpenUrlHandler handleOpenUrl = nullptr)
+    static ListenerComponent* create(Node* parent, const std::string& url, const RichText::OpenUrlHandler& handleOpenUrl = nullptr)
     {
         auto component = new (std::nothrow) ListenerComponent(parent, url, handleOpenUrl);
         component->autorelease();
         return component;
     }
 
-    explicit ListenerComponent(Node* parent, const std::string& url, const RichText::OpenUrlHandler handleOpenUrl)
+    explicit ListenerComponent(Node* parent, const std::string& url, const RichText::OpenUrlHandler& handleOpenUrl)
     : _parent(parent)
     , _url(url)
     , _handleOpenUrl(handleOpenUrl)
@@ -822,7 +823,7 @@ void MyXMLVisitor::pushBackElement(RichElement* element)
 
 void MyXMLVisitor::setTagDescription(const std::string& tag, bool isFontElement, RichText::VisitEnterHandler handleVisitEnter)
 {
-    MyXMLVisitor::_tagTables[tag] = {isFontElement, handleVisitEnter};
+    MyXMLVisitor::_tagTables[tag] = {isFontElement, std::move(handleVisitEnter)};
 }
 
 void MyXMLVisitor::removeTagDescription(const std::string& tag)
@@ -1327,7 +1328,7 @@ std::string RichText::stringWithColor4B(const cocos2d::Color4B& color4b)
 
 void RichText::setTagDescription(const std::string& tag, bool isFontElement, VisitEnterHandler handleVisitEnter)
 {
-    MyXMLVisitor::setTagDescription(tag, isFontElement, handleVisitEnter);
+    MyXMLVisitor::setTagDescription(tag, isFontElement, std::move(handleVisitEnter));
 }
 
 void RichText::removeTagDescription(const std::string& tag)

--- a/cocos/ui/UIRichText.h
+++ b/cocos/ui/UIRichText.h
@@ -533,7 +533,7 @@ public:
      * @param isFontElement use attributes of text tag
      * @param handleVisitEnter callback
      */
-    static void setTagDescription(const std::string& tag, bool isFontElement, VisitEnterHandler handleVisitEnter);
+    static void setTagDescription(const std::string& tag, bool isFontElement, const VisitEnterHandler& handleVisitEnter);
 
     /**
      * @brief remove a callback to own tag.

--- a/tests/cpp-tests/Classes/BaseTest.cpp
+++ b/tests/cpp-tests/Classes/BaseTest.cpp
@@ -132,7 +132,7 @@ TestList::TestList()
     _shouldRestoreTableOffset = false;
 }
 
-void TestList::addTest(const std::string& testName, std::function<TestBase*()> callback)
+void TestList::addTest(const std::string& testName, const std::function<TestBase*()>& callback)
 {
     if (!testName.empty())
     {
@@ -256,7 +256,7 @@ ssize_t TestList::numberOfCellsInTableView(TableView *table)
 }
 
 //TestSuite
-void TestSuite::addTestCase(const std::string& testName, std::function<Scene*()> callback)
+void TestSuite::addTestCase(const std::string& testName, const std::function<Scene*()>& callback)
 {
     if (!testName.empty() && callback)
     {

--- a/tests/cpp-tests/Classes/BaseTest.h
+++ b/tests/cpp-tests/Classes/BaseTest.h
@@ -157,7 +157,7 @@ class TestController;
 class TestSuite : public TestBase
 {
 public:
-    void addTestCase(const std::string& testName, std::function<cocos2d::Scene*()> callback);
+    void addTestCase(const std::string& testName, const std::function<cocos2d::Scene*()>& callback);
 
     virtual void restartCurrTest();
     virtual void enterNextTest();
@@ -181,7 +181,7 @@ class TestList : public TestBase, public cocos2d::extension::TableViewDataSource
 public:
     TestList();
 
-    void addTest(const std::string& testName, std::function<TestBase*()> callback);
+    void addTest(const std::string& testName, const std::function<TestBase*()>& callback);
 
     virtual void runThisTest() override;
 

--- a/tests/cpp-tests/Classes/Camera3DTest/Camera3DTest.cpp
+++ b/tests/cpp-tests/Classes/Camera3DTest/Camera3DTest.cpp
@@ -379,7 +379,7 @@ void Camera3DTestDemo::onExit()
     }
 }
 
-void Camera3DTestDemo::addNewSpriteWithCoords(Vec3 p,std::string fileName,bool playAnimation,float scale,bool bindCamera)
+void Camera3DTestDemo::addNewSpriteWithCoords(Vec3 p,const std::string& fileName,bool playAnimation,float scale,bool bindCamera)
 {
     auto sprite = Sprite3D::create(fileName);
     _layer3D->addChild(sprite);

--- a/tests/cpp-tests/Classes/Camera3DTest/Camera3DTest.h
+++ b/tests/cpp-tests/Classes/Camera3DTest/Camera3DTest.h
@@ -106,7 +106,7 @@ public:
     virtual void onExit() override;
     // overrides
     virtual std::string title() const override;
-    void addNewSpriteWithCoords(cocos2d::Vec3 p,std::string fileName,bool playAnimation=false,float scale=1.0f,bool bindCamera=false);
+    void addNewSpriteWithCoords(cocos2d::Vec3 p,const std::string& fileName,bool playAnimation=false,float scale=1.0f,bool bindCamera=false);
 
     void onTouchesBegan(const std::vector<cocos2d::Touch*>& touches, cocos2d::Event  *event);
     void onTouchesMoved(const std::vector<cocos2d::Touch*>& touches, cocos2d::Event  *event);

--- a/tests/cpp-tests/Classes/ReleasePoolTest/ReleasePoolTest.cpp
+++ b/tests/cpp-tests/Classes/ReleasePoolTest/ReleasePoolTest.cpp
@@ -36,7 +36,7 @@ class TestObject : public Ref
 public:
     TestObject() : _name(""){}
     
-    TestObject(std::string name) : _name(name)
+    TestObject(std::string name) : _name(std::move(name))
     {
         CCLOG("TestObject:%s is created", _name.c_str());
     }

--- a/tests/lua-tests/project/Classes/lua_test_bindings.cpp
+++ b/tests/lua-tests/project/Classes/lua_test_bindings.cpp
@@ -323,10 +323,10 @@ void DrawNode3D::setBlendFunc(const BlendFunc &blendFunc)
 class ValueTypeJudgeInTable:public Node
 {
 public:
-    static ValueTypeJudgeInTable* create(ValueMap valueMap);
+    static ValueTypeJudgeInTable* create(const ValueMap& valueMap);
 };
 
-ValueTypeJudgeInTable* ValueTypeJudgeInTable::create(ValueMap valueMap)
+ValueTypeJudgeInTable* ValueTypeJudgeInTable::create(const ValueMap& valueMap)
 {
     ValueTypeJudgeInTable* ret = new (std::nothrow) ValueTypeJudgeInTable();
     if (ret)


### PR DESCRIPTION
The changes are made with clang-tidy option `performance-unnecessary-value-param`. However, this option makes questionable changes to the code.

For example, it changes `std::function<>` to `const std::function<>&`. `std::function` is almost always passed by value, from the code I've seen. And we're using clang-tidy 7, it doesn't offer a option to specifically allowing a type to be copied. We can enable this option, if the system supports clang-tidy 8 in the future.

So we just leave the option disabled, but keep some of the changes it made. The `-` sign in front of `-performance-unnecessary-value-param` disables this check.

Reference: https://clang.llvm.org/extra/clang-tidy/checks/performance-unnecessary-value-param.html