### PR TITLE
UIVideoPlayer-ios.mm regression fix.

### DIFF
--- a/cocos/ui/UIVideoPlayer-ios.mm
+++ b/cocos/ui/UIVideoPlayer-ios.mm
@@ -103,6 +103,7 @@ typedef NS_ENUM(NSInteger, PlayerbackState) {
 
 -(void) dealloc
 {
+    _videoPlayer = nullptr;
     [self clean];
     [self.playerController release];
     [super dealloc];
@@ -110,7 +111,6 @@ typedef NS_ENUM(NSInteger, PlayerbackState) {
 
 -(void) clean
 {
-    _videoPlayer = nullptr;
     [self stop];
     [self removePlayerEventListener];
     [self.playerController.view removeFromSuperview];


### PR DESCRIPTION
[UIVideoViewWrapperIos clean] shouldn't reset _videoPlayer pointer,
since it is called in setUrl method and leaves instance in invalid
state. Subsequent calls to play, pause, etc. end up with crash.