### PR TITLE
Issue 19659 fix 3b

### DIFF
--- a/cocos/ui/UIRichText.cpp
+++ b/cocos/ui/UIRichText.cpp
@@ -1498,7 +1498,17 @@ void RichText::formatText()
 namespace {
     inline bool isUTF8CharWrappable(const StringUtils::StringUTF8::CharUTF8& ch)
     {
-        return (!ch.isASCII() || !std::isalnum(ch._char[0], std::locale()));
+        int len = strlen((char*) ch._char.c_str());
+        bool ret = ch._char.c_str()[0] == 32 || ch._char.c_str()[0] == 45 || len >= 3; // space or '-' or CJK Unified Ideographs (Chinese, Japanese, and Korean)
+
+        char* chars = (char*)ch._char.c_str();
+        CCLOG("*** ch:%s ch:%X  ch.isASCII():%d isalnum:%d len:%d ch[0-5]: %X %X %X %X %X %X    ret:%d ",
+                ch._char.c_str(), chars,
+                ch.isASCII(), std::isalnum(ch._char[0], std::locale()), len,
+                chars[0], chars[1], chars[2], chars[3], chars[4], chars[5],
+                ret);
+
+        return ret;
     }
 
     int getPrevWordPos(const StringUtils::StringUTF8& text, int idx)

--- a/cocos/ui/UIRichText.cpp
+++ b/cocos/ui/UIRichText.cpp
@@ -1499,16 +1499,7 @@ namespace {
     inline bool isUTF8CharWrappable(const StringUtils::StringUTF8::CharUTF8& ch)
     {
         int len = strlen((char*) ch._char.c_str());
-        bool ret = ch._char.c_str()[0] == 32 || ch._char.c_str()[0] == 45 || len >= 3; // space or '-' or CJK Unified Ideographs (Chinese, Japanese, and Korean)
-
-        char* chars = (char*)ch._char.c_str();
-        CCLOG("*** ch:%s ch:%X  ch.isASCII():%d isalnum:%d len:%d ch[0-5]: %X %X %X %X %X %X    ret:%d ",
-                ch._char.c_str(), chars,
-                ch.isASCII(), std::isalnum(ch._char[0], std::locale()), len,
-                chars[0], chars[1], chars[2], chars[3], chars[4], chars[5],
-                ret);
-
-        return ret;
+        return ch._char.c_str()[0] == 32 || ch._char.c_str()[0] == 45 || len >= 3; // space or '-' or CJK Unified Ideographs (Chinese, Japanese, and Korean)
     }
 
     int getPrevWordPos(const StringUtils::StringUTF8& text, int idx)

--- a/cocos/ui/UIRichText.h
+++ b/cocos/ui/UIRichText.h
@@ -350,6 +350,12 @@ public:
         WRAP_PER_WORD,
         WRAP_PER_CHAR
     };
+
+    enum WordSeparatorMode: int {
+        WordSeparatorBasedOnDevice,                /*!< The wrapping will be compute based on the device setting */
+        WordSeparatorSpaceSlashNotHighUnicode,     /*!< Spaces and '-' will be consider words separators.  Recommended for Korean */
+        WordSeparatorSpaceSlashAndKCJ              /*!< Spaces, '-' and KCJ unicodes will be consider words separators. */
+    };
     
     enum class HorizontalAlignment {
         LEFT,
@@ -372,6 +378,7 @@ public:
     
     static const std::string KEY_VERTICAL_SPACE;                    /*!< key of vertical space */
     static const std::string KEY_WRAP_MODE;                         /*!< key of per word, or per char */
+    static const std::string KEY_WORD_SEPARATOR_MODE;               /*!< key of word separator mode */
     static const std::string KEY_HORIZONTAL_ALIGNMENT;              /*!< key of left, right, or center */
     static const std::string KEY_FONT_COLOR_STRING;                 /*!< key of font color */
     static const std::string KEY_FONT_SIZE;                         /*!< key of font size */
@@ -486,6 +493,8 @@ public:
 
     void setWrapMode(WrapMode wrapMode);                /*!< sets the wrapping mode: WRAP_PER_CHAR or WRAP_PER_WORD */
     WrapMode getWrapMode() const;                       /*!< returns the current wrapping mode */
+    void setWordSeparatorMode(WordSeparatorMode wordSeparatorMode); /*!< sets the word separator mode */
+    WordSeparatorMode getWordSeparatorMode();                       /*!< returns the current word separator mode */
     void setHorizontalAlignment(HorizontalAlignment a); /*!< sets the horizontal alignment mode: LEFT, CENTER, or RIGHT */
     HorizontalAlignment getHorizontalAlignment() const; /*!< returns the current horizontal alignment mode */
     void setFontColor(const std::string& color);        /*!< Set the font color. @param color the #RRGGBB hexadecimal notation. */

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIRichTextTest/UIRichTextTest.cpp
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIRichTextTest/UIRichTextTest.cpp
@@ -55,28 +55,19 @@ UIRichTextTests::UIRichTextTests()
 //
 // UIRichTextTest
 //
+
+#define _RICH_TEXT_TAG (15)
+
 bool UIRichTextTest::init()
 {
     if (UIScene::init())
     {
         Size widgetSize = _widget->getContentSize();
+        float x = widgetSize.width * 1 / 4;
 
-        auto config = Configuration::getInstance();
-        config->loadConfigFile("configs/config-test-ok.plist");
-
-
-        std::string str1 = config->getValue("Chinese").asString();
-        std::string str2 = config->getValue("Japanese").asString();
-        CCLOG("str1:%s ascii length = %ld, utf8 length = %ld, substr = %s",
-            str1.c_str(),
-            static_cast<long>(str1.length()),
-            StringUtils::getCharacterCountInUTF8String(str1),
-            Helper::getSubStringOfUTF8String(str1, 0, 5).c_str());
-        CCLOG("str2:%s ascii length = %ld, utf8 length = %ld, substr = %s",
-            str2.c_str(),
-            static_cast<long>(str2.length()),
-            StringUtils::getCharacterCountInUTF8String(str2),
-            Helper::getSubStringOfUTF8String(str2, 0, 2).c_str());
+        _currentWrappingMode = RichText::WRAP_PER_WORD;
+        _currentAlignment = RichText::HorizontalAlignment::LEFT;
+        _currentLanguage = RichTextWrapLanguage_Original;
 
         // Add the alert
         Text *alert = Text::create("RichText", "fonts/Marker Felt.ttf", 30);
@@ -87,15 +78,17 @@ bool UIRichTextTest::init()
         Button* button = Button::create("cocosui/animationbuttonnormal.png", "cocosui/animationbuttonpressed.png");
         button->setTouchEnabled(true);
         button->setTitleText("switch");
-        button->setPosition(Vec2(widgetSize.width * 1 / 3, widgetSize.height / 2.0f + button->getContentSize().height * 2.5));
+        button->setPosition(Vec2(x, widgetSize.height / 2.0f + button->getContentSize().height * 2.5));
         button->addTouchEventListener(CC_CALLBACK_2(UIRichTextTest::touchEvent, this));
         button->setLocalZOrder(10);
         _widget->addChild(button);
 
+        float x_inc = button->getContentSize().width * 0.9;
+
         Button* button2 = Button::create("cocosui/animationbuttonnormal.png", "cocosui/animationbuttonpressed.png");
         button2->setTouchEnabled(true);
         button2->setTitleText("wrap mode");
-        button2->setPosition(Vec2(widgetSize.width / 2, widgetSize.height / 2.0f + button2->getContentSize().height * 2.5));
+        button2->setPosition(Vec2(x + x_inc, widgetSize.height / 2.0f + button2->getContentSize().height * 2.5));
         button2->addTouchEventListener(CC_CALLBACK_2(UIRichTextTest::switchWrapMode, this));
         button2->setLocalZOrder(10);
         _widget->addChild(button2);
@@ -103,52 +96,152 @@ bool UIRichTextTest::init()
         Button* button3 = Button::create("cocosui/animationbuttonnormal.png", "cocosui/animationbuttonpressed.png");
         button3->setTouchEnabled(true);
         button3->setTitleText("alignment");
-        button3->setPosition(Vec2(widgetSize.width * 2 / 3, widgetSize.height / 2.0f + button2->getContentSize().height * 2.5));
+        button3->setPosition(Vec2(x + x_inc * 2, widgetSize.height / 2.0f + button2->getContentSize().height * 2.5));
         button3->addTouchEventListener(CC_CALLBACK_2(UIRichTextTest::switchAlignment, this));
         button3->setLocalZOrder(10);
         _widget->addChild(button3);
 
-        // RichText
-        _richText = RichText::create();
-        _richText->ignoreContentAdaptWithSize(false);
-        _richText->setContentSize(Size(100, 100));
+        Button* button4 = Button::create("cocosui/animationbuttonnormal.png", "cocosui/animationbuttonpressed.png");
+        button4->setTouchEnabled(true);
+        button4->setTitleText("language");
+        button4->setPosition(Vec2(x+ x_inc * 3, widgetSize.height / 2.0f + button2->getContentSize().height * 2.5));
+        button4->addTouchEventListener(CC_CALLBACK_2(UIRichTextTest::switchLanguage, this));
+        button4->setLocalZOrder(10);
+        _widget->addChild(button4);
 
-        RichElementText* re1 = RichElementText::create(1, Color3B::WHITE, 255, str1, "SimSun", 10);
-        RichElementText* re2 = RichElementText::create(2, Color3B::YELLOW, 255, "And this is yellow. ", "Helvetica", 10);
-        RichElementText* re3 = RichElementText::create(3, Color3B::GRAY, 255, str2, "Yu Mincho", 10);
-        RichElementText* re4 = RichElementText::create(4, Color3B::GREEN, 255, "And green with TTF support. ", "fonts/Marker Felt.ttf", 10);
-        RichElementText* re5 = RichElementText::create(5, Color3B::RED, 255, "Last one is red ", "Helvetica", 10);
-
-        RichElementImage* reimg = RichElementImage::create(6, Color3B::WHITE, 255, "cocosui/sliderballnormal.png");
+        setLanguage(_currentLanguage);
 
 //        TODO
 //        cocostudio::ArmatureDataManager::getInstance()->addArmatureFileInfo("cocosui/100/100.ExportJson");
 //        cocostudio::Armature *pAr = cocostudio::Armature::create("100"); //
 //        pAr->getAnimation()->play("Animation1");
 
-//        RichElementCustomNode* recustom = RichElementCustomNode::create(1, Color3B::WHITE, 255, pAr);
-        RichElementText* re6 = RichElementText::create(7, Color3B::ORANGE, 255, "Have fun!! ", "Helvetica", 10);
-        _richText->pushBackElement(re1);
-        _richText->insertElement(re2, 1);
-        _richText->pushBackElement(re3);
-        _richText->pushBackElement(re4);
-        _richText->pushBackElement(re5);
-        _richText->insertElement(reimg, 2);
-//        _richText->pushBackElement(recustom);
-        _richText->pushBackElement(re6);
-
-        _richText->setPosition(Vec2(widgetSize.width / 2, widgetSize.height / 2));
-        _richText->setLocalZOrder(10);
-
-
-        _widget->addChild(_richText);
-
-        // test remove all children, this call won't effect the test
-        _richText->removeAllChildren();
-
         return true;
     }
     return false;
+}
+
+void UIRichTextTest::setLanguage(RichTextWrapLanguage language)
+{
+    Size widgetSize = _widget->getContentSize();
+
+    _widget->removeChildByTag(_RICH_TEXT_TAG);
+
+    switch(language) {
+        case RichTextWrapLanguage_Original: {
+            auto config = Configuration::getInstance();
+            config->loadConfigFile("configs/config-test-ok.plist");
+
+            std::string str1 = config->getValue("Chinese").asString();
+            std::string str2 = config->getValue("Japanese").asString();
+
+            CCLOG("str1:%s ascii length = %ld, utf8 length = %ld, substr = %s",
+                  str1.c_str(),
+                  static_cast<long>(str1.length()),
+                  StringUtils::getCharacterCountInUTF8String(str1),
+                  Helper::getSubStringOfUTF8String(str1, 0, 5).c_str());
+            CCLOG("str2:%s ascii length = %ld, utf8 length = %ld, substr = %s",
+                  str2.c_str(),
+                  static_cast<long>(str2.length()),
+                  StringUtils::getCharacterCountInUTF8String(str2),
+                  Helper::getSubStringOfUTF8String(str2, 0, 2).c_str());
+
+            // RichText
+            _richText = RichText::create();
+            _richText->setTag(_RICH_TEXT_TAG);
+            _richText->setWrapMode(_currentWrappingMode);
+            _richText->setHorizontalAlignment(_currentAlignment);
+            _richText->ignoreContentAdaptWithSize(false);
+            _richText->setContentSize(Size(100, 100));
+
+            RichElementText *re1 = RichElementText::create(1, Color3B::WHITE, 255, str1, "SimSun",
+                                                           10);
+            RichElementText *re2 = RichElementText::create(2, Color3B::YELLOW, 255,
+                                                           "And this is yellow. ", "Helvetica", 10);
+            RichElementText *re3 = RichElementText::create(3, Color3B::GRAY, 255, str2, "Yu Mincho",
+                                                           10);
+            RichElementText *re4 = RichElementText::create(4, Color3B::GREEN, 255,
+                                                           "And green with TTF support. ",
+                                                           "fonts/Marker Felt.ttf", 10);
+            RichElementText *re5 = RichElementText::create(5, Color3B::RED, 255, "Last one is red ",
+                                                           "Helvetica", 10);
+
+            RichElementImage *reimg = RichElementImage::create(6, Color3B::WHITE, 255,
+                                                               "cocosui/sliderballnormal.png");
+
+            //        RichElementCustomNode* recustom = RichElementCustomNode::create(1, Color3B::WHITE, 255, pAr);
+            RichElementText *re6 = RichElementText::create(7, Color3B::ORANGE, 255, "Have fun!! ",
+                                                           "Helvetica", 10);
+            _richText->pushBackElement(re1);
+            _richText->insertElement(re2, 1);
+            _richText->pushBackElement(re3);
+            _richText->pushBackElement(re4);
+            _richText->pushBackElement(re5);
+            _richText->insertElement(reimg, 2);
+//        _richText->pushBackElement(recustom);
+            _richText->pushBackElement(re6);
+
+            _richText->setPosition(Vec2(widgetSize.width / 2, widgetSize.height / 2));
+            _richText->setLocalZOrder(10);
+
+            _widget->addChild(_richText);
+
+            // test remove all children, this call won't effect the test
+            _richText->removeAllChildren();
+        }
+            break;
+
+        case RichTextWrapLanguage_Spanish:
+            addSingleRichTextWithText("Pingüino Pingüino Pingüino canción canción canción canción tamaño tamaño tamaño.");
+            break;
+
+        case RichTextWrapLanguage_Romanian:
+            addSingleRichTextWithText("Cântecul Cântecul Cântecul Cântecul Cântecul politică politică politică politică.");
+            break;
+
+        case RichTextWrapLanguage_Russian:
+            addSingleRichTextWithText("Франция с завтрашнего дня закроет свои границы со странами, не входящими в Евросоюз: она пытается избежать нового ограничения");
+            break;
+
+        case RichTextWrapLanguage_English:
+            addSingleRichTextWithText("Testing word-wrapping. Testing word-wrapping. Testing word-wrapping. Testing word-wrapping.");
+            break;
+
+        case RichTextWrapLanguage_French:
+            addSingleRichTextWithText("espère espère espère l'appel l'appel l'opposant Alexeï Alexeï enquête Royaume-Uni Royaume-Uni");
+            break;
+
+        case RichTextWrapLanguage_Korean:
+            addSingleRichTextWithText("차가운 대리석으로 둘러싸인 담으로 둘러싸인 정원에서 승인 된 라임 나무 줄, 난 자랍니다");
+            break;
+
+        case RichTextWrapLanguage_Chinese:
+            addSingleRichTextWithText("在圍牆花園裡四周是冷大理石和成行的樹我成長");
+            break;
+    }
+}
+
+void UIRichTextTest::addSingleRichTextWithText(const std::string& text)
+{
+    Size widgetSize = _widget->getContentSize();
+
+    _richText = RichText::create();
+    _richText->setTag(_RICH_TEXT_TAG);
+    _richText->setWrapMode(_currentWrappingMode);
+    _richText->setHorizontalAlignment(_currentAlignment);
+    _richText->ignoreContentAdaptWithSize(false);
+    _richText->setContentSize(Size(100, 100));
+
+    RichElementText *re = RichElementText::create(5, Color3B::YELLOW, 255,
+                                                  text,
+                                                  "Helvetica", 10);
+    _richText->pushBackElement(re);
+
+    _richText->setPosition(Vec2(widgetSize.width / 2, widgetSize.height / 2));
+    _richText->setLocalZOrder(10);
+
+    _widget->addChild(_richText);
+    _richText->removeAllChildren();
 }
 
 void UIRichTextTest::touchEvent(Ref *pSender, Widget::TouchEventType type)
@@ -178,20 +271,27 @@ void UIRichTextTest::switchWrapMode(Ref *pSender, Widget::TouchEventType type)
 {
     if (type == Widget::TouchEventType::ENDED)
     {
-        auto wrapMode = _richText->getWrapMode();
-        wrapMode = (wrapMode == RichText::WRAP_PER_WORD) ? RichText::WRAP_PER_CHAR : RichText::WRAP_PER_WORD;
-        _richText->setWrapMode(wrapMode);
+        _currentWrappingMode = (_currentWrappingMode == RichText::WRAP_PER_WORD) ? RichText::WRAP_PER_CHAR : RichText::WRAP_PER_WORD;
+        _richText->setWrapMode(_currentWrappingMode);
     }
 }
 
 void UIRichTextTest::switchAlignment(Ref *sender, Widget::TouchEventType type) {
     if (type == Widget::TouchEventType::ENDED)
     {
-        auto alignment = _richText->getHorizontalAlignment();
-        alignment = static_cast<RichText::HorizontalAlignment>((static_cast<std::underlying_type<RichText::HorizontalAlignment>::type>(alignment) + 1) % 3);
-        _richText->setHorizontalAlignment(alignment);
+        _currentAlignment = static_cast<RichText::HorizontalAlignment>((static_cast<std::underlying_type<RichText::HorizontalAlignment>::type>(_currentAlignment) + 1) % 3);
+        _richText->setHorizontalAlignment(_currentAlignment);
     }
 }
+
+void UIRichTextTest::switchLanguage(Ref *sender, Widget::TouchEventType type) {
+    if (type == Widget::TouchEventType::ENDED)
+    {
+        _currentLanguage = static_cast<RichTextWrapLanguage>((_currentLanguage + 1) % RichTextWrapLanguage_Max);
+        setLanguage(_currentLanguage);
+    }
+}
+
 
 //
 // UIRichTextXMLBasic

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIRichTextTest/UIRichTextTest.cpp
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIRichTextTest/UIRichTextTest.cpp
@@ -128,6 +128,7 @@ void UIRichTextTest::setLanguage(RichTextWrapLanguage language)
     _widget->removeChildByTag(_RICH_TEXT_TAG);
 
     switch(language) {
+        default:
         case RichTextWrapLanguage_Original: {
             auto config = Configuration::getInstance();
             config->loadConfigFile("configs/config-test-ok.plist");
@@ -192,42 +193,50 @@ void UIRichTextTest::setLanguage(RichTextWrapLanguage language)
             break;
 
         case RichTextWrapLanguage_Spanish:
-            addSingleRichTextWithText("Pingüino Pingüino Pingüino canción canción canción canción tamaño tamaño tamaño.");
+            addSingleRichTextWithText("Pingüino Pingüino Pingüino canción canción canción canción tamaño tamaño tamaño.",
+                                      RichText::WordSeparatorSpaceSlashAndKCJ);
             break;
 
         case RichTextWrapLanguage_Romanian:
-            addSingleRichTextWithText("Cântecul Cântecul Cântecul Cântecul Cântecul politică politică politică politică.");
+            addSingleRichTextWithText("Cântecul Cântecul Cântecul Cântecul Cântecul politică politică politică politică.",
+                                      RichText::WordSeparatorSpaceSlashAndKCJ);
             break;
 
         case RichTextWrapLanguage_Russian:
-            addSingleRichTextWithText("Франция с завтрашнего дня закроет свои границы со странами, не входящими в Евросоюз: она пытается избежать нового ограничения");
+            addSingleRichTextWithText("Франция с завтрашнего дня закроет свои границы со странами, не входящими в Евросоюз: она пытается избежать нового ограничения",
+                                      RichText::WordSeparatorSpaceSlashAndKCJ);
             break;
 
         case RichTextWrapLanguage_English:
-            addSingleRichTextWithText("Testing word-wrapping. Testing word-wrapping. Testing word-wrapping. Testing word-wrapping.");
+            addSingleRichTextWithText("Testing word-wrapping. Testing word-wrapping. Testing word-wrapping. Testing word-wrapping.",
+                                      RichText::WordSeparatorSpaceSlashAndKCJ);
             break;
 
         case RichTextWrapLanguage_French:
-            addSingleRichTextWithText("espère espère espère l'appel l'appel l'opposant Alexeï Alexeï enquête Royaume-Uni Royaume-Uni");
+            addSingleRichTextWithText("espère espère espère l'appel l'appel l'opposant Alexeï Alexeï enquête Royaume-Uni Royaume-Uni",
+                                      RichText::WordSeparatorSpaceSlashAndKCJ);
             break;
 
         case RichTextWrapLanguage_Korean:
-            addSingleRichTextWithText("차가운 대리석으로 둘러싸인 담으로 둘러싸인 정원에서 승인 된 라임 나무 줄, 난 자랍니다");
+            addSingleRichTextWithText("차가운 대리석으로 대리석으로 대리석으로 둘러싸인 둘러싸인 담으로 둘러싸인 정원에서 승인 된 라임 나무 줄, 난 자랍니다",
+                                      RichText::WordSeparatorSpaceSlashNotHighUnicode);
             break;
 
         case RichTextWrapLanguage_Chinese:
-            addSingleRichTextWithText("在圍牆花園裡四周是冷大理石和成行的樹我成長");
+            addSingleRichTextWithText("在圍牆花園裡四周是冷大理石和成行的樹我成長",
+                                      RichText::WordSeparatorSpaceSlashAndKCJ);
             break;
     }
 }
 
-void UIRichTextTest::addSingleRichTextWithText(const std::string& text)
+void UIRichTextTest::addSingleRichTextWithText(const std::string& text, const RichText::WordSeparatorMode& wordSeparatorMode)
 {
     Size widgetSize = _widget->getContentSize();
 
     _richText = RichText::create();
     _richText->setTag(_RICH_TEXT_TAG);
     _richText->setWrapMode(_currentWrappingMode);
+    _richText->setWordSeparatorMode(wordSeparatorMode);
     _richText->setHorizontalAlignment(_currentAlignment);
     _richText->ignoreContentAdaptWithSize(false);
     _richText->setContentSize(Size(100, 100));

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIRichTextTest/UIRichTextTest.h
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIRichTextTest/UIRichTextTest.h
@@ -30,6 +30,20 @@
 #include "../UIScene.h"
 
 DEFINE_TEST_SUITE(UIRichTextTests);
+using namespace cocos2d::ui;
+
+enum RichTextWrapLanguage: int {
+    RichTextWrapLanguage_Original = 0,
+    RichTextWrapLanguage_Spanish,
+    RichTextWrapLanguage_Romanian,
+    RichTextWrapLanguage_Russian,
+    RichTextWrapLanguage_English,
+    RichTextWrapLanguage_French,
+    RichTextWrapLanguage_Korean,
+    RichTextWrapLanguage_Chinese,
+
+    RichTextWrapLanguage_Max
+};
 
 class UIRichTextTest : public UIScene
 {
@@ -37,12 +51,19 @@ public:
     CREATE_FUNC(UIRichTextTest);
 
     bool init() override;
+    void setLanguage(RichTextWrapLanguage language);
+    void addSingleRichTextWithText(const std::string& text);
     void touchEvent(cocos2d::Ref* sender, cocos2d::ui::Widget::TouchEventType type);
     void switchWrapMode(cocos2d::Ref* sender, cocos2d::ui::Widget::TouchEventType type);
     void switchAlignment(cocos2d::Ref* sender, cocos2d::ui::Widget::TouchEventType type);
+    void switchLanguage(cocos2d::Ref* sender, cocos2d::ui::Widget::TouchEventType type);
 
 protected:
     cocos2d::ui::RichText* _richText;
+    RichTextWrapLanguage _currentLanguage;
+    RichText::WrapMode _currentWrappingMode;
+    RichText::HorizontalAlignment _currentAlignment;
+
 };
 
 class UIRichTextXMLBasic : public UIScene

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIRichTextTest/UIRichTextTest.h
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIRichTextTest/UIRichTextTest.h
@@ -52,7 +52,7 @@ public:
 
     bool init() override;
     void setLanguage(RichTextWrapLanguage language);
-    void addSingleRichTextWithText(const std::string& text);
+    void addSingleRichTextWithText(const std::string& text, const RichText::WordSeparatorMode& wordSeparatorMode);
     void touchEvent(cocos2d::Ref* sender, cocos2d::ui::Widget::TouchEventType type);
     void switchWrapMode(cocos2d::Ref* sender, cocos2d::ui::Widget::TouchEventType type);
     void switchAlignment(cocos2d::Ref* sender, cocos2d::ui::Widget::TouchEventType type);

--- a/tests/cpp-tests/proj.android/build.gradle
+++ b/tests/cpp-tests/proj.android/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.0'
+        classpath 'com.android.tools.build:gradle:4.1.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/tests/cpp-tests/proj.android/build.gradle
+++ b/tests/cpp-tests/proj.android/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.1'
+        classpath 'com.android.tools.build:gradle:3.1.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
The current implementation based the decision of which char is a word separator on the location of the device but some games let the user decide the language from a settings, so it is good to let them the choice.

I added these option for the developer to choose from:
        
`WordSeparatorBasedOnDevice:  ` current implementation
`WordSeparatorSpaceSlashNotHighUnicode:`  Spaces and '-' will be consider words separators.  Recommended for Korean 
`WordSeparatorSpaceSlashAndKCJ:` Spaces, '-' and KCJ unicodes will be consider words separators.  Recommended for Spanish 

You can see the test on:
Node:UI > GUI Dynamic Create Test > RichTest Test > language

The function findSplitPositionForWord receives the parameter wordSeparatorMode and chooses the inline function (`charWrappableFunctionPointer`) to be use in `getNextWordPos` and then in `std::find_if` to look for a good spot to but the sentence.

**To make the decision I use these facts:**
- space (32) as word separator for Spanish, English, Russian, etc.
- char '-' (45) is also a separator for English
- CJK unicodes has a len of 3 or more. (named as HighUnicode)
- Chinese has CJK but no separator
- Korean has CJK but space is a separator

