### PR TITLE
fix setScissorRect crash

### DIFF
--- a/cocos/renderer/backend/metal/CommandBufferMTL.mm
+++ b/cocos/renderer/backend/metal/CommandBufferMTL.mm
@@ -205,6 +205,10 @@ namespace
                 return nil;
         }
     }
+
+    inline int clamp(int value, int min, int max) {
+        return std::min(max, std::max(min, value));
+    }
 }
 
 CommandBufferMTL::CommandBufferMTL(DeviceMTL* deviceMTL)
@@ -484,10 +488,19 @@ void CommandBufferMTL::setScissorRect(bool isEnabled, float x, float y, float wi
     MTLScissorRect scissorRect;
     if(isEnabled)
     {
-        scissorRect.x = x;
-        scissorRect.y = _renderTargetHeight - height - y;
-        scissorRect.width = width;
-        scissorRect.height = height;
+        y = _renderTargetHeight - height - y;
+        int minX = clamp((int)x, 0, (int)_renderTargetWidth);
+        int minY = clamp((int)y, 0, (int)_renderTargetHeight);
+        int maxX = clamp((int)(x + width), 0, (int)_renderTargetWidth);
+        int maxY = clamp((int)(y + height), 0, (int)_renderTargetHeight);
+        scissorRect.x = minX;
+        scissorRect.y = minY;
+        scissorRect.width = maxX - minX;
+        scissorRect.height = maxY - minY;
+        if (scissorRect.width == 0 || scissorRect.height == 0) {
+            scissorRect.width = 0;
+            scissorRect.height = 0;
+        }
     }
     else
     {


### PR DESCRIPTION
When part of scissorRect is out of render target viewport, it crash on mac.
Error message like this: -[MTLDebugRenderCommandEncoder setScissorRect:]:2703: failed assertion `(rect.y(568) + rect.height(447))(1015) must be <= render pass height(1000)'