### PR TITLE
Fixes so that in the web view we are able to navigate different links properly

### DIFF
--- a/cocos/ui/UIWebViewImpl-ios.mm
+++ b/cocos/ui/UIWebViewImpl-ios.mm
@@ -250,7 +250,7 @@
 
 #pragma mark - WKNavigationDelegate
 - (void)webView:(WKWebView *)webView decidePolicyForNavigationAction:(WKNavigationAction *)navigationAction decisionHandler:(void (^)(WKNavigationActionPolicy))decisionHandler {
-    NSString *url = [webView.URL absoluteString];
+    NSString *url = [[[navigationAction request] URL] absoluteString];
     if ([[webView.URL scheme] isEqualToString:self.jsScheme]) {
         self.onJsCallback([url UTF8String]);
         decisionHandler(WKNavigationActionPolicyCancel);


### PR DESCRIPTION
After loading a page inside a WebView we were unable to navigate the links correctly because the URL used is always the webview's url. The correct URL should be picked-up from the [navigationAction request] URL].