### PR TITLE
uses the same precision for uniforms

### DIFF
--- a/cocos/renderer/CCGLProgram.cpp
+++ b/cocos/renderer/CCGLProgram.cpp
@@ -491,7 +491,7 @@ bool GLProgram::compileShader(GLuint * shader, GLenum type, const GLchar* source
 #elif CC_TARGET_PLATFORM == CC_PLATFORM_ANDROID
         headersDef = (type == GL_VERTEX_SHADER ?
             "#version 100\n precision highp float;\n precision highp int;\n" :
-            "#version 100\n precision mediump float;\n precision mediump int;\n");
+            "#version 100\n precision highp float;\n precision highp int;\n");
 #elif (CC_TARGET_PLATFORM != CC_PLATFORM_WIN32 && CC_TARGET_PLATFORM != CC_PLATFORM_LINUX && CC_TARGET_PLATFORM != CC_PLATFORM_MAC)
         headersDef = (type == GL_VERTEX_SHADER ? "precision highp float;\n precision highp int;\n" : "precision mediump float;\n precision mediump int;\n");
 #endif

--- a/cocos/renderer/ccShader_PositionTextureColor_noMVP.frag
+++ b/cocos/renderer/ccShader_PositionTextureColor_noMVP.frag
@@ -24,9 +24,6 @@
  */
 
 const char* ccPositionTextureColor_noMVP_frag = R"(
-#ifdef GL_ES
-precision lowp float;
-#endif
 
 varying vec4 v_fragmentColor;
 varying vec2 v_texCoord;


### PR DESCRIPTION
If using different precision for uniforms, then will meet link error in Android 10. So change to use highp both in vertex and fragment shader. It may affect the performance(i am not sure because engine builtin shaders are not complex), so it is a hot fix. 