### PR TITLE
fix HttpCookie: correct tailmatch and secure boolean parsing logic

### DIFF
--- a/cocos/network/HttpCookie.cpp
+++ b/cocos/network/HttpCookie.cpp
@@ -76,9 +76,9 @@ void HttpCookie::readFile()
             {
                 co.domain = co.domain.substr(1);
             }
-            co.tailmatch = strcmp("TRUE", elems[1].c_str())?true: false;
+            co.tailmatch = strcmp("TRUE", elems[1].c_str()) == 0;
             co.path   = elems[2];
-            co.secure = strcmp("TRUE", elems[3].c_str())?true: false;
+            co.secure = strcmp("TRUE", elems[3].c_str()) == 0;
             co.expires = elems[4];
             co.name = elems[5];
             co.value = elems[6];


### PR DESCRIPTION
The original ternary expression strcmp("TRUE", x)?true:false was inverted - strcmp returns 0 when strings match (falsy in C++), causing TRUE to parse as false. Changed to strcmp("TRUE", x) == 0 for correct boolean conversion.