### PR TITLE
update Node::getTag comment

### DIFF
--- a/cocos/2d/CCNode.h
+++ b/cocos/2d/CCNode.h
@@ -967,7 +967,7 @@ public:
      *
      * @return An integer that identifies the node.
      *
-     * Please use `getTag()` instead.
+     * Please use `getName()` instead.
      */
      virtual int getTag() const;
     /**


### PR DESCRIPTION
this fixes a typo where getTag should suggest to use getName, like setTag and removeChildrenByTag does.