### PR TITLE
fix position errors

### DIFF
--- a/cocos/2d/CCSprite.cpp
+++ b/cocos/2d/CCSprite.cpp
@@ -261,7 +261,10 @@ bool Sprite::initWithTexture(Texture2D *texture, const Rect& rect, bool rotated)
         setDirty(false);
 
         _flippedX = _flippedY = false;
-
+        
+        //need reset if _texture is changed
+        _unflippedOffsetPositionFromCenter = Vec2::ZERO;
+        
         // default transform anchor: center
         setAnchorPoint(Vec2::ANCHOR_MIDDLE);
 


### PR DESCRIPTION
1. I used initWithSpriteFrame and spriteFrame->getOffset() is not zero, so _unflippedOffsetPositionFromCenter  is not zero.
2.  used initWithFile ，the position will be wrong,because _unflippedOffsetPositionFromCenter  is not reset.