### PR TITLE
clang tidy modernize redundant void arg

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -24,6 +24,7 @@ Checks: >
   bugprone-forwarding-reference-overload,
   bugprone-inaccurate-erase,
   bugprone-incorrect-roundings,
+  modernize-redundant-void-arg,
 
 WarningsAsErrors: '*'
 HeaderFilterRegex: '/(?!external)/.*'

--- a/cocos/scripting/js-bindings/auto/jsb_cocos2dx_auto.cpp
+++ b/cocos/scripting/js-bindings/auto/jsb_cocos2dx_auto.cpp
@@ -19069,7 +19069,7 @@ bool js_cocos2dx_FileUtils_getStringFromFile(JSContext *cx, uint32_t argc, jsval
 			    {
 			        JS::RootedObject jstarget(cx, args.thisv().toObjectOrNull());
 			        std::shared_ptr<JSFunctionWrapper> func(new JSFunctionWrapper(cx, jstarget, args.get(1), args.thisv()));
-			        auto lambda = [=](std::string larg0) -> void {
+			        auto lambda = [=](const std::string& larg0) -> void {
 			            JSB_AUTOCOMPARTMENT_WITH_GLOBAL_OBJCET
 			            jsval largv[1];
 			            largv[0] = std_string_to_jsval(cx, larg0);

--- a/cocos/scripting/js-bindings/auto/jsb_cocos2dx_extension_auto.cpp
+++ b/cocos/scripting/js-bindings/auto/jsb_cocos2dx_extension_auto.cpp
@@ -6737,7 +6737,7 @@ bool js_cocos2dx_extension_AssetsManagerEx_setVerifyCallback(JSContext *cx, uint
 		    {
 		        JS::RootedObject jstarget(cx, args.thisv().toObjectOrNull());
 		        std::shared_ptr<JSFunctionWrapper> func(new JSFunctionWrapper(cx, jstarget, args.get(0), args.thisv()));
-		        auto lambda = [=](const std::string& larg0, cocos2d::extension::ManifestAsset larg1) -> bool {
+		        auto lambda = [=](const std::string& larg0, const cocos2d::extension::ManifestAsset& larg1) -> bool {
 		            JSB_AUTOCOMPARTMENT_WITH_GLOBAL_OBJCET
 		            jsval largv[2];
 		            largv[0] = std_string_to_jsval(cx, larg0);

--- a/tests/cpp-tests/Classes/ActionManagerTest/ActionManagerTest.cpp
+++ b/tests/cpp-tests/Classes/ActionManagerTest/ActionManagerTest.cpp
@@ -53,11 +53,11 @@ ActionManagerTests::ActionManagerTests()
 //
 //------------------------------------------------------------------
 
-ActionManagerTest::ActionManagerTest(void)
+ActionManagerTest::ActionManagerTest()
 {
 }
 
-ActionManagerTest::~ActionManagerTest(void)
+ActionManagerTest::~ActionManagerTest()
 {
 }
 

--- a/tests/cpp-tests/Classes/ActionsEaseTest/ActionsEaseTest.cpp
+++ b/tests/cpp-tests/Classes/ActionsEaseTest/ActionsEaseTest.cpp
@@ -1003,11 +1003,11 @@ ActionsEaseTests::ActionsEaseTests()
     ADD_TEST_CASE(SpeedTest);
 }
 
-EaseSpriteDemo::EaseSpriteDemo(void)
+EaseSpriteDemo::EaseSpriteDemo()
 {
 }
 
-EaseSpriteDemo::~EaseSpriteDemo(void)
+EaseSpriteDemo::~EaseSpriteDemo()
 {
     _grossini->release();
     _tamara->release();

--- a/tests/cpp-tests/Classes/ActionsProgressTest/ActionsProgressTest.cpp
+++ b/tests/cpp-tests/Classes/ActionsProgressTest/ActionsProgressTest.cpp
@@ -45,11 +45,11 @@ ActionsProgressTests::ActionsProgressTests()
 // SpriteDemo
 //
 //------------------------------------------------------------------
-SpriteDemo::SpriteDemo(void)
+SpriteDemo::SpriteDemo()
 {
 }
 
-SpriteDemo::~SpriteDemo(void)
+SpriteDemo::~SpriteDemo()
 {
 }
 

--- a/tests/cpp-tests/Classes/Box2DTestBed/Box2dView.cpp
+++ b/tests/cpp-tests/Classes/Box2DTestBed/Box2dView.cpp
@@ -128,7 +128,7 @@ void Box2dTestBed::onTouchMoved(Touch* touch, Event* event)
 // Box2DView
 //
 //------------------------------------------------------------------
-Box2DView::Box2DView(void)
+Box2DView::Box2DView()
 {
 }
 

--- a/tests/cpp-tests/Classes/Box2DTestBed/GLES-Render.cpp
+++ b/tests/cpp-tests/Classes/Box2DTestBed/GLES-Render.cpp
@@ -38,7 +38,7 @@ GLESDebugDraw::GLESDebugDraw( float32 ratio )
     this->initShader();
 }
 
-void GLESDebugDraw::initShader( void )
+void GLESDebugDraw::initShader( )
 {
     mShaderProgram = GLProgramCache::getInstance()->getGLProgram(GLProgram::SHADER_NAME_POSITION_U_COLOR);
 

--- a/tests/cpp-tests/Classes/Camera3DTest/Camera3DTest.cpp
+++ b/tests/cpp-tests/Classes/Camera3DTest/Camera3DTest.cpp
@@ -176,7 +176,7 @@ void CameraRotationTest::update(float dt)
 // Camera3DTestDemo
 //
 //------------------------------------------------------------------
-Camera3DTestDemo::Camera3DTestDemo(void)
+Camera3DTestDemo::Camera3DTestDemo()
 : _cameraType(CameraType::Free)
 , _incRot(nullptr)
 , _decRot(nullptr)
@@ -187,7 +187,7 @@ Camera3DTestDemo::Camera3DTestDemo(void)
 , _bRotateRight(false)
 {
 }
-Camera3DTestDemo::~Camera3DTestDemo(void)
+Camera3DTestDemo::~Camera3DTestDemo()
 {
 }
 void Camera3DTestDemo::reachEndCallBack()
@@ -701,7 +701,7 @@ void Camera3DTestDemo::onTouchesRotateRightEnd(Touch* touch, Event* event)
 
 ////////////////////////////////////////////////////////////
 // CameraCullingDemo
-CameraCullingDemo::CameraCullingDemo(void)
+CameraCullingDemo::CameraCullingDemo()
 : _layer3D(nullptr)
 , _cameraType(CameraType::FirstPerson)
 , _cameraFirst(nullptr)
@@ -712,7 +712,7 @@ CameraCullingDemo::CameraCullingDemo(void)
 , _row(3)
 {
 }
-CameraCullingDemo::~CameraCullingDemo(void)
+CameraCullingDemo::~CameraCullingDemo()
 {
 }
 
@@ -982,7 +982,7 @@ void CameraCullingDemo::drawCameraFrustum()
 
 ////////////////////////////////////////////////////////////
 // CameraArcBallDemo
-CameraArcBallDemo::CameraArcBallDemo(void)
+CameraArcBallDemo::CameraArcBallDemo()
 : CameraBaseTest()
 , _layer3D(nullptr)
 , _cameraType(CameraType::Free)
@@ -997,7 +997,7 @@ CameraArcBallDemo::CameraArcBallDemo(void)
 , _sprite3D2(nullptr)
 {
 }
-CameraArcBallDemo::~CameraArcBallDemo(void)
+CameraArcBallDemo::~CameraArcBallDemo()
 {
 }
 
@@ -1204,7 +1204,7 @@ void CameraArcBallDemo::update(float dt)
 
 ////////////////////////////////////////////////////////////
 // FogTestDemo
-FogTestDemo::FogTestDemo(void)
+FogTestDemo::FogTestDemo()
 : CameraBaseTest()
 , _layer3D(nullptr)
 , _cameraType(CameraType::Free)
@@ -1213,7 +1213,7 @@ FogTestDemo::FogTestDemo(void)
 , _state(nullptr)
 {
 }
-FogTestDemo::~FogTestDemo(void)
+FogTestDemo::~FogTestDemo()
 {
 }
 

--- a/tests/cpp-tests/Classes/ConsoleTest/ConsoleTest.cpp
+++ b/tests/cpp-tests/Classes/ConsoleTest/ConsoleTest.cpp
@@ -55,7 +55,7 @@ BaseTestConsole::BaseTestConsole()
 {
 }
 
-BaseTestConsole::~BaseTestConsole(void)
+BaseTestConsole::~BaseTestConsole()
 {
 }
 

--- a/tests/cpp-tests/Classes/EffectsAdvancedTest/EffectsAdvancedTest.cpp
+++ b/tests/cpp-tests/Classes/EffectsAdvancedTest/EffectsAdvancedTest.cpp
@@ -307,7 +307,7 @@ std::string Issue631::subtitle() const
 //
 //------------------------------------------------------------------
 
-void EffectAdvanceBaseTest::onEnter(void)
+void EffectAdvanceBaseTest::onEnter()
 {
     TestCase::onEnter();
     
@@ -344,7 +344,7 @@ void EffectAdvanceBaseTest::onEnter(void)
 
 }
 
-EffectAdvanceBaseTest::~EffectAdvanceBaseTest(void)
+EffectAdvanceBaseTest::~EffectAdvanceBaseTest()
 {
 }
 

--- a/tests/cpp-tests/Classes/EffectsTest/EffectsTest.cpp
+++ b/tests/cpp-tests/Classes/EffectsTest/EffectsTest.cpp
@@ -402,6 +402,6 @@ void EffectBaseTest::checkAnim(float dt)
         _gridNodeTarget->setGrid(nullptr);
 }
 
-EffectBaseTest::~EffectBaseTest(void)
+EffectBaseTest::~EffectBaseTest()
 {
 }

--- a/tests/cpp-tests/Classes/ExtensionsTest/NetworkTest/SocketIOTest.cpp
+++ b/tests/cpp-tests/Classes/ExtensionsTest/NetworkTest/SocketIOTest.cpp
@@ -108,7 +108,7 @@ SocketIOTest::SocketIOTest()
 }
 
 
-SocketIOTest::~SocketIOTest(void)
+SocketIOTest::~SocketIOTest()
 {
 }
 

--- a/tests/cpp-tests/Classes/MotionStreakTest/MotionStreakTest.cpp
+++ b/tests/cpp-tests/Classes/MotionStreakTest/MotionStreakTest.cpp
@@ -237,11 +237,11 @@ std::string Issue12226::subtitle() const
 //
 //------------------------------------------------------------------
 
-MotionStreakTest::MotionStreakTest(void)
+MotionStreakTest::MotionStreakTest()
 {
 }
 
-MotionStreakTest::~MotionStreakTest(void)
+MotionStreakTest::~MotionStreakTest()
 {
 }
 

--- a/tests/cpp-tests/Classes/NavMeshTest/NavMeshTest.cpp
+++ b/tests/cpp-tests/Classes/NavMeshTest/NavMeshTest.cpp
@@ -63,14 +63,14 @@ void NavMeshDisabled::onEnter()
 }
 #else
 
-NavMeshBaseTestDemo::NavMeshBaseTestDemo(void)
+NavMeshBaseTestDemo::NavMeshBaseTestDemo()
     : _camera(nullptr)
     , _needMoveAgents(false)
 {
 
 }
 
-NavMeshBaseTestDemo::~NavMeshBaseTestDemo(void)
+NavMeshBaseTestDemo::~NavMeshBaseTestDemo()
 {
     for (auto iter : _agents){
         AgentUserData *data = static_cast<AgentUserData *>(iter.first->getUserData());
@@ -263,12 +263,12 @@ void NavMeshBaseTestDemo::update(float delta)
     }
 }
 
-NavMeshBasicTestDemo::NavMeshBasicTestDemo(void)
+NavMeshBasicTestDemo::NavMeshBasicTestDemo()
 {
 
 }
 
-NavMeshBasicTestDemo::~NavMeshBasicTestDemo(void)
+NavMeshBasicTestDemo::~NavMeshBasicTestDemo()
 {
 }
 
@@ -335,12 +335,12 @@ void NavMeshBasicTestDemo::onEnter()
     createAgent(result.hitPosition);
 }
 
-NavMeshAdvanceTestDemo::NavMeshAdvanceTestDemo(void)
+NavMeshAdvanceTestDemo::NavMeshAdvanceTestDemo()
 {
 
 }
 
-NavMeshAdvanceTestDemo::~NavMeshAdvanceTestDemo(void)
+NavMeshAdvanceTestDemo::~NavMeshAdvanceTestDemo()
 {
 
 }

--- a/tests/cpp-tests/Classes/NodeTest/NodeTest.cpp
+++ b/tests/cpp-tests/Classes/NodeTest/NodeTest.cpp
@@ -76,11 +76,11 @@ CocosNodeTests::CocosNodeTests()
     ADD_TEST_CASE(Issue16735Test);
 }
 
-TestCocosNodeDemo::TestCocosNodeDemo(void)
+TestCocosNodeDemo::TestCocosNodeDemo()
 {
 }
 
-TestCocosNodeDemo::~TestCocosNodeDemo(void)
+TestCocosNodeDemo::~TestCocosNodeDemo()
 {
 }
 

--- a/tests/cpp-tests/Classes/Particle3DTest/Particle3DTest.cpp
+++ b/tests/cpp-tests/Classes/Particle3DTest/Particle3DTest.cpp
@@ -113,7 +113,7 @@ void Particle3DTestDemo::onTouchesEnded(const std::vector<Touch*>& touches, coco
     
 }
 
-Particle3DTestDemo::Particle3DTestDemo( void )
+Particle3DTestDemo::Particle3DTestDemo()
 : _angle(0.0f)
 {
 
@@ -138,7 +138,7 @@ void Particle3DTestDemo::update( float delta )
     }
 }
 
-Particle3DTestDemo::~Particle3DTestDemo( void )
+Particle3DTestDemo::~Particle3DTestDemo()
 {
     _particleLab->release();
 }

--- a/tests/cpp-tests/Classes/ParticleTest/ParticleTest.cpp
+++ b/tests/cpp-tests/Classes/ParticleTest/ParticleTest.cpp
@@ -1075,12 +1075,12 @@ ParticleTests::ParticleTests()
     ADD_TEST_CASE(ParticleSpriteFrame);
 }
 
-ParticleDemo::~ParticleDemo(void)
+ParticleDemo::~ParticleDemo()
 {
     CC_SAFE_RELEASE(_emitter);
 }
 
-void ParticleDemo::onEnter(void)
+void ParticleDemo::onEnter()
 {
     TestCase::onEnter();
 

--- a/tests/cpp-tests/Classes/Physics3DTest/Physics3DTest.cpp
+++ b/tests/cpp-tests/Classes/Physics3DTest/Physics3DTest.cpp
@@ -176,7 +176,7 @@ void Physics3DTestDemo::onTouchesEnded(const std::vector<Touch*>& touches, cocos
     }
 }
 
-Physics3DTestDemo::Physics3DTestDemo( void )
+Physics3DTestDemo::Physics3DTestDemo()
 : _angle(0.0f)
 , _camera(nullptr)
 {
@@ -188,7 +188,7 @@ void Physics3DTestDemo::update( float /*delta*/ )
     
 }
 
-Physics3DTestDemo::~Physics3DTestDemo( void )
+Physics3DTestDemo::~Physics3DTestDemo()
 {
     
 }

--- a/tests/cpp-tests/Classes/PhysicsTest/PhysicsTest.cpp
+++ b/tests/cpp-tests/Classes/PhysicsTest/PhysicsTest.cpp
@@ -180,7 +180,7 @@ namespace
         return (LOGO_IMAGE[(x >> 3) + y * LOGO_RAW_LENGTH] >> (~x & 0x7)) & 1;
     }
     
-    float frand(void)
+    float frand()
     {
         return rand() / RAND_MAX;
     }

--- a/tests/cpp-tests/Classes/TileMapTest/TileMapTest.cpp
+++ b/tests/cpp-tests/Classes/TileMapTest/TileMapTest.cpp
@@ -94,7 +94,7 @@ TileDemo::TileDemo()
     _eventDispatcher->addEventListenerWithSceneGraphPriority(listener, this);
 }
 
-TileDemo::~TileDemo(void)
+TileDemo::~TileDemo()
 {
 }
 

--- a/tests/cpp-tests/Classes/TouchesTest/Ball.cpp
+++ b/tests/cpp-tests/Classes/TouchesTest/Ball.cpp
@@ -28,11 +28,11 @@
 
 USING_NS_CC;
 
-Ball::Ball(void)
+Ball::Ball()
 {
 }
 
-Ball::~Ball(void)
+Ball::~Ball()
 {
 }
 

--- a/tests/cpp-tests/Classes/TouchesTest/Paddle.cpp
+++ b/tests/cpp-tests/Classes/TouchesTest/Paddle.cpp
@@ -26,11 +26,11 @@
 
 USING_NS_CC;
 
-Paddle::Paddle(void)
+Paddle::Paddle()
 {
 }
 
-Paddle::~Paddle(void)
+Paddle::~Paddle()
 {
 }
 


### PR DESCRIPTION
* add new clang-tidy option above
* fix warnings from performance-unnecessary-value-param

1. This commit changes `int f(void)` to `int f()`, removing redundant void arg.

2. The `performance-unnecessary-value-param` warnings are introduced from this PR, [updating luabinding & jsbinding & cocos_file.json automatically](https://github.com/cocos2d/cocos2d-x/pull/19895). Is this generated by a script, and how can we fix it? It went through because [ci skip] is used.

Reference: https://releases.llvm.org/7.0.0/tools/clang/tools/extra/docs/clang-tidy/checks/modernize-redundant-void-arg.html