### PR TITLE
fix edit box position error

### DIFF
--- a/cocos/ui/UIEditBox/UIEditBoxImpl-mac.mm
+++ b/cocos/ui/UIEditBox/UIEditBoxImpl-mac.mm
@@ -196,10 +196,10 @@ void EditBoxImplMac::setNativeVisible(bool visible)
 void EditBoxImplMac::updateNativeFrame(const cocos2d::Rect &rect)
 {
     GLView* eglView = Director::getInstance()->getOpenGLView();
-    auto viewPortRect = eglView->getViewPortRect();
+    auto frameSize = eglView->getFrameSize();
     // Coordinate System on OSX has its origin at the lower left corner.
 //    https://developer.apple.com/library/ios/documentation/General/Conceptual/Devpedia-CocoaApp/CoordinateSystem.html
-    auto screenPosY = viewPortRect.size.height - rect.origin.y - rect.size.height;
+    auto screenPosY = frameSize.height - rect.origin.y - rect.size.height;
     [_sysEdit updateFrame:CGRectMake(rect.origin.x,
                                      screenPosY,
                                      rect.size.width, rect.size.height)];


### PR DESCRIPTION
'sysEdit' y position is relate with frame height, not the viewport height. When in FIXED_WIDTH mode, if frame height is bigger than viewport height, it will got error y position.