### PR TITLE
Revert "Small performance boost in using Mat4::operator*= instead of …operator* (#19960)"

### DIFF
--- a/cocos/2d/CCNode.cpp
+++ b/cocos/2d/CCNode.cpp
@@ -1686,7 +1686,7 @@ Mat4 Node::getNodeToParentTransform(Node* ancestor) const
 
     for (Node *p = _parent;  p != nullptr && p != ancestor ; p = p->getParent())
     {
-        t *= p->getNodeToParentTransform();
+        t = p->getNodeToParentTransform() * t;
     }
 
     return t;


### PR DESCRIPTION
This reverts commit a242a792ba99f6679965a211b07ff573bc0bb7c9.