### PR TITLE
fix Physics3DDebugDrawer

### DIFF
--- a/cocos/physics3d/CCPhysics3DDebugDrawer.cpp
+++ b/cocos/physics3d/CCPhysics3DDebugDrawer.cpp
@@ -106,7 +106,7 @@ void Physics3DDebugDrawer::draw( Renderer *renderer)
         _dirty = false;
     }
 
-    _customCommand.setIndexDrawInfo(0, _buffer.size());
+    _customCommand.setVertexDrawInfo(0, _buffer.size());
 
     CC_INCREMENT_GL_DRAWN_BATCHES_AND_VERTICES(1, _buffer.size());
 

--- a/cocos/physics3d/CCPhysics3DDebugDrawer.h
+++ b/cocos/physics3d/CCPhysics3DDebugDrawer.h
@@ -46,7 +46,6 @@ NS_CC_BEGIN
  * @{
  */
 
-class GLProgram;
 class Renderer;
 
 /** @brief Physics3DDebugDrawer: debug draw the physics object, used by Physics3DWorld */


### PR DESCRIPTION
ref issue [here](https://discuss.cocos2d-x.org/t/are-you-using-v4-metal-currently/47145/45): Since drawing type is `ARRAY`, should use  `setVertexDrawInfo` instead.