### PR TITLE
needs update texture info

### DIFF
--- a/cocos/2d/CCSprite.cpp
+++ b/cocos/2d/CCSprite.cpp
@@ -417,6 +417,8 @@ void Sprite::setProgramState(backend::ProgramState *programState)
 
 void Sprite::setTexture(Texture2D *texture)
 {
+    auto isETC1 = texture && texture->getAlphaTextureName();
+    setProgramState((isETC1) ? backend::ProgramType::ETC1 : backend::ProgramType::POSITION_TEXTURE_COLOR);
     CCASSERT(! _batchNode || (texture &&  texture == _batchNode->getTexture()), "CCSprite: Batched sprites should use the same texture as the batchnode");
     // accept texture==nil as argument
     CCASSERT( !texture || dynamic_cast<Texture2D*>(texture), "setTexture expects a Texture2D. Invalid argument");
@@ -448,8 +450,7 @@ void Sprite::setTexture(Texture2D *texture)
         }
         updateBlendFunc();
     }
-    auto isETC1 = texture && texture->getAlphaTextureName();
-    setProgramState((isETC1) ? backend::ProgramType::ETC1 : backend::ProgramType::POSITION_TEXTURE_COLOR);
+    updateProgramState();
 }
 
 void Sprite::updateProgramState()

--- a/cocos/2d/CCSprite.cpp
+++ b/cocos/2d/CCSprite.cpp
@@ -411,7 +411,7 @@ void Sprite::setProgramState(backend::ProgramState *programState)
     _alphaTextureLocation = pipelineDescriptor.programState->getUniformLocation(backend::Uniform::TEXTURE1);
 
     setVertexLayout();
-    updateProgramState();
+    updateProgramStateTexture();
     setMVPMatrixUniform();
 }
 
@@ -450,10 +450,10 @@ void Sprite::setTexture(Texture2D *texture)
         }
         updateBlendFunc();
     }
-    updateProgramState();
+    updateProgramStateTexture();
 }
 
-void Sprite::updateProgramState()
+void Sprite::updateProgramStateTexture()
 {
     if (_texture == nullptr || _texture->getBackendTexture() == nullptr)
         return;

--- a/cocos/2d/CCSprite.h
+++ b/cocos/2d/CCSprite.h
@@ -635,7 +635,7 @@ protected:
     virtual void setDirtyRecursively(bool value);
     virtual void flipX();
     virtual void flipY();
-    virtual void updateProgramState();
+    virtual void updateProgramStateTexture();
 
     void updatePoly();
     void updateStretchFactor();


### PR DESCRIPTION
It makes sense that `ProgramState` is created if needed at the `Sprite::setTexture` beginning, then texture uniform is updated with real texture in `updateProgramState` at the function end.
[ref](https://discuss.cocos2d-x.org/t/metal-support-rc0-released/47797/70).