### PR TITLE
Avoid Using "|" with Previously Declared Enum Values

### DIFF
--- a/cocos/2d/CCNode.h
+++ b/cocos/2d/CCNode.h
@@ -117,7 +117,8 @@ public:
         FLAGS_CONTENT_SIZE_DIRTY = (1 << 1),
         FLAGS_RENDER_AS_3D = (1 << 3),
 
-        FLAGS_DIRTY_MASK = (FLAGS_TRANSFORM_DIRTY | FLAGS_CONTENT_SIZE_DIRTY),
+        // FLAGS_DIRTY_MASK = (FLAGS_TRANSFORM_DIRTY | FLAGS_CONTENT_SIZE_DIRTY)
+        FLAGS_DIRTY_MASK = ((1 << 0) | (1 << 1)),
     };
     /// @{
     /// @name Constructor, Destructor and Initializers
@@ -133,7 +134,7 @@ public:
      */
     static int getAttachedNodeCount();
 public:
-    
+
     /**
      * Gets the description string. It makes debugging easier.
      * @return A string
@@ -154,11 +155,11 @@ public:
 
      The Node's parent will sort all its children based on the LocalZOrder value.
      If two nodes have the same LocalZOrder, then the node that was added first to the children's array will be in front of the other node in the array.
-     
+
      Also, the Scene Graph is traversed using the "In-Order" tree traversal algorithm ( http://en.wikipedia.org/wiki/Tree_traversal#In-order )
      And Nodes that have LocalZOrder values < 0 are the "left" subtree
      While Nodes with LocalZOrder >=0 are the "right" subtree.
-     
+
      @see `setGlobalZOrder`
      @see `setVertexZ`
      *
@@ -167,8 +168,8 @@ public:
     virtual void setLocalZOrder(std::int32_t localZOrder);
 
     CC_DEPRECATED_ATTRIBUTE virtual void setZOrder(std::int32_t localZOrder) { setLocalZOrder(localZOrder); }
-    
-    /* 
+
+    /*
      Helper function used by `setLocalZOrder`. Don't use it unless you know what you are doing.
      @js NA
      */
@@ -201,14 +202,14 @@ public:
     /**
      Defines the order in which the nodes are renderer.
      Nodes that have a Global Z Order lower, are renderer first.
-     
+
      In case two or more nodes have the same Global Z Order, the order is not guaranteed.
      The only exception if the Nodes have a Global Z Order == 0. In that case, the Scene Graph order is used.
-     
+
      By default, all nodes have a Global Z Order = 0. That means that by default, the Scene Graph order is used to render the nodes.
-     
+
      Global Z Order is useful when you need to render nodes in an order different than the Scene Graph order.
-     
+
      Limitations: Global Z Order can't be used by Nodes that have SpriteBatchNode as one of their ancestors.
      And if ClippingNode is one of the ancestors, then "global Z order" will be relative to the ClippingNode.
 
@@ -363,7 +364,7 @@ public:
     virtual const Vec2& getPosition() const;
 
     /** Returns the normalized position.
-     * 
+     *
      * @return The normalized position.
      */
     virtual const Vec2& getPositionNormalized() const;
@@ -424,7 +425,7 @@ public:
 
     /**
      * Sets the position (X, Y, and Z) in its parent's coordinate system.
-     * 
+     *
      * @param position The position (X, Y, and Z) in its parent's coordinate system.
      * @js NA
      */
@@ -613,12 +614,12 @@ public:
     virtual void setRotation3D(const Vec3& rotation);
     /**
      * Returns the rotation (X,Y,Z) in degrees.
-     * 
+     *
      * @return The rotation of the node in 3d.
      * @js NA
      */
     virtual Vec3 getRotation3D() const;
-    
+
     /**
      * Set rotation by quaternion. You should make sure the quaternion is normalized.
      *
@@ -626,7 +627,7 @@ public:
      * @js NA
      */
     virtual void setRotationQuat(const Quaternion& quat);
-    
+
     /**
      * Return the rotation by quaternion, Note that when _rotationZ_X == _rotationZ_Y, the returned quaternion equals to RotationZ_X * RotationY * RotationX,
      * it equals to RotationY * RotationX otherwise.
@@ -659,7 +660,7 @@ public:
      * @see `setRotationSkewX(float)`
      *
      * @return The X rotation in degrees.
-     * @js getRotationX 
+     * @js getRotationX
      */
     virtual float getRotationSkewX() const;
     CC_DEPRECATED_ATTRIBUTE virtual float getRotationX() const { return getRotationSkewX(); }
@@ -711,7 +712,7 @@ public:
      */
     virtual void setIgnoreAnchorPointForPosition(bool ignore);
     CC_DEPRECATED_ATTRIBUTE virtual void ignoreAnchorPointForPosition(bool ignore) { setIgnoreAnchorPointForPosition(ignore); }
-    
+
     /**
      * Gets whether the anchor point will be (0,0) when you position this node.
      *
@@ -752,7 +753,7 @@ public:
      * @param child         A child node.
      * @param localZOrder   Z order for drawing priority. Please refer to `setLocalZOrder(int)`.
      * @param tag           An integer to identify the node easily. Please refer to `setTag(int)`.
-     * 
+     *
      * Please use `addChild(Node* child, int localZOrder, const std::string &name)` instead.
      */
      virtual void addChild(Node* child, int localZOrder, int tag);
@@ -777,7 +778,7 @@ public:
      * Please use `getChildByName()` instead.
      */
      virtual Node * getChildByTag(int tag) const;
-    
+
      /**
      * Gets a child from the container with its tag that can be cast to Type T.
      *
@@ -787,7 +788,7 @@ public:
     */
     template <typename T>
     T getChildByTag(int tag) const { return static_cast<T>(getChildByTag(tag)); }
-    
+
     /**
      * Gets a child from the container with its name.
      *
@@ -828,7 +829,7 @@ public:
      * @warning Only support alpha or number for name, and not support unicode.
      *
      * @param callback A callback function to execute on nodes that match the `name` parameter. The function takes the following arguments:
-     *  `node` 
+     *  `node`
      *      A node that matches the name
      *  And returns a boolean result. Your callback can return `true` to terminate the enumeration.
      *
@@ -842,8 +843,8 @@ public:
      */
     virtual Vector<Node*>& getChildren() { return _children; }
     virtual const Vector<Node*>& getChildren() const { return _children; }
-    
-    /** 
+
+    /**
      * Returns the amount of children.
      *
      * @return The amount of children.
@@ -958,7 +959,7 @@ public:
     }
 
     /// @} end of Children and Parent
-    
+
     /// @{
     /// @name Tag & User data
 
@@ -980,10 +981,10 @@ public:
      * Please use `setName()` instead.
      */
      virtual void setTag(int tag);
-    
+
     /** Returns a string that is used to identify the node.
      * @return A string that identifies the node.
-     * 
+     *
      * @since v3.2
      */
     virtual const std::string& getName() const;
@@ -994,7 +995,7 @@ public:
      */
     virtual void setName(const std::string& name);
 
-    
+
     /**
      * Returns a custom user data pointer.
      *
@@ -1072,7 +1073,7 @@ public:
      */
     virtual void setGLProgram(GLProgram *glprogram);
     CC_DEPRECATED_ATTRIBUTE void setShaderProgram(GLProgram *glprogram) { setGLProgram(glprogram); }
-    
+
     /**
      * Return the GLProgramState currently used for this node.
      *
@@ -1085,7 +1086,7 @@ public:
      * @param glProgramState The GLProgramState for this node.
      */
     virtual void setGLProgramState(GLProgramState *glProgramState);
-    
+
     /// @} end of Shader Program
 
 
@@ -1162,7 +1163,7 @@ public:
      * - `glEnable(GL_TEXTURE_2D);`
      * AND YOU SHOULD NOT DISABLE THEM AFTER DRAWING YOUR NODE
      * But if you enable any other GL state, you should disable it after drawing your node.
-     * 
+     *
      * @param renderer A given renderer.
      * @param transform A transform matrix.
      * @param flags Renderer flag.
@@ -1257,7 +1258,7 @@ public:
      * @param tag   A tag that indicates the action to be removed.
      */
     void stopActionByTag(int tag);
-    
+
     /**
      * Removes all actions from the running action list by its tag.
      *
@@ -1572,7 +1573,7 @@ public:
      */
     virtual AffineTransform getNodeToParentAffineTransform(Node* ancestor) const;
 
-    /** 
+    /**
      * Sets the transformation matrix manually.
      *
      * @param transform A given transformation matrix.
@@ -1714,7 +1715,7 @@ public:
      */
     virtual bool removeComponent(const std::string& name);
 
-    /** 
+    /**
      * Removes a component by its pointer.
      *
      * @param component A given component.
@@ -1726,7 +1727,7 @@ public:
      */
     virtual void removeAllComponents();
     /// @} end of component functions
-    
+
     // overrides
     /**
      * Return the node's opacity.
@@ -1844,7 +1845,7 @@ public:
      * @return std::function<void()>
      */
     const std::function<void()>& getonExitTransitionDidStartCallback() const { return _onExitTransitionDidStartCallback; }
-    
+
     /**
      * get & set camera mask, the node is visible by the camera whose camera flag & node's camera mask is true
      */
@@ -1867,7 +1868,7 @@ CC_CONSTRUCTOR_ACCESS:
 protected:
     /// lazy allocs
     void childrenAlloc();
-    
+
     /// helper that reorder a child
     void insertChild(Node* child, int z);
 
@@ -1885,21 +1886,21 @@ protected:
     virtual void updateCascadeColor();
     virtual void disableCascadeColor();
     virtual void updateColor() {}
-    
+
     bool doEnumerate(std::string name, const std::function<bool (Node *)>& callback) const;
     bool doEnumerateRecursive(const Node* node, const std::string &name, const std::function<bool (Node *)>& callback) const;
-    
+
     //check whether this camera mask is visible by the current visiting camera
     bool isVisitableByVisitingCamera() const;
-    
+
     // update quaternion from Rotation3D
     void updateRotationQuat();
     // update Rotation3D from quaternion
     void updateRotation3D();
-    
+
 private:
     void addChildHelper(Node* child, int localZOrder, int tag, const std::string &name, bool setTag);
-    
+
 protected:
 
     float _rotationX;               ///< rotation on the X-axis
@@ -1908,7 +1909,7 @@ protected:
     // rotation Z is decomposed in 2 to simulate Skew for Flash animations
     float _rotationZ_X;             ///< rotation angle on Z-axis, component X
     float _rotationZ_Y;             ///< rotation angle on Z-axis, component Y
-    
+
     Quaternion _rotationQuat;       ///rotation using quaternion, if _rotationZ_X == _rotationZ_Y, _rotationQuat = RotationZ_X * RotationY * RotationX, else _rotationQuat = RotationY * RotationX
 
     float _scaleX;                  ///< scaling factor on x-axis
@@ -1967,7 +1968,7 @@ protected:
     Node *_parent;                  ///< weak reference to parent node
     Director* _director;            //cached director pointer to improve rendering performance
     int _tag;                       ///< a tag. Can be any number you assigned just to identify this node
-    
+
     std::string _name;              ///<a string label, an user defined string to identify this node
     size_t _hashOfName;             ///<hash value of _name, used for speed in getChildByName
 
@@ -1997,9 +1998,9 @@ protected:
     int _updateScriptHandler;         ///< script handler for update() callback per frame, which is invoked from lua & javascript.
     ccScriptType _scriptType;         ///< type of script binding, lua or javascript
 #endif
-    
+
     ComponentContainer *_componentContainer;        ///< Dictionary of components
-    
+
     // opacity controls
     GLubyte     _displayedOpacity;
     GLubyte     _realOpacity;
@@ -2010,13 +2011,13 @@ protected:
 
     // camera mask, it is visible only when _cameraMask & current camera' camera flag is true
     unsigned short _cameraMask;
-    
+
     std::function<void()> _onEnterCallback;
     std::function<void()> _onExitCallback;
     std::function<void()> _onEnterTransitionDidFinishCallback;
     std::function<void()> _onExitTransitionDidStartCallback;
 
-//Physics:remaining backwardly compatible  
+//Physics:remaining backwardly compatible
 #if CC_USE_PHYSICS
     PhysicsBody* _physicsBody;
 public:
@@ -2035,7 +2036,7 @@ public:
 #endif
 
     static int __attachedNodeCount;
-    
+
 private:
     CC_DISALLOW_COPY_AND_ASSIGN(Node);
 };
@@ -2061,11 +2062,11 @@ bool CC_DLL isScreenPointInRect(const Vec2 &pt, const Camera* camera, const Mat4
 
 /** @class __NodeRGBA
  * @brief __NodeRGBA is a subclass of Node that implements the RGBAProtocol protocol.
- 
+
  All features from Node are valid, plus the following new features:
  - opacity
  - RGB colors
- 
+
  Opacity/Color propagates into children that conform to the RGBAProtocol if cascadeOpacity/cascadeColor is enabled.
  @since v2.1
  @js NA

--- a/cocos/2d/CCTMXXMLParser.h
+++ b/cocos/2d/CCTMXXMLParser.h
@@ -79,7 +79,8 @@ typedef enum TMXTileFlags_ {
     kTMXTileHorizontalFlag  = 0x80000000,
     kTMXTileVerticalFlag    = 0x40000000,
     kTMXTileDiagonalFlag    = 0x20000000,
-    kTMXFlipedAll           = (kTMXTileHorizontalFlag|kTMXTileVerticalFlag|kTMXTileDiagonalFlag),
+    // kTMXFlipedAll           = (kTMXTileHorizontalFlag|kTMXTileVerticalFlag|kTMXTileDiagonalFlag),
+    kTMXFlipedAll           = (0x80000000|0x40000000|0x20000000),
     kTMXFlippedMask         = ~(kTMXFlipedAll)
 } TMXTileFlags;
 
@@ -127,7 +128,7 @@ public:
 - Image used for the tiles
 - Image size
 
-This information is obtained from the TMX file. 
+This information is obtained from the TMX file.
 */
 class CC_DLL TMXTilesetInfo : public Ref
 {
@@ -171,13 +172,13 @@ This information is obtained from the TMX file.
 
 */
 class CC_DLL TMXMapInfo : public Ref, public SAXDelegator
-{    
-public:    
+{
+public:
     /** creates a TMX Format with a tmx file */
     static TMXMapInfo * create(const std::string& tmxFile);
     /** creates a TMX Format with an XML string and a TMX resource path */
     static TMXMapInfo * createWithXML(const std::string& tmxString, const std::string& resourcePath);
-    
+
     /** creates a TMX Format with a tmx file */
     CC_DEPRECATED_ATTRIBUTE static TMXMapInfo * formatWithTMXFile(const char *tmxFile) { return TMXMapInfo::create(tmxFile); };
     /** creates a TMX Format with an XML string and a TMX resource path */
@@ -191,7 +192,7 @@ public:
      * @lua NA
      */
     virtual ~TMXMapInfo();
-    
+
     /** initializes a TMX format with a  tmx file */
     bool initWithTMXFile(const std::string& tmxFile);
     /** initializes a TMX format with an XML string and a TMX resource path */
@@ -209,7 +210,7 @@ public:
     /// map orientation
     int getOrientation() const { return _orientation; }
     void setOrientation(int orientation) { _orientation = orientation; }
-    
+
     /// map staggeraxis
     int getStaggerAxis() const { return _staggerAxis; }
     void setStaggerAxis(int staggerAxis) { _staggerAxis = staggerAxis; }
@@ -229,7 +230,7 @@ public:
     /// tiles width & height
     const Size& getTileSize() const { return _tileSize; }
     void setTileSize(const Size& tileSize) { _tileSize = tileSize; }
-    
+
     /// Layers
     const Vector<TMXLayerInfo*>& getLayers() const { return _layers; }
     Vector<TMXLayerInfo*>& getLayers() { return _layers; }
@@ -274,7 +275,7 @@ public:
     void setProperties(const ValueMap& properties) {
         _properties = properties;
     }
-    
+
     // implement pure virtual methods of SAXDelegator
     /**
      * @js NA
@@ -291,7 +292,7 @@ public:
      * @lua NA
      */
     void textHandler(void *ctx, const char *ch, size_t len) override;
-    
+
     const std::string& getCurrentString() const { return _currentString; }
     void setCurrentString(const std::string& currentString){ _currentString = currentString; }
     const std::string& getTMXFileName() const { return _TMXFileName; }
@@ -331,7 +332,7 @@ protected:
     ValueMap _properties;
     //! xml format tile index
     int _xmlTileIndex;
-    
+
     //! tmx filename
     std::string _TMXFileName;
     // tmx resource path

--- a/cocos/deprecated/CCString.h
+++ b/cocos/deprecated/CCString.h
@@ -77,83 +77,83 @@ public:
      * @lua NA
      */
     virtual ~__String();
-    
-    /* override assignment operator 
+
+    /* override assignment operator
      * @js NA
      * @lua NA
      */
     __String& operator= (const __String& other);
 
-    /** init a string with format, it's similar with the c function 'sprintf' 
+    /** init a string with format, it's similar with the c function 'sprintf'
      * @js NA
      * @lua NA
      */
     bool initWithFormat(const char* format, ...) CC_FORMAT_PRINTF(2, 3);
 
-    /** convert to int value 
+    /** convert to int value
      * @js NA
      */
     int intValue() const;
 
-    /** convert to unsigned int value 
+    /** convert to unsigned int value
      * @js NA
      */
     unsigned int uintValue() const;
 
-    /** convert to float value 
+    /** convert to float value
      * @js NA
      */
     float floatValue() const;
 
-    /** convert to double value 
+    /** convert to double value
      * @js NA
      */
     double doubleValue() const;
 
-    /** convert to bool value 
+    /** convert to bool value
      * @js NA
      */
     bool boolValue() const;
 
-    /** get the C string 
+    /** get the C string
      * @js NA
      */
     const char* getCString() const;
 
-    /** get the length of string 
+    /** get the length of string
      * @js NA
      */
     int length() const;
 
-    /** compare to a c string 
+    /** compare to a c string
      * @js NA
      */
     int compare(const char *) const;
 
-    /** append additional characters at the end of its current value 
+    /** append additional characters at the end of its current value
      * @js NA
      * @lua NA
      */
     void append(const std::string& str);
 
-    /** append(w/ format) additional characters at the end of its current value 
+    /** append(w/ format) additional characters at the end of its current value
      * @js NA
      * @lua NA
      */
     void appendWithFormat(const char* format, ...);
 
-    /** split a string 
+    /** split a string
      * @js NA
      * @lua NA
      */
     __Array* componentsSeparatedByString(const char *delimiter);
-    
-    /* override functions 
+
+    /* override functions
      * @js NA
      */
     virtual bool isEqual(const Ref* pObject);
 
-    /** create a string with std string, you can also pass a c string pointer because the default constructor of std::string can access a c string pointer. 
+    /** create a string with std string, you can also pass a c string pointer because the default constructor of std::string can access a c string pointer.
      *  @return A String pointer which is an autorelease object pointer,
      *          it means that you needn't do a release operation unless you retain it.
      * @js NA
@@ -168,14 +168,14 @@ public:
      */
     static __String* createWithFormat(const char* format, ...) CC_FORMAT_PRINTF(1, 2);
 
-    /** create a string with binary data 
+    /** create a string with binary data
      *  @return A String pointer which is an autorelease object pointer,
      *          it means that you needn't do a release operation unless you retain it.
      * @js NA
      */
     static __String* createWithData(const unsigned char* pData, size_t nLen);
 
-    /** create a string with a file, 
+    /** create a string with a file,
      *  @return A String pointer which is an autorelease object pointer,
      *          it means that you needn't do a release operation unless you retain it.
      * @js NA
@@ -191,7 +191,7 @@ public:
      * @lua NA
      */
     virtual __String* clone() const override;
-    
+
 private:
 
     /** only for internal use */
@@ -201,7 +201,7 @@ public:
     std::string _string;
 };
 
-struct StringCompare : public std::binary_function<__String *, __String *, bool> {
+struct StringCompare : public std::function<bool(__String *, __String *)> {
     public:
         bool operator() (__String * a, __String * b) const {
             return strcmp(a->getCString(), b->getCString()) < 0;

--- a/cocos/renderer/ccGLStateCache.h
+++ b/cocos/renderer/ccGLStateCache.h
@@ -55,11 +55,12 @@ enum {
     VERTEX_ATTRIB_FLAG_NORMAL = 1 << 3,
     VERTEX_ATTRIB_FLAG_BLEND_WEIGHT = 1 << 4,
     VERTEX_ATTRIB_FLAG_BLEND_INDEX = 1 << 5,
-    
-    VERTEX_ATTRIB_FLAG_POS_COLOR_TEX = (VERTEX_ATTRIB_FLAG_POSITION | VERTEX_ATTRIB_FLAG_COLOR | VERTEX_ATTRIB_FLAG_TEX_COORD),
+
+    // VERTEX_ATTRIB_FLAG_POS_COLOR_TEX = (VERTEX_ATTRIB_FLAG_POSITION | VERTEX_ATTRIB_FLAG_COLOR | VERTEX_ATTRIB_FLAG_TEX_COORD),
+    VERTEX_ATTRIB_FLAG_POS_COLOR_TEX = ((1 << 0) | (1 << 1) | (1 << 2)),
 };
 
-/** 
+/**
  * Invalidates the GL state cache.
  *
  * If CC_ENABLE_GL_STATE_CACHE it will reset the GL state cache.
@@ -67,7 +68,7 @@ enum {
  */
 void CC_DLL invalidateStateCache();
 
-/** 
+/**
  * Uses the GL program in case program is different than the current one.
 
  * If CC_ENABLE_GL_STATE_CACHE is disabled, it will the glUseProgram() directly.
@@ -75,7 +76,7 @@ void CC_DLL invalidateStateCache();
  */
 void CC_DLL useProgram(GLuint program);
 
-/** 
+/**
  * Deletes the GL program. If it is the one that is being used, it invalidates it.
  *
  * If CC_ENABLE_GL_STATE_CACHE is disabled, it will the glDeleteProgram() directly.
@@ -83,7 +84,7 @@ void CC_DLL useProgram(GLuint program);
  */
 void CC_DLL deleteProgram(GLuint program);
 
-/** 
+/**
  * Uses a blending function in case it not already used.
  *
  * If CC_ENABLE_GL_STATE_CACHE is disabled, it will the glBlendFunc() directly.
@@ -91,7 +92,7 @@ void CC_DLL deleteProgram(GLuint program);
  */
 void CC_DLL blendFunc(GLenum sfactor, GLenum dfactor);
 
-/** 
+/**
  * Resets the blending mode back to the cached state in case you used glBlendFuncSeparate() or glBlendEquation().
  *
  * If CC_ENABLE_GL_STATE_CACHE is disabled, it will just set the default blending mode using GL_FUNC_ADD.
@@ -99,27 +100,27 @@ void CC_DLL blendFunc(GLenum sfactor, GLenum dfactor);
  */
 void CC_DLL blendResetToCache();
 
-/** 
+/**
  * Sets the projection matrix as dirty.
  * @since v2.0.0
  */
 void CC_DLL setProjectionMatrixDirty();
 
-/** 
+/**
  * Will enable the vertex attribs that are passed as flags.
  * Possible flags:
- * 
+ *
  *    * VERTEX_ATTRIB_FLAG_POSITION
  *    * VERTEX_ATTRIB_FLAG_COLOR
  *    * VERTEX_ATTRIB_FLAG_TEX_COORDS
- * 
+ *
  * These flags can be ORed. The flags that are not present, will be disabled.
- * 
+ *
  * @since v2.0.0
  */
 void CC_DLL enableVertexAttribs(uint32_t flags);
 
-/** 
+/**
  * If the texture is not already bound to texture unit 0, it binds it.
  *
  * If CC_ENABLE_GL_STATE_CACHE is disabled, it will call glBindTexture() directly.
@@ -137,7 +138,7 @@ void CC_DLL bindTexture2D(GLuint textureId);
 */
 void CC_DLL bindTexture2D(Texture2D* texture);
 
-/** 
+/**
  * If the texture is not already bound to a given unit, it binds it.
  *
  * If CC_ENABLE_GL_STATE_CACHE is disabled, it will call glBindTexture() directly.
@@ -151,7 +152,7 @@ void CC_DLL bindTexture2DN(GLuint textureUnit, GLuint textureId);
  */
 void CC_DLL bindTextureN(GLuint textureUnit, GLuint textureId, GLuint textureType = GL_TEXTURE_2D);
 
-/** 
+/**
  * It will delete a given texture. If the texture was bound, it will invalidate the cached.
  *
  * If CC_ENABLE_GL_STATE_CACHE is disabled, it will call glDeleteTextures() directly.
@@ -159,7 +160,7 @@ void CC_DLL bindTextureN(GLuint textureUnit, GLuint textureId, GLuint textureTyp
  */
 void CC_DLL deleteTexture(GLuint textureId);
 
-/** 
+/**
  * It will delete a given texture. If the texture was bound, it will invalidate the cached for the given texture unit.
  *
  * If CC_ENABLE_GL_STATE_CACHE is disabled, it will call glDeleteTextures() directly.
@@ -167,7 +168,7 @@ void CC_DLL deleteTexture(GLuint textureId);
  */
 CC_DEPRECATED_ATTRIBUTE void CC_DLL deleteTextureN(GLuint textureUnit, GLuint textureId);
 
-/** 
+/**
  * Select active texture unit.
  *
  * If CC_ENABLE_GL_STATE_CACHE is disabled, it will call glActiveTexture() directly.
@@ -175,7 +176,7 @@ CC_DEPRECATED_ATTRIBUTE void CC_DLL deleteTextureN(GLuint textureUnit, GLuint te
  */
 void CC_DLL activeTexture(GLenum texture);
 
-/** 
+/**
  * If the vertex array is not already bound, it binds it.
  *
  * If CC_ENABLE_GL_STATE_CACHE is disabled, it will call glBindVertexArray() directly.
@@ -188,6 +189,6 @@ void CC_DLL bindVAO(GLuint vaoId);
 
 } // Namespace GL
 NS_CC_END
-    
+
 
 #endif /* __CCGLSTATE_H__ */


### PR DESCRIPTION
Unfortunately, without using only literals when declaring enum values, the following error will occur when I compiled with MSVC 2019 v142:

"expression did not evaluate to a constant"

`Node::FLAGS_DIRTY_MASK`, `GL::VERTEX_ATTRIB_FLAG_POS_COLOR_TEX` and `TMXTileFlags::kTMXFlipedAll` are edited.

I do not think this is the most elegant solution but at least this let's my project compile.

I have kept the original assignment lines in comments for reference.

If there are other ways to circumvent this, please let me know. I would much prefer to do it without changing this part.