### PR TITLE
Fixed an issue where the shader would come off when run setTexture.

### DIFF
--- a/cocos/2d/CCSprite.cpp
+++ b/cocos/2d/CCSprite.cpp
@@ -417,8 +417,11 @@ void Sprite::setProgramState(backend::ProgramState *programState)
 
 void Sprite::setTexture(Texture2D *texture)
 {
-    auto isETC1 = texture && texture->getAlphaTextureName();
-    setProgramState((isETC1) ? backend::ProgramType::ETC1 : backend::ProgramType::POSITION_TEXTURE_COLOR);
+    if (_programState == nullptr) {
+        const auto isETC1 = texture && texture->getAlphaTextureName();
+        setProgramState((isETC1) ? backend::ProgramType::ETC1 : backend::ProgramType::POSITION_TEXTURE_COLOR);
+    }
+    
     CCASSERT(! _batchNode || (texture &&  texture == _batchNode->getTexture()), "CCSprite: Batched sprites should use the same texture as the batchnode");
     // accept texture==nil as argument
     CCASSERT( !texture || dynamic_cast<Texture2D*>(texture), "setTexture expects a Texture2D. Invalid argument");

--- a/cocos/2d/CCSprite.cpp
+++ b/cocos/2d/CCSprite.cpp
@@ -417,7 +417,7 @@ void Sprite::setProgramState(backend::ProgramState *programState)
 
 void Sprite::setTexture(Texture2D *texture)
 {
-    if (_programState == nullptr) {
+    if (_programState == nullptr || _programState->getProgram()->getProgramType() == backend::ProgramType::POSITION_TEXTURE_COLOR) {
         const auto isETC1 = texture && texture->getAlphaTextureName();
         setProgramState((isETC1) ? backend::ProgramType::ETC1 : backend::ProgramType::POSITION_TEXTURE_COLOR);
     }

--- a/cocos/2d/CCSprite.cpp
+++ b/cocos/2d/CCSprite.cpp
@@ -417,7 +417,8 @@ void Sprite::setProgramState(backend::ProgramState *programState)
 
 void Sprite::setTexture(Texture2D *texture)
 {
-    if (_programState == nullptr || _programState->getProgram()->getProgramType() == backend::ProgramType::POSITION_TEXTURE_COLOR) {
+    if (_programState == nullptr || _programState->getProgram()->getProgramType() == backend::ProgramType::POSITION_TEXTURE_COLOR ||
+        _programState->getProgram()->getProgramType() == backend::ProgramType::ETC1) {
         const auto isETC1 = texture && texture->getAlphaTextureName();
         setProgramState((isETC1) ? backend::ProgramType::ETC1 : backend::ProgramType::POSITION_TEXTURE_COLOR);
     }


### PR DESCRIPTION
### Summary
Fix issue https://github.com/cocos2d/cocos2d-x/issues/20600 , When I set a shader in `Sprite` and execute `setTexture`, the shader comes off.

### Event

1. After doing `setProgramState` as below ...
```cpp
sprite->setProgramState(programState);
```

2. Try calling `setTexture`.
```cpp
sprite->setTexture(filePath);
```

Then the shader will not run.

### Why I submitted a Pull Request.

Currently, it can be dealt with by calling `setProgramState` immediately after calling `setTexture` as shown below.
```cpp
sprite->setTexture(filePath);
sprite->setProgramState(mProgramState);
```
But developers need to explicitly keep `ProgramState`, and I think it's a redundant implementation.
So I submitted a Pull Request.