### PR TITLE
Fix build fail when using Visual Studio 2019 to build win32

### DIFF
--- a/cocos/CMakeLists.txt
+++ b/cocos/CMakeLists.txt
@@ -105,6 +105,10 @@ set(COCOS_SRC cocos2d.cpp
     ${COCOS_STORAGE_SRC}
     )
 
+if(WINDOWS)
+    list(INSERT COCOS_SRC 0 precheader.cpp)
+endif()
+
 list(APPEND COCOS_SRC ${COCOS_HEADER})
 
 add_library(cocos2d ${COCOS_SRC})
@@ -150,7 +154,6 @@ endif()
 
 if(WINDOWS)
     # precompiled header. Compilation time speedup ~4x.
-    target_sources(cocos2d PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/precheader.cpp")
     set_target_properties(cocos2d PROPERTIES COMPILE_FLAGS "/Yuprecheader.h /FIprecheader.h")
     set_source_files_properties("${CMAKE_CURRENT_SOURCE_DIR}/precheader.cpp" PROPERTIES COMPILE_FLAGS "/Ycprecheader.h")
     # compile c as c++. needed for precompiled header


### PR DESCRIPTION
Steps:
- Create new project with "cocos new" command
- Open project in Visual Studio 2019, it creates the default x64-Debug configuration
- Create x86-Debug configuration
- Build fails with errors: C1083: Cannot open precompiled header file: 'precheader.pch': No such file or directory