### PR TITLE
fix memory leak in CCUserDefault (#19853)

### DIFF
--- a/cocos/base/CCUserDefault.cpp
+++ b/cocos/base/CCUserDefault.cpp
@@ -324,7 +324,7 @@ Data UserDefault::getDataForKey(const char* pKey, const Data& defaultValue)
         encodedData = (const char*)(node->FirstChild()->Value());
     }
     
-    Data ret = defaultValue;
+    Data ret;
     
     if (encodedData)
     {
@@ -334,6 +334,10 @@ Data UserDefault::getDataForKey(const char* pKey, const Data& defaultValue)
         if (decodedData) {
             ret.fastSet(decodedData, decodedDataLen);
         }
+    }
+    else
+    {
+        ret = defaultValue;
     }
     
     if (doc) delete doc;


### PR DESCRIPTION
fastSet makes the Data object managing a new memory area in
[bytes, bytes + size), but it doesn't releasing the old data
it managed. Failure to release the old data causes memory leak.

The default constructed Data manages null memory, so calling
fastSet on it is fine.

Because `Data ret = defaultValue;` malloc new memory, we might
have better performance without it.