### PR TITLE
Added support for saving non-premultiplied alpha images from RenderTexture

### DIFF
--- a/cocos/2d/CCRenderTexture.h
+++ b/cocos/2d/CCRenderTexture.h
@@ -168,7 +168,31 @@ public:
      * @param callback When the file is save finished,it will callback this function.
      * @return Returns true if the operation is successful.
      */
+    bool saveToFileAsNonPMA(const std::string& filename, bool isRGBA = true, std::function<void(RenderTexture*, const std::string&)> callback = nullptr);
+
+    /** Saves the texture into a file using JPEG format. The file will be saved in the Documents folder.
+     * Returns true if the operation is successful.
+     *
+     * @param filename The file name.
+     * @param isRGBA The file is RGBA or not.
+     * @param callback When the file is save finished,it will callback this function.
+     * @return Returns true if the operation is successful.
+     */
     bool saveToFile(const std::string& filename, bool isRGBA = true, std::function<void (RenderTexture*, const std::string&)> callback = nullptr);
+
+   /** saves the texture into a file in non-PMA. The format could be JPG or PNG. The file will be saved in the Documents folder.
+        Returns true if the operation is successful.
+     * Notes: since v3.x, saveToFile will generate a custom command, which will be called in the following render->render().
+     * So if this function is called in a event handler, the actual save file will be called in the next frame. If we switch to a different scene, the game will crash.
+     * To solve this, add Director::getInstance()->getRenderer()->render(); after this function.
+     *
+     * @param filename The file name.
+     * @param format The image format.
+     * @param isRGBA The file is RGBA or not.
+     * @param callback When the file is save finished,it will callback this function.
+     * @return Returns true if the operation is successful.
+     */
+    bool saveToFileAsNonPMA(const std::string& fileName, Image::Format format, bool isRGBA, std::function<void(RenderTexture*, const std::string&)> callback);
 
     /** saves the texture into a file. The format could be JPG or PNG. The file will be saved in the Documents folder.
         Returns true if the operation is successful.
@@ -322,7 +346,7 @@ protected:
     void onEnd();
     void clearColorAttachment();
 
-    void onSaveToFile(const std::string& fileName, bool isRGBA = true);
+    void onSaveToFile(const std::string& fileName, bool isRGBA = true, bool forceNonPMA = false);
 
     bool         _keepMatrix = false;
     Rect         _rtTextureRect;

--- a/cocos/platform/CCImage.h
+++ b/cocos/platform/CCImage.h
@@ -155,6 +155,8 @@ public:
      @param    isToRGB        whether the image is saved as RGB format.
      */
     bool saveToFile(const std::string &filename, bool isToRGB = true);
+    void premultiplyAlpha();
+    void reversePremultipliedAlpha();   
 
 protected:
     bool initWithJpgData(const unsigned char *  data, ssize_t dataLen);
@@ -173,7 +175,7 @@ protected:
     bool saveImageToPNG(const std::string& filePath, bool isToRGB = true);
     bool saveImageToJPG(const std::string& filePath);
     
-    void premultipliedAlpha();
+
     
 protected:
     /**

--- a/cocos/platform/ios/CCImage-ios.mm
+++ b/cocos/platform/ios/CCImage-ios.mm
@@ -91,7 +91,14 @@ bool cocos2d::Image::saveToFile(const std::string& filename, bool isToRGB)
     CGBitmapInfo bitmapInfo = kCGBitmapByteOrderDefault;
     if (saveToPNG && hasAlpha() && (! isToRGB))
     {
-        bitmapInfo |= kCGImageAlphaPremultipliedLast;
+        if (_hasPremultipliedAlpha)
+        {
+            bitmapInfo |= kCGImageAlphaPremultipliedLast;
+        }
+        else
+        {
+            bitmapInfo |= kCGImageAlphaLast;
+        }        
     }
     CGDataProviderRef provider        = CGDataProviderCreateWithData(nullptr, pixels, myDataLength, nullptr);
     CGColorSpaceRef colorSpaceRef    = CGColorSpaceCreateDeviceRGB();

--- a/tests/cpp-tests/Classes/RenderTextureTest/RenderTextureTest.cpp
+++ b/tests/cpp-tests/Classes/RenderTextureTest/RenderTextureTest.cpp
@@ -62,12 +62,15 @@ RenderTextureSave::RenderTextureSave()
     
     // Save Image menu
     MenuItemFont::setFontSize(16);
-    auto item1 = MenuItemFont::create("Save Image", CC_CALLBACK_1(RenderTextureSave::saveImage, this));
-    auto item2 = MenuItemFont::create("Clear", CC_CALLBACK_1(RenderTextureSave::clearImage, this));
-    auto menu = Menu::create(item1, item2, nullptr);
+    auto item1 = MenuItemFont::create("Save Image PMA", CC_CALLBACK_1(RenderTextureSave::saveImageWithPremultipliedAlpha, this));
+    auto item2 = MenuItemFont::create("Save Image Non-PMA", CC_CALLBACK_1(RenderTextureSave::saveImageWithNonPremultipliedAlpha, this));
+    auto item3 = MenuItemFont::create("Add Image", CC_CALLBACK_1(RenderTextureSave::addImage, this));
+    auto item4 = MenuItemFont::create("Clear to Random", CC_CALLBACK_1(RenderTextureSave::clearImage, this));
+    auto item5 = MenuItemFont::create("Clear to Transparent", CC_CALLBACK_1(RenderTextureSave::clearImageTransparent, this));
+    auto menu = Menu::create(item1, item2, item3, item4, item5, nullptr);
     this->addChild(menu);
     menu->alignItemsVertically();
-    menu->setPosition(Vec2(VisibleRect::rightTop().x - 80, VisibleRect::rightTop().y - 30));
+    menu->setPosition(Vec2(VisibleRect::rightTop().x - 80, VisibleRect::rightTop().y - 100));
 }
 
 std::string RenderTextureSave::title() const
@@ -85,12 +88,43 @@ void RenderTextureSave::clearImage(cocos2d::Ref *sender)
     _target->clear(CCRANDOM_0_1(), CCRANDOM_0_1(), CCRANDOM_0_1(), CCRANDOM_0_1());
 }
 
-void RenderTextureSave::saveImage(cocos2d::Ref *sender)
+void RenderTextureSave::clearImageTransparent(cocos2d::Ref* sender)
+{
+    _target->clear(0, 0, 0, 0);
+}
+
+void RenderTextureSave::saveImageWithPremultipliedAlpha(cocos2d::Ref* sender)
 {
     static int counter = 0;
 
     char png[20];
-    sprintf(png, "image-%d.png", counter);
+    sprintf(png, "image-pma-%d.png", counter);
+
+    auto callback = [&](RenderTexture* rt, const std::string& path)
+    {
+        auto sprite = Sprite::create(path);
+        addChild(sprite);
+        sprite->setScale(0.3f);
+        sprite->setPosition(Vec2(40, 40));
+        sprite->setRotation(counter * 3);
+        _target->release();
+    };
+
+    _target->retain();
+    _target->saveToFile(png, Image::Format::PNG, true, callback);
+    //Add this function to avoid crash if we switch to a new scene.
+    Director::getInstance()->getRenderer()->render();
+    CCLOG("Image saved %s", png);
+
+    counter++;
+}
+
+void RenderTextureSave::saveImageWithNonPremultipliedAlpha(cocos2d::Ref *sender)
+{
+    static int counter = 0;
+
+    char png[20];
+    sprintf(png, "image-no-pma-%d.png", counter);
     
     auto callback = [&](RenderTexture* rt, const std::string& path)
     {
@@ -103,12 +137,28 @@ void RenderTextureSave::saveImage(cocos2d::Ref *sender)
     };
     
     _target->retain();
-    _target->saveToFile(png, Image::Format::PNG, true, callback);
+    _target->saveToFileAsNonPMA(png, Image::Format::PNG, true, callback);
+                                                                 
     //Add this function to avoid crash if we switch to a new scene.
     Director::getInstance()->getRenderer()->render();
     CCLOG("Image saved %s", png);
 
     counter++;
+}
+
+void RenderTextureSave::addImage(cocos2d::Ref* sender)
+{
+    auto s = Director::getInstance()->getWinSize();
+
+    // begin drawing to the render texture
+    _target->begin();
+
+    Sprite* sprite = Sprite::create("Images/test-rgba1.png");
+    sprite->setPosition(sprite->getContentSize().width + CCRANDOM_0_1() * (s.width - sprite->getContentSize().width), sprite->getContentSize().height + CCRANDOM_0_1() * (s.height - sprite->getContentSize().height));
+    sprite->visit();
+
+    // finish drawing and return context back to the screen
+    _target->end();
 }
 
 RenderTextureSave::~RenderTextureSave()

--- a/tests/cpp-tests/Classes/RenderTextureTest/RenderTextureTest.h
+++ b/tests/cpp-tests/Classes/RenderTextureTest/RenderTextureTest.h
@@ -44,7 +44,10 @@ public:
     virtual std::string subtitle() const override;
     void onTouchesMoved(const std::vector<cocos2d::Touch*>& touches, cocos2d::Event* event);
     void clearImage(cocos2d::Ref* pSender);
-    void saveImage(cocos2d::Ref* pSender);
+    void clearImageTransparent(cocos2d::Ref* sender);
+    void saveImageWithPremultipliedAlpha(cocos2d::Ref* pSender);
+    void saveImageWithNonPremultipliedAlpha(cocos2d::Ref* pSender);
+    void addImage(cocos2d::Ref* sender);
 
 private:
     cocos2d::RenderTexture* _target;


### PR DESCRIPTION
This is similar to the v3 code in PR #19782 but adapted to work with v4.