### PR TITLE
Reset stencil mask prior to clear for LM-V600 GL Driver.

### DIFF
--- a/cocos/renderer/backend/opengl/CommandBufferGL.cpp
+++ b/cocos/renderer/backend/opengl/CommandBufferGL.cpp
@@ -275,6 +275,7 @@ void CommandBufferGL::applyRenderPassDescriptor(const RenderPassDescriptor& desc
     if (descirptor.needClearStencil)
     {
         mask |= GL_STENCIL_BUFFER_BIT;
+        glStencilMask(0xff);
         glClearStencil(descirptor.clearStencilValue);
     }
 


### PR DESCRIPTION
This fixes a crash on LG ThinQ V60 (LM-V600). From libEGL.so eglSwapBuffers() the libGLESv2_adreno.so causes a segmentation violation (invalid memory reference) without first performing the recommended step of setting the stencil mask back to 0xff.