### PR TITLE
fix crash when plist filename hasn't suffix

### DIFF
--- a/cocos/2d/CCSpriteFrameCache.cpp
+++ b/cocos/2d/CCSpriteFrameCache.cpp
@@ -393,7 +393,6 @@ void SpriteFrameCache::addSpriteFramesWithFile(const std::string& plist)
         {
             texturePath = texturePath.erase(startPos);
         }
-        texturePath = texturePath.erase(startPos);
 
         // append .png
         texturePath = texturePath.append(".png");
@@ -699,6 +698,7 @@ bool SpriteFrameCache::reloadTexture(const std::string& plist)
         {
             texturePath = texturePath.erase(startPos);
         }
+        
         // append .png
         texturePath = texturePath.append(".png");
     }

--- a/cocos/2d/CCSpriteFrameCache.cpp
+++ b/cocos/2d/CCSpriteFrameCache.cpp
@@ -691,6 +691,10 @@ bool SpriteFrameCache::reloadTexture(const std::string& plist)
 
         // remove .xxx
         size_t startPos = texturePath.find_last_of('.');
+        if(stratPos == string::npos)
+        {
+            return;
+        }
         texturePath = texturePath.erase(startPos);
 
         // append .png

--- a/cocos/2d/CCSpriteFrameCache.cpp
+++ b/cocos/2d/CCSpriteFrameCache.cpp
@@ -691,7 +691,7 @@ bool SpriteFrameCache::reloadTexture(const std::string& plist)
 
         // remove .xxx
         size_t startPos = texturePath.find_last_of('.');
-        if(stratPos == string::npos)
+        if(startPos == string::npos)
         {
             return;
         }

--- a/cocos/2d/CCSpriteFrameCache.cpp
+++ b/cocos/2d/CCSpriteFrameCache.cpp
@@ -389,6 +389,10 @@ void SpriteFrameCache::addSpriteFramesWithFile(const std::string& plist)
 
         // remove .xxx
         size_t startPos = texturePath.find_last_of('.'); 
+        if(startPos != string::npos)
+        {
+            texturePath = texturePath.erase(startPos);
+        }
         texturePath = texturePath.erase(startPos);
 
         // append .png
@@ -691,12 +695,10 @@ bool SpriteFrameCache::reloadTexture(const std::string& plist)
 
         // remove .xxx
         size_t startPos = texturePath.find_last_of('.');
-        if(startPos == string::npos)
+        if(startPos != string::npos)
         {
-            return;
+            texturePath = texturePath.erase(startPos);
         }
-        texturePath = texturePath.erase(startPos);
-
         // append .png
         texturePath = texturePath.append(".png");
     }


### PR DESCRIPTION
should't call erase when the file name has't suffix