### PR TITLE
Sprite::setScaleY: fix a potential crash on iOS

### DIFF
--- a/cocos/2d/CCSprite.cpp
+++ b/cocos/2d/CCSprite.cpp
@@ -1347,7 +1347,7 @@ void Sprite::setScaleX(float scaleX)
 void Sprite::setScaleY(float scaleY)
 {
 #ifdef CC_USE_METAL
-    if(_texture->isRenderTarget())
+    if (_texture && _texture->isRenderTarget())
        scaleY = std::abs(scaleY);
 #endif
     Node::setScaleY(scaleY);


### PR DESCRIPTION
The crash occurs if the sprite has no texture assigned. Need to add a null check for a bit of Metal specific code.