### PR TITLE
Don't use MTL_ pixelformat when building for iOS Simulator.

### DIFF
--- a/cocos/renderer/CCTexture2D.cpp
+++ b/cocos/renderer/CCTexture2D.cpp
@@ -406,7 +406,7 @@ bool Texture2D::initWithImage(Image *image, backend::PixelFormat format)
     //override renderFormat, since some render format is not supported by metal
     switch (renderFormat)
     {
-#if (CC_TARGET_PLATFORM == CC_PLATFORM_IOS)
+#if (CC_TARGET_PLATFORM == CC_PLATFORM_IOS && !TARGET_OS_SIMULATOR)
         //packed 16 bits pixels only available on iOS
         case PixelFormat::RGB565:
             renderFormat = PixelFormat::MTL_B5G6R5;


### PR DESCRIPTION
This simple fix allows metal to run under the iOS Simulator.