### PR TITLE
add specific define for metal

### DIFF
--- a/cocos/renderer/backend/metal/ProgramMTL.mm
+++ b/cocos/renderer/backend/metal/ProgramMTL.mm
@@ -27,12 +27,15 @@
 #include "base/ccMacros.h"
 
 CC_BACKEND_BEGIN
+namespace {
+    const std::string metalSpecificDefine = "#define METAL\n";
+}
 
 ProgramMTL::ProgramMTL(const std::string& vertexShader, const std::string& fragmentShader)
 : Program(vertexShader, fragmentShader)
 {
     _vertexShader = static_cast<ShaderModuleMTL*>(ShaderCache::newVertexShaderModule(vertexShader));
-    _fragmentShader = static_cast<ShaderModuleMTL*>(ShaderCache::newFragmentShaderModule(fragmentShader));
+    _fragmentShader = static_cast<ShaderModuleMTL*>(ShaderCache::newFragmentShaderModule(std::move(metalSpecificDefine + fragmentShader)));
 
     CC_SAFE_RETAIN(_vertexShader);
     CC_SAFE_RETAIN(_fragmentShader);

--- a/tests/cpp-tests/Classes/ShaderTest/ShaderTest.cpp
+++ b/tests/cpp-tests/Classes/ShaderTest/ShaderTest.cpp
@@ -202,6 +202,12 @@ void ShaderNode::updateUniforms()
     _locTime        = _programState->getUniformLocation("u_Time");
     _locSinTime     = _programState->getUniformLocation("u_SinTime");
     _locCosTime     = _programState->getUniformLocation("u_CosTime");
+    _locScreenSize  = _programState->getUniformLocation("u_screenSize");
+    
+    const Vec2& frameSize = Director::getInstance()->getOpenGLView()->getFrameSize();
+    float retinaFactor = Director::getInstance()->getOpenGLView()->getRetinaFactor();
+    auto screenSizeInPixels = frameSize * retinaFactor;
+    _programState->setUniform(_locScreenSize, &screenSizeInPixels, sizeof(screenSizeInPixels));
 }
 
 /// ShaderMonjori
@@ -598,8 +604,13 @@ bool ShaderRetroEffect::init()
         char * fragSource = (char*)fragStr.c_str();
 
         auto p = new backend::ProgramState(positionTextureColor_vert, fragSource);
-
         auto director = Director::getInstance();
+        const auto& screenSizeLocation = p->getUniformLocation("u_screenSize");
+        const auto& frameSize = director->getOpenGLView()->getFrameSize();
+        float retinaFactor = director->getOpenGLView()->getRetinaFactor();
+        auto screenSizeInPixels = frameSize * retinaFactor;
+        p->setUniform(screenSizeLocation, &screenSizeInPixels, sizeof(screenSizeInPixels));
+        
         auto s = director->getWinSize();
 
         _label = Label::createWithBMFont("fonts/west_england-64.fnt","RETRO EFFECT");

--- a/tests/cpp-tests/Classes/ShaderTest/ShaderTest.h
+++ b/tests/cpp-tests/Classes/ShaderTest/ShaderTest.h
@@ -182,6 +182,7 @@ protected:
     cocos2d::backend::UniformLocation   _locTime;
     cocos2d::backend::UniformLocation   _locSinTime;
     cocos2d::backend::UniformLocation   _locCosTime;
+    cocos2d::backend::UniformLocation   _locScreenSize;
 };
 
 class ShaderLensFlare : public ShaderTestDemo

--- a/tests/cpp-tests/Resources/Shaders/example_Flower.fsh
+++ b/tests/cpp-tests/Resources/Shaders/example_Flower.fsh
@@ -6,7 +6,7 @@ precision highp float;
 
 uniform vec2 center;
 uniform vec2 resolution;
-
+uniform vec2 u_screenSize;
 uniform vec4 u_Time;
 
 //float u( float x ) { return 0.5+0.5*sign(x); }
@@ -16,7 +16,12 @@ float u( float x ) { return (x>0.0)?1.0:0.0; }
 void main(void)
 {
 	float time = u_Time[1];
-	vec2 p = 2.0 * (gl_FragCoord.xy - center.xy) / resolution.xy;
+#ifdef METAL
+	vec2 fragCoord = vec2(gl_FragCoord.x, u_screenSize.y - gl_FragCoord.y);
+#else
+	vec2 fragCoord = gl_FragCoord.xy;
+#endif
+	vec2 p = 2.0 * (fragCoord - center.xy) / resolution.xy;
 	
 	float a = atan(p.x,p.y);
 	float r = length(p)*.75;

--- a/tests/cpp-tests/Resources/Shaders/example_Heart.fsh
+++ b/tests/cpp-tests/Resources/Shaders/example_Heart.fsh
@@ -6,13 +6,18 @@ precision highp float;
 
 uniform vec2 center;
 uniform vec2 resolution;
-
+uniform vec2 u_screenSize;
 uniform vec4 u_Time;
 
 void main(void)
 {
     float time = u_Time[1];
-    vec2 p = 2.0 * (gl_FragCoord.xy - center.xy) / resolution.xy;
+#ifdef METAL
+    vec2 fragCoord = vec2(gl_FragCoord.x, u_screenSize.y - gl_FragCoord.y);
+#else
+    vec2 fragCoord = gl_FragCoord.xy;
+#endif
+    vec2 p = 2.0 * (fragCoord - center.xy) / resolution.xy;
 
     // animate
     float tt = mod(time,2.0)/2.0;

--- a/tests/cpp-tests/Resources/Shaders/example_HorizontalColor.fsh
+++ b/tests/cpp-tests/Resources/Shaders/example_HorizontalColor.fsh
@@ -6,13 +6,18 @@ precision lowp float;
 
 varying vec2 v_texCoord;
 
+uniform vec2 u_screenSize;
 uniform sampler2D u_texture;
 
 void main(void)
 {
 	vec4 optColor;
-	
-	int y = int( mod(gl_FragCoord.y / 3.0, 10.0 ) );
+#ifdef METAL
+	float fragCoordY = u_screenSize.y - gl_FragCoord.y;
+#else
+	float fragCoordY = gl_FragCoord.y;
+#endif
+	int y = int( mod(fragCoordY / 3.0, 10.0 ) );
 	if(y == 0)	optColor = vec4(1,0,0,1);
 	else if(y == 1) optColor = vec4(0,1,0,1);
 	else if(y == 2) optColor = vec4(0,0,1,1);

--- a/tests/cpp-tests/Resources/Shaders/example_Julia.fsh
+++ b/tests/cpp-tests/Resources/Shaders/example_Julia.fsh
@@ -6,13 +6,18 @@ precision highp float;
 
 uniform vec2 center;
 uniform vec2 resolution;
-
+uniform vec2 u_screenSize;
 uniform vec4 u_Time;
 
 void main(void)
 {
     float time = u_Time[1];
-    vec2 p = 2.0 * (gl_FragCoord.xy - center.xy) / resolution.xy;
+#ifdef METAL
+	vec2 fragCoord = vec2(gl_FragCoord.x, u_screenSize.y - gl_FragCoord.y);
+#else
+	vec2 fragCoord = gl_FragCoord.xy;
+#endif
+    vec2 p = 2.0 * (fragCoord - center.xy) / resolution.xy;
     vec2 cc = vec2( cos(.25*time), sin(.25*time*1.423) );
 
     float dmin = 1000.0;

--- a/tests/cpp-tests/Resources/Shaders/example_Mandelbrot.fsh
+++ b/tests/cpp-tests/Resources/Shaders/example_Mandelbrot.fsh
@@ -6,12 +6,17 @@ precision highp float;
 
 uniform vec2 center;
 uniform vec2 resolution;
-
+uniform vec2 u_screenSize;
 uniform vec4 u_Time;
 
 void main(void)
 {
-    vec2 p = 2.0 * (gl_FragCoord.xy - center.xy) / resolution.xy;
+#ifdef METAL
+	vec2 fragCoord = vec2(gl_FragCoord.x, u_screenSize.y - gl_FragCoord.y);
+#else
+	vec2 fragCoord = gl_FragCoord.xy;
+#endif
+    vec2 p = 2.0 * (fragCoord - center.xy) / resolution.xy;
 	p.x *= resolution.x/resolution.y;
 
 	float zoo = .62+.38*sin(.1*u_Time[1]);

--- a/tests/cpp-tests/Resources/Shaders/example_Monjori.fsh
+++ b/tests/cpp-tests/Resources/Shaders/example_Monjori.fsh
@@ -7,10 +7,16 @@ precision highp float;
 uniform vec2 center;
 uniform vec2 resolution;
 uniform vec4 u_Time;
+uniform vec2 u_screenSize;
 
 void main(void)
 {
-    vec2 p = 2.0 * (gl_FragCoord.xy - center.xy) / resolution.xy;
+#ifdef METAL
+	vec2 fragCoord = vec2(gl_FragCoord.x, u_screenSize.y - gl_FragCoord.y);
+#else
+	vec2 fragCoord = gl_FragCoord.xy;
+#endif
+    vec2 p = 2.0 * (fragCoord - center.xy) / resolution.xy;
     float a = u_Time[1]*40.0;
     float d,e,f,g=1.0/40.0,h,i,r,q;
     e=400.0*(p.x*0.5+0.5);

--- a/tests/cpp-tests/Resources/Shaders/example_Noisy.fsh
+++ b/tests/cpp-tests/Resources/Shaders/example_Noisy.fsh
@@ -10,6 +10,7 @@ varying vec2 v_texCoord;
 uniform vec2 resolution;
 uniform sampler2D u_texture;
 uniform vec4 u_Time;
+uniform vec2 u_screenSize;
 
 const float intensity = 0.05;
 vec3 noise(vec2 uv)
@@ -22,7 +23,12 @@ vec3 noise(vec2 uv)
 
 void main(void)
 {
-	gl_FragColor.xyz = intensity * noise(gl_FragCoord.xy / sin(resolution.xy * u_Time[1] * 0.01)) + (1. - intensity) *
+#ifdef METAL
+	vec2 fragCoord = vec2(gl_FragCoord.x, u_screenSize.y - gl_FragCoord.y);
+#else
+	vec2 fragCoord = gl_FragCoord.xy;
+#endif
+	gl_FragColor.xyz = intensity * noise(fragCoord / sin(resolution.xy * u_Time[1] * 0.01)) + (1. - intensity) *
 			texture2D(u_texture,v_texCoord.xy).xyz;
 	gl_FragColor.w = 1.;
 }

--- a/tests/cpp-tests/Resources/Shaders/example_Plasma.fsh
+++ b/tests/cpp-tests/Resources/Shaders/example_Plasma.fsh
@@ -6,14 +6,19 @@ precision highp float;
 
 uniform vec2 center;
 uniform vec2 resolution;
-
+uniform vec2 u_screenSize;
 uniform vec4 u_Time;
 
 void main(void)
 {
+#ifdef METAL
+	float fragCoordY = u_screenSize.y - gl_FragCoord.y;
+#else
+	float fragCoordY = gl_FragCoord.y;
+#endif
    float time = u_Time[1];
-    float x = gl_FragCoord.x - (center.x - resolution.x / 2.0);
-   float y = gl_FragCoord.y - (center.y - resolution.y / 2.0);
+   float x = gl_FragCoord.x - (center.x - resolution.x / 2.0);
+   float y = fragCoordY - (center.y - resolution.y / 2.0);
    float mov0 = x+y+cos(sin(time)*2.)*100.+sin(x/100.)*1000.;
    float mov1 = y / resolution.y / 0.2 + time;
    float mov2 = x / resolution.x / 0.2;

--- a/tests/cpp-tests/Resources/Shaders/example_Twist.fsh
+++ b/tests/cpp-tests/Resources/Shaders/example_Twist.fsh
@@ -7,14 +7,19 @@ precision highp float;
 uniform vec2 resolution;
 uniform sampler2D tex0;
 uniform sampler2D tex1;
-
+uniform vec2 u_screenSize;
 uniform vec4 u_Time;
 uniform vec4 u_CosTime
 
 void main(void)
 {
+#ifdef METAL
+	vec2 fragCoord = vec2(gl_FragCoord.x, u_screenSize.y - gl_FragCoord.y);
+#else
+	vec2 fragCoord = gl_FragCoord.xy;
+#endif
     float time = u_Time[1];
-    vec2 p = -1.0 + 2.0 * gl_FragCoord.xy / resolution.xy;
+    vec2 p = -1.0 + 2.0 * fragCoord / resolution.xy;
     vec2 uv;
 
     float a = atan(p.y,p.x);

--- a/tests/cpp-tests/Resources/Shaders/shadertoy_FireBall.fsh
+++ b/tests/cpp-tests/Resources/Shaders/shadertoy_FireBall.fsh
@@ -1,6 +1,7 @@
 
 uniform vec2 center;
 uniform vec2 resolution;
+uniform vec2 u_screenSize;
 
 vec2   iCenter = center;
 //uniform float     iChannelTime[4];       // channel playback time (in seconds)
@@ -35,12 +36,17 @@ float snoise(vec3 uv, float res)
 
 void main(void)
 {
+#ifdef METAL
+	vec2 fragCoord = vec2(gl_FragCoord.x, u_screenSize.y - gl_FragCoord.y);
+#else
+	vec2 fragCoord = gl_FragCoord.xy;
+#endif
     vec2   iResolution = resolution;           // viewport resolution (in pixels)
     float  iGlobalTime = u_Time[1];           // shader playback time (in seconds)
 
-	//vec2 p = -.5 + gl_FragCoord.xy / iResolution.xy;
+	//vec2 p = -.5 + fragCoord.xy / iResolution.xy;
     
-    vec2 p = (gl_FragCoord.xy - center.xy) / iResolution.xy;
+    vec2 p = (fragCoord.xy - center.xy) / iResolution.xy;
 	p.x *= iResolution.x/iResolution.y;
 	
 	float color = 3.0 - (3.*length(2.*p));

--- a/tests/cpp-tests/Resources/Shaders/shadertoy_Glow.fsh
+++ b/tests/cpp-tests/Resources/Shaders/shadertoy_Glow.fsh
@@ -1,7 +1,7 @@
 
 uniform vec2 center;
 uniform vec2 resolution;
-
+uniform vec2 u_screenSize;
 
 //uniform float     iChannelTime[4];       // channel playback time (in seconds)
 //uniform vec3      iChannelResolution[4]; // channel resolution (in pixels)
@@ -13,6 +13,11 @@ uniform vec4 u_Time;
 
 void main(void)
 {
+#ifdef METAL
+	vec2 fragCoord = vec2(gl_FragCoord.x, u_screenSize.y - gl_FragCoord.y);
+#else
+	vec2 fragCoord = gl_FragCoord.xy;
+#endif
     vec2   iResolution = resolution;           // viewport resolution (in pixels)
     float  iGlobalTime = u_Time[1];           // shader playback time (in seconds)
 
@@ -22,8 +27,8 @@ void main(void)
 	
 	float minDimension = min(iResolution.x, iResolution.y);
 	vec2 bounds = vec2(iResolution.x / minDimension, iResolution.y / minDimension);
-	//vec2 uv = gl_FragCoord.xy / minDimension;
-	vec2 uv = (2. * gl_FragCoord.xy - center.xy) / iResolution.xy;
+	//vec2 uv = fragCoord.xy / minDimension;
+	vec2 uv = (2. * fragCoord.xy - center.xy) / iResolution.xy;
     
 	vec3 pointR = vec3(0.0, 0.0, 1.0);
 	vec3 pointG = vec3(0.0, 0.0, 1.0);

--- a/tests/cpp-tests/Resources/Shaders/shadertoy_LensFlare.fsh
+++ b/tests/cpp-tests/Resources/Shaders/shadertoy_LensFlare.fsh
@@ -1,7 +1,7 @@
 
 uniform vec2 center;
 uniform vec2 resolution;
-
+uniform vec2 u_screenSize;
 //uniform float     iChannelTime[4];       // channel playback time (in seconds)
 //uniform vec3      iChannelResolution[4]; // channel resolution (in pixels)
 vec4      iMouse = vec4(0,0,0,0);                // mouse pixel coords. xy: current (if MLB down), zw: click
@@ -81,11 +81,16 @@ vec3 cc(vec3 color, float factor,float factor2) // color modifier
 
 void main(void)
 {
+#ifdef METAL
+	vec2 fragCoord = vec2(gl_FragCoord.x, u_screenSize.y - gl_FragCoord.y);
+#else
+	vec2 fragCoord = gl_FragCoord.xy;
+#endif
     vec2   iResolution = resolution;           // viewport resolution (in pixels)
     float  iGlobalTime = u_Time[1];           // shader playback time (in seconds)
 
 	//vec2 uv = gl_FragCoord.xy / iResolution.xy - 0.5;
-    vec2 uv = (gl_FragCoord.xy - center.xy) / iResolution.xy;
+    vec2 uv = (fragCoord.xy - center.xy) / iResolution.xy;
 	uv.x *= iResolution.x/iResolution.y; //fix aspect ratio
 	vec3 mouse = vec3(iMouse.xy/iResolution.xy - 0.5,iMouse.z-.5);
 	mouse.x *= iResolution.x/iResolution.y; //fix aspect ratio
@@ -96,7 +101,7 @@ void main(void)
 	}
 	
 	vec3 color = vec3(1.4,1.2,1.0)*lensflare(uv,mouse.xy);
-	color -= noise(gl_FragCoord.xy)*.015;
+	color -= noise(fragCoord.xy)*.015;
 	color = cc(color,.5,.1);
 	gl_FragColor = vec4(color,1.0);
 }


### PR DESCRIPTION
In Metal, the origin of texture coordinate system is at the top-left corner. So need specific defines for metal to deal with `gl_FragCoord` issue.