### PR TITLE
fix Wformat warnings

### DIFF
--- a/cocos/base/ccCArray.cpp
+++ b/cocos/base/ccCArray.cpp
@@ -72,9 +72,9 @@ void ccArrayEnsureExtraCapacity(ccArray *arr, ssize_t extra)
 {
 	while (arr->max < arr->num + extra)
     {
-        CCLOGINFO("cocos2d: ccCArray: resizing ccArray capacity from [%d] to [%d].",
-              static_cast<int>(arr->max),
-              static_cast<int>(arr->max*2));
+        CCLOGINFO("cocos2d: ccCArray: resizing ccArray capacity from [%zd] to [%zd].",
+              arr->max,
+              arr->max*2);
 
 		ccArrayDoubleCapacity(arr);
     }

--- a/cocos/scripting/js-bindings/manual/network/XMLHTTPRequest.cpp
+++ b/cocos/scripting/js-bindings/manual/network/XMLHTTPRequest.cpp
@@ -240,7 +240,7 @@ MinXmlHttpRequest::EncodingType MinXmlHttpRequest::_getEncodingType() const
     }
     else
     {
-        CCLOG("[error] bad unrecongized Content-Encoding value ", encodingTypeStr.c_str(), ", use \"identity\" as default");
+        CCLOG("[error] unrecongized Content-Encoding value %s, %s", encodingTypeStr.c_str(), "use \"identity\" as default");
         return EncodingType::IDENTITY;
     }
 }

--- a/tests/cpp-tests/Classes/FileUtilsTest/FileUtilsTest.cpp
+++ b/tests/cpp-tests/Classes/FileUtilsTest/FileUtilsTest.cpp
@@ -1413,7 +1413,7 @@ void TestListFiles::onEnter()
     std::vector<std::string> list = FileUtils::getInstance()->listFiles (defaultPath);
 
     char cntBuffer[200] = { 0 };
-    snprintf(cntBuffer, 200, "'fonts/' %d, $defaultResourceRootPath %d",listFonts.size(), list.size());
+    snprintf(cntBuffer, 200, "'fonts/' %zu, $defaultResourceRootPath %zu",listFonts.size(), list.size());
 
     for(int i=0;i<listFonts.size();i++)
     {


### PR DESCRIPTION
* Don't static_cast `ssize_t` type to `int`, use `zd` for what is supposed to do

* use `zu` for `size_t`