### PR TITLE
Revert "don't compile codes for binding generator if it is a pull request"

### DIFF
--- a/tools/travis-scripts/run-script.sh
+++ b/tools/travis-scripts/run-script.sh
@@ -279,7 +279,7 @@ function run_after_merge()
 }
 
 # build pull request
-if [ "$TRAVIS_PULL_REQUEST" != "false" ] && [ x$GEN_BINDING_AND_COCOSFILE != x"true" ]; then
+if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
     run_pull_request
 fi
 


### PR DESCRIPTION
Reverts cocos2d/cocos2d-x#20237, or linux target is not built.