### PR TITLE
add setInsertionPointColor to EditBox

### DIFF
--- a/cocos/ui/UIEditBox/Mac/CCUIEditBoxMac.h
+++ b/cocos/ui/UIEditBox/Mac/CCUIEditBoxMac.h
@@ -67,6 +67,7 @@
 - (void)setVisible:(BOOL)visible;
 - (void)setTextColor:(NSColor*)color;
 - (void)setFont:(NSFont *)font;
+- (void)setInsertionPointColor:(NSColor *)color;
 - (void)setPlaceholderFontColor:(NSColor*)color;
 - (void)setPlaceholderFont:(NSFont*)font;
 - (void)setText:(NSString *)text;

--- a/cocos/ui/UIEditBox/Mac/CCUIEditBoxMac.mm
+++ b/cocos/ui/UIEditBox/Mac/CCUIEditBoxMac.mm
@@ -289,6 +289,11 @@
     }
 }
 
+- (void)setInsertionPointColor:(NSColor *)color
+{
+    [self.textInput setInsertionPointColor:color];
+}
+
 - (void)setPlaceholderFontColor:(NSColor *)color
 {
     self.textInput.ccui_placeholderColor = color;

--- a/cocos/ui/UIEditBox/UIEditBox.cpp
+++ b/cocos/ui/UIEditBox/UIEditBox.cpp
@@ -543,6 +543,19 @@ const Color4B& EditBox::getFontColor() const
     return Color4B::WHITE;
 }
 
+void EditBox::setInsertionPointColor(const Color3B& color)
+{
+    setInsertionPointColor(Color4B(color));
+}
+
+void EditBox::setInsertionPointColor(const Color4B& color)
+{
+    if (_editBoxImpl != nullptr)
+    {
+        _editBoxImpl->setInsertionPointColor(color);
+    }
+}
+
 void EditBox::setPlaceholderFont(const char* pFontName, int fontSize)
 {
     CCASSERT(pFontName != nullptr, "fontName can't be nullptr");

--- a/cocos/ui/UIEditBox/UIEditBox.h
+++ b/cocos/ui/UIEditBox/UIEditBox.h
@@ -485,7 +485,14 @@ namespace ui {
         /**
          * Get the font color of the widget's text.
          */
-        const Color4B& getFontColor() const;
+        const Color4B& getFontColor() const;  
+
+        /**
+         * Set the insertion point color.
+         */
+        void setInsertionPointColor(const Color3B& color);
+        void setInsertionPointColor(const Color4B& color);
+
 
         /**
          * Set the placeholder's font. Only system font is allowed.

--- a/cocos/ui/UIEditBox/UIEditBoxImpl-android.cpp
+++ b/cocos/ui/UIEditBox/UIEditBoxImpl-android.cpp
@@ -134,6 +134,11 @@ void EditBoxImplAndroid::setNativeFontColor(const Color4B& color)
                                     (int)color.r, (int)color.g, (int)color.b, (int)color.a);
 }
 
+void EditBoxImplAndroid::setNativeInsertionPointColor(const Color4B& color)
+{
+    // not implemented
+}
+
 void EditBoxImplAndroid::setNativePlaceholderFont(const char* pFontName, int fontSize)
 {
     CCLOG("Warning! You can't change Android Hint fontName and fontSize");

--- a/cocos/ui/UIEditBox/UIEditBoxImpl-android.h
+++ b/cocos/ui/UIEditBox/UIEditBoxImpl-android.h
@@ -59,6 +59,7 @@ public:
     virtual void createNativeControl(const Rect& frame) override;
     virtual void setNativeFont(const char* pFontName, int fontSize) override;
     virtual void setNativeFontColor(const Color4B& color) override;
+    virtual void setNativeInsertionPointColor(const Color4B& color) override;
     virtual void setNativePlaceholderFont(const char* pFontName, int fontSize) override;
     virtual void setNativePlaceholderFontColor(const Color4B& color) override;
     virtual void setNativeInputMode(EditBox::InputMode inputMode) override;

--- a/cocos/ui/UIEditBox/UIEditBoxImpl-common.cpp
+++ b/cocos/ui/UIEditBox/UIEditBoxImpl-common.cpp
@@ -178,6 +178,11 @@ void EditBoxImplCommon::setFontColor(const Color4B& color)
     _label->setTextColor(color);
 }
 
+void EditBoxImplCommon::setInsertionPointColor(const Color4B& color)
+{
+    this->setNativeInsertionPointColor(color);
+}
+
 void EditBoxImplCommon::setPlaceholderFont(const char* pFontName, int fontSize)
 {
     _placeholderFontName = pFontName;

--- a/cocos/ui/UIEditBox/UIEditBoxImpl-common.h
+++ b/cocos/ui/UIEditBox/UIEditBoxImpl-common.h
@@ -56,6 +56,7 @@ public:
 
     virtual void setFont(const char* pFontName, int fontSize) override;
     virtual void setFontColor(const Color4B& color) override;
+    virtual void setInsertionPointColor(const Color4B& color) override;
     virtual void setPlaceholderFont(const char* pFontName, int fontSize) override;
     virtual void setPlaceholderFontColor(const Color4B& color) override;
     virtual void setInputMode(EditBox::InputMode inputMode) override;
@@ -115,6 +116,7 @@ public:
     virtual void createNativeControl(const Rect& frame) = 0;
     virtual void setNativeFont(const char* pFontName, int fontSize) = 0;
     virtual void setNativeFontColor(const Color4B& color) = 0;
+    virtual void setNativeInsertionPointColor(const Color4B& color) = 0;
     virtual void setNativePlaceholderFont(const char* pFontName, int fontSize) = 0;
     virtual void setNativePlaceholderFontColor(const Color4B& color) = 0;
     virtual void setNativeInputMode(EditBox::InputMode inputMode) = 0;

--- a/cocos/ui/UIEditBox/UIEditBoxImpl-ios.h
+++ b/cocos/ui/UIEditBox/UIEditBoxImpl-ios.h
@@ -59,6 +59,7 @@ public:
     virtual void createNativeControl(const Rect& frame) override;
     virtual void setNativeFont(const char* pFontName, int fontSize) override;
     virtual void setNativeFontColor(const Color4B& color) override;
+    virtual void setNativeInsertionPointColor(const Color4B& color) override;
     virtual void setNativePlaceholderFont(const char* pFontName, int fontSize) override;
     virtual void setNativePlaceholderFontColor(const Color4B& color) override;
     virtual void setNativeInputMode(EditBox::InputMode inputMode) override;

--- a/cocos/ui/UIEditBox/UIEditBoxImpl-ios.mm
+++ b/cocos/ui/UIEditBox/UIEditBoxImpl-ios.mm
@@ -113,6 +113,14 @@ void EditBoxImplIOS::setNativeFontColor(const Color4B& color)
 
 }
 
+void EditBoxImplIOS::setNativeInsertionPointColor(const Color4B& color)
+{
+    _systemControl.textInput.tintColor = [UIColor colorWithRed:color.r / 255.0f
+                                                        green:color.g / 255.0f
+                                                         blue:color.b / 255.0f
+                                                        alpha:color.a / 255.f];
+}
+
 void EditBoxImplIOS::setNativePlaceholderFont(const char* pFontName, int fontSize)
 {
     UIFont* textFont = constructFont(pFontName, fontSize);

--- a/cocos/ui/UIEditBox/UIEditBoxImpl-linux.h
+++ b/cocos/ui/UIEditBox/UIEditBoxImpl-linux.h
@@ -59,6 +59,7 @@ public:
     virtual void createNativeControl(const Rect& frame) override {}
     virtual void setNativeFont(const char* pFontName, int fontSize) override {}
     virtual void setNativeFontColor(const Color4B& color) override {}
+    virtual void setNativeInsertionPointColor(const Color4B& color) override {};
     virtual void setNativePlaceholderFont(const char* pFontName, int fontSize) override {}
     virtual void setNativePlaceholderFontColor(const Color4B& color) override {}
     virtual void setNativeInputMode(EditBox::InputMode inputMode) override {}

--- a/cocos/ui/UIEditBox/UIEditBoxImpl-mac.h
+++ b/cocos/ui/UIEditBox/UIEditBoxImpl-mac.h
@@ -59,6 +59,7 @@ public:
     virtual void createNativeControl(const Rect& frame) override;
     virtual void setNativeFont(const char* pFontName, int fontSize) override;
     virtual void setNativeFontColor(const Color4B& color) override;
+    virtual void setNativeInsertionPointColor(const Color4B& color) override;
     virtual void setNativePlaceholderFont(const char* pFontName, int fontSize) override;
     virtual void setNativePlaceholderFontColor(const Color4B& color) override;
     virtual void setNativeInputMode(EditBox::InputMode inputMode) override;

--- a/cocos/ui/UIEditBox/UIEditBoxImpl-mac.mm
+++ b/cocos/ui/UIEditBox/UIEditBoxImpl-mac.mm
@@ -134,6 +134,14 @@ void EditBoxImplMac::setNativeFontColor(const cocos2d::Color4B &color)
     [_sysEdit setTextColor:newColor];
 }
     
+void EditBoxImplMac::setNativeInsertionPointColor(const Color4B& color)
+{
+    [_sysEdit setInsertionPointColor:[NSColor colorWithCalibratedRed:color.r / 255.0f
+                                                         green:color.g / 255.0f
+                                                          blue:color.b / 255.0f
+                                                         alpha:color.a / 255.f]];
+}
+
 void EditBoxImplMac::setNativePlaceholderFontColor(const cocos2d::Color4B &color)
 {
     NSColor *newColor = [NSColor colorWithCalibratedRed:color.r/255.f

--- a/cocos/ui/UIEditBox/UIEditBoxImpl-win32.cpp
+++ b/cocos/ui/UIEditBox/UIEditBoxImpl-win32.cpp
@@ -158,6 +158,11 @@ namespace ui {
         //not implemented yet
     }
 
+    void EditBoxImplWin::setNativeInsertionPointColor(const Color4B& color)
+    {
+        //not implemented yet
+    }
+
     void EditBoxImplWin::setNativePlaceholderFont(const char* pFontName, int fontSize)
     {
         //not implemented yet

--- a/cocos/ui/UIEditBox/UIEditBoxImpl-win32.h
+++ b/cocos/ui/UIEditBox/UIEditBoxImpl-win32.h
@@ -48,6 +48,7 @@ namespace ui {
         virtual bool isEditing() override;
         virtual void createNativeControl(const Rect& frame) override;
         virtual void setNativeFont(const char* pFontName, int fontSize) override;
+        virtual void setNativeInsertionPointColor(const Color4B& color) override;
         virtual void setNativeFontColor(const Color4B& color) override;
         virtual void setNativePlaceholderFont(const char* pFontName, int fontSize) override;
         virtual void setNativePlaceholderFontColor(const Color4B& color) override;

--- a/cocos/ui/UIEditBox/UIEditBoxImpl-winrt.cpp
+++ b/cocos/ui/UIEditBox/UIEditBoxImpl-winrt.cpp
@@ -425,6 +425,11 @@ namespace cocos2d {
       _system_control->setFontColor(win_color);
     }
 
+    void UIEditBoxImplWinrt::setNativeInsertionPointColor(const Color4B& color)
+    {
+        //not implemented yet
+    }
+    
     void UIEditBoxImplWinrt::setNativeInputMode(EditBox::InputMode inputMode)
     {
       _system_control->setInputMode((int)inputMode);

--- a/cocos/ui/UIEditBox/UIEditBoxImpl-winrt.h
+++ b/cocos/ui/UIEditBox/UIEditBoxImpl-winrt.h
@@ -127,6 +127,7 @@ namespace ui {
     virtual void createNativeControl(const Rect& frame) override {  }
     virtual void setNativeFont(const char* pFontName, int fontSize) override;
     virtual void setNativeFontColor(const Color4B& color) override;
+    virtual void setNativeInsertionPointColor(const Color4B& color) override;
     virtual void setNativePlaceholderFont(const char* pFontName, int fontSize) override { CCLOG("Warning! You can't change WinRT placeholder font"); }
     virtual void setNativePlaceholderFontColor(const Color4B& color) override { CCLOG("Warning! You can't change WinRT placeholder font color"); }
     virtual void setNativeInputMode(EditBox::InputMode inputMode) override;

--- a/cocos/ui/UIEditBox/UIEditBoxImpl.h
+++ b/cocos/ui/UIEditBox/UIEditBoxImpl.h
@@ -49,6 +49,7 @@ namespace cocos2d {
             virtual bool initWithSize(const Size& size) = 0;
             virtual void setFont(const char* pFontName, int fontSize) = 0;
             virtual void setFontColor(const Color4B& color) = 0;
+            virtual void setInsertionPointColor(const Color4B& color) = 0;
             virtual void setPlaceholderFont(const char* pFontName, int fontSize) = 0;
             virtual void setPlaceholderFontColor(const Color4B& color) = 0;
             virtual void setInputMode(EditBox::InputMode inputMode) = 0;


### PR DESCRIPTION
The default text cursor color is black, if the background of editbox is also black, the cursor will be invisible, in that occation, we may want to change the text cursor color.

This patch adds `setInsertionPointColor` to `EditBox`, only implemented for `ios/mac`, leave other platforms unimplemented.


Example that uses this api is here: https://github.com/zhiqiangxu/client/blob/master/editor/Classes/EditorScene.cpp#L22