### PR TITLE
Update AudioMacros.h

### DIFF
--- a/cocos/audio/win32/AudioMacros.h
+++ b/cocos/audio/win32/AudioMacros.h
@@ -51,7 +51,7 @@ void audioLog(const char * format, ...);
 #if defined(COCOS2D_DEBUG) && COCOS2D_DEBUG > 0
 #define CHECK_AL_ERROR_DEBUG() \
 do { \
-    GLenum __error = alGetError(); \
+    ALenum __error = alGetError(); \
     if (__error) { \
         ALOGE("OpenAL error 0x%04X in %s %s %d\n", __error, __FILE__, __FUNCTION__, __LINE__); \
     } \


### PR DESCRIPTION
Fix to compile with Visual Studio 2019.
Ricardo.