### PR TITLE
[v4] update external version to metal-support-16

### DIFF
--- a/external/config.json
+++ b/external/config.json
@@ -1,5 +1,5 @@
 {
-    "version": "metal-support-15",
+    "version": "metal-support-16",
     "zip_file_size": "146254799",
     "repo_name": "cocos2d-x-3rd-party-libs-bin",
     "repo_parent": "https://github.com/cocos2d/",


### PR DESCRIPTION
recompile libfreetype.a for ubuntu 18