### PR TITLE
Recompile libfreetype for ubuntu18.04

### DIFF
--- a/external/config.json
+++ b/external/config.json
@@ -1,5 +1,5 @@
 {
-    "version": "v3-deps-162",
+    "version": "v3-deps-163",
     "zip_file_size": "141133955",
     "repo_name": "cocos2d-x-3rd-party-libs-bin",
     "repo_parent": "https://github.com/cocos2d/",


### PR DESCRIPTION
recompile libfreetype.a with `-fPIC`