### PR TITLE
Fix cocos2d-js issue: Font height was not getting calculated properly in iOS.

### DIFF
--- a/cocos/platform/ios/CCDevice-ios.mm
+++ b/cocos/platform/ios/CCDevice-ios.mm
@@ -145,7 +145,7 @@ static CGSize _calculateShrinkedSizeForString(NSAttributedString **str,
             *str = __attributedStringWithFontSize(mutableString, fontSize);
             
             CGSize fitSize = [*str boundingRectWithSize:CGSizeMake(constrainSize.width, MAX_MEASURE_HEIGHT)
-                                    options:(NSStringDrawingUsesLineFragmentOrigin|NSStringDrawingUsesFontLeading)
+                                    options:(NSStringDrawingUsesLineFragmentOrigin)
                                     context:nil].size;
 
             if (fitSize.width == 0 || fitSize.height == 0) {
@@ -364,7 +364,7 @@ static CGSize _calculateStringSize(NSAttributedString *str, id font, CGSize *con
 
     CGSize dim;
     dim = [str boundingRectWithSize:CGSizeMake(textRect.width, textRect.height)
-                                 options:(NSStringDrawingUsesLineFragmentOrigin|NSStringDrawingUsesFontLeading)
+                                 options:(NSStringDrawingUsesLineFragmentOrigin)
                             context:nil].size;
 
     dim.width = ceilf(dim.width);


### PR DESCRIPTION
For calculating font height for iOS we were using wrong option. We were using [nsstringdrawingusesfontleading](https://developer.apple.com/documentation/uikit/nsstringdrawingoptions/nsstringdrawingusesfontleading?language=objc) which include [font leading](https://en.wikipedia.org/wiki/Leading)(Extra padding need to be added before starting next line) in total height. Due to this text was not getting vertically middled properly. We should only use NSStringDrawingUsesLineFragmentOrigin as it automatically include font leading in case we provide multiline text. 

You can use calibri font to check the issue.