### PR TITLE
fix MaterialID type err

### DIFF
--- a/cocos/renderer/CCRenderer.cpp
+++ b/cocos/renderer/CCRenderer.cpp
@@ -568,7 +568,8 @@ void Renderer::drawBatchedTriangles()
     _triBatchesToDraw[0].cmd = nullptr;
     
     int batchesTotal = 0;
-    int prevMaterialID = -1;
+    unsigned int prevMaterialID = -1;
+    bool isValidMaterialID = false;
     bool firstCommand = true;
 
     _filledVertex = 0;
@@ -582,7 +583,7 @@ void Renderer::drawBatchedTriangles()
         fillVerticesAndIndices(cmd, vertexBufferFillOffset);
         
         // in the same batch ?
-        if (batchable && (prevMaterialID == currentMaterialID || firstCommand))
+        if (batchable && ((isValidMaterialID && prevMaterialID == currentMaterialID) || firstCommand))
         {
             CC_ASSERT((firstCommand || _triBatchesToDraw[batchesTotal].cmd->getMaterialID() == cmd->getMaterialID()) && "argh... error in logic");
             _triBatchesToDraw[batchesTotal].indicesToDraw += cmd->getIndexCount();
@@ -600,10 +601,10 @@ void Renderer::drawBatchedTriangles()
             
             _triBatchesToDraw[batchesTotal].cmd = cmd;
             _triBatchesToDraw[batchesTotal].indicesToDraw = (int) cmd->getIndexCount();
-            
+            isValidMaterialID = true;
             // is this a single batch ? Prevent creating a batch group then
             if (!batchable)
-                currentMaterialID = -1;
+                isValidMaterialID = false;
         }
         
         // capacity full ?


### PR DESCRIPTION
MaterialID是由hash计算得来的unsigned int型，drawBatchedTriangles函数prevMaterialID为int型，可能导致batch失败