### PR TITLE
fix RotateTo animation when angle is bigger than 360

### DIFF
--- a/cocos/2d/CCActionInterval.cpp
+++ b/cocos/2d/CCActionInterval.cpp
@@ -943,6 +943,8 @@ void RotateTo::calculateAngles(float &startAngle, float &diffAngle, float dstAng
     }
 
     diffAngle = dstAngle - startAngle;
+    //fix angle when angle is bigger than 360
+    diffAngle = diffAngle - (int)diffAngle / 360 * 360;
     if (diffAngle > 180)
     {
         diffAngle -= 360;


### PR DESCRIPTION
```c++
sprite->runAction(RotateTo::create(1, 720));
```
Sprite rotate 720 degrees should be unchanged, but the sprite rotated 360 degrees.