### PR TITLE
fix incorrect hash structure for RenderPipeline

### DIFF
--- a/cocos/renderer/CCTrianglesCommand.cpp
+++ b/cocos/renderer/CCTrianglesCommand.cpp
@@ -48,16 +48,16 @@ void TrianglesCommand::init(float globalOrder, Texture2D* texture, const BlendFu
     }
     _mv = mv;
 
-    if (_program != _pipelineDescriptor.programState->getProgram() ||
+    if (_programType != _pipelineDescriptor.programState->getProgram()->getProgramType() ||
         _texture != texture->getBackendTexture() ||
         _blendType != blendType)
     {
-        _program = _pipelineDescriptor.programState->getProgram();
+        _programType = _pipelineDescriptor.programState->getProgram()->getProgramType();
         _texture = texture->getBackendTexture();
         _blendType = blendType;
         
         //since it would be too expensive to check the uniforms, simplify enable batching for built-in program.
-        if(_program->getProgramType() == backend::ProgramType::INVALID_PROGRAM)
+        if(_programType == backend::ProgramType::CUSTOM_PROGRAM)
             setSkipBatching(true);
         
         //TODO: minggo set it in Node?
@@ -86,7 +86,7 @@ void TrianglesCommand::generateMaterialID()
     struct
     {
         void* texture;
-        void* program;
+        backend::ProgramType programType;
         backend::BlendFactor src;
         backend::BlendFactor dst;
     }hashMe;
@@ -99,7 +99,7 @@ void TrianglesCommand::generateMaterialID()
     hashMe.texture = _texture;
     hashMe.src = _blendType.src;
     hashMe.dst = _blendType.dst;
-    hashMe.program = _program;
+    hashMe.programType = _programType;
     _materialID = XXH32((const void*)&hashMe, sizeof(hashMe), 0);
 }
 

--- a/cocos/renderer/CCTrianglesCommand.h
+++ b/cocos/renderer/CCTrianglesCommand.h
@@ -118,7 +118,7 @@ protected:
 
     // Cached value to determine to generate material id or not.
     BlendFunc _blendType = BlendFunc::DISABLE;
-    backend::Program* _program = nullptr;
+    backend::ProgramType _programType = backend::ProgramType::CUSTOM_PROGRAM;
     backend::TextureBackend* _texture = nullptr;
 };
 

--- a/cocos/renderer/backend/Program.h
+++ b/cocos/renderer/backend/Program.h
@@ -121,12 +121,6 @@ public:
     ProgramType getProgramType() const { return _programType; }
 
     /**
-     * Set engin built-in program type.
-     * @param type Specifies the program type.
-     */
-    void setProgramType(ProgramType type);
-
-    /**
      * Get uniform buffer size in bytes that can hold all the uniforms.
      * @param stage Specifies the shader stage. The symbolic constant can be either VERTEX or FRAGMENT.
      * @return The uniform buffer size in bytes.
@@ -146,8 +140,14 @@ public:
      * @return The uniformInfos.
      */
     virtual const std::unordered_map<std::string, UniformInfo>& getAllActiveUniformInfo(ShaderStage stage) const = 0;
-
+    
 protected:
+    /**
+     * Set engin built-in program type.
+     * @param type Specifies the program type.
+     */
+    void setProgramType(ProgramType type);
+    
     /**
      * @param vs Specifes the vertex shader source.
      * @param fs Specifes the fragment shader source.
@@ -179,12 +179,12 @@ protected:
      */
     virtual const std::unordered_map<std::string, int> getAllUniformsLocation() const = 0;
     friend class ProgramState;
-    friend class ProgramCache;
 #endif
+    friend class ProgramCache;
     
     std::string _vertexShader; ///< Vertex shader.
     std::string _fragmentShader; ///< Fragment shader.
-    ProgramType _programType = ProgramType::CUSTOM_PROGRAM; ///< built-in program type.
+    ProgramType _programType = ProgramType::CUSTOM_PROGRAM; ///< built-in program type, initial value is CUSTOM_PROGRAM.
 };
 
 //end of _backend group

--- a/cocos/renderer/backend/Program.h
+++ b/cocos/renderer/backend/Program.h
@@ -184,7 +184,7 @@ protected:
     
     std::string _vertexShader; ///< Vertex shader.
     std::string _fragmentShader; ///< Fragment shader.
-    ProgramType _programType = ProgramType::INVALID_PROGRAM; ///< built-in program type.
+    ProgramType _programType = ProgramType::CUSTOM_PROGRAM; ///< built-in program type.
 };
 
 //end of _backend group

--- a/cocos/renderer/backend/ShaderCache.cpp
+++ b/cocos/renderer/backend/ShaderCache.cpp
@@ -82,6 +82,7 @@ backend::ShaderModule* ShaderCache::newShaderModule(backend::ShaderStage stage, 
         return iter->second;
     
     auto shader = backend::Device::getInstance()->newShaderModule(stage, shaderSource);
+    shader->setHashValue(key);
     _cachedShaders.emplace(key, shader);
     
     return shader;

--- a/cocos/renderer/backend/ShaderModule.h
+++ b/cocos/renderer/backend/ShaderModule.h
@@ -71,12 +71,16 @@ public:
      */
     ShaderStage getShaderStage() const;
 
+    virtual std::size_t getHashValue() const { return _hash; }
     
 protected:
     ShaderModule(ShaderStage stage);
     virtual ~ShaderModule();
-
+    virtual void setHashValue(std::size_t hash) { _hash = hash; }
+    
+    friend class ShaderCache;
     ShaderStage _stage = ShaderStage::VERTEX;
+    std::size_t _hash = 0;
 };
 
 //end of _backend group

--- a/cocos/renderer/backend/ShaderModule.h
+++ b/cocos/renderer/backend/ShaderModule.h
@@ -71,12 +71,12 @@ public:
      */
     ShaderStage getShaderStage() const;
 
-    virtual std::size_t getHashValue() const { return _hash; }
+    std::size_t getHashValue() const { return _hash; }
     
 protected:
     ShaderModule(ShaderStage stage);
     virtual ~ShaderModule();
-    virtual void setHashValue(std::size_t hash) { _hash = hash; }
+    void setHashValue(std::size_t hash) { _hash = hash; }
     
     friend class ShaderCache;
     ShaderStage _stage = ShaderStage::VERTEX;

--- a/cocos/renderer/backend/Types.h
+++ b/cocos/renderer/backend/Types.h
@@ -326,9 +326,8 @@ enum class TextureCubeFace : uint32_t
     NEGATIVE_Z = 5
 };
 
-enum class ProgramType : int
+enum class ProgramType : size_t
 {
-    INVALID_PROGRAM = -1,
     POSITION_COLOR_LENGTH_TEXTURE,          //positionColorLengthTexture_vert, positionColorLengthTexture_frag
     POSITION_COLOR_TEXTURE_AS_POINTSIZE,    //positionColorTextureAsPointsize_vert, positionColor_frag
     POSITION_COLOR,                         //positionColor_vert,           positionColor_frag
@@ -362,6 +361,8 @@ enum class ProgramType : int
     SKINPOSITION_BUMPEDNORMAL_TEXTURE_3D,   //CC3D_skinPositionNormalTexture_vert,  CC3D_colorNormalTexture_frag
     PARTICLE_TEXTURE_3D,                    //CC3D_particle_vert,                   CC3D_particleTexture_frag
     PARTICLE_COLOR_3D,                      //CC3D_particle_vert,                   CC3D_particleColor_frag
+
+    CUSTOM_PROGRAM,                         //user-define program
 };
 
 ///built-in uniform name

--- a/cocos/renderer/backend/metal/RenderPipelineMTL.mm
+++ b/cocos/renderer/backend/metal/RenderPipelineMTL.mm
@@ -167,7 +167,8 @@ void RenderPipelineMTL::update(const PipelineDescriptor & pipelineDescirptor,
 {
     struct
     {
-        backend::ProgramType programType;
+        size_t vertexShaderHash;
+        size_t fragmentShaderHash;
         unsigned int vertexLayoutInfo[32];
         backend::PixelFormat colorAttachment;
         backend::PixelFormat depthAttachment;
@@ -185,8 +186,9 @@ void RenderPipelineMTL::update(const PipelineDescriptor & pipelineDescirptor,
     memset(&hashMe, 0, sizeof(hashMe));
     const auto& blendDescriptor = pipelineDescirptor.blendDescriptor;
     getAttachmentFormat(renderPassDescriptor, _colorAttachmentsFormat[0], _depthAttachmentFormat, _stencilAttachmentFormat);
-    auto program = pipelineDescirptor.programState->getProgram();
-    hashMe.programType = program->getProgramType();
+    auto program = static_cast<ProgramMTL*>(pipelineDescirptor.programState->getProgram());
+    hashMe.vertexShaderHash = program->getVertexShader()->getHashValue();
+    hashMe.fragmentShaderHash = program->getFragmentShader()->getHashValue();
     hashMe.colorAttachment = _colorAttachmentsFormat[0];
     hashMe.depthAttachment = _depthAttachmentFormat;
     hashMe.stencilAttachment =_stencilAttachmentFormat;

--- a/cocos/renderer/backend/metal/RenderPipelineMTL.mm
+++ b/cocos/renderer/backend/metal/RenderPipelineMTL.mm
@@ -167,7 +167,7 @@ void RenderPipelineMTL::update(const PipelineDescriptor & pipelineDescirptor,
 {
     struct
     {
-        void* program;
+        backend::ProgramType programType;
         unsigned int vertexLayoutInfo[32];
         backend::PixelFormat colorAttachment;
         backend::PixelFormat depthAttachment;
@@ -185,7 +185,8 @@ void RenderPipelineMTL::update(const PipelineDescriptor & pipelineDescirptor,
     memset(&hashMe, 0, sizeof(hashMe));
     const auto& blendDescriptor = pipelineDescirptor.blendDescriptor;
     getAttachmentFormat(renderPassDescriptor, _colorAttachmentsFormat[0], _depthAttachmentFormat, _stencilAttachmentFormat);
-    hashMe.program = pipelineDescirptor.programState->getProgram();
+    auto program = pipelineDescirptor.programState->getProgram();
+    hashMe.programType = program->getProgramType();
     hashMe.colorAttachment = _colorAttachmentsFormat[0];
     hashMe.depthAttachment = _depthAttachmentFormat;
     hashMe.stencilAttachment =_stencilAttachmentFormat;
@@ -215,8 +216,8 @@ void RenderPipelineMTL::update(const PipelineDescriptor & pipelineDescirptor,
         ((unsigned int)attribute.needToBeNormallized & 0x1);
     }
     
-    NSUInteger hash = XXH32((const void*)&hashMe, sizeof(hashMe), 0);
-    NSNumber* key = [[NSNumber numberWithUnsignedInteger:hash] autorelease];
+    unsigned int hash = XXH32((const void*)&hashMe, sizeof(hashMe), 0);
+    NSNumber* key = @(hash);
     id obj = [_mtlRenderPipelineStateCache objectForKey:key];
     if (obj != nil)
     {

--- a/tests/cpp-tests/Classes/ShaderTest/ShaderTest2.cpp
+++ b/tests/cpp-tests/Classes/ShaderTest/ShaderTest2.cpp
@@ -180,10 +180,6 @@ bool Effect::initProgramState(const std::string &fragmentFilename)
     _fragSource = fragSource;
 #endif
     auto program = backend::Device::getInstance()->newProgram(positionTextureColor_vert, fragSource.c_str());
-    auto vsHash = std::hash < std::string>{}(positionTextureColor_vert);
-    auto fsHash = std::hash < std::string>{}(fragSource);
-    auto hash =  vsHash ^ (fsHash << 1);
-    program->setProgramType(static_cast<backend::ProgramType>(hash));
     auto programState = new backend::ProgramState(program);
     CC_SAFE_RELEASE(_programState);
     CC_SAFE_RELEASE(program);

--- a/tests/cpp-tests/Classes/ShaderTest/ShaderTest2.cpp
+++ b/tests/cpp-tests/Classes/ShaderTest/ShaderTest2.cpp
@@ -180,6 +180,10 @@ bool Effect::initProgramState(const std::string &fragmentFilename)
     _fragSource = fragSource;
 #endif
     auto program = backend::Device::getInstance()->newProgram(positionTextureColor_vert, fragSource.c_str());
+    auto vsHash = std::hash < std::string>{}(positionTextureColor_vert);
+    auto fsHash = std::hash < std::string>{}(fragSource);
+    auto hash =  vsHash ^ (fsHash << 1);
+    program->setProgramType(static_cast<backend::ProgramType>(hash));
     auto programState = new backend::ProgramState(program);
     CC_SAFE_RELEASE(_programState);
     CC_SAFE_RELEASE(program);


### PR DESCRIPTION
A program may be release and its memory address will be allocated to another program, result in getting incorrect renderpipelineState object.