### PR TITLE
Update Android Gradle Plugin from 3.2.0 to 3.6.3

### DIFF
--- a/templates/cpp-template-default/proj.android/build.gradle
+++ b/templates/cpp-template-default/proj.android/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.0'
+        classpath 'com.android.tools.build:gradle:3.6.3'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/templates/cpp-template-default/proj.android/gradle/wrapper/gradle-wrapper.properties
+++ b/templates/cpp-template-default/proj.android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip

--- a/templates/lua-template-default/frameworks/runtime-src/proj.android/build.gradle
+++ b/templates/lua-template-default/frameworks/runtime-src/proj.android/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.0'
+        classpath 'com.android.tools.build:gradle:3.6.3'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/templates/lua-template-default/frameworks/runtime-src/proj.android/gradle/wrapper/gradle-wrapper.properties
+++ b/templates/lua-template-default/frameworks/runtime-src/proj.android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip

--- a/tests/cpp-empty-test/proj.android/build.gradle
+++ b/tests/cpp-empty-test/proj.android/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.0'
+        classpath 'com.android.tools.build:gradle:3.6.3'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/tests/cpp-empty-test/proj.android/gradle/wrapper/gradle-wrapper.properties
+++ b/tests/cpp-empty-test/proj.android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip

--- a/tests/cpp-tests/proj.android/build.gradle
+++ b/tests/cpp-tests/proj.android/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.0'
+        classpath 'com.android.tools.build:gradle:3.6.3'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/tests/cpp-tests/proj.android/gradle/wrapper/gradle-wrapper.properties
+++ b/tests/cpp-tests/proj.android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip

--- a/tests/lua-empty-test/project/proj.android/build.gradle
+++ b/tests/lua-empty-test/project/proj.android/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.0'
+        classpath 'com.android.tools.build:gradle:3.6.3'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/tests/lua-empty-test/project/proj.android/gradle/wrapper/gradle-wrapper.properties
+++ b/tests/lua-empty-test/project/proj.android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip

--- a/tests/lua-tests/project/proj.android/build.gradle
+++ b/tests/lua-tests/project/proj.android/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.0'
+        classpath 'com.android.tools.build:gradle:3.6.3'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/tests/lua-tests/project/proj.android/gradle/wrapper/gradle-wrapper.properties
+++ b/tests/lua-tests/project/proj.android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip

--- a/tests/performance-tests/proj.android/build.gradle
+++ b/tests/performance-tests/proj.android/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.0'
+        classpath 'com.android.tools.build:gradle:3.6.3'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/tests/performance-tests/proj.android/gradle/wrapper/gradle-wrapper.properties
+++ b/tests/performance-tests/proj.android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip


### PR DESCRIPTION
Also updated the Gradle version to the minimum required (5.6.4).

Changes were made with the following commands:
find . -name build.gradle -print0 | xargs -0 sed -i '' -e 's/3.1.0/3.6.3/g'
find . -name gradle-wrapper.properties -print0 | xargs -0 sed -i '' -e 's/5.1.1/5.6.4/g'

Checked build speed by running "./gradlew build" in the directory "tests/cpp-empty-test/proj.android". After running gradlew once to download dependencies, build speed is unaffected:
./gradlew clean build
Before (with AGP 3.2.0): BUILD SUCCESSFUL in 3m 52s
After (with AGP 3.6.3): BUILD SUCCESSFUL in 3m 41s