### PR TITLE
Create SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,15 @@
+## Report a security issue
+
+The Cocos2d project team welcomes security reports and is committed to providing prompt attention to security issues.
+Security issues should be reported privately via [email]
+
+| Version | Supported          |
+| ------- | ------------------ |
+| >= 4.0.x| :white_check_mark: |
+| < 4.0   | :x:                |
+
+## Security advisories
+
+Remediation of security vulnerabilities is prioritized by the project team based on the overall impact.
+The project team is committed to transparency in the disclosure process.
+The team announces security issues via Github Release notes, Cocos Release notes, as well as the Cocos website on a best-effort basis.


### PR DESCRIPTION
Hello team,
I'd like to suggest the creation of a private mailing list to handle reports of security issues. This way security issues can be reported privately for safety. 

There are several security issues I would like to report, but Github bug issue tracker is not the most appropriate place to post them.
Thanks,