### PR TITLE
Add further options for slimmer builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,13 +53,17 @@ add_subdirectory(${COCOS2DX_ROOT_PATH}/cocos ${ENGINE_BINARY_PATH}/cocos/core)
 set(BUILD_ENGINE_DONE ON)
 
 # add cpp tests default
-add_subdirectory(${COCOS2DX_ROOT_PATH}/tests/cpp-empty-test ${ENGINE_BINARY_PATH}/tests/cpp-empty-test)
-add_subdirectory(${COCOS2DX_ROOT_PATH}/tests/cpp-tests ${ENGINE_BINARY_PATH}/tests/cpp-tests)
+if(BUILD_CPP_TESTS)
+  add_subdirectory(${COCOS2DX_ROOT_PATH}/tests/cpp-empty-test ${ENGINE_BINARY_PATH}/tests/cpp-empty-test)
+  add_subdirectory(${COCOS2DX_ROOT_PATH}/tests/cpp-tests ${ENGINE_BINARY_PATH}/tests/cpp-tests)
+endif()
 
 if(BUILD_LUA_LIBS)
   add_subdirectory(${COCOS2DX_ROOT_PATH}/tests/lua-empty-test/project ${ENGINE_BINARY_PATH}/tests/lua-empty-test)
   add_subdirectory(${COCOS2DX_ROOT_PATH}/tests/lua-tests/project ${ENGINE_BINARY_PATH}/tests/lua-test)
-endif(BUILD_LUA_LIBS)
+endif()
 
-# add cpp-template-default into project(Cocos2d-x) for tmp test
-add_subdirectory(${COCOS2DX_ROOT_PATH}/templates/cpp-template-default ${ENGINE_BINARY_PATH}/tests/HelloCpp)
+if(BUILD_CPP_TEMPLATE)
+  # add cpp-template-default into project(Cocos2d-x) for tmp test
+  add_subdirectory(${COCOS2DX_ROOT_PATH}/templates/cpp-template-default ${ENGINE_BINARY_PATH}/tests/HelloCpp)
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,8 +47,6 @@ include(PreventInSourceBuilds)
 # works before build libcocos2d
 include(CocosBuildSet)
 
-set(BUILD_LUA_LIBS ON) 
-
 add_subdirectory(${COCOS2DX_ROOT_PATH}/cocos ${ENGINE_BINARY_PATH}/cocos/core)
 
 # prevent tests project to build "cocos2d-x/cocos" again

--- a/cocos/CMakeLists.txt
+++ b/cocos/CMakeLists.txt
@@ -150,7 +150,7 @@ endif()
 
 if(${CMAKE_VERSION} VERSION_GREATER "3.16.0")
     message("CMake 3.16 target_precompile_headers")
-    target_precompile_headers(cocos2d PRIVATE
+    target_precompile_headers(cocos2d PRIVATE 
        "$<$<COMPILE_LANGUAGE:CXX>:cocos2d.h>")
 endif()
 
@@ -159,17 +159,3 @@ endif()
 #    # TODO: Only turn this off if ${CMAKE_XCODE_ATTRIBUTE_IPHONEOS_DEPLOYMENT_TARGET} < 11.0
 #    target_compile_options(cocos2d PUBLIC $<$<COMPILE_LANGUAGE:CXX>:-fno-aligned-allocation>)
 #endif()
-
-export(TARGETS cocos2d
-    external
-    ext_recast
-    ext_tinyxml2
-    ext_xxhash
-    ext_xxtea
-    ext_clipper
-    ext_edtaa3func
-    ext_convertUTF
-    ext_poly2tri
-    ext_md5
-    ext_unzip
-    FILE cocos2d-export.cmake)

--- a/cocos/CMakeLists.txt
+++ b/cocos/CMakeLists.txt
@@ -150,7 +150,7 @@ endif()
 
 if(${CMAKE_VERSION} VERSION_GREATER "3.16.0")
     message("CMake 3.16 target_precompile_headers")
-    target_precompile_headers(cocos2d PRIVATE 
+    target_precompile_headers(cocos2d PRIVATE
        "$<$<COMPILE_LANGUAGE:CXX>:cocos2d.h>")
 endif()
 
@@ -159,3 +159,17 @@ endif()
 #    # TODO: Only turn this off if ${CMAKE_XCODE_ATTRIBUTE_IPHONEOS_DEPLOYMENT_TARGET} < 11.0
 #    target_compile_options(cocos2d PUBLIC $<$<COMPILE_LANGUAGE:CXX>:-fno-aligned-allocation>)
 #endif()
+
+export(TARGETS cocos2d
+    external
+    ext_recast
+    ext_tinyxml2
+    ext_xxhash
+    ext_xxtea
+    ext_clipper
+    ext_edtaa3func
+    ext_convertUTF
+    ext_poly2tri
+    ext_md5
+    ext_unzip
+    FILE cocos2d-export.cmake)

--- a/cocos/CMakeLists.txt
+++ b/cocos/CMakeLists.txt
@@ -148,10 +148,12 @@ if(XCODE OR VS)
     cocos_mark_code_files("cocos2d")
 endif()
 
-if(${CMAKE_VERSION} VERSION_GREATER "3.16.0")
-    message("CMake 3.16 target_precompile_headers")
-    target_precompile_headers(cocos2d PRIVATE 
-       "$<$<COMPILE_LANGUAGE:CXX>:cocos2d.h>")
+if(!APPLE)
+    if(${CMAKE_VERSION} VERSION_GREATER "3.16.0")
+        message("CMake 3.16 target_precompile_headers")
+        target_precompile_headers(cocos2d PRIVATE
+        "$<$<COMPILE_LANGUAGE:CXX>:cocos2d.h>")
+    endif()
 endif()
 
 #if(XCODE)

--- a/download-deps.py
+++ b/download-deps.py
@@ -5,7 +5,7 @@
 # ./download-deps.py
 #
 # Downloads Cocos2D-x 3rd party dependencies from github:
-# https://github.com/cocos2d/cocos2d-x-3rd-party-libs-bin) and extracts the zip
+# https://github.com/heroiclabs/cocos2d-x-3rd-party-libs-bin) and extracts the zip
 # file
 #
 # Having the dependencies outside the official cocos2d-x repo helps prevent

--- a/external/config.json
+++ b/external/config.json
@@ -1,5 +1,5 @@
 {
-    "version": "metal-support-22",
+    "version": "e8f42341de16c620179bcf25e4b539db122b7565",
     "zip_file_size": "146254799",
     "repo_name": "cocos2d-x-3rd-party-libs-bin",
     "repo_parent": "https://github.com/heroiclabs/",

--- a/external/config.json
+++ b/external/config.json
@@ -2,7 +2,7 @@
     "version": "metal-support-22",
     "zip_file_size": "146254799",
     "repo_name": "cocos2d-x-3rd-party-libs-bin",
-    "repo_parent": "https://github.com/cocos2d/",
+    "repo_parent": "https://github.com/heroiclabs/",
     "move_dirs": {
         "fbx-conv": "tools"
     }


### PR DESCRIPTION
- Doesn't force `BUILD_LUA_LIBS` to be on near the end of the CMakeLists.txt file.
- Adds options for building cpp tests and templates.