### PR TITLE
Fix: Null Image Data In RenderTexture::newImage Callback Error(#20776)

### DIFF
--- a/cocos/2d/CCRenderTexture.cpp
+++ b/cocos/2d/CCRenderTexture.cpp
@@ -501,6 +501,13 @@ void RenderTexture::newImage(std::function<void(Image*)> imageCallback, bool fli
 //    } while (0);
 }
 
+void RenderTexture::createNewImage(std::function<void(Image*)> imageCallback, bool flipImage)
+{
+    _newImageCommand.init(_globalZOrder);
+    _newImageCommand.func = CC_CALLBACK_0(RenderTexture::newImage, this, imageCallback, flipImage);
+    Director::getInstance()->getRenderer()->addCommand(&_newImageCommand);
+}
+
 void RenderTexture::draw(Renderer *renderer, const Mat4 &transform, uint32_t flags)
 {
     if (_autoDraw)

--- a/cocos/2d/CCRenderTexture.h
+++ b/cocos/2d/CCRenderTexture.h
@@ -159,6 +159,15 @@ public:
      * @js NA
      */
     void newImage(std::function<void(Image*)> imageCallback, bool flipImage = true);
+
+    /**
+     * New Version Of Create a new Image from with the texture's data.
+     * FIX: Null Image Data In RenderTexture::newImage Callback Issue (#20776)
+     * 
+     * @param imageCallback 
+     * @param flipImage 
+     */
+    void createNewImage(std::function<void(Image*)> imageCallback, bool flipImage = true);
     
     /** Saves the texture into a file using JPEG format. The file will be saved in the Documents folder.
      * Returns true if the operation is successful.
@@ -390,6 +399,12 @@ protected:
      and the command and callback will be executed twice.
     */
     CallbackCommand _saveToFileCommand;
+
+    /**
+     * This Command Use to Fix Null Image Data In RenderTexture::newImage(#20776)
+     */
+    CallbackCommand _newImageCommand;
+
     std::function<void (RenderTexture*, const std::string&)> _saveFileCallback = nullptr;
     
     Mat4 _oldTransMatrix, _oldProjMatrix;


### PR DESCRIPTION
See [Null Image Data In RenderTexture::newImage Callback (#20776)](https://github.com/cocos2d/cocos2d-x/issues/20776)
I have try solve It, I test on windows, It worked, Help me test on Android、or another operating system publish version.