### PR TITLE
refactor AudioEngine-Linux (#19822)

### DIFF
--- a/cocos/audio/AudioEngine.cpp
+++ b/cocos/audio/AudioEngine.cpp
@@ -345,7 +345,7 @@ void AudioEngine::remove(int audioID)
             it->second.profileHelper->audioIDs.remove(audioID);
         }
         _audioPathIDMap[*it->second.filePath].remove(audioID);
-        _audioIDInfoMap.erase(audioID);
+        _audioIDInfoMap.erase(it);
     }
 }
 
@@ -390,16 +390,13 @@ void AudioEngine::uncache(const std::string &filePath)
                 {
                     itInfo->second.profileHelper->audioIDs.remove(audioID);
                 }
-                _audioIDInfoMap.erase(audioID);
+                _audioIDInfoMap.erase(itInfo);
             }
         }
         _audioPathIDMap.erase(filePath);
     }
 
-    if (_audioEngineImpl)
-    {
-        _audioEngineImpl->uncache(filePath);
-    }
+    _audioEngineImpl->uncache(filePath);
 }
 
 void AudioEngine::uncacheAll()

--- a/cocos/audio/linux/AudioEngine-linux.cpp
+++ b/cocos/audio/linux/AudioEngine-linux.cpp
@@ -72,8 +72,6 @@ AudioEngineImpl::AudioEngineImpl()
 AudioEngineImpl::~AudioEngineImpl()
 {
     FMOD_RESULT result;
-    result = pSystem->close();
-    ERRCHECKWITHEXIT(result);
     result = pSystem->release();
     ERRCHECKWITHEXIT(result);
 }
@@ -109,7 +107,8 @@ int AudioEngineImpl::play2d(const std::string &fileFullPath, bool loop, float vo
     int id = preload(fileFullPath, nullptr);
     if (id >= 0) {
         mapChannelInfo[id].loop=loop;
-        mapChannelInfo[id].channel->setPaused(true);
+        // channel is null here. Don't dereference it. It's only set in resume(id).
+        //mapChannelInfo[id].channel->setPaused(true);
         mapChannelInfo[id].volume = volume;
         AudioEngine::_audioIDInfoMap[id].state = AudioEngine::AudioState::PAUSED;
         resume(id);
@@ -287,8 +286,7 @@ void AudioEngineImpl::uncache(const std::string& path)
         }
         mapSound.erase(it);
     }
-    if (mapId.find(path) != mapId.end())
-        mapId.erase(path);
+    mapId.erase(path);
 }
 
 void AudioEngineImpl::uncacheAll()
@@ -320,10 +318,9 @@ int AudioEngineImpl::preload(const std::string& filePath, std::function<void(boo
     }
 
     int id = static_cast<int>(mapChannelInfo.size()) + 1;
-    if (mapId.find(filePath) == mapId.end())
-        mapId.insert({filePath, id});
-    else
-        id = mapId.at(filePath);
+    // std::map::insert returns std::pair<iter, bool>
+    auto channelInfoIter = mapId.insert({filePath, id});
+    id = channelInfoIter.first->second;
 
     auto& chanelInfo = mapChannelInfo[id];
     chanelInfo.sound = sound;


### PR DESCRIPTION
* refactor AudioEngine and AudioEngine-linux

* map::erase() can handle case if key doesn't exist.

* use map::iterator when it has already obtained.

* mapChannelInfo[id].channel is nullptr befor resume(). Don't
dereference it.

* FMOD::System::release() calls close, so calling close before release
is not necessary.

* use std::map::insert properly.

* remove unnecessary null check on _audioEngineImpl

* add comment on nullptr dereference