### PR TITLE
Getters and setters for Long preference values

### DIFF
--- a/cocos/base/CCUserDefault-android.cpp
+++ b/cocos/base/CCUserDefault-android.cpp
@@ -228,6 +228,42 @@ int UserDefault::getIntegerForKey(const char* pKey, int defaultValue)
 	return JniHelper::callStaticIntMethod(helperClassName, "getIntegerForKey", pKey, defaultValue);
 }
 
+long UserDefault::getLongForKey(const char* pKey)
+{
+    return getLongForKey(pKey, 0);
+}
+
+long UserDefault::getLongForKey(const char* pKey, long defaultValue)
+{
+#ifdef KEEP_COMPATABILITY
+    tinyxml2::XMLDocument* doc = nullptr;
+    tinyxml2::XMLElement* node = getXMLNodeForKey(pKey, &doc);
+    if (node)
+    {
+        if (node->FirstChild())
+        {
+            long ret = atol((const char*)node->FirstChild()->Value());
+
+            // set value in NSUserDefaults
+            setLongForKey(pKey, ret);
+            flush();
+
+            // delete xmle node
+            deleteNode(doc, node);
+
+            return ret;
+        }
+        else
+        {
+            // delete xmle node
+            deleteNode(doc, node);
+        }
+    }
+#endif
+
+	return JniHelper::callStaticLongMethod(helperClassName, "getLongForKey", pKey, defaultValue);
+}
+
 float UserDefault::getFloatForKey(const char* pKey)
 {
     return getFloatForKey(pKey, 0.0f);
@@ -419,6 +455,15 @@ void UserDefault::setIntegerForKey(const char* pKey, int value)
 #endif
 
     JniHelper::callStaticVoidMethod(helperClassName, "setIntegerForKey", pKey, value);
+}
+
+void UserDefault::setLongForKey(const char* pKey, long value)
+{
+#ifdef KEEP_COMPATABILITY
+    deleteNodeByKey(pKey);
+#endif
+
+    JniHelper::callStaticVoidMethod(helperClassName, "setLongForKey", pKey, value);
 }
 
 void UserDefault::setFloatForKey(const char* pKey, float value)

--- a/cocos/base/CCUserDefault-android.cpp
+++ b/cocos/base/CCUserDefault-android.cpp
@@ -261,7 +261,7 @@ int64_t UserDefault::getLongForKey(const char* pKey, int64_t defaultValue)
     }
 #endif
 
-	return JniHelper::callStaticLongMethod(helperClassName, "getLongForKey", pKey, defaultValue);
+	return JniHelper::callStaticLongMethod(helperClassName, "getLongForKey", pKey, static_cast<long>(defaultValue));
 }
 
 float UserDefault::getFloatForKey(const char* pKey)
@@ -457,13 +457,13 @@ void UserDefault::setIntegerForKey(const char* pKey, int value)
     JniHelper::callStaticVoidMethod(helperClassName, "setIntegerForKey", pKey, value);
 }
 
-void UserDefault::setLongForKey(const char* pKey, long value)
+void UserDefault::setLongForKey(const char* pKey, int64_t value)
 {
 #ifdef KEEP_COMPATABILITY
     deleteNodeByKey(pKey);
 #endif
 
-    JniHelper::callStaticVoidMethod(helperClassName, "setLongForKey", pKey, value);
+    JniHelper::callStaticVoidMethod(helperClassName, "setLongForKey", pKey, static_cast<long>(value));
 }
 
 void UserDefault::setFloatForKey(const char* pKey, float value)

--- a/cocos/base/CCUserDefault-android.cpp
+++ b/cocos/base/CCUserDefault-android.cpp
@@ -228,12 +228,12 @@ int UserDefault::getIntegerForKey(const char* pKey, int defaultValue)
 	return JniHelper::callStaticIntMethod(helperClassName, "getIntegerForKey", pKey, defaultValue);
 }
 
-long UserDefault::getLongForKey(const char* pKey)
+int64_t UserDefault::getLongForKey(const char* pKey)
 {
     return getLongForKey(pKey, 0);
 }
 
-long UserDefault::getLongForKey(const char* pKey, long defaultValue)
+int64_t UserDefault::getLongForKey(const char* pKey, int64_t defaultValue)
 {
 #ifdef KEEP_COMPATABILITY
     tinyxml2::XMLDocument* doc = nullptr;
@@ -242,7 +242,7 @@ long UserDefault::getLongForKey(const char* pKey, long defaultValue)
     {
         if (node->FirstChild())
         {
-            long ret = atol((const char*)node->FirstChild()->Value());
+            int64_t ret = atol((const char*)node->FirstChild()->Value());
 
             // set value in NSUserDefaults
             setLongForKey(pKey, ret);

--- a/cocos/base/CCUserDefault-apple.mm
+++ b/cocos/base/CCUserDefault-apple.mm
@@ -236,6 +236,50 @@ int UserDefault::getIntegerForKey(const char* pKey, int defaultValue)
     return ret;
 }
 
+long UserDefault::getLongForKey(const char* pKey)
+{
+    return getLongForKey(pKey, 0);
+}
+
+long UserDefault::getLongForKey(const char* pKey, long defaultValue)
+{
+#ifdef KEEP_COMPATABILITY
+    tinyxml2::XMLDocument* doc = nullptr;
+    tinyxml2::XMLElement* node = getXMLNodeForKey(pKey, &doc);
+    if (node)
+    {
+        if (node->FirstChild())
+        {
+            long ret = atol((const char*)node->FirstChild()->Value());
+
+            // set value in NSUserDefaults
+            setLongForKey(pKey, ret);
+            flush();
+
+            // delete xmle node
+            deleteNode(doc, node);
+
+            return ret;
+        }
+        else
+        {
+            // delete xmle node
+            deleteNode(doc, node);
+        }
+    }
+#endif
+
+    long ret = defaultValue;
+
+    NSNumber *value = [[NSUserDefaults standardUserDefaults] objectForKey:[NSString stringWithUTF8String:pKey]];
+    if (value)
+    {
+        ret = [value longValue];
+    }
+
+    return ret;
+}
+
 float UserDefault::getFloatForKey(const char* pKey)
 {
     return getFloatForKey(pKey, 0);
@@ -438,6 +482,15 @@ void UserDefault::setIntegerForKey(const char* pKey, int value)
 #endif
 
     [[NSUserDefaults standardUserDefaults] setObject:[NSNumber numberWithInt:value] forKey:[NSString stringWithUTF8String:pKey]];
+}
+
+void UserDefault::setLongForKey(const char* pKey, long value)
+{
+#ifdef KEEP_COMPATABILITY
+    deleteNodeByKey(pKey);
+#endif
+
+    [[NSUserDefaults standardUserDefaults] setObject:[NSNumber numberWithLong:value] forKey:[NSString stringWithUTF8String:pKey]];
 }
 
 void UserDefault::setFloatForKey(const char* pKey, float value)

--- a/cocos/base/CCUserDefault-apple.mm
+++ b/cocos/base/CCUserDefault-apple.mm
@@ -236,12 +236,12 @@ int UserDefault::getIntegerForKey(const char* pKey, int defaultValue)
     return ret;
 }
 
-long UserDefault::getLongForKey(const char* pKey)
+int64_t UserDefault::getLongForKey(const char* pKey)
 {
     return getLongForKey(pKey, 0);
 }
 
-long UserDefault::getLongForKey(const char* pKey, long defaultValue)
+int64_t UserDefault::getLongForKey(const char* pKey, int64_t defaultValue)
 {
 #ifdef KEEP_COMPATABILITY
     tinyxml2::XMLDocument* doc = nullptr;
@@ -250,7 +250,7 @@ long UserDefault::getLongForKey(const char* pKey, long defaultValue)
     {
         if (node->FirstChild())
         {
-            long ret = atol((const char*)node->FirstChild()->Value());
+            int64_t ret = atol((const char*)node->FirstChild()->Value());
 
             // set value in NSUserDefaults
             setLongForKey(pKey, ret);
@@ -269,7 +269,7 @@ long UserDefault::getLongForKey(const char* pKey, long defaultValue)
     }
 #endif
 
-    long ret = defaultValue;
+    int64_t ret = defaultValue;
 
     NSNumber *value = [[NSUserDefaults standardUserDefaults] objectForKey:[NSString stringWithUTF8String:pKey]];
     if (value)
@@ -484,7 +484,7 @@ void UserDefault::setIntegerForKey(const char* pKey, int value)
     [[NSUserDefaults standardUserDefaults] setObject:[NSNumber numberWithInt:value] forKey:[NSString stringWithUTF8String:pKey]];
 }
 
-void UserDefault::setLongForKey(const char* pKey, long value)
+void UserDefault::setLongForKey(const char* pKey, int64_t value)
 {
 #ifdef KEEP_COMPATABILITY
     deleteNodeByKey(pKey);

--- a/cocos/base/CCUserDefault.cpp
+++ b/cocos/base/CCUserDefault.cpp
@@ -239,7 +239,7 @@ int64_t UserDefault::getLongForKey(const char* pKey)
     return getLongForKey(pKey, 0);
 }
 
-int64_t UserDefault::getLongForKey(const char* pKey, long defaultValue)
+int64_t UserDefault::getLongForKey(const char* pKey, int64_t defaultValue)
 {
     const char* value = nullptr;
     tinyxml2::XMLElement* rootNode;

--- a/cocos/base/CCUserDefault.cpp
+++ b/cocos/base/CCUserDefault.cpp
@@ -234,6 +234,40 @@ int UserDefault::getIntegerForKey(const char* pKey, int defaultValue)
     return ret;
 }
 
+long UserDefault::getLongForKey(const char* pKey)
+{
+    return getLongForKey(pKey, 0);
+}
+
+long UserDefault::getLongForKey(const char* pKey, long defaultValue)
+{
+    const char* value = nullptr;
+    tinyxml2::XMLElement* rootNode;
+    tinyxml2::XMLDocument* doc;
+    tinyxml2::XMLElement* node;
+    node =  getXMLNodeForKey(pKey, &rootNode, &doc);
+    // find the node
+    if (node && node->FirstChild())
+    {
+        value = (const char*)(node->FirstChild()->Value());
+    }
+
+    long ret = defaultValue;
+
+    if (value)
+    {
+        ret = atol(value);
+    }
+
+    if(doc)
+    {
+        delete doc;
+    }
+
+
+    return ret;
+}
+
 float UserDefault::getFloatForKey(const char* pKey)
 {
     return getFloatForKey(pKey, 0.0f);
@@ -372,6 +406,22 @@ void UserDefault::setIntegerForKey(const char* pKey, int value)
     char tmp[50];
     memset(tmp, 0, 50);
     sprintf(tmp, "%d", value);
+
+    setValueForKey(pKey, tmp);
+}
+
+void UserDefault::setLongForKey(const char* pKey, long value)
+{
+    // check key
+    if (! pKey)
+    {
+        return;
+    }
+
+    // format the value
+    char tmp[50];
+    memset(tmp, 0, 50);
+    sprintf(tmp, "%ld", value);
 
     setValueForKey(pKey, tmp);
 }

--- a/cocos/base/CCUserDefault.cpp
+++ b/cocos/base/CCUserDefault.cpp
@@ -234,12 +234,12 @@ int UserDefault::getIntegerForKey(const char* pKey, int defaultValue)
     return ret;
 }
 
-long UserDefault::getLongForKey(const char* pKey)
+int64_t UserDefault::getLongForKey(const char* pKey)
 {
     return getLongForKey(pKey, 0);
 }
 
-long UserDefault::getLongForKey(const char* pKey, long defaultValue)
+int64_t UserDefault::getLongForKey(const char* pKey, long defaultValue)
 {
     const char* value = nullptr;
     tinyxml2::XMLElement* rootNode;
@@ -252,7 +252,7 @@ long UserDefault::getLongForKey(const char* pKey, long defaultValue)
         value = (const char*)(node->FirstChild()->Value());
     }
 
-    long ret = defaultValue;
+    int64_t ret = defaultValue;
 
     if (value)
     {
@@ -410,7 +410,7 @@ void UserDefault::setIntegerForKey(const char* pKey, int value)
     setValueForKey(pKey, tmp);
 }
 
-void UserDefault::setLongForKey(const char* pKey, long value)
+void UserDefault::setLongForKey(const char* pKey, int64_t value)
 {
     // check key
     if (! pKey)

--- a/cocos/base/CCUserDefault.h
+++ b/cocos/base/CCUserDefault.h
@@ -104,7 +104,7 @@ public:
      * @return Long (64bit integer) value of the key.
      * @js NA
      */
-    virtual int64_t getLongForKey(const char* key, long defaultValue);
+    virtual int64_t getLongForKey(const char* key, int64_t defaultValue);
     
     /**
      * Get float value by key, if the key doesn't exist, will return 0.0.

--- a/cocos/base/CCUserDefault.h
+++ b/cocos/base/CCUserDefault.h
@@ -89,6 +89,24 @@ public:
     virtual int getIntegerForKey(const char* key, int defaultValue);
     
     /**
+     * Get long value by key, if the key doesn't exist, will return 0.
+     * You can set the default value, or it is 0.
+     * @param key The key to get value.
+     * @return Long value of the key.
+     * @js NA
+     */
+    long     getLongForKey(const char* key);
+    
+    /**
+     * Get long value by key, if the key doesn't exist, will return passed default value.
+     * @param key The key to get value.
+     * @param defaultValue The default value to return if the key doesn't exist.
+     * @return Long value of the key.
+     * @js NA
+     */
+    virtual long getLongForKey(const char* key, long defaultValue);
+    
+    /**
      * Get float value by key, if the key doesn't exist, will return 0.0.
      * @param key The key to get value.
      * @return Float value of the key.
@@ -172,6 +190,13 @@ public:
      * @js NA
      */
     virtual void setIntegerForKey(const char* key, int value);
+    /**
+     * Set long value by key.
+     * @param key The key to set.
+     * @param value A long value to set to the key.
+     * @js NA
+     */
+    virtual void setLongForKey(const char* key, long value);
     /**
      * Set float value by key.
      * @param key The key to set.

--- a/cocos/base/CCUserDefault.h
+++ b/cocos/base/CCUserDefault.h
@@ -80,7 +80,7 @@ public:
     int     getIntegerForKey(const char* key);
     
     /**
-     * Get bool value by key, if the key doesn't exist, will return passed default value.
+     * Get integer value by key, if the key doesn't exist, will return passed default value.
      * @param key The key to get value.
      * @param defaultValue The default value to return if the key doesn't exist.
      * @return Integer value of the key.
@@ -89,22 +89,22 @@ public:
     virtual int getIntegerForKey(const char* key, int defaultValue);
     
     /**
-     * Get long value by key, if the key doesn't exist, will return 0.
+     * Get long (64bit integer) value by key, if the key doesn't exist, will return 0.
      * You can set the default value, or it is 0.
      * @param key The key to get value.
-     * @return Long value of the key.
+     * @return Long (64bit integer) value of the key.
      * @js NA
      */
-    long     getLongForKey(const char* key);
+    int64_t     getLongForKey(const char* key);
     
     /**
-     * Get long value by key, if the key doesn't exist, will return passed default value.
+     * Get long (64bit integer) value by key, if the key doesn't exist, will return passed default value.
      * @param key The key to get value.
      * @param defaultValue The default value to return if the key doesn't exist.
-     * @return Long value of the key.
+     * @return Long (64bit integer) value of the key.
      * @js NA
      */
-    virtual long getLongForKey(const char* key, long defaultValue);
+    virtual int64_t getLongForKey(const char* key, long defaultValue);
     
     /**
      * Get float value by key, if the key doesn't exist, will return 0.0.
@@ -191,12 +191,12 @@ public:
      */
     virtual void setIntegerForKey(const char* key, int value);
     /**
-     * Set long value by key.
+     * Set long (64bit integer) value by key.
      * @param key The key to set.
      * @param value A long value to set to the key.
      * @js NA
      */
-    virtual void setLongForKey(const char* key, long value);
+    virtual void setLongForKey(const char* key, int64_t value);
     /**
      * Set float value by key.
      * @param key The key to set.

--- a/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxHelper.java
+++ b/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxHelper.java
@@ -485,6 +485,34 @@ public class Cocos2dxHelper {
         return defaultValue;
     }
     
+    public static long getLongForKey(String key, long defaultValue) {
+        SharedPreferences settings = sActivity.getSharedPreferences(Cocos2dxHelper.PREFS_NAME, 0);
+        try {
+            return settings.getLong(key, defaultValue);
+        }
+        catch (Exception ex) {
+            ex.printStackTrace();
+
+            Map allValues = settings.getAll();
+            Object value = allValues.get(key);
+            if ( value instanceof String) {
+                return  Long.parseLong(value.toString());
+            }
+            else if (value instanceof Float)
+            {
+                return ((Float) value).longValue();
+            }
+            else if (value instanceof Boolean)
+            {
+                boolean booleanValue = ((Boolean) value).booleanValue();
+                if (booleanValue)
+                    return 1L;
+            }
+        }
+
+        return defaultValue;
+    }
+    
     public static float getFloatForKey(String key, float defaultValue) {
         SharedPreferences settings = sActivity.getSharedPreferences(Cocos2dxHelper.PREFS_NAME, 0);
         try {
@@ -541,6 +569,13 @@ public class Cocos2dxHelper {
         SharedPreferences settings = sActivity.getSharedPreferences(Cocos2dxHelper.PREFS_NAME, 0);
         SharedPreferences.Editor editor = settings.edit();
         editor.putInt(key, value);
+        editor.apply();
+    }
+    
+    public static void setLongForKey(String key, long value) {
+        SharedPreferences settings = sActivity.getSharedPreferences(Cocos2dxHelper.PREFS_NAME, 0);
+        SharedPreferences.Editor editor = settings.edit();
+        editor.putLong(key, value);
         editor.apply();
     }
     

--- a/cocos/platform/android/jni/JniHelper.h
+++ b/cocos/platform/android/jni/JniHelper.h
@@ -140,7 +140,7 @@ public:
     @return value from Java static long method if there are proper JniMethodInfo; otherwise 0.
     */
     template <typename... Ts>
-    static long callStaticLongMethod(const std::string& className, 
+    static int64_t callStaticLongMethod(const std::string& className, 
                                    const std::string& methodName, 
                                    Ts... xs) {
         jlong ret = 0;

--- a/cocos/platform/android/jni/JniHelper.h
+++ b/cocos/platform/android/jni/JniHelper.h
@@ -136,6 +136,28 @@ public:
     }
 
     /**
+    @brief Call of Java static long method
+    @return value from Java static long method if there are proper JniMethodInfo; otherwise 0.
+    */
+    template <typename... Ts>
+    static long callStaticLongMethod(const std::string& className, 
+                                   const std::string& methodName, 
+                                   Ts... xs) {
+        jlong ret = 0;
+        cocos2d::JniMethodInfo t;
+        std::string signature = "(" + std::string(getJNISignature(xs...)) + ")J";
+        if (cocos2d::JniHelper::getStaticMethodInfo(t, className.c_str(), methodName.c_str(), signature.c_str())) {
+            LocalRefMapType localRefs;
+            ret = t.env->CallStaticLongMethod(t.classID, t.methodID, convert(localRefs, t, xs)...);
+            t.env->DeleteLocalRef(t.classID);
+            deleteLocalRefs(t.env, localRefs);
+        } else {
+            reportError(className, methodName, signature);
+        }
+        return ret;
+    }
+
+    /**
     @brief Call of Java static float method
     @return value from Java static float method if there are proper JniMethodInfo; otherwise 0.
     */

--- a/tests/cpp-tests/Classes/UserDefaultTest/UserDefaultTest.cpp
+++ b/tests/cpp-tests/Classes/UserDefaultTest/UserDefaultTest.cpp
@@ -111,18 +111,21 @@ void UserDefaultTest::doTest()
 
     UserDefault::getInstance()->setStringForKey("string", "value1");
     UserDefault::getInstance()->setIntegerForKey("integer", 10);
+    UserDefault::getInstance()->setLongForKey("long", 200l);
     UserDefault::getInstance()->setFloatForKey("float", 2.3f);
     UserDefault::getInstance()->setDoubleForKey("double", 2.4);
     UserDefault::getInstance()->setBoolForKey("bool", true);
 
     // test saving of Data buffers
     setData<int>("int_data");
+    setData<long>("long_data");
     setData<float>("float_data");
     setData<double>("double_data");
 
     printValue();
 
     logData<int>("int_data");
+    logData<long>("long_data");
     logData<float>("float_data");
     logData<double>("double_data");
 
@@ -134,11 +137,13 @@ void UserDefaultTest::doTest()
 
     UserDefault::getInstance()->setStringForKey("string", "value2");
     UserDefault::getInstance()->setIntegerForKey("integer", 11);
+    UserDefault::getInstance()->setLongForKey("long", 200l);
     UserDefault::getInstance()->setFloatForKey("float", 2.5f);
     UserDefault::getInstance()->setDoubleForKey("double", 2.6);
     UserDefault::getInstance()->setBoolForKey("bool", false);
 
     setData2<int>("int_data");
+    setData2<long>("long_data");
     setData2<float>("float_data");
     setData2<double>("double_data");
 
@@ -148,6 +153,7 @@ void UserDefaultTest::doTest()
     printValue();
 
     logData<int>("int_data");
+    logData<long>("long_data");
     logData<float>("float_data");
     logData<double>("double_data");
 
@@ -155,6 +161,7 @@ void UserDefaultTest::doTest()
 
     UserDefault::getInstance()->deleteValueForKey("string");
     UserDefault::getInstance()->deleteValueForKey("integer");
+    UserDefault::getInstance()->deleteValueForKey("long");
     UserDefault::getInstance()->deleteValueForKey("float");
     UserDefault::getInstance()->deleteValueForKey("double");
     UserDefault::getInstance()->deleteValueForKey("bool");
@@ -177,6 +184,10 @@ void UserDefaultTest::printValue()
 
     int i = UserDefault::getInstance()->getIntegerForKey("integer");
     sprintf(strTemp, "integer is %d", i);
+    this->_label->setString(this->_label->getString() + "\n" + strTemp);
+
+    long l = UserDefault::getInstance()->getLongForKey("long");
+    sprintf(strTemp, "long is %ld", l);
     this->_label->setString(this->_label->getString() + "\n" + strTemp);
 
     float f = UserDefault::getInstance()->getFloatForKey("float");

--- a/tests/cpp-tests/Classes/UserDefaultTest/UserDefaultTest.cpp
+++ b/tests/cpp-tests/Classes/UserDefaultTest/UserDefaultTest.cpp
@@ -118,14 +118,14 @@ void UserDefaultTest::doTest()
 
     // test saving of Data buffers
     setData<int>("int_data");
-    setData<long>("long_data");
+    setData<uint64_t>("long_data");
     setData<float>("float_data");
     setData<double>("double_data");
 
     printValue();
 
     logData<int>("int_data");
-    logData<long>("long_data");
+    logData<uint64_t>("long_data");
     logData<float>("float_data");
     logData<double>("double_data");
 
@@ -143,7 +143,7 @@ void UserDefaultTest::doTest()
     UserDefault::getInstance()->setBoolForKey("bool", false);
 
     setData2<int>("int_data");
-    setData2<long>("long_data");
+    setData2<uint64_t>("long_data");
     setData2<float>("float_data");
     setData2<double>("double_data");
 
@@ -153,7 +153,7 @@ void UserDefaultTest::doTest()
     printValue();
 
     logData<int>("int_data");
-    logData<long>("long_data");
+    logData<uint64_t>("long_data");
     logData<float>("float_data");
     logData<double>("double_data");
 
@@ -186,7 +186,7 @@ void UserDefaultTest::printValue()
     sprintf(strTemp, "integer is %d", i);
     this->_label->setString(this->_label->getString() + "\n" + strTemp);
 
-    long l = UserDefault::getInstance()->getLongForKey("long");
+    uint64_t l = UserDefault::getInstance()->getLongForKey("long");
     sprintf(strTemp, "long is %ld", l);
     this->_label->setString(this->_label->getString() + "\n" + strTemp);
 


### PR DESCRIPTION
I needed to store Long values for my game, so I added the getter and setter methods for each supported platform. In fact, I should have done this earlier, since I made these changes when I was using version 3.17.