### PR TITLE
Fix memory leak on Texture2DGL::getBytes()

### DIFF
--- a/cocos/renderer/backend/opengl/TextureGL.cpp
+++ b/cocos/renderer/backend/opengl/TextureGL.cpp
@@ -327,8 +327,8 @@ void Texture2DGL::getBytes(std::size_t x, std::size_t y, std::size_t width, std:
     } else
     {
         callback(image, width, height);
-        CC_SAFE_DELETE_ARRAY(image);
     }
+    CC_SAFE_DELETE_ARRAY(image);
 
     glBindFramebuffer(GL_FRAMEBUFFER, defaultFBO);
     glDeleteFramebuffers(1, &frameBuffer);


### PR DESCRIPTION
When using Texture2DGL::getBytes() on flipped images, only memory for flipped image is being released and original image memory is not.
This pull fix this issue freeing original image in all cases.