### PR TITLE
Fix error with update line height

### DIFF
--- a/cocos/2d/CCFontAtlas.cpp
+++ b/cocos/2d/CCFontAtlas.cpp
@@ -72,6 +72,12 @@ FontAtlas::FontAtlas(Font &theFont)
             _letterPadding += 2 * FontFreeType::DistanceMapSpread;    
         }
 
+        auto outlineSize = _fontFreeType->getOutlineSize();
+        if (outlineSize > 0)
+        {
+            _lineHeight += 2 * outlineSize;
+        }
+
 #if CC_ENABLE_CACHE_TEXTURE_DATA
         auto eventDispatcher = Director::getInstance()->getEventDispatcher();
 
@@ -96,7 +102,6 @@ void FontAtlas::reinit()
     auto outlineSize = _fontFreeType->getOutlineSize();
     if(outlineSize > 0)
     {
-        _lineHeight += 2 * outlineSize;
         _currentPageDataSize *= 2;
     }
     


### PR DESCRIPTION
After movig font atlas `reinit()` (https://github.com/cocos2d/cocos2d-x/pull/19384) there was indused a problem: the first display of text with a outline in the label does not update line height. This is because the atlas `reinit()` does not occur when the outline is activated. In this case, a new atlas will be created, but the line height will not be taken from it, because line height calculate in `updateContent()`. I propose line height calculating to return to the font atlas constructor.