### PR TITLE
Updated readme to specify to build

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ cocos2d-x is:
   * Easy to use
   * Community supported
 
-Git user attention
+Instructions to build and install from source
 -----------------------
 
 1. Clone the repo from GitHub.
@@ -39,6 +39,17 @@ Git user attention
 3. After running `download-deps.py`.
 
          cocos2d-x $ git submodule update --init
+
+4. If on linux, run `install-deps-linux.sh`
+
+5. Build with cmake:
+
+```
+mkdir build
+cd build
+cmake ..
+make
+```
 
 Download stable versions
 -----------------------
@@ -113,13 +124,6 @@ $ cd cocos2d-x
 $ ./setup.py
 $ source FILE_TO_SAVE_SYSTEM_VARIABLE
 
-```
-
-Should invoke this script if using linux system
-
-```
-$ cd cocos2d-x
-$ ./install-linux-deps.sh
 ```
 
 Running Tests


### PR DESCRIPTION
The readme didn't tell me how to build; I could see it was a cmake project, so I understood, but it should really be all there atop the readme. I also changed the title so it's clear these are build instructions (rather than 'note for git users'), and moved a requirement for linux building up into those steps, instead of being way down by the runtime instructions. That last one may not be entirely correct, since I'm not sure if that step is needed for building cocos2d itself, the application you make using cocos, or both. If it is only for the application you intend to make, then it should be moved back down.