### PR TITLE
remove extern "C" from base/base64.h for avoiding base64 function sym…

### DIFF
--- a/cocos/base/base64.h
+++ b/cocos/base/base64.h
@@ -29,10 +29,6 @@ THE SOFTWARE.
 /// @cond DO_NOT_SHOW
 
 #include "platform/CCPlatformMacros.h"
-
-#ifdef __cplusplus
-extern "C" {
-#endif    
     
 namespace cocos2d {
 
@@ -62,9 +58,6 @@ int CC_DLL base64Encode(const unsigned char *in, unsigned int inLength, char **o
 
 }//namespace   cocos2d 
 
-#ifdef __cplusplus
-}
-#endif    
 
 /// @endcond
 #endif // __SUPPORT_BASE64_H__


### PR DESCRIPTION
…bols conflict at linking libraries. (#20276)