### PR TITLE
Fixing a crash in iOS 9.3.5 when we have a layer with WebView getting deallocated

### DIFF
--- a/cocos/ui/UIWebViewImpl-ios.mm
+++ b/cocos/ui/UIWebViewImpl-ios.mm
@@ -124,7 +124,7 @@
 
 - (void)setupWebView {
     if (!self.wkWebView) {
-        self.wkWebView = [[[WKWebView alloc] init] autorelease];
+        self.wkWebView = [[[[WKWebView alloc] init] autorelease] retain];
         self.wkWebView.UIDelegate = self;
         self.wkWebView.navigationDelegate = self;
     }

--- a/cocos/ui/UIWebViewImpl-ios.mm
+++ b/cocos/ui/UIWebViewImpl-ios.mm
@@ -88,7 +88,7 @@
 
 
 @interface UIWebViewWrapper () <WKUIDelegate, WKNavigationDelegate>
-@property(nonatomic, retain) WKWebView *wkWebView;
+@property(nonatomic) WKWebView *wkWebView;
 
 @property(nonatomic, copy) NSString *jsScheme;
 @end

--- a/cocos/ui/UIWebViewImpl-ios.mm
+++ b/cocos/ui/UIWebViewImpl-ios.mm
@@ -124,7 +124,7 @@
 
 - (void)setupWebView {
     if (!self.wkWebView) {
-        self.wkWebView = [[[[WKWebView alloc] init] autorelease] retain];
+        self.wkWebView = [[WKWebView alloc] init];
         self.wkWebView.UIDelegate = self;
         self.wkWebView.navigationDelegate = self;
     }


### PR DESCRIPTION
- Have a layer with a web view on it
- Try to launch it in iOS 9.3.5
- When this layer exits and memory is deallocated
- The class `UIWebViewWrapper` tries to release the property `[self.wkWebView release];`
- When the property was initialised it wasn't retained.
- Because of this the code crashes giving an error like releasing an instance that was not allocated.
- This is observed only in iOS 9.3.5 and 9.3.6. In iOS 12+ it works fine thought. 
- However I feel it should have crashed in other versions of the iOS too.
- This commit tries to fix the crash.