### PR TITLE
Update CCPlatformConfig.h

### DIFF
--- a/cocos/platform/CCPlatformConfig.h
+++ b/cocos/platform/CCPlatformConfig.h
@@ -58,7 +58,7 @@ THE SOFTWARE.
 #define CC_TARGET_PLATFORM             CC_PLATFORM_UNKNOWN
 
 // Apple: Mac and iOS
-#if defined(__APPLE__) && !defined(ANDROID) // exclude android for binding generator.
+#if defined(__APPLE__) && !defined(__ANDROID__) // exclude android for binding generator.
     #include <TargetConditionals.h>
     #if TARGET_OS_IPHONE // TARGET_OS_IPHONE includes TARGET_OS_IOS TARGET_OS_TV and TARGET_OS_WATCH. see TargetConditionals.h
         #undef  CC_TARGET_PLATFORM
@@ -70,7 +70,7 @@ THE SOFTWARE.
 #endif
 
 // android
-#if defined(ANDROID)
+#if defined(__ANDROID__)
     #undef  CC_TARGET_PLATFORM
     #define CC_TARGET_PLATFORM         CC_PLATFORM_ANDROID
 #endif


### PR DESCRIPTION
With latest ndk23 there is no more ```ANDROID``` define. 
The correct way (before and now) is to use ```__ANDROID__```
https://iq.opengenus.org/detect-operating-system-in-c/