### PR TITLE
fix AudioEngine maybe crash on android

### DIFF
--- a/cocos/audio/AudioEngine.cpp
+++ b/cocos/audio/AudioEngine.cpp
@@ -77,6 +77,7 @@ AudioEngine::AudioInfo::AudioInfo()
 
 AudioEngine::AudioInfo::~AudioInfo()
 {
+    delete filePath;
 }
 
 class AudioEngine::AudioEngineThreadPool
@@ -241,7 +242,7 @@ int AudioEngine::play2d(const std::string& filePath, bool loop, float volume, co
             auto& audioRef = _audioIDInfoMap[ret];
             audioRef.volume = volume;
             audioRef.loop = loop;
-            audioRef.filePath = &it->first;
+            audioRef.filePath = new std::string(it->first.c_str());
 
             if (profileHelper) {
                 profileHelper->lastPlayTime = utils::gettime();

--- a/cocos/audio/AudioEngine.cpp
+++ b/cocos/audio/AudioEngine.cpp
@@ -65,8 +65,7 @@ AudioEngine::AudioEngineThreadPool* AudioEngine::s_threadPool = nullptr;
 bool AudioEngine::_isEnabled = true;
 
 AudioEngine::AudioInfo::AudioInfo()
-: filePath(nullptr)
-, profileHelper(nullptr)
+: profileHelper(nullptr)
 , volume(1.0f)
 , loop(false)
 , duration(TIME_UNKNOWN)
@@ -77,7 +76,6 @@ AudioEngine::AudioInfo::AudioInfo()
 
 AudioEngine::AudioInfo::~AudioInfo()
 {
-    delete filePath;
 }
 
 class AudioEngine::AudioEngineThreadPool
@@ -242,7 +240,7 @@ int AudioEngine::play2d(const std::string& filePath, bool loop, float volume, co
             auto& audioRef = _audioIDInfoMap[ret];
             audioRef.volume = volume;
             audioRef.loop = loop;
-            audioRef.filePath = new std::string(it->first.c_str());
+            audioRef.filePath = it->first;
 
             if (profileHelper) {
                 profileHelper->lastPlayTime = utils::gettime();
@@ -343,7 +341,7 @@ void AudioEngine::remove(int audioID)
         if (it->second.profileHelper) {
             it->second.profileHelper->audioIDs.remove(audioID);
         }
-        _audioPathIDMap[*it->second.filePath].remove(audioID);
+        _audioPathIDMap[it->second.filePath].remove(audioID);
         _audioIDInfoMap.erase(it);
     }
 }

--- a/cocos/audio/apple/AudioEngine-inl.mm
+++ b/cocos/audio/apple/AudioEngine-inl.mm
@@ -672,7 +672,7 @@ void AudioEngineImpl::update(float dt)
             std::string filePath;
             if (player->_finishCallbak) {
                 auto& audioInfo = AudioEngine::_audioIDInfoMap[audioID];
-                filePath = *audioInfo.filePath;
+                filePath = audioInfo.filePath;
             }
 
             AudioEngine::remove(audioID);

--- a/cocos/audio/include/AudioEngine.h
+++ b/cocos/audio/include/AudioEngine.h
@@ -326,7 +326,7 @@ protected:
     
     struct AudioInfo
     {
-        const std::string* filePath;
+        std::string filePath;
         ProfileHelper* profileHelper;
         
         float volume;

--- a/cocos/audio/win32/AudioEngine-win32.cpp
+++ b/cocos/audio/win32/AudioEngine-win32.cpp
@@ -476,7 +476,7 @@ void AudioEngineImpl::update(float dt)
             std::string filePath;
             if (player->_finishCallbak) {
                 auto& audioInfo = AudioEngine::_audioIDInfoMap[audioID];
-                filePath = *audioInfo.filePath;
+                filePath = audioInfo.filePath;
             }
 
             AudioEngine::remove(audioID);


### PR DESCRIPTION
I receive many crash about std::base_string in bugly(tencent) crash report, i can't prove those crash is relate with this, but when after  fix, i never receive again. so i think there maybe some situation will cause crash.