### PR TITLE
Support multiple build configurations

### DIFF
--- a/cmake/Modules/CocosBuildSet.cmake
+++ b/cmake/Modules/CocosBuildSet.cmake
@@ -22,8 +22,7 @@ message(STATUS "CMAKE_MODULE_PATH:" ${CMAKE_MODULE_PATH})
 message(STATUS "PROJECT_BINARY_DIR:" ${PROJECT_BINARY_DIR})
 message(STATUS "ENGINE_BINARY_PATH:" ${ENGINE_BINARY_PATH})
 
-# the default behavior of build module
-option(DEBUG_MODE "Debug or Release?" ON)
+
 option(BUILD_LUA_LIBS "Build lua libraries" OFF)
 
 # include helper functions

--- a/cmake/Modules/CocosConfigDefine.cmake
+++ b/cmake/Modules/CocosConfigDefine.cmake
@@ -45,20 +45,6 @@ elseif(CMAKE_GENERATOR MATCHES Visual)
 endif()
 message(STATUS "CMAKE_GENERATOR: ${CMAKE_GENERATOR}")
 
-if(CMAKE_CONFIGURATION_TYPES)
-    set(CMAKE_CONFIGURATION_TYPES "Debug;Release" CACHE STRING "Reset the configurations to what we need" FORCE)
-    message(STATUS "CMAKE_CONFIGURATION_TYPES: ${CMAKE_CONFIGURATION_TYPES}")
-else()
-    if(NOT CMAKE_BUILD_TYPE)
-        if(DEBUG_MODE) # build mode, Debug is default value
-            set(CMAKE_BUILD_TYPE Debug)
-        else()
-            set(CMAKE_BUILD_TYPE Release)
-        endif()
-    endif()
-    message(STATUS "CMAKE_BUILD_TYPE: ${CMAKE_BUILD_TYPE}")
-endif()
-
 # custom target property for lua/js link
 define_property(TARGET
     PROPERTY CC_JS_DEPEND


### PR DESCRIPTION
Support multiple configurations
https://cmake.org/cmake/help/v3.16/variable/CMAKE_CONFIGURATION_TYPES.html#variable:CMAKE_CONFIGURATION_TYPES
https://cmake.org/cmake/help/v3.16/prop_tgt/MAP_IMPORTED_CONFIG_CONFIG.html

For windows to enable default cmake configuration: RELWITHDEBINFO and MINSIZEREL below pull request is needed:
https://github.com/cocos2d/cocos2d-x-3rd-party-libs-bin/pull/391