### PR TITLE
disable clang-tidy checks on script bindings code

### DIFF
--- a/tools/travis-scripts/run-script.sh
+++ b/tools/travis-scripts/run-script.sh
@@ -45,8 +45,8 @@ function build_linux_clang_tidy()
     cd clang-tidy-build
     cmake ../.. -DCMAKE_EXPORT_COMPILE_COMMANDS=on
     clang_tidy_script=$(dirname $(dirname $(readlink -f `which clang-tidy`)))/share/clang/run-clang-tidy.py 
-    # run clang-tidy on all files except those in external directory
-    python $clang_tidy_script '^((?!/cocos2d-x/external/).)*$'
+    # disable clang-tidy checks on external directory and cocos/scripting directory
+    python $clang_tidy_script '^((?!/cocos2d-x/external/|/cocos/scripting/).)*$'
 }
 
 function build_mac()


### PR DESCRIPTION
This PR is based on previous discussion, https://github.com/cocos2d/cocos2d-x/pull/19900#issuecomment-512639299

Here is a simple test case for the new regular expression

    '^((?!/cocos2d-x/external/|/cocos/scripting/).)*$'

It disables clang-tidy checks on `external` directory and `cocos/scripting` directory.

```python
#!/usr/bin/env python
import re

files = [ 
"/home/john/cocos2d-x/external/openssl/include/linux/openssl/bio.h",
"/home/john/cocos2d-x/external/tiff/include/linux/tiff.h",
"/home/john/git/cocos/cocos2d-x/cocos/scripting/lua-bindings/auto/lua_cocos2dx_3d_auto.cpp"
"/home/john/cocos2d-x/external/json/stringbuffer.h",
"/home/john/cocos2d-x/cocos/base/ccUtils.h",
"/home/john/git/cocos/cocos2d-x/cocos/scripting/js-bindings/precheader.cpp",
"/home/john/cocos2d-x/cocos/physics/CCPhysicsBody.cpp",
"/home/john/cocos2d-x/tests/cpp-tests/Classes/ActionsEaseTest/ActionsEaseTest.cpp",
"/home/john/cocos2d-x/templates/cpp-template-default/Classes/AppDelegate.cpp",
"/home/john/git/cocos/cocos2d-x/cocos/scripting/js-bindings/proj.android/CMakeLists.txt",
]

pattern = '^((?!/cocos2d-x/external/|/cocos/scripting/).)*$'

for file in files:
    m = re.search(pattern, file)
    if m:
        print m.group(0)
```
The output is

```bash
/home/john/cocos2d-x/cocos/base/ccUtils.h
/home/john/cocos2d-x/cocos/physics/CCPhysicsBody.cpp
/home/john/cocos2d-x/tests/cpp-tests/Classes/ActionsEaseTest/ActionsEaseTest.cpp
/home/john/cocos2d-x/templates/cpp-template-default/Classes/AppDelegate.cpp
```