### PR TITLE
fix #17245, using spine before restartVM will cause memory leak quickly

### DIFF
--- a/cocos/editor-support/spine/SkeletonBatch.cpp
+++ b/cocos/editor-support/spine/SkeletonBatch.cpp
@@ -34,6 +34,7 @@
 
 USING_NS_CC;
 #define EVENT_AFTER_DRAW_RESET_POSITION "director_after_draw"
+#define EVENT_ON_DIRECTOR_RESET "director_reset"
 using std::max;
 #define INITIAL_SIZE (10000)
 
@@ -67,10 +68,15 @@ SkeletonBatch::SkeletonBatch () {
 	Director::getInstance()->getEventDispatcher()->addCustomEventListener(EVENT_AFTER_DRAW_RESET_POSITION, [this](EventCustom* eventCustom){
 		this->update(0);
 	});;
+	// when director is reset, all event lisners will be removed, so SkeletonBatch::update won't been invoked anymore
+	Director::getInstance()->getEventDispatcher()->addCustomEventListener(EVENT_ON_DIRECTOR_RESET, [this](EventCustom* eventCustom){
+		this->destroyInstance();
+	});
 }
 
 SkeletonBatch::~SkeletonBatch () {
 	Director::getInstance()->getEventDispatcher()->removeCustomEventListeners(EVENT_AFTER_DRAW_RESET_POSITION);
+	Director::getInstance()->getEventDispatcher()->removeCustomEventListeners(EVENT_ON_DIRECTOR_RESET);
 
 	spUnsignedShortArray_dispose(_indices);
 	

--- a/cocos/editor-support/spine/SkeletonTwoColorBatch.cpp
+++ b/cocos/editor-support/spine/SkeletonTwoColorBatch.cpp
@@ -35,6 +35,7 @@
 
 USING_NS_CC;
 #define EVENT_AFTER_DRAW_RESET_POSITION "director_after_draw"
+#define EVENT_ON_DIRECTOR_RESET "director_reset"
 using std::max;
 #define INITIAL_SIZE (10000)
 #define MAX_VERTICES 64000
@@ -182,6 +183,10 @@ SkeletonTwoColorBatch::SkeletonTwoColorBatch () {
 	Director::getInstance()->getEventDispatcher()->addCustomEventListener(EVENT_AFTER_DRAW_RESET_POSITION, [this](EventCustom* eventCustom){
 		this->update(0);
 	});;
+	// when director is reset, all event lisners will be removed, so SkeletonTwoColorBatch::update won't been invoked anymore.
+	Director::getInstance()->getEventDispatcher()->addCustomEventListener(EVENT_ON_DIRECTOR_RESET, [this](EventCustom* eventCustom){
+		this->destroyInstance();
+	});
 	
 	_twoColorTintShader = cocos2d::GLProgram::createWithByteArrays(TWO_COLOR_TINT_VERTEX_SHADER, TWO_COLOR_TINT_FRAGMENT_SHADER);
 	_twoColorTintShaderState = GLProgramState::getOrCreateWithGLProgram(_twoColorTintShader);
@@ -199,6 +204,7 @@ SkeletonTwoColorBatch::SkeletonTwoColorBatch () {
 
 SkeletonTwoColorBatch::~SkeletonTwoColorBatch () {
 	Director::getInstance()->getEventDispatcher()->removeCustomEventListeners(EVENT_AFTER_DRAW_RESET_POSITION);
+	Director::getInstance()->getEventDispatcher()->removeCustomEventListeners(EVENT_ON_DIRECTOR_RESET);
 	
 	spUnsignedShortArray_dispose(_indices);
 	
@@ -207,7 +213,7 @@ SkeletonTwoColorBatch::~SkeletonTwoColorBatch () {
 		_commandsPool[i] = nullptr;
 	}
 	_twoColorTintShader->release();
-	delete _vertexBuffer;
+	delete[] _vertexBuffer;
 	delete _indexBuffer;
 }
 


### PR DESCRIPTION
When director is reset, SkeletonBatch and SkeletonTwoColorBatch instances will be destroyed, and they can be recreated when invoking SkeletonBatch::getInstance() or SkeletonTwoColorBatch::getInstance() next time.