### PR TITLE
don't convert const char* to char*

### DIFF
--- a/cocos/scripting/lua-bindings/manual/LuaBasicConversions.cpp
+++ b/cocos/scripting/lua-bindings/manual/LuaBasicConversions.cpp
@@ -3286,7 +3286,7 @@ void node_to_luaval(lua_State* L, const char* type, cocos2d::Node* node)
 }
 
 
-bool luaval_to_vertexLayout(lua_State* L, int pos, cocos2d::backend::VertexLayout& outLayout,  char *message)
+bool luaval_to_vertexLayout(lua_State* L, int pos, cocos2d::backend::VertexLayout& outLayout, const char *message)
 {
     if (L == nullptr)
         return false;
@@ -3302,7 +3302,7 @@ bool luaval_to_vertexLayout(lua_State* L, int pos, cocos2d::backend::VertexLayou
 }
 
 
-bool luaval_to_samplerDescriptor(lua_State* L, int pos, cocos2d::backend::SamplerDescriptor& output, char *message)
+bool luaval_to_samplerDescriptor(lua_State* L, int pos, cocos2d::backend::SamplerDescriptor& output, const char *message)
 {
     if (L == nullptr)
         return false;
@@ -3342,7 +3342,7 @@ bool luaval_to_samplerDescriptor(lua_State* L, int pos, cocos2d::backend::Sample
     return true;
 }
 
-bool luaval_to_uniformLocation(lua_State* L, int pos, cocos2d::backend::UniformLocation& loc, char *message)
+bool luaval_to_uniformLocation(lua_State* L, int pos, cocos2d::backend::UniformLocation& loc, const char *message)
 {
     if (L == nullptr)
         return false;

--- a/cocos/scripting/lua-bindings/manual/LuaBasicConversions.h
+++ b/cocos/scripting/lua-bindings/manual/LuaBasicConversions.h
@@ -1286,17 +1286,17 @@ CC_LUA_DLL extern void node_to_luaval(lua_State* L, const char* type, cocos2d::N
 /**
 * convert lua object VertexLayout to native object
 */
-CC_LUA_DLL bool luaval_to_vertexLayout(lua_State* L, int pos, cocos2d::backend::VertexLayout& outLayout, char *message);
+CC_LUA_DLL bool luaval_to_vertexLayout(lua_State* L, int pos, cocos2d::backend::VertexLayout& outLayout, const char *message);
 
 /**
 * convert lua object SamplerDescriptor to native object
 */
-CC_LUA_DLL bool luaval_to_samplerDescriptor(lua_State* L, int pos, cocos2d::backend::SamplerDescriptor& desc, char *message);
+CC_LUA_DLL bool luaval_to_samplerDescriptor(lua_State* L, int pos, cocos2d::backend::SamplerDescriptor& desc, const char *message);
 
 /**
 * convert lua object to cocos2d::backend::UniformLocation
 */
-CC_LUA_DLL bool luaval_to_uniformLocation(lua_State* L, int pos, cocos2d::backend::UniformLocation& desc, char *message);
+CC_LUA_DLL bool luaval_to_uniformLocation(lua_State* L, int pos, cocos2d::backend::UniformLocation& desc, const char *message);
 
 /**
 * convert cocos2d::backend::UniformLocation to lua object


### PR DESCRIPTION
* C++ forbids conversion from const char* string to char*, so we change
function signature from char* to const char* in lua basic conversion
functions.

This fixes issue: https://github.com/cocos2d/cocos2d-x/issues/20038