### PR TITLE
Fix issue #20608 - Fix compile error on MacOSX big sur

### DIFF
--- a/cmake/Modules/CocosConfigDepend.cmake
+++ b/cmake/Modules/CocosConfigDepend.cmake
@@ -24,7 +24,7 @@ macro(cocos2dx_depend)
     elseif(APPLE)
 
         include_directories(/System/Library/Frameworks)
-        find_library(ICONV_LIBRARY iconv)
+        find_library(SYS_ICONV_LIBRARY iconv)
         find_library(AUDIOTOOLBOX_LIBRARY AudioToolbox)
         find_library(FOUNDATION_LIBRARY Foundation)
         find_library(OPENAL_LIBRARY OpenAL)
@@ -35,7 +35,7 @@ macro(cocos2dx_depend)
             ${AUDIOTOOLBOX_LIBRARY}
             ${QUARTZCORE_LIBRARY}
             ${FOUNDATION_LIBRARY}
-            ${ICONV_LIBRARY}
+            ${SYS_ICONV_LIBRARY}
             ${GAMECONTROLLER_LIBRARY}
             )
 


### PR DESCRIPTION
Fixed: https://github.com/cocos2d/cocos2d-x/issues/20608
Maybe related: https://github.com/cocos2d/cocos2d-x/issues/20435

## environment

OS: MacOSX 11.3 big sur
Xcode: 13.1
cmake: 3.21.2

## description

Compile errors occurred when Xcode project is generated from cmake  on MacOSX big sur.

`clang: error: no such file or directory: '/usr/lib/libiconv.dylib'`

Bacause iconv path is resolved by find_library in CocosConfigDepend.cmake as below.

`find_library(ICONV_LIBRARY iconv)`

But ICONV_LIBRARY always be set `/usr/lib/libconv.dylib` ignoring sys_root.  /usr/lib seems to be no longer available and it is located at `/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.0.sdk/usr/lib/libiconv.tbd` on big sur.

I guess ICONV_LIBRARY is already defined by cmake system so find_library do nothing.
https://cmake.org/cmake/help/latest/module/FindIconv.html

## solution

I used other name so that avoid conflicting name.

