### PR TITLE
cocosstudio/CCSkin.cpp's _quadCommand lost the pipelineDescriptor.pro…

### DIFF
--- a/cocos/editor-support/cocostudio/CCSkin.cpp
+++ b/cocos/editor-support/cocostudio/CCSkin.cpp
@@ -233,6 +233,9 @@ Mat4 Skin::getNodeToWorldTransformAR() const
 void Skin::draw(Renderer *renderer, const Mat4 &/*transform*/, uint32_t flags)
 {
     auto mv = Director::getInstance()->getMatrix(MATRIX_STACK_TYPE::MATRIX_STACK_MODELVIEW);
+    
+    auto& pipelineDescriptor = _quadCommand.getPipelineDescriptor();
+    pipelineDescriptor.programState = getProgramState();
 
     // TODO: implement z order
     _quadCommand.init(_globalZOrder, 


### PR DESCRIPTION
cocosstudio/CCSkin.cpp's _quadCommand lost the pipelineDescriptor.programState, which could cause the CCArmature disable and crash. 
So adding the getProgramState() to pipelineDescriptor.programState which would bring it back into working order.