### PR TITLE
Fix incorrect rendering of tilemaps with csv data on windows

### DIFF
--- a/cocos/2d/CCTMXXMLParser.cpp
+++ b/cocos/2d/CCTMXXMLParser.cpp
@@ -726,6 +726,12 @@ void TMXMapInfo::endElement(void* /*ctx*/, const char *name)
             tmxMapInfo->setStoringCharacters(false);
             std::string currentString = tmxMapInfo->getCurrentString();
 
+#if (CC_TARGET_PLATFORM == CC_PLATFORM_WIN32)
+			// Fix bug when tilemap data is in csv format.
+			// We have to remove all '\r' from the string
+			currentString.erase(std::remove(currentString.begin(), currentString.end(), '\r'), currentString.end());
+#endif
+
             vector<string> gidTokens;
             istringstream filestr(currentString);
             string sRow;


### PR DESCRIPTION
Each tilemap row would be shifted to the right a certain number of tiles.

When saving Tiled maps with data in CSV format it is saved like this:
```
<data encoding="csv">
7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,
7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,
7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,
7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,
7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,
7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,
7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,
7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,
7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,
7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7
</data>
```

When reading each line there is a carriage return at the beginning which in windows is '\r\n'\.
Because of how each line is parsed the '\r' at the beginning of each line would be parsed as a tile id.
On windows we must remove all '\r' from the parsed string.

I had talked about the issue here: https://discuss.cocos2d-x.org/t/cocos2d-x-v4-0-released/48487/106?u=bolin

