### PR TITLE
Fix memory leak when adding a custom program which already exists

### DIFF
--- a/cocos/renderer/backend/ProgramCache.cpp
+++ b/cocos/renderer/backend/ProgramCache.cpp
@@ -64,6 +64,8 @@ namespace
 }
 
 std::unordered_map<backend::ProgramType, backend::Program*>  ProgramCache::_cachedPrograms;
+std::unordered_map<std::string, backend::Program*> ProgramCache::_cachedCustomPrograms;
+
 ProgramCache* ProgramCache::_sharedProgramCache = nullptr;
 
 ProgramCache* ProgramCache::getInstance()
@@ -303,6 +305,29 @@ void ProgramCache::removeAllPrograms()
         program.second->release();
     }
     _cachedPrograms.clear();
+    
+    for (auto& program : _cachedCustomPrograms)
+    {
+        program.second->release();
+    }
+    _cachedCustomPrograms.clear();
+}
+
+void ProgramCache::addCustomProgram(const std::string &key, backend::Program *program)
+{
+    _cachedCustomPrograms.emplace(key, program);
+}
+
+backend::Program* ProgramCache::getCustomProgram(const std::string &key) const
+{
+    const auto& iter = ProgramCache::_cachedCustomPrograms.find(key);
+    if (ProgramCache::_cachedCustomPrograms.end() != iter)
+    {
+        return iter->second;
+    }
+    
+    CCLOG("Warning: program %s not found in cache.", key.c_str());
+    return nullptr;
 }
 
 CC_BACKEND_END

--- a/cocos/renderer/backend/ProgramCache.cpp
+++ b/cocos/renderer/backend/ProgramCache.cpp
@@ -315,6 +315,13 @@ void ProgramCache::removeAllPrograms()
 
 void ProgramCache::addCustomProgram(const std::string &key, backend::Program *program)
 {
+    const auto& iter = _cachedCustomPrograms.find(key);
+    if (_cachedCustomPrograms.end() != iter)
+    {
+        iter->second->release();
+        _cachedCustomPrograms.erase(iter);
+    }
+    
     _cachedCustomPrograms.emplace(key, program);
 }
 

--- a/cocos/renderer/backend/ProgramCache.h
+++ b/cocos/renderer/backend/ProgramCache.h
@@ -69,6 +69,16 @@ public:
      */
     void removeAllPrograms();
     
+    /**
+     * Add custom program to the cache.
+     * @param key Specifies the key used to store the program.
+     * @param program Specifies the program to store in the cache.
+     */
+    void addCustomProgram(const std::string& key, backend::Program* program);
+    
+    /// Get custom program from cache.
+    backend::Program* getCustomProgram(const std::string& key) const;
+    
 protected:
     ProgramCache() = default;
     virtual ~ProgramCache();
@@ -82,6 +92,7 @@ protected:
     void addProgram(ProgramType type);
     
     static std::unordered_map<backend::ProgramType, backend::Program*> _cachedPrograms; ///< The cached program object.
+    static std::unordered_map<std::string, backend::Program*> _cachedCustomPrograms; ///< The cached custom program object.
     static ProgramCache *_sharedProgramCache; ///< A shared instance of the program cache.
 };
 


### PR DESCRIPTION
Release previous program and eraste it from cache before inserting new one.

This is fix for my previous PR: https://github.com/cocos2d/cocos2d-x/pull/20496