### PR TITLE
bugfix: memory leak

### DIFF
--- a/cocos/renderer/backend/opengl/CommandBufferGL.cpp
+++ b/cocos/renderer/backend/opengl/CommandBufferGL.cpp
@@ -330,7 +330,7 @@ void CommandBufferGL::setWinding(Winding winding)
 void CommandBufferGL::setIndexBuffer(Buffer* buffer)
 {
     assert(buffer != nullptr);
-    if (buffer == nullptr)
+    if (buffer == nullptr || _indexBuffer == buffer)
         return;
     
     buffer->retain();
@@ -345,6 +345,7 @@ void CommandBufferGL::setVertexBuffer(Buffer* buffer)
         return;
     
     buffer->retain();
+    CC_SAFE_RELEASE(_vertexBuffer);
     _vertexBuffer = static_cast<BufferGL*>(buffer);
 }
 


### PR DESCRIPTION
i think *CommandBufferGL::setVertexBuffer*  and *CommandBufferGL::setIndexBuffer* should do same things.

1. check weather new value is different from old value.
2. release old value, retain new value.

there's memory leak in *CommandBufferGL::setVertexBuffer* if not release old value