### PR TITLE
fix installation error on some Android devices

### DIFF
--- a/templates/cpp-template-default/proj.android/gradle.properties
+++ b/templates/cpp-template-default/proj.android/gradle.properties
@@ -38,3 +38,5 @@ PROP_APP_ABI=armeabi-v7a
 #RELEASE_STORE_PASSWORD=password of keystore
 #RELEASE_KEY_ALIAS=alias of key
 #RELEASE_KEY_PASSWORD=password of key
+
+android.injected.testOnly=false

--- a/templates/lua-template-default/frameworks/runtime-src/proj.android/gradle.properties
+++ b/templates/lua-template-default/frameworks/runtime-src/proj.android/gradle.properties
@@ -38,3 +38,5 @@ PROP_APP_ABI=armeabi-v7a
 #RELEASE_STORE_PASSWORD=password of keystore
 #RELEASE_KEY_ALIAS=alias of key
 #RELEASE_KEY_PASSWORD=password of key
+
+android.injected.testOnly=false

--- a/tests/cpp-empty-test/proj.android/gradle.properties
+++ b/tests/cpp-empty-test/proj.android/gradle.properties
@@ -38,3 +38,5 @@ PROP_APP_ABI=armeabi-v7a
 #RELEASE_STORE_PASSWORD=password of keystore
 #RELEASE_KEY_ALIAS=alias of key
 #RELEASE_KEY_PASSWORD=password of key
+
+android.injected.testOnly=false

--- a/tests/cpp-tests/proj.android/gradle.properties
+++ b/tests/cpp-tests/proj.android/gradle.properties
@@ -38,3 +38,5 @@ PROP_APP_ABI=armeabi-v7a
 #RELEASE_STORE_PASSWORD=password of keystore
 #RELEASE_KEY_ALIAS=alias of key
 #RELEASE_KEY_PASSWORD=password of key
+
+android.injected.testOnly=false

--- a/tests/lua-empty-test/project/proj.android/gradle.properties
+++ b/tests/lua-empty-test/project/proj.android/gradle.properties
@@ -38,3 +38,5 @@ PROP_APP_ABI=armeabi-v7a
 #RELEASE_STORE_PASSWORD=password of keystore
 #RELEASE_KEY_ALIAS=alias of key
 #RELEASE_KEY_PASSWORD=password of key
+
+android.injected.testOnly=false

--- a/tests/lua-tests/project/proj.android/gradle.properties
+++ b/tests/lua-tests/project/proj.android/gradle.properties
@@ -38,3 +38,5 @@ PROP_APP_ABI=armeabi-v7a
 #RELEASE_STORE_PASSWORD=password of keystore
 #RELEASE_KEY_ALIAS=alias of key
 #RELEASE_KEY_PASSWORD=password of key
+
+android.injected.testOnly=false

--- a/tests/performance-tests/proj.android/gradle.properties
+++ b/tests/performance-tests/proj.android/gradle.properties
@@ -43,3 +43,5 @@ PROP_BUILD_TYPE=cmake
 #RELEASE_STORE_PASSWORD=password of keystore
 #RELEASE_KEY_ALIAS=alias of key
 #RELEASE_KEY_PASSWORD=password of key
+
+android.injected.testOnly=false


### PR DESCRIPTION
May meet "The application could not be installed: INSTALL_FAILED_TEST_ONLY" error on some devices(such as vivo NEX S).