### PR TITLE
Rename cocos2d::MessageBox to cocos2d::ccMessageBox. (#20159)

### DIFF
--- a/cocos/platform/CCCommon.h
+++ b/cocos/platform/CCCommon.h
@@ -45,7 +45,7 @@ void CC_DLL LuaLog(const char * format);
 /**
 @brief Pop out a message box
 */
-void CC_DLL MessageBox(const char * msg, const char * title);
+void CC_DLL ccMessageBox(const char * msg, const char * title);
 
 /**
 @brief Enum the language type supported now

--- a/cocos/platform/android/CCCommon-android.cpp
+++ b/cocos/platform/android/CCCommon-android.cpp
@@ -37,7 +37,7 @@ NS_CC_BEGIN
 
 #define MAX_LEN         (cocos2d::kMaxLogLen + 1)
 
-void MessageBox(const char * pszMsg, const char * pszTitle)
+void ccMessageBox(const char * pszMsg, const char * pszTitle)
 {
     JniHelper::callStaticVoidMethod("org.cocos2dx.lib.Cocos2dxHelper", "showDialog", pszTitle, pszMsg);
 }

--- a/cocos/platform/desktop/CCGLViewImpl-desktop.cpp
+++ b/cocos/platform/desktop/CCGLViewImpl-desktop.cpp
@@ -316,7 +316,7 @@ bool GLViewImpl::initWithRect(const std::string& viewName, Rect rect, float fram
             message.append(_glfwError);
         }
 
-        MessageBox(message.c_str(), "Error launch application");
+        ccMessageBox(message.c_str(), "Error launch application");
         return false;
     }
 
@@ -367,7 +367,7 @@ bool GLViewImpl::initWithRect(const std::string& viewName, Rect rect, float fram
         sprintf(strComplain,
                 "OpenGL 1.5 or higher is required (your version is %s). Please upgrade the driver of your video card.",
                 glVersion);
-        MessageBox(strComplain, "OpenGL version too old");
+        ccMessageBox(strComplain, "OpenGL version too old");
         return false;
     }
 
@@ -1012,7 +1012,7 @@ bool GLViewImpl::initGlew()
     GLenum GlewInitResult = glewInit();
     if (GLEW_OK != GlewInitResult)
     {
-        MessageBox((char *)glewGetErrorString(GlewInitResult), "OpenGL error");
+        ccMessageBox((char *)glewGetErrorString(GlewInitResult), "OpenGL error");
         return false;
     }
 
@@ -1038,7 +1038,7 @@ bool GLViewImpl::initGlew()
 #if (CC_TARGET_PLATFORM == CC_PLATFORM_WIN32)
     if(glew_dynamic_binding() == false)
     {
-        MessageBox("No OpenGL framebuffer support. Please upgrade the driver of your video card.", "OpenGL error");
+        ccMessageBox("No OpenGL framebuffer support. Please upgrade the driver of your video card.", "OpenGL error");
         return false;
     }
 #endif //#if (CC_TARGET_PLATFORM == CC_PLATFORM_WIN32)

--- a/cocos/platform/ios/CCCommon-ios.mm
+++ b/cocos/platform/ios/CCCommon-ios.mm
@@ -39,7 +39,7 @@
 NS_CC_BEGIN
 
 // ios no MessageBox, use log instead
-void MessageBox(const char * msg, const char * title)
+void ccMessageBox(const char * msg, const char * title)
 {
     // only enable it on iOS.
     // FIXME: Implement it for tvOS

--- a/cocos/platform/linux/CCCommon-linux.cpp
+++ b/cocos/platform/linux/CCCommon-linux.cpp
@@ -33,7 +33,7 @@ THE SOFTWARE.
 
 NS_CC_BEGIN
 
-void MessageBox(const char * msg, const char * title)
+void ccMessageBox(const char * msg, const char * title)
 {
     log("%s: %s", title, msg);
 }

--- a/cocos/platform/mac/CCCommon-mac.mm
+++ b/cocos/platform/mac/CCCommon-mac.mm
@@ -43,7 +43,7 @@ void LuaLog(const char * format)
 }
 
 // ios no MessageBox, use log instead
-void MessageBox(const char * msg, const char * title)
+void ccMessageBox(const char * msg, const char * title)
 {
     NSString * tmpTitle = (title) ? [NSString stringWithUTF8String : title] : nil;
     NSString * tmpMsg = (msg) ? [NSString stringWithUTF8String : msg] : nil;

--- a/cocos/platform/mac/CCGLViewImpl-mac.mm
+++ b/cocos/platform/mac/CCGLViewImpl-mac.mm
@@ -316,7 +316,7 @@ bool GLViewImpl::initWithRect(const std::string& viewName, Rect rect, float fram
             message.append(_glfwError);
         }
 
-        MessageBox(message.c_str(), "Error launch application");
+        ccMessageBox(message.c_str(), "Error launch application");
         return false;
     }
     

--- a/cocos/platform/win32/CCCommon-win32.cpp
+++ b/cocos/platform/win32/CCCommon-win32.cpp
@@ -35,7 +35,7 @@ NS_CC_BEGIN
 
 #define MAX_LEN         (cocos2d::kMaxLogLen + 1)
 
-void MessageBox(const char * pszMsg, const char * pszTitle)
+void ccMessageBox(const char * pszMsg, const char * pszTitle)
 {
     std::wstring wsMsg = cocos2d::StringUtf8ToWideChar(pszMsg);
     std::wstring wsTitle = cocos2d::StringUtf8ToWideChar(pszTitle);

--- a/cocos/platform/win32/CCStdC-win32.h
+++ b/cocos/platform/win32/CCStdC-win32.h
@@ -139,11 +139,6 @@ inline errno_t strcpy_s(char *strDestination, size_t numberOfElements,
 #endif
 #endif // __MINGW32__
 
-// Conflicted with cocos2d::MessageBox, so we need to undef it.
-#ifdef MessageBox
-#undef MessageBox
-#endif
-
 // Conflicted with ParticleSystem::PositionType::RELATIVE, so we need to undef it.
 #ifdef RELATIVE
 #undef RELATIVE


### PR DESCRIPTION
* Rename cocos2d::MessageBox to cocos2d::ccMessageBox to avoid confilicit with win32 API macro 'MessageBox'.

* Sync non-win32 platforms.