### PR TITLE
avoid audio crash when force exit app

### DIFF
--- a/templates/cpp-template-default/Classes/AppDelegate.cpp
+++ b/templates/cpp-template-default/Classes/AppDelegate.cpp
@@ -54,7 +54,8 @@ AppDelegate::AppDelegate()
 AppDelegate::~AppDelegate() 
 {
 #if USE_AUDIO_ENGINE
-    AudioEngine::end();
+    // cause iOS/macOS crash when force exit app
+    // AudioEngine::end();
 #elif USE_SIMPLE_AUDIO_ENGINE
     SimpleAudioEngine::end();
 #endif

--- a/templates/js-template-default/frameworks/runtime-src/Classes/AppDelegate.cpp
+++ b/templates/js-template-default/frameworks/runtime-src/Classes/AppDelegate.cpp
@@ -91,7 +91,8 @@ AppDelegate::AppDelegate()
 AppDelegate::~AppDelegate()
 {
 #if USE_AUDIO_ENGINE
-    AudioEngine::end();
+    // cause iOS/macOS crash when force exit app
+    // AudioEngine::end();
 #elif USE_SIMPLE_AUDIO_ENGINE
     SimpleAudioEngine::end();
 #endif

--- a/templates/lua-template-default/frameworks/runtime-src/Classes/AppDelegate.cpp
+++ b/templates/lua-template-default/frameworks/runtime-src/Classes/AppDelegate.cpp
@@ -52,7 +52,8 @@ AppDelegate::AppDelegate()
 AppDelegate::~AppDelegate()
 {
 #if USE_AUDIO_ENGINE
-    AudioEngine::end();
+    // cause iOS/macOS crash when force exit app
+    // AudioEngine::end();
 #elif USE_SIMPLE_AUDIO_ENGINE
     SimpleAudioEngine::end();
 #endif

--- a/tests/cpp-tests/Classes/AppDelegate.cpp
+++ b/tests/cpp-tests/Classes/AppDelegate.cpp
@@ -31,6 +31,21 @@
 #include "editor-support/cocostudio/CocoStudio.h"
 #include "extensions/cocos-ext.h"
 
+#define USE_AUDIO_ENGINE 1
+#define USE_SIMPLE_AUDIO_ENGINE 0
+
+#if USE_AUDIO_ENGINE && USE_SIMPLE_AUDIO_ENGINE
+#error "Don't use AudioEngine and SimpleAudioEngine at the same time. Please just select one in your game!"
+#endif
+
+#if USE_AUDIO_ENGINE
+#include "audio/include/AudioEngine.h"
+using namespace cocos2d::experimental;
+#elif USE_SIMPLE_AUDIO_ENGINE
+#include "audio/include/SimpleAudioEngine.h"
+using namespace CocosDenshion;
+#endif
+
 USING_NS_CC;
 
 AppDelegate::AppDelegate()
@@ -40,7 +55,12 @@ AppDelegate::AppDelegate()
 
 AppDelegate::~AppDelegate()
 {
-    //SimpleAudioEngine::end();
+#if USE_AUDIO_ENGINE
+    // cause iOS/macOS crash when force exit app
+    AudioEngine::end();
+#elif USE_SIMPLE_AUDIO_ENGINE
+    SimpleAudioEngine::end();
+#endif
     cocostudio::ArmatureDataManager::destroyInstance();
 }
 
@@ -127,6 +147,13 @@ void AppDelegate::applicationDidEnterBackground()
     }
     
     Director::getInstance()->stopAnimation();
+
+#if USE_AUDIO_ENGINE
+    AudioEngine::pauseAll();
+#elif USE_SIMPLE_AUDIO_ENGINE
+    SimpleAudioEngine::getInstance()->pauseBackgroundMusic();
+    SimpleAudioEngine::getInstance()->pauseAllEffects();
+#endif
 }
 
 // this function will be called when the app is active again
@@ -138,4 +165,11 @@ void AppDelegate::applicationWillEnterForeground()
     }
     
     Director::getInstance()->startAnimation();
+
+#if USE_AUDIO_ENGINE
+    AudioEngine::resumeAll();
+#elif USE_SIMPLE_AUDIO_ENGINE
+    SimpleAudioEngine::getInstance()->resumeBackgroundMusic();
+    SimpleAudioEngine::getInstance()->resumeAllEffects();
+#endif
 }


### PR DESCRIPTION
cpp-tests never test the feature of #17555 added, that code bring a crash issue when force exit app.

reproduce steps:

  1. add the audio codes in template into cpp-tests
  2. enable `USE_AUDIO_ENGINE`
  2. run cpp-tests on macOS/iOS, play any audio test case
  3. click `X` button in window, XCode will catch crash  

the crash info

```
2020-02-07 18:11:20.798480+0800 cpp-tests Mac[94346:3986692] ==94346==ERROR: AddressSanitizer: heap-use-after-free on address 0x61100000a5a0 at pc 0x0001049d916f bp 0x7ffeefbfec50 sp 0x7ffeefbfec48
2020-02-07 18:11:20.798537+0800 cpp-tests Mac[94346:3986692] READ of size 8 at 0x61100000a5a0 thread T0
2020-02-07 18:11:20.798589+0800 cpp-tests Mac[94346:3986692]     #0 0x1049d916e in cocos2d::Scheduler::unschedule(void (cocos2d::Ref::*)(float), cocos2d::Ref*) CCScheduler.cpp:1049
2020-02-07 18:11:20.798642+0800 cpp-tests Mac[94346:3986692]     #1 0x1035444c2 in cocos2d::experimental::AudioEngineImpl::~AudioEngineImpl() AudioEngine-inl.mm:262
2020-02-07 18:11:20.798683+0800 cpp-tests Mac[94346:3986692]     #2 0x1035456c4 in cocos2d::experimental::AudioEngineImpl::~AudioEngineImpl() AudioEngine-inl.mm:259
2020-02-07 18:11:20.798729+0800 cpp-tests Mac[94346:3986692]     #3 0x1035456e8 in cocos2d::experimental::AudioEngineImpl::~AudioEngineImpl() AudioEngine-inl.mm:259
2020-02-07 18:11:20.798777+0800 cpp-tests Mac[94346:3986692]     #4 0x10476ac7f in cocos2d::experimental::AudioEngine::end() AudioEngine.cpp:161
2020-02-07 18:11:20.798817+0800 cpp-tests Mac[94346:3986692]     #5 0x100547a45 in AppDelegate::~AppDelegate() AppDelegate.cpp:60
2020-02-07 18:11:20.798865+0800 cpp-tests Mac[94346:3986692]     #6 0x100547ab4 in AppDelegate::~AppDelegate() AppDelegate.cpp:57
2020-02-07 18:11:20.798905+0800 cpp-tests Mac[94346:3986692]     #7 0x102c77322 in main main.cpp:34
2020-02-07 18:11:20.798956+0800 cpp-tests Mac[94346:3986692]     #8 0x100002033 in start (cpp-tests Mac:x86_64+0x100002033)
2020-02-07 18:11:20.799002+0800 cpp-tests Mac[94346:3986692] 
2020-02-07 18:11:20.799042+0800 cpp-tests Mac[94346:3986692] 0x61100000a5a0 is located 96 bytes inside of 232-byte region [0x61100000a540,0x61100000a628)
2020-02-07 18:11:20.799132+0800 cpp-tests Mac[94346:3986692] freed by thread T0 here:
2020-02-07 18:11:20.799271+0800 cpp-tests Mac[94346:3986692]     #0 0x10fd80b02 in wrap__ZdlPv (libclang_rt.asan_osx_dynamic.dylib:x86_64h+0x6eb02)
2020-02-07 18:11:20.799336+0800 cpp-tests Mac[94346:3986692]     #1 0x1049de001 in cocos2d::Scheduler::~Scheduler() CCScheduler.cpp:272
2020-02-07 18:11:20.799388+0800 cpp-tests Mac[94346:3986692]     #2 0x102efeaa3 in cocos2d::Ref::release() CCRef.cpp:150
2020-02-07 18:11:20.799437+0800 cpp-tests Mac[94346:3986692]     #3 0x103c0480c in cocos2d::Director::~Director() CCDirector.cpp:173
2020-02-07 18:11:20.799481+0800 cpp-tests Mac[94346:3986692]     #4 0x103c051c4 in cocos2d::Director::~Director() CCDirector.cpp:164
2020-02-07 18:11:20.799528+0800 cpp-tests Mac[94346:3986692]     #5 0x103c051e8 in cocos2d::Director::~Director() CCDirector.cpp:164
2020-02-07 18:11:20.799602+0800 cpp-tests Mac[94346:3986692]     #6 0x102efeaa3 in cocos2d::Ref::release() CCRef.cpp:150
2020-02-07 18:11:20.799646+0800 cpp-tests Mac[94346:3986692]     #7 0x103c11661 in cocos2d::Director::purgeDirector() CCDirector.cpp:1135
2020-02-07 18:11:20.799686+0800 cpp-tests Mac[94346:3986692]     #8 0x103c151a1 in cocos2d::Director::mainLoop() CCDirector.cpp:1469
2020-02-07 18:11:20.799738+0800 cpp-tests Mac[94346:3986692]     #9 0x104ba5757 in cocos2d::Application::run() CCApplication-mac.mm:115
2020-02-07 18:11:20.799780+0800 cpp-tests Mac[94346:3986692]     #10 0x102c7730b in main main.cpp:33
2020-02-07 18:11:20.799821+0800 cpp-tests Mac[94346:3986692]     #11 0x100002033 in start (cpp-tests Mac:x86_64+0x100002033)
2020-02-07 18:11:20.799869+0800 cpp-tests Mac[94346:3986692] 
2020-02-07 18:11:20.799909+0800 cpp-tests Mac[94346:3986692] previously allocated by thread T0 here:
2020-02-07 18:11:20.799948+0800 cpp-tests Mac[94346:3986692]     #0 0x10fd80822 in wrap__ZnwmRKSt9nothrow_t (libclang_rt.asan_osx_dynamic.dylib:x86_64h+0x6e822)
2020-02-07 18:11:20.799996+0800 cpp-tests Mac[94346:3986692]     #1 0x103c0017b in cocos2d::Director::init() CCDirector.cpp:129
2020-02-07 18:11:20.800039+0800 cpp-tests Mac[94346:3986692]     #2 0x103bffdb8 in cocos2d::Director::getInstance() CCDirector.cpp:107
2020-02-07 18:11:20.800082+0800 cpp-tests Mac[94346:3986692]     #3 0x102da05f9 in cocos2d::Configuration::loadConfigFile(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&) CCConfiguration.cpp:426
2020-02-07 18:11:20.800148+0800 cpp-tests Mac[94346:3986692]     #4 0x100547e62 in AppDelegate::applicationDidFinishLaunching() AppDelegate.cpp:82
2020-02-07 18:11:20.800193+0800 cpp-tests Mac[94346:3986692]     #5 0x104ba5355 in cocos2d::Application::run() CCApplication-mac.mm:69
2020-02-07 18:11:20.800265+0800 cpp-tests Mac[94346:3986692]     #6 0x102c7730b in main main.cpp:33
2020-02-07 18:11:20.800338+0800 cpp-tests Mac[94346:3986692]     #7 0x100002033 in start (cpp-tests Mac:x86_64+0x100002033)
2020-02-07 18:11:20.800387+0800 cpp-tests Mac[94346:3986692] 

```