### PR TITLE
Fix bug when an action with RepeatForever should exec action multiple times in one frame

### DIFF
--- a/cocos/2d/CCActionInterval.cpp
+++ b/cocos/2d/CCActionInterval.cpp
@@ -610,11 +610,30 @@ void RepeatForever::step(float dt)
     if (_innerAction->isDone() && _innerAction->getDuration() > 0)
     {
         float diff = _innerAction->getElapsed() - _innerAction->getDuration();
+        int time = 0;
         if (diff > _innerAction->getDuration())
+        {
+            time = (int)(diff / _innerAction->getDuration());
             diff = fmodf(diff, _innerAction->getDuration());
-        _innerAction->startWithTarget(_target);
-        // to prevent jerk. cocos2d-iphone issue #390, 1247
-        _innerAction->step(0.0f);
+        }
+        
+        while(time--)
+        {
+            if(_innerAction->isDone())
+            {
+                _innerAction->startWithTarget(_target);
+                // to prevent jerk. cocos2d-iphone issue #390, 1247
+                _innerAction->step(0.0f);
+            }
+            _innerAction->step(_innerAction->getDuration());
+        }
+        
+        if(_innerAction->isDone())
+        {
+            _innerAction->startWithTarget(_target);
+            // to prevent jerk. cocos2d-iphone issue #390, 1247
+            _innerAction->step(0.0f);
+        }
         _innerAction->step(diff);
     }
 }

--- a/cocos/2d/CCActionInterval.cpp
+++ b/cocos/2d/CCActionInterval.cpp
@@ -611,7 +611,7 @@ void RepeatForever::step(float dt)
     {
         float diff = _innerAction->getElapsed() - _innerAction->getDuration();
         
-        while(fabsf(diff) > MATH_EPSILON && diff > 0.0f)
+        while(fabsf(diff) > FLT_EPSILON && diff > 0.0f)
         {
             if(_innerAction->isDone())
             {

--- a/cocos/2d/CCActionInterval.cpp
+++ b/cocos/2d/CCActionInterval.cpp
@@ -610,14 +610,8 @@ void RepeatForever::step(float dt)
     if (_innerAction->isDone() && _innerAction->getDuration() > 0)
     {
         float diff = _innerAction->getElapsed() - _innerAction->getDuration();
-        int time = 0;
-        if (diff > _innerAction->getDuration())
-        {
-            time = (int)(diff / _innerAction->getDuration());
-            diff = fmodf(diff, _innerAction->getDuration());
-        }
         
-        while(time--)
+        while(fabsf(diff) > MATH_EPSILON && diff > 0.0f)
         {
             if(_innerAction->isDone())
             {
@@ -625,16 +619,9 @@ void RepeatForever::step(float dt)
                 // to prevent jerk. cocos2d-iphone issue #390, 1247
                 _innerAction->step(0.0f);
             }
-            _innerAction->step(_innerAction->getDuration());
+            _innerAction->step(diff);
+            diff = _innerAction->getElapsed() - _innerAction->getDuration();
         }
-        
-        if(_innerAction->isDone())
-        {
-            _innerAction->startWithTarget(_target);
-            // to prevent jerk. cocos2d-iphone issue #390, 1247
-            _innerAction->step(0.0f);
-        }
-        _innerAction->step(diff);
     }
 }
 


### PR DESCRIPTION
If an action with RepeatForever should exec multiple times in one frame, it can only exec less than twice.
example:
```c++
auto scale = ScaleBy::create(0.2, 1.5);
auto repeat = RepeatForever::create(scale);
sprite->runAction(repeat);
sprite->runAction(Sequence::createWithTwoActions(DelayTime::create(1.0f), CallFunc::create([sprite](){
    log("%f", sprite->getScale());
})));
```
If I set fps is 60, console output 7.813323 (about 1.5^5, no problem)
But if I set fps is 1, console output 1.503364 (the action only exec once)
If I set fps is 2, console output 2.262938 (the action only exec twice)