### PR TITLE
fix a wrong camera position setting

### DIFF
--- a/tests/cpp-tests/Classes/Camera3DTest/Camera3DTest.cpp
+++ b/tests/cpp-tests/Classes/Camera3DTest/Camera3DTest.cpp
@@ -247,7 +247,7 @@ void Camera3DTestDemo::SwitchViewCallback(Ref* sender, CameraType cameraType)
         _sprite3D->getWorldToNodeTransform().getForwardVector(&newFaceDir);
         newFaceDir.normalize();
         _camera->setPosition3D(Vec3(0,35,0) + _sprite3D->getPosition3D());
-        _camera->lookAt(_sprite3D->getPosition3D() + newFaceDir*50);
+        _camera->lookAt(_sprite3D->getPosition3D() - newFaceDir*50);
         
         _RotateRightlabel->setColor(Color3B::WHITE);
         _RotateLeftlabel->setColor(Color3B::WHITE);


### PR DESCRIPTION
the Camera3DTestDemo's firstperson view will set _camera->lookAt(_sprite3D->getPosition3D() + newFaceDir*50);but the vec3 newFaceDir is getWorldToNodeTransform,so it's Coordinate system is different with the _camera's Coordinate system.In fact,you should use_sprite3D->getPosition3D() - newFaceDir*50.you can put the _camera behind the sprite and you will see the vec is contrary with sprite's faced.