### PR TITLE
fix FastTMXLayer

### DIFF
--- a/cocos/2d/CCFastTMXLayer.cpp
+++ b/cocos/2d/CCFastTMXLayer.cpp
@@ -154,8 +154,8 @@ void TMXLayer::draw(Renderer *renderer, const Mat4& transform, uint32_t flags)
     {
         Size s = Director::getInstance()->getVisibleSize();
         const Vec2 &anchor = getAnchorPoint();
-        auto rect = Rect(Camera::getVisitingCamera()->getPositionX() - s.width * anchor.x,
-                     Camera::getVisitingCamera()->getPositionY() - s.height * anchor.y,
+        auto rect = Rect(Camera::getVisitingCamera()->getPositionX() - s.width * (anchor.x == 0.0f ? 0.5f : anchor.x),
+                     Camera::getVisitingCamera()->getPositionY() - s.height * (anchor.y == 0.0f ? 0.5f : anchor.y),
                      s.width,
                      s.height);
         


### PR DESCRIPTION
ref [19759](https://github.com/cocos2d/cocos2d-x/pull/19759): set to default values when the resulting anchor is zero.