### PR TITLE
Small performance boost in using Mat4::operator*= instead of operator*

### DIFF
--- a/cocos/2d/CCNode.cpp
+++ b/cocos/2d/CCNode.cpp
@@ -1686,7 +1686,7 @@ Mat4 Node::getNodeToParentTransform(Node* ancestor) const
 
     for (Node *p = _parent;  p != nullptr && p != ancestor ; p = p->getParent())
     {
-        t = p->getNodeToParentTransform() * t;
+        t *= p->getNodeToParentTransform();
     }
 
     return t;


### PR DESCRIPTION
This avoids creating a new temporary Mat4 transform in operator* https://github.com/cocos2d/cocos2d-x/blob/v3/cocos/math/Mat4.inl#L60