### PR TITLE
Modified the install-deps-linux file for installing dependencies with…

### DIFF
--- a/install-deps-linux.sh
+++ b/install-deps-linux.sh
@@ -32,4 +32,11 @@ DEPENDS+=' libssl-dev'
 DEPENDS+=' libgtk-3-dev'
 DEPENDS+=' binutils'
 
-sudo apt-get install --force-yes --yes $DEPENDS > /dev/null
+# sudo apt-get install --force-yes --yes $DEPENDS > /dev/null
+
+# SOURCE: --force-yes is deprecated due to some reasons. The following can be used to install it without any errors. 
+# https://superuser.com/questions/1438031/ubuntu-18-command-apt-get-dist-upgrade-qq-force-yes-deprecated/1444431
+
+sudo apt-get install --allow-unauthenticated $DEPENDS > /dev/null
+
+


### PR DESCRIPTION
…out error.

The attribute '--force-yes' is deprecated in the latest releases of linux. It is divided into several small attributes.
Each consisting of a separate use of it's own. Here it is used to install dependencies of unauthorized package so the changes are made accordingly. Source is added in the comments of the code.