### PR TITLE
Fix Label::draw

### DIFF
--- a/cocos/2d/CCLabel.cpp
+++ b/cocos/2d/CCLabel.cpp
@@ -1907,7 +1907,7 @@ void Label::draw(Renderer *renderer, const Mat4 &transform, uint32_t flags)
             {
                 auto textureAtlas = batchNode->getTextureAtlas();
                 if (!textureAtlas->getTotalQuads())
-                    return;
+                    continue;
 
                 auto &batch = _batchCommands[i++];
                 auto &&commands = batch.getCommandArray();


### PR DESCRIPTION
Fix Label::draw skips drawing when batchNodes are more than one and have empty quads