### PR TITLE
remove duplicate function call in cmake (#19697)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,6 @@ set(CMAKE_MODULE_PATH ${COCOS2DX_ROOT_PATH}/cmake/Modules/)
 
 # prevent in-source-build
 include(PreventInSourceBuilds)
-AssureOutOfSourceBuilds()
 
 # works before build libcocos2d
 include(CocosBuildSet)


### PR DESCRIPTION
* AssureOutOfSourceBuilds() is called in module file. No need to
call it in root cmake file.