### PR TITLE
Fixed: KeyguardManager crashed for Instant App

### DIFF
--- a/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxActivity.java
+++ b/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxActivity.java
@@ -359,9 +359,11 @@ public abstract class Cocos2dxActivity extends Activity implements Cocos2dxHelpe
    }
 
     private static boolean isDeviceLocked() {
+	boolean locked = false;
         KeyguardManager keyguardManager = (KeyguardManager)getContext().getSystemService(Context.KEYGUARD_SERVICE);
-        boolean locked = keyguardManager.inKeyguardRestrictedInputMode();
-        return locked;
+	if(keyguardManager != null) {
+        	locked = keyguardManager.inKeyguardRestrictedInputMode();
+	}
     }
 
     private static boolean isDeviceAsleep() {


### PR DESCRIPTION
Fixed exceptions after running Instant App

```
E/AndroidRuntime: FATAL EXCEPTION: main
    Process: ru.jsoft.awalk, PID: 30800
    java.lang.RuntimeException: Unable to resume activity {ru.jsoft.awalk/org.cocos2dx.cpp.AppActivity}: java.lang.NullPointerException: Attempt to invoke virtual method 'boolean android.app.KeyguardManager.inKeyguardRestrictedInputMode()' on a null object reference
        at android.app.ActivityThread.performResumeActivity(ActivityThread.java:4539)
        at android.app.ActivityThread.handleResumeActivity(ActivityThread.java:4572)
        at android.app.servertransaction.ResumeActivityItem.execute(ResumeActivityItem.java:52)
        at android.app.servertransaction.TransactionExecutor.executeLifecycleState(TransactionExecutor.java:176)
        at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:97)
        at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2220)
        at android.os.Handler.dispatchMessage(Handler.java:107)
        at android.os.Looper.loop(Looper.java:237)
        at android.app.ActivityThread.main(ActivityThread.java:8016)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:493)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1076)
     Caused by: java.lang.NullPointerException: Attempt to invoke virtual method 'boolean android.app.KeyguardManager.inKeyguardRestrictedInputMode()' on a null object reference
        at org.cocos2dx.lib.Cocos2dxActivity.isDeviceLocked(Unknown Source:12)
        at org.cocos2dx.lib.Cocos2dxActivity.resumeIfHasFocus(Unknown Source:0)
        at org.cocos2dx.lib.Cocos2dxActivity.onResume(Unknown Source:23)
        at com.sdkbox.plugin.SDKBoxActivity.onResume(Unknown Source:0)
        at android.app.Instrumentation.callActivityOnResume(Instrumentation.java:1454)
        at android.app.Activity.performResume(Activity.java:8105)
        at android.app.ActivityThread.performResumeActivity(ActivityThread.java:4529)
        at android.app.ActivityThread.handleResumeActivity(ActivityThread.java:4572) 
        at android.app.servertransaction.ResumeActivityItem.execute(ResumeActivityItem.java:52) 
        at android.app.servertransaction.TransactionExecutor.executeLifecycleState(TransactionExecutor.java:176) 
        at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:97) 
        at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2220) 
        at android.os.Handler.dispatchMessage(Handler.java:107) 
        at android.os.Looper.loop(Looper.java:237) 
        at android.app.ActivityThread.main(ActivityThread.java:8016) 
        at java.lang.reflect.Method.invoke(Native Method) 
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:493) 
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1076) 
```