### PR TITLE
refactor ObjectFactory

### DIFF
--- a/cocos/base/ObjectFactory.cpp
+++ b/cocos/base/ObjectFactory.cpp
@@ -24,69 +24,26 @@ THE SOFTWARE.
 ****************************************************************************/
 
 #include "base/ObjectFactory.h"
-#include <functional>
 #include <utility>
 
 
 NS_CC_BEGIN
 
-ObjectFactory::TInfo::TInfo()
-:_class("")
-,_fun(nullptr)
-,_func(nullptr)
-{
-}
-
 ObjectFactory::TInfo::TInfo(const std::string& type, Instance ins)
 :_class(type)
 ,_fun(ins)
-,_func(nullptr)
 {
     ObjectFactory::getInstance()->registerType(*this);
 }
 
 ObjectFactory::TInfo::TInfo(const std::string& type, const InstanceFunc& ins)
-    :_class(type)
-    ,_fun(nullptr)
-    ,_func(ins)
+:_class(type)
+,_func(ins)
 {
     ObjectFactory::getInstance()->registerType(*this);
 }
 
-ObjectFactory::TInfo::TInfo(const TInfo &t)
-{
-    _class = t._class;
-    _fun = t._fun;
-    _func = t._func;
-}
-
-ObjectFactory::TInfo::~TInfo()
-{
-   _class = "";
-   _fun = nullptr;
-   _func = nullptr;
-}
-
-ObjectFactory::TInfo& ObjectFactory::TInfo::operator= (const TInfo &t)
-{
-    _class = t._class;
-    _fun = t._fun;
-    _func = t._func;
-    return *this;
-}
-
-
 ObjectFactory* ObjectFactory::_sharedFactory = nullptr;
-
-ObjectFactory::ObjectFactory()
-{
-
-}
-
-ObjectFactory::~ObjectFactory()
-{
-    _typeMap.clear();
-}
 
 ObjectFactory* ObjectFactory::getInstance()
 {
@@ -104,20 +61,14 @@ void ObjectFactory::destroyInstance()
 
 Ref* ObjectFactory::createObject(const std::string &name)
 {
-    Ref *o = nullptr;
-    do 
-    {
-        const TInfo t = _typeMap[name];
-        if (t._fun != nullptr)
-        {
-            o = t._fun();
-        }else if (t._func != nullptr)
-        {
-            o = t._func();
-        }
-    } while (0);
-   
-    return o;
+    const TInfo t = _typeMap[name];
+    if (t._fun != nullptr) {
+        return t._fun();
+    }
+    if (t._func != nullptr) {
+        return t._func();
+    }
+    return nullptr;
 }
 
 void ObjectFactory::registerType(const TInfo &t)

--- a/cocos/base/ObjectFactory.h
+++ b/cocos/base/ObjectFactory.h
@@ -26,11 +26,11 @@ THE SOFTWARE.
 #ifndef __TRIGGERFACTORY_H__
 #define __TRIGGERFACTORY_H__
 
-#include <string>
-#include <unordered_map>
-#include <functional>
 #include "base/CCRef.h"
 #include "platform/CCPlatformMacros.h"
+#include <functional>
+#include <string>
+#include <unordered_map>
 
 NS_CC_BEGIN
 
@@ -41,31 +41,26 @@ public:
     typedef std::function<cocos2d::Ref* ()> InstanceFunc;
     struct CC_DLL TInfo
     {
-        TInfo();
-        TInfo(const std::string& type, Instance ins = nullptr);
-        TInfo(const std::string& type, const InstanceFunc& ins = nullptr);
-        TInfo(const TInfo &t);
-        ~TInfo();
-        TInfo& operator= (const TInfo &t);
+        TInfo() = default;
+        TInfo(const std::string& type, Instance ins);
+        TInfo(const std::string& type, const InstanceFunc& ins);
         std::string _class;
-        Instance _fun;
+        Instance _fun = nullptr;
         InstanceFunc _func;
     };
-    typedef std::unordered_map<std::string, TInfo>  FactoryMap;
 
     static ObjectFactory* getInstance();
     static void destroyInstance();
-    cocos2d::Ref* createObject(const std::string &name);
 
+    cocos2d::Ref* createObject(const std::string &name);
     void registerType(const TInfo &t);
-    void removeAll();
 
 protected:
-    ObjectFactory();
-    virtual ~ObjectFactory();
+    ObjectFactory() = default;
+    virtual ~ObjectFactory() = default;
 private:
     static ObjectFactory *_sharedFactory;
-    FactoryMap _typeMap;
+    std::unordered_map<std::string, TInfo> _typeMap;
 };
 
 NS_CC_END


### PR DESCRIPTION
* remove redundant copy constructor, copy assignment operator, and
destructor in TInfo.
* prefer in-class member initialization.
* remove <functional> in cpp file as it's already included in header file.