### PR TITLE
fix: visual jump diring vertical scroll when inner container size is …

### DIFF
--- a/cocos/ui/UIScrollView.cpp
+++ b/cocos/ui/UIScrollView.cpp
@@ -199,6 +199,12 @@ void ScrollView::setInnerContainerSize(const Size &size)
     {
         innerSizeHeight = size.height;
     }
+
+    if (_autoScrolling)
+    {
+        _autoScrollStartPosition.y -= innerSizeHeight - _innerContainer->getContentSize().height;
+    }
+    
     _innerContainer->setContentSize(Size(innerSizeWidth, innerSizeHeight));
 
     // Calculate and set the position of the inner container.


### PR DESCRIPTION
If size (more specifically -- height) of inner container in `ScrollView` was changed (from `X` to `Y`) during autoscroll then content of container visually "jumps up" (by (`Y - X`)).

It happens because implementation of  `ScrollView::processAutoScrolling` set `newPosition` based on `_autoScrollStartPosition` which is set in `ScrollView::startAutoScroll` and which is not changing when size is updated.

I fixed this issue by adding compensation to `_autoScrollStartPosition` in `ScrollView::setInnerContainerSize` function.

