### PR TITLE
clang-tidy clang-tidy-modernize-use-emplace

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -25,6 +25,7 @@ Checks: >
   bugprone-inaccurate-erase,
   bugprone-incorrect-roundings,
   modernize-redundant-void-arg,
+  modernize-use-emplace,
 
 WarningsAsErrors: '*'
 HeaderFilterRegex: '/(?!external)/.*'

--- a/cocos/2d/CCAutoPolygon.cpp
+++ b/cocos/2d/CCAutoPolygon.cpp
@@ -416,7 +416,7 @@ std::vector<cocos2d::Vec2> AutoPolygon::marchSquare(const Rect& rect, const Vec2
         }
         else
         {
-            _points.push_back(Vec2((float)(curx - rect.origin.x) / _scaleFactor, (float)(rect.size.height - cury + rect.origin.y) / _scaleFactor));
+            _points.emplace_back((float)(curx - rect.origin.x) / _scaleFactor, (float)(rect.size.height - cury + rect.origin.y) / _scaleFactor);
         }
 
         count++;
@@ -569,7 +569,7 @@ std::vector<Vec2> AutoPolygon::expand(const std::vector<Vec2>& points, const coc
     }
     for(const auto& pt : p2->Contour)
     {
-        outPoints.push_back(Vec2(pt.X/PRECISION, pt.Y/PRECISION));
+        outPoints.emplace_back(pt.X/PRECISION, pt.Y/PRECISION);
     }
     return outPoints;
 }

--- a/cocos/3d/CCBundle3D.cpp
+++ b/cocos/3d/CCBundle3D.cpp
@@ -314,7 +314,7 @@ bool Bundle3D::loadObj(MeshDatas& meshdatas, MaterialDatas& materialdatas, NodeD
                 meshdata->subMeshIndices.push_back(submesh.second);
                 meshdata->subMeshAABB.push_back(calculateAABB(meshdata->vertex, meshdata->getPerVertexSize(), submesh.second));
                 sprintf(str, "%d", ++i);
-                meshdata->subMeshIds.push_back(str);
+                meshdata->subMeshIds.emplace_back(str);
                 
                 auto modelnode = new (std::nothrow) ModelData();
                 modelnode->materialId = submesh.first == -1 ? "" : materials[submesh.first].name;
@@ -474,7 +474,7 @@ bool  Bundle3D::loadMeshDatasBinary(MeshDatas& meshdatas)
                     CCLOG("warning: Failed to read meshdata: aabb '%s'.", _path.c_str());
                     goto FAILED;
                 }
-                meshData->subMeshAABB.push_back(AABB(Vec3(aabb[0], aabb[1], aabb[2]), Vec3(aabb[3], aabb[4], aabb[5])));
+                meshData->subMeshAABB.emplace_back(Vec3(aabb[0], aabb[1], aabb[2]), Vec3(aabb[3], aabb[4], aabb[5]));
             }
             else
             {
@@ -774,7 +774,7 @@ bool  Bundle3D::loadMeshDatasJson(MeshDatas& meshdatas)
         {
             std::vector<unsigned short>      indexArray;
             const rapidjson::Value& mesh_part = mesh_part_array[i];
-            meshData->subMeshIds.push_back(mesh_part[ID].GetString());
+            meshData->subMeshIds.emplace_back(mesh_part[ID].GetString());
             // index_number
             const rapidjson::Value& indices_val_array = mesh_part[INDICES];
             for (rapidjson::SizeType j = 0, indices_val_array_size = indices_val_array.Size(); j < indices_val_array_size; ++j)
@@ -792,7 +792,7 @@ bool  Bundle3D::loadMeshDatasJson(MeshDatas& meshdatas)
                              mesh_part_aabb[(rapidjson::SizeType)1].GetDouble(), mesh_part_aabb[(rapidjson::SizeType)2].GetDouble());
                     Vec3 max(mesh_part_aabb[(rapidjson::SizeType)3].GetDouble(),
                              mesh_part_aabb[(rapidjson::SizeType)4].GetDouble(), mesh_part_aabb[(rapidjson::SizeType)5].GetDouble());
-                    meshData->subMeshAABB.push_back(AABB(min, max));
+                    meshData->subMeshAABB.emplace_back(min, max);
                 }
                 else
                 {
@@ -1321,7 +1321,7 @@ bool Bundle3D::loadSkinDataBinary(SkinData* skindata)
             CCLOG("warning: Failed to load SkinData: bindpos '%s'.", _path.c_str());
             return false;
         }
-        skindata->inverseBindPoseMatrices.push_back(bindpos);
+        skindata->inverseBindPoseMatrices.emplace_back(bindpos);
     }
     
     skindata->skinBoneOriginMatrices.resize(boneNum);
@@ -1335,7 +1335,7 @@ bool Bundle3D::loadSkinDataBinary(SkinData* skindata)
     {
         skindata->addNodeBoneNames(boneName);
         rootIndex = skindata->getBoneNameIndex(boneName);
-        skindata->nodeBoneOriginMatrices.push_back(bindShape);
+        skindata->nodeBoneOriginMatrices.emplace_back(bindShape);
     }
     else
     {
@@ -1367,7 +1367,7 @@ bool Bundle3D::loadSkinDataBinary(SkinData* skindata)
         {
             skindata->addNodeBoneNames(id);
             index = skindata->getBoneNameIndex(id);
-            skindata->nodeBoneOriginMatrices.push_back(transform);
+            skindata->nodeBoneOriginMatrices.emplace_back(transform);
         }
         else
         {
@@ -1755,7 +1755,7 @@ NodeData* Bundle3D::parseNodesRecursivelyJson(const rapidjson::Value& jvalue, bo
                         return nullptr;
                     }
 
-                    modelnodedata->bones.push_back(bone[NODE].GetString());
+                    modelnodedata->bones.emplace_back(bone[NODE].GetString());
 
                     Mat4 invbindpos;
                     const rapidjson::Value& jinvbindpos = bone[TRANSFORM];
@@ -2212,7 +2212,7 @@ std::vector<Vec3> Bundle3D::getTrianglesList(const std::string& path)
         int preVertexSize = iter->getPerVertexSize() / sizeof(float);
         for (const auto& indexArray : iter->subMeshIndices){
             for (auto i : indexArray){
-                trianglesList.push_back(Vec3(iter->vertex[i * preVertexSize], iter->vertex[i * preVertexSize + 1], iter->vertex[i * preVertexSize + 2]));
+                trianglesList.emplace_back(iter->vertex[i * preVertexSize], iter->vertex[i * preVertexSize + 1], iter->vertex[i * preVertexSize + 2]);
             }
         }
     }

--- a/cocos/3d/CCMesh.cpp
+++ b/cocos/3d/CCMesh.cpp
@@ -235,7 +235,7 @@ Mesh* Mesh::create(const std::vector<float>& vertices, int /*perVertexSizeInFloa
     meshdata.attribs = attribs;
     meshdata.vertex = vertices;
     meshdata.subMeshIndices.push_back(indices);
-    meshdata.subMeshIds.push_back("");
+    meshdata.subMeshIds.emplace_back("");
     auto meshvertexdata = MeshVertexData::create(meshdata);
     auto indexData = meshvertexdata->getMeshIndexDataByIndex(0);
     

--- a/cocos/base/CCConsole.cpp
+++ b/cocos/base/CCConsole.cpp
@@ -715,7 +715,7 @@ void Console::log(const char* buf)
 {
     if( _sendDebugStrings ) {
         _DebugStringsMutex.lock();
-        _DebugStrings.push_back(buf);
+        _DebugStrings.emplace_back(buf);
         _DebugStringsMutex.unlock();
     }
 }

--- a/cocos/base/CCProperties.cpp
+++ b/cocos/base/CCProperties.cpp
@@ -235,7 +235,7 @@ void Properties::readProperties()
                 else
                 {
                     // Normal name/value pair
-                    _properties.push_back(Property(name, value));
+                    _properties.emplace_back(name, value);
                 }
             }
             else
@@ -383,11 +383,11 @@ void Properties::readProperties()
                             // Store "name value" as a name/value pair, or even just "name".
                             if (value != NULL)
                             {
-                                _properties.push_back(Property(name, value));
+                                _properties.emplace_back(name, value);
                             }
                             else
                             {
-                                _properties.push_back(Property(name, ""));
+                                _properties.emplace_back(name, "");
                             }
                         }
                     }
@@ -832,7 +832,7 @@ bool Properties::setString(const char* name, const char* value)
         }
 
         // There is no property with this name, so add one
-        _properties.push_back(Property(name, value ? value : ""));
+        _properties.emplace_back(name, value ? value : "");
     }
     else
     {

--- a/cocos/editor-support/cocostudio/CCColliderDetector.cpp
+++ b/cocos/editor-support/cocostudio/CCColliderDetector.cpp
@@ -194,6 +194,7 @@ void ColliderDetector::addContourData(ContourData *contourData)
     std::vector<Vec2> &calculatedVertexList = colliderBody->_calculatedVertexList;
     
     unsigned long num = contourData->vertexList.size();
+    calculatedVertexList.reserve(num);
     for (unsigned long i = 0; i < num; i++)
     {
         calculatedVertexList.emplace_back();

--- a/cocos/editor-support/cocostudio/CCColliderDetector.cpp
+++ b/cocos/editor-support/cocostudio/CCColliderDetector.cpp
@@ -196,7 +196,7 @@ void ColliderDetector::addContourData(ContourData *contourData)
     unsigned long num = contourData->vertexList.size();
     for (unsigned long i = 0; i < num; i++)
     {
-        calculatedVertexList.push_back(Vec2());
+        calculatedVertexList.emplace_back();
     }
 #endif
 }

--- a/cocos/navmesh/CCNavMesh.cpp
+++ b/cocos/navmesh/CCNavMesh.cpp
@@ -516,7 +516,7 @@ void cocos2d::NavMesh::findPath(const Vec3 &start, const Vec3 &end, std::vector<
         //dtVcopy(&m_smoothPath[m_nsmoothPath * 3], iterPos);
         //m_nsmoothPath++;
 
-        pathPoints.push_back(Vec3(iterPos[0], iterPos[1], iterPos[2]));
+        pathPoints.emplace_back(iterPos[0], iterPos[1], iterPos[2]);
         nsmoothPath++;
 
         // Move towards target a small advancement at a time until target reached or
@@ -571,7 +571,7 @@ void cocos2d::NavMesh::findPath(const Vec3 &start, const Vec3 &end, std::vector<
                 {
                     //dtVcopy(&m_smoothPath[m_nsmoothPath * 3], iterPos);
                     //m_nsmoothPath++;
-                    pathPoints.push_back(Vec3(iterPos[0], iterPos[1], iterPos[2]));
+                    pathPoints.emplace_back(iterPos[0], iterPos[1], iterPos[2]);
                     nsmoothPath++;
                 }
                 break;
@@ -602,14 +602,14 @@ void cocos2d::NavMesh::findPath(const Vec3 &start, const Vec3 &end, std::vector<
                     {
                         //dtVcopy(&m_smoothPath[m_nsmoothPath * 3], startPos);
                         //m_nsmoothPath++;
-                        pathPoints.push_back(Vec3(startPos[0], startPos[1], startPos[2]));
+                        pathPoints.emplace_back(startPos[0], startPos[1], startPos[2]);
                         nsmoothPath++;
                         // Hack to make the dotted path not visible during off-mesh connection.
                         if (nsmoothPath & 1)
                         {
                             //dtVcopy(&m_smoothPath[m_nsmoothPath * 3], startPos);
                             //m_nsmoothPath++;
-                            pathPoints.push_back(Vec3(startPos[0], startPos[1], startPos[2]));
+                            pathPoints.emplace_back(startPos[0], startPos[1], startPos[2]);
                             nsmoothPath++;
                         }
                     }
@@ -627,7 +627,7 @@ void cocos2d::NavMesh::findPath(const Vec3 &start, const Vec3 &end, std::vector<
                 //dtVcopy(&m_smoothPath[m_nsmoothPath * 3], iterPos);
                 //m_nsmoothPath++;
 
-                pathPoints.push_back(Vec3(iterPos[0], iterPos[1], iterPos[2]));
+                pathPoints.emplace_back(iterPos[0], iterPos[1], iterPos[2]);
                 nsmoothPath++;
             }
         }

--- a/cocos/network/CCDownloader-curl.cpp
+++ b/cocos/network/CCDownloader-curl.cpp
@@ -261,12 +261,12 @@ namespace cocos2d { namespace network {
             if (DownloadTask::ERROR_NO_ERROR == coTask->_errCode)
             {
                 lock_guard<mutex> lock(_requestMutex);
-                _requestQueue.push_back(make_pair(task, coTask));
+                _requestQueue.emplace_back(task, coTask);
             }
             else
             {
                 lock_guard<mutex> lock(_finishedMutex);
-                _finishedQueue.push_back(make_pair(task, coTask));
+                _finishedQueue.emplace_back(task, coTask);
             }
         }
 

--- a/cocos/network/SocketIO.cpp
+++ b/cocos/network/SocketIO.cpp
@@ -107,15 +107,15 @@ private:
 
 SocketIOPacket::SocketIOPacket() :_endpointseparator(""), _separator(":")
 {
-    _types.push_back("disconnect");
-    _types.push_back("connect");
-    _types.push_back("heartbeat");
-    _types.push_back("message");
-    _types.push_back("json");
-    _types.push_back("event");
-    _types.push_back("ack");
-    _types.push_back("error");
-    _types.push_back("noop");
+    _types.emplace_back("disconnect");
+    _types.emplace_back("connect");
+    _types.emplace_back("heartbeat");
+    _types.emplace_back("message");
+    _types.emplace_back("json");
+    _types.emplace_back("event");
+    _types.emplace_back("ack");
+    _types.emplace_back("error");
+    _types.emplace_back("noop");
 }
 
 SocketIOPacket::~SocketIOPacket()
@@ -236,20 +236,20 @@ SocketIOPacketV10x::SocketIOPacketV10x()
 {
     _separator = "";
     _endpointseparator = ",";
-    _types.push_back("disconnected");
-    _types.push_back("connected");
-    _types.push_back("heartbeat");
-    _types.push_back("pong");
-    _types.push_back("message");
-    _types.push_back("upgrade");
-    _types.push_back("noop");
-    _typesMessage.push_back("connect");
-    _typesMessage.push_back("disconnect");
-    _typesMessage.push_back("event");
-    _typesMessage.push_back("ack");
-    _typesMessage.push_back("error");
-    _typesMessage.push_back("binarevent");
-    _typesMessage.push_back("binaryack");
+    _types.emplace_back("disconnected");
+    _types.emplace_back("connected");
+    _types.emplace_back("heartbeat");
+    _types.emplace_back("pong");
+    _types.emplace_back("message");
+    _types.emplace_back("upgrade");
+    _types.emplace_back("noop");
+    _typesMessage.emplace_back("connect");
+    _typesMessage.emplace_back("disconnect");
+    _typesMessage.emplace_back("event");
+    _typesMessage.emplace_back("ack");
+    _typesMessage.emplace_back("error");
+    _typesMessage.emplace_back("binarevent");
+    _typesMessage.emplace_back("binaryack");
 }
 
 int SocketIOPacketV10x::typeAsNumber()const

--- a/cocos/platform/CCFileUtils.cpp
+++ b/cocos/platform/CCFileUtils.cpp
@@ -615,7 +615,7 @@ bool FileUtils::init()
 {
     DECLARE_GUARD;
     _searchPathArray.push_back(_defaultResRootPath);
-    _searchResolutionsOrderArray.push_back("");
+    _searchResolutionsOrderArray.emplace_back("");
     return true;
 }
 
@@ -955,7 +955,7 @@ void FileUtils::setSearchResolutionsOrder(const std::vector<std::string>& search
 
     if (!existDefault)
     {
-        _searchResolutionsOrderArray.push_back("");
+        _searchResolutionsOrderArray.emplace_back("");
     }
 }
 

--- a/extensions/assets-manager/Manifest.cpp
+++ b/extensions/assets-manager/Manifest.cpp
@@ -532,7 +532,7 @@ void Manifest::loadManifest(const rapidjson::Document &json)
             for (rapidjson::SizeType i = 0; i < paths.Size(); ++i)
             {
                 if (paths[i].IsString()) {
-                    _searchPaths.push_back(paths[i].GetString());
+                    _searchPaths.emplace_back(paths[i].GetString());
                 }
             }
         }

--- a/tests/cpp-empty-test/Classes/AppDelegate.cpp
+++ b/tests/cpp-empty-test/Classes/AppDelegate.cpp
@@ -91,21 +91,21 @@ bool AppDelegate::applicationDidFinishLaunching()
     // If the frame's height is larger than the height of medium resource size, select large resource.
     if (frameSize.height > mediumResource.size.height)
     {
-        searchPath.push_back(largeResource.directory);
+        searchPath.emplace_back(largeResource.directory);
 
         director->setContentScaleFactor(MIN(largeResource.size.height/designResolutionSize.height, largeResource.size.width/designResolutionSize.width));
     }
     // If the frame's height is larger than the height of small resource size, select medium resource.
     else if (frameSize.height > smallResource.size.height)
     {
-        searchPath.push_back(mediumResource.directory);
+        searchPath.emplace_back(mediumResource.directory);
         
         director->setContentScaleFactor(MIN(mediumResource.size.height/designResolutionSize.height, mediumResource.size.width/designResolutionSize.width));
     }
     // If the frame's height is smaller than the height of medium resource size, select small resource.
     else
     {
-        searchPath.push_back(smallResource.directory);
+        searchPath.emplace_back(smallResource.directory);
 
         director->setContentScaleFactor(MIN(smallResource.size.height/designResolutionSize.height, smallResource.size.width/designResolutionSize.width));
     }

--- a/tests/cpp-tests/Classes/AppDelegate.cpp
+++ b/tests/cpp-tests/Classes/AppDelegate.cpp
@@ -81,19 +81,19 @@ bool AppDelegate::applicationDidFinishLaunching()
     if (screenSize.height > 320)
     {
         auto resourceSize = Size(960, 640);
-        searchPaths.push_back("hd");
-        searchPaths.push_back("ccs-res/hd");
-        searchPaths.push_back("ccs-res");
-        searchPaths.push_back("Manifests");
+        searchPaths.emplace_back("hd");
+        searchPaths.emplace_back("ccs-res/hd");
+        searchPaths.emplace_back("ccs-res");
+        searchPaths.emplace_back("Manifests");
         director->setContentScaleFactor(resourceSize.height/designSize.height);
 
-        searchPaths.push_back("hd/ActionTimeline");
+        searchPaths.emplace_back("hd/ActionTimeline");
     }
     else
     {
-        searchPaths.push_back("ccs-res");
+        searchPaths.emplace_back("ccs-res");
         
-        searchPaths.push_back("ActionTimeline");
+        searchPaths.emplace_back("ActionTimeline");
     }
     
     fileUtils->setSearchPaths(searchPaths);

--- a/tests/cpp-tests/Classes/ExtensionsTest/NetworkTest/HttpClientTest.cpp
+++ b/tests/cpp-tests/Classes/ExtensionsTest/NetworkTest/HttpClientTest.cpp
@@ -215,7 +215,7 @@ void HttpClientTest::onMenuPostTestClicked(cocos2d::Ref *sender, bool isImmediat
         request->setUrl("http://httpbin.org/post");
         request->setRequestType(HttpRequest::Type::POST);
         std::vector<std::string> headers;
-        headers.push_back("Content-Type: application/json; charset=utf-8");
+        headers.emplace_back("Content-Type: application/json; charset=utf-8");
         request->setHeaders(headers);
         request->setResponseCallback(CC_CALLBACK_2(HttpClientTest::onHttpRequestCompleted, this));
         
@@ -295,7 +295,7 @@ void HttpClientTest::onMenuPutTestClicked(Ref *sender, bool isImmediate)
         request->setUrl("http://httpbin.org/put");
         request->setRequestType(HttpRequest::Type::PUT);
         std::vector<std::string> headers;
-        headers.push_back("Content-Type: application/json; charset=utf-8");
+        headers.emplace_back("Content-Type: application/json; charset=utf-8");
         request->setHeaders(headers);
         request->setResponseCallback(CC_CALLBACK_2(HttpClientTest::onHttpRequestCompleted, this));
 

--- a/tests/cpp-tests/Classes/ExtensionsTest/NetworkTest/WebSocketDelayTest.cpp
+++ b/tests/cpp-tests/Classes/ExtensionsTest/NetworkTest/WebSocketDelayTest.cpp
@@ -98,8 +98,8 @@ void WebSocketDelayTest::startTestCallback(Ref* sender)
     _wsiSendText = new network::WebSocket();
     
     std::vector<std::string> protocols;
-    protocols.push_back("myprotocol_1");
-    protocols.push_back("myprotocol_2");
+    protocols.emplace_back("myprotocol_1");
+    protocols.emplace_back("myprotocol_2");
     if (!_wsiSendText->init(*this, "wss://echo.websocket.org", &protocols, "cacert.pem"))
     {
         CC_SAFE_DELETE(_wsiSendText);

--- a/tests/cpp-tests/Classes/ExtensionsTest/NetworkTest/WebSocketTest.cpp
+++ b/tests/cpp-tests/Classes/ExtensionsTest/NetworkTest/WebSocketTest.cpp
@@ -135,8 +135,8 @@ void WebSocketTest::startTestCallback(Ref* sender)
     _wsiError = new network::WebSocket();
 
     std::vector<std::string> protocols;
-    protocols.push_back("myprotocol_1");
-    protocols.push_back("myprotocol_2");
+    protocols.emplace_back("myprotocol_1");
+    protocols.emplace_back("myprotocol_2");
     if (!_wsiSendText->init(*this, "wss://echo.websocket.org", &protocols, "cacert.pem"))
     {
         CC_SAFE_DELETE(_wsiSendText);

--- a/tests/cpp-tests/Classes/NavMeshTest/NavMeshTest.cpp
+++ b/tests/cpp-tests/Classes/NavMeshTest/NavMeshTest.cpp
@@ -198,7 +198,7 @@ void NavMeshBaseTestDemo::createAgent(const Vec3 &pos)
         animate->setSpeed(0);
     }
 
-    _agents.push_back(std::make_pair(agent, animate));
+    _agents.emplace_back(agent, animate);
 }
 
 void NavMeshBaseTestDemo::createObstacle(const Vec3 &pos)

--- a/tests/cpp-tests/Classes/Physics3DTest/Physics3DTest.cpp
+++ b/tests/cpp-tests/Classes/Physics3DTest/Physics3DTest.cpp
@@ -651,18 +651,18 @@ bool Physics3DTerrainDemo::init()
         Mat4 localTrans;
         auto bodyshape = Physics3DShape::createBox(Vec3(2.0f, 4.0f, 2.0f));
         Mat4::createTranslation(0.0f, 2.0f, 0.0f, &localTrans);
-        shapeList.push_back(std::make_pair(bodyshape, localTrans));
+        shapeList.emplace_back(bodyshape, localTrans);
         auto headshape = Physics3DShape::createSphere(1.5f);
         Mat4::createTranslation(0.6f, 5.0f, -1.5f, &localTrans);
-        shapeList.push_back(std::make_pair(headshape, localTrans));
+        shapeList.emplace_back(headshape, localTrans);
         auto lhandshape = Physics3DShape::createBox(Vec3(1.0f, 3.0f, 1.0f));
         Mat4::createRotation(Vec3(1.0f, 0.0f, 0.0f), CC_DEGREES_TO_RADIANS(15.0f), &localTrans);
         localTrans.m[12] = -1.5f; localTrans.m[13] = 2.5f; localTrans.m[14] = -2.5f;
-        shapeList.push_back(std::make_pair(lhandshape, localTrans));
+        shapeList.emplace_back(lhandshape, localTrans);
         auto rhandshape = Physics3DShape::createBox(Vec3(1.0f, 3.0f, 1.0f));
         Mat4::createRotation(Vec3(1.0f, 0.0f, 0.0f), CC_DEGREES_TO_RADIANS(-15.0f), &localTrans);
         localTrans.m[12] = 2.0f; localTrans.m[13] = 2.5f; localTrans.m[14] = 1.f;
-        shapeList.push_back(std::make_pair(rhandshape, localTrans));
+        shapeList.emplace_back(rhandshape, localTrans);
 
         rbDes.mass = 10.0f;
         rbDes.shape = Physics3DShape::createCompoundShape(shapeList);

--- a/tests/cpp-tests/Classes/Scene3DTest/Scene3DTest.cpp
+++ b/tests/cpp-tests/Classes/Scene3DTest/Scene3DTest.cpp
@@ -807,32 +807,32 @@ void Scene3DTestScene::createDescDlg()
     }
     
     auto& body = _skins[(int)SkinType::UPPER_BODY];
-    body.push_back("Girl_UpperBody01");
-    body.push_back("Girl_UpperBody02");
+    body.emplace_back("Girl_UpperBody01");
+    body.emplace_back("Girl_UpperBody02");
     
     auto& pants = _skins[(int)SkinType::PANTS];
-    pants.push_back("Girl_LowerBody01");
-    pants.push_back("Girl_LowerBody02");
+    pants.emplace_back("Girl_LowerBody01");
+    pants.emplace_back("Girl_LowerBody02");
     
     auto& shoes = _skins[(int)SkinType::SHOES];
-    shoes.push_back("Girl_Shoes01");
-    shoes.push_back("Girl_Shoes02");
+    shoes.emplace_back("Girl_Shoes01");
+    shoes.emplace_back("Girl_Shoes02");
     
     auto& hair = _skins[(int)SkinType::HAIR];
-    hair.push_back("Girl_Hair01");
-    hair.push_back("Girl_Hair02");
+    hair.emplace_back("Girl_Hair01");
+    hair.emplace_back("Girl_Hair02");
     
     auto& face = _skins[(int)SkinType::FACE];
-    face.push_back("Girl_Face01");
-    face.push_back("Girl_Face02");
+    face.emplace_back("Girl_Face01");
+    face.emplace_back("Girl_Face02");
     
     auto& hand = _skins[(int)SkinType::HAND];
-    hand.push_back("Girl_Hand01");
-    hand.push_back("Girl_Hand02");
+    hand.emplace_back("Girl_Hand01");
+    hand.emplace_back("Girl_Hand02");
     
     auto& glasses = _skins[(int)SkinType::GLASSES];
-    glasses.push_back("");
-    glasses.push_back("Girl_Glasses01");
+    glasses.emplace_back("");
+    glasses.emplace_back("Girl_Glasses01");
     
     memset(_curSkin, 0, (int)SkinType::MAX_TYPE * sizeof(int));
     

--- a/tests/cpp-tests/Classes/ShaderTest/ShaderTest2.cpp
+++ b/tests/cpp-tests/Classes/ShaderTest/ShaderTest2.cpp
@@ -74,7 +74,7 @@ public:
         effect->retain();
         effect->setTarget(this);
 
-        _effects.push_back(std::make_tuple(order,effect,QuadCommand()));
+        _effects.emplace_back(order,effect,QuadCommand());
 
         std::sort(std::begin(_effects), std::end(_effects), tuple_sort);
     }

--- a/tests/cpp-tests/Classes/Sprite3DTest/Sprite3DTest.cpp
+++ b/tests/cpp-tests/Classes/Sprite3DTest/Sprite3DTest.cpp
@@ -826,11 +826,11 @@ void Sprite3DEffectTest::onTouchesEnded(const std::vector<Touch*>& touches, Even
 
 AsyncLoadSprite3DTest::AsyncLoadSprite3DTest()
 {
-    _paths.push_back("Sprite3DTest/boss.obj");
-    _paths.push_back("Sprite3DTest/girl.c3b");
-    _paths.push_back("Sprite3DTest/orc.c3b");
-    _paths.push_back("Sprite3DTest/ReskinGirl.c3b");
-    _paths.push_back("Sprite3DTest/axe.c3b");
+    _paths.emplace_back("Sprite3DTest/boss.obj");
+    _paths.emplace_back("Sprite3DTest/girl.c3b");
+    _paths.emplace_back("Sprite3DTest/orc.c3b");
+    _paths.emplace_back("Sprite3DTest/ReskinGirl.c3b");
+    _paths.emplace_back("Sprite3DTest/axe.c3b");
     
     TTFConfig ttfConfig("fonts/arial.ttf", 15);
     auto label1 = Label::createWithTTF(ttfConfig,"AsyncLoad Sprite3D");
@@ -1346,32 +1346,32 @@ void Sprite3DReskinTest::addNewSpriteWithCoords(Vec2 p)
     _sprite = sprite;
     
     auto& body = _skins[(int)SkinType::UPPER_BODY];
-    body.push_back("Girl_UpperBody01");
-    body.push_back("Girl_UpperBody02");
+    body.emplace_back("Girl_UpperBody01");
+    body.emplace_back("Girl_UpperBody02");
     
     auto& pants = _skins[(int)SkinType::PANTS];
-    pants.push_back("Girl_LowerBody01");
-    pants.push_back("Girl_LowerBody02");
+    pants.emplace_back("Girl_LowerBody01");
+    pants.emplace_back("Girl_LowerBody02");
     
     auto& shoes = _skins[(int)SkinType::SHOES];
-    shoes.push_back("Girl_Shoes01");
-    shoes.push_back("Girl_Shoes02");
+    shoes.emplace_back("Girl_Shoes01");
+    shoes.emplace_back("Girl_Shoes02");
     
     auto& hair = _skins[(int)SkinType::HAIR];
-    hair.push_back("Girl_Hair01");
-    hair.push_back("Girl_Hair02");
+    hair.emplace_back("Girl_Hair01");
+    hair.emplace_back("Girl_Hair02");
     
     auto& face = _skins[(int)SkinType::FACE];
-    face.push_back("Girl_Face01");
-    face.push_back("Girl_Face02");
+    face.emplace_back("Girl_Face01");
+    face.emplace_back("Girl_Face02");
     
     auto& hand = _skins[(int)SkinType::HAND];
-    hand.push_back("Girl_Hand01");
-    hand.push_back("Girl_Hand02");
+    hand.emplace_back("Girl_Hand01");
+    hand.emplace_back("Girl_Hand02");
     
     auto& glasses = _skins[(int)SkinType::GLASSES];
-    glasses.push_back("");
-    glasses.push_back("Girl_Glasses01");
+    glasses.emplace_back("");
+    glasses.emplace_back("Girl_Glasses01");
     
     memset(_curSkin, 0, (int)SkinType::MAX_TYPE * sizeof(int));
     

--- a/tests/cpp-tests/Classes/UnitTest/UnitTest.cpp
+++ b/tests/cpp-tests/Classes/UnitTest/UnitTest.cpp
@@ -502,9 +502,9 @@ void TemplateMapTest::onEnter()
     CCASSERT(mapForErase.size() == 18, "mapForErase's size is 18.");
 
     std::vector<std::string> itemsToRemove;
-    itemsToRemove.push_back("2");
-    itemsToRemove.push_back("3");
-    itemsToRemove.push_back("4");
+    itemsToRemove.emplace_back("2");
+    itemsToRemove.emplace_back("3");
+    itemsToRemove.emplace_back("4");
     mapForErase.erase(itemsToRemove);
     CCASSERT(mapForErase.size() == 15, "mapForErase's size is 15.");
 

--- a/tests/js-tests/project/Classes/js_Effect3D_bindings.cpp
+++ b/tests/js-tests/project/Classes/js_Effect3D_bindings.cpp
@@ -176,7 +176,7 @@ void EffectSprite3D::addEffect(Effect3DOutline* effect, ssize_t order)
     effect->retain();
     effect->setTarget(this);
 
-    _effects.push_back(std::make_tuple(order,effect,CustomCommand()));
+    _effects.emplace_back(order,effect,CustomCommand());
 
     std::sort(std::begin(_effects), std::end(_effects), tuple_sort);
 }


### PR DESCRIPTION
A example of clang-tidy fix is shown below.

Before:

```cpp
outPoints.push_back(Vec2(pt.X/PRECISION, pt.Y/PRECISION));
```

After

```cpp
outPoints.emplace_back(pt.X/PRECISION, pt.Y/PRECISION);
```


Reference: https://clang.llvm.org/extra/clang-tidy/checks/modernize-use-emplace.html