### PR TITLE
Fixed bug size does not change when the screen is rotated in v4

### DIFF
--- a/cocos/platform/ios/CCEAGLView-ios.mm
+++ b/cocos/platform/ios/CCEAGLView-ios.mm
@@ -70,6 +70,7 @@ Copyright (C) 2008 Apple Inc. All Rights Reserved.
 #import "base/CCIMEDispatcher.h"
 #import "renderer/backend/metal/DeviceMTL.h"
 #import "platform/ios/CCInputView-ios.h"
+#include "renderer/backend/metal/Utils.h"
 
 //CLASS IMPLEMENTATIONS:
 
@@ -194,6 +195,8 @@ Copyright (C) 2008 Apple Inc. All Rights Reserved.
     size_ = [self bounds].size;
     size_.width *= self.contentScaleFactor;
     size_.height *= self.contentScaleFactor;
+
+    cocos2d::backend::Utils::resizeDefaultAttachmentTexture(size_.width, size_.height);
 
     // Avoid flicker. Issue #350
     if ([NSThread isMainThread])


### PR DESCRIPTION
## in forum discuss

https://discuss.cocos2d-x.org/t/in-cocos2dx-v4-0-the-screen-becomes-half-size-when-you-change-the-device-from-portrait-to-landscape/51631

## background

* After updating cocos2dx from v3 to v4, there was a bug that the screen was not drawn properly when the screen orientation of the device was changed
  * As I posted in the forum, I solved the problem by regenerating the CCEAGLView, but there was a problem with the drawing, so I had to do a root solution

## Cause of the problem

It turns out that the cause of the problem is that the layer of CCEAGLView is CAMetalLayer, and CAMetalLayer.drawableSize is not updated when CCEAGLView.layoutSubView is used.

## Revision details

Fixed to resize CAMetalLayer on CCEAGLView layoutSubviews.

## related issues

* #20618