### PR TITLE
Fixing a bug in Node::enumerateChildren

### DIFF
--- a/cocos/2d/CCNode.cpp
+++ b/cocos/2d/CCNode.cpp
@@ -865,7 +865,7 @@ void Node::enumerateChildren(const std::string &name, const std::function<bool (
     if (searchRecursively)
     {
         // name is '//xxx'
-        target->doEnumerateRecursive(this, newName, callback);
+        target->doEnumerateRecursive(target, newName, callback);
     }
     else
     {

--- a/tests/cpp-tests/Classes/NodeTest/NodeTest.cpp
+++ b/tests/cpp-tests/Classes/NodeTest/NodeTest.cpp
@@ -1384,14 +1384,14 @@ void NodeNameTest::test(float dt)
     // search from parent
     // name is xxx/..
     i = 0;
-    parent->enumerateChildren("node/..", [&i](Node* node) -> bool {
+    parent->getChildByName("node1")->enumerateChildren("node[[:digit:]]+/node/..", [&i](Node* node) -> bool {
         ++i;
         return true;
     });
     CCAssert(i == 1, "");
     
     i = 0;
-    parent->enumerateChildren("node/..", [&i](Node* node) -> bool {
+    parent->getChildByName("node1")->enumerateChildren("node[[:digit:]]+/node/..", [&i](Node* node) -> bool {
         ++i;
         return false;
     });
@@ -1430,11 +1430,11 @@ void NodeNameTest::test(float dt)
     CCAssert(i == 1, "");
     
     i = 0;
-    parent->enumerateChildren("//node[[:digit:]]+/..", [&i](Node* node) -> bool {
+    parent->getChildByName("node1")->enumerateChildren("//node[[:digit:]]+/..", [&i](Node* node) -> bool {
         ++i;
         return false;
     });
-    CCAssert(i == 100, "");
+    CCAssert(i == 110, "");
     
     // utils::findChildren()
     


### PR DESCRIPTION
This patch fixes an issue that if both // (recursive enumeration)
and .. (starting from parent node) are specified,
Node::enumerateChildren does not honor the latter and starts searching
from current node rather than parent node.
This fix also completes the work done in #20007 