### PR TITLE
Fixing a crash in iOS 9.3.5 when we have a layer with WebView getting…

### DIFF
--- a/cocos/ui/UIWebView/UIWebViewImpl-ios.mm
+++ b/cocos/ui/UIWebView/UIWebViewImpl-ios.mm
@@ -82,7 +82,7 @@
 
 
 @interface UIWebViewWrapper () <WKUIDelegate, WKNavigationDelegate>
-@property(nonatomic, retain) WKWebView *wkWebView;
+@property(nonatomic) WKWebView *wkWebView;
 
 @property(nonatomic, copy) NSString *jsScheme;
 @end
@@ -118,7 +118,7 @@
 
 - (void)setupWebView {
     if (!self.wkWebView) {
-        self.wkWebView = [[[WKWebView alloc] init] autorelease];
+        self.wkWebView = [[WKWebView alloc] init];
         self.wkWebView.UIDelegate = self;
         self.wkWebView.navigationDelegate = self;
     }


### PR DESCRIPTION
… deallocated (#20285)

* In case of iOS 9.3.5 when we show a web view and deallocate the layer it is trying to release memory associated with WKWebView instance, but it hadn’t retained it in the first place. This results in a crash. This commit fixes that crash.

* Removing the autorelease and retain parts from the WKWebView instantiation.

* Changes so that we can remove the retain from the property declaration and depend only on manual retain and release of memory <Deep>