### PR TITLE
Kill process if Cocos2dxActivity.onDestroy is invoked

### DIFF
--- a/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxActivity.java
+++ b/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxActivity.java
@@ -227,6 +227,10 @@ public abstract class Cocos2dxActivity extends Activity implements Cocos2dxHelpe
         if(gainAudioFocus)
             Cocos2dxAudioFocusManager.unregisterAudioFocusListener(this);
         super.onDestroy();
+
+        if (mGLSurfaceView != null) {
+            Cocos2dxHelper.terminateProcess();
+        }
     }
 
     @Override


### PR DESCRIPTION
Prevents crash if app goes to background for a long time and Activity is recycled by system.
Prevents spidermonkey JS_AbortIfWrongThread issue in v3.17.x. #20466 

**Referenced PR (cocos2d-x-lite):** [https://github.com/cocos-creator/cocos2d-x-lite/pull/1027](1027)