### PR TITLE
MSAA for metal.

### DIFF
--- a/cocos/2d/CCRenderTexture.cpp
+++ b/cocos/2d/CCRenderTexture.cpp
@@ -627,7 +627,8 @@ void RenderTexture::onBegin()
     _oldStencilAttachment = renderer->getStencilAttachment();
     _oldRenderTargetFlag = renderer->getRenderTargetFlag();
 
-    renderer->setRenderTarget(_renderTargetFlags, _textureMsaaTarget ?: _texture2D, _depthStencilTexture, _depthStencilTexture);
+    auto* texTarget = _textureMsaaTarget ? _textureMsaaTarget : _texture2D;
+    renderer->setRenderTarget(_renderTargetFlags, texTarget, _depthStencilTexture, _depthStencilTexture);
 }
 
 void RenderTexture::onEnd()

--- a/cocos/2d/CCRenderTexture.cpp
+++ b/cocos/2d/CCRenderTexture.cpp
@@ -41,6 +41,8 @@ THE SOFTWARE.
 
 NS_CC_BEGIN
 
+static const bool sUnified = false;
+
 // implementation RenderTexture
 RenderTexture::RenderTexture()
 {
@@ -58,6 +60,7 @@ RenderTexture::RenderTexture()
 RenderTexture::~RenderTexture()
 {
     CC_SAFE_RELEASE(_sprite);
+    CC_SAFE_RELEASE(_textureMsaaTarget);
     CC_SAFE_RELEASE(_texture2DCopy);
     CC_SAFE_RELEASE(_depthStencilTexture);
     CC_SAFE_RELEASE(_UITextureImage);
@@ -75,6 +78,7 @@ void RenderTexture::listenToBackground(EventCustom* /*event*/)
             CC_SAFE_RELEASE(_UITextureImage);
             _UITextureImage = uiTextureImage;
             CC_SAFE_RETAIN(_UITextureImage);
+                        
             const Size& s = _texture2D->getContentSizeInPixels();
             VolatileTextureMgr::addDataTexture(_texture2D, uiTextureImage->getData(), s.width * s.height * 4, backend::PixelFormat::RGBA8888, s);
 
@@ -110,6 +114,10 @@ void RenderTexture::listenToForeground(EventCustom* /*event*/)
     {
         _texture2DCopy->setAntiAliasTexParameters();
     }
+    if(_textureMsaaTarget)
+    {
+        _textureMsaaTarget->setAntiAliasTexParameters();
+    }
 #endif
 }
 
@@ -130,6 +138,23 @@ RenderTexture * RenderTexture::create(int w ,int h, backend::PixelFormat eFormat
 {
     RenderTexture *ret = new (std::nothrow) RenderTexture();
 
+    if(ret && ret->initWithWidthAndHeight(w, h, eFormat, uDepthStencilFormat))
+    {
+        ret->autorelease();
+        return ret;
+    }
+    CC_SAFE_DELETE(ret);
+    return nullptr;
+}
+
+RenderTexture * RenderTexture::create(int w ,int h, backend::PixelFormat eFormat, PixelFormat uDepthStencilFormat, MsaaMode multisampling)
+{
+    RenderTexture *ret = new (std::nothrow) RenderTexture();
+#ifdef CC_USE_METAL
+    if(GLView::getGLContextAttrs().multisamplingCount > 1){
+        ret->_multisampling = multisampling;
+    }
+#endif
     if(ret && ret->initWithWidthAndHeight(w, h, eFormat, uDepthStencilFormat))
     {
         ret->autorelease();
@@ -197,19 +222,46 @@ bool RenderTexture::initWithWidthAndHeight(int w, int h, backend::PixelFormat fo
         if (_texture2D)
         {
             _texture2D->initWithBackendTexture(texture, CC_ENABLE_PREMULTIPLIED_ALPHA != 0);
-            _texture2D->setRenderTarget(true);
             texture->release();
         }
         else
             break;
-
+        
         _renderTargetFlags = RenderTargetFlag::COLOR;
+
+        if(_multisampling != MsaaMode::None)
+        {
+            _renderTargetFlags |= RenderTargetFlag::MSAA;
+            
+            // setup msaaTarget and depth textures as multisampe
+            descriptor.msaaEnabled = true;
+            
+            { // create msaaTarget texture
+                texture = backend::Device::getInstance()->newTexture(descriptor);
+                if (! texture)
+                    break;
+
+                _textureMsaaTarget = new (std::nothrow) Texture2D;
+                if (!_textureMsaaTarget)
+                {
+                    texture->release();
+                    break;
+                }
+                _textureMsaaTarget->initWithBackendTexture(texture);
+                _textureMsaaTarget->setRenderTarget(true);
+                texture->release();
+            }
+        }
+        
+        _texture2D->setRenderTarget(true);
 
         clearColorAttachment();
 
         if (PixelFormat::D24S8 == depthStencilFormat)
         {
-            _renderTargetFlags = RenderTargetFlag::ALL;
+            _renderTargetFlags |= RenderTargetFlag::DEPTH;
+            _renderTargetFlags |= RenderTargetFlag::STENCIL;
+            
             descriptor.textureFormat = depthStencilFormat;
             texture = backend::Device::getInstance()->newTexture(descriptor);
             if (! texture)
@@ -231,7 +283,10 @@ bool RenderTexture::initWithWidthAndHeight(int w, int h, backend::PixelFormat fo
         {
             _texture2DCopy->setAntiAliasTexParameters();
         }
-
+        if (_textureMsaaTarget)
+        {
+            _textureMsaaTarget->setAntiAliasTexParameters();
+        }
         // retained
         setSprite(Sprite::createWithTexture(_texture2D));
 
@@ -310,7 +365,11 @@ void RenderTexture::beginWithClear(float r, float g, float b, float a, float dep
     setClearStencil(stencilValue);
     setClearFlags(flags);
     begin();
-    Director::getInstance()->getRenderer()->clear(_clearFlags, _clearColor, _clearDepth, _clearStencil, _globalZOrder);
+    Renderer* renderer = Director::getInstance()->getRenderer();
+    if(_multisampling == MsaaMode::MtlUnified)
+        renderer->beginUnifiedMsaa(_texture2D, _clearColor, _clearDepth, _clearStencil, _globalZOrder);
+    else
+        renderer->clear(_clearFlags, _clearColor, _clearDepth, _clearStencil, _globalZOrder);
 }
 
 void RenderTexture::clear(float r, float g, float b, float a)
@@ -568,16 +627,22 @@ void RenderTexture::onBegin()
     _oldStencilAttachment = renderer->getStencilAttachment();
     _oldRenderTargetFlag = renderer->getRenderTargetFlag();
 
-    renderer->setRenderTarget(_renderTargetFlags, _texture2D, _depthStencilTexture, _depthStencilTexture);
+    renderer->setRenderTarget(_renderTargetFlags, _textureMsaaTarget ?: _texture2D, _depthStencilTexture, _depthStencilTexture);
 }
 
 void RenderTexture::onEnd()
 {
     Director *director = Director::getInstance();
+    Renderer *renderer =  Director::getInstance()->getRenderer();
+    
+    if(_multisampling == MsaaMode::MtlCommon)
+        renderer->resolveMsaaColorTo(_texture2D);
+    else if(_multisampling == MsaaMode::MtlUnified)
+        renderer->endUnifiedMsaa();
+    
     director->loadMatrix(MATRIX_STACK_TYPE::MATRIX_STACK_PROJECTION, _oldProjMatrix);
     director->loadMatrix(MATRIX_STACK_TYPE::MATRIX_STACK_MODELVIEW, _oldTransMatrix);
-    
-    Renderer *renderer =  Director::getInstance()->getRenderer();
+        
     renderer->setViewPort(_oldViewport.x, _oldViewport.y, _oldViewport.w, _oldViewport.h);
     renderer->setRenderTarget(_oldRenderTargetFlag, _oldColorAttachment, _oldDepthAttachment, _oldStencilAttachment);
 }
@@ -650,9 +715,14 @@ void RenderTexture::setClearFlags(ClearFlag clearFlags)
 void RenderTexture::clearColorAttachment()
 {
     auto renderer = Director::getInstance()->getRenderer();
+    RenderTargetFlag oldFlags = renderer->getRenderTargetFlag();
+    RenderTargetFlag flags = RenderTargetFlag::COLOR;
+    if(_multisampling != MsaaMode::None)
+        flags |= RenderTargetFlag::MSAA;
+    
     _beforeClearAttachmentCommand.func = [=]() -> void {
         _oldColorAttachment = renderer->getColorAttachment();
-        renderer->setRenderTarget(RenderTargetFlag::COLOR, _texture2D, nullptr, nullptr);
+        renderer->setRenderTarget(flags, _texture2D, nullptr, nullptr);
     };
     renderer->addCommand(&_beforeClearAttachmentCommand);
 
@@ -660,7 +730,7 @@ void RenderTexture::clearColorAttachment()
     renderer->clear(ClearFlag::COLOR, color, 1, 0, _globalZOrder);
 
     _afterClearAttachmentCommand.func = [=]() -> void {
-        renderer->setRenderTarget(RenderTargetFlag::COLOR, _oldColorAttachment, nullptr, nullptr);
+        renderer->setRenderTarget(oldFlags, _oldColorAttachment, nullptr, nullptr);
     };
     renderer->addCommand(&_afterClearAttachmentCommand);
 }

--- a/cocos/2d/CCRenderTexture.h
+++ b/cocos/2d/CCRenderTexture.h
@@ -60,6 +60,17 @@ class EventCustom;
 class CC_DLL RenderTexture : public Node 
 {
 public:
+    enum class MsaaMode : int {
+        /// Render without msaa
+        None = 0,
+        /// General render-pipeline with enabled msaa (Metal only).
+        /// Will create new encoder on clear, MSAA resolving, and every 2d/3d switch.
+        MtlCommon = 1,
+        /// Create a unified-encoder on beginWithClear (Metal only).
+        /// Unified encoder provide single metal-pass for clear, MSAA-Resolve, and every 2d/3d switch operations.
+        MtlUnified = 2
+    };
+    
     /** Initializes a RenderTexture object with width and height in Points and a pixel format( only RGB and RGBA formats are valid ) and depthStencil format. 
      *
      * @param w The RenderTexture object width.
@@ -68,6 +79,7 @@ public:
      * @param depthStencilFormat The depthStencil format.
      */
     static RenderTexture * create(int w ,int h, backend::PixelFormat format, backend::PixelFormat depthStencilFormat);
+    static RenderTexture * create(int w ,int h, backend::PixelFormat format, backend::PixelFormat depthStencilFormat, MsaaMode multisampling);
 
     /** Creates a RenderTexture object with width and height in Points and a pixel format, only RGB and RGBA formats are valid. 
      *
@@ -344,6 +356,7 @@ protected:
     //renderer caches and callbacks
     void onBegin();
     void onEnd();
+    void resolveMsaaColorTexture();
     void clearColorAttachment();
 
     void onSaveToFile(const std::string& fileName, bool isRGBA = true, bool forceNonPMA = false);
@@ -358,6 +371,7 @@ protected:
     Texture2D* _texture2D = nullptr;
     Texture2D* _depthStencilTexture = nullptr;
     Texture2D* _texture2DCopy = nullptr;    // a copy of _texture
+    Texture2D* _textureMsaaTarget = nullptr;
     Texture2D* _oldColorAttachment = nullptr;
     Texture2D* _oldDepthAttachment = nullptr;
     Texture2D* _oldStencilAttachment = nullptr;
@@ -370,6 +384,7 @@ protected:
     float _clearDepth = 1.f;
     int _clearStencil = 0;
     bool _autoDraw = false;
+    MsaaMode _multisampling = MsaaMode::None;
     ClearFlag _clearFlags = ClearFlag::NONE;
 
     /** The Sprite being used.

--- a/cocos/base/CCDirector.cpp
+++ b/cocos/base/CCDirector.cpp
@@ -1180,7 +1180,7 @@ void Director::showStats()
         // to make the FPS stable
         if (_accumDt > CC_DIRECTOR_STATS_INTERVAL)
         {
-            sprintf(buffer, "%.1f / %.3f", _frames / _accumDt, _secondsPerFrame);
+            sprintf(buffer, "FPS: %.1f / %.3f", _frames / _accumDt, _secondsPerFrame);
             _FPSLabel->setString(buffer);
             _accumDt = 0;
             _frames = 0;
@@ -1188,8 +1188,12 @@ void Director::showStats()
 
         auto currentCalls = (unsigned long)_renderer->getDrawnBatches();
         auto currentVerts = (unsigned long)_renderer->getDrawnVertices();
+        auto metalEncoders = (unsigned long)_renderer->getUsedMetalEncoders();
         if( currentCalls != prevCalls ) {
-            sprintf(buffer, "GL calls:%6lu", currentCalls);
+            if(metalEncoders)
+                sprintf(buffer, "MTL calls:%5lu[%lu]", currentCalls, metalEncoders);
+            else
+                sprintf(buffer, "GL calls:%6lu", currentCalls);
             _drawnBatchesLabel->setString(buffer);
             prevCalls = currentCalls;
         }

--- a/cocos/base/ccTypes.h
+++ b/cocos/base/ccTypes.h
@@ -649,6 +649,7 @@ enum class RenderTargetFlag : uint8_t
     COLOR = 1,
     DEPTH = 1 << 1,
     STENCIL = 1 << 2,
+    MSAA = 1 << 4,
     ALL = COLOR | DEPTH | STENCIL
 };
 ENABLE_BITMASK_OPERATORS(RenderTargetFlag)

--- a/cocos/platform/ios/CCEAGLView-ios.mm
+++ b/cocos/platform/ios/CCEAGLView-ios.mm
@@ -149,6 +149,7 @@ Copyright (C) 2008 Apple Inc. All Rights Reserved.
         metalLayer.device = device;
         metalLayer.pixelFormat = MTLPixelFormatBGRA8Unorm;
         metalLayer.framebufferOnly = YES;
+        metalLayer.drawableSize =  CGSizeMake(originalRect_.size.width * self.contentScaleFactor, originalRect_.size.height * self.contentScaleFactor);
         cocos2d::backend::DeviceMTL::setCAMetalLayer(metalLayer);
     }
     

--- a/cocos/renderer/CCRenderer.h
+++ b/cocos/renderer/CCRenderer.h
@@ -172,10 +172,13 @@ public:
     void addDrawnBatches(ssize_t number) { _drawnBatches += number; };
     /* returns the number of drawn triangles in the last frame */
     ssize_t getDrawnVertices() const { return _drawnVertices; }
+    /* returns the number of created metal encoders */
+    ssize_t getUsedMetalEncoders() const { return _metalEncoders; }
     /* RenderCommands (except) TrianglesCommand should update this value */
     void addDrawnVertices(ssize_t number) { _drawnVertices += number; };
+    void addMetalEncoderUse(ssize_t number) { _metalEncoders += number; };
     /* clear draw stats */
-    void clearDrawStats() { _drawnBatches = _drawnVertices = 0; }
+    void clearDrawStats() { _drawnBatches = _drawnVertices = _metalEncoders =  0; }
 
     /**
      Set render targets. If not set, will use default render targets. It will effect all commands.
@@ -404,7 +407,11 @@ public:
 
     /** returns whether or not a rectangle is visible or not */
     bool checkVisibility(const Mat4& transform, const Size& size);
-    
+
+    void beginUnifiedMsaa(Texture2D* resolveTex, const Color4F& color, float depth, unsigned int stencil, float globalOrder);
+    void endUnifiedMsaa();
+    void resolveMsaaColorTo(Texture2D*);
+
 protected:
     friend class Director;
     friend class GroupCommand;
@@ -529,9 +536,9 @@ protected:
     // stats
     unsigned int _drawnBatches = 0;
     unsigned int _drawnVertices = 0;
+    unsigned int _metalEncoders = 0;
     //the flag for checking whether renderer is rendering
     bool _isRendering = false;
-    bool _isDepthTestFor2D = false;
         
     GroupCommandManager* _groupCommandManager = nullptr;
 

--- a/cocos/renderer/backend/CommandBuffer.cpp
+++ b/cocos/renderer/backend/CommandBuffer.cpp
@@ -37,4 +37,9 @@ void CommandBuffer::setStencilReferenceValue(unsigned int frontRef, unsigned int
     _stencilReferenceValueBack = backRef;
 }
 
+void CommandBuffer::unlockMtlEncoder()
+{
+    // do nothing
+}
+
 CC_BACKEND_END

--- a/cocos/renderer/backend/CommandBuffer.h
+++ b/cocos/renderer/backend/CommandBuffer.h
@@ -31,7 +31,7 @@
 #include "Macros.h"
 #include "Types.h"
 #include "RenderPassDescriptor.h"
-#include "CCStdC.h"
+#include "platform/CCStdC.h"
 #include "ProgramState.h"
 #include "VertexLayout.h"
 
@@ -183,6 +183,8 @@ public:
      * @param backRef Specifies back stencil reference value.
      */
     void setStencilReferenceValue(unsigned int frontRef, unsigned int backRef);
+    
+    virtual void unlockMtlEncoder();
 
 protected:
     virtual ~CommandBuffer() = default;

--- a/cocos/renderer/backend/DepthStencilState.h
+++ b/cocos/renderer/backend/DepthStencilState.h
@@ -61,6 +61,7 @@ struct DepthStencilDescriptor
     bool depthTestEnabled = false;
     
     bool stencilTestEnabled = false;
+    bool encodeUnifiedMsaa = false;
     StencilDescriptor backFaceStencil;
     StencilDescriptor frontFaceStencil;
 };

--- a/cocos/renderer/backend/RenderPassDescriptor.cpp
+++ b/cocos/renderer/backend/RenderPassDescriptor.cpp
@@ -41,6 +41,11 @@ RenderPassDescriptor& RenderPassDescriptor::operator=(const RenderPassDescriptor
     stencilAttachmentTexture = descriptor.stencilAttachmentTexture;
     colorAttachmentsTexture[0] = descriptor.colorAttachmentsTexture[0];
     
+    msaaEnabled = descriptor.msaaEnabled;
+    encodeUnifiedMsaa = descriptor.encodeUnifiedMsaa;
+    msaaResolveTexture = descriptor.msaaResolveTexture;
+    encodeMsaaResolve = descriptor.encodeMsaaResolve;
+    
     return *this;
 }
 
@@ -57,7 +62,11 @@ bool RenderPassDescriptor::operator==(const RenderPassDescriptor& descriptor) co
         needClearStencil == descriptor.needClearStencil &&
         depthAttachmentTexture == descriptor.depthAttachmentTexture &&
         stencilAttachmentTexture == descriptor.stencilAttachmentTexture &&
-        colorAttachmentsTexture[0] == descriptor.colorAttachmentsTexture[0])
+        colorAttachmentsTexture[0] == descriptor.colorAttachmentsTexture[0] &&
+        msaaEnabled == descriptor.msaaEnabled &&
+       encodeMsaaResolve == descriptor.encodeMsaaResolve &&
+        encodeUnifiedMsaa == descriptor.encodeUnifiedMsaa &&
+        msaaResolveTexture == descriptor.msaaResolveTexture )
     {
         return true;
     }
@@ -65,6 +74,11 @@ bool RenderPassDescriptor::operator==(const RenderPassDescriptor& descriptor) co
     {
         return false;
     }
+}
+
+bool RenderPassDescriptor::needDepthStencilAttachment() const
+{
+    return depthTestEnabled || stencilTestEnabled;    
 }
 
 CC_BACKEND_END

--- a/cocos/renderer/backend/RenderPassDescriptor.h
+++ b/cocos/renderer/backend/RenderPassDescriptor.h
@@ -45,7 +45,7 @@ struct RenderPassDescriptor
 {
     RenderPassDescriptor& operator=(const RenderPassDescriptor& descriptor);
     bool operator==(const RenderPassDescriptor& descriptor) const;
-    bool needDepthStencilAttachment() const { return depthTestEnabled || stencilTestEnabled; }
+    bool needDepthStencilAttachment() const;
 
     float clearDepthValue = 0.f;
     float clearStencilValue = 0.f;
@@ -56,6 +56,10 @@ struct RenderPassDescriptor
     bool needClearColor = false;
     bool needClearDepth = false;
     bool needClearStencil = false;
+    bool msaaEnabled = false;
+    bool encodeUnifiedMsaa = false;
+    bool encodeMsaaResolve = false;
+    TextureBackend* msaaResolveTexture = nullptr;
     TextureBackend* depthAttachmentTexture = nullptr;
     TextureBackend* stencilAttachmentTexture = nullptr;
     TextureBackend* colorAttachmentsTexture[MAX_COLOR_ATTCHMENT] = { nullptr };

--- a/cocos/renderer/backend/Texture.h
+++ b/cocos/renderer/backend/Texture.h
@@ -48,6 +48,7 @@ struct TextureDescriptor
     uint32_t height = 0;
     uint32_t depth = 0;
     SamplerDescriptor samplerDescriptor;
+    bool msaaEnabled = false;
 };
 
 /**

--- a/cocos/renderer/backend/metal/CommandBufferMTL.h
+++ b/cocos/renderer/backend/metal/CommandBufferMTL.h
@@ -172,6 +172,8 @@ public:
      */
     virtual void captureScreen(std::function<void(const unsigned char*, int, int)> callback) override;
     
+    void unlockMtlEncoder() override;
+    
 private:
     void prepareDrawing() const;
     void setTextures() const;
@@ -196,6 +198,10 @@ private:
     dispatch_semaphore_t _frameBoundarySemaphore;
     RenderPassDescriptor _prevRenderPassDescriptor;
     NSAutoreleasePool* _autoReleasePool = nil;
+    
+    bool _isMtlEncoderLocked = false;
+    unsigned int _lockedEncoderColorId = 0;
+    unsigned int _lockedEncoderDepthId = 0;
 };
 
 // end of _metal group

--- a/cocos/renderer/backend/metal/DepthStencilStateMTL.mm
+++ b/cocos/renderer/backend/metal/DepthStencilStateMTL.mm
@@ -106,7 +106,7 @@ namespace
 DepthStencilStateMTL::DepthStencilStateMTL(id<MTLDevice> mtlDevice, const DepthStencilDescriptor& descriptor)
 : DepthStencilState(descriptor)
 {
-    if (!descriptor.depthTestEnabled && !descriptor.stencilTestEnabled && !descriptor.depthWriteEnabled)
+    if (!descriptor.depthTestEnabled && !descriptor.stencilTestEnabled && !descriptor.depthWriteEnabled && !descriptor.encodeUnifiedMsaa)
         return;
     
     MTLDepthStencilDescriptor* mtlDescriptor = [[MTLDepthStencilDescriptor alloc] init];
@@ -125,6 +125,7 @@ DepthStencilStateMTL::DepthStencilStateMTL(id<MTLDevice> mtlDevice, const DepthS
     }
 
     _mtlDepthStencilState = [mtlDevice newDepthStencilStateWithDescriptor:mtlDescriptor];
+    [_mtlDepthStencilState retain];
     [mtlDescriptor release];
 }
 

--- a/cocos/renderer/backend/metal/DeviceMTL.h
+++ b/cocos/renderer/backend/metal/DeviceMTL.h
@@ -25,10 +25,13 @@
 #pragma once
 
 #include "../Device.h"
+#include "base/CCMap.h"
 #import <Metal/Metal.h>
 #import <QuartzCore/CAMetalLayer.h>
 
 CC_BACKEND_BEGIN
+
+class DepthStencilStateMTL;
 
 /**
  * @addtogroup _metal
@@ -154,6 +157,7 @@ private:
     
     id<MTLDevice> _mtlDevice = nil;
     id<MTLCommandQueue> _mtlCommandQueue = nil;
+    Map<unsigned int, DepthStencilStateMTL*>  _depthStencilStateCache;
 };
 
 // end of _metal group

--- a/cocos/renderer/backend/metal/DeviceMTL.mm
+++ b/cocos/renderer/backend/metal/DeviceMTL.mm
@@ -32,6 +32,7 @@
 #include "Utils.h"
 #include "ProgramMTL.h"
 #include "DeviceInfoMTL.h"
+#include "xxhash.h"
 
 #include "base/ccMacros.h"
 
@@ -116,10 +117,18 @@ ShaderModule* DeviceMTL::newShaderModule(ShaderStage stage, const std::string& s
 
 DepthStencilState* DeviceMTL::createDepthStencilState(const DepthStencilDescriptor& descriptor)
 {
+    unsigned int hash = XXH32((const void*)&descriptor, sizeof(descriptor), 0);
+
+    auto it = _depthStencilStateCache.find(hash);
+    if(it != _depthStencilStateCache.end())
+        return it->second;
+
     auto ret = new (std::nothrow) DepthStencilStateMTL(_mtlDevice, descriptor);
     if (ret)
         ret->autorelease();
-    
+
+    _depthStencilStateCache.insert(hash, ret);
+
     return ret;
 }
 

--- a/cocos/renderer/backend/metal/RenderPipelineMTL.mm
+++ b/cocos/renderer/backend/metal/RenderPipelineMTL.mm
@@ -24,11 +24,13 @@
  
 #include "RenderPipelineMTL.h"
 #include "DeviceMTL.h"
+#include "TextureMTL.h"
 #include "ShaderModuleMTL.h"
 #include "DepthStencilStateMTL.h"
 #include "Utils.h"
 #include "ProgramMTL.h"
 #include "xxhash.h"
+#include "platform/CCGLView.h"
 
 CC_BACKEND_BEGIN
 
@@ -181,6 +183,7 @@ void RenderPipelineMTL::update(const PipelineDescriptor & pipelineDescirptor,
         unsigned int destinationRGBBlendFactor;
         unsigned int sourceAlphaBlendFactor;
         unsigned int destinationAlphaBlendFactor;
+        bool msaaEnabled;
     }hashMe;
     
     memset(&hashMe, 0, sizeof(hashMe));
@@ -200,6 +203,7 @@ void RenderPipelineMTL::update(const PipelineDescriptor & pipelineDescirptor,
     hashMe.destinationRGBBlendFactor = (unsigned int)blendDescriptor.destinationRGBBlendFactor;
     hashMe.sourceAlphaBlendFactor = (unsigned int)blendDescriptor.sourceAlphaBlendFactor;
     hashMe.destinationAlphaBlendFactor = (unsigned int)blendDescriptor.destinationAlphaBlendFactor;
+    hashMe.msaaEnabled = renderPassDescriptor.msaaEnabled;
     int index = 0;
     auto vertexLayout = pipelineDescirptor.programState->getVertexLayout();
     const auto& attributes = vertexLayout->getAttributes();
@@ -228,6 +232,12 @@ void RenderPipelineMTL::update(const PipelineDescriptor & pipelineDescirptor,
     }
     
     _mtlRenderPipelineDescriptor = [[MTLRenderPipelineDescriptor alloc] init];
+    
+    if(renderPassDescriptor.msaaEnabled){
+        int msaaCount = GLView::getGLContextAttrs().multisamplingCount;
+        // the sampleCount value of all the render target textures must match this sampleCount value
+        [_mtlRenderPipelineDescriptor setSampleCount: msaaCount];
+    }
     
     setShaderModules(pipelineDescirptor);
     setVertexLayout(_mtlRenderPipelineDescriptor, pipelineDescirptor);

--- a/cocos/renderer/backend/metal/TextureMTL.mm
+++ b/cocos/renderer/backend/metal/TextureMTL.mm
@@ -25,6 +25,7 @@
 #include "TextureMTL.h"
 #include "Utils.h"
 #include "base/ccMacros.h"
+#include "platform/CCGLView.h"
 
 CC_BACKEND_BEGIN
 
@@ -275,11 +276,22 @@ void TextureMTL::createTexture(id<MTLDevice> mtlDevice, const TextureDescriptor&
                                                           mipmapped:YES];
     
     if (TextureUsage::RENDER_TARGET == descriptor.textureUsage)
-    {
-        //DepthStencil, and Multisample textures must be allocated with the MTLResourceStorageModePrivate resource option
-        if(PixelFormat::D24S8 == descriptor.textureFormat)
+    {        
+        // DepthStencil, and Multisample textures must be allocated with the MTLResourceStorageModePrivate resource option
+        if(PixelFormat::D24S8 == descriptor.textureFormat){
             textureDescriptor.resourceOptions = MTLResourceStorageModePrivate;
+            textureDescriptor.usage = MTLTextureUsageUnknown;
+        }
+        
         textureDescriptor.usage = MTLTextureUsageRenderTarget | MTLTextureUsageShaderRead;
+
+        if (descriptor.msaaEnabled) {
+            int msaaCount = GLView::getGLContextAttrs().multisamplingCount;
+            textureDescriptor.resourceOptions = MTLResourceStorageModePrivate;
+            textureDescriptor.textureType = MTLTextureType2DMultisample;
+            textureDescriptor.sampleCount = msaaCount;
+            textureDescriptor.mipmapLevelCount = 1;
+        }
     }
     
     if(_mtlTexture)

--- a/cocos/renderer/backend/metal/Utils.h
+++ b/cocos/renderer/backend/metal/Utils.h
@@ -100,13 +100,40 @@ public:
      */
     static void swizzleImage(unsigned char* image, std::size_t width, std::size_t height, MTLPixelFormat format);
     
+    /**
+     * Get the default msaa color texture.
+     * @return Will return or create msaa bufer appropriate for
+     * DeviceMTL::getCurrentDrawable().texture size
+     */
+    static id<MTLTexture> getDefaultMsaaColorTarget();
+    /**
+    * Get the default msaa depth and stencil texture.
+    * @return Will return or create msaa bufer appropriate for
+    * DeviceMTL::getCurrentDrawable().texture size
+    */
+    static id<MTLTexture> getDefaultMsaaDepthTarget();
+    static id<MTLTexture> getDefaultDepthTarget(bool withMsaa);
+    
 private:
     static id<MTLTexture> createDepthStencilAttachmentTexture();
-
+    
+    static id<MTLTexture> createDefaultMsaaDepthTarget();
+    static id<MTLTexture> createDefaultMsaaColorTarget();
     
     static id<MTLTexture> _defaultColorAttachmentTexture;
     static id<MTLTexture> _defaultDepthStencilAttachmentTexture;
+    
+    static id<MTLTexture> _defaultMsaaColorTarget;
+    static id<MTLTexture> _defaultMsaaDepthTarget;
 };
+
+inline id<MTLTexture> Utils::getDefaultDepthTarget(bool withMsaa)
+{
+    if(withMsaa)
+        return getDefaultMsaaDepthTarget();
+    else
+        return getDefaultDepthStencilTexture();
+}
 
 // end of _metal group
 /// @}

--- a/tests/cpp-tests/Classes/AppDelegate.cpp
+++ b/tests/cpp-tests/Classes/AppDelegate.cpp
@@ -49,7 +49,7 @@ AppDelegate::~AppDelegate()
 void AppDelegate::initGLContextAttrs()
 {
     // set OpenGL context attributes: red,green,blue,alpha,depth,stencil
-    GLContextAttrs glContextAttrs = {8, 8, 8, 8, 24, 8, 0};
+    GLContextAttrs glContextAttrs = {8, 8, 8, 8, 24, 8, 4};
 
     GLView::setGLContextAttrs(glContextAttrs);
 }

--- a/tests/cpp-tests/Classes/RenderTextureTest/RenderTextureTest.h
+++ b/tests/cpp-tests/Classes/RenderTextureTest/RenderTextureTest.h
@@ -197,4 +197,33 @@ private:
     cocos2d::RenderTexture* _renderTexWithBuffer;
 };
 
+class RenderTextureWithMsaaSprite3D : public RenderTextureTest
+{
+   
+public:
+    CREATE_FUNC(RenderTextureWithMsaaSprite3D);
+    RenderTextureWithMsaaSprite3D();
+    
+    void resetTest();
+    
+    virtual void visit(cocos2d::Renderer *renderer, const cocos2d::Mat4& parentTransform, uint32_t parentFlags) override;
+
+    virtual std::string title() const override;
+    virtual std::string subtitle() const override;
+    
+    virtual void update(float t)override;
+    
+    void onScaleTest(cocos2d::Ref* sender);
+    void onMssa(cocos2d::Ref* sender);
+
+private:
+    cocos2d::Vector<cocos2d::Node*> _nodes;
+    cocos2d::RenderTexture* _renderTexWithBuffer = nullptr;
+    int _testScale = 1;
+    cocos2d::RenderTexture::MsaaMode _useMsaa = cocos2d::RenderTexture::MsaaMode::None;
+    
+    cocos2d::MenuItemFont* _btnScale = nullptr;
+    cocos2d::MenuItemFont* _btnMsaa = nullptr;
+};
+
 #endif


### PR DESCRIPTION
1) MSAA may be enabled for the general Metal pipeline with the new flag:
> ENABLE_MSAA_GLOBAL_METAL (CCRenderer.cpp:156).

![3](https://user-images.githubusercontent.com/64310561/80384797-ffc45c80-88ad-11ea-84f4-e65473e76852.jpg)

2) MSAA also can be enabled during drawing in to render texture (metal only).
It's available the new test under the "RenderTextureTest" section. Where one can compare the quality of rendering with and without MSAA.
> RenderTextureWithMsaaSprite3D (RenderTextureTest.h:200)

3) I have a mixed 2d/3d pipeline due to the specifics of my current project. And I noticed that it takes a lot of time to create each new CommandEncoder.
Here provided an ad hoc solution to this issue.
> MsaaMode::MtlUnified (CCRenderTexture.h:71, CommandBufferMTL.cpp::100, CCRenderer.cpp:900 ..)

You may also compare the performance of common and unified multisampling in RenderTextureWithMsaaSprite3D test.

I realize that this solution is pretty dirty and situational to be merged to cocos-2d master. But its a good start point for future development. Here is the capture of this test running on a 6 scale.  
https://www.youtube.com/watch?v=8LinKjoj4Y8
The speedup was 12 to 60 fps on my iPhone 10. 

4) The creation of DepthStencilStateMTL was a bottleneck for mixed 2d/3d rendering. Depth/stencil state cache was implemented to make it's creation faster.
> _depthStencilStateCache (DeviceMTL.h:160)