### PR TITLE
Fix warning when call Node::addComponent twice

### DIFF
--- a/cocos/2d/CCNode.cpp
+++ b/cocos/2d/CCNode.cpp
@@ -1963,10 +1963,12 @@ bool Node::addComponent(Component *component)
 {
     // lazy alloc
     if (!_componentContainer)
+    {
         _componentContainer = new (std::nothrow) ComponentContainer(this);
+        // should enable schedule update, then all components can receive this call back
+        scheduleUpdate();
+    }
     
-    // should enable schedule update, then all components can receive this call back
-    scheduleUpdate();
     
     return _componentContainer->add(component);
 }


### PR DESCRIPTION
If i call Node::addComponent twice, scheduleUpdate will be called twice, and then console output "warning: don't update it again"(CCScheduler.cpp line484). I think scheduleUpdate only should be called in the first time.