### PR TITLE
Fix divide by zero in ui::Slider (#19957)

### DIFF
--- a/cocos/ui/UISlider.cpp
+++ b/cocos/ui/UISlider.cpp
@@ -465,7 +465,15 @@ void Slider::setPercent(int percent)
 
 void Slider::updateVisualSlider()
 {
-    float res = 1.0 * _percent / _maxPercent;
+    float res;
+    if (_maxPercent > 0)
+    {
+        res = 1.0f * _percent / _maxPercent;
+    }
+    else
+    {
+        res = 0.f;
+    }
     float dis = _barLength * res;
     _slidBallRenderer->setPosition(dis, _contentSize.height / 2.0f);
     if (_scale9Enabled)


### PR DESCRIPTION
* Added RenderTexture::saveToFileAsNonPMA() to save images without PMA.
Set the PMA parameter to true when calling initWithRawData() inside RenderTexture::newImage(), since textures are PMA.
Renamed Image::premultipliedAlpha() to Image::premultiplyAlpha() to better reflect it's action, and made it public.
Added Image::reversePremultipliedAlpha() to allow the reversing of the PMA.
Updated CCImage-ios.mm to set the correct bitmapInfo for PMA and non-PMA images before saving a file.
Updated RenderTextureTest::RenderTextureSave() to cater for non-PMA file saving.

* [CCImage-ios.mm] Fixed indentation.

* [UISlider.cpp] Divide by 0 error if _maxPercent is equal to 0, which is an allowed value.