### PR TITLE
in Node::enumerateChildren, searchFromParent shouldn't search from children

### DIFF
--- a/cocos/2d/CCNode.cpp
+++ b/cocos/2d/CCNode.cpp
@@ -850,22 +850,27 @@ void Node::enumerateChildren(const std::string &name, const std::function<bool (
     
     // Remove '//', '/..' if exist
     std::string newName = name.substr(subStrStartPos, subStrlength);
-
+    
+    const Node* target = this;
+    
     if (searchFromParent)
     {
-        newName.insert(0, "[[:alnum:]]+/");
+        target = getParent();
+        if (nullptr == target)
+        {
+            return;
+        }
     }
-    
     
     if (searchRecursively)
     {
         // name is '//xxx'
-        doEnumerateRecursive(this, newName, callback);
+        target->doEnumerateRecursive(this, newName, callback);
     }
     else
     {
         // name is xxx
-        doEnumerate(newName, callback);
+        target->doEnumerate(newName, callback);
     }
 }
 

--- a/cocos/2d/CCNode.cpp
+++ b/cocos/2d/CCNode.cpp
@@ -855,11 +855,11 @@ void Node::enumerateChildren(const std::string &name, const std::function<bool (
     
     if (searchFromParent)
     {
-        target = getParent();
-        if (nullptr == target)
+        if (nullptr == _parent)
         {
             return;
         }
+        target = _parent;
     }
     
     if (searchRecursively)

--- a/cocos/2d/CCNode.h
+++ b/cocos/2d/CCNode.h
@@ -812,7 +812,7 @@ public:
      * @param name The name to search for, supports c++11 regular expression.
      * Search syntax options:
      * `//`: Can only be placed at the begin of the search string. This indicates that it will search recursively.
-     * `..`: The search should move up to the node's parent. Can only be placed at the end of string.
+     * `/..`: The search should move up to the node's parent. Can only be placed at the end of string.
      * `/` : When placed anywhere but the start of the search string, this indicates that the search should move to the node's children.
      *
      * @code


### PR DESCRIPTION
scene tree:
scene -> node1 -> node2 -> node3
run code:
```c++
node1-> enumerateChildren("[[:alnum:]]+\..", [](Node* node){
    log("%s", node->getName().c_str());
    return false;
});
```
should output: node1
but output: node3
`\..` means that `The search should move up to the node's parent. Can only be placed at the end of string.` not move down to the node's children.