### PR TITLE
Fix isVariable method buffer overflow.

### DIFF
--- a/cocos/base/CCProperties.cpp
+++ b/cocos/base/CCProperties.cpp
@@ -139,8 +139,8 @@ static bool isVariable(const char* str, char* outName, size_t outSize)
         size_t size = len - 3;
         if (size > (outSize - 1))
             size = outSize - 1;
-        strncpy(outName, str + 2, len - 3);
-        outName[len - 3] = 0;
+        strncpy(outName, str + 2, size);
+        outName[size] = 0;
         return true;
     }
 


### PR DESCRIPTION
The safe size was calculated but not used, maybe is a hand mistake.