### PR TITLE
Fixing Mac m1 zlib issue

### DIFF
--- a/cmake/Modules/CocosConfigDepend.cmake
+++ b/cmake/Modules/CocosConfigDepend.cmake
@@ -48,6 +48,8 @@ macro(cocos2dx_depend)
             find_library(IOKIT_LIBRARY IOKit)
             find_library(APPKIT_LIBRARY AppKit)
             find_library(ICONV_LIBRARY iconv)
+            find_library(ZLIB z)
+            find_library(ICONVLIB iconv)
             list(APPEND PLATFORM_SPECIFIC_LIBS
                  ${COCOA_LIBRARY}
                  ${OPENGL_LIBRARY}


### PR DESCRIPTION
cocos run -p mac :
  "_uncompress", referenced from:
      cocos2d::ZipUtils::inflateCCZBuffer(unsigned char const*, long, unsigned char**) in libcocos2d.a(ZipUtils.o)
ld: symbol(s) not found for architecture arm64
clang: error: linker command failed with exit code 1 (use -v to see invocation)