### PR TITLE
Value optimizations

### DIFF
--- a/cocos/base/CCValue.cpp
+++ b/cocos/base/CCValue.cpp
@@ -96,6 +96,13 @@ Value::Value(const std::string& v)
     *_field.strVal = v;
 }
 
+Value::Value(std::string&& v)
+: _type(Type::STRING)
+{
+    _field.strVal = new (std::nothrow) std::string();
+    *_field.strVal = std::move(v);
+}
+
 Value::Value(const ValueVector& v)
 : _type(Type::VECTOR)
 {
@@ -316,6 +323,13 @@ Value& Value::operator= (const std::string& v)
 {
     reset(Type::STRING);
     *_field.strVal = v;
+    return *this;
+}
+
+Value& Value::operator= (std::string&& v)
+{
+    reset(Type::STRING);
+    *_field.strVal = std::move(v);
     return *this;
 }
 

--- a/cocos/base/CCValue.h
+++ b/cocos/base/CCValue.h
@@ -84,6 +84,8 @@ public:
     
     /** Create a Value by a string. */
     explicit Value(const std::string& v);
+    /** Create a Value by a string. It will use std::move internally. */
+    explicit Value(std::string&& v);
     
     /** Create a Value by a ValueVector object. */
     explicit Value(const ValueVector& v);
@@ -129,6 +131,8 @@ public:
     Value& operator= (const char* v);
     /** Assignment operator, assign from string to Value. */
     Value& operator= (const std::string& v);
+    /** Assignment operator, assign from string to Value. It will use std::move internally. */
+    Value& operator= (std::string&& v);
 
     /** Assignment operator, assign from ValueVector to Value. */
     Value& operator= (const ValueVector& v);

--- a/cocos/platform/apple/CCFileUtils-apple.mm
+++ b/cocos/platform/apple/CCFileUtils-apple.mm
@@ -153,24 +153,26 @@ static cocos2d::Value convertNSObjectToCCValue(id item)
     if ([item isKindOfClass:[NSDictionary class]])
     {
         ValueMap dict;
+        dict.reserve([item count]);
         for (id subKey in [item allKeys])
         {
             id subValue = [item objectForKey:subKey];
             addNSObjectToCCMap(subKey, subValue, dict);
         }
         
-        return Value(dict);
+        return Value(std::move(dict));
     }
     
     // add array value into array
     if ([item isKindOfClass:[NSArray class]])
     {
         ValueVector subArray;
+        subArray.reserve([item count]);
         for (id subItem in item)
         {
             addNSObjectToCCVector(subItem, subArray);
         }
-        return Value(subArray);
+        return Value(std::move(subArray));
     }
     
     return Value::Null;
@@ -191,7 +193,7 @@ static void addNSObjectToCCMap(id nsKey, id nsValue, ValueMap& dict)
     // the key must be a string
     CCASSERT([nsKey isKindOfClass:[NSString class]], "The key should be a string!");
     std::string key = [nsKey UTF8String];
-    dict[key] = convertNSObjectToCCValue(nsValue);
+    dict[std::move(key)] = convertNSObjectToCCValue(nsValue);
 }
 
 static void addCCValueToNSDictionary(const std::string& key, const Value& value, NSMutableDictionary *dict)
@@ -382,6 +384,7 @@ ValueMap FileUtilsApple::getValueMapFromData(const char* filedata, int filesize)
 
     if (dict != nil)
     {
+        ret.reserve([dict count]);
         for (id key in [dict allKeys])
         {
             id value = [dict objectForKey:key];
@@ -490,6 +493,7 @@ ValueVector FileUtilsApple::getValueVectorFromFile(const std::string& filename) 
     NSArray* array = [NSArray arrayWithContentsOfFile:path];
 
     ValueVector ret;
+    ret.reserve([array count]);
 
     for (id value in array)
     {


### PR DESCRIPTION
I was having trouble with long loading times of large (4+ mb) .plist files using method `FileUtilsApple::getValueMapFromFile`.
Using the profiling tools I found out that large amount of time was spent in function `Value& Value::operator= (const Value& other)`.
By using `reserve` I have avoided copying due to reallocations and by using `std::move` I have removed calls to copy constructor/assignment methods.
These changes in `CCFileUtils-apple.mm` have made execution of `FileUtilsApple::getValueMapFromFile` 2.375x faster.

I have also added rvalue constructor/assignment methods for `std::string` to class `Value`.
By using these methods, execution time is decreased from linear to constant time.
This improvement is most noticeable on large strings.